### PR TITLE
fix(config): stop custom providers inheriting DeepSeek's defaults

### DIFF
--- a/internal/config/decode.go
+++ b/internal/config/decode.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/BurntSushi/toml"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
@@ -23,5 +25,43 @@ func decodeTOMLFileResolved(path string, v any) (toml.MetaData, error) {
 }
 
 func decodeTOMLBytes(data []byte, v any) (toml.MetaData, error) {
-	return toml.Decode(string(fileencoding.DecodeToUTF8(data)), v)
+	text := string(fileencoding.DecodeToUTF8(data))
+	meta, err := toml.Decode(text, v)
+	if err != nil {
+		return meta, err
+	}
+	if cfg, ok := v.(*Config); ok {
+		if err := isolateDecodedProviders(text, meta, cfg); err != nil {
+			return meta, err
+		}
+	}
+	return meta, nil
+}
+
+// isolateDecodedProviders stops one vendor's defaults from being written onto
+// another vendor's provider entry.
+//
+// TOML array-of-tables decoding is positional: BurntSushi/toml unifies
+// [[providers]][i] onto whatever the destination slice already holds at index i
+// instead of onto a zero value. Every config load seeds from Default(), which
+// ships two official DeepSeek entries, so a user's first two [[providers]]
+// inherit every DeepSeek field they did not set themselves — balance_url,
+// the USD price table and context_window = 1000000 (#7357, #7358).
+//
+// Re-decoding the same bytes onto an empty slice makes a declared provider list
+// carry only what the file declares. Defaults that are genuinely correct for an
+// entry are then reapplied by the explicit backfill helpers, which key on the
+// endpoint rather than on list position.
+func isolateDecodedProviders(text string, meta toml.MetaData, cfg *Config) error {
+	if cfg == nil || len(cfg.Providers) == 0 || !meta.IsDefined("providers") {
+		return nil
+	}
+	var isolated struct {
+		Providers []ProviderEntry `toml:"providers"`
+	}
+	if _, err := toml.Decode(text, &isolated); err != nil {
+		return fmt.Errorf("decode providers: %w", err)
+	}
+	cfg.Providers = isolated.Providers
+	return nil
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -390,6 +390,7 @@ func backfillDeepSeekOfficialPrices(c *Config) {
 		if officialProviderKind(p) != "deepseek" {
 			continue
 		}
+		backfillDeepSeekOfficialEndpointDefaults(p)
 		currency := c.DeepSeekOfficialPricingCurrency()
 		if c.DesktopCurrency() == "" && p.persistedOfficialCurrency != "" {
 			currency = p.persistedOfficialCurrency
@@ -407,6 +408,25 @@ func backfillDeepSeekOfficialPrices(c *Config) {
 			}
 		}
 	}
+}
+
+// backfillDeepSeekOfficialEndpointDefaults restores the two official-endpoint
+// fields a config may legitimately omit. Both are safe to infer here precisely
+// because the caller already matched api.deepseek.com: the wallet endpoint is
+// the vendor's own, and 1M is that vendor's real window. Values the file
+// declares are never overwritten.
+//
+// This is keyed on the endpoint rather than on list position, so it cannot leak
+// onto a custom provider the way the previous positional decode overlay did
+// (#7357, #7358).
+func backfillDeepSeekOfficialEndpointDefaults(p *ProviderEntry) {
+	if p == nil {
+		return
+	}
+	if strings.TrimSpace(p.BalanceURL) == "" {
+		p.BalanceURL = "https://api.deepseek.com/user/balance"
+	}
+	backfillOfficialContextWindow(p, 1_000_000)
 }
 
 func officialProviderKind(p *ProviderEntry) string {

--- a/internal/config/provider_isolation_test.go
+++ b/internal/config/provider_isolation_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// customProviderTOML declares a single self-hosted OpenAI-compatible provider
+// and none of the vendor-specific fields an official DeepSeek entry carries.
+const customProviderTOML = `config_version = 1
+default_model = "gateway/my-model"
+
+[[providers]]
+name        = "gateway"
+kind        = "openai"
+base_url    = "http://localhost:8021/v1"
+models      = ["my-model"]
+api_key_env = "GATEWAY_API_KEY"
+`
+
+func assertNoOfficialDeepSeekFields(t *testing.T, tag string, p *ProviderEntry) {
+	t.Helper()
+	if p.BalanceURL != "" {
+		t.Errorf("%s: custom provider gained balance_url %q; a self-hosted endpoint must not be pointed at another vendor's wallet API", tag, p.BalanceURL)
+	}
+	if p.ContextWindow != 0 {
+		t.Errorf("%s: custom provider gained context_window %d; an undeclared window must stay unset so compaction is not sized against a foreign default", tag, p.ContextWindow)
+	}
+	if p.Price != nil {
+		t.Errorf("%s: custom provider gained price %+v; another vendor's price table must not be applied to it", tag, *p.Price)
+	}
+	if p.Model != "" {
+		t.Errorf("%s: custom provider gained model %q from a built-in default", tag, p.Model)
+	}
+}
+
+// TestLoadForEditKeepsCustomProviderFreeOfOfficialDefaults covers #7357/#7358.
+// Config loads seed from Default(), which ships two official DeepSeek entries.
+// TOML array-of-tables decoding is positional, so the first [[providers]] in a
+// user file used to be unified onto the DeepSeek entry already occupying index
+// 0 and silently inherit every field the user had not set.
+func TestLoadForEditKeepsCustomProviderFreeOfOfficialDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(customProviderTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadForEditWithoutCredentials(path)
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1", len(cfg.Providers))
+	}
+	p := &cfg.Providers[0]
+	if p.Name != "gateway" || p.BaseURL != "http://localhost:8021/v1" {
+		t.Fatalf("unexpected provider identity: name=%q base_url=%q", p.Name, p.BaseURL)
+	}
+	assertNoOfficialDeepSeekFields(t, "LoadForEdit", p)
+}
+
+// TestSaveAfterLoadForEditDoesNotWriteForeignProviderFields is the on-disk half
+// of #7357: the leaked fields were persisted into the user's own file on the
+// next rewrite, so they outlived the process that invented them.
+func TestSaveAfterLoadForEditDoesNotWriteForeignProviderFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(customProviderTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadForEditWithoutCredentials(path)
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unwanted := range []string{"balance_url", "context_window", "price"} {
+		if strings.Contains(string(raw), unwanted) {
+			t.Errorf("rewritten config contains %q for a custom provider:\n%s", unwanted, raw)
+		}
+	}
+}
+
+// TestLoadForRootKeepsCustomProviderFreeOfOfficialDefaults exercises the same
+// leak through the runtime loader, which is what the agent and compaction read.
+func TestLoadForRootKeepsCustomProviderFreeOfOfficialDefaults(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(customProviderTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.Provider("gateway")
+	if !ok {
+		t.Fatal("gateway provider missing after load")
+	}
+	assertNoOfficialDeepSeekFields(t, "LoadForRoot", p)
+}
+
+// TestLastKnownGoodRecoveryKeepsCustomProviderFreeOfOfficialDefaults covers the
+// recovery path, which decodes a snapshot onto a freshly seeded Config and so
+// leaked through the same positional overlay.
+func TestLastKnownGoodRecoveryKeepsCustomProviderFreeOfOfficialDefaults(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	// Malformed live config forces the last-known-good branch.
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("config_version = ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lkg := LastKnownGoodConfigPath()
+	if lkg == "" {
+		t.Skip("last-known-good path unavailable in this environment")
+	}
+	if err := os.MkdirAll(filepath.Dir(lkg), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lkg, []byte(customProviderTOML), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.Provider("gateway")
+	if !ok {
+		t.Fatal("gateway provider missing after last-known-good recovery")
+	}
+	assertNoOfficialDeepSeekFields(t, "last-known-good", p)
+}
+
+// TestSecondCustomProviderKeepsNoOfficialDefaults guards the index-1 overlay:
+// Default() ships two DeepSeek entries, so the second declared provider used to
+// inherit the Pro SKU's price table and model.
+func TestSecondCustomProviderKeepsNoOfficialDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	raw := customProviderTOML + `
+[[providers]]
+name        = "second"
+kind        = "openai"
+base_url    = "http://localhost:9000/v1"
+models      = ["m2"]
+api_key_env = "SECOND_KEY"
+`
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadForEditWithoutCredentials(path)
+	if len(cfg.Providers) != 2 {
+		t.Fatalf("providers = %d, want 2", len(cfg.Providers))
+	}
+	for i := range cfg.Providers {
+		assertNoOfficialDeepSeekFields(t, cfg.Providers[i].Name, &cfg.Providers[i])
+	}
+}
+
+// TestOfficialDeepSeekProviderStillGetsItsDefaults pins the other half of the
+// contract: removing the positional overlay must not stop a genuinely official
+// endpoint from being priced, because that backfill is keyed on the endpoint.
+func TestOfficialDeepSeekProviderStillGetsItsDefaults(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	official := `config_version = 1
+default_model = "deepseek-flash/deepseek-v4-flash"
+
+[[providers]]
+name        = "deepseek-flash"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+`
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(official), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, ok := cfg.Provider("deepseek-flash")
+	if !ok {
+		t.Fatal("official deepseek-flash provider missing after load")
+	}
+	if p.Prices["deepseek-v4-flash"] == nil {
+		t.Errorf("official DeepSeek provider lost its per-model price backfill: prices=%v", p.Prices)
+	}
+}

--- a/internal/config/provider_isolation_test.go
+++ b/internal/config/provider_isolation_test.go
@@ -166,24 +166,92 @@ api_key_env = "SECOND_KEY"
 	}
 }
 
-// TestOfficialDeepSeekProviderStillGetsItsDefaults pins the other half of the
-// contract: removing the positional overlay must not stop a genuinely official
-// endpoint from being priced, because that backfill is keyed on the endpoint.
-func TestOfficialDeepSeekProviderStillGetsItsDefaults(t *testing.T) {
-	home := t.TempDir()
-	ws := t.TempDir()
-	t.Setenv("REASONIX_HOME", home)
-	official := `config_version = 1
-default_model = "deepseek-flash/deepseek-v4-flash"
+// officialDeepSeekTOML declares the official endpoint under name without
+// context_window, balance_url or price, which a documented config may omit.
+func officialDeepSeekTOML(name string) string {
+	return `config_version = 1
+default_model = "` + name + `/deepseek-v4-flash"
 
 [[providers]]
-name        = "deepseek-flash"
+name        = "` + name + `"
 kind        = "openai"
 base_url    = "https://api.deepseek.com"
 model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
 `
-	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(official), 0o600); err != nil {
+}
+
+func assertOfficialDeepSeekDefaults(t *testing.T, tag string, p *ProviderEntry) {
+	t.Helper()
+	if p.ContextWindow != 1_000_000 {
+		t.Errorf("%s: official DeepSeek provider has context_window %d, want 1000000; a zero window disables compaction", tag, p.ContextWindow)
+	}
+	if p.BalanceURL != "https://api.deepseek.com/user/balance" {
+		t.Errorf("%s: official DeepSeek provider has balance_url %q, want the vendor wallet endpoint; empty removes the balance readout", tag, p.BalanceURL)
+	}
+	if p.Prices["deepseek-v4-flash"] == nil {
+		t.Errorf("%s: official DeepSeek provider lost its per-model price backfill: prices=%v", tag, p.Prices)
+	}
+}
+
+// TestOfficialDeepSeekProviderStillGetsItsDefaults pins the other half of the
+// contract. Isolating the decoded provider list must not strip the defaults a
+// genuinely official endpoint may omit, so they are reapplied by an
+// endpoint-keyed backfill that a custom provider can never match.
+//
+// Both loaders are checked because they normalize through different entry
+// points: the runtime loader feeds the agent and compaction, while the edit
+// loader is what desktop Settings reads and writes back.
+func TestOfficialDeepSeekProviderStillGetsItsDefaults(t *testing.T) {
+	for _, name := range []string{"deepseek", "deepseek-flash"} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			ws := t.TempDir()
+			t.Setenv("REASONIX_HOME", home)
+			path := filepath.Join(home, "config.toml")
+			if err := os.WriteFile(path, []byte(officialDeepSeekTOML(name)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := LoadForRootReadOnly(ws)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p, ok := cfg.Provider(name)
+			if !ok {
+				t.Fatalf("official %q provider missing after runtime load", name)
+			}
+			assertOfficialDeepSeekDefaults(t, "LoadForRoot/"+name, p)
+
+			edit := LoadForEditWithoutCredentials(path)
+			ep, ok := edit.Provider(name)
+			if !ok {
+				t.Fatalf("official %q provider missing after edit load", name)
+			}
+			assertOfficialDeepSeekDefaults(t, "LoadForEdit/"+name, ep)
+		})
+	}
+}
+
+// TestOfficialDeepSeekBackfillRespectsDeclaredValues keeps the backfill from
+// overriding a user who deliberately narrowed the window or disabled the
+// balance readout for the official endpoint.
+func TestOfficialDeepSeekBackfillRespectsDeclaredValues(t *testing.T) {
+	home := t.TempDir()
+	ws := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	declared := `config_version = 1
+default_model = "deepseek-flash/deepseek-v4-flash"
+
+[[providers]]
+name           = "deepseek-flash"
+kind           = "openai"
+base_url       = "https://api.deepseek.com"
+model          = "deepseek-v4-flash"
+api_key_env    = "DEEPSEEK_API_KEY"
+context_window = 65536
+`
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(declared), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -195,7 +263,7 @@ api_key_env = "DEEPSEEK_API_KEY"
 	if !ok {
 		t.Fatal("official deepseek-flash provider missing after load")
 	}
-	if p.Prices["deepseek-v4-flash"] == nil {
-		t.Errorf("official DeepSeek provider lost its per-model price backfill: prices=%v", p.Prices)
+	if p.ContextWindow != 65536 {
+		t.Errorf("declared context_window was overwritten: got %d, want 65536", p.ContextWindow)
 	}
 }


### PR DESCRIPTION
## Summary

A user-defined provider silently acquired DeepSeek's `balance_url`, USD price table and `context_window = 1000000` the first time its config was loaded, and those values were then written into the user's own `config.toml` on the next rewrite.

TOML array-of-tables decoding is positional: BurntSushi/toml unifies `[[providers]][i]` onto whatever the destination slice already holds at index `i` rather than onto a zero value. Every config load seeds from `Default()`, which ships two official DeepSeek entries, so the first two `[[providers]]` a user declares were overlaid onto them and inherited every field left unset. The second entry inherited the Pro SKU's table, which is why a two-provider file produced two different wrong price tables.

This is the shared root cause of #7357 and #7358. Both reports attributed the behaviour to a specific backfill helper (`backfillOfficialContextWindow`, the billing defaults), but those helpers are endpoint-keyed and correctly skip custom providers. The leak happened one layer earlier, in decoding, which is also why it reached fields nobody had a backfill for at all — including `model`, silently set to `deepseek-v4-flash`.

Consequences were not limited to cosmetics:

- A self-hosted or air-gapped endpoint was configured to query `api.deepseek.com/user/balance`, with the custom provider's key in scope.
- Cost readouts applied a foreign price table with nothing marking the number as inferred.
- Compaction was sized against a 1M window instead of the real one, so on a smaller backend it never fired before the endpoint began rejecting requests mid-task. This is a plausible contributor to #7326.

The fix re-decodes the providers array onto an empty slice, so a declared entry carries only what the file declares. The defaults that are genuinely correct for an entry are then reapplied by endpoint-keyed backfills, which a custom provider can never match.

That second half also closes a pre-existing bug the overlay was masking. An official provider that omits `context_window` got the 1M default *only* on the edit loader, and only by accident via this same overlay; the runtime loader, which is what feeds compaction, always saw `0`:

| | `main-v2` | with this PR |
|---|---|---|
| `LoadForRootReadOnly` | `ctx=0` | `ctx=1000000` |
| `LoadForEdit` | `ctx=1000000` | `ctx=1000000` |

So one accident was simultaneously supplying a correct default to official entries and a wrong one to custom entries. `backfillDeepSeekOfficialEndpointDefaults` restores `context_window` and `balance_url` for any entry on `api.deepseek.com`, on both loaders, without overwriting anything the file declares.

Scoped deliberately narrowly: `providers` is the only non-empty slice-of-struct in `Default()`, verified by reflection walk, so it is the only field this positional overlay could affect.

## Issues

Fixes #7357
Fixes #7358

## Verification

Eight regression tests in `internal/config/provider_isolation_test.go`, covering the runtime loader, the edit/save path, the last-known-good recovery path, and the index-1 overlay. Confirmed each fails on `main-v2` and passes with the fix:

```
LoadForEdit: custom provider gained balance_url "https://api.deepseek.com/user/balance"
LoadForEdit: custom provider gained context_window 1000000
LoadForEdit: custom provider gained price {CacheHit:0.0028 Input:0.14 Output:0.28 Currency:$}
LoadForEdit: custom provider gained model "deepseek-v4-flash" from a built-in default
```

`TestOfficialDeepSeekProviderStillGetsItsDefaults` asserts `context_window`, `balance_url` and prices across both `deepseek` and `deepseek-flash`, on both loaders. Verified as a real guard by deleting the backfill call — it then fails on all four combinations with `context_window 0, want 1000000`. `TestOfficialDeepSeekBackfillRespectsDeclaredValues` pins that a deliberately narrowed window is not overwritten.

```bash
gofmt -l internal/config/          # clean
go vet ./internal/config/          # clean
go build ./...                     # ok
go test ./internal/... ./cmd/...   # all pass
go test -race ./internal/config/   # ok
cd desktop && go test ./...        # all pass (heaviest LoadForEdit consumer)
./scripts/cache-guard.sh           # all 8 cases pass
```

## Cache impact

Cache-impact: none — config decoding only; no prompt construction, tool schema, memory prefix, or provider request serialization is touched. `scripts/check-cache-impact.sh` reports no cache-sensitive files changed for this diff.
Cache-guard: `./scripts/cache-guard.sh` run anyway as a precaution; all 8 cases pass with tail averages 92–95% against the 90% threshold.
System-prompt-review: N/A — no system prompt, memory prefix, output style, or skill index behavior changes.