### PR TITLE
feat(provider): append endpoint-specific guidance to missing-reasoning warn

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1323,9 +1323,15 @@ func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasonin
 	if a.missingReasoningWarnPendingResolveAt.IsZero() {
 		a.missingReasoningWarnStateChecked = true
 	}
+	detail := fmt.Sprintf("this round carried %d tool call(s), but the endpoint omitted the thinking content DeepSeek requires clients to replay. Check the selected model, endpoint, and reasoning protocol. Repeated broken rounds are rate-limited for this exact provider configuration for up to 24 hours; a healthy tool-call turn re-arms future regressions.", len(calls))
+	if p, ok := a.prov.(provider.MissingToolCallReasoningGuidancePolicy); ok {
+		if guidance := strings.TrimSpace(p.MissingToolCallReasoningGuidance()); guidance != "" {
+			detail += " " + guidance
+		}
+	}
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text:   fmt.Sprintf("%s returned tool calls without replayable thinking content; continuing with degraded reasoning (shown once for this incident)", a.prov.Name()),
-		Detail: fmt.Sprintf("this round carried %d tool call(s), but the endpoint omitted the thinking content DeepSeek requires clients to replay. Check the selected model, endpoint, and reasoning protocol. Repeated broken rounds are rate-limited for this exact provider configuration for up to 24 hours; a healthy tool-call turn re-arms future regressions.", len(calls))})
+		Detail: detail})
 }
 
 // maxStepsPause is the deliberate stop when a positive tool-call budget runs

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -30,6 +30,18 @@ func (p configuredToolCallReasoningProvider) MissingToolCallReasoningWarningIden
 	return p.identity
 }
 
+// guidedToolCallReasoningProvider simulates a third-party relay that requires
+// tool-call reasoning but supplies endpoint-specific guidance for it.
+type guidedToolCallReasoningProvider struct {
+	*testutil.MockProvider
+	guidance string
+}
+
+func (p guidedToolCallReasoningProvider) RequiresToolCallReasoning() bool { return true }
+func (p guidedToolCallReasoningProvider) MissingToolCallReasoningGuidance() string {
+	return p.guidance
+}
+
 func echoRegistry() *tool.Registry {
 	reg := tool.NewRegistry()
 	reg.Add(echoTool{})
@@ -414,6 +426,35 @@ func TestRunWarnsAndContinuesOnMissingToolCallReasoning(t *testing.T) {
 	}
 	if warns != 1 {
 		t.Fatalf("missing-reasoning warn notices = %d, want exactly 1 (first round warns, repeats stay silent)", warns)
+	}
+}
+
+// TestRunAppendsEndpointGuidanceToMissingReasoningWarn: providers that
+// implement MissingToolCallReasoningGuidancePolicy (e.g. the OpenAI adapter
+// for third-party relays) append actionable, endpoint-specific advice to the
+// missing-reasoning warning detail.
+func TestRunAppendsEndpointGuidanceToMissingReasoningWarn(t *testing.T) {
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &recordSink{}
+	a := New(guidedToolCallReasoningProvider{mp, "relay hint: set capability mode to Plain chat"}, echoRegistry(), NewSession(""), Options{}, sink)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var detail string
+	for _, e := range sink.kinds(event.Notice) {
+		if e.Level == event.LevelWarn && strings.Contains(e.Text, "without replayable thinking content") {
+			detail = e.Detail
+		}
+	}
+	if detail == "" {
+		t.Fatal("missing-reasoning warn notice not emitted")
+	}
+	if !strings.Contains(detail, "relay hint: set capability mode to Plain chat") {
+		t.Fatalf("warn detail = %q, want endpoint guidance appended", detail)
 	}
 }
 

--- a/internal/provider/openai/missing_reasoning_guidance_test.go
+++ b/internal/provider/openai/missing_reasoning_guidance_test.go
@@ -1,0 +1,64 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestMissingToolCallReasoningGuidance(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		extra   map[string]any
+		want    string // "" = generic guidance stays; non-empty = relay hint appended
+	}{
+		{
+			name:    "official deepseek endpoint gets endpoint-behavior hint",
+			baseURL: "https://api.deepseek.com/v1",
+			want:    "api-docs.deepseek.com",
+		},
+		{
+			name:    "official endpoint with thinking disabled stays silent",
+			baseURL: "https://api.deepseek.com/v1",
+			extra:   map[string]any{"thinking": "disabled"},
+			want:    "",
+		},
+		{
+			name:    "non-deepseek endpoint stays silent",
+			baseURL: "https://relay.example.com/v1",
+			want:    "",
+		},
+		{
+			name:    "third-party relay with explicit deepseek protocol gets the hint",
+			baseURL: "https://relay.example.com/v1",
+			extra:   map[string]any{"reasoning_protocol": "deepseek"},
+			want:    "not api.deepseek.com",
+		},
+		{
+			name:    "third-party relay with plain chat protocol stays silent",
+			baseURL: "https://relay.example.com/v1",
+			extra:   map[string]any{"reasoning_protocol": "none"},
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := New(provider.Config{Name: "p", BaseURL: tc.baseURL, Model: "deepseek-v4-flash", APIKey: "k", Extra: tc.extra})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			got := p.(*client).MissingToolCallReasoningGuidance()
+			if tc.want == "" {
+				if got != "" {
+					t.Fatalf("guidance = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("guidance = %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -205,28 +205,29 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		return nil, fmt.Errorf("openai: network: %w", err)
 	}
 	return &client{
-		name:          name,
-		apiKey:        cfg.APIKey,
-		keyEnv:        keyEnv,
-		keySource:     keySource,
-		baseURL:       strings.TrimRight(cfg.BaseURL, "/"),
-		chatURL:       chatURL,
-		prefixChatURL: prefixChatURL,
-		headers:       cleanCustomHeaders(headers),
-		extraBody:     cleanExtraBody(extraBody),
-		model:         normalizeModelID(cfg.BaseURL, cfg.Model),
-		deepseek:      deepseek,
-		minimax:       minimax,
-		zhipu:         zhipu,
-		longcat:       longcat,
-		kimiK3:        kimiK3,
-		mimo:          IsMiMo(cfg.BaseURL),
-		thinkingType:  thinkingType,
-		vision:        vision,
-		visionDetail:  visionDetail,
-		effort:        effort,
-		http:          httpClient,
-		idleTimeout:   defaultStreamIdleTimeout,
+		name:             name,
+		apiKey:           cfg.APIKey,
+		keyEnv:           keyEnv,
+		keySource:        keySource,
+		baseURL:          strings.TrimRight(cfg.BaseURL, "/"),
+		chatURL:          chatURL,
+		prefixChatURL:    prefixChatURL,
+		headers:          cleanCustomHeaders(headers),
+		extraBody:        cleanExtraBody(extraBody),
+		model:            normalizeModelID(cfg.BaseURL, cfg.Model),
+		deepseek:         deepseek,
+		officialDeepSeek: officialDeepSeek,
+		minimax:          minimax,
+		zhipu:            zhipu,
+		longcat:          longcat,
+		kimiK3:           kimiK3,
+		mimo:             IsMiMo(cfg.BaseURL),
+		thinkingType:     thinkingType,
+		vision:           vision,
+		visionDetail:     visionDetail,
+		effort:           effort,
+		http:             httpClient,
+		idleTimeout:      defaultStreamIdleTimeout,
 	}, nil
 }
 
@@ -251,29 +252,30 @@ func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 }
 
 type client struct {
-	name          string
-	apiKey        string
-	keyEnv        string // api_key_env name, surfaced in auth errors
-	keySource     string // source of keyEnv, surfaced in auth errors
-	baseURL       string
-	chatURL       string
-	prefixChatURL string // official DeepSeek Beta endpoint; empty for custom gateways
-	headers       map[string]string
-	extraBody     map[string]any
-	model         string
-	http          *http.Client
-	deepseek      bool
-	minimax       bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
-	zhipu         bool          // true for Zhipu GLM (bigmodel.cn / z.ai) — gates thinking via thinking.type, ignores reasoning_effort
-	longcat       bool          // true for LongCat — gates thinking via thinking.type, ignores reasoning_effort
-	kimiK3        bool          // true only for kimi-k3 on Moonshot's official direct API hosts
-	mimo          bool          // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
-	thinkingType  string        // explicit `thinking` config override (enabled|disabled); "" = no override
-	vision        bool          // model accepts image input — embed attached images as image_url parts
-	visionDetail  string        // image_url detail hint (low|high); "" = auto/omit
-	effort        string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
-	idleTimeout   time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
-	authed        atomic.Bool   // a request has succeeded — gate transient-401 retry
+	name             string
+	apiKey           string
+	keyEnv           string // api_key_env name, surfaced in auth errors
+	keySource        string // source of keyEnv, surfaced in auth errors
+	baseURL          string
+	chatURL          string
+	prefixChatURL    string // official DeepSeek Beta endpoint; empty for custom gateways
+	headers          map[string]string
+	extraBody        map[string]any
+	model            string
+	http             *http.Client
+	deepseek         bool
+	officialDeepSeek bool          // base_url is api.deepseek.com, not a third-party relay
+	minimax          bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
+	zhipu            bool          // true for Zhipu GLM (bigmodel.cn / z.ai) — gates thinking via thinking.type, ignores reasoning_effort
+	longcat          bool          // true for LongCat — gates thinking via thinking.type, ignores reasoning_effort
+	kimiK3           bool          // true only for kimi-k3 on Moonshot's official direct API hosts
+	mimo             bool          // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
+	thinkingType     string        // explicit `thinking` config override (enabled|disabled); "" = no override
+	vision           bool          // model accepts image input — embed attached images as image_url parts
+	visionDetail     string        // image_url detail hint (low|high); "" = auto/omit
+	effort           string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	idleTimeout      time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
+	authed           atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
 
 func (c *client) Name() string { return c.name }
@@ -314,6 +316,21 @@ func (c *client) MissingToolCallReasoningWarningIdentity() string {
 		"openai", strings.TrimSpace(c.name), strings.TrimSpace(c.baseURL),
 		strings.TrimSpace(c.model), protocol, strings.TrimSpace(c.thinkingType), strings.TrimSpace(c.effort),
 	}, "\x00")
+}
+
+// MissingToolCallReasoningGuidance appends endpoint-specific advice to the
+// missing-reasoning warning. Official api.deepseek.com and third-party relays
+// get different hints: relays commonly strip reasoning_content, while on the
+// official endpoint frequent absence on tool-call turns (notably with
+// deepseek-v4-flash) is an endpoint behavior the user can work around.
+func (c *client) MissingToolCallReasoningGuidance() string {
+	if c == nil || !c.deepseek || !c.RequiresToolCallReasoning() {
+		return ""
+	}
+	if !c.officialDeepSeek {
+		return "This base_url is not api.deepseek.com: third-party relays often omit reasoning_content. If the relay does not replay DeepSeek thinking, set the Model capability mode to Plain chat or OpenAI reasoning in Compatibility settings (reasoning_protocol in config.toml) to stop this check."
+	}
+	return "Official DeepSeek Thinking Mode requires reasoning_content on tool-call turns (see api-docs.deepseek.com/guides/thinking_mode). If this repeats on every tool-call round with deepseek-v4-flash, the endpoint is omitting it — thinking context for those rounds is lost, but the turn still completes. To silence the warning, set thinking=disabled for this provider, or use a model that returns thinking on tool calls."
 }
 
 func (c *client) sendOpts() provider.SendOptions {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -781,6 +781,15 @@ type MissingToolCallReasoningWarningIdentityPolicy interface {
 	MissingToolCallReasoningWarningIdentity() string
 }
 
+// MissingToolCallReasoningGuidancePolicy optionally supplies actionable,
+// endpoint-specific guidance appended to a missing-reasoning warning.
+// Adapters distinguish official endpoints (a genuine incident worth reporting)
+// from third-party relays that may not forward reasoning_content; an empty
+// string keeps the default generic guidance.
+type MissingToolCallReasoningGuidancePolicy interface {
+	MissingToolCallReasoningGuidance() string
+}
+
 // WarnOnMissingToolCallReasoning reports whether a tool_calls turn with empty
 // reasoning_content should surface a visible warning.
 func WarnOnMissingToolCallReasoning(p Provider) bool {


### PR DESCRIPTION
## Problem

The missing-reasoning warning (introduced for #6259 / refined in #7059) fires when a DeepSeek thinking-mode tool-call turn arrives without replayable `reasoning_content`:

> `deepseek returned tool calls without replayable thinking content; continuing with degraded reasoning`
> `... Check the selected model, endpoint, and reasoning protocol.`

The generic guidance gives users nothing actionable in either common scenario:
- **Third-party relays** commonly strip `reasoning_content` and only forward the standard OpenAI `content` field — the fix is a configuration change (Model capability mode → Plain chat / OpenAI reasoning).
- **Official `api.deepseek.com`** can also omit it on tool-call turns (observed reliably with `deepseek-v4-flash`, even at max reasoning effort; see #7059) — the user should know this is an endpoint behavior with concrete workarounds, not a config error.

## Change

- New optional provider policy `provider.MissingToolCallReasoningGuidancePolicy` (`MissingToolCallReasoningGuidance() string`), following the existing optional-policy pattern in the package.
- The OpenAI adapter implements it with endpoint-specific hints:
  - `base_url` is not `api.deepseek.com` (relay) → hint to set the capability mode to Plain chat / OpenAI reasoning (`reasoning_protocol` in config.toml).
  - Official endpoint → points at the DeepSeek Thinking Mode contract (api-docs.deepseek.com/guides/thinking_mode), notes that repeated absence on tool-call turns with `deepseek-v4-flash` is endpoint behavior, and lists workarounds (`thinking=disabled` or a model that returns thinking on tool calls).
  - Empty when the warning would not fire (`RequiresToolCallReasoning()` false, e.g. thinking disabled) or for non-DeepSeek endpoints.
- `Agent.warnMissingToolCallReasoning` appends the guidance to the warn `Detail`. The warn text, rate limiting, and resolution semantics are unchanged.

## Tests

- `TestMissingToolCallReasoningGuidance` (openai, 5 cases): official endpoint → contract hint; official endpoint with thinking disabled → empty; non-DeepSeek endpoint → empty; relay with explicit `reasoning_protocol = "deepseek"` → relay hint; relay with `"none"` → empty.
- `TestRunAppendsEndpointGuidanceToMissingReasoningWarn` (agent e2e): a provider implementing the guidance policy gets its hint appended to the warn `Detail`.

## Verification

- `go test ./internal/provider/... ./internal/agent/` — pass (agent suite run multiple times; one Windows environment flake unrelated to this change, re-runs green)
- `gofmt -l` clean, `go vet` clean

Cache-impact: none — warn-event detail only; no system prompt, tool schema, memory prefix, or provider request serialization changes. (`internal/provider/openai/openai.go` and `internal/agent/agent.go` are cache-sensitive paths, but the diff adds an optional guidance string to a runtime warning, not to any provider-visible prefix.)
Cache-guard: existing agent/provider suites pass unchanged, plus the new tests above.
