### PR TITLE
test(instruction): isolate Windows home imports / 隔离 Windows Home 测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/cli/... ./internal/control/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/cli/... ./internal/control/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'

--- a/internal/instruction/resolver_test.go
+++ b/internal/instruction/resolver_test.go
@@ -130,6 +130,7 @@ func TestResolveImportsAreProvenancedDeduplicatedAndConfined(t *testing.T) {
 func TestResolveUserInstructionsImportTrustedConventionRoots(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 	userDir := filepath.Join(home, ".reasonix")
 	agentsDir := filepath.Join(home, ".agents")
 	root := filepath.Join(home, "repo")
@@ -153,6 +154,7 @@ func TestResolveUserInstructionsImportTrustedConventionRoots(t *testing.T) {
 func TestResolveProjectInstructionsCannotImportUserConventionRoots(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 	root := filepath.Join(home, "repo")
 	mustWriteInstruction(t, filepath.Join(home, ".agents", "AGENTS.md"), "PRIVATE USER RULE")
 	mustWriteInstruction(t, filepath.Join(root, "AGENTS.md"), "@~/.agents/AGENTS.md")
@@ -169,6 +171,7 @@ func TestResolveProjectInstructionsCannotImportUserConventionRoots(t *testing.T)
 func TestResolveUserInstructionsRejectArbitraryHomeAndConventionSymlinkEscape(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 	userDir := filepath.Join(home, ".reasonix")
 	agentsDir := filepath.Join(home, ".agents")
 	mustWriteInstruction(t, filepath.Join(home, "secret.md"), "HOME SECRET")


### PR DESCRIPTION
## Problem

The first full Windows `main-v2` CI run after #7201 failed two `internal/instruction` home-import tests. The tests redirected `HOME` into a temporary directory, but `os.UserHomeDir` reads `USERPROFILE` on Windows, so `~/.agents/...` resolved against the runner account instead of the isolated fixture.

## Fix

- Set `USERPROFILE` alongside `HOME` in the three instruction resolver tests that exercise tilde-based user convention imports.
- Add `internal/instruction` to the bounded Windows pull-request smoke suite so the platform-specific contract is checked before merging.
- Keep production resolution and its security boundary unchanged; this is test-environment isolation only.

## Verification

- `go test ./internal/instruction -count=1`
- Repeated the three affected home-import cases 20 times.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`
- `git diff --check`

The exact Windows regression is now exercised by the PR's Windows CI runner.
