### PR TITLE
fix(grep): prevent GB18030 truncation goroutine leak

### DIFF
--- a/internal/tool/builtin/builtin_test.go
+++ b/internal/tool/builtin/builtin_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"unicode/utf16"
 
+	"go.uber.org/goleak"
 	"golang.org/x/text/encoding/simplifiedchinese"
 
 	"reasonix/internal/tool"
@@ -553,5 +554,32 @@ func TestGrepGB18030(t *testing.T) {
 	out := runTool(t, grepTool{}, map[string]any{"pattern": "函数", "path": dir})
 	if !strings.Contains(out, "函数") {
 		t.Errorf("expected match in decoded GB18030 text, got:\n%s", out)
+	}
+}
+
+func TestGrepGB18030TruncationDoesNotLeakGoroutine(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	var content strings.Builder
+	for range grepMaxMatches {
+		content.WriteString("命中\n")
+	}
+	content.WriteString(strings.Repeat("padding\n", 2000))
+	gb, err := simplifiedchinese.GB18030.NewEncoder().String(content.String())
+	if err != nil {
+		t.Fatalf("encode GB18030: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "many-matches.gbk")
+	if err := os.WriteFile(path, []byte(gb), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	out := runTool(t, grepTool{}, map[string]any{"pattern": "命中", "path": path})
+	if got := strings.Count(out, ":命中"); got != grepMaxMatches {
+		t.Fatalf("matches = %d, want %d:\n%s", got, grepMaxMatches, out)
+	}
+	if !strings.Contains(out, "truncated at 200 matches") {
+		t.Fatalf("missing truncation marker:\n%s", out)
 	}
 }

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -203,19 +203,11 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 			all := append(peek, rest...)
 			src = bytes.NewReader(fileenc.Decode(all, enc))
 		} else {
-			// Non-BOM path: stream. The peek bytes are prepended via
-			// io.MultiReader; the remaining bytes flow through a decoder
-			// pipe so the scanner can stop as soon as the cap is reached.
+			// Non-BOM path: stream through the decoder so the scanner can
+			// stop as soon as the cap is reached without buffering the file.
 			dec := fileenc.Decoder(enc)
 			if dec != nil {
-				head := append([]byte(nil), peek...) // goroutine can outlive an early return; don't alias the reused buffer
-				pr, pw := io.Pipe()
-				go func() {
-					_, _ = pw.Write(head)
-					io.Copy(pw, f) //nolint:errcheck
-					pw.Close()
-				}()
-				src = transform.NewReader(pr, dec)
+				src = transform.NewReader(io.MultiReader(bytes.NewReader(peek), f), dec)
 			} else {
 				// UTF-8 or LossyUTF8 — no transformation needed.
 				src = io.MultiReader(bytes.NewReader(peek), f)


### PR DESCRIPTION
## Summary

- Prevent native GB18030 grep from leaving a blocked pipe writer after it reaches the 200-match limit.
- Cover the capped-search path with a goroutine-leak regression test.

## Issues

- None.

## Verification

- `go test ./...`
- `go test -race ./internal/tool/builtin`
- `go vet ./...`

Cache-impact: none — the tool schema and provider-visible prompt are unchanged; this only removes an internal decoder pipe.
Cache-guard: `go test ./internal/tool/builtin -run TestGrepGB18030TruncationDoesNotLeakGoroutine -count=1`
