### PR TITLE
fix(crash-dashboard): put preferences back on the 30-day window

### DIFF
--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import {
   groupFingerprintFromPath,
   isDevelopmentReport,
@@ -449,6 +449,7 @@ describe("diagnostics dashboard lanes", () => {
       previousMetrics: [],
       metricUsers: [],
       metricUsersUnavailable: false,
+      metricUsersComputedAt: "",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 4, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 1 },
       latestVersion: "v1.40.0",
@@ -462,7 +463,6 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
-        windowExplicit: false,
         preferenceMode: "users",
       },
     };
@@ -496,6 +496,7 @@ describe("diagnostics dashboard lanes", () => {
       previousMetrics: [],
       metricUsers: [],
       metricUsersUnavailable: false,
+      metricUsersComputedAt: "",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
       latestVersion: "",
@@ -509,7 +510,6 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
-        windowExplicit: false,
         preferenceMode: "users",
       },
     };
@@ -533,7 +533,8 @@ describe("diagnostics dashboard lanes", () => {
       metrics: [],
       previousMetrics: [],
       metricUsers: [],
-      metricUsersUnavailable: true,
+        metricUsersUnavailable: true,
+      metricUsersComputedAt: "",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
       latestVersion: "",
@@ -547,7 +548,6 @@ describe("diagnostics dashboard lanes", () => {
         newLatest: false,
         regressed: false,
         windowDays: 30,
-        windowExplicit: true,
         preferenceMode: "users",
       },
     };
@@ -562,17 +562,18 @@ describe("diagnostics dashboard lanes", () => {
     expect(installs).not.toContain("No settings preference metrics yet");
   });
 
-  it("keeps an unchosen 7d window out of the other modules' links", () => {
+  it("shows how old the precomputed window is", () => {
     type StatsData = Parameters<typeof renderStats>[0];
-    const base: StatsData = {
+    const data: StatsData = {
       daily: [],
       versions: [],
       platforms: [],
       crashes: [],
       metrics: [],
       previousMetrics: [],
-      metricUsers: [],
+      metricUsers: [{ signal: "settings_theme", bucket: "dark", total: 12 }],
       metricUsersUnavailable: false,
+      metricUsersComputedAt: "2026-08-03T07:28:41.019Z",
       sources: [],
       overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
       latestVersion: "",
@@ -585,15 +586,11 @@ describe("diagnostics dashboard lanes", () => {
         platform: "",
         newLatest: false,
         regressed: false,
-        windowDays: 7,
-        windowExplicit: false,
+        windowDays: 30,
         preferenceMode: "users",
       },
     };
     const user = { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" } as const;
-
-    expect(renderStats(base, user, "preferences")).toContain('href="/stats"');
-    const chosen = { ...base, filters: { ...base.filters, windowExplicit: true } };
-    expect(renderStats(chosen, user, "preferences")).toContain("/stats?window=7d");
+    expect(renderStats(data, user, "preferences")).toContain("2026-08-03 07:28Z");
   });
 });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -699,8 +699,6 @@ type StatsFilters = {
   newLatest: boolean;
   regressed: boolean;
   windowDays: 7 | 30;
-  /** True only when the reader picked the window; a module default leaves it false. */
-  windowExplicit: boolean;
   preferenceMode: "users" | "opens";
 };
 
@@ -718,7 +716,6 @@ function statsFilters(url: URL): StatsFilters {
     newLatest: url.searchParams.get("new") === "latest",
     regressed: url.searchParams.get("regressed") === "1",
     windowDays: windowParam === "7d" ? 7 : 30,
-    windowExplicit: windowParam === "7d" || windowParam === "30d",
     preferenceMode: url.searchParams.get("prefs") === "opens" ? "opens" : "users",
   };
 }
@@ -992,15 +989,21 @@ async function metricRows(env: Env, days: 7 | 30, surface: ClientSurfaceName, pr
 // live exceeds what D1 spends on one query (see refreshMetricUserRollup). Null
 // here means "not computed yet", which the dashboard says out loud rather than
 // rendering as an empty result.
-async function rollupMetricUserRows(env: Env): Promise<{ signal: string; bucket: string; total: number }[] | null> {
+async function rollupMetricUserRows(
+  env: Env,
+): Promise<{ rows: { signal: string; bucket: string; total: number }[]; computedAt: string } | null> {
   try {
     await ensureRollupSchema(env);
     const rows = await env.DB.prepare(
-      `SELECT signal, bucket, total FROM metric_user_rollup WHERE window_days = ?1 ORDER BY signal, total DESC`,
+      `SELECT signal, bucket, total, computed_at FROM metric_user_rollup WHERE window_days = ?1 ORDER BY signal, total DESC`,
     )
       .bind(ROLLUP_WINDOW_DAYS)
-      .all<{ signal: string; bucket: string; total: number }>();
-    return rows.results.length ? rows.results : null;
+      .all<{ signal: string; bucket: string; total: number; computed_at: string }>();
+    if (!rows.results.length) return null;
+    // Oldest wins: the cursor refreshes a slice at a time, so this is how far
+    // behind the least recently recomputed signal is.
+    const computedAt = rows.results.reduce((min, r) => (r.computed_at < min ? r.computed_at : min), rows.results[0].computed_at);
+    return { rows: rows.results, computedAt };
   } catch (err) {
     console.warn("metric_user_rollup read failed", err);
     return null;
@@ -1015,14 +1018,14 @@ async function metricUserRows(
   env: Env,
   days: 7 | 30,
   surface: ClientSurfaceName,
-): Promise<{ signal: string; bucket: string; total: number }[] | null> {
+): Promise<{ rows: { signal: string; bucket: string; total: number }[]; computedAt: string } | null> {
   if (surface === "desktop" && days === ROLLUP_WINDOW_DAYS) return rollupMetricUserRows(env);
   try {
     const table = telemetryTableNames(surface).metricUsers;
     const rows = await env.DB.prepare(
       `SELECT signal, bucket, COUNT(DISTINCT install_id) AS total FROM ${table} WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY signal, bucket ORDER BY signal, total DESC`,
     ).all<{ signal: string; bucket: string; total: number }>();
-    return rows.results;
+    return { rows: rows.results, computedAt: "" };
   } catch (err) {
     console.warn("metric_users query failed", err);
     return null;
@@ -1038,10 +1041,6 @@ type MetricTotals = { signal: string; bucket: string; total: number }[];
 async function handleStats(request: Request, env: Env, user: User, activeModule: StatsModule): Promise<Response> {
   const url = new URL(request.url);
   const filters = statsFilters(url);
-  // The preferences module reads metric_users, whose 30-day window is past what
-  // D1 finishes in one query. Default it to the window that returns; an explicit
-  // 30d still runs, and says so when it fails.
-  if (activeModule === "preferences" && !filters.windowExplicit) filters.windowDays = 7;
   const days = filters.windowDays;
   const since = currentWindowSince(days);
   const surface = activeModule === "diagnostics" ? "desktop" : filters.surface;
@@ -1062,6 +1061,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
   let previousMetrics: MetricTotals = [];
   let metricUsers: MetricTotals = [];
   let metricUsersUnavailable = false;
+  let metricUsersComputedAt = "";
   let sources: Bar[] = [];
   let overview: OverviewCounts = {
     latestAdoptionPct: null,
@@ -1104,14 +1104,15 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     const [metricsR, usersR] = await Promise.all([metricRows(env, days, surface), metricUserRows(env, days, surface)]);
     metrics = metricsR;
     metricUsersUnavailable = usersR === null;
-    metricUsers = usersR ?? [];
+    metricUsers = usersR?.rows ?? [];
+    metricUsersComputedAt = usersR?.computedAt ?? "";
   } else {
     [metrics, previousMetrics] = await Promise.all([metricRows(env, days, surface), metricRows(env, days, surface, true)]);
   }
 
   return html(
     renderStats(
-      { daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, metricUsersUnavailable, sources, overview, latestVersion, filters },
+      { daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, metricUsersUnavailable, metricUsersComputedAt, sources, overview, latestVersion, filters },
       user,
       activeModule,
     ),

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -591,6 +591,8 @@ export function renderStats(
     previousMetrics: MetricRow[];
     metricUsers: MetricRow[];
     metricUsersUnavailable: boolean;
+    /** Oldest computed_at in the rollup; empty when the window was queried live. */
+    metricUsersComputedAt: string;
     sources: { label: string; users: number }[];
     overview: OverviewCounts;
     latestVersion: string;
@@ -604,7 +606,6 @@ export function renderStats(
       newLatest: boolean;
       regressed: boolean;
       windowDays: 7 | 30;
-      windowExplicit: boolean;
       preferenceMode: "users" | "opens";
     };
   },
@@ -650,9 +651,7 @@ export function renderStats(
     put("surface", data.filters.surface === "cli" ? "cli" : "");
     if (data.filters.newLatest) params.set("new", "latest");
     if (data.filters.regressed) params.set("regressed", "1");
-    // Only carry the window when the reader chose it — otherwise the
-    // preferences module's 7d default would follow them into every other module.
-    if (data.filters.windowDays === 7 && data.filters.windowExplicit) params.set("window", "7d");
+    if (data.filters.windowDays === 7) params.set("window", "7d");
     if (module === "preferences" && data.filters.preferenceMode === "opens") params.set("prefs", "opens");
     for (const [k, v] of Object.entries(patch)) {
       if (v) params.set(k, v);
@@ -742,8 +741,16 @@ ${filters}
           `30 天去重统计由后台每小时预聚合，目前还没覆盖到全部信号。<a href="${sevenDayHref}">先看 7 天</a>。`,
         )
       : i18nHTML(`The ${rangeText} deduplication did not finish.`, `${rangeText} 的去重统计没能跑完。`);
+  // A precomputed window can silently go stale if the rollup cron stops, so the
+  // heading carries how old the least recently recomputed signal is.
+  const computedAt = data.metricUsersComputedAt
+    ? ` <b>${esc(data.metricUsersComputedAt.slice(0, 16).replace("T", " "))}Z</b>`
+    : "";
   const installsPanel = preferencePanel(
-    i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`),
+    i18nHTML(
+      `Deduplicated installs <b>— ${rangeText}</b>${computedAt ? ` computed${computedAt}` : ""}`,
+      `按安装去重 <b>— ${rangeText}</b>${computedAt ? ` 统计于${computedAt}` : ""}`,
+    ),
     data.metricUsersUnavailable
       ? `<div class="empty">${unavailableNotice}</div>`
       : settingsDashboard(settingsMetricUsers, { collapseSections: true }),


### PR DESCRIPTION
Follow-up to #7279, now that the rollup is populated in production.

## The default is backwards now

#7271 pinned the preferences module to 7 days because the 30-day window did not complete. With #7279's rollup filled, that has inverted — measured against production:

| window | path | duration |
|---|---|---:|
| 30 days | `metric_user_rollup` | **68ms** |
| 7 days | live `COUNT(DISTINCT)` over 6.9M rows | 5,667ms |

The 30-day view is now roughly 80× faster than the 7-day one, and it is also the more representative window for "how many installs chose this setting". Defaulting to 7 days means defaulting everyone to the slower path and the narrower answer.

The first pass is already in place: 14,118 rows across 59 signals (the other 7 are CLI-only signals with no rows in the desktop table).

## Retires `windowExplicit`

It existed for one reason — to stop the preferences module's 7-day default from following the reader into the other modules' links. With no module default left, it is always equivalent to `windowDays === 7`. Dead weight, so it goes, along with the test that pinned that behaviour.

## Makes staleness visible

A precomputed window can go stale silently if the rollup cron stops — the page would keep rendering perfectly plausible numbers from a week ago. The panel heading now carries the **oldest** `computed_at` across the rollup. Oldest rather than newest on purpose: the cursor refreshes eight signals at a time, so the oldest entry is how far behind the least recently recomputed signal is, which is the number that tells you whether the cron is alive.

## Verification

- `npm test` — 80 pass; the retired test is replaced by one covering the freshness stamp
- `npm run typecheck` — clean
- 68ms and 5,667ms are both measured on the live `reasonix-crash` database

## Note

The hourly cron has not fired in production yet — the rollup was populated by hand so the window would be usable immediately. Worth a look at the `computed_at` stamp tomorrow: if it is not advancing, the cron is not running and this heading is how you would find out.
