### PR TITLE
fix(release): tolerate npm alias propagation delay

### DIFF
--- a/scripts/finalize-npm-official-release.mjs
+++ b/scripts/finalize-npm-official-release.mjs
@@ -1,14 +1,23 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 
 const version = process.argv[2];
 const expectedSha = process.env.EXPECTED_SHA || "";
+const verifyDelayMs = Number.parseInt(process.env.NPM_TAG_VERIFY_DELAY_MS || "2000", 10);
+const verifyAttempts = Number.parseInt(process.env.NPM_TAG_VERIFY_ATTEMPTS || "15", 10);
 if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(version || "")) {
   throw new Error("usage: finalize-npm-official-release.mjs MAJOR.MINOR.PATCH");
 }
 if (expectedSha && !/^[0-9a-f]{40}$/.test(expectedSha)) {
   throw new Error("EXPECTED_SHA must be a full lowercase commit SHA");
+}
+if (!Number.isSafeInteger(verifyDelayMs) || verifyDelayMs < 0) {
+  throw new Error("NPM_TAG_VERIFY_DELAY_MS must be a non-negative integer");
+}
+if (!Number.isSafeInteger(verifyAttempts) || verifyAttempts < 1) {
+  throw new Error("NPM_TAG_VERIFY_ATTEMPTS must be a positive integer");
 }
 
 const packages = [
@@ -25,6 +34,23 @@ function metadata(name) {
     { encoding: "utf8" },
   );
   return JSON.parse(output);
+}
+
+function distTags(name) {
+  return JSON.parse(execFileSync("npm", ["view", name, "dist-tags", "--json"], { encoding: "utf8" }));
+}
+
+async function waitForOfficialAliases(name) {
+  let tags = {};
+  for (let attempt = 1; attempt <= verifyAttempts; attempt += 1) {
+    tags = distTags(name);
+    if (["latest", "canary", "next"].every((tag) => tags[tag] === version)) return tags;
+    if (attempt < verifyAttempts) await delay(verifyDelayMs);
+  }
+  const actual = ["latest", "canary", "next"]
+    .map((tag) => `${tag}=${tags[tag] || "<missing>"}`)
+    .join(", ");
+  throw new Error(`${name} aliases did not converge to ${version}: ${actual}`);
 }
 
 for (const name of packages) {
@@ -44,12 +70,8 @@ for (const name of packages) {
   for (const tag of ["latest", "canary", "next"]) {
     execFileSync("npm", ["dist-tag", "add", `${name}@${version}`, tag], { stdio: "inherit" });
   }
-  const tags = JSON.parse(execFileSync("npm", ["view", name, "dist-tags", "--json"], { encoding: "utf8" }));
-  for (const tag of ["latest", "canary", "next"]) {
-    if (tags[tag] !== version) throw new Error(`${name} ${tag} is ${tags[tag] || "<missing>"}; want ${version}`);
-  }
+  const tags = await waitForOfficialAliases(name);
   if (tags["official-staging"] === version) {
     execFileSync("npm", ["dist-tag", "rm", name, "official-staging"], { stdio: "inherit" });
   }
 }
-

--- a/scripts/finalize-npm-official-release.test.mjs
+++ b/scripts/finalize-npm-official-release.test.mjs
@@ -7,16 +7,24 @@ import test from "node:test";
 
 const candidate = "c46e3af1c2732fe2b3dedb0bd47eb39a629357d2";
 
-function run(expectedSha = candidate, publishedSha = candidate) {
+function run(expectedSha = candidate, publishedSha = candidate, staleReads = 0) {
   const directory = mkdtempSync(join(tmpdir(), "reasonix-npm-alias-test-"));
   const npm = join(directory, "npm");
+  const state = join(directory, "state");
   writeFileSync(npm, `#!/usr/bin/env node
+const fs = require("node:fs");
 const args = process.argv.slice(2);
 if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json") {
   const name = args[1].slice(0, -"@1.19.2".length);
   console.log(JSON.stringify({ name, version: "1.19.2", gitHead: ${JSON.stringify(publishedSha)}, reasonixCandidateSha: ${JSON.stringify(publishedSha)} }));
 } else if (args[0] === "view" && args[2] === "dist-tags") {
-  console.log(JSON.stringify({ latest: "1.19.2", canary: "1.19.2", next: "1.19.2" }));
+  const statePath = process.env.NPM_FAKE_STATE;
+  const reads = fs.existsSync(statePath) ? Number(fs.readFileSync(statePath, "utf8")) : 0;
+  fs.writeFileSync(statePath, String(reads + 1));
+  const stale = reads < Number(process.env.NPM_FAKE_STALE_READS || 0);
+  console.log(JSON.stringify(stale
+    ? { latest: "1.19.2", canary: "1.19.2-canary.1", next: "1.19.0-rc.3" }
+    : { latest: "1.19.2", canary: "1.19.2", next: "1.19.2" }));
 } else if (args[0] === "dist-tag" && args[1] === "add") {
   process.exit(0);
 } else {
@@ -28,7 +36,14 @@ if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json
   return spawnSync(process.execPath, ["scripts/finalize-npm-official-release.mjs", "1.19.2"], {
     cwd: new URL("..", import.meta.url),
     encoding: "utf8",
-    env: { ...process.env, EXPECTED_SHA: expectedSha, PATH: `${directory}:${process.env.PATH}` },
+    env: {
+      ...process.env,
+      EXPECTED_SHA: expectedSha,
+      NPM_FAKE_STATE: state,
+      NPM_FAKE_STALE_READS: String(staleReads),
+      NPM_TAG_VERIFY_DELAY_MS: "1",
+      PATH: `${directory}:${process.env.PATH}`,
+    },
   });
 }
 
@@ -37,9 +52,13 @@ test("aligns all aliases after exact package provenance validation", () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("waits for npm alias propagation before continuing", () => {
+  const result = run(candidate, candidate, 2);
+  assert.equal(result.status, 0, result.stderr);
+});
+
 test("fails closed before alias mutation when provenance differs", () => {
   const result = run(candidate, "a".repeat(40));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /does not match/);
 });
-


### PR DESCRIPTION
## Problem

The one-time npm alias migration stopped after updating the root package because the registry briefly returned stale `dist-tags` immediately after a successful write. The root aliases eventually converged, but the six platform packages were not processed.

## Root cause

`finalize-npm-official-release.mjs` performed a single immediate read-after-write assertion. npm dist-tag updates can take a short time to become visible through subsequent registry reads.

## Fix

- keep the existing all-package version and exact candidate-SHA validation before any mutation
- retry alias verification for a bounded 30-second window per package
- remain idempotent after partial success
- add a deterministic propagation-delay regression test

## Verification

- `node --test scripts/finalize-npm-official-release.test.mjs`
- `bash scripts/release-workflows.test.sh`
- `git diff --check`

After merge, rerun **Migrate npm release aliases**. It will safely resume from the already-converged root package and update only the remaining platform aliases.
