### PR TITLE
fix(agent,desktop): sanitize stored display titles at the read boundary

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -60,6 +60,12 @@ func loadSessionTitles(dir string) map[string]string {
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	// Older builds could persist titles polluted with internal wrappers
+	// (memory-compiler contracts, transient blocks) — clean at the read
+	// boundary; UserPreviewText is a no-op on clean titles (#5666).
+	for key, title := range m {
+		m[key] = agent.UserPreviewText(title)
+	}
 	return m
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4673,7 +4673,11 @@ func topicTitleUserTurnsFromSession(path string) []string {
 		if !agent.IsUserAuthoredTurn(msg.Text) {
 			continue
 		}
-		content := control.StripComposePrefixes(agent.HandoffTask(msg.Text))
+		// UserPreviewText is the canonical user-authored view: it unwraps
+		// memory-compiler execution contracts and strips transient blocks
+		// (and runs HandoffTask), so internal wrappers can never become a
+		// title basis (#5666).
+		content := control.StripComposePrefixes(agent.UserPreviewText(msg.Text))
 		content = control.StripReferencedContextPrefix(content)
 		if strings.TrimSpace(content) != "" {
 			users = append(users, content)
@@ -5752,6 +5756,11 @@ func loadTopicTitles(workspaceRoot string) map[string]string {
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	// Same read-boundary cleaning as loadSessionTitles: older builds could
+	// persist titles carrying internal wrappers (#5666).
+	for key, title := range m {
+		m[key] = agent.UserPreviewText(title)
+	}
 	return m
 }
 

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -135,7 +135,27 @@ func LoadBranchMeta(sessionPath string) (BranchMeta, bool, error) {
 	if m.ID == "" {
 		m.ID = BranchID(sessionPath)
 	}
+	m.sanitizeDisplayFields()
 	return m, true, nil
+}
+
+// sanitizeDisplayFields cleans persisted display strings that older builds
+// polluted with internal wrappers (memory-compiler execution contracts,
+// transient blocks) — #5666. Every reader goes through LoadBranchMeta, so this
+// is the single boundary; UserPreviewText is a no-op on clean text, and a
+// field that was pure wrapper falls back to empty so callers use their normal
+// fallbacks (preview, default title).
+func (m *BranchMeta) sanitizeDisplayFields() {
+	m.TopicTitle = sanitizeStoredDisplayText(m.TopicTitle)
+	m.CustomTitle = sanitizeStoredDisplayText(m.CustomTitle)
+	m.Preview = sanitizeStoredDisplayText(m.Preview)
+}
+
+func sanitizeStoredDisplayText(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return strings.TrimSpace(s)
+	}
+	return UserPreviewText(s)
 }
 
 // branchMetaReadBackoffs paces the re-reads of a branch-meta sidecar that

--- a/internal/agent/branch_sanitize_test.go
+++ b/internal/agent/branch_sanitize_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Older builds persisted display fields polluted with internal wrappers.
+// LoadBranchMeta is the single read boundary, so it must return the
+// user-authored text instead (#5666).
+func TestLoadBranchMetaSanitizesPollutedDisplayFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	polluted := realContract("fix the login bug")
+	if err := SaveBranchMeta(path, BranchMeta{
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+		TopicTitle:  polluted,
+		CustomTitle: polluted,
+		Preview:     polluted,
+	}); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+	}
+	for name, got := range map[string]string{
+		"TopicTitle":  meta.TopicTitle,
+		"CustomTitle": meta.CustomTitle,
+		"Preview":     meta.Preview,
+	} {
+		if got != "fix the login bug" {
+			t.Errorf("%s = %q, want the unwrapped user prompt", name, got)
+		}
+	}
+
+	// Clean values pass through untouched.
+	if err := SaveBranchMeta(path, BranchMeta{CreatedAt: time.Now(), UpdatedAt: time.Now(), TopicTitle: "My topic"}); err != nil {
+		t.Fatalf("SaveBranchMeta clean: %v", err)
+	}
+	meta, _, err = LoadBranchMeta(path)
+	if err != nil {
+		t.Fatalf("LoadBranchMeta clean: %v", err)
+	}
+	if meta.TopicTitle != "My topic" {
+		t.Errorf("clean TopicTitle = %q, want unchanged", meta.TopicTitle)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the remaining half of #5666 (history/session names rendering as raw internal strings). Supersedes #5718 — credit to @GTC2080 for the diagnosis and test intent; that branch had drifted into conflict and cleaned per display site, while this lands the same protection at the read boundaries instead.

Memory-compiler execution contracts (and transient blocks) written into persisted titles/previews by older builds surfaced raw in history, tabs, and the project tree — and a polluted first turn could seed a brand-new auto-title.

## Fix — one rule, three seams

`agent.UserPreviewText` is already the canonical "user-authored view" (unwraps `<memory-compiler-execution>` to the original prompt, strips transient blocks, runs HandoffTask, no-op on clean text). This PR applies it at the places stored display text enters the process:

1. **`LoadBranchMeta` sanitizes `TopicTitle`/`CustomTitle`/`Preview`** — the single boundary every reader (agent listings, desktop session bindings, CLI resume picker) goes through. The next save persists the cleaned value, so legacy sidecars self-heal.
2. **Desktop session/topic title sidecar loaders** (`loadSessionTitles`, `loadTopicTitles`) clean at read the same way — these are separate JSON files that don't pass through BranchMeta.
3. **Auto-title derivation** (`topicTitleUserTurnsFromSession`) now bases titles on `UserPreviewText` instead of an ad-hoc strip chain, so wrappers can never become a title basis again.

No new cleaning helpers, no per-display-site scrubbing — the existing canonical filter, applied at ingestion.

## Tests

- New `TestLoadBranchMetaSanitizesPollutedDisplayFields` (contract-wrapped title/custom-title/preview → unwrapped prompt; clean values untouched), using the same contract fixture as the preview tests.
- `go test ./internal/agent/` green; vet + gofmt clean. Desktop cannot build locally (known cgo `-arch` limitation) — relying on the CI desktop job.

Documentation-impact: none - restores intended display of existing features; no documented behavior changes.

Cache-impact: none - display sidecars only; session message content and prompt construction untouched.
Cache-guard: TestLoadBranchMetaSanitizesPollutedDisplayFields — sanitization touches BranchMeta display fields only; session .jsonl bytes are never rewritten.