### PR TITLE
fix(desktop): stop recreating a deleted workspace folder

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -5849,13 +5849,24 @@ func loadTopicCreatedAtsForUpdate(workspaceRoot string) (map[string]int64, error
 	return loadInt64MapForUpdate(topicCreatedAtsPath(workspaceRoot))
 }
 
+// ensureTopicStateDir prepares the directory holding a topic-state file. A
+// project file lives under the workspace root, so the directory is only created
+// while that root still exists — otherwise deleting the folder outside Reasonix
+// resurrects it on the next launch (#4566).
+func ensureTopicStateDir(workspaceRoot, path string) error {
+	if root := strings.TrimSpace(workspaceRoot); root != "" && !existingDirectory(root) {
+		return fmt.Errorf("workspace root %q no longer exists", root)
+	}
+	return os.MkdirAll(filepath.Dir(path), 0o755)
+}
+
 func saveTopicTitles(workspaceRoot string, m map[string]string) error {
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
 	}
 	path := topicTitlesPath(workspaceRoot)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
 		return err
 	}
 	tmp := path + ".tmp"
@@ -5871,7 +5882,7 @@ func saveTopicTitleSources(workspaceRoot string, m map[string]string) error {
 		return err
 	}
 	path := topicTitleSourcesPath(workspaceRoot)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
 		return err
 	}
 	tmp := path + ".tmp"
@@ -5887,7 +5898,7 @@ func saveTopicCreatedAts(workspaceRoot string, m map[string]int64) error {
 		return err
 	}
 	path := topicCreatedAtsPath(workspaceRoot)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
 		return err
 	}
 	tmp := path + ".tmp"
@@ -5903,7 +5914,7 @@ func saveTopicAutoTitleMeta(workspaceRoot string, m map[string]topicAutoTitleMet
 		return err
 	}
 	path := topicAutoTitleMetaPath(workspaceRoot)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := ensureTopicStateDir(workspaceRoot, path); err != nil {
 		return err
 	}
 	tmp := path + ".tmp"

--- a/desktop/topic_state_dir_test.go
+++ b/desktop/topic_state_dir_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTopicStateWritesSkipDeletedWorkspaceRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "workspace-a")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicTitles(root, map[string]string{"topic_1": "kept"}); err != nil {
+		t.Fatalf("saveTopicTitles on a live root: %v", err)
+	}
+
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicTitles(root, map[string]string{"topic_1": "resurrected"}); err == nil {
+		t.Fatal("writing topic titles into a deleted workspace must fail instead of recreating it")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("workspace root was recreated: %v", err)
+	}
+}
+
+func TestTopicStateWritesStillCreateGlobalDir(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+
+	if err := saveTopicTitles("", map[string]string{"topic_1": "global"}); err != nil {
+		t.Fatalf("global topic titles must still be writable: %v", err)
+	}
+	if got := loadTopicTitles("")["topic_1"]; got != "global" {
+		t.Fatalf("global topic title = %q, want %q", got, "global")
+	}
+}


### PR DESCRIPTION
Delete a workspace folder in Explorer, reopen Reasonix, and the folder is back — confirmed still happening by two people after the original report.

Cause: the tab record still points at that root, and the topic-state writers (`saveTopicTitles`, `saveTopicTitleSources`, `saveTopicCreatedAts`, `saveTopicAutoTitleMeta`) each ran `os.MkdirAll(<root>/.reasonix)`. `MkdirAll` creates every missing parent, so the first title write on startup rebuilt `<root>` itself.

`ensureTopicStateDir` now refuses to create the directory when the workspace root is gone, and the writers return that error instead of resurrecting the tree. Callers already treat these writes as best-effort, so a missing project degrades to "no topic metadata" rather than a failure. Global-scope state (`<desktop config>/global/…`) keeps its old behaviour — there's no workspace root to check.

Tests: a project write into a deleted root fails and leaves the directory absent; a global write still creates its directory and round-trips.

Closes #4566