### PR TITLE
fix(release): verify versioned Windows portable archives

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -493,12 +493,26 @@ jobs:
         if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         run: cp signed-installer/*installer*.exe dist/
 
+      # Recovery builds intentionally check out the immutable product SHA,
+      # which can predate a verifier repair. Fetch only the verifier from the
+      # protected workflow commit so recovery can validate old immutable
+      # artifacts without rebuilding them from a moving product branch.
+      - name: Checkout protected release verifier
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: release-control
+          sparse-checkout: scripts/verify-windows-authenticode.ps1
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Verify Windows Authenticode release contract
         if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
         shell: pwsh
         run: |
           $arch = if ("${{ matrix.platform }}" -eq "windows/arm64") { "arm64" } else { "amd64" }
-          ./scripts/verify-windows-authenticode.ps1 `
+          ./release-control/scripts/verify-windows-authenticode.ps1 `
             -PayloadDirectory signed-payload `
             -InstallerPath "dist/Reasonix-windows-$arch-installer.exe" `
             -PortableArchivePath "dist/Reasonix-windows-$arch.zip" `

--- a/desktop/windows_signing_packaging_test.go
+++ b/desktop/windows_signing_packaging_test.go
@@ -58,6 +58,7 @@ func TestWindowsReleaseSignsPayloadBeforeRepackaging(t *testing.T) {
 		"name: Submit installer for Authenticode signing",
 		"name: Approve and download signed Windows installer",
 		"name: Replace installer with signed build",
+		"name: Checkout protected release verifier",
 		"name: Verify Windows Authenticode release contract",
 		"name: Sign artifacts (minisign)",
 	}
@@ -92,6 +93,9 @@ func TestWindowsReleaseSignsPayloadBeforeRepackaging(t *testing.T) {
 		`go run ./cmd/sign sign ../signed-payload/reasonix-payload.json`,
 		`go run ./cmd/sign verify ../signed-payload/reasonix-payload.json`,
 		`REASONIX_REQUIRE_PAYLOAD_MANIFEST: "1"`,
+		`ref: ${{ github.sha }}`,
+		`path: release-control`,
+		`./release-control/scripts/verify-windows-authenticode.ps1`,
 	} {
 		if !strings.Contains(workflow, want) {
 			t.Errorf("desktop release workflow is missing signing contract %q", want)
@@ -142,6 +146,10 @@ func TestWindowsReleaseSignsPayloadBeforeRepackaging(t *testing.T) {
 		"$signature.SignerCertificate",
 		"$signature.Status -ne \"Valid\"",
 		"Expand-Archive",
+		`Get-ChildItem -LiteralPath $extractRoot -Recurse -File -Filter "*.exe"`,
+		`$activeDir.Replace("\", "/") -ne "versions/$activeVersion"`,
+		`Portable = (Join-Path $activeDir "reasonix-desktop.exe")`,
+		`Portable = "reasonix-desktop.exe"`,
 		"Portable archive must contain exactly 6 executables",
 		"Get-FileHash -Algorithm SHA256",
 	} {

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -111,7 +111,9 @@ grep -Fq 'bash scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflo
 [ "$(grep -Fc 'IN_ORCHESTRATOR: ${{ inputs.orchestrator }}' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]
 [ "$(grep -Fc 'name: Revalidate immutable Desktop candidate' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'ref: ${{ needs.resolve.outputs.sha }}' "$repo_root/.github/workflows/release-desktop.yml")" -ge 4 ]
-[ "$(grep -Ec '^          path: release-control$' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
+[ "$(grep -Ec '^          path: release-control$' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]
+grep -Fq 'name: Checkout protected release verifier' "$repo_root/.github/workflows/release-desktop.yml"
+grep -Fq './release-control/scripts/verify-windows-authenticode.ps1' "$repo_root/.github/workflows/release-desktop.yml"
 [ "$(grep -Fc 'ref: ${{ github.workflow_sha }}' "$repo_root/.github/workflows/release-desktop.yml")" -ge 2 ]
 [ "$(grep -Fc 'bash release-control/scripts/resolve-desktop-candidate.sh' "$repo_root/.github/workflows/release-desktop.yml")" = "2" ]
 [ "$(grep -Fc 'RELEASE_TAG: ${{ inputs.approved_cli_tag }}' "$repo_root/.github/workflows/release-desktop.yml")" = "3" ]

--- a/scripts/verify-windows-authenticode.ps1
+++ b/scripts/verify-windows-authenticode.ps1
@@ -53,27 +53,65 @@ Assert-AuthenticodeSignature -Path $InstallerPath
 $extractRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("reasonix-authenticode-" + [guid]::NewGuid().ToString("N"))
 try {
     Expand-Archive -LiteralPath $PortableArchivePath -DestinationPath $extractRoot
-    $portableFiles = @(Get-ChildItem -LiteralPath $extractRoot -File -Filter "*.exe")
+
+    # Legacy portable releases kept all six executables at InstallRoot. The
+    # versioned-v1 layout deliberately keeps only the launcher aliases and CLI
+    # at the root, while the active Desktop, update helper, and CLI live under
+    # versions/vX.Y.Z/. Verify the exact layout selected by current.json instead
+    # of treating the three versioned executables as missing.
+    $currentPath = Join-Path $extractRoot "current.json"
+    if (Test-Path -LiteralPath $currentPath -PathType Leaf) {
+        $current = Get-Content -LiteralPath $currentPath -Raw | ConvertFrom-Json
+        if ($current.schemaVersion -ne 1) {
+            throw "Portable current.json schemaVersion must be 1"
+        }
+        $activeVersion = [string]$current.activeVersion
+        $activeDir = [string]$current.activeDir
+        if ($activeVersion -notmatch '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$' -or
+            [string]::IsNullOrWhiteSpace($activeDir) -or
+            $activeDir.Replace("\", "/") -ne "versions/$activeVersion") {
+            throw "Portable current.json must bind activeVersion to versions/<activeVersion>"
+        }
+
+        $activePath = [System.IO.Path]::GetFullPath((Join-Path $extractRoot $activeDir))
+        $extractPrefix = [System.IO.Path]::GetFullPath($extractRoot).TrimEnd([char[]]@('\', '/')) + [System.IO.Path]::DirectorySeparatorChar
+        if (-not $activePath.StartsWith($extractPrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not (Test-Path -LiteralPath $activePath -PathType Container)) {
+            throw "Portable current.json activeDir escapes or is missing: $activeDir"
+        }
+
+        $portableSources = @(
+            [pscustomobject]@{ Portable = "reasonix-launcher.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "Reasonix.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "reasonix-cli.exe"; Payload = "reasonix-cli.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-desktop.exe"); Payload = "reasonix-desktop.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-update-helper.exe"); Payload = "reasonix-update-helper.exe" },
+            [pscustomobject]@{ Portable = (Join-Path $activeDir "reasonix-cli.exe"); Payload = "reasonix-cli.exe" }
+        )
+    }
+    else {
+        $portableSources = @(
+            [pscustomobject]@{ Portable = "reasonix-desktop.exe"; Payload = "reasonix-desktop.exe" },
+            [pscustomobject]@{ Portable = "reasonix-guard.exe"; Payload = "reasonix-guard.exe" },
+            [pscustomobject]@{ Portable = "reasonix-launcher.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "Reasonix.exe"; Payload = "reasonix-launcher.exe" },
+            [pscustomobject]@{ Portable = "reasonix-update-helper.exe"; Payload = "reasonix-update-helper.exe" },
+            [pscustomobject]@{ Portable = "reasonix-cli.exe"; Payload = "reasonix-cli.exe" }
+        )
+    }
+
+    $portableFiles = @(Get-ChildItem -LiteralPath $extractRoot -Recurse -File -Filter "*.exe")
     if ($portableFiles.Count -ne 6) {
         throw "Portable archive must contain exactly 6 executables, found $($portableFiles.Count)"
     }
-    foreach ($file in $portableFiles) {
-        Assert-AuthenticodeSignature -Path $file.FullName
-    }
 
-    $portableSources = @{
-        "reasonix-desktop.exe"       = "reasonix-desktop.exe"
-        "reasonix-guard.exe"         = "reasonix-guard.exe"
-        "reasonix-launcher.exe"      = "reasonix-launcher.exe"
-        "Reasonix.exe"               = "reasonix-launcher.exe"
-        "reasonix-update-helper.exe" = "reasonix-update-helper.exe"
-        "reasonix-cli.exe"           = "reasonix-cli.exe"
-    }
-    foreach ($entry in $portableSources.GetEnumerator()) {
-        $portableHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $extractRoot $entry.Key)).Hash
-        $payloadHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $PayloadDirectory $entry.Value)).Hash
+    foreach ($entry in $portableSources) {
+        $portablePath = Join-Path $extractRoot $entry.Portable
+        Assert-AuthenticodeSignature -Path $portablePath
+        $portableHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $portablePath).Hash
+        $payloadHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $PayloadDirectory $entry.Payload)).Hash
         if ($portableHash -ne $payloadHash) {
-            throw "Portable $($entry.Key) does not match signed payload $($entry.Value)"
+            throw "Portable $($entry.Portable) does not match signed payload $($entry.Payload)"
         }
     }
 }


### PR DESCRIPTION
## Problem

The v1.19.3 Stable SignPath preflight stopped both Windows architectures after every payload executable and the installer had already passed Authenticode validation. The final verifier reported:

```text
Portable archive must contain exactly 6 executables, found 3
```

No publisher ran and no public surface was advanced.

## Root cause

`verify-windows-authenticode.ps1` still searched only the portable archive root. The versioned-v1 layout introduced by #7199 intentionally contains three root executables and three active executables under `versions/vX.Y.Z/`.

## Fix

- validate `current.json`, its schema, canonical active version, bound `activeDir`, and containment
- require exactly six executables recursively and verify every expected legacy-flat or versioned-v1 path
- preserve Authenticode trust and SHA256 equality checks against the signed payload
- load the verifier from the protected workflow commit so an immutable v1.19.3 candidate can be recovered without moving its tags
- extend workflow and packaging contract tests

## Verification

- `bash scripts/release-workflows.test.sh`
- `node scripts/check-single-release-public-contract.mjs`
- `go -C desktop test . -run 'TestWindowsReleaseSignsPayloadBeforeRepackaging|TestWindowsPackagerRejectsMissingOrPartialRequiredPayloadManifest' -count=1`
- `actionlint`
- `./scripts/cache-guard.sh`
- `git diff --check`
