### PR TITLE
fix(provider): name the payload that failed to decode in a stream

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -555,7 +555,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 		var ev streamEvent
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
-			send(provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: decode stream: %w", c.name, err)})
+			send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamDecodeError(c.name, data, err)})
 			return
 		}
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -972,7 +972,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 		var sr streamResponse
 		if err := json.Unmarshal([]byte(data), &sr); err != nil {
-			return emitted, fmt.Errorf("%s: decode stream: %w", c.name, err)
+			return emitted, provider.StreamDecodeError(c.name, data, err)
 		}
 		if sr.Error != nil {
 			return emitted, fmt.Errorf("%s: %s", c.name, sr.Error.Message)

--- a/internal/provider/stream_error.go
+++ b/internal/provider/stream_error.go
@@ -1,0 +1,28 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const streamPayloadExcerpt = 120
+
+// StreamDecodeError reports an SSE data payload that failed to parse, quoting a
+// bounded excerpt of it. Gateways put non-JSON on `data:` lines — HTML error
+// pages, bare sentinels, proxy notices — and the decoder error alone names only
+// the first offending byte, which is not enough to identify the sender.
+func StreamDecodeError(provider string, payload string, err error) error {
+	return fmt.Errorf("%s: decode stream: %w (payload %s)", provider, err, streamPayloadSnippet(payload))
+}
+
+func streamPayloadSnippet(payload string) string {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return "(empty)"
+	}
+	if len(payload) > streamPayloadExcerpt {
+		return strconv.Quote(payload[:streamPayloadExcerpt]) + "…"
+	}
+	return strconv.Quote(payload)
+}

--- a/internal/provider/stream_error_test.go
+++ b/internal/provider/stream_error_test.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestStreamDecodeErrorQuotesPayload(t *testing.T) {
+	err := StreamDecodeError("openrouter", "DONE", errors.New("invalid character 'D' looking for beginning of value"))
+	got := err.Error()
+	if !strings.Contains(got, `payload "DONE"`) {
+		t.Errorf("error should quote the offending payload: %q", got)
+	}
+	if !strings.Contains(got, "openrouter") {
+		t.Errorf("error should name the provider: %q", got)
+	}
+}
+
+func TestStreamDecodeErrorBoundsPayload(t *testing.T) {
+	long := strings.Repeat("x", streamPayloadExcerpt*3)
+	got := StreamDecodeError("p", long, errors.New("boom")).Error()
+	if len(got) > streamPayloadExcerpt*2 {
+		t.Errorf("excerpt is unbounded: %d chars", len(got))
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("truncated excerpt should be marked: %q", got)
+	}
+}
+
+func TestStreamDecodeErrorEmptyPayload(t *testing.T) {
+	got := StreamDecodeError("p", "  ", errors.New("boom")).Error()
+	if !strings.Contains(got, "(empty)") {
+		t.Errorf("empty payload should say so: %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

When an OpenAI-compatible or Anthropic gateway puts something that isn't JSON on a `data:` line, the whole stream fails with:

```
OpenRouter: decode stream: invalid character 'D' looking for beginning of value
```

That names the first offending byte and nothing else. It doesn't say what arrived, so neither the user nor I can tell whether it was a bare `DONE` sentinel, an HTML error page from a proxy, a rate-limit notice, or a truncated frame — and a bug report built on it can't be acted on. (This came up under #4729 from an OpenRouter user; there's no way to diagnose it from the message alone.)

## Fix

`provider.StreamDecodeError` quotes a bounded excerpt (120 chars) of the payload that failed to parse, shared by both the OpenAI and Anthropic stream loops. Same failure, same behaviour — the error just says what it choked on.

The excerpt is the payload the JSON decoder already rejected, so it isn't a model delta; it's whatever the gateway substituted for one.

## Verification

- `go test ./internal/provider/...`
- `go vet ./internal/provider/...`, `gofmt -l`, `go build ./...`

Tests cover the quoted payload, the bounded excerpt for a long payload, and the empty-payload case.

## Documentation impact

Documentation-impact: none - error text only; no documented behavior, flag, or configuration changes.

## Cache impact

Cache-impact: none - response-decoding error message only. Nothing on the request path, tool schema, or prompt prefix changes.
Cache-guard: `go test ./internal/provider/...`; the new helper is only reachable from a payload the JSON decoder has already rejected.
System-prompt-review: N/A
