### PR TITLE
docs(readme): swap the daily Trendshift badge for the ranked pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/27020"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/daily" alt="#2 Repository Of The Day"/></a>
+  <a href="https://trendshift.io/repositories/27020?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-27020" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/monthly?language=Go" alt="esengine/DeepSeek-Reasonix | Trendshift" width="250" height="55"/></a>
+  <a href="https://trendshift.io/repositories/27020?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-27020" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/27020" alt="esengine/DeepSeek-Reasonix | Trendshift" width="250" height="55"/></a>
 </p>
 
 <br/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,8 @@
 </p>
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/27020"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/daily" alt="#2 Repository Of The Day"/></a>
+  <a href="https://trendshift.io/repositories/27020?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-27020" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/27020/monthly?language=Go" alt="esengine/DeepSeek-Reasonix | Trendshift" width="250" height="55"/></a>
+  <a href="https://trendshift.io/repositories/27020?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-27020" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/27020" alt="esengine/DeepSeek-Reasonix | Trendshift" width="250" height="55"/></a>
 </p>
 
 <br/>


### PR DESCRIPTION
#7363 landed the daily Trendshift badge, whose alt text is pinned to "#2 Repository Of The Day" — accurate for one day, misleading after that. Both READMEs now carry the monthly-Go and repository badges instead, which keep themselves current.

Same centered row below the shields line; the badge endpoints were checked and return `image/svg+xml`.