### PR TITLE
fix(permission): treat destructive git commands as destructive

### DIFF
--- a/internal/permission/bash_destructive_git_test.go
+++ b/internal/permission/bash_destructive_git_test.go
@@ -1,0 +1,58 @@
+package permission
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func bashArgs(t *testing.T, command string) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(map[string]string{"command": command})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestGitTagIsReadOnlyOnlyWhenListing(t *testing.T) {
+	readOnly := []string{"git tag", "git tag -l", "git tag --list", "git tag -l 'v1.*'", "git tag --sort=-creatordate"}
+	for _, cmd := range readOnly {
+		if !BashCommandIsReadOnly(bashArgs(t, cmd)) {
+			t.Errorf("%q only lists tags and should stay read-only", cmd)
+		}
+	}
+	writes := []string{"git tag v1.2.3", "git tag -d v1.2.3", "git tag -a v1.2.3 -m release", "git tag --delete v1.2.3"}
+	for _, cmd := range writes {
+		if BashCommandIsReadOnly(bashArgs(t, cmd)) {
+			t.Errorf("%q writes the ref namespace and must not count as read-only", cmd)
+		}
+	}
+}
+
+func TestDestructiveGitCommandsAreWarned(t *testing.T) {
+	for _, cmd := range []string{
+		"git restore src/main.go",
+		"git restore --staged .",
+		"git checkout -- src/main.go",
+		"git stash drop",
+		"git stash clear",
+	} {
+		if BashDangerWarning(cmd) == "" {
+			t.Errorf("%q can destroy uncommitted work and should carry a warning", cmd)
+		}
+	}
+	for _, cmd := range []string{"git status", "git checkout -b feature", "git stash list"} {
+		if w := BashDangerWarning(cmd); w != "" {
+			t.Errorf("%q is not destructive but was labelled %q", cmd, w)
+		}
+	}
+}
+
+func TestDestructiveGitCommandsGetNoPrefixGrant(t *testing.T) {
+	if got := BashCommandPrefix("git restore src/main.go"); got != "" {
+		t.Errorf("a session grant for git restore must stay exact, got prefix %q", got)
+	}
+	if got := BashCommandPrefix("git status --short"); got == "" {
+		t.Error("ordinary read-only git commands should still earn a prefix grant")
+	}
+}

--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -78,6 +78,9 @@ func hasUnsafePrefixArgs(base, subcmd string, args []string) bool {
 		switch subcmd {
 		case "diff", "show", "log":
 			return hasAnyArg(args, "--output") || hasArgWithPrefix(args, "--output=")
+		case "tag":
+			// Bare `git tag` lists; with a name it creates one, and -d deletes.
+			return !gitTagIsListing(args)
 		}
 	case "go":
 		if subcmd == "env" {
@@ -85,6 +88,33 @@ func hasUnsafePrefixArgs(base, subcmd string, args []string) bool {
 		}
 	}
 	return false
+}
+
+// gitTagIsListing reports whether a `git tag` invocation only lists tags. A
+// bare `git tag` lists; a name creates one and -d deletes, so anything that
+// isn't an explicit listing form writes the ref namespace.
+func gitTagIsListing(args []string) bool {
+	listing := false
+	var operands []string
+	for _, arg := range args {
+		switch {
+		case arg == "-l" || arg == "--list":
+			listing = true
+		case arg == "-d" || arg == "--delete" || arg == "-a" || arg == "-s" || arg == "-f" || arg == "--force" || arg == "-m" || arg == "-F":
+			return false
+		case strings.HasPrefix(arg, "-"):
+			// Remaining flags (-n, --sort=, --format=, --contains, …) are output
+			// shaping; unknown ones fail closed below only when paired with an
+			// operand, which is the create/delete form.
+			continue
+		default:
+			operands = append(operands, arg)
+		}
+	}
+	if listing {
+		return true // operands are shell patterns for the listing filter
+	}
+	return len(operands) == 0
 }
 
 func hasArgWithPrefix(args []string, prefix string) bool {
@@ -121,6 +151,11 @@ var dangerousBashPatterns = []struct {
 	{"git push*-f*", "force push"},
 	{"git reset --hard*", "hard reset"},
 	{"git clean -f*", "force clean"},
+	{"git restore*", "discards uncommitted changes"},
+	{"git checkout -- *", "discards uncommitted changes"},
+	{"git checkout .*", "discards uncommitted changes"},
+	{"git stash drop*", "drops stashed changes"},
+	{"git stash clear*", "drops stashed changes"},
 	{"chmod 777*", "world-writable"},
 	{"chmod -R 777*", "world-writable recursive"},
 	{"chown *", "ownership change"},


### PR DESCRIPTION
From #4629, where an agent ran `git restore` and destroyed unstaged work. Chasing that turned up two real gaps in command classification.

**1. `git tag` was read-only regardless of arguments.** `ReadOnlyPrefixes` lists `tag` as a read-only git subcommand, and the only per-argument check for git covered `diff`/`show`/`log --output`. So `git tag -d v1.2.3` (deletes a tag) and `git tag v1.2.3` (creates one) passed `BashCommandIsReadOnly` — the boundary plan mode and capability-restricted runners use. Now only listing forms qualify: bare `git tag`, `-l`/`--list` (with patterns), and output-shaping flags; anything with an operand or a create/delete flag is a write.

**2. Destructive-but-legitimate git commands carried no danger label.** `git restore`, `git checkout -- <path>`, `git stash drop`/`clear` can discard uncommitted work, and `dangerousBashPatterns` didn't cover them. Two consequences, both now fixed:
- the approval card shows no warning for a command that is about to delete your changes;
- `BashCommandPrefix` returns "" for dangerous commands, so **approving one `git restore` for the session no longer grants `git restore:*`** — each one asks again, which is the behaviour people expect from a destructive command.

Deliberately not done: adding these to a **default deny list**, as #4629 suggested. `git checkout`/`restore` are ordinary work in a coding agent, and a shipped deny would break normal use for everyone; a per-user `[permissions] deny` (which that reporter is already using) is the right place for a personal policy. What was actually missing was that these commands didn't *look* dangerous to the machinery — that part is fixed here.

Tests cover both directions: listing forms of `git tag` stay read-only while create/delete don't; destructive commands warn while `git status` / `git checkout -b` / `git stash list` don't; and destructive commands get no prefix grant while read-only ones still do.

Refs #4629
