### PR TITLE
Fix false-positive missing tool-call reasoning warning

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1269,10 +1269,16 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 // warnMissingToolCallReasoning surfaces a thinking-mode tool-call turn that
 // arrived without replayable provider reasoning. DeepSeek requires that
 // thinking content to be returned and replayed, so absence is a compatibility
-// incident rather than a permanent provider trait. Repeated broken rounds are
-// rate-limited by exact provider configuration, while a healthy round resolves
-// the incident and re-arms a future regression (#6259, #7059).
-func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) {
+// incident rather than a permanent provider trait — except when the service
+// reports no thinking tokens were spent: thinking mode is opportunistic, so
+// models like deepseek-v4-flash may call tools directly without producing
+// reasoning_content (usage.reasoning_tokens == 0), which the API accepts and
+// never requires replaying. Only a turn where the service reports thinking
+// tokens (reasoning_tokens > 0) yet no content arrived counts as an incident.
+// Repeated broken rounds are rate-limited by exact provider configuration,
+// while a healthy round resolves the incident and re-arms a future regression
+// (#6259, #7059).
+func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasoning string, usage *provider.Usage) {
 	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.prov) {
 		return
 	}
@@ -1296,6 +1302,14 @@ func (a *Agent) warnMissingToolCallReasoning(calls []provider.ToolCall, reasonin
 				a.missingReasoningWarnStateChecked = false
 			}
 		}
+		return
+	}
+	// A tool-call turn without reasoning is only an incident when the service
+	// reports thinking tokens were spent: reasoning_tokens == 0 proves the
+	// model skipped thinking this round (healthy opportunistic behaviour), so
+	// there is nothing the client could have lost or must replay. Absent
+	// usage we stay conservative and keep the original warning path.
+	if usage != nil && usage.ReasoningTokens == 0 {
 		return
 	}
 	if a.warnedMissingToolCallReasoning {

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -585,7 +585,7 @@ func TestHealthyToolCallReasoningRetriesTransientStateWriteFailure(t *testing.T)
 		return count
 	}
 
-	a.warnMissingToolCallReasoning(calls, "")
+	a.warnMissingToolCallReasoning(calls, "", nil)
 	if got := warnCount(); got != 1 {
 		t.Fatalf("initial warnings = %d, want 1", got)
 	}
@@ -598,15 +598,84 @@ func TestHealthyToolCallReasoningRetriesTransientStateWriteFailure(t *testing.T)
 			_ = os.Chmod(stateDir, 0o700)
 		}
 	}()
-	a.warnMissingToolCallReasoning(calls, "healthy reasoning")
+	a.warnMissingToolCallReasoning(calls, "healthy reasoning", nil)
 	if err := os.Chmod(stateDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	permissionsRestored = true
 
-	a.warnMissingToolCallReasoning(calls, "")
+	a.warnMissingToolCallReasoning(calls, "", nil)
 	if got := warnCount(); got != 2 {
 		t.Fatalf("warnings after transient healthy-state write failure = %d, want 2", got)
+	}
+}
+
+// TestRunSkipsMissingToolCallReasoningWarnWhenModelSkippedThinking: thinking
+// mode is opportunistic — deepseek-v4-flash and similar models may call tools
+// without producing reasoning_content (usage.reasoning_tokens == 0), which is
+// healthy model behaviour, not a lost-reasoning incident. The warning must
+// fire only when the service reports thinking tokens were spent
+// (reasoning_tokens > 0) yet no content arrived; with no usage telemetry the
+// conservative warning path stays in place.
+func TestRunSkipsMissingToolCallReasoningWarnWhenModelSkippedThinking(t *testing.T) {
+	warnCount := func(sink *recordSink) int {
+		var n int
+		for _, e := range sink.kinds(event.Notice) {
+			if e.Level == event.LevelWarn && strings.Contains(e.Text, "without replayable thinking content") {
+				n++
+			}
+		}
+		return n
+	}
+
+	// reasoning_tokens == 0: the model skipped thinking, so no warning.
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}},
+			Usage:     &provider.Usage{ReasoningTokens: 0},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &recordSink{}
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), NewSession(""), Options{}, sink)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := warnCount(sink); got != 0 {
+		t.Fatalf("warn notices for a turn where the model skipped thinking (reasoning_tokens=0) = %d, want 0", got)
+	}
+
+	// reasoning_tokens > 0: thinking happened but no content arrived — incident.
+	mp2 := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "c2", Name: "echo", Arguments: `{"text":"hi"}`}},
+			Usage:     &provider.Usage{ReasoningTokens: 42},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink2 := &recordSink{}
+	a2 := New(toolCallReasoningRequiredProvider{mp2}, echoRegistry(), NewSession(""), Options{}, sink2)
+	if err := a2.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := warnCount(sink2); got != 1 {
+		t.Fatalf("warn notices with reasoning_tokens=42 and no content = %d, want 1", got)
+	}
+
+	// usage == nil: unknown, keep the conservative warning path.
+	mp3 := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "c3", Name: "echo", Arguments: `{"text":"hi"}`}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink3 := &recordSink{}
+	a3 := New(toolCallReasoningRequiredProvider{mp3}, echoRegistry(), NewSession(""), Options{}, sink3)
+	if err := a3.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := warnCount(sink3); got != 1 {
+		t.Fatalf("warn notices with no usage telemetry = %d, want 1 (conservative)", got)
 	}
 }
 

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -231,7 +231,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		// archive. Most OpenAI-compatible backends do not replay it; providers
 		// with an explicit round-trip contract retain the raw provider text.
 		calls = a.withPreviewFileDiffs(calls)
-		a.warnMissingToolCallReasoning(calls, reasoning)
+		a.warnMissingToolCallReasoning(calls, reasoning, usage)
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,


### PR DESCRIPTION
warnMissingToolCallReasoning 之前将 thinking 模式下每个缺少 reasoning_content 的工具调用轮都视为兼容性事故。DeepSeek 的 thinking 模式是机会式的：像 deepseek-v4-flash 这类模型可能直接调用工具而不产生推理内容（usage.reasoning_tokens == 0），API 接受这种情况且无需客户端回放——这是正常行为，并非推理内容丢失。

现在警告仅在服务端报告产生了思考 token（reasoning_tokens > 0）但 reasoning_content 未送达时触发；当缺少 usage 遥测时，保留原有保守告警路径（#6259、#7059 的事故仍会被捕获）。

## Summary

- 修复误报：thinking 模式下模型自主跳过思考直接调用工具（reasoning_tokens == 0）时，不再弹出 "returned tool calls without replayable thinking content" 警告
- 判别依据：provider usage 的 reasoning_tokens；为 0 表示模型未思考（正常），大于 0 但无内容才是真事故
- 不改变请求序列化、system prompt、工具 schema 与写入会话的消息，prompt-cache 前缀字节不变

## Issues

<!--
如本 PR 关联 issue，请单独一行写 `Fixes #123` 或 `Refs #123`；无关联可删除本段。
-->

## Verification

- go build ./...
- go vet ./internal/agent/
- go test ./internal/agent/... ./internal/provider/...（全绿，含新增测试 TestRunSkipsMissingToolCallReasoningWarnWhenModelSkippedThinking）

## Cache impact

- Cache-impact: none - Diagnostic-only change in warnMissingToolCallReasoning (agent.go); request serialization, system prompt, tool schemas, and session messages are untouched, so the prompt-cache prefix is byte-identical.
- Cache-guard: go test ./internal/agent/ -run TestRunWarnsAndContinuesOnMissingToolCallReasoning -count=1