### PR TITLE
fix(rewind): show the typed prompt, not the composed turn

### DIFF
--- a/internal/control/checkpoint_prompt_test.go
+++ b/internal/control/checkpoint_prompt_test.go
@@ -1,0 +1,50 @@
+package control
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+// A checkpoint opens with the composed turn, so its stored prompt carries the
+// plan-mode marker and transient blocks. Every consumer treats Prompt as a
+// label — and the rewind picker restores it into the composer — so Checkpoints
+// must hand back what the user typed. Leaving it composed put
+// "必须使用简体中文…" in the rewind list (#6903).
+func TestCheckpointsReturnUserPromptWithoutComposedPrefixes(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &recordingSessionRunner{session: sess}
+	c := New(Options{
+		Runner:      runner,
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: filepath.Join(dir, "session.jsonl"),
+		Label:       "test",
+	})
+
+	const typed = "修复登录逻辑"
+	composed := agent.ReasoningLanguageBlock("zh") + "\n\n" +
+		PlanModeMarker + "\n\n" +
+		typed
+	o := newTurnOrchestrator(c)
+	if err := o.runTurnWithRawDisplay(context.Background(), composed, typed, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	cps := c.Checkpoints()
+	if len(cps) != 1 {
+		t.Fatalf("checkpoints = %+v, want one", cps)
+	}
+	if cps[0].Prompt != typed {
+		t.Fatalf("checkpoint prompt = %q, want %q", cps[0].Prompt, typed)
+	}
+	if strings.Contains(cps[0].Prompt, "<reasoning-language>") || strings.Contains(cps[0].Prompt, PlanModeMarker) {
+		t.Fatalf("checkpoint prompt still carries composed prefixes: %q", cps[0].Prompt)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2901,8 +2901,20 @@ const (
 )
 
 // Checkpoints lists the session's rewind points (one per user turn), oldest first.
+//
+// Each Meta.Prompt is reduced to what the user typed. A checkpoint opens with
+// the composed turn, so the stored prompt can carry the plan-mode marker and
+// transient blocks; every consumer of this list is a label (the rewind picker,
+// the desktop change list, the workbench projection) and the picker also
+// restores the prompt into the composer, so composed text must not reach them.
+// Stripping on read rather than only on write keeps checkpoints already on disk
+// readable — they were recorded composed.
 func (c *Controller) Checkpoints() []checkpoint.Meta {
-	return c.checkpoints.list()
+	metas := c.checkpoints.list()
+	for i := range metas {
+		metas[i].Prompt = StripComposePrefixes(metas[i].Prompt)
+	}
+	return metas
 }
 
 func (c *Controller) CheckpointFileState(path string) (checkpoint.FileState, bool) {


### PR DESCRIPTION
## Summary

A checkpoint opens with the *composed* turn, so `checkpoint.Meta.Prompt` carries whatever the controller prepended — the plan-mode marker and the transient blocks. Nothing stripped that back out on the way to a consumer, and every consumer treats `Prompt` as a human label:

- the TUI rewind picker (list rows and the restore header),
- the desktop workspace change list (`LatestPrompt`),
- the workbench projection.

The rewind picker also **restores the prompt into the composer**, so selecting an entry pasted controller markup into the user's input.

What users saw (#6903): a rewind list whose entries all read `必须使用简体中文…` — the first line of the reasoning-language block, repeated for every turn, with the actual prompts pushed out of the visible width.

`Checkpoints()` now reduces each `Prompt` through `StripComposePrefixes` — the helper that already exists for exactly this and knows about both the plan-mode marker and the transient blocks. Doing it on read rather than only on write also fixes sessions whose checkpoints are already on disk, since those were recorded composed.

## Why here

`Controller.Checkpoints()` is the single accessor every consumer goes through (it is the method on the `port.go` interface), so one reduction covers the TUI, the desktop app, and the remote workbench. `store.List()` builds fresh `Meta` values per call, so rewriting the field in place does not mutate stored state.

## Verification

- New `TestCheckpointsReturnUserPromptWithoutComposedPrefixes`: runs a turn whose composed input carries a reasoning-language block and the plan-mode marker, asserts the checkpoint hands back only the typed text.
- `LANG=en_US.UTF-8 go test ./internal/control/ ./internal/cli/` green, including the existing checkpoint/rewind coverage that pins turn boundaries.

Cache-impact: none. `Meta.Prompt` is a display label; nothing about the prompt sent to the model changes.

Cache-guard: existing `internal/control` turn-orchestrator and rewind tests pass unchanged, including the boundary assertions around `Rewind`.

System-prompt-review: esengine session review 2026-08-03 — no system-prompt text is touched.

Fixes #6903.