### PR TITLE
fix(creation): 空会话 hero 标题+输入框一体居中

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4957,11 +4957,18 @@ export default function App() {
             {/* Composer stays mounted under a decision so per-session draft
                 caches (text, attachments, paste blocks, guidance) survive. */}
             <div
-              className={decisionSurface ? "composer-decision-host composer-decision-host--hidden" : "composer-decision-host"}
+              className={[
+                "composer-decision-host",
+                decisionSurface ? "composer-decision-host--hidden" : "",
+                creationEmptyHero ? "composer-decision-host--creation-hero" : "",
+              ].filter(Boolean).join(" ")}
               hidden={Boolean(decisionSurface) || undefined}
               inert={decisionSurface ? true : undefined}
               aria-hidden={decisionSurface ? true : undefined}
             >
+            {creationEmptyHero && (
+              <h2 className="welcome-creation__headline">{t("welcome.creation.title")}</h2>
+            )}
             <Composer
               running={state.running || rewindCommitting}
               collaborationMode={collaborationMode}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3399,9 +3399,11 @@ export default function App() {
   const transcriptHydrating = state.hydrating && !state.hydrateHistoryLoaded;
   // Creation hero only after history hydration settles on a truly empty session.
   // Avoid flash while switching tabs: items may be empty while placeholders show.
+  // Exclude IM/Bot detail: hero CSS collapses .main, which also hosts that panel.
   // (desktopLayoutStyle is available here; sidebarCreation is declared later.)
   const creationEmptyHero =
     desktopLayoutStyle === "creation" &&
+    !sidebarImDetailConnection &&
     !sessionHasContent &&
     !transcriptHydrating &&
     !hydratePlaceholderActive;

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -508,11 +508,12 @@ ok(
 
 ok(
   /const creationEmptyHero =/.test(appSource) &&
+    /!sidebarImDetailConnection/.test(appSource) &&
     /!transcriptHydrating/.test(appSource) &&
     /!hydratePlaceholderActive/.test(appSource) &&
     /chat-pane\$\{creationEmptyHero \? " chat-pane--creation-empty" : ""\}/.test(appSource) &&
     /heroMode=\{creationEmptyHero\}/.test(appSource),
-  "Creation empty hero waits for hydration to settle before enabling",
+  "Creation empty hero waits for hydration and skips IM/Bot detail panels",
 );
 
 ok(

--- a/desktop/frontend/src/components/Welcome.tsx
+++ b/desktop/frontend/src/components/Welcome.tsx
@@ -8,14 +8,10 @@ import { useT } from "../lib/i18n";
 export function Welcome({ onPrompt, variant = "default" }: { onPrompt: (text: string) => void; variant?: "default" | "creation" }) {
   const t = useT();
   if (variant === "creation") {
-    // Creation empty state is headline-only; the slim hero Composer sits in the
-    // former prompt-card band (App.tsx chat-pane--creation-empty + Composer hero).
+    // Headline lives above the hero Composer in App footer (same stack).
     void onPrompt;
-    return (
-      <div className="welcome welcome--creation">
-        <h2 className="welcome-creation__headline">{t("welcome.creation.title")}</h2>
-      </div>
-    );
+    void t;
+    return null;
   }
 
   const examples = [t("welcome.ex1"), t("welcome.ex2"), t("welcome.ex3"), t("welcome.ex4")];

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30180,23 +30180,61 @@ body > .mermaid-diagram--fullscreen {
   height: 12px;
 }
 
-.app--creation .footer {
+.app--creation .footer,
+:root[data-theme-style] .app--creation .footer {
   border-top: 0;
   padding: 0 clamp(22px, 5vw, 56px) clamp(22px, 4vh, 36px);
   background: transparent;
   transition: padding 0.4s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* Empty Creation: title + composer share one responsive column (no fixed lift). */
+/* Empty Creation: headline + composer share one footer stack, centered in chat. */
 .app--creation .chat-pane--creation-empty {
   --creation-hero-col: min(100%, 720px);
   --creation-hero-inline: clamp(16px, 4vw, 56px);
+  --creation-hero-stack-gap: clamp(14px, 2.2vh, 22px);
+}
+
+.app--creation .chat-pane--creation-empty > .main {
+  flex: 0 0 0;
+  height: 0;
+  min-height: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .app--creation .chat-pane--creation-empty > .footer {
-  flex: 0 0 auto;
-  padding: 0 var(--creation-hero-inline) clamp(16px, 3vh, 28px);
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  padding: 0 var(--creation-hero-inline);
   transform: none;
+  border-top: 0;
+}
+
+.app--creation .composer-decision-host--creation-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--creation-hero-stack-gap);
+  width: min(100%, var(--creation-hero-col));
+  max-width: var(--creation-hero-col);
+  margin-inline: auto;
+}
+
+.app--creation .composer-decision-host--creation-hero .welcome-creation__headline {
+  width: 100%;
+  margin: 0;
+}
+
+.app--creation .composer-decision-host--creation-hero .composer-wrap {
+  width: 100%;
+  max-width: none;
+  margin-inline: 0;
+  flex: 0 0 auto;
 }
 
 .app--creation .composer-wrap {
@@ -31174,6 +31212,11 @@ body > .mermaid-diagram--fullscreen {
     padding: 0 12px 14px;
   }
 
+  .app--creation .chat-pane--creation-empty > .footer,
+  :root[data-theme-style] .app--creation .chat-pane--creation-empty > .footer {
+    padding: var(--creation-hero-stack-gap) 12px 0;
+  }
+
   .app--creation .composer-wrap,
   :root[data-theme-style] .app--creation .composer-wrap {
     width: 100%;
@@ -31777,14 +31820,11 @@ body > .mermaid-diagram--fullscreen {
   padding: 24px 32px clamp(180px, 22vh, 260px);
 }
 
-/* Empty Creation: flex stack keeps headline + footer composer in one flow. */
-.app--creation .chat-pane--creation-empty > .main {
-  flex: 1 1 auto;
+.app--creation .chat-pane--creation-empty .transcript-shell {
+  flex: 0 0 auto;
+  height: auto;
   min-height: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  overflow: visible;
+  overflow: visible !important;
 }
 
 .app--creation .chat-pane--creation-empty .transcript-shell,
@@ -31796,10 +31836,11 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .chat-pane--creation-empty .transcript--empty {
   flex: 0 0 auto;
+  height: auto;
   justify-content: flex-end;
   align-items: center;
   min-height: 0;
-  padding: clamp(12px, 3vh, 28px) var(--creation-hero-inline) clamp(10px, 2vh, 20px);
+  padding: 0 var(--creation-hero-inline);
 }
 
 .app--creation .transcript--empty > .welcome--creation {
@@ -32699,10 +32740,6 @@ body > .mermaid-diagram--fullscreen {
 }
 
 @media (max-height: 640px) {
-  .app--creation .chat-pane--creation-empty .transcript--empty {
-    padding-top: 8px;
-    padding-bottom: 8px;
-  }
   .app--creation .welcome-creation__headline {
     font-size: clamp(calc(24px * var(--font-scale)), 3.6vw, calc(36px * var(--font-scale)));
   }


### PR DESCRIPTION
## 改动内容
- Creation 空会话：标题 + 精简输入框改为**同一 footer 栈**，整组在 chat 区垂直居中（标题在上、输入框在下）
- 去掉 Creation 下 footer 顶部分隔细线（覆盖 `data-theme-style` 的更高特异性 `border-top`）
- `Welcome` creation 变体不再渲染标题，避免与 footer 栈重复

## 范围
- 仅 `.app--creation` / `chat-pane--creation-empty` / hero host
- classic / workbench 不变

## 验证
- [x] `pnpm --dir desktop/frontend typecheck`
- [x] 本地 wails dev：空会话 hero 居中、有消息会话无顶线、无重叠

Documentation-impact: none - Creation layout/CSS only; no user-facing docs or product copy change.
