### PR TITLE
Keep bot recovery session ownership aligned / 保持 Bot 恢复会话所有权一致

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -55,15 +55,17 @@ type GatewayConfig struct {
 	//
 	// Reentrancy contract for all GatewayConfig callbacks (OnInbound,
 	// OnSessionReady, OnToolApprovalModeChange): they run synchronously on
-	// gateway-owned dispatch/turn goroutines that Stop drains before returning.
-	// A callback must therefore never call Stop, nor block until a goroutine
-	// that does so completes — Stop would wait on the very goroutine running
-	// the callback, a guaranteed deadlock. Hosts that want to shut the gateway
-	// down in reaction to a callback must trigger the shutdown asynchronously.
+	// gateway-owned dispatch/turn goroutines; OnSessionReady can also run on a
+	// controller recovery/autosave goroutine. Stop drains all of those paths
+	// before returning. A callback must therefore never call Stop, nor block
+	// until a goroutine that does so completes — Stop would wait on the very
+	// goroutine running the callback, a guaranteed deadlock. Hosts that want to
+	// shut the gateway down in reaction to a callback must trigger the shutdown
+	// asynchronously.
 	OnInbound func(InboundMessage)
-	// OnSessionReady notifies the host after the bot has created or reused the
-	// controller for an inbound remote. Hosts may persist the concrete session ID
-	// or keep the remote as a read-only channel.
+	// OnSessionReady notifies the host after the bot has created, reused, or
+	// recovered the controller for an inbound remote. Hosts may persist the
+	// concrete session ID or keep the remote as a read-only channel.
 	OnSessionReady func(InboundMessage, string) error
 	// OnToolApprovalModeChange persists a remote IM request such as /yolo on.
 	// The gateway updates the live session and in-memory defaults first; this
@@ -2195,25 +2197,44 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		gw.mu.Unlock()
 	}
 
-	// 创建新 Controller
+	// Create the lease owner before the controller so automatic conflict
+	// recovery can move ownership to the recovery branch before the controller
+	// commits to writing it. Without this callback the bot kept guarding the
+	// original path while continuing on an unleased recovery path.
 	sessionSink := &sessionEventSink{}
+	leases := control.NewSessionLeaseKeeper()
+	state := &sessionState{
+		sink:             sessionSink,
+		leases:           leases,
+		platform:         msg.Platform,
+		connectionID:     strings.TrimSpace(msg.ConnectionID),
+		model:            profile.model,
+		workspaceRoot:    profile.workspaceRoot,
+		toolApprovalMode: profile.toolApprovalMode,
+		sessionPath:      profile.sessionPath,
+		pendingAsks:      make(map[string][]event.AskQuestion),
+		createdAt:        time.Now(),
+		lastActive:       time.Now(),
+	}
 	gw.logger.Info("bot session creating", "platform", msg.Platform, "chat_type", msg.ChatType, "chat", hashID(msg.ChatID), "session", key[:8], "model", profile.model, "workspace_set", profile.workspaceRoot != "", "tool_approval_mode", profile.toolApprovalMode)
 	ctrl, err := boot.Build(ctx, boot.Options{
-		Model:           profile.model,
-		MaxSteps:        gw.cfg.MaxSteps,
-		MaxStepsKey:     "bot.max_steps",
-		RequireKey:      true,
-		Sink:            sessionSink,
-		StatsSource:     "bot",
-		WorkspaceRoot:   profile.workspaceRoot,
-		SessionDir:      botSessionDir(profile.workspaceRoot),
-		ApprovalTimeout: gw.approvalTimeout(),
+		Model:              profile.model,
+		MaxSteps:           gw.cfg.MaxSteps,
+		MaxStepsKey:        "bot.max_steps",
+		RequireKey:         true,
+		Sink:               sessionSink,
+		StatsSource:        "bot",
+		WorkspaceRoot:      profile.workspaceRoot,
+		SessionDir:         botSessionDir(profile.workspaceRoot),
+		ApprovalTimeout:    gw.approvalTimeout(),
+		OnSessionRecovered: gw.botSessionRecoveredHandler(key, msg, state),
 	})
 	if err != nil {
+		leases.Release()
 		gw.logger.Error("build controller failed", "err", secrets.RedactError(err))
 		return nil
 	}
-	leases := control.NewSessionLeaseKeeper()
+	state.ctrl = ctrl
 	if profile.sessionPath != "" {
 		if err := leases.Rebind(profile.sessionPath); err != nil {
 			ctrl.Close()
@@ -2261,20 +2282,6 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 		}
 		delete(gw.controllers, key)
 		replace = existing
-	}
-	state := &sessionState{
-		ctrl:             ctrl,
-		sink:             sessionSink,
-		leases:           leases,
-		platform:         msg.Platform,
-		connectionID:     strings.TrimSpace(msg.ConnectionID),
-		model:            profile.model,
-		workspaceRoot:    profile.workspaceRoot,
-		toolApprovalMode: profile.toolApprovalMode,
-		sessionPath:      profile.sessionPath,
-		pendingAsks:      make(map[string][]event.AskQuestion),
-		createdAt:        time.Now(),
-		lastActive:       time.Now(),
 	}
 	gw.controllers[key] = state
 	gw.mu.Unlock()
@@ -2400,12 +2407,57 @@ func (gw *BotGateway) rememberSessionReady(msg InboundMessage, ctrl botControlle
 	if gw.cfg.OnSessionReady == nil || ctrl == nil {
 		return
 	}
-	sessionID := botSessionTarget(ctrl.SessionPath())
+	gw.rememberSessionPath(msg, ctrl.SessionPath())
+}
+
+func (gw *BotGateway) rememberSessionPath(msg InboundMessage, sessionPath string) {
+	if gw.cfg.OnSessionReady == nil {
+		return
+	}
+	sessionID := botSessionTarget(sessionPath)
 	if sessionID == "" {
 		return
 	}
 	if err := gw.cfg.OnSessionReady(msg, sessionID); err != nil {
 		gw.logger.Warn("remember bot session failed", "platform", msg.Platform, "connection", msg.ConnectionID, "err", err)
+	}
+}
+
+// botSessionRecoveredHandler keeps the controller path, its writer lease, and
+// the remote-to-session mapping on the same recovery generation. The lease
+// handoff runs first and is failure-atomic: if the recovery path is already
+// owned, the controller stays on the original path and the old lease remains
+// held. Mapping updates are limited to this exact sessionState so a late
+// callback from a retired controller cannot overwrite its replacement.
+func (gw *BotGateway) botSessionRecoveredHandler(key string, msg InboundMessage, state *sessionState) func(control.SessionRecoveryInfo) error {
+	return func(info control.SessionRecoveryInfo) error {
+		if state == nil || state.leases == nil {
+			return nil
+		}
+		if err := state.leases.HandleSessionRecovered(info); err != nil {
+			return err
+		}
+
+		originalPath := canonicalBotPath(info.OriginalPath)
+		recoveryPath := canonicalBotPath(info.RecoveryPath)
+		live := false
+		gw.mu.Lock()
+		if gw.controllers[key] == state {
+			live = true
+			if canonicalBotPath(state.sessionPath) == originalPath {
+				state.sessionPath = recoveryPath
+			}
+			if override, ok := gw.sessionOverrides[key]; ok && canonicalBotPath(override.sessionPath) == originalPath {
+				override.sessionPath = recoveryPath
+				gw.sessionOverrides[key] = override
+			}
+		}
+		gw.mu.Unlock()
+
+		if live {
+			gw.rememberSessionPath(msg, recoveryPath)
+		}
+		return nil
 	}
 }
 

--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -203,6 +203,8 @@ type botController interface {
 }
 
 type sessionState struct {
+	lifecycleMu      sync.Mutex
+	retired          bool
 	ctrl             botController
 	sink             *sessionEventSink
 	leases           *control.SessionLeaseKeeper
@@ -220,6 +222,8 @@ type sessionState struct {
 	createdAt        time.Time
 	lastActive       time.Time
 }
+
+var errBotSessionRetired = errors.New("bot session retired during recovery")
 
 type sessionRuntimeProfile struct {
 	model            string
@@ -637,6 +641,19 @@ func (gw *BotGateway) closeSessionState(state *sessionState) {
 	if state == nil {
 		return
 	}
+	// Serialize retirement with recovery ownership handoffs. Stop unlinks
+	// sessions before turn goroutines drain, so a recovery callback captured by
+	// the controller can still arrive here. Marking the state retired under the
+	// same lock prevents that callback from reacquiring a lease after teardown;
+	// an already-running handoff completes before the lease is released below.
+	state.lifecycleMu.Lock()
+	if state.retired {
+		state.lifecycleMu.Unlock()
+		return
+	}
+	state.retired = true
+	state.lifecycleMu.Unlock()
+
 	gw.mu.Lock()
 	cancel := state.cancel
 	state.cancel = nil
@@ -2433,6 +2450,14 @@ func (gw *BotGateway) botSessionRecoveredHandler(key string, msg InboundMessage,
 	return func(info control.SessionRecoveryInfo) error {
 		if state == nil || state.leases == nil {
 			return nil
+		}
+		// Keep the lease handoff and mapping publication atomic with respect to
+		// state retirement. In particular, never let a callback that outlives
+		// Stop reacquire a lease after closeSessionState has released it.
+		state.lifecycleMu.Lock()
+		defer state.lifecycleMu.Unlock()
+		if state.retired {
+			return errBotSessionRetired
 		}
 		if err := state.leases.HandleSessionRecovered(info); err != nil {
 			return err

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -1071,6 +1071,45 @@ func TestGatewayLateRecoveryCannotReplaceCurrentSessionMapping(t *testing.T) {
 	}
 }
 
+func TestGatewayLateRecoveryAfterRetirementDoesNotReacquireLease(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "original.jsonl")
+	recoveryPath := filepath.Join(dir, "recovery.jsonl")
+	gw := NewGateway(GatewayConfig{}, nil, logger)
+	msg := InboundMessage{Platform: PlatformWeixin, ChatType: ChatDM, ChatID: "chat", UserID: "user"}
+	key := BuildSessionKey(msg.Session())
+	leases := control.NewSessionLeaseKeeper()
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("bind original session lease: %v", err)
+	}
+	state := &sessionState{leases: leases, sessionPath: originalPath}
+	gw.controllers[key] = state
+	handler := gw.botSessionRecoveredHandler(key, msg, state)
+
+	// Gateway shutdown retires and releases the state before waiting for every
+	// turn goroutine. A callback already captured by the controller must not
+	// reacquire a lease after that teardown.
+	gw.closeSessions()
+	if got := leases.HeldPath(); got != "" {
+		t.Fatalf("lease after retirement = %q, want empty", got)
+	}
+	if err := handler(control.SessionRecoveryInfo{
+		OriginalPath: originalPath,
+		RecoveryPath: recoveryPath,
+	}); !errors.Is(err, errBotSessionRetired) {
+		t.Fatalf("late recovery error = %v, want %v", err, errBotSessionRetired)
+	}
+	if got := leases.HeldPath(); got != "" {
+		t.Fatalf("late recovery reacquired lease after retirement: %q", got)
+	}
+	probe, err := agent.TryAcquireSessionLease(recoveryPath)
+	if err != nil {
+		t.Fatalf("recovery lease remained unavailable after late callback: %v", err)
+	}
+	probe.Release()
+}
+
 func TestGatewayNewSessionLeaseFailureRetiresSession(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	readyCalls := 0

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -877,6 +877,200 @@ func TestGatewayNewSessionRemembersRotatedSessionPath(t *testing.T) {
 	gw.closeSessions()
 }
 
+func TestGatewayRecoveryRebindsLeaseAndRemembersSessionPath(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "session.jsonl")
+
+	disk := agent.NewSession("sys")
+	disk.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	disk.Add(provider.Message{Role: provider.RoleAssistant, Content: "disk"})
+	if err := disk.Save(originalPath); err != nil {
+		t.Fatalf("save disk session: %v", err)
+	}
+
+	local := agent.NewSession("sys")
+	local.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	local.Add(provider.Message{Role: provider.RoleAssistant, Content: "local"})
+	exec := agent.New(nil, nil, local, agent.Options{}, event.Discard)
+
+	var remembered []string
+	gw := NewGateway(GatewayConfig{
+		OnSessionReady: func(_ InboundMessage, sessionID string) error {
+			remembered = append(remembered, sessionID)
+			return nil
+		},
+	}, nil, logger)
+	msg := InboundMessage{
+		Platform:     PlatformWeixin,
+		ConnectionID: "weixin-main",
+		Domain:       "weixin",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+	}
+	key := BuildSessionKey(msg.Session())
+	leases := control.NewSessionLeaseKeeper()
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("bind original session lease: %v", err)
+	}
+	state := &sessionState{leases: leases, sessionPath: originalPath}
+	gw.controllers[key] = state
+	gw.sessionOverrides[key] = sessionRuntimeOverride{sessionPath: originalPath, label: "session:original"}
+	ctrl := control.New(control.Options{
+		Executor:           exec,
+		SessionDir:         dir,
+		SessionPath:        originalPath,
+		Label:              "test",
+		OnSessionRecovered: gw.botSessionRecoveredHandler(key, msg, state),
+	})
+	state.ctrl = ctrl
+	t.Cleanup(gw.closeSessions)
+
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("snapshot diverged session: %v", err)
+	}
+	recoveryPath := ctrl.SessionPath()
+	if recoveryPath == "" || recoveryPath == originalPath {
+		t.Fatalf("controller path = %q, want recovery path", recoveryPath)
+	}
+	if got := leases.HeldPath(); got != agent.CanonicalSessionPath(recoveryPath) {
+		t.Fatalf("held lease = %q, want recovery path %q", got, agent.CanonicalSessionPath(recoveryPath))
+	}
+	oldLease, err := agent.TryAcquireSessionLease(originalPath)
+	if err != nil {
+		t.Fatalf("original session lease was not released: %v", err)
+	}
+	oldLease.Release()
+
+	gw.mu.Lock()
+	gotStatePath := state.sessionPath
+	gotOverridePath := gw.sessionOverrides[key].sessionPath
+	gw.mu.Unlock()
+	if canonicalBotPath(gotStatePath) != canonicalBotPath(recoveryPath) {
+		t.Fatalf("state path = %q, want recovery path %q", gotStatePath, recoveryPath)
+	}
+	if canonicalBotPath(gotOverridePath) != canonicalBotPath(recoveryPath) {
+		t.Fatalf("override path = %q, want recovery path %q", gotOverridePath, recoveryPath)
+	}
+	if len(remembered) != 1 || remembered[0] != botSessionTarget(recoveryPath) {
+		t.Fatalf("remembered sessions = %v, want [%q]", remembered, botSessionTarget(recoveryPath))
+	}
+
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("snapshot recovered session: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob recovery sessions: %v", err)
+	}
+	transcripts := matches[:0]
+	for _, path := range matches {
+		if !strings.HasSuffix(path, ".events.jsonl") && !strings.HasSuffix(path, ".conflicts.jsonl") {
+			transcripts = append(transcripts, path)
+		}
+	}
+	if len(transcripts) != 1 || transcripts[0] != recoveryPath {
+		t.Fatalf("recovery transcripts = %v, want only %q", transcripts, recoveryPath)
+	}
+}
+
+func TestGatewayRecoveryLeaseFailureKeepsOriginalGeneration(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+	originalPath := filepath.Join(dir, "original.jsonl")
+	recoveryPath := filepath.Join(dir, "recovery.jsonl")
+	readyCalls := 0
+	gw := NewGateway(GatewayConfig{
+		OnSessionReady: func(InboundMessage, string) error {
+			readyCalls++
+			return nil
+		},
+	}, nil, logger)
+	msg := InboundMessage{Platform: PlatformWeixin, ChatType: ChatDM, ChatID: "chat", UserID: "user"}
+	key := BuildSessionKey(msg.Session())
+	leases := control.NewSessionLeaseKeeper()
+	if err := leases.Rebind(originalPath); err != nil {
+		t.Fatalf("bind original session lease: %v", err)
+	}
+	defer leases.Release()
+	blocker, err := agent.TryAcquireSessionLease(recoveryPath)
+	if err != nil {
+		t.Fatalf("bind recovery blocker: %v", err)
+	}
+	defer blocker.Release()
+	state := &sessionState{leases: leases, sessionPath: originalPath}
+	gw.controllers[key] = state
+	gw.sessionOverrides[key] = sessionRuntimeOverride{sessionPath: originalPath}
+
+	err = gw.botSessionRecoveredHandler(key, msg, state)(control.SessionRecoveryInfo{
+		OriginalPath: originalPath,
+		RecoveryPath: recoveryPath,
+	})
+	if err == nil {
+		t.Fatal("recovery handoff succeeded while recovery lease was held")
+	}
+	if got := leases.HeldPath(); got != agent.CanonicalSessionPath(originalPath) {
+		t.Fatalf("held lease = %q, want original path %q", got, agent.CanonicalSessionPath(originalPath))
+	}
+	gw.mu.Lock()
+	gotStatePath := state.sessionPath
+	gotOverridePath := gw.sessionOverrides[key].sessionPath
+	gw.mu.Unlock()
+	if gotStatePath != originalPath || gotOverridePath != originalPath {
+		t.Fatalf("paths changed after failed handoff: state=%q override=%q", gotStatePath, gotOverridePath)
+	}
+	if readyCalls != 0 {
+		t.Fatalf("session-ready callback ran %d times after failed handoff", readyCalls)
+	}
+}
+
+func TestGatewayLateRecoveryCannotReplaceCurrentSessionMapping(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.jsonl")
+	oldRecoveryPath := filepath.Join(dir, "old-recovery.jsonl")
+	currentPath := filepath.Join(dir, "current.jsonl")
+	readyCalls := 0
+	gw := NewGateway(GatewayConfig{
+		OnSessionReady: func(InboundMessage, string) error {
+			readyCalls++
+			return nil
+		},
+	}, nil, logger)
+	msg := InboundMessage{Platform: PlatformWeixin, ChatType: ChatDM, ChatID: "chat", UserID: "user"}
+	key := BuildSessionKey(msg.Session())
+	oldLeases := control.NewSessionLeaseKeeper()
+	if err := oldLeases.Rebind(oldPath); err != nil {
+		t.Fatalf("bind old session lease: %v", err)
+	}
+	defer oldLeases.Release()
+	oldState := &sessionState{leases: oldLeases, sessionPath: oldPath}
+	currentState := &sessionState{sessionPath: currentPath}
+	gw.controllers[key] = currentState
+	gw.sessionOverrides[key] = sessionRuntimeOverride{sessionPath: currentPath}
+
+	if err := gw.botSessionRecoveredHandler(key, msg, oldState)(control.SessionRecoveryInfo{
+		OriginalPath: oldPath,
+		RecoveryPath: oldRecoveryPath,
+	}); err != nil {
+		t.Fatalf("late recovery handoff: %v", err)
+	}
+	if got := oldLeases.HeldPath(); got != agent.CanonicalSessionPath(oldRecoveryPath) {
+		t.Fatalf("old generation lease = %q, want recovery path %q", got, agent.CanonicalSessionPath(oldRecoveryPath))
+	}
+	gw.mu.Lock()
+	gotCurrentPath := currentState.sessionPath
+	gotOverridePath := gw.sessionOverrides[key].sessionPath
+	gw.mu.Unlock()
+	if gotCurrentPath != currentPath || gotOverridePath != currentPath {
+		t.Fatalf("current mapping overwritten by late recovery: state=%q override=%q", gotCurrentPath, gotOverridePath)
+	}
+	if readyCalls != 0 {
+		t.Fatalf("session-ready callback ran %d times for retired generation", readyCalls)
+	}
+}
+
 func TestGatewayNewSessionLeaseFailureRetiresSession(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	readyCalls := 0


### PR DESCRIPTION
## Problem

An IM bot controller can move to an automatic conflict-recovery transcript while its writer lease and remote session mapping remain on the original path. The current process then owns one path but writes another, and an attached chat can be routed back to the stale transcript on its next turn.

Related to #7215. This PR fixes the confirmed recovery-cascade path; it does not suppress the warning or claim that every source of an initial snapshot divergence is identified.

## Root cause

The bot created its `SessionLeaseKeeper` after `boot.Build` and did not install `OnSessionRecovered`. Other single-session frontends already use that callback to acquire the recovery-path lease before the controller commits the path switch.

## Fix

- Create the bot lease keeper before controller construction and wire the existing failure-atomic recovery handoff into `boot.Build`.
- Keep an attached runtime override on the controller's actual recovery path.
- Persist the recovered path through the existing host callback without requiring a setting, restart, or manual cleanup.
- Apply mapping changes only when the callback belongs to the currently published `sessionState`, so a replaced controller cannot overwrite its replacement.
- Serialize recovery handoff with state retirement, so an in-flight handoff finishes before teardown releases its lease and callbacks arriving after retirement cannot reacquire it.

## Concurrency and ownership audit

| Path | Result |
| --- | --- |
| Successful recovery | The recovery lease is acquired before the controller commits its new path; the original lease is then released. |
| Recovery lease already held | The handoff fails without changing the controller path, mapping, or original lease. |
| Late callback from a replaced controller | Its private lease can finish teardown, but the generation guard prevents it from updating the current mapping. |
| Recovery racing state retirement | An in-flight handoff completes before teardown releases its lease; a callback arriving after retirement fails before rebinding. |
| Repeated snapshot after recovery | The controller remains on the single leased recovery transcript; no additional recovery branch is created. |

## Compatibility and product cost

| Surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| Session transcript and branch metadata | No persisted schema or identifier changes. Existing sessions load unchanged. | Backward compatible |
| Bot connection mappings | Uses the existing `path:` target and existing persistence callback. | Backward compatible |
| Fresh/default configuration | Recovery ownership is automatic; no new option or setup step. | Zero additional user cost |
| Existing recovery branches | Left untouched; this PR only changes ownership during future recovery handoffs. | Non-destructive |
| Provider/cache surface | No prompt, tool schema, provider request, or compaction changes. | Cache neutral |

## Verification

- `go test ./internal/bot ./internal/control ./internal/agent`
- `go test -race ./internal/bot`
- `go vet ./...`
- `go test ./...`
- `cd desktop && go test ./...`

The regression tests force a real diverged snapshot and verify lease/path/mapping alignment, failure atomicity, generation safety, teardown safety, and the absence of a second recovery branch.
