### PR TITLE
docs(release): prepare v1.19.1 notes / 准备 v1.19.1 更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -2,6 +2,231 @@
   "schemaVersion": 1,
   "releases": [
     {
+      "version": "1.19.1",
+      "date": "2026-08-01",
+      "channel": "stable",
+      "title": {
+        "en": "Reasonix Desktop v1.19.1",
+        "zh": "Reasonix 桌面端 v1.19.1"
+      },
+      "summary": {
+        "en": "This stable release fixes several user-reported issues, including wallet currency alignment, macOS icon rendering, menu clipping, and update recovery.",
+        "zh": "此稳定版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。"
+      },
+      "surfaces": [
+        "desktop"
+      ],
+      "guides": [],
+      "highlights": [
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Wallet balance now matches selected currency",
+            "zh": "钱包余额现已与所选币种一致"
+          },
+          "body": {
+            "en": "After selecting a pricing currency in Settings, the desktop status bar now shows the wallet balance in that currency. If the matching balance is unavailable, the actual currency prefix (e.g., CNY) is shown without implicit conversion.",
+            "zh": "在设置中选择定价币种后，桌面状态栏现在会以该币种显示钱包余额。若无法提供匹配余额，则显示实际币种前缀（如 CNY），不进行隐式转换。"
+          },
+          "refs": [
+            7160
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "macOS app icon safe area restored",
+            "zh": "macOS 应用图标安全区域已恢复"
+          },
+          "body": {
+            "en": "The macOS application icon now renders correctly in the Dock and other system interfaces, matching the intended design.",
+            "zh": "macOS 应用图标现在在 Dock 及其他系统界面中正确显示，符合预期设计。"
+          },
+          "refs": [
+            7123
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Anchored popovers remain visible during layout",
+            "zh": "锚定浮层在布局期间保持可见"
+          },
+          "body": {
+            "en": "Fixed an issue where anchored popovers (e.g., capability level and model selectors) could disappear immediately after opening. They now stay visible at the viewport edge until the final position is computed.",
+            "zh": "修复了锚定浮层（如能力等级和模型选择器）在打开后可能立即消失的问题。现在它们在计算最终位置前会保持在视口边缘可见。"
+          },
+          "refs": [
+            7132
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Prevented goroutine leak in GB18030 search",
+            "zh": "防止 GB18030 搜索协程泄漏"
+          },
+          "body": {
+            "en": "Fixed a goroutine leak that could occur when native GB18030 grep reached the 200-match limit, improving long-running stability.",
+            "zh": "修复了在原生 GB18030 搜索达到 200 个匹配限制时可能发生的协程泄漏，提升长时间运行稳定性。"
+          },
+          "refs": [
+            7147
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Automatic recovery from stuck update transactions",
+            "zh": "自动恢复卡住的更新事务"
+          },
+          "body": {
+            "en": "If a previous update attempt was interrupted, the app now automatically reconciles the state, eliminating 'a pending update already exists' errors and allowing updates to proceed.",
+            "zh": "若之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。"
+          },
+          "refs": [
+            7149
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Composer menus now display at full height",
+            "zh": "输入框菜单现已完整显示"
+          },
+          "body": {
+            "en": "The slash command and mention menus no longer appear clipped above the input box; they expand to their full height as intended.",
+            "zh": "斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开至完整高度。"
+          },
+          "refs": [
+            7128
+          ]
+        }
+      ],
+      "changes": {
+        "new": [],
+        "improved": [],
+        "fixed": [
+          {
+            "title": {
+              "en": "Wallet balance now matches selected currency",
+              "zh": "钱包余额现已与所选币种一致"
+            },
+            "body": {
+              "en": "After selecting a pricing currency in Settings, the desktop status bar now shows the wallet balance in that currency. If the matching balance is unavailable, the actual currency prefix (e.g., CNY) is shown without implicit conversion.",
+              "zh": "在设置中选择定价币种后，桌面状态栏现在会以该币种显示钱包余额。若无法提供匹配余额，则显示实际币种前缀（如 CNY），不进行隐式转换。"
+            },
+            "refs": [
+              7160
+            ]
+          },
+          {
+            "title": {
+              "en": "macOS app icon safe area restored",
+              "zh": "macOS 应用图标安全区域已恢复"
+            },
+            "body": {
+              "en": "The macOS application icon now renders correctly in the Dock and other system interfaces, matching the intended design.",
+              "zh": "macOS 应用图标现在在 Dock 及其他系统界面中正确显示，符合预期设计。"
+            },
+            "refs": [
+              7123
+            ]
+          },
+          {
+            "title": {
+              "en": "Anchored popovers remain visible during layout",
+              "zh": "锚定浮层在布局期间保持可见"
+            },
+            "body": {
+              "en": "Fixed an issue where anchored popovers (e.g., capability level and model selectors) could disappear immediately after opening. They now stay visible at the viewport edge until the final position is computed.",
+              "zh": "修复了锚定浮层（如能力等级和模型选择器）在打开后可能立即消失的问题。现在它们在计算最终位置前会保持在视口边缘可见。"
+            },
+            "refs": [
+              7132
+            ]
+          },
+          {
+            "title": {
+              "en": "Prevented goroutine leak in GB18030 search",
+              "zh": "防止 GB18030 搜索协程泄漏"
+            },
+            "body": {
+              "en": "Fixed a goroutine leak that could occur when native GB18030 grep reached the 200-match limit, improving long-running stability.",
+              "zh": "修复了在原生 GB18030 搜索达到 200 个匹配限制时可能发生的协程泄漏，提升长时间运行稳定性。"
+            },
+            "refs": [
+              7147
+            ]
+          },
+          {
+            "title": {
+              "en": "Automatic recovery from stuck update transactions",
+              "zh": "自动恢复卡住的更新事务"
+            },
+            "body": {
+              "en": "If a previous update attempt was interrupted, the app now automatically reconciles the state, eliminating 'a pending update already exists' errors and allowing updates to proceed.",
+              "zh": "若之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。"
+            },
+            "refs": [
+              7149
+            ]
+          },
+          {
+            "title": {
+              "en": "Composer menus now display at full height",
+              "zh": "输入框菜单现已完整显示"
+            },
+            "body": {
+              "en": "The slash command and mention menus no longer appear clipped above the input box; they expand to their full height as intended.",
+              "zh": "斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开至完整高度。"
+            },
+            "refs": [
+              7128
+            ]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": {
+            "en": "Automatic update recovery",
+            "zh": "自动更新恢复"
+          },
+          "body": {
+            "en": "After updating, the desktop app will automatically reconcile any previously stuck update transactions. You may briefly see a 'recovering' state in the update banner.",
+            "zh": "更新后，桌面应用将自动调和任何先前卡住的更新事务。您可能会在更新横幅中短暂看到“恢复中”状态。"
+          },
+          "refs": [
+            7149
+          ]
+        }
+      ],
+      "risks": [],
+      "contributors": [
+        "SivanCola",
+        "LouF666",
+        "QingLong-C",
+        "ShiroKSH",
+        "clearnature"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.19.1",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/v1.19.0...desktop-v1.19.1",
+        "download": "https://reasonix.io/?download=desktop&channel=stable#start"
+      },
+      "releaseId": "1.19.1",
+      "baseVersion": "1.19.1",
+      "status": "reviewed",
+      "previousRelease": "1.19.0",
+      "builds": {
+        "cli": "v1.19.1",
+        "desktop": "v1.19.1",
+        "npm": "1.19.1"
+      }
+    },
+    {
       "version": "1.19.0",
       "date": "2026-08-01",
       "channel": "stable",


### PR DESCRIPTION
> 此稳定版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。

**发布渠道：稳定版 · v1.19.1**

[English →](https://reasonix.io/changelog/v1.19.1/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v1.19.1/)

## 概览

**Reasonix v1.19.1 — Reasonix 桌面端 v1.19.1**

此稳定版修复了多个用户报告的问题，包括钱包币种对齐、macOS 图标渲染、菜单裁剪和更新恢复。

发布日期：2026-08-01

## 重点内容

- **钱包余额现已与所选币种一致** — 在设置中选择定价币种后，桌面状态栏现在会以该币种显示钱包余额。若无法提供匹配余额，则显示实际币种前缀（如 CNY），不进行隐式转换。 ([#7160](https://github.com/esengine/DeepSeek-Reasonix/pull/7160))
- **macOS 应用图标安全区域已恢复** — macOS 应用图标现在在 Dock 及其他系统界面中正确显示，符合预期设计。 ([#7123](https://github.com/esengine/DeepSeek-Reasonix/pull/7123))
- **锚定浮层在布局期间保持可见** — 修复了锚定浮层（如能力等级和模型选择器）在打开后可能立即消失的问题。现在它们在计算最终位置前会保持在视口边缘可见。 ([#7132](https://github.com/esengine/DeepSeek-Reasonix/pull/7132))
- **防止 GB18030 搜索协程泄漏** — 修复了在原生 GB18030 搜索达到 200 个匹配限制时可能发生的协程泄漏，提升长时间运行稳定性。 ([#7147](https://github.com/esengine/DeepSeek-Reasonix/pull/7147))
- **自动恢复卡住的更新事务** — 若之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))
- **输入框菜单现已完整显示** — 斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开至完整高度。 ([#7128](https://github.com/esengine/DeepSeek-Reasonix/pull/7128))

## 修复

- **钱包余额现已与所选币种一致** — 在设置中选择定价币种后，桌面状态栏现在会以该币种显示钱包余额。若无法提供匹配余额，则显示实际币种前缀（如 CNY），不进行隐式转换。 ([#7160](https://github.com/esengine/DeepSeek-Reasonix/pull/7160))
- **macOS 应用图标安全区域已恢复** — macOS 应用图标现在在 Dock 及其他系统界面中正确显示，符合预期设计。 ([#7123](https://github.com/esengine/DeepSeek-Reasonix/pull/7123))
- **锚定浮层在布局期间保持可见** — 修复了锚定浮层（如能力等级和模型选择器）在打开后可能立即消失的问题。现在它们在计算最终位置前会保持在视口边缘可见。 ([#7132](https://github.com/esengine/DeepSeek-Reasonix/pull/7132))
- **防止 GB18030 搜索协程泄漏** — 修复了在原生 GB18030 搜索达到 200 个匹配限制时可能发生的协程泄漏，提升长时间运行稳定性。 ([#7147](https://github.com/esengine/DeepSeek-Reasonix/pull/7147))
- **自动恢复卡住的更新事务** — 若之前的更新尝试中断，应用现在会自动调和状态，消除“待处理更新已存在”错误并允许继续更新。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))
- **输入框菜单现已完整显示** — 斜杠命令和提及菜单不再在输入框上方被裁剪，它们按预期展开至完整高度。 ([#7128](https://github.com/esengine/DeepSeek-Reasonix/pull/7128))

## 升级提醒

- **自动更新恢复** — 更新后，桌面应用将自动调和任何先前卡住的更新事务。您可能会在更新横幅中短暂看到“恢复中”状态。 ([#7149](https://github.com/esengine/DeepSeek-Reasonix/pull/7149))

## 风险提示

当前没有需要额外操作的已知风险。

## 致谢

感谢本版本的贡献者：[@SivanCola](https://github.com/SivanCola)、[@LouF666](https://github.com/LouF666)、[@QingLong-C](https://github.com/QingLong-C)、[@ShiroKSH](https://github.com/ShiroKSH)、[@clearnature](https://github.com/clearnature)

## 下载与安装

- [官网按平台下载](https://reasonix.io/?download=desktop&channel=stable#start)
- [查看完整差异](https://github.com/esengine/DeepSeek-Reasonix/compare/v1.19.0...desktop-v1.19.1)
