### PR TITLE
fix(diagnostics): improve hang signal quality / 提升卡顿诊断信号质量

### DIFF
--- a/desktop/crash_diagnostics_test.go
+++ b/desktop/crash_diagnostics_test.go
@@ -22,12 +22,34 @@ func TestParseWebView2ProcessFailure(t *testing.T) {
 }
 
 func TestWebView2ProcessFailureReportIsStructured(t *testing.T) {
-	report := webView2ProcessFailureReport(2)
+	report := webView2ProcessFailureReportWithContext(2, 3, "132.0.2957.140")
 	if report.Source != "webview2.process" || report.Label != "windows.webview2.process_failed" {
 		t.Fatalf("report = %+v", report)
 	}
 	if report.FingerprintHint != "windows.webview2.render_process_unresponsive" {
 		t.Fatalf("fingerprint hint = %q", report.FingerprintHint)
+	}
+	for _, want := range []string{"runtime version: 132.0.2957.140", "same-process occurrence: 3", "exit code: unavailable"} {
+		if !strings.Contains(report.Message, want) {
+			t.Fatalf("report message missing %q: %s", want, report.Message)
+		}
+	}
+}
+
+func TestWebView2FailureTrackerDeduplicatesSessionBursts(t *testing.T) {
+	var tracker webView2FailureTracker
+	base := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	if occurrence, report := tracker.observe(2, base); occurrence != 1 || !report {
+		t.Fatalf("first observation = (%d, %v)", occurrence, report)
+	}
+	if occurrence, report := tracker.observe(2, base.Add(time.Minute)); occurrence != 2 || report {
+		t.Fatalf("burst observation = (%d, %v)", occurrence, report)
+	}
+	if occurrence, report := tracker.observe(2, base.Add(webView2FailureReportCooldown)); occurrence != 3 || !report {
+		t.Fatalf("post-cooldown observation = (%d, %v)", occurrence, report)
+	}
+	if occurrence, report := tracker.observe(6, base.Add(time.Minute)); occurrence != 1 || !report {
+		t.Fatalf("different kind observation = (%d, %v)", occurrence, report)
 	}
 }
 

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -13,6 +13,7 @@ import {
   opaqueScriptFingerprintHint,
   parseReportedPerf,
   performanceLabelForReason,
+  performanceFingerprintHintForReason,
   serializeReportedPerf,
   shouldPromptForLongTasks,
   shouldPromptForEventLoopLag,
@@ -54,7 +55,7 @@ const legacyObject = function LegacyObject() {} as unknown as ObjectConstructor 
 installObjectHasOwnPolyfill(legacyObject);
 eq(legacyObject.hasOwn?.({ own: true }, "own"), true, "Object.hasOwn polyfill accepts own properties");
 eq(legacyObject.hasOwn?.(Object.create({ inherited: true }), "inherited"), false, "Object.hasOwn polyfill rejects inherited properties");
-for (const file of ["../components/VirtualMenu.tsx", "../components/WorkspacePanel.tsx", "../components/editors/HljsDiff.tsx"]) {
+for (const file of ["../components/VirtualMenu.tsx", "../components/WorkspacePanel.tsx", "../components/editors/HljsDiff.tsx", "../components/editors/LineNumberCode.tsx"]) {
   const source = readFileSync(resolve(testDir, file), "utf8");
   const fileParts = file.split("/");
   const label = fileParts[fileParts.length - 1];
@@ -186,6 +187,14 @@ eq(formatPerformanceContext(perf).includes("long tasks: 3"), true, "formats long
 eq(perfPayload.message.includes("event loop lag 1300ms"), true, "payload message keeps lag context");
 eq(performanceLabelForReason("long task 900ms"), "performance.longtask", "labels long task pressure");
 eq(performanceLabelForReason("js heap 87% of limit"), "performance.heap", "labels heap pressure");
+eq(performanceFingerprintHintForReason("js heap 87% of limit"), "frontend.performance.heap.high", "tracks high heap pressure separately");
+eq(performanceFingerprintHintForReason("js heap 97% of limit"), "frontend.performance.heap.critical", "tracks critical heap pressure separately");
+eq(performanceFingerprintHintForReason("long task 900ms"), undefined, "does not repartition non-heap performance groups");
+eq(
+  buildPerformancePayload({ ...perf, reason: "js heap 97% of limit" }).fingerprintHint,
+  "frontend.performance.heap.critical",
+  "adds the heap tier to the report fingerprint",
+);
 eq(shouldRecordLongTaskSample(14_000, 900, 15_000), false, "ignores startup long tasks before grace ends");
 eq(shouldRecordLongTaskSample(16_000, 40, 15_000), false, "ignores short long-task observer entries");
 eq(shouldRecordLongTaskSample(16_000, 900, 15_000), true, "records post-grace long tasks");

--- a/desktop/frontend/src/components/editors/LineNumberCode.tsx
+++ b/desktop/frontend/src/components/editors/LineNumberCode.tsx
@@ -338,6 +338,10 @@ export default function LineNumberCode({
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT_ESTIMATE,
     overscan: OVERSCAN,
+    // Syntax-highlighted rows can still require measurement when the user
+    // changes typography, but measurement/scroll updates should not feed a
+    // React render loop for a long code block.
+    directDomUpdates: true,
   });
 
   const scrollToLine = useCallback(
@@ -594,8 +598,9 @@ export default function LineNumberCode({
       >
         {isVirtual ? (
           <div
+            ref={virtualizer.containerRef}
             className="code-lines-wrap"
-            style={{ height: virtualizer.getTotalSize(), width: "100%", position: "relative" }}
+            style={{ width: "100%", position: "relative" }}
           >
             {virtualizer.getVirtualItems().map((row) => (
               <div
@@ -607,7 +612,6 @@ export default function LineNumberCode({
                   top: 0,
                   left: 0,
                   width: "100%",
-                  transform: `translateY(${row.start}px)`,
                 }}
               >
                 {renderRow(row.index)}

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -438,6 +438,17 @@ export function performanceLabelForReason(reason: string): string {
   return "performance.pressure";
 }
 
+export function performanceFingerprintHintForReason(reason: string): string | undefined {
+  const normalized = reason.trim().toLowerCase();
+  if (!normalized.startsWith("js heap")) return undefined;
+  const match = normalized.match(/(\d+(?:\.\d+)?)%/);
+  const percent = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isFinite(percent)) return "frontend.performance.heap.unknown";
+  return percent >= 95
+    ? "frontend.performance.heap.critical"
+    : "frontend.performance.heap.high";
+}
+
 export function shouldRecordLongTaskSample(
   startMs: number,
   durationMs: number,
@@ -561,6 +572,7 @@ export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPay
     errorType: "PerformancePressure",
     errorMessage,
     topFrame: "frontend.performance",
+    fingerprintHint: performanceFingerprintHintForReason(snapshot.reason),
     buildCommit,
     channel: typeof __BUILD_CHANNEL__ === "string" ? __BUILD_CHANNEL__ : "",
     language: typeof navigator !== "undefined" ? navigator.language || "" : "",

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/tc-hib/winres v0.3.1
+	github.com/wailsapp/go-webview2 v1.0.23
 	github.com/wailsapp/wails/v2 v2.12.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/image v0.43.0
@@ -70,7 +71,6 @@ require (
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/desktop/hang_watchdog.go
+++ b/desktop/hang_watchdog.go
@@ -45,6 +45,17 @@ func mainThreadHeartbeatAge(now time.Time) (time.Duration, time.Time, bool) {
 	return age, time.Unix(0, lastWall), true
 }
 
+func resetMainThreadHeartbeatAfterSleep(lastCheck, now time.Time) bool {
+	if now.Sub(lastCheck) <= mainThreadSleepSkip {
+		return false
+	}
+	// The native UI heartbeat and this Go ticker are both suspended while the
+	// machine sleeps. Treat wake as a fresh observation epoch so the sleep gap
+	// cannot be reported as a multi-minute UI-thread hang on the next tick.
+	recordMainThreadHeartbeat(now)
+	return true
+}
+
 func (a *App) startMainThreadWatchdog() {
 	if !mainThreadWatchdogSupported() {
 		return
@@ -89,7 +100,7 @@ func (a *App) watchMainThreadHeartbeat(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-ticker.C:
-			if now.Sub(lastCheck) > mainThreadSleepSkip {
+			if resetMainThreadHeartbeatAfterSleep(lastCheck, now) {
 				lastCheck = now
 				continue
 			}

--- a/desktop/hang_watchdog_test.go
+++ b/desktop/hang_watchdog_test.go
@@ -72,6 +72,32 @@ func TestMainThreadHeartbeatAgeIgnoresWallClockJump(t *testing.T) {
 	}
 }
 
+func TestWatchdogResetsHeartbeatAfterSleepGap(t *testing.T) {
+	oldBase := mainThreadClockBase
+	oldElapsed := mainThreadLastHeartbeatElapsed.Load()
+	oldWall := mainThreadLastHeartbeatWall.Load()
+	t.Cleanup(func() {
+		mainThreadClockBase = oldBase
+		mainThreadLastHeartbeatElapsed.Store(oldElapsed)
+		mainThreadLastHeartbeatWall.Store(oldWall)
+	})
+
+	base := time.Now()
+	mainThreadClockBase = base
+	recordMainThreadHeartbeat(base)
+	wake := base.Add(8 * time.Hour)
+	if !resetMainThreadHeartbeatAfterSleep(base, wake) {
+		t.Fatal("expected sleep gap to reset the heartbeat")
+	}
+	age, _, ok := mainThreadHeartbeatAge(wake.Add(mainThreadHangCheckInterval))
+	if !ok || age != mainThreadHangCheckInterval {
+		t.Fatalf("age after wake = %s, ok=%v; want %s", age, ok, mainThreadHangCheckInterval)
+	}
+	if resetMainThreadHeartbeatAfterSleep(wake, wake.Add(mainThreadHangCheckInterval)) {
+		t.Fatal("ordinary watchdog interval was treated as sleep")
+	}
+}
+
 func TestRecordMainThreadHangWritesPendingReportAndMetrics(t *testing.T) {
 	t.Cleanup(func() {
 		removeAllPendingCrashes()

--- a/desktop/wails_logger.go
+++ b/desktop/wails_logger.go
@@ -5,14 +5,40 @@ import (
 	goruntime "runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/wailsapp/wails/v2/pkg/logger"
 )
 
 type crashCaptureLogger struct {
-	delegate logger.Logger
-	app      *App
+	delegate         logger.Logger
+	app              *App
+	webView2Failures webView2FailureTracker
+}
+
+const webView2FailureReportCooldown = 10 * time.Minute
+
+type webView2FailureTracker struct {
+	mu           sync.Mutex
+	counts       map[int]int
+	lastReported map[int]time.Time
+}
+
+func (t *webView2FailureTracker) observe(kind int, now time.Time) (occurrence int, shouldReport bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.counts == nil {
+		t.counts = make(map[int]int)
+		t.lastReported = make(map[int]time.Time)
+	}
+	t.counts[kind]++
+	last := t.lastReported[kind]
+	if last.IsZero() || now.Sub(last) >= webView2FailureReportCooldown {
+		t.lastReported[kind] = now
+		return t.counts[kind], true
+	}
+	return t.counts[kind], false
 }
 
 func newCrashCaptureLogger(app *App) logger.Logger {
@@ -41,11 +67,15 @@ func (l *crashCaptureLogger) captureWebView2Failure(message string) {
 	if !ok {
 		return
 	}
-	report := webView2ProcessFailureReport(kind)
-	_ = writePendingReport(report, true)
 	if l.app != nil {
 		l.app.recordDiagnosticMetric("desktop_webview2_failure", webView2ProcessKindBucket(kind))
 	}
+	occurrence, shouldReport := l.webView2Failures.observe(kind, time.Now())
+	if !shouldReport {
+		return
+	}
+	report := webView2ProcessFailureReportWithContext(kind, occurrence, webView2RuntimeVersion())
+	_ = writePendingReport(report, true)
 }
 
 func parseWebView2ProcessFailure(message string) (int, bool) {
@@ -79,6 +109,10 @@ func webView2ProcessKindBucket(kind int) string {
 }
 
 func webView2ProcessFailureReport(kind int) crashReport {
+	return webView2ProcessFailureReportWithContext(kind, 1, webView2RuntimeVersion())
+}
+
+func webView2ProcessFailureReportWithContext(kind, occurrence int, runtimeVersion string) crashReport {
 	bucket := webView2ProcessKindBucket(kind)
 	report := baseCrashReport("crash")
 	report.SchemaVersion = 2
@@ -89,11 +123,19 @@ func webView2ProcessFailureReport(kind int) crashReport {
 	report.TopFrame = "webview2.process." + bucket
 	report.FingerprintHint = "windows.webview2." + bucket
 	report.OccurredAt = time.Now().UTC().Format(time.RFC3339)
+	runtimeVersion = sanitizeCrashField(runtimeVersion, 128)
+	if runtimeVersion == "" {
+		runtimeVersion = "unavailable"
+	}
 	report.Message = sanitizeCrashText(fmt.Sprintf(`[windows.webview2.process_failed]
 
 WebView2 reported a failed child process.
 
 process kind: %s
-kind code: %d`, bucket, kind), maxCrashDetailBytes)
+kind code: %d
+runtime version: %s
+same-process occurrence: %d
+exit code: unavailable from the current Wails ProcessFailed callback
+GPU/driver: unavailable from the current Wails ProcessFailed callback`, bucket, kind, runtimeVersion, occurrence), maxCrashDetailBytes)
 	return report
 }

--- a/desktop/wails_logger.go
+++ b/desktop/wails_logger.go
@@ -108,10 +108,6 @@ func webView2ProcessKindBucket(kind int) string {
 	return names[kind]
 }
 
-func webView2ProcessFailureReport(kind int) crashReport {
-	return webView2ProcessFailureReportWithContext(kind, 1, webView2RuntimeVersion())
-}
-
 func webView2ProcessFailureReportWithContext(kind, occurrence int, runtimeVersion string) crashReport {
 	bucket := webView2ProcessKindBucket(kind)
 	report := baseCrashReport("crash")

--- a/desktop/webview2_runtime_other.go
+++ b/desktop/webview2_runtime_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func webView2RuntimeVersion() string { return "" }

--- a/desktop/webview2_runtime_windows.go
+++ b/desktop/webview2_runtime_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"sync"
+
+	"github.com/wailsapp/go-webview2/webviewloader"
+)
+
+var (
+	webView2RuntimeOnce   sync.Once
+	webView2RuntimeCached string
+)
+
+func webView2RuntimeVersion() string {
+	webView2RuntimeOnce.Do(func() {
+		version, err := webviewloader.GetAvailableCoreWebView2BrowserVersionString("")
+		if err == nil {
+			webView2RuntimeCached = version
+		}
+	})
+	return webView2RuntimeCached
+}

--- a/workers/crash-report/src/index.test.ts
+++ b/workers/crash-report/src/index.test.ts
@@ -6,6 +6,8 @@ import {
   isDevelopmentGroup,
   isKnownNonCrashDiagnostic,
   namespaceReportFingerprint,
+  newestReleaseVersion,
+  diagnosticWindowWhere,
   normalizeForFingerprint,
   Ping,
   Metrics,
@@ -124,6 +126,17 @@ describe("metrics compatibility", () => {
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
     expect(parsed.data.counters).toHaveLength(4);
+  });
+});
+
+describe("stats window and release baseline", () => {
+  it("uses an inclusive calendar window for diagnostic groups", () => {
+    expect(diagnosticWindowWhere(7)).toBe("date(last_seen) >= date('now', '-6 day')");
+    expect(diagnosticWindowWhere(30)).toBe("date(last_seen) >= date('now', '-29 day')");
+  });
+
+  it("does not promote prerelease or synthetic non-semver labels", () => {
+    expect(newestReleaseVersion(["v1.19.4", "v1.20.0-beta.1", "dev", "v9.9.9-test"])).toBe("v1.19.4");
   });
 });
 
@@ -592,5 +605,44 @@ describe("diagnostics dashboard lanes", () => {
     };
     const user = { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" } as const;
     expect(renderStats(data, user, "preferences")).toContain("2026-08-03 07:28Z");
+  });
+
+  it("shows deduplicated affected installs on agent health", () => {
+    type StatsData = Parameters<typeof renderStats>[0];
+    const data: StatsData = {
+      daily: [],
+      versions: [],
+      platforms: [],
+      crashes: [],
+      metrics: [{ signal: "desktop_hang", bucket: "windows_ui_thread", total: 12 }],
+      previousMetrics: [],
+      metricUsers: [{ signal: "desktop_hang", bucket: "windows_ui_thread", total: 3 }],
+      metricUsersUnavailable: false,
+      metricUsersComputedAt: "",
+      sources: [],
+      overview: { latestAdoptionPct: null, openReports: 0, newLatestReports: 0, regressedReports: 0, criticalOpenReports: 0 },
+      latestVersion: "v1.19.4",
+      filters: {
+        surface: "desktop",
+        status: "",
+        source: "",
+        version: "",
+        os: "",
+        platform: "",
+        newLatest: false,
+        regressed: false,
+        windowDays: 7,
+        preferenceMode: "users",
+      },
+    };
+    const html = renderStats(
+      data,
+      { id: 1, email: "viewer@example.com", role: "viewer", created_at: "", approved_at: "" },
+      "health",
+    );
+    const installs = html.slice(html.indexOf("Affected installs"), html.indexOf("Signal distributions"));
+    expect(installs).toContain("Desktop hangs");
+    expect(installs).toContain(">3<");
+    expect(installs).not.toContain(">12<");
   });
 });

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -721,7 +721,7 @@ function statsFilters(url: URL): StatsFilters {
 }
 
 async function crashGroups(env: Env, filters: StatsFilters, latestVersion: string) {
-  const where: string[] = [];
+  const where: string[] = [diagnosticWindowWhere(filters.windowDays)];
   const binds: unknown[] = [];
   const add = (sql: string, value?: unknown) => {
     where.push(sql.replace("?", `?${binds.length + 1}`));
@@ -846,7 +846,10 @@ type ParsedVersion = {
 };
 
 function parseReleaseVersion(version: string): ParsedVersion | null {
-  const m = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  // The dashboard's "latest" lane is for shipped stable builds. Development,
+  // prerelease, and build-metadata values remain visible in version facets but
+  // must not become the release baseline used for regression triage.
+  const m = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
   if (!m) return null;
   return {
     version,
@@ -856,7 +859,7 @@ function parseReleaseVersion(version: string): ParsedVersion | null {
   };
 }
 
-function newestReleaseVersion(versions: string[]): string {
+export function newestReleaseVersion(versions: string[]): string {
   const parsed = versions
     .filter((v) => v && v.toLowerCase() !== "dev")
     .map(parseReleaseVersion)
@@ -873,13 +876,12 @@ function newestReleaseVersion(versions: string[]): string {
 
 async function latestObservedVersion(env: Env, surface: ClientSurfaceName): Promise<string> {
   const table = telemetryTableNames(surface).pings;
-  const sql = surface === "desktop"
-    ? `SELECT version FROM (
-         SELECT version FROM ${table} WHERE date >= date('now', '-29 day')
-         UNION
-         SELECT last_version AS version FROM groups
-       ) AS versions WHERE version <> ''`
-    : `SELECT version FROM ${table} WHERE date >= date('now', '-29 day') AND version <> ''`;
+  // Require independent installations and use pings as the sole source of
+  // release truth. A single synthetic diagnostic must never promote v9.9.9 (or
+  // a prerelease) to "latest" for every report group.
+  const sql = `SELECT version FROM ${table}
+    WHERE date >= date('now', '-29 day') AND version <> ''
+    GROUP BY version HAVING COUNT(DISTINCT install_id) >= 2`;
   const rows = await env.DB.prepare(sql).all<{ version: string }>();
   return newestReleaseVersion(rows.results.map((r) => r.version));
 }
@@ -937,7 +939,7 @@ async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30,
           SUM(CASE WHEN first_version = ?1 THEN 1 ELSE 0 END) AS new_latest_reports,
           SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
           SUM(CASE WHEN status = 'open' AND ${criticalActionable} THEN 1 ELSE 0 END) AS critical_open_reports
-        FROM groups`,
+        FROM groups WHERE ${diagnosticWindowWhere(days)}`,
       )
         .bind(latestVersion)
         .first<{ open_reports: number; new_latest_reports: number; regressed_reports: number; critical_open_reports: number }>()
@@ -947,7 +949,7 @@ async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30,
           0 AS new_latest_reports,
           SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
           SUM(CASE WHEN status = 'open' AND ${criticalActionable} THEN 1 ELSE 0 END) AS critical_open_reports
-        FROM groups`,
+        FROM groups WHERE ${diagnosticWindowWhere(days)}`,
       ).first<{ open_reports: number; new_latest_reports: number; regressed_reports: number; critical_open_reports: number }>();
   const [row, adoptionPct] = await Promise.all([
     diagnosticCounts,
@@ -964,6 +966,10 @@ async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30,
 
 function currentWindowSince(days: 7 | 30): string {
   return `-${days - 1} day`;
+}
+
+export function diagnosticWindowWhere(days: 7 | 30): string {
+  return `date(last_seen) >= date('now', '${currentWindowSince(days)}')`;
 }
 
 function previousWindowSince(days: 7 | 30): string {
@@ -1092,7 +1098,7 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     latestVersion = await latestObservedVersion(env, "desktop");
     const [crashesR, sourcesR, versionsR, platformsR] = await Promise.all([
       crashGroups(env, filters, latestVersion),
-      bars("SELECT source AS label, COUNT(*) AS users FROM groups GROUP BY source ORDER BY users DESC"),
+      bars(`SELECT source AS label, COUNT(*) AS users FROM groups WHERE ${diagnosticWindowWhere(days)} GROUP BY source ORDER BY users DESC`),
       pingVersions(),
       pingPlatforms(),
     ]);
@@ -1107,7 +1113,16 @@ async function handleStats(request: Request, env: Env, user: User, activeModule:
     metricUsers = usersR?.rows ?? [];
     metricUsersComputedAt = usersR?.computedAt ?? "";
   } else {
-    [metrics, previousMetrics] = await Promise.all([metricRows(env, days, surface), metricRows(env, days, surface, true)]);
+    const [metricsR, previousMetricsR, usersR] = await Promise.all([
+      metricRows(env, days, surface),
+      metricRows(env, days, surface, true),
+      metricUserRows(env, days, surface),
+    ]);
+    metrics = metricsR;
+    previousMetrics = previousMetricsR;
+    metricUsersUnavailable = usersR === null;
+    metricUsers = usersR?.rows ?? [];
+    metricUsersComputedAt = usersR?.computedAt ?? "";
   }
 
   return html(

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -564,7 +564,7 @@ function preferencePanel(title: string, body: string, active: boolean): string {
 
 function reportGroups(rows: CrashRow[], compact = false): string {
   if (!rows.length) return `<div class="empty">${i18n("No diagnostic reports yet — that's the good kind of empty", "还没有诊断报告，这是好消息")}</div>`;
-  return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span>${i18n("count", "次数")}</span></div>${rows
+  return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span title="${i18n("Groups are filtered by the selected window; occurrence totals are lifetime counts", "分组按所选时间窗口过滤；次数为全生命周期累计")}">${i18n("lifetime count", "累计次数")}</span></div>${rows
     .map((c) => {
       const platform = [c.last_os, c.last_arch].filter(Boolean).join("/");
       const versions = `${c.first_version || "?"} → ${c.last_version || "?"}`;
@@ -619,6 +619,7 @@ export function renderStats(
   const anyPing = days.some((d) => d.opens > 0);
   const agentMetrics = data.metrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
   const previousAgentMetrics = data.previousMetrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
+  const agentMetricUsers = data.metricUsers.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
   const isSettingsSignal = (signal: string) =>
     signal === "client_surface" || signal === "client_version" || signal.startsWith("settings_") ||
     ["cli_mode", "cli_profile", "cli_permission_mode", "cli_session_mode"].includes(signal);
@@ -746,6 +747,9 @@ ${filters}
   const computedAt = data.metricUsersComputedAt
     ? ` <b>${esc(data.metricUsersComputedAt.slice(0, 16).replace("T", " "))}Z</b>`
     : "";
+  const healthComputedAt = data.metricUsersComputedAt
+    ? ` ${esc(data.metricUsersComputedAt.slice(0, 16).replace("T", " "))}Z`
+    : "";
   const installsPanel = preferencePanel(
     i18nHTML(
       `Deduplicated installs <b>— ${rangeText}</b>${computedAt ? ` computed${computedAt}` : ""}`,
@@ -766,6 +770,13 @@ ${filters}
 <div class="preference-compare">${preferencePanels}</div></section>`;
   const healthModule = `<section id="health" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Agent health", "运行健康")}</h2></div><div class="module-actions"><a class="module-action" href="${esc(filterQS({}, "preferences"))}">${i18n("Preferences", "设置偏好")}</a></div></div>
 <section class="module-panel"><h3>${i18nHTML(`Health summary <b>— ${rangeText}, compared with previous window</b>`, `健康摘要 <b>— ${rangeText}，对比上一窗口</b>`)}</h3>${agentHealth(agentMetrics, previousAgentMetrics)}</section>
+<section class="module-panel"><h3>${i18nHTML(`Affected installs <b>— ${rangeText}, deduplicated${healthComputedAt ? `, computed ${healthComputedAt}` : ""}</b>`, `受影响安装 <b>— ${rangeText}，按安装去重${healthComputedAt ? `，统计于 ${healthComputedAt}` : ""}</b>`)}</h3>${
+    data.metricUsersUnavailable
+      ? `<div class="empty">${range === 30
+          ? i18nHTML(`The 30-day deduplication is not ready. <a href="${esc(filterQS({ window: "7d" }, "health"))}">Use 7d</a> meanwhile.`, `30 天去重统计尚未就绪。<a href="${esc(filterQS({ window: "7d" }, "health"))}">先看 7 天</a>。`)
+          : i18n(`The ${rangeText} deduplication did not finish.`, `${rangeText} 的去重统计没能跑完。`)}</div>`
+      : metricsCards(agentMetricUsers, ["desktop_hang", "desktop_hang_age", "desktop_webview2_failure", "desktop_restore", "desktop_exit"])
+  }</section>
 <section class="module-panel"><h3>${i18nHTML(`Signal distributions <b>— ${rangeText}, opt-in aggregate</b>`, `信号分布 <b>— ${rangeText}，opt-in 汇总</b>`)}</h3>${metricsCards(agentMetrics)}</section>
 </section>`;
   const activeModuleHTML: Record<StatsModule, string> = {


### PR DESCRIPTION
## Summary

- make diagnostics 7d and 30d filters apply consistently to report groups, source facets, and overview counts while labeling occurrence totals as lifetime values
- derive the latest stable release only from independent installation pings, and add deduplicated affected-install counts to Agent Health
- reduce virtual-list measurement render churn, reset watchdog epochs after sleep, tier heap-pressure groups, and enrich throttled WebView2 reports with runtime and same-process occurrence context

## Issues

Refs #6748

Follow-up to #6900.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go test -race .`
- `cd desktop && go vet ./...`
- `cd desktop && GOOS=windows GOARCH=amd64 go test -c -o /tmp/reasonix-windows-compile/desktop.test.exe ./`
- frontend crash-reporting and line-number viewer tests: 164 passed
- `cd desktop/frontend && pnpm run typecheck`
- `cd workers/crash-report && npm test`: 83 passed
- `cd workers/crash-report && npm run typecheck`
- `./scripts/cache-guard.sh`
- `git diff --check origin/main-v2...HEAD`

## Compatibility

| Change | Old-data / old-version behavior | Conclusion |
| --- | --- | --- |
| Diagnostic window filters | Existing group rows and schema are unchanged; groups are selected by the existing `last_seen` field | Backward-safe |
| Latest release baseline | Read-only dashboard logic now ignores diagnostic-only and prerelease values | Backward-safe |
| WebView2 report context | Uses the existing report schema and adds bounded text context only | Backward-safe |
| Heap pressure tiers | Uses the already-optional `fingerprintHint`; old clients continue grouping as before | Backward-safe |
| Virtualizer and watchdog state | No persisted or Wails JSON contract changes | Backward-safe |

## Concurrency audit

- VERIFIED SAFE: WebView2 per-process counters and cooldown timestamps share one mutex.
- VERIFIED SAFE: Windows Runtime version lookup is guarded by `sync.Once`.
- VERIFIED SAFE: watchdog heartbeat state continues to use the existing atomics; wake reset writes through the same helper.
- No session, controller, lease, or persisted-state ownership path is changed.

## Cache impact

Cache-impact: none — no provider-visible prompt, tool schema or order, memory prefix, compaction, or request serialization changes.
Cache-guard: `./scripts/cache-guard.sh` passed all scenarios.
System-prompt-review: N/A