### PR TITLE
feat(release): Stage-1 Preview/Stable promotion infrastructure / 落地 Stage-1 晋级基础设施（不激活）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,14 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       desktop: ${{ steps.filter.outputs.desktop }}
       site: ${{ steps.filter.outputs.site }}
+      release_workflows: ${{ steps.filter.outputs.release_workflows }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: filter
         run: |
-          code=true; desktop=true; site=true
+          code=true; desktop=true; site=true; release_workflows=true
           base=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="${{ github.event.pull_request.base.sha }}"
@@ -45,7 +46,7 @@ jobs:
           if [ -n "$base" ] && git cat-file -e "$base^{commit}" 2>/dev/null; then
             files=$(git diff --name-only "$base" HEAD)
             if [ -n "$files" ]; then
-              code=false; desktop=false; site=false
+              code=false; desktop=false; site=false; release_workflows=false
               # Root-module CI: desktop/ is a separate module, so only the
               # clearly unrelated paths below can skip it.
               if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|desktop/|workers/|[^/]+\.md$)'; then code=true; fi
@@ -53,9 +54,10 @@ jobs:
               # so only this clearly-unrelated set is safe to skip.
               if echo "$files" | grep -qvE '^(docs/|site/|release-notes/|workers/|benchmarks/|npm/|[^/]+\.md$)'; then desktop=true; fi
               if echo "$files" | grep -q '^site/'; then site=true; fi
+              if echo "$files" | grep -qE '^docs/releasing/stage3-workflows/[^/]+\.ya?ml$'; then release_workflows=true; fi
             fi
           fi
-          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; } >> "$GITHUB_OUTPUT"
+          { echo "code=$code"; echo "desktop=$desktop"; echo "site=$site"; echo "release_workflows=$release_workflows"; } >> "$GITHUB_OUTPUT"
 
   # The ruleset requires the per-OS check names (test (ubuntu-latest) etc.).
   # A matrix job skipped at job level reports no per-leg checks at all, so
@@ -359,7 +361,10 @@ jobs:
 
   lint:
     needs: changes
-    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.code != 'false')
+    if: >-
+      always() && (github.event_name != 'pull_request' ||
+      needs.changes.outputs.code != 'false' ||
+      needs.changes.outputs.release_workflows == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -405,7 +410,12 @@ jobs:
             .github/workflows/prepare-release-notes.yml \
             .github/workflows/release.yml \
             .github/workflows/release-npm.yml \
-            .github/workflows/release-desktop.yml
+            .github/workflows/release-desktop.yml \
+            docs/releasing/stage3-workflows/release-preview.yml \
+            docs/releasing/stage3-workflows/release-stable.yml \
+            docs/releasing/stage3-workflows/release-preview-recovery.yml \
+            docs/releasing/stage3-workflows/release-stable-recovery.yml \
+            docs/releasing/stage3-workflows/release-stable-emergency.yml
           bash scripts/release-workflows.test.sh
 
   # The site/ auth client has security-sensitive redirect-validation logic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,8 +398,11 @@ jobs:
           go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 \
             -ignore 'label "windows-11-arm" is unknown' \
             .github/workflows/release-stable.yml \
+            .github/workflows/release-stable-shadow.yml \
             .github/workflows/release-preview.yml \
+            .github/workflows/release-stable-trigger.yml \
             .github/workflows/release-cli-trigger.yml \
+            .github/workflows/prepare-release-notes.yml \
             .github/workflows/release.yml \
             .github/workflows/release-npm.yml \
             .github/workflows/release-desktop.yml

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -11,6 +11,10 @@ on:
         description: "Previous release tag (defaults to the newest catalog entry)"
         required: false
         type: string
+      promote_from:
+        description: "Preview tag promoted by Stable notes, for example v1.20.0-preview.3"
+        required: false
+        type: string
       target_pr:
         description: "Optional open same-repository PR into main-v2 to reuse instead of opening a release-only PR"
         required: false
@@ -91,10 +95,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.version }}
           FROM_TAG: ${{ inputs.from_tag }}
+          PROMOTE_FROM: ${{ inputs.promote_from }}
         run: |
           set -euo pipefail
           args=(--version "$VERSION")
           if [ -n "$FROM_TAG" ]; then args+=(--from "$FROM_TAG"); fi
+          if [ -n "$PROMOTE_FROM" ]; then args+=(--promote-from "$PROMOTE_FROM"); fi
           node scripts/generate-release-notes.mjs "${args[@]}"
           node scripts/release-notes.mjs validate
           node --test scripts/release-notes.test.mjs

--- a/.github/workflows/release-stable-shadow.yml
+++ b/.github/workflows/release-stable-shadow.yml
@@ -1,0 +1,95 @@
+name: Shadow validate stable promotion
+run-name: Shadow validate stable promotion
+
+# Read-only promotion proof for Stage-1 infrastructure and Stage-2 drills.
+# Resolves the newest pending Stable promotion and verifies CI, soak, notes,
+# and public Preview surfaces without creating tags or publishing anything.
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  shadow:
+    name: shadow validate pending Stable promotion
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Resolve pending promotion
+        id: identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          GITHUB_OUTPUT=/tmp/stable-identity bash scripts/resolve-stable-promotion.sh
+          cat /tmp/stable-identity >> "$GITHUB_OUTPUT"
+          {
+            echo "## Shadow Stable promotion"
+            echo ""
+            echo "- Preview: \`$(grep -E '^preview_tag=' /tmp/stable-identity | cut -d= -f2-)\`"
+            echo "- Stable: \`$(grep -E '^cli_tag=' /tmp/stable-identity | cut -d= -f2-)\`"
+            echo "- Candidate SHA: \`$(grep -E '^sha=' /tmp/stable-identity | cut -d= -f2-)\`"
+            echo "- No tags will be created and no surfaces will be published."
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate reviewed Stable notes
+        env:
+          VERSION: ${{ steps.identity.outputs.version }}
+        run: node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md
+      - name: Validate source Preview event
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          PREVIEW_VERSION: ${{ steps.identity.outputs.preview_version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          mkdir -p /tmp/source-preview
+          gh release download "$PREVIEW_TAG" --pattern release-event.json --dir /tmp/source-preview
+          node scripts/release-event.mjs validate \
+            --version "$PREVIEW_VERSION" --input /tmp/source-preview/release-event.json
+          jq -e --arg sha "$RELEASE_SHA" '.candidateSha == $sha and .channel == "preview"' \
+            /tmp/source-preview/release-event.json >/dev/null
+      - name: Enforce Preview observation period
+        run: node scripts/verify-preview-soak.mjs --input /tmp/source-preview/release-event.json --minimum-hours 24
+      - name: Require successful CI for the exact candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          gh run list --workflow ci.yml --commit "$RELEASE_SHA" --event push --limit 20 \
+            --json databaseId,url,headSha,headBranch,event,createdAt,status,conclusion > /tmp/ci-runs.json
+          node scripts/verify-release-ci.mjs --input /tmp/ci-runs.json --sha "$RELEASE_SHA"
+      - name: Verify immutable Preview public surfaces
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          EXPECTED_SHA: ${{ steps.identity.outputs.sha }}
+        run: bash scripts/verify-preview-release-artifacts.sh
+      - name: Revalidate as if tags were about to be created
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: stable
+          VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+          RELEASE_TAGS: ${{ format('{0} {1} {2}', steps.identity.outputs.cli_tag, steps.identity.outputs.npm_tag, steps.identity.outputs.desktop_tag) }}
+          PREVIEW_VERSION: ${{ steps.identity.outputs.preview_version }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+        run: bash scripts/revalidate-release-candidate.sh
+      - name: Record shadow success
+        env:
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          CLI_TAG: ${{ steps.identity.outputs.cli_tag }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          {
+            echo ""
+            echo "Shadow validation passed for \`$PREVIEW_TAG\` → \`$CLI_TAG\` at \`$RELEASE_SHA\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-stable-shadow.yml
+++ b/.github/workflows/release-stable-shadow.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+      - if: ${{ vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK == 'true' }}
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Resolve pending promotion
         id: identity
         env:
@@ -72,6 +77,7 @@ jobs:
           RELEASE_REPOSITORY: ${{ github.repository }}
           PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
           EXPECTED_SHA: ${{ steps.identity.outputs.sha }}
+          PREVIEW_FULL_DOWNLOAD_CHECK: ${{ vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK || 'false' }}
         run: bash scripts/verify-preview-release-artifacts.sh
       - name: Revalidate as if tags were about to be created
         env:
@@ -82,6 +88,7 @@ jobs:
           RELEASE_TAGS: ${{ format('{0} {1} {2}', steps.identity.outputs.cli_tag, steps.identity.outputs.npm_tag, steps.identity.outputs.desktop_tag) }}
           PREVIEW_VERSION: ${{ steps.identity.outputs.preview_version }}
           PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
         run: bash scripts/revalidate-release-candidate.sh
       - name: Record shadow success
         env:

--- a/.github/workflows/release-stable-trigger.yml
+++ b/.github/workflows/release-stable-trigger.yml
@@ -4,6 +4,9 @@ run-name: Relay stable release ${{ github.ref_name }}
 # The tag event itself has a tag-shaped origin. Relay the immutable tag name to
 # release-stable.yml on protected main-v2 so the production SignPath policy can
 # allow exactly one branch name without trusting wildcard tag-like branches.
+#
+# Stage 1: human Stable tags still relay. When the Stage-3 release-tagger App
+# creates the atomic Stable set, skip relay to avoid a duplicate orchestrator.
 on:
   push:
     tags:
@@ -23,11 +26,16 @@ jobs:
         uses: actions/github-script@v9
         env:
           RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_ACTOR: ${{ github.actor }}
           CONTROL_PLANE_REF: ${{ github.event.repository.default_branch }}
         with:
           script: |
             if (process.env.CONTROL_PLANE_REF !== 'main-v2') {
               core.setFailed(`Unexpected default branch: ${process.env.CONTROL_PLANE_REF}`);
+              return;
+            }
+            if (process.env.RELEASE_ACTOR === 'reasonix-release-tagger[bot]') {
+              core.info('Release stable already owns publication for this automated tag set.');
               return;
             }
             await github.rest.actions.createWorkflowDispatch({

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -269,3 +269,19 @@ strict separation from repository writers is required.
   only for Developer ID signed and notarized builds; ad-hoc/local builds fall
   back to the download page. Desktop `latest.json` keeps `platforms` for
   portable channels and adds optional `native_packages` for OS packages.
+
+## Phased Preview → Stable promotion rollout
+
+Reasonix is landing automated same-SHA promotion in stages. **Current production
+entrypoints remain the legacy tag + relay path** until Stage 3 activates.
+
+| Stage | What lands | Production release impact |
+| --- | --- | --- |
+| **1 – Infrastructure** | Release-notes `promote_from` / event `promotion` schema, promotion/CI/soak/artifact helper scripts, bare-remote contract tests, App-aware but human-compatible tag relays, read-only **Shadow validate stable promotion** | None. Operators still prepare exact Preview notes, push Preview tags, and push atomic Stable tags as before. |
+| **1b – Cutoff config** | Fill `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA` in `scripts/release-activation.sh` with the Stage-1 merge SHA | Still no entrypoint change. Shadow now only accepts Previews at or after that commit. |
+| **2 – Dry run** | Create `reasonix-release-tagger` App + environment secrets; keep dual create rules; publish a new Preview from post-cutoff `main-v2`; prepare Stable notes with `promote_from`; after ≥24h run shadow validation | Still ship with legacy tags if needed. |
+| **3 – Activation** | Copy drafts from `docs/releasing/stage3-workflows/`, switch App-only Preview/Stable create rules in the same window, enable one-input Preview / zero-input Stable and isolated recovery/emergency entrypoints | Operators stop hand-tagging normal Preview/Stable. |
+
+Do not merge Stage-3 workflow activation until shadow validation has succeeded
+against a real post-cutoff Preview. Stage-3 drafts under
+`docs/releasing/stage3-workflows/` are not active GitHub Actions workflows.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -279,9 +279,15 @@ entrypoints remain the legacy tag + relay path** until Stage 3 activates.
 | --- | --- | --- |
 | **1 – Infrastructure** | Release-notes `promote_from` / event `promotion` schema, promotion/CI/soak/artifact helper scripts, bare-remote contract tests, App-aware but human-compatible tag relays, read-only **Shadow validate stable promotion** | None. Operators still prepare exact Preview notes, push Preview tags, and push atomic Stable tags as before. |
 | **1b – Cutoff config** | Fill `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA` in `scripts/release-activation.sh` with the Stage-1 merge SHA | Still no entrypoint change. Shadow now only accepts Previews at or after that commit. |
-| **2 – Dry run** | Create `reasonix-release-tagger` App + environment secrets; keep dual create rules; publish a new Preview from post-cutoff `main-v2`; prepare Stable notes with `promote_from`; after ≥24h run shadow validation | Still ship with legacy tags if needed. |
+| **2 – Dry run** | Create `reasonix-release-tagger` App + environment secrets; keep dual create rules; set repository variable `RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK=true` for the first cutover proof; publish a new Preview from post-cutoff `main-v2`; prepare Stable notes with `promote_from`; after ≥24h run shadow validation | Still ship with legacy tags if needed. Shadow downloads every Desktop payload and signature, verifies manifest size/SHA-256 and the embedded minisign public key, and remains read-only. |
 | **3 – Activation** | Copy drafts from `docs/releasing/stage3-workflows/`, switch App-only Preview/Stable create rules in the same window, enable one-input Preview / zero-input Stable and isolated recovery/emergency entrypoints | Operators stop hand-tagging normal Preview/Stable. |
 
 Do not merge Stage-3 workflow activation until shadow validation has succeeded
 against a real post-cutoff Preview. Stage-3 drafts under
-`docs/releasing/stage3-workflows/` are not active GitHub Actions workflows.
+`docs/releasing/stage3-workflows/` are not active GitHub Actions workflows, but
+CI actionlints them offline. The activated Preview and Stable workflows must
+retain their shared `release-promotion` concurrency group so a Preview cannot
+be created between Stable's final revalidation and atomic tag push. After the
+first full-download cutover proof, the repository variable may be set to
+`false` for metadata-only daily shadow runs and re-enabled for any publication
+where fresh public-byte verification is required.

--- a/docs/releasing/stage3-workflows/README.md
+++ b/docs/releasing/stage3-workflows/README.md
@@ -1,0 +1,34 @@
+# Stage 3 activation workflow drafts
+
+These files are **not** active GitHub Actions workflows. They are the activation
+diff prepared for Stage 3 and must not live under `.github/workflows/` until:
+
+1. Stage 1 infrastructure has merged
+2. `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA` is set to that merge SHA
+3. The `reasonix-release-tagger` App, environment secrets, and compatible tag
+   rulesets are configured
+4. A Preview published from the post-cutoff `main-v2` history has soaked ≥24h
+5. Shadow validation has succeeded
+
+## Contents
+
+| Draft | Role after activation |
+| --- | --- |
+| `release-preview.yml` | One-input Preview orchestrator + App tag creation |
+| `release-stable.yml` | Zero-input Stable promotion + App atomic tags |
+| `release-preview-recovery.yml` | Isolated Preview recovery request |
+| `release-stable-recovery.yml` | Isolated Stable recovery request |
+| `release-stable-emergency.yml` | P0 observation-period override request |
+| `release-cli-trigger.yml` | Block human Preview tags; accept App only |
+| `release-stable-trigger.yml` | Block human Stable tags; accept App only |
+
+## Activation steps
+
+1. Copy these files over `.github/workflows/` counterparts (and add the three
+   request workflows).
+2. In Stage-3 promote paths set `RELEASE_REQUIRE_PROMOTION_CUTOFF=true` (or keep
+   a non-empty `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA`).
+3. Switch repository tag rulesets to App-only create for Preview/Stable in the
+   same change window.
+4. Update `docs/RELEASING.md` and the `reasonix-develop` skill only after the
+   workflows are live.

--- a/docs/releasing/stage3-workflows/release-cli-trigger.yml
+++ b/docs/releasing/stage3-workflows/release-cli-trigger.yml
@@ -4,10 +4,6 @@ run-name: Relay CLI prerelease ${{ github.ref_name }}
 # Keep native CLI publication on protected main-v2. The tag-triggered workflow
 # carries only the immutable candidate tag and its classified channel into the
 # protected release control plane.
-#
-# Stage 1: human Preview tags still relay into Release preview. When the
-# Stage-3 release-tagger App creates a Preview tag, skip relay so the
-# orchestrator that already owns publication is not duplicated.
 on:
   push:
     tags: ["v*-*"]
@@ -34,14 +30,18 @@ jobs:
             }
             const tag = process.env.RELEASE_TAG;
             const preview = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-preview\.(?:0|[1-9]\d*)$/.test(tag);
-            if (preview && context.actor === 'reasonix-release-tagger[bot]') {
-              core.info('Release preview already owns publication for this automated tag.');
+            if (preview) {
+              if (context.actor === 'reasonix-release-tagger[bot]') {
+                core.info('Release preview already owns publication for this automated tag.');
+                return;
+              }
+              core.setFailed('Preview tags must be created by Actions → Release preview; use Request preview recovery for an existing tag.');
               return;
             }
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: preview ? 'release-preview.yml' : 'release.yml',
+              workflow_id: 'release.yml',
               ref: process.env.CONTROL_PLANE_REF,
-              inputs: preview ? { tag } : { channel: 'stable', tag },
+              inputs: { channel: 'stable', tag },
             });

--- a/docs/releasing/stage3-workflows/release-preview-recovery.yml
+++ b/docs/releasing/stage3-workflows/release-preview-recovery.yml
@@ -1,0 +1,37 @@
+name: Request preview recovery
+run-name: Request preview recovery ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing Preview tag, for example v1.20.0-preview.3"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  request:
+    name: record Preview recovery request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require protected control branch
+        env:
+          CONTROL_BRANCH: ${{ github.ref_name }}
+        run: |
+          [ "$CONTROL_BRANCH" = "main-v2" ] || {
+            echo "::error::Preview recovery requests must run from main-v2"
+            exit 1
+          }
+      - name: Write request
+        env:
+          TAG: ${{ inputs.tag }}
+        run: jq -n --arg tag "$TAG" '{tag:$tag}' > /tmp/request.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: preview-recovery-request
+          path: /tmp/request.json
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/releasing/stage3-workflows/release-preview.yml
+++ b/docs/releasing/stage3-workflows/release-preview.yml
@@ -1,0 +1,329 @@
+name: Release preview
+run-name: >-
+  Release preview ${{ inputs.base_version || format('recovery {0}', github.event.workflow_run.display_title) }}
+
+# The normal form asks only for a release-train version. Recovery is requested
+# by a separate workflow and arrives as a completed, immutable artifact.
+on:
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "Release train, for example 1.20.0"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Request preview recovery"]
+    types: [completed]
+
+concurrency:
+  group: preview-release
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  preflight:
+    name: resolve and validate Preview
+    runs-on: ubuntu-latest
+    outputs:
+      control_plane_sha: ${{ steps.freeze.outputs.control_plane_sha }}
+      version: ${{ steps.identity.outputs.version }}
+      base_version: ${{ steps.identity.outputs.base_version }}
+      preview_number: ${{ steps.identity.outputs.preview_number }}
+      cli_tag: ${{ steps.identity.outputs.cli_tag }}
+      sha: ${{ steps.identity.outputs.sha }}
+      recovery: ${{ steps.identity.outputs.recovery }}
+      ci_run_url: ${{ steps.ci.outputs.ci_run_url }}
+    steps:
+      - name: Freeze protected control plane
+        id: freeze
+        run: |
+          set -euo pipefail
+          echo "control_plane_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Preview control plane"
+            echo ""
+            echo "- Frozen control plane SHA: \`${{ github.sha }}\`"
+            echo "- Event: \`${{ github.event_name }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Resolve normal or recovery request
+        id: identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          BASE_VERSION: ${{ inputs.base_version }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SOURCE_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          SOURCE_RUN_NAME: ${{ github.event.workflow_run.name }}
+          SOURCE_RUN_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          set -euo pipefail
+          output=/tmp/preview-identity
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            REQUEST_KIND=preview-recovery \
+              EXPECTED_WORKFLOW_NAME="Request preview recovery" \
+              EXPECTED_ARTIFACT_NAME=preview-recovery-request \
+              REQUEST_OUTPUT=/tmp/preview-request.json \
+              bash scripts/consume-release-request.sh
+            tag="$(jq -er '.tag' /tmp/preview-request.json)"
+            GITHUB_OUTPUT="$output" RELEASE_TAG="$tag" ALLOW_PREVIEW_RECOVERY=true \
+              bash scripts/resolve-preview-release.sh
+            echo "recovery=true" >> "$output"
+          else
+            GITHUB_OUTPUT="$output" bash scripts/resolve-preview-candidate.sh || {
+              echo "::error::Prepare the exact next Preview notes first via Actions → Prepare release notes, then re-run Release preview."
+              exit 1
+            }
+            echo "recovery=false" >> "$output"
+          fi
+          cat "$output" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Preview candidate"
+            echo ""
+            echo "- Version: \`$(grep -E '^version=' "$output" | cut -d= -f2-)\`"
+            echo "- CLI tag: \`$(grep -E '^cli_tag=' "$output" | cut -d= -f2-)\`"
+            echo "- Candidate SHA: \`$(grep -E '^sha=' "$output" | cut -d= -f2-)\`"
+            echo "- Recovery: \`$(grep -E '^recovery=' "$output" | cut -d= -f2-)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate exact reviewed Preview notes
+        env:
+          VERSION: ${{ steps.identity.outputs.version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md || {
+            echo "::error::Reviewed Preview notes for $VERSION are missing or invalid. Run Actions → Prepare release notes for $VERSION before Release preview."
+            exit 1
+          }
+          node scripts/release-event.mjs generate \
+            --version "$VERSION" --sha "$RELEASE_SHA" \
+            --published-at 2000-01-01T00:00:00.000Z \
+            --output /tmp/release-event.json
+      - name: Require successful CI for the exact candidate
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          gh run list --workflow ci.yml --commit "$RELEASE_SHA" --event push --limit 20 \
+            --json databaseId,url,headSha,headBranch,event,createdAt,status,conclusion > /tmp/ci-runs.json
+          node scripts/verify-release-ci.mjs --input /tmp/ci-runs.json --sha "$RELEASE_SHA"
+          ci_url="$(grep -E '^ci_run_url=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2- || true)"
+          echo "- Exact CI run: ${ci_url:-verified}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload reviewed release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: orchestrator-reviewed-release-notes
+          path: /tmp/release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+
+  authorize:
+    name: approve Preview ${{ needs.preflight.outputs.cli_tag }} @ ${{ needs.preflight.outputs.sha }}
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: canary
+    permissions:
+      contents: write
+    outputs:
+      control_plane_sha: ${{ steps.approved.outputs.control_plane_sha }}
+      version: ${{ steps.approved.outputs.version }}
+      base_version: ${{ steps.approved.outputs.base_version }}
+      preview_number: ${{ steps.approved.outputs.preview_number }}
+      cli_tag: ${{ steps.approved.outputs.cli_tag }}
+      sha: ${{ steps.approved.outputs.sha }}
+      recovery: ${{ steps.approved.outputs.recovery }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.preflight.outputs.control_plane_sha }}
+      - name: Revalidate before tag creation
+        if: ${{ needs.preflight.outputs.recovery != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: preview
+          VERSION: ${{ needs.preflight.outputs.version }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          RELEASE_TAGS: ${{ needs.preflight.outputs.cli_tag }}
+        run: bash scripts/revalidate-release-candidate.sh
+      - name: Mint release-tagger token
+        id: app-token
+        if: ${{ needs.preflight.outputs.recovery != 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.RELEASE_TAGGER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TAGGER_PRIVATE_KEY }}
+      - name: Create canonical Preview tag
+        if: ${{ needs.preflight.outputs.recovery != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          RELEASE_TAGS: ${{ needs.preflight.outputs.cli_tag }}
+        run: |
+          gh auth setup-git
+          bash scripts/create-release-tags.sh
+      - name: Record approved Preview
+        id: approved
+        env:
+          CONTROL_PLANE_SHA: ${{ needs.preflight.outputs.control_plane_sha }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+          BASE_VERSION: ${{ needs.preflight.outputs.base_version }}
+          PREVIEW_NUMBER: ${{ needs.preflight.outputs.preview_number }}
+          CLI_TAG: ${{ needs.preflight.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          RECOVERY: ${{ needs.preflight.outputs.recovery }}
+          CI_RUN_URL: ${{ needs.preflight.outputs.ci_run_url }}
+        run: |
+          {
+            echo "control_plane_sha=$CONTROL_PLANE_SHA"
+            echo "version=$VERSION"
+            echo "base_version=$BASE_VERSION"
+            echo "preview_number=$PREVIEW_NUMBER"
+            echo "cli_tag=$CLI_TAG"
+            echo "sha=$RELEASE_SHA"
+            echo "recovery=$RECOVERY"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Approved Preview identity"
+            echo ""
+            echo "- \`$CLI_TAG\` @ \`$RELEASE_SHA\`"
+            echo "- Recovery: \`$RECOVERY\`"
+            echo "- Exact CI: $CI_RUN_URL"
+            echo "- Channels: CLI prerelease, Desktop preview/canary, npm canary"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Approved Preview $VERSION at $RELEASE_SHA (recovery=$RECOVERY)"
+
+  signpath-preflight:
+    name: verify Preview SignPath control plane
+    needs: authorize
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: preview
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+      signing_preflight: true
+    secrets: inherit
+
+  cli:
+    name: publish CLI Preview
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      channel: preview
+      tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+      # The approved candidate may become an ancestor while approval/builds are
+      # running; keep publishing that immutable SHA instead of racing main-v2.
+      allow_preview_recovery: true
+    secrets: inherit
+
+  npm:
+    name: publish npm Canary
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release-npm.yml
+    with:
+      channel: canary
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+    secrets: inherit
+
+  desktop:
+    name: publish Desktop Preview
+    needs: [authorize, signpath-preflight]
+    if: ${{ needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' }}
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: preview
+      base_version: ${{ needs.authorize.outputs.base_version }}
+      preview_number: ${{ needs.authorize.outputs.preview_number }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      orchestrator: preview
+      signing_preflight_verified: true
+    secrets: inherit
+
+  postflight:
+    name: publish Preview release record
+    needs: [authorize, cli, npm, desktop]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Require every Preview publisher to succeed
+        env:
+          CLI_RESULT: ${{ needs.cli.result }}
+          NPM_RESULT: ${{ needs.npm.result }}
+          DESKTOP_RESULT: ${{ needs.desktop.result }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+        run: |
+          set -euo pipefail
+          failed=false
+          for surface in CLI NPM DESKTOP; do
+            result_var="${surface}_RESULT"
+            if [ "${!result_var}" != "success" ]; then
+              echo "::error::$surface Preview publisher result is ${!result_var}, expected success"
+              failed=true
+            fi
+          done
+          if [ "$failed" = true ]; then
+            echo "::error::Recover missing Preview surfaces via Actions → Request preview recovery with tag $CLI_TAG (do not move or recreate the tag)."
+            exit 1
+          fi
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.authorize.outputs.control_plane_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Upload immutable public release marker
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.authorize.outputs.sha }}
+        run: |
+          set -euo pipefail
+          node scripts/release-event.mjs generate \
+            --version "$VERSION" --sha "$RELEASE_SHA" \
+            --published-at "$(gh api "repos/${{ github.repository }}/releases/tags/$CLI_TAG" --jq .published_at)" \
+            --output /tmp/release-event.json
+          existing="$(mktemp -d)"
+          if gh release download "$CLI_TAG" --pattern release-event.json --dir "$existing" 2>/dev/null; then
+            cmp -s /tmp/release-event.json "$existing/release-event.json" || {
+              echo "::error::published release-event.json differs from the approved Preview event"
+              exit 1
+            }
+          else
+            gh release upload "$CLI_TAG" /tmp/release-event.json
+          fi
+      - name: Refresh public changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main-v2

--- a/docs/releasing/stage3-workflows/release-preview.yml
+++ b/docs/releasing/stage3-workflows/release-preview.yml
@@ -16,7 +16,9 @@ on:
     types: [completed]
 
 concurrency:
-  group: preview-release
+  # Preview tag creation and Stable promotion share one lock so no newer
+  # Preview can appear between Stable revalidation and its atomic tag push.
+  group: release-promotion
   cancel-in-progress: false
 
 permissions:

--- a/docs/releasing/stage3-workflows/release-stable-emergency.yml
+++ b/docs/releasing/stage3-workflows/release-stable-emergency.yml
@@ -1,0 +1,43 @@
+name: Emergency stable promotion
+run-name: Emergency stable promotion (${{ inputs.reason }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "P0 reason code"
+        required: true
+        type: choice
+        options:
+          - security
+          - data-loss
+          - update-blocker
+          - service-unavailable
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    name: approve emergency observation-period override
+    runs-on: ubuntu-latest
+    environment: emergency-release
+    steps:
+      - name: Require protected control branch
+        env:
+          CONTROL_BRANCH: ${{ github.ref_name }}
+        run: |
+          [ "$CONTROL_BRANCH" = "main-v2" ] || {
+            echo "::error::Emergency Stable promotion must run from main-v2"
+            exit 1
+          }
+      - name: Write audited request
+        env:
+          REASON: ${{ inputs.reason }}
+        run: jq -n --arg reason "$REASON" '{reason:$reason}' > /tmp/request.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stable-emergency-request
+          path: /tmp/request.json
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/releasing/stage3-workflows/release-stable-recovery.yml
+++ b/docs/releasing/stage3-workflows/release-stable-recovery.yml
@@ -1,0 +1,68 @@
+name: Request stable recovery
+run-name: Request stable recovery ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing Stable CLI tag, for example v1.20.0"
+        required: true
+        type: string
+      publish_cli:
+        description: "Recover CLI and Homebrew"
+        required: false
+        default: false
+        type: boolean
+      publish_npm:
+        description: "Recover npm"
+        required: false
+        default: false
+        type: boolean
+      publish_desktop:
+        description: "Recover Desktop and R2"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  request:
+    name: record Stable recovery request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require protected control branch and one surface
+        env:
+          CONTROL_BRANCH: ${{ github.ref_name }}
+          PUBLISH_CLI: ${{ inputs.publish_cli }}
+          PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PUBLISH_DESKTOP: ${{ inputs.publish_desktop }}
+        run: |
+          [ "$CONTROL_BRANCH" = "main-v2" ] || {
+            echo "::error::Stable recovery requests must run from main-v2"
+            exit 1
+          }
+          [ "$PUBLISH_CLI" = true ] || [ "$PUBLISH_NPM" = true ] || [ "$PUBLISH_DESKTOP" = true ] || {
+            echo "::error::Select at least one surface to recover"
+            exit 1
+          }
+      - name: Write request
+        env:
+          TAG: ${{ inputs.tag }}
+          PUBLISH_CLI: ${{ inputs.publish_cli }}
+          PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PUBLISH_DESKTOP: ${{ inputs.publish_desktop }}
+        run: |
+          jq -n --arg tag "$TAG" \
+            --argjson publish_cli "$PUBLISH_CLI" \
+            --argjson publish_npm "$PUBLISH_NPM" \
+            --argjson publish_desktop "$PUBLISH_DESKTOP" \
+            '{tag:$tag,publish_cli:$publish_cli,publish_npm:$publish_npm,publish_desktop:$publish_desktop}' \
+            > /tmp/request.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stable-recovery-request
+          path: /tmp/request.json
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/releasing/stage3-workflows/release-stable-trigger.yml
+++ b/docs/releasing/stage3-workflows/release-stable-trigger.yml
@@ -1,0 +1,32 @@
+name: Relay stable release
+run-name: Relay stable release ${{ github.ref_name }}
+
+# Normal Stable tags are created by Release stable after its approval. This
+# tag-side guard prevents that App push from starting a duplicate orchestrator
+# and rejects legacy manual tag creation with an actionable message.
+on:
+  push:
+    tags:
+      - 'v*'
+      - '!v*-*'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  relay:
+    name: guard automated Stable tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Accept only release-tagger automation
+        uses: actions/github-script@v9
+        env:
+          RELEASE_ACTOR: ${{ github.actor }}
+        with:
+          script: |
+            if (process.env.RELEASE_ACTOR === 'reasonix-release-tagger[bot]') {
+              core.info('Release stable already owns publication for this automated tag set.');
+              return;
+            }
+            core.setFailed('Stable tags must be created by Actions → Release stable; use Request stable recovery for an existing tag set.');

--- a/docs/releasing/stage3-workflows/release-stable.yml
+++ b/docs/releasing/stage3-workflows/release-stable.yml
@@ -1,0 +1,460 @@
+name: Release stable
+run-name: >-
+  Release stable ${{ github.event.workflow_run.display_title || 'latest eligible Preview' }}
+
+# Normal promotion has no inputs. Recovery and emergency approval are isolated
+# request workflows whose completed artifacts are consumed on protected main-v2.
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Request stable recovery", "Emergency stable promotion"]
+    types: [completed]
+
+concurrency:
+  group: stable-release
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  preflight:
+    name: resolve and validate Stable release
+    runs-on: ubuntu-latest
+    outputs:
+      control_plane_sha: ${{ steps.freeze.outputs.control_plane_sha }}
+      mode: ${{ steps.identity.outputs.mode }}
+      version: ${{ steps.identity.outputs.version }}
+      cli_tag: ${{ steps.identity.outputs.cli_tag }}
+      npm_tag: ${{ steps.identity.outputs.npm_tag }}
+      desktop_tag: ${{ steps.identity.outputs.desktop_tag }}
+      preview_version: ${{ steps.identity.outputs.preview_version }}
+      preview_tag: ${{ steps.identity.outputs.preview_tag }}
+      sha: ${{ steps.identity.outputs.sha }}
+      publish_cli: ${{ steps.identity.outputs.publish_cli }}
+      publish_npm: ${{ steps.identity.outputs.publish_npm }}
+      publish_desktop: ${{ steps.identity.outputs.publish_desktop }}
+      emergency_reason: ${{ steps.identity.outputs.emergency_reason }}
+      source_published_at: ${{ steps.soak.outputs.source_published_at }}
+      preview_age_hours: ${{ steps.soak.outputs.preview_age_hours }}
+      ci_run_url: ${{ steps.ci.outputs.ci_run_url }}
+    steps:
+      - name: Freeze protected control plane
+        id: freeze
+        run: |
+          set -euo pipefail
+          echo "control_plane_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Stable control plane"
+            echo ""
+            echo "- Frozen control plane SHA: \`${{ github.sha }}\`"
+            echo "- Event: \`${{ github.event_name }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Resolve promotion, recovery, or emergency request
+        id: identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          SOURCE_RUN_NAME: ${{ github.event.workflow_run.name }}
+          SOURCE_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SOURCE_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          SOURCE_RUN_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
+        run: |
+          set -euo pipefail
+          output=/tmp/stable-identity
+          mode=promote
+          publish_cli=true
+          publish_npm=true
+          publish_desktop=true
+          emergency_reason=""
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            if [ "$SOURCE_RUN_NAME" = "Request stable recovery" ]; then
+              mode=recover
+              REQUEST_KIND=stable-recovery \
+                EXPECTED_WORKFLOW_NAME="Request stable recovery" \
+                EXPECTED_ARTIFACT_NAME=stable-recovery-request \
+                REQUEST_OUTPUT=/tmp/stable-request.json \
+                bash scripts/consume-release-request.sh
+              tag="$(jq -er '.tag' /tmp/stable-request.json)"
+              publish_cli="$(jq -er '.publish_cli' /tmp/stable-request.json)"
+              publish_npm="$(jq -er '.publish_npm' /tmp/stable-request.json)"
+              publish_desktop="$(jq -er '.publish_desktop' /tmp/stable-request.json)"
+              GITHUB_OUTPUT="$output" RELEASE_TAG="$tag" ALLOW_STABLE_RECOVERY=true \
+                bash scripts/resolve-stable-release.sh
+            elif [ "$SOURCE_RUN_NAME" = "Emergency stable promotion" ]; then
+              mode=emergency
+              REQUEST_KIND=stable-emergency \
+                EXPECTED_WORKFLOW_NAME="Emergency stable promotion" \
+                EXPECTED_ARTIFACT_NAME=stable-emergency-request \
+                REQUEST_OUTPUT=/tmp/stable-request.json \
+                bash scripts/consume-release-request.sh
+              emergency_reason="$(jq -er '.reason' /tmp/stable-request.json)"
+              GITHUB_OUTPUT="$output" RELEASE_REQUIRE_PROMOTION_CUTOFF=true bash scripts/resolve-stable-promotion.sh || {
+                echo "::error::No eligible emergency promotion found. Prepare Stable notes with promote_from via Actions → Prepare release notes."
+                exit 1
+              }
+            else
+              echo "::error::Unexpected Stable request workflow: $SOURCE_RUN_NAME"
+              exit 1
+            fi
+          else
+            GITHUB_OUTPUT="$output" RELEASE_REQUIRE_PROMOTION_CUTOFF=true bash scripts/resolve-stable-promotion.sh || {
+              echo "::error::No pending reviewed Stable promotion. Prepare notes with promote_from via Actions → Prepare release notes, then re-run Release stable."
+              exit 1
+            }
+          fi
+          {
+            echo "mode=$mode"
+            echo "publish_cli=$publish_cli"
+            echo "publish_npm=$publish_npm"
+            echo "publish_desktop=$publish_desktop"
+            echo "emergency_reason=$emergency_reason"
+          } >> "$output"
+          cat "$output" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Stable candidate"
+            echo ""
+            echo "- Mode: \`$mode\`"
+            echo "- Version: \`$(grep -E '^version=' "$output" | cut -d= -f2-)\`"
+            echo "- Preview: \`$(grep -E '^preview_tag=' "$output" | cut -d= -f2- || true)\`"
+            echo "- Candidate SHA: \`$(grep -E '^sha=' "$output" | cut -d= -f2-)\`"
+            echo "- Surfaces: cli=$publish_cli npm=$publish_npm desktop=$publish_desktop"
+            if [ -n "$emergency_reason" ]; then
+              echo "- Emergency reason: \`$emergency_reason\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Validate reviewed Stable notes
+        env:
+          VERSION: ${{ steps.identity.outputs.version }}
+        run: node scripts/release-notes.mjs render --version "$VERSION" --output /tmp/release-notes.md
+      - name: Download and validate source Preview event
+        if: ${{ steps.identity.outputs.mode != 'recover' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          PREVIEW_VERSION: ${{ steps.identity.outputs.preview_version }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          mkdir -p /tmp/source-preview
+          gh release download "$PREVIEW_TAG" --pattern release-event.json --dir /tmp/source-preview
+          node scripts/release-event.mjs validate \
+            --version "$PREVIEW_VERSION" --input /tmp/source-preview/release-event.json
+          jq -e --arg sha "$RELEASE_SHA" '.candidateSha == $sha and .channel == "preview"' \
+            /tmp/source-preview/release-event.json >/dev/null
+      - name: Enforce Preview observation period
+        id: soak
+        if: ${{ steps.identity.outputs.mode != 'recover' }}
+        env:
+          MODE: ${{ steps.identity.outputs.mode }}
+        run: |
+          args=(--input /tmp/source-preview/release-event.json --minimum-hours 24)
+          if [ "$MODE" = "emergency" ]; then args+=(--allow-early); fi
+          node scripts/verify-preview-soak.mjs "${args[@]}"
+      - name: Require successful CI for the exact candidate
+        id: ci
+        if: ${{ steps.identity.outputs.mode != 'recover' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          gh run list --workflow ci.yml --commit "$RELEASE_SHA" --event push --limit 20 \
+            --json databaseId,url,headSha,headBranch,event,createdAt,status,conclusion > /tmp/ci-runs.json
+          node scripts/verify-release-ci.mjs --input /tmp/ci-runs.json --sha "$RELEASE_SHA"
+      - name: Verify immutable Preview public surfaces
+        if: ${{ steps.identity.outputs.mode != 'recover' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          EXPECTED_SHA: ${{ steps.identity.outputs.sha }}
+        run: bash scripts/verify-preview-release-artifacts.sh
+      - name: Summarize release approval identity
+        env:
+          VERSION: ${{ steps.identity.outputs.version }}
+          PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
+          RELEASE_SHA: ${{ steps.identity.outputs.sha }}
+          SOURCE_PUBLISHED_AT: ${{ steps.soak.outputs.source_published_at }}
+          PREVIEW_AGE: ${{ steps.soak.outputs.preview_age_hours }}
+          CI_RUN_URL: ${{ steps.ci.outputs.ci_run_url }}
+          MODE: ${{ steps.identity.outputs.mode }}
+          EMERGENCY_REASON: ${{ steps.identity.outputs.emergency_reason }}
+        run: |
+          {
+            echo "## Stable approval summary"
+            echo ""
+            if [ -n "$PREVIEW_TAG" ]; then
+              echo "- \`$PREVIEW_TAG\` → \`v$VERSION\`"
+            else
+              echo "- Recovery of \`v$VERSION\`"
+            fi
+            echo "- Candidate SHA: \`$RELEASE_SHA\`"
+            echo "- Preview published: \`${SOURCE_PUBLISHED_AT:-n/a}\` (age ${PREVIEW_AGE:-n/a}h)"
+            echo "- Exact CI: $CI_RUN_URL"
+            echo "- CLI / Desktop / npm verification: required before approval"
+            echo "- Emergency status: \`$MODE\`${EMERGENCY_REASON:+ ($EMERGENCY_REASON)}"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload reviewed release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: orchestrator-reviewed-release-notes
+          path: /tmp/release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+      - name: Cache hit guard
+        run: ./scripts/cache-guard.sh
+
+  authorize:
+    name: >-
+      approve Stable ${{ needs.preflight.outputs.cli_tag }}
+      from ${{ needs.preflight.outputs.preview_tag || 'recovery' }}
+      @ ${{ needs.preflight.outputs.sha }}
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    outputs:
+      control_plane_sha: ${{ steps.approved.outputs.control_plane_sha }}
+      mode: ${{ steps.approved.outputs.mode }}
+      version: ${{ steps.approved.outputs.version }}
+      cli_tag: ${{ steps.approved.outputs.cli_tag }}
+      npm_tag: ${{ steps.approved.outputs.npm_tag }}
+      desktop_tag: ${{ steps.approved.outputs.desktop_tag }}
+      preview_version: ${{ steps.approved.outputs.preview_version }}
+      sha: ${{ steps.approved.outputs.sha }}
+      publish_cli: ${{ steps.approved.outputs.publish_cli }}
+      publish_npm: ${{ steps.approved.outputs.publish_npm }}
+      publish_desktop: ${{ steps.approved.outputs.publish_desktop }}
+      emergency_reason: ${{ steps.approved.outputs.emergency_reason }}
+      source_published_at: ${{ steps.approved.outputs.source_published_at }}
+      ci_run_url: ${{ steps.approved.outputs.ci_run_url }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.preflight.outputs.control_plane_sha }}
+      - name: Revalidate before atomic tag creation
+        if: ${{ needs.preflight.outputs.mode != 'recover' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MODE: stable
+          VERSION: ${{ needs.preflight.outputs.version }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          RELEASE_TAGS: ${{ format('{0} {1} {2}', needs.preflight.outputs.cli_tag, needs.preflight.outputs.npm_tag, needs.preflight.outputs.desktop_tag) }}
+          PREVIEW_VERSION: ${{ needs.preflight.outputs.preview_version }}
+          PREVIEW_TAG: ${{ needs.preflight.outputs.preview_tag }}
+        run: bash scripts/revalidate-release-candidate.sh
+      - name: Mint release-tagger token
+        id: app-token
+        if: ${{ needs.preflight.outputs.mode != 'recover' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.RELEASE_TAGGER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_TAGGER_PRIVATE_KEY }}
+      - name: Create atomic Stable tag set
+        if: ${{ needs.preflight.outputs.mode != 'recover' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          RELEASE_TAGS: ${{ format('{0} {1} {2}', needs.preflight.outputs.cli_tag, needs.preflight.outputs.npm_tag, needs.preflight.outputs.desktop_tag) }}
+        run: |
+          gh auth setup-git
+          bash scripts/create-release-tags.sh
+      - name: Record approved Stable release
+        id: approved
+        env:
+          CONTROL_PLANE_SHA: ${{ needs.preflight.outputs.control_plane_sha }}
+          MODE: ${{ needs.preflight.outputs.mode }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+          CLI_TAG: ${{ needs.preflight.outputs.cli_tag }}
+          NPM_TAG: ${{ needs.preflight.outputs.npm_tag }}
+          DESKTOP_TAG: ${{ needs.preflight.outputs.desktop_tag }}
+          PREVIEW_VERSION: ${{ needs.preflight.outputs.preview_version }}
+          RELEASE_SHA: ${{ needs.preflight.outputs.sha }}
+          PUBLISH_CLI: ${{ needs.preflight.outputs.publish_cli }}
+          PUBLISH_NPM: ${{ needs.preflight.outputs.publish_npm }}
+          PUBLISH_DESKTOP: ${{ needs.preflight.outputs.publish_desktop }}
+          EMERGENCY_REASON: ${{ needs.preflight.outputs.emergency_reason }}
+          SOURCE_PUBLISHED_AT: ${{ needs.preflight.outputs.source_published_at }}
+          CI_RUN_URL: ${{ needs.preflight.outputs.ci_run_url }}
+        run: |
+          {
+            echo "control_plane_sha=$CONTROL_PLANE_SHA"
+            echo "mode=$MODE"
+            echo "version=$VERSION"
+            echo "cli_tag=$CLI_TAG"
+            echo "npm_tag=$NPM_TAG"
+            echo "desktop_tag=$DESKTOP_TAG"
+            echo "preview_version=$PREVIEW_VERSION"
+            echo "sha=$RELEASE_SHA"
+            echo "publish_cli=$PUBLISH_CLI"
+            echo "publish_npm=$PUBLISH_NPM"
+            echo "publish_desktop=$PUBLISH_DESKTOP"
+            echo "emergency_reason=$EMERGENCY_REASON"
+            echo "source_published_at=$SOURCE_PUBLISHED_AT"
+            echo "ci_run_url=$CI_RUN_URL"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Approved Stable identity"
+            echo ""
+            echo "- \`${PREVIEW_VERSION:+v$PREVIEW_VERSION → }$CLI_TAG\` @ \`$RELEASE_SHA\`"
+            echo "- Tags: \`$CLI_TAG\` \`$NPM_TAG\` \`$DESKTOP_TAG\`"
+            echo "- Mode: \`$MODE\`${EMERGENCY_REASON:+ / $EMERGENCY_REASON}"
+            echo "- Exact CI: $CI_RUN_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Approved Stable $VERSION at $RELEASE_SHA from ${PREVIEW_VERSION:-legacy recovery}"
+
+  signpath-preflight:
+    name: verify Stable SignPath control plane
+    needs: authorize
+    if: ${{ needs.authorize.outputs.publish_desktop == 'true' }}
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: stable
+      tag: ${{ needs.authorize.outputs.desktop_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      signing_preflight: true
+    secrets: inherit
+
+  cli:
+    name: publish CLI and Homebrew
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && (needs.signpath-preflight.result == 'success' || needs.signpath-preflight.result == 'skipped') && needs.authorize.outputs.publish_cli == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+    secrets: inherit
+
+  npm:
+    name: publish npm
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && (needs.signpath-preflight.result == 'success' || needs.signpath-preflight.result == 'skipped') && needs.authorize.outputs.publish_npm == 'true' }}
+    uses: ./.github/workflows/release-npm.yml
+    with:
+      channel: stable
+      base_version: ${{ needs.authorize.outputs.version }}
+      tag: ${{ needs.authorize.outputs.npm_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+    secrets: inherit
+
+  desktop:
+    name: publish Desktop
+    needs: [authorize, signpath-preflight]
+    if: ${{ always() && !cancelled() && needs.authorize.result == 'success' && needs.signpath-preflight.result == 'success' && needs.authorize.outputs.publish_desktop == 'true' }}
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      channel: stable
+      tag: ${{ needs.authorize.outputs.desktop_tag }}
+      approved_cli_tag: ${{ needs.authorize.outputs.cli_tag }}
+      approved_sha: ${{ needs.authorize.outputs.sha }}
+      orchestrated: true
+      signing_preflight_verified: true
+    secrets: inherit
+
+  postflight:
+    name: verify Stable release artifacts
+    needs: [authorize, cli, npm, desktop]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Require selected publishers to succeed
+        env:
+          PUBLISH_CLI: ${{ needs.authorize.outputs.publish_cli }}
+          PUBLISH_NPM: ${{ needs.authorize.outputs.publish_npm }}
+          PUBLISH_DESKTOP: ${{ needs.authorize.outputs.publish_desktop }}
+          CLI_RESULT: ${{ needs.cli.result }}
+          NPM_RESULT: ${{ needs.npm.result }}
+          DESKTOP_RESULT: ${{ needs.desktop.result }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+        run: |
+          set -euo pipefail
+          failed=false
+          for channel in cli npm desktop; do
+            selected_var="PUBLISH_${channel^^}"
+            result_var="${channel^^}_RESULT"
+            if [ "${!selected_var}" != "true" ]; then
+              echo "$channel recovery skipped; public postflight will still verify it"
+              continue
+            fi
+            if [ "${!result_var}" != "success" ]; then
+              echo "::error::$channel Stable publisher result is ${!result_var}, expected success"
+              failed=true
+            fi
+          done
+          if [ "$failed" = true ]; then
+            echo "::error::Recover missing Stable surfaces via Actions → Request stable recovery with tag $CLI_TAG (select only missing channels; do not move tags)."
+            exit 1
+          fi
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.authorize.outputs.control_plane_sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Verify public artifacts and npm latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_VERSION: ${{ needs.authorize.outputs.version }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+          DESKTOP_TAG: ${{ needs.authorize.outputs.desktop_tag }}
+        run: bash scripts/verify-stable-release-artifacts.sh
+      - name: Publish exact Stable release record
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          CLI_TAG: ${{ needs.authorize.outputs.cli_tag }}
+          RELEASE_SHA: ${{ needs.authorize.outputs.sha }}
+          PREVIEW_VERSION: ${{ needs.authorize.outputs.preview_version }}
+          SOURCE_PUBLISHED_AT: ${{ needs.authorize.outputs.source_published_at }}
+          MODE: ${{ needs.authorize.outputs.mode }}
+          EMERGENCY_REASON: ${{ needs.authorize.outputs.emergency_reason }}
+        run: |
+          set -euo pipefail
+          args=(generate --version "$VERSION" --sha "$RELEASE_SHA"
+            --published-at "$(gh api "repos/${{ github.repository }}/releases/tags/$CLI_TAG" --jq .published_at)"
+            --output /tmp/release-event.json)
+          if [ -n "$PREVIEW_VERSION" ]; then
+            args+=(--source-published-at "$SOURCE_PUBLISHED_AT"
+              --emergency "$([ "$MODE" = emergency ] && echo true || echo false)"
+              --emergency-reason "$EMERGENCY_REASON"
+              --workflow-run "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          fi
+          node scripts/release-event.mjs "${args[@]}"
+          existing="$(mktemp -d)"
+          if gh release download "$CLI_TAG" --pattern release-event.json --dir "$existing" 2>/dev/null; then
+            cmp -s /tmp/release-event.json "$existing/release-event.json" || {
+              echo "::error::published release-event.json differs from the approved Stable event"
+              exit 1
+            }
+          else
+            gh release upload "$CLI_TAG" /tmp/release-event.json
+          fi
+      - name: Refresh public changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main-v2

--- a/docs/releasing/stage3-workflows/release-stable.yml
+++ b/docs/releasing/stage3-workflows/release-stable.yml
@@ -11,7 +11,8 @@ on:
     types: [completed]
 
 concurrency:
-  group: stable-release
+  # Share the Preview lock through approval, revalidation, and atomic tag push.
+  group: release-promotion
   cancel-in-progress: false
 
 permissions:
@@ -181,6 +182,7 @@ jobs:
           RELEASE_REPOSITORY: ${{ github.repository }}
           PREVIEW_TAG: ${{ steps.identity.outputs.preview_tag }}
           EXPECTED_SHA: ${{ steps.identity.outputs.sha }}
+          PREVIEW_FULL_DOWNLOAD_CHECK: ${{ vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK || 'false' }}
         run: bash scripts/verify-preview-release-artifacts.sh
       - name: Summarize release approval identity
         env:
@@ -257,6 +259,7 @@ jobs:
           RELEASE_TAGS: ${{ format('{0} {1} {2}', needs.preflight.outputs.cli_tag, needs.preflight.outputs.npm_tag, needs.preflight.outputs.desktop_tag) }}
           PREVIEW_VERSION: ${{ needs.preflight.outputs.preview_version }}
           PREVIEW_TAG: ${{ needs.preflight.outputs.preview_tag }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
         run: bash scripts/revalidate-release-candidate.sh
       - name: Mint release-tagger token
         id: app-token

--- a/scripts/consume-release-request.sh
+++ b/scripts/consume-release-request.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Consume a completed request workflow artifact with a fail-closed trust boundary.
+#
+# Required env:
+#   GH_TOKEN, REPOSITORY
+#   SOURCE_RUN_ID, SOURCE_RUN_CONCLUSION, SOURCE_RUN_BRANCH
+#   SOURCE_RUN_EVENT, SOURCE_RUN_NAME, SOURCE_RUN_REPOSITORY
+#   EXPECTED_WORKFLOW_NAME, EXPECTED_ARTIFACT_NAME
+#   REQUEST_KIND = preview-recovery | stable-recovery | stable-emergency
+#
+# Writes the validated request JSON to REQUEST_OUTPUT (default /tmp/request.json)
+# and emits mode-specific GitHub Actions outputs when GITHUB_OUTPUT is set.
+set -euo pipefail
+
+repository="${REPOSITORY:?REPOSITORY is required}"
+source_run_id="${SOURCE_RUN_ID:?SOURCE_RUN_ID is required}"
+source_run_conclusion="${SOURCE_RUN_CONCLUSION:?SOURCE_RUN_CONCLUSION is required}"
+source_run_branch="${SOURCE_RUN_BRANCH:?SOURCE_RUN_BRANCH is required}"
+source_run_event="${SOURCE_RUN_EVENT:?SOURCE_RUN_EVENT is required}"
+source_run_name="${SOURCE_RUN_NAME:?SOURCE_RUN_NAME is required}"
+source_run_repository="${SOURCE_RUN_REPOSITORY:?SOURCE_RUN_REPOSITORY is required}"
+expected_workflow_name="${EXPECTED_WORKFLOW_NAME:?EXPECTED_WORKFLOW_NAME is required}"
+expected_artifact_name="${EXPECTED_ARTIFACT_NAME:?EXPECTED_ARTIFACT_NAME is required}"
+request_kind="${REQUEST_KIND:?REQUEST_KIND is required}"
+request_output="${REQUEST_OUTPUT:-/tmp/request.json}"
+download_dir="${REQUEST_DOWNLOAD_DIR:-/tmp/release-request}"
+
+if [ "$source_run_repository" != "$repository" ]; then
+	echo "::error::request run repository is $source_run_repository, expected $repository" >&2
+	exit 1
+fi
+if [ "$source_run_event" != "workflow_dispatch" ]; then
+	echo "::error::request run event is $source_run_event, expected workflow_dispatch" >&2
+	exit 1
+fi
+if [ "$source_run_branch" != "main-v2" ]; then
+	echo "::error::request run branch is $source_run_branch, expected main-v2" >&2
+	exit 1
+fi
+if [ "$source_run_conclusion" != "success" ]; then
+	echo "::error::request run conclusion is $source_run_conclusion, expected success" >&2
+	exit 1
+fi
+if [ "$source_run_name" != "$expected_workflow_name" ]; then
+	echo "::error::request workflow is '$source_run_name', expected '$expected_workflow_name'" >&2
+	exit 1
+fi
+
+mkdir -p "$download_dir"
+# Confirm exactly one artifact with the expected name exists for this run.
+artifact_count="$(
+	gh api "repos/$repository/actions/runs/$source_run_id/artifacts" --paginate \
+		--jq --arg name "$expected_artifact_name" \
+		'[.artifacts[] | select(.name == $name and .expired == false)] | length'
+)"
+if [ "$artifact_count" != "1" ]; then
+	echo "::error::expected exactly one live artifact named $expected_artifact_name, found $artifact_count" >&2
+	exit 1
+fi
+
+rm -rf "$download_dir"
+mkdir -p "$download_dir"
+gh run download "$source_run_id" --repo "$repository" \
+	--name "$expected_artifact_name" --dir "$download_dir"
+
+if [ ! -f "$download_dir/request.json" ]; then
+	echo "::error::request artifact is missing request.json" >&2
+	exit 1
+fi
+
+case "$request_kind" in
+preview-recovery)
+	jq -e '
+    type == "object" and
+    (.tag | type == "string" and test("^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-preview\\.[1-9][0-9]*$")) and
+    (keys | sort == ["tag"])
+  ' "$download_dir/request.json" >/dev/null || {
+		echo "::error::preview recovery request JSON is invalid" >&2
+		exit 1
+	}
+	;;
+stable-recovery)
+	jq -e '
+    type == "object" and
+    (.tag | type == "string" and test("^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+    (.publish_cli | type == "boolean") and
+    (.publish_npm | type == "boolean") and
+    (.publish_desktop | type == "boolean") and
+    ((.publish_cli or .publish_npm or .publish_desktop) == true) and
+    (keys | sort == ["publish_cli", "publish_desktop", "publish_npm", "tag"])
+  ' "$download_dir/request.json" >/dev/null || {
+		echo "::error::stable recovery request JSON is invalid" >&2
+		exit 1
+	}
+	;;
+stable-emergency)
+	jq -e '
+    type == "object" and
+    (.reason | type == "string" and
+      (. == "security" or . == "data-loss" or . == "update-blocker" or . == "service-unavailable")) and
+    (keys | sort == ["reason"])
+  ' "$download_dir/request.json" >/dev/null || {
+		echo "::error::stable emergency request JSON is invalid" >&2
+		exit 1
+	}
+	;;
+*)
+	echo "::error::unknown REQUEST_KIND: $request_kind" >&2
+	exit 1
+	;;
+esac
+
+cp "$download_dir/request.json" "$request_output"
+echo "Validated $request_kind request artifact from run $source_run_id"

--- a/scripts/consume-release-request.sh
+++ b/scripts/consume-release-request.sh
@@ -23,7 +23,6 @@ expected_workflow_name="${EXPECTED_WORKFLOW_NAME:?EXPECTED_WORKFLOW_NAME is requ
 expected_artifact_name="${EXPECTED_ARTIFACT_NAME:?EXPECTED_ARTIFACT_NAME is required}"
 request_kind="${REQUEST_KIND:?REQUEST_KIND is required}"
 request_output="${REQUEST_OUTPUT:-/tmp/request.json}"
-download_dir="${REQUEST_DOWNLOAD_DIR:-/tmp/release-request}"
 
 if [ "$source_run_repository" != "$repository" ]; then
 	echo "::error::request run repository is $source_run_repository, expected $repository" >&2
@@ -46,7 +45,6 @@ if [ "$source_run_name" != "$expected_workflow_name" ]; then
 	exit 1
 fi
 
-mkdir -p "$download_dir"
 # Confirm exactly one artifact with the expected name exists for this run.
 artifact_count="$(
 	gh api "repos/$repository/actions/runs/$source_run_id/artifacts" --paginate \
@@ -58,8 +56,14 @@ if [ "$artifact_count" != "1" ]; then
 	exit 1
 fi
 
-rm -rf "$download_dir"
-mkdir -p "$download_dir"
+download_dir="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-release-request.XXXXXX")"
+cleanup_request_download() {
+	case "$download_dir" in
+	*/reasonix-release-request.*) rm -r -- "$download_dir" ;;
+	*) echo "refusing to clean unexpected request download directory: $download_dir" >&2 ;;
+	esac
+}
+trap cleanup_request_download EXIT
 gh run download "$source_run_id" --repo "$repository" \
 	--name "$expected_artifact_name" --dir "$download_dir"
 

--- a/scripts/create-release-tags.sh
+++ b/scripts/create-release-tags.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Create one Preview tag or the three Stable tags as one immutable operation.
+set -euo pipefail
+
+candidate_sha="${RELEASE_SHA:?RELEASE_SHA is required}"
+release_remote="${RELEASE_REMOTE:-origin}"
+read -r -a release_tags <<<"${RELEASE_TAGS:?RELEASE_TAGS is required}"
+
+if [[ ! "$candidate_sha" =~ ^[0-9a-f]{40}$ ]]; then
+	echo "::error::RELEASE_SHA must be a full commit SHA" >&2
+	exit 1
+fi
+if [ "${#release_tags[@]}" -eq 1 ]; then
+	[[ "${release_tags[0]}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.([1-9][0-9]*)$ ]] || {
+		echo "::error::single-tag creation is reserved for a canonical Preview tag" >&2
+		exit 1
+	}
+elif [ "${#release_tags[@]}" -eq 3 ]; then
+	[[ "${release_tags[0]}" =~ ^v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))$ ]] || {
+		echo "::error::the first Stable tag must be vMAJOR.MINOR.PATCH" >&2
+		exit 1
+	}
+	version="${BASH_REMATCH[1]}"
+	[ "${release_tags[1]}" = "npm-v$version" ] && [ "${release_tags[2]}" = "desktop-v$version" ] || {
+		echo "::error::Stable tags must be ordered as v$version npm-v$version desktop-v$version" >&2
+		exit 1
+	}
+else
+	echo "::error::RELEASE_TAGS must contain one Preview tag or three Stable tags" >&2
+	exit 1
+fi
+
+git cat-file -e "$candidate_sha^{commit}"
+main_sha="$(git ls-remote "$release_remote" refs/heads/main-v2 | awk 'NR == 1 { print $1 }')"
+git fetch --quiet --no-tags "$release_remote" refs/heads/main-v2
+if [ -z "$main_sha" ] || ! git merge-base --is-ancestor "$candidate_sha" "$main_sha"; then
+	echo "::error::release candidate $candidate_sha is not on $release_remote/main-v2 history" >&2
+	exit 1
+fi
+
+refspecs=()
+for tag in "${release_tags[@]}"; do
+	if git ls-remote --exit-code --tags --refs "$release_remote" "refs/tags/$tag" >/dev/null 2>&1; then
+		echo "::error::release tag already exists: $tag" >&2
+		exit 1
+	fi
+	refspecs+=("$candidate_sha:refs/tags/$tag")
+done
+
+git push --atomic "$release_remote" "${refspecs[@]}"
+for tag in "${release_tags[@]}"; do
+	remote_sha="$(git ls-remote --tags --refs "$release_remote" "refs/tags/$tag" | awk 'NR == 1 { print $1 }')"
+	if [ "$remote_sha" != "$candidate_sha" ]; then
+		echo "::error::$tag read back as ${remote_sha:-<missing>}, expected $candidate_sha" >&2
+		exit 1
+	fi
+done
+
+echo "Created release tags at $candidate_sha: ${release_tags[*]}"

--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -159,6 +159,19 @@ async function main() {
   const catalog = await loadCatalog();
   const channel = version.includes("-") ? "prerelease" : "stable";
   const baseVersion = version.split("-")[0];
+  const promoteFromTag = args["promote-from"];
+  let promotedFrom;
+  let promotedCandidateSha;
+  if (promoteFromTag) {
+    if (channel !== "stable") throw new Error("--promote-from is only valid for Stable release notes");
+    const match = normalizeVersion(promoteFromTag).match(/^(.+)-preview\.([1-9][0-9]*)$/);
+    if (!match || match[1] !== baseVersion) {
+      throw new Error("--promote-from must be a Preview tag of the same Stable base version");
+    }
+    promotedFrom = normalizeVersion(promoteFromTag);
+    promotedCandidateSha = runGit(["rev-list", "-n1", `v${promotedFrom}`]);
+    if (!promotedCandidateSha) throw new Error(`cannot resolve v${promotedFrom}`);
+  }
   const previousRecord = channel === "stable"
     ? catalog.releases.find((release) => release.version !== version && release.channel === "stable")
     : catalog.releases.find(
@@ -176,7 +189,7 @@ async function main() {
     : previousIsPreview
       ? `v${previousVersion}`
       : `desktop-v${previousVersion}`;
-  const to = args.to || "HEAD";
+  const to = args.to || (promotedFrom ? `v${promotedFrom}` : "HEAD");
   const repository = repositoryName();
   const commits = commitRange(from, to);
   if (!commits.length) throw new Error(`no commits found in ${from}..${to}`);
@@ -201,6 +214,10 @@ async function main() {
   release.channel = source.channel;
   release.status = "reviewed";
   release.previousRelease = previousVersion;
+  if (promotedFrom) {
+    release.promotedFrom = promotedFrom;
+    release.candidateSha = promotedCandidateSha;
+  }
   const previewOrdinal = version.match(/-preview\.([1-9][0-9]*)$/)?.[1];
   if (channel === "prerelease") {
     if (!previewOrdinal) throw new Error("Preview release version must use MAJOR.MINOR.PATCH-preview.N");

--- a/scripts/release-activation.sh
+++ b/scripts/release-activation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Activation cutoff for Preview → Stable promotion proofs.
+#
+# Rollout:
+#   Stage 1 infrastructure PR: leave DEFAULT empty. Shadow validation and
+#   fixture tests may run without an ancestry gate.
+#   Config-only commit after Stage 1 merges: set DEFAULT to that merge SHA so
+#   only later Previews are promotion candidates. Do not flip Stage-3 entrypoints
+#   in the same commit.
+#   Stage 3 activation PR: keep the filled SHA and enable App-owned entrypoints.
+#
+# Override with RELEASE_MIN_PROMOTION_CANDIDATE_SHA for local fixtures/tests.
+# Set RELEASE_REQUIRE_PROMOTION_CUTOFF=true to fail closed when the cutoff is
+# empty (used by Stage-3 production promote paths).
+set -euo pipefail
+
+# Empty until the post-Stage-1 config commit records the infrastructure merge SHA.
+DEFAULT_MIN_PROMOTION_CANDIDATE_SHA=""
+
+MIN_PROMOTION_CANDIDATE_SHA="${RELEASE_MIN_PROMOTION_CANDIDATE_SHA:-$DEFAULT_MIN_PROMOTION_CANDIDATE_SHA}"
+REQUIRE_PROMOTION_CUTOFF="${RELEASE_REQUIRE_PROMOTION_CUTOFF:-false}"
+
+require_promotion_activation_cutoff() {
+	local candidate_sha="${1:?candidate SHA is required}"
+	if [ -z "$MIN_PROMOTION_CANDIDATE_SHA" ]; then
+		if [ "$REQUIRE_PROMOTION_CUTOFF" = "true" ]; then
+			echo "::error::promotion activation cutoff is not configured; set DEFAULT_MIN_PROMOTION_CANDIDATE_SHA after the Stage-1 infrastructure merge" >&2
+			exit 1
+		fi
+		echo "promotion activation cutoff is unset; Stage-1 shadow/infrastructure mode allows any main-v2 Preview" >&2
+		return 0
+	fi
+	if [[ ! "$MIN_PROMOTION_CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+		echo "::error::MIN_PROMOTION_CANDIDATE_SHA must be a full commit SHA" >&2
+		exit 1
+	fi
+	if [[ ! "$candidate_sha" =~ ^[0-9a-f]{40}$ ]]; then
+		echo "::error::promotion candidate SHA must be a full commit SHA" >&2
+		exit 1
+	fi
+	if ! git cat-file -e "$MIN_PROMOTION_CANDIDATE_SHA^{commit}" 2>/dev/null; then
+		git fetch --quiet --no-tags "${RELEASE_REMOTE:-origin}" "$MIN_PROMOTION_CANDIDATE_SHA" 2>/dev/null || true
+	fi
+	if ! git cat-file -e "$MIN_PROMOTION_CANDIDATE_SHA^{commit}" 2>/dev/null; then
+		echo "::error::promotion activation cutoff $MIN_PROMOTION_CANDIDATE_SHA is not available in this checkout" >&2
+		exit 1
+	fi
+	if ! git merge-base --is-ancestor "$MIN_PROMOTION_CANDIDATE_SHA" "$candidate_sha"; then
+		echo "::error::candidate $candidate_sha predates the promotion activation cutoff $MIN_PROMOTION_CANDIDATE_SHA" >&2
+		exit 1
+	fi
+}

--- a/scripts/release-event.mjs
+++ b/scripts/release-event.mjs
@@ -41,6 +41,22 @@ export function validateReleaseEvent(event, release) {
       invariant(event.builds[surface] === release.builds[surface], `release event builds.${surface} does not match reviewed notes`);
     }
   }
+  if (release.promotedFrom) {
+    invariant(event.promotion && typeof event.promotion === "object", "Stable promotion metadata is required");
+    invariant(event.promotion.sourceReleaseId === release.promotedFrom, "promotion sourceReleaseId does not match reviewed notes");
+    invariant(event.promotion.sourceTag === `v${release.promotedFrom}`, "promotion sourceTag does not match reviewed notes");
+    invariant(/^\d{4}-\d{2}-\d{2}T/.test(event.promotion.sourcePublishedAt), "promotion sourcePublishedAt must be an ISO timestamp");
+    invariant(typeof event.promotion.emergency === "boolean", "promotion emergency must be boolean");
+    const reasonCodes = new Set(["security", "data-loss", "update-blocker", "service-unavailable"]);
+    if (event.promotion.emergency) {
+      invariant(reasonCodes.has(event.promotion.emergencyReasonCode), "promotion emergencyReasonCode is invalid");
+    } else {
+      invariant(event.promotion.emergencyReasonCode === null, "normal promotion must not have an emergencyReasonCode");
+    }
+    invariant(/^https:\/\/github\.com\//.test(event.promotion.workflowRun), "promotion workflowRun must be a GitHub URL");
+  } else {
+    invariant(event.promotion === undefined, "legacy release event must not contain promotion metadata");
+  }
   return event;
 }
 
@@ -53,6 +69,14 @@ async function main() {
   if (args.command === "generate") {
     invariant(args.sha, "generate requires --sha");
     invariant(args.output, "generate requires --output");
+    const promotion = release.promotedFrom ? {
+      sourceReleaseId: release.promotedFrom,
+      sourceTag: `v${release.promotedFrom}`,
+      sourcePublishedAt: args["source-published-at"],
+      emergency: args.emergency === "true",
+      emergencyReasonCode: args.emergency === "true" ? args["emergency-reason"] : null,
+      workflowRun: args["workflow-run"],
+    } : undefined;
     const event = validateReleaseEvent({
       schemaVersion: 1,
       releaseId: release.version,
@@ -61,6 +85,7 @@ async function main() {
       publishedAt: args["published-at"] || new Date().toISOString(),
       releaseNotesUrl: `https://reasonix.io/changelog/v${release.version}/`,
       builds: release.builds,
+      ...(promotion ? { promotion } : {}),
     }, release);
     await writeFile(resolve(args.output), `${JSON.stringify(event, null, 2)}\n`);
     return;

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -92,6 +92,14 @@ export function validateCatalog(catalog) {
     if (release.candidateSha !== undefined) {
       invariant(/^[0-9a-f]{40}$/.test(release.candidateSha), `${path}.candidateSha must be a full commit SHA`);
     }
+    if (release.promotedFrom !== undefined) {
+      invariant(release.channel === "stable", `${path}.promotedFrom is only valid for Stable releases`);
+      invariant(
+        new RegExp(`^${release.version.replaceAll(".", "\\.")}-preview\\.[1-9][0-9]*$`).test(release.promotedFrom),
+        `${path}.promotedFrom must be a Preview of the same base version`,
+      );
+      invariant(release.candidateSha !== undefined, `${path}.candidateSha is required with promotedFrom`);
+    }
     if (release.previousRelease !== undefined) {
       semverParts(release.previousRelease);
       invariant(release.previousRelease !== release.version, `${path}.previousRelease must differ from version`);

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { loadCatalog, releaseForVersion, renderGitHubRelease, validateCatalog } from "./release-notes.mjs";
 import { validateReleaseEvent } from "./release-event.mjs";
+import { verifyPreviewSoak } from "./verify-preview-soak.mjs";
+import { verifyReleaseCI } from "./verify-release-ci.mjs";
 
 test("the committed release catalog is valid and newest first", async () => {
   const catalog = await loadCatalog();
@@ -117,5 +119,117 @@ test("publication marker is bound to reviewed version, channel, SHA, and builds"
   assert.throws(
     () => validateReleaseEvent({ ...event, candidateSha: "b".repeat(40) }, release),
     /candidateSha/,
+  );
+});
+
+test("Stable promotion metadata preserves old records and binds new records", () => {
+  const base = {
+    version: "2.0.0",
+    releaseId: "2.0.0",
+    baseVersion: "2.0.0",
+    date: "2026-08-02",
+    channel: "stable",
+    status: "reviewed",
+    previousRelease: "1.19.0",
+    builds: { cli: "v2.0.0", desktop: "v2.0.0", npm: "2.0.0" },
+    title: { en: "Stable", zh: "稳定版" },
+    summary: { en: "Stable summary", zh: "稳定版摘要" },
+    surfaces: ["cli"], guides: [],
+    highlights: [{ kind: "fixed", title: { en: "Fix", zh: "修复" }, body: { en: "Fix.", zh: "修复。" }, refs: [1] }],
+    changes: { new: [], improved: [], fixed: [] }, upgrade: [], risks: [], contributors: [],
+    links: { github: "https://example.com/release", compare: "https://example.com/compare", download: "https://example.com/download" },
+  };
+  assert.doesNotThrow(() => validateCatalog({ schemaVersion: 1, releases: [base] }));
+  assert.throws(
+    () => validateCatalog({ schemaVersion: 1, releases: [{ ...base, promotedFrom: "2.0.0-preview.1" }] }),
+    /candidateSha is required/,
+  );
+  const release = { ...base, promotedFrom: "2.0.0-preview.1", candidateSha: "a".repeat(40) };
+  assert.doesNotThrow(() => validateCatalog({ schemaVersion: 1, releases: [release] }));
+  const event = {
+    schemaVersion: 1, releaseId: "2.0.0", channel: "stable", candidateSha: "a".repeat(40),
+    publishedAt: "2026-08-03T00:00:00Z", releaseNotesUrl: "https://reasonix.io/changelog/v2.0.0/",
+    builds: release.builds,
+    promotion: {
+      sourceReleaseId: "2.0.0-preview.1", sourceTag: "v2.0.0-preview.1",
+      sourcePublishedAt: "2026-08-02T00:00:00Z", emergency: false,
+      emergencyReasonCode: null, workflowRun: "https://github.com/example/reasonix/actions/runs/1",
+    },
+  };
+  assert.doesNotThrow(() => validateReleaseEvent(event, release));
+  assert.throws(() => validateReleaseEvent({ ...event, promotion: { ...event.promotion, sourceTag: "v2.0.0-preview.2" } }, release), /sourceTag/);
+});
+
+test("Preview soak and exact-SHA CI gates fail closed", () => {
+  const publishedAt = "2026-08-01T00:00:00Z";
+  assert.throws(
+    () => verifyPreviewSoak({ channel: "preview", publishedAt }, { now: Date.parse("2026-08-01T23:59:59Z") }),
+    /24h is required/,
+  );
+  assert.doesNotThrow(
+    () => verifyPreviewSoak({ channel: "preview", publishedAt }, { now: Date.parse("2026-08-02T00:00:00Z") }),
+  );
+  assert.throws(
+    () => verifyPreviewSoak({ channel: "preview", publishedAt: "2099-01-01T00:00:00Z" }, { now: Date.parse("2026-08-02T00:00:00Z") }),
+    /cannot be in the future/,
+  );
+  assert.doesNotThrow(
+    () => verifyPreviewSoak({ channel: "preview", publishedAt }, { now: Date.parse("2026-08-01T23:59:59Z"), allowEarly: true }),
+  );
+  const sha = "b".repeat(40);
+  const run = { databaseId: 1, url: "https://github.com/example/run/1", headSha: sha, headBranch: "main-v2", event: "push", createdAt: "2026-08-02T00:00:00Z", status: "completed", conclusion: "success" };
+  assert.equal(verifyReleaseCI([run], sha), run);
+  assert.throws(() => verifyReleaseCI([{ ...run, conclusion: "failure" }], sha), /completed\/failure/);
+  assert.throws(() => verifyReleaseCI([{ ...run, status: "in_progress", conclusion: null }], sha), /in_progress/);
+  assert.throws(() => verifyReleaseCI([{ ...run, headBranch: "topic" }], sha), /no main-v2 push CI run/);
+  assert.throws(() => verifyReleaseCI([], sha), /no main-v2 push CI run/);
+  const olderFailure = { ...run, databaseId: 0, createdAt: "2026-08-01T00:00:00Z", conclusion: "failure" };
+  const newerSuccess = { ...run, databaseId: 2, createdAt: "2026-08-03T00:00:00Z", conclusion: "success" };
+  assert.equal(verifyReleaseCI([olderFailure, newerSuccess], sha), newerSuccess);
+});
+
+test("emergency promotion metadata requires a public-safe reason code", () => {
+  const release = {
+    version: "2.0.0",
+    releaseId: "2.0.0",
+    baseVersion: "2.0.0",
+    date: "2026-08-02",
+    channel: "stable",
+    status: "reviewed",
+    previousRelease: "1.19.0",
+    promotedFrom: "2.0.0-preview.1",
+    candidateSha: "a".repeat(40),
+    builds: { cli: "v2.0.0", desktop: "v2.0.0", npm: "2.0.0" },
+    title: { en: "Stable", zh: "稳定版" },
+    summary: { en: "Stable summary", zh: "稳定版摘要" },
+    surfaces: ["cli"], guides: [],
+    highlights: [{ kind: "fixed", title: { en: "Fix", zh: "修复" }, body: { en: "Fix.", zh: "修复。" }, refs: [1] }],
+    changes: { new: [], improved: [], fixed: [] }, upgrade: [], risks: [], contributors: [],
+    links: { github: "https://example.com/release", compare: "https://example.com/compare", download: "https://example.com/download" },
+  };
+  const event = {
+    schemaVersion: 1, releaseId: "2.0.0", channel: "stable", candidateSha: "a".repeat(40),
+    publishedAt: "2026-08-03T00:00:00Z", releaseNotesUrl: "https://reasonix.io/changelog/v2.0.0/",
+    builds: release.builds,
+    promotion: {
+      sourceReleaseId: "2.0.0-preview.1", sourceTag: "v2.0.0-preview.1",
+      sourcePublishedAt: "2026-08-02T00:00:00Z", emergency: true,
+      emergencyReasonCode: "security", workflowRun: "https://github.com/example/reasonix/actions/runs/1",
+    },
+  };
+  assert.doesNotThrow(() => validateReleaseEvent(event, release));
+  assert.throws(
+    () => validateReleaseEvent({
+      ...event,
+      promotion: { ...event.promotion, emergencyReasonCode: "convenience" },
+    }, release),
+    /emergencyReasonCode/,
+  );
+  assert.throws(
+    () => validateReleaseEvent({
+      ...event,
+      promotion: { ...event.promotion, emergency: false, emergencyReasonCode: "security" },
+    }, release),
+    /must not have an emergencyReasonCode/,
   );
 });

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -84,10 +84,23 @@ for draft in release-preview.yml release-stable.yml release-preview-recovery.yml
 		echo "missing Stage-3 draft workflow: $draft" >&2
 		exit 1
 	}
+	grep -Fq "docs/releasing/stage3-workflows/$draft" \
+		"$repo_root/.github/workflows/ci.yml" || {
+		echo "Stage-3 draft workflow is missing offline actionlint coverage: $draft" >&2
+		exit 1
+	}
 done
 grep -Eq '^      base_version:$' "$stage3_dir/release-preview.yml"
 grep -Eq 'create-github-app-token' "$stage3_dir/release-preview.yml"
 grep -Eq 'create-github-app-token' "$stage3_dir/release-stable.yml"
+[ "$(grep -hE '^  group: release-promotion$' \
+	"$stage3_dir/release-preview.yml" "$stage3_dir/release-stable.yml" | wc -l | tr -d '[:space:]')" = "2" ]
+grep -Fq "PREVIEW_FULL_DOWNLOAD_CHECK: \${{ vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK || 'false' }}" \
+	"$stage3_dir/release-stable.yml"
+grep -Fq "PREVIEW_FULL_DOWNLOAD_CHECK: \${{ vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK || 'false' }}" \
+	"$repo_root/.github/workflows/release-stable-shadow.yml"
+grep -Fq "vars.RELEASE_PREVIEW_FULL_DOWNLOAD_CHECK == 'true'" \
+	"$repo_root/.github/workflows/release-stable-shadow.yml"
 grep -Eq '^name: Request preview recovery$' "$stage3_dir/release-preview-recovery.yml"
 grep -Eq '^name: Request stable recovery$' "$stage3_dir/release-stable-recovery.yml"
 grep -Eq '^name: Emergency stable promotion$' "$stage3_dir/release-stable-emergency.yml"
@@ -102,12 +115,10 @@ if grep -Eq 'create-release-tags\.sh|create-github-app-token' \
 	echo "shadow validation must not create tags or mint a release-tagger token" >&2
 	exit 1
 fi
-if grep -Fq '.github/workflows/release-preview-recovery.yml' "$repo_root/.github/workflows/ci.yml" ||
-	grep -Fq '.github/workflows/release-stable-recovery.yml' "$repo_root/.github/workflows/ci.yml" ||
-	grep -Fq '.github/workflows/release-stable-emergency.yml' "$repo_root/.github/workflows/ci.yml"; then
-	echo "Stage 1 CI must not actionlint inactive Stage-3 request workflows" >&2
-	exit 1
-fi
+grep -Fq 'release_workflows: ${{ steps.filter.outputs.release_workflows }}' \
+	"$repo_root/.github/workflows/ci.yml"
+grep -Fq "needs.changes.outputs.release_workflows == 'true'" \
+	"$repo_root/.github/workflows/ci.yml"
 grep -Fq 'ref: ${{ github.sha }}' "$repo_root/.github/workflows/release-preview.yml"
 grep -Fq 'ref: ${{ github.sha }}' "$repo_root/.github/workflows/release-stable.yml"
 if grep -Eq '^  push:$' "$repo_root/.github/workflows/release-stable.yml" ||
@@ -842,6 +853,76 @@ if bash "$desktop_manifest_asset_verifier" \
 	exit 1
 fi
 
+# The opt-in Preview cutover check must download manifest-bound payloads and
+# signatures, then enforce size, digest, and minisign verification.
+preview_download_verifier="$repo_root/scripts/verify-preview-desktop-downloads.sh"
+test -x "$preview_download_verifier"
+preview_download_source="$test_root/preview-download-source"
+preview_download_output="$test_root/preview-download-output"
+preview_fake_bin="$test_root/preview-fake-bin"
+mkdir -p "$preview_download_source" "$preview_download_output" "$preview_fake_bin"
+printf 'preview-download-payload\n' >"$preview_download_source/payload.zip"
+printf 'preview-download-signature\n' >"$preview_download_source/payload.zip.minisig"
+preview_download_sha="$(shasum -a 256 "$preview_download_source/payload.zip" | awk '{print $1}')"
+preview_download_size="$(wc -c <"$preview_download_source/payload.zip" | tr -d '[:space:]')"
+jq -n \
+	--arg url 'https://downloads.example.invalid/payload.zip' \
+	--arg sig 'https://downloads.example.invalid/payload.zip.minisig' \
+	--arg sha "$preview_download_sha" \
+	--argjson size "$preview_download_size" \
+	'{
+		platforms: {test: {url: $url, sig: $sig, sha256: $sha, size: $size}},
+		native_packages: {},
+		downloads: {}
+	}' >"$test_root/preview-download-manifest.json"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'set -euo pipefail' \
+	'output=""' \
+	'url=""' \
+	'while [ "$#" -gt 0 ]; do' \
+	'  case "$1" in' \
+	'    --output) output="$2"; shift 2 ;;' \
+	'    --write-out) shift 2 ;;' \
+	'    --fail|--location|--silent|--show-error) shift ;;' \
+	'    *) url="$1"; shift ;;' \
+	'  esac' \
+	'done' \
+	'[ -n "$output" ] && [ -n "$url" ]' \
+	'cp "$FAKE_PREVIEW_ASSET_SOURCE/${url##*/}" "$output"' \
+	'printf 200' >"$preview_fake_bin/curl"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'set -euo pipefail' \
+	'[ "$1" = verify ]' \
+	'[ -s "$2.minisig" ]' \
+	'printf "%s\\n" "$2" >> "$FAKE_PREVIEW_SIGNATURE_LOG"' \
+	>"$preview_fake_bin/sign-verifier"
+chmod +x "$preview_fake_bin/curl" "$preview_fake_bin/sign-verifier"
+FAKE_PREVIEW_ASSET_SOURCE="$preview_download_source" \
+	FAKE_PREVIEW_SIGNATURE_LOG="$test_root/preview-signatures.log" \
+	PATH="$preview_fake_bin:$PATH" \
+	bash "$preview_download_verifier" \
+		"$test_root/preview-download-manifest.json" \
+		"$preview_download_output" "$preview_fake_bin/sign-verifier"
+grep -Eq '/payload\.zip$' "$test_root/preview-signatures.log"
+printf 'preview-download-payloae\n' >"$preview_download_source/payload.zip"
+rm -rf -- "$preview_download_output"
+mkdir -p "$preview_download_output"
+if FAKE_PREVIEW_ASSET_SOURCE="$preview_download_source" \
+	FAKE_PREVIEW_SIGNATURE_LOG="$test_root/preview-signatures-corrupt.log" \
+	PATH="$preview_fake_bin:$PATH" \
+	bash "$preview_download_verifier" \
+		"$test_root/preview-download-manifest.json" \
+		"$preview_download_output" "$preview_fake_bin/sign-verifier" \
+		>"$test_root/preview-download-corrupt.log" 2>&1; then
+	echo "Preview full download verification accepted a digest mismatch" >&2
+	exit 1
+fi
+grep -Eq 'digest does not match payload\.zip' "$test_root/preview-download-corrupt.log"
+grep -Fq 'verify-preview-desktop-downloads.sh' \
+	"$repo_root/scripts/verify-preview-release-artifacts.sh"
+
 # GitHub release recovery uses the same immutable-subset rule: an interrupted
 # release may fill missing assets, while conflicting or extra assets fail closed.
 desktop_github_publisher="$repo_root/scripts/publish-desktop-github-release.sh"
@@ -1520,18 +1601,59 @@ git clone -q "$test_root/automation-remote.git" "$test_root/automation-repo"
 	fi
 	grep -Eq 'predates the promotion activation cutoff' "$test_root/activation-cutoff.log"
 
-	MODE=stable VERSION=2.0.0 RELEASE_SHA="$preview_sha" \
+	if MODE=stable VERSION=2.0.0 RELEASE_SHA="$preview_sha" \
 		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
 		PREVIEW_VERSION=2.0.0-preview.1 PREVIEW_TAG=v2.0.0-preview.1 \
 		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/revalidate-release-candidate.sh" \
+		>"$test_root/revalidate-missing-event.log" 2>&1; then
+		echo "Stable revalidation ignored an unreadable newer Preview event" >&2
+		exit 1
+	fi
+	grep -Eq 'cannot revalidate release-event\.json for v2\.0\.0-preview\.2' \
+		"$test_root/revalidate-missing-event.log"
+
+	mkdir -p "$test_root/preview-events/v2.0.0-preview.2"
+	printf '%s\n' "{\"schemaVersion\":1,\"releaseId\":\"2.0.0-preview.2\",\"channel\":\"preview\",\"candidateSha\":\"$incomplete_sha\",\"publishedAt\":\"2026-08-01T01:00:00.000Z\",\"releaseNotesUrl\":\"https://reasonix.io/changelog/v2.0.0-preview.2/\",\"builds\":{\"cli\":\"v2.0.0-preview.2\",\"desktop\":\"v2.0.0-preview.2\",\"npm\":\"2.0.0-canary.2\"}}" \
+		>"$test_root/preview-events/v2.0.0-preview.2/release-event.json"
+	if MODE=stable VERSION=2.0.0 RELEASE_SHA="$preview_sha" \
+		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
+		PREVIEW_VERSION=2.0.0-preview.1 PREVIEW_TAG=v2.0.0-preview.1 \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/revalidate-release-candidate.sh" \
+		>"$test_root/revalidate-newer-preview.log" 2>&1; then
+		echo "Stable revalidation accepted an older complete Preview" >&2
+		exit 1
+	fi
+	grep -Eq 'latest complete is preview\.2' "$test_root/revalidate-newer-preview.log"
+
+	printf '%s\n' "{\"releases\":[{\"version\":\"2.0.0\",\"baseVersion\":\"2.0.0\",\"channel\":\"stable\",\"status\":\"reviewed\",\"promotedFrom\":\"2.0.0-preview.2\",\"candidateSha\":\"$incomplete_sha\"}]}" \
+		>release-notes/releases.json
+	git add release-notes/releases.json
+	git commit -q -m "promote newest complete preview"
+	git push -q origin main-v2
+	GITHUB_OUTPUT="$test_root/automated-stable-newest.out" \
+		RELEASE_MIN_PROMOTION_CANDIDATE_SHA="$preview_sha" \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/resolve-stable-promotion.sh"
+	grep -Eq '^preview_tag=v2\.0\.0-preview\.2$' "$test_root/automated-stable-newest.out"
+	grep -Eq '^sha='"$incomplete_sha"'$' "$test_root/automated-stable-newest.out"
+	# Historical older Preview events are irrelevant once a newer approved
+	# ordinal is selected; only the approved and newer tags must revalidate.
+	mv "$test_root/preview-events/v2.0.0-preview.1/release-event.json" \
+		"$test_root/preview-events/v2.0.0-preview.1/release-event.legacy"
+	MODE=stable VERSION=2.0.0 RELEASE_SHA="$incomplete_sha" \
+		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
+		PREVIEW_VERSION=2.0.0-preview.2 PREVIEW_TAG=v2.0.0-preview.2 \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
 		"$repo_root/scripts/revalidate-release-candidate.sh"
-	RELEASE_SHA="$preview_sha" \
+	RELEASE_SHA="$incomplete_sha" \
 		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
 		"$repo_root/scripts/create-release-tags.sh"
 	for tag in v2.0.0 npm-v2.0.0 desktop-v2.0.0; do
-		[ "$(git ls-remote --tags --refs origin "refs/tags/$tag" | awk '{ print $1 }')" = "$preview_sha" ]
+		[ "$(git ls-remote --tags --refs origin "refs/tags/$tag" | awk '{ print $1 }')" = "$incomplete_sha" ]
 	done
-	if RELEASE_SHA="$preview_sha" \
+	if RELEASE_SHA="$incomplete_sha" \
 		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
 		"$repo_root/scripts/create-release-tags.sh" >"$test_root/atomic-exists.log" 2>&1; then
 		echo "duplicate Stable tags unexpectedly passed" >&2
@@ -1541,9 +1663,55 @@ git clone -q "$test_root/automation-remote.git" "$test_root/automation-repo"
 )
 
 # Request artifact trust boundary fails closed on malformed payloads.
+grep -Fq 'reasonix-release-request.XXXXXX' "$repo_root/scripts/consume-release-request.sh"
+if grep -Fq 'REQUEST_DOWNLOAD_DIR' "$repo_root/scripts/consume-release-request.sh" ||
+	grep -Fq 'rm -rf "$download_dir"' "$repo_root/scripts/consume-release-request.sh"; then
+	echo "request consumer still permits unsafe recursive cleanup overrides" >&2
+	exit 1
+fi
 mkdir -p "$test_root/request-good" "$test_root/request-bad"
 printf '%s\n' '{"tag":"v2.0.0-preview.1"}' >"$test_root/request-good/request.json"
 printf '%s\n' '{"tag":"v2.0.0","extra":true}' >"$test_root/request-bad/request.json"
+request_fake_bin="$test_root/request-fake-bin"
+mkdir -p "$request_fake_bin"
+printf '%s\n' \
+	'#!/usr/bin/env bash' \
+	'set -euo pipefail' \
+	'if [ "$1" = api ]; then printf "1\\n"; exit 0; fi' \
+	'if [ "$1" = run ] && [ "$2" = download ]; then' \
+	'  shift 2' \
+	'  download_dir=""' \
+	'  while [ "$#" -gt 0 ]; do' \
+	'    case "$1" in --dir) download_dir="$2"; shift 2 ;; *) shift ;; esac' \
+	'  done' \
+	'  printf "%s\\n" "$download_dir" > "$FAKE_REQUEST_DOWNLOAD_LOG"' \
+	'  cp "$FAKE_REQUEST_SOURCE/request.json" "$download_dir/request.json"' \
+	'  exit 0' \
+	'fi' \
+	'exit 1' >"$request_fake_bin/gh"
+chmod +x "$request_fake_bin/gh"
+FAKE_REQUEST_SOURCE="$test_root/request-good" \
+	FAKE_REQUEST_DOWNLOAD_LOG="$test_root/request-download.log" \
+	PATH="$request_fake_bin:$PATH" \
+	REQUEST_KIND=preview-recovery \
+	EXPECTED_WORKFLOW_NAME="Request preview recovery" \
+	EXPECTED_ARTIFACT_NAME=preview-recovery-request \
+	REQUEST_OUTPUT="$test_root/request-output.json" \
+	REPOSITORY=example/reasonix \
+	SOURCE_RUN_ID=1 SOURCE_RUN_CONCLUSION=success SOURCE_RUN_BRANCH=main-v2 \
+	SOURCE_RUN_EVENT=workflow_dispatch SOURCE_RUN_NAME="Request preview recovery" \
+	SOURCE_RUN_REPOSITORY=example/reasonix \
+	bash "$repo_root/scripts/consume-release-request.sh"
+cmp -s "$test_root/request-good/request.json" "$test_root/request-output.json"
+request_download_dir="$(cat "$test_root/request-download.log")"
+case "$request_download_dir" in
+*/reasonix-release-request.*) ;;
+*) echo "request consumer did not use its scoped temporary directory" >&2; exit 1 ;;
+esac
+[ ! -e "$request_download_dir" ] || {
+	echo "request consumer did not clean its scoped temporary directory" >&2
+	exit 1
+}
 if REQUEST_KIND=preview-recovery \
 	EXPECTED_WORKFLOW_NAME="Request preview recovery" \
 	EXPECTED_ARTIFACT_NAME=preview-recovery-request \

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -11,28 +11,31 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Stable tags have one entrypoint and one protected environment. Reusable
-# publishers must verify that only that entrypoint can claim prior approval.
+# Stage 1 keeps legacy tag+relay production entrypoints while landing promotion
+# helpers, shadow validation, and App-aware (but human-compatible) relays.
+# Stage-3 activated workflows live only under docs/releasing/stage3-workflows/.
 [ "$(grep -Ec '^    environment: release$' "$repo_root/.github/workflows/release-stable.yml")" = "1" ]
-for relay in release-stable-trigger.yml release-cli-trigger.yml release-desktop-trigger.yml; do
+for relay in release-cli-trigger.yml release-desktop-trigger.yml release-stable-trigger.yml; do
 	grep -Eq 'actions: write' "$repo_root/.github/workflows/$relay"
 	grep -Eq "CONTROL_PLANE_REF.*default_branch" "$repo_root/.github/workflows/$relay"
 	grep -Eq "CONTROL_PLANE_REF !== 'main-v2'" "$repo_root/.github/workflows/$relay"
 	grep -Eq 'createWorkflowDispatch' "$repo_root/.github/workflows/$relay"
 	grep -Eq 'ref: process\.env\.CONTROL_PLANE_REF' "$repo_root/.github/workflows/$relay"
 done
-grep -Eq "workflow_id: 'release-stable\.yml'" \
-	"$repo_root/.github/workflows/release-stable-trigger.yml"
-grep -Eq "allow_recovery: 'false'" \
-	"$repo_root/.github/workflows/release-stable-trigger.yml"
-grep -Eq 'ALLOW_STABLE_RECOVERY:.*inputs\.allow_recovery' \
-	"$repo_root/.github/workflows/release-stable.yml"
+grep -Fq 'reasonix-release-tagger[bot]' "$repo_root/.github/workflows/release-stable-trigger.yml"
+grep -Fq 'reasonix-release-tagger[bot]' "$repo_root/.github/workflows/release-cli-trigger.yml"
+grep -Fq "workflow_id: 'release-stable.yml'" "$repo_root/.github/workflows/release-stable-trigger.yml"
+grep -Fq "'release-preview.yml'" "$repo_root/.github/workflows/release-cli-trigger.yml"
+if grep -Fq 'Stable tags must be created by Actions' "$repo_root/.github/workflows/release-stable-trigger.yml" ||
+	grep -Fq 'Preview tags must be created by Actions' "$repo_root/.github/workflows/release-cli-trigger.yml"; then
+	echo "Stage 1 must keep human tag relays working; blocking messages belong in Stage 3 drafts" >&2
+	exit 1
+fi
 grep -Eq "workflow_id: 'release-desktop\.yml'" \
 	"$repo_root/.github/workflows/release-desktop-trigger.yml"
 grep -Fq 'Desktop Preview must be dispatched without a Git tag' \
 	"$repo_root/.github/workflows/release-desktop-trigger.yml"
-grep -Fq "workflow_id: preview ? 'release-preview.yml' : 'release.yml'" \
-	"$repo_root/.github/workflows/release-cli-trigger.yml"
+grep -Fq "'release.yml'" "$repo_root/.github/workflows/release-cli-trigger.yml"
 grep -Eq "preview\\\\\." "$repo_root/.github/workflows/release-cli-trigger.yml"
 grep -Eq '^name: Release preview$' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq '^  group: preview-release$' "$repo_root/.github/workflows/release-preview.yml"
@@ -41,16 +44,72 @@ if grep -Fq 'group: preview-release-${{ inputs.tag }}' "$repo_root/.github/workf
 	exit 1
 fi
 grep -Eq '^    environment: canary$' "$repo_root/.github/workflows/release-preview.yml"
+# Stage 1 production Preview still accepts an existing tag (+ recovery flag).
+grep -Eq '^      tag:$' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq '^      recovery:$' "$repo_root/.github/workflows/release-preview.yml"
-grep -Fq 'ALLOW_PREVIEW_RECOVERY: ${{ inputs.recovery }}' "$repo_root/.github/workflows/release-preview.yml"
-grep -Fq 'allow_preview_recovery: ${{ inputs.recovery }}' "$repo_root/.github/workflows/release-preview.yml"
+if grep -Eq '^      base_version:$' "$repo_root/.github/workflows/release-preview.yml"; then
+	echo "Stage 1 must not activate one-input Preview (base_version) on the production workflow" >&2
+	exit 1
+fi
+if grep -Eq 'create-github-app-token|create-release-tags\.sh' \
+	"$repo_root/.github/workflows/release-preview.yml" \
+	"$repo_root/.github/workflows/release-stable.yml"; then
+	echo "Stage 1 production orchestrators must not mint App tokens or create tags" >&2
+	exit 1
+fi
 grep -Eq '^  signpath-preflight:$' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq 'signing_preflight: true' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq 'signing_preflight_verified: true' "$repo_root/.github/workflows/release-preview.yml"
 [ "$(grep -Ec 'needs: \[authorize, signpath-preflight\]' "$repo_root/.github/workflows/release-preview.yml")" = "3" ]
 grep -Eq 'release-event\.mjs generate' "$repo_root/.github/workflows/release-preview.yml"
 grep -Eq 'gh workflow run pages\.yml' "$repo_root/.github/workflows/release-preview.yml"
+# Stage 1 Stable remains tag/recovery dispatch, not zero-input promote.
+grep -Eq '^      tag:$' "$repo_root/.github/workflows/release-stable.yml"
+grep -Eq '^      allow_recovery:$' "$repo_root/.github/workflows/release-stable.yml"
+if grep -Eq 'workflow_run:|Request stable recovery|Emergency stable promotion' \
+	"$repo_root/.github/workflows/release-stable.yml"; then
+	echo "Stage 1 must not activate workflow_run Stable consumers" >&2
+	exit 1
+fi
+if [ -e "$repo_root/.github/workflows/release-preview-recovery.yml" ] ||
+	[ -e "$repo_root/.github/workflows/release-stable-recovery.yml" ] ||
+	[ -e "$repo_root/.github/workflows/release-stable-emergency.yml" ]; then
+	echo "Stage-3 request workflows must stay under docs/releasing/stage3-workflows/ until activation" >&2
+	exit 1
+fi
+stage3_dir="$repo_root/docs/releasing/stage3-workflows"
+for draft in release-preview.yml release-stable.yml release-preview-recovery.yml \
+	release-stable-recovery.yml release-stable-emergency.yml; do
+	[ -f "$stage3_dir/$draft" ] || {
+		echo "missing Stage-3 draft workflow: $draft" >&2
+		exit 1
+	}
+done
+grep -Eq '^      base_version:$' "$stage3_dir/release-preview.yml"
+grep -Eq 'create-github-app-token' "$stage3_dir/release-preview.yml"
+grep -Eq 'create-github-app-token' "$stage3_dir/release-stable.yml"
+grep -Eq '^name: Request preview recovery$' "$stage3_dir/release-preview-recovery.yml"
+grep -Eq '^name: Request stable recovery$' "$stage3_dir/release-stable-recovery.yml"
+grep -Eq '^name: Emergency stable promotion$' "$stage3_dir/release-stable-emergency.yml"
+grep -Eq '^    environment: emergency-release$' "$stage3_dir/release-stable-emergency.yml"
 grep -Eq 'release-cli-trigger\.yml' "$repo_root/.github/workflows/ci.yml"
+grep -Fq '.github/workflows/prepare-release-notes.yml' "$repo_root/.github/workflows/ci.yml"
+grep -Fq '.github/workflows/release-stable-shadow.yml' "$repo_root/.github/workflows/ci.yml"
+grep -Eq '^name: Shadow validate stable promotion$' \
+	"$repo_root/.github/workflows/release-stable-shadow.yml"
+if grep -Eq 'create-release-tags\.sh|create-github-app-token' \
+	"$repo_root/.github/workflows/release-stable-shadow.yml"; then
+	echo "shadow validation must not create tags or mint a release-tagger token" >&2
+	exit 1
+fi
+if grep -Fq '.github/workflows/release-preview-recovery.yml' "$repo_root/.github/workflows/ci.yml" ||
+	grep -Fq '.github/workflows/release-stable-recovery.yml' "$repo_root/.github/workflows/ci.yml" ||
+	grep -Fq '.github/workflows/release-stable-emergency.yml' "$repo_root/.github/workflows/ci.yml"; then
+	echo "Stage 1 CI must not actionlint inactive Stage-3 request workflows" >&2
+	exit 1
+fi
+grep -Fq 'ref: ${{ github.sha }}' "$repo_root/.github/workflows/release-preview.yml"
+grep -Fq 'ref: ${{ github.sha }}' "$repo_root/.github/workflows/release-stable.yml"
 if grep -Eq '^  push:$' "$repo_root/.github/workflows/release-stable.yml" ||
 	grep -Eq '^  push:$' "$repo_root/.github/workflows/release.yml" ||
 	grep -Eq '^  push:$' "$repo_root/.github/workflows/release-desktop.yml"; then
@@ -264,6 +323,12 @@ for channel in cli npm desktop; do
 	grep -Eq '^      publish_'"$channel"':' "$repo_root/.github/workflows/release-stable.yml"
 	grep -Eq "inputs\.publish_$channel" "$repo_root/.github/workflows/release-stable.yml"
 done
+# Stage-3 recovery draft defaults all surfaces off and requires at least one.
+for channel in cli npm desktop; do
+	grep -Eq '^      publish_'"$channel"':' "$stage3_dir/release-stable-recovery.yml"
+	grep -Eq 'default: false' <<<"$(grep -A4 -E "^      publish_${channel}:" "$stage3_dir/release-stable-recovery.yml")"
+done
+grep -Fq 'Select at least one surface to recover' "$stage3_dir/release-stable-recovery.yml"
 
 # The checked-in SignPath policy contract is the single source of truth for the
 # provider allowlist and every top-level workflow that can reach signing.
@@ -1236,6 +1301,12 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 		CALLER_WORKFLOW_SHA="$approved_sha" CALLER_SHA="$approved_sha" \
 		APPROVED_CHANNEL=preview APPROVED_CLI_TAG=v1.3.0-preview.42 APPROVED_SHA="$approved_sha" \
 		"$repo_root/scripts/verify-release-authorization.sh"
+	ACTUAL_CALLER_WORKFLOW_REF='example/reasonix/.github/workflows/release-preview.yml@refs/heads/main-v2' \
+		EXPECTED_CALLER_WORKFLOW_REF='example/reasonix/.github/workflows/release-preview.yml@refs/heads/main-v2' \
+		CALLER_EVENT_NAME=workflow_run CALLER_REF=refs/heads/main-v2 CALLER_REF_PROTECTED=true \
+		CALLER_WORKFLOW_SHA="$approved_sha" CALLER_SHA="$approved_sha" \
+		APPROVED_CHANNEL=preview APPROVED_CLI_TAG=v1.3.0-preview.42 APPROVED_SHA="$approved_sha" \
+		"$repo_root/scripts/verify-release-authorization.sh"
 	RELEASE_TAG=desktop-v1.2.3 APPROVED_SHA="$approved_sha" \
 		"$repo_root/scripts/verify-release-tag.sh"
 
@@ -1372,6 +1443,120 @@ git clone -q "$test_root/remote.git" "$test_root/repo"
 	fi
 	grep -Eq 'stable release tag must be vMAJOR.MINOR.PATCH' "$test_root/prerelease.log"
 )
+
+# The low-friction entrypoints must derive one Preview tag, promote its exact
+# SHA, and create the Stable tag set atomically without moving main-v2.
+git init --bare -q "$test_root/automation-remote.git"
+git clone -q "$test_root/automation-remote.git" "$test_root/automation-repo"
+(
+	cd "$test_root/automation-repo"
+	git config user.name "Release Automation Test"
+	git config user.email "release-automation-test@example.invalid"
+	mkdir -p .github/workflows release-notes
+	printf '%s\n' '{"schemaVersion":1,"releases":[{"version":"2.0.0-preview.1","baseVersion":"2.0.0","channel":"prerelease","status":"reviewed"}]}' \
+		> release-notes/releases.json
+	git add .github release-notes
+	git commit -q -m "preview candidate"
+	git branch -M main-v2
+	git push -q -u origin main-v2
+	preview_sha="$(git rev-parse HEAD)"
+	GITHUB_OUTPUT="$test_root/automated-preview.out" BASE_VERSION=2.0.0 \
+		"$repo_root/scripts/resolve-preview-candidate.sh"
+	grep -Eq '^cli_tag=v2\.0\.0-preview\.1$' "$test_root/automated-preview.out"
+	RELEASE_SHA="$preview_sha" RELEASE_TAGS='v2.0.0-preview.1' \
+		"$repo_root/scripts/create-release-tags.sh"
+	[ "$(git ls-remote --tags --refs origin refs/tags/v2.0.0-preview.1 | awk '{ print $1 }')" = "$preview_sha" ]
+	if RELEASE_SHA="$preview_sha" RELEASE_TAGS='v2.0.0-preview.1' \
+		"$repo_root/scripts/create-release-tags.sh" >"$test_root/duplicate-automated-preview.log" 2>&1; then
+		echo "duplicate automated Preview tag unexpectedly passed" >&2
+		exit 1
+	fi
+	grep -Eq 'release tag already exists' "$test_root/duplicate-automated-preview.log"
+
+	# Incomplete Preview tags must not look like the newest complete release.
+	mkdir -p "$test_root/preview-events/v2.0.0-preview.1"
+	printf '%s\n' "{\"schemaVersion\":1,\"releaseId\":\"2.0.0-preview.1\",\"channel\":\"preview\",\"candidateSha\":\"$preview_sha\",\"publishedAt\":\"2026-08-01T00:00:00.000Z\",\"releaseNotesUrl\":\"https://reasonix.io/changelog/v2.0.0-preview.1/\",\"builds\":{\"cli\":\"v2.0.0-preview.1\",\"desktop\":\"v2.0.0-preview.1\",\"npm\":\"2.0.0-canary.1\"}}" \
+		>"$test_root/preview-events/v2.0.0-preview.1/release-event.json"
+	git commit --allow-empty -q -m "incomplete newer preview"
+	git push -q origin main-v2
+	incomplete_sha="$(git rev-parse HEAD)"
+	RELEASE_SHA="$incomplete_sha" RELEASE_TAGS='v2.0.0-preview.2' \
+		"$repo_root/scripts/create-release-tags.sh"
+
+	printf '%s\n' "{\"releases\":[{\"version\":\"2.0.0\",\"baseVersion\":\"2.0.0\",\"channel\":\"stable\",\"status\":\"reviewed\",\"promotedFrom\":\"2.0.0-preview.1\",\"candidateSha\":\"$preview_sha\"}]}" \
+		> release-notes/releases.json
+	git add release-notes/releases.json
+	git commit -q -m "stable promotion record"
+	git push -q origin main-v2
+	GITHUB_OUTPUT="$test_root/automated-stable.out" \
+		RELEASE_MIN_PROMOTION_CANDIDATE_SHA="$preview_sha" \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/resolve-stable-promotion.sh"
+
+	# Stage-1 empty cutoff remains allowed for shadow/infrastructure proofs.
+	GITHUB_OUTPUT="$test_root/automated-stable-empty-cutoff.out" \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/resolve-stable-promotion.sh"
+	grep -Eq '^preview_tag=v2\.0\.0-preview\.1$' "$test_root/automated-stable-empty-cutoff.out"
+	if RELEASE_REQUIRE_PROMOTION_CUTOFF=true \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/resolve-stable-promotion.sh" \
+		>"$test_root/require-cutoff.log" 2>&1; then
+		echo "empty cutoff with REQUIRE unexpectedly passed" >&2
+		exit 1
+	fi
+	grep -Eq 'promotion activation cutoff is not configured' "$test_root/require-cutoff.log"
+
+	grep -Eq '^preview_tag=v2\.0\.0-preview\.1$' "$test_root/automated-stable.out"
+	grep -Eq '^sha='"$preview_sha"'$' "$test_root/automated-stable.out"
+
+	# Activation cutoff blocks pre-infrastructure candidates.
+	if RELEASE_MIN_PROMOTION_CANDIDATE_SHA="$(git rev-parse HEAD)" \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/resolve-stable-promotion.sh" \
+		>"$test_root/activation-cutoff.log" 2>&1; then
+		echo "pre-cutoff Preview unexpectedly promoted" >&2
+		exit 1
+	fi
+	grep -Eq 'predates the promotion activation cutoff' "$test_root/activation-cutoff.log"
+
+	MODE=stable VERSION=2.0.0 RELEASE_SHA="$preview_sha" \
+		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
+		PREVIEW_VERSION=2.0.0-preview.1 PREVIEW_TAG=v2.0.0-preview.1 \
+		RELEASE_PREVIEW_EVENT_STORE="$test_root/preview-events" \
+		"$repo_root/scripts/revalidate-release-candidate.sh"
+	RELEASE_SHA="$preview_sha" \
+		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
+		"$repo_root/scripts/create-release-tags.sh"
+	for tag in v2.0.0 npm-v2.0.0 desktop-v2.0.0; do
+		[ "$(git ls-remote --tags --refs origin "refs/tags/$tag" | awk '{ print $1 }')" = "$preview_sha" ]
+	done
+	if RELEASE_SHA="$preview_sha" \
+		RELEASE_TAGS='v2.0.0 npm-v2.0.0 desktop-v2.0.0' \
+		"$repo_root/scripts/create-release-tags.sh" >"$test_root/atomic-exists.log" 2>&1; then
+		echo "duplicate Stable tags unexpectedly passed" >&2
+		exit 1
+	fi
+	grep -Eq 'release tag already exists' "$test_root/atomic-exists.log"
+)
+
+# Request artifact trust boundary fails closed on malformed payloads.
+mkdir -p "$test_root/request-good" "$test_root/request-bad"
+printf '%s\n' '{"tag":"v2.0.0-preview.1"}' >"$test_root/request-good/request.json"
+printf '%s\n' '{"tag":"v2.0.0","extra":true}' >"$test_root/request-bad/request.json"
+if REQUEST_KIND=preview-recovery \
+	EXPECTED_WORKFLOW_NAME="Request preview recovery" \
+	EXPECTED_ARTIFACT_NAME=preview-recovery-request \
+	REPOSITORY=example/reasonix \
+	SOURCE_RUN_ID=1 SOURCE_RUN_CONCLUSION=success SOURCE_RUN_BRANCH=main-v2 \
+	SOURCE_RUN_EVENT=push SOURCE_RUN_NAME="Request preview recovery" \
+	SOURCE_RUN_REPOSITORY=example/reasonix \
+	bash "$repo_root/scripts/consume-release-request.sh" \
+	>"$test_root/request-event.log" 2>&1; then
+	echo "non-dispatch request event unexpectedly passed" >&2
+	exit 1
+fi
+grep -Eq 'expected workflow_dispatch' "$test_root/request-event.log"
 
 EVENT_NAME=push IN_CHANNEL=stable IN_TAG=desktop-v1.2.3 REF_NAME=v1.2.3 RUN_NUMBER=10 \
 	GITHUB_OUTPUT="$test_root/desktop-stable.out" bash "$repo_root/scripts/resolve-desktop-release.sh"

--- a/scripts/resolve-preview-candidate.sh
+++ b/scripts/resolve-preview-candidate.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolve the next reviewed Preview identity for the current main-v2 commit.
+set -euo pipefail
+
+base_version="${BASE_VERSION:?BASE_VERSION is required}"
+release_remote="${RELEASE_REMOTE:-origin}"
+
+if [[ ! "$base_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+	echo "::error::BASE_VERSION must be MAJOR.MINOR.PATCH, got: $base_version" >&2
+	exit 1
+fi
+
+checkout_sha="$(git rev-parse HEAD^{commit})"
+main_sha="$(git ls-remote "$release_remote" refs/heads/main-v2 | awk 'NR == 1 { print $1 }')"
+if [ -z "$main_sha" ] || [ "$checkout_sha" != "$main_sha" ]; then
+	echo "::error::Preview control checkout must equal current $release_remote/main-v2 ($main_sha), got $checkout_sha" >&2
+	exit 1
+fi
+
+if git ls-remote --exit-code --tags --refs "$release_remote" "refs/tags/v$base_version" >/dev/null 2>&1; then
+	echo "::error::v$base_version is already Stable; choose the next release-train version" >&2
+	exit 1
+fi
+
+highest=0
+while IFS= read -r ref; do
+	tag="${ref#refs/tags/}"
+	if [[ "$tag" =~ ^v${base_version//./\.}-preview\.([1-9][0-9]*)$ ]] &&
+		[ "${BASH_REMATCH[1]}" -gt "$highest" ]; then
+		highest="${BASH_REMATCH[1]}"
+	fi
+done < <(git ls-remote --tags --refs "$release_remote" "refs/tags/v$base_version-preview.*" | awk '{ print $2 }')
+
+preview_number=$((highest + 1))
+version="$base_version-preview.$preview_number"
+cli_tag="v$version"
+
+RELEASE_VERSION="$version" RELEASE_SHA="$checkout_sha" node <<'NODE'
+const catalog = require("./release-notes/releases.json");
+const release = catalog.releases.find((entry) => entry.version === process.env.RELEASE_VERSION);
+if (!release) throw new Error(`reviewed release notes for ${process.env.RELEASE_VERSION} are missing`);
+if (release.channel !== "prerelease" || release.status !== "reviewed") {
+  throw new Error(`${process.env.RELEASE_VERSION} must be a reviewed Preview release record`);
+}
+if (release.baseVersion !== process.env.RELEASE_VERSION.split("-")[0]) {
+  throw new Error(`${process.env.RELEASE_VERSION} has the wrong baseVersion`);
+}
+if (release.candidateSha && release.candidateSha !== process.env.RELEASE_SHA) {
+  throw new Error(`${process.env.RELEASE_VERSION} candidateSha does not match current main-v2`);
+}
+NODE
+
+{
+	echo "version=$version"
+	echo "base_version=$base_version"
+	echo "preview_number=$preview_number"
+	echo "cli_tag=$cli_tag"
+	echo "desktop_tag=desktop-v$version"
+	echo "npm_version=$base_version-canary.$preview_number"
+	echo "sha=$checkout_sha"
+} >>"${GITHUB_OUTPUT:-/dev/stdout}"
+
+echo "Preview candidate resolved: $cli_tag at $checkout_sha"

--- a/scripts/resolve-stable-promotion.sh
+++ b/scripts/resolve-stable-promotion.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Select the newest reviewed Stable record that explicitly promotes a Preview.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release-activation.sh
+source "$script_dir/release-activation.sh"
+
+release_remote="${RELEASE_REMOTE:-origin}"
+checkout_sha="$(git rev-parse HEAD^{commit})"
+main_sha="$(git ls-remote "$release_remote" refs/heads/main-v2 | awk 'NR == 1 { print $1 }')"
+if [ -z "$main_sha" ] || [ "$checkout_sha" != "$main_sha" ]; then
+	echo "::error::Stable control checkout must equal current $release_remote/main-v2 ($main_sha), got $checkout_sha" >&2
+	exit 1
+fi
+
+candidates=()
+while IFS= read -r candidate; do
+	candidates+=("$candidate")
+done < <(node <<'NODE'
+const catalog = require("./release-notes/releases.json");
+for (const release of catalog.releases) {
+  if (release.channel === "stable" && release.status === "reviewed" &&
+      release.promotedFrom && release.candidateSha) {
+    process.stdout.write(`${release.version}\t${release.promotedFrom}\t${release.candidateSha}\n`);
+  }
+}
+NODE
+)
+
+load_preview_event() {
+	local preview_tag="$1"
+	local dest="$2"
+	if [ -n "${RELEASE_PREVIEW_EVENT_STORE:-}" ]; then
+		if [ -f "$RELEASE_PREVIEW_EVENT_STORE/$preview_tag/release-event.json" ]; then
+			cp "$RELEASE_PREVIEW_EVENT_STORE/$preview_tag/release-event.json" "$dest/release-event.json"
+			return 0
+		fi
+		return 1
+	fi
+	gh release download "$preview_tag" --pattern release-event.json --dir "$dest" 2>/dev/null
+}
+
+preview_event_complete() {
+	local preview_tag="$1"
+	local expected_sha="$2"
+	local event_dir
+	event_dir="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-preview-complete.XXXXXX")"
+	if ! load_preview_event "$preview_tag" "$event_dir"; then
+		rm -rf -- "$event_dir"
+		return 1
+	fi
+	# Structural completeness only: full catalog-bound validation happens later
+	# against the frozen control-plane notes during Stable preflight.
+	if ! jq -e --arg sha "$expected_sha" --arg id "${preview_tag#v}" '
+    .schemaVersion == 1 and
+    .releaseId == $id and
+    .channel == "preview" and
+    .candidateSha == $sha and
+    (.publishedAt | type == "string" and test("^\\d{4}-\\d{2}-\\d{2}T")) and
+    (.builds.cli | type == "string" and length > 0) and
+    (.builds.desktop | type == "string" and length > 0) and
+    (.builds.npm | type == "string" and length > 0)
+  ' "$event_dir/release-event.json" >/dev/null 2>&1; then
+		rm -rf -- "$event_dir"
+		return 1
+	fi
+	rm -rf -- "$event_dir"
+	return 0
+}
+
+highest_complete_preview() {
+	local version="$1"
+	local highest=0
+	local incomplete=()
+	while IFS= read -r ref; do
+		local tag="${ref#refs/tags/}"
+		if [[ "$tag" =~ ^v${version//./\.}-preview\.([1-9][0-9]*)$ ]]; then
+			local number="${BASH_REMATCH[1]}"
+			local tag_sha
+			tag_sha="$(
+				git ls-remote --tags "$release_remote" "refs/tags/$tag" "refs/tags/$tag^{}" |
+					awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
+			)"
+			if [ -n "$tag_sha" ] && preview_event_complete "$tag" "$tag_sha"; then
+				if [ "$number" -gt "$highest" ]; then
+					highest="$number"
+				fi
+			else
+				incomplete+=("$tag")
+			fi
+		fi
+	done < <(git ls-remote --tags --refs "$release_remote" "refs/tags/v$version-preview.*" | awk '{ print $2 }')
+	if [ "${#incomplete[@]}" -gt 0 ]; then
+		echo "Incomplete Preview tags (use Request preview recovery): ${incomplete[*]}" >&2
+	fi
+	echo "$highest"
+}
+
+for candidate in "${candidates[@]}"; do
+	IFS=$'\t' read -r version promoted_from candidate_sha <<<"$candidate"
+	cli_tag="v$version"
+	npm_tag="npm-v$version"
+	desktop_tag="desktop-v$version"
+	preview_tag="v$promoted_from"
+
+	existing=0
+	for tag in "$cli_tag" "$npm_tag" "$desktop_tag"; do
+		if git ls-remote --exit-code --tags --refs "$release_remote" "refs/tags/$tag" >/dev/null 2>&1; then
+			existing=$((existing + 1))
+		fi
+	done
+	if [ "$existing" -eq 3 ]; then
+		continue
+	fi
+	if [ "$existing" -ne 0 ]; then
+		echo "::error::Stable $version has a partial tag set; use Request stable recovery after repairing the public identity" >&2
+		exit 1
+	fi
+
+	if [[ ! "$promoted_from" =~ ^${version//./\.}-preview\.([1-9][0-9]*)$ ]]; then
+		echo "::error::$version promotedFrom must be a Preview of the same base version, got: $promoted_from" >&2
+		exit 1
+	fi
+	promoted_number="${BASH_REMATCH[1]}"
+
+	tag_sha="$(
+		git ls-remote --tags "$release_remote" "refs/tags/$preview_tag" "refs/tags/$preview_tag^{}" |
+			awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
+	)"
+	if [ -z "$tag_sha" ] || [ "$tag_sha" != "$candidate_sha" ]; then
+		echo "::error::$preview_tag resolves to ${tag_sha:-<missing>}, expected catalog candidateSha $candidate_sha" >&2
+		exit 1
+	fi
+
+	if ! preview_event_complete "$preview_tag" "$candidate_sha"; then
+		echo "::error::$preview_tag is incomplete (missing or invalid release-event.json); use Request preview recovery before promotion" >&2
+		exit 1
+	fi
+
+	highest="$(highest_complete_preview "$version")"
+	if [ "$promoted_number" -ne "$highest" ]; then
+		echo "::error::$preview_tag is not the newest complete Preview for $version (latest complete is preview.$highest)" >&2
+		exit 1
+	fi
+
+	git fetch --quiet --no-tags "$release_remote" "refs/tags/$preview_tag"
+	if ! git merge-base --is-ancestor "$candidate_sha" "$main_sha"; then
+		echo "::error::$preview_tag is not on current main-v2 history" >&2
+		exit 1
+	fi
+	require_promotion_activation_cutoff "$candidate_sha"
+
+	{
+		echo "version=$version"
+		echo "cli_tag=$cli_tag"
+		echo "npm_tag=$npm_tag"
+		echo "desktop_tag=$desktop_tag"
+		echo "preview_version=$promoted_from"
+		echo "preview_tag=$preview_tag"
+		echo "sha=$candidate_sha"
+	} >>"${GITHUB_OUTPUT:-/dev/stdout}"
+	echo "Stable promotion resolved: $preview_tag -> $cli_tag at $candidate_sha"
+	exit 0
+done
+
+echo "::error::No pending reviewed Stable promotion was found. Prepare Stable notes with promotedFrom and candidateSha first (Actions → Prepare release notes)." >&2
+exit 1

--- a/scripts/revalidate-release-candidate.sh
+++ b/scripts/revalidate-release-candidate.sh
@@ -102,27 +102,67 @@ NODE
 		echo "::error::$preview_tag resolves to ${tag_sha:-<missing>}, expected approved $candidate_sha" >&2
 		exit 1
 	fi
+	# Freeze and validate the approved and every newer same-base Preview. A missing or
+	# unreadable release event is indistinguishable from a transient control-plane
+	# failure here, so normal promotion must fail closed and be retried/recovered.
+	event_root="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-revalidate-preview.XXXXXX")"
+	cleanup_revalidation_events() {
+		case "$event_root" in
+		*/reasonix-revalidate-preview.*) rm -r -- "$event_root" ;;
+		*) echo "refusing to clean unexpected revalidation directory: $event_root" >&2 ;;
+		esac
+	}
+	trap cleanup_revalidation_events EXIT
+	preview_refs="$event_root/preview-refs.txt"
+	if ! git ls-remote --tags --refs "$release_remote" \
+		"refs/tags/v$version-preview.*" >"$preview_refs"; then
+		echo "::error::cannot enumerate Preview tags for $version from $release_remote" >&2
+		exit 1
+	fi
+
+	approved_number="${preview_version##*-preview.}"
 	# Reject when a newer complete Preview for the same base version appeared.
 	highest_complete=0
 	while IFS= read -r ref; do
 		tag="${ref#refs/tags/}"
 		if [[ "$tag" =~ ^v${version//./\.}-preview\.([1-9][0-9]*)$ ]]; then
 			number="${BASH_REMATCH[1]}"
-			event_dir="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-revalidate-preview.XXXXXX")"
-			event_ok=false
-			if [ -n "${RELEASE_PREVIEW_EVENT_STORE:-}" ] &&
-				[ -f "$RELEASE_PREVIEW_EVENT_STORE/$tag/release-event.json" ]; then
-				cp "$RELEASE_PREVIEW_EVENT_STORE/$tag/release-event.json" "$event_dir/release-event.json"
-				event_ok=true
-			elif gh release download "$tag" --pattern release-event.json --dir "$event_dir" 2>/dev/null; then
-				event_ok=true
+			if [ "$number" -lt "$approved_number" ]; then
+				continue
+			fi
+			event_dir="$event_root/$tag"
+			mkdir -p "$event_dir"
+			if [ -n "${RELEASE_PREVIEW_EVENT_STORE:-}" ]; then
+				if ! cp "$RELEASE_PREVIEW_EVENT_STORE/$tag/release-event.json" \
+					"$event_dir/release-event.json" 2>/dev/null; then
+					echo "::error::cannot revalidate release-event.json for $tag" >&2
+					exit 1
+				fi
+			else
+				gh_repo_args=()
+				if [ -n "${RELEASE_REPOSITORY:-}" ]; then
+					gh_repo_args=(--repo "$RELEASE_REPOSITORY")
+				fi
+				if ! gh release download "$tag" "${gh_repo_args[@]}" \
+					--pattern release-event.json --dir "$event_dir"; then
+					echo "::error::cannot revalidate release-event.json for $tag" >&2
+					exit 1
+				fi
+			fi
+			if ! tag_refs="$(git ls-remote --tags "$release_remote" \
+				"refs/tags/$tag" "refs/tags/$tag^{}")"; then
+				echo "::error::cannot resolve Preview tag $tag during revalidation" >&2
+				exit 1
 			fi
 			tag_sha="$(
-				git ls-remote --tags "$release_remote" "refs/tags/$tag" "refs/tags/$tag^{}" |
+				printf '%s\n' "$tag_refs" |
 					awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
 			)"
-			if [ "$event_ok" = true ] &&
-				jq -e --arg sha "$tag_sha" --arg id "${tag#v}" '
+			if [ -z "$tag_sha" ]; then
+				echo "::error::cannot resolve Preview tag $tag during revalidation" >&2
+				exit 1
+			fi
+			if ! jq -e --arg sha "$tag_sha" --arg id "${tag#v}" '
           .schemaVersion == 1 and
           .releaseId == $id and
           .channel == "preview" and
@@ -131,17 +171,21 @@ NODE
           (.builds.cli | type == "string" and length > 0) and
           (.builds.desktop | type == "string" and length > 0) and
           (.builds.npm | type == "string" and length > 0)
-        ' "$event_dir/release-event.json" >/dev/null 2>&1; then
-				if [ "$number" -gt "$highest_complete" ]; then
-					highest_complete="$number"
-				fi
+			' "$event_dir/release-event.json" >/dev/null; then
+				echo "::error::release-event.json for $tag is incomplete or does not match its immutable tag" >&2
+				exit 1
 			fi
-			rm -rf -- "$event_dir"
+			if [ "$number" -gt "$highest_complete" ]; then
+				highest_complete="$number"
+			fi
 		fi
-	done < <(git ls-remote --tags --refs "$release_remote" "refs/tags/v$version-preview.*" | awk '{ print $2 }')
-	approved_number="${preview_version##*-preview.}"
-	if [ "$highest_complete" -gt 0 ] && [ "$approved_number" -ne "$highest_complete" ]; then
-		echo "::error::$preview_tag is no longer the newest complete Preview for $version (latest complete is preview.$highest_complete); use Request preview recovery for incomplete tags" >&2
+	done < <(awk '{ print $2 }' "$preview_refs")
+	if [ "$highest_complete" -eq 0 ]; then
+		echo "::error::no complete Preview could be revalidated for $version" >&2
+		exit 1
+	fi
+	if [ "$approved_number" -ne "$highest_complete" ]; then
+		echo "::error::$preview_tag is no longer the newest complete Preview for $version (latest complete is preview.$highest_complete)" >&2
 		exit 1
 	fi
 	;;

--- a/scripts/revalidate-release-candidate.sh
+++ b/scripts/revalidate-release-candidate.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Re-check an approved release identity immediately before tag creation.
+#
+# Modes:
+#   MODE=preview  RELEASE_TAGS="vX.Y.Z-preview.N" RELEASE_SHA=... VERSION=...
+#   MODE=stable   RELEASE_TAGS="vX.Y.Z npm-vX.Y.Z desktop-vX.Y.Z" RELEASE_SHA=...
+#                 VERSION=... PREVIEW_VERSION=... PREVIEW_TAG=...
+set -euo pipefail
+
+mode="${MODE:?MODE is required}"
+candidate_sha="${RELEASE_SHA:?RELEASE_SHA is required}"
+version="${VERSION:?VERSION is required}"
+release_remote="${RELEASE_REMOTE:-origin}"
+read -r -a release_tags <<<"${RELEASE_TAGS:?RELEASE_TAGS is required}"
+
+if [[ ! "$candidate_sha" =~ ^[0-9a-f]{40}$ ]]; then
+	echo "::error::RELEASE_SHA must be a full commit SHA" >&2
+	exit 1
+fi
+
+git cat-file -e "$candidate_sha^{commit}"
+main_sha="$(git ls-remote "$release_remote" refs/heads/main-v2 | awk 'NR == 1 { print $1 }')"
+if [ -z "$main_sha" ]; then
+	echo "::error::cannot resolve $release_remote/main-v2" >&2
+	exit 1
+fi
+git fetch --quiet --no-tags "$release_remote" refs/heads/main-v2
+if ! git merge-base --is-ancestor "$candidate_sha" "$main_sha"; then
+	echo "::error::approved candidate $candidate_sha is no longer on $release_remote/main-v2 history" >&2
+	exit 1
+fi
+
+for tag in "${release_tags[@]}"; do
+	if git ls-remote --exit-code --tags --refs "$release_remote" "refs/tags/$tag" >/dev/null 2>&1; then
+		echo "::error::target release tag already exists before creation: $tag" >&2
+		exit 1
+	fi
+done
+
+case "$mode" in
+preview)
+	if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-preview\.([1-9][0-9]*)$ ]]; then
+		echo "::error::Preview VERSION is invalid: $version" >&2
+		exit 1
+	fi
+	[ "${#release_tags[@]}" -eq 1 ] && [ "${release_tags[0]}" = "v$version" ] || {
+		echo "::error::Preview revalidation expects RELEASE_TAGS=v$version" >&2
+		exit 1
+	}
+	RELEASE_VERSION="$version" RELEASE_SHA="$candidate_sha" node <<'NODE'
+const catalog = require("./release-notes/releases.json");
+const release = catalog.releases.find((entry) => entry.version === process.env.RELEASE_VERSION);
+if (!release) throw new Error(`reviewed release notes for ${process.env.RELEASE_VERSION} are missing`);
+if (release.channel !== "prerelease" || release.status !== "reviewed") {
+  throw new Error(`${process.env.RELEASE_VERSION} must remain a reviewed Preview record`);
+}
+if (release.candidateSha && release.candidateSha !== process.env.RELEASE_SHA) {
+  throw new Error(`${process.env.RELEASE_VERSION} candidateSha no longer matches the approved SHA`);
+}
+NODE
+	;;
+stable)
+	if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+		echo "::error::Stable VERSION is invalid: $version" >&2
+		exit 1
+	fi
+	preview_version="${PREVIEW_VERSION:?PREVIEW_VERSION is required}"
+	preview_tag="${PREVIEW_TAG:?PREVIEW_TAG is required}"
+	[ "${#release_tags[@]}" -eq 3 ] || {
+		echo "::error::Stable revalidation expects three tags" >&2
+		exit 1
+	}
+	[ "${release_tags[0]}" = "v$version" ] &&
+		[ "${release_tags[1]}" = "npm-v$version" ] &&
+		[ "${release_tags[2]}" = "desktop-v$version" ] || {
+		echo "::error::Stable tags must be v$version npm-v$version desktop-v$version" >&2
+		exit 1
+	}
+	[ "$preview_tag" = "v$preview_version" ] || {
+		echo "::error::PREVIEW_TAG must equal v$PREVIEW_VERSION" >&2
+		exit 1
+	}
+	RELEASE_VERSION="$version" PREVIEW_VERSION="$preview_version" RELEASE_SHA="$candidate_sha" node <<'NODE'
+const catalog = require("./release-notes/releases.json");
+const release = catalog.releases.find((entry) => entry.version === process.env.RELEASE_VERSION);
+if (!release) throw new Error(`reviewed release notes for ${process.env.RELEASE_VERSION} are missing`);
+if (release.channel !== "stable" || release.status !== "reviewed") {
+  throw new Error(`${process.env.RELEASE_VERSION} must remain a reviewed Stable record`);
+}
+if (release.promotedFrom !== process.env.PREVIEW_VERSION) {
+  throw new Error(`${process.env.RELEASE_VERSION} promotedFrom no longer matches the approved Preview`);
+}
+if (release.candidateSha !== process.env.RELEASE_SHA) {
+  throw new Error(`${process.env.RELEASE_VERSION} candidateSha no longer matches the approved SHA`);
+}
+NODE
+	tag_sha="$(
+		git ls-remote --tags "$release_remote" "refs/tags/$preview_tag" "refs/tags/$preview_tag^{}" |
+			awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
+	)"
+	if [ -z "$tag_sha" ] || [ "$tag_sha" != "$candidate_sha" ]; then
+		echo "::error::$preview_tag resolves to ${tag_sha:-<missing>}, expected approved $candidate_sha" >&2
+		exit 1
+	fi
+	# Reject when a newer complete Preview for the same base version appeared.
+	highest_complete=0
+	while IFS= read -r ref; do
+		tag="${ref#refs/tags/}"
+		if [[ "$tag" =~ ^v${version//./\.}-preview\.([1-9][0-9]*)$ ]]; then
+			number="${BASH_REMATCH[1]}"
+			event_dir="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-revalidate-preview.XXXXXX")"
+			event_ok=false
+			if [ -n "${RELEASE_PREVIEW_EVENT_STORE:-}" ] &&
+				[ -f "$RELEASE_PREVIEW_EVENT_STORE/$tag/release-event.json" ]; then
+				cp "$RELEASE_PREVIEW_EVENT_STORE/$tag/release-event.json" "$event_dir/release-event.json"
+				event_ok=true
+			elif gh release download "$tag" --pattern release-event.json --dir "$event_dir" 2>/dev/null; then
+				event_ok=true
+			fi
+			tag_sha="$(
+				git ls-remote --tags "$release_remote" "refs/tags/$tag" "refs/tags/$tag^{}" |
+					awk '/\^\{\}$/ { print $1; found = 1; exit } NR == 1 { first = $1 } END { if (!found) print first }'
+			)"
+			if [ "$event_ok" = true ] &&
+				jq -e --arg sha "$tag_sha" --arg id "${tag#v}" '
+          .schemaVersion == 1 and
+          .releaseId == $id and
+          .channel == "preview" and
+          .candidateSha == $sha and
+          (.publishedAt | type == "string" and test("^\\d{4}-\\d{2}-\\d{2}T")) and
+          (.builds.cli | type == "string" and length > 0) and
+          (.builds.desktop | type == "string" and length > 0) and
+          (.builds.npm | type == "string" and length > 0)
+        ' "$event_dir/release-event.json" >/dev/null 2>&1; then
+				if [ "$number" -gt "$highest_complete" ]; then
+					highest_complete="$number"
+				fi
+			fi
+			rm -rf -- "$event_dir"
+		fi
+	done < <(git ls-remote --tags --refs "$release_remote" "refs/tags/v$version-preview.*" | awk '{ print $2 }')
+	approved_number="${preview_version##*-preview.}"
+	if [ "$highest_complete" -gt 0 ] && [ "$approved_number" -ne "$highest_complete" ]; then
+		echo "::error::$preview_tag is no longer the newest complete Preview for $version (latest complete is preview.$highest_complete); use Request preview recovery for incomplete tags" >&2
+		exit 1
+	fi
+	;;
+*)
+	echo "::error::unknown MODE: $mode" >&2
+	exit 1
+	;;
+esac
+
+echo "Revalidated $mode release candidate $version at $candidate_sha"

--- a/scripts/verify-desktop-release-manifest-assets.sh
+++ b/scripts/verify-desktop-release-manifest-assets.sh
@@ -12,7 +12,7 @@ fi
 entries="$(mktemp)"
 trap 'rm -f "$entries"' EXIT
 jq -er '
-	[.platforms, .native_packages, (.downloads // {})]
+	[(.platforms // {}), (.native_packages // {}), (.downloads // {})]
 	| map(to_entries)
 	| add[]
 	| [.value.url, .value.sha256, (.value.size | tostring)]

--- a/scripts/verify-preview-desktop-downloads.sh
+++ b/scripts/verify-preview-desktop-downloads.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Download and authenticate every Desktop payload referenced by a Preview manifest.
+set -euo pipefail
+
+manifest="${1:-}"
+download_dir="${2:-}"
+signature_verifier="${3:-}"
+
+if [ ! -f "$manifest" ] || [ ! -d "$download_dir" ] || [ ! -x "$signature_verifier" ]; then
+	echo "usage: $0 MANIFEST DOWNLOAD_DIRECTORY SIGNATURE_VERIFIER" >&2
+	exit 2
+fi
+if [ -n "$(find "$download_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+	echo "Preview download directory must be empty: $download_dir" >&2
+	exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entries="$(mktemp "${TMPDIR:-/tmp}/reasonix-preview-downloads.XXXXXX")"
+download_map="$(mktemp "${TMPDIR:-/tmp}/reasonix-preview-download-map.XXXXXX")"
+payload_names="$(mktemp "${TMPDIR:-/tmp}/reasonix-preview-payloads.XXXXXX")"
+cleanup_preview_download_metadata() {
+	rm -f -- "$entries" "$download_map" "$payload_names"
+}
+trap cleanup_preview_download_metadata EXIT
+
+jq -er '
+  [(.platforms // {}), (.native_packages // {}), (.downloads // {})]
+  | map(to_entries) | add[]
+  | [.value.url, .value.sig]
+  | @tsv
+' "$manifest" >"$entries"
+[ -s "$entries" ] || {
+	echo "::error::Preview manifest has no downloadable Desktop assets" >&2
+	exit 1
+}
+
+download_asset() {
+	local url="$1"
+	local name existing_url status
+	name="${url##*/}"
+	if [[ ! "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+		echo "::error::Preview manifest has an unsafe asset URL: $url" >&2
+		exit 1
+	fi
+	existing_url="$(awk -F '\t' -v name="$name" '$1 == name { print $2; exit }' "$download_map")"
+	if [ -n "$existing_url" ]; then
+		if [ "$existing_url" != "$url" ]; then
+			echo "::error::Preview manifest maps multiple URLs to asset name $name" >&2
+			exit 1
+		fi
+		return
+	fi
+	if ! status="$(curl --fail --location --silent --show-error \
+		--output "$download_dir/$name" --write-out '%{http_code}' "$url")"; then
+		echo "::error::Preview asset download failed: $url" >&2
+		exit 1
+	fi
+	if [ "$status" != "200" ] || [ ! -s "$download_dir/$name" ]; then
+		echo "::error::Preview asset download failed or was empty (HTTP $status): $url" >&2
+		exit 1
+	fi
+	printf '%s\t%s\n' "$name" "$url" >>"$download_map"
+}
+
+while IFS=$'\t' read -r url signature_url; do
+	[ -n "$url" ] && [ -n "$signature_url" ] || {
+		echo "::error::Preview manifest contains an empty payload or signature URL" >&2
+		exit 1
+	}
+	if [ "$signature_url" != "$url.minisig" ]; then
+		echo "::error::Preview signature URL does not match payload URL: $url" >&2
+		exit 1
+	fi
+	download_asset "$url"
+	download_asset "$signature_url"
+	printf '%s\n' "${url##*/}" >>"$payload_names"
+done <"$entries"
+
+bash "$script_dir/verify-desktop-release-manifest-assets.sh" "$manifest" "$download_dir"
+sort -u "$payload_names" -o "$payload_names"
+while IFS= read -r payload_name; do
+	"$signature_verifier" verify "$download_dir/$payload_name"
+done <"$payload_names"
+
+echo "Preview Desktop payload hashes, sizes, and signatures verified"

--- a/scripts/verify-preview-release-artifacts.sh
+++ b/scripts/verify-preview-release-artifacts.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Verify the immutable Preview event and every public product surface before promotion.
+set -euo pipefail
+
+repository="${RELEASE_REPOSITORY:?RELEASE_REPOSITORY is required}"
+preview_tag="${PREVIEW_TAG:?PREVIEW_TAG is required}"
+expected_sha="${EXPECTED_SHA:?EXPECTED_SHA is required}"
+r2_base="${R2_BASE:-https://dl.reasonix.io}"
+gateway_base="${GATEWAY_BASE:-https://crash.reasonix.io/v1/desktop/releases}"
+# Daily promotion uses immutable markers and metadata proofs. Set
+# PREVIEW_FULL_DOWNLOAD_CHECK=true for the first production cutover.
+full_download_check="${PREVIEW_FULL_DOWNLOAD_CHECK:-false}"
+
+if [[ ! "$preview_tag" =~ ^v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))-preview\.([1-9][0-9]*)$ ]]; then
+	echo "::error::PREVIEW_TAG must be vMAJOR.MINOR.PATCH-preview.N" >&2
+	exit 1
+fi
+base_version="${BASH_REMATCH[1]}"
+preview_number="${BASH_REMATCH[5]}"
+preview_version="${preview_tag#v}"
+npm_version="$base_version-canary.$preview_number"
+desktop_version="desktop-$preview_tag"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/reasonix-preview-proof.XXXXXX")"
+cleanup() {
+	case "$tmp_dir" in
+	*/reasonix-preview-proof.*) rm -r -- "$tmp_dir" ;;
+	*) echo "refusing to clean unexpected Preview proof directory: $tmp_dir" >&2 ;;
+	esac
+}
+trap cleanup EXIT
+
+gh release view "$preview_tag" --repo "$repository" \
+	--json isDraft,isPrerelease,assets >"$tmp_dir/release.json"
+jq -e '
+  .isDraft == false and .isPrerelease == true and
+  ([.assets[].name] as $names |
+    ["SHA256SUMS", "release-event.json", "reasonix-darwin-amd64.tar.gz",
+     "reasonix-darwin-arm64.tar.gz", "reasonix-linux-amd64.tar.gz",
+     "reasonix-linux-arm64.tar.gz", "reasonix-windows-amd64.zip",
+     "reasonix-windows-arm64.zip"] |
+    all(. as $required | $names | index($required)))
+' "$tmp_dir/release.json" >/dev/null
+
+gh release download "$preview_tag" --repo "$repository" \
+	--pattern SHA256SUMS --pattern release-event.json --dir "$tmp_dir"
+node scripts/release-event.mjs validate \
+	--version "$preview_version" --input "$tmp_dir/release-event.json"
+jq -e --arg sha "$expected_sha" '.candidateSha == $sha and .channel == "preview"' \
+	"$tmp_dir/release-event.json" >/dev/null
+
+# Require GitHub asset digests to match SHA256SUMS for every required archive.
+while IFS= read -r line; do
+	hash="${line%%  *}"
+	name="${line#*  }"
+	[ -n "$hash" ] && [ -n "$name" ] || continue
+	if [[ ! "$hash" =~ ^[0-9a-f]{64}$ ]]; then
+		echo "::error::SHA256SUMS contains a non-sha256 digest for $name" >&2
+		exit 1
+	fi
+	digest="$(
+		jq -r --arg name "$name" '
+      .assets[] | select(.name == $name) | (.digest // empty)
+    ' "$tmp_dir/release.json"
+	)"
+	if [ -z "$digest" ]; then
+		echo "::error::CLI asset $name is missing a GitHub digest" >&2
+		exit 1
+	fi
+	expected_digest="sha256:$hash"
+	if [ "$digest" != "$expected_digest" ]; then
+		echo "::error::CLI asset $name digest $digest does not match SHA256SUMS $expected_digest" >&2
+		exit 1
+	fi
+done <"$tmp_dir/SHA256SUMS"
+
+for asset in \
+	SHA256SUMS \
+	reasonix-darwin-amd64.tar.gz \
+	reasonix-darwin-arm64.tar.gz \
+	reasonix-linux-amd64.tar.gz \
+	reasonix-linux-arm64.tar.gz \
+	reasonix-windows-amd64.zip \
+	reasonix-windows-arm64.zip; do
+	grep -Eq "  ${asset//./\\.}$" "$tmp_dir/SHA256SUMS" || {
+		echo "::error::SHA256SUMS is missing required asset $asset" >&2
+		exit 1
+	}
+done
+
+npm view "reasonix@$npm_version" \
+	version gitHead reasonixCandidateSha optionalDependencies --json >"$tmp_dir/npm-root.json"
+jq -e --arg version "$npm_version" --arg sha "$expected_sha" '
+  .version == $version and .gitHead == $sha and .reasonixCandidateSha == $sha and
+  (.optionalDependencies | type == "object" and length == 6 and
+   all(to_entries[]; .value == $version))
+' "$tmp_dir/npm-root.json" >/dev/null
+while IFS= read -r package_name; do
+	npm view "$package_name@$npm_version" version gitHead reasonixCandidateSha --json \
+		>"$tmp_dir/npm-package.json"
+	jq -e --arg version "$npm_version" --arg sha "$expected_sha" '
+    .version == $version and .gitHead == $sha and .reasonixCandidateSha == $sha
+  ' "$tmp_dir/npm-package.json" >/dev/null
+done < <(jq -r '.optionalDependencies | keys[]' "$tmp_dir/npm-root.json")
+
+first_manifest=""
+urls_file="$tmp_dir/urls.txt"
+: >"$urls_file"
+for entry in \
+	"preview|$r2_base/preview/latest.json" \
+	"canary|$r2_base/canary/latest.json" \
+	"gateway|$gateway_base/preview/latest.json" \
+	"immutable|$r2_base/$desktop_version/latest.json"; do
+	label="${entry%%|*}"
+	url="${entry#*|}"
+	manifest="$tmp_dir/$label.json"
+	status="$(curl -sSLo "$manifest" -w '%{http_code}' "$url")"
+	[ "$status" = "200" ] || {
+		echo "::error::$label Preview manifest returned HTTP $status" >&2
+		exit 1
+	}
+	jq -e --arg version "v$preview_version" '
+    .version == $version and
+    ((.platforms // {}) + (.native_packages // {}) + (.downloads // {})) as $items |
+    ($items | length) > 0 and
+    all($items[];
+      (.url | type == "string" and length > 0) and
+      (.sig | type == "string" and length > 0) and
+      (.sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+      (.size | type == "number" and . > 0))
+  ' "$manifest" >/dev/null
+	jq -r '
+    ((.platforms // {}) + (.native_packages // {}) + (.downloads // {}))[] |
+    .url, .sig
+  ' "$manifest" >>"$urls_file"
+	if [ -z "$first_manifest" ]; then
+		first_manifest="$manifest"
+	else
+		cmp -s "$first_manifest" "$manifest" || {
+			echo "::error::$label Preview manifest differs from the immutable manifest" >&2
+			exit 1
+		}
+	fi
+done
+
+[ -s "$urls_file" ] || {
+	echo "::error::Preview manifest URL extraction is empty" >&2
+	exit 1
+}
+sort -u "$urls_file" -o "$urls_file"
+while IFS= read -r url; do
+	[ -n "$url" ] || {
+		echo "::error::Preview manifest contains an empty asset URL" >&2
+		exit 1
+	}
+	if [ "$full_download_check" = "true" ]; then
+		status="$(curl -sSLo /dev/null -w '%{http_code}' "$url")"
+	else
+		status="$(curl -sSIL -o /dev/null -w '%{http_code}' "$url")"
+	fi
+	[ "$status" = "200" ] || {
+		echo "::error::Preview asset returned HTTP $status: $url" >&2
+		exit 1
+	}
+done <"$urls_file"
+
+echo "Preview public proof verified: $preview_tag at $expected_sha"

--- a/scripts/verify-preview-release-artifacts.sh
+++ b/scripts/verify-preview-release-artifacts.sh
@@ -11,6 +11,11 @@ gateway_base="${GATEWAY_BASE:-https://crash.reasonix.io/v1/desktop/releases}"
 # PREVIEW_FULL_DOWNLOAD_CHECK=true for the first production cutover.
 full_download_check="${PREVIEW_FULL_DOWNLOAD_CHECK:-false}"
 
+if [ "$full_download_check" != "true" ] && [ "$full_download_check" != "false" ]; then
+	echo "::error::PREVIEW_FULL_DOWNLOAD_CHECK must be true or false" >&2
+	exit 1
+fi
+
 if [[ ! "$preview_tag" =~ ^v((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))-preview\.([1-9][0-9]*)$ ]]; then
 	echo "::error::PREVIEW_TAG must be vMAJOR.MINOR.PATCH-preview.N" >&2
 	exit 1
@@ -148,20 +153,25 @@ done
 	exit 1
 }
 sort -u "$urls_file" -o "$urls_file"
-while IFS= read -r url; do
-	[ -n "$url" ] || {
-		echo "::error::Preview manifest contains an empty asset URL" >&2
-		exit 1
-	}
-	if [ "$full_download_check" = "true" ]; then
-		status="$(curl -sSLo /dev/null -w '%{http_code}' "$url")"
-	else
+if [ "$full_download_check" = "true" ]; then
+	desktop_assets="$tmp_dir/desktop-assets"
+	signature_verifier="$tmp_dir/reasonix-desktop-sign"
+	mkdir -p "$desktop_assets"
+	go -C desktop build -o "$signature_verifier" ./cmd/sign
+	bash scripts/verify-preview-desktop-downloads.sh \
+		"$first_manifest" "$desktop_assets" "$signature_verifier"
+else
+	while IFS= read -r url; do
+		[ -n "$url" ] || {
+			echo "::error::Preview manifest contains an empty asset URL" >&2
+			exit 1
+		}
 		status="$(curl -sSIL -o /dev/null -w '%{http_code}' "$url")"
-	fi
-	[ "$status" = "200" ] || {
-		echo "::error::Preview asset returned HTTP $status: $url" >&2
-		exit 1
-	}
-done <"$urls_file"
+		[ "$status" = "200" ] || {
+			echo "::error::Preview asset returned HTTP $status: $url" >&2
+			exit 1
+		}
+	done <"$urls_file"
+fi
 
 echo "Preview public proof verified: $preview_tag at $expected_sha"

--- a/scripts/verify-preview-soak.mjs
+++ b/scripts/verify-preview-soak.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function verifyPreviewSoak(event, { now = Date.now(), minimumHours = 24, allowEarly = false } = {}) {
+  invariant(event?.channel === "preview", "source release event must be Preview");
+  const publishedAt = Date.parse(event.publishedAt);
+  invariant(Number.isFinite(publishedAt), "source Preview publishedAt must be a valid ISO timestamp");
+  invariant(publishedAt <= now, "source Preview publishedAt cannot be in the future");
+  const ageMs = now - publishedAt;
+  const minimumMs = minimumHours * 60 * 60 * 1000;
+  invariant(allowEarly || ageMs >= minimumMs, `source Preview is only ${(ageMs / 3_600_000).toFixed(2)}h old; ${minimumHours}h is required`);
+  return { publishedAt: event.publishedAt, ageHours: ageMs / 3_600_000 };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const inputIndex = args.indexOf("--input");
+  invariant(inputIndex >= 0 && args[inputIndex + 1], "--input is required");
+  const hoursIndex = args.indexOf("--minimum-hours");
+  const minimumHours = hoursIndex >= 0 ? Number(args[hoursIndex + 1]) : 24;
+  invariant(Number.isFinite(minimumHours) && minimumHours >= 0, "--minimum-hours must be non-negative");
+  const event = JSON.parse(await readFile(resolve(args[inputIndex + 1]), "utf8"));
+  const result = verifyPreviewSoak(event, {
+    minimumHours,
+    allowEarly: args.includes("--allow-early"),
+    now: process.env.NOW_EPOCH_MS ? Number(process.env.NOW_EPOCH_MS) : Date.now(),
+  });
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(process.env.GITHUB_OUTPUT, `source_published_at=${result.publishedAt}\npreview_age_hours=${result.ageHours.toFixed(2)}\n`);
+  }
+  console.log(`Preview soak verified: ${result.ageHours.toFixed(2)}h${args.includes("--allow-early") ? " (emergency override)" : ""}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`verify-preview-soak: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-release-authorization.sh
+++ b/scripts/verify-release-authorization.sh
@@ -50,7 +50,7 @@ push)
 		exit 1
 	fi
 	;;
-workflow_dispatch)
+workflow_dispatch | workflow_run)
 	expected_ref="refs/heads/main-v2"
 	if [ "$caller_workflow_sha" != "$caller_sha" ]; then
 		echo "::error::recovery caller workflow SHA is $caller_workflow_sha, expected protected main-v2 SHA $caller_sha" >&2

--- a/scripts/verify-release-ci.mjs
+++ b/scripts/verify-release-ci.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+export function verifyReleaseCI(runs, sha) {
+  invariant(/^[0-9a-f]{40}$/.test(sha), "candidate SHA must be a full commit SHA");
+  invariant(Array.isArray(runs), "CI run input must be an array");
+  const matching = runs
+    .filter((run) => run.headSha === sha && run.headBranch === "main-v2" && run.event === "push")
+    .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+  invariant(matching.length > 0, `no main-v2 push CI run exists for ${sha}`);
+  const latest = matching[0];
+  invariant(latest.status === "completed" && latest.conclusion === "success", `latest CI run for ${sha} is ${latest.status}/${latest.conclusion || "none"}`);
+  return latest;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const inputIndex = args.indexOf("--input");
+  const shaIndex = args.indexOf("--sha");
+  invariant(inputIndex >= 0 && args[inputIndex + 1], "--input is required");
+  invariant(shaIndex >= 0 && args[shaIndex + 1], "--sha is required");
+  const runs = JSON.parse(await readFile(resolve(args[inputIndex + 1]), "utf8"));
+  const run = verifyReleaseCI(runs, args[shaIndex + 1]);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `ci_run_id=${run.databaseId}\nci_run_url=${run.url}\n`);
+  }
+  console.log(`Release CI verified: ${run.url || run.databaseId}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`verify-release-ci: ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Stage-1 infrastructure for the planned Preview → Stable same-SHA promotion path.

This PR does **not** activate production release entrypoints:

- Active `release-preview.yml` and `release-stable.yml` remain the legacy tag + relay path (byte-identical to `main-v2` for those workflows).
- Human Preview/Stable tag relays still dispatch; only the future `reasonix-release-tagger[bot]` actor is skipped to avoid a duplicate orchestrator later.
- Stage-3 activation workflows live only under `docs/releasing/stage3-workflows/` and are not loaded by Actions.

### What lands

- Release Notes / release-event compatibility: optional `promote_from` / `promotedFrom` + required `candidateSha`, optional Stable `promotion` metadata.
- Helper scripts: promotion selection, exact-SHA CI, 24h soak, Preview public proof, atomic tags, post-approval revalidation, request-artifact trust boundary, activation cutoff.
- Read-only **Shadow validate stable promotion** workflow.
- App-aware but human-compatible tag relays.
- Contract tests and CI actionlint coverage for active release workflows.
- Phased rollout notes in `docs/RELEASING.md`.

### Explicit non-goals (later stages)

- One-input Preview / zero-input Stable production entrypoints
- App-created tags after environment approval
- Blocking human Preview/Stable tag creation
- Filling `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA` (config-only commit after this merge)
- Publishing the updated `reasonix-develop` skill

### Suggested follow-up order

1. Merge this Stage-1 PR.
2. Config-only commit: set `DEFAULT_MIN_PROMOTION_CANDIDATE_SHA` to this merge SHA.
3. Configure App, environment secrets, and dual create rules.
4. Publish a post-cutoff Preview; prepare Stable notes with `promote_from`.
5. After ≥24h, run shadow validation.
6. Same change window: Stage-3 activation + App-only tag rules.
7. Zero-input Stable and independent postflight.

## Test plan

- [x] `node --test scripts/release-notes.test.mjs` (9 pass)
- [x] `bash scripts/release-workflows.test.sh` (PASS)
- [x] `actionlint` on active release workflows (PASS)
- [x] `git diff --check` (PASS)
- [x] Confirm active `release-preview.yml` / `release-stable.yml` match `origin/main-v2`
- [ ] CI green on this PR
- [ ] After merge: optional Stage-1b cutoff SHA config commit only
