### PR TITLE
 fix(cli): rewind picker shows real user prompts and stays within viewport

### DIFF
--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -939,6 +939,60 @@ func TestModalPanelsHideComposerBox(t *testing.T) {
 	}
 }
 
+// TestRewindPickerWindowsLongSession verifies the Esc-Esc turn list windows
+// long sessions (one row per turn) so the overlay cannot outgrow the terminal:
+// at most quickPickerMaxVisible rows render, with ↑/↓ more markers pointing at
+// the hidden turns and the window following the selection.
+func TestRewindPickerWindowsLongSession(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+
+	metas := make([]checkpoint.Meta, 12)
+	for i := range metas {
+		metas[i] = checkpoint.Meta{Turn: i, Prompt: fmt.Sprintf("turn %d", i)}
+	}
+
+	// Newest turn selected (default): window shows rows 4..11.
+	m.rewind = &rewindPicker{metas: metas, sel: 11}
+	card := m.renderRewind()
+	if !strings.Contains(card, "↑ more") {
+		t.Fatalf("newest selection should show ↑ more: %q", card)
+	}
+	if strings.Contains(card, "↓ more") {
+		t.Fatalf("newest selection must not show ↓ more: %q", card)
+	}
+	if !strings.Contains(card, "turn 11") || strings.Contains(card, "turn 0") {
+		t.Fatalf("window must cover rows 4..11, got: %q", card)
+	}
+
+	// Oldest turn selected: window shows rows 0..7.
+	m.rewind = &rewindPicker{metas: metas, sel: 0}
+	card = m.renderRewind()
+	if !strings.Contains(card, "↓ more") {
+		t.Fatalf("oldest selection should show ↓ more: %q", card)
+	}
+	if strings.Contains(card, "↑ more") {
+		t.Fatalf("oldest selection must not show ↑ more: %q", card)
+	}
+	if !strings.Contains(card, "turn 0") || strings.Contains(card, "turn 11") {
+		t.Fatalf("window must cover rows 0..7, got: %q", card)
+	}
+
+	// Short session (≤8 turns): every row visible, no markers.
+	m.rewind = &rewindPicker{metas: metas[:4], sel: 0}
+	card = m.renderRewind()
+	if strings.Contains(card, "more") {
+		t.Fatalf("short session must not show more markers: %q", card)
+	}
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(card, fmt.Sprintf("turn %d", i)) {
+			t.Fatalf("short session row %d missing: %q", i, card)
+		}
+	}
+}
+
 func TestApprovalChoicesPreserveDecisionSemantics(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cli/rewind.go
+++ b/internal/cli/rewind.go
@@ -157,8 +157,18 @@ func (m chatTUI) renderRewind() string {
 	var b strings.Builder
 	if r.stage == 0 {
 		b.WriteString(accent(i18n.M.RewindPickTitle) + "\n")
-		for i, meta := range r.metas {
+		// Long sessions list one row per turn; window it like quickPicker so
+		// the overlay never outgrows the terminal (no scrolling viewport).
+		start, end := quickPickerWindow(len(r.metas), r.sel)
+		if start > 0 {
+			b.WriteString(dim("  ↑ more") + "\n")
+		}
+		for i := start; i < end; i++ {
+			meta := r.metas[i]
 			b.WriteString(rowLine(i == r.sel, meta.Turn+1, "", turnLabel(meta, w), false) + "\n")
+		}
+		if end < len(r.metas) {
+			b.WriteString(dim("  ↓ more") + "\n")
 		}
 		b.WriteString(dim(i18n.M.RewindPickHint))
 		return choicePanelStyle.Width(w).Render(b.String())

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -112,7 +112,11 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	defer c.recordDisplayForNewUser(startMessages, display)
-	c.beginCheckpoint(input)
+	// The checkpoint prompt labels the turn in the rewind picker (and is
+	// prefilled into the composer after a conversation rewind), so it must be
+	// the user's own text — never the composed provider input with its
+	// transient <response-language>/<reasoning-language>/memory/hook blocks.
+	c.beginCheckpoint(firstNonEmpty(raw, task))
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}
@@ -209,9 +213,12 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	// appended, so the recorded message boundary precedes it and pre-edit
 	// snapshots land here. Synthetic continuations stay attached to the visible
 	// turn that spawned them; otherwise hidden user-role messages would advance
-	// backend checkpoint turns without a matching frontend turn.
+	// backend checkpoint turns without a matching frontend turn. The label is
+	// the user's own text (raw, falling back to the expanded input) — the
+	// composed provider input carries transient prefab blocks that must never
+	// surface in the rewind picker or be prefilled into the composer.
 	if !turn.synthetic {
-		c.beginCheckpoint(input)
+		c.beginCheckpoint(firstNonEmpty(turn.raw, turn.input))
 	}
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -669,6 +669,46 @@ func TestTurnOrchestratorSyntheticTurnDoesNotCreateCheckpoint(t *testing.T) {
 	}
 }
 
+// TestTurnOrchestratorCheckpointPromptIsRawUserInput verifies the rewind picker
+// label records the user's own text, not the composed provider input. compose()
+// prefixes the turn with transient blocks (<response-language>,
+// <reasoning-language>, plan marker, memory, hook context, …); storing that
+// string as checkpoint.Prompt made the Esc-Esc picker show a wall of prefab
+// prompt text instead of the user's messages.
+func TestTurnOrchestratorCheckpointPromptIsRawUserInput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &recordingSessionRunner{session: sess}
+	c := New(Options{
+		Runner:            runner,
+		Executor:          exec,
+		SessionDir:        dir,
+		SessionPath:       path,
+		Label:             "test",
+		ResponseLanguage:  "zh",
+		ReasoningLanguage: "en",
+	})
+	o := newTurnOrchestrator(c)
+	const raw = "fix the parser"
+	if err := o.runTurnWithRawDisplay(context.Background(), raw, raw, ""); err != nil {
+		t.Fatal(err)
+	}
+	cps := c.Checkpoints()
+	if len(cps) != 1 {
+		t.Fatalf("checkpoints = %+v, want exactly one", cps)
+	}
+	if got := cps[0].Prompt; got != raw {
+		t.Fatalf("checkpoint prompt = %q, want raw user input %q (composed text leaked into the rewind picker)", got, raw)
+	}
+	for _, prefab := range []string{"<response-language>", "<reasoning-language>"} {
+		if strings.Contains(cps[0].Prompt, prefab) {
+			t.Fatalf("checkpoint prompt contains %q: %q", prefab, cps[0].Prompt)
+		}
+	}
+}
+
 func TestTurnOrchestratorStopFailureHookCancelledContext(t *testing.T) {
 	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
 	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)


### PR DESCRIPTION
 ## 问题#7028
  
   双击 Esc 打开 rewind（回退对话）选择器时：
  
  1. **历史对话显示的不是用户输入**：checkpoint 的 `Prompt` 存的是 `compose()` 之后的完整 provider
输入，包含一串提前预制的提示词块（`<response-language>`、`<reasoning-language>`、plan marker、memory/hook
上下文等），用户自己的话被截断在最后、完全不可见。`applyRewind` 后还会把这串预制文本预填进
composer，重新发送等于把系统提示词再发给模型。
  2. **无法显示完全历史对话**：`renderRewind` 无滚动窗口地渲染所有轮次，长会话时整个列表超出终端高度、composer
被挤出屏幕且无法滚动。
  
## 修复
 
- `internal/control/turn_orchestrator.go`：`beginCheckpoint` 改存用户原始输入（`firstNonEmpty(turn.raw,
turn.input)`；subagent skill 轮次用 `firstNonEmpty(raw, task)`），发送给模型的 `input` 不变。附带回归测试：设置
`ResponseLanguage`/`ReasoningLanguage` 后断言 `Checkpoints()[0].Prompt == 用户原始输入`。
 - `internal/cli/rewind.go`：rewind 列表复用 `quickPickerWindow`，最多显示 8 行并带 `↑ more` / `↓ more`
标记，窗口跟随选择滚动。附带窗口测试（12 轮选最新/最旧、短会话三种情形）。

## 验证

- `go test ./internal/control/ ./internal/cli/ ./internal/checkpoint/` 全部通过
- `go vet ./internal/control/ ./internal/cli/ ./internal/checkpoint/` 无警告
- `go build ./...` 通过

Cache-impact: none — 改动仅涉及 internal/control/ 与
internal/cli/，未触碰缓存敏感路径（internal/boot/、internal/tool/、internal/provider/ 等