### PR TITLE
fix(agent): stop autoresearch evidence blocks leaking into displayed answers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2802,7 +2802,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 				if text.Len() > 0 || display != "" {
 					sink.Emit(event.Event{
 						Kind:      event.Message,
-						Text:      StripGoalMarkers(text.String()),
+						Text:      DisplayAssistantText(text.String()),
 						Reasoning: display,
 					})
 				}

--- a/internal/agent/goal_display.go
+++ b/internal/agent/goal_display.go
@@ -30,3 +30,38 @@ func StripGoalMarkers(text string) string {
 	}
 	return strings.TrimSpace(strings.Join(cleaned, "\n"))
 }
+
+const (
+	autoResearchEvidenceOpen  = "<autoresearch-evidence>"
+	autoResearchEvidenceClose = "</autoresearch-evidence>"
+)
+
+// StripAutoResearchEvidenceBlocks removes <autoresearch-evidence> protocol
+// blocks the model emits for the controller's evidence recorder. Like goal
+// markers, they stay in the session history for parsing (#6665).
+func StripAutoResearchEvidenceBlocks(text string) string {
+	var b strings.Builder
+	rest := text
+	for {
+		start := strings.Index(rest, autoResearchEvidenceOpen)
+		if start < 0 {
+			b.WriteString(rest)
+			return strings.TrimSpace(b.String())
+		}
+		b.WriteString(rest[:start])
+		afterOpen := rest[start+len(autoResearchEvidenceOpen):]
+		end := strings.Index(afterOpen, autoResearchEvidenceClose)
+		if end < 0 {
+			return strings.TrimSpace(b.String())
+		}
+		rest = afterOpen[end+len(autoResearchEvidenceClose):]
+	}
+}
+
+// DisplayAssistantText is the single display filter for assistant answer text:
+// it removes every protocol artifact ([goal:*] markers, autoresearch evidence
+// blocks) before the text reaches a sink. Session history keeps the raw text —
+// apply this at emission or render boundaries only.
+func DisplayAssistantText(text string) string {
+	return StripGoalMarkers(StripAutoResearchEvidenceBlocks(text))
+}

--- a/internal/agent/goal_display_test.go
+++ b/internal/agent/goal_display_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import "testing"
+
+func TestStripAutoResearchEvidenceBlocks(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"no block", "plain answer", "plain answer"},
+		{
+			"single block",
+			"Findings so far.\n<autoresearch-evidence>{\"id\":\"e1\"}</autoresearch-evidence>\nNext steps.",
+			"Findings so far.\n\nNext steps.",
+		},
+		{
+			"multiple blocks",
+			"<autoresearch-evidence>{\"id\":\"e1\"}</autoresearch-evidence>middle<autoresearch-evidence>{\"id\":\"e2\"}</autoresearch-evidence>",
+			"middle",
+		},
+		{
+			"unterminated block drops the tail",
+			"answer\n<autoresearch-evidence>{\"id\":\"e1\"}",
+			"answer",
+		},
+	}
+	for _, tc := range cases {
+		if got := StripAutoResearchEvidenceBlocks(tc.in); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestDisplayAssistantTextStripsAllProtocolArtifacts guards #6665: the single
+// display filter must remove both goal markers and evidence blocks before
+// answer text reaches any sink.
+func TestDisplayAssistantTextStripsAllProtocolArtifacts(t *testing.T) {
+	in := "Done with the survey.\n[goal:continue]\n<autoresearch-evidence>{\"id\":\"e1\",\"summary\":\"x\"}</autoresearch-evidence>"
+	want := "Done with the survey."
+	if got := DisplayAssistantText(in); got != want {
+		t.Errorf("DisplayAssistantText = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3794,6 +3794,12 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 
 	case event.Message:
 		// The answer stream is complete — freeze reasoning + the markdown answer.
+		// Message.Text is the canonical display text (protocol markers already
+		// stripped at emission), so it replaces the raw streamed accumulation.
+		if e.Text != "" && m.pending.Len() > 0 {
+			m.pending.Reset()
+			m.pending.WriteString(e.Text)
+		}
 		m.commitReasoning()
 		m.commitPending()
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -4181,3 +4181,20 @@ func TestQuitGesturesRouteThroughShutdown(t *testing.T) {
 		t.Fatalf("Ctrl+D emitted %T, want tuiShutdownMsg", msg)
 	}
 }
+
+// TestMessageEventReplacesStreamedAnswer guards #6665 on the TUI side: the
+// final Message event carries the canonical display text (protocol blocks
+// stripped at emission), and it must replace the raw streamed accumulation.
+func TestMessageEventReplacesStreamedAnswer(t *testing.T) {
+	m := newTestChatTUI()
+	m.ingestEvent(event.Event{Kind: event.Text, Text: "answer <autoresearch-evidence>{\"id\":\"e1\"}</autoresearch-evidence> tail"})
+	m.ingestEvent(event.Event{Kind: event.Message, Text: "answer  tail"})
+
+	joined := strings.Join(m.transcript, "\n")
+	if strings.Contains(joined, "autoresearch-evidence") {
+		t.Fatalf("committed transcript still contains evidence block:\n%s", joined)
+	}
+	if !strings.Contains(joined, "answer") {
+		t.Fatalf("committed transcript lost the answer text:\n%s", joined)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2514,7 +2514,7 @@ func parseAutoResearchEvidenceBlocks(text string) []autoResearchEvidenceBlock {
 }
 
 func autoResearchDirectionSummary(text string) string {
-	text = stripAutoResearchEvidenceBlocks(text)
+	text = agent.StripAutoResearchEvidenceBlocks(text)
 	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimSpace(line)
 		lower := strings.ToLower(line)
@@ -2527,25 +2527,6 @@ func autoResearchDirectionSummary(text string) string {
 		return line
 	}
 	return "turn completed"
-}
-
-func stripAutoResearchEvidenceBlocks(text string) string {
-	var b strings.Builder
-	rest := text
-	for {
-		start := strings.Index(rest, autoResearchEvidenceOpen)
-		if start < 0 {
-			b.WriteString(rest)
-			return b.String()
-		}
-		b.WriteString(rest[:start])
-		afterOpen := rest[start+len(autoResearchEvidenceOpen):]
-		end := strings.Index(afterOpen, autoResearchEvidenceClose)
-		if end < 0 {
-			return b.String()
-		}
-		rest = afterOpen[end+len(autoResearchEvidenceClose):]
-	}
 }
 
 func (c *Controller) autoResearchReadinessFailure() string {

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -166,8 +166,9 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 		toolEvent.Output = answer
 		c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: toolEvent})
 		c.executor.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: answer})
-		c.sink.Emit(event.Event{Kind: event.Text, Text: answer})
-		c.sink.Emit(event.Event{Kind: event.Message, Text: answer})
+		display := agent.DisplayAssistantText(answer)
+		c.sink.Emit(event.Event{Kind: event.Text, Text: display})
+		c.sink.Emit(event.Event{Kind: event.Message, Text: display})
 	}
 
 	c.clearInFlightTurn()


### PR DESCRIPTION
## Summary

Fixes #6665

`<autoresearch-evidence>` blocks are protocol the model emits for the controller's evidence recorder. A strip helper existed but was only applied in `autoResearchDirectionSummary` — transcript rendering never filtered them, so every surface (desktop, TUI, bot/text sinks) showed the raw blocks after an AutoResearch answer.

## Fix — one display filter, applied at emission

Follows the existing goal-marker pattern (`StripGoalMarkers`: strip for display, keep raw in history):

- New `agent.DisplayAssistantText` = goal markers + evidence blocks, documented as **the** display filter for assistant answer text.
- Applied at both `event.Message` emission points (agent stream end, PE orchestrator relay) so every sink receives clean text.
- `internal/control` drops its private `stripAutoResearchEvidenceBlocks` copy and reuses the shared exported helper (single source).
- TUI: the final `Message` event now replaces the raw streamed accumulation with the canonical stripped text (matching the desktop's replace-on-Message semantics).

Session history is untouched — evidence parsing (`recordAutoResearchEvidenceFromAssistant`) and model replay still see the raw blocks.

Known remainder: during live streaming the tag can flash briefly (deltas are unfiltered); the final committed answer is always clean. A streaming-side filter would need a hold-back state machine and is left as follow-up if anyone reports it.

## Tests

- `TestStripAutoResearchEvidenceBlocks` (incl. multiple blocks + unterminated tail)
- `TestDisplayAssistantTextStripsAllProtocolArtifacts`
- `TestMessageEventReplacesStreamedAnswer` (TUI transcript ends clean)
- `go test ./internal/agent/ ./internal/control/ ./internal/cli/` green; vet + gofmt clean

Documentation-impact: none - display-only fix; no documented behavior or configuration changes.

Cache-impact: none - no prompt construction or provider request surface touched; session history bytes are unchanged.
Cache-guard: TestDisplayAssistantTextStripsAllProtocolArtifacts + existing session-history tests — filtering happens at event emission only; Session().Add stores raw text, so replayed prompt bytes (the cached prefix) are byte-identical.