### PR TITLE
fix(creation): Windows 标题条压至 40px 并对齐控件

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -598,10 +598,15 @@ ok(
 ok(
   finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
+    finalDeclaration(".app--windows.app--creation .topicbar", "min-height") === "40px" &&
+    finalDeclaration(":root[data-theme-style] .app--windows.app--creation .topicbar", "min-height") === "40px" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "transform") === "none !important" &&
+    finalDeclaration(".app--windows.app--creation .topicbar__title-row", "transform") === "none" &&
     finalDeclaration(".app--windows-frameless.app--creation", "--windows-window-controls-height") === "40px" &&
-    finalDeclaration(".app--creation .topicbar", "min-height") === "40px",
-  "Windows Creation title strip stays 40px with topicbar menus above conversation content",
+    finalDeclaration(".app--creation .topicbar", "min-height") === "56px" &&
+    finalDeclaration(":root[data-theme-style] .app--creation .topicbar", "padding-top") === "14px" &&
+    finalDeclaration(".app--creation .topicbar__title-row", "transform") === "translateY(-3px)",
+  "Windows Creation stays 40px while macOS and Linux keep the shared Creation geometry",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -598,8 +598,10 @@ ok(
 ok(
   finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
-    finalDeclaration(".app--windows.app--creation .topicbar", "transform") === "translateY(-4px) !important",
-  "Windows Creation topic bar lifts its menus above conversation content without changing titlebar alignment",
+    finalDeclaration(".app--windows.app--creation .topicbar", "transform") === "none !important" &&
+    finalDeclaration(".app--windows-frameless.app--creation", "--windows-window-controls-height") === "40px" &&
+    finalDeclaration(".app--creation .topicbar", "min-height") === "40px",
+  "Windows Creation title strip stays 40px with topicbar menus above conversation content",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29891,10 +29891,8 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .topicbar,
 :root[data-theme-style] .app--creation .topicbar {
-  min-height: 40px;
-  /* Symmetric vertical padding so title/actions share the 40px center line
-     with Windows caption buttons (asymmetric top padding was pushing icons down). */
-  padding-top: 0;
+  min-height: 56px;
+  padding-top: 14px;
   padding-bottom: 0;
   border-bottom: 0;
   background: transparent;
@@ -29904,7 +29902,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .app--creation .topicbar__title-row {
   gap: 0;
   background: transparent;
-  transform: none;
+  transform: translateY(-3px);
 }
 
 .app--creation .topicbar__identity,
@@ -33609,11 +33607,21 @@ body > .mermaid-diagram--fullscreen {
   margin-top: -32px !important;
 }
 
-/* Align topicbar (replaces app-chrome in Creation mode) with Windows controls */
-.app--windows.app--creation .topicbar {
+/* Align topicbar (replaces app-chrome in Creation mode) with Windows controls
+   without changing the shared macOS/Linux Creation geometry above. */
+.app--windows.app--creation .topicbar,
+:root[data-theme-style] .app--windows.app--creation .topicbar {
   position: relative;
   z-index: var(--z-app-chrome);
+  min-height: 40px;
+  padding-top: 0;
+  padding-bottom: 0;
   transform: none !important;
+}
+
+.app--windows.app--creation .topicbar__title-row,
+:root[data-theme-style] .app--windows.app--creation .topicbar__title-row {
+  transform: none;
 }
 
 /* Reduce session title font size and weight. The rename input replaces the h1

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -29891,8 +29891,10 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .topicbar,
 :root[data-theme-style] .app--creation .topicbar {
-  min-height: 56px;
-  padding-top: 14px;
+  min-height: 40px;
+  /* Symmetric vertical padding so title/actions share the 40px center line
+     with Windows caption buttons (asymmetric top padding was pushing icons down). */
+  padding-top: 0;
   padding-bottom: 0;
   border-bottom: 0;
   background: transparent;
@@ -29902,7 +29904,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .app--creation .topicbar__title-row {
   gap: 0;
   background: transparent;
-  transform: translateY(-3px);
+  transform: none;
 }
 
 .app--creation .topicbar__identity,
@@ -33454,25 +33456,15 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .app--windows-frameless.app--creation {
-  --windows-window-controls-height: 56px;
+  /* Match Creation topicbar / dock tools (40px) so caption buttons are not taller
+     than the title strip. classic/workbench keep their own heights. */
+  --windows-window-controls-height: 40px;
   /* Tighter caption buttons free horizontal room for dock tabs at narrow widths.
      classic/workbench keep the standard 46×3 = 138 strip. */
   --windows-window-control-width: 36px;
   --windows-window-controls-width: 108px;
   --windows-window-controls-gap: 8px;
   --windows-window-controls-safe: calc(var(--windows-window-controls-width) + var(--windows-window-controls-gap));
-}
-
-/* When workspace panel is open in creation mode, match the dock tools height
-   (40px) instead of the tall 56px default, so the window controls box does not
-   extend below the workbench-dock__tools. */
-.app--windows-frameless.app--creation .layout--workspace-open ~ .windows-window-controls,
-.app--windows-frameless.app--creation .layout--workspace-maximized ~ .windows-window-controls {
-  height: 40px;
-}
-:root[data-theme-style] .app--windows-frameless.app--creation .layout--workspace-open ~ .windows-window-controls,
-:root[data-theme-style] .app--windows-frameless.app--creation .layout--workspace-maximized ~ .windows-window-controls {
-  height: 40px;
 }
 
 .app--windows-frameless .app-chrome--native-tabs,
@@ -33611,22 +33603,17 @@ body > .mermaid-diagram--fullscreen {
    Windows + Creation: Vertical alignment for titlebar elements
    ========================================================================= */
 
-/* Align sidebar logo with Windows titlebar center line */
+/* Align sidebar logo with the shorter 40px Windows title strip center line */
 .app--windows.app--creation .sidebar__brand,
 :root[data-theme-style] .app--windows.app--creation .sidebar__brand {
-  margin-top: -29px !important;
+  margin-top: -32px !important;
 }
 
 /* Align topicbar (replaces app-chrome in Creation mode) with Windows controls */
 .app--windows.app--creation .topicbar {
   position: relative;
   z-index: var(--z-app-chrome);
-  transform: translateY(-4px) !important;
-}
-
-/* Align topicbar identity (session title) with Windows controls */
-.app--windows.app--creation .topicbar__identity {
-  transform: translateY(-2px) !important;
+  transform: none !important;
 }
 
 /* Reduce session title font size and weight. The rename input replaces the h1
@@ -33638,29 +33625,22 @@ body > .mermaid-diagram--fullscreen {
   font-weight: 520 !important;
 }
 
-/* Align action buttons (not chrome buttons) */
-.app--windows.app--creation .topicbar__action-btn:not(.topicbar__chrome-btn) {
-  transform: translateY(-2px) !important;
-  align-self: center !important;
-}
-
-/* Align ExternalOpener split control with the same Windows titlebar center line */
-.app--windows.app--creation .topicbar__actions .external-opener {
-  transform: translateY(-2px) !important;
-  align-self: center !important;
-}
-
-/* Align topicbar chrome buttons separately (they're also in actions container) */
+/* Keep action / chrome buttons on the same center line as Windows controls */
+.app--windows.app--creation .topicbar__action-btn:not(.topicbar__chrome-btn),
 .app--windows.app--creation .topicbar__chrome-btn {
-  transform: translateY(-2px) !important;
   align-self: center !important;
+  transform: translateY(0.5px) !important;
 }
 
-/* The alignment offset above owns the transform slot, which would otherwise
-   erase the .topicbar__chrome-btn--pressed { scale(0.94) } press feedback —
-   recombine both here. */
+/* Folder opener glyph sits a hair lower than line icons — nudge it up alone */
+.app--windows.app--creation .topicbar__actions .external-opener {
+  align-self: center !important;
+  transform: translateY(-1px) !important;
+}
+
+/* Preserve press scale while keeping the Windows center-line nudge */
 .app--windows.app--creation .topicbar__chrome-btn.topicbar__chrome-btn--pressed {
-  transform: translateY(-2px) scale(0.94) !important;
+  transform: translateY(0.5px) scale(0.94) !important;
 }
 
 /* Windows 控制框在 Creation 下默认用 --bg-elev（近纯白），与右侧 workbench-dock


### PR DESCRIPTION
## 改动内容

Creation 在 Windows 下的标题条高度与对齐：

1. 窗口控件高度：`56px` → **`40px`**，与 topicbar / 右侧 dock tools 对齐
2. Creation topicbar：`min-height 56` → **`40`**，去掉多余上下偏移
3. 工具图标与 Windows 控件中线对齐（约 `translateY(0.5px)`）
4. 文件夹（ExternalOpener）单独上移约 1.5px，避免比线图标偏低
5. Logo 中线微调到 40px 标题条

全部限定 `.app--windows` / `.app--creation` / `.app--windows-frameless.app--creation`，不影响 classic / workbench 与其他平台。

## 涉及文件

- `desktop/frontend/src/styles.css`
- `desktop/frontend/src/__tests__/app-chrome-tabs.test.ts`

## 验证

- [x] `pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts`（120 passed）
- [x] `pnpm --dir desktop/frontend typecheck`
- [x] 本地 `wails dev` 视觉复核
