### PR TITLE
perf(read_file): cache line starts for paginated reads

### DIFF
--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -22,6 +22,7 @@ import (
 const (
 	readFileBinaryPeek   = 8 * 1024   // bytes scanned for NUL before reading further
 	readFileDetectSample = 256 * 1024 // bytes sampled for encoding detection before streaming
+	readFileMaxLineBytes = 1024 * 1024
 )
 
 func init() { tool.RegisterBuiltin(readFile{}) }
@@ -112,7 +113,8 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// A directory can be os.Open'd but not read as text — catch it up front with
 	// an actionable message (and avoid the doubled "read X: read X:" the scanner's
 	// error would otherwise produce) so the model switches to the ls tool.
-	if info, err := os.Stat(p.Path); err == nil && info.IsDir() {
+	info, statErr := os.Stat(p.Path)
+	if statErr == nil && info.IsDir() {
 		return "", fmt.Errorf("%s is a directory, not a file — use the ls tool to list it, or read a specific file inside it", displayPath)
 	}
 
@@ -124,6 +126,11 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("read %s: %w", displayPath, err)
 	}
 	defer f.Close()
+	if info == nil {
+		if info, err = f.Stat(); err != nil {
+			return "", fmt.Errorf("read %s: %w", displayPath, err)
+		}
+	}
 
 	// Peek the first 8 KiB to reject binary files cheaply (a NUL byte) before
 	// reading further — keeps a multi-GB archive from being slurped just to be
@@ -205,7 +212,95 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if dec := fileenc.Decoder(enc); dec != nil {
 		return r.scan(transform.NewReader(src, dec), p.Offset, p.Limit)
 	}
-	return r.scan(src, p.Offset, p.Limit)
+	return r.scanRawFile(p.Path, info, f, head, p.Offset, p.Limit)
+}
+
+func (r readFile) scanRawFile(path string, info os.FileInfo, f *os.File, head []byte, offset, limit int) (string, error) {
+	startLine, startByte := 0, int64(0)
+	if offset > 0 {
+		if line, byteOffset, ok := readFileLineStarts.nearest(path, info, offset); ok && byteOffset >= int64(len(head)) {
+			startLine, startByte = line, byteOffset
+		}
+	}
+
+	var src io.Reader
+	if startByte > 0 {
+		if _, err := f.Seek(startByte, io.SeekStart); err != nil {
+			return "", fmt.Errorf("scan: seek: %w", err)
+		}
+		src = f
+	} else {
+		src = io.MultiReader(bytes.NewReader(head), f)
+	}
+	return r.scanRawWindow(path, info, src, startLine, startByte, offset, limit)
+}
+
+func (r readFile) scanRawWindow(path string, info os.FileInfo, src io.Reader, startLine int, startByte int64, offset, limit int) (string, error) {
+	reader := bufio.NewReaderSize(src, 64*1024)
+	collected := make([]string, 0, min(limit, 64))
+	starts := []readFileLineStart{{line: startLine, byteOffset: startByte}}
+	lineNo := startLine
+	bytePos := startByte
+	hasMore := false
+
+	for {
+		raw, n, err := readFileRawLine(reader)
+		if err != nil && err != io.EOF {
+			return "", fmt.Errorf("scan: %w", err)
+		}
+		if n == 0 {
+			break
+		}
+
+		lineNo++
+		bytePos += int64(n)
+		if len(raw) > 0 && raw[len(raw)-1] == '\n' && lineNo <= readFileLineStartCacheMax && bytePos < info.Size() {
+			starts = append(starts, readFileLineStart{line: lineNo, byteOffset: bytePos})
+		}
+
+		if lineNo > offset {
+			if len(collected) < limit {
+				collected = append(collected, readFileTrimRawLine(raw))
+			} else {
+				hasMore = true
+				break
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+	}
+
+	readFileLineStarts.record(path, info, starts)
+	return formatReadFileWindow(collected, offset, lineNo, hasMore), nil
+}
+
+func readFileRawLine(r *bufio.Reader) ([]byte, int, error) {
+	var line []byte
+	for {
+		part, err := r.ReadSlice('\n')
+		if len(part) > 0 {
+			if len(line)+len(part) > readFileMaxLineBytes {
+				return nil, 0, fmt.Errorf("bufio.Scanner: token too long")
+			}
+			line = append(line, part...)
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		return line, len(line), err
+	}
+}
+
+func readFileTrimRawLine(raw []byte) string {
+	end := len(raw)
+	if end > 0 && raw[end-1] == '\n' {
+		end--
+		if end > 0 && raw[end-1] == '\r' {
+			end--
+		}
+	}
+	return string(raw[:end])
 }
 
 // scan reads lines from src and returns the formatted output with line numbers.
@@ -213,7 +308,7 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	scanner := bufio.NewScanner(src)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
-	var collected []string
+	collected := make([]string, 0, min(limit, 64))
 	lineNo := 0
 	hasMore := false
 	for scanner.Scan() {
@@ -234,11 +329,15 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 		return "", fmt.Errorf("scan: %w", err)
 	}
 
+	return formatReadFileWindow(collected, offset, lineNo, hasMore), nil
+}
+
+func formatReadFileWindow(collected []string, offset, lineNo int, hasMore bool) string {
 	if lineNo == 0 {
-		return "(empty file)", nil
+		return "(empty file)"
 	}
 	if len(collected) == 0 {
-		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, lineNo), nil
+		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, lineNo)
 	}
 
 	maxShown := offset + len(collected)
@@ -251,5 +350,5 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	if hasMore {
 		fmt.Fprintf(&b, "\n[more lines below; pass offset=%d to continue]\n", offset+len(collected))
 	}
-	return b.String(), nil
+	return b.String()
 }

--- a/internal/tool/builtin/readfile_line_cache.go
+++ b/internal/tool/builtin/readfile_line_cache.go
@@ -1,0 +1,103 @@
+package builtin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	readFileLineStartCacheEntries = 32
+	readFileLineStartCacheMax     = 200_000
+)
+
+var readFileLineStarts = newReadFileLineStartCache(readFileLineStartCacheEntries)
+
+type readFileLineStartCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	order      []string
+	entries    map[string]*readFileLineStartEntry
+}
+
+type readFileLineStartEntry struct {
+	starts []int64
+}
+
+type readFileLineStart struct {
+	line       int
+	byteOffset int64
+}
+
+func newReadFileLineStartCache(maxEntries int) *readFileLineStartCache {
+	if maxEntries <= 0 {
+		maxEntries = 1
+	}
+	return &readFileLineStartCache{
+		maxEntries: maxEntries,
+		entries:    make(map[string]*readFileLineStartEntry),
+	}
+}
+
+func readFileLineStartKey(path string, info os.FileInfo) string {
+	return fmt.Sprintf("%s\x00%d\x00%d", filepath.Clean(path), info.Size(), info.ModTime().UnixNano())
+}
+
+func (c *readFileLineStartCache) nearest(path string, info os.FileInfo, target int) (int, int64, bool) {
+	if c == nil || info == nil || info.Size() <= 0 || target < 0 {
+		return 0, 0, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := c.entries[readFileLineStartKey(path, info)]
+	if entry == nil || len(entry.starts) == 0 {
+		return 0, 0, false
+	}
+	if target >= len(entry.starts) {
+		target = len(entry.starts) - 1
+	}
+	return target, entry.starts[target], true
+}
+
+func (c *readFileLineStartCache) record(path string, info os.FileInfo, starts []readFileLineStart) {
+	if c == nil || info == nil || info.Size() <= 0 || len(starts) == 0 {
+		return
+	}
+	key := readFileLineStartKey(path, info)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := c.entries[key]
+	if entry == nil {
+		entry = &readFileLineStartEntry{starts: []int64{0}}
+		c.entries[key] = entry
+		c.order = append(c.order, key)
+		c.evictOldest()
+	}
+
+	for _, start := range starts {
+		if start.line < 0 || start.line > readFileLineStartCacheMax || start.byteOffset < 0 || start.byteOffset >= info.Size() {
+			continue
+		}
+		if start.line < len(entry.starts) {
+			if entry.starts[start.line] == start.byteOffset {
+				continue
+			}
+			entry.starts = entry.starts[:start.line]
+		}
+		if start.line == len(entry.starts) {
+			entry.starts = append(entry.starts, start.byteOffset)
+		}
+	}
+}
+
+func (c *readFileLineStartCache) evictOldest() {
+	for len(c.entries) > c.maxEntries && len(c.order) > 0 {
+		key := c.order[0]
+		c.order = c.order[1:]
+		delete(c.entries, key)
+	}
+}

--- a/internal/tool/builtin/readfile_window_test.go
+++ b/internal/tool/builtin/readfile_window_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -52,4 +54,43 @@ func TestScanWindowedReadDoesNotConsumeWholeFile(t *testing.T) {
 		t.Fatalf("read %d of %d bytes for a 3-line window; should read only a small prefix", cr.n, total)
 	}
 	t.Logf("read %d of %d bytes (%.1f%%) for a 3-line window", cr.n, total, 100*float64(cr.n)/float64(total))
+}
+
+func TestReadFileReusesLineOffsetCacheForRepeatedPagination(t *testing.T) {
+	oldCache := readFileLineStarts
+	readFileLineStarts = newReadFileLineStartCache(2)
+	t.Cleanup(func() { readFileLineStarts = oldCache })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "large.txt")
+	var buf bytes.Buffer
+	for i := 1; i <= 20_000; i++ {
+		fmt.Fprintf(&buf, "line %05d payload payload payload payload\n", i)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const firstLimit = 10_000
+	first := runTool(t, readFile{}, map[string]any{"path": path, "offset": 0, "limit": firstLimit})
+	if !strings.Contains(first, "10000→line 10000") {
+		t.Fatalf("first page did not include line 10000:\n%s", first)
+	}
+	line, byteOffset, ok := readFileLineStarts.nearest(path, info, firstLimit)
+	if !ok || line != firstLimit || byteOffset <= 0 {
+		t.Fatalf("cache did not retain line %d start after first page: line=%d byte=%d ok=%v", firstLimit+1, line, byteOffset, ok)
+	}
+
+	second := runTool(t, readFile{}, map[string]any{"path": path, "offset": firstLimit, "limit": 2})
+	if !strings.Contains(second, "10001→line 10001") || !strings.Contains(second, "10002→line 10002") {
+		t.Fatalf("second page read wrong window:\n%s", second)
+	}
+	line, byteOffset, ok = readFileLineStarts.nearest(path, info, firstLimit+2)
+	if !ok || line < firstLimit+2 || byteOffset <= 0 {
+		t.Fatalf("cache did not advance after second page: line=%d byte=%d ok=%v", line, byteOffset, ok)
+	}
 }


### PR DESCRIPTION
## Summary

- Add a small stat-keyed line-start cache for raw disk `read_file` reads.
- Reuse cached byte offsets when continuing through a large file with `offset`, avoiding repeated rescans of already-indexed pages.
- Keep the `read_file` tool schema and model-visible output format unchanged; decoded/overlay paths stay on the existing scanner.

## Issues

No linked issue.

## Verification

- `go test ./internal/tool/builtin -run TestReadFileReusesLineOffsetCacheForRepeatedPagination -count=1 -v`
- `go test ./... -count=1`
- `go vet ./...`

## Cache impact

Cache-impact: low; implementation-only change to `read_file` execution, with no tool schema, system prompt, memory prefix, output style, or provider request serialization changes.
Cache-guard: `go test ./internal/tool/builtin -run TestReadFileReusesLineOffsetCacheForRepeatedPagination -count=1 -v`
System-prompt-review: N/A
