### PR TITLE
fix(subagent): treat a non-directory store path as an error on Windows

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -242,8 +242,13 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 	}
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
+		// Windows reports a non-directory at this path as ENOENT, so a plain
+		// IsNotExist check would silently accept a corrupt store instead of
+		// surfacing it. Only treat it as "no store yet" when nothing is there.
 		if os.IsNotExist(err) {
-			return 0, nil
+			if _, statErr := os.Lstat(s.dir); statErr != nil {
+				return 0, nil
+			}
 		}
 		return 0, err
 	}


### PR DESCRIPTION
## Problem

`TestNewSubagentStoreNeverCachesCleanupError` fails on every Windows checkout of `main-v2`:

```
subagent_cleanup_recovery_test.go:89: newSubagentStore attempt 1 unexpectedly succeeded
```

The test puts a regular file where the `subagents/` directory belongs and expects the store to refuse to boot. It passes on CI because `os.ReadDir` on a non-directory reports `ENOTDIR` on unix — which falls through to the error return. On Windows the same call reports `ENOENT`, so `os.IsNotExist(err)` is true and `CleanupStaleRunning` returns `0, nil`: a corrupt store reads as "no sub-agents yet" and startup continues past it.

So the platform where this matters is the one where the guard didn't hold.

## Fix

Only take the "nothing here yet" branch when the path is genuinely absent — `os.Lstat` decides, which is portable and doesn't need a syscall-errno check per GOOS.

## Verification

- `go test ./internal/boot/ -run TestNewSubagentStore` — was failing on Windows, now passes
- `go test ./internal/agent/`
- `go vet ./internal/agent/ ./internal/boot/`, `gofmt -l`

No new test: the existing one was already asserting the right contract and was simply never satisfied on Windows.

## Documentation impact

Documentation-impact: none - this restores the intended behavior of an internal startup guard on one platform; no documented behavior changes.
