### PR TITLE
feat(telemetry): separate the 400s that need different fixes

### DIFF
--- a/desktop/metrics_app.go
+++ b/desktop/metrics_app.go
@@ -347,12 +347,37 @@ func cacheBucket(hit, miss int) string {
 	}
 }
 
+// badRequestReason separates the 400s that need different fixes. Every arm
+// returns a fixed label matched against a fixed substring, so nothing the
+// provider echoed back can reach the bucket — the same constraint errorClass
+// works under. Unrecognized shapes stay plain http_400 rather than guessing.
+func badRequestReason(low string) string {
+	switch {
+	case strings.Contains(low, "image_url"), strings.Contains(low, "unknown variant"):
+		return "content"
+	case strings.Contains(low, "is not of type"), strings.Contains(low, "invalid schema for function"):
+		return "schema"
+	case strings.Contains(low, "thinking") && strings.Contains(low, "passed back"):
+		return "reasoning_replay"
+	case strings.Contains(low, "thinking") && (strings.Contains(low, "expected a boolean") || strings.Contains(low, "invalid type")):
+		return "thinking_shape"
+	case strings.Contains(low, "context length"), strings.Contains(low, "maximum context"), strings.Contains(low, "too long"):
+		return "context_length"
+	case strings.Contains(low, "tool_calls"), strings.Contains(low, "missing field name"):
+		return "tool_calls"
+	}
+	return ""
+}
+
 // errorClass extracts only the failure category — never the message itself, which
 // can echo request content back from a provider.
 func errorClass(msg string) string {
 	if mm := statusCodePattern.FindStringSubmatch(msg); mm != nil {
 		switch code := mm[1]; {
 		case code == "400":
+			if reason := badRequestReason(strings.ToLower(msg)); reason != "" {
+				return "http_400_" + reason
+			}
 			return "http_400"
 		case code == "401" || code == "403":
 			return "http_401"

--- a/desktop/metrics_app_test.go
+++ b/desktop/metrics_app_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"reasonix/internal/config"
@@ -244,5 +245,44 @@ func TestPersistMergesAcrossSessions(t *testing.T) {
 	}
 	if n := len(flatten(readCounters(path))); n != 1 {
 		t.Errorf("flatten produced %d counters, want 1", n)
+	}
+}
+
+func TestErrorClassSeparatesBadRequestCauses(t *testing.T) {
+	// Verbatim provider bodies from reported issues, each needing a different fix.
+	cases := map[string]string{
+		`status 400: messages[203]: unknown variant ` + "`image_url`" + `, expected ` + "`text`": "http_400_content",
+		`status 400: Invalid schema for function 'ls': null is not of type "array"`:              "http_400_schema",
+		"status 400: The `content[].thinking` in the thinking mode must be passed back":          "http_400_reasoning_replay",
+		"status 400: thinking: invalid type: map, expected a boolean":                            "http_400_thinking_shape",
+		"status 400: This model's maximum context length is 65536 tokens":                        "http_400_context_length",
+		"status 400: missing field name at line 1":                                               "http_400_tool_calls",
+		"status 400: something nobody has classified yet":                                        "http_400",
+	}
+	for msg, want := range cases {
+		if got := errorClass(msg); got != want {
+			t.Errorf("errorClass(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}
+
+func TestErrorClassNeverEchoesProviderText(t *testing.T) {
+	// The bucket is uploaded; the message is not. A label must be a fixed token,
+	// so no substring of a body carrying user code or prompt text can reach it.
+	secrets := []string{
+		"status 400: Invalid schema for function 'ls': /home/alice/secret-project is not of type \"array\"",
+		"status 400: unknown variant `image_url` in ~/work/client-contract.pdf",
+		"status 400: thinking: invalid type: map, expected a boolean, key=sk-abc123",
+	}
+	for _, msg := range secrets {
+		got := errorClass(msg)
+		for _, leak := range []string{"alice", "secret", "client-contract", "sk-abc123", "/home", "~/work"} {
+			if strings.Contains(got, leak) {
+				t.Fatalf("errorClass(%q) = %q, leaked %q", msg, got, leak)
+			}
+		}
+		if !strings.HasPrefix(got, "http_400") {
+			t.Errorf("errorClass(%q) = %q, want an http_400 label", msg, got)
+		}
 	}
 }


### PR DESCRIPTION
## Why

Production telemetry, last 30 days of `provider_error`:

```
other                 495,834
stream_interrupted      6,841
timeout                 6,355
http_5xx                  743
http_400                   46
authorization_failed       14
```

46 four-hundreds, and the bucket says nothing about which. Triaging four such reports by hand this week found four unrelated causes:

| report | provider said | needs |
|---|---|---|
| #6975 | `unknown variant image_url, expected text` | stop replaying images to text-only models |
| #6604 | `Invalid schema for function 'ls': null is not of type "array"` | emit `required: []` |
| #6555 | `thinking: invalid type: map, expected a boolean` | per-endpoint thinking shape |
| #6541 | `content[].thinking must be passed back` | replay reasoning on that protocol |

Four different fixes. From the dashboard, one number.

## What this does

Splits `http_400` by cause: `http_400_content`, `_schema`, `_thinking_shape`, `_reasoning_replay`, `_context_length`, `_tool_calls`. Anything unrecognized stays plain `http_400` rather than being guessed at.

## The constraint it works under

`errorClass` carries this comment, and it is load-bearing:

> extracts only the failure category — never the message itself, which can echo request content back from a provider

That is why the bucket was coarse in the first place — it is a privacy decision, not an oversight. So every arm here matches a **fixed substring** and returns a **fixed token**. No part of the body can reach the label. `TestErrorClassNeverEchoesProviderText` pins it with bodies carrying a home path, a client filename and an API key, asserting none of them appear in the result.

## What it does not change

The user-facing message. `control.apiErrorReason` already appends the provider's verbatim reason to the localized line — that is precisely why the four reports above were diagnosable by reading them. The gap was only ever on the aggregate side.

## Cache

**Cache-impact: none.** `desktop/metrics_app.go` is not on the cache-sensitive path list in `scripts/check-cache-impact.sh`; no prompt or tool bytes change.
**Cache-guard:** not applicable, same reason.

## Verification

- `go test ./desktop` — full module passes
- new: `TestErrorClassSeparatesBadRequestCauses` uses verbatim bodies from the four issues above
- new: `TestErrorClassNeverEchoesProviderText` is the privacy guard

## Follow-on

Once this has run for a while, the split tells us whether any single cause is worth paying for. Concretely: emitting `required: []` for all-optional tools would fix #6604, but it changes tool-schema bytes for everyone and costs a one-time cache miss across the install base. At 46 total 400s a month that trade did not look worth making on a guess — after this, it stops being a guess.
