### PR TITLE
fix(desktop): zoom on title-bar double click on macOS

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4125,8 +4125,12 @@ export default function App() {
   const topicbarCanRename = !sidebarImDetailConnection && Boolean(activeTab?.topicId);
   const topicbarTitleEditSize = Math.min(56, Math.max(4, topicTitleDraft.length || topicbarTitle.length || 1));
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
-  const handleWindowsTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
-    if (!windowsFramelessChrome) return;
+  // The Wails drag runtime ignores anything with detail !== 1, so a double click
+  // on a --wails-draggable region never reaches the OS. Both platforms that hide
+  // their native title bar need this handled here.
+  const chromeDoubleClickZooms = windowsFramelessChrome || desktopPlatform === "darwin";
+  const handleChromeTitlebarDoubleClick = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    if (!chromeDoubleClickZooms) return;
     const target = event.target as HTMLElement | null;
     if (!target?.closest(".app-chrome, .topicbar, .workbench-dock__tools")) return;
     if (target.closest("button, input, textarea, select, a, [role='button'], [role='tab'], .windows-window-controls")) return;
@@ -4134,7 +4138,7 @@ export default function App() {
     void app.ToggleMaximiseMainWindow()
       .then(() => window.setTimeout(syncMainWindowMaximised, 80))
       .catch(() => undefined);
-  }, [syncMainWindowMaximised, windowsFramelessChrome]);
+  }, [chromeDoubleClickZooms, syncMainWindowMaximised]);
   // Creation keeps the classic sidebar/chat structure while gating chrome tweaks
   // behind its own style flag so classic/workbench remain unchanged.
   const appChromeHidden = sidebarWorkbench || sidebarCreation;
@@ -4152,7 +4156,7 @@ export default function App() {
     <TextSizeHotkeys />
       <div
         ref={appRef}
-        onDoubleClickCapture={handleWindowsTitlebarDoubleClick}
+        onDoubleClickCapture={handleChromeTitlebarDoubleClick}
         className={[
         "app",
         `app--${desktopPlatform}`,

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -796,5 +796,17 @@ ok(
   "offscreen skip link does not leak its focus shadow into the workbench title area",
 );
 
+// The Wails drag runtime drops any mousedown with detail !== 1, so a double
+// click on a drag region never reaches the OS: both title-bar-hiding platforms
+// have to zoom from here or not at all.
+ok(
+  /chromeDoubleClickZooms\s*=\s*windowsFramelessChrome\s*\|\|\s*desktopPlatform === "darwin"/.test(appSource),
+  "title-bar double click zooms on macOS as well as frameless Windows",
+);
+ok(
+  /handleChromeTitlebarDoubleClick[\s\S]{0,400}?closest\("button, input, textarea, select, a, \[role='button'\], \[role='tab'\], \.windows-window-controls"\)/.test(appSource),
+  "title-bar double click still ignores interactive controls",
+);
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

macOS runs with `mac.TitleBarHiddenInset()`, so the header the user sees is our own markup, not the system title bar. Double-clicking it did nothing.

The reason isn't a missing CSS region — it's the Wails drag runtime itself:

```js
if (e.detail !== 1) {
    // Do not start dragging if more than once has been clicked, e.g. when double clicking
    return false;
}
```

`--wails-draggable` deliberately ignores anything past the first click and does not forward it to the OS, so zoom-on-double-click can only come from the app. Windows already did this via `handleWindowsTitlebarDoubleClick`; macOS, which hides its title bar the same way, had no equivalent.

Gate the existing handler on `windowsFramelessChrome || desktopPlatform === "darwin"` instead of Windows alone. Same surfaces (`.app-chrome`, `.topicbar`, `.workbench-dock__tools`), same exclusion of buttons/inputs/tabs, same `WindowToggleMaximise` call — which is AppKit's zoom on macOS, i.e. what double-clicking a title bar is supposed to do. Linux keeps its native title bar and is unaffected.

This does not address the other half of #4755 (the draggable region being narrower than expected on macOS); that stays open.

## Issues

Refs #4755

## Verification

- `tsx src/__tests__/app-chrome-tabs.test.ts` — 127 passed, including two new assertions: the handler covers darwin as well as frameless Windows, and it still ignores interactive controls.

## Documentation impact

Documentation-impact: none - restores a standard platform window gesture; no documented behavior, shortcut, or setting changes.
