### PR TITLE
docs(release): 准备 v1.19.5 中英更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -2,6 +2,427 @@
   "schemaVersion": 1,
   "releases": [
     {
+      "version": "1.19.5",
+      "date": "2026-08-03",
+      "channel": "stable",
+      "title": {
+        "en": "Usage insights, configurable compaction, and safer session recovery",
+        "zh": "用量洞察、可配置压缩与更安全的会话恢复"
+      },
+      "summary": {
+        "en": "This release adds product-wide usage statistics, configurable context-compaction thresholds, opt-in server-side web search for Anthropic-compatible providers, and terminal theme controls. It also hardens session replay and recovery, secures custom system-prompt loading, honors provider-declared reasoning efforts, and improves CLI, updater, Serve, Remote Workbench, and documentation reliability.",
+        "zh": "此版本新增全产品用量统计、可配置的上下文压缩阈值、Anthropic 兼容提供商的可选服务端网页搜索，以及终端主题控制。同时加强会话重放与恢复安全，保护自定义系统提示词加载，尊重提供商声明的推理强度，并提升 CLI、更新器、Serve、Remote Workbench 与文档的可靠性。"
+      },
+      "surfaces": [
+        "desktop",
+        "cli",
+        "serve",
+        "provider",
+        "bot",
+        "remote",
+        "site"
+      ],
+      "guides": [
+        {
+          "title": {
+            "en": "Reasonix CLI guide",
+            "zh": "Reasonix CLI 指南"
+          },
+          "body": {
+            "en": "Configure and inspect the context-compaction threshold from the command line.",
+            "zh": "从命令行配置并查看上下文压缩阈值。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/bf0be67b7c4fa321ce4c57a5b39e31f32251095a/docs/CLI.md"
+        },
+        {
+          "title": {
+            "en": "Reasonix specification",
+            "zh": "Reasonix 规范文档"
+          },
+          "body": {
+            "en": "Review the configuration and provider behavior documented for this release.",
+            "zh": "查看本版本记录的配置与提供商行为。"
+          },
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/bf0be67b7c4fa321ce4c57a5b39e31f32251095a/docs/SPEC.md"
+        }
+      ],
+      "highlights": [
+        {
+          "kind": "new",
+          "title": {
+            "en": "Product-wide usage statistics",
+            "zh": "全产品用量统计"
+          },
+          "body": {
+            "en": "Desktop Settings now shows daily token usage, requests, sessions, cache hit rate, activity heatmaps, trends, and model breakdowns across Desktop, CLI, Serve, bots, and Remote Workbench, with source and date filters.",
+            "zh": "桌面端设置现在可按来源与日期查看桌面端、CLI、Serve、机器人和 Remote Workbench 的每日 token 用量、请求数、会话数、缓存命中率、活跃热力图、趋势与模型分布。"
+          },
+          "refs": [
+            7238
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Configurable context compaction",
+            "zh": "可配置的上下文压缩阈值"
+          },
+          "body": {
+            "en": "Choose guarded 70%, 80%, or 85% presets, or a custom 65%–85% threshold, from Desktop or the new `reasonix config compact-ratio` command. Project overrides and effective configuration sources are shown explicitly.",
+            "zh": "可在桌面端或新的 `reasonix config compact-ratio` 命令中选择受保护的 70%、80%、85% 预设，或 65%–85% 的自定义阈值，并明确显示项目覆盖与有效配置来源。"
+          },
+          "refs": [
+            7233
+          ]
+        },
+        {
+          "kind": "new",
+          "title": {
+            "en": "Opt-in server-side web search",
+            "zh": "可选的服务端网页搜索"
+          },
+          "body": {
+            "en": "Anthropic-compatible providers can opt into the typed server-side web-search tool with `web_search = true`; search results stream back into the transcript without adding a search backend to Reasonix core.",
+            "zh": "Anthropic 兼容提供商可通过 `web_search = true` 启用类型化的服务端网页搜索工具；搜索结果会流式写入会话，无需在 Reasonix 核心中引入搜索后端。"
+          },
+          "refs": [
+            7340
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Bounded, data-preserving session replay",
+            "zh": "有界且保留数据的会话重放"
+          },
+          "body": {
+            "en": "Native event-log replay now enforces byte, record, and message budgets before constructing unbounded message graphs. Oversized logs fail closed without truncating authoritative history, and Desktop surfaces pinned-session load failures instead of opening a blank replacement.",
+            "zh": "原生事件日志重放现在会在构造无界消息图之前限制字节数、记录数和消息数。超限日志会安全拒绝且不截断权威历史，桌面端也会显示固定会话加载失败，而不是静默打开空白替代会话。"
+          },
+          "refs": [
+            7335
+          ]
+        },
+        {
+          "kind": "security",
+          "title": {
+            "en": "Safer configuration and repository boundaries",
+            "zh": "更安全的配置与仓库边界"
+          },
+          "body": {
+            "en": "Project-selected system-prompt files are confined to the workspace while trusted user configuration retains safe fallback behavior. Verification links now use the configured origin, session ancestry rejects traversal identifiers, and internal Git inspection uses a shared hardened invocation baseline.",
+            "zh": "项目选择的系统提示词文件现在被限制在工作区内，可信用户配置仍保留安全的降级路径。验证链接改用已配置的来源，会话祖先链拒绝路径穿越标识符，内部 Git 检查也统一使用加固后的调用基线。"
+          },
+          "refs": [
+            7353,
+            7341,
+            7343
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Reliable recovery ownership for bots and sessions",
+            "zh": "可靠的机器人与会话恢复所有权"
+          },
+          "body": {
+            "en": "IM bots now hand off writer leases and mappings atomically when conflict recovery changes the transcript path. Serve titles remain stable across ordinary appends but refresh after a turn-zero rewind, and Remote Workbench listeners stop promptly when canceled.",
+            "zh": "IM 机器人在冲突恢复切换会话路径时会原子交接写入租约与映射。Serve 标题在普通追加后保持缓存，但在第零轮回退后会正确刷新；Remote Workbench 监听器也会在取消时及时退出。"
+          },
+          "refs": [
+            7351,
+            7349,
+            7321
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
+            "en": "Provider-declared reasoning efforts are honored",
+            "zh": "尊重提供商声明的推理强度"
+          },
+          "body": {
+            "en": "Generic OpenAI-compatible and DeepSeek-thinking endpoints now validate against an explicit `supported_efforts` list, preserving declared custom values while keeping existing defaults and undeclared-provider guardrails unchanged.",
+            "zh": "通用 OpenAI 兼容端点和 DeepSeek thinking 端点现在会按显式 `supported_efforts` 列表校验，保留声明的自定义取值，同时不改变既有默认值与未声明提供商的保护规则。"
+          },
+          "refs": [
+            7328,
+            7350
+          ]
+        },
+        {
+          "kind": "improved",
+          "title": {
+            "en": "Terminal themes and clearer recovery controls",
+            "zh": "终端主题与更清晰的恢复控制"
+          },
+          "body": {
+            "en": "Terminal sessions can follow the app theme or use explicit light and dark palettes, including live updates. Update failures now distinguish retryable, recovery, and manual paths and keep the official signed-installer fallback visible.",
+            "zh": "终端会话可跟随应用主题，或显式使用浅色与深色调色板，并支持实时更新。更新失败现在会区分可重试、恢复与手动处理路径，并持续显示官方签名安装包的降级入口。"
+          },
+          "refs": [
+            7210,
+            7336
+          ]
+        }
+      ],
+      "changes": {
+        "new": [
+          {
+            "title": {
+              "en": "Usage statistics dashboard",
+              "zh": "用量统计面板"
+            },
+            "body": {
+              "en": "Added durable daily JSONL usage recording and a filterable Desktop dashboard with heatmaps, trends, cache hit rate, and model attribution.",
+              "zh": "新增持久化的每日 JSONL 用量记录，以及带热力图、趋势、缓存命中率和模型归属的可筛选桌面端面板。"
+            },
+            "refs": [
+              7238
+            ]
+          },
+          {
+            "title": {
+              "en": "Context-compaction controls",
+              "zh": "上下文压缩控制"
+            },
+            "body": {
+              "en": "Added Desktop and CLI controls for guarded compaction thresholds while retaining 80% as the default.",
+              "zh": "新增桌面端与 CLI 的受保护压缩阈值控制，同时保留 80% 默认值。"
+            },
+            "refs": [
+              7233
+            ]
+          },
+          {
+            "title": {
+              "en": "Anthropic-compatible web search",
+              "zh": "Anthropic 兼容网页搜索"
+            },
+            "body": {
+              "en": "Added an opt-in typed server tool for provider-side web search and readable streamed result links.",
+              "zh": "新增可选的提供商侧网页搜索类型化服务端工具，并以可读链接流式显示结果。"
+            },
+            "refs": [
+              7340
+            ]
+          }
+        ],
+        "improved": [
+          {
+            "title": {
+              "en": "Terminal appearance",
+              "zh": "终端外观"
+            },
+            "body": {
+              "en": "Added persisted follow-app, light, and dark terminal themes that update existing sessions live.",
+              "zh": "新增可持久化的跟随应用、浅色和深色终端主题，并实时更新已有会话。"
+            },
+            "refs": [
+              7210
+            ]
+          },
+          {
+            "title": {
+              "en": "CLI flag behavior",
+              "zh": "CLI 参数行为"
+            },
+            "body": {
+              "en": "Unified malformed-flag and help handling, and made both documented argument orders work for `remote connect`.",
+              "zh": "统一错误参数与帮助请求处理，并让 `remote connect` 支持文档中的两种参数顺序。"
+            },
+            "refs": [
+              7311
+            ]
+          },
+          {
+            "title": {
+              "en": "Diagnostics and telemetry signals",
+              "zh": "诊断与遥测信号"
+            },
+            "body": {
+              "en": "Improved hang diagnostics and split provider HTTP 400 telemetry into fixed, privacy-safe cause categories without copying provider messages into labels.",
+              "zh": "改进卡顿诊断，并将提供商 HTTP 400 遥测拆分为固定且保护隐私的原因类别，不会把提供商消息复制到标签中。"
+            },
+            "refs": [
+              7327,
+              7316
+            ]
+          }
+        ],
+        "fixed": [
+          {
+            "title": {
+              "en": "Session replay and recovery",
+              "zh": "会话重放与恢复"
+            },
+            "body": {
+              "en": "Bounded native event-log replay, preserved hard load errors, and aligned bot recovery paths with their leases and connection mappings.",
+              "zh": "限制原生事件日志重放，保留硬加载错误，并让机器人恢复路径与租约及连接映射保持一致。"
+            },
+            "refs": [
+              7335,
+              7351
+            ]
+          },
+          {
+            "title": {
+              "en": "System-prompt file fallback",
+              "zh": "系统提示词文件降级"
+            },
+            "body": {
+              "en": "Missing allowed prompt files now fall back with a warning, while project path escapes and non-missing I/O failures fail closed.",
+              "zh": "允许位置中的提示词文件缺失时会警告并降级，而项目路径越界和非缺失类 I/O 错误会安全失败。"
+            },
+            "refs": [
+              7353
+            ]
+          },
+          {
+            "title": {
+              "en": "Reasoning effort compatibility",
+              "zh": "推理强度兼容性"
+            },
+            "body": {
+              "en": "Explicit provider effort vocabularies now override built-in validation without weakening undeclared-provider defaults.",
+              "zh": "显式提供商推理强度词表现在可覆盖内置校验，同时不会削弱未声明提供商的默认保护。"
+            },
+            "refs": [
+              7328,
+              7350
+            ]
+          },
+          {
+            "title": {
+              "en": "Serve titles, deletes, rewinds, and transient markup",
+              "zh": "Serve 标题、删除、回退与瞬态标记"
+            },
+            "body": {
+              "en": "Stabilized title generation and caching, surfaced session-delete failures, removed composed controller markup from rewind labels, and unified transient-block stripping.",
+              "zh": "稳定标题生成与缓存，显示会话删除失败，从回退标签中移除控制器组合标记，并统一瞬态块清理。"
+            },
+            "refs": [
+              7349,
+              7334,
+              7346,
+              7345
+            ]
+          },
+          {
+            "title": {
+              "en": "Desktop settings layout and lazy loading",
+              "zh": "桌面端设置布局与懒加载"
+            },
+            "body": {
+              "en": "Long permission rules wrap without hiding delete controls, and Settings CSS remains lazy-loaded without breaking direct component tests.",
+              "zh": "较长的权限规则会自动换行且不再遮挡删除按钮，设置 CSS 也保持懒加载且不会破坏组件直接测试。"
+            },
+            "refs": [
+              7320,
+              7361
+            ]
+          },
+          {
+            "title": {
+              "en": "Updater, Remote Workbench, and documentation reliability",
+              "zh": "更新器、Remote Workbench 与文档可靠性"
+            },
+            "body": {
+              "en": "Added actionable update recovery paths, stopped canceled Workbench listeners promptly, and restored line breaks and copy-button clearance in documentation code blocks.",
+              "zh": "新增可操作的更新恢复路径，让取消后的 Workbench 监听器及时退出，并恢复文档代码块换行及复制按钮的安全间距。"
+            },
+            "refs": [
+              7336,
+              7321,
+              7360
+            ]
+          },
+          {
+            "title": {
+              "en": "Verification links and session lineage paths",
+              "zh": "验证链接与会话祖先链路径"
+            },
+            "body": {
+              "en": "Verification emails now use the configured application origin, and session ancestry rejects traversal-shaped identifiers before path construction.",
+              "zh": "验证邮件现在使用已配置的应用来源，会话祖先链也会在构造路径前拒绝路径穿越形态的标识符。"
+            },
+            "refs": [
+              7341
+            ]
+          }
+        ]
+      },
+      "upgrade": [
+        {
+          "level": "info",
+          "title": {
+            "en": "Usage history starts with this release",
+            "zh": "用量历史从本版本开始"
+          },
+          "body": {
+            "en": "Historical token usage was not previously persisted, so the new statistics dashboard begins accumulating data after upgrading to v1.19.5.",
+            "zh": "此前未持久化历史 token 用量，因此新的统计面板会从升级到 v1.19.5 后开始累计数据。"
+          },
+          "refs": [
+            7238
+          ]
+        },
+        {
+          "level": "warning",
+          "title": {
+            "en": "Project prompt files must stay inside the workspace",
+            "zh": "项目提示词文件必须位于工作区内"
+          },
+          "body": {
+            "en": "A project-level `system_prompt_file` that is absolute, contains `..`, or escapes through a symlink is now rejected. Move the file into the workspace or configure the path in trusted user configuration.",
+            "zh": "项目级 `system_prompt_file` 若为绝对路径、包含 `..` 或通过符号链接越出工作区，现在会被拒绝。请将文件移入工作区，或在可信用户配置中设置该路径。"
+          },
+          "refs": [
+            7353
+          ]
+        }
+      ],
+      "risks": [
+        {
+          "title": {
+            "en": "Web-search usage visibility",
+            "zh": "网页搜索用量可见性"
+          },
+          "body": {
+            "en": "When `web_search = true` is enabled, provider-side searches and returned result text can add metered search requests and input tokens; those search-request counts are not yet surfaced in Reasonix's cost pipeline.",
+            "zh": "启用 `web_search = true` 后，提供商侧搜索及返回的结果文本可能增加计费搜索请求与输入 token；这些搜索请求次数尚未显示在 Reasonix 成本管线中。"
+          },
+          "refs": [
+            7340
+          ]
+        }
+      ],
+      "contributors": [
+        "HaoyueQin",
+        "Li-Charles-One",
+        "Nath-Vikky",
+        "SivanCola",
+        "SprayHank",
+        "esengine",
+        "jackie-cqz",
+        "skyzhao1223"
+      ],
+      "links": {
+        "github": "https://github.com/esengine/DeepSeek-Reasonix/releases/tag/desktop-v1.19.5",
+        "compare": "https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.19.4...desktop-v1.19.5",
+        "download": "https://reasonix.io/?download=desktop&channel=stable#start"
+      },
+      "releaseId": "1.19.5",
+      "baseVersion": "1.19.5",
+      "status": "reviewed",
+      "previousRelease": "1.19.4",
+      "builds": {
+        "cli": "v1.19.5",
+        "desktop": "v1.19.5",
+        "npm": "1.19.5"
+      }
+    },
+    {
       "version": "1.19.4",
       "date": "2026-08-03",
       "channel": "stable",


### PR DESCRIPTION
> 此版本新增全产品用量统计、可配置的上下文压缩阈值、Anthropic 兼容提供商的可选服务端网页搜索，以及终端主题控制。同时加强会话重放与恢复安全，保护自定义系统提示词加载，尊重提供商声明的推理强度，并提升 CLI、更新器、Serve、Remote Workbench 与文档的可靠性。

**发布渠道：稳定版 · v1.19.5**

[English →](https://reasonix.io/changelog/v1.19.5/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v1.19.5/)

## 使用攻略

- [**Reasonix CLI 指南**](https://github.com/esengine/DeepSeek-Reasonix/blob/bf0be67b7c4fa321ce4c57a5b39e31f32251095a/docs/CLI.md) — 从命令行配置并查看上下文压缩阈值。
- [**Reasonix 规范文档**](https://github.com/esengine/DeepSeek-Reasonix/blob/bf0be67b7c4fa321ce4c57a5b39e31f32251095a/docs/SPEC.md) — 查看本版本记录的配置与提供商行为。

## 概览

**Reasonix v1.19.5 — 用量洞察、可配置压缩与更安全的会话恢复**

此版本新增全产品用量统计、可配置的上下文压缩阈值、Anthropic 兼容提供商的可选服务端网页搜索，以及终端主题控制。同时加强会话重放与恢复安全，保护自定义系统提示词加载，尊重提供商声明的推理强度，并提升 CLI、更新器、Serve、Remote Workbench 与文档的可靠性。

发布日期：2026-08-03

## 重点内容

- **全产品用量统计** — 桌面端设置现在可按来源与日期查看桌面端、CLI、Serve、机器人和 Remote Workbench 的每日 token 用量、请求数、会话数、缓存命中率、活跃热力图、趋势与模型分布。 ([#7238](https://github.com/esengine/DeepSeek-Reasonix/pull/7238))
- **可配置的上下文压缩阈值** — 可在桌面端或新的 `reasonix config compact-ratio` 命令中选择受保护的 70%、80%、85% 预设，或 65%–85% 的自定义阈值，并明确显示项目覆盖与有效配置来源。 ([#7233](https://github.com/esengine/DeepSeek-Reasonix/pull/7233))
- **可选的服务端网页搜索** — Anthropic 兼容提供商可通过 `web_search = true` 启用类型化的服务端网页搜索工具；搜索结果会流式写入会话，无需在 Reasonix 核心中引入搜索后端。 ([#7340](https://github.com/esengine/DeepSeek-Reasonix/pull/7340))
- **有界且保留数据的会话重放** — 原生事件日志重放现在会在构造无界消息图之前限制字节数、记录数和消息数。超限日志会安全拒绝且不截断权威历史，桌面端也会显示固定会话加载失败，而不是静默打开空白替代会话。 ([#7335](https://github.com/esengine/DeepSeek-Reasonix/pull/7335))
- **更安全的配置与仓库边界** — 项目选择的系统提示词文件现在被限制在工作区内，可信用户配置仍保留安全的降级路径。验证链接改用已配置的来源，会话祖先链拒绝路径穿越标识符，内部 Git 检查也统一使用加固后的调用基线。 ([#7353](https://github.com/esengine/DeepSeek-Reasonix/pull/7353), [#7341](https://github.com/esengine/DeepSeek-Reasonix/pull/7341), [#7343](https://github.com/esengine/DeepSeek-Reasonix/pull/7343))
- **可靠的机器人与会话恢复所有权** — IM 机器人在冲突恢复切换会话路径时会原子交接写入租约与映射。Serve 标题在普通追加后保持缓存，但在第零轮回退后会正确刷新；Remote Workbench 监听器也会在取消时及时退出。 ([#7351](https://github.com/esengine/DeepSeek-Reasonix/pull/7351), [#7349](https://github.com/esengine/DeepSeek-Reasonix/pull/7349), [#7321](https://github.com/esengine/DeepSeek-Reasonix/pull/7321))
- **尊重提供商声明的推理强度** — 通用 OpenAI 兼容端点和 DeepSeek thinking 端点现在会按显式 `supported_efforts` 列表校验，保留声明的自定义取值，同时不改变既有默认值与未声明提供商的保护规则。 ([#7328](https://github.com/esengine/DeepSeek-Reasonix/pull/7328), [#7350](https://github.com/esengine/DeepSeek-Reasonix/pull/7350))
- **终端主题与更清晰的恢复控制** — 终端会话可跟随应用主题，或显式使用浅色与深色调色板，并支持实时更新。更新失败现在会区分可重试、恢复与手动处理路径，并持续显示官方签名安装包的降级入口。 ([#7210](https://github.com/esengine/DeepSeek-Reasonix/pull/7210), [#7336](https://github.com/esengine/DeepSeek-Reasonix/pull/7336))

## 新功能

- **用量统计面板** — 新增持久化的每日 JSONL 用量记录，以及带热力图、趋势、缓存命中率和模型归属的可筛选桌面端面板。 ([#7238](https://github.com/esengine/DeepSeek-Reasonix/pull/7238))
- **上下文压缩控制** — 新增桌面端与 CLI 的受保护压缩阈值控制，同时保留 80% 默认值。 ([#7233](https://github.com/esengine/DeepSeek-Reasonix/pull/7233))
- **Anthropic 兼容网页搜索** — 新增可选的提供商侧网页搜索类型化服务端工具，并以可读链接流式显示结果。 ([#7340](https://github.com/esengine/DeepSeek-Reasonix/pull/7340))

## 改进

- **终端外观** — 新增可持久化的跟随应用、浅色和深色终端主题，并实时更新已有会话。 ([#7210](https://github.com/esengine/DeepSeek-Reasonix/pull/7210))
- **CLI 参数行为** — 统一错误参数与帮助请求处理，并让 `remote connect` 支持文档中的两种参数顺序。 ([#7311](https://github.com/esengine/DeepSeek-Reasonix/pull/7311))
- **诊断与遥测信号** — 改进卡顿诊断，并将提供商 HTTP 400 遥测拆分为固定且保护隐私的原因类别，不会把提供商消息复制到标签中。 ([#7327](https://github.com/esengine/DeepSeek-Reasonix/pull/7327), [#7316](https://github.com/esengine/DeepSeek-Reasonix/pull/7316))

## 修复

- **会话重放与恢复** — 限制原生事件日志重放，保留硬加载错误，并让机器人恢复路径与租约及连接映射保持一致。 ([#7335](https://github.com/esengine/DeepSeek-Reasonix/pull/7335), [#7351](https://github.com/esengine/DeepSeek-Reasonix/pull/7351))
- **系统提示词文件降级** — 允许位置中的提示词文件缺失时会警告并降级，而项目路径越界和非缺失类 I/O 错误会安全失败。 ([#7353](https://github.com/esengine/DeepSeek-Reasonix/pull/7353))
- **推理强度兼容性** — 显式提供商推理强度词表现在可覆盖内置校验，同时不会削弱未声明提供商的默认保护。 ([#7328](https://github.com/esengine/DeepSeek-Reasonix/pull/7328), [#7350](https://github.com/esengine/DeepSeek-Reasonix/pull/7350))
- **Serve 标题、删除、回退与瞬态标记** — 稳定标题生成与缓存，显示会话删除失败，从回退标签中移除控制器组合标记，并统一瞬态块清理。 ([#7349](https://github.com/esengine/DeepSeek-Reasonix/pull/7349), [#7334](https://github.com/esengine/DeepSeek-Reasonix/pull/7334), [#7346](https://github.com/esengine/DeepSeek-Reasonix/pull/7346), [#7345](https://github.com/esengine/DeepSeek-Reasonix/pull/7345))
- **桌面端设置布局与懒加载** — 较长的权限规则会自动换行且不再遮挡删除按钮，设置 CSS 也保持懒加载且不会破坏组件直接测试。 ([#7320](https://github.com/esengine/DeepSeek-Reasonix/pull/7320), [#7361](https://github.com/esengine/DeepSeek-Reasonix/pull/7361))
- **更新器、Remote Workbench 与文档可靠性** — 新增可操作的更新恢复路径，让取消后的 Workbench 监听器及时退出，并恢复文档代码块换行及复制按钮的安全间距。 ([#7336](https://github.com/esengine/DeepSeek-Reasonix/pull/7336), [#7321](https://github.com/esengine/DeepSeek-Reasonix/pull/7321), [#7360](https://github.com/esengine/DeepSeek-Reasonix/pull/7360))
- **验证链接与会话祖先链路径** — 验证邮件现在使用已配置的应用来源，会话祖先链也会在构造路径前拒绝路径穿越形态的标识符。 ([#7341](https://github.com/esengine/DeepSeek-Reasonix/pull/7341))

## 升级提醒

- **用量历史从本版本开始** — 此前未持久化历史 token 用量，因此新的统计面板会从升级到 v1.19.5 后开始累计数据。 ([#7238](https://github.com/esengine/DeepSeek-Reasonix/pull/7238))
- **项目提示词文件必须位于工作区内** — 项目级 `system_prompt_file` 若为绝对路径、包含 `..` 或通过符号链接越出工作区，现在会被拒绝。请将文件移入工作区，或在可信用户配置中设置该路径。 ([#7353](https://github.com/esengine/DeepSeek-Reasonix/pull/7353))

## 风险提示

- **网页搜索用量可见性** — 启用 `web_search = true` 后，提供商侧搜索及返回的结果文本可能增加计费搜索请求与输入 token；这些搜索请求次数尚未显示在 Reasonix 成本管线中。 ([#7340](https://github.com/esengine/DeepSeek-Reasonix/pull/7340))

## 致谢

感谢本版本的贡献者：[@HaoyueQin](https://github.com/HaoyueQin)、[@Li-Charles-One](https://github.com/Li-Charles-One)、[@Nath-Vikky](https://github.com/Nath-Vikky)、[@SivanCola](https://github.com/SivanCola)、[@SprayHank](https://github.com/SprayHank)、[@esengine](https://github.com/esengine)、[@jackie-cqz](https://github.com/jackie-cqz)、[@skyzhao1223](https://github.com/skyzhao1223)

## 下载与安装

- [官网按平台下载](https://reasonix.io/?download=desktop&channel=stable#start)
- [查看完整差异](https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.19.4...desktop-v1.19.5)
