### PR TITLE
docs: recognize source PR contributor / 记录来源 PR 贡献者

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,14 @@
+# Repository Contributors
+
+Reasonix recognizes contributions from merged commits and from source pull
+requests that materially inform a maintainer integration, even when the source
+implementation is not merged verbatim. GitHub-recognized co-contributor credit
+is recorded with public `Co-authored-by` commit trailers; this file preserves
+the contribution and integration outcome in human-readable form.
+
+| Source pull request | Contributor | Recognized contribution | Integration outcome |
+| --- | --- | --- | --- |
+| [#7254](https://github.com/esengine/DeepSeek-Reasonix/pull/7254) | [@orz0219](https://github.com/orz0219) | Identified and covered DeepSeek V4 Flash tool-call responses that can report zero reasoning tokens while omitting replayable `reasoning_content`, exposing a misleading user warning. | [#7259](https://github.com/esengine/DeepSeek-Reasonix/pull/7259) used the reported behavior and test direction to define a bounded silent-recovery path. It did not adopt the proposed zero-token exemption because the wire format cannot always distinguish an explicit zero from an omitted field. Commit [`2a2d0e6`](https://github.com/esengine/DeepSeek-Reasonix/commit/2a2d0e674a1fb2f663276a739ae9a071d2296e09) records the contributor with a public co-author trailer. |
+
+The complete automatically generated commit-contributor graph remains available
+on [GitHub](https://github.com/esengine/DeepSeek-Reasonix/graphs/contributors?all=1).

--- a/CONTRIBUTORS.zh-CN.md
+++ b/CONTRIBUTORS.zh-CN.md
@@ -1,0 +1,11 @@
+# 仓库贡献者
+
+Reasonix 不仅认可已合入 commit 的贡献，也认可那些虽然未原样合入、但对维护者集成方案产生实质影响的来源 PR。GitHub 可识别的共同贡献者归属通过公开的
+`Co-authored-by` commit trailer 记录；本文档则长期保留具体贡献及其集成结果。
+
+| 来源 PR | 贡献者 | 获认可的贡献 | 集成结果 |
+| --- | --- | --- | --- |
+| [#7254](https://github.com/esengine/DeepSeek-Reasonix/pull/7254) | [@orz0219](https://github.com/orz0219) | 发现并覆盖了 DeepSeek V4 Flash 工具调用可能在缺少可回放 `reasoning_content` 的同时报告零推理 token 的行为；该行为会触发误导用户的告警。 | [#7259](https://github.com/esengine/DeepSeek-Reasonix/pull/7259) 根据这一现象和测试方向设计了有界的静默恢复路径。由于 wire 格式不能始终区分“明确返回零”和“字段缺失”，集成方案没有采用“零 token 即豁免”的判定。Commit [`2a2d0e6`](https://github.com/esengine/DeepSeek-Reasonix/commit/2a2d0e674a1fb2f663276a739ae9a071d2296e09) 已通过公开 co-author trailer 记录该贡献者。 |
+
+完整的自动生成 commit 贡献者图仍可在
+[GitHub](https://github.com/esengine/DeepSeek-Reasonix/graphs/contributors?all=1) 查看。


### PR DESCRIPTION
## Summary

- Add matching English and Chinese repository contributor records for source PR contributions that materially inform maintainer integrations.
- Recognize @orz0219 and #7254 for identifying and covering the real DeepSeek V4 Flash zero-reasoning-token, missing-`reasoning_content` response shape.
- Record the accurate integration outcome: #7259 used that evidence and test direction to design bounded silent recovery, while not adopting the zero-token exemption because an omitted wire field can normalize to the same zero value.
- Link the existing GitHub-recognized co-author commit, `2a2d0e6`.

## Attribution

- Source PR: #7254 by @orz0219
- Follow-up integration: #7259
- Repository co-contributor record: commit `2a2d0e674a1fb2f663276a739ae9a071d2296e09` and this commit both use the public GitHub noreply `Co-authored-by` identity.

## Overlap

#7263 refreshes the generated top-20 acknowledgments tables. This PR does not edit those generated sections and can merge independently.

## Compatibility

| Surface | Existing behavior | Conclusion |
| --- | --- | --- |
| Runtime and provider requests | Documentation-only; no code or request bytes change. | Safe |
| Persisted data | No schema or file-format changes. | Safe |
| Existing acknowledgments automation | Generated README markers are untouched. | Safe |

## Verification

- `git diff --check`
- Verified every public GitHub link in both documents returns HTTP 200.

## Cache impact

Cache-impact: none - documentation-only contributor attribution; no prompt, tool schema, provider request, or session bytes change.
Cache-guard: N/A - no runtime or provider-visible files changed.
System-prompt-review: N/A