### PR TITLE
fix(config): secure system prompt file fallback / 安全修复系统提示词文件降级

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -372,7 +372,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
 	if err != nil {
-		return nil, err
+		if !config.IsMissingSystemPromptFile(err) {
+			return nil, err
+		}
+		// A stale missing prompt file must not block startup: warn and fall back
+		// to the inline (or built-in default) system prompt. Other read failures
+		// stay fatal so Reasonix never runs without explicitly configured policy.
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: err.Error() + "; falling back to inline/default system prompt"})
+		sysPrompt = cfg.InlineSystemPrompt()
 	}
 	// Output style: fold the selected persona/tone block into the base prompt
 	// before language/memory/skills append, so a "replace" style (keep-coding

--- a/internal/boot/system_prompt_file_test.go
+++ b/internal/boot/system_prompt_file_test.go
@@ -1,0 +1,77 @@
+package boot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestBuildMissingSystemPromptFileFallsBackToInlinePrompt(t *testing.T) {
+	isolateConfigHome(t)
+	root := robustTempDir(t)
+	t.Setenv("REASONIX_HOME", robustTempDir(t))
+	writeFile(t, root, "reasonix.toml", systemPromptFileTestConfig("prompts/missing.md"))
+
+	var notices []event.Event
+	ctrl, err := Build(context.Background(), Options{
+		WorkspaceRoot: root,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if got := systemMessage(ctrl.History()); !strings.Contains(got, "INLINE FALLBACK") {
+		t.Fatalf("system prompt did not use inline fallback:\n%s", got)
+	}
+	for _, notice := range notices {
+		if notice.Level == event.LevelWarn && strings.Contains(notice.Text, "falling back to inline/default system prompt") {
+			return
+		}
+	}
+	t.Fatalf("missing fallback warning: %#v", notices)
+}
+
+func TestBuildNonMissingSystemPromptReadFailureStaysFatal(t *testing.T) {
+	isolateConfigHome(t)
+	root := robustTempDir(t)
+	t.Setenv("REASONIX_HOME", robustTempDir(t))
+	writeFile(t, root, "reasonix.toml", systemPromptFileTestConfig("prompts"))
+	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl, err := Build(context.Background(), Options{WorkspaceRoot: root})
+	if ctrl != nil {
+		ctrl.Close()
+		t.Fatal("Build returned a controller after system prompt read failure")
+	}
+	if err == nil || !strings.Contains(err.Error(), "could not be read") {
+		t.Fatalf("Build error = %v, want fatal system prompt read error", err)
+	}
+}
+
+func systemPromptFileTestConfig(path string) string {
+	return `
+default_model = "test-model"
+
+[agent]
+system_prompt = "INLINE FALLBACK"
+system_prompt_file = "` + path + `"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"net/netip"
 	"net/url"
 	"os"
@@ -63,6 +66,7 @@ type Config struct {
 	Secrets          SecretsConfig       `toml:"secrets"`
 	Remote           RemoteConfig        `toml:"remote"`
 
+	systemPromptFileSource     promptFileSource
 	providerSources            map[string]providerSourceScope
 	shadowedProjectProviders   []ProviderEntry
 	ignoredProjectDefaultModel string
@@ -76,6 +80,44 @@ type Config struct {
 	// user/project files recovered via last-known-good or defaults). They never
 	// rewrite the original file; the UI may surface them for doctor repair.
 	loadWarnings []string
+}
+
+type promptFileSource uint8
+
+const (
+	promptFileSourceUnknown promptFileSource = iota
+	promptFileSourceUser
+	promptFileSourceProject
+)
+
+type systemPromptFileError struct {
+	configured string
+	candidates []string
+	errors     []error
+	allMissing bool
+}
+
+func (e *systemPromptFileError) Error() string {
+	detail := "could not be read from any configured location"
+	if e.allMissing {
+		detail = "not found at any configured location"
+	}
+	message := fmt.Sprintf("system_prompt_file %q %s: %s", e.configured, detail, strings.Join(e.candidates, ", "))
+	if !e.allMissing && len(e.errors) > 0 {
+		message += ": " + errors.Join(e.errors...).Error()
+	}
+	return message
+}
+
+func (e *systemPromptFileError) Unwrap() error { return errors.Join(e.errors...) }
+
+// IsMissingSystemPromptFile reports whether every allowed location for a
+// configured prompt file was absent. Permission, containment, and other I/O
+// failures deliberately return false so callers do not start without an
+// explicitly configured prompt.
+func IsMissingSystemPromptFile(err error) bool {
+	var target *systemPromptFileError
+	return errors.As(err, &target) && target.allMissing
 }
 
 // TelemetryConfig controls content-free CLI usage metrics. It is user-global:
@@ -2109,23 +2151,98 @@ func (c *Config) ResolveSystemPrompt() (string, error) {
 
 // ResolveSystemPromptForRoot is like ResolveSystemPrompt but resolves a relative
 // system_prompt_file against root. Desktop tabs pass their workspace root here so
-// prompt files are project-scoped even when the process cwd is elsewhere.
+// prompt files are project-scoped even when the process cwd is elsewhere. A path
+// inherited from user config may fall back to Reasonix home, while a path chosen
+// by project config is confined to the workspace and never probes user files.
 func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
-	if c.Agent.SystemPromptFile != "" {
-		path := c.Agent.SystemPromptFile
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(resolveRoot(root), path)
+	path := c.Agent.SystemPromptFile
+	if path == "" {
+		return c.InlineSystemPrompt(), nil
+	}
+
+	if c.systemPromptFileSource == promptFileSourceProject {
+		if filepath.IsAbs(path) || !filepath.IsLocal(filepath.Clean(path)) {
+			return "", fmt.Errorf("project system_prompt_file %q must be a relative path within the workspace", path)
 		}
-		b, err := fileencoding.ReadFileUTF8(path)
+		candidate := filepath.Join(resolveRoot(root), path)
+		b, err := readProjectSystemPromptFile(root, path)
 		if err != nil {
-			return "", fmt.Errorf("system_prompt_file: %w", err)
+			return "", newSystemPromptFileError(path, []string{candidate}, []error{err})
 		}
 		return strings.TrimSpace(string(b)), nil
 	}
-	if strings.TrimSpace(c.Agent.SystemPrompt) == "" {
-		return DefaultSystemPrompt, nil
+
+	if filepath.IsAbs(path) {
+		b, err := fileencoding.ReadFileUTF8(path)
+		if err != nil {
+			return "", newSystemPromptFileError(path, []string{path}, []error{err})
+		}
+		return strings.TrimSpace(string(b)), nil
 	}
-	return c.Agent.SystemPrompt, nil
+
+	candidates := []string{filepath.Join(resolveRoot(root), path)}
+	if home := ReasonixHomeDir(); home != "" {
+		homeCandidate := filepath.Join(home, path)
+		if filepath.Clean(homeCandidate) != filepath.Clean(candidates[0]) {
+			candidates = append(candidates, homeCandidate)
+		}
+	}
+	readErrors := make([]error, 0, len(candidates))
+	for _, candidate := range candidates {
+		b, err := fileencoding.ReadFileUTF8(candidate)
+		if err == nil {
+			return strings.TrimSpace(string(b)), nil
+		}
+		readErrors = append(readErrors, fmt.Errorf("%s: %w", candidate, err))
+	}
+	return "", newSystemPromptFileError(path, candidates, readErrors)
+}
+
+func readProjectSystemPromptFile(root, path string) ([]byte, error) {
+	workspace, err := filepath.Abs(resolveRoot(root))
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace root: %w", err)
+	}
+	rootHandle, err := os.OpenRoot(workspace)
+	if err != nil {
+		return nil, fmt.Errorf("open workspace root %q: %w", workspace, err)
+	}
+	defer rootHandle.Close()
+	f, err := rootHandle.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return fileencoding.DecodeToUTF8(b), nil
+}
+
+func newSystemPromptFileError(configured string, candidates []string, readErrors []error) error {
+	allMissing := len(readErrors) > 0
+	for _, err := range readErrors {
+		if !errors.Is(err, fs.ErrNotExist) {
+			allMissing = false
+			break
+		}
+	}
+	return &systemPromptFileError{
+		configured: configured,
+		candidates: append([]string(nil), candidates...),
+		errors:     append([]error(nil), readErrors...),
+		allMissing: allMissing,
+	}
+}
+
+// InlineSystemPrompt returns the configured system_prompt, or DefaultSystemPrompt
+// when unset. It is the fallback when system_prompt_file cannot be read.
+func (c *Config) InlineSystemPrompt() string {
+	if strings.TrimSpace(c.Agent.SystemPrompt) == "" {
+		return DefaultSystemPrompt
+	}
+	return c.Agent.SystemPrompt
 }
 
 // Validate checks that the selected model's provider is usable.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -51,6 +51,9 @@ func LoadUserConfigReadOnly() (*Config, error) {
 		if err := mergeFile(cfg, path); err != nil {
 			return nil, err
 		}
+		if tomlFileDefinesKey(path, "agent", "system_prompt_file") {
+			cfg.systemPromptFileSource = promptFileSourceUser
+		}
 	}
 	normalizeConfigForEdit(cfg)
 	return cfg, nil
@@ -106,7 +109,15 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 			}
 		} else {
 			userDefaultModelExplicit = tomlFileDefinesKey(uc, "default_model")
+			if tomlFileDefinesKey(uc, "agent", "system_prompt_file") {
+				cfg.systemPromptFileSource = promptFileSourceUser
+			}
 		}
+	}
+	// A last-known-good recovery is still trusted user configuration even though
+	// the broken source file cannot provide usable TOML metadata.
+	if cfg.systemPromptFileSource == promptFileSourceUnknown && cfg.Agent.SystemPromptFile != "" {
+		cfg.systemPromptFileSource = promptFileSourceUser
 	}
 	userDefaultModel := cfg.DefaultModel
 	globalCLI := cfg.CLI
@@ -117,6 +128,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	globalTelemetry := cfg.Telemetry
 
 	tomlSources = append(tomlSources, projectTOML)
+	projectSystemPromptFileDefined := tomlFileDefinesKey(projectTOML, "agent", "system_prompt_file")
 	if err := mergeTOML(cfg, projectTOML); err != nil {
 		// Project config damage is isolated to this workspace: continue with
 		// user/global config so other tabs stay available.
@@ -127,6 +139,8 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 		// Drop the project path from later multi-file merges so a broken TOML
 		// cannot fail plugin/provider re-merges.
 		tomlSources = tomlSources[:len(tomlSources)-1]
+	} else if projectSystemPromptFileDefined {
+		cfg.systemPromptFileSource = promptFileSourceProject
 	}
 	// The native CLI update channel controls the one user-installed binary.
 	// A repository-local reasonix.toml must never switch that global choice.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
+
 	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/provider"
@@ -48,10 +50,11 @@ func LoadForRootReadOnly(root string) (*Config, error) {
 func LoadUserConfigReadOnly() (*Config, error) {
 	cfg := Default()
 	if path := userConfigLoadPath(); path != "" {
-		if err := mergeFile(cfg, path); err != nil {
+		meta, err := mergeFileSnapshot(cfg, path)
+		if err != nil {
 			return nil, err
 		}
-		if tomlFileDefinesKey(path, "agent", "system_prompt_file") {
+		if meta.IsDefined("agent", "system_prompt_file") {
 			cfg.systemPromptFileSource = promptFileSourceUser
 		}
 	}
@@ -79,16 +82,17 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 		return nil, err
 	}
 
-	mergeTOML := mergeFile
+	mergeTOML := mergeFileSnapshot
 	if migrateOnDisk {
-		mergeTOML = mergeRuntimeTOMLFile
+		mergeTOML = mergeRuntimeTOMLFileSnapshot
 	}
 
 	var tomlSources []string
 	userDefaultModelExplicit := false
 	if uc := userConfigLoadPath(); uc != "" {
 		tomlSources = append(tomlSources, uc)
-		if err := mergeTOML(cfg, uc); err != nil {
+		meta, err := mergeTOML(cfg, uc)
+		if err != nil {
 			// Never rewrite the broken original file. Prefer the last verified
 			// snapshot in memory, then built-in defaults, and keep loading so
 			// the rest of the app stays usable.
@@ -108,8 +112,8 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 				))
 			}
 		} else {
-			userDefaultModelExplicit = tomlFileDefinesKey(uc, "default_model")
-			if tomlFileDefinesKey(uc, "agent", "system_prompt_file") {
+			userDefaultModelExplicit = meta.IsDefined("default_model")
+			if meta.IsDefined("agent", "system_prompt_file") {
 				cfg.systemPromptFileSource = promptFileSourceUser
 			}
 		}
@@ -128,8 +132,8 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	globalTelemetry := cfg.Telemetry
 
 	tomlSources = append(tomlSources, projectTOML)
-	projectSystemPromptFileDefined := tomlFileDefinesKey(projectTOML, "agent", "system_prompt_file")
-	if err := mergeTOML(cfg, projectTOML); err != nil {
+	projectMeta, err := mergeTOML(cfg, projectTOML)
+	if err != nil {
 		// Project config damage is isolated to this workspace: continue with
 		// user/global config so other tabs stay available.
 		cfg.addLoadWarning(fmt.Sprintf(
@@ -139,7 +143,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 		// Drop the project path from later multi-file merges so a broken TOML
 		// cannot fail plugin/provider re-merges.
 		tomlSources = tomlSources[:len(tomlSources)-1]
-	} else if projectSystemPromptFileDefined {
+	} else if projectMeta.IsDefined("agent", "system_prompt_file") {
 		cfg.systemPromptFileSource = promptFileSourceProject
 	}
 	// The native CLI update channel controls the one user-installed binary.
@@ -761,29 +765,47 @@ func loadDotEnvForEditPath(path string) {
 
 // mergeFile decodes a TOML file onto cfg if it exists. An absent file is not an error.
 func mergeFile(cfg *Config, path string) error {
+	_, err := mergeFileSnapshot(cfg, path)
+	return err
+}
+
+// mergeFileSnapshot decodes one immutable read of a TOML file onto cfg and
+// returns metadata from those exact bytes. Callers that derive source or
+// precedence decisions from metadata must use this result instead of reading
+// the path again: a config file may be atomically replaced between reads.
+func mergeFileSnapshot(cfg *Config, path string) (toml.MetaData, error) {
+	return mergeFileSnapshotWithRead(cfg, path, fileencoding.ReadFileUTF8)
+}
+
+func mergeFileSnapshotWithRead(cfg *Config, path string, readFile func(string) ([]byte, error)) (toml.MetaData, error) {
 	resolved, exists, err := statConfigPath(path)
 	if err != nil {
-		return err
+		return toml.MetaData{}, err
 	}
 	if !exists {
-		return nil
+		return toml.MetaData{}, nil
+	}
+	data, err := readFile(resolved)
+	if err != nil {
+		return toml.MetaData{}, fmt.Errorf("config %s: %w", path, err)
 	}
 	// BurntSushi/toml decodes struct fields incrementally and can leave earlier
 	// fields mutated when a later value has the wrong type. Validate the complete
-	// file against a disposable Config before merging it into the active object.
-	// This makes user LKG fallback and project-level isolation transactional.
+	// snapshot against a disposable Config before merging those same bytes into
+	// the active object. This makes user LKG fallback, project-level isolation,
+	// and metadata-derived provenance transactional with respect to file changes.
 	var validated Config
-	if _, err := decodeTOMLFileResolved(resolved, &validated); err != nil {
-		return fmt.Errorf("config %s: %w", path, err)
+	if _, err := decodeTOMLBytes(data, &validated); err != nil {
+		return toml.MetaData{}, fmt.Errorf("config %s: %w", path, err)
 	}
-	meta, err := decodeTOMLFileResolved(resolved, cfg)
+	meta, err := decodeTOMLBytes(data, cfg)
 	if err != nil {
-		return fmt.Errorf("config %s: %w", path, err)
+		return toml.MetaData{}, fmt.Errorf("config %s: %w", path, err)
 	}
 	if meta.IsDefined("providers") {
 		var persisted Config
-		if _, err := decodeTOMLFileResolved(resolved, &persisted); err != nil {
-			return fmt.Errorf("config %s: %w", path, err)
+		if _, err := decodeTOMLBytes(data, &persisted); err != nil {
+			return toml.MetaData{}, fmt.Errorf("config %s: %w", path, err)
 		}
 		markPersistedDeepSeekOfficialPricing(&persisted)
 		markers := map[string]string{}
@@ -794,16 +816,21 @@ func mergeFile(cfg *Config, path string) error {
 			cfg.Providers[i].persistedOfficialCurrency = markers[providerMergeKey(cfg.Providers[i])]
 		}
 	}
-	return nil
+	return meta, nil
 }
 
 func mergeRuntimeTOMLFile(cfg *Config, path string) error {
+	_, err := mergeRuntimeTOMLFileSnapshot(cfg, path)
+	return err
+}
+
+func mergeRuntimeTOMLFileSnapshot(cfg *Config, path string) (toml.MetaData, error) {
 	if _, err := os.Stat(path); err == nil {
 		if err := migrateLegacyMCPTiersFile(path); err != nil {
 			slog.Warn("config: legacy mcp tier migration failed", "path", path, "err", err)
 		}
 	}
-	return mergeFile(cfg, path)
+	return mergeFileSnapshot(cfg, path)
 }
 
 // normalizeLegacyMCPTiers keeps loaded legacy config files on the new product

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -30,7 +30,7 @@ func Load() (*Config, error) {
 // changing the process cwd, while provider keys stay rooted in Reasonix home.
 //
 // Note: LoadForRoot may rewrite legacy MCP `tier` lines on disk (see
-// mergeRuntimeTOMLFile). Callers that must not mutate config files should use
+// mergeRuntimeTOMLFileSnapshot). Callers that must not mutate config files should use
 // LoadForRootReadOnly instead.
 func LoadForRoot(root string) (*Config, error) {
 	return loadForRoot(root, true)
@@ -817,11 +817,6 @@ func mergeFileSnapshotWithRead(cfg *Config, path string, readFile func(string) (
 		}
 	}
 	return meta, nil
-}
-
-func mergeRuntimeTOMLFile(cfg *Config, path string) error {
-	_, err := mergeRuntimeTOMLFileSnapshot(cfg, path)
-	return err
 }
 
 func mergeRuntimeTOMLFileSnapshot(cfg *Config, path string) (toml.MetaData, error) {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -212,7 +212,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	if c.Agent.SystemPromptFile != "" {
 		fmt.Fprintf(&b, "system_prompt_file = %q\n", c.Agent.SystemPromptFile)
 	} else {
-		b.WriteString("# system_prompt_file = \"prompts/system.md\"   # overrides system_prompt when set\n")
+		b.WriteString("# system_prompt_file = \"prompts/system.md\"   # project paths stay in <workspace>; user paths may fall back to <reasonix home>\n")
 	}
 	fmt.Fprintf(&b, "temperature       = %s\n", formatFloat(c.Agent.Temperature))
 	if strings.TrimSpace(c.Agent.RecoveryModel) != "" {

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,7 @@ func TestDefaultSystemPromptStaysLean(t *testing.T) {
 
 func TestResolveSystemPromptForRootRelativePath(t *testing.T) {
 	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -67,8 +69,240 @@ func TestResolveSystemPromptForRootAbsolutePath(t *testing.T) {
 	}
 }
 
+func TestResolveSystemPromptForRootMissingFile(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = "prompts/does-not-exist.md"
+
+	_, err := cfg.ResolveSystemPromptForRoot(root)
+	if err == nil {
+		t.Fatal("expected error for missing system_prompt_file")
+	}
+	if !strings.Contains(err.Error(), "not found at any configured location") {
+		t.Fatalf("error %q missing friendly not-found message", err)
+	}
+	// All probed locations must be listed so users can see where it looked.
+	for _, tried := range []string{filepath.Join(root, "prompts", "does-not-exist.md"), filepath.Join(home, "prompts", "does-not-exist.md")} {
+		if !strings.Contains(err.Error(), tried) {
+			t.Fatalf("error %q does not list tried path %q", err, tried)
+		}
+	}
+	if got := cfg.InlineSystemPrompt(); got != DefaultSystemPrompt {
+		t.Fatalf("InlineSystemPrompt fallback = %q, want DefaultSystemPrompt", got)
+	}
+}
+
+func TestResolveSystemPromptProjectCannotReadReasonixHome(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	secret := "OTHER_PROVIDER_SECRET=must-not-enter-prompt"
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("[agent]\nsystem_prompt_file = \".env\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err == nil {
+		t.Fatalf("ResolveSystemPromptForRoot = %q, want missing workspace file error", got)
+	}
+	if !IsMissingSystemPromptFile(err) {
+		t.Fatalf("error = %v, want missing prompt classification", err)
+	}
+	if strings.Contains(err.Error(), filepath.Join(home, ".env")) || strings.Contains(got, secret) {
+		t.Fatalf("project prompt resolution probed Reasonix credentials: got=%q err=%v", got, err)
+	}
+}
+
+func TestResolveSystemPromptUserConfigCanFallBackToReasonixHome(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("[agent]\nsystem_prompt_file = \"prompts/system.md\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "system.md"), []byte("trusted home prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "trusted home prompt" {
+		t.Fatalf("system prompt = %q, want trusted home prompt", got)
+	}
+}
+
+func TestResolveSystemPromptProjectPathStaysInWorkspace(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	for _, dir := range []string{filepath.Join(home, "prompts"), filepath.Join(root, "prompts")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("[agent]\nsystem_prompt_file = \"prompts/system.md\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "system.md"), []byte("home prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("[agent]\nsystem_prompt_file = \"prompts/system.md\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "prompts", "system.md"), []byte("workspace prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "workspace prompt" {
+		t.Fatalf("system prompt = %q, want workspace prompt", got)
+	}
+}
+
+func TestResolveSystemPromptRejectsProjectPathEscapes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	for _, test := range []struct {
+		name string
+		path func(root string) string
+	}{
+		{name: "parent", path: func(string) string { return filepath.Join("..", "outside.md") }},
+		{name: "absolute", path: func(root string) string { return filepath.Join(filepath.Dir(root), "outside.md") }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			outside := test.path(root)
+			if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte(fmt.Sprintf("[agent]\nsystem_prompt_file = %q\n", outside)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadForRootReadOnly(root)
+			if err != nil {
+				t.Fatalf("LoadForRootReadOnly: %v", err)
+			}
+			if _, err := cfg.ResolveSystemPromptForRoot(root); err == nil || IsMissingSystemPromptFile(err) || !strings.Contains(err.Error(), "relative path within the workspace") {
+				t.Fatalf("ResolveSystemPromptForRoot error = %v, want fatal containment error", err)
+			}
+		})
+	}
+}
+
+func TestResolveSystemPromptRejectsProjectSymlinkEscape(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.WriteFile(outside, []byte("outside secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "prompts", "system.md")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("[agent]\nsystem_prompt_file = \"prompts/system.md\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	if got, err := cfg.ResolveSystemPromptForRoot(root); err == nil || IsMissingSystemPromptFile(err) || strings.Contains(got, "outside secret") {
+		t.Fatalf("ResolveSystemPromptForRoot = %q, %v; want fatal symlink containment error", got, err)
+	}
+}
+
+func TestResolveSystemPromptMixedReadErrorsAreNotMissing(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts", "system.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "system.md")
+	if _, err := cfg.ResolveSystemPromptForRoot(root); err == nil || IsMissingSystemPromptFile(err) {
+		t.Fatalf("ResolveSystemPromptForRoot error = %v, want non-missing read failure", err)
+	}
+}
+
+func TestResolveSystemPromptForRootFallsBackToReasonixHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "system.md"), []byte(" home prompt \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "system.md")
+
+	// Workspace root has no such file; the Reasonix-home copy must win the probe.
+	got, err := cfg.ResolveSystemPromptForRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "home prompt" {
+		t.Fatalf("system prompt = %q, want %q", got, "home prompt")
+	}
+}
+
+func TestResolveSystemPromptForRootWorkspaceWins(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	for dir, content := range map[string]string{home: "home prompt", root: "workspace prompt"} {
+		if err := os.MkdirAll(filepath.Join(dir, "prompts"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "prompts", "system.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "system.md")
+
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "workspace prompt" {
+		t.Fatalf("system prompt = %q, want workspace copy to win, got %q", got, "workspace prompt")
+	}
+}
+
 func TestResolveSystemPromptForRootDecodesGB18030(t *testing.T) {
 	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -123,6 +123,54 @@ func TestResolveSystemPromptProjectCannotReadReasonixHome(t *testing.T) {
 	}
 }
 
+func TestMergeFileSnapshotKeepsProjectPromptSourceAtomic(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	const secret = "PROVIDER_SECRET=must-not-enter-system-prompt"
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	projectConfig := filepath.Join(root, "reasonix.toml")
+	if err := os.WriteFile(projectConfig, []byte("[agent]\nsystem_prompt_file = \".env\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	reads := 0
+	meta, err := mergeFileSnapshotWithRead(cfg, projectConfig, func(path string) ([]byte, error) {
+		reads++
+		data, err := fileencoding.ReadFileUTF8(path)
+		if err != nil {
+			return nil, err
+		}
+		// Simulate an atomic config replacement after the read. The merged value
+		// and its provenance must still come from data, not from a second read.
+		if err := os.WriteFile(path, []byte("[agent]\nsystem_prompt = \"replacement\"\n"), 0o600); err != nil {
+			return nil, err
+		}
+		return data, nil
+	})
+	if err != nil {
+		t.Fatalf("mergeFileSnapshotWithRead: %v", err)
+	}
+	if reads != 1 {
+		t.Fatalf("config reads = %d, want exactly one", reads)
+	}
+	if !meta.IsDefined("agent", "system_prompt_file") {
+		t.Fatal("snapshot metadata lost project system_prompt_file")
+	}
+	cfg.systemPromptFileSource = promptFileSourceProject
+
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err == nil || !IsMissingSystemPromptFile(err) {
+		t.Fatalf("ResolveSystemPromptForRoot = %q, %v; want project-scoped missing error", got, err)
+	}
+	if strings.Contains(got, secret) || strings.Contains(err.Error(), filepath.Join(home, ".env")) {
+		t.Fatalf("project prompt resolution probed Reasonix credentials: got=%q err=%v", got, err)
+	}
+}
+
 func TestResolveSystemPromptUserConfigCanFallBackToReasonixHome(t *testing.T) {
 	home := t.TempDir()
 	root := t.TempDir()

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -28,7 +28,7 @@ ask_request = true   # notify when a question is waiting
 
 [agent]
 # system_prompt = "You are ..."   # custom persona/prompt; unset or empty = built-in default
-# system_prompt_file = "prompts/system.md"   # overrides system_prompt when set
+# system_prompt_file = "prompts/system.md"   # project paths stay in <workspace>; user paths may fall back to <reasonix home>
 temperature       = 0.0
 # recovery_model = ""               # optional reviewer for low-risk automatic recovery; falls back to guardian_model then main model
 # reasoning_language = "auto"   # visible reasoning text: auto|zh|en


### PR DESCRIPTION
## Summary

- Keep startup usable when every allowed `system_prompt_file` location is missing: emit a warning and fall back to the configured inline prompt or the built-in default.
- Preserve where the setting came from. Project-selected relative paths stay confined to the workspace; trusted user configuration may fall back to Reasonix home.
- Derive each TOML value and its provenance from the same single-read byte snapshot, so an atomic file replacement cannot mix trust scopes.
- Fail closed for absolute or escaping project paths, symlink escapes, permission failures, directories, and other non-missing I/O errors so Reasonix never silently runs without explicitly configured policy.
- Report the allowed locations that were tried and keep existing text-decoding behavior.

## Root cause

The original configuration merge retained only the final `system_prompt_file` string, not whether it came from user or project scope. A workspace-controlled `reasonix.toml` could therefore make fallback resolution probe Reasonix home, including its credential `.env`. Boot also treated every resolver error as if the file were merely absent.

## Security boundary

Project configuration is repository-controlled and must not select files outside the workspace. This change derives the effective prompt path and its provenance from one immutable TOML byte snapshot, records provenance in memory, and uses `os.Root` for project-scoped reads, preventing lexical and symlink escapes even if the path changes during resolution. Only an all-missing result is eligible for startup fallback.

## Superseding and contributor credit

This PR supersedes #7330 after its contributor branch could not be updated by a maintainer.

| Source PR | Contributor | Disposition | Kept or adapted |
| --- | --- | --- | --- |
| #7330 | @SprayHank | Kept and security-hardened | Missing-file startup fallback, workspace/Reasonix-home resolution intent, actionable diagnostics, documentation, and focused prompt-file tests |

The integration commit includes a public `Co-authored-by` trailer for @SprayHank.

## Compatibility

| Configuration | Behavior | Conclusion |
| --- | --- | --- |
| No `system_prompt_file` | Inline or built-in prompt remains unchanged | Compatible |
| Existing readable absolute user path | Reads the same file and prompt bytes | Compatible |
| Existing readable relative workspace path | Workspace copy still wins | Compatible |
| Trusted user relative path missing in workspace | May resolve next to the user config in Reasonix home | New recovery path |
| Every allowed location missing | Warns and uses inline/default prompt instead of aborting startup | Intentional resilience improvement |
| Permission, directory, containment, or other I/O failure | Startup fails with the underlying diagnostic | Intentional fail-closed behavior |
| Absolute, `..`, or escaping symlink selected by project config | Rejected; move the prompt into the workspace or configure it in trusted user config | Intentional security migration |
| Persisted TOML | No new key or serialized field; provenance is in-memory only | Cross-version safe |

## Cache impact

Cache-impact: low - successful prompt loads keep identical bytes; only previously failing fallback and fail-closed security paths change.
Cache-guard: `./scripts/cache-guard.sh` passed with every release scenario above its threshold.
System-prompt-review: Security and cache behavior self-reviewed by @SivanCola; explicit maintainer approval is still required before merge.

Cache impact is low. Configurations that already loaded a prompt successfully keep the same prompt bytes. The new home fallback only makes a previously failing configuration usable, and the security checks add no per-turn or per-session dynamic prompt data.

Cache guard: `./scripts/cache-guard.sh` passed with every release scenario above its threshold.

## Verification

- `go test ./internal/config ./internal/boot -count=1`
- `go test -race ./internal/config ./internal/boot -count=1`
- `go vet ./...`
- `./scripts/cache-guard.sh`
- `go test ./... -count=1`
- `git diff --check origin/main-v2...HEAD`

Concurrency audit: TOML values and provenance metadata come from the same single-read snapshot, and a regression test deterministically replaces the project config after that read. Focused race tests passed; loaded provenance remains immutable and prompt resolution is synchronous.
