### PR TITLE
fix(agent): derive transient-block handling from one tag list

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -8,7 +8,36 @@ import (
 	"reasonix/internal/provider"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route|interrupted-turn-recovery)(?:\s+[^>]*)?>.*?</(?:response-language|reasoning-language|memory-update|background-jobs|active-goal|hook-context|capability-route|interrupted-turn-recovery)>\s*\n?`)
+// TransientUserBlockTags names every block the host prepends to a user turn as
+// runtime context rather than something the user typed. Previews, titles, and
+// the rewind picker strip them; a tag missing from this list leaks raw markup
+// into the UI, which is how <autoresearch-runtime> surfaced in session titles.
+//
+// This is the single source of truth: the strip regex is built from it, and
+// hasLeadingInjectedBlock walks it. Anything that starts prepending a new block
+// to user turns belongs here.
+var TransientUserBlockTags = []string{
+	"response-language",
+	"reasoning-language",
+	"memory-update",
+	"background-jobs",
+	"active-goal",
+	"autoresearch-runtime",
+	"hook-context",
+	"capability-route",
+	"interrupted-turn-recovery",
+}
+
+var reTransientUserBlock = buildTransientUserBlockRE(TransientUserBlockTags)
+
+// buildTransientUserBlockRE matches one leading transient block: an open tag
+// (with optional attributes), its content, and its own closing tag. The
+// alternation is generated so the open and close lists cannot drift apart —
+// spelling them out twice by hand is what let tags go missing from one side.
+func buildTransientUserBlockRE(tags []string) *regexp.Regexp {
+	alt := strings.Join(tags, "|")
+	return regexp.MustCompile(`(?s)^\s*<(?:` + alt + `)(?:\s+[^>]*)?>.*?</(?:` + alt + `)>\s*\n?`)
+}
 
 // stripTrailingDeliveryRuntime removes the exact delivery-runtime marker the
 // agent appends to user turns in delivery mode (agent.go DeliveryRuntimeMarker).

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -204,46 +204,40 @@ func WithReasoningLanguageForSource(content, lang, source string) string {
 	return block + "\n\n" + content
 }
 
+// hasLeadingInjectedBlock reports whether target is already among the transient
+// blocks leading content, skipping past any other injected block on the way.
+// It walks TransientUserBlockTags rather than a list of its own: when the two
+// disagreed, a block the host had started injecting was treated as user prose
+// and stopped the walk early, so an already-present target went undetected and
+// was injected a second time.
 func hasLeadingInjectedBlock(content, target string) bool {
 	s := strings.TrimLeft(content, " \t\r\n")
 	for {
-		switch {
-		case strings.HasPrefix(s, "<"+target+">"):
+		if hasOpenTag(s, target) {
 			return strings.Contains(s, "</"+target+">")
-		case target != "response-language" && strings.HasPrefix(s, "<response-language>"):
-			var ok bool
-			s, ok = trimLeadingTransientBlock(s, "response-language")
+		}
+		skipped := false
+		for _, tag := range TransientUserBlockTags {
+			if tag == target || !hasOpenTag(s, tag) {
+				continue
+			}
+			rest, ok := trimLeadingTransientBlock(s, tag)
 			if !ok {
 				return false
 			}
-		case target != "reasoning-language" && strings.HasPrefix(s, "<reasoning-language>"):
-			var ok bool
-			s, ok = trimLeadingTransientBlock(s, "reasoning-language")
-			if !ok {
-				return false
-			}
-		case strings.HasPrefix(s, "<memory-update>"):
-			var ok bool
-			s, ok = trimLeadingTransientBlock(s, "memory-update")
-			if !ok {
-				return false
-			}
-		case strings.HasPrefix(s, "<background-jobs>"):
-			var ok bool
-			s, ok = trimLeadingTransientBlock(s, "background-jobs")
-			if !ok {
-				return false
-			}
-		case strings.HasPrefix(s, "<hook-context"):
-			var ok bool
-			s, ok = trimLeadingTransientBlock(s, "hook-context")
-			if !ok {
-				return false
-			}
-		default:
+			s, skipped = rest, true
+			break
+		}
+		if !skipped {
 			return false
 		}
 	}
+}
+
+// hasOpenTag reports whether s opens with tag, with or without attributes
+// (hook-context and capability-route carry them).
+func hasOpenTag(s, tag string) bool {
+	return strings.HasPrefix(s, "<"+tag+">") || strings.HasPrefix(s, "<"+tag+" ")
 }
 
 func trimLeadingTransientBlock(content, tag string) (string, bool) {

--- a/internal/agent/transient_tags_test.go
+++ b/internal/agent/transient_tags_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every tag the host prepends must strip cleanly, whatever else precedes it.
+// A tag missing from TransientUserBlockTags used to reach the UI verbatim —
+// <autoresearch-runtime> showed up in session titles and the rewind picker.
+func TestStripTransientUserBlocksCoversEveryDeclaredTag(t *testing.T) {
+	const prompt = "refactor the parser"
+	for _, tag := range TransientUserBlockTags {
+		t.Run(tag, func(t *testing.T) {
+			block := "<" + tag + ">\nruntime detail\n</" + tag + ">\n\n"
+			if got := StripTransientUserBlocks(block + prompt); got != prompt {
+				t.Fatalf("StripTransientUserBlocks(%q) = %q, want %q", block+prompt, got, prompt)
+			}
+			if got := UserPreviewText(block + prompt); !strings.HasPrefix(got, prompt) {
+				t.Fatalf("UserPreviewText leaked markup: %q", got)
+			}
+		})
+	}
+}
+
+// The blocks arrive stacked (active-goal then autoresearch-runtime then the
+// language blocks), so stripping has to consume the whole run, not just the
+// first one.
+func TestStripTransientUserBlocksConsumesStackedBlocks(t *testing.T) {
+	const prompt = "继续执行计划"
+	stacked := "<active-goal>\ngoal: ship it\n</active-goal>\n\n" +
+		"<autoresearch-runtime>\nstatus: running\n</autoresearch-runtime>\n\n" +
+		"<response-language>\nprefer zh\n</response-language>\n\n" +
+		prompt
+	if got := StripTransientUserBlocks(stacked); got != prompt {
+		t.Fatalf("StripTransientUserBlocks = %q, want %q", got, prompt)
+	}
+}
+
+// Attribute-carrying open tags (hook-context, capability-route) must strip too.
+func TestStripTransientUserBlocksHandlesAttributedTags(t *testing.T) {
+	const prompt = "run the tests"
+	in := `<capability-route version="1">` + "\nroute: test\n</capability-route>\n\n" + prompt
+	if got := StripTransientUserBlocks(in); got != prompt {
+		t.Fatalf("StripTransientUserBlocks = %q, want %q", got, prompt)
+	}
+}
+
+// hasLeadingInjectedBlock walks the same list, so a block already present
+// behind other injected blocks is detected instead of being added twice.
+func TestHasLeadingInjectedBlockSkipsEveryDeclaredTag(t *testing.T) {
+	const target = "reasoning-language"
+	for _, tag := range TransientUserBlockTags {
+		if tag == target {
+			continue
+		}
+		t.Run(tag, func(t *testing.T) {
+			content := "<" + tag + ">\nx\n</" + tag + ">\n\n" +
+				"<" + target + ">\nprefer zh\n</" + target + ">\n\nhello"
+			if !hasLeadingInjectedBlock(content, target) {
+				t.Fatalf("hasLeadingInjectedBlock(%q) = false, want the existing %s block detected", content, target)
+			}
+		})
+	}
+}
+
+func TestHasLeadingInjectedBlockIgnoresUserProse(t *testing.T) {
+	if hasLeadingInjectedBlock("what does <response-language> mean?", "response-language") {
+		t.Fatal("prose mentioning a tag must not count as an injected block")
+	}
+	if hasLeadingInjectedBlock("<active-goal>\ng\n</active-goal>\n\nplain text", "reasoning-language") {
+		t.Fatal("walking past other blocks must not invent a target block")
+	}
+}


### PR DESCRIPTION
## Summary

The set of blocks the host prepends to a user turn was spelled out three times: twice inside the strip regex (opening alternation, closing alternation) and again as a switch in `hasLeadingInjectedBlock`. The copies had already diverged — `<autoresearch-runtime>` was in none of them, and the switch was also missing `active-goal`, `capability-route`, and `interrupted-turn-recovery`.

Two user-visible consequences:

1. **Markup leaked into the UI.** A tag absent from the regex was never stripped, so it survived into previews, session titles, and the rewind picker — the `<autoresearch-runtime>` report in #6534.
2. **Blocks were injected twice.** `hasLeadingInjectedBlock` stopped walking at the first block it did not recognize, so an already-present `response-language`/`reasoning-language` block sitting behind e.g. an `active-goal` block went undetected and a second copy was prepended. (This is the mechanism behind the double-injection reports in #6090/#6267; those describe wider handoff behavior, so leaving them open pending a check against this fix.)

`TransientUserBlockTags` is now the single source: the regex is generated from it and the walk iterates it. Attribute-carrying open tags (`hook-context`, `capability-route`) go through one shared helper instead of ad-hoc prefix checks that had to remember the `<tag ` form.

## Verification

- New tests iterate `TransientUserBlockTags` rather than restating it, so a tag added later is covered without editing them: every declared tag strips cleanly from previews, stacked runs are consumed whole, attributed tags strip, and every tag is walked past when detecting an existing block.
- Negative cases pinned: prose mentioning a tag is not treated as an injected block, and walking past other blocks does not invent a target block.
- `LANG=en_US.UTF-8 go test ./...` green on the full root module; `gofmt`/`go vet` clean.

Cache-impact: none. This changes how persisted user text is *displayed* and whether a duplicate block is prepended; the block contents and their order in the prompt are unchanged, so the cached prefix is unaffected. Removing a duplicated block can only shorten a turn that was previously wrong.

Cache-guard: existing `internal/agent` and `internal/control` suites pass unchanged, including the reasoning-language injection tests that pin when a block is and is not added.

System-prompt-review: esengine session review 2026-08-03 — the system prompt is not touched; these blocks ride in user turns precisely to stay out of it.

Fixes #6534.