### PR TITLE
fix(openai): recover half-open stream stalls and tolerate empty data: lines

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -878,6 +878,9 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 			sawDone = true
 			break
 		}
+		if data == "" {
+			continue
+		}
 
 		var sr streamResponse
 		if err := json.Unmarshal([]byte(data), &sr); err != nil {
@@ -983,7 +986,13 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		return emitted, err
 	}
 	if stalled.Load() {
-		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)
+		// Wrap io.ErrUnexpectedEOF so streamWithReconnect treats a half-open
+		// stall — a proxy that drops silently mid-stream with no FIN/RST, the
+		// watchdog's primary target — as recoverable, identical to the clean-FIN
+		// idle-close just below. Without it the stall bypasses reconnect and
+		// hard-fails the turn instead of replaying (pre-output) or surfacing a
+		// retryable StreamInterruptedError (post-output).
+		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped: %w", c.name, idleTimeout, io.ErrUnexpectedEOF)
 	}
 	if err := scanner.Err(); err != nil {
 		return emitted, fmt.Errorf("%s: read stream: %w", c.name, err)

--- a/internal/provider/openai/stall_recover_test.go
+++ b/internal/provider/openai/stall_recover_test.go
@@ -1,0 +1,106 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// TestStreamStallRecoversViaReconnect exercises the watchdog's primary target:
+// a proxy that drops a long-lived SSE connection silently mid-stream (no FIN,
+// no RST) during a reasoner's first-token gap, before any model output. The
+// stall must be treated as recoverable and replayed — like a clean idle-close —
+// not surfaced as a hard failure. Before the fix the stall error was plain and
+// bypassed streamWithReconnect, so this test would fail with a "stalled" error.
+func TestStreamStallRecoversViaReconnect(t *testing.T) {
+	release := make(chan struct{})
+	var reqs atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if reqs.Add(1) == 1 {
+			// First connection: one keep-alive comment (resets the watchdog
+			// once) then total silence — a half-open connection that never
+			// delivers data and never closes.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flush(w)
+			_, _ = io.WriteString(w, ": keep-alive\n\n")
+			flush(w)
+			<-release
+			return
+		}
+		// Reconnect serves a complete stream.
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	p.(*client).idleTimeout = 150 * time.Millisecond
+
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var text strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("a pre-output half-open stall should reconnect, not surface: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			text.WriteString(chunk.Text)
+		}
+	}
+	if got := text.String(); got != "recovered" {
+		t.Errorf("text = %q, want %q (stall should have triggered a reconnect)", got, "recovered")
+	}
+	if got := reqs.Load(); got != 2 {
+		t.Errorf("server saw %d requests, want 2 (one stall + one replay)", got)
+	}
+}
+
+// TestStreamToleratesEmptyDataLine: an OpenAI-compatible gateway may emit an
+// empty or heartbeat `data:` line. Before the fix the empty payload failed
+// json.Unmarshal ("unexpected end of JSON input") and fatally aborted the whole
+// turn; the sibling Anthropic/Responses transports tolerate it.
+func TestStreamToleratesEmptyDataLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data:\n\n") // heartbeat / empty payload
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var text strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("empty data: line should be tolerated, not abort the stream: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			text.WriteString(chunk.Text)
+		}
+	}
+	if got := text.String(); got != "ok" {
+		t.Errorf("text = %q, want %q", got, "ok")
+	}
+}


### PR DESCRIPTION
## Summary

Two stream-robustness fixes in the OpenAI-compatible provider (`internal/provider/openai/openai.go`), which serves DeepSeek, MiMo, MiniMax-M3, and any OpenAI-compatible gateway.

### 1. A watchdog stall bypassed stream recovery (high)

The idle watchdog turns a **half-open TCP drop** into a recoverable error — the common failure when a local proxy (v2rayN / sing-box) silently drops the long-lived SSE connection during a reasoner's first-token gap, sending no FIN and no RST. It detected the stall but returned a *plain* `stream stalled` error, while the **clean-FIN** idle-close path just below wraps `io.ErrUnexpectedEOF`:

```go
if stalled.Load() {
    return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout) // plain
}
// …
if !sawDone && lastFinishReason == "" {
    return emitted, fmt.Errorf("%s: stream ended before completion: %w", c.name, io.ErrUnexpectedEOF) // wrapped
}
```

`streamWithReconnect` gates reconnect (pre-output) / `StreamInterruptedError` (post-output) on `provider.IsConnReset`, which matches `io.ErrUnexpectedEOF`. The plain stall error failed that check, so a half-open stall **hard-failed the turn** instead of replaying — even though a clean idle-close on the same connection recovered fine. The watchdog's primary target was the one case not actually recovered.

Fix: wrap the stall error with `%w io.ErrUnexpectedEOF`, so the half-open stall is treated identically to the clean-FIN drop. Cancellation/deadline still bypass reconnect (`IsConnReset` excludes `context.Canceled`/`DeadlineExceeded` — `TestStreamCancelDoesNotReconnect` holds).

### 2. An empty / heartbeat `data:` line fatally aborted the stream (medium)

`readStream` unmarshaled every `data:` payload with no empty guard:

```go
data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
if data == "[DONE]" { sawDone = true; break }
var sr streamResponse
if err := json.Unmarshal([]byte(data), &sr); err != nil {
    return emitted, fmt.Errorf("%s: decode stream: %w", c.name, err) // fatal
}
```

`json.Unmarshal([]byte(""))` returns `unexpected end of JSON input`, so a heartbeat/keep-alive `data:\n\n` from a compatible gateway killed the whole turn with a confusing "decode stream" error. The Anthropic (`anthropic.go`) and Responses (`responses.go`) transports both tolerate empty data: lines; OpenAI was the outlier. Fix: `if data == "" { continue }` (Anthropic style).

## Tests

`internal/provider/openai/stall_recover_test.go`:
- `TestStreamStallRecoversViaReconnect` — first connection stalls (half-open, no FIN) before any output, second serves a complete stream → turn completes with `"recovered"`, server saw 2 requests. (Before the fix: a hard `stream stalled` error.)
- `TestStreamToleratesEmptyDataLine` — an empty `data:` line followed by real data + `[DONE]` completes with `"ok"`. (Before the fix: `decode stream: unexpected end of JSON input`.)

Existing `TestStreamStallTimesOut`, `TestStreamReconnectsOnEarlyConnReset`, and `TestStreamCancelDoesNotReconnect` pass unchanged. `go vet ./...` and the full `internal/provider/openai` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cache-impact: none - reconnect replays the identical request body (same messages/prompt via the unchanged newReq/body closure), so the prefix-cache prefix is stable; the empty-data: skip only changes handling of a heartbeat line, not the request payload or message history.
Cache-guard: existing TestStreamReconnectsOnEarlyConnReset asserts the replay is byte-identical; new TestStreamStallRecoversViaReconnect asserts stall->replay completes; reconnect reuses the same request bytes so prefix boundaries do not move.

Documentation-impact: none - transport-level stream recovery; retry/reconnect behavior is already documented at the feature level and unchanged, this makes it apply to half-open stalls.