### PR TITLE
feat(cli): add Ctrl+Insert copy and Shift+Insert paste to the chat TUI

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1089,14 +1089,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		// Any keystroke dismisses a finished selection (copy is a right-click),
-		// with a few exceptions: Ctrl/Super/Meta+C copies the selection, the
-		// paste shortcuts keep it so the async clipboard result can replace
-		// it, and Left/Right collapse it to its ordered start/end.
+		// with a few exceptions: Ctrl/Super/Meta+C and Ctrl+Insert copy the
+		// selection, the paste shortcuts keep it so the async clipboard result
+		// can replace it, and Left/Right collapse it to its ordered start/end.
 		sel := m.sel
 		m.sel = selection{}
 		if m.validComposerSelection() && !m.composerSel.empty() {
 			switch {
-			case msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c":
+			case msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c" || msg.String() == "ctrl+insert":
 				cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
 				return m, finalize(m, cmds)
 			case imagePasteShortcut(msg.String(), runtime.GOOS):
@@ -1289,6 +1289,17 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, finalize(m, cmds)
 		}
+		// Shift+Insert is the classic terminal paste key. Most terminals
+		// intercept it themselves and deliver the clipboard text as bracketed
+		// paste (tea.PasteMsg); some forward the key sequence instead (e.g. via
+		// the kitty keyboard protocol). Bind it explicitly so paste works
+		// either way — same native-clipboard read path as right-click, so SSH
+		// sessions get the same remote hint and never read the remote host's
+		// clipboard.
+		if msg.String() == "shift+insert" {
+			cmds = append(cmds, pasteClipboardText())
+			return m, finalize(m, cmds)
+		}
 		switch msg.String() {
 		case "esc":
 			// "Back out" of the most specific in-progress state: un-send a just-sent
@@ -1326,6 +1337,21 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.input.Reset()
 					m.pastedBlocks = nil
 				}
+			}
+			return m, nil
+		case "ctrl+insert":
+			// Terminal-convention copy without Ctrl+C's destructive side
+			// effects: copy an active selection if there is one, otherwise do
+			// nothing (no clear-input, no cancel, no quit). The selection lives
+			// in-app because Reasonix owns the mouse, so the terminal's own
+			// Ctrl+Insert (which copies the terminal selection) would see an
+			// empty one.
+			if sel.active && !sel.empty() {
+				m.sel = sel // restore so selectedText() can read it
+				text := m.selectedText()
+				m.sel = selection{}
+				cmds = append(cmds, m.copySelectionWithNotice(text))
+				return m, finalize(m, cmds)
 			}
 			return m, nil
 		case "ctrl+c", "super+c", "meta+c":

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1710,6 +1710,58 @@ func TestMouseRightClickWithoutSelectionPastesClipboardText(t *testing.T) {
 	}
 }
 
+func TestShiftInsertPastesClipboardText(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before ")
+
+	previous := readNativeClipboardText
+	t.Cleanup(func() { readNativeClipboardText = previous })
+	readNativeClipboardText = func() (string, error) { return "pasted text", nil }
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModShift})
+	m = next.(chatTUI)
+	if got := m.input.Value(); got != "before " {
+		t.Fatalf("Shift+Insert changed the composer before the async read: %q", got)
+	}
+	result := clipboardTextPasteResultFromCmd(t, cmd)
+	next, _ = m.Update(result)
+	m = next.(chatTUI)
+
+	if got := m.input.Value(); got != "before pasted text" {
+		t.Fatalf("Shift+Insert paste produced %q, want %q", got, "before pasted text")
+	}
+}
+
+func TestShiftInsertPasteOverSSHDoesNotReadRemoteClipboard(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "host 22 client 1234")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before ")
+
+	previous := readNativeClipboardText
+	t.Cleanup(func() { readNativeClipboardText = previous })
+	readNativeClipboardText = func() (string, error) {
+		t.Fatal("SSH Shift+Insert paste must not read the remote host clipboard")
+		return "", nil
+	}
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModShift})
+	m = next.(chatTUI)
+	result := clipboardTextPasteResultFromCmd(t, cmd)
+	if !result.remote {
+		t.Fatalf("SSH Shift+Insert paste result = %+v, want remote hint", result)
+	}
+
+	next, _ = m.Update(result)
+	m = next.(chatTUI)
+	if got := m.input.Value(); got != "before " {
+		t.Fatalf("SSH Shift+Insert paste changed composer to %q", got)
+	}
+}
+
 func TestMouseRightClickPasteOverSSHDoesNotReadRemoteClipboard(t *testing.T) {
 	t.Setenv("SSH_CONNECTION", "host 22 client 1234")
 	t.Setenv("SSH_CLIENT", "")
@@ -1992,6 +2044,85 @@ func TestMouseDragReleaseAutoCopies(t *testing.T) {
 	m3 := out.(chatTUI)
 	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
 		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertCopiesTranscriptSelection verifies the terminal-convention
+// Ctrl+Insert copy key copies an active transcript selection to the clipboard
+// and arms the copied notice, without Ctrl+C's destructive side effects.
+func TestCtrlInsertCopiesTranscriptSelection(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newTestChatTUI()
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 0}, head: selPos{line: 0, col: 5}}
+
+	previous := writeNativeClipboardText
+	t.Cleanup(func() { writeNativeClipboardText = previous })
+	writeNativeClipboardText = func(text string) error {
+		if text != "hello" {
+			t.Fatalf("native clipboard text = %q, want hello", text)
+		}
+		return nil
+	}
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	if m2.input.Value() != "" {
+		t.Fatalf("Ctrl+Insert must not touch the composer, got %q", m2.input.Value())
+	}
+	result := clipboardCopyResultFromCmd(t, cmd)
+	out, _ = m2.Update(result)
+	m3 := out.(chatTUI)
+	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
+		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertCopiesComposerSelection verifies Ctrl+Insert also copies an
+// active selection inside the composer, mirroring the Ctrl+C handling.
+func TestCtrlInsertCopiesComposerSelection(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("hello world")
+	m.composerSel = composerSelection{active: true, anchor: 0, head: 5, value: m.input.Value()}
+
+	previous := writeNativeClipboardText
+	t.Cleanup(func() { writeNativeClipboardText = previous })
+	writeNativeClipboardText = func(text string) error {
+		if text != "hello" {
+			t.Fatalf("native clipboard text = %q, want hello", text)
+		}
+		return nil
+	}
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	result := clipboardCopyResultFromCmd(t, cmd)
+	out, _ = m2.Update(result)
+	m3 := out.(chatTUI)
+	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
+		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertWithoutSelectionIsNoOp verifies Ctrl+Insert with no active
+// selection leaves the composer and the session state untouched — unlike
+// Ctrl+C, it must never clear input or quit.
+func TestCtrlInsertWithoutSelectionIsNoOp(t *testing.T) {
+	m := newTestChatTUI()
+	m.input.SetValue("draft text")
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	if cmd != nil {
+		t.Fatalf("Ctrl+Insert without a selection should be a no-op, got cmd %T", cmd)
+	}
+	if got := m2.input.Value(); got != "draft text" {
+		t.Fatalf("Ctrl+Insert without a selection changed the composer to %q", got)
+	}
+	if m2.state != tuiIdle {
+		t.Fatalf("Ctrl+Insert without a selection changed state to %v, want idle", m2.state)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add the classic terminal clipboard keys to the chat TUI:

- **Ctrl+Insert** copies an active transcript or composer selection to the native clipboard and arms the copied notice, mirroring Ctrl+C without its destructive side effects. With no active selection it is a strict no-op — it never clears the input, cancels an in-flight request, or quits.
- **Shift+Insert** pastes through the same async native-clipboard read path as right-click, so it works whether the terminal delivers bracketed paste or forwards the key sequence (e.g. the kitty keyboard protocol), and SSH sessions get the same remote hint without ever reading the remote host's clipboard.

The selection lives in-app because Reasonix owns the mouse, so the terminal's own selection copy would see an empty selection — binding the key explicitly is what makes it work.

## Issues

## Verification

- `go test ./internal/cli/ -run 'TestShiftInsert|TestCtrlInsert|TestMouseRightClick' -count=1` — ok
- `gofmt -l internal/cli/chat_tui.go internal/cli/chat_tui_test.go` — no output (clean)
- New tests: `TestShiftInsertPastesClipboardText`, `TestShiftInsertPasteOverSSHDoesNotReadRemoteClipboard`, `TestCtrlInsertCopiesTranscriptSelection`, `TestCtrlInsertCopiesComposerSelection`, `TestCtrlInsertWithoutSelectionIsNoOp`

## Cache impact

Cache-impact: none — changes are limited to `internal/cli/chat_tui.go` and its tests; no provider, tool, boot, config, memory, or output-style code is touched.
Cache-guard: none needed — no cache-sensitive paths are modified.
System-prompt-review: N/A