### PR TITLE
Fix resilient Serve session titles / 修复 Serve 会话标题生成与缓存

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -178,6 +178,17 @@ func UserPreviewText(content string) string {
 	return strings.TrimSpace(s)
 }
 
+// pasteDisplayLabelPattern matches the standalone label desktop prepends to a
+// pasted-text turn. It is UI chrome rather than user intent, so title and
+// preview derivation may remove it without touching inline label mentions.
+var pasteDisplayLabelPattern = regexp.MustCompile(`^\[(?:已粘贴文本|已貼上文字|Pasted text) #[0-9]+ · [0-9]+ (?:行|lines)\][ \t]*(?:\r?\n)?`)
+
+// StripPasteDisplayLabel removes one leading desktop pasted-text label while
+// preserving the remainder byte-for-byte.
+func StripPasteDisplayLabel(content string) string {
+	return pasteDisplayLabelPattern.ReplaceAllString(content, "")
+}
+
 // UserMessageText returns the best user-authored view of a persisted user turn.
 // New sessions carry the exact raw text explicitly; older sessions fall back to
 // deterministic wrapper stripping.
@@ -241,6 +252,7 @@ func hasLegacyProviderWrapper(content string) bool {
 // sites in internal/agent/agent.go, internal/agent/compact.go, and
 // internal/control (plan approval, goal loop).
 var SyntheticUserPrefixes = []string{
+	"<reasoning-language>",
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
 	"You are already in the executor phase",
@@ -274,6 +286,9 @@ func IsSyntheticUserText(content string) bool {
 // steer. Preview/title/turn-count derivations share this so a delivery
 // readiness nudge can never become a session title or inflate turn counts.
 func IsUserAuthoredTurn(content string) bool {
+	if strings.TrimSpace(StripTransientUserBlocks(content)) == "" {
+		return false
+	}
 	if IsSyntheticUserText(content) {
 		return false
 	}

--- a/internal/agent/title_test.go
+++ b/internal/agent/title_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import "testing"
+
+func TestReasoningLanguageDirectiveIsNotUserAuthored(t *testing.T) {
+	for _, injected := range []string{
+		"<reasoning-language>\nUse Simplified Chinese",
+		"<reasoning-language>\nUse Simplified Chinese\n</reasoning-language>",
+	} {
+		if IsUserAuthoredTurn(injected) {
+			t.Fatalf("reasoning-language directive %q must not count as user-authored", injected)
+		}
+	}
+}
+
+func TestStripPasteDisplayLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "simplified Chinese", in: "[已粘贴文本 #1 · 100 行]\npackage main", want: "package main"},
+		{name: "traditional Chinese", in: "[已貼上文字 #2 · 5 行]\r\n帮我看看这段代码", want: "帮我看看这段代码"},
+		{name: "English", in: "[Pasted text #3 · 42 lines]\nfunc foo() {}", want: "func foo() {}"},
+		{name: "inline mention", in: "Explain [Pasted text #1 · 2 lines] handling", want: "Explain [Pasted text #1 · 2 lines] handling"},
+		{name: "later standalone line", in: "Keep this\n[Pasted text #1 · 2 lines]\nverbatim", want: "Keep this\n[Pasted text #1 · 2 lines]\nverbatim"},
+		{name: "no label", in: "debug the login issue", want: "debug the login issue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPasteDisplayLabel(tt.in); got != tt.want {
+				t.Fatalf("StripPasteDisplayLabel(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -158,13 +158,7 @@ func (s *Server) initTitleProvider() {
 	if !ok {
 		return
 	}
-	prov, err := provider.New(entry.Kind, provider.Config{
-		Name:    entry.Name,
-		BaseURL: entry.BaseURL,
-		Model:   entry.Model,
-		APIKey:  entry.APIKey(),
-		Extra:   map[string]any{"effort": "off"},
-	})
+	prov, err := provider.New(entry.Kind, titleProviderConfig(entry))
 	if err != nil {
 		return
 	}
@@ -174,6 +168,18 @@ func (s *Server) initTitleProvider() {
 	// Title generation is accounting-only; do not inject its usage event into
 	// the shared chat SSE stream.
 	s.titleUsageSink = stats.NewRecorder(event.Discard, config.StatsDir(), "serve")
+}
+
+func titleProviderConfig(entry *config.ProviderEntry) provider.Config {
+	return provider.Config{
+		Name:    entry.Name,
+		BaseURL: entry.BaseURL,
+		Model:   entry.Model,
+		APIKey:  entry.APIKey(),
+		// Title generation needs a short visible answer, not chain-of-thought.
+		// "off" is a retired DeepSeek effort value and now falls back to high.
+		Extra: map[string]any{"effort": "disabled"},
+	}
 }
 
 // switchModel rebuilds the controller with a new model, carrying over the
@@ -1198,12 +1204,28 @@ func (s *Server) status(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, sess)
 }
 
-const titlePrompt = `Generate a very short title (3-5 words max) for this conversation based on the user's first message. Use the same language as the user's message. Reply with ONLY the title, no quotes, no punctuation at the end.`
+const titlePrompt = `Generate a very short title (3-7 words max) for this conversation based on the user's message. Use the same language as the user's message. The title should be clear enough that the user recognizes the session in a list. Reply with ONLY the title, no quotes, no punctuation at the end.
+
+Good examples:
+Help me debug the login loop
+添加 OAuth 登录
+重构 API 客户端错误处理
+Debug failing CI tests
+
+Bad (too vague): 代码修改
+Bad (too long): 帮我看看为什么登录按钮在移动端不响应并修复这个问题
+
+The user's message below may start with UI labels or injected directives — ignore those and title based on the real intent.`
+
+func titleSource(first string) string {
+	return strings.TrimSpace(agent.StripPasteDisplayLabel(first))
+}
 
 // generateTitle calls a lightweight LLM to produce a short session title.
 // Returns empty string on any error — callers should fall back to a preview.
 func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
-	if nilutil.IsNil(s.titleProv) || strings.TrimSpace(firstMsg) == "" {
+	firstMsg = titleSource(firstMsg)
+	if nilutil.IsNil(s.titleProv) || firstMsg == "" {
 		return ""
 	}
 	if r := []rune(firstMsg); len(r) > 300 {
@@ -1223,7 +1245,7 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 			{Role: provider.RoleUser, Content: firstMsg},
 		},
 		Temperature: provider.TemperaturePtr(0),
-		MaxTokens:   20,
+		MaxTokens:   60,
 	})
 	if err != nil {
 		return ""
@@ -1403,20 +1425,23 @@ func removeSessionFiles(absDir, abs string) error {
 }
 
 // sessionTitle returns a title for a session: the cached flash-generated title
-// when it matches the file's mtime, otherwise a freshly generated one (cached
-// for next time), falling back to a truncated preview when generation is off.
+// when its first user message is unchanged, otherwise a freshly generated one
+// (cached for next time), falling back to a truncated preview when generation
+// is off.
 func (s *Server) sessionTitle(ctx context.Context, name, first string, mod int64) string {
-	if cached, ok := s.titles.get(name, mod); ok {
+	source := titleSource(first)
+	if cached, ok := s.titles.get(name, source, mod); ok {
 		return cached
 	}
-	if title := s.generateTitle(ctx, first); title != "" {
-		s.titles.put(name, title, mod)
+	if title := s.generateTitle(ctx, source); title != "" {
+		s.titles.put(name, title, source, mod)
 		return title
 	}
-	return previewTitle(first)
+	return previewTitle(source)
 }
 
 func previewTitle(first string) string {
+	first = titleSource(first)
 	if r := []rune(first); len(r) > 50 {
 		return string(r[:47]) + "..."
 	}

--- a/internal/serve/title_test.go
+++ b/internal/serve/title_test.go
@@ -1,0 +1,97 @@
+package serve
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/provider"
+)
+
+type recordingTitleProvider struct {
+	requests []provider.Request
+}
+
+func (p *recordingTitleProvider) Name() string { return "recording-title" }
+
+func (p *recordingTitleProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.requests = append(p.requests, req)
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: req.Messages[len(req.Messages)-1].Content}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestTitleProviderDisablesReasoning(t *testing.T) {
+	cfg := titleProviderConfig(&config.ProviderEntry{
+		Name:    "deepseek-flash",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v4-flash",
+	})
+	if got := cfg.Extra["effort"]; got != "disabled" {
+		t.Fatalf("title provider effort = %v, want disabled", got)
+	}
+}
+
+func TestGenerateTitleStripsPasteLabelAndUsesShortBudget(t *testing.T) {
+	prov := &recordingTitleProvider{}
+	s := &Server{titleProv: prov}
+	got := s.generateTitle(context.Background(), "[已粘贴文本 #1 · 20 行]\nfix the login loop")
+	if got != "fix the login loop" {
+		t.Fatalf("title = %q, want pasted label removed", got)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(prov.requests))
+	}
+	req := prov.requests[0]
+	if req.MaxTokens != 60 {
+		t.Fatalf("MaxTokens = %d, want 60", req.MaxTokens)
+	}
+	if req.Messages[0].Content != titlePrompt || req.Messages[1].Content != "fix the login loop" {
+		t.Fatalf("title messages = %+v", req.Messages)
+	}
+}
+
+func TestSessionTitleCachesByFirstMessageAcrossMtimeChanges(t *testing.T) {
+	dir := t.TempDir()
+	prov := &recordingTitleProvider{}
+	s := &Server{titleProv: prov, titles: newTitleCache(dir)}
+
+	if got := s.sessionTitle(context.Background(), "a.jsonl", "first prompt", 100); got != "first prompt" {
+		t.Fatalf("first title = %q", got)
+	}
+	if got := s.sessionTitle(context.Background(), "a.jsonl", "first prompt", 200); got != "first prompt" {
+		t.Fatalf("title after append = %q", got)
+	}
+	if len(prov.requests) != 1 {
+		t.Fatalf("requests after mtime-only change = %d, want 1", len(prov.requests))
+	}
+
+	if got := s.sessionTitle(context.Background(), "a.jsonl", "replacement prompt", 300); got != "replacement prompt" {
+		t.Fatalf("title after replacing first turn = %q", got)
+	}
+	if len(prov.requests) != 2 {
+		t.Fatalf("requests after replacing first turn = %d, want 2", len(prov.requests))
+	}
+
+	freshProv := &recordingTitleProvider{}
+	fresh := &Server{titleProv: freshProv, titles: newTitleCache(dir)}
+	if got := fresh.sessionTitle(context.Background(), "a.jsonl", "replacement prompt", 400); got != "replacement prompt" {
+		t.Fatalf("persisted title = %q", got)
+	}
+	if len(freshProv.requests) != 0 {
+		t.Fatalf("fresh server regenerated persisted title %d time(s)", len(freshProv.requests))
+	}
+}
+
+func TestPreviewTitleStripsOnlyLeadingPasteLabel(t *testing.T) {
+	if got := previewTitle("[Pasted text #2 · 42 lines]\nfunc foo() { return 1 }"); got != "func foo() { return 1 }" {
+		t.Fatalf("previewTitle = %q", got)
+	}
+	const inline = "Explain [Pasted text #2 · 42 lines] handling"
+	if got := previewTitle(inline); got != inline {
+		t.Fatalf("inline label changed to %q", got)
+	}
+}

--- a/internal/serve/titlecache.go
+++ b/internal/serve/titlecache.go
@@ -1,6 +1,8 @@
 package serve
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,10 +11,11 @@ import (
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
 
-// titleCache persists generated session titles to <dir>/.session-titles.json,
-// keyed by file name and invalidated by mtime, so the flash model is queried
-// once per session rather than on every sidebar refresh. Persistence is
-// best-effort: a missing or unreadable cache just regenerates.
+// titleCache persists generated session titles to <dir>/.session-titles.json.
+// Entries are keyed by file name and the first user message: appending turns
+// changes the transcript mtime without invalidating the title, while replacing
+// the first turn (for example by rewinding turn zero) produces a cache miss.
+// Persistence is best-effort: a missing or unreadable cache just regenerates.
 type titleCache struct {
 	mu      sync.Mutex
 	dir     string
@@ -21,8 +24,9 @@ type titleCache struct {
 }
 
 type titleEntry struct {
-	Title string `json:"title"`
-	Mod   int64  `json:"mod"`
+	Title      string `json:"title"`
+	Mod        int64  `json:"mod"`
+	SourceHash string `json:"source_hash,omitempty"`
 }
 
 func newTitleCache(dir string) *titleCache {
@@ -39,21 +43,39 @@ func (c *titleCache) load() {
 	}
 }
 
-func (c *titleCache) get(name string, mod int64) (string, bool) {
+func titleSourceHash(source string) string {
+	sum := sha256.Sum256([]byte(source))
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *titleCache) get(name, source string, mod int64) (string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.load()
-	if e, ok := c.entries[name]; ok && e.Mod == mod {
+	e, ok := c.entries[name]
+	if !ok {
+		return "", false
+	}
+	if e.SourceHash == "" {
+		// Legacy entries used only mtime. Accept a still-current entry without
+		// rewriting the cache; the next transcript append regenerates once and
+		// upgrades it to source_hash automatically.
+		if e.Mod == mod {
+			return e.Title, true
+		}
+		return "", false
+	}
+	if e.SourceHash == titleSourceHash(source) {
 		return e.Title, true
 	}
 	return "", false
 }
 
-func (c *titleCache) put(name, title string, mod int64) {
+func (c *titleCache) put(name, title, source string, mod int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.load()
-	c.entries[name] = titleEntry{Title: title, Mod: mod}
+	c.entries[name] = titleEntry{Title: title, Mod: mod, SourceHash: titleSourceHash(source)}
 	if data, err := json.Marshal(c.entries); err == nil {
 		_ = os.WriteFile(filepath.Join(c.dir, ".session-titles.json"), data, 0o644)
 	}

--- a/internal/serve/titlecache_test.go
+++ b/internal/serve/titlecache_test.go
@@ -1,36 +1,78 @@
 package serve
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestTitleCacheReusesUntilMtimeChanges(t *testing.T) {
+func TestTitleCacheKeepsTitleAcrossMtimeChanges(t *testing.T) {
 	dir := t.TempDir()
 	c := newTitleCache(dir)
 
-	if _, ok := c.get("a.jsonl", 100); ok {
+	if _, ok := c.get("a.jsonl", "first prompt", 100); ok {
 		t.Fatal("empty cache should miss")
 	}
 
-	c.put("a.jsonl", "First Title", 100)
-	if got, ok := c.get("a.jsonl", 100); !ok || got != "First Title" {
-		t.Fatalf("hit on matching mtime = %q,%v, want First Title,true", got, ok)
+	c.put("a.jsonl", "First Title", "first prompt", 100)
+	if got, ok := c.get("a.jsonl", "first prompt", 200); !ok || got != "First Title" {
+		t.Fatalf("hit after mtime change = %q,%v, want First Title,true", got, ok)
 	}
-	if _, ok := c.get("a.jsonl", 200); ok {
-		t.Fatal("changed mtime should invalidate the cached title")
+}
+
+func TestTitleCacheInvalidatesWhenFirstMessageChanges(t *testing.T) {
+	dir := t.TempDir()
+	c := newTitleCache(dir)
+	c.put("a.jsonl", "First Title", "first prompt", 100)
+
+	if _, ok := c.get("a.jsonl", "replacement prompt", 100); ok {
+		t.Fatal("a replaced first message must invalidate the cached title")
 	}
 }
 
 func TestTitleCachePersistsAcrossInstances(t *testing.T) {
 	dir := t.TempDir()
-	newTitleCache(dir).put("a.jsonl", "Persisted", 7)
+	newTitleCache(dir).put("a.jsonl", "Persisted", "first prompt", 7)
 
 	if _, err := os.Stat(filepath.Join(dir, ".session-titles.json")); err != nil {
 		t.Fatalf("cache file not written: %v", err)
 	}
-	if got, ok := newTitleCache(dir).get("a.jsonl", 7); !ok || got != "Persisted" {
+	if got, ok := newTitleCache(dir).get("a.jsonl", "first prompt", 8); !ok || got != "Persisted" {
 		t.Fatalf("fresh instance get = %q,%v, want Persisted,true", got, ok)
+	}
+}
+
+func TestTitleCacheReadsLegacyMtimeEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".session-titles.json")
+	if err := os.WriteFile(path, []byte(`{"a.jsonl":{"title":"Legacy","mod":7}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := newTitleCache(dir).get("a.jsonl", "first prompt", 7); !ok || got != "Legacy" {
+		t.Fatalf("matching legacy entry = %q,%v, want Legacy,true", got, ok)
+	}
+	if _, ok := newTitleCache(dir).get("a.jsonl", "first prompt", 8); ok {
+		t.Fatal("legacy entry with changed mtime must regenerate once before becoming sticky")
+	}
+}
+
+func TestTitleCacheWritesRemainReadableByOlderVersions(t *testing.T) {
+	dir := t.TempDir()
+	newTitleCache(dir).put("a.jsonl", "Compatible", "first prompt", 7)
+	data, err := os.ReadFile(filepath.Join(dir, ".session-titles.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var legacy map[string]struct {
+		Title string `json:"title"`
+		Mod   int64  `json:"mod"`
+	}
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		t.Fatalf("legacy unmarshal: %v", err)
+	}
+	if got := legacy["a.jsonl"]; got.Title != "Compatible" || got.Mod != 7 {
+		t.Fatalf("legacy entry = %+v, want title and mod preserved", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Keep Serve session titles clean by removing leading pasted-text UI labels and excluding synthetic reasoning-language turns.
- Disable reasoning for the dedicated title provider and use a focused 60-token title request, so short titles do not need a large reasoning budget.
- Cache titles by session file plus a SHA-256 fingerprint of the normalized first user message. Ordinary transcript appends stay cached, while rewinding turn zero and replacing the first prompt invalidates the title correctly.

This integration PR supersedes #7264 and #7329 with one latest-`main-v2` implementation.

## Problem

Serve title generation had three related failure modes:

1. Pasted-text display labels and injected language directives could become the visible session title.
2. The title provider still used the retired `effort=off` value, which DeepSeek now maps to thinking-on; a 20-token request could spend its entire budget on reasoning and return no visible title.
3. The cache used transcript mtime as identity, so every append to an active session regenerated its title. Making the entry permanently sticky by file name would avoid that cost but return a stale title after a turn-zero rewind replaces the first prompt.

## Fix

- Strip only a leading standalone pasted-text label in Simplified Chinese, Traditional Chinese, or English. Inline and later label-shaped text remains untouched.
- Treat pure or incomplete `<reasoning-language>` directives as synthetic rather than user-authored turns.
- Configure the title provider with `effort=disabled`, improve the stable title prompt, and keep the output budget bounded at 60 tokens.
- Persist `source_hash`, a SHA-256 fingerprint of the normalized first prompt, alongside the existing title and mtime. Raw prompt text is not added to the cache file.
- Reuse a title across mtime-only changes, but regenerate when the first prompt changes or a session file name is reused for different content.

## Consolidation notes and contributor credit

### Kept and adapted

- #7264 by @Q1hangL contributed the pasted-label diagnosis and locale coverage, synthetic reasoning-language filtering, the clearer title prompt, and the 60-token bounded request. This PR narrows label removal to the leading UI label so later user-authored text is preserved.
- #7329 by @SprayHank contributed the DeepSeek reasoning-budget diagnosis and identified mtime churn as the cause of repeated title generation. This PR adapts those findings by disabling title reasoning and replacing mtime identity with a first-message fingerprint.

Both contributors are also recorded with public GitHub `Co-authored-by` trailers on the integration commit.

### Reviewed but not adopted as written

- #7329's 200-token title budget is not carried over: disabling reasoning fixes the root cause while the 60-token cap keeps cold-cache cost bounded.
- #7329's file-name-only sticky cache is not carried over because a turn-zero rewind can replace the first user message without changing the session path.
- #7264's multiline label replacement is narrowed to a single leading label so label-shaped content later in the prompt remains user-authored.

## Backward compatibility

| Field/change | Old-data and cross-version behavior | Conclusion |
| --- | --- | --- |
| Existing `title` and `mod` | Preserved unchanged in every new cache entry. | Safe for older readers. |
| New `source_hash,omitempty` | Missing legacy hashes use the old mtime check; a changed legacy entry regenerates once and upgrades automatically. | Safe upgrade path. |
| Older build reads a new entry | Unknown `source_hash` is ignored; the older build continues using `title` and `mod`. | Safe downgrade/coexistence. |
| Older build rewrites the cache | It may drop `source_hash`; a newer build falls back to the legacy mtime rule and may regenerate once. | No corruption or stale cross-content hit. |

## Related work

- #7345 now provides the transient user-block single source on `main-v2`. This PR is rebased on that merged implementation and adds only the title-specific incomplete-directive fallback and pasted-label handling.

## Cache, concurrency, and security impact

- Main-chat cache impact: none. The changed prompt belongs only to the separate title provider and does not alter the conversation system prompt, tool schemas, compaction, or provider serialization for chat turns.
- The title prompt is stable across requests; only the existing per-session user message varies.
- The title cache map and writes remain serialized by the existing mutex. A source hash prevents an older generation from becoming a valid hit for a newer first prompt.
- Concurrent cold misses can still duplicate best-effort title calls, as before, but cannot produce a wrong-source cache hit.
- No dependency, privilege, authentication, command-execution, or external data-flow changes are introduced. The cache stores a one-way fingerprint instead of raw first-prompt text.

## Verification

- `go test ./...`
- `go test ./internal/serve ./internal/agent`
- `go test -race ./internal/serve ./internal/agent`
- `go test ./internal/provider/openai -run 'TestBuildRequestDeepSeekDisabled|TestNewDeepSeekThinkingDefaultsAndValidation'`
- `go vet ./internal/serve ./internal/agent`
- `./scripts/cache-guard.sh`
- `git diff --check`
- Final-head verification includes merged #7345: `go test ./internal/agent ./internal/serve`

Refs #7264, #7329.
