### PR TITLE
Fix lazy Settings CSS test loading / 修复设置懒加载 CSS 测试

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -284,7 +284,7 @@ function NoticePreviewPanel() {
 }
 
 const HistoryPanel = lazy(() => import("./components/HistoryPanel").then((module) => ({ default: module.HistoryPanel })));
-const SettingsPanel = lazy(() => import("./components/SettingsPanel").then((module) => ({ default: module.SettingsPanel })));
+const SettingsPanel = lazy(() => import("./components/SettingsPanelEntry").then((module) => ({ default: module.SettingsPanel })));
 const RemotePanel = lazy(() => import("./components/RemotePanel").then((module) => ({ default: module.RemotePanel })));
 const TerminalPanel = lazy(() => import("./components/TerminalPanel").then((module) => ({ default: module.TerminalPanel })));
 

--- a/desktop/frontend/src/__tests__/bundle-contract.test.ts
+++ b/desktop/frontend/src/__tests__/bundle-contract.test.ts
@@ -20,6 +20,7 @@ function ok(cond: boolean, label: string) {
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
 const projectTreeSource = readFileSync(resolve(here, "../components/ProjectTree.tsx"), "utf8");
+const settingsEntrySource = readFileSync(resolve(here, "../components/SettingsPanelEntry.tsx"), "utf8");
 const settingsSource = readFileSync(resolve(here, "../components/SettingsPanel.tsx"), "utf8");
 const markdownSource = readFileSync(resolve(here, "../components/Markdown.tsx"), "utf8");
 const i18nSource = readFileSync(resolve(here, "../lib/i18n.tsx"), "utf8");
@@ -42,9 +43,15 @@ ok(
   "App keeps secondary drawers out of the initial chunk",
 );
 ok(
-  appSource.includes('import("./components/SettingsPanel")') &&
+  appSource.includes('import("./components/SettingsPanelEntry")') &&
     appSource.includes('import("./components/HistoryPanel")'),
   "App loads secondary drawers on demand",
+);
+ok(
+  settingsEntrySource.includes('import "./CompactRatioSettings.css"') &&
+    settingsEntrySource.includes('from "./SettingsPanel"') &&
+    !settingsSource.includes('import "./CompactRatioSettings.css"'),
+  "Settings CSS stays in the lazy production entry without breaking direct module tests",
 );
 ok(
   !appSource.includes("openAllHistory") &&

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,6 +1,5 @@
 import { lazy, memo, Suspense, startTransition, useCallback, useDeferredValue, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
 import { Bot as BotIcon, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, ExternalLink, GripVertical, KeyRound, Loader2, MessageCircle, Play, QrCode, RefreshCw, Send } from "lucide-react";
-import "./CompactRatioSettings.css";
 import { asArray } from "../lib/array";
 import { useDeferredClose } from "../lib/useMountTransition";
 import { app, openExternal } from "../lib/bridge";

--- a/desktop/frontend/src/components/SettingsPanelEntry.tsx
+++ b/desktop/frontend/src/components/SettingsPanelEntry.tsx
@@ -1,0 +1,3 @@
+import "./CompactRatioSettings.css";
+
+export { SettingsPanel } from "./SettingsPanel";


### PR DESCRIPTION
## Summary

- keep the compaction settings stylesheet in the lazy production chunk
- move the CSS side effect out of the reusable SettingsPanel module so direct TSX tests and SubagentsPanel imports do not require a Node CSS loader
- extend the bundle contract to lock both properties

## Issues

Release-blocking regression found during v1.19.5 candidate validation.

## Verification

- `pnpm --dir desktop/frontend test:all`
- `pnpm --dir desktop/frontend build`
- focused SettingsPanel direct/import-path tests
- `git diff --check`

## Cache impact

Cache-impact: none - this changes only the frontend lazy module boundary and does not affect provider-visible prompts, tool schemas, ordering, or request serialization.
Cache-guard: `./scripts/cache-guard.sh` passed during v1.19.5 candidate validation.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior changed.