### PR TITLE
Make CLI release recovery idempotent / 让 CLI 发布恢复具备幂等性

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,46 @@ jobs:
           RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
           APPROVED_SHA: ${{ needs.resolve.outputs.sha }}
         run: bash scripts/verify-release-tag.sh
+      - name: Decide whether CLI artifacts need publication
+        id: publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+          PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          validation_channel="$CHANNEL"
+          if [ "$CHANNEL" = "stable" ] && [ "$PRERELEASE" = "true" ]; then
+            validation_channel=any
+          fi
+          release_json=/tmp/existing-cli-release.json
+          release_error=/tmp/existing-cli-release.error
+          checksums=/tmp/existing-cli-release-SHA256SUMS
+          if gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+            >"$release_json" 2>"$release_error"; then
+            gh release download "$TAG" -R "${{ github.repository }}" \
+              --pattern SHA256SUMS --output "$checksums"
+            decision="$(
+              bash scripts/decide-cli-release-publication.sh \
+                "$validation_channel" "$TAG" "${{ github.repository }}" \
+                "$release_json" "$checksums"
+            )"
+            echo "existing CLI release $TAG is complete and checksum-bound; reusing it"
+          elif grep -Eiq 'HTTP 404|Not Found' "$release_error"; then
+            decision="$(
+              bash scripts/decide-cli-release-publication.sh \
+                "$validation_channel" "$TAG" "${{ github.repository }}" - -
+            )"
+            echo "CLI release $TAG does not exist; GoReleaser will publish it"
+          else
+            cat "$release_error" >&2
+            exit 1
+          fi
+          test "$decision" = "publish" -o "$decision" = "reuse"
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
       - uses: goreleaser/goreleaser-action@v7
+        if: ${{ steps.publication.outputs.decision == 'publish' }}
         with:
           version: '~> v2'
           args: release --clean

--- a/scripts/decide-cli-release-publication.sh
+++ b/scripts/decide-cli-release-publication.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+channel="${1:-}"
+tag="${2:-}"
+repository="${3:-}"
+release_json="${4:-}"
+checksums="${5:-}"
+
+stable_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+preview_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.(0|[1-9][0-9]*)$'
+release_tag_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*)?)?$'
+
+case "$channel" in
+	stable)
+		tag_pattern="$stable_tag_pattern"
+		expected_prerelease=false
+		;;
+	preview)
+		tag_pattern="$preview_tag_pattern"
+		expected_prerelease=true
+		;;
+	any)
+		tag_pattern="$release_tag_pattern"
+		expected_prerelease=any
+		;;
+	*)
+		echo "CLI publication channel must be stable, preview, or any: $channel" >&2
+		exit 2
+		;;
+esac
+
+if [[ ! "$tag" =~ $tag_pattern ]]; then
+	echo "invalid $channel CLI publication tag: $tag" >&2
+	exit 1
+fi
+if [[ ! "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+	echo "invalid GitHub repository: $repository" >&2
+	exit 1
+fi
+
+if [ "$release_json" = "-" ]; then
+	echo publish
+	exit 0
+fi
+if [ ! -f "$release_json" ]; then
+	echo "CLI GitHub release record does not exist: $release_json" >&2
+	exit 1
+fi
+if [ ! -f "$checksums" ]; then
+	echo "CLI GitHub release checksum asset does not exist: $checksums" >&2
+	exit 1
+fi
+
+required_assets='[
+  "reasonix-darwin-amd64.tar.gz",
+  "reasonix-darwin-arm64.tar.gz",
+  "reasonix-linux-amd64.tar.gz",
+  "reasonix-linux-arm64.tar.gz",
+  "reasonix-windows-amd64.zip",
+  "reasonix-windows-arm64.zip",
+  "SHA256SUMS"
+]'
+
+jq -e \
+	--arg tag "$tag" \
+	--arg repository "$repository" \
+	--arg expected_prerelease "$expected_prerelease" \
+	--argjson required "$required_assets" '
+	(type == "object") and
+	(.tag_name == $tag) and
+	(.draft == false) and
+	(if $expected_prerelease == "any"
+		then (.prerelease | type == "boolean")
+		else (.prerelease == ($expected_prerelease == "true"))
+	end) and
+	(.html_url == ("https://github.com/" + $repository + "/releases/tag/" + $tag)) and
+	(.assets | type == "array") and
+	(.assets | length == ($required | length)) and
+	((.assets | map(.name) | sort) == ($required | sort)) and
+	(.assets | all(
+		(type == "object") and
+		(.state == "uploaded") and
+		(.size | type == "number" and . > 0 and . <= 1073741824 and floor == .) and
+		(.browser_download_url ==
+			("https://github.com/" + $repository + "/releases/download/" + $tag + "/" + .name)) and
+		(.digest | type == "string" and test("^sha256:[0-9a-f]{64}$"))
+	))
+' "$release_json" >/dev/null || {
+	echo "existing CLI GitHub release is incomplete or does not match approved release $tag" >&2
+	exit 1
+}
+
+expected_checksums="$(mktemp)"
+actual_checksums="$(mktemp)"
+trap 'rm -f "$expected_checksums" "$actual_checksums"' EXIT
+
+jq -r '
+	.assets[] |
+	select(.name != "SHA256SUMS") |
+	((.digest | sub("^sha256:"; "")) + "  " + .name)
+' "$release_json" | LC_ALL=C sort >"$expected_checksums"
+
+if ! awk '
+	BEGIN { valid = 1 }
+	$0 !~ /^[0-9a-f]{64}  reasonix-(darwin|linux|windows)-(amd64|arm64)\.(tar\.gz|zip)$/ {
+		valid = 0
+	}
+	{ print }
+	END { if (NR != 6 || !valid) exit 1 }
+' "$checksums" | LC_ALL=C sort >"$actual_checksums"; then
+	echo "existing CLI SHA256SUMS is malformed or incomplete" >&2
+	exit 1
+fi
+
+if ! cmp -s "$expected_checksums" "$actual_checksums"; then
+	echo "existing CLI SHA256SUMS does not match GitHub asset digests" >&2
+	exit 1
+fi
+
+checksum_asset_digest="$(
+	jq -er '.assets[] | select(.name == "SHA256SUMS") | .digest | sub("^sha256:"; "")' \
+		"$release_json"
+)"
+downloaded_checksum_digest="$(shasum -a 256 "$checksums" | awk '{print $1}')"
+if [ "$downloaded_checksum_digest" != "$checksum_asset_digest" ]; then
+	echo "downloaded CLI SHA256SUMS digest does not match GitHub release metadata" >&2
+	exit 1
+fi
+
+echo reuse

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -954,6 +954,10 @@ jq 'del(.downloads)' "$test_root/desktop-rolling-preview.json" \
 	>"$test_root/desktop-legacy-preview.json"
 bash "$desktop_validator" legacy-preview "$desktop_preview_version" \
 	"https://dl.reasonix.io/desktop-preview/" "$test_root/desktop-legacy-preview.json"
+jq 'del(.release_notes_url, .downloads)' "$desktop_preview_manifest" \
+	>"$test_root/desktop-legacy-preview-immutable.json"
+bash "$desktop_validator" legacy-preview "$desktop_preview_version" \
+	"$desktop_preview_base" "$test_root/desktop-legacy-preview-immutable.json"
 jq 'del(.downloads)' "$desktop_stable_manifest" >"$test_root/desktop-legacy-stable.json"
 bash "$desktop_validator" legacy-stable "$desktop_stable_version" \
 	"$desktop_stable_base" "$test_root/desktop-legacy-stable.json"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -235,6 +235,9 @@ grep -Fq "group: release-cli-\${{ inputs.channel || 'stable' }}" "$cli_release_w
 grep -Fq 'scripts/decide-cli-pointer-update.sh' "$cli_release_workflow"
 grep -Fq 'scripts/validate-cli-release-manifest.sh' "$cli_release_workflow"
 grep -Fq 'scripts/compare-cli-release-manifests.sh' "$cli_release_workflow"
+grep -Eq 'name: Decide whether CLI artifacts need publication' "$cli_release_workflow"
+grep -Fq 'scripts/decide-cli-release-publication.sh' "$cli_release_workflow"
+grep -Fq "if: \${{ steps.publication.outputs.decision == 'publish' }}" "$cli_release_workflow"
 grep -Fq 'immutable CLI release metadata for $TAG already exists with different content' "$cli_release_workflow"
 grep -Fq 'cmp -s /tmp/cli-release.json /tmp/cli-release.pointer.json' "$cli_release_workflow"
 grep -Eq 'internal CLI release .*Stable and Preview pointers remain unchanged' "$cli_release_workflow"
@@ -298,6 +301,86 @@ for asset in \
 	SHA256SUMS; do
 	grep -Fq "\"$asset\"" "$cli_release_workflow"
 done
+publication_decider="$repo_root/scripts/decide-cli-release-publication.sh"
+test -x "$publication_decider"
+[ "$(bash "$publication_decider" stable v1.2.3 esengine/DeepSeek-Reasonix - -)" = "publish" ]
+publication_checksums="$test_root/cli-publication-SHA256SUMS"
+publication_release="$test_root/cli-publication-release.json"
+publication_hash="0000000000000000000000000000000000000000000000000000000000000000"
+publication_assets='[
+	"reasonix-darwin-amd64.tar.gz",
+	"reasonix-darwin-arm64.tar.gz",
+	"reasonix-linux-amd64.tar.gz",
+	"reasonix-linux-arm64.tar.gz",
+	"reasonix-windows-amd64.zip",
+	"reasonix-windows-arm64.zip",
+	"SHA256SUMS"
+]'
+for asset in \
+	reasonix-darwin-amd64.tar.gz \
+	reasonix-darwin-arm64.tar.gz \
+	reasonix-linux-amd64.tar.gz \
+	reasonix-linux-arm64.tar.gz \
+	reasonix-windows-amd64.zip \
+	reasonix-windows-arm64.zip; do
+	printf '%s  %s\n' "$publication_hash" "$asset"
+done >"$publication_checksums"
+publication_checksum_hash="$(shasum -a 256 "$publication_checksums" | awk '{print $1}')"
+jq -n \
+	--arg repo "esengine/DeepSeek-Reasonix" \
+	--arg tag "v1.2.3" \
+	--arg archive_hash "$publication_hash" \
+	--arg checksum_hash "$publication_checksum_hash" \
+	--argjson names "$publication_assets" '
+	{
+		tag_name: $tag,
+		draft: false,
+		prerelease: false,
+		html_url: ("https://github.com/" + $repo + "/releases/tag/" + $tag),
+		assets: [
+			$names[] as $name |
+			{
+				name: $name,
+				state: "uploaded",
+				size: 1,
+				browser_download_url:
+					("https://github.com/" + $repo + "/releases/download/" + $tag + "/" + $name),
+				digest: ("sha256:" + (if $name == "SHA256SUMS" then $checksum_hash else $archive_hash end))
+			}
+		]
+	}
+' >"$publication_release"
+[ "$(bash "$publication_decider" stable v1.2.3 esengine/DeepSeek-Reasonix \
+	"$publication_release" "$publication_checksums")" = "reuse" ]
+publication_preview="$test_root/cli-publication-preview-release.json"
+jq '.tag_name = "v1.2.3-preview.4" | .prerelease = true |
+	.html_url = "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.2.3-preview.4" |
+	.assets |= map(.browser_download_url |= sub("/v1.2.3/"; "/v1.2.3-preview.4/"))' \
+	"$publication_release" >"$publication_preview"
+[ "$(bash "$publication_decider" preview v1.2.3-preview.4 esengine/DeepSeek-Reasonix \
+	"$publication_preview" "$publication_checksums")" = "reuse" ]
+publication_rc="$test_root/cli-publication-rc-release.json"
+jq '.tag_name = "v1.2.3-rc.1" | .prerelease = true |
+	.html_url = "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.2.3-rc.1" |
+	.assets |= map(.browser_download_url |= sub("/v1.2.3/"; "/v1.2.3-rc.1/"))' \
+	"$publication_release" >"$publication_rc"
+[ "$(bash "$publication_decider" any v1.2.3-rc.1 esengine/DeepSeek-Reasonix \
+	"$publication_rc" "$publication_checksums")" = "reuse" ]
+publication_partial="$test_root/cli-publication-partial-release.json"
+jq '.assets |= map(select(.name != "reasonix-linux-arm64.tar.gz"))' \
+	"$publication_release" >"$publication_partial"
+if bash "$publication_decider" stable v1.2.3 esengine/DeepSeek-Reasonix \
+	"$publication_partial" "$publication_checksums" >/dev/null 2>&1; then
+	echo "CLI publication decider accepted a partial existing release" >&2
+	exit 1
+fi
+publication_bad_checksums="$test_root/cli-publication-bad-SHA256SUMS"
+sed '1s/^0/1/' "$publication_checksums" >"$publication_bad_checksums"
+if bash "$publication_decider" stable v1.2.3 esengine/DeepSeek-Reasonix \
+	"$publication_release" "$publication_bad_checksums" >/dev/null 2>&1; then
+	echo "CLI publication decider accepted mismatched checksums" >&2
+	exit 1
+fi
 manifest_validator="$repo_root/scripts/validate-cli-release-manifest.sh"
 manifest_comparator="$repo_root/scripts/compare-cli-release-manifests.sh"
 test -x "$manifest_validator"

--- a/scripts/validate-desktop-release-manifest.sh
+++ b/scripts/validate-desktop-release-manifest.sh
@@ -55,16 +55,9 @@ expected_tag="desktop-${version}"
 github_base="https://github.com/esengine/DeepSeek-Reasonix/releases/download/${expected_tag}/"
 r2_base="https://dl.reasonix.io/${expected_tag}/"
 legacy_preview_base="https://dl.reasonix.io/desktop-preview/"
-if [ "$channel" = "legacy-preview" ]; then
-	allowed_base="$legacy_preview_base"
-else
-	allowed_base=""
-fi
-if [ -n "$allowed_base" ] && [ "$asset_base" != "$allowed_base" ]; then
-	echo "invalid legacy Desktop asset base: $asset_base" >&2
-	exit 1
-fi
-if [ -z "$allowed_base" ] && [ "$asset_base" != "$github_base" ] && [ "$asset_base" != "$r2_base" ]; then
+if [ "$channel" = "legacy-preview" ] && [ "$asset_base" = "$legacy_preview_base" ]; then
+	:
+elif [ "$asset_base" != "$github_base" ] && [ "$asset_base" != "$r2_base" ]; then
 	echo "invalid official Desktop asset base: $asset_base" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Problem

Preview 1.19.0 recovery exposed two independent idempotency gaps after the original publication had already made progress:

1. The CLI publisher rebuilt the candidate and failed all seven uploads with HTTP 422 `already_exists`, preventing downstream R2 metadata repair.
2. The Desktop R2 publisher uploaded and verified the immutable asset directory, then rejected its correct tag-scoped `desktop-v1.19.0-preview.2/` manifest because legacy-field validation was incorrectly restricted to the old mutable `desktop-preview/` path.

## Root cause

The recovery control plane can reuse an immutable historical Preview candidate, but the CLI publisher unconditionally invoked GoReleaser. Separately, the Desktop manifest validator conflated compatibility for legacy missing fields with compatibility for the legacy mutable Preview path.

## Fix

- Inspect the tag-scoped GitHub Release before invoking GoReleaser.
- Publish normally when the release is absent.
- Reuse an existing release only when its channel, draft/prerelease state, exact seven-asset set, upload states, sizes, URLs, and GitHub SHA-256 digests are valid.
- Download `SHA256SUMS`, bind its own digest to GitHub metadata, and require its six archive checksums to match the corresponding GitHub asset digests.
- Fail closed for partial or inconsistent releases; do not delete or overwrite published assets.
- Preserve standalone RC recovery through the existing `any` channel contract.
- Allow legacy-field Desktop validation on either the official immutable tag path or, for historical pointers only, the old mutable Preview path. All other asset bases remain rejected.

## Verification

- `bash scripts/release-workflows.test.sh`
- `bash -n scripts/decide-cli-release-publication.sh scripts/validate-desktop-release-manifest.sh scripts/release-workflows.test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 ...release workflows...`
- `git diff --check`
- Live `v1.19.0-preview.2` GitHub Release JSON plus downloaded `SHA256SUMS` returns `reuse`.
- Recovery run 30683377615 reproduced the prior CLI bug as seven HTTP 422 `already_exists` uploads.
- The same run completed all four Desktop platform builds, GitHub publication, and the 451.6 MiB immutable R2 asset mirror before reproducing the tag-scoped legacy validation bug.
- Regression fixtures cover complete/partial/checksum-mismatched CLI releases, Preview and RC recovery, the legacy mutable Desktop Preview path, and the immutable tag-scoped legacy-field path.

## Compatibility and cache impact

- No runtime, provider-visible prompt, tool schema, persisted format, or cache-sensitive behavior changes.
- First publication remains unchanged. Recovery skips GoReleaser only after cryptographic and structural validation; downstream release notes, R2 metadata, and public postflight still run.
- Desktop validation still rejects non-official bases and keeps the strict new-publication contract.