### PR TITLE
fix(desktop): scale transcript text with the text-size setting

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -357,5 +357,27 @@ ok(
   "narrow workbench layout hides side panels and keeps chat single-column",
 );
 
+for (const selector of [
+  ".reasoning__head",
+  ".turn-collapse__reasoning-head",
+  ".process-card__head",
+  ".tool__difflabel",
+  ".msg-memory-citations",
+  ".msg-memory-citations__source",
+  ".msg-memory-citations__note",
+  ".msg-attachment__name",
+  ".msg-attachment__meta",
+  ".msg-pasted-head",
+  ".msg-pasted-expanded",
+  ".msg-edit__input",
+  ".msg-edit__btn",
+  ".msg__send-failed",
+  ":root[data-theme-style] .process-card__kind",
+  ':root[data-theme-style] .msg--assistant > .process-card[data-tone="violet"] .process-card__name',
+]) {
+  const size = finalDeclaration(selector, "font-size");
+  ok(size !== undefined && !/^[0-9.]+px$/.test(size), `${selector} font size follows the text-size scale`);
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3993,7 +3993,7 @@ a[href] {
   background: transparent;
   color: inherit;
   font: inherit;
-  font-size: 15px;
+  font-size: var(--text-lg);
   font-weight: 450;
   line-height: 1.65;
   white-space: pre-wrap;
@@ -4015,7 +4015,7 @@ a[href] {
   background: var(--button-bg);
   color: var(--button-fg);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 650;
   line-height: 1;
   transition: color 0.12s, background 0.12s, border-color 0.12s, opacity 0.12s;
@@ -4262,7 +4262,7 @@ a[href] {
 }
 .msg__send-failed {
   margin-top: 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--danger);
 }
 .msg-attachments {
@@ -4344,13 +4344,13 @@ a[href] {
 }
 .msg-attachment__name {
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 560;
   line-height: 1.25;
 }
 .msg-attachment__meta {
   color: var(--fg-faint);
-  font-size: 11px;
+  font-size: var(--text-xs);
   line-height: 1.25;
 }
 
@@ -4374,7 +4374,7 @@ a[href] {
   min-height: 32px;
   padding: 5px 6px 5px 9px;
   color: var(--fg-dim);
-  font-size: 13px;
+  font-size: var(--text-md);
 }
 .msg-pasted-head > svg {
   flex-shrink: 0;
@@ -4405,7 +4405,7 @@ a[href] {
   background: transparent;
   color: var(--fg-faint);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 .msg-pasted-head button:hover {
@@ -4418,7 +4418,7 @@ a[href] {
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-md);
   line-height: 1.5;
 }
 .msg-pasted-expanded .md {
@@ -4493,7 +4493,7 @@ a[href] {
   border: none;
   background: none;
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 560;
   color: var(--fg-faint);
   border-radius: 6px;
@@ -4536,7 +4536,7 @@ a[href] {
   background: transparent;
   color: var(--fg-faint);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 560;
   line-height: 1.4;
   text-align: left;
@@ -4561,7 +4561,7 @@ a[href] {
   gap: 6px;
   margin-top: 2px;
   color: var(--fg-faint);
-  font-size: 13px;
+  font-size: var(--text-md);
 }
 .msg-memory-citations__toggle {
   display: inline-flex;
@@ -4606,7 +4606,7 @@ a[href] {
   flex-wrap: wrap;
   gap: 8px;
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 560;
   line-height: 1.35;
 }
@@ -4616,7 +4616,7 @@ a[href] {
 }
 .msg-memory-citations__note {
   color: var(--fg-dim);
-  font-size: 13px;
+  font-size: var(--text-md);
   line-height: 1.45;
 }
 
@@ -4694,7 +4694,7 @@ a[href] {
   border: none;
   color: var(--fg-faint);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-md);
   text-align: left;
   cursor: pointer;
   border-radius: 4px;
@@ -19934,7 +19934,7 @@ body > .mermaid-diagram--fullscreen {
 /* ── tool card extras: nested sub-agent, multi-edit labels ───── */
 .tool__difflabel {
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--fg-faint);
   margin: 6px 0 2px;
 }
@@ -27307,7 +27307,7 @@ body > .mermaid-diagram--fullscreen {
 
 :root[data-theme-style] .process-card__kind {
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 700;
   letter-spacing: 0;
   text-transform: none;
@@ -27321,7 +27321,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .msg--assistant > .process-card[data-tone="violet"] .process-card__name {
   color: var(--fg);
   font-family: inherit;
-  font-size: 13px;
+  font-size: var(--text-md);
   font-weight: 700;
 }
 
@@ -27329,7 +27329,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .process-card__meta {
   color: var(--fg-faint);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--text-sm);
   font-weight: 500;
 }
 


### PR DESCRIPTION
## Problem

Ctrl+= / Ctrl+- and Settings → 外观 → 字体大小 change `--global-font-scale`, and the transcript region redeclares the proportional tokens (`--text-xs` … `--text-lg`) so descendants scale with it. A set of conversation elements never used those tokens — they carried literal pixel sizes:

- the thinking header (`.reasoning__head`, `.turn-collapse__reasoning-head`)
- tool card chrome (`.process-card__head`, `.tool__difflabel`, and the `data-theme-style` overrides of `__kind` / `__name` / `__meta`)
- attachment and pasted-block rows, memory citations, the inline message editor, the send-failed notice

So raising the text size grew the message body and left the labels around it at 11–15px. At `xxlarge` (1.32×) the mismatch is very visible, which is exactly the setting someone changing text size is most likely to pick.

## Fix

Point those declarations at the tokens the region already publishes — `13px` → `var(--text-md)`, `12px` → `var(--text-sm)`, `11px` → `var(--text-xs)`, `15px` → `var(--text-lg)`. No new variables and no layout change: at the default scale every value resolves to the same pixel size it had before.

This is scoped to the conversation area, which is what was reported. Other regions still contain literal sizes; sweeping all 500-odd of them is a separate job with a much wider blast radius.

## Verification

- `tsx src/__tests__/typography-overflow-contract.test.ts` — 152 passed, including 16 new assertions that these selectors resolve their font size through a token rather than a literal
- `tsx src/__tests__/typography-preferences.test.ts`, `tsx src/__tests__/text-size.test.ts`

Closes #4723

## Documentation impact

Documentation-impact: none - the text-size setting and its shortcuts are documented already; this makes them apply where they were supposed to.
