### PR TITLE
docs(release): 准备 v1.19.6 中英更新日志

### DIFF
--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -31,7 +31,7 @@
             "en": "Use /docs to access version-matched product documentation directly in Reasonix.",
             "zh": "使用 /docs 直接在 Reasonix 中访问版本匹配的产品文档。"
           },
-          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/36d697587c3deb7f3d1c881d0a959c62111a8314/docs/GUIDE.md"
+          "href": "https://github.com/esengine/DeepSeek-Reasonix/blob/786dc6d33e5ee396f17a3b7e936b803008deaa96/docs/GUIDE.md"
         }
       ],
       "highlights": [
@@ -535,6 +535,19 @@
             },
             "refs": [
               7468
+            ]
+          },
+          {
+            "title": {
+              "en": "Changes panel uses readable Git status labels",
+              "zh": "改动面板显示易读的 Git 状态"
+            },
+            "body": {
+              "en": "Changed files now show localized labels such as Modified, Untracked, and Conflict instead of raw porcelain codes like MM and ??.",
+              "zh": "改动文件现在显示“已修改”“未跟踪”“冲突”等本地化标签，而不再直接展示 MM、?? 等原始状态码。"
+            },
+            "refs": [
+              7469
             ]
           },
           {


### PR DESCRIPTION
> 此版本带来内置版本匹配文档、事务性回滚、更安全的子代理清理以及大量桌面和 CLI 修复。

**发布渠道：稳定版 · v1.19.6**

[English →](https://reasonix.io/changelog/v1.19.6/?lang=en) · [网页版完整更新日志 →](https://reasonix.io/changelog/v1.19.6/)

## 使用攻略

- [**内置文档**](https://github.com/esengine/DeepSeek-Reasonix/blob/786dc6d33e5ee396f17a3b7e936b803008deaa96/docs/GUIDE.md) — 使用 /docs 直接在 Reasonix 中访问版本匹配的产品文档。

## 概览

**Reasonix v1.19.6 — 版本化文档、事务性回滚与更安全的恢复**

此版本带来内置版本匹配文档、事务性回滚、更安全的子代理清理以及大量桌面和 CLI 修复。

发布日期：2026-08-04

## 重点内容

- **内置版本匹配文档** — 使用 /docs 命令直接在 Reasonix 中访问官方产品文档和发布历史。内置文档工具在 AI 撰写答案前检索版本匹配的证据。 ([#7402](https://github.com/esengine/DeepSeek-Reasonix/pull/7402))
- **事务性回滚与单文件还原** — 回滚操作现在使用持久事务，具有 SHA-256 验证的 blob、崩溃恢复和冲突检测。代码回滚和单文件会话还原均支持撤销。 ([#7356](https://github.com/esengine/DeepSeek-Reasonix/pull/7356))
- **更安全的子代理清理与启动** — 子代理清理不再导致误启动错误或因损坏的元数据而阻塞。每次控制器构建时都会通过父会话活跃探测清理过时的子代理。 ([#7405](https://github.com/esengine/DeepSeek-Reasonix/pull/7405), [#7225](https://github.com/esengine/DeepSeek-Reasonix/pull/7225))
- **桌面与 CLI 质量改进** — 中键关闭标签页、统一的 token 显示、工作区配置覆盖警告以及众多布局和权限修复改善了日常体验。 ([#4330](https://github.com/esengine/DeepSeek-Reasonix/pull/4330), [#7404](https://github.com/esengine/DeepSeek-Reasonix/pull/7404), [#7413](https://github.com/esengine/DeepSeek-Reasonix/pull/7413), [#7362](https://github.com/esengine/DeepSeek-Reasonix/pull/7362), [#7437](https://github.com/esengine/DeepSeek-Reasonix/pull/7437), [#7430](https://github.com/esengine/DeepSeek-Reasonix/pull/7430), [#7317](https://github.com/esengine/DeepSeek-Reasonix/pull/7317))
- **更新器与恢复修复** — 孤立的 macOS 应用备份现在可恢复，残留的待处理更新不再阻塞后续更新或强制安全模式。 ([#7369](https://github.com/esengine/DeepSeek-Reasonix/pull/7369), [#7366](https://github.com/esengine/DeepSeek-Reasonix/pull/7366))

## 新功能

- **内置版本匹配文档** — 使用 /docs 命令直接在 Reasonix 中访问官方产品文档和发布历史。 ([#7402](https://github.com/esengine/DeepSeek-Reasonix/pull/7402))
- **事务性回滚与单文件还原** — 回滚操作现在使用持久事务，具有 SHA-256 验证的 blob、崩溃恢复和冲突检测。 ([#7356](https://github.com/esengine/DeepSeek-Reasonix/pull/7356))
- **中键关闭标签页** — 用中键点击标签页即可关闭，符合常见浏览器行为。 ([#4330](https://github.com/esengine/DeepSeek-Reasonix/pull/4330))
- **统一的 token 显示格式** — token 计数现在在作曲器和上下文面板中使用一致的 K/M 缩写。 ([#7404](https://github.com/esengine/DeepSeek-Reasonix/pull/7404))
- **精简的创作欢迎页** — 空会话欢迎页现在显示居中的 hero 输入框，仅保留模型选择。 ([#7317](https://github.com/esengine/DeepSeek-Reasonix/pull/7317))

## 改进

- **更安全的子代理清理** — 子代理清理不再导致误启动错误或因损坏的元数据而阻塞。 ([#7405](https://github.com/esengine/DeepSeek-Reasonix/pull/7405), [#7225](https://github.com/esengine/DeepSeek-Reasonix/pull/7225))
- **工作区配置覆盖警告** — 设置面板现在会在工作区 reasonix.toml 覆盖用户配置时发出警告。 ([#7413](https://github.com/esengine/DeepSeek-Reasonix/pull/7413))
- **响应式设置布局** — 设置页面现在在窄窗口下正确换行，防止溢出和错位。 ([#7362](https://github.com/esengine/DeepSeek-Reasonix/pull/7362))
- **破坏性 git 命令分类** — git restore 和 git stash drop 等命令现在显示危险警告，并每次都需要重新批准。 ([#7437](https://github.com/esengine/DeepSeek-Reasonix/pull/7437))
- **CLI /status 显示活动配置文件** — /status 命令现在报告当前生效的配置文件。 ([#7393](https://github.com/esengine/DeepSeek-Reasonix/pull/7393))
- **CLI 中使用 Ctrl+箭头移动单词** — 在 Windows 和 Linux 上，Ctrl+左/右箭头现在可在作曲器中按单词移动。 ([#7390](https://github.com/esengine/DeepSeek-Reasonix/pull/7390))
- **Windows 控制台 ANSI 支持** — 旧版 Windows 控制台现在可在 setup 和 config 命令中正确显示彩色输出。 ([#7387](https://github.com/esengine/DeepSeek-Reasonix/pull/7387))
- **恢复通知不再发送到 IM 聊天** — 内部恢复通知不再转发到微信、QQ 或飞书对话。 ([#7421](https://github.com/esengine/DeepSeek-Reasonix/pull/7421))
- **子代理列表显示开始时间** — 子代理的 CreatedAt 现在反映实际生成时间而非完成时间。 ([#7309](https://github.com/esengine/DeepSeek-Reasonix/pull/7309))
- **CLI 恢复会话分组** — 冲突恢复副本现在与其源会话分组，并标有简短的父 ID。 ([#7344](https://github.com/esengine/DeepSeek-Reasonix/pull/7344))
- **构建输出从 @ 补全中排除** — target、__pycache__、venv 等生成目录不再出现在文件补全中。 ([#7401](https://github.com/esengine/DeepSeek-Reasonix/pull/7401))
- **项目 provider_access 不再隐藏用户提供者** — 仅项目级别的 provider_access 列表不再在模型切换器中隐藏账户级提供者。 ([#7395](https://github.com/esengine/DeepSeek-Reasonix/pull/7395))
- **无法解析提供者时规划器模型降级** — 当 planner_model 指定未知提供者时，桌面现在会发出警告并仅使用执行器继续运行。 ([#7434](https://github.com/esengine/DeepSeek-Reasonix/pull/7434))
- **已删除的工作区文件夹不再重新创建** — 在资源管理器中删除工作区文件夹不再导致 Reasonix 在启动时重新创建它。 ([#7432](https://github.com/esengine/DeepSeek-Reasonix/pull/7432))
- **全局钩子迁移** — settings.json 中的全局钩子现在迁移到新的配置目录。 ([#7445](https://github.com/esengine/DeepSeek-Reasonix/pull/7445))
- **TUI 长批准命令显示** — 等待批准的长命令现在在 TUI 中换行显示，而不是被截断。 ([#7447](https://github.com/esengine/DeepSeek-Reasonix/pull/7447))
- **递归 Glob 遍历支持超时** — 递归 Glob 搜索现在默认 30 秒超时，并返回明确标记的不完整结果，避免长时间占用当前对话轮次。 ([#7455](https://github.com/esengine/DeepSeek-Reasonix/pull/7455))

## 修复

- **孤立的 macOS 更新器备份恢复** — 中断的更新不再留下永久备份阻塞后续更新。 ([#7369](https://github.com/esengine/DeepSeek-Reasonix/pull/7369))
- **待处理更新残留恢复** — 无效的待处理更新标记现在会被清理，而不是强制安全模式。 ([#7366](https://github.com/esengine/DeepSeek-Reasonix/pull/7366))
- **npm 依赖安全告警已解决** — 桌面和 worker 依赖中所有 24 个开放的 Dependabot 告警已解决。 ([#7446](https://github.com/esengine/DeepSeek-Reasonix/pull/7446))
- **CLI 升级 GitHub 认证** — reasonix upgrade 现在使用 GITHUB_TOKEN 进行认证的 GitHub API 请求，避免速率限制。 ([#7418](https://github.com/esengine/DeepSeek-Reasonix/pull/7418))
- **提供者流错误可定位异常载荷** — 当网关发送无效 SSE 数据时，解码错误现在会标明提供者，并附带长度受限的异常载荷片段。 ([#7461](https://github.com/esengine/DeepSeek-Reasonix/pull/7461))
- **遵循更长的 Retry-After 等待时间** — 限流响应现在可将重试延迟到最长 60 秒，并支持 HTTP-date 格式的 Retry-After，避免在限流窗口内耗尽重试次数。 ([#7459](https://github.com/esengine/DeepSeek-Reasonix/pull/7459))
- **对话元素跟随文字大小设置** — 思考标题、工具卡片、附件、记忆引用和行内编辑现在会随对话文字大小设置同步缩放。 ([#7457](https://github.com/esengine/DeepSeek-Reasonix/pull/7457))
- **Windows 可识别异常子代理存储** — 当文件占用子代理存储路径时，Windows 现在会正确报告错误，而不会将其误判为存储目录不存在。 ([#7456](https://github.com/esengine/DeepSeek-Reasonix/pull/7456))
- **会话预览优先显示实际请求** — 以文件引用开头的提示词现在会使用后续请求文本生成会话预览和侧边栏标题，而不再只显示文件路径。 ([#7464](https://github.com/esengine/DeepSeek-Reasonix/pull/7464))
- **工作区切换按钮与面板边缘对齐** — 工作区折叠与展开按钮现在在 Workbench 和 Creation 布局中都位于主题栏操作区末端。 ([#7468](https://github.com/esengine/DeepSeek-Reasonix/pull/7468))
- **改动面板显示易读的 Git 状态** — 改动文件现在显示“已修改”“未跟踪”“冲突”等本地化标签，而不再直接展示 MM、?? 等原始状态码。 ([#7469](https://github.com/esengine/DeepSeek-Reasonix/pull/7469))
- **ACP session/set_config_option 文档** — ACP 文档现在正确记录了 configId 参数。 ([#7359](https://github.com/esengine/DeepSeek-Reasonix/pull/7359))

## 升级提醒

本版本无需手动迁移。

## 风险提示

当前没有需要额外操作的已知风险。

## 致谢

感谢本版本的贡献者：[@SivanCola](https://github.com/SivanCola)、[@esengine](https://github.com/esengine)、[@zdjmrq](https://github.com/zdjmrq)、[@Li-Charles-One](https://github.com/Li-Charles-One)、[@Lxiny-zy](https://github.com/Lxiny-zy)、[@skyzhao1223](https://github.com/skyzhao1223)、[@HaoyueQin](https://github.com/HaoyueQin)、[@HBLADEH](https://github.com/HBLADEH)、[@tic-top](https://github.com/tic-top)

## 下载与安装

- [官网按平台下载](https://reasonix.io/?download=desktop&channel=stable#start)
- [查看完整差异](https://github.com/esengine/DeepSeek-Reasonix/compare/desktop-v1.19.5...desktop-v1.19.6)
