### PR TITLE
feat(crash-worker): precompute the 30-day preferences deduplication

### DIFF
--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -131,6 +131,26 @@ CREATE TABLE IF NOT EXISTS cli_metric_users (
   PRIMARY KEY (date, signal, bucket, install_id)
 );
 
+-- Cron-built answer to the preferences module's 30-day deduplication, which
+-- spans ~28M rows of metric_users: too many to count per request, and not
+-- summable from daily totals. refreshMetricUserRollup fills it one signal at a
+-- time. The worker creates both tables at runtime, so existing databases need
+-- no manual migration.
+CREATE TABLE IF NOT EXISTS metric_user_rollup (
+  window_days INTEGER NOT NULL,
+  signal TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  total INTEGER NOT NULL,
+  computed_at TEXT NOT NULL,
+  PRIMARY KEY (window_days, signal, bucket)
+);
+
+CREATE TABLE IF NOT EXISTS metric_user_rollup_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  next_signal INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 -- Legacy local auth — superseded by id.reasonix.io identity + the `access`
 -- table below. Kept during the transition; migrate-access.sql copies roles over.
 CREATE TABLE IF NOT EXISTS users (

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   Metrics,
   CLI_TELEMETRY_SCHEMA_SQL,
   ensureCLITelemetrySchema,
+  refreshMetricUserRollup,
   severityForReport,
   telemetryTableNames,
 } from "./index";
@@ -201,6 +202,85 @@ describe("telemetry deployment order compatibility", () => {
     await expect(ensureCLITelemetrySchema({ DB: db })).rejects.toThrow("temporary D1 failure");
     await expect(ensureCLITelemetrySchema({ DB: db })).resolves.toBeUndefined();
     expect(batches).toBe(2);
+  });
+});
+
+function fakeRollupDB(options: { failAtQuery?: number } = {}) {
+  const cursor = { next_signal: 0 };
+  const queried: string[] = [];
+  const batches: string[][] = [];
+  const db = {
+    prepare(sql: string) {
+      const stmt = {
+        sql,
+        binds: [] as unknown[],
+        bind(...args: unknown[]) {
+          stmt.binds = args;
+          return stmt;
+        },
+        async first() {
+          return sql.includes("FROM metric_user_rollup_state") ? { next_signal: cursor.next_signal } : null;
+        },
+        async all() {
+          if (!sql.includes("COUNT(DISTINCT install_id)")) return { results: [] };
+          const nth = queried.length;
+          queried.push(String(stmt.binds[0]));
+          if (options.failAtQuery === nth) throw new Error("D1 DB exceeded its CPU time limit and was reset");
+          return { results: [{ bucket: "dark", total: 7 }] };
+        },
+        async run() {
+          if (sql.includes("INSERT INTO metric_user_rollup_state")) cursor.next_signal = Number(stmt.binds[0]);
+          return {};
+        },
+      };
+      return stmt;
+    },
+    async batch(stmts: { sql: string }[]) {
+      batches.push(stmts.map((s) => s.sql));
+      return [];
+    },
+  } as unknown as D1Database;
+  return { env: { DB: db } as unknown as Parameters<typeof refreshMetricUserRollup>[0], cursor, queried, batches };
+}
+
+describe("metric_user rollup", () => {
+  it("walks the whole signal list across runs without repeating one", async () => {
+    const { env, cursor, queried } = fakeRollupDB();
+
+    await refreshMetricUserRollup(env, 3);
+    expect(cursor.next_signal).toBe(3);
+    await refreshMetricUserRollup(env, 3);
+    expect(cursor.next_signal).toBe(6);
+
+    expect(queried).toHaveLength(6);
+    expect(new Set(queried).size).toBe(6);
+  });
+
+  it("wraps the cursor back to the start after a full pass", async () => {
+    const { env, cursor, queried } = fakeRollupDB();
+    await refreshMetricUserRollup(env, 10_000);
+    expect(queried.length).toBeGreaterThan(50);
+    expect(new Set(queried).size).toBe(queried.length);
+    expect(cursor.next_signal).toBe(0);
+  });
+
+  it("moves past a signal whose query is abandoned instead of retrying it forever", async () => {
+    const { env, cursor, queried } = fakeRollupDB({ failAtQuery: 1 });
+    await refreshMetricUserRollup(env, 3);
+    expect(queried).toHaveLength(3);
+    expect(cursor.next_signal).toBe(3);
+  });
+
+  it("replaces a signal's rows in one batch so no reader sees it half-written", async () => {
+    const { env, batches } = fakeRollupDB();
+    await refreshMetricUserRollup(env, 2);
+
+    const writes = batches.filter((b) => b.some((sql) => /DELETE FROM metric_user_rollup\b/.test(sql)));
+    expect(writes).toHaveLength(2);
+    for (const batch of writes) {
+      expect(batch[0]).toMatch(/DELETE FROM metric_user_rollup\b/);
+      expect(batch.slice(1).every((sql) => /INSERT INTO metric_user_rollup\b/.test(sql))).toBe(true);
+    }
   });
 });
 
@@ -477,7 +557,7 @@ describe("diagnostics dashboard lanes", () => {
       "preferences",
     );
     const installs = html.slice(html.indexOf("Deduplicated installs"), html.indexOf("Launch/open snapshots"));
-    expect(installs).toContain("did not finish");
+    expect(installs).toContain("deduplication");
     expect(installs).toContain("window=7d");
     expect(installs).not.toContain("No settings preference metrics yet");
   });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -988,6 +988,25 @@ async function metricRows(env: Env, days: 7 | 30, surface: ClientSurfaceName, pr
   return rows.results;
 }
 
+// The 30-day desktop window is served from the cron-built rollup: computing it
+// live exceeds what D1 spends on one query (see refreshMetricUserRollup). Null
+// here means "not computed yet", which the dashboard says out loud rather than
+// rendering as an empty result.
+async function rollupMetricUserRows(env: Env): Promise<{ signal: string; bucket: string; total: number }[] | null> {
+  try {
+    await ensureRollupSchema(env);
+    const rows = await env.DB.prepare(
+      `SELECT signal, bucket, total FROM metric_user_rollup WHERE window_days = ?1 ORDER BY signal, total DESC`,
+    )
+      .bind(ROLLUP_WINDOW_DAYS)
+      .all<{ signal: string; bucket: string; total: number }>();
+    return rows.results.length ? rows.results : null;
+  } catch (err) {
+    console.warn("metric_user_rollup read failed", err);
+    return null;
+  }
+}
+
 // Null means the query did not complete, which is distinct from "no rows": at
 // ~1M rows a day, the 30-day COUNT(DISTINCT install_id) exceeds what D1 will
 // spend on one query and comes back as a CPU-limit reset. Rendering that as an
@@ -997,6 +1016,7 @@ async function metricUserRows(
   days: 7 | 30,
   surface: ClientSurfaceName,
 ): Promise<{ signal: string; bucket: string; total: number }[] | null> {
+  if (surface === "desktop" && days === ROLLUP_WINDOW_DAYS) return rollupMetricUserRows(env);
   try {
     const table = telemetryTableNames(surface).metricUsers;
     const rows = await env.DB.prepare(
@@ -1331,6 +1351,101 @@ const RETENTION_MAX_CHUNKS = 200;
 // scheduled handler dispatches on controller.cron; every other trigger
 // (the retention cron, manual runs) falls through to the purge.
 const SENTINEL_CRON = "17 1,7,13,19 * * *";
+const ROLLUP_CRON = "23 * * * *";
+
+// The preferences module's 30-day COUNT(DISTINCT install_id) spans ~28M rows
+// and D1 abandons it mid-query. It cannot be summed from per-day totals either:
+// an install active on twelve days would count twelve times. So the window is
+// computed here instead, one signal at a time — a single signal takes ~1s, and
+// the cursor spreads the ~57 of them across hourly runs rather than blowing one
+// invocation's CPU budget.
+const ROLLUP_WINDOW_DAYS = 30;
+const ROLLUP_SIGNALS_PER_RUN = 8;
+
+const ROLLUP_SCHEMA_SQL = [
+  `CREATE TABLE IF NOT EXISTS metric_user_rollup (
+     window_days INTEGER NOT NULL,
+     signal TEXT NOT NULL,
+     bucket TEXT NOT NULL,
+     total INTEGER NOT NULL,
+     computed_at TEXT NOT NULL,
+     PRIMARY KEY (window_days, signal, bucket)
+   )`,
+  `CREATE TABLE IF NOT EXISTS metric_user_rollup_state (
+     id INTEGER PRIMARY KEY CHECK (id = 1),
+     next_signal INTEGER NOT NULL,
+     updated_at TEXT NOT NULL
+   )`,
+] as const;
+
+const rollupSchemaPromises = new WeakMap<object, Promise<void>>();
+
+function ensureRollupSchema(env: Pick<Env, "DB">): Promise<void> {
+  const key = env.DB as unknown as object;
+  const existing = rollupSchemaPromises.get(key);
+  if (existing) return existing;
+  const creation = env.DB
+    .batch(ROLLUP_SCHEMA_SQL.map((sql) => env.DB.prepare(sql)))
+    .then(() => undefined)
+    .catch((err) => {
+      rollupSchemaPromises.delete(key);
+      throw err;
+    });
+  rollupSchemaPromises.set(key, creation);
+  return creation;
+}
+
+export async function refreshMetricUserRollup(env: Env, signalsPerRun = ROLLUP_SIGNALS_PER_RUN): Promise<void> {
+  await ensureRollupSchema(env);
+  const state = await env.DB.prepare("SELECT next_signal FROM metric_user_rollup_state WHERE id = 1").first<{
+    next_signal: number;
+  }>();
+  const start = Number(state?.next_signal ?? 0) % METRIC_SIGNALS.length;
+  const now = new Date().toISOString();
+  let advanced = 0;
+
+  for (let i = 0; i < signalsPerRun && i < METRIC_SIGNALS.length; i++) {
+    const signal = METRIC_SIGNALS[(start + i) % METRIC_SIGNALS.length];
+    try {
+      const rows = await env.DB.prepare(
+        `SELECT bucket, COUNT(DISTINCT install_id) AS total FROM metric_users
+         WHERE date >= date('now', '-${ROLLUP_WINDOW_DAYS - 1} day') AND signal = ?1
+         GROUP BY bucket`,
+      )
+        .bind(signal)
+        .all<{ bucket: string; total: number }>();
+      // Delete and insert in one batch so a reader never sees a signal
+      // half-replaced; an empty result still clears the previous window's rows.
+      await env.DB.batch([
+        env.DB
+          .prepare("DELETE FROM metric_user_rollup WHERE window_days = ?1 AND signal = ?2")
+          .bind(ROLLUP_WINDOW_DAYS, signal),
+        ...rows.results.map((r) =>
+          env.DB
+            .prepare(
+              `INSERT INTO metric_user_rollup (window_days, signal, bucket, total, computed_at)
+               VALUES (?1, ?2, ?3, ?4, ?5)`,
+            )
+            .bind(ROLLUP_WINDOW_DAYS, signal, r.bucket, r.total, now),
+        ),
+      ]);
+      advanced++;
+    } catch (err) {
+      // One signal timing out must not strand the cursor on it forever.
+      console.error(`rollup: ${signal} failed`, err);
+      advanced++;
+    }
+  }
+
+  await env.DB
+    .prepare(
+      `INSERT INTO metric_user_rollup_state (id, next_signal, updated_at) VALUES (1, ?1, ?2)
+       ON CONFLICT(id) DO UPDATE SET next_signal = ?1, updated_at = ?2`,
+    )
+    .bind((start + advanced) % METRIC_SIGNALS.length, now)
+    .run();
+  console.log(`rollup: refreshed ${advanced} signals from index ${start}`);
+}
 
 // Ingest sentinel. The 2026-07-03 blackout went unnoticed for ten days because
 // clients swallow ping failures by design and nothing watched the write path.
@@ -1560,6 +1675,10 @@ export default {
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
     if (controller.cron === SENTINEL_CRON) {
       ctx.waitUntil(runIngestSentinel(env));
+      return;
+    }
+    if (controller.cron === ROLLUP_CRON) {
+      ctx.waitUntil(refreshMetricUserRollup(env));
       return;
     }
     ctx.waitUntil(purgeExpiredStatsRows(env));

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -735,13 +735,17 @@ ${filters}
 <section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
 </section>`;
   const sevenDayHref = esc(filterQS({ window: "7d" }, "preferences"));
+  const unavailableNotice =
+    range === 30
+      ? i18nHTML(
+          `The 30-day deduplication is precomputed hourly and has not reached every signal yet. <a href="${sevenDayHref}">Use 7d</a> meanwhile.`,
+          `30 天去重统计由后台每小时预聚合，目前还没覆盖到全部信号。<a href="${sevenDayHref}">先看 7 天</a>。`,
+        )
+      : i18nHTML(`The ${rangeText} deduplication did not finish.`, `${rangeText} 的去重统计没能跑完。`);
   const installsPanel = preferencePanel(
     i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`),
     data.metricUsersUnavailable
-      ? `<div class="empty">${i18nHTML(
-          `The ${rangeText} deduplication did not finish — that window is larger than one D1 query is given. <a href="${sevenDayHref}">Use 7d</a>.`,
-          `${rangeText} 的去重统计没能跑完 —— 这个窗口超出了单条 D1 查询的预算。<a href="${sevenDayHref}">改用 7 天</a>。`,
-        )}</div>`
+      ? `<div class="empty">${unavailableNotice}</div>`
       : settingsDashboard(settingsMetricUsers, { collapseSections: true }),
     data.filters.preferenceMode === "users",
   );

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -14,8 +14,12 @@ routes = [{ pattern = "crash.reasonix.io", custom_domain = true }]
 # secret of the same name by deploy-crash-worker.yml on every deploy — set it
 # under repo Settings → Secrets → Actions, no Cloudflare login needed. The
 # sentinel expression must stay in sync with SENTINEL_CRON in src/index.ts.
+# Third entry: hourly metric_user rollup (refreshMetricUserRollup) — the
+# preferences module reads it instead of a 30-day query D1 will not finish. Each
+# run advances a cursor through the signal list, so a full pass takes several
+# hours. Must stay in sync with ROLLUP_CRON in src/index.ts.
 [triggers]
-crons = ["47 19 * * *", "17 1,7,13,19 * * *"]
+crons = ["47 19 * * *", "17 1,7,13,19 * * *", "23 * * * *"]
 
 [vars]
 # Emails force-promoted to dashboard admin — the owner is never locked out even


### PR DESCRIPTION
Closes #7272. Makes the 30-day preferences view work again, after #7271 pinned the module to 7 days to keep the page loading at all.

## Why it must be precomputed rather than derived

A cross-day `COUNT(DISTINCT install_id)` **cannot be summed from per-day totals** — an install active on twelve days would count twelve times. Any design storing a daily *number* answers a different question. So the 30-day window is computed, and the only question was how.

## What the benchmarks ruled out

**Reducing granularity (one JSON row per install per day, expanded with `json_each`).** D1 does support `json_each`, and it is purely a server-side change — the ingest payload is already a full snapshot. But seeded at production shape (840k rows, equivalent to 51M in the current shape):

```
30-day preferences query: 103,468ms
plan: SEARCH ... (date>?) | SCAN je VIRTUAL TABLE | USE TEMP B-TREE FOR GROUP BY
    | USE TEMP B-TREE FOR count(DISTINCT) | USE TEMP B-TREE FOR ORDER BY
```

Parsing JSON per row and expanding it into virtual rows costs more than the I/O it saves — worse than the shape we already have. It remains attractive for storage and write volume, but it is not the answer to this issue.

## What works

Splitting the query by signal. Measured against production:

```
SELECT bucket, COUNT(DISTINCT install_id) FROM metric_users
WHERE date >= date('now','-29 day') AND signal = 'settings_theme' GROUP BY bucket
→ sql_duration_ms: 1044,  rows_read: 6,738,080
```

~1s per signal. An hourly cron walks the ~57 signals eight at a time behind a cursor, so one run stays well inside its CPU budget and a full pass takes about seven hours — fine for a daily-grain statistic.

Three properties worth naming, each covered by a test:

- **A signal is replaced in one batch.** `DELETE` and the `INSERT`s go in the same `env.DB.batch`, so a reader never sees a signal half-written.
- **An abandoned signal still advances the cursor.** Otherwise one expensive signal would block every signal behind it, forever.
- **The cursor wraps.** A full pass returns it to zero and starts over, so the window keeps sliding.

The dashboard reads the rollup for the 30-day desktop window and stays live everywhere else (CLI, and the 7-day window, are both small enough). Until the first pass finishes, the panel says the precompute has not reached every signal yet — it does not render an empty dashboard.

## Deployment

Both tables are created at runtime, the same way `ingest_sentinel_state` and the `cli_*` tables bootstrap, so **no manual migration is needed** — unlike #7258's index drops. `schema.sql` carries them for new databases.

The new cron entry must stay in sync between `wrangler.toml` and `ROLLUP_CRON`; `wrangler deploy` registers it.

## Verification

- `npm test` — 80 pass, 4 new covering the properties above
- `npm run typecheck` — clean
- the 1044ms and 103,468ms figures are measured, on production and on a seeded copy respectively

## Not in this PR

The module still **defaults** to 7 days, from #7271. Flipping the default back to 30 is one line, but it should wait until the first full pass has actually run in production — otherwise every reader lands on the not-yet-computed notice.
