### PR TITLE
fix(config): stop tests reading the developer's real credentials

### DIFF
--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -11,5 +11,20 @@ func TestMain(m *testing.M) {
 	if os.Getenv("REASONIX_CONFIG_LOCK_HELPER") == "1" {
 		os.Exit(m.Run())
 	}
+	// RunWithIsolatedUserState redirects every path-shaped location, but the OS
+	// keyring has no environment variable in front of it, so legacy migration
+	// would read the credentials of whoever is running the tests. Cases that
+	// exercise the lookup substitute their own.
+	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
 	testenv.RunWithIsolatedUserState(m)
+}
+
+// Guards the isolation above: a clean CI runner has an empty keyring and would
+// stay green either way, so the substitution itself is what gets asserted.
+func TestKeyringLookupStaysOutOfTheRealStore(t *testing.T) {
+	for _, key := range []string{"DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
+		if value, ok := legacyKeyringCredentialValueLookup(key); ok || value != "" {
+			t.Fatalf("%s resolved through the real keyring in tests (ok=%v, %d bytes)", key, ok, len(value))
+		}
+	}
 }

--- a/scripts/credential-leak-check.mjs
+++ b/scripts/credential-leak-check.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Fails when a test prints a credential that is not one of its own fixtures.
+//
+// A test suite may print sk-legacy-123 because it wrote it a line earlier. It
+// may not print a value that exists only in the developer's real credential
+// store — that means the suite reached past its sandbox. The difference between
+// the two is whether the value appears anywhere in the test sources.
+//
+//   node scripts/credential-leak-check.mjs [./package/...]
+//
+// Exit 0 clean, 1 leaked. Values are never printed; a short digest identifies
+// them across runs so a fix can be verified against the same finding.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+
+const PKG = process.argv[2] ?? "./internal/config/";
+
+// Anything shaped like a provider token. Deliberately loose: a false positive
+// costs one look at the fixtures, a false negative costs a leaked key.
+const SECRET = /\b(?:sk|pk|api|key|token)[-_][A-Za-z0-9_-]{6,}\b/gi;
+
+const digest = (s) => createHash("sha256").update(s).digest("hex").slice(0, 8);
+const redact = (s) => `${s.slice(0, 3)}…${s.length} chars, sha256:${digest(s)}`;
+
+function collectSources(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) {
+      if (name !== "node_modules" && name !== ".git") collectSources(p, out);
+    } else if (/\.(go|ts|tsx|js|mjs|json|toml|ya?ml)$/.test(name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+// Everything written down in the repo is a fixture by definition — it cannot
+// have come from the machine running the tests.
+const fixtures = new Set();
+for (const file of collectSources(".")) {
+  let text;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  for (const m of text.matchAll(SECRET)) fixtures.add(m[0]);
+}
+
+let output = "";
+try {
+  output = execFileSync("go", ["test", PKG, "-count=1"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+} catch (err) {
+  output = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+}
+
+const leaked = new Map();
+for (const line of output.split("\n")) {
+  for (const m of line.matchAll(SECRET)) {
+    if (fixtures.has(m[0])) continue;
+    if (!leaked.has(m[0])) leaked.set(m[0], line.trim().slice(0, 120));
+  }
+}
+
+console.log(`package:  ${PKG}`);
+console.log(`fixtures: ${fixtures.size} credential-shaped literals found in repo sources`);
+
+if (leaked.size === 0) {
+  console.log("\nCLEAN — every credential printed by the suite is one of its own fixtures.");
+  process.exit(0);
+}
+
+console.log(`\nLEAKED — ${leaked.size} value(s) printed that exist nowhere in the sources:\n`);
+for (const [value, context] of leaked) {
+  console.log(`  ${redact(value)}`);
+  console.log(`    context: ${context.replace(value, "<redacted>")}\n`);
+}
+console.log("A value the suite did not write can only have come from the machine's");
+console.log("real credential store, which means the test escaped its sandbox.");
+process.exit(1);


### PR DESCRIPTION
Closes #2419.

## The leak

`RunWithIsolatedUserState` redirects `HOME`, `USERPROFILE`, `XDG_*` and `AppData` — every location that is addressed by a path. The OS keyring is not one of those. It is per-user, and nothing stands in front of it that a test can redirect, so legacy credential migration walked straight past the sandbox into the real store.

The symptom is `TestMigrateImportsLegacyStateHomeDotEnvCredentials` failing by printing the developer's actual API key where its own fixture was expected:

```
migrate_test.go:929: migrated credentials = "DEEPSEEK_API_KEY=<a real key from this machine>"
```

Note where that lands: in test output, which is the single most commonly pasted artefact in a bug report. The exposure is not hypothetical.

**Why nobody noticed.** A clean CI runner has an empty keyring, so the suite passes there. It only breaks for people who actually use the tool they are working on. #2419 reported `internal/config` failing on Windows two months ago and went unanswered; this is why.

## The fix

One substitution in `TestMain`, so isolation is the package default rather than something each test must remember — this one forgot, and the three cases that genuinely exercise the lookup already install their own.

## Verification

Two checks, deliberately failing in different places:

**`scripts/credential-leak-check.mjs`** runs the suite and flags any credential-shaped value printed that appears nowhere in the repo's sources. A value the tests did not write can only have come from the machine running them, which cleanly separates a leak from a fixture like `sk-legacy-123`. Same machine, same package:

| | before | after |
|---|---|---|
| result | `LEAKED` (1 value, `sha256:66504037`) | `CLEAN` |
| exit | 1 | 0 |

This is the only check that can observe the bug at all — it needs a populated keyring, so it belongs on a developer machine, not in CI.

**`TestKeyringLookupStaysOutOfTheRealStore`** asserts the substitution itself, which holds on an empty CI keyring where the leak is invisible. Verified it actually bites: removing the substitution turns it red with

```
DEEPSEEK_API_KEY resolved through the real keyring in tests (ok=true, 35 bytes)
```

Neither prints a credential — the tool reports a SHA-256 prefix, the guard reports a byte count.

## Also closes the reported failure

`go test ./internal/config/` now passes on Windows, which is what #2419 opened about. `internal/tool/builtin`, the other package named there, had already been fixed separately.

## Note for maintainers

Anyone who has run this package's tests on a machine with saved credentials has had their key printed to a terminal. Worth a rotation if that output went anywhere.
