### PR TITLE
fix(cli): make -c shorthand resolve for --continue

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -435,6 +435,14 @@ func withNotifications(sink event.Sink, cfg *config.Config) event.Sink {
 	return notify.NewSink(sink, newNotificationSender(), cfg.Notifications)
 }
 
+// registerContinueFlag registers --continue with its -c shorthand. The
+// shorthand must go through BoolP (pflag shorthand), not BoolVar: BoolVar
+// registers "c" as a long flag name, which leaves "-c" unparseable
+// ("unknown shorthand flag: 'c' in -c") while accidentally accepting "--c".
+func registerContinueFlag(fs *pflag.FlagSet) *bool {
+	return fs.BoolP("continue", "c", false, "resume the most recent saved session")
+}
+
 func runAgent(args []string, version string) int {
 	fs := pflag.NewFlagSet("run", pflag.ContinueOnError)
 	fs.SetInterspersed(true)
@@ -444,8 +452,7 @@ func runAgent(args []string, version string) int {
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
-	cont := fs.Bool("continue", false, "resume the most recent saved session")
-	fs.BoolVar(cont, "c", false, "shorthand for --continue")
+	cont := registerContinueFlag(fs)
 	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
 	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	effort := fs.String("effort", "", "session reasoning effort override")
@@ -952,8 +959,7 @@ func chatREPL(args []string, version string) int {
 	model := fs.String("model", "", "provider name (default: config default_model)")
 	profileFlag := fs.String("profile", "balanced", "runtime profile: economy | balanced | delivery")
 	maxSteps := fs.Int("max-steps", 0, "one-off max tool-call rounds (0 = automatic)")
-	cont := fs.Bool("continue", false, "resume the most recent saved session")
-	fs.BoolVar(cont, "c", false, "shorthand for --continue")
+	cont := registerContinueFlag(fs)
 	resume := fs.StringP("resume", "r", "", "resume by session ID/query, or open the picker when no value is given")
 	fs.Lookup("resume").NoOptDefVal = resumePickerSentinel
 	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the selected session and continue in the copy (escape hatch when the original is held by another Reasonix process)")

--- a/internal/cli/cli_flags_test.go
+++ b/internal/cli/cli_flags_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"reasonix/internal/agent"
 	"reasonix/internal/provider"
 )
@@ -30,6 +31,43 @@ func TestSplitAllowedToolRulesRejectsUnbalancedParentheses(t *testing.T) {
 		if _, err := splitAllowedToolRules([]string{input}); err == nil {
 			t.Fatalf("splitAllowedToolRules(%q) unexpectedly succeeded", input)
 		}
+	}
+}
+
+func TestRegisterContinueFlagShorthandParses(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"-c"}, true},
+		{[]string{"-c=true"}, true},
+		{[]string{"--continue"}, true},
+		{[]string{"--continue=true"}, true},
+		{[]string{}, false},
+	}
+	for _, tc := range cases {
+		fs := pflag.NewFlagSet("reasonix", pflag.ContinueOnError)
+		cont := registerContinueFlag(fs)
+		if err := fs.Parse(tc.args); err != nil {
+			t.Fatalf("Parse(%#v): %v", tc.args, err)
+		}
+		if *cont != tc.want {
+			t.Fatalf("Parse(%#v) continue = %v, want %v", tc.args, *cont, tc.want)
+		}
+	}
+}
+
+// Regression guard: registering the shorthand with BoolVar instead of BoolP
+// leaves "-c" unparseable ("unknown shorthand flag") while accidentally
+// accepting "--c" as a long flag name (the pre-fix bug, #7156/#7171).
+func TestRegisterContinueFlagRejectsAccidentalLongC(t *testing.T) {
+	fs := pflag.NewFlagSet("reasonix", pflag.ContinueOnError)
+	cont := registerContinueFlag(fs)
+	if err := fs.Parse([]string{"--c"}); err == nil {
+		t.Fatalf("Parse(--c) should fail: --c must not exist as a long flag name")
+	}
+	if *cont {
+		t.Fatalf("--c unexpectedly set the continue flag")
 	}
 }
 


### PR DESCRIPTION
## Problem

`reasonix -c` fails silently with exit code 2 and no output, while `--continue` works as documented. Reported in #7156 (Windows 11) and #7171 (Linux); `docs/CLI.md` documents `-c, --continue` as equivalent.

## Root cause

`internal/cli/cli.go` registered the shorthand with `fs.BoolVar(cont, "c", ...)`. `BoolVar` takes a **long** flag name — it registered `"c"` as a long flag instead of a shorthand (the shorthand variant is `BoolVarP`/`BoolP`). pflag then rejects `-c` with `unknown shorthand flag: 'c' in -c`, and the error is silently swallowed by the `if err := fs.Parse(...); err != nil { return 2 }` path — hence the silent exit. As a side effect, `--c` (double dash) accidentally worked.

Affected entries (both still present on `main-v2`):

- `runAgent` flag set: `reasonix run -c ...`
- `chatREPL` flag set: `reasonix -c`, `reasonix chat -c`, `reasonix code -c`

## Fix

Add a shared `registerContinueFlag` helper using `fs.BoolP("continue", "c", ...)` — the same pattern already used correctly for `-r`, `-y`, `-p` — and use it in both flag sets. `--c` is no longer accepted, matching the documented CLI surface.

## Tests

- `TestRegisterContinueFlagShorthandParses`: `-c`, `-c=true`, `--continue`, `--continue=true` all parse with the expected value.
- `TestRegisterContinueFlagRejectsAccidentalLongC`: regression guard — `--c` must fail instead of silently setting the flag.
- Existing `TestRunRoutesBareInteractiveFlagsToSession` still passes; it only exercised routing (the session runner is mocked), which is exactly why the bug was not caught before.

## Verification

- `go test ./internal/cli/` — pass
- `go vet ./internal/cli/` — clean
- `gofmt -l internal/cli/` — clean
- `go build ./cmd/reasonix` + `go test ./cmd/reasonix/` — pass
- End-to-end: `reasonix run -c -h` now prints `-c, --continue` in usage; `reasonix run -c "task"` proceeds past flag parsing (previously silent exit 2).

Cache-impact: none — `internal/cli` is not on the cache-sensitive path list in `scripts/check-cache-impact.sh`; no provider-visible system prompt, tool schema, memory prefix, or compaction changes.
Cache-guard: existing CLI guards — `go test ./internal/cli/` passes including the new shorthand regression tests.
