### PR TITLE
Keep recovery notices out of IM chats / 避免向 IM 聊天转发恢复通知

### DIFF
--- a/desktop/bot_event_sink.go
+++ b/desktop/bot_event_sink.go
@@ -105,6 +105,10 @@ func (f *botEventForwarder) Emit(e event.Event) {
 		f.sendToAll(qb.String())
 
 	case event.Notice:
+		if e.Audience == event.NoticeAudienceOperator {
+			// Local runtime maintenance is not actionable in the remote IM chat.
+			break
+		}
 		if e.Level == event.LevelWarn {
 			f.sendToAll("⚠️ " + e.Text)
 		}

--- a/desktop/bot_event_sink_test.go
+++ b/desktop/bot_event_sink_test.go
@@ -131,3 +131,36 @@ func TestBotEventForwarderApprovalNoticeDoesNotExposeReplyID(t *testing.T) {
 		t.Fatal("approval notice was not sent")
 	}
 }
+
+func TestBotEventForwarderSuppressesOperatorNoticesWithoutHidingUserWarnings(t *testing.T) {
+	forwarder := &botEventForwarder{
+		runtime: &desktopBotRuntime{},
+		targets: []botForwardTarget{{
+			ConnID:   "feishu-lark",
+			Domain:   "lark",
+			ChatID:   "oc-group-1",
+			ChatType: bot.ChatGroup,
+		}},
+		queue: make(chan string, 2),
+	}
+
+	forwarder.Emit(event.Event{
+		Kind:     event.Notice,
+		Level:    event.LevelWarn,
+		Audience: event.NoticeAudienceOperator,
+		Code:     event.NoticeCodeSessionRecoveryForked,
+		Text:     "local session maintenance",
+	})
+	forwarder.Emit(event.Event{
+		Kind:  event.Notice,
+		Level: event.LevelWarn,
+		Text:  "please retry the user action",
+	})
+
+	if got := len(forwarder.queue); got != 1 {
+		t.Fatalf("queued messages = %d, want only the actionable user warning", got)
+	}
+	if got := <-forwarder.queue; got != "⚠️ please retry the user action" {
+		t.Fatalf("queued message = %q, want the ordinary user warning", got)
+	}
+}

--- a/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
+++ b/desktop/frontend/src/__tests__/recovery-quiet-notifications.test.ts
@@ -39,8 +39,8 @@ ok(!appSource.includes("OpenTabRecoveryParent"), "App does not expose recovery c
 ok(!appSource.includes("recovery.openOriginalFailed"), "App does not carry recovery compare failure text");
 
 ok(controllerSource.includes("function quietTranscriptNoticeKey"), "controller centralizes quiet transcript notices");
-ok(controllerSource.includes("if (quietTranscriptNoticeKey(rawText))"), "raw quiet notices are skipped before localization");
-ok(controllerSource.includes("if (quietTranscriptNoticeKey(text))"), "localized quiet notices are skipped before rendering");
+ok(controllerSource.includes("if (quietTranscriptNoticeKey(rawText, code))"), "raw quiet notices are skipped before localization");
+ok(controllerSource.includes("if (quietTranscriptNoticeKey(text, code))"), "localized quiet notices are skipped before rendering");
 
 const removedPromptKeys = [
   "recovery.open",

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -261,6 +261,21 @@ console.log("\nuse controller meta");
     "unapplied steer keeps the user's guidance while localizing the warning",
   );
   eq(
+    localizedNoticeText("reworded recovery copy", "session_recovery_forked"),
+    "The session changed on disk, so the unsaved local transcript was kept as a conflict copy.",
+    "session recovery fork localization uses its stable notice code",
+  );
+  eq(
+    localizedNoticeText("reworded covered adoption", "session_recovery_adopted_covered"),
+    "The session changed on disk, so Reasonix adopted the newer transcript; the local changes were already covered.",
+    "covered session adoption localization uses its stable notice code",
+  );
+  eq(
+    localizedNoticeText("reworded depth cap", "session_recovery_depth_cap"),
+    "Repeated save conflicts were detected, so the current conflict copy was saved in place.",
+    "session recovery depth-cap localization uses its stable notice code",
+  );
+  eq(
     localizedNoticeText("Tool round limit reached; asking the assistant to summarize progress.", "unknown_future_code"),
     "Tool round limit reached; asking the assistant to summarize progress.",
     "an unknown notice code falls back to exact-text matching",
@@ -275,7 +290,7 @@ console.log("\nuse controller meta");
 {
   let s = reducer(initialState, {
     type: "event",
-    e: { kind: "notice", level: "warn", text: "session conflicts kept recurring; kept the transcript on the current recovery branch" },
+    e: { kind: "notice", level: "warn", code: "session_recovery_depth_cap", text: "reworded recovery maintenance" },
   });
   s = reducer(s, {
     type: "event",

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1561,6 +1561,11 @@ const noticeCodeKeys: Record<string, DictKey> = {
   loop_guard: "notice.loopGuard",
   workspace_lease: "notice.workspaceLease",
   cancelled_turn_display: "notice.cancelledTurnDisplay",
+  session_recovery_forked: "recovery.noticeSavedCopy",
+  session_recovery_adopted: "recovery.noticeAdopted",
+  session_recovery_adopted_covered: "recovery.noticeAdoptedCovered",
+  session_recovery_depth_cap: "recovery.noticeKeptCurrent",
+  session_shutdown_recovery_forked: "recovery.noticeSavedCopy",
 };
 
 // localizedNoticeText localizes a notice's main copy by its stable code first,
@@ -1693,7 +1698,18 @@ function backendNoticeKey(msg: string): DictKey | "" {
   }
 }
 
-function recoveryNoticeDedupeKey(text: string): string {
+function recoveryNoticeDedupeKey(text: string, code?: string): string {
+  switch (code) {
+    case "session_recovery_forked":
+    case "session_shutdown_recovery_forked":
+      return "recovery:saved-copy";
+    case "session_recovery_depth_cap":
+      return "recovery:kept-current";
+    case "session_recovery_adopted_covered":
+      return "recovery:adopted-covered";
+    case "session_recovery_adopted":
+      return "recovery:adopted";
+  }
   const msg = text.trim();
   if (
     /^session changed on disk; unsaved local transcript was saved as a conflict copy$/i.test(msg) ||
@@ -1724,8 +1740,8 @@ function recoveryNoticeDedupeKey(text: string): string {
   return "";
 }
 
-function quietTranscriptNoticeKey(text: string): string {
-  const recovery = recoveryNoticeDedupeKey(text);
+function quietTranscriptNoticeKey(text: string, code?: string): string {
+  const recovery = recoveryNoticeDedupeKey(text, code);
   if (recovery) return recovery;
 
   const msg = text.trim();
@@ -1752,11 +1768,11 @@ function quietTranscriptNoticeKey(text: string): string {
 }
 
 function appendNoticeItem(items: Item[], seq: number, id: string, level: "info" | "warn", rawText: string, detail?: string, code?: string): { items: Item[]; seq: number } {
-  if (quietTranscriptNoticeKey(rawText)) {
+  if (quietTranscriptNoticeKey(rawText, code)) {
     return { items, seq };
   }
   const text = localizedNoticeText(rawText, code);
-  if (quietTranscriptNoticeKey(text)) {
+  if (quietTranscriptNoticeKey(text, code)) {
     return { items, seq };
   }
   const trimmedDetail = detail?.trim();

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -910,11 +910,18 @@ func TestGatewayRecoveryRebindsLeaseAndRemembersSessionPath(t *testing.T) {
 		UserID:       "user",
 	}
 	key := BuildSessionKey(msg.Session())
+	adapter := newFakeAdapter(PlatformWeixin, "fake-weixin")
+	sessionSink := &sessionEventSink{}
+	sessionSink.setTarget(newRenderSink(
+		context.Background(), adapter, msg.ConnectionID, msg.Domain, msg.ChatID,
+		msg.ChatType, msg.UserID, msg.MessageID, logger, nil, nil,
+	))
+	t.Cleanup(func() { sessionSink.setTarget(nil) })
 	leases := control.NewSessionLeaseKeeper()
 	if err := leases.Rebind(originalPath); err != nil {
 		t.Fatalf("bind original session lease: %v", err)
 	}
-	state := &sessionState{leases: leases, sessionPath: originalPath}
+	state := &sessionState{sink: sessionSink, leases: leases, sessionPath: originalPath}
 	gw.controllers[key] = state
 	gw.sessionOverrides[key] = sessionRuntimeOverride{sessionPath: originalPath, label: "session:original"}
 	ctrl := control.New(control.Options{
@@ -922,6 +929,7 @@ func TestGatewayRecoveryRebindsLeaseAndRemembersSessionPath(t *testing.T) {
 		SessionDir:         dir,
 		SessionPath:        originalPath,
 		Label:              "test",
+		Sink:               sessionSink,
 		OnSessionRecovered: gw.botSessionRecoveredHandler(key, msg, state),
 	})
 	state.ctrl = ctrl
@@ -972,6 +980,9 @@ func TestGatewayRecoveryRebindsLeaseAndRemembersSessionPath(t *testing.T) {
 	}
 	if len(transcripts) != 1 || transcripts[0] != recoveryPath {
 		t.Fatalf("recovery transcripts = %v, want only %q", transcripts, recoveryPath)
+	}
+	if sent := adapter.sentMessages(); len(sent) != 0 {
+		t.Fatalf("recovery maintenance leaked into IM messages: %+v", sent)
 	}
 }
 

--- a/internal/bot/render.go
+++ b/internal/bot/render.go
@@ -193,6 +193,13 @@ func (s *renderSink) Emit(e event.Event) {
 		}
 
 	case event.Notice:
+		if e.Audience == event.NoticeAudienceOperator {
+			// Persistence recovery remains available through controller logs and
+			// local operator surfaces. It is not actionable for the remote chat
+			// participant and must not interrupt their conversation (#7215).
+			s.logger.Debug("bot suppressed operator notice", "code", e.Code)
+			break
+		}
 		if e.Level == event.LevelWarn {
 			_ = s.send(OutboundMessage{
 				ConnectionID: s.connID,

--- a/internal/bot/render_test.go
+++ b/internal/bot/render_test.go
@@ -494,3 +494,32 @@ func TestRenderSinkSuppressesReasoning(t *testing.T) {
 		t.Fatalf("reasoning leaked into IM message: %q", sent[0].Text)
 	}
 }
+
+func TestRenderSinkSuppressesOperatorNoticesWithoutHidingUserWarnings(t *testing.T) {
+	adapter := newFakeAdapter(PlatformWeixin, "fake-weixin")
+	sink := newRenderSink(context.Background(), adapter, "weixin-weixin", "weixin", "chat-1", ChatDM, "user-1", "msg-1", slog.New(slog.NewTextHandler(io.Discard, nil)), nil, nil)
+
+	sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "please resend your message"})
+	for _, code := range []string{
+		event.NoticeCodeSessionRecoveryForked,
+		event.NoticeCodeSessionRecoveryAdopted,
+		event.NoticeCodeSessionRecoveryAdoptedCovered,
+		event.NoticeCodeSessionRecoveryDepthCap,
+		event.NoticeCodeSessionShutdownRecoveryForked,
+	} {
+		sink.Emit(event.Event{
+			Kind: event.Notice, Level: event.LevelWarn,
+			Audience: event.NoticeAudienceOperator,
+			Code:     code,
+			Text:     "local session maintenance",
+		})
+	}
+
+	sent := adapter.sentMessages()
+	if len(sent) != 1 {
+		t.Fatalf("sent = %+v, want only the actionable user warning", sent)
+	}
+	if sent[0].Text != "⚠️ please resend your message" {
+		t.Fatalf("sent text = %q, want the ordinary user warning", sent[0].Text)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3639,6 +3639,16 @@ const (
 
 const recoveryDepthCapNoticeText = "repeated save conflicts were detected; saved the current conflict copy in place"
 
+func sessionRecoveryNotice(code, text string) event.Event {
+	return event.Event{
+		Kind:     event.Notice,
+		Level:    event.LevelWarn,
+		Audience: event.NoticeAudienceOperator,
+		Code:     code,
+		Text:     text,
+	}
+}
+
 func (c *Controller) emitRecoveryDepthCapNotice(path string) {
 	key := filepath.Clean(strings.TrimSpace(path))
 	c.mu.Lock()
@@ -3651,7 +3661,7 @@ func (c *Controller) emitRecoveryDepthCapNotice(path string) {
 	}
 	c.recoveryDepthCapNotices[key] = true
 	c.mu.Unlock()
-	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: recoveryDepthCapNoticeText})
+	c.sink.Emit(sessionRecoveryNotice(event.NoticeCodeSessionRecoveryDepthCap, recoveryDepthCapNoticeText))
 }
 
 func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRewrite bool) (string, conflictOutcome, error) {
@@ -3667,8 +3677,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 		if c.adoptDiskSession(path) {
 			appendSnapshotConflictDiagnostic(path, mode, "adopted_newer_disk_transcript", saveErr, "", false)
 			slog.Warn("controller: snapshot conflict; adopted newer disk transcript", logAttrs...)
-			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-				Text: "session changed on disk; adopted the newer transcript"})
+			c.sink.Emit(sessionRecoveryNotice(event.NoticeCodeSessionRecoveryAdopted,
+				"session changed on disk; adopted the newer transcript"))
 			return path, conflictAdoptedDisk, nil
 		}
 	}
@@ -3706,8 +3716,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 			if c.adoptDiskSession(path) {
 				appendSnapshotConflictDiagnostic(path, mode, "recovery_not_needed_adopted_disk_transcript", saveErr, "", false)
 				slog.Warn("controller: snapshot conflict; recovery not needed, adopted disk transcript", logAttrs...)
-				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-					Text: "session changed on disk; adopted the newer transcript (local changes already covered)"})
+				c.sink.Emit(sessionRecoveryNotice(event.NoticeCodeSessionRecoveryAdoptedCovered,
+					"session changed on disk; adopted the newer transcript (local changes already covered)"))
 				return path, conflictAdoptedDisk, nil
 			}
 			// Nothing was recovered AND the disk transcript could not be
@@ -3725,8 +3735,8 @@ func (c *Controller) recoverSnapshotConflict(path string, saveErr error, forceRe
 	appendSnapshotConflictDiagnostic(path, mode, "forked_recovery_branch", saveErr, info.Path, info.Existing)
 	slog.Warn("controller: snapshot conflict; forked recovery branch",
 		append(logAttrs, "recovery", info.Path, "existing", info.Existing)...)
-	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-		Text: "session changed on disk; unsaved local transcript was saved as a conflict copy"})
+	c.sink.Emit(sessionRecoveryNotice(event.NoticeCodeSessionRecoveryForked,
+		"session changed on disk; unsaved local transcript was saved as a conflict copy"))
 	return info.Path, conflictForkedBranch, nil
 }
 
@@ -3754,8 +3764,8 @@ func (c *Controller) recoverShutdownSnapshot(path string, saveErr error) (string
 	appendSnapshotConflictDiagnostic(path, "shutdown", "forked_file_lock_recovery", saveErr, info.Path, info.Existing)
 	slog.Warn("controller: shutdown snapshot lock timed out; forked recovery branch",
 		"path", path, "recovery", info.Path, "existing", info.Existing)
-	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-		Text: "session file stayed busy during shutdown; unsaved transcript was saved as a recovery copy"})
+	c.sink.Emit(sessionRecoveryNotice(event.NoticeCodeSessionShutdownRecoveryForked,
+		"session file stayed busy during shutdown; unsaved transcript was saved as a recovery copy"))
 	return info.Path, nil
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -740,7 +740,8 @@ func TestSnapshotAdoptsNewerDiskForPureStalePrefix(t *testing.T) {
 	staleSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
 	staleSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
 	staleExec := agent.New(nil, nil, staleSess, agent.Options{}, event.Discard)
-	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test"})
+	sink := &noticeSink{}
+	stale := New(Options{Executor: staleExec, SessionDir: dir, SessionPath: path, Label: "test", Sink: sink})
 
 	currentSess := agent.NewSession("sys")
 	currentSess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
@@ -769,6 +770,10 @@ func TestSnapshotAdoptsNewerDiskForPureStalePrefix(t *testing.T) {
 	}
 	if got := len(stale.executor.Session().Snapshot()); got != 5 {
 		t.Fatalf("stale controller adopted message count = %d, want 5", got)
+	}
+	notice, ok := sink.lastNotice()
+	if !ok || notice.Code != event.NoticeCodeSessionRecoveryAdopted || notice.Audience != event.NoticeAudienceOperator {
+		t.Fatalf("adoption notice = %+v, want typed operator recovery notice", notice)
 	}
 }
 
@@ -1219,7 +1224,11 @@ func TestRecoveryBranchPersistsLaterOwnedCompactionRewrite(t *testing.T) {
 	}
 	notices := sink.notices()
 	if len(notices) == 0 {
-		t.Fatal("initial recovery emitted no user notice")
+		t.Fatal("initial recovery emitted no operator notice")
+	}
+	notice, ok := sink.lastNotice()
+	if !ok || notice.Code != event.NoticeCodeSessionRecoveryForked || notice.Audience != event.NoticeAudienceOperator {
+		t.Fatalf("fork recovery notice = %+v, want typed operator recovery notice", notice)
 	}
 	if got := notices[len(notices)-1]; strings.Contains(got, agent.BranchID(recoveryPath)) || strings.Contains(got, "recovery branch") {
 		t.Fatalf("initial recovery notice exposed internal branch detail: %q", got)
@@ -1357,11 +1366,13 @@ func TestRecoverShutdownSnapshotPersistsAndReanchorsSession(t *testing.T) {
 	current.Add(provider.Message{Role: provider.RoleAssistant, Content: "shutdown tail"})
 	exec := agent.New(nil, nil, current, agent.Options{}, event.Discard)
 	var handoff SessionRecoveryInfo
+	sink := &noticeSink{}
 	c := New(Options{
 		Executor:    exec,
 		SessionDir:  dir,
 		SessionPath: path,
 		Label:       "shutdown",
+		Sink:        sink,
 		OnSessionRecovered: func(info SessionRecoveryInfo) error {
 			handoff = info
 			return nil
@@ -1387,6 +1398,10 @@ func TestRecoverShutdownSnapshotPersistsAndReanchorsSession(t *testing.T) {
 	}
 	if got := recovered.Snapshot(); len(got) != 3 || got[2].Content != "shutdown tail" {
 		t.Fatalf("shutdown recovery transcript = %+v", got)
+	}
+	notice, ok := sink.lastNotice()
+	if !ok || notice.Code != event.NoticeCodeSessionShutdownRecoveryForked || notice.Audience != event.NoticeAudienceOperator {
+		t.Fatalf("shutdown recovery notice = %+v, want typed operator recovery notice", notice)
 	}
 }
 
@@ -1984,6 +1999,22 @@ type noticeSink struct {
 	events []event.Event
 }
 
+func TestSessionRecoveryNoticesAreOperatorScoped(t *testing.T) {
+	for _, code := range []string{
+		event.NoticeCodeSessionRecoveryForked,
+		event.NoticeCodeSessionRecoveryAdopted,
+		event.NoticeCodeSessionRecoveryAdoptedCovered,
+		event.NoticeCodeSessionRecoveryDepthCap,
+		event.NoticeCodeSessionShutdownRecoveryForked,
+	} {
+		notice := sessionRecoveryNotice(code, "maintenance")
+		if notice.Kind != event.Notice || notice.Level != event.LevelWarn ||
+			notice.Audience != event.NoticeAudienceOperator || notice.Code != code {
+			t.Fatalf("session recovery notice %q = %+v, want typed operator warning", code, notice)
+		}
+	}
+}
+
 func (s *noticeSink) Emit(e event.Event) {
 	s.mu.Lock()
 	s.events = append(s.events, e)
@@ -2000,6 +2031,17 @@ func (s *noticeSink) notices() []string {
 		}
 	}
 	return out
+}
+
+func (s *noticeSink) lastNotice() (event.Event, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := len(s.events) - 1; i >= 0; i-- {
+		if s.events[i].Kind == event.Notice {
+			return s.events[i], true
+		}
+	}
+	return event.Event{}, false
 }
 
 func TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch(t *testing.T) {
@@ -2054,6 +2096,10 @@ func TestSnapshotConflictAtRecoveryDepthCapForceSavesCurrentBranch(t *testing.T)
 	notices := sink.notices()
 	if len(notices) == 0 || !strings.Contains(notices[len(notices)-1], "saved the current conflict copy in place") {
 		t.Fatalf("notices = %v, want depth-cap notice", notices)
+	}
+	notice, ok := sink.lastNotice()
+	if !ok || notice.Code != event.NoticeCodeSessionRecoveryDepthCap || notice.Audience != event.NoticeAudienceOperator {
+		t.Fatalf("depth-cap notice = %+v, want typed operator recovery notice", notice)
 	}
 	if stale.NeedsRewriteSave() {
 		t.Fatal("rewrite baseline not re-anchored by depth-cap force save")

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -113,6 +113,18 @@ const (
 	LevelWarn
 )
 
+// NoticeAudience separates a notice's recipient from its severity. The empty
+// default preserves the existing contract: ordinary notices are eligible for
+// every frontend. Operator notices describe local runtime maintenance and must
+// not be forwarded as end-user chat messages. Local frontends and diagnostics
+// remain free to surface or quietly record them under their own policy.
+type NoticeAudience string
+
+const (
+	NoticeAudienceDefault  NoticeAudience = ""
+	NoticeAudienceOperator NoticeAudience = "operator"
+)
+
 // Profile carries the subagent model/effort resolved for this call.
 type Profile struct {
 	Model  string
@@ -304,14 +316,19 @@ const (
 // wording edits in Go no longer silently break localization. Values are
 // wire-stable: never rename or reuse one once shipped.
 const (
-	NoticeCodeFinalReadiness  = "final_readiness"
-	NoticeCodeEmptyFinal      = "empty_final"
-	NoticeCodeExecutorHandoff = "executor_handoff"
-	NoticeCodeToolBudget      = "tool_budget"
-	NoticeCodeLoopGuard       = "loop_guard"
-	NoticeCodeWorkspaceLease  = "workspace_lease"
-	NoticeCodeCancelledTurn   = "cancelled_turn_display"
-	NoticeCodeUnappliedSteer  = "unapplied_steer"
+	NoticeCodeFinalReadiness                = "final_readiness"
+	NoticeCodeEmptyFinal                    = "empty_final"
+	NoticeCodeExecutorHandoff               = "executor_handoff"
+	NoticeCodeToolBudget                    = "tool_budget"
+	NoticeCodeLoopGuard                     = "loop_guard"
+	NoticeCodeWorkspaceLease                = "workspace_lease"
+	NoticeCodeCancelledTurn                 = "cancelled_turn_display"
+	NoticeCodeUnappliedSteer                = "unapplied_steer"
+	NoticeCodeSessionRecoveryForked         = "session_recovery_forked"
+	NoticeCodeSessionRecoveryAdopted        = "session_recovery_adopted"
+	NoticeCodeSessionRecoveryAdoptedCovered = "session_recovery_adopted_covered"
+	NoticeCodeSessionRecoveryDepthCap       = "session_recovery_depth_cap"
+	NoticeCodeSessionShutdownRecoveryForked = "session_shutdown_recovery_forked"
 )
 
 type Event struct {
@@ -335,6 +352,7 @@ type Event struct {
 	SessionHit   int             // Usage: cumulative cache-hit prompt tokens this session
 	SessionMiss  int             // Usage: cumulative cache-miss prompt tokens this session
 	Level        Level           // Notice
+	Audience     NoticeAudience  // Notice: empty = ordinary frontend delivery; operator = no end-user chat forwarding
 	Approval     Approval        // ApprovalRequest
 	Ask          Ask             // AskRequest
 	Err          error           // TurnDone: non-nil on failure

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -34,6 +34,15 @@ func TestLevelConstants(t *testing.T) {
 	}
 }
 
+func TestNoticeAudienceConstants(t *testing.T) {
+	if NoticeAudienceDefault != "" {
+		t.Errorf("NoticeAudienceDefault = %q, want empty for backward-compatible delivery", NoticeAudienceDefault)
+	}
+	if NoticeAudienceOperator != "operator" {
+		t.Errorf("NoticeAudienceOperator = %q, want operator", NoticeAudienceOperator)
+	}
+}
+
 // --- FuncSink ---
 
 func TestFuncSinkEmit(t *testing.T) {


### PR DESCRIPTION
## Problem

When a CLI-hosted IM bot successfully recovers from a session snapshot conflict, the controller emits a warning such as:

```text
session changed on disk; unsaved local transcript was saved as a conflict copy
```

The IM event forwarders treated every Warn-level Notice as an end-user message, so local persistence maintenance interrupted WeChat, QQ, and Feishu conversations even though the transcript had already been preserved.

PR #7351 fixed the confirmed bot recovery ownership/cascade path, and PR #7344 improved recovery-copy hygiene. Neither changed the delivery policy reported in #7215, so a future legitimate recovery could still leak an internal warning into IM.

## Root cause

Notice severity doubled as recipient policy. Recovery notices had neither an explicit audience nor stable machine-readable identities, leaving IM forwarders with no safe distinction between:

- an actionable warning that the chat participant should see; and
- a successful local recovery outcome intended for operators and diagnostics.

A text or code-specific filter in one renderer would only hide today's wording and would leave sibling IM delivery paths exposed.

## Fix

- Add a backward-compatible `operator` notice audience. The empty/default audience preserves existing delivery for every ordinary notice.
- Give all five controller recovery outcomes stable notice codes and mark them as operator-only at their source.
- Suppress operator notices in both the CLI bot renderer and the Desktop bot event forwarder while preserving ordinary Warn notices unchanged.
- Route Desktop recovery localization and quiet-notice deduplication by stable code first, with the existing text matching retained for older persisted records.
- Extend the real CLI bot recovery handoff regression test to force an actual diverged snapshot and prove that no recovery maintenance message reaches the IM adapter.
- Add a deterministic Desktop forwarding regression proving that operator notices never enter the IM queue while an ordinary user warning still does.

This deliberately requires no new user setting: recipient policy belongs to the event producer, and the safe default for existing uncategorized warnings remains unchanged.

## Concurrency and ownership audit

| Path | Result |
| --- | --- |
| Recovery event emission | The audience and code are immutable values on the emitted event; no shared state or lock ordering changes. |
| CLI bot rendering | The renderer reads the audience before sending and does not mutate gateway/session state. |
| Desktop bot forwarding | The forwarder reads the audience before acquiring its queue lock; queue lifecycle and ordering are unchanged. |
| Recovery lease handoff | The existing #7351 lifecycle/lease handoff remains unchanged; the integration regression exercises the real handoff and subsequent snapshot. |
| Repeated/late recovery outcomes | Every current controller recovery notice uses the same typed constructor, so new wording cannot bypass IM suppression. |

## Compatibility and product cost

| Surface | Behavior | Conclusion |
| --- | --- | --- |
| Existing notices | Empty audience keeps the previous IM delivery behavior. | Backward compatible |
| Existing session/event history | No persisted schema migration; old codeless recovery records retain the text fallback. | Backward compatible |
| Desktop/remote event wire | Stable recovery codes use the existing optional notice-code field; the runtime audience does not change the wire schema. | Protocol compatible |
| CLI/desktop operator handling | Recovery still occurs, remains logged, and is available to local frontends under their existing display policy. | No loss of diagnostics |
| Bot configuration | No new option, migration, or per-channel setup. | Zero additional user cost |
| Provider/cache surface | No prompt, tool schema/order, provider request, or compaction input changes. | Cache neutral |

## Verification

- `go test ./internal/event ./internal/control ./internal/bot`
- `go test -race ./internal/event ./internal/control ./internal/bot`
- `go test ./...`
- `go vet ./...`
- `cd desktop && go test . -run 'TestBotEventForwarder' -count=1`
- `cd desktop && go test -race . -run 'TestBotEventForwarder' -count=1`
- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm build`
- focused Desktop recovery-code and quiet-notification tests
- cache-impact guard: no cache-sensitive prompt/tool files changed

The first Desktop full-suite run hit an unrelated transient `bad file descriptor` in `TestApplyLinuxVersionedActivatesWithoutPersistingGuard`. The failing updater test and implementation are unchanged by this PR; the focused test passed immediately, and a second `cd desktop && go test ./...` run passed completely.

`pnpm test` passed the modified recovery-notice tests, then reached an unrelated existing static layout assertion in `capabilities-panel-actions.test.ts`. That test and its referenced Subagents UI/style files are unchanged from the `main-v2` base.

Fixes #7215
