### PR TITLE
fix(cli): authenticate release lookups with GITHUB_TOKEN

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -493,6 +493,33 @@ func pickCLIRelease(rels []ghRelease, channel cliReleaseChannel) *ghRelease {
 	return &rels[best]
 }
 
+// githubAPIToken returns the token to authenticate release lookups with.
+// Anonymous GitHub API requests share a 60/hour quota per IP, which a NAT or
+// office network exhausts long before one user's upgrades do (#4449).
+func githubAPIToken() string {
+	for _, name := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// githubRateLimitHint names the fix when a refusal is the anonymous quota
+// rather than a broken request.
+func githubRateLimitHint(resp *http.Response) string {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return ""
+	}
+	if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+		return ""
+	}
+	if githubAPIToken() != "" {
+		return " (rate limited; retry after the window resets)"
+	}
+	return " (rate limited; set GITHUB_TOKEN to raise the quota)"
+}
+
 // fetchLatestRelease queries the GitHub Releases API and returns the newest
 // strict CLI release in the selected public channel.
 func fetchLatestRelease(c *http.Client, channel cliReleaseChannel) (*ghRelease, error) {
@@ -508,6 +535,9 @@ func fetchLatestRelease(c *http.Client, channel cliReleaseChannel) (*ghRelease, 
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "reasonix-cli")
+	if token := githubAPIToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := c.Do(req)
 	if err != nil {
@@ -515,7 +545,7 @@ func fetchLatestRelease(c *http.Client, channel cliReleaseChannel) (*ghRelease, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("release gateway: %v; GitHub API: %s", pointerErr, resp.Status)
+		return nil, fmt.Errorf("release gateway: %v; GitHub API: %s%s", pointerErr, resp.Status, githubRateLimitHint(resp))
 	}
 
 	var rels []ghRelease

--- a/internal/cli/upgrade_token_test.go
+++ b/internal/cli/upgrade_token_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestFetchLatestReleaseAuthenticatesWithGitHubToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "ghp_example")
+	t.Setenv("GH_TOKEN", "")
+	var gatewayAuth, apiAuth string
+
+	client := &http.Client{Transport: upgradeRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		switch request.URL.String() {
+		case cliGatewayBase + "/stable/latest.json":
+			gatewayAuth = request.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found", Header: make(http.Header),
+				Body: io.NopCloser(strings.NewReader("")), Request: request}, nil
+		case ghAPIReleases:
+			apiAuth = request.Header.Get("Authorization")
+			body, err := json.Marshal([]ghRelease{completeCLIRelease("v1.9.0", false)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Header: make(http.Header),
+				Body: io.NopCloser(bytes.NewReader(body)), Request: request}, nil
+		default:
+			t.Fatalf("unexpected release request: %s", request.URL)
+			return nil, nil
+		}
+	})}
+
+	if _, err := fetchLatestRelease(client, cliReleaseStable); err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if apiAuth != "Bearer ghp_example" {
+		t.Errorf("GitHub API Authorization = %q, want the configured token", apiAuth)
+	}
+	if gatewayAuth != "" {
+		t.Errorf("release gateway received Authorization %q; the token must not leave api.github.com", gatewayAuth)
+	}
+}
+
+func TestFetchLatestReleaseWithoutTokenStaysAnonymous(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+	var apiAuth string
+	seen := false
+
+	client := &http.Client{Transport: upgradeRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.URL.String() == ghAPIReleases {
+			seen = true
+			apiAuth = request.Header.Get("Authorization")
+			header := make(http.Header)
+			header.Set("X-RateLimit-Remaining", "0")
+			return &http.Response{StatusCode: http.StatusForbidden, Status: "403 Forbidden", Header: header,
+				Body: io.NopCloser(strings.NewReader("")), Request: request}, nil
+		}
+		return &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found", Header: make(http.Header),
+			Body: io.NopCloser(strings.NewReader("")), Request: request}, nil
+	})}
+
+	_, err := fetchLatestRelease(client, cliReleaseStable)
+	if !seen {
+		t.Fatal("GitHub API fallback was not attempted")
+	}
+	if apiAuth != "" {
+		t.Errorf("Authorization = %q, want no header when no token is configured", apiAuth)
+	}
+	if err == nil || !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Errorf("rate-limited failure should name the fix, got %v", err)
+	}
+}


### PR DESCRIPTION
`reasonix upgrade` falls back to the GitHub Releases API when the release gateway is unreachable, and that request was anonymous. Anonymous GitHub API quota is **60 requests/hour per IP** — shared across everyone behind the same NAT — so the fallback fails with `403 Forbidden` on office and campus networks even for a user who has never run it before. Having `GITHUB_TOKEN` exported didn't help, because nothing read it.

- Sends `Authorization: Bearer <token>` from `GITHUB_TOKEN` (or `GH_TOKEN`) on the api.github.com request only. The release-gateway request stays unauthenticated — a test pins that, so the token can't leak to a non-GitHub host.
- A 403/429 whose `X-RateLimit-Remaining` is `0` now says what to do: `(rate limited; set GITHUB_TOKEN to raise the quota)`, or "retry after the window resets" when a token is already in play. Other 403s are unchanged, since they aren't quota problems.

Tests: token present → header set on the API call and absent from the gateway call; no token → no header, and the rate-limited error names `GITHUB_TOKEN`.

Closes #4449