### PR TITLE
Keep the release-notes JSON budget / 保证发布说明 JSON 输出预算

### DIFF
--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -118,6 +118,10 @@ async function askDeepSeek(payload, retry = true) {
     headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
     body: JSON.stringify({
       model,
+      // Release notes need deterministic structured output, not hidden chain of
+      // thought. Thinking tokens share the generation budget with content and
+      // can otherwise leave response_format JSON empty or truncated.
+      thinking: { type: "disabled" },
       temperature: 0,
       max_tokens: 8000,
       response_format: { type: "json_object" },
@@ -144,10 +148,13 @@ Return guides only for supplied documentation URLs. Mention upgrade action or ri
   });
   if (!response.ok) throw new Error(`DeepSeek API failed: ${response.status} ${await response.text()}`);
   const data = await response.json();
+  const choice = data.choices?.[0];
   try {
-    return extractJson(data.choices?.[0]?.message?.content);
+    return extractJson(choice?.message?.content);
   } catch (error) {
-    if (!retry) throw error;
+    if (!retry) {
+      throw new Error(`${error.message} (finish_reason=${choice?.finish_reason || "unknown"})`);
+    }
     return askDeepSeek(payload, false);
   }
 }

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1131,6 +1131,7 @@ expect_invalid_desktop_manifest "a non-official asset base" preview "$desktop_pr
 # Release notes use one deterministic branch per official version. Failure to
 # open the PR must preserve that branch and print an exact manual handoff.
 prepare_notes="$repo_root/.github/workflows/prepare-release-notes.yml"
+generate_notes="$repo_root/scripts/generate-release-notes.mjs"
 if grep -Eq '^      (target_pr|from_tag):$' "$prepare_notes"; then
 	echo "Prepare release must expose only the official version input" >&2
 	exit 1
@@ -1139,6 +1140,7 @@ grep -Fq 'branch="release-notes/v${VERSION}"' "$prepare_notes"
 grep -Fq 'GitHub Actions could not open the PR; the reviewed branch is preserved.' "$prepare_notes"
 grep -Fq 'gh pr create --repo ${{ github.repository }} --base main-v2 --head $RELEASE_NOTES_BRANCH --fill' "$prepare_notes"
 grep -Eq 'GITHUB_STEP_SUMMARY' "$prepare_notes"
+grep -Fq 'thinking: { type: "disabled" }' "$generate_notes"
 
 desktop_candidate_resolver="$repo_root/scripts/resolve-desktop-candidate.sh"
 test -x "$desktop_candidate_resolver"


### PR DESCRIPTION
## Summary

- disable DeepSeek thinking for deterministic release-note JSON generation
- keep the full 8K generation budget available for the structured response
- report the final API finish reason when both responses are invalid
- lock the non-thinking request contract into the release workflow tests

## Release blocker

Prepare release for v1.19.6 failed twice. The first run returned empty content and the second ended with truncated JSON after hidden reasoning consumed the shared generation budget.

## Verification

- node --check scripts/generate-release-notes.mjs
- bash scripts/release-workflows.test.sh
- git diff --check

## Compatibility and concurrency

This changes only the release-note editor request. Runtime code, persisted data, public protocol, provider-visible product prompts, publishing concurrency, and release tag semantics are unchanged.

Documentation-impact: none - this is an internal release automation reliability fix; the documented release procedure and user-facing product behavior remain unchanged.