### PR TITLE
fix(release): load npm recovery control plane

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -120,6 +120,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.approved_sha || inputs.tag || github.ref }}
+      - name: Load approved standalone recovery control plane
+        if: ${{ !inputs.orchestrated }}
+        env:
+          RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$RECOVERY_CONTROL_SHA"
+          git restore --source="$RECOVERY_CONTROL_SHA" -- \
+            npm/publish.mjs \
+            scripts/finalize-npm-official-release.mjs
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -156,6 +156,13 @@ if sed -n '/^  workflow_dispatch:/,/^  workflow_call:/p' "$repo_root/.github/wor
 fi
 grep -Fq 'if: ${{ !inputs.orchestrated }}' "$repo_root/.github/workflows/release-npm.yml"
 grep -Fq 'Publish or recover immutable npm packages' "$repo_root/.github/workflows/release-npm.yml"
+grep -Fq 'RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}' \
+	"$repo_root/.github/workflows/release-npm.yml"
+grep -Fq 'git restore --source="$RECOVERY_CONTROL_SHA"' \
+	"$repo_root/.github/workflows/release-npm.yml"
+for recovery_script in npm/publish.mjs scripts/finalize-npm-official-release.mjs; do
+	grep -Fq "$recovery_script" "$repo_root/.github/workflows/release-npm.yml"
+done
 grep -Fq 'publishPackages' "$repo_root/npm/build.mjs"
 grep -Eq 'signing-policy-slug: release-signing' "$repo_root/.github/workflows/release-desktop.yml"
 if grep -Eq 'signing-policy-slug:.*test-signing' "$repo_root/.github/workflows/release-desktop.yml"; then


### PR DESCRIPTION
## Summary

- keep standalone npm recovery checked out at the immutable release candidate for builds and provenance
- load only the approved workflow SHA versions of the resumable publisher and alias finalizer
- leave normal orchestrated publication unchanged

## Release recovery

The first v1.19.6 recovery still executed the candidate-era publisher because checkout replaced the workspace with `npm-v1.19.6`. This makes the approved recovery control plane effective without changing the candidate HEAD or package source.

Documentation-impact: none - existing release documentation already defines standalone npm recovery; this fixes which approved control scripts that recovery executes.

## Tests

- `bash scripts/release-workflows.test.sh`