### PR TITLE
Prefer content topic sessions over blank fallbacks

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -426,7 +426,7 @@ func sessionFileHasConversationContent(sessionPath string) bool {
 		return false
 	}
 	info, err := os.Stat(sessionPath)
-	if err != nil || info.IsDir() || info.Size() == 0 {
+	if err != nil || info.IsDir() {
 		return false
 	}
 	session, err := agent.LoadSession(sessionPath)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -9055,26 +9055,42 @@ func (a *App) findTopicSessionForTargetByContent(scope, workspaceRoot, topicID s
 	if topicID == "" {
 		return "", ""
 	}
-	var bestPath string
-	var bestDir string
-	var bestTime time.Time
+	var bestContentPath string
+	var bestContentDir string
+	var bestContentTime time.Time
+	var bestBlankPath string
+	var bestBlankDir string
+	var bestBlankTime time.Time
 	for _, dir := range a.knownSessionDirs() {
 		for _, match := range topicSessionMatches(dir, topicID) {
-			if requireContent && !sessionFileHasConversationContent(match.path) {
-				continue
-			}
 			if !topicSessionMatchMatchesTarget(match, scope, workspaceRoot) {
 				continue
 			}
-			if bestPath == "" || match.updatedAt.After(bestTime) ||
-				(match.updatedAt.Equal(bestTime) && match.path < bestPath) {
-				bestPath = match.path
-				bestDir = dir
-				bestTime = match.updatedAt
+			hasContent := sessionFileHasConversationContent(match.path)
+			if requireContent && !hasContent {
+				continue
+			}
+			if hasContent {
+				if bestContentPath == "" || match.updatedAt.After(bestContentTime) ||
+					(match.updatedAt.Equal(bestContentTime) && match.path < bestContentPath) {
+					bestContentPath = match.path
+					bestContentDir = dir
+					bestContentTime = match.updatedAt
+				}
+				continue
+			}
+			if bestBlankPath == "" || match.updatedAt.After(bestBlankTime) ||
+				(match.updatedAt.Equal(bestBlankTime) && match.path < bestBlankPath) {
+				bestBlankPath = match.path
+				bestBlankDir = dir
+				bestBlankTime = match.updatedAt
 			}
 		}
 	}
-	return bestPath, bestDir
+	if bestContentPath != "" {
+		return bestContentPath, bestContentDir
+	}
+	return bestBlankPath, bestBlankDir
 }
 
 type topicSessionFileSignature struct {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -14,6 +14,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/provider"
 )
 
 type runtimeStatusSessionController struct {
@@ -79,6 +80,34 @@ func writeTopicSessionWithPrompt(t *testing.T, dir, name, topicID, topicTitle, w
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(`{"role":"user","content":`+strconv.Quote(prompt)+`}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write session: %v", err)
+	}
+	scope := "global"
+	if strings.TrimSpace(workspaceRoot) != "" {
+		scope = "project"
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+		CreatedAt:     updatedAt.Add(-time.Minute),
+		UpdatedAt:     updatedAt,
+		Scope:         scope,
+		WorkspaceRoot: workspaceRoot,
+		TopicID:       topicID,
+		TopicTitle:    topicTitle,
+	}); err != nil {
+		t.Fatalf("save branch meta: %v", err)
+	}
+	return path
+}
+
+func writeTopicEventSessionWithPrompt(t *testing.T, dir, name, topicID, topicTitle, workspaceRoot, prompt string, updatedAt time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	s := agent.NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: prompt})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("save event session: %v", err)
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		t.Fatalf("truncate checkpoint: %v", err)
 	}
 	scope := "global"
 	if strings.TrimSpace(workspaceRoot) != "" {
@@ -4102,6 +4131,55 @@ func TestOpenProjectTabSkipsCleanupPendingTopicSession(t *testing.T) {
 		if msg.Content == "pending topic prompt" {
 			t.Fatalf("opened cleanup-pending topic history at path %q: %+v", tab.Ctrl.SessionPath(), tab.Ctrl.History())
 		}
+	}
+}
+
+func TestFindTopicSessionForTargetPrefersContentOverNewerBlankTopicSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	movedRoot := filepath.Join(t.TempDir(), "moved-project")
+	app := NewApp()
+	installNoopRuntimeEvents(app)
+	topic, err := app.CreateTopic("project", projectRoot, "Recovered topic")
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realPath := writeTopicEventSessionWithPrompt(t, dir, "real-topic.jsonl", topic.ID, "Recovered topic", movedRoot, "real history", time.Now().Add(-time.Hour))
+
+	if got, _ := app.findTopicSessionForTarget("project", projectRoot, topic.ID); got != "" {
+		t.Fatalf("precondition topic lookup = %q, want no match while workspace root differs", got)
+	}
+	blankPath, err := createEmptySessionFile(dir, "")
+	if err != nil {
+		t.Fatalf("create blank topic session: %v", err)
+	}
+	if err := pinNewEmptySessionBranchMeta(blankPath, "project", projectRoot, topic.ID, "Recovered topic"); err != nil {
+		t.Fatalf("pin blank topic session: %v", err)
+	}
+	if blankPath == realPath {
+		t.Fatalf("blank session path unexpectedly matches real session %q", realPath)
+	}
+	if sessionFileHasConversationContent(blankPath) {
+		t.Fatalf("created fallback session %q should be blank", blankPath)
+	}
+
+	realMeta, ok, err := agent.LoadBranchMeta(realPath)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta(%q): ok=%v err=%v", realPath, ok, err)
+	}
+	realMeta.WorkspaceRoot = projectRoot
+	if err := agent.SaveBranchMetaPreserveUpdated(realPath, realMeta); err != nil {
+		t.Fatalf("restore real session workspace root: %v", err)
+	}
+	invalidateTopicSessionIndex(dir)
+
+	if got, _ := app.findTopicSessionForTarget("project", projectRoot, topic.ID); got != realPath {
+		t.Fatalf("topic lookup = %q, want content-bearing real session %q instead of newer blank %q", got, realPath, blankPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

- prefer content-bearing topic sessions over newer blank fallback sessions when resolving a project/global topic
- make topic content detection event-log aware by letting `agent.LoadSession` inspect sidecar event logs even when the primary `.jsonl` checkpoint is 0 bytes
- add a regression test for the #7305 flow where a temporarily unmatched real topic session is later shadowed by a newer blank session

Fixes #7305

## Root cause

When a topic click had no currently matching session, desktop created and pinned an empty fallback session for that topic. After the real session became matchable again, `findTopicSessionForTargetByContent` selected the newest matching session by `UpdatedAt`, so the newer blank fallback won forever.

In v2 this was made worse by event-log storage: a valid recovered session can have a 0-byte primary `.jsonl` checkpoint with conversation content in `<id>.events.jsonl`. `sessionFileHasConversationContent` returned false before loading those event logs, so recovered sessions could be misclassified as blank.

## Validation

- `git diff --check`
- `go test ./desktop -run "Test(FindTopicSessionForTargetPrefersContentOverNewerBlankTopicSession|FindTopicSessionIndexRefreshesWhenMetaChanges|FindTopicSessionSkipsCleanupPending|CloseTabKeepsIndexedBlankSession|TrashSessionMatchesLiveSeesEventLogDivergence|DeleteSessionValidTrashRemovesEmptyLiveStub)" -count=1`

Note: the local git hooks currently run `npm run lint` / `npm run verify` from the repository root, but this v2 checkout has no root `package.json`. I used the hooks' built-in `SKIP_SIMPLE_GIT_HOOKS=1` escape hatch after running the Go-focused checks above.