### PR TITLE
fix(provider): let a declared effort vocabulary outrank the built-in one

### DIFF
--- a/internal/provider/openai/effort_declared_test.go
+++ b/internal/provider/openai/effort_declared_test.go
@@ -1,0 +1,68 @@
+package openai
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// A third-party endpoint can serve a DeepSeek model under its own effort scale.
+// Declaring supported_efforts is how the config says so, and our built-in
+// DeepSeek vocabulary must not override that declaration (#7273) — the same
+// rule the "low" level already followed.
+func TestDeepSeekThinkingHonorsDeclaredEffortVocabulary(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "proxy",
+		BaseURL: "https://proxy.example.com/v1",
+		Model:   "deepseek-v4-flash",
+		APIKey:  "test",
+		Extra: map[string]any{
+			"effort":             "medium",
+			"reasoning_protocol": "deepseek",
+			"supported_efforts":  []string{"low", "medium", "high", "none"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New with declared effort vocabulary: %v", err)
+	}
+	if got := p.(*client).buildRequest(provider.Request{}).ReasoningEffort; got != "medium" {
+		t.Fatalf("reasoning_effort = %q, want the declared level forwarded", got)
+	}
+}
+
+// Without a declaration there is nothing to defer to, so an unknown level is
+// still rejected rather than silently forwarded to the official endpoint.
+func TestDeepSeekThinkingRejectsUndeclaredEffort(t *testing.T) {
+	_, err := New(provider.Config{
+		Name:    "official",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v4-flash",
+		APIKey:  "test",
+		Extra: map[string]any{
+			"effort":             "medium",
+			"reasoning_protocol": "deepseek",
+		},
+	})
+	if err == nil {
+		t.Fatal("New with an undeclared effort level = nil error, want rejection")
+	}
+}
+
+// A declaration that does not list the requested level is still a rejection:
+// honoring the config means honoring what it actually says.
+func TestDeepSeekThinkingRejectsEffortOutsideDeclaration(t *testing.T) {
+	_, err := New(provider.Config{
+		Name:    "proxy",
+		BaseURL: "https://proxy.example.com/v1",
+		Model:   "deepseek-v4-flash",
+		APIKey:  "test",
+		Extra: map[string]any{
+			"effort":             "medium",
+			"reasoning_protocol": "deepseek",
+			"supported_efforts":  []string{"low", "high"},
+		},
+	})
+	if err == nil {
+		t.Fatal("New with an effort outside the declaration = nil error, want rejection")
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -138,7 +138,15 @@ func New(cfg provider.Config) (provider.Provider, error) {
 			}
 		case "high", "max":
 		default:
-			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be low, high, max, or disabled", name)
+			// A provider that declares supported_efforts is stating its own
+			// effort vocabulary, which is the whole point of the field on a
+			// third-party endpoint that merely serves a DeepSeek model under a
+			// different scale. Our built-in vocabulary must not override that
+			// declaration — the same reasoning already applies to "low" above.
+			if supportsEffort(supportedEfforts, effort) {
+				break
+			}
+			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be low, high, max, or disabled, or declared in supported_efforts", name)
 		}
 	case minimax:
 		// M3's knob is binary. The config effort layer normalises user input


### PR DESCRIPTION
## Summary

A third-party endpoint can serve a DeepSeek model under its own effort scale — #7273 reports one whose scale is `low/medium/high/none`. Declaring `supported_efforts` is how the config states that, and it is the only way to describe such an endpoint at all.

The DeepSeek thinking branch validated the selected level against our **built-in** vocabulary and rejected anything outside `low/high/max/disabled`, ignoring the declaration:

```
推理力度切换失败：openai: provider "商汤科技" uses DeepSeek thinking; effort must be low, high, max, or disabled
```

The deference already existed one case up: `low` is accepted on a non-flash model precisely when `supported_efforts` declares it (`explicitLowEffort`). This applies the same rule to the rest of the vocabulary rather than to one level.

## Scope

- A declaration only widens what that provider accepts; it never changes what an undeclared provider does.
- Undeclared levels are still rejected, so the official endpoint keeps its guardrail.
- A declaration that does **not** list the requested level is still a rejection — honoring the config means honoring what it actually says.
- The error message now points at the escape hatch instead of only restating the built-in list.

## Verification

- New tests cover all three paths: declared level forwarded, undeclared level rejected, level outside a declaration rejected.
- `LANG=en_US.UTF-8 go test ./internal/provider/... ./internal/config/` green; `gofmt` clean.

Cache-impact: none. `reasoning_effort` is a per-request field, not part of the cached prefix, and nothing changes for a provider that does not declare `supported_efforts`.

Cache-guard: the existing `internal/provider/openai` effort suite passes unchanged, including the DeepSeek thinking-type and low-effort cases that pin when a level is and is not forwarded.

System-prompt-review: esengine session review 2026-08-03 — no system-prompt text is touched.

Fixes #7273.