### PR TITLE
fix(agent): require consecutive healthy turns to clear missing-reasoning warn

### DIFF
--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -561,6 +561,23 @@ func TestHealthyToolCallReasoningRearmsFutureRegression(t *testing.T) {
 	if got := run(healthy); got != 0 {
 		t.Fatalf("healthy turn warnings = %d, want 0", got)
 	}
+	// A single intermittent healthy turn must not re-arm the cooldown
+	// (deepseek-v4-flash returns thinking only occasionally; re-arming on one
+	// healthy turn would re-warn on every tool call).
+	if got := run(missing); got != 0 {
+		t.Fatalf("regression after a single healthy turn warnings = %d, want 0", got)
+	}
+	// Three consecutive healthy turns resolve the incident, so a later
+	// regression warns again.
+	if got := run(healthy); got != 0 {
+		t.Fatalf("healthy turn warnings = %d, want 0", got)
+	}
+	if got := run(healthy); got != 0 {
+		t.Fatalf("healthy turn warnings = %d, want 0", got)
+	}
+	if got := run(healthy); got != 0 {
+		t.Fatalf("healthy turn warnings = %d, want 0", got)
+	}
 	if got := run(missing); got != 1 {
 		t.Fatalf("post-recovery regression warnings = %d, want 1", got)
 	}

--- a/internal/agent/reasoning_warn_state.go
+++ b/internal/agent/reasoning_warn_state.go
@@ -30,9 +30,15 @@ const missingReasoningWarnStateFilename = "tool-call-reasoning-warning.json"
 
 const (
 	missingReasoningWarnStateLockFilename = "tool-call-reasoning-warning.lock"
-	missingReasoningWarnStateVersion      = 2
+	missingReasoningWarnStateVersion      = 3
 	missingReasoningWarnStateCooldown     = 24 * time.Hour
 	missingReasoningWarnStateMaxIncidents = 256
+	// missingReasoningWarnResolveStreak is the number of consecutive healthy
+	// tool-call turns required to resolve an active incident. Endpoints such as
+	// deepseek-v4-flash intermittently return replayable thinking on tool-call
+	// turns; resolving on a single healthy turn would re-arm the cooldown on
+	// every round and re-warn on each tool call (#7059).
+	missingReasoningWarnResolveStreak = 3
 	// A diagnostic must never make a turn wait indefinitely behind another
 	// process. On contention or I/O failure, callers emit the warning rather
 	// than silently losing it.
@@ -45,6 +51,10 @@ type missingReasoningIncident struct {
 	LastMissingUnixMs      int64  `json:"lastMissingAtUnixMs,omitempty"`
 	LastMissingUnixNano    int64  `json:"lastMissingAtUnixNano,omitempty"`
 	LastResolvedAtUnixNano int64  `json:"lastResolvedAtUnixNano,omitempty"`
+	// ResolveStreak counts consecutive healthy tool-call turns; the incident
+	// resolves only after missingReasoningWarnResolveStreak consecutive turns
+	// so intermittent health cannot re-arm the cooldown every round.
+	ResolveStreak int `json:"resolveStreak,omitempty"`
 }
 
 type missingReasoningWarnDocument struct {
@@ -213,7 +223,9 @@ func (s *missingReasoningWarnState) load(now time.Time) (map[string]missingReaso
 		return nil, err
 	}
 	var doc missingReasoningWarnDocument
-	if json.Unmarshal(b, &doc) != nil || doc.Version != missingReasoningWarnStateVersion {
+	// v2 documents (no resolve streak) load as streak 0 so an upgrade keeps the
+	// existing incident and its cooldown instead of losing it.
+	if json.Unmarshal(b, &doc) != nil || (doc.Version != 2 && doc.Version != missingReasoningWarnStateVersion) {
 		return incidents, nil
 	}
 	for _, rawIncident := range doc.Incidents {
@@ -320,6 +332,8 @@ func (s *missingReasoningWarnState) persistClaimAt(fingerprint string, observedA
 		incident.LastMissingUnixMs = observedAt.UnixMilli()
 		incident.LastMissingUnixNano = observedAtUnixNano
 	}
+	// A missing observation breaks the consecutive healthy-turn streak.
+	incident.ResolveStreak = 0
 	incidents[fingerprint] = incident
 	if err := s.save(incidents); err != nil {
 		return true
@@ -410,7 +424,19 @@ func (s *missingReasoningWarnState) resolveAt(fingerprint string, observedAt tim
 	if !exists {
 		incident = missingReasoningIncident{Fingerprint: fingerprint}
 	}
-	incident.LastResolvedAtUnixNano = observedAtUnixNano
+	// Resolve only after missingReasoningWarnResolveStreak consecutive healthy
+	// tool-call turns. A single intermittent healthy turn (deepseek-v4-flash)
+	// records progress but must not re-arm the cooldown; once the streak is
+	// reached the incident resolves and a future regression warns again. The
+	// method reports whether the state was recorded correctly, not whether the
+	// streak threshold was reached, so the caller never retries a recorded
+	// healthy observation (which would double-count it).
+	if incident.ResolveStreak+1 >= missingReasoningWarnResolveStreak {
+		incident.LastResolvedAtUnixNano = observedAtUnixNano
+		incident.ResolveStreak = 0
+	} else {
+		incident.ResolveStreak++
+	}
 	incidents[fingerprint] = incident
 	return s.save(incidents) == nil
 }

--- a/internal/agent/reasoning_warn_state_test.go
+++ b/internal/agent/reasoning_warn_state_test.go
@@ -43,7 +43,7 @@ func TestMissingReasoningWarnStatePersistsCurrentIncidentAcrossInstances(t *test
 		t.Fatalf("state file missing after claim: %v", err)
 	}
 	latestObservedAt := observedAt.Add(time.Minute)
-	want := fmt.Sprintf(`{"version":2,"incidents":[{"fingerprint":"%s","warnedAtUnixMs":%d,"lastMissingAtUnixMs":%d,"lastMissingAtUnixNano":%d}]}`,
+	want := fmt.Sprintf(`{"version":3,"incidents":[{"fingerprint":"%s","warnedAtUnixMs":%d,"lastMissingAtUnixMs":%d,"lastMissingAtUnixNano":%d}]}`,
 		fingerprint, observedAt.UnixMilli(), latestObservedAt.UnixMilli(), latestObservedAt.UnixNano())
 	if got := string(b); got != want {
 		t.Fatalf("state file = %s, want %s", got, want)
@@ -90,9 +90,40 @@ func TestMissingReasoningWarnStateHealthyTurnRearmsRegression(t *testing.T) {
 	if !s.claimAt(fingerprint, now) {
 		t.Fatal("fresh incident must warn")
 	}
+	// A single healthy turn must not re-arm the incident: endpoints such as
+	// deepseek-v4-flash intermittently return thinking on tool-call turns, and
+	// resolving on one healthy turn would re-warn on every tool call.
 	s.resolveAt(fingerprint, now.Add(time.Minute))
-	if !s.claimAt(fingerprint, now.Add(2*time.Minute)) {
-		t.Fatal("regression after a healthy turn must warn again")
+	if s.claimAt(fingerprint, now.Add(2*time.Minute)) {
+		t.Fatal("single healthy turn re-armed the incident")
+	}
+	// Three consecutive healthy turns resolve the incident, so a later
+	// regression warns again.
+	s.resolveAt(fingerprint, now.Add(3*time.Minute))
+	s.resolveAt(fingerprint, now.Add(4*time.Minute))
+	s.resolveAt(fingerprint, now.Add(5*time.Minute))
+	if !s.claimAt(fingerprint, now.Add(6*time.Minute)) {
+		t.Fatal("regression after three consecutive healthy turns must warn again")
+	}
+}
+
+func TestMissingReasoningWarnStateIntermittentHealthDoesNotRearmEveryRound(t *testing.T) {
+	s := newMissingReasoningWarnState(t.TempDir())
+	fingerprint := warningFingerprint("config")
+	now := missingReasoningTestNow()
+	if !s.claimAt(fingerprint, now) {
+		t.Fatal("fresh incident must warn")
+	}
+	// Intermittent health (deepseek-v4-flash) must not re-arm the cooldown:
+	// a missing observation between healthy turns resets the streak, so the
+	// incident stays quiet for the whole 24h cooldown.
+	s.resolveAt(fingerprint, now.Add(time.Minute))
+	if s.claimAt(fingerprint, now.Add(2*time.Minute)) {
+		t.Fatal("intermittent healthy turn re-armed the incident")
+	}
+	s.resolveAt(fingerprint, now.Add(3*time.Minute))
+	if s.claimAt(fingerprint, now.Add(4*time.Minute)) {
+		t.Fatal("interrupted healthy streak re-armed the incident")
 	}
 }
 
@@ -126,12 +157,14 @@ func TestMissingReasoningWarnStateDelayedFailureCannotReviveResolvedIncident(t *
 		t.Fatal("fresh incident must warn")
 	}
 	s.resolveAt(fingerprint, healthyAt)
+	s.resolveAt(fingerprint, healthyAt.Add(time.Millisecond))
+	s.resolveAt(fingerprint, healthyAt.Add(2*time.Millisecond))
 	// Simulate a missing observation that happened before the healthy result but
 	// completed its cross-process transaction afterward.
 	if s.persistClaimAt(fingerprint, delayedMissingAt) {
 		t.Fatal("delayed pre-recovery failure revived a resolved incident")
 	}
-	if !s.claimAt(fingerprint, now) {
+	if !s.claimAt(fingerprint, now.Add(5*time.Millisecond)) {
 		t.Fatal("healthy result did not re-arm a later regression")
 	}
 }
@@ -178,8 +211,8 @@ func TestMissingReasoningWarnStateLegacyPreviewRearmsAndMigrates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(b), `"providers"`) || !strings.Contains(string(b), `"version":2`) {
-		t.Fatalf("legacy state was not migrated to v2: %s", b)
+	if strings.Contains(string(b), `"providers"`) || !strings.Contains(string(b), `"version":3`) {
+		t.Fatalf("legacy state was not migrated to v3: %s", b)
 	}
 }
 


### PR DESCRIPTION
## Problem

The 24h missing-reasoning rate limit (#7059 → #7109) is re-armed by **a single** healthy tool-call turn. Endpoints such as `deepseek-v4-flash` intermittently return replayable thinking on tool-call turns: most tool rounds omit `reasoning_content`, but one occasionally carries it. Each such turn resolves the incident, so the next missing round warns again — users on the official DeepSeek API with `deepseek-v4-flash` see the warning on **nearly every tool call**, defeating the rate limit entirely (observed state file: `warnedAt` … `lastResolvedAt` 6 minutes later, repeated every round).

## Change

Resolve an incident only after **`missingReasoningWarnResolveStreak` (3) consecutive healthy tool-call turns**:

- `missingReasoningIncident` gains `ResolveStreak`; state schema moves to **v3**.
- `resolveAt` increments the streak and records `LastResolvedAtUnixNano` only when the streak reaches 3; it still reports "state recorded" (not "threshold reached"), so callers never retry and double-count a healthy observation.
- `persistClaimAt` resets the streak on every missing observation — an intermittent healthy turn can never accumulate into a resolve.
- `load` accepts v2 documents (streak 0), so an upgrade keeps the existing incident and its active cooldown instead of losing it and re-warning.

Behavior matrix:

| Pattern | Before | After |
| --- | --- | --- |
| Intermittent health (flash) | warns on nearly every tool call | silent for the 24h cooldown |
| Sustained regression | one warning per 24h | unchanged |
| True recovery (3+ healthy turns) | re-armed | re-armed (future regressions still visible) |

## Tests

- `TestMissingReasoningWarnStateHealthyTurnRearmsRegression`: one healthy turn must **not** re-arm; three consecutive healthy turns must.
- `TestMissingReasoningWarnStateIntermittentHealthDoesNotRearmEveryRound`: missing observations between healthy turns reset the streak; the incident stays quiet through the cooldown.
- `TestMissingReasoningWarnStateDelayedFailureCannotReviveResolvedIncident` / `TestMissingReasoningWarnStateFutureLastMissingSelfHeals`: updated to the three-turn resolve semantics; watermark ordering guarantees preserved.
- `TestHealthyToolCallReasoningRearmsFutureRegression` (e2e): single healthy turn keeps the cooldown; three consecutive healthy turns re-arm a later regression.
- `TestMissingReasoningWarnStateLoadsV2IncidentWithoutNanosecondField` / `...LegacyPreviewRearmsAndMigrates`: v2/v1 upgrade paths still pass (migration now targets v3).

## Verification

- `go test -count=1 ./internal/agent/` — pass (full package)
- `gofmt -l internal/agent/` clean, `go vet ./internal/agent/` clean, `go build ./cmd/reasonix` pass

Cache-impact: none — diagnostic rate-limit state only; no provider-visible system prompt, tool schema, memory prefix, or request serialization changes. (`internal/agent/reasoning_warn_state.go` is not on the cache-sensitive path list.)
Cache-guard: existing agent suite passes unchanged, plus the streak regression tests above.
