### PR TITLE
Harden CLI and Desktop recovery control / 加固 CLI 与 Desktop 恢复控制

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -712,6 +712,12 @@ jobs:
           path: release-control
           ref: ${{ github.workflow_sha }}
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: release-control/desktop/go.mod
+          cache: true
+          cache-dependency-path: release-control/desktop/go.sum
+
       - name: Revalidate immutable Desktop candidate
         env:
           RELEASE_CHANNEL: ${{ needs.resolve.outputs.channel }}
@@ -849,6 +855,22 @@ jobs:
           asset_base="https://dl.reasonix.io/${TAG}/"
           existing_manifest=false
 
+          signature_verifier=/tmp/reasonix-desktop-sign
+          go -C release-control/desktop build -o "$signature_verifier" ./cmd/sign
+          verify_signature_directory() {
+            local directory="$1"
+            local signature payload
+            while IFS= read -r -d '' signature; do
+              payload="${signature%.minisig}"
+              if [ ! -f "$payload" ]; then
+                echo "::error::Desktop signature has no matching payload: $signature"
+                return 1
+              fi
+              "$signature_verifier" verify "$payload"
+            done < <(find "$directory" -type f -name '*.minisig' -print0)
+          }
+          verify_signature_directory assets
+
           # A version directory is immutable once written. Recovery may fill an
           # incomplete candidate subset, but it may never replace conflicting or
           # unexpected content, including an already-written latest.json.
@@ -864,8 +886,10 @@ jobs:
           if [ -n "$existing_keys" ] && [ "$existing_keys" != "None" ]; then
             aws s3 cp "s3://${R2_BUCKET}/${TAG}/" "$existing_directory/" \
               --recursive --endpoint-url "$ENDPOINT"
+            verify_signature_directory "$existing_directory"
             bash release-control/scripts/verify-desktop-release-directory.sh \
-              --allow-missing --allow-legacy-manifest assets "$existing_directory"
+              --allow-missing --allow-legacy-manifest \
+              --allow-signature-differences assets "$existing_directory"
             if [ -f "$existing_directory/latest.json" ]; then
               existing_manifest=true
               bash release-control/scripts/validate-desktop-release-manifest.sh \
@@ -874,6 +898,15 @@ jobs:
               bash release-control/scripts/compare-desktop-release-manifests.sh \
                 assets/latest.json "$existing_directory/latest.json"
             fi
+
+            # Preserve already-published valid signature bytes. Minisign
+            # signatures are intentionally non-deterministic, so a recovery
+            # may fill missing signatures but must not replace existing ones.
+            while IFS= read -r -d '' signature; do
+              relative="${signature#"$existing_directory"/}"
+              mkdir -p "assets/$(dirname "$relative")"
+              cp "$signature" "assets/$relative"
+            done < <(find "$existing_directory" -type f -name '*.minisig' -print0)
           fi
 
           aws s3 cp assets/ "s3://${R2_BUCKET}/${TAG}/" \
@@ -892,6 +925,7 @@ jobs:
             --recursive --endpoint-url "$ENDPOINT"
           bash release-control/scripts/verify-desktop-release-directory.sh \
             --allow-legacy-manifest assets "$published_directory"
+          verify_signature_directory "$published_directory"
 
           aws s3 cp "s3://${R2_BUCKET}/${TAG}/latest.json" \
             /tmp/reasonix-desktop-tag-latest.json --endpoint-url "$ENDPOINT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve.outputs.sha }}
+      # Recovery may build an immutable tag that predates the current recovery
+      # policy. Keep product sources pinned above, but execute publication
+      # decisions from the protected workflow commit.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          path: release-control
+          ref: ${{ github.workflow_sha }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -244,14 +252,14 @@ jobs:
             gh release download "$TAG" -R "${{ github.repository }}" \
               --pattern SHA256SUMS --output "$checksums"
             decision="$(
-              bash scripts/decide-cli-release-publication.sh \
+              bash release-control/scripts/decide-cli-release-publication.sh \
                 "$validation_channel" "$TAG" "${{ github.repository }}" \
                 "$release_json" "$checksums"
             )"
             echo "existing CLI release $TAG is complete and checksum-bound; reusing it"
           elif grep -Eiq 'HTTP 404|Not Found' "$release_error"; then
             decision="$(
-              bash scripts/decide-cli-release-publication.sh \
+              bash release-control/scripts/decide-cli-release-publication.sh \
                 "$validation_channel" "$TAG" "${{ github.repository }}" - -
             )"
             echo "CLI release $TAG does not exist; GoReleaser will publish it"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -236,7 +236,14 @@ grep -Fq 'scripts/decide-cli-pointer-update.sh' "$cli_release_workflow"
 grep -Fq 'scripts/validate-cli-release-manifest.sh' "$cli_release_workflow"
 grep -Fq 'scripts/compare-cli-release-manifests.sh' "$cli_release_workflow"
 grep -Eq 'name: Decide whether CLI artifacts need publication' "$cli_release_workflow"
-grep -Fq 'scripts/decide-cli-release-publication.sh' "$cli_release_workflow"
+grep -Fq 'path: release-control' "$cli_release_workflow"
+grep -Fq 'ref: ${{ github.workflow_sha }}' "$cli_release_workflow"
+grep -Fq 'release-control/scripts/decide-cli-release-publication.sh' "$cli_release_workflow"
+if sed -n '/^  goreleaser:/,$p' "$cli_release_workflow" |
+	grep -Fq 'bash scripts/decide-cli-release-publication.sh'; then
+	echo "CLI recovery uses candidate-controlled publication policy" >&2
+	exit 1
+fi
 grep -Fq "if: \${{ steps.publication.outputs.decision == 'publish' }}" "$cli_release_workflow"
 grep -Fq 'immutable CLI release metadata for $TAG already exists with different content' "$cli_release_workflow"
 grep -Fq 'cmp -s /tmp/cli-release.json /tmp/cli-release.pointer.json' "$cli_release_workflow"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -86,7 +86,7 @@ grep -Fq 'bash scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflo
 [ "$(grep -Fc 'IN_ORCHESTRATOR: ${{ inputs.orchestrator }}' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]
 [ "$(grep -Fc 'name: Revalidate immutable Desktop candidate' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'ref: ${{ needs.resolve.outputs.sha }}' "$repo_root/.github/workflows/release-desktop.yml")" -ge 4 ]
-[ "$(grep -Fc 'path: release-control' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
+[ "$(grep -Ec '^          path: release-control$' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'ref: ${{ github.workflow_sha }}' "$repo_root/.github/workflows/release-desktop.yml")" -ge 2 ]
 [ "$(grep -Fc 'bash release-control/scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'RELEASE_TAG: ${{ inputs.approved_cli_tag }}' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]
@@ -170,6 +170,16 @@ fi
 grep -Fq 'scripts/decide-desktop-pointer-update.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'scripts/verify-desktop-release-directory.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'scripts/compare-desktop-release-manifests.sh' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'go -C release-control/desktop build -o "$signature_verifier" ./cmd/sign' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'verify_signature_directory assets' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'verify_signature_directory "$existing_directory"' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq -- '--allow-signature-differences' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'cp "$signature" "assets/$relative"' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'verify_signature_directory "$published_directory"' \
+	"$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "preview/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "canary/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'publish_pointer canary' "$repo_root/.github/workflows/release-desktop.yml"
@@ -596,6 +606,21 @@ if bash "$desktop_directory_verifier" "$candidate_directory" "$existing_director
 fi
 cp "$candidate_directory/b" "$existing_directory/b"
 bash "$desktop_directory_verifier" "$candidate_directory" "$existing_directory"
+printf 'candidate-signature\n' >"$candidate_directory/a.minisig"
+printf 'existing-signature\n' >"$existing_directory/a.minisig"
+if bash "$desktop_directory_verifier" "$candidate_directory" "$existing_directory" >/dev/null 2>&1; then
+	echo "Desktop release directory verifier accepted a byte-distinct signature without opt-in" >&2
+	exit 1
+fi
+bash "$desktop_directory_verifier" --allow-signature-differences \
+	"$candidate_directory" "$existing_directory"
+printf '' >"$existing_directory/a.minisig"
+if bash "$desktop_directory_verifier" --allow-signature-differences \
+	"$candidate_directory" "$existing_directory" >/dev/null 2>&1; then
+	echo "Desktop release directory verifier accepted an empty recovered signature" >&2
+	exit 1
+fi
+cp "$candidate_directory/a.minisig" "$existing_directory/a.minisig"
 printf 'conflict\n' >"$existing_directory/a"
 if bash "$desktop_directory_verifier" --allow-missing "$candidate_directory" "$existing_directory" >/dev/null 2>&1; then
 	echo "Desktop release directory verifier accepted conflicting immutable content" >&2

--- a/scripts/verify-desktop-release-directory.sh
+++ b/scripts/verify-desktop-release-directory.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 allow_missing=false
 allow_legacy_manifest=false
+allow_signature_differences=false
 while [ "$#" -gt 0 ]; do
 	case "$1" in
 	--allow-missing)
@@ -13,11 +14,18 @@ while [ "$#" -gt 0 ]; do
 		allow_legacy_manifest=true
 		shift
 		;;
+	--allow-signature-differences)
+		# Callers must cryptographically verify both signature sets before using
+		# this comparison mode. Minisign trusted comments make two valid
+		# signatures for identical content byte-distinct across recovery runs.
+		allow_signature_differences=true
+		shift
+		;;
 	*) break ;;
 	esac
 done
 if [ "$#" -ne 2 ]; then
-	echo "usage: $0 [--allow-missing] [--allow-legacy-manifest] CANDIDATE_DIRECTORY EXISTING_DIRECTORY" >&2
+	echo "usage: $0 [--allow-missing] [--allow-legacy-manifest] [--allow-signature-differences] CANDIDATE_DIRECTORY EXISTING_DIRECTORY" >&2
 	exit 2
 fi
 
@@ -44,6 +52,13 @@ verify_subset() {
 			if ! bash "$script_dir/compare-desktop-release-manifests.sh" \
 				"$candidate_dir/latest.json" "$existing_dir/latest.json"; then
 				echo "Desktop release directory has conflicting content for $relative" >&2
+				return 1
+			fi
+			continue
+		fi
+		if [ "$allow_signature_differences" = "true" ] && [[ "$relative" = *.minisig ]]; then
+			if [ ! -s "$source_file" ] || [ ! -s "$target_file" ]; then
+				echo "Desktop release directory has an empty signature for $relative" >&2
 				return 1
 			fi
 			continue


### PR DESCRIPTION
## Problem

Preview 1.19.0 recovery exposed two remaining trust/idempotency boundaries:

1. CLI correctly checked out immutable product candidate `be16778f`, but the newly added publication policy was absent from that historical tree, causing `No such file or directory`.
2. Desktop verified an otherwise identical 451.6 MiB immutable R2 directory, but rejected a byte-distinct `.minisig`. Re-signing identical content produces a different valid detached-signature file, so raw signature equality is not a reproducibility invariant.

## Root cause

- The CLI publisher used one checkout for both product source and release control policy.
- The Desktop directory verifier treated nondeterministic detached signatures like reproducible payload bytes.

## Fix

### CLI control plane

- Keep product source pinned to the approved immutable candidate.
- Add a separate `release-control` checkout pinned to protected `github.workflow_sha`.
- Run the CLI publication decision only from that control checkout.
- Reject candidate-controlled recovery policy in contract tests.

### Desktop signatures

- Build the existing Desktop signature verifier from the protected control checkout.
- Verify both newly built and already published signature sets against the embedded public key.
- Allow signature-byte differences only after that cryptographic verification; payload bytes and manifests must still match exactly.
- Preserve existing valid signature bytes before upload, so recovery fills missing objects without replacing immutable signatures.
- Re-download the published directory, require exact equality to the preserved recovery set, and verify all signatures again.

## Verification

- `bash scripts/release-workflows.test.sh`
- `bash -n scripts/release-workflows.test.sh scripts/decide-cli-release-publication.sh scripts/verify-desktop-release-directory.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 ...release workflows...`
- `git diff --check`
- Recovery run 30685048909 reproduced the CLI checkout boundary exactly.
- The same run completed all Desktop builds and signing, then isolated the R2 conflict to `Reasonix-windows-amd64-installer.exe.minisig`; payload/manifests passed earlier checks.
- Public Preview Linux archive and the exact Windows installer implicated by the recovery log both verify against the Desktop embedded minisign public key.
- Regression fixtures require explicit opt-in for signature-byte differences and still reject empty signatures, changed payloads, unexpected files, and non-legacy manifest differences.

## Compatibility and cache impact

- No runtime, provider-visible prompt, tool schema, persisted format, or cache-sensitive behavior changes.
- Candidate source and binary identity remain unchanged.
- The recovery path narrows trust: policy comes from the protected workflow commit, and signature differences are accepted only after cryptographic verification while existing immutable bytes are preserved.