### PR TITLE
fix(desktop): make local file paths in chat clickable (#7426)

### DIFF
--- a/desktop/frontend/src/__tests__/local-path-click-e2e.test.tsx
+++ b/desktop/frontend/src/__tests__/local-path-click-e2e.test.tsx
@@ -1,0 +1,139 @@
+// Run: tsx src/__tests__/local-path-click-e2e.test.tsx
+//
+// Headless end-to-end of the click-to-open chain from issue #7426: chat
+// markdown with a plain Windows path is rendered with the real production
+// pipeline (remarkLocalPathLinks + urlTransform + RichMarkdownLink), the
+// anchor is clicked in a JSDOM document, and the native OpenLocalPath binding
+// must receive the decoded local path. A plain http link must instead go to
+// the system browser. No UI is involved — the Wails bridge is stubbed via
+// window.go.main.App / window.runtime.
+
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "https://reasonix.local/" });
+const { window } = dom;
+
+// Set globals BEFORE dynamically importing React DOM so the renderer sees a
+// real document (ESM imports are hoisted, hence dynamic import below).
+(globalThis as Record<string, unknown>).window = window;
+(globalThis as Record<string, unknown>).document = window.document;
+(globalThis as Record<string, unknown>).HTMLElement = window.HTMLElement;
+(globalThis as Record<string, unknown>).MouseEvent = window.MouseEvent;
+// React 19 requires this flag for act() to flush renders/pass-through events.
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Bridge spies: OpenLocalPath is what the click must call; BrowserOpenURL is
+// what plain http links must call instead.
+const opened: string[] = [];
+const browsed: string[] = [];
+(window as unknown as Record<string, unknown>).go = {
+  main: {
+    App: {
+      OpenLocalPath: async (path: string) => {
+        opened.push(path);
+      },
+    },
+  },
+};
+(window as unknown as Record<string, unknown>).runtime = {
+  BrowserOpenURL: (url: string) => {
+    browsed.push(url);
+  },
+};
+
+let passed = 0;
+let failed = 0;
+function ok(value: unknown, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+const { createElement } = await import("react");
+const { act } = await import("react");
+const { createRoot } = await import("react-dom/client");
+const { default: ReactMarkdown, defaultUrlTransform } = await import("react-markdown");
+const { default: remarkGfm } = await import("remark-gfm");
+const { remarkLocalPathLinks } = await import("../lib/localPathLinks");
+const { RichMarkdownLink } = await import("../components/githubLink");
+
+const markdownUrlTransform = (value: string) =>
+  value.startsWith("file:///") ? value : defaultUrlTransform(value);
+
+const components = { a: RichMarkdownLink };
+
+async function renderClick(markdown: string): Promise<HTMLAnchorElement[]> {
+  const container = window.document.createElement("div");
+  window.document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      createElement(
+        ReactMarkdown,
+        { remarkPlugins: [remarkGfm, remarkLocalPathLinks], urlTransform: markdownUrlTransform, components },
+        markdown,
+      ),
+    );
+  });
+  return Array.from(container.querySelectorAll("a"));
+}
+
+console.log("\nheadless click-to-open e2e");
+
+// 1. Issue #7426 scenario: plain Windows path in chat text, CJK dirs.
+{
+  const anchors = await renderClick("文件在 D:\\Project\\Jhtj\\20250804_000000_001_中停时分析\\05-静态验收.md 已生成");
+  ok(anchors.length === 1, "exactly one anchor rendered");
+  const href = anchors[0]?.getAttribute("href") ?? "";
+  ok(href === "file:///D:/Project/Jhtj/20250804_000000_001_%E4%B8%AD%E5%81%9C%E6%97%B6%E5%88%86%E6%9E%90/05-%E9%9D%99%E6%80%81%E9%AA%8C%E6%94%B6.md",
+    `anchor href is the encoded file URL (${href})`);
+  await act(async () => {
+    anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  ok(opened.length === 1, "click invoked OpenLocalPath once");
+  ok(opened[0] === "D:/Project/Jhtj/20250804_000000_001_中停时分析/05-静态验收.md",
+    `OpenLocalPath received the decoded CJK path (${opened[0]})`);
+  ok(browsed.length === 0, "system browser was not involved");
+}
+
+// 2. UNC path (markdown folds \\ into \, linkify restores it; the href uses
+// forward slashes, which Windows accepts as a UNC form).
+{
+  const anchors = await renderClick("共享盘 \\\\nas\\share\\docs\\report.md 已生成");
+  await act(async () => {
+    anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  ok(opened[1] === "//nas/share/docs/report.md", `UNC path forwarded as slash form (${opened[1]})`);
+}
+
+// 3. Explicit markdown link to a local file keeps working through the same path.
+{
+  const anchors = await renderClick("[验收单](file:///D:/docs/acceptance.md)");
+  await act(async () => {
+    anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  ok(opened[2] === "D:/docs/acceptance.md", "explicit file:/// markdown link opens locally");
+}
+
+// 4. Plain http link must NOT hit OpenLocalPath.
+{
+  const anchors = await renderClick("见 https://example.com/page 文档");
+  await act(async () => {
+    anchors[0].dispatchEvent(new window.MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  ok(browsed.length === 1 && browsed[0] === "https://example.com/page", "http link went to the system browser");
+  ok(opened.length === 3, "OpenLocalPath was not called for the http link");
+}
+
+// 5. Non-path text renders no anchors and no clicks.
+{
+  const anchors = await renderClick("版本 1.2.3 已发布");
+  ok(anchors.length === 0, "no anchors for plain text");
+}
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/local-path-links.test.tsx
+++ b/desktop/frontend/src/__tests__/local-path-links.test.tsx
@@ -1,0 +1,153 @@
+// Run: tsx src/__tests__/local-path-links.test.tsx
+//
+// Recognition matrix for chat markdown local-path linkification (issue
+// #7426): Windows drive paths, UNC paths and file:/// URLs become clickable
+// links; sentence punctuation and non-path lookalikes must not be captured.
+// Also covers the file:/// href round-trip used by RichMarkdownLink.
+
+import { linkifyLocalPaths, localPathHref, remarkLocalPathLinks } from "../lib/localPathLinks";
+import { localPathFromHref } from "../components/githubLink";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(
+      `  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`,
+    );
+    failed += 1;
+  }
+}
+
+function ok(value: unknown, label: string) {
+  eq(Boolean(value), true, label);
+}
+
+function firstPath(text: string): string | undefined {
+  return linkifyLocalPaths(text).find((s) => s.path !== undefined)?.path;
+}
+
+function pathCount(text: string): number {
+  return linkifyLocalPaths(text).filter((s) => s.path !== undefined).length;
+}
+
+console.log("\nlinkifyLocalPaths — drive paths");
+
+eq(firstPath("文件在 D:\\Project\\Jhtj\\20250804_000000_001_中停时分析\\05-静态验收.md 已生成"),
+  "D:\\Project\\Jhtj\\20250804_000000_001_中停时分析\\05-静态验收.md",
+  "issue case: Chinese dirs and underscores survive");
+eq(firstPath("see D:\\a\\b c.md note"), "D:\\a\\b", "unescaped space still ends the path");
+eq(firstPath("see D:\\a\\b\\ c.md"), "D:\\a\\b c.md", "escaped space unescapes to the real path");
+eq(firstPath("saved C:/Users/me/AppData/Local/x.md here"), "C:/Users/me/AppData/Local/x.md",
+  "forward-slash drive path");
+eq(firstPath("see D:\\x\\y.md. done"), "D:\\x\\y.md", "trailing period stripped");
+eq(firstPath("path D:\\x\\y.md, ok"), "D:\\x\\y.md", "trailing comma stripped");
+eq(firstPath("see D:\\x\\y.md) done"), "D:\\x\\y.md", "trailing closing paren stripped");
+eq(firstPath("see D:\\x\\y.md... done"), "D:\\x\\y.md", "trailing ellipsis stripped");
+eq(firstPath("see D:\\x\\y.md。打开它"), "D:\\x\\y.md", "CJK period stops the path");
+eq(firstPath("见 D:\\x\\y.md，查看详情"), "D:\\x\\y.md", "CJK comma stops the path");
+eq(firstPath("打开 D:\\x\\y.md; 完成"), "D:\\x\\y.md", "semicolon stops the path");
+eq(firstPath("见 D:\\x\\y.md（已生成）"), "D:\\x\\y.md", "full-width parens stop the path");
+eq(firstPath("报告 D:\\x\\y.md（终版）完成"), "D:\\x\\y.md", "full-width paren group after path");
+
+console.log("\nlinkifyLocalPaths — file:/// and UNC");
+
+eq(firstPath("see file:///D:/Project/report/05-final.md"), "file:///D:/Project/report/05-final.md",
+  "file URL matched whole, drive part not double-matched");
+eq(firstPath("见 file:///D:/Project/中停时分析/05-静态验收.md"), "file:///D:/Project/中停时分析/05-静态验收.md",
+  "file URL with CJK dirs");
+eq(firstPath("see file:///D:/x/y.md. done"), "file:///D:/x/y.md", "file URL trailing period stripped");
+eq(firstPath("see \\nas\\share\\docs\\report.md done"), "\\\\nas\\share\\docs\\report.md",
+  "UNC path matched whole and \\\\ prefix restored");
+
+console.log("\nlinkifyLocalPaths — lookalikes and non-paths");
+
+eq(pathCount("C: drive"), 0, "bare drive letter is not a path");
+eq(pathCount("at 10:30 now"), 0, "clock time is not a path");
+eq(pathCount("version 1.2.3 released"), 0, "version string is not a path");
+eq(pathCount("http://example.com 正常"), 0, "http URL untouched (GFM handles it)");
+eq(pathCount("a\\b\\c.md 讨论"), 0, "share-less backslash path in prose is not a UNC path");
+eq(firstPath("见 \\nas\\share\\x.md"), "\\\\nas\\share\\x.md", "real UNC path still matches");
+eq(firstPath("见 C:\\Program\\ Files\\ (x86) 完成"), "C:\\Program Files (x86)", "escaped-space path with (x86) keeps its closing paren");
+
+console.log("\nsegment alternation");
+
+const segs = linkifyLocalPaths("见 D:\\x\\y.md 然后 file:///C:/a/b.txt 完成");
+eq(segs.length, 5, "text/link/text/link/text alternation");
+eq(segs[0], { text: "见 " }, "leading plain text");
+eq(segs[1].path, "D:\\x\\y.md", "first link segment");
+eq(segs[2], { text: " 然后 " }, "middle plain text");
+eq(segs[3].path, "file:///C:/a/b.txt", "second link segment");
+eq(segs[4], { text: " 完成" }, "trailing plain text");
+
+console.log("\nlocalPathHref round-trip");
+
+eq(localPathHref("D:\\x\\y.md"), "file:///D:/x/y.md", "backslashes become forward slashes");
+eq(localPathHref("D:\\Project\\中停时分析\\05-静态验收.md"), "file:///D:/Project/%E4%B8%AD%E5%81%9C%E6%97%B6%E5%88%86%E6%9E%90/05-%E9%9D%99%E6%80%81%E9%AA%8C%E6%94%B6.md",
+  "CJK percent-encoded");
+eq(localPathHref("D:\\a\\b#c.md"), "file:///D:/a/b%23c.md", "hash escaped for URL safety");
+eq(localPathHref("file:///C:/a/b.txt"), "file:///C:/a/b.txt", "already-absolute file URL is not double-prefixed");
+eq(localPathHref("file:///D:/a%20b.txt"), "file:///D:/a%20b.txt", "literal %xx in a file URL is not double-encoded");
+eq(localPathFromHref("file:///D:/a%20b.txt"), "D:/a b.txt", "decoded %20 becomes a real space");
+
+eq(localPathFromHref("file:///D:/x/y.md"), "D:/x/y.md", "decodes plain path");
+eq(localPathFromHref("file:///D:/Project/%E4%B8%AD%E5%81%9C%E6%97%B6%E5%88%86%E6%9E%90/05-%E9%9D%99%E6%80%81%E9%AA%8C%E6%94%B6.md"),
+  "D:/Project/中停时分析/05-静态验收.md", "decodes percent-encoded CJK");
+eq(localPathFromHref("file:///D:/x/%zz"), null, "malformed escapes yield null");
+eq(localPathFromHref("https://example.com/x"), null, "http URL is not local");
+eq(localPathFromHref(undefined), null, "undefined href is not local");
+
+console.log("\nremark plugin via react-markdown render");
+
+import React from "react";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import { renderToStaticMarkup } from "react-dom/server";
+
+// Mirrors MarkdownRenderer: file:/// anchors survive the default sanitizer.
+const markdownUrlTransform = (value: string) =>
+  value.startsWith("file:///") ? value : defaultUrlTransform(value);
+
+const html = renderToStaticMarkup(
+  <ReactMarkdown remarkPlugins={[remarkLocalPathLinks]} urlTransform={markdownUrlTransform}>
+    {"文件在 D:\\Project\\x\\05-静态验收.md 已生成"}
+  </ReactMarkdown>,
+);
+ok(html.includes('href="file:///D:/Project/x/05-%E9%9D%99%E6%80%81%E9%AA%8C%E6%94%B6.md"'),
+  "plain drive path renders as a file:/// anchor");
+ok(html.includes("05-静态验收.md"), "anchor label keeps the original text");
+
+const mixed = renderToStaticMarkup(
+  <ReactMarkdown remarkPlugins={[remarkLocalPathLinks]} urlTransform={markdownUrlTransform}>
+    {"见 D:\\x\\y.md，然后 file:///C:/a/b.txt 完成"}
+  </ReactMarkdown>,
+);
+ok(mixed.includes('href="file:///D:/x/y.md"'), "CJK comma boundary renders drive link");
+ok(mixed.includes('href="file:///C:/a/b.txt"'), "explicit file URL renders its own anchor");
+
+const plain = renderToStaticMarkup(
+  <ReactMarkdown remarkPlugins={[remarkLocalPathLinks]} urlTransform={markdownUrlTransform}>
+    {"no paths here"}
+  </ReactMarkdown>,
+);
+ok(!plain.includes("<a"), "plain text without paths renders no anchors");
+
+const nested = renderToStaticMarkup(
+  <ReactMarkdown remarkPlugins={[remarkLocalPathLinks]} urlTransform={markdownUrlTransform}>
+    {"[D:\\x\\y.md](https://example.com)"}
+  </ReactMarkdown>,
+);
+ok(!nested.includes("file:///"), "explicit link text is not re-linkified (no nested anchors)");
+
+const uppercase = renderToStaticMarkup(
+  <ReactMarkdown remarkPlugins={[remarkLocalPathLinks]} urlTransform={markdownUrlTransform}>
+    {"see FILE:///C:/x/y.md"}
+  </ReactMarkdown>,
+);
+ok(!uppercase.includes("file:///"), "uppercase FILE:/// stays inert (case-sensitive allowlist)");
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/MarkdownRenderer.tsx
+++ b/desktop/frontend/src/components/MarkdownRenderer.tsx
@@ -1,5 +1,5 @@
 import { lazy, memo, Suspense, useMemo, useRef } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 import { CodeViewer } from "./CodeViewer";
@@ -23,6 +23,13 @@ const STATUS_MARKER_RE = /(?:✅|☑|☒|✔️?|✓|\[[xX ]\])/;
 const STATUS_MARKER_GLOBAL_RE = /(?:✅|☑|☒|✔️?|✓|\[[xX ]\])/g;
 const BULLET_RE = /^[-*•]\s+\S/;
 const DIVIDER_RE = /^[\s\-_=─━—]+$/;
+
+// file:/// hrefs come from local-path linkification (remarkLocalPathLinks)
+// and must survive react-markdown's default URL sanitisation, which would
+// otherwise blank them along with javascript: and friends.
+function markdownUrlTransform(value: string): string {
+  return value.startsWith("file:///") ? value : defaultUrlTransform(value);
+}
 
 function splitStatusLine(line: string): string[] {
   const parts = (line.match(STATUS_MARKER_GLOBAL_RE) ?? []).length > 1
@@ -137,6 +144,9 @@ const MarkdownRenderer = memo(function MarkdownRenderer({
       remarkPlugins={reasonixRemarkPlugins}
       rehypePlugins={reasonixRehypePlugins}
       components={components}
+      // file:/// anchors (local path linkification) are safe to keep; the
+      // default transform would blank them along with javascript: etc.
+      urlTransform={markdownUrlTransform}
     >
       {mathContent}
     </ReactMarkdown>

--- a/desktop/frontend/src/components/githubLink.tsx
+++ b/desktop/frontend/src/components/githubLink.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { ExternalLink, Mail } from "lucide-react";
-import { openExternal } from "../lib/bridge";
+import { app, openExternal } from "../lib/bridge";
 
 export interface GitHubLinkInfo {
   kind: "issue" | "pull" | "commit";
@@ -102,7 +102,25 @@ function LinkMark({ kind }: { kind: LinkIconKind }) {
 }
 
 function openLink(href: string | undefined) {
+  const local = localPathFromHref(href);
+  if (local !== null) {
+    // Local paths (linkified plain text or explicit file:/// links) open in
+    // the OS default app via the native binding, never in the system browser.
+    void app.OpenLocalPath(local).catch(() => {});
+    return;
+  }
   if (href) openExternal(href);
+}
+
+// localPathFromHref returns the decoded local filesystem path when href is a
+// file:/// URL (the form remarkLocalPathLinks emits), or null otherwise.
+export function localPathFromHref(href?: string): string | null {
+  if (!href || !href.startsWith("file:///")) return null;
+  try {
+    return decodeURIComponent(href.slice("file:///".length));
+  } catch {
+    return null;
+  }
 }
 
 export function RichMarkdownLink({

--- a/desktop/frontend/src/components/markdownRemarkPlugins.ts
+++ b/desktop/frontend/src/components/markdownRemarkPlugins.ts
@@ -1,7 +1,8 @@
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { remarkMathPolicy } from "./remarkMathPolicy";
+import { remarkLocalPathLinks } from "../lib/localPathLinks";
 
 // One shared parser policy keeps live Markdown and session exports identical.
-export const reasonixRemarkPlugins = [remarkGfm, remarkMath, remarkMathPolicy];
+export const reasonixRemarkPlugins = [remarkGfm, remarkMath, remarkMathPolicy, remarkLocalPathLinks];
 export { reasonixRehypePlugins } from "./rehypeReasonixKatex";

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -352,6 +352,7 @@ export interface AppBindings {
   RevealWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
+  OpenLocalPath(path: string): Promise<void>;
   SavePastedImage(dataUrl: string): Promise<string>;
   SaveClipboardImage(): Promise<string>;
   SavePastedFile(name: string, dataUrl: string): Promise<string>;
@@ -3689,6 +3690,9 @@ function makeMockApp(): AppBindings {
     },
     async OpenWorkspacePath(rel: string) {
       console.info("mock OpenWorkspacePath", rel);
+    },
+    async OpenLocalPath(path: string) {
+      console.info("mock OpenLocalPath", path);
     },
     async OpenWorkspacePathForTab(_tabID: string, rel: string) {
       await this.OpenWorkspacePath(rel);

--- a/desktop/frontend/src/lib/localPathLinks.ts
+++ b/desktop/frontend/src/lib/localPathLinks.ts
@@ -1,0 +1,175 @@
+// Local-path linkification for chat markdown (issue #7426).
+//
+// AI replies frequently print local file paths as plain text (Windows drive
+// paths, UNC paths, file:/// URLs). GFM autolink literals only recognize
+// http(s)/www/email, so these render as inert text. This module rewrites
+// matching text nodes into markdown links whose href is a file:/// URL; the
+// link click handler (RichMarkdownLink) routes those to the native
+// OpenLocalPath binding instead of the system browser.
+
+import { visit } from "unist-util-visit";
+import type { Parent, Link, Root, Text } from "mdast";
+import { unescapeRefPath } from "./refToken";
+
+// Sentence punctuation is excluded from path characters: Windows forbids `：`
+// in file names, and the CJK/ASCII punctuation set below almost never appears
+// inside a real path. Excluding it at match time is far more reliable than
+// trimming a trailing marker after the fact ("D:\x\y.md。已生成" must stop at
+// `。`). `.` is deliberately kept (extensions) and only stripped when it is
+// actually trailing.
+const SENT_PUNCT = "，。；、！？,;!?（）";
+
+// One path character: either a backslash-escaped space/tab (kept, matching the
+// @path grammar in lib/refToken), or any non-whitespace char that is not a
+// quote, angle bracket, pipe, `?`, `*`, colon or sentence punctuation.
+// The `\\[ \t]` alternative must come FIRST: in a `(?:A|B)+` loop the engine
+// backtracks by dropping repetitions, not by retrying the alternative at the
+// same position, so a trailing `\ ` would otherwise never be consumed.
+const PATH_CHAR = String.raw`(?:\\[ \t]|[^\s<>"|?*：${SENT_PUNCT}])`;
+
+// file:/// URLs are matched whole (their `:` and `.` are legal there). Drive
+// paths require a `(?<![:/A-Za-z])` prefix so `file:///D:` cannot re-match the
+// `e:` inside `file` or the `D:` after a slash.
+const FILE_RE = new RegExp(String.raw`file:///[^\s<>"|?*${SENT_PUNCT}]+`, "g");
+const DRIVE_RE = new RegExp(String.raw`(?<![:/A-Za-z])[A-Za-z]:[\\/]${PATH_CHAR}+`, "g");
+// UNC share paths: the plugin runs on parsed markdown text nodes, where
+// CommonMark backslash escaping has already folded `\\` into `\`. A share
+// therefore arrives as `\nas\share\docs\report.md` (single leading
+// backslash); linkify restores the `\\` prefix so the native opener receives
+// the real UNC form. The leading `\` is mandatory (the fold always leaves
+// one) and the `(?<![\\/\w:；：，。、！？（）])` guard keeps `C:\nas` or a
+// plain `a\b` from being mistaken for a share start.
+const UNC_RE = new RegExp(
+  String.raw`(?<![\\/\w:；：，。、！？（）])\\(?!\\)[^\s\\<>"|?*：${SENT_PUNCT}]+\\${PATH_CHAR}+`,
+  "g",
+);
+
+// Trailing closers that are more likely sentence punctuation than file name
+// characters. A trailing `)` is only stripped when parens are unbalanced —
+// "C:\Program Files (x86)" keeps its closing paren, "D:\x\y.md)." loses it.
+const TRAIL_STRIP_RE = /[.)\]]+$/;
+
+function stripTrailingClosers(raw: string): string {
+  const stripped = raw.replace(TRAIL_STRIP_RE, "");
+  if (stripped === raw) return raw;
+  // A trailing `)` may be a real file-name character inside balanced parens
+  // ("C:\Program Files (x86)") — only strip it when parens are unbalanced,
+  // i.e. the removed part contains a `)` with no matching opener.
+  if (raw.slice(stripped.length).includes(")")) {
+    const open = (raw.match(/\(/g) ?? []).length;
+    const close = (raw.match(/\)/g) ?? []).length;
+    if (close <= open) return raw;
+  }
+  return stripped;
+}
+
+export interface LocalPathSegment {
+  /** Raw text to render (keeps the original spelling, escapes intact). */
+  text: string;
+  /** When present, this segment is a clickable local path. */
+  path?: string;
+}
+
+/**
+ * Splits `text` into plain segments and clickable local-path segments.
+ * Pure function — unit tests cover the full recognition matrix here.
+ */
+export function linkifyLocalPaths(text: string): LocalPathSegment[] {
+  const matches: Array<{ start: number; end: number; raw: string; kind: "file" | "drive" | "unc" }> = [];
+  const patterns: Array<[RegExp, "file" | "drive" | "unc"]> = [
+    [FILE_RE, "file"],
+    [DRIVE_RE, "drive"],
+    [UNC_RE, "unc"],
+  ];
+  for (const [re, kind] of patterns) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const match = m;
+      const matchEnd = match.index + match[0].length;
+      // RegExpExecArray has no start/end — compare via index/length.
+      const overlapped = matches.some((p) => !(matchEnd <= p.start || match.index >= p.end));
+      if (!overlapped) {
+        matches.push({ start: match.index, end: matchEnd, raw: match[0], kind });
+      }
+      if (match.index === re.lastIndex) re.lastIndex += 1; // guard against zero-width
+    }
+  }
+  matches.sort((a, b) => a.start - b.start);
+
+  const segments: LocalPathSegment[] = [];
+  let cursor = 0;
+  for (const m of matches) {
+    if (m.start > cursor) segments.push({ text: text.slice(cursor, m.start) });
+    // UNC text arrives with a single leading backslash (markdown folded the
+    // `\\` escape); restore the real UNC prefix for the native opener.
+    const path = m.kind === "unc" ? "\\" + stripTrailingClosers(m.raw) : stripTrailingClosers(m.raw);
+    if (path) {
+      segments.push({ text: m.raw, path: unescapeRefPath(path) });
+    } else {
+      segments.push({ text: m.raw });
+    }
+    cursor = Math.max(cursor, m.end);
+  }
+  if (cursor < text.length) segments.push({ text: text.slice(cursor) });
+  return segments;
+}
+
+/**
+ * Builds the href for a clickable local path. Uses file:/// with forward
+ * slashes (the standard Windows form) and percent-encodes non-ASCII and `#`.
+ * Already-absolute file:/// matches (FILE_RE raw text) are decoded first so
+ * their literal %xx sequences are not double-encoded. The click handler
+ * decodes it back before calling the native opener.
+ */
+export function localPathHref(path: string): string {
+  if (path.startsWith("file:///")) {
+    try {
+      path = decodeURIComponent(path.slice("file:///".length));
+    } catch {
+      // Malformed escapes: keep the literal text rather than failing.
+    }
+  }
+  return "file:///" + encodeURI(path.replace(/\\/g, "/")).replace(/#/g, "%23");
+}
+
+/**
+ * Remark plugin: rewrites plain-text nodes containing local paths into link
+ * nodes (text + link alternation), so the markdown renderer hands them to
+ * RichMarkdownLink which routes them to the native opener.
+ *
+ * Collection and replacement are separate passes: replacing during the visit
+ * would re-visit the freshly inserted link children and nest anchors.
+ */
+export function remarkLocalPathLinks() {
+  return (tree: Root) => {
+    const plan: Array<{ parent: Parent; index: number; nodes: Array<Text | Link> }> = [];
+    visit(tree, "text", (node: Text, index: number | undefined, parent) => {
+      if (parent === undefined || parent === null || index === undefined || index === null) return;
+      // Skip link internals: rewriting their text would nest <a> elements
+      // (mdast forbids links inside links) and double-fire on click.
+      if (parent.type === "link" || parent.type === "linkReference") return;
+      const segments = linkifyLocalPaths(node.value);
+      if (segments.length === 1 && segments[0].path === undefined) return;
+      plan.push({
+        parent,
+        index,
+        nodes: segments.map<Text | Link>((seg) =>
+          seg.path !== undefined
+            ? {
+                type: "link",
+                url: localPathHref(seg.path),
+                title: null,
+                children: [{ type: "text", value: seg.text }],
+              }
+            : { type: "text", value: seg.text },
+        ),
+      });
+    });
+    // Back-to-front keeps earlier indices valid within the same parent.
+    for (let i = plan.length - 1; i >= 0; i--) {
+      const { parent, index, nodes } = plan[i];
+      parent.children.splice(index, 1, ...nodes);
+    }
+  };
+}

--- a/desktop/frontend/src/lib/sessionExportCore.ts
+++ b/desktop/frontend/src/lib/sessionExportCore.ts
@@ -76,6 +76,10 @@ export function transformExportMarkdownUrl(
 ): string {
   const trimmed = value.trim();
   if (key === "src" && isSafeInlineExportImage(trimmed)) return trimmed;
+  // Local-path anchors (file:/// from remarkLocalPathLinks) are kept so an
+  // exported document stays clickable; everything else goes through the
+  // default transform which blanks javascript: etc.
+  if (key === "href" && trimmed.startsWith("file:///")) return trimmed;
   return fallback(value);
 }
 

--- a/desktop/open_local_path.go
+++ b/desktop/open_local_path.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// normalizeLocalOpenPath validates and normalizes a user-clicked local path
+// before it is handed to the OS opener. It accepts either a plain absolute
+// path (D:\a\b.md or D:/a/b.md) or a file:/// URL produced by the markdown
+// linkifier; the frontend decodes percent-escapes before calling
+// OpenLocalPath, so no URL decoding happens here.
+func normalizeLocalOpenPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", os.ErrInvalid
+	}
+	if strings.HasPrefix(path, "file:///") {
+		path = strings.TrimPrefix(path, "file:///")
+	}
+	// Normalize forward slashes (file URLs, slash-form UNC "//nas/share")
+	// to the platform-native separators the opener expects.
+	path = filepath.FromSlash(path)
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("path is not absolute: %q", path)
+	}
+	return path, nil
+}
+
+// openTargetAllowed reports whether a resolved path may be handed to the OS
+// "open" verb. Directories and documents open normally; executable targets
+// are refused because OpenLocalPath is fed by AI-generated chat content —
+// a prompt-injected or hallucinated ".bat" path must not run on click.
+// openWorkspacePath itself stays untouched: it is also used by
+// RevealWorkspacePathForTab with trusted workspace inputs.
+var executableOpenSuffixes = map[string]bool{
+	".bat": true, ".cmd": true, ".com": true, ".exe": true,
+	".ps1": true, ".vbs": true, ".jse": true, ".js": true,
+	".lnk": true, ".url": true, ".scr": true, ".msi": true,
+	".reg": true, ".pif": true, ".hta": true, ".wsf": true,
+}
+
+func openTargetAllowed(path string, isDir bool) bool {
+	if isDir {
+		return true
+	}
+	return !executableOpenSuffixes[strings.ToLower(filepath.Ext(path))]
+}
+
+// OpenLocalPath opens an arbitrary local absolute path (file or directory)
+// with the OS default application. It backs clicking a local path rendered in
+// chat markdown (issue #7426) — Windows drive paths, UNC paths and file:///
+// URLs included. Remote workspaces are rejected: their paths live on another
+// machine and cannot be opened by this desktop app (mirrors
+// RevealWorkspacePathForTab).
+func (a *App) OpenLocalPath(path string) error {
+	path, err := normalizeLocalOpenPath(path)
+	if err != nil {
+		return err
+	}
+	if _, _, _, _, ok := a.activeRemoteWorkbench(); ok {
+		return fmt.Errorf("CAPABILITY_UNAVAILABLE: Remote workspace paths cannot be opened by the Desktop file manager")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !openTargetAllowed(path, info.IsDir()) {
+		return fmt.Errorf("refusing to open executable target %q", path)
+	}
+	return openWorkspacePath(path)
+}

--- a/desktop/open_local_path_test.go
+++ b/desktop/open_local_path_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeLocalOpenPath(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "report.md")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"blank", "   ", ""},
+		{"plain absolute", abs, abs},
+		{"file URL", "file:///" + filepath.ToSlash(abs), abs},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeLocalOpenPath(tc.in)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("normalizeLocalOpenPath(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeLocalOpenPath(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeLocalOpenPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLocalOpenPathRejectsRelative(t *testing.T) {
+	for _, in := range []string{"report.md", "dir/report.md", "file:///report.md", "file:///dir/report.md"} {
+		if _, err := normalizeLocalOpenPath(in); err == nil || !strings.Contains(err.Error(), "not absolute") {
+			t.Fatalf("normalizeLocalOpenPath(%q) err = %v, want not-absolute error", in, err)
+		}
+	}
+}
+
+func TestNormalizeLocalOpenPathWindowsUNC(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC paths are Windows-only")
+	}
+	got, err := normalizeLocalOpenPath(`\\server\share\docs\report.md`)
+	if err != nil {
+		t.Fatalf("UNC path rejected: %v", err)
+	}
+	if got != `\\server\share\docs\report.md` {
+		t.Fatalf("UNC path = %q, want unchanged", got)
+	}
+}
+
+func TestOpenLocalPathRejectsMissingFile(t *testing.T) {
+	a := &App{}
+	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
+	if err := a.OpenLocalPath(missing); err == nil {
+		t.Fatal("OpenLocalPath on a missing path succeeded, want error")
+	}
+}
+
+func TestOpenLocalPathRejectsRelativeAndEmpty(t *testing.T) {
+	a := &App{}
+	if err := a.OpenLocalPath(""); !errors.Is(err, os.ErrInvalid) {
+		t.Fatalf("OpenLocalPath(\"\") err = %v, want os.ErrInvalid", err)
+	}
+	if err := a.OpenLocalPath("relative.md"); err == nil {
+		t.Fatal("OpenLocalPath(relative) succeeded, want error")
+	}
+}
+
+func TestOpenTargetAllowed(t *testing.T) {
+	if !openTargetAllowed(filepath.Join("C:", "docs", "report.md"), false) {
+		t.Fatal("markdown document should be openable")
+	}
+	if !openTargetAllowed(filepath.Join("C:", "docs"), true) {
+		t.Fatal("directory should be openable")
+	}
+	for _, name := range []string{"evil.bat", "evil.cmd", "evil.exe", "evil.ps1", "evil.lnk", "evil.url", "evil.msi", "run.BAT", "EVIL.Scr"} {
+		if openTargetAllowed(filepath.Join("C:", "temp", name), false) {
+			t.Fatalf("executable target %q should be refused", name)
+		}
+	}
+}
+
+func TestOpenLocalPathRejectsExecutable(t *testing.T) {
+	a := &App{}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "clicked.bat")
+	if err := os.WriteFile(script, []byte("@echo off"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.OpenLocalPath(script); err == nil || !strings.Contains(err.Error(), "executable") {
+		t.Fatalf("OpenLocalPath(.bat) err = %v, want executable refusal", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #7426 — file paths printed by the AI in chat replies were not clickable
on Windows. A plain `D:\Project\...\05-静态验收.md` (or a `file:///D:/...`
form) rendered as inert text: clicking did nothing.

**Root cause** (two layers):

1. **Rendering layer** — react-markdown + remark-gfm only autolink
   `http(s)://`, `www.` and email forms. Windows drive paths (`D:\...`) are
   not URLs, and `file:///` is not in the GFM autolink protocol allowlist, so
   both render as plain text nodes with **no click handler at all**.
2. **Click layer** — even when a markdown link *was* produced, every link
   click went through `openExternal` → `BrowserOpenURL` (system browser),
   which is meaningless for local file paths; and there was no backend
   binding able to open an arbitrary local absolute path.

**Fix approach** (3 steps, one per layer):

1. **Recognition** — a new remark plugin (`remarkLocalPathLinks`) rewrites
   plain-text nodes containing local paths into `file:///` links, so the
   renderer hands them to the existing `RichMarkdownLink` component.
2. **Routing** — `RichMarkdownLink` now detects `file:///` hrefs and calls a
   new native binding `OpenLocalPath` instead of the system browser; http
   links keep their previous behavior.
3. **Opening** — a new `OpenLocalPath` backend binding validates the path
   (absolute, local, non-executable) and opens it with the OS default
   application via the existing `openWorkspacePath` (ShellExecuteW "open").

---

## Design details

### `desktop/frontend/src/lib/localPathLinks.ts` (new, core)

**Recognition regexes** operate on parsed markdown text nodes:

- **Drive paths** `D:\x\y.md` / `C:/x/y.md` — with a `(?<![:/A-Za-z])`
  lookbehind so the `e:` inside `file:///` cannot re-match, and drive letter
  is required before `:`.
- **UNC paths** `\\nas\share\docs\report.md` — **critical detail**: the
  plugin runs on *parsed* markdown, and CommonMark backslash escaping folds
  `\\` into `\`, so a share arrives as `\nas\share\...` (single leading
  backslash). The regex matches the folded form and **restores the `\\`
  prefix** so the native opener receives the real UNC path. The leading `\`
  is mandatory and guarded by `(?<![\\/\w:；：，。、！？（）])` so `a\b\c.md`
  prose or `C:\nas` is never mistaken for a share.
- **`file:///` URLs** — matched whole (their `:` is legal there), decoded
  once before re-encoding so literal `%xx` sequences are not double-encoded.

**Punctuation boundaries** — sentence punctuation (`，。；、！？,;!?（）`) is
excluded from the path character class *at match time*, which is far more
reliable than trimming after the fact: `D:\x\y.md。已生成` stops at `。`
correctly, and full-width parens in `（已生成）` no longer get swallowed into
the path. `.` is deliberately kept (extensions) and only stripped when
trailing; a trailing `)` is stripped **only when parens are unbalanced**, so
`C:\Program Files (x86)` keeps its closing paren while `D:\x\y.md).` loses it.

**Escaped spaces** — `D:\a\b\ c.md` keeps the `\ ` pair in the matched text
and unescapes it to the real path (`D:\a\b c.md`) for the opener, consistent
with the existing `@path` grammar in `lib/refToken`.

**No nested anchors** — collection and replacement are separate passes;
replacing during the visit would re-visit freshly inserted link children and
nest `<a>` elements (mdast forbids links inside links), which also double-
fires clicks on explicit `[D:\x\y.md](https://…)` links.

### `desktop/frontend/src/components/MarkdownRenderer.tsx` + `lib/sessionExportCore.ts`

react-markdown v10's default `urlTransform` sanitizer blanks any protocol
outside its allowlist — **including `file:///`** — which silently destroyed
the generated hrefs. Both the live renderer and the export path now keep
`file:///` hrefs and pass everything else through the default transform
(`javascript:` etc. stay blocked).

### `desktop/frontend/src/components/githubLink.tsx`

`openLink` now checks `localPathFromHref` first: `file:///` URLs are decoded
back to a filesystem path and sent to `app.OpenLocalPath`; anything else
keeps the previous `openExternal` path. Malformed percent-escapes yield
`null` and fall through to the browser path.

### `desktop/frontend/src/lib/bridge.ts`

`OpenLocalPath(path): Promise<void>` added to the `AppBindings` interface and
to the dev mock.

### `desktop/open_local_path.go` (new, backend)

- `normalizeLocalOpenPath` — trims, strips a `file:///` prefix, converts
  forward slashes to native separators (`filepath.FromSlash`), and requires
  an absolute path.
- **Remote rejection** — `CAPABILITY_UNAVAILABLE` when the active tab is a
  remote workbench (paths live on another machine), mirroring
  `RevealWorkspacePathForTab`.
- **Executable refusal** — `OpenLocalPath` input is *AI-generated chat
  content* (prompt injection / hallucinated paths are possible), and
  ShellExecute "open" on `.bat/.exe/.ps1/.lnk/.msi/...` executes rather than
  views. A 16-entry suffix blacklist refuses those targets; directories and
  documents open normally. `openWorkspacePath` itself is untouched because it
  is also used with trusted workspace inputs.
- Opens via the existing `openWorkspacePath` (Windows `ShellExecuteW("open")`),
  so the OS default app handles `.md` and every other document type.

---

## Relationship to #6642

PR #6642 makes **manual `@path` references** clickable (user-inserted
tokens). This PR covers **free-form paths the model prints on its own** in
reply text (`D:\...`, `\\server\share\...`, `file:///...`) — the exact
scenario in issue #7426. The two are complementary and share the backend
opening mechanism.

---

## Tests & results

### New test suites

| Suite | Scope | Result |
|---|---|---|
| `local-path-links.test.tsx` (new) | Recognition matrix: drive/UNC/file URL, CJK + ASCII punctuation boundaries, escaped spaces, paren balance `(x86)`, `%xx` round-trip, multi-path text, lookalikes (`C: drive`, `10:30`, `1.2.3`, `http://`), no-nesting guard, `FILE:///` case-sensitivity, href encode/decode round-trip | **48/48 passed** |
| `local-path-click-e2e.test.tsx` (new) | Headless click-to-open: JSDOM document + real production pipeline (ReactMarkdown + remark-gfm + plugin + urlTransform + RichMarkdownLink), real `click` event dispatched, `window.go.main.App.OpenLocalPath` spied | **10/10 passed** |
| `open_local_path_test.go` (new) | normalize (empty/relative/file URL/UNC), remote-agnostic validation, missing path, relative/empty rejection, executable-target refusal | **7/7 passed** |

### e2e assertions (abridged)

    PASS  OpenLocalPath received the decoded CJK path (D:/Project/Jhtj/.../05-静态验收.md)
    PASS  system browser was not involved
    PASS  UNC path forwarded as slash form (//nas/share/docs/report.md)
    PASS  explicit file:/// markdown link opens locally
    PASS  http link went to the system browser
    PASS  OpenLocalPath was not called for the http link

### Regression

- **Frontend related suites**: github-link-rendering 28/28, ref-token 15/15,
  markdown-image-proxy 7/7, mermaid-rendering 61/61, session-export,
  attachment-display 13/13, approval-modal-file-reference 55/55 — all green.
- **`tsc --noEmit`** clean; **eslint** clean on all changed files; **gofmt**
  clean.
- **`go test ./...`** (desktop + sub-packages): full suite green.
- **Full frontend suite (`pnpm test`)**: 3 failures that are **pre-existing
  on clean main-v2** (verified via `git stash` with no local changes):
  `context-window-ring` ×2, `statusbar-workspace` ×1 — unrelated to this PR,
  reported separately.

### Bugs the headless e2e caught that unit tests could not

1. UNC paths never matched in real rendering — CommonMark folds `\\` → `\`
   before the plugin sees the text.
2. `a\b\c.md` prose was misread as a UNC share (optional-prefix regex let a
   word character act as the share name).
3. react-markdown's default `urlTransform` blanked `file:///` hrefs.

---

## Known limitations

- Paths containing unescaped spaces are cut at the space (markdown folding
  also collapses `\ `), matching the existing `@path` convention: use
  backticks or the `@path` reference for spaces.
- `file://server/share` (single-slash host form) is not recognized; the
  canonical `\\server\share` and `file:///C:/...` forms are.
- File names that literally contain sentence punctuation (`D:\a,b.md`) are
  cut at the punctuation — rare, and `@path` is the workaround.
- "Open" of the file itself was verified through the full click chain down
  to the binding boundary; the final `ShellExecuteW` call is standard
  behavior already exercised by the existing workspace-open feature.
Documentation-impact: none - bug fix confined to desktop chat markdown rendering and a new desktop opener binding; no user-facing docs describe path-click behavior, so existing docs remain correct.