### PR TITLE
fix(config): never let a missing system_prompt_file abort startup; probe workspace then Reasonix home

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -360,7 +360,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
 	if err != nil {
-		return nil, err
+		// A missing or unreadable prompt file must not block startup: warn and
+		// fall back to the inline (or built-in default) system prompt.
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: err.Error() + "; falling back to inline/default system prompt"})
+		sysPrompt = cfg.InlineSystemPrompt()
 	}
 	// Output style: fold the selected persona/tone block into the base prompt
 	// before language/memory/skills append, so a "replace" style (keep-coding

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2103,17 +2103,34 @@ func (c *Config) ResolveSystemPrompt() (string, error) {
 // ResolveSystemPromptForRoot is like ResolveSystemPrompt but resolves a relative
 // system_prompt_file against root. Desktop tabs pass their workspace root here so
 // prompt files are project-scoped even when the process cwd is elsewhere.
+// A relative path is probed under the workspace root first (project override),
+// then under the Reasonix home (global default); only when every location is
+// unreadable does it return an error, and callers fall back to the inline prompt.
 func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 	if c.Agent.SystemPromptFile != "" {
 		path := c.Agent.SystemPromptFile
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(resolveRoot(root), path)
+		if filepath.IsAbs(path) {
+			b, err := fileencoding.ReadFileUTF8(path)
+			if err != nil {
+				return "", fmt.Errorf("system_prompt_file: %w", err)
+			}
+			return strings.TrimSpace(string(b)), nil
 		}
-		b, err := fileencoding.ReadFileUTF8(path)
-		if err != nil {
-			return "", fmt.Errorf("system_prompt_file: %w", err)
+		candidates := []string{filepath.Join(resolveRoot(root), path)}
+		if home := ReasonixHomeDir(); home != "" {
+			candidates = append(candidates, filepath.Join(home, path))
 		}
-		return strings.TrimSpace(string(b)), nil
+		var firstErr error
+		for _, candidate := range candidates {
+			b, err := fileencoding.ReadFileUTF8(candidate)
+			if err == nil {
+				return strings.TrimSpace(string(b)), nil
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+		return "", fmt.Errorf("system_prompt_file: %w (tried: %s)", firstErr, strings.Join(candidates, ", "))
 	}
 	return c.InlineSystemPrompt(), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2115,10 +2115,16 @@ func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 		}
 		return strings.TrimSpace(string(b)), nil
 	}
+	return c.InlineSystemPrompt(), nil
+}
+
+// InlineSystemPrompt returns the configured system_prompt, or DefaultSystemPrompt
+// when unset. It is the fallback when system_prompt_file cannot be read.
+func (c *Config) InlineSystemPrompt() string {
 	if strings.TrimSpace(c.Agent.SystemPrompt) == "" {
-		return DefaultSystemPrompt, nil
+		return DefaultSystemPrompt
 	}
-	return c.Agent.SystemPrompt, nil
+	return c.Agent.SystemPrompt
 }
 
 // Validate checks that the selected model's provider is usable.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2130,7 +2130,7 @@ func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 				firstErr = err
 			}
 		}
-		return "", fmt.Errorf("system_prompt_file: %w (tried: %s)", firstErr, strings.Join(candidates, ", "))
+		return "", fmt.Errorf("system_prompt_file %q not found at any of these locations: %s (%w)", path, strings.Join(candidates, ", "), firstErr)
 	}
 	return c.InlineSystemPrompt(), nil
 }

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -212,7 +212,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	if c.Agent.SystemPromptFile != "" {
 		fmt.Fprintf(&b, "system_prompt_file = %q\n", c.Agent.SystemPromptFile)
 	} else {
-		b.WriteString("# system_prompt_file = \"prompts/system.md\"   # overrides system_prompt when set\n")
+		b.WriteString("# system_prompt_file = \"prompts/system.md\"   # overrides system_prompt when set; relative paths probe <workspace> then <reasonix home>\n")
 	}
 	fmt.Fprintf(&b, "temperature       = %s\n", formatFloat(c.Agent.Temperature))
 	if strings.TrimSpace(c.Agent.RecoveryModel) != "" {

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -27,6 +27,7 @@ func TestDefaultSystemPromptStaysLean(t *testing.T) {
 
 func TestResolveSystemPromptForRootRelativePath(t *testing.T) {
 	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -68,19 +69,79 @@ func TestResolveSystemPromptForRootAbsolutePath(t *testing.T) {
 }
 
 func TestResolveSystemPromptForRootMissingFile(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
 	cfg := Default()
 	cfg.Agent.SystemPromptFile = "prompts/does-not-exist.md"
 
-	if _, err := cfg.ResolveSystemPromptForRoot(t.TempDir()); err == nil {
+	_, err := cfg.ResolveSystemPromptForRoot(root)
+	if err == nil {
 		t.Fatal("expected error for missing system_prompt_file")
+	}
+	// All probed locations must be listed so users can see where it looked.
+	for _, tried := range []string{filepath.Join(root, "prompts", "does-not-exist.md"), filepath.Join(home, "prompts", "does-not-exist.md")} {
+		if !strings.Contains(err.Error(), tried) {
+			t.Fatalf("error %q does not list tried path %q", err, tried)
+		}
 	}
 	if got := cfg.InlineSystemPrompt(); got != DefaultSystemPrompt {
 		t.Fatalf("InlineSystemPrompt fallback = %q, want DefaultSystemPrompt", got)
 	}
 }
 
+func TestResolveSystemPromptForRootFallsBackToReasonixHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "system.md"), []byte(" home prompt \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "system.md")
+
+	// Workspace root has no such file; the Reasonix-home copy must win the probe.
+	got, err := cfg.ResolveSystemPromptForRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "home prompt" {
+		t.Fatalf("system prompt = %q, want %q", got, "home prompt")
+	}
+}
+
+func TestResolveSystemPromptForRootWorkspaceWins(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	for dir, content := range map[string]string{home: "home prompt", root: "workspace prompt"} {
+		if err := os.MkdirAll(filepath.Join(dir, "prompts"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "prompts", "system.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "system.md")
+
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "workspace prompt" {
+		t.Fatalf("system prompt = %q, want workspace copy to win, got %q", got, "workspace prompt")
+	}
+}
+
 func TestResolveSystemPromptForRootDecodesGB18030(t *testing.T) {
 	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -80,6 +80,9 @@ func TestResolveSystemPromptForRootMissingFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing system_prompt_file")
 	}
+	if !strings.Contains(err.Error(), "not found at any of these locations") {
+		t.Fatalf("error %q missing friendly not-found message", err)
+	}
 	// All probed locations must be listed so users can see where it looked.
 	for _, tried := range []string{filepath.Join(root, "prompts", "does-not-exist.md"), filepath.Join(home, "prompts", "does-not-exist.md")} {
 		if !strings.Contains(err.Error(), tried) {

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -67,6 +67,18 @@ func TestResolveSystemPromptForRootAbsolutePath(t *testing.T) {
 	}
 }
 
+func TestResolveSystemPromptForRootMissingFile(t *testing.T) {
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = "prompts/does-not-exist.md"
+
+	if _, err := cfg.ResolveSystemPromptForRoot(t.TempDir()); err == nil {
+		t.Fatal("expected error for missing system_prompt_file")
+	}
+	if got := cfg.InlineSystemPrompt(); got != DefaultSystemPrompt {
+		t.Fatalf("InlineSystemPrompt fallback = %q, want DefaultSystemPrompt", got)
+	}
+}
+
 func TestResolveSystemPromptForRootDecodesGB18030(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -28,7 +28,7 @@ ask_request = true   # notify when a question is waiting
 
 [agent]
 # system_prompt = "You are ..."   # custom persona/prompt; unset or empty = built-in default
-# system_prompt_file = "prompts/system.md"   # overrides system_prompt when set
+# system_prompt_file = "prompts/system.md"   # overrides system_prompt when set; relative paths probe <workspace> then <reasonix home>
 temperature       = 0.0
 # recovery_model = ""               # optional reviewer for low-risk automatic recovery; falls back to guardian_model then main model
 # reasoning_language = "auto"   # visible reasoning text: auto|zh|en


### PR DESCRIPTION
## Summary

Three related changes to `system_prompt_file` handling:

1. **Startup crash fix.** A missing or unreadable `system_prompt_file` aborted boot (`return nil, err`), so a stale path in config made the CLI/serve fail to start at all. Boot now warns (`system_prompt_file ... falling back to inline/default system prompt`) and falls back to the configured `system_prompt` or the built-in default.
2. **Multi-location probe for relative paths.** A relative `system_prompt_file` used to resolve only against the workspace root. It now probes the workspace root first (project override), then the Reasonix home (global default, next to `config.toml`) — matching where users naturally put the file. Only when every location misses does resolution fail.
3. **Actionable error.** When all locations miss, the error names the configured value and lists every tried path: `system_prompt_file "prompts/system.md" not found at any of these locations: ...`.

Absolute paths behave exactly as before; the workspace copy still wins when both exist.

## Issues

No existing report found.

## Verification

- Reproduced the crash with v1.17.21/1.19.3: `error: system_prompt_file: open .../prompts/system.md: no such file or directory`, exit 1 before any session starts.
- After the fix the same setup warns and continues with the fallback prompt.
- `go test ./internal/config/` passes, including new `TestResolveSystemPromptForRootMissingFile` (error lists all tried paths), `TestResolveSystemPromptForRootFallsBackToReasonixHome`, and `TestResolveSystemPromptForRootWorkspaceWins`.

## Cache impact

Cache-impact: low — prompt content is unchanged for every configuration that worked before (absolute paths and workspace-relative files resolve identically; workspace still wins). Only the previously crashing missing-file case now yields the default prompt instead of a boot error.
Cache-guard: `go test ./internal/config/ -run TestResolveSystemPrompt` (6 focused tests covering relative/absolute/GB18030/missing/home-fallback/workspace-precedence).
System-prompt-review: touches `system_prompt_file` resolution (fallback + one extra probe location); no change to the resolved prompt bytes for previously working setups.