### PR TITLE
docs(plugins): add safe community listing guidance / 添加安全的社区插件收录指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="./docs/ACP.md">ACP</a>
   &nbsp;·&nbsp;
   <a href="./docs/SPEC.md">Spec</a>
- &nbsp;·&nbsp;
+  &nbsp;·&nbsp;
   <a href="./docs/PLUGINS.md">Plugins</a>
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">Website</a>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <a href="./docs/ACP.md">ACP</a>
   &nbsp;·&nbsp;
   <a href="./docs/SPEC.md">Spec</a>
+ &nbsp;·&nbsp;
+  <a href="./docs/PLUGINS.md">Plugins</a>
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">Website</a>
   &nbsp;·&nbsp;
@@ -194,7 +196,6 @@ for designing the project logo, and to
   <br/>
   <sub>Built by the community at <a href="https://github.com/esengine/DeepSeek-Reasonix/graphs/contributors">esengine/DeepSeek-Reasonix</a></sub>
 </p>
-
 ---
 
 <p align="center"><sub><strong>Support this project</strong></sub></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
   &nbsp;·&nbsp;
   <a href="./docs/SPEC.zh-CN.md">规格</a>
   &nbsp;·&nbsp;
+  <a href="./docs/PLUGINS.zh-CN.md">插件</a>
+  &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">官方网站</a>
   &nbsp;·&nbsp;
   <strong><a href="https://discord.gg/XF78rEME2D">Discord</a></strong>

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,45 @@
+# Community Plugins
+
+Reasonix loads external tools as **MCP servers** — subprocesses it talks to over
+stdio JSON-RPC — declared in `reasonix.toml` (see
+[SPEC §3.3](./SPEC.md#33-plugins-internalplugin--mcp-client) and
+[§5](./SPEC.md#5-configuration-toml)). Plugins live in their own repos/packages and
+are **not** bundled into core; this page is a discovery list so users can find them
+and authors can be linked.
+
+> This is a discovery list, not an endorsement or a quality guarantee. Vet a
+> plugin before installing it — an installed MCP server is trusted with its tools.
+
+## How to add a plugin
+
+Each `[[plugins]]` entry names a server and how to launch it. `type` defaults to
+`stdio`; `${VAR}` / `${VAR:-default}` are expanded in `command` / `args` / `env`.
+
+```toml
+[[plugins]]
+name    = "example"
+command = "npx"
+args    = ["some-reasonix-plugin"]
+# env   = { SOME_TOKEN = "${SOME_TOKEN}" }
+```
+
+After launch, a plugin's tools appear in-session namespaced as
+`mcp__<name>__<tool>`. Run `/mcp` in the chat TUI to see connected servers and
+their tool counts.
+
+## Plugins
+
+| Plugin | Tools | Install |
+| --- | --- | --- |
+| [reasonix-plugin-git-context](https://github.com/kashifmahi/reasonix-plugin-git-context) | Read-only git: `blame`, `log`, `show`, `diff`, `file_history`, `pickaxe`, `pr_context` | `npx reasonix-plugin-git-context` |
+
+<!-- Add your plugin above in the same format: name (link), a short tool summary,
+     and the launch command. Keep entries alphabetical by plugin name. -->
+
+## Publishing your own
+
+1. Build an MCP server (any language) that speaks stdio JSON-RPC — see
+   `cmd/reasonix-plugin-example` for a runnable reference.
+2. Declare its tools with honest `annotations` (`readOnlyHint` for safe readers).
+3. Ship it as its own package with a README that includes the `[[plugins]]` snippet.
+4. Open a PR adding a row to the table above.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,45 +1,51 @@
 # Community Plugins
 
-Reasonix loads external tools as **MCP servers** — subprocesses it talks to over
-stdio JSON-RPC — declared in `reasonix.toml` (see
-[SPEC §3.3](./SPEC.md#33-plugins-internalplugin--mcp-client) and
-[§5](./SPEC.md#5-configuration-toml)). Plugins live in their own repos/packages and
-are **not** bundled into core; this page is a discovery list so users can find them
-and authors can be linked.
+Reasonix loads external tools as **MCP servers**. The normal discovery path is
+the official MCP Registry: use **Settings → MCP servers → Browse registry** or
+`reasonix mcp browse [query]`. See the [Guide](./GUIDE.md#plugins-mcp) for the
+installation and runtime model.
 
-> This is a discovery list, not an endorsement or a quality guarantee. Vet a
-> plugin before installing it — an installed MCP server is trusted with its tools.
+This page complements the registry with community servers that include
+Reasonix-specific setup guidance. Listings are links, not bundled dependencies,
+endorsements, or quality guarantees.
+
+> Installing or declaring an MCP server is a trust decision. A local stdio
+> server runs as a subprocess, and its `readOnlyHint` / `destructiveHint` values
+> are workflow metadata rather than containment against malicious code. Review
+> the public source and published package before adding one.
 
 ## How to add a plugin
 
 Each `[[plugins]]` entry names a server and how to launch it. `type` defaults to
-`stdio`; `${VAR}` / `${VAR:-default}` are expanded in `command` / `args` / `env`.
+`stdio`; `${VAR}` / `${VAR:-default}` are expanded in `command`, `args`, and
+`env`. Pin package versions so a reviewed configuration does not silently start
+running a different release. `-y` prevents `npx`'s first-run installation prompt
+from blocking the MCP stdio handshake.
 
 ```toml
 [[plugins]]
 name    = "example"
 command = "npx"
-args    = ["some-reasonix-plugin"]
+args    = ["-y", "some-reasonix-plugin@1.2.3"]
 # env   = { SOME_TOKEN = "${SOME_TOKEN}" }
 ```
 
-After launch, a plugin's tools appear in-session namespaced as
-`mcp__<name>__<tool>`. Run `/mcp` in the chat TUI to see connected servers and
-their tool counts.
+After launch, tools appear in-session as `mcp__<name>__<tool>`. Run `/mcp` in
+the chat TUI to inspect connected servers and their tool counts.
 
-## Plugins
+## Community plugins
 
-| Plugin | Tools | Install |
-| --- | --- | --- |
-| [reasonix-plugin-git-context](https://github.com/kashifmahi/reasonix-plugin-git-context) | Read-only git: `blame`, `log`, `show`, `diff`, `file_history`, `pickaxe`, `pr_context` | `npx reasonix-plugin-git-context` |
-
-<!-- Add your plugin above in the same format: name (link), a short tool summary,
-     and the launch command. Keep entries alphabetical by plugin name. -->
+No entries are listed yet. A listing must have a reachable public source
+repository and a published, versioned release so users can inspect what the
+documented command executes.
 
 ## Publishing your own
 
-1. Build an MCP server (any language) that speaks stdio JSON-RPC — see
+1. Build an MCP server (any language) that speaks stdio JSON-RPC; see
    `cmd/reasonix-plugin-example` for a runnable reference.
-2. Declare its tools with honest `annotations` (`readOnlyHint` for safe readers).
-3. Ship it as its own package with a README that includes the `[[plugins]]` snippet.
-4. Open a PR adding a row to the table above.
+2. Publish its source, license, tests, and versioned installation artifact.
+3. Declare its tools with honest annotations, including `readOnlyHint` only for
+   tools whose behavior is actually read-only.
+4. Document a complete, copyable `[[plugins]]` entry with a pinned version.
+5. Open a PR adding the entry to both this page and `PLUGINS.zh-CN.md`, keeping
+   entries alphabetical by plugin name.

--- a/docs/PLUGINS.zh-CN.md
+++ b/docs/PLUGINS.zh-CN.md
@@ -1,0 +1,45 @@
+# 社区插件
+
+Reasonix 会将外部工具作为 **MCP 服务器**加载。常规发现入口是官方 MCP
+Registry：可在 **设置 → MCP 服务器 → 浏览 Registry** 中查找，也可运行
+`reasonix mcp browse [query]`。安装和运行机制详见[指南](./GUIDE.zh-CN.md#插件mcp)。
+
+本页作为 Registry 的补充，收录提供 Reasonix 专用接入说明的社区服务器。
+收录项只是外部链接，不会打包进 Reasonix，也不代表官方背书或质量保证。
+
+> 安装或声明 MCP 服务器就是一次信任决定。本地 stdio 服务器会作为子进程
+> 运行；`readOnlyHint` / `destructiveHint` 是工作流元数据，不是针对恶意
+> 代码的隔离边界。添加前请审查公开源码和已发布的软件包。
+
+## 如何添加插件
+
+每个 `[[plugins]]` 配置项都会声明服务器名称和启动方式。`type` 默认为
+`stdio`；`command`、`args` 和 `env` 中的 `${VAR}` / `${VAR:-default}` 会被
+展开。请固定软件包版本，避免已审查的配置在无感知的情况下运行其他
+版本。`-y` 可避免 `npx` 首次安装确认阻塞 MCP stdio 握手。
+
+```toml
+[[plugins]]
+name    = "example"
+command = "npx"
+args    = ["-y", "some-reasonix-plugin@1.2.3"]
+# env   = { SOME_TOKEN = "${SOME_TOKEN}" }
+```
+
+启动后，工具会以 `mcp__<name>__<tool>` 的名称出现在会话中。可在聊天 TUI
+中运行 `/mcp` 查看已连接服务器及其工具数量。
+
+## 社区插件
+
+暂无符合收录要求的条目。每个收录项都必须提供可访问的公开源码仓库和已发布的
+版本化产物，让用户能够审查文档命令实际会执行的内容。
+
+## 发布自己的插件
+
+1. 使用任意语言构建支持 stdio JSON-RPC 的 MCP 服务器；可参考可运行的
+   `cmd/reasonix-plugin-example`。
+2. 发布源码、许可证、测试以及版本化安装产物。
+3. 为工具声明真实的 annotations；只有行为确实只读的工具才能声明
+   `readOnlyHint`。
+4. 文档必须提供完整、可复制且固定版本的 `[[plugins]]` 配置。
+5. 提交 PR，同时更新本页和 `PLUGINS.md`，并按插件名字母顺序排列。


### PR DESCRIPTION
## Summary
- Add English and Chinese Community Plugins pages with a complete, pinned `[[plugins]]` adoption example.
- Link the pages from both README navigation bars.
- Position the page as a Reasonix-specific complement to the official MCP Registry.
- Document the MCP trust boundary and require reachable public source plus a versioned release before listing a community server.
- Keep the list empty until an entry satisfies those provenance requirements.

## Issue
Closes #7165

## Security
- Installing or declaring an MCP server is explicitly documented as a trust decision.
- `readOnlyHint` and `destructiveHint` are identified as workflow metadata, not containment against malicious code.
- The example pins the package version and uses `npx -y` so the first-run prompt cannot block the stdio handshake.

## Verification
- `git diff --check`
- English and Chinese Guide anchors verified
- README and local documentation targets verified
- Synthetic merge tree with the latest `main-v2` verified

## Cache impact
- Cache-impact: none
- Cache-guard: N/A; documentation only
- System-prompt-review: N/A; no provider-visible prompt, memory prefix, tool schema, or request serialization changes