### PR TITLE
fix(desktop): warn when a workspace config overrides settings

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -400,6 +400,7 @@ export function SettingsPanel({
                   <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}>
                     <UpdatesSection
                       configPath={s.configPath}
+                      shadowedByPath={s.shadowedByPath}
                       checkUpdates={s.checkUpdates}
                       telemetry={s.telemetry !== false}
                       metrics={s.metrics !== false}
@@ -7005,6 +7006,7 @@ const mb = (n: number) => (n / MB).toFixed(1);
 // action with inline progress and errors.
 function UpdatesSection({
   configPath,
+  shadowedByPath,
   checkUpdates,
   telemetry,
   metrics,
@@ -7012,6 +7014,7 @@ function UpdatesSection({
   applySettings,
 }: {
   configPath: string;
+  shadowedByPath?: string;
   checkUpdates: boolean;
   telemetry: boolean;
   metrics: boolean;
@@ -7264,6 +7267,11 @@ function UpdatesSection({
           {configPath && (
             <Tooltip label={configPath} fill block className="mem-hint settings-config-path">
               {t("settings.config", { path: configPath })}
+            </Tooltip>
+          )}
+          {shadowedByPath && (
+            <Tooltip label={shadowedByPath} fill block className="mem-hint settings-config-path settings-config-path--shadowed">
+              {t("settings.configShadowed", { path: shadowedByPath })}
             </Tooltip>
           )}
         </div>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1650,7 +1650,8 @@ function makeMockApp(): AppBindings {
     updateChannel: "stable",
     telemetry: true,
     metrics: true,
-    configPath: "~/projects/reasonix/reasonix.toml",
+    configPath: "~/.reasonix/config.toml",
+    shadowedByPath: "~/projects/reasonix/reasonix.toml",
     providerKinds: ["openai", "anthropic"],
     autoApproveTools: false,
     bypass: false,
@@ -1681,6 +1682,7 @@ function makeMockApp(): AppBindings {
   );
   if (freshMock) {
     settings.configPath = "~/.reasonix/config.toml";
+    settings.shadowedByPath = "";
   }
   const mockNow = Date.now();
   const mockProjectTree: ProjectNode[] = freshMock ? [] : [

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -1877,6 +1877,7 @@ export interface SettingsView {
   telemetry: boolean; // anonymous launch ping + scrubbed next-launch native crash diagnostics
   metrics: boolean; // aggregate quality/lifecycle metrics (anonymous signal/bucket counts)
   configPath: string;
+  shadowedByPath?: string; // workspace reasonix.toml that outranks configPath, when one exists
   providerKinds: string[]; // provider implementations the kernel registered (for the kind picker)
   autoApproveTools: boolean;
   bypass: boolean; // legacy JSON key for live YOLO/full-access tool auto-approval

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2638,6 +2638,7 @@ export const en = {
   "settings.currency": "Pricing currency",
   "settings.currencyAuto": "Auto (language)",
   "settings.config": "config: {path}",
+  "settings.configShadowed": "overridden by workspace config: {path} (changes here may not take effect)",
   "settings.generativeMusic": "Generative background music",
   "settings.generativeMusicHint": "Ambient music that loops during AI generation",
   "settings.generativeMusicPreset": "Sound preset",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1801,6 +1801,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.currency": "計價幣別",
   "settings.currencyAuto": "自動（跟隨語言）",
   "settings.config": "設定檔：{path}",
+  "settings.configShadowed": "被工作區設定覆蓋：{path}（這裡的修改可能不會生效）",
 
   // 待辦欄
   "todo.title": "待辦",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2641,6 +2641,7 @@ export const zh: Record<DictKey, string> = {
   "settings.currency": "计价币种",
   "settings.currencyAuto": "自动（跟随语言）",
   "settings.config": "配置文件：{path}",
+  "settings.configShadowed": "被工作区配置覆盖：{path}（这里的修改可能不生效）",
   "settings.generativeMusic": "生成式背景音乐",
   "settings.generativeMusicHint": "对话生成过程中播放背景音乐",
   "settings.generativeMusicPreset": "音乐预设",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -307,6 +308,10 @@ type SettingsView struct {
 	ExpandThinking    bool   `json:"expandThinking"`
 	ConversationWidth string `json:"conversationWidth,omitempty"`
 	ConfigPath        string `json:"configPath"`
+	// ShadowedByPath is the workspace reasonix.toml that outranks the file this
+	// panel writes, so an edit here can be overridden with nothing on screen to
+	// explain it (#4333). Empty when the panel's file is the one in effect.
+	ShadowedByPath string `json:"shadowedByPath,omitempty"`
 	// ProviderKinds lists the provider implementations the kernel actually
 	// registered (provider.Kinds()), so the editor's "kind" picker offers only
 	// kinds that resolve — selecting an unregistered one would fail the rebuild.
@@ -339,6 +344,33 @@ type DesktopStartupSettingsView struct {
 	// recovered in memory (last-known-good or defaults) without rewriting files.
 	ConfigWarnings []string `json:"configWarnings,omitempty"`
 	ConfigPath     string   `json:"configPath,omitempty"`
+}
+
+// shadowingConfigPath returns the config file that outranks writePath for the
+// workspace at root, or "" when writePath is the one in effect. A project
+// reasonix.toml beats the user config, so settings written here would otherwise
+// look ignored (#4333).
+func shadowingConfigPath(writePath, root string) string {
+	effective := config.SourcePathForRoot(root)
+	if effective == "" || samePath(effective, writePath) {
+		return ""
+	}
+	if abs, err := filepath.Abs(effective); err == nil {
+		return abs
+	}
+	return effective
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(absA), filepath.Clean(absB))
+	}
+	return filepath.Clean(absA) == filepath.Clean(absB)
 }
 
 func nonNil(s []string) []string {
@@ -1061,6 +1093,7 @@ func (a *App) Settings() SettingsView {
 		ExpandThinking:          cfg.Desktop.ExpandThinking,
 		ConversationWidth:       cfg.DesktopConversationWidth(),
 		ConfigPath:              cfgPath,
+		ShadowedByPath:          shadowingConfigPath(cfgPath, root),
 		ProviderKinds:           nonNil(provider.Kinds()),
 		AutoApproveTools:        ctrl != nil && ctrl.AutoApproveTools(),
 		Bypass:                  ctrl != nil && ctrl.AutoApproveTools(),

--- a/desktop/settings_shadow_test.go
+++ b/desktop/settings_shadow_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShadowingConfigPathReportsProjectFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	userPath := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(userPath, []byte("default_model = \"a\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	project := filepath.Join(root, "reasonix.toml")
+	if err := os.WriteFile(project, []byte("default_model = \"b\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := shadowingConfigPath(userPath, root)
+	if !samePath(got, project) {
+		t.Fatalf("shadowingConfigPath = %q, want the project file %q", got, project)
+	}
+}
+
+func TestShadowingConfigPathEmptyWhenUserConfigWins(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	userPath := filepath.Join(home, "config.toml")
+	if err := os.WriteFile(userPath, []byte("default_model = \"a\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := shadowingConfigPath(userPath, t.TempDir()); got != "" {
+		t.Fatalf("shadowingConfigPath = %q, want empty when the panel writes the effective file", got)
+	}
+}


### PR DESCRIPTION
Settings writes the **user** config (`<Reasonix home>/config.toml`), but resolution order is `flag > ./reasonix.toml > user config > defaults`. So in a workspace that has its own `reasonix.toml`, flipping sandbox mode or permission mode in the GUI writes a file that loses — the panel shows one thing, the agent does another, and nothing says why.

The panel now names the file actually in effect whenever it differs from the one it writes:

> 被工作区配置覆盖：/path/to/project/reasonix.toml（这里的修改可能不生效）

Same information the CLI's `/status` gained in #7393, on the surface where the edit is being made.

- `shadowingConfigPath` resolves the effective file for the active workspace root and returns empty when that *is* the panel's file (case-insensitive path compare on Windows).
- Bindings contract synced by hand: Go struct → `types.ts` → dev mock in `bridge.ts` (the mock exercises the shadowed case, and `freshMock` clears it).
- Strings added for zh / zh-TW / en.

Verified: `go test ./ -run TestShadowingConfigPath`, `tsc --noEmit` clean, plus `startup-settings-contract`, `settings-refresh-snapshot` and `bundle-contract` frontend suites.

Closes #4333