### PR TITLE
bot: restore last used session from session_mappings after restart

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -2305,6 +2305,14 @@ func (gw *BotGateway) sessionProfileForMessage(msg InboundMessage) sessionRuntim
 	var sessionPath string
 	if override, ok := gw.sessionRuntimeOverrideForMessage(msg); ok {
 		sessionPath = override.sessionPath
+	} else {
+		// After the gateway process restarts (desktop or machine reboot) the
+		// in-memory override is gone: fall back to the persisted
+		// session_mappings entry for this remote chat, equivalent to an
+		// automatic /attach session on startup. The context then survives
+		// process restarts until the user explicitly runs /new, /attach
+		// session, or /use project.
+		sessionPath = gw.savedSessionPathForMessage(msg)
 	}
 	return sessionRuntimeProfile{
 		model:            strings.TrimSpace(model),
@@ -2312,6 +2320,40 @@ func (gw *BotGateway) sessionProfileForMessage(msg InboundMessage) sessionRuntim
 		toolApprovalMode: normalizeBotToolApprovalMode(toolApprovalMode),
 		sessionPath:      canonicalBotPath(sessionPath),
 	}
+}
+
+// savedSessionPathForMessage restores the session file path this remote chat
+// last used from the persisted session_mappings when no in-memory override
+// exists. It returns an empty string unless the session file still exists and
+// is not a directory, so a cleaned-up old session degrades to a fresh session
+// instead of failing Resume and leaving the bot unresponsive for that chat.
+// The file availability check matches /attach session.
+func (gw *BotGateway) savedSessionPathForMessage(msg InboundMessage) string {
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	var mappings []SessionMapping
+	if msg.ConnectionID != "" {
+		if connChannel, ok := gw.cfg.ConnectionChannels[msg.ConnectionID]; ok {
+			mappings = connChannel.SessionMappings
+		}
+	}
+	if len(mappings) == 0 {
+		if platChannel, ok := gw.cfg.Channels[msg.Platform]; ok {
+			mappings = platChannel.SessionMappings
+		}
+	}
+	mapping, ok := matchingSessionMapping(mappings, msg)
+	if !ok {
+		return ""
+	}
+	sessionPath := botSessionPathFromTarget(mapping.SessionID)
+	if sessionPath == "" {
+		return ""
+	}
+	if info, err := os.Stat(sessionPath); err != nil || info.IsDir() {
+		return ""
+	}
+	return sessionPath
 }
 
 func sessionStateMatchesRuntime(state *sessionState, profile sessionRuntimeProfile) bool {

--- a/internal/bot/session_restore_test.go
+++ b/internal/bot/session_restore_test.go
@@ -1,0 +1,123 @@
+package bot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSavedSessionPathForMessageRestoresLastSession verifies that after a
+// gateway restart (no in-memory override), the session file path this remote
+// chat last used is restored from the persisted session_mappings, including
+// stripping the path: prefix.
+func TestSavedSessionPathForMessageRestoresLastSession(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "20260802-000000.000000000-deepseek-v4-flash.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	cfg := GatewayConfig{
+		ConnectionChannels: map[string]ChannelConfig{
+			"weixin-weixin": {
+				SessionMappings: []SessionMapping{{
+					RemoteID:  "user@im.wechat",
+					SessionID: "path:" + sessionPath,
+				}},
+			},
+		},
+	}
+	gw := NewGateway(cfg, nil, nil)
+	msg := InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-weixin",
+		ChatType:     ChatDM,
+		ChatID:       "user@im.wechat",
+	}
+	got := gw.savedSessionPathForMessage(msg)
+	want := filepath.Clean(sessionPath)
+	if got != want {
+		t.Fatalf("savedSessionPathForMessage = %q, want %q", got, want)
+	}
+}
+
+// TestSavedSessionPathForMessageMissingFile verifies that a missing session
+// file yields an empty string so the bot starts a fresh session instead of
+// failing Resume and becoming unresponsive.
+func TestSavedSessionPathForMessageMissingFile(t *testing.T) {
+	cfg := GatewayConfig{
+		ConnectionChannels: map[string]ChannelConfig{
+			"weixin-weixin": {
+				SessionMappings: []SessionMapping{{
+					RemoteID:  "user@im.wechat",
+					SessionID: "path:" + filepath.Join(t.TempDir(), "gone.jsonl"),
+				}},
+			},
+		},
+	}
+	gw := NewGateway(cfg, nil, nil)
+	msg := InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-weixin",
+		ChatType:     ChatDM,
+		ChatID:       "user@im.wechat",
+	}
+	if got := gw.savedSessionPathForMessage(msg); got != "" {
+		t.Fatalf("savedSessionPathForMessage = %q, want empty for missing session file", got)
+	}
+}
+
+// TestSavedSessionPathForMessageNoMapping verifies that no matching mapping
+// yields an empty string (new user / new chat starts a fresh session).
+func TestSavedSessionPathForMessageNoMapping(t *testing.T) {
+	cfg := GatewayConfig{
+		ConnectionChannels: map[string]ChannelConfig{
+			"weixin-weixin": {
+				SessionMappings: []SessionMapping{{
+					RemoteID:  "other@im.wechat",
+					SessionID: "path:" + filepath.Join(t.TempDir(), "x.jsonl"),
+				}},
+			},
+		},
+	}
+	gw := NewGateway(cfg, nil, nil)
+	msg := InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-weixin",
+		ChatType:     ChatDM,
+		ChatID:       "user@im.wechat",
+	}
+	if got := gw.savedSessionPathForMessage(msg); got != "" {
+		t.Fatalf("savedSessionPathForMessage = %q, want empty for no matching mapping", got)
+	}
+}
+
+// TestSavedSessionPathForMessagePlatformFallback verifies that mappings are
+// read from the platform-level Channels when no per-connection mapping exists.
+func TestSavedSessionPathForMessagePlatformFallback(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "20260802-000000.000000000-deepseek-v4-flash.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	cfg := GatewayConfig{
+		Channels: map[Platform]ChannelConfig{
+			PlatformWeixin: {
+				SessionMappings: []SessionMapping{{
+					RemoteID:  "user@im.wechat",
+					SessionID: "path:" + sessionPath,
+				}},
+			},
+		},
+	}
+	gw := NewGateway(cfg, nil, nil)
+	msg := InboundMessage{
+		Platform: PlatformWeixin,
+		ChatType: ChatDM,
+		ChatID:   "user@im.wechat",
+	}
+	got := gw.savedSessionPathForMessage(msg)
+	want := filepath.Clean(sessionPath)
+	if got != want {
+		t.Fatalf("savedSessionPathForMessage = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

When the bot gateway process restarts (desktop app restart or machine reboot),
the first inbound message from a remote chat always starts a brand-new
session, losing the previous conversation context.

Root cause in `internal/bot/gateway.go`:

- Session reuse (`gw.controllers`) and session binding (`gw.sessionOverrides`)
  are in-memory only and are cleared on restart.
- `sessionProfileForMessage` only reads the in-memory override for the session
  path; the persisted `session_mappings` (written by `OnSessionReady`) are used
  only for workspace routing and the desktop UI, never fed back into the
  gateway to resume a session.

## Change

`sessionProfileForMessage` now falls back to the persisted `session_mappings`
entry for the inbound message when no in-memory override exists, resuming the
recorded `session_id` (a `path:` session file) if it still exists. This is
equivalent to an automatic `/attach session` right after gateway startup, so a
DM keeps one conversation across restarts until the user explicitly runs
`/new`, `/attach session`, or `/use project` (overrides keep precedence).

If the recorded session file no longer exists, the fallback returns empty and
the bot starts a fresh session instead of failing Resume.

## Tests

Added `internal/bot/session_restore_test.go` covering: restore from mapping,
missing session file (empty result), no matching mapping (empty result), and
platform-level mapping fallback.

Note: I could not run `go test ./...` locally (no Go toolchain available);
the change was reviewed against the existing APIs. CI verification appreciated.
