### PR TITLE
Restore null return for empty candidates

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -5661,9 +5661,15 @@ export const ProviderEditorModelPicker = memo(function ProviderEditorModelPicker
     ? candidates.filter((model) => model.toLowerCase().includes(q))
     : candidates;
   const deferredCandidates = useDeferredValue(visibleCandidates);
-  if (candidates.length === 0) return null;
+
+  //当拉取自定义 provider 模型时，candidates 从空变成非空，React 发现 hook 数量变化 → 崩溃。
+  //if (candidates.length === 0) return null;
   const selected = new Set(selectedModels);
   const vision = new Set(visionModels);
+
+
+  //useDeferredValue 这个 hook 在提前返回之后。
+  if (candidates.length === 0) return null;
   return (
     <div className="provider-model-draft provider-model-draft--inline">
       <div className="provider-model-draft__head">


### PR DESCRIPTION
修复当拉取自定义 provider 模型时，candidates 从空变成非空时导致的崩溃。

## Summary

- 修复 ProviderEditorModelPicker

## Issues


<!--
If this resolves a report, put `Fixes #123` on its own line — GitHub only
auto-closes from a bare line, so `- Fixes #123` in a list does nothing and the
report stays open. If it only relates to one, use `Refs #123` instead: the
release workflow then asks that reporter to verify once the fix ships.

Fixs #1把提前返回移到 useDeferredValue 之后，保持 hook 调用顺序稳定。
-->

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
