### PR TITLE
fix(session): drop leading @file refs from the session preview

### DIFF
--- a/internal/agent/preview_prose_test.go
+++ b/internal/agent/preview_prose_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import "testing"
+
+func TestPreviewProseDropsLeadingFileRefs(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"@src/App.tsx 帮我把这个组件拆一下", "帮我把这个组件拆一下"},
+		{"@a.ts @b.ts fix the imports", "fix the imports"},
+		{"  @src/App.tsx\tcheck this", "check this"},
+		{"@__reasonix_external_folder/mock/notes/ summarise", "summarise"},
+		{"no refs here", "no refs here"},
+		{"look at @src/App.tsx", "look at @src/App.tsx"},
+	} {
+		if got := previewProse(tc.in); got != tc.want {
+			t.Errorf("previewProse(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestPreviewProseKeepsRefOnlyPrompts(t *testing.T) {
+	for _, in := range []string{"@src/App.tsx", "@a.ts @b.ts", "@a.ts   "} {
+		if got := previewProse(in); got != in {
+			t.Errorf("previewProse(%q) = %q, want it unchanged", in, got)
+		}
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -2033,7 +2033,7 @@ func SessionPreviewFromMessages(msgs []provider.Message) (string, int) {
 		if m.Role == provider.RoleUser && IsUserAuthoredTurn(UserMessageText(m)) {
 			turns++
 			if first == "" {
-				first = truncatePreview(UserMessageText(m))
+				first = truncatePreview(previewProse(UserMessageText(m)))
 			}
 		}
 	}
@@ -2054,11 +2054,33 @@ func previewSession(path string) (string, int) {
 		if m.Role == provider.RoleUser && IsUserAuthoredTurn(UserMessageText(m)) {
 			turns++
 			if first == "" {
-				first = truncatePreview(UserMessageText(m))
+				first = truncatePreview(previewProse(UserMessageText(m)))
 			}
 		}
 	}
 	return first, turns
+}
+
+// previewProse drops the leading @file references a prompt opens with so the
+// preview shows what was asked rather than a row of paths. A prompt that is
+// nothing but references keeps them — there is nothing else to show.
+func previewProse(s string) string {
+	rest := strings.TrimLeft(s, " \t")
+	for strings.HasPrefix(rest, "@") {
+		end := strings.IndexAny(rest, " \t\r\n")
+		if end < 0 {
+			return s
+		}
+		next := strings.TrimLeft(rest[end:], " \t")
+		if strings.TrimSpace(next) == "" {
+			return s
+		}
+		rest = next
+	}
+	if rest == "" {
+		return s
+	}
+	return rest
 }
 
 // truncatePreview clamps a preview line to 80 runes with an ellipsis, matching


### PR DESCRIPTION
## Summary

A session's preview line is the first user turn, clamped to 80 runes, and the sidebar falls back to it when there's no custom or topic title. For anyone who works by referencing files first — `@src/App.tsx @src/lib/api.ts 帮我把这个组件拆一下` — the whole clamp is spent on paths and the actual request never appears. Every such session ends up labelled with a row of `@`-paths, so the list stops being scannable.

`previewProse` skips the run of leading `@` references before the preview is clamped. A prompt that is *only* references keeps them, since there's nothing else to show, and a reference appearing mid-sentence (`look at @src/App.tsx`) is left alone — only the leading run is dropped.

Both preview paths go through it: `previewSession` (decoded from the file) and `SessionPreviewFromMessages` (the autosave path), which are required to agree byte-for-byte.

Existing sessions keep the preview already written into their sidecar; this applies from the next save onward.

## Issues

Refs #4748

## Verification

- `go test ./internal/agent/ ./internal/control/`
- `go vet ./internal/agent/`, `gofmt -l`

New table test covers a leading ref, several leading refs, tab separation, the external-folder session token, a prompt with no refs, a mid-sentence ref, and ref-only prompts.

## Documentation impact

Documentation-impact: none - the preview line is derived display text, not a documented format or configurable surface.

## Cache impact

Cache-impact: none - previews are sidecar/display metadata and never reach a provider request. No prompt prefix, tool schema, or memory text changes.
Cache-guard: `go test ./internal/agent/`; `previewProse` is only reachable from the two preview builders, neither of which participates in request construction.
System-prompt-review: N/A
