### PR TITLE
fix(feishu): close resource file handle after reading

### DIFF
--- a/internal/bot/feishu/inbound.go
+++ b/internal/bot/feishu/inbound.go
@@ -219,6 +219,9 @@ func (a *adapter) sdkFetchResource(ctx context.Context, messageID, key, typ stri
 		if !resp.Success() {
 			return fmt.Errorf("feishu resource error: %s", feishuCodeError(resp.Code, resp.Msg))
 		}
+		if closer, ok := resp.File.(io.ReadCloser); ok {
+			defer closer.Close()
+		}
 		raw, err := io.ReadAll(io.LimitReader(resp.File, maxFeishuMediaBytes+1))
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

- **Problem**: `sdkFetchResource` reads `resp.File` via `io.ReadAll` without closing it, causing file handle leakage on every resource download (images/files from Feishu messages).
- **Root cause**: `resp.File` implements `io.ReadCloser` at runtime (the SDK returns an HTTP response body), but the code never calls `Close()`.
- **Fix**: Add a type-asserted `defer closer.Close()` after validating the response, ensuring the underlying file handle is released regardless of read success or failure.
- **Files changed**: `internal/bot/feishu/inbound.go` (+3 lines)

## Verification

```
gofmt -l internal/bot/feishu/inbound.go   # OK (no diff)
go vet ./internal/bot/feishu/              # OK
go build ./internal/bot/feishu/            # OK
go test ./internal/bot/feishu/ -count=1    # 25/25 PASS (0.055s)
```

## Cache impact

Cache-impact: none
Cache-guard: N/A (no cache-affecting changes)
System-prompt-review: N/A

---

*Discovered by [SmartBench](https://github.com/xianyu-sheng/SmartBench) evidence-gated multi-agent review.*