### PR TITLE
Fix Remote Workbench CLI provisioning over SSH / 修复远程工作台 SSH CLI 供给

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ branch.
 
 ### Fixed
 
+- Fixed Remote Workbench failing with only `initialize: workbench-desktop:
+  connection closed` on fresh or cross-platform SSH hosts. Desktop now proves
+  the exact Host CLI Build ID, provisions the matching verified release without
+  requiring remote npm, runs the managed binary explicitly, and preserves a
+  safe structured bootstrap error when the remote command exits early.
 - Hardened Bash permission reuse for dynamic and indirect execution. Parameter/arithmetic expansions,
   assignments, redirects, heredocs, and globs can only be remembered as exact
   `Bash=<literal>` rules, while still using Auto's normal fallback. Nested or

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1353,7 +1353,7 @@ export const en = {
   "remote.host.useSSHConfig": "Use ~/.ssh/config for unset connection options",
   "remote.host.proxyJump": "Proxy jump",
   "remote.host.defaultWorkspace": "Default workspace",
-  "remote.host.serveInstall": "Serve install",
+  "remote.host.serveInstall": "Remote CLI install",
   "remote.host.save": "Save",
   "remote.host.cancel": "Cancel",
   "remote.host.edit": "Edit",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1027,7 +1027,7 @@ export const zhTW: Record<DictKey, string> = {
   "remote.host.useSSHConfig": "使用 ~/.ssh/config 補齊未設定的連線參數",
   "remote.host.proxyJump": "跳板",
   "remote.host.defaultWorkspace": "預設工作區",
-  "remote.host.serveInstall": "serve 安裝方式",
+  "remote.host.serveInstall": "遠端 CLI 安裝方式",
   "remote.host.save": "儲存",
   "remote.host.cancel": "取消",
   "remote.host.edit": "編輯",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1355,7 +1355,7 @@ export const zh: Record<DictKey, string> = {
   "remote.host.useSSHConfig": "使用 ~/.ssh/config 补全未设置的连接参数",
   "remote.host.proxyJump": "跳板",
   "remote.host.defaultWorkspace": "默认工作区",
-  "remote.host.serveInstall": "serve 安装方式",
+  "remote.host.serveInstall": "远端 CLI 安装方式",
   "remote.host.save": "保存",
   "remote.host.cancel": "取消",
   "remote.host.edit": "编辑",

--- a/desktop/remote_app.go
+++ b/desktop/remote_app.go
@@ -18,6 +18,7 @@ import (
 	"reasonix/internal/remote"
 	"reasonix/internal/remote/bootstrap"
 	"reasonix/internal/remote/forward"
+	"reasonix/internal/remote/protocol"
 )
 
 // ── View structs mirrored in frontend/src/lib/types.ts ──
@@ -517,13 +518,15 @@ type desktopRemoteManager struct {
 	mu    sync.Mutex
 	hosts map[string]*managedHost
 
-	newClient   func(remote.Options) (desktopSSHClient, error)
-	ensureServe func(context.Context, bootstrap.Conn, bootstrap.Options) (bootstrap.Result, error)
-	stopServe   func(context.Context, bootstrap.Conn, string) error
-	serveLogs   func(context.Context, bootstrap.Conn, string, int, *strings.Builder) error
-	localBinary func() string
-	promptGate  chan struct{}
-	promptSeq   uint64
+	newClient          func(remote.Options) (desktopSSHClient, error)
+	ensureServe        func(context.Context, bootstrap.Conn, bootstrap.Options) (bootstrap.Result, error)
+	ensureWorkbenchCLI func(context.Context, bootstrap.Conn, bootstrap.WorkbenchOptions) (bootstrap.WorkbenchCLI, error)
+	stopServe          func(context.Context, bootstrap.Conn, string) error
+	serveLogs          func(context.Context, bootstrap.Conn, string, int, *strings.Builder) error
+	localBinary        func() string
+	fetchRemoteBinary  func(context.Context, string, string, string) ([]byte, error)
+	promptGate         chan struct{}
+	promptSeq          uint64
 }
 
 func newDesktopRemoteManager(sink remoteEventSink) *desktopRemoteManager {
@@ -533,13 +536,15 @@ func newDesktopRemoteManager(sink remoteEventSink) *desktopRemoteManager {
 		newClient: func(opts remote.Options) (desktopSSHClient, error) {
 			return remote.New(opts)
 		},
-		ensureServe: bootstrap.EnsureServe,
-		stopServe:   bootstrap.Stop,
+		ensureServe:        bootstrap.EnsureServe,
+		ensureWorkbenchCLI: bootstrap.EnsureWorkbenchCLI,
+		stopServe:          bootstrap.Stop,
 		serveLogs: func(ctx context.Context, conn bootstrap.Conn, workspace string, n int, out *strings.Builder) error {
 			return bootstrap.Logs(ctx, conn, workspace, n, out)
 		},
-		localBinary: desktopCLIBinaryPath,
-		promptGate:  make(chan struct{}, 1),
+		localBinary:       desktopCLIBinaryPath,
+		fetchRemoteBinary: downloadRemoteCLIBinary,
+		promptGate:        make(chan struct{}, 1),
 	}
 }
 
@@ -1285,12 +1290,14 @@ func (m *desktopRemoteManager) EnsureServer(ctx context.Context, hostID, workspa
 		return RemoteServerView{}, "", fmt.Errorf("host %q connection was replaced", hostID)
 	}
 	res, err := m.ensureServe(opCtx, c, bootstrap.Options{
-		Workspace:   workspace,
-		Install:     entry.ServeInstallMode(),
-		LocalBinary: m.localBinary(),
-		LocalGOOS:   runtime.GOOS,
-		LocalGOARCH: runtime.GOARCH,
-		MinVersion:  bootstrap.MinServeVersion,
+		Workspace:      workspace,
+		Install:        entry.ServeInstallMode(),
+		LocalBinary:    m.localBinary(),
+		LocalGOOS:      runtime.GOOS,
+		LocalGOARCH:    runtime.GOARCH,
+		ProductVersion: version,
+		FetchBinary:    m.fetchRemoteBinary,
+		MinVersion:     bootstrap.MinServeVersion,
 		Progress: func(step, detail string) {
 			view := RemoteServerView{HostID: hostID, Workspace: workspace, State: step, Message: detail}
 			m.publishServerIfCurrent(hostID, mh, view, "")
@@ -1333,6 +1340,38 @@ func (m *desktopRemoteManager) EnsureServer(ctx context.Context, hostID, workspa
 		return RemoteServerView{}, "", fmt.Errorf("host %q connection was replaced", hostID)
 	}
 	return view, res.Token, nil
+}
+
+// EnsureWorkbenchCLI prepares the exact Host executable required by the
+// Desktop's strict Remote Workbench Build ID. The per-host bootstrap mutex also
+// prevents the legacy serve installer from racing the Workbench installer.
+func (m *desktopRemoteManager) EnsureWorkbenchCLI(ctx context.Context, hostID string, entry config.RemoteHostEntry, expected protocol.BuildID) (string, error) {
+	mh := m.managed(hostID)
+	if mh == nil || mh.client == nil {
+		return "", fmt.Errorf("host %q is not connected", hostID)
+	}
+	mh.serveMu.Lock()
+	defer mh.serveMu.Unlock()
+	if !m.isCurrent(hostID, mh) {
+		return "", fmt.Errorf("host %q connection was replaced", hostID)
+	}
+	opCtx, cancel := managedOperationContext(ctx, mh)
+	defer cancel()
+	result, err := m.ensureWorkbenchCLI(opCtx, mh.client, bootstrap.WorkbenchOptions{
+		Install:       entry.ServeInstallMode(),
+		LocalBinary:   m.localBinary(),
+		LocalGOOS:     runtime.GOOS,
+		LocalGOARCH:   runtime.GOARCH,
+		ExpectedBuild: expected,
+		FetchBinary:   m.fetchRemoteBinary,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !m.isCurrent(hostID, mh) {
+		return "", fmt.Errorf("host %q connection was replaced", hostID)
+	}
+	return result.Path, nil
 }
 
 func (m *desktopRemoteManager) StopServer(hostID string) error {

--- a/desktop/remote_cli_download.go
+++ b/desktop/remote_cli_download.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/netclient"
+	"reasonix/internal/releaseasset"
+)
+
+const remoteCLIDownloadTimeout = 2 * time.Minute
+
+func downloadRemoteCLIBinary(ctx context.Context, version, goos, goarch string) ([]byte, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	client, err := netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{
+		ResponseHeaderTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	client.Timeout = remoteCLIDownloadTimeout
+	return releaseasset.DownloadCLI(ctx, client, version, goos, goarch)
+}

--- a/desktop/remote_lifecycle_test.go
+++ b/desktop/remote_lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 	"reasonix/internal/remote"
 	"reasonix/internal/remote/bootstrap"
 	"reasonix/internal/remote/forward"
+	"reasonix/internal/remote/protocol"
 	"reasonix/internal/remote/sftpfs"
 )
 
@@ -284,6 +285,34 @@ func TestEnsureServerResultCannotMutateReplacement(t *testing.T) {
 	}
 	if replacement.token != "new-token" {
 		t.Fatalf("replacement token = %q, want new-token", replacement.token)
+	}
+}
+
+func TestEnsureWorkbenchCLIUsesHostInstallPolicyAndExactBuild(t *testing.T) {
+	mgr := newDesktopRemoteManager(nil)
+	hostCtx, hostCancel := context.WithCancel(context.Background())
+	defer hostCancel()
+	mgr.hosts["box"] = &managedHost{ctx: hostCtx, cancel: hostCancel, client: newLifecycleSSHClient(nil)}
+	expected, err := protocol.NewBuildID("v1.2.3", strings.Repeat("a", 40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgr.localBinary = func() string { return "/packaged/reasonix" }
+	mgr.fetchRemoteBinary = func(context.Context, string, string, string) ([]byte, error) {
+		return []byte("downloaded"), nil
+	}
+	mgr.ensureWorkbenchCLI = func(_ context.Context, _ bootstrap.Conn, opts bootstrap.WorkbenchOptions) (bootstrap.WorkbenchCLI, error) {
+		if opts.Install != "npm" || opts.LocalBinary != "/packaged/reasonix" || opts.ExpectedBuild != expected || opts.FetchBinary == nil {
+			t.Fatalf("Workbench options = %+v", opts)
+		}
+		return bootstrap.WorkbenchCLI{Path: "/home/dev/.reasonix/remote/workbench/build/reasonix", Installed: true}, nil
+	}
+	got, err := mgr.EnsureWorkbenchCLI(context.Background(), "box", config.RemoteHostEntry{ServeInstall: "npm"}, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/home/dev/.reasonix/remote/workbench/build/reasonix" {
+		t.Fatalf("binary = %q", got)
 	}
 }
 

--- a/desktop/remote_ssh_transport.go
+++ b/desktop/remote_ssh_transport.go
@@ -72,10 +72,25 @@ var errRemoteSSHProcessIsolation = errors.New("OpenSSH process isolation is unav
 type RemoteSSHTransportFactory struct {
 	SSHPath        string
 	SSHConfigPath  string
+	RemoteBinary   string
 	AskPass        *RemoteAskPassBroker
 	AskPassHelper  string
 	StderrLimit    int
 	commandContext remoteSSHCommandContext // test seam; nil uses exec.CommandContext
+}
+
+func (f *RemoteSSHTransportFactory) workbenchCommand() ([]string, error) {
+	binary, err := validateRemoteWorkbenchBinary(f.RemoteBinary)
+	if err != nil {
+		return nil, err
+	}
+	if binary != "reasonix" {
+		// OpenSSH concatenates remote command argv with spaces before the remote
+		// login shell parses it. Quote the absolute managed path as shell data so
+		// home directories containing spaces or quotes remain one safe operand.
+		binary = shellSingleQuote(binary)
+	}
+	return []string{binary, "remote", "attach-workspace", "--stdio"}, nil
 }
 
 func (f *RemoteSSHTransportFactory) Start(ctx context.Context, alias string) (*RemoteSSHTransport, error) {
@@ -90,7 +105,12 @@ func (f *RemoteSSHTransportFactory) Start(ctx context.Context, alias string) (*R
 		args = append(args, "-F", f.SSHConfigPath)
 	}
 	args = append(args, remoteSSHPolicyArgs()...)
-	args = append(args, "--", alias, "reasonix", "remote", "attach-workspace", "--stdio")
+	command, err := f.workbenchCommand()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--", alias)
+	args = append(args, command...)
 	return f.start(ctx, args)
 }
 
@@ -134,7 +154,12 @@ func (f *RemoteSSHTransportFactory) StartConfigured(ctx context.Context, alias, 
 		}
 		args = append(args, "-J", proxyJump)
 	}
-	args = append(args, "--", alias, "reasonix", "remote", "attach-workspace", "--stdio")
+	command, err := f.workbenchCommand()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--", alias)
+	args = append(args, command...)
 	return f.start(ctx, args)
 }
 
@@ -178,7 +203,12 @@ func (f *RemoteSSHTransportFactory) StartDirectConfigured(ctx context.Context, d
 		}
 		args = append(args, "-J", proxyJump)
 	}
-	args = append(args, "--", target.Host, "reasonix", "remote", "attach-workspace", "--stdio")
+	command, err := f.workbenchCommand()
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, "--", target.Host)
+	args = append(args, command...)
 	return f.start(ctx, args)
 }
 
@@ -472,7 +502,8 @@ func classifyRemoteSSHExit(stderr []byte, bootstrapStarted bool, contextErr erro
 	}
 	if !bootstrapStarted && containsAnyRemoteSSHDiagnostic(lower,
 		"reasonix: command not found", "reasonix: not found",
-		"'reasonix' is not recognized", "exec: reasonix: not found") {
+		"/reasonix: not found", "'reasonix' is not recognized", "exec: reasonix: not found",
+		"unknown remote subcommand \"attach-workspace\"") {
 		return &RemoteSSHConnectionFailure{
 			Code: RemoteSSHCLINotFound, Stage: RemoteSSHStageBootstrap,
 			Retryable: false, Message: "The Reasonix CLI was not found on the remote Host.",

--- a/desktop/remote_ssh_transport_test.go
+++ b/desktop/remote_ssh_transport_test.go
@@ -138,6 +138,28 @@ func TestRemoteSSHTransportConfiguredAliasPreservesExplicitOverrides(t *testing.
 	}
 }
 
+func TestRemoteSSHTransportUsesProvisionedWorkbenchBinary(t *testing.T) {
+	t.Setenv("GO_WANT_REMOTE_SSH_FAKE", "1")
+	t.Setenv("REMOTE_SSH_FAKE_MODE", "protocol")
+	var gotArgs []string
+	factory := &RemoteSSHTransportFactory{
+		RemoteBinary: "/home/dev user's/.reasonix/remote/workbench/abc/reasonix",
+		commandContext: func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+			gotArgs = append([]string(nil), args...)
+			return remoteSSHFakeCommand(ctx)
+		},
+	}
+	transport, err := factory.Start(context.Background(), "gpu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	wantTail := []string{"--", "gpu", shellSingleQuote(factory.RemoteBinary), "remote", "attach-workspace", "--stdio"}
+	if len(gotArgs) < len(wantTail) || !reflect.DeepEqual(gotArgs[len(gotArgs)-len(wantTail):], wantTail) {
+		t.Fatalf("argv = %#v, want tail %#v", gotArgs, wantTail)
+	}
+}
+
 func slicesContains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/desktop/remote_workbench_integration_windows_test.go
+++ b/desktop/remote_workbench_integration_windows_test.go
@@ -108,13 +108,12 @@ func TestRemoteWorkbenchWindowsToLinuxPhysicalAcceptance(t *testing.T) {
 
 	newClient := func(generation uint64) (*workbenchclient.Client, *windowsWorkbenchSSHFactory) {
 		t.Helper()
-		rawFactory, factoryErr := newWindowsWorkbenchSSHFactory(entry, func(context.Context, RemoteAskPassPrompt) (RemoteAskPassAnswer, error) {
+		factory, factoryErr := newWindowsWorkbenchSSHFactoryForBinary(entry, "reasonix", func(context.Context, RemoteAskPassPrompt) (RemoteAskPassAnswer, error) {
 			return RemoteAskPassAnswer{}, fmt.Errorf("unexpected SSH prompt; acceptance fixture must provide a trusted host key and non-interactive identity")
 		})
 		if factoryErr != nil {
 			t.Fatal(factoryErr)
 		}
-		factory := rawFactory.(*windowsWorkbenchSSHFactory)
 		brokerOpts := remotebroker.Options{
 			Catalog: func(context.Context, map[string]struct{}) ([]protocol.BrokerProviderDescriptor, error) {
 				return []protocol.BrokerProviderDescriptor{

--- a/desktop/workbench_adapter.go
+++ b/desktop/workbench_adapter.go
@@ -269,6 +269,11 @@ func (a *App) WorkbenchConnectRemote(hostID, workspace string) error {
 	if err != nil {
 		return fail(err)
 	}
+	currentBuild := protocol.CurrentBuildID(version)
+	remoteBinary, err := a.workbenchEnsureRemoteCLI(hostID, entry, currentBuild)
+	if err != nil {
+		return fail(err)
+	}
 	refs := localProviderRefs(cfg)
 	if len(refs) == 0 {
 		return fail(fmt.Errorf("no configured local chat model is available for Remote Workbench"))
@@ -305,7 +310,7 @@ func (a *App) WorkbenchConnectRemote(hostID, workspace string) error {
 	// Bind the attach transport to the workspace selected for this connection,
 	// not a possibly stale default from the persisted host entry.
 	entry.Workspace = workspace
-	factory, err := a.workbenchTransportFactory(hostID, entry)
+	factory, err := a.workbenchTransportFactory(hostID, entry, remoteBinary)
 	if err != nil {
 		return fail(err)
 	}
@@ -331,7 +336,6 @@ func (a *App) WorkbenchConnectRemote(hostID, workspace string) error {
 			return openLocalProviderStream(ctx, current, ref, effort, req)
 		},
 	}
-	currentBuild := protocol.CurrentBuildID(version)
 	buildID := map[string]any{
 		"productVersion": currentBuild.ProductVersion, "sourceRevision": currentBuild.SourceRevision,
 		"protocolVersion": currentBuild.ProtocolVersion, "schemaHash": currentBuild.SchemaHash,
@@ -430,6 +434,18 @@ func (a *App) WorkbenchConnectRemote(hostID, workspace string) error {
 	a.emitReady(a.ctx, tabID)
 	a.emitRuntimeEvent("runtime:rebuilt", tabID)
 	return nil
+}
+
+func (a *App) workbenchEnsureRemoteCLI(hostID string, entry config.RemoteHostEntry, expected protocol.BuildID) (string, error) {
+	rt, err := a.remoteRT()
+	if err != nil {
+		return "", err
+	}
+	manager, ok := rt.(*desktopRemoteManager)
+	if !ok {
+		return "", fmt.Errorf("remote manager cannot provision the Workbench CLI")
+	}
+	return manager.EnsureWorkbenchCLI(a.bootContext(), hostID, entry, expected)
 }
 
 type workbenchPeerIdentitySource interface {
@@ -662,7 +678,7 @@ func (a *App) workbenchHostIdentity(hostID string) (fingerprint, keyType, hostLa
 	return fingerprint, keyType, hostLabel, nil
 }
 
-func (a *App) workbenchTransportFactory(hostID string, entry config.RemoteHostEntry) (transport.Factory, error) {
+func (a *App) workbenchTransportFactory(hostID string, entry config.RemoteHostEntry, remoteBinary ...string) (transport.Factory, error) {
 	// Windows: system OpenSSH. Other platforms: Go SSH stdio session.
 	rt, err := a.remoteRT()
 	if err != nil {
@@ -672,7 +688,11 @@ func (a *App) workbenchTransportFactory(hostID string, entry config.RemoteHostEn
 	if !ok {
 		return nil, fmt.Errorf("remote manager cannot service SSH authentication prompts")
 	}
-	return newWorkbenchSSHFactory(entry, manager.workbenchAskPassHandler(hostID, entry))
+	binary := ""
+	if len(remoteBinary) > 0 {
+		binary = remoteBinary[0]
+	}
+	return newWorkbenchSSHFactoryForBinary(entry, binary, manager.workbenchAskPassHandler(hostID, entry))
 }
 
 func (a *App) emitWorkbenchTarget(state string, id target.Identity, gen, seq uint64, errText string) {

--- a/desktop/workbench_ssh.go
+++ b/desktop/workbench_ssh.go
@@ -21,13 +21,9 @@ import (
 	"reasonix/internal/remote/workbench/transport"
 )
 
-// newWorkbenchSSHFactory returns a transport factory for the workbench path.
+// newWorkbenchSSHFactoryForBinary returns a transport factory for the workbench path.
 // Windows uses system OpenSSH + AskPass + Job Object; other platforms use Go SSH
 // stdio running `reasonix remote attach-workspace --stdio`.
-func newWorkbenchSSHFactory(entry config.RemoteHostEntry, askPassHandler RemoteAskPassHandler) (transport.Factory, error) {
-	return newWorkbenchSSHFactoryForBinary(entry, "", askPassHandler)
-}
-
 func newWorkbenchSSHFactoryForBinary(entry config.RemoteHostEntry, remoteBinary string, askPassHandler RemoteAskPassHandler) (transport.Factory, error) {
 	binary, err := validateRemoteWorkbenchBinary(remoteBinary)
 	if err != nil {
@@ -63,10 +59,6 @@ type windowsWorkbenchSSHFactory struct {
 	handler    RemoteAskPassHandler
 	mu         sync.Mutex
 	transport  *RemoteSSHTransport
-}
-
-func newWindowsWorkbenchSSHFactory(entry config.RemoteHostEntry, handler RemoteAskPassHandler) (transport.Factory, error) {
-	return newWindowsWorkbenchSSHFactoryForBinary(entry, "reasonix", handler)
 }
 
 func newWindowsWorkbenchSSHFactoryForBinary(entry config.RemoteHostEntry, binary string, handler RemoteAskPassHandler) (transport.Factory, error) {
@@ -176,10 +168,6 @@ type goSSHWorkbenchFactory struct {
 type workbenchPeerIdentity struct {
 	KeyType     string
 	Fingerprint string
-}
-
-func newGoSSHWorkbenchFactory(entry config.RemoteHostEntry, handler RemoteAskPassHandler) (*goSSHWorkbenchFactory, error) {
-	return newGoSSHWorkbenchFactoryForBinary(entry, "reasonix", handler)
 }
 
 func newGoSSHWorkbenchFactoryForBinary(entry config.RemoteHostEntry, binary string, handler RemoteAskPassHandler) (*goSSHWorkbenchFactory, error) {

--- a/desktop/workbench_ssh.go
+++ b/desktop/workbench_ssh.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -23,22 +25,51 @@ import (
 // Windows uses system OpenSSH + AskPass + Job Object; other platforms use Go SSH
 // stdio running `reasonix remote attach-workspace --stdio`.
 func newWorkbenchSSHFactory(entry config.RemoteHostEntry, askPassHandler RemoteAskPassHandler) (transport.Factory, error) {
-	if runtime.GOOS == "windows" {
-		return newWindowsWorkbenchSSHFactory(entry, askPassHandler)
+	return newWorkbenchSSHFactoryForBinary(entry, "", askPassHandler)
+}
+
+func newWorkbenchSSHFactoryForBinary(entry config.RemoteHostEntry, remoteBinary string, askPassHandler RemoteAskPassHandler) (transport.Factory, error) {
+	binary, err := validateRemoteWorkbenchBinary(remoteBinary)
+	if err != nil {
+		return nil, err
 	}
-	return newGoSSHWorkbenchFactory(entry, askPassHandler)
+	if runtime.GOOS == "windows" {
+		return newWindowsWorkbenchSSHFactoryForBinary(entry, binary, askPassHandler)
+	}
+	return newGoSSHWorkbenchFactoryForBinary(entry, binary, askPassHandler)
+}
+
+func validateRemoteWorkbenchBinary(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "reasonix" {
+		return "reasonix", nil
+	}
+	if !strings.HasPrefix(value, "/") || path.Clean(value) != value {
+		return "", fmt.Errorf("remote Workbench binary must be an absolute POSIX path")
+	}
+	for _, r := range value {
+		if r == 0 || r == '\r' || r == '\n' {
+			return "", fmt.Errorf("remote Workbench binary path contains control characters")
+		}
+	}
+	return value, nil
 }
 
 type windowsWorkbenchSSHFactory struct {
 	entry      config.RemoteHostEntry
 	boundEntry RemoteHostEntry
 	helperPath string
+	binary     string
 	handler    RemoteAskPassHandler
 	mu         sync.Mutex
 	transport  *RemoteSSHTransport
 }
 
 func newWindowsWorkbenchSSHFactory(entry config.RemoteHostEntry, handler RemoteAskPassHandler) (transport.Factory, error) {
+	return newWindowsWorkbenchSSHFactoryForBinary(entry, "reasonix", handler)
+}
+
+func newWindowsWorkbenchSSHFactoryForBinary(entry config.RemoteHostEntry, binary string, handler RemoteAskPassHandler) (transport.Factory, error) {
 	if handler == nil {
 		return nil, fmt.Errorf("AskPass handler is required")
 	}
@@ -54,7 +85,7 @@ func newWindowsWorkbenchSSHFactory(entry config.RemoteHostEntry, handler RemoteA
 	if err != nil {
 		return nil, fmt.Errorf("resolve Desktop AskPass helper: %w", err)
 	}
-	return &windowsWorkbenchSSHFactory{entry: entry, boundEntry: hostEntry, helperPath: helperPath, handler: handler}, nil
+	return &windowsWorkbenchSSHFactory{entry: entry, boundEntry: hostEntry, helperPath: helperPath, binary: binary, handler: handler}, nil
 }
 
 func (f *windowsWorkbenchSSHFactory) Open(ctx context.Context) (transport.Stream, error) {
@@ -62,7 +93,7 @@ func (f *windowsWorkbenchSSHFactory) Open(ctx context.Context) (transport.Stream
 	if err != nil {
 		return nil, err
 	}
-	sshFactory := &RemoteSSHTransportFactory{AskPass: broker, AskPassHelper: f.helperPath}
+	sshFactory := &RemoteSSHTransportFactory{AskPass: broker, AskPassHelper: f.helperPath, RemoteBinary: f.binary}
 	var stream transport.Stream
 	stream, err = openWindowsWorkbenchSSH(ctx, sshFactory, f.entry, f.boundEntry)
 	if err != nil {
@@ -136,6 +167,7 @@ func mapConfigHostToWorkbenchEntry(entry config.RemoteHostEntry) (RemoteHostEntr
 
 type goSSHWorkbenchFactory struct {
 	entry   config.RemoteHostEntry
+	binary  string
 	handler RemoteAskPassHandler
 	mu      sync.Mutex
 	peer    remote.HostKeyQuestion
@@ -147,17 +179,21 @@ type workbenchPeerIdentity struct {
 }
 
 func newGoSSHWorkbenchFactory(entry config.RemoteHostEntry, handler RemoteAskPassHandler) (*goSSHWorkbenchFactory, error) {
+	return newGoSSHWorkbenchFactoryForBinary(entry, "reasonix", handler)
+}
+
+func newGoSSHWorkbenchFactoryForBinary(entry config.RemoteHostEntry, binary string, handler RemoteAskPassHandler) (*goSSHWorkbenchFactory, error) {
 	if strings.TrimSpace(entry.Name) == "" {
 		return nil, fmt.Errorf("remote host name is required")
 	}
 	if handler == nil {
 		return nil, fmt.Errorf("SSH secret prompt handler is required")
 	}
-	return &goSSHWorkbenchFactory{entry: entry, handler: handler}, nil
+	return &goSSHWorkbenchFactory{entry: entry, binary: binary, handler: handler}, nil
 }
 
 func (f *goSSHWorkbenchFactory) Open(ctx context.Context) (transport.Stream, error) {
-	return openGoSSHAttachWorkspace(ctx, f.entry, f.handler, func(q remote.HostKeyQuestion) {
+	return openGoSSHAttachWorkspace(ctx, f.entry, f.binary, f.handler, func(q remote.HostKeyQuestion) {
 		f.mu.Lock()
 		f.peer = q
 		f.mu.Unlock()
@@ -172,15 +208,56 @@ func (f *goSSHWorkbenchFactory) PeerIdentity() (workbenchPeerIdentity, bool) {
 
 // goSSHStream adapts a Go SSH session's stdio to transport.Stream.
 type goSSHStream struct {
-	client  *remote.Client
-	session *ssh.Session
-	stdin   io.WriteCloser
-	stdout  io.Reader
-	cancel  context.CancelFunc
+	client           *remote.Client
+	session          *ssh.Session
+	stdin            io.WriteCloser
+	stdout           io.Reader
+	stderr           *boundedRemoteSSHStderr
+	ctx              context.Context
+	cancel           context.CancelFunc
+	waitCh           chan error
+	waitMu           sync.Mutex
+	waitDone         bool
+	waitErr          error
+	bootstrapStarted bool
 }
 
-func (s *goSSHStream) Read(p []byte) (int, error)  { return s.stdout.Read(p) }
+func (s *goSSHStream) Read(p []byte) (int, error) {
+	n, err := s.stdout.Read(p)
+	if n > 0 {
+		s.waitMu.Lock()
+		s.bootstrapStarted = true
+		s.waitMu.Unlock()
+	}
+	if n == 0 && errors.Is(err, io.EOF) {
+		if waitErr := s.wait(); waitErr != nil {
+			return 0, waitErr
+		}
+	}
+	return n, err
+}
 func (s *goSSHStream) Write(p []byte) (int, error) { return s.stdin.Write(p) }
+
+func (s *goSSHStream) wait() error {
+	s.waitMu.Lock()
+	defer s.waitMu.Unlock()
+	if s.waitDone {
+		return s.waitErr
+	}
+	err := <-s.waitCh
+	s.waitDone = true
+	if err == nil {
+		return nil
+	}
+	raw, _, _ := s.stderr.snapshot()
+	var contextErr error
+	if s.ctx != nil {
+		contextErr = s.ctx.Err()
+	}
+	s.waitErr = classifyRemoteSSHExit(raw, s.bootstrapStarted, contextErr)
+	return s.waitErr
+}
+
 func (s *goSSHStream) Close() error {
 	if s.cancel != nil {
 		s.cancel()
@@ -197,7 +274,7 @@ func (s *goSSHStream) Close() error {
 	return nil
 }
 
-func openGoSSHAttachWorkspace(ctx context.Context, entry config.RemoteHostEntry, handler RemoteAskPassHandler, verified func(remote.HostKeyQuestion)) (transport.Stream, error) {
+func openGoSSHAttachWorkspace(ctx context.Context, entry config.RemoteHostEntry, remoteBinary string, handler RemoteAskPassHandler, verified func(remote.HostKeyQuestion)) (transport.Stream, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
@@ -286,7 +363,14 @@ func openGoSSHAttachWorkspace(ctx context.Context, entry config.RemoteHostEntry,
 		_ = c.Close()
 		return nil, err
 	}
-	cmd := "reasonix remote attach-workspace --stdio"
+	stderr := newBoundedRemoteSSHStderr(defaultRemoteSSHStderrLimit)
+	sess.Stderr = stderr
+	binary, err := validateRemoteWorkbenchBinary(remoteBinary)
+	if err != nil {
+		_ = c.Close()
+		return nil, err
+	}
+	cmd := shellSingleQuote(binary) + " remote attach-workspace --stdio"
 	if ws := strings.TrimSpace(entry.Workspace); ws != "" {
 		cmd = "REASONIX_ATTACH_WORKSPACE=" + shellSingleQuote(ws) + " " + cmd
 	}
@@ -299,8 +383,15 @@ func openGoSSHAttachWorkspace(ctx context.Context, entry config.RemoteHostEntry,
 		<-ctx2.Done()
 		_ = sess.Close()
 	}()
-	go func() { _ = sess.Wait(); cancel() }()
-	return &goSSHStream{client: c, session: sess, stdin: stdin, stdout: stdout, cancel: cancel}, nil
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- sess.Wait()
+		cancel()
+	}()
+	return &goSSHStream{
+		client: c, session: sess, stdin: stdin, stdout: stdout, stderr: stderr,
+		ctx: ctx, cancel: cancel, waitCh: waitCh,
+	}, nil
 }
 
 func shellSingleQuote(s string) string {

--- a/desktop/workbench_ssh_test.go
+++ b/desktop/workbench_ssh_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +14,36 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/remote/workbench/transport"
 )
+
+func TestGoSSHStreamSurfacesMissingRemoteCLI(t *testing.T) {
+	stderr := newBoundedRemoteSSHStderr(1024)
+	_, _ = stderr.Write([]byte("bash: reasonix: command not found\n"))
+	stream := &goSSHStream{
+		stdout: strings.NewReader(""), stderr: stderr, ctx: context.Background(),
+		waitCh: make(chan error, 1),
+	}
+	stream.waitCh <- errors.New("remote command exited")
+	_, err := stream.Read(make([]byte, 1))
+	var failure *RemoteSSHConnectionFailure
+	if !errors.As(err, &failure) || failure.Code != RemoteSSHCLINotFound || failure.Stage != RemoteSSHStageBootstrap {
+		t.Fatalf("Read error = %#v, want CLI_NOT_FOUND/bootstrap", err)
+	}
+	if strings.Contains(failure.Message, "command not found") {
+		t.Fatalf("safe error leaked raw stderr: %q", failure.Message)
+	}
+}
+
+func TestRemoteWorkbenchBinaryValidation(t *testing.T) {
+	got, err := validateRemoteWorkbenchBinary("/home/dev user/.reasonix/remote/workbench/abc/reasonix")
+	if err != nil || got == "" {
+		t.Fatalf("valid path = %q err=%v", got, err)
+	}
+	for _, value := range []string{"relative/reasonix", "/tmp/../bin/reasonix", "/tmp/x\n/evil"} {
+		if _, err := validateRemoteWorkbenchBinary(value); err == nil {
+			t.Fatalf("unsafe path %q accepted", value)
+		}
+	}
+}
 
 func TestMapConfigHostKeepsEverySSHConfigAliasInConfigMode(t *testing.T) {
 	for _, entry := range []config.RemoteHostEntry{

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -276,7 +276,7 @@ host          = "203.0.113.7"
 user          = "dev"
 identity_file = "~/.ssh/id_ed25519"
 workspace     = "~/projects/app"
-serve_install = "auto"            # auto | npm | upload | never
+serve_install = "auto"            # Remote CLI: auto | npm | upload | never
 
 [[remote.hosts.forwards]]
 type   = "local"                  # local (-L) | remote (-R)

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -243,7 +243,7 @@ host          = "203.0.113.7"
 user          = "dev"
 identity_file = "~/.ssh/id_ed25519"
 workspace     = "~/projects/app"
-serve_install = "auto"            # auto | npm | upload | never
+serve_install = "auto"            # 远端 CLI：auto | npm | upload | never
 
 [[remote.hosts.forwards]]
 type   = "local"                  # local (-L) | remote (-R)

--- a/docs/REMOTE_WORKBENCH.md
+++ b/docs/REMOTE_WORKBENCH.md
@@ -26,7 +26,14 @@ remote-runtime --broker RPC→ Desktop Provider Broker → local Provider / API 
   - `desktop/frontend/src/generated/remoteProtocol.generated.ts`
 - Regenerate: `go run ./cmd/remote-protocol-gen -root .`
 - Check: `go run ./cmd/remote-protocol-gen -check -root .`
-- Handshake compares the complete **Build ID** (`productVersion`, source revision, protocol version, and Schema Hash). Any mismatch is rejected before the Provider Broker is activated. V1 does not auto-install or auto-upgrade the Host CLI.
+- Before the handshake, Desktop probes the Host CLI's complete **Build ID**
+  (`productVersion`, source revision, protocol version, and Schema Hash). With
+  `serve_install = "auto"`, an exact packaged CLI is uploaded for a matching
+  platform; for a different Host platform, Desktop downloads the corresponding
+  immutable official CLI release, verifies `SHA256SUMS`, and atomically uploads
+  it to a build-specific path under `~/.reasonix/remote/workbench/`. npm is only
+  the final fallback. `npm`, `upload`, and `never` retain their explicit policy
+  meanings. Any remaining mismatch is rejected before Provider Broker activation.
 
 ## Provider Broker
 

--- a/docs/REMOTE_WORKBENCH.zh-CN.md
+++ b/docs/REMOTE_WORKBENCH.zh-CN.md
@@ -26,7 +26,7 @@ remote-runtime --broker RPC→ Desktop Provider Broker → 本机 Provider / API
   - `desktop/frontend/src/generated/remoteProtocol.generated.ts`
 - 生成：`go run ./cmd/remote-protocol-gen -root .`
 - 校验：`go run ./cmd/remote-protocol-gen -check -root .`
-- 握手严格比较完整 Build ID（产品版本、源码 revision、协议版本、Schema Hash）；任何一项不一致都会在 Provider Broker 激活前拒绝连接。V1 不自动安装或升级 Host CLI。
+- 握手前，Desktop 会探测 Host CLI 的完整 Build ID（产品版本、源码 revision、协议版本、Schema Hash）。当 `serve_install = "auto"` 时，同平台优先上传桌面随附的精确 CLI；Host 平台不同时，Desktop 会下载对应的官方不可变 CLI 发布包，校验 `SHA256SUMS`，再原子上传到 `~/.reasonix/remote/workbench/` 下按构建隔离的路径。npm 仅作为最终兜底。`npm`、`upload`、`never` 仍保持各自明确的策略语义。仍不匹配的版本会在 Provider Broker 激活前拒绝连接。
 
 ## Provider Broker
 

--- a/internal/cli/remote.go
+++ b/internal/cli/remote.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/i18n"
 	"reasonix/internal/remote"
+	"reasonix/internal/remote/protocol"
 )
 
 // remoteCommand dispatches `reasonix remote <sub>`, mirroring mcpCommand.
@@ -37,13 +39,15 @@ func remoteCommand(args []string, version string) int {
 	case "forward":
 		return remoteForwardCLI(args[1:])
 	case "serve":
-		return remoteServeCLI(args[1:])
+		return remoteServeCLI(args[1:], version)
 	case "fs":
 		return remoteFSCLI(args[1:])
 	case "attach-workspace":
 		return remoteAttachWorkspaceCLI(args[1:], version)
 	case "runtime-workbench":
 		return remoteRuntimeWorkbenchCLI(args[1:], version)
+	case "workbench-build-id":
+		return remoteWorkbenchBuildIDCLI(args[1:], version)
 	case "help", "-h", "--help":
 		remoteUsage()
 		return 0
@@ -52,6 +56,21 @@ func remoteCommand(args []string, version string) int {
 		remoteUsage()
 		return 2
 	}
+}
+
+// remoteWorkbenchBuildIDCLI is a machine-only bootstrap probe. It intentionally
+// stays out of remoteUsage: Desktop uses it to prove that the remote executable
+// exactly matches the frozen Workbench protocol before opening rpcwire stdio.
+func remoteWorkbenchBuildIDCLI(args []string, version string) int {
+	if len(args) != 0 {
+		fmt.Fprintln(os.Stderr, "usage: reasonix remote workbench-build-id")
+		return 2
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(protocol.CurrentBuildID(version)); err != nil {
+		fmt.Fprintln(os.Stderr, "workbench-build-id:", err)
+		return 1
+	}
+	return 0
 }
 
 // editUserConfig runs mutate against the user-global config file under the edit
@@ -87,7 +106,7 @@ func remoteAddCLI(args []string) int {
 	jump := fs.String("jump", "", "ProxyJump chain (OpenSSH syntax)")
 	workspace := fs.String("workspace", "", "default remote workspace directory")
 	useSSHConfig := fs.Bool("use-ssh-config", false, "layer ~/.ssh/config values under unset fields")
-	serveInstall := fs.String("serve-install", "auto", "serve install strategy: auto|npm|upload|never")
+	serveInstall := fs.String("serve-install", "auto", "remote CLI install strategy: auto|npm|upload|never")
 	passphraseEnv := fs.String("passphrase-env", "", "env var name holding the key passphrase")
 	passwordEnv := fs.String("password-env", "", "env var name holding the login password")
 	if err := fs.Parse(args[2:]); err != nil {

--- a/internal/cli/remote_cmd_test.go
+++ b/internal/cli/remote_cmd_test.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/remote/protocol"
 )
 
 func TestRemoteCommandUsageExit(t *testing.T) {
@@ -18,6 +21,29 @@ func TestRemoteCommandUsageExit(t *testing.T) {
 	}
 	if got := remoteCommand([]string{"help"}, "test"); got != 0 {
 		t.Errorf("help exit = %d, want 0", got)
+	}
+}
+
+func TestRemoteWorkbenchBuildIDCLI(t *testing.T) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+	if got := remoteCommand([]string{"workbench-build-id"}, "v1.2.3"); got != 0 {
+		t.Fatalf("exit = %d", got)
+	}
+	_ = w.Close()
+	var output bytes.Buffer
+	_, _ = output.ReadFrom(r)
+	var id protocol.BuildID
+	if err := json.Unmarshal(output.Bytes(), &id); err != nil {
+		t.Fatal(err)
+	}
+	if id.ProductVersion != "v1.2.3" || id.ProtocolVersion == "" || !strings.HasPrefix(id.SchemaHash, "sha256:") {
+		t.Fatalf("build ID = %+v", id)
 	}
 }
 

--- a/internal/cli/remote_connect.go
+++ b/internal/cli/remote_connect.go
@@ -19,6 +19,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/i18n"
 	"reasonix/internal/netclient"
+	"reasonix/internal/releaseasset"
 	"reasonix/internal/remote"
 	"reasonix/internal/remote/bootstrap"
 	"reasonix/internal/remote/forward"
@@ -199,12 +200,14 @@ func remoteConnectCLI(args []string, version string) int {
 
 	if !*noServe && !*forwardOnly {
 		res, err := bootstrap.EnsureServe(ctx, client, bootstrap.Options{
-			Workspace:   ws,
-			Install:     entry.ServeInstallMode(),
-			LocalBinary: currentExecutable(),
-			LocalGOOS:   runtime.GOOS,
-			LocalGOARCH: runtime.GOARCH,
-			MinVersion:  bootstrap.MinServeVersion,
+			Workspace:      ws,
+			Install:        entry.ServeInstallMode(),
+			LocalBinary:    currentExecutable(),
+			LocalGOOS:      runtime.GOOS,
+			LocalGOARCH:    runtime.GOARCH,
+			ProductVersion: version,
+			FetchBinary:    fetchRemoteCLIBinary,
+			MinVersion:     bootstrap.MinServeVersion,
 			Progress: func(step, detail string) {
 				fmt.Fprintf(os.Stderr, i18n.M.RemoteBootstrapStepFmt+"\n", step, detail)
 			},
@@ -279,8 +282,23 @@ func currentExecutable() string {
 	return ""
 }
 
+func fetchRemoteCLIBinary(ctx context.Context, version, goos, goarch string) ([]byte, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	client, err := netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{
+		ResponseHeaderTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	client.Timeout = 2 * time.Minute
+	return releaseasset.DownloadCLI(ctx, client, version, goos, goarch)
+}
+
 // remoteServeCLI: serve start|stop|status|logs <name>.
-func remoteServeCLI(args []string) int {
+func remoteServeCLI(args []string, version string) int {
 	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: reasonix remote serve start|stop|status|logs <name> [--workspace PATH] [-n N]")
 		return 2
@@ -323,7 +341,7 @@ func remoteServeCLI(args []string) int {
 		res, err := bootstrap.EnsureServe(ctx, client, bootstrap.Options{
 			Workspace: ws, Install: entry.ServeInstallMode(),
 			LocalBinary: currentExecutable(), LocalGOOS: runtime.GOOS, LocalGOARCH: runtime.GOARCH,
-			MinVersion: bootstrap.MinServeVersion,
+			ProductVersion: version, FetchBinary: fetchRemoteCLIBinary, MinVersion: bootstrap.MinServeVersion,
 		})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)

--- a/internal/config/remote.go
+++ b/internal/config/remote.go
@@ -32,7 +32,7 @@ type RemoteHostEntry struct {
 	PasswordEnv   string               `toml:"password_env"`
 	ProxyJump     string               `toml:"proxy_jump"`     // OpenSSH ProxyJump syntax, comma-separated chain
 	Workspace     string               `toml:"workspace"`      // default remote workspace dir
-	ServeInstall  string               `toml:"serve_install"`  // auto|npm|upload|never
+	ServeInstall  string               `toml:"serve_install"`  // remote CLI: auto|npm|upload|never
 	UseSSHConfig  bool                 `toml:"use_ssh_config"` // layer ~/.ssh/config values under unset fields
 	Forwards      []RemoteForwardEntry `toml:"forwards"`
 }

--- a/internal/releaseasset/cli.go
+++ b/internal/releaseasset/cli.go
@@ -1,0 +1,184 @@
+// Package releaseasset downloads and verifies immutable Reasonix CLI release
+// artifacts for a requested platform. It is used when a local Desktop needs to
+// provision the matching Workbench host binary without requiring Node/npm on
+// the remote machine.
+package releaseasset
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+)
+
+const (
+	cliReleaseBase       = "https://github.com/esengine/DeepSeek-Reasonix/releases/download"
+	maxCLIArchiveBytes   = int64(256 << 20)
+	maxCLIChecksumBytes  = int64(1 << 20)
+	maxExtractedCLIBytes = int64(128 << 20)
+)
+
+var cliReleaseVersionPattern = regexp.MustCompile(`^v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:preview|rc)\.(?:0|[1-9][0-9]*))?$`)
+
+// DownloadCLI downloads the exact official CLI release for version and target,
+// verifies it against SHA256SUMS from the same immutable release, and returns
+// the extracted executable bytes. V1 Remote Workbench supports Unix hosts.
+func DownloadCLI(ctx context.Context, client *http.Client, version, goos, goarch string) ([]byte, error) {
+	if !cliReleaseVersionPattern.MatchString(strings.TrimSpace(version)) {
+		return nil, fmt.Errorf("remote CLI download requires a released version, got %q", version)
+	}
+	if goos != "linux" && goos != "darwin" {
+		return nil, fmt.Errorf("remote CLI download does not support OS %q", goos)
+	}
+	if goarch != "amd64" && goarch != "arm64" {
+		return nil, fmt.Errorf("remote CLI download does not support architecture %q", goarch)
+	}
+	return downloadCLIFromBase(ctx, client, cliReleaseBase, version, goos, goarch, true)
+}
+
+func downloadCLIFromBase(ctx context.Context, client *http.Client, base, version, goos, goarch string, official bool) ([]byte, error) {
+	if client == nil {
+		return nil, errors.New("remote CLI download requires an HTTP client")
+	}
+	assetName := fmt.Sprintf("reasonix-%s-%s.tar.gz", goos, goarch)
+	releaseBase := strings.TrimRight(base, "/") + "/" + url.PathEscape(version) + "/"
+	archiveURL := releaseBase + assetName
+	checksumURL := releaseBase + "SHA256SUMS"
+
+	copyOfClient := *client
+	if official {
+		copyOfClient.CheckRedirect = validateOfficialRedirect
+	}
+	archive, err := fetchBounded(ctx, &copyOfClient, archiveURL, maxCLIArchiveBytes)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", assetName, err)
+	}
+	checksums, err := fetchBounded(ctx, &copyOfClient, checksumURL, maxCLIChecksumBytes)
+	if err != nil {
+		return nil, fmt.Errorf("download SHA256SUMS: %w", err)
+	}
+	if err := verifyChecksum(archive, assetName, checksums); err != nil {
+		return nil, err
+	}
+	binary, err := extractCLI(archive)
+	if err != nil {
+		return nil, fmt.Errorf("extract %s: %w", assetName, err)
+	}
+	return binary, nil
+}
+
+func fetchBounded(ctx context.Context, client *http.Client, rawURL string, limit int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("User-Agent", "reasonix-remote-bootstrap")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", rawURL, resp.Status)
+	}
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("asset exceeds %d-byte limit", limit)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("asset exceeds %d-byte limit", limit)
+	}
+	return data, nil
+}
+
+func verifyChecksum(data []byte, assetName string, checksums []byte) error {
+	want := ""
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || strings.TrimPrefix(fields[1], "*") != assetName {
+			continue
+		}
+		if want != "" {
+			return fmt.Errorf("SHA256SUMS contains duplicate entries for %s", assetName)
+		}
+		want = strings.ToLower(fields[0])
+	}
+	if len(want) != sha256.Size*2 {
+		return fmt.Errorf("SHA256SUMS has no valid entry for %s", assetName)
+	}
+	if _, err := hex.DecodeString(want); err != nil {
+		return fmt.Errorf("SHA256SUMS has an invalid digest for %s", assetName)
+	}
+	got := sha256.Sum256(data)
+	if hex.EncodeToString(got[:]) != want {
+		return fmt.Errorf("SHA-256 mismatch for %s", assetName)
+	}
+	return nil
+}
+
+func extractCLI(archive []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	var binary []byte
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if path.Base(path.Clean(header.Name)) != "reasonix" {
+			continue
+		}
+		if header.Typeflag != tar.TypeReg || header.Size <= 0 || header.Size > maxExtractedCLIBytes {
+			return nil, errors.New("reasonix archive entry is not a bounded regular file")
+		}
+		if binary != nil {
+			return nil, errors.New("reasonix archive contains duplicate binaries")
+		}
+		binary, err = io.ReadAll(io.LimitReader(tr, maxExtractedCLIBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(binary)) != header.Size {
+			return nil, errors.New("reasonix archive entry size mismatch")
+		}
+	}
+	if len(binary) == 0 {
+		return nil, errors.New("reasonix binary not found in archive")
+	}
+	return binary, nil
+}
+
+func validateOfficialRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("remote CLI download stopped after 10 redirects")
+	}
+	if req == nil || req.URL == nil || !strings.EqualFold(req.URL.Scheme, "https") || req.URL.User != nil || req.URL.Port() != "" {
+		return errors.New("remote CLI download refused an unsafe redirect")
+	}
+	host := strings.ToLower(strings.TrimSuffix(req.URL.Hostname(), "."))
+	if host != "github.com" && !strings.HasSuffix(host, ".githubusercontent.com") {
+		return fmt.Errorf("remote CLI download refused redirect host %q", req.URL.Host)
+	}
+	return nil
+}

--- a/internal/releaseasset/cli_test.go
+++ b/internal/releaseasset/cli_test.go
@@ -1,0 +1,87 @@
+package releaseasset
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDownloadCLIFromBaseVerifiesAndExtracts(t *testing.T) {
+	binary := []byte("reasonix-binary")
+	archive := testCLIArchive(t, binary)
+	digest := sha256.Sum256(archive)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1.2.3/reasonix-linux-arm64.tar.gz":
+			_, _ = w.Write(archive)
+		case "/v1.2.3/SHA256SUMS":
+			_, _ = fmt.Fprintf(w, "%s  reasonix-linux-arm64.tar.gz\n", hex.EncodeToString(digest[:]))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	got, err := downloadCLIFromBase(context.Background(), server.Client(), server.URL, "v1.2.3", "linux", "arm64", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, binary) {
+		t.Fatalf("binary = %q, want %q", got, binary)
+	}
+}
+
+func TestDownloadCLIFromBaseRejectsChecksumMismatch(t *testing.T) {
+	archive := testCLIArchive(t, []byte("reasonix-binary"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1.2.3/reasonix-linux-amd64.tar.gz" {
+			_, _ = w.Write(archive)
+			return
+		}
+		_, _ = fmt.Fprintf(w, "%064d  reasonix-linux-amd64.tar.gz\n", 0)
+	}))
+	defer server.Close()
+
+	if _, err := downloadCLIFromBase(context.Background(), server.Client(), server.URL, "v1.2.3", "linux", "amd64", false); err == nil {
+		t.Fatal("checksum mismatch was accepted")
+	}
+}
+
+func TestDownloadCLIRejectsDevelopmentAndUnsupportedTargets(t *testing.T) {
+	for _, test := range []struct{ version, goos, goarch string }{
+		{"dev", "linux", "amd64"},
+		{"v1.2.3", "windows", "amd64"},
+		{"v1.2.3", "linux", "riscv64"},
+	} {
+		if _, err := DownloadCLI(context.Background(), http.DefaultClient, test.version, test.goos, test.goarch); err == nil {
+			t.Fatalf("DownloadCLI(%q,%q,%q) unexpectedly succeeded", test.version, test.goos, test.goarch)
+		}
+	}
+}
+
+func testCLIArchive(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "reasonix", Mode: 0o755, Size: int64(len(binary)), Typeflag: tar.TypeReg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}

--- a/internal/remote/bootstrap/bootstrap.go
+++ b/internal/remote/bootstrap/bootstrap.go
@@ -47,14 +47,16 @@ const MinServeVersion = "flag:port-file"
 
 // Options configures EnsureServe.
 type Options struct {
-	Workspace   string                    // remote workspace path (may start with ~)
-	Install     string                    // auto|npm|upload|never
-	LocalBinary string                    // path to the running reasonix binary, for same-platform upload
-	LocalGOOS   string                    // GOOS of LocalBinary
-	LocalGOARCH string                    // GOARCH of LocalBinary
-	MinVersion  string                    // minimum acceptable remote version
-	Progress    func(step, detail string) // optional progress callback
-	Clock       func() time.Time          // nil => time.Now
+	Workspace      string                                                        // remote workspace path (may start with ~)
+	Install        string                                                        // auto|npm|upload|never
+	LocalBinary    string                                                        // path to the running reasonix binary, for same-platform upload
+	LocalGOOS      string                                                        // GOOS of LocalBinary
+	LocalGOARCH    string                                                        // GOARCH of LocalBinary
+	ProductVersion string                                                        // exact local release used for a cross-platform official download
+	FetchBinary    func(context.Context, string, string, string) ([]byte, error) // local verified release fetcher
+	MinVersion     string                                                        // minimum acceptable remote version
+	Progress       func(step, detail string)                                     // optional progress callback
+	Clock          func() time.Time                                              // nil => time.Now
 }
 
 func (o Options) progress(step, detail string) {

--- a/internal/remote/bootstrap/ensure_test.go
+++ b/internal/remote/bootstrap/ensure_test.go
@@ -22,6 +22,7 @@ import (
 // remote home, so ~ resolves to it.
 type fakeConn struct {
 	fs      *sftpfs.FS
+	sftpErr error
 	mu      sync.Mutex
 	execs   []string
 	handler func(cmd string) (remote.ExecResult, error)
@@ -34,7 +35,12 @@ func (f *fakeConn) Exec(_ context.Context, cmd string) (remote.ExecResult, error
 	return f.handler(cmd)
 }
 
-func (f *fakeConn) SFTP() (*sftpfs.FS, error) { return f.fs, nil }
+func (f *fakeConn) SFTP() (*sftpfs.FS, error) {
+	if f.sftpErr != nil {
+		return nil, f.sftpErr
+	}
+	return f.fs, nil
+}
 
 func (f *fakeConn) ranContaining(sub string) bool {
 	f.mu.Lock()

--- a/internal/remote/bootstrap/hardening_test.go
+++ b/internal/remote/bootstrap/hardening_test.go
@@ -115,3 +115,40 @@ func TestAutoInstallPreservesNPMFailureWhenNoUploadBinaryExists(t *testing.T) {
 		t.Fatalf("auto install hid the actionable failures: %v", err)
 	}
 }
+
+func TestAutoInstallDownloadsVerifiedCrossPlatformBinaryAfterNPMFailure(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	uploaded := uploadedBinPath(root)
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		switch {
+		case strings.Contains(cmd, "npm i -g reasonix"):
+			return remote.ExecResult{Stdout: []byte("npm: command not found"), ExitCode: 127}, nil
+		case strings.Contains(cmd, "command -v reasonix"):
+			if _, err := os.Stat(uploaded); err == nil {
+				return ok(uploaded + "\nreasonix v1.2.3\nportfile:yes\n")
+			}
+			return ok("\n")
+		default:
+			return ok("")
+		}
+	})
+	fetched := false
+	bin, _, err := ensureBinary(context.Background(), conn, conn.fs, Options{
+		Install: InstallAuto, LocalBinary: "/local/reasonix", LocalGOOS: "darwin", LocalGOARCH: "arm64",
+		ProductVersion: "v1.2.3",
+		FetchBinary: func(_ context.Context, version, goos, goarch string) ([]byte, error) {
+			fetched = true
+			if version != "v1.2.3" || goos != "linux" || goarch != "amd64" {
+				t.Fatalf("fetch target = %s %s/%s", version, goos, goarch)
+			}
+			return []byte("linux-amd64-cli"), nil
+		},
+	}, root, "linux", "amd64", pathsFor(root, root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fetched || bin != uploaded {
+		t.Fatalf("bin=%q fetched=%v", bin, fetched)
+	}
+}

--- a/internal/remote/bootstrap/install.go
+++ b/internal/remote/bootstrap/install.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -32,13 +33,36 @@ func ensureBinary(ctx context.Context, conn Conn, fs *sftpfs.FS, opts Options, h
 		return installViaNPM(ctx, conn, opts.MinVersion)
 	case InstallUpload:
 		return installViaUpload(ctx, conn, fs, opts, home, goos, goarch, uploaded)
-	default: // auto: try npm, then upload
+	default: // auto: try npm, packaged same-platform upload, then verified release upload
 		if b, v, nerr := installViaNPM(ctx, conn, opts.MinVersion); nerr == nil {
 			return b, v, nil
-		} else if opts.LocalBinary == "" {
-			return "", "", fmt.Errorf("%w; bootstrap: no local Reasonix CLI is available for upload", nerr)
+		} else {
+			attempts := []error{nerr}
+			if opts.LocalBinary != "" && opts.LocalGOOS == goos && opts.LocalGOARCH == goarch {
+				if b, v, uploadErr := installViaUpload(ctx, conn, fs, opts, home, goos, goarch, uploaded); uploadErr == nil {
+					return b, v, nil
+				} else {
+					attempts = append(attempts, uploadErr)
+				}
+			} else if opts.LocalBinary == "" {
+				attempts = append(attempts, errors.New("bootstrap: no local Reasonix CLI is available for upload"))
+			} else {
+				attempts = append(attempts, fmt.Errorf("bootstrap: local binary is %s/%s but remote is %s/%s", opts.LocalGOOS, opts.LocalGOARCH, goos, goarch))
+			}
+			if opts.FetchBinary != nil {
+				binary, fetchErr := opts.FetchBinary(ctx, opts.ProductVersion, goos, goarch)
+				if fetchErr == nil {
+					if b, v, uploadErr := installBinaryBytes(ctx, conn, fs, binary, opts.MinVersion, home, uploaded); uploadErr == nil {
+						return b, v, nil
+					} else {
+						attempts = append(attempts, uploadErr)
+					}
+				} else {
+					attempts = append(attempts, fmt.Errorf("bootstrap: fetch official %s/%s CLI: %w", goos, goarch, fetchErr))
+				}
+			}
+			return "", "", fmt.Errorf("bootstrap: automatic install failed: %w", errors.Join(attempts...))
 		}
-		return installViaUpload(ctx, conn, fs, opts, home, goos, goarch, uploaded)
 	}
 }
 
@@ -107,13 +131,20 @@ func installViaUpload(ctx context.Context, conn Conn, fs *sftpfs.FS, opts Option
 	if rerr != nil {
 		return "", "", fmt.Errorf("bootstrap: read local binary: %w", rerr)
 	}
+	return installBinaryBytes(ctx, conn, fs, data, opts.MinVersion, home, uploaded)
+}
+
+func installBinaryBytes(ctx context.Context, conn Conn, fs *sftpfs.FS, data []byte, minVersion, home, uploaded string) (bin, version string, err error) {
+	if len(data) == 0 {
+		return "", "", fmt.Errorf("bootstrap: downloaded binary is empty")
+	}
 	if err := fs.MkdirAll(ctx, dirOf(uploaded)); err != nil {
 		return "", "", err
 	}
 	if err := fs.WriteFileAtomic(ctx, uploaded, data, 0o755); err != nil {
 		return "", "", fmt.Errorf("bootstrap: upload binary: %w", err)
 	}
-	loc, ver := locate(ctx, conn, uploaded, opts.MinVersion)
+	loc, ver := locate(ctx, conn, uploaded, minVersion)
 	if loc == "" {
 		return "", "", fmt.Errorf("bootstrap: uploaded binary not runnable on remote")
 	}

--- a/internal/remote/bootstrap/workbench.go
+++ b/internal/remote/bootstrap/workbench.go
@@ -51,6 +51,13 @@ func EnsureWorkbenchCLI(ctx context.Context, conn Conn, opts WorkbenchOptions) (
 	if err := opts.ExpectedBuild.Validate(); err != nil {
 		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: invalid expected build: %w", err)
 	}
+	opts.progress("detect", "")
+	pathBinary, pathErr := probeWorkbenchCLI(ctx, conn, "", opts.ExpectedBuild)
+	if pathBinary != "" {
+		opts.progress("reuse", pathBinary)
+		return WorkbenchCLI{Path: pathBinary}, nil
+	}
+
 	fs, err := conn.SFTP()
 	if err != nil {
 		return WorkbenchCLI{}, err
@@ -59,28 +66,14 @@ func EnsureWorkbenchCLI(ctx context.Context, conn Conn, opts WorkbenchOptions) (
 	if err != nil {
 		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: resolve remote home: %w", err)
 	}
-	opts.progress("detect", "")
-	platform, err := conn.Exec(ctx, "uname -sm")
-	if err != nil {
-		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: uname: %w", err)
-	}
-	goos, goarch, err := ParseUname(string(platform.Stdout))
-	if err != nil {
-		return WorkbenchCLI{}, err
-	}
 	managedPath := workbenchBinPath(home, opts.ExpectedBuild)
 
-	// Prefer a previously provisioned immutable build, then an exact compatible
-	// CLI already on PATH. A stale system CLI is never allowed to answer the
-	// strict initialize handshake by accident.
+	// Reuse a previously provisioned immutable build when PATH does not already
+	// provide an exact match. A stale CLI is never allowed to answer the strict
+	// initialize handshake by accident.
 	if bin, _ := probeWorkbenchCLI(ctx, conn, managedPath, opts.ExpectedBuild); bin != "" {
 		opts.progress("reuse", bin)
 		return WorkbenchCLI{Path: bin}, nil
-	}
-	pathBinary, pathErr := probeWorkbenchCLI(ctx, conn, "", opts.ExpectedBuild)
-	if pathBinary != "" {
-		opts.progress("reuse", pathBinary)
-		return WorkbenchCLI{Path: pathBinary}, nil
 	}
 
 	strategy := strings.ToLower(strings.TrimSpace(opts.Install))
@@ -91,6 +84,14 @@ func EnsureWorkbenchCLI(ctx context.Context, conn Conn, opts WorkbenchOptions) (
 		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: no compatible remote Reasonix CLI and serve_install = never: %w", pathErr)
 	}
 	opts.progress("install", strategy)
+	platform, err := conn.Exec(ctx, "uname -sm")
+	if err != nil {
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: uname: %w", err)
+	}
+	goos, goarch, err := ParseUname(string(platform.Stdout))
+	if err != nil {
+		return WorkbenchCLI{}, err
+	}
 
 	var attempts []error
 	tryUpload := func(binary []byte, source string) (WorkbenchCLI, bool) {
@@ -207,7 +208,11 @@ func probeWorkbenchCLI(ctx context.Context, conn Conn, candidate string, expecte
 	if err := protocol.CompareBuildID(expected, actual); err != nil {
 		return "", fmt.Errorf("remote reasonix is incompatible: %w", err)
 	}
-	return strings.TrimSpace(lines[0]), nil
+	binary := strings.TrimSpace(lines[0])
+	if !path.IsAbs(binary) || path.Clean(binary) != binary {
+		return "", fmt.Errorf("remote reasonix resolved to non-absolute path %q", binary)
+	}
+	return binary, nil
 }
 
 // WorkbenchProbeCommand prints the resolved binary path followed by its strict

--- a/internal/remote/bootstrap/workbench.go
+++ b/internal/remote/bootstrap/workbench.go
@@ -1,0 +1,241 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"reasonix/internal/remote/protocol"
+	"reasonix/internal/remote/sftpfs"
+)
+
+// WorkbenchOptions configures provisioning of the exact CLI build required by
+// Remote Workbench. FetchBinary runs on the local client and returns a verified
+// official release executable for the requested remote platform.
+type WorkbenchOptions struct {
+	Install       string
+	LocalBinary   string
+	LocalGOOS     string
+	LocalGOARCH   string
+	ExpectedBuild protocol.BuildID
+	FetchBinary   func(context.Context, string, string, string) ([]byte, error)
+	Progress      func(step, detail string)
+}
+
+func (o WorkbenchOptions) progress(step, detail string) {
+	if o.Progress != nil {
+		o.Progress(step, detail)
+	}
+}
+
+// WorkbenchCLI identifies a compatible remote executable. Path is always an
+// absolute remote path so the attach command does not depend on non-interactive
+// shell PATH configuration.
+type WorkbenchCLI struct {
+	Path      string
+	Installed bool
+}
+
+// EnsureWorkbenchCLI locates or provisions the exact CLI build required by the
+// Desktop's frozen Remote Workbench protocol. Managed binaries live in a
+// build-specific directory, so concurrent versions never overwrite each other.
+func EnsureWorkbenchCLI(ctx context.Context, conn Conn, opts WorkbenchOptions) (WorkbenchCLI, error) {
+	if err := opts.ExpectedBuild.Validate(); err != nil {
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: invalid expected build: %w", err)
+	}
+	fs, err := conn.SFTP()
+	if err != nil {
+		return WorkbenchCLI{}, err
+	}
+	home, err := fs.RealPath(ctx, "~")
+	if err != nil {
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: resolve remote home: %w", err)
+	}
+	opts.progress("detect", "")
+	platform, err := conn.Exec(ctx, "uname -sm")
+	if err != nil {
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: uname: %w", err)
+	}
+	goos, goarch, err := ParseUname(string(platform.Stdout))
+	if err != nil {
+		return WorkbenchCLI{}, err
+	}
+	managedPath := workbenchBinPath(home, opts.ExpectedBuild)
+
+	// Prefer a previously provisioned immutable build, then an exact compatible
+	// CLI already on PATH. A stale system CLI is never allowed to answer the
+	// strict initialize handshake by accident.
+	if bin, _ := probeWorkbenchCLI(ctx, conn, managedPath, opts.ExpectedBuild); bin != "" {
+		opts.progress("reuse", bin)
+		return WorkbenchCLI{Path: bin}, nil
+	}
+	pathBinary, pathErr := probeWorkbenchCLI(ctx, conn, "", opts.ExpectedBuild)
+	if pathBinary != "" {
+		opts.progress("reuse", pathBinary)
+		return WorkbenchCLI{Path: pathBinary}, nil
+	}
+
+	strategy := strings.ToLower(strings.TrimSpace(opts.Install))
+	if strategy == "" {
+		strategy = InstallAuto
+	}
+	if strategy == InstallNever {
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: no compatible remote Reasonix CLI and serve_install = never: %w", pathErr)
+	}
+	opts.progress("install", strategy)
+
+	var attempts []error
+	tryUpload := func(binary []byte, source string) (WorkbenchCLI, bool) {
+		if len(binary) == 0 {
+			attempts = append(attempts, fmt.Errorf("%s returned an empty binary", source))
+			return WorkbenchCLI{}, false
+		}
+		if err := installWorkbenchBinary(ctx, fs, managedPath, binary); err != nil {
+			attempts = append(attempts, fmt.Errorf("%s upload: %w", source, err))
+			return WorkbenchCLI{}, false
+		}
+		bin, probeErr := probeWorkbenchCLI(ctx, conn, managedPath, opts.ExpectedBuild)
+		if bin == "" {
+			attempts = append(attempts, fmt.Errorf("%s verification: %w", source, probeErr))
+			return WorkbenchCLI{}, false
+		}
+		return WorkbenchCLI{Path: bin, Installed: true}, true
+	}
+	localBinary := func() ([]byte, error) {
+		if strings.TrimSpace(opts.LocalBinary) == "" {
+			return nil, errors.New("no packaged local Reasonix CLI is available")
+		}
+		if opts.LocalGOOS != goos || opts.LocalGOARCH != goarch {
+			return nil, fmt.Errorf("local binary is %s/%s but remote is %s/%s", opts.LocalGOOS, opts.LocalGOARCH, goos, goarch)
+		}
+		return os.ReadFile(opts.LocalBinary)
+	}
+	tryLocal := func() (WorkbenchCLI, bool) {
+		binary, readErr := localBinary()
+		if readErr != nil {
+			attempts = append(attempts, fmt.Errorf("packaged CLI: %w", readErr))
+			return WorkbenchCLI{}, false
+		}
+		return tryUpload(binary, "packaged CLI")
+	}
+	tryRelease := func() (WorkbenchCLI, bool) {
+		if opts.FetchBinary == nil {
+			attempts = append(attempts, errors.New("official release downloader is unavailable"))
+			return WorkbenchCLI{}, false
+		}
+		binary, fetchErr := opts.FetchBinary(ctx, opts.ExpectedBuild.ProductVersion, goos, goarch)
+		if fetchErr != nil {
+			attempts = append(attempts, fmt.Errorf("official %s/%s CLI: %w", goos, goarch, fetchErr))
+			return WorkbenchCLI{}, false
+		}
+		return tryUpload(binary, "official release CLI")
+	}
+	tryNPM := func() (WorkbenchCLI, bool) {
+		bin, installErr := installWorkbenchViaNPM(ctx, conn, opts.ExpectedBuild)
+		if installErr != nil {
+			attempts = append(attempts, installErr)
+			return WorkbenchCLI{}, false
+		}
+		return WorkbenchCLI{Path: bin, Installed: true}, true
+	}
+
+	switch strategy {
+	case InstallUpload:
+		if result, ok := tryLocal(); ok {
+			return result, nil
+		}
+	case InstallNPM:
+		if result, ok := tryNPM(); ok {
+			return result, nil
+		}
+	case InstallAuto:
+		if opts.LocalGOOS == goos && opts.LocalGOARCH == goarch {
+			if result, ok := tryLocal(); ok {
+				return result, nil
+			}
+		}
+		if result, ok := tryRelease(); ok {
+			return result, nil
+		}
+		if result, ok := tryNPM(); ok {
+			return result, nil
+		}
+	default:
+		return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap: unsupported install strategy %q", strategy)
+	}
+	return WorkbenchCLI{}, fmt.Errorf("workbench bootstrap could not provision a compatible remote CLI: %w", errors.Join(attempts...))
+}
+
+func workbenchBinPath(home string, build protocol.BuildID) string {
+	raw, _ := json.Marshal(build)
+	digest := sha256.Sum256(raw)
+	key := hex.EncodeToString(digest[:8])
+	return path.Join(remoteDir(home), "workbench", key, "reasonix")
+}
+
+func installWorkbenchBinary(ctx context.Context, fs *sftpfs.FS, destination string, binary []byte) error {
+	if err := fs.MkdirAll(ctx, path.Dir(destination)); err != nil {
+		return err
+	}
+	if err := fs.WriteFileAtomic(ctx, destination, binary, 0o755); err != nil {
+		return err
+	}
+	return nil
+}
+
+func probeWorkbenchCLI(ctx context.Context, conn Conn, candidate string, expected protocol.BuildID) (string, error) {
+	res, err := conn.Exec(ctx, WorkbenchProbeCommand(candidate))
+	if err != nil {
+		return "", err
+	}
+	lines := strings.Split(strings.TrimSpace(string(res.Stdout)), "\n")
+	if len(lines) < 2 || strings.TrimSpace(lines[0]) == "" {
+		return "", errors.New("compatible reasonix command was not found")
+	}
+	var actual protocol.BuildID
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &actual); err != nil {
+		return "", errors.New("remote reasonix does not expose a Workbench build ID")
+	}
+	if err := protocol.CompareBuildID(expected, actual); err != nil {
+		return "", fmt.Errorf("remote reasonix is incompatible: %w", err)
+	}
+	return strings.TrimSpace(lines[0]), nil
+}
+
+// WorkbenchProbeCommand prints the resolved binary path followed by its strict
+// Build ID. candidate must be either empty (PATH lookup) or an absolute managed
+// path. Every interpolated operand is POSIX-shell quoted.
+func WorkbenchProbeCommand(candidate string) string {
+	if candidate == "" {
+		return `BIN="$(command -v reasonix 2>/dev/null)"; echo "$BIN"; [ -n "$BIN" ] && "$BIN" remote workbench-build-id 2>/dev/null`
+	}
+	return fmt.Sprintf("BIN=%s; [ -x \"$BIN\" ] || BIN=; echo \"$BIN\"; [ -n \"$BIN\" ] && \"$BIN\" remote workbench-build-id 2>/dev/null", shellQuote(candidate))
+}
+
+func installWorkbenchViaNPM(ctx context.Context, conn Conn, expected protocol.BuildID) (string, error) {
+	productVersion := strings.TrimSpace(expected.ProductVersion)
+	version := strings.TrimPrefix(productVersion, "v")
+	if !semver.IsValid(productVersion) || version == "" || strings.ContainsAny(version, " \t\r\n/@") {
+		return "", fmt.Errorf("workbench bootstrap: product version %q cannot be installed through npm", expected.ProductVersion)
+	}
+	res, err := conn.Exec(ctx, "npm i -g "+shellQuote("reasonix@"+version)+" 2>&1")
+	if err != nil {
+		return "", fmt.Errorf("workbench bootstrap: npm install: %w", err)
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("workbench bootstrap: npm install failed: %s", tail(res.Stdout, 400))
+	}
+	bin, probeErr := probeWorkbenchCLI(ctx, conn, "", expected)
+	if bin == "" {
+		return "", fmt.Errorf("workbench bootstrap: npm installed an incompatible or unreachable CLI: %w", probeErr)
+	}
+	return bin, nil
+}

--- a/internal/remote/bootstrap/workbench_test.go
+++ b/internal/remote/bootstrap/workbench_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func TestEnsureWorkbenchCLIAutoDownloadsCrossPlatformRelease(t *testing.T) {
 			}
 			return ok("\n")
 		case strings.Contains(cmd, "command -v reasonix"):
-			return ok("\n")
+			return ok("bin/reasonix\n" + string(encoded) + "\n")
 		default:
 			return ok("")
 		}
@@ -89,6 +90,31 @@ func TestEnsureWorkbenchCLIReusesExactPATHBuild(t *testing.T) {
 	}
 }
 
+func TestEnsureWorkbenchCLIReusesExactPATHBuildWithoutSFTP(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	expected := testWorkbenchBuild(t)
+	encoded, _ := json.Marshal(expected)
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		if strings.Contains(cmd, "command -v reasonix") {
+			return ok("/usr/local/bin/reasonix\n" + string(encoded) + "\n")
+		}
+		return ok("\n")
+	})
+	conn.sftpErr = errors.New("SFTP subsystem is disabled")
+
+	result, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{Install: InstallNever, ExpectedBuild: expected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Path != "/usr/local/bin/reasonix" || result.Installed {
+		t.Fatalf("result = %+v", result)
+	}
+	if conn.ranContaining("uname -sm") {
+		t.Fatal("exact PATH reuse unexpectedly probed the remote platform")
+	}
+}
+
 func TestEnsureWorkbenchCLIRejectsStalePATHBuildWhenInstallNever(t *testing.T) {
 	skipOnWindows(t)
 	root := t.TempDir()
@@ -107,6 +133,24 @@ func TestEnsureWorkbenchCLIRejectsStalePATHBuildWhenInstallNever(t *testing.T) {
 	})
 	_, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{Install: InstallNever, ExpectedBuild: expected})
 	if err == nil || !strings.Contains(err.Error(), "serve_install = never") || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEnsureWorkbenchCLIRejectsRelativePATHBuild(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	expected := testWorkbenchBuild(t)
+	encoded, _ := json.Marshal(expected)
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		if strings.Contains(cmd, "command -v reasonix") {
+			return ok("bin/reasonix\n" + string(encoded) + "\n")
+		}
+		return ok("\n")
+	})
+
+	_, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{Install: InstallNever, ExpectedBuild: expected})
+	if err == nil || !strings.Contains(err.Error(), "serve_install = never") || !strings.Contains(err.Error(), "non-absolute path") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/remote/bootstrap/workbench_test.go
+++ b/internal/remote/bootstrap/workbench_test.go
@@ -1,0 +1,119 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"reasonix/internal/remote"
+	"reasonix/internal/remote/protocol"
+)
+
+func testWorkbenchBuild(t *testing.T) protocol.BuildID {
+	t.Helper()
+	id, err := protocol.NewBuildID("v1.2.3", strings.Repeat("a", 40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func TestEnsureWorkbenchCLIAutoDownloadsCrossPlatformRelease(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	expected := testWorkbenchBuild(t)
+	encoded, _ := json.Marshal(expected)
+	managed := workbenchBinPath(root, expected)
+	fetched := false
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		switch {
+		case strings.Contains(cmd, "uname -sm"):
+			return ok("Linux aarch64\n")
+		case strings.Contains(cmd, "workbench-build-id") && strings.Contains(cmd, managed):
+			if _, err := os.Stat(managed); err == nil {
+				return ok(managed + "\n" + string(encoded) + "\n")
+			}
+			return ok("\n")
+		case strings.Contains(cmd, "command -v reasonix"):
+			return ok("\n")
+		default:
+			return ok("")
+		}
+	})
+	result, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{
+		Install: InstallAuto, LocalBinary: "/local/reasonix", LocalGOOS: "darwin", LocalGOARCH: "arm64",
+		ExpectedBuild: expected,
+		FetchBinary: func(_ context.Context, version, goos, goarch string) ([]byte, error) {
+			fetched = true
+			if version != "v1.2.3" || goos != "linux" || goarch != "arm64" {
+				t.Fatalf("fetch target = %s %s/%s", version, goos, goarch)
+			}
+			return []byte("linux-arm64-cli"), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fetched || !result.Installed || result.Path != managed {
+		t.Fatalf("result=%+v fetched=%v", result, fetched)
+	}
+	data, err := os.ReadFile(managed)
+	if err != nil || string(data) != "linux-arm64-cli" {
+		t.Fatalf("managed binary = %q err=%v", data, err)
+	}
+}
+
+func TestEnsureWorkbenchCLIReusesExactPATHBuild(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	expected := testWorkbenchBuild(t)
+	encoded, _ := json.Marshal(expected)
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		switch {
+		case strings.Contains(cmd, "uname -sm"):
+			return ok("Linux x86_64\n")
+		case strings.Contains(cmd, "command -v reasonix"):
+			return ok("/usr/local/bin/reasonix\n" + string(encoded) + "\n")
+		default:
+			return ok("\n")
+		}
+	})
+	result, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{Install: InstallNever, ExpectedBuild: expected})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Path != "/usr/local/bin/reasonix" || result.Installed {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestEnsureWorkbenchCLIRejectsStalePATHBuildWhenInstallNever(t *testing.T) {
+	skipOnWindows(t)
+	root := t.TempDir()
+	expected := testWorkbenchBuild(t)
+	stale, _ := protocol.NewBuildID("v1.2.2", strings.Repeat("b", 40))
+	encoded, _ := json.Marshal(stale)
+	conn := newFakeConn(t, root, func(cmd string) (remote.ExecResult, error) {
+		switch {
+		case strings.Contains(cmd, "uname -sm"):
+			return ok("Linux x86_64\n")
+		case strings.Contains(cmd, "command -v reasonix"):
+			return ok("/usr/bin/reasonix\n" + string(encoded) + "\n")
+		default:
+			return ok("\n")
+		}
+	})
+	_, err := EnsureWorkbenchCLI(context.Background(), conn, WorkbenchOptions{Install: InstallNever, ExpectedBuild: expected})
+	if err == nil || !strings.Contains(err.Error(), "serve_install = never") || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestWorkbenchProbeCommandQuotesManagedPath(t *testing.T) {
+	cmd := WorkbenchProbeCommand("/tmp/a b/'quoted'/reasonix")
+	if strings.Contains(cmd, "BIN=/tmp/a b") || !strings.Contains(cmd, `'\''`) {
+		t.Fatalf("probe command is not safely quoted: %s", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

- provision the exact Remote Workbench Host CLI before opening the strict stdio handshake
- support fresh and cross-platform Linux/macOS SSH hosts without requiring remote npm
- preserve safe, classified SSH bootstrap failures instead of collapsing early exits into `connection closed`
- clarify that `serve_install` controls remote CLI installation and document the automatic path

Fixes #7006.

## Problem

Remote Workbench launched `reasonix remote attach-workspace --stdio` directly from the remote non-interactive shell `PATH`. Fresh hosts, stale CLI installations, and hosts whose OS or architecture differed from Desktop could therefore exit before `initialize`. The Go SSH transport discarded the session exit result and stderr, leaving users with only `initialize: workbench-desktop: connection closed`.

## Root cause

The Workbench path bypassed the existing remote bootstrap owner and had no exact Build ID provisioning step. The legacy automatic installer also fell back only to a same-platform local upload after npm, while the Go SSH adapter treated an early remote command exit as plain EOF.

## Fix

- add a hidden machine-readable `remote workbench-build-id` probe and require the complete product version, source revision, protocol version, and schema hash
- reuse an exact compatible CLI when available; otherwise install into a build-specific path under `~/.reasonix/remote/workbench/`
- download the immutable official release for the remote OS/architecture, bound downloads and extraction, validate trusted HTTPS redirects, verify `SHA256SUMS`, and atomically upload the executable
- explicitly launch the verified absolute remote binary with POSIX-safe quoting
- capture bounded SSH stderr and session exit status so missing/incompatible CLI and transport failures remain actionable without exposing raw remote output
- extend legacy `remote connect/open/serve` automatic bootstrap with the same verified cross-platform release fallback

## Security and concurrency

- managed paths are absolute, normalized, shell-quoted, and isolated by Build ID
- archive/checksum sizes and extracted executable size are bounded; duplicate or malformed archive entries are rejected
- per-host bootstrap operations share the existing server mutex, use managed connection contexts, re-check connection generation, and write binaries atomically
- stderr remains bounded and is converted to safe structured categories before reaching UI surfaces

## Compatibility

| Surface | Previous data/client behavior | Result |
| --- | --- | --- |
| `serve_install` config | Existing `auto`, `npm`, `upload`, and `never` values remain valid; missing values still default to `auto` | Backward compatible |
| Remote managed files | New binaries use an isolated Workbench subdirectory; older clients ignore it | Backward compatible |
| Workbench protocol schema | No protocol or generated schema changes | Unchanged |
| Older remote CLI | Missing Build ID probe is detected and triggers the selected provisioning policy | Recoverable |
| Wails/frontend contracts | No persisted JSON or bridge shape changes | Unchanged |

## Verification

- `go test -p 1 ./... -count=1`
- `cd desktop && go test ./... -count=1`
- `go test -race ./internal/remote/bootstrap ./internal/releaseasset ./internal/cli -run 'Workbench|AutoInstallDownloads' -count=1`
- `cd desktop && go test -race . -run 'Test(EnsureWorkbenchCLI|GoSSHStream|RemoteSSHTransport)' -count=1`
- `go vet ./internal/remote/bootstrap ./internal/releaseasset ./internal/cli`
- `cd desktop && go vet . ./cmd/...`
- `cd desktop/frontend && pnpm test:remote && pnpm typecheck && pnpm build`
- `./scripts/cache-guard.sh`
- `./scripts/check-cache-impact.sh`
- `go run ./cmd/remote-protocol-gen -check -root .`
- Windows root/Desktop and Linux arm64 cross-compilation checks

## Test boundary

The deterministic SSH/bootstrap coverage, official release artifact verification, and cross-platform compile checks pass. A live external SSH Host end-to-end run was not available in the local test environment.
