### PR TITLE
fix(security): harden verification links and session lineage paths

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -454,7 +454,6 @@ func (s *SubagentStore) sessionAncestors(current string) ([]string, error) {
 	if current == "" {
 		return nil, nil
 	}
-	sessionDir := filepath.Dir(s.dir)
 	var ancestors []string
 	seen := map[string]bool{}
 	for cursor := current; cursor != ""; {
@@ -462,7 +461,15 @@ func (s *SubagentStore) sessionAncestors(current string) ([]string, error) {
 			return nil, fmt.Errorf("cycle at session %q", cursor)
 		}
 		seen[cursor] = true
-		meta, ok, err := LoadBranchMeta(filepath.Join(sessionDir, cursor+".jsonl"))
+		// Route through parentSessionPath so both the caller-provided id and
+		// every parent id read from disk metadata get the same bare-filename
+		// validation — a raw Join would let "../"-shaped ids escape the
+		// session directory.
+		metaPath, valid := s.parentSessionPath(cursor)
+		if !valid {
+			return nil, fmt.Errorf("invalid session identifier %q", cursor)
+		}
+		meta, ok, err := LoadBranchMeta(metaPath)
 		if err != nil {
 			return nil, err
 		}
@@ -729,14 +736,21 @@ func (s *SubagentStore) isAncestorSession(ancestor, current string) (bool, error
 	if ancestor == "" || current == "" {
 		return false, nil
 	}
-	sessionDir := filepath.Dir(s.dir)
 	seen := map[string]bool{}
 	for cursor := current; cursor != ""; {
 		if seen[cursor] {
 			return false, fmt.Errorf("cycle at session %q", cursor)
 		}
 		seen[cursor] = true
-		meta, ok, err := LoadBranchMeta(filepath.Join(sessionDir, cursor+".jsonl"))
+		// Route through parentSessionPath so both the caller-provided id and
+		// every parent id read from disk metadata get the same bare-filename
+		// validation — a raw Join would let "../"-shaped ids escape the
+		// session directory.
+		metaPath, valid := s.parentSessionPath(cursor)
+		if !valid {
+			return false, fmt.Errorf("invalid session identifier %q", cursor)
+		}
+		meta, ok, err := LoadBranchMeta(metaPath)
 		if err != nil {
 			return false, err
 		}

--- a/internal/agent/subagent_store_traversal_test.go
+++ b/internal/agent/subagent_store_traversal_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Lineage walks build paths from session identifiers — the caller-provided
+// parent id and every parent id read back from branch metadata. All of them
+// must be validated as bare filename stems so a "../"-shaped id can never
+// escape the session directory (#5551).
+func TestSessionLineageRejectsTraversalIdentifiers(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+
+	for _, id := range []string{"../evil", "..", ".", "nested/evil", "/abs"} {
+		if _, err := store.sessionAncestors(id); err == nil || !strings.Contains(err.Error(), "invalid session identifier") {
+			t.Fatalf("sessionAncestors(%q) error = %v, want invalid-identifier rejection", id, err)
+		}
+		if _, err := store.isAncestorSession("root", id); err == nil || !strings.Contains(err.Error(), "invalid session identifier") {
+			t.Fatalf("isAncestorSession(root, %q) error = %v, want invalid-identifier rejection", id, err)
+		}
+	}
+}
+
+func TestSessionLineageRejectsTraversalParentFromMetadata(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+
+	// A well-formed child whose stored metadata declares a traversal parent:
+	// the walk must stop with a validation error instead of joining the path.
+	saveTestBranchMeta(t, sessionDir, "child", "../evil")
+	if _, err := store.sessionAncestors("child"); err == nil || !strings.Contains(err.Error(), "invalid session identifier") {
+		t.Fatalf("sessionAncestors(child) error = %v, want invalid-identifier rejection for stored parent", err)
+	}
+}

--- a/workers/accounts/src/routes/auth.ts
+++ b/workers/accounts/src/routes/auth.ts
@@ -37,8 +37,12 @@ async function uniqueHandle(users: UserRepo, base: string): Promise<string> {
   return `user${randomSuffix(8)}`;
 }
 
-function verifyLink(c: { req: { url: string } }, token: string): string {
-  return `${new URL(c.req.url).origin}/auth/verify?token=${token}`;
+// Built from the configured APP_ORIGIN, never the request origin: the Host
+// header is caller-controlled, so a request-derived origin would let emailed
+// verification links point at an attacker-chosen host (#5550).
+function verifyLink(c: { env: { APP_ORIGIN: string } }, token: string): string {
+  const base = c.env.APP_ORIGIN.replace(/\/+$/, "");
+  return `${base}/auth/verify?token=${encodeURIComponent(token)}`;
 }
 
 // Register is deliberately enumeration-safe: the response is identical whether or


### PR DESCRIPTION
## Summary

Verifies and fixes both findings from the automated security reports #5550 and #5551 (both confirmed real against current main-v2):

1. **Accounts worker — Host-header-derived verification links (#5550)**: `verifyLink` built emailed verification URLs from `new URL(c.req.url).origin`, which derives from the caller-controlled Host header. It now uses the configured `c.env.APP_ORIGIN` (the binding already existed and every other emailed link already used it) and URL-encodes the token.

2. **Subagent store — path traversal via session identifiers (#5551)**: `sessionAncestors` and `isAncestorSession` joined `sessionDir + cursor + ".jsonl"` without validating `cursor`. Both walks now route every session id — the caller-provided parent and every parent id read back from branch metadata — through the existing `parentSessionPath` bare-filename guard, so a `"../"`-shaped id fails with `invalid session identifier` instead of escaping the session directory. (Exploitation was already made harder by the `meta.ID == cursor` post-check; this closes the path construction itself.)

## Verification

- New tests: `TestSessionLineageRejectsTraversalIdentifiers` (caller-provided ids: `../evil`, `..`, `.`, `nested/evil`, `/abs`) and `TestSessionLineageRejectsTraversalParentFromMetadata` (traversal id stored in branch metadata).
- `LANG=en_US.UTF-8 go test ./internal/agent/` green; `gofmt` clean.
- `pnpm typecheck` green in `workers/accounts`.

Fixes #5550. Fixes #5551.