### PR TITLE
fix(bash): reassemble multi-byte UTF-8 across progress-stream chunk boundaries

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"mvdan.cc/sh/v3/syntax"
 
@@ -406,13 +407,55 @@ func reapShellProcess(cmd *exec.Cmd, tracked *proc.TrackedCommand) {
 
 // progressWriter forwards each chunk the command writes to a tool.ProgressFunc,
 // so foreground bash output streams to the frontend as it is produced.
-type progressWriter struct{ emit tool.ProgressFunc }
+type progressWriter struct {
+	emit tool.ProgressFunc
+	// tail holds the trailing bytes of an incomplete UTF-8 rune that straddled
+	// two Write calls, so it can be completed and emitted on the next Write.
+	tail []byte
+}
 
 func newProgressWriter(emit tool.ProgressFunc) *progressWriter { return &progressWriter{emit: emit} }
 
 func (w *progressWriter) Write(p []byte) (int, error) {
-	w.emit(string(p))
+	// os/exec copies pipe output at arbitrary byte boundaries, so a multi-byte
+	// UTF-8 rune (CJK, emoji) can land split across two Writes. Each chunk is
+	// emitted as its own ToolProgress event and JSON-encoded independently, so a
+	// split rune would be replaced with U+FFFD and the character lost in the
+	// live stream. Hold back a trailing incomplete rune for the next Write; a
+	// genuinely invalid byte has no completion to wait for and is left in place.
+	combined := append(w.tail, p...)
+	w.tail = nil
+	emit := combined
+	if start, ok := incompleteTailStart(combined); ok {
+		emit = combined[:start]
+		w.tail = append([]byte(nil), combined[start:]...)
+	}
+	if len(emit) > 0 {
+		w.emit(string(emit))
+	}
 	return len(p), nil
+}
+
+// incompleteTailStart reports whether p ends inside an unfinished multi-byte
+// UTF-8 rune and, if so, returns the index where that rune begins so the caller
+// can hold it back. It leaves genuinely invalid bytes (a stray continuation
+// with no lead) in place rather than holding them forever, which would stall
+// the stream.
+func incompleteTailStart(p []byte) (int, bool) {
+	// Walk back over trailing continuation bytes to the lead byte of the last
+	// rune (ASCII bytes are their own lead, so this stops at them too).
+	end := len(p)
+	for end > 0 && !utf8.RuneStart(p[end-1]) {
+		end--
+	}
+	if end == 0 {
+		return 0, false // buffer is all continuation bytes (no lead) — malformed, don't hold
+	}
+	start := end - 1 // index of the last rune's lead byte
+	if utf8.FullRune(p[start:]) {
+		return 0, false // last rune is complete
+	}
+	return start, true
 }
 
 // hasUnquotedSeq reports whether seq appears in s outside any single- or

--- a/internal/tool/builtin/bash_progress_test.go
+++ b/internal/tool/builtin/bash_progress_test.go
@@ -1,0 +1,94 @@
+package builtin
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// recordingEmit collects every emitted chunk in order so a test can assert on
+// both the per-chunk boundaries and the reassembled stream.
+func recordingEmit() (func(string), func() string) {
+	var b strings.Builder
+	fn := func(chunk string) { b.WriteString(chunk) }
+	return fn, b.String
+}
+
+// "中" is U+4E2D = E4 B8 AD in UTF-8; splitting it across two Write calls is the
+// core regression: without byte-boundary reassembly each half is emitted as a
+// standalone (invalid) string and JSON-encoded into U+FFFD before the other
+// half arrives.
+func TestProgressWriterReassemblesSplitMultibyteRune(t *testing.T) {
+	emit, result := recordingEmit()
+	w := &progressWriter{emit: emit}
+
+	if n, err := w.Write([]byte{0xE4, 0xB8}); err != nil || n != 2 {
+		t.Fatalf("first write: n=%d err=%v, want n=2 err=nil", n, err)
+	}
+	// The incomplete rune must be held back, not flushed as invalid UTF-8.
+	if result() != "" {
+		t.Fatalf("after partial rune emitted %q; want it held back", result())
+	}
+	if _, err := w.Write([]byte{0xAD}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if got := result(); got != "中" {
+		t.Fatalf("reassembled %q, want %q", got, "中")
+	}
+}
+
+func TestProgressWriterEmitsCompleteRunesImmediately(t *testing.T) {
+	emit, result := recordingEmit()
+	w := &progressWriter{emit: emit}
+	if _, err := w.Write([]byte("ok 日本")); err != nil {
+		t.Fatal(err)
+	}
+	if got := result(); got != "ok 日本" {
+		t.Fatalf("got %q, want %q", got, "ok 日本")
+	}
+}
+
+func TestProgressWriterReassemblesEverySplitPosition(t *testing.T) {
+	orig := "你好世界🎉"
+	emit, result := recordingEmit()
+	w := &progressWriter{emit: emit}
+	// One byte at a time exercises every possible split inside a rune.
+	for _, b := range []byte(orig) {
+		if _, err := w.Write([]byte{b}); err != nil {
+			t.Fatal(err)
+		}
+		// At no intermediate point may the emitted stream be invalid UTF-8.
+		if !utf8.ValidString(result()) {
+			t.Fatalf("emitted invalid UTF-8 mid-stream: %q", result())
+		}
+	}
+	if got := result(); got != orig {
+		t.Fatalf("reassembled %q, want %q", got, orig)
+	}
+}
+
+func TestProgressWriterReportsFullLengthWhileHoldingBack(t *testing.T) {
+	w := &progressWriter{emit: func(string) {}}
+	// Write must report the full byte count even when it buffers the tail, or
+	// the io copy driving the pipe would short-read / block.
+	if n, err := w.Write([]byte{0xE4, 0xB8}); err != nil || n != 2 {
+		t.Fatalf("got n=%d err=%v, want n=2 err=nil", n, err)
+	}
+}
+
+func TestProgressWriterDoesNotStallOnInvalidByte(t *testing.T) {
+	var emitted bytes.Buffer
+	w := &progressWriter{emit: func(s string) { emitted.WriteString(s) }}
+	// A stray invalid byte (0xFF) has no valid completion; it must be emitted
+	// rather than buffered forever, so subsequent output is not swallowed.
+	if _, err := w.Write([]byte{0xFF}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("tail")); err != nil {
+		t.Fatal(err)
+	}
+	if emitted.Len() == 0 || !strings.HasSuffix(emitted.String(), "tail") {
+		t.Fatalf("got %q; invalid byte must not stall later output", emitted.String())
+	}
+}


### PR DESCRIPTION
## Summary

Foreground bash output is streamed to the frontend as it's produced: `progressWriter` forwards each chunk the command writes to a `tool.ProgressFunc`, which emits a `ToolProgress` event per chunk. The bug is in how a chunk becomes a string.

`os/exec` copies pipe output at **arbitrary byte boundaries** (~32 KB), so a multi-byte UTF-8 rune (CJK, emoji) routinely lands split across two `Write` calls. `progressWriter.Write` did `w.emit(string(p))` — and because each chunk is emitted as its **own** `ToolProgress` event and JSON-encoded independently, a split rune is replaced with `U+FFFD` and the character is permanently lost in the live progress stream.

```go
func (w *progressWriter) Write(p []byte) (int, error) {
	w.emit(string(p))   // p may end mid-rune → invalid UTF-8 → U+FFFD on JSON encode
	return len(p), nil
}
```

The buffered result ultimately returned to the model (`bytes.Buffer`) is correct (it accumulates raw bytes), so only the **streamed display** is mangled — but that is every line of non-ASCII command output, which matters a great deal for this project's CJK user base.

### Repro

A process emits `"中"` (`E4 B8 AD`) across two pipe reads:
1. `Write([E4 B8])` → emits `"\xe4\xb8"` → JSON-encoded as `"��"`
2. `Write([AD])` → emits `"\xad"` → JSON-encoded as `"�"`

The live stream shows three replacement characters; the rune is unrecoverable.

## Fix

Buffer the trailing bytes of an incomplete rune and complete them on the next `Write`, emitting only up to the last complete rune boundary (`unicode/utf8.RuneStart` + `FullRune`). A genuinely invalid byte (no valid completion — e.g. a stray continuation byte) is passed through rather than held forever, which would stall the stream. `Write` still reports the full byte count so the `io` pipe copy never short-reads or blocks.

## Tests

`internal/tool/builtin/bash_progress_test.go` covers:
- a rune split at the one boundary that matters (`E4 B8` | `AD`) — nothing emitted until complete, then `"中"`;
- complete runes in one `Write` emit immediately;
- every split position (byte-at-a-time) of `你好世界🎉` reassembles to valid UTF-8 with no mid-stream `U+FFFD`;
- `Write` reports the full length while holding back;
- a stray invalid byte does not stall later output.

`go vet ./...` and the full `internal/tool/builtin` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cache-impact: none - only changes how foreground bash stdout/stderr pipe chunks are buffered before being emitted as ToolProgress progress events; the model-facing request payload, prompt, and message history (and thus DeepSeek prefix-cache boundaries) are untouched.
Cache-guard: internal/tool/builtin/bash_progress_test.go (TestProgressWriterReassemblesSplitMultibyteRune, TestProgressWriterReassemblesEverySplitPosition) guards rune-boundary reassembly; the bytes.Buffer result returned to the model is unchanged.
