### PR TITLE
fix(e2e): allow unattended benchmark writes / 允许无人值守基准写入

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -55,6 +55,18 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install and verify Linux sandbox backend
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          if sysctl -n kernel.unprivileged_userns_clone >/dev/null 2>&1; then
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+          if sysctl -n kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          bwrap --ro-bind / / --dev /dev --proc /proc -- true
+
       - name: Build harness + fallback agent from the default branch
         # Harness (e2ebench) and suite always come from main-v2 so a PR can't weaken
         # its own grader or tests. The agent is rebuilt from the PR head below; this

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -224,15 +224,7 @@ func runTask(bin, model, profile string, t task) result {
 	defer cancel()
 
 	metricsPath := filepath.Join(work, ".run-metrics.json")
-	args := []string{"run", "--metrics", metricsPath}
-	if model != "" {
-		args = append(args, "--model", model)
-	}
-	if t.MaxSteps > 0 {
-		args = append(args, "--max-steps", fmt.Sprint(t.MaxSteps))
-	}
-	args = appendBenchmarkProfileArgs(args, profile)
-	args = append(args, t.Prompt)
+	args := buildRunTaskArgs(metricsPath, model, profile, t.MaxSteps, t.Prompt)
 
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = work
@@ -251,6 +243,20 @@ func runTask(bin, model, profile string, t task) result {
 
 	r.Passed = grade(work, t.dir)
 	return r
+}
+
+func buildRunTaskArgs(metricsPath, model, profile string, maxSteps int, prompt string) []string {
+	// Benchmarks are unattended and their fixtures require ordinary workspace
+	// writes. Auto still honors explicit ask/deny rules and the sandbox boundary.
+	args := []string{"run", "--auto", "--metrics", metricsPath}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	if maxSteps > 0 {
+		args = append(args, "--max-steps", fmt.Sprint(maxSteps))
+	}
+	args = appendBenchmarkProfileArgs(args, profile)
+	return append(args, prompt)
 }
 
 func grade(work, taskDir string) bool {

--- a/cmd/e2ebench/profile_test.go
+++ b/cmd/e2ebench/profile_test.go
@@ -21,6 +21,18 @@ func TestAppendBenchmarkProfileArgsDeliveryUsesRealRuntimeProfile(t *testing.T) 
 	}
 }
 
+func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
+	got := buildRunTaskArgs("metrics.json", "e2e", benchmarkProfileDelivery, 12, "fix it")
+	want := []string{
+		"run", "--auto", "--metrics", "metrics.json",
+		"--model", "e2e", "--max-steps", "12",
+		"--profile", "delivery", "fix it",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("run task args = %v, want %v", got, want)
+	}
+}
+
 func TestNormalizeBenchmarkProfile(t *testing.T) {
 	for _, input := range []string{"", "baseline", " BASELINE "} {
 		if got, err := normalizeBenchmarkProfile(input); err != nil || got != benchmarkProfileBaseline {


### PR DESCRIPTION
## Problem

The real-provider fixed suite produced correct edits, but every file mutation was denied. The runner also lacked bubblewrap, so Bash sandboxing failed closed. Three tasks failed and the remaining two were skipped after the 400k-token budget was exhausted.

## Root cause

- e2ebench launched headless reasonix run in the default Ask posture instead of explicitly selecting unattended Auto mode.
- e2e-bot did not install and verify the Linux sandbox backend used by the product.

## Fix

- Launch fixed-suite tasks with --auto so ordinary workspace writer fallbacks can run without an unavailable interactive approver.
- Install and verify bubblewrap before executing PR-head code.
- Keep explicit ask/deny rules and the sandbox boundary intact.
- Add a focused argument-construction regression test.

## Verification

- go test ./cmd/e2ebench -count=5
- go vet ./cmd/e2ebench
- actionlint .github/workflows/e2e-bot.yml
- bash scripts/release-workflows.test.sh

## Security and compatibility

This changes only the trusted, environment-approved E2E runner. It does not change product defaults, persisted formats, provider-visible prompts, tool schemas, or cache ordering. The provider credential remains isolated in the ephemeral Reasonix home.