### PR TITLE
Separate Stable and Preview release histories / 拆分稳定版与预览版发布档案

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 /.signpath/ @SivanCola @esengine
 /.github/workflows/release-stable.yml @SivanCola @esengine
 /.github/workflows/release-stable-trigger.yml @SivanCola @esengine
+/.github/workflows/release-preview.yml @SivanCola @esengine
+/.github/workflows/release-cli-trigger.yml @SivanCola @esengine
 /.github/workflows/release-desktop.yml @SivanCola @esengine
 /.github/workflows/release-desktop-trigger.yml @SivanCola @esengine
 /scripts/complete-signpath-request.ps1 @SivanCola @esengine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,7 @@ jobs:
           go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 \
             -ignore 'label "windows-11-arm" is unknown' \
             .github/workflows/release-stable.yml \
+            .github/workflows/release-preview.yml \
             .github/workflows/release-cli-trigger.yml \
             .github/workflows/release.yml \
             .github/workflows/release-npm.yml \

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version without a tag prefix (for example 1.18.0)"
+        description: "Exact release version without a tag prefix (for example 1.18.0 or 1.19.0-preview.3)"
         required: true
         type: string
       from_tag:

--- a/.github/workflows/release-cli-trigger.yml
+++ b/.github/workflows/release-cli-trigger.yml
@@ -29,16 +29,11 @@ jobs:
               return;
             }
             const tag = process.env.RELEASE_TAG;
-            const channel = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-preview\.(?:0|[1-9]\d*)$/.test(tag)
-              ? 'preview'
-              : 'stable';
+            const preview = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-preview\.(?:0|[1-9]\d*)$/.test(tag);
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'release.yml',
+              workflow_id: preview ? 'release-preview.yml' : 'release.yml',
               ref: process.env.CONTROL_PLANE_REF,
-              inputs: {
-                channel,
-                tag,
-              },
+              inputs: preview ? { tag } : { channel: 'stable', tag },
             });

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -74,6 +74,16 @@ on:
         required: false
         default: false
         type: boolean
+      orchestrator:
+        description: "Trusted release orchestrator: stable or preview"
+        required: false
+        default: stable
+        type: string
+      preview_number:
+        description: "Canonical Preview ordinal supplied by release-preview.yml"
+        required: false
+        default: ""
+        type: string
       signing_preflight:
         description: "Verify both Windows signing stages without publishing"
         required: false
@@ -121,6 +131,7 @@ jobs:
           IN_BASE_VERSION: ${{ inputs.base_version }}
           REF_NAME: ${{ github.ref_name }}
           RUN_NUMBER: ${{ github.run_number }}
+          IN_PREVIEW_NUMBER: ${{ inputs.preview_number }}
         run: bash scripts/resolve-desktop-release.sh
 
       - name: Resolve immutable candidate
@@ -152,7 +163,7 @@ jobs:
       - name: Verify caller and approved release ref
         env:
           ACTUAL_CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
-          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-stable.yml@{1}', github.repository, github.ref) }}
+          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-{1}.yml@{2}', github.repository, inputs.orchestrator, github.ref) }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}
           CALLER_REF_PROTECTED: ${{ github.ref_protected }}
@@ -160,7 +171,8 @@ jobs:
           CALLER_SHA: ${{ github.sha }}
           APPROVED_CLI_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
-          RELEASE_TAG: ${{ inputs.tag }}
+          APPROVED_CHANNEL: ${{ inputs.orchestrator }}
+          RELEASE_TAG: ${{ inputs.approved_cli_tag }}
           VERIFY_RELEASE_CHECKOUT: false
         run: |
           bash scripts/verify-release-authorization.sh
@@ -598,14 +610,14 @@ jobs:
         if: ${{ inputs.orchestrated && needs.resolve.outputs.channel != 'preview' }}
         uses: actions/download-artifact@v8
         with:
-          name: stable-reviewed-release-notes
-          path: /tmp/stable-reviewed-release-notes
+          name: orchestrator-reviewed-release-notes
+          path: /tmp/orchestrator-reviewed-release-notes
 
       - name: Use orchestrator-reviewed release notes
         if: ${{ inputs.orchestrated && needs.resolve.outputs.channel != 'preview' }}
         run: |
-          test -s /tmp/stable-reviewed-release-notes/release-notes.md
-          cp /tmp/stable-reviewed-release-notes/release-notes.md /tmp/release-notes.md
+          test -s /tmp/orchestrator-reviewed-release-notes/release-notes.md
+          cp /tmp/orchestrator-reviewed-release-notes/release-notes.md /tmp/release-notes.md
 
       # Preview never appears on the GitHub releases page; the mirror job picks up
       # the signed dist via the preview-dist artifact below. Stable publishes a
@@ -617,7 +629,7 @@ jobs:
       - name: Revalidate approved release ref
         if: ${{ inputs.orchestrated }}
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
         run: bash scripts/verify-release-tag.sh
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -12,13 +12,11 @@ name: Release desktop
 # release and mirrored to R2 (the updater reads R2 first, then the crash worker
 # release gateway; stable desktop releases own GitHub's repository-wide "latest").
 #
-# The same build/sign/manifest pipeline serves two channels. An orchestrated
-# `desktop-v*` tag (or manual stable recovery) publishes a GitHub release and
-# moves R2's latest/ pointer. A manual `channel: preview` dispatch builds with
-# -X main.channel=preview
-# and uploads only to R2's preview/ pointer — no GitHub release, so Preview never
-# shows on the releases page and never touches latest/. The legacy canary/
-# pointer is mirrored for clients released before the channel rename.
+# The same build/sign/manifest pipeline serves two channels. Approved
+# orchestrators publish Stable or Preview, while manual dispatch supports
+# Stable/RC recovery and non-publishing Preview signing checks. Preview advances
+# only R2's preview/ pointer and never appears on the GitHub releases page. The
+# legacy canary/ pointer is mirrored for clients released before the rename.
 on:
   workflow_dispatch:
     inputs:
@@ -32,7 +30,7 @@ on:
         required: false
         type: string
       base_version:
-        description: "preview: intended next stable version, e.g. 1.5.0"
+        description: "Preview signing checks: intended next stable version, e.g. 1.5.0"
         required: false
         type: string
       production_signing_smoke:
@@ -70,7 +68,7 @@ on:
         required: true
         type: string
       orchestrated:
-        description: "True only when called by release-stable.yml after approval"
+        description: "True only when called by an approved release orchestrator"
         required: false
         default: false
         type: boolean
@@ -127,9 +125,12 @@ jobs:
         id: release
         env:
           EVENT_NAME: ${{ github.event_name }}
+          IN_ORCHESTRATED: ${{ inputs.orchestrated }}
           IN_CHANNEL: ${{ inputs.channel }}
           IN_TAG: ${{ inputs.tag }}
           IN_BASE_VERSION: ${{ inputs.base_version }}
+          IN_PRODUCTION_SIGNING_SMOKE: ${{ inputs.production_signing_smoke }}
+          IN_SIGNING_PREFLIGHT: ${{ inputs.signing_preflight }}
           REF_NAME: ${{ github.ref_name }}
           RUN_NUMBER: ${{ github.run_number }}
           IN_PREVIEW_NUMBER: ${{ inputs.preview_number }}
@@ -186,9 +187,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Keep Preview fast, but do not make its public, formally signed binaries an
-    # unreviewed path. The `canary` environment must use the same required
-    # reviewers as `release`.
+    # Standalone Preview is limited to non-publishing signing checks, but still
+    # exercises the production policy behind the protected `canary` environment.
     environment: ${{ needs.resolve.outputs.channel == 'preview' && 'canary' || 'release' }}
     steps:
       - env:
@@ -533,10 +533,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # The stable caller has already passed the single GitHub release approval.
-    # Direct prereleases, manual stable recovery, and Preview all pass the
-    # appropriate release gate. The SignPath CI identity records each payload
-    # and installer approval after that GitHub gate.
+    # Approved orchestrators have already passed the matching GitHub environment.
+    # Direct prereleases and manual Stable recovery pass release-gate above. The
+    # SignPath CI identity records each payload and installer approval after it.
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -115,6 +115,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       channel: ${{ steps.release.outputs.channel }}
       prerelease: ${{ steps.release.outputs.prerelease }}
+      notes_version: ${{ steps.release.outputs.notes_version }}
       sha: ${{ steps.candidate.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
@@ -587,7 +588,11 @@ jobs:
       # rewrites them to R2 afterwards. GITHUB_REPOSITORY is provided by the runner.
       - name: Generate manifest
         working-directory: desktop
-        run: go run ./cmd/sign manifest ../dist "${{ needs.resolve.outputs.version }}" "${{ needs.resolve.outputs.tag }}"
+        run: >-
+          go run ./cmd/sign manifest ../dist
+          "${{ needs.resolve.outputs.version }}"
+          "${{ needs.resolve.outputs.tag }}"
+          "${{ needs.resolve.outputs.notes_version }}"
 
       - name: Validate generated manifest before publication
         env:
@@ -595,6 +600,7 @@ jobs:
           PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
           TAG: ${{ needs.resolve.outputs.tag }}
           VERSION: ${{ needs.resolve.outputs.version }}
+          NOTES_VERSION: ${{ needs.resolve.outputs.notes_version }}
         run: |
           set -euo pipefail
           validation_channel="$CHANNEL"
@@ -604,7 +610,7 @@ jobs:
           bash release-control/scripts/validate-desktop-release-manifest.sh \
             "$validation_channel" "$VERSION" \
             "https://github.com/esengine/DeepSeek-Reasonix/releases/download/${TAG}/" \
-            dist/latest.json
+            dist/latest.json "$NOTES_VERSION"
 
       - name: Download orchestrator-reviewed release notes
         if: ${{ inputs.orchestrated && needs.resolve.outputs.channel != 'preview' }}
@@ -624,7 +630,7 @@ jobs:
       # GitHub release as usual.
       - name: Render reviewed release notes
         if: ${{ !inputs.orchestrated && needs.resolve.outputs.channel != 'preview' }}
-        run: node scripts/release-notes.mjs render --version "${{ needs.resolve.outputs.version }}" --output /tmp/release-notes.md
+        run: node scripts/release-notes.mjs render --version "${{ needs.resolve.outputs.notes_version }}" --output /tmp/release-notes.md
 
       - name: Revalidate approved release ref
         if: ${{ inputs.orchestrated }}
@@ -781,6 +787,7 @@ jobs:
           PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
           TAG: ${{ needs.resolve.outputs.tag }}
           VERSION: ${{ needs.resolve.outputs.version }}
+          NOTES_VERSION: ${{ needs.resolve.outputs.notes_version }}
         run: |
           set -euo pipefail
           validation_channel="$CHANNEL"
@@ -790,7 +797,7 @@ jobs:
           bash release-control/scripts/validate-desktop-release-manifest.sh \
             "$validation_channel" "$VERSION" \
             "https://dl.reasonix.io/${TAG}/" \
-            assets/latest.json
+            assets/latest.json "$NOTES_VERSION"
 
       - name: Configure AWS CLI for R2
         if: env.HAS_R2 == 'true'
@@ -809,6 +816,7 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           TAG: ${{ needs.resolve.outputs.tag }}
           VERSION: ${{ needs.resolve.outputs.version }}
+          NOTES_VERSION: ${{ needs.resolve.outputs.notes_version }}
         run: |
           set -euo pipefail
           ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -837,6 +845,7 @@ jobs:
             validation_channel="any"
           fi
           asset_base="https://dl.reasonix.io/${TAG}/"
+          existing_manifest=false
 
           # A version directory is immutable once written. Recovery may fill an
           # incomplete candidate subset, but it may never replace conflicting or
@@ -854,31 +863,41 @@ jobs:
             aws s3 cp "s3://${R2_BUCKET}/${TAG}/" "$existing_directory/" \
               --recursive --endpoint-url "$ENDPOINT"
             bash release-control/scripts/verify-desktop-release-directory.sh \
-              --allow-missing assets "$existing_directory"
+              --allow-missing --allow-legacy-manifest assets "$existing_directory"
             if [ -f "$existing_directory/latest.json" ]; then
+              existing_manifest=true
               bash release-control/scripts/validate-desktop-release-manifest.sh \
-                "$validation_channel" "$VERSION" "$asset_base" \
-                "$existing_directory/latest.json"
-              cmp -s assets/latest.json "$existing_directory/latest.json"
+                "legacy-${validation_channel}" "$VERSION" "$asset_base" \
+                "$existing_directory/latest.json" "$NOTES_VERSION"
+              bash release-control/scripts/compare-desktop-release-manifests.sh \
+                assets/latest.json "$existing_directory/latest.json"
             fi
           fi
 
           aws s3 cp assets/ "s3://${R2_BUCKET}/${TAG}/" \
             --recursive \
+            --exclude latest.json \
             --endpoint-url "$ENDPOINT" \
             --cache-control "public, max-age=31536000, immutable"
+          if [ "$existing_manifest" != "true" ]; then
+            aws s3 cp assets/latest.json "s3://${R2_BUCKET}/${TAG}/latest.json" \
+              --endpoint-url "$ENDPOINT" \
+              --content-type "application/json; charset=utf-8" \
+              --cache-control "public, max-age=31536000, immutable"
+          fi
           published_directory="$(mktemp -d)"
           aws s3 cp "s3://${R2_BUCKET}/${TAG}/" "$published_directory/" \
             --recursive --endpoint-url "$ENDPOINT"
           bash release-control/scripts/verify-desktop-release-directory.sh \
-            assets "$published_directory"
+            --allow-legacy-manifest assets "$published_directory"
 
           aws s3 cp "s3://${R2_BUCKET}/${TAG}/latest.json" \
             /tmp/reasonix-desktop-tag-latest.json --endpoint-url "$ENDPOINT"
           bash release-control/scripts/validate-desktop-release-manifest.sh \
-            "$validation_channel" "$VERSION" "$asset_base" \
-            /tmp/reasonix-desktop-tag-latest.json
-          cmp -s assets/latest.json /tmp/reasonix-desktop-tag-latest.json
+            "legacy-${validation_channel}" "$VERSION" "$asset_base" \
+            /tmp/reasonix-desktop-tag-latest.json "$NOTES_VERSION"
+          bash release-control/scripts/compare-desktop-release-manifests.sh \
+            assets/latest.json /tmp/reasonix-desktop-tag-latest.json
 
           # Internal RCs retain their immutable record but never move a public
           # channel pointer.
@@ -1021,6 +1040,7 @@ jobs:
           VERSION: ${{ needs.resolve.outputs.version }}
           CHANNEL: ${{ needs.resolve.outputs.channel }}
           PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
+          NOTES_VERSION: ${{ needs.resolve.outputs.notes_version }}
           POINTER_MOVED: ${{ steps.mirror_r2.outputs.pointer_moved }}
           POINTER_VERSION: ${{ steps.mirror_r2.outputs.pointer_version }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
@@ -1035,13 +1055,14 @@ jobs:
           fi
           asset_base="https://dl.reasonix.io/${TAG}/"
           bash release-control/scripts/validate-desktop-release-manifest.sh \
-            "$validation_channel" "$VERSION" "$asset_base" "$f"
+            "$validation_channel" "$VERSION" "$asset_base" "$f" "$NOTES_VERSION"
 
           aws s3 cp "s3://${R2_BUCKET}/${TAG}/latest.json" /tmp/reasonix-desktop-tag-latest.json --endpoint-url "$ENDPOINT"
           bash release-control/scripts/validate-desktop-release-manifest.sh \
-            "$validation_channel" "$VERSION" "$asset_base" \
-            /tmp/reasonix-desktop-tag-latest.json
-          cmp -s "$f" /tmp/reasonix-desktop-tag-latest.json
+            "legacy-${validation_channel}" "$VERSION" "$asset_base" \
+            /tmp/reasonix-desktop-tag-latest.json "$NOTES_VERSION"
+          bash release-control/scripts/compare-desktop-release-manifests.sh \
+            "$f" /tmp/reasonix-desktop-tag-latest.json
 
           if [ "$POINTER_MOVED" = "true" ]; then
             pointer="latest"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -63,6 +63,16 @@ on:
         required: false
         default: false
         type: boolean
+      orchestrator:
+        description: "Trusted release orchestrator: stable or preview"
+        required: false
+        default: stable
+        type: string
+      preview_number:
+        description: "Canonical Preview ordinal supplied by release-preview.yml"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -82,7 +92,7 @@ jobs:
       - name: Verify caller and approved release ref
         env:
           ACTUAL_CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
-          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-stable.yml@{1}', github.repository, github.ref) }}
+          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-{1}.yml@{2}', github.repository, inputs.orchestrator, github.ref) }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}
           CALLER_REF_PROTECTED: ${{ github.ref_protected }}
@@ -90,7 +100,8 @@ jobs:
           CALLER_SHA: ${{ github.sha }}
           APPROVED_CLI_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
-          RELEASE_TAG: ${{ inputs.tag }}
+          APPROVED_CHANNEL: ${{ inputs.orchestrator }}
+          RELEASE_TAG: ${{ inputs.approved_cli_tag }}
           VERIFY_RELEASE_CHECKOUT: false
         run: |
           bash scripts/verify-release-authorization.sh
@@ -154,11 +165,12 @@ jobs:
           IN_TAG: ${{ inputs.tag }}
           REF_NAME: ${{ github.ref_name }}
           RUN_NUMBER: ${{ github.run_number }}
+          IN_PREVIEW_NUMBER: ${{ inputs.preview_number }}
         run: bash scripts/resolve-npm-release.sh
       - name: Revalidate approved release ref
         if: ${{ inputs.orchestrated }}
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
         run: bash scripts/verify-release-tag.sh
       - env:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -7,12 +7,12 @@ name: Release npm
 #   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
 #   git push origin <tag>
 #
-# A manual workflow_dispatch can publish either an opt-in canary from the current
-# ref or recover an approved stable version from an existing tag. Canary publishes
-# to the `canary` dist-tag (npm i reasonix@canary) and never moves
-# `next`/`latest`. build.mjs decides the dist-tag: a `-canary.` build is `canary`,
-# any other prerelease is `next`, and a stable version is `latest` (#5822 — the
-# old "promote latest by hand" rule left it pinned at 0.53.2 and downgraded
+# Manual workflow_dispatch recovers only an approved Stable version from an
+# existing tag. Public canary publication is owned by release-preview.yml so its
+# version remains aligned with CLI, Desktop, and the immutable release marker.
+# build.mjs decides the dist-tag: a `-canary.` build is `canary`, any other
+# prerelease is `next`, and a stable version is `latest` (#5822 — the old
+# "promote latest by hand" rule left it pinned at 0.53.2 and downgraded
 # `npm update -g` users). The verify step below asserts the tag actually landed.
 on:
   push:
@@ -20,15 +20,14 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Publish channel"
+        description: "Standalone npm recovery channel"
         required: true
-        default: canary
+        default: stable
         type: choice
         options:
-          - canary
           - stable
       base_version:
-        description: "Version to publish. Canary appends -canary.<run_number>; stable publishes exactly this version."
+        description: "Stable version to recover exactly"
         required: true
         type: string
       tag:
@@ -59,7 +58,7 @@ on:
         required: true
         type: string
       orchestrated:
-        description: "True only when called by release-stable.yml after approval"
+        description: "True only when called by an approved release orchestrator"
         required: false
         default: false
         type: boolean
@@ -76,6 +75,12 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  # Serialize every publisher for one npm dist-tag. In particular, canary
+  # remains ordered even if another approved orchestrator is added later.
+  group: release-npm-${{ inputs.channel || 'next' }}
+  cancel-in-progress: false
 
 jobs:
   orchestration-guard:
@@ -109,7 +114,7 @@ jobs:
 
   release-gate:
     name: approve standalone npm release
-    if: ${{ !inputs.orchestrated && !(github.event_name == 'workflow_dispatch' && inputs.channel == 'canary') }}
+    if: ${{ !inputs.orchestrated }}
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -120,7 +125,7 @@ jobs:
   cache-guard:
     name: cache hit guard
     needs: [orchestration-guard, release-gate]
-    if: ${{ always() && !cancelled() && ((inputs.orchestrated && needs.orchestration-guard.result == 'success') || (!inputs.orchestrated && ((github.event_name == 'workflow_dispatch' && inputs.channel == 'canary') || needs.release-gate.result == 'success'))) }}
+    if: ${{ always() && !cancelled() && ((inputs.orchestrated && needs.orchestration-guard.result == 'success') || (!inputs.orchestrated && needs.release-gate.result == 'success')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -137,9 +142,8 @@ jobs:
     needs: cache-guard
     if: ${{ always() && !cancelled() && needs.cache-guard.result == 'success' }}
     runs-on: ubuntu-latest
-    # The stable caller has already passed the single GitHub release approval.
-    # Direct prereleases/manual stable recovery pass release-gate above; canaries
-    # run free.
+    # Orchestrated releases have already passed their GitHub environment
+    # approval. Direct prereleases and manual Stable recovery pass release-gate.
     steps:
       - uses: actions/checkout@v7
         with:
@@ -152,8 +156,8 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      # Tag push uses the npm-v* tag. A canary dispatch synthesizes a
-      # <base>-canary.<run_number> version; a manual stable dispatch publishes
+      # Tag push uses the npm-v* tag. The Preview orchestrator synthesizes a
+      # <base>-canary.<preview_number> version; a manual Stable dispatch publishes
       # the requested semver exactly. build.mjs strips the leading `npm-`/`v`.
       - name: Resolve version
         id: ver

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -13,7 +13,8 @@ name: Release npm
 # build.mjs decides the dist-tag: a `-canary.` build is `canary`, any other
 # prerelease is `next`, and a stable version is `latest` (#5822 — the old
 # "promote latest by hand" rule left it pinned at 0.53.2 and downgraded
-# `npm update -g` users). The verify step below asserts the tag actually landed.
+# `npm update -g` users). The publisher verifies every immutable package and
+# advances each public dist-tag only when the candidate is newer.
 on:
   push:
     tags: ['npm-v*-*']
@@ -177,34 +178,8 @@ jobs:
           RELEASE_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
         run: bash scripts/verify-release-tag.sh
-      - env:
+      - name: Publish or recover immutable npm packages
+        env:
           VERSION_ARG: ${{ steps.ver.outputs.arg }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node npm/build.mjs "$VERSION_ARG" --publish
-      # Assert the dist-tag landed where build.mjs aimed it. This is the guard
-      # that #5822 lacked: `latest` sat on 0.53.2 for months while stables went
-      # to `next`, and nothing noticed until users got downgraded. The registry
-      # applies tags asynchronously after publish, hence the poll.
-      - name: Verify dist-tags
-        env:
-          VERSION_ARG: ${{ steps.ver.outputs.arg }}
-        run: |
-          set -euo pipefail
-          version="$VERSION_ARG"
-          version="${version#npm-}"; version="${version#v}"
-          case "$version" in
-            *-canary.*) tag=canary ;;
-            *-*)        tag=next ;;
-            *)          tag=latest ;;
-          esac
-          for attempt in 1 2 3 4 5 6; do
-            got="$(npm view reasonix dist-tags."$tag" 2>/dev/null || true)"
-            if [ "$got" = "$version" ]; then
-              echo "dist-tag $tag -> $got"
-              exit 0
-            fi
-            echo "dist-tag $tag -> ${got:-<unset>}, want $version (attempt $attempt)"
-            sleep 10
-          done
-          echo "::error::npm dist-tag '$tag' never landed on $version"
-          exit 1

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,210 @@
+name: Release preview
+run-name: Release preview ${{ inputs.tag }}
+
+# One protected Preview event owns the public CLI, Desktop, npm, and changelog
+# identities. The CLI tag supplies the canonical preview ordinal; child
+# publishers retain their native version syntax but use that same ordinal.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing protected CLI Preview tag, e.g. v1.19.0-preview.3"
+        required: true
+        type: string
+
+concurrency:
+  group: preview-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  preflight:
+    name: validate Preview release event
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      base_version: ${{ steps.release.outputs.base_version }}
+      preview_number: ${{ steps.release.outputs.preview_number }}
+      cli_tag: ${{ steps.release.outputs.cli_tag }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Resolve Preview release
+        id: release
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: bash scripts/resolve-preview-release.sh
+      - name: Validate exact reviewed Preview notes
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+        run: |
+          node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md
+          node scripts/release-event.mjs generate \
+            --version "$VERSION" \
+            --sha "$RELEASE_SHA" \
+            --published-at 2000-01-01T00:00:00.000Z \
+            --output /tmp/release-event.json
+      - name: Upload reviewed release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: orchestrator-reviewed-release-notes
+          path: /tmp/release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+
+  authorize:
+    name: approve Preview release
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: canary
+    outputs:
+      version: ${{ steps.approved.outputs.version }}
+      base_version: ${{ steps.approved.outputs.base_version }}
+      preview_number: ${{ steps.approved.outputs.preview_number }}
+      cli_tag: ${{ steps.approved.outputs.cli_tag }}
+      sha: ${{ steps.approved.outputs.sha }}
+    steps:
+      - name: Record approved Preview event
+        id: approved
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+          BASE_VERSION: ${{ needs.preflight.outputs.base_version }}
+          PREVIEW_NUMBER: ${{ needs.preflight.outputs.preview_number }}
+          CLI_TAG: ${{ needs.preflight.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+        run: |
+          {
+            echo "version=$VERSION"
+            echo "base_version=$BASE_VERSION"
+            echo "preview_number=$PREVIEW_NUMBER"
+            echo "cli_tag=$CLI_TAG"
+            echo "sha=$RELEASE_SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Approved Preview release $VERSION at $RELEASE_SHA"
+
+  signpath-preflight:
+    name: verify Preview SignPath control plane
+    needs: authorize
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: preview
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+      signing_preflight: true
+    secrets: inherit
+
+  cli:
+    name: publish CLI Preview
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      channel: preview
+      tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+    secrets: inherit
+
+  npm:
+    name: publish npm Canary
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release-npm.yml
+    with:
+      channel: canary
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+    secrets: inherit
+
+  desktop:
+    name: publish Desktop Preview
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: preview
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+      signing_preflight_verified: true
+    secrets: inherit
+
+  postflight:
+    name: publish Preview release record
+    needs: [authorize, cli, npm, desktop]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Require every Preview publisher to succeed
+        env:
+          CLI_RESULT: ${{ needs.cli.result }}
+          NPM_RESULT: ${{ needs.npm.result }}
+          DESKTOP_RESULT: ${{ needs.desktop.result }}
+        run: |
+          set -euo pipefail
+          for surface in CLI NPM DESKTOP; do
+            result_var="${surface}_RESULT"
+            if [ "${!result_var}" != "success" ]; then
+              echo "::error::$surface Preview publisher result is ${!result_var}, expected success"
+              exit 1
+            fi
+          done
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Upload immutable public release marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.authorize.outputs.sha }}
+        run: |
+          set -euo pipefail
+          node scripts/release-event.mjs generate \
+            --version "$VERSION" --sha "$RELEASE_SHA" \
+            --published-at "$(gh api "repos/${{ github.repository }}/releases/tags/$CLI_TAG" --jq .published_at)" \
+            --output /tmp/release-event.json
+          existing="$(mktemp -d)"
+          if gh release download "$CLI_TAG" --pattern release-event.json --dir "$existing" 2>/dev/null; then
+            cmp -s /tmp/release-event.json "$existing/release-event.json" || {
+              echo "::error::published release-event.json differs from the approved Preview event"
+              exit 1
+            }
+          else
+            gh release upload "$CLI_TAG" /tmp/release-event.json
+          fi
+      - name: Refresh public changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main-v2

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -13,7 +13,9 @@ on:
         type: string
 
 concurrency:
-  group: preview-release-${{ inputs.tag }}
+  # Every Preview version advances the same public CLI, Desktop, and npm
+  # channels. Keep the whole all-surface event serialized across versions.
+  group: preview-release
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Upload reviewed release notes
         uses: actions/upload-artifact@v7
         with:
-          name: stable-reviewed-release-notes
+          name: orchestrator-reviewed-release-notes
           path: /tmp/release-notes.md
           if-no-files-found: error
           retention-days: 1
@@ -188,7 +188,8 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      actions: write
+      contents: write
     steps:
       - name: Require every publisher to succeed
         env:
@@ -230,3 +231,36 @@ jobs:
           CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
           DESKTOP_TAG: ${{ needs.authorize.outputs.desktop_tag }}
         run: bash scripts/verify-stable-release-artifacts.sh
+      - name: Publish exact Stable release record
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.authorize.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if ! node -e '
+            const catalog = require("./release-notes/releases.json");
+            const release = catalog.releases.find((item) => item.version === process.env.VERSION);
+            process.exit(release?.status === "reviewed" ? 0 : 1);
+          '; then
+            echo "Legacy Stable notes do not require a publication marker"
+            exit 0
+          fi
+          node scripts/release-event.mjs generate \
+            --version "$VERSION" --sha "$RELEASE_SHA" \
+            --published-at "$(gh api "repos/${{ github.repository }}/releases/tags/$CLI_TAG" --jq .published_at)" \
+            --output /tmp/release-event.json
+          existing="$(mktemp -d)"
+          if gh release download "$CLI_TAG" --pattern release-event.json --dir "$existing" 2>/dev/null; then
+            cmp -s /tmp/release-event.json "$existing/release-event.json" || {
+              echo "::error::published release-event.json differs from the approved Stable event"
+              exit 1
+            }
+          else
+            gh release upload "$CLI_TAG" /tmp/release-event.json
+          fi
+      - name: Refresh public changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main-v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,22 @@
 name: Release
 
-# Native CLI binary line. Stable releases are called by release-stable.yml after
-# its single GitHub `release`-environment approval. Preview uses immutable
-# vX.Y.Z-preview.N tags, publishes a GitHub prerelease behind the same `canary`
-# gate as Desktop Preview, and never moves Homebrew or GitHub Latest. Other
-# standalone prereleases remain internal stable-channel checkpoints behind the
-# `release` gate.
+# Native CLI binary line. Stable and Preview releases are called by their
+# approved all-surface orchestrators. Manual dispatch remains available only for
+# Stable/RC recovery; standalone prereleases remain internal stable-channel
+# checkpoints behind the `release` gate.
 on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Native CLI release channel"
+        description: "Standalone CLI recovery channel"
         required: true
-        # Preserve existing tag-only recovery dispatches as Stable. Preview must
-        # be an explicit operator choice or arrive through the tag relay.
+        # Public Preview recovery reruns release-preview.yml so every surface and
+        # its immutable release-event marker stay aligned.
         default: stable
         type: choice
-        options: [stable, preview]
+        options: [stable]
       tag:
-        description: "Existing protected CLI tag (Preview: v1.18.0-preview.1; Stable/RC: v1.18.0-rc.1)"
+        description: "Existing protected Stable/RC CLI tag (for example v1.18.0 or v1.18.0-rc.1)"
         required: true
         type: string
   workflow_call:
@@ -41,7 +39,7 @@ on:
         required: true
         type: string
       orchestrated:
-        description: "True only when called by release-stable.yml after approval"
+        description: "True only when called by an approved release orchestrator"
         required: false
         default: false
         type: boolean
@@ -149,7 +147,7 @@ jobs:
     needs: resolve
     if: ${{ !inputs.orchestrated }}
     runs-on: ubuntu-latest
-    environment: ${{ needs.resolve.outputs.channel == 'preview' && 'canary' || 'release' }}
+    environment: release
     steps:
       - env:
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: false
         type: boolean
+      orchestrator:
+        description: "Trusted release orchestrator: stable or preview"
+        required: false
+        default: stable
+        type: string
 
 permissions:
   contents: write # create the release and upload archives
@@ -124,7 +129,7 @@ jobs:
       - name: Verify caller and approved release ref
         env:
           ACTUAL_CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
-          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-stable.yml@{1}', github.repository, github.ref) }}
+          EXPECTED_CALLER_WORKFLOW_REF: ${{ format('{0}/.github/workflows/release-{1}.yml@{2}', github.repository, inputs.orchestrator, github.ref) }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}
           CALLER_REF_PROTECTED: ${{ github.ref_protected }}
@@ -132,6 +137,7 @@ jobs:
           CALLER_SHA: ${{ github.sha }}
           APPROVED_CLI_TAG: ${{ inputs.approved_cli_tag }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
+          APPROVED_CHANNEL: ${{ inputs.orchestrator }}
           RELEASE_TAG: ${{ inputs.tag }}
           VERIFY_RELEASE_CHECKOUT: false
         run: |
@@ -189,13 +195,13 @@ jobs:
         if: ${{ inputs.orchestrated }}
         uses: actions/download-artifact@v8
         with:
-          name: stable-reviewed-release-notes
-          path: /tmp/stable-reviewed-release-notes
+          name: orchestrator-reviewed-release-notes
+          path: /tmp/orchestrator-reviewed-release-notes
       - name: Use orchestrator-reviewed release notes
         if: ${{ inputs.orchestrated }}
         run: |
-          test -s /tmp/stable-reviewed-release-notes/release-notes.md
-          cp /tmp/stable-reviewed-release-notes/release-notes.md /tmp/release-notes.md
+          test -s /tmp/orchestrator-reviewed-release-notes/release-notes.md
+          cp /tmp/orchestrator-reviewed-release-notes/release-notes.md /tmp/release-notes.md
       - name: Render reviewed release notes
         if: ${{ !inputs.orchestrated }}
         env:
@@ -270,6 +276,7 @@ jobs:
               tag_name: $release.tag_name,
               prerelease: $release.prerelease,
               html_url: $release.html_url,
+              release_notes_url: ("https://reasonix.io/changelog/" + $tag + "/"),
               assets: [
                 $required[] as $name |
                 $assets[$name] |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve.outputs.tag }}
+          NOTES_TAG: ${{ needs.resolve.outputs.notes_version }}
           HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -266,7 +267,7 @@ jobs:
             "SHA256SUMS"
           ]'
           gh api "repos/${{ github.repository }}/releases/tags/$TAG" > /tmp/cli-release.raw.json
-          jq --arg tag "$TAG" --argjson required "$required_assets" '
+          jq --arg tag "$TAG" --arg notes_tag "$NOTES_TAG" --argjson required "$required_assets" '
             if .tag_name != $tag then error("release tag mismatch") else . end |
             if .draft then error("draft release cannot be published") else . end |
             . as $release |
@@ -276,7 +277,7 @@ jobs:
               tag_name: $release.tag_name,
               prerelease: $release.prerelease,
               html_url: $release.html_url,
-              release_notes_url: ("https://reasonix.io/changelog/" + $tag + "/"),
+              release_notes_url: ("https://reasonix.io/changelog/" + $notes_tag + "/"),
               assets: [
                 $required[] as $name |
                 $assets[$name] |
@@ -292,10 +293,10 @@ jobs:
           ' /tmp/cli-release.raw.json > /tmp/cli-release.json
           if [ -n "$channel" ]; then
             bash scripts/validate-cli-release-manifest.sh \
-              "$channel" "$TAG" "${{ github.repository }}" /tmp/cli-release.json
+              "$channel" "$TAG" "${{ github.repository }}" /tmp/cli-release.json "$NOTES_TAG"
           else
             bash scripts/validate-cli-release-manifest.sh \
-              any "$TAG" "${{ github.repository }}" /tmp/cli-release.json
+              any "$TAG" "${{ github.repository }}" /tmp/cli-release.json "$NOTES_TAG"
           fi
 
           endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -305,9 +306,10 @@ jobs:
           if aws s3 cp "s3://${R2_BUCKET}/${immutable_key}" /tmp/cli-release.immutable.json \
             --endpoint-url "$endpoint" 2>"$immutable_error"; then
             bash scripts/validate-cli-release-manifest.sh \
-              "$validation_channel" "$TAG" "${{ github.repository }}" \
-              /tmp/cli-release.immutable.json
-            if ! cmp -s /tmp/cli-release.json /tmp/cli-release.immutable.json; then
+              "legacy-${validation_channel}" "$TAG" "${{ github.repository }}" \
+              /tmp/cli-release.immutable.json "$NOTES_TAG"
+            if ! bash scripts/compare-cli-release-manifests.sh \
+              /tmp/cli-release.json /tmp/cli-release.immutable.json; then
               echo "::error::immutable CLI release metadata for $TAG already exists with different content"
               exit 1
             fi
@@ -326,9 +328,10 @@ jobs:
           aws s3 cp "s3://${R2_BUCKET}/${immutable_key}" /tmp/cli-release.immutable.json \
             --endpoint-url "$endpoint"
           bash scripts/validate-cli-release-manifest.sh \
-            "$validation_channel" "$TAG" "${{ github.repository }}" \
-            /tmp/cli-release.immutable.json
-          cmp -s /tmp/cli-release.json /tmp/cli-release.immutable.json
+            "legacy-${validation_channel}" "$TAG" "${{ github.repository }}" \
+            /tmp/cli-release.immutable.json "$NOTES_TAG"
+          bash scripts/compare-cli-release-manifests.sh \
+            /tmp/cli-release.json /tmp/cli-release.immutable.json
 
           if [ -z "$channel" ]; then
             echo "internal CLI release $TAG; Stable and Preview pointers remain unchanged"
@@ -341,7 +344,8 @@ jobs:
             --endpoint-url "$endpoint" 2>"$pointer_error"; then
             current_tag="$(jq -er '.tag_name | strings' /tmp/cli-release.pointer.json)"
             bash scripts/validate-cli-release-manifest.sh \
-              "$channel" "$current_tag" "${{ github.repository }}" /tmp/cli-release.pointer.json
+              "legacy-${channel}" "$current_tag" "${{ github.repository }}" \
+              /tmp/cli-release.pointer.json "$current_tag"
           elif grep -Eiq '404|NoSuchKey|Not Found' "$pointer_error"; then
             echo "CLI $channel pointer does not exist yet"
           else
@@ -370,7 +374,8 @@ jobs:
           aws s3 cp "s3://${R2_BUCKET}/cli/${channel}/latest.json" /tmp/cli-release.pointer.json \
             --endpoint-url "$endpoint"
           bash scripts/validate-cli-release-manifest.sh \
-            "$channel" "$TAG" "${{ github.repository }}" /tmp/cli-release.pointer.json
+            "$channel" "$TAG" "${{ github.repository }}" \
+            /tmp/cli-release.pointer.json "$NOTES_TAG"
           cmp -s /tmp/cli-release.json /tmp/cli-release.pointer.json
           echo "CLI $channel pointer -> $TAG"
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ temp/
 scripts/official-theme-art/out/
 scripts/official-theme-art/__pycache__/
 agent-complexity-report.txt
+site/.generated/

--- a/.signpath/contracts/release-signing.yml
+++ b/.signpath/contracts/release-signing.yml
@@ -6,10 +6,13 @@ allowed_branch_names:
   - main-v2
 allowed_build_definitions:
   - .github/workflows/release-stable.yml
+  - .github/workflows/release-preview.yml
   - .github/workflows/release-desktop.yml
 fingerprint_files:
   - .github/workflows/release-stable.yml
   - .github/workflows/release-stable-trigger.yml
+  - .github/workflows/release-preview.yml
+  - .github/workflows/release-cli-trigger.yml
   - .github/workflows/release-desktop.yml
   - .github/workflows/release-desktop-trigger.yml
   - .signpath/artifact-configurations/windows-payload.xml

--- a/cmd/signpath-contract/main_test.go
+++ b/cmd/signpath-contract/main_test.go
@@ -28,6 +28,7 @@ func TestTopLevelSignPathWorkflowCallGraph(t *testing.T) {
 	}
 	want := []string{
 		".github/workflows/release-desktop.yml",
+		".github/workflows/release-preview.yml",
 		".github/workflows/release-stable.yml",
 	}
 	if !reflect.DeepEqual(got, want) {

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -10,7 +10,8 @@
 //	                             encrypted minisign private key in $MINISIGN_PRIVATE_KEY
 //	                             (decrypted with $MINISIGN_PASSWORD).
 //
-//	manifest <dir> <ver> <tag>   Scan <dir> for the per-platform artifacts, compute
+//	manifest <dir> <ver> <tag> [notes-ver]
+//	                             Scan <dir> for the per-platform artifacts, compute
 //	                             size + sha256, and write <dir>/latest.json with GitHub
 //	                             release download URLs. The R2 mirror step rewrites those
 //	                             URLs to the CDN afterwards (url + sig fields together).
@@ -54,10 +55,14 @@ func main() {
 	case "sign":
 		err = signFiles(os.Args[2:])
 	case "manifest":
-		if len(os.Args) != 5 {
+		if len(os.Args) != 5 && len(os.Args) != 6 {
 			usage()
 		}
-		err = genManifest(os.Args[2], os.Args[3], os.Args[4])
+		notesVersion := os.Args[3]
+		if len(os.Args) == 6 {
+			notesVersion = os.Args[5]
+		}
+		err = genManifest(os.Args[2], os.Args[3], os.Args[4], notesVersion)
 	case "windows-payload":
 		if len(os.Args) != 4 {
 			usage()
@@ -83,7 +88,7 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage:\n  sign <file>...\n  manifest <dir> <version> <tag>\n  windows-payload <dir> <version>\n  genkey <dir>\n  verify <file>")
+	fmt.Fprintln(os.Stderr, "usage:\n  sign <file>...\n  manifest <dir> <version> <tag> [notes-version]\n  windows-payload <dir> <version>\n  genkey <dir>\n  verify <file>")
 	os.Exit(2)
 }
 
@@ -205,15 +210,22 @@ func signFiles(files []string) error {
 // Portable updater channels land in platforms (tarballs/installers). Debian/Ubuntu
 // .deb packages land only in native_packages so older clients keep resolving the
 // tarball under platforms["linux-amd64"].
-func genManifest(dir, version, tag string) error {
+func genManifest(dir, version, tag string, notesVersions ...string) error {
 	repo := os.Getenv("GITHUB_REPOSITORY")
 	if repo == "" || repo == "esengine/reasonix" {
 		repo = "esengine/DeepSeek-Reasonix"
 	}
+	notesVersion := version
+	if len(notesVersions) > 1 {
+		return fmt.Errorf("manifest: expected at most one release-notes version")
+	}
+	if len(notesVersions) == 1 {
+		notesVersion = notesVersions[0]
+	}
 	m := update.Manifest{
 		Version:         version,
 		DownloadPage:    "https://reasonix.io/?download=desktop#start",
-		ReleaseNotesURL: "https://reasonix.io/changelog/" + version + "/",
+		ReleaseNotesURL: "https://reasonix.io/changelog/" + notesVersion + "/",
 		Platforms:       map[string]update.Asset{},
 		NativePackages:  map[string]update.Asset{},
 		Downloads:       map[string]update.Asset{},

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -211,11 +211,12 @@ func genManifest(dir, version, tag string) error {
 		repo = "esengine/DeepSeek-Reasonix"
 	}
 	m := update.Manifest{
-		Version:        version,
-		DownloadPage:   "https://reasonix.io/?download=desktop#start",
-		Platforms:      map[string]update.Asset{},
-		NativePackages: map[string]update.Asset{},
-		Downloads:      map[string]update.Asset{},
+		Version:         version,
+		DownloadPage:    "https://reasonix.io/?download=desktop#start",
+		ReleaseNotesURL: "https://reasonix.io/changelog/" + version + "/",
+		Platforms:       map[string]update.Asset{},
+		NativePackages:  map[string]update.Asset{},
+		Downloads:       map[string]update.Asset{},
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -157,6 +157,27 @@ func TestGenManifest(t *testing.T) {
 	}
 }
 
+func TestGenManifestCanReuseStableNotesForStandaloneRC(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Reasonix-linux-amd64.tar.gz"), []byte("rc"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := genManifest(dir, "v1.3.0-rc.1", "desktop-v1.3.0-rc.1", "v1.3.0"); err != nil {
+		t.Fatalf("genManifest: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "latest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m update.Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.ReleaseNotesURL != "https://reasonix.io/changelog/v1.3.0/" {
+		t.Fatalf("release_notes_url = %q, want stable base history", m.ReleaseNotesURL)
+	}
+}
+
 // TestGenManifestIgnoresUnknownNativePackages ensures a .deb without a known
 // platform key is skipped rather than inventing a native_packages entry.
 func TestGenManifestIgnoresUnknownNativePackages(t *testing.T) {

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -89,6 +89,9 @@ func TestGenManifest(t *testing.T) {
 	if m.DownloadPage != "https://reasonix.io/?download=desktop#start" {
 		t.Fatalf("download_page = %q, want official install page", m.DownloadPage)
 	}
+	if m.ReleaseNotesURL != "https://reasonix.io/changelog/v1.2.0/" {
+		t.Fatalf("release_notes_url = %q, want exact version history", m.ReleaseNotesURL)
+	}
 	if len(m.Platforms) != 5 {
 		t.Fatalf("want 5 platforms, got %d: %v", len(m.Platforms), m.Platforms)
 	}

--- a/desktop/internal/update/manifest.go
+++ b/desktop/internal/update/manifest.go
@@ -12,13 +12,14 @@ import "runtime"
 // Version against the running build, and looks up the running platform's artifact
 // via Asset / NativePackage.
 type Manifest struct {
-	Version        string           `json:"version"`                   // release version, e.g. "v1.1.0"
-	Notes          string           `json:"notes"`                     // markdown release notes
-	PubDate        string           `json:"pub_date"`                  // RFC3339, optional
-	DownloadPage   string           `json:"download_page"`             // human-facing download page (macOS manual-update fallback)
-	Platforms      map[string]Asset `json:"platforms"`                 // keyed by PlatformKey, e.g. "darwin-arm64"
-	NativePackages map[string]Asset `json:"native_packages,omitempty"` // optional OS package assets, e.g. linux-amd64 → .deb
-	Downloads      map[string]Asset `json:"downloads,omitempty"`       // optional signed human-download assets keyed by exact filename
+	Version         string           `json:"version"`                     // release version, e.g. "v1.1.0"
+	Notes           string           `json:"notes"`                       // markdown release notes
+	PubDate         string           `json:"pub_date"`                    // RFC3339, optional
+	DownloadPage    string           `json:"download_page"`               // human-facing download page (macOS manual-update fallback)
+	ReleaseNotesURL string           `json:"release_notes_url,omitempty"` // exact version history page; older manifests omit it
+	Platforms       map[string]Asset `json:"platforms"`                   // keyed by PlatformKey, e.g. "darwin-arm64"
+	NativePackages  map[string]Asset `json:"native_packages,omitempty"`   // optional OS package assets, e.g. linux-amd64 → .deb
+	Downloads       map[string]Asset `json:"downloads,omitempty"`         // optional signed human-download assets keyed by exact filename
 }
 
 // Asset is one platform's downloadable artifact plus the metadata the updater

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -217,8 +217,11 @@ strict separation from repository writers is required.
   protected `main-v2` with the existing `vX.Y.Z-preview.N` tag. Do not dispatch
   the CLI, Desktop, or npm publisher directly: those paths cannot create the
   all-surface `release-event.json` marker and are blocked from public Preview
-  publication. Standalone Desktop Preview dispatch remains available only for
-  non-publishing SignPath preflight and production-signing smoke checks.
+  publication. npm recovery verifies and reuses packages already published from
+  the approved candidate, fills only missing packages, and never rolls `canary`
+  back when a newer Preview is already public. Standalone Desktop Preview
+  dispatch remains available only for non-publishing SignPath preflight and
+  production-signing smoke checks.
 - Windows release signing uses SignPath trusted-build, origin verification, and
   malware scanning. Keep the checked-in `windows-payload` and
   `windows-installer-v2` artifact configurations synchronized with the matching

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -40,7 +40,9 @@ publish the public Preview pointer.
 An RC is not a third user-facing channel. If a weekly candidate needs a freeze,
 use a surface-specific `vX.Y.Z-rc.N` or `desktop-vX.Y.Z-rc.N` tag as an
 internal candidate checkpoint. Neither moves a rolling pointer or Homebrew.
-npm retains its separate `next` and `canary` dist-tags.
+CLI and Desktop RCs reuse the reviewed `X.Y.Z` Stable notes instead of creating
+a third public changelog identity, so prepare and merge that Stable record
+before cutting the RC. npm retains its separate `next` and `canary` dist-tags.
 
 ### Desktop channel compatibility
 
@@ -60,7 +62,7 @@ npm retains its separate `next` and `canary` dist-tags.
 |---|---|---|
 | **Ship Preview** | release-tag creator + configured reviewer | prepare notes for the exact `X.Y.Z-preview.N` version, then create and push its protected CLI tag; a minimal relay dispatches **Release preview** on protected `main-v2`, which pauses once on `canary` and publishes aligned CLI, Desktop, npm, and changelog identities |
 | **Ship stable** | release-tag creators + one configured reviewer | atomically push the three stable tags; a minimal tag relay dispatches **Release stable** on protected `main-v2`, which requests one GitHub `release`-environment approval before every channel publishes |
-| **Ship a standalone RC** | release-tag creators + one configured reviewer | push the surface-specific prerelease tag; a minimal relay dispatches the standalone workflow on protected `main-v2`, which requests one `release` approval |
+| **Ship a standalone RC** | release-tag creators + one configured reviewer | prepare the reviewed `X.Y.Z` Stable notes, then push the surface-specific prerelease tag; a minimal relay dispatches the standalone workflow on protected `main-v2`, reuses those notes, and requests one `release` approval |
 
 Preview remains operationally fast, but its public artifacts are not an
 unreviewed or test-certificate path. The unified Preview event pauses once at
@@ -105,7 +107,9 @@ strict separation from repository writers is required.
    (`X.Y.Z` for Stable or `X.Y.Z-preview.N` for Preview), the previous release
    tag when needed, and the number of an existing release-bound PR when one is
    available. Every exact Stable and Preview identity gets its own reviewed
-   catalog record. The reusable PR must be open, target `main-v2`, come from a
+   catalog record. Do not create an `X.Y.Z-rc.N` catalog record: standalone
+   CLI/Desktop RCs are internal checkpoints and reuse the `X.Y.Z` Stable
+   record. The reusable PR must be open, target `main-v2`, come from a
    branch in this repository, and already include the latest `main-v2`. The
    workflow commits the generated notes onto that branch, so product changes and
    their release copy share one PR and one review surface. The added commit still

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -58,15 +58,14 @@ npm retains its separate `next` and `canary` dist-tags.
 
 | Action | Who | Mechanism |
 |---|---|---|
-| **Cut Native CLI Preview** | release-tag creator + configured reviewer | create and push a protected `vX.Y.Z-preview.N` tag; a minimal relay dispatches **Release** on protected `main-v2`, which classifies it as Preview, pauses on the `canary` environment, and publishes a GitHub prerelease without touching Homebrew or Latest |
-| **Cut Desktop Preview** | maintainer + configured reviewer | dispatch **Release desktop** on protected `main-v2`; the `canary` GitHub environment is retained as a compatibility name and must have the same required reviewers as `release` |
+| **Ship Preview** | release-tag creator + configured reviewer | prepare notes for the exact `X.Y.Z-preview.N` version, then create and push its protected CLI tag; a minimal relay dispatches **Release preview** on protected `main-v2`, which pauses once on `canary` and publishes aligned CLI, Desktop, npm, and changelog identities |
 | **Ship stable** | release-tag creators + one configured reviewer | atomically push the three stable tags; a minimal tag relay dispatches **Release stable** on protected `main-v2`, which requests one GitHub `release`-environment approval before every channel publishes |
 | **Ship a standalone RC** | release-tag creators + one configured reviewer | push the surface-specific prerelease tag; a minimal relay dispatches the standalone workflow on protected `main-v2`, which requests one `release` approval |
 
 Preview remains operationally fast, but its public artifacts are not an
-unreviewed or test-certificate path. Native CLI Preview tag runs and Desktop
-Preview dispatches pause at the legacy `canary` environment approval. Desktop
-then uses the production SignPath policy. A stable release pauses once in
+unreviewed or test-certificate path. The unified Preview event pauses once at
+the legacy `canary` environment approval, then uses the production SignPath
+policy. A stable release pauses once in
 **Release stable** until a configured reviewer approves the `release`
 environment. The jobs then continue without another human approval: SignPath
 verifies the trusted GitHub origin, scans and signs every installed executable,
@@ -90,7 +89,8 @@ cannot claim that it already passed the approval job.
 Repository `write` access remains a privileged role because repository-level
 Actions secrets are available to workflows on repository branches. Production
 Windows signing has an additional provider-side boundary: SignPath accepts the
-trusted `.github/workflows/release-stable.yml` and
+trusted `.github/workflows/release-stable.yml`,
+`.github/workflows/release-preview.yml`, and
 `.github/workflows/release-desktop.yml` build definitions only when their
 origin branch is exactly `main-v2`. Never broaden that policy to `**` or a
 tag-shaped wildcard. Other publication credentials should move to protected
@@ -101,9 +101,11 @@ strict separation from repository writers is required.
 
 1. **Develop** — PRs land on `main-v2` (branch auto-deletes on merge).
 2. **Prepare the release notes without creating a release-only PR by default** —
-   Actions → **Prepare release notes**. Enter the intended version, the previous
-   desktop tag when needed, and the number of an existing release-bound PR when
-   one is available. The reusable PR must be open, target `main-v2`, come from a
+   Actions → **Prepare release notes**. Enter the exact intended version
+   (`X.Y.Z` for Stable or `X.Y.Z-preview.N` for Preview), the previous release
+   tag when needed, and the number of an existing release-bound PR when one is
+   available. Every exact Stable and Preview identity gets its own reviewed
+   catalog record. The reusable PR must be open, target `main-v2`, come from a
    branch in this repository, and already include the latest `main-v2`. The
    workflow commits the generated notes onto that branch, so product changes and
    their release copy share one PR and one review surface. The added commit still
@@ -118,20 +120,25 @@ strict separation from repository writers is required.
    equivalent English and Chinese product notes, validates their structure and
    citations, and includes the rendered draft in the workflow summary. Review
    the catalog diff like product copy. Once merged, the same entry drives
-   `/changelog/` and both CLI and Desktop GitHub Releases; the desktop app links
-   to that web history from Settings → Updates. A missing catalog entry still
-   blocks stable publication.
+   the exact `/changelog/vX.Y.Z/` or `/changelog/vX.Y.Z-preview.N/` page and the
+   corresponding release surfaces; the desktop app links directly to that exact
+   web history from Settings → Updates. A reviewed record stays hidden until the
+   all-surface postflight uploads its matching immutable `release-event.json`.
+   Missing or mismatched notes block publication.
 3. **Cut Preview** during the intended release cycle (e.g. heading for `1.4.0`):
-   - Native CLI: create and push the next protected Preview tag:
+   - First merge the reviewed notes for the exact Preview identity, then create
+     and push its protected tag:
      ```sh
      git tag v1.4.0-preview.1
      git push origin v1.4.0-preview.1
      ```
-   - Desktop: Actions → **Release desktop** → `channel: preview`, `base_version: 1.4.0`
-   - CLI: Actions → **Release npm** → `base_version: 1.4.0`
-   - Publishes the native CLI as a GitHub prerelease and Desktop to R2
-     `preview/` (no Desktop GitHub release), mirroring Desktop `canary/` only
-     for older clients. npm still publishes its independent `@canary` channel.
+   - The tag relay dispatches **Release preview** on protected `main-v2`. After
+     one `canary` approval and a zero-publication SignPath preflight, it publishes
+     CLI `v1.4.0-preview.1`, Desktop `1.4.0-preview.1`, npm
+     `1.4.0-canary.1`, and the exact Preview changelog as one event.
+   - Desktop advances only R2 `preview/` (and mirrors `canary/` for older
+     clients); no Desktop Preview appears on the GitHub releases page. npm
+     advances only `@canary`; Homebrew and Stable pointers remain untouched.
 4. **Test** — native CLI testers download the immutable GitHub prerelease;
    desktop users opt into Preview in Settings → Updates; npm CLI testers
    install `reasonix@canary`.
@@ -191,9 +198,11 @@ strict separation from repository writers is required.
 
 ## Notes
 
-- Native CLI Preview uses the protected tag's explicit `N`; Desktop Preview and
-  npm Canary use their workflow `run_number`, so suffixes can differ. Only
-  monotonicity per surface matters.
+- Native CLI Preview supplies the protected tag's explicit `N`; the unified
+  Preview orchestrator reuses that ordinal for Desktop `preview.N` and npm
+  `canary.N`. The exact versions are recorded in one reviewed changelog entry;
+  the immutable publication marker adds the actual candidate SHA after all
+  surfaces succeed.
 - A stable `-rc` tag (e.g. `npm-v1.4.0-rc.1`) still ships under `next`, not `canary`.
 - Recover an interrupted stable release by dispatching **Release stable** from
   protected `main-v2` with the existing `vX.Y.Z` tag. Recovery requires the CLI,
@@ -216,7 +225,8 @@ strict separation from repository writers is required.
   request through the SignPath API. Human SignPath approvers remain available
   for emergency recovery, but normal releases do not require additional
   SignPath clicks. SignPath must restrict `release-signing` to the trusted
-  `.github/workflows/release-stable.yml` and
+  `.github/workflows/release-stable.yml`,
+  `.github/workflows/release-preview.yml`, and
   `.github/workflows/release-desktop.yml` build definitions and exact `main-v2`
   branch. Stable and prerelease tag events are relayed to that protected control
   plane; do not replace exact matches with wildcards. The machine-readable
@@ -224,9 +234,9 @@ strict separation from repository writers is required.
   workflow call graph in CI. Standalone Desktop releases require
   `SIGNPATH_RELEASE_SIGNING_ATTESTATION` to match the current contract hash;
   `signing_preflight=true` refreshes it only after both architectures complete
-  both signing stages. Stable performs the same live preflight in its approved
-  run before CLI, npm, or Desktop publication, so a provider-side policy drift
-  fails before any public channel starts.
+  both signing stages. Stable and unified Preview perform the same live
+  preflight in their approved runs before CLI, npm, or Desktop publication, so
+  a provider-side policy drift fails before any public channel starts.
 - Desktop in-app updates use R2 first, then the `crash.reasonix.io` desktop release
   gateway. The gateway resolves the `desktop-v*` release line directly and never uses
   GitHub's repository-wide `/releases/latest`, because plain `v*` tags are the CLI

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -213,6 +213,12 @@ strict separation from repository writers is required.
   npm, and Desktop tags to remain aligned on an ancestor of current `main-v2`,
   then uses the same single approval and postflight. Never move or recreate the
   published tags to pick up a workflow fix.
+- Recover an interrupted Preview release by rerunning **Release preview** from
+  protected `main-v2` with the existing `vX.Y.Z-preview.N` tag. Do not dispatch
+  the CLI, Desktop, or npm publisher directly: those paths cannot create the
+  all-surface `release-event.json` marker and are blocked from public Preview
+  publication. Standalone Desktop Preview dispatch remains available only for
+  non-publishing SignPath preflight and production-signing smoke checks.
 - Windows release signing uses SignPath trusted-build, origin verification, and
   malware scanning. Keep the checked-in `windows-payload` and
   `windows-installer-v2` artifact configurations synchronized with the matching

--- a/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md
+++ b/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md
@@ -9,6 +9,7 @@ Reasonix Windows Authenticode 两阶段签名链路。
 - Preview 渠道改造：[esengine/DeepSeek-Reasonix#6155](https://github.com/esengine/DeepSeek-Reasonix/pull/6155)
 - 本 SOP 的验收对象：每次执行前通过 PR API 读回的当前 PR Head
 - 签名工作流：`.github/workflows/release-stable.yml`、
+  `.github/workflows/release-preview.yml`、
   `.github/workflows/release-desktop.yml`
 - 机器契约：`.signpath/contracts/release-signing.yml`
 - Authenticode 验证脚本：`scripts/verify-windows-authenticode.ps1`
@@ -73,6 +74,7 @@ SignPath 权限说明：
 - `release-signing` 开启 `Use approval process`，Required approvals 为 `1`。
 - `release-signing` 的 Allowed build definitions 精确允许：
   - `.github/workflows/release-stable.yml`
+  - `.github/workflows/release-preview.yml`
   - `.github/workflows/release-desktop.yml`
 - `release-signing` 的 Allowed branches 必须精确为 `main-v2`；稳定版和 RC
   标签由最小 relay workflow 转发到该受保护控制面。
@@ -250,10 +252,11 @@ GitHub `upload-artifact` 提交给 SignPath 的产物是 ZIP，因此配置根�
   ```
 
 - Allowed branches：**只能填写 `main-v2`**
-- Allowed build definitions：**只能逐行填写以下两个精确路径**：
+- Allowed build definitions：**只能逐行填写以下三个精确路径**：
 
   ```text
   .github/workflows/release-stable.yml
+  .github/workflows/release-preview.yml
   .github/workflows/release-desktop.yml
   ```
 
@@ -274,11 +277,11 @@ GitHub `upload-artifact` 提交给 SignPath 的产物是 ZIP，因此配置根�
   `desktop-v*` 或临时测试分支。
 - Allowed build definitions 与仓库机器契约逐项相同，没有通配符。
 
-正式版和 RC 的标签事件由 `release-stable-trigger.yml` /
-`release-desktop-trigger.yml` 转发：relay 只携带候选 tag，实际
-`release-desktop.yml` 固定运行在受保护的 `main-v2`，再签署该 tag 指向的
-不可变候选 SHA。不能把 Allowed branches 改成标签通配符，因为普通分支也可以
-取形如 `v-malicious` 的名字。
+Stable、Preview 和 RC 的标签事件由 `release-stable-trigger.yml`、
+`release-cli-trigger.yml` / `release-desktop-trigger.yml` 转发：relay
+只携带候选 tag，实际顶层发布 workflow 固定运行在受保护的 `main-v2`，
+再签署该 tag 指向的不可变候选 SHA。不能把 Allowed branches 改成标签通配符，
+因为普通分支也可以取形如 `v-malicious` 的名字。
 
 `Release certificate 2026` 的 Restrictions 明确要求所有使用该证书的策略启用
 审批流程。尝试关闭时，SignPath 会拒绝保存并提示：
@@ -357,6 +360,8 @@ gh workflow run release-desktop.yml \
 Stable 发布由 `.github/workflows/release-stable.yml` 在唯一的 `release`
 environment 审批之后自动调用相同预检。该预检完成前，CLI、npm 和 Desktop
 三个公开 publisher 均不会启动，因此 SignPath 策略漂移不会再形成半发布。
+统一 Preview 发布由 `.github/workflows/release-preview.yml` 在唯一的
+`canary` environment 审批之后执行同样的预检，并具有相同的失败关闭语义。
 
 ### 10.1 监控运行
 
@@ -419,7 +424,8 @@ SignPath Signing Requests 中应出现 4 个成功请求：
 - 旧 `windows-installer` 未改变。
 - `release-signing` 的证书级审批保持开启，正式审批人可用。
 - `release-signing` 的 Build Definitions 精确允许
-  `.github/workflows/release-stable.yml` 和
+  `.github/workflows/release-stable.yml`、
+  `.github/workflows/release-preview.yml` 和
   `.github/workflows/release-desktop.yml`。
 - `release-signing` 的 Allowed branches 精确为 `main-v2`。
 - `CI builds` 是 `release-signing` 的 Submitter 和 Approver，GitHub Secret 使用其专用
@@ -538,7 +544,7 @@ gh variable set SIGNPATH_RELEASE_SIGNING_ATTESTATION \
 - [ ] `SIGNPATH_API_TOKEN` 对应专用 `CI builds`，不是个人账号
 - [ ] `release-signing` 已开启 Trusted Build System
 - [ ] `release-signing` 已开启 Origin Verification
-- [ ] `release-signing` 的 Allowed build definitions 精确为 `.github/workflows/release-stable.yml` 和 `.github/workflows/release-desktop.yml`
+- [ ] `release-signing` 的 Allowed build definitions 精确为 `.github/workflows/release-stable.yml`、`.github/workflows/release-preview.yml` 和 `.github/workflows/release-desktop.yml`
 - [ ] `release-signing` 的 Allowed branches 精确为 `main-v2`
 - [ ] `release-signing` 的 SignPath 审批已开启，Required approvals 为 `1`
 - [ ] GitHub `release` environment 的正式发布审批人和响应流程已经明确

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { publishPackages } from "./publish.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(HERE, "..");
@@ -25,6 +26,10 @@ if (!tag) {
 const version = tag.replace(/^(npm-)?v/, "");
 const binaryVersion = `v${version}`;
 const publish = process.argv.includes("--publish");
+const candidateSha = execFileSync("git", ["rev-parse", "HEAD"], {
+  cwd: ROOT,
+  encoding: "utf8",
+}).trim();
 
 rmSync(STAGE, { recursive: true, force: true });
 mkdirSync(STAGE, { recursive: true });
@@ -70,6 +75,7 @@ for (const t of TARGETS) {
           type: "git",
           url: "git+https://github.com/esengine/DeepSeek-Reasonix.git",
         },
+        reasonixCandidateSha: candidateSha,
       },
       null,
       2,
@@ -87,6 +93,7 @@ const mainPkg = JSON.parse(
   readFileSync(join(HERE, "reasonix", "package.json"), "utf8"),
 );
 mainPkg.version = version;
+mainPkg.reasonixCandidateSha = candidateSha;
 for (const key of Object.keys(mainPkg.optionalDependencies)) {
   mainPkg.optionalDependencies[key] = version;
 }
@@ -100,24 +107,11 @@ if (!publish) {
   process.exit(0);
 }
 
-// Three independent dist-tags: a `-canary.` build is the opt-in tester channel
-// (`canary`); any other prerelease (rc, beta) ships under `next`; a stable
-// version is promoted to `latest` automatically. The old "0.x stable owns
-// latest" rule was a migration guard while the 1.x Go line was rc-only — once
-// 1.x went stable it left `latest` pinned at 0.53.2, silently downgrading
-// every `npm update -g` / `pnpm update -g` user back to the retired line
-// (#5822). Stable now always moves `latest`; release-npm.yml verifies the tag
-// landed after publish.
-const distTag = version.includes("-canary.")
-  ? "canary"
-  : version.includes("-")
-    ? "next"
-    : "latest";
-const publishArgs = ["publish", "--access", "public", "--tag", distTag];
-
-for (const sub of subPackages) {
-  console.log(`publish ${sub.name}@${version} (${distTag})`);
-  execFileSync("npm", publishArgs, { cwd: sub.dir, stdio: "inherit" });
-}
-console.log(`publish reasonix@${version} (${distTag})`);
-execFileSync("npm", publishArgs, { cwd: mainDir, stdio: "inherit" });
+// Publish every immutable package before advancing the public channel. Recovery
+// reuses packages that already prove the same candidate SHA, fills only missing
+// packages, and never moves latest/next/canary back to an older version.
+publishPackages({
+  packages: [...subPackages, { name: "reasonix", dir: mainDir }],
+  version,
+  candidateSha,
+});

--- a/npm/publish.mjs
+++ b/npm/publish.mjs
@@ -1,0 +1,339 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const CANDIDATE_SHA_RE = /^[0-9a-f]{40}$/;
+const STABLE_RE = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const CANARY_RE = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-canary\.(0|[1-9][0-9]*)$/;
+const SEMVER_RE = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+function compareNumeric(a, b) {
+  const normalizedA = a.replace(/^0+(?=\d)/, "");
+  const normalizedB = b.replace(/^0+(?=\d)/, "");
+  if (normalizedA.length !== normalizedB.length) {
+    return normalizedA.length > normalizedB.length ? 1 : -1;
+  }
+  if (normalizedA === normalizedB) return 0;
+  return normalizedA > normalizedB ? 1 : -1;
+}
+
+function compareIdentifiers(a, b) {
+  const numericA = /^[0-9]+$/.test(a);
+  const numericB = /^[0-9]+$/.test(b);
+  if (numericA && numericB) return compareNumeric(a, b);
+  if (numericA !== numericB) return numericA ? -1 : 1;
+  if (a === b) return 0;
+  return a > b ? 1 : -1;
+}
+
+function parseSemver(version) {
+  const match = String(version).match(SEMVER_RE);
+  if (!match) throw new Error(`invalid npm release version: ${version}`);
+  return {
+    core: match.slice(1, 4),
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+function compareSemver(a, b) {
+  const aa = parseSemver(a);
+  const bb = parseSemver(b);
+  for (let i = 0; i < aa.core.length; i += 1) {
+    const compared = compareNumeric(aa.core[i], bb.core[i]);
+    if (compared !== 0) return compared;
+  }
+  if (!aa.prerelease.length || !bb.prerelease.length) {
+    if (aa.prerelease.length === bb.prerelease.length) return 0;
+    return aa.prerelease.length ? -1 : 1;
+  }
+  const count = Math.max(aa.prerelease.length, bb.prerelease.length);
+  for (let i = 0; i < count; i += 1) {
+    if (aa.prerelease[i] === undefined) return -1;
+    if (bb.prerelease[i] === undefined) return 1;
+    const compared = compareIdentifiers(aa.prerelease[i], bb.prerelease[i]);
+    if (compared !== 0) return compared;
+  }
+  return 0;
+}
+
+function requireVersionForDistTag(distTag, version) {
+  if (distTag === "latest" && STABLE_RE.test(version)) return;
+  if (distTag === "canary" && CANARY_RE.test(version)) return;
+  if (
+    distTag === "next" &&
+    SEMVER_RE.test(version) &&
+    version.includes("-") &&
+    !CANARY_RE.test(version)
+  ) {
+    return;
+  }
+  throw new Error(`version ${version} does not belong to npm dist-tag ${distTag}`);
+}
+
+export function distTagForVersion(version) {
+  if (CANARY_RE.test(version)) return "canary";
+  if (SEMVER_RE.test(version) && version.includes("-")) return "next";
+  if (STABLE_RE.test(version)) return "latest";
+  throw new Error(`invalid npm release version: ${version}`);
+}
+
+// Returns a positive value when candidate is newer, zero when it is current,
+// and a negative value when recovery is for an older immutable version.
+export function compareDistTagVersions(distTag, candidate, current) {
+  requireVersionForDistTag(distTag, candidate);
+  if (!current) return 1;
+  requireVersionForDistTag(distTag, current);
+  return compareSemver(candidate, current);
+}
+
+function defaultSleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function defaultRunner(args, { cwd, missingOk = false, inherit = false } = {}) {
+  const result = spawnSync("npm", args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: inherit ? "inherit" : ["ignore", "pipe", "pipe"],
+  });
+  if (result.status === 0) return inherit ? "" : result.stdout.trim();
+
+  const output = `${result.stdout || ""}\n${result.stderr || ""}`;
+  if (missingOk && /\bE404\b/.test(output)) return null;
+  const detail = output.trim();
+  throw new Error(
+    `npm ${args[0]} failed with exit code ${result.status}${detail ? `: ${detail}` : ""}`,
+  );
+}
+
+function parseJSON(output, description) {
+  if (output === null || output === "") return null;
+  try {
+    return JSON.parse(output);
+  } catch (error) {
+    throw new Error(`${description} returned invalid JSON: ${error.message}`);
+  }
+}
+
+function readLocalPackage(entry, version, candidateSha) {
+  const pkg = JSON.parse(readFileSync(`${entry.dir}/package.json`, "utf8"));
+  if (pkg.name !== entry.name || pkg.version !== version) {
+    throw new Error(
+      `local package identity mismatch: expected ${entry.name}@${version}, got ${pkg.name}@${pkg.version}`,
+    );
+  }
+  if (pkg.reasonixCandidateSha !== candidateSha) {
+    throw new Error(
+      `${entry.name}@${version} does not record candidate ${candidateSha}`,
+    );
+  }
+  return pkg;
+}
+
+function registryPackage(runner, name, version) {
+  const output = runner(
+    [
+      "view",
+      `${name}@${version}`,
+      "name",
+      "version",
+      "reasonixCandidateSha",
+      "gitHead",
+      "--json",
+    ],
+    { missingOk: true },
+  );
+  return parseJSON(output, `${name}@${version} metadata`);
+}
+
+function verifyRegistryPackage(metadata, name, version, candidateSha) {
+  if (!metadata) return false;
+  if (metadata.name !== name || metadata.version !== version) {
+    throw new Error(
+      `registry package identity mismatch: expected ${name}@${version}, got ${metadata.name}@${metadata.version}`,
+    );
+  }
+
+  const recordedCandidate = metadata.reasonixCandidateSha;
+  const gitHead = metadata.gitHead;
+  if (recordedCandidate && recordedCandidate !== candidateSha) {
+    throw new Error(
+      `immutable npm package ${name}@${version} belongs to candidate ${recordedCandidate}, expected ${candidateSha}`,
+    );
+  }
+  if (gitHead && gitHead !== candidateSha) {
+    throw new Error(
+      `immutable npm package ${name}@${version} has gitHead ${gitHead}, expected ${candidateSha}`,
+    );
+  }
+  if (!recordedCandidate && !gitHead) {
+    throw new Error(
+      `immutable npm package ${name}@${version} has no candidate provenance`,
+    );
+  }
+  return true;
+}
+
+function readDistTag(runner, name, distTag) {
+  const output = runner(
+    ["view", name, `dist-tags.${distTag}`, "--json"],
+    { missingOk: true },
+  );
+  const value = parseJSON(output, `${name} dist-tag ${distTag}`);
+  if (value === null || value === undefined) return "";
+  if (typeof value !== "string") {
+    throw new Error(`${name} dist-tag ${distTag} returned a non-string value`);
+  }
+  return value;
+}
+
+function waitForPackage(
+  runner,
+  entry,
+  version,
+  candidateSha,
+  attempts,
+  sleep,
+) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const metadata = registryPackage(runner, entry.name, version);
+    if (metadata) {
+      verifyRegistryPackage(metadata, entry.name, version, candidateSha);
+      return;
+    }
+    if (attempt < attempts) sleep(10_000);
+  }
+  throw new Error(`${entry.name}@${version} did not become visible in the npm registry`);
+}
+
+function ensurePackage(
+  runner,
+  entry,
+  version,
+  candidateSha,
+  stagingTag,
+  attempts,
+  sleep,
+  log,
+) {
+  readLocalPackage(entry, version, candidateSha);
+  const existing = registryPackage(runner, entry.name, version);
+  if (existing) {
+    verifyRegistryPackage(existing, entry.name, version, candidateSha);
+    log(`reuse ${entry.name}@${version} from candidate ${candidateSha}`);
+    return;
+  }
+
+  log(`publish ${entry.name}@${version} (${stagingTag})`);
+  try {
+    runner(
+      ["publish", "--access", "public", "--tag", stagingTag],
+      { cwd: entry.dir, inherit: true },
+    );
+  } catch (error) {
+    // A concurrent or retried publisher may have won after our read. Accept it
+    // only when the immutable registry metadata proves the same candidate.
+    const raced = registryPackage(runner, entry.name, version);
+    if (!raced) throw error;
+    verifyRegistryPackage(raced, entry.name, version, candidateSha);
+  }
+  waitForPackage(
+    runner,
+    entry,
+    version,
+    candidateSha,
+    attempts,
+    sleep,
+  );
+}
+
+function advanceDistTag(runner, name, version, distTag, attempts, sleep, log) {
+  const current = readDistTag(runner, name, distTag);
+  const comparison = compareDistTagVersions(distTag, version, current);
+  if (comparison > 0) {
+    log(`advance ${name} ${distTag}: ${current || "<unset>"} -> ${version}`);
+    runner(["dist-tag", "add", `${name}@${version}`, distTag], { inherit: true });
+  } else if (comparison === 0) {
+    log(`${name} ${distTag} already points to ${version}`);
+  } else {
+    log(`keep newer ${name} ${distTag} at ${current}; recovered ${version}`);
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const observed = readDistTag(runner, name, distTag);
+    if (
+      observed &&
+      compareDistTagVersions(distTag, observed, version) >= 0
+    ) {
+      return;
+    }
+    if (attempt < attempts) sleep(10_000);
+  }
+  throw new Error(`${name} dist-tag ${distTag} did not reach ${version} or newer`);
+}
+
+function cleanupStagingTag(runner, name, version, stagingTag, log) {
+  const current = readDistTag(runner, name, stagingTag);
+  if (current !== version) return;
+  log(`remove temporary ${name} dist-tag ${stagingTag}`);
+  runner(["dist-tag", "rm", name, stagingTag], { inherit: true });
+}
+
+export function publishPackages({
+  packages,
+  version,
+  candidateSha,
+  runner = defaultRunner,
+  sleep = defaultSleep,
+  attempts = 6,
+  log = console.log,
+}) {
+  if (!Array.isArray(packages) || packages.length === 0) {
+    throw new Error("npm publication requires at least one package");
+  }
+  if (!CANDIDATE_SHA_RE.test(candidateSha)) {
+    throw new Error(`invalid release candidate SHA: ${candidateSha}`);
+  }
+  const distTag = distTagForVersion(version);
+  const stagingTag = `${distTag}-staging`;
+  let failure;
+
+  try {
+    for (const entry of packages) {
+      ensurePackage(
+        runner,
+        entry,
+        version,
+        candidateSha,
+        stagingTag,
+        attempts,
+        sleep,
+        log,
+      );
+    }
+    for (const entry of packages) {
+      advanceDistTag(
+        runner,
+        entry.name,
+        version,
+        distTag,
+        attempts,
+        sleep,
+        log,
+      );
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  try {
+    for (const entry of packages) {
+      cleanupStagingTag(runner, entry.name, version, stagingTag, log);
+    }
+  } catch (error) {
+    if (!failure) failure = error;
+  }
+
+  if (failure) throw failure;
+  return { distTag, version };
+}

--- a/npm/publish.test.mjs
+++ b/npm/publish.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  compareDistTagVersions,
+  publishPackages,
+} from "./publish.mjs";
+
+const candidateSha = "a".repeat(40);
+
+function splitPackageSpec(spec) {
+  const separator = spec.lastIndexOf("@");
+  return [spec.slice(0, separator), spec.slice(separator + 1)];
+}
+
+function fixture(t, version = "1.5.0-canary.42") {
+  const root = mkdtempSync(join(tmpdir(), "reasonix-npm-publish-test-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const packages = ["@reasonix/cli-linux-x64", "reasonix"].map((name, index) => {
+    const dir = join(root, `package-${index}`);
+    mkdirSync(dir);
+    writeFileSync(
+      join(dir, "package.json"),
+      `${JSON.stringify({ name, version, reasonixCandidateSha: candidateSha })}\n`,
+    );
+    return { name, dir };
+  });
+  const registry = new Map(
+    packages.map(({ name }) => [name, { versions: new Map(), tags: new Map() }]),
+  );
+  const calls = [];
+
+  function packageState(name) {
+    if (!registry.has(name)) {
+      registry.set(name, { versions: new Map(), tags: new Map() });
+    }
+    return registry.get(name);
+  }
+
+  function runner(args, { cwd, missingOk = false } = {}) {
+    calls.push({ args: [...args], cwd });
+    if (args[0] === "view" && args[2]?.startsWith("dist-tags.")) {
+      const state = registry.get(args[1]);
+      if (!state) return missingOk ? null : "";
+      const value = state.tags.get(args[2].slice("dist-tags.".length));
+      return value ? JSON.stringify(value) : "";
+    }
+    if (args[0] === "view") {
+      const [name, requestedVersion] = splitPackageSpec(args[1]);
+      const metadata = registry.get(name)?.versions.get(requestedVersion);
+      return metadata ? JSON.stringify(metadata) : missingOk ? null : "";
+    }
+    if (args[0] === "publish") {
+      const pkg = JSON.parse(readFileSync(join(cwd, "package.json"), "utf8"));
+      const state = packageState(pkg.name);
+      if (state.versions.has(pkg.version)) {
+        throw new Error(`version already exists: ${pkg.name}@${pkg.version}`);
+      }
+      state.versions.set(pkg.version, {
+        name: pkg.name,
+        version: pkg.version,
+        reasonixCandidateSha: pkg.reasonixCandidateSha,
+        gitHead: pkg.reasonixCandidateSha,
+      });
+      state.tags.set(args[args.indexOf("--tag") + 1], pkg.version);
+      return "";
+    }
+    if (args[0] === "dist-tag" && args[1] === "add") {
+      const [name, requestedVersion] = splitPackageSpec(args[2]);
+      assert.ok(packageState(name).versions.has(requestedVersion));
+      packageState(name).tags.set(args[3], requestedVersion);
+      return "";
+    }
+    if (args[0] === "dist-tag" && args[1] === "rm") {
+      packageState(args[2]).tags.delete(args[3]);
+      return "";
+    }
+    throw new Error(`unsupported fake npm invocation: ${args.join(" ")}`);
+  }
+
+  function publish() {
+    return publishPackages({
+      packages,
+      version,
+      candidateSha,
+      runner,
+      sleep: () => {},
+      attempts: 2,
+      log: () => {},
+    });
+  }
+
+  function addVersion(name, publishedVersion = version, sha = candidateSha) {
+    packageState(name).versions.set(publishedVersion, {
+      name,
+      version: publishedVersion,
+      reasonixCandidateSha: sha,
+      gitHead: sha,
+    });
+  }
+
+  return { packages, registry, calls, publish, addVersion };
+}
+
+test("reuses a fully published npm candidate without republishing", (t) => {
+  const fx = fixture(t);
+  for (const { name } of fx.packages) {
+    fx.addVersion(name);
+    fx.registry.get(name).tags.set("canary", "1.5.0-canary.42");
+  }
+
+  assert.deepEqual(fx.publish(), {
+    distTag: "canary",
+    version: "1.5.0-canary.42",
+  });
+  assert.equal(fx.calls.filter(({ args }) => args[0] === "publish").length, 0);
+});
+
+test("fills a partially published package set before advancing canary", (t) => {
+  const fx = fixture(t);
+  fx.addVersion(fx.packages[0].name);
+  for (const { name } of fx.packages) {
+    fx.registry.get(name).tags.set("canary", "1.5.0-canary.41");
+  }
+
+  fx.publish();
+
+  const publishes = fx.calls.filter(({ args }) => args[0] === "publish");
+  assert.equal(publishes.length, 1);
+  assert.equal(publishes[0].cwd, fx.packages[1].dir);
+  for (const { name } of fx.packages) {
+    assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.42");
+    assert.equal(fx.registry.get(name).tags.has("canary-staging"), false);
+  }
+});
+
+test("rejects an immutable package owned by another candidate", (t) => {
+  const fx = fixture(t);
+  fx.addVersion(fx.packages[0].name, "1.5.0-canary.42", "b".repeat(40));
+
+  assert.throws(
+    () => fx.publish(),
+    /belongs to candidate b{40}, expected a{40}/,
+  );
+  assert.equal(fx.calls.filter(({ args }) => args[0] === "publish").length, 0);
+});
+
+test("stale recovery publishes missing packages without rolling canary back", (t) => {
+  const fx = fixture(t);
+  fx.addVersion(fx.packages[0].name);
+  for (const { name } of fx.packages) {
+    fx.addVersion(name, "1.5.0-canary.43");
+    fx.registry.get(name).tags.set("canary", "1.5.0-canary.43");
+  }
+
+  fx.publish();
+
+  assert.ok(
+    fx.registry
+      .get(fx.packages[1].name)
+      .versions.has("1.5.0-canary.42"),
+  );
+  for (const { name } of fx.packages) {
+    assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.43");
+  }
+  assert.equal(
+    fx.calls.some(
+      ({ args }) =>
+        args[0] === "dist-tag" &&
+        args[1] === "add" &&
+        args[3] === "canary",
+    ),
+    false,
+  );
+});
+
+test("accepts legacy packages whose gitHead proves the candidate", (t) => {
+  const fx = fixture(t);
+  for (const { name } of fx.packages) {
+    fx.registry.get(name).versions.set("1.5.0-canary.42", {
+      name,
+      version: "1.5.0-canary.42",
+      gitHead: candidateSha,
+    });
+    fx.registry.get(name).tags.set("canary", "1.5.0-canary.42");
+  }
+
+  assert.doesNotThrow(() => fx.publish());
+});
+
+test("compares channel versions without integer truncation", () => {
+  assert.equal(
+    compareDistTagVersions(
+      "canary",
+      "1.5.0-canary.100000000000000000000",
+      "1.5.0-canary.99999999999999999999",
+    ),
+    1,
+  );
+  assert.equal(
+    compareDistTagVersions("latest", "2.0.0", "10.0.0"),
+    -1,
+  );
+  assert.equal(
+    compareDistTagVersions("next", "1.5.0-rc.10", "1.5.0-rc.2"),
+    1,
+  );
+});

--- a/scripts/compare-cli-release-manifests.sh
+++ b/scripts/compare-cli-release-manifests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+candidate="${1:-}"
+existing="${2:-}"
+
+for manifest in "$candidate" "$existing"; do
+	if [ ! -f "$manifest" ]; then
+		echo "CLI release manifest does not exist: $manifest" >&2
+		exit 1
+	fi
+done
+
+# Immutable manifests published before release_notes_url existed remain valid.
+# Normalize only that missing field from the strict candidate; every other
+# semantic difference must still fail the immutable recovery check.
+jq -e -s '
+	.[0] as $candidate |
+	.[1] as $existing |
+	($existing | .release_notes_url = (.release_notes_url // $candidate.release_notes_url)) == $candidate
+' "$candidate" "$existing" >/dev/null

--- a/scripts/compare-desktop-release-manifests.sh
+++ b/scripts/compare-desktop-release-manifests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+candidate="${1:-}"
+existing="${2:-}"
+
+for manifest in "$candidate" "$existing"; do
+	if [ ! -f "$manifest" ]; then
+		echo "Desktop release manifest does not exist: $manifest" >&2
+		exit 1
+	fi
+done
+
+# Preserve immutable manifests created before release_notes_url existed. Only
+# that absent field inherits the strict candidate value; all other manifest
+# content must remain semantically identical.
+jq -e -s '
+	.[0] as $candidate |
+	.[1] as $existing |
+	($existing | .release_notes_url = (.release_notes_url // $candidate.release_notes_url)) == $candidate
+' "$candidate" "$existing" >/dev/null

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -157,9 +157,25 @@ async function main() {
   if (!args.version) throw new Error("--version is required");
   const version = normalizeVersion(args.version);
   const catalog = await loadCatalog();
-  const previous = args.from || catalog.releases.find((release) => release.version !== version)?.version;
+  const channel = version.includes("-") ? "prerelease" : "stable";
+  const baseVersion = version.split("-")[0];
+  const previousRecord = channel === "stable"
+    ? catalog.releases.find((release) => release.version !== version && release.channel === "stable")
+    : catalog.releases.find(
+        (release) =>
+          release.version !== version &&
+          release.channel === "prerelease" &&
+          release.baseVersion === baseVersion,
+      ) || catalog.releases.find((release) => release.channel === "stable");
+  const previous = args.from || previousRecord?.version;
   if (!previous) throw new Error("--from is required when no previous release exists");
-  const from = previous.match(/^(?:desktop-|npm-)?v/) ? previous : `desktop-v${previous}`;
+  const previousVersion = normalizeVersion(previous);
+  const previousIsPreview = previousVersion.includes("-");
+  const from = previous.match(/^(?:desktop-|npm-)?v/)
+    ? previous
+    : previousIsPreview
+      ? `v${previousVersion}`
+      : `desktop-v${previousVersion}`;
   const to = args.to || "HEAD";
   const repository = repositoryName();
   const commits = commitRange(from, to);
@@ -168,24 +184,45 @@ async function main() {
   if (!pulls.length) throw new Error(`no pull requests found in ${from}..${to}`);
   const docLinks = collectDocLinks(from, repository, to);
   const date = args.date || new Date().toISOString().slice(0, 10);
-  const tag = args.tag || `desktop-v${version}`;
+  const tag = args.tag || (channel === "prerelease" ? `v${version}` : `desktop-v${version}`);
   const source = {
     version,
     date,
-    channel: version.includes("-") ? "prerelease" : "stable",
+    channel,
     range: `${from}..${to}`,
     pullRequests: pulls,
     documentationUrls: docLinks,
   };
   const release = await askDeepSeek(source);
   release.version = version;
+  release.releaseId = version;
+  release.baseVersion = baseVersion;
   release.date = date;
   release.channel = source.channel;
+  release.status = "reviewed";
+  release.previousRelease = previousVersion;
+  const previewOrdinal = version.match(/-preview\.([1-9][0-9]*)$/)?.[1];
+  if (channel === "prerelease") {
+    if (!previewOrdinal) throw new Error("Preview release version must use MAJOR.MINOR.PATCH-preview.N");
+    release.builds = {
+      cli: `v${version}`,
+      desktop: `v${baseVersion}-preview.${previewOrdinal}`,
+      npm: `${baseVersion}-canary.${previewOrdinal}`,
+    };
+  } else {
+    release.builds = {
+      cli: `v${version}`,
+      desktop: `v${version}`,
+      npm: version,
+    };
+  }
   release.contributors = [...new Set(pulls.map((pull) => pull.author).filter(Boolean))];
   release.links = {
     github: `https://github.com/${repository}/releases/tag/${tag}`,
     compare: `https://github.com/${repository}/compare/${from}...${tag}`,
-    download: "https://reasonix.io/?download=desktop#start",
+    download: channel === "prerelease"
+      ? "https://reasonix.io/?download=desktop&channel=preview#start"
+      : "https://reasonix.io/?download=desktop&channel=stable#start",
   };
   release.guides = (release.guides || []).filter((guide) => docLinks.includes(guide.href));
   assertGroundedRefs(release, new Set(pulls.map((pull) => pull.number)));

--- a/scripts/release-event.mjs
+++ b/scripts/release-event.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadCatalog, releaseForVersion } from "./release-notes.mjs";
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseArgs(argv) {
+  const [command = "validate", ...rest] = argv;
+  const values = { command };
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (!arg.startsWith("--")) throw new Error(`unexpected argument ${arg}`);
+    values[arg.slice(2)] = rest[++index];
+  }
+  return values;
+}
+
+export function validateReleaseEvent(event, release) {
+  invariant(event && typeof event === "object" && !Array.isArray(event), "release event must be an object");
+  invariant(event.schemaVersion === 1, "release event schemaVersion must be 1");
+  invariant(event.releaseId === release.version, "release event releaseId does not match reviewed notes");
+  invariant(
+    event.channel === (release.channel === "prerelease" ? "preview" : "stable"),
+    "release event channel does not match reviewed notes",
+  );
+  invariant(/^[0-9a-f]{40}$/.test(event.candidateSha), "release event candidateSha must be a full commit SHA");
+  if (release.candidateSha) {
+    invariant(event.candidateSha === release.candidateSha, "release event candidateSha does not match reviewed notes");
+  }
+  invariant(/^\d{4}-\d{2}-\d{2}T/.test(event.publishedAt), "release event publishedAt must be an ISO timestamp");
+  invariant(event.releaseNotesUrl === `https://reasonix.io/changelog/v${release.version}/`, "release event URL is invalid");
+  invariant(event.builds && typeof event.builds === "object", "release event builds are required");
+  for (const surface of ["cli", "desktop", "npm"]) {
+    invariant(typeof event.builds[surface] === "string" && event.builds[surface], `release event builds.${surface} is required`);
+    if (release.builds?.[surface]) {
+      invariant(event.builds[surface] === release.builds[surface], `release event builds.${surface} does not match reviewed notes`);
+    }
+  }
+  return event;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  invariant(args.version, "--version is required");
+  const catalog = await loadCatalog(args.catalog ? resolve(args.catalog) : undefined);
+  const release = releaseForVersion(catalog, args.version);
+
+  if (args.command === "generate") {
+    invariant(args.sha, "generate requires --sha");
+    invariant(args.output, "generate requires --output");
+    const event = validateReleaseEvent({
+      schemaVersion: 1,
+      releaseId: release.version,
+      channel: release.channel === "prerelease" ? "preview" : "stable",
+      candidateSha: args.sha,
+      publishedAt: args["published-at"] || new Date().toISOString(),
+      releaseNotesUrl: `https://reasonix.io/changelog/v${release.version}/`,
+      builds: release.builds,
+    }, release);
+    await writeFile(resolve(args.output), `${JSON.stringify(event, null, 2)}\n`);
+    return;
+  }
+
+  invariant(args.command === "validate", `unknown command ${args.command}`);
+  invariant(args.input, "validate requires --input");
+  const event = JSON.parse(await readFile(resolve(args.input), "utf8"));
+  validateReleaseEvent(event, release);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -10,6 +10,8 @@ export const defaultCatalogPath = resolve(repoRoot, "release-notes/releases.json
 const localizedFields = ["title", "body"];
 const changeKinds = ["new", "improved", "fixed"];
 const itemKinds = new Set(["new", "improved", "fixed", "security"]);
+const releaseChannels = new Set(["stable", "prerelease"]);
+const releaseStatuses = new Set(["reviewed", "published"]);
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -47,7 +49,7 @@ function semverParts(version) {
   return [Number(match[1]), Number(match[2]), Number(match[3]), match[4] || ""];
 }
 
-function compareVersionsDesc(a, b) {
+export function compareVersionsDesc(a, b) {
   const aa = semverParts(a);
   const bb = semverParts(b);
   for (let i = 0; i < 3; i += 1) {
@@ -72,7 +74,58 @@ export function validateCatalog(catalog) {
     invariant(!versions.has(release.version), `duplicate version ${release.version}`);
     versions.add(release.version);
     invariant(/^\d{4}-\d{2}-\d{2}$/.test(release.date), `${path}.date must use YYYY-MM-DD`);
-    invariant(release.channel === "stable" || release.channel === "prerelease", `${path}.channel is invalid`);
+    invariant(releaseChannels.has(release.channel), `${path}.channel is invalid`);
+    if (release.releaseId !== undefined) {
+      invariant(release.releaseId === release.version, `${path}.releaseId must equal version`);
+    }
+    if (release.baseVersion !== undefined) {
+      semverParts(release.baseVersion);
+      invariant(!release.baseVersion.includes("-"), `${path}.baseVersion must be stable semver`);
+      invariant(
+        release.version === release.baseVersion || release.version.startsWith(`${release.baseVersion}-`),
+        `${path}.baseVersion does not match version`,
+      );
+    }
+    if (release.status !== undefined) {
+      invariant(releaseStatuses.has(release.status), `${path}.status is invalid`);
+    }
+    if (release.candidateSha !== undefined) {
+      invariant(/^[0-9a-f]{40}$/.test(release.candidateSha), `${path}.candidateSha must be a full commit SHA`);
+    }
+    if (release.previousRelease !== undefined) {
+      semverParts(release.previousRelease);
+      invariant(release.previousRelease !== release.version, `${path}.previousRelease must differ from version`);
+    }
+    if (release.builds !== undefined) {
+      invariant(isObject(release.builds), `${path}.builds must be an object`);
+      for (const surface of ["cli", "desktop", "npm"]) {
+        invariant(
+          typeof release.builds[surface] === "string" && release.builds[surface].trim(),
+          `${path}.builds.${surface} must be a non-empty string`,
+        );
+      }
+    }
+    if (release.status !== undefined) {
+      for (const field of ["releaseId", "baseVersion", "previousRelease", "builds"]) {
+        invariant(release[field] !== undefined, `${path}.${field} is required for managed release records`);
+      }
+      if (release.channel === "stable") {
+        invariant(release.version === release.baseVersion, `${path}.stable version must equal baseVersion`);
+        invariant(release.builds.cli === `v${release.version}`, `${path}.builds.cli does not match Stable version`);
+        invariant(release.builds.desktop === `v${release.version}`, `${path}.builds.desktop does not match Stable version`);
+        invariant(release.builds.npm === release.version, `${path}.builds.npm does not match Stable version`);
+      } else {
+        const preview = release.version.match(/^(\d+\.\d+\.\d+)-preview\.([1-9][0-9]*)$/);
+        invariant(preview, `${path}.managed prerelease must use MAJOR.MINOR.PATCH-preview.N`);
+        invariant(preview[1] === release.baseVersion, `${path}.Preview baseVersion does not match version`);
+        invariant(release.builds.cli === `v${release.version}`, `${path}.builds.cli does not match Preview version`);
+        invariant(release.builds.desktop === `v${release.version}`, `${path}.builds.desktop does not match Preview version`);
+        invariant(
+          release.builds.npm === `${release.baseVersion}-canary.${preview[2]}`,
+          `${path}.builds.npm does not match Preview ordinal`,
+        );
+      }
+    }
     validateLocalized(release.title, `${path}.title`);
     validateLocalized(release.summary, `${path}.summary`);
     invariant(Array.isArray(release.surfaces) && release.surfaces.length > 0, `${path}.surfaces must not be empty`);
@@ -136,8 +189,12 @@ function renderItems(items, lang) {
 
 export function renderGitHubRelease(release, lang = "zh") {
   const isZh = lang === "zh";
+  const isPreview = release.channel === "prerelease";
+  const channelLabel = isPreview ? (isZh ? "预览版" : "Preview") : (isZh ? "稳定版" : "Stable");
   const lines = [
     `> ${localized(release.summary, lang)}`,
+    "",
+    `**${isZh ? "发布渠道" : "Release channel"}：${channelLabel} · v${release.version}**`,
     "",
     isZh
       ? `[English →](https://reasonix.io/changelog/v${release.version}/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v${release.version}/)`

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { loadCatalog, releaseForVersion, renderGitHubRelease, validateCatalog } from "./release-notes.mjs";
+import { validateReleaseEvent } from "./release-event.mjs";
 
 test("the committed release catalog is valid and newest first", async () => {
   const catalog = await loadCatalog();
@@ -43,5 +44,78 @@ test("validation rejects bilingual drift", () => {
         ],
       }),
     /title\.zh/,
+  );
+});
+
+test("managed Preview records bind every surface to one exact ordinal", () => {
+  const release = {
+    version: "1.19.0-preview.3",
+    releaseId: "1.19.0-preview.3",
+    baseVersion: "1.19.0",
+    date: "2026-07-31",
+    channel: "prerelease",
+    status: "reviewed",
+    previousRelease: "1.19.0-preview.2",
+    builds: {
+      cli: "v1.19.0-preview.3",
+      desktop: "v1.19.0-preview.3",
+      npm: "1.19.0-canary.3",
+    },
+    title: { en: "Preview", zh: "预览版" },
+    summary: { en: "Preview summary", zh: "预览版摘要" },
+    surfaces: ["cli"],
+    guides: [],
+    highlights: [{
+      kind: "fixed",
+      title: { en: "Fix", zh: "修复" },
+      body: { en: "A fix.", zh: "一项修复。" },
+      refs: [1],
+    }],
+    changes: { new: [], improved: [], fixed: [] },
+    upgrade: [],
+    risks: [],
+    contributors: [],
+    links: {
+      github: "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.19.0-preview.3",
+      compare: "https://github.com/esengine/DeepSeek-Reasonix/compare/v1.19.0-preview.2...v1.19.0-preview.3",
+      download: "https://reasonix.io/?download=desktop&channel=preview#start",
+    },
+  };
+
+  assert.doesNotThrow(() => validateCatalog({ schemaVersion: 1, releases: [release] }));
+  assert.throws(
+    () => validateCatalog({
+      schemaVersion: 1,
+      releases: [{ ...release, builds: { ...release.builds, npm: "1.19.0-canary.4" } }],
+    }),
+    /builds\.npm/,
+  );
+});
+
+test("publication marker is bound to reviewed version, channel, SHA, and builds", () => {
+  const release = {
+    version: "1.19.0-preview.3",
+    channel: "prerelease",
+    candidateSha: "a".repeat(40),
+    builds: {
+      cli: "v1.19.0-preview.3",
+      desktop: "v1.19.0-preview.3",
+      npm: "1.19.0-canary.3",
+    },
+  };
+  const event = {
+    schemaVersion: 1,
+    releaseId: release.version,
+    channel: "preview",
+    candidateSha: release.candidateSha,
+    publishedAt: "2026-07-31T00:00:00.000Z",
+    releaseNotesUrl: "https://reasonix.io/changelog/v1.19.0-preview.3/",
+    builds: release.builds,
+  };
+
+  assert.doesNotThrow(() => validateReleaseEvent(event, release));
+  assert.throws(
+    () => validateReleaseEvent({ ...event, candidateSha: "b".repeat(40) }, release),
+    /candidateSha/,
   );
 });

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -137,6 +137,7 @@ if grep -Eq 'gh release create .*dist/' "$repo_root/.github/workflows/release-de
 fi
 grep -Fq 'scripts/decide-desktop-pointer-update.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'scripts/verify-desktop-release-directory.sh' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'scripts/compare-desktop-release-manifests.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "preview/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "canary/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'publish_pointer canary' "$repo_root/.github/workflows/release-desktop.yml"
@@ -201,8 +202,8 @@ grep -Fq 'cli/${channel}/latest.json' "$cli_release_workflow"
 grep -Fq "group: release-cli-\${{ inputs.channel || 'stable' }}" "$cli_release_workflow"
 grep -Fq 'scripts/decide-cli-pointer-update.sh' "$cli_release_workflow"
 grep -Fq 'scripts/validate-cli-release-manifest.sh' "$cli_release_workflow"
+grep -Fq 'scripts/compare-cli-release-manifests.sh' "$cli_release_workflow"
 grep -Fq 'immutable CLI release metadata for $TAG already exists with different content' "$cli_release_workflow"
-grep -Fq 'cmp -s /tmp/cli-release.json /tmp/cli-release.immutable.json' "$cli_release_workflow"
 grep -Fq 'cmp -s /tmp/cli-release.json /tmp/cli-release.pointer.json' "$cli_release_workflow"
 grep -Eq 'internal CLI release .*Stable and Preview pointers remain unchanged' "$cli_release_workflow"
 cli_public_validation_line="$(
@@ -266,7 +267,9 @@ for asset in \
 	grep -Fq "\"$asset\"" "$cli_release_workflow"
 done
 manifest_validator="$repo_root/scripts/validate-cli-release-manifest.sh"
+manifest_comparator="$repo_root/scripts/compare-cli-release-manifests.sh"
 test -x "$manifest_validator"
+test -x "$manifest_comparator"
 manifest_assets='[
 	"reasonix-darwin-amd64.tar.gz",
 	"reasonix-darwin-arm64.tar.gz",
@@ -301,6 +304,45 @@ jq -n \
 ' >"$manifest_file"
 bash "$manifest_validator" stable "$manifest_tag" "$manifest_repo" "$manifest_file"
 bash "$manifest_validator" any "$manifest_tag" "$manifest_repo" "$manifest_file"
+
+legacy_manifest="$test_root/cli-release-manifest-legacy.json"
+jq 'del(.release_notes_url)' "$manifest_file" >"$legacy_manifest"
+bash "$manifest_validator" legacy-stable "$manifest_tag" "$manifest_repo" "$legacy_manifest"
+bash "$manifest_comparator" "$manifest_file" "$legacy_manifest"
+if bash "$manifest_validator" stable "$manifest_tag" "$manifest_repo" "$legacy_manifest" >/dev/null 2>&1; then
+	echo "strict CLI manifest validator accepted a legacy manifest" >&2
+	exit 1
+fi
+wrong_legacy_notes="$test_root/cli-release-manifest-wrong-legacy-notes.json"
+jq '.release_notes_url = "https://reasonix.io/changelog/v9.9.9/"' \
+	"$manifest_file" >"$wrong_legacy_notes"
+if bash "$manifest_validator" legacy-stable "$manifest_tag" "$manifest_repo" \
+	"$wrong_legacy_notes" >/dev/null 2>&1; then
+	echo "legacy CLI manifest validator accepted a mismatched release-notes URL" >&2
+	exit 1
+fi
+if bash "$manifest_comparator" "$manifest_file" "$wrong_legacy_notes" >/dev/null 2>&1; then
+	echo "CLI manifest comparator ignored a non-legacy difference" >&2
+	exit 1
+fi
+
+rc_manifest_tag="v1.2.4-rc.1"
+rc_notes_tag="v1.2.4"
+rc_manifest="$test_root/cli-release-manifest-rc.json"
+jq \
+	--arg repo "$manifest_repo" \
+	--arg tag "$rc_manifest_tag" \
+	--arg notes_tag "$rc_notes_tag" '
+	.tag_name = $tag |
+	.prerelease = true |
+	.html_url = ("https://github.com/" + $repo + "/releases/tag/" + $tag) |
+	.release_notes_url = ("https://reasonix.io/changelog/" + $notes_tag + "/") |
+	.assets |= map(
+		.browser_download_url =
+			("https://github.com/" + $repo + "/releases/download/" + $tag + "/" + .name)
+	)
+' "$manifest_file" >"$rc_manifest"
+bash "$manifest_validator" any "$rc_manifest_tag" "$manifest_repo" "$rc_manifest" "$rc_notes_tag"
 
 expect_invalid_cli_manifest() {
 	local description="$1"
@@ -441,6 +483,34 @@ cp "$candidate_directory/a" "$existing_directory/a"
 printf 'unexpected\n' >"$existing_directory/unexpected"
 if bash "$desktop_directory_verifier" --allow-missing "$candidate_directory" "$existing_directory" >/dev/null 2>&1; then
 	echo "Desktop release directory verifier accepted an unexpected immutable object" >&2
+	exit 1
+fi
+
+legacy_candidate_directory="$test_root/desktop-directory-legacy-candidate"
+legacy_existing_directory="$test_root/desktop-directory-legacy-existing"
+mkdir -p "$legacy_candidate_directory" "$legacy_existing_directory"
+printf 'asset\n' >"$legacy_candidate_directory/artifact"
+cp "$legacy_candidate_directory/artifact" "$legacy_existing_directory/artifact"
+jq -n '{
+	version: "v1.2.3",
+	release_notes_url: "https://reasonix.io/changelog/v1.2.3/",
+	platforms: {"darwin-arm64": {size: 42}}
+}' >"$legacy_candidate_directory/latest.json"
+jq 'del(.release_notes_url)' "$legacy_candidate_directory/latest.json" \
+	>"$legacy_existing_directory/latest.json"
+bash "$desktop_directory_verifier" --allow-legacy-manifest \
+	"$legacy_candidate_directory" "$legacy_existing_directory"
+if bash "$desktop_directory_verifier" \
+	"$legacy_candidate_directory" "$legacy_existing_directory" >/dev/null 2>&1; then
+	echo "Desktop release directory verifier accepted a legacy manifest without opt-in" >&2
+	exit 1
+fi
+jq '.platforms["darwin-arm64"].size = 99' "$legacy_existing_directory/latest.json" \
+	>"$legacy_existing_directory/latest-conflict.json"
+mv "$legacy_existing_directory/latest-conflict.json" "$legacy_existing_directory/latest.json"
+if bash "$desktop_directory_verifier" --allow-legacy-manifest \
+	"$legacy_candidate_directory" "$legacy_existing_directory" >/dev/null 2>&1; then
+	echo "Desktop release directory verifier ignored a non-legacy manifest difference" >&2
 	exit 1
 fi
 
@@ -630,12 +700,16 @@ if PATH="$fake_gh_bin:$PATH" FAKE_GH_STATE="$fake_gh_state" \
 fi
 
 desktop_validator="$repo_root/scripts/validate-desktop-release-manifest.sh"
+desktop_manifest_comparator="$repo_root/scripts/compare-desktop-release-manifests.sh"
 test -x "$desktop_validator"
+test -x "$desktop_manifest_comparator"
 write_desktop_manifest() {
 	local version="$1"
 	local base="$2"
 	local output="$3"
-	jq -n --arg version "$version" --arg base "$base" --arg sha "$(printf 'a%.0s' {1..64})" '
+	local notes_version="${4:-$version}"
+	jq -n --arg version "$version" --arg notes_version "$notes_version" \
+		--arg base "$base" --arg sha "$(printf 'a%.0s' {1..64})" '
 		def asset($name): {
 			url: ($base + $name),
 			sig: ($base + $name + ".minisig"),
@@ -645,7 +719,7 @@ write_desktop_manifest() {
 		{
 			version: $version,
 			download_page: "https://reasonix.io/?download=desktop#start",
-			release_notes_url: ("https://reasonix.io/changelog/" + $version + "/"),
+			release_notes_url: ("https://reasonix.io/changelog/" + $notes_version + "/"),
 			platforms: {
 				"darwin-arm64": asset("Reasonix-darwin-arm64.zip"),
 				"darwin-amd64": asset("Reasonix-darwin-amd64.zip"),
@@ -682,10 +756,31 @@ write_desktop_manifest "$desktop_preview_version" "$desktop_preview_base" "$desk
 bash "$desktop_validator" preview "$desktop_preview_version" "$desktop_preview_base" "$desktop_preview_manifest"
 
 desktop_rc_version="v1.3.0-rc.1"
+desktop_rc_notes_version="v1.3.0"
 desktop_rc_base="https://dl.reasonix.io/desktop-${desktop_rc_version}/"
 desktop_rc_manifest="$test_root/desktop-rc.json"
-write_desktop_manifest "$desktop_rc_version" "$desktop_rc_base" "$desktop_rc_manifest"
-bash "$desktop_validator" any "$desktop_rc_version" "$desktop_rc_base" "$desktop_rc_manifest"
+write_desktop_manifest "$desktop_rc_version" "$desktop_rc_base" "$desktop_rc_manifest" \
+	"$desktop_rc_notes_version"
+bash "$desktop_validator" any "$desktop_rc_version" "$desktop_rc_base" \
+	"$desktop_rc_manifest" "$desktop_rc_notes_version"
+
+desktop_legacy_notes_manifest="$test_root/desktop-stable-legacy-notes.json"
+jq 'del(.release_notes_url)' "$desktop_stable_manifest" >"$desktop_legacy_notes_manifest"
+bash "$desktop_validator" legacy-stable "$desktop_stable_version" \
+	"$desktop_stable_base" "$desktop_legacy_notes_manifest"
+bash "$desktop_manifest_comparator" "$desktop_stable_manifest" "$desktop_legacy_notes_manifest"
+if bash "$desktop_validator" stable "$desktop_stable_version" "$desktop_stable_base" \
+	"$desktop_legacy_notes_manifest" >/dev/null 2>&1; then
+	echo "strict Desktop manifest validator accepted a legacy release-notes manifest" >&2
+	exit 1
+fi
+jq '.release_notes_url = "https://reasonix.io/changelog/v9.9.9/"' \
+	"$desktop_stable_manifest" >"$test_root/desktop-wrong-legacy-notes.json"
+if bash "$desktop_manifest_comparator" "$desktop_stable_manifest" \
+	"$test_root/desktop-wrong-legacy-notes.json" >/dev/null 2>&1; then
+	echo "Desktop manifest comparator ignored a non-legacy difference" >&2
+	exit 1
+fi
 
 expect_invalid_desktop_manifest() {
 	local description="$1"
@@ -975,12 +1070,14 @@ EVENT_NAME=push IN_CHANNEL=stable IN_TAG=desktop-v1.2.3 REF_NAME=v1.2.3 RUN_NUMB
 	GITHUB_OUTPUT="$test_root/desktop-stable.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
 grep -Eq '^tag=desktop-v1\.2\.3$' "$test_root/desktop-stable.out"
 grep -Eq '^version=v1\.2\.3$' "$test_root/desktop-stable.out"
+grep -Eq '^notes_version=v1\.2\.3$' "$test_root/desktop-stable.out"
 
 EVENT_NAME=workflow_dispatch IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=42 \
 	GITHUB_OUTPUT="$test_root/desktop-preview.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
 grep -Eq '^version=v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 grep -Eq '^tag=desktop-v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 grep -Eq '^channel=preview$' "$test_root/desktop-preview.out"
+grep -Eq '^notes_version=v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 
 if EVENT_NAME=workflow_dispatch IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 \
 	IN_TAG=desktop-v1.3.0-preview.42 REF_NAME=main-v2 RUN_NUMBER=42 \
@@ -1004,6 +1101,7 @@ grep -Eq '^channel=preview$' "$test_root/desktop-canary-compat.out"
 EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=desktop-v1.4.0-rc.1 RUN_NUMBER=50 \
 	GITHUB_OUTPUT="$test_root/desktop-rc.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
 grep -Eq '^prerelease=true$' "$test_root/desktop-rc.out"
+grep -Eq '^notes_version=v1\.4\.0$' "$test_root/desktop-rc.out"
 
 if EVENT_NAME=workflow_dispatch IN_CHANNEL=stable IN_TAG=desktop-v1.4.0-preview.1 \
 	REF_NAME=main-v2 RUN_NUMBER=50 GITHUB_OUTPUT="$test_root/desktop-preview-as-stable.out" \
@@ -1042,6 +1140,7 @@ EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=v1.3.0-rc.1 \
 	GITHUB_OUTPUT="$test_root/cli-rc.out" bash "$repo_root/scripts/resolve-cli-release.sh"
 grep -Eq '^channel=stable$' "$test_root/cli-rc.out"
 grep -Eq '^prerelease=true$' "$test_root/cli-rc.out"
+grep -Eq '^notes_version=v1\.3\.0$' "$test_root/cli-rc.out"
 
 if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=stable \
 	IN_TAG=v1.3.0-preview.42 REF_NAME=main-v2 CALLER_REF=refs/heads/main-v2 \

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -116,6 +116,8 @@ if sed -n '/^  workflow_dispatch:/,/^  workflow_call:/p' "$repo_root/.github/wor
 	exit 1
 fi
 grep -Fq 'if: ${{ !inputs.orchestrated }}' "$repo_root/.github/workflows/release-npm.yml"
+grep -Fq 'Publish or recover immutable npm packages' "$repo_root/.github/workflows/release-npm.yml"
+grep -Fq 'publishPackages' "$repo_root/npm/build.mjs"
 grep -Eq 'signing-policy-slug: release-signing' "$repo_root/.github/workflows/release-desktop.yml"
 if grep -Eq 'signing-policy-slug:.*test-signing' "$repo_root/.github/workflows/release-desktop.yml"; then
 	echo "public desktop workflow must not use the SignPath test certificate" >&2
@@ -1242,5 +1244,7 @@ if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=stable IN_BASE_
 	exit 1
 fi
 grep -Eq 'does not match requested version' "$test_root/npm-mismatch.log"
+
+node --test "$repo_root/npm/publish.test.mjs"
 
 echo "release workflow contract tests: PASS"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -31,9 +31,17 @@ grep -Eq "workflow_id: 'release-desktop\.yml'" \
 	"$repo_root/.github/workflows/release-desktop-trigger.yml"
 grep -Fq 'Desktop Preview must be dispatched without a Git tag' \
 	"$repo_root/.github/workflows/release-desktop-trigger.yml"
-grep -Eq "workflow_id: 'release\.yml'" \
+grep -Fq "workflow_id: preview ? 'release-preview.yml' : 'release.yml'" \
 	"$repo_root/.github/workflows/release-cli-trigger.yml"
 grep -Eq "preview\\\\\." "$repo_root/.github/workflows/release-cli-trigger.yml"
+grep -Eq '^name: Release preview$' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq '^    environment: canary$' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq '^  signpath-preflight:$' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq 'signing_preflight: true' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq 'signing_preflight_verified: true' "$repo_root/.github/workflows/release-preview.yml"
+[ "$(grep -Ec 'needs: \[authorize, signpath-preflight\]' "$repo_root/.github/workflows/release-preview.yml")" = "3" ]
+grep -Eq 'release-event\.mjs generate' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq 'gh workflow run pages\.yml' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq 'release-cli-trigger\.yml' "$repo_root/.github/workflows/ci.yml"
 if grep -Eq '^  push:$' "$repo_root/.github/workflows/release-stable.yml" ||
 	grep -Eq '^  push:$' "$repo_root/.github/workflows/release.yml" ||
@@ -46,7 +54,7 @@ for workflow in release.yml release-npm.yml release-desktop.yml; do
 	grep -Eq 'github\.ref_protected' "$repo_root/.github/workflows/$workflow"
 	grep -Eq 'inputs\.approved_sha' "$repo_root/.github/workflows/$workflow"
 	grep -Eq 'verify-release-tag\.sh' "$repo_root/.github/workflows/$workflow"
-	grep -Eq 'release-stable\.yml' "$repo_root/.github/workflows/$workflow"
+	grep -Eq 'release-\{1\}\.yml' "$repo_root/.github/workflows/$workflow"
 	grep -Eq "needs\.cache-guard\.result == 'success'" "$repo_root/.github/workflows/$workflow"
 done
 grep -Eq 'options: \[stable, preview\]' "$repo_root/.github/workflows/release.yml"
@@ -163,7 +171,9 @@ desktop_r2_upload_line="$(
 grep -Eq '^  postflight:$' "$repo_root/.github/workflows/release-stable.yml"
 grep -Eq 'verify-stable-release-artifacts\.sh' "$repo_root/.github/workflows/release-stable.yml"
 grep -Eq 'name: Upload reviewed release notes' "$repo_root/.github/workflows/release-stable.yml"
-grep -Eq 'name: stable-reviewed-release-notes' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'name: orchestrator-reviewed-release-notes' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq 'name: Upload reviewed release notes' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq 'name: orchestrator-reviewed-release-notes' "$repo_root/.github/workflows/release-preview.yml"
 for channel in cli npm desktop; do
 	grep -Eq '^      publish_'"$channel"':' "$repo_root/.github/workflows/release-stable.yml"
 	grep -Eq "inputs\.publish_$channel" "$repo_root/.github/workflows/release-stable.yml"
@@ -177,7 +187,7 @@ grep -Eq '^v1:[0-9a-f]{64}$' <<<"$contract_fingerprint"
 grep -Eq 'public postflight will still verify it' "$repo_root/.github/workflows/release-stable.yml"
 for workflow in release.yml release-desktop.yml; do
 	grep -Eq 'name: Download orchestrator-reviewed release notes' "$repo_root/.github/workflows/$workflow"
-	grep -Eq 'name: stable-reviewed-release-notes' "$repo_root/.github/workflows/$workflow"
+	grep -Eq 'name: orchestrator-reviewed-release-notes' "$repo_root/.github/workflows/$workflow"
 	grep -Eq 'if: \$\{\{ !inputs\.orchestrated' "$repo_root/.github/workflows/$workflow"
 done
 
@@ -277,6 +287,7 @@ jq -n \
 		tag_name: $tag,
 		prerelease: false,
 		html_url: ("https://github.com/" + $repo + "/releases/tag/" + $tag),
+		release_notes_url: ("https://reasonix.io/changelog/" + $tag + "/"),
 		assets: [
 			$names[] as $name |
 			{
@@ -634,6 +645,7 @@ write_desktop_manifest() {
 		{
 			version: $version,
 			download_page: "https://reasonix.io/?download=desktop#start",
+			release_notes_url: ("https://reasonix.io/changelog/" + $version + "/"),
 			platforms: {
 				"darwin-arm64": asset("Reasonix-darwin-arm64.zip"),
 				"darwin-amd64": asset("Reasonix-darwin-amd64.zip"),
@@ -782,10 +794,16 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 	git tag v1.2.3
 	git tag npm-v1.2.3
 	git tag -a desktop-v1.2.3 -m "desktop release"
-	git push -q origin v1.2.3 npm-v1.2.3 desktop-v1.2.3
+	git tag v1.3.0-preview.42
+	git push -q origin v1.2.3 npm-v1.2.3 desktop-v1.2.3 v1.3.0-preview.42
 	GITHUB_OUTPUT="$test_root/stable.out" RELEASE_TAG=v1.2.3 "$repo_root/scripts/resolve-stable-release.sh"
 	grep -Eq '^version=1\.2\.3$' "$test_root/stable.out"
 	grep -Eq '^desktop_tag=desktop-v1\.2\.3$' "$test_root/stable.out"
+	GITHUB_OUTPUT="$test_root/preview.out" RELEASE_TAG=v1.3.0-preview.42 \
+		"$repo_root/scripts/resolve-preview-release.sh"
+	grep -Eq '^version=1\.3\.0-preview\.42$' "$test_root/preview.out"
+	grep -Eq '^desktop_tag=desktop-v1\.3\.0-preview\.42$' "$test_root/preview.out"
+	grep -Eq '^npm_version=1\.3\.0-canary\.42$' "$test_root/preview.out"
 	approved_sha="$(git rev-parse HEAD)"
 	GITHUB_OUTPUT="$test_root/desktop-stable-candidate.out" \
 		RELEASE_CHANNEL=stable RELEASE_TAG=desktop-v1.2.3 \
@@ -831,6 +849,12 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 		CALLER_EVENT_NAME=push CALLER_REF=refs/tags/v1.2.3 CALLER_REF_PROTECTED=true \
 		CALLER_WORKFLOW_SHA="$approved_sha" CALLER_SHA="$approved_sha" \
 		APPROVED_CLI_TAG=v1.2.3 APPROVED_SHA="$approved_sha" \
+		"$repo_root/scripts/verify-release-authorization.sh"
+	ACTUAL_CALLER_WORKFLOW_REF='example/reasonix/.github/workflows/release-preview.yml@refs/heads/main-v2' \
+		EXPECTED_CALLER_WORKFLOW_REF='example/reasonix/.github/workflows/release-preview.yml@refs/heads/main-v2' \
+		CALLER_EVENT_NAME=workflow_dispatch CALLER_REF=refs/heads/main-v2 CALLER_REF_PROTECTED=true \
+		CALLER_WORKFLOW_SHA="$approved_sha" CALLER_SHA="$approved_sha" \
+		APPROVED_CHANNEL=preview APPROVED_CLI_TAG=v1.3.0-preview.42 APPROVED_SHA="$approved_sha" \
 		"$repo_root/scripts/verify-release-authorization.sh"
 	RELEASE_TAG=desktop-v1.2.3 APPROVED_SHA="$approved_sha" \
 		"$repo_root/scripts/verify-release-tag.sh"
@@ -1004,7 +1028,7 @@ EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=v1.3.0-preview.42 \
 grep -Eq '^tag=v1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
 grep -Eq '^version=1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
 grep -Eq '^base_version=1\.3\.0$' "$test_root/cli-preview-push.out"
-grep -Eq '^notes_version=v1\.3\.0$' "$test_root/cli-preview-push.out"
+grep -Eq '^notes_version=v1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
 grep -Eq '^channel=preview$' "$test_root/cli-preview-push.out"
 grep -Eq '^prerelease=true$' "$test_root/cli-preview-push.out"
 

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -35,6 +35,11 @@ grep -Fq "workflow_id: preview ? 'release-preview.yml' : 'release.yml'" \
 	"$repo_root/.github/workflows/release-cli-trigger.yml"
 grep -Eq "preview\\\\\." "$repo_root/.github/workflows/release-cli-trigger.yml"
 grep -Eq '^name: Release preview$' "$repo_root/.github/workflows/release-preview.yml"
+grep -Eq '^  group: preview-release$' "$repo_root/.github/workflows/release-preview.yml"
+if grep -Fq 'group: preview-release-${{ inputs.tag }}' "$repo_root/.github/workflows/release-preview.yml"; then
+	echo "Preview releases must serialize across versions" >&2
+	exit 1
+fi
 grep -Eq '^    environment: canary$' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq '^  signpath-preflight:$' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq 'signing_preflight: true' "$repo_root/.github/workflows/release-preview.yml"
@@ -57,11 +62,10 @@ for workflow in release.yml release-npm.yml release-desktop.yml; do
 	grep -Eq 'release-\{1\}\.yml' "$repo_root/.github/workflows/$workflow"
 	grep -Eq "needs\.cache-guard\.result == 'success'" "$repo_root/.github/workflows/$workflow"
 done
-grep -Eq 'options: \[stable, preview\]' "$repo_root/.github/workflows/release.yml"
+grep -Eq 'options: \[stable\]' "$repo_root/.github/workflows/release.yml"
 grep -A6 -E '^      channel:' "$repo_root/.github/workflows/release.yml" |
 	grep -Eq 'default: stable'
-grep -Eq "needs\.resolve\.outputs\.channel == 'preview'.*'canary'.*'release'" \
-	"$repo_root/.github/workflows/release.yml"
+grep -Eq '^    environment: release$' "$repo_root/.github/workflows/release.yml"
 grep -Eq 'GORELEASER_CURRENT_TAG:.*needs\.resolve\.outputs\.tag' \
 	"$repo_root/.github/workflows/release.yml"
 grep -Eq 'bash scripts/resolve-cli-release\.sh' "$repo_root/.github/workflows/release.yml"
@@ -98,6 +102,20 @@ if grep -Fq 'ref: ${{ inputs.approved_sha || inputs.tag || github.ref }}' \
 fi
 grep -Fq "group: release-desktop-\${{ (inputs.channel == 'preview' || inputs.channel == 'canary') && 'preview' || 'stable' }}" \
 	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq 'IN_PRODUCTION_SIGNING_SMOKE:.*inputs\.production_signing_smoke' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Eq 'IN_SIGNING_PREFLIGHT:.*inputs\.signing_preflight' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq "group: release-npm-\${{ inputs.channel || 'next' }}" \
+	"$repo_root/.github/workflows/release-npm.yml"
+sed -n '/^  workflow_dispatch:/,/^  workflow_call:/p' "$repo_root/.github/workflows/release-npm.yml" |
+	grep -Eq 'default: stable'
+if sed -n '/^  workflow_dispatch:/,/^  workflow_call:/p' "$repo_root/.github/workflows/release-npm.yml" |
+	grep -Eq '^          - canary$'; then
+	echo "Standalone npm dispatch must not expose public Canary publication" >&2
+	exit 1
+fi
+grep -Fq 'if: ${{ !inputs.orchestrated }}' "$repo_root/.github/workflows/release-npm.yml"
 grep -Eq 'signing-policy-slug: release-signing' "$repo_root/.github/workflows/release-desktop.yml"
 if grep -Eq 'signing-policy-slug:.*test-signing' "$repo_root/.github/workflows/release-desktop.yml"; then
 	echo "public desktop workflow must not use the SignPath test certificate" >&2
@@ -1072,14 +1090,15 @@ grep -Eq '^tag=desktop-v1\.2\.3$' "$test_root/desktop-stable.out"
 grep -Eq '^version=v1\.2\.3$' "$test_root/desktop-stable.out"
 grep -Eq '^notes_version=v1\.2\.3$' "$test_root/desktop-stable.out"
 
-EVENT_NAME=workflow_dispatch IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=42 \
+EVENT_NAME=workflow_call IN_ORCHESTRATED=true IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 \
+	IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=999 IN_PREVIEW_NUMBER=42 \
 	GITHUB_OUTPUT="$test_root/desktop-preview.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
 grep -Eq '^version=v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 grep -Eq '^tag=desktop-v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 grep -Eq '^channel=preview$' "$test_root/desktop-preview.out"
 grep -Eq '^notes_version=v1\.3\.0-preview\.42$' "$test_root/desktop-preview.out"
 
-if EVENT_NAME=workflow_dispatch IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 \
+if EVENT_NAME=workflow_call IN_ORCHESTRATED=true IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 \
 	IN_TAG=desktop-v1.3.0-preview.42 REF_NAME=main-v2 RUN_NUMBER=42 \
 	GITHUB_OUTPUT="$test_root/desktop-preview-tagged.out" \
 	bash "$repo_root/scripts/resolve-desktop-release.sh" \
@@ -1090,13 +1109,30 @@ fi
 grep -Eq 'Desktop Preview versions are synthesized from protected main-v2' \
 	"$test_root/desktop-preview-tagged.log"
 
-# Legacy automation may still dispatch `canary`; normalize it to Preview without
-# exposing a third user-facing release channel.
-EVENT_NAME=workflow_dispatch IN_CHANNEL=canary IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=43 \
+# Legacy signing automation may still dispatch `canary`; normalize it to Preview
+# without exposing a third public release path.
+EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_SIGNING_PREFLIGHT=true \
+	IN_CHANNEL=canary IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=43 \
 	GITHUB_OUTPUT="$test_root/desktop-canary-compat.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
 grep -Eq '^version=v1\.3\.0-preview\.43$' "$test_root/desktop-canary-compat.out"
 grep -Eq '^tag=desktop-v1\.3\.0-preview\.43$' "$test_root/desktop-canary-compat.out"
 grep -Eq '^channel=preview$' "$test_root/desktop-canary-compat.out"
+
+EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_PRODUCTION_SIGNING_SMOKE=true \
+	IN_CHANNEL=preview IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=44 \
+	GITHUB_OUTPUT="$test_root/desktop-preview-smoke.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
+grep -Eq '^version=v1\.3\.0-preview\.44$' "$test_root/desktop-preview-smoke.out"
+
+if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=preview \
+	IN_BASE_VERSION=1.3.0 IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=45 \
+	GITHUB_OUTPUT="$test_root/desktop-preview-direct.out" \
+	bash "$repo_root/scripts/resolve-desktop-release.sh" \
+	>"$test_root/desktop-preview-direct.log" 2>&1; then
+	echo "standalone public Desktop Preview unexpectedly passed" >&2
+	exit 1
+fi
+grep -Eq 'public Desktop Preview releases must be dispatched by release-preview.yml' \
+	"$test_root/desktop-preview-direct.log"
 
 EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=desktop-v1.4.0-rc.1 RUN_NUMBER=50 \
 	GITHUB_OUTPUT="$test_root/desktop-rc.out" bash "$repo_root/scripts/resolve-desktop-release.sh"
@@ -1121,20 +1157,26 @@ if EVENT_NAME=workflow_dispatch IN_CHANNEL=stable IN_TAG='' REF_NAME=main-v2 RUN
 fi
 grep -Eq 'stable dispatch requires tag' "$test_root/desktop-missing-tag.log"
 
-EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=v1.3.0-preview.42 \
-	GITHUB_OUTPUT="$test_root/cli-preview-push.out" bash "$repo_root/scripts/resolve-cli-release.sh"
-grep -Eq '^tag=v1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
-grep -Eq '^version=1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
-grep -Eq '^base_version=1\.3\.0$' "$test_root/cli-preview-push.out"
-grep -Eq '^notes_version=v1\.3\.0-preview\.42$' "$test_root/cli-preview-push.out"
-grep -Eq '^channel=preview$' "$test_root/cli-preview-push.out"
-grep -Eq '^prerelease=true$' "$test_root/cli-preview-push.out"
+EVENT_NAME=workflow_call IN_ORCHESTRATED=true IN_CHANNEL=preview IN_TAG=v1.3.0-preview.42 \
+	REF_NAME=main-v2 GITHUB_OUTPUT="$test_root/cli-preview-call.out" \
+	bash "$repo_root/scripts/resolve-cli-release.sh"
+grep -Eq '^tag=v1\.3\.0-preview\.42$' "$test_root/cli-preview-call.out"
+grep -Eq '^version=1\.3\.0-preview\.42$' "$test_root/cli-preview-call.out"
+grep -Eq '^base_version=1\.3\.0$' "$test_root/cli-preview-call.out"
+grep -Eq '^notes_version=v1\.3\.0-preview\.42$' "$test_root/cli-preview-call.out"
+grep -Eq '^channel=preview$' "$test_root/cli-preview-call.out"
+grep -Eq '^prerelease=true$' "$test_root/cli-preview-call.out"
 
-EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=preview \
+if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=preview \
 	IN_TAG=v1.3.0-preview.42 REF_NAME=main-v2 CALLER_REF=refs/heads/main-v2 \
 	CALLER_REF_PROTECTED=true GITHUB_OUTPUT="$test_root/cli-preview-dispatch.out" \
-	bash "$repo_root/scripts/resolve-cli-release.sh"
-grep -Eq '^channel=preview$' "$test_root/cli-preview-dispatch.out"
+	bash "$repo_root/scripts/resolve-cli-release.sh" \
+	>"$test_root/cli-preview-dispatch.log" 2>&1; then
+	echo "standalone public CLI Preview unexpectedly passed" >&2
+	exit 1
+fi
+grep -Eq 'public CLI Preview releases must be dispatched by release-preview.yml' \
+	"$test_root/cli-preview-dispatch.log"
 
 EVENT_NAME=push IN_CHANNEL='' IN_TAG='' REF_NAME=v1.3.0-rc.1 \
 	GITHUB_OUTPUT="$test_root/cli-rc.out" bash "$repo_root/scripts/resolve-cli-release.sh"
@@ -1177,6 +1219,21 @@ EVENT_NAME=push IN_ORCHESTRATED=true IN_CHANNEL=stable IN_BASE_VERSION=1.5.0 \
 	IN_TAG=npm-v1.5.0 REF_NAME=v1.5.0 RUN_NUMBER=51 GITHUB_OUTPUT="$test_root/npm-stable.out" \
 	bash "$repo_root/scripts/resolve-npm-release.sh"
 grep -Eq '^arg=v1\.5\.0$' "$test_root/npm-stable.out"
+
+EVENT_NAME=workflow_call IN_ORCHESTRATED=true IN_CHANNEL=canary IN_BASE_VERSION=1.5.0 \
+	IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=999 IN_PREVIEW_NUMBER=42 \
+	GITHUB_OUTPUT="$test_root/npm-canary.out" bash "$repo_root/scripts/resolve-npm-release.sh"
+grep -Eq '^arg=v1\.5\.0-canary\.42$' "$test_root/npm-canary.out"
+
+if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=canary IN_BASE_VERSION=1.5.0 \
+	IN_TAG='' REF_NAME=main-v2 RUN_NUMBER=52 GITHUB_OUTPUT="$test_root/npm-canary-direct.out" \
+	bash "$repo_root/scripts/resolve-npm-release.sh" \
+	>"$test_root/npm-canary-direct.log" 2>&1; then
+	echo "standalone public npm Canary unexpectedly passed" >&2
+	exit 1
+fi
+grep -Eq 'public npm Canary releases must be dispatched by release-preview.yml' \
+	"$test_root/npm-canary-direct.log"
 
 if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=stable IN_BASE_VERSION=1.5.0 \
 	IN_TAG=npm-v1.5.1 REF_NAME=main-v2 RUN_NUMBER=52 GITHUB_OUTPUT="$test_root/npm-mismatch.out" \

--- a/scripts/resolve-cli-release.sh
+++ b/scripts/resolve-cli-release.sh
@@ -66,6 +66,11 @@ if [ -n "$requested_channel" ]; then
 	fi
 fi
 
+if [ "$channel" = "preview" ] && [ "${IN_ORCHESTRATED:-false}" != "true" ]; then
+	echo "::error::public CLI Preview releases must be dispatched by release-preview.yml" >&2
+	exit 1
+fi
+
 {
 	echo "tag=$tag"
 	echo "version=$version"

--- a/scripts/resolve-cli-release.sh
+++ b/scripts/resolve-cli-release.sh
@@ -36,7 +36,7 @@ esac
 
 if [[ "$tag" =~ $preview_semver_re ]]; then
 	channel="preview"
-	notes_version="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+	notes_version="$tag"
 else
 	case "$tag" in
 	v*-preview*)

--- a/scripts/resolve-cli-release.sh
+++ b/scripts/resolve-cli-release.sh
@@ -45,7 +45,10 @@ else
 		;;
 	esac
 	channel="stable"
-	notes_version="$tag"
+	case "$version" in
+	*-*) notes_version="v${base_version}" ;;
+	*) notes_version="$tag" ;;
+	esac
 fi
 
 requested_channel="${IN_CHANNEL:-}"

--- a/scripts/resolve-desktop-release.sh
+++ b/scripts/resolve-desktop-release.sh
@@ -5,10 +5,10 @@
 #
 #   stable: from a desktop-v* prerelease tag push, a manual dispatch with `tag`,
 #           or the stable release orchestrator's workflow_call input.
-#   preview: a manual dispatch with channel=preview (legacy canary accepted);
-#            version is synthesized from base_version + the monotonic run_number,
-#            tag is the matching immutable asset directory, and it is always a
-#            prerelease.
+#   preview: public publication requires the approved Preview orchestrator;
+#            standalone Preview is limited to non-publishing signing checks.
+#            Legacy canary input is accepted for those checks. The version uses
+#            the orchestrator ordinal or, for a signing check, the run number.
 set -euo pipefail
 
 stable_semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
@@ -16,6 +16,12 @@ release_semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za
 preview_semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$'
 
 if [ "${IN_CHANNEL:-stable}" = "preview" ] || [ "${IN_CHANNEL:-stable}" = "canary" ]; then
+	if [ "${IN_ORCHESTRATED:-false}" != "true" ] && \
+		[ "${IN_PRODUCTION_SIGNING_SMOKE:-false}" != "true" ] && \
+		[ "${IN_SIGNING_PREFLIGHT:-false}" != "true" ]; then
+		echo "::error::public Desktop Preview releases must be dispatched by release-preview.yml" >&2
+		exit 1
+	fi
 	if [ -n "${IN_TAG:-}" ]; then
 		echo "::error::Desktop Preview versions are synthesized from protected main-v2; tag must be empty" >&2
 		exit 1

--- a/scripts/resolve-desktop-release.sh
+++ b/scripts/resolve-desktop-release.sh
@@ -27,7 +27,12 @@ if [ "${IN_CHANNEL:-stable}" = "preview" ] || [ "${IN_CHANNEL:-stable}" = "canar
 		echo "::error::preview base version must be MAJOR.MINOR.PATCH, got: $base" >&2
 		exit 1
 	fi
-	version="v${base}-preview.${RUN_NUMBER}"
+	preview_number="${IN_PREVIEW_NUMBER:-${RUN_NUMBER:-}}"
+	if [[ ! "$preview_number" =~ ^(0|[1-9][0-9]*)$ ]]; then
+		echo "::error::preview number must be a non-negative integer, got: $preview_number" >&2
+		exit 1
+	fi
+	version="v${base}-preview.${preview_number}"
 	tag="desktop-${version}"
 	channel="preview"
 	prerelease="true"

--- a/scripts/resolve-desktop-release.sh
+++ b/scripts/resolve-desktop-release.sh
@@ -36,6 +36,7 @@ if [ "${IN_CHANNEL:-stable}" = "preview" ] || [ "${IN_CHANNEL:-stable}" = "canar
 	tag="desktop-${version}"
 	channel="preview"
 	prerelease="true"
+	notes_version="$version"
 else
 	if [ -n "${IN_TAG:-}" ]; then
 		tag="${IN_TAG}"
@@ -56,8 +57,14 @@ else
 	fi
 	channel="stable"
 	case "$version" in
-	*-*) prerelease="true" ;;
-	*) prerelease="false" ;;
+	*-*)
+		prerelease="true"
+		notes_version="${version%%-*}"
+		;;
+	*)
+		prerelease="false"
+		notes_version="$version"
+		;;
 	esac
 fi
 
@@ -66,6 +73,7 @@ fi
 	echo "version=$version"
 	echo "channel=$channel"
 	echo "prerelease=$prerelease"
+	echo "notes_version=$notes_version"
 } >>"$GITHUB_OUTPUT"
 
 echo "resolved: tag=$tag version=$version channel=$channel prerelease=$prerelease"

--- a/scripts/resolve-npm-release.sh
+++ b/scripts/resolve-npm-release.sh
@@ -15,6 +15,10 @@ if [ "${EVENT_NAME:-}" = "workflow_dispatch" ] || [ "${IN_ORCHESTRATED:-false}" 
 		exit 1
 	fi
 	if [ "${IN_CHANNEL:-stable}" = "canary" ]; then
+		if [ "${IN_ORCHESTRATED:-false}" != "true" ]; then
+			echo "::error::public npm Canary releases must be dispatched by release-preview.yml" >&2
+			exit 1
+		fi
 		preview_number="${IN_PREVIEW_NUMBER:-${RUN_NUMBER:-}}"
 		if [[ ! "$preview_number" =~ ^(0|[1-9][0-9]*)$ ]]; then
 			echo "::error::canary preview number must be a non-negative integer, got: $preview_number" >&2

--- a/scripts/resolve-npm-release.sh
+++ b/scripts/resolve-npm-release.sh
@@ -15,7 +15,12 @@ if [ "${EVENT_NAME:-}" = "workflow_dispatch" ] || [ "${IN_ORCHESTRATED:-false}" 
 		exit 1
 	fi
 	if [ "${IN_CHANNEL:-stable}" = "canary" ]; then
-		arg="v${base}-canary.${RUN_NUMBER:?canary requires run number}"
+		preview_number="${IN_PREVIEW_NUMBER:-${RUN_NUMBER:-}}"
+		if [[ ! "$preview_number" =~ ^(0|[1-9][0-9]*)$ ]]; then
+			echo "::error::canary preview number must be a non-negative integer, got: $preview_number" >&2
+			exit 1
+		fi
+		arg="v${base}-canary.${preview_number}"
 	else
 		tag="${IN_TAG:-}"
 		if [ -z "$tag" ]; then

--- a/scripts/resolve-preview-release.sh
+++ b/scripts/resolve-preview-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Validate one canonical Preview release tag and emit the shared release event
+# identity used by CLI, Desktop, npm, and the exact changelog entry.
+set -euo pipefail
+
+release_tag="${RELEASE_TAG:?RELEASE_TAG is required}"
+release_remote="${RELEASE_REMOTE:-origin}"
+
+if [[ ! "$release_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.([1-9][0-9]*)$ ]]; then
+	echo "::error::Preview release tag must be vMAJOR.MINOR.PATCH-preview.N, got: $release_tag" >&2
+	exit 1
+fi
+
+base_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+preview_number="${BASH_REMATCH[4]}"
+checkout_sha="$(git rev-parse HEAD^{commit})"
+main_sha="$(git ls-remote "$release_remote" refs/heads/main-v2 | awk 'NR == 1 { print $1 }')"
+tag_sha="$(
+	git ls-remote --tags "$release_remote" "refs/tags/$release_tag" "refs/tags/$release_tag^{}" |
+		awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
+)"
+
+if [ -z "$main_sha" ] || [ "$checkout_sha" != "$main_sha" ]; then
+	echo "::error::Preview control checkout must equal current $release_remote/main-v2 ($main_sha), got $checkout_sha" >&2
+	exit 1
+fi
+if [ -z "$tag_sha" ] || [ "$tag_sha" != "$main_sha" ]; then
+	echo "::error::$release_tag must point to current $release_remote/main-v2 ($main_sha), got ${tag_sha:-missing}" >&2
+	exit 1
+fi
+
+{
+	echo "version=${release_tag#v}"
+	echo "base_version=$base_version"
+	echo "preview_number=$preview_number"
+	echo "cli_tag=$release_tag"
+	echo "desktop_tag=desktop-v${base_version}-preview.${preview_number}"
+	echo "npm_version=${base_version}-canary.${preview_number}"
+	echo "sha=$main_sha"
+} >>"${GITHUB_OUTPUT:-/dev/stdout}"
+
+echo "Preview release resolved: ${release_tag#v} at $main_sha"

--- a/scripts/validate-cli-release-manifest.sh
+++ b/scripts/validate-cli-release-manifest.sh
@@ -65,6 +65,7 @@ jq -e \
 		else (.prerelease == ($expected_prerelease == "true"))
 	end) and
 	(.html_url == ("https://github.com/" + $repository + "/releases/tag/" + $tag)) and
+	(.release_notes_url == ("https://reasonix.io/changelog/" + $tag + "/")) and
 	(.assets | type == "array") and
 	(.assets | length == ($required | length)) and
 	((.assets | map(.name) | sort) == ($required | sort)) and

--- a/scripts/validate-cli-release-manifest.sh
+++ b/scripts/validate-cli-release-manifest.sh
@@ -5,6 +5,7 @@ channel="${1:-}"
 tag="${2:-}"
 repository="${3:-}"
 manifest="${4:-}"
+notes_tag="${5:-$tag}"
 
 stable_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 preview_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$'
@@ -14,17 +15,35 @@ case "$channel" in
 	stable)
 		tag_pattern="$stable_tag_pattern"
 		expected_prerelease=false
+		legacy=false
 		;;
 	preview)
 		tag_pattern="$preview_tag_pattern"
 		expected_prerelease=true
+		legacy=false
 		;;
 	any)
 		tag_pattern="$release_tag_pattern"
 		expected_prerelease=any
+		legacy=false
+		;;
+	legacy-stable)
+		tag_pattern="$stable_tag_pattern"
+		expected_prerelease=false
+		legacy=true
+		;;
+	legacy-preview)
+		tag_pattern="$preview_tag_pattern"
+		expected_prerelease=true
+		legacy=true
+		;;
+	legacy-any)
+		tag_pattern="$release_tag_pattern"
+		expected_prerelease=any
+		legacy=true
 		;;
 	*)
-		echo "CLI manifest channel must be stable, preview, or any: $channel" >&2
+		echo "CLI manifest channel must be stable, preview, any, legacy-stable, legacy-preview, or legacy-any: $channel" >&2
 		exit 2
 		;;
 esac
@@ -35,6 +54,10 @@ if [[ ! "$tag" =~ $tag_pattern ]]; then
 fi
 if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
 	echo "invalid GitHub repository: $repository" >&2
+	exit 1
+fi
+if [[ ! "$notes_tag" =~ $release_tag_pattern ]]; then
+	echo "invalid CLI release-notes tag: $notes_tag" >&2
 	exit 1
 fi
 if [ ! -f "$manifest" ]; then
@@ -55,8 +78,10 @@ required_assets='[
 jq -e \
 	--arg channel "$channel" \
 	--arg tag "$tag" \
+	--arg notes_tag "$notes_tag" \
 	--arg repository "$repository" \
 	--arg expected_prerelease "$expected_prerelease" \
+	--argjson legacy "$legacy" \
 	--argjson required "$required_assets" '
 	(type == "object") and
 	(.tag_name == $tag) and
@@ -65,7 +90,11 @@ jq -e \
 		else (.prerelease == ($expected_prerelease == "true"))
 	end) and
 	(.html_url == ("https://github.com/" + $repository + "/releases/tag/" + $tag)) and
-	(.release_notes_url == ("https://reasonix.io/changelog/" + $tag + "/")) and
+	(if $legacy
+		then (.release_notes_url == null or
+			.release_notes_url == ("https://reasonix.io/changelog/" + $notes_tag + "/"))
+		else (.release_notes_url == ("https://reasonix.io/changelog/" + $notes_tag + "/"))
+	end) and
 	(.assets | type == "array") and
 	(.assets | length == ($required | length)) and
 	((.assets | map(.name) | sort) == ($required | sort)) and

--- a/scripts/validate-desktop-release-manifest.sh
+++ b/scripts/validate-desktop-release-manifest.sh
@@ -5,6 +5,7 @@ channel="${1:-}"
 version="${2:-}"
 asset_base="${3:-}"
 manifest="${4:-}"
+notes_version="${5:-$version}"
 
 stable_version_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 preview_version_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$'
@@ -31,14 +32,22 @@ case "$channel" in
 		version_pattern="$preview_version_pattern"
 		legacy=true
 		;;
+	legacy-any)
+		version_pattern="$release_version_pattern"
+		legacy=true
+		;;
 	*)
-		echo "Desktop manifest channel must be stable, preview, any, legacy-stable, or legacy-preview: $channel" >&2
+		echo "Desktop manifest channel must be stable, preview, any, legacy-stable, legacy-preview, or legacy-any: $channel" >&2
 		exit 2
 		;;
 esac
 
 if [[ ! "$version" =~ $version_pattern ]]; then
 	echo "invalid $channel Desktop manifest version: $version" >&2
+	exit 1
+fi
+if [[ ! "$notes_version" =~ $release_version_pattern ]]; then
+	echo "invalid Desktop release-notes version: $notes_version" >&2
 	exit 1
 fi
 
@@ -66,6 +75,7 @@ fi
 
 jq -e \
 	--arg version "$version" \
+	--arg notes_version "$notes_version" \
 	--arg base "$asset_base" \
 	--argjson legacy "$legacy" '
 	def exact_keys($expected):
@@ -81,8 +91,8 @@ jq -e \
 	(.version == $version) and
 	(.download_page == "https://reasonix.io/?download=desktop#start") and
 	(if $legacy
-		then (.release_notes_url == null or .release_notes_url == ("https://reasonix.io/changelog/" + $version + "/"))
-		else (.release_notes_url == ("https://reasonix.io/changelog/" + $version + "/"))
+		then (.release_notes_url == null or .release_notes_url == ("https://reasonix.io/changelog/" + $notes_version + "/"))
+		else (.release_notes_url == ("https://reasonix.io/changelog/" + $notes_version + "/"))
 	end) and
 	(.platforms | exact_keys([
 		"darwin-arm64",

--- a/scripts/validate-desktop-release-manifest.sh
+++ b/scripts/validate-desktop-release-manifest.sh
@@ -80,6 +80,10 @@ jq -e \
 	(type == "object") and
 	(.version == $version) and
 	(.download_page == "https://reasonix.io/?download=desktop#start") and
+	(if $legacy
+		then (.release_notes_url == null or .release_notes_url == ("https://reasonix.io/changelog/" + $version + "/"))
+		else (.release_notes_url == ("https://reasonix.io/changelog/" + $version + "/"))
+	end) and
 	(.platforms | exact_keys([
 		"darwin-arm64",
 		"darwin-amd64",

--- a/scripts/verify-desktop-release-directory.sh
+++ b/scripts/verify-desktop-release-directory.sh
@@ -2,17 +2,28 @@
 set -euo pipefail
 
 allow_missing=false
-if [ "${1:-}" = "--allow-missing" ]; then
-	allow_missing=true
-	shift
-fi
+allow_legacy_manifest=false
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--allow-missing)
+		allow_missing=true
+		shift
+		;;
+	--allow-legacy-manifest)
+		allow_legacy_manifest=true
+		shift
+		;;
+	*) break ;;
+	esac
+done
 if [ "$#" -ne 2 ]; then
-	echo "usage: $0 [--allow-missing] CANDIDATE_DIRECTORY EXISTING_DIRECTORY" >&2
+	echo "usage: $0 [--allow-missing] [--allow-legacy-manifest] CANDIDATE_DIRECTORY EXISTING_DIRECTORY" >&2
 	exit 2
 fi
 
 candidate_dir="${1%/}"
 existing_dir="${2%/}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ ! -d "$candidate_dir" ] || [ ! -d "$existing_dir" ]; then
 	echo "Desktop release comparison requires two directories" >&2
 	exit 2
@@ -28,6 +39,14 @@ verify_subset() {
 		if [ ! -f "$target_file" ]; then
 			echo "Desktop release directory is missing $relative" >&2
 			return 1
+		fi
+		if [ "$allow_legacy_manifest" = "true" ] && [ "$relative" = "latest.json" ]; then
+			if ! bash "$script_dir/compare-desktop-release-manifests.sh" \
+				"$candidate_dir/latest.json" "$existing_dir/latest.json"; then
+				echo "Desktop release directory has conflicting content for $relative" >&2
+				return 1
+			fi
+			continue
 		fi
 		if ! cmp -s "$source_file" "$target_file"; then
 			echo "Desktop release directory has conflicting content for $relative" >&2

--- a/scripts/verify-release-authorization.sh
+++ b/scripts/verify-release-authorization.sh
@@ -13,6 +13,7 @@ caller_workflow_sha="${CALLER_WORKFLOW_SHA:?CALLER_WORKFLOW_SHA is required}"
 caller_sha="${CALLER_SHA:?CALLER_SHA is required}"
 approved_cli_tag="${APPROVED_CLI_TAG:?APPROVED_CLI_TAG is required}"
 approved_sha="${APPROVED_SHA:?APPROVED_SHA is required}"
+approved_channel="${APPROVED_CHANNEL:-stable}"
 
 if [ "$actual_caller" != "$expected_caller" ]; then
 	echo "::error::orchestrated release caller is $actual_caller, expected $expected_caller" >&2
@@ -22,8 +23,22 @@ if [ "$caller_ref_protected" != "true" ]; then
 	echo "::error::orchestrated release caller ref is not protected: $caller_ref" >&2
 	exit 1
 fi
-if [[ ! "$approved_cli_tag" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-	echo "::error::approved CLI tag must be vMAJOR.MINOR.PATCH, got: $approved_cli_tag" >&2
+case "$approved_channel" in
+stable)
+	approved_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+	approved_tag_description='vMAJOR.MINOR.PATCH'
+	;;
+preview)
+	approved_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.([1-9][0-9]*)$'
+	approved_tag_description='vMAJOR.MINOR.PATCH-preview.N'
+	;;
+*)
+	echo "::error::approved release channel must be stable or preview, got: $approved_channel" >&2
+	exit 1
+	;;
+esac
+if [[ ! "$approved_cli_tag" =~ $approved_tag_pattern ]]; then
+	echo "::error::approved CLI tag must be $approved_tag_description, got: $approved_cli_tag" >&2
 	exit 1
 fi
 
@@ -43,7 +58,7 @@ workflow_dispatch)
 	fi
 	;;
 *)
-	echo "::error::unsupported stable release caller event: $caller_event" >&2
+	echo "::error::unsupported orchestrated release caller event: $caller_event" >&2
 	exit 1
 	;;
 esac

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "prebuild": "node scripts/fetch-community.mjs",
+    "prebuild": "node scripts/fetch-community.mjs && node scripts/fetch-publications.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "test": "node --test src/scripts/*.test.mjs"

--- a/site/scripts/fetch-publications.mjs
+++ b/site/scripts/fetch-publications.mjs
@@ -1,0 +1,50 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { validateReleaseEvent } from "../../scripts/release-event.mjs";
+
+const siteRoot = resolve(import.meta.dirname, "..");
+const repoRoot = resolve(siteRoot, "..");
+const catalog = JSON.parse(await readFile(resolve(repoRoot, "release-notes/releases.json"), "utf8"));
+const output = resolve(siteRoot, ".generated/publications.json");
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "reasonix-site-publications",
+};
+if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+const publications = [];
+for (const release of catalog.releases) {
+  // Legacy entries predate publication markers and remain public. Every new
+  // reviewed entry fails closed until its exact CLI release carries the marker
+  // uploaded by the all-surface postflight.
+  if (!release.status || release.status === "published") {
+    publications.push(release.version);
+    continue;
+  }
+  const tag = `v${release.version}`;
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases/tags/${encodeURIComponent(tag)}`,
+      { headers, signal: AbortSignal.timeout(20_000) },
+    );
+    if (!response.ok) continue;
+    const githubRelease = await response.json();
+    const marker = githubRelease.assets?.find((asset) => asset.name === "release-event.json" && asset.size > 0);
+    if (!marker?.browser_download_url) continue;
+    const markerResponse = await fetch(marker.browser_download_url, {
+      headers,
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!markerResponse.ok) continue;
+    const event = await markerResponse.json();
+    validateReleaseEvent(event, release);
+    publications.push(release.version);
+  } catch {
+    // A reviewed release must never become public because an upstream lookup
+    // failed. The next Pages build retries after the release postflight.
+  }
+}
+
+await mkdir(resolve(siteRoot, ".generated"), { recursive: true });
+await writeFile(output, `${JSON.stringify({ schemaVersion: 1, publications }, null, 2)}\n`);
+console.log(`Resolved ${publications.length} public release note(s).`);

--- a/site/src/components/ChangelogPage.astro
+++ b/site/src/components/ChangelogPage.astro
@@ -19,6 +19,9 @@ const prHref = (ref: number) => `${repo}/pull/${ref}`;
    patch release — it gets the compact hero; anything else (including
    "Reasonix 1.18.0 — Better agents") keeps the full hero. */
 const isThematic = isThematicTitle(release.title.en, release.version);
+const isPreview = release.channel === 'prerelease';
+const channelLabel = isPreview ? { en: 'Preview', zh: '预览版' } : { en: 'Stable', zh: '稳定版' };
+const latestForChannel = releases.find((item) => item.channel === release.channel);
 
 const kindLabel = (kind: string) => ({
   new: { en: 'New', zh: '新增' },
@@ -82,16 +85,22 @@ const description = release.summary.en;
     <div class="release-grid">
       <aside class="release-rail" aria-label="Release versions">
         <div class="release-rail__eyebrow"><span class="release-rail__mark"></span><span class="l-en">Release ledger</span><span class="l-zh">版本档案</span></div>
+        <div class="release-channel-tabs">
+          <a class:list={{ active: !isPreview }} aria-current={!isPreview ? 'page' : undefined} href={`${base}/changelog/stable`}><span class="l-en">Stable</span><span class="l-zh">稳定版</span></a>
+          <a class:list={{ active: isPreview }} aria-current={isPreview ? 'page' : undefined} href={`${base}/changelog/preview`}><span class="l-en">Preview</span><span class="l-zh">预览版</span></a>
+        </div>
         <nav>
           {railGroups.map((group) => {
-            const visible = group.items.slice(0, RAIL_VISIBLE);
-            const overflow = group.items.slice(RAIL_VISIBLE);
+            const channelItems = group.items.filter((item) => item.channel === release.channel);
+            if (!channelItems.length) return null;
+            const visible = channelItems.slice(0, RAIL_VISIBLE);
+            const overflow = channelItems.slice(RAIL_VISIBLE);
             return (
               <div class="release-rail__group">
                 <p class="release-rail__minor">{group.key}.x</p>
                 {visible.map((item) => (
                   <a class:list={["release-version-link", { active: item.version === release.version }]} href={`${base}${releasePath(item.version)}`}>
-                    <span class="release-version-link__line"><strong>v{item.version}</strong>{item === releases[0] && <em><span class="l-en">Latest</span><span class="l-zh">最新</span></em>}</span>
+                    <span class="release-version-link__line"><strong>v{item.version}</strong>{item === latestForChannel && <em><span class="l-en">Latest</span><span class="l-zh">最新</span></em>}</span>
                     <small>{item.date}</small>
                   </a>
                 ))}
@@ -103,7 +112,7 @@ const description = release.summary.en;
                     </summary>
                     {overflow.map((item) => (
                       <a class:list={["release-version-link", { active: item.version === release.version }]} href={`${base}${releasePath(item.version)}`}>
-                        <span class="release-version-link__line"><strong>v{item.version}</strong>{item === releases[0] && <em><span class="l-en">Latest</span><span class="l-zh">最新</span></em>}</span>
+                        <span class="release-version-link__line"><strong>v{item.version}</strong>{item === latestForChannel && <em><span class="l-en">Latest</span><span class="l-zh">最新</span></em>}</span>
                         <small>{item.date}</small>
                       </a>
                     ))}
@@ -119,7 +128,7 @@ const description = release.summary.en;
       <article class="release-paper">
         <header class:list={["release-hero", { "release-hero--compact": !isThematic }]}>
           <div class="release-hero__meta">
-            <span class="release-channel"><span class="release-channel__dot"></span>{release.channel}</span>
+            <span class:list={["release-channel", { "release-channel--preview": isPreview }]}><span class="release-channel__dot"></span><span class="l-en">{channelLabel.en}</span><span class="l-zh">{channelLabel.zh}</span></span>
             <time datetime={release.date}>{release.date}</time>
           </div>
           {isThematic && <p class="release-hero__version">Reasonix / v{release.version}</p>}
@@ -130,6 +139,13 @@ const description = release.summary.en;
               return <span><span class="l-en">{label.en}</span><span class="l-zh">{label.zh}</span></span>;
             })}
           </div>
+          {release.builds && (
+            <div class="release-builds" aria-label="Published builds">
+              <span><strong>CLI</strong> {release.builds.cli}</span>
+              <span><strong>Desktop</strong> {release.builds.desktop}</span>
+              <span><strong>npm</strong> {release.builds.npm}</span>
+            </div>
+          )}
           {isThematic ? (
             <blockquote><span class="l-en">{release.summary.en}</span><span class="l-zh">{release.summary.zh}</span></blockquote>
           ) : (

--- a/site/src/data/releases.ts
+++ b/site/src/data/releases.ts
@@ -1,4 +1,6 @@
 import source from '../../../release-notes/releases.json';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 export type LocalizedText = { en: string; zh: string };
 
@@ -17,8 +19,14 @@ export type ReleaseUpgrade = ReleaseItem & { level: 'info' | 'warning' };
 
 export type ReleaseRecord = {
   version: string;
+  releaseId?: string;
+  baseVersion?: string;
   date: string;
   channel: 'stable' | 'prerelease';
+  status?: 'reviewed' | 'published';
+  candidateSha?: string;
+  previousRelease?: string;
+  builds?: { cli: string; desktop: string; npm: string };
   title: LocalizedText;
   summary: LocalizedText;
   surfaces: string[];
@@ -32,8 +40,27 @@ export type ReleaseRecord = {
 };
 
 export const releaseCatalog = source as { schemaVersion: number; releases: ReleaseRecord[] };
-export const releases = releaseCatalog.releases;
-export const latestRelease = releases[0];
+export const allReleases = releaseCatalog.releases;
+
+let publishedIds = new Set<string>();
+try {
+  const generated = JSON.parse(
+    readFileSync(resolve(process.cwd(), '.generated/publications.json'), 'utf8'),
+  ) as { publications?: string[] };
+  publishedIds = new Set(generated.publications ?? []);
+} catch {
+  // Before prebuild, preserve legacy entries and fail closed for reviewed
+  // releases that require a successful all-surface publication marker.
+}
+
+export const releases = allReleases.filter(
+  (release) => !release.status || release.status === 'published' || publishedIds.has(release.version),
+);
+export const stableReleases = releases.filter((release) => release.channel === 'stable');
+export const previewReleases = releases.filter((release) => release.channel === 'prerelease');
+export const latestStableRelease = stableReleases[0];
+export const latestPreviewRelease = previewReleases[0];
+export const latestRelease = latestStableRelease ?? latestPreviewRelease;
 
 export function releasePath(version: string): string {
   return `/changelog/v${version}/`;

--- a/site/src/pages/changelog/[version].astro
+++ b/site/src/pages/changelog/[version].astro
@@ -1,12 +1,19 @@
 ---
 import ChangelogPage from '../../components/ChangelogPage.astro';
-import { releases } from '../../data/releases';
+import { allReleases, releases } from '../../data/releases';
 
 export function getStaticPaths() {
-  return releases.map((release) => ({ params: { version: `v${release.version}` }, props: { release } }));
+  const publishedVersions = new Set(releases.map((release) => release.version));
+  return allReleases.map((release) => ({
+    params: { version: `v${release.version}` },
+    props: { release, published: publishedVersions.has(release.version) },
+  }));
 }
 
-const { release } = Astro.props;
+const { release, published } = Astro.props;
+if (!published) {
+  return Astro.redirect(release.channel === 'prerelease' ? '/changelog/preview/' : '/changelog/stable/');
+}
 ---
 
 <ChangelogPage release={release} releases={releases} />

--- a/site/src/pages/changelog/preview.astro
+++ b/site/src/pages/changelog/preview.astro
@@ -1,0 +1,11 @@
+---
+import ChangelogPage from '../../components/ChangelogPage.astro';
+import { latestPreviewRelease, releases, releasePath } from '../../data/releases';
+
+if (!latestPreviewRelease) {
+  return Astro.redirect('/changelog/');
+}
+const canonical = new URL(releasePath(latestPreviewRelease.version), Astro.site).href;
+---
+
+<ChangelogPage release={latestPreviewRelease} releases={releases} canonical={canonical} />

--- a/site/src/pages/changelog/stable.astro
+++ b/site/src/pages/changelog/stable.astro
@@ -2,8 +2,6 @@
 import ChangelogPage from '../../components/ChangelogPage.astro';
 import { latestStableRelease, releases, releasePath } from '../../data/releases';
 
-/* /changelog/ renders the latest release but canonicalizes to its version URL
-   to avoid duplicate content with /changelog/vX.Y.Z/. */
 const canonical = new URL(releasePath(latestStableRelease.version), Astro.site).href;
 ---
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -315,7 +315,7 @@ const ld = {
             </div>
           </div>
         </div>
-        <div class="dl-note"><span class="l-en">Switch channels later in Settings → Updates · <a href={`${repo}/releases`}>all releases →</a></span><span class="l-zh">安装后可在“设置 → 更新”中切换渠道 · <a href={`${repo}/releases`}>全部版本 →</a></span></div>
+        <div class="dl-note"><span class="l-en">Switch channels later in Settings → Updates · <a href={`${base}/changelog/stable/`} data-release-notes="desktop">release notes →</a> · <a href={`${repo}/releases`}>all releases →</a></span><span class="l-zh">安装后可在“设置 → 更新”中切换渠道 · <a href={`${base}/changelog/stable/`} data-release-notes="desktop">更新日志 →</a> · <a href={`${repo}/releases`}>全部版本 →</a></span></div>
         <div class="dl-help">
           <strong><span class="l-en">macOS opens with a quarantine warning?</span><span class="l-zh">macOS 提示无法打开或已损坏?</span></strong>
           <span><span class="l-en">If the app was installed from the official download and placed in <code>/Applications</code>, quit Reasonix, then run:</span><span class="l-zh">如果来自官网下载并已放入 <code>/Applications</code>,先退出 Reasonix,再运行:</span></span>
@@ -355,7 +355,7 @@ const ld = {
             <div class="os-options"><a href={repoReleases} data-cli-asset="reasonix-linux-arm64.tar.gz">ARM64 tar.gz</a></div>
           </div>
         </div>
-        <div class="dl-note"><span class="l-en"><a href={repoReleases} data-cli-asset="SHA256SUMS">SHA256SUMS →</a> · npm and Homebrew continue to track Stable</span><span class="l-zh"><a href={repoReleases} data-cli-asset="SHA256SUMS">SHA256SUMS →</a> · npm 与 Homebrew 继续跟随正式版</span></div>
+        <div class="dl-note"><span class="l-en"><a href={repoReleases} data-cli-asset="SHA256SUMS">SHA256SUMS →</a> · <a href={`${base}/changelog/stable/`} data-release-notes="cli">release notes →</a> · npm and Homebrew continue to track Stable</span><span class="l-zh"><a href={repoReleases} data-cli-asset="SHA256SUMS">SHA256SUMS →</a> · <a href={`${base}/changelog/stable/`} data-release-notes="cli">更新日志 →</a> · npm 与 Homebrew 继续跟随正式版</span></div>
       </div>
 
       <div class="dl-pane" id="download-pane-vscode" data-pane="vscode" role="tabpanel" aria-labelledby="download-tab-vscode" hidden>

--- a/site/src/scripts/changelog-style-contract.test.mjs
+++ b/site/src/scripts/changelog-style-contract.test.mjs
@@ -4,6 +4,7 @@ import { test } from "node:test";
 
 const css = await readFile(new URL("../styles/changelog.css", import.meta.url), "utf8");
 const component = await readFile(new URL("../components/ChangelogPage.astro", import.meta.url), "utf8");
+const versionPage = await readFile(new URL("../pages/changelog/[version].astro", import.meta.url), "utf8");
 
 test("changelog channel tabs use the shared accent hierarchy in both color schemes", () => {
   assert.doesNotMatch(css, /var\(--(?:muted|paper)\)/);
@@ -21,4 +22,13 @@ test("changelog channel navigation exposes current-page and keyboard-focus state
     css,
     /\.release-channel-tabs a:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--accent\);[^}]*outline-offset:\s*2px;/s,
   );
+});
+
+test("reviewed exact-version routes redirect safely until their publication marker exists", () => {
+  assert.match(versionPage, /import \{ allReleases, releases \}/);
+  assert.match(versionPage, /publishedVersions\.has\(release\.version\)/);
+  assert.match(versionPage, /if \(!published\)/);
+  assert.match(versionPage, /return Astro\.redirect/);
+  assert.match(versionPage, /'\/changelog\/preview\/'/);
+  assert.match(versionPage, /'\/changelog\/stable\/'/);
 });

--- a/site/src/scripts/changelog-style-contract.test.mjs
+++ b/site/src/scripts/changelog-style-contract.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const css = await readFile(new URL("../styles/changelog.css", import.meta.url), "utf8");
+const component = await readFile(new URL("../components/ChangelogPage.astro", import.meta.url), "utf8");
+
+test("changelog channel tabs use the shared accent hierarchy in both color schemes", () => {
+  assert.doesNotMatch(css, /var\(--(?:muted|paper)\)/);
+  assert.match(
+    css,
+    /\.release-channel-tabs a\.active\s*\{[^}]*background:\s*var\(--accent-soft\);[^}]*border-color:[^}]*var\(--accent\)[^}]*color:\s*var\(--accent-deep\);/s,
+  );
+});
+
+test("changelog channel navigation exposes current-page and keyboard-focus states", () => {
+  assert.equal((component.match(/aria-current=/g) ?? []).length, 2);
+  assert.match(component, /aria-current=\{!isPreview \? 'page' : undefined\}/);
+  assert.match(component, /aria-current=\{isPreview \? 'page' : undefined\}/);
+  assert.match(
+    css,
+    /\.release-channel-tabs a:focus-visible\s*\{[^}]*outline:\s*2px solid var\(--accent\);[^}]*outline-offset:\s*2px;/s,
+  );
+});

--- a/site/src/scripts/release-channels.js
+++ b/site/src/scripts/release-channels.js
@@ -154,12 +154,17 @@ export function cliReleaseModel(releases, requestedChannel) {
   const assets = releaseAssetMap(release);
   if (!assets) return null;
   const releaseURL = `https://github.com/esengine/DeepSeek-Reasonix/releases/tag/${parsed.tag}`;
+  const exactChangelogURL = `https://reasonix.io/changelog/${parsed.tag}/`;
+  const changelogURL = release.release_notes_url === exactChangelogURL
+    ? exactChangelogURL
+    : `https://reasonix.io/changelog/${channel}/`;
   return {
     channel,
     version: parsed.tag,
     displayVersion: parsed.tag.slice(1),
     assets,
     releaseURL,
+    changelogURL,
   };
 }
 
@@ -230,6 +235,9 @@ export function desktopReleaseModel(manifest, requestedChannel) {
     version: parsed.tag,
     displayVersion: parsed.tag.slice(1),
     assets,
+    changelogURL: manifest.release_notes_url === `https://reasonix.io/changelog/${parsed.tag}/`
+      ? manifest.release_notes_url
+      : `https://reasonix.io/changelog/${parsed.channel}/`,
   };
 }
 
@@ -272,6 +280,7 @@ export function desktopGitHubReleaseModel(release) {
     version: match[1],
     displayVersion: match[1].slice(1),
     assets: Object.fromEntries(DESKTOP_ASSETS.map(([, , name]) => [name, found[name]])),
+    changelogURL: "https://reasonix.io/changelog/stable/",
   };
 }
 

--- a/site/src/scripts/release-channels.test.mjs
+++ b/site/src/scripts/release-channels.test.mjs
@@ -161,7 +161,7 @@ test("CLI selection compares arbitrarily large numeric version components exactl
   assert.equal(selectCLIRelease(releases, "stable")?.tag_name, "v100000000000000000000.0.0");
 });
 
-test("CLI release notes always use the canonical repository tag URL", () => {
+test("CLI release links are derived from the validated canonical tag", () => {
   const release = {
     tag_name: "v1.18.0",
     prerelease: false,
@@ -172,6 +172,12 @@ test("CLI release notes always use the canonical repository tag URL", () => {
     cliReleaseModel([release], "stable")?.releaseURL,
     "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.18.0",
   );
+  assert.equal(
+    cliReleaseModel([release], "stable")?.changelogURL,
+    "https://reasonix.io/changelog/stable/",
+  );
+  release.release_notes_url = "https://reasonix.io/changelog/v1.18.0/";
+  assert.equal(cliReleaseModel([release], "stable")?.changelogURL, release.release_notes_url);
 });
 
 test("CLI assets reject spoofed hosts and cross-tag URLs", () => {
@@ -226,6 +232,9 @@ test("Desktop manifests accept only the exact official Stable and Preview bases"
   assert.equal(desktopReleaseModel(preview, "stable"), null);
   const model = desktopReleaseModel(preview, "preview");
   assert.equal(model?.displayVersion, "1.18.0-preview.62");
+  assert.equal(model?.changelogURL, "https://reasonix.io/changelog/preview/");
+  preview.release_notes_url = "https://reasonix.io/changelog/v1.18.0-preview.62/";
+  assert.equal(desktopReleaseModel(preview, "preview")?.changelogURL, preview.release_notes_url);
   assert.equal(model?.assets["Reasonix-darwin-universal.dmg"],
     "https://dl.reasonix.io/desktop-v1.18.0-preview.62/Reasonix-darwin-universal.dmg");
   assert.equal(model?.assets["Reasonix-windows-amd64.zip"],

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -270,6 +270,10 @@ import { initTheme } from "./theme.js";
     document.querySelectorAll('[data-release-summary="' + surface + '"] [data-channel-copy]').forEach((copy) => {
       copy.hidden = copy.dataset.channelCopy !== channel;
     });
+    document.querySelectorAll('[data-release-notes="' + surface + '"]').forEach((link) => {
+      const path = model?.changelogURL ? new URL(model.changelogURL).pathname : "changelog/" + channel + "/";
+      link.href = new URL(path, window.location.origin + "/").href;
+    });
     document.querySelectorAll('[data-release-switch="' + surface + '"] [data-release-channel]').forEach((button) => {
       const active = button.dataset.releaseChannel === channel;
       button.classList.toggle("active", active);

--- a/site/src/styles/changelog.css
+++ b/site/src/styles/changelog.css
@@ -409,6 +409,55 @@ body {
   .release-footer > span { order: 3; width: 100%; margin: 0; }
 }
 
+.release-channel-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin: 14px 0 18px;
+}
+
+.release-channel-tabs a {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink-2);
+  padding: 7px 10px;
+  text-align: center;
+  text-decoration: none;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.release-channel-tabs a:hover {
+  border-color: color-mix(in oklch, var(--accent) 40%, var(--line));
+  color: var(--accent-deep);
+}
+
+.release-channel-tabs a.active {
+  background: var(--accent-soft);
+  border-color: color-mix(in oklch, var(--accent) 46%, var(--line));
+  color: var(--accent-deep);
+}
+
+.release-channel-tabs a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.release-builds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.release-builds span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  padding: 6px 10px;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .release-version-link, .release-guide { transition: none; }
+  .release-version-link, .release-guide, .release-channel-tabs a { transition: none; }
 }


### PR DESCRIPTION
## Summary

- add one protected Preview orchestrator that publishes CLI, Desktop, npm, and the exact changelog record with a shared preview ordinal
- give every Stable and Preview identity its own reviewed release metadata and immutable all-surface publication marker
- route website downloads, release-note links, and changelog archives by channel
- add an accessible, theme-aware Stable/Preview archive switcher
- extend release authorization, SignPath policy checks, manifest validation, CI contracts, and operator documentation

## Why

Stable and Preview already exposed different public artifacts, but their release identities and changelog history were not managed as one end-to-end event. Preview suffixes could drift between surfaces, and a reviewed changelog entry could not prove that every required artifact had actually shipped.

This change binds the CLI tag, Desktop build, npm canary, candidate SHA, and exact release notes to one protected event. The website fails closed for newly reviewed records until the release postflight publishes the matching immutable marker.

## Release safety

- Preview pauses once on the protected `canary` environment.
- A zero-publication SignPath preflight completes before any Preview publisher starts.
- Every child workflow revalidates the approved tag and candidate SHA.
- The postflight advances the changelog only after CLI, Desktop, and npm all succeed.
- npm recovery reuses only matching immutable packages, fills missing packages, and never rolls a public dist-tag backward.
- Stable and Preview pointers remain independent, while Desktop Preview continues mirroring the legacy canary pointer for older clients.

## Compatibility

| Area | Existing behavior | Result |
| --- | --- | --- |
| Legacy release catalog entries | Records do not contain managed status or publication markers | They remain readable and public |
| Stable release tags and pointers | Existing `vX.Y.Z`, `desktop-vX.Y.Z`, npm latest, and Stable R2 paths | Unchanged |
| Desktop Preview clients | Older clients may read the canary pointer | Preview still mirrors canary |
| Existing npm packages | Packages may predate candidate metadata | Matching legacy `gitHead` remains recoverable; new packages record the candidate SHA |
| Persisted user data and Wails contracts | Existing formats | No changes |

## Validation

- `node --test npm/publish.test.mjs` — 6 passed
- `bash scripts/release-workflows.test.sh`
- `node --test scripts/release-notes.test.mjs` — 6 passed
- `cd desktop && go test ./cmd/sign ./internal/update`
- `cd site && npm test` — 47 passed
- `cd site && npm run build` — 29 pages generated
- Actionlint across all Stable, Preview, CLI, npm, and Desktop release workflows
- Browser verification of the Stable/Preview changelog navigation in light and dark themes