### PR TITLE
fix(agent): strip paste labels and injected directives from session titles

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -149,6 +149,22 @@ func UserPreviewText(content string) string {
 	return strings.TrimSpace(s)
 }
 
+// pasteDisplayLabelPattern matches the UI display label line that desktop
+// prepends to pasted-text user turns, e.g.
+// "[已粘贴文本 #1 · 100 行]", "[已貼上文字 #2 · 5 行]", "[Pasted text #3 · 42 lines]".
+// The label is a UI artifact, not user content: session titles and previews
+// must not start with it, otherwise a paste-first session gets a title like
+// "[已粘贴文本 #1 · 100 行]…". Keep in sync with desktop/app.go
+// pastedTextDisplayLabelPattern and desktop/frontend composer.pastedLabel.
+var pasteDisplayLabelPattern = regexp.MustCompile(`(?m)^\[(?:已粘贴文本|已貼上文字|Pasted text) #[0-9]+ · [0-9]+ (?:行|lines)\][ \t]*\n?`)
+
+// StripPasteDisplayLabel removes the pasted-text display label line (and its
+// trailing newline) from user-authored content. Used by preview/title
+// derivation so UI chrome never leaks into session titles.
+func StripPasteDisplayLabel(content string) string {
+	return pasteDisplayLabelPattern.ReplaceAllString(content, "")
+}
+
 // UserMessageText returns the best user-authored view of a persisted user turn.
 // New sessions carry the exact raw text explicitly; older sessions fall back to
 // deterministic wrapper stripping.
@@ -212,6 +228,7 @@ func hasLegacyProviderWrapper(content string) bool {
 // sites in internal/agent/agent.go, internal/agent/compact.go, and
 // internal/control (plan approval, goal loop).
 var SyntheticUserPrefixes = []string{
+	"<reasoning-language>",
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
 	"You are already in the executor phase",

--- a/internal/agent/title_test.go
+++ b/internal/agent/title_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"testing"
+)
+
+// TestReasoningLanguageDirectiveIsSynthetic: 宿主按用户配置在每轮注入的
+// "<reasoning-language> …" 指令（role=user）不是用户手打内容，不得成为
+// 会话预览/标题/turn 计数的一部分（用户真实会话中它曾是 first 消息，
+// 导致标题变成 "<reasoning-language> 必须使用简体中文…"）。
+func TestReasoningLanguageDirectiveIsSynthetic(t *testing.T) {
+	injected := "<reasoning-language>\n必须使用简体中文书写全部可见思考/推理文本：从第一个字开始就用中文"
+	if IsUserAuthoredTurn(injected) {
+		t.Fatalf("<reasoning-language> 注入指令不应被算作 user-authored")
+	}
+}
+
+// TestStripPasteDisplayLabel: 剥离桌面端粘贴标签（简体/繁体/英文三种形态），
+// 无标签文本保持不变。
+func TestStripPasteDisplayLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"简体", "[已粘贴文本 #1 · 100 行]\npackage main\n\nfunc main() {}",
+			"package main\n\nfunc main() {}"},
+		{"繁体", "[已貼上文字 #2 · 5 行]\n帮我看看这段代码", "帮我看看这段代码"},
+		{"英文", "[Pasted text #3 · 42 lines]\nfunc foo() {}", "func foo() {}"},
+		{"标签在行中不误删", "看这个 [已粘贴文本 #1 · 2 行] 的处理", "看这个 [已粘贴文本 #1 · 2 行] 的处理"},
+		{"无标签", "帮我调试登录问题", "帮我调试登录问题"},
+	}
+	for _, c := range cases {
+		if got := StripPasteDisplayLabel(c.in); got != c.want {
+			t.Errorf("%s: StripPasteDisplayLabel(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1190,7 +1190,18 @@ func (s *Server) status(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, sess)
 }
 
-const titlePrompt = `Generate a very short title (3-5 words max) for this conversation based on the user's first message. Use the same language as the user's message. Reply with ONLY the title, no quotes, no punctuation at the end.`
+const titlePrompt = `Generate a very short title (3-7 words max) for this conversation based on the user's message. Use the same language as the user's message. The title should be clear enough that the user recognizes the session in a list. Reply with ONLY the title, no quotes, no punctuation at the end.
+
+Good examples:
+Help me debug the login loop
+添加 OAuth 登录
+重构 API 客户端错误处理
+Debug failing CI tests
+
+Bad (too vague): 代码修改
+Bad (too long): 帮我看看为什么登录按钮在移动端不响应并修复这个问题
+
+The user's message below may start with UI labels or injected directives — ignore those and title based on the real intent.`
 
 // generateTitle calls a lightweight LLM to produce a short session title.
 // Returns empty string on any error — callers should fall back to a preview.
@@ -1198,6 +1209,9 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 	if nilutil.IsNil(s.titleProv) || strings.TrimSpace(firstMsg) == "" {
 		return ""
 	}
+	// The desktop prepends a "[已粘贴文本 #N · M 行]" display label to pasted
+	// turns; it is UI chrome, not user intent, and must not shape the title.
+	firstMsg = agent.StripPasteDisplayLabel(firstMsg)
 	if r := []rune(firstMsg); len(r) > 300 {
 		firstMsg = string(r[:300]) + "..."
 	}
@@ -1207,7 +1221,7 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 			{Role: provider.RoleUser, Content: firstMsg},
 		},
 		Temperature: provider.TemperaturePtr(0),
-		MaxTokens:   20,
+		MaxTokens:   60,
 	})
 	if err != nil {
 		return ""
@@ -1405,6 +1419,9 @@ func (s *Server) sessionTitle(ctx context.Context, name, first string, mod int64
 }
 
 func previewTitle(first string) string {
+	// Strip the pasted-text display label so a paste-first session falls back
+	// to the real content instead of "[已粘贴文本 #1 · 100 行]…".
+	first = agent.StripPasteDisplayLabel(first)
 	if r := []rune(first); len(r) > 50 {
 		return string(r[:47]) + "..."
 	}

--- a/internal/serve/title_test.go
+++ b/internal/serve/title_test.go
@@ -1,0 +1,38 @@
+package serve
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPreviewTitleStripsPasteLabel guards the title fallback path: a
+// paste-first session's first message starts with the desktop display label
+// "[已粘贴文本 #N · M 行]" (or 已貼上文字 / Pasted text). previewTitle must
+// strip the label so the session title reflects the pasted content, not UI
+// chrome.
+func TestPreviewTitleStripsPasteLabel(t *testing.T) {
+	cases := []struct {
+		label string
+		first string
+	}{
+		{"简体", "[已粘贴文本 #1 · 100 行]\npackage main\n\nfunc main() { fmt.Println(\"hi\") }"},
+		{"繁体", "[已貼上文字 #2 · 5 行]\n帮我看看这段代码有没有问题"},
+		{"英文", "[Pasted text #3 · 42 lines]\nfunc foo() { return 1 }"},
+	}
+	for _, c := range cases {
+		got := previewTitle(c.first)
+		if strings.Contains(got, "已粘贴文本") || strings.Contains(got, "已貼上文字") || strings.Contains(got, "Pasted text") {
+			t.Errorf("%s: previewTitle 未剥离粘贴标签，标题 = %q", c.label, got)
+		}
+		if !strings.Contains(got, "package main") && !strings.Contains(got, "帮我看看") && !strings.Contains(got, "func foo") {
+			t.Errorf("%s: 标题应保留真实内容，标题 = %q", c.label, got)
+		}
+	}
+}
+
+// TestPreviewTitleKeepsShortFirstMessage: 无粘贴标签的普通消息行为不变。
+func TestPreviewTitleKeepsShortFirstMessage(t *testing.T) {
+	if got := previewTitle("帮我调试登录问题"); got != "帮我调试登录问题" {
+		t.Fatalf("短消息应原样返回，got %q", got)
+	}
+}


### PR DESCRIPTION
## 问题

会话标题基于首条用户消息派生（serve.go sessionTitle/previewTitle），两类 UI 伪影泄漏进标题生成：

1. **粘贴标签泄漏**：桌面端给粘贴文本消息加显示标签 `[已粘贴文本 #1 · 100 行]`（`desktop/app.go` pastedTextDisplayLabelPattern，三语言形态）。当标题生成回退到 `previewTitle` 时，标题直接变成 `[已粘贴文本 #1 · 100 行]
package main…` 这种截断。
2. **注入指令误当首条消息**：宿主按用户配置每轮注入 `<reasoning-language> …`（role=user），但不在 `SyntheticUserPrefixes` 列表 → 被 `IsUserAuthoredTurn` 算作 user-authored → 成为标题素材（真实会话验证：first 消息 = `<reasoning-language> 必须使用简体中文…`）。

## 改动

- `internal/agent/preview.go`：`SyntheticUserPrefixes` 增加 `<reasoning-language>`；新增 `StripPasteDisplayLabel()`（剥离粘贴标签行，简体/繁体/英文三形态，行中提及不误删）
- `internal/serve/serve.go`：`generateTitle` 输入与 `previewTitle` 兜底均先剥离标签；`titlePrompt` 增加 few-shot 示例并提示忽略 UI 标签/注入指令；`MaxTokens` 20→60
- 测试：`internal/agent/title_test.go`（注入指令不再算 user-authored + 三语言剥离 + 行中不误删）、`internal/serve/title_test.go`（previewTitle 剥离标签 + 短消息无回归）

## 验证（本机 Go 1.26.5 实测）

```
gofmt -l internal/agent internal/serve   # 空输出
go test ./internal/serve/                # ok（全量）
go test ./internal/agent/ -run "Preview|UserMessage|Synthetic|Strip"  # ok
```

4 个新增测试全 PASS，既有 `TestReasoningLanguageBlockZhStaysImperative` 无回归。

## 影响面

- 仅影响标题/预览/turn 计数的派生路径，不改 provider 消息本体、不改桌面端粘贴 UI
- `desktop/app.go` 的 display pattern 保留，与 `StripPasteDisplayLabel` 注释互指保持同步