### PR TITLE
fix(crash-worker): stop recreating the cli_* window-scan indexes

### DIFF
--- a/workers/crash-report/migrate-client-surface.sql
+++ b/workers/crash-report/migrate-client-surface.sql
@@ -35,6 +35,5 @@ CREATE TABLE IF NOT EXISTS cli_metric_users (
   PRIMARY KEY (date, signal, bucket, install_id)
 );
 
-CREATE INDEX IF NOT EXISTS cli_pings_version ON cli_pings (version);
-CREATE INDEX IF NOT EXISTS cli_metrics_signal_bucket ON cli_metrics (signal, bucket);
-CREATE INDEX IF NOT EXISTS cli_metric_users_signal_bucket ON cli_metric_users (signal, bucket);
+-- No secondary indexes here: every primary key above already leads with `date`.
+-- migrate-window-index-fix.sql explains what adding one costs.

--- a/workers/crash-report/migrate-window-index-fix.sql
+++ b/workers/crash-report/migrate-window-index-fix.sql
@@ -9,6 +9,12 @@
 --   metric_users  5.3M rows:  31.6s -> 3.3s
 --   pings         568k rows:  672ms -> 459ms
 -- Dropping them also drops their write cost on the ingest path.
+--
+-- Run this only against a worker that no longer creates the cli_* three:
+-- ensureCLITelemetrySchema used to rebuild them on the next CLI request.
 DROP INDEX IF EXISTS metrics_signal_bucket;
 DROP INDEX IF EXISTS metric_users_signal_bucket;
 DROP INDEX IF EXISTS pings_version;
+DROP INDEX IF EXISTS cli_metrics_signal_bucket;
+DROP INDEX IF EXISTS cli_metric_users_signal_bucket;
+DROP INDEX IF EXISTS cli_pings_version;

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -126,9 +126,8 @@ export const CLI_TELEMETRY_SCHEMA_SQL = [
      os TEXT NOT NULL,
      PRIMARY KEY (date, signal, bucket, install_id)
    )`,
-  "CREATE INDEX IF NOT EXISTS cli_pings_version ON cli_pings (version)",
-  "CREATE INDEX IF NOT EXISTS cli_metrics_signal_bucket ON cli_metrics (signal, bucket)",
-  "CREATE INDEX IF NOT EXISTS cli_metric_users_signal_bucket ON cli_metric_users (signal, bucket)",
+  // No secondary indexes: each primary key already leads with `date`, which is
+  // what every dashboard query filters on. See migrate-window-index-fix.sql.
 ] as const;
 
 const cliTelemetrySchemaPromises = new WeakMap<object, Promise<void>>();


### PR DESCRIPTION
Follow-up to #7258, found while applying its migration against production.

Listing the live indexes on `reasonix-crash` turned up **six** window-scan indexes, not three:

```
cli_metric_users_signal_bucket
cli_metrics_signal_bucket
cli_pings_version
metric_users_signal_bucket
metrics_signal_bucket
pings_version
```

The `cli_` three are a worse problem than a stale migration. `ensureCLITelemetrySchema` issues their `CREATE INDEX` statements on every cold start, so dropping them in D1 only holds until the next CLI request rebuilds them. `migrate-client-surface.sql` creates them too, so a fresh database gets them on day one.

`cli_pings`, `cli_metrics` and `cli_metric_users` carry the same primary keys as their desktop counterparts — all leading with `date` — so they lose the window prune exactly the same way. #7258 measured that cost at 31.6s → 3.3s on 5.3M rows.

This removes the `CREATE INDEX` statements from both places and extends the drop migration to all six.

## Ordering

The migration now has a prerequisite it did not have before: **it must run against a worker that no longer recreates the `cli_` three**. `deploy-crash-worker.yml` deploys on merge, so the sequence is merge → deploy completes → apply `migrate-window-index-fix.sql`. Running it earlier just means the `cli_` half comes back.

The desktop three have no such constraint — nothing in the worker recreates them.

## Verification

- `npm test` in `workers/crash-report` — 74 pass
- `npm run typecheck` — clean
- `index.test.ts` asserts the prepared statements equal `CLI_TELEMETRY_SCHEMA_SQL`, so it stays honest as the list shrinks

## Note on the production database

While listing indexes, the first query — a plain `sqlite_master` read — came back `D1 DB exceeded its CPU time limit and was reset`, then succeeded on retry. The database reports `size_after` of 1.63 GB. Worth watching once the indexes are gone and the dashboard stops reading every retained row.
