### PR TITLE
docs(release): prepare v1.19.0-preview.3 notes / 准备 v1.19.0-preview.3 更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -670,6 +670,217 @@
       }
     },
     {
+      "version": "1.19.0-preview.3",
+      "date": "2026-08-01",
+      "channel": "prerelease",
+      "title": {
+        "en": "Reasonix Desktop v1.19.0-preview.3",
+        "zh": "Reasonix 桌面端 v1.19.0-preview.3"
+      },
+      "summary": {
+        "en": "This preview release resolves several user-reported issues, including wallet currency alignment, macOS icon rendering, menu clipping, and update recovery.",
+        "zh": "此预览版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。"
+      },
+      "surfaces": [
+        "desktop"
+      ],
+      "guides": [],
+      "highlights": [
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Wallet balance now matches pricing currency",
+            "zh": "钱包余额现已与定价币种一致"
+          },
+          "body": {
+            "en": "When you select USD pricing, the desktop status bar now shows your balance in USD. If USD is unavailable, it shows the actual currency prefix (e.g., CNY) without applying an implicit rate.",
+            "zh": "选择美元定价后，桌面状态栏现在会显示美元余额。若无法提供美元余额，则显示实际币种前缀（如 CNY），不进行隐式汇率转换。"
+          },
+          "refs": [
+            7160
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "macOS icon safe area restored",
+            "zh": "macOS 图标安全区域已恢复"
+          },
+          "body": {
+            "en": "The macOS app icon now appears correctly in the Dock and other system surfaces, matching the intended design.",
+            "zh": "macOS 应用图标现在在 Dock 和其他系统界面中显示正确，符合预期设计。"
+          },
+          "refs": [
+            7123
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Popover menus stay visible during layout",
+            "zh": "浮层菜单在布局期间保持可见"
+          },
+          "body": {
+            "en": "Anchored popovers (such as effort and model selectors) no longer disappear on first open. They remain visible at the edge of the viewport until the final position is calculated.",
+            "zh": "锚定浮层（如能力等级和模型选择器）不再在首次打开时消失。在计算最终位置前，它们会保留在视口边缘可见。"
+          },
+          "refs": [
+            7132
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Stuck update transactions automatically recovered",
+            "zh": "卡住的更新事务自动恢复"
+          },
+          "body": {
+            "en": "If a previous update attempt was interrupted, the app now automatically reconciles the state, eliminating the 'pending update already exists' error and allowing updates to proceed.",
+            "zh": "如果之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。"
+          },
+          "refs": [
+            7149
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Composer menus now fully visible",
+            "zh": "输入框菜单现已完整显示"
+          },
+          "body": {
+            "en": "The slash command and mention menus no longer clip above the input box; they expand to full height as expected.",
+            "zh": "斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开完整高度。"
+          },
+          "refs": [
+            7128
+          ]
+        }
+      ],
+      "changes": {
+        "new": [],
+        "improved": [],
+        "fixed": [
+          {
+            "title": {
+              "en": "Wallet balance now matches pricing currency",
+              "zh": "钱包余额现已与定价币种一致"
+            },
+            "body": {
+              "en": "When USD pricing is selected, the status bar balance now shows USD, with explicit currency prefix fallback when unavailable.",
+              "zh": "选择美元定价后，状态栏余额现在显示美元，无法提供时以明确的币种前缀作为备用。"
+            },
+            "refs": [
+              7160
+            ]
+          },
+          {
+            "title": {
+              "en": "macOS icon safe area restored",
+              "zh": "macOS 图标安全区域已恢复"
+            },
+            "body": {
+              "en": "The macOS app icon now displays correctly in the Dock and other system surfaces.",
+              "zh": "macOS 应用图标现在在 Dock 和其他系统界面中正确显示。"
+            },
+            "refs": [
+              7123
+            ]
+          },
+          {
+            "title": {
+              "en": "Popover menus stay visible during layout",
+              "zh": "浮层菜单在布局期间保持可见"
+            },
+            "body": {
+              "en": "Anchored popovers no longer disappear on first open; they remain visible until the final position is calculated.",
+              "zh": "锚定浮层不再在首次打开时消失，它们在计算最终位置前保持可见。"
+            },
+            "refs": [
+              7132
+            ]
+          },
+          {
+            "title": {
+              "en": "Prevent GB18030 grep goroutine leak",
+              "zh": "防止 GB18030 搜索协程泄漏"
+            },
+            "body": {
+              "en": "Fixed a goroutine leak that could occur during native GB18030 grep when the 200-match limit is reached.",
+              "zh": "修复了在达到 200 个匹配限制时，原生 GB18030 搜索期间可能发生的协程泄漏。"
+            },
+            "refs": [
+              7147
+            ]
+          },
+          {
+            "title": {
+              "en": "Stuck update transactions automatically recovered",
+              "zh": "卡住的更新事务自动恢复"
+            },
+            "body": {
+              "en": "Interrupted update attempts are now automatically reconciled, removing the 'pending update already exists' block.",
+              "zh": "中断的更新尝试现在会自动调和，消除了“待处理更新已存在”的阻塞。"
+            },
+            "refs": [
+              7149
+            ]
+          },
+          {
+            "title": {
+              "en": "Composer menus now fully visible",
+              "zh": "输入框菜单现已完整显示"
+            },
+            "body": {
+              "en": "The slash command and mention menus no longer get clipped; they expand to full height.",
+              "zh": "斜杠命令和提及菜单不再被裁剪，它们展开至完整高度。"
+            },
+            "refs": [
+              7128
+            ]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": {
+            "en": "Automatic update recovery",
+            "zh": "自动更新恢复"
+          },
+          "body": {
+            "en": "After updating, the desktop app will automatically reconcile any previously stuck update transactions. You may see a brief recovering state in the update banner.",
+            "zh": "更新后，桌面应用将自动调和任何先前卡住的更新事务。您可能会在更新横幅中看到短暂的恢复状态。"
+          },
+          "refs": [
+            7149
+          ]
+        }
+      ],
+      "risks": [],
+      "contributors": [
+        "SivanCola",
+        "LouF666",
+        "QingLong-C",
+        "ShiroKSH",
+        "clearnature"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.19.0-preview.3",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/v1.19.0-preview.2...v1.19.0-preview.3",
+        "download": "https://reasonix.io/?download=desktop&channel=preview#start"
+      },
+      "releaseId": "1.19.0-preview.3",
+      "baseVersion": "1.19.0",
+      "status": "reviewed",
+      "previousRelease": "1.19.0-preview.2",
+      "builds": {
+        "cli": "v1.19.0-preview.3",
+        "desktop": "v1.19.0-preview.3",
+        "npm": "1.19.0-canary.3"
+      }
+    },
+    {
       "version": "1.19.0-preview.2",
       "date": "2026-08-01",
       "channel": "prerelease",


### PR DESCRIPTION
> 此预览版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。

**发布渠道：预览版 · v1.19.0-preview.3**

[English →](https://reasonix.io/changelog/v1.19.0-preview.3/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v1.19.0-preview.3/)

## 概览

**Reasonix v1.19.0-preview.3 — Reasonix 桌面端 v1.19.0-preview.3**

此预览版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。

发布日期：2026-08-01

## 重点内容

- **钱包余额现已与定价币种一致** — 选择美元定价后，桌面状态栏现在会显示美元余额。若无法提供美元余额，则显示实际币种前缀（如 CNY），不进行隐式汇率转换。 ([#7160](https://github.com/esengine/DeepSeek-Reasonix/pull/7160))
- **macOS 图标安全区域已恢复** — macOS 应用图标现在在 Dock 和其他系统界面中显示正确，符合预期设计。 ([#7123](https://github.com/esengine/DeepSeek-Reasonix/pull/7123))
- **浮层菜单在布局期间保持可见** — 锚定浮层（如能力等级和模型选择器）不再在首次打开时消失。在计算最终位置前，它们会保留在视口边缘可见。 ([#7132](https://github.com/esengine/DeepSeek-Reasonix/pull/7132))
- **卡住的更新事务自动恢复** — 如果之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))
- **输入框菜单现已完整显示** — 斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开完整高度。 ([#7128](https://github.com/esengine/DeepSeek-Reasonix/pull/7128))

## 修复

- **钱包余额现已与定价币种一致** — 选择美元定价后，状态栏余额现在显示美元，无法提供时以明确的币种前缀作为备用。 ([#7160](https://github.com/esengine/DeepSeek-Reasonix/pull/7160))
- **macOS 图标安全区域已恢复** — macOS 应用图标现在在 Dock 和其他系统界面中正确显示。 ([#7123](https://github.com/esengine/DeepSeek-Reasonix/pull/7123))
- **浮层菜单在布局期间保持可见** — 锚定浮层不再在首次打开时消失，它们在计算最终位置前保持可见。 ([#7132](https://github.com/esengine/DeepSeek-Reasonix/pull/7132))
- **防止 GB18030 搜索协程泄漏** — 修复了在达到 200 个匹配限制时，原生 GB18030 搜索期间可能发生的协程泄漏。 ([#7147](https://github.com/esengine/DeepSeek-Reasonix/pull/7147))
- **卡住的更新事务自动恢复** — 中断的更新尝试现在会自动调和，消除了“待处理更新已存在”的阻塞。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))
- **输入框菜单现已完整显示** — 斜杠命令和提及菜单不再被裁剪，它们展开至完整高度。 ([#7128](https://github.com/esengine/DeepSeek-Reasonix/pull/7128))

## 升级提醒

- **自动更新恢复** — 更新后，桌面应用将自动调和任何先前卡住的更新事务。您可能会在更新横幅中看到短暂的恢复状态。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))

## 风险提示

当前没有需要额外操作的已知风险。

## 致谢

感谢本版本的贡献者：[@SivanCola](https://github.com/SivanCola)、[@LouF666](https://github.com/LouF666)、[@QingLong-C](https://github.com/QingLong-C)、[@ShiroKSH](https://github.com/ShiroKSH)、[@clearnature](https://github.com/clearnature)

## 下载与安装

- [官网按平台下载](https://reasonix.io/?download=desktop&channel=preview#start)
- [查看完整差异](https://github.com/esengine/DeepSeek-Reasonix/compare/v1.19.0-preview.2...v1.19.0-preview.3)
