### PR TITLE
fix(agent): skip corrupt subagent metadata during startup cleanup

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -125,6 +125,9 @@ type SubagentStore struct {
 	dir       string
 	destroyed func(parentSession string) bool
 
+	// cleanupBeforeReread is a test seam for deterministic lease interleavings.
+	cleanupBeforeReread func(parentSession, ref string)
+
 	mu     sync.Mutex
 	locked map[string]bool
 }
@@ -292,14 +295,17 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 			return cleaned, fmt.Errorf("acquire parent session lease %q: %w", parentID, err)
 		}
 		for _, ref := range parent.refs {
+			if s.cleanupBeforeReread != nil {
+				s.cleanupBeforeReread(parentID, ref)
+			}
 			// Re-read after acquiring the parent lease: the former owner may
 			// have completed the child between the initial scan and handoff.
 			meta, err := s.LoadMeta(ref)
 			if err != nil {
-				lease.Release()
 				if isSubagentMetaDecodeError(err) {
 					continue
 				}
+				lease.Release()
 				return cleaned, err
 			}
 			if meta.Status != SubagentRunning || strings.TrimSpace(meta.ParentSession) != parentID {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -228,6 +228,16 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 		}
 		meta, err := s.LoadMeta(ref)
 		if err != nil {
+			// A corrupt metadata file (truncated write, killed process) must
+			// not abort startup: skip it. ListSubagentsByParent tolerates any
+			// undecodable entry; here the tolerance is deliberately narrower —
+			// only JSON decode failures are skipped, while genuine I/O errors
+			// still fail so storage problems stay visible.
+			var syntaxErr *json.SyntaxError
+			var typeErr *json.UnmarshalTypeError
+			if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+				continue
+			}
 			return 0, err
 		}
 		if meta.Status != SubagentRunning {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -49,6 +49,25 @@ type SubagentMeta struct {
 	Effort           string         `json:"effort"`
 }
 
+// subagentMetaDecodeError distinguishes malformed metadata content from file
+// I/O failures. Cleanup may safely skip one undecodable record, but storage
+// errors must remain visible because they can affect every subagent record.
+type subagentMetaDecodeError struct {
+	ref string
+	err error
+}
+
+func (e *subagentMetaDecodeError) Error() string {
+	return fmt.Sprintf("decode subagent metadata %q: %v", e.ref, e.err)
+}
+
+func (e *subagentMetaDecodeError) Unwrap() error { return e.err }
+
+func isSubagentMetaDecodeError(err error) bool {
+	var decodeErr *subagentMetaDecodeError
+	return errors.As(err, &decodeErr)
+}
+
 // SubagentSpec describes the current invocation identity.
 type SubagentSpec struct {
 	Kind             string
@@ -229,13 +248,10 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 		meta, err := s.LoadMeta(ref)
 		if err != nil {
 			// A corrupt metadata file (truncated write, killed process) must
-			// not abort startup: skip it. ListSubagentsByParent tolerates any
-			// undecodable entry; here the tolerance is deliberately narrower —
-			// only JSON decode failures are skipped, while genuine I/O errors
-			// still fail so storage problems stay visible.
-			var syntaxErr *json.SyntaxError
-			var typeErr *json.UnmarshalTypeError
-			if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+			// not abort startup. Skip all content decode failures, including
+			// errors from custom field decoders such as time.Time, while genuine
+			// file I/O errors remain fatal so storage problems stay visible.
+			if isSubagentMetaDecodeError(err) {
 				continue
 			}
 			return 0, err
@@ -281,6 +297,9 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 			meta, err := s.LoadMeta(ref)
 			if err != nil {
 				lease.Release()
+				if isSubagentMetaDecodeError(err) {
+					continue
+				}
 				return cleaned, err
 			}
 			if meta.Status != SubagentRunning || strings.TrimSpace(meta.ParentSession) != parentID {
@@ -640,7 +659,7 @@ func (s *SubagentStore) LoadMeta(ref string) (SubagentMeta, error) {
 		return meta, fmt.Errorf("load subagent metadata %q: %w", ref, err)
 	}
 	if err := json.Unmarshal(data, &meta); err != nil {
-		return meta, fmt.Errorf("decode subagent metadata %q: %w", ref, err)
+		return meta, &subagentMetaDecodeError{ref: ref, err: err}
 	}
 	return meta, nil
 }

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -2,10 +2,12 @@ package agent
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -725,6 +727,61 @@ func TestSubagentStoreCleanupStaleRunningSkipsCorruptMeta(t *testing.T) {
 	}
 	if meta.Status != SubagentInterrupted {
 		t.Fatalf("status = %q, want interrupted", meta.Status)
+	}
+}
+
+func TestSubagentStoreCleanupStaleRunningKeepsParentLeaseAfterCorruptReread(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "lease-parent"
+
+	refs := make([]string, 0, 2)
+	for range 2 {
+		run, err := store.PrepareFresh(spec)
+		if err != nil {
+			t.Fatalf("PrepareFresh: %v", err)
+		}
+		if err := store.MarkRunning(run); err != nil {
+			t.Fatalf("MarkRunning: %v", err)
+		}
+		refs = append(refs, run.Ref)
+		run.Release()
+	}
+	sort.Strings(refs)
+
+	var probeErr error
+	store.cleanupBeforeReread = func(parentSession, ref string) {
+		switch ref {
+		case refs[0]:
+			if err := os.WriteFile(store.metaPath(ref), []byte(`{"createdAt":"not-a-time"}`), 0o600); err != nil {
+				t.Fatalf("corrupt first metadata reread: %v", err)
+			}
+		case refs[1]:
+			probe, err := TryAcquireSessionLease(filepath.Join(sessionDir, parentSession+".jsonl"))
+			probeErr = err
+			if probe != nil {
+				probe.Release()
+			}
+		}
+	}
+
+	cleaned, err := store.CleanupStaleRunning()
+	if err != nil {
+		t.Fatalf("CleanupStaleRunning: %v", err)
+	}
+	if !errors.Is(probeErr, ErrSessionLeaseHeld) {
+		t.Fatalf("parent lease probe before second reread = %v, want ErrSessionLeaseHeld", probeErr)
+	}
+	if cleaned != 1 {
+		t.Fatalf("cleaned = %d, want 1", cleaned)
+	}
+	meta, err := store.LoadMeta(refs[1])
+	if err != nil {
+		t.Fatalf("LoadMeta second ref: %v", err)
+	}
+	if meta.Status != SubagentInterrupted {
+		t.Fatalf("second ref status = %q, want interrupted", meta.Status)
 	}
 }
 

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -699,9 +699,13 @@ func TestSubagentStoreCleanupStaleRunningSkipsCorruptMeta(t *testing.T) {
 	ref := run.Ref
 	run.Release()
 
-	// Corrupt metadata files (truncated JSON and empty) must be skipped,
-	// not abort the whole startup cleanup.
-	for i, corrupt := range []string{`{"status":"running"`, ""} {
+	// Corrupt metadata files (truncated JSON, empty, and invalid custom field
+	// values) must be skipped, not abort the whole startup cleanup.
+	for i, corrupt := range []string{
+		`{"status":"running"`,
+		"",
+		`{"createdAt":"not-a-time"}`,
+	} {
 		corruptRef := fmt.Sprintf("sa_corrupt_%d", i)
 		if err := os.WriteFile(filepath.Join(store.dir, corruptRef+".meta.json"), []byte(corrupt), 0o600); err != nil {
 			t.Fatalf("write corrupt meta %d: %v", i, err)

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -682,6 +683,44 @@ func TestSubagentStoreCleanupStaleRunningSkipsMissingParentProof(t *testing.T) {
 	}
 	if meta.Status != SubagentRunning {
 		t.Fatalf("status = %q without parent proof, want running", meta.Status)
+	}
+}
+
+func TestSubagentStoreCleanupStaleRunningSkipsCorruptMeta(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.MarkRunning(run); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+
+	// Corrupt metadata files (truncated JSON and empty) must be skipped,
+	// not abort the whole startup cleanup.
+	for i, corrupt := range []string{`{"status":"running"`, ""} {
+		corruptRef := fmt.Sprintf("sa_corrupt_%d", i)
+		if err := os.WriteFile(filepath.Join(store.dir, corruptRef+".meta.json"), []byte(corrupt), 0o600); err != nil {
+			t.Fatalf("write corrupt meta %d: %v", i, err)
+		}
+	}
+
+	cleaned, err := store.CleanupStaleRunning()
+	if err != nil {
+		t.Fatalf("CleanupStaleRunning should skip corrupt meta: %v", err)
+	}
+	if cleaned != 1 {
+		t.Fatalf("cleaned = %d, want 1 (corrupt metas skipped, running meta interrupted)", cleaned)
+	}
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentInterrupted {
+		t.Fatalf("status = %q, want interrupted", meta.Status)
 	}
 }
 


### PR DESCRIPTION
## Problem

Reported in #7191: one corrupt subagent `.meta.json` can abort `CleanupStaleRunning` and block Reasonix startup. Corruption is not limited to invalid JSON; valid JSON with an invalid custom-decoded field, such as a malformed `time.Time`, fails the same startup path.

Cleanup also rereads metadata after acquiring the parent session lease. If one of those rereads became corrupt, releasing the lease before skipping that record allowed later refs for the same parent to be rewritten without ownership protection.

## Root cause

`LoadMeta` originally wrapped file-read and content-decode failures as ordinary errors, forcing callers to enumerate concrete JSON error types. The lease-protected reread then released its parent lease before deciding whether an error was skippable or fatal.

## Fix

- Return a private typed decode error from `LoadMeta` while preserving the existing error text and underlying cause.
- Skip that decode-error category at both metadata reads in `CleanupStaleRunning`.
- Keep genuine file I/O failures fatal so storage-wide problems remain visible.
- Retain the parent session lease across skippable corrupt rereads; release it before fatal returns or after all refs for that parent are processed.

## Tests

- `TestSubagentStoreCleanupStaleRunningSkipsCorruptMeta` covers truncated JSON, an empty file, and valid JSON containing an invalid timestamp while confirming a healthy running record is still interrupted.
- `TestSubagentStoreCleanupStaleRunningKeepsParentLeaseAfterCorruptReread` deterministically corrupts the first ref after lease acquisition, probes the same parent lease before the second ref, and verifies that the lease remains held throughout the parent batch.

## Verification

- `go test ./internal/agent -count=1`
- `go test -race ./internal/agent -count=1`
- `go vet ./internal/agent`
- `go test ./internal/boot -count=1`
- `go test ./... -count=1`
- Focused cleanup tests: 20 normal repetitions and 5 race repetitions
- Integration check by replaying the PR commits onto `main-v2` at `510abd2b6`
- Combined integration with #7405: focused agent, boot, and desktop lease-contention tests passed

## Compatibility

- Persisted JSON schema: unchanged; existing records remain readable.
- Error surface: internal typed classification only; the prior message and unwrap behavior are preserved.
- Historical corrupt sidecars: skipped during cleanup, not rewritten or deleted.
- Cross-version behavior: no persisted bytes or public contracts changed.

Cache-impact: none — this only changes local subagent metadata cleanup and does not affect provider-visible prompts, tool schemas, memory prefixes, or request serialization.

Related to #7191.
