### PR TITLE
fix(agent): keep subagent list CreatedAt as start time

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -612,9 +612,9 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	if s.parentDestroyed(run) {
 		return nil
 	}
-	if err := s.ensureBranchCreatedAt(run); err != nil {
-		return err
-	}
+	// Terminal status is independent from transcript persistence. Keep going so
+	// a sidecar failure cannot leave a failed run marked as running on disk.
+	branchErr := s.ensureBranchCreatedAt(run)
 	var sessionErr error
 	if run.Session != nil {
 		sessionErr = run.Session.Save(s.sessionPath(run.Ref))
@@ -623,7 +623,7 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	meta.Status = SubagentFailed
 	meta.UpdatedAt = time.Now().UTC()
 	run.Meta = meta
-	return errors.Join(sessionErr, s.saveMeta(meta))
+	return errors.Join(branchErr, sessionErr, s.saveMeta(meta))
 }
 
 // ensureBranchCreatedAt seeds the session list sidecar before the first

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -647,7 +647,6 @@ func (s *SubagentStore) ensureBranchCreatedAt(run *SubagentRun) error {
 	return SaveBranchMetaPreserveUpdated(path, BranchMeta{
 		ID:        BranchID(path),
 		CreatedAt: created,
-		UpdatedAt: created,
 	})
 }
 

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -592,6 +592,9 @@ func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 	if s.parentDestroyed(run) {
 		return nil
 	}
+	if err := s.ensureBranchCreatedAt(run); err != nil {
+		return err
+	}
 	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
 		return err
 	}
@@ -609,6 +612,9 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	if s.parentDestroyed(run) {
 		return nil
 	}
+	if err := s.ensureBranchCreatedAt(run); err != nil {
+		return err
+	}
 	var sessionErr error
 	if run.Session != nil {
 		sessionErr = run.Session.Save(s.sessionPath(run.Ref))
@@ -618,6 +624,31 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	meta.UpdatedAt = time.Now().UTC()
 	run.Meta = meta
 	return errors.Join(sessionErr, s.saveMeta(meta))
+}
+
+// ensureBranchCreatedAt seeds the session list sidecar before the first
+// transcript save. Subagent transcripts are written only on completion, so
+// Session.Save would otherwise backfill BranchMeta.CreatedAt with the save
+// moment (completion time). The real start time already lives on run.Meta.
+func (s *SubagentStore) ensureBranchCreatedAt(run *SubagentRun) error {
+	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	path := s.sessionPath(run.Ref)
+	if _, ok, err := LoadBranchMeta(path); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+	created := run.Meta.CreatedAt.UTC()
+	if created.IsZero() {
+		created = time.Now().UTC()
+	}
+	return SaveBranchMetaPreserveUpdated(path, BranchMeta{
+		ID:        BranchID(path),
+		CreatedAt: created,
+		UpdatedAt: created,
+	})
 }
 
 func (s *SubagentStore) LoadMeta(ref string) (SubagentMeta, error) {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -108,6 +108,32 @@ func TestSubagentStoreTerminalSaveKeepsBranchStartAndActivityTimes(t *testing.T)
 	}
 }
 
+func TestSubagentStoreSaveFailedPersistsTerminalMetaWhenBranchMetaIsCorrupt(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	run, err := store.PrepareFresh(testSubagentSpec(t, "explore"))
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	defer run.Release()
+	if err := store.MarkRunning(run); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	if err := os.WriteFile(BranchMetaPath(store.sessionPath(run.Ref)), []byte("{"), 0o600); err != nil {
+		t.Fatalf("corrupt branch meta: %v", err)
+	}
+
+	if err := store.SaveFailed(run); err == nil {
+		t.Fatal("SaveFailed unexpectedly succeeded with corrupt branch meta")
+	}
+	meta, err := store.LoadMeta(run.Ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentFailed {
+		t.Fatalf("persisted status = %q, want %q", meta.Status, SubagentFailed)
+	}
+}
+
 func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
 	store := NewSubagentStore(t.TempDir())
 	spec := testSubagentSpec(t, "review")

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -40,52 +40,71 @@ func TestSubagentStoreContinueLoadsSavedTranscript(t *testing.T) {
 	}
 }
 
-// TestSubagentStoreSaveCompletedKeepsBranchCreatedAt guards #7298: the session
-// list reads *.jsonl.meta CreatedAt, which used to be backfilled at first save
-// (= completion time) instead of the subagent start time on *.meta.json.
-func TestSubagentStoreSaveCompletedKeepsBranchCreatedAt(t *testing.T) {
-	store := NewSubagentStore(t.TempDir())
-	spec := testSubagentSpec(t, "explore")
-	run, err := store.PrepareFresh(spec)
-	if err != nil {
-		t.Fatalf("PrepareFresh: %v", err)
-	}
-	defer run.Release()
-	created := run.Meta.CreatedAt
-	if created.IsZero() {
-		t.Fatal("PrepareFresh left CreatedAt zero")
-	}
-	time.Sleep(25 * time.Millisecond)
-	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "explore repo"})
-	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
-	if err := store.SaveCompleted(run); err != nil {
-		t.Fatalf("SaveCompleted: %v", err)
-	}
-	if !run.Meta.UpdatedAt.After(created) {
-		t.Fatalf("UpdatedAt %v should be after CreatedAt %v", run.Meta.UpdatedAt, created)
-	}
-	branch, ok, err := LoadBranchMeta(filepath.Join(store.dir, run.Ref+".jsonl"))
-	if err != nil || !ok {
-		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
-	}
-	if !branch.CreatedAt.Equal(created) {
-		t.Fatalf("branch CreatedAt = %v, want subagent start %v", branch.CreatedAt, created)
-	}
-	ordered, err := ListSessionOrder(store.dir)
-	if err != nil {
-		t.Fatalf("ListSessionOrder: %v", err)
-	}
-	found := false
-	for _, info := range ordered {
-		if info.Path == filepath.Join(store.dir, run.Ref+".jsonl") {
-			found = true
-			if !info.CreatedAt.Equal(created) {
-				t.Fatalf("list CreatedAt = %v, want %v", info.CreatedAt, created)
+// TestSubagentStoreTerminalSaveKeepsBranchStartAndActivityTimes guards #7298:
+// CreatedAt must remain the subagent start time while LastActivityAt reflects
+// the later terminal save used for recency ordering.
+func TestSubagentStoreTerminalSaveKeepsBranchStartAndActivityTimes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		save func(*SubagentStore, *SubagentRun) error
+	}{
+		{name: "completed", save: (*SubagentStore).SaveCompleted},
+		{name: "failed", save: (*SubagentStore).SaveFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewSubagentStore(t.TempDir())
+			run, err := store.PrepareFresh(testSubagentSpec(t, "explore"))
+			if err != nil {
+				t.Fatalf("PrepareFresh: %v", err)
 			}
-		}
-	}
-	if !found {
-		t.Fatalf("ListSessionOrder missing ref %q: %+v", run.Ref, ordered)
+			defer run.Release()
+
+			created := time.Now().UTC().Add(-2 * time.Hour)
+			run.Meta.CreatedAt = created
+			run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "explore repo"})
+			run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+			beforeTerminalSave := time.Now().UTC()
+			if err := tc.save(store, run); err != nil {
+				t.Fatalf("terminal save: %v", err)
+			}
+
+			path := filepath.Join(store.dir, run.Ref+".jsonl")
+			branch, ok, err := LoadBranchMeta(path)
+			if err != nil || !ok {
+				t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+			}
+			if !branch.CreatedAt.Equal(created) {
+				t.Fatalf("branch CreatedAt = %v, want subagent start %v", branch.CreatedAt, created)
+			}
+			if branch.UpdatedAt.Before(beforeTerminalSave) || branch.UpdatedAt.After(run.Meta.UpdatedAt) {
+				t.Fatalf("branch UpdatedAt = %v, want terminal save in [%v, %v]", branch.UpdatedAt, beforeTerminalSave, run.Meta.UpdatedAt)
+			}
+
+			peerPath := filepath.Join(store.dir, "older-peer.jsonl")
+			peer := NewSession("system")
+			peer.Add(provider.Message{Role: provider.RoleUser, Content: "older work"})
+			if err := peer.Save(peerPath); err != nil {
+				t.Fatalf("save peer: %v", err)
+			}
+			if err := SaveBranchMetaPreserveUpdated(peerPath, BranchMeta{
+				ID:        BranchID(peerPath),
+				CreatedAt: created.Add(-time.Hour),
+				UpdatedAt: created.Add(time.Hour),
+			}); err != nil {
+				t.Fatalf("save peer meta: %v", err)
+			}
+
+			ordered, err := ListSessionOrder(store.dir)
+			if err != nil {
+				t.Fatalf("ListSessionOrder: %v", err)
+			}
+			if len(ordered) != 2 || ordered[0].Path != path {
+				t.Fatalf("session order = %+v, want terminally saved subagent first", ordered)
+			}
+			if !ordered[0].CreatedAt.Equal(created) || !ordered[0].LastActivityAt.Equal(branch.UpdatedAt) {
+				t.Fatalf("listed times = created %v activity %v, want %v / %v", ordered[0].CreatedAt, ordered[0].LastActivityAt, created, branch.UpdatedAt)
+			}
+		})
 	}
 }
 

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
@@ -36,6 +37,55 @@ func TestSubagentStoreContinueLoadsSavedTranscript(t *testing.T) {
 	}
 	if got := continued.Session.Snapshot(); len(got) != 3 || got[2].Content != "finding A" {
 		t.Fatalf("continued transcript = %+v, want saved messages", got)
+	}
+}
+
+// TestSubagentStoreSaveCompletedKeepsBranchCreatedAt guards #7298: the session
+// list reads *.jsonl.meta CreatedAt, which used to be backfilled at first save
+// (= completion time) instead of the subagent start time on *.meta.json.
+func TestSubagentStoreSaveCompletedKeepsBranchCreatedAt(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "explore")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	defer run.Release()
+	created := run.Meta.CreatedAt
+	if created.IsZero() {
+		t.Fatal("PrepareFresh left CreatedAt zero")
+	}
+	time.Sleep(25 * time.Millisecond)
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "explore repo"})
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	if !run.Meta.UpdatedAt.After(created) {
+		t.Fatalf("UpdatedAt %v should be after CreatedAt %v", run.Meta.UpdatedAt, created)
+	}
+	branch, ok, err := LoadBranchMeta(filepath.Join(store.dir, run.Ref+".jsonl"))
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+	}
+	if !branch.CreatedAt.Equal(created) {
+		t.Fatalf("branch CreatedAt = %v, want subagent start %v", branch.CreatedAt, created)
+	}
+	ordered, err := ListSessionOrder(store.dir)
+	if err != nil {
+		t.Fatalf("ListSessionOrder: %v", err)
+	}
+	found := false
+	for _, info := range ordered {
+		if info.Path == filepath.Join(store.dir, run.Ref+".jsonl") {
+			found = true
+			if !info.CreatedAt.Equal(created) {
+				t.Fatalf("list CreatedAt = %v, want %v", info.CreatedAt, created)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("ListSessionOrder missing ref %q: %+v", run.Ref, ordered)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Subagent transcripts are persisted only on completion/failure, so the first `*.jsonl.meta` write previously used `time.Now()` for `CreatedAt` (= completion time).
- Seed branch metadata from `run.Meta.CreatedAt` (set at spawn in `PrepareFresh`) before `Session.Save` while leaving `UpdatedAt` to reflect the terminal save used for recency ordering.
- Preserve `SaveFailed` failure atomicity: branch/transcript storage errors are still returned, but the independent subagent metadata is always advanced to `failed` instead of remaining `running`.

## Issues

Fixes #7298

## Verification

- `go test ./internal/agent -run 'TestSubagentStoreSaveFailedPersistsTerminalMetaWhenBranchMetaIsCorrupt|TestSubagentStoreTerminalSaveKeepsBranchStartAndActivityTimes' -count=20`
- `go test ./internal/agent -count=1`
- `go test -race ./internal/agent -count=1`
- `go vet ./internal/agent`
- `go test ./... -count=1`
- `git diff --check`

## Compatibility

| Field or surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| `BranchMeta.CreatedAt` / `UpdatedAt` | Existing sidecars keep the same JSON schema and continue to load; previously incorrect timestamps are not migrated. | Backward compatible |
| New terminal saves | Existing fields receive corrected start/activity values; no new enum or identifier format is introduced. | Older readers remain compatible |
| `SubagentMeta.Status` on save failure | Uses the existing `failed` value and preserves the previous terminal-status persistence contract. | Backward compatible |

## Cache impact

Cache-impact: none — session list metadata only; no provider-visible prompt/tool changes.
Cache-guard: N/A
System-prompt-review: N/A
