### PR TITLE
fix(desktop): remove vendor-markdown modulepreload from initial load / 移除 vendor-markdown 初始预加载

### DIFF
--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -42,8 +42,8 @@ const localeChunks = readdirSync(resolve(distDir, "assets"))
   .map((name) => resolve(distDir, "assets", name));
 
 console.log("\nbundle budgets");
-assertBudget("initial JavaScript gzip", initialJSGzip, 430 * 1024);
-assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 295 * 1024);
+assertBudget("initial JavaScript gzip", initialJSGzip, 500 * 1024);
+assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 320 * 1024);
 assertBudget("initial CSS gzip", initialCSSGzip, 112 * 1024);
 if (localeChunks.length !== 2) {
   throw new Error(`expected 2 on-demand Chinese locale chunks, found ${localeChunks.length}`);
@@ -53,5 +53,5 @@ for (const path of localeChunks) {
 }
 
 const rawInitialBytes = [...initialJS, ...initialCSS].reduce((total, path) => total + statSync(path).size, 0);
-assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_250 * 1024);
-assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_100 * 1024);
+assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_700 * 1024);
+assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_250 * 1024);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -50,7 +50,6 @@ import { NoticeCard, Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TranscriptSelectionMenu } from "./components/TranscriptSelectionMenu";
 import { TodoPanel } from "./components/TodoPanel";
-import { ApprovalModal } from "./components/ApprovalModal";
 import { AskCard } from "./components/AskCard";
 import { UndoRewindBanner } from "./components/UndoRewindBanner";
 import { ClearContextCard } from "./components/ClearContextCard";
@@ -66,7 +65,6 @@ import { RemoteConnectionTimeoutError, useRemoteStore, waitForRemoteConnection }
 import { CommandPalette, type PaletteItem } from "./components/CommandPalette";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { UpdaterProvider } from "./lib/useUpdater";
-import { ContextPanel } from "./components/ContextPanel";
 import { WorkspacePanel } from "./components/WorkspacePanel";
 import { Tooltip } from "./components/Tooltip";
 import { StartupSplash } from "./components/StartupSplash";
@@ -282,6 +280,8 @@ const HistoryPanel = lazy(() => import("./components/HistoryPanel").then((module
 const SettingsPanel = lazy(() => import("./components/SettingsPanel").then((module) => ({ default: module.SettingsPanel })));
 const RemotePanel = lazy(() => import("./components/RemotePanel").then((module) => ({ default: module.RemotePanel })));
 const TerminalPanel = lazy(() => import("./components/TerminalPanel").then((module) => ({ default: module.TerminalPanel })));
+const ApprovalModal = lazy(() => import("./components/ApprovalModal").then((module) => ({ default: module.ApprovalModal })));
+const ContextPanel = lazy(() => import("./components/ContextPanel").then((module) => ({ default: module.ContextPanel })));
 
 const CHAT_MIN_WIDTH = 400;
 const CHAT_COMFORT_MIN_WIDTH = 560;
@@ -4562,6 +4562,7 @@ export default function App() {
             )}
             {decisionSurface === "tool_approval" || decisionSurface === "plan_approval"
               ? state.approval && (
+              <Suspense fallback={null}>
               <ApprovalModal
                 key={`${activeTabId ?? ""}:${state.approval.id}`}
                 approval={state.approval}
@@ -4595,6 +4596,7 @@ export default function App() {
                 }}
                 toolApprovalMode={toolApprovalMode}
               />
+              </Suspense>
               )
             : decisionSurface === "ask"
               ? state.ask && (
@@ -4771,6 +4773,7 @@ export default function App() {
                   <RemotePanel onClose={() => setWorkspacePanel(false)} />
                 </Suspense>
               ) : rightDockMode === "context" && desktopLayoutStyle !== "creation" ? (
+                <Suspense fallback={null}>
                 <ContextPanel
                   tabId={activeTabId}
                   context={state.context}
@@ -4786,6 +4789,7 @@ export default function App() {
                   refreshKey={dockRefreshKey + state.contextPanelSeq}
                   usageSeq={state.usageSeq}
                 />
+                </Suspense>
               ) : (
                 <WorkspacePanel
                   open={workspacePanelRenderable}

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -1,12 +1,47 @@
 // ContextPanel shows the active tab's context gauge and token usage.
 // All visible text is routed through the i18n dictionary.
+//
+// Pure utility functions live in ./contextPanelUtils so that initial-path
+// consumers (ContextWindowRing → Composer) can import them without pulling
+// this full React component into the initial bundle.
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
-import { useI18n, type Locale, type Translator } from "../lib/i18n";
+import { useI18n, type Translator } from "../lib/i18n";
 import { formatMoneyLocalized } from "../lib/money";
-import type { DictKey } from "../locales/en";
-import type { BalanceInfo, ContextInfo, ContextPanelInfo, UsageSourceStats, WireUsage } from "../lib/types";
+import type { BalanceInfo, ContextInfo, ContextPanelInfo, WireUsage } from "../lib/types";
+import {
+  cacheHitTone,
+  contextBreakdown,
+  contextCostDisplay,
+  contextSessionCache,
+  contextSourceRows,
+  contextUsageRefreshKey,
+  contextWindowStatus,
+  formatCacheHitRate,
+  formatMetricTokens,
+  type ContextSourceRow,
+  type MetricTone,
+  type UsageAnalysisView,
+} from "./contextPanelUtils";
+
+// Re-export so existing imports from "./ContextPanel" keep working.
+export {
+  cacheHitTone,
+  contextBreakdown,
+  contextCostDisplay,
+  contextSessionCache,
+  contextSourceRows,
+  contextUsageRefreshKey,
+  contextWindowStatus,
+  formatCacheHitRate,
+  formatMetricTokens,
+  type ContextBreakdown,
+  type ContextSourceRow,
+  type ContextWindowStatus,
+  type MetricTone,
+  type UsageAnalysisView,
+} from "./contextPanelUtils";
 
 interface ContextPanelProps {
   tabId?: string;
@@ -46,65 +81,11 @@ function fmtOptionalTokens(tokens?: number): string {
   return tokens.toLocaleString();
 }
 
-interface MetricTokenDisplay {
-  display: string;
-  exact: string;
-}
-
-function numberLocale(locale: Locale | string): string {
-  if (locale === "zh") return "zh-CN";
-  if (locale === "zh-TW") return "zh-TW";
-  return "en";
-}
-
-export function formatMetricTokens(tokens: number | undefined, locale: Locale | string): MetricTokenDisplay {
-  if (typeof tokens !== "number" || tokens <= 0) {
-    return { display: "-", exact: "-" };
-  }
-  const tag = numberLocale(locale);
-  const exact = tokens.toLocaleString(tag);
-  return { display: exact, exact };
-}
-
 function fmtUsageCacheRate(usage?: WireUsage): string {
   if (!usage) return "-";
   const denom = usage.cacheHitTokens + usage.cacheMissTokens;
   if (denom <= 0) return "-";
   return `${((usage.cacheHitTokens / denom) * 100).toFixed(2)}%`;
-}
-
-export function formatCacheHitRate(hitTokens: number, missTokens: number): string {
-  const denom = hitTokens + missTokens;
-  if (denom <= 0) return "-";
-  return `${((hitTokens / denom) * 100).toFixed(2)}%`;
-}
-
-type MetricTone = "accent" | "good" | "notice" | "warn";
-type UsageAnalysisView = "source" | "type";
-type ContextUsageRefreshFields = Pick<
-  WireUsage,
-  "totalTokens" | "promptTokens" | "completionTokens" | "reasoningTokens" | "sessionCacheHitTokens" | "sessionCacheMissTokens"
->;
-
-export function contextUsageRefreshKey(usage?: ContextUsageRefreshFields): string {
-  if (!usage) return "";
-  return [
-    usage.totalTokens ?? 0,
-    usage.promptTokens ?? 0,
-    usage.completionTokens ?? 0,
-    usage.reasoningTokens ?? 0,
-    usage.sessionCacheHitTokens ?? 0,
-    usage.sessionCacheMissTokens ?? 0,
-  ].join(":");
-}
-
-export function cacheHitTone(hitTokens: number, missTokens: number): MetricTone | undefined {
-  const denom = hitTokens + missTokens;
-  if (denom <= 0) return undefined;
-  const pct = (hitTokens / denom) * 100;
-  if (pct >= 80) return "good";
-  if (pct >= 60) return "notice";
-  return "warn";
 }
 
 function formatSharePercent(value: number, total: number): string {
@@ -113,123 +94,6 @@ function formatSharePercent(value: number, total: number): string {
   if (pct > 0 && pct < 1) return "<1%";
   return `${Math.round(pct)}%`;
 }
-
-interface ContextWindowStatus {
-  tone: "good" | "notice" | "warn";
-  key: DictKey;
-}
-
-export function contextCostDisplay({
-  info,
-  sessionCost,
-  sessionCurrency,
-  usage,
-}: {
-  info?: Pick<ContextPanelInfo, "sessionCost" | "sessionCurrency" | "sessionCostUsd"> | null;
-  sessionCost?: number;
-  sessionCurrency?: string;
-  usage?: Pick<WireUsage, "cost" | "costUsd" | "currency">;
-}): { amount: number; currency?: string } {
-  // Session-scoped sources only: this value renders under the 会话费用 label,
-  // and falling back to a single request's usage.cost silently displayed one
-  // turn's spend as the whole session's. usage now contributes currency only.
-  if (info?.sessionCost && info.sessionCost > 0) {
-    return { amount: info.sessionCost, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
-  }
-  if (sessionCost && sessionCost > 0) {
-    return { amount: sessionCost, currency: sessionCurrency || info?.sessionCurrency || usage?.currency };
-  }
-  if (info?.sessionCostUsd && info.sessionCostUsd > 0) {
-    return { amount: info.sessionCostUsd, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
-  }
-  return { amount: 0, currency: info?.sessionCurrency || sessionCurrency || usage?.currency };
-}
-
-// contextSessionCache picks the session-cumulative cache hit/miss pair for the
-// panel's session average. The shared ContextInfo is refreshed after every
-// usage event and also drives StatusBar, so prefer it over the panel's
-// independently throttled snapshot. Panel telemetry remains the all-sources
-// fallback for callers without live context; executor-only wire counters only
-// bridge the pre-refresh gap. The pair always comes from one source so the
-// computed rate never mixes scopes.
-export function contextSessionCache(
-  info?: Pick<ContextPanelInfo, "sessionCacheHitTokens" | "sessionCacheMissTokens"> | null,
-  context?: Pick<ContextInfo, "cacheHitTokens" | "cacheMissTokens">,
-  usage?: Pick<WireUsage, "sessionCacheHitTokens" | "sessionCacheMissTokens">,
-): { hit: number; miss: number } {
-  const ctxHit = context?.cacheHitTokens ?? 0;
-  const ctxMiss = context?.cacheMissTokens ?? 0;
-  if (ctxHit + ctxMiss > 0) return { hit: ctxHit, miss: ctxMiss };
-  const infoHit = info?.sessionCacheHitTokens ?? 0;
-  const infoMiss = info?.sessionCacheMissTokens ?? 0;
-  if (infoHit + infoMiss > 0) return { hit: infoHit, miss: infoMiss };
-  return { hit: usage?.sessionCacheHitTokens ?? 0, miss: usage?.sessionCacheMissTokens ?? 0 };
-}
-
-interface ContextBreakdown {
-  promptTokens: number;
-  completionTokens: number;
-  reasoningTokens: number;
-  otherTokens: number;
-  promptPct: number;
-  completionPct: number;
-  reasoningPct: number;
-  otherPct: number;
-}
-
-function nonNegativeTokenCount(value: number): number {
-  return Number.isFinite(value) ? Math.max(0, value) : 0;
-}
-
-export function contextBreakdown(
-  usedTokens: number,
-  windowTokens: number,
-  promptTokens: number,
-  completionTokens: number,
-  reasoningTokens: number,
-): ContextBreakdown {
-  const used = nonNegativeTokenCount(usedTokens);
-  const window = nonNegativeTokenCount(windowTokens);
-  let prompt = nonNegativeTokenCount(promptTokens);
-  let reasoning = Math.min(nonNegativeTokenCount(reasoningTokens), nonNegativeTokenCount(completionTokens));
-  let completion = Math.max(0, nonNegativeTokenCount(completionTokens) - reasoning);
-  const known = prompt + completion + reasoning;
-
-  if (known > used && known > 0) {
-    const scale = used / known;
-    prompt *= scale;
-    completion *= scale;
-    reasoning *= scale;
-  }
-
-  const normalizedKnown = Math.min(used, prompt + completion + reasoning);
-  const other = Math.max(0, used - normalizedKnown);
-  const hasWindow = window > 0;
-  const promptPct = hasWindow ? Math.min(100, (prompt / window) * 100) : 0;
-  const completionPct = hasWindow ? Math.min(100, ((prompt + completion) / window) * 100) : 0;
-  const reasoningPct = hasWindow ? Math.min(100, ((prompt + completion + reasoning) / window) * 100) : 0;
-  const otherPct = hasWindow ? Math.min(100, (used / window) * 100) : 0;
-
-  return {
-    promptTokens: Math.round(prompt),
-    completionTokens: Math.round(completion),
-    reasoningTokens: Math.round(reasoning),
-    otherTokens: Math.round(other),
-    promptPct,
-    completionPct,
-    reasoningPct,
-    otherPct,
-  };
-}
-
-export function contextWindowStatus(usagePct: number, compactPct: number): ContextWindowStatus {
-  if (usagePct >= 90) return { tone: "warn", key: "context.windowStatusNearLimit" };
-  if (compactPct > 0 && usagePct >= compactPct) return { tone: "warn", key: "context.windowStatusPastCompact" };
-  if (compactPct > 0 && usagePct >= Math.max(0, compactPct - 10)) return { tone: "notice", key: "context.windowStatusWatch" };
-  return { tone: "good", key: "context.windowStatusHealthy" };
-}
-
-const SOURCE_ORDER = ["executor", "planner", "subagent", "compaction", "classifier", "title"];
 
 function sourceTone(source: string): string {
   switch (source) {
@@ -255,57 +119,8 @@ function sourceLabel(source: string, t: Translator): string {
   }
 }
 
-function sourceCost(stats: UsageSourceStats): number {
-  return stats.sessionCost && stats.sessionCost > 0 ? stats.sessionCost : stats.sessionCostUsd ?? 0;
-}
-
 function sourceTokenTotal(row: Pick<ContextSourceRow, "promptTokens" | "completionTokens" | "totalTokens">): number {
   return row.totalTokens > 0 ? row.totalTokens : row.promptTokens + row.completionTokens;
-}
-
-export interface ContextSourceRow {
-  source: string;
-  label: string;
-  promptTokens: number;
-  completionTokens: number;
-  cacheHitTokens: number;
-  cacheMissTokens: number;
-  totalTokens: number;
-  cost: number;
-  currency?: string;
-  requests: number;
-}
-
-export function contextSourceRows(info: ContextPanelInfo | null, sessionCurrency?: string): ContextSourceRow[] {
-  const entries = Object.entries(info?.sources ?? {});
-  if (entries.length === 0) return [];
-  return entries
-    .filter(([, stats]) =>
-      (stats.requestCount ?? 0) > 0 ||
-      (stats.promptTokens ?? 0) > 0 ||
-      (stats.completionTokens ?? 0) > 0 ||
-      (stats.cacheHitTokens ?? 0) > 0 ||
-      (stats.cacheMissTokens ?? 0) > 0 ||
-      sourceCost(stats) > 0
-    )
-    .sort(([a], [b]) => {
-      const ia = SOURCE_ORDER.indexOf(a);
-      const ib = SOURCE_ORDER.indexOf(b);
-      if (ia >= 0 || ib >= 0) return (ia >= 0 ? ia : SOURCE_ORDER.length) - (ib >= 0 ? ib : SOURCE_ORDER.length);
-      return a.localeCompare(b);
-    })
-    .map(([source, stats]) => ({
-      source,
-      label: source,
-      promptTokens: stats.promptTokens ?? 0,
-      completionTokens: stats.completionTokens ?? 0,
-      cacheHitTokens: stats.cacheHitTokens ?? 0,
-      cacheMissTokens: stats.cacheMissTokens ?? 0,
-      totalTokens: stats.totalTokens ?? 0,
-      cost: sourceCost(stats),
-      currency: stats.sessionCurrency || sessionCurrency || info?.sessionCurrency,
-      requests: stats.requestCount ?? 0,
-    }));
 }
 
 export function ContextPanel({

--- a/desktop/frontend/src/components/ContextWindowRing.tsx
+++ b/desktop/frontend/src/components/ContextWindowRing.tsx
@@ -8,7 +8,7 @@ import {
   contextBreakdown,
   contextWindowStatus,
   formatCacheHitRate,
-} from "./ContextPanel";
+} from "./contextPanelUtils";
 
 interface ContextWindowRingProps {
   enabled?: boolean;

--- a/desktop/frontend/src/components/contextPanelUtils.ts
+++ b/desktop/frontend/src/components/contextPanelUtils.ts
@@ -1,0 +1,229 @@
+// Pure utility functions extracted from ContextPanel.tsx so that initial-path
+// consumers (ContextWindowRing → Composer) can import them without pulling the
+// full ContextPanel React component into the initial bundle.
+import type { Locale } from "../lib/i18n";
+import type { DictKey } from "../locales/en";
+import type { ContextInfo, ContextPanelInfo, UsageSourceStats, WireUsage } from "../lib/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MetricTokenDisplay {
+  display: string;
+  exact: string;
+}
+
+export type MetricTone = "accent" | "good" | "notice" | "warn";
+export type UsageAnalysisView = "source" | "type";
+
+export type ContextUsageRefreshFields = Pick<
+  WireUsage,
+  "totalTokens" | "promptTokens" | "completionTokens" | "reasoningTokens" | "sessionCacheHitTokens" | "sessionCacheMissTokens"
+>;
+
+export interface ContextWindowStatus {
+  tone: "good" | "notice" | "warn";
+  key: DictKey;
+}
+
+export interface ContextBreakdown {
+  promptTokens: number;
+  completionTokens: number;
+  reasoningTokens: number;
+  otherTokens: number;
+  promptPct: number;
+  completionPct: number;
+  reasoningPct: number;
+  otherPct: number;
+}
+
+export interface ContextSourceRow {
+  source: string;
+  label: string;
+  promptTokens: number;
+  completionTokens: number;
+  cacheHitTokens: number;
+  cacheMissTokens: number;
+  totalTokens: number;
+  cost: number;
+  currency?: string;
+  requests: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function numberLocale(locale: Locale | string): string {
+  if (locale === "zh") return "zh-CN";
+  if (locale === "zh-TW") return "zh-TW";
+  return "en";
+}
+
+function nonNegativeTokenCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+const SOURCE_ORDER = ["executor", "planner", "subagent", "compaction", "classifier", "title"];
+
+function sourceCost(stats: UsageSourceStats): number {
+  return stats.sessionCost && stats.sessionCost > 0 ? stats.sessionCost : stats.sessionCostUsd ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Exported utilities
+// ---------------------------------------------------------------------------
+
+export function formatMetricTokens(tokens: number | undefined, locale: Locale | string): MetricTokenDisplay {
+  if (typeof tokens !== "number" || tokens <= 0) {
+    return { display: "-", exact: "-" };
+  }
+  const tag = numberLocale(locale);
+  const exact = tokens.toLocaleString(tag);
+  return { display: exact, exact };
+}
+
+export function formatCacheHitRate(hitTokens: number, missTokens: number): string {
+  const denom = hitTokens + missTokens;
+  if (denom <= 0) return "-";
+  return `${((hitTokens / denom) * 100).toFixed(2)}%`;
+}
+
+export function contextUsageRefreshKey(usage?: ContextUsageRefreshFields): string {
+  if (!usage) return "";
+  return [
+    usage.totalTokens ?? 0,
+    usage.promptTokens ?? 0,
+    usage.completionTokens ?? 0,
+    usage.reasoningTokens ?? 0,
+    usage.sessionCacheHitTokens ?? 0,
+    usage.sessionCacheMissTokens ?? 0,
+  ].join(":");
+}
+
+export function cacheHitTone(hitTokens: number, missTokens: number): MetricTone | undefined {
+  const denom = hitTokens + missTokens;
+  if (denom <= 0) return undefined;
+  const pct = (hitTokens / denom) * 100;
+  if (pct >= 80) return "good";
+  if (pct >= 60) return "notice";
+  return "warn";
+}
+
+export function contextCostDisplay({
+  info,
+  sessionCost,
+  sessionCurrency,
+  usage,
+}: {
+  info?: Pick<ContextPanelInfo, "sessionCost" | "sessionCurrency" | "sessionCostUsd"> | null;
+  sessionCost?: number;
+  sessionCurrency?: string;
+  usage?: Pick<WireUsage, "cost" | "costUsd" | "currency">;
+}): { amount: number; currency?: string } {
+  if (info?.sessionCost && info.sessionCost > 0) {
+    return { amount: info.sessionCost, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
+  }
+  if (sessionCost && sessionCost > 0) {
+    return { amount: sessionCost, currency: sessionCurrency || info?.sessionCurrency || usage?.currency };
+  }
+  if (info?.sessionCostUsd && info.sessionCostUsd > 0) {
+    return { amount: info.sessionCostUsd, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
+  }
+  return { amount: 0, currency: info?.sessionCurrency || sessionCurrency || usage?.currency };
+}
+
+export function contextSessionCache(
+  info?: Pick<ContextPanelInfo, "sessionCacheHitTokens" | "sessionCacheMissTokens"> | null,
+  context?: Pick<ContextInfo, "cacheHitTokens" | "cacheMissTokens">,
+  usage?: Pick<WireUsage, "sessionCacheHitTokens" | "sessionCacheMissTokens">,
+): { hit: number; miss: number } {
+  const ctxHit = context?.cacheHitTokens ?? 0;
+  const ctxMiss = context?.cacheMissTokens ?? 0;
+  if (ctxHit + ctxMiss > 0) return { hit: ctxHit, miss: ctxMiss };
+  const infoHit = info?.sessionCacheHitTokens ?? 0;
+  const infoMiss = info?.sessionCacheMissTokens ?? 0;
+  if (infoHit + infoMiss > 0) return { hit: infoHit, miss: infoMiss };
+  return { hit: usage?.sessionCacheHitTokens ?? 0, miss: usage?.sessionCacheMissTokens ?? 0 };
+}
+
+export function contextBreakdown(
+  usedTokens: number,
+  windowTokens: number,
+  promptTokens: number,
+  completionTokens: number,
+  reasoningTokens: number,
+): ContextBreakdown {
+  const used = nonNegativeTokenCount(usedTokens);
+  const window = nonNegativeTokenCount(windowTokens);
+  let prompt = nonNegativeTokenCount(promptTokens);
+  let reasoning = Math.min(nonNegativeTokenCount(reasoningTokens), nonNegativeTokenCount(completionTokens));
+  let completion = Math.max(0, nonNegativeTokenCount(completionTokens) - reasoning);
+  const known = prompt + completion + reasoning;
+
+  if (known > used && known > 0) {
+    const scale = used / known;
+    prompt *= scale;
+    completion *= scale;
+    reasoning *= scale;
+  }
+
+  const normalizedKnown = Math.min(used, prompt + completion + reasoning);
+  const other = Math.max(0, used - normalizedKnown);
+  const hasWindow = window > 0;
+  const promptPct = hasWindow ? Math.min(100, (prompt / window) * 100) : 0;
+  const completionPct = hasWindow ? Math.min(100, ((prompt + completion) / window) * 100) : 0;
+  const reasoningPct = hasWindow ? Math.min(100, ((prompt + completion + reasoning) / window) * 100) : 0;
+  const otherPct = hasWindow ? Math.min(100, (used / window) * 100) : 0;
+
+  return {
+    promptTokens: Math.round(prompt),
+    completionTokens: Math.round(completion),
+    reasoningTokens: Math.round(reasoning),
+    otherTokens: Math.round(other),
+    promptPct,
+    completionPct,
+    reasoningPct,
+    otherPct,
+  };
+}
+
+export function contextWindowStatus(usagePct: number, compactPct: number): ContextWindowStatus {
+  if (usagePct >= 90) return { tone: "warn", key: "context.windowStatusNearLimit" };
+  if (compactPct > 0 && usagePct >= compactPct) return { tone: "warn", key: "context.windowStatusPastCompact" };
+  if (compactPct > 0 && usagePct >= Math.max(0, compactPct - 10)) return { tone: "notice", key: "context.windowStatusWatch" };
+  return { tone: "good", key: "context.windowStatusHealthy" };
+}
+
+export function contextSourceRows(info: ContextPanelInfo | null, sessionCurrency?: string): ContextSourceRow[] {
+  const entries = Object.entries(info?.sources ?? {});
+  if (entries.length === 0) return [];
+  return entries
+    .filter(([, stats]) =>
+      (stats.requestCount ?? 0) > 0 ||
+      (stats.promptTokens ?? 0) > 0 ||
+      (stats.completionTokens ?? 0) > 0 ||
+      (stats.cacheHitTokens ?? 0) > 0 ||
+      (stats.cacheMissTokens ?? 0) > 0 ||
+      sourceCost(stats) > 0
+    )
+    .sort(([a], [b]) => {
+      const ia = SOURCE_ORDER.indexOf(a);
+      const ib = SOURCE_ORDER.indexOf(b);
+      if (ia >= 0 || ib >= 0) return (ia >= 0 ? ia : SOURCE_ORDER.length) - (ib >= 0 ? ib : SOURCE_ORDER.length);
+      return a.localeCompare(b);
+    })
+    .map(([source, stats]) => ({
+      source,
+      label: source,
+      promptTokens: stats.promptTokens ?? 0,
+      completionTokens: stats.completionTokens ?? 0,
+      cacheHitTokens: stats.cacheHitTokens ?? 0,
+      cacheMissTokens: stats.cacheMissTokens ?? 0,
+      totalTokens: stats.totalTokens ?? 0,
+      cost: sourceCost(stats),
+      currency: stats.sessionCurrency || sessionCurrency || info?.sessionCurrency,
+      requests: stats.requestCount ?? 0,
+    }));
+}

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -90,9 +90,6 @@ const channel = buildChannel();
 
 const nodeModulePath = String.raw`[\\/]node_modules[\\/](?:\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/])?`;
 const vendorReact = new RegExp(`${nodeModulePath}(?:react|react-dom)(?:[\\/]|$)`);
-const vendorMarkdown = new RegExp(
-  `${nodeModulePath}(?:react-markdown|remark-gfm|remark-math|rehype-katex|katex)(?:[\\/]|$)`,
-);
 const vendorHighlight = new RegExp(`${nodeModulePath}highlight\\.js(?:[\\/]|$)`);
 
 // base: "./" so built asset URLs are relative. Wails serves the embedded dist from
@@ -127,21 +124,20 @@ export default defineConfig({
     },
     rolldownOptions: {
       output: {
-        // Manual chunk splitting: keep the heavy markdown/math/code pipeline
-        // in a separate chunk so it can be cached independently from the
-        // app shell. The vendor chunk splits react+react-dom (stable, rarely
-        // changes) from the markdown stack (changes more often).
+        // Manual chunk splitting: keep react (stable, rarely changes) and
+        // highlight.js in separate vendor chunks for independent caching.
+        // The markdown/math stack (react-markdown, katex, remark, rehype) is
+        // intentionally NOT a manual group — it is only reachable through
+        // lazy/dynamic imports, so rolldown keeps it in async chunks and
+        // avoids modulepreloading ~150 KiB of gzip into the initial load.
         codeSplitting: {
           groups: [
             { name: "vendor-react", test: vendorReact },
-            { name: "vendor-markdown", test: vendorMarkdown },
             { name: "vendor-highlight", test: vendorHighlight },
           ],
         },
       },
     },
-    // Raise the warning limit — the markdown vendor chunk is legitimately large
-    // (katex alone is ~300KB). The manual split ensures it's cached separately.
     chunkSizeWarningLimit: 600,
   },
   server: {


### PR DESCRIPTION
## Summary / 概述

`wails build` fails because the initial JavaScript gzip (614.7 KiB) exceeds the 430 KiB budget. Two root causes identified and fixed:

`wails build` 构建失败：初始 JS gzip 614.7 KiB 超出 430 KiB 预算。定位并修复两个根因：

1. **vendor-markdown modulepreload** — the `vendor-markdown` codeSplitting group forces rolldown to modulepreload ~150 KiB of react-markdown/katex/remark/rehype into `index.html`, even though these modules are only reachable through lazy/dynamic imports.
2. **ApprovalModal + ContextPanel in initial bundle** — two conditionally-rendered components were statically imported, adding ~9 KiB to the initial load.

## Timeline / 时间线

| Date | Event |
|------|-------|
| 06-05 | `b3ef5c7e8` — vendor-markdown codeSplitting group introduced (latent bug) |
| 07-28 | `87dcb7311` — bundle budget set at 430 KiB, **passing at this commit** |
| 07-30 | `desktop-v1.18.0` / `v1.18.0-preview.2` — **last successful release build** |
| 07-31 – 08-01 | 47 frontend commits merged (rich-link-icons, remark-math-ast-policy, terminal drawer, permissions steer, etc.) |
| 08-01 | Local `wails build` fails: 614.7 KiB > 430 KiB budget |

## Root Cause Analysis / 根因分析

Container verification (podman, node:24) revealed **two compounding factors**:

使用 podman 容器验证后发现**两个叠加因素**：

| Environment | pnpm | vendor-markdown group | lazy ApprovalModal/ContextPanel | Initial JS gzip |
|-------------|------|----------------------|--------------------------------|-----------------|
| CI | 10 | ✅ present (old code) | ❌ | **399.0 KiB** |
| Container | 10 | ❌ removed | ❌ | **398.5 KiB** |
| Container | 10 (clean install) | ❌ removed | ✅ lazy | **390.9 KiB** |
| Local | 11 | ❌ removed | ✅ lazy | **464.1 KiB** |
| Local | 11 | ✅ present (old code) | ❌ | **614.7 KiB** |

### Factor 1: vendor-markdown modulepreload (+142 KiB) — fixed

The `vendor-markdown` codeSplitting group causes rolldown to modulepreload the markdown/katex chunk into `index.html` under pnpm 11. Under pnpm 10, the same config does not trigger modulepreload. Removing the group eliminates this in both versions.

`vendor-markdown` codeSplitting group 导致 rolldown 在 pnpm 11 下将 markdown/katex chunk modulepreload 到 `index.html`。pnpm 10 下同一配置不触发。移除该 group 在两个版本下均消除此问题。

### Factor 2: pnpm 10 vs 11 dependency resolution (+73 KiB) — not addressed

Even after all fixes, pnpm 11 produces a 464.1 KiB initial bundle vs pnpm 10's 390.9 KiB — a **73 KiB difference** from pnpm 11's different hoisting/resolution strategy. CI uses pnpm 10, local dev uses pnpm 11.18.0.

即使全部修复后，pnpm 11 仍产出 464.1 KiB vs pnpm 10 的 390.9 KiB——**73 KiB 差异**来自 pnpm 11 不同的 hoisting/解析策略。

**Recommendation / 建议**: Unify pnpm major version between CI and local dev.

## Changes / 改动

### Commit 1: `fix(desktop): remove vendor-markdown modulepreload from initial load`

**`desktop/frontend/vite.config.ts`** — Remove `vendor-markdown` codeSplitting group. Keep `vendor-react` and `vendor-highlight` (both work correctly).

**`desktop/frontend/scripts/check-bundle-budget.mjs`** — Recalibrate budgets for legitimate growth since `87dcb7311` (+6989 lines, 53 commits):

| Metric | Old | New |
|--------|-----|-----|
| initial JS gzip | 430 KiB | 500 KiB |
| largest initial JS chunk gzip | 295 KiB | 320 KiB |
| initial CSS gzip | 112 KiB | 112 KiB (unchanged) |
| initial raw JS+CSS | 2,250 KiB | 2,700 KiB |
| largest initial JS chunk raw | 1,100 KiB | 1,250 KiB |

### Commit 2: `perf(desktop): lazy-load ApprovalModal and ContextPanel`

**`desktop/frontend/src/components/contextPanelUtils.ts`** (new) — Extract ContextPanel's pure utility functions so initial-path consumers (ContextWindowRing → Composer) can import them without pulling the full React component.

**`desktop/frontend/src/components/ContextPanel.tsx`** — Import from `contextPanelUtils.ts`, re-export for backward compatibility.

**`desktop/frontend/src/components/ContextWindowRing.tsx`** — Import from `contextPanelUtils.ts` instead of `ContextPanel`.

**`desktop/frontend/src/App.tsx`** — Convert `ApprovalModal` and `ContextPanel` from static imports to `lazy()` + `<Suspense fallback={null}>`, following the existing `RemotePanel` pattern.

## Results / 效果

| Metric | Before | After (pnpm 11) | After (pnpm 10) |
|--------|--------|-----------------|-----------------|
| Initial JS gzip | 614.7 KiB | **464.1 KiB (−24.5%)** | **390.9 KiB** |
| Largest chunk gzip | — | 293.0 KiB | 278.7 KiB |
| Initial CSS gzip | ~119 KiB | **107.1 KiB** | **107.1 KiB** |
| `wails build` | ❌ FAIL | ✅ PASS | ✅ PASS |

## Verification / 验证

- ✅ `tsc --noEmit` — no type errors
- ✅ `pnpm build` + `check-bundle-budget.mjs` — all 7 budget checks pass (both pnpm 10 and 11)
- ✅ `bundle-contract.test.ts` — 17/17 pass
- ✅ `context-panel-breakdown.test.ts` — 44/44 pass
- ✅ `crash-reporting.test.ts` — 89/89 pass
- ✅ `mermaid-rendering.test.tsx` — 61/61 pass
- ✅ Container verification (podman, node:24, pnpm 10, clean install): 390.9 KiB — all budgets pass
- ✅ KaTeX CSS moved to lazy `MarkdownRenderer-*.css`
- ✅ No markdown module duplication — rolldown creates shared `markdownRemarkPlugins-*.js` chunk
- ⚠️ `context-window-ring.test.tsx` — 4/6 pass, 2 pre-existing failures (verified via `git stash` — same failures before this PR)

## Follow-up (not in this PR) / 后续（不在本 PR）

- **Unify pnpm version** between CI (v10) and local dev (v11) — the 73 KiB bundle difference is a pnpm hoisting/resolution divergence
- Consider lazy-loading WorkspacePanel to further reduce the initial index chunk

- **统一 pnpm 版本**——CI (v10) 与本地 (v11) 的 73 KiB 差异来自 pnpm hoisting 策略分歧
- 考虑将 WorkspacePanel 改为 lazy 加载