### PR TITLE
fix(e2e): budget the complete fixed suite / 为完整固定套件校准预算

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -162,7 +162,9 @@ jobs:
             BASE=$(git merge-base "origin/$BASE_REF" HEAD)
             "$RUNNER_TEMP/e2ebench" -mode diff -bin "${{ steps.agent.outputs.bin }}" -repo . -base "$BASE" -model e2e -attempts "$ATTEMPTS" -out report.md
           else
-            "$RUNNER_TEMP/e2ebench" -bin "${{ steps.agent.outputs.bin }}" -suite "$RUNNER_TEMP/suite" -model e2e -out report.md -json report.json -budget 400000
+            # The current five-task baseline can exceed 400k after only three
+            # successful tasks. Keep bounded headroom so every scenario is graded.
+            "$RUNNER_TEMP/e2ebench" -bin "${{ steps.agent.outputs.bin }}" -suite "$RUNNER_TEMP/suite" -model e2e -out report.md -json report.json -budget 800000
             node -e '
               const results = require("./report.json");
               const unsuccessful = results.filter((result) => !result.Passed || result.Skipped);

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -64,6 +64,8 @@ type result struct {
 	Note    string
 }
 
+const defaultSuiteTokenBudget = 800_000
+
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "e2ebench — Reasonix end-to-end benchmark.\n\n")
@@ -85,7 +87,7 @@ func main() {
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
-	budget := flag.Int("budget", 400_000, "abort once total tokens cross this (0 = no cap)")
+	budget := flag.Int("budget", defaultSuiteTokenBudget, "abort once total tokens cross this (0 = no cap)")
 	// diff-mode flags
 	repo := flag.String("repo", ".", "repo root (diff mode)")
 	base := flag.String("base", "", "base ref to diff the PR head against (diff mode)")

--- a/cmd/e2ebench/profile_test.go
+++ b/cmd/e2ebench/profile_test.go
@@ -33,6 +33,15 @@ func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
 	}
 }
 
+func TestDefaultSuiteBudgetCoversCurrentFiveTaskBaseline(t *testing.T) {
+	// The real-provider baseline exceeded 400k after only three successful
+	// tasks. Keep enough headroom to grade all five instead of silently skipping
+	// the final scenarios as normal model and cache usage varies.
+	if defaultSuiteTokenBudget < 800_000 {
+		t.Fatalf("default suite token budget = %d, want at least 800000", defaultSuiteTokenBudget)
+	}
+}
+
 func TestNormalizeBenchmarkProfile(t *testing.T) {
 	for _, input := range []string{"", "baseline", " BASELINE "} {
 		if got, err := normalizeBenchmarkProfile(input); err != nil || got != benchmarkProfileBaseline {


### PR DESCRIPTION
## Problem

After the unattended-write fix, the first three fixed-suite tasks all passed, with an 83% cache hit rate and about $0.0122 provider cost. They nevertheless consumed 424,671 total tokens, crossing the old 400k cap before the final palindrome and sub-agent scenarios could run.

## Root cause

The harness default and workflow override were calibrated for an older model/runtime token profile. The gate now correctly rejects skipped tasks, which exposed that the old cap could not cover the current five-task suite.

## Fix

- Raise the bounded fixed-suite budget from 400k to 800k in both the harness default and the E2E workflow.
- Keep the strict completion contract: any failed or skipped task still fails the workflow.
- Add a regression contract that prevents the five-task baseline budget from being lowered below the newly measured floor.

At the observed pricing and cache rate, a complete run remains a low-cost bounded validation measured in only a few cents.

## Verification

- go test ./cmd/e2ebench -count=5
- go vet ./cmd/e2ebench
- actionlint .github/workflows/e2e-bot.yml
- bash scripts/release-workflows.test.sh

## Security and compatibility

This changes only the trusted, environment-approved E2E benchmark budget. It does not change product defaults, persisted formats, provider-visible prompts, tool schemas, credentials, sandbox policy, or cache ordering.