### PR TITLE
fix(cli): unify flag errors and remote connect ordering / 统一参数错误与远程连接顺序

### DIFF
--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -39,8 +39,8 @@ func acpCommand(args []string, version string) int {
 	networkFlag := fs.String("sandbox-network", "auto", "sandbox network policy: auto | on | off")
 	bashFlag := fs.String("sandbox-bash", "auto", "bash sandbox policy: auto | enforce")
 	workspaceOnly := fs.Bool("workspace-only", false, "ignore configured extra write roots and confine writes to the session cwd")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	plannerMode := strings.ToLower(strings.TrimSpace(*plannerFlag))
 	if plannerMode != "auto" && plannerMode != "off" {

--- a/internal/cli/bot.go
+++ b/internal/cli/bot.go
@@ -51,8 +51,8 @@ func botStart(args []string, version string) int {
 	dir := fs.String("dir", "", "工作目录")
 	model := fs.String("model", "", "模型名（空则用 default_model）")
 
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -191,8 +191,8 @@ func botDoctor(args []string) int {
 	jsonOut := fs.Bool("json", false, "JSON 格式输出")
 	deep := fs.Bool("deep", false, "执行更详细的本机诊断")
 
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 
 	cfg, err := loadBotCommandConfig()
@@ -481,8 +481,8 @@ Usage:
 func botWeixinLogin(args []string) int {
 	fs := flag.NewFlagSet("bot weixin-login", flag.ContinueOnError)
 	timeoutSeconds := fs.Int("timeout", 480, "登录超时时间（秒）")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 
 	cfg, err := loadBotCommandConfig()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -466,8 +466,8 @@ func runAgent(args []string, version string) int {
 	var allowedToolValues []string
 	fs.StringArrayVar(&allowedToolValues, "allowed-tools", nil, "comma or space-separated permission rules to allow")
 	fs.StringArrayVar(&allowedToolValues, "allowedTools", nil, "alias for --allowed-tools")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	resolvedPermissionMode, err := resolveRunPermissionMode(*permissionMode, *autoApprove, fs.Changed("permission-mode"))
 	if err != nil {
@@ -755,8 +755,8 @@ func runServe(args []string) int {
 	portFile := fs.String("port-file", "", "write the actual bound listen address (host:port) to this file after binding")
 	tokenFile := fs.String("token-file", "", "read the auth=token pre-shared token from this file (overrides --token; keeps the secret out of argv)")
 	pidFile := fs.String("pid-file", "", "write the server process id to this file")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	profile, err := parseRuntimeProfile(*profileFlag)
 	if err != nil {
@@ -973,8 +973,8 @@ func chatREPL(args []string, version string) int {
 	var allowedToolValues []string
 	fs.StringArrayVar(&allowedToolValues, "allowed-tools", nil, "comma or space-separated permission rules to allow")
 	fs.StringArrayVar(&allowedToolValues, "allowedTools", nil, "alias for --allowed-tools")
-	if err := fs.Parse(normalizeOptionalResumeArg(args)); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, normalizeOptionalResumeArg(args)); !ok {
+		return code
 	}
 	allowedTools, err := splitAllowedToolRules(allowedToolValues)
 	if err != nil {
@@ -2268,8 +2268,8 @@ func configCommand(args []string) int {
 func configCurrencyCommand(args []string) int {
 	fs := flag.NewFlagSet("config currency", flag.ContinueOnError)
 	local := fs.Bool("local", false, "unsupported; pricing currency is user-level only")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if *local {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "currency is user-level only; --local is not supported")
@@ -2342,8 +2342,8 @@ var (
 
 func configTelemetryCommand(args []string) int {
 	fs := flag.NewFlagSet("config telemetry", flag.ContinueOnError)
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	rest := fs.Args()
 	if len(rest) > 1 {
@@ -2391,8 +2391,8 @@ func configTelemetryCommand(args []string) int {
 func configAutoPlanCompatibilityCommand(args []string) int {
 	fs := flag.NewFlagSet("config auto-plan", flag.ContinueOnError)
 	local := fs.Bool("local", false, "unsupported; automatic plan mode is retired")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if *local {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "auto-plan is user-level only; --local is not supported")
@@ -2419,8 +2419,8 @@ func configAutoPlanCompatibilityCommand(args []string) int {
 func configReasoningLanguageCommand(args []string) int {
 	fs := flag.NewFlagSet("config reasoning-language", flag.ContinueOnError)
 	local := fs.Bool("local", false, "write ./reasonix.toml instead of the user config")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	rest := fs.Args()
 	if len(rest) > 1 {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -293,16 +293,19 @@ func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 }
 
 func TestRunDispatchesACPLongFlagAlias(t *testing.T) {
-	errOut := captureStderr(t, func() {
+	out, errOut := captureCLIOutput(t, func() {
 		if rc := Run([]string{"--acp", "-h"}, "test-version"); rc != 0 {
 			t.Fatalf("Run --acp -h rc = %d, want 0", rc)
 		}
 	})
-	if !strings.Contains(errOut, "Usage of acp:") {
-		t.Fatalf("--acp should dispatch to the ACP command, got stderr:\n%s", errOut)
+	if !strings.Contains(out, "Usage of acp:") {
+		t.Fatalf("--acp should dispatch to the ACP command, got stdout:\n%s", out)
 	}
-	if strings.Contains(errOut, "unknown command") {
-		t.Fatalf("--acp should not be treated as an unknown command:\n%s", errOut)
+	if errOut != "" {
+		t.Fatalf("--acp help wrote stderr: %q", errOut)
+	}
+	if strings.Contains(out, "unknown command") {
+		t.Fatalf("--acp should not be treated as an unknown command:\n%s", out)
 	}
 }
 
@@ -423,35 +426,58 @@ func TestRunReportsFlagParseErrors(t *testing.T) {
 func TestSubcommandHelpReturnsSuccess(t *testing.T) {
 	isolateCLIConfigHome(t)
 
-	for _, args := range [][]string{
-		{"run", "--help"},
-		{"chat", "--help"},
-		{"serve", "--help"},
-		{"upgrade", "--help"},
-	} {
-		stderr := captureStderr(t, func() {
-			if rc := Run(args, "test-version"); rc != 0 {
-				t.Fatalf("Run(%q) rc = %d, want 0", args, rc)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "run", args: []string{"run", "--help"}, want: "Usage of run:"},
+		{name: "chat", args: []string{"chat", "--help"}, want: "Usage of reasonix:"},
+		{name: "serve", args: []string{"serve", "--help"}, want: "Usage of serve:"},
+		{name: "upgrade", args: []string{"upgrade", "--help"}, want: "Usage of upgrade:"},
+		{name: "remote connect", args: []string{"remote", "connect", "--help"}, want: "Usage of remote connect:"},
+		{name: "remote add before name", args: []string{"remote", "add", "--help"}, want: remoteAddUsage},
+		{name: "remote add before target", args: []string{"remote", "add", "box", "--help"}, want: remoteAddUsage},
+		{name: "remote serve before action", args: []string{"remote", "serve", "--help"}, want: remoteServeUsage},
+		{name: "remote serve before name", args: []string{"remote", "serve", "start", "--help"}, want: remoteServeUsage},
+		{name: "subagent create", args: []string{"subagent", "create", "--help"}, want: subagentUsageText},
+		{name: "subagent edit", args: []string{"subagent", "edit", "--help"}, want: subagentUsageText},
+		{name: "subagent delete", args: []string{"subagent", "delete", "--help"}, want: subagentUsageText},
+		{name: "subagent try", args: []string{"subagent", "try", "--help"}, want: subagentUsageText},
+		{name: "subagent run", args: []string{"subagent", "run", "--help"}, want: subagentUsageText},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr := captureCLIOutput(t, func() {
+				if rc := Run(tt.args, "test-version"); rc != 0 {
+					t.Fatalf("Run(%q) rc = %d, want 0", tt.args, rc)
+				}
+			})
+			if !strings.Contains(stdout, tt.want) {
+				t.Fatalf("Run(%q) help missing %q:\n%s", tt.args, tt.want, stdout)
+			}
+			if stderr != "" {
+				t.Fatalf("Run(%q) help wrote stderr: %q", tt.args, stderr)
+			}
+			if strings.Contains(stdout, "help requested") {
+				t.Fatalf("Run(%q) reported help as an error:\n%s", tt.args, stdout)
 			}
 		})
-		if !strings.Contains(stderr, "Usage of") {
-			t.Fatalf("Run(%q) help missing usage:\n%s", args, stderr)
-		}
-		if strings.Contains(stderr, "help requested") {
-			t.Fatalf("Run(%q) reported help as an error:\n%s", args, stderr)
-		}
 	}
 }
 
 func TestRunPrintAliasDispatchesRunFlags(t *testing.T) {
 	isolateCLIConfigHome(t)
-	errOut := captureStderr(t, func() {
+	out, errOut := captureCLIOutput(t, func() {
 		if rc := Run([]string{"-p", "-h"}, "test-version"); rc != 0 {
 			t.Fatalf("Run(-p -h) rc = %d, want 0", rc)
 		}
 	})
-	if !strings.Contains(errOut, "Usage of run:") {
-		t.Fatalf("-p should dispatch to one-shot run flags, got:\n%s", errOut)
+	if !strings.Contains(out, "Usage of run:") {
+		t.Fatalf("-p should dispatch to one-shot run flags, got:\n%s", out)
+	}
+	if errOut != "" {
+		t.Fatalf("-p help wrote stderr: %q", errOut)
 	}
 }
 
@@ -466,13 +492,16 @@ func TestRunPrintFlagAfterLeadingFlagsDispatchesRun(t *testing.T) {
 		t.Fatal("print flag after leading flags must not route to the interactive session")
 		return 0
 	}
-	errOut := captureStderr(t, func() {
+	out, errOut := captureCLIOutput(t, func() {
 		if rc := Run([]string{"--model", "x", "-p", "-h"}, "test-version"); rc != 0 {
 			t.Fatalf("Run(--model x -p -h) rc = %d, want 0", rc)
 		}
 	})
-	if !strings.Contains(errOut, "Usage of run:") {
-		t.Fatalf("--model x -p should dispatch to one-shot run flags, got:\n%s", errOut)
+	if !strings.Contains(out, "Usage of run:") {
+		t.Fatalf("--model x -p should dispatch to one-shot run flags, got:\n%s", out)
+	}
+	if errOut != "" {
+		t.Fatalf("--model x -p help wrote stderr: %q", errOut)
 	}
 }
 
@@ -1976,6 +2005,14 @@ func captureStderr(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+func captureCLIOutput(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	stderr = captureStderr(t, func() {
+		stdout = captureStdout(t, fn)
+	})
+	return stdout, stderr
 }
 
 func TestProvidersWithMissingKeysOnlyReferenced(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -294,8 +294,8 @@ func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 
 func TestRunDispatchesACPLongFlagAlias(t *testing.T) {
 	errOut := captureStderr(t, func() {
-		if rc := Run([]string{"--acp", "-h"}, "test-version"); rc != 2 {
-			t.Fatalf("Run --acp -h rc = %d, want 2", rc)
+		if rc := Run([]string{"--acp", "-h"}, "test-version"); rc != 0 {
+			t.Fatalf("Run --acp -h rc = %d, want 0", rc)
 		}
 	})
 	if !strings.Contains(errOut, "Usage of acp:") {
@@ -388,11 +388,66 @@ func TestRunRoutesBareInteractiveFlagsToSession(t *testing.T) {
 	}
 }
 
+func TestRunReportsFlagParseErrors(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "run unknown flag", args: []string{"run", "--unknown"}, want: "unknown flag: --unknown"},
+		{name: "run invalid value", args: []string{"run", "--max-steps=invalid"}, want: "invalid argument \"invalid\" for \"--max-steps\" flag"},
+		{name: "run missing value", args: []string{"run", "--model"}, want: "flag needs an argument: --model"},
+		{name: "chat unknown flag", args: []string{"chat", "--unknown"}, want: "unknown flag: --unknown"},
+		{name: "serve unknown flag", args: []string{"serve", "--unknown"}, want: "flag provided but not defined: -unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stderr := captureStderr(t, func() {
+				if rc := Run(tt.args, "test-version"); rc != 2 {
+					t.Fatalf("Run(%q) rc = %d, want 2", tt.args, rc)
+				}
+			})
+			if !strings.Contains(stderr, tt.want) {
+				t.Fatalf("Run(%q) stderr = %q, want %q", tt.args, stderr, tt.want)
+			}
+			if strings.Contains(stderr, "Usage of") {
+				t.Fatalf("Run(%q) should print a concise error, got:\n%s", tt.args, stderr)
+			}
+		})
+	}
+}
+
+func TestSubcommandHelpReturnsSuccess(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	for _, args := range [][]string{
+		{"run", "--help"},
+		{"chat", "--help"},
+		{"serve", "--help"},
+		{"upgrade", "--help"},
+	} {
+		stderr := captureStderr(t, func() {
+			if rc := Run(args, "test-version"); rc != 0 {
+				t.Fatalf("Run(%q) rc = %d, want 0", args, rc)
+			}
+		})
+		if !strings.Contains(stderr, "Usage of") {
+			t.Fatalf("Run(%q) help missing usage:\n%s", args, stderr)
+		}
+		if strings.Contains(stderr, "help requested") {
+			t.Fatalf("Run(%q) reported help as an error:\n%s", args, stderr)
+		}
+	}
+}
+
 func TestRunPrintAliasDispatchesRunFlags(t *testing.T) {
 	isolateCLIConfigHome(t)
 	errOut := captureStderr(t, func() {
-		if rc := Run([]string{"-p", "-h"}, "test-version"); rc != 2 {
-			t.Fatalf("Run(-p -h) rc = %d, want 2", rc)
+		if rc := Run([]string{"-p", "-h"}, "test-version"); rc != 0 {
+			t.Fatalf("Run(-p -h) rc = %d, want 0", rc)
 		}
 	})
 	if !strings.Contains(errOut, "Usage of run:") {
@@ -412,8 +467,8 @@ func TestRunPrintFlagAfterLeadingFlagsDispatchesRun(t *testing.T) {
 		return 0
 	}
 	errOut := captureStderr(t, func() {
-		if rc := Run([]string{"--model", "x", "-p", "-h"}, "test-version"); rc != 2 {
-			t.Fatalf("Run(--model x -p -h) rc = %d, want 2", rc)
+		if rc := Run([]string{"--model", "x", "-p", "-h"}, "test-version"); rc != 0 {
+			t.Fatalf("Run(--model x -p -h) rc = %d, want 0", rc)
 		}
 	})
 	if !strings.Contains(errOut, "Usage of run:") {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -29,8 +29,8 @@ func doctorCommand(args []string, version string) int {
 	}
 	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
 	jsonOut := fs.Bool("json", false, "print diagnostics as JSON")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 
 	report := doctor.Collect(doctor.Options{Version: version})
@@ -53,8 +53,8 @@ func doctorRepairCommand(args []string) int {
 	apply := fs.Bool("apply", false, "quarantine invalid config and restore the last-known-good global snapshot")
 	includeProject := fs.Bool("project", false, "allow --apply to quarantine an invalid project reasonix.toml")
 	jsonOut := fs.Bool("json", false, "print result as JSON")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(os.Stderr, "usage: reasonix doctor repair [--root PATH] [--apply] [--project] [--json]")
@@ -167,8 +167,8 @@ func doctorRedactSessionsCommand(args []string) int {
 	dryRun := fs.Bool("dry-run", false, "show how many session files would be redacted without writing")
 	jsonOut := fs.Bool("json", false, "print result as JSON")
 	fs.Var(&dirs, "dir", "session directory to scan; repeat to scan multiple directories")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(os.Stderr, "usage: reasonix doctor redact-sessions [--dry-run] [--json] [--dir PATH]")

--- a/internal/cli/doctor_capabilities.go
+++ b/internal/cli/doctor_capabilities.go
@@ -18,8 +18,8 @@ func doctorCapabilitiesCommand(args []string) int {
 	jsonOut := fs.Bool("json", false, "print a single JSON object to stdout")
 	live := fs.Bool("live", false, "start automatic MCP servers in an isolated Host (may network)")
 	timeoutStr := fs.String("timeout", "", "per-server live probe timeout (1s-60s; requires --live; default 5s)")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(os.Stderr, "usage: reasonix doctor capabilities [--root PATH] [--json] [--live] [--timeout 5s]")

--- a/internal/cli/flag_parse.go
+++ b/internal/cli/flag_parse.go
@@ -18,22 +18,53 @@ type commandFlagSet interface {
 	SetOutput(io.Writer)
 }
 
-// parseCommandFlags gives standard flag and pflag commands the same public
-// behavior: help is successful, while malformed input prints one concise error
-// and returns the conventional command-line usage exit code.
-func parseCommandFlags(fs commandFlagSet, args []string) (exitCode int, proceed bool) {
+// commandFlagError keeps parse output attached to the returned error so pure
+// syntax parsers can defer user-facing reporting to their command boundary.
+type commandFlagError struct {
+	err         error
+	output      io.Writer
+	parseOutput string
+}
+
+func (e *commandFlagError) Error() string { return e.err.Error() }
+func (e *commandFlagError) Unwrap() error { return e.err }
+
+func parseCommandFlagSet(fs commandFlagSet, args []string) error {
 	output := fs.Output()
 	var parseOutput bytes.Buffer
 	fs.SetOutput(&parseOutput)
 	err := fs.Parse(args)
 	fs.SetOutput(output)
 	if err == nil {
-		return 0, true
+		return nil
 	}
-	if errors.Is(err, flag.ErrHelp) || errors.Is(err, pflag.ErrHelp) {
-		_, _ = io.Copy(output, &parseOutput)
+	return &commandFlagError{err: err, output: output, parseOutput: parseOutput.String()}
+}
+
+func reportCommandFlagError(err error) (exitCode int, handled bool) {
+	var parseErr *commandFlagError
+	if !errors.As(err, &parseErr) {
 		return 0, false
 	}
-	fmt.Fprintln(output, i18n.M.ErrorPrefix, err)
+	if errors.Is(parseErr, flag.ErrHelp) || errors.Is(parseErr, pflag.ErrHelp) {
+		_, _ = io.WriteString(parseErr.output, parseErr.parseOutput)
+		return 0, true
+	}
+	fmt.Fprintln(parseErr.output, i18n.M.ErrorPrefix, parseErr.err)
+	return 2, true
+}
+
+// parseCommandFlags gives standard flag and pflag commands the same public
+// behavior: help is successful, while malformed input prints one concise error
+// and returns the conventional command-line usage exit code.
+func parseCommandFlags(fs commandFlagSet, args []string) (exitCode int, proceed bool) {
+	err := parseCommandFlagSet(fs, args)
+	if err == nil {
+		return 0, true
+	}
+	if code, ok := reportCommandFlagError(err); ok {
+		return code, false
+	}
+	fmt.Fprintln(fs.Output(), i18n.M.ErrorPrefix, err)
 	return 2, false
 }

--- a/internal/cli/flag_parse.go
+++ b/internal/cli/flag_parse.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"reasonix/internal/i18n"
+
+	"github.com/spf13/pflag"
+)
+
+type commandFlagSet interface {
+	Output() io.Writer
+	Parse([]string) error
+	SetOutput(io.Writer)
+}
+
+// parseCommandFlags gives standard flag and pflag commands the same public
+// behavior: help is successful, while malformed input prints one concise error
+// and returns the conventional command-line usage exit code.
+func parseCommandFlags(fs commandFlagSet, args []string) (exitCode int, proceed bool) {
+	output := fs.Output()
+	var parseOutput bytes.Buffer
+	fs.SetOutput(&parseOutput)
+	err := fs.Parse(args)
+	fs.SetOutput(output)
+	if err == nil {
+		return 0, true
+	}
+	if errors.Is(err, flag.ErrHelp) || errors.Is(err, pflag.ErrHelp) {
+		_, _ = io.Copy(output, &parseOutput)
+		return 0, false
+	}
+	fmt.Fprintln(output, i18n.M.ErrorPrefix, err)
+	return 2, false
+}

--- a/internal/cli/flag_parse.go
+++ b/internal/cli/flag_parse.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 
 	"reasonix/internal/i18n"
 
@@ -29,6 +30,21 @@ type commandFlagError struct {
 func (e *commandFlagError) Error() string { return e.err.Error() }
 func (e *commandFlagError) Unwrap() error { return e.err }
 
+// commandHelpRequested reports explicit help flags in the positional prefix a
+// command validates before constructing its FlagSet. Once parsing starts, the
+// FlagSet's ErrHelp path remains the source of truth.
+func commandHelpRequested(args []string, positionalPrefix int) bool {
+	if positionalPrefix > len(args) {
+		positionalPrefix = len(args)
+	}
+	for _, arg := range args[:positionalPrefix] {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
 func parseCommandFlagSet(fs commandFlagSet, args []string) error {
 	output := fs.Output()
 	var parseOutput bytes.Buffer
@@ -47,7 +63,7 @@ func reportCommandFlagError(err error) (exitCode int, handled bool) {
 		return 0, false
 	}
 	if errors.Is(parseErr, flag.ErrHelp) || errors.Is(parseErr, pflag.ErrHelp) {
-		_, _ = io.WriteString(parseErr.output, parseErr.parseOutput)
+		_, _ = io.WriteString(os.Stdout, parseErr.parseOutput)
 		return 0, true
 	}
 	fmt.Fprintln(parseErr.output, i18n.M.ErrorPrefix, parseErr.err)

--- a/internal/cli/flag_parse_test.go
+++ b/internal/cli/flag_parse_test.go
@@ -100,17 +100,20 @@ func TestParseCommandFlagsTreatsHelpAsSuccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var code int
 			var proceed bool
-			stderr := captureStderr(t, func() {
+			stdout, stderr := captureCLIOutput(t, func() {
 				code, proceed = parseCommandFlags(tt.newFlagSet(), []string{"--help"})
 			})
 			if code != 0 || proceed {
 				t.Fatalf("parseCommandFlags(--help) = (%d, %v), want (0, false)", code, proceed)
 			}
-			if !strings.Contains(stderr, "Usage of test:") || !strings.Contains(stderr, "model name") {
-				t.Fatalf("help output missing usage:\n%s", stderr)
+			if !strings.Contains(stdout, "Usage of test:") || !strings.Contains(stdout, "model name") {
+				t.Fatalf("help output missing usage:\n%s", stdout)
 			}
-			if strings.Contains(stderr, "Error:") || strings.Contains(stderr, "flag: help requested") {
-				t.Fatalf("help should not be reported as an error:\n%s", stderr)
+			if stderr != "" {
+				t.Fatalf("help wrote stderr: %q", stderr)
+			}
+			if strings.Contains(stdout, "Error:") || strings.Contains(stdout, "flag: help requested") {
+				t.Fatalf("help should not be reported as an error:\n%s", stdout)
 			}
 		})
 	}

--- a/internal/cli/flag_parse_test.go
+++ b/internal/cli/flag_parse_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestParseCommandFlagsReportsErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		newFlagSet func() commandFlagSet
+		args       []string
+		want       string
+	}{
+		{
+			name: "unknown pflag",
+			newFlagSet: func() commandFlagSet {
+				return pflag.NewFlagSet("test", pflag.ContinueOnError)
+			},
+			args: []string{"--unknown"},
+			want: "unknown flag: --unknown",
+		},
+		{
+			name: "invalid pflag value",
+			newFlagSet: func() commandFlagSet {
+				fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				fs.Int("count", 0, "item count")
+				return fs
+			},
+			args: []string{"--count=invalid"},
+			want: "invalid argument \"invalid\" for \"--count\" flag",
+		},
+		{
+			name: "missing pflag value",
+			newFlagSet: func() commandFlagSet {
+				fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				fs.String("model", "", "model name")
+				return fs
+			},
+			args: []string{"--model"},
+			want: "flag needs an argument: --model",
+		},
+		{
+			name: "unknown standard flag",
+			newFlagSet: func() commandFlagSet {
+				return flag.NewFlagSet("test", flag.ContinueOnError)
+			},
+			args: []string{"--unknown"},
+			want: "flag provided but not defined: -unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var code int
+			var proceed bool
+			stderr := captureStderr(t, func() {
+				code, proceed = parseCommandFlags(tt.newFlagSet(), tt.args)
+			})
+			if code != 2 || proceed {
+				t.Fatalf("parseCommandFlags(%q) = (%d, %v), want (2, false)", tt.args, code, proceed)
+			}
+			if !strings.Contains(stderr, tt.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, tt.want)
+			}
+			if strings.Contains(stderr, "Usage of") {
+				t.Fatalf("parse error should be concise, got usage in stderr:\n%s", stderr)
+			}
+		})
+	}
+}
+
+func TestParseCommandFlagsTreatsHelpAsSuccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		newFlagSet func() commandFlagSet
+	}{
+		{
+			name: "pflag",
+			newFlagSet: func() commandFlagSet {
+				fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				fs.String("model", "", "model name")
+				return fs
+			},
+		},
+		{
+			name: "standard flag",
+			newFlagSet: func() commandFlagSet {
+				fs := flag.NewFlagSet("test", flag.ContinueOnError)
+				fs.String("model", "", "model name")
+				return fs
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var code int
+			var proceed bool
+			stderr := captureStderr(t, func() {
+				code, proceed = parseCommandFlags(tt.newFlagSet(), []string{"--help"})
+			})
+			if code != 0 || proceed {
+				t.Fatalf("parseCommandFlags(--help) = (%d, %v), want (0, false)", code, proceed)
+			}
+			if !strings.Contains(stderr, "Usage of test:") || !strings.Contains(stderr, "model name") {
+				t.Fatalf("help output missing usage:\n%s", stderr)
+			}
+			if strings.Contains(stderr, "Error:") || strings.Contains(stderr, "flag: help requested") {
+				t.Fatalf("help should not be reported as an error:\n%s", stderr)
+			}
+		})
+	}
+}
+
+func TestParseCommandFlagsSuccessProceedsSilently(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	name := fs.String("name", "", "name")
+	var code int
+	var proceed bool
+	stderr := captureStderr(t, func() {
+		code, proceed = parseCommandFlags(fs, []string{"--name", "reasonix"})
+	})
+	if code != 0 || !proceed || *name != "reasonix" {
+		t.Fatalf("parseCommandFlags success = (%d, %v, %q), want (0, true, reasonix)", code, proceed, *name)
+	}
+	if stderr != "" {
+		t.Fatalf("successful parse wrote stderr: %q", stderr)
+	}
+}

--- a/internal/cli/remote.go
+++ b/internal/cli/remote.go
@@ -93,11 +93,17 @@ func editUserConfig(mutate func(*config.Config) error) error {
 	return cfg.SaveTo(path)
 }
 
+const remoteAddUsage = "usage: reasonix remote add <name> [user@]host[:port] [flags]"
+
 func remoteAddCLI(args []string) int {
 	// Positionals come first (name, target); Go's flag package stops at the
 	// first non-flag argument, so the flags are parsed from what follows.
+	if commandHelpRequested(args, 2) {
+		fmt.Fprintln(os.Stdout, remoteAddUsage)
+		return 0
+	}
 	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix remote add <name> [user@]host[:port] [flags]")
+		fmt.Fprintln(os.Stderr, remoteAddUsage)
 		return 2
 	}
 	name, target := args[0], args[1]

--- a/internal/cli/remote.go
+++ b/internal/cli/remote.go
@@ -109,8 +109,8 @@ func remoteAddCLI(args []string) int {
 	serveInstall := fs.String("serve-install", "auto", "remote CLI install strategy: auto|npm|upload|never")
 	passphraseEnv := fs.String("passphrase-env", "", "env var name holding the key passphrase")
 	passwordEnv := fs.String("password-env", "", "env var name holding the login password")
-	if err := fs.Parse(args[2:]); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args[2:]); !ok {
+		return code
 	}
 	user, host, port, err := remote.ParseTarget(target)
 	if err != nil {
@@ -214,8 +214,8 @@ func remoteRemoveCLI(args []string) int {
 func remoteImportCLI(args []string) int {
 	fs := newFlagSet("remote import")
 	all := fs.Bool("all", false, "import every concrete ~/.ssh/config alias")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	src, err := remote.LoadUserSSHConfig()
 	if err != nil {

--- a/internal/cli/remote_cmd_test.go
+++ b/internal/cli/remote_cmd_test.go
@@ -224,3 +224,114 @@ func TestSplitHostPath(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRemoteConnectSyntaxFlagOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		openAlias bool
+		wantName  string
+		wantOpen  bool
+		wantWS    string
+		wantPort  int
+		wantErr   bool
+	}{
+		{
+			name:     "name then flags (documented / GUIDE order)",
+			args:     []string{"gpu-box", "--open", "--workspace", "/tmp/ws", "--local-port", "8080"},
+			wantName: "gpu-box",
+			wantOpen: true,
+			wantWS:   "/tmp/ws",
+			wantPort: 8080,
+		},
+		{
+			name:     "flags then name",
+			args:     []string{"--open", "--workspace", "/tmp/ws", "gpu-box"},
+			wantName: "gpu-box",
+			wantOpen: true,
+			wantWS:   "/tmp/ws",
+		},
+		{
+			name:     "single-dash open before name",
+			args:     []string{"-open", "gpu-box"},
+			wantName: "gpu-box",
+			wantOpen: true,
+		},
+		{
+			name:     "name only",
+			args:     []string{"gpu-box"},
+			wantName: "gpu-box",
+		},
+		{
+			name:      "open alias sets open without flag",
+			args:      []string{"gpu-box"},
+			openAlias: true,
+			wantName:  "gpu-box",
+			wantOpen:  true,
+		},
+		{
+			name:    "missing name",
+			args:    []string{"--open"},
+			wantErr: true,
+		},
+		{
+			name:    "extra positional after name-first flags",
+			args:    []string{"gpu-box", "extra"},
+			wantErr: true,
+		},
+		{
+			name:    "two names after flags",
+			args:    []string{"--open", "a", "b"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRemoteConnectSyntax(tt.args, tt.openAlias)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.name != tt.wantName || got.open != tt.wantOpen || got.workspace != tt.wantWS || got.localPort != tt.wantPort {
+				t.Fatalf("got %+v, want name=%q open=%v workspace=%q localPort=%d", got, tt.wantName, tt.wantOpen, tt.wantWS, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestRemoteConnectSyntaxUsesSharedFlagContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantCode int
+		want     string
+		noUsage  bool
+	}{
+		{name: "help before name", args: []string{"connect", "--help"}, wantCode: 0, want: "Usage of remote connect:"},
+		{name: "help after name", args: []string{"connect", "gpu-box", "--help"}, wantCode: 0, want: "Usage of remote connect:"},
+		{name: "unknown flag before name", args: []string{"connect", "--unknown", "gpu-box"}, wantCode: 2, want: "flag provided but not defined: -unknown", noUsage: true},
+		{name: "unknown flag after name", args: []string{"connect", "gpu-box", "--unknown"}, wantCode: 2, want: "flag provided but not defined: -unknown", noUsage: true},
+		{name: "missing name", args: []string{"connect", "--open"}, wantCode: 2, want: remoteConnectUsage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stderr := captureStderr(t, func() {
+				if code := remoteConnectCLI(tt.args, "test-version"); code != tt.wantCode {
+					t.Fatalf("remoteConnectCLI(%q) = %d, want %d", tt.args, code, tt.wantCode)
+				}
+			})
+			if !strings.Contains(stderr, tt.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, tt.want)
+			}
+			if tt.noUsage && strings.Contains(stderr, "Usage of") {
+				t.Fatalf("parse error should be concise, got usage:\n%s", stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/remote_cmd_test.go
+++ b/internal/cli/remote_cmd_test.go
@@ -321,16 +321,25 @@ func TestRemoteConnectSyntaxUsesSharedFlagContract(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stderr := captureStderr(t, func() {
+			stdout, stderr := captureCLIOutput(t, func() {
 				if code := remoteConnectCLI(tt.args, "test-version"); code != tt.wantCode {
 					t.Fatalf("remoteConnectCLI(%q) = %d, want %d", tt.args, code, tt.wantCode)
 				}
 			})
-			if !strings.Contains(stderr, tt.want) {
-				t.Fatalf("stderr = %q, want %q", stderr, tt.want)
+			output := stderr
+			if tt.wantCode == 0 {
+				output = stdout
+				if stderr != "" {
+					t.Fatalf("help wrote stderr: %q", stderr)
+				}
+			} else if stdout != "" {
+				t.Fatalf("error wrote stdout: %q", stdout)
 			}
-			if tt.noUsage && strings.Contains(stderr, "Usage of") {
-				t.Fatalf("parse error should be concise, got usage:\n%s", stderr)
+			if !strings.Contains(output, tt.want) {
+				t.Fatalf("output = %q, want %q", output, tt.want)
+			}
+			if tt.noUsage && strings.Contains(output, "Usage of") {
+				t.Fatalf("parse error should be concise, got usage:\n%s", output)
 			}
 		})
 	}

--- a/internal/cli/remote_connect.go
+++ b/internal/cli/remote_connect.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -127,27 +128,78 @@ func terminalHostKeyPrompt(_ context.Context, q remote.HostKeyQuestion) (bool, e
 	return answer == "y" || answer == "yes", nil
 }
 
-// remoteConnectCLI runs a foreground supervisor: connect, bootstrap serve,
-// forward the serve port and configured forwards, and hold the tunnel until
-// Ctrl-C. The remote serve keeps running after disconnect.
-func remoteConnectCLI(args []string, version string) int {
-	// args[0] is "connect" or "open".
-	openAlias := args[0] == "open"
+// remoteConnectSyntax is the parsed form of `reasonix remote connect|open …`.
+type remoteConnectSyntax struct {
+	name        string
+	workspace   string
+	localPort   int
+	noServe     bool
+	open        bool
+	forwardOnly bool
+}
+
+const remoteConnectUsage = "usage: reasonix remote connect <name> [flags]"
+
+// parseRemoteConnectSyntax accepts both documented orders:
+//
+//	reasonix remote connect <name> [flags]
+//	reasonix remote connect [flags] <name>
+//
+// Go's flag package stops at the first positional, so `<name> --open` used to
+// fail even though help/GUIDE show that form. We keep stdlib flags (so `-open`
+// still works) and only special-case a leading host name.
+func parseRemoteConnectSyntax(args []string, openAlias bool) (remoteConnectSyntax, error) {
 	fs := newFlagSet("remote connect")
 	workspace := fs.String("workspace", "", "remote workspace directory")
 	localPort := fs.Int("local-port", 0, "local port to bind for the serve tunnel (0 = auto)")
 	noServe := fs.Bool("no-serve", false, "only establish forwards; do not bootstrap serve")
 	open := fs.Bool("open", openAlias, "print/open the serve URL")
 	forwardOnly := fs.Bool("forward-only", false, "apply configured forwards only; no serve")
-	if code, ok := parseCommandFlags(fs, args[1:]); !ok {
-		return code
+
+	var name string
+	flagArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		name = args[0]
+		flagArgs = args[1:]
+	}
+	if err := parseCommandFlagSet(fs, flagArgs); err != nil {
+		return remoteConnectSyntax{}, err
 	}
 	rest := fs.Args()
-	if len(rest) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix remote connect <name> [flags]")
+	switch {
+	case name != "" && len(rest) == 0:
+		// name-first: connect <name> [flags]
+	case name == "" && len(rest) == 1:
+		// flags-first: connect [flags] <name>
+		name = rest[0]
+	default:
+		return remoteConnectSyntax{}, errors.New(remoteConnectUsage)
+	}
+	return remoteConnectSyntax{
+		name:        name,
+		workspace:   *workspace,
+		localPort:   *localPort,
+		noServe:     *noServe,
+		open:        *open,
+		forwardOnly: *forwardOnly,
+	}, nil
+}
+
+// remoteConnectCLI runs a foreground supervisor: connect, bootstrap serve,
+// forward the serve port and configured forwards, and hold the tunnel until
+// Ctrl-C. The remote serve keeps running after disconnect.
+func remoteConnectCLI(args []string, version string) int {
+	// args[0] is "connect" or "open".
+	openAlias := args[0] == "open"
+	syntax, err := parseRemoteConnectSyntax(args[1:], openAlias)
+	if err != nil {
+		if code, ok := reportCommandFlagError(err); ok {
+			return code
+		}
+		fmt.Fprintln(os.Stderr, err)
 		return 2
 	}
-	name := rest[0]
+	name := syntax.name
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -155,7 +207,7 @@ func remoteConnectCLI(args []string, version string) int {
 		return 1
 	}
 	entry, _ := cfg.RemoteHost(name)
-	ws := *workspace
+	ws := syntax.workspace
 	if ws == "" {
 		ws = entry.Workspace
 	}
@@ -198,7 +250,7 @@ func remoteConnectCLI(args []string, version string) int {
 		fmt.Fprintf(os.Stderr, "%s %v\n", i18n.M.ErrorPrefix, err)
 	}
 
-	if !*noServe && !*forwardOnly {
+	if !syntax.noServe && !syntax.forwardOnly {
 		res, err := bootstrap.EnsureServe(ctx, client, bootstrap.Options{
 			Workspace:      ws,
 			Install:        entry.ServeInstallMode(),
@@ -216,13 +268,13 @@ func remoteConnectCLI(args []string, version string) int {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 			return 1
 		}
-		localURL, ferr := forwardServe(client, res.State.Addr, *localPort, res.Token)
+		localURL, ferr := forwardServe(client, res.State.Addr, syntax.localPort, res.Token)
 		if ferr != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, ferr)
 			return 1
 		}
 		fmt.Printf(i18n.M.RemoteServeReadyFmt+"\n", localURL)
-		if *open {
+		if syntax.open {
 			_ = openInBrowser(localURL)
 		}
 	}

--- a/internal/cli/remote_connect.go
+++ b/internal/cli/remote_connect.go
@@ -349,10 +349,16 @@ func fetchRemoteCLIBinary(ctx context.Context, version, goos, goarch string) ([]
 	return releaseasset.DownloadCLI(ctx, client, version, goos, goarch)
 }
 
+const remoteServeUsage = "usage: reasonix remote serve start|stop|status|logs <name> [--workspace PATH] [-n N]"
+
 // remoteServeCLI: serve start|stop|status|logs <name>.
 func remoteServeCLI(args []string, version string) int {
+	if commandHelpRequested(args, 2) {
+		fmt.Fprintln(os.Stdout, remoteServeUsage)
+		return 0
+	}
 	if len(args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: reasonix remote serve start|stop|status|logs <name> [--workspace PATH] [-n N]")
+		fmt.Fprintln(os.Stderr, remoteServeUsage)
 		return 2
 	}
 	action := args[0]

--- a/internal/cli/remote_connect.go
+++ b/internal/cli/remote_connect.go
@@ -139,8 +139,8 @@ func remoteConnectCLI(args []string, version string) int {
 	noServe := fs.Bool("no-serve", false, "only establish forwards; do not bootstrap serve")
 	open := fs.Bool("open", openAlias, "print/open the serve URL")
 	forwardOnly := fs.Bool("forward-only", false, "apply configured forwards only; no serve")
-	if err := fs.Parse(args[1:]); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args[1:]); !ok {
+		return code
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
@@ -307,8 +307,8 @@ func remoteServeCLI(args []string, version string) int {
 	fs := newFlagSet("remote serve")
 	workspace := fs.String("workspace", "", "remote workspace directory")
 	n := fs.Int("n", 200, "log lines to show (logs)")
-	if err := fs.Parse(args[2:]); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args[2:]); !ok {
+		return code
 	}
 	name := args[1]
 	cfg, err := config.Load()

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -23,8 +23,8 @@ func reviewCommand(args []string) int {
 	commit := fs.String("commit", "", "review a specific commit (shows changes introduced by that commit)")
 	model := fs.String("model", "", "provider name override (default: config default_model)")
 	instructions := fs.String("instructions", "", "extra review instructions appended to the prompt")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 
 	// 1. Get the diff.

--- a/internal/cli/subagent.go
+++ b/internal/cli/subagent.go
@@ -143,7 +143,18 @@ func addSubagentProfileFlags(fs *flag.FlagSet, values *subagentProfileFlags) {
 	fs.StringVar(&values.dir, "dir", "", "project root")
 }
 
+func reportNamedSubagentHelp(args []string) bool {
+	if !commandHelpRequested(args, 1) {
+		return false
+	}
+	fmt.Fprint(os.Stdout, subagentUsageText)
+	return true
+}
+
 func subagentCreateCommand(args []string) int {
+	if reportNamedSubagentHelp(args) {
+		return 0
+	}
 	name, rest, ok := namedSubagentArgs(args)
 	if !ok {
 		fmt.Fprint(os.Stderr, subagentUsageText)
@@ -200,6 +211,9 @@ func subagentCreateCommand(args []string) int {
 }
 
 func subagentEditCommand(args []string) int {
+	if reportNamedSubagentHelp(args) {
+		return 0
+	}
 	name, rest, ok := namedSubagentArgs(args)
 	if !ok {
 		fmt.Fprint(os.Stderr, subagentUsageText)
@@ -279,6 +293,9 @@ func subagentEditCommand(args []string) int {
 }
 
 func subagentDeleteCommand(args []string) int {
+	if reportNamedSubagentHelp(args) {
+		return 0
+	}
 	name, rest, ok := namedSubagentArgs(args)
 	if !ok {
 		fmt.Fprint(os.Stderr, subagentUsageText)
@@ -319,6 +336,9 @@ func subagentDeleteCommand(args []string) int {
 }
 
 func subagentRunCommand(args []string, readOnly bool) int {
+	if reportNamedSubagentHelp(args) {
+		return 0
+	}
 	name, rest, ok := namedSubagentArgs(args)
 	if !ok {
 		fmt.Fprint(os.Stderr, subagentUsageText)

--- a/internal/cli/subagent.go
+++ b/internal/cli/subagent.go
@@ -64,8 +64,8 @@ func subagentCommand(args []string) int {
 func subagentListCommand(args []string) int {
 	fs := flag.NewFlagSet("subagent list", flag.ContinueOnError)
 	dir := fs.String("dir", "", "project root")
-	if err := fs.Parse(args); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, args); !ok {
+		return code
 	}
 	if len(fs.Args()) != 0 {
 		fmt.Fprint(os.Stderr, subagentUsageText)
@@ -153,7 +153,10 @@ func subagentCreateCommand(args []string) int {
 	var values subagentProfileFlags
 	addSubagentProfileFlags(fs, &values)
 	scopeText := fs.String("scope", "", "project or global (default: project)")
-	if err := fs.Parse(rest); err != nil || len(fs.Args()) != 0 {
+	if code, ok := parseCommandFlags(fs, rest); !ok {
+		return code
+	}
+	if len(fs.Args()) != 0 {
 		return 2
 	}
 	if rc := chdirTo(values.dir); rc != 0 {
@@ -205,7 +208,10 @@ func subagentEditCommand(args []string) int {
 	fs := flag.NewFlagSet("subagent edit", flag.ContinueOnError)
 	var values subagentProfileFlags
 	addSubagentProfileFlags(fs, &values)
-	if err := fs.Parse(rest); err != nil || len(fs.Args()) != 0 {
+	if code, ok := parseCommandFlags(fs, rest); !ok {
+		return code
+	}
+	if len(fs.Args()) != 0 {
 		return 2
 	}
 	if rc := chdirTo(values.dir); rc != 0 {
@@ -281,7 +287,10 @@ func subagentDeleteCommand(args []string) int {
 	fs := flag.NewFlagSet("subagent delete", flag.ContinueOnError)
 	yes := fs.Bool("yes", false, "confirm deletion")
 	dir := fs.String("dir", "", "project root")
-	if err := fs.Parse(rest); err != nil || len(fs.Args()) != 0 {
+	if code, ok := parseCommandFlags(fs, rest); !ok {
+		return code
+	}
+	if len(fs.Args()) != 0 {
 		return 2
 	}
 	if !*yes {
@@ -323,8 +332,8 @@ func subagentRunCommand(args []string, readOnly bool) int {
 	model := fs.String("model", "", "default model reference")
 	maxSteps := fs.Int("max-steps", 0, "max tool-call rounds")
 	dir := fs.String("dir", "", "project root")
-	if err := fs.Parse(rest); err != nil {
-		return 2
+	if code, ok := parseCommandFlags(fs, rest); !ok {
+		return code
 	}
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -81,10 +81,12 @@ func parseCLIReleaseChannel(value string) (cliReleaseChannel, error) {
 }
 
 type cliUpgradeSyntax struct {
-	checkOnly   bool
-	force       bool
-	positional  *cliReleaseChannel
-	flagChannel *cliReleaseChannel
+	checkOnly     bool
+	force         bool
+	positional    *cliReleaseChannel
+	flagChannel   *cliReleaseChannel
+	helpRequested bool
+	helpText      string
 }
 
 // parseCLIUpgradeSyntax accepts the ergonomic positional channel while keeping
@@ -93,11 +95,15 @@ type cliUpgradeSyntax struct {
 func parseCLIUpgradeSyntax(args []string) (cliUpgradeSyntax, error) {
 	fs := pflag.NewFlagSet("upgrade", pflag.ContinueOnError)
 	fs.SetInterspersed(true)
-	fs.SetOutput(io.Discard)
+	var parseOutput bytes.Buffer
+	fs.SetOutput(&parseOutput)
 	checkOnly := fs.Bool("check", false, "check for updates without installing")
 	force := fs.Bool("force", false, "reinstall even if already on the latest version")
 	channelValue := fs.String("channel", "", "deprecated compatibility option; updates use the official release")
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, pflag.ErrHelp) {
+			return cliUpgradeSyntax{helpRequested: true, helpText: parseOutput.String()}, nil
+		}
 		return cliUpgradeSyntax{}, err
 	}
 
@@ -176,6 +182,10 @@ func upgradeCommand(args []string, version string) int {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 2
+	}
+	if syntax.helpRequested {
+		fmt.Fprint(os.Stderr, syntax.helpText)
+		return 0
 	}
 
 	// 1. Normalize running version.

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -184,7 +184,7 @@ func upgradeCommand(args []string, version string) int {
 		return 2
 	}
 	if syntax.helpRequested {
-		fmt.Fprint(os.Stderr, syntax.helpText)
+		fmt.Fprint(os.Stdout, syntax.helpText)
 		return 0
 	}
 


### PR DESCRIPTION
## Summary

This PR consolidates CLI flag parsing behavior and fixes the documented `remote connect <name> [flags]` form.

Go's standard `flag` parser stops at the first positional argument. As a result, flags placed after the remote name were never parsed, even though the repository documentation presents that order. At the same time, direct CLI call sites handled malformed flags and help requests inconsistently.

## What changed

- Add a shared typed flag-error carrier for standard `flag` and `pflag`.
- Print malformed flag errors to stderr and keep exit status 2.
- Treat `-h` / `--help` as successful help requests with exit status 0 and write help to stdout, including nested commands that validate required positionals before parsing flags.
- Accept both remote-connect forms:
  - `reasonix remote connect <name> [flags]`
  - `reasonix remote connect [flags] <name>`
- Preserve `-open`, the `remote open` alias, workspace, port, no-serve, and forward-only behavior.
- Keep the `-c` compatibility introduced by the merged #7223 work.

Fixes #7255.

## Consolidation and contribution attribution

### Contribution from #7306

#7306 by @skyzhao1223 contributed the core remote-connect direction that this PR preserves and adapts:

- extracting a focused `remoteConnectSyntax` parser;
- accepting both name-first and flags-first forms;
- retaining standard-library `-open` and `remote open` compatibility;
- adding the focused flag-order and validation test matrix.

The integration commit records @skyzhao1223 with a public GitHub `Co-authored-by` trailer, so this contribution is also attributed in repository history.

### Repository / #7311 contribution

The final implementation integrates that parser with the repository's shared CLI contract developed in #7311 and builds on the merged #7223 flag work:

- typed deferred parse errors instead of direct `fs.Parse` reporting;
- help exits successfully in either argument order;
- malformed flags remain concise, localized, and exit with status 2;
- existing command entry points share the same reporting behavior.

### Reviewed but not adopted verbatim

The direct `fs.Parse` error handling and string comparison for usage errors from #7306 were not copied verbatim. They were replaced with #7311's typed error/help contract to avoid behavior differences between the two accepted argument orders.

## Behavior

| Invocation | Result |
| --- | --- |
| malformed or unknown flag | concise stderr error, exit 2 |
| `-h` / `--help` | usage on stdout, exit 0 |
| `remote connect <name> [flags]` | accepted |
| `remote connect [flags] <name>` | accepted |
| missing or extra remote name | usage output, exit 2 |

## Compatibility

- No persisted data, protocol, API, or configuration format changes.
- Existing valid flags and aliases remain supported.
- The previously documented name-first order now works.
- Help on stdout with status 0 is intentional; malformed input remains on stderr with status 2.

## Verification

- `go test ./... -count=1`
- `go test ./internal/cli ./cmd/reasonix -count=1`
- `go test -race ./internal/cli -count=1`
- `go vet ./...`
- `scripts/check-cache-impact.sh` on all touched CLI files
- `git diff --check origin/main-v2...HEAD`

## Risk review

- **Concurrency:** no goroutines, synchronization, or shared mutable state were added.
- **Security:** no network, authentication, authorization, secret, or permission behavior changed; this only parses existing CLI arguments.
- **Cache impact:** no cache-sensitive prompt or tool files changed; no cache version bump is required.
