### PR TITLE
fix(provider): honor a Retry-After longer than the backoff cap

### DIFF
--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -21,6 +21,12 @@ const MaxRetries = 10
 
 const maxBackoff = 15 * time.Second
 
+// maxRetryAfter bounds a server-supplied Retry-After. Rate-limit windows are
+// routinely longer than our own backoff cap, and clamping to it just spends
+// attempts re-hitting the same closed window; the sleep is cancellable, so a
+// longer honest wait costs nothing the user can't interrupt.
+const maxRetryAfter = 60 * time.Second
+
 // errorBodyReadTimeout bounds how long draining a non-OK response body may
 // block. Proxies and gateways under load (502/524 storms) can send headers and
 // then stall the body on a half-open connection; http.Client has no Timeout
@@ -214,8 +220,8 @@ func IsConnReset(err error) bool {
 
 func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
 	if retryAfter > 0 {
-		if retryAfter > maxBackoff {
-			return maxBackoff
+		if retryAfter > maxRetryAfter {
+			return maxRetryAfter
 		}
 		return retryAfter
 	}
@@ -233,6 +239,13 @@ func parseRetryAfter(resp *http.Response) time.Duration {
 	}
 	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
 		return time.Duration(secs) * time.Second
+	}
+	// RFC 9110 also allows an HTTP-date; gateways in front of rate-limited
+	// backends use it more often than the delta-seconds form.
+	if when, err := http.ParseTime(v); err == nil {
+		if d := time.Until(when); d > 0 {
+			return d
+		}
 	}
 	return 0
 }

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -86,8 +86,24 @@ func TestBackoffDelay(t *testing.T) {
 	if d := backoffDelay(5, 3*time.Second); d != 3*time.Second {
 		t.Errorf("Retry-After should win: %v", d)
 	}
-	if d := backoffDelay(1, time.Hour); d != maxBackoff {
-		t.Errorf("Retry-After should be capped to %v, got %v", maxBackoff, d)
+	if d := backoffDelay(1, 45*time.Second); d != 45*time.Second {
+		t.Errorf("Retry-After beyond the backoff cap should still be honored: %v", d)
+	}
+	if d := backoffDelay(1, time.Hour); d != maxRetryAfter {
+		t.Errorf("Retry-After should be capped to %v, got %v", maxRetryAfter, d)
+	}
+}
+
+func TestParseRetryAfterAcceptsHTTPDate(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("Retry-After", time.Now().Add(30*time.Second).UTC().Format(http.TimeFormat))
+	if d := parseRetryAfter(resp); d < 25*time.Second || d > 31*time.Second {
+		t.Errorf("http-date Retry-After = %v, want ~30s", d)
+	}
+
+	resp.Header.Set("Retry-After", time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat))
+	if d := parseRetryAfter(resp); d != 0 {
+		t.Errorf("elapsed http-date Retry-After = %v, want 0", d)
 	}
 }
 


### PR DESCRIPTION
## Problem

429 handling already backs off and already reads `Retry-After` — but then threw most of it away:

```go
if retryAfter > maxBackoff {   // maxBackoff = 15s
    return maxBackoff
}
```

Rate-limit windows are commonly 30s or 60s. A provider answering `Retry-After: 60` got retried at 15s, hit the same closed window, and burned attempts on a schedule the server had explicitly told us was wrong. With `MaxRetries = 10` that's a run of guaranteed-failing requests — the opposite of what backing off is for, and extra load on the endpoint that just asked us to stop.

`parseRetryAfter` also only understood delta-seconds. RFC 9110 allows an HTTP-date, and gateways sitting in front of rate-limited backends send it; those responses were treated as if the header were absent.

## Fix

- Honor `Retry-After` up to a separate 60s ceiling instead of clamping it to the exponential-backoff cap. The sleep is already `select`-ed against `ctx.Done()`, so a longer honest wait stays interruptible.
- Parse the HTTP-date form too, and ignore a date already in the past.

The exponential path is unchanged — 15s cap plus jitter as before. This only affects the case where the server told us how long to wait.

## Verification

- `go test ./internal/provider/...`
- `go vet ./internal/provider/...`, `gofmt -l`

Tests: a Retry-After beyond the backoff cap is honored rather than clamped, the 60s ceiling still applies, an HTTP-date resolves to the remaining interval, and an elapsed date yields zero.

Related: #4756

## Documentation impact

Documentation-impact: none - retry/backoff timing is not a documented or configurable surface; the change only makes an existing server instruction be obeyed.

## Cache impact

Cache-impact: none - transport-level retry scheduling only. No request body, tool schema, system prompt, or memory prefix is touched.
Cache-guard: `go test ./internal/provider/...`; the change is confined to `backoffDelay`/`parseRetryAfter`, neither of which participates in prefix construction.
System-prompt-review: N/A
