### PR TITLE
fix(release): load recovery control in npm job

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -120,16 +120,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.approved_sha || inputs.tag || github.ref }}
-      - name: Load approved standalone recovery control plane
-        if: ${{ !inputs.orchestrated }}
-        env:
-          RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$RECOVERY_CONTROL_SHA"
-          git restore --source="$RECOVERY_CONTROL_SHA" -- \
-            npm/publish.mjs \
-            scripts/finalize-npm-official-release.mjs
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -159,6 +149,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.approved_sha || inputs.tag || github.ref }}
+      - name: Load approved standalone recovery control plane
+        if: ${{ !inputs.orchestrated }}
+        env:
+          RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$RECOVERY_CONTROL_SHA"
+          git restore --source="$RECOVERY_CONTROL_SHA" -- \
+            npm/publish.mjs \
+            scripts/finalize-npm-official-release.mjs
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -156,12 +156,19 @@ if sed -n '/^  workflow_dispatch:/,/^  workflow_call:/p' "$repo_root/.github/wor
 fi
 grep -Fq 'if: ${{ !inputs.orchestrated }}' "$repo_root/.github/workflows/release-npm.yml"
 grep -Fq 'Publish or recover immutable npm packages' "$repo_root/.github/workflows/release-npm.yml"
-grep -Fq 'RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}' \
-	"$repo_root/.github/workflows/release-npm.yml"
-grep -Fq 'git restore --source="$RECOVERY_CONTROL_SHA"' \
-	"$repo_root/.github/workflows/release-npm.yml"
+if sed -n '/^  cache-guard:/,/^  npm:/p' \
+	"$repo_root/.github/workflows/release-npm.yml" |
+	grep -Fq 'RECOVERY_CONTROL_SHA'; then
+	echo "npm recovery control plane must load in the publisher job after candidate checkout" >&2
+	exit 1
+fi
+sed -n '/^  npm:/,$p' "$repo_root/.github/workflows/release-npm.yml" |
+	grep -Fq 'RECOVERY_CONTROL_SHA: ${{ github.workflow_sha }}'
+sed -n '/^  npm:/,$p' "$repo_root/.github/workflows/release-npm.yml" |
+	grep -Fq 'git restore --source="$RECOVERY_CONTROL_SHA"'
 for recovery_script in npm/publish.mjs scripts/finalize-npm-official-release.mjs; do
-	grep -Fq "$recovery_script" "$repo_root/.github/workflows/release-npm.yml"
+	sed -n '/^  npm:/,$p' "$repo_root/.github/workflows/release-npm.yml" |
+		grep -Fq "$recovery_script"
 done
 grep -Fq 'publishPackages' "$repo_root/npm/build.mjs"
 grep -Eq 'signing-policy-slug: release-signing' "$repo_root/.github/workflows/release-desktop.yml"


### PR DESCRIPTION
## Summary

- move standalone npm recovery control loading into the publisher job, immediately after immutable candidate checkout
- assert the control plane is not loaded only in the cache guard
- keep candidate HEAD and package source unchanged

## Release recovery

The previous control-plane step ran in the cache guard and was discarded by the publisher job checkout. This places it where `npm/build.mjs` and the alias finalizer actually execute.

Documentation-impact: none - existing release documentation already defines standalone npm recovery; this corrects the internal job placement.

## Tests

- `bash scripts/release-workflows.test.sh`