### PR TITLE
feat: add android/arm64 (Termux) prebuilt support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w -X main.version={{ .Tag }}
-    goos: [darwin, linux, windows]
+    goos: [darwin, linux, windows, android]
     goarch: [amd64, arm64]
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ hooks:
 
 cross:
 	@mkdir -p dist
-	@for p in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64; do \
+	@for p in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 android/arm64 windows/amd64 windows/arm64; do \
 		os=$${p%/*}; arch=$${p#*/}; ext=; [ $$os = windows ] && ext=.exe; \
 		echo "build $$os/$$arch"; \
 		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -ldflags "$(LDFLAGS)" -o dist/reasonix-$$os-$$arch$$ext ./cmd/reasonix; \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
   summary, stale tool output is snipped/pruned before summary compaction, and the
   built-in tool schema contract is documented for regression review.
 - **Zero-friction distribution.** `CGO_ENABLED=0` single binary; cross-compile
-  to six targets with one command. The only dependency is a TOML parser.
+  to seven targets with one command. The only dependency is a TOML parser.
 
 ## Install
 
@@ -72,8 +72,22 @@ npm i -g reasonix                  # any OS; pulls the prebuilt native binary
 brew install esengine/reasonix/reasonix   # macOS
 ```
 
-Prebuilt archives (`darwin|linux|windows × amd64|arm64`) and `SHA256SUMS` are on
-every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
+On Android, run it natively in [Termux](https://termux.com/) (Node.js 18+ via
+`pkg install nodejs`):
+
+```sh
+pkg install nodejs
+npm i -g reasonix
+reasonix --version
+```
+
+Android builds are PIE executables (`GOOS=android`), which the Android kernel
+requires; the npm package ships a matching `@reasonix/cli-android-arm64`
+prebuilt binary for ARM64 devices.
+
+Prebuilt archives (`darwin|linux|windows|android × amd64|arm64`) and
+`SHA256SUMS` are on every
+[GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 
 ### Path B: Desktop app
 
@@ -105,7 +119,7 @@ approvals, model selection, and workspace sessions.
 git clone https://github.com/esengine/DeepSeek-Reasonix.git
 cd DeepSeek-Reasonix
 make build      # -> bin/reasonix(.exe)
-make cross      # -> dist/ (darwin|linux|windows × amd64|arm64)
+make cross      # -> dist/ (darwin|linux|windows|android × amd64|arm64)
 ```
 
 ## Quick start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,7 +50,7 @@
   内置工具在编译期自注册。
 - **缓存友好的上下文维护**：启动时注入稳定的环境摘要；旧工具输出会先 snip/prune，
   再进入摘要 compaction；内置工具 schema 合约有文档和回归测试保护。
-- **零摩擦分发**：`CGO_ENABLED=0` 单二进制；一条命令交叉编译到六个目标平台。
+- **零摩擦分发**：`CGO_ENABLED=0` 单二进制；一条命令交叉编译到七个目标平台。
   唯一依赖是一个 TOML 解析库。
 
 ## 安装
@@ -67,8 +67,20 @@ npm i -g reasonix                  # 任意系统;自动拉取对应平台的原
 brew install esengine/reasonix/reasonix   # macOS
 ```
 
-预编译归档(`darwin|linux|windows × amd64|arm64`)和 `SHA256SUMS` 见每个
+预编译归档(`darwin|linux|windows|android × amd64|arm64`)和 `SHA256SUMS` 见每个
 [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases)。
+
+在 Android 上，可原生运行于 [Termux](https://termux.com/)（Node.js 18+，通过
+`pkg install nodejs` 安装）：
+
+```sh
+pkg install nodejs
+npm i -g reasonix
+reasonix --version
+```
+
+Android 构建是 PIE 可执行文件（`GOOS=android`），这是 Android 内核的硬性要求；
+npm 包会附带对应的 `@reasonix/cli-android-arm64` ARM64 预编译二进制。
 
 ### 路径 B：桌面端
 
@@ -98,7 +110,7 @@ Windows 安装器通过 [SignPath.io](https://signpath.io/) 完成代码签名�
 git clone https://github.com/esengine/DeepSeek-Reasonix.git
 cd DeepSeek-Reasonix
 make build      # -> bin/reasonix(.exe)
-make cross      # -> dist/（darwin|linux|windows × amd64|arm64）
+make cross      # -> dist/（darwin|linux|windows|android × amd64|arm64）
 ```
 
 ## 快速开始

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -13,6 +13,7 @@ const TARGETS = [
   { node: "darwin-x64", goos: "darwin", goarch: "amd64" },
   { node: "linux-arm64", goos: "linux", goarch: "arm64" },
   { node: "linux-x64", goos: "linux", goarch: "amd64" },
+  { node: "android-arm64", goos: "android", goarch: "arm64" },
   { node: "win32-arm64", goos: "windows", goarch: "arm64" },
   { node: "win32-x64", goos: "windows", goarch: "amd64" },
 ];

--- a/npm/reasonix/package.json
+++ b/npm/reasonix/package.json
@@ -33,6 +33,7 @@
     "@reasonix/cli-darwin-x64": "0.0.0",
     "@reasonix/cli-linux-arm64": "0.0.0",
     "@reasonix/cli-linux-x64": "0.0.0",
+    "@reasonix/cli-android-arm64": "0.0.0",
     "@reasonix/cli-win32-arm64": "0.0.0",
     "@reasonix/cli-win32-x64": "0.0.0"
   }


### PR DESCRIPTION
## Summary

The npm package ships no binary for `android-arm64`, so `npm i -g reasonix` fails with `no prebuilt binary for android-arm64` on Termux (Android). The prebuilt `linux-arm64` binary cannot be reused there either: the Android kernel/linker64 rejects the default non-PIE (`ET_EXEC`) build with `"%s" has unexpected e_type`.

This PR adds `android/arm64` to the distribution pipeline:

- `npm/build.mjs`: new `android-arm64` target in the build matrix
- `npm/reasonix/package.json`: `@reasonix/cli-android-arm64` optionalDependency
- `Makefile`: `android/arm64` added to the `cross` target
- `.goreleaser.yaml`: `android` added to `goos` (validated target: `androidarm64` is in GoReleaser's `validTargets`; `android` is in `validGoos`)
- `README.md` + `README.zh-CN.md`: Termux install instructions

No wrapper change is needed: on Termux, Node.js reports `process.platform === "android"` and `process.arch === "arm64"`, so `reasonix.js` already resolves `@reasonix/cli-android-arm64`.

## Why it works

`GOOS=android` makes Go emit a PIE (`ET_DYN`) executable by default, which is the format Android's `linker64` requires. `CGO_ENABLED=0` keeps it a single static binary, same as the other targets.

## Verification

Built with `GOOS=android GOARCH=arm64 CGO_ENABLED=0` on aarch64 Termux (Go 1.26.4). The resulting binary is `ELF shared object ... dynamic (/system/bin/linker64)`, `Type: DYN`, and runs natively:

```
$ ./reasonix --version
reasonix dev
```

Also ran `node npm/build.mjs v1.19.1` (dry run) to confirm the expanded matrix builds cleanly.

Cache-impact: none (build/packaging/docs only; no provider-visible code paths touched)
Cache-guard: N/A
System-prompt-review: N/A

Generated with [Continue](https://continue.dev)

Co-Authored-By: Continue <noreply@continue.dev>