### PR TITLE
feat(cli): show the active config file in /status

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4190,7 +4190,23 @@ func (m *chatTUI) showStatusDetails() {
 	if tag := m.mouseTag(); tag != "" {
 		lines = append(lines, "  mouse      "+tag)
 	}
+	lines = append(lines, "  config     "+activeConfigTag())
 	m.commitLine(strings.Join(lines, "\n"))
+}
+
+// activeConfigTag names the config file actually in effect. A ./reasonix.toml
+// outranks the user-global file, so a session started in a directory holding
+// one silently ignores global edits unless the source is visible (#3317).
+func activeConfigTag() string {
+	path := config.SourcePath()
+	if path == "" {
+		return "(defaults — no config file)"
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return displayPath(path)
+	}
+	return displayPath(abs)
 }
 
 func (m *chatTUI) runGoalSubcommand(input string) tea.Cmd {

--- a/internal/cli/status_config_tag_test.go
+++ b/internal/cli/status_config_tag_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestActiveConfigTagNamesTheShadowingProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte("default_model = \"a\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	work := t.TempDir()
+	t.Chdir(work)
+
+	if got := activeConfigTag(); !strings.HasSuffix(got, "config.toml") {
+		t.Fatalf("user-global config should be reported, got %q", got)
+	}
+
+	local := filepath.Join(work, "reasonix.toml")
+	if err := os.WriteFile(local, []byte("default_model = \"b\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := activeConfigTag(); !strings.HasSuffix(got, "reasonix.toml") {
+		t.Fatalf("project config outranks the global one and must be reported, got %q", got)
+	}
+}
+
+func TestActiveConfigTagWithoutAnyConfigFile(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	if got := activeConfigTag(); !strings.Contains(got, "defaults") {
+		t.Fatalf("no config file must be stated explicitly, got %q", got)
+	}
+}


### PR DESCRIPTION
Config precedence is `./reasonix.toml` > user-global `config.toml` > defaults. That's intended, but nothing in the UI says which file won, so a `reasonix.toml` sitting in the directory you happen to start from (a home directory, for instance) makes every edit to the global config look like it did nothing.

`/status` now ends with the config source — the absolute path, home-shortened — or `(defaults — no config file)` when none exists.

Tests cover both: the global file when it's the only one, the project file once it shadows it, and the no-config case.

Closes #3317