### PR TITLE
feat(provider): server-side web_search passthrough for Anthropic-kind providers

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2223,6 +2223,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"vision":                config.EffectiveVision(e),
 			"vision_model_explicit": config.ExplicitModelVision(e),
 			"vision_detail":         e.VisionDetail,
+			"web_search":            e.WebSearch,
 			"mode":                  e.ResponsesMode,
 			// Keep nil as nil so the responses provider can vendor-detect its
 			// default instead of accidentally treating every endpoint as stateful.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1292,6 +1292,13 @@ type ProviderEntry struct {
 	// (the field is omitted). "low" caps an image to a fixed ~85 tokens for cheap
 	// coarse reads; ignored by providers without the knob (e.g. anthropic).
 	VisionDetail string `toml:"vision_detail"`
+	// WebSearch enables the server-side web_search tool for the anthropic
+	// provider kind. When true, the provider includes {"type":"web_search"} in
+	// the tools array, and the API executes searches server-side, returning
+	// web_search_tool_result content blocks in the stream. This is the primary
+	// way to use DeepSeek's built-in search via its Anthropic-compatible
+	// endpoint (https://api.deepseek.com/anthropic). Off by default.
+	WebSearch bool `toml:"web_search"`
 	// ReasoningProtocol selects the request shape for OpenAI-compatible reasoning
 	// models. Empty/auto uses the model capability registry plus endpoint
 	// heuristics; glm selects GLM's thinking.type toggle; none disables automatic

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -364,6 +364,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q   # openai image detail hint: low|high; empty = auto\n", p.VisionDetail)
 			}
+			if p.WebSearch {
+				b.WriteString("web_search  = true   # enable server-side web_search tool (Anthropic/DeepSeek API)\n")
+			}
 			if p.ReasoningProtocol != "" {
 				fmt.Fprintf(&b, "reasoning_protocol = %q   # auto|deepseek|glm|openai|none; overrides model/endpoint reasoning detection\n", p.ReasoningProtocol)
 			}
@@ -1054,6 +1057,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 			}
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q\n", p.VisionDetail)
+			}
+			if p.WebSearch {
+				b.WriteString("web_search  = true\n")
 			}
 			if p.ReasoningProtocol != "" {
 				fmt.Fprintf(&b, "reasoning_protocol = %q\n", p.ReasoningProtocol)

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -723,24 +723,20 @@ func formatWebSearchResults(raw json.RawMessage) string {
 	if err := json.Unmarshal(raw, &results); err != nil {
 		return ""
 	}
-	if len(results) == 0 {
-		return ""
-	}
 	var b strings.Builder
-	b.WriteString("\n")
-	for i, r := range results {
+	for _, r := range results {
 		if r.Title == "" && r.URL == "" {
 			continue
 		}
-		b.WriteString(fmt.Sprintf("\n- **%s**", r.Title))
+		fmt.Fprintf(&b, "\n- **%s**", r.Title)
 		if r.URL != "" {
-			b.WriteString(fmt.Sprintf("\n  <%s>", r.URL))
-		}
-		if i == len(results)-1 {
-			b.WriteByte('\n')
+			fmt.Fprintf(&b, "\n  <%s>", r.URL)
 		}
 	}
-	return b.String()
+	if b.Len() == 0 {
+		return ""
+	}
+	return "\n" + b.String() + "\n"
 }
 
 // --- Messages API wire protocol ---

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -80,6 +80,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
+	webSearch, _ := cfg.Extra["web_search"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)
 	maxOutputTokens, _ := cfg.Extra["max_output_tokens"].(int)
@@ -119,6 +120,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		effort:           effort,
 		vision:           vision,
 		mimo:             provider.IsMiMoEndpoint(root),
+		webSearch:        webSearch,
 		headers:          cleanCustomHeaders(headers),
 		authHeader:       authHeader,
 		defaultMaxTokens: maxOutputTokens,
@@ -144,6 +146,7 @@ type client struct {
 	effort           string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
 	vision           bool   // model accepts image input — embed attached images as base64 image blocks
 	mimo             bool   // true for MiMo — upgrades legacy tuple schemas to Draft 2020-12
+	webSearch        bool   // enable server-side web_search tool (DeepSeek Anthropic API)
 	headers          map[string]string
 	authHeader       bool // send Authorization: Bearer instead of Anthropic's x-api-key header
 	defaultMaxTokens int
@@ -370,6 +373,9 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 	}
 
 	var tools []anthTool
+	if c.webSearch {
+		tools = append(tools, anthTool{Type: "web_search_20250305", Name: "web_search"})
+	}
 	for _, t := range req.Tools {
 		schema := t.Parameters
 		if len(schema) == 0 {
@@ -558,11 +564,27 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 				mergeUsage(ev.Message.Usage)
 			}
 		case "content_block_start":
-			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
-				tc := &provider.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
-				tools[ev.Index] = tc
-				if !send(provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}}) {
-					return
+			if ev.ContentBlock != nil {
+				switch ev.ContentBlock.Type {
+				case "tool_use":
+					tc := &provider.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
+					tools[ev.Index] = tc
+					if !send(provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}}) {
+						return
+					}
+				case "web_search_tool_result":
+					// Search results are delivered inline in content_block.content as a
+					// JSON array of result objects (title, url, encrypted_content).
+					// Only the model sees the plain text; we surface titles and URLs.
+					// server_tool_use blocks (the model initiating the search) are
+					// intentionally skipped — the API executes them server-side and
+					// the results appear here.
+					formatted := formatWebSearchResults(ev.ContentBlock.Content)
+					if formatted != "" {
+						if !send(provider.Chunk{Type: provider.ChunkText, Text: formatted}) {
+							return
+						}
+					}
 				}
 			}
 		case "content_block_delta":
@@ -681,6 +703,46 @@ func mapStopReason(s string) string {
 	}
 }
 
+// webSearchResult is a single result from a web_search_tool_result block.
+type webSearchResult struct {
+	URL      string `json:"url"`
+	Title    string `json:"title"`
+	Text     string `json:"text"`
+	SiteName string `json:"site_name"`
+}
+
+// formatWebSearchResults parses a web_search_tool_result content array
+// and formats titles and URLs as human-readable text. DeepSeek returns
+// encrypted_content rather than plain text at the transport layer; the
+// model still sees the original content.
+func formatWebSearchResults(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var results []webSearchResult
+	if err := json.Unmarshal(raw, &results); err != nil {
+		return ""
+	}
+	if len(results) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n")
+	for i, r := range results {
+		if r.Title == "" && r.URL == "" {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("\n- **%s**", r.Title))
+		if r.URL != "" {
+			b.WriteString(fmt.Sprintf("\n  <%s>", r.URL))
+		}
+		if i == len(results)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
 // --- Messages API wire protocol ---
 
 func ephemeral() *cacheControl { return &cacheControl{Type: "ephemeral"} }
@@ -762,9 +824,10 @@ func toolResultBlocks(text string, images []string) []contentBlock {
 }
 
 type anthTool struct {
-	Name         string          `json:"name"`
+	Type         string          `json:"type,omitempty"` // "web_search" for server-side search; empty for named tools
+	Name         string          `json:"name,omitempty"`
 	Description  string          `json:"description,omitempty"`
-	InputSchema  json.RawMessage `json:"input_schema"`
+	InputSchema  json.RawMessage `json:"input_schema,omitempty"`
 	CacheControl *cacheControl   `json:"cache_control,omitempty"`
 }
 
@@ -776,17 +839,20 @@ type streamEvent struct {
 		Usage *wireUsage `json:"usage"`
 	} `json:"message"`
 	ContentBlock *struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
-		Name string `json:"name"`
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		Name      string          `json:"name"`
+		ToolUseID string          `json:"tool_use_id"` // web_search_tool_result
+		Content   json.RawMessage `json:"content"`     // web_search_tool_result: array of result objects
 	} `json:"content_block"`
 	Delta *struct {
-		Type        string `json:"type"`         // text_delta | thinking_delta | signature_delta | input_json_delta
-		Text        string `json:"text"`         // text_delta
-		Thinking    string `json:"thinking"`     // thinking_delta
-		Signature   string `json:"signature"`    // signature_delta
-		PartialJSON string `json:"partial_json"` // input_json_delta
-		StopReason  string `json:"stop_reason"`  // message_delta
+		Type             string          `json:"type"`         // text_delta | thinking_delta | signature_delta | input_json_delta | web_search_tool_result_delta
+		Text             string          `json:"text"`         // text_delta
+		Thinking         string          `json:"thinking"`     // thinking_delta
+		Signature        string          `json:"signature"`    // signature_delta
+		PartialJSON      string          `json:"partial_json"` // input_json_delta
+		StopReason       string          `json:"stop_reason"`  // message_delta
+		WebSearchResults json.RawMessage `json:"results"`      // web_search_tool_result_delta
 	} `json:"delta"`
 	Usage *wireUsage `json:"usage"` // message_delta (cumulative output_tokens)
 	Error *struct {

--- a/internal/provider/anthropic/web_search_test.go
+++ b/internal/provider/anthropic/web_search_test.go
@@ -1,0 +1,153 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestBuildRequestWebSearchServerTool covers the tools-array shape when the
+// server-side web_search tool is enabled: it is prepended as a typed entry
+// without an input_schema, and named tools keep their schema untouched.
+func TestBuildRequestWebSearchServerTool(t *testing.T) {
+	c := &client{name: "deepseek", model: "deepseek-v4-flash", webSearch: true}
+	r := c.buildRequest(provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Tools:    []provider.ToolSchema{{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)}},
+	})
+	if len(r.Tools) != 2 {
+		t.Fatalf("want 2 tools (web_search + read_file), got %d: %+v", len(r.Tools), r.Tools)
+	}
+	if r.Tools[0].Type != "web_search_20250305" || r.Tools[0].Name != "web_search" {
+		t.Fatalf("tools[0] = %+v, want typed web_search server tool", r.Tools[0])
+	}
+	if len(r.Tools[0].InputSchema) != 0 {
+		t.Fatalf("server tool must not carry input_schema, got %s", r.Tools[0].InputSchema)
+	}
+	if r.Tools[1].Type != "" || r.Tools[1].Name != "read_file" || len(r.Tools[1].InputSchema) == 0 {
+		t.Fatalf("tools[1] = %+v, want named tool with schema and no type", r.Tools[1])
+	}
+
+	// Disabled (default) ⇒ no server tool is injected.
+	off := &client{name: "deepseek", model: "deepseek-v4-flash"}
+	r = off.buildRequest(provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Tools:    []provider.ToolSchema{{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)}},
+	})
+	if len(r.Tools) != 1 || r.Tools[0].Name != "read_file" {
+		t.Fatalf("webSearch off: tools = %+v, want only read_file", r.Tools)
+	}
+}
+
+// TestAnthToolWireShape pins the JSON encoding both tool kinds put on the wire:
+// the typed server tool omits input_schema entirely, and the omitempty on
+// input_schema must not leak into named tools (every named tool keeps a schema
+// because buildRequest substitutes a default for empty parameters).
+func TestAnthToolWireShape(t *testing.T) {
+	server, err := json.Marshal(anthTool{Type: "web_search_20250305", Name: "web_search"})
+	if err != nil {
+		t.Fatalf("marshal server tool: %v", err)
+	}
+	if got := string(server); got != `{"type":"web_search_20250305","name":"web_search"}` {
+		t.Fatalf("server tool wire = %s", got)
+	}
+
+	named, err := json.Marshal(anthTool{Name: "read_file", InputSchema: json.RawMessage(`{"type":"object"}`)})
+	if err != nil {
+		t.Fatalf("marshal named tool: %v", err)
+	}
+	if got := string(named); got != `{"name":"read_file","input_schema":{"type":"object"}}` {
+		t.Fatalf("named tool wire = %s", got)
+	}
+}
+
+func TestFormatWebSearchResults(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty payload", "", ""},
+		{"malformed json", `{"not":"an array"`, ""},
+		{"non-array json", `{"title":"x"}`, ""},
+		{"empty array", `[]`, ""},
+		{"all entries blank", `[{"text":"body only"},{}]`, ""},
+		{
+			// DeepSeek returns encrypted_content alongside title/url; unknown
+			// fields must be ignored rather than failing the whole block.
+			"titles and urls",
+			`[{"type":"web_search_result","title":"Change Log","url":"https://api-docs.deepseek.com/updates/","encrypted_content":"xxx"},{"title":"No URL"}]`,
+			"\n\n- **Change Log**\n  <https://api-docs.deepseek.com/updates/>\n- **No URL**\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatWebSearchResults(json.RawMessage(tc.raw)); got != tc.want {
+				t.Fatalf("formatWebSearchResults(%s) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStreamSurfacesWebSearchResults drives a full SSE round-trip: a
+// web_search_tool_result block must surface as readable text chunks, and the
+// server_tool_use block (the model initiating the search) must not be mistaken
+// for a client tool call.
+func TestStreamSurfacesWebSearchResults(t *testing.T) {
+	sse := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"s1","name":"web_search"}}`,
+		``,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"s1","content":[{"title":"Change Log","url":"https://api-docs.deepseek.com/updates/"}]}}`,
+		``,
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"text"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"answer"}}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(sse))
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "k", Extra: map[string]any{"web_search": true}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "search something"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkToolCallStart, provider.ChunkToolCall:
+			t.Fatalf("server-side search must not surface as a client tool call, got %+v", chunk)
+		case provider.ChunkError:
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	got := text.String()
+	if !strings.Contains(got, "**Change Log**") || !strings.Contains(got, "<https://api-docs.deepseek.com/updates/>") {
+		t.Fatalf("stream text missing formatted search results: %q", got)
+	}
+	if !strings.Contains(got, "answer") {
+		t.Fatalf("stream text missing model answer: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `web_search = true` flag on `[[providers]]` entries of the anthropic kind. When enabled, the provider includes the typed `web_search_20250305` server tool in the tools array; the API executes searches server-side and streams back `web_search_tool_result` blocks, which we surface as readable titles/URLs in the transcript. Off by default; no search backend enters core.

Carries #6593 by @seankhliao (original commit kept with authorship; rebased onto current main-v2 and conflict-resolved against the `defaultMaxTokens` / `deepseek` client fields), plus a hardening commit:

- `formatWebSearchResults`: no stray output when every result entry is blank; lint cleanup.
- Wire-shape tests: the typed server tool omits `input_schema`; `omitempty` must not strip schemas from named tools.
- `buildRequest` ordering test with the flag on/off.
- Full SSE round-trip test: results surface as text, and `server_tool_use` is never mistaken for a client tool call.

## Why

Discovery is the one gap `web_fetch` cannot cover (SERP scraping is blocked/broken for the primary audience — see #3112/#4112). This closes it with a provider capability instead of infrastructure.

## Verification

- Live probe against `api.deepseek.com/anthropic` with `deepseek-v4-flash`: the endpoint executed searches server-side (`server_tool_use` → 10-result `web_search_tool_result`), the model's answer was verifiably current, and usage metered the call as `"server_tool_use": {"web_search_requests": 1}`.
- `LANG=en_US.UTF-8 go test ./...` green on the full root module; `gofmt`/`go vet` clean.

Cache-impact: none by default — the flag is off unless configured, and the request bytes are unchanged when off (covered by the flag-off ordering test). When enabled, the server tool is prepended to the tools array, which is a config-level prefix change: stable within a session, so DeepSeek's automatic prefix cache re-warms once per config change. Native-Anthropic breakpoint placement is unaffected (system-block marker still caches tools+system; DeepSeek wire carries no cache_control at all).

Cache-guard: TestBuildRequestWebSearchServerTool pins that the flag-off tools array is byte-identical to before (no server tool injected), and TestAnthToolWireShape pins that named tools keep their exact wire shape despite the new omitempty tags.

System-prompt-review: esengine session review 2026-08-03 — no system-prompt text is touched; boot.go only threads the provider Extra flag and config.go adds the documented `web_search` field.

## Follow-up (not in this PR)

Surface `usage.server_tool_use.web_search_requests` in the cost pipeline so metered searches are visible; note that search results ride input tokens (~5.4k for a one-line query in the probe).

Supersedes #6593.
