### PR TITLE
docs(desktop): correct the Windows signing state

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -154,22 +154,23 @@ not depend on homepage badge semantics. Self-update behavior by platform:
   in-place swap would be blocked by Gatekeeper; the banner links to the download
   page for a manual update instead.
 
-### Unsigned builds — first launch
+### Code signing — first launch
 
-There are no Apple/Windows code-signing certificates yet, so a downloaded build
-trips the OS gatekeepers on first run:
-
-- **macOS** — open `Reasonix-darwin-universal.dmg` and drag Reasonix into
-  Applications. Gatekeeper may then report the app "is damaged" or is from an
-  unidentified developer; clear the quarantine attribute and open it:
+- **Windows** — stable builds carry an Authenticode signature (SignPath, approved
+  per release; `release-desktop.yml` verifies every payload binary through
+  `scripts/verify-windows-authenticode.ps1` and fails the release otherwise). A
+  brand-new version can still show SmartScreen until the signature accumulates
+  reputation: *More info → Run anyway*.
+- **macOS** — still unsigned and un-notarized. Open
+  `Reasonix-darwin-universal.dmg`, drag Reasonix into Applications, then clear the
+  quarantine attribute when Gatekeeper reports the app "is damaged" or is from an
+  unidentified developer:
   ```sh
   xattr -dr com.apple.quarantine /Applications/Reasonix.app
   ```
-- **Windows** — SmartScreen shows "Windows protected your PC". Click *More info →
-  Run anyway*.
-
-When Developer ID / Authenticode certificates are added, the release workflow's
-`HAS_APPLE_CERT` gate flips to the signed path and these steps go away.
+  This is also why macOS has no in-place self-update: the swap would be blocked.
+  Adding a Developer ID certificate flips the release workflow's `HAS_APPLE_CERT`
+  gate to the signed path and removes both.
 
 ### Verifying a download
 


### PR DESCRIPTION
## Summary

`desktop/README.md` still said "There are no Apple/Windows code-signing certificates yet". That has been wrong for Windows since `desktop-v1.14.1`: stable builds are Authenticode-signed through SignPath with per-release approval, and `release-desktop.yml` runs `scripts/verify-windows-authenticode.ps1` over the payload and fails the release if anything is unsigned.

It isn't a harmless stale line — in #4798 a reporter on a locked-down cloud desktop read it (plus `.goreleaser.yaml`, which builds the CLI, not the desktop app) and concluded that unsigned binaries were being blocked from making outbound connections, then filed a signing proposal for a problem that turned out to be proxy resolution.

Rewritten as two separate statements: Windows is signed (and may still trip SmartScreen on a new version until the signature builds reputation), macOS is genuinely unsigned and un-notarized — which is also why macOS has no in-place self-update.

## Issues

Refs #4798

## Verification

- Cross-checked against `.github/workflows/release-desktop.yml` (SignPath contract validation, trust verification) and `scripts/verify-windows-authenticode.ps1`.
- `grep` for other "unsigned" claims in `desktop/README.md`, `README.md`, `README.zh-CN.md`: the only remaining one is the macOS self-update note, which is still accurate.

## Documentation impact

Documentation-impact: none - the signing pipeline's own documentation, `docs/SIGNPATH_WINDOWS_ADMIN_SOP.md`, already describes the Authenticode chain correctly and needs no change; this PR only removes a contradicting claim from the developer README beside it. No `docs/*.md` states the outdated position.
