### PR TITLE
fix(config): migrate global hooks to the new home

### DIFF
--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -634,7 +634,9 @@ func writeCredentialsEnv(home string, lines []string) error {
 
 func migrateSupportData(legacyDir, newDir string) []string {
 	var warnings []string
-	items := []string{"sessions", "projects", "skills", "archive", "hooks.json"}
+	// settings.json carries the global hooks; leaving it out silently emptied
+	// them for anyone whose home moved (#4652).
+	items := []string{"sessions", "projects", "skills", "archive", "hooks.json", "settings.json"}
 	for _, item := range items {
 		src := filepath.Join(legacyDir, item)
 		fi, err := os.Stat(src)
@@ -653,6 +655,12 @@ func migrateSupportData(legacyDir, newDir string) []string {
 				warnings = append(warnings, fmt.Sprintf("successfully migrated directory %s", item))
 			}
 		} else {
+			if _, err := os.Stat(dst); err == nil {
+				// A file already written at the destination is newer than the
+				// legacy copy; never overwrite user state during migration.
+				warnings = append(warnings, fmt.Sprintf("kept existing file %s", item))
+				continue
+			}
 			if err := copyFile(src, dst); err != nil {
 				warnings = append(warnings, fmt.Sprintf("failed to migrate file %s: %v", item, err))
 			} else {

--- a/internal/config/migrate_hooks_test.go
+++ b/internal/config/migrate_hooks_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMigrateSupportDataCarriesGlobalHooks(t *testing.T) {
+	legacy := t.TempDir()
+	fresh := t.TempDir()
+	hooks := `{"hooks":{"Stop":[{"command":"echo done"}]}}`
+	if err := os.WriteFile(filepath.Join(legacy, "settings.json"), []byte(hooks), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateSupportData(legacy, fresh)
+
+	got, err := os.ReadFile(filepath.Join(fresh, "settings.json"))
+	if err != nil {
+		t.Fatalf("global hooks were not migrated: %v", err)
+	}
+	if string(got) != hooks {
+		t.Fatalf("migrated hooks = %q, want %q", got, hooks)
+	}
+}
+
+func TestMigrateSupportDataKeepsExistingFiles(t *testing.T) {
+	legacy := t.TempDir()
+	fresh := t.TempDir()
+	if err := os.WriteFile(filepath.Join(legacy, "settings.json"), []byte(`{"hooks":{"Stop":[]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	current := `{"hooks":{"Stop":[{"command":"current"}]}}`
+	if err := os.WriteFile(filepath.Join(fresh, "settings.json"), []byte(current), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := migrateSupportData(legacy, fresh)
+
+	got, err := os.ReadFile(filepath.Join(fresh, "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != current {
+		t.Fatalf("migration overwrote live settings: got %q, want %q", got, current)
+	}
+	var reported bool
+	for _, w := range warnings {
+		if strings.Contains(w, "kept existing file settings.json") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Fatalf("skipping an existing file should be reported, got %v", warnings)
+	}
+}


### PR DESCRIPTION
From #4652: global hooks disappear after upgrading.

The legacy-path migration copies `sessions`, `projects`, `skills`, `archive` and `hooks.json`. Global hooks live in **`settings.json`** (`<Reasonix home>/settings.json`), which wasn't on that list — so when the home moved to the unified location, everything else came along and the hooks were left behind in a directory nothing reads anymore.

- Adds `settings.json` to the migrated items.
- File items now **skip** rather than overwrite when the destination already has that file, and report `kept existing file <name>`. Migration is one-shot and only runs when the new location has no config, but a user's live hooks are not something to clobber on the strength of that assumption.

Tests: legacy `settings.json` lands at the new home with its contents intact; an existing destination file survives and the skip is reported.

Closes #4652
