### PR TITLE
Publish v1.19.5 changelog / 发布 v1.19.5 更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -414,7 +414,7 @@
       },
       "releaseId": "1.19.5",
       "baseVersion": "1.19.5",
-      "status": "reviewed",
+      "status": "published",
       "previousRelease": "1.19.4",
       "builds": {
         "cli": "v1.19.5",


### PR DESCRIPTION
## Summary

- Publish the existing bilingual v1.19.5 release record on the public changelog.
- Make both `/changelog/` and `/changelog/v1.19.5/` render the release after deployment.

## Verification

- `node scripts/release-notes.mjs validate --version 1.19.5`
- `npm test --prefix site` (51 passed)
- `npm run build --prefix site` (39 pages built)
- Confirmed the generated changelog index and exact-version page contain the v1.19.5 bilingual content.

## Compatibility

| Field | Existing behavior | Conclusion |
| --- | --- | --- |
| `status` | The catalog already accepts `reviewed` and `published`; only the v1.19.5 record changes to the existing `published` value. | Backward compatible |

Merging this release-notes change triggers the Pages deployment workflow.