### PR TITLE
fix(fileref): keep build outputs out of @ completion

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -10701,31 +10701,6 @@ type WorkspaceChangeDetailView struct {
 	Truncated bool    `json:"truncated,omitempty"`
 }
 
-// workspaceNoiseNames are local cache/vendor entries hidden from the file tree
-// and "@" menu regardless of where they appear.
-var workspaceNoiseNames = map[string]bool{
-	".codex":       true,
-	".DS_Store":    true,
-	".git":         true,
-	".npm":         true,
-	".pnpm-store":  true,
-	"node_modules": true,
-	"Thumbs.db":    true,
-}
-
-var workspaceNoiseDirs = map[string]bool{
-	"bin":                      true,
-	"desktop/build":            true,
-	"desktop/frontend/dist":    true,
-	"desktop/frontend/wailsjs": true,
-	"dist":                     true,
-	"npm/.stage":               true,
-	"site/.astro":              true,
-	"site/dist":                true,
-	"stage":                    true,
-	"tmp":                      true,
-}
-
 const filePreviewLimit = 2 * 1024 * 1024 // 2 MiB — full file preview for the workspace panel
 const fileRefSearchLimit = 20
 
@@ -10779,10 +10754,7 @@ func workspaceEntryRel(rel, name string) string {
 }
 
 func skipWorkspaceEntry(rel, name string, isDir bool) bool {
-	if workspaceNoiseNames[name] {
-		return true
-	}
-	return isDir && workspaceNoiseDirs[workspaceEntryRel(rel, name)]
+	return fileref.SkipEntry(workspaceEntryRel(rel, name), name, isDir)
 }
 
 func (a *App) activeWorkspaceBase() (string, error) {

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -17,9 +17,33 @@ var skipEntryNames = map[string]bool{
 	"Thumbs.db":    true,
 }
 
+// skipDirNames are build outputs across ecosystems: their contents are
+// generated, so an "@" hit inside one points at a file nobody edits (#3900).
 var skipDirNames = map[string]bool{
-	"build": true,
-	"dist":  true,
+	"build":         true,
+	"dist":          true,
+	"target":        true,
+	"__pycache__":   true,
+	"venv":          true,
+	".venv":         true,
+	".gradle":       true,
+	".next":         true,
+	".nuxt":         true,
+	".svelte-kit":   true,
+	".pytest_cache": true,
+	".mypy_cache":   true,
+	".tox":          true,
+	".terraform":    true,
+	".dart_tool":    true,
+}
+
+// SkipEntry reports whether a workspace entry is hidden from file pickers. rel
+// is the entry's slash-separated path from the workspace root.
+func SkipEntry(rel, name string, isDir bool) bool {
+	if skipEntryNames[name] {
+		return true
+	}
+	return isDir && (skipDirNames[name] || skipDirPaths[rel])
 }
 
 var skipDirPaths = map[string]bool{
@@ -83,7 +107,7 @@ func Search(root, query string, limit int) []SearchResult {
 				return filepath.SkipDir
 			}
 			rel = filepath.ToSlash(rel)
-			if skipEntryNames[name] || skipDirNames[name] || skipDirPaths[rel] || (!showHidden && strings.HasPrefix(name, ".")) {
+			if SkipEntry(rel, name, true) || (!showHidden && strings.HasPrefix(name, ".")) {
 				return filepath.SkipDir
 			}
 			// Allow matching directory names so the user can select a

--- a/internal/fileref/skip_test.go
+++ b/internal/fileref/skip_test.go
@@ -1,0 +1,44 @@
+package fileref
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSkipEntryHidesBuildOutputDirectories(t *testing.T) {
+	for _, name := range []string{"target", "build", "dist", "__pycache__", ".venv", "node_modules"} {
+		if !SkipEntry(name, name, true) {
+			t.Errorf("%q is a build output and must stay out of file pickers", name)
+		}
+	}
+}
+
+func TestSkipEntryKeepsSourceDirectories(t *testing.T) {
+	for _, name := range []string{"src", "internal", "docs", "targets", "buildkite"} {
+		if SkipEntry(name, name, true) {
+			t.Errorf("%q is not a build output and must remain browsable", name)
+		}
+	}
+}
+
+func TestSkipEntryIgnoresBuildNamesOnFiles(t *testing.T) {
+	if SkipEntry("cmd/build", "build", false) {
+		t.Error("a file named build is source, not a build directory")
+	}
+}
+
+func TestSearchSkipsGeneratedClassFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "main", "java", "App.java"))
+	writeFile(t, filepath.Join(root, "target", "classes", "App.class"))
+
+	got := resultPaths(Search(root, "app", 50))
+	for _, path := range got {
+		if path == "target/classes/App.class" {
+			t.Fatalf("generated output leaked into @ results: %v", got)
+		}
+	}
+	if len(got) == 0 {
+		t.Fatalf("the source file should still match: %v", got)
+	}
+}


### PR DESCRIPTION
`@` completion listed generated files: a Maven `target/` full of `.class` files, `__pycache__`, a `venv`. The skip list only knew `build` and `dist` by name, plus a handful of paths specific to this repo's own layout (`desktop/frontend/dist`, `site/.astro`, …), so every other ecosystem's output directory came through.

Adds the common ones — `target`, `__pycache__`, `venv`/`.venv`, `.gradle`, `.next`, `.nuxt`, `.svelte-kit`, `.pytest_cache`, `.mypy_cache`, `.tox`, `.terraform`, `.dart_tool` — matched as directories only, so a *file* called `build` still shows up.

Also collapses the duplication: the desktop had its own copy of the same two maps and its own `skipWorkspaceEntry`; both now call `fileref.SkipEntry`, so the file tree and the `@` menu can't drift apart again.

Deliberately not included: `out`, `obj`, `vendor`. Each is a build output in one ecosystem and hand-written source in another, and hiding real files is worse than showing generated ones.

Tests: build outputs skipped, source directories (`src`, `targets`, `buildkite`) kept, a file named `build` kept, and an end-to-end `Search` check that `target/classes/App.class` no longer matches while the Java source still does. Desktop workspace tests pass.

Closes #3900