### PR TITLE
feat(desktop): add Visual Studio opener on Windows

### DIFF
--- a/desktop/external_opener_windows.go
+++ b/desktop/external_opener_windows.go
@@ -3,10 +3,12 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -19,6 +21,7 @@ const (
 	dibRGBColors           = 0
 	drawIconNormal         = 0x0003
 	windowsOpenerIconWidth = 32
+	windowsVSWhereTimeout  = 2 * time.Second
 )
 
 type windowsShellFileInfo struct {
@@ -80,6 +83,10 @@ func firstWindowsExecutable(names []string, candidates ...string) string {
 			return path
 		}
 	}
+	return firstWindowsExistingFile(candidates...)
+}
+
+func firstWindowsExistingFile(candidates ...string) string {
 	for _, candidate := range candidates {
 		if candidate == "" {
 			continue
@@ -93,6 +100,42 @@ func firstWindowsExecutable(names []string, candidates ...string) string {
 		}
 	}
 	return ""
+}
+
+func queryWindowsVSWhere(vswherePath string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), windowsVSWhereTimeout)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, vswherePath,
+		"-latest", "-products", "*", "-property", "installationPath", "-utf8").Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func findWindowsVisualStudioExecutable(programFiles, programFilesX86 string, queryVSWhere func(string) (string, error)) string {
+	vswhere := firstWindowsExistingFile(
+		joinWindowsInstallPath(programFilesX86, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
+		joinWindowsInstallPath(programFiles, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
+	)
+	if vswhere == "" {
+		vswhere = firstWindowsExecutable([]string{"vswhere.exe"})
+	}
+	if vswhere != "" && queryVSWhere != nil {
+		if output, err := queryVSWhere(vswhere); err == nil {
+			if path := firstWindowsExistingFile(windowsVisualStudioDevenvCandidates(output)...); path != "" {
+				return path
+			}
+		}
+	}
+	if path := firstWindowsExistingFile(windowsVisualStudioFallbackCandidatePaths(programFiles, programFilesX86)...); path != "" {
+		return path
+	}
+	return firstWindowsExecutable([]string{"devenv.exe"})
+}
+
+func windowsVisualStudioExecutable(programFiles, programFilesX86 string) string {
+	return findWindowsVisualStudioExecutable(programFiles, programFilesX86, queryWindowsVSWhere)
 }
 
 // windowsAppPathExecutable resolves an install registered under
@@ -222,6 +265,14 @@ func platformExternalOpenerSpecs() []externalOpenerSpec {
 		joinWindowsInstallPath(programFilesX86, "Microsoft VS Code", "Code.exe"))
 	add("vscode-insiders", "VS Code Insiders", externalOpenerEditor, "path", []string{"Code - Insiders.exe"},
 		joinWindowsInstallPath(local, "Programs", "Microsoft VS Code Insiders", "Code - Insiders.exe"))
+	if path := windowsVisualStudioExecutable(programFiles, programFilesX86); path != "" {
+		specs = append(specs, externalOpenerSpec{
+			View:       ExternalOpenerView{ID: "visual-studio", Name: "Visual Studio", Kind: externalOpenerEditor},
+			Target:     path,
+			LaunchMode: "path",
+			IconSource: path,
+		})
+	}
 	add("cursor", "Cursor", externalOpenerEditor, "path", []string{"Cursor.exe"},
 		joinWindowsInstallPath(local, "Programs", "cursor", "Cursor.exe"),
 		joinWindowsInstallPath(programFiles, "Cursor", "Cursor.exe"))

--- a/desktop/external_opener_windows_helpers.go
+++ b/desktop/external_opener_windows_helpers.go
@@ -5,6 +5,44 @@ import (
 	"strings"
 )
 
+// windowsVisualStudioDevenvCandidates converts vswhere installationPath output
+// into ordered devenv.exe paths. vswhere -latest normally returns one line, but
+// accepting multiple non-empty lines keeps the parser resilient to wrappers and
+// makes the first valid installation win deterministically.
+func windowsVisualStudioDevenvCandidates(vswhereOutput string) []string {
+	var out []string
+	for _, line := range strings.Split(strings.ReplaceAll(vswhereOutput, "\r\n", "\n"), "\n") {
+		installPath := strings.TrimPrefix(strings.TrimSpace(line), "\ufeff")
+		installPath = strings.Trim(strings.TrimSpace(installPath), `"`)
+		if installPath == "" {
+			continue
+		}
+		out = append(out, filepath.Join(installPath, "Common7", "IDE", "devenv.exe"))
+	}
+	return out
+}
+
+// windowsVisualStudioFallbackCandidatePaths returns standard Visual Studio
+// install globs in newest-version-first order. Visual Studio 2022 (17.x) and
+// 2026 (18.x) are 64-bit applications, but the x86 root remains a compatibility
+// fallback for customized or upgraded installations.
+func windowsVisualStudioFallbackCandidatePaths(programFiles, programFilesX86 string) []string {
+	var roots []string
+	for _, root := range []string{programFiles, programFilesX86} {
+		root = strings.TrimSpace(root)
+		if root != "" {
+			roots = append(roots, root)
+		}
+	}
+	var out []string
+	for _, version := range []string{"2026", "2022"} {
+		for _, root := range roots {
+			out = append(out, filepath.Join(root, "Microsoft Visual Studio", version, "*", "Common7", "IDE", "devenv.exe"))
+		}
+	}
+	return out
+}
+
 // windowsTerminalIconCandidatePaths returns ordered icon lookup paths for
 // Windows Terminal. Store installs register only a wt.exe App Execution Alias
 // under LocalAppData\Microsoft\WindowsApps; the real WindowsTerminal.exe lives

--- a/desktop/external_opener_windows_helpers_test.go
+++ b/desktop/external_opener_windows_helpers_test.go
@@ -2,9 +2,38 @@ package main
 
 import (
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestWindowsVisualStudioDevenvCandidatesParseVSWhereOutput(t *testing.T) {
+	install := filepath.Join(`C:\Program Files`, "Microsoft Visual Studio", "2026", "Professional")
+	preview := filepath.Join(`D:\Apps`, "Microsoft Visual Studio", "2022", "Preview")
+	got := windowsVisualStudioDevenvCandidates("\ufeff\"" + install + "\"\r\n\r\n" + preview + "\n")
+	want := []string{
+		filepath.Join(install, "Common7", "IDE", "devenv.exe"),
+		filepath.Join(preview, "Common7", "IDE", "devenv.exe"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("devenv candidates = %v, want %v", got, want)
+	}
+}
+
+func TestWindowsVisualStudioFallbackCandidatesPreferNewestVersion(t *testing.T) {
+	programFiles := filepath.Join("C:", "Program Files")
+	programFilesX86 := filepath.Join("C:", "Program Files (x86)")
+	got := windowsVisualStudioFallbackCandidatePaths(programFiles, programFilesX86)
+	want := []string{
+		filepath.Join(programFiles, "Microsoft Visual Studio", "2026", "*", "Common7", "IDE", "devenv.exe"),
+		filepath.Join(programFilesX86, "Microsoft Visual Studio", "2026", "*", "Common7", "IDE", "devenv.exe"),
+		filepath.Join(programFiles, "Microsoft Visual Studio", "2022", "*", "Common7", "IDE", "devenv.exe"),
+		filepath.Join(programFilesX86, "Microsoft Visual Studio", "2022", "*", "Common7", "IDE", "devenv.exe"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback candidates = %v, want %v", got, want)
+	}
+}
 
 func TestWindowsTerminalIconCandidatePathsPreferPackageBinary(t *testing.T) {
 	// Use fixed Windows-style roots so the assertion is OS-independent; helpers

--- a/desktop/external_opener_windows_test.go
+++ b/desktop/external_opener_windows_test.go
@@ -3,11 +3,57 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestFindWindowsVisualStudioExecutablePrefersVSWhere(t *testing.T) {
+	programFiles := filepath.Join(t.TempDir(), "Program Files")
+	programFilesX86 := filepath.Join(t.TempDir(), "Program Files (x86)")
+	vswhere := filepath.Join(programFilesX86, "Microsoft Visual Studio", "Installer", "vswhere.exe")
+	install := filepath.Join(t.TempDir(), "Microsoft Visual Studio", "2026", "Professional")
+	devenv := filepath.Join(install, "Common7", "IDE", "devenv.exe")
+	for _, path := range []string{vswhere, devenv} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := findWindowsVisualStudioExecutable(programFiles, programFilesX86, func(path string) (string, error) {
+		if path != vswhere {
+			t.Fatalf("vswhere path = %q, want %q", path, vswhere)
+		}
+		return install + "\r\n", nil
+	})
+	if got != devenv {
+		t.Fatalf("Visual Studio executable = %q, want vswhere result %q", got, devenv)
+	}
+}
+
+func TestFindWindowsVisualStudioExecutableFallsBackToStandardPaths(t *testing.T) {
+	programFiles := filepath.Join(t.TempDir(), "Program Files")
+	programFilesX86 := filepath.Join(t.TempDir(), "Program Files (x86)")
+	devenv := filepath.Join(programFiles, "Microsoft Visual Studio", "2026", "Community", "Common7", "IDE", "devenv.exe")
+	if err := os.MkdirAll(filepath.Dir(devenv), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(devenv, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findWindowsVisualStudioExecutable(programFiles, programFilesX86, func(string) (string, error) {
+		return "", errors.New("vswhere unavailable")
+	})
+	if got != devenv {
+		t.Fatalf("Visual Studio executable = %q, want standard-path result %q", got, devenv)
+	}
+}
 
 func TestWindowsExternalOpenerIconUsesShellIcon(t *testing.T) {
 	explorer := filepath.Join(os.Getenv("WINDIR"), "explorer.exe")


### PR DESCRIPTION
## Summary

- detect Visual Studio on Windows with `vswhere` first, covering installed editions and current versions
- fall back to standard Visual Studio 2026 and 2022 install paths, then registered/PATH `devenv.exe`
- add Visual Studio to the desktop Open menu with the native executable icon and launch the workspace as one path argument
- add cross-platform candidate parsing tests and Windows discovery tests for both `vswhere` and fallback paths

## User impact

Windows desktop users with Visual Studio 2022 or 2026 can select Visual Studio from the top-right Open control and open the current workspace directly.

## Implementation notes

Discovery invokes `vswhere.exe` directly without a shell and bounds it to two seconds. Only existing `devenv.exe` files are accepted. Launching reuses the existing `path` mode, so workspace paths with spaces or shell metacharacters remain one process argument.

## Issues

Fixes #7250

## Verification

- `gofmt -l` on changed Go files (no output)
- `git diff --check`
- GitHub CI and CodeQL are awaiting the repository's first-time-contributor workflow approval

## Documentation impact

Documentation-impact: none - Existing documentation does not enumerate platform-specific external opener integrations; the Visual Studio option follows the existing desktop Open menu behavior.

## Cache impact

Cache-impact: none — this only changes desktop-native external opener discovery and tests.
Cache-guard: focused candidate-order and Windows discovery regressions cover `vswhere` and standard install fallbacks.
System-prompt-review: N/A
