### PR TITLE
feat(evidence): recognize swift test as a delivery verification command

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1804,9 +1804,11 @@ func bashSegmentIsVerification(fields []string) bool {
 		return len(args) > 0 && args[0] == "test"
 	case "swift":
 		// swift test runs the SwiftPM test suite without emitting build
-		// artifacts beyond the package's own .build directory; other swift
-		// subcommands (build/run/package) can write binaries or mutate the
-		// package, so only the test form is a recognized verifier.
+		// artifacts beyond the package's own .build directory (including
+		// --enable-code-coverage coverage reports, which stay under .build);
+		// other swift subcommands (build/run/package) can write binaries or
+		// mutate the package, so only the test form is a recognized verifier.
+		// Explicit report destinations are rejected by writeOutputFlags.
 		return len(args) > 0 && args[0] == "test"
 	case "mvn", "mvnw", "gradle", "gradlew":
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")
@@ -2054,6 +2056,7 @@ var writeOutputFlags = map[string]bool{
 	"gocoverdir":      true, // go test binary
 	"outputfile":      true, // jest/vitest --outputFile (with --json)
 	"report-log":      true, // pytest-reportlog
+	"xunit-output":    true, // swift test --xunit-output writes a JUnit XML report
 }
 
 func hasWriteOutputFlag(args []string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1719,6 +1719,7 @@ func verificationCommandRecommendations() []verificationCommandRecommendation {
 		{label: "make|just test|check|lint|verify|ci", examples: []string{"make test", "just verify"}},
 		{label: "python -m pytest|unittest", examples: []string{"python -m pytest", "python -m unittest"}},
 		{label: "dotnet test", examples: []string{"dotnet test"}},
+		{label: "swift test", examples: []string{"swift test"}},
 		{label: "mvn|gradle test|check|verify", examples: []string{"mvn test", "gradle check"}},
 	}
 }
@@ -1800,6 +1801,12 @@ func bashSegmentIsVerification(fields []string) bool {
 	case "python", "python3":
 		return len(args) > 1 && args[0] == "-m" && hasCommandArg(args[1:2], "pytest", "unittest")
 	case "dotnet":
+		return len(args) > 0 && args[0] == "test"
+	case "swift":
+		// swift test runs the SwiftPM test suite without emitting build
+		// artifacts beyond the package's own .build directory; other swift
+		// subcommands (build/run/package) can write binaries or mutate the
+		// package, so only the test form is a recognized verifier.
 		return len(args) > 0 && args[0] == "test"
 	case "mvn", "mvnw", "gradle", "gradlew":
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1807,8 +1807,10 @@ func bashSegmentIsVerification(fields []string) bool {
 		// the package's own .build directory (including --enable-code-coverage
 		// reports). Other swift subcommands (build/run/package) can write
 		// binaries or mutate the package, so only the test form is a
-		// recognized verifier. Explicit report destinations and scratch-dir
-		// redirects are rejected by writeOutputFlags.
+		// recognized verifier. Explicit report destinations, attachment dirs,
+		// and scratch-dir redirects are rejected by writeOutputFlags. Note
+		// that swift test may run Package.swift build plugins (arbitrary
+		// code) — the same trust boundary as go test / cargo test.
 		return len(args) > 0 && args[0] == "test"
 	case "mvn", "mvnw", "gradle", "gradlew":
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")
@@ -2059,6 +2061,10 @@ var writeOutputFlags = map[string]bool{
 	"xunit-output":    true, // swift test --xunit-output writes a JUnit XML report
 	"scratch-path":    true, // swift test --scratch-path redirects the build dir
 	"build-path":      true, // swift test --build-path: legacy alias of --scratch-path
+	"event-stream-output-path":           true, // swift test (Swift 6.x): swift-testing JSON output
+	"experimental-event-stream-output":   true, // swift test (Swift 6.x): experimental event-stream output
+	"attachments-path":                   true, // swift test (Swift 6.x): Swift Testing attachments dir
+	"experimental-attachments-path":      true, // swift test (Swift 6.x): experimental attachments dir
 }
 
 func hasWriteOutputFlag(args []string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1803,12 +1803,12 @@ func bashSegmentIsVerification(fields []string) bool {
 	case "dotnet":
 		return len(args) > 0 && args[0] == "test"
 	case "swift":
-		// swift test runs the SwiftPM test suite without emitting build
-		// artifacts beyond the package's own .build directory (including
-		// --enable-code-coverage coverage reports, which stay under .build);
-		// other swift subcommands (build/run/package) can write binaries or
-		// mutate the package, so only the test form is a recognized verifier.
-		// Explicit report destinations are rejected by writeOutputFlags.
+		// swift test runs the SwiftPM test suite; build artifacts stay under
+		// the package's own .build directory (including --enable-code-coverage
+		// reports). Other swift subcommands (build/run/package) can write
+		// binaries or mutate the package, so only the test form is a
+		// recognized verifier. Explicit report destinations and scratch-dir
+		// redirects are rejected by writeOutputFlags.
 		return len(args) > 0 && args[0] == "test"
 	case "mvn", "mvnw", "gradle", "gradlew":
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")
@@ -2057,6 +2057,7 @@ var writeOutputFlags = map[string]bool{
 	"outputfile":      true, // jest/vitest --outputFile (with --json)
 	"report-log":      true, // pytest-reportlog
 	"xunit-output":    true, // swift test --xunit-output writes a JUnit XML report
+	"scratch-path":    true, // swift test --scratch-path redirects the build dir (--build-path is its legacy alias)
 }
 
 func hasWriteOutputFlag(args []string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -2057,7 +2057,8 @@ var writeOutputFlags = map[string]bool{
 	"outputfile":      true, // jest/vitest --outputFile (with --json)
 	"report-log":      true, // pytest-reportlog
 	"xunit-output":    true, // swift test --xunit-output writes a JUnit XML report
-	"scratch-path":    true, // swift test --scratch-path redirects the build dir (--build-path is its legacy alias)
+	"scratch-path":    true, // swift test --scratch-path redirects the build dir
+	"build-path":      true, // swift test --build-path: legacy alias of --scratch-path
 }
 
 func hasWriteOutputFlag(args []string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1811,7 +1811,22 @@ func bashSegmentIsVerification(fields []string) bool {
 		// and scratch-dir redirects are rejected by writeOutputFlags. Note
 		// that swift test may run Package.swift build plugins (arbitrary
 		// code) — the same trust boundary as go test / cargo test.
-		return len(args) > 0 && args[0] == "test"
+		if len(args) == 0 || args[0] != "test" {
+			return false
+		}
+		// Control modes that do not run the test suite (help, listing) must
+		// not count as verification; mirror the tsc treatment of --help.
+		for _, arg := range args[1:] {
+			name := strings.TrimLeft(strings.ToLower(arg), "-")
+			if i := strings.IndexByte(name, '='); i >= 0 {
+				name = name[:i]
+			}
+			switch name {
+			case "help", "h", "version", "list-tests", "l":
+				return false
+			}
+		}
+		return true
 	case "mvn", "mvnw", "gradle", "gradlew":
 		return len(args) > 0 && hasCommandArg(args, "test", "check", "verify")
 	}
@@ -2043,28 +2058,29 @@ func hasCommandArg(args []string, candidates ...string) bool {
 // A runner invoked with one of them changes workspace state, so the segment
 // must not count as read-only verification.
 var writeOutputFlags = map[string]bool{
-	"snapshot-update": true, // pytest-snapshot / syrupy
-	"updatesnapshot":  true, // jest --updateSnapshot via npm/yarn wrappers
-	"junitxml":        true, // pytest
-	"junit-xml":       true, // pytest / mypy
-	"junitfile":       true, // gotestsum
-	"jsonfile":        true, // gotestsum
-	"coverprofile":    true, // go test
-	"cpuprofile":      true, // go test
-	"memprofile":      true, // go test
-	"blockprofile":    true, // go test
-	"mutexprofile":    true, // go test
-	"testlogfile":     true, // go test binary
-	"gocoverdir":      true, // go test binary
-	"outputfile":      true, // jest/vitest --outputFile (with --json)
-	"report-log":      true, // pytest-reportlog
-	"xunit-output":    true, // swift test --xunit-output writes a JUnit XML report
-	"scratch-path":    true, // swift test --scratch-path redirects the build dir
-	"build-path":      true, // swift test --build-path: legacy alias of --scratch-path
-	"event-stream-output-path":           true, // swift test (Swift 6.x): swift-testing JSON output
-	"experimental-event-stream-output":   true, // swift test (Swift 6.x): experimental event-stream output
-	"attachments-path":                   true, // swift test (Swift 6.x): Swift Testing attachments dir
-	"experimental-attachments-path":      true, // swift test (Swift 6.x): experimental attachments dir
+	"snapshot-update":                  true, // pytest-snapshot / syrupy
+	"updatesnapshot":                   true, // jest --updateSnapshot via npm/yarn wrappers
+	"junitxml":                         true, // pytest
+	"junit-xml":                        true, // pytest / mypy
+	"junitfile":                        true, // gotestsum
+	"jsonfile":                         true, // gotestsum
+	"coverprofile":                     true, // go test
+	"cpuprofile":                       true, // go test
+	"memprofile":                       true, // go test
+	"blockprofile":                     true, // go test
+	"mutexprofile":                     true, // go test
+	"testlogfile":                      true, // go test binary
+	"gocoverdir":                       true, // go test binary
+	"outputfile":                       true, // jest/vitest --outputFile (with --json)
+	"report-log":                       true, // pytest-reportlog
+	"xunit-output":                     true, // swift test --xunit-output writes a JUnit XML report
+	"scratch-path":                     true, // swift test --scratch-path redirects the build dir
+	"build-path":                       true, // swift test --build-path: legacy alias of --scratch-path
+	"cache-path":                       true, // swift test --cache-path redirects the shared cache dir
+	"event-stream-output-path":         true, // swift test (Swift 6.x): swift-testing JSON output
+	"experimental-event-stream-output": true, // swift test (Swift 6.x): experimental event-stream output
+	"attachments-path":                 true, // swift test (Swift 6.x): Swift Testing attachments dir
+	"experimental-attachments-path":    true, // swift test (Swift 6.x): experimental attachments dir
 }
 
 func hasWriteOutputFlag(args []string) bool {

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -132,6 +132,53 @@ func TestTSCVerificationRequiresExplicitNoEmit(t *testing.T) {
 	}
 }
 
+func TestSwiftTestRecognizedAsVerification(t *testing.T) {
+	// swift test runs the SwiftPM test suite; the build cache lands in the
+	// package's own .build directory, mirroring cargo test acceptance. Other
+	// swift subcommands emit binaries, run arbitrary code, or mutate the
+	// package graph and must fail closed as mutations.
+	for _, command := range []string{
+		"swift test",
+		"swift test --parallel",
+		"swift test --filter SomeTests",
+	} {
+		if !IsDeliveryVerificationCommand(command) {
+			t.Errorf("%q should be recognized as a read-only Swift test verifier", command)
+		}
+		args, err := json.Marshal(map[string]string{"command": command})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ToolCallMutates("bash", args, false) {
+			t.Errorf("%q should remain a non-mutating verification", command)
+		}
+	}
+
+	for _, command := range []string{
+		"swift",
+		"swift build",
+		"swift build -c release",
+		"swift run",
+		"swift package resolve",
+		"swift package update",
+	} {
+		if IsDeliveryVerificationCommand(command) {
+			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)
+		}
+		args, err := json.Marshal(map[string]string{"command": command})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ToolCallMutates("bash", args, false) {
+			t.Errorf("%q must fail closed as a mutation", command)
+		}
+	}
+
+	if !strings.Contains(VerificationCommandSummary(), "swift test") {
+		t.Fatal("recovery summary must render the concrete Swift test command")
+	}
+}
+
 func TestPythonCompileallAlwaysCountsAsMutation(t *testing.T) {
 	for _, command := range []string{
 		"python -m compileall .",

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -161,6 +161,7 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift run",
 		"swift package resolve",
 		"swift package update",
+		"swift test --xunit-output report.xml",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -166,6 +166,7 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift test --xunit-output=report.xml",
 		"swift test --scratch-path /tmp/out",
 		"swift test --build-path /tmp/out",
+		"swift test --build-path=/tmp/out",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -171,6 +171,9 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift test --experimental-event-stream-output /tmp/events.json",
 		"swift test --attachments-path /tmp/attachments",
 		"swift test --experimental-attachments-path /tmp/attachments",
+		"swift test --cache-path /tmp/cache",
+		"swift test --help",
+		"swift test --list-tests",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -167,6 +167,10 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift test --scratch-path /tmp/out",
 		"swift test --build-path /tmp/out",
 		"swift test --build-path=/tmp/out",
+		"swift test --event-stream-output-path /tmp/events.json",
+		"swift test --experimental-event-stream-output /tmp/events.json",
+		"swift test --attachments-path /tmp/attachments",
+		"swift test --experimental-attachments-path /tmp/attachments",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -141,6 +141,7 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift test",
 		"swift test --parallel",
 		"swift test --filter SomeTests",
+		"swift test --enable-code-coverage",
 	} {
 		if !IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q should be recognized as a read-only Swift test verifier", command)
@@ -162,6 +163,8 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift package resolve",
 		"swift package update",
 		"swift test --xunit-output report.xml",
+		"swift test --xunit-output=report.xml",
+		"swift test --scratch-path /tmp/out",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)

--- a/internal/evidence/verification_summary_test.go
+++ b/internal/evidence/verification_summary_test.go
@@ -165,6 +165,7 @@ func TestSwiftTestRecognizedAsVerification(t *testing.T) {
 		"swift test --xunit-output report.xml",
 		"swift test --xunit-output=report.xml",
 		"swift test --scratch-path /tmp/out",
+		"swift test --build-path /tmp/out",
 	} {
 		if IsDeliveryVerificationCommand(command) {
 			t.Errorf("%q can build, run, or mutate the package and must not count as verification", command)


### PR DESCRIPTION
## Why

Swift/SwiftPM projects currently have **no host-recognized verification command** for delivery finalization: `swift test` is rejected by the delivery classifier, so every sign-off on a Swift workspace falls back to `git diff --check` (which does not actually run the test suite).

## What

- `internal/evidence/evidence.go` — add a `swift` branch to `bashSegmentIsVerification`:
  - `swift test` (and flags like `--parallel` / `--filter`) → recognized as a non-mutating verifier, mirroring `cargo test` / `dotnet test` acceptance (SwiftPM build artifacts land in the package's own `.build/` directory)
  - `swift build` / `swift run` / `swift package resolve|update` → fail closed as mutations (they emit binaries, run arbitrary code, or mutate the package graph)
- Add `swift test` to `verificationCommandRecommendations` so the recovery summary advertises it
- `internal/evidence/verification_summary_test.go` — new `TestSwiftTestRecognizedAsVerification` covering accept/reject/summary paths

## Verification

`go test ./internal/evidence/` passes (`ok reasonix/internal/evidence`), including the new test.