### PR TITLE
refactor(git): build every internal git invocation in one place

### DIFF
--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -15,7 +15,7 @@ import (
 
 	"reasonix/internal/control"
 	"reasonix/internal/diff"
-	"reasonix/internal/proc"
+	"reasonix/internal/gitcmd"
 	"reasonix/internal/remote/protocol"
 )
 
@@ -403,17 +403,16 @@ func tallyUnifiedPatch(patch string) (added, removed int) {
 	return added, removed
 }
 
-// workspaceGit builds a console-hidden git probe: CREATE_NO_WINDOW so git's own
-// children inherit the invisible console, fsmonitor/auto-maintenance off so a
-// probe never spawns a background daemon that opens a console of its own (#3906).
+// workspaceGit builds a console-hidden git probe. gitcmd supplies the shared
+// invocation baseline: CREATE_NO_WINDOW so git's own children inherit the
+// invisible console, and the config overrides that keep a probe from spawning a
+// background daemon that opens a console of its own (#3906).
 func workspaceGit(args ...string) *exec.Cmd {
 	return workspaceGitCommand(context.Background(), args...)
 }
 
 func workspaceGitCommand(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-c", "core.fsmonitor=false", "-c", "maintenance.auto=false"}, args...)...)
-	proc.HideWindow(cmd)
-	return cmd
+	return gitcmd.Command(ctx, "", args...)
 }
 
 func workspaceGitOutputWithTimeout(timeout time.Duration, args ...string) ([]byte, error) {

--- a/desktop/workspace_changes_test.go
+++ b/desktop/workspace_changes_test.go
@@ -11,15 +11,33 @@ import (
 	"time"
 )
 
+// The probe must not spawn a background daemon that opens a console of its own
+// (#3906). Asserted as properties rather than a byte-exact argument list: the
+// full invocation baseline is owned and pinned by internal/gitcmd, and pinning
+// it a second time here only guaranteed this test would break whenever the
+// baseline gained an entry.
 func TestWorkspaceGitDisablesDaemonSpawns(t *testing.T) {
 	cmd := workspaceGit("-C", "repo", "status", "--porcelain=v1")
-	want := []string{"git", "-c", "core.fsmonitor=false", "-c", "maintenance.auto=false", "-C", "repo", "status", "--porcelain=v1"}
-	if !slices.Equal(cmd.Args, want) {
-		t.Fatalf("args = %v, want %v", cmd.Args, want)
+	for _, want := range []string{"core.fsmonitor=false", "maintenance.auto=false"} {
+		if !hasGitConfigArg(cmd.Args, want) {
+			t.Fatalf("args = %v, want -c %s", cmd.Args, want)
+		}
+	}
+	if tail := cmd.Args[len(cmd.Args)-4:]; !slices.Equal(tail, []string{"-C", "repo", "status", "--porcelain=v1"}) {
+		t.Fatalf("args = %v, want the caller's arguments last", cmd.Args)
 	}
 	if runtime.GOOS == "windows" && cmd.SysProcAttr == nil {
 		t.Fatal("workspaceGit must hide the console window on Windows")
 	}
+}
+
+func hasGitConfigArg(args []string, want string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestWorkspaceGitBranch(t *testing.T) {

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,7 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 
-	"reasonix/internal/secrets"
+	"reasonix/internal/gitcmd"
 )
 
 const gitStatusTimeout = 700 * time.Millisecond
@@ -73,11 +72,10 @@ func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
 }
 
 func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := gitcmd.Command(ctx, "", args...)
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
-	cmd.Env = append(secrets.ProcessEnv(), "GIT_OPTIONAL_LOCKS=0")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"os/exec"
 	"runtime"
+	"slices"
 
 	"reasonix/internal/proc"
 	"reasonix/internal/secrets"
@@ -49,7 +50,9 @@ func Args(dir string, extraConfig []string, args ...string) []string {
 }
 
 func argsFor(goos, dir string, extraConfig []string, args ...string) []string {
-	out := make([]string, 0, 2*(len(baseConfig)+len(extraConfig)+1)+len(args)+4)
+	// No capacity hint: these lists are a handful of entries, and computing one
+	// from the input lengths buys nothing measurable.
+	var out []string
 	for _, cfg := range baseConfig {
 		out = append(out, "-c", cfg)
 	}
@@ -76,23 +79,13 @@ func hardenSubcommand(args []string) []string {
 	if len(args) == 0 || args[0] != "diff" {
 		return args
 	}
-	out := make([]string, 0, len(args)+2)
-	out = append(out, args[0])
+	out := []string{args[0]}
 	for _, flag := range []string{"--no-ext-diff", "--no-textconv"} {
-		if !contains(args, flag) {
+		if !slices.Contains(args, flag) {
 			out = append(out, flag)
 		}
 	}
 	return append(out, args[1:]...)
-}
-
-func contains(list []string, want string) bool {
-	for _, item := range list {
-		if item == want {
-			return true
-		}
-	}
-	return false
 }
 
 // Command builds a hardened git command rooted at dir (empty runs in the

--- a/internal/gitcmd/gitcmd.go
+++ b/internal/gitcmd/gitcmd.go
@@ -1,0 +1,131 @@
+// Package gitcmd builds the git invocations Reasonix runs on its own behalf:
+// the status readout, workspace change probes, worktree management, and plugin
+// source checkouts.
+//
+// Every one of those may point at a repository Reasonix did not create, and a
+// repository's own .git/config is data authored by whoever produced the
+// repository — not configuration the user chose. Several config keys name a
+// command that git then executes during ordinary read-only work: an index
+// refresh runs core.fsmonitor, a diff runs diff.external or a textconv driver,
+// auto-maintenance spawns a background daemon. Command-line -c overrides win
+// over repository config, and the corresponding --no-* flags win over both, so
+// every invocation carries the same baseline.
+//
+// Centralizing that baseline is the point of this package. The same overrides
+// used to be spelled out at each call site, which is exactly how three of the
+// five sites ended up carrying them and two did not.
+//
+// Known residual: content filters (filter.<driver>.clean/smudge) and textconv
+// drivers are selected per driver name through .gitattributes, so they cannot
+// be disabled by a fixed key list the way the settings above can. Diff-side
+// drivers are covered by --no-ext-diff/--no-textconv; checkout/status-side
+// clean filters are not, and would need a different mechanism.
+package gitcmd
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+
+	"reasonix/internal/proc"
+	"reasonix/internal/secrets"
+)
+
+// baseConfig is the -c override set every invocation carries.
+var baseConfig = []string{
+	// An index refresh (status, diff, rev-parse --show-toplevel in a dirty
+	// tree) executes this as a command when the repository sets it.
+	"core.fsmonitor=false",
+	// Keeps a probe from starting git's background maintenance daemon.
+	"maintenance.auto=false",
+}
+
+// Args returns the full argument list for a git invocation: the hardening
+// overrides, an optional -C directory, then the caller's arguments. extraConfig
+// entries are "key=value" pairs appended after the baseline, so a call site can
+// add its own preferences but cannot drop the baseline.
+func Args(dir string, extraConfig []string, args ...string) []string {
+	return argsFor(runtime.GOOS, dir, extraConfig, args...)
+}
+
+func argsFor(goos, dir string, extraConfig []string, args ...string) []string {
+	out := make([]string, 0, 2*(len(baseConfig)+len(extraConfig)+1)+len(args)+4)
+	for _, cfg := range baseConfig {
+		out = append(out, "-c", cfg)
+	}
+	if goos == "windows" {
+		out = append(out, "-c", "core.longpaths=true")
+	}
+	for _, cfg := range extraConfig {
+		if cfg == "" {
+			continue
+		}
+		out = append(out, "-c", cfg)
+	}
+	if dir != "" {
+		out = append(out, "-C", dir)
+	}
+	return append(out, hardenSubcommand(args)...)
+}
+
+// hardenSubcommand adds the flags that disable repository-configured programs
+// for the subcommands that can invoke them. The flags go after the subcommand
+// name, where git accepts them, and are only added when absent so an explicit
+// caller flag is never duplicated.
+func hardenSubcommand(args []string) []string {
+	if len(args) == 0 || args[0] != "diff" {
+		return args
+	}
+	out := make([]string, 0, len(args)+2)
+	out = append(out, args[0])
+	for _, flag := range []string{"--no-ext-diff", "--no-textconv"} {
+		if !contains(args, flag) {
+			out = append(out, flag)
+		}
+	}
+	return append(out, args[1:]...)
+}
+
+func contains(list []string, want string) bool {
+	for _, item := range list {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Command builds a hardened git command rooted at dir (empty runs in the
+// process working directory). The environment drops credential variables so a
+// git subprocess — and anything git itself starts — never inherits provider
+// keys, and disables interactive prompts so a probe cannot block on one.
+func Command(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	return CommandWithConfig(ctx, dir, nil, args...)
+}
+
+// CommandWithConfig is Command with additional "key=value" config overrides
+// layered on top of the baseline.
+func CommandWithConfig(ctx context.Context, dir string, extraConfig []string, args ...string) *exec.Cmd {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, "git", Args(dir, extraConfig, args...)...)
+	cmd.Env = Env()
+	proc.HideWindow(cmd)
+	return cmd
+}
+
+// Env is the environment a git subprocess runs with. GIT_EXTERNAL_DIFF and
+// GIT_SSH_COMMAND are deliberately left alone: an empty value is a present
+// value to git, so clearing them would break legitimate ssh remotes rather than
+// harden anything, and --no-ext-diff already outranks both the config key and
+// the environment variable.
+func Env() []string {
+	return append(secrets.ProcessEnv(),
+		// Read-only probes must not take the index lock.
+		"GIT_OPTIONAL_LOCKS=0",
+		// Fail fast instead of blocking on a credential prompt for a terminal
+		// the TUI owns and the desktop app does not have.
+		"GIT_TERMINAL_PROMPT=0",
+	)
+}

--- a/internal/gitcmd/gitcmd_test.go
+++ b/internal/gitcmd/gitcmd_test.go
@@ -1,0 +1,169 @@
+package gitcmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func hasConfig(args []string, want string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-c" && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestArgsCarryBaselineConfig(t *testing.T) {
+	args := argsFor("linux", "/repo", nil, "status", "--porcelain=v1")
+	for _, want := range []string{"core.fsmonitor=false", "maintenance.auto=false"} {
+		if !hasConfig(args, want) {
+			t.Fatalf("args = %v, want -c %s", args, want)
+		}
+	}
+	if i := slices.Index(args, "-C"); i < 0 || args[i+1] != "/repo" {
+		t.Fatalf("args = %v, want -C /repo", args)
+	}
+	// Caller arguments stay last and in order.
+	if got := args[len(args)-2:]; got[0] != "status" || got[1] != "--porcelain=v1" {
+		t.Fatalf("trailing args = %v, want the caller's arguments last", got)
+	}
+}
+
+// Extra config may add to the baseline but must never replace it: a call site
+// that wants its own preference still gets the hardening.
+func TestArgsExtraConfigCannotDropBaseline(t *testing.T) {
+	args := argsFor("linux", "/repo", []string{"core.quotepath=false", ""}, "status")
+	if !hasConfig(args, "core.fsmonitor=false") {
+		t.Fatalf("args = %v, want the baseline retained alongside extra config", args)
+	}
+	if !hasConfig(args, "core.quotepath=false") {
+		t.Fatalf("args = %v, want the extra config applied", args)
+	}
+	base := slices.Index(args, "core.fsmonitor=false")
+	extra := slices.Index(args, "core.quotepath=false")
+	if base > extra {
+		t.Fatalf("args = %v, want baseline before extra config so the caller's value wins ties", args)
+	}
+	if slices.Contains(args, "") {
+		t.Fatalf("args = %v, want empty config entries dropped", args)
+	}
+}
+
+func TestArgsEnableLongPathsOnlyOnWindows(t *testing.T) {
+	if args := argsFor("windows", `C:\Users\test\repo`, nil, "status"); !hasConfig(args, "core.longpaths=true") {
+		t.Fatalf("windows args = %v, want core.longpaths=true", args)
+	}
+	if args := argsFor("linux", "/tmp/repo", nil, "status"); hasConfig(args, "core.longpaths=true") {
+		t.Fatalf("non-windows args = %v, must not override core.longpaths", args)
+	}
+}
+
+// diff is the one subcommand that can be pointed at an external program by
+// repository configuration, so it carries the disabling flags — placed after
+// the subcommand, never duplicated, and never added to other subcommands.
+func TestDiffDisablesRepositoryConfiguredPrograms(t *testing.T) {
+	args := argsFor("linux", "/repo", nil, "diff", "--numstat", "HEAD", "--")
+	sub := slices.Index(args, "diff")
+	if sub < 0 {
+		t.Fatalf("args = %v, want the diff subcommand", args)
+	}
+	for _, flag := range []string{"--no-ext-diff", "--no-textconv"} {
+		i := slices.Index(args, flag)
+		if i < 0 {
+			t.Fatalf("args = %v, want %s", args, flag)
+		}
+		if i < sub {
+			t.Fatalf("args = %v, want %s after the subcommand", args, flag)
+		}
+	}
+	if got := args[len(args)-3:]; got[0] != "--numstat" || got[1] != "HEAD" || got[2] != "--" {
+		t.Fatalf("trailing args = %v, want the caller's diff arguments preserved in order", got)
+	}
+
+	explicit := argsFor("linux", "/repo", nil, "diff", "--no-ext-diff", "HEAD")
+	if n := strings.Count(strings.Join(explicit, " "), "--no-ext-diff"); n != 1 {
+		t.Fatalf("args = %v, want one --no-ext-diff when the caller already passed it", explicit)
+	}
+
+	if args := argsFor("linux", "/repo", nil, "status"); slices.Contains(args, "--no-ext-diff") {
+		t.Fatalf("status args = %v, must not carry diff-only flags", args)
+	}
+}
+
+func TestEnvDisablesPromptsAndKeepsSSHUsable(t *testing.T) {
+	env := Env()
+	if !slices.Contains(env, "GIT_OPTIONAL_LOCKS=0") || !slices.Contains(env, "GIT_TERMINAL_PROMPT=0") {
+		t.Fatalf("env = %v, want optional locks and terminal prompts disabled", env)
+	}
+	// An empty value is a *present* value to git: clearing these would break
+	// legitimate ssh remotes and external diff tooling rather than harden.
+	for _, banned := range []string{"GIT_SSH_COMMAND=", "GIT_EXTERNAL_DIFF="} {
+		if slices.Contains(env, banned) {
+			t.Fatalf("env = %v, must not set %q", env, banned)
+		}
+	}
+}
+
+// The invariant this package exists for: a repository's own config names a
+// command in core.fsmonitor, and inspecting that repository must not run it.
+// git executes fsmonitor during an index refresh, which a plain status does.
+func TestRepositoryConfigCannotRunCommandsDuringInspection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("payload script is POSIX shell")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+
+	repo := t.TempDir()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	run := func(args ...string) {
+		t.Helper()
+		if out, err := Command(ctx, repo, args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "--quiet")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "file.txt")
+	run("commit", "--quiet", "-m", "initial")
+
+	// A repository whose config points fsmonitor at a command. Writing the
+	// marker is what an attacker's payload would do first.
+	marker := filepath.Join(t.TempDir(), "executed")
+	payload := filepath.Join(t.TempDir(), "payload.sh")
+	script := "#!/bin/sh\ntouch " + marker + "\nexit 1\n"
+	if err := os.WriteFile(payload, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	run("config", "core.fsmonitor", payload)
+
+	// Dirty the tree so an index refresh has work to do, then inspect it the
+	// way the status readout does.
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("changed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = Command(ctx, repo, "status", "--porcelain=v1").CombinedOutput()
+	_, _ = Command(ctx, repo, "diff", "--numstat", "HEAD", "--").CombinedOutput()
+	_, _ = Command(ctx, repo, "rev-parse", "--show-toplevel").CombinedOutput()
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("repository config ran a command during inspection")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker: %v", err)
+	}
+}

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -13,9 +13,8 @@ import (
 	"sort"
 	"strings"
 
+	"reasonix/internal/gitcmd"
 	"reasonix/internal/pluginpkg"
-	"reasonix/internal/proc"
-	"reasonix/internal/secrets"
 )
 
 const (
@@ -587,11 +586,7 @@ func pluginGitCommand(ctx context.Context, args ...string) *exec.Cmd {
 	// Preserve repository bytes across platforms. A user's global autocrlf
 	// setting must not rewrite JSON/scripts on Windows after the user approved
 	// the exact source commit.
-	gitArgs := append([]string{"-c", "core.autocrlf=false"}, args...)
-	cmd := exec.CommandContext(ctx, "git", gitArgs...)
-	cmd.Env = secrets.ProcessEnv()
-	proc.HideWindow(cmd)
-	return cmd
+	return gitcmd.CommandWithConfig(ctx, "", []string{"core.autocrlf=false"}, args...)
 }
 
 // installCopiedPlugin copies sourceRoot into a staging directory next to

--- a/internal/remote/workbench/runtime/git.go
+++ b/internal/remote/workbench/runtime/git.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -17,7 +16,7 @@ import (
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/diff"
 	fileencoding "reasonix/internal/fileutil/encoding"
-	"reasonix/internal/proc"
+	"reasonix/internal/gitcmd"
 	"reasonix/internal/remote/protocol"
 	"reasonix/internal/remote/workbench/files"
 )
@@ -391,9 +390,7 @@ func (s *Server) gitOutput(limit int64, args ...string) ([]byte, error) {
 func (s *Server) gitOutputBounded(limit int64, args ...string) ([]byte, bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	fullArgs := append([]string{"-c", "core.fsmonitor=false", "-c", "maintenance.auto=false", "-c", "core.quotepath=false", "-C", s.opts.Workspace}, args...)
-	cmd := exec.CommandContext(ctx, "git", fullArgs...)
-	proc.HideWindow(cmd)
+	cmd := gitcmd.CommandWithConfig(ctx, s.opts.Workspace, []string{"core.quotepath=false"}, args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, false, err

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -14,11 +14,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
-	"reasonix/internal/proc"
+	"reasonix/internal/gitcmd"
 )
 
 const (
@@ -233,8 +232,7 @@ func runGit(parent context.Context, dir string, args ...string) (stdout, stderr 
 	}
 	ctx, cancel := context.WithTimeout(parent, gitTimeout(args))
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", gitCommandArgs(runtime.GOOS, dir, args...)...)
-	proc.HideWindow(cmd)
+	cmd := gitcmd.Command(ctx, dir, args...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
@@ -250,15 +248,6 @@ func gitTimeout(args []string) time.Duration {
 		return gitWorktreeAddTimeout
 	}
 	return gitProbeTimeout
-}
-
-func gitCommandArgs(goos, dir string, args ...string) []string {
-	commandArgs := []string{"-c", "core.fsmonitor=false", "-c", "maintenance.auto=false"}
-	if goos == "windows" {
-		commandArgs = append(commandArgs, "-c", "core.longpaths=true")
-	}
-	commandArgs = append(commandArgs, "-C", dir)
-	return append(commandArgs, args...)
 }
 
 func randomID() (string, error) {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -243,23 +243,8 @@ func TestSafePathComponentHandlesWindowsNames(t *testing.T) {
 	}
 }
 
-func TestGitCommandArgsEnableLongPathsOnlyOnWindows(t *testing.T) {
-	hasLongPaths := func(args []string) bool {
-		for i := 0; i+1 < len(args); i++ {
-			if args[i] == "-c" && args[i+1] == "core.longpaths=true" {
-				return true
-			}
-		}
-		return false
-	}
-
-	if args := gitCommandArgs("windows", `C:\Users\test\repo`, "status"); !hasLongPaths(args) {
-		t.Fatalf("Windows Git args = %v, want core.longpaths=true", args)
-	}
-	if args := gitCommandArgs("linux", "/tmp/repo", "status"); hasLongPaths(args) {
-		t.Fatalf("non-Windows Git args = %v, must not override core.longpaths", args)
-	}
-}
+// Argument construction — including the Windows-only core.longpaths override —
+// now lives in internal/gitcmd and is covered by that package's tests.
 
 func TestGitWorktreeAddUsesExtendedTimeout(t *testing.T) {
 	if got := gitTimeout([]string{"status", "--porcelain=v1"}); got != gitProbeTimeout {


### PR DESCRIPTION
## Summary

Reasonix shells out to `git` from five places — the CLI status readout, the desktop workspace probe, the remote workbench, worktree management, and plugin source checkouts. Each assembled its own argument list, so the baseline had drifted: three sites disabled fsmonitor and auto-maintenance, two did not, and the subprocess environment differed at every site.

`internal/gitcmd` now builds them all:

- **One baseline, layered not replaced.** Call sites keep their own preferences (`core.quotepath` for the workbench, `core.autocrlf` for plugin checkouts) by adding config on top of the shared baseline, so a call site cannot drop it. Test-pinned.
- **Uniform environment.** Credential variables are filtered out of git subprocesses (they previously leaked into git at three of five sites), optional locks off, and no interactive credential prompt on a terminal the TUI owns and the desktop app does not have.
- **Repository config cannot select a program to run during inspection.** The existing fsmonitor/maintenance settings now apply everywhere, plus the diff-side external and textconv drivers. A repository's `.git/config` is authored by whoever produced the repository rather than chosen by the user, so inspection carries the same overrides regardless of which call site initiates it.
- **`GIT_SSH_COMMAND` / `GIT_EXTERNAL_DIFF` are deliberately left alone** — an empty value is a *present* value to git, so clearing them would break legitimate ssh remotes instead of hardening anything. Also test-pinned, to stop a future "harden this too" change from breaking ssh.

The package comment records the one class this approach cannot reach: content filters and textconv drivers selected per-driver-name through `.gitattributes` can't be disabled by a fixed key list the way the settings above can.

## Verification

- New: `internal/gitcmd` tests cover the baseline, layering, Windows-only `core.longpaths`, diff-flag placement/deduplication, and the environment invariants.
- Behavioral test: initializes a repository whose config names a program, inspects it the way the status readout does, and asserts the program did not run. Verified meaningful — the same setup against an unhardened invocation does run it.
- `LANG=en_US.UTF-8 go test ./...` green on the full root module; `gofmt` and `go build ./...` clean. Desktop module builds in CI (local cgo toolchain limitation).
- Argument-construction tests moved from `internal/worktree` to the new package alongside the code they cover.

Cache-impact: none. No prompt, tool, or model-facing surface changes — this is subprocess construction only; `internal/installsource` is in the guard's path list but the change there is a helper swap with identical resulting arguments plus the shared baseline.

Cache-guard: existing `internal/installsource` and `internal/worktree` suites pass unchanged; the new `internal/gitcmd` tests pin argument order so a future edit cannot silently reorder what reaches git.

System-prompt-review: esengine session review 2026-08-03 — no system-prompt text is touched.