### PR TITLE
fix(release): make Windows full gate portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,15 +129,16 @@ jobs:
         run: go test ./...
 
       # Pull requests run a Windows smoke suite: the packages that actually
-      # carry *_windows.go code, plus cmd/. The full ./... sweep stays on
-      # pushes to main-v2; the Unix legs always run the full suite.
+      # carry *_windows.go code, the startup/checkpoint packages with portable
+      # filesystem contracts, plus cmd/. The full ./... sweep stays on pushes
+      # to main-v2; the Unix legs always run the full suite.
       - name: test (Windows smoke)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 10
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -240,6 +240,20 @@ func (s *SubagentStore) CleanupStaleRunning() (int, error) {
 	if s == nil {
 		return 0, nil
 	}
+	// On Windows, os.ReadDir can report ERROR_DIRECTORY as an IsNotExist
+	// error when the store path exists but is a regular file. Check the leaf
+	// first so a malformed store remains a startup error instead of being
+	// mistaken for an absent store.
+	info, err := os.Stat(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !info.IsDir() {
+		return 0, fmt.Errorf("subagent store path %q is not a directory", s.dir)
+	}
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/checkpoint/transaction_test.go
+++ b/internal/checkpoint/transaction_test.go
@@ -527,8 +527,23 @@ func TestUndoRejectsPermissionOnlyChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(path, 0o600); err != nil {
+	before, err := os.Stat(path)
+	if err != nil {
 		t.Fatal(err)
+	}
+	wantMode := os.FileMode(0o600)
+	if before.Mode().Perm() == wantMode {
+		wantMode = 0o644
+	}
+	if err := os.Chmod(path, wantMode); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Mode().Perm() == before.Mode().Perm() {
+		t.Skip("filesystem does not expose permission-only changes")
 	}
 	if _, err := store.UndoRewind(result.TransactionID, nil); err == nil {
 		t.Fatal("undo overwrote a permission-only user change")
@@ -537,8 +552,8 @@ func TestUndoRejectsPermissionOnlyChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("mode after refused undo = %o, want 600", got)
+	if got := info.Mode().Perm(); got != wantMode {
+		t.Fatalf("mode after refused undo = %o, want %o", got, wantMode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject a non-directory subagent store path even when Windows classifies `ReadDir` as not found
- skip the permission-only checkpoint test when the filesystem cannot expose Unix permission changes
- include boot and checkpoint packages in the Windows PR smoke gate

Documentation-impact: none - existing recovery and checkpoint behavior remains unchanged; this makes error handling and test coverage portable across Windows filesystems.

## Validation
- `go test ./...`
- `go vet ./...`
- `bash scripts/release-workflows.test.sh`
- `node scripts/check-single-release-public-contract.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -ignore 'label "windows-11-arm" is unknown' .github/workflows/ci.yml`