### PR TITLE
fix(mcp): keep slow startup alive in background / 修复 MCP 慢启动反复重启

### DIFF
--- a/docs/CAPABILITY_DIAGNOSTICS.md
+++ b/docs/CAPABILITY_DIAGNOSTICS.md
@@ -87,6 +87,13 @@ Common codes: `mcp.command_not_found`, `mcp.invalid_transport`,
 with “Include current session runtime” to read the **active tab Host** without
 starting a second Host.
 
+Each MCP entry identifies the exact winning configuration with `source`,
+`source_path`, and `effective`. Startup failures also report `startup_stage`
+(`launch`, `authorization`, `initialize`, or `tools/list`),
+`startup_elapsed_ms`, and a bounded, credential-redacted `stderr` tail. This
+distinguishes duplicate/shadowed registration from a genuinely slow or broken
+handshake without exposing full process output.
+
 ### 4. Ask the agent (`reasonix-guide`)
 
 In an interactive session:

--- a/docs/CAPABILITY_DIAGNOSTICS.zh-CN.md
+++ b/docs/CAPABILITY_DIAGNOSTICS.zh-CN.md
@@ -83,6 +83,11 @@ reasonix doctor capabilities | sed -n '/Hooks/,/Plugins/p'
 `mcp.start_failed`、`mcp.no_tools`。桌面端更推荐 **设置 → 诊断** 打开
 「包含当前会话运行状态」——只读取**活动标签 Host**，不会再起第二个 Host。
 
+每个 MCP 条目通过 `source`、`source_path` 和 `effective` 标明真正生效的配置及其来源。
+启动失败还会报告 `startup_stage`（`launch`、`authorization`、`initialize` 或
+`tools/list`）、`startup_elapsed_ms`，以及有长度上限且已做凭据脱敏的 `stderr` 尾部。
+这可以区分重复/被覆盖的注册与真正缓慢或失败的握手，同时不会暴露完整进程输出。
+
 ### 4. 让 Agent 按手册排查（`reasonix-guide`）
 
 交互式会话中：

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -79,6 +79,7 @@ api_key_env = "DEEPSEEK_API_KEY"
 [tools]
 enabled = []   # omit/empty = all built-ins
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+mcp_startup_timeout_seconds = 30   # background initialize + tools/list safety cap
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
 
 [environment]
@@ -110,6 +111,7 @@ auth_mode = "none"             # none|token|password; use auth before binding be
 [[plugins]]
 name    = "example"
 command = "reasonix-plugin-example"
+startup_timeout_seconds = 60   # optional initialize + tools/list cap
 call_timeout_seconds = 600   # optional per-server MCP call timeout
 tool_timeout_seconds = { "generate_video" = 1800 }   # optional raw MCP tool names
 ```
@@ -802,6 +804,7 @@ resource) you can copy.
 [[plugins]]                       # local stdio server
 name    = "example"
 command = "reasonix-plugin-example"
+# startup_timeout_seconds = 60    # optional initialize + tools/list cap
 # call_timeout_seconds = 600       # optional per-server MCP call timeout
 # tool_timeout_seconds = { "generate_video" = 1800 }   # optional raw MCP tool names
 
@@ -819,6 +822,13 @@ disable a server for the current session. For a read-only config/runtime health
 report across skills, hooks, packages, and MCP (without changing settings), see
 [Capability diagnostics](./CAPABILITY_DIAGNOSTICS.md)
 (`reasonix doctor capabilities` or **Settings → Diagnostics**).
+
+An interactive caller waits only briefly for a cold server. If that wait ends,
+the shared startup continues in the background rather than being killed and
+restarted; retry the tool after it comes online. `mcp_startup_timeout_seconds`
+(default `30`) bounds the full launch, authorization, initialize, and
+`tools/list` sequence. `mcp_call_timeout_seconds` applies only after the server
+is connected. Either value can be overridden per server.
 
 **Already have an `.mcp.json`?** Drop it in the project root and Reasonix
 reads it as-is — the `mcpServers` spec (`command`/`args`/`env`, `type`/`url`/

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -73,6 +73,7 @@ api_key_env = "DEEPSEEK_API_KEY"
 [tools]
 enabled = []   # 省略/为空 = 全部内置工具
 bash_timeout_seconds = 120   # 前台安全上限；设为 0 表示不设工具层超时
+mcp_startup_timeout_seconds = 30   # 后台 initialize + tools/list 安全上限
 mcp_call_timeout_seconds = 300   # MCP 调用默认安全上限；可用 plugin/tool 覆盖
 
 [environment]
@@ -104,6 +105,7 @@ auth_mode = "none"             # none|token|password；绑定到非 localhost �
 [[plugins]]
 name    = "example"
 command = "reasonix-plugin-example"
+startup_timeout_seconds = 60   # 可选：initialize + tools/list 上限
 call_timeout_seconds = 600   # 可选：单个 MCP server 的调用超时
 tool_timeout_seconds = { "generate_video" = 1800 }   # 可选：raw MCP tool 名称
 ```
@@ -638,6 +640,7 @@ stdio 参考实现（`echo`、`wordcount`、一个 `review` prompt、一个 styl
 [[plugins]]                       # 本地 stdio 服务器
 name    = "example"
 command = "reasonix-plugin-example"
+# startup_timeout_seconds = 60    # 可选：initialize + tools/list 上限
 # call_timeout_seconds = 600       # 可选：单个 MCP server 的调用超时
 # tool_timeout_seconds = { "generate_video" = 1800 }   # 可选：raw MCP tool 名称
 
@@ -653,6 +656,11 @@ headers = { Authorization = "Bearer ${STRIPE_KEY}" }
 若要跨 skills / hooks / 插件包 / MCP 做只读健康检查（不改配置），见
 [能力诊断](./CAPABILITY_DIAGNOSTICS.zh-CN.md)
 （`reasonix doctor capabilities` 或 **设置 → 诊断**）。
+
+交互调用方只会为冷启动短暂等待；即使等待结束，共享启动仍会在后台继续，不会被杀掉后反复重启，
+服务器上线后重试工具即可。`mcp_startup_timeout_seconds`（默认 `30`）限制从进程启动、授权、
+`initialize` 到 `tools/list` 的完整启动流程；`mcp_call_timeout_seconds` 只作用于连接成功后的
+RPC 调用。两者都可按服务器覆盖。
 
 **已有 Claude Code 的 `.mcp.json`？** 直接放到项目根目录，Reasonix 会原样读取——其
 `mcpServers` 规范（`command`/`args`/`env`、`type`/`url`/`headers`、`${VAR}` 展开）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -704,6 +704,7 @@ enabled = true   # inject a stable startup summary of OS, shell, and common tool
 [tools]
 enabled = []   # omit/empty = all built-ins
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+mcp_startup_timeout_seconds = 30   # background initialize + tools/list safety cap
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; plugin/tool overrides may raise it
 
 [tools.shell]
@@ -737,6 +738,7 @@ name    = "example"            # type defaults to "stdio"
 command = "reasonix-plugin-example"
 args    = []
 # env   = { FOO = "bar" }
+# startup_timeout_seconds = 60         # initialize + tools/list cap; 0 = global/default cap
 # call_timeout_seconds = 600            # per-server MCP call timeout; 0 = global/default cap
 # tool_timeout_seconds = { "generate_video" = 1800 }   # raw MCP tool names
 # [[plugins]]                   # a remote MCP server over Streamable HTTP
@@ -786,6 +788,13 @@ Code's exact `mcpServers` schema (`command`/`args`/`env`, `type`/`url`/`headers`
 `[[plugins]]`; on a name collision `reasonix.toml` wins (it is the more explicit,
 Reasonix-specific source). This lets a server already configured for Claude work in
 Reasonix unchanged.
+
+MCP startup has a separate lifecycle from an individual tool call. A caller
+waits briefly for cold startup, while the shared launch/authorization/
+`initialize`/`tools/list` sequence may continue in the background up to
+`mcp_startup_timeout_seconds` (default `30`). A per-server
+`startup_timeout_seconds` overrides that cap. MCP call timeouts begin only after
+the connection is ready.
 
 ```json
 { "mcpServers": {

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -247,6 +247,7 @@ context_window = 1000000
 [tools]
 enabled = []
 bash_timeout_seconds = 120
+mcp_startup_timeout_seconds = 30
 mcp_call_timeout_seconds = 300
 
 [permissions]
@@ -272,6 +273,10 @@ auth_mode = "none"
 `[serve]` 控制 `reasonix serve` 的 browser frontend。默认 `auth_mode = "none"` 仅适合 loopback；暴露到其他机器时必须使用 token 或 password。只有位于可信 reverse proxy 后方时才能启用 `behind_proxy`。
 
 项目根目录的 `.mcp.json` 可使用 Claude Code 的 `mcpServers` schema；与 `reasonix.toml` 同名时，以后者为准。
+
+MCP 启动与单次工具调用使用不同生命周期。调用方只短暂等待冷启动，而共享的进程启动、授权、
+`initialize`、`tools/list` 可在后台继续，最长由 `mcp_startup_timeout_seconds`（默认 `30`）
+限制；单个服务器可用 `startup_timeout_seconds` 覆盖。MCP 调用超时只在连接就绪后开始计算。
 
 ## 6. 错误处理
 

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -1151,17 +1151,29 @@ func (t *UseCapabilityTool) ensureServerToolsForSpec(ctx context.Context, server
 	if t.host.HasClient(server) {
 		return t.serverToolsForSpec(ctx, server, spec)
 	}
-	// On-demand connect: the handshake gets a short budget, but the child
-	// process lifetime belongs to the session-scoped lifeCtx — canceling the
-	// handshake context after connect must not kill a stdio server the tool
-	// call is about to use. Tools stay off the main registry.
+	// On-demand connect: the child and handshake belong to the session. This
+	// tool call waits briefly, but a slow healthy server continues in the
+	// background instead of being killed and restarted on every retry. Tools
+	// stay off the main provider-visible registry.
 	life := t.lifeCtx
 	if life == nil {
 		life = context.Background()
 	}
-	handshakeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	tools, err := t.host.AddWithLifecycle(life, handshakeCtx, spec)
+	result := t.host.EnsureConnectedInBackground(life, spec)
+	waitBudget := plugin.DefaultStartupWaitBudget()
+	timer := time.NewTimer(waitBudget)
+	defer timer.Stop()
+	var tools []tool.Tool
+	var err error
+	select {
+	case connected := <-result:
+		tools, err = connected.Tools, connected.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timer.C:
+		return nil, fmt.Errorf("MCP server %q is still initializing after %s; startup continues in background (limit %s) — retry on a later turn",
+			server, waitBudget, spec.ResolvedStartupTimeout())
+	}
 	if err != nil {
 		if plugin.IsServerAlreadyConnected(err) {
 			return t.serverToolsForSpec(ctx, server, spec)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -528,14 +528,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// a single background catalog discovery. First real tool call uses
 	// EnsureConnected so parent/child/tab runtimes share one process.
 	pluginSpecOptions := PluginSpecOptions{
-		DefaultCallTimeout: time.Duration(cfg.MCPCallTimeoutSeconds()) * time.Second,
-		LaunchManager:      mcplaunch.ForWorkspace(config.ReasonixHomeDir(), root),
-		ConfigSource:       "workspace_config",
-		StateHome:          config.ReasonixHomeDir(),
-		WriterRoots:        writeRoots,
-		ForbidReadRoots:    forbidReadRoots,
-		Network:            networkEnabled,
-		PackageOwners:      pluginPackageOwners(cfg),
+		DefaultStartupTimeout: time.Duration(cfg.MCPStartupTimeoutSeconds()) * time.Second,
+		DefaultCallTimeout:    time.Duration(cfg.MCPCallTimeoutSeconds()) * time.Second,
+		LaunchManager:         mcplaunch.ForWorkspace(config.ReasonixHomeDir(), root),
+		ConfigSource:          "workspace_config",
+		StateHome:             config.ReasonixHomeDir(),
+		WriterRoots:           writeRoots,
+		ForbidReadRoots:       forbidReadRoots,
+		Network:               networkEnabled,
+		PackageOwners:         pluginPackageOwners(cfg),
 	}
 	autoStartEntries := cfg.EnabledPlugins(root, config.DefaultMCPActivationStore())
 	enabledMCPNames := make(map[string]bool, len(autoStartEntries))
@@ -555,9 +556,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		// plugins, so a recovery boot never starts external processes.
 		extraPlugins = nil
 	}
-	extraSpecs := applyDefaultMCPCallTimeout(
-		applyKnownPluginOverrides(extraPlugins, root),
-		pluginSpecOptions.DefaultCallTimeout,
+	extraSpecs := applyDefaultMCPStartupTimeout(
+		applyDefaultMCPCallTimeout(
+			applyKnownPluginOverrides(extraPlugins, root),
+			pluginSpecOptions.DefaultCallTimeout,
+		),
+		pluginSpecOptions.DefaultStartupTimeout,
 	)
 	for i := range extraSpecs {
 		if strings.TrimSpace(extraSpecs[i].WorkspaceRoot) == "" {
@@ -1701,6 +1705,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			if strings.TrimSpace(spec.ConfigSource) == "" {
 				spec.ConfigSource = pluginSpecOptions.ConfigSource
 			}
+			if spec.DefaultStartupTimeout <= 0 {
+				spec.DefaultStartupTimeout = pluginSpecOptions.DefaultStartupTimeout
+			}
 			applyMCPIsolation(spec, root, pluginSpecOptions)
 		},
 		CapabilityRuntime:      capRuntime,
@@ -2363,14 +2370,15 @@ func PluginSpecsForRoot(entries []config.PluginEntry, workspaceRoot string) []pl
 // PluginSpecOptions carries runtime policy that is not stored on each plugin
 // entry but still needs to reach plugin.Spec.
 type PluginSpecOptions struct {
-	DefaultCallTimeout time.Duration
-	LaunchManager      *mcplaunch.Manager
-	ConfigSource       string
-	StateHome          string
-	WriterRoots        []string
-	ForbidReadRoots    []string
-	Network            bool
-	PackageOwners      map[string]string
+	DefaultStartupTimeout time.Duration
+	DefaultCallTimeout    time.Duration
+	LaunchManager         *mcplaunch.Manager
+	ConfigSource          string
+	StateHome             string
+	WriterRoots           []string
+	ForbidReadRoots       []string
+	Network               bool
+	PackageOwners         map[string]string
 }
 
 // PluginSpecsForRootWithOptions maps configured plugin entries to plugin.Spec
@@ -2390,21 +2398,23 @@ func pluginSpecFromEntryWithOptions(e config.PluginEntry, workspaceRoot string, 
 		configSource = opts.ConfigSource
 	}
 	spec := plugin.ApplyKnownOverrides(plugin.Spec{
-		Name:               e.Name,
-		Package:            strings.TrimSpace(opts.PackageOwners[e.Name]),
-		Type:               e.Type,
-		Command:            e.Command,
-		Args:               e.Args,
-		Env:                e.Env,
-		URL:                e.URL,
-		Headers:            e.Headers,
-		DefaultCallTimeout: opts.DefaultCallTimeout,
-		CallTimeout:        secondsDuration(e.CallTimeoutSeconds),
-		ToolTimeouts:       toolTimeoutDurations(e.ToolTimeoutSeconds),
-		WorkspaceRoot:      strings.TrimSpace(workspaceRoot),
-		LaunchManager:      opts.LaunchManager,
-		ConfigSource:       configSource,
-		Authorized:         e.Source.UserAuthorized(),
+		Name:                  e.Name,
+		Package:               strings.TrimSpace(opts.PackageOwners[e.Name]),
+		Type:                  e.Type,
+		Command:               e.Command,
+		Args:                  e.Args,
+		Env:                   e.Env,
+		URL:                   e.URL,
+		Headers:               e.Headers,
+		DefaultStartupTimeout: opts.DefaultStartupTimeout,
+		StartupTimeout:        secondsDuration(e.StartupTimeoutSeconds),
+		DefaultCallTimeout:    opts.DefaultCallTimeout,
+		CallTimeout:           secondsDuration(e.CallTimeoutSeconds),
+		ToolTimeouts:          toolTimeoutDurations(e.ToolTimeoutSeconds),
+		WorkspaceRoot:         strings.TrimSpace(workspaceRoot),
+		LaunchManager:         opts.LaunchManager,
+		ConfigSource:          configSource,
+		Authorized:            e.Source.UserAuthorized(),
 	}, workspaceRoot)
 	if e.Source.ProjectScoped() && strings.TrimSpace(spec.Dir) == "" {
 		spec.Dir = workspaceRoot
@@ -2540,6 +2550,20 @@ func applyDefaultMCPCallTimeout(specs []plugin.Spec, timeout time.Duration) []pl
 		out[i] = spec
 		if out[i].DefaultCallTimeout <= 0 {
 			out[i].DefaultCallTimeout = timeout
+		}
+	}
+	return out
+}
+
+func applyDefaultMCPStartupTimeout(specs []plugin.Spec, timeout time.Duration) []plugin.Spec {
+	if len(specs) == 0 || timeout <= 0 {
+		return specs
+	}
+	out := make([]plugin.Spec, len(specs))
+	for i, spec := range specs {
+		out[i] = spec
+		if out[i].DefaultStartupTimeout <= 0 {
+			out[i].DefaultStartupTimeout = timeout
 		}
 	}
 	return out

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -4339,22 +4339,29 @@ func TestPartitionByTier(t *testing.T) {
 	}
 }
 
-func TestPluginSpecsMapConfiguredCallTimeouts(t *testing.T) {
+func TestPluginSpecsMapConfiguredMCPTimeouts(t *testing.T) {
 	specs := PluginSpecsForRootWithOptions([]config.PluginEntry{{
-		Name:               "maker",
-		Command:            "maker-mcp",
-		CallTimeoutSeconds: 600,
+		Name:                  "maker",
+		Command:               "maker-mcp",
+		StartupTimeoutSeconds: 45,
+		CallTimeoutSeconds:    600,
 		ToolTimeoutSeconds: map[string]int{
 			"generate_video": 1800,
 			" ":              120,
 			"zero":           0,
 		},
-	}}, "", PluginSpecOptions{DefaultCallTimeout: 300 * time.Second})
+	}}, "", PluginSpecOptions{
+		DefaultStartupTimeout: 30 * time.Second,
+		DefaultCallTimeout:    300 * time.Second,
+	})
 	if len(specs) != 1 {
 		t.Fatalf("PluginSpecs returned %d specs, want 1", len(specs))
 	}
 	if specs[0].DefaultCallTimeout != 5*time.Minute {
 		t.Fatalf("DefaultCallTimeout = %v, want 5m", specs[0].DefaultCallTimeout)
+	}
+	if specs[0].DefaultStartupTimeout != 30*time.Second || specs[0].StartupTimeout != 45*time.Second {
+		t.Fatalf("startup timeouts = default %v override %v, want 30s/45s", specs[0].DefaultStartupTimeout, specs[0].StartupTimeout)
 	}
 	if specs[0].CallTimeout != 10*time.Minute {
 		t.Fatalf("CallTimeout = %v, want 10m", specs[0].CallTimeout)
@@ -4458,6 +4465,19 @@ func TestApplyDefaultMCPCallTimeoutPreservesConfiguredDefault(t *testing.T) {
 	}
 	if specs[1].DefaultCallTimeout != 5*time.Minute {
 		t.Fatalf("empty DefaultCallTimeout = %v, want 5m", specs[1].DefaultCallTimeout)
+	}
+}
+
+func TestApplyDefaultMCPStartupTimeoutPreservesConfiguredDefault(t *testing.T) {
+	specs := applyDefaultMCPStartupTimeout([]plugin.Spec{
+		{Name: "configured", DefaultStartupTimeout: 20 * time.Second},
+		{Name: "empty"},
+	}, 30*time.Second)
+	if specs[0].DefaultStartupTimeout != 20*time.Second {
+		t.Fatalf("configured DefaultStartupTimeout overwritten: %v", specs[0].DefaultStartupTimeout)
+	}
+	if specs[1].DefaultStartupTimeout != 30*time.Second {
+		t.Fatalf("empty DefaultStartupTimeout = %v, want 30s", specs[1].DefaultStartupTimeout)
 	}
 }
 

--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -477,6 +477,7 @@ func collectMCP(cfg *config.Config, root, home string, disp func(string) string)
 	for _, p := range entries {
 		info := MCPServerInfo{
 			Name:        p.Name,
+			Effective:   true,
 			Transport:   transportOf(p.Type),
 			StartIntent: "automatic",
 			EnvKeys:     sortedKeys(p.Env),
@@ -489,7 +490,13 @@ func collectMCP(cfg *config.Config, root, home string, disp func(string) string)
 			info.PackageOwner = owner
 			info.Source = "plugin_package"
 		} else {
-			info.Source = guessMCPSource(root, p.Name)
+			info.Source = strings.TrimSpace(string(p.Source))
+			if info.Source == "" {
+				info.Source = guessMCPSource(root, p.Name)
+			}
+			if sourcePath := config.MCPConfigPathForEntry(root, p); strings.TrimSpace(sourcePath) != "" {
+				info.SourcePath = disp(sourcePath)
+			}
 		}
 		if info.Transport == "stdio" {
 			info.Command = redactCommandDisplay(p.Command, root, home)
@@ -610,6 +617,9 @@ func mergeRuntimeHost(rep *MCPReport, host *plugin.Host, root, home string, issu
 		if i, ok := byName[f.Name]; ok {
 			rep.Servers[i].RuntimeStatus = "failed"
 			rep.Servers[i].Error = errText
+			rep.Servers[i].StartupStage = f.Stage
+			rep.Servers[i].StartupElapsedMS = f.Elapsed.Milliseconds()
+			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home)
 		}
 		*issues = append(*issues, Issue{
 			Severity: "error", Code: "mcp.start_failed", Subsystem: "mcp",

--- a/internal/capdiag/collect_test.go
+++ b/internal/capdiag/collect_test.go
@@ -62,6 +62,13 @@ auto_start = false
 	if r.Live {
 		t.Fatal("static mode must set live=false")
 	}
+	if len(r.MCP.Servers) != 1 {
+		t.Fatalf("MCP servers = %+v, want one effective entry", r.MCP.Servers)
+	}
+	mcp := r.MCP.Servers[0]
+	if !mcp.Effective || mcp.Source != "project_config" || mcp.SourcePath != "<workspace>/reasonix.toml" {
+		t.Fatalf("effective MCP provenance = %+v", mcp)
+	}
 	// Missing convention dirs should not produce warnings.
 	for _, is := range r.Issues {
 		if strings.Contains(is.Message, "missing") && is.Subsystem == "skills" && is.Code != "skill.missing_description" {

--- a/internal/capdiag/live.go
+++ b/internal/capdiag/live.go
@@ -103,6 +103,9 @@ func probeLiveMCP(rep *MCPReport, cfg *config.Config, root, home string, timeout
 		if i, ok := byName[f.Name]; ok {
 			rep.Servers[i].RuntimeStatus = "failed"
 			rep.Servers[i].Error = errText
+			rep.Servers[i].StartupStage = f.Stage
+			rep.Servers[i].StartupElapsedMS = f.Elapsed.Milliseconds()
+			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home)
 		}
 		issues = append(issues, Issue{
 			Severity: "error", Code: "mcp.start_failed", Subsystem: "mcp",

--- a/internal/capdiag/render.go
+++ b/internal/capdiag/render.go
@@ -77,7 +77,7 @@ func RenderText(r Report) string {
 
 	fmt.Fprintf(&b, "MCP (%d)\n", len(r.MCP.Servers))
 	for _, s := range r.MCP.Servers {
-		fmt.Fprintf(&b, "  - %s transport=%s intent=%s source=%s", s.Name, s.Transport, s.StartIntent, s.Source)
+		fmt.Fprintf(&b, "  - %s transport=%s intent=%s source=%s effective=%v", s.Name, s.Transport, s.StartIntent, s.Source, s.Effective)
 		if s.RuntimeStatus != "" {
 			fmt.Fprintf(&b, " runtime=%s", s.RuntimeStatus)
 		}
@@ -85,8 +85,17 @@ func RenderText(r Report) string {
 			fmt.Fprintf(&b, " tools=%d", s.ToolCount)
 		}
 		b.WriteByte('\n')
+		if s.SourcePath != "" {
+			fmt.Fprintf(&b, "    source_path: %s\n", s.SourcePath)
+		}
+		if s.StartupStage != "" {
+			fmt.Fprintf(&b, "    startup: stage=%s elapsed_ms=%d\n", s.StartupStage, s.StartupElapsedMS)
+		}
 		if s.Error != "" {
 			fmt.Fprintf(&b, "    error: %s\n", s.Error)
+		}
+		if s.Stderr != "" {
+			fmt.Fprintf(&b, "    stderr: %s\n", s.Stderr)
 		}
 	}
 	if len(r.MCP.Servers) == 0 {

--- a/internal/capdiag/types.go
+++ b/internal/capdiag/types.go
@@ -173,19 +173,24 @@ type MCPReport struct {
 
 // MCPServerInfo is one merged MCP server.
 type MCPServerInfo struct {
-	Name          string        `json:"name"`
-	Source        string        `json:"source,omitempty"` // toml | mcp_json | plugin_package
-	PackageOwner  string        `json:"package_owner,omitempty"`
-	Transport     string        `json:"transport"`
-	StartIntent   string        `json:"start_intent"`      // automatic | off
-	Command       string        `json:"command,omitempty"` // redacted path form
-	URLHost       string        `json:"url_host,omitempty"`
-	EnvKeys       []string      `json:"env_keys,omitempty"`
-	HeaderKeys    []string      `json:"header_keys,omitempty"`
-	RuntimeStatus string        `json:"runtime_status,omitempty"` // connected | failed | deferred | disabled | skipped | probed
-	ToolCount     int           `json:"tool_count,omitempty"`
-	Tools         []MCPToolInfo `json:"tools,omitempty"`
-	Error         string        `json:"error,omitempty"`
+	Name             string        `json:"name"`
+	Source           string        `json:"source,omitempty"` // user_config | project_config | project_mcp_json | plugin_package | host_session
+	SourcePath       string        `json:"source_path,omitempty"`
+	Effective        bool          `json:"effective"`
+	PackageOwner     string        `json:"package_owner,omitempty"`
+	Transport        string        `json:"transport"`
+	StartIntent      string        `json:"start_intent"`      // automatic | off
+	Command          string        `json:"command,omitempty"` // redacted path form
+	URLHost          string        `json:"url_host,omitempty"`
+	EnvKeys          []string      `json:"env_keys,omitempty"`
+	HeaderKeys       []string      `json:"header_keys,omitempty"`
+	RuntimeStatus    string        `json:"runtime_status,omitempty"` // connected | failed | deferred | disabled | skipped | probed
+	ToolCount        int           `json:"tool_count,omitempty"`
+	Tools            []MCPToolInfo `json:"tools,omitempty"`
+	Error            string        `json:"error,omitempty"`
+	StartupStage     string        `json:"startup_stage,omitempty"`
+	StartupElapsedMS int64         `json:"startup_elapsed_ms,omitempty"`
+	Stderr           string        `json:"stderr,omitempty"`
 }
 
 // MCPToolInfo is one tool discovered during live/runtime probe.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1476,16 +1476,18 @@ func clonePricing(p *provider.Pricing) *provider.Pricing {
 
 // ToolsConfig selects which built-in tools are enabled. Empty means all of them.
 type ToolsConfig struct {
-	Enabled               []string             `toml:"enabled"`
-	BashTimeoutSeconds    *int                 `toml:"bash_timeout_seconds"`
-	MCPCallTimeoutSeconds *int                 `toml:"mcp_call_timeout_seconds"`
-	BackgroundJobs        BackgroundJobsConfig `toml:"background_jobs"`
-	Search                SearchConfig         `toml:"search"`
-	Shell                 ShellConfig          `toml:"shell"`
+	Enabled                  []string             `toml:"enabled"`
+	BashTimeoutSeconds       *int                 `toml:"bash_timeout_seconds"`
+	MCPStartupTimeoutSeconds *int                 `toml:"mcp_startup_timeout_seconds"`
+	MCPCallTimeoutSeconds    *int                 `toml:"mcp_call_timeout_seconds"`
+	BackgroundJobs           BackgroundJobsConfig `toml:"background_jobs"`
+	Search                   SearchConfig         `toml:"search"`
+	Shell                    ShellConfig          `toml:"shell"`
 }
 
 const (
 	defaultBashTimeoutSeconds             = 120
+	defaultMCPStartupTimeoutSeconds       = 30
 	defaultMCPCallTimeoutSeconds          = 300
 	defaultBackgroundJobStalledWarningSec = 900
 	maxBackgroundJobStalledWarningSec     = 86400
@@ -1510,6 +1512,17 @@ func (c *Config) MCPCallTimeoutSeconds() int {
 		return defaultMCPCallTimeoutSeconds
 	}
 	return *c.Tools.MCPCallTimeoutSeconds
+}
+
+// MCPStartupTimeoutSeconds returns the background initialize + tools/list
+// safety cap. Omitted, zero, and negative values keep the built-in default so
+// a slow but healthy MCP can outlive the short interactive wait without running
+// indefinitely.
+func (c *Config) MCPStartupTimeoutSeconds() int {
+	if c.Tools.MCPStartupTimeoutSeconds == nil || *c.Tools.MCPStartupTimeoutSeconds <= 0 {
+		return defaultMCPStartupTimeoutSeconds
+	}
+	return *c.Tools.MCPStartupTimeoutSeconds
 }
 
 // BackgroundJobsConfig tunes parent-created background jobs.
@@ -1607,6 +1620,9 @@ type PluginEntry struct {
 	Env     map[string]string `toml:"env"`
 	URL     string            `toml:"url"`
 	Headers map[string]string `toml:"headers"`
+	// StartupTimeoutSeconds overrides [tools].mcp_startup_timeout_seconds for
+	// initialize + tools/list. Zero keeps the global/default cap.
+	StartupTimeoutSeconds int `toml:"startup_timeout_seconds"`
 	// CallTimeoutSeconds overrides the default per-call deadline for this MCP
 	// server. Zero falls back to [tools].mcp_call_timeout_seconds.
 	CallTimeoutSeconds int `toml:"call_timeout_seconds"`

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1461,6 +1461,9 @@ func validatePlugin(e PluginEntry) error {
 	if strings.TrimSpace(e.Name) == "" {
 		return fmt.Errorf("plugin: name is required")
 	}
+	if e.StartupTimeoutSeconds < 0 {
+		return fmt.Errorf("plugin %q: startup_timeout_seconds must be >= 0", e.Name)
+	}
 	if e.CallTimeoutSeconds < 0 {
 		return fmt.Errorf("plugin %q: call_timeout_seconds must be >= 0", e.Name)
 	}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1028,6 +1028,9 @@ func TestPluginMutators(t *testing.T) {
 	if err := c.UpsertPlugin(PluginEntry{Name: "bad", Command: "x", CallTimeoutSeconds: -1}); err == nil {
 		t.Error("negative call_timeout_seconds should error")
 	}
+	if err := c.UpsertPlugin(PluginEntry{Name: "bad", Command: "x", StartupTimeoutSeconds: -1}); err == nil {
+		t.Error("negative startup_timeout_seconds should error")
+	}
 	if err := c.UpsertPlugin(PluginEntry{Name: "bad", Command: "x", ToolTimeoutSeconds: map[string]int{"generate": -1}}); err == nil {
 		t.Error("negative tool_timeout_seconds should error")
 	}

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -22,17 +22,18 @@ const mcpJSONFile = ".mcp.json"
 // mcpServerSpec mirrors one entry of Claude Code's "mcpServers" map. The field
 // names and semantics match PluginEntry: command/args/env describe a local
 // stdio server; type/url/headers describe a remote one. Reasonix also accepts
-// timeout fields as MCP call policy extensions.
+// startup and call timeout fields as Reasonix policy extensions.
 type mcpServerSpec struct {
-	Type               string            `json:"type"`
-	Command            string            `json:"command"`
-	Args               []string          `json:"args"`
-	Env                map[string]string `json:"env"`
-	URL                string            `json:"url"`
-	Headers            map[string]string `json:"headers"`
-	CallTimeoutSeconds int               `json:"call_timeout_seconds"`
-	ToolTimeoutSeconds map[string]int    `json:"tool_timeout_seconds"`
-	AutoStart          *bool             `json:"auto_start"`
+	Type                  string            `json:"type"`
+	Command               string            `json:"command"`
+	Args                  []string          `json:"args"`
+	Env                   map[string]string `json:"env"`
+	URL                   string            `json:"url"`
+	Headers               map[string]string `json:"headers"`
+	StartupTimeoutSeconds int               `json:"startup_timeout_seconds"`
+	CallTimeoutSeconds    int               `json:"call_timeout_seconds"`
+	ToolTimeoutSeconds    map[string]int    `json:"tool_timeout_seconds"`
+	AutoStart             *bool             `json:"auto_start"`
 }
 
 // loadMCPJSON reads path (Claude Code's .mcp.json) and returns its servers as
@@ -202,16 +203,17 @@ func anonymousMCPName(i int) string {
 
 func pluginEntryFromMCPSpec(name string, s mcpServerSpec) PluginEntry {
 	e := PluginEntry{
-		Name:               name,
-		Type:               s.Type,
-		Command:            s.Command,
-		Args:               s.Args,
-		Env:                s.Env,
-		URL:                s.URL,
-		Headers:            s.Headers,
-		CallTimeoutSeconds: s.CallTimeoutSeconds,
-		ToolTimeoutSeconds: s.ToolTimeoutSeconds,
-		AutoStart:          s.AutoStart,
+		Name:                  name,
+		Type:                  s.Type,
+		Command:               s.Command,
+		Args:                  s.Args,
+		Env:                   s.Env,
+		URL:                   s.URL,
+		Headers:               s.Headers,
+		StartupTimeoutSeconds: s.StartupTimeoutSeconds,
+		CallTimeoutSeconds:    s.CallTimeoutSeconds,
+		ToolTimeoutSeconds:    s.ToolTimeoutSeconds,
+		AutoStart:             s.AutoStart,
 	}
 	e, _ = NormalizePluginCommandLine(e)
 	return e
@@ -340,6 +342,7 @@ func applyPluginEntryToMCPJSONServer(server map[string]json.RawMessage, entry Pl
 		delete(server, "command")
 		delete(server, "args")
 	}
+	setMCPJSONInt(server, "startup_timeout_seconds", entry.StartupTimeoutSeconds)
 	setMCPJSONInt(server, "call_timeout_seconds", entry.CallTimeoutSeconds)
 	setMCPJSONIntMap(server, "tool_timeout_seconds", entry.ToolTimeoutSeconds)
 	// The removed per-tool reader list is accepted on load for compatibility but

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -116,9 +116,10 @@ func TestMCPJSONCallTimeoutsRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := UpsertMCPJSONPlugin(path, PluginEntry{
-		Name:               "maker",
-		Command:            "maker-mcp",
-		CallTimeoutSeconds: 600,
+		Name:                  "maker",
+		Command:               "maker-mcp",
+		StartupTimeoutSeconds: 60,
+		CallTimeoutSeconds:    600,
 		ToolTimeoutSeconds: map[string]int{
 			"generate/video": 1800,
 			"search":         120,
@@ -136,6 +137,9 @@ func TestMCPJSONCallTimeoutsRoundTrip(t *testing.T) {
 	}
 	if got[0].CallTimeoutSeconds != 600 {
 		t.Fatalf("call_timeout_seconds = %d, want 600", got[0].CallTimeoutSeconds)
+	}
+	if got[0].StartupTimeoutSeconds != 60 {
+		t.Fatalf("startup_timeout_seconds = %d, want 60", got[0].StartupTimeoutSeconds)
 	}
 	if got[0].ToolTimeoutSeconds["generate/video"] != 1800 || got[0].ToolTimeoutSeconds["search"] != 120 {
 		t.Fatalf("tool_timeout_seconds = %+v, want generate/video=1800 search=120", got[0].ToolTimeoutSeconds)

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -400,6 +400,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("]\n")
 	}
 	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # foreground safety cap; set 0 for no tool-local cap\n", c.BashTimeoutSeconds())
+	fmt.Fprintf(&b, "mcp_startup_timeout_seconds = %d   # background initialize + tools/list safety cap; per-plugin overrides may raise it\n", c.MCPStartupTimeoutSeconds())
 	fmt.Fprintf(&b, "mcp_call_timeout_seconds = %d   # default MCP call safety cap; per-plugin/tool overrides may raise it\n\n", c.MCPCallTimeoutSeconds())
 
 	b.WriteString("[tools.background_jobs]\n")
@@ -731,6 +732,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("# [[plugins]]\n")
 		b.WriteString("# name    = \"example\"\n")
 		b.WriteString("# command = \"reasonix-plugin-example\"\n")
+		b.WriteString("# startup_timeout_seconds = 60    # optional initialize + tools/list cap\n")
 		b.WriteString("# call_timeout_seconds = 600       # optional per-server MCP call timeout\n")
 		b.WriteString("# tool_timeout_seconds = { \"generate_video\" = 1800 }   # raw MCP tool names\n")
 		b.WriteString("# [[plugins]]                                  # a remote server over Streamable HTTP\n")
@@ -759,6 +761,10 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			}
 			if len(pl.Env) > 0 {
 				fmt.Fprintf(&b, "env     = %s\n", renderStringMap(pl.Env))
+			}
+			if pl.StartupTimeoutSeconds > 0 {
+				b.WriteString("# Per-server MCP initialize + tools/list timeout; 0 keeps the global/default cap.\n")
+				fmt.Fprintf(&b, "startup_timeout_seconds = %d\n", pl.StartupTimeoutSeconds)
 			}
 			if pl.CallTimeoutSeconds > 0 {
 				b.WriteString("# Per-server MCP call timeout; 0 keeps the global/default cap.\n")
@@ -1071,6 +1077,7 @@ func RenderTOMLProjectDelta(c *Config) string {
 	// [tools]
 	if len(c.Tools.Enabled) > 0 ||
 		(c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0) ||
+		(c.Tools.MCPStartupTimeoutSeconds != nil && *c.Tools.MCPStartupTimeoutSeconds > 0) ||
 		(c.Tools.MCPCallTimeoutSeconds != nil && *c.Tools.MCPCallTimeoutSeconds > 0) {
 		b.WriteString("[tools]\n")
 		if len(c.Tools.Enabled) > 0 {
@@ -1078,6 +1085,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		}
 		if c.Tools.BashTimeoutSeconds != nil && *c.Tools.BashTimeoutSeconds != 0 {
 			fmt.Fprintf(&b, "bash_timeout_seconds = %d\n", *c.Tools.BashTimeoutSeconds)
+		}
+		if c.Tools.MCPStartupTimeoutSeconds != nil && *c.Tools.MCPStartupTimeoutSeconds > 0 {
+			fmt.Fprintf(&b, "mcp_startup_timeout_seconds = %d\n", *c.Tools.MCPStartupTimeoutSeconds)
 		}
 		if c.Tools.MCPCallTimeoutSeconds != nil && *c.Tools.MCPCallTimeoutSeconds > 0 {
 			fmt.Fprintf(&b, "mcp_call_timeout_seconds = %d\n", *c.Tools.MCPCallTimeoutSeconds)
@@ -1208,6 +1218,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		}
 		if len(pl.Env) > 0 {
 			fmt.Fprintf(&b, "env     = %s\n", renderStringMap(pl.Env))
+		}
+		if pl.StartupTimeoutSeconds > 0 {
+			fmt.Fprintf(&b, "startup_timeout_seconds = %d\n", pl.StartupTimeoutSeconds)
 		}
 		if pl.CallTimeoutSeconds > 0 {
 			b.WriteString("# Per-server MCP call timeout; 0 keeps the global/default cap.\n")

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -585,13 +585,15 @@ approval_mode = "prompt"
 	}
 }
 
-func TestRenderTOMLPreservesMCPCallTimeouts(t *testing.T) {
+func TestRenderTOMLPreservesMCPTimeouts(t *testing.T) {
 	cfg := Default()
 	cfg.Tools.MCPCallTimeoutSeconds = intPtr(450)
+	cfg.Tools.MCPStartupTimeoutSeconds = intPtr(45)
 	cfg.Plugins = []PluginEntry{{
-		Name:               "maker",
-		Command:            "maker-mcp",
-		CallTimeoutSeconds: 600,
+		Name:                  "maker",
+		Command:               "maker-mcp",
+		StartupTimeoutSeconds: 60,
+		CallTimeoutSeconds:    600,
 		ToolTimeoutSeconds: map[string]int{
 			"generate/video": 1800,
 			"search":         120,
@@ -601,6 +603,8 @@ func TestRenderTOMLPreservesMCPCallTimeouts(t *testing.T) {
 	rendered := RenderTOML(cfg)
 	for _, want := range []string{
 		"mcp_call_timeout_seconds = 450",
+		"mcp_startup_timeout_seconds = 45",
+		"startup_timeout_seconds = 60",
 		"call_timeout_seconds = 600",
 		`tool_timeout_seconds = { "generate/video" = 1800, "search" = 120 }`,
 		"Raw MCP tool names",
@@ -616,6 +620,12 @@ func TestRenderTOMLPreservesMCPCallTimeouts(t *testing.T) {
 	}
 	if got.Tools.MCPCallTimeoutSeconds == nil || *got.Tools.MCPCallTimeoutSeconds != 450 {
 		t.Fatalf("MCPCallTimeoutSeconds round trip = %v, want 450", got.Tools.MCPCallTimeoutSeconds)
+	}
+	if got.Tools.MCPStartupTimeoutSeconds == nil || *got.Tools.MCPStartupTimeoutSeconds != 45 {
+		t.Fatalf("MCPStartupTimeoutSeconds round trip = %v, want 45", got.Tools.MCPStartupTimeoutSeconds)
+	}
+	if got.Plugins[0].StartupTimeoutSeconds != 60 {
+		t.Fatalf("StartupTimeoutSeconds round trip = %d, want 60", got.Plugins[0].StartupTimeoutSeconds)
 	}
 	if got.Plugins[0].CallTimeoutSeconds != 600 {
 		t.Fatalf("CallTimeoutSeconds round trip = %d, want 600", got.Plugins[0].CallTimeoutSeconds)

--- a/internal/config/tools_test.go
+++ b/internal/config/tools_test.go
@@ -80,6 +80,38 @@ func TestMCPCallTimeoutSecondsFallsBackForZeroOrNegative(t *testing.T) {
 	}
 }
 
+func TestMCPStartupTimeoutSecondsDefaultsToBackgroundSafetyCap(t *testing.T) {
+	cfg := Default()
+	if cfg.Tools.MCPStartupTimeoutSeconds != nil {
+		t.Fatalf("default raw MCP startup timeout = %v, want nil", *cfg.Tools.MCPStartupTimeoutSeconds)
+	}
+	if got := cfg.MCPStartupTimeoutSeconds(); got != 30 {
+		t.Fatalf("MCPStartupTimeoutSeconds() = %d, want 30", got)
+	}
+}
+
+func TestMCPStartupTimeoutSecondsExplicitPositive(t *testing.T) {
+	cfg := Default()
+	if _, err := toml.Decode("[tools]\nmcp_startup_timeout_seconds = 45\n", cfg); err != nil {
+		t.Fatalf("decode MCP startup timeout: %v", err)
+	}
+	if got := cfg.MCPStartupTimeoutSeconds(); got != 45 {
+		t.Fatalf("MCPStartupTimeoutSeconds() = %d, want 45", got)
+	}
+}
+
+func TestMCPStartupTimeoutSecondsFallsBackForZeroOrNegative(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.MCPStartupTimeoutSeconds = intPtr(0)
+	if got := cfg.MCPStartupTimeoutSeconds(); got != 30 {
+		t.Fatalf("zero MCPStartupTimeoutSeconds() = %d, want 30", got)
+	}
+	cfg.Tools.MCPStartupTimeoutSeconds = intPtr(-1)
+	if got := cfg.MCPStartupTimeoutSeconds(); got != 30 {
+		t.Fatalf("negative MCPStartupTimeoutSeconds() = %d, want 30", got)
+	}
+}
+
 func TestBackgroundJobStalledWarningSecondsDefault(t *testing.T) {
 	cfg := Default()
 	if cfg.Tools.BackgroundJobs.StalledWarningSeconds != nil {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4786,6 +4786,7 @@ func (c *Controller) mcpSpec(e config.PluginEntry) plugin.Spec {
 		Env:                exp.Env,
 		URL:                exp.URL,
 		Headers:            exp.Headers,
+		StartupTimeout:     controllerMCPTimeout(exp.StartupTimeoutSeconds),
 		DefaultCallTimeout: c.mcpDefaultCallTimeout,
 		CallTimeout:        controllerMCPTimeout(exp.CallTimeoutSeconds),
 		ToolTimeouts:       controllerMCPToolTimeouts(exp.ToolTimeoutSeconds),

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -712,6 +712,7 @@ func TestPlanMCPJSONIgnoresRetiredApprovalPolicy(t *testing.T) {
   "mcpServers": {
     "admin": {
       "command": "admin-mcp",
+      "startup_timeout_seconds": 30,
       "call_timeout_seconds": 45,
       "tool_timeout_seconds": {"wipe": 120},
       "trusted_read_only_tools": ["status"],
@@ -725,7 +726,7 @@ func TestPlanMCPJSONIgnoresRetiredApprovalPolicy(t *testing.T) {
 		t.Fatalf("parseMCPJSON: entries=%+v warnings=%v err=%v", entries, warnings, err)
 	}
 	got := entries[0]
-	if got.CallTimeoutSeconds != 45 || got.ToolTimeoutSeconds["wipe"] != 120 {
+	if got.StartupTimeoutSeconds != 30 || got.CallTimeoutSeconds != 45 || got.ToolTimeoutSeconds["wipe"] != 120 {
 		t.Fatalf("MCP timeout config was dropped: %+v", got)
 	}
 }

--- a/internal/installsource/mcp.go
+++ b/internal/installsource/mcp.go
@@ -174,16 +174,17 @@ func readMCPJSON(path string) ([]config.PluginEntry, []string, error) {
 func parseMCPJSON(b []byte) ([]config.PluginEntry, []string, error) {
 	var raw struct {
 		MCPServers map[string]struct {
-			Type               string            `json:"type"`
-			Command            string            `json:"command"`
-			Args               []string          `json:"args"`
-			Env                map[string]string `json:"env"`
-			URL                string            `json:"url"`
-			Headers            map[string]string `json:"headers"`
-			AutoStart          *bool             `json:"auto_start"`
-			CallTimeoutSeconds int               `json:"call_timeout_seconds"`
-			ToolTimeoutSeconds map[string]int    `json:"tool_timeout_seconds"`
-			Tier               string            `json:"tier"`
+			Type                  string            `json:"type"`
+			Command               string            `json:"command"`
+			Args                  []string          `json:"args"`
+			Env                   map[string]string `json:"env"`
+			URL                   string            `json:"url"`
+			Headers               map[string]string `json:"headers"`
+			AutoStart             *bool             `json:"auto_start"`
+			StartupTimeoutSeconds int               `json:"startup_timeout_seconds"`
+			CallTimeoutSeconds    int               `json:"call_timeout_seconds"`
+			ToolTimeoutSeconds    map[string]int    `json:"tool_timeout_seconds"`
+			Tier                  string            `json:"tier"`
 		} `json:"mcpServers"`
 	}
 	if err := json.Unmarshal(b, &raw); err != nil {
@@ -220,17 +221,18 @@ func parseMCPJSON(b []byte) ([]config.PluginEntry, []string, error) {
 			warnings = append(warnings, fmt.Sprintf("%s: tier %q is unknown; treating as background", name, s.Tier))
 		}
 		e := config.PluginEntry{
-			Name:               name,
-			Type:               typ,
-			Command:            strings.TrimSpace(s.Command),
-			Args:               append([]string(nil), s.Args...),
-			Env:                cleanMap(s.Env),
-			URL:                strings.TrimSpace(s.URL),
-			Headers:            cleanMap(s.Headers),
-			AutoStart:          s.AutoStart,
-			CallTimeoutSeconds: s.CallTimeoutSeconds,
-			ToolTimeoutSeconds: s.ToolTimeoutSeconds,
-			Tier:               tier,
+			Name:                  name,
+			Type:                  typ,
+			Command:               strings.TrimSpace(s.Command),
+			Args:                  append([]string(nil), s.Args...),
+			Env:                   cleanMap(s.Env),
+			URL:                   strings.TrimSpace(s.URL),
+			Headers:               cleanMap(s.Headers),
+			AutoStart:             s.AutoStart,
+			StartupTimeoutSeconds: s.StartupTimeoutSeconds,
+			CallTimeoutSeconds:    s.CallTimeoutSeconds,
+			ToolTimeoutSeconds:    s.ToolTimeoutSeconds,
+			Tier:                  tier,
 		}
 		// An empty Type is the canonical "stdio" form; keep it that way so
 		// the rest of the config layer (UpsertPlugin / ShouldAutoStart)

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/mcplaunch"
 	"reasonix/internal/sandbox"
@@ -194,6 +195,16 @@ func TestCacheInvalidatesOnSchemaCacheKeyMismatch(t *testing.T) {
 	}
 	if _, ok := LoadCachedSchema(spec.Name, "different-cache-key"); ok {
 		t.Fatal("LoadCachedSchema: hit despite mismatching expectedKey")
+	}
+}
+
+func TestSchemaCacheKeyIgnoresHostOnlyStartupTimeouts(t *testing.T) {
+	spec := sampleSpec()
+	want := SchemaCacheKey(spec)
+	spec.DefaultStartupTimeout = 30 * time.Second
+	spec.StartupTimeout = 90 * time.Second
+	if got := SchemaCacheKey(spec); got != want {
+		t.Fatalf("host-only startup timeout changed provider schema cache key: got %q want %q", got, want)
 	}
 }
 

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -62,6 +62,9 @@ type lazySpawn struct {
 	real     map[string]tool.Tool // namespaced name → real tool, populated on success
 	spawnErr error
 	swapped  bool
+	// waitBudget bounds how long one tool call waits for a shared startup. The
+	// handshake itself uses spec.startupTimeout and continues in the background.
+	waitBudget time.Duration
 	// ready is closed when state leaves spawnInFlight so concurrent waiters can
 	// observe the result without killing a shared host process.
 	ready chan struct{}
@@ -116,7 +119,13 @@ func (s *lazySpawn) kick() {
 // run does the handshake without holding mu (host.EnsureConnected can take
 // seconds), then reacquires mu to publish the result.
 func (s *lazySpawn) run() {
-	real, err := s.host.EnsureConnectedWithLifecycle(s.ctx, s.ctx, s.spec, s.generation)
+	started := time.Now()
+	startupCtx, cancel := context.WithTimeout(s.ctx, s.spec.startupTimeout())
+	real, err := s.host.EnsureConnectedWithLifecycle(s.ctx, startupCtx, s.spec, s.generation)
+	cancel()
+	if err != nil {
+		err = newStartupFailure("connect", started, "", err)
+	}
 	var cacheTools []tool.Tool
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -203,8 +212,8 @@ type lazyTool struct {
 	// destructive is guarded by shared.mu because a live handshake may promote
 	// a stale cached false value before asking the model to retry.
 	destructive bool
-	// hasCache true → schema is trusted, so Execute runs the handshake
-	// synchronously and forwards in one turn. false → schema is empty, so we
+	// hasCache true → schema is trusted, so Execute starts the shared handshake,
+	// waits briefly, and forwards in the same turn when ready. false → schema is empty, so we
 	// can't honour the model's call; we kick the spawn async and ask for a
 	// retry on the next turn, when the swap will have installed the real
 	// tools with real schemas.
@@ -295,14 +304,10 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 			if wait == nil {
 				continue
 			}
-			select {
-			case <-wait:
-				continue
-			case <-ctx.Done():
-				return "", ctx.Err()
-			case <-sp.ctx.Done():
-				return "", sp.ctx.Err()
+			if err := waitForLazyStartup(ctx, sp.ctx, wait, sp.waitBudget, sp.spec.Name, sp.spec.startupTimeout()); err != nil {
+				return "", err
 			}
+			continue
 
 		case spawnIdle:
 			if !lt.hasCache {
@@ -322,76 +327,48 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 				sp.mu.Unlock()
 				return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
 			}
-			// Cache-hit: run the handshake synchronously via EnsureConnected so
-			// concurrent parent/child/tab callers share one process and waiters
-			// complete in the same turn. Bound startup so a wedged server cannot
-			// hang the turn forever (#4806).
+			// Cache-hit: start the shared handshake in the background. The current
+			// call waits briefly so healthy fast servers still complete in one turn;
+			// slow servers keep initializing under the session-owned lifecycle and
+			// become ready for a later retry instead of being killed and restarted.
 			if !sp.beginInFlight() {
 				err := sp.spawnErr
 				sp.mu.Unlock()
 				return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
 			}
+			wait := sp.ready
+			go func() {
+				defer sp.host.endDeferredSpawn()
+				sp.run()
+			}()
 			sp.mu.Unlock()
-
-			spawnCtx, cancel := context.WithTimeout(sp.ctx, defaultStartTimeout)
-			real, err := sp.host.EnsureConnectedWithLifecycle(sp.ctx, spawnCtx, sp.spec, sp.generation)
-			cancel()
-
-			sp.mu.Lock()
-			if err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					// Transient startup budget miss: allow a later turn to retry.
-					sp.state = spawnIdle
-					sp.spawnErr = nil
-					sp.broadcastReady()
-					sp.mu.Unlock()
-					sp.host.endDeferredSpawn()
-					return "", fmt.Errorf("MCP server %q startup timed out — retry this tool on a later turn", sp.spec.Name)
-				}
-				if errors.Is(err, ErrDeferredSpawnCancelled) || errors.Is(err, context.Canceled) {
-					sp.state = spawnFailed
-					sp.spawnErr = err
-					sp.broadcastReady()
-					sp.mu.Unlock()
-					sp.host.endDeferredSpawn()
-					return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
-				}
-				sp.state = spawnFailed
-				sp.spawnErr = err
-				sp.host.RecordFailure(sp.spec, err)
-				sp.broadcastReady()
-				sp.mu.Unlock()
-				sp.host.endDeferredSpawn()
-				return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
+			if err := waitForLazyStartup(ctx, sp.ctx, wait, sp.waitBudget, sp.spec.Name, sp.spec.startupTimeout()); err != nil {
+				return "", err
 			}
-			sp.real = make(map[string]tool.Tool, len(real))
-			for _, t := range real {
-				sp.real[t.Name()] = t
-			}
-			sp.state = spawnReady
-			sp.trySwap()
-			r := sp.real[lt.name]
-			if r == nil {
-				sp.broadcastReady()
-				sp.mu.Unlock()
-				sp.host.endDeferredSpawn()
-				return "", fmt.Errorf("MCP server %q did not expose tool %q (the cached schema may be stale)", sp.spec.Name, lt.name)
-			}
-			safetyErr := lt.reconcileLiveSafety(r)
-			sp.broadcastReady()
-			sp.mu.Unlock()
-			sp.host.queueBackgroundWrite(func() {
-				saveLazyCachedSchema(sp.spec, real)
-			})
-			sp.host.endDeferredSpawn()
-			if safetyErr != nil {
-				return "", safetyErr
-			}
-			return r.Execute(ctx, args)
+			continue
 		}
 
 		sp.mu.Unlock()
 		return "", fmt.Errorf("deferred plugin %q in unexpected state", sp.spec.Name)
+	}
+}
+
+func waitForLazyStartup(ctx, sessionCtx context.Context, ready <-chan struct{}, waitBudget time.Duration, server string, startupLimit time.Duration) error {
+	if waitBudget <= 0 {
+		waitBudget = defaultStartTimeout
+	}
+	timer := time.NewTimer(waitBudget)
+	defer timer.Stop()
+	select {
+	case <-ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-sessionCtx.Done():
+		return sessionCtx.Err()
+	case <-timer.C:
+		return fmt.Errorf("MCP server %q is still initializing after %s; startup continues in background (limit %s) — retry this tool on a later turn",
+			server, formatTimeout(waitBudget), formatTimeout(startupLimit))
 	}
 }
 
@@ -415,7 +392,8 @@ func (lt *lazyTool) reconcileLiveSafety(real tool.Tool) error {
 // LazyToolset returns the placeholder tools to register for one enabled MCP.
 // When cs is non-nil (cache hit) the returned slice has one lazyTool per cached
 // tool, carrying the cached schema so the model can pass real args. Execute
-// waits for EnsureConnected and completes the call in the same turn. When cs is
+// waits briefly for EnsureConnected and completes the call in the same turn
+// when startup is fast; slow startup continues in the background. When cs is
 // nil (cache miss) the returned slice has a single stub named
 // "mcp__<server>__connect": the model can call it to drive the handshake, and
 // the real tools surface on the next turn.
@@ -435,10 +413,11 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 	spec = ResolveStoredAuthorization(sessionCtx, spec)
 	spawnCtx, cancel := context.WithCancel(sessionCtx)
 	shared := &lazySpawn{
-		spec: spec,
-		host: host,
-		reg:  reg,
-		ctx:  spawnCtx,
+		spec:       spec,
+		host:       host,
+		reg:        reg,
+		ctx:        spawnCtx,
+		waitBudget: defaultStartTimeout,
 	}
 	shared.generation = host.registerDeferredCancel(spec.Name, cancel)
 

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -370,10 +370,11 @@ func TestAddWithLifecycleCoalescesConcurrentSameServer(t *testing.T) {
 	}
 }
 
-func TestLazyCacheHitStartupTimeoutCanRetry(t *testing.T) {
+func TestLazyCacheHitSlowStartupContinuesInBackground(t *testing.T) {
 	redirectCache(t)
 	spec := helperSpec()
-	spec.Env["GO_WANT_HELPER_INIT_MS"] = fmt.Sprint(int(defaultStartTimeout/time.Millisecond) + 200)
+	spec.StartupTimeout = 2 * time.Second
+	spec.Env["GO_WANT_HELPER_INIT_MS"] = "200"
 	writeMockCache(t, spec)
 
 	cs, ok := LoadCachedSchema(spec.Name, SchemaCacheKey(spec))
@@ -399,18 +400,24 @@ func TestLazyCacheHitStartupTimeoutCanRetry(t *testing.T) {
 	if !ok {
 		t.Fatalf("pre-Execute echo should be a *lazyTool, got %T", echo)
 	}
+	lazyEcho.shared.waitBudget = 25 * time.Millisecond
+	beforeName := echo.Name()
+	beforeDescription := echo.Description()
+	beforeSchema := string(echo.Schema())
 
-	if _, err := echo.Execute(ctx, json.RawMessage(`{"msg":"slow"}`)); err == nil || !strings.Contains(err.Error(), "startup timed out") {
-		t.Fatalf("first Execute error = %v, want startup timed out", err)
+	if _, err := echo.Execute(ctx, json.RawMessage(`{"msg":"slow"}`)); err == nil || !strings.Contains(err.Error(), "continues in background") {
+		t.Fatalf("first Execute error = %v, want background startup notice", err)
 	}
-
-	lazyEcho.shared.spec.Env["GO_WANT_HELPER_INIT_MS"] = "0"
+	waitForServer(t, host, spec.Name, 2*time.Second)
 	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"retry"}`))
 	if err != nil {
-		t.Fatalf("second Execute after timeout should retry: %v", err)
+		t.Fatalf("second Execute after background startup should succeed: %v", err)
 	}
 	if out != "echo: retry" {
 		t.Fatalf("Execute result = %q, want %q", out, "echo: retry")
+	}
+	if echo.Name() != beforeName || echo.Description() != beforeDescription || string(echo.Schema()) != beforeSchema {
+		t.Fatalf("provider-visible cached tool changed across background startup")
 	}
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -27,6 +27,7 @@ import (
 	"reasonix/internal/mcplaunch"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/secrets"
 	"reasonix/internal/tool"
 )
 
@@ -77,6 +78,12 @@ type Spec struct {
 	Env     map[string]string
 	URL     string
 	Headers map[string]string
+	// DefaultStartupTimeout is the background initialize + tools/list safety cap
+	// for this server. Zero keeps Reasonix's built-in default.
+	DefaultStartupTimeout time.Duration
+	// StartupTimeout overrides DefaultStartupTimeout for this server. It is
+	// host-only lifecycle policy and never changes provider-visible tool schemas.
+	StartupTimeout time.Duration
 	// DefaultCallTimeout is the global MCP call cap for this server. Zero keeps
 	// Reasonix's built-in defaultCallTimeout.
 	DefaultCallTimeout time.Duration
@@ -393,6 +400,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			ts, err := c.listTools(callCtx)
 			if err != nil {
 				phaseADur := recordedPhaseADur()
+				err = newStartupFailure("tools/list", phaseAStart, c.startupStderr(), err)
 				cancelStartup()
 				if !p.SkipPersistence {
 					h.bgWrites.Add(1)
@@ -703,6 +711,9 @@ type Failure struct {
 	Name                   string
 	Transport              string
 	Error                  string
+	Stage                  string
+	Elapsed                time.Duration
+	Stderr                 string
 	RequiresLaunchApproval bool
 }
 
@@ -784,8 +795,10 @@ func (h *Host) RecordFailure(s Spec, err error) {
 	if tt == "" {
 		tt = "stdio"
 	}
+	stage, elapsed, stderr := startupFailureDetails(err)
 	f := Failure{
 		Name: s.Name, Transport: tt, Error: summarizeFailureError(err),
+		Stage: stage, Elapsed: elapsed, Stderr: stderr,
 		RequiresLaunchApproval: requiresLaunchApproval(err),
 	}
 	for i := range h.failures {
@@ -872,6 +885,45 @@ type spawnAttempt struct {
 	done  chan struct{}
 	tools []tool.Tool
 	err   error
+}
+
+// ConnectionResult is the eventual result of a session-owned background MCP
+// handshake. Tools are provider adapters and remain off the caller's registry
+// unless the caller explicitly registers them.
+type ConnectionResult struct {
+	Tools []tool.Tool
+	Err   error
+}
+
+// EnsureConnectedInBackground starts or joins one shared initialize +
+// tools/list handshake owned by lifeCtx. The returned channel is buffered, so a
+// caller may stop waiting while the server continues toward readiness. Host
+// shutdown and Remove cancel the background work and wait for its goroutine.
+func (h *Host) EnsureConnectedInBackground(lifeCtx context.Context, s Spec) <-chan ConnectionResult {
+	result := make(chan ConnectionResult, 1)
+	startupBase, cancelStartupBase := context.WithCancel(lifeCtx)
+	h.registerDeferredCancel(s.Name, cancelStartupBase)
+	if !h.beginDeferredSpawn() {
+		cancelStartupBase()
+		result <- ConnectionResult{Err: fmt.Errorf("plugin host is closed")}
+		return result
+	}
+	go func() {
+		defer h.endDeferredSpawn()
+		defer cancelStartupBase()
+		started := time.Now()
+		startupCtx, cancelStartup := context.WithTimeout(startupBase, s.startupTimeout())
+		tools, err := h.EnsureConnectedWithLifecycle(lifeCtx, startupCtx, s, 0)
+		cancelStartup()
+		if err != nil {
+			err = newStartupFailure("connect", started, "", err)
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, ErrDeferredSpawnCancelled) {
+				h.RecordFailure(s, err)
+			}
+		}
+		result <- ConnectionResult{Tools: tools, Err: err}
+	}()
+	return result
 }
 
 // beginSpawn atomically claims the sole right to spawn the named server.
@@ -1009,6 +1061,8 @@ type mcpRuntimeSpecIdentity struct {
 	Env                     map[string]string
 	URL                     string
 	Headers                 map[string]string
+	DefaultStartupTimeout   time.Duration
+	StartupTimeout          time.Duration
 	DefaultCallTimeout      time.Duration
 	CallTimeout             time.Duration
 	ToolTimeouts            map[string]time.Duration
@@ -1043,6 +1097,8 @@ func mcpRuntimeSpecIdentityOf(s Spec) mcpRuntimeSpecIdentity {
 		Env:                     nonEmptyStringMap(s.Env),
 		URL:                     s.URL,
 		Headers:                 nonEmptyStringMap(s.Headers),
+		DefaultStartupTimeout:   s.DefaultStartupTimeout,
+		StartupTimeout:          s.StartupTimeout,
 		DefaultCallTimeout:      s.DefaultCallTimeout,
 		CallTimeout:             s.CallTimeout,
 		ToolTimeouts:            nonEmptyDurationMap(s.ToolTimeouts),
@@ -1202,6 +1258,7 @@ func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 }
 
 func (h *Host) addConnectedWithLifecycle(lifeCtx, callCtx context.Context, s Spec, deferredGeneration uint64) ([]tool.Tool, error) {
+	startupStarted := time.Now()
 	h.mu.RLock()
 	if h.closed {
 		h.mu.RUnlock()
@@ -1215,6 +1272,7 @@ func (h *Host) addConnectedWithLifecycle(lifeCtx, callCtx context.Context, s Spe
 	}
 	ts, err := c.listTools(callCtx)
 	if err != nil {
+		err = newStartupFailure("tools/list", startupStarted, c.startupStderr(), err)
 		c.close()
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
@@ -1329,18 +1387,19 @@ var ErrDeferredSpawnCancelled = errors.New("deferred MCP spawn cancelled")
 // (prompts + resources) can still call it later. Callers that don't care pass
 // the same ctx for both.
 func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
+	started := time.Now()
 	var err error
 	s, err = applyStoredLauncherLock(s)
 	if err != nil {
-		return nil, err
+		return nil, newStartupFailure("launch", started, "", err)
 	}
 	s, err = resolveProjectLaunchAuthorization(callCtx, s)
 	if err != nil {
-		return nil, err
+		return nil, newStartupFailure("authorization", started, "", err)
 	}
 	t, err := newTransport(lifeCtx, s)
 	if err != nil {
-		return nil, err
+		return nil, newStartupFailure("launch", started, "", err)
 	}
 	tt := strings.ToLower(strings.TrimSpace(s.Type))
 	if tt == "" {
@@ -1348,6 +1407,7 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	}
 	c := &Client{name: s.Name, t: t, spec: s, transport: tt}
 	if err := c.initialize(callCtx); err != nil {
+		err = newStartupFailure("initialize", started, c.startupStderr(), err)
 		c.close()
 		return nil, err
 	}
@@ -1816,7 +1876,7 @@ func shortNameHash(s string) string {
 }
 
 func summarizeFailureError(err error) string {
-	msg := strings.Join(strings.Fields(err.Error()), " ")
+	msg := strings.Join(strings.Fields(secrets.RedactCredentials(err.Error())), " ")
 	const max = 500
 	if len(msg) > max {
 		msg = msg[:max] + "..."

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -400,13 +400,13 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			ts, err := c.listTools(callCtx)
 			if err != nil {
 				phaseADur := recordedPhaseADur()
-				err = newStartupFailure("tools/list", phaseAStart, c.startupStderr(), err)
 				cancelStartup()
 				if !p.SkipPersistence {
 					h.bgWrites.Add(1)
 					go func() { defer h.bgWrites.Done(); _ = RecordStartup(spec.Name, phaseADur) }()
 				}
 				c.close()
+				err = newStartupFailure("tools/list", phaseAStart, c.startupStderr(), err)
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
 			}
@@ -1281,8 +1281,8 @@ func (h *Host) addConnectedWithLifecycle(lifeCtx, callCtx context.Context, s Spe
 	}
 	ts, err := c.listTools(callCtx)
 	if err != nil {
-		err = newStartupFailure("tools/list", startupStarted, c.startupStderr(), err)
 		c.close()
+		err = newStartupFailure("tools/list", startupStarted, c.startupStderr(), err)
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
 	c.toolCount = len(ts)
@@ -1416,8 +1416,8 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	}
 	c := &Client{name: s.Name, t: t, spec: s, transport: tt}
 	if err := c.initialize(callCtx); err != nil {
-		err = newStartupFailure("initialize", started, c.startupStderr(), err)
 		c.close()
+		err = newStartupFailure("initialize", started, c.startupStderr(), err)
 		return nil, err
 	}
 	return c, nil

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -779,8 +779,16 @@ func (h *Host) Failures() []Failure {
 func (h *Host) ConnectingServers() []string {
 	h.spawningMu.Lock()
 	defer h.spawningMu.Unlock()
-	out := make([]string, 0, len(h.spawning))
-	for name := range h.spawning {
+	names := make(map[string]struct{}, len(h.spawning))
+	for key, attempt := range h.spawning {
+		name := key
+		if attempt != nil && strings.TrimSpace(attempt.server) != "" {
+			name = attempt.server
+		}
+		names[name] = struct{}{}
+	}
+	out := make([]string, 0, len(names))
+	for name := range names {
 		out = append(out, name)
 	}
 	sort.Strings(out)
@@ -882,9 +890,10 @@ func (h *Host) endDeferredSpawn() {
 var ErrSpawningInFlight = errors.New("server spawn already in progress")
 
 type spawnAttempt struct {
-	done  chan struct{}
-	tools []tool.Tool
-	err   error
+	server string
+	done   chan struct{}
+	tools  []tool.Tool
+	err    error
 }
 
 // ConnectionResult is the eventual result of a session-owned background MCP
@@ -902,7 +911,7 @@ type ConnectionResult struct {
 func (h *Host) EnsureConnectedInBackground(lifeCtx context.Context, s Spec) <-chan ConnectionResult {
 	result := make(chan ConnectionResult, 1)
 	startupBase, cancelStartupBase := context.WithCancel(lifeCtx)
-	h.registerDeferredCancel(s.Name, cancelStartupBase)
+	generation := h.registerDeferredCancel(s.Name, cancelStartupBase)
 	if !h.beginDeferredSpawn() {
 		cancelStartupBase()
 		result <- ConnectionResult{Err: fmt.Errorf("plugin host is closed")}
@@ -913,7 +922,7 @@ func (h *Host) EnsureConnectedInBackground(lifeCtx context.Context, s Spec) <-ch
 		defer cancelStartupBase()
 		started := time.Now()
 		startupCtx, cancelStartup := context.WithTimeout(startupBase, s.startupTimeout())
-		tools, err := h.EnsureConnectedWithLifecycle(lifeCtx, startupCtx, s, 0)
+		tools, err := h.EnsureConnectedWithLifecycle(lifeCtx, startupCtx, s, generation)
 		cancelStartup()
 		if err != nil {
 			err = newStartupFailure("connect", started, "", err)
@@ -930,17 +939,17 @@ func (h *Host) EnsureConnectedInBackground(lifeCtx context.Context, s Spec) <-ch
 // Returns owner=true if the caller should proceed. When another caller is
 // already spawning the same server, owner=false and done is closed when that
 // spawn finishes.
-func (h *Host) beginSpawn(name string) (*spawnAttempt, bool) {
+func (h *Host) beginSpawn(key, server string) (*spawnAttempt, bool) {
 	h.spawningMu.Lock()
 	defer h.spawningMu.Unlock()
 	if h.spawning == nil {
 		h.spawning = make(map[string]*spawnAttempt)
 	}
-	if attempt, ok := h.spawning[name]; ok {
+	if attempt, ok := h.spawning[key]; ok {
 		return attempt, false
 	}
-	attempt := &spawnAttempt{done: make(chan struct{})}
-	h.spawning[name] = attempt
+	attempt := &spawnAttempt{server: server, done: make(chan struct{})}
+	h.spawning[key] = attempt
 	return attempt, true
 }
 
@@ -1226,7 +1235,7 @@ func (h *Host) addWithLifecycle(lifeCtx, callCtx context.Context, s Spec, deferr
 	if deferredGeneration != 0 {
 		spawnKey = fmt.Sprintf("%s#%d", s.Name, deferredGeneration)
 	}
-	attempt, owner := h.beginSpawn(spawnKey)
+	attempt, owner := h.beginSpawn(spawnKey, s.Name)
 	if !owner {
 		select {
 		case <-attempt.done:

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -862,6 +862,52 @@ func TestEnsureConnectedInBackgroundSurvivesShortCallerWait(t *testing.T) {
 	}
 }
 
+func TestEnsureConnectedInBackgroundRemoveDoesNotResurrectServer(t *testing.T) {
+	lifeCtx, cancelLife := context.WithCancel(context.Background())
+	defer cancelLife()
+	host := NewHost()
+	defer host.Close()
+	spec := Spec{
+		Name:           "removed-background",
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=TestHelperProcess", "--"},
+		StartupTimeout: 2 * time.Second,
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "500",
+		},
+	}
+	result := host.EnsureConnectedInBackground(lifeCtx, spec)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		connecting := host.ConnectingServers()
+		if len(connecting) > 0 {
+			if len(connecting) != 1 || connecting[0] != spec.Name {
+				t.Fatalf("ConnectingServers = %v, want exact configured name %q", connecting, spec.Name)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background startup never entered the in-flight state")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, found := host.Remove(spec.Name); !found {
+		t.Fatal("Host.Remove did not cancel the background generation")
+	}
+	select {
+	case got := <-result:
+		if got.Err == nil {
+			t.Fatalf("removed background startup unexpectedly succeeded: %+v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("removed background startup did not settle")
+	}
+	if host.HasClient(spec.Name) || len(host.ServerNames()) != 0 {
+		t.Fatalf("removed background server was resurrected: %v", host.ServerNames())
+	}
+}
+
 func TestStdioUsesConfiguredPATHForCommandLookup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -143,6 +143,7 @@ func TestMCPRuntimeSpecMatchesExactHostIdentity(t *testing.T) {
 		Name: "database", Package: "trusted-package", Type: "http",
 		Command: "launcher", Args: []string{"--serve"}, Env: map[string]string{"TOKEN": "secret-a"},
 		URL: "https://example.invalid/mcp", Headers: map[string]string{"Authorization": "Bearer secret-a"},
+		DefaultStartupTimeout: 30 * time.Second, StartupTimeout: 45 * time.Second,
 		DefaultCallTimeout: 5 * time.Minute, CallTimeout: 30 * time.Second,
 		ToolTimeouts: map[string]time.Duration{"query": 45 * time.Second},
 		Dir:          "/work", WorkspaceRoot: workspace, LaunchManager: managerA,
@@ -180,6 +181,8 @@ func TestMCPRuntimeSpecMatchesExactHostIdentity(t *testing.T) {
 		{name: "endpoint", mutate: func(s *Spec) { s.URL = "https://other.invalid/mcp" }},
 		{name: "header secret", mutate: func(s *Spec) { s.Headers = map[string]string{"Authorization": "Bearer secret-b"} }},
 		{name: "environment secret", mutate: func(s *Spec) { s.Env = map[string]string{"TOKEN": "secret-b"} }},
+		{name: "default startup timeout", mutate: func(s *Spec) { s.DefaultStartupTimeout = time.Minute }},
+		{name: "startup timeout", mutate: func(s *Spec) { s.StartupTimeout = time.Minute }},
 		{name: "config source", mutate: func(s *Spec) { s.ConfigSource = "user_config" }},
 		{name: "workspace", mutate: func(s *Spec) { s.WorkspaceRoot = "/other-workspace" }},
 		{name: "launcher digest", mutate: func(s *Spec) { s.LauncherDigest = "digest-b" }},
@@ -775,6 +778,90 @@ func TestStdioFailureCapturesStderr(t *testing.T) {
 	}
 }
 
+func TestStartupFailureReportsStageElapsedAndRedactedStderr(t *testing.T) {
+	lifeCtx, cancelLife := context.WithCancel(context.Background())
+	defer cancelLife()
+	startupCtx, cancelStartup := context.WithTimeout(lifeCtx, 40*time.Millisecond)
+	defer cancelStartup()
+
+	host := NewHost()
+	defer host.Close()
+	spec := Spec{
+		Name:    "slow-stderr",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":        "1",
+			"GO_WANT_HELPER_INIT_MS":        "250",
+			"GO_WANT_HELPER_STARTUP_STDERR": "Authorization: Bearer startup-secret-value",
+		},
+	}
+	_, err := host.AddWithLifecycle(lifeCtx, startupCtx, spec)
+	if err == nil {
+		t.Fatal("slow initialize unexpectedly succeeded")
+	}
+	msg := err.Error()
+	for _, want := range []string{"initialize", "after ", "stderr:", "Bearer [redacted]"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("startup error missing %q: %v", want, err)
+		}
+	}
+	if strings.Contains(msg, "startup-secret-value") {
+		t.Fatalf("startup error leaked credential: %v", err)
+	}
+
+	host.RecordFailure(spec, err)
+	failures := host.Failures()
+	if len(failures) != 1 || failures[0].Stage != "initialize" || failures[0].Elapsed <= 0 {
+		t.Fatalf("structured startup failure = %+v", failures)
+	}
+	if !strings.Contains(failures[0].Stderr, "Bearer [redacted]") {
+		t.Fatalf("structured stderr was not redacted: %+v", failures[0])
+	}
+}
+
+func TestFailureSummaryRedactsCredentials(t *testing.T) {
+	got := summarizeFailureError(errors.New("startup failed: Authorization: Bearer summary-secret-value"))
+	if strings.Contains(got, "summary-secret-value") || !strings.Contains(got, "Bearer [redacted]") {
+		t.Fatalf("failure summary was not redacted: %q", got)
+	}
+}
+
+func TestEnsureConnectedInBackgroundSurvivesShortCallerWait(t *testing.T) {
+	lifeCtx, cancelLife := context.WithCancel(context.Background())
+	defer cancelLife()
+	host := NewHost()
+	defer host.Close()
+	spec := Spec{
+		Name:           "slow-background",
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=TestHelperProcess", "--"},
+		StartupTimeout: 2 * time.Second,
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "150",
+		},
+	}
+	result := host.EnsureConnectedInBackground(lifeCtx, spec)
+	select {
+	case got := <-result:
+		t.Fatalf("background startup settled before the short caller wait: %+v", got)
+	case <-time.After(20 * time.Millisecond):
+		// The caller can return here without cancelling the session-owned startup.
+	}
+	select {
+	case got := <-result:
+		if got.Err != nil || len(got.Tools) != 2 {
+			t.Fatalf("background startup result = %+v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("background startup did not finish")
+	}
+	if !host.HasClient(spec.Name) {
+		t.Fatal("successful background startup did not leave a session-owned client")
+	}
+}
+
 func TestStdioUsesConfiguredPATHForCommandLookup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1146,6 +1233,9 @@ func TestHelperProcess(t *testing.T) {
 	}
 	defer os.Exit(0)
 	incrementHelperCounter(os.Getenv("GO_WANT_HELPER_START_COUNT"))
+	if msg := os.Getenv("GO_WANT_HELPER_STARTUP_STDERR"); msg != "" {
+		_, _ = os.Stderr.WriteString(msg + "\n")
+	}
 
 	var initDelay time.Duration
 	if ms := os.Getenv("GO_WANT_HELPER_INIT_MS"); ms != "" {

--- a/internal/plugin/startup.go
+++ b/internal/plugin/startup.go
@@ -1,0 +1,115 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"reasonix/internal/secrets"
+)
+
+// defaultStartupTimeout bounds the real initialize + tools/list handshake.
+// The model-facing wait stays shorter so a slow but healthy server can finish
+// in the background without holding an interactive turn open.
+const defaultStartupTimeout = 30 * time.Second
+
+// DefaultStartupTimeout is the default background handshake safety cap used by
+// config and host adapters when no explicit server override is present.
+func DefaultStartupTimeout() time.Duration { return defaultStartupTimeout }
+
+// DefaultStartupWaitBudget is the maximum time one interactive tool call waits
+// for a shared background handshake before asking the model to retry later.
+func DefaultStartupWaitBudget() time.Duration { return defaultStartTimeout }
+
+func (s Spec) startupTimeout() time.Duration {
+	if s.StartupTimeout > 0 {
+		return s.StartupTimeout
+	}
+	if s.DefaultStartupTimeout > 0 {
+		return s.DefaultStartupTimeout
+	}
+	return defaultStartupTimeout
+}
+
+// ResolvedStartupTimeout returns the server override, global default, or the
+// built-in background handshake cap, in that order.
+func (s Spec) ResolvedStartupTimeout() time.Duration { return s.startupTimeout() }
+
+type startupFailure struct {
+	Stage   string
+	Elapsed time.Duration
+	Stderr  string
+	Err     error
+}
+
+func (e *startupFailure) Error() string {
+	if e == nil {
+		return "MCP startup failed"
+	}
+	stage := strings.TrimSpace(e.Stage)
+	if stage == "" {
+		stage = "unknown"
+	}
+	msg := fmt.Sprintf("MCP startup %s failed after %s: %v", stage, formatElapsed(e.Elapsed), e.Err)
+	if stderr := strings.TrimSpace(e.Stderr); stderr != "" {
+		msg += "; stderr: " + stderr
+	}
+	return msg
+}
+
+func (e *startupFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func newStartupFailure(stage string, started time.Time, stderr string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var existing *startupFailure
+	if errors.As(err, &existing) {
+		return err
+	}
+	elapsed := time.Since(started)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return &startupFailure{
+		Stage:   strings.TrimSpace(stage),
+		Elapsed: elapsed,
+		Stderr:  secrets.RedactCredentials(strings.TrimSpace(stderr)),
+		Err:     err,
+	}
+}
+
+func startupFailureDetails(err error) (stage string, elapsed time.Duration, stderr string) {
+	var startupErr *startupFailure
+	if !errors.As(err, &startupErr) || startupErr == nil {
+		return "", 0, ""
+	}
+	return startupErr.Stage, startupErr.Elapsed, startupErr.Stderr
+}
+
+func formatElapsed(elapsed time.Duration) string {
+	if elapsed < time.Millisecond {
+		return elapsed.String()
+	}
+	return elapsed.Round(time.Millisecond).String()
+}
+
+type startupDiagnosticTransport interface {
+	startupStderr() string
+}
+
+func (c *Client) startupStderr() string {
+	if c == nil || c.t == nil {
+		return ""
+	}
+	if diagnostic, ok := c.t.(startupDiagnosticTransport); ok {
+		return diagnostic.startupStderr()
+	}
+	return ""
+}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -709,11 +709,21 @@ func (t *stdioTransport) withStderr(err error) error {
 	// close), and this path runs with callMu held — an unbounded wait here
 	// would wedge every future call on this transport.
 	waitWithBudget(t.wait, closeWaitBudget)
-	msg := t.stderr.String()
+	// This error is returned directly to callers outside startup as well as
+	// copied into diagnostics. Redact at the transport boundary so an early
+	// child exit cannot bypass the startup-specific redaction layer.
+	msg := secrets.RedactCredentials(t.stderr.String())
 	if msg == "" {
 		return err
 	}
 	return fmt.Errorf("%w: stderr: %s", err, msg)
+}
+
+func (t *stdioTransport) startupStderr() string {
+	if t == nil || t.stderr == nil {
+		return ""
+	}
+	return secrets.RedactCredentials(t.stderr.String())
 }
 
 // wait reaps the child exactly once; cmd.Wait blocks until the stderr-copy

--- a/internal/plugin/transport_stdio_wait_test.go
+++ b/internal/plugin/transport_stdio_wait_test.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -50,5 +52,14 @@ func TestWaitFinishedWithinBudgetReportsGracefulExit(t *testing.T) {
 	t.Cleanup(func() { close(blocked) })
 	if waitFinishedWithinBudget(func() { <-blocked }, 10*time.Millisecond) {
 		t.Fatal("blocked wait should require forced process cleanup")
+	}
+}
+
+func TestWithStderrRedactsCredentials(t *testing.T) {
+	tr := &stdioTransport{stderr: &tailBuffer{limit: 1024}}
+	_, _ = tr.stderr.Write([]byte("Authorization: Bearer transport-secret-value"))
+	got := tr.withStderr(errors.New("child exited")).Error()
+	if strings.Contains(got, "transport-secret-value") || !strings.Contains(got, "Bearer [redacted]") {
+		t.Fatalf("stderr error was not redacted: %q", got)
 	}
 }

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -119,6 +119,7 @@ enabled = true   # inject a stable startup summary of OS, shell, and common tool
 [tools]
 enabled = []   # empty = all built-in tools
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+mcp_startup_timeout_seconds = 30   # background initialize + tools/list safety cap; per-server overrides may raise it
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
 
 [tools.background_jobs]
@@ -167,6 +168,8 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # [[plugins]]
 # name    = "example"
 # command = "reasonix-plugin-example"
+# # Startup may continue in the background after the first caller stops waiting.
+# # startup_timeout_seconds = 60
 # # Per-server MCP call timeout; 0 keeps the global/default cap.
 # # call_timeout_seconds = 600
 # # Raw MCP tool names with per-tool call timeouts.


### PR DESCRIPTION
## Summary

- Keep a shared MCP cold start running under the session lifecycle after an interactive caller stops waiting.
- Add a 30-second default startup safety cap with optional global and per-server overrides.
- Report the effective configuration source, startup stage, elapsed time, and a bounded credential-redacted stderr tail.
- Preserve pinned provider-visible MCP tool names, order, descriptions, and schemas for the full session.

## Problem

A cold MCP server that needed longer than the five-second interactive wait was canceled by that same wait context. Retrying the tool started the server again, so a healthy but slow server could enter a restart loop and the user only saw repeated generic failures.

## Root cause

The interactive caller wait and the shared launch / authorization / `initialize` / `tools/list` handshake used the same cancellation lifetime. The short UX budget therefore terminated work that should have belonged to the session.

## Fix

The caller now waits briefly for a session-owned background connection result. If the wait expires, Reasonix returns an actionable retry-later error while the same startup continues up to the configured startup cap. Host shutdown and server removal still cancel and drain the background work.

Configuration:

- `[tools].mcp_startup_timeout_seconds` defaults to `30`.
- `[[plugins]].startup_timeout_seconds` optionally overrides one server.
- The same per-server extension round-trips through `.mcp.json`.

## Compatibility audit

| Surface | Old data / old behavior | Result |
| --- | --- | --- |
| Existing TOML without `mcp_startup_timeout_seconds` | Missing value resolves to the 30-second built-in default. | Compatible |
| Existing `[[plugins]]` entries | Missing per-server value remains zero and inherits the global/default cap. | Compatible |
| Existing `.mcp.json` | Missing extension remains zero; unknown fields continue to round-trip through the raw JSON map. | Compatible |
| Capability diagnostics JSON | New source/startup fields are additive; existing fields and schema version remain unchanged. | Compatible |
| Provider-visible MCP tool surface | Cached names, ordering, descriptions, schemas, and schema cache keys are unchanged during the session. | Compatible |
| Host runtime identity | Startup policy participates in host-local identity so incompatible runtime configurations are not reused. | Compatible |

## Security and concurrency

- No dependency, permission, sandbox, or network-scope changes.
- Stdio startup output remains bounded and is credential-redacted at both the transport and diagnostic-summary boundaries.
- Background startup is registered with the Host wait group and cancellation registry, and still uses the existing singleflight spawn owner.
- Deferred generation identity is checked again before client publication, so a concurrent remove cannot resurrect an old startup.
- Connection diagnostics expose the configured server name rather than the internal generation-qualified spawn key.
- Host close cancels and drains in-flight startup before taking the final client snapshot.

## Cache impact

Cache-impact: low - this changes host-only startup lifecycle and diagnostics, while pinned provider-visible tool bytes and schema cache keys remain stable.

Cache-guard: `./scripts/cache-guard.sh`, `TestSchemaCacheKeyIgnoresHostOnlyStartupTimeouts`, and the slow cache-hit startup regression all passed.

System-prompt-review: Reviewed the boot/config plumbing and confirmed this change does not alter system-prompt bytes.

## Related PR integration

- #6759 touches the same MCP boot/config/transport owners. Its current head has merge conflicts with this PR, so the recommended order is to merge this focused lifecycle fix first, then rebase #6759 while preserving the startup fields and generation fence.
- #7061 overlaps shared boot/config/docs files but changes PowerShell support rather than MCP behavior. Its current head also needs a rebase; no semantic conflict was found in the reviewed areas.
- No other open PR was found with the same slow-start lifecycle contract.

## Verification

- `go test -p 4 ./... -count=1`
- `go test -race ./internal/plugin ./internal/control ./internal/agent -count=1`
- `go test ./internal/plugin ./internal/config ./internal/boot ./internal/capdiag ./internal/control ./internal/agent ./internal/installsource -count=1`
- `./scripts/cache-guard.sh`
- `go vet ./internal/plugin ./internal/config ./internal/boot ./internal/capdiag ./internal/control ./internal/agent ./internal/installsource`
- `git diff --check origin/main-v2...HEAD`