### PR TITLE
fix(serve): make Auto mode reversible

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -1703,8 +1703,9 @@ function updateGoalUI(){
 async function setToolApprovalMode(mode){toolApprovalMode=mode;bypassMode=mode==='yolo';updateModeButtons();await post('/tool-approval-mode',{mode});}
 async function setPlan(on){planMode=on;updateModeButtons();await post('/plan',{on});}
 async function cycleMode(){if(goalMode){goalMode=false;updateGoalUI();return;}await setPlan(!planMode);setTimeout(fetchStatus,200);}
+async function toggleAutoMode(){const auto=!bypassMode&&toolApprovalMode==='auto';await setToolApprovalMode(auto?'ask':'auto');setTimeout(fetchStatus,200);}
 async function toggleYolo(){if(bypassMode){const restore=yoloRestoreMode==='auto'?'auto':'ask';await setToolApprovalMode(restore);}else{yoloRestoreMode=toolApprovalMode==='auto'?'auto':'ask';await setToolApprovalMode('yolo');}setTimeout(fetchStatus,200);}
-async function setMode(m){if(m==='auto')await setToolApprovalMode('auto');else if(m==='plan')await setPlan(!planMode);else if(m==='yolo')await toggleYolo();else if(m==='goal')toggleGoalMode();}
+async function setMode(m){if(m==='auto')await toggleAutoMode();else if(m==='plan')await setPlan(!planMode);else if(m==='yolo')await toggleYolo();else if(m==='goal')toggleGoalMode();}
 function toggleGoalMode(){
   if(goalActive){
     // Clear active goal

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -313,6 +313,19 @@ func TestServeIndexDefinesQueryHelpers(t *testing.T) {
 	}
 }
 
+func TestServeIndexAutoModeButtonCanTurnAutoOff(t *testing.T) {
+	html := string(indexHTML)
+	for _, want := range []string{
+		"async function toggleAutoMode(){",
+		"await setToolApprovalMode(auto?'ask':'auto');",
+		"if(m==='auto')await toggleAutoMode();",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("serve index missing reversible Auto mode behavior %q", want)
+		}
+	}
+}
+
 func TestServeIndexHandlesRetryingEvents(t *testing.T) {
 	html := string(indexHTML)
 	for _, want := range []string{


### PR DESCRIPTION
## Summary

- Make the `reasonix serve` Auto approval button reversible: clicking it while Auto is active now switches back to ask mode.
- Add a serve index regression contract so the Auto button keeps a toggle-to-ask path.

## Issues

Fixes #7208

## Verification

- `go test ./internal/serve -run TestServeIndexAutoModeButtonCanTurnAutoOff -count=1`
- `go test ./internal/serve -count=1`
- `go test ./... -count=1` attempted locally; `reasonix/internal/serve` passed, while unrelated Windows environment-sensitive packages failed due local Git Bash/POSIX shell, symlink privilege, SSH/MCP/plugin, and bot/CLI test requirements.

## Cache impact

Cache-impact: none; serve web UI client behavior only, no provider-visible prompt/tool/schema serialization changes.
Cache-guard: `go test ./internal/serve -run TestServeIndexAutoModeButtonCanTurnAutoOff -count=1`
System-prompt-review: N/A