### PR TITLE
fix(update): reconcile pending update transactions / 自动对账挂起更新事务

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -9,6 +9,8 @@ package main
 import (
 	"context"
 	"embed"
+	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
@@ -138,6 +140,19 @@ func main() {
 			healthyUpdateCreatedAt = tx.CreatedAt
 			healthyUpdateTransactionID = repair.UpdateTransactionID(tx)
 		}
+	}
+	// Reconcile the pending update before the window opens: stale prepared
+	// transactions are cancelled, failed installs rolled back, restored
+	// transactions settled; probationary transactions are preserved for the
+	// healthy-start commit.
+	if result, err := repair.ReconcilePendingUpdate(version); err != nil {
+		if !errors.Is(err, repair.ErrPendingUpdateAwaitingHealth) {
+			slog.Warn("update reconciliation failed", "err", err)
+		}
+	} else if result.RolledBack {
+		slog.Info("update recovery", "state", "restored", "from", result.FromVersion, "to", result.ToVersion)
+	} else if result.Cleared {
+		slog.Info("update recovery", "state", "cleared", "to", result.ToVersion)
 	}
 	if trackerOwned {
 		_ = tracker.MarkLaunchContext(installProfile, updateFrom, updateTo)

--- a/desktop/update_reconcile_app.go
+++ b/desktop/update_reconcile_app.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"reasonix/internal/repair"
+)
+
+// updateRecoveryView mirrors the repair package's content-free state so the
+// frontend can render an explicit recovery state instead of a generic
+// "a pending update already exists" error.
+type updateRecoveryView struct {
+	State       string `json:"state"`
+	FromVersion string `json:"fromVersion,omitempty"`
+	ToVersion   string `json:"toVersion,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Action      string `json:"action,omitempty"`
+	Retryable   bool   `json:"retryable,omitempty"`
+}
+
+// reconcileUpdatesBeforeAction runs the pending-update reconciliation before a
+// check or install, emitting the explicit recovery phases so the UI never
+// shows the opaque "a pending update already exists" error.
+//
+// The read-only InspectPendingUpdate derives the seven-state view (including
+// active_handoff and restored, which the executor's cancel-or-rollback path
+// does not model); the executor (repair.ReconcilePendingUpdate) performs the
+// safe transition. A settled restored transaction is ended through the
+// verified end path. The returned view is nil when there is nothing to
+// recover.
+func (a *App) reconcileUpdatesBeforeAction(requestID, phase string) (*updateRecoveryView, error) {
+	// Inspect first so the recovery phases are emitted while the action is
+	// actually happening (rolling_back is sent before the rollback runs).
+	inspect, inspectedTx, err := repair.InspectPendingUpdateTransaction(version)
+	if err != nil {
+		a.recordUpdateError(fmt.Errorf("update recovery: %w", err))
+		return nil, err
+	}
+	// active_handoff must never be acted on: the macOS handoff owner is alive
+	// and a second transaction must not be created.
+	if inspect.State == repair.UpdateRecoveryActiveHandoff {
+		view := updateRecoveryView{
+			State:       string(inspect.State),
+			FromVersion: inspect.FromVersion,
+			ToVersion:   inspect.ToVersion,
+			Message:     inspect.Message,
+			Action:      inspect.Action,
+			Retryable:   inspect.Retryable,
+		}
+		a.emitUpdateProgress(requestID, inspect.ToVersion, phase, 0, 0)
+		return &view, nil
+	}
+	// A settled restored transaction (previous release running with the
+	// install record still present) ends through the verified end path.
+	if inspect.State == repair.UpdateRecoveryRestored {
+		endErr := repair.EndRestoredPendingUpdateTransaction(inspectedTx, version)
+		if endErr == nil {
+			a.emitUpdateProgress(requestID, inspect.ToVersion, "reconciling", 0, 0)
+			a.emitUpdateProgress(requestID, inspect.FromVersion, "recovered", 0, 0)
+			view := updateRecoveryView{State: "none", FromVersion: inspect.FromVersion, ToVersion: inspect.ToVersion, Action: "commit", Retryable: true}
+			return &view, nil
+		}
+		a.recordUpdateError(fmt.Errorf("update recovery: restored transaction changed before commit: %w", endErr))
+		view := updateRecoveryView{
+			State:       "blocked",
+			FromVersion: inspect.FromVersion,
+			ToVersion:   inspect.ToVersion,
+			Message:     "the restored update changed before recovery could finish; no recovery files were removed",
+			Action:      "none",
+			Retryable:   true,
+		}
+		return &view, nil
+	}
+	if inspect.State == repair.UpdateRecoveryFailedInstall {
+		a.emitUpdateProgress(requestID, inspect.ToVersion, "rolling_back", 0, 0)
+	}
+	result, err := repair.ReconcilePendingUpdate(version)
+	if err != nil {
+		if errors.Is(err, repair.ErrPendingUpdateAwaitingHealth) {
+			// The new version is running and will commit after a healthy
+			// start; no second installation.
+			view := updateRecoveryView{
+				State:       "probationary",
+				FromVersion: inspect.FromVersion,
+				ToVersion:   inspect.ToVersion,
+				Message:     "the new version is already running and will commit after a healthy start",
+				Action:      "wait",
+				Retryable:   false,
+			}
+			a.emitUpdateProgress(requestID, inspect.ToVersion, phase, 0, 0)
+			return &view, nil
+		}
+		a.recordUpdateError(fmt.Errorf("update recovery: %w", err))
+		state := "blocked"
+		if inspect.State == repair.UpdateRecoveryFailedInstall {
+			state = "failed_install"
+		}
+		view := updateRecoveryView{
+			State:       state,
+			FromVersion: inspect.FromVersion,
+			ToVersion:   inspect.ToVersion,
+			Message:     "the pending update could not be recovered automatically; run reasonix-guard diagnose or reinstall",
+			Action:      "none",
+			Retryable:   true,
+		}
+		a.emitUpdateProgress(requestID, inspect.ToVersion, phase, 0, 0)
+		return &view, nil
+	}
+	if result.Cleared {
+		// A stale prepared transaction was cancelled so a new update may
+		// start.
+		a.emitUpdateProgress(requestID, inspect.ToVersion, "reconciling", 0, 0)
+		view := updateRecoveryView{
+			State:       "none",
+			FromVersion: inspect.FromVersion,
+			ToVersion:   inspect.ToVersion,
+			Message:     "stale prepared update cancelled; a new update can start",
+			Action:      "cancel",
+			Retryable:   true,
+		}
+		return &view, nil
+	}
+	if result.RolledBack {
+		a.emitUpdateProgress(requestID, inspect.FromVersion, "recovered", 0, 0)
+		view := updateRecoveryView{
+			State:       "restored",
+			FromVersion: inspect.FromVersion,
+			ToVersion:   inspect.ToVersion,
+			Message:     "the previous release was restored after an unfinished update",
+			Action:      "rollback",
+			Retryable:   true,
+		}
+		return &view, nil
+	}
+	return nil, nil
+}
+
+// updateRecoveryBlocksInstall reports whether the reconciliation result
+// prevents starting a new installation right now.
+func updateRecoveryBlocksInstall(view *updateRecoveryView) error {
+	if view == nil {
+		return nil
+	}
+	switch view.State {
+	case "probationary":
+		return fmt.Errorf("update: the new version is already running and will commit after a healthy start; no second installation")
+	case "active_handoff":
+		return fmt.Errorf("update: an update handoff is still running; wait for it to finish")
+	case "blocked":
+		return fmt.Errorf("update: the pending update is damaged; run reasonix-guard diagnose or reinstall")
+	}
+	return nil
+}
+
+func (a *App) emitUpdateProgress(requestID, updVersion, phase string, received, total int64) {
+	a.emitProgress(requestID, "", updVersion, phase, received, total, "")
+}

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -96,7 +96,7 @@ func normalizeUpdateChannel(ch string) string {
 }
 
 func configuredUpdateChannel() string {
-	cfg, err := config.Load()
+	cfg, err := config.LoadUpdateNetworkConfig()
 	if err != nil {
 		return "stable"
 	}
@@ -183,6 +183,10 @@ type UpdateInfo struct {
 	DownloadURL       string `json:"downloadUrl"`   // human-facing releases page (macOS path / fallback link)
 	AssetSize         int64  `json:"assetSize"`     // running platform's artifact size, for the progress bar
 	Err               string `json:"err,omitempty"` // set when the check itself failed (both endpoints down)
+	// Recovery carries the pending-update reconciliation outcome (explicit
+	// state/message/action) when an earlier update was not completed; the
+	// frontend shows it instead of a generic "pending update" error.
+	Recovery *updateRecoveryView `json:"recovery,omitempty"`
 }
 
 // UpdateDownloadResult is returned after an artifact has been downloaded,
@@ -215,7 +219,7 @@ func httpClient() (*http.Client, error) { return newHTTPClient(false) }
 func httpClientIPv4() (*http.Client, error) { return newHTTPClient(true) }
 
 func newHTTPClient(forceIPv4 bool) (*http.Client, error) {
-	cfg, err := config.Load()
+	cfg, err := config.LoadUpdateNetworkConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -82,6 +82,9 @@ func (a *App) Version() string { return version }
 // surfaces in UpdateInfo.Err rather than failing, so the UI can stay quiet.
 func (a *App) CheckUpdate(selectedChannel string) (*UpdateInfo, error) {
 	selectedChannel = targetUpdateChannel(selectedChannel)
+	// Reconcile any pending update first so a stale prepared transaction is
+	// cancelled (or a failed install rolled back) before the check runs.
+	recovery, _ := a.reconcileUpdatesBeforeAction("", "checking")
 	profile := detectInstallProfile()
 	c, err := httpClient()
 	if err != nil {
@@ -117,6 +120,7 @@ func (a *App) CheckUpdate(selectedChannel string) (*UpdateInfo, error) {
 		}, nil
 	}
 	info := evaluateForChannel(version, selectedChannel, m)
+	info.Recovery = recovery
 	return &info, nil
 }
 
@@ -235,6 +239,16 @@ func (a *App) InstallUpdateRequest(selectedChannel, expectedVersion, requestID s
 	requestID, selectedChannel, expectedVersion, err := validateUpdaterRequest(requestID, selectedChannel, expectedVersion)
 	if err != nil {
 		return err
+	}
+	// Reconcile before install: a probationary update must not be installed a
+	// second time, an in-flight handoff must not get a second transaction, and
+	// a damaged transaction fails closed.
+	recovery, reconcileErr := a.reconcileUpdatesBeforeAction(requestID, "installing")
+	if reconcileErr != nil {
+		return a.failUpdate(requestID, selectedChannel, expectedVersion, reconcileErr)
+	}
+	if err := updateRecoveryBlocksInstall(recovery); err != nil {
+		return a.failUpdate(requestID, selectedChannel, expectedVersion, err)
 	}
 	finish, err := a.beginUpdaterOperation(requestID)
 	if err != nil {

--- a/internal/config/updatenet.go
+++ b/internal/config/updatenet.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// LastKnownGoodConfigPath is the fixed recovery snapshot of the user config,
+// maintained by the Guard repair pipeline. The updater's minimal network
+// loader falls back to it when the live user config cannot be parsed, so a
+// damaged config never blocks checking for or installing updates.
+func LastKnownGoodConfigPath() string {
+	if root := MemoryUserDir(); root != "" {
+		return filepath.Join(root, "repair", "config.toml.last-known-good")
+	}
+	return ""
+}
+
+// LoadUpdateNetworkConfig builds the minimal configuration the updater needs:
+// update channel, proxy, CA and network fields only. It never reads project
+// reasonix.toml files, plugins, MCP or prompt configuration, so even a config
+// damaged by a plugin path still allows checking for updates, downloading an
+// installer, or entering the recovery UI.
+//
+// Resolution order:
+//
+//  1. the live user-global config;
+//  2. the last-known-good snapshot when the live config cannot be parsed;
+//  3. environment proxy settings with built-in network defaults.
+func LoadUpdateNetworkConfig() (*Config, error) {
+	if SafeModeRequested() {
+		return loadSafeModeForRoot("."), nil
+	}
+	cfg, err := LoadUserConfigReadOnly()
+	if err == nil {
+		return cfg, nil
+	}
+	if lkg := LastKnownGoodConfigPath(); lkg != "" {
+		if b, readErr := os.ReadFile(lkg); readErr == nil {
+			candidate := Default()
+			if _, decodeErr := decodeTOMLBytes(b, candidate); decodeErr == nil {
+				return candidate, nil
+			}
+		}
+	}
+	// Environment proxy settings are already honored by the default network
+	// configuration (NetworkProxyMode defaults to "env").
+	return Default(), nil
+}

--- a/internal/config/updatenet_test.go
+++ b/internal/config/updatenet_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadUpdateNetworkConfigReadsUserConfigOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	userPath := filepath.Join(home, "config.toml")
+	body := "[desktop]\nupdate_channel = \"preview\"\n\n[network]\nproxy_mode = \"custom\"\nproxy_url = \"socks5://127.0.0.1:7890\"\n"
+	if err := os.WriteFile(userPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A project config with an unparseable plugin path must be irrelevant.
+	root := t.TempDir()
+	project := filepath.Join(root, "reasonix.toml")
+	if err := os.WriteFile(project, []byte("[[plugins]]\ncommand = \"D:\\开发\\broken.exe\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadUpdateNetworkConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DesktopUpdateChannel() != "stable" {
+		t.Errorf("update channel = %q, want official stable channel", cfg.DesktopUpdateChannel())
+	}
+	if cfg.NetworkProxyMode() != "custom" {
+		t.Errorf("proxy mode = %q, want custom", cfg.NetworkProxyMode())
+	}
+	if cfg.Network.ProxyURL != "socks5://127.0.0.1:7890" {
+		t.Errorf("proxy url = %q", cfg.Network.ProxyURL)
+	}
+}
+
+func TestLoadUpdateNetworkConfigFallsBackToLastKnownGood(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	userPath := filepath.Join(home, "config.toml")
+	// The live config is damaged (invalid escape).
+	if err := os.WriteFile(userPath, []byte("command = \"D:\\开发\\x.exe\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The last-known-good snapshot still carries the update settings.
+	lkg := filepath.Join(home, "repair", "config.toml.last-known-good")
+	if err := os.MkdirAll(filepath.Dir(lkg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lkgBody := "[cli]\nupdate_channel = \"preview\"\n\n[network]\nproxy_url = \"http://proxy.example:8080\"\n"
+	if err := os.WriteFile(lkg, []byte(lkgBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadUpdateNetworkConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CLIUpdateChannel() != "stable" {
+		t.Errorf("update channel = %q, want legacy snapshot normalized to stable", cfg.CLIUpdateChannel())
+	}
+	if cfg.Network.ProxyURL != "http://proxy.example:8080" {
+		t.Errorf("proxy url = %q, want snapshot value", cfg.Network.ProxyURL)
+	}
+}
+
+func TestLoadUpdateNetworkConfigEnvDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	// No config at all: env proxy + defaults must still work.
+	cfg, err := LoadUpdateNetworkConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NetworkProxyMode() != "auto" {
+		t.Errorf("proxy mode = %q, want auto (env-driven)", cfg.NetworkProxyMode())
+	}
+	if cfg.DesktopUpdateChannel() != "stable" {
+		t.Errorf("update channel = %q, want stable default", cfg.DesktopUpdateChannel())
+	}
+}

--- a/internal/repair/config.go
+++ b/internal/repair/config.go
@@ -297,11 +297,7 @@ func RecordHealthyConfig(version string) error {
 }
 
 func lastKnownGoodConfigPath() string {
-	root := config.MemoryUserDir()
-	if root == "" {
-		return ""
-	}
-	return filepath.Join(root, "repair", "config.toml.last-known-good")
+	return config.LastKnownGoodConfigPath()
 }
 
 func restoreLastKnownGoodConfig(dest string) error {

--- a/internal/repair/process_alive_unix.go
+++ b/internal/repair/process_alive_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package repair
+
+import "syscall"
+
+// processAlive reports whether a process with the given PID is still running.
+// Used to distinguish an in-flight macOS update handoff (wait) from a stale
+// prepared transaction (safe to cancel).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/internal/repair/process_alive_windows.go
+++ b/internal/repair/process_alive_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package repair
+
+import "golang.org/x/sys/windows"
+
+const processStillActiveExitCode = 259 // STILL_ACTIVE
+
+// processAlive reports whether a process with the given PID is still running.
+// Used to distinguish an in-flight update handoff (wait) from a stale prepared
+// transaction (safe to cancel).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	var code uint32
+	return windows.GetExitCodeProcess(handle, &code) == nil && code == processStillActiveExitCode
+}

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -1,6 +1,7 @@
 package repair
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -1509,6 +1510,10 @@ func writePendingUpdate(tx *UpdateTransaction, createOnly bool) error {
 }
 
 func removePendingUpdateExactVerified(expected *UpdateTransaction, verify func() error) error {
+	return removePendingUpdateExactRawVerified(expected, nil, verify)
+}
+
+func removePendingUpdateExactRawVerified(expected *UpdateTransaction, expectedRaw []byte, verify func() error) error {
 	if expected == nil {
 		return fmt.Errorf("clear pending update: transaction identity is incomplete")
 	}
@@ -1531,6 +1536,9 @@ func removePendingUpdateExactVerified(expected *UpdateTransaction, verify func()
 	b, err := os.ReadFile(cleanup)
 	if err != nil {
 		return restore(err)
+	}
+	if expectedRaw != nil && !bytes.Equal(b, expectedRaw) {
+		return restore(fmt.Errorf("clear pending update: pending transaction raw content changed"))
 	}
 	var actual UpdateTransaction
 	if err := json.Unmarshal(b, &actual); err != nil {

--- a/internal/repair/update_reconcile.go
+++ b/internal/repair/update_reconcile.go
@@ -1,0 +1,301 @@
+package repair
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+// UpdateRecoveryState classifies a pending update transaction without guessing:
+// the transaction file, the installed release-unit state, the failure marker,
+// the running version, and the OS lock together determine the state.
+type UpdateRecoveryState string
+
+const (
+	UpdateRecoveryNone          UpdateRecoveryState = "none"
+	UpdateRecoveryPrepared      UpdateRecoveryState = "prepared"
+	UpdateRecoveryProbationary  UpdateRecoveryState = "probationary"
+	UpdateRecoveryFailedInstall UpdateRecoveryState = "failed_install"
+	UpdateRecoveryRestored      UpdateRecoveryState = "restored"
+	UpdateRecoveryActiveHandoff UpdateRecoveryState = "active_handoff"
+	UpdateRecoveryBlocked       UpdateRecoveryState = "blocked"
+)
+
+// UpdateRecoveryView is the content-free reconciliation result surfaced by the
+// updater UI: an explicit state, message and action instead of a generic
+// "a pending update already exists".
+type UpdateRecoveryView struct {
+	State       UpdateRecoveryState `json:"state"`
+	FromVersion string              `json:"fromVersion,omitempty"`
+	ToVersion   string              `json:"toVersion,omitempty"`
+	Message     string              `json:"message,omitempty"`
+	Action      string              `json:"action,omitempty"` // commit|cancel|rollback|wait|none
+	Retryable   bool                `json:"retryable,omitempty"`
+}
+
+// PendingUpdateTransactionSnapshot binds a parsed transaction to the exact
+// pending-update path and raw bytes that produced it. The fields are private so
+// callers cannot mutate the authorization token between inspection and commit.
+type PendingUpdateTransactionSnapshot struct {
+	path        string
+	raw         []byte
+	transaction UpdateTransaction
+}
+
+func updateRecoveryView(state UpdateRecoveryState, tx *UpdateTransaction, message, action string, retryable bool) UpdateRecoveryView {
+	view := UpdateRecoveryView{State: state, Message: message, Action: action, Retryable: retryable}
+	if tx != nil {
+		view.FromVersion = tx.FromVersion
+		view.ToVersion = tx.ToVersion
+	}
+	return view
+}
+
+// InspectPendingUpdate derives the current pending-update state read-only.
+func InspectPendingUpdate(runningVersion string) (UpdateRecoveryView, error) {
+	view, _, err := InspectPendingUpdateTransaction(runningVersion)
+	return view, err
+}
+
+// InspectPendingUpdateTransaction returns the state together with the exact
+// transaction bytes used to derive it. It never mutates files or takes the
+// pending-update lock; callers must pass this snapshot to a lock-protected
+// action so a later read cannot silently authorize a different transaction.
+func InspectPendingUpdateTransaction(runningVersion string) (UpdateRecoveryView, *PendingUpdateTransactionSnapshot, error) {
+	path := PendingUpdatePath()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No transaction: a failure marker without a complete transaction
+			// is stale and never authorizes rollback, but the next launch can
+			// still surface the installer failure.
+			if failure, ok := ReadUpdateApplyFailure(); ok && strings.TrimSpace(failure.UpdateTransactionID) != "" {
+				return updateRecoveryView(UpdateRecoveryFailedInstall, nil,
+					"the update installer failed; the previous release will be restored on the next launch", "rollback", true), nil, nil
+			}
+			return updateRecoveryView(UpdateRecoveryNone, nil, "", "", false), nil, nil
+		}
+		return UpdateRecoveryView{}, nil, err
+	}
+	var tx UpdateTransaction
+	if json.Unmarshal(b, &tx) != nil {
+		return updateRecoveryView(UpdateRecoveryBlocked, nil,
+			"the pending update transaction is corrupt; run reasonix-guard diagnose or reinstall", "none", false), nil, nil
+	}
+	snapshot := &PendingUpdateTransactionSnapshot{
+		path:        path,
+		raw:         append([]byte(nil), b...),
+		transaction: tx,
+	}
+	if err := validateUpdateTransaction(&tx); err != nil {
+		return updateRecoveryView(UpdateRecoveryBlocked, &tx,
+			"the pending update transaction is invalid: "+err.Error(), "none", false), snapshot, nil
+	}
+
+	// A failure marker bound to this transaction takes precedence: the
+	// installer reported failure and the previous release must be restored.
+	if failure, ok := ReadUpdateApplyFailure(); ok && updateFailureMatchesTransaction(failure, &tx) {
+		return updateRecoveryView(UpdateRecoveryFailedInstall, &tx,
+			"the update installer failed; the previous release will be restored", "rollback", true), snapshot, nil
+	}
+
+	// An installed release-unit state means the new release was published.
+	if record, stateErr := readInstalledFileUpdateState(&tx); stateErr == nil && record != nil && record.UpdateTransactionID == UpdateTransactionID(&tx) {
+		switch strings.TrimSpace(runningVersion) {
+		case strings.TrimSpace(tx.ToVersion):
+			return updateRecoveryView(UpdateRecoveryProbationary, &tx,
+				"the new version is running and will commit after a healthy start", "wait", false), snapshot, nil
+		case strings.TrimSpace(tx.FromVersion):
+			// The old release is in place again with the install record still
+			// present: the update was reverted (or the swap never launched)
+			// and the transaction can end once the release unit matches its
+			// backup.
+			if err := verifyUpdateRestoredUnit(&tx); err != nil {
+				return updateRecoveryView(UpdateRecoveryBlocked, &tx,
+					"the restored release unit does not match its backup: "+err.Error(), "none", false), snapshot, nil
+			}
+			return updateRecoveryView(UpdateRecoveryRestored, &tx,
+				"the previous version is running; the pending transaction can end", "commit", false), snapshot, nil
+		default:
+			return updateRecoveryView(UpdateRecoveryBlocked, &tx,
+				"the running version cannot be attributed to this transaction", "none", false), snapshot, nil
+		}
+	}
+
+	// No install record: the release was not published yet.
+	if tx.TargetKind == "app-bundle" && tx.HandoffOwnerPID > 0 && processAlive(tx.HandoffOwnerPID) {
+		return updateRecoveryView(UpdateRecoveryActiveHandoff, &tx,
+			"an update handoff process is running; wait for it to finish", "wait", false), snapshot, nil
+	}
+	// The transaction must still be exactly reversible.
+	if err := verifyUpdatePreparedState(&tx); err != nil {
+		return updateRecoveryView(UpdateRecoveryBlocked, &tx,
+			"the prepared update is no longer intact: "+err.Error(), "none", false), snapshot, nil
+	}
+	return updateRecoveryView(UpdateRecoveryPrepared, &tx,
+		"an update is prepared but not installed", "cancel", true), snapshot, nil
+}
+
+func (s *PendingUpdateTransactionSnapshot) matches(other *PendingUpdateTransactionSnapshot) bool {
+	return s != nil && other != nil && s.path == other.path && bytes.Equal(s.raw, other.raw) &&
+		reflect.DeepEqual(s.transaction, other.transaction)
+}
+
+func (s *PendingUpdateTransactionSnapshot) verifyCurrentRaw() error {
+	if s == nil || strings.TrimSpace(s.path) == "" || len(s.raw) == 0 {
+		return fmt.Errorf("pending transaction snapshot is incomplete")
+	}
+	if PendingUpdatePath() != s.path {
+		return fmt.Errorf("pending transaction path changed")
+	}
+	b, err := os.ReadFile(s.path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(b, s.raw) {
+		return fmt.Errorf("pending transaction raw content changed")
+	}
+	return nil
+}
+
+func updateFailureMatchesTransaction(failure *UpdateApplyFailure, tx *UpdateTransaction) bool {
+	if failure == nil || tx == nil {
+		return false
+	}
+	if id := strings.TrimSpace(failure.UpdateTransactionID); id != "" {
+		return id == UpdateTransactionID(tx)
+	}
+	return strings.TrimSpace(failure.ToVersion) == strings.TrimSpace(tx.ToVersion) &&
+		strings.TrimSpace(failure.UpdateCreatedAt) == strings.TrimSpace(tx.CreatedAt)
+}
+
+// verifyUpdatePreparedState confirms the transaction is still exactly
+// reversible before it is acted on.
+func verifyUpdatePreparedState(tx *UpdateTransaction) error {
+	switch tx.TargetKind {
+	case "app-bundle":
+		if err := VerifyAppBundleUpdateHandoffSource(tx); err != nil {
+			return err
+		}
+		return VerifyAppBundleUpdateHandoffOriginal(tx)
+	default:
+		return verifyPreparedFileUpdateBackups(tx)
+	}
+}
+
+// verifyUpdateRestoredUnit confirms the current release unit matches the
+// transaction's backup (the old release is in place again).
+func verifyUpdateRestoredUnit(tx *UpdateTransaction) error {
+	switch tx.TargetKind {
+	case "app-bundle":
+		return VerifyAppBundleUpdateHandoffOriginal(tx)
+	default:
+		return verifyRestoredFileUpdateTargets(tx.Files)
+	}
+}
+
+// EndPendingUpdateTransactionVerified ends a transaction whose release unit is
+// already settled (the restored state: the running version is the previous
+// release and the installed record still exists). The pending update and its
+// backups are removed only after the verification callback confirms the
+// release unit matches the transaction's backup, and the exact transaction
+// identity still matches under the pending and target locks.
+func EndPendingUpdateTransactionVerified(expected *UpdateTransaction, verify func() error) error {
+	return endPendingUpdateTransactionVerified(expected, nil, nil, verify, verify)
+}
+
+// EndRestoredPendingUpdateTransaction ends only the exact transaction whose
+// initial inspection reported restored. The state, transaction identity,
+// installed record and restored release unit are all re-verified under the
+// pending/target locks; any drift leaves every recovery artifact intact.
+func EndRestoredPendingUpdateTransaction(expected *PendingUpdateTransactionSnapshot, runningVersion string) error {
+	if expected == nil {
+		return fmt.Errorf("end restored update transaction: transaction identity is incomplete")
+	}
+	tx := expected.transaction
+	verifyUnit := func() error {
+		return verifyUpdateRestoredUnit(&tx)
+	}
+	verifyState := func() error {
+		view, current, err := InspectPendingUpdateTransaction(runningVersion)
+		if err != nil {
+			return fmt.Errorf("end restored update transaction: inspect current state: %w", err)
+		}
+		if !expected.matches(current) {
+			return fmt.Errorf("end restored update transaction: pending transaction changed")
+		}
+		if view.State != UpdateRecoveryRestored {
+			return fmt.Errorf("end restored update transaction: state changed to %s", view.State)
+		}
+		return verifyUnit()
+	}
+	extraLocks := []string{installedFileUpdateStatePath(&tx)}
+	return endPendingUpdateTransactionVerified(&tx, expected, extraLocks, verifyState, verifyUnit)
+}
+
+func endPendingUpdateTransactionVerified(expected *UpdateTransaction, snapshot *PendingUpdateTransactionSnapshot, extraLockPaths []string, verifyBefore, verifyAfter func() error) error {
+	if expected == nil {
+		return fmt.Errorf("end update transaction: transaction identity is incomplete")
+	}
+	expectedID := UpdateTransactionID(expected)
+	unlock, err := acquirePendingUpdateLock()
+	if err != nil {
+		return fmt.Errorf("end update transaction: lock pending transaction: %w", err)
+	}
+	defer unlock()
+	if snapshot != nil {
+		if err := snapshot.verifyCurrentRaw(); err != nil {
+			return fmt.Errorf("end update transaction: %w", err)
+		}
+	}
+	tx, err := ReadPendingUpdate()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if expectedID != "" && UpdateTransactionID(tx) != expectedID {
+		return fmt.Errorf("end update transaction: pending transaction changed")
+	}
+	if !reflect.DeepEqual(expected, tx) {
+		return fmt.Errorf("end update transaction: pending transaction changed while waiting")
+	}
+	lockPaths := append(pendingUpdateTargetPaths(tx), extraLockPaths...)
+	unlockTargets, lockErr := lockRepairMutations(lockPaths...)
+	if lockErr != nil {
+		return fmt.Errorf("end update transaction: lock targets: %w", lockErr)
+	}
+	defer unlockTargets()
+	if snapshot != nil {
+		if err := snapshot.verifyCurrentRaw(); err != nil {
+			return fmt.Errorf("end update transaction: %w", err)
+		}
+	}
+	current, err := ReadPendingUpdate()
+	if err != nil {
+		return fmt.Errorf("end update transaction: re-read pending transaction: %w", err)
+	}
+	if !reflect.DeepEqual(tx, current) {
+		return fmt.Errorf("end update transaction: pending transaction changed while waiting")
+	}
+	tx = current
+	if verifyBefore != nil {
+		if err := verifyBefore(); err != nil {
+			return err
+		}
+	}
+	var expectedRaw []byte
+	if snapshot != nil {
+		expectedRaw = snapshot.raw
+	}
+	if err := removePendingUpdateExactRawVerified(tx, expectedRaw, verifyAfter); err != nil {
+		return err
+	}
+	removeUpdateBackups(tx)
+	_ = removeInstalledFileUpdateState(tx)
+	return nil
+}

--- a/internal/repair/update_reconcile_test.go
+++ b/internal/repair/update_reconcile_test.go
@@ -1,0 +1,461 @@
+package repair
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func reconcileFileUpdateFixture(t *testing.T, fromVersion, toVersion string) (*UpdateTransaction, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "reasonix-desktop")
+	guard := filepath.Join(dir, "reasonix-guard")
+	originalExecutable := repairExecutable
+	repairExecutable = func() (string, error) { return guard, nil }
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := PrepareFileUpdate(fromVersion, toVersion, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tx, target
+}
+
+func publishFileUpdateForTest(t *testing.T, tx *UpdateTransaction, content string) {
+	t.Helper()
+	targetPaths := make([]string, 0, len(tx.Files))
+	for _, file := range tx.Files {
+		targetPaths = append(targetPaths, file.TargetPath)
+	}
+	claimed, release, err := ClaimPendingFileUpdateExact(
+		tx.ToVersion,
+		tx.CreatedAt,
+		UpdateTransactionID(tx),
+		filepath.Join(filepath.Dir(tx.TargetPath), "reasonix-launcher"),
+		targetPaths,
+		time.Second*10,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	receipts := make([]FileUpdateInstallReceipt, 0, len(tx.Files))
+	for _, file := range tx.Files {
+		receipt, err := PublishClaimedFileUpdateMemberExact(claimed, file.TargetPath, []byte(content), 0o700)
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = append(receipts, receipt)
+	}
+	if _, err := RecordClaimedFileUpdateInstalled(tx, receipts...); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilePreparedCancelsStaleTransaction(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	_ = target
+
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryPrepared {
+		t.Fatalf("state = %s, want prepared", view.State)
+	}
+
+	result, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Cleared {
+		t.Fatalf("reconcile result = %+v, want cleared", result)
+	}
+	if HasPendingUpdate() {
+		t.Fatal("pending transaction survived prepared reconcile")
+	}
+	// A new update may now start.
+	if _, err := PrepareFileUpdate("v1", "v2", tx.TargetPath); err != nil {
+		t.Fatalf("new prepare after reconcile: %v", err)
+	}
+}
+
+func TestReconcileProbationaryKeepsTransaction(t *testing.T) {
+	tx, _ := reconcileFileUpdateFixture(t, "v1", "v2")
+	publishFileUpdateForTest(t, tx, "new")
+
+	view, err := InspectPendingUpdate("v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryProbationary {
+		t.Fatalf("state = %s, want probationary", view.State)
+	}
+	result, err := ReconcilePendingUpdate("v2")
+	if !errors.Is(err, ErrPendingUpdateAwaitingHealth) {
+		t.Fatalf("reconcile err = %v, want ErrPendingUpdateAwaitingHealth", err)
+	}
+	if !result.AwaitingHealth {
+		t.Fatalf("reconcile result = %+v, want awaitingHealth", result)
+	}
+	if !HasPendingUpdate() {
+		t.Fatal("probationary transaction was removed")
+	}
+}
+
+func TestReconcileFailedInstallRollsBack(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	if err := MarkUpdateApplyFailedMatching("v2", tx.CreatedAt, "installer exited 5"); err != nil {
+		t.Fatal(err)
+	}
+
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryFailedInstall {
+		t.Fatalf("state = %s, want failed_install", view.State)
+	}
+	// The installer-failure marker is correlated and rolled back by
+	// RecoverFailedInstall (the Guard's first startup step).
+	result, _, err := RecoverFailedInstall()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.RolledBack {
+		t.Fatalf("recover result = %+v, want rolled back", result)
+	}
+	b, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "old" {
+		t.Fatalf("binary after rollback = %q, want old", b)
+	}
+	if HasPendingUpdate() {
+		t.Fatal("pending transaction survived failed-install rollback")
+	}
+	if _, ok := ReadUpdateApplyFailure(); ok {
+		t.Fatal("failure marker survived rollback")
+	}
+	// Idempotent: a second reconcile is a no-op.
+	result2, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result2.Pending {
+		t.Fatalf("second reconcile result = %+v, want no pending transaction", result2)
+	}
+}
+
+func TestReconcileRestoredEndsTransaction(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	publishFileUpdateForTest(t, tx, "new")
+	// The old release is back in place (a rollback that died before ending
+	// the transaction), while the install record still exists.
+	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryRestored {
+		t.Fatalf("state = %s, want restored", view.State)
+	}
+	// The settled transaction ends through the verified end path (targets
+	// match the backups); the mainline rollback correctly refuses because the
+	// installed record no longer matches the published state.
+	if err := EndPendingUpdateTransactionVerified(tx, func() error {
+		return verifyUpdateRestoredUnit(tx)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if HasPendingUpdate() {
+		t.Fatal("restored transaction was not ended")
+	}
+}
+
+func TestReconcileRestoredRefusesTamperedUnit(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	publishFileUpdateForTest(t, tx, "new")
+	// The old release is back but with different bytes than the backup.
+	if err := os.WriteFile(target, []byte("tampered"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryBlocked {
+		t.Fatalf("state = %s, want blocked for tampered restored unit", view.State)
+	}
+	if !HasPendingUpdate() {
+		t.Fatal("blocked transaction must not be deleted")
+	}
+}
+
+func TestEndRestoredTransactionRefusesUnitChangedAfterInspect(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	publishFileUpdateForTest(t, tx, "new")
+	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	view, inspectedTx, err := InspectPendingUpdateTransaction("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryRestored || inspectedTx == nil {
+		t.Fatalf("inspection = %+v tx=%v, want restored with identity", view, inspectedTx)
+	}
+	if err := os.WriteFile(target, []byte("tampered-after-inspect"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := EndRestoredPendingUpdateTransaction(inspectedTx, "v1"); err == nil {
+		t.Fatal("changed restored unit must fail closed")
+	}
+	if !HasPendingUpdate() {
+		t.Fatal("changed restored unit caused pending transaction deletion")
+	}
+	if _, err := os.Stat(tx.Files[0].BackupPath); err != nil {
+		t.Fatalf("changed restored unit caused backup deletion: %v", err)
+	}
+}
+
+func TestEndRestoredTransactionRefusesUnknownFieldAddedAfterInspect(t *testing.T) {
+	tx, target := reconcileFileUpdateFixture(t, "v1", "v2")
+	publishFileUpdateForTest(t, tx, "new")
+	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	view, inspectedTx, err := InspectPendingUpdateTransaction("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryRestored || inspectedTx == nil {
+		t.Fatalf("inspection = %+v tx=%v, want restored with identity", view, inspectedTx)
+	}
+
+	path := PendingUpdatePath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["future_recovery_policy"] = map[string]any{"keep_backup": true}
+	mutated, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated = append(mutated, '\n')
+	if err := os.WriteFile(path, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// An older binary still derives restored from the known fields. The raw
+	// transaction snapshot must nevertheless prevent it from discarding a
+	// newer binary's unknown recovery metadata.
+	current, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.State != UpdateRecoveryRestored {
+		t.Fatalf("state after adding unknown field = %s, want restored", current.State)
+	}
+
+	if err := EndRestoredPendingUpdateTransaction(inspectedTx, "v1"); err == nil {
+		t.Fatal("unknown transaction field added after inspection must fail closed")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("changed pending transaction was deleted: %v", err)
+	}
+	if string(got) != string(mutated) {
+		t.Fatalf("changed pending transaction was rewritten: got %q want %q", got, mutated)
+	}
+	if _, err := os.Stat(tx.Files[0].BackupPath); err != nil {
+		t.Fatalf("changed transaction caused backup deletion: %v", err)
+	}
+	if _, err := os.Stat(installedFileUpdateStatePath(tx)); err != nil {
+		t.Fatalf("changed transaction caused installed-state deletion: %v", err)
+	}
+}
+
+func TestReconcileBlockedCorruptTransaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	path := PendingUpdatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryBlocked {
+		t.Fatalf("state = %s, want blocked", view.State)
+	}
+	if _, err := ReconcilePendingUpdate("v1"); err == nil {
+		t.Fatal("reconcile of a corrupt transaction must fail closed")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("corrupt transaction was deleted: %v", err)
+	}
+}
+
+func TestReconcileActiveHandoffWhenOwnerAlive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := filepath.Join(dir, "Reasonix.app")
+	exe := filepath.Join(app, "Contents", "MacOS", "Reasonix")
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The transaction must belong to the current Guard installation: point the
+	// launcher at the test bundle's executable.
+	originalExecutable := repairExecutable
+	repairExecutable = func() (string, error) { return exe, nil }
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+	staging := filepath.Join(os.TempDir(), "reasonix-mac-update-reconcile-test")
+	stagedApp := filepath.Join(staging, "Reasonix.app")
+	if err := os.MkdirAll(stagedApp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(staging) })
+	// A prepared app-bundle handoff owned by the current (live) process.
+	tx, err := PrepareAppBundleUpdateHandoff("v1", "v2", app, app+".reasonix-update-backup", stagedApp, staging, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryActiveHandoff {
+		t.Fatalf("state = %s, want active_handoff (owner alive)", view.State)
+	}
+	if !processAlive(os.Getpid()) {
+		t.Fatal("test process must be alive")
+	}
+	_ = tx
+}
+
+func TestReconcileNoneWithoutTransaction(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryNone {
+		t.Fatalf("state = %s, want none", view.State)
+	}
+	result, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Pending {
+		t.Fatalf("reconcile result = %+v, want no pending transaction", result)
+	}
+}
+
+func TestReconcilePreparedIdempotent(t *testing.T) {
+	_, _ = reconcileFileUpdateFixture(t, "v1", "v2")
+	first, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Cleared || second.Pending {
+		t.Fatalf("idempotence broken: first=%+v second=%+v", first, second)
+	}
+}
+
+func TestReconcilePreparedTargetMismatchRefused(t *testing.T) {
+	tx, _ := reconcileFileUpdateFixture(t, "v1", "v2")
+	// The prepared transaction's backup disappeared: the transaction is no
+	// longer exactly reversible and must fail closed instead of cancelling.
+	backup := tx.Files[0].BackupPath
+	if err := os.Remove(backup); err != nil {
+		t.Fatal(err)
+	}
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryBlocked {
+		t.Fatalf("state = %s, want blocked (backup missing)", view.State)
+	}
+	// The transaction file must survive untouched (fail closed); the backup
+	// removal invalidates validation, so check the file directly.
+	if _, err := os.Stat(PendingUpdatePath()); err != nil {
+		t.Fatalf("blocked transaction file was removed: %v", err)
+	}
+}
+
+func TestUpdateFailureMarkerWithoutTransactionIsStale(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	// A marker with a transaction identity but no transaction file: surfaced
+	// as failed_install, then the stale marker is cleared by reconciliation.
+	if err := markUpdateApplyFailed("v2", "2026-01-01T00:00:00Z", "some-transaction-id", "installer exited 5"); err != nil {
+		t.Fatal(err)
+	}
+	view, err := InspectPendingUpdate("v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.State != UpdateRecoveryFailedInstall {
+		t.Fatalf("state = %s, want failed_install surfaced", view.State)
+	}
+	if _, _, err := RecoverFailedInstall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadUpdateApplyFailure(); ok {
+		t.Fatal("stale failure marker survived recovery")
+	}
+}
+
+func TestReconcileActiveHandoffLockTimeout(t *testing.T) {
+	tx, _ := reconcileFileUpdateFixture(t, "v1", "v2")
+	// Hold the pending-update lock like an in-flight updater helper would.
+	unlock, err := acquirePendingUpdateLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ReconcilePendingUpdate("v1")
+	unlock()
+	if err == nil {
+		t.Fatal("reconcile under a busy lock must wait or fail, not cancel")
+	}
+	if !HasPendingUpdate() {
+		t.Fatal("transaction must survive a busy lock")
+	}
+	_ = tx
+}


### PR DESCRIPTION
## Summary

Split slice of #7192: minimal updater network config loading and explicit seven-state pending-update reconciliation.

### Retained / adapted from #7192

- `LoadUpdateNetworkConfig`: expose only update channel, proxy, CA, and network settings to the updater; fall back to LKG, env proxy, and defaults when the live config is damaged.
- Seven-state inspection: `none` / `prepared` / `probationary` / `failed_install` / `restored` / `active_handoff` / `blocked`.
- Cancel, rollback, and restored cleanup re-read under pending/target locks and bind original transaction bytes, transaction ID, installed record, and release unit (`PendingUpdateTransactionSnapshot`, `removePendingUpdateExactRawVerified`).
- Unified call sites: Desktop launch, check-update, install-update (Guard already reconciled on main via #7149).
- UI surfaces `UpdateInfo.Recovery` and explicit progress phases instead of opaque "a pending update already exists".
- P1: unknown JSON fields present before first Inspect enter `blocked` without deleting transaction, backup, or install records; cleanup-semantic field additions require schema version bumps.

### Explicitly excluded

| Area | Destination |
| --- | --- |
| TOML encode / safe write pipeline | PR 1 (#7228) |
| Config escape auto-repair / banners | PR 2 |
| Session ownership recovery | PR 4 |
| Smart close / config v6 | PR 5 |
| Background jobs / mode switch | #7198 |

### Dependencies

- None relative to PR 1/2. Base: latest `main-v2`.
- Builds on already-merged #7149 reconciliation executor; this PR adds inspect views, raw-byte end paths, network-only config load, and Desktop UI wiring.

### Compatibility

| Surface | Old data / older binary | Conclusion |
| --- | --- | --- |
| Pending update JSON | Extra unknown fields → blocked, no destructive cleanup | Safe |
| `UpdateInfo.Recovery` | New optional field (`omitempty`) | Backward compatible |
| Progress phase strings | Additive | Older UIs ignore unknown phases |
| Full config load for updates | Replaced by network-only loader | Updater still works with damaged plugins/MCP config |

### Cache impact

None expected: no prompt, tool schema, or request serialization changes.

### Verification

```bash
go test ./internal/config -run 'UpdateNetwork|LoadUpdate'
go test ./internal/repair -run 'Update|Pending|Reconcile|Inspect'
go test -race ./internal/repair -run 'Update|Pending|Reconcile|Inspect'
cd desktop && go test -run 'Update|Reconcile|Pending' .
```

Real install matrix (Windows installer/portable, macOS signed app, Linux tar/deb upgrade/rollback/restart) remains a release gate and is not substituted by unit tests.

Refs: #7192 (supersede mapping will land after all five split PRs exist); builds on #7149