### PR TITLE
fix(deps): resolve npm security advisories / 修复 npm 依赖安全告警

### DIFF
--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   mdast-util-gfm-autolink-literal: 2.0.0
+  undici: 7.29.0
 
 importers:
 
@@ -1932,8 +1933,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -3373,7 +3374,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4177,7 +4178,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/desktop/frontend/pnpm-workspace.yaml
+++ b/desktop/frontend/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ allowBuilds:
 
 overrides:
   mdast-util-gfm-autolink-literal: 2.0.0
+  undici: 7.29.0

--- a/workers/accounts/package.json
+++ b/workers/accounts/package.json
@@ -10,7 +10,7 @@
     "db:apply:remote": "wrangler d1 migrations apply reasonix-accounts --remote"
   },
   "dependencies": {
-    "hono": "^4.6.14",
+    "hono": "^4.12.34",
     "zod": "^3.25.0"
   },
   "devDependencies": {
@@ -20,5 +20,10 @@
   },
   "overrides": {
     "esbuild": "0.28.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "undici": "7.29.0"
+    }
   }
 }

--- a/workers/accounts/pnpm-lock.yaml
+++ b/workers/accounts/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: 7.29.0
+
 importers:
 
   .:
     dependencies:
       hono:
-        specifier: ^4.6.14
-        version: 4.12.27
+        specifier: ^4.12.34
+        version: 4.13.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -448,8 +451,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   kleur@4.1.5:
@@ -488,8 +491,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -816,7 +819,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  hono@4.12.27: {}
+  hono@4.13.0: {}
 
   kleur@4.1.5: {}
 
@@ -824,7 +827,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260722.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -877,7 +880,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/workers/crash-report/package-lock.json
+++ b/workers/crash-report/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "reasonix-crash-report",
       "dependencies": {
-        "hono": "^4.6.14",
+        "hono": "^4.12.34",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2047,9 +2047,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2067,7 +2067,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/workers/crash-report/package.json
+++ b/workers/crash-report/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "hono": "^4.6.14",
+    "hono": "^4.12.34",
     "zod": "^3.25.0"
   },
   "devDependencies": {
@@ -19,6 +19,8 @@
     "wrangler": "^4.114.0"
   },
   "overrides": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "postcss": "8.5.23",
+    "undici": "7.29.0"
   }
 }

--- a/workers/forum/package.json
+++ b/workers/forum/package.json
@@ -10,7 +10,7 @@
     "db:apply:remote": "wrangler d1 execute reasonix-forum --remote --file=schema.sql"
   },
   "dependencies": {
-    "hono": "^4.6.14",
+    "hono": "^4.12.34",
     "zod": "^3.25.0"
   },
   "devDependencies": {
@@ -20,5 +20,10 @@
   },
   "overrides": {
     "esbuild": "0.28.1"
+  },
+  "pnpm": {
+    "overrides": {
+      "undici": "7.29.0"
+    }
   }
 }

--- a/workers/forum/pnpm-lock.yaml
+++ b/workers/forum/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: 7.29.0
+
 importers:
 
   .:
     dependencies:
       hono:
-        specifier: ^4.6.14
-        version: 4.12.27
+        specifier: ^4.12.34
+        version: 4.13.0
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -448,8 +451,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   kleur@4.1.5:
@@ -488,8 +491,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -816,7 +819,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  hono@4.12.27: {}
+  hono@4.13.0: {}
 
   kleur@4.1.5: {}
 
@@ -824,7 +827,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260722.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -877,7 +880,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary

- Resolve all 24 open Dependabot alerts across the desktop frontend and three Worker dependency trees.
- Raise the Hono security floor to `^4.12.34` and regenerate the affected lockfiles, resolving to Hono 4.13.0.
- Override transitive Undici pins with the patched 7.29.0 release and pin crash-report PostCSS to 8.5.23.
- Keep the overrides package-manager-native: `pnpm-workspace.yaml` / `pnpm.overrides` for pnpm projects and npm `overrides` for crash-report.

## Issues

Refs #7409

This consolidates the forum-only Hono bump with the remaining Hono, Undici, and PostCSS alerts across all affected manifests.

## Verification

- `pnpm audit` in `desktop/frontend`, `workers/accounts`, and `workers/forum`: no known vulnerabilities
- `npm audit` in `workers/crash-report`: 0 vulnerabilities
- `pnpm run typecheck` in `workers/accounts` and `workers/forum`
- `npm run typecheck` and `npm test` in `workers/crash-report`: 83 tests passed
- `pnpm run build` in `desktop/frontend`: production build and bundle budgets passed
- Wrangler dry-run deploys for accounts, forum, and crash-report Workers

## Documentation impact

Documentation-impact: none - dependency-only security maintenance does not change user-visible behavior or embedded documentation.

## Cache impact

Cache-impact: none - no provider-visible prompt, tool schema, serialization, or runtime request construction changed.
Cache-guard: N/A - dependency lockfile-only scope outside prompt-cache paths.
System-prompt-review: N/A