### PR TITLE
fix(desktop): center the selection add-to-chat action over the selection

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-selection-menu.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-selection-menu.test.tsx
@@ -348,6 +348,56 @@ console.log("\ntranscript selection menu");
 }
 
 {
+  // Positioning: the floating action centers horizontally over the selection
+  // and prefers the space above it, flipping below when the top edge would
+  // collide with the window. jsdom measures a zero-size rect for the action
+  // itself, so the expected left is the exact selection center.
+  const dom = installDom();
+  document.body.insertAdjacentHTML("beforeend", "<div class=\"msg__body\">positioned reply text</div>");
+  const msgBody = document.querySelector(".msg__body") as HTMLElement;
+
+  const root = createRoot(document.getElementById("root") as HTMLElement);
+  await act(async () => {
+    root.render(
+      <LocaleProvider>
+        <TranscriptSelectionMenu onAddToChat={() => {}} />
+      </LocaleProvider>,
+    );
+    await flushTimers();
+  });
+
+  const originalRangeRect = window.Range.prototype.getBoundingClientRect;
+  const rectAt = (left: number, top: number, width: number, height: number) =>
+    () => ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top, toJSON: () => ({}) }) as DOMRect;
+
+  selectNodeText(msgBody.firstChild as Node);
+  window.Range.prototype.getBoundingClientRect = rectAt(100, 200, 300, 20);
+  await act(async () => {
+    msgBody.dispatchEvent(new window.MouseEvent("pointerup", { bubbles: true, button: 0 }));
+    await drainFrame();
+  });
+  const action = document.querySelector(".transcript-selection-action") as HTMLElement | null;
+  eq(action?.style.left, "250px", "the action centers horizontally over the selection");
+  eq(action?.style.top, "192px", "the action sits above the selection");
+
+  // Top edge too tight (selection starts at y=2): flip below the selection.
+  window.Range.prototype.getBoundingClientRect = rectAt(100, 2, 300, 20);
+  await act(async () => {
+    msgBody.dispatchEvent(new window.MouseEvent("pointerup", { bubbles: true, button: 0 }));
+    await drainFrame();
+  });
+  const flipped = document.querySelector(".transcript-selection-action") as HTMLElement | null;
+  eq(flipped?.style.top, "30px", "the action flips below the selection when the top edge is too tight");
+  eq(flipped?.style.left, "250px", "the flipped action stays centered over the selection");
+
+  window.Range.prototype.getBoundingClientRect = originalRangeRect;
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
   // Plain browser (no window.runtime): the native menu owns right-click.
   const dom = installDom();
   document.body.insertAdjacentHTML("beforeend", "<div class=\"msg__body\">browser text</div>");

--- a/desktop/frontend/src/components/TranscriptSelectionMenu.tsx
+++ b/desktop/frontend/src/components/TranscriptSelectionMenu.tsx
@@ -23,6 +23,10 @@ import { useT } from "../lib/i18n";
 type SelectionAction = {
   text: string;
   point: ContextMenuPoint;
+  // Bounding rect of the selected range. The floating action centers itself
+  // horizontally over this rect and prefers the space above it, flipping below
+  // when the top edge would collide with the window.
+  anchor?: { left: number; top: number; width: number; height: number };
 };
 
 const ACTION_EDGE_GAP = 8;
@@ -106,16 +110,32 @@ export function TranscriptSelectionMenu({
       setActionPoint(action.point);
       return;
     }
-    setActionPoint({
-      left: Math.min(
-        Math.max(ACTION_EDGE_GAP, action.point.left),
-        Math.max(ACTION_EDGE_GAP, window.innerWidth - rect.width - ACTION_EDGE_GAP),
-      ),
-      top: Math.min(
-        Math.max(ACTION_EDGE_GAP, action.point.top),
-        Math.max(ACTION_EDGE_GAP, window.innerHeight - rect.height - ACTION_EDGE_GAP),
-      ),
-    });
+    if (!action.anchor) {
+      // No measurable selection rect (e.g. synthetic ranges): keep the raw
+      // point, only clamped to the window edges.
+      setActionPoint({
+        left: Math.min(
+          Math.max(ACTION_EDGE_GAP, action.point.left),
+          Math.max(ACTION_EDGE_GAP, window.innerWidth - rect.width - ACTION_EDGE_GAP),
+        ),
+        top: Math.min(
+          Math.max(ACTION_EDGE_GAP, action.point.top),
+          Math.max(ACTION_EDGE_GAP, window.innerHeight - rect.height - ACTION_EDGE_GAP),
+        ),
+      });
+      return;
+    }
+    const { left: anchorLeft, top: anchorTop, width: anchorWidth, height: anchorHeight } = action.anchor;
+    const centeredLeft = anchorLeft + anchorWidth / 2 - rect.width / 2;
+    const left = Math.min(
+      Math.max(ACTION_EDGE_GAP, centeredLeft),
+      Math.max(ACTION_EDGE_GAP, window.innerWidth - rect.width - ACTION_EDGE_GAP),
+    );
+    // Prefer the space above the selection; flip below when the top edge
+    // would collide with the window.
+    const above = anchorTop - rect.height - ACTION_EDGE_GAP;
+    const top = above >= ACTION_EDGE_GAP ? above : anchorTop + anchorHeight + ACTION_EDGE_GAP;
+    setActionPoint({ left, top });
   }, [action]);
 
   useEffect(() => {
@@ -150,12 +170,15 @@ export function TranscriptSelectionMenu({
       if (dismissedRef.current === selected) return;
       dismissedRef.current = null;
       const rect = typeof range.getBoundingClientRect === "function" ? range.getBoundingClientRect() : null;
-      setAction({
-        text: selected,
-        point: rect && (rect.width > 0 || rect.height > 0)
-          ? { left: rect.right, top: rect.bottom + 8 }
-          : { left: 12, top: 12 },
-      });
+      setAction(
+        rect && (rect.width > 0 || rect.height > 0)
+          ? {
+              text: selected,
+              point: { left: rect.left + rect.width / 2, top: rect.top - ACTION_EDGE_GAP },
+              anchor: { left: rect.left, top: rect.top, width: rect.width, height: rect.height },
+            }
+          : { text: selected, point: { left: 12, top: 12 } },
+      );
     };
     const scheduleShow = (target: EventTarget | null) => {
       if (frame !== null) cancelAnimationFrame(frame);


### PR DESCRIPTION
## Summary

The floating "Add to Chat" action that appears after selecting transcript text was anchored at the bottom-right corner of the selection (`rect.right / rect.bottom + 8`), which is easy to miss and visually disconnected from the highlighted text.

The action is now placed **directly above the selection, horizontally centered** (8px gap). When the space above the selection is too tight to fit the action, it flips below the selection and stays centered. When no measurable selection rect exists (e.g. synthetic ranges), it falls back to the previous window-edge-clamped placement.

Changes:
- `desktop/frontend/src/components/TranscriptSelectionMenu.tsx`
  - `SelectionAction` now carries the selection's bounding rect (`anchor`)
  - Horizontal centering over the selection with window-edge clamping
  - Prefer above, flip below on top-edge collision
- `desktop/frontend/src/__tests__/transcript-selection-menu.test.tsx`
  - 4 new regression assertions: centered above, flip below when the top edge is too tight, and centered in both cases

## Issues

No linked issue — UI improvement.

## Verification

- `tsx src/__tests__/transcript-selection-menu.test.tsx` → **41 passed, 0 failed** (4 new assertions included)
- ESLint passes on both changed files
- `wails build -debug` (darwin/arm64) builds successfully
- Manual verification in an isolated native desktop window (separate `REASONIX_HOME` / `REASONIX_STATE_HOME` / `REASONIX_CACHE_HOME`, no Safe Mode): the action appears centered above the selection, and flips below when the selection is near the top edge

## Cache impact

Cache-impact: none (pure client-side UI positioning; no model-visible prompt or cache content changes)
Cache-guard: N/A (no cache-sensitive code paths touched)
System-prompt-review: N/A