### PR TITLE
fix(ci): label issue version from the reported version, not the dropdown

### DIFF
--- a/.github/workflows/issue-version-label.yml
+++ b/.github/workflows/issue-version-label.yml
@@ -22,14 +22,29 @@ jobs:
         with:
           script: |
             const body = context.payload.issue.body || '';
-            // Pull the "Version line" section out of the rendered issue form.
-            const section = body.split(/^###\s+/m).find(s => /^Version line/i.test(s)) || '';
-            const m = section.match(/\bv([12])\b/i);
+            const sectionOf = (name) =>
+              body.split(/^###\s+/m).find((s) => new RegExp(`^${name}`, 'i').test(s)) || '';
+
+            const m = sectionOf('Version line').match(/\bv([12])\b/i);
             if (!m) {
               core.info('No version line found; nothing to label.');
               return;
             }
-            const choice = 'v' + m[1];
+            let choice = 'v' + m[1];
+
+            // The dropdown is a choice, and v2 sits first, so it gets picked by
+            // reporters who are actually on 0.x. `Exact version` is pasted from
+            // `reasonix --version`, so when it parses it is the better evidence:
+            // 0.x is the TypeScript line, 1.x the Go rewrite. Anything that does
+            // not parse (a commit sha, "main-v2") leaves the dropdown to decide.
+            const exact = sectionOf('Exact version').match(/\b(\d+)\.(\d+)\.(\d+)/);
+            if (exact) {
+              const fromVersion = Number(exact[1]) === 0 ? 'v1' : 'v2';
+              if (fromVersion !== choice) {
+                core.info(`Version line says ${choice} but ${exact[0]} says ${fromVersion}; trusting the version.`);
+                choice = fromVersion;
+              }
+            }
             const other = choice === 'v2' ? 'v1' : 'v2';
             await github.rest.issues.addLabels({
               ...context.repo,


### PR DESCRIPTION
Closes #2549.

## The problem

The labeller copies the "Version line" dropdown straight onto the issue. But the dropdown is a *choice*, and `v2 — Go rewrite (1.x), main-v2 (active development)` sits first — so reporters actually running 0.x pick it. `Exact version` is different: it is pasted from `reasonix --version`, so it is evidence rather than a selection.

When it parses, it now wins. `0.x` is the TypeScript line, `1.x` is the Go rewrite — an unambiguous split. When it does not parse (a commit sha, `main-v2`, a blank) the dropdown still decides, because a wrong guess is worse than the status quo.

## What it changes, measured

Replayed both rules over all 1161 open issues:

```
1161 open issues
 156 have no parseable "Version line" (untouched by either rule)
  11 would be labelled differently
```

Every one of the 11 goes `v2 -> v1`, and every one carries the wrong label today:

| issue | reported | currently |
|---|---|---|
| #7193 | 0.3.0 | v2 |
| #6459 | 0.53.2 | v2 |
| #5479 | 0.53.2 | v2 |
| #4435 | 0.46.1 | v2 |
| #4344 | 0.53.2 | v2 |
| #3810 | 0.53.0 | v2 |
| #3527 | 0.53.0 | v2 |
| #3479 | 0.53.2 | v2 |
| #3355 | 0.47.0 | v2 |
| #3309 | 0.53.2 | v2 |
| #2842 | 0.53.0 | v2 |

**Nothing moves the other way.** The cross-check only fires where the reported version and the dropdown genuinely disagree, and in every real case so far the version was right.

## Why it is worth fixing rather than tolerating

Filtering by `v2` is how the backlog actually gets triaged — it is 1024 of the 1165 open issues. Legacy 0.x reports sitting inside that filter are noise in exactly the place where attention gets allocated, and they are invisible as noise because the label looks authoritative.

## Existing mislabels

The workflow only fires on `opened`/`edited`, so these 11 keep their current labels until touched. Correcting them is a separate, one-time pass rather than something this PR does implicitly.
