### PR TITLE
Prepare v1.19.0 stable release notes / 准备 v1.19.0 稳定版发布说明

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -2,6 +2,674 @@
   "schemaVersion": 1,
   "releases": [
     {
+      "version": "1.19.0",
+      "date": "2026-08-01",
+      "channel": "stable",
+      "title": {
+        "en": "New provider support, hardened sessions, and refined desktop experience",
+        "zh": "新增提供商支持、加固会话与优化桌面体验"
+      },
+      "summary": {
+        "en": "This release adds DeepSeek Anthropic and Responses API support, improves model polling performance, hardens session durability and permission handling, and fixes several desktop UI issues.",
+        "zh": "此版本新增 DeepSeek Anthropic 与 Responses API 支持，改进模型轮询性能，加固会话持久性与权限处理，并修复多项桌面 UI 问题。"
+      },
+      "surfaces": [
+        "desktop"
+      ],
+      "guides": [
+        {
+          "title": {
+            "en": "CLI Guide",
+            "zh": "CLI 指南"
+          },
+          "body": {
+            "en": "Command-line interface usage and options.",
+            "zh": "命令行界面用法与选项。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/CLI.md"
+        },
+        {
+          "title": {
+            "en": "CLI Guide (Chinese)",
+            "zh": "CLI 指南（中文）"
+          },
+          "body": {
+            "en": "Command-line interface usage and options in Chinese.",
+            "zh": "命令行界面用法与选项（中文）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/CLI.zh-CN.md"
+        },
+        {
+          "title": {
+            "en": "User Guide",
+            "zh": "用户指南"
+          },
+          "body": {
+            "en": "General usage guide.",
+            "zh": "通用使用指南。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/GUIDE.md"
+        },
+        {
+          "title": {
+            "en": "User Guide (Chinese)",
+            "zh": "用户指南（中文）"
+          },
+          "body": {
+            "en": "General usage guide in Chinese.",
+            "zh": "通用使用指南（中文）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/GUIDE.zh-CN.md"
+        },
+        {
+          "title": {
+            "en": "Reasoning Providers",
+            "zh": "推理提供商"
+          },
+          "body": {
+            "en": "Configuration for reasoning providers.",
+            "zh": "推理提供商的配置。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/REASONING_PROVIDERS.md"
+        },
+        {
+          "title": {
+            "en": "Release Process",
+            "zh": "发布流程"
+          },
+          "body": {
+            "en": "Documentation for releasing new versions.",
+            "zh": "发布新版本的文档。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/RELEASING.md"
+        },
+        {
+          "title": {
+            "en": "Remote Workbench",
+            "zh": "远程工作台"
+          },
+          "body": {
+            "en": "Guide for using Remote Workbench.",
+            "zh": "使用远程工作台的指南。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/REMOTE_WORKBENCH.md"
+        },
+        {
+          "title": {
+            "en": "Remote Workbench (Chinese)",
+            "zh": "远程工作台（中文）"
+          },
+          "body": {
+            "en": "Guide for using Remote Workbench in Chinese.",
+            "zh": "使用远程工作台的指南（中文）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/REMOTE_WORKBENCH.zh-CN.md"
+        },
+        {
+          "title": {
+            "en": "SignPath Windows Admin SOP",
+            "zh": "SignPath Windows 管理员 SOP"
+          },
+          "body": {
+            "en": "Standard operating procedure for Windows admin with SignPath.",
+            "zh": "使用 SignPath 的 Windows 管理员标准操作流程。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/SIGNPATH_WINDOWS_ADMIN_SOP.md"
+        },
+        {
+          "title": {
+            "en": "Specification",
+            "zh": "规格说明"
+          },
+          "body": {
+            "en": "Technical specification.",
+            "zh": "技术规格说明。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/SPEC.md"
+        },
+        {
+          "title": {
+            "en": "Specification (Chinese)",
+            "zh": "规格说明（中文）"
+          },
+          "body": {
+            "en": "Technical specification in Chinese.",
+            "zh": "技术规格说明（中文）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/SPEC.zh-CN.md"
+        },
+        {
+          "title": {
+            "en": "Tool Approval Modes",
+            "zh": "工具审批模式"
+          },
+          "body": {
+            "en": "Documentation for tool approval modes.",
+            "zh": "工具审批模式的文档。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/TOOL_APPROVAL_MODES.md"
+        },
+        {
+          "title": {
+            "en": "Tool Approval Modes (Chinese)",
+            "zh": "工具审批模式（中文）"
+          },
+          "body": {
+            "en": "Documentation for tool approval modes in Chinese.",
+            "zh": "工具审批模式的文档（中文）。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/ee2ace1dbd3967d387ff50247e15e7fb53feaa0f/docs/TOOL_APPROVAL_MODES.zh-CN.md"
+        }
+      ],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": {
+            "en": "DeepSeek Anthropic-compatible endpoint support",
+            "zh": "支持 DeepSeek Anthropic 兼容端点"
+          },
+          "body": {
+            "en": "Added an optional preset for DeepSeek's Anthropic-compatible Messages endpoint, with correct handling of unsigned reasoning blocks, text-only input, and automatic caching.",
+            "zh": "新增可选的 DeepSeek Anthropic 兼容 Messages 端点预设，正确处理无符号推理块、纯文本输入和自动缓存。"
+          },
+          "refs": [
+            7103
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Hardened Responses API support",
+            "zh": "加固的 Responses API 支持"
+          },
+          "body": {
+            "en": "Added a new provider kind for the Responses API, including stateless mode for DeepSeek, correct tool call handling, and automatic retry on expired response IDs.",
+            "zh": "新增 Responses API 提供商类型，包括 DeepSeek 的无状态模式、正确的工具调用处理以及过期响应 ID 的自动重试。"
+          },
+          "refs": [
+            7099
+          ]
+        },
+        {
+          "kind": "improved",
+          "title": {
+            "en": "Faster model list loading in Settings",
+            "zh": "设置中模型列表加载更快"
+          },
+          "body": {
+            "en": "Model polling is now batched and cached, reducing jank when many providers are configured. Stale writes are prevented with fingerprint-based invalidation.",
+            "zh": "模型轮询现在批量进行并缓存，减少配置多个提供商时的卡顿。通过基于指纹的失效机制防止过期写入。"
+          },
+          "refs": [
+            7094
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Session and permission hardening",
+            "zh": "会话与权限加固"
+          },
+          "body": {
+            "en": "Fixed several regressions in session durability, steering, and permission handling, including fail-closed headless Ask and bounded parallel task batches.",
+            "zh": "修复了会话持久性、转向和权限处理中的多个回归，包括无头 Ask 的失败关闭和并行任务批次限制。"
+          },
+          "refs": [
+            7077,
+            7074,
+            7078
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Desktop UI fixes",
+            "zh": "桌面 UI 修复"
+          },
+          "body": {
+            "en": "Fixed terminal drawer layout, decision card overflow, and preserved pasted text and file reference cards across session switches.",
+            "zh": "修复了终端抽屉布局、决策卡片溢出，以及切换会话后粘贴文本和文件引用卡片的保留问题。"
+          },
+          "refs": [
+            7072,
+            7069,
+            7064
+          ]
+        }
+      ],
+      "changes": {
+        "new": [
+          {
+            "title": {
+              "en": "DeepSeek Anthropic preset",
+              "zh": "DeepSeek Anthropic 预设"
+            },
+            "body": {
+              "en": "Added optional preset for DeepSeek's Anthropic-compatible endpoint.",
+              "zh": "新增可选的 DeepSeek Anthropic 兼容端点预设。"
+            },
+            "refs": [
+              7103
+            ]
+          },
+          {
+            "title": {
+              "en": "Responses API provider kind",
+              "zh": "Responses API 提供商类型"
+            },
+            "body": {
+              "en": "Added new provider kind for Responses API with DeepSeek stateless mode.",
+              "zh": "新增 Responses API 提供商类型，支持 DeepSeek 无状态模式。"
+            },
+            "refs": [
+              7099
+            ]
+          },
+          {
+            "title": {
+              "en": "Supervisor status and hard overrides for ACP",
+              "zh": "ACP 监督者状态与硬覆盖"
+            },
+            "body": {
+              "en": "Added explicit ACP runtime overrides and session status reporting.",
+              "zh": "新增显式 ACP 运行时覆盖和会话状态报告。"
+            },
+            "refs": [
+              7097
+            ]
+          },
+          {
+            "title": {
+              "en": "DeepSeek V4 Flash low reasoning effort",
+              "zh": "DeepSeek V4 Flash 低推理档位"
+            },
+            "body": {
+              "en": "Exposed 'low' reasoning effort for deepseek-v4-flash.",
+              "zh": "为 deepseek-v4-flash 开放 'low' 推理档位。"
+            },
+            "refs": [
+              7102
+            ]
+          },
+          {
+            "title": {
+              "en": "Rich Markdown links",
+              "zh": "富样式 Markdown 链接"
+            },
+            "body": {
+              "en": "Added icons and concise labels for GitHub, external, and mail links in assistant messages.",
+              "zh": "在助手消息中为 GitHub、外部和邮件链接添加图标和简洁标签。"
+            },
+            "refs": [
+              6976
+            ]
+          }
+        ],
+        "improved": [
+          {
+            "title": {
+              "en": "Model polling performance",
+              "zh": "模型轮询性能"
+            },
+            "body": {
+              "en": "Batched and cached model polling, with stale write prevention.",
+              "zh": "批量并缓存模型轮询，防止过期写入。"
+            },
+            "refs": [
+              7094
+            ]
+          },
+          {
+            "title": {
+              "en": "DeepSeek truncated reply continuation",
+              "zh": "DeepSeek 截断回复继续"
+            },
+            "body": {
+              "en": "Automatically continue truncated DeepSeek replies using assistant-prefix completion.",
+              "zh": "使用助手前缀补全自动继续被截断的 DeepSeek 回复。"
+            },
+            "refs": [
+              7101
+            ]
+          },
+          {
+            "title": {
+              "en": "Gemini thought signature preservation",
+              "zh": "Gemini 思维签名保留"
+            },
+            "body": {
+              "en": "Preserved Gemini thought signatures in function calling, including legacy format.",
+              "zh": "在函数调用中保留 Gemini 思维签名，包括旧格式。"
+            },
+            "refs": [
+              7092
+            ]
+          },
+          {
+            "title": {
+              "en": "Remote Workbench CLI provisioning",
+              "zh": "远程工作台 CLI 供给"
+            },
+            "body": {
+              "en": "Provision exact CLI version over SSH with verified downloads.",
+              "zh": "通过 SSH 提供精确 CLI 版本，并验证下载。"
+            },
+            "refs": [
+              7105
+            ]
+          },
+          {
+            "title": {
+              "en": "Terminal drawer redesign",
+              "zh": "终端抽屉重新设计"
+            },
+            "body": {
+              "en": "Terminal is now an independent bottom drawer with resize handle and animation.",
+              "zh": "终端现在是独立的底部抽屉，带有调整大小手柄和动画。"
+            },
+            "refs": [
+              7072
+            ]
+          },
+          {
+            "title": {
+              "en": "Stable/Preview release history separation",
+              "zh": "稳定版/预览版发布历史分离"
+            },
+            "body": {
+              "en": "Separated release histories for stable and preview channels.",
+              "zh": "分离稳定版和预览版的发布历史。"
+            },
+            "refs": [
+              7076
+            ]
+          },
+          {
+            "title": {
+              "en": "True-color detection on Windows Terminal",
+              "zh": "Windows Terminal 真彩色检测"
+            },
+            "body": {
+              "en": "Fixed true-color detection and unified color capability handling.",
+              "zh": "修复真彩色检测并统一颜色能力处理。"
+            },
+            "refs": [
+              7053
+            ]
+          }
+        ],
+        "fixed": [
+          {
+            "title": {
+              "en": "GLM Coding Plan default model",
+              "zh": "GLM Coding Plan 默认模型"
+            },
+            "body": {
+              "en": "Fixed default model for GLM Coding Plan Anthropic presets.",
+              "zh": "修复 GLM Coding Plan Anthropic 预设的默认模型。"
+            },
+            "refs": [
+              7113
+            ]
+          },
+          {
+            "title": {
+              "en": "Advisory diagnostics evidence gate",
+              "zh": "诊断建议证据门"
+            },
+            "body": {
+              "en": "Preserved advisory diagnostics without weakening evidence requirements.",
+              "zh": "保留诊断建议而不削弱证据要求。"
+            },
+            "refs": [
+              7086
+            ]
+          },
+          {
+            "title": {
+              "en": "Session durability and steering",
+              "zh": "会话持久性与转向"
+            },
+            "body": {
+              "en": "Hardened session append durability and late steering admission.",
+              "zh": "加固会话追加持久性和延迟转向准入。"
+            },
+            "refs": [
+              7074
+            ]
+          },
+          {
+            "title": {
+              "en": "Permission handling",
+              "zh": "权限处理"
+            },
+            "body": {
+              "en": "Made guarded execution predictable, including fail-closed headless Ask.",
+              "zh": "使受保护执行可预测，包括无头 Ask 的失败关闭。"
+            },
+            "refs": [
+              7078
+            ]
+          },
+          {
+            "title": {
+              "en": "Inline math policy",
+              "zh": "行内数学策略"
+            },
+            "body": {
+              "en": "Moved inline math classification to remark AST, fixing currency vs math detection.",
+              "zh": "将行内数学分类迁移到 remark AST，修复货币与数学检测。"
+            },
+            "refs": [
+              7073
+            ]
+          },
+          {
+            "title": {
+              "en": "LaTeX copy preservation",
+              "zh": "LaTeX 复制保留"
+            },
+            "body": {
+              "en": "Preserved original LaTeX when copying rendered math.",
+              "zh": "复制渲染数学时保留原始 LaTeX。"
+            },
+            "refs": [
+              7007
+            ]
+          },
+          {
+            "title": {
+              "en": "Session recovery and Qwen context limits",
+              "zh": "会话恢复与 Qwen 上下文限制"
+            },
+            "body": {
+              "en": "Hardened session recovery and applied per-model context limits for Qwen presets.",
+              "zh": "加固会话恢复并为 Qwen 预设应用按模型上下文限制。"
+            },
+            "refs": [
+              6971
+            ]
+          },
+          {
+            "title": {
+              "en": "Pasted text and file reference cards",
+              "zh": "粘贴文本与文件引用卡片"
+            },
+            "body": {
+              "en": "Preserved pasted text and file reference inline cards across session switches.",
+              "zh": "切换会话后保留粘贴文本和文件引用内联卡片。"
+            },
+            "refs": [
+              7064
+            ]
+          },
+          {
+            "title": {
+              "en": "Right panel and status bar data persistence",
+              "zh": "右侧栏和状态栏数据持久化"
+            },
+            "body": {
+              "en": "Persisted latest executor turn context fill and token breakdown across session switches.",
+              "zh": "切换会话后持久化最新执行器回合的上下文填充和令牌分解。"
+            },
+            "refs": [
+              6995
+            ]
+          },
+          {
+            "title": {
+              "en": "Decision card overflow",
+              "zh": "决策卡片溢出"
+            },
+            "body": {
+              "en": "Prevented decision cards from overflowing behind the status bar.",
+              "zh": "防止决策卡片溢出到状态栏后面。"
+            },
+            "refs": [
+              7069
+            ]
+          },
+          {
+            "title": {
+              "en": "Detached runtime reattachment",
+              "zh": "分离运行时重新附加"
+            },
+            "body": {
+              "en": "Fixed rapid session switching by reattaching detached runtimes.",
+              "zh": "通过重新附加分离运行时修复快速切换会话。"
+            },
+            "refs": [
+              6957
+            ]
+          },
+          {
+            "title": {
+              "en": "Empty effort levels encoding",
+              "zh": "空 effort 级别编码"
+            },
+            "body": {
+              "en": "Encoded empty effort levels as an array instead of null in workspace catalog.",
+              "zh": "在工作区目录中将空 effort 级别编码为数组而非 null。"
+            },
+            "refs": [
+              6992
+            ]
+          },
+          {
+            "title": {
+              "en": "BranchMeta scope pinning",
+              "zh": "BranchMeta 范围固定"
+            },
+            "body": {
+              "en": "Pinned session scope on new sessions to prevent project-to-global misclassification.",
+              "zh": "固定新会话的范围，防止项目到全局的错误分类。"
+            },
+            "refs": [
+              6967
+            ]
+          },
+          {
+            "title": {
+              "en": "Anthropic-style usage fallback",
+              "zh": "Anthropic 风格用量回退"
+            },
+            "body": {
+              "en": "Normalized Anthropic-style usage counters in OpenAI-compatible responses.",
+              "zh": "在 OpenAI 兼容响应中规范化 Anthropic 风格用量计数器。"
+            },
+            "refs": [
+              6940
+            ]
+          },
+          {
+            "title": {
+              "en": "Goal idle reset on blocked",
+              "zh": "阻塞时重置空闲计数"
+            },
+            "body": {
+              "en": "Reset idleTurns on [goal:blocked] to prevent premature idle intercept.",
+              "zh": "在 [goal:blocked] 时重置 idleTurns，防止过早空闲拦截。"
+            },
+            "refs": [
+              6960
+            ]
+          },
+          {
+            "title": {
+              "en": "Stale report sweep age calculation",
+              "zh": "过期报告清理年龄计算"
+            },
+            "body": {
+              "en": "Take sweep age from whole report body, not version field, and require bug label.",
+              "zh": "从整个报告正文而非版本字段计算清理年龄，并要求 bug 标签。"
+            },
+            "refs": [
+              7060
+            ]
+          },
+          {
+            "title": {
+              "en": "Ask before closing old reports",
+              "zh": "关闭旧报告前询问"
+            },
+            "body": {
+              "en": "Ask reporters to verify before closing reports too old to confirm.",
+              "zh": "在关闭无法确认的旧报告前询问报告者验证。"
+            },
+            "refs": [
+              7058
+            ]
+          },
+          {
+            "title": {
+              "en": "Release verification requests",
+              "zh": "发布验证请求"
+            },
+            "body": {
+              "en": "Ask reporters to verify on the release that carries their fix.",
+              "zh": "要求报告者在包含其修复的发布上验证。"
+            },
+            "refs": [
+              7057
+            ]
+          }
+        ]
+      },
+      "upgrade": [],
+      "risks": [],
+      "contributors": [
+        "SivanCola",
+        "Oumuamu4",
+        "xianyu-sheng",
+        "clearnature",
+        "rixzkiye",
+        "jackijianxa",
+        "HaoyueQin",
+        "EMEEEEMMMM",
+        "erphenheimer",
+        "myipanta",
+        "wqshan-cn",
+        "Nath-Vikky",
+        "zdjmrq",
+        "ikelvingo",
+        "esengine"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.19.0",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/v1.18.0...desktop-v1.19.0",
+        "download": "https://reasonix.io/?download=desktop&channel=stable#start"
+      },
+      "releaseId": "1.19.0",
+      "baseVersion": "1.19.0",
+      "status": "reviewed",
+      "previousRelease": "1.18.0",
+      "builds": {
+        "cli": "v1.19.0",
+        "desktop": "v1.19.0",
+        "npm": "1.19.0"
+      }
+    },
+    {
       "version": "1.19.0-preview.1",
       "date": "2026-08-01",
       "channel": "prerelease",


### PR DESCRIPTION
## Summary

- Add the reviewed bilingual release catalog record for stable `1.19.0`.
- Reuse the reviewed product-change record from `1.19.0-preview.1` because `v1.18.0` and `v1.18.0-preview.2` share the same source SHA.
- Bind CLI `v1.19.0`, Desktop `v1.19.0`, and npm `1.19.0` to one stable identity.

The hosted generator returned empty content twice, while two live fallback generations were rejected by schema validation. This PR therefore applies a deterministic identity/channel transformation to the already validated preview record.

## Verification

- `node scripts/release-notes.mjs validate`
- `node --test scripts/release-notes.test.mjs`
- `git diff --check`
- Release-record privacy scan

## Cache impact

Cache-impact: none - release catalog data only.

Cache-guard: N/A

System-prompt-review: N/A