### PR TITLE
fix(release): only write the npm aliases that are actually behind

### DIFF
--- a/scripts/finalize-npm-official-release.mjs
+++ b/scripts/finalize-npm-official-release.mjs
@@ -27,6 +27,14 @@ const packages = [
   "@reasonix/cli-win32-arm64", "@reasonix/cli-win32-x64",
 ];
 
+const OFFICIAL_ALIASES = ["latest", "canary", "next"];
+
+// The publisher stages a stable release under "<dist-tag>-staging" and removes
+// it once the official aliases land (npm/publish.mjs). This cleanup used to name
+// "official-staging", which nothing creates, so it never removed anything and a
+// staging alias left behind by a failed publish stayed on the registry.
+const stagingTag = "latest-staging";
+
 function metadata(name) {
   const output = execFileSync(
     "npm",
@@ -44,10 +52,10 @@ async function waitForOfficialAliases(name) {
   let tags = {};
   for (let attempt = 1; attempt <= verifyAttempts; attempt += 1) {
     tags = distTags(name);
-    if (["latest", "canary", "next"].every((tag) => tags[tag] === version)) return tags;
+    if (OFFICIAL_ALIASES.every((tag) => tags[tag] === version)) return tags;
     if (attempt < verifyAttempts) await delay(verifyDelayMs);
   }
-  const actual = ["latest", "canary", "next"]
+  const actual = OFFICIAL_ALIASES
     .map((tag) => `${tag}=${tags[tag] || "<missing>"}`)
     .join(", ");
   throw new Error(`${name} aliases did not converge to ${version}: ${actual}`);
@@ -66,12 +74,20 @@ for (const name of packages) {
   }
 }
 
+// Recovery reruns this after an alias write already succeeded — including after
+// someone realigned the aliases by hand because the automation could not. Every
+// dist-tag write is a registry mutation that can be refused (npm treats them as
+// sensitive operations, so an automation token gets a 403 where an interactive
+// session does not), and refusing a write we did not need would fail a rerun
+// that had nothing left to do. So read first and only write what is missing.
 for (const name of packages) {
-  for (const tag of ["latest", "canary", "next"]) {
+  const before = distTags(name);
+  for (const tag of OFFICIAL_ALIASES) {
+    if (before[tag] === version) continue;
     execFileSync("npm", ["dist-tag", "add", `${name}@${version}`, tag], { stdio: "inherit" });
   }
   const tags = await waitForOfficialAliases(name);
-  if (tags["official-staging"] === version) {
-    execFileSync("npm", ["dist-tag", "rm", name, "official-staging"], { stdio: "inherit" });
+  if (tags[stagingTag] === version) {
+    execFileSync("npm", ["dist-tag", "rm", name, stagingTag], { stdio: "inherit" });
   }
 }

--- a/scripts/finalize-npm-official-release.test.mjs
+++ b/scripts/finalize-npm-official-release.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -7,10 +7,14 @@ import test from "node:test";
 
 const candidate = "c46e3af1c2732fe2b3dedb0bd47eb39a629357d2";
 
-function run(expectedSha = candidate, publishedSha = candidate, staleReads = 0) {
+// The fake npm records every dist-tag mutation so a test can assert not just
+// the outcome but how many registry writes it took to get there — the whole
+// point of the idempotent path is that a rerun performs none.
+function run(expectedSha = candidate, publishedSha = candidate, staleReads = 0, { staging = false } = {}) {
   const directory = mkdtempSync(join(tmpdir(), "reasonix-npm-alias-test-"));
   const npm = join(directory, "npm");
   const state = join(directory, "state");
+  const writes = join(directory, "writes");
   writeFileSync(npm, `#!/usr/bin/env node
 const fs = require("node:fs");
 const args = process.argv.slice(2);
@@ -22,10 +26,13 @@ if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json
   const reads = fs.existsSync(statePath) ? Number(fs.readFileSync(statePath, "utf8")) : 0;
   fs.writeFileSync(statePath, String(reads + 1));
   const stale = reads < Number(process.env.NPM_FAKE_STALE_READS || 0);
-  console.log(JSON.stringify(stale
+  const tags = stale
     ? { latest: "1.19.2", canary: "1.19.2-canary.1", next: "1.19.0-rc.3" }
-    : { latest: "1.19.2", canary: "1.19.2", next: "1.19.2" }));
-} else if (args[0] === "dist-tag" && args[1] === "add") {
+    : { latest: "1.19.2", canary: "1.19.2", next: "1.19.2" };
+  if (process.env.NPM_FAKE_STAGING === "1") tags["latest-staging"] = "1.19.2";
+  console.log(JSON.stringify(tags));
+} else if (args[0] === "dist-tag" && (args[1] === "add" || args[1] === "rm")) {
+  fs.appendFileSync(process.env.NPM_FAKE_WRITES, JSON.stringify(args) + "\\n");
   process.exit(0);
 } else {
   console.error("unexpected npm arguments", JSON.stringify(args));
@@ -33,7 +40,7 @@ if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json
 }
 `);
   chmodSync(npm, 0o755);
-  return spawnSync(process.execPath, ["scripts/finalize-npm-official-release.mjs", "1.19.2"], {
+  const result = spawnSync(process.execPath, ["scripts/finalize-npm-official-release.mjs", "1.19.2"], {
     cwd: new URL("..", import.meta.url),
     encoding: "utf8",
     env: {
@@ -41,13 +48,19 @@ if (args[0] === "view" && args[1].includes("@1.19.2") && args.at(-1) === "--json
       EXPECTED_SHA: expectedSha,
       NPM_FAKE_STATE: state,
       NPM_FAKE_STALE_READS: String(staleReads),
+      NPM_FAKE_STAGING: staging ? "1" : "0",
+      NPM_FAKE_WRITES: writes,
       NPM_TAG_VERIFY_DELAY_MS: "1",
       PATH: `${directory}:${process.env.PATH}`,
     },
   });
+  result.writes = existsSync(writes)
+    ? readFileSync(writes, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line))
+    : [];
+  return result;
 }
 
-test("aligns all aliases after exact package provenance validation", () => {
+test("completes after exact package provenance validation", () => {
   const result = run();
   assert.equal(result.status, 0, result.stderr);
 });
@@ -61,4 +74,38 @@ test("fails closed before alias mutation when provenance differs", () => {
   const result = run(candidate, "a".repeat(40));
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /does not match/);
+  assert.deepEqual(result.writes, [], "provenance mismatch must not touch the registry");
+});
+
+// Recovery reruns this after the aliases are already correct — including after a
+// manual realignment, which is exactly what happens when the automation token is
+// refused. Writing anyway turned a rerun with nothing to do into a 403 (#7342
+// cluster), so an already-aligned release must perform zero registry writes.
+test("writes nothing when the official aliases already point at the release", () => {
+  const result = run();
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.writes, [], `unexpected registry writes: ${JSON.stringify(result.writes)}`);
+});
+
+// Only the aliases that are actually behind get written.
+test("writes only the aliases that are missing", () => {
+  const result = run(candidate, candidate, 1);
+  assert.equal(result.status, 0, result.stderr);
+  const added = result.writes.filter((args) => args[1] === "add").map((args) => args.at(-1));
+  assert.ok(added.length > 0, "a stale alias must still be written");
+  assert.ok(!added.includes("latest"), `latest was already current: ${JSON.stringify(result.writes)}`);
+  assert.deepEqual([...new Set(added)].sort(), ["canary", "next"]);
+});
+
+// The publisher stages under "<dist-tag>-staging"; cleanup used to name
+// "official-staging", which nothing creates, so a leftover staging alias
+// survived on the registry.
+test("removes the staging alias the publisher actually creates", () => {
+  const result = run(candidate, candidate, 0, { staging: true });
+  assert.equal(result.status, 0, result.stderr);
+  const removed = result.writes.filter((args) => args[1] === "rm");
+  assert.equal(removed.length, 7, `expected one removal per package: ${JSON.stringify(removed)}`);
+  for (const args of removed) {
+    assert.equal(args.at(-1), "latest-staging");
+  }
 });


### PR DESCRIPTION
## Summary

The "Align legacy aliases with the official release" step rewrote `latest`/`canary`/`next` unconditionally, so a recovery rerun performed three registry mutations per package even when all seven already pointed at the release.

That matters because npm treats dist-tag writes as sensitive operations — an automation token is refused where an interactive session is not. A rerun with nothing left to do still failed on the first write it did not need to make:

```
npm error 403 Forbidden - PUT .../@reasonix%2fcli-darwin-arm64/dist-tags/latest
```

This is the shape of the v1.19.5 recovery ([failed run](https://github.com/esengine/DeepSeek-Reasonix/actions/runs/30841487103)): the publish itself succeeded and all seven packages carry the correct `gitHead`/`reasonixCandidateSha`, so the aliases have to be realigned by hand — after which rerunning the workflow should be a no-op. It was not, which is what made the recovery path unusable rather than merely slow.

The step now reads the current aliases first and writes only what is missing, with the candidate-SHA validation still ahead of any mutation.

## Second fix: the staging cleanup named a tag nothing creates

Cleanup removed `official-staging`. The publisher stages under `` `${distTag}-staging` `` (`npm/publish.mjs`), which for a stable release is `latest-staging`. So the cleanup never matched anything, and a staging alias left behind by a failed publish stayed on the registry — exactly what happened to `latest-staging` in 1.19.5, where it is still pointing at the release now.

While here, the `["latest","canary","next"]` list was written out three times in one file; it is now one constant, since a list restated per use is how these drift apart.

## Verification

The fake npm in the test harness now records every `dist-tag` invocation, so the tests assert **how many registry writes each path takes** rather than only its exit status:

- zero writes when the aliases already point at the release (the rerun case this fixes),
- only the stale aliases written otherwise — `latest` is skipped while `canary`/`next` are written,
- zero writes when provenance validation fails (fail-closed, unchanged),
- one staging removal per package, under `latest-staging`.

`node --test scripts/*.test.mjs npm/*.test.mjs` → 47 passing.

## Not in scope

The manual realignment of the 1.19.5 aliases still has to be done by the account owner in an interactive session; this only makes the workflow rerun afterwards succeed instead of failing on writes it does not need.