### PR TITLE
fix(serve): surface session-delete failures in the web UI

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -691,6 +691,7 @@ const __T = {
     'delete': 'Delete',
     'delete_session': 'Delete Session',
     'cannot_delete_active': 'Cannot delete the active session',
+    'delete_failed': 'Could not delete the session. Check your connection and try again.',
     'search_sessions': 'Search sessions',
     'active': 'Active',
     'use_model': 'Use',
@@ -827,6 +828,7 @@ const __T = {
     'delete': '删除',
     'delete_session': '删除会话',
     'cannot_delete_active': '无法删除当前会话',
+    'delete_failed': '无法删除会话，请检查连接后重试',
     'search_sessions': '搜索会话',
     'active': '当前',
     'use_model': '使用',
@@ -1863,7 +1865,7 @@ $('#delete-confirm').onclick=()=>{
   post('/delete-session',{name}).then(async r=>{
     if(!r.ok){showNotice((await r.text()).trim()||('HTTP '+r.status),'warn');}
     loadSessions();
-  });
+  }).catch(()=>showNotice(__('delete_failed'),'warn'));
 };
 
 // welcome examples

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -690,6 +690,7 @@ const __T = {
     'cancel_plain': 'Cancel',
     'delete': 'Delete',
     'delete_session': 'Delete Session',
+    'cannot_delete_active': 'Cannot delete the active session',
     'search_sessions': 'Search sessions',
     'active': 'Active',
     'use_model': 'Use',
@@ -825,6 +826,7 @@ const __T = {
     'cancel_plain': '取消',
     'delete': '删除',
     'delete_session': '删除会话',
+    'cannot_delete_active': '无法删除当前会话',
     'search_sessions': '搜索会话',
     'active': '当前',
     'use_model': '使用',
@@ -1846,7 +1848,10 @@ document.addEventListener('click',e=>{
   const del=e.target.closest('.session-del');
   if(!del)return;
   e.stopPropagation();
-  openDeleteSession(del.dataset.name);
+  const name=del.dataset.name;
+  const target=sessionsCache.find(s=>s.name===name);
+  if(target&&target.current){showNotice(__('cannot_delete_active'),'warn');return;}
+  openDeleteSession(name);
 });
 $('#delete-modal-close').onclick=()=>closeDeleteSession();
 $('#delete-cancel').onclick=()=>closeDeleteSession();
@@ -1855,7 +1860,10 @@ $('#delete-confirm').onclick=()=>{
   const name=pendingDeleteSession;
   if(!name)return;
   closeDeleteSession();
-  post('/delete-session',{name}).then(()=>loadSessions());
+  post('/delete-session',{name}).then(async r=>{
+    if(!r.ok){showNotice((await r.text()).trim()||('HTTP '+r.status),'warn');}
+    loadSessions();
+  });
 };
 
 // welcome examples

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -313,6 +313,23 @@ func TestServeIndexDefinesQueryHelpers(t *testing.T) {
 	}
 }
 
+func TestServeIndexReportsSessionDeleteFailures(t *testing.T) {
+	html := string(indexHTML)
+	for _, want := range []string{
+		"'cannot_delete_active': 'Cannot delete the active session'",
+		"'cannot_delete_active': '无法删除当前会话'",
+		"'delete_failed': 'Could not delete the session. Check your connection and try again.'",
+		"'delete_failed': '无法删除会话，请检查连接后重试'",
+		"if(target&&target.current){showNotice(__('cannot_delete_active'),'warn');return;}",
+		"if(!r.ok){showNotice((await r.text()).trim()||('HTTP '+r.status),'warn');}",
+		"}).catch(()=>showNotice(__('delete_failed'),'warn'));",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("serve index missing session delete failure handling %q", want)
+		}
+	}
+}
+
 func TestServeIndexHandlesRetryingEvents(t *testing.T) {
 	html := string(indexHTML)
 	for _, want := range []string{


### PR DESCRIPTION
## Summary

Deleting a session from the sidebar silently swallowed non-2xx responses, so the click appeared to do nothing. The most common case: deleting the **active** session, which the server correctly refuses with `409 cannot delete active session` — the frontend's `post().then()` never checked the status, silently reloaded the list, and the user could not tell whether the delete failed, the list didn't refresh, or things were just slow.

Two changes in `internal/serve/index.html`:

1. Clicking the delete (×) button on the **active** session now shows a localized notice — `无法删除当前会话` / `Cannot delete the active session` — without opening the confirmation modal or calling the API (the entry is already marked `current` in `/sessions`).
2. Any other non-2xx delete response shows the server's error text via `showNotice` instead of failing silently.

## Issues

No existing report found.

## Verification

- `POST /delete-session` for the active session returns `409 cannot delete active session`; for an inactive session `204` and the files are removed (both exercised against a live serve).
- The served page contains the new `cannot_delete_active` strings (en + zh) and guard logic.
- `go test ./internal/serve/` passes.

## Cache impact

Cache-impact: none — frontend HTML/JS only, no prompt or provider-visible surface.
Cache-guard: `go test ./internal/serve/`.
System-prompt-review: N/A