### PR TITLE
Fix documentation code block layout / 修复文档代码块布局

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -4,6 +4,9 @@ import sitemap from '@astrojs/sitemap';
 // Served from the custom domain reasonix.io at the site root.
 export default defineConfig({
   site: 'https://reasonix.io',
+  // Documentation code samples intentionally use source newlines as content.
+  // Astro 7's JSX-style compression removes those newlines unless disabled.
+  compressHTML: false,
   build: { assets: 'static' },
   integrations: [sitemap({
     filter: (page) => !/\/changelog\/(?:stable|preview)\/?$/.test(page) &&

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -78,7 +78,7 @@ const goVer = 'latest';
 
       <h2 id="install"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></h2>
       <p><span class="l-en">Install the terminal app with one command on macOS, Linux, Windows, or WSL. <code>reasonix</code> opens the interactive TUI; <code>reasonix run</code> is the headless automation entry.</span><span class="l-zh">一条命令安装终端应用,支持 macOS、Linux、Windows 或 WSL。<code>reasonix</code> 打开交互式 TUI；<code>reasonix run</code> 用于无界面自动执行。</span></p>
-      <div class="codeblock"><button data-copy="npm i -g reasonix">Copy</button><span class="c"># npm (recommended · 推荐)</span>
+      <div class="codeblock codeblock--copy"><button data-copy="npm i -g reasonix">Copy</button><span class="c"># npm (recommended · 推荐)</span>
 npm i -g reasonix
 
 <span class="c"># Homebrew</span>
@@ -147,13 +147,13 @@ brew install esengine/reasonix/reasonix</div>
       </div>
       <h3 id="macos-quarantine"><span class="l-en">macOS quarantine warning</span><span class="l-zh">macOS 隔离属性提示</span></h3>
       <p><span class="l-en">Use this only when Reasonix was downloaded from the official site or GitHub release, moved to <code>/Applications</code>, and macOS still says the app cannot be opened, cannot be verified, or is damaged. This removes the quarantine flag that macOS attaches to downloaded apps.</span><span class="l-zh">仅在 Reasonix 来自官网或 GitHub Release、已经放入 <code>/Applications</code>,但 macOS 仍提示“无法打开”“无法验证开发者”或“应用已损坏”时使用。它会移除 macOS 给下载应用附加的隔离属性。</span></p>
-      <div class="codeblock"><button data-copy="sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app">Copy</button><span class="c"># Quit Reasonix first, then run in Terminal.</span>
+      <div class="codeblock codeblock--copy"><button data-copy="sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app">Copy</button><span class="c"># Quit Reasonix first, then run in Terminal.</span>
 sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app</div>
       <div class="callout"><span class="ico">!</span><span><span class="l-en">Only run this for an official Reasonix app you trust. If the app is installed somewhere else, replace <code>/Applications/Reasonix.app</code> with that exact app path, then reopen Reasonix.</span><span class="l-zh">只对可信的官方 Reasonix 应用执行这条命令。如果安装在其他位置,请把 <code>/Applications/Reasonix.app</code> 替换为实际 app 路径,然后重新打开 Reasonix。</span></span></div>
 
       <h2 id="quickstart"><span class="l-en">Quick start</span><span class="l-zh">快速上手</span></h2>
       <p><span class="l-en">First run is minimal — <code>reasonix setup</code> walks you through picking a provider and key, then saves it under Reasonix home. Then point Reasonix at a repo and start a session:</span><span class="l-zh">首次运行很简单——<code>reasonix setup</code> 引导你选择 provider 并填写密钥,然后保存到 Reasonix home。接着指向仓库、开始会话:</span></p>
-      <div class="codeblock"><button data-copy="cd your-project && reasonix">Copy</button>cd your-project
+      <div class="codeblock codeblock--copy"><button data-copy="cd your-project && reasonix">Copy</button>cd your-project
 reasonix</div>
       <p><span class="l-en">Then just describe the task:</span><span class="l-zh">然后直接描述任务:</span></p>
       <div class="codeblock"><span class="a">›</span> add retry with backoff to the http client
@@ -163,7 +163,7 @@ reasonix</div>
 
       <h2 id="serve"><span class="l-en">Web frontend</span><span class="l-zh">Web 前端</span></h2>
       <p><span class="l-en"><code>reasonix serve</code> starts the same local Reasonix engine behind a browser UI. Use it when you want a desktop-style surface without installing the desktop app, when running Reasonix on a remote development box through a tunnel, or when you want a shareable view of a live session.</span><span class="l-zh"><code>reasonix serve</code> 会用同一个本地 Reasonix 引擎启动浏览器 UI。适合不安装桌面端但想用可视化界面、在远程开发机上通过 tunnel 使用,或把当前会话临时共享给浏览器查看。</span></p>
-      <div class="codeblock"><button data-copy="cd your-project && reasonix serve">Copy</button>cd your-project
+      <div class="codeblock codeblock--copy"><button data-copy="cd your-project && reasonix serve">Copy</button>cd your-project
 reasonix serve
 <span class="c"># open http://127.0.0.1:8787</span></div>
       <div class="web-panel">
@@ -176,7 +176,7 @@ reasonix serve
         </ul>
       </div>
       <p><span class="l-en">The default listen address is <code>127.0.0.1:8787</code> with <code>auth_mode = "none"</code>. Keep that for local-only use. If the server is reachable from another machine, enable auth before sharing the URL.</span><span class="l-zh">默认监听 <code>127.0.0.1:8787</code>,认证模式是 <code>auth_mode = "none"</code>。这个默认值只适合本机使用；如果其他机器能访问,请先开启认证再分享 URL。</span></p>
-      <div class="codeblock"><button data-copy="reasonix serve --auth token">Copy</button><span class="c"># token auth prints a share URL with ?token=...</span>
+      <div class="codeblock codeblock--copy"><button data-copy="reasonix serve --auth token">Copy</button><span class="c"># token auth prints a share URL with ?token=...</span>
 reasonix serve --auth token
 reasonix serve --addr 0.0.0.0:8787 --auth token
 
@@ -191,7 +191,7 @@ behind_proxy = true    <span class="c"># only behind a trusted reverse proxy</sp
 
       <h2 id="config"><span class="l-en">Configuration</span><span class="l-zh">配置</span></h2>
       <p><span class="l-en">Reasonix talks directly to configured OpenAI-compatible providers such as DeepSeek or MiMo with your own API keys. Provider config stores only the key name in <code>api_key_env</code>; the actual secret saved by <code>reasonix setup</code> or desktop Settings lives in the global <code>&lt;Reasonix home&gt;/.env</code>.</span><span class="l-zh">Reasonix 使用你自己的 API Key 直连配置好的 OpenAI-compatible provider,例如 DeepSeek 或 MiMo。Provider 配置只在 <code>api_key_env</code> 里记录密钥名称；通过 <code>reasonix setup</code> 或桌面端设置保存的真实密钥会写入全局 <code>&lt;Reasonix home&gt;/.env</code>。</span></p>
-      <div class="codeblock"><button data-copy="reasonix setup">Copy</button>reasonix setup
+      <div class="codeblock codeblock--copy"><button data-copy="reasonix setup">Copy</button>reasonix setup
 <span class="c"># saves provider keys to &lt;Reasonix home&gt;/.env, for example:</span>
 DEEPSEEK_API_KEY=sk-...</div>
       <p><span class="l-en">Project <code>.env</code> files are not provider-key fallbacks. They are only used for workspace-scoped variable expansion in MCP/plugin settings. Persistent options live in the <a href="#configfile">config file</a>.</span><span class="l-zh">项目 <code>.env</code> 不是 provider key 的 fallback。它只用于 MCP/plugin 配置里的工作区级变量展开。持久化选项见<a href="#configfile">配置文件</a>。</span></p>
@@ -227,7 +227,7 @@ headers = &#123; Authorization = "Bearer $&#123;STRIPE_KEY&#125;" &#125;</div>
 
       <h2 id="acp"><span class="l-en">Editor integration (ACP)</span><span class="l-zh">编辑器接入（ACP）</span></h2>
       <p><span class="l-en">Reasonix implements Agent Client Protocol (ACP) v1 as an NDJSON JSON-RPC 2.0 agent over stdio. An ACP-compatible editor or host starts <code>reasonix acp</code>, opens workspace-scoped sessions, and receives streamed messages, tool activity, plans, permission requests, and configuration updates.</span><span class="l-zh">Reasonix 实现了 Agent Client Protocol（ACP）v1，通过 stdio 提供 NDJSON JSON-RPC 2.0 agent。兼容 ACP 的编辑器或 host 启动 <code>reasonix acp</code>、打开工作区会话，并接收流式消息、工具活动、计划、权限请求和配置更新。</span></p>
-      <div class="codeblock"><button data-copy="reasonix acp">Copy</button>reasonix acp                    <span class="c"># use the configured default model</span>
+      <div class="codeblock codeblock--copy"><button data-copy="reasonix acp">Copy</button>reasonix acp                    <span class="c"># use the configured default model</span>
 reasonix acp --model &lt;name&gt;     <span class="c"># choose the startup model</span>
 reasonix acp --profile delivery <span class="c"># economy | balanced | delivery</span></div>
       <div class="doc-choice-grid">

--- a/site/src/scripts/docs-codeblock-contract.test.mjs
+++ b/site/src/scripts/docs-codeblock-contract.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const configSource = () => readFile(new URL("../../astro.config.mjs", import.meta.url), "utf8");
+const docsSource = () => readFile(new URL("../pages/docs.astro", import.meta.url), "utf8");
+const stylesSource = () => readFile(new URL("../styles/global.css", import.meta.url), "utf8");
+
+test("Astro preserves documentation code sample newlines", async () => {
+  const config = await configSource();
+
+  assert.match(config, /compressHTML:\s*false/);
+});
+
+test("copyable documentation code blocks reserve space for their buttons", async () => {
+  const [page, styles] = await Promise.all([docsSource(), stylesSource()]);
+  const codeblocks = [...page.matchAll(/<div class="([^"]*\bcodeblock\b[^"]*)">([\s\S]*?)<\/div>/g)];
+  const copyable = codeblocks.filter(([, , body]) => body.includes("data-copy="));
+
+  assert.ok(copyable.length > 0);
+  for (const [, classes] of copyable) {
+    assert.match(classes, /(?:^|\s)codeblock--copy(?:\s|$)/);
+  }
+  assert.match(styles, /\.codeblock--copy\s*\{\s*padding-top:\s*52px;\s*\}/);
+});
+
+test("the macOS quarantine comment and command remain separate source lines", async () => {
+  const page = await docsSource();
+
+  assert.match(
+    page,
+    /# Quit Reasonix first, then run in Terminal\.<\/span>\nsudo xattr -rd com\.apple\.quarantine \/Applications\/Reasonix\.app/,
+  );
+});

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -828,6 +828,7 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
   font-family: var(--font-mono); font-size: 13.5px; line-height: 1.85;
   color: oklch(0.9 0.004 260); overflow-x: auto; white-space: pre;
 }
+.codeblock--copy { padding-top: 52px; }
 .codeblock .c { color: oklch(0.58 0.008 260); }
 .codeblock .a { color: var(--acc-1); }
 .codeblock button {


### PR DESCRIPTION
## Summary

- Preserve the intentional source newlines in all 15 documentation code blocks after the Astro 7 upgrade.
- Reserve a dedicated action area for all 7 copyable code blocks so the Copy button cannot cover code at narrow widths.
- Add regression contracts for whitespace preservation, copyable-block layout, and the macOS quarantine command.

## Root cause

Astro 7 defaults to JSX-style HTML compression. The documentation code blocks use source newlines as preformatted content, so the compiler removed the separators between commands, comments, prompts, and configuration lines. The absolutely positioned Copy button then shared the same visual row as the collapsed content.

## User impact

Commands and configuration examples render on their intended lines again. Copy buttons remain visible without obscuring text, while genuinely long lines continue to scroll inside their own code block instead of widening the page.

## Verification

- `cd site && npm test` — 51/51 passed.
- `cd site && npm run build` — 38 pages built successfully.
- Browser geometry at 1280×720 — all 15 code blocks retained their intended line counts, 0 button/text overlaps, and no page-level horizontal overflow.
- Browser geometry at 390×844 — the same line counts and 0 overlaps; long lines scroll only inside their code blocks.
- Current-production comparison for `/docs/`: raw HTML changed from 58,540 to 60,640 bytes, while gzip size measured 19,528 versus 19,409 bytes locally, so the whitespace restoration did not introduce a measured transfer-size increase.

## Compatibility and risk

| Area | Behavior | Conclusion |
| --- | --- | --- |
| Persisted data and config | No runtime or persisted Reasonix formats changed | Compatible |
| Provider prompt/cache | Site-only markup, CSS, and tests | No cache impact |
| Security | Existing copy payloads and command text are unchanged | No new security boundary |
| Site output | `compressHTML: false` restores pre-Astro-7 whitespace semantics across static pages | Full production build passed; docs transfer size remained effectively unchanged |
