### PR TITLE
fix(e2e): enforce provider credential gate / 强制真实 Provider 凭据门禁

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -131,8 +131,13 @@ jobs:
         run: |
           if [ -z "$DEEPSEEK_API_KEY" ]; then
             printf 'missing DEEPSEEK_API_KEY secret\n\nAdd a repository secret named DEEPSEEK_API_KEY to enable the e2e bot.\n' > report.md
-            exit 0
+            exit 1
           fi
+          # Provider credentials are deliberately loaded only from Reasonix's
+          # global credential file, not inherited process variables. Keep this
+          # ephemeral runner copy private and outside the checked-out project.
+          umask 077
+          printf 'DEEPSEEK_API_KEY=%s\n' "$DEEPSEEK_API_KEY" > "$HOME/.config/reasonix/.env"
           if printf '%s' "$COMMENT_BODY" | grep -q '/e2e[[:space:]]\+diff'; then
             ATTEMPTS=$(printf '%s' "$COMMENT_BODY" | sed -nE 's@.*/e2e[[:space:]]+diff[[:space:]]+x([0-9]+).*@\1@p' | head -1)
             [ -z "$ATTEMPTS" ] && ATTEMPTS=1
@@ -143,9 +148,18 @@ jobs:
             "$RUNNER_TEMP/e2ebench" -mode diff -bin "${{ steps.agent.outputs.bin }}" -repo . -base "$BASE" -model e2e -attempts "$ATTEMPTS" -out report.md
           else
             "$RUNNER_TEMP/e2ebench" -bin "${{ steps.agent.outputs.bin }}" -suite "$RUNNER_TEMP/suite" -model e2e -out report.md -json report.json -budget 400000
+            node -e '
+              const results = require("./report.json");
+              const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);
+              if (results.length === 0 || unsuccessful.length > 0) {
+                console.error(`e2e suite incomplete: ${unsuccessful.length}/${results.length} unsuccessful`);
+                process.exit(1);
+              }
+            '
           fi
 
       - name: Post report
+        if: always() && hashFiles('report.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIGGER_USER: ${{ github.event.comment.user.login }}

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1545,6 +1545,15 @@ if EVENT_NAME=workflow_dispatch IN_ORCHESTRATED=false IN_CHANNEL=stable IN_BASE_
 fi
 grep -Eq 'does not match requested version' "$test_root/npm-mismatch.log"
 
+e2e_workflow="$repo_root/.github/workflows/e2e-bot.yml"
+grep -Fq "printf 'DEEPSEEK_API_KEY=%s\\n' \"\$DEEPSEEK_API_KEY\" > \"\$HOME/.config/reasonix/.env\"" "$e2e_workflow"
+grep -Fq 'const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);' "$e2e_workflow"
+grep -Fq "if: always() && hashFiles('report.md') != ''" "$e2e_workflow"
+if grep -A2 -F 'missing DEEPSEEK_API_KEY secret' "$e2e_workflow" | grep -Fq 'exit 0'; then
+	echo "e2e bot still treats a missing provider secret as success" >&2
+	exit 1
+fi
+
 node --test "$repo_root/npm/publish.test.mjs"
 node --test "$repo_root/scripts/finalize-npm-official-release.test.mjs"
 bash "$repo_root/scripts/release-stable.test.sh"


### PR DESCRIPTION
## Summary

- write the e2e provider secret to the ephemeral global Reasonix credential file expected by the runtime credential boundary
- fail the fixed e2e suite when any task fails or is skipped
- keep posting the benchmark report on failures so the result remains diagnosable
- pin these behaviors in the release workflow contract test

## Why

The release-candidate run on #7294 injected the repository secret into the job, but the candidate correctly ignored inherited provider variables and reported `missing env DEEPSEEK_API_KEY` for every task. The harness then posted 0/5 accuracy with zero tokens while the workflow concluded success. This produced a false-green release signal.

The runner is ephemeral, the credentials file is created with `umask 077`, and it remains outside the checked-out project.

## Verification

- `bash scripts/release-workflows.test.sh`
- `actionlint .github/workflows/e2e-bot.yml`
- `git diff --check`
- public diff privacy scan

## 中文说明

修复真实 provider e2e 的两个门禁缺口：按运行时凭据边界写入一次性全局凭据文件，并在固定套件出现失败或跳过时让工作流失败；失败报告仍会正常发布，便于诊断。
