### PR TITLE
fix(remote): stop Workbench listener on context cancellation

### DIFF
--- a/internal/remote/workbench/runtime/server.go
+++ b/internal/remote/workbench/runtime/server.go
@@ -307,6 +307,10 @@ func (s *Server) ListenAndServe(ctx context.Context, socket string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = ln.Close() }()
+	// Accept does not observe ctx directly, so close the listener to unblock it.
+	stopAccept := context.AfterFunc(ctx, func() { _ = ln.Close() })
+	defer stopAccept()
 	_ = os.Chmod(socket, 0o600)
 	s.mu.Lock()
 	s.ln, s.socket, s.lockPath = ln, socket, lockPath

--- a/internal/remote/workbench/runtime/server_test.go
+++ b/internal/remote/workbench/runtime/server_test.go
@@ -102,6 +102,72 @@ func TestSocketPathStaysWithinPortableUnixLimitForLongHome(t *testing.T) {
 	}
 }
 
+func testRuntimeSocket(t *testing.T) string {
+	t.Helper()
+	socket := filepath.Join(t.TempDir(), "r.sock")
+	if len(socket) <= 100 {
+		return socket
+	}
+	tempBase := os.TempDir()
+	if goruntime.GOOS == "darwin" {
+		tempBase = "/tmp"
+	}
+	shortDir, err := os.MkdirTemp(tempBase, "rx-wb-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(shortDir) })
+	return filepath.Join(shortDir, "r.sock")
+}
+
+func TestListenAndServeReturnsWhenContextIsCanceled(t *testing.T) {
+	socket := testRuntimeSocket(t)
+	srv := New(Options{Workspace: t.TempDir(), Version: "test"})
+	t.Cleanup(srv.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe(ctx, socket) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		srv.mu.Lock()
+		listening := srv.ln != nil
+		srv.mu.Unlock()
+		if listening {
+			break
+		}
+		select {
+		case err := <-errCh:
+			t.Fatalf("ListenAndServe returned before cancellation: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("runtime did not start listening")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(socket + ".lock"); err != nil {
+		t.Fatalf("runtime lock was not created: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ListenAndServe error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListenAndServe did not return after context cancellation")
+	}
+
+	for _, path := range []string{socket, socket + ".lock"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("runtime path %q still exists after shutdown: %v", path, err)
+		}
+	}
+}
+
 type persistentFakeController struct {
 	*fakeController
 	sessionDir  string
@@ -667,20 +733,7 @@ func TestRuntimeSessionCreateAndFileList(t *testing.T) {
 	ws := t.TempDir()
 	sessionDir := filepath.Join(t.TempDir(), "sessions")
 	registryPath := filepath.Join(t.TempDir(), "remote-sessions.json")
-	// Short absolute socket path — macOS rejects long unix paths.
-	sock := filepath.Join(t.TempDir(), "r.sock")
-	if len(sock) > 100 {
-		tempBase := os.TempDir()
-		if goruntime.GOOS == "darwin" {
-			tempBase = "/tmp"
-		}
-		shortDir, err := os.MkdirTemp(tempBase, "rx-wb-")
-		if err != nil {
-			t.Fatal(err)
-		}
-		t.Cleanup(func() { _ = os.RemoveAll(shortDir) })
-		sock = filepath.Join(shortDir, "r.sock")
-	}
+	sock := testRuntimeSocket(t)
 	srv := New(Options{Workspace: ws, Version: "test", SessionDir: sessionDir, RegistryPath: registryPath, BuildController: func(_ context.Context, model string, _ *string, _ event.Sink) (SessionController, error) {
 		return &persistentFakeController{fakeController: &fakeController{model: model}, sessionDir: sessionDir}, nil
 	}})


### PR DESCRIPTION
## Summary

- Close the Remote Workbench listener when its server context is canceled so a blocked `Accept` call unblocks and `ListenAndServe` exits promptly.
- Add regression coverage for cancellation and Unix socket/lock cleanup while sharing the existing portable socket-path setup.

## Issues

No linked issue; found during code review.

## Verification

- `go test ./internal/remote/workbench/runtime -run '^TestListenAndServeReturnsWhenContextIsCanceled$' -count=50`
- `go test ./internal/remote/workbench/runtime -count=1`
- `go vet ./internal/remote/workbench/runtime`
- `go build ./...`

## Cache impact

Cache-impact: none — this only changes the Remote Workbench listener shutdown path; provider-visible prompts and tool surfaces are unchanged.
Cache-guard: `go test ./internal/remote/workbench/runtime -run '^TestListenAndServeReturnsWhenContextIsCanceled$' -count=50`
System-prompt-review: N/A