### PR TITLE
fix(desktop): enable double-click titlebar zoom on macOS

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4123,16 +4123,28 @@ export default function App() {
   const topicbarCanRename = !sidebarImDetailConnection && Boolean(activeTab?.topicId);
   const topicbarTitleEditSize = Math.min(56, Math.max(4, topicTitleDraft.length || topicbarTitle.length || 1));
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
-  const handleWindowsTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
-    if (!windowsFramelessChrome) return;
+  const handleTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    // Windows: the frameless chrome replaces the native titlebar, so the
+    // double-click zoom gesture has to be re-implemented in JS.
+    // macOS: TitleBarHiddenInset keeps only the traffic lights; the webview
+    // covers the title region and WKWebView does not turn a double-click on
+    // the CSS drag region into the native zoom gesture, so handle it here too
+    // (runtime.WindowToggleMaximise maps to the native zoom on macOS).
+    if (!windowsFramelessChrome && desktopPlatform !== "darwin") return;
+    // macOS keeps the sidebar itself draggable (it extends the title region
+    // up to the traffic lights), so its blank areas join the zoom zones;
+    // the Windows sidebar is explicitly no-drag and stays out.
+    const zoomZones = desktopPlatform === "darwin"
+      ? ".app-chrome, .topicbar, .workbench-dock__tools, .sidebar"
+      : ".app-chrome, .topicbar, .workbench-dock__tools";
     const target = event.target as HTMLElement | null;
-    if (!target?.closest(".app-chrome, .topicbar, .workbench-dock__tools")) return;
+    if (!target?.closest(zoomZones)) return;
     if (target.closest("button, input, textarea, select, a, [role='button'], [role='tab'], .windows-window-controls")) return;
     event.preventDefault();
     void app.ToggleMaximiseMainWindow()
       .then(() => window.setTimeout(syncMainWindowMaximised, 80))
       .catch(() => undefined);
-  }, [syncMainWindowMaximised, windowsFramelessChrome]);
+  }, [desktopPlatform, syncMainWindowMaximised, windowsFramelessChrome]);
   // Creation keeps the classic sidebar/chat structure while gating chrome tweaks
   // behind its own style flag so classic/workbench remain unchanged.
   const appChromeHidden = sidebarWorkbench || sidebarCreation;
@@ -4150,7 +4162,7 @@ export default function App() {
     <TextSizeHotkeys />
       <div
         ref={appRef}
-        onDoubleClickCapture={handleWindowsTitlebarDoubleClick}
+        onDoubleClickCapture={handleTitlebarDoubleClick}
         className={[
         "app",
         `app--${desktopPlatform}`,

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -795,5 +795,21 @@ ok(
   "offscreen skip link does not leak its focus shadow into the workbench title area",
 );
 
+ok(
+  // The double-click zoom gesture is re-implemented for both frameless
+  // Windows chrome and macOS TitleBarHiddenInset (WKWebView does not turn a
+  // double-click on the CSS drag region into the native zoom). macOS also
+  // includes the draggable sidebar (it reaches the traffic lights), while the
+  // Windows sidebar is no-drag and must stay out of the zoom zones.
+  appSource.includes('onDoubleClickCapture={handleTitlebarDoubleClick}') &&
+    /const handleTitlebarDoubleClick = useCallback\(/.test(appSource) &&
+    /if \(!windowsFramelessChrome && desktopPlatform !== "darwin"\) return;/.test(appSource) &&
+    /const zoomZones = desktopPlatform === "darwin"\s*\n\s*\? "\.app-chrome, \.topicbar, \.workbench-dock__tools, \.sidebar"\s*\n\s*: "\.app-chrome, \.topicbar, \.workbench-dock__tools";/.test(appSource) &&
+    /target\?\.closest\(zoomZones\)/.test(appSource) &&
+    /target\.closest\("button, input, textarea, select, a, \[role='button'\], \[role='tab'\], \.windows-window-controls"\)/.test(appSource) &&
+    /void app\.ToggleMaximiseMainWindow\(\)/.test(appSource),
+  "titlebar double-click zoom is wired for Windows frameless chrome and macOS inset titlebar (sidebar included on macOS)",
+);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Double-clicking the top title region to zoom the window worked on Windows (the frameless chrome re-implements the gesture in JS) but did nothing on macOS: the window uses `mac.TitleBarHiddenInset()`, so only the traffic lights remain and the webview covers the title region. WKWebView does not turn a double-click on the CSS drag region (`--wails-draggable: drag`) into the native zoom gesture.

The existing titlebar double-click handler is now shared across both platforms:

- **Windows** (unchanged): zoom zones stay `.app-chrome`, `.topicbar`, `.workbench-dock__tools`; the Windows sidebar is explicitly `no-drag` and stays out.
- **macOS** (new): the same zones plus `.sidebar`, which is draggable on macOS (it extends the title region up to the traffic lights), so double-clicking the blank areas next to the traffic lights / above the wordmark zooms too.

The gesture calls the existing `ToggleMaximiseMainWindow`, which maps to the native `[mainWindow zoom:nil]` on macOS — the standard zoom (toggle between the user's previous size and the zoomed size), not a forced fill-screen maximise. Interactive elements (`button`, `input`, `textarea`, `select`, `a`, `[role=button]`, `[role=tab]`) are excluded in both platforms.

## Issues

No linked issue — UX parity improvement.

## Verification

- `tsx src/__tests__/app-chrome-tabs.test.ts` → **126 passed, 0 failed** (new contract assertion locks in the cross-platform wiring: macOS zoom zones include `.sidebar`, Windows zones do not)
- ESLint passes on both changed files
- TypeScript typecheck: no new errors
- `wails build -debug` (darwin/arm64) builds successfully
- Manual verification in an isolated native desktop window (separate `REASONIX_HOME` / `REASONIX_STATE_HOME` / `REASONIX_CACHE_HOME`, no Safe Mode): double-click zoom works on the center/right title areas and on the sidebar region next to the traffic lights; interactive controls still ignore the gesture

## Cache impact

Cache-impact: none (pure client-side UI gesture; no model-visible prompt or cache content changes)
Cache-guard: N/A (no cache-sensitive code paths touched)
System-prompt-review: N/A