### PR TITLE
fix(desktop): move the workspace toggle to the end of the topic bar

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4539,24 +4539,6 @@ export default function App() {
             </div>
             <div className="topicbar__spacer" />
             <div className="topicbar__actions">
-              {workbenchChromeHidden && (
-                <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>
-                  <button
-                    className={[
-                      "topicbar__chrome-btn",
-                      "topicbar__chrome-btn--workspace",
-                      workspacePanelRenderable ? "topicbar__chrome-btn--active" : "",
-                      workspaceTogglePressed ? "topicbar__chrome-btn--pressed" : "",
-                    ].filter(Boolean).join(" ")}
-                    type="button"
-                    onClick={toggleWorkspacePanel}
-                    aria-label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
-                    aria-pressed={workspacePanelRenderable}
-                  >
-                    <PanelRight size={15} />
-                  </button>
-                </Tooltip>
-              )}
               {sidebarCreation && !sidebarImDetailConnection && activeTab?.scope === "project" && (
                 <ExternalOpener tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
               )}
@@ -4666,7 +4648,7 @@ export default function App() {
                   {!sidebarCreation && <span>{t("topicBar.command")}</span>}
                 </button>
               </Tooltip>
-              {sidebarCreation && (
+              {(sidebarCreation || workbenchChromeHidden) && (
                 <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>
                   <button
                     className={[


### PR DESCRIPTION
## Summary

The workspace collapse/expand control was rendered as the **first** child of `.topicbar__actions` under the Workbench layout, which puts it left of copy, export, changed, terminal, the shortcut help and the command palette — so it reads as mid-bar rather than as the edge control for the panel it opens.

The Creation layout already rendered the same button last, from a duplicate JSX block. So the two layouts disagreed on where the same control lives, for no reason other than the duplication.

Render one block at the end, gated on `sidebarCreation || workbenchChromeHidden`. Same markup, same classes, same handler — it just stops being first in Workbench, and the duplicate goes away.

## Issues

Refs #4743

## Verification

- The change is a JSX move within one parent; the `.topicbar__chrome-btn` rules carry no positional selectors (`:first-child`/`:nth-*`), so the Creation-specific styling at `.app--creation .topicbar__actions .topicbar__chrome-btn--workspace` still matches.
- Frontend typecheck and tests run in CI (this worktree has no `node_modules`).

## Documentation impact

Documentation-impact: none - control placement within an existing toolbar; no documented behavior, shortcut, or setting changes.
