### PR TITLE
fix(serve): unbreak session titles on reasoning models and stop per-poll regeneration

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1207,7 +1207,12 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 			{Role: provider.RoleUser, Content: firstMsg},
 		},
 		Temperature: provider.TemperaturePtr(0),
-		MaxTokens:   20,
+		// Reasoning models (DeepSeek v4 thinks by default; the retired
+		// effort=off now falls back to thinking-on) burn part of the budget on
+		// reasoning before any visible title text. 20 tokens gets fully eaten
+		// by reasoning, yielding an empty title and a title cache that never
+		// fills — so /sessions re-generates every title on every request.
+		MaxTokens: 200,
 	})
 	if err != nil {
 		return ""

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1399,7 +1399,7 @@ func removeSessionFiles(absDir, abs string) error {
 // when it matches the file's mtime, otherwise a freshly generated one (cached
 // for next time), falling back to a truncated preview when generation is off.
 func (s *Server) sessionTitle(ctx context.Context, name, first string, mod int64) string {
-	if cached, ok := s.titles.get(name, mod); ok {
+	if cached, ok := s.titles.get(name); ok {
 		return cached
 	}
 	if title := s.generateTitle(ctx, first); title != "" {

--- a/internal/serve/titlecache.go
+++ b/internal/serve/titlecache.go
@@ -10,9 +10,11 @@ import (
 )
 
 // titleCache persists generated session titles to <dir>/.session-titles.json,
-// keyed by file name and invalidated by mtime, so the flash model is queried
-// once per session rather than on every sidebar refresh. Persistence is
-// best-effort: a missing or unreadable cache just regenerates.
+// keyed by file name, so the flash model is queried once per session rather
+// than on every sidebar refresh. Titles are sticky: they summarize the first
+// message, which never changes, so mtime churn on an active session must not
+// trigger regeneration. Persistence is best-effort: a missing or unreadable
+// cache just regenerates.
 type titleCache struct {
 	mu      sync.Mutex
 	dir     string
@@ -39,11 +41,11 @@ func (c *titleCache) load() {
 	}
 }
 
-func (c *titleCache) get(name string, mod int64) (string, bool) {
+func (c *titleCache) get(name string) (string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.load()
-	if e, ok := c.entries[name]; ok && e.Mod == mod {
+	if e, ok := c.entries[name]; ok {
 		return e.Title, true
 	}
 	return "", false

--- a/internal/serve/titlecache_test.go
+++ b/internal/serve/titlecache_test.go
@@ -6,20 +6,24 @@ import (
 	"testing"
 )
 
-func TestTitleCacheReusesUntilMtimeChanges(t *testing.T) {
+func TestTitleCacheStickyAcrossMtimeChanges(t *testing.T) {
 	dir := t.TempDir()
 	c := newTitleCache(dir)
 
-	if _, ok := c.get("a.jsonl", 100); ok {
+	if _, ok := c.get("a.jsonl"); ok {
 		t.Fatal("empty cache should miss")
 	}
 
 	c.put("a.jsonl", "First Title", 100)
-	if got, ok := c.get("a.jsonl", 100); !ok || got != "First Title" {
-		t.Fatalf("hit on matching mtime = %q,%v, want First Title,true", got, ok)
+	if got, ok := c.get("a.jsonl"); !ok || got != "First Title" {
+		t.Fatalf("hit after put = %q,%v, want First Title,true", got, ok)
 	}
-	if _, ok := c.get("a.jsonl", 200); ok {
-		t.Fatal("changed mtime should invalidate the cached title")
+	// Mtime churn on an active session must not invalidate: the title
+	// summarizes the first message, which never changes. Re-validating by
+	// mtime cost one LLM call on every sidebar poll while chatting.
+	c.put("a.jsonl", "First Title", 200)
+	if got, ok := c.get("a.jsonl"); !ok || got != "First Title" {
+		t.Fatalf("mtime change must not invalidate sticky title = %q,%v", got, ok)
 	}
 }
 
@@ -30,7 +34,7 @@ func TestTitleCachePersistsAcrossInstances(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, ".session-titles.json")); err != nil {
 		t.Fatalf("cache file not written: %v", err)
 	}
-	if got, ok := newTitleCache(dir).get("a.jsonl", 7); !ok || got != "Persisted" {
+	if got, ok := newTitleCache(dir).get("a.jsonl"); !ok || got != "Persisted" {
 		t.Fatalf("fresh instance get = %q,%v, want Persisted,true", got, ok)
 	}
 }


### PR DESCRIPTION
## Summary

- Session-title generation called the flash provider with `MaxTokens: 20`. Reasoning models (DeepSeek v4 thinks by default; the retired `effort=off` now falls back to thinking-on) spend the whole budget on reasoning and return empty content, so titles never generate and the on-disk title cache never fills. `GET /sessions` then re-runs one LLM call per untitled session on **every** sidebar poll (~28s per request with ~20 sessions), stalling the web UI.
- The title cache was keyed by (name, mtime). Active sessions change mtime constantly, so their titles were invalidated and regenerated on every poll — one extra LLM call per refresh even after the cache had warmed.

Fixes:

1. Raise the title request to `MaxTokens: 200` so reasoning plus a short title fit.
2. Make titles sticky per session file name; mtime no longer invalidates (a title summarizes the first message, which never changes).

## Issues

No existing report found for this (searched "session title" issues/PRs; existing ones cover title text/localization, not this performance failure).

## Verification

- Reproduced against api.deepseek.com: a title-style request with `max_tokens=20` returns `finish_reason: "length"` with empty `content` (all budget consumed by reasoning).
- Before: `GET /sessions` consistently 28–34s. After: first poll ~63s (cold cache, ~20 titles), subsequent polls 0.12–0.18s; `.session-titles.json` persists and no regeneration occurs while the session is active.
- `go test ./internal/serve/` passes, including updated `TestTitleCacheStickyAcrossMtimeChanges` and `TestTitleCachePersistsAcrossInstances`.

## Cache impact

Cache-impact: none — the title provider is a separate lightweight flash client; no shared prompt prefix or session-cache surface changes.
Cache-guard: `go test ./internal/serve/` (TestTitleCacheStickyAcrossMtimeChanges, TestTitleCachePersistsAcrossInstances).
System-prompt-review: N/A