### PR TITLE
fix(updater): agree on what a pending update is, and recover from debris

### DIFF
--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1555,16 +1556,138 @@ func removePendingUpdateExactVerified(expected *UpdateTransaction, verify func()
 // the new transaction is durable, destroying the previous rollback material if
 // preparation later fails.
 func ensureNoPendingUpdate() error {
-	path := PendingUpdatePath()
-	if path == "" {
-		return fmt.Errorf("prepare update: Reasonix state directory is unavailable")
+	disposition, _, err := classifyPendingUpdate()
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
 	}
-	if _, err := os.Lstat(path); err == nil {
+	switch disposition {
+	case pendingUpdateActionable:
 		return fmt.Errorf("prepare update: a pending update already exists")
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("prepare update: inspect pending transaction: %w", err)
+	case pendingUpdateDebris:
+		// Refusing here would be refusing forever: debris cannot be resumed,
+		// rolled back, or cleared by reconciliation, so every future update
+		// would fail on a transaction nothing can act on.
+		if _, err := quarantinePendingUpdate("blocked a new update"); err != nil {
+			return fmt.Errorf("prepare update: quarantine unusable transaction: %w", err)
+		}
 	}
 	return nil
+}
+
+// pendingUpdateDisposition is what the pending-update marker on disk currently
+// means. Preparation and reconciliation both classify through it so they cannot
+// disagree about whether a transaction exists — when they did, a marker that
+// reconciliation could not act on still made preparation refuse, and updates
+// stayed blocked permanently (#7342).
+type pendingUpdateDisposition int
+
+const (
+	// pendingUpdateNone: no marker on disk.
+	pendingUpdateNone pendingUpdateDisposition = iota
+	// pendingUpdateActionable: a transaction that can still be resumed or
+	// rolled back. Preparation must refuse over one of these — writing a new
+	// transaction would overwrite fixed backup paths and destroy the rollback
+	// material this one still owns.
+	pendingUpdateActionable
+	// pendingUpdateDebris: a marker that cannot describe a recoverable
+	// transaction, so it owns no rollback material worth protecting.
+	pendingUpdateDebris
+)
+
+// classifyPendingUpdate reads the marker and decides what can be done with it.
+//
+// The line between debris and an actionable transaction is deliberately drawn
+// at self-description. A transaction that cannot be parsed, or that does not
+// say which release it targets, for which platform, and when it was opened,
+// names nothing to roll back to — discarding it loses nothing. Every other
+// validation failure is environment-relative (the launcher path, whether the
+// target sits inside this Guard installation, where the backup lives) and can
+// fail for a perfectly good transaction observed from the wrong install, so
+// those keep the old refusal rather than risking real rollback material.
+//
+// IO failures are errors, never debris: an unreadable marker is not an absent
+// one, and quarantining on a transient permission error would throw away a
+// recoverable transaction.
+func classifyPendingUpdate() (pendingUpdateDisposition, *UpdateTransaction, error) {
+	path := PendingUpdatePath()
+	if path == "" {
+		return pendingUpdateNone, nil, fmt.Errorf("Reasonix state directory is unavailable")
+	}
+	if _, err := os.Lstat(path); err != nil {
+		if os.IsNotExist(err) {
+			return pendingUpdateNone, nil, nil
+		}
+		return pendingUpdateNone, nil, fmt.Errorf("inspect pending transaction: %w", err)
+	}
+	tx, err := readPendingUpdateUnchecked()
+	if err != nil {
+		switch {
+		case os.IsNotExist(err):
+			return pendingUpdateNone, nil, nil
+		case isPendingUpdateContentError(err):
+			return pendingUpdateDebris, nil, nil
+		default:
+			return pendingUpdateNone, nil, fmt.Errorf("read pending transaction: %w", err)
+		}
+	}
+	if !pendingUpdateSelfDescribing(tx) {
+		return pendingUpdateDebris, nil, nil
+	}
+	if err := validateUpdateTransaction(tx); err != nil {
+		return pendingUpdateActionable, nil, nil
+	}
+	return pendingUpdateActionable, tx, nil
+}
+
+// isPendingUpdateContentError reports whether err means the bytes on disk are
+// not a transaction, as opposed to the file being unreadable. A prepare
+// interrupted mid-write leaves a truncated object, which decodes to a syntax
+// error rather than an IO error.
+func isPendingUpdateContentError(err error) bool {
+	var syntax *json.SyntaxError
+	var unmarshalType *json.UnmarshalTypeError
+	return errors.As(err, &syntax) || errors.As(err, &unmarshalType) || errors.Is(err, io.ErrUnexpectedEOF)
+}
+
+// pendingUpdateSelfDescribing reports whether tx carries the identity any
+// recovery needs regardless of where Reasonix is installed: which release it
+// targets, for which platform, and when it was opened.
+func pendingUpdateSelfDescribing(tx *UpdateTransaction) bool {
+	if tx == nil || tx.SchemaVersion != updateTransactionVersion || strings.TrimSpace(tx.ToVersion) == "" {
+		return false
+	}
+	if strings.TrimSpace(tx.Platform) == "" || strings.TrimSpace(tx.CreatedAt) == "" {
+		return false
+	}
+	_, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(tx.CreatedAt))
+	return err == nil
+}
+
+// quarantinePendingUpdate moves an unusable marker aside and returns where it
+// went. It is deliberately not a delete: the marker is the only evidence of
+// what went wrong, and a user who reports a stuck updater should still have it.
+// Callers hold the pending-update lock.
+func quarantinePendingUpdate(reason string) (string, error) {
+	path := PendingUpdatePath()
+	if path == "" {
+		return "", fmt.Errorf("Reasonix state directory is unavailable")
+	}
+	base := path + ".unusable-" + time.Now().UTC().Format("20060102T150405Z")
+	aside := base
+	for i := 1; ; i++ {
+		if _, err := os.Lstat(aside); os.IsNotExist(err) {
+			break
+		} else if err != nil {
+			return "", err
+		}
+		aside = fmt.Sprintf("%s-%d", base, i)
+	}
+	if err := os.Rename(path, aside); err != nil {
+		return "", err
+	}
+	slog.Warn("repair: quarantined an unusable pending update transaction",
+		"path", aside, "reason", reason)
+	return aside, nil
 }
 
 func ReadPendingUpdate() (*UpdateTransaction, error) {
@@ -1634,10 +1757,27 @@ func PendingUpdateExists() bool {
 // its rollback state is intact. Version equality alone is not installation
 // evidence: a same-version/manual launch may observe an abandoned prepare.
 func ReconcilePendingUpdate(runningVersion string) (PendingUpdateReconcileResult, error) {
-	tx, err := ReadPendingUpdate()
-	if err != nil {
-		if os.IsNotExist(err) {
-			return PendingUpdateReconcileResult{}, nil
+	disposition, tx, classifyErr := classifyPendingUpdate()
+	if classifyErr != nil {
+		return PendingUpdateReconcileResult{Pending: true}, fmt.Errorf("reconcile pending update: %w", classifyErr)
+	}
+	switch {
+	case disposition == pendingUpdateNone:
+		return PendingUpdateReconcileResult{}, nil
+	case disposition == pendingUpdateDebris:
+		// Nothing here can be resumed or rolled back. Leaving it in place is
+		// what stranded users: startup kept failing to recover it while
+		// preparation kept refusing to write over it.
+		if _, err := quarantinePendingUpdate("no recoverable transaction to reconcile"); err != nil {
+			return PendingUpdateReconcileResult{Pending: true}, fmt.Errorf("reconcile pending update: quarantine unusable transaction: %w", err)
+		}
+		return PendingUpdateReconcileResult{Pending: true, Cleared: true}, nil
+	case tx == nil:
+		// Self-describing but not valid for this installation. Recovery needs
+		// the full transaction, so surface the reason instead of guessing.
+		_, err := ReadPendingUpdate()
+		if err == nil {
+			err = fmt.Errorf("pending update is not valid for this installation")
 		}
 		return PendingUpdateReconcileResult{Pending: true}, fmt.Errorf("reconcile pending update: %w", err)
 	}

--- a/internal/repair/update_debris_test.go
+++ b/internal/repair/update_debris_test.go
@@ -1,0 +1,193 @@
+package repair
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writePendingUpdateRaw drops arbitrary bytes where the transaction lives.
+func writePendingUpdateRaw(t *testing.T, body string) string {
+	t.Helper()
+	path := PendingUpdatePath()
+	if path == "" {
+		t.Fatal("pending update path unavailable")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func quarantinedCopies(t *testing.T) []string {
+	t.Helper()
+	path := PendingUpdatePath()
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	prefix := filepath.Base(path) + ".unusable-"
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), prefix) {
+			out = append(out, entry.Name())
+		}
+	}
+	return out
+}
+
+// A marker that cannot describe a recoverable transaction used to block every
+// future update forever: preparation refused over it and reconciliation could
+// not act on it, so neither retrying nor reinstalling helped (#7342).
+func TestPrepareUpdateRecoversFromUnusablePendingTransaction(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"truncated write", `{"schema_version":1,"to_version":"v2"`},
+		{"not json at all", "\x00\x00garbage"},
+		{"wrong types", `{"schema_version":"one"}`},
+		{"empty file", ""},
+		{"no target release", `{"schema_version":1,"to_version":""}`},
+		{"missing identity", `{"schema_version":1,"to_version":"v2"}`},
+		{"unparseable creation time", `{"schema_version":1,"to_version":"v2","platform":"test","created_at":"yesterday"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("REASONIX_HOME", home)
+			target := filepath.Join(t.TempDir(), "reasonix-desktop")
+			originalExecutable := repairExecutable
+			repairExecutable = func() (string, error) { return filepath.Join(filepath.Dir(target), "reasonix-guard"), nil }
+			t.Cleanup(func() { repairExecutable = originalExecutable })
+			if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			writePendingUpdateRaw(t, tc.body)
+
+			if _, err := PrepareFileUpdate("v1", "v2", target); err != nil {
+				t.Fatalf("PrepareFileUpdate over an unusable transaction: %v", err)
+			}
+			if got := quarantinedCopies(t); len(got) != 1 {
+				t.Fatalf("quarantined copies = %v, want the unusable marker preserved exactly once", got)
+			}
+			tx, err := ReadPendingUpdate()
+			if err != nil {
+				t.Fatalf("ReadPendingUpdate after recovery: %v", err)
+			}
+			if tx.ToVersion != "v2" {
+				t.Fatalf("pending transaction = %+v, want the newly prepared one", tx)
+			}
+		})
+	}
+}
+
+// The guard still has to hold for a transaction that can actually be recovered:
+// preparing over one would overwrite the fixed backup paths it still owns.
+func TestPrepareUpdateStillRefusesOverRecoverableTransaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	target := filepath.Join(t.TempDir(), "reasonix-desktop")
+	originalExecutable := repairExecutable
+	repairExecutable = func() (string, error) { return filepath.Join(filepath.Dir(target), "reasonix-guard"), nil }
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PrepareFileUpdate("v1", "v2", target); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := PrepareFileUpdate("v2", "v3", target); err == nil {
+		t.Fatal("PrepareFileUpdate over a recoverable transaction = nil error, want refusal")
+	} else if !strings.Contains(err.Error(), "a pending update already exists") {
+		t.Fatalf("error = %v, want the pending-update refusal", err)
+	}
+	if got := quarantinedCopies(t); len(got) != 0 {
+		t.Fatalf("quarantined copies = %v, want a recoverable transaction left alone", got)
+	}
+}
+
+// Reconciliation must clear debris too, otherwise startup keeps reporting a
+// recovery failure that nothing can resolve.
+func TestReconcilePendingUpdateQuarantinesDebris(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	writePendingUpdateRaw(t, `{"schema_version":1,"to_version":"v2"`)
+
+	result, err := ReconcilePendingUpdate("v1")
+	if err != nil {
+		t.Fatalf("ReconcilePendingUpdate over debris: %v", err)
+	}
+	if !result.Cleared {
+		t.Fatalf("result = %+v, want the debris reported as cleared", result)
+	}
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("pending marker still present after reconciliation: %v", err)
+	}
+	if got := quarantinedCopies(t); len(got) != 1 {
+		t.Fatalf("quarantined copies = %v, want the debris preserved for diagnosis", got)
+	}
+}
+
+// Quarantine preserves evidence rather than deleting it, and repeated recovery
+// never overwrites an earlier copy.
+func TestQuarantinePendingUpdatePreservesEveryCopy(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	for i := range 3 {
+		writePendingUpdateRaw(t, `{"broken":`)
+		aside, err := quarantinePendingUpdate("test")
+		if err != nil {
+			t.Fatalf("quarantine %d: %v", i, err)
+		}
+		body, err := os.ReadFile(aside)
+		if err != nil {
+			t.Fatalf("read quarantined copy %d: %v", i, err)
+		}
+		if string(body) != `{"broken":` {
+			t.Fatalf("quarantined body = %q, want the original bytes", body)
+		}
+	}
+	if got := quarantinedCopies(t); len(got) != 3 {
+		t.Fatalf("quarantined copies = %v, want all three preserved", got)
+	}
+}
+
+// A transaction that describes itself but does not validate for this
+// installation is not debris: it may own real rollback material and simply be
+// observed from the wrong install, so it must survive classification.
+func TestSelfDescribingTransactionIsNotTreatedAsDebris(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	body, err := json.Marshal(UpdateTransaction{
+		SchemaVersion: updateTransactionVersion,
+		ToVersion:     "v2",
+		FromVersion:   "v1",
+		Platform:      "test",
+		CreatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+		TargetKind:    "file",
+		TargetPath:    filepath.Join("elsewhere", "reasonix-desktop"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePendingUpdateRaw(t, string(body))
+
+	disposition, tx, classifyErr := classifyPendingUpdate()
+	if classifyErr != nil {
+		t.Fatalf("classifyPendingUpdate: %v", classifyErr)
+	}
+	if disposition != pendingUpdateActionable {
+		t.Fatalf("disposition = %v, want a self-describing transaction treated as actionable", disposition)
+	}
+	if tx != nil {
+		t.Fatal("a transaction that fails installation validation must not be handed back as usable")
+	}
+	if got := quarantinedCopies(t); len(got) != 0 {
+		t.Fatalf("quarantined copies = %v, want none", got)
+	}
+}


### PR DESCRIPTION
## Summary

Preparation and reconciliation each had their own notion of "a pending update exists":

- `ensureNoPendingUpdate` checked only that the marker file was **present** (`Lstat`) and refused.
- `ReconcilePendingUpdate` **read and validated** it, and on a validation failure returned an error without clearing anything.

A marker that fails validation satisfied neither. Nothing could resume it, roll it back, or remove it, while its presence kept refusing every future update — a permanent dead end. Retrying did nothing; **reinstalling did nothing either**, because the marker lives in the state directory (`<state>/repair/pending-update.json`), not the install directory.

The blast radius was larger than "updates fail": startup reported the failed recovery and dropped 1.19.x into **safe mode**, which disabled plugins, MCP, hooks, bots and automation. That is what #7175 and #7241 were experiencing — not separate bugs, the same stuck transaction presenting as "the whole app is broken". Safe mode is gone in v1.20+, but the stuck updater is exactly what prevented reaching it.

Roughly ten reports in two days: #7342, #7172, #7244, #7253, #7176, plus the safe-mode reports downstream of it.

## Approach

Both paths now classify through one function, so they cannot disagree again. The line between debris and a recoverable transaction is drawn at **self-description**:

- **Debris** — bytes that do not parse, or that do not say which release they target, for which platform, and when they were opened. These name nothing to roll back to, so discarding them loses nothing.
- **Actionable** — everything else. In particular, every *environment-relative* validation failure (the launcher path, whether the target sits inside this Guard installation, where the backup lives) keeps the old refusal, because those can fail for a perfectly good transaction merely observed from the wrong install. Quarantining one of those would destroy real rollback material, which is the outcome this guard exists to prevent.
- **IO failures stay errors.** An unreadable marker is not an absent one; quarantining on a transient permission error would throw away a recoverable transaction.

Debris is **quarantined, not deleted** — moved to `pending-update.json.unusable-<timestamp>` beside the original. It is the only evidence of what went wrong, and someone reporting a stuck updater should still have it. Repeated recovery never overwrites an earlier copy.

## Verification

- `TestPrepareUpdateRecoversFromUnusablePendingTransaction` covers seven corruption shapes (truncated write, non-JSON bytes, wrong field types, empty file, no target release, missing identity, unparseable creation time) and asserts that preparation succeeds, the marker is preserved exactly once, and the newly prepared transaction is readable afterwards.
- `TestPrepareUpdateStillRefusesOverRecoverableTransaction` pins that the guard is unchanged for a real transaction, and that nothing is quarantined.
- `TestSelfDescribingTransactionIsNotTreatedAsDebris` pins the dangerous case explicitly: a transaction that describes itself but fails installation validation is classified actionable and left on disk.
- `TestReconcilePendingUpdateQuarantinesDebris` and `TestQuarantinePendingUpdatePreservesEveryCopy` cover the startup path and the evidence-preservation guarantee.
- `LANG=en_US.UTF-8 go test ./...` green on the full root module; `gofmt`/`go vet` clean.

Cache-impact: none. This is update-transaction state on disk; no prompt, tool, or model-facing surface is involved.

Cache-guard: the existing `internal/repair` suite passes unchanged, including the rollback, cancel, handoff and file-claim tests that pin the transaction lifecycle.

System-prompt-review: esengine session review 2026-08-03 — no system-prompt text is touched.

Fixes #7342.