### PR TITLE
fix(cli): enable Windows VT processing before emitting ANSI

### DIFF
--- a/internal/cli/ansi_console_other.go
+++ b/internal/cli/ansi_console_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package cli
+
+func ansiConsoleReady() bool { return true }

--- a/internal/cli/ansi_console_windows.go
+++ b/internal/cli/ansi_console_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// ansiConsoleReady reports whether stdout can render SGR sequences, enabling
+// VT processing when the console has it off (legacy conhost prints the escapes
+// literally instead — see #3242). A non-console stdout is left to colorprofile.
+func ansiConsoleReady() bool {
+	enableVirtualTerminal(os.Stderr)
+	return enableVirtualTerminal(os.Stdout)
+}
+
+func enableVirtualTerminal(f *os.File) bool {
+	h := windows.Handle(f.Fd())
+	var mode uint32
+	if err := windows.GetConsoleMode(h, &mode); err != nil {
+		return true
+	}
+	if mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+		return true
+	}
+	return windows.SetConsoleMode(h, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == nil
+}

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -10,7 +10,14 @@ import (
 // colorprofile owns the NO_COLOR, CLICOLOR_FORCE, TERM=dumb and isatty rules,
 // so piped output stays plain. Colour fidelity is derived from it, never probed
 // a second time.
-var activeColorProfile = colorprofile.Detect(os.Stdout, os.Environ())
+var activeColorProfile = detectColorProfile(ansiConsoleReady())
+
+func detectColorProfile(ansiReady bool) colorprofile.Profile {
+	if !ansiReady {
+		return colorprofile.ASCII
+	}
+	return colorprofile.Detect(os.Stdout, os.Environ())
+}
 
 func colorOn() bool {
 	return activeColorProfile > colorprofile.ASCII

--- a/internal/cli/style_profile_test.go
+++ b/internal/cli/style_profile_test.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/colorprofile"
+)
+
+func TestDetectColorProfileWithoutANSIConsole(t *testing.T) {
+	if got := detectColorProfile(false); got != colorprofile.ASCII {
+		t.Fatalf("console without VT processing must render plain, got %v", got)
+	}
+}


### PR DESCRIPTION
On a legacy Windows console (Win10, PowerShell outside Windows Terminal), `reasonix setup` prints raw escapes — `^[[38;5;173m▌^[[0m` — instead of colored output.

Cause: `colorprofile` derives the Windows profile from the NT build number and never checks the console mode, so it reports TrueColor on any build ≥ 14931 even when the attached console has `ENABLE_VIRTUAL_TERMINAL_PROCESSING` off. Bubbletea enables VT for the TUI, but `setup`, `config` and `doctor` render outside it.

Fix: enable VT for stdout and stderr at `internal/cli` init, before the profile is detected. A non-console stdout (pipe, file) is left to colorprofile as before; a console that refuses VT drops us to plain ASCII output instead of garbage.

Verified: `go test ./internal/cli/` — the one failure, `TestRunResumeCopyContinuesInDuplicate`, fails identically on `main-v2` without this change (pre-existing local baseline).

Closes #3242