### PR TITLE
Fix/issue 7399 sweep race

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4848,18 +4848,24 @@ func (a *App) buildSessionRebindCandidate(
 }
 
 func (a *App) acquireCandidateSessionLease(tab *WorkspaceTab, path string) (*agent.SessionLease, error) {
-	lease, err := agent.TryAcquireSessionLease(path)
-	if err == nil {
-		return lease, nil
-	}
-	if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
-		if reclaimed, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
-			return reclaimed, nil
-		} else {
-			err = reclaimErr
+	lease, err := withSessionLeaseContentionRetry(func() (*agent.SessionLease, error) {
+		lease, err := agent.TryAcquireSessionLease(path)
+		if err == nil {
+			return lease, nil
 		}
+		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
+			if reclaimed, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
+				return reclaimed, nil
+			} else {
+				err = reclaimErr
+			}
+		}
+		return nil, err
+	})
+	if err != nil {
+		return nil, userFacingSessionLeaseError("", err)
 	}
-	return nil, userFacingSessionLeaseError("", err)
+	return lease, nil
 }
 
 func loadResumableSession(sessionPath string) (*agent.Session, error) {
@@ -10009,21 +10015,59 @@ func sessionPathAfterSnapshot(ctrl control.SessionAPI, fallback string) string {
 	return fallback
 }
 
+var (
+	// sessionLeaseContentionRetryInterval and sessionLeaseContentionRetryAttempts
+	// bound the retry window for startup session-lease binds that hit a
+	// transient in-process holder. CleanupStaleRunning probes a running
+	// sub-agent's parent session lease inside every controller build, holding
+	// it only for the duration of a metadata rewrite (sub-millisecond); a
+	// concurrent tab build that races that probe must not surface a spurious
+	// "already open in another Reasonix window" error for a lease that is
+	// genuinely free once the probe releases it. A lease held by another
+	// window or process stays held for its whole lifetime, so the bounded
+	// retry still fails fast there.
+	sessionLeaseContentionRetryInterval = 50 * time.Millisecond
+	sessionLeaseContentionRetryAttempts = 2
+)
+
+// withSessionLeaseContentionRetry retries acquire while it fails with
+// agent.ErrSessionLeaseHeld, absorbing sub-second contention windows created
+// by transient in-process lease probes. Any other error is returned
+// immediately, and a lease that remains held after the bounded retries is
+// reported as-is.
+func withSessionLeaseContentionRetry[T any](acquire func() (T, error)) (T, error) {
+	var zero T
+	for attempt := 0; ; attempt++ {
+		got, err := acquire()
+		if err == nil {
+			return got, nil
+		}
+		if !errors.Is(err, agent.ErrSessionLeaseHeld) || attempt >= sessionLeaseContentionRetryAttempts {
+			return zero, err
+		}
+		time.Sleep(sessionLeaseContentionRetryInterval)
+	}
+}
+
 func (a *App) ensureTabSessionLeaseForRebuild(tab *WorkspaceTab, path, setting string) error {
 	transition, reserveErr := a.reserveSessionRuntimePath(tab, path)
 	if reserveErr != nil {
 		return userFacingSessionLeaseError(setting, reserveErr)
 	}
-	if err := tab.ensureSessionLease(path); err != nil {
-		if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
-			if lease, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
-				tab.adoptSessionLease(lease)
-				a.commitSessionRuntimePath(transition)
-				return nil
-			} else {
-				err = reclaimErr
+	if _, err := withSessionLeaseContentionRetry(func() (struct{}, error) {
+		if err := tab.ensureSessionLease(path); err != nil {
+			if a.canReclaimCurrentProcessSessionLease(tab, path, err) {
+				if lease, reclaimErr := agent.TryReclaimCurrentProcessSessionLease(path); reclaimErr == nil {
+					tab.adoptSessionLease(lease)
+					return struct{}{}, nil
+				} else {
+					err = reclaimErr
+				}
 			}
+			return struct{}{}, err
 		}
+		return struct{}{}, nil
+	}); err != nil {
 		a.rollbackSessionRuntimePath(transition)
 		return userFacingSessionLeaseError(setting, err)
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2476,6 +2476,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.Sessi
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		if teardownTimedOut {
@@ -4815,6 +4816,7 @@ func (a *App) buildSessionRebindCandidate(
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		sink.clearContext()
@@ -10281,6 +10283,7 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		return err
@@ -10463,6 +10466,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		return err
@@ -10604,6 +10608,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		return err

--- a/desktop/session_runtime.go
+++ b/desktop/session_runtime.go
@@ -459,3 +459,39 @@ func sameCurrentProcessLease(err error) bool {
 	host, _ := os.Hostname()
 	return strings.TrimSpace(leaseErr.Info.Hostname) == strings.TrimSpace(host)
 }
+
+// sessionParentLive reports whether sessionPath is actively owned by this
+// process: a registered runtime (starting placeholder through ready), an open
+// tab whose persisted session path matches — which also covers the
+// controller-build window before claimSessionRuntime publishes the registry
+// entry — or a detached runtime. CleanupStaleRunning consults it through
+// boot.Options.SubagentParentLive, so the stale sub-agent sweep never races a
+// live tab's startup bind for the parent session lease and never mislabels a
+// live parent's running sub-agents as interrupted. It only needs a read view
+// of tab/runtime state and is safe to call from inside a controller build
+// (which holds runtimeAdmissionMu.RLock, always acquired before a.mu).
+func (a *App) sessionParentLive(sessionPath string) bool {
+	key := sessionRuntimeKey(sessionPath)
+	if key == "" {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if rt := a.runtimeBySessionKey[key]; rt != nil && a.runtimeOwnerLiveLocked(rt) {
+		return true
+	}
+	for _, tab := range a.runtimeTabsLocked() {
+		if tab == nil {
+			continue
+		}
+		if sessionRuntimeKey(tab.SessionPath) == key {
+			return true
+		}
+		if ctrl := tab.Ctrl; ctrl != nil {
+			if p := sessionRuntimeKey(ctrl.SessionPath()); p != "" && p == key {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/desktop/session_runtime_test.go
+++ b/desktop/session_runtime_test.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
 
 func TestMetaNeverReportsReadyWithoutController(t *testing.T) {
@@ -187,5 +191,133 @@ func TestBackendRejectsSubmitWhenRuntimeIsNotReady(t *testing.T) {
 	}
 	if status := ctrl.RuntimeStatus(); status != (control.RuntimeStatus{}) {
 		t.Fatalf("controller status changed after rejected submit: %+v", status)
+	}
+}
+
+func TestSessionParentLive(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "live-session.jsonl")
+	other := filepath.Join(dir, "other-session.jsonl")
+	app := NewApp()
+
+	// No tabs: nothing is live.
+	if app.sessionParentLive(path) {
+		t.Fatal("sessionParentLive(path) = true with no tabs, want false")
+	}
+
+	// A tab in the controller-build window (Ctrl nil, persisted SessionPath
+	// already pinned) is live: the stale sweep must not probe its lease.
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", SessionPath: path, buildGeneration: 1}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	if !app.sessionParentLive(path) {
+		t.Fatal("sessionParentLive(path) = false for a building tab, want true")
+	}
+	if app.sessionParentLive(other) {
+		t.Fatal("sessionParentLive(other) = true, want false")
+	}
+
+	// A ready controller whose session path matches is live.
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "live", Sink: event.Discard})
+	defer ctrl.Close()
+	tab2 := &WorkspaceTab{ID: "tab2", Scope: "global", SessionPath: path, Ctrl: ctrl, Ready: true}
+	app.tabs[tab2.ID] = tab2
+	app.tabOrder = append(app.tabOrder, tab2.ID)
+	if !app.sessionParentLive(path) {
+		t.Fatal("sessionParentLive(path) = false for a ready controller, want true")
+	}
+
+	// A detached runtime (backgrounded tab) is live too.
+	detachedKey := sessionRuntimeKey(path)
+	app.ensureDetachedSessionsLocked()
+	app.detachedSessions[detachedKey] = &WorkspaceTab{ID: "detached", Scope: "global", SessionPath: path, Ctrl: ctrl, Ready: true}
+	if !app.sessionParentLive(path) {
+		t.Fatal("sessionParentLive(path) = false for a detached runtime, want true")
+	}
+}
+
+// TestCleanupStaleRunningWithDesktopProbe wires the desktop parent-liveness
+// probe into the stale sub-agent sweep end to end: a running sub-agent whose
+// parent session is open (or building) in the desktop must be left untouched
+// and its parent lease must not be probed, while an unowned parent is still
+// cleaned as a crash leftover.
+func TestCleanupStaleRunningWithDesktopProbe(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	sessionDir := t.TempDir()
+	parentID := "session-parent"
+	parentPath := filepath.Join(sessionDir, parentID+".jsonl")
+	newRunning := func() string {
+		store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+		spec := agent.SubagentSpec{
+			Kind:          "task",
+			Name:          "task",
+			WorkspaceRoot: t.TempDir(),
+			ParentSession: parentID,
+			SystemPrompt:  "sys",
+			Registry:      tool.NewRegistry(),
+			Model:         "base-model",
+		}
+		run, err := store.PrepareFresh(spec)
+		if err != nil {
+			t.Fatalf("PrepareFresh: %v", err)
+		}
+		if err := store.MarkRunning(run); err != nil {
+			t.Fatalf("MarkRunning: %v", err)
+		}
+		ref := run.Ref
+		run.Release()
+		return ref
+	}
+
+	app := NewApp()
+
+	// Parent live in desktop (tab building): sweep skips it.
+	liveRef := newRunning()
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", SessionPath: parentPath, buildGeneration: 1}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	liveStore := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	liveStore.WithParentSessionProbe(app.sessionParentLive)
+	if cleaned, err := liveStore.CleanupStaleRunning(); err != nil {
+		t.Fatalf("CleanupStaleRunning: %v", err)
+	} else if cleaned != 0 {
+		t.Fatalf("cleaned = %d for a live parent, want 0", cleaned)
+	}
+	meta, err := liveStore.LoadMeta(liveRef)
+	if err != nil {
+		t.Fatalf("LoadMeta(live): %v", err)
+	}
+	if meta.Status != agent.SubagentRunning {
+		t.Fatalf("live parent sub-agent status = %q, want running", meta.Status)
+	}
+
+	// No live parent: sweep cleans the crash leftovers — the previously
+	// skipped run now has no owner either, so both are interrupted.
+	delete(app.tabs, tab.ID)
+	staleRef := newRunning()
+	staleStore := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	staleStore.WithParentSessionProbe(app.sessionParentLive)
+	if cleaned, err := staleStore.CleanupStaleRunning(); err != nil {
+		t.Fatalf("CleanupStaleRunning: %v", err)
+	} else if cleaned != 2 {
+		t.Fatalf("cleaned = %d for dead parents, want 2", cleaned)
+	}
+	meta, err = staleStore.LoadMeta(staleRef)
+	if err != nil {
+		t.Fatalf("LoadMeta(stale): %v", err)
+	}
+	if meta.Status != agent.SubagentInterrupted {
+		t.Fatalf("dead parent sub-agent status = %q, want interrupted", meta.Status)
+	}
+	meta, err = staleStore.LoadMeta(liveRef)
+	if err != nil {
+		t.Fatalf("LoadMeta(live, now dead): %v", err)
+	}
+	if meta.Status != agent.SubagentInterrupted {
+		t.Fatalf("previously-live parent sub-agent status = %q, want interrupted after parent closed", meta.Status)
 	}
 }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1849,6 +1849,7 @@ func (a *App) rebuildSettingTurnLocked(setting string, tab *WorkspaceTab, admiss
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		if oldCtrl == nil {

--- a/desktop/startup_lease_contention_test.go
+++ b/desktop/startup_lease_contention_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+)
+
+// TestEnsureTabSessionLeaseForRebuildSurvivesTransientHolder reproduces the
+// startup "this session is already open in another Reasonix window" false
+// positive: a transient lease holder — CleanupStaleRunning probing a running
+// subagent's parent session during a concurrent controller build — holds the
+// session lease for a few milliseconds while the tab's own startup bind runs.
+// The bind must retry against the genuinely-free lease instead of surfacing a
+// spurious ErrSessionLeaseHeld.
+func TestEnsureTabSessionLeaseForRebuildSurvivesTransientHolder(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := filepath.Join(dir, "contended-session.jsonl")
+
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, SessionPath: path}
+	app := &App{
+		tabs:     map[string]*WorkspaceTab{tab.ID: tab},
+		tabOrder: []string{tab.ID},
+	}
+	t.Cleanup(tab.releaseSessionLease)
+
+	// Simulate CleanupStaleRunning's transient parent-session lease probe:
+	// acquire, hold briefly, then release. The probe targets the same runtime
+	// key the tab's bind uses (case-folded on Windows), so the contention is
+	// real on every platform.
+	key := sessionRuntimeKey(path)
+	acquired := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		lease, err := agent.TryAcquireSessionLease(key)
+		if err != nil {
+			t.Errorf("probe lease acquire: %v", err)
+			close(acquired)
+			return
+		}
+		close(acquired)
+		<-releaseProbe
+		lease.Release()
+	}()
+
+	<-acquired // the probe now holds the lease
+
+	bindErr := make(chan error, 1)
+	go func() {
+		bindErr <- app.ensureTabSessionLeaseForRebuild(tab, path, "")
+	}()
+
+	// Give the first bind attempt time to fail against the held lease, then
+	// release the probe: the bind must succeed on a later attempt.
+	time.Sleep(50 * time.Millisecond)
+	close(releaseProbe)
+
+	select {
+	case err := <-bindErr:
+		if err != nil {
+			t.Fatalf("startup bind failed against a transient holder: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("startup bind did not complete after the transient holder released")
+	}
+	<-probeDone
+
+	if key := tab.sessionLeaseRuntimeKey(); key != sessionRuntimeKey(path) {
+		t.Fatalf("tab lease key = %q, want %q", key, sessionRuntimeKey(path))
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3770,6 +3770,7 @@ func (a *App) buildTabControllerWithContextAdmissionHeld(tab *WorkspaceTab, load
 		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		SubagentParentLive:       a.sessionParentLive,
 	})
 	if err != nil {
 		leaseHeld := false

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -106,6 +106,15 @@ type SubagentStore struct {
 	dir       string
 	destroyed func(parentSession string) bool
 
+	// parentSessionProbe, when non-nil, reports whether a parent session path
+	// is actively owned by this process (an open tab, a detached runtime, or a
+	// controller build in flight). CleanupStaleRunning consults it BEFORE
+	// acquiring the parent session lease: a live parent's lease can be
+	// transiently free during a rebuild window, and probing it there would race
+	// the tab's own startup bind and could mislabel a running sub-agent of a
+	// live session as interrupted. Nil keeps the legacy lease-probe behavior.
+	parentSessionProbe func(sessionPath string) bool
+
 	mu     sync.Mutex
 	locked map[string]bool
 }
@@ -115,6 +124,16 @@ func NewSubagentStore(dir string) *SubagentStore {
 		return nil
 	}
 	return &SubagentStore{dir: dir, locked: map[string]bool{}}
+}
+
+// WithParentSessionProbe installs the parent-session liveness probe consulted
+// by CleanupStaleRunning (see SubagentStore.parentSessionProbe). Returns s for
+// chaining.
+func (s *SubagentStore) WithParentSessionProbe(probe func(sessionPath string) bool) *SubagentStore {
+	if s != nil {
+		s.parentSessionProbe = probe
+	}
+	return s
 }
 
 // WithDestroyedChecker makes saves for destroyed parent sessions no-op. This is
@@ -258,6 +277,15 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 	cleaned := 0
 	for _, parentID := range parentIDs {
 		parent := parents[parentID]
+		if s.parentSessionProbe != nil && s.parentSessionProbe(parent.sessionPath) {
+			// The parent is live in this process (open tab, detached runtime,
+			// or a controller build in flight). Its lease can be transiently
+			// free during a rebuild window; probing it now would race the
+			// tab's own startup bind and could mislabel a running sub-agent of
+			// a live session as interrupted. The sweep is only for crash
+			// leftovers, and a live parent is by definition not one.
+			continue
+		}
 		lease, err := TryAcquireSessionLease(parent.sessionPath)
 		if errors.Is(err, ErrSessionLeaseHeld) {
 			continue

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -948,3 +948,88 @@ func prepareCompletedSubagentForLineageTest(t *testing.T, parentSession string) 
 	run.Release()
 	return sessionDir, store, run.Ref, spec
 }
+
+func TestCleanupStaleRunningSkipsLiveParentViaProbe(t *testing.T) {
+	newRunning := func(t *testing.T, dir string) string {
+		store := NewSubagentStore(filepath.Join(dir, "subagents"))
+		spec := testSubagentSpec(t, "review")
+		run, err := store.PrepareFresh(spec)
+		if err != nil {
+			t.Fatalf("PrepareFresh: %v", err)
+		}
+		if err := store.MarkRunning(run); err != nil {
+			t.Fatalf("MarkRunning: %v", err)
+		}
+		ref := run.Ref
+		run.Release()
+		return ref
+	}
+	parentPath := func(dir string) string {
+		return filepath.Join(filepath.Dir(filepath.Join(dir, "subagents")), "parent-session.jsonl")
+	}
+
+	t.Run("probe_hit_skips_sweep", func(t *testing.T) {
+		dir := t.TempDir()
+		ref := newRunning(t, dir)
+		store := NewSubagentStore(filepath.Join(dir, "subagents"))
+		store.WithParentSessionProbe(func(path string) bool { return path == parentPath(dir) })
+
+		cleaned, err := store.CleanupStaleRunning()
+		if err != nil {
+			t.Fatalf("CleanupStaleRunning: %v", err)
+		}
+		if cleaned != 0 {
+			t.Fatalf("cleaned = %d with live parent probe, want 0", cleaned)
+		}
+		meta, err := store.LoadMeta(ref)
+		if err != nil {
+			t.Fatalf("LoadMeta: %v", err)
+		}
+		if meta.Status != SubagentRunning {
+			t.Fatalf("status = %q, want running (live parent must not be mislabeled)", meta.Status)
+		}
+	})
+
+	t.Run("probe_miss_cleans", func(t *testing.T) {
+		dir := t.TempDir()
+		ref := newRunning(t, dir)
+		store := NewSubagentStore(filepath.Join(dir, "subagents"))
+		store.WithParentSessionProbe(func(path string) bool { return false })
+
+		cleaned, err := store.CleanupStaleRunning()
+		if err != nil {
+			t.Fatalf("CleanupStaleRunning: %v", err)
+		}
+		if cleaned != 1 {
+			t.Fatalf("cleaned = %d with dead parent probe, want 1", cleaned)
+		}
+		meta, err := store.LoadMeta(ref)
+		if err != nil {
+			t.Fatalf("LoadMeta: %v", err)
+		}
+		if meta.Status != SubagentInterrupted {
+			t.Fatalf("status = %q, want interrupted", meta.Status)
+		}
+	})
+
+	t.Run("nil_probe_keeps_legacy_behavior", func(t *testing.T) {
+		dir := t.TempDir()
+		ref := newRunning(t, dir)
+		store := NewSubagentStore(filepath.Join(dir, "subagents"))
+
+		cleaned, err := store.CleanupStaleRunning()
+		if err != nil {
+			t.Fatalf("CleanupStaleRunning: %v", err)
+		}
+		if cleaned != 1 {
+			t.Fatalf("cleaned = %d without probe, want 1", cleaned)
+		}
+		meta, err := store.LoadMeta(ref)
+		if err != nil {
+			t.Fatalf("LoadMeta: %v", err)
+		}
+		if meta.Status != SubagentInterrupted {
+			t.Fatalf("status = %q, want interrupted", meta.Status)
+		}
+	})
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/agent"
@@ -2167,13 +2168,31 @@ func isGitMarker(path string) bool {
 	return err == nil && (fi.IsDir() || fi.Mode().IsRegular())
 }
 
+// subagentCleanupSwept tracks session dirs whose stale-running sub-agent
+// sweep has already run in this process. Desktop tabs share one global
+// session dir, so without this every controller build (startup, model/effort
+// switch, provider retarget, deferred rebuild) re-swept the shared subagents
+// directory. Each sweep transiently acquires the running sub-agent's parent
+// session lease, so concurrent tab builds raced the probe against their own
+// startup bind and surfaced spurious "already open in another Reasonix
+// window" errors. CLI/serve runs are fresh processes, so their sweep-once
+// semantics are unchanged.
+var subagentCleanupSwept sync.Map // sessionDir -> struct{}
+
 func newSubagentStore(sessionDir string) (*agent.SubagentStore, error) {
 	sessionDir = strings.TrimSpace(sessionDir)
 	if sessionDir == "" {
 		return nil, nil
 	}
 	store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	key := filepath.Clean(sessionDir)
+	if _, loaded := subagentCleanupSwept.LoadOrStore(key, struct{}{}); loaded {
+		return store, nil
+	}
 	if _, err := store.CleanupStaleRunning(); err != nil {
+		// A failed sweep must not wedge the session dir as "already swept":
+		// drop the marker so a later build retries the cleanup.
+		subagentCleanupSwept.Delete(key)
 		return nil, fmt.Errorf("cleanup stale subagents: %w", err)
 	}
 	return store, nil

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -156,6 +156,14 @@ type Options struct {
 	// local UI metadata to automatic transcript recovery branches.
 	SessionRecoveryMeta func(control.SessionRecoveryRequest) agent.BranchMeta
 	OnSessionRecovered  func(control.SessionRecoveryInfo) error
+	// SubagentParentLive lets a frontend report whether a session path is
+	// actively owned by this process (an open tab, a detached runtime, or a
+	// controller build in flight). CleanupStaleRunning consults it before
+	// acquiring a running sub-agent's parent session lease, so the stale
+	// sweep never races a live tab's startup bind nor mislabels an active
+	// parent's sub-agents as interrupted. Nil keeps the legacy lease-probe
+	// behavior (safe for single-controller frontends like the CLI).
+	SubagentParentLive func(sessionPath string) bool
 	// FileOverlay and TerminalRunner let a host transport (ACP) serve file
 	// content from editor buffers and run foreground bash in a host terminal.
 	// Both only change where tool I/O happens — tool names, descriptions, and
@@ -738,7 +746,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
-	subagentStore, err := newSubagentStore(sessionDir)
+	subagentStore, err := newSubagentStore(sessionDir, opts.SubagentParentLive)
 	if err != nil {
 		return nil, err
 	}
@@ -2179,12 +2187,13 @@ func isGitMarker(path string) bool {
 // semantics are unchanged.
 var subagentCleanupSwept sync.Map // sessionDir -> struct{}
 
-func newSubagentStore(sessionDir string) (*agent.SubagentStore, error) {
+func newSubagentStore(sessionDir string, parentLive func(sessionPath string) bool) (*agent.SubagentStore, error) {
 	sessionDir = strings.TrimSpace(sessionDir)
 	if sessionDir == "" {
 		return nil, nil
 	}
 	store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	store.WithParentSessionProbe(parentLive)
 	key := filepath.Clean(sessionDir)
 	if _, loaded := subagentCleanupSwept.LoadOrStore(key, struct{}{}); loaded {
 		return store, nil

--- a/internal/boot/subagent_cleanup_once_test.go
+++ b/internal/boot/subagent_cleanup_once_test.go
@@ -1,0 +1,70 @@
+package boot
+
+import (
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/tool"
+)
+
+// TestNewSubagentStoreCleansStaleRunningOncePerSessionDir pins the
+// per-process sweep-once contract: repeated controller builds for the same
+// session dir must not re-scan the shared subagents directory. Each sweep
+// transiently acquires the running subagent's parent session lease, so
+// sweeping inside every concurrent desktop tab build makes those builds race
+// the probe against their own startup bind and surface spurious
+// "already open in another Reasonix window" errors.
+func TestNewSubagentStoreCleansStaleRunningOncePerSessionDir(t *testing.T) {
+	sessionDir := t.TempDir()
+	newRunning := func() string {
+		store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+		spec := agent.SubagentSpec{
+			Kind:          "task",
+			Name:          "task",
+			WorkspaceRoot: t.TempDir(),
+			ParentSession: "parent-session",
+			SystemPrompt:  "sys",
+			Registry:      tool.NewRegistry(),
+			Model:         "base-model",
+		}
+		run, err := store.PrepareFresh(spec)
+		if err != nil {
+			t.Fatalf("PrepareFresh: %v", err)
+		}
+		if err := store.MarkRunning(run); err != nil {
+			t.Fatalf("MarkRunning: %v", err)
+		}
+		ref := run.Ref
+		run.Release()
+		return ref
+	}
+
+	// First controller build for this session dir sweeps stale running
+	// sub-agents, as it always has.
+	firstRef := newRunning()
+	if _, err := newSubagentStore(sessionDir); err != nil {
+		t.Fatalf("newSubagentStore (first): %v", err)
+	}
+	meta, err := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents")).LoadMeta(firstRef)
+	if err != nil {
+		t.Fatalf("LoadMeta(first): %v", err)
+	}
+	if meta.Status != agent.SubagentInterrupted {
+		t.Fatalf("first sweep status = %q, want interrupted", meta.Status)
+	}
+
+	// A later build for the same session dir (desktop: every tab rebuild)
+	// must not sweep again.
+	secondRef := newRunning()
+	if _, err := newSubagentStore(sessionDir); err != nil {
+		t.Fatalf("newSubagentStore (second): %v", err)
+	}
+	meta, err = agent.NewSubagentStore(filepath.Join(sessionDir, "subagents")).LoadMeta(secondRef)
+	if err != nil {
+		t.Fatalf("LoadMeta(second): %v", err)
+	}
+	if meta.Status != agent.SubagentRunning {
+		t.Fatalf("second sweep status = %q, want running (sweep must run once per process)", meta.Status)
+	}
+}

--- a/internal/boot/subagent_cleanup_once_test.go
+++ b/internal/boot/subagent_cleanup_once_test.go
@@ -43,7 +43,7 @@ func TestNewSubagentStoreCleansStaleRunningOncePerSessionDir(t *testing.T) {
 	// First controller build for this session dir sweeps stale running
 	// sub-agents, as it always has.
 	firstRef := newRunning()
-	if _, err := newSubagentStore(sessionDir); err != nil {
+	if _, err := newSubagentStore(sessionDir, nil); err != nil {
 		t.Fatalf("newSubagentStore (first): %v", err)
 	}
 	meta, err := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents")).LoadMeta(firstRef)
@@ -57,7 +57,7 @@ func TestNewSubagentStoreCleansStaleRunningOncePerSessionDir(t *testing.T) {
 	// A later build for the same session dir (desktop: every tab rebuild)
 	// must not sweep again.
 	secondRef := newRunning()
-	if _, err := newSubagentStore(sessionDir); err != nil {
+	if _, err := newSubagentStore(sessionDir, nil); err != nil {
 		t.Fatalf("newSubagentStore (second): %v", err)
 	}
 	meta, err = agent.NewSubagentStore(filepath.Join(sessionDir, "subagents")).LoadMeta(secondRef)
@@ -66,5 +66,47 @@ func TestNewSubagentStoreCleansStaleRunningOncePerSessionDir(t *testing.T) {
 	}
 	if meta.Status != agent.SubagentRunning {
 		t.Fatalf("second sweep status = %q, want running (sweep must run once per process)", meta.Status)
+	}
+}
+
+// TestNewSubagentStoreParentProbeSkipsLiveParent verifies that the
+// parent-liveness probe wired through newSubagentStore makes the very first
+// sweep skip a parent session that is live in this process — the controller
+// build window where the tab's lease is transiently free is exactly what the
+// probe must protect (no spurious "already open" race, no mislabeling of a
+// live session's running sub-agents).
+func TestNewSubagentStoreParentProbeSkipsLiveParent(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := agent.SubagentSpec{
+		Kind:          "task",
+		Name:          "task",
+		WorkspaceRoot: t.TempDir(),
+		ParentSession: "parent-session",
+		SystemPrompt:  "sys",
+		Registry:      tool.NewRegistry(),
+		Model:         "base-model",
+	}
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.MarkRunning(run); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+
+	parentPath := filepath.Join(sessionDir, "parent-session.jsonl")
+	got, err := newSubagentStore(sessionDir, func(path string) bool { return path == parentPath })
+	if err != nil {
+		t.Fatalf("newSubagentStore: %v", err)
+	}
+	meta, err := got.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != agent.SubagentRunning {
+		t.Fatalf("status = %q, want running (probe reported a live parent)", meta.Status)
 	}
 }

--- a/internal/boot/subagent_model_test.go
+++ b/internal/boot/subagent_model_test.go
@@ -144,13 +144,13 @@ func TestSubagentEffectiveIdentityUsesAuthoritativeExternalResolver(t *testing.T
 }
 
 func TestNewSubagentStoreRequiresSessionDir(t *testing.T) {
-	if got, err := newSubagentStore(""); err != nil || got != nil {
+	if got, err := newSubagentStore("", nil); err != nil || got != nil {
 		if err != nil {
 			t.Fatalf("empty session dir error = %v", err)
 		}
 		t.Fatalf("empty session dir should disable subagent store, got %#v", got)
 	}
-	if got, err := newSubagentStore(t.TempDir()); err != nil || got == nil {
+	if got, err := newSubagentStore(t.TempDir(), nil); err != nil || got == nil {
 		if err != nil {
 			t.Fatalf("non-empty session dir error = %v", err)
 		}
@@ -180,7 +180,7 @@ func TestNewSubagentStoreCleansStaleRunningRefs(t *testing.T) {
 	ref := run.Ref
 	run.Release()
 
-	got, err := newSubagentStore(sessionDir)
+	got, err := newSubagentStore(sessionDir, nil)
 	if err != nil {
 		t.Fatalf("newSubagentStore: %v", err)
 	}


### PR DESCRIPTION
## Summary

修复 #7399：多会话 + 后台子代理场景下，某个会话启动时报 "this session is already open in another Reasonix window"，但实际没有第二个窗口，重启才能恢复。

根因：`CleanupStaleRunning()` 在每次 controller 构建时执行，会短暂获取每个 running 子代理**父会话的租约**再释放；桌面端所有 tab 共享同一 sessionDir，并发构建时该探针与 tab 自己的启动绑定竞争同一把租约，输家对一把毫秒后本来就空闲的锁误报 "already open"。

本次为两层修复：

1. **最小修复**：启动租约绑定（`ensureTabSessionLeaseForRebuild`、`acquireCandidateSessionLease`）遇到 `ErrSessionLeaseHeld` 时短暂重试（50ms × 2，共 3 次），吸收毫秒级进程内竞争；`CleanupStaleRunning` 改为每 sessionDir 每进程只执行一次（`sync.Map` 标记，失败回滚可重试），从源头减少竞争窗口。真实跨进程持有者全程持锁，重试耗尽后照常报错，不会掩盖真实冲突。
2. **彻底修复**：给 `SubagentStore` 增加父会话存活探针（`WithParentSessionProbe` / `boot.Options.SubagentParentLive`），桌面端通过 `App.sessionParentLive()` 告知清理逻辑哪些父会话在本进程存活（打开中、构建中、后台 detached 运行时）。存活父会话直接跳过、**连租约都不碰**，从结构上消除竞争，同时避免把活会话的 running 子代理误标为 interrupted。CLI/serve 等单 controller 前端传 nil，保留原行为。

## Issues

Fixes #7399

## Verification

- `go test ./internal/boot/... ./internal/agent/... -count=1` — PASS
- 桌面端：`go test . -run 'Lease|SessionRuntime|TabBuild|Deferred|Startup|Resume|Rebind|Contention' -count=1` — PASS
- 新增回归测试全部 PASS：
  - `TestEnsureTabSessionLeaseForRebuildSurvivesTransientHolder`（修复前可一字不差复现 issue 报错）
  - `TestSessionParentLive`、`TestCleanupStaleRunningWithDesktopProbe`
  - `TestNewSubagentStoreCleansStaleRunningOncePerSessionDir`、`TestNewSubagentStoreParentProbeSkipsLiveParent`
  - `TestCleanupStaleRunningSkipsLiveParentViaProbe`（含 nil 探针保留旧行为）
- `go vet ./internal/boot/... ./internal/agent/...` — PASS
- `./scripts/cache-guard.sh` — PASS（全部用例 tail_avg 92–95%，阈值 90%）
- 说明：desktop 模块 `go vet .` 有一个**与本次改动无关的既有告警**（`remote_ssh_process_windows.go` 使用 `os.WithHandle`，而 desktop/go.mod 仍声明 go 1.25），未触碰该文件。

## Cache impact

Cache-impact: low — 不修改任何系统提示词、配置、工具 schema 或模型输入；仅调整子代理清理时机（每进程一次）与桌面启动租约绑定的重试，不进入缓存前缀路径。

Cache-guard: `./scripts/cache-guard.sh` 已运行并通过（tail_avg 92–95% > 90% 阈值）。

System-prompt-review: 请维护者复核 — 改动仅涉及 internal/boot 的子代理清理辅助函数与桌面会话租约绑定路径，不触及系统提示词/记忆前缀/输出风格/skill index 组装；目录级保守标记触发本检查。