### PR TITLE
feat(desktop): unify token display format with K/M abbreviations

### DIFF
--- a/desktop/frontend/src/__tests__/format-tokens.test.ts
+++ b/desktop/frontend/src/__tests__/format-tokens.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { formatTokens, formatOptionalTokens } from "../lib/format";
+
+describe("formatTokens", () => {
+  it("returns '-' for undefined, zero, and negative values", () => {
+    expect(formatTokens(undefined)).toBe("-");
+    expect(formatTokens(0)).toBe("-");
+    expect(formatTokens(-100)).toBe("-");
+  });
+
+  it("formats values below threshold as plain numbers", () => {
+    expect(formatTokens(1)).toBe("1");
+    expect(formatTokens(500)).toBe("500");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("abbreviates thousands with K suffix", () => {
+    expect(formatTokens(1000)).toBe("1K");
+    expect(formatTokens(1500)).toBe("1.5K");
+    expect(formatTokens(142000)).toBe("142K");
+    expect(formatTokens(999999)).toBe("1000K");
+  });
+
+  it("abbreviates millions with M suffix", () => {
+    expect(formatTokens(1_000_000)).toBe("1M");
+    expect(formatTokens(1_500_000)).toBe("1.5M");
+    expect(formatTokens(25_000_000)).toBe("25M");
+  });
+
+  it("strips trailing .0 for exact multiples", () => {
+    expect(formatTokens(1000)).toBe("1K");
+    expect(formatTokens(2000)).toBe("2K");
+    expect(formatTokens(1_000_000)).toBe("1M");
+  });
+
+  it("keeps one decimal place when needed", () => {
+    expect(formatTokens(1500)).toBe("1.5K");
+    expect(formatTokens(234000)).toBe("234K");
+    expect(formatTokens(1_230_000)).toBe("1.2M");
+  });
+
+  it("respects custom decimals option", () => {
+    expect(formatTokens(1500, { decimals: 2 })).toBe("1.5K");
+    expect(formatTokens(1555, { decimals: 2 })).toBe("1.55K");
+    expect(formatTokens(1_555_000, { decimals: 2 })).toBe("1.55M");
+  });
+
+  it("respects custom threshold option", () => {
+    expect(formatTokens(500, { threshold: 100 })).toBe("0.5K");
+    expect(formatTokens(99, { threshold: 100 })).toBe("99");
+    expect(formatTokens(100, { threshold: 100 })).toBe("0.1K");
+  });
+
+  it("returns locale-formatted string when compact is false", () => {
+    const result = formatTokens(142000, { compact: false });
+    // toLocaleString output varies by locale, but should contain digits
+    expect(result).toMatch(/142/);
+    expect(result).not.toMatch(/[KM]/);
+  });
+});
+
+describe("formatOptionalTokens", () => {
+  it("returns '-' for missing, zero, and negative values", () => {
+    expect(formatOptionalTokens(undefined)).toBe("-");
+    expect(formatOptionalTokens(null)).toBe("-");
+    expect(formatOptionalTokens(0)).toBe("-");
+    expect(formatOptionalTokens(-50)).toBe("-");
+  });
+
+  it("formats positive values identically to formatTokens", () => {
+    expect(formatOptionalTokens(1500)).toBe("1.5K");
+    expect(formatOptionalTokens(1_000_000)).toBe("1M");
+    expect(formatOptionalTokens(500)).toBe("500");
+  });
+});

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -21,6 +21,7 @@ import {
   type ComposerInvocation,
   type StructuredInvocationSubmit,
 } from "../lib/invocationDisplay";
+import { formatTokens } from "../lib/format";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { createRafResizeUpdater } from "../lib/resizeDrag";
 import { observeComposerMenuViewport } from "../lib/composerMenuViewport";
@@ -373,11 +374,6 @@ function composerAutoInputMaxHeight(extraReservedHeight = 0): number {
 
 function loadComposerHeight(): number | null {
   return loadOptionalLayoutSize("composerHeight", clampComposerHeight);
-}
-
-function fmtTokens(n: number): string {
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
 }
 
 function fmtElapsed(ms: number): string {
@@ -3635,7 +3631,7 @@ export function Composer({
         const words = SPINNER_WORDS[locale];
         const word = words[Math.floor(elapsedMs / 3000) % words.length];
         const liveTokens = (turnTokens ?? 0) + Math.round((turnArgChars ?? 0) / 4);
-        const tok = liveTokens > 0 ? ` · ↓ ${fmtTokens(liveTokens)} ${t("status.tokens")}` : "";
+        const tok = liveTokens > 0 ? ` · ↓ ${formatTokens(liveTokens)} ${t("status.tokens")}` : "";
         return `${word}… ${fmtElapsed(elapsedMs)}${tok}`;
       })()
     : null;

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -5,6 +5,7 @@ import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useI18n, type Locale, type Translator } from "../lib/i18n";
 import { formatMoneyLocalized } from "../lib/money";
+import { formatTokens, formatOptionalTokens } from "../lib/format";
 import type { DictKey } from "../locales/en";
 import type { BalanceInfo, ContextInfo, ContextPanelInfo, UsageSourceStats, WireUsage } from "../lib/types";
 
@@ -27,10 +28,6 @@ interface ContextPanelProps {
   usageSeq?: number;
 }
 
-function fmtFullTokens(n: number): string {
-  if (n <= 0) return "0";
-  return String(Math.round(n));
-}
 
 function fmtDuration(ms: number, t: Translator): string {
   if (ms <= 0) return "-";
@@ -41,10 +38,6 @@ function fmtDuration(ms: number, t: Translator): string {
   return t("context.durationMinutesSeconds", { minutes, seconds });
 }
 
-function fmtOptionalTokens(tokens?: number): string {
-  if (typeof tokens !== "number" || tokens <= 0) return "-";
-  return tokens.toLocaleString();
-}
 
 interface MetricTokenDisplay {
   display: string;
@@ -419,9 +412,9 @@ export function ContextPanel({
   const turnCostLabel = markEstimated(formatMoneyLocalized(turnCost, sessionCurrency, { locale, empty: "dash" }), turnEstimated);
   const sessionCostLabel = markEstimated(formatMoneyLocalized(cost.amount, cost.currency, { locale, empty: "dash" }), sessionEstimated);
   const totalTokensTitle = totalTokensMetric.exact === "-" ? "-" : t("context.tokensValue", { value: totalTokensMetric.exact });
-  const usedLabel = fmtFullTokens(usedTokens);
-  const windowLabel = fmtFullTokens(windowTokens);
-  const compactRemainingLabel = tokensUntilCompact > 0 ? fmtFullTokens(tokensUntilCompact) : "0";
+  const usedLabel = formatTokens(usedTokens);
+  const windowLabel = formatTokens(windowTokens);
+  const compactRemainingLabel = tokensUntilCompact > 0 ? formatTokens(tokensUntilCompact) : "0";
   const compactMarkerPct = Math.max(0, Math.min(100, compactPct));
   const usageMarkerPct = Math.max(6, Math.min(94, usagePct));
   const compactLabelPct = Math.max(6, Math.min(94, compactMarkerPct));
@@ -539,7 +532,7 @@ export function ContextPanel({
           </section>
           <section className="context-panel__creation-grid" aria-label={t("context.overview")}>
             <MetricCard label={t("status.cacheLabel")} value={fmtUsageCacheRate(usage)} tone="accent" />
-            <MetricCard label={t("status.turnTokensLabel")} value={fmtOptionalTokens(turnTokens)} />
+            <MetricCard label={t("status.turnTokensLabel")} value={formatOptionalTokens(turnTokens)} />
             <MetricCard label={t("status.turnCostLabel")} value={turnCostLabel} />
             <MetricCard label={t("status.balanceLabel")} value={balanceLabel} tone="accent" />
           </section>

--- a/desktop/frontend/src/lib/format.ts
+++ b/desktop/frontend/src/lib/format.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared formatting utilities for token counts and numeric displays.
+ *
+ * Centralises the previously duplicated fmtTokens / fmtFullTokens helpers
+ * scattered across ContextPanel and Composer so every surface renders
+ * identical compact token strings (e.g. "1.5K", "2.0M").
+ */
+
+/** Options controlling how {@link formatTokens} renders a count. */
+export interface TokenFormatOptions {
+  /**
+   * When `true` (the default) large values are abbreviated with K / M suffixes.
+   * When `false` the raw locale-formatted number is returned instead.
+   */
+  compact?: boolean;
+
+  /** Maximum fractional digits kept in the abbreviated form (default `1`). */
+  decimals?: number;
+
+  /**
+   * Minimum value before the K-suffix kicks in (default `1000`).
+   * Useful for contexts that want to show plain numbers up to a higher bound.
+   */
+  threshold?: number;
+}
+
+/** Strip trailing zeros after the decimal point: "1.50" → "1.5", "1.00" → "1". */
+function stripTrailingZeros(s: string): string {
+  return s.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+}
+
+/**
+ * Format a token count for human-readable display.
+ *
+ * Behaviour:
+ *  - Returns `"-"` for missing, zero, or negative inputs.
+ *  - In compact mode (default): values >= 1 000 000 use the `M` suffix,
+ *    values >= `threshold` (default 1 000) use the `K` suffix, and smaller
+ *    values are rendered as-is.
+ *  - Trailing `.0` is stripped so `1000` becomes `"1K"` rather than `"1.0K"`.
+ *  - In non-compact mode `toLocaleString()` is used for locale-aware grouping.
+ *
+ * @example
+ *  formatTokens(1500)        // "1.5K"
+ *  formatTokens(1000)        // "1K"
+ *  formatTokens(142000)      // "142K"
+ *  formatTokens(1_500_000)   // "1.5M"
+ *  formatTokens(999)         // "999"
+ *  formatTokens(undefined)   // "-"
+ */
+export function formatTokens(tokens: number | undefined, options?: TokenFormatOptions): string {
+  if (typeof tokens !== "number" || tokens <= 0) return "-";
+
+  const { compact = true, decimals = 1, threshold = 1000 } = options ?? {};
+
+  if (!compact) {
+    return tokens.toLocaleString();
+  }
+
+  if (tokens >= 1_000_000) {
+    return `${stripTrailingZeros((tokens / 1_000_000).toFixed(decimals))}M`;
+  }
+  if (tokens >= threshold) {
+    return `${stripTrailingZeros((tokens / 1000).toFixed(decimals))}K`;
+  }
+
+  return String(tokens);
+}
+
+/**
+ * Convenience wrapper for optional token counts (session / turn totals).
+ *
+ * Delegates to {@link formatTokens} and returns `"-"` when the value is
+ * absent, zero, or negative — matching the old `fmtOptionalTokens` helper
+ * it replaces.
+ */
+export function formatOptionalTokens(tokens?: number | null, options?: TokenFormatOptions): string {
+  if (typeof tokens !== "number" || tokens <= 0) return "-";
+  return formatTokens(tokens, options);
+}


### PR DESCRIPTION
Ports @HUQIANTAO's #5982 onto current `main-v2` — that branch went conflicting as `Composer.tsx` moved on, and it's been sitting green-but-unmergeable for a month. Implementation and tests are theirs; I resolved the two conflicts (import block, run-ticker hunk) and kept HEAD's surrounding code.

**Problem.** Four independent formatters produced four shapes for the same number:

| Surface | 1500 | 142000 |
| --- | --- | --- |
| ContextPanel (full) | `1500` | `142000` |
| ContextPanel (optional) | `1,500` | `142,000` |
| Composer | `1.5k` | `142.0k` |
| CLI/TUI | `1.5K` | `142.0K` |

The long forms are also what overflows the sidebar's token column at its default width (#4123).

**Change.** One `formatTokens` in `lib/format.ts` (K/M, trailing `.0` stripped, `-` for missing/zero, options for decimals/threshold/compact), used by the composer ticker and the context panel; the per-component helpers are gone.

Verified in a clean worktree: `tsc --noEmit` clean, `vitest src/__tests__/format-tokens.test.ts` 11/11 pass.

Closes #5809
Closes #4123