### PR TITLE
fix(cli): resolve global hooks from platform Reasonix home in hook machine

### DIFF
--- a/internal/cli/hook_machine.go
+++ b/internal/cli/hook_machine.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"reasonix/internal/config"
 	"reasonix/internal/hook"
 )
 
@@ -67,9 +66,12 @@ func runHookCommand(args []string, out io.Writer) int {
 	if options.projectRoot == "" {
 		options.projectRoot, _ = os.Getwd()
 	}
-	if options.homeDir == "" {
-		options.homeDir = config.ReasonixHomeDir()
-	}
+	// hook.Inspect's HomeDir is an OS user home directory: a non-empty value
+	// has .reasonix appended inside the hook package, and passing
+	// config.ReasonixHomeDir() here double-appends it. Leave it empty so the
+	// hook package resolves the platform Reasonix home itself (correct on
+	// every OS, including Windows where the home is %AppData%\Roaming\reasonix
+	// rather than ~/.reasonix) (#7420).
 	inspection := hook.Inspect(hook.LoadOptions{
 		ProjectRoot: options.projectRoot,
 		HomeDir:     options.homeDir,

--- a/internal/cli/hook_machine_test.go
+++ b/internal/cli/hook_machine_test.go
@@ -140,3 +140,35 @@ func TestHookMachineStatusHasStableRedactedSources(t *testing.T) {
 		t.Fatalf("sources are not stable: %+v", response.Sources)
 	}
 }
+
+// TestHookMachineListFindsGlobalHooksWithoutHomeDir: with no --home-dir, the
+// hook machine resolves global hooks from the platform Reasonix home
+// (config.ReasonixHomeDir → settings.json), not a doubled .reasonix segment
+// (#7420). REASONIX_HOME is set explicitly so the resolved path is
+// deterministic regardless of the OS user-config lookup.
+func TestHookMachineListFindsGlobalHooksWithoutHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	settingsPath := filepath.Join(home, "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"Stop":[{"command":"PRIVATE_GLOBAL"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if code := runHookCommand([]string{"list", "--json", "--project-root", t.TempDir()}, &out); code != 0 {
+		t.Fatalf("hook list exit code = %d, output = %s", code, out.String())
+	}
+	var response machineHookList
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatalf("decode hook list: %v", err)
+	}
+	for _, h := range response.Hooks {
+		if h.Event == "Stop" && h.Status == "active" {
+			return
+		}
+	}
+	t.Fatalf("global Stop hook not found active: %+v", response.Hooks)
+}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -562,6 +562,59 @@ func TestLoadIncludesPluginSessionStartHook(t *testing.T) {
 	}
 }
 
+// TestInspectNoHomeDirResolvesPluginRootFromPlatformHome: with HomeDir empty
+// (the hook-machine default after #7420) and an isolated REASONIX_HOME, the
+// plugin probe and global settings resolve from the platform Reasonix home —
+// <home>/plugins and <home>/settings.json — not a doubled .reasonix segment.
+func TestInspectNoHomeDirResolvesPluginRootFromPlatformHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	root := filepath.Join(home, "plugins", "superpowers")
+	// Global settings live directly under the platform Reasonix home
+	// (writeSettings would add .reasonix, the OS-home convention #7420 fixes).
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "settings.json"), []byte(`{"hooks":{"PostToolUse":[{"command":"echo global"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeHookTestFile(t, filepath.Join(root, pluginpkg.CodexManifest), `{
+  "name": "superpowers",
+  "version": "6.1.0",
+  "skills": "./skills/"
+}`)
+	writeHookTestFile(t, filepath.Join(root, "hooks", "session-start-codex"), "#!/usr/bin/env bash\necho ok\n")
+	if err := pluginpkg.Upsert(home, pluginpkg.InstalledPlugin{
+		Name:         "superpowers",
+		Root:         "plugins/superpowers",
+		Version:      "6.1.0",
+		ManifestKind: "codex",
+		Enabled:      true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	insp := Inspect(LoadOptions{ProjectRoot: "/workspace"})
+	// Inspect reports project + plugin + global sources; assertions focus on
+	// the two that #7420 broke: plugin and global must resolve from the
+	// platform Reasonix home, not a doubled .reasonix segment.
+	var pluginOK, globalOK bool
+	for _, s := range insp.Sources {
+		switch s.Scope {
+		case ScopePlugin:
+			pluginOK = s.Status == "ok" && strings.Contains(s.Path, filepath.Join(home, "plugins"))
+		case ScopeGlobal:
+			globalOK = s.Status == "ok" && strings.Contains(s.Path, filepath.Join(home, "settings.json"))
+		}
+	}
+	if !pluginOK {
+		t.Fatalf("plugin source not resolved from platform home: %+v", insp.Sources)
+	}
+	if !globalOK {
+		t.Fatalf("global source not resolved from platform home: %+v", insp.Sources)
+	}
+}
+
 func TestLoadIncludesPluginClaudeCompatibilityHooks(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(home, ".reasonix")


### PR DESCRIPTION
## Problem

`reasonix hook status --json` / `reasonix hook list --json` report global hooks as missing even when they are configured (reported in #7420; same class of bug as #7411).

Root cause: `runHookCommand` defaulted `options.homeDir` to `config.ReasonixHomeDir()` when no `--home-dir` was given, then passed it as `hook.LoadOptions.HomeDir`. The hook package treats `HomeDir` as an **OS user home** and appends `.reasonix` inside (`reasonixHome` → `filepath.Join(override, SettingsDirname)`). The double append resolved global hooks from `<Reasonix home>/.reasonix/settings.json` instead of the real `<Reasonix home>/settings.json`:

- **Every OS**: `<home>/.reasonix/.reasonix/settings.json` — global hooks always reported missing.
- **Windows additionally**: even a single append is wrong, because the platform Reasonix home is `%AppData%\Roaming\reasonix`, not `~/.reasonix`.

Runtime hook execution (`hook.Load` in `boot.go`) and `doctor` resolve the same paths correctly (empty `HomeDir` → the hook package's own `config.ReasonixHomeDir()`), which is exactly why only `hook status|list --json` was affected.

## Fix

Remove the defaulting entirely: pass `options.homeDir` straight through, leaving it empty when `--home-dir` is absent. The hook package then resolves the platform Reasonix home itself (`reasonixHome("")` → `config.ReasonixHomeDir()`), which is correct on every OS. The explicit `--home-dir` override path is unchanged (still a real OS home with `.reasonix` appended inside the hook package).

## Related behavior change (intentional)

A non-empty wrong `HomeDir` also steered the **plugin-hook probe** (`appendPluginInspect`) to `<Reasonix home>/.reasonix/plugins`. With the fix it probes the correct location `<Reasonix home>/plugins` (matching `pluginpkg.PluginsDir`, `pluginpkg.go:237`) — the same location the runtime `boot.go` load already used. Consequence: plugin hooks that were previously placed under a wrong `.reasonix/plugins` path stop being listed; plugins installed via the normal install flow (state file + `<home>/plugins/<name>`) are unaffected and are now reported correctly.

## Tests

- `internal/cli/hook_machine_test.go` — `TestHookMachineListFindsGlobalHooksWithoutHomeDir`: sets `REASONIX_HOME`, seeds `<REASONIX_HOME>/settings.json` with a global Stop hook, runs `hook list --json` without `--home-dir`, asserts the hook is reported `active`.
- `internal/hook/hook_test.go` — `TestInspectNoHomeDirResolvesPluginRootFromPlatformHome`: with `REASONIX_HOME` isolated and `HomeDir` empty, `Inspect` reports the plugin source from `<home>/plugins/...` and the global source from `<home>/settings.json`.
- Existing explicit-`--home-dir` tests (`TestHookMachineListRedactsCommandsAndEnablesProjectHooks`, plugin-hook load tests) still pass unchanged.

## Verification

- `go test ./internal/hook/ ./internal/cli/` — pass
- `gofmt -l internal/hook/ internal/cli/` clean, `go vet ./internal/hook/ ./internal/cli/` clean

Cache-impact: none — `internal/cli` and `internal/hook` are not on the cache-sensitive path list; no provider-visible system prompt, tool schema, memory prefix, or request serialization changes.
Cache-guard: existing hook + CLI suites pass unchanged, plus the two new regression tests.
Documentation-impact: none - no docs/*.md change; hook status/list JSON output shape is unchanged, and the corrected global-hook path matches the already-documented platform Reasonix home convention (docs/GUIDE.md covers hooks via settings.json location).
