### PR TITLE
feat(glob): bound the recursive walk with a timeout

### DIFF
--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -3,11 +3,13 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 
@@ -35,7 +37,7 @@ func (globTool) Description() string {
 }
 
 func (globTool) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern (supports ** for recursive matching)"}},"required":["pattern"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern (supports ** for recursive matching)"},"timeout_seconds":{"type":"integer","description":"Walk timeout in seconds (default 30, max 300); partial results are returned when it expires"}},"required":["pattern"]}`)
 }
 
 func (globTool) ReadOnly() bool { return true }
@@ -46,11 +48,29 @@ func (globTool) SnipHint() tool.SnipHint {
 	return tool.SnipHint{Head: 80, Tail: 8, HeadChars: 10000, TailChars: 1000}
 }
 
-const globMaxResults = 1000
+const (
+	globMaxResults     = 1000
+	globDefaultTimeout = 30 * time.Second
+	globMaxTimeout     = 300 * time.Second
+)
+
+// globTimeout clamps a caller-supplied second count to a sane bound; 0 (omitted)
+// falls back to the default so a deep tree can't hold a turn open for minutes.
+func globTimeout(sec int) time.Duration {
+	switch {
+	case sec <= 0:
+		return globDefaultTimeout
+	case time.Duration(sec)*time.Second > globMaxTimeout:
+		return globMaxTimeout
+	default:
+		return time.Duration(sec) * time.Second
+	}
+}
 
 func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Pattern string `json:"pattern"`
+		Pattern        string `json:"pattern"`
+		TimeoutSeconds int    `json:"timeout_seconds"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -58,6 +78,9 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if p.Pattern == "" {
 		return "", fmt.Errorf("pattern is required")
 	}
+	to := globTimeout(p.TimeoutSeconds)
+	ctx, cancel := context.WithTimeout(ctx, to)
+	defer cancel()
 	// Save the original pattern before resolveIn prepends workDir, so the
 	// simple-filename recursive-fallback check below works on the raw input
 	// — not the already-joined absolute path that always contains separators.
@@ -70,7 +93,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// If the pattern contains **, use recursive matching via doublestar semantics
 	// while retaining Reasonix's cancellation and read-forbid pruning.
 	if strings.Contains(p.Pattern, "**") {
-		return g.globRecursive(ctx, p.Pattern, displayPattern, rp)
+		return g.globRecursive(ctx, p.Pattern, displayPattern, rp, to)
 	}
 
 	// For patterns without **, try filepath.Glob first. If no matches are
@@ -89,7 +112,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	matches = filterForbidMatches(matches, g.forbidRoots)
 	if len(matches) == 0 && !strings.ContainsAny(rawPattern, "/\\") {
 		fallback := filepath.Join(g.workDir, "**", rawPattern)
-		return g.globRecursive(ctx, fallback, fallback, ResolvedPath{})
+		return g.globRecursive(ctx, fallback, fallback, ResolvedPath{}, to)
 	}
 	if len(matches) == 0 {
 		return "(no matches)", nil
@@ -117,8 +140,9 @@ func filterForbidMatches(matches, forbidRoots []string) []string {
 
 // globRecursive handles patterns containing ** by walking the stable non-meta
 // prefix and matching relative paths with doublestar. Accepts a context so the
-// walk can be interrupted on cancellation.
-func (g globTool) globRecursive(ctx context.Context, pattern, displayPattern string, rp ResolvedPath) (string, error) {
+// walk can be interrupted on cancellation, and to so an expired deadline can be
+// reported as incomplete results rather than as a failure.
+func (g globTool) globRecursive(ctx context.Context, pattern, displayPattern string, rp ResolvedPath, to time.Duration) (string, error) {
 	rootSlash, relPattern := doublestar.SplitPattern(filepath.ToSlash(filepath.Clean(pattern)))
 	root := filepath.FromSlash(rootSlash)
 	if relPattern == "" {
@@ -140,7 +164,7 @@ func (g globTool) globRecursive(ctx context.Context, pattern, displayPattern str
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if ctx.Err() != nil {
-			return ctx.Err() // abort promptly on cancel — a huge tree is interruptible
+			return ctx.Err() // abort promptly on cancel/deadline — a huge tree is interruptible
 		}
 		if err != nil {
 			return nil // skip unreadable entries
@@ -167,7 +191,8 @@ func (g globTool) globRecursive(ctx context.Context, pattern, displayPattern str
 		}
 		return nil
 	})
-	if err != nil {
+	timedOut := errors.Is(err, context.DeadlineExceeded)
+	if err != nil && !timedOut {
 		if rp.External {
 			return "", fmt.Errorf("glob %q: %s", displayPattern, rp.ErrorText(err))
 		}
@@ -175,13 +200,19 @@ func (g globTool) globRecursive(ctx context.Context, pattern, displayPattern str
 	}
 
 	if len(matches) == 0 {
+		if timedOut {
+			return fmt.Sprintf("(no matches; timed out after %s — narrow the pattern or raise timeout_seconds)", to), nil
+		}
 		return "(no matches)", nil
 	}
 	sort.Strings(matches)
 	matches = displayGlobMatches(matches, rp)
 	result := strings.Join(matches, "\n")
-	if truncated {
+	switch {
+	case truncated:
 		result += fmt.Sprintf("\n... (truncated at %d results)", globMaxResults)
+	case timedOut:
+		result += fmt.Sprintf("\n... (timed out after %s; results incomplete — narrow the pattern or raise timeout_seconds)", to)
 	}
 	return result, nil
 }

--- a/internal/tool/builtin/walk_cancel_test.go
+++ b/internal/tool/builtin/walk_cancel_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestGrepWalkInterruptible proves the native (no-ripgrep) grep walk aborts on a
@@ -39,5 +40,39 @@ func TestGlobWalkInterruptible(t *testing.T) {
 	args, _ := json.Marshal(map[string]any{"pattern": filepath.Join(dir, "**", "*.go")})
 	if _, err := (globTool{}).Execute(ctx, args); err == nil {
 		t.Fatal("cancelled glob should surface a context error, not finish the walk")
+	}
+}
+
+// TestGlobDeadlineReportsIncomplete proves an expired walk budget degrades to a
+// labelled partial result instead of an error, so a deep tree can't hang a turn.
+func TestGlobDeadlineReportsIncomplete(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "a.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	args, _ := json.Marshal(map[string]any{"pattern": filepath.Join(dir, "**", "*.go")})
+	out, err := (globTool{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("expired glob budget should return partial results, got error: %v", err)
+	}
+	if !strings.Contains(out, "timed out") {
+		t.Fatalf("expired glob budget should label the result, got %q", out)
+	}
+}
+
+func TestGlobTimeoutClamp(t *testing.T) {
+	if got := globTimeout(0); got != globDefaultTimeout {
+		t.Errorf("globTimeout(0) = %s, want %s", got, globDefaultTimeout)
+	}
+	if got := globTimeout(5); got != 5*time.Second {
+		t.Errorf("globTimeout(5) = %s, want 5s", got)
+	}
+	if got := globTimeout(100000); got != globMaxTimeout {
+		t.Errorf("globTimeout(100000) = %s, want %s", got, globMaxTimeout)
 	}
 }


### PR DESCRIPTION
## Problem

`glob` had no walk budget. A pattern like `**/*.ts` against a deep tree — or one on a network drive, or a Windows workspace with a large dependency tree that isn't in the vendor skip list — could keep walking for tens of minutes. From the user's side the turn looks hung: no output, no partial result, and the only way out is interrupting the turn.

`grep` already solved this: a default budget, a caller override, and a labelled partial result when the budget expires. `glob` just never got the same treatment.

## Fix

Mirror `grep` exactly:

- default the recursive walk to 30s, `timeout_seconds` overrides up to 300s;
- an expired budget returns the matches found so far with `... (timed out after 30s; results incomplete — narrow the pattern or raise timeout_seconds)`, so the model can act on a partial list or retry more narrowly;
- with no matches at all it says so rather than returning a bare `(no matches)` that would read as "this file doesn't exist".

Cancellation keeps its current behaviour and still surfaces as an error — an interrupt must not be mistaken for a finished search. The distinction is `errors.Is(err, context.DeadlineExceeded)`, so a cancelled parent context stays on the error path.

## Verification

- `go test ./internal/tool/...`
- `go test ./internal/agent/... ./internal/control/...`
- `go vet ./internal/tool/...`, `gofmt -l`

New tests: an expired deadline returns a labelled partial result instead of an error, and the timeout clamp (`0` → default, in-range passthrough, oversized → max). The existing `TestGlobWalkInterruptible` still pins that a cancelled walk errors.

Closes #4707

## Documentation impact

Documentation-impact: none - `docs/*.md` documents commands and configuration, not builtin tool parameters; the schema description is the surface the model reads and it carries the new field.

## Cache impact

Cache-impact: low - the glob tool schema gains one optional property, so the tool-definition block of the cached prefix changes once on upgrade. Same class as adding any tool; sessions re-cache on their next turn and nothing else in the prefix moves.
Cache-guard: `go test ./internal/tool/...` covers the schema surface; no prompt/memory/system-prompt text is touched, so the existing prefix guards apply unchanged.
System-prompt-review: N/A
