### PR TITLE
fix(updater): recover orphaned macOS app backups / 恢复 macOS 更新残留备份

### DIFF
--- a/desktop/frontend/src/__tests__/updater-shared-state.test.tsx
+++ b/desktop/frontend/src/__tests__/updater-shared-state.test.tsx
@@ -69,6 +69,7 @@ await act(async () => {
 ok(document.getElementById("banner-status")?.textContent === "idle", "banner starts idle");
 ok(document.getElementById("settings-status")?.textContent === "idle", "settings starts idle");
 ok(classifyUpdateError("prepare update: a pending update already exists") === "recovery", "pending update errors require recovery fallback");
+ok(classifyUpdateError("prepare update: recover existing handoff backup: operation not permitted") === "recovery", "macOS backup permission errors require recovery fallback");
 ok(classifyUpdateError("update: manual update required") === "manual", "manual-only errors prefer the official download");
 ok(classifyUpdateError("connection reset by peer") === "retryable", "transient errors remain retryable");
 

--- a/desktop/frontend/src/lib/useUpdater.ts
+++ b/desktop/frontend/src/lib/useUpdater.ts
@@ -37,7 +37,7 @@ function errMsg(e: unknown): string {
 
 export function classifyUpdateError(message: string): UpdateErrorDisposition {
   const low = message.toLowerCase();
-  if (/pending update already exists|could not safely finish the previous update/.test(low)) {
+  if (/pending update already exists|could not safely finish the previous update|handoff backup/.test(low)) {
     return "recovery";
   }
   if (/authorization failed|manual update required|pkexec|sudo apt install/.test(low)) {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2854,7 +2854,7 @@ export const en = {
   "updater.done": "Update complete — restarting…",
   "updater.failed": "Update failed: {msg}",
   "updater.recoveryBlocked": "The previous update has not finished.",
-  "updater.recoveryHint": "Restarting Reasonix may recover it automatically. If it still fails, download the latest signed installer and install it over the current version without uninstalling first.",
+  "updater.recoveryHint": "Restart Reasonix and retry. On macOS, allow Reasonix in System Settings > Privacy & Security > App Management. If recovery is still blocked, download the latest signed installer and install it over the current version without uninstalling first.",
   "updater.manualUpdateRequired": "Automatic installation is unavailable.",
   "updater.manualFallbackHint": "Download the latest signed installer from the official site and install it over the current version.",
   "updater.errorDetails": "Details: {msg}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1993,7 +1993,7 @@ export const zhTW: Record<DictKey, string> = {
   "updater.done": "更新完成，正在重新啟動…",
   "updater.failed": "更新失敗：{msg}",
   "updater.recoveryBlocked": "上次更新尚未完成。",
-  "updater.recoveryHint": "重新啟動 Reasonix 通常可以自動恢復；若仍然失敗，請從官網下載最新簽署安裝包，直接覆蓋安裝，無需先解除安裝。",
+  "updater.recoveryHint": "請重新啟動 Reasonix 後重試。macOS 使用者可在「系統設定 > 隱私權與安全性 > App 管理」中允許 Reasonix；若仍無法恢復，請從官網下載最新簽署安裝包直接覆蓋安裝，無需先解除安裝。",
   "updater.manualUpdateRequired": "目前環境無法自動安裝更新。",
   "updater.manualFallbackHint": "請從官網下載最新簽署安裝包，直接覆蓋安裝目前版本。",
   "updater.errorDetails": "詳細資訊：{msg}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2857,7 +2857,7 @@ export const zh: Record<DictKey, string> = {
   "updater.done": "更新完成，正在重启…",
   "updater.failed": "更新失败：{msg}",
   "updater.recoveryBlocked": "上次更新尚未完成。",
-  "updater.recoveryHint": "重新启动 Reasonix 通常可以自动恢复；若仍然失败，请从官网下载最新签名安装包，直接覆盖安装，无需先卸载。",
+  "updater.recoveryHint": "请重新启动 Reasonix 后重试。macOS 用户可在“系统设置 > 隐私与安全性 > App 管理”中允许 Reasonix；若仍无法恢复，请从官网下载最新签名安装包直接覆盖安装，无需先卸载。",
   "updater.manualUpdateRequired": "当前环境无法自动安装更新。",
   "updater.manualFallbackHint": "请从官网下载最新签名安装包，直接覆盖安装当前版本。",
   "updater.errorDetails": "详细信息：{msg}",

--- a/internal/repair/plan.go
+++ b/internal/repair/plan.go
@@ -773,6 +773,7 @@ func pendingUpdateTargetPaths(tx *UpdateTransaction) []string {
 	add(tx.TargetPath)
 	if strings.EqualFold(strings.TrimSpace(tx.TargetKind), "app-bundle") {
 		add(tx.BackupPath)
+		add(tx.OrphanedBackupPath)
 	}
 	return paths
 }

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -56,6 +56,12 @@ type UpdateTransaction struct {
 	// BackupTreeID binds a macOS rollback backup to the bundle captured before
 	// the update. It remains optional for legacy transactions.
 	BackupTreeID string `json:"backupTreeId,omitempty"`
+	// OrphanedBackupPath and OrphanedBackupTreeID bind a quarantined backup to
+	// the transaction that displaced it. Terminal transaction cleanup removes
+	// only this exact tree after re-verifying its digest; older transactions
+	// without these optional fields retain their existing behavior.
+	OrphanedBackupPath   string `json:"orphanedBackupPath,omitempty"`
+	OrphanedBackupTreeID string `json:"orphanedBackupTreeId,omitempty"`
 }
 
 type UpdateTransactionFile struct {
@@ -340,9 +346,12 @@ func PrepareAppBundleUpdateHandoff(fromVersion, toVersion, appPath, backupPath, 
 	if err := VerifyAppBundleUpdateHandoffOriginal(tx); err != nil {
 		return nil, fmt.Errorf("prepare update: %w", err)
 	}
-	if _, err := quarantineExistingAppBundleUpdateBackup(tx); err != nil {
+	orphanedBackup, orphanedTreeID, err := quarantineExistingAppBundleUpdateBackup(tx)
+	if err != nil {
 		return nil, fmt.Errorf("prepare update: recover existing handoff backup: %w", err)
 	}
+	tx.OrphanedBackupPath = orphanedBackup
+	tx.OrphanedBackupTreeID = orphanedTreeID
 	// An uncooperative writer is not covered by Reasonix's mutation lock. Recheck
 	// the public path after quarantine so a recreated node is never adopted as the
 	// rollback backup of the new transaction.
@@ -457,7 +466,7 @@ func claimPendingAppBundleUpdateHandoff(
 		return fail(fmt.Errorf("claim update handoff: handoff metadata is missing"))
 	}
 
-	unlockTargets, err := lockRepairMutationsTimeout(timeout, tx.TargetPath, tx.BackupPath)
+	unlockTargets, err := lockRepairMutationsTimeout(timeout, pendingUpdateTargetPaths(tx)...)
 	if err != nil {
 		return fail(fmt.Errorf("claim update handoff: lock targets: %w", err))
 	}
@@ -1212,7 +1221,7 @@ func cancelPendingAppBundleUpdateHandoff(
 	if expected := strings.TrimSpace(expectedTransactionID); expected != "" && expected != repairPlanStateID(tx) {
 		return nil, fmt.Errorf("cancel update handoff: pending transaction changed")
 	}
-	unlockTargets, err := lockRepairMutationsTimeout(timeout, tx.TargetPath, tx.BackupPath)
+	unlockTargets, err := lockRepairMutationsTimeout(timeout, pendingUpdateTargetPaths(tx)...)
 	if err != nil {
 		return nil, fmt.Errorf("cancel update handoff: lock targets: %w", err)
 	}
@@ -1409,42 +1418,42 @@ func verifyAppBundleUpdateHandoffBackupAbsent(tx *UpdateTransaction) error {
 // The caller holds both the pending-update lock and the target mutation locks.
 // The current executable binding prevents a crafted caller from quarantining a
 // similarly named bundle beside an unrelated application.
-func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, error) {
+func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, string, error) {
 	if tx == nil || tx.TargetKind != "app-bundle" ||
 		tx.BackupPath != tx.TargetPath+".reasonix-update-backup" {
-		return "", fmt.Errorf("handoff backup transaction is invalid")
+		return "", "", fmt.Errorf("handoff backup transaction is invalid")
 	}
 	info, err := os.Lstat(tx.BackupPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return "", "", nil
 		}
-		return "", fmt.Errorf("inspect existing handoff backup: %w", err)
+		return "", "", fmt.Errorf("inspect existing handoff backup: %w", err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("existing handoff backup is not a directory")
+		return "", "", fmt.Errorf("existing handoff backup is not a directory")
 	}
 
 	launcher, err := repairExecutable()
 	if err != nil {
-		return "", fmt.Errorf("resolve current Reasonix executable: %w", err)
+		return "", "", fmt.Errorf("resolve current Reasonix executable: %w", err)
 	}
 	resolvedTarget, err := filepath.EvalSymlinks(tx.TargetPath)
 	if err != nil {
-		return "", fmt.Errorf("resolve current app bundle: %w", err)
+		return "", "", fmt.Errorf("resolve current app bundle: %w", err)
 	}
 	resolvedLauncher, err := filepath.EvalSymlinks(launcher)
 	if err != nil {
-		return "", fmt.Errorf("resolve current Reasonix executable: %w", err)
+		return "", "", fmt.Errorf("resolve current Reasonix executable: %w", err)
 	}
 	rel, err := filepath.Rel(resolvedTarget, resolvedLauncher)
 	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("existing handoff backup is outside the current Reasonix installation")
+		return "", "", fmt.Errorf("existing handoff backup is outside the current Reasonix installation")
 	}
 
 	expectedTreeID, err := repairPlanTreeContentStateID(tx.BackupPath)
 	if err != nil {
-		return "", fmt.Errorf("read existing handoff backup digest: %w", err)
+		return "", "", fmt.Errorf("read existing handoff backup digest: %w", err)
 	}
 	for attempt := 0; attempt < 16; attempt++ {
 		quarantine := fmt.Sprintf(
@@ -1457,7 +1466,7 @@ func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, err
 			if os.IsExist(err) {
 				continue
 			}
-			return "", fmt.Errorf("quarantine existing handoff backup: %w", err)
+			return "", "", fmt.Errorf("quarantine existing handoff backup: %w", err)
 		}
 		updateBackupAfterQuarantine(tx.BackupPath, quarantine)
 
@@ -1475,19 +1484,34 @@ func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, err
 
 		actualTreeID, digestErr := repairPlanTreeContentStateID(quarantine)
 		if digestErr != nil {
-			return "", restore(fmt.Errorf("read quarantined handoff backup digest: %w", digestErr))
+			return "", "", restore(fmt.Errorf("read quarantined handoff backup digest: %w", digestErr))
 		}
 		if actualTreeID != expectedTreeID {
-			return "", restore(fmt.Errorf("existing handoff backup changed during quarantine"))
+			return "", "", restore(fmt.Errorf("existing handoff backup changed during quarantine"))
 		}
 		if _, statErr := os.Lstat(tx.BackupPath); statErr == nil {
-			return "", fmt.Errorf("handoff backup path was recreated during recovery; preserved quarantined backup at %s", quarantine)
+			return "", "", fmt.Errorf("handoff backup path was recreated during recovery; preserved quarantined backup at %s", quarantine)
 		} else if !os.IsNotExist(statErr) {
-			return "", fmt.Errorf("inspect recovered handoff backup path: %w", statErr)
+			return "", "", fmt.Errorf("inspect recovered handoff backup path: %w", statErr)
 		}
-		return quarantine, nil
+		return quarantine, actualTreeID, nil
 	}
-	return "", fmt.Errorf("cannot allocate handoff backup quarantine path")
+	return "", "", fmt.Errorf("cannot allocate handoff backup quarantine path")
+}
+
+// cleanupOrphanedAppBundleUpdateBackup retires only the quarantine recorded by
+// a terminal transaction. The no-replace move and digest check keep a changed
+// or concurrently replaced directory intact for diagnosis instead of deleting
+// a path merely because its name resembles a Reasonix quarantine.
+func cleanupOrphanedAppBundleUpdateBackup(tx *UpdateTransaction) {
+	if validateOrphanedAppBundleBackupMetadata(tx) != nil ||
+		strings.TrimSpace(tx.OrphanedBackupPath) == "" {
+		return
+	}
+	if err := removeUpdateBackupTreeMatching(tx.OrphanedBackupPath, tx.OrphanedBackupTreeID); err != nil {
+		slog.Warn("repair: preserving quarantined app backup after cleanup failed",
+			"path", tx.OrphanedBackupPath, "error", err)
+	}
 }
 
 func verifyAppBundleUpdateTree(path, expected, mismatch string) error {
@@ -1645,6 +1669,7 @@ func removePendingUpdateExactVerified(expected *UpdateTransaction, verify func()
 	if err := removePendingUpdateFile(cleanup); err != nil {
 		return restore(err)
 	}
+	cleanupOrphanedAppBundleUpdateBackup(expected)
 	return nil
 }
 
@@ -3209,6 +3234,9 @@ func validateUpdateTransactionForLauncher(tx *UpdateTransaction, launcher string
 		if err := validateAppBundleHandoffMetadata(tx); err != nil {
 			return fmt.Errorf("pending update %w", err)
 		}
+		if err := validateOrphanedAppBundleBackupMetadata(tx); err != nil {
+			return fmt.Errorf("pending update %w", err)
+		}
 	default:
 		return fmt.Errorf("pending update target kind is invalid")
 	}
@@ -3274,6 +3302,47 @@ func validateAppBundleHandoffMetadata(tx *UpdateTransaction) error {
 	if !strings.HasPrefix(stagingBase, "reasonix-mac-update-") {
 		return fmt.Errorf("handoff staging directory has an unexpected name")
 	}
+	return nil
+}
+
+func validateOrphanedAppBundleBackupMetadata(tx *UpdateTransaction) error {
+	if tx == nil {
+		return fmt.Errorf("orphaned backup metadata is incomplete")
+	}
+	path := strings.TrimSpace(tx.OrphanedBackupPath)
+	treeID := strings.TrimSpace(tx.OrphanedBackupTreeID)
+	if path == "" && treeID == "" {
+		return nil
+	}
+	if tx.TargetKind != "app-bundle" || path == "" || treeID == "" {
+		return fmt.Errorf("orphaned backup metadata is incomplete")
+	}
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) || filepath.Dir(path) != filepath.Dir(tx.BackupPath) {
+		return fmt.Errorf("orphaned backup path is outside the app installation directory")
+	}
+	prefix := filepath.Base(tx.BackupPath) + ".reasonix-orphaned-"
+	suffix, ok := strings.CutPrefix(filepath.Base(path), prefix)
+	if !ok {
+		return fmt.Errorf("orphaned backup path has an unexpected name")
+	}
+	parts := strings.Split(suffix, "-")
+	if len(parts) != 2 {
+		return fmt.Errorf("orphaned backup path has an unexpected name")
+	}
+	for _, part := range parts {
+		if part == "" || strings.Trim(part, "0123456789") != "" {
+			return fmt.Errorf("orphaned backup path has an unexpected name")
+		}
+	}
+	if len(treeID) != sha256.Size*2 {
+		return fmt.Errorf("orphaned backup digest is invalid")
+	}
+	if _, err := hex.DecodeString(treeID); err != nil {
+		return fmt.Errorf("orphaned backup digest is invalid")
+	}
+	tx.OrphanedBackupPath = path
+	tx.OrphanedBackupTreeID = treeID
 	return nil
 }
 

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -27,6 +27,7 @@ const updateTransactionVersion = 1
 const pendingUpdateLockTimeout = 5 * time.Second
 
 var repairExecutable = os.Executable
+var updateBackupAfterQuarantine = func(string, string) {}
 
 type UpdateTransaction struct {
 	SchemaVersion int    `json:"schemaVersion"`
@@ -321,9 +322,6 @@ func PrepareAppBundleUpdateHandoff(fromVersion, toVersion, appPath, backupPath, 
 		return nil, fmt.Errorf("prepare update: lock targets: %w", err)
 	}
 	defer unlockTargets()
-	if err := verifyAppBundleUpdateHandoffBackupAbsent(tx); err != nil {
-		return nil, fmt.Errorf("prepare update: %w", err)
-	}
 	tx.HandoffAppTreeID, err = repairPlanTreeContentStateID(tx.HandoffAppPath)
 	if err != nil {
 		return nil, fmt.Errorf("prepare update: stage bundle digest: %w", err)
@@ -340,6 +338,15 @@ func PrepareAppBundleUpdateHandoff(fromVersion, toVersion, appPath, backupPath, 
 		return nil, fmt.Errorf("prepare update: %w", err)
 	}
 	if err := VerifyAppBundleUpdateHandoffOriginal(tx); err != nil {
+		return nil, fmt.Errorf("prepare update: %w", err)
+	}
+	if _, err := quarantineExistingAppBundleUpdateBackup(tx); err != nil {
+		return nil, fmt.Errorf("prepare update: recover existing handoff backup: %w", err)
+	}
+	// An uncooperative writer is not covered by Reasonix's mutation lock. Recheck
+	// the public path after quarantine so a recreated node is never adopted as the
+	// rollback backup of the new transaction.
+	if err := verifyAppBundleUpdateHandoffBackupAbsent(tx); err != nil {
 		return nil, fmt.Errorf("prepare update: %w", err)
 	}
 	if err := ensureNoPendingUpdate(); err != nil {
@@ -1391,6 +1398,96 @@ func verifyAppBundleUpdateHandoffBackupAbsent(tx *UpdateTransaction) error {
 		return fmt.Errorf("inspect handoff backup path: %w", err)
 	}
 	return nil
+}
+
+// quarantineExistingAppBundleUpdateBackup recovers the pre-v1.20 state where
+// a committed macOS update removed pending-update.json but its sibling rollback
+// bundle survived best-effort cleanup. Without the transaction there is no
+// trustworthy authority to delete or reuse that bundle, so preparation moves it
+// aside with a no-replace rename and preserves it for diagnosis.
+//
+// The caller holds both the pending-update lock and the target mutation locks.
+// The current executable binding prevents a crafted caller from quarantining a
+// similarly named bundle beside an unrelated application.
+func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, error) {
+	if tx == nil || tx.TargetKind != "app-bundle" ||
+		tx.BackupPath != tx.TargetPath+".reasonix-update-backup" {
+		return "", fmt.Errorf("handoff backup transaction is invalid")
+	}
+	info, err := os.Lstat(tx.BackupPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("inspect existing handoff backup: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("existing handoff backup is not a directory")
+	}
+
+	launcher, err := repairExecutable()
+	if err != nil {
+		return "", fmt.Errorf("resolve current Reasonix executable: %w", err)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(tx.TargetPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve current app bundle: %w", err)
+	}
+	resolvedLauncher, err := filepath.EvalSymlinks(launcher)
+	if err != nil {
+		return "", fmt.Errorf("resolve current Reasonix executable: %w", err)
+	}
+	rel, err := filepath.Rel(resolvedTarget, resolvedLauncher)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("existing handoff backup is outside the current Reasonix installation")
+	}
+
+	expectedTreeID, err := repairPlanTreeContentStateID(tx.BackupPath)
+	if err != nil {
+		return "", fmt.Errorf("read existing handoff backup digest: %w", err)
+	}
+	for attempt := 0; attempt < 16; attempt++ {
+		quarantine := fmt.Sprintf(
+			"%s.reasonix-orphaned-%d-%d",
+			tx.BackupPath,
+			time.Now().UTC().UnixNano(),
+			attempt,
+		)
+		if err := renameRepairNodeNoReplace(tx.BackupPath, quarantine); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("quarantine existing handoff backup: %w", err)
+		}
+		updateBackupAfterQuarantine(tx.BackupPath, quarantine)
+
+		restore := func(cause error) error {
+			if _, statErr := os.Lstat(tx.BackupPath); statErr == nil {
+				return fmt.Errorf("%w; preserved quarantined backup at %s because the public path was recreated", cause, quarantine)
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("%w; inspect recreated handoff backup: %v", cause, statErr)
+			}
+			if restoreErr := renameRepairNodeNoReplace(quarantine, tx.BackupPath); restoreErr != nil {
+				return fmt.Errorf("%w; preserved quarantined backup at %s: %v", cause, quarantine, restoreErr)
+			}
+			return cause
+		}
+
+		actualTreeID, digestErr := repairPlanTreeContentStateID(quarantine)
+		if digestErr != nil {
+			return "", restore(fmt.Errorf("read quarantined handoff backup digest: %w", digestErr))
+		}
+		if actualTreeID != expectedTreeID {
+			return "", restore(fmt.Errorf("existing handoff backup changed during quarantine"))
+		}
+		if _, statErr := os.Lstat(tx.BackupPath); statErr == nil {
+			return "", fmt.Errorf("handoff backup path was recreated during recovery; preserved quarantined backup at %s", quarantine)
+		} else if !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("inspect recovered handoff backup path: %w", statErr)
+		}
+		return quarantine, nil
+	}
+	return "", fmt.Errorf("cannot allocate handoff backup quarantine path")
 }
 
 func verifyAppBundleUpdateTree(path, expected, mismatch string) error {

--- a/internal/repair/update_handoff_darwin_smoke_test.go
+++ b/internal/repair/update_handoff_darwin_smoke_test.go
@@ -1,0 +1,102 @@
+//go:build darwin
+
+package repair
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDarwinApplicationsOrphanBackupLifecycleSmoke is opt-in because it probes
+// the real App Management boundary under /Applications. It creates only a
+// uniquely owned synthetic app directory, never touches an installed app, and
+// verifies both the macOS no-replace quarantine rename and terminal cleanup.
+//
+// Run with:
+//
+//	REASONIX_MACOS_APPLICATIONS_SMOKE=1 go test ./internal/repair \
+//	  -run TestDarwinApplicationsOrphanBackupLifecycleSmoke -count=1
+func TestDarwinApplicationsOrphanBackupLifecycleSmoke(t *testing.T) {
+	if os.Getenv("REASONIX_MACOS_APPLICATIONS_SMOKE") != "1" {
+		t.Skip("set REASONIX_MACOS_APPLICATIONS_SMOKE=1 to probe /Applications")
+	}
+
+	smokeRoot, err := os.MkdirTemp("/Applications", ".reasonix-updater-smoke-")
+	if err != nil {
+		t.Fatalf("create isolated /Applications smoke root (allow the terminal in App Management): %v", err)
+	}
+	owned, err := os.Lstat(smokeRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		current, statErr := os.Lstat(smokeRoot)
+		if os.IsNotExist(statErr) {
+			return
+		}
+		if statErr != nil || !os.SameFile(owned, current) {
+			t.Errorf("preserving changed smoke root %s: %v", smokeRoot, statErr)
+			return
+		}
+		if removeErr := os.RemoveAll(smokeRoot); removeErr != nil {
+			t.Errorf("remove owned smoke root %s: %v", smokeRoot, removeErr)
+		}
+	})
+
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	app := filepath.Join(smokeRoot, "Reasonix.app")
+	executable := filepath.Join(app, "Contents", "MacOS", "Reasonix")
+	backup := app + ".reasonix-update-backup"
+	staging, err := os.MkdirTemp("", "reasonix-mac-update-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(staging) })
+	stagedApp := filepath.Join(staging, "Reasonix.app")
+	for _, dir := range []string{filepath.Dir(executable), backup, stagedApp} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(executable, []byte("synthetic-current"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(backup, "marker"), []byte("orphan"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedApp, "marker"), []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	originalExecutable := repairExecutable
+	repairExecutable = func() (string, error) { return executable, nil }
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+
+	tx, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", app, backup, stagedApp, staging, os.Getpid(),
+	)
+	if err != nil {
+		t.Fatalf("prepare handoff through /Applications: %v", err)
+	}
+	if tx.OrphanedBackupPath == "" || tx.OrphanedBackupTreeID == "" {
+		t.Fatal("prepared transaction did not bind the quarantined backup")
+	}
+	if got, err := os.ReadFile(filepath.Join(tx.OrphanedBackupPath, "marker")); err != nil || string(got) != "orphan" {
+		t.Fatalf("quarantined backup marker = %q, %v", got, err)
+	}
+	if _, err := os.Lstat(backup); !os.IsNotExist(err) {
+		t.Fatalf("public backup path still exists after quarantine: %v", err)
+	}
+
+	if _, err := CancelPendingAppBundleUpdateHandoffExact(tx, 5*time.Second); err != nil {
+		t.Fatalf("finish smoke transaction: %v", err)
+	}
+	if _, err := os.Lstat(tx.OrphanedBackupPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal cleanup retained the owned quarantine: %v", err)
+	}
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("terminal cleanup retained pending-update.json: %v", err)
+	}
+}

--- a/internal/repair/update_handoff_test.go
+++ b/internal/repair/update_handoff_test.go
@@ -231,7 +231,15 @@ func TestClaimPendingAppBundleUpdateHandoffExactRejectsRewrittenTransaction(t *t
 	}
 }
 
-func TestPrepareAppBundleUpdateHandoffRejectsExistingBackup(t *testing.T) {
+type existingAppBundleBackupFixture struct {
+	app       string
+	backup    string
+	stagedApp string
+	staging   string
+}
+
+func newExistingAppBundleBackupFixture(t *testing.T) existingAppBundleBackupFixture {
+	t.Helper()
 	t.Setenv("REASONIX_HOME", t.TempDir())
 	installRoot, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
@@ -254,17 +262,128 @@ func TestPrepareAppBundleUpdateHandoffRejectsExistingBackup(t *testing.T) {
 	if err := os.WriteFile(exe, []byte("current"), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(backup, "marker"), []byte("preserve"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	originalExecutable := repairExecutable
 	repairExecutable = func() (string, error) { return exe, nil }
 	t.Cleanup(func() { repairExecutable = originalExecutable })
+	return existingAppBundleBackupFixture{
+		app:       app,
+		backup:    backup,
+		stagedApp: stagedApp,
+		staging:   staging,
+	}
+}
 
-	if _, err := PrepareAppBundleUpdateHandoff(
-		"v1", "v2", app, backup, stagedApp, staging, os.Getpid(),
-	); err == nil || !strings.Contains(err.Error(), "backup path already exists") {
-		t.Fatalf("prepare error = %v, want existing-backup rejection", err)
+func TestPrepareAppBundleUpdateHandoffQuarantinesExistingBackup(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+
+	tx, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(fixture.backup); !os.IsNotExist(err) {
+		t.Fatalf("existing backup still blocks prepare: %v", err)
+	}
+	quarantines, err := filepath.Glob(fixture.backup + ".reasonix-orphaned-*")
+	if err != nil || len(quarantines) != 1 {
+		t.Fatalf("quarantined backups = %v, %v", quarantines, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(quarantines[0], "marker")); err != nil || string(got) != "preserve" {
+		t.Fatalf("quarantined backup marker = %q, %v", got, err)
+	}
+	current, err := ReadPendingUpdate()
+	if err != nil || UpdateTransactionID(current) != UpdateTransactionID(tx) {
+		t.Fatalf("pending transaction = %+v, %v", current, err)
+	}
+}
+
+func TestPrepareAppBundleUpdateHandoffPreservesConcurrentBackupRecreate(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	originalHook := updateBackupAfterQuarantine
+	updateBackupAfterQuarantine = func(original, _ string) {
+		if original != fixture.backup {
+			return
+		}
+		if err := os.Mkdir(original, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(original, "concurrent"), []byte("keep"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { updateBackupAfterQuarantine = originalHook })
+
+	_, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "recreated") {
+		t.Fatalf("prepare error = %v, want recreated-backup rejection", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fixture.backup, "concurrent")); err != nil || string(got) != "keep" {
+		t.Fatalf("concurrent backup = %q, %v", got, err)
+	}
+	quarantines, globErr := filepath.Glob(fixture.backup + ".reasonix-orphaned-*")
+	if globErr != nil || len(quarantines) != 1 {
+		t.Fatalf("preserved quarantines = %v, %v", quarantines, globErr)
 	}
 	if _, err := os.Stat(PendingUpdatePath()); !os.IsNotExist(err) {
-		t.Fatalf("rejected prepare wrote pending transaction: %v", err)
+		t.Fatalf("failed prepare wrote pending transaction: %v", err)
+	}
+}
+
+func TestPrepareAppBundleUpdateHandoffRestoresBackupChangedDuringQuarantine(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	originalHook := updateBackupAfterQuarantine
+	updateBackupAfterQuarantine = func(original, quarantine string) {
+		if original != fixture.backup {
+			return
+		}
+		if err := os.WriteFile(filepath.Join(quarantine, "changed"), []byte("keep"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { updateBackupAfterQuarantine = originalHook })
+
+	_, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed during quarantine") {
+		t.Fatalf("prepare error = %v, want changed-backup rejection", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fixture.backup, "changed")); err != nil || string(got) != "keep" {
+		t.Fatalf("changed backup was not restored = %q, %v", got, err)
+	}
+	if matches, _ := filepath.Glob(fixture.backup + ".reasonix-orphaned-*"); len(matches) != 0 {
+		t.Fatalf("restored backup left a quarantine: %v", matches)
+	}
+	if _, err := os.Stat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("failed prepare wrote pending transaction: %v", err)
+	}
+}
+
+func TestPrepareAppBundleUpdateHandoffRejectsUnboundExistingBackup(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	outside := filepath.Join(t.TempDir(), "Reasonix")
+	if err := os.WriteFile(outside, []byte("outside"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	repairExecutable = func() (string, error) { return outside, nil }
+
+	_, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "outside the current Reasonix installation") {
+		t.Fatalf("prepare error = %v, want current-installation rejection", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(fixture.backup, "marker")); err != nil || string(got) != "preserve" {
+		t.Fatalf("unbound backup changed = %q, %v", got, err)
+	}
+	if matches, _ := filepath.Glob(fixture.backup + ".reasonix-orphaned-*"); len(matches) != 0 {
+		t.Fatalf("unbound backup was quarantined: %v", matches)
 	}
 }
 

--- a/internal/repair/update_handoff_test.go
+++ b/internal/repair/update_handoff_test.go
@@ -295,9 +295,113 @@ func TestPrepareAppBundleUpdateHandoffQuarantinesExistingBackup(t *testing.T) {
 	if got, err := os.ReadFile(filepath.Join(quarantines[0], "marker")); err != nil || string(got) != "preserve" {
 		t.Fatalf("quarantined backup marker = %q, %v", got, err)
 	}
+	if tx.OrphanedBackupPath != quarantines[0] || strings.TrimSpace(tx.OrphanedBackupTreeID) == "" {
+		t.Fatalf("quarantine ownership = %q %q, want recorded path and digest", tx.OrphanedBackupPath, tx.OrphanedBackupTreeID)
+	}
 	current, err := ReadPendingUpdate()
 	if err != nil || UpdateTransactionID(current) != UpdateTransactionID(tx) {
 		t.Fatalf("pending transaction = %+v, %v", current, err)
+	}
+}
+
+func TestCancelAppBundleUpdateHandoffCleansOwnedQuarantine(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	tx, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CancelPendingAppBundleUpdateHandoffExact(tx, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(tx.OrphanedBackupPath); !os.IsNotExist(err) {
+		t.Fatalf("terminal transaction retained owned quarantine: %v", err)
+	}
+	if matches, _ := filepath.Glob(tx.OrphanedBackupPath + ".reasonix-cleanup-*"); len(matches) != 0 {
+		t.Fatalf("terminal cleanup retained temporary paths: %v", matches)
+	}
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("cancelled transaction remains pending: %v", err)
+	}
+}
+
+func TestCancelAppBundleUpdateHandoffPreservesChangedQuarantine(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	tx, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := filepath.Join(tx.OrphanedBackupPath, "changed-after-prepare")
+	if err := os.WriteFile(changed, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := CancelPendingAppBundleUpdateHandoffExact(tx, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(changed); err != nil || string(got) != "keep" {
+		t.Fatalf("changed quarantine = %q, %v; want preserved", got, err)
+	}
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("cancelled transaction remains pending: %v", err)
+	}
+}
+
+func TestCancelAppBundleUpdateHandoffPreservesConcurrentQuarantineRecreate(t *testing.T) {
+	fixture := newExistingAppBundleBackupFixture(t)
+	tx, err := PrepareAppBundleUpdateHandoff(
+		"v1", "v2", fixture.app, fixture.backup, fixture.stagedApp, fixture.staging, os.Getpid(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalHook := updateCleanupAfterRename
+	updateCleanupAfterRename = func(original, _ string) {
+		if original != tx.OrphanedBackupPath {
+			return
+		}
+		if err := os.Mkdir(original, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(original, "concurrent"), []byte("keep"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() { updateCleanupAfterRename = originalHook })
+
+	if _, err := CancelPendingAppBundleUpdateHandoffExact(tx, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(tx.OrphanedBackupPath, "concurrent")); err != nil || string(got) != "keep" {
+		t.Fatalf("concurrently recreated quarantine = %q, %v; want preserved", got, err)
+	}
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
+		t.Fatalf("cancelled transaction remains pending: %v", err)
+	}
+}
+
+func TestAppBundleUpdateRejectsForgedOrphanedBackupMetadata(t *testing.T) {
+	tx, _ := prepareTestAppBundleHandoff(t)
+	tx.OrphanedBackupPath = filepath.Join(filepath.Dir(tx.TargetPath), "unrelated.reasonix-orphaned-1-0")
+	tx.OrphanedBackupTreeID = strings.Repeat("0", 64)
+	if err := validateUpdateTransaction(tx); err == nil || !strings.Contains(err.Error(), "unexpected name") {
+		t.Fatalf("validation error = %v, want forged quarantine rejection", err)
+	}
+}
+
+func TestAppBundleUpdateWithoutOrphanKeepsLegacyTransactionShape(t *testing.T) {
+	prepareTestAppBundleHandoff(t)
+	body, err := os.ReadFile(PendingUpdatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "orphanedBackup") {
+		t.Fatalf("ordinary transaction unexpectedly gained orphan metadata: %s", body)
+	}
+	if _, err := ReadPendingUpdate(); err != nil {
+		t.Fatalf("ordinary transaction is no longer readable: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recover the macOS updater when the fixed `.reasonix-update-backup` directory survives but no pending transaction owns it.
- Quarantine the exact orphaned backup to a unique sibling instead of deleting or reusing unknown rollback material.
- Bind the quarantine path and tree digest to the new pending transaction, then retire only that exact tree after a verified terminal transition.
- Classify backup handoff failures as recovery errors and provide localized, non-destructive recovery guidance.

## Root cause

App-bundle handoff uses a fixed sibling backup path. If an interrupted update left that directory behind after the pending marker disappeared, every later preparation refused the path, while no transaction remained that could cancel or roll it back. Retry and reinstall therefore could not make progress.

The initial recovery preserved every quarantined app bundle indefinitely because the transaction retained no ownership evidence that could authorize later cleanup.

## Recovery and cleanup lifecycle

1. Preparation classifies pending-update state while holding the pending-update lock. An actionable transaction still blocks recovery.
2. The exact fixed backup is hashed and moved with an atomic no-replace rename to a unique sibling.
3. The quarantine path and digest are recorded as optional fields in the immutable pending transaction.
4. Claim, cancel, health confirmation, and rollback include the quarantine in the sorted mutation-lock set.
5. When the exact transaction reaches a verified terminal transition, cleanup atomically moves only the recorded quarantine, rechecks its digest, and removes it.
6. Changed or concurrently recreated paths are preserved. No directory is deleted merely because its name resembles a Reasonix quarantine.

## Safety and concurrency

- Recovery runs only after pending-update classification reports no actionable transaction and while the pending-update and target mutation locks are held.
- The backup must be the exact sibling of the current Reasonix app, must be a real directory, and the running executable must belong to that app.
- The backup tree is hashed before and after an atomic no-replace rename.
- Concurrent recreation or content drift fails closed. The quarantined copy is preserved, and restoration is attempted when it is safe.
- A new transaction is written only after the fixed public backup path is verified absent again.
- Terminal cleanup is transaction-bound by exact path and digest; the quarantine participates in the same canonical, sorted lock order.
- Deterministic tests force both content drift and same-path recreation during cleanup.

## Compatibility

| Contract | Behavior | Result |
| --- | --- | --- |
| Older `pending-update.json` | New quarantine fields use `omitempty`; transactions without them keep the prior JSON shape and remain readable | Backward compatible |
| New orphan ownership fields | Same-release parent/helper bind cleanup to the exact quarantine path and digest | Fail closed across transaction identity checks |
| Existing orphan backup | Renamed and preserved through the recovery transaction; removed only after an exact verified terminal transition | Non-destructive recovery with bounded normal lifecycle |
| Changed or concurrently recreated quarantine | Digest or path ownership check fails; the directory is preserved | No blind deletion |
| Concurrent writers | No-replace rename, digest verification, sorted mutation locks, and post-move path checks | Fails closed |
| Provider, prompt, and tool cache | No provider-visible surface is changed | No cache impact |

## Relationship to recent updater work

PR #7366 recovers unusable pending-marker debris. This PR covers the complementary state from #7232: there is no pending marker, but the fixed app-bundle backup directory still exists.

## Verification

- `go test ./internal/repair -count=1`
- `go test -race ./internal/repair -run 'AppBundle|PendingUpdate|Handoff|Quarantine|Orphan' -count=1`
- `go test ./...`
- `go vet ./...`
- `(cd desktop && go test ./...)`
- `(cd desktop && go vet ./...)`
- `pnpm --dir desktop/frontend test:updater`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend build`
- `git diff --check`

### macOS App Management smoke test

An opt-in Darwin test creates a uniquely owned synthetic app sandbox under `/Applications`, exercises the real macOS no-replace quarantine rename and terminal cleanup, verifies ownership before recursive cleanup, and never touches an installed app:

```sh
REASONIX_MACOS_APPLICATIONS_SMOKE=1 \
  go test ./internal/repair \
  -run TestDarwinApplicationsOrphanBackupLifecycleSmoke \
  -count=1 -v
```

This smoke test passed on macOS arm64. No `.reasonix-updater-smoke-*` directory remained afterward. A destructive test against the installed signed Reasonix app was intentionally not performed.

Fixes #7232.
