### PR TITLE
fix(desktop): 细粒度权限规则长命令不再溢出（Fixes #7315）

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6348,7 +6348,7 @@ function RuleList({
         {rules.length === 0 && <span className="mem-empty">{t("common.none")}</span>}
         {rules.map((r) => (
           <span className="set-rule" key={r}>
-            {r}
+            <span className="set-rule__text" title={r}>{r}</span>
             <Tooltip label={t("common.delete")}>
               <button className="set-rule__x" disabled={busy} onClick={() => void onRemove(r)}>
                 ✕

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16832,26 +16832,44 @@ body > .mermaid-diagram--fullscreen {
 }
 .set-rule {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 5px;
+  max-width: 100%;
+  min-width: 0;
   font-family: var(--mono);
   font-size: 11px;
   padding: 3px 4px 3px 7px;
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 6px;
+  /* Long permission commands must wrap inside the chip so the delete control
+     stays visible (Fixes #7315). Path rules already needed this; apply to all. */
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 .set-rule--path {
   max-width: 100%;
   overflow-wrap: anywhere;
   white-space: normal;
 }
+.set-rule__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .set-rule__x {
+  flex: 0 0 auto;
+  align-self: flex-start;
   border: none;
   background: transparent;
   color: var(--fg-faint);
   padding: 0 2px;
   font-size: 11px;
+  line-height: 1.35;
+}
+.set-rule .tooltip-trigger {
+  flex: 0 0 auto;
 }
 .set-rule__x:hover {
   color: var(--err);


### PR DESCRIPTION
## 改动内容

修复设置 → 权限 → 细粒度规则里**长命令溢出卡片、删除按钮被挤没**的问题（Fixes #7315）。

1. 规则 chip（`.set-rule`）统一限宽并允许长文本换行
2. 命令文本包进 `.set-rule__text`，可收缩换行
3. 删除按钮（✕）`flex: 0 0 auto`，始终可见可点

路径规则原先已有类似处理；本次对所有规则 chip 生效，避免 allow/deny 长命令再撑破布局。

## 涉及文件

- `desktop/frontend/src/components/SettingsPanel.tsx`
- `desktop/frontend/src/styles.css`

## 验证

- [x] `tsc --noEmit` 通过
- [ ] 本地设置页加一条超长 allow 规则，确认文本换行且 ✕ 可见可删
