### PR TITLE
feat(creation): 精简输入模式 pill 并将标题栏文件夹前置

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4533,6 +4533,9 @@ export default function App() {
                   </button>
                 </Tooltip>
               )}
+              {sidebarCreation && !sidebarImDetailConnection && activeTab?.scope === "project" && (
+                <ExternalOpener tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
+              )}
               {!sidebarImDetailConnection && (
               <>
               <Tooltip label={t("topicBar.copyAll")}>
@@ -4607,7 +4610,7 @@ export default function App() {
                   </button>
                 </Tooltip>
               )}
-              {!sidebarImDetailConnection && activeTab?.scope === "project" && (
+              {!sidebarCreation && !sidebarImDetailConnection && activeTab?.scope === "project" && (
                 <ExternalOpener tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
               )}
               <Tooltip label={t("shortcuts.cheatsheetTitle")}>

--- a/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-run-strip.test.tsx
@@ -138,6 +138,43 @@ async function renderComposer(props: Partial<Parameters<typeof Composer>[0]> = {
   return { root, calls, rerender: paint };
 }
 
+function installWindowTimerQueue() {
+  let clock = 0;
+  let nextId = 1;
+  const tasks = new Map<number, { at: number; callback: () => void }>();
+  const originalSetTimeout = window.setTimeout;
+  const originalClearTimeout = window.clearTimeout;
+
+  window.setTimeout = ((handler: TimerHandler, delay = 0, ...args: unknown[]) => {
+    if (typeof handler !== "function") throw new Error("string timers are unsupported in tests");
+    const id = nextId++;
+    tasks.set(id, { at: clock + Number(delay), callback: () => handler(...args) });
+    return id;
+  }) as typeof window.setTimeout;
+  window.clearTimeout = ((id?: number) => {
+    if (id !== undefined) tasks.delete(id);
+  }) as typeof window.clearTimeout;
+
+  return {
+    advance(ms: number) {
+      clock += ms;
+      while (true) {
+        const next = [...tasks.entries()]
+          .filter(([, task]) => task.at <= clock)
+          .sort((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+        if (!next) break;
+        tasks.delete(next[0]);
+        next[1].callback();
+      }
+    },
+    restore() {
+      tasks.clear();
+      window.setTimeout = originalSetTimeout;
+      window.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
 console.log("\ncomposer run strip");
 
 // Idle: no strip, no stop button, plain send arrow.
@@ -212,6 +249,48 @@ console.log("\ncomposer run strip");
   eq(document.querySelector(".composer-intent-menu")?.textContent?.includes("Work mode"), false, "task-intent menu no longer owns work mode");
   eq(document.querySelectorAll('.composer-intent-menu [role="menuitemradio"]').length, 3, "task method menu exposes direct, plan, and goal");
 
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+// A short Creation hover must stay a no-op. In particular, leaving before the
+// 120ms open delay must not manufacture a closing-only popover or flash the
+// trigger's open styling 140ms later.
+{
+  const dom = installDom();
+  const timers = installWindowTimerQueue();
+  const { root } = await renderComposer({ showContextWindowRing: true });
+
+  for (const selector of [".composer-task-mode-trigger", ".composer-profile-trigger"]) {
+    const trigger = document.querySelector(selector) as HTMLButtonElement | null;
+    if (!trigger) throw new Error(`missing Creation hover trigger: ${selector}`);
+
+    await act(async () => {
+      trigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: null }));
+      timers.advance(119);
+      trigger.dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }));
+      timers.advance(140);
+    });
+
+    ok(!trigger.classList.contains(`${selector.slice(1)}--open`), `${selector} stays visually closed after a short hover`);
+    ok(
+      document.querySelector(selector.includes("task") ? ".composer-intent-menu" : ".composer-profile-menu") === null,
+      `${selector} does not render a closing-only menu`,
+    );
+  }
+
+  const intentTrigger = document.querySelector(".composer-task-mode-trigger") as HTMLButtonElement | null;
+  if (!intentTrigger) throw new Error("missing Creation intent trigger");
+  await act(async () => {
+    intentTrigger.dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: null }));
+    timers.advance(120);
+  });
+  ok(intentTrigger.classList.contains("composer-task-mode-trigger--open"), "a sustained Creation hover still opens the trigger");
+  ok(document.querySelector(".composer-intent-menu") !== null, "a sustained Creation hover still renders the menu");
+
+  timers.restore();
   await act(async () => {
     root.unmount();
   });

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -741,10 +741,8 @@ export function Composer({
   const profileCloseTimerRef = useRef<number | null>(null);
   const moreCloseTimerRef = useRef<number | null>(null);
   // Creation chrome: hover-open task/profile menus (same pattern as ContextWindowRing).
-  const intentHoverEnterTimerRef = useRef<number | null>(null);
-  const intentHoverLeaveTimerRef = useRef<number | null>(null);
-  const profileHoverEnterTimerRef = useRef<number | null>(null);
-  const profileHoverLeaveTimerRef = useRef<number | null>(null);
+  const intentHoverTimerRef = useRef<number | null>(null);
+  const profileHoverTimerRef = useRef<number | null>(null);
   const creationChrome = showContextWindowRing;
   const wasRunningByDraftRef = useRef<Record<string, boolean>>({ [draftKey]: running });
   const composingRef = useRef(false);
@@ -1865,32 +1863,16 @@ export function Composer({
   }, []);
 
   // Hover timers only touch refs — no useCallback cross-deps (avoids TDZ on HMR).
-  const clearIntentHoverTimers = () => {
-    if (intentHoverEnterTimerRef.current != null) {
-      window.clearTimeout(intentHoverEnterTimerRef.current);
-      intentHoverEnterTimerRef.current = null;
-    }
-    if (intentHoverLeaveTimerRef.current != null) {
-      window.clearTimeout(intentHoverLeaveTimerRef.current);
-      intentHoverLeaveTimerRef.current = null;
-    }
-  };
-
-  const clearProfileHoverTimers = () => {
-    if (profileHoverEnterTimerRef.current != null) {
-      window.clearTimeout(profileHoverEnterTimerRef.current);
-      profileHoverEnterTimerRef.current = null;
-    }
-    if (profileHoverLeaveTimerRef.current != null) {
-      window.clearTimeout(profileHoverLeaveTimerRef.current);
-      profileHoverLeaveTimerRef.current = null;
-    }
+  const clearHoverTimer = (timerRef: { current: number | null }) => {
+    if (timerRef.current == null) return;
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
   };
 
   const openIntentMenu = useCallback(() => {
     clearIntentCloseTimer();
-    clearIntentHoverTimers();
-    clearProfileHoverTimers();
+    clearHoverTimer(intentHoverTimerRef);
+    clearHoverTimer(profileHoverTimerRef);
     if (profileCloseTimerRef.current != null) {
       window.clearTimeout(profileCloseTimerRef.current);
       profileCloseTimerRef.current = null;
@@ -1906,7 +1888,7 @@ export function Composer({
 
   const closeIntentMenu = useCallback((afterClose?: () => void) => {
     clearIntentCloseTimer();
-    clearIntentHoverTimers();
+    clearHoverTimer(intentHoverTimerRef);
     setIntentMenuClosing(true);
     window.requestAnimationFrame(() => setIntentMenuOpen(false));
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -1919,8 +1901,8 @@ export function Composer({
 
   const openProfileMenu = useCallback(() => {
     clearProfileCloseTimer();
-    clearProfileHoverTimers();
-    clearIntentHoverTimers();
+    clearHoverTimer(profileHoverTimerRef);
+    clearHoverTimer(intentHoverTimerRef);
     if (intentCloseTimerRef.current != null) {
       window.clearTimeout(intentCloseTimerRef.current);
       intentCloseTimerRef.current = null;
@@ -1936,7 +1918,7 @@ export function Composer({
 
   const closeProfileMenu = useCallback((afterClose?: () => void) => {
     clearProfileCloseTimer();
-    clearProfileHoverTimers();
+    clearHoverTimer(profileHoverTimerRef);
     setProfileMenuClosing(true);
     window.requestAnimationFrame(() => setProfileMenuOpen(false));
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -1949,57 +1931,57 @@ export function Composer({
 
   useEffect(() => () => {
     clearIntentCloseTimer();
-    clearIntentHoverTimers();
+    clearHoverTimer(intentHoverTimerRef);
     clearProfileCloseTimer();
-    clearProfileHoverTimers();
+    clearHoverTimer(profileHoverTimerRef);
   }, [clearIntentCloseTimer, clearProfileCloseTimer]);
 
   const onIntentHoverEnter = useCallback(() => {
     if (!creationChrome || disabled || running) return;
-    clearIntentHoverTimers();
-    intentHoverEnterTimerRef.current = window.setTimeout(() => {
-      intentHoverEnterTimerRef.current = null;
+    clearHoverTimer(intentHoverTimerRef);
+    intentHoverTimerRef.current = window.setTimeout(() => {
+      intentHoverTimerRef.current = null;
       openIntentMenu();
     }, 120);
   }, [creationChrome, disabled, openIntentMenu, running]);
 
   const onIntentHoverLeave = useCallback(() => {
     if (!creationChrome) return;
-    clearIntentHoverTimers();
+    clearHoverTimer(intentHoverTimerRef);
     if (!intentMenuOpen && !intentMenuClosing) return;
-    intentHoverLeaveTimerRef.current = window.setTimeout(() => {
-      intentHoverLeaveTimerRef.current = null;
+    intentHoverTimerRef.current = window.setTimeout(() => {
+      intentHoverTimerRef.current = null;
       closeIntentMenu();
     }, 140);
   }, [closeIntentMenu, creationChrome, intentMenuClosing, intentMenuOpen]);
 
   const onIntentPopoverEnter = useCallback(() => {
     if (!creationChrome) return;
-    clearIntentHoverTimers();
+    clearHoverTimer(intentHoverTimerRef);
   }, [creationChrome]);
 
   const onProfileHoverEnter = useCallback(() => {
     if (!creationChrome || disabled || running) return;
-    clearProfileHoverTimers();
-    profileHoverEnterTimerRef.current = window.setTimeout(() => {
-      profileHoverEnterTimerRef.current = null;
+    clearHoverTimer(profileHoverTimerRef);
+    profileHoverTimerRef.current = window.setTimeout(() => {
+      profileHoverTimerRef.current = null;
       openProfileMenu();
     }, 120);
   }, [creationChrome, disabled, openProfileMenu, running]);
 
   const onProfileHoverLeave = useCallback(() => {
     if (!creationChrome) return;
-    clearProfileHoverTimers();
+    clearHoverTimer(profileHoverTimerRef);
     if (!profileMenuOpen && !profileMenuClosing) return;
-    profileHoverLeaveTimerRef.current = window.setTimeout(() => {
-      profileHoverLeaveTimerRef.current = null;
+    profileHoverTimerRef.current = window.setTimeout(() => {
+      profileHoverTimerRef.current = null;
       closeProfileMenu();
     }, 140);
   }, [closeProfileMenu, creationChrome, profileMenuClosing, profileMenuOpen]);
 
   const onProfilePopoverEnter = useCallback(() => {
     if (!creationChrome) return;
-    clearProfileHoverTimers();
+    clearHoverTimer(profileHoverTimerRef);
   }, [creationChrome]);
 
   const clearMoreCloseTimer = useCallback(() => {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1966,11 +1966,12 @@ export function Composer({
   const onIntentHoverLeave = useCallback(() => {
     if (!creationChrome) return;
     clearIntentHoverTimers();
+    if (!intentMenuOpen && !intentMenuClosing) return;
     intentHoverLeaveTimerRef.current = window.setTimeout(() => {
       intentHoverLeaveTimerRef.current = null;
       closeIntentMenu();
     }, 140);
-  }, [closeIntentMenu, creationChrome]);
+  }, [closeIntentMenu, creationChrome, intentMenuClosing, intentMenuOpen]);
 
   const onIntentPopoverEnter = useCallback(() => {
     if (!creationChrome) return;
@@ -1989,11 +1990,12 @@ export function Composer({
   const onProfileHoverLeave = useCallback(() => {
     if (!creationChrome) return;
     clearProfileHoverTimers();
+    if (!profileMenuOpen && !profileMenuClosing) return;
     profileHoverLeaveTimerRef.current = window.setTimeout(() => {
       profileHoverLeaveTimerRef.current = null;
       closeProfileMenu();
     }, 140);
-  }, [closeProfileMenu, creationChrome]);
+  }, [closeProfileMenu, creationChrome, profileMenuClosing, profileMenuOpen]);
 
   const onProfilePopoverEnter = useCallback(() => {
     if (!creationChrome) return;

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -740,6 +740,12 @@ export function Composer({
   const intentCloseTimerRef = useRef<number | null>(null);
   const profileCloseTimerRef = useRef<number | null>(null);
   const moreCloseTimerRef = useRef<number | null>(null);
+  // Creation chrome: hover-open task/profile menus (same pattern as ContextWindowRing).
+  const intentHoverEnterTimerRef = useRef<number | null>(null);
+  const intentHoverLeaveTimerRef = useRef<number | null>(null);
+  const profileHoverEnterTimerRef = useRef<number | null>(null);
+  const profileHoverLeaveTimerRef = useRef<number | null>(null);
+  const creationChrome = showContextWindowRing;
   const wasRunningByDraftRef = useRef<Record<string, boolean>>({ [draftKey]: running });
   const composingRef = useRef(false);
   const lastCompositionEndAt = useRef(0);
@@ -1852,8 +1858,45 @@ export function Composer({
     intentCloseTimerRef.current = null;
   }, []);
 
+  const clearProfileCloseTimer = useCallback(() => {
+    if (profileCloseTimerRef.current === null) return;
+    window.clearTimeout(profileCloseTimerRef.current);
+    profileCloseTimerRef.current = null;
+  }, []);
+
+  // Hover timers only touch refs — no useCallback cross-deps (avoids TDZ on HMR).
+  const clearIntentHoverTimers = () => {
+    if (intentHoverEnterTimerRef.current != null) {
+      window.clearTimeout(intentHoverEnterTimerRef.current);
+      intentHoverEnterTimerRef.current = null;
+    }
+    if (intentHoverLeaveTimerRef.current != null) {
+      window.clearTimeout(intentHoverLeaveTimerRef.current);
+      intentHoverLeaveTimerRef.current = null;
+    }
+  };
+
+  const clearProfileHoverTimers = () => {
+    if (profileHoverEnterTimerRef.current != null) {
+      window.clearTimeout(profileHoverEnterTimerRef.current);
+      profileHoverEnterTimerRef.current = null;
+    }
+    if (profileHoverLeaveTimerRef.current != null) {
+      window.clearTimeout(profileHoverLeaveTimerRef.current);
+      profileHoverLeaveTimerRef.current = null;
+    }
+  };
+
   const openIntentMenu = useCallback(() => {
     clearIntentCloseTimer();
+    clearIntentHoverTimers();
+    clearProfileHoverTimers();
+    if (profileCloseTimerRef.current != null) {
+      window.clearTimeout(profileCloseTimerRef.current);
+      profileCloseTimerRef.current = null;
+    }
+    setProfileMenuOpen(false);
+    setProfileMenuClosing(false);
     setContentMenuOpen(false);
     setDirectPastChats(false);
     setDismissed(true);
@@ -1863,6 +1906,7 @@ export function Composer({
 
   const closeIntentMenu = useCallback((afterClose?: () => void) => {
     clearIntentCloseTimer();
+    clearIntentHoverTimers();
     setIntentMenuClosing(true);
     window.requestAnimationFrame(() => setIntentMenuOpen(false));
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -1873,16 +1917,16 @@ export function Composer({
     }, reduceMotion ? 0 : ANCHORED_POPOVER_CLOSE_MS);
   }, [clearIntentCloseTimer]);
 
-  useEffect(() => () => clearIntentCloseTimer(), [clearIntentCloseTimer]);
-
-  const clearProfileCloseTimer = useCallback(() => {
-    if (profileCloseTimerRef.current === null) return;
-    window.clearTimeout(profileCloseTimerRef.current);
-    profileCloseTimerRef.current = null;
-  }, []);
-
   const openProfileMenu = useCallback(() => {
     clearProfileCloseTimer();
+    clearProfileHoverTimers();
+    clearIntentHoverTimers();
+    if (intentCloseTimerRef.current != null) {
+      window.clearTimeout(intentCloseTimerRef.current);
+      intentCloseTimerRef.current = null;
+    }
+    setIntentMenuOpen(false);
+    setIntentMenuClosing(false);
     setContentMenuOpen(false);
     setDirectPastChats(false);
     setDismissed(true);
@@ -1892,6 +1936,7 @@ export function Composer({
 
   const closeProfileMenu = useCallback((afterClose?: () => void) => {
     clearProfileCloseTimer();
+    clearProfileHoverTimers();
     setProfileMenuClosing(true);
     window.requestAnimationFrame(() => setProfileMenuOpen(false));
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -1902,7 +1947,58 @@ export function Composer({
     }, reduceMotion ? 0 : ANCHORED_POPOVER_CLOSE_MS);
   }, [clearProfileCloseTimer]);
 
-  useEffect(() => () => clearProfileCloseTimer(), [clearProfileCloseTimer]);
+  useEffect(() => () => {
+    clearIntentCloseTimer();
+    clearIntentHoverTimers();
+    clearProfileCloseTimer();
+    clearProfileHoverTimers();
+  }, [clearIntentCloseTimer, clearProfileCloseTimer]);
+
+  const onIntentHoverEnter = useCallback(() => {
+    if (!creationChrome || disabled || running) return;
+    clearIntentHoverTimers();
+    intentHoverEnterTimerRef.current = window.setTimeout(() => {
+      intentHoverEnterTimerRef.current = null;
+      openIntentMenu();
+    }, 120);
+  }, [creationChrome, disabled, openIntentMenu, running]);
+
+  const onIntentHoverLeave = useCallback(() => {
+    if (!creationChrome) return;
+    clearIntentHoverTimers();
+    intentHoverLeaveTimerRef.current = window.setTimeout(() => {
+      intentHoverLeaveTimerRef.current = null;
+      closeIntentMenu();
+    }, 140);
+  }, [closeIntentMenu, creationChrome]);
+
+  const onIntentPopoverEnter = useCallback(() => {
+    if (!creationChrome) return;
+    clearIntentHoverTimers();
+  }, [creationChrome]);
+
+  const onProfileHoverEnter = useCallback(() => {
+    if (!creationChrome || disabled || running) return;
+    clearProfileHoverTimers();
+    profileHoverEnterTimerRef.current = window.setTimeout(() => {
+      profileHoverEnterTimerRef.current = null;
+      openProfileMenu();
+    }, 120);
+  }, [creationChrome, disabled, openProfileMenu, running]);
+
+  const onProfileHoverLeave = useCallback(() => {
+    if (!creationChrome) return;
+    clearProfileHoverTimers();
+    profileHoverLeaveTimerRef.current = window.setTimeout(() => {
+      profileHoverLeaveTimerRef.current = null;
+      closeProfileMenu();
+    }, 140);
+  }, [closeProfileMenu, creationChrome]);
+
+  const onProfilePopoverEnter = useCallback(() => {
+    if (!creationChrome) return;
+    clearProfileHoverTimers();
+  }, [creationChrome]);
 
   const clearMoreCloseTimer = useCallback(() => {
     if (moreCloseTimerRef.current === null) return;
@@ -3720,7 +3816,13 @@ export function Composer({
         className="composer-access-menu composer-intent-menu"
         align="start"
       >
-        <div className="composer-access-menu__section" role="menu" aria-label={t("composer.intentMenuTitle")}>
+        <div
+          className="composer-access-menu__section"
+          role="menu"
+          aria-label={t("composer.intentMenuTitle")}
+          onMouseEnter={creationChrome ? onIntentPopoverEnter : undefined}
+          onMouseLeave={creationChrome ? onIntentHoverLeave : undefined}
+        >
           <div className="composer-access-menu__label">{t("composer.intentMenuTitle")}</div>
           <button
             type="button"
@@ -3788,7 +3890,13 @@ export function Composer({
         className="composer-access-menu composer-profile-menu"
         align="start"
       >
-        <div className="composer-access-menu__section" role="menu" aria-label={t("composer.runtimeProfileTitle")}>
+        <div
+          className="composer-access-menu__section"
+          role="menu"
+          aria-label={t("composer.runtimeProfileTitle")}
+          onMouseEnter={creationChrome ? onProfilePopoverEnter : undefined}
+          onMouseLeave={creationChrome ? onProfileHoverLeave : undefined}
+        >
           <div className="composer-access-menu__label">{t("composer.runtimeProfileTitle")}</div>
           {([
             ["economy", Gauge, "composer.runtimeProfileEconomy", "composer.runtimeProfileEconomyDesc"],
@@ -4375,17 +4483,19 @@ export function Composer({
               </Tooltip>
             </div>
             <div className="composer-meta__control composer-meta__control--intent">
-              <Tooltip label={taskModeTooltipLabel} disabled={intentMenuOpen || intentMenuClosing}>
+              <Tooltip label={taskModeTooltipLabel} disabled={intentMenuOpen || intentMenuClosing || creationChrome}>
                 <button
                   ref={intentMenuAnchorRef}
                   type="button"
                   className={`composer-task-mode-trigger${intentMenuOpen || intentMenuClosing ? " composer-task-mode-trigger--open" : ""}`}
                   onClick={() => (intentMenuOpen || intentMenuClosing ? closeIntentMenu() : openIntentMenu())}
+                  onMouseEnter={creationChrome ? onIntentHoverEnter : undefined}
+                  onMouseLeave={creationChrome ? onIntentHoverLeave : undefined}
                   disabled={disabled || running}
                   aria-haspopup="menu"
                   aria-expanded={intentMenuOpen && !intentMenuClosing}
                   aria-label={taskModeTriggerLabel}
-                  title={intentMenuOpen || intentMenuClosing ? undefined : taskModeTriggerLabel}
+                  title={intentMenuOpen || intentMenuClosing || creationChrome ? undefined : taskModeTriggerLabel}
                 >
                   <TaskModeIcon size={14} aria-hidden="true" />
                   <span className="composer-task-mode-trigger__value">{t(taskModeShortKey)}</span>
@@ -4394,18 +4504,20 @@ export function Composer({
               </Tooltip>
             </div>
             <div className="composer-meta__control composer-meta__control--profile">
-              <Tooltip label={runtimeProfileTooltipLabel} disabled={profileMenuOpen || profileMenuClosing}>
+              <Tooltip label={runtimeProfileTooltipLabel} disabled={profileMenuOpen || profileMenuClosing || creationChrome}>
                 <button
                   ref={profileMenuAnchorRef}
                   type="button"
                   data-profile={tokenMode}
                   className={`composer-profile-trigger${profileMenuOpen || profileMenuClosing ? " composer-profile-trigger--open" : ""}`}
                   onClick={() => (profileMenuOpen || profileMenuClosing ? closeProfileMenu() : openProfileMenu())}
+                  onMouseEnter={creationChrome ? onProfileHoverEnter : undefined}
+                  onMouseLeave={creationChrome ? onProfileHoverLeave : undefined}
                   disabled={disabled || running}
                   aria-haspopup="menu"
                   aria-expanded={profileMenuOpen && !profileMenuClosing}
                   aria-label={runtimeProfileTriggerLabel}
-                  title={profileMenuOpen || profileMenuClosing ? undefined : runtimeProfileTriggerLabel}
+                  title={profileMenuOpen || profileMenuClosing || creationChrome ? undefined : runtimeProfileTriggerLabel}
                 >
                   <RuntimeProfileIcon size={14} strokeWidth={1.75} aria-hidden="true" />
                   <span className="composer-profile-trigger__label">

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30475,20 +30475,63 @@ body > .mermaid-diagram--fullscreen {
 .app--creation .composer-profile-trigger,
 :root[data-theme-style] .app--creation .composer-profile-trigger {
   height: 28px;
-  padding-inline: 7px;
+  gap: 0;
+  padding-inline: 9px;
   box-shadow: none;
+  font-size: calc(11.5px * var(--font-scale));
+  font-weight: 500;
 }
 
 .app--creation .composer-task-mode-trigger,
 :root[data-theme-style] .app--creation .composer-task-mode-trigger {
   height: 28px;
-  padding-inline: 7px;
+  gap: 0;
+  padding-inline: 9px;
+  font-size: calc(11.5px * var(--font-scale));
+  font-weight: 500;
 }
 
-.app--creation .composer-task-mode-trigger svg,
-:root[data-theme-style] .app--creation .composer-task-mode-trigger svg {
-  width: 15px;
-  height: 15px;
+/* Creation: text-only pills — drop leading icons + chevrons (match modelsw) */
+.app--creation .composer-task-mode-trigger > svg,
+.app--creation .composer-profile-trigger > svg,
+:root[data-theme-style] .app--creation .composer-task-mode-trigger > svg,
+:root[data-theme-style] .app--creation .composer-profile-trigger > svg {
+  display: none;
+}
+
+.app--creation .composer-task-mode-trigger__value,
+.app--creation .composer-profile-trigger__value,
+:root[data-theme-style] .app--creation .composer-task-mode-trigger__value,
+:root[data-theme-style] .app--creation .composer-profile-trigger__value {
+  color: color-mix(in srgb, var(--fg) 88%, transparent);
+  font-weight: 500;
+}
+
+.app--creation .composer-task-mode-trigger:hover:not(:disabled),
+.app--creation .composer-task-mode-trigger:focus-visible,
+.app--creation .composer-task-mode-trigger--open,
+.app--creation .composer-profile-trigger:hover:not(:disabled),
+.app--creation .composer-profile-trigger:focus-visible,
+.app--creation .composer-profile-trigger--open,
+:root[data-theme-style] .app--creation .composer-task-mode-trigger:hover:not(:disabled),
+:root[data-theme-style] .app--creation .composer-task-mode-trigger:focus-visible,
+:root[data-theme-style] .app--creation .composer-task-mode-trigger--open,
+:root[data-theme-style] .app--creation .composer-profile-trigger:hover:not(:disabled),
+:root[data-theme-style] .app--creation .composer-profile-trigger:focus-visible,
+:root[data-theme-style] .app--creation .composer-profile-trigger--open {
+  border-color: color-mix(in srgb, var(--fg-faint) 18%, transparent);
+  background: color-mix(in srgb, var(--bg-elev) 14%, transparent);
+  color: var(--fg);
+}
+
+.app--creation .composer-meta__control--profile,
+:root[data-theme-style] .app--creation .composer-meta__control--profile {
+  max-width: 64px;
+}
+
+.app--creation .composer-meta__control--intent,
+:root[data-theme-style] .app--creation .composer-meta__control--intent {
+  max-width: 64px;
 }
 
 .app--creation .composer-modebar,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29991,6 +29991,79 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg);
 }
 
+/* Creation topicbar: slim ExternalOpener split control to match utility icons. */
+.app--creation .topicbar__actions .external-opener,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener {
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.app--creation .topicbar__actions .external-opener--open,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener--open {
+  border: none;
+  background: color-mix(in srgb, var(--fg-faint) 10%, transparent);
+}
+
+.app--creation .topicbar__actions .external-opener__primary,
+.app--creation .topicbar__actions .external-opener__menu-trigger,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__primary,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__menu-trigger {
+  height: 28px;
+  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
+}
+
+.app--creation .topicbar__actions .external-opener__primary,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__primary {
+  width: 26px;
+  border-radius: 7px 0 0 7px;
+}
+
+.app--creation .topicbar__actions .external-opener__menu-trigger,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__menu-trigger {
+  width: 18px;
+  border-left: 1px solid color-mix(in srgb, var(--border-soft) 72%, transparent);
+  border-radius: 0 7px 7px 0;
+}
+
+.app--creation .topicbar__actions .external-opener__primary:hover:not(:disabled),
+.app--creation .topicbar__actions .external-opener__primary:focus-visible:not(:disabled),
+.app--creation .topicbar__actions .external-opener__menu-trigger:hover:not(:disabled),
+.app--creation .topicbar__actions .external-opener__menu-trigger:focus-visible:not(:disabled),
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__primary:hover:not(:disabled),
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__primary:focus-visible:not(:disabled),
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__menu-trigger:hover:not(:disabled),
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__menu-trigger:focus-visible:not(:disabled) {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg-faint) 12%, transparent);
+}
+
+.app--creation .topicbar__actions .external-opener__app-icon,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__app-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.app--creation .topicbar__actions .external-opener__fallback-icon,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__fallback-icon {
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.app--creation .topicbar__actions .external-opener__fallback-icon svg,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__fallback-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.app--creation .topicbar__actions .external-opener__menu-trigger svg,
+:root[data-theme-style] .app--creation .topicbar__actions .external-opener__menu-trigger svg {
+  width: 12px;
+  height: 12px;
+}
+
 .app--creation .footer,
 :root[data-theme-style] .app--creation .footer {
   border-top: 0;
@@ -33529,6 +33602,12 @@ body > .mermaid-diagram--fullscreen {
 
 /* Align action buttons (not chrome buttons) */
 .app--windows.app--creation .topicbar__action-btn:not(.topicbar__chrome-btn) {
+  transform: translateY(-2px) !important;
+  align-self: center !important;
+}
+
+/* Align ExternalOpener split control with the same Windows titlebar center line */
+.app--windows.app--creation .topicbar__actions .external-opener {
   transform: translateY(-2px) !important;
   align-self: center !important;
 }


### PR DESCRIPTION
## 改动内容

仅 Creation 创作风格打磨，classic / workbench 不受影响。

### 1. 输入框「常规 / 均衡」pill
- Creation 下去掉图标与 chevron，改为纯文字 pill
- 菜单支持 hover 打开
- 作用域限定在 Creation 路径与 `.app--creation` 样式

### 2. 标题栏 ExternalOpener（文件夹打开器）
- Creation 下整块移到工具区**最前**
- 缩小尺寸，与旁侧 utility 图标更协调
- 保留系统原生图标颜色/饱和度（不做灰化）
- classic / workbench 顺序与样式不变

## 涉及文件
- `desktop/frontend/src/components/Composer.tsx`
- `desktop/frontend/src/App.tsx`
- `desktop/frontend/src/styles.css`

## 验证
- `pnpm --dir desktop/frontend typecheck` — 通过
- 本地 Windows Creation（暗色）`wails dev` 目视确认

## 兼容性
| 表面 | 行为 | 结论 |
| --- | --- | --- |
| classic / workbench | 非 creation 路径 DOM 顺序与样式不变 | 不受影响 |
| Creation topicbar | 仅 `.app--creation` 下前置 + 缩小 opener | 预期行为 |
| External opener API | 无 bridge / 契约变更 | 向后兼容 |

## Cache impact
Cache-impact: none — presentation-only desktop frontend changes.
