### PR TITLE
fix(acp): 合并 session/update chunk，缓解 VS Code 聊天卡死 (#7193)

### DIFF
--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -132,6 +132,12 @@ audio are not advertised. During a turn, Reasonix may send:
 - `session/request_permission` requests for permission-gated tools and user
   questions.
 
+Consecutive `agent_message_chunk` / `agent_thought_chunk` notifications are
+coalesced (up to a small byte budget) so hosts that rebuild their UI on every
+`session/update` are less likely to freeze under token-stream load.
+`session/load` also applies a tighter display clip to replayed tool results;
+prefer `session/resume` when the host already has a transcript view.
+
 Hosts should keep the `session/prompt` request open until Reasonix returns its
 stop reason, while continuing to process requests and notifications in both
 directions.

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -121,6 +121,11 @@ Reasonix 把互不相关的选择拆成独立控制轴，而不是混在一个 m
 - 当前 mode 和配置项更新；
 - 针对受权限控制工具及用户问题的 `session/request_permission` 请求。
 
+连续的 `agent_message_chunk` / `agent_thought_chunk` 会在小字节预算内合并发送，减轻
+在每条 `session/update` 上都全量重绘 UI 的 Host（如 VS Code webview）在 token 流下卡死
+的风险。`session/load` 回放工具结果时也会使用更紧的展示裁剪；若 Host 已有 transcript
+视图，优先使用 `session/resume`。
+
 Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止原因；期间仍需同时处理
 双向 request 和 notification。
 

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -31,6 +31,20 @@ type notifier interface {
 // dispatch.ts (the full result still goes to the model; this is display only).
 const maxResultChars = 8000
 
+// maxReplayResultChars is a tighter display clip used when session/load replays
+// history. Hosts that rebuild their full UI on every session/update (notably the
+// VS Code webview) can freeze or blank a workspace when a long git-review
+// transcript is replayed at the live 8 KiB clip; the model still sees the full
+// on-disk tool output on subsequent turns.
+const maxReplayResultChars = 2000
+
+// chunkCoalesceMaxBytes merges consecutive agent_message_chunk /
+// agent_thought_chunk notifications until this many bytes are buffered, a
+// different update kind arrives, or the turn ends. Provider streams often emit
+// one token per event; without coalescing, ACP hosts that full-rerender on each
+// session/update can busy-loop the UI thread (see #7193).
+const chunkCoalesceMaxBytes = 512
+
 // updateSink is an event.Sink bound to one session that maps the agent's typed
 // event stream onto ACP session/update notifications. It is the v2 counterpart of
 // main's dispatchKernelEvent: where main translated kernel events, we translate
@@ -58,6 +72,11 @@ type updateSink struct {
 	status  func(event.Event)
 	mu      sync.Mutex
 	turnCtx context.Context
+	// pendingKind / pendingText coalesce consecutive Text/Reasoning chunks.
+	// Only Emit and flushPending touch these; the agent calls Emit serially and
+	// flushPending runs after the turn (or before a non-chunk update).
+	pendingKind string
+	pendingText strings.Builder
 }
 
 func newUpdateSink(conn notifier, sessionID string) *updateSink {
@@ -94,6 +113,9 @@ func (s *updateSink) setTurnContext(ctx context.Context) {
 }
 
 func (s *updateSink) clearTurnContext() {
+	// Flush any coalesced text/thought before dropping the turn context so the
+	// host sees the final tokens before session/prompt's stopReason.
+	s.flushPending()
 	s.mu.Lock()
 	s.turnCtx = nil
 	s.mu.Unlock()
@@ -110,23 +132,17 @@ func (s *updateSink) currentTurnContext() context.Context {
 }
 
 // Emit implements event.Sink. The agent calls it serially (see event.Sink), so no
-// locking is needed; write serialization lives in Conn.
+// locking is needed for the coalesce buffer; write serialization lives in Conn.
 func (s *updateSink) Emit(e event.Event) {
 	if s.status != nil {
 		s.status(e)
 	}
 	switch e.Kind {
 	case event.Reasoning:
-		if e.Text == "" {
-			return
-		}
-		s.send(messageChunk{SessionUpdate: "agent_thought_chunk", Content: textBlock(e.Text)})
+		s.queueChunk("agent_thought_chunk", e.Text)
 
 	case event.Text:
-		if e.Text == "" {
-			return
-		}
-		s.send(messageChunk{SessionUpdate: "agent_message_chunk", Content: textBlock(e.Text)})
+		s.queueChunk("agent_message_chunk", e.Text)
 
 	case event.ToolDispatch:
 		// Skip the early (Partial) dispatch and later same-ID preview refresh: ACP
@@ -134,6 +150,7 @@ func (s *updateSink) Emit(e event.Event) {
 		if e.Tool.Partial || e.Tool.Refreshed {
 			return
 		}
+		s.flushPending()
 		// todo_write is the agent's task list; mirror it as an ACP plan update so
 		// the client renders structured progress alongside the tool_call.
 		if e.Tool.Name == "todo_write" {
@@ -152,6 +169,7 @@ func (s *updateSink) Emit(e event.Event) {
 		})
 
 	case event.ToolResult:
+		s.flushPending()
 		status := "completed"
 		text := e.Tool.Output
 		if e.Tool.Err != "" {
@@ -169,6 +187,7 @@ func (s *updateSink) Emit(e event.Event) {
 		// Surface warnings to the host as a message chunk so they're not lost;
 		// info-level notices stay out of band.
 		if e.Level == event.LevelWarn && e.Text != "" {
+			s.flushPending()
 			s.send(messageChunk{
 				SessionUpdate: "agent_message_chunk",
 				Content:       textBlock("\n\n[warning] " + e.Text),
@@ -179,6 +198,7 @@ func (s *updateSink) Emit(e event.Event) {
 		// ACP has no compaction-card concept; surface a one-line note so the host
 		// knows the context was summarized (an aborted pass has no summary).
 		if e.Compaction.Summary != "" {
+			s.flushPending()
 			s.send(messageChunk{
 				SessionUpdate: "agent_message_chunk",
 				Content:       textBlock(fmt.Sprintf("\n\n[compacted %d earlier messages to save context]", e.Compaction.Messages)),
@@ -189,6 +209,7 @@ func (s *updateSink) Emit(e event.Event) {
 		// The run loop is now blocked awaiting Approve(id, …). Do the
 		// client round-trip off the emit goroutine so Emit returns at once
 		// (the agent emits serially); the answer unblocks the loop.
+		s.flushPending()
 		turnCtx := s.currentTurnContext()
 		go s.requestPermission(turnCtx, e.Approval)
 
@@ -196,9 +217,38 @@ func (s *updateSink) Emit(e event.Event) {
 		// ACP has no separate "ask the user a business question" method. Reuse
 		// the standard permission round-trip with the question options as choices;
 		// clients such as Zed already know how to render this interaction.
+		s.flushPending()
 		turnCtx := s.currentTurnContext()
 		go s.requestAsk(turnCtx, e.Ask)
 	}
+}
+
+// queueChunk appends a text/thought delta into the coalesce buffer, flushing when
+// the kind changes or the byte budget is reached.
+func (s *updateSink) queueChunk(kind, text string) {
+	if text == "" {
+		return
+	}
+	if s.pendingKind != "" && s.pendingKind != kind {
+		s.flushPending()
+	}
+	s.pendingKind = kind
+	s.pendingText.WriteString(text)
+	if s.pendingText.Len() >= chunkCoalesceMaxBytes {
+		s.flushPending()
+	}
+}
+
+// flushPending sends any buffered agent_message_chunk / agent_thought_chunk.
+func (s *updateSink) flushPending() {
+	if s.pendingKind == "" || s.pendingText.Len() == 0 {
+		s.pendingKind = ""
+		s.pendingText.Reset()
+		return
+	}
+	s.send(messageChunk{SessionUpdate: s.pendingKind, Content: textBlock(s.pendingText.String())})
+	s.pendingKind = ""
+	s.pendingText.Reset()
 }
 
 func (s *updateSink) send(update any) {
@@ -250,7 +300,7 @@ func (s *updateSink) replay(msgs []provider.Message) {
 				SessionUpdate: "tool_call_update",
 				ToolCallID:    m.ToolCallID,
 				Status:        "completed",
-				Content:       []toolContent{{Type: "content", Content: textBlock(clip(m.Content))}},
+				Content:       []toolContent{{Type: "content", Content: textBlock(clipN(m.Content, maxReplayResultChars))}},
 			})
 		}
 	}
@@ -460,10 +510,15 @@ func rawJSON(args string) json.RawMessage {
 
 // clip truncates text to maxResultChars, appending a note, matching dispatch.ts.
 func clip(text string) string {
-	if len(text) <= maxResultChars {
+	return clipN(text, maxResultChars)
+}
+
+// clipN truncates text to limit bytes (UTF-8 safe), appending a note.
+func clipN(text string, limit int) string {
+	if limit <= 0 || len(text) <= limit {
 		return text
 	}
-	end := maxResultChars
+	end := limit
 	for end > 0 && !utf8.ValidString(text[:end]) {
 		end--
 	}

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -675,3 +675,100 @@ func TestClip(t *testing.T) {
 		t.Errorf("clip note missing: %q", got[len(got)-40:])
 	}
 }
+
+func TestUpdateSinkCoalescesConsecutiveTextChunks(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+
+	sink.Emit(event.Event{Kind: event.Text, Text: "Hel"})
+	sink.Emit(event.Event{Kind: event.Text, Text: "lo"})
+	sink.Emit(event.Event{Kind: event.Text, Text: "!"})
+	if got := len(fn.notifs); got != 0 {
+		t.Fatalf("buffered text flushed early: %d notifications", got)
+	}
+
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: "c1", Name: "bash", Args: `{"command":"git status"}`,
+	}})
+	if got := len(fn.notifs); got != 2 {
+		t.Fatalf("after tool dispatch got %d notifications, want 1 message + 1 tool_call", got)
+	}
+	u := fn.updateMap(t, 0)
+	if u["sessionUpdate"] != "agent_message_chunk" {
+		t.Fatalf("update 0 = %v, want agent_message_chunk", u["sessionUpdate"])
+	}
+	if content, _ := u["content"].(map[string]any); content["text"] != "Hello!" {
+		t.Fatalf("coalesced text = %v, want Hello!", content["text"])
+	}
+}
+
+func TestUpdateSinkFlushesCoalesceOnKindChangeAndTurnEnd(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+
+	sink.Emit(event.Event{Kind: event.Reasoning, Text: "plan"})
+	sink.Emit(event.Event{Kind: event.Text, Text: "do it"})
+	if got := len(fn.notifs); got != 1 {
+		t.Fatalf("kind change should flush thought first: got %d", got)
+	}
+	if u := fn.updateMap(t, 0); u["sessionUpdate"] != "agent_thought_chunk" {
+		t.Fatalf("update 0 = %v, want agent_thought_chunk", u["sessionUpdate"])
+	}
+
+	sink.clearTurnContext()
+	if got := len(fn.notifs); got != 2 {
+		t.Fatalf("turn end should flush message: got %d", got)
+	}
+	u := fn.updateMap(t, 1)
+	if u["sessionUpdate"] != "agent_message_chunk" {
+		t.Fatalf("update 1 = %v, want agent_message_chunk", u["sessionUpdate"])
+	}
+	if content, _ := u["content"].(map[string]any); content["text"] != "do it" {
+		t.Fatalf("flushed text = %v", content)
+	}
+}
+
+func TestUpdateSinkCoalesceFlushesAtByteBudget(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+
+	chunk := strings.Repeat("a", chunkCoalesceMaxBytes/2)
+	sink.Emit(event.Event{Kind: event.Text, Text: chunk})
+	if got := len(fn.notifs); got != 0 {
+		t.Fatalf("under-budget chunk flushed early: %d", got)
+	}
+	sink.Emit(event.Event{Kind: event.Text, Text: chunk})
+	if got := len(fn.notifs); got != 1 {
+		t.Fatalf("at-budget coalesce should flush once, got %d", got)
+	}
+	u := fn.updateMap(t, 0)
+	if content, _ := u["content"].(map[string]any); content["text"] != chunk+chunk {
+		t.Fatalf("budget flush text len = %d, want %d", len(content["text"].(string)), len(chunk)*2)
+	}
+}
+
+func TestUpdateSinkReplayClipsToolResultsTightly(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+	long := strings.Repeat("d", maxReplayResultChars+25)
+	sink.replay([]provider.Message{{
+		Role:       provider.RoleTool,
+		ToolCallID: "c1",
+		Content:    long,
+	}})
+
+	u := fn.updateMap(t, 0)
+	arr, _ := u["content"].([]any)
+	wrap, _ := arr[0].(map[string]any)
+	inner, _ := wrap["content"].(map[string]any)
+	got, _ := inner["text"].(string)
+	if !strings.HasPrefix(got, strings.Repeat("d", maxReplayResultChars)) {
+		t.Fatalf("replay clip did not keep the head")
+	}
+	if !strings.Contains(got, "25 more chars truncated") {
+		t.Fatalf("replay clip note missing: %q", got[len(got)-50:])
+	}
+	if strings.Contains(got, strings.Repeat("d", maxResultChars)) {
+		t.Fatal("replay used the live clip budget instead of the tighter replay budget")
+	}
+}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -280,7 +280,9 @@ type SessionLoadParams struct {
 }
 
 // SessionLoadResult is the empty ack; the conversation has already arrived as a
-// burst of session/update notifications by the time it is sent.
+// burst of session/update notifications by the time it is sent. Replayed tool
+// results use a tighter display clip than live turns so hosts that full-rerender
+// on every update are less likely to freeze on long transcripts.
 type SessionLoadResult struct {
 	Models        *SessionModelState    `json:"models,omitempty"`
 	Modes         *SessionModeState     `json:"modes,omitempty"`


### PR DESCRIPTION
## Summary
- 在 ACP `updateSink` 中合并连续的 `agent_message_chunk` / `agent_thought_chunk`（按字节预算，并在工具调用、审批、回合结束时刷新），降低 token 流对 Host UI 的刷新风暴。
- `session/load` 回放工具结果改用更紧的展示裁剪（2000 字符），减轻长会话（尤其是 git review）全量重绘时的卡死/白屏风险。
- 补充单测，并更新 ACP 中英文文档说明 Host 侧应优先 `session/resume`、避免对每条 update 全量重绘。

Fixes https://github.com/esengine/DeepSeek-Reasonix/issues/7193

## 背景
Issue #7193：在 VS Code 中连接 Reasonix 并处理仓库变更/提交类任务后，窗口可 100% 卡死；反复复现后 inotify 耗尽；重启后**仅该工作区**聊天视图永久空白。CLI 正常。根因更接近 Host 对每条 `session/update` 做全量 `stateSnapshot` + DOM 重建，被细粒度 token 流与长 transcript 回放放大；本 PR 从 agent 侧降低通知洪峰。

## Test plan
- [x] `go test ./internal/acp/ -count=1`
- [ ] 用 VS Code 扩展连接本地构建的 `reasonix acp`，多轮对话（含 `git status`/`git diff`）确认窗口保持可响应
- [ ] 对已有长会话执行 `session/load`，确认回放不再轻易卡死；空白工作区可新建会话或 `session/resume` 恢复
- [ ] 确认工具结果展示仍可读，模型侧仍使用完整工具输出

Cache-impact: none — 仅调整 ACP 对外 session/update 通知的合并与展示裁剪，不改动 system prompt、工具 schema 或 provider 请求前缀。
Cache-guard: n/a