### PR TITLE
docs(acp): document session/set_config_option's parameters

### DIFF
--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -110,6 +110,25 @@ one mode selector:
 | Tool approval | `ask`, `auto`, `yolo` | `configOptions` with id `tool_approval` |
 
 Use `session/set_config_option` for model, effort, work mode, and tool approval.
+Its parameters are `sessionId`, `configId` and `value`, where `configId` is the
+`id` of the option as advertised in `configOptions`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "session-id",
+    "configId": "tool_approval",
+    "value": "yolo"
+  }
+}
+```
+
+Note that the field is `configId`, not `optionId`. The result is the full
+refreshed `configOptions` array. An unknown id returns `-32602 InvalidParams`.
+
 Model, effort, and work-mode changes rebuild the session controller while
 preserving its history and the other axes. Tool-approval changes update the
 gate without rebuilding the controller.

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -101,9 +101,28 @@ Reasonix 把互不相关的选择拆成独立控制轴，而不是混在一个 m
 | 工作模式 | `economy`、`balanced`、`delivery` | id 为 `work_mode` 的 `configOptions` |
 | 工具审批 | `ask`、`auto`、`yolo` | id 为 `tool_approval` 的 `configOptions` |
 
-模型、推理强度、工作模式和工具审批统一使用 `session/set_config_option`。切换模型、
-推理强度或工作模式时会重建会话 Controller，同时保留历史和其他控制轴；切换工具审批
-只更新 gate，不重建 Controller。
+模型、推理强度、工作模式和工具审批统一使用 `session/set_config_option`。它的参数是
+`sessionId`、`configId` 和 `value`，其中 `configId` 取 `configOptions` 中该选项的
+`id`：
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/set_config_option",
+  "params": {
+    "sessionId": "session-id",
+    "configId": "tool_approval",
+    "value": "yolo"
+  }
+}
+```
+
+注意字段名是 `configId`，不是 `optionId`。返回值是刷新后的完整 `configOptions`
+数组；id 未知时返回 `-32602 InvalidParams`。
+
+切换模型、推理强度或工作模式时会重建会话 Controller，同时保留历史和其他控制轴；
+切换工具审批只更新 gate，不重建 Controller。
 
 旧客户端仍可使用 `session/set_model`。`session/set_mode` 也继续接受 legacy 值
 `default` 和 `auto`，分别表示“常规 + 询问”和“常规 + Yolo”；新客户端应使用上面的


### PR DESCRIPTION
## What

Documents the request shape of `session/set_config_option` in `docs/ACP.md` and `docs/ACP.zh-CN.md`.

## Why

The **Session controls** section names the method and lists the option ids, but never says what the request body looks like. Writing an ACP client against it, the natural guess is `optionId` — you are setting an option, and the ids come from `configOptions` — and that guess fails in a way that points at the wrong thing:

```
-32602  session/set_config_option: unknown config option
```

The name is interpolated at the end of that string, so with the wrong field it is empty and the message reads as *"that option does not exist"* rather than *"you named the parameter wrong"*. Meanwhile `session/new` really is advertising the option:

```json
{"id": "tool_approval", "name": "Tool Approval", "category": "tool_approval",
 "type": "select", "currentValue": "ask",
 "options": [{"value": "ask"}, {"value": "auto"}, {"value": "yolo"}]}
```

The cost of getting it wrong is not cosmetic. `tool_approval` silently stays at `ask`, so an unattended host — CI, a bench harness, anything with no human at the keyboard — blocks on `session/request_permission` for every gated tool call instead of running. That is what happened to me, on v1.19.4, and it took reading `internal/acp/protocol.go` to find the answer:

```go
type SetSessionConfigOptionParams struct {
	SessionID string `json:"sessionId"`
	ConfigID  string `json:"configId"`
	Value     string `json:"value"`
}
```

## What changed

Both language versions get the parameter list, a worked example, an explicit "the field is `configId`, not `optionId`" note, and the result/error shapes. No behaviour change — docs only.

A separate, optional improvement I did not make here because it touches Go: `internal/acp/service.go:1191` could avoid the confusing message entirely by rejecting an empty `ConfigID` as "missing configId" rather than falling through to the unknown-option path. Happy to send that as a follow-up if you would like it.

Cache-impact: none — documentation only, no provider-visible prompt, tool schema, or serialization change.
Cache-guard: not applicable; no code paths touched.

## Context

Found while writing an ACP client that drives `reasonix acp` headlessly against self-hosted OpenAI-compatible models. Also filed #7357 and #7358 from the same integration work.
