### PR TITLE
Fix desktop shortcut icons after updates / 修复更新后的桌面快捷方式图标

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -30,6 +30,7 @@
 !/build/linux/nfpm.yaml
 !/build/linux/reasonix.desktop
 !/build/linux/io.reasonix.desktop.update.policy
+!/build/linux/postinstall.sh
 !/build/linux/icons
 !/build/linux/icons/**
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -485,6 +485,11 @@ func (a *App) startup(ctx context.Context) {
 	installSystemQuitHook()
 	a.startTray()
 	a.enableDeferredRebuildRetry()
+	a.goSafe("repairDesktopIconIntegration", func() {
+		if err := repairDesktopIconIntegration(); err != nil {
+			slog.Debug("desktop: repair native icon integration", "err", err)
+		}
+	})
 
 	if cfg, err := config.Load(); err == nil && cfg.DesktopMetrics() && version != "dev" {
 		a.metrics.Store(newMetricsAggregator(config.MemoryUserDir()))

--- a/desktop/build/linux/nfpm.yaml
+++ b/desktop/build/linux/nfpm.yaml
@@ -20,6 +20,8 @@ description: |
 vendor: "Reasonix Contributors"
 homepage: "https://github.com/esengine/DeepSeek-Reasonix"
 license: "MIT"
+scripts:
+  postinstall: ./build/linux/postinstall.sh
 # Runtime libraries the WebKitGTK 4.1 build links against (-tags webkit2_41); apt
 # pulls them in on install. These package names ship from Ubuntu 22.04 / Debian 12 on.
 # pkexec is required for the in-app Polkit authorization update path.

--- a/desktop/build/linux/postinstall.sh
+++ b/desktop/build/linux/postinstall.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Refresh desktop integration after both fresh installs and upgrades. Debian's
+# package triggers usually do this too, but an explicit best-effort refresh
+# repairs stale blank icons on desktops that kept an older cache.
+
+if [ -x /usr/bin/gtk-update-icon-cache ]; then
+	/usr/bin/gtk-update-icon-cache --force --quiet /usr/share/icons/hicolor || true
+fi
+
+if [ -x /usr/bin/update-desktop-database ]; then
+	/usr/bin/update-desktop-database --quiet /usr/share/applications || true
+fi
+
+exit 0

--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -367,8 +367,11 @@ reasonix_layout_activated:
     Delete "$INSTDIR\${REASONIX_UPDATE_HELPER}"
 
     !if /FileExists "${REASONIX_LAUNCHER}"
-    CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0
-    CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0
+    ; Keep both target and icon on the stable launcher. Pointing IconLocation at
+    ; versions\vX\reasonix-desktop.exe leaves a blank shortcut as soon as version
+    ; retention removes that directory after a later update.
+    CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\${REASONIX_LAUNCHER}" 0
+    CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\${REASONIX_LAUNCHER}" 0
     !else
     CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}"
     CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}"

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -16,6 +16,7 @@ require (
 	fyne.io/systray v1.12.2
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/creack/pty v1.1.24
+	github.com/go-ole/go-ole v1.3.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/tc-hib/winres v0.3.1
 	github.com/wailsapp/wails/v2 v2.12.0
@@ -35,7 +36,6 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
-	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/desktop/guard_packaging_test.go
+++ b/desktop/guard_packaging_test.go
@@ -148,6 +148,21 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 	if !strings.Contains(nfpm, "dst: /usr/bin/reasonix-launcher") || strings.Contains(nfpm, "dst: /usr/bin/reasonix-guard") {
 		t.Fatal("Linux deb must install the permanent launcher and must not persist Guard")
 	}
+	if !strings.Contains(nfpm, "postinstall: ./build/linux/postinstall.sh") {
+		t.Fatal("Linux deb must refresh native desktop icon caches after install and upgrade")
+	}
+	if !strings.Contains(nfpm, "dst: /usr/share/applications/reasonix.desktop") {
+		t.Fatal("Linux deb must install the Reasonix desktop entry")
+	}
+	postInstall, err := os.ReadFile("build/linux/postinstall.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"gtk-update-icon-cache", "update-desktop-database"} {
+		if !strings.Contains(string(postInstall), want) {
+			t.Errorf("Linux post-install icon repair missing %q", want)
+		}
+	}
 
 	windowsData, err := os.ReadFile("build/windows/installer/project.nsi")
 	if err != nil {
@@ -161,8 +176,8 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 		`StrCpy $R9 "$INSTDIR\versions\.installer-v${INFO_PRODUCTVERSION}-$R8"`,
 		`File "/oname=${REASONIX_LAYOUT_INSTALLER}" "${REASONIX_GUARD}"`,
 		`--activate-staging "$R9" --no-relaunch`,
-		`CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0`,
-		`CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0`,
+		`CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\${REASONIX_LAUNCHER}" 0`,
+		`CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\${REASONIX_LAUNCHER}" 0`,
 		`StrCmp $ReasonixStageMode "1" reasonix_stage_payload`,
 		`File "/oname=${REASONIX_GUARD}" "${REASONIX_GUARD}"`,
 	} {
@@ -173,5 +188,9 @@ func TestDesktopPackagesPreserveNativePlatformLaunchers(t *testing.T) {
 	if strings.Contains(windows, `FileOpen $0 "$INSTDIR\current.json" w`) ||
 		strings.Contains(windows, `SetOutPath "$INSTDIR\versions\v${INFO_PRODUCTVERSION}"`) {
 		t.Fatal("normal Windows installer must not write the live version or current.json in place")
+	}
+	if strings.Contains(windows, `CreateShortcut "$SMPROGRAMS\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0`) ||
+		strings.Contains(windows, `CreateShortCut "$DESKTOP\${INFO_PRODUCTNAME}.lnk" "$INSTDIR\${REASONIX_LAUNCHER}" "" "$INSTDIR\versions\v${INFO_PRODUCTVERSION}\${PRODUCT_EXECUTABLE}" 0`) {
+		t.Fatal("Windows shortcut icon must not point into a version directory that retention removes")
 	}
 }

--- a/desktop/icon_repair_darwin.go
+++ b/desktop/icon_repair_darwin.go
@@ -1,0 +1,130 @@
+//go:build darwin && cgo
+
+package main
+
+/*
+#cgo LDFLAGS: -framework Foundation
+#include <stdlib.h>
+
+int reasonix_repair_alias(const char *alias_path, const char *current_app_path,
+                          int allow_broken, char **error_message);
+int reasonix_write_alias(const char *target_path, const char *alias_path,
+                         char **error_message);
+int reasonix_resolve_alias(const char *alias_path, char **target_path,
+                           char **error_message);
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+)
+
+func repairDesktopIconIntegration() error {
+	currentApp, err := currentMacAppBundle()
+	if err != nil {
+		// Developer binaries and tests are not installed app bundles.
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	return repairMacDesktopAliases(filepath.Join(home, "Desktop"), currentApp)
+}
+
+func repairMacDesktopAliases(desktopDir, currentApp string) error {
+	entries, err := os.ReadDir(desktopDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var repairErr error
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(desktopDir, entry.Name())
+		allowBroken := reasonixExactAliasName(entry.Name())
+		repaired, err := repairMacAlias(path, currentApp, allowBroken)
+		if err != nil {
+			repairErr = errors.Join(repairErr, fmt.Errorf("%s: %w", entry.Name(), err))
+			continue
+		}
+		_ = repaired // Native code returns false for ordinary desktop files.
+	}
+	return repairErr
+}
+
+func reasonixExactAliasName(name string) bool {
+	name = strings.TrimSpace(name)
+	return strings.EqualFold(name, "Reasonix") || strings.EqualFold(name, "Reasonix.app")
+}
+
+func repairMacAlias(aliasPath, currentApp string, allowBroken bool) (bool, error) {
+	aliasCString := C.CString(aliasPath)
+	appCString := C.CString(currentApp)
+	defer C.free(unsafe.Pointer(aliasCString))
+	defer C.free(unsafe.Pointer(appCString))
+	var nativeErr *C.char
+	allow := C.int(0)
+	if allowBroken {
+		allow = 1
+	}
+	result := C.reasonix_repair_alias(aliasCString, appCString, allow, &nativeErr)
+	if nativeErr != nil {
+		defer C.free(unsafe.Pointer(nativeErr))
+	}
+	if result < 0 {
+		if nativeErr == nil {
+			return false, fmt.Errorf("native alias repair failed")
+		}
+		return false, fmt.Errorf("%s", C.GoString(nativeErr))
+	}
+	return result == 1, nil
+}
+
+func writeMacAlias(targetPath, aliasPath string) error {
+	targetCString := C.CString(targetPath)
+	aliasCString := C.CString(aliasPath)
+	defer C.free(unsafe.Pointer(targetCString))
+	defer C.free(unsafe.Pointer(aliasCString))
+	var nativeErr *C.char
+	result := C.reasonix_write_alias(targetCString, aliasCString, &nativeErr)
+	if nativeErr != nil {
+		defer C.free(unsafe.Pointer(nativeErr))
+	}
+	if result != 0 {
+		if nativeErr == nil {
+			return fmt.Errorf("native alias write failed")
+		}
+		return fmt.Errorf("%s", C.GoString(nativeErr))
+	}
+	return nil
+}
+
+func resolveMacAlias(aliasPath string) (string, error) {
+	aliasCString := C.CString(aliasPath)
+	defer C.free(unsafe.Pointer(aliasCString))
+	var target, nativeErr *C.char
+	result := C.reasonix_resolve_alias(aliasCString, &target, &nativeErr)
+	if target != nil {
+		defer C.free(unsafe.Pointer(target))
+	}
+	if nativeErr != nil {
+		defer C.free(unsafe.Pointer(nativeErr))
+	}
+	if result != 0 {
+		if nativeErr == nil {
+			return "", fmt.Errorf("native alias resolution failed")
+		}
+		return "", fmt.Errorf("%s", C.GoString(nativeErr))
+	}
+	return C.GoString(target), nil
+}

--- a/desktop/icon_repair_darwin.m
+++ b/desktop/icon_repair_darwin.m
@@ -1,0 +1,125 @@
+//go:build darwin && cgo
+
+#import <Foundation/Foundation.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+static void reasonix_set_error(char **output, NSError *error, NSString *fallback) {
+    if (output == NULL) {
+        return;
+    }
+    NSString *message = error.localizedDescription ?: fallback;
+    *output = strdup(message.UTF8String ?: "unknown macOS alias error");
+}
+
+static BOOL reasonix_is_alias(NSURL *url, NSError **error) {
+    NSNumber *value = nil;
+    if (![url getResourceValue:&value forKey:NSURLIsAliasFileKey error:error]) {
+        return NO;
+    }
+    return value.boolValue;
+}
+
+static int reasonix_create_alias(NSURL *targetURL, NSURL *aliasURL, char **error_message) {
+    NSError *error = nil;
+    NSData *bookmark = [targetURL bookmarkDataWithOptions:NSURLBookmarkCreationSuitableForBookmarkFile
+                           includingResourceValuesForKeys:nil
+                                            relativeToURL:nil
+                                                    error:&error];
+    if (bookmark == nil) {
+        reasonix_set_error(error_message, error, @"create Finder alias bookmark");
+        return -1;
+    }
+    if (![NSURL writeBookmarkData:bookmark toURL:aliasURL options:0 error:&error]) {
+        reasonix_set_error(error_message, error, @"write Finder alias bookmark");
+        return -1;
+    }
+    return 0;
+}
+
+int reasonix_write_alias(const char *target_path, const char *alias_path,
+                         char **error_message) {
+    @autoreleasepool {
+        NSURL *targetURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:target_path]];
+        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+        return reasonix_create_alias(targetURL, aliasURL, error_message);
+    }
+}
+
+int reasonix_resolve_alias(const char *alias_path, char **target_path,
+                           char **error_message) {
+    @autoreleasepool {
+        NSError *error = nil;
+        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+        NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
+                                                     options:NSURLBookmarkResolutionWithoutUI |
+                                                             NSURLBookmarkResolutionWithoutMounting
+                                                       error:&error];
+        if (resolved == nil) {
+            reasonix_set_error(error_message, error, @"resolve Finder alias");
+            return -1;
+        }
+        if (target_path != NULL) {
+            *target_path = strdup(resolved.path.UTF8String);
+        }
+        return 0;
+    }
+}
+
+int reasonix_repair_alias(const char *alias_path, const char *current_app_path,
+                          int allow_broken, char **error_message) {
+    @autoreleasepool {
+        NSError *error = nil;
+        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+        if (!reasonix_is_alias(aliasURL, &error)) {
+            // Missing metadata means this is an ordinary desktop file, not an
+            // owned integration failure. Never replace it merely by name.
+            return 0;
+        }
+
+        NSURL *currentURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:current_app_path]];
+        NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
+                                                     options:NSURLBookmarkResolutionWithoutUI |
+                                                             NSURLBookmarkResolutionWithoutMounting
+                                                       error:&error];
+        BOOL owned = NO;
+        if (resolved != nil) {
+            NSString *resolvedPath = resolved.URLByResolvingSymlinksInPath.standardizedURL.path;
+            NSString *currentPath = currentURL.URLByResolvingSymlinksInPath.standardizedURL.path;
+            if ([resolvedPath isEqualToString:currentPath]) {
+                owned = YES;
+            } else {
+                NSBundle *bundle = [NSBundle bundleWithURL:resolved];
+                owned = [bundle.bundleIdentifier isEqualToString:@"com.wails.reasonix-desktop"];
+            }
+        } else if (allow_broken != 0) {
+            // A broken alias has no resolvable target to prove ownership. Only
+            // the exact historical installer names are admitted by Go.
+            owned = YES;
+        }
+        if (!owned) {
+            return 0;
+        }
+
+        NSURL *directory = [aliasURL URLByDeletingLastPathComponent];
+        NSString *temporaryName = [NSString stringWithFormat:@".reasonix-alias-%@", NSUUID.UUID.UUIDString];
+        NSURL *temporaryURL = [directory URLByAppendingPathComponent:temporaryName];
+        if (reasonix_create_alias(currentURL, temporaryURL, error_message) != 0) {
+            return -1;
+        }
+
+        NSURL *resultingURL = nil;
+        if (![[NSFileManager defaultManager] replaceItemAtURL:aliasURL
+                                                withItemAtURL:temporaryURL
+                                               backupItemName:nil
+                                                      options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                             resultingItemURL:&resultingURL
+                                                        error:&error]) {
+            [[NSFileManager defaultManager] removeItemAtURL:temporaryURL error:nil];
+            reasonix_set_error(error_message, error, @"replace Finder alias");
+            return -1;
+        }
+        return 1;
+    }
+}

--- a/desktop/icon_repair_darwin.m
+++ b/desktop/icon_repair_darwin.m
@@ -88,7 +88,9 @@ int reasonix_repair_alias(const char *alias_path, const char *current_app_path,
             NSString *resolvedPath = resolved.URLByResolvingSymlinksInPath.standardizedURL.path;
             NSString *currentPath = currentURL.URLByResolvingSymlinksInPath.standardizedURL.path;
             if ([resolvedPath isEqualToString:currentPath]) {
-                owned = YES;
+                // The alias is already healthy. Avoid rewriting it on every
+                // launch so Finder metadata and any user customization remain.
+                return 0;
             } else {
                 NSBundle *bundle = [NSBundle bundleWithURL:resolved];
                 owned = [bundle.bundleIdentifier isEqualToString:@"com.wails.reasonix-desktop"];

--- a/desktop/icon_repair_darwin_nocgo.go
+++ b/desktop/icon_repair_darwin_nocgo.go
@@ -1,0 +1,7 @@
+//go:build darwin && !cgo
+
+package main
+
+// The Wails macOS build always uses cgo. Keep source-only/cross checks working
+// without attempting to mutate Finder aliases when Foundation is unavailable.
+func repairDesktopIconIntegration() error { return nil }

--- a/desktop/icon_repair_darwin_test.go
+++ b/desktop/icon_repair_darwin_test.go
@@ -1,0 +1,116 @@
+//go:build darwin && cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeReasonixTestBundle(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(path, "Contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.wails.reasonix-desktop</string></dict></plist>`
+	if err := os.WriteFile(filepath.Join(path, "Contents", "Info.plist"), []byte(plist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepairMacDesktopAliasesRetargetsBrokenReasonixAlias(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldApp := filepath.Join(root, "Reasonix.app.reasonix-update-backup")
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, oldApp)
+	writeReasonixTestBundle(t, currentApp)
+	alias := filepath.Join(desktop, "Reasonix")
+	if err := writeMacAlias(oldApp, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(oldApp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveMacAlias(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(currentApp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != want {
+		t.Fatalf("alias target = %q, want %q", resolved, want)
+	}
+}
+
+func TestRepairMacDesktopAliasesPreservesUnrelatedBrokenAlias(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldTarget := filepath.Join(root, "Other.app")
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, oldTarget)
+	writeReasonixTestBundle(t, currentApp)
+	alias := filepath.Join(desktop, "Other")
+	if err := writeMacAlias(oldTarget, alias); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(oldTarget); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("unrelated broken Finder alias was rewritten")
+	}
+}
+
+func TestRepairMacDesktopAliasesPreservesOrdinaryReasonixFile(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, currentApp)
+	ordinary := filepath.Join(desktop, "Reasonix")
+	const content = "user-owned file"
+	if err := os.WriteFile(ordinary, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(ordinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Fatalf("ordinary Reasonix file changed to %q", got)
+	}
+}

--- a/desktop/icon_repair_darwin_test.go
+++ b/desktop/icon_repair_darwin_test.go
@@ -114,3 +114,32 @@ func TestRepairMacDesktopAliasesPreservesOrdinaryReasonixFile(t *testing.T) {
 		t.Fatalf("ordinary Reasonix file changed to %q", got)
 	}
 }
+
+func TestRepairMacDesktopAliasesPreservesHealthyReasonixAlias(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, currentApp)
+	alias := filepath.Join(desktop, "Reasonix")
+	if err := writeMacAlias(currentApp, alias); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("healthy Finder alias was rewritten")
+	}
+}

--- a/desktop/icon_repair_other.go
+++ b/desktop/icon_repair_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !windows
+
+package main
+
+// Linux package installs refresh the system icon and desktop caches from the
+// package post-install script. Portable archives do not own desktop launchers.
+func repairDesktopIconIntegration() error { return nil }

--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -119,6 +120,15 @@ func repairWindowsShortcut(shortcutPath, launcher string) (bool, error) {
 	if !reasonixWindowsShortcutTarget(target, launcher) {
 		return false, nil
 	}
+	iconValue, err := oleutil.GetProperty(shortcut, "IconLocation")
+	if err != nil {
+		return false, fmt.Errorf("read IconLocation: %w", err)
+	}
+	iconLocation := iconValue.ToString()
+	_ = iconValue.Clear()
+	if !reasonixWindowsStaleIcon(iconLocation, launcher) {
+		return false, nil
+	}
 
 	result, err := oleutil.PutProperty(shortcut, "IconLocation", launcher+",0")
 	if result != nil {
@@ -151,6 +161,27 @@ func reasonixWindowsShortcutTarget(target, launcher string) bool {
 		}
 	}
 	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	return len(parts) == 3 && strings.EqualFold(parts[0], "versions") &&
+		strings.EqualFold(parts[2], "reasonix-desktop.exe")
+}
+
+func reasonixWindowsStaleIcon(iconLocation, launcher string) bool {
+	iconPath := strings.TrimSpace(iconLocation)
+	if comma := strings.LastIndex(iconPath, ","); comma >= 0 {
+		if _, err := strconv.Atoi(strings.TrimSpace(iconPath[comma+1:])); err == nil {
+			iconPath = iconPath[:comma]
+		}
+	}
+	iconPath = strings.Trim(strings.TrimSpace(iconPath), `"`)
+	if iconPath == "" {
+		return false
+	}
+	root := filepath.Dir(filepath.Clean(strings.TrimSpace(launcher)))
+	rel, err := filepath.Rel(root, filepath.Clean(iconPath))
 	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return false
 	}

--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"unsafe"
 
 	"github.com/go-ole/go-ole"
@@ -19,7 +20,7 @@ import (
 
 var (
 	windowsKnownFolderPath      = windows.KnownFolderPath
-	windowsWriteShortcut        = writeWindowsShortcut
+	windowsRepairShortcut       = repairWindowsShortcut
 	windowsNotifyShortcutChange = notifyWindowsShortcutChanged
 )
 
@@ -40,7 +41,7 @@ func repairDesktopIconIntegration() error {
 	if err != nil {
 		return err
 	}
-	return repairExistingWindowsShortcuts(paths, launcher, windowsWriteShortcut)
+	return repairExistingWindowsShortcuts(paths, launcher, windowsRepairShortcut)
 }
 
 func reasonixWindowsShortcutPaths() ([]string, error) {
@@ -55,7 +56,7 @@ func reasonixWindowsShortcutPaths() ([]string, error) {
 	}, nil
 }
 
-func repairExistingWindowsShortcuts(paths []string, launcher string, writer func(string, string) error) error {
+func repairExistingWindowsShortcuts(paths []string, launcher string, repair func(string, string) (bool, error)) error {
 	var repairErr error
 	for _, path := range paths {
 		info, err := os.Lstat(path)
@@ -68,63 +69,94 @@ func repairExistingWindowsShortcuts(paths []string, launcher string, writer func
 		if !info.Mode().IsRegular() {
 			continue
 		}
-		if err := writer(path, launcher); err != nil {
+		repaired, err := repair(path, launcher)
+		if err != nil {
 			repairErr = errors.Join(repairErr, fmt.Errorf("%s: %w", path, err))
 			continue
 		}
-		windowsNotifyShortcutChange(path)
+		if repaired {
+			windowsNotifyShortcutChange(path)
+		}
 	}
 	return repairErr
 }
 
-func writeWindowsShortcut(shortcutPath, launcher string) error {
+func repairWindowsShortcut(shortcutPath, launcher string) (bool, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	if err := ole.CoInitializeEx(0, ole.COINIT_APARTMENTTHREADED); err != nil {
-		return err
+		return false, err
 	}
 	defer ole.CoUninitialize()
 
 	unknown, err := oleutil.CreateObject("WScript.Shell")
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer unknown.Release()
 	shell, err := unknown.QueryInterface(ole.IID_IDispatch)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer shell.Release()
 	created, err := oleutil.CallMethod(shell, "CreateShortcut", shortcutPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	shortcut := created.ToIDispatch()
 	if shortcut == nil {
 		_ = created.Clear()
-		return fmt.Errorf("WScript.Shell returned no shortcut object")
+		return false, fmt.Errorf("WScript.Shell returned no shortcut object")
 	}
 	defer shortcut.Release()
 
-	for name, value := range map[string]string{
-		"TargetPath":       launcher,
-		"IconLocation":     launcher + ",0",
-		"WorkingDirectory": filepath.Dir(launcher),
-		"Description":      "Reasonix",
-	} {
-		result, err := oleutil.PutProperty(shortcut, name, value)
-		if result != nil {
-			_ = result.Clear()
-		}
-		if err != nil {
-			return fmt.Errorf("set %s: %w", name, err)
-		}
+	targetValue, err := oleutil.GetProperty(shortcut, "TargetPath")
+	if err != nil {
+		return false, fmt.Errorf("read TargetPath: %w", err)
 	}
-	result, err := oleutil.CallMethod(shortcut, "Save")
+	target := targetValue.ToString()
+	_ = targetValue.Clear()
+	if !reasonixWindowsShortcutTarget(target, launcher) {
+		return false, nil
+	}
+
+	result, err := oleutil.PutProperty(shortcut, "IconLocation", launcher+",0")
 	if result != nil {
 		_ = result.Clear()
 	}
-	return err
+	if err != nil {
+		return false, fmt.Errorf("set IconLocation: %w", err)
+	}
+	result, err = oleutil.CallMethod(shortcut, "Save")
+	if result != nil {
+		_ = result.Clear()
+	}
+	return err == nil, err
+}
+
+func reasonixWindowsShortcutTarget(target, launcher string) bool {
+	target = filepath.Clean(strings.TrimSpace(target))
+	launcher = filepath.Clean(strings.TrimSpace(launcher))
+	if target == "." || launcher == "." {
+		return false
+	}
+	root := filepath.Dir(launcher)
+	for _, owned := range []string{
+		launcher,
+		filepath.Join(root, "Reasonix.exe"),
+		filepath.Join(root, "reasonix-desktop.exe"),
+	} {
+		if strings.EqualFold(target, owned) {
+			return true
+		}
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	return len(parts) == 3 && strings.EqualFold(parts[0], "versions") &&
+		strings.EqualFold(parts[2], "reasonix-desktop.exe")
 }
 
 func notifyWindowsShortcutChanged(path string) {

--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -1,0 +1,143 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"github.com/go-ole/go-ole"
+	"github.com/go-ole/go-ole/oleutil"
+	"golang.org/x/sys/windows"
+
+	"reasonix/internal/installlayout"
+)
+
+var (
+	windowsKnownFolderPath      = windows.KnownFolderPath
+	windowsWriteShortcut        = writeWindowsShortcut
+	windowsNotifyShortcutChange = notifyWindowsShortcutChanged
+)
+
+func repairDesktopIconIntegration() error {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	installRoot, err := installlayout.ResolveInstallRoot(executable)
+	if err != nil || installRoot == "" {
+		return nil
+	}
+	launcher := filepath.Join(installRoot, "reasonix-launcher.exe")
+	if info, err := os.Lstat(launcher); err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	paths, err := reasonixWindowsShortcutPaths()
+	if err != nil {
+		return err
+	}
+	return repairExistingWindowsShortcuts(paths, launcher, windowsWriteShortcut)
+}
+
+func reasonixWindowsShortcutPaths() ([]string, error) {
+	desktop, desktopErr := windowsKnownFolderPath(windows.FOLDERID_Desktop, windows.KF_FLAG_DEFAULT)
+	programs, programsErr := windowsKnownFolderPath(windows.FOLDERID_Programs, windows.KF_FLAG_DEFAULT)
+	if desktopErr != nil || programsErr != nil {
+		return nil, errors.Join(desktopErr, programsErr)
+	}
+	return []string{
+		filepath.Join(desktop, "Reasonix.lnk"),
+		filepath.Join(programs, "Reasonix.lnk"),
+	}, nil
+}
+
+func repairExistingWindowsShortcuts(paths []string, launcher string, writer func(string, string) error) error {
+	var repairErr error
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				repairErr = errors.Join(repairErr, err)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		if err := writer(path, launcher); err != nil {
+			repairErr = errors.Join(repairErr, fmt.Errorf("%s: %w", path, err))
+			continue
+		}
+		windowsNotifyShortcutChange(path)
+	}
+	return repairErr
+}
+
+func writeWindowsShortcut(shortcutPath, launcher string) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if err := ole.CoInitializeEx(0, ole.COINIT_APARTMENTTHREADED); err != nil {
+		return err
+	}
+	defer ole.CoUninitialize()
+
+	unknown, err := oleutil.CreateObject("WScript.Shell")
+	if err != nil {
+		return err
+	}
+	defer unknown.Release()
+	shell, err := unknown.QueryInterface(ole.IID_IDispatch)
+	if err != nil {
+		return err
+	}
+	defer shell.Release()
+	created, err := oleutil.CallMethod(shell, "CreateShortcut", shortcutPath)
+	if err != nil {
+		return err
+	}
+	shortcut := created.ToIDispatch()
+	if shortcut == nil {
+		_ = created.Clear()
+		return fmt.Errorf("WScript.Shell returned no shortcut object")
+	}
+	defer shortcut.Release()
+
+	for name, value := range map[string]string{
+		"TargetPath":       launcher,
+		"IconLocation":     launcher + ",0",
+		"WorkingDirectory": filepath.Dir(launcher),
+		"Description":      "Reasonix",
+	} {
+		result, err := oleutil.PutProperty(shortcut, name, value)
+		if result != nil {
+			_ = result.Clear()
+		}
+		if err != nil {
+			return fmt.Errorf("set %s: %w", name, err)
+		}
+	}
+	result, err := oleutil.CallMethod(shortcut, "Save")
+	if result != nil {
+		_ = result.Clear()
+	}
+	return err
+}
+
+func notifyWindowsShortcutChanged(path string) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return
+	}
+	// SHCNE_UPDATEITEM + SHCNF_PATHW asks Explorer to invalidate only this
+	// shortcut instead of flushing the entire association cache.
+	const (
+		shcneUpdateItem = 0x00002000
+		shcnfPathW      = 0x0005
+	)
+	proc := windows.NewLazySystemDLL("shell32.dll").NewProc("SHChangeNotify")
+	_, _, _ = proc.Call(shcneUpdateItem, shcnfPathW, uintptr(unsafe.Pointer(pathPtr)), 0)
+}

--- a/desktop/icon_repair_windows_test.go
+++ b/desktop/icon_repair_windows_test.go
@@ -11,8 +11,12 @@ import (
 func TestRepairExistingWindowsShortcutsRepairsOnlyExistingFiles(t *testing.T) {
 	root := t.TempDir()
 	existing := filepath.Join(root, "Reasonix.lnk")
+	custom := filepath.Join(root, "Custom.lnk")
 	missing := filepath.Join(root, "Missing.lnk")
 	if err := os.WriteFile(existing, []byte("old shortcut"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(custom, []byte("custom shortcut"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	launcher := filepath.Join(root, "reasonix-launcher.exe")
@@ -22,23 +26,48 @@ func TestRepairExistingWindowsShortcutsRepairsOnlyExistingFiles(t *testing.T) {
 	t.Cleanup(func() { windowsNotifyShortcutChange = originalNotify })
 
 	err := repairExistingWindowsShortcuts(
-		[]string{existing, missing},
+		[]string{existing, custom, missing},
 		launcher,
-		func(path, target string) error {
+		func(path, target string) (bool, error) {
 			if target != launcher {
 				t.Fatalf("shortcut target = %q, want %q", target, launcher)
 			}
 			wrote = append(wrote, path)
-			return nil
+			return path == existing, nil
 		},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(wrote) != 1 || wrote[0] != existing {
-		t.Fatalf("rewritten shortcuts = %v, want only %q", wrote, existing)
+	if len(wrote) != 2 || wrote[0] != existing || wrote[1] != custom {
+		t.Fatalf("repair attempts = %v, want %q and %q", wrote, existing, custom)
 	}
 	if len(notified) != 1 || notified[0] != existing {
 		t.Fatalf("shell notifications = %v, want only %q", notified, existing)
+	}
+}
+
+func TestReasonixWindowsShortcutTargetRequiresCurrentInstall(t *testing.T) {
+	root := filepath.Join(`C:\Program Files`, "Reasonix")
+	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	tests := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{name: "launcher", target: launcher, want: true},
+		{name: "flat desktop", target: filepath.Join(root, "reasonix-desktop.exe"), want: true},
+		{name: "launcher alias", target: filepath.Join(root, "Reasonix.exe"), want: true},
+		{name: "versioned desktop", target: filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe"), want: true},
+		{name: "other install", target: filepath.Join(`D:\Apps`, "Reasonix", "reasonix-launcher.exe"), want: false},
+		{name: "unrelated app", target: filepath.Join(root, "other.exe"), want: false},
+		{name: "empty", target: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reasonixWindowsShortcutTarget(tt.target, launcher); got != tt.want {
+				t.Fatalf("reasonixWindowsShortcutTarget(%q, %q) = %v, want %v", tt.target, launcher, got, tt.want)
+			}
+		})
 	}
 }

--- a/desktop/icon_repair_windows_test.go
+++ b/desktop/icon_repair_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepairExistingWindowsShortcutsRepairsOnlyExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	existing := filepath.Join(root, "Reasonix.lnk")
+	missing := filepath.Join(root, "Missing.lnk")
+	if err := os.WriteFile(existing, []byte("old shortcut"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	var wrote, notified []string
+	originalNotify := windowsNotifyShortcutChange
+	windowsNotifyShortcutChange = func(path string) { notified = append(notified, path) }
+	t.Cleanup(func() { windowsNotifyShortcutChange = originalNotify })
+
+	err := repairExistingWindowsShortcuts(
+		[]string{existing, missing},
+		launcher,
+		func(path, target string) error {
+			if target != launcher {
+				t.Fatalf("shortcut target = %q, want %q", target, launcher)
+			}
+			wrote = append(wrote, path)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wrote) != 1 || wrote[0] != existing {
+		t.Fatalf("rewritten shortcuts = %v, want only %q", wrote, existing)
+	}
+	if len(notified) != 1 || notified[0] != existing {
+		t.Fatalf("shell notifications = %v, want only %q", notified, existing)
+	}
+}

--- a/desktop/icon_repair_windows_test.go
+++ b/desktop/icon_repair_windows_test.go
@@ -71,3 +71,27 @@ func TestReasonixWindowsShortcutTargetRequiresCurrentInstall(t *testing.T) {
 		})
 	}
 }
+
+func TestReasonixWindowsStaleIconOnlyMatchesVersionedDesktop(t *testing.T) {
+	root := filepath.Join(`C:\Program Files, Inc`, "Reasonix")
+	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	tests := []struct {
+		name string
+		icon string
+		want bool
+	}{
+		{name: "versioned", icon: filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: true},
+		{name: "quoted versioned", icon: `"` + filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + `", 0`, want: true},
+		{name: "stable launcher", icon: launcher + ",0", want: false},
+		{name: "custom icon", icon: filepath.Join(root, "custom.ico") + ",0", want: false},
+		{name: "other install", icon: filepath.Join(`D:\Apps`, "Reasonix", "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: false},
+		{name: "empty", icon: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reasonixWindowsStaleIcon(tt.icon, launcher); got != tt.want {
+				t.Fatalf("reasonixWindowsStaleIcon(%q, %q) = %v, want %v", tt.icon, launcher, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Keep new Windows shortcuts on the stable launcher and repair only stale version-scoped icon references after verifying ownership.
- Repair owned macOS Finder aliases only when their target is broken or still points to an older Reasonix bundle.
- Refresh Linux icon and desktop-entry caches from the native package post-install script after fresh installs and upgrades.
- Keep every repair best-effort and idempotent so failures never block startup and healthy integrations are not rewritten.

## Root cause

Windows shortcuts used an icon path inside `versions/vX`, which becomes invalid after version retention removes that directory. macOS bundle replacement can leave a Finder alias targeting the replaced bundle. Linux desktop environments may keep stale icon or desktop-entry caches after a package upgrade.

## Platform behavior

| Platform | Repair behavior | Ownership boundary |
| --- | --- | --- |
| Windows | Verify the existing target, replace only a stale version-scoped `IconLocation`, and notify Explorer | Deleted or unrelated shortcuts are not modified; custom target, icon, arguments, working directory, and description are preserved |
| macOS | Atomically retarget broken or old Reasonix Finder aliases to the running app bundle | Healthy aliases, ordinary files, and unrelated aliases are preserved |
| Linux | Refresh hicolor and desktop-entry caches during `.deb` installation or upgrade | Portable archives do not claim desktop-launcher ownership |

## Issues

No linked issue.

Related open work: #7124 changes macOS artwork and #6781 updates desktop dependencies. They have mechanical file overlap but do not implement or conflict with this repair behavior.

## Verification

- `(cd desktop && go test ./...)`
- `(cd desktop && go test -race . -run "TestRepairMacDesktopAliases|TestDesktopPackagesPreserveNativePlatformLaunchers")`
- `(cd desktop && go vet ./...)`
- Windows amd64 and arm64 cross-compilation with `CGO_ENABLED=0`, including shortcut ownership and stale-icon regression tests
- Wails macOS arm64 production build plus strict code-signature verification
- Linux nFPM Debian package smoke test, including extraction and verification of `postinst`
- `git diff --check`

## Compatibility

| Contract | Result |
| --- | --- |
| Persisted data and configuration | No schema or format changes |
| Existing shortcuts and aliases | Only the known stale upgrade state is repaired; healthy and custom integrations remain intact |
| Older installers | The first launch of this version repairs their existing integration |
| Provider and prompt contracts | Unchanged |

## Cache impact

Cache-impact: none — provider-visible prompts, schemas, and request serialization are unchanged.
Cache-guard: The diff is limited to desktop startup integration and native packaging contracts; `go test ./...` covers the affected package.
System-prompt-review: N/A