### PR TITLE
fix(updater): recover superseded pending transactions / 自动恢复过期更新事务

### DIFF
--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"runtime"
@@ -28,8 +29,9 @@ var errUpdateInProgress = errors.New("update: another download or install is alr
 var updaterRequestIDRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
 
 var (
-	pendingUpdateExistsForInstall    = repair.PendingUpdateExists
-	reconcilePendingUpdateForInstall = repair.ReconcilePendingUpdate
+	pendingUpdateExistsForInstall            = repair.PendingUpdateExists
+	archiveSupersededPendingUpdateForInstall = archiveSupersededLegacyUpdateAfterReady
+	reconcilePendingUpdateForInstall         = repair.ReconcilePendingUpdate
 )
 
 func validateUpdaterRequest(requestID, selectedChannel, expectedVersion string) (string, string, string, error) {
@@ -246,7 +248,7 @@ func (a *App) installUpdateRequest(selectedChannel, expectedVersion, requestID s
 	if artifactKindFromMeta(meta.ArtifactKind) != artifactKindFromMeta(wantKind) {
 		return a.failUpdate(requestID, selectedChannel, expectedVersion, errUpdateCacheMismatch)
 	}
-	if err := a.reconcilePendingUpdateBeforeInstall(requestID, meta); err != nil {
+	if err := a.reconcilePendingUpdateForRequest(requestID, meta); err != nil {
 		return err
 	}
 
@@ -258,12 +260,22 @@ func (a *App) installUpdateRequest(selectedChannel, expectedVersion, requestID s
 	}
 }
 
-// reconcilePendingUpdateBeforeInstall runs before install-mode dispatch so a
-// profile change cannot let the deb or portable path bypass an unfinished
-// release-unit transaction from the previous attempt.
-func (a *App) reconcilePendingUpdateBeforeInstall(requestID string, meta *cachedUpdate) error {
+// reconcilePendingUpdateForRequest runs before download and again before
+// install-mode dispatch. The early pass avoids paying download and verification
+// costs for a blocked update; the second pass prevents a profile change or a
+// concurrent process from bypassing an unfinished release-unit transaction.
+func (a *App) reconcilePendingUpdateForRequest(requestID string, meta *cachedUpdate) error {
 	if pendingUpdateExistsForInstall() {
 		a.emitProgress(requestID, meta.Channel, meta.Version, "recovering", meta.Size, meta.Size, "")
+		// A user-initiated update proves the versioned desktop reached a usable
+		// UI. Retire a superseded flat-layout transaction here as well as in the
+		// delayed post-DOM health task, so an immediate click never has to fail
+		// once and ask the user to retry.
+		if archived, archiveErr := archiveSupersededPendingUpdateForInstall(); archiveErr != nil {
+			slog.Debug("desktop: superseded update was not eligible for automatic archival", "err", archiveErr)
+		} else if archived {
+			slog.Info("desktop: archived superseded update before install")
+		}
 	}
 	if _, err := reconcilePendingUpdateForInstall(version); err != nil {
 		if errors.Is(err, repair.ErrPendingUpdateAwaitingHealth) {
@@ -400,6 +412,12 @@ func (a *App) ApplyUpdateRequest(selectedChannel, expectedVersion, requestID str
 	// sequence, so another request cannot slip into the former phase gap.
 	defer finish()
 
+	if err := a.reconcilePendingUpdateForRequest(requestID, &cachedUpdate{
+		Channel: selectedChannel,
+		Version: expectedVersion,
+	}); err != nil {
+		return err
+	}
 	if _, err := a.downloadUpdateRequest(selectedChannel, expectedVersion, requestID); err != nil {
 		return err
 	}

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -146,14 +146,17 @@ func TestUpdaterNativeOperationsFailFastWhileBusy(t *testing.T) {
 
 func TestUpdaterReconcilesPendingUpdateBeforeInstallModeDispatch(t *testing.T) {
 	originalExists := pendingUpdateExistsForInstall
+	originalArchive := archiveSupersededPendingUpdateForInstall
 	originalReconcile := reconcilePendingUpdateForInstall
 	t.Cleanup(func() {
 		pendingUpdateExistsForInstall = originalExists
+		archiveSupersededPendingUpdateForInstall = originalArchive
 		reconcilePendingUpdateForInstall = originalReconcile
 	})
 
 	called := false
 	pendingUpdateExistsForInstall = func() bool { return true }
+	archiveSupersededPendingUpdateForInstall = func() (bool, error) { return false, nil }
 	reconcilePendingUpdateForInstall = func(runningVersion string) (repair.PendingUpdateReconcileResult, error) {
 		called = true
 		if runningVersion != version {
@@ -162,7 +165,7 @@ func TestUpdaterReconcilesPendingUpdateBeforeInstallModeDispatch(t *testing.T) {
 		return repair.PendingUpdateReconcileResult{Pending: true, Cleared: true}, nil
 	}
 	meta := &cachedUpdate{Channel: "preview", Version: "v1.18.0-preview.65", Size: 42}
-	if err := (&App{}).reconcilePendingUpdateBeforeInstall("install-1", meta); err != nil {
+	if err := (&App{}).reconcilePendingUpdateForRequest("install-1", meta); err != nil {
 		t.Fatal(err)
 	}
 	if !called {
@@ -170,20 +173,74 @@ func TestUpdaterReconcilesPendingUpdateBeforeInstallModeDispatch(t *testing.T) {
 	}
 }
 
-func TestUpdaterBlocksInstallWhilePreviousReleaseAwaitsHealth(t *testing.T) {
+func TestUpdaterArchivesSupersededUpdateBeforeReconciliation(t *testing.T) {
 	originalExists := pendingUpdateExistsForInstall
+	originalArchive := archiveSupersededPendingUpdateForInstall
 	originalReconcile := reconcilePendingUpdateForInstall
 	t.Cleanup(func() {
 		pendingUpdateExistsForInstall = originalExists
+		archiveSupersededPendingUpdateForInstall = originalArchive
+		reconcilePendingUpdateForInstall = originalReconcile
+	})
+
+	archived := false
+	pendingUpdateExistsForInstall = func() bool { return true }
+	archiveSupersededPendingUpdateForInstall = func() (bool, error) {
+		archived = true
+		return true, nil
+	}
+	reconcilePendingUpdateForInstall = func(string) (repair.PendingUpdateReconcileResult, error) {
+		if !archived {
+			t.Fatal("reconciliation ran before superseded update archival")
+		}
+		return repair.PendingUpdateReconcileResult{}, nil
+	}
+	meta := &cachedUpdate{Channel: "stable", Version: "v1.20.0", Size: 42}
+	if err := (&App{}).reconcilePendingUpdateForRequest("install-1", meta); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdaterReconcilesBeforeDownloading(t *testing.T) {
+	originalExists := pendingUpdateExistsForInstall
+	originalArchive := archiveSupersededPendingUpdateForInstall
+	originalReconcile := reconcilePendingUpdateForInstall
+	t.Cleanup(func() {
+		pendingUpdateExistsForInstall = originalExists
+		archiveSupersededPendingUpdateForInstall = originalArchive
 		reconcilePendingUpdateForInstall = originalReconcile
 	})
 
 	pendingUpdateExistsForInstall = func() bool { return true }
+	archiveSupersededPendingUpdateForInstall = func() (bool, error) { return false, nil }
+	reconcilePendingUpdateForInstall = func(string) (repair.PendingUpdateReconcileResult, error) {
+		return repair.PendingUpdateReconcileResult{Pending: true}, errors.New("blocked before download")
+	}
+	err := (&App{}).ApplyUpdateRequest("stable", "v1.20.0", "preflight-recovery")
+	if err == nil || !strings.Contains(err.Error(), "blocked before download") {
+		t.Fatalf("pre-download recovery error=%v", err)
+	}
+}
+
+func TestUpdaterBlocksInstallWhilePreviousReleaseAwaitsHealth(t *testing.T) {
+	originalExists := pendingUpdateExistsForInstall
+	originalArchive := archiveSupersededPendingUpdateForInstall
+	originalReconcile := reconcilePendingUpdateForInstall
+	t.Cleanup(func() {
+		pendingUpdateExistsForInstall = originalExists
+		archiveSupersededPendingUpdateForInstall = originalArchive
+		reconcilePendingUpdateForInstall = originalReconcile
+	})
+
+	pendingUpdateExistsForInstall = func() bool { return true }
+	archiveSupersededPendingUpdateForInstall = func() (bool, error) {
+		return false, errors.New("not a superseded flat-layout transaction")
+	}
 	reconcilePendingUpdateForInstall = func(string) (repair.PendingUpdateReconcileResult, error) {
 		return repair.PendingUpdateReconcileResult{Pending: true, AwaitingHealth: true}, repair.ErrPendingUpdateAwaitingHealth
 	}
 	meta := &cachedUpdate{Channel: "preview", Version: "v1.18.0-preview.65", Size: 42}
-	err := (&App{}).reconcilePendingUpdateBeforeInstall("install-1", meta)
+	err := (&App{}).reconcilePendingUpdateForRequest("install-1", meta)
 	if err == nil || !strings.Contains(err.Error(), "startup health check") {
 		t.Fatalf("health-check recovery error = %v", err)
 	}

--- a/internal/repair/update_legacy.go
+++ b/internal/repair/update_legacy.go
@@ -1,6 +1,7 @@
 package repair
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,19 +10,25 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+
+	"reasonix/internal/config"
+	"reasonix/internal/installlayout"
 )
 
-// ArchiveSupersededPendingFileUpdate retires an older file-update transaction
-// after a newer versioned installation has started successfully. It never
-// deletes the transaction or trusts version text alone: every recorded target
-// must belong to installRoot, the running version must be strictly newer, and
-// the exact transaction is revalidated under the pending-update lock.
+var supersededUpdateBeforeArchive = func(string) {}
+
+// ArchiveSupersededPendingFileUpdate retires a superseded file-update transaction
+// after the same or a newer versioned installation has started successfully.
+// It never deletes the transaction or trusts version text alone: the current
+// process must be the active desktop named by a valid current.json, every
+// recorded target must belong to the superseded flat installRoot, and the exact
+// transaction is revalidated under the pending-update lock.
 //
 // This is the recovery path for users whose v1.18-v1.19 update completed but
 // whose old Guard never committed startup health. The original JSON is moved to
 // repair/legacy-updates for diagnostics; rollback backups are left untouched.
 func ArchiveSupersededPendingFileUpdate(runningVersion, installRoot string) (bool, error) {
-	tx, err := ReadPendingUpdate()
+	tx, err := readSupersededPendingFileUpdate(runningVersion, installRoot)
 	if os.IsNotExist(err) {
 		return false, nil
 	}
@@ -29,16 +36,13 @@ func ArchiveSupersededPendingFileUpdate(runningVersion, installRoot string) (boo
 		return false, fmt.Errorf("archive superseded pending update: %w", err)
 	}
 	expectedID := UpdateTransactionID(tx)
-	if err := validateSupersededPendingFileUpdate(tx, runningVersion, installRoot); err != nil {
-		return false, err
-	}
 
 	unlock, err := acquirePendingUpdateLock()
 	if err != nil {
 		return false, fmt.Errorf("archive superseded pending update: lock transaction: %w", err)
 	}
 	defer unlock()
-	current, err := ReadPendingUpdate()
+	current, err := readSupersededPendingFileUpdate(runningVersion, installRoot)
 	if os.IsNotExist(err) {
 		return false, nil
 	}
@@ -48,24 +52,65 @@ func ArchiveSupersededPendingFileUpdate(runningVersion, installRoot string) (boo
 	if UpdateTransactionID(current) != expectedID {
 		return false, fmt.Errorf("archive superseded pending update: transaction changed while waiting")
 	}
-	if err := validateSupersededPendingFileUpdate(current, runningVersion, installRoot); err != nil {
-		return false, err
-	}
 
 	pendingPath := PendingUpdatePath()
 	archiveDir := filepath.Join(filepath.Dir(pendingPath), "legacy-updates")
 	if err := os.MkdirAll(archiveDir, 0o700); err != nil {
 		return false, fmt.Errorf("archive superseded pending update: create archive: %w", err)
 	}
+	if !pathInsideResolvedRoot(filepath.Join(config.MemoryUserDir(), "repair"), archiveDir) {
+		return false, fmt.Errorf("archive superseded pending update: archive directory resolves outside the repair directory")
+	}
 	shortID := expectedID
 	if len(shortID) > 16 {
 		shortID = shortID[:16]
 	}
-	archivePath := filepath.Join(archiveDir, fmt.Sprintf("%s-%s.json", time.Now().UTC().Format("20060102T150405.000000000Z"), shortID))
-	if err := os.Rename(pendingPath, archivePath); err != nil {
-		return false, fmt.Errorf("archive superseded pending update: move transaction: %w", err)
+	archiveBase := filepath.Join(archiveDir, fmt.Sprintf("%s-%s", time.Now().UTC().Format("20060102T150405.000000000Z"), shortID))
+	supersededUpdateBeforeArchive(pendingPath)
+	for attempt := 0; attempt < 16; attempt++ {
+		archivePath := fmt.Sprintf("%s-%d.json", archiveBase, attempt)
+		if err := renameRepairNodeNoReplace(pendingPath, archivePath); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("archive superseded pending update: move transaction: %w", err)
+		}
+		restore := func(cause error) error {
+			if restoreErr := renameRepairNodeNoReplace(archivePath, pendingPath); restoreErr != nil {
+				return fmt.Errorf("%w; preserved moved transaction at %s: %v", cause, archivePath, restoreErr)
+			}
+			return cause
+		}
+		body, readErr := os.ReadFile(archivePath)
+		if readErr != nil {
+			return false, restore(fmt.Errorf("archive superseded pending update: verify moved transaction: %w", readErr))
+		}
+		var archived UpdateTransaction
+		if unmarshalErr := json.Unmarshal(body, &archived); unmarshalErr != nil {
+			return false, restore(fmt.Errorf("archive superseded pending update: verify moved transaction: %w", unmarshalErr))
+		}
+		if UpdateTransactionID(&archived) != expectedID {
+			return false, restore(fmt.Errorf("archive superseded pending update: transaction changed before archival"))
+		}
+		return true, nil
 	}
-	return true, nil
+	return false, fmt.Errorf("archive superseded pending update: cannot allocate archive path")
+}
+
+// readSupersededPendingFileUpdate deliberately bypasses the ordinary
+// current-Guard directory check. That check is correct for rollback, but a
+// versioned install runs from versions/<version>/ while the superseded
+// transaction names flat binaries at InstallRoot. Requiring the ordinary read
+// here made this recovery path reject the only state it was designed to heal.
+func readSupersededPendingFileUpdate(runningVersion, installRoot string) (*UpdateTransaction, error) {
+	tx, err := readPendingUpdateUnchecked()
+	if err != nil {
+		return nil, err
+	}
+	if err := validateSupersededPendingFileUpdate(tx, runningVersion, installRoot); err != nil {
+		return nil, err
+	}
+	return tx, nil
 }
 
 func validateSupersededPendingFileUpdate(tx *UpdateTransaction, runningVersion, installRoot string) error {
@@ -74,20 +119,59 @@ func validateSupersededPendingFileUpdate(tx *UpdateTransaction, runningVersion, 
 	}
 	runningVersion = canonicalSemver(runningVersion)
 	pendingVersion := canonicalSemver(tx.ToVersion)
-	if !semver.IsValid(runningVersion) || !semver.IsValid(pendingVersion) || semver.Compare(runningVersion, pendingVersion) <= 0 {
-		return fmt.Errorf("archive superseded pending update: running version %q is not newer than %q", runningVersion, pendingVersion)
+	if !semver.IsValid(runningVersion) || !semver.IsValid(pendingVersion) || semver.Compare(runningVersion, pendingVersion) < 0 {
+		return fmt.Errorf("archive superseded pending update: running version %q is older than %q", runningVersion, pendingVersion)
 	}
 	installRoot = canonicalLegacyInstallPath(installRoot)
 	if installRoot == "" || !filepath.IsAbs(installRoot) {
 		return fmt.Errorf("archive superseded pending update: install root is invalid")
+	}
+	launcher, err := repairExecutable()
+	if err != nil {
+		return fmt.Errorf("archive superseded pending update: current executable is unavailable")
+	}
+	resolvedRoot, err := installlayout.ResolveInstallRoot(launcher)
+	if err != nil || canonicalLegacyInstallPath(resolvedRoot) != installRoot {
+		return fmt.Errorf("archive superseded pending update: current executable is outside the install root")
+	}
+	ptr, err := installlayout.ReadCurrent(installRoot)
+	if err != nil {
+		return fmt.Errorf("archive superseded pending update: current installation is not versioned: %w", err)
+	}
+	if canonicalSemver(ptr.ActiveVersion) != runningVersion {
+		return fmt.Errorf("archive superseded pending update: active install version %q does not match running version %q", ptr.ActiveVersion, runningVersion)
+	}
+	activeDesktop, err := installlayout.ActiveDesktopPath(installRoot)
+	if err != nil {
+		return fmt.Errorf("archive superseded pending update: active desktop is unavailable: %w", err)
+	}
+	if canonicalRepairPath(activeDesktop) != canonicalRepairPath(launcher) {
+		return fmt.Errorf("archive superseded pending update: current executable is not the active desktop")
+	}
+	platform := strings.TrimSpace(tx.Platform)
+	if slash := strings.IndexByte(platform, '/'); slash >= 0 {
+		platform = platform[:slash]
+	}
+	if platform != runtime.GOOS {
+		return fmt.Errorf("archive superseded pending update: transaction platform %q does not match %q", tx.Platform, runtime.GOOS)
+	}
+	// Validate every transaction field and backup path while substituting the
+	// old primary target as the legacy launcher's location. The only ordinary
+	// invariant intentionally relaxed is that this target must sit beside the
+	// current versioned desktop.
+	if err := validateUpdateTransactionForLauncher(tx, tx.TargetPath); err != nil {
+		return fmt.Errorf("archive superseded pending update: invalid transaction: %w", err)
+	}
+	if canonicalLegacyInstallPath(filepath.Dir(tx.TargetPath)) != installRoot {
+		return fmt.Errorf("archive superseded pending update: target is not a flat install member")
 	}
 	targets := []string{tx.TargetPath}
 	for _, file := range tx.Files {
 		targets = append(targets, file.TargetPath)
 	}
 	for _, target := range targets {
-		if !legacyTargetWithinRoot(installRoot, target) {
-			return fmt.Errorf("archive superseded pending update: target escapes install root")
+		if canonicalLegacyInstallPath(filepath.Dir(target)) != installRoot {
+			return fmt.Errorf("archive superseded pending update: release member is not in the flat install root")
 		}
 	}
 	return nil
@@ -107,13 +191,4 @@ func canonicalLegacyInstallPath(path string) string {
 		path = strings.ToLower(path)
 	}
 	return path
-}
-
-func legacyTargetWithinRoot(root, target string) bool {
-	target = canonicalLegacyInstallPath(target)
-	if target == "" || !filepath.IsAbs(target) {
-		return false
-	}
-	rel, err := filepath.Rel(root, target)
-	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel)
 }

--- a/internal/repair/update_legacy_test.go
+++ b/internal/repair/update_legacy_test.go
@@ -3,78 +3,317 @@ package repair
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
+
+	"reasonix/internal/installlayout"
 )
 
-func TestArchiveSupersededPendingFileUpdateMovesExactTransaction(t *testing.T) {
+type supersededUpdateFixture struct {
+	home        string
+	root        string
+	target      string
+	active      string
+	backup      string
+	pendingBody []byte
+	transaction *UpdateTransaction
+	running     string
+}
+
+func prepareSupersededUpdateFixture(t *testing.T, pendingVersion, runningVersion string) supersededUpdateFixture {
+	t.Helper()
 	home := t.TempDir()
 	t.Setenv("REASONIX_HOME", home)
 	root := t.TempDir()
-	setLegacyRepairExecutable(t, root)
-	target := filepath.Join(root, "reasonix-desktop")
-	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
+	originalExecutable := repairExecutable
+	t.Cleanup(func() { repairExecutable = originalExecutable })
+
+	target := filepath.Join(root, installlayout.DesktopBinaryName())
+	if err := os.WriteFile(target, []byte("old desktop"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := PrepareFileUpdate("v1.18.0", "v1.19.1", target); err != nil {
+	guardName := "reasonix-guard"
+	if runtime.GOOS == "windows" {
+		guardName += ".exe"
+	}
+	guard := filepath.Join(root, guardName)
+	if err := os.WriteFile(guard, []byte("old guard"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	archived, err := ArchiveSupersededPendingFileUpdate("v1.20.0", root)
+	repairExecutable = func() (string, error) { return guard, nil }
+	tx, err := PrepareFileUpdate("v1.18.0", pendingVersion, target, guard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingBody, err := os.ReadFile(PendingUpdatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runningVersion = canonicalSemver(runningVersion)
+	activeDir := filepath.Join(root, filepath.FromSlash(installlayout.VersionDirRelative(runningVersion)))
+	if err := os.MkdirAll(activeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(activeDir, installlayout.DesktopBinaryName())
+	if err := os.WriteFile(active, []byte("healthy versioned desktop"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := installlayout.WriteCurrent(root, installlayout.CurrentPointer{
+		ActiveVersion: runningVersion,
+		ActiveDir:     installlayout.VersionDirRelative(runningVersion),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	repairExecutable = func() (string, error) { return active, nil }
+
+	return supersededUpdateFixture{
+		home: home, root: root, target: target, active: active,
+		backup: tx.BackupPath, pendingBody: pendingBody, transaction: tx,
+		running: runningVersion,
+	}
+}
+
+func TestArchiveSupersededPendingFileUpdateHealsGuardDirectoryMismatch(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	if _, err := ReadPendingUpdate(); err == nil || !strings.Contains(err.Error(), "outside the current Guard installation") {
+		t.Fatalf("ReadPendingUpdate error = %v, want the reported Guard-directory mismatch", err)
+	}
+
+	archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
 	if err != nil || !archived {
 		t.Fatalf("archived=%v err=%v", archived, err)
 	}
-	if _, err := ReadPendingUpdate(); !os.IsNotExist(err) {
+	if _, err := os.Lstat(PendingUpdatePath()); !os.IsNotExist(err) {
 		t.Fatalf("pending transaction survived: %v", err)
 	}
-	entries, err := os.ReadDir(filepath.Join(home, "repair", "legacy-updates"))
+	entries, err := os.ReadDir(filepath.Join(fixture.home, "repair", "legacy-updates"))
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("archive entries=%v err=%v", entries, err)
 	}
-	if body, err := os.ReadFile(target); err != nil || string(body) != "old" {
-		t.Fatalf("target=%q err=%v", body, err)
+	archivedBody, err := os.ReadFile(filepath.Join(fixture.home, "repair", "legacy-updates", entries[0].Name()))
+	if err != nil || string(archivedBody) != string(fixture.pendingBody) {
+		t.Fatalf("archived transaction changed: err=%v\n got=%q\nwant=%q", err, archivedBody, fixture.pendingBody)
+	}
+	if body, err := os.ReadFile(fixture.backup); err != nil || string(body) != "old desktop" {
+		t.Fatalf("rollback backup=%q err=%v", body, err)
+	}
+	if len(fixture.transaction.Files) != 2 {
+		t.Fatalf("release-unit files=%d, want desktop and Guard", len(fixture.transaction.Files))
+	}
+	if body, err := os.ReadFile(fixture.transaction.Files[1].BackupPath); err != nil || string(body) != "old guard" {
+		t.Fatalf("Guard rollback backup=%q err=%v", body, err)
+	}
+	if body, err := os.ReadFile(fixture.active); err != nil || string(body) != "healthy versioned desktop" {
+		t.Fatalf("active desktop=%q err=%v", body, err)
 	}
 }
 
-func TestArchiveSupersededPendingFileUpdateRejectsEqualVersion(t *testing.T) {
-	t.Setenv("REASONIX_HOME", t.TempDir())
-	root := t.TempDir()
-	setLegacyRepairExecutable(t, root)
-	target := filepath.Join(root, "reasonix-desktop")
-	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
-		t.Fatal(err)
+func TestArchiveSupersededPendingFileUpdateAcceptsSameVersionReinstall(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.3", "v1.19.3")
+	archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
+	if err != nil || !archived {
+		t.Fatalf("same-version healthy reinstall archived=%v err=%v", archived, err)
 	}
-	if _, err := PrepareFileUpdate("v1.18.0", "v1.19.1", target); err != nil {
-		t.Fatal(err)
-	}
-	if archived, err := ArchiveSupersededPendingFileUpdate("v1.19.1", root); err == nil || archived {
+}
+
+func TestArchiveSupersededPendingFileUpdateRejectsOlderRunningVersion(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.20.0", "v1.19.3")
+	if archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root); err == nil || archived {
 		t.Fatalf("archived=%v err=%v", archived, err)
 	}
-	if _, err := ReadPendingUpdate(); err != nil {
-		t.Fatalf("rejected transaction was removed: %v", err)
-	}
+	assertPendingTransactionUnchanged(t, fixture.pendingBody)
 }
 
 func TestArchiveSupersededPendingFileUpdateRejectsForeignInstall(t *testing.T) {
-	t.Setenv("REASONIX_HOME", t.TempDir())
-	owner := t.TempDir()
-	setLegacyRepairExecutable(t, owner)
-	target := filepath.Join(owner, "reasonix-desktop")
-	if err := os.WriteFile(target, []byte("old"), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := PrepareFileUpdate("v1.18.0", "v1.19.1", target); err != nil {
-		t.Fatal(err)
-	}
-	if archived, err := ArchiveSupersededPendingFileUpdate("v1.20.0", t.TempDir()); err == nil || archived {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	if archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, t.TempDir()); err == nil || archived {
 		t.Fatalf("archived=%v err=%v", archived, err)
 	}
-	if _, err := ReadPendingUpdate(); err != nil {
-		t.Fatalf("foreign transaction was removed: %v", err)
+	assertPendingTransactionUnchanged(t, fixture.pendingBody)
+}
+
+func TestArchiveSupersededPendingFileUpdateRejectsNonActiveExecutable(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	other := filepath.Join(filepath.Dir(fixture.active), "other-desktop")
+	if err := os.WriteFile(other, []byte("other"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	repairExecutable = func() (string, error) { return other, nil }
+	if archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root); err == nil || archived {
+		t.Fatalf("archived=%v err=%v", archived, err)
+	}
+	assertPendingTransactionUnchanged(t, fixture.pendingBody)
+}
+
+func TestArchiveSupersededPendingFileUpdateRejectsPlatformMismatch(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	changed := *fixture.transaction
+	changed.Platform = "foreign/amd64"
+	if err := overwritePendingUpdateForTest(&changed); err != nil {
+		t.Fatal(err)
+	}
+	changedBody, err := os.ReadFile(PendingUpdatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root); err == nil || archived {
+		t.Fatalf("archived=%v err=%v", archived, err)
+	}
+	assertPendingTransactionUnchanged(t, changedBody)
+}
+
+func TestArchiveSupersededPendingFileUpdateRejectsNestedLegacyTarget(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	nestedDir := filepath.Join(fixture.root, "other")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nestedTarget := filepath.Join(nestedDir, installlayout.DesktopBinaryName())
+	changed := *fixture.transaction
+	changed.TargetPath = nestedTarget
+	changed.Files = append([]UpdateTransactionFile(nil), fixture.transaction.Files...)
+	for i := range changed.Files {
+		changed.Files[i].TargetPath = nestedTarget
+	}
+	if err := overwritePendingUpdateForTest(&changed); err != nil {
+		t.Fatal(err)
+	}
+	changedBody, err := os.ReadFile(PendingUpdatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root); err == nil || archived {
+		t.Fatalf("archived=%v err=%v", archived, err)
+	}
+	assertPendingTransactionUnchanged(t, changedBody)
+}
+
+func TestArchiveSupersededPendingFileUpdateDetectsConcurrentReplacement(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	originalAcquire := acquirePendingUpdateLock
+	attempted := make(chan struct{})
+	release := make(chan struct{})
+	acquirePendingUpdateLock = func() (func(), error) {
+		close(attempted)
+		<-release
+		return func() {}, nil
+	}
+	t.Cleanup(func() { acquirePendingUpdateLock = originalAcquire })
+
+	type outcome struct {
+		archived bool
+		err      error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
+		done <- outcome{archived: archived, err: err}
+	}()
+	<-attempted
+	changed := *fixture.transaction
+	changed.CreatedAt = time.Now().UTC().Add(time.Second).Format(time.RFC3339Nano)
+	if err := overwritePendingUpdateForTest(&changed); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	result := <-done
+	if result.err == nil || result.archived || !strings.Contains(result.err.Error(), "transaction changed while waiting") {
+		t.Fatalf("archived=%v err=%v", result.archived, result.err)
+	}
+	current, err := readPendingUpdateUnchecked()
+	if err != nil || UpdateTransactionID(current) != UpdateTransactionID(&changed) {
+		t.Fatalf("concurrent transaction was not preserved: current=%+v err=%v", current, err)
 	}
 }
 
-func setLegacyRepairExecutable(t *testing.T, root string) {
+func TestArchiveSupersededPendingFileUpdateRestoresLateConcurrentRewrite(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	changed := *fixture.transaction
+	changed.CreatedAt = time.Now().UTC().Add(2 * time.Second).Format(time.RFC3339Nano)
+	originalHook := supersededUpdateBeforeArchive
+	supersededUpdateBeforeArchive = func(string) {
+		if err := overwritePendingUpdateForTest(&changed); err != nil {
+			t.Fatalf("rewrite pending transaction: %v", err)
+		}
+	}
+	t.Cleanup(func() { supersededUpdateBeforeArchive = originalHook })
+
+	archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
+	if err == nil || archived || !strings.Contains(err.Error(), "transaction changed before archival") {
+		t.Fatalf("archived=%v err=%v", archived, err)
+	}
+	current, readErr := readPendingUpdateUnchecked()
+	if readErr != nil || UpdateTransactionID(current) != UpdateTransactionID(&changed) {
+		t.Fatalf("late replacement was not restored: current=%+v err=%v", current, readErr)
+	}
+	entries, readDirErr := os.ReadDir(filepath.Join(fixture.home, "repair", "legacy-updates"))
+	if readDirErr != nil || len(entries) != 0 {
+		t.Fatalf("unexpected archive after restored rewrite: entries=%v err=%v", entries, readDirErr)
+	}
+}
+
+func TestArchiveSupersededPendingFileUpdateSerializesConcurrentRecovery(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	start := make(chan struct{})
+	type outcome struct {
+		archived bool
+		err      error
+	}
+	done := make(chan outcome, 2)
+	for range 2 {
+		go func() {
+			<-start
+			archived, err := ArchiveSupersededPendingFileUpdate(fixture.running, fixture.root)
+			done <- outcome{archived: archived, err: err}
+		}()
+	}
+	close(start)
+	archivedCount := 0
+	for range 2 {
+		result := <-done
+		if result.err != nil {
+			t.Fatalf("concurrent recovery error: %v", result.err)
+		}
+		if result.archived {
+			archivedCount++
+		}
+	}
+	if archivedCount != 1 {
+		t.Fatalf("archived count=%d, want exactly one", archivedCount)
+	}
+	entries, err := os.ReadDir(filepath.Join(fixture.home, "repair", "legacy-updates"))
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("archive entries=%v err=%v", entries, err)
+	}
+}
+
+func TestArchiveSupersededPendingFileUpdateRejectsMalformedTransaction(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	body := `{"schemaVersion":1,"toVersion":`
+	writePendingUpdateRaw(t, body)
+	if archived, err := ArchiveSupersededPendingFileUpdate("v1.20.0", t.TempDir()); err == nil || archived {
+		t.Fatalf("archived=%v err=%v", archived, err)
+	}
+	got, err := os.ReadFile(PendingUpdatePath())
+	if err != nil || string(got) != body {
+		t.Fatalf("malformed transaction changed: got=%q err=%v", got, err)
+	}
+}
+
+func assertPendingTransactionUnchanged(t *testing.T, want []byte) {
 	t.Helper()
-	original := repairExecutable
-	repairExecutable = func() (string, error) { return filepath.Join(root, "reasonix-guard"), nil }
-	t.Cleanup(func() { repairExecutable = original })
+	got, err := os.ReadFile(PendingUpdatePath())
+	if err != nil || string(got) != string(want) {
+		t.Fatalf("pending transaction changed: err=%v\n got=%q\nwant=%q", err, got, want)
+	}
+}
+
+func TestSupersededUpdateFixtureUsesCurrentPlatform(t *testing.T) {
+	fixture := prepareSupersededUpdateFixture(t, "v1.19.1", "v1.20.0")
+	if !strings.HasPrefix(fixture.transaction.Platform, runtime.GOOS+"/") {
+		t.Fatalf("transaction platform=%q, want %s", fixture.transaction.Platform, runtime.GOOS)
+	}
 }


### PR DESCRIPTION
## Summary

- recover valid pending file-update transactions that belong to the superseded flat install layout
- prove the running process is the active versioned desktop before archiving any transaction
- reconcile before downloading and again before install dispatch, avoiding wasted bandwidth and a fail-once/retry user flow
- preserve the exact transaction JSON and every rollback backup for diagnosis or manual recovery

## Problem

After a flat-to-versioned Windows reinstall or upgrade, `pending-update.json` can still describe the old flat desktop and Guard release unit. The transaction is structurally valid, so the debris recovery added by #7366 correctly preserves it. Ordinary reconciliation then compares its targets with the current versioned executable directory and fails with:

```text
update recovery: could not safely finish the previous update: reconcile pending update: pending update target is outside the current Guard installation
```

Retrying or reinstalling does not help because the transaction lives in the Reasonix state directory. Every later in-app update remains blocked.

## Root cause

`ArchiveSupersededPendingFileUpdate` was intended to retire this old transaction after the versioned desktop started successfully, but it began with `ReadPendingUpdate`. That reader enforces the same current-launcher-directory invariant that rejects old flat-layout targets, so the recovery path could never reach the transaction it was designed to heal.

## Fix

The superseded path now performs a separate, strict eligibility check:

1. the running executable must resolve to the supplied install root;
2. a valid `current.json` must name the running version and exact active desktop;
3. the pending transaction platform must match the current platform;
4. the ordinary transaction, member, hash, filename, and backup invariants must all pass;
5. the primary target and every release-unit member must be direct children of the old flat install root;
6. the running version must be the same as or newer than the pending target version.

The transaction is read again under the pending-update lock and its full identity is compared. Archival uses a no-replace rename, verifies the moved JSON, restores it if a late rewrite is detected, and never deletes rollback backups. Foreign, newer, malformed, or concurrently replaced state continues to fail closed.

The Desktop updater attempts this recovery before download, then runs ordinary reconciliation. It repeats reconciliation immediately before install dispatch to close profile-change and concurrent-process gaps.

## User impact

- no manual deletion of `pending-update.json`
- no reinstall ritual
- no first failed update followed by a retry
- no full installer download when an unrecoverable pending transaction should block the request
- same-version reinstall recovery is supported when the active versioned-install identity is proven

## Compatibility

| State or contract | Behavior | Result |
| --- | --- | --- |
| Existing pending-update JSON | No schema or field changes | Backward compatible |
| Valid current-layout transaction | Ordinary cancel/rollback/reconcile remains authoritative | Preserved |
| Valid superseded flat-layout transaction | Archived only after active versioned-install identity is proven | Automatically recovered |
| Structurally unusable marker | Existing #7366 debris classification remains authoritative | Preserved |
| Foreign install, platform mismatch, newer pending version, or changed transaction | Refused without deletion | Fail closed |
| Rollback backups | Never removed by superseded archival | Preserved |
| Provider, prompt, tool, or cache contracts | Unchanged | No cache impact |

## Concurrency and security

- the initial snapshot is re-read and compared under the existing cross-process pending lock
- archive destinations are constrained to the repair directory and never replaced
- the moved transaction is parsed and identity-checked before success is reported
- deterministic tests cover replacement while waiting for the lock, a late uncooperative rewrite, and two concurrent recovery attempts

## Verification

- `go test ./...`
- `go vet ./...`
- `go test ./internal/repair -count=1`
- `go test -race ./internal/repair -run 'ArchiveSuperseded|PendingUpdate|Reconcile' -count=1`
- `go test ./internal/repair -run 'TestArchiveSupersededPendingFileUpdate' -count=10`
- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `cd desktop && go test . -run 'TestUpdater(ArchivesSuperseded|ReconcilesPending|ReconcilesBeforeDownloading|BlocksInstall)' -count=5`
- Windows amd64 cross-compilation of the repair and Desktop test binaries
- `git diff --check`

## Related

- follow-up to #7366 for valid environment-relative transactions that must not be treated as debris
- addresses the Windows failure reported in #7244 and consolidated in #7342
- independent of #7369; the PRs do not modify the same files
