### PR TITLE
fix(cli): accept Ctrl+arrows for composer word motion

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -640,6 +640,10 @@ func configureChatTextarea(ti *textarea.Model) {
 	// Plain Enter submits (the chatTUI handler intercepts it), so the textarea's
 	// own InsertNewline binding moves to Alt+Enter / Ctrl+J / Shift+Enter.
 	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
+	// bubbles binds word motion to Alt+arrows (the macOS convention); Windows and
+	// Linux terminals send Ctrl+arrows for the same intent.
+	ti.KeyMap.WordForward = key.NewBinding(key.WithKeys("alt+right", "alt+f", "ctrl+right"))
+	ti.KeyMap.WordBackward = key.NewBinding(key.WithKeys("alt+left", "alt+b", "ctrl+left"))
 	ti.Focus()
 }
 

--- a/internal/cli/composer_word_motion_test.go
+++ b/internal/cli/composer_word_motion_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"slices"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+)
+
+func TestComposerWordMotionAcceptsCtrlArrows(t *testing.T) {
+	ti := textarea.New()
+	configureChatTextarea(&ti)
+
+	for _, tc := range []struct {
+		motion string
+		keys   []string
+		ctrl   string
+		alt    string
+	}{
+		{"forward", ti.KeyMap.WordForward.Keys(), "ctrl+right", "alt+right"},
+		{"backward", ti.KeyMap.WordBackward.Keys(), "ctrl+left", "alt+left"},
+	} {
+		if !slices.Contains(tc.keys, tc.ctrl) {
+			t.Errorf("word %s is missing %s: %v", tc.motion, tc.ctrl, tc.keys)
+		}
+		if !slices.Contains(tc.keys, tc.alt) {
+			t.Errorf("word %s dropped %s: %v", tc.motion, tc.alt, tc.keys)
+		}
+	}
+}


### PR DESCRIPTION
`bubbles` binds word motion to Alt+Left/Right (and Alt+B/F) — the macOS convention. On Windows and Linux, Ctrl+Left/Right is the expected shortcut, and in the composer it did nothing.

Adds Ctrl+arrows alongside the existing Alt bindings; no key is removed, and neither collides with the TUI's own Ctrl handlers (ctrl+home/end/z/c/d/l/y/o/b).

Test pins both bindings so a bubbles upgrade resetting the defaults fails loudly.

Closes #3302