### PR TITLE
feat(acp): add supervisor status and hard overrides

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -278,7 +278,6 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 			Status:     "pending",
 			RawInput:   rawJSON(string(a.RawInput)),
 			Locations:  s.toolLocations(a.Tool, string(a.RawInput)),
-			Reason:     a.Reason,
 			Meta:       s.permissionMeta(a),
 		},
 		Options: options,
@@ -310,6 +309,9 @@ func (s *updateSink) permissionMeta(a event.Approval) map[string]any {
 		"tool":       a.Tool,
 		"subject":    a.Subject,
 		"fresh":      a.Fresh,
+	}
+	if reason := strings.TrimSpace(a.Reason); reason != "" {
+		reasonix["reason"] = reason
 	}
 	if a.Tool == "bash" && strings.TrimSpace(s.cwd) != "" {
 		var input struct {

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -15,6 +15,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/permission"
 	"reasonix/internal/provider"
+	"reasonix/internal/shellparse"
 )
 
 // notifier is the slice of Conn the dispatch sink depends on: it pushes
@@ -54,6 +55,7 @@ type updateSink struct {
 	cwd     string
 	approve func(id string, allow, session, persist bool)
 	answer  func(id string, answers []event.AskAnswer)
+	status  func(event.Event)
 	mu      sync.Mutex
 	turnCtx context.Context
 }
@@ -81,6 +83,10 @@ func (s *updateSink) bindAnswer(fn func(id string, answers []event.AskAnswer)) {
 	s.answer = fn
 }
 
+// bindStatus installs the vendor-status observer. It receives typed events,
+// never raw reasoning text or terminal transcripts.
+func (s *updateSink) bindStatus(fn func(event.Event)) { s.status = fn }
+
 func (s *updateSink) setTurnContext(ctx context.Context) {
 	s.mu.Lock()
 	s.turnCtx = ctx
@@ -106,6 +112,9 @@ func (s *updateSink) currentTurnContext() context.Context {
 // Emit implements event.Sink. The agent calls it serially (see event.Sink), so no
 // locking is needed; write serialization lives in Conn.
 func (s *updateSink) Emit(e event.Event) {
+	if s.status != nil {
+		s.status(e)
+	}
 	switch e.Kind {
 	case event.Reasoning:
 		if e.Text == "" {
@@ -267,6 +276,10 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 			Title:      title,
 			Kind:       toolKindFor(a.Tool),
 			Status:     "pending",
+			RawInput:   rawJSON(string(a.RawInput)),
+			Locations:  s.toolLocations(a.Tool, string(a.RawInput)),
+			Reason:     a.Reason,
+			Meta:       s.permissionMeta(a),
 		},
 		Options: options,
 	}
@@ -284,6 +297,48 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 		}
 	}
 	s.approve(a.ID, allow, session, persist)
+}
+
+// permissionMeta carries Reasonix-owned structured data that an ACP supervisor
+// may trust independently from model-supplied rawInput. A foreground bash call
+// receives argv only when the command is a single static command: shell
+// expansion, control operators, redirects, assignments, and background jobs all
+// fail closed and remain interactive.
+func (s *updateSink) permissionMeta(a event.Approval) map[string]any {
+	reasonix := map[string]any{
+		"approvalId": a.ID,
+		"tool":       a.Tool,
+		"subject":    a.Subject,
+		"fresh":      a.Fresh,
+	}
+	if a.Tool == "bash" && strings.TrimSpace(s.cwd) != "" {
+		var input struct {
+			Command                     string `json:"command"`
+			RunInBackground             bool   `json:"run_in_background"`
+			PreserveBackgroundProcesses bool   `json:"preserve_background_processes"`
+		}
+		if json.Unmarshal(a.RawInput, &input) == nil &&
+			!input.RunInBackground && !input.PreserveBackgroundProcesses {
+			cwd, cwdErr := filepath.Abs(s.cwd)
+			features, featureOK := shellparse.AnalyzeApprovalFeatures(input.Command)
+			command, commandErr := shellparse.ParseStaticCommand(input.Command, shellparse.StaticCommandPolicy{})
+			exact := featureOK && !features.DynamicCommandName && !features.NestedExecution &&
+				!features.Expansion && !features.Assignment && !features.Redirection &&
+				!shellparse.ContainsUnquotedGlob(input.Command)
+			for _, arg := range command.Argv {
+				// Tilde expansion is shell-dependent and therefore not exact argv.
+				if strings.HasPrefix(arg, "~") {
+					exact = false
+				}
+			}
+			if cwdErr == nil && commandErr == nil && exact && len(command.Argv) > 0 {
+				reasonix["commandSchemaVersion"] = 1
+				reasonix["argv"] = command.Argv
+				reasonix["cwd"] = cwd
+			}
+		}
+	}
+	return map[string]any{"reasonix.io": reasonix}
 }
 
 func (s *updateSink) requestAsk(ctx context.Context, a event.Ask) {

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -273,6 +274,48 @@ func TestUpdateSinkApprovalAllowAlways(t *testing.T) {
 	}
 }
 
+func TestUpdateSinkPermissionCarriesStructuredContext(t *testing.T) {
+	fn := &fakeNotifier{onReq: func(_ string, params any) (json.RawMessage, error) {
+		raw, _ := json.Marshal(params)
+		var p PermissionRequestParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("permission params: %v", err)
+		}
+		if string(p.ToolCall.RawInput) != `{"path":"src/main.go","content":"next"}` {
+			t.Fatalf("rawInput = %s", p.ToolCall.RawInput)
+		}
+		if len(p.ToolCall.Locations) != 1 || !strings.HasSuffix(filepath.ToSlash(p.ToolCall.Locations[0].Path), "/src/main.go") {
+			t.Fatalf("locations = %+v", p.ToolCall.Locations)
+		}
+		if p.ToolCall.Reason != "write requested by the active goal" {
+			t.Fatalf("reason = %q", p.ToolCall.Reason)
+		}
+		meta, ok := p.ToolCall.Meta["reasonix.io"].(map[string]any)
+		if !ok || meta["tool"] != "write_file" || meta["approvalId"] != "structured" {
+			t.Fatalf("metadata = %#v", p.ToolCall.Meta)
+		}
+		res, _ := json.Marshal(PermissionRequestResult{Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptRejectOnce)}})
+		return res, nil
+	}}
+	sink := newUpdateSink(fn, "sess-structured")
+	sink.bindCwd(t.TempDir())
+	got := make(chan approveCall, 1)
+	sink.bindApprove(func(id string, allow, session, persist bool) { got <- approveCall{id, allow, session, persist} })
+	sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{
+		ID: "structured", Tool: "write_file", Subject: "src/main.go",
+		Reason:   "write requested by the active goal",
+		RawInput: json.RawMessage(`{"path":"src/main.go","content":"next"}`),
+	}})
+	select {
+	case decision := <-got:
+		if decision.allow {
+			t.Fatalf("rejected permission was allowed: %+v", decision)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission was never resolved")
+	}
+}
+
 func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 	fn := &fakeNotifier{onReq: func(_ string, params any) (json.RawMessage, error) {
 		raw, _ := json.Marshal(params)
@@ -321,6 +364,52 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("approve was never called")
+	}
+}
+
+func TestPermissionMetaOnlyTrustsForegroundStaticBash(t *testing.T) {
+	cwd := t.TempDir()
+	sink := newUpdateSink(&fakeNotifier{}, "sess-static-command")
+	sink.bindCwd(cwd)
+
+	for _, tc := range []struct {
+		name     string
+		rawInput string
+		wantArgv []string
+	}{
+		{name: "static", rawInput: `{"command":"go test ./..."}`, wantArgv: []string{"go", "test", "./..."}},
+		{name: "quoted static", rawInput: `{"command":"node -e 'process.exit(0)'"}`, wantArgv: []string{"node", "-e", "process.exit(0)"}},
+		{name: "expansion", rawInput: `{"command":"go test $PACKAGE"}`},
+		{name: "glob expansion", rawInput: `{"command":"go test ./*.go"}`},
+		{name: "brace expansion", rawInput: `{"command":"printf '%s' {a,b}"}`},
+		{name: "tilde expansion", rawInput: `{"command":"test -f ~/.config/reasonix.toml"}`},
+		{name: "control syntax", rawInput: `{"command":"go test ./... && git status"}`},
+		{name: "background", rawInput: `{"command":"go test ./...","run_in_background":true}`},
+		{name: "preserved descendants", rawInput: `{"command":"go test ./...","preserve_background_processes":true}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := sink.permissionMeta(event.Approval{
+				ID: "command", Tool: "bash", Subject: "command", RawInput: json.RawMessage(tc.rawInput),
+			})
+			reasonix, ok := meta["reasonix.io"].(map[string]any)
+			if !ok {
+				t.Fatalf("reasonix metadata = %#v", meta)
+			}
+			argv, present := reasonix["argv"]
+			if len(tc.wantArgv) == 0 {
+				if present {
+					t.Fatalf("unsafe command received trusted argv: %#v", argv)
+				}
+				return
+			}
+			got, ok := argv.([]string)
+			if !ok || strings.Join(got, "\x00") != strings.Join(tc.wantArgv, "\x00") {
+				t.Fatalf("argv = %#v, want %#v", argv, tc.wantArgv)
+			}
+			if reasonix["commandSchemaVersion"] != 1 || reasonix["cwd"] != filepath.Clean(cwd) {
+				t.Fatalf("trusted command metadata = %#v", reasonix)
+			}
+		})
 	}
 }
 

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -287,12 +287,20 @@ func TestUpdateSinkPermissionCarriesStructuredContext(t *testing.T) {
 		if len(p.ToolCall.Locations) != 1 || !strings.HasSuffix(filepath.ToSlash(p.ToolCall.Locations[0].Path), "/src/main.go") {
 			t.Fatalf("locations = %+v", p.ToolCall.Locations)
 		}
-		if p.ToolCall.Reason != "write requested by the active goal" {
-			t.Fatalf("reason = %q", p.ToolCall.Reason)
-		}
 		meta, ok := p.ToolCall.Meta["reasonix.io"].(map[string]any)
-		if !ok || meta["tool"] != "write_file" || meta["approvalId"] != "structured" {
+		if !ok || meta["tool"] != "write_file" || meta["approvalId"] != "structured" || meta["reason"] != "write requested by the active goal" {
 			t.Fatalf("metadata = %#v", p.ToolCall.Meta)
+		}
+		var wire map[string]any
+		if err := json.Unmarshal(raw, &wire); err != nil {
+			t.Fatalf("permission wire shape: %v", err)
+		}
+		toolCall, ok := wire["toolCall"].(map[string]any)
+		if !ok {
+			t.Fatalf("toolCall wire shape = %#v", wire["toolCall"])
+		}
+		if _, present := toolCall["reason"]; present {
+			t.Fatalf("ACP v1 toolCall has non-standard root reason: %#v", toolCall)
 		}
 		res, _ := json.Marshal(PermissionRequestResult{Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptRejectOnce)}})
 		return res, nil

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -688,7 +688,6 @@ type PermissionToolCall struct {
 	Content    []toolContent      `json:"content,omitempty"`
 	RawInput   json.RawMessage    `json:"rawInput,omitempty"`
 	Locations  []ToolCallLocation `json:"locations,omitempty"`
-	Reason     string             `json:"reason,omitempty"`
 	Meta       map[string]any     `json:"_meta,omitempty"`
 }
 

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -681,12 +681,15 @@ type PermissionRequestParams struct {
 
 // PermissionToolCall describes the call awaiting approval.
 type PermissionToolCall struct {
-	ToolCallID string          `json:"toolCallId"`
-	Title      string          `json:"title,omitempty"`
-	Kind       string          `json:"kind,omitempty"`
-	Status     string          `json:"status,omitempty"`
-	Content    []toolContent   `json:"content,omitempty"`
-	RawInput   json.RawMessage `json:"rawInput,omitempty"`
+	ToolCallID string             `json:"toolCallId"`
+	Title      string             `json:"title,omitempty"`
+	Kind       string             `json:"kind,omitempty"`
+	Status     string             `json:"status,omitempty"`
+	Content    []toolContent      `json:"content,omitempty"`
+	RawInput   json.RawMessage    `json:"rawInput,omitempty"`
+	Locations  []ToolCallLocation `json:"locations,omitempty"`
+	Reason     string             `json:"reason,omitempty"`
+	Meta       map[string]any     `json:"_meta,omitempty"`
 }
 
 // PermissionRequestResult is the client's reply to a permission request.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -628,6 +628,12 @@ func TestServeLifecycle(t *testing.T) {
 	if steer == nil || steer.Method != sessionSteerMethod {
 		t.Errorf("sessionSteer capability = %+v, want method %q", steer, sessionSteerMethod)
 	}
+	for _, method := range []string{sessionStatusMethod, sessionStatusUpdateMethod} {
+		capability, ok := ir.AgentCapabilities.Meta[method].(map[string]any)
+		if !ok || capability["schemaVersion"] != float64(reasonixStatusSchemaVersion) {
+			t.Errorf("%s capability = %#v, want schemaVersion %d", method, ir.AgentCapabilities.Meta[method], reasonixStatusSchemaVersion)
+		}
+	}
 	if len(ir.AuthMethods) != 1 || ir.AuthMethods[0].ID != "reasonix-setup" || ir.AuthMethods[0].Type != "terminal" {
 		t.Fatalf("authMethods = %+v, want terminal reasonix setup", ir.AuthMethods)
 	}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -614,12 +614,11 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
 	}
 	cfgState = withToolApprovalConfig(cfgState, control.ToolApprovalAsk)
-	runtimeState, err := s.sessionRuntimeState(ctx, cwd)
+	runtimeState, err := s.sessionRuntimeState(ctx, SessionRuntimeStateParams{
+		Cwd: cwd, Model: cfgState.Model, RuntimeProfile: cfgState.RuntimeProfile,
+	})
 	if err != nil {
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
-	}
-	if cfgState.RuntimeProfile == "economy" {
-		runtimeState.PlannerMode = "off"
 	}
 
 	id, err := newSessionID()
@@ -915,12 +914,11 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	if err != nil {
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
-	runtimeState, err := s.sessionRuntimeState(ctx, cwd)
+	runtimeState, err := s.sessionRuntimeState(ctx, SessionRuntimeStateParams{
+		Cwd: cwd, Model: cfgState.Model, RuntimeProfile: cfgState.RuntimeProfile,
+	})
 	if err != nil {
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
-	}
-	if cfgState.RuntimeProfile == "economy" {
-		runtimeState.PlannerMode = "off"
 	}
 
 	sink := newUpdateSink(s.conn, id)
@@ -1544,6 +1542,13 @@ func (s *service) rebuildSessionLocked(ctx context.Context, sess *acpSession, cf
 		return &RPCError{Code: ErrInternal, Message: "session config: " + err.Error()}
 	}
 	newCtrl.EnableInteractiveApproval()
+	runtimeState, err := s.sessionRuntimeState(ctx, SessionRuntimeStateParams{
+		Cwd: cwd, Model: cfgState.Model, RuntimeProfile: cfgState.RuntimeProfile,
+	})
+	if err != nil {
+		newCtrl.ReleaseResources()
+		return &RPCError{Code: ErrInternal, Message: "session config: runtime state: " + err.Error()}
+	}
 	// The freshly built controller's own leading system message carries the
 	// target profile's contract (see boot/token_profile.go); AdoptHistory below
 	// replaces the whole history with carried, so splice that message in first
@@ -1609,6 +1614,7 @@ func (s *service) rebuildSessionLocked(ctx context.Context, sess *acpSession, cf
 	sess.effortOverride = cloneStringPtr(cfgState.EffortOverride)
 	sess.runtimeProfile = cfgState.RuntimeProfile
 	sess.toolApprovalMode = toolApprovalMode
+	sess.runtimeState = runtimeState
 	sess.modeID = modeID
 	sess.goalDraftMode = goalDraftMode
 	if sess.transcript != "" && sessionFileExists(sess.transcript) {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -126,6 +126,7 @@ func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info 
 	conn.Handle("session/resume", svc.sessionResume)
 	conn.Handle("session/prompt", svc.sessionPrompt)
 	conn.Handle(sessionSteerMethod, svc.sessionSteer)
+	conn.Handle(sessionStatusMethod, svc.sessionStatus)
 	conn.Handle("session/set_config_option", svc.sessionSetConfigOption)
 	conn.Handle("session/set_model", svc.sessionSetModel)
 	conn.Handle("session/set_mode", svc.sessionSetMode)
@@ -227,6 +228,10 @@ type acpSession struct {
 	effortOverride   *string
 	runtimeProfile   string
 	toolApprovalMode string
+	// runtimeState is the effective planner/sandbox posture captured after CLI
+	// hard overrides. status snapshots never reconstruct it from user config.
+	runtimeState SessionRuntimeState
+	status       *statusTelemetry
 	// modeID is the ACP collaboration mode last reported to the client (normal |
 	// plan | goal). Goal draft mode turns the next user prompt into the goal.
 	// Both are guarded by mu; controller-side completion/plan exit is reconciled
@@ -555,6 +560,8 @@ func (s *service) initialize(_ context.Context, raw json.RawMessage) (any, error
 				"reasonix.io": ReasonixExtensionCapabilities{
 					SessionSteer: &SessionSteerCapability{Method: sessionSteerMethod},
 				},
+				sessionStatusMethod:       ReasonixSchemaCapability{SchemaVersion: reasonixStatusSchemaVersion},
+				sessionStatusUpdateMethod: ReasonixSchemaCapability{SchemaVersion: reasonixStatusSchemaVersion},
 			},
 		},
 		AgentInfo:   Implementation{Name: s.info.Name, Version: s.info.Version},
@@ -607,6 +614,13 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
 	}
 	cfgState = withToolApprovalConfig(cfgState, control.ToolApprovalAsk)
+	runtimeState, err := s.sessionRuntimeState(ctx, cwd)
+	if err != nil {
+		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
+	}
+	if cfgState.RuntimeProfile == "economy" {
+		runtimeState.PlannerMode = "off"
+	}
 
 	id, err := newSessionID()
 	if err != nil {
@@ -644,10 +658,13 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 		effortOverride:   cloneStringPtr(cfgState.EffortOverride),
 		runtimeProfile:   cfgState.RuntimeProfile,
 		toolApprovalMode: control.ToolApprovalAsk,
+		runtimeState:     runtimeState,
+		status:           newStatusTelemetry(),
 		modeID:           sessionModeNormal,
 		createdAt:        now,
 		updatedAt:        now,
 	}
+	s.bindStatusEvents(sess)
 	// Pin a transcript file keyed by session id when the controller has a session
 	// dir, so every turn auto-saves there, session/prompt can hand the path back,
 	// and session/load can find it again by id across process restarts. The
@@ -898,6 +915,13 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	if err != nil {
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
+	runtimeState, err := s.sessionRuntimeState(ctx, cwd)
+	if err != nil {
+		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
+	}
+	if cfgState.RuntimeProfile == "economy" {
+		runtimeState.PlannerMode = "off"
+	}
 
 	sink := newUpdateSink(s.conn, id)
 	sink.bindCwd(cwd)
@@ -981,6 +1005,8 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		effortOverride:   cloneStringPtr(cfgState.EffortOverride),
 		runtimeProfile:   cfgState.RuntimeProfile,
 		toolApprovalMode: toolApprovalMode,
+		runtimeState:     runtimeState,
+		status:           restoreStatusTelemetry(saved.Status),
 		modeID:           modeID,
 		goalDraftMode:    goalDraftMode,
 		title:            meta.Title,
@@ -988,6 +1014,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		updatedAt:        meta.UpdatedAt,
 		lease:            lease,
 	}
+	s.bindStatusEvents(sess)
 	if err := saveACPMeta(path, sess.meta()); err != nil {
 		sess.releaseSessionLease()
 		ctrl.Close()
@@ -1065,6 +1092,11 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	if !ok {
 		return nil, &RPCError{Code: ErrInvalidRequest, Message: "session/prompt: session already has an active prompt"}
 	}
+	if sess.status == nil {
+		sess.status = newStatusTelemetry()
+	}
+	sess.status.beginTurn()
+	s.publishStatus(sess, "phase")
 	sess.sink.setTurnContext(runCtx)
 	if sess.takeGoalDraftMode() {
 		sess.currentCtrl().SetGoal(text)
@@ -1077,8 +1109,15 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	}()
 	runErr := sess.ctrl.RunTurn(runCtx, text)
 
-	// Persist after the turn (best-effort) so a crash loses at most this prompt;
-	// save even on cancel/error since the partial conversation is still resumable.
+	statusEvent := sess.status.finishTurn(
+		runErr,
+		runCtx.Err() != nil,
+		sess.currentCtrl().GoalStatus(),
+		finalAssistantSummary(sess.currentCtrl()),
+	)
+	s.publishStatus(sess, statusEvent)
+	// Persist after status finalization (best-effort) so reconnect recovers both
+	// the transcript and the same sequence/usage/outcome snapshot.
 	sess.persistAfterTurn(text)
 
 	stop := StopEndTurn
@@ -2126,6 +2165,7 @@ func (s *acpSession) metaLocked() acpSessionMeta {
 		Title:             s.title,
 		CreatedAt:         s.createdAt,
 		UpdatedAt:         s.updatedAt,
+		Status:            s.status.persisted(),
 	}
 }
 
@@ -2248,16 +2288,17 @@ func (s *service) resolveSlashPrompt(ctx context.Context, sess *acpSession, text
 }
 
 type acpSessionMeta struct {
-	SessionID         string    `json:"sessionId"`
-	Cwd               string    `json:"cwd"`
-	Model             string    `json:"model,omitempty"`
-	EffortOverride    *string   `json:"effortOverride,omitempty"`
-	RuntimeProfile    string    `json:"runtimeProfile,omitempty"`
-	ToolApprovalMode  string    `json:"toolApprovalMode,omitempty"`
-	CollaborationMode string    `json:"collaborationMode,omitempty"`
-	Title             string    `json:"title,omitempty"`
-	CreatedAt         time.Time `json:"createdAt"`
-	UpdatedAt         time.Time `json:"updatedAt"`
+	SessionID         string                    `json:"sessionId"`
+	Cwd               string                    `json:"cwd"`
+	Model             string                    `json:"model,omitempty"`
+	EffortOverride    *string                   `json:"effortOverride,omitempty"`
+	RuntimeProfile    string                    `json:"runtimeProfile,omitempty"`
+	ToolApprovalMode  string                    `json:"toolApprovalMode,omitempty"`
+	CollaborationMode string                    `json:"collaborationMode,omitempty"`
+	Title             string                    `json:"title,omitempty"`
+	CreatedAt         time.Time                 `json:"createdAt"`
+	UpdatedAt         time.Time                 `json:"updatedAt"`
+	Status            *persistedStatusTelemetry `json:"status,omitempty"`
 	// ActiveTranscript, when set on the id-keyed sidecar, is the basename of
 	// the transcript this session currently lives in: a snapshot recovery
 	// moved the live session onto a recovery branch and left this redirect

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -404,11 +404,12 @@ func restoreStatusTelemetry(saved *persistedStatusTelemetry) *statusTelemetry {
 	if saved == nil {
 		return t
 	}
+	interrupted := saved.State == "running"
 	t.sequence = saved.Sequence
-	t.state = saved.State
-	if t.state != "running" {
-		t.state = "idle"
-	}
+	// A restored process never owns the turn that wrote a running snapshot.
+	// Publish a new, terminal recovery state instead of leaving supervisors
+	// waiting on work that no longer exists in this runtime.
+	t.state = "idle"
 	t.phase = normalizePersistedStatusPhase(saved.Phase)
 	t.turnOutcome = saved.TurnOutcome
 	if t.turnOutcome.Kind == "" {
@@ -422,6 +423,12 @@ func restoreStatusTelemetry(saved *persistedStatusTelemetry) *statusTelemetry {
 	t.turnUsage = restoreUsage(saved.TurnUsage)
 	t.cumulative = restoreUsage(saved.Cumulative)
 	t.goalOverride = saved.GoalOverride
+	if interrupted {
+		t.sequence++
+		t.phase = "recovery_paused"
+		t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: "previous turn interrupted"}
+		t.finalReadiness.ReadyForReview = false
+	}
 	return t
 }
 

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -1,0 +1,617 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"runtime"
+	"strings"
+	"sync"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+const (
+	reasonixStatusSchemaVersion = 1
+	sessionStatusMethod         = "_reasonix.io/session/status"
+	sessionStatusUpdateMethod   = "_reasonix.io/session/status_update"
+)
+
+// ReasonixSchemaCapability advertises one versioned vendor extension in
+// agentCapabilities._meta. The method name is the map key so clients can fail
+// closed before opening a session.
+type ReasonixSchemaCapability struct {
+	SchemaVersion int `json:"schemaVersion"`
+}
+
+// SessionStatusParams addresses one live ACP session.
+type SessionStatusParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// SessionSandboxState is the effective sandbox, after all CLI hard overrides
+// have been applied. It deliberately reports no credentials or environment.
+type SessionSandboxState struct {
+	Mode           string   `json:"mode"`
+	Engine         string   `json:"engine"`
+	WorkspaceRoot  string   `json:"workspaceRoot"`
+	WriteRoots     []string `json:"writeRoots"`
+	NetworkEnabled bool     `json:"networkEnabled"`
+}
+
+// SessionRuntimeState is supplied by the composition root because only it can
+// truthfully report config-derived sandbox and planner state.
+type SessionRuntimeState struct {
+	PlannerMode string              `json:"plannerMode"`
+	Sandbox     SessionSandboxState `json:"sandbox"`
+}
+
+// SessionRuntimeStateProvider exposes effective process/session policy without
+// coupling the ACP adapter to Reasonix configuration internals.
+type SessionRuntimeStateProvider interface {
+	SessionRuntimeState(ctx context.Context, cwd string) (SessionRuntimeState, error)
+}
+
+type ReasonixStatusGoal struct {
+	Status    string `json:"status"`
+	Objective string `json:"objective,omitempty"`
+}
+
+type ReasonixTurnOutcome struct {
+	Kind   string `json:"kind"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type ReasonixFinalReadiness struct {
+	ReadyForReview bool     `json:"readyForReview"`
+	Summary        string   `json:"summary"`
+	Risks          []string `json:"risks"`
+}
+
+type ReasonixUsage struct {
+	PromptTokens     int      `json:"promptTokens"`
+	CompletionTokens int      `json:"completionTokens"`
+	ReasoningTokens  int      `json:"reasoningTokens"`
+	CacheHitTokens   int      `json:"cacheHitTokens"`
+	CacheMissTokens  int      `json:"cacheMissTokens"`
+	CacheHitRatio    *float64 `json:"cacheHitRatio"`
+	EstimatedCost    *float64 `json:"estimatedCost"`
+	Currency         *string  `json:"currency"`
+	UsageSource      string   `json:"usageSource"`
+}
+
+type ReasonixStatusUsage struct {
+	Turn       ReasonixUsage `json:"turn"`
+	Cumulative ReasonixUsage `json:"cumulative"`
+}
+
+// ReasonixSessionStatus is the stable schemaVersion=1 recovery snapshot.
+// Reasoning text and unbounded terminal output are intentionally absent.
+type ReasonixSessionStatus struct {
+	SchemaVersion  int                    `json:"schemaVersion"`
+	Sequence       uint64                 `json:"sequence"`
+	SessionID      string                 `json:"sessionId"`
+	State          string                 `json:"state"`
+	Model          string                 `json:"model"`
+	Effort         string                 `json:"effort"`
+	Mode           string                 `json:"mode"`
+	WorkMode       string                 `json:"workMode"`
+	PlannerMode    string                 `json:"plannerMode"`
+	Goal           ReasonixStatusGoal     `json:"goal"`
+	Phase          string                 `json:"phase"`
+	TurnOutcome    ReasonixTurnOutcome    `json:"turnOutcome"`
+	FinalReadiness ReasonixFinalReadiness `json:"finalReadiness"`
+	Sandbox        SessionSandboxState    `json:"sandbox"`
+	Usage          ReasonixStatusUsage    `json:"usage"`
+}
+
+type ReasonixStatusUpdate struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	Sequence      uint64                `json:"sequence"`
+	SessionID     string                `json:"sessionId"`
+	Event         string                `json:"event"`
+	Status        ReasonixSessionStatus `json:"status"`
+}
+
+type usageAccumulator struct {
+	promptTokens     int
+	completionTokens int
+	reasoningTokens  int
+	cacheHitTokens   int
+	cacheMissTokens  int
+	events           int
+	pricedEvents     int
+	estimatedCost    float64
+	currency         string
+	source           string
+}
+
+func (a *usageAccumulator) add(u *provider.Usage, pricing *provider.Pricing, source string) {
+	if u == nil {
+		return
+	}
+	a.promptTokens += u.PromptTokens
+	a.completionTokens += u.CompletionTokens
+	a.reasoningTokens += u.ReasoningTokens
+	a.cacheHitTokens += u.CacheHitTokens
+	a.cacheMissTokens += u.CacheMissTokens
+	a.events++
+	source = strings.TrimSpace(source)
+	if source == "" {
+		source = event.UsageSourceExecutor
+	}
+	if a.source == "" {
+		a.source = source
+	} else if a.source != source {
+		a.source = "mixed"
+	}
+	if pricing != nil {
+		currency := strings.TrimSpace(pricing.Currency)
+		if currency == "" {
+			currency = pricing.Symbol()
+		}
+		if a.pricedEvents == 0 {
+			a.currency = currency
+		} else if a.currency != currency {
+			a.currency = ""
+		}
+		a.estimatedCost += pricing.Cost(u)
+		a.pricedEvents++
+	}
+}
+
+func (a usageAccumulator) wire() ReasonixUsage {
+	usage := ReasonixUsage{
+		PromptTokens:     a.promptTokens,
+		CompletionTokens: a.completionTokens,
+		ReasoningTokens:  a.reasoningTokens,
+		CacheHitTokens:   a.cacheHitTokens,
+		CacheMissTokens:  a.cacheMissTokens,
+		UsageSource:      a.source,
+	}
+	if usage.UsageSource == "" {
+		usage.UsageSource = event.UsageSourceExecutor
+	}
+	if total := a.cacheHitTokens + a.cacheMissTokens; total > 0 {
+		ratio := float64(a.cacheHitTokens) / float64(total)
+		usage.CacheHitRatio = &ratio
+	}
+	if a.events > 0 && a.pricedEvents == a.events && a.currency != "" && !math.IsNaN(a.estimatedCost) && !math.IsInf(a.estimatedCost, 0) {
+		cost := a.estimatedCost
+		currency := a.currency
+		usage.EstimatedCost = &cost
+		usage.Currency = &currency
+	}
+	return usage
+}
+
+type statusTelemetry struct {
+	mu             sync.Mutex
+	sequence       uint64
+	state          string
+	phase          string
+	turnOutcome    ReasonixTurnOutcome
+	finalReadiness ReasonixFinalReadiness
+	turnUsage      usageAccumulator
+	cumulative     usageAccumulator
+	goalOverride   string
+}
+
+func newStatusTelemetry() *statusTelemetry {
+	return &statusTelemetry{
+		state:       "idle",
+		phase:       "idle",
+		turnOutcome: ReasonixTurnOutcome{Kind: "none"},
+		finalReadiness: ReasonixFinalReadiness{
+			Risks: []string{},
+		},
+	}
+}
+
+func (t *statusTelemetry) mutate(fn func(*statusTelemetry)) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	fn(t)
+	t.sequence++
+	return t.sequence
+}
+
+func (t *statusTelemetry) beginTurn() {
+	t.mutate(func(t *statusTelemetry) {
+		t.state = "running"
+		t.phase = "starting"
+		t.turnOutcome = ReasonixTurnOutcome{Kind: "none"}
+		t.finalReadiness = ReasonixFinalReadiness{Risks: []string{}}
+		t.turnUsage = usageAccumulator{}
+		t.goalOverride = ""
+	})
+}
+
+func (t *statusTelemetry) onEvent(e event.Event) (string, bool) {
+	switch e.Kind {
+	case event.Phase:
+		t.mutate(func(t *statusTelemetry) {
+			if phase := strings.TrimSpace(e.Text); phase != "" {
+				t.phase = phase
+			}
+		})
+		return "phase", true
+	case event.Usage:
+		t.mutate(func(t *statusTelemetry) {
+			t.turnUsage.add(e.Usage, e.Pricing, e.UsageSource)
+			t.cumulative.add(e.Usage, e.Pricing, e.UsageSource)
+		})
+		return "usage", true
+	case event.ApprovalRequest:
+		t.mutate(func(t *statusTelemetry) { t.phase = "waiting_permission" })
+		return "phase", true
+	case event.AskRequest:
+		t.mutate(func(t *statusTelemetry) { t.phase = "waiting_input" })
+		return "phase", true
+	case event.ToolDispatch:
+		t.mutate(func(t *statusTelemetry) { t.phase = "implementing" })
+	case event.Notice:
+		if e.Code == event.NoticeCodeFinalReadiness {
+			t.mutate(func(t *statusTelemetry) { t.phase = "checking_readiness" })
+			return "phase", true
+		}
+	}
+	return "", false
+}
+
+func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, summary string) string {
+	eventName := "completion"
+	t.mutate(func(t *statusTelemetry) {
+		t.state = "idle"
+		t.finalReadiness.Summary = clipStatusText(summary, 16_384)
+		t.finalReadiness.Risks = []string{}
+		t.goalOverride = ""
+		switch {
+		case cancelled:
+			t.phase = "cancelled"
+			t.turnOutcome = ReasonixTurnOutcome{Kind: "cancelled"}
+			t.goalOverride = "cancelled"
+			eventName = "completion"
+		case runErr == nil && goalStatus == control.GoalStatusComplete:
+			t.phase = "review_ready"
+			t.turnOutcome = ReasonixTurnOutcome{Kind: "completed"}
+			t.finalReadiness.ReadyForReview = true
+		case runErr == nil && (goalStatus == "" || goalStatus == control.GoalStatusStopped):
+			t.phase = "completed"
+			t.turnOutcome = ReasonixTurnOutcome{Kind: "completed"}
+			t.finalReadiness.ReadyForReview = true
+		case goalStatus == control.GoalStatusBlocked:
+			t.phase = "paused"
+			t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: "goal blocked"}
+			eventName = "pause"
+		default:
+			var readinessErr *agent.FinalReadinessError
+			var recoveryPause *agent.RecoveryPauseError
+			switch {
+			case errors.As(runErr, &readinessErr):
+				t.phase = "readiness_paused"
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusText(readinessErr.Error(), 2_048)}
+				t.finalReadiness.Risks = append([]string(nil), readinessErr.Missing...)
+				eventName = "pause"
+			case errors.As(runErr, &recoveryPause):
+				t.phase = "recovery_paused"
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusText(recoveryPause.Error(), 2_048)}
+				eventName = "pause"
+			case runErr != nil:
+				t.phase = "error"
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "error", Reason: clipStatusText(runErr.Error(), 2_048)}
+				t.goalOverride = "failed"
+				eventName = "error"
+			default:
+				t.phase = "paused"
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: "goal is not complete"}
+				eventName = "pause"
+			}
+		}
+	})
+	return eventName
+}
+
+type statusTelemetrySnapshot struct {
+	sequence       uint64
+	state          string
+	phase          string
+	turnOutcome    ReasonixTurnOutcome
+	finalReadiness ReasonixFinalReadiness
+	turnUsage      ReasonixUsage
+	cumulative     ReasonixUsage
+	goalOverride   string
+}
+
+type persistedUsageAccumulator struct {
+	PromptTokens     int     `json:"promptTokens"`
+	CompletionTokens int     `json:"completionTokens"`
+	ReasoningTokens  int     `json:"reasoningTokens"`
+	CacheHitTokens   int     `json:"cacheHitTokens"`
+	CacheMissTokens  int     `json:"cacheMissTokens"`
+	Events           int     `json:"events"`
+	PricedEvents     int     `json:"pricedEvents"`
+	EstimatedCost    float64 `json:"estimatedCost"`
+	Currency         string  `json:"currency,omitempty"`
+	Source           string  `json:"source,omitempty"`
+}
+
+type persistedStatusTelemetry struct {
+	Sequence       uint64                    `json:"sequence"`
+	State          string                    `json:"state"`
+	Phase          string                    `json:"phase"`
+	TurnOutcome    ReasonixTurnOutcome       `json:"turnOutcome"`
+	FinalReadiness ReasonixFinalReadiness    `json:"finalReadiness"`
+	TurnUsage      persistedUsageAccumulator `json:"turnUsage"`
+	Cumulative     persistedUsageAccumulator `json:"cumulative"`
+	GoalOverride   string                    `json:"goalOverride,omitempty"`
+}
+
+func persistUsage(a usageAccumulator) persistedUsageAccumulator {
+	return persistedUsageAccumulator{
+		PromptTokens: a.promptTokens, CompletionTokens: a.completionTokens,
+		ReasoningTokens: a.reasoningTokens, CacheHitTokens: a.cacheHitTokens,
+		CacheMissTokens: a.cacheMissTokens, Events: a.events,
+		PricedEvents: a.pricedEvents, EstimatedCost: a.estimatedCost,
+		Currency: a.currency, Source: a.source,
+	}
+}
+
+func restoreUsage(a persistedUsageAccumulator) usageAccumulator {
+	return usageAccumulator{
+		promptTokens: a.PromptTokens, completionTokens: a.CompletionTokens,
+		reasoningTokens: a.ReasoningTokens, cacheHitTokens: a.CacheHitTokens,
+		cacheMissTokens: a.CacheMissTokens, events: a.Events,
+		pricedEvents: a.PricedEvents, estimatedCost: a.EstimatedCost,
+		currency: a.Currency, source: a.Source,
+	}
+}
+
+func (t *statusTelemetry) persisted() *persistedStatusTelemetry {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return &persistedStatusTelemetry{
+		Sequence: t.sequence, State: t.state, Phase: t.phase,
+		TurnOutcome: t.turnOutcome,
+		FinalReadiness: ReasonixFinalReadiness{
+			ReadyForReview: t.finalReadiness.ReadyForReview,
+			Summary:        t.finalReadiness.Summary,
+			Risks:          append([]string(nil), t.finalReadiness.Risks...),
+		},
+		TurnUsage: persistUsage(t.turnUsage), Cumulative: persistUsage(t.cumulative),
+		GoalOverride: t.goalOverride,
+	}
+}
+
+func restoreStatusTelemetry(saved *persistedStatusTelemetry) *statusTelemetry {
+	t := newStatusTelemetry()
+	if saved == nil {
+		return t
+	}
+	t.sequence = saved.Sequence
+	t.state = saved.State
+	if t.state != "running" {
+		t.state = "idle"
+	}
+	t.phase = saved.Phase
+	t.turnOutcome = saved.TurnOutcome
+	if t.turnOutcome.Kind == "" {
+		t.turnOutcome.Kind = "none"
+	}
+	t.finalReadiness = ReasonixFinalReadiness{
+		ReadyForReview: saved.FinalReadiness.ReadyForReview,
+		Summary:        saved.FinalReadiness.Summary,
+		Risks:          append([]string(nil), saved.FinalReadiness.Risks...),
+	}
+	if t.finalReadiness.Risks == nil {
+		t.finalReadiness.Risks = []string{}
+	}
+	t.turnUsage = restoreUsage(saved.TurnUsage)
+	t.cumulative = restoreUsage(saved.Cumulative)
+	t.goalOverride = saved.GoalOverride
+	return t
+}
+
+func (t *statusTelemetry) snapshot() statusTelemetrySnapshot {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return statusTelemetrySnapshot{
+		sequence:       t.sequence,
+		state:          t.state,
+		phase:          t.phase,
+		turnOutcome:    t.turnOutcome,
+		finalReadiness: ReasonixFinalReadiness{ReadyForReview: t.finalReadiness.ReadyForReview, Summary: t.finalReadiness.Summary, Risks: append([]string(nil), t.finalReadiness.Risks...)},
+		turnUsage:      t.turnUsage.wire(),
+		cumulative:     t.cumulative.wire(),
+		goalOverride:   t.goalOverride,
+	}
+}
+
+func defaultSessionRuntimeState(cwd string) SessionRuntimeState {
+	engine := "bubblewrap"
+	if runtime.GOOS == "darwin" {
+		engine = "seatbelt"
+	}
+	return SessionRuntimeState{
+		PlannerMode: "on",
+		Sandbox: SessionSandboxState{
+			Mode:          "enforce",
+			Engine:        engine,
+			WorkspaceRoot: cwd,
+			WriteRoots:    []string{cwd},
+		},
+	}
+}
+
+func normalizeStatusEffort(value *string) string {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return "auto"
+	}
+	return strings.TrimSpace(*value)
+}
+
+func normalizeGoalStatus(value string) string {
+	switch value {
+	case control.GoalStatusRunning, control.GoalStatusComplete, control.GoalStatusBlocked:
+		return value
+	default:
+		return "none"
+	}
+}
+
+func clipStatusText(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}
+
+func (s *service) sessionRuntimeState(ctx context.Context, cwd string) (SessionRuntimeState, error) {
+	if provider, ok := s.factory.(SessionRuntimeStateProvider); ok {
+		state, err := provider.SessionRuntimeState(ctx, cwd)
+		if err != nil {
+			return SessionRuntimeState{}, err
+		}
+		if strings.TrimSpace(state.PlannerMode) == "" {
+			state.PlannerMode = "on"
+		}
+		if state.Sandbox.WriteRoots == nil {
+			state.Sandbox.WriteRoots = []string{}
+		}
+		return state, nil
+	}
+	return defaultSessionRuntimeState(cwd), nil
+}
+
+func (s *service) bindStatusEvents(sess *acpSession) {
+	if sess == nil || sess.sink == nil {
+		return
+	}
+	if sess.status == nil {
+		sess.status = newStatusTelemetry()
+	}
+	sess.sink.bindStatus(func(e event.Event) {
+		eventName, publish := sess.status.onEvent(e)
+		if publish {
+			s.publishStatus(sess, eventName)
+		}
+	})
+}
+
+func (s *service) sessionStatus(_ context.Context, raw json.RawMessage) (any, error) {
+	var p SessionStatusParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: sessionStatusMethod + ": " + err.Error()}
+	}
+	sess := s.session(p.SessionID)
+	if sess == nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: sessionStatusMethod + ": unknown session " + p.SessionID}
+	}
+	return sess.statusSnapshot(), nil
+}
+
+func (s *service) publishStatus(sess *acpSession, eventName string) {
+	if sess == nil {
+		return
+	}
+	status := sess.statusSnapshot()
+	_ = s.conn.Notify(sessionStatusUpdateMethod, ReasonixStatusUpdate{
+		SchemaVersion: reasonixStatusSchemaVersion,
+		Sequence:      status.Sequence,
+		SessionID:     status.SessionID,
+		Event:         eventName,
+		Status:        status,
+	})
+}
+
+func (s *acpSession) statusSnapshot() ReasonixSessionStatus {
+	s.mu.Lock()
+	id := s.id
+	ctrl := s.ctrl
+	model := s.model
+	effort := cloneStringPtr(s.effortOverride)
+	workMode := s.runtimeProfile
+	mode := s.modeID
+	runtimeState := s.runtimeState
+	telemetry := s.status
+	s.mu.Unlock()
+
+	if telemetry == nil {
+		telemetry = newStatusTelemetry()
+	}
+	t := telemetry.snapshot()
+	goalStatus := "none"
+	goalObjective := ""
+	if ctrl != nil {
+		goalStatus = normalizeGoalStatus(ctrl.GoalStatus())
+		goalObjective = clipStatusText(ctrl.Goal(), 16_384)
+	}
+	if t.goalOverride != "" {
+		goalStatus = t.goalOverride
+	}
+	mode = normalizeACPCollaborationMode(mode)
+	workMode = strings.ToLower(strings.TrimSpace(workMode))
+	switch workMode {
+	case "economy", "delivery":
+	default:
+		workMode = "balanced"
+	}
+	if runtimeState.PlannerMode != "off" {
+		runtimeState.PlannerMode = "on"
+	}
+	if runtimeState.Sandbox.WriteRoots == nil {
+		runtimeState.Sandbox.WriteRoots = []string{}
+	}
+	phase := strings.TrimSpace(t.phase)
+	if phase == "" {
+		phase = "idle"
+	}
+	state := t.state
+	if state != "running" {
+		state = "idle"
+	}
+	return ReasonixSessionStatus{
+		SchemaVersion: reasonixStatusSchemaVersion,
+		Sequence:      t.sequence,
+		SessionID:     id,
+		State:         state,
+		Model:         strings.TrimSpace(model),
+		Effort:        normalizeStatusEffort(effort),
+		Mode:          mode,
+		WorkMode:      workMode,
+		PlannerMode:   runtimeState.PlannerMode,
+		Goal: ReasonixStatusGoal{
+			Status:    goalStatus,
+			Objective: goalObjective,
+		},
+		Phase:          phase,
+		TurnOutcome:    t.turnOutcome,
+		FinalReadiness: t.finalReadiness,
+		Sandbox:        runtimeState.Sandbox,
+		Usage: ReasonixStatusUsage{
+			Turn:       t.turnUsage,
+			Cumulative: t.cumulative,
+		},
+	}
+}
+
+func finalAssistantSummary(ctrl acpController) string {
+	if ctrl == nil {
+		return ""
+	}
+	history := ctrl.History()
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == provider.RoleAssistant && strings.TrimSpace(history[i].Content) != "" {
+			return history[i].Content
+		}
+	}
+	return ""
+}

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/secrets"
 )
 
 const (
@@ -38,6 +39,7 @@ type SessionStatusParams struct {
 type SessionSandboxState struct {
 	Mode           string   `json:"mode"`
 	Engine         string   `json:"engine"`
+	Available      bool     `json:"available"`
 	WorkspaceRoot  string   `json:"workspaceRoot"`
 	WriteRoots     []string `json:"writeRoots"`
 	NetworkEnabled bool     `json:"networkEnabled"`
@@ -50,10 +52,19 @@ type SessionRuntimeState struct {
 	Sandbox     SessionSandboxState `json:"sandbox"`
 }
 
+// SessionRuntimeStateParams identifies the exact controller configuration whose
+// effective policy is being reported. Model/profile switches rebuild the
+// controller, so status must be recomputed from the same resolved inputs.
+type SessionRuntimeStateParams struct {
+	Cwd            string
+	Model          string
+	RuntimeProfile string
+}
+
 // SessionRuntimeStateProvider exposes effective process/session policy without
 // coupling the ACP adapter to Reasonix configuration internals.
 type SessionRuntimeStateProvider interface {
-	SessionRuntimeState(ctx context.Context, cwd string) (SessionRuntimeState, error)
+	SessionRuntimeState(ctx context.Context, p SessionRuntimeStateParams) (SessionRuntimeState, error)
 }
 
 type ReasonixStatusGoal struct {
@@ -235,9 +246,7 @@ func (t *statusTelemetry) onEvent(e event.Event) (string, bool) {
 	switch e.Kind {
 	case event.Phase:
 		t.mutate(func(t *statusTelemetry) {
-			if phase := strings.TrimSpace(e.Text); phase != "" {
-				t.phase = phase
-			}
+			t.phase = normalizeStatusPhase(e)
 		})
 		return "phase", true
 	case event.Usage:
@@ -295,7 +304,7 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 			case errors.As(runErr, &readinessErr):
 				t.phase = "readiness_paused"
 				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusText(readinessErr.Error(), 2_048)}
-				t.finalReadiness.Risks = append([]string(nil), readinessErr.Missing...)
+				t.finalReadiness.Risks = redactStatusTexts(readinessErr.Missing, 2_048)
 				eventName = "pause"
 			case errors.As(runErr, &recoveryPause):
 				t.phase = "recovery_paused"
@@ -382,8 +391,8 @@ func (t *statusTelemetry) persisted() *persistedStatusTelemetry {
 		TurnOutcome: t.turnOutcome,
 		FinalReadiness: ReasonixFinalReadiness{
 			ReadyForReview: t.finalReadiness.ReadyForReview,
-			Summary:        t.finalReadiness.Summary,
-			Risks:          append([]string(nil), t.finalReadiness.Risks...),
+			Summary:        clipStatusText(t.finalReadiness.Summary, 16_384),
+			Risks:          redactStatusTexts(t.finalReadiness.Risks, 2_048),
 		},
 		TurnUsage: persistUsage(t.turnUsage), Cumulative: persistUsage(t.cumulative),
 		GoalOverride: t.goalOverride,
@@ -400,18 +409,15 @@ func restoreStatusTelemetry(saved *persistedStatusTelemetry) *statusTelemetry {
 	if t.state != "running" {
 		t.state = "idle"
 	}
-	t.phase = saved.Phase
+	t.phase = normalizePersistedStatusPhase(saved.Phase)
 	t.turnOutcome = saved.TurnOutcome
 	if t.turnOutcome.Kind == "" {
 		t.turnOutcome.Kind = "none"
 	}
 	t.finalReadiness = ReasonixFinalReadiness{
 		ReadyForReview: saved.FinalReadiness.ReadyForReview,
-		Summary:        saved.FinalReadiness.Summary,
-		Risks:          append([]string(nil), saved.FinalReadiness.Risks...),
-	}
-	if t.finalReadiness.Risks == nil {
-		t.finalReadiness.Risks = []string{}
+		Summary:        clipStatusText(saved.FinalReadiness.Summary, 16_384),
+		Risks:          redactStatusTexts(saved.FinalReadiness.Risks, 2_048),
 	}
 	t.turnUsage = restoreUsage(saved.TurnUsage)
 	t.cumulative = restoreUsage(saved.Cumulative)
@@ -423,14 +429,20 @@ func (t *statusTelemetry) snapshot() statusTelemetrySnapshot {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return statusTelemetrySnapshot{
-		sequence:       t.sequence,
-		state:          t.state,
-		phase:          t.phase,
-		turnOutcome:    t.turnOutcome,
-		finalReadiness: ReasonixFinalReadiness{ReadyForReview: t.finalReadiness.ReadyForReview, Summary: t.finalReadiness.Summary, Risks: append([]string(nil), t.finalReadiness.Risks...)},
-		turnUsage:      t.turnUsage.wire(),
-		cumulative:     t.cumulative.wire(),
-		goalOverride:   t.goalOverride,
+		sequence: t.sequence,
+		state:    t.state,
+		phase:    t.phase,
+		turnOutcome: ReasonixTurnOutcome{
+			Kind: t.turnOutcome.Kind, Reason: clipStatusText(t.turnOutcome.Reason, 2_048),
+		},
+		finalReadiness: ReasonixFinalReadiness{
+			ReadyForReview: t.finalReadiness.ReadyForReview,
+			Summary:        clipStatusText(t.finalReadiness.Summary, 16_384),
+			Risks:          redactStatusTexts(t.finalReadiness.Risks, 2_048),
+		},
+		turnUsage:    t.turnUsage.wire(),
+		cumulative:   t.cumulative.wire(),
+		goalOverride: t.goalOverride,
 	}
 }
 
@@ -444,6 +456,7 @@ func defaultSessionRuntimeState(cwd string) SessionRuntimeState {
 		Sandbox: SessionSandboxState{
 			Mode:          "enforce",
 			Engine:        engine,
+			Available:     true,
 			WorkspaceRoot: cwd,
 			WriteRoots:    []string{cwd},
 		},
@@ -467,18 +480,60 @@ func normalizeGoalStatus(value string) string {
 }
 
 func clipStatusText(value string, limit int) string {
-	value = strings.TrimSpace(value)
+	value = strings.TrimSpace(secrets.Redact(value))
 	if len(value) <= limit {
 		return value
 	}
 	return value[:limit]
 }
 
-func (s *service) sessionRuntimeState(ctx context.Context, cwd string) (SessionRuntimeState, error) {
+func redactStatusTexts(values []string, limit int) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		out = append(out, clipStatusText(value, limit))
+	}
+	return out
+}
+
+func normalizeStatusPhase(e event.Event) string {
+	switch strings.TrimSpace(e.Source) {
+	case event.UsageSourcePlanner:
+		return "planning"
+	case event.UsageSourceExecutor:
+		return "implementing"
+	}
+	lower := strings.ToLower(strings.TrimSpace(e.Text))
+	switch {
+	case strings.Contains(lower, "planning"):
+		return "planning"
+	case strings.Contains(lower, "executing"), strings.Contains(lower, "implementing"):
+		return "implementing"
+	default:
+		return "working"
+	}
+}
+
+func normalizePersistedStatusPhase(value string) string {
+	value = strings.TrimSpace(value)
+	switch value {
+	case "idle", "starting", "planning", "working", "implementing",
+		"waiting_permission", "waiting_input", "checking_readiness",
+		"cancelled", "review_ready", "completed", "paused",
+		"readiness_paused", "recovery_paused", "error":
+		return value
+	default:
+		return normalizeStatusPhase(event.Event{Kind: event.Phase, Text: value})
+	}
+}
+
+func (s *service) sessionRuntimeState(ctx context.Context, p SessionRuntimeStateParams) (SessionRuntimeState, error) {
 	if provider, ok := s.factory.(SessionRuntimeStateProvider); ok {
-		state, err := provider.SessionRuntimeState(ctx, cwd)
+		state, err := provider.SessionRuntimeState(ctx, p)
 		if err != nil {
 			return SessionRuntimeState{}, err
+		}
+		if strings.EqualFold(strings.TrimSpace(p.RuntimeProfile), "economy") {
+			state.PlannerMode = "off"
 		}
 		if strings.TrimSpace(state.PlannerMode) == "" {
 			state.PlannerMode = "on"
@@ -488,7 +543,11 @@ func (s *service) sessionRuntimeState(ctx context.Context, cwd string) (SessionR
 		}
 		return state, nil
 	}
-	return defaultSessionRuntimeState(cwd), nil
+	state := defaultSessionRuntimeState(p.Cwd)
+	if strings.EqualFold(strings.TrimSpace(p.RuntimeProfile), "economy") {
+		state.PlannerMode = "off"
+	}
+	return state, nil
 }
 
 func (s *service) bindStatusEvents(sess *acpSession) {

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"reasonix/internal/agent"
@@ -16,12 +17,26 @@ type statusFactory struct {
 	*configurableFactory
 }
 
-func (f *statusFactory) SessionRuntimeState(_ context.Context, cwd string) (SessionRuntimeState, error) {
+type runtimeTrackingFactory struct {
+	*configurableFactory
+}
+
+func (f *statusFactory) SessionRuntimeState(_ context.Context, p SessionRuntimeStateParams) (SessionRuntimeState, error) {
 	return SessionRuntimeState{
 		PlannerMode: "off",
 		Sandbox: SessionSandboxState{
-			Mode: "enforce", Engine: "bubblewrap", WorkspaceRoot: cwd,
-			WriteRoots: []string{cwd}, NetworkEnabled: false,
+			Mode: "enforce", Engine: "bubblewrap", Available: true, WorkspaceRoot: p.Cwd,
+			WriteRoots: []string{p.Cwd}, NetworkEnabled: false,
+		},
+	}, nil
+}
+
+func (f *runtimeTrackingFactory) SessionRuntimeState(_ context.Context, p SessionRuntimeStateParams) (SessionRuntimeState, error) {
+	return SessionRuntimeState{
+		PlannerMode: "on",
+		Sandbox: SessionSandboxState{
+			Mode: "enforce", Engine: "bubblewrap", Available: true, WorkspaceRoot: p.Cwd,
+			WriteRoots: []string{p.Cwd},
 		},
 	}, nil
 }
@@ -55,7 +70,7 @@ func getStatus(t *testing.T, client *rpcClient, sessionID string) ReasonixSessio
 func TestStatusExtensionTracksMultipleSessionsAndUsage(t *testing.T) {
 	factory := &statusFactory{configurableFactory: &configurableFactory{
 		behavior: func(_ context.Context, sink event.Sink, input string, _ SessionParams) error {
-			sink.Emit(event.Event{Kind: event.Phase, Text: "executor · implementing"})
+			sink.Emit(event.Event{Kind: event.Phase, Source: event.UsageSourceExecutor, Text: "executor · implementing"})
 			sink.Emit(event.Event{Kind: event.Usage, Usage: &provider.Usage{
 				PromptTokens: 10, CompletionTokens: 4, ReasoningTokens: 2,
 				CacheHitTokens: 7, CacheMissTokens: 3,
@@ -122,6 +137,85 @@ func TestStatusExtensionTracksMultipleSessionsAndUsage(t *testing.T) {
 	}
 	if !sawPhase || !sawUsage || !sawCompletion {
 		t.Fatalf("status events phase=%v usage=%v completion=%v", sawPhase, sawUsage, sawCompletion)
+	}
+}
+
+func TestStatusNormalizesPhaseAndRedactsPublicText(t *testing.T) {
+	telemetry := newStatusTelemetry()
+	telemetry.beginTurn()
+	telemetry.onEvent(event.Event{Kind: event.Phase, Source: event.UsageSourcePlanner, Text: "planner · private stage label"})
+	if got := telemetry.snapshot().phase; got != "planning" {
+		t.Fatalf("planner phase = %q, want planning", got)
+	}
+	telemetry.onEvent(event.Event{Kind: event.Phase, Text: "provider-specific handoff"})
+	if got := telemetry.snapshot().phase; got != "working" {
+		t.Fatalf("unknown phase = %q, want working", got)
+	}
+	telemetry.finishTurn(&agent.FinalReadinessError{
+		Attempts: 1,
+		Reason:   "token=secret-reason",
+		Missing:  []string{"api_key=secret-risk"},
+	}, false, "running", "authorization: bearer secret-summary")
+	snapshot := telemetry.snapshot()
+	encoded, err := json.Marshal(snapshot.finalReadiness)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "secret-") || !strings.Contains(string(encoded), "[redacted]") {
+		t.Fatalf("status text was not redacted: %s", encoded)
+	}
+	if strings.Contains(snapshot.turnOutcome.Reason, "secret-") {
+		t.Fatalf("turn outcome was not redacted: %q", snapshot.turnOutcome.Reason)
+	}
+
+	empty, err := json.Marshal(newStatusTelemetry().snapshot().finalReadiness)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(empty), `"risks":[]`) {
+		t.Fatalf("empty risks must encode as [], got %s", empty)
+	}
+}
+
+func TestRestoreStatusNormalizesLegacyPresentationPhase(t *testing.T) {
+	restored := restoreStatusTelemetry(&persistedStatusTelemetry{
+		Phase:          "executor · implementing local patch",
+		FinalReadiness: ReasonixFinalReadiness{},
+	})
+	if got := restored.snapshot().phase; got != "implementing" {
+		t.Fatalf("restored phase = %q, want implementing", got)
+	}
+}
+
+func TestStatusRecomputesPlannerModeAfterWorkModeSwitch(t *testing.T) {
+	factory := &runtimeTrackingFactory{configurableFactory: &configurableFactory{}}
+	client, stop := startServer(t, factory)
+	defer stop()
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	sessionID := openStatusSession(t, client, t.TempDir())
+	if status := getStatus(t, client, sessionID); status.WorkMode != "balanced" || status.PlannerMode != "on" {
+		t.Fatalf("initial runtime status = %+v", status)
+	}
+
+	for _, tc := range []struct {
+		profile string
+		planner string
+	}{
+		{profile: "economy", planner: "off"},
+		{profile: "delivery", planner: "on"},
+	} {
+		resp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+			SessionID: sessionID,
+			ConfigID:  "work_mode",
+			Value:     tc.profile,
+		})
+		if resp.Error != nil {
+			t.Fatalf("set work mode %q: %+v", tc.profile, resp.Error)
+		}
+		status := getStatus(t, client, sessionID)
+		if status.WorkMode != tc.profile || status.PlannerMode != tc.planner {
+			t.Fatalf("runtime status after %q = %+v", tc.profile, status)
+		}
 	}
 }
 

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -187,6 +187,34 @@ func TestRestoreStatusNormalizesLegacyPresentationPhase(t *testing.T) {
 	}
 }
 
+func TestRestoreStatusMarksInterruptedTurnPaused(t *testing.T) {
+	restored := restoreStatusTelemetry(&persistedStatusTelemetry{
+		Sequence:    7,
+		State:       "running",
+		Phase:       "implementing",
+		TurnOutcome: ReasonixTurnOutcome{Kind: "none"},
+		FinalReadiness: ReasonixFinalReadiness{
+			ReadyForReview: true,
+			Risks:          []string{},
+		},
+		TurnUsage:  persistedUsageAccumulator{PromptTokens: 3, Events: 1},
+		Cumulative: persistedUsageAccumulator{PromptTokens: 11, Events: 2},
+	})
+	snapshot := restored.snapshot()
+	if snapshot.state != "idle" || snapshot.phase != "recovery_paused" {
+		t.Fatalf("restored interrupted state = state:%q phase:%q, want idle/recovery_paused", snapshot.state, snapshot.phase)
+	}
+	if snapshot.sequence != 8 || snapshot.turnOutcome.Kind != "paused" || snapshot.turnOutcome.Reason != "previous turn interrupted" {
+		t.Fatalf("restored interrupted outcome = sequence:%d outcome:%+v", snapshot.sequence, snapshot.turnOutcome)
+	}
+	if snapshot.finalReadiness.ReadyForReview {
+		t.Fatal("interrupted turn remained ready for review")
+	}
+	if snapshot.turnUsage.PromptTokens != 3 || snapshot.cumulative.PromptTokens != 11 {
+		t.Fatalf("interrupted usage was lost: turn=%+v cumulative=%+v", snapshot.turnUsage, snapshot.cumulative)
+	}
+}
+
 func TestStatusRecomputesPlannerModeAfterWorkModeSwitch(t *testing.T) {
 	factory := &runtimeTrackingFactory{configurableFactory: &configurableFactory{}}
 	client, stop := startServer(t, factory)
@@ -269,5 +297,42 @@ func TestStatusSnapshotSurvivesSessionResume(t *testing.T) {
 	after := getStatus(t, reconnected, sessionID)
 	if after.Sequence != telemetry.snapshot().sequence || after.Usage.Cumulative.PromptTokens != 8 || after.State != "idle" || after.FinalReadiness.Summary != "persisted summary" {
 		t.Fatalf("recovered status = %+v", after)
+	}
+}
+
+func TestStatusInterruptedSnapshotResumesPaused(t *testing.T) {
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	sessionID := "status-interrupted"
+	telemetry := newStatusTelemetry()
+	telemetry.beginTurn()
+	telemetry.onEvent(event.Event{Kind: event.Usage, Usage: &provider.Usage{
+		PromptTokens: 5, CompletionTokens: 1,
+	}, UsageSource: event.UsageSourceExecutor})
+	path := filepath.Join(dir, sessionID+".jsonl")
+	if err := agent.NewSession("system").Save(path); err != nil {
+		t.Fatalf("save transcript: %v", err)
+	}
+	if err := saveACPMeta(path, acpSessionMeta{
+		SessionID: sessionID, Cwd: cwd, Model: "fast", RuntimeProfile: "balanced",
+		Status: telemetry.persisted(),
+	}); err != nil {
+		t.Fatalf("save ACP metadata: %v", err)
+	}
+
+	factory := &statusFactory{configurableFactory: &configurableFactory{dir: dir}}
+	client, stop := startServer(t, factory)
+	defer stop()
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	resume := client.call(t, "session/resume", SessionResumeParams{SessionID: sessionID, Cwd: cwd})
+	if resume.Error != nil {
+		t.Fatalf("session/resume: %+v", resume.Error)
+	}
+	after := getStatus(t, client, sessionID)
+	if after.State != "idle" || after.Phase != "recovery_paused" || after.TurnOutcome.Kind != "paused" {
+		t.Fatalf("resumed interrupted status = %+v", after)
+	}
+	if after.Sequence != telemetry.snapshot().sequence+1 || after.Usage.Turn.PromptTokens != 5 || after.Usage.Cumulative.PromptTokens != 5 {
+		t.Fatalf("resumed interrupted sequence/usage = %+v", after)
 	}
 }

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -1,0 +1,179 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type statusFactory struct {
+	*configurableFactory
+}
+
+func (f *statusFactory) SessionRuntimeState(_ context.Context, cwd string) (SessionRuntimeState, error) {
+	return SessionRuntimeState{
+		PlannerMode: "off",
+		Sandbox: SessionSandboxState{
+			Mode: "enforce", Engine: "bubblewrap", WorkspaceRoot: cwd,
+			WriteRoots: []string{cwd}, NetworkEnabled: false,
+		},
+	}, nil
+}
+
+func openStatusSession(t *testing.T, client *rpcClient, cwd string) string {
+	t.Helper()
+	resp := client.call(t, "session/new", SessionNewParams{Cwd: cwd})
+	if resp.Error != nil {
+		t.Fatalf("session/new: %+v", resp.Error)
+	}
+	var opened SessionNewResult
+	if err := json.Unmarshal(resp.Result, &opened); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	return opened.SessionID
+}
+
+func getStatus(t *testing.T, client *rpcClient, sessionID string) ReasonixSessionStatus {
+	t.Helper()
+	resp := client.call(t, sessionStatusMethod, SessionStatusParams{SessionID: sessionID})
+	if resp.Error != nil {
+		t.Fatalf("session/status: %+v", resp.Error)
+	}
+	var status ReasonixSessionStatus
+	if err := json.Unmarshal(resp.Result, &status); err != nil {
+		t.Fatalf("session/status result: %v", err)
+	}
+	return status
+}
+
+func TestStatusExtensionTracksMultipleSessionsAndUsage(t *testing.T) {
+	factory := &statusFactory{configurableFactory: &configurableFactory{
+		behavior: func(_ context.Context, sink event.Sink, input string, _ SessionParams) error {
+			sink.Emit(event.Event{Kind: event.Phase, Text: "executor · implementing"})
+			sink.Emit(event.Event{Kind: event.Usage, Usage: &provider.Usage{
+				PromptTokens: 10, CompletionTokens: 4, ReasoningTokens: 2,
+				CacheHitTokens: 7, CacheMissTokens: 3,
+			}, Pricing: &provider.Pricing{CacheHit: 0.1, Input: 1, Output: 2, Currency: "USD"}, UsageSource: event.UsageSourceExecutor})
+			sink.Emit(event.Event{Kind: event.Usage, Usage: &provider.Usage{
+				PromptTokens: 5, CompletionTokens: 1, CacheMissTokens: 5,
+			}, Pricing: &provider.Pricing{CacheHit: 0.1, Input: 1, Output: 2, Currency: "USD"}, UsageSource: event.UsageSourceCompaction})
+			sink.Emit(event.Event{Kind: event.Text, Text: input})
+			return nil
+		},
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	first := openStatusSession(t, client, t.TempDir())
+	second := openStatusSession(t, client, t.TempDir())
+
+	initialSecond := getStatus(t, client, second)
+	prompt := client.callAsync("session/prompt", SessionPromptParams{SessionID: first, Prompt: []ContentBlock{{Type: "text", Text: "ship"}}})
+	notifications, response := drainPrompt(t, client, prompt)
+	if response.Error != nil {
+		t.Fatalf("session/prompt: %+v", response.Error)
+	}
+
+	firstStatus := getStatus(t, client, first)
+	if firstStatus.Sequence == 0 || firstStatus.State != "idle" || firstStatus.TurnOutcome.Kind != "completed" {
+		t.Fatalf("first status = %+v", firstStatus)
+	}
+	if firstStatus.PlannerMode != "off" || firstStatus.Sandbox.WorkspaceRoot == "" || len(firstStatus.Sandbox.WriteRoots) != 1 {
+		t.Fatalf("effective runtime status = %+v", firstStatus)
+	}
+	usage := firstStatus.Usage.Cumulative
+	if usage.PromptTokens != 15 || usage.CompletionTokens != 5 || usage.ReasoningTokens != 2 || usage.CacheHitTokens != 7 || usage.CacheMissTokens != 8 {
+		t.Fatalf("cumulative usage = %+v", usage)
+	}
+	if usage.UsageSource != "mixed" || usage.CacheHitRatio == nil || usage.EstimatedCost == nil || usage.Currency == nil || *usage.Currency != "USD" {
+		t.Fatalf("usage metadata = %+v", usage)
+	}
+	secondStatus := getStatus(t, client, second)
+	if secondStatus.Sequence != initialSecond.Sequence || secondStatus.Usage.Cumulative.PromptTokens != 0 {
+		t.Fatalf("second session telemetry leaked: before=%+v after=%+v", initialSecond, secondStatus)
+	}
+
+	var sawPhase, sawUsage, sawCompletion bool
+	for _, notification := range notifications {
+		if notification.Method != sessionStatusUpdateMethod {
+			continue
+		}
+		var update ReasonixStatusUpdate
+		if err := json.Unmarshal(notification.Params, &update); err != nil {
+			t.Fatalf("status update: %v", err)
+		}
+		if update.Sequence != update.Status.Sequence || update.SessionID != first {
+			t.Fatalf("status update correlation = %+v", update)
+		}
+		switch update.Event {
+		case "phase":
+			sawPhase = true
+		case "usage":
+			sawUsage = true
+		case "completion":
+			sawCompletion = true
+		}
+	}
+	if !sawPhase || !sawUsage || !sawCompletion {
+		t.Fatalf("status events phase=%v usage=%v completion=%v", sawPhase, sawUsage, sawCompletion)
+	}
+}
+
+func TestStatusClassifiesPauseAndError(t *testing.T) {
+	telemetry := newStatusTelemetry()
+	telemetry.beginTurn()
+	pauseEvent := telemetry.finishTurn(&agent.FinalReadinessError{Attempts: 3, Reason: "missing verification", Missing: []string{"verify"}}, false, "running", "partial")
+	paused := telemetry.snapshot()
+	if pauseEvent != "pause" || paused.turnOutcome.Kind != "paused" || len(paused.finalReadiness.Risks) != 1 {
+		t.Fatalf("pause classification = event %q snapshot %+v", pauseEvent, paused)
+	}
+
+	telemetry.beginTurn()
+	errorEvent := telemetry.finishTurn(errors.New("provider failed"), false, "running", "")
+	failed := telemetry.snapshot()
+	if errorEvent != "error" || failed.turnOutcome.Kind != "error" || failed.goalOverride != "failed" {
+		t.Fatalf("error classification = event %q snapshot %+v", errorEvent, failed)
+	}
+}
+
+func TestStatusSnapshotSurvivesSessionResume(t *testing.T) {
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	sessionID := "status-reconnect"
+	telemetry := newStatusTelemetry()
+	telemetry.beginTurn()
+	telemetry.onEvent(event.Event{Kind: event.Usage, Usage: &provider.Usage{
+		PromptTokens: 8, CompletionTokens: 2, CacheHitTokens: 6, CacheMissTokens: 2,
+	}, UsageSource: event.UsageSourceExecutor})
+	telemetry.finishTurn(nil, false, "", "persisted summary")
+	path := filepath.Join(dir, sessionID+".jsonl")
+	if err := agent.NewSession("system").Save(path); err != nil {
+		t.Fatalf("save transcript: %v", err)
+	}
+	if err := saveACPMeta(path, acpSessionMeta{
+		SessionID: sessionID, Cwd: cwd, Model: "fast", RuntimeProfile: "delivery",
+		Status: telemetry.persisted(),
+	}); err != nil {
+		t.Fatalf("save ACP metadata: %v", err)
+	}
+	factory := &statusFactory{configurableFactory: &configurableFactory{
+		dir: dir,
+	}}
+	reconnected, stopReconnected := startServer(t, factory)
+	defer stopReconnected()
+	reconnected.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	resume := reconnected.call(t, "session/resume", SessionResumeParams{SessionID: sessionID, Cwd: cwd})
+	if resume.Error != nil {
+		t.Fatalf("session/resume: %+v", resume.Error)
+	}
+	after := getStatus(t, reconnected, sessionID)
+	if after.Sequence != telemetry.snapshot().sequence || after.Usage.Cumulative.PromptTokens != 8 || after.State != "idle" || after.FinalReadiness.Summary != "persisted summary" {
+		t.Fatalf("recovered status = %+v", after)
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -161,6 +161,15 @@ type Options struct {
 	// catalog. Remote Workbench injects a Broker resolver so no credential or
 	// provider endpoint has to exist on the Host. Nil preserves local behavior.
 	ProviderResolver provider.Resolver
+	// DisablePlanner is a process-local hard override used by supervised ACP
+	// workers. It wins over user/project planner_model configuration without
+	// mutating config or changing the provider-visible prompt/tool surface.
+	DisablePlanner bool
+	// SandboxNetworkOverride and WorkspaceOnly are process-local hard bounds for
+	// supervised ACP workers. Nil/false preserve normal Reasonix config.
+	SandboxNetworkOverride *bool
+	SandboxBashOverride    string
+	WorkspaceOnly          bool
 }
 
 func recoveryHeadlessMode(opts Options) bool {
@@ -459,6 +468,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	reg := tool.NewRegistry()
 	writeRoots := cfg.WriteRootsForRoot(root)
 	writeRoots = appendUniquePaths(writeRoots, additionalDirs...)
+	if opts.WorkspaceOnly {
+		writeRoots = []string{root}
+	}
+	networkEnabled := cfg.Sandbox.Network
+	if opts.SandboxNetworkOverride != nil {
+		networkEnabled = *opts.SandboxNetworkOverride
+	}
+	bashMode := cfg.BashMode()
+	if override := strings.TrimSpace(opts.SandboxBashOverride); override != "" {
+		bashMode = override
+	}
 	forbidReadRoots := RuntimeForbidReadRoots(cfg, root)
 	// managedConfig names the Reasonix-owned config FILES (config.toml,
 	// compatibility TOMLs, legacy v0.x config.json) the file-writers may repair
@@ -466,12 +486,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// OS-sandbox write roots deliberately stay unwidened: config repair goes
 	// through the approval-gated file tools, not raw shell writes.
 	managedConfig := builtin.NewManagedConfigPaths(config.ReasonixManagedConfigPaths())
-	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Network: cfg.Sandbox.Network}
+	bashSpec := sandbox.Spec{Mode: bashMode, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Network: networkEnabled}
 	bashSpec.Shell = shell
 	// The session-data guard blocks agent writes into Reasonix's own session
 	// stores (they race the app's saves and surface as conflict-copy loops);
 	// explicit allow_write entries stay a sanctioned escape hatch.
-	sessionGuard := builtin.NewSessionDataGuard(config.MemoryUserDir(), cfg.AllowWriteRoots())
+	allowWriteRoots := cfg.AllowWriteRoots()
+	if opts.WorkspaceOnly {
+		allowWriteRoots = nil
+	}
+	sessionGuard := builtin.NewSessionDataGuard(config.MemoryUserDir(), allowWriteRoots)
 	if bashSpec.Mode == "enforce" && !sandbox.Available() {
 		fmt.Fprintln(stderr, "warning: "+sandbox.UnavailableMessage())
 	}
@@ -510,7 +534,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		StateHome:          config.ReasonixHomeDir(),
 		WriterRoots:        writeRoots,
 		ForbidReadRoots:    forbidReadRoots,
-		Network:            cfg.Sandbox.Network,
+		Network:            networkEnabled,
 		PackageOwners:      pluginPackageOwners(cfg),
 	}
 	autoStartEntries := cfg.EnabledPlugins(root, config.DefaultMCPActivationStore())
@@ -1478,7 +1502,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// use_capability surface to both Planner and Executor. Their frontends keep
 	// independent ledgers/audits while sharing the session MCP runtime.
 	dualModelPlanner := false
-	if pm := cfg.Agent.PlannerModel; pm != "" && !tokenEconomy {
+	if pm := effectivePlannerModel(cfg, opts, tokenEconomy); pm != "" {
 		if pe, ok := resolveOptionalEntry(opts, cfg, pm); ok && pe.Model != entry.Model {
 			dualModelPlanner = true
 		}
@@ -1598,7 +1622,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// Coordinator with its own session, kept separate for cache stability. The
 	// planner gets the same standing memory context and a filtered read-only
 	// research tool set, so it can inspect rules/code without side effects.
-	if pm := cfg.Agent.PlannerModel; pm != "" && !tokenEconomy {
+	if pm := effectivePlannerModel(cfg, opts, tokenEconomy); pm != "" {
 		pe, ok := resolveOptionalEntry(opts, cfg, pm)
 		if !ok {
 			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
@@ -1785,6 +1809,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ctrl.SetCapabilityProxyRouting(true)
 	}
 	return ctrl, nil
+}
+
+// effectivePlannerModel centralizes planner precedence. The explicit ACP hard
+// override is checked before user/project config and cannot be reversed by a
+// later assembly branch.
+func effectivePlannerModel(cfg *config.Config, opts Options, tokenEconomy bool) string {
+	if cfg == nil || opts.DisablePlanner || tokenEconomy {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Agent.PlannerModel)
 }
 
 func applyRuntimeAutoPricingCurrency(cfg *config.Config, currency string) {

--- a/internal/boot/planner_override_test.go
+++ b/internal/boot/planner_override_test.go
@@ -1,0 +1,21 @@
+package boot
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func TestPlannerOffHasHighestPrecedence(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Agent.PlannerModel = "configured-planner"
+	if got := effectivePlannerModel(cfg, Options{}, false); got != "configured-planner" {
+		t.Fatalf("ordinary planner model = %q", got)
+	}
+	if got := effectivePlannerModel(cfg, Options{DisablePlanner: true}, false); got != "" {
+		t.Fatalf("planner-off returned %q, want disabled", got)
+	}
+	if got := effectivePlannerModel(cfg, Options{}, true); got != "" {
+		t.Fatalf("economy returned %q, want disabled", got)
+	}
+}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -78,7 +78,7 @@ func acpCommand(args []string, version string) int {
 	factory := &acpFactory{
 		model: *model, profile: profile, plannerOff: plannerMode == "off",
 		networkOverride: networkOverride, workspaceOnly: *workspaceOnly,
-		bashOverride: bashMode,
+		bashOverride: bashMode, requireSandbox: bashMode == "enforce",
 	}
 	info := acp.AgentInfo{Name: "reasonix", Version: version}
 	if err := acp.Serve(ctx, os.Stdin, os.Stdout, factory, info); err != nil {
@@ -93,12 +93,14 @@ func acpCommand(args []string, version string) int {
 // desktop, and serve assembly while still adding the host-supplied MCP servers
 // for this session only.
 type acpFactory struct {
-	model           string
-	profile         string
-	plannerOff      bool
-	networkOverride *bool
-	bashOverride    string
-	workspaceOnly   bool
+	model            string
+	profile          string
+	plannerOff       bool
+	networkOverride  *bool
+	bashOverride     string
+	workspaceOnly    bool
+	requireSandbox   bool
+	sandboxAvailable func() bool
 }
 
 func (f *acpFactory) SessionDir() string {
@@ -141,22 +143,15 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	})
 }
 
-func (f *acpFactory) SessionRuntimeState(_ context.Context, cwd string) (acp.SessionRuntimeState, error) {
-	cfg, err := config.LoadForRoot(cwd)
+func (f *acpFactory) SessionRuntimeState(_ context.Context, p acp.SessionRuntimeStateParams) (acp.SessionRuntimeState, error) {
+	cfg, err := config.LoadForRoot(p.Cwd)
 	if err != nil {
 		return acp.SessionRuntimeState{}, err
 	}
-	engine := "bubblewrap"
-	if runtime.GOOS == "darwin" {
-		engine = "seatbelt"
-	}
-	plannerMode := "off"
-	if !f.plannerOff && strings.TrimSpace(cfg.Agent.PlannerModel) != "" {
-		plannerMode = "on"
-	}
-	writeRoots := cfg.WriteRootsForRoot(cwd)
+	plannerMode := effectiveACPPlannerMode(cfg, f.plannerOff, p.Model, p.RuntimeProfile)
+	writeRoots := cfg.WriteRootsForRoot(p.Cwd)
 	if f.workspaceOnly {
-		writeRoots = []string{cwd}
+		writeRoots = []string{p.Cwd}
 	}
 	networkEnabled := cfg.Sandbox.Network
 	if f.networkOverride != nil {
@@ -166,19 +161,65 @@ func (f *acpFactory) SessionRuntimeState(_ context.Context, cwd string) (acp.Ses
 	if f.bashOverride == "enforce" {
 		effectiveBash = "enforce"
 	}
-	if effectiveBash == "enforce" && !sandbox.Available() {
+	sandboxAvailable := true
+	if effectiveBash == "enforce" {
+		sandboxAvailable = f.isSandboxAvailable()
+	} else {
+		// Without an OS sandbox the shell is intentionally unconfined, including
+		// network access; report the actual posture rather than the inert config bit.
+		networkEnabled = true
+	}
+	if f.requireSandbox && !sandboxAvailable {
 		return acp.SessionRuntimeState{}, fmt.Errorf("effective bash sandbox unavailable: %s", sandbox.UnavailableMessage())
 	}
 	return acp.SessionRuntimeState{
 		PlannerMode: plannerMode,
 		Sandbox: acp.SessionSandboxState{
 			Mode:           effectiveBash,
-			Engine:         engine,
-			WorkspaceRoot:  cwd,
+			Engine:         acpSandboxEngine(effectiveBash),
+			Available:      sandboxAvailable,
+			WorkspaceRoot:  p.Cwd,
 			WriteRoots:     writeRoots,
 			NetworkEnabled: networkEnabled,
 		},
 	}, nil
+}
+
+func (f *acpFactory) isSandboxAvailable() bool {
+	if f.sandboxAvailable != nil {
+		return f.sandboxAvailable()
+	}
+	return sandbox.Available()
+}
+
+func effectiveACPPlannerMode(cfg *config.Config, disabled bool, model, profile string) string {
+	if cfg == nil || disabled || acpRuntimeProfile(profile) == "economy" {
+		return "off"
+	}
+	plannerRef := strings.TrimSpace(cfg.Agent.PlannerModel)
+	if plannerRef == "" {
+		return "off"
+	}
+	planner, plannerOK := cfg.ResolveModel(plannerRef)
+	executor, executorOK := cfg.ResolveModel(strings.TrimSpace(model))
+	if !plannerOK || !executorOK || planner.Model == executor.Model {
+		return "off"
+	}
+	return "on"
+}
+
+func acpSandboxEngine(mode string) string {
+	if mode != "enforce" {
+		return "none"
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return "seatbelt"
+	case "linux":
+		return "bubblewrap"
+	default:
+		return "none"
+	}
 }
 
 func (f *acpFactory) SessionConfigState(_ context.Context, p acp.SessionConfigStateParams) (acp.SessionConfigState, error) {

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -34,7 +35,35 @@ func acpCommand(args []string, version string) int {
 	fs := flag.NewFlagSet("acp", flag.ContinueOnError)
 	model := fs.String("model", "", "provider name (default: config default_model)")
 	profileFlag := fs.String("profile", "balanced", "runtime profile: economy | balanced | delivery")
+	plannerFlag := fs.String("planner", "auto", "planner policy: auto | off")
+	networkFlag := fs.String("sandbox-network", "auto", "sandbox network policy: auto | on | off")
+	bashFlag := fs.String("sandbox-bash", "auto", "bash sandbox policy: auto | enforce")
+	workspaceOnly := fs.Bool("workspace-only", false, "ignore configured extra write roots and confine writes to the session cwd")
 	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	plannerMode := strings.ToLower(strings.TrimSpace(*plannerFlag))
+	if plannerMode != "auto" && plannerMode != "off" {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "planner must be auto or off")
+		return 2
+	}
+	networkMode := strings.ToLower(strings.TrimSpace(*networkFlag))
+	var networkOverride *bool
+	switch networkMode {
+	case "auto":
+	case "on":
+		on := true
+		networkOverride = &on
+	case "off":
+		off := false
+		networkOverride = &off
+	default:
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "sandbox-network must be auto, on, or off")
+		return 2
+	}
+	bashMode := strings.ToLower(strings.TrimSpace(*bashFlag))
+	if bashMode != "auto" && bashMode != "enforce" {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "sandbox-bash must be auto or enforce")
 		return 2
 	}
 	profile, err := parseRuntimeProfile(*profileFlag)
@@ -46,7 +75,11 @@ func acpCommand(args []string, version string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	factory := &acpFactory{model: *model, profile: profile}
+	factory := &acpFactory{
+		model: *model, profile: profile, plannerOff: plannerMode == "off",
+		networkOverride: networkOverride, workspaceOnly: *workspaceOnly,
+		bashOverride: bashMode,
+	}
 	info := acp.AgentInfo{Name: "reasonix", Version: version}
 	if err := acp.Serve(ctx, os.Stdin, os.Stdout, factory, info); err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -60,8 +93,12 @@ func acpCommand(args []string, version string) int {
 // desktop, and serve assembly while still adding the host-supplied MCP servers
 // for this session only.
 type acpFactory struct {
-	model   string
-	profile string
+	model           string
+	profile         string
+	plannerOff      bool
+	networkOverride *bool
+	bashOverride    string
+	workspaceOnly   bool
 }
 
 func (f *acpFactory) SessionDir() string {
@@ -80,6 +117,10 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	if root != "" && !filepath.IsAbs(root) {
 		return nil, fmt.Errorf("session cwd must be an absolute path: %s", root)
 	}
+	bashOverride := ""
+	if f.bashOverride == "enforce" {
+		bashOverride = "enforce"
+	}
 	return boot.Build(ctx, boot.Options{
 		Model:                    firstNonEmpty(p.Model, f.model),
 		TokenMode:                firstNonEmpty(p.RuntimeProfile, f.profile),
@@ -93,7 +134,51 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		OnSessionRecovered:       p.OnSessionRecovered,
 		FileOverlay:              p.FileOverlay,
 		TerminalRunner:           p.Terminal,
+		DisablePlanner:           f.plannerOff,
+		SandboxNetworkOverride:   f.networkOverride,
+		SandboxBashOverride:      bashOverride,
+		WorkspaceOnly:            f.workspaceOnly,
 	})
+}
+
+func (f *acpFactory) SessionRuntimeState(_ context.Context, cwd string) (acp.SessionRuntimeState, error) {
+	cfg, err := config.LoadForRoot(cwd)
+	if err != nil {
+		return acp.SessionRuntimeState{}, err
+	}
+	engine := "bubblewrap"
+	if runtime.GOOS == "darwin" {
+		engine = "seatbelt"
+	}
+	plannerMode := "off"
+	if !f.plannerOff && strings.TrimSpace(cfg.Agent.PlannerModel) != "" {
+		plannerMode = "on"
+	}
+	writeRoots := cfg.WriteRootsForRoot(cwd)
+	if f.workspaceOnly {
+		writeRoots = []string{cwd}
+	}
+	networkEnabled := cfg.Sandbox.Network
+	if f.networkOverride != nil {
+		networkEnabled = *f.networkOverride
+	}
+	effectiveBash := cfg.BashMode()
+	if f.bashOverride == "enforce" {
+		effectiveBash = "enforce"
+	}
+	if effectiveBash == "enforce" && !sandbox.Available() {
+		return acp.SessionRuntimeState{}, fmt.Errorf("effective bash sandbox unavailable: %s", sandbox.UnavailableMessage())
+	}
+	return acp.SessionRuntimeState{
+		PlannerMode: plannerMode,
+		Sandbox: acp.SessionSandboxState{
+			Mode:           effectiveBash,
+			Engine:         engine,
+			WorkspaceRoot:  cwd,
+			WriteRoots:     writeRoots,
+			NetworkEnabled: networkEnabled,
+		},
+	}, nil
 }
 
 func (f *acpFactory) SessionConfigState(_ context.Context, p acp.SessionConfigStateParams) (acp.SessionConfigState, error) {

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -100,7 +100,9 @@ allow_write = ["../outside"]
 	factory := &acpFactory{
 		plannerOff: true, networkOverride: &off, bashOverride: "enforce", workspaceOnly: true,
 	}
-	state, err := factory.SessionRuntimeState(context.Background(), project)
+	state, err := factory.SessionRuntimeState(context.Background(), acp.SessionRuntimeStateParams{
+		Cwd: project, Model: "configured-planner", RuntimeProfile: "balanced",
+	})
 	if err != nil {
 		t.Fatalf("SessionRuntimeState: %v", err)
 	}
@@ -109,6 +111,47 @@ allow_write = ["../outside"]
 	}
 	if len(state.Sandbox.WriteRoots) != 1 || state.Sandbox.WriteRoots[0] != project || state.Sandbox.WorkspaceRoot != project {
 		t.Fatalf("workspace confinement = %+v", state.Sandbox)
+	}
+}
+
+func TestACPSupervisorRuntimeStateDegradesWhenSandboxIsUnavailable(t *testing.T) {
+	isolateCLIConfigHome(t)
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte("[sandbox]\nbash = \"enforce\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unavailable := func() bool { return false }
+	params := acp.SessionRuntimeStateParams{Cwd: project, RuntimeProfile: "balanced"}
+
+	state, err := (&acpFactory{sandboxAvailable: unavailable}).SessionRuntimeState(context.Background(), params)
+	if err != nil {
+		t.Fatalf("default ACP startup must report unavailable sandbox instead of failing: %v", err)
+	}
+	if state.Sandbox.Mode != "enforce" || state.Sandbox.Available {
+		t.Fatalf("degraded sandbox state = %+v", state.Sandbox)
+	}
+
+	_, err = (&acpFactory{requireSandbox: true, sandboxAvailable: unavailable}).SessionRuntimeState(context.Background(), params)
+	if err == nil || !strings.Contains(err.Error(), "sandbox unavailable") {
+		t.Fatalf("explicit enforce must fail closed, got %v", err)
+	}
+}
+
+func TestEffectiveACPPlannerModeMatchesSelectedRuntime(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.PlannerModel = "planner/planner-model"
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "executor", Kind: "openai", Model: "executor-model"},
+		{Name: "planner", Kind: "openai", Model: "planner-model"},
+	}
+	if got := effectiveACPPlannerMode(cfg, false, "executor/executor-model", "balanced"); got != "on" {
+		t.Fatalf("balanced split-model planner mode = %q, want on", got)
+	}
+	if got := effectiveACPPlannerMode(cfg, false, "executor/executor-model", "economy"); got != "off" {
+		t.Fatalf("economy planner mode = %q, want off", got)
+	}
+	if got := effectiveACPPlannerMode(cfg, false, "planner/planner-model", "balanced"); got != "off" {
+		t.Fatalf("same-model planner mode = %q, want off", got)
 	}
 }
 

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -69,6 +69,49 @@ func TestACPInitializesWithoutAPIKey(t *testing.T) {
 	}
 }
 
+func TestACPRejectsInvalidSupervisorFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"--planner=maybe"},
+		{"--sandbox-network=maybe"},
+		{"--sandbox-bash=maybe"},
+	} {
+		if rc := acpCommand(args, "test-version"); rc != 2 {
+			t.Fatalf("acpCommand(%v) rc = %d, want 2", args, rc)
+		}
+	}
+}
+
+func TestACPSupervisorRuntimeStateUsesHardOverrides(t *testing.T) {
+	isolateCLIConfigHome(t)
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
+[agent]
+planner_model = "configured-planner"
+
+[sandbox]
+network = true
+bash = "off"
+
+allow_write = ["../outside"]
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	off := false
+	factory := &acpFactory{
+		plannerOff: true, networkOverride: &off, bashOverride: "enforce", workspaceOnly: true,
+	}
+	state, err := factory.SessionRuntimeState(context.Background(), project)
+	if err != nil {
+		t.Fatalf("SessionRuntimeState: %v", err)
+	}
+	if state.PlannerMode != "off" || state.Sandbox.Mode != "enforce" || state.Sandbox.NetworkEnabled {
+		t.Fatalf("runtime overrides = %+v", state)
+	}
+	if len(state.Sandbox.WriteRoots) != 1 || state.Sandbox.WriteRoots[0] != project || state.Sandbox.WorkspaceRoot != project {
+		t.Fatalf("workspace confinement = %+v", state.Sandbox)
+	}
+}
+
 func TestACPFactoryLoadsSessionCwdProjectConfig(t *testing.T) {
 	home := isolateCLIConfigHome(t)
 	if _, err := config.SetCredential("REASONIX_TEST_KEY", "test-key"); err != nil {

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -123,7 +123,9 @@ func TestACPSupervisorRuntimeStateDegradesWhenSandboxIsUnavailable(t *testing.T)
 	unavailable := func() bool { return false }
 	params := acp.SessionRuntimeStateParams{Cwd: project, RuntimeProfile: "balanced"}
 
-	state, err := (&acpFactory{sandboxAvailable: unavailable}).SessionRuntimeState(context.Background(), params)
+	state, err := (&acpFactory{
+		bashOverride: "enforce", sandboxAvailable: unavailable,
+	}).SessionRuntimeState(context.Background(), params)
 	if err != nil {
 		t.Fatalf("default ACP startup must report unavailable sandbox instead of failing: %v", err)
 	}
@@ -131,7 +133,9 @@ func TestACPSupervisorRuntimeStateDegradesWhenSandboxIsUnavailable(t *testing.T)
 		t.Fatalf("degraded sandbox state = %+v", state.Sandbox)
 	}
 
-	_, err = (&acpFactory{requireSandbox: true, sandboxAvailable: unavailable}).SessionRuntimeState(context.Background(), params)
+	_, err = (&acpFactory{
+		bashOverride: "enforce", requireSandbox: true, sandboxAvailable: unavailable,
+	}).SessionRuntimeState(context.Background(), params)
 	if err == nil || !strings.Contains(err.Error(), "sandbox unavailable") {
 		t.Fatalf("explicit enforce must fail closed, got %v", err)
 	}

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -220,19 +220,31 @@ func (a *approvalManager) preApprovedForRequiredHuman(tool, subject string) bool
 // register allocates an approval ID, records the pending prompt, and returns the
 // reply channel the resolve path will signal.
 func (a *approvalManager) register(tool, subject, reason string) (string, chan approvalReply) {
-	return a.registerDecision(tool, subject, reason, false, false)
+	return a.registerWithInput(tool, subject, reason, nil)
+}
+
+func (a *approvalManager) registerWithInput(tool, subject, reason string, rawInput json.RawMessage) (string, chan approvalReply) {
+	return a.registerDecisionWithInput(tool, subject, reason, rawInput, false, false)
 }
 
 // registerDecision allocates an approval ID for either an ordinary tool
 // permission or a fresh user decision. Fresh decisions are not auto-drained when
 // the user switches to auto/yolo tool approval while the prompt is visible.
 func (a *approvalManager) registerDecision(tool, subject, reason string, fresh, requireHuman bool) (string, chan approvalReply) {
-	return a.registerDecisionKind(tool, subject, reason, fresh, requireHuman, "", nil)
+	return a.registerDecisionWithInput(tool, subject, reason, nil, fresh, requireHuman)
+}
+
+func (a *approvalManager) registerDecisionWithInput(tool, subject, reason string, rawInput json.RawMessage, fresh, requireHuman bool) (string, chan approvalReply) {
+	return a.registerDecisionKindWithInput(tool, subject, reason, rawInput, fresh, requireHuman, "", nil)
 }
 
 // registerDecisionKind is registerDecision with optional Kind/Recovery payload
 // so Auto Guard cards survive ReplayPendingPrompts.
 func (a *approvalManager) registerDecisionKind(tool, subject, reason string, fresh, requireHuman bool, kind string, rec *event.RecoveryApproval) (string, chan approvalReply) {
+	return a.registerDecisionKindWithInput(tool, subject, reason, nil, fresh, requireHuman, kind, rec)
+}
+
+func (a *approvalManager) registerDecisionKindWithInput(tool, subject, reason string, rawInput json.RawMessage, fresh, requireHuman bool, kind string, rec *event.RecoveryApproval) (string, chan approvalReply) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.nextID++
@@ -243,7 +255,7 @@ func (a *approvalManager) registerDecisionKind(tool, subject, reason string, fre
 		autoDrain = a.autoApprovalWouldAllowLocked(tool, subject)
 	}
 	a.approvals[id] = pendingApproval{
-		tool: tool, subject: subject, reason: reason, fresh: fresh, requireHuman: requireHuman,
+		tool: tool, subject: subject, reason: reason, rawInput: append(json.RawMessage(nil), rawInput...), fresh: fresh, requireHuman: requireHuman,
 		autoDrain: autoDrain, kind: kind, recovery: rec, reply: reply,
 	}
 	return id, reply
@@ -431,7 +443,7 @@ func (a *approvalManager) snapshotPrompts() ([]event.Approval, []event.Ask) {
 	approvals := make([]event.Approval, 0, len(a.approvals))
 	for id, p := range a.approvals {
 		approvals = append(approvals, event.Approval{
-			ID: id, Tool: p.tool, Subject: p.subject, Reason: p.reason, Fresh: p.fresh,
+			ID: id, Tool: p.tool, Subject: p.subject, Reason: p.reason, RawInput: append(json.RawMessage(nil), p.rawInput...), Fresh: p.fresh,
 			Kind: p.kind, Recovery: p.recovery,
 		})
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -260,6 +260,7 @@ type pendingApproval struct {
 	tool         string
 	subject      string
 	reason       string
+	rawInput     json.RawMessage
 	fresh        bool
 	requireHuman bool
 	autoDrain    bool
@@ -5996,12 +5997,12 @@ func (c *Controller) requestApprovalDecisionWithOptions(ctx context.Context, too
 	var id string
 	var reply chan approvalReply
 	if opts.fresh || opts.requireHuman {
-		id, reply = c.approval.registerDecision(tool, subject, reason, opts.fresh, opts.requireHuman)
+		id, reply = c.approval.registerDecisionWithInput(tool, subject, reason, args, opts.fresh, opts.requireHuman)
 	} else {
-		id, reply = c.approval.register(tool, subject, reason)
+		id, reply = c.approval.registerWithInput(tool, subject, reason, args)
 	}
 
-	c.sink.Emit(c.approvalRequestEvent(event.Approval{ID: id, Tool: tool, Subject: subject, Reason: reason, Fresh: opts.fresh}))
+	c.sink.Emit(c.approvalRequestEvent(event.Approval{ID: id, Tool: tool, Subject: subject, Reason: reason, RawInput: append(json.RawMessage(nil), args...), Fresh: opts.fresh}))
 	// The agent now needs the user's attention; a Notification hook can ping an
 	// external channel (desktop notice, phone) while the run blocks on the reply.
 	go c.hooks.Notification(ctx, approvalNotificationText(tool, subject), "permission_prompt")

--- a/internal/control/replay_pending_test.go
+++ b/internal/control/replay_pending_test.go
@@ -2,6 +2,8 @@ package control
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"reasonix/internal/event"
@@ -22,7 +24,7 @@ func TestReplayPendingPromptsReEmitsBlockedApproval(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_, _, _ = gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", nil)
+		_, _, _ = gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", json.RawMessage(`{"command":"go test ./..."}`))
 	}()
 
 	first := <-reqs
@@ -33,7 +35,7 @@ func TestReplayPendingPromptsReEmitsBlockedApproval(t *testing.T) {
 	c.ReplayPendingPrompts()
 
 	replayed := <-reqs
-	if replayed != first {
+	if !reflect.DeepEqual(replayed, first) {
 		t.Fatalf("replayed = %+v, want identical re-emit of %+v", replayed, first)
 	}
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -12,6 +12,8 @@
 package event
 
 import (
+	"encoding/json"
+
 	"reasonix/internal/evidence"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
@@ -173,7 +175,10 @@ type Approval struct {
 	Tool    string
 	Subject string
 	Reason  string // optional annotation explaining why approval is needed
-	Fresh   bool   // current human decision required; do not offer remembered grants
+	// RawInput is the exact structured tool input. ACP permission clients use it
+	// together with locations/reason instead of parsing a human title.
+	RawInput json.RawMessage
+	Fresh    bool // current human decision required; do not offer remembered grants
 	// Kind classifies the approval surface: "tool" (default), "plan", or
 	// "recovery". Empty means ordinary tool permission for backward compat.
 	Kind string


### PR DESCRIPTION
## Summary

- add explicit ACP runtime overrides such as `reasonix acp --planner=off`, with command-line overrides taking precedence over user and project configuration
- advertise `_reasonix.io/session/status` and `_reasonix.io/session/status_update` with `schemaVersion: 1`, monotonic sequences, normalized phase/outcome/final-readiness data, and per-turn plus cumulative usage/cache/cost data
- populate ACP permission requests with standard `rawInput` and `locations`; Reasonix-specific reason and static argv context stay under `_meta["reasonix.io"]`
- derive sandbox availability and degradation truthfully for each session while preserving default startup behavior
- recover a persisted `running` snapshot as `idle / recovery_paused`, advance its sequence, mark the interrupted turn paused, and preserve partial usage so supervisors cannot wait on work that no longer exists
- cover multi-session isolation, sequence deduplication, usage aggregation, pause/error classification, reconnect recovery, planner precedence, sandbox posture, and permission payloads

Status payloads exclude reasoning and tool output. Diagnostic and summary text is normalized and credential-like material is redacted before publication. Existing `_reasonix.io/session/steer` behavior is preserved.

## Issues

Refs #3540

Refs #5094

Refs #5667

Refs #4732

## Compatibility audit

| Surface | Old or interrupted state | Behavior after this PR | Compatibility |
| --- | --- | --- | --- |
| Persisted ACP metadata | No `status` sidecar field | Starts with a fresh idle snapshot | Backward compatible |
| Interrupted process | Persisted `state: running` | Restores `idle / recovery_paused`, advances the sequence, and preserves partial usage | Intentional crash-recovery correction |
| ACP capabilities | Client does not know Reasonix status methods | Client can ignore additive vendor capability metadata and methods | ACP v1 compatible |
| Permission requests | Standard ACP fields only | Standard fields remain at the root; Reasonix additions live under `_meta["reasonix.io"]` | ACP v1 compatible |
| Internal events | Existing Desktop/Remote projections | Additive `RawInput` context does not change existing eventwire projections | Backward compatible |
| Sandbox posture | No `available` status field | Adds truthful availability/degradation data to the new Reasonix status schema | Additive, unreleased vendor schema |

## Related work

- #7074 is merged into `main-v2`; this PR has been tested on the current combined tree
- #6649 also evolves usage contracts and should rebase after this PR before resolving overlapping status usage fields
- #6930 evolves sandbox capabilities and should recheck the availability/degradation mapping after rebase
- #6831 renames planner configuration and should rebase the explicit `--planner=off` precedence tests
- #6884 has no conflicting session replay behavior in the current combined-tree audit

## Verification

- `git diff --check`
- `go test ./internal/acp ./internal/cli ./internal/control ./internal/boot`
- `go test -race ./internal/acp ./internal/cli ./internal/control ./internal/boot`
- `GOOS=windows CGO_ENABLED=0 go test -c ./internal/cli`
- `./scripts/cache-guard.sh`
- `go test ./...`
- `cd desktop && go test ./...`
- repeated the focused, race, cache-guard, root, and Desktop suites on a synthetic merge commit built from the current `main-v2` and PR head

## Cache impact

Cache-impact: none for default provider-visible prompts, tool schemas, tool prefixes, or request serialization. The explicit planner override changes runtime model selection only when requested.

Cache-guard: `./scripts/cache-guard.sh` passed all eight scenarios with tail averages of 92-95 (threshold 90).

System-prompt-review: the patch changes runtime posture, telemetry, and permission metadata; it does not change prompt construction, memory prefixes, output styles, skill indexing, or provider request serialization.
