### PR TITLE
fix(sysproxy): record why Windows proxy detection fell through

### DIFF
--- a/internal/sysproxy/system_windows.go
+++ b/internal/sysproxy/system_windows.go
@@ -3,6 +3,7 @@
 package sysproxy
 
 import (
+	"log/slog"
 	"net/url"
 	"strings"
 	"unsafe"
@@ -59,7 +60,12 @@ func ForURL(target *url.URL) (*url.URL, error) {
 		return nil, nil
 	}
 	var ie ieProxyConfig
-	if r, _, _ := procGetIEProxyConfig.Call(uintptr(unsafe.Pointer(&ie))); r == 0 {
+	if r, _, callErr := procGetIEProxyConfig.Call(uintptr(unsafe.Pointer(&ie))); r == 0 {
+		// A service account or an RDP session with no per-user IE config fails
+		// here, which is indistinguishable from "system is set to direct"
+		// unless the errno is recorded (#4798).
+		slog.Debug("sysproxy: WinHttpGetIEProxyConfigForCurrentUser failed",
+			"err", callErr, "host", target.Hostname())
 		return nil, nil
 	}
 	defer globalFree(ie.lpszProxy)
@@ -84,6 +90,11 @@ func ForURL(target *url.URL) (*url.URL, error) {
 			return u, nil
 		}
 	}
+	slog.Debug("sysproxy: no system proxy applies; using a direct connection",
+		"host", target.Hostname(),
+		"static_proxy", ie.lpszProxy != nil,
+		"auto_detect", ie.fAutoDetect != 0,
+		"pac_url", ie.lpszAutoConfigURL != nil)
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

`sysproxy.ForURL` is the fallback that lets a corporate Windows machine reach the API without anyone setting `HTTP_PROXY` by hand. When it fails it returns `nil, nil` — the same thing it returns when the system genuinely has no proxy. From the outside those are identical, so "the proxy stopped working" arrives as a report with nothing to act on.

Two silent paths, both from #4798:

- `WinHttpGetIEProxyConfigForCurrentUser` failing. This is the one that matters: a service account or an RDP/cloud-desktop session with no per-user IE configuration fails here even when the machine is behind a proxy. The syscall's errno was discarded.
- Everything resolving to direct. Whether the static proxy, WPAD auto-detect or a PAC URL was even present was not recorded, so there's no way to tell "no proxy configured" from "PAC lookup returned nothing".

Both now log at debug with the host and what was found. No behavior change — the resolver returns exactly what it returned before, and a direct connection is still the fallback.

## Issues

Refs #4798

## Verification

- `go build ./...`, `go vet ./internal/sysproxy/ ./internal/netclient/`, `gofmt -l`
- `go test ./internal/sysproxy/ ./internal/netclient/`

No new test: the change is two `slog.Debug` calls on a path whose only branch condition is a Windows syscall result, and this package deliberately does not exercise the real registry or WinHTTP from unit tests.

## Documentation impact

Documentation-impact: none - debug logging only; proxy resolution order and configuration are unchanged.
