### PR TITLE
test(cli): preserve bare -c routing regression / 保留裸 -c 路由回归覆盖

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -368,6 +368,7 @@ func TestRunRoutesBareInteractiveFlagsToSession(t *testing.T) {
 	for _, args := range [][]string{
 		{"--continue"},
 		{"--continue=true"},
+		{"-c"},
 		{"-c=true"},
 		{"--resume=true"},
 		{"-r=true"},


### PR DESCRIPTION
## Summary

- Add the bare `-c` form to the top-level interactive-routing regression matrix.
- Preserve the remaining incremental test coverage proposed in #7308 after the underlying shorthand fix landed through #7223.

## Contribution

This follow-up adopts the bare `reasonix -c` routing regression case from @skyzhao1223's #7308. The commit includes a valid `Co-authored-by` trailer using the contributor's public GitHub noreply identity, so the adopted work is recorded at commit level rather than only acknowledged in this PR body.

## Verification

- `go test ./internal/cli -run TestRunRoutesBareInteractiveFlagsToSession -count=1`
- `go test ./internal/cli -count=1`
- `git diff --check`

## Cache impact

Cache-impact: none — test-only change; no provider-visible prompt, tool schema, request serialization, memory prefix, or runtime behavior changes.

Refs #7308
