### PR TITLE
fix(tui): snapshot the session on every quit gesture

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -417,6 +417,12 @@ type compactDoneMsg struct{ err error }
 // stale controller captured before an in-TUI rebuild.
 type tuiShutdownMsg struct{}
 
+// shutdownNow is the tea.Cmd every in-TUI quit gesture returns instead of
+// tea.Quit. Routing through tuiShutdownMsg gives all exits the same
+// finalization (Snapshot + lease follow); quitting directly would drop
+// whatever the controller holds beyond the last snapshot (#5879).
+func shutdownNow() tea.Msg { return tuiShutdownMsg{} }
+
 // elapsedTickMsg fires once a second while a turn runs, driving the "thinking
 // Ns" counter in the status line.
 type elapsedTickMsg struct{}
@@ -1346,7 +1352,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
 				} else if m.cancelRequested() {
 					m.ctrl.Cancel()
-					return m, tea.Quit
+					return m, shutdownNow
 				} else {
 					m.ctrl.Cancel()
 				}
@@ -1376,13 +1382,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if !m.lastCtrlCAt.IsZero() && time.Since(m.lastCtrlCAt) < 1500*time.Millisecond {
-				return m, tea.Quit
+				return m, shutdownNow
 			}
 			m.lastCtrlCAt = time.Now()
 			m.notice(i18n.M.CtrlCQuitHint)
 			return m, finalize(m, nil)
 		case "ctrl+d":
-			return m, tea.Quit
+			return m, shutdownNow
 		case "ctrl+l":
 			if m.state != tuiRunning {
 				m.finalizeStreamed()
@@ -1440,7 +1446,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			if line == "exit" || line == "quit" || line == ":q" {
-				return m, tea.Quit
+				return m, shutdownNow
 			}
 			m.rememberSubmittedInput(line)
 
@@ -4142,7 +4148,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 			m.notice("remembered → " + path)
 		}
 	case "/quit", "/exit":
-		return tea.Quit
+		return shutdownNow
 	case "/copy":
 		return m.runCopyCommand(input)
 	case "/export":

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -3455,8 +3455,9 @@ func TestFreshApprovalSessionChoiceIsLimitedToSandboxEscape(t *testing.T) {
 	}
 }
 
-// TestSlashQuitExit verifies that /quit and /exit slash commands return tea.Quit,
-// providing an alternative to Ctrl+D and the bare "quit"/"exit" text commands.
+// TestSlashQuitExit verifies that /quit and /exit slash commands quit through
+// the shutdown path (tuiShutdownMsg → snapshot → tea.Quit, #5879), providing an
+// alternative to Ctrl+D and the bare "quit"/"exit" text commands.
 func TestSlashQuitExit(t *testing.T) {
 	m := newTestChatTUI()
 	for _, cmd := range []string{"/quit", "/exit"} {
@@ -3466,8 +3467,8 @@ func TestSlashQuitExit(t *testing.T) {
 			continue
 		}
 		msg := got()
-		if _, ok := msg.(tea.QuitMsg); !ok {
-			t.Errorf("%s cmd should produce QuitMsg, got %T", cmd, msg)
+		if _, ok := msg.(tuiShutdownMsg); !ok {
+			t.Errorf("%s cmd should produce tuiShutdownMsg, got %T", cmd, msg)
 		}
 	}
 }
@@ -3607,8 +3608,8 @@ func TestSecondCtrlCQuitsAfterCancelIsAlreadyRequested(t *testing.T) {
 	if secondCmd == nil {
 		t.Fatal("second Ctrl+C after cancel request should quit")
 	}
-	if msg := secondCmd(); msg != (tea.QuitMsg{}) {
-		t.Fatalf("second Ctrl+C command = %T, want tea.QuitMsg", msg)
+	if msg := secondCmd(); msg != (tuiShutdownMsg{}) {
+		t.Fatalf("second Ctrl+C command = %T, want tuiShutdownMsg (snapshot-before-quit, #5879)", msg)
 	}
 }
 
@@ -4088,5 +4089,39 @@ func TestShiftTabLeavesDontAskForAskMode(t *testing.T) {
 	m.cycleMode()
 	if got := m.ctrl.ToolApprovalMode(); got != control.ToolApprovalAsk {
 		t.Fatalf("Shift+Tab from dontAsk = %q, want ask", got)
+	}
+}
+
+// TestQuitGesturesRouteThroughShutdown guards #5879: every in-TUI quit gesture
+// must emit tuiShutdownMsg (whose handler snapshots the session) rather than
+// tea.Quit directly, which would drop everything past the last snapshot.
+func TestQuitGesturesRouteThroughShutdown(t *testing.T) {
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	// Double Ctrl+C on an idle, empty composer.
+	m := newTestChatTUI()
+	model, cmd := m.Update(ctrlC)
+	m = model.(chatTUI)
+	if cmd != nil {
+		if msg := cmd(); msg == (tea.QuitMsg{}) {
+			t.Fatal("first Ctrl+C must not quit")
+		}
+	}
+	_, cmd = m.Update(ctrlC)
+	if cmd == nil {
+		t.Fatal("second Ctrl+C should return a command")
+	}
+	if msg := cmd(); msg != (tuiShutdownMsg{}) {
+		t.Fatalf("double Ctrl+C emitted %T, want tuiShutdownMsg", msg)
+	}
+
+	// Ctrl+D.
+	m = newTestChatTUI()
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("Ctrl+D should return a command")
+	}
+	if msg := cmd(); msg != (tuiShutdownMsg{}) {
+		t.Fatalf("Ctrl+D emitted %T, want tuiShutdownMsg", msg)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #5879

The signal-driven shutdown path (`tuiShutdownMsg`) snapshots the session and follows the lease before quitting — but five in-TUI quit gestures returned `tea.Quit` directly and skipped that finalization:

- double Ctrl+C on an idle empty composer
- second Ctrl+C while running (cancel already requested)
- Ctrl+D
- typed `exit` / `quit` / `:q`
- `/quit` / `/exit`

Anything the controller held beyond the last snapshot was silently lost on those exits — the data-loss reported in #5879.

## Fix

Add a shared `shutdownNow` `tea.Cmd` that emits `tuiShutdownMsg`, and route all five gestures through it so every exit runs the same Snapshot + lease-follow finalization. The shutdown handler remains the single place that returns `tea.Quit`.

## Tests

- New `TestQuitGesturesRouteThroughShutdown` (double Ctrl+C and Ctrl+D must emit `tuiShutdownMsg`, first Ctrl+C must not quit)
- Updated `TestSlashQuitExit` and `TestSecondCtrlCQuitsAfterCancelIsAlreadyRequested` to expect the shutdown route
- `LANG=en_US.UTF-8 go test ./internal/cli/` green locally; vet + gofmt clean

Documentation-impact: none - internal persistence fix; quit gestures behave identically from the user's perspective, they just stop losing data.

Cache-impact: none - TUI-only change, no prompt or provider surface touched.