### PR TITLE
chore(release): align legacy npm aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,7 @@ jobs:
             .github/workflows/release-stable.yml \
             .github/workflows/release-preview.yml \
             .github/workflows/release-cli-trigger.yml \
+            .github/workflows/migrate-npm-release-aliases.yml \
             .github/workflows/release.yml \
             .github/workflows/release-npm.yml \
             .github/workflows/release-desktop.yml

--- a/.github/workflows/migrate-npm-release-aliases.yml
+++ b/.github/workflows/migrate-npm-release-aliases.yml
@@ -1,0 +1,29 @@
+name: Migrate npm release aliases
+run-name: Align npm aliases to v1.19.2
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: official-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: align latest, canary, and next
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+      - name: Verify provenance and align compatibility aliases
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          EXPECTED_SHA: c46e3af1c2732fe2b3dedb0bd47eb39a629357d2
+        run: node scripts/finalize-npm-official-release.mjs 1.19.2

--- a/scripts/finalize-npm-official-release.mjs
+++ b/scripts/finalize-npm-official-release.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const version = process.argv[2];
+const expectedSha = process.env.EXPECTED_SHA || "";
+if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(version || "")) {
+  throw new Error("usage: finalize-npm-official-release.mjs MAJOR.MINOR.PATCH");
+}
+if (expectedSha && !/^[0-9a-f]{40}$/.test(expectedSha)) {
+  throw new Error("EXPECTED_SHA must be a full lowercase commit SHA");
+}
+
+const packages = [
+  "reasonix",
+  "@reasonix/cli-darwin-arm64", "@reasonix/cli-darwin-x64",
+  "@reasonix/cli-linux-arm64", "@reasonix/cli-linux-x64",
+  "@reasonix/cli-win32-arm64", "@reasonix/cli-win32-x64",
+];
+
+function metadata(name) {
+  const output = execFileSync(
+    "npm",
+    ["view", `${name}@${version}`, "name", "version", "gitHead", "reasonixCandidateSha", "--json"],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output);
+}
+
+for (const name of packages) {
+  const actual = metadata(name);
+  if (actual.name !== name || actual.version !== version) {
+    throw new Error(`${name}@${version} is unavailable or resolved to another package`);
+  }
+  if (expectedSha && actual.gitHead !== expectedSha) {
+    throw new Error(`${name}@${version} gitHead ${actual.gitHead || "<missing>"} does not match ${expectedSha}`);
+  }
+  if (expectedSha && actual.reasonixCandidateSha !== expectedSha) {
+    throw new Error(`${name}@${version} reasonixCandidateSha ${actual.reasonixCandidateSha || "<missing>"} does not match ${expectedSha}`);
+  }
+}
+
+for (const name of packages) {
+  for (const tag of ["latest", "canary", "next"]) {
+    execFileSync("npm", ["dist-tag", "add", `${name}@${version}`, tag], { stdio: "inherit" });
+  }
+  const tags = JSON.parse(execFileSync("npm", ["view", name, "dist-tags", "--json"], { encoding: "utf8" }));
+  for (const tag of ["latest", "canary", "next"]) {
+    if (tags[tag] !== version) throw new Error(`${name} ${tag} is ${tags[tag] || "<missing>"}; want ${version}`);
+  }
+  if (tags["official-staging"] === version) {
+    execFileSync("npm", ["dist-tag", "rm", name, "official-staging"], { stdio: "inherit" });
+  }
+}
+

--- a/scripts/finalize-npm-official-release.test.mjs
+++ b/scripts/finalize-npm-official-release.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const candidate = "c46e3af1c2732fe2b3dedb0bd47eb39a629357d2";
+
+function run(expectedSha = candidate, publishedSha = candidate) {
+  const directory = mkdtempSync(join(tmpdir(), "reasonix-npm-alias-test-"));
+  const npm = join(directory, "npm");
+  writeFileSync(npm, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json") {
+  const name = args[1].slice(0, -"@1.19.2".length);
+  console.log(JSON.stringify({ name, version: "1.19.2", gitHead: ${JSON.stringify(publishedSha)}, reasonixCandidateSha: ${JSON.stringify(publishedSha)} }));
+} else if (args[0] === "view" && args[2] === "dist-tags") {
+  console.log(JSON.stringify({ latest: "1.19.2", canary: "1.19.2", next: "1.19.2" }));
+} else if (args[0] === "dist-tag" && args[1] === "add") {
+  process.exit(0);
+} else {
+  console.error("unexpected npm arguments", JSON.stringify(args));
+  process.exit(2);
+}
+`);
+  chmodSync(npm, 0o755);
+  return spawnSync(process.execPath, ["scripts/finalize-npm-official-release.mjs", "1.19.2"], {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+    env: { ...process.env, EXPECTED_SHA: expectedSha, PATH: `${directory}:${process.env.PATH}` },
+  });
+}
+
+test("aligns all aliases after exact package provenance validation", () => {
+  const result = run();
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("fails closed before alias mutation when provenance differs", () => {
+  const result = run(candidate, "a".repeat(40));
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not match/);
+});
+

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1533,5 +1533,6 @@ fi
 grep -Eq 'does not match requested version' "$test_root/npm-mismatch.log"
 
 node --test "$repo_root/npm/publish.test.mjs"
+node --test "$repo_root/scripts/finalize-npm-official-release.test.mjs"
 
 echo "release workflow contract tests: PASS"


### PR DESCRIPTION
## Problem

The final bridge release published `reasonix@1.19.2` to `latest`, but the compatibility aliases still resolve to public prereleases:

- `canary = 1.19.2-canary.1`
- `next = 1.19.0-rc.3`

The single-channel contract requires `latest == canary == next == 1.19.2`.

## Fix

Add a zero-input, one-time **Migrate npm release aliases** workflow. It:

- requires the existing `release` environment approval;
- verifies all seven npm packages exist at `1.19.2`;
- requires `gitHead` and `reasonixCandidateSha` to equal `c46e3af1c2732fe2b3dedb0bd47eb39a629357d2` before mutation;
- aligns `latest`, `canary`, and `next` for every package;
- verifies the final registry state and fails closed on any mismatch.

The temporary workflow will be removed by the single-channel activation PR after this migration succeeds.

## Verification

- `node --test scripts/finalize-npm-official-release.test.mjs`
- `bash scripts/release-workflows.test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/migrate-npm-release-aliases.yml .github/workflows/ci.yml`
- `git diff --check`