### PR TITLE
fix(acp): replay the user-authored view, not the persisted wire form

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -213,9 +213,15 @@ func (s *updateSink) replay(msgs []provider.Message) {
 	for _, m := range msgs {
 		switch m.Role {
 		case provider.RoleUser:
+			// Replay the user-authored view, not the persisted wire form:
+			// UserMessageText strips injected transient blocks (<response-language>
+			// etc.) and unwraps memory-compiler contracts, same as every other
+			// surface (#6882). A turn that was pure injection replays as nothing.
 			text := m.Content
 			if steer, ok := agent.SteerText(text); ok {
 				text = steer
+			} else {
+				text = agent.UserMessageText(m)
 			}
 			if text != "" {
 				s.send(messageChunk{SessionUpdate: "user_message_chunk", Content: textBlock(text)})
@@ -224,8 +230,10 @@ func (s *updateSink) replay(msgs []provider.Message) {
 			if m.ReasoningContent != "" {
 				s.send(messageChunk{SessionUpdate: "agent_thought_chunk", Content: textBlock(m.ReasoningContent)})
 			}
-			if m.Content != "" {
-				s.send(messageChunk{SessionUpdate: "agent_message_chunk", Content: textBlock(m.Content)})
+			// Same display filter as live emission: goal markers and evidence
+			// blocks stay in history for parsing but never reach the client.
+			if display := agent.DisplayAssistantText(m.Content); display != "" {
+				s.send(messageChunk{SessionUpdate: "agent_message_chunk", Content: textBlock(display)})
 			}
 			for _, tc := range m.ToolCalls {
 				s.send(toolCall{

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -675,3 +675,33 @@ func TestClip(t *testing.T) {
 		t.Errorf("clip note missing: %q", got[len(got)-40:])
 	}
 }
+
+// Replay must show the user-authored view, not the persisted wire form:
+// injected transient blocks and protocol markers stay in history for parsing
+// but never reach the client (#6882).
+func TestUpdateSinkReplayStripsInjectedWrappers(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+	sink.replay([]provider.Message{
+		{
+			Role: provider.RoleUser,
+			Content: "<response-language>\nFinal answer language preference: use Simplified Chinese.\n</response-language>\n" +
+				"Introduce yourself",
+		},
+		{
+			Role:    provider.RoleAssistant,
+			Content: "Here you go.\n[goal:continue]",
+		},
+	})
+
+	u := fn.updateMap(t, 0)
+	content, _ := u["content"].(map[string]any)
+	if content["text"] != "Introduce yourself" {
+		t.Fatalf("replayed user text = %v, want the authored text only", content["text"])
+	}
+	u = fn.updateMap(t, 1)
+	content, _ = u["content"].(map[string]any)
+	if content["text"] != "Here you go." {
+		t.Fatalf("replayed assistant text = %v, want goal marker stripped", content["text"])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #6882

ACP `session/load` replayed `provider.Message.Content` raw, so reopening a session showed injected transient blocks (`<response-language>` etc.) on user turns — and would show protocol markers (goal markers, evidence blocks) on assistant turns.

## Fix

Reuse the canonical display filters the other surfaces already use — no new stripping logic:

- User turns: `agent.UserMessageText` (honors `RawContent`, unwraps memory-compiler contracts, strips transient blocks). The existing steer-wrapper special case keeps its precedence. A turn that was pure injection replays as nothing.
- Assistant turns: `agent.DisplayAssistantText` (goal markers + autoresearch evidence blocks) — the same filter applied at live `Message` emission since #7493.

Session history bytes are untouched; this is replay-display only.

## Tests

- New `TestUpdateSinkReplayStripsInjectedWrappers` (user transient block + assistant goal marker).
- Existing steer replay test still green; `go test ./internal/acp/` green; vet + gofmt clean.

Documentation-impact: none - restores intended replay display; no documented behavior changes.

Cache-impact: none - replay/display only; session history and prompt construction untouched.