### PR TITLE
feat(config): fall back to $HOME/.env then the account home .env for credentials

### DIFF
--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -200,7 +201,11 @@ func (c *Config) CredentialEnvNames() []string {
 	for _, name := range names {
 		seen[name] = true
 	}
-	if file, ok := readDotEnvFile(UserCredentialsPath()); ok {
+	collect := func(path string) {
+		file, ok := readDotEnvFile(path)
+		if !ok {
+			return
+		}
 		for name := range file.Values {
 			name = strings.TrimSpace(name)
 			if !isCredentialKey(name) || seen[name] {
@@ -209,6 +214,10 @@ func (c *Config) CredentialEnvNames() []string {
 			seen[name] = true
 			names = append(names, name)
 		}
+	}
+	collect(UserCredentialsPath())
+	for _, p := range homeCredentialFallbackPaths() {
+		collect(p)
 	}
 	sort.Strings(names)
 	return names
@@ -259,6 +268,48 @@ func loadCredentialStoreForRoot(root string) {
 	if p := UserCredentialsPath(); p != "" {
 		loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"})
 	}
+	for _, p := range homeCredentialFallbackPaths() {
+		loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceHomeEnv, Path: p, Label: "user home .env"})
+	}
+}
+
+// currentAccountHome resolves the OS account's home from the user database
+// (not $HOME). A var so tests can stub it.
+var currentAccountHome = func() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.HomeDir)
+}
+
+// homeCredentialFallbackPaths lists user-level .env fallbacks probed after the
+// primary Reasonix credentials file: $HOME/.env first, then the OS account
+// home's .env (covers launchers and services that override HOME). Fallbacks
+// never override keys that are already set — loadDotEnvFileAs skips existing
+// keys for non-"credentials" sources — so precedence is: Reasonix credentials
+// file > process environment > $HOME/.env > account home .env.
+func homeCredentialFallbackPaths() []string {
+	primary := UserCredentialsPath()
+	seen := map[string]bool{}
+	var paths []string
+	add := func(path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		if primary != "" && samePath(path, primary) {
+			return
+		}
+		paths = append(paths, path)
+	}
+	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		add(filepath.Join(home, ".env"))
+	}
+	if home := currentAccountHome(); home != "" {
+		add(filepath.Join(home, ".env"))
+	}
+	return paths
 }
 
 // StoreCredentialLines stores KEY=value assignments in Reasonix's global .env
@@ -538,6 +589,13 @@ func storedCredentialValue(key string) (string, CredentialSource, bool) {
 	if p := UserCredentialsPath(); p != "" {
 		if value, ok := envFileValue(p, key); ok && value != "" {
 			return value, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"}, true
+		}
+	}
+	// User-level fallbacks, same probe order as loadCredentialStoreForRoot:
+	// $HOME/.env, then the OS account home's .env.
+	for _, p := range homeCredentialFallbackPaths() {
+		if value, ok := envFileValue(p, key); ok && value != "" {
+			return value, CredentialSource{Kind: CredentialSourceHomeEnv, Path: p, Label: "user home .env"}, true
 		}
 	}
 	return "", CredentialSource{}, false

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -9,7 +9,7 @@ import (
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
 
-func TestLoadDotEnvDoesNotImportProjectOrHomeEnv(t *testing.T) {
+func TestLoadDotEnvImportsHomeEnvFallbackButNotProjectEnv(t *testing.T) {
 	cwd := t.TempDir()
 	home := t.TempDir()
 
@@ -25,6 +25,10 @@ func TestLoadDotEnvDoesNotImportProjectOrHomeEnv(t *testing.T) {
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 
+	prev := currentAccountHome
+	currentAccountHome = func() string { return home }
+	t.Cleanup(func() { currentAccountHome = prev })
+
 	// Start clean so the file values are what land (Setenv auto-restores).
 	t.Setenv("KEY_CWD", "")
 	os.Unsetenv("KEY_CWD")
@@ -38,16 +42,122 @@ func TestLoadDotEnvDoesNotImportProjectOrHomeEnv(t *testing.T) {
 	if got := os.Getenv("KEY_CWD"); got != "" {
 		t.Errorf("project .env key was imported into process env: KEY_CWD=%q", got)
 	}
-	if got := os.Getenv("KEY_HOME"); got != "" {
-		t.Errorf("home .env key was loaded: KEY_HOME=%q", got)
+	// The user home .env is a credential fallback: it fills keys that neither
+	// the primary credentials file nor the process environment provides.
+	if got := os.Getenv("KEY_HOME"); got != "from_home" {
+		t.Errorf("home .env fallback not loaded: KEY_HOME=%q want from_home", got)
 	}
-	if got := os.Getenv("KEY_SHARED"); got != "" {
-		t.Errorf("project/home .env shared key was imported: KEY_SHARED=%q", got)
+	if got := os.Getenv("KEY_SHARED"); got != "home_loses" {
+		t.Errorf("project .env must stay unimported; home fallback should win: KEY_SHARED=%q want home_loses", got)
 	}
 }
 
-// TestLoadDotEnvReadsGlobalCredentials proves `reasonix setup`'s target — the
-// reasonix-owned credentials file under Reasonix home — is loaded from any
+// TestLoadDotEnvHomeEnvFallbackPrecedence pins the credential precedence:
+// Reasonix credentials file > process environment > $HOME/.env fallback.
+func TestLoadDotEnvHomeEnvFallbackPrecedence(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	credHome := t.TempDir()
+
+	t.Chdir(cwd)
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("REASONIX_HOME", credHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	prev := currentAccountHome
+	currentAccountHome = func() string { return home }
+	t.Cleanup(func() { currentAccountHome = prev })
+
+	if err := os.WriteFile(filepath.Join(credHome, ".env"), []byte("KEY_PRIMARY=from_credentials\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte("KEY_PRIMARY=from_home\nKEY_HOME_ONLY=from_home\nKEY_ENV=from_home\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("KEY_ENV", "from_env") // process environment must beat the home fallback
+	t.Setenv("KEY_PRIMARY", "")
+	os.Unsetenv("KEY_PRIMARY")
+	t.Setenv("KEY_HOME_ONLY", "")
+	os.Unsetenv("KEY_HOME_ONLY")
+
+	loadDotEnv()
+
+	if got := os.Getenv("KEY_PRIMARY"); got != "from_credentials" {
+		t.Errorf("primary credentials file should win over home fallback: KEY_PRIMARY=%q", got)
+	}
+	if got := os.Getenv("KEY_HOME_ONLY"); got != "from_home" {
+		t.Errorf("home fallback should fill unset keys: KEY_HOME_ONLY=%q", got)
+	}
+	if got := os.Getenv("KEY_ENV"); got != "from_env" {
+		t.Errorf("process environment should win over home fallback: KEY_ENV=%q", got)
+	}
+}
+
+// TestLoadDotEnvFallsBackToAccountHomeEnv covers launchers/services that
+// override HOME: when $HOME has no .env, the OS account home's .env is probed.
+func TestLoadDotEnvFallsBackToAccountHomeEnv(t *testing.T) {
+	cwd := t.TempDir()
+	fakeHome := t.TempDir()
+	acctHome := t.TempDir()
+	credHome := t.TempDir()
+
+	t.Chdir(cwd)
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+	t.Setenv("REASONIX_HOME", credHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	prev := currentAccountHome
+	currentAccountHome = func() string { return acctHome }
+	t.Cleanup(func() { currentAccountHome = prev })
+
+	if err := os.WriteFile(filepath.Join(acctHome, ".env"), []byte("KEY_ACCT=from_account_home\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KEY_ACCT", "")
+	os.Unsetenv("KEY_ACCT")
+
+	loadDotEnv()
+
+	if got := os.Getenv("KEY_ACCT"); got != "from_account_home" {
+		t.Errorf("account home .env fallback not loaded: KEY_ACCT=%q want from_account_home", got)
+	}
+}
+
+// TestStoredCredentialValueFallsBackToHomeEnv pins the file-lookup side of
+// credential resolution (Validate/APIKey): a key absent from the Reasonix
+// credentials file resolves from the user home .env fallback.
+func TestStoredCredentialValueFallsBackToHomeEnv(t *testing.T) {
+	home := t.TempDir()
+	credHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("REASONIX_HOME", credHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	prev := currentAccountHome
+	currentAccountHome = func() string { return home }
+	t.Cleanup(func() { currentAccountHome = prev })
+
+	if err := os.WriteFile(filepath.Join(home, ".env"), []byte("KEY_LOOKUP=from_home\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	value, source, ok := storedCredentialValue("KEY_LOOKUP")
+	if !ok || value != "from_home" {
+		t.Fatalf("storedCredentialValue = %q,%v, want from_home,true", value, ok)
+	}
+	if source.Kind != CredentialSourceHomeEnv {
+		t.Fatalf("source kind = %q, want %q", source.Kind, CredentialSourceHomeEnv)
+	}
+	if _, _, ok := storedCredentialValue("KEY_MISSING"); ok {
+		t.Fatal("unknown key should not resolve")
+	}
+}
+
+// TestLoadDotEnvReadsGlobalCredentials proves `reasonix setup`'s target — the// reasonix-owned credentials file under Reasonix home — is loaded from any
 // working directory and wins over a project ./.env on a shared key.
 func TestLoadDotEnvReadsGlobalCredentials(t *testing.T) {
 	cwd := t.TempDir()


### PR DESCRIPTION
## Summary

The credential store only reads `<Reasonix home>/.env`. When Reasonix runs with `REASONIX_HOME` pointing elsewhere or with `HOME` overridden (launchers, systemd units that force `HOME` onto a config dir), provider keys stored in the user's real home are never found and every command fails with `missing env X_API_KEY` / HTTP 401.

This adds user-level fallback probes — `$HOME/.env` first, then the OS account home's `.env` (from the user database, unaffected by `HOME` overrides) — applied consistently in both credential paths:

- `loadCredentialStoreForRoot` sets fallback keys into the process env, never overriding the primary credentials file or existing env (fallback sources are not `credentials`-kind, so `loadDotEnvFileAs` skips already-set keys);
- `storedCredentialValue` resolves from the same fallback files, so `Validate`/`APIKey()` agree with the loader;
- `CredentialEnvNames` includes fallback-file keys so the subprocess secret filter keeps covering them.

Precedence: Reasonix credentials file > process environment > `$HOME/.env` > account home `.env`. The **project** `./.env` remains deliberately unimported — this change only adds *user-home* fallbacks.

**Note for reviewers:** this intentionally revisits the isolation asserted by the former `TestLoadDotEnvDoesNotImportProjectOrHomeEnv` (rewritten as `TestLoadDotEnvImportsHomeEnvFallbackButNotProjectEnv`). Project-.env isolation is preserved; only the user-home fallback semantics change. If you prefer this behind a config flag, say the word.

## Issues

Refs #7331 (same deployment family: overridden-HOME service installs)

## Verification

- Reproduced with `REASONIX_HOME` pointing at a dir without `.env` and the key present in `/root/.env`: before — `error: provider "deepseek-flash": missing env DEEPSEEK_API_KEY`; after — session starts and a real API call succeeds.
- Launcher-overridden-`HOME` scenario still resolves the primary credentials file first (unchanged).
- `go test ./internal/config/` passes, including new `TestLoadDotEnvHomeEnvFallbackPrecedence`, `TestLoadDotEnvFallsBackToAccountHomeEnv`, and `TestStoredCredentialValueFallsBackToHomeEnv`.

## Cache impact

Cache-impact: none — credential resolution only; no prompt or provider-visible surface changes.
Cache-guard: `go test ./internal/config/` (dotenv/credential suites above).
System-prompt-review: N/A