### PR TITLE
fix(desktop): resolve Windows launcher junctions / 修复 Windows 启动器目录联接解析

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/cli/... ./internal/control/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'

--- a/internal/desktoplauncher/executable_path_other.go
+++ b/internal/desktoplauncher/executable_path_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package desktoplauncher
+
+import "path/filepath"
+
+func resolveExecutablePath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path, nil
+	}
+	return resolved, nil
+}

--- a/internal/desktoplauncher/executable_path_other_test.go
+++ b/internal/desktoplauncher/executable_path_other_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package desktoplauncher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveInstallRootThroughSymlink(t *testing.T) {
+	root := t.TempDir()
+	launcher := filepath.Join(root, "reasonix-launcher")
+	if err := os.WriteFile(launcher, []byte("launcher"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(t.TempDir(), "reasonix-launcher")
+	if err := os.Symlink(launcher, link); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveInstallRoot(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("resolveInstallRoot() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveInstallRootPreservesUnresolvedPathFallback(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-launcher")
+	got, err := resolveInstallRoot(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Dir(missing)
+	if got != want {
+		t.Fatalf("resolveInstallRoot() = %q, want %q", got, want)
+	}
+}

--- a/internal/desktoplauncher/executable_path_windows.go
+++ b/internal/desktoplauncher/executable_path_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package desktoplauncher
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+const maxFinalPathUTF16 = 1 << 16
+
+// resolveExecutablePath opens the launcher and asks Windows for the final DOS
+// path represented by that handle. Unlike filepath.EvalSymlinks, this resolves
+// directory junctions such as Scoop's stable current entry.
+func resolveExecutablePath(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open executable: %w", err)
+	}
+	defer file.Close()
+
+	handle := windows.Handle(file.Fd())
+	size := uint32(256)
+	for {
+		buf := make([]uint16, size)
+		n, err := windows.GetFinalPathNameByHandle(handle, &buf[0], size, 0)
+		if err != nil {
+			return "", fmt.Errorf("get final executable path: %w", err)
+		}
+		if n < size {
+			return normalizeFinalWindowsPath(windows.UTF16ToString(buf[:n])), nil
+		}
+		if n >= maxFinalPathUTF16 {
+			return "", fmt.Errorf("get final executable path: required buffer is too large: %d", n)
+		}
+		size = n + 1
+	}
+}
+
+func normalizeFinalWindowsPath(path string) string {
+	const (
+		extendedPrefix = `\\?\`
+		extendedUNC    = `\\?\UNC\`
+	)
+	if len(path) >= len(extendedUNC) && strings.EqualFold(path[:len(extendedUNC)], extendedUNC) {
+		return `\\` + path[len(extendedUNC):]
+	}
+	if len(path) >= 7 && strings.EqualFold(path[:len(extendedPrefix)], extendedPrefix) &&
+		isASCIILetter(path[4]) && path[5] == ':' && path[6] == '\\' {
+		return path[len(extendedPrefix):]
+	}
+	return path
+}
+
+func isASCIILetter(ch byte) bool {
+	return ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+}

--- a/internal/desktoplauncher/executable_path_windows_test.go
+++ b/internal/desktoplauncher/executable_path_windows_test.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package desktoplauncher
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveInstallRootThroughDirectoryJunction(t *testing.T) {
+	root := t.TempDir()
+	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	if err := os.WriteFile(launcher, []byte("launcher"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	junction := filepath.Join(t.TempDir(), "current")
+	output, err := exec.Command("cmd", "/c", "mklink", "/J", junction, root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("create directory junction: %v: %s", err, output)
+	}
+
+	got, err := resolveInstallRoot(filepath.Join(junction, "reasonix-launcher.exe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameWindowsPath(got, root) {
+		t.Fatalf("resolveInstallRoot() = %q, want %q", got, root)
+	}
+}
+
+func TestNormalizeFinalWindowsPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "drive", path: `\\?\C:\Apps\Reasonix`, want: `C:\Apps\Reasonix`},
+		{name: "UNC", path: `\\?\UNC\server\share\Reasonix`, want: `\\server\share\Reasonix`},
+		{name: "volume GUID", path: `\\?\Volume{abc}\Reasonix`, want: `\\?\Volume{abc}\Reasonix`},
+		{name: "ordinary", path: `C:\Apps\Reasonix`, want: `C:\Apps\Reasonix`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeFinalWindowsPath(test.path); got != test.want {
+				t.Fatalf("normalizeFinalWindowsPath(%q) = %q, want %q", test.path, got, test.want)
+			}
+		})
+	}
+}
+
+func sameWindowsPath(left, right string) bool {
+	return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
+}

--- a/internal/desktoplauncher/executable_path_windows_test.go
+++ b/internal/desktoplauncher/executable_path_windows_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -27,7 +26,15 @@ func TestResolveInstallRootThroughDirectoryJunction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !sameWindowsPath(got, root) {
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantInfo, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
 		t.Fatalf("resolveInstallRoot() = %q, want %q", got, root)
 	}
 }
@@ -50,8 +57,4 @@ func TestNormalizeFinalWindowsPath(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sameWindowsPath(left, right string) bool {
-	return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
 }

--- a/internal/desktoplauncher/launcher.go
+++ b/internal/desktoplauncher/launcher.go
@@ -69,10 +69,15 @@ func ResolveInstallRoot() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve launcher path: %w", err)
 	}
-	if resolved, resolveErr := filepath.EvalSymlinks(exe); resolveErr == nil {
-		exe = resolved
+	return resolveInstallRoot(exe)
+}
+
+func resolveInstallRoot(exe string) (string, error) {
+	resolved, err := resolveExecutablePath(exe)
+	if err != nil {
+		return "", fmt.Errorf("resolve launcher path: %w", err)
 	}
-	return filepath.Clean(filepath.Dir(exe)), nil
+	return filepath.Clean(filepath.Dir(resolved)), nil
 }
 
 // ResolveDesktopPath resolves current.json when present. A present but invalid


### PR DESCRIPTION
## Summary

- Resolve the running Windows launcher through its file handle so Scoop's `current` directory junction maps to the physical version directory before install-root validation.
- Normalize DOS and UNC paths returned by `GetFinalPathNameByHandle` while preserving volume-GUID paths.
- Keep the previous non-Windows symlink fallback and the existing install-root security guard unchanged.
- Add Windows junction regression coverage to the pull-request CI smoke suite.

Release availability: not yet released; targeted for the next stable patch, 1.19.4.

## Issues

Closes #7269

## Verification

- `go test ./...`
- `go vet ./...`
- `cd desktop && go test ./... && go vet ./...`
- `go test -count=20 ./internal/desktoplauncher`
- `go test -race ./internal/desktoplauncher ./internal/installlayout`
- Windows amd64/arm64 cross-compilation of `./internal/desktoplauncher` tests and `./cmd/reasonix-launcher`
- `bash scripts/release-workflows.test.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`

One unrelated timing-sensitive agent test initially exceeded its 600 ms threshold under concurrent full-suite load. It passed 20 focused repetitions, its owning package rerun, and the subsequent full root suite.

## Cache impact

Cache-impact: none; launcher path resolution does not touch prompts, provider requests, tools, memory, or persisted cache inputs.
Cache-guard: N/A; no cache-sensitive surface changed.
System-prompt-review: N/A
