### PR TITLE
fix(desktop): align Windows workspace dock tabs / 统一 Windows 工作区标签栏

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -5058,16 +5058,6 @@ export default function App() {
                     <span className="workbench-dock__tab-label">{t("rightDock.remote")}</span>
                   </button>
                 )}
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={terminalPanelOpen}
-                  className={`workbench-dock__tab${terminalPanelOpen ? " workbench-dock__tab--active" : ""}`}
-                  onClick={toggleTerminalPanel}
-                >
-                  <TerminalSquare size={13} />
-                  <span className="workbench-dock__tab-label">{t("rightDock.terminal")}</span>
-                </button>
               </div>
             </div>
             <div className="workbench-dock__body">

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -644,15 +644,56 @@ ok(
   "active dock underline stays inside the visible dock edge",
 );
 
-const narrowDockRule = stylesSource.match(/@container \(max-width: 420px\) \{[\s\S]*?\.app--windows-frameless\.app--workbench \.workbench-dock__tab[\s\S]*?\n\}/)?.[0] || "";
+for (const selector of [
+  ".app--classic .workbench-dock__tab + .workbench-dock__tab::before",
+  ".app--workbench .workbench-dock__tab + .workbench-dock__tab::before",
+]) {
+  ok(
+    finalDeclaration(selector, "width") === "1px" &&
+      finalDeclaration(selector, "height") === "16px" &&
+      finalDeclaration(selector, "background")?.includes("--border-soft"),
+    `${selector} renders a restrained divider between right-dock tabs`,
+  );
+}
+
 ok(
-  narrowDockRule.includes("padding-left: clamp(") &&
-    narrowDockRule.includes("gap: clamp(") &&
-    narrowDockRule.includes("flex: 0 0 auto") &&
-    narrowDockRule.includes("max-width: none") &&
-    !narrowDockRule.includes("text-overflow: ellipsis") &&
-    !narrowDockRule.includes("overflow: hidden"),
-  "narrow Windows frameless workbench compresses spacing without shrinking or truncating dock tabs",
+  finalDeclaration(".app--creation .workbench-dock__tab + .workbench-dock__tab::before", "content") === undefined,
+  "Creation right-dock tabs keep their equal-column treatment without dividers",
+);
+
+for (const selector of [
+  ".app--windows-frameless.app--workbench .workbench-dock__tools",
+  ":root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools",
+]) {
+  const padding = finalDeclaration(selector, "padding") ?? "";
+  ok(
+    finalDeclaration(selector, "height") === "calc(40px + var(--windows-window-controls-height))" &&
+      padding === "var(--windows-window-controls-height) 12px 0" &&
+      !padding.includes("--windows-window-controls-safe"),
+    `${selector} keeps dock tabs on a full-width row below Windows controls`,
+  );
+}
+
+for (const selector of [
+  ".app--windows-frameless.app--workbench .workbench-dock__tools::before",
+  ":root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools::before",
+]) {
+  ok(
+    finalDeclaration(selector, "top") === "calc(var(--windows-window-controls-height) - 1px)" &&
+      finalDeclaration(selector, "height") === "1px",
+    `${selector} separates the Windows title row from the dock tabs`,
+  );
+}
+
+ok(
+  finalDeclaration(".app--windows-frameless:not(.app--workbench) .workbench-dock__tools", "padding-right") === undefined &&
+    finalDeclaration(":root[data-theme-style] .app--windows-frameless:not(.app--workbench) .workbench-dock__tools", "padding-right") === undefined,
+  "classic dock tabs do not reserve native window-control space on their separate chrome row",
+);
+
+ok(
+  /@container \(max-width: 420px\) \{[\s\S]*?\.app--classic \.workbench-dock__tab,[\s\S]*?\.app--workbench \.workbench-dock__tab,[\s\S]*?padding-left:\s*10px;[\s\S]*?padding-right:\s*10px;[\s\S]*?gap:\s*4px;/.test(stylesSource),
+  "classic and workbench share the same compact four-tab spacing at narrow dock widths",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -228,10 +228,13 @@ eq(
   true,
   "workbench sidebar does not reserve the docked status bar twice",
 );
+const workspaceDockTabsSource = appSource.match(/<div className="workbench-dock__tabs"[\s\S]*?<div className="workbench-dock__body">/)?.[0] ?? "";
 eq(
-  /workbench-dock__tab[\s\S]*?terminalPanelOpen/.test(appSource),
+  workspaceDockTabsSource.length > 0
+    && !/rightDock\.terminal|terminalPanelOpen|toggleTerminalPanel/.test(workspaceDockTabsSource)
+    && /className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"[\s\S]*?aria-label=\{t\("rightDock\.terminal"\)\}[\s\S]*?onClick=\{toggleTerminalPanel\}/.test(appSource),
   true,
-  "terminal tab in workspace dock toggles the independent terminal panel, not rightDockMode",
+  "workspace dock omits the terminal view while the topic bar keeps the terminal drawer action",
 );
 eq(
   /\.topicbar \{\s*position: relative;\s*z-index: var\(--z-inline-sticky\);/.test(stylesSource)

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -27818,6 +27818,27 @@ body > .mermaid-diagram--fullscreen {
   animation: graphite-tab-underline var(--dur-base) var(--ease-out) both;
 }
 
+/* Classic and Workbench use compact text tabs in the right dock. A restrained
+   hairline clarifies each hit target without turning the strip into boxed
+   segmented controls. Creation keeps its separate equal-column treatment. */
+.app--classic .workbench-dock__tab + .workbench-dock__tab,
+.app--workbench .workbench-dock__tab + .workbench-dock__tab {
+  position: relative;
+}
+
+.app--classic .workbench-dock__tab + .workbench-dock__tab::before,
+.app--workbench .workbench-dock__tab + .workbench-dock__tab::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -1px;
+  width: 1px;
+  height: 16px;
+  background: color-mix(in srgb, var(--border-soft) 86%, transparent);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
 :root[data-theme-style] .workspace-panel,
 :root[data-theme-style] .workspace-files,
 :root[data-theme-style] .workspace-preview,
@@ -33365,9 +33386,26 @@ body > .mermaid-diagram--fullscreen {
   padding-right: 18px;
 }
 
-.app--windows-frameless .workbench-dock__tools,
-:root[data-theme-style] .app--windows-frameless .workbench-dock__tools {
-  padding-right: var(--windows-window-controls-safe);
+/* Workbench hides AppChrome, so its dock is also the native title surface.
+   Keep the Windows caption buttons on a dedicated first row and render the
+   complete dock tab strip below it, matching Classic's separated chrome. */
+.app--windows-frameless.app--workbench .workbench-dock__tools,
+:root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools {
+  position: relative;
+  height: calc(40px + var(--windows-window-controls-height));
+  padding: var(--windows-window-controls-height) 12px 0;
+}
+
+.app--windows-frameless.app--workbench .workbench-dock__tools::before,
+:root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools::before {
+  content: "";
+  position: absolute;
+  top: calc(var(--windows-window-controls-height) - 1px);
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: var(--border-soft);
+  pointer-events: none;
 }
 
 /* Creation sets tools padding via shorthand; re-assert the Windows safe
@@ -36595,29 +36633,15 @@ body > .mermaid-diagram--fullscreen {
   padding-bottom: 4px !important;
 }
 
-/* ── Windows frameless workbench: dock tab compression ─────────── */
-/* Only compress spacing; never shrink tabs or truncate labels.
-   Classic layout (.app--classic) is untouched. */
+/* Classic and Workbench share the same compact four-view strip at the dock's
+   minimum width. Creation keeps its equal-column tab treatment. */
 @container (max-width: 420px) {
-  .app--windows-frameless.app--workbench .workbench-dock__tools,
-  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tools {
-    /* 420 px dock → 12 px left pad     300 px dock →  4 px          */
-    padding-left: clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
-  }
-  .app--windows-frameless.app--workbench .workbench-dock__tabs,
-  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tabs {
-    /* 420 px dock →  2 px gap          300 px dock →  0 px          */
-    gap: clamp(0px, calc(1.667 * 1cqi - 5px), 2px);
-  }
-  .app--windows-frameless.app--workbench .workbench-dock__tab,
-  :root[data-theme-style] .app--windows-frameless.app--workbench .workbench-dock__tab {
-    flex: 0 0 auto;
-    min-width: auto;
-    max-width: none;
-    /* 420 px dock → 12 px padding      300 px dock →  4 px          */
-    padding-left:  clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
-    padding-right: clamp(4px, calc(6.667 * 1cqi - 16px), 12px);
-    /* icon↔label gap: 420→6px          300→2px                     */
-    gap:           clamp(2px, calc(3.333 * 1cqi - 8px), 6px);
+  .app--classic .workbench-dock__tab,
+  .app--workbench .workbench-dock__tab,
+  :root[data-theme-style] .app--classic .workbench-dock__tab,
+  :root[data-theme-style] .app--workbench .workbench-dock__tab {
+    padding-left: 10px;
+    padding-right: 10px;
+    gap: 4px;
   }
 }


### PR DESCRIPTION
## Summary

- Keep the Classic and Workbench right dock focused on the four workspace views: Overview, Files, Changes, and Remote.
- Keep Terminal as the existing independent bottom drawer, accessible from the topic bar and command palette instead of duplicating it as a fifth dock tab.
- Put the Windows Workbench caption controls on their own row and share dividers plus narrow-width tab geometry with Classic.

## Issues

N/A

## Verification

- `pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts` — 120 passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/workspace-layout.test.ts` — 40 passed
- `pnpm --dir desktop/frontend check:css` — passed
- `pnpm --dir desktop/frontend build` — passed, including bundle budgets
- Windows browser preview — all four labels rendered completely with matching Classic/Workbench metrics and no console warnings or errors

Native Wails caption-button placement and drag behavior were not re-exercised in a real Windows shell; the existing drag-region contracts remain covered by the source tests.

## Compatibility

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Workspace panel preference | Existing open/closed and selected-view state is unchanged | Backward-compatible |
| Terminal drawer preference | Existing drawer state and topic-bar action are unchanged | Backward-compatible |
| Persisted schemas / Wails contracts | No format or contract changes | Backward-compatible |
| Cross-version coexistence | No persisted writes were added or changed | Safe |

## Review notes

- Security: no dependency, network, file-system, permission, or credential surface changed.
- Concurrency: verified safe; the diff adds no asynchronous state path and preserves the existing terminal toggle handler.
- Cache: provider-visible prompts, tool schemas, request serialization, memory, and compaction are untouched.

## Cache impact

Cache-impact: none — presentation-only desktop frontend changes.
Cache-guard: N/A — no provider-visible cache surface changed.
System-prompt-review: N/A