### PR TITLE
Fix Desktop recovery manifest ordering / 修复桌面恢复清单顺序

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -898,9 +898,6 @@ jobs:
             aws s3 cp "s3://${R2_BUCKET}/${TAG}/" "$existing_directory/" \
               --recursive --endpoint-url "$ENDPOINT"
             verify_signature_directory "$existing_directory"
-            bash release-control/scripts/verify-desktop-release-directory.sh \
-              --allow-missing --allow-legacy-manifest \
-              --allow-authenticated-payload-differences assets "$existing_directory"
             if [ -f "$existing_directory/latest.json" ]; then
               existing_manifest=true
               bash release-control/scripts/validate-desktop-release-manifest.sh \
@@ -910,6 +907,9 @@ jobs:
                 "$existing_directory/latest.json" "$existing_directory"
               cp "$existing_directory/latest.json" assets/latest.json
             fi
+            bash release-control/scripts/verify-desktop-release-directory.sh \
+              --allow-missing --allow-legacy-manifest \
+              --allow-authenticated-payload-differences assets "$existing_directory"
 
             # Preserve every already-published authenticated payload/signature
             # pair. Platform signing and packaging are non-deterministic, so a

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -182,6 +182,15 @@ grep -Fq 'cp "$signature" "assets/$relative"' "$repo_root/.github/workflows/rele
 grep -Fq 'verify-desktop-release-manifest-assets.sh' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'verify_signature_directory "$published_directory"' \
 	"$repo_root/.github/workflows/release-desktop.yml"
+manifest_adoption_line="$(grep -nF 'cp "$existing_directory/latest.json" assets/latest.json' \
+	"$repo_root/.github/workflows/release-desktop.yml" | cut -d: -f1)"
+authenticated_compare_line="$(grep -nF -- '--allow-authenticated-payload-differences assets "$existing_directory"' \
+	"$repo_root/.github/workflows/release-desktop.yml" | cut -d: -f1)"
+if [ -z "$manifest_adoption_line" ] || [ -z "$authenticated_compare_line" ] ||
+	[ "$manifest_adoption_line" -ge "$authenticated_compare_line" ]; then
+	echo "Desktop recovery must adopt a validated existing manifest before directory comparison" >&2
+	exit 1
+fi
 grep -Fq 'download_optional "preview/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "canary/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'publish_pointer canary' "$repo_root/.github/workflows/release-desktop.yml"
@@ -653,6 +662,28 @@ if bash "$desktop_directory_verifier" --allow-missing "$candidate_directory" "$e
 	echo "Desktop release directory verifier accepted an unexpected immutable object" >&2
 	exit 1
 fi
+
+recovery_candidate_directory="$test_root/desktop-directory-recovery-candidate"
+recovery_existing_directory="$test_root/desktop-directory-recovery-existing"
+mkdir -p "$recovery_candidate_directory" "$recovery_existing_directory"
+printf 'candidate-payload\n' >"$recovery_candidate_directory/artifact"
+printf 'candidate-signature\n' >"$recovery_candidate_directory/artifact.minisig"
+printf 'existing-payload\n' >"$recovery_existing_directory/artifact"
+printf 'existing-signature\n' >"$recovery_existing_directory/artifact.minisig"
+printf '{"version":"v1.2.3","release_notes_url":"https://reasonix.io/changelog/v1.2.3/","marker":"candidate"}\n' \
+	>"$recovery_candidate_directory/latest.json"
+printf '{"version":"v1.2.3","release_notes_url":"https://reasonix.io/changelog/v1.2.3/","marker":"existing"}\n' \
+	>"$recovery_existing_directory/latest.json"
+if bash "$desktop_directory_verifier" --allow-missing --allow-legacy-manifest \
+	--allow-authenticated-payload-differences \
+	"$recovery_candidate_directory" "$recovery_existing_directory" >/dev/null 2>&1; then
+	echo "Desktop recovery accepted a conflicting manifest before validated adoption" >&2
+	exit 1
+fi
+cp "$recovery_existing_directory/latest.json" "$recovery_candidate_directory/latest.json"
+bash "$desktop_directory_verifier" --allow-missing --allow-legacy-manifest \
+	--allow-authenticated-payload-differences \
+	"$recovery_candidate_directory" "$recovery_existing_directory"
 
 legacy_candidate_directory="$test_root/desktop-directory-legacy-candidate"
 legacy_existing_directory="$test_root/desktop-directory-legacy-existing"


### PR DESCRIPTION
## Summary

- validate the existing immutable Desktop manifest against its published payload sizes and SHA-256 digests before directory comparison
- adopt that validated manifest before comparing authenticated recovery payloads
- lock the ordering with both behavioral and workflow-structure regression coverage

## Root cause

The authenticated payload recovery path correctly verified every existing payload, but compared `latest.json` before adopting the already-published immutable manifest. Rebuilds produce different package hashes, so the comparison necessarily failed even though the published manifest remained valid and bound to its payloads.

## Verification

- `bash scripts/release-workflows.test.sh`
- release Desktop workflow actionlint
- `bash scripts/cache-guard.sh`
- shell syntax and `git diff --check`