### PR TITLE
fix(hooks): honor Windows Reasonix home in diagnostics

### DIFF
--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -287,14 +287,10 @@ func collectCommands(root string, disp func(string) string) (AssetReport, []Issu
 
 func collectHooks(root, home, reasonixHome string, cfg *config.Config, disp func(string) string) (HookReport, []Issue) {
 	var issues []Issue
-	// Prefer explicit home for settings when tests isolate HOME.
-	homeDir := home
-	if reasonixHome != "" && home == "" {
-		homeDir = filepath.Dir(reasonixHome)
-	}
 	insp := hook.Inspect(hook.LoadOptions{
-		ProjectRoot: root,
-		HomeDir:     homeDir,
+		ProjectRoot:     root,
+		HomeDir:         home,
+		ReasonixHomeDir: reasonixHome,
 	})
 	runtimeOptions := hook.RuntimeOptions{}
 	if cfg != nil {

--- a/internal/capdiag/collect_test.go
+++ b/internal/capdiag/collect_test.go
@@ -122,6 +122,35 @@ auto_start = false
 	}
 }
 
+func TestCollectUsesExactReasonixHomeForGlobalHooks(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, "AppData", "Roaming", "reasonix")
+	write(t, filepath.Join(reasonixHome, "settings.json"), `{
+  "hooks": {
+    "SessionStart": [{"command": "echo exact-home"}]
+  }
+}`)
+
+	report := capdiag.Collect(capdiag.Options{
+		Root:            root,
+		HomeDir:         home,
+		ReasonixHomeDir: reasonixHome,
+	})
+	if report.Summary.Hooks != 1 || len(report.Hooks.Entries) != 1 {
+		t.Fatalf("hooks = %+v, summary = %+v", report.Hooks, report.Summary)
+	}
+	for _, source := range report.Hooks.Sources {
+		if source.Scope == "global" {
+			if source.Status != "ok" || source.HookCount != 1 {
+				t.Fatalf("global hook source = %+v, want exact Reasonix home settings", source)
+			}
+			return
+		}
+	}
+	t.Fatal("global hook source not reported")
+}
+
 func TestMissingConventionDirsNoWarning(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -214,7 +214,12 @@ func ContextFileUsable(path string) bool {
 // LoadOptions configure Load.
 type LoadOptions struct {
 	ProjectRoot string
-	HomeDir     string
+	// HomeDir overrides the user home used by legacy callers and tests. The
+	// canonical global hook path remains <HomeDir>/.reasonix/settings.json.
+	HomeDir string
+	// ReasonixHomeDir is the exact current Reasonix home. When set, it takes
+	// precedence over HomeDir for global settings and plugin hooks.
+	ReasonixHomeDir string
 	// Trusted is retained for source compatibility. Project hooks are enabled
 	// automatically now, so callers no longer need to set it.
 	Trusted bool
@@ -231,8 +236,9 @@ func Load(opts LoadOptions) []ResolvedHook {
 			appendResolved(&out, s, ScopeProject, p)
 		}
 	}
-	appendPluginHooks(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
-	g := GlobalSettingsPath(opts.HomeDir)
+	reasonixHomeDir := reasonixHomeForOptions(opts)
+	appendPluginHooks(&out, reasonixHomeDir, opts.ProjectRoot)
+	g := filepath.Join(reasonixHomeDir, SettingsFilename)
 	if s := readSettings(g); s != nil {
 		appendResolved(&out, s, ScopeGlobal, g)
 	} else if !pathExists(g) {
@@ -1578,6 +1584,13 @@ func reasonixHome(override string) string {
 		return filepath.Join(h, SettingsDirname)
 	}
 	return ""
+}
+
+func reasonixHomeForOptions(opts LoadOptions) string {
+	if dir := strings.TrimSpace(opts.ReasonixHomeDir); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return reasonixHome(opts.HomeDir)
 }
 
 func legacyGlobalSettingsPath(homeDir string) string {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1024,6 +1024,23 @@ func TestReasonixHomeOverridesGlobalHookPaths(t *testing.T) {
 	}
 }
 
+func TestLoadOptionsReasonixHomeDirUsesExactGlobalHookPath(t *testing.T) {
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, "AppData", "Roaming", "reasonix")
+	settingsPath := filepath.Join(reasonixHome, SettingsFilename)
+	if err := os.MkdirAll(reasonixHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"Stop":[{"command":"echo exact"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := Load(LoadOptions{HomeDir: home, ReasonixHomeDir: reasonixHome})
+	if len(hooks) != 1 || hooks[0].Command != "echo exact" || hooks[0].Source != settingsPath {
+		t.Fatalf("Load hooks = %+v, want exact Reasonix home hook", hooks)
+	}
+}
+
 func TestReasonixHomeDoesNotFallBackToLegacyWhenIsolated(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(t.TempDir(), "rx-home")

--- a/internal/hook/inspect.go
+++ b/internal/hook/inspect.go
@@ -66,10 +66,11 @@ func Inspect(opts LoadOptions) Inspection {
 		}
 	}
 
+	reasonixHomeDir := reasonixHomeForOptions(opts)
 	// Plugin hooks (enabled packages only — same as Load).
-	appendPluginInspect(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
+	appendPluginInspect(&out, reasonixHomeDir, opts.ProjectRoot)
 
-	g := GlobalSettingsPath(opts.HomeDir)
+	g := filepath.Join(reasonixHomeDir, SettingsFilename)
 	st := inspectSettingsFile(g, ScopeGlobal)
 	if st.Status == "missing" {
 		if legacy := legacyGlobalSettingsPath(opts.HomeDir); legacy != "" {


### PR DESCRIPTION
## Summary

- let hook loading and inspection accept the exact resolved Reasonix home in addition to the legacy user-home test override
- pass capability diagnostics' resolved Reasonix home through to hook inspection, so Windows reads `%APPDATA%\reasonix\settings.json`
- add hook-loader and capability-report regressions using a Windows-style AppData path

## Root cause

`capdiag.Collect` resolved the correct platform-specific Reasonix home, but `collectHooks` discarded it and passed the user profile directory to the hook loader. The hook loader then appended `.reasonix`, causing Windows diagnostics to inspect `~/.reasonix/settings.json` instead of `%APPDATA%\reasonix\settings.json`.

## User impact

`reasonix doctor capabilities` now reports and reads the same global hooks file used by the rest of Reasonix on Windows. Existing `HomeDir` test and compatibility behavior remains unchanged.

## Issues

Fixes #7411

## Verification

- `gofmt -l` on changed Go files (no output)
- `git diff --check`
- GitHub CI and CodeQL are awaiting the repository's first-time-contributor workflow approval

## Cache impact

Cache-impact: none — this only changes host-side hook path resolution and diagnostics tests.
Cache-guard: focused hook and capability diagnostics regressions cover exact Reasonix-home resolution.
Documentation-impact: none - this only corrects internal Windows hook path resolution; no user-facing documentation changes are required.
System-prompt-review: N/A
