### PR TITLE
Add GitHub header link and responsive navigation / 添加 GitHub 入口并优化响应式导航

### DIFF
--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,5 +1,5 @@
 ---
-type ActiveItem = 'features' | 'how' | 'skills' | 'community' | 'docs' | 'changelog' | 'start';
+type ActiveItem = 'features' | 'how' | 'skills' | 'community' | 'docs' | 'changelog';
 
 const {
   active,
@@ -12,6 +12,7 @@ const {
 };
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 const items: Array<{
   id: ActiveItem;
   href: string;
@@ -25,7 +26,6 @@ const items: Array<{
   { id: 'community', href: `${base}/#community`, en: 'Community', zh: '社区', secondary: true },
   { id: 'docs', href: `${base}/docs/`, en: 'Docs', zh: '文档' },
   { id: 'changelog', href: `${base}/changelog/`, en: 'Changelog', zh: '更新日志' },
-  { id: 'start', href: `${base}/#start`, en: 'Get started', zh: '快速开始', secondary: true },
 ];
 ---
 
@@ -47,6 +47,18 @@ const items: Array<{
         </a>
       ))}
     </nav>
+    <a
+      class="nav-github"
+      href={repo}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Reasonix GitHub repository"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M12 .7a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.3c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.4-1.3-5.4-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.3 2.8.1 3.1.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.4 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .7Z" />
+      </svg>
+      <span class="nav-github-label">GitHub</span>
+    </a>
     <div class="lang-switch" role="group" aria-label="Language">
       <button type="button" data-lang="en" class="active">EN</button>
       <button type="button" data-lang="zh">中文</button>

--- a/site/src/scripts/header-contract.test.mjs
+++ b/site/src/scripts/header-contract.test.mjs
@@ -22,10 +22,16 @@ test("primary site pages share the same header component", async () => {
 test("the shared header owns the complete global navigation", async () => {
   const header = await source("../components/SiteHeader.astro");
 
-  for (const id of ["features", "how", "skills", "community", "docs", "changelog", "start"]) {
+  for (const id of ["features", "how", "skills", "community", "docs", "changelog"]) {
     assert.match(header, new RegExp(`id: '${id}'`));
   }
 
+  assert.doesNotMatch(header, /id: 'start'/);
+  assert.equal((header.match(/#start/g) ?? []).length, 1);
   assert.match(header, /nav-sign-in/);
   assert.match(header, /nav-install/);
+  assert.match(header, /class="nav-github"/);
+  assert.match(header, /https:\/\/github[.]com\/esengine\/DeepSeek-Reasonix/);
+  assert.match(header, /target="_blank"/);
+  assert.match(header, /aria-label="Reasonix GitHub repository"/);
 });

--- a/site/src/scripts/mobile-nav-contract.test.mjs
+++ b/site/src/scripts/mobile-nav-contract.test.mjs
@@ -26,6 +26,17 @@ test("≤640px: marketing nav contracts to fit 390px viewports", async () => {
   assert.match(block, /\.theme-switch button \{ padding: 6px 9px/);
 });
 
+test("≤1100px: marketing navigation collapses before controls overlap", async () => {
+  const css = await source("../styles/global.css");
+  const tabletBlock = mediaBlock(css, 1100);
+  const mobileBlock = mediaBlock(css, 900);
+
+  assert.match(tabletBlock, /\.nav-links \{ display: none/);
+  assert.match(tabletBlock, /\.nav-github \{ margin-left: auto; padding-inline: 8px/);
+  assert.match(tabletBlock, /\.nav-github-label \{ display: none/);
+  assert.match(mobileBlock, /\.nav-github \{ display: none/);
+});
+
 test("≤360px: marketing nav keeps every control within 320px", async () => {
   const css = await source("../styles/global.css");
   const block = mediaBlock(css, 360);

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -111,6 +111,15 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 }
 .nav-links a:hover { color: var(--ink); background: var(--bg-soft); }
 .nav-links a.here { color: var(--accent); background: var(--accent-soft); }
+.nav-github {
+  display: inline-flex; flex: none; align-items: center; gap: 8px;
+  color: var(--ink-2); text-decoration: none; font-size: 14px; font-weight: 500;
+  padding: 8px 10px; border-radius: 999px;
+  transition: color 0.2s, background 0.2s;
+}
+.nav-github svg { width: 18px; height: 18px; display: block; }
+.nav-github:hover { color: var(--ink); background: var(--bg-soft); }
+.nav-github:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 8px;
@@ -127,6 +136,12 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 
 @media (max-width: 1260px) {
   .nav-link--secondary { display: none; }
+}
+
+@media (max-width: 1100px) {
+  .nav-links { display: none; }
+  .nav-github { margin-left: auto; padding-inline: 8px; }
+  .nav-github-label { display: none; }
 }
 
 /* hero */
@@ -957,7 +972,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
 
 @media (max-width: 900px) {
   .wrap { padding: 0 24px; }
-  .nav-links { display: none; }
+  .nav-github { display: none; }
   .lang-switch { margin-left: auto; }
   .docs-layout { grid-template-columns: 1fr; gap: 36px; padding: 110px 24px 80px; }
   .docs-side { position: static; max-height: none; overflow: visible; padding-right: 0; }


### PR DESCRIPTION
## Summary

- Add an accessible GitHub repository link to the shared marketing header.
- Show the GitHub label on wide screens, collapse it to an icon at tablet widths, and hide it on compact mobile layouts.
- Collapse the primary navigation before its non-shrinking links can overlap the right-side controls.
- Remove the redundant Get started navigation item while preserving the primary Install CTA.
- Extend header and responsive-layout contract coverage.

## Problem and root cause

The marketing header did not provide a direct source-repository entry. At intermediate widths, `.nav-links` could shrink below the width required by its non-shrinking children, so the visible Changelog link overflowed into the GitHub control. The shared header also exposed two links to the same `#start` installation destination.

## Implementation

- Add a neutral, keyboard-focusable GitHub link with an inline icon, accessible name, and safe external-link attributes.
- At `1100px` and below, hide the primary navigation and right-align the compact GitHub icon.
- At `900px` and below, hide the GitHub icon to preserve the existing mobile control budget.
- Keep only the Install CTA as the header entry for the installation section.

## Verification

- `cd site && npm test` — 48 tests passed.
- `cd site && npx astro build` — 36 static pages built successfully.
- Browser DOM/layout checks passed at 1101px, 1100px, 952px, and 900px in English and Chinese.
- The reproduced 952px overlap decreased from 46px to 0px, with no header overflow.
- Browser console reported no errors or warnings.

## Compatibility and security

| Area | Result |
| --- | --- |
| Persisted data and APIs | No changes |
| Runtime and prompt cache | No changes |
| External navigation | Uses `target="_blank"`, `rel="noreferrer"`, and an explicit accessible name |
| Existing installation flow | Preserved through the primary Install CTA |