### PR TITLE
fix(crash-dashboard): default preferences to the window D1 can finish

### DIFF
--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -368,6 +368,7 @@ describe("diagnostics dashboard lanes", () => {
       metrics: [],
       previousMetrics: [],
       metricUsers: [],
+      metricUsersUnavailable: false,
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 4, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 1 },
       latestVersion: "v1.40.0",
@@ -381,6 +382,7 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
+        windowExplicit: false,
         preferenceMode: "users",
       },
     };
@@ -413,6 +415,7 @@ describe("diagnostics dashboard lanes", () => {
       metrics: [],
       previousMetrics: [],
       metricUsers: [],
+      metricUsersUnavailable: false,
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
       latestVersion: "",
@@ -426,6 +429,7 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
+        windowExplicit: false,
         preferenceMode: "users",
       },
     };
@@ -437,5 +441,79 @@ describe("diagnostics dashboard lanes", () => {
     expect(html).toContain("surface=cli");
     expect(html).toContain('aria-label="Client surface"');
     expect(html).toContain('href="/stats"');
+  });
+
+  it("says the deduplication did not finish instead of showing an empty dashboard", () => {
+    type StatsData = Parameters<typeof renderStats>[0];
+    const data: StatsData = {
+      daily: [],
+      versions: [],
+      platforms: [],
+      crashes: [],
+      metrics: [],
+      previousMetrics: [],
+      metricUsers: [],
+      metricUsersUnavailable: true,
+      sources: [],
+      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
+      latestVersion: "",
+      filters: {
+        surface: "desktop",
+        status: "",
+        source: "",
+        version: "",
+        os: "",
+        platform: "",
+        newLatest: false,
+        regressed: false,
+        windowDays: 30,
+        windowExplicit: true,
+        preferenceMode: "users",
+      },
+    };
+    const html = renderStats(
+      data,
+      { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" },
+      "preferences",
+    );
+    const installs = html.slice(html.indexOf("Deduplicated installs"), html.indexOf("Launch/open snapshots"));
+    expect(installs).toContain("did not finish");
+    expect(installs).toContain("window=7d");
+    expect(installs).not.toContain("No settings preference metrics yet");
+  });
+
+  it("keeps an unchosen 7d window out of the other modules' links", () => {
+    type StatsData = Parameters<typeof renderStats>[0];
+    const base: StatsData = {
+      daily: [],
+      versions: [],
+      platforms: [],
+      crashes: [],
+      metrics: [],
+      previousMetrics: [],
+      metricUsers: [],
+      metricUsersUnavailable: false,
+      sources: [],
+      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
+      latestVersion: "",
+      filters: {
+        surface: "desktop",
+        status: "",
+        source: "",
+        version: "",
+        os: "",
+        platform: "",
+        newLatest: false,
+        regressed: false,
+        windowDays: 7,
+        windowExplicit: false,
+        preferenceMode: "users",
+      },
+    };
+    const user = { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" } as const;
+
+    expect(renderStats(base, user, "preferences")).toContain('href="/stats"');
+    const chosen = { ...base, filters: { ...base.filters, windowExplicit: true } };
+    expect(renderStats(chosen, user, "preferences")).toContain("/stats?window=7d");
   });
 });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -699,6 +699,8 @@ type StatsFilters = {
   newLatest: boolean;
   regressed: boolean;
   windowDays: 7 | 30;
+  /** True only when the reader picked the window; a module default leaves it false. */
+  windowExplicit: boolean;
   preferenceMode: "users" | "opens";
 };
 
@@ -716,6 +718,7 @@ function statsFilters(url: URL): StatsFilters {
     newLatest: url.searchParams.get("new") === "latest",
     regressed: url.searchParams.get("regressed") === "1",
     windowDays: windowParam === "7d" ? 7 : 30,
+    windowExplicit: windowParam === "7d" || windowParam === "30d",
     preferenceMode: url.searchParams.get("prefs") === "opens" ? "opens" : "users",
   };
 }
@@ -985,7 +988,15 @@ async function metricRows(env: Env, days: 7 | 30, surface: ClientSurfaceName, pr
   return rows.results;
 }
 
-async function metricUserRows(env: Env, days: 7 | 30, surface: ClientSurfaceName): Promise<{ signal: string; bucket: string; total: number }[]> {
+// Null means the query did not complete, which is distinct from "no rows": at
+// ~1M rows a day, the 30-day COUNT(DISTINCT install_id) exceeds what D1 will
+// spend on one query and comes back as a CPU-limit reset. Rendering that as an
+// empty dashboard would read as "nobody uses these settings".
+async function metricUserRows(
+  env: Env,
+  days: 7 | 30,
+  surface: ClientSurfaceName,
+): Promise<{ signal: string; bucket: string; total: number }[] | null> {
   try {
     const table = telemetryTableNames(surface).metricUsers;
     const rows = await env.DB.prepare(
@@ -994,7 +1005,7 @@ async function metricUserRows(env: Env, days: 7 | 30, surface: ClientSurfaceName
     return rows.results;
   } catch (err) {
     console.warn("metric_users query failed", err);
-    return [];
+    return null;
   }
 }
 
@@ -1007,6 +1018,10 @@ type MetricTotals = { signal: string; bucket: string; total: number }[];
 async function handleStats(request: Request, env: Env, user: User, activeModule: StatsModule): Promise<Response> {
   const url = new URL(request.url);
   const filters = statsFilters(url);
+  // The preferences module reads metric_users, whose 30-day window is past what
+  // D1 finishes in one query. Default it to the window that returns; an explicit
+  // 30d still runs, and says so when it fails.
+  if (activeModule === "preferences" && !filters.windowExplicit) filters.windowDays = 7;
   const days = filters.windowDays;
   const since = currentWindowSince(days);
   const surface = activeModule === "diagnostics" ? "desktop" : filters.surface;
@@ -1026,6 +1041,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
   let metrics: MetricTotals = [];
   let previousMetrics: MetricTotals = [];
   let metricUsers: MetricTotals = [];
+  let metricUsersUnavailable = false;
   let sources: Bar[] = [];
   let overview: OverviewCounts = {
     latestAdoptionPct: null,
@@ -1065,14 +1081,17 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     versions = versionsR;
     platforms = platformsR;
   } else if (activeModule === "preferences") {
-    [metrics, metricUsers] = await Promise.all([metricRows(env, days, surface), metricUserRows(env, days, surface)]);
+    const [metricsR, usersR] = await Promise.all([metricRows(env, days, surface), metricUserRows(env, days, surface)]);
+    metrics = metricsR;
+    metricUsersUnavailable = usersR === null;
+    metricUsers = usersR ?? [];
   } else {
     [metrics, previousMetrics] = await Promise.all([metricRows(env, days, surface), metricRows(env, days, surface, true)]);
   }
 
   return html(
     renderStats(
-      { daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, sources, overview, latestVersion, filters },
+      { daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, metricUsersUnavailable, sources, overview, latestVersion, filters },
       user,
       activeModule,
     ),

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -590,6 +590,7 @@ export function renderStats(
     metrics: MetricRow[];
     previousMetrics: MetricRow[];
     metricUsers: MetricRow[];
+    metricUsersUnavailable: boolean;
     sources: { label: string; users: number }[];
     overview: OverviewCounts;
     latestVersion: string;
@@ -603,6 +604,7 @@ export function renderStats(
       newLatest: boolean;
       regressed: boolean;
       windowDays: 7 | 30;
+      windowExplicit: boolean;
       preferenceMode: "users" | "opens";
     };
   },
@@ -648,7 +650,9 @@ export function renderStats(
     put("surface", data.filters.surface === "cli" ? "cli" : "");
     if (data.filters.newLatest) params.set("new", "latest");
     if (data.filters.regressed) params.set("regressed", "1");
-    if (data.filters.windowDays === 7) params.set("window", "7d");
+    // Only carry the window when the reader chose it — otherwise the
+    // preferences module's 7d default would follow them into every other module.
+    if (data.filters.windowDays === 7 && data.filters.windowExplicit) params.set("window", "7d");
     if (module === "preferences" && data.filters.preferenceMode === "opens") params.set("prefs", "opens");
     for (const [k, v] of Object.entries(patch)) {
       if (v) params.set(k, v);
@@ -730,9 +734,15 @@ ${developmentDiagnostics.length ? `<section class="module-panel"><h3>${i18nHTML(
 ${filters}
 <section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
 </section>`;
+  const sevenDayHref = esc(filterQS({ window: "7d" }, "preferences"));
   const installsPanel = preferencePanel(
     i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`),
-    settingsDashboard(settingsMetricUsers, { collapseSections: true }),
+    data.metricUsersUnavailable
+      ? `<div class="empty">${i18nHTML(
+          `The ${rangeText} deduplication did not finish — that window is larger than one D1 query is given. <a href="${sevenDayHref}">Use 7d</a>.`,
+          `${rangeText} 的去重统计没能跑完 —— 这个窗口超出了单条 D1 查询的预算。<a href="${sevenDayHref}">改用 7 天</a>。`,
+        )}</div>`
+      : settingsDashboard(settingsMetricUsers, { collapseSections: true }),
     data.filters.preferenceMode === "users",
   );
   const opensPanel = preferencePanel(


### PR DESCRIPTION
Stopgap for `/stats/preferences`, which does not load in production.

## What is actually wrong

`metric_users` stores one row per install × per signal × per day. At ~28k daily installs and ~34 signals that is **~960k rows a day**, measured — so the 30-day window the preferences module reads spans **~28M rows**, and the database is 1.63 GB.

D1 will not finish a `COUNT(DISTINCT install_id)` over that. Run against production it returns `D1 DB exceeded its CPU time limit and was reset`, and on a retry `internal error [code: 7500]`.

#7258 and #7266 dropped the window-scan indexes and that fixed everything around this query — `metrics` went 959ms → 643ms, `pings` version facet is 540ms, the daily chart 188ms. It could not fix this one, because the index was never the binding constraint here. Row count is.

Measured after the drops:

| window | rows scanned | result |
|---|---:|---|
| 7 days | 6.9M | 5,667ms |
| 30 days | ~28M | does not complete |

## What this does

**Defaults the module to 7 days.** An explicitly chosen 30d still runs — the reader may want to try it, and it may start completing once pre-aggregation lands.

**Makes the failure legible.** `metricUserRows` caught the error and returned `[]`, which the dashboard rendered as its "no metrics yet" empty state. A timeout was reading as *nobody uses these settings* — the one reading that is worse than an error. It now returns `null` for did-not-complete, and the panel says the deduplication did not finish and links to the 7d view.

**Keeps the default from leaking.** A module default is not a reader's choice, so `windowExplicit` distinguishes them; only a chosen 7d is carried into the other modules' links. Without this, visiting preferences would silently move the whole dashboard to 7d.

## This is not the fix

Pre-aggregation is, and it needs its own design rather than being tacked on here. The constraint that makes it non-trivial: **a cross-day `COUNT(DISTINCT)` cannot be summed from daily rollups** — an install active on twelve days would be counted twelve times. Options and measurements are in #7272.

## Verification

- `npm test` — 76 pass, including two new ones: the did-not-finish notice replaces the empty state, and an unchosen 7d stays out of other modules' links
- `npm run typecheck` — clean
- numbers above are from the live `reasonix-crash` database, not seeded copies
