### PR TITLE
feat: add hardened Responses API support / 新增并加固 Responses API 支持

### DIFF
--- a/cmd/reasonix-guard/assist.go
+++ b/cmd/reasonix-guard/assist.go
@@ -15,6 +15,7 @@ import (
 	"reasonix/internal/provider"
 	_ "reasonix/internal/provider/anthropic"
 	_ "reasonix/internal/provider/openai"
+	_ "reasonix/internal/provider/responses"
 	"reasonix/internal/repair"
 )
 

--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -12,6 +12,7 @@ import (
 	// Blank imports wire compile-time built-ins into their registries.
 	_ "reasonix/internal/provider/anthropic"
 	_ "reasonix/internal/provider/openai"
+	_ "reasonix/internal/provider/responses"
 	_ "reasonix/internal/tool/builtin"
 )
 

--- a/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
+++ b/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
@@ -27,6 +27,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
 const bridgeSource = readFileSync(resolve(here, "../lib/bridge.ts"), "utf8");
 const settingsSource = readFileSync(resolve(here, "../components/SettingsPanel.tsx"), "utf8");
+const enLocaleSource = readFileSync(resolve(here, "../locales/en.ts"), "utf8");
+const zhLocaleSource = readFileSync(resolve(here, "../locales/zh.ts"), "utf8");
+const zhTWLocaleSource = readFileSync(resolve(here, "../locales/zh-TW.ts"), "utf8");
 
 console.log("\nstartup settings contract");
 
@@ -53,6 +56,20 @@ ok(
 ok(
   /initialFocus\?\.target === "model-access" \? "access" : "usage"/.test(settingsSource),
   "model settings honor the onboarding access target while preserving usage as the default",
+);
+ok(
+  /case "deepseek-responses":\s*return t\("settings\.addProvider\.preset\.deepseekResponsesDesc"\)/.test(settingsSource),
+  "DeepSeek Responses preset uses a localized description",
+);
+ok(
+  [enLocaleSource, zhLocaleSource, zhTWLocaleSource].every((source) =>
+    source.includes('"settings.addProvider.preset.deepseekResponsesDesc"'),
+  ),
+  "DeepSeek Responses description is present in every supported locale",
+);
+ok(
+  /function mockProviderPresetDisplayRank\(id: string\): number \{\s*if \(id === "deepseek-responses"\) return -1;/.test(bridgeSource),
+  "browser mock ranks DeepSeek Responses first among presets so it is second after DeepSeek Official",
 );
 
 const values = new Map<string, string>();

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -4828,6 +4828,8 @@ function providerTemplateConflictProviderName(choice: ProviderTemplateChoice): s
 
 function providerPresetDescription(preset: ProviderPresetView, t: ReturnType<typeof useT>): string {
   switch (preset.id) {
+    case "deepseek-responses":
+      return t("settings.addProvider.preset.deepseekResponsesDesc");
     case "longcat-openai":
       return t("settings.addProvider.preset.longcatOpenAIDesc");
     case "longcat-anthropic":

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1093,6 +1093,7 @@ const mockVercelModels = ["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-
 const mockOllamaCloudModels = ["glm-5.2", "kimi-k2.7-code", "deepseek-v4-pro", "deepseek-v4-flash", "minimax-m3", "nemotron-3-nano:30b", "qwen3-coder-next"];
 
 const mockProviderPresetTemplates: MockProviderPresetTemplate[] = [
+  mockPreset("deepseek-responses", "DeepSeek Responses API", "DeepSeek official stateless Responses API for deepseek-v4-flash.", "DEEPSEEK_API_KEY", mockProviderTemplate({ name: "deepseek-responses", kind: "responses", baseUrl: "https://api.deepseek.com", models: ["deepseek-v4-flash"], default: "deepseek-v4-flash", apiKeyEnv: "DEEPSEEK_API_KEY", balanceUrl: "https://api.deepseek.com/user/balance", contextWindow: 1000000, supportedEfforts: ["low", "high", "max"], defaultEffort: "high" })),
   mockPreset("longcat-openai", "LongCat OpenAI", "LongCat Platform OpenAI-compatible endpoint for LongCat-2.0.", "LONGCAT_API_KEY", mockProviderTemplate({ name: "longcat-openai", kind: "openai", baseUrl: "https://api.longcat.chat/openai/v1", modelsUrl: "https://api.longcat.chat/openai/v1/models", models: mockLongCatModels, default: "LongCat-2.0", apiKeyEnv: "LONGCAT_API_KEY", contextWindow: 131072, thinking: "enabled", supportedEfforts: ["enabled", "disabled"], defaultEffort: "enabled" })),
   mockPreset("longcat-anthropic", "LongCat Anthropic", "LongCat Platform Anthropic-compatible Messages endpoint for LongCat-2.0.", "LONGCAT_API_KEY", mockProviderTemplate({ name: "longcat-anthropic", kind: "anthropic", baseUrl: "https://api.longcat.chat/anthropic", modelsUrl: "https://api.longcat.chat/anthropic/v1/models", models: mockLongCatModels, default: "LongCat-2.0", apiKeyEnv: "LONGCAT_API_KEY", authHeader: true, contextWindow: 131072, thinking: "enabled", supportedEfforts: ["enabled", "disabled"], defaultEffort: "enabled" })),
   mockPreset("kimi-cn", "Kimi CN API", "Moonshot Kimi China OpenAI-compatible API.", "KIMI_API_KEY", mockProviderTemplate({ name: "kimi-cn", kind: "openai", baseUrl: "https://api.moonshot.cn/v1", models: mockKimiAPIModels, visionModels: mockKimiAPIModels, default: "kimi-k2.7-code", apiKeyEnv: "KIMI_API_KEY", balanceUrl: "https://api.moonshot.cn/v1/users/me/balance", contextWindow: 262144, reasoningProtocol: "none", modelOverrides: [{ model: "kimi-k3", reasoningProtocol: "openai", supportedEfforts: ["low", "high", "max"], defaultEffort: "max", contextWindow: 1048576 }] })),
@@ -1154,6 +1155,7 @@ function mockProviderPresetViews(): ProviderPresetView[] {
 }
 
 function mockProviderPresetDisplayRank(id: string): number {
+  if (id === "deepseek-responses") return -1;
   if (id === "glm-cn" || id === "zai-global" || id.startsWith("glm-coding-plan-") || id.startsWith("zai-coding-plan-")) return 0;
   if (id.startsWith("longcat-")) return 1;
   if (id.startsWith("kimi-")) return 2;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2373,6 +2373,7 @@ export const en = {
   "settings.addProvider.customHint": "Use this for proxies, aggregators, or other OpenAI-compatible services.",
   "settings.addProvider.official.deepseek": "DeepSeek Official",
   "settings.addProvider.official.deepseekDesc": "Official API key access with DeepSeek V4 Flash / Pro.",
+  "settings.addProvider.preset.deepseekResponsesDesc": "DeepSeek official stateless Responses API for deepseek-v4-flash.",
   "settings.addProvider.preset.longcatOpenAIDesc": "LongCat Platform OpenAI-compatible endpoint with LongCat-2.0 default.",
   "settings.addProvider.preset.longcatAnthropicDesc": "LongCat Platform Anthropic-compatible Messages endpoint using Bearer auth.",
   "settings.addProvider.preset.kimiCnDesc": "Kimi China API via Moonshot CN endpoint with K2 vision models.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1589,6 +1589,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.customHint": "適合代理、聚合平台或其它 OpenAI-compatible 服務。",
   "settings.addProvider.official.deepseek": "DeepSeek 官方",
   "settings.addProvider.official.deepseekDesc": "官方 API Key 接入，可用 DeepSeek V4 Flash / Pro。",
+  "settings.addProvider.preset.deepseekResponsesDesc": "DeepSeek 官方無狀態 Responses API，適用於 deepseek-v4-flash。",
   "settings.addProvider.preset.longcatOpenAIDesc": "LongCat 開放平台 OpenAI-compatible 端點，預設 LongCat-2.0。",
   "settings.addProvider.preset.longcatAnthropicDesc": "LongCat 開放平台 Anthropic-compatible Messages 端點，使用 Bearer 認證。",
   "settings.addProvider.preset.kimiCnDesc": "Kimi 中國 API，走 Moonshot CN 端點，預置 K2 視覺模型。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2376,6 +2376,7 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.customHint": "适合代理、聚合平台或其它 OpenAI-compatible 服务。",
   "settings.addProvider.official.deepseek": "DeepSeek 官方",
   "settings.addProvider.official.deepseekDesc": "官方 API Key 接入，可用 DeepSeek V4 Flash / Pro。",
+  "settings.addProvider.preset.deepseekResponsesDesc": "DeepSeek 官方无状态 Responses API，适用于 deepseek-v4-flash。",
   "settings.addProvider.preset.longcatOpenAIDesc": "LongCat 开放平台 OpenAI-compatible 端点，默认 LongCat-2.0。",
   "settings.addProvider.preset.longcatAnthropicDesc": "LongCat 开放平台 Anthropic-compatible Messages 端点，使用 Bearer 认证。",
   "settings.addProvider.preset.kimiCnDesc": "Kimi 国内 API，走 Moonshot CN 端点，预置 K2 视觉模型。",

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -26,6 +26,7 @@ import (
 	"reasonix/internal/config"
 	_ "reasonix/internal/provider/anthropic"
 	_ "reasonix/internal/provider/openai"
+	_ "reasonix/internal/provider/responses"
 	"reasonix/internal/repair"
 	_ "reasonix/internal/tool/builtin"
 )

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2223,6 +2223,10 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"vision":                config.EffectiveVision(e),
 			"vision_model_explicit": config.ExplicitModelVision(e),
 			"vision_detail":         e.VisionDetail,
+			"mode":                  e.ResponsesMode,
+			// Keep nil as nil so the responses provider can vendor-detect its
+			// default instead of accidentally treating every endpoint as stateful.
+			"stateful": e.ResponsesStateful,
 		},
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1214,26 +1214,33 @@ type AgentConfig struct {
 // token budget; the harness compacts older history as a turn's prompt approaches
 // it (see agent compaction). 0 disables compaction for the instance.
 type ProviderEntry struct {
-	Name           string            `toml:"name"`
-	Kind           string            `toml:"kind"`
-	BaseURL        string            `toml:"base_url"`
-	ChatURL        string            `toml:"chat_url"`
-	Model          string            `toml:"model"`      // a single model (back-compat)
-	Models         []string          `toml:"models"`     // a vendor's model list (one base_url/key, many models)
-	ModelsURL      string            `toml:"models_url"` // auto-fetch models from this URL on startup
-	Default        string            `toml:"default"`    // default model when Models is set (else Models[0])
-	APIKeyEnv      string            `toml:"api_key_env"`
-	PresetID       string            `toml:"preset_id"`      // curated preset identity; UI-only metadata, not sent to model providers.
-	PresetVersion  int               `toml:"preset_version"` // curated preset schema version for future migrations.
-	Headers        map[string]string `toml:"headers"`        // optional extra HTTP headers for compatible gateways; secrets should stay in api_key_env.
-	ExtraBody      map[string]any    `toml:"extra_body"`     // optional extra top-level JSON request body fields for OpenAI-compatible gateways.
-	AuthHeader     bool              `toml:"auth_header"`    // for Anthropic-compatible gateways that expect Authorization: Bearer instead of x-api-key.
-	resolvedAPIKey string
-	resolvedSource CredentialSource
-	BalanceURL     string                       `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
-	ContextWindow  int                          `toml:"context_window"`
-	Price          *provider.Pricing            `toml:"price"`  // legacy/provider-wide fallback
-	Prices         map[string]*provider.Pricing `toml:"prices"` // optional per-model prices; keys are model ids
+	Name          string            `toml:"name"`
+	Kind          string            `toml:"kind"`
+	BaseURL       string            `toml:"base_url"`
+	ChatURL       string            `toml:"chat_url"`
+	Model         string            `toml:"model"`      // a single model (back-compat)
+	Models        []string          `toml:"models"`     // a vendor's model list (one base_url/key, many models)
+	ModelsURL     string            `toml:"models_url"` // auto-fetch models from this URL on startup
+	Default       string            `toml:"default"`    // default model when Models is set (else Models[0])
+	APIKeyEnv     string            `toml:"api_key_env"`
+	PresetID      string            `toml:"preset_id"`      // curated preset identity; UI-only metadata, not sent to model providers.
+	PresetVersion int               `toml:"preset_version"` // curated preset schema version for future migrations.
+	Headers       map[string]string `toml:"headers"`        // optional extra HTTP headers for compatible gateways; secrets should stay in api_key_env.
+	ExtraBody     map[string]any    `toml:"extra_body"`     // optional extra top-level JSON request body fields for OpenAI-compatible gateways.
+	AuthHeader    bool              `toml:"auth_header"`    // for Anthropic-compatible gateways that expect Authorization: Bearer instead of x-api-key.
+	// ResponsesMode selects the Responses API context strategy. Empty preserves
+	// vendor detection; DeepSeek is stateless while compatible endpoints may use
+	// stateful previous_response_id continuation.
+	ResponsesMode string `toml:"responses_mode"`
+	// ResponsesStateful is the legacy boolean form retained for config
+	// compatibility. ResponsesMode wins when both are present.
+	ResponsesStateful *bool `toml:"responses_stateful"`
+	resolvedAPIKey    string
+	resolvedSource    CredentialSource
+	BalanceURL        string                       `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
+	ContextWindow     int                          `toml:"context_window"`
+	Price             *provider.Pricing            `toml:"price"`  // legacy/provider-wide fallback
+	Prices            map[string]*provider.Pricing `toml:"prices"` // optional per-model prices; keys are model ids
 
 	persistedOfficialCurrency string
 

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -76,6 +76,7 @@ var (
 
 	minimaxMSeriesModels       = []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"}
 	minimaxMSeriesVisionModels = []string{"MiniMax-M3"}
+	deepSeekResponsesModels    = []string{"deepseek-v4-flash"}
 
 	glmAPIModels       = []string{"glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"}
 	glmAPIVisionModels = []string{"glm-5v-turbo"}
@@ -436,6 +437,27 @@ var curatedProviderPresets = []ProviderPreset{
 			APIKeyEnv:     "MINIMAX_API_KEY",
 			AuthHeader:    true,
 			ContextWindow: 1048576,
+		}},
+	},
+	{
+		ID:          "deepseek-responses",
+		Label:       "DeepSeek Responses API",
+		Description: "DeepSeek official stateless Responses API for deepseek-v4-flash.",
+		KeyEnv:      "DEEPSEEK_API_KEY",
+		Entries: []ProviderEntry{{
+			Name:             "deepseek-responses",
+			Kind:             "responses",
+			BaseURL:          "https://api.deepseek.com",
+			ModelsURL:        "https://api.deepseek.com/models",
+			Models:           deepSeekResponsesModels,
+			Default:          "deepseek-v4-flash",
+			APIKeyEnv:        "DEEPSEEK_API_KEY",
+			BalanceURL:       "https://api.deepseek.com/user/balance",
+			ContextWindow:    1_000_000,
+			Price:            deepSeekV4FlashPriceUSD(),
+			ResponsesMode:    "stateless",
+			SupportedEfforts: []string{"low", "high", "max"},
+			DefaultEffort:    "high",
 		}},
 	},
 	{

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -50,6 +50,8 @@ func CuratedProviderPreset(id string) (ProviderPreset, bool) {
 
 func providerPresetDisplayRank(id string) int {
 	switch {
+	case id == "deepseek-responses":
+		return -1
 	case id == "glm-cn" || id == "zai-global" || strings.HasPrefix(id, "glm-coding-plan-") || strings.HasPrefix(id, "zai-coding-plan-"):
 		return 0
 	case strings.HasPrefix(id, "longcat-"):

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -448,7 +448,6 @@ var curatedProviderPresets = []ProviderPreset{
 			Name:             "deepseek-responses",
 			Kind:             "responses",
 			BaseURL:          "https://api.deepseek.com",
-			ModelsURL:        "https://api.deepseek.com/models",
 			Models:           deepSeekResponsesModels,
 			Default:          "deepseek-v4-flash",
 			APIKeyEnv:        "DEEPSEEK_API_KEY",

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -21,6 +21,7 @@ func TestCuratedProviderPresetsCoverRequestedProviders(t *testing.T) {
 		"minimax-global-api",
 		"minimax-cn-anthropic",
 		"minimax-global-anthropic",
+		"deepseek-responses",
 		"glm-cn",
 		"zai-global",
 		"glm-coding-plan-cn",
@@ -72,6 +73,20 @@ func TestCuratedProviderPresetsCoverRequestedProviders(t *testing.T) {
 		if _, ok := got[id]; !ok {
 			t.Fatalf("missing preset %q", id)
 		}
+	}
+}
+
+func TestDeepSeekResponsesPresetMatchesOfficialSupport(t *testing.T) {
+	preset, ok := CuratedProviderPreset("deepseek-responses")
+	if !ok || len(preset.Entries) != 1 {
+		t.Fatalf("deepseek responses preset = %+v, found=%v", preset, ok)
+	}
+	entry := preset.Entries[0]
+	if entry.Kind != "responses" || entry.BaseURL != "https://api.deepseek.com" || entry.ResponsesMode != "stateless" {
+		t.Fatalf("deepseek responses endpoint = %+v", entry)
+	}
+	if len(entry.Models) != 1 || entry.Models[0] != "deepseek-v4-flash" || entry.Default != "deepseek-v4-flash" {
+		t.Fatalf("deepseek responses models = %v default=%q", entry.Models, entry.Default)
 	}
 }
 

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -95,6 +95,7 @@ func TestDeepSeekResponsesPresetMatchesOfficialSupport(t *testing.T) {
 
 func TestCuratedProviderPresetsDisplayOrder(t *testing.T) {
 	wantPrefix := []string{
+		"deepseek-responses",
 		"glm-cn",
 		"zai-global",
 		"glm-coding-plan-cn",

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -88,6 +88,9 @@ func TestDeepSeekResponsesPresetMatchesOfficialSupport(t *testing.T) {
 	if len(entry.Models) != 1 || entry.Models[0] != "deepseek-v4-flash" || entry.Default != "deepseek-v4-flash" {
 		t.Fatalf("deepseek responses models = %v default=%q", entry.Models, entry.Default)
 	}
+	if entry.ModelsURL != "" {
+		t.Fatalf("deepseek responses models URL = %q, want static supported-model list", entry.ModelsURL)
+	}
 }
 
 func TestCuratedProviderPresetsDisplayOrder(t *testing.T) {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -334,6 +334,12 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			if p.AuthHeader {
 				b.WriteString("auth_header = true   # Anthropic-compatible: send Authorization: Bearer <api_key> instead of x-api-key\n")
 			}
+			if p.ResponsesMode != "" {
+				fmt.Fprintf(&b, "responses_mode = %q   # responses provider: stateless|stateful\n", p.ResponsesMode)
+			}
+			if p.ResponsesStateful != nil {
+				fmt.Fprintf(&b, "responses_stateful = %t   # legacy responses mode switch\n", *p.ResponsesStateful)
+			}
 			if p.BalanceURL != "" {
 				fmt.Fprintf(&b, "balance_url = %q   # optional; wallet-balance endpoint shown in the status bar\n", p.BalanceURL)
 			}
@@ -1004,6 +1010,12 @@ func RenderTOMLProjectDelta(c *Config) string {
 			}
 			if p.AuthHeader {
 				b.WriteString("auth_header = true\n")
+			}
+			if p.ResponsesMode != "" {
+				fmt.Fprintf(&b, "responses_mode = %q\n", p.ResponsesMode)
+			}
+			if p.ResponsesStateful != nil {
+				fmt.Fprintf(&b, "responses_stateful = %t\n", *p.ResponsesStateful)
 			}
 			if p.BalanceURL != "" {
 				fmt.Fprintf(&b, "balance_url = %q\n", p.BalanceURL)

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -886,6 +886,30 @@ func TestProjectDeltaRendersToolsShellOverrides(t *testing.T) {
 	}
 }
 
+func TestResponsesProviderModeRoundTripsInUserAndProjectRender(t *testing.T) {
+	legacyFalse := false
+	cfg := Default()
+	cfg.Providers = append(cfg.Providers, ProviderEntry{
+		Name: "responses-test", Kind: "responses", BaseURL: "https://example.com/v1",
+		Model: "model", APIKeyEnv: "RESPONSES_API_KEY",
+		ResponsesMode: "stateful", ResponsesStateful: &legacyFalse,
+	})
+
+	for _, rendered := range []string{RenderTOMLForScope(cfg, RenderScopeUser), RenderTOMLProjectDelta(cfg)} {
+		if !strings.Contains(rendered, `responses_mode = "stateful"`) || !strings.Contains(rendered, "responses_stateful = false") {
+			t.Fatalf("responses settings missing from render:\n%s", rendered)
+		}
+		var decoded Config
+		if _, err := toml.Decode(rendered, &decoded); err != nil {
+			t.Fatalf("decode responses config: %v\n%s", err, rendered)
+		}
+		entry, ok := decoded.Provider("responses-test")
+		if !ok || entry.ResponsesMode != "stateful" || entry.ResponsesStateful == nil || *entry.ResponsesStateful {
+			t.Fatalf("responses settings did not round-trip: %+v, found=%v", entry, ok)
+		}
+	}
+}
+
 func TestProjectDeltaRendersUICursorShape(t *testing.T) {
 	c := Default()
 	c.UI.CursorShape = "block"

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -236,6 +236,10 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 		}
 		body["tools"] = tools
 	}
+	instructions, rest := splitInstructions(messages)
+	if instructions != "" {
+		body["instructions"] = instructions
+	}
 
 	c.mu.Lock()
 	previousID, expectedDigest := c.lastResponseID, c.expectedPrefixDigest
@@ -248,10 +252,6 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 		return body, true, messages
 	}
 
-	instructions, rest := splitInstructions(messages)
-	if instructions != "" {
-		body["instructions"] = instructions
-	}
 	body["input"] = messagesToInput(rest)
 	return body, false, messages
 }

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -1,0 +1,649 @@
+// Package responses implements the OpenAI Responses API wire protocol.
+// DeepSeek uses it statelessly and requires the complete input history on every
+// request; compatible stateful endpoints may opt into previous_response_id.
+package responses
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"reasonix/internal/netclient"
+	"reasonix/internal/provider"
+)
+
+const defaultStreamIdleTimeout = 120 * time.Second
+
+func init() {
+	provider.Register("responses", newFromConfig)
+	provider.Register("dashscope-responses", newFromConfig)
+}
+
+func newFromConfig(cfg provider.Config) (provider.Provider, error) {
+	effort, _ := cfg.Extra["effort"].(string)
+	mode, _ := cfg.Extra["mode"].(string)
+	var stateful *bool
+	switch value := cfg.Extra["stateful"].(type) {
+	case bool:
+		stateful = &value
+	case *bool:
+		stateful = value
+	}
+	proxy, _ := cfg.Extra["proxy_spec"].(netclient.ProxySpec)
+	keyEnv, _ := cfg.Extra["api_key_env"].(string)
+	keySource, _ := cfg.Extra["api_key_source"].(string)
+	return New(Config{
+		Name: cfg.Name, APIKey: cfg.APIKey, BaseURL: cfg.BaseURL, Model: cfg.Model,
+		Effort: effort, Mode: mode, Stateful: stateful, Proxy: proxy,
+		KeyEnv: keyEnv, KeySource: keySource,
+	}), nil
+}
+
+// Config holds Responses API provider settings.
+type Config struct {
+	Name      string
+	APIKey    string
+	BaseURL   string
+	Model     string
+	Effort    string
+	Mode      string // stateful | stateless; empty uses vendor detection.
+	Stateful  *bool  // legacy form of Mode; nil preserves vendor detection.
+	Proxy     netclient.ProxySpec
+	KeyEnv    string
+	KeySource string
+	// SessionCache controls DashScope's opt-in header. The header is never sent
+	// to non-DashScope endpoints even when this value is true.
+	SessionCache *bool
+}
+
+func (c Config) mode() string {
+	mode := strings.ToLower(strings.TrimSpace(c.Mode))
+	if mode == "stateful" || mode == "stateless" {
+		return mode
+	}
+	if c.Stateful != nil {
+		if *c.Stateful {
+			return "stateful"
+		}
+		return "stateless"
+	}
+	if DetectVendor(c.BaseURL) == "deepseek" {
+		return "stateless"
+	}
+	return "stateful"
+}
+
+// DetectVendor identifies endpoint behavior that affects the Responses wire.
+func DetectVendor(baseURL string) string {
+	u := strings.ToLower(strings.TrimSpace(baseURL))
+	switch {
+	case strings.Contains(u, "dashscope.aliyuncs.com"), strings.Contains(u, ".maas.aliyuncs.com"):
+		return "dashscope"
+	case strings.Contains(u, "api.deepseek.com"):
+		return "deepseek"
+	default:
+		return ""
+	}
+}
+
+type client struct {
+	name, apiKey, keyEnv, keySource string
+	baseURL, model, effort          string
+	vendor, mode                    string
+	sessionCache                    bool
+	http                            *http.Client
+	idleTimeout                     time.Duration
+	authed                          atomic.Bool
+
+	mu                   sync.Mutex
+	lastResponseID       string
+	expectedPrefixDigest string
+}
+
+// New creates a Responses API provider.
+func New(cfg Config) provider.Provider {
+	vendor := DetectVendor(cfg.BaseURL)
+	sessionCache := vendor == "dashscope"
+	if cfg.SessionCache != nil {
+		sessionCache = *cfg.SessionCache
+	}
+	httpClient := &http.Client{Timeout: 300 * time.Second}
+	if built, err := netclient.NewHTTPClient(cfg.Proxy, netclient.TransportOptions{
+		DialTimeout: 30 * time.Second, KeepAlive: 30 * time.Second,
+		TLSHandshakeTimeout: 15 * time.Second, ResponseHeaderTimeout: 120 * time.Second,
+	}); err == nil {
+		httpClient = built
+	}
+	return &client{
+		name: cfg.Name, apiKey: cfg.APIKey, keyEnv: cfg.KeyEnv, keySource: cfg.KeySource,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"), model: cfg.Model, effort: cfg.Effort,
+		vendor: vendor, mode: cfg.mode(), sessionCache: sessionCache,
+		http: httpClient, idleTimeout: defaultStreamIdleTimeout,
+	}
+}
+
+func (c *client) Name() string { return c.name }
+
+// RequiresToolCallReasoning tells the agent to preserve DeepSeek reasoning on
+// assistant tool-call turns so the stateless follow-up can replay it.
+func (c *client) RequiresToolCallReasoning() bool { return c.vendor == "deepseek" }
+
+func (c *client) sendOpts() provider.SendOptions {
+	return provider.SendOptions{Provider: c.name, KeyEnv: c.keyEnv, KeySource: c.keySource, KeyPresent: c.apiKey != "", RetryAuth: c.authed.Load()}
+}
+
+// ResetContext drops stateful continuation metadata. Full-input stateless mode
+// is unaffected.
+func (c *client) ResetContext() {
+	c.mu.Lock()
+	c.lastResponseID = ""
+	c.expectedPrefixDigest = ""
+	c.mu.Unlock()
+}
+
+func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	body, usedPrevious, wireMessages := c.buildRequestBody(req)
+	resp, err := c.send(ctx, body)
+	if err != nil && usedPrevious && isStalePreviousResponseError(err) {
+		// A stateful response ID may expire server-side. Retrying once with full
+		// history is safe because no response body has started streaming.
+		c.ResetContext()
+		body, _, wireMessages = c.buildRequestBody(req)
+		resp, err = c.send(ctx, body)
+	}
+	if err != nil {
+		return nil, err
+	}
+	c.authed.Store(true)
+	out := make(chan provider.Chunk, 64)
+	go c.readStream(ctx, resp, out, wireMessages)
+	return out, nil
+}
+
+func (c *client) send(ctx context.Context, body map[string]any) (*http.Response, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("responses: marshal request: %w", err)
+	}
+	newRequest := func(ctx context.Context) (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/responses", bytes.NewReader(payload))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		if c.vendor == "dashscope" && c.sessionCache {
+			req.Header.Set("x-dashscope-session-cache", "enable")
+		}
+		return req, nil
+	}
+	return provider.SendWithRetry(ctx, c.http, c.sendOpts(), newRequest)
+}
+
+func isStalePreviousResponseError(err error) bool {
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusBadRequest {
+		return false
+	}
+	body := strings.ToLower(apiErr.Body)
+	mentionsID := strings.Contains(body, "previous_response_id") || strings.Contains(body, "previous response") || strings.Contains(body, "response id")
+	return mentionsID &&
+		(strings.Contains(body, "not found") || strings.Contains(body, "invalid") || strings.Contains(body, "expired"))
+}
+
+func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, []provider.Message) {
+	messages := provider.SanitizeToolPairing(provider.ModelMessages(req.Messages))
+	body := map[string]any{"model": c.model, "stream": true}
+
+	effort := strings.ToLower(strings.TrimSpace(c.effort))
+	switch effort {
+	case "auto":
+		effort = ""
+	case "disabled", "off":
+		effort = "none"
+	}
+	if effort != "" {
+		body["reasoning"] = map[string]any{"effort": effort}
+	}
+	if req.MaxTokens > 0 {
+		body["max_output_tokens"] = req.MaxTokens
+	}
+	if req.Temperature != nil {
+		body["temperature"] = *req.Temperature
+	}
+	if len(req.Tools) > 0 {
+		tools := make([]map[string]any, 0, len(req.Tools))
+		for _, tool := range req.Tools {
+			parameters := tool.Parameters
+			if len(parameters) == 0 {
+				parameters = provider.CanonicalizeSchema(nil)
+			}
+			tools = append(tools, map[string]any{
+				"type": "function", "name": tool.Name, "description": tool.Description,
+				"parameters": json.RawMessage(parameters),
+			})
+		}
+		body["tools"] = tools
+	}
+
+	c.mu.Lock()
+	previousID, expectedDigest := c.lastResponseID, c.expectedPrefixDigest
+	c.mu.Unlock()
+	if c.mode == "stateful" && previousID != "" && len(messages) > 0 &&
+		messages[len(messages)-1].Role == provider.RoleUser &&
+		conversationDigest(messages[:len(messages)-1]) == expectedDigest {
+		body["input"] = messages[len(messages)-1].Content
+		body["previous_response_id"] = previousID
+		return body, true, messages
+	}
+
+	instructions, rest := splitInstructions(messages)
+	if instructions != "" {
+		body["instructions"] = instructions
+	}
+	body["input"] = messagesToInput(rest)
+	return body, false, messages
+}
+
+func splitInstructions(messages []provider.Message) (string, []provider.Message) {
+	if len(messages) == 0 || messages[0].Role != provider.RoleSystem {
+		return "", messages
+	}
+	return messages[0].Content, messages[1:]
+}
+
+func messagesToInput(messages []provider.Message) []map[string]any {
+	input := make([]map[string]any, 0, len(messages)*2)
+	for _, message := range messages {
+		switch message.Role {
+		case provider.RoleSystem, provider.RoleUser:
+			input = append(input, map[string]any{"role": string(message.Role), "content": message.Content})
+		case provider.RoleAssistant:
+			if message.ReasoningContent != "" {
+				input = append(input, map[string]any{
+					"type":    "reasoning",
+					"content": []map[string]string{{"type": "reasoning_text", "text": message.ReasoningContent}},
+				})
+			}
+			if message.Content != "" || len(message.ToolCalls) == 0 {
+				input = append(input, map[string]any{"role": "assistant", "content": message.Content})
+			}
+			for _, call := range message.ToolCalls {
+				input = append(input, map[string]any{
+					"type": "function_call", "call_id": call.ID,
+					"name": call.Name, "arguments": call.Arguments,
+				})
+			}
+		case provider.RoleTool:
+			input = append(input, map[string]any{
+				"type": "function_call_output", "call_id": message.ToolCallID, "output": message.Content,
+			})
+		}
+	}
+	return input
+}
+
+func conversationDigest(messages []provider.Message) string {
+	instructions, rest := splitInstructions(messages)
+	payload, _ := json.Marshal(struct {
+		Instructions string           `json:"instructions,omitempty"`
+		Input        []map[string]any `json:"input"`
+	}{Instructions: instructions, Input: messagesToInput(rest)})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+type streamedCall struct {
+	id, name, arguments string
+	argChars            int
+	completed           bool
+}
+
+func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<- provider.Chunk, requestMessages []provider.Message) {
+	defer resp.Body.Close()
+	defer close(out)
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	idle := c.idleTimeout
+	if idle <= 0 {
+		idle = defaultStreamIdleTimeout
+	}
+	watchDone := make(chan struct{})
+	activity := make(chan struct{}, 1)
+	var stalled atomic.Bool
+	go func() {
+		timer := time.NewTimer(idle)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				_ = resp.Body.Close()
+				return
+			case <-watchDone:
+				return
+			case <-activity:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(idle)
+			case <-timer.C:
+				stalled.Store(true)
+				_ = resp.Body.Close()
+				return
+			}
+		}
+	}()
+	defer close(watchDone)
+
+	calls := make(map[string]*streamedCall)
+	callOrder := make([]string, 0)
+	callForItem := func(itemID string) *streamedCall {
+		if call := calls[itemID]; call != nil {
+			return call
+		}
+		call := &streamedCall{id: itemID}
+		calls[itemID] = call
+		callOrder = append(callOrder, itemID)
+		return call
+	}
+	textDeltas := make(map[string]bool)
+	reasoningDeltas := make(map[string]bool)
+	var text, reasoning strings.Builder
+	terminal := false
+	failed := false
+	completedResponseID := ""
+
+	for scanner.Scan() {
+		select {
+		case activity <- struct{}{}:
+		default:
+		}
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" {
+			terminal = true
+			break
+		}
+		var event sseEvent
+		if json.Unmarshal([]byte(data), &event) != nil {
+			continue
+		}
+		key := fmt.Sprintf("%s:%d", event.ItemID, event.ContentIndex)
+		switch event.Type {
+		case "response.output_text.delta":
+			textDeltas[key] = true
+			text.WriteString(event.Delta)
+			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkText, Text: event.Delta}) {
+				return
+			}
+		case "response.output_text.done":
+			if event.Text != "" && !textDeltas[key] {
+				text.WriteString(event.Text)
+				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkText, Text: event.Text}) {
+					return
+				}
+			}
+		case "response.reasoning_text.delta", "response.reasoning_summary_text.delta":
+			reasoningDeltas[key] = true
+			reasoning.WriteString(event.Delta)
+			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: event.Delta}) {
+				return
+			}
+		case "response.reasoning_text.done", "response.reasoning_summary_text.done":
+			if event.Text != "" && !reasoningDeltas[key] {
+				reasoning.WriteString(event.Text)
+				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkReasoning, Text: event.Text}) {
+					return
+				}
+			}
+		case "response.output_item.added":
+			if event.Item != nil && event.Item.Type == "function_call" {
+				call := callForItem(event.Item.ID)
+				call.id = event.Item.CallID
+				call.name = event.Item.Name
+				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: call.id, Name: call.name}}) {
+					return
+				}
+			}
+		case "response.function_call_arguments.delta":
+			call := callForItem(event.ItemID)
+			call.arguments += event.Delta
+			call.argChars += len(event.Delta)
+			if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCallArgsDelta, ToolCall: &provider.ToolCall{ID: call.id, Name: call.name}, ArgChars: call.argChars}) {
+				return
+			}
+		case "response.function_call_arguments.done":
+			call := callForItem(event.ItemID)
+			if event.Arguments != "" {
+				call.arguments = event.Arguments
+			}
+			if !call.completed {
+				call.completed = true
+				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: call.id, Name: call.name, Arguments: call.arguments}}) {
+					return
+				}
+			}
+		case "response.output_item.done":
+			if event.Item != nil && event.Item.Type == "function_call" {
+				call := callForItem(event.Item.ID)
+				if event.Item.CallID != "" {
+					call.id = event.Item.CallID
+				}
+				if event.Item.Name != "" {
+					call.name = event.Item.Name
+				}
+				if event.Item.Arguments != "" {
+					call.arguments = event.Item.Arguments
+				}
+				if !call.completed {
+					call.completed = true
+					if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: call.id, Name: call.name, Arguments: call.arguments}}) {
+						return
+					}
+				}
+			}
+		case "response.completed", "response.incomplete", "response.failed":
+			terminal = true
+			if event.Response != nil {
+				if event.Type == "response.completed" {
+					completedResponseID = event.Response.ID
+				}
+				usage := usageFromResponse(event.Response)
+				if event.Type == "response.incomplete" {
+					switch event.Response.IncompleteDetails.Reason {
+					case "max_output_tokens":
+						usage.FinishReason = "length"
+					case "content_filter":
+						usage.FinishReason = "content_filter"
+					default:
+						usage.FinishReason = "incomplete"
+					}
+				}
+				if event.Response.Usage != nil || usage.FinishReason != "" {
+					if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkUsage, Usage: usage}) {
+						return
+					}
+				}
+			}
+			if event.Type == "response.failed" {
+				failed = true
+				err := fmt.Errorf("responses: response failed")
+				if event.Response != nil && event.Response.Error != nil {
+					if authErr := authErrorFromResponse(c, event.Response.Error); authErr != nil {
+						err = authErr
+					} else {
+						err = fmt.Errorf("responses: %s", event.Response.Error.Message)
+					}
+				}
+				if !sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err}) {
+					return
+				}
+			}
+			break
+		}
+		if terminal {
+			break
+		}
+	}
+
+	if ctx.Err() != nil {
+		return
+	}
+	if err := scanner.Err(); err != nil {
+		if stalled.Load() {
+			err = fmt.Errorf("responses: stream idle timeout after %s", idle)
+		}
+		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: &provider.StreamInterruptedError{Err: err}})
+		return
+	}
+	if !terminal {
+		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: &provider.StreamInterruptedError{Err: io.ErrUnexpectedEOF}})
+		return
+	}
+	if completedResponseID != "" {
+		assistant := provider.Message{Role: provider.RoleAssistant, Content: text.String(), ReasoningContent: reasoning.String()}
+		for _, itemID := range callOrder {
+			call := calls[itemID]
+			if call.completed {
+				assistant.ToolCalls = append(assistant.ToolCalls, provider.ToolCall{ID: call.id, Name: call.name, Arguments: call.arguments})
+			}
+		}
+		expected := append(append([]provider.Message(nil), requestMessages...), assistant)
+		c.mu.Lock()
+		c.lastResponseID = completedResponseID
+		c.expectedPrefixDigest = conversationDigest(expected)
+		c.mu.Unlock()
+	} else {
+		c.ResetContext()
+	}
+	if !failed {
+		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkDone})
+	}
+}
+
+func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Chunk) bool {
+	select {
+	case out <- chunk:
+		return true
+	default:
+	}
+	select {
+	case out <- chunk:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func usageFromResponse(response *sseResponse) *provider.Usage {
+	usage := &provider.Usage{}
+	if response == nil || response.Usage == nil {
+		return usage
+	}
+	u := response.Usage
+	cached, reasoning := 0, 0
+	if u.InputTokensDetails != nil {
+		cached = u.InputTokensDetails.CachedTokens
+	}
+	if u.OutputTokensDetails != nil {
+		reasoning = u.OutputTokensDetails.ReasoningTokens
+	}
+	miss := u.InputTokens - cached
+	if miss < 0 {
+		miss = 0
+	}
+	total := u.TotalTokens
+	if total == 0 {
+		total = u.InputTokens + u.OutputTokens
+	}
+	return &provider.Usage{PromptTokens: u.InputTokens, CompletionTokens: u.OutputTokens, TotalTokens: total, CacheHitTokens: cached, CacheMissTokens: miss, ReasoningTokens: reasoning}
+}
+
+func authErrorFromResponse(c *client, responseError *sseError) error {
+	if responseError == nil {
+		return nil
+	}
+	value := strings.ToLower(responseError.Code + " " + responseError.Message)
+	if !strings.Contains(value, "auth") && !strings.Contains(value, "api key") && !strings.Contains(value, "unauthorized") && !strings.Contains(value, "forbidden") && !strings.Contains(value, "permission") {
+		return nil
+	}
+	status := http.StatusUnauthorized
+	if strings.Contains(value, "forbidden") || strings.Contains(value, "permission") {
+		status = http.StatusForbidden
+	}
+	return &provider.AuthError{Provider: c.name, KeyEnv: c.keyEnv, KeySource: c.keySource, Status: status, HasKey: c.apiKey != "", Body: responseError.Message}
+}
+
+type sseEvent struct {
+	Type         string       `json:"type"`
+	Delta        string       `json:"delta"`
+	Text         string       `json:"text"`
+	Arguments    string       `json:"arguments"`
+	ItemID       string       `json:"item_id"`
+	ContentIndex int          `json:"content_index"`
+	Item         *sseItem     `json:"item"`
+	Response     *sseResponse `json:"response"`
+}
+
+type sseItem struct {
+	ID, Type, CallID, Name, Arguments string
+}
+
+func (i *sseItem) UnmarshalJSON(data []byte) error {
+	var wire struct {
+		ID        string `json:"id"`
+		Type      string `json:"type"`
+		CallID    string `json:"call_id"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	*i = sseItem{ID: wire.ID, Type: wire.Type, CallID: wire.CallID, Name: wire.Name, Arguments: wire.Arguments}
+	return nil
+}
+
+type sseResponse struct {
+	ID                string            `json:"id"`
+	Usage             *sseUsage         `json:"usage"`
+	Error             *sseError         `json:"error"`
+	IncompleteDetails incompleteDetails `json:"incomplete_details"`
+}
+
+type incompleteDetails struct {
+	Reason string `json:"reason"`
+}
+type sseError struct {
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+type sseUsage struct {
+	InputTokens        int `json:"input_tokens"`
+	OutputTokens       int `json:"output_tokens"`
+	TotalTokens        int `json:"total_tokens"`
+	InputTokensDetails *struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+	OutputTokensDetails *struct {
+		ReasoningTokens int `json:"reasoning_tokens"`
+	} `json:"output_tokens_details"`
+}

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -497,7 +497,6 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 					return
 				}
 			}
-			break
 		}
 		if terminal {
 			break

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -1,0 +1,374 @@
+package responses
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+func boolPtr(value bool) *bool { return &value }
+
+func collect(t *testing.T, p provider.Provider, req provider.Request) []provider.Chunk {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := p.Stream(ctx, req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var chunks []provider.Chunk
+	for chunk := range stream {
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}
+
+func writeEvents(w http.ResponseWriter, events ...string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	for _, event := range events {
+		_, _ = w.Write([]byte("event: ignored\n"))
+		_, _ = w.Write([]byte("data: " + event + "\n\n"))
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func TestDetectVendorAndModeDefaults(t *testing.T) {
+	tests := []struct{ url, vendor, mode string }{
+		{"https://api.deepseek.com", "deepseek", "stateless"},
+		{"https://dashscope.aliyuncs.com/compatible-mode/v1", "dashscope", "stateful"},
+		{"https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", "dashscope", "stateful"},
+		{"https://example.com/v1", "", "stateful"},
+	}
+	for _, test := range tests {
+		if got := DetectVendor(test.url); got != test.vendor {
+			t.Errorf("DetectVendor(%q) = %q, want %q", test.url, got, test.vendor)
+		}
+		if got := (Config{BaseURL: test.url}).mode(); got != test.mode {
+			t.Errorf("mode(%q) = %q, want %q", test.url, got, test.mode)
+		}
+	}
+	if got := (Config{BaseURL: "https://api.deepseek.com", Mode: "stateful"}).mode(); got != "stateful" {
+		t.Fatalf("explicit mode = %q", got)
+	}
+	if got := (Config{BaseURL: "https://api.deepseek.com", Mode: "stateful", Stateful: boolPtr(false)}).mode(); got != "stateful" {
+		t.Fatalf("mode must win over legacy stateful, got %q", got)
+	}
+	if got := (Config{BaseURL: "https://example.com", Stateful: boolPtr(false)}).mode(); got != "stateless" {
+		t.Fatalf("legacy stateful=false mode = %q", got)
+	}
+}
+
+func TestDeepSeekEffortUsesResponsesReasoningShape(t *testing.T) {
+	tests := []struct{ effort, want string }{
+		{"auto", ""}, {"disabled", "none"}, {"minimal", "minimal"}, {"low", "low"}, {"high", "high"}, {"max", "max"},
+	}
+	for _, test := range tests {
+		client := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Effort: test.effort}).(*client)
+		body, _, _ := client.buildRequestBody(provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+		reasoning, _ := body["reasoning"].(map[string]any)
+		got, _ := reasoning["effort"].(string)
+		if got != test.want {
+			t.Errorf("effort %q serialized as %q, want %q", test.effort, got, test.want)
+		}
+	}
+}
+
+func TestFactoryPreservesUnsetLegacyStatefulForVendorDetection(t *testing.T) {
+	p, err := newFromConfig(provider.Config{
+		Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash",
+		Extra: map[string]any{"stateful": (*bool)(nil)},
+	})
+	if err != nil {
+		t.Fatalf("newFromConfig: %v", err)
+	}
+	if got := p.(*client).mode; got != "stateless" {
+		t.Fatalf("unset stateful mode = %q, want DeepSeek vendor default stateless", got)
+	}
+}
+
+func TestStatelessRequestReplaysReasoningContentAndToolPair(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeEvents(w, `{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}`)
+	}))
+	defer server.Close()
+
+	p := New(Config{Name: "deepseek", APIKey: "key", BaseURL: server.URL, Model: "deepseek-v4-flash", Mode: "stateless", Effort: "high"})
+	collect(t, p, provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "weather"},
+		{Role: provider.RoleAssistant, Content: "checking", ReasoningContent: "need a tool", ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "weather", Arguments: `{"city":"SG"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "weather", Content: "sunny"},
+	}})
+
+	if body["previous_response_id"] != nil {
+		t.Fatalf("stateless request has previous_response_id: %#v", body)
+	}
+	if body["instructions"] != "system" {
+		t.Fatalf("instructions = %#v", body["instructions"])
+	}
+	items, ok := body["input"].([]any)
+	if !ok || len(items) != 5 {
+		t.Fatalf("input = %#v, want user/reasoning/assistant/call/output", body["input"])
+	}
+	wantTypes := []string{"", "reasoning", "", "function_call", "function_call_output"}
+	for i, want := range wantTypes {
+		item := items[i].(map[string]any)
+		if got, _ := item["type"].(string); got != want {
+			t.Errorf("item[%d].type = %q, want %q: %#v", i, got, want, item)
+		}
+	}
+	assistant := items[2].(map[string]any)
+	if assistant["content"] != "checking" {
+		t.Fatalf("assistant content lost: %#v", assistant)
+	}
+	reasoning := items[1].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if reasoning["type"] != "reasoning_text" || reasoning["text"] != "need a tool" {
+		t.Fatalf("reasoning item = %#v", reasoning)
+	}
+}
+
+func TestStatelessRequestSanitizesMissingToolOutput(t *testing.T) {
+	client := New(Config{Name: "test", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"}).(*client)
+	body, _, _ := client.buildRequestBody(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "run"},
+		{Role: provider.RoleAssistant, ReasoningContent: "call", ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{"command":"pwd"}`}}},
+	}})
+	items := body["input"].([]map[string]any)
+	if got := items[len(items)-1]["type"]; got != "function_call_output" {
+		t.Fatalf("last input item = %#v, want repaired function_call_output", items[len(items)-1])
+	}
+}
+
+func TestStreamDoesNotDuplicateDoneText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEvents(w,
+			`{"type":"response.output_text.delta","item_id":"msg_1","content_index":0,"delta":"hello"}`,
+			`{"type":"response.output_text.done","item_id":"msg_1","content_index":0,"text":"hello"}`,
+			`{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":3,"input_tokens_details":{"cached_tokens":2},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":1},"total_tokens":4}}}`,
+		)
+	}))
+	defer server.Close()
+
+	chunks := collect(t, New(Config{Name: "test", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateless"}), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	var text string
+	var usage *provider.Usage
+	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkText {
+			text += chunk.Text
+		}
+		if chunk.Type == provider.ChunkUsage {
+			usage = chunk.Usage
+		}
+	}
+	if text != "hello" {
+		t.Fatalf("streamed text = %q, want one copy", text)
+	}
+	if usage == nil || usage.CacheHitTokens != 2 || usage.CacheMissTokens != 1 || usage.ReasoningTokens != 1 {
+		t.Fatalf("usage = %+v", usage)
+	}
+	if chunks[len(chunks)-1].Type != provider.ChunkDone {
+		t.Fatalf("last chunk = %v", chunks[len(chunks)-1].Type)
+	}
+}
+
+func TestFunctionArgumentEventsUseOutputItemMappingAndCumulativeProgress(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEvents(w,
+			`{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"bash"}}`,
+			`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"command\":"}`,
+			`{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"\"pwd\"}"}`,
+			`{"type":"response.function_call_arguments.done","item_id":"fc_1","arguments":"{\"command\":\"pwd\"}"}`,
+			`{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"bash","arguments":"{\"command\":\"pwd\"}"}}`,
+			`{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":2,"output_tokens":2,"total_tokens":4}}}`,
+		)
+	}))
+	defer server.Close()
+
+	chunks := collect(t, New(Config{Name: "test", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateless"}), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "pwd"}}})
+	var starts, completed int
+	var progress []int
+	for _, chunk := range chunks {
+		switch chunk.Type {
+		case provider.ChunkToolCallStart:
+			starts++
+			if chunk.ToolCall.ID != "call_1" || chunk.ToolCall.Name != "bash" {
+				t.Errorf("start = %+v", chunk.ToolCall)
+			}
+		case provider.ChunkToolCallArgsDelta:
+			progress = append(progress, chunk.ArgChars)
+			if chunk.ToolCall.ID != "call_1" {
+				t.Errorf("delta ID = %q", chunk.ToolCall.ID)
+			}
+		case provider.ChunkToolCall:
+			completed++
+			if chunk.ToolCall.ID != "call_1" || chunk.ToolCall.Name != "bash" || chunk.ToolCall.Arguments != `{"command":"pwd"}` {
+				t.Errorf("complete = %+v", chunk.ToolCall)
+			}
+		}
+	}
+	if starts != 1 || completed != 1 {
+		t.Fatalf("starts=%d completed=%d", starts, completed)
+	}
+	if len(progress) != 2 || progress[1] <= progress[0] {
+		t.Fatalf("argument progress = %v, want cumulative", progress)
+	}
+}
+
+func TestIncompleteResponseSurfacesFinishReason(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEvents(w, `{"type":"response.incomplete","response":{"id":"resp_1","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}`)
+	}))
+	defer server.Close()
+	p := New(Config{Name: "test", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateful"}).(*client)
+	p.lastResponseID = "stale"
+	p.expectedPrefixDigest = "stale"
+	chunks := collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkUsage {
+			if chunk.Usage.FinishReason != "length" {
+				t.Fatalf("finish reason = %q", chunk.Usage.FinishReason)
+			}
+			if p.lastResponseID != "" || p.expectedPrefixDigest != "" {
+				t.Fatalf("incomplete response retained stateful context: id=%q digest=%q", p.lastResponseID, p.expectedPrefixDigest)
+			}
+			return
+		}
+	}
+	t.Fatal("missing usage chunk")
+}
+
+func TestStatefulContinuationValidatesConversationPrefix(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		id := len(bodies)
+		mu.Unlock()
+		writeEvents(w,
+			`{"type":"response.output_text.delta","item_id":"msg","delta":"answer"}`,
+			`{"type":"response.completed","response":{"id":"resp_`+string(rune('0'+id))+`","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		)
+	}))
+	defer server.Close()
+	p := New(Config{Name: "stateful", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateful"})
+
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "sys"}, {Role: provider.RoleUser, Content: "one"}}})
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "sys"}, {Role: provider.RoleUser, Content: "one"}, {Role: provider.RoleAssistant, Content: "answer"}, {Role: provider.RoleUser, Content: "two"}}})
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "different"}, {Role: provider.RoleUser, Content: "new session"}}})
+
+	if bodies[1]["previous_response_id"] != "resp_1" || bodies[1]["input"] != "two" {
+		t.Fatalf("valid continuation = %#v", bodies[1])
+	}
+	if _, ok := bodies[2]["previous_response_id"]; ok {
+		t.Fatalf("session switch reused previous response: %#v", bodies[2])
+	}
+	if _, ok := bodies[2]["input"].([]any); !ok {
+		t.Fatalf("session switch did not send full input: %#v", bodies[2]["input"])
+	}
+}
+
+func TestExpiredPreviousResponseRetriesOnceWithFullHistory(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		attempt := len(bodies)
+		mu.Unlock()
+		if attempt == 2 {
+			http.Error(w, `previous_response_id expired`, http.StatusBadRequest)
+			return
+		}
+		id := "resp_1"
+		if attempt == 3 {
+			id = "resp_2"
+		}
+		writeEvents(w,
+			`{"type":"response.output_text.delta","item_id":"msg","delta":"answer"}`,
+			`{"type":"response.completed","response":{"id":"`+id+`","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`,
+		)
+	}))
+	defer server.Close()
+	p := New(Config{Name: "stateful", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateful"})
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "one"}}})
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "one"}, {Role: provider.RoleAssistant, Content: "answer"}, {Role: provider.RoleUser, Content: "two"}}})
+	if len(bodies) != 3 {
+		t.Fatalf("request count = %d, want initial + stale + retry", len(bodies))
+	}
+	if bodies[1]["previous_response_id"] != "resp_1" {
+		t.Fatalf("stale attempt = %#v", bodies[1])
+	}
+	if _, ok := bodies[2]["previous_response_id"]; ok {
+		t.Fatalf("retry still has previous response: %#v", bodies[2])
+	}
+	if _, ok := bodies[2]["input"].([]any); !ok {
+		t.Fatalf("retry input = %#v, want full array", bodies[2]["input"])
+	}
+}
+
+func TestDashScopeCacheHeaderIsVendorScoped(t *testing.T) {
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("x-dashscope-session-cache")
+		writeEvents(w, `{"type":"response.completed","response":{"id":"resp","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`)
+	}))
+	defer server.Close()
+	p := New(Config{Name: "test", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateless", SessionCache: boolPtr(true)}).(*client)
+	p.vendor = "deepseek"
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if got != "" {
+		t.Fatalf("DeepSeek request leaked DashScope header %q", got)
+	}
+	p.vendor = "dashscope"
+	collect(t, p, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if got != "enable" {
+		t.Fatalf("DashScope header = %q", got)
+	}
+}
+
+func TestRequiresToolCallReasoningOnlyForDeepSeek(t *testing.T) {
+	deepseek := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"})
+	if !provider.RequiresToolCallReasoning(deepseek) {
+		t.Fatal("DeepSeek Responses provider must preserve tool-call reasoning")
+	}
+	other := New(Config{Name: "other", BaseURL: "https://example.com", Model: "m"})
+	if provider.RequiresToolCallReasoning(other) {
+		t.Fatal("unknown Responses endpoint unexpectedly requires DeepSeek reasoning")
+	}
+}
+
+func TestFailedEventSurfacesAuthenticationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeEvents(w, `{"type":"response.failed","response":{"id":"resp","error":{"code":"invalid_api_key","message":"bad API key"}}}`)
+	}))
+	defer server.Close()
+	chunks := collect(t, New(Config{Name: "test", APIKey: "key", KeyEnv: "TEST_API_KEY", BaseURL: server.URL, Model: "m"}), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkError {
+			if _, ok := chunk.Err.(*provider.AuthError); !ok || !strings.Contains(chunk.Err.Error(), "TEST_API_KEY") {
+				t.Fatalf("error = %T %v", chunk.Err, chunk.Err)
+			}
+			return
+		}
+	}
+	t.Fatal("missing error chunk")
+}

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -276,6 +276,9 @@ func TestStatefulContinuationValidatesConversationPrefix(t *testing.T) {
 	if bodies[1]["previous_response_id"] != "resp_1" || bodies[1]["input"] != "two" {
 		t.Fatalf("valid continuation = %#v", bodies[1])
 	}
+	if bodies[1]["instructions"] != "sys" {
+		t.Fatalf("valid continuation instructions = %#v, want %q", bodies[1]["instructions"], "sys")
+	}
 	if _, ok := bodies[2]["previous_response_id"]; ok {
 		t.Fatalf("session switch reused previous response: %#v", bodies[2])
 	}


### PR DESCRIPTION
## 概要

本 PR 在最新 `main-v2` 上重建为一个聚焦的 Responses API 适配，响应 #4183，并针对 DeepSeek V4 Flash 正式版的官方协议完成加固：

- 新增 `responses` provider kind，并保留 `dashscope-responses` 兼容别名。
- DeepSeek 自动使用无状态模式：每轮稳定回传完整 input 历史，不发送 `previous_response_id`。
- 新增 `deepseek-responses` 可编辑 preset；模型目录只包含官方当前支持的 `deepseek-v4-flash`，未提前开放 V4 Pro。
- CLI、Guard 与 Desktop 均注册新 provider。

## 协议正确性修复

- 完整序列化 `reasoning`、assistant 正文、`function_call` 与 `function_call_output`，并在发包前修复不完整的工具配对。
- `response.output_text.done` / `reasoning_text.done` 只作为 delta 缺失时的 fallback，不再重复输出完整文本。
- 通过 output item ID 映射真实 `call_id`，工具参数进度为累计字符数，并去重 `arguments.done` / `output_item.done` 的完成事件。
- 正确处理 `completed` / `incomplete` / `failed`；截断原因进入 `FinishReason`，失败事件保留可操作的认证错误。
- Stateful 兼容路径以完整会话前缀摘要校验 continuation；会话切换/压缩历史自动退回全量 input，过期 response ID 会在尚未开始流式输出时自动全量重试一次。
- `x-dashscope-session-cache` 只发送给 DashScope endpoint，不会泄漏到 DeepSeek 请求。

## 配置兼容性

| 场景 | 行为 |
|---|---|
| 旧配置没有 `responses_mode` / `responses_stateful` | 保持 vendor 自动检测；DeepSeek stateless，其他兼容 endpoint 默认 stateful |
| 旧配置显式设置 `responses_stateful` | 继续生效 |
| 同时设置 `responses_mode` 与 legacy bool | `responses_mode` 优先 |
| 保存 user `config.toml` 或 project `reasonix.toml` | 两个字段均可往返持久化，不再静默丢失 |
| 现有 `openai` / `anthropic` provider | 请求序列化与缓存行为不变 |

## 范围收敛

原分支中的本地环境、二进制、日志、Agent 配置、未验证的跨协议缓存修改、全局 compaction/定价修改和 29 组 benchmark 均未迁入。最终 diff 仅含 11 个 Responses/config/registration 相关文件；贡献者工作通过 commit co-author 保留署名。

## 验证

- `go test ./internal/provider/responses ./internal/config ./internal/boot`
- `go test -race ./internal/provider/responses ./internal/config ./internal/boot`
- `go test ./...`
- `(cd desktop && go test ./...)`
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `./scripts/cache-guard.sh`
- `git diff --check origin/main-v2...HEAD`

覆盖的回归场景包括：官方 DeepSeek SSE 终止序列、text done 去重、reasoning/tool 完整回传、tool item/call ID 映射、累计参数进度、incomplete finish reason、stateful 会话切换、过期 response ID 自动重试、DashScope header vendor scope，以及 user/project 配置往返。

Closes #4183

Cache-impact: medium - adds deterministic serialization for the new Responses provider; existing OpenAI/Anthropic request prefixes are unchanged.

Cache-guard: `./scripts/cache-guard.sh` plus focused Responses serialization and tool-round-trip tests passed on the latest main-v2 tree.

System-prompt-review: @SivanCola reviewed the final diff; no system-prompt content or composition order changed, and the new provider deterministically maps the leading system message to `instructions`.
