### PR TITLE
docs: add Trendshift achievement badge / 文档：添加 Trendshift 成就徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@
   <a href="https://discord.gg/XF78rEME2D"><img src="https://img.shields.io/badge/discord-join-5865F2.svg?style=flat-square&labelColor=161b22&logo=discord&logoColor=white" alt="Discord"/></a>
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/27020"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/daily" alt="#2 Repository Of The Day"/></a>
+</p>
+
 <br/>
 
 <h3 align="center">A DeepSeek-native AI coding agent for your terminal.</h3>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,10 @@
   <a href="https://discord.gg/XF78rEME2D"><img src="https://img.shields.io/badge/discord-join-5865F2.svg?style=flat-square&labelColor=161b22&logo=discord&logoColor=white" alt="Discord"/></a>
 </p>
 
+<p align="center">
+  <a href="https://trendshift.io/repositories/27020"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/daily" alt="#2 Repository Of The Day"/></a>
+</p>
+
 <br/>
 
 <h3 align="center">面向终端的 DeepSeek 原生 AI coding agent。</h3>


### PR DESCRIPTION
## Summary

- Add the official Trendshift #2 Repository Of The Day achievement badge to the English and Chinese README pages.
- Link the badge to the Reasonix repository profile on Trendshift.

## Verification

- git diff --check
- Confirmed the badge endpoint returns HTTP 200 with image/svg+xml.
- Rendered the latest local README and confirmed the 250 x 55 badge loads successfully.

## Compatibility

| Field / surface | Old-data behavior | Conclusion |
| --- | --- | --- |
| README markup only | No runtime or persisted data is read or written | Backward-compatible |

No source code, configuration, runtime behavior, or persisted formats are changed.