### PR TITLE
fix(boot): keep the executor when planner_model is unresolvable

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1617,11 +1617,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// Coordinator with its own session, kept separate for cache stability. The
 	// planner gets the same standing memory context and a filtered read-only
 	// research tool set, so it can inspect rules/code without side effects.
-	if pm := effectivePlannerModel(cfg, opts, tokenEconomy); pm != "" {
-		pe, ok := resolveOptionalEntry(opts, cfg, pm)
-		if !ok {
-			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
-		}
+	pm := effectivePlannerModel(cfg, opts, tokenEconomy)
+	pe, plannerResolved := resolveOptionalEntry(opts, cfg, pm)
+	if pm != "" && !plannerResolved {
+		// An unusable optional planner must not take the session down with it —
+		// the executor is what the user talks to. Degrades like the guardian
+		// model below (#4615).
+		slog.Warn("planner model is not a configured provider — planning disabled", "model", pm)
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+			Text: fmt.Sprintf("planner_model %q is not a configured provider — continuing with the executor alone", pm)})
+	}
+	if pm != "" && plannerResolved {
 		if pe.Model != entry.Model {
 			plannerProv, err := resolveProvider(opts, cfg, proxySpec, provider.Selection{Ref: modelRefFromEntry(pe)})
 			if err != nil {

--- a/internal/boot/planner_missing_test.go
+++ b/internal/boot/planner_missing_test.go
@@ -1,0 +1,55 @@
+package boot
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+)
+
+func TestBuildKeepsExecutorWhenPlannerModelIsUnresolvable(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	setBootTokenProfileTestProvider(t, testutil.NewMock("planner-missing"))
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "executor"
+
+[agent]
+planner_model = "OpenRouter/moonshotai/kimi-k2.6:free"
+
+[[providers]]
+name = "executor"
+kind = "boot-token-profile-test"
+model = "executor-model"
+`)
+
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	ctrl, err := Build(context.Background(), Options{Sink: sink})
+	if err != nil {
+		t.Fatalf("an unusable optional planner must not block startup: %v", err)
+	}
+	if ctrl == nil {
+		t.Fatal("Build returned no controller")
+	}
+
+	var warned bool
+	for _, n := range notices {
+		if strings.Contains(n, "planner_model") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("the dropped planner must be announced, got notices %v", notices)
+	}
+}


### PR DESCRIPTION
#4615: after a forced shutdown the desktop restarts into `planner_model "OpenRouter/…" is not a configured provider` and there's no usable chat surface at all — the executor was fine, but boot failed before it could be used.

`planner_model` is optional. The guardian model one screen below already degrades on the same condition (`slog.Warn("guardian model is not a configured provider — guardian disabled")`); the planner hard-failed instead. It now warns, emits a user-visible notice, and continues with the executor alone.

Deliberately unchanged: a planner that *resolves* but whose provider can't be constructed still fails loudly — that's a live misconfiguration worth surfacing, not stale state.

Credit to @GTC2080, who diagnosed this in #4615 and proposed a fix in #4616 (closed unmerged during the PE-handoff consolidation). This takes the narrower route — degrade rather than broaden ref matching — so the failure mode is gone regardless of why the ref stopped resolving.

Test: a config whose `planner_model` names an unknown provider builds successfully and announces the dropped planner.

Closes #4615
