### PR TITLE
fix(release): accept immutable legacy desktop pointers / 兼容版本化旧桌面指针

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -972,14 +972,22 @@ jobs:
               return 0
             fi
 
-            local legacy_base="$current_base"
-            if [ "$current_channel" = "preview" ]; then
-              legacy_base="https://dl.reasonix.io/desktop-preview/"
-            fi
             if bash release-control/scripts/validate-desktop-release-manifest.sh \
-              "legacy-${current_channel}" "$current_version" "$legacy_base" \
+              "legacy-${current_channel}" "$current_version" "$current_base" \
               "$current_file"; then
-              echo "using legacy $current_channel manifest $current_version only as the monotonic migration baseline"
+              echo "using legacy $current_channel manifest $current_version at its immutable base only as the monotonic migration baseline"
+              return 0
+            fi
+
+            # Early Preview pointers referenced the mutable desktop-preview/
+            # directory. Try that layout only after the immutable legacy layout
+            # so later legacy pointers retain their version-bound asset URLs.
+            local legacy_preview_base="https://dl.reasonix.io/desktop-preview/"
+            if [ "$current_channel" = "preview" ] && \
+              bash release-control/scripts/validate-desktop-release-manifest.sh \
+                legacy-preview "$current_version" "$legacy_preview_base" \
+                "$current_file"; then
+              echo "using legacy Preview manifest $current_version at the rolling base only as the monotonic migration baseline"
               return 0
             fi
             echo "::error::existing Desktop $current_channel pointer is invalid"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -193,6 +193,10 @@ if [ -z "$manifest_adoption_line" ] || [ -z "$authenticated_compare_line" ] ||
 fi
 grep -Fq 'download_optional "preview/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'download_optional "canary/latest.json"' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq '"legacy-${current_channel}" "$current_version" "$current_base"' \
+	"$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq 'legacy-preview "$current_version" "$legacy_preview_base"' \
+	"$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'publish_pointer canary' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'publish_pointer preview' "$repo_root/.github/workflows/release-desktop.yml"
 grep -Fq 'cmp -s /tmp/reasonix-desktop-canary-latest.json /tmp/reasonix-desktop-preview-latest.json' \
@@ -1074,6 +1078,10 @@ jq 'del(.release_notes_url, .downloads)' "$desktop_preview_manifest" \
 	>"$test_root/desktop-legacy-preview-immutable.json"
 bash "$desktop_validator" legacy-preview "$desktop_preview_version" \
 	"$desktop_preview_base" "$test_root/desktop-legacy-preview-immutable.json"
+jq '.release_notes_url = null' "$desktop_preview_manifest" \
+	>"$test_root/desktop-null-legacy-preview-immutable.json"
+bash "$desktop_validator" legacy-preview "$desktop_preview_version" \
+	"$desktop_preview_base" "$test_root/desktop-null-legacy-preview-immutable.json"
 jq 'del(.downloads)' "$desktop_stable_manifest" >"$test_root/desktop-legacy-stable.json"
 bash "$desktop_validator" legacy-stable "$desktop_stable_version" \
 	"$desktop_stable_base" "$test_root/desktop-legacy-stable.json"


### PR DESCRIPTION
## Problem

Preview recovery rejected the existing public Desktop pointer even though its asset URLs are bound to the official immutable version directory.

## Root cause

The legacy Preview fallback always substituted the historical rolling `desktop-preview/` base. Public `v1.18.0-preview.65` instead combines the legacy nullable release-notes field with immutable `desktop-v1.18.0-preview.65/` asset URLs, so neither existing validation attempt matched it.

## Fix

- validate the immutable legacy layout before considering the historical rolling layout
- keep the rolling Preview directory as a narrow second fallback
- cover the workflow call contract and a nullable release-notes immutable manifest

## Verification

- `bash scripts/release-workflows.test.sh`
- Actionlint v1.7.7 for release workflows
- `bash scripts/cache-guard.sh`
- `git diff --check`