### PR TITLE
feat(agent): add runtime evidence experiments and recovery journals

### DIFF
--- a/cmd/e2ebench/harness_ab.go
+++ b/cmd/e2ebench/harness_ab.go
@@ -1,0 +1,844 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+const abSchemaVersion = 1
+
+const abHarnessProtocol = "reasonix-e2ebench-ab-v1"
+
+const (
+	abEventAdmissionStarted = "admission_started"
+	abEventAttemptFinished  = "attempt_finished"
+
+	abOutcomePassed               = "passed"
+	abOutcomeVerificationFailed   = "verification_failed"
+	abOutcomeAgentError           = "agent_error"
+	abOutcomeTimeout              = "timeout"
+	abOutcomeSuiteBudgetExhausted = "suite_budget_exhausted"
+	abOutcomeInfraFailed          = "infra_failed"
+)
+
+type harnessABOpts struct {
+	suite, model, runDir, runID, environmentID string
+	baselineBin, candidateBin                  string
+	baselineProfile, candidateProfile          string
+	repetitions, infraRetries, tokenBudget     int
+}
+
+type abManifest struct {
+	SchemaVersion   int              `json:"schema_version"`
+	HarnessProtocol string           `json:"harness_protocol"`
+	RunID           string           `json:"run_id"`
+	CreatedAt       string           `json:"created_at"`
+	Suite           abSuiteManifest  `json:"suite"`
+	Model           string           `json:"model"`
+	EnvironmentID   string           `json:"environment_id"`
+	Repetitions     int              `json:"repetitions"`
+	InfraRetries    int              `json:"infra_retries"`
+	TokenBudget     int              `json:"token_budget_per_arm"`
+	Arms            []abArmManifest  `json:"arms"`
+	Tasks           []abTaskManifest `json:"tasks"`
+}
+
+type abSuiteManifest struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+type abArmManifest struct {
+	ID           string `json:"id"`
+	Binary       string `json:"binary"`
+	BinarySHA256 string `json:"binary_sha256"`
+	Profile      string `json:"profile"`
+	binaryPath   string `json:"-"`
+}
+
+type abTaskManifest struct {
+	ID         string `json:"id"`
+	SHA256     string `json:"sha256"`
+	MaxSteps   int    `json:"max_steps"`
+	TimeoutSec int    `json:"timeout_sec"`
+}
+
+type abRecord struct {
+	SchemaVersion    int        `json:"schema_version"`
+	Event            string     `json:"event"`
+	RunID            string     `json:"run_id"`
+	ArmID            string     `json:"arm_id"`
+	TaskID           string     `json:"task_id"`
+	Repetition       int        `json:"repetition"`
+	Attempt          int        `json:"attempt"`
+	StartedAt        string     `json:"started_at"`
+	FinishedAt       string     `json:"finished_at"`
+	DurationMS       int64      `json:"duration_ms"`
+	Outcome          string     `json:"outcome"`
+	Passed           bool       `json:"passed"`
+	Scored           bool       `json:"scored"`
+	MetricsAvailable bool       `json:"metrics_available"`
+	Metrics          runMetrics `json:"metrics"`
+	Note             string     `json:"note,omitempty"`
+}
+
+type abCellKey struct {
+	armID      string
+	taskID     string
+	repetition int
+}
+
+func runHarnessAB(o harnessABOpts) error {
+	if strings.TrimSpace(o.runDir) == "" {
+		return errors.New("-run-dir is required")
+	}
+	if o.repetitions < 1 {
+		return errors.New("-repetitions must be at least 1")
+	}
+	if o.infraRetries < 0 {
+		return errors.New("-infra-retries cannot be negative")
+	}
+	if o.tokenBudget < 0 {
+		return errors.New("-budget cannot be negative")
+	}
+
+	tasks, err := loadTasks(o.suite)
+	if err != nil {
+		return fmt.Errorf("load suite: %w", err)
+	}
+	if len(tasks) == 0 {
+		return fmt.Errorf("no tasks found under %s", filepath.Join(o.suite, "tasks"))
+	}
+	if err := os.MkdirAll(o.runDir, 0o755); err != nil {
+		return fmt.Errorf("create run directory: %w", err)
+	}
+
+	manifest, err := prepareABManifest(o, tasks)
+	if err != nil {
+		return err
+	}
+	walPath := filepath.Join(o.runDir, "attempts.jsonl")
+	records, err := loadABRecords(walPath, manifest)
+	if err != nil {
+		return err
+	}
+	latest := latestABRecords(records)
+	if err := closeInterruptedABAdmissions(o.runDir, walPath, manifest, &records, &latest); err != nil {
+		return err
+	}
+	if err := writeABProjections(o.runDir, manifest, records); err != nil {
+		return err
+	}
+	spentTokens := abSpentTokens(records)
+	maxAttempts := 1 + o.infraRetries
+	for repetition := 1; repetition <= manifest.Repetitions; repetition++ {
+		for taskIndex, t := range tasks {
+			arms := append([]abArmManifest(nil), manifest.Arms...)
+			if (taskIndex+repetition-1)%2 == 1 {
+				arms[0], arms[1] = arms[1], arms[0]
+			}
+			for _, arm := range arms {
+				key := abCellKey{armID: arm.ID, taskID: t.ID, repetition: repetition}
+				previous, exists := latest[key]
+				if exists && (previous.Scored || previous.Attempt >= maxAttempts) {
+					continue
+				}
+
+				nextAttempt := 1
+				if exists {
+					nextAttempt = previous.Attempt + 1
+				}
+				for attempt := nextAttempt; attempt <= maxAttempts; attempt++ {
+					if o.tokenBudget > 0 && spentTokens[arm.ID] >= o.tokenBudget {
+						now := time.Now().UTC()
+						r := abRecord{
+							SchemaVersion: abSchemaVersion, Event: abEventAttemptFinished, RunID: manifest.RunID,
+							ArmID: arm.ID, TaskID: t.ID, Repetition: repetition, Attempt: attempt,
+							StartedAt: now.Format(time.RFC3339Nano), FinishedAt: now.Format(time.RFC3339Nano),
+							Outcome: abOutcomeSuiteBudgetExhausted, Scored: true,
+							MetricsAvailable: true,
+							Note:             fmt.Sprintf("per-arm token budget %d reached", o.tokenBudget),
+						}
+						if err := persistABRecord(o.runDir, walPath, manifest, &records, &latest, r); err != nil {
+							return err
+						}
+						break
+					}
+
+					fmt.Fprintf(os.Stderr, "harness-ab: %s / %s / repetition %d / attempt %d\n", arm.ID, t.ID, repetition, attempt)
+					admitted := time.Now().UTC()
+					admission := abRecord{
+						SchemaVersion: abSchemaVersion, Event: abEventAdmissionStarted, RunID: manifest.RunID,
+						ArmID: arm.ID, TaskID: t.ID, Repetition: repetition, Attempt: attempt,
+						StartedAt: admitted.Format(time.RFC3339Nano),
+					}
+					if err := persistABRecord(o.runDir, walPath, manifest, &records, &latest, admission); err != nil {
+						return err
+					}
+					r := executeABTask(manifest.RunID, arm, t, repetition, attempt, o.model)
+					if err := persistABRecord(o.runDir, walPath, manifest, &records, &latest, r); err != nil {
+						return err
+					}
+					spentTokens[arm.ID] += r.Metrics.PromptTokens + r.Metrics.CompletionTokens
+					if r.Scored {
+						break
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "harness-ab: report written to %s\n", filepath.Join(o.runDir, "report.md"))
+	return nil
+}
+
+func prepareABManifest(o harnessABOpts, tasks []task) (abManifest, error) {
+	manifestPath := filepath.Join(o.runDir, "manifest.json")
+	existing, hasExisting, err := readABManifest(manifestPath)
+	if err != nil {
+		return abManifest{}, err
+	}
+	runID := strings.TrimSpace(o.runID)
+	if hasExisting {
+		if runID != "" && runID != existing.RunID {
+			return abManifest{}, fmt.Errorf("run ID %q does not match frozen manifest run ID %q", runID, existing.RunID)
+		}
+		runID = existing.RunID
+	}
+	if runID == "" {
+		runID = "reasonix-ab-" + time.Now().UTC().Format("20060102T150405.000000000Z")
+	}
+
+	manifest, err := buildABManifest(o, tasks, runID)
+	if err != nil {
+		return abManifest{}, err
+	}
+	if hasExisting {
+		manifest.CreatedAt = existing.CreatedAt
+		frozen := manifest
+		frozen.Arms = append([]abArmManifest(nil), manifest.Arms...)
+		for i := range frozen.Arms {
+			frozen.Arms[i].binaryPath = ""
+		}
+		if !reflect.DeepEqual(existing, frozen) {
+			return abManifest{}, errors.New("frozen manifest mismatch: suite, binary, model/environment, profile, repetitions, retry policy, or budget changed; use a new -run-dir")
+		}
+		return manifest, nil
+	}
+	if err := writeJSONAtomic(manifestPath, manifest); err != nil {
+		return abManifest{}, fmt.Errorf("write manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func buildABManifest(o harnessABOpts, tasks []task, runID string) (abManifest, error) {
+	suitePath, err := filepath.Abs(o.suite)
+	if err != nil {
+		return abManifest{}, fmt.Errorf("resolve suite path: %w", err)
+	}
+	suiteHash, err := hashTree(filepath.Join(suitePath, "tasks"))
+	if err != nil {
+		return abManifest{}, fmt.Errorf("fingerprint suite: %w", err)
+	}
+	baseline, err := buildABArm("baseline", o.baselineBin, o.baselineProfile)
+	if err != nil {
+		return abManifest{}, err
+	}
+	candidate, err := buildABArm("candidate", o.candidateBin, o.candidateProfile)
+	if err != nil {
+		return abManifest{}, err
+	}
+	taskManifests := make([]abTaskManifest, 0, len(tasks))
+	for _, t := range tasks {
+		hash, err := hashTree(t.dir)
+		if err != nil {
+			return abManifest{}, fmt.Errorf("fingerprint task %s: %w", t.ID, err)
+		}
+		taskManifests = append(taskManifests, abTaskManifest{
+			ID: t.ID, SHA256: hash, MaxSteps: t.MaxSteps, TimeoutSec: t.TimeoutSec,
+		})
+	}
+	return abManifest{
+		SchemaVersion:   abSchemaVersion,
+		HarnessProtocol: abHarnessProtocol,
+		RunID:           runID,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		Suite:           abSuiteManifest{Path: publicABPathLabel(o.suite, suitePath), SHA256: suiteHash},
+		Model:           o.model,
+		EnvironmentID:   strings.TrimSpace(o.environmentID),
+		Repetitions:     o.repetitions,
+		InfraRetries:    o.infraRetries,
+		TokenBudget:     o.tokenBudget,
+		Arms:            []abArmManifest{baseline, candidate},
+		Tasks:           taskManifests,
+	}, nil
+}
+
+func buildABArm(id, binary, profile string) (abArmManifest, error) {
+	resolved, err := exec.LookPath(binary)
+	if err != nil {
+		return abArmManifest{}, fmt.Errorf("resolve %s binary %q: %w", id, binary, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return abArmManifest{}, fmt.Errorf("resolve %s binary path: %w", id, err)
+	}
+	if evaluated, evalErr := filepath.EvalSymlinks(resolved); evalErr == nil {
+		resolved = evaluated
+	}
+	hash, err := hashFile(resolved)
+	if err != nil {
+		return abArmManifest{}, fmt.Errorf("fingerprint %s binary: %w", id, err)
+	}
+	return abArmManifest{ID: id, Binary: filepath.Base(resolved), BinarySHA256: hash, Profile: profile, binaryPath: resolved}, nil
+}
+
+func publicABPathLabel(input, absolute string) string {
+	cleaned := filepath.Clean(input)
+	if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return filepath.Base(absolute)
+	}
+	return filepath.ToSlash(cleaned)
+}
+
+func readABManifest(path string) (abManifest, bool, error) {
+	var manifest abManifest
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return manifest, false, nil
+	}
+	if err != nil {
+		return manifest, false, fmt.Errorf("read manifest: %w", err)
+	}
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return manifest, false, fmt.Errorf("decode manifest: %w", err)
+	}
+	if manifest.SchemaVersion != abSchemaVersion {
+		return manifest, false, fmt.Errorf("unsupported manifest schema_version %d", manifest.SchemaVersion)
+	}
+	if err := validateABManifest(manifest); err != nil {
+		return manifest, false, fmt.Errorf("invalid manifest: %w", err)
+	}
+	return manifest, true, nil
+}
+
+func validateABManifest(manifest abManifest) error {
+	if manifest.RunID == "" {
+		return errors.New("run_id is empty")
+	}
+	if manifest.HarnessProtocol != abHarnessProtocol {
+		return fmt.Errorf("unsupported harness_protocol %q", manifest.HarnessProtocol)
+	}
+	if manifest.Repetitions < 1 || manifest.InfraRetries < 0 || manifest.TokenBudget < 0 {
+		return errors.New("invalid repetitions, infra_retries, or token_budget_per_arm")
+	}
+	if manifest.Suite.Path == "" || manifest.Suite.SHA256 == "" {
+		return errors.New("suite label or digest is empty")
+	}
+	if len(manifest.Arms) != 2 || manifest.Arms[0].ID != "baseline" || manifest.Arms[1].ID != "candidate" {
+		return errors.New("arms must be baseline followed by candidate")
+	}
+	for _, arm := range manifest.Arms {
+		if arm.Binary == "" || arm.BinarySHA256 == "" {
+			return fmt.Errorf("arm %q has an empty binary label or digest", arm.ID)
+		}
+		if _, err := normalizeBenchmarkProfile(arm.Profile); err != nil {
+			return fmt.Errorf("arm %q: %w", arm.ID, err)
+		}
+	}
+	seen := make(map[string]bool, len(manifest.Tasks))
+	for _, task := range manifest.Tasks {
+		if task.ID == "" || task.SHA256 == "" || task.TimeoutSec < 1 || seen[task.ID] {
+			return fmt.Errorf("task %q has an empty ID/digest, invalid timeout, or duplicate ID", task.ID)
+		}
+		seen[task.ID] = true
+	}
+	if len(seen) == 0 {
+		return errors.New("task list is empty")
+	}
+	return nil
+}
+
+func executeABTask(runID string, arm abArmManifest, t task, repetition, attempt int, model string) (r abRecord) {
+	started := time.Now().UTC()
+	r = abRecord{
+		SchemaVersion: abSchemaVersion, Event: abEventAttemptFinished, RunID: runID, ArmID: arm.ID, TaskID: t.ID,
+		Repetition: repetition, Attempt: attempt, StartedAt: started.Format(time.RFC3339Nano),
+		Outcome: abOutcomeInfraFailed,
+	}
+	defer func() {
+		finished := time.Now().UTC()
+		r.FinishedAt = finished.Format(time.RFC3339Nano)
+		r.DurationMS = finished.Sub(started).Milliseconds()
+	}()
+
+	verify := filepath.Join(t.dir, "verify.sh")
+	if !fileExists(verify) {
+		r.Note = "grader missing for task " + t.ID
+		return r
+	}
+	work, err := os.MkdirTemp("", "e2ebench-ab-"+t.ID+"-")
+	if err != nil {
+		r.Note = "mktemp: " + err.Error()
+		return r
+	}
+	defer os.RemoveAll(work)
+	if seed := filepath.Join(t.dir, "workdir"); dirExists(seed) {
+		if err := copyDir(seed, work); err != nil {
+			r.Note = "copy seed: " + sanitizeABError(err, t.dir, "<task>", work, "<workdir>")
+			return r
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(t.TimeoutSec)*time.Second)
+	defer cancel()
+	metricsPath := filepath.Join(work, ".run-metrics.json")
+	args := []string{"run", "--metrics", metricsPath}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	if t.MaxSteps > 0 {
+		args = append(args, "--max-steps", fmt.Sprint(t.MaxSteps))
+	}
+	args = appendBenchmarkProfileArgs(args, arm.Profile)
+	args = append(args, t.Prompt)
+
+	cmd := exec.CommandContext(ctx, arm.binaryPath, args...)
+	cmd.Dir = work
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 10 * time.Second
+	runErr := cmd.Run()
+	metrics, metricsErr := readMetrics(metricsPath)
+	r.MetricsAvailable = metricsErr == nil
+	if r.MetricsAvailable {
+		r.Metrics = metrics
+	}
+
+	passed, gradeErr := gradeAB(work, t.dir)
+	if gradeErr != nil {
+		r.Note = "grader infrastructure: " + sanitizeABError(gradeErr, t.dir, "<task>", work, "<workdir>")
+		return r
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		r.Outcome = abOutcomeTimeout
+		r.Scored = true
+		r.Note = "agent deadline exceeded"
+		if metricsErr != nil {
+			r.Note += "; metrics unavailable: " + sanitizeABError(metricsErr, metricsPath, "<workdir>/.run-metrics.json", work, "<workdir>")
+		}
+		return r
+	}
+	var startErr *exec.Error
+	if errors.As(runErr, &startErr) {
+		r.Note = "start agent: " + sanitizeABError(startErr, arm.binaryPath, "<binary>")
+		return r
+	}
+	if metricsErr != nil {
+		r.Note = "metrics infrastructure: " + sanitizeABError(metricsErr, metricsPath, "<workdir>/.run-metrics.json", work, "<workdir>")
+		return r
+	}
+	r.Scored = true
+	r.Passed = passed
+	if passed {
+		r.Outcome = abOutcomePassed
+		if runErr != nil {
+			r.Note = "agent exited non-zero but grader passed: " + runErr.Error()
+		}
+		return r
+	}
+	if runErr != nil {
+		r.Outcome = abOutcomeAgentError
+		r.Note = "agent: " + runErr.Error()
+		return r
+	}
+	r.Outcome = abOutcomeVerificationFailed
+	return r
+}
+
+func sanitizeABError(err error, replacements ...string) string {
+	message := err.Error()
+	for i := 0; i+1 < len(replacements); i += 2 {
+		if replacements[i] != "" {
+			message = strings.ReplaceAll(message, replacements[i], replacements[i+1])
+		}
+	}
+	return message
+}
+
+func gradeAB(work, taskDir string) (bool, error) {
+	verify := filepath.Join(taskDir, "verify.sh")
+	dst := filepath.Join(work, "verify.sh")
+	if err := copyFile(verify, dst); err != nil {
+		return false, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "verify.sh")
+	cmd.Dir = work
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return false, errors.New("grader deadline exceeded")
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return false, nil
+	}
+	return false, err
+}
+
+func persistABRecord(runDir, walPath string, manifest abManifest, records *[]abRecord, latest *map[abCellKey]abRecord, r abRecord) error {
+	if err := appendABRecord(walPath, r); err != nil {
+		return fmt.Errorf("append attempt: %w", err)
+	}
+	*records = append(*records, r)
+	(*latest)[abCellKey{armID: r.ArmID, taskID: r.TaskID, repetition: r.Repetition}] = r
+	if err := writeABProjections(runDir, manifest, *records); err != nil {
+		return fmt.Errorf("refresh projections: %w", err)
+	}
+	return nil
+}
+
+func closeInterruptedABAdmissions(runDir, walPath string, manifest abManifest, records *[]abRecord, latest *map[abCellKey]abRecord) error {
+	var dangling []abRecord
+	for _, r := range *latest {
+		if r.Event == abEventAdmissionStarted {
+			dangling = append(dangling, r)
+		}
+	}
+	sort.Slice(dangling, func(i, j int) bool {
+		if dangling[i].TaskID != dangling[j].TaskID {
+			return dangling[i].TaskID < dangling[j].TaskID
+		}
+		if dangling[i].Repetition != dangling[j].Repetition {
+			return dangling[i].Repetition < dangling[j].Repetition
+		}
+		return dangling[i].ArmID < dangling[j].ArmID
+	})
+	for _, admission := range dangling {
+		finished := time.Now().UTC()
+		closed := admission
+		closed.Event = abEventAttemptFinished
+		closed.FinishedAt = finished.Format(time.RFC3339Nano)
+		closed.Outcome = abOutcomeInfraFailed
+		closed.Note = "interrupted after durable admission and before durable result"
+		if started, err := time.Parse(time.RFC3339Nano, admission.StartedAt); err == nil {
+			closed.DurationMS = finished.Sub(started).Milliseconds()
+		}
+		if err := persistABRecord(runDir, walPath, manifest, records, latest, closed); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendABRecord(path string, r abRecord) error {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	syncParentBestEffort(path)
+	return nil
+}
+
+func loadABRecords(path string, manifest abManifest) ([]abRecord, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read attempts: %w", err)
+	}
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		lastNewline := bytes.LastIndexByte(b, '\n')
+		tail := b[lastNewline+1:]
+		var candidate abRecord
+		if json.Unmarshal(tail, &candidate) == nil {
+			if err := appendWALNewline(path); err != nil {
+				return nil, fmt.Errorf("repair attempts newline: %w", err)
+			}
+			b = append(b, '\n')
+		} else {
+			validLength := int64(lastNewline + 1)
+			if err := truncateWAL(path, validLength); err != nil {
+				return nil, fmt.Errorf("truncate torn attempt: %w", err)
+			}
+			b = b[:validLength]
+		}
+	}
+
+	lines := bytes.Split(b, []byte{'\n'})
+	records := make([]abRecord, 0, len(lines))
+	for i, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var r abRecord
+		if err := json.Unmarshal(line, &r); err != nil {
+			return nil, fmt.Errorf("decode attempts line %d: %w", i+1, err)
+		}
+		if r.SchemaVersion != abSchemaVersion {
+			return nil, fmt.Errorf("attempts line %d has unsupported schema_version %d", i+1, r.SchemaVersion)
+		}
+		if r.RunID != manifest.RunID {
+			return nil, fmt.Errorf("attempts line %d belongs to run %q, want %q", i+1, r.RunID, manifest.RunID)
+		}
+		if err := validateABRecord(r, manifest); err != nil {
+			return nil, fmt.Errorf("invalid attempts line %d: %w", i+1, err)
+		}
+		records = append(records, r)
+	}
+	return records, nil
+}
+
+func validateABRecord(r abRecord, manifest abManifest) error {
+	if r.ArmID != "baseline" && r.ArmID != "candidate" {
+		return fmt.Errorf("unknown arm_id %q", r.ArmID)
+	}
+	knownTask := false
+	for _, task := range manifest.Tasks {
+		if r.TaskID == task.ID {
+			knownTask = true
+			break
+		}
+	}
+	if !knownTask {
+		return fmt.Errorf("unknown task_id %q", r.TaskID)
+	}
+	if r.Repetition < 1 || r.Repetition > manifest.Repetitions || r.Attempt < 1 || r.Attempt > 1+manifest.InfraRetries {
+		return errors.New("repetition or attempt is outside the frozen policy")
+	}
+	if r.Event == abEventAdmissionStarted {
+		if r.StartedAt == "" || r.Outcome != "" || r.Scored || r.Passed || r.FinishedAt != "" {
+			return errors.New("admission_started cannot contain a terminal result")
+		}
+		if _, err := time.Parse(time.RFC3339Nano, r.StartedAt); err != nil {
+			return fmt.Errorf("invalid started_at: %w", err)
+		}
+		return nil
+	}
+	if r.Event != abEventAttemptFinished {
+		return fmt.Errorf("unknown event %q", r.Event)
+	}
+	if r.StartedAt == "" || r.FinishedAt == "" {
+		return errors.New("attempt_finished requires started_at and finished_at")
+	}
+	started, startErr := time.Parse(time.RFC3339Nano, r.StartedAt)
+	finished, finishErr := time.Parse(time.RFC3339Nano, r.FinishedAt)
+	if startErr != nil || finishErr != nil || finished.Before(started) || r.DurationMS < 0 {
+		return errors.New("attempt_finished has invalid timestamps or duration")
+	}
+	if r.Metrics.PromptTokens < 0 || r.Metrics.CompletionTokens < 0 || r.Metrics.CacheHitTokens < 0 ||
+		r.Metrics.CacheMissTokens < 0 || r.Metrics.Cost < 0 {
+		return errors.New("attempt_finished has negative metrics")
+	}
+	validOutcome := r.Outcome == abOutcomePassed || r.Outcome == abOutcomeVerificationFailed ||
+		r.Outcome == abOutcomeAgentError || r.Outcome == abOutcomeTimeout ||
+		r.Outcome == abOutcomeSuiteBudgetExhausted || r.Outcome == abOutcomeInfraFailed
+	if !validOutcome {
+		return fmt.Errorf("unknown outcome %q", r.Outcome)
+	}
+	if r.Scored == (r.Outcome == abOutcomeInfraFailed) {
+		return errors.New("infra_failed must be unscored and all other outcomes must be scored")
+	}
+	if r.Passed != (r.Outcome == abOutcomePassed) {
+		return errors.New("passed must match the passed outcome")
+	}
+	return nil
+}
+
+func appendWALNewline(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write([]byte{'\n'}); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func truncateWAL(path string, size int64) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	if err := f.Truncate(size); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func latestABRecords(records []abRecord) map[abCellKey]abRecord {
+	latest := make(map[abCellKey]abRecord)
+	for _, r := range records {
+		key := abCellKey{armID: r.ArmID, taskID: r.TaskID, repetition: r.Repetition}
+		if previous, ok := latest[key]; !ok || r.Attempt >= previous.Attempt {
+			latest[key] = r
+		}
+	}
+	return latest
+}
+
+func abSpentTokens(records []abRecord) map[string]int {
+	spent := make(map[string]int)
+	for _, r := range records {
+		if r.Event != abEventAttemptFinished {
+			continue
+		}
+		spent[r.ArmID] += r.Metrics.PromptTokens + r.Metrics.CompletionTokens
+	}
+	return spent
+}
+
+func hashTree(root string) (string, error) {
+	type entry struct {
+		path  string
+		mode  fs.FileMode
+		isDir bool
+	}
+	var entries []entry
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel != "." {
+			entries = append(entries, entry{path: filepath.ToSlash(rel), mode: info.Mode().Perm(), isDir: d.IsDir()})
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	h := sha256.New()
+	for _, e := range entries {
+		kind := "file"
+		if e.isDir {
+			kind = "dir"
+		}
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00%04o\x00", e.path, kind, e.mode)
+		if e.isDir {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(e.path)))
+		if err != nil {
+			return "", err
+		}
+		_, _ = h.Write(b)
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func writeJSONAtomic(path string, value any) error {
+	b, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return writeFileAtomic(path, b, 0o644)
+}
+
+func writeFileAtomic(path string, body []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".e2ebench-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := f.Write(body); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	syncParentBestEffort(path)
+	return nil
+}
+
+func syncParentBestEffort(path string) {
+	if dir, err := os.Open(filepath.Dir(path)); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+}

--- a/cmd/e2ebench/harness_ab_report.go
+++ b/cmd/e2ebench/harness_ab_report.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type abProjection struct {
+	SchemaVersion int            `json:"schema_version"`
+	Manifest      abManifest     `json:"manifest"`
+	Cells         []abRecord     `json:"cells"`
+	Arms          []abArmSummary `json:"arms"`
+	Paired        abPairSummary  `json:"paired"`
+}
+
+type abArmSummary struct {
+	ArmID                  string   `json:"arm_id"`
+	Scored                 int      `json:"scored"`
+	Passed                 int      `json:"passed"`
+	TerminalInfraFailures  int      `json:"terminal_infra_failures"`
+	InfraAttempts          int      `json:"infra_attempts"`
+	MissingMetricsAttempts int      `json:"missing_metrics_attempts"`
+	Timeouts               int      `json:"timeouts"`
+	BudgetExhausted        int      `json:"suite_budget_exhausted"`
+	PromptTokens           int      `json:"prompt_tokens"`
+	CompletionTokens       int      `json:"completion_tokens"`
+	CacheHitTokens         int      `json:"cache_hit_tokens"`
+	CacheMissTokens        int      `json:"cache_miss_tokens"`
+	ToolResultsProjected   int      `json:"tool_results_projected"`
+	ProjectionSavedChars   int      `json:"projection_saved_chars"`
+	Cost                   float64  `json:"cost"`
+	Currency               string   `json:"currency"`
+	CostPerPass            *float64 `json:"cost_per_pass"`
+}
+
+type abPairSummary struct {
+	EligiblePairs int      `json:"eligible_pairs"`
+	TotalPairs    int      `json:"total_pairs"`
+	BothPass      int      `json:"both_pass"`
+	BaselineOnly  int      `json:"baseline_only"`
+	CandidateOnly int      `json:"candidate_only"`
+	BothFail      int      `json:"both_fail"`
+	DeltaPP       *float64 `json:"candidate_minus_baseline_percentage_points"`
+	McNemarP      *float64 `json:"mcnemar_exact_p"`
+}
+
+func writeABProjections(runDir string, manifest abManifest, records []abRecord) error {
+	projection := buildABProjection(manifest, records)
+	if err := writeJSONAtomic(filepath.Join(runDir, "results.json"), projection); err != nil {
+		return err
+	}
+	csvBody, err := renderABCSV(manifest, latestABRecords(records))
+	if err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(runDir, "results.csv"), csvBody, 0o644); err != nil {
+		return err
+	}
+	return writeFileAtomic(filepath.Join(runDir, "report.md"), []byte(renderABReport(projection)), 0o644)
+}
+
+func buildABProjection(manifest abManifest, records []abRecord) abProjection {
+	latestMap := latestABRecords(records)
+	cells := make([]abRecord, 0, len(latestMap))
+	for _, r := range latestMap {
+		cells = append(cells, r)
+	}
+	sort.Slice(cells, func(i, j int) bool {
+		if cells[i].TaskID != cells[j].TaskID {
+			return cells[i].TaskID < cells[j].TaskID
+		}
+		if cells[i].Repetition != cells[j].Repetition {
+			return cells[i].Repetition < cells[j].Repetition
+		}
+		return cells[i].ArmID < cells[j].ArmID
+	})
+
+	arms := make([]abArmSummary, 0, len(manifest.Arms))
+	for _, arm := range manifest.Arms {
+		summary := abArmSummary{ArmID: arm.ID}
+		currencies := make(map[string]bool)
+		for _, r := range cells {
+			if r.ArmID != arm.ID {
+				continue
+			}
+			if r.Scored {
+				summary.Scored++
+				if r.Passed {
+					summary.Passed++
+				}
+			}
+			if r.Event == abEventAttemptFinished && !r.Scored && r.Attempt >= 1+manifest.InfraRetries {
+				summary.TerminalInfraFailures++
+			}
+			if r.Outcome == abOutcomeTimeout {
+				summary.Timeouts++
+			}
+			if r.Outcome == abOutcomeSuiteBudgetExhausted {
+				summary.BudgetExhausted++
+			}
+		}
+		for _, r := range records {
+			if r.ArmID != arm.ID || r.Event != abEventAttemptFinished {
+				continue
+			}
+			summary.PromptTokens += r.Metrics.PromptTokens
+			summary.CompletionTokens += r.Metrics.CompletionTokens
+			summary.CacheHitTokens += r.Metrics.CacheHitTokens
+			summary.CacheMissTokens += r.Metrics.CacheMissTokens
+			summary.ToolResultsProjected += r.Metrics.ToolResultsProjected
+			summary.ProjectionSavedChars += r.Metrics.ProjectionSavedChars
+			summary.Cost += r.Metrics.Cost
+			if r.Metrics.Currency != "" {
+				currencies[r.Metrics.Currency] = true
+			}
+			if r.Outcome == abOutcomeInfraFailed {
+				summary.InfraAttempts++
+			}
+			if !r.MetricsAvailable {
+				summary.MissingMetricsAttempts++
+			}
+		}
+		for currency := range currencies {
+			summary.Currency = currency
+		}
+		if len(currencies) > 1 {
+			summary.Currency = "mixed"
+		}
+		if summary.Passed > 0 && summary.Currency != "mixed" {
+			costPerPass := summary.Cost / float64(summary.Passed)
+			summary.CostPerPass = &costPerPass
+		}
+		arms = append(arms, summary)
+	}
+
+	return abProjection{
+		SchemaVersion: abSchemaVersion,
+		Manifest:      manifest,
+		Cells:         cells,
+		Arms:          arms,
+		Paired:        pairedABSummary(manifest, latestMap),
+	}
+}
+
+func pairedABSummary(manifest abManifest, latest map[abCellKey]abRecord) abPairSummary {
+	summary := abPairSummary{TotalPairs: len(manifest.Tasks) * manifest.Repetitions}
+	for _, t := range manifest.Tasks {
+		for repetition := 1; repetition <= manifest.Repetitions; repetition++ {
+			baseline, baselineOK := latest[abCellKey{armID: "baseline", taskID: t.ID, repetition: repetition}]
+			candidate, candidateOK := latest[abCellKey{armID: "candidate", taskID: t.ID, repetition: repetition}]
+			if !baselineOK || !candidateOK || !baseline.Scored || !candidate.Scored {
+				continue
+			}
+			summary.EligiblePairs++
+			switch {
+			case baseline.Passed && candidate.Passed:
+				summary.BothPass++
+			case baseline.Passed:
+				summary.BaselineOnly++
+			case candidate.Passed:
+				summary.CandidateOnly++
+			default:
+				summary.BothFail++
+			}
+		}
+	}
+	if summary.EligiblePairs > 0 {
+		delta := 100 * float64(summary.CandidateOnly-summary.BaselineOnly) / float64(summary.EligiblePairs)
+		summary.DeltaPP = &delta
+		p := exactMcNemarP(summary.BaselineOnly, summary.CandidateOnly)
+		summary.McNemarP = &p
+	}
+	return summary
+}
+
+func exactMcNemarP(baselineOnly, candidateOnly int) float64 {
+	n := baselineOnly + candidateOnly
+	if n == 0 {
+		return 1
+	}
+	kMax := min(baselineOnly, candidateOnly)
+	logTwo := math.Log(2)
+	sum := 0.0
+	for k := 0; k <= kMax; k++ {
+		logChoose, _ := math.Lgamma(float64(n + 1))
+		logK, _ := math.Lgamma(float64(k + 1))
+		logNK, _ := math.Lgamma(float64(n - k + 1))
+		sum += math.Exp(logChoose - logK - logNK - float64(n)*logTwo)
+	}
+	return math.Min(1, 2*sum)
+}
+
+func renderABCSV(manifest abManifest, latest map[abCellKey]abRecord) ([]byte, error) {
+	var b strings.Builder
+	w := csv.NewWriter(&b)
+	header := []string{
+		"run_id", "task_id", "repetition",
+		"baseline_outcome", "baseline_scored", "baseline_passed", "baseline_attempt", "baseline_metrics_available", "baseline_prompt_tokens", "baseline_completion_tokens", "baseline_cache_hit_tokens", "baseline_cache_miss_tokens", "baseline_tool_results_projected", "baseline_projection_saved_chars", "baseline_cost",
+		"candidate_outcome", "candidate_scored", "candidate_passed", "candidate_attempt", "candidate_metrics_available", "candidate_prompt_tokens", "candidate_completion_tokens", "candidate_cache_hit_tokens", "candidate_cache_miss_tokens", "candidate_tool_results_projected", "candidate_projection_saved_chars", "candidate_cost",
+	}
+	if err := w.Write(header); err != nil {
+		return nil, err
+	}
+	for _, t := range manifest.Tasks {
+		for repetition := 1; repetition <= manifest.Repetitions; repetition++ {
+			baseline := latest[abCellKey{armID: "baseline", taskID: t.ID, repetition: repetition}]
+			candidate := latest[abCellKey{armID: "candidate", taskID: t.ID, repetition: repetition}]
+			row := []string{manifest.RunID, t.ID, strconv.Itoa(repetition)}
+			row = append(row, abCSVCell(baseline)...)
+			row = append(row, abCSVCell(candidate)...)
+			if err := w.Write(row); err != nil {
+				return nil, err
+			}
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, err
+	}
+	return []byte(b.String()), nil
+}
+
+func abCSVCell(r abRecord) []string {
+	outcome := r.Outcome
+	if r.Event == abEventAdmissionStarted {
+		outcome = abEventAdmissionStarted
+	}
+	if outcome == "" {
+		outcome = "pending"
+	}
+	return []string{
+		outcome, strconv.FormatBool(r.Scored), strconv.FormatBool(r.Passed), strconv.Itoa(r.Attempt), strconv.FormatBool(r.MetricsAvailable),
+		strconv.Itoa(r.Metrics.PromptTokens), strconv.Itoa(r.Metrics.CompletionTokens),
+		strconv.Itoa(r.Metrics.CacheHitTokens), strconv.Itoa(r.Metrics.CacheMissTokens),
+		strconv.Itoa(r.Metrics.ToolResultsProjected), strconv.Itoa(r.Metrics.ProjectionSavedChars),
+		strconv.FormatFloat(r.Metrics.Cost, 'f', 8, 64),
+	}
+}
+
+func renderABReport(p abProjection) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Reasonix Harness A/B — `%s`\n\n", p.Manifest.RunID)
+	status := "partial"
+	terminal := 0
+	for _, cell := range p.Cells {
+		if cell.Event == abEventAttemptFinished && (cell.Scored || cell.Attempt >= 1+p.Manifest.InfraRetries) {
+			terminal++
+		}
+	}
+	if terminal == p.Paired.TotalPairs*2 {
+		status = "complete"
+	}
+	fmt.Fprintf(&b, "**Status:** %s · **Model:** `%s` · **Environment:** `%s` · **Paired cells:** %d/%d · **Repetitions:** %d\n\n",
+		status, emptyAsDefault(p.Manifest.Model), emptyAsDefault(p.Manifest.EnvironmentID), p.Paired.EligiblePairs, p.Paired.TotalPairs, p.Manifest.Repetitions)
+
+	fmt.Fprintf(&b, "## Arm summary\n\n")
+	fmt.Fprintf(&b, "| Arm | Binary | Profile | Accuracy | Cache hit | Projections / chars saved | Tokens | Cost | Cost/pass | Timeout | Infra attempts | Metrics gaps |\n")
+	fmt.Fprintf(&b, "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+	for i, arm := range p.Manifest.Arms {
+		s := p.Arms[i]
+		costPerPass := "n/a"
+		if s.CostPerPass != nil {
+			costPerPass = fmt.Sprintf("%s%.4f", currencySym(s.Currency), *s.CostPerPass)
+		}
+		cost := fmt.Sprintf("%s%.4f", currencySym(s.Currency), s.Cost)
+		if s.Currency == "mixed" {
+			cost = "mixed currencies"
+		}
+		fmt.Fprintf(&b, "| `%s` | `%s` (`%s`) | `%s` | %d/%d (%s) | %s | %d / %s | %s | %s | %s | %d | %d | %d |\n",
+			arm.ID, arm.Binary, shortHash(arm.BinarySHA256), arm.Profile,
+			s.Passed, s.Scored, pct(s.Passed, s.Scored), pct(s.CacheHitTokens, s.CacheHitTokens+s.CacheMissTokens),
+			s.ToolResultsProjected, comma(s.ProjectionSavedChars), comma(s.PromptTokens+s.CompletionTokens), cost, costPerPass, s.Timeouts, s.InfraAttempts, s.MissingMetricsAttempts)
+	}
+
+	fmt.Fprintf(&b, "\n## Paired result\n\n")
+	fmt.Fprintf(&b, "| Both pass | Baseline only | Candidate only | Both fail | Candidate Δ | Exact McNemar p |\n")
+	fmt.Fprintf(&b, "|---:|---:|---:|---:|---:|---:|\n")
+	delta, pValue := "n/a", "n/a"
+	if p.Paired.DeltaPP != nil {
+		delta = fmt.Sprintf("%+.2f pp", *p.Paired.DeltaPP)
+	}
+	if p.Paired.McNemarP != nil {
+		pValue = fmt.Sprintf("%.6f", *p.Paired.McNemarP)
+	}
+	fmt.Fprintf(&b, "| %d | %d | %d | %d | %s | %s |\n",
+		p.Paired.BothPass, p.Paired.BaselineOnly, p.Paired.CandidateOnly, p.Paired.BothFail, delta, pValue)
+
+	fmt.Fprintf(&b, "\n## Per-task results\n\n")
+	fmt.Fprintf(&b, "| Task | Rep | Baseline | Candidate |\n")
+	fmt.Fprintf(&b, "|---|---:|---|---|\n")
+	latest := make(map[abCellKey]abRecord, len(p.Cells))
+	for _, cell := range p.Cells {
+		latest[abCellKey{armID: cell.ArmID, taskID: cell.TaskID, repetition: cell.Repetition}] = cell
+	}
+	for _, task := range p.Manifest.Tasks {
+		for repetition := 1; repetition <= p.Manifest.Repetitions; repetition++ {
+			baseline := latest[abCellKey{armID: "baseline", taskID: task.ID, repetition: repetition}]
+			candidate := latest[abCellKey{armID: "candidate", taskID: task.ID, repetition: repetition}]
+			fmt.Fprintf(&b, "| `%s` | %d | %s | %s |\n", task.ID, repetition, renderABCell(baseline), renderABCell(candidate))
+		}
+	}
+
+	fmt.Fprintf(&b, "\n<sub>Accuracy uses terminal scored cells. Infrastructure failures are excluded from paired statistics; attempts with available metrics still count toward token and cost totals. Metrics gaps make those totals lower bounds. The exact two-sided McNemar test uses discordant pairs only. Manifest SHA-256: `%s`.</sub>\n",
+		shortHash(p.Manifest.Suite.SHA256))
+	return b.String()
+}
+
+func renderABCell(r abRecord) string {
+	if r.Event == abEventAdmissionStarted {
+		return fmt.Sprintf("⏳ %s (attempt %d)", abEventAdmissionStarted, r.Attempt)
+	}
+	if r.Outcome == "" {
+		return "⏳ pending"
+	}
+	if !r.Scored {
+		return fmt.Sprintf("⚠️ %s (attempt %d)", r.Outcome, r.Attempt)
+	}
+	icon := "❌"
+	if r.Passed {
+		icon = "✅"
+	}
+	return fmt.Sprintf("%s %s", icon, r.Outcome)
+}
+
+func shortHash(hash string) string {
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
+}
+
+func emptyAsDefault(value string) string {
+	if value == "" {
+		return "config default"
+	}
+	return value
+}

--- a/cmd/e2ebench/harness_ab_test.go
+++ b/cmd/e2ebench/harness_ab_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestExactMcNemarP(t *testing.T) {
+	tests := []struct {
+		baselineOnly, candidateOnly int
+		want                        float64
+	}{
+		{0, 0, 1},
+		{0, 8, 0.0078125},
+		{8, 0, 0.0078125},
+		{1, 5, 0.21875},
+	}
+	for _, tt := range tests {
+		got := exactMcNemarP(tt.baselineOnly, tt.candidateOnly)
+		if math.Abs(got-tt.want) > 1e-12 {
+			t.Errorf("exactMcNemarP(%d, %d) = %.12f, want %.12f", tt.baselineOnly, tt.candidateOnly, got, tt.want)
+		}
+	}
+}
+
+func TestSanitizeABErrorRemovesLocalPaths(t *testing.T) {
+	got := sanitizeABError(errors.New("copy /Users/alice/private/task to /tmp/run/work"),
+		"/Users/alice/private/task", "<task>", "/tmp/run/work", "<workdir>")
+	if got != "copy <task> to <workdir>" {
+		t.Fatalf("sanitized error = %q", got)
+	}
+}
+
+func TestHashTreeIncludesEmptyDirectories(t *testing.T) {
+	root := t.TempDir()
+	empty := filepath.Join(root, "empty")
+	if err := os.Mkdir(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withEmpty, err := hashTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(empty); err != nil {
+		t.Fatal(err)
+	}
+	withoutEmpty, err := hashTree(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withEmpty == withoutEmpty {
+		t.Fatal("tree digest ignored an empty directory that copyDir preserves")
+	}
+}
+
+func TestBuildABProjectionUsesLatestCellAndAllAttemptCosts(t *testing.T) {
+	manifest := testABManifest(1, "task")
+	records := []abRecord{
+		testABRecord("baseline", "task", 1, 1, abOutcomeInfraFailed, false, false, 3),
+		testABRecord("baseline", "task", 1, 2, abOutcomePassed, true, true, 5),
+		testABRecord("candidate", "task", 1, 1, abOutcomeVerificationFailed, true, false, 7),
+	}
+	projection := buildABProjection(manifest, records)
+	if got, want := len(projection.Cells), 2; got != want {
+		t.Fatalf("latest cells = %d, want %d", got, want)
+	}
+	baseline := projection.Arms[0]
+	if baseline.Passed != 1 || baseline.Scored != 1 || baseline.InfraAttempts != 1 {
+		t.Fatalf("baseline summary = %+v", baseline)
+	}
+	if got, want := baseline.PromptTokens, 8; got != want {
+		t.Fatalf("baseline prompt tokens = %d, want all-attempt total %d", got, want)
+	}
+	if projection.Paired.BaselineOnly != 1 || projection.Paired.EligiblePairs != 1 {
+		t.Fatalf("paired summary = %+v", projection.Paired)
+	}
+}
+
+func TestLoadABRecordsRepairsTornTail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "attempts.jsonl")
+	manifest := testABManifest(1, "task")
+	want := testABRecord("baseline", "task", 1, 1, abOutcomePassed, true, true, 1)
+	if err := appendABRecord(path, want); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"schema_version":1,"run_id":"run"`); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadABRecords(path, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []abRecord{want}) {
+		t.Fatalf("records = %#v, want %#v", got, []abRecord{want})
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(body), "\n") || strings.Count(string(body), "\n") != 1 {
+		t.Fatalf("WAL was not repaired: %q", body)
+	}
+
+	candidate := testABRecord("candidate", "task", 1, 1, abOutcomeVerificationFailed, true, false, 2)
+	if err := appendABRecord(path, candidate); err != nil {
+		t.Fatal(err)
+	}
+	got, err = loadABRecords(path, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("records after append = %d, want 2", len(got))
+	}
+}
+
+func TestLoadABRecordsRepairsMissingFinalNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "attempts.jsonl")
+	manifest := testABManifest(1, "task")
+	want := testABRecord("baseline", "task", 1, 1, abOutcomePassed, true, true, 1)
+	body, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadABRecords(path, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, []abRecord{want}) {
+		t.Fatalf("records = %#v, want %#v", got, []abRecord{want})
+	}
+	repaired, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(repaired), "\n") {
+		t.Fatalf("missing final newline was not repaired: %q", repaired)
+	}
+}
+
+func TestCloseInterruptedABAdmissionBecomesInfrastructureFailure(t *testing.T) {
+	runDir := t.TempDir()
+	walPath := filepath.Join(runDir, "attempts.jsonl")
+	manifest := testABManifest(1, "task")
+	admission := abRecord{
+		SchemaVersion: abSchemaVersion, Event: abEventAdmissionStarted, RunID: manifest.RunID,
+		ArmID: "baseline", TaskID: "task", Repetition: 1, Attempt: 1,
+		StartedAt: "2026-01-01T00:00:00Z",
+	}
+	if err := appendABRecord(walPath, admission); err != nil {
+		t.Fatal(err)
+	}
+	records := []abRecord{admission}
+	latest := latestABRecords(records)
+	if err := closeInterruptedABAdmissions(runDir, walPath, manifest, &records, &latest); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(records), 2; got != want {
+		t.Fatalf("records = %d, want admission + closure (%d)", got, want)
+	}
+	closed := latest[abCellKey{armID: "baseline", taskID: "task", repetition: 1}]
+	if closed.Event != abEventAttemptFinished || closed.Outcome != abOutcomeInfraFailed || closed.Scored {
+		t.Fatalf("closed admission = %+v", closed)
+	}
+	loaded, err := loadABRecords(walPath, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(loaded, records) {
+		t.Fatalf("loaded records = %#v, want %#v", loaded, records)
+	}
+}
+
+func TestPrepareABManifestRefusesChangedSuite(t *testing.T) {
+	suite, tasks := writeABTestSuite(t)
+	runDir := filepath.Join(t.TempDir(), "run")
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := harnessABOpts{
+		suite: suite, runDir: runDir, runID: "fixed-run", baselineBin: binary, candidateBin: binary,
+		baselineProfile: benchmarkProfileBaseline, candidateProfile: benchmarkProfileBaseline,
+		repetitions: 1, infraRetries: 1,
+	}
+	first, err := prepareABManifest(opts, tasks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicManifest, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(publicManifest), filepath.Dir(suite)) || strings.Contains(string(publicManifest), binary) {
+		t.Fatalf("manifest leaked an absolute local path: %s", publicManifest)
+	}
+	if first.Arms[0].binaryPath == "" {
+		t.Fatal("runtime binary path was not retained in memory")
+	}
+	second, err := prepareABManifest(opts, tasks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("unchanged manifest did not resume identically")
+	}
+	verify := filepath.Join(suite, "tasks", "task", "verify.sh")
+	if err := os.WriteFile(verify, []byte("#!/usr/bin/env bash\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareABManifest(opts, tasks); err == nil || !strings.Contains(err.Error(), "frozen manifest mismatch") {
+		t.Fatalf("changed suite error = %v, want frozen manifest mismatch", err)
+	}
+}
+
+func TestRunHarnessABResumesWithoutDuplicateAttempts(t *testing.T) {
+	suite, _ := writeABTestSuite(t)
+	root := t.TempDir()
+	fake := filepath.Join(root, "fake-reasonix")
+	script := `#!/usr/bin/env bash
+set -eu
+metrics=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--metrics" ]; then
+    metrics="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+printf '{"prompt_tokens":10,"completion_tokens":2,"cache_hit_tokens":8,"cache_miss_tokens":2,"cost":0.01,"currency":"USD"}\n' > "$metrics"
+printf 'ok\n' > answer.txt
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runDir := filepath.Join(root, "run")
+	opts := harnessABOpts{
+		suite: suite, runDir: runDir, runID: "resume-run", baselineBin: fake, candidateBin: fake,
+		baselineProfile: benchmarkProfileBaseline, candidateProfile: benchmarkProfileBaseline,
+		repetitions: 1, infraRetries: 1,
+	}
+	if err := runHarnessAB(opts); err != nil {
+		t.Fatal(err)
+	}
+	manifest, ok, err := readABManifest(filepath.Join(runDir, "manifest.json"))
+	if err != nil || !ok {
+		t.Fatalf("read manifest: ok=%v err=%v", ok, err)
+	}
+	records, err := loadABRecords(filepath.Join(runDir, "attempts.jsonl"), manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(records), 4; got != want {
+		t.Fatalf("first run attempts = %d, want %d", got, want)
+	}
+	for _, record := range records {
+		if record.Event == abEventAttemptFinished && record.FinishedAt == "" {
+			t.Fatalf("finished event has no finished_at: %+v", record)
+		}
+	}
+	if err := runHarnessAB(opts); err != nil {
+		t.Fatal(err)
+	}
+	records, err = loadABRecords(filepath.Join(runDir, "attempts.jsonl"), manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(records), 4; got != want {
+		t.Fatalf("resumed attempts = %d, want no duplicates (%d)", got, want)
+	}
+	for _, name := range []string{"manifest.json", "attempts.jsonl", "results.json", "results.csv", "report.md"} {
+		if _, err := os.Stat(filepath.Join(runDir, name)); err != nil {
+			t.Errorf("artifact %s: %v", name, err)
+		}
+	}
+	report, err := os.ReadFile(filepath.Join(runDir, "report.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(report), "**Status:** complete") || !strings.Contains(string(report), "**Paired cells:** 1/1") {
+		t.Fatalf("unexpected report:\n%s", report)
+	}
+}
+
+func testABManifest(infraRetries int, taskIDs ...string) abManifest {
+	tasks := make([]abTaskManifest, 0, len(taskIDs))
+	for _, id := range taskIDs {
+		tasks = append(tasks, abTaskManifest{ID: id, SHA256: "task-hash", TimeoutSec: 10})
+	}
+	return abManifest{
+		SchemaVersion: abSchemaVersion, HarnessProtocol: abHarnessProtocol, RunID: "run", CreatedAt: "2026-01-01T00:00:00Z",
+		Suite: abSuiteManifest{Path: "/suite", SHA256: "suite-hash"}, Repetitions: 1, InfraRetries: infraRetries,
+		Arms: []abArmManifest{
+			{ID: "baseline", Binary: "/baseline", BinarySHA256: "base-hash", Profile: benchmarkProfileBaseline},
+			{ID: "candidate", Binary: "/candidate", BinarySHA256: "candidate-hash", Profile: benchmarkProfileBaseline},
+		},
+		Tasks: tasks,
+	}
+}
+
+func testABRecord(armID, taskID string, repetition, attempt int, outcome string, scored, passed bool, promptTokens int) abRecord {
+	return abRecord{
+		SchemaVersion: abSchemaVersion, Event: abEventAttemptFinished, RunID: "run", ArmID: armID, TaskID: taskID,
+		Repetition: repetition, Attempt: attempt, StartedAt: "2026-01-01T00:00:00Z", FinishedAt: "2026-01-01T00:00:01Z",
+		DurationMS: 1000, Outcome: outcome, Scored: scored, Passed: passed,
+		MetricsAvailable: true,
+		Metrics:          runMetrics{PromptTokens: promptTokens, CacheHitTokens: promptTokens, Cost: float64(promptTokens) / 100, Currency: "USD"},
+	}
+}
+
+func writeABTestSuite(t *testing.T) (string, []task) {
+	t.Helper()
+	suite := t.TempDir()
+	taskDir := filepath.Join(suite, "tasks", "task")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	taskBody := "prompt = \"create answer.txt\"\nmax_steps = 4\ntimeout_sec = 10\n"
+	if err := os.WriteFile(filepath.Join(taskDir, "task.toml"), []byte(taskBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	verify := "#!/usr/bin/env bash\nset -eu\ntest -f answer.txt\n"
+	if err := os.WriteFile(filepath.Join(taskDir, "verify.sh"), []byte(verify), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := loadTasks(suite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return suite, tasks
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -29,14 +29,16 @@ type task struct {
 }
 
 type runMetrics struct {
-	PromptTokens     int     `json:"prompt_tokens"`
-	CompletionTokens int     `json:"completion_tokens"`
-	CacheHitTokens   int     `json:"cache_hit_tokens"`
-	CacheMissTokens  int     `json:"cache_miss_tokens"`
-	Steps            int     `json:"steps"`
-	Cost             float64 `json:"cost"`
-	Currency         string  `json:"currency"`
-	Compactions      int     `json:"compactions"`
+	PromptTokens         int     `json:"prompt_tokens"`
+	CompletionTokens     int     `json:"completion_tokens"`
+	CacheHitTokens       int     `json:"cache_hit_tokens"`
+	CacheMissTokens      int     `json:"cache_miss_tokens"`
+	Steps                int     `json:"steps"`
+	Cost                 float64 `json:"cost"`
+	Currency             string  `json:"currency"`
+	Compactions          int     `json:"compactions"`
+	ToolResultsProjected int     `json:"tool_results_projected,omitempty"`
+	ProjectionSavedChars int     `json:"projection_saved_chars,omitempty"`
 
 	// Optional Delivery capability counters (omitempty for baseline/old metrics).
 	ReadinessChecks            int     `json:"readiness_checks,omitempty"`
@@ -76,16 +78,18 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -mode diff -base origin/main -repo . -attempts 3 -timeout 1800\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
 		fmt.Fprintf(flag.CommandLine.Output(), "\n  # Run the same suite with the delivery contract:\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -profile delivery\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
+		fmt.Fprintf(flag.CommandLine.Output(), "\n  # Run a resumable paired Harness A/B experiment:\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -mode harness-ab -run-dir .reasonix-bench/run-001 -baseline-bin ./reasonix-main -candidate-bin ./reasonix-head\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
 	}
 
-	mode := flag.String("mode", "suite", "suite | diff (diff = generate tests for the PR diff and grade with the repo's tests)")
+	mode := flag.String("mode", "suite", "suite | diff | harness-ab")
 	suite := flag.String("suite", "benchmarks/e2e", "suite root (contains tasks/<id>/)")
 	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
 	model := flag.String("model", "", "provider/model name (default: config default)")
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
-	budget := flag.Int("budget", 400_000, "abort once total tokens cross this (0 = no cap)")
+	budget := flag.Int("budget", 400_000, "token cap (suite: total; harness-ab: independently per arm; 0 = no cap)")
 	// diff-mode flags
 	repo := flag.String("repo", ".", "repo root (diff mode)")
 	base := flag.String("base", "", "base ref to diff the PR head against (diff mode)")
@@ -93,6 +97,16 @@ func main() {
 	maxSteps := flag.Int("max-steps", 80, "agent tool-call cap for the diff task")
 	timeoutSec := flag.Int("timeout", 1200, "agent timeout in seconds (diff mode)")
 	attempts := flag.Int("attempts", 1, "diff mode: retry up to N times until a run passes (stochastic agent)")
+	// harness-ab mode flags
+	runDir := flag.String("run-dir", "", "persistent experiment directory (harness-ab mode; required)")
+	runID := flag.String("run-id", "", "stable experiment ID (harness-ab mode; generated for a new run when empty)")
+	environmentID := flag.String("environment-id", "", "non-secret provider/model/pricing identity label (harness-ab mode)")
+	baselineBin := flag.String("baseline-bin", "reasonix", "baseline Reasonix binary (harness-ab mode)")
+	candidateBin := flag.String("candidate-bin", "reasonix", "candidate Reasonix binary (harness-ab mode)")
+	baselineProfile := flag.String("baseline-profile", benchmarkProfileBaseline, "baseline prompt profile (harness-ab mode)")
+	candidateProfile := flag.String("candidate-profile", benchmarkProfileBaseline, "candidate prompt profile (harness-ab mode)")
+	repetitions := flag.Int("repetitions", 1, "paired repetitions per task (harness-ab mode)")
+	infraRetries := flag.Int("infra-retries", 1, "retries for infrastructure failures only (harness-ab mode)")
 	flag.Parse()
 	profile, err := normalizeBenchmarkProfile(*profileFlag)
 	if err != nil {
@@ -107,6 +121,33 @@ func main() {
 		})
 		emit(report, *outMD, "")
 		return
+	}
+	if *mode == "harness-ab" {
+		baseline, err := normalizeBenchmarkProfile(*baselineProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "baseline profile:", err)
+			os.Exit(2)
+		}
+		candidate, err := normalizeBenchmarkProfile(*candidateProfile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "candidate profile:", err)
+			os.Exit(2)
+		}
+		err = runHarnessAB(harnessABOpts{
+			suite: *suite, model: *model, runDir: *runDir, runID: *runID, environmentID: *environmentID,
+			baselineBin: *baselineBin, candidateBin: *candidateBin,
+			baselineProfile: baseline, candidateProfile: candidate,
+			repetitions: *repetitions, infraRetries: *infraRetries, tokenBudget: *budget,
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "harness-ab:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if *mode != "suite" {
+		fmt.Fprintf(os.Stderr, "unknown mode %q (want suite, diff, or harness-ab)\n", *mode)
+		os.Exit(2)
 	}
 
 	tasks, err := loadTasks(*suite)

--- a/cmd/e2ebench/profile.go
+++ b/cmd/e2ebench/profile.go
@@ -6,8 +6,10 @@ import (
 )
 
 const (
-	benchmarkProfileBaseline = "baseline"
-	benchmarkProfileDelivery = "delivery"
+	benchmarkProfileBaseline           = "baseline"
+	benchmarkProfileDelivery           = "delivery"
+	benchmarkProfileProjection         = "projection"
+	benchmarkProfileDeliveryProjection = "delivery-projection"
 )
 
 func normalizeBenchmarkProfile(profile string) (string, error) {
@@ -16,14 +18,21 @@ func normalizeBenchmarkProfile(profile string) (string, error) {
 		return benchmarkProfileBaseline, nil
 	case benchmarkProfileDelivery:
 		return benchmarkProfileDelivery, nil
+	case benchmarkProfileProjection:
+		return benchmarkProfileProjection, nil
+	case benchmarkProfileDeliveryProjection:
+		return benchmarkProfileDeliveryProjection, nil
 	default:
-		return "", fmt.Errorf("unknown benchmark profile %q (want baseline or delivery)", profile)
+		return "", fmt.Errorf("unknown benchmark profile %q (want baseline, delivery, projection, or delivery-projection)", profile)
 	}
 }
 
 func appendBenchmarkProfileArgs(args []string, profile string) []string {
-	if profile == benchmarkProfileDelivery {
-		return append(args, "--profile", "delivery")
+	if profile == benchmarkProfileDelivery || profile == benchmarkProfileDeliveryProjection {
+		args = append(args, "--profile", "delivery")
+	}
+	if profile == benchmarkProfileProjection || profile == benchmarkProfileDeliveryProjection {
+		args = append(args, "--tool-result-projection")
 	}
 	return args
 }

--- a/cmd/e2ebench/profile_test.go
+++ b/cmd/e2ebench/profile_test.go
@@ -34,3 +34,11 @@ func TestNormalizeBenchmarkProfile(t *testing.T) {
 		t.Fatal("unknown profile should fail")
 	}
 }
+
+func TestAppendBenchmarkProjectionProfileArgs(t *testing.T) {
+	got := appendBenchmarkProfileArgs([]string{"run"}, benchmarkProfileDeliveryProjection)
+	want := []string{"run", "--profile", "delivery", "--tool-result-projection"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+}

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -67,6 +67,7 @@ reasoning_language = "auto"      # visible reasoning text: auto|zh|en
 # max_subagent_concurrency = 6        # session-wide sub-agent concurrency (task/fleet/skills)
 # max_parallel_writers = 3            # concurrent writers with non-overlapping write_paths
 tool_result_snip_ratio = 0.6       # shorten stale tool output before summary compaction
+tool_result_projection = false     # opt-in deterministic projection experiment
 
 [[providers]]
 name        = "deepseek-flash"

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -61,6 +61,7 @@ reasoning_language = "auto"      # 可见思考过程语言：auto|zh|en
 # max_subagent_concurrency = 6        # 会话级子代理总并发（task/fleet/skills）
 # max_parallel_writers = 3            # 互不重叠 write_paths 时的并行写入上限
 tool_result_snip_ratio = 0.6       # 在摘要 compaction 前先缩短旧工具输出
+tool_result_projection = false     # 可选的确定性旧结果投影实验
 
 [[providers]]
 name        = "deepseek-flash"

--- a/docs/HARNESS_AB.md
+++ b/docs/HARNESS_AB.md
@@ -1,0 +1,55 @@
+# Harness A/B experiments
+
+`e2ebench -mode harness-ab` runs a paired, resumable experiment over the committed end-to-end task suite. It is intended for comparing two Reasonix builds or prompt profiles while holding the model, tasks, deadlines, grader, retry policy, and per-arm token budget constant.
+
+## Run an experiment
+
+Build or otherwise provide the two binaries first, then use a new persistent directory for the experiment:
+
+```bash
+go run ./cmd/e2ebench \
+  -mode harness-ab \
+  -suite benchmarks/e2e \
+  -model e2e \
+  -environment-id deepseek-v4-flash-2026-08-03 \
+  -baseline-bin /path/to/reasonix-baseline \
+  -candidate-bin /path/to/reasonix-candidate \
+  -baseline-profile baseline \
+  -candidate-profile projection \
+  -repetitions 3 \
+  -infra-retries 1 \
+  -budget 400000 \
+  -run-dir .reasonix-bench/cache-projection-001
+```
+
+The token budget is applied independently to each arm. Task order is stable, while which arm runs first alternates across task/repetition cells to reduce ordering bias. `-environment-id` is a non-secret, user-defined label for the provider route, resolved model, pricing revision, and other external conditions that the harness cannot safely derive from credentials; use a new run directory if those conditions change.
+
+Re-run the exact command with the same `-run-dir` to resume. Completed cells are not admitted again. Each provider admission is logged before the process starts; after a crash, an admission without a durable result is closed as `infra_failed` and follows the frozen infrastructure-retry policy. Run only one harness process against a run directory at a time.
+
+If the suite, either binary, model, profile, repetitions, retry policy, or budget changed, the harness refuses to reuse the frozen run directory; start a new experiment instead.
+
+## Artifacts
+
+The run directory contains:
+
+- `manifest.json`: schema-versioned harness protocol and experiment identity, privacy-safe binary/suite labels and SHA-256 digests, task digests, model/environment labels, profiles, deadlines, repetitions, retry policy, and budget. Resolved absolute paths remain process-local.
+- `attempts.jsonl`: append-only, fsynced write-ahead log. An actual attempt has an `admission_started` event followed by `attempt_finished`. A torn final line is removed on resume; earlier corruption is an error.
+- `results.json`: machine-readable projection of latest cells, arm totals, and paired statistics.
+- `results.csv`: one row per task/repetition pair for external analysis.
+- `report.md`: continuously refreshed human-readable summary.
+
+The artifacts contain no provider credentials or resolved local paths; common infrastructure errors are path-sanitized before persistence. Treat task IDs, user-supplied labels, and benchmark outputs according to the repository's normal privacy policy.
+
+## Scoring and retries
+
+Outcomes use a fixed taxonomy: `passed`, `verification_failed`, `agent_error`, `timeout`, `suite_budget_exhausted`, and `infra_failed`.
+
+Only `infra_failed` is retried automatically. Agent errors, failed verification, timeouts, and budget exhaustion are terminal scored outcomes. A terminal infrastructure failure remains visible but is excluded from accuracy and paired statistics. Tokens and cost from every actual attempt with available metrics, including infrastructure retries, remain in the arm totals. The report exposes metric gaps; totals are lower bounds when a killed process could not flush its metrics file.
+
+The paired report includes the four pass/fail cells, candidate-minus-baseline percentage-point delta, and an exact two-sided McNemar p-value based only on discordant eligible pairs. A small task suite has low statistical power; do not treat a positive point estimate alone as evidence of a general improvement.
+
+## Cache interpretation
+
+Cache hit rate is cached prompt tokens divided by cache-hit plus cache-miss tokens reported by `reasonix run --metrics`. Harness A/B does not change provider-visible prompts itself. For cache experiments, keep the provider/model route and stable prefix identical, and change only the component under test.
+
+Profiles are `baseline`, `delivery`, `projection`, and `delivery-projection`. Projection profiles apply a process-local experiment override and do not modify persisted user configuration.

--- a/docs/HARNESS_AB.zh-CN.md
+++ b/docs/HARNESS_AB.zh-CN.md
@@ -1,0 +1,55 @@
+# Harness A/B 实验
+
+`e2ebench -mode harness-ab` 会在仓库的端到端任务集上执行配对、可断点续跑的实验。它适合比较两个 Reasonix 构建或 prompt profile，同时固定模型、任务、截止时间、grader、重试策略和每个实验臂的 token 预算。
+
+## 运行实验
+
+先准备两个二进制文件，再为实验指定一个新的持久化目录：
+
+```bash
+go run ./cmd/e2ebench \
+  -mode harness-ab \
+  -suite benchmarks/e2e \
+  -model e2e \
+  -environment-id deepseek-v4-flash-2026-08-03 \
+  -baseline-bin /path/to/reasonix-baseline \
+  -candidate-bin /path/to/reasonix-candidate \
+  -baseline-profile baseline \
+  -candidate-profile projection \
+  -repetitions 3 \
+  -infra-retries 1 \
+  -budget 400000 \
+  -run-dir .reasonix-bench/cache-projection-001
+```
+
+token 预算分别作用于两个实验臂。任务顺序保持稳定，但每个任务/重复 cell 中先运行哪个实验臂会交替，以降低顺序偏差。`-environment-id` 是不含秘密、由用户定义的 provider 路由、实际模型、计价版本及其他外部条件标签；harness 无法从凭证中安全推导这些信息，如果这些条件变化，应创建新的运行目录。
+
+使用完全相同的参数和 `-run-dir` 再次执行即可恢复；已经完成的 cell 不会再次请求模型。每次 provider admission 都会在启动进程前写入日志；崩溃后，只有 admission 而没有持久化结果的尝试会被结算为 `infra_failed`，再按冻结的基础设施重试策略处理。同一个运行目录同一时间只能由一个 harness 进程使用。
+
+如果任务集、任一二进制文件、模型、profile、重复次数、重试策略或预算发生变化，harness 会拒绝复用被冻结的运行目录，此时应创建新实验。
+
+## 产物
+
+运行目录包含：
+
+- `manifest.json`：带 schema 版本的 harness 协议和实验身份，包括隐私安全的二进制/suite 标签及 SHA-256、任务摘要、模型/环境标签、profile、截止时间、重复次数、重试策略和预算；解析后的绝对路径只保留在当前进程内。
+- `attempts.jsonl`：只追加并执行 `fsync` 的 WAL；一次实际尝试先写 `admission_started`，再写 `attempt_finished`。恢复时会移除末尾未写完的一行，较早位置的损坏则直接报错。
+- `results.json`：最新 cell、实验臂汇总和配对统计的机器可读投影。
+- `results.csv`：每个任务/重复配对一行，便于外部分析。
+- `report.md`：每完成一次尝试都会刷新的可读报告。
+
+产物不会写入 provider 凭证或解析后的本地路径，常见基础设施错误在持久化前也会清理路径。任务 ID、用户提供的标签与基准输出仍需遵循仓库既有隐私规范。
+
+## 计分与重试
+
+结果使用固定分类：`passed`、`verification_failed`、`agent_error`、`timeout`、`suite_budget_exhausted` 和 `infra_failed`。
+
+只有 `infra_failed` 会自动重试。Agent 错误、验证失败、超时和预算耗尽都是终态计分结果。最终仍失败的基础设施 cell 会保留在报告中，但不进入准确率和配对统计。只要 metrics 可用，所有实际请求产生的 token 与成本（包括基础设施重试）都会计入实验臂总量。报告会显示 metrics 缺口；如果被终止的进程来不及落盘 metrics，总量应视为下界。
+
+配对报告给出四格通过/失败计数、candidate 相对 baseline 的百分点变化，以及仅基于有效不一致配对计算的双侧精确 McNemar p 值。小任务集的统计功效有限，不能只凭正向点估计断言整体能力提升。
+
+## 缓存解读
+
+缓存命中率等于 `reasonix run --metrics` 报告的缓存 prompt token，除以 cache-hit 与 cache-miss token 之和。Harness A/B 本身不会改变 provider 可见 prompt。做缓存实验时，应保持 provider/model 路由和稳定前缀一致，只改变被测组件。
+
+profile 可选 `baseline`、`delivery`、`projection`、`delivery-projection`。projection 变体使用只作用于当前进程的实验 override，不修改用户持久化配置。

--- a/docs/RUNTIME_EVIDENCE.md
+++ b/docs/RUNTIME_EVIDENCE.md
@@ -1,0 +1,10 @@
+# Runtime Evidence and Recovery
+
+Reasonix keeps runtime evidence local and outside the provider prompt. Two session-owned stores complement the authoritative transcript:
+
+- `<session>.run-journal.ndjson` is a schema-versioned, append-only Run Journal. It records run boundaries and tool-receipt classifications using counters and SHA-256 digests. Raw prompts, arguments, commands, output, errors, and paths are never persisted. Writes use mode `0600`, `fsync`, monotonic sequences, torn-tail repair, and fail closed on future schema versions.
+- `deliveryCheckpoint.evidenceLedger` in `<session>.goal-state.json` is a bounded Goal Evidence Ledger. It retains the latest 64 successful evidence identities, mutation generations, and the generation that passed the live completion gates. It is additive: legacy checkpoint booleans remain authoritative and a restored ledger never bypasses fresh verification, review, or sign-off.
+
+Both stores rotate with the session and are included in current session cleanup. Older goal states without ledger fields load conservatively. Older binaries ignore the new JSON fields; the `.ndjson` journal suffix prevents their `.jsonl` session scanners from treating the sidecar as a conversation.
+
+Every successful mutation advances `mutationGeneration`. Verification, review, inspection, criteria, and sign-off receipts are projected into that generation. Only after the existing host readiness checks pass does `closedGeneration` advance and `pendingMutation` clear. A crash therefore leaves a durable, content-free explanation of the unfinished generation while the next run still has to produce valid live evidence.

--- a/docs/RUNTIME_EVIDENCE.zh-CN.md
+++ b/docs/RUNTIME_EVIDENCE.zh-CN.md
@@ -1,0 +1,10 @@
+# 运行证据与恢复闭环
+
+Reasonix 把运行证据保留在本地，不放入 provider prompt。除权威 transcript 外，每个 session 还有两个配套存储：
+
+- `<session>.run-journal.ndjson` 是带 schema 版本、只追加的 Run Journal。它只用计数器和 SHA-256 摘要记录 run 边界及工具 receipt 分类，不持久化原始 prompt、参数、命令、输出、错误或路径。文件权限为 `0600`，每次追加执行 `fsync`，sequence 单调递增；恢复时修复未写完的尾行，遇到未来 schema 则保守失败。
+- `<session>.goal-state.json` 中的 `deliveryCheckpoint.evidenceLedger` 是有界 Goal Evidence Ledger。它保留最近 64 条成功证据身份、mutation generation，以及通过实时完成门禁的 generation。它只是增量审计信息：旧 checkpoint 布尔字段仍然有效，恢复出的账本不能跳过新的验证、审查或签收。
+
+两种存储都随 session 切换，并纳入当前版本的 session 清理。缺少新字段的旧 goal state 会保守加载；旧二进制会忽略新增 JSON 字段。journal 使用 `.ndjson`，可避免旧版 `.jsonl` 扫描器把 sidecar 误认成会话。
+
+每次成功 mutation 都会推进 `mutationGeneration`；验证、审查、检查、验收标准和签收 receipt 会投影到对应 generation。只有现有 host readiness 门禁全部通过时，`closedGeneration` 才会前进，`pendingMutation` 才会清除。因此崩溃后仍能用不含内容的记录解释哪个 generation 尚未闭环，而下一次运行依然必须提供有效的实时证据。

--- a/docs/TOOL_RESULT_PROJECTION.md
+++ b/docs/TOOL_RESULT_PROJECTION.md
@@ -1,0 +1,14 @@
+# Active Tool Result Projection
+
+Active Tool Result Projection is an opt-in cache experiment:
+
+```toml
+[agent]
+tool_result_projection = true
+```
+
+It can also be enabled for one headless run with `reasonix run --tool-result-projection ...`.
+
+At the configured stale-result threshold, Reasonix archives the full result locally and rewrites only results before the protected recent/active-turn tail. The provider-visible projection is deterministic: tool name, original byte count, a short SHA-256 identity, and bounded head/tail content. It contains no archive path or timestamp. System prompts, tool schemas, tool order, tool-call pairs, assistant reasoning, errors covered by `keep`, and the active tail stay unchanged.
+
+The switch defaults to `false` to preserve the historical snip/prune baseline. Usage metrics expose `tool_results_projected` and `projection_saved_chars` on the next provider request, where the projected history actually participates. Use `e2ebench -mode harness-ab` with `baseline` versus `projection` (or `delivery` versus `delivery-projection`) profiles to compare task success, cache hit rate, tokens, and cost.

--- a/docs/TOOL_RESULT_PROJECTION.zh-CN.md
+++ b/docs/TOOL_RESULT_PROJECTION.zh-CN.md
@@ -1,0 +1,14 @@
+# Active Tool Result Projection
+
+Active Tool Result Projection 是默认关闭的缓存实验：
+
+```toml
+[agent]
+tool_result_projection = true
+```
+
+也可以只对一次 headless 运行启用：`reasonix run --tool-result-projection ...`。
+
+到达旧结果阈值后，Reasonix 先在本地归档完整结果，只改写受保护的 recent/active-turn tail 之前的陈旧结果。provider 可见投影是确定性的：工具名、原始字节数、短 SHA-256 身份以及有界首尾内容；不含 archive 路径和时间。system prompt、tool schema、工具顺序、tool-call 配对、assistant reasoning、受 `keep` 保护的错误以及活动尾部都保持不变。
+
+默认值为 `false`，用于保留历史 snip/prune 基线。下一次 provider 请求实际使用投影历史时，Usage metrics 会报告 `tool_results_projected` 和 `projection_saved_chars`。可用 `e2ebench -mode harness-ab` 比较 `baseline` 与 `projection`，或比较 `delivery` 与 `delivery-projection`，同时观察任务成功率、cache hit、token 和成本。

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/nilutil"
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
+	"reasonix/internal/runjournal"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
@@ -426,6 +427,9 @@ type Agent struct {
 	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
+	// runJournal is a session-owned, content-free audit trail. It is rebound by
+	// the Controller whenever the session path rotates and never enters prompts.
+	runJournal *runjournal.Journal
 
 	// todoState is the host's canonical task list: the latest successful
 	// todo_write with completions applied by complete_step. Unlike the per-turn
@@ -455,6 +459,7 @@ type Agent struct {
 	deliveryScopeID             string
 	deliveryScopeActive         bool
 	deliveryCheckpoint          evidence.DeliveryCheckpoint
+	deliveryProjectedReceipts   int
 
 	// classifierTaskText is the host-trusted task text for delivery intent
 	// classification, set by sub-agent spawners whose Run input carries host
@@ -503,17 +508,20 @@ type Agent struct {
 	// under the window (consecutiveCompacts crosses the limit), so auto-compaction
 	// pauses instead of looping. softCompactNoticed gates the one-shot soft-ratio
 	// notice so it fires once per approach, not every turn.
-	contextWindow       int
-	softCompactRatio    float64
-	toolResultSnipRatio float64
-	compactRatio        float64
-	compactForceRatio   float64
-	softCompactNoticed  bool
-	recentKeep          int
-	archiveDir          string
-	keepPolicy          KeepPolicy
-	compactStuck        bool
-	consecutiveCompacts int
+	contextWindow               int
+	softCompactRatio            float64
+	toolResultSnipRatio         float64
+	compactRatio                float64
+	compactForceRatio           float64
+	softCompactNoticed          bool
+	recentKeep                  int
+	archiveDir                  string
+	keepPolicy                  KeepPolicy
+	compactStuck                bool
+	consecutiveCompacts         int
+	toolResultProjection        bool
+	pendingProjectedResults     int
+	pendingProjectionSavedChars int
 	// activeTurnCreatedAt identifies the real/synthetic user message that began
 	// the currently running turn. Compaction may rewrite older history while a
 	// tool loop is active, but it must keep this message and everything after it
@@ -1079,6 +1087,10 @@ type Options struct {
 	// depth 0; child subagents are depth 1. MaxSubagentDepth caps delegation.
 	SubagentDepth    int
 	MaxSubagentDepth int
+
+	// ToolResultProjection enables deterministic projection as an experiment
+	// profile. Default false preserves the legacy snip/prune baseline for A/B.
+	ToolResultProjection bool
 }
 
 // New constructs an Agent. MaxSteps <= 0 means no cap — the run loop continues
@@ -1145,6 +1157,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if reasoningByteLimit == 0 {
 		reasoningByteLimit = defaultReasoningByteLimit
 	}
+	ledger := evidence.NewLedger()
+	journal := runjournal.New()
 	a := &Agent{
 		prov:                      prov,
 		tools:                     tools,
@@ -1172,7 +1186,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		writeWorkspaceRoot:        strings.TrimSpace(opts.WriteWorkspaceRoot),
 		workspaceLease:            opts.WorkspaceLease,
 		missingReasoningWarnState: missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
-		evidence:                  evidence.NewLedger(),
+		evidence:                  ledger,
+		runJournal:                journal,
 		projectChecks:             append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		deliveryProfile:           opts.DeliveryProfile,
 		classifierTaskText:        opts.ClassifierTaskText,
@@ -1186,12 +1201,54 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		recentKeep:                opts.RecentKeep,
 		archiveDir:                opts.ArchiveDir,
 		keepPolicy:                opts.KeepPolicy,
+		toolResultProjection:      opts.ToolResultProjection,
 		subagentDepth:             subagentDepth,
 		maxSubagentDepth:          maxSubagentDepth,
 	}
+	ledger.SetObserver(a.recordRunJournalReceipt)
 	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
 	return a
+}
+
+// SetRunJournalPath binds the local runtime journal to the active session.
+func (a *Agent) SetRunJournalPath(path string) error {
+	if a == nil || a.runJournal == nil {
+		return nil
+	}
+	return a.runJournal.Bind(path)
+}
+
+func (a *Agent) recordRunJournalReceipt(r evidence.Receipt) {
+	if a == nil || a.runJournal == nil {
+		return
+	}
+	paths := make([]string, 0, len(r.Paths))
+	for _, p := range r.Paths {
+		if len(paths) == 8 {
+			break
+		}
+		paths = append(paths, runjournal.Digest(p))
+	}
+	success := r.Success
+	detail := "work"
+	switch {
+	case r.Mutation || r.Write:
+		detail = "mutation"
+	case r.ToolName == "todo_write":
+		detail = "criteria"
+	case r.ToolName == "complete_step":
+		detail = "signoff"
+	case r.ToolName == "review" || r.ToolName == "review_report" || (r.ToolName == "task" && r.Profile == "review"):
+		detail = "review"
+	case r.ToolName == "bash" && evidence.IsDeliveryVerificationCommand(r.Command):
+		detail = "verification"
+	case r.Read:
+		detail = "inspection"
+	}
+	_ = a.runJournal.Append(runjournal.Entry{Type: "tool_receipt", Tool: r.ToolName,
+		Success: &success, InputDigest: runjournal.Digest(string(r.Args)), PathDigests: paths,
+		OutputBytes: r.OutputBytes, Detail: detail})
 }
 
 func usageSourceOrDefault(source, fallback string) string {
@@ -1251,12 +1308,29 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			runMaxStepsKey = limit.key
 		}
 	}
-	a.recoveryRunSeq.Add(1)
+	turnStartedAt := time.Now()
+	runSeq := a.recoveryRunSeq.Add(1)
+	runID := fmt.Sprintf("run-%d", runSeq)
+	scopeDigest := ""
+	if scope, ok := DeliveryExecutionScopeFromContext(ctx); ok {
+		scopeDigest = runjournal.Digest(scope.ID)
+	}
+	if a.runJournal != nil {
+		_ = a.runJournal.Append(runjournal.Entry{Type: "run_started", RunID: runID,
+			ScopeDigest: scopeDigest, InputDigest: runjournal.Digest(input)})
+		defer func() {
+			detail := "success"
+			if runErr != nil {
+				detail = "error"
+			}
+			_ = a.runJournal.Append(runjournal.Entry{Type: "run_finished", RunID: runID,
+				ScopeDigest: scopeDigest, DurationMS: time.Since(turnStartedAt).Milliseconds(), Detail: detail})
+		}()
+	}
 	if a.deliveryProfile && a.workspaceLease != nil {
 		a.workspaceLease.BeginRun()
 		defer a.workspaceLease.EndRun()
 	}
-	turnStartedAt := time.Now()
 	workDurationMs := func() int64 {
 		if elapsed := time.Since(turnStartedAt).Milliseconds(); elapsed > 0 {
 			return elapsed
@@ -1668,16 +1742,30 @@ func (a *Agent) updateDeliveryCheckpoint(runErr error) {
 	cp := a.deliveryCheckpoint
 	if cp.ScopeID != a.deliveryScopeID {
 		cp = evidence.DeliveryCheckpoint{ScopeID: a.deliveryScopeID}
+		a.deliveryProjectedReceipts = 0
 	}
 	cp.CriteriaEstablished = cp.CriteriaEstablished || a.deliveryCriteriaEstablished || a.evidence.HasSuccessfulTodoWrite()
 	cp.WorkObserved = cp.WorkObserved || a.evidence.HasSuccessfulWorkReceipt()
+	// Legacy checkpoints predate generation counters. Seed their already-known
+	// mutation as generation 1 before projecting any new receipt.
+	if cp.MutationObserved && cp.MutationGeneration == 0 {
+		cp.MutationGeneration = 1
+	}
 	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
 		cp.MutationObserved = true
 		cp.PendingMutation = true
 	}
-	if runErr == nil && cp.PendingMutation && a.deliveryMutationCheckpointReady() {
+	ready := runErr == nil && cp.PendingMutation && a.deliveryMutationCheckpointReady()
+	if ready {
 		cp.PendingMutation = false
 	}
+	receipts := a.evidence.Receipts()
+	start := a.deliveryProjectedReceipts
+	if start < 0 || start > len(receipts) {
+		start = 0
+	}
+	cp = evidence.ProjectGoalEvidence(cp, receipts[start:], ready)
+	a.deliveryProjectedReceipts = len(receipts)
 	a.deliveryCheckpoint = cp
 }
 

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -99,10 +99,25 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	}
 	if u.PromptTokens >= snip && u.PromptTokens < high {
 		ratio := a.tokPerChar()
-		if st, err := a.SnipStaleToolResults(); err == nil && st.Results > 0 {
+		var st PruneStats
+		var err error
+		if a.toolResultProjection {
+			st, err = a.ProjectStaleToolResults()
+		} else {
+			st, err = a.SnipStaleToolResults()
+		}
+		if err == nil && st.Results > 0 {
+			if a.toolResultProjection {
+				a.pendingProjectedResults += st.Results
+				a.pendingProjectionSavedChars += st.SavedChars
+			}
 			saved := int(float64(st.SavedChars) * ratio)
+			verb := "snipped"
+			if a.toolResultProjection {
+				verb = "projected"
+			}
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
-				"snipped %d stale tool results (~%d tokens est.) before compaction", st.Results, saved)})
+				"%s %d stale tool results (~%d tokens est.) before compaction", verb, st.Results, saved)})
 		}
 		return
 	}
@@ -120,7 +135,18 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	// Prune before folding: when eliding stale tool results alone clears the
 	// trigger, this turn's (paid) summarize call is skipped entirely.
 	ratio := a.tokPerChar()
-	if st, err := a.PruneStaleToolResults(); err == nil && st.Results > 0 {
+	var st PruneStats
+	var err error
+	if a.toolResultProjection {
+		st, err = a.ProjectStaleToolResults()
+	} else {
+		st, err = a.PruneStaleToolResults()
+	}
+	if err == nil && st.Results > 0 {
+		if a.toolResultProjection {
+			a.pendingProjectedResults += st.Results
+			a.pendingProjectionSavedChars += st.SavedChars
+		}
 		saved := int(float64(st.SavedChars) * ratio)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
 			"pruned %d stale tool results (~%d tokens est.) before compaction", st.Results, saved)})

--- a/internal/agent/delivery_scope_test.go
+++ b/internal/agent/delivery_scope_test.go
@@ -86,6 +86,10 @@ func TestDeliveryGoalScopeCarriesSignedOffMutationAcrossTurns(t *testing.T) {
 	if err := a.Run(ctx, "finish the goal"); err != nil {
 		t.Fatalf("verification-only completion should reuse scoped evidence: %v", err)
 	}
+	cp := a.DeliveryCheckpoint()
+	if cp.MutationGeneration != 1 || cp.ClosedGeneration != 1 {
+		t.Fatalf("same scoped receipts were projected twice: %+v", cp)
+	}
 }
 
 func TestDeliveryGoalRestoredPendingMutationCompletesWithoutNewWrite(t *testing.T) {
@@ -114,6 +118,8 @@ func TestDeliveryGoalRestoredPendingMutationCompletesWithoutNewWrite(t *testing.
 	}
 	if cp := a.DeliveryCheckpoint(); cp.PendingMutation {
 		t.Fatalf("checkpoint = %+v, want PendingMutation cleared after sign-off", cp)
+	} else if cp.MutationGeneration != 1 || cp.ClosedGeneration != 1 {
+		t.Fatalf("legacy mutation recovery did not close generation 1: %+v", cp)
 	}
 }
 

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -13,9 +14,10 @@ import (
 // them needs no summarizer call and never drops a message. tool_call/result
 // pairing and assistant content (including signed reasoning) are untouched.
 const (
-	snippedMarker = "[snipped tool result — "
-	prunedMarker  = "[elided tool result — "
-	minPruneBytes = 1024
+	snippedMarker   = "[snipped tool result — "
+	prunedMarker    = "[elided tool result — "
+	projectedMarker = "[projected tool result — "
+	minPruneBytes   = 1024
 )
 
 type toolResultMaintenanceMode int
@@ -23,6 +25,7 @@ type toolResultMaintenanceMode int
 const (
 	toolResultSnip toolResultMaintenanceMode = iota
 	toolResultPrune
+	toolResultProject
 )
 
 // PruneStats reports one maintenance pass.
@@ -44,6 +47,13 @@ func (a *Agent) SnipStaleToolResults() (PruneStats, error) {
 // snipped results to a shorter placeholder.
 func (a *Agent) PruneStaleToolResults() (PruneStats, error) {
 	return a.maintainStaleToolResults(toolResultPrune)
+}
+
+// ProjectStaleToolResults deterministically retains the salient head/tail of
+// stale results. Full originals are archived locally, but provider-visible text
+// contains only stable metadata and never an archive path or timestamp.
+func (a *Agent) ProjectStaleToolResults() (PruneStats, error) {
+	return a.maintainStaleToolResults(toolResultProject)
 }
 
 func (a *Agent) maintainStaleToolResults(mode toolResultMaintenanceMode) (PruneStats, error) {
@@ -118,10 +128,10 @@ func shouldMaintainToolResult(m provider.Message, mode toolResultMaintenanceMode
 	if m.LocalOnly || m.Role != provider.RoleTool {
 		return false
 	}
-	if strings.HasPrefix(m.Content, prunedMarker) {
+	if strings.HasPrefix(m.Content, prunedMarker) || strings.HasPrefix(m.Content, projectedMarker) {
 		return false
 	}
-	if mode == toolResultSnip {
+	if mode == toolResultSnip || mode == toolResultProject {
 		return len(m.Content) >= minPruneBytes && !strings.HasPrefix(m.Content, snippedMarker)
 	}
 	if strings.HasPrefix(m.Content, snippedMarker) {
@@ -134,7 +144,23 @@ func rewriteToolResult(m provider.Message, mode toolResultMaintenanceMode, archi
 	if mode == toolResultPrune {
 		return pruneToolResult(m, archive)
 	}
+	if mode == toolResultProject {
+		return projectToolResult(m, strategy)
+	}
 	return snipToolResult(m, archive, strategy)
+}
+
+func projectToolResult(m provider.Message, strategy snipStrategy) string {
+	sum := sha256.Sum256([]byte(m.Content))
+	headChars := minInt(strategy.headChars, 6000)
+	tailChars := minInt(strategy.tailChars, 2000)
+	if headChars+tailChars >= len(m.Content) {
+		headChars = len(m.Content) / 2
+		tailChars = len(m.Content) / 4
+	}
+	return fmt.Sprintf("%s%s; original_bytes=%d; sha256=%x; deterministic head/tail projection]\n%s\n[... %d bytes omitted ...]\n%s",
+		projectedMarker, m.Name, len(m.Content), sum[:8],
+		firstRunes(m.Content, headChars), omittedBytes(m.Content, headChars, tailChars), lastRunes(m.Content, tailChars))
 }
 
 func pruneToolResult(m provider.Message, archive string) string {

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -82,6 +83,52 @@ func TestPruneStaleToolResults(t *testing.T) {
 	}
 	if got := sess.RewriteVersion(); got != 1 {
 		t.Errorf("no-op pass bumped RewriteVersion to %d", got)
+	}
+}
+
+func TestProjectStaleToolResultsIsDeterministicAndPathFree(t *testing.T) {
+	big := strings.Repeat("alpha\n", 1200)
+	project := func(dir string) (string, PruneStats) {
+		sess := pruneFixture(big)
+		beforeMessages := sess.Snapshot()
+		beforeShape := CaptureShape(beforeMessages[0].Content, nil, sess.RewriteVersion())
+		a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: dir, ToolResultProjection: true}, event.Discard)
+		st, err := a.ProjectStaleToolResults()
+		if err != nil {
+			t.Fatal(err)
+		}
+		afterMessages := sess.Snapshot()
+		afterShape := CaptureShape(afterMessages[0].Content, nil, sess.RewriteVersion())
+		if beforeShape.SystemHash != afterShape.SystemHash || beforeShape.ToolsHash != afterShape.ToolsHash {
+			t.Fatal("projection changed cache-stable system/tool shape")
+		}
+		if !reflect.DeepEqual(beforeMessages[4:], afterMessages[4:]) {
+			t.Fatal("projection changed the protected recent tail")
+		}
+		return sess.Snapshot()[3].Content, st
+	}
+	one, st1 := project(filepath.Join(t.TempDir(), "one"))
+	two, st2 := project(filepath.Join(t.TempDir(), "two"))
+	if one != two {
+		t.Fatal("projection changed with archive location")
+	}
+	if !strings.HasPrefix(one, projectedMarker) || !strings.Contains(one, "sha256=") {
+		t.Fatalf("unexpected projection: %.120q", one)
+	}
+	if strings.Contains(one, st1.Archive) || strings.Contains(two, st2.Archive) {
+		t.Fatal("projection leaked local archive path")
+	}
+	if st1.Results != 1 || st1.SavedChars <= 0 {
+		t.Fatalf("stats = %+v", st1)
+	}
+}
+
+func TestMaybeCompactProjectionReportsNextUsageCounters(t *testing.T) {
+	sess := pruneFixture(strings.Repeat("x", 5000))
+	a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ToolResultProjection: true}, event.Discard)
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 650})
+	if a.pendingProjectedResults != 1 || a.pendingProjectionSavedChars <= 0 {
+		t.Fatalf("pending projection metrics = %d/%d", a.pendingProjectedResults, a.pendingProjectionSavedChars)
 	}
 }
 

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -142,6 +142,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 			a.evidence.ResetBackgroundLeases()
 		default:
 			a.evidence.Reset()
+			a.deliveryProjectedReceipts = 0
 		}
 	}
 	a.preserveEvidenceOnce = false
@@ -156,6 +157,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	a.deliveryScopeActive = scoped
 	if scoped && a.deliveryCheckpoint.ScopeID != scope.ID {
 		a.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: scope.ID}
+		a.deliveryProjectedReceipts = 0
 	}
 	// Re-lease this session's background-job mutations that no turn has
 	// committed yet. The Reset above just wiped any lease a failed or
@@ -450,11 +452,17 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	if usage == nil || usage.TotalTokens <= 0 {
 		return
 	}
+	if cacheDiagnostics != nil {
+		cacheDiagnostics.ToolResultsProjected = a.pendingProjectedResults
+		cacheDiagnostics.ProjectionSavedChars = a.pendingProjectionSavedChars
+	}
 	a.lastUsage.Store(usage)
 	a.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: a.pricing,
 		UsageSource:      a.usageSource,
 		CacheDiagnostics: cacheDiagnostics,
 		SessionHit:       int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load())})
+	a.pendingProjectedResults = 0
+	a.pendingProjectionSavedChars = 0
 }
 
 // handleFinalResponse processes a no-tool assistant turn: recovery pause,

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -226,32 +226,33 @@ func (readOnlyBash) ReadOnly() bool { return true }
 // parallel research across independent areas (the parallel-dispatch path picks
 // these up only when readOnly, which task is not).
 type TaskTool struct {
-	prov                provider.Provider
-	pricing             *provider.Pricing
-	parentReg           *tool.Registry
-	maxSteps            int
-	contextWindow       int
-	softCompactRatio    float64
-	toolResultSnipRatio float64
-	compactRatio        float64
-	compactForceRatio   float64
-	recentKeep          int
-	temperature         float64
-	archiveDir          string
-	keepPolicy          KeepPolicy
-	sysPrompt           string
-	gate                Gate
-	subagentModel       string
-	subagentEffort      string
-	resolveProvider     func(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error)
-	transcripts         *SubagentStore
-	workspaceRoot       string
-	baseModel           string
-	baseEffort          string
-	identityProfile     func(modelRef, effort string) (string, string)
-	maxSubagentDepth    int
-	deliveryProfile     bool
-	workspaceLease      *workspacelease.Owner
+	prov                 provider.Provider
+	pricing              *provider.Pricing
+	parentReg            *tool.Registry
+	maxSteps             int
+	contextWindow        int
+	softCompactRatio     float64
+	toolResultSnipRatio  float64
+	toolResultProjection bool
+	compactRatio         float64
+	compactForceRatio    float64
+	recentKeep           int
+	temperature          float64
+	archiveDir           string
+	keepPolicy           KeepPolicy
+	sysPrompt            string
+	gate                 Gate
+	subagentModel        string
+	subagentEffort       string
+	resolveProvider      func(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error)
+	transcripts          *SubagentStore
+	workspaceRoot        string
+	baseModel            string
+	baseEffort           string
+	identityProfile      func(modelRef, effort string) (string, string)
+	maxSubagentDepth     int
+	deliveryProfile      bool
+	workspaceLease       *workspacelease.Owner
 	// scheduler is the session-scoped concurrency + write-claim controller.
 	// nil falls back to the legacy jobs.ReserveStart cap for background tasks.
 	scheduler *SubagentScheduler
@@ -278,24 +279,25 @@ type TaskTool struct {
 // Prefer NewTaskToolWithOptions for new call sites; the positional NewTaskTool
 // remains as a compatibility wrapper for one full iteration cycle.
 type TaskToolOptions struct {
-	Provider            provider.Provider
-	Pricing             *provider.Pricing
-	ParentRegistry      *tool.Registry
-	MaxSteps            int
-	ContextWindow       int
-	RecentKeep          int
-	SoftCompactRatio    float64
-	ToolResultSnipRatio float64
-	CompactRatio        float64
-	CompactForceRatio   float64
-	Temperature         float64
-	ArchiveDir          string
-	SysPrompt           string
-	Gate                Gate
-	KeepPolicy          KeepPolicy
-	SubagentModel       string
-	SubagentEffort      string
-	ResolveProvider     func(string, string) (provider.Provider, *provider.Pricing, int, error)
+	Provider             provider.Provider
+	Pricing              *provider.Pricing
+	ParentRegistry       *tool.Registry
+	MaxSteps             int
+	ContextWindow        int
+	RecentKeep           int
+	SoftCompactRatio     float64
+	ToolResultSnipRatio  float64
+	ToolResultProjection bool
+	CompactRatio         float64
+	CompactForceRatio    float64
+	Temperature          float64
+	ArchiveDir           string
+	SysPrompt            string
+	Gate                 Gate
+	KeepPolicy           KeepPolicy
+	SubagentModel        string
+	SubagentEffort       string
+	ResolveProvider      func(string, string) (provider.Provider, *provider.Pricing, int, error)
 }
 
 // NewTaskToolWithOptions is the internal standard constructor for TaskTool.
@@ -308,25 +310,26 @@ func NewTaskToolWithOptions(opts TaskToolOptions) *TaskTool {
 		sysPrompt = DefaultTaskSystemPrompt
 	}
 	return &TaskTool{
-		prov:                opts.Provider,
-		pricing:             opts.Pricing,
-		parentReg:           opts.ParentRegistry,
-		maxSteps:            opts.MaxSteps,
-		contextWindow:       opts.ContextWindow,
-		recentKeep:          opts.RecentKeep,
-		softCompactRatio:    opts.SoftCompactRatio,
-		toolResultSnipRatio: opts.ToolResultSnipRatio,
-		compactRatio:        opts.CompactRatio,
-		compactForceRatio:   opts.CompactForceRatio,
-		temperature:         opts.Temperature,
-		archiveDir:          opts.ArchiveDir,
-		keepPolicy:          opts.KeepPolicy,
-		sysPrompt:           sysPrompt,
-		gate:                opts.Gate,
-		subagentModel:       opts.SubagentModel,
-		subagentEffort:      opts.SubagentEffort,
-		resolveProvider:     opts.ResolveProvider,
-		maxSubagentDepth:    DefaultMaxSubagentDepth,
+		prov:                 opts.Provider,
+		pricing:              opts.Pricing,
+		parentReg:            opts.ParentRegistry,
+		maxSteps:             opts.MaxSteps,
+		contextWindow:        opts.ContextWindow,
+		recentKeep:           opts.RecentKeep,
+		softCompactRatio:     opts.SoftCompactRatio,
+		toolResultSnipRatio:  opts.ToolResultSnipRatio,
+		toolResultProjection: opts.ToolResultProjection,
+		compactRatio:         opts.CompactRatio,
+		compactForceRatio:    opts.CompactForceRatio,
+		temperature:          opts.Temperature,
+		archiveDir:           opts.ArchiveDir,
+		keepPolicy:           opts.KeepPolicy,
+		sysPrompt:            sysPrompt,
+		gate:                 opts.Gate,
+		subagentModel:        opts.SubagentModel,
+		subagentEffort:       opts.SubagentEffort,
+		resolveProvider:      opts.ResolveProvider,
+		maxSubagentDepth:     DefaultMaxSubagentDepth,
 	}
 }
 
@@ -1608,28 +1611,29 @@ func (t *TaskTool) runReadOnlySubSession(ctx context.Context, prompt string, sub
 // must stay uniform across those paths — add new fields here, not at call sites.
 func (t *TaskTool) subagentOptions(ctx context.Context, maxSteps int, pricing *provider.Pricing, ctxWin, childDepth int, recoveryTaskID string) Options {
 	return Options{
-		MaxSteps:            maxSteps,
-		Temperature:         t.temperature,
-		Pricing:             pricing,
-		UsageSource:         event.UsageSourceSubagent,
-		Gate:                t.gate,
-		ContextWindow:       ctxWin,
-		RecentKeep:          t.recentKeep,
-		SoftCompactRatio:    t.softCompactRatio,
-		ToolResultSnipRatio: t.toolResultSnipRatio,
-		CompactRatio:        t.compactRatio,
-		CompactForceRatio:   t.compactForceRatio,
-		ArchiveDir:          t.archiveDir,
-		KeepPolicy:          t.keepPolicy,
-		ResponseLanguage:    ResponseLanguageFromContext(ctx),
-		ReasoningLanguage:   ReasoningLanguageFromContext(ctx),
-		SubagentDepth:       childDepth,
-		MaxSubagentDepth:    t.maxDepth(),
-		DeliveryProfile:     t.deliveryProfile,
-		WorkspaceLease:      t.workspaceLease,
-		RecoveryGate:        t.recoveryGate,
-		RecoveryAgentID:     "subagent",
-		RecoveryTaskID:      recoveryTaskID,
+		MaxSteps:             maxSteps,
+		Temperature:          t.temperature,
+		Pricing:              pricing,
+		UsageSource:          event.UsageSourceSubagent,
+		Gate:                 t.gate,
+		ContextWindow:        ctxWin,
+		RecentKeep:           t.recentKeep,
+		SoftCompactRatio:     t.softCompactRatio,
+		ToolResultSnipRatio:  t.toolResultSnipRatio,
+		ToolResultProjection: t.toolResultProjection,
+		CompactRatio:         t.compactRatio,
+		CompactForceRatio:    t.compactForceRatio,
+		ArchiveDir:           t.archiveDir,
+		KeepPolicy:           t.keepPolicy,
+		ResponseLanguage:     ResponseLanguageFromContext(ctx),
+		ReasoningLanguage:    ReasoningLanguageFromContext(ctx),
+		SubagentDepth:        childDepth,
+		MaxSubagentDepth:     t.maxDepth(),
+		DeliveryProfile:      t.deliveryProfile,
+		WorkspaceLease:       t.workspaceLease,
+		RecoveryGate:         t.recoveryGate,
+		RecoveryAgentID:      "subagent",
+		RecoveryTaskID:       recoveryTaskID,
 	}
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -86,6 +86,9 @@ type Options struct {
 	MaxStepsKey string
 	RequireKey  bool
 	Sink        event.Sink
+	// ToolResultProjection overrides the persisted experiment switch for this
+	// process only. Nil uses config; used by the benchmark harness profile.
+	ToolResultProjection *bool
 	// EffortOverride is a session-local reasoning effort override. Nil means use
 	// the resolved provider config; a non-nil empty string means provider default.
 	EffortOverride *string
@@ -200,6 +203,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		return nil, err
+	}
+	if opts.ToolResultProjection != nil {
+		cfg.Agent.ToolResultProjection = *opts.ToolResultProjection
 	}
 	applyRuntimeAutoPricingCurrency(cfg, opts.AutoPricingCurrency)
 	// Arm the credential-protection layers from the user-global [secrets]
@@ -847,24 +853,25 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	var capRuntime *agent.MCPCapabilityRuntime
 	newTaskTool := func() *agent.TaskTool {
 		return agent.NewTaskToolWithOptions(agent.TaskToolOptions{
-			Provider:            execProv,
-			Pricing:             entry.Price,
-			ParentRegistry:      reg,
-			MaxSteps:            maxSteps,
-			ContextWindow:       entry.ContextWindow,
-			RecentKeep:          cfg.Agent.RecentKeep,
-			SoftCompactRatio:    cfg.Agent.SoftCompactRatio,
-			ToolResultSnipRatio: cfg.Agent.ToolResultSnipRatio,
-			CompactRatio:        cfg.Agent.CompactRatio,
-			CompactForceRatio:   cfg.Agent.CompactForceRatio,
-			Temperature:         cfg.Agent.Temperature,
-			ArchiveDir:          config.ArchiveDir(),
-			SysPrompt:           "",
-			Gate:                headlessGate,
-			KeepPolicy:          keepPolicy,
-			SubagentModel:       taskModel,
-			SubagentEffort:      taskEffort,
-			ResolveProvider:     resolveSubagentProvider,
+			Provider:             execProv,
+			Pricing:              entry.Price,
+			ParentRegistry:       reg,
+			MaxSteps:             maxSteps,
+			ContextWindow:        entry.ContextWindow,
+			RecentKeep:           cfg.Agent.RecentKeep,
+			SoftCompactRatio:     cfg.Agent.SoftCompactRatio,
+			ToolResultSnipRatio:  cfg.Agent.ToolResultSnipRatio,
+			ToolResultProjection: cfg.Agent.ToolResultProjection,
+			CompactRatio:         cfg.Agent.CompactRatio,
+			CompactForceRatio:    cfg.Agent.CompactForceRatio,
+			Temperature:          cfg.Agent.Temperature,
+			ArchiveDir:           config.ArchiveDir(),
+			SysPrompt:            "",
+			Gate:                 headlessGate,
+			KeepPolicy:           keepPolicy,
+			SubagentModel:        taskModel,
+			SubagentEffort:       taskEffort,
+			ResolveProvider:      resolveSubagentProvider,
 		}).
 			WithTranscripts(subagentStore, root, modelName, entry.Effort).
 			WithTranscriptIdentityResolver(subagentIdentity).
@@ -956,25 +963,26 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// compaction or language settings — add new fields here, not per runner.
 	subagentSkillOptions := func(sctx context.Context, steps int, price *provider.Pricing, ctxWin, childDepth int) agent.Options {
 		return agent.Options{
-			MaxSteps:            steps,
-			Temperature:         cfg.Agent.Temperature,
-			Pricing:             price,
-			UsageSource:         event.UsageSourceSubagent,
-			Gate:                headlessGate,
-			ContextWindow:       ctxWin,
-			RecentKeep:          cfg.Agent.RecentKeep,
-			SoftCompactRatio:    cfg.Agent.SoftCompactRatio,
-			ToolResultSnipRatio: cfg.Agent.ToolResultSnipRatio,
-			CompactRatio:        cfg.Agent.CompactRatio,
-			CompactForceRatio:   cfg.Agent.CompactForceRatio,
-			ArchiveDir:          config.ArchiveDir(),
-			KeepPolicy:          keepPolicy,
-			ResponseLanguage:    agent.ResponseLanguageFromContext(sctx),
-			ReasoningLanguage:   agent.ReasoningLanguageFromContext(sctx),
-			SubagentDepth:       childDepth,
-			MaxSubagentDepth:    maxSubagentDepth,
-			DeliveryProfile:     tokenDelivery,
-			WorkspaceLease:      workspaceLease,
+			MaxSteps:             steps,
+			Temperature:          cfg.Agent.Temperature,
+			Pricing:              price,
+			UsageSource:          event.UsageSourceSubagent,
+			Gate:                 headlessGate,
+			ContextWindow:        ctxWin,
+			RecentKeep:           cfg.Agent.RecentKeep,
+			SoftCompactRatio:     cfg.Agent.SoftCompactRatio,
+			ToolResultSnipRatio:  cfg.Agent.ToolResultSnipRatio,
+			ToolResultProjection: cfg.Agent.ToolResultProjection,
+			CompactRatio:         cfg.Agent.CompactRatio,
+			CompactForceRatio:    cfg.Agent.CompactForceRatio,
+			ArchiveDir:           config.ArchiveDir(),
+			KeepPolicy:           keepPolicy,
+			ResponseLanguage:     agent.ResponseLanguageFromContext(sctx),
+			ReasoningLanguage:    agent.ReasoningLanguageFromContext(sctx),
+			SubagentDepth:        childDepth,
+			MaxSubagentDepth:     maxSubagentDepth,
+			DeliveryProfile:      tokenDelivery,
+			WorkspaceLease:       workspaceLease,
 		}
 	}
 	readOnlySkillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
@@ -1560,6 +1568,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ContextWindow:                entry.ContextWindow,
 		SoftCompactRatio:             cfg.Agent.SoftCompactRatio,
 		ToolResultSnipRatio:          cfg.Agent.ToolResultSnipRatio,
+		ToolResultProjection:         cfg.Agent.ToolResultProjection,
 		CompactRatio:                 cfg.Agent.CompactRatio,
 		CompactForceRatio:            cfg.Agent.CompactForceRatio,
 		RecentKeep:                   cfg.Agent.RecentKeep,
@@ -1608,6 +1617,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				ContextWindow:                pe.ContextWindow,
 				SoftCompactRatio:             cfg.Agent.SoftCompactRatio,
 				ToolResultSnipRatio:          cfg.Agent.ToolResultSnipRatio,
+				ToolResultProjection:         cfg.Agent.ToolResultProjection,
 				CompactRatio:                 cfg.Agent.CompactRatio,
 				CompactForceRatio:            cfg.Agent.CompactForceRatio,
 				RecentKeep:                   cfg.Agent.RecentKeep,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -250,6 +250,7 @@ type cliBuildOverrides struct {
 	HeadlessApprovalMode string
 	Stderr               io.Writer
 	OnSessionRecovered   func(control.SessionRecoveryInfo) error
+	ToolResultProjection *bool
 }
 
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
@@ -273,6 +274,7 @@ func cliProfileBuildOptions(modelName string, maxStepsOverride int, requireKey b
 		HeadlessApprovalMode: overrides.HeadlessApprovalMode,
 		AutoPricingCurrency:  cliAutoPricingCurrency(),
 		Stderr:               overrides.Stderr,
+		ToolResultProjection: overrides.ToolResultProjection,
 		OnSessionRecovered:   overrides.OnSessionRecovered,
 	}
 }
@@ -443,6 +445,7 @@ func runAgent(args []string, version string) int {
 	maxSteps := fs.Int("max-steps", 0, "one-off max tool-call rounds (0 = automatic)")
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
+	toolResultProjection := fs.Bool("tool-result-projection", false, "enable deterministic stale tool-result projection experiment")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := fs.Bool("continue", false, "resume the most recent saved session")
 	fs.BoolVar(cont, "c", false, "shorthand for --continue")
@@ -645,6 +648,9 @@ func runAgent(args []string, version string) int {
 		WorkspaceRoot:        workspaceRoot,
 		HeadlessApprovalMode: permissions.approval,
 		OnSessionRecovered:   cliSessionRecoveredHandler(leases),
+	}
+	if fs.Changed("tool-result-projection") {
+		overrides.ToolResultProjection = toolResultProjection
 	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, true, sink, profile, overrides)
 	if err != nil {

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -20,6 +20,8 @@ type RunMetrics struct {
 	Currency                       string  `json:"currency"`
 	Estimated                      bool    `json:"estimated,omitempty"`
 	Compactions                    int     `json:"compactions"`
+	ToolResultsProjected           int     `json:"tool_results_projected,omitempty"`
+	ProjectionSavedChars           int     `json:"projection_saved_chars,omitempty"`
 	ReadinessChecks                int     `json:"readiness_checks"`
 	ReadinessAllowed               int     `json:"readiness_allowed"`
 	ReadinessBlocks                int     `json:"readiness_blocks"`
@@ -84,6 +86,10 @@ func (s *metricsSink) Emit(e event.Event) {
 		s.m.CacheMissTokens += u.CacheMissTokens
 		s.m.Steps++
 		s.m.Estimated = s.m.Estimated || u.Estimated
+		if e.CacheDiagnostics != nil {
+			s.m.ToolResultsProjected += e.CacheDiagnostics.ToolResultsProjected
+			s.m.ProjectionSavedChars += e.CacheDiagnostics.ProjectionSavedChars
+		}
 		var stepCost float64
 		if p := e.Pricing; p != nil {
 			stepCost = (float64(u.CacheHitTokens)*p.CacheHit +

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1214,10 +1214,11 @@ type AgentConfig struct {
 	// readable, but loading clears it and rendering omits it.
 	AutoPlanClassifier string `toml:"auto_plan_classifier"`
 	// Compaction window fractions: soft = notice only, compact = trigger, force = hard ceiling.
-	SoftCompactRatio    float64 `toml:"soft_compact_ratio"`
-	ToolResultSnipRatio float64 `toml:"tool_result_snip_ratio"`
-	CompactRatio        float64 `toml:"compact_ratio"`
-	CompactForceRatio   float64 `toml:"compact_force_ratio"`
+	SoftCompactRatio     float64 `toml:"soft_compact_ratio"`
+	ToolResultSnipRatio  float64 `toml:"tool_result_snip_ratio"`
+	ToolResultProjection bool    `toml:"tool_result_projection"`
+	CompactRatio         float64 `toml:"compact_ratio"`
+	CompactForceRatio    float64 `toml:"compact_force_ratio"`
 	// Keep controls which compactable messages stay verbatim beyond the current
 	// user-fact/digest floor and recent tail. Empty uses the conservative default
 	// of keeping error tool results.

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -227,6 +227,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	}
 	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
 	fmt.Fprintf(&b, "tool_result_snip_ratio = %s   # snip stale tool results at this fraction before summary compaction\n", formatFloat(c.Agent.ToolResultSnipRatio))
+	fmt.Fprintf(&b, "tool_result_projection = %t   # deterministic stale-result projection experiment\n", c.Agent.ToolResultProjection)
 	fmt.Fprintf(&b, "compact_ratio       = %s   # try compacting when prompt reaches this fraction\n", formatFloat(c.Agent.CompactRatio))
 	fmt.Fprintf(&b, "compact_force_ratio = %s   # force compacting at this high-water mark\n", formatFloat(c.Agent.CompactForceRatio))
 	if c.Agent.Keep != nil {
@@ -920,6 +921,10 @@ func RenderTOMLProjectDelta(c *Config) string {
 	}
 	if c.Agent.ToolResultSnipRatio != d.Agent.ToolResultSnipRatio {
 		fmt.Fprintf(&agentBuf, "tool_result_snip_ratio = %s\n", formatFloat(c.Agent.ToolResultSnipRatio))
+		anyAgent = true
+	}
+	if c.Agent.ToolResultProjection != d.Agent.ToolResultProjection {
+		fmt.Fprintf(&agentBuf, "tool_result_projection = %t\n", c.Agent.ToolResultProjection)
 		anyAgent = true
 	}
 	if c.Agent.CompactRatio != d.Agent.CompactRatio {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -654,6 +654,11 @@ func ckptDir(sessionPath string) string {
 func (c *Controller) rebindCheckpoints(sessionPath string) {
 	c.goals.setStatePath(goalStatePath(sessionPath))
 	c.checkpoints.rebind(ckptDir(sessionPath), c.workspaceRoot)
+	if c.executor != nil {
+		if err := c.executor.SetRunJournalPath(store.SessionRunJournal(sessionPath)); err != nil {
+			c.noticeDetail("Run journal is unavailable for this session.", err.Error())
+		}
+	}
 }
 
 // beginCheckpoint opens a checkpoint for the turn about to run, recording the

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -266,15 +266,17 @@ type AskAnswer struct {
 // the last turn. It rides on the Usage event so every frontend can show
 // cache-churn attribution.
 type CacheDiagnostics struct {
-	PrefixHash          string
-	PrefixChanged       bool
-	PrefixChangeReasons []string // "system", "tools", "log_rewrite"
-	SystemHash          string
-	ToolsHash           string
-	LogRewriteVersion   int
-	ToolSchemaTokens    int
-	CacheMissTokens     int
-	CacheHitTokens      int
+	PrefixHash           string
+	PrefixChanged        bool
+	PrefixChangeReasons  []string // "system", "tools", "log_rewrite"
+	SystemHash           string
+	ToolsHash            string
+	LogRewriteVersion    int
+	ToolSchemaTokens     int
+	CacheMissTokens      int
+	CacheHitTokens       int
+	ToolResultsProjected int
+	ProjectionSavedChars int
 }
 
 // FinalReadiness carries machine-readable recovery requirements on TurnDone.

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -365,11 +365,33 @@ type BackgroundLease struct {
 // output. PendingMutation means a previously observed change still needs fresh
 // verification, review, and sign-off before the Goal can finalize.
 type DeliveryCheckpoint struct {
-	ScopeID             string `json:"scopeID,omitempty"`
-	CriteriaEstablished bool   `json:"criteriaEstablished,omitempty"`
-	WorkObserved        bool   `json:"workObserved,omitempty"`
-	MutationObserved    bool   `json:"mutationObserved,omitempty"`
-	PendingMutation     bool   `json:"pendingMutation,omitempty"`
+	ScopeID             string              `json:"scopeID,omitempty"`
+	CriteriaEstablished bool                `json:"criteriaEstablished,omitempty"`
+	WorkObserved        bool                `json:"workObserved,omitempty"`
+	MutationObserved    bool                `json:"mutationObserved,omitempty"`
+	PendingMutation     bool                `json:"pendingMutation,omitempty"`
+	EvidenceVersion     int                 `json:"evidenceVersion,omitempty"`
+	MutationGeneration  uint64              `json:"mutationGeneration,omitempty"`
+	ClosedGeneration    uint64              `json:"closedGeneration,omitempty"`
+	EvidenceSequence    uint64              `json:"evidenceSequence,omitempty"`
+	EvidenceLedger      *GoalEvidenceLedger `json:"evidenceLedger,omitempty"`
+}
+
+type GoalEvidenceLedger struct {
+	Entries []GoalEvidenceEntry `json:"entries,omitempty"`
+}
+
+// GoalEvidenceEntry is a bounded, content-free projection of a successful
+// receipt. It is additive checkpoint metadata: final readiness still requires
+// the live host gates, so old evidence can never authorize a new completion.
+type GoalEvidenceEntry struct {
+	Sequence    uint64   `json:"sequence"`
+	Generation  uint64   `json:"generation,omitempty"`
+	Kind        string   `json:"kind"`
+	Tool        string   `json:"tool,omitempty"`
+	InputDigest string   `json:"inputDigest,omitempty"`
+	PathDigests []string `json:"pathDigests,omitempty"`
+	OutputBytes int      `json:"outputBytes,omitempty"`
 }
 
 // Ledger stores the receipts available to complete_step for the current turn.
@@ -377,9 +399,21 @@ type Ledger struct {
 	mu               sync.Mutex
 	receipts         []Receipt
 	backgroundLeases []BackgroundLease
+	observer         func(Receipt)
 }
 
 func NewLedger() *Ledger { return &Ledger{} }
+
+// SetObserver installs an optional local audit observer. It runs after Record
+// releases the ledger lock and receives a defensive copy.
+func (l *Ledger) SetObserver(observer func(Receipt)) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.observer = observer
+	l.mu.Unlock()
+}
 
 // Reset clears receipts and background leases between user turns.
 func (l *Ledger) Reset() {
@@ -456,13 +490,132 @@ func (l *Ledger) Record(r Receipt) {
 	}
 
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if r.ToolName == "complete_step" && r.Step != "" && r.TodoStep == nil {
 		if match := latestTodoStep(r.Step, l.receipts); match.Found {
 			r.TodoStep = &match
 		}
 	}
 	l.receipts = append(l.receipts, r)
+	observer := l.observer
+	l.mu.Unlock()
+	if observer != nil {
+		observer(cloneReceipt(r))
+	}
+}
+
+// Receipts returns a defensive snapshot for content-limited checkpoint
+// projection. Raw fields remain in memory and are never copied into the
+// persisted projection itself.
+func (l *Ledger) Receipts() []Receipt {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]Receipt, len(l.receipts))
+	for i := range l.receipts {
+		out[i] = cloneReceipt(l.receipts[i])
+	}
+	return out
+}
+
+func cloneReceipt(r Receipt) Receipt {
+	r.Args = append(json.RawMessage(nil), r.Args...)
+	r.Paths = append([]string(nil), r.Paths...)
+	r.Todos = append([]TodoItem(nil), r.Todos...)
+	if r.TodoStep != nil {
+		cp := *r.TodoStep
+		r.TodoStep = &cp
+	}
+	return r
+}
+
+// ProjectGoalEvidence adds bounded receipt identities to a durable Goal
+// checkpoint. The host supplies closed only after all existing live readiness
+// gates passed; projection itself grants no authority.
+func ProjectGoalEvidence(cp DeliveryCheckpoint, receipts []Receipt, closed bool) DeliveryCheckpoint {
+	const maxEntries = 64
+	cp.EvidenceVersion = 1
+	entries := []GoalEvidenceEntry(nil)
+	if cp.EvidenceLedger != nil {
+		entries = append(entries, cp.EvidenceLedger.Entries...)
+	}
+	for _, r := range receipts {
+		if !r.Success {
+			continue
+		}
+		kind := goalEvidenceKind(r)
+		if kind == "" {
+			continue
+		}
+		if kind == "mutation" {
+			cp.MutationGeneration++
+		}
+		cp.EvidenceSequence++
+		e := GoalEvidenceEntry{
+			Sequence: cp.EvidenceSequence, Generation: cp.MutationGeneration,
+			Kind: kind, Tool: boundedEvidenceText(r.ToolName, 64),
+			InputDigest: evidenceDigest(string(r.Args)), OutputBytes: maxInt(r.OutputBytes, 0),
+		}
+		for _, p := range r.Paths {
+			if len(e.PathDigests) == 8 {
+				break
+			}
+			e.PathDigests = append(e.PathDigests, evidenceDigest(filepath.ToSlash(p)))
+		}
+		entries = append(entries, e)
+		if len(entries) > maxEntries {
+			entries = append([]GoalEvidenceEntry(nil), entries[len(entries)-maxEntries:]...)
+		}
+	}
+	if len(entries) > 0 {
+		cp.EvidenceLedger = &GoalEvidenceLedger{Entries: entries}
+	}
+	if closed && cp.MutationGeneration > 0 {
+		cp.ClosedGeneration = cp.MutationGeneration
+	}
+	return cp
+}
+
+func goalEvidenceKind(r Receipt) string {
+	switch {
+	case r.Mutation || r.Write:
+		return "mutation"
+	case r.ToolName == "todo_write":
+		return "criteria"
+	case r.ToolName == "complete_step":
+		return "signoff"
+	case r.ToolName == "review" || r.ToolName == "review_report" || (r.ToolName == "task" && r.Profile == "review"):
+		return "review"
+	case r.ToolName == "bash" && IsDeliveryVerificationCommand(r.Command):
+		return "verification"
+	case r.Read && r.OutputBytes > 0:
+		return "inspection"
+	case r.Command != "":
+		return "command"
+	default:
+		return "work"
+	}
+}
+
+func evidenceDigest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("sha256:%x", sum)
+}
+
+func boundedEvidenceText(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // Len returns the number of receipts recorded this turn, giving callers a

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -3,6 +3,7 @@ package evidence
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -28,6 +29,56 @@ func TestLedgerRecordsSuccessAndFailureReceipts(t *testing.T) {
 	}
 	if ledger.HasSuccessfulCommand("go test ./internal/...") {
 		t.Fatal("failed bash command must not verify")
+	}
+}
+
+func TestProjectGoalEvidenceIsBoundedContentFreeAndClosesGeneration(t *testing.T) {
+	rawPath := "/private/work/secret.go"
+	cp := ProjectGoalEvidence(DeliveryCheckpoint{ScopeID: "goal-1", PendingMutation: true}, []Receipt{
+		{ToolName: "write_file", Args: json.RawMessage(`{"path":"/private/work/secret.go"}`), Success: true, Write: true, Mutation: true, Paths: []string{rawPath}, OutputBytes: 10},
+		{ToolName: "bash", Args: json.RawMessage(`{"command":"go test ./..."}`), Command: "go test ./...", Success: true, OutputBytes: 20},
+		{ToolName: "complete_step", Args: json.RawMessage(`{"step":"ship"}`), Success: true},
+	}, true)
+	if cp.EvidenceVersion != 1 || cp.MutationGeneration != 1 || cp.ClosedGeneration != 1 {
+		t.Fatalf("checkpoint generations = %+v", cp)
+	}
+	if cp.EvidenceLedger == nil || len(cp.EvidenceLedger.Entries) != 3 {
+		t.Fatalf("ledger = %+v", cp.EvidenceLedger)
+	}
+	b, err := json.Marshal(cp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), rawPath) || strings.Contains(string(b), "go test ./...") {
+		t.Fatalf("ledger leaked raw content: %s", b)
+	}
+	entries := cp.EvidenceLedger.Entries
+	if entries[0].Kind != "mutation" || entries[1].Kind != "verification" || entries[2].Kind != "signoff" {
+		t.Fatalf("unexpected kinds: %+v", entries)
+	}
+}
+
+func TestProjectGoalEvidenceKeepsLatest64Entries(t *testing.T) {
+	var receipts []Receipt
+	for i := 0; i < 80; i++ {
+		receipts = append(receipts, Receipt{ToolName: "read_file", Args: json.RawMessage(fmt.Sprintf(`{"n":%d}`, i)), Success: true, Read: true, OutputBytes: 1})
+	}
+	cp := ProjectGoalEvidence(DeliveryCheckpoint{}, receipts, false)
+	if cp.EvidenceLedger == nil || len(cp.EvidenceLedger.Entries) != 64 {
+		t.Fatalf("ledger = %+v", cp.EvidenceLedger)
+	}
+	if cp.EvidenceLedger.Entries[0].Sequence != 17 || cp.EvidenceSequence != 80 {
+		t.Fatalf("sequence window = first %d last %d", cp.EvidenceLedger.Entries[0].Sequence, cp.EvidenceSequence)
+	}
+}
+
+func TestDeliveryCheckpointLegacyJSONRemainsConservative(t *testing.T) {
+	var cp DeliveryCheckpoint
+	if err := json.Unmarshal([]byte(`{"scopeID":"old","mutationObserved":true,"pendingMutation":true}`), &cp); err != nil {
+		t.Fatal(err)
+	}
+	if cp.ScopeID != "old" || !cp.PendingMutation || cp.EvidenceVersion != 0 || cp.EvidenceLedger != nil {
+		t.Fatalf("legacy checkpoint = %+v", cp)
 	}
 }
 

--- a/internal/runjournal/journal.go
+++ b/internal/runjournal/journal.go
@@ -1,0 +1,233 @@
+// Package runjournal persists a bounded, content-free audit trail for agent
+// runs. Entries contain only classifications, counters, and SHA-256 digests;
+// raw prompts, tool arguments, output, commands, and paths are never written.
+package runjournal
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	SchemaVersion = 1
+	maxTextBytes  = 96
+	maxEntryBytes = 4096
+)
+
+// Entry is deliberately content-limited. Digests identify inputs and paths
+// without persisting their values; Detail is a stable host classification.
+type Entry struct {
+	SchemaVersion int      `json:"schema_version"`
+	Sequence      uint64   `json:"sequence"`
+	Timestamp     string   `json:"timestamp"`
+	Type          string   `json:"type"`
+	RunID         string   `json:"run_id,omitempty"`
+	ScopeDigest   string   `json:"scope_digest,omitempty"`
+	Tool          string   `json:"tool,omitempty"`
+	Success       *bool    `json:"success,omitempty"`
+	InputDigest   string   `json:"input_digest,omitempty"`
+	PathDigests   []string `json:"path_digests,omitempty"`
+	OutputBytes   int      `json:"output_bytes,omitempty"`
+	DurationMS    int64    `json:"duration_ms,omitempty"`
+	Detail        string   `json:"detail,omitempty"`
+}
+
+// Journal is safe for concurrent receipt recording and session rebinding.
+type Journal struct {
+	mu   sync.Mutex
+	path string
+	seq  uint64
+	now  func() time.Time
+}
+
+func New() *Journal { return &Journal{now: time.Now} }
+
+// Digest returns a stable content identifier suitable for journal fields.
+func Digest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Bind switches the journal to path and repairs an incomplete final record.
+// An empty path disables persistence. Future schema versions fail closed.
+func (j *Journal) Bind(path string) error {
+	if j == nil {
+		return nil
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	path = strings.TrimSpace(path)
+	j.path, j.seq = path, 0
+	if path == "" {
+		return nil
+	}
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		j.path = ""
+		return fmt.Errorf("read run journal: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		j.path = ""
+		return fmt.Errorf("secure run journal: %w", err)
+	}
+	complete := b
+	appendNewline := false
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		last := bytes.LastIndexByte(b, '\n')
+		tail := b[last+1:]
+		var probe Entry
+		if json.Unmarshal(tail, &probe) == nil {
+			appendNewline = true
+		} else {
+			complete = b[:last+1]
+			if err := os.Truncate(path, int64(len(complete))); err != nil {
+				j.path = ""
+				return fmt.Errorf("repair run journal tail: %w", err)
+			}
+		}
+	}
+	s := bufio.NewScanner(bytes.NewReader(complete))
+	s.Buffer(make([]byte, 4096), maxEntryBytes+1)
+	for s.Scan() {
+		line := s.Bytes()
+		var e Entry
+		if err := json.Unmarshal(line, &e); err != nil {
+			j.path = ""
+			return fmt.Errorf("invalid run journal record: %w", err)
+		}
+		if e.SchemaVersion > SchemaVersion {
+			j.path = ""
+			return fmt.Errorf("run journal schema %d is newer than supported %d", e.SchemaVersion, SchemaVersion)
+		}
+		if e.SchemaVersion != SchemaVersion || e.Sequence <= j.seq {
+			j.path = ""
+			return fmt.Errorf("invalid run journal record at sequence %d", e.Sequence)
+		}
+		j.seq = e.Sequence
+	}
+	if err := s.Err(); err != nil {
+		j.path = ""
+		return fmt.Errorf("scan run journal: %w", err)
+	}
+	if appendNewline {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+		if err == nil {
+			_, err = f.Write([]byte{'\n'})
+		}
+		if err == nil {
+			err = f.Sync()
+		}
+		if f != nil {
+			_ = f.Close()
+		}
+		if err != nil {
+			j.path = ""
+			return fmt.Errorf("repair run journal delimiter: %w", err)
+		}
+	}
+	return nil
+}
+
+// Append validates and durably appends one record. It is a no-op while unbound.
+func (j *Journal) Append(e Entry) error {
+	if j == nil {
+		return nil
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.path == "" {
+		return nil
+	}
+	j.seq++
+	e.SchemaVersion = SchemaVersion
+	e.Sequence = j.seq
+	e.Timestamp = j.now().UTC().Format(time.RFC3339Nano)
+	e.Type = bounded(e.Type)
+	e.RunID = bounded(e.RunID)
+	e.Tool = bounded(e.Tool)
+	e.Detail = bounded(e.Detail)
+	e.ScopeDigest = validDigest(e.ScopeDigest)
+	e.InputDigest = validDigest(e.InputDigest)
+	if e.OutputBytes < 0 {
+		e.OutputBytes = 0
+	}
+	if e.DurationMS < 0 {
+		e.DurationMS = 0
+	}
+	if len(e.PathDigests) > 8 {
+		e.PathDigests = e.PathDigests[:8]
+	}
+	for i := range e.PathDigests {
+		e.PathDigests[i] = validDigest(e.PathDigests[i])
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		j.seq--
+		return err
+	}
+	if len(b)+1 > maxEntryBytes {
+		j.seq--
+		return fmt.Errorf("run journal record exceeds %d bytes", maxEntryBytes)
+	}
+	if err := os.MkdirAll(filepath.Dir(j.path), 0o700); err != nil {
+		j.seq--
+		return err
+	}
+	f, err := os.OpenFile(j.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		j.seq--
+		return err
+	}
+	info, statErr := f.Stat()
+	if statErr != nil {
+		_ = f.Close()
+		j.seq--
+		return statErr
+	}
+	start := info.Size()
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		j.seq--
+		return err
+	}
+	_, writeErr := f.Write(append(b, '\n'))
+	if writeErr == nil {
+		writeErr = f.Sync()
+	}
+	closeErr := f.Close()
+	if writeErr != nil {
+		_ = os.Truncate(j.path, start)
+		j.seq--
+		return writeErr
+	}
+	return closeErr
+}
+
+func bounded(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxTextBytes {
+		return s
+	}
+	return s[:maxTextBytes]
+}
+
+func validDigest(s string) string {
+	if len(s) == len("sha256:")+sha256.Size*2 && strings.HasPrefix(s, "sha256:") {
+		if _, err := hex.DecodeString(strings.TrimPrefix(s, "sha256:")); err == nil {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/runjournal/journal_test.go
+++ b/internal/runjournal/journal_test.go
@@ -1,0 +1,69 @@
+package runjournal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJournalContentLimitedAndRepairsTornTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.ndjson")
+	j := New()
+	if err := j.Bind(path); err != nil {
+		t.Fatal(err)
+	}
+	raw := "/private/work/secret.txt"
+	if err := j.Append(Entry{Type: "tool_receipt", Tool: "read", InputDigest: Digest(raw), PathDigests: []string{Digest(raw)}, OutputBytes: 42}); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), raw) {
+		t.Fatalf("journal leaked raw content: %s", b)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("journal mode = %o, want 600", got)
+	}
+	if err := os.WriteFile(path, append(b, []byte(`{"schema_version":1`)...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	j2 := New()
+	if err := j2.Bind(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := j2.Append(Entry{Type: "run_finished", Detail: "success"}); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = os.ReadFile(path)
+	if strings.Contains(string(b), `{"schema_version":1{"`) {
+		t.Fatalf("torn tail was not repaired: %s", b)
+	}
+}
+
+func TestJournalRejectsFutureSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.ndjson")
+	if err := os.WriteFile(path, []byte(`{"schema_version":99,"sequence":1}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := New().Bind(path); err == nil {
+		t.Fatal("expected future schema error")
+	}
+}
+
+func TestJournalRejectsCorruptionBeforeTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.ndjson")
+	body := `{"schema_version":1,"sequence":1,"timestamp":"x","type":"ok"}` + "\n" + `{broken}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := New().Bind(path); err == nil {
+		t.Fatal("expected complete-line corruption error")
+	}
+}

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -38,6 +38,17 @@ func SessionRecoveryState(sessionPath string) string {
 	return sessionStem(sessionPath) + ".recovery.json"
 }
 
+// SessionRunJournal is the content-limited runtime audit journal. The ndjson
+// suffix deliberately avoids .jsonl so older session scanners cannot mistake
+// it for a primary transcript.
+func SessionRunJournal(sessionPath string) string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".run-journal.ndjson"
+}
+
 // sessionStem strips the .jsonl suffix so a sidecar sits beside the session as
 // <id>.<kind> rather than <id>.jsonl.<kind>.
 func sessionStem(sessionPath string) string {
@@ -173,5 +184,6 @@ func SessionSidecarFiles(sessionPath string) []string {
 		SessionEventIndex(sessionPath),
 		SessionConflictLog(sessionPath),
 		SessionRecoveryState(sessionPath),
+		SessionRunJournal(sessionPath),
 	}
 }

--- a/internal/store/session_test.go
+++ b/internal/store/session_test.go
@@ -22,6 +22,7 @@ func TestSessionSidecarLayout(t *testing.T) {
 		{"checkpoint", SessionCheckpointDir(p), "/home/u/.reasonix/sessions/abc.ckpt"},
 		{"jobs", SessionJobsDir(p), "/home/u/.reasonix/sessions/abc.jobs"},
 		{"cleanup-pending", SessionCleanupPending(p), "/home/u/.reasonix/sessions/abc.cleanup-pending.json"},
+		{"run-journal", SessionRunJournal(p), "/home/u/.reasonix/sessions/abc.run-journal.ndjson"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {
@@ -47,6 +48,7 @@ func TestSessionSidecarEmptyPath(t *testing.T) {
 		{"checkpoint", SessionCheckpointDir},
 		{"jobs", SessionJobsDir},
 		{"cleanup-pending", SessionCleanupPending},
+		{"run-journal", SessionRunJournal},
 	} {
 		if got := fn.f(""); got != "" {
 			t.Errorf("%s(\"\") = %q, want empty", fn.name, got)
@@ -87,6 +89,7 @@ func TestSessionSidecarFiles(t *testing.T) {
 		"/home/u/.reasonix/sessions/abc.event-index.json",
 		"/home/u/.reasonix/sessions/abc.conflicts.jsonl",
 		"/home/u/.reasonix/sessions/abc.recovery.json",
+		"/home/u/.reasonix/sessions/abc.run-journal.ndjson",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("SessionSidecarFiles = %v, want %v", got, want)


### PR DESCRIPTION
## Summary

- Add a schema-versioned, resumable A/B benchmark harness with frozen manifests, per-task projections, budget accounting, and exact paired statistics.
- Add opt-in deterministic stale tool-result projection plus cache/cost experiment profiles and metrics.
- Add a content-limited session run journal and bounded goal evidence ledger for conservative crash recovery.

## Issues

N/A

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runjournal ./internal/evidence ./internal/agent ./internal/control`

## Cache impact

Cache-impact: medium — the opt-in projection profile deterministically rewrites stale tool results; the default remains the existing snip/prune baseline.
Cache-guard: `TestProjectStaleToolResultsIsDeterministicAndPathFree`, `TestMaybeCompactProjectionReportsNextUsageCounters`, and Harness A/B cache metrics.
System-prompt-review: N/A