### PR TITLE
fix(e2e): use isolated Reasonix home / 使用隔离的 Reasonix Home

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -93,10 +93,12 @@ jobs:
           echo "agent under test: $src"
 
       - name: Write provider config
+        env:
+          REASONIX_HOME: ${{ runner.temp }}/reasonix-e2e-home
         # User config covers suite tasks (they run in temp dirs); the repo-root copy
         # covers diff mode (the agent runs in the repo root, where project config wins).
         run: |
-          mkdir -p ~/.config/reasonix
+          mkdir -p "$REASONIX_HOME"
           cat > /tmp/reasonix-e2e.toml <<EOF
           default_model = "e2e"
 
@@ -120,12 +122,13 @@ jobs:
           [codegraph]
           enabled = false
           EOF
-          cp /tmp/reasonix-e2e.toml ~/.config/reasonix/config.toml
+          cp /tmp/reasonix-e2e.toml "$REASONIX_HOME/config.toml"
           cp /tmp/reasonix-e2e.toml ./reasonix.toml
 
       - name: Run e2e
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          REASONIX_HOME: ${{ runner.temp }}/reasonix-e2e-home
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
@@ -137,7 +140,7 @@ jobs:
           # global credential file, not inherited process variables. Keep this
           # ephemeral runner copy private and outside the checked-out project.
           umask 077
-          printf 'DEEPSEEK_API_KEY=%s\n' "$DEEPSEEK_API_KEY" > "$HOME/.config/reasonix/.env"
+          printf 'DEEPSEEK_API_KEY=%s\n' "$DEEPSEEK_API_KEY" > "$REASONIX_HOME/.env"
           if printf '%s' "$COMMENT_BODY" | grep -q '/e2e[[:space:]]\+diff'; then
             ATTEMPTS=$(printf '%s' "$COMMENT_BODY" | sed -nE 's@.*/e2e[[:space:]]+diff[[:space:]]+x([0-9]+).*@\1@p' | head -1)
             [ -z "$ATTEMPTS" ] && ATTEMPTS=1

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1546,7 +1546,9 @@ fi
 grep -Eq 'does not match requested version' "$test_root/npm-mismatch.log"
 
 e2e_workflow="$repo_root/.github/workflows/e2e-bot.yml"
-grep -Fq "printf 'DEEPSEEK_API_KEY=%s\\n' \"\$DEEPSEEK_API_KEY\" > \"\$HOME/.config/reasonix/.env\"" "$e2e_workflow"
+grep -Fq 'REASONIX_HOME: ${{ runner.temp }}/reasonix-e2e-home' "$e2e_workflow"
+grep -Fq 'cp /tmp/reasonix-e2e.toml "$REASONIX_HOME/config.toml"' "$e2e_workflow"
+grep -Fq "printf 'DEEPSEEK_API_KEY=%s\\n' \"\$DEEPSEEK_API_KEY\" > \"\$REASONIX_HOME/.env\"" "$e2e_workflow"
 grep -Fq 'const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);' "$e2e_workflow"
 grep -Fq "if: always() && hashFiles('report.md') != ''" "$e2e_workflow"
 if grep -A2 -F 'missing DEEPSEEK_API_KEY secret' "$e2e_workflow" | grep -Fq 'exit 0'; then


### PR DESCRIPTION
## Summary

- give the e2e runner an explicit ephemeral `REASONIX_HOME`
- place both `config.toml` and the provider credential file under that same home
- retain the project config copy used by diff mode
- extend the workflow contract test to pin the isolated-home wiring

## Why

The first credential-gate fix correctly stopped false-green 0/5 runs, but wrote the key to the legacy XDG config directory. Current Reasonix uses `<Reasonix home>/.env` as the only provider credential source; on Linux the default home is `~/.reasonix`, while the old config directory remains readable only as a compatibility fallback.

Using an explicit runner-temporary `REASONIX_HOME` makes the config and credential locations unambiguous and keeps them outside the checkout.

## Verification

- `bash scripts/release-workflows.test.sh`
- `actionlint .github/workflows/e2e-bot.yml`
- focused `UserConfigPath` and `UserCredentialsPath` tests
- `git diff --check`
- public diff privacy scan

## 中文说明

将真实 provider e2e 的配置与凭据统一放入一次性的 `REASONIX_HOME`，修复 Linux 下写入旧 XDG 路径导致候选仍无法读取凭据的问题。
