### PR TITLE
fix(config): keep project provider_access from hiding user providers

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -545,6 +545,7 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 	var merged []string
 	seen := map[string]bool{}
 	saw := false
+	userDeclared := false
 	for _, path := range paths {
 		_, exists, err := statConfigPath(path)
 		if err != nil {
@@ -568,6 +569,9 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 			merged = []string{}
 		}
 		saw = true
+		if isUserConfigPath(path) {
+			userDeclared = true
+		}
 		for _, name := range f.Desktop.ProviderAccess {
 			name = strings.TrimSpace(name)
 			if name == "" || seen[name] {
@@ -576,6 +580,11 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 			seen[name] = true
 			merged = append(merged, name)
 		}
+	}
+	// An undeclared user list means "allow all"; a union with a project-only
+	// list would silently narrow that to whatever the project happens to name.
+	if saw && !userDeclared {
+		return nil, false, nil
 	}
 	return merged, saw, nil
 }

--- a/internal/config/loadedit_test.go
+++ b/internal/config/loadedit_test.go
@@ -40,12 +40,9 @@ api_key_env = "X_KEY"
 }
 
 func TestMergeTOMLProviderAccessPreservesExplicitEmpty(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "reasonix.toml")
-	if err := os.WriteFile(path, []byte("[desktop]\nprovider_access = []\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	userPath := writeUserProviderAccess(t, "[desktop]\nprovider_access = []\n")
 
-	access, declared, err := mergeTOMLProviderAccess([]string{path})
+	access, declared, err := mergeTOMLProviderAccess([]string{userPath})
 	if err != nil {
 		t.Fatalf("mergeTOMLProviderAccess: %v", err)
 	}
@@ -55,6 +52,58 @@ func TestMergeTOMLProviderAccessPreservesExplicitEmpty(t *testing.T) {
 	if access == nil || len(access) != 0 {
 		t.Fatalf("provider_access = %#v, want a non-nil empty slice", access)
 	}
+}
+
+func TestMergeTOMLProviderAccessIgnoresProjectOnlyList(t *testing.T) {
+	isolateUserConfigHome(t)
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte("default_model = \"deepseek/deepseek-v4-flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(t.TempDir(), "reasonix.toml")
+	if err := os.WriteFile(projectPath, []byte("[desktop]\nprovider_access = [\"deepseek\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	access, declared, err := mergeTOMLProviderAccess([]string{userPath, projectPath})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if declared || access != nil {
+		t.Fatalf("project-only access = %#v (declared=%v); an undeclared user list means allow-all", access, declared)
+	}
+}
+
+func TestMergeTOMLProviderAccessUnionsWhenUserDeclares(t *testing.T) {
+	userPath := writeUserProviderAccess(t, "[desktop]\nprovider_access = [\"deepseek\"]\n")
+	projectPath := filepath.Join(t.TempDir(), "reasonix.toml")
+	if err := os.WriteFile(projectPath, []byte("[desktop]\nprovider_access = [\"project-b\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	access, declared, err := mergeTOMLProviderAccess([]string{userPath, projectPath})
+	if err != nil {
+		t.Fatalf("mergeTOMLProviderAccess: %v", err)
+	}
+	if !declared || len(access) != 2 || access[0] != "deepseek" || access[1] != "project-b" {
+		t.Fatalf("access = %#v (declared=%v), want the union of both scopes", access, declared)
+	}
+}
+
+func writeUserProviderAccess(t *testing.T, body string) string {
+	t.Helper()
+	isolateUserConfigHome(t)
+	path := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestLoadForEditDecodesGB18030TOML(t *testing.T) {


### PR DESCRIPTION
Ports @ttmouse's fix from #6601 onto current `main-v2` (that branch predates the `statConfigPath` / `meta.IsDefined` rework in `mergeTOMLProviderAccess` and no longer applies cleanly). Original diagnosis and approach are theirs.

**Bug.** An undeclared user-level `desktop.provider_access` means "allow all" (`modelProviderAccessAllowed` returns true on a nil list). `mergeTOMLProviderAccess` unions the declarations it finds, so when only a project `reasonix.toml` declares one, the union *is* the project's list — and every account-level provider vanishes from the desktop model switcher inside that workspace. #4492 merged `provider_access` across scopes precisely so project settings would not hide account providers; the union misses the common case where the user never declared a list at all.

**Fix.** Track whether the declaration came from the user config. A project-only list is ignored (allow-all is preserved); once the user config declares its own list, the union behaves as before.

**Semantics note.** `TestMergeTOMLProviderAccessPreservesExplicitEmpty` now writes to the user config path instead of an anonymous temp file. Explicit-empty ("I removed every provider") stays meaningful at the scope that can express it — the user config — while a project's empty list no longer blanks the switcher. Two tests added: project-only ignored, and union when both scopes declare.

Verified: `go test ./internal/config/` and the full `desktop` module (`go test ./...`, 454s) pass.

Refs #6601, #3476