### PR TITLE
fix: add null guards for model/provider fields to prevent React crash

### DIFF
--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -80,7 +80,7 @@ export function ModelSwitcher({
   const keyword = query.trim().toLowerCase();
   const filtered = useMemo(
     () => keyword
-      ? models.filter((m) => m.model.toLowerCase().includes(keyword) || m.provider.toLowerCase().includes(keyword))
+      ? models.filter((m) => (m.model ?? '').toLowerCase().includes(keyword) || (m.provider ?? '').toLowerCase().includes(keyword))
       : models,
     [models, keyword],
   );
@@ -90,10 +90,11 @@ export function ModelSwitcher({
     const map = new Map<string, ModelInfo[]>();
     let currentProvider = "";
     for (const m of filtered) {
-      if (m.current) currentProvider = m.provider;
-      const list = map.get(m.provider);
+      const prov = m.provider ?? '';
+      if (m.current) currentProvider = prov;
+      const list = map.get(prov);
       if (list) list.push(m);
-      else map.set(m.provider, [m]);
+      else map.set(prov, [m]);
     }
     return [...map.entries()]
       .sort(([a], [b]) => {

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -5529,12 +5529,13 @@ function providerBaseHost(baseUrl: string): string {
 }
 
 function canonicalOfficialProviderName(name: string): string {
-  switch (name.trim()) {
+  const safeName = (name ?? '').trim();
+  switch (safeName) {
     case "deepseek-flash":
     case "deepseek-pro":
       return "deepseek";
     default:
-      return name.trim();
+      return safeName;
   }
 }
 
@@ -5549,19 +5550,19 @@ function officialProviderKind(p: ProviderView): string {
 function providerGroupID(p: ProviderView): string {
   const official = officialProviderKind(p);
   if (official) return `builtin:${official}`;
-  return `custom:${p.name}`;
+  return `custom:${p.name ?? 'unknown'}`;
 }
 
 function providerGroupLabel(p: ProviderView, t?: ReturnType<typeof useT>): string {
   const id = providerGroupID(p);
   if (id === "builtin:deepseek") return t ? t("settings.providerLabel.deepseek") : "DeepSeek";
-  return p.name;
+  return p.name ?? '';
 }
 
 function providerGroupDescription(p: ProviderView, t: ReturnType<typeof useT>): string {
   const id = providerGroupID(p);
   if (id === "builtin:deepseek") return t("settings.providerDesc.deepseek");
-  return p.baseUrl;
+  return p.baseUrl ?? '';
 }
 
 function uniqueStrings(values: string[]): string[] {


### PR DESCRIPTION
## Problem

The model picker crashes when `ModelInfo.model` or `ModelInfo.provider` is null/undefined, and similarly when `ProviderView.name` or `ProviderView.baseUrl` is missing. This affects ModelSwitcher.tsx (line 83) and SettingsPanel.tsx (the canonicalOfficialProviderName name.trim() call chain in providerGroupID).

Refs #7189, #7221

## Fix

Added nullish coalescing guards at every call site that calls .toLowerCase() or .trim() on potentially-null model/provider/name fields:

**ModelSwitcher.tsx:**
- m.model.toLowerCase() -> (m.model || '').toLowerCase()
- m.provider.toLowerCase() -> (m.provider || '').toLowerCase()
- m.provider in groupBy map -> m.provider || ''

**SettingsPanel.tsx:**
- canonicalOfficialProviderName: name.trim() -> (name || '').trim()
- providerGroupID: p.name -> p.name || 'unknown'
- providerGroupLabel: return p.name -> return p.name || ''
- providerGroupDescription: return p.baseUrl -> return p.baseUrl || ''

## Testing

Verified by inspecting that all .toLowerCase(), .trim(), and .name/.baseUrl return expressions in the affected functions are now guarded.
