### PR TITLE
Fix Preview Desktop orchestrator authorization / 修复预览版 Desktop 编排授权

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -142,6 +142,7 @@ jobs:
           RELEASE_CHANNEL: ${{ steps.release.outputs.channel }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           IN_ORCHESTRATED: ${{ inputs.orchestrated }}
+          IN_ORCHESTRATOR: ${{ inputs.orchestrator }}
           APPROVED_SHA: ${{ inputs.approved_sha }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}
@@ -557,6 +558,7 @@ jobs:
           RELEASE_CHANNEL: ${{ needs.resolve.outputs.channel }}
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
           IN_ORCHESTRATED: ${{ inputs.orchestrated }}
+          IN_ORCHESTRATOR: ${{ inputs.orchestrator }}
           APPROVED_SHA: ${{ needs.resolve.outputs.sha }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}
@@ -715,6 +717,7 @@ jobs:
           RELEASE_CHANNEL: ${{ needs.resolve.outputs.channel }}
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
           IN_ORCHESTRATED: ${{ inputs.orchestrated }}
+          IN_ORCHESTRATOR: ${{ inputs.orchestrator }}
           APPROVED_SHA: ${{ needs.resolve.outputs.sha }}
           CALLER_EVENT_NAME: ${{ github.event_name }}
           CALLER_REF: ${{ github.ref }}

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -78,6 +78,7 @@ grep -Eq 'options: \[stable, preview\]' "$repo_root/.github/workflows/release-de
 grep -Eq '^  resolve:$' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Eq 'sha:.*steps\.candidate\.outputs\.sha' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'bash scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflows/release-desktop.yml"
+[ "$(grep -Fc 'IN_ORCHESTRATOR: ${{ inputs.orchestrator }}' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]
 [ "$(grep -Fc 'name: Revalidate immutable Desktop candidate' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'ref: ${{ needs.resolve.outputs.sha }}' "$repo_root/.github/workflows/release-desktop.yml")" -ge 4 ]
 [ "$(grep -Fc 'path: release-control' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
@@ -934,6 +935,20 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 		CALLER_SHA="$approved_sha" CALLER_WORKFLOW_SHA="$approved_sha" \
 		"$desktop_candidate_resolver"
 	grep -Eq '^sha='"$approved_sha"'$' "$test_root/desktop-preview-candidate.out"
+	GITHUB_OUTPUT="$test_root/desktop-orchestrated-preview-candidate.out" \
+		RELEASE_CHANNEL=preview RELEASE_TAG=desktop-v1.3.0-preview.42 \
+		IN_ORCHESTRATED=true IN_ORCHESTRATOR=preview APPROVED_SHA="$approved_sha" \
+		"$desktop_candidate_resolver"
+	grep -Eq '^sha='"$approved_sha"'$' "$test_root/desktop-orchestrated-preview-candidate.out"
+	if GITHUB_OUTPUT="$test_root/desktop-wrong-orchestrator-candidate.out" \
+		RELEASE_CHANNEL=preview RELEASE_TAG=desktop-v1.3.0-preview.42 \
+		IN_ORCHESTRATED=true IN_ORCHESTRATOR=stable APPROVED_SHA="$approved_sha" \
+		"$desktop_candidate_resolver" >"$test_root/desktop-wrong-orchestrator-candidate.log" 2>&1; then
+		echo "stable orchestrator unexpectedly authorized a Desktop Preview candidate" >&2
+		exit 1
+	fi
+	grep -Eq 'stable orchestrator cannot authorize a Desktop preview candidate' \
+		"$test_root/desktop-wrong-orchestrator-candidate.log"
 	if GITHUB_OUTPUT="$test_root/desktop-unprotected-candidate.out" \
 		RELEASE_CHANNEL=preview RELEASE_TAG=desktop-v1.3.0-preview.42 \
 		IN_ORCHESTRATED=false CALLER_EVENT_NAME=workflow_dispatch \
@@ -988,6 +1003,12 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 	fi
 	grep -Eq 'Desktop Preview must use current main-v2' \
 		"$test_root/desktop-stale-preview-candidate.log"
+	GITHUB_OUTPUT="$test_root/desktop-orchestrated-preview-recovery-candidate.out" \
+		RELEASE_CHANNEL=preview RELEASE_TAG=desktop-v1.3.0-preview.42 \
+		IN_ORCHESTRATED=true IN_ORCHESTRATOR=preview APPROVED_SHA="$approved_sha" \
+		"$desktop_candidate_resolver"
+	grep -Eq '^sha='"$approved_sha"'$' \
+		"$test_root/desktop-orchestrated-preview-recovery-candidate.out"
 	GITHUB_OUTPUT="$test_root/desktop-stable-recovery-candidate.out" \
 		RELEASE_CHANNEL=stable RELEASE_TAG=desktop-v1.2.3 \
 		IN_ORCHESTRATED=false CALLER_EVENT_NAME=workflow_dispatch \

--- a/scripts/resolve-desktop-candidate.sh
+++ b/scripts/resolve-desktop-candidate.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 channel="${RELEASE_CHANNEL:?RELEASE_CHANNEL is required}"
 tag="${RELEASE_TAG:?RELEASE_TAG is required}"
 orchestrated="${IN_ORCHESTRATED:-false}"
+orchestrator="${IN_ORCHESTRATOR:-}"
 approved_sha="${APPROVED_SHA:-}"
 caller_event="${CALLER_EVENT_NAME:-}"
 caller_ref="${CALLER_REF:-}"
@@ -25,6 +26,19 @@ true | false) ;;
 	exit 2
 	;;
 esac
+if [ "$orchestrated" = "true" ]; then
+	case "$orchestrator" in
+	stable | preview) ;;
+	*)
+		echo "::error::IN_ORCHESTRATOR must be stable or preview for an orchestrated Desktop release, got: $orchestrator" >&2
+		exit 2
+		;;
+	esac
+	if [ "$orchestrator" != "$channel" ]; then
+		echo "::error::the $orchestrator orchestrator cannot authorize a Desktop $channel candidate" >&2
+		exit 1
+	fi
+fi
 case "$require_current_main" in
 true | false) ;;
 *)
@@ -53,10 +67,6 @@ stable)
 preview)
 	if [[ ! "$tag" =~ $preview_tag_pattern ]]; then
 		echo "::error::Preview Desktop candidate requires desktop-vMAJOR.MINOR.PATCH-preview.N: $tag" >&2
-		exit 1
-	fi
-	if [ "$orchestrated" = "true" ]; then
-		echo "::error::the stable orchestrator cannot authorize a Desktop Preview candidate" >&2
 		exit 1
 	fi
 	;;
@@ -111,7 +121,7 @@ if [ "$channel" = "stable" ]; then
 elif git show-ref --verify --quiet "refs/tags/$tag"; then
 	echo "::error::Desktop Preview uses an immutable asset directory, not a Git tag: $tag" >&2
 	exit 1
-elif [ "$require_current_main" = "true" ] && [ "$candidate" != "$main_sha" ]; then
+elif [ "$orchestrated" != "true" ] && [ "$require_current_main" = "true" ] && [ "$candidate" != "$main_sha" ]; then
 	echo "::error::Desktop Preview must use current main-v2 $main_sha, got: $candidate" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- Forward the trusted `stable|preview` orchestrator identity into every Desktop candidate resolution step.
- Allow the protected Preview orchestrator to authorize its approved immutable SHA while preserving ancestry, tag, workflow-ref, and checkout checks.
- Cover Preview orchestrator success, wrong-orchestrator rejection, and recovery after `main-v2` advances.

## Issues

The live `v1.19.0-preview.1` release exposed this blocker: `release-preview.yml` correctly called the reusable Desktop workflow with `orchestrator: preview`, but the candidate resolver treated every `orchestrated=true` call as Stable and failed with `the stable orchestrator cannot authorize a Desktop Preview candidate`.

## Verification

- `bash scripts/release-workflows.test.sh`
- `git diff --check`
- Patch privacy scan

## Cache impact

Cache-impact: none - release control-plane authorization only; no runtime prompt, tool schema, provider request, or ordering changes.

Cache-guard: N/A

System-prompt-review: N/A