### PR TITLE
fix(tui): show the whole command on a long approval

### DIFF
--- a/internal/cli/approval_subject_test.go
+++ b/internal/cli/approval_subject_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApprovalSubjectBodyShowsClippedCommandInFull(t *testing.T) {
+	full := "bash -lc 'cd /very/long/path/to/project && go test ./... -run TestSomethingWithAVeryLongName -count=1 -race'"
+	preview := truncateSubject(full, 80)
+	if preview == full {
+		t.Fatal("fixture must be long enough to clip at this width")
+	}
+
+	body := approvalSubjectBody(full, preview, 80)
+	if body == "" {
+		t.Fatal("a clipped command must be expanded below the banner")
+	}
+	flattened := strings.ReplaceAll(body, "\n", "")
+	if !strings.Contains(flattened, "-race") {
+		t.Errorf("the tail of the command must survive wrapping, got %q", body)
+	}
+}
+
+func TestApprovalSubjectBodyStaysEmptyForShortCommands(t *testing.T) {
+	full := "git status"
+	if body := approvalSubjectBody(full, full, 80); body != "" {
+		t.Errorf("a command the banner already shows must not be repeated, got %q", body)
+	}
+}
+
+func TestApprovalSubjectBodyIsBounded(t *testing.T) {
+	full := strings.Repeat("echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && ", 200)
+	body := approvalSubjectBody(full, truncateSubject(full, 60), 60)
+	lines := strings.Split(body, "\n")
+	if len(lines) > maxApprovalSubjectLines {
+		t.Fatalf("expanded command must stay bounded, got %d lines", len(lines))
+	}
+	if !strings.HasSuffix(lines[len(lines)-1], "…") {
+		t.Errorf("a command longer than the bound must end with an ellipsis, got %q", lines[len(lines)-1])
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3178,10 +3178,16 @@ func (m chatTUI) renderApprovalBanner() string {
 	} else {
 		name, detail := approvalToolDetails(m.pendingApproval.Tool)
 		subj := strings.TrimSpace(m.pendingApproval.Subject)
+		full := subj
 		if subj != "" {
 			subj = " " + truncateSubject(subj, w)
 		}
 		text = strings.TrimSpace(fmt.Sprintf(i18n.M.ToolApprovalPromptFmt, name, subj, detail, ""))
+		// A command clipped to one line can hide the part that matters — the
+		// path being written, the flag that makes it destructive (#4682).
+		if body := approvalSubjectBody(full, strings.TrimSpace(subj), w); body != "" {
+			planDetails = append(planDetails, body)
+		}
 	}
 	if reason := strings.TrimSpace(m.pendingApproval.Reason); reason != "" {
 		text += " · " + truncateSubject(reason, w)
@@ -3196,6 +3202,30 @@ func (m chatTUI) renderApprovalBanner() string {
 	}
 	b.WriteString(dim("↑/↓ navigate · Enter select · y/a/p/n shortcuts"))
 	return choicePanelStyle.Width(w).Render(b.String())
+}
+
+// maxApprovalSubjectLines bounds the expanded command so a heredoc cannot push
+// the composer off screen.
+const maxApprovalSubjectLines = 8
+
+// approvalSubjectBody returns the full command wrapped over several lines when
+// the banner's one-line preview had to clip it, or "" when the preview already
+// showed everything.
+func approvalSubjectBody(full, preview string, width int) string {
+	full = strings.TrimSpace(full)
+	if full == "" || full == preview {
+		return ""
+	}
+	wrapWidth := width - 4
+	if wrapWidth < 20 {
+		wrapWidth = 20
+	}
+	lines := strings.Split(wrapStatusLine(full, wrapWidth), "\n")
+	if len(lines) > maxApprovalSubjectLines {
+		lines = lines[:maxApprovalSubjectLines]
+		lines[maxApprovalSubjectLines-1] = ansi.Truncate(lines[maxApprovalSubjectLines-1], wrapWidth-1, "") + "…"
+	}
+	return strings.Join(lines, "\n")
 }
 
 func compactApprovalPlan(plan string) string {


### PR DESCRIPTION
From #4682: a long command awaiting approval can't be read in full in the TUI.

`renderApprovalBanner` ran the subject through `truncateSubject`, which clips to a single line with an ellipsis. For an approval prompt that's the wrong trade: the clipped tail is often exactly what decides the answer — which path is being written, whether there's a `--force`, what the redirect targets.

The desktop already wraps this text (`.approval-subject` is `pre-wrap` with a scroll cap); the TUI didn't.

- When the one-line preview had to clip, the full command is now wrapped below the banner alongside the existing plan-detail lines.
- Bounded at 8 lines with a trailing ellipsis, so a heredoc or a 200-command chain can't push the composer off screen.
- Short commands are unchanged — nothing is repeated when the preview already showed everything.

Tests: a clipped command's tail survives wrapping; a short command produces no extra body; a very long command stays within the bound and ends with an ellipsis.

Closes #4682
