### PR TITLE
Bound session event-log replay / 限制会话事件日志重放

### DIFF
--- a/desktop/session_errors.go
+++ b/desktop/session_errors.go
@@ -4,16 +4,34 @@ import (
 	"errors"
 	"log/slog"
 	"syscall"
+
+	"reasonix/internal/agent"
 )
 
 // Sanitized errors surfaced when a destructive or restore session operation
 // hits a real filesystem blocker. Like errSessionBusyElsewhere, they
 // intentionally carry no path, so raw OS error text never reaches the UI.
 var (
-	errSessionFileLocked       = errors.New("a session file is temporarily locked by another program (often antivirus or sync tools) — wait a moment and retry")
-	errSessionFileAccessDenied = errors.New("access to a session file was denied — close programs that may be using it or check folder permissions, then retry")
-	errSessionDiskFull         = errors.New("not enough disk space to finish the operation — free some space and retry")
+	errSessionFileLocked        = errors.New("a session file is temporarily locked by another program (often antivirus or sync tools) — wait a moment and retry")
+	errSessionFileAccessDenied  = errors.New("access to a session file was denied — close programs that may be using it or check folder permissions, then retry")
+	errSessionDiskFull          = errors.New("not enough disk space to finish the operation — free some space and retry")
+	errSessionHistoryUnreadable = errors.New("session history could not be loaded safely; the session files were left unchanged")
 )
+
+// friendlySessionLoadError keeps decoder details and local paths in logs while
+// preserving the already path-free replay-budget error for the startup banner.
+// A failed authoritative event log must never be hidden by opening an empty
+// session or falling back to an older checkpoint.
+func friendlySessionLoadError(err error) error {
+	if err == nil || errors.Is(err, agent.ErrSessionReplayLimitExceeded) {
+		return err
+	}
+	if friendly := friendlySessionFileError(err); !errors.Is(friendly, err) {
+		return friendly
+	}
+	slog.Warn("desktop: session history load failed", "err", err)
+	return errSessionHistoryUnreadable
+}
 
 // friendlySessionFileError rewrites raw OS-level filesystem errors from the
 // session trash/restore/purge flows (e.g. a Windows sharing violation while a

--- a/desktop/session_errors_test.go
+++ b/desktop/session_errors_test.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
 	"testing"
+
+	"reasonix/internal/agent"
 )
 
 // Platform errnos for the blocked-file classes. Windows values follow the
@@ -71,5 +75,27 @@ func TestFriendlySessionFileErrorPassesThroughOtherErrors(t *testing.T) {
 	notExist := &os.PathError{Op: "lstat", Path: "gone.jsonl", Err: syscall.ENOENT}
 	if got := friendlySessionFileError(notExist); got != error(notExist) {
 		t.Fatalf("not-exist error rewritten to %v", got)
+	}
+}
+
+func TestFriendlySessionLoadErrorPreservesBudgetAndSanitizesDecoderDetails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "private-session.jsonl")
+	limitErr := &agent.SessionReplayLimitError{
+		Path: path, Resource: "encoded_bytes", Value: 200, Limit: 100,
+	}
+	if got := friendlySessionLoadError(limitErr); got != limitErr {
+		t.Fatalf("budget error = %v, want original path-free error", got)
+	}
+	if strings.Contains(limitErr.Error(), path) {
+		t.Fatalf("budget error leaked path: %q", limitErr)
+	}
+
+	decodeErr := fmt.Errorf("decode %s: malformed event", path)
+	got := friendlySessionLoadError(decodeErr)
+	if !errors.Is(got, errSessionHistoryUnreadable) {
+		t.Fatalf("decoder error = %v, want errSessionHistoryUnreadable", got)
+	}
+	if strings.Contains(got.Error(), path) {
+		t.Fatalf("sanitized decoder error leaked path: %q", got)
 	}
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3832,21 +3832,55 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 		}
 		var path string
 		var resumeSession *agent.Session
+		var resumeLoadErr error
 		// Prefer the exact session file persisted for this tab. Topic lookup is a
 		// compatibility fallback for older desktop-tabs.json files that only stored
 		// topicId and could pick the wrong session when one topic had multiple files.
-		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tabSessionPath, loadedSession); ok {
+		if loaded, pinnedPath, ok, loadErr := loadPinnedTabSessionWithPreload(dir, tabSessionPath, loadedSession); loadErr != nil {
+			resumeLoadErr = loadErr
+		} else if ok {
 			path = pinnedPath
 			resumeSession = loaded
 		}
-		if path == "" && tabTopicID != "" {
+		if resumeLoadErr == nil && path == "" && tabTopicID != "" {
 			existingPath := findTopicSession(dir, tabTopicID)
 			if existingPath != "" {
 				if loaded, err := loadResumableSession(existingPath); err == nil {
 					path = existingPath
 					resumeSession = loaded
+				} else {
+					resumeLoadErr = err
 				}
 			}
+		}
+		if resumeLoadErr != nil {
+			resumeLoadErr = friendlySessionLoadError(resumeLoadErr)
+			leaseHeld := false
+			a.mu.Lock()
+			if a.tabBuildSupersededLocked(tab, buildGeneration) {
+				a.mu.Unlock()
+				a.abandonSupersededBuild(tab, ctrl, rootKey, "")
+				return
+			}
+			leaseHeld = setTabStartupError(tab, resumeLoadErr)
+			tab.Ready = false
+			if leaseHeld {
+				a.setSessionRuntimePhaseLocked(tab, sessionRuntimeLeaseBlocked, resumeLoadErr)
+			} else {
+				a.setSessionRuntimePhaseLocked(tab, sessionRuntimeFailed, resumeLoadErr)
+			}
+			hostKey := takeTabSharedHostKey(tab)
+			tab.releaseSessionLease()
+			a.mu.Unlock()
+			ctrl.Close()
+			if hostKey != "" {
+				a.releaseSharedHost(hostKey)
+			}
+			if leaseHeld {
+				a.scheduleDeferredStartupBuild(tab.ID)
+			}
+			a.emitReady(wailsCtx, tab.ID)
+			return
 		}
 		if path == "" {
 			path = agent.NewSessionPath(dir, ctrl.Label())
@@ -8545,46 +8579,46 @@ func globalTabWorkspaceRoot() string {
 	return root
 }
 
-func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool) {
+func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool, error) {
 	return loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath, loadedTabSession{}, true)
 }
 
-func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTabSession) (*agent.Session, string, bool) {
+func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTabSession) (*agent.Session, string, bool, error) {
 	return loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath, preloaded, false)
 }
 
-func loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath string, preloaded loadedTabSession, allowMigrationFallback bool) (*agent.Session, string, bool) {
+func loadPinnedTabSessionWithPreloadAndMigrationFallback(dir, sessionPath string, preloaded loadedTabSession, allowMigrationFallback bool) (*agent.Session, string, bool, error) {
 	path, ok := pinnedTabSessionPath(dir, sessionPath)
 	if !ok && allowMigrationFallback {
 		path, ok = migratedPinnedTabSessionPath(dir, sessionPath)
 	}
 	if !ok {
-		return nil, "", false
+		return nil, "", false, nil
 	}
 	if agent.IsCleanupPending(path) {
-		return nil, "", false
+		return nil, "", false, nil
 	}
 	if preloaded.matches(path) {
 		if preloaded.Session != nil && len(preloaded.Session.Snapshot()) == 0 {
-			return nil, path, true
+			return nil, path, true, nil
 		}
-		return preloaded.Session, path, true
+		return preloaded.Session, path, true, nil
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, path, true
+			return nil, path, true, nil
 		}
-		return nil, "", false
+		return nil, path, true, err
 	}
 	// An empty file (0 messages) is a pre-created placeholder, not a real
 	// session to resume.  Treating it as valid would make ctrl.Resume replace
 	// the executor's live session (with system prompt) with the empty one,
 	// causing the saved transcript to lack the agent identity contract.
 	if len(loaded.Snapshot()) == 0 {
-		return nil, path, true
+		return nil, path, true, nil
 	}
-	return loaded, path, true
+	return loaded, path, true, nil
 }
 
 func migratedPinnedTabSessionPath(dir, sessionPath string) (string, bool) {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1840,7 +1840,10 @@ func TestLoadPinnedTabSessionFallsBackToMigratedBasename(t *testing.T) {
 	path := writeLegacySession(t, dir, "migrated-tab.jsonl", "resume after path migration", time.Now())
 	oldPath := filepath.Join(t.TempDir(), "old-reasonix", "projects", "slug", "sessions", filepath.Base(path))
 
-	loaded, pinnedPath, ok := loadPinnedTabSession(dir, oldPath)
+	loaded, pinnedPath, ok, err := loadPinnedTabSession(dir, oldPath)
+	if err != nil {
+		t.Fatalf("loadPinnedTabSession: %v", err)
+	}
 	if !ok || loaded == nil {
 		t.Fatalf("loadPinnedTabSession did not recover migrated basename: ok=%v loaded=%v path=%q", ok, loaded, pinnedPath)
 	}
@@ -1874,8 +1877,101 @@ func TestLoadPinnedTabSessionSkipsCleanupPending(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if loaded, pinnedPath, ok := loadPinnedTabSession(dir, path); ok || loaded != nil || pinnedPath != "" {
+	if loaded, pinnedPath, ok, err := loadPinnedTabSession(dir, path); err != nil || ok || loaded != nil || pinnedPath != "" {
 		t.Fatalf("loadPinnedTabSession cleanup-pending = loaded:%v path:%q ok:%v, want skipped", loaded, pinnedPath, ok)
+	}
+}
+
+func TestLoadPinnedTabSessionPreservesLoadError(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := writeLegacySession(t, dir, "unsafe-pinned.jsonl", "checkpoint", time.Now())
+	events := `{"schema_version":99,"type":"replace","messages":[{"role":"user","content":"newer"}]}` + "\n"
+	if err := os.WriteFile(agent.SessionEventLogPath(path), []byte(events), 0o600); err != nil {
+		t.Fatalf("write future event log: %v", err)
+	}
+
+	loaded, pinnedPath, ok, err := loadPinnedTabSession(dir, path)
+	if err == nil || !strings.Contains(err.Error(), "uses schema 99") {
+		t.Fatalf("loadPinnedTabSession error = %v, want future-schema refusal", err)
+	}
+	if loaded != nil || !ok || filepath.Clean(pinnedPath) != filepath.Clean(path) {
+		t.Fatalf("load result = loaded:%v path:%q ok:%v, want pinned path retained with hard error", loaded, pinnedPath, ok)
+	}
+	if got, readErr := os.ReadFile(agent.SessionEventLogPath(path)); readErr != nil || string(got) != events {
+		t.Fatalf("event log changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestBuildTabControllerSurfacesPinnedSessionLoadError(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "test-provider/test-model"
+
+[[providers]]
+name = "test-provider"
+kind = "openai"
+base_url = "https://test.invalid/v1"
+model = "test-model"
+api_key_env = "REASONIX_TEST_KEY"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := writeLegacySession(t, dir, "unsafe-startup.jsonl", "checkpoint", time.Now())
+	events := `{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"newer"}]}` + "\n"
+	logPath := agent.SessionEventLogPath(path)
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write native event log: %v", err)
+	}
+	const oversizedSparseLog = int64(1 << 30)
+	if err := os.Truncate(logPath, oversizedSparseLog); err != nil {
+		t.Fatalf("make sparse oversized event log: %v", err)
+	}
+
+	app := NewApp()
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "tab_unsafe_startup")
+	tab.SessionPath = path
+	tab.model = "test-provider/test-model"
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.buildTabController(tab)
+	if tab.Ctrl != nil || tab.Ready {
+		t.Fatalf("unsafe session runtime = hasCtrl:%v ready:%v, want failed startup", tab.Ctrl != nil, tab.Ready)
+	}
+	if !strings.Contains(tab.StartupErr, agent.ErrSessionReplayLimitExceeded.Error()) || strings.Contains(tab.StartupErr, path) {
+		t.Fatalf("startup error = %q, want path-free replay-budget error", tab.StartupErr)
+	}
+	if filepath.Clean(tab.SessionPath) != filepath.Clean(path) {
+		t.Fatalf("session path = %q, want original %q", tab.SessionPath, path)
+	}
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat event log after startup refusal: %v", err)
+	}
+	if info.Size() != oversizedSparseLog {
+		t.Fatalf("event log size after startup refusal = %d, want %d", info.Size(), oversizedSparseLog)
+	}
+	app.sharedHostsMu.Lock()
+	sharedHosts := len(app.sharedHosts)
+	app.sharedHostsMu.Unlock()
+	if sharedHosts != 0 {
+		t.Fatalf("shared hosts after failed startup = %d, want 0", sharedHosts)
 	}
 }
 

--- a/internal/agent/session_content.go
+++ b/internal/agent/session_content.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"time"
 
@@ -46,9 +47,23 @@ type SessionUserMessage struct {
 // after the first save once an event log exists, so surfaces like prompt
 // history must use this instead.
 func LoadSessionUserMessages(path string) ([]SessionUserMessage, error) {
-	if probe, err := probeSessionEventLog(path); err == nil && probe.native && probe.size > 0 {
-		replay, err := replaySessionEventLog(store.SessionEventLog(path))
-		if err == nil && replay.records > 0 {
+	return loadSessionUserMessagesWithLimits(path, defaultSessionReplayLimits)
+}
+
+func loadSessionUserMessagesWithLimits(path string, limits sessionReplayLimits) ([]SessionUserMessage, error) {
+	probe, err := probeSessionEventLogWithLimits(path, limits)
+	if err != nil {
+		return nil, err
+	}
+	if probe.futureSchema {
+		return nil, fmt.Errorf("session event log for %s uses schema %d; this build supports up to %d", path, probe.schemaVersion, sessionEventSchemaVersion)
+	}
+	if probe.native && probe.size > 0 {
+		replay, err := replaySessionEventLogWithLimits(store.SessionEventLog(path), limits)
+		if err != nil {
+			return nil, err
+		}
+		if replay.records > 0 {
 			out := make([]SessionUserMessage, 0, len(replay.msgs))
 			for i, m := range replay.msgs {
 				if m.Role != provider.RoleUser {

--- a/internal/agent/session_events.go
+++ b/internal/agent/session_events.go
@@ -21,6 +21,16 @@ const (
 	sessionEventSchemaVersion = 1
 	sessionEventTypeReplace   = "replace"
 	sessionEventTypeAppend    = "append"
+	// sessionEventReplayMaxBytes caps decoder input before encoding/json can
+	// allocate an arbitrarily large record. Session logs normally compact far
+	// below this threshold; the generous ceiling still accommodates histories
+	// with embedded images while keeping corrupt logs from exhausting the host.
+	sessionEventReplayMaxBytes = int64(128 << 20)
+	// A byte limit alone is insufficient: a compact JSON array can expand into
+	// a much larger graph of messages and event records after decoding.
+	sessionEventReplayMaxRecords  = 100_000
+	sessionEventReplayMaxMessages = 100_000
+	sessionEventProbeMaxBytes     = int64(4 << 10)
 	// sessionEventLogCompactFloor is the smallest log size that can trigger
 	// compaction, so short sessions never pay a checkpoint rewrite.
 	sessionEventLogCompactFloor = int64(256 << 10)
@@ -30,6 +40,51 @@ const (
 	// file without bound.
 	sessionEventLogCompactFactor = int64(4)
 )
+
+// ErrSessionReplayLimitExceeded identifies a session that was left untouched
+// because replaying it would exceed the process safety budget. Callers must not
+// fall back to an older checkpoint: the event log may contain newer turns.
+var ErrSessionReplayLimitExceeded = errors.New("session history exceeds safe replay limits")
+
+// SessionReplayLimitError carries machine-readable diagnostics while keeping
+// Error free of local paths for Desktop surfaces that display startup errors.
+type SessionReplayLimitError struct {
+	Path     string
+	Resource string
+	Value    int64
+	Limit    int64
+}
+
+func (e *SessionReplayLimitError) Error() string {
+	if e == nil {
+		return ErrSessionReplayLimitExceeded.Error()
+	}
+	return fmt.Sprintf("%s: %s=%d, limit=%d; session files were left unchanged",
+		ErrSessionReplayLimitExceeded, e.Resource, e.Value, e.Limit)
+}
+
+func (e *SessionReplayLimitError) Unwrap() error {
+	return ErrSessionReplayLimitExceeded
+}
+
+type sessionReplayLimits struct {
+	maxBytes    int64
+	maxRecords  int
+	maxMessages int
+}
+
+var defaultSessionReplayLimits = sessionReplayLimits{
+	maxBytes:    sessionEventReplayMaxBytes,
+	maxRecords:  sessionEventReplayMaxRecords,
+	maxMessages: sessionEventReplayMaxMessages,
+}
+
+func sessionReplayLimitError(path, resource string, value, limit int64) error {
+	err := &SessionReplayLimitError{Path: path, Resource: resource, Value: value, Limit: limit}
+	slog.Warn("session: refusing unsafe event-log replay",
+		"path", path, "resource", resource, "value", value, "limit", limit)
+	return err
+}
 
 type sessionEventRecord struct {
 	SchemaVersion int                `json:"schema_version"`
@@ -159,25 +214,52 @@ func probeSessionEventLog(sessionPath string) (sessionEventLogProbe, error) {
 		return sessionEventLogProbe{}, err
 	}
 	defer f.Close()
-	var rec struct {
-		SchemaVersion int    `json:"schema_version"`
-		Type          string `json:"type"`
-	}
-	if err := json.NewDecoder(f).Decode(&rec); err != nil {
+	schemaVersion, eventType, ok := probeSessionEventHeader(f)
+	if !ok {
 		// Nothing decodable at the head: not a native log this build can own.
 		return probe, nil
 	}
-	probe.schemaVersion = rec.SchemaVersion
+	probe.schemaVersion = schemaVersion
 	switch {
-	case rec.SchemaVersion == sessionEventSchemaVersion &&
-		(rec.Type == sessionEventTypeReplace || rec.Type == sessionEventTypeAppend):
+	case schemaVersion == sessionEventSchemaVersion &&
+		(eventType == sessionEventTypeReplace || eventType == sessionEventTypeAppend):
 		probe.native = true
-	case rec.SchemaVersion > sessionEventSchemaVersion:
+	case schemaVersion > sessionEventSchemaVersion:
 		// A newer writer owns this log; ignoring or truncating it would
 		// silently discard that writer's transcript.
 		probe.futureSchema = true
 	}
 	return probe, nil
+}
+
+// probeSessionEventHeader reads only the two leading fields emitted by
+// sessionEventRecord. Using Decode on a partial struct still buffers the whole
+// JSON value, so a corrupt first record could exhaust memory before replay's
+// byte budget had a chance to run.
+func probeSessionEventHeader(r io.Reader) (schemaVersion int, eventType string, ok bool) {
+	dec := json.NewDecoder(io.LimitReader(r, sessionEventProbeMaxBytes))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, "", false
+	}
+	if delim, isDelim := tok.(json.Delim); !isDelim || delim != '{' {
+		return 0, "", false
+	}
+	key, err := dec.Token()
+	if err != nil || key != "schema_version" {
+		return 0, "", false
+	}
+	if err := dec.Decode(&schemaVersion); err != nil {
+		return 0, "", false
+	}
+	key, err = dec.Token()
+	if err != nil || key != "type" {
+		return 0, "", false
+	}
+	if err := dec.Decode(&eventType); err != nil {
+		return 0, "", false
+	}
+	return schemaVersion, eventType, true
 }
 
 // replaySessionEventLog decodes an event log tolerantly: decoding stops at the
@@ -186,6 +268,10 @@ func probeSessionEventLog(sessionPath string) (sessionEventLogProbe, error) {
 // versions and unknown event types stay hard errors — they mean a newer writer
 // owns this log, and truncating it would discard that writer's data.
 func replaySessionEventLog(path string) (sessionEventReplay, error) {
+	return replaySessionEventLogWithLimits(path, defaultSessionReplayLimits)
+}
+
+func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (sessionEventReplay, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return sessionEventReplay{}, err
@@ -196,10 +282,19 @@ func replaySessionEventLog(path string) (sessionEventReplay, error) {
 		return sessionEventReplay{}, err
 	}
 	replay := sessionEventReplay{size: info.Size()}
-	dec := json.NewDecoder(f)
+	if info.Size() > limits.maxBytes {
+		return replay, sessionReplayLimitError(path, "encoded_bytes", info.Size(), limits.maxBytes)
+	}
+	// Stat and read are not atomic across processes. LimitReader keeps a log
+	// that grows after Stat inside the same byte budget.
+	limited := &io.LimitedReader{R: f, N: limits.maxBytes + 1}
+	dec := json.NewDecoder(limited)
 	for {
 		var rec sessionEventRecord
 		if err := dec.Decode(&rec); err != nil {
+			if limited.N == 0 {
+				return replay, sessionReplayLimitError(path, "encoded_bytes", limits.maxBytes+1, limits.maxBytes)
+			}
 			if errors.Is(err, io.EOF) {
 				return replay, nil
 			}
@@ -209,14 +304,23 @@ func replaySessionEventLog(path string) (sessionEventReplay, error) {
 		if rec.SchemaVersion != sessionEventSchemaVersion {
 			return replay, fmt.Errorf("decode session event log %s: unsupported schema version %d", path, rec.SchemaVersion)
 		}
+		if replay.records >= limits.maxRecords {
+			return replay, sessionReplayLimitError(path, "event_records", int64(replay.records+1), int64(limits.maxRecords))
+		}
 		switch rec.Type {
 		case sessionEventTypeReplace:
+			if len(rec.Messages) > limits.maxMessages {
+				return replay, sessionReplayLimitError(path, "messages", int64(len(rec.Messages)), int64(limits.maxMessages))
+			}
 			replay.msgs = append([]provider.Message(nil), rec.Messages...)
 			replay.times = make([]time.Time, len(replay.msgs))
 		case sessionEventTypeAppend:
 			if rec.MessageIndex != len(replay.msgs) {
 				replay.damaged = true
 				return replay, nil
+			}
+			if len(rec.Messages) > limits.maxMessages-len(replay.msgs) {
+				return replay, sessionReplayLimitError(path, "messages", int64(len(replay.msgs)+len(rec.Messages)), int64(limits.maxMessages))
 			}
 			replay.msgs = append(replay.msgs, rec.Messages...)
 			for range rec.Messages {
@@ -237,6 +341,10 @@ func replaySessionEventLog(path string) (sessionEventReplay, error) {
 // not be replayed to its end (torn tail or corrupt record); callers that write
 // should rewrite-and-compact to heal it.
 func loadSessionMessages(sessionPath string) (msgs []provider.Message, fromEvents, damaged bool, err error) {
+	return loadSessionMessagesWithLimits(sessionPath, defaultSessionReplayLimits)
+}
+
+func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimits) (msgs []provider.Message, fromEvents, damaged bool, err error) {
 	probe, err := probeSessionEventLog(sessionPath)
 	if err != nil {
 		return nil, false, false, err
@@ -245,7 +353,7 @@ func loadSessionMessages(sessionPath string) (msgs []provider.Message, fromEvent
 		return nil, true, false, fmt.Errorf("session event log for %s uses schema %d; this build supports up to %d", sessionPath, probe.schemaVersion, sessionEventSchemaVersion)
 	}
 	if probe.native && probe.size > 0 {
-		replay, replayErr := replaySessionEventLog(store.SessionEventLog(sessionPath))
+		replay, replayErr := replaySessionEventLogWithLimits(store.SessionEventLog(sessionPath), limits)
 		if replayErr != nil {
 			return nil, true, false, replayErr
 		}

--- a/internal/agent/session_events.go
+++ b/internal/agent/session_events.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -99,6 +100,22 @@ type sessionEventRecord struct {
 	CreatedAt     time.Time          `json:"created_at"`
 }
 
+// sessionEventWireRecord keeps the messages array encoded until the replay
+// budget has been checked. Decoding directly into sessionEventRecord would
+// materialize every provider.Message before replay could enforce maxMessages.
+type sessionEventWireRecord struct {
+	SchemaVersion int             `json:"schema_version"`
+	Type          string          `json:"type"`
+	Revision      int64           `json:"revision,omitempty"`
+	BaseRevision  int64           `json:"base_revision,omitempty"`
+	MessageIndex  int             `json:"message_index,omitempty"`
+	Messages      json.RawMessage `json:"messages,omitempty"`
+	ContentDigest string          `json:"content_digest,omitempty"`
+	WriterID      string          `json:"writer_id,omitempty"`
+	Reason        string          `json:"reason,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
 type sessionEventIndex struct {
 	SchemaVersion int       `json:"schema_version"`
 	LogSize       int64     `json:"log_size"`
@@ -188,6 +205,10 @@ func sessionEventSidecarsFit(sessionPath string) bool {
 // record — or a transcript name too long for the sidecars to fit — marks the
 // file as not ours.
 func probeSessionEventLog(sessionPath string) (sessionEventLogProbe, error) {
+	return probeSessionEventLogWithLimits(sessionPath, defaultSessionReplayLimits)
+}
+
+func probeSessionEventLogWithLimits(sessionPath string, limits sessionReplayLimits) (sessionEventLogProbe, error) {
 	path := store.SessionEventLog(sessionPath)
 	if path == "" {
 		return sessionEventLogProbe{native: true}, nil
@@ -214,7 +235,27 @@ func probeSessionEventLog(sessionPath string) (sessionEventLogProbe, error) {
 		return sessionEventLogProbe{}, err
 	}
 	defer f.Close()
-	schemaVersion, eventType, ok := probeSessionEventHeader(f)
+	var schemaVersion int
+	var eventType string
+	var ok bool
+	schemaVersion, eventType, ok = probeSessionEventHeader(f)
+	if !ok && info.Size() <= limits.maxBytes {
+		// Native writers put both identifying fields in the bounded prefix. For
+		// other valid in-budget JSON, fall back to a minimal struct decode so
+		// field order remains a compatibility property rather than a format
+		// requirement. Unknown fields are not materialized into messages.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return sessionEventLogProbe{}, err
+		}
+		var header struct {
+			SchemaVersion int    `json:"schema_version"`
+			Type          string `json:"type"`
+		}
+		dec := json.NewDecoder(&io.LimitedReader{R: f, N: limits.maxBytes + 1})
+		if err := dec.Decode(&header); err == nil {
+			schemaVersion, eventType, ok = header.SchemaVersion, header.Type, true
+		}
+	}
 	if !ok {
 		// Nothing decodable at the head: not a native log this build can own.
 		return probe, nil
@@ -232,10 +273,9 @@ func probeSessionEventLog(sessionPath string) (sessionEventLogProbe, error) {
 	return probe, nil
 }
 
-// probeSessionEventHeader reads only the two leading fields emitted by
-// sessionEventRecord. Using Decode on a partial struct still buffers the whole
-// JSON value, so a corrupt first record could exhaust memory before replay's
-// byte budget had a chance to run.
+// probeSessionEventHeader searches a bounded prefix for the identifying fields.
+// Using Decode on a partial struct still buffers the whole JSON value, so native
+// writer output must take this fast path before replay's byte budget is checked.
 func probeSessionEventHeader(r io.Reader) (schemaVersion int, eventType string, ok bool) {
 	dec := json.NewDecoder(io.LimitReader(r, sessionEventProbeMaxBytes))
 	tok, err := dec.Token()
@@ -245,21 +285,38 @@ func probeSessionEventHeader(r io.Reader) (schemaVersion int, eventType string, 
 	if delim, isDelim := tok.(json.Delim); !isDelim || delim != '{' {
 		return 0, "", false
 	}
-	key, err := dec.Token()
-	if err != nil || key != "schema_version" {
-		return 0, "", false
+	var haveSchema, haveType bool
+	for dec.More() {
+		key, err := dec.Token()
+		if err != nil {
+			return 0, "", false
+		}
+		name, isString := key.(string)
+		if !isString {
+			return 0, "", false
+		}
+		switch name {
+		case "schema_version":
+			if err := dec.Decode(&schemaVersion); err != nil {
+				return 0, "", false
+			}
+			haveSchema = true
+		case "type":
+			if err := dec.Decode(&eventType); err != nil {
+				return 0, "", false
+			}
+			haveType = true
+		default:
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				return 0, "", false
+			}
+		}
+		if haveSchema && haveType {
+			return schemaVersion, eventType, true
+		}
 	}
-	if err := dec.Decode(&schemaVersion); err != nil {
-		return 0, "", false
-	}
-	key, err = dec.Token()
-	if err != nil || key != "type" {
-		return 0, "", false
-	}
-	if err := dec.Decode(&eventType); err != nil {
-		return 0, "", false
-	}
-	return schemaVersion, eventType, true
+	return 0, "", false
 }
 
 // replaySessionEventLog decodes an event log tolerantly: decoding stops at the
@@ -290,7 +347,7 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 	limited := &io.LimitedReader{R: f, N: limits.maxBytes + 1}
 	dec := json.NewDecoder(limited)
 	for {
-		var rec sessionEventRecord
+		var rec sessionEventWireRecord
 		if err := dec.Decode(&rec); err != nil {
 			if limited.N == 0 {
 				return replay, sessionReplayLimitError(path, "encoded_bytes", limits.maxBytes+1, limits.maxBytes)
@@ -309,21 +366,31 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 		}
 		switch rec.Type {
 		case sessionEventTypeReplace:
-			if len(rec.Messages) > limits.maxMessages {
-				return replay, sessionReplayLimitError(path, "messages", int64(len(rec.Messages)), int64(limits.maxMessages))
+			msgs, err := decodeSessionEventMessages(path, rec.Messages, 0, limits.maxMessages)
+			if err != nil {
+				if errors.Is(err, ErrSessionReplayLimitExceeded) {
+					return replay, err
+				}
+				replay.damaged = true
+				return replay, nil
 			}
-			replay.msgs = append([]provider.Message(nil), rec.Messages...)
+			replay.msgs = msgs
 			replay.times = make([]time.Time, len(replay.msgs))
 		case sessionEventTypeAppend:
 			if rec.MessageIndex != len(replay.msgs) {
 				replay.damaged = true
 				return replay, nil
 			}
-			if len(rec.Messages) > limits.maxMessages-len(replay.msgs) {
-				return replay, sessionReplayLimitError(path, "messages", int64(len(replay.msgs)+len(rec.Messages)), int64(limits.maxMessages))
+			msgs, err := decodeSessionEventMessages(path, rec.Messages, len(replay.msgs), limits.maxMessages)
+			if err != nil {
+				if errors.Is(err, ErrSessionReplayLimitExceeded) {
+					return replay, err
+				}
+				replay.damaged = true
+				return replay, nil
 			}
-			replay.msgs = append(replay.msgs, rec.Messages...)
-			for range rec.Messages {
+			replay.msgs = append(replay.msgs, msgs...)
+			for range msgs {
 				replay.times = append(replay.times, rec.CreatedAt)
 			}
 		default:
@@ -332,6 +399,39 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 		replay.records++
 		replay.lastGoodEnd = dec.InputOffset()
 	}
+}
+
+// decodeSessionEventMessages enforces the aggregate message budget before
+// decoding each element. Keeping the array as json.RawMessage in the outer
+// record bounds encoded input without constructing an unbounded object graph.
+func decodeSessionEventMessages(path string, raw json.RawMessage, existing, maxMessages int) ([]provider.Message, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
+		return nil, fmt.Errorf("messages must be an array")
+	}
+	var msgs []provider.Message
+	for dec.More() {
+		if existing+len(msgs) >= maxMessages {
+			return nil, sessionReplayLimitError(path, "messages", int64(existing+len(msgs)+1), int64(maxMessages))
+		}
+		var msg provider.Message
+		if err := dec.Decode(&msg); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, msg)
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	return msgs, nil
 }
 
 // loadSessionMessages returns the session transcript, preferring the event log
@@ -345,7 +445,7 @@ func loadSessionMessages(sessionPath string) (msgs []provider.Message, fromEvent
 }
 
 func loadSessionMessagesWithLimits(sessionPath string, limits sessionReplayLimits) (msgs []provider.Message, fromEvents, damaged bool, err error) {
-	probe, err := probeSessionEventLog(sessionPath)
+	probe, err := probeSessionEventLogWithLimits(sessionPath, limits)
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/internal/agent/session_events.go
+++ b/internal/agent/session_events.go
@@ -29,9 +29,10 @@ const (
 	sessionEventReplayMaxBytes = int64(128 << 20)
 	// A byte limit alone is insufficient: a compact JSON array can expand into
 	// a much larger graph of messages and event records after decoding.
-	sessionEventReplayMaxRecords  = 100_000
-	sessionEventReplayMaxMessages = 100_000
-	sessionEventProbeMaxBytes     = int64(4 << 10)
+	sessionEventReplayMaxRecords         = 100_000
+	sessionEventReplayMaxMessages        = 100_000
+	sessionEventReplayMaxCollectionItems = 100_000
+	sessionEventProbeMaxBytes            = int64(4 << 10)
 	// sessionEventLogCompactFloor is the smallest log size that can trigger
 	// compaction, so short sessions never pay a checkpoint rewrite.
 	sessionEventLogCompactFloor = int64(256 << 10)
@@ -69,15 +70,17 @@ func (e *SessionReplayLimitError) Unwrap() error {
 }
 
 type sessionReplayLimits struct {
-	maxBytes    int64
-	maxRecords  int
-	maxMessages int
+	maxBytes           int64
+	maxRecords         int
+	maxMessages        int
+	maxCollectionItems int
 }
 
 var defaultSessionReplayLimits = sessionReplayLimits{
-	maxBytes:    sessionEventReplayMaxBytes,
-	maxRecords:  sessionEventReplayMaxRecords,
-	maxMessages: sessionEventReplayMaxMessages,
+	maxBytes:           sessionEventReplayMaxBytes,
+	maxRecords:         sessionEventReplayMaxRecords,
+	maxMessages:        sessionEventReplayMaxMessages,
+	maxCollectionItems: sessionEventReplayMaxCollectionItems,
 }
 
 func sessionReplayLimitError(path, resource string, value, limit int64) error {
@@ -159,6 +162,11 @@ func sessionEventLogOversized(logSize, contentBytes int64) bool {
 // for writers to self-heal a torn tail.
 type sessionEventReplay struct {
 	msgs []provider.Message
+	// collectionItems counts the elements in every JSON array nested below a
+	// live message. Keeping this alongside msgs bounds slices such as tool calls,
+	// images, memory citations, and interrupted-turn recovery metadata without
+	// coupling replay safety to today's provider.Message field list.
+	collectionItems int
 	// times mirrors msgs with each message's record CreatedAt. Replace events
 	// collapse per-turn history, so their messages get the zero time and
 	// callers fall back to coarser timestamps.
@@ -366,7 +374,7 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 		}
 		switch rec.Type {
 		case sessionEventTypeReplace:
-			msgs, err := decodeSessionEventMessages(path, rec.Messages, 0, limits.maxMessages)
+			msgs, collectionItems, err := decodeSessionEventMessages(path, rec.Messages, 0, 0, limits)
 			if err != nil {
 				if errors.Is(err, ErrSessionReplayLimitExceeded) {
 					return replay, err
@@ -375,13 +383,16 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 				return replay, nil
 			}
 			replay.msgs = msgs
+			replay.collectionItems = collectionItems
 			replay.times = make([]time.Time, len(replay.msgs))
 		case sessionEventTypeAppend:
 			if rec.MessageIndex != len(replay.msgs) {
 				replay.damaged = true
 				return replay, nil
 			}
-			msgs, err := decodeSessionEventMessages(path, rec.Messages, len(replay.msgs), limits.maxMessages)
+			msgs, collectionItems, err := decodeSessionEventMessages(
+				path, rec.Messages, len(replay.msgs), replay.collectionItems, limits,
+			)
 			if err != nil {
 				if errors.Is(err, ErrSessionReplayLimitExceeded) {
 					return replay, err
@@ -390,6 +401,7 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 				return replay, nil
 			}
 			replay.msgs = append(replay.msgs, msgs...)
+			replay.collectionItems = collectionItems
 			for range msgs {
 				replay.times = append(replay.times, rec.CreatedAt)
 			}
@@ -401,37 +413,140 @@ func replaySessionEventLogWithLimits(path string, limits sessionReplayLimits) (s
 	}
 }
 
-// decodeSessionEventMessages enforces the aggregate message budget before
-// decoding each element. Keeping the array as json.RawMessage in the outer
-// record bounds encoded input without constructing an unbounded object graph.
-func decodeSessionEventMessages(path string, raw json.RawMessage, existing, maxMessages int) ([]provider.Message, error) {
+// decodeSessionEventMessages preflights both the top-level message count and
+// every nested JSON collection before constructing provider.Message values.
+// The token walk is independent of today's provider.Message fields, so future
+// slice fields inherit the same aggregate object-graph bound automatically.
+func decodeSessionEventMessages(
+	path string,
+	raw json.RawMessage,
+	existingMessages, existingCollectionItems int,
+	limits sessionReplayLimits,
+) ([]provider.Message, int, error) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
-		return nil, nil
+		return nil, existingCollectionItems, nil
+	}
+	messageCount, collectionItems, err := preflightSessionEventMessages(
+		path, trimmed, existingMessages, existingCollectionItems, limits,
+	)
+	if err != nil {
+		return nil, existingCollectionItems, err
 	}
 	dec := json.NewDecoder(bytes.NewReader(trimmed))
 	tok, err := dec.Token()
 	if err != nil {
-		return nil, err
+		return nil, existingCollectionItems, err
 	}
 	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
-		return nil, fmt.Errorf("messages must be an array")
+		return nil, existingCollectionItems, fmt.Errorf("messages must be an array")
 	}
-	var msgs []provider.Message
+	msgs := make([]provider.Message, 0, messageCount)
 	for dec.More() {
-		if existing+len(msgs) >= maxMessages {
-			return nil, sessionReplayLimitError(path, "messages", int64(existing+len(msgs)+1), int64(maxMessages))
-		}
 		var msg provider.Message
 		if err := dec.Decode(&msg); err != nil {
-			return nil, err
+			return nil, existingCollectionItems, err
 		}
 		msgs = append(msgs, msg)
 	}
 	if _, err := dec.Token(); err != nil {
-		return nil, err
+		return nil, existingCollectionItems, err
 	}
-	return msgs, nil
+	return msgs, collectionItems, nil
+}
+
+func preflightSessionEventMessages(
+	path string,
+	raw []byte,
+	existingMessages, existingCollectionItems int,
+	limits sessionReplayLimits,
+) (messageCount, collectionItems int, err error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, existingCollectionItems, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '[' {
+		return 0, existingCollectionItems, fmt.Errorf("messages must be an array")
+	}
+	collectionItems = existingCollectionItems
+	for dec.More() {
+		if existingMessages+messageCount >= limits.maxMessages {
+			return 0, existingCollectionItems, sessionReplayLimitError(
+				path, "messages", int64(existingMessages+messageCount+1), int64(limits.maxMessages),
+			)
+		}
+		messageCount++
+		if err := preflightSessionEventValue(path, dec, &collectionItems, limits.maxCollectionItems); err != nil {
+			return 0, existingCollectionItems, err
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return 0, existingCollectionItems, err
+	}
+	return messageCount, collectionItems, nil
+}
+
+// preflightSessionEventValue walks one JSON value without materializing maps or
+// slices. Each array element is charged before its value is read, so an invalid
+// over-limit element cannot allocate a typed provider collection first.
+func preflightSessionEventValue(path string, dec *json.Decoder, collectionItems *int, maxCollectionItems int) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		for dec.More() {
+			key, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			if _, ok := key.(string); !ok {
+				return fmt.Errorf("object key must be a string")
+			}
+			if err := preflightSessionEventValue(path, dec, collectionItems, maxCollectionItems); err != nil {
+				return err
+			}
+		}
+		end, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return fmt.Errorf("object is not terminated")
+		}
+		return nil
+	case '[':
+		for dec.More() {
+			if *collectionItems >= maxCollectionItems {
+				return sessionReplayLimitError(
+					path,
+					"message_collection_items",
+					int64(*collectionItems+1),
+					int64(maxCollectionItems),
+				)
+			}
+			(*collectionItems)++
+			if err := preflightSessionEventValue(path, dec, collectionItems, maxCollectionItems); err != nil {
+				return err
+			}
+		}
+		end, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return fmt.Errorf("array is not terminated")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delim)
+	}
 }
 
 // loadSessionMessages returns the session transcript, preferring the event log

--- a/internal/agent/session_events_test.go
+++ b/internal/agent/session_events_test.go
@@ -389,6 +389,58 @@ func TestReplayChecksMessageBudgetBeforeDecodingOverLimitElement(t *testing.T) {
 	}
 }
 
+func TestReplayChecksCollectionBudgetBeforeDecodingOverLimitElement(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "bounded-collection-before-decode.events.jsonl")
+	// The third tool call cannot decode into provider.ToolCall. A two-item
+	// collection budget must reject it before constructing the typed slice.
+	events := `{"schema_version":1,"type":"replace","messages":[{"role":"assistant","tool_calls":[{}, {}, 42]}]}` + "\n"
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
+		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 10, maxCollectionItems: 2,
+	})
+	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
+		t.Fatalf("replay error = %v, want collection replay limit", err)
+	}
+	var limitErr *SessionReplayLimitError
+	if !errors.As(err, &limitErr) || limitErr.Resource != "message_collection_items" || limitErr.Value != 3 {
+		t.Fatalf("limit error = %#v, want third collection item rejected before decode", limitErr)
+	}
+	if replay.records != 0 || len(replay.msgs) != 0 {
+		t.Fatalf("partial over-limit record was applied: records=%d messages=%d", replay.records, len(replay.msgs))
+	}
+	if got, readErr := os.ReadFile(logPath); readErr != nil || string(got) != events {
+		t.Fatalf("event log changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestReplayCollectionBudgetAggregatesAcrossRecords(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "aggregate-collection-budget.events.jsonl")
+	replace := `{"schema_version":1,"type":"replace","messages":[{"role":"user","images":["one"]}]}` + "\n"
+	appendEvent := `{"schema_version":1,"type":"append","message_index":1,"messages":[{"role":"assistant","tool_calls":[{},{}]}]}` + "\n"
+	events := replace + appendEvent
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
+		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 10, maxCollectionItems: 2,
+	})
+	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
+		t.Fatalf("replay error = %v, want aggregate collection replay limit", err)
+	}
+	var limitErr *SessionReplayLimitError
+	if !errors.As(err, &limitErr) || limitErr.Resource != "message_collection_items" || limitErr.Value != 3 {
+		t.Fatalf("limit error = %#v, want third live collection item rejected", limitErr)
+	}
+	if replay.records != 1 || len(replay.msgs) != 1 || replay.collectionItems != 1 {
+		t.Fatalf("replay prefix = records:%d messages:%d collections:%d, want first record only",
+			replay.records, len(replay.msgs), replay.collectionItems)
+	}
+}
+
 func TestLoadSessionMessagesDoesNotFallbackAfterEventReplayBudget(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	checkpoint := `{"role":"system","content":"older checkpoint"}` + "\n"
@@ -662,6 +714,55 @@ func TestLoadSessionUserMessagesSeesEventLogTurns(t *testing.T) {
 	}
 	if users[1].At.IsZero() {
 		t.Fatal("appended prompt lost its event timestamp")
+	}
+}
+
+func TestLoadSessionUserMessagesDoesNotFallbackAfterEventReplayBudget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	checkpoint := `{"role":"user","content":"older checkpoint prompt"}` + "\n"
+	if err := os.WriteFile(path, []byte(checkpoint), 0o600); err != nil {
+		t.Fatalf("write checkpoint: %v", err)
+	}
+	logPath := store.SessionEventLog(path)
+	events := `{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"newer prompt"},{"role":"assistant","content":"reply"}]}` + "\n"
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	users, err := loadSessionUserMessagesWithLimits(path, sessionReplayLimits{
+		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 1, maxCollectionItems: 10,
+	})
+	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
+		t.Fatalf("load error = %v, want ErrSessionReplayLimitExceeded", err)
+	}
+	if users != nil {
+		t.Fatalf("user messages = %+v, want no stale checkpoint fallback", users)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != checkpoint {
+		t.Fatalf("checkpoint changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+	if got, readErr := os.ReadFile(logPath); readErr != nil || string(got) != events {
+		t.Fatalf("event log changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestLoadSessionUserMessagesDoesNotFallbackFromFutureEventSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	checkpoint := `{"role":"user","content":"older checkpoint prompt"}` + "\n"
+	if err := os.WriteFile(path, []byte(checkpoint), 0o600); err != nil {
+		t.Fatalf("write checkpoint: %v", err)
+	}
+	events := `{"schema_version":99,"type":"replace","messages":[{"role":"user","content":"future prompt"}]}` + "\n"
+	if err := os.WriteFile(store.SessionEventLog(path), []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	users, err := LoadSessionUserMessages(path)
+	if err == nil || !strings.Contains(err.Error(), "uses schema 99") {
+		t.Fatalf("load error = %v, want future-schema refusal", err)
+	}
+	if users != nil {
+		t.Fatalf("user messages = %+v, want no stale checkpoint fallback", users)
 	}
 }
 

--- a/internal/agent/session_events_test.go
+++ b/internal/agent/session_events_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -293,6 +294,113 @@ func TestReplayRejectsUnsupportedSchemaVersion(t *testing.T) {
 	}
 	if _, err := replaySessionEventLog(logPath); err == nil {
 		t.Fatal("replay of future schema succeeded, want hard error (no silent truncation of newer writers)")
+	}
+}
+
+func TestReplaySessionEventLogEnforcesResourceBudgetsWithoutMutation(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "bounded.events.jsonl")
+	replace := `{"schema_version":1,"type":"replace","messages":[{"role":"system","content":"sys"},{"role":"user","content":"prompt"}]}` + "\n"
+	appendEvent := `{"schema_version":1,"type":"append","message_index":2,"messages":[{"role":"assistant","content":"reply"}]}` + "\n"
+	contents := replace + appendEvent
+	if err := os.WriteFile(logPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		limits   sessionReplayLimits
+		resource string
+	}{
+		{
+			name: "encoded bytes",
+			limits: sessionReplayLimits{
+				maxBytes: int64(len(contents) - 1), maxRecords: 10, maxMessages: 10,
+			},
+			resource: "encoded_bytes",
+		},
+		{
+			name: "event records",
+			limits: sessionReplayLimits{
+				maxBytes: int64(len(contents) + 1), maxRecords: 1, maxMessages: 10,
+			},
+			resource: "event_records",
+		},
+		{
+			name: "messages",
+			limits: sessionReplayLimits{
+				maxBytes: int64(len(contents) + 1), maxRecords: 10, maxMessages: 1,
+			},
+			resource: "messages",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := replaySessionEventLogWithLimits(logPath, tc.limits); !errors.Is(err, ErrSessionReplayLimitExceeded) {
+				t.Fatalf("replay error = %v, want ErrSessionReplayLimitExceeded", err)
+			} else {
+				var limitErr *SessionReplayLimitError
+				if !errors.As(err, &limitErr) || limitErr.Resource != tc.resource {
+					t.Fatalf("limit error = %#v, want resource %q", limitErr, tc.resource)
+				}
+				if strings.Contains(err.Error(), logPath) {
+					t.Fatalf("user-facing error leaked local path: %q", err)
+				}
+			}
+			got, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read event log after rejection: %v", err)
+			}
+			if string(got) != contents {
+				t.Fatal("resource-budget rejection modified the event log")
+			}
+		})
+	}
+}
+
+func TestLoadSessionMessagesDoesNotFallbackAfterEventReplayBudget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	checkpoint := `{"role":"system","content":"older checkpoint"}` + "\n"
+	if err := os.WriteFile(path, []byte(checkpoint), 0o600); err != nil {
+		t.Fatalf("write checkpoint: %v", err)
+	}
+	logPath := store.SessionEventLog(path)
+	events := `{"schema_version":1,"type":"replace","messages":[{"role":"system","content":"newer event state"},{"role":"user","content":"must not disappear"}]}` + "\n"
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	msgs, fromEvents, damaged, err := loadSessionMessagesWithLimits(path, sessionReplayLimits{
+		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 1,
+	})
+	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
+		t.Fatalf("load error = %v, want ErrSessionReplayLimitExceeded", err)
+	}
+	if msgs != nil || !fromEvents || damaged {
+		t.Fatalf("load result = msgs:%v fromEvents:%v damaged:%v, want hard event-log refusal", msgs, fromEvents, damaged)
+	}
+	if got, readErr := os.ReadFile(path); readErr != nil || string(got) != checkpoint {
+		t.Fatalf("checkpoint changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+	if got, readErr := os.ReadFile(logPath); readErr != nil || string(got) != events {
+		t.Fatalf("event log changed after refusal: bytes=%q err=%v", got, readErr)
+	}
+}
+
+func TestProbeSessionEventLogReadsOnlyNativeHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	logPath := store.SessionEventLog(path)
+	largeRecord := `{"schema_version":1,"type":"replace","messages":[{"role":"user","content":"` +
+		strings.Repeat("x", int(sessionEventProbeMaxBytes*2)) + `"}]}` + "\n"
+	if err := os.WriteFile(logPath, []byte(largeRecord), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+	probe, err := probeSessionEventLog(path)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !probe.native || probe.size != int64(len(largeRecord)) {
+		t.Fatalf("probe = %+v, want native size %d", probe, len(largeRecord))
 	}
 }
 

--- a/internal/agent/session_events_test.go
+++ b/internal/agent/session_events_test.go
@@ -333,6 +333,13 @@ func TestReplaySessionEventLogEnforcesResourceBudgetsWithoutMutation(t *testing.
 			},
 			resource: "messages",
 		},
+		{
+			name: "aggregate messages across records",
+			limits: sessionReplayLimits{
+				maxBytes: int64(len(contents) + 1), maxRecords: 10, maxMessages: 2,
+			},
+			resource: "messages",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -355,6 +362,30 @@ func TestReplaySessionEventLogEnforcesResourceBudgetsWithoutMutation(t *testing.
 				t.Fatal("resource-budget rejection modified the event log")
 			}
 		})
+	}
+}
+
+func TestReplayChecksMessageBudgetBeforeDecodingOverLimitElement(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "bounded-before-decode.events.jsonl")
+	// The third element is valid JSON but cannot decode into provider.Message.
+	// A two-message budget must reject it before attempting that decode.
+	events := `{"schema_version":1,"type":"replace","messages":[{}, {}, 42]}` + "\n"
+	if err := os.WriteFile(logPath, []byte(events), 0o600); err != nil {
+		t.Fatalf("write event log: %v", err)
+	}
+
+	replay, err := replaySessionEventLogWithLimits(logPath, sessionReplayLimits{
+		maxBytes: int64(len(events) + 1), maxRecords: 10, maxMessages: 2,
+	})
+	if !errors.Is(err, ErrSessionReplayLimitExceeded) {
+		t.Fatalf("replay error = %v, want message replay limit", err)
+	}
+	var limitErr *SessionReplayLimitError
+	if !errors.As(err, &limitErr) || limitErr.Resource != "messages" || limitErr.Value != 3 {
+		t.Fatalf("limit error = %#v, want third message rejected before decode", limitErr)
+	}
+	if replay.records != 0 || len(replay.msgs) != 0 {
+		t.Fatalf("partial over-limit record was applied: records=%d messages=%d", replay.records, len(replay.msgs))
 	}
 }
 
@@ -395,12 +426,41 @@ func TestProbeSessionEventLogReadsOnlyNativeHeader(t *testing.T) {
 	if err := os.WriteFile(logPath, []byte(largeRecord), 0o600); err != nil {
 		t.Fatalf("write event log: %v", err)
 	}
-	probe, err := probeSessionEventLog(path)
+	probe, err := probeSessionEventLogWithLimits(path, sessionReplayLimits{
+		maxBytes: 128, maxRecords: 10, maxMessages: 10,
+	})
 	if err != nil {
 		t.Fatalf("probe: %v", err)
 	}
 	if !probe.native || probe.size != int64(len(largeRecord)) {
 		t.Fatalf("probe = %+v, want native size %d", probe, len(largeRecord))
+	}
+}
+
+func TestLoadSessionMessagesAcceptsReorderedEventHeader(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	checkpoint := `{"role":"system","content":"older checkpoint"}` + "\n"
+	if err := os.WriteFile(path, []byte(checkpoint), 0o600); err != nil {
+		t.Fatalf("write checkpoint: %v", err)
+	}
+	content := "newer event state " + strings.Repeat("x", int(sessionEventProbeMaxBytes*2))
+	// schema_version deliberately follows a messages payload larger than the
+	// prefix probe. Valid in-budget JSON must remain field-order independent.
+	events := `{"type":"replace","messages":[{"role":"system","content":"sys"},{"role":"user","content":"` +
+		content + `"}],"schema_version":1}` + "\n"
+	if err := os.WriteFile(store.SessionEventLog(path), []byte(events), 0o600); err != nil {
+		t.Fatalf("write reordered event log: %v", err)
+	}
+
+	msgs, fromEvents, damaged, err := loadSessionMessages(path)
+	if err != nil {
+		t.Fatalf("load reordered event log: %v", err)
+	}
+	if !fromEvents || damaged {
+		t.Fatalf("load result fromEvents=%v damaged=%v, want clean native replay", fromEvents, damaged)
+	}
+	if len(msgs) != 2 || msgs[1].Content != content {
+		t.Fatalf("loaded messages = %d, want reordered event state", len(msgs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bound native session event-log replay to 128 MiB, 100,000 records, and 100,000 messages.
- Keep message arrays encoded until each element passes the aggregate message budget, so over-limit arrays are rejected before constructing an unbounded `provider.Message` graph.
- Use a 4 KiB native-header fast path while preserving JSON field-order independence for valid logs within the replay byte budget.
- Preserve authoritative event logs on any budget failure instead of falling back to an older checkpoint.
- Surface pinned-session load failures in Desktop instead of silently opening a blank replacement, while cleaning up the partially built controller and shared host.

## Problem

Native session event logs were decoded during startup without byte, record, or message budgets. A corrupt or unexpectedly large log could therefore consume unbounded memory before startup completed.

A message-count check performed only after decoding the complete array would still allow a compact record with many small objects to exhaust memory before the check ran. Treating the first two JSON keys as a fixed header contract would also misclassify valid reordered native logs and hide newer event history behind an older checkpoint.

Desktop also collapsed non-ENOENT pinned-session load errors into a false result. That allowed startup to continue with a new blank session, hiding the original failure and making the affected history appear missing.

## Root cause

The ownership probe originally used `json.Decoder.Decode` on a partial struct, which still buffered the complete first JSON value. The bounded replacement then required `schema_version` and `type` in a fixed order. Replay decoded `[]provider.Message` in the outer event record before checking its length, and the Desktop pinned-session helper did not preserve hard load errors.

## Compatibility

| Surface | Existing-data behavior | Conclusion |
| --- | --- | --- |
| Session event schema | No fields or schema versions change | Backward compatible |
| Normal existing logs | Replay is unchanged below the safety budgets, including reordered JSON fields | Backward compatible |
| Oversized or pathological logs | Loading fails closed; checkpoint and event log remain untouched | Data preserving |
| Older Reasonix versions | No new on-disk fields are written | Cross-version readable |

## Concurrency and data safety

- A `LimitedReader` enforces the same byte ceiling if another process grows the log after `Stat`.
- Budget errors are typed and path-free for UI surfaces; structured logs retain the local diagnostic path and measured limit.
- The authoritative event log is never truncated or replaced on refusal.
- Desktop retains the pinned session path and releases partially acquired runtime resources.
- The replay changes add no goroutines, locks, or shared mutable state; concurrent-load coverage remains green under the race detector.

## Verification

- `go test ./... -count=1`
- `cd desktop && go test ./... -count=1`
- Focused agent and Desktop `go test -race` suites
- `go vet ./internal/agent`
- `cd desktop && go vet .`
- Latest-`main-v2` merge-tree agent suite and Desktop pinned-session critical-path tests
- A 1 GiB sparse native-log startup regression verifies early refusal without reading the payload, modifying files, or leaking shared hosts.
- Regressions verify that over-limit elements are refused before element decoding and reordered in-budget headers do not fall back to stale checkpoints.

## Scope

Related to #7323. This PR hardens one confirmed memory-amplification path. It does not claim to resolve the still-unattributed WebKit/native memory growth or the separate recurring snapshot-conflict investigation.
