### PR TITLE
feat(desktop): Primer data-viz two-set palette for model usage charts / 使用统计图表改用 Primer 深浅两套配色

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import {
   Pencil,
   Trash2,
   AlarmClock,
+  BarChart3,
   Brain,
   Cpu,
   Palette,
@@ -3898,6 +3899,7 @@ export default function App() {
       },
       { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, compact: true, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
       { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, compact: true, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
+      { id: "cmd-usage-stats", group: t("palette.group.commands"), title: t("palette.cmd.usageStats"), icon: <BarChart3 size={15} />, compact: true, keywords: ["usage", "stats", "statistics", "用量", "统计"], run: () => { setSettingsFocus({ target: "model-stats" }); setSettingsTarget("models"); } },
       { id: "cmd-terminal", group: t("palette.group.commands"), title: t("rightDock.terminal"), icon: <TerminalSquare size={15} />, compact: true, keywords: ["terminal", "shell", "终端"], run: () => toggleTerminalPanel() },
     ];
     const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3899,7 +3899,21 @@ export default function App() {
       },
       { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, compact: true, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
       { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, compact: true, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
-      { id: "cmd-usage-stats", group: t("palette.group.commands"), title: t("palette.cmd.usageStats"), icon: <BarChart3 size={15} />, compact: true, keywords: ["usage", "stats", "statistics", "用量", "统计"], run: () => { setSettingsFocus({ target: "model-stats" }); setSettingsTarget("models"); } },
+      {
+        id: "cmd-usage-stats",
+        group: t("palette.group.commands"),
+        title: t("palette.cmd.usageStats"),
+        icon: <BarChart3 size={15} />,
+        compact: true,
+        keywords: ["usage", "stats", "statistics", "用量", "统计"],
+        run: () => {
+          setSettingsFocus((current) => ({
+            target: "model-stats",
+            requestId: (current?.requestId ?? 0) + 1,
+          }));
+          setSettingsTarget("models");
+        },
+      },
       { id: "cmd-terminal", group: t("palette.group.commands"), title: t("rightDock.terminal"), icon: <TerminalSquare size={15} />, compact: true, keywords: ["terminal", "shell", "终端"], run: () => toggleTerminalPanel() },
     ];
     const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();

--- a/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
+++ b/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
@@ -54,8 +54,17 @@ ok(
   "onboarding opens the model access flow instead of model usage",
 );
 ok(
-  /initialFocus\?\.target === "model-access" \? "access" : "usage"/.test(settingsSource),
-  "model settings honor the onboarding access target while preserving usage as the default",
+  /initialFocus\?\.target === "model-access"[\s\S]*?initialFocus\?\.target === "model-stats"[\s\S]*?"usage"/.test(settingsSource),
+  "model settings honor access and statistics focus targets while preserving usage as the default",
+);
+ok(
+  !settingsSource.includes("modelFocusHandledRef"),
+  "each fresh model focus object can re-target the same subtab again",
+);
+ok(
+  /setSettingsFocus\(\(current\) => \(\{[\s\S]*?target: "model-stats",[\s\S]*?requestId: \(current\?\.requestId \?\? 0\) \+ 1,[\s\S]*?\}\)\)/.test(appSource) &&
+    /initialFocus\?\.requestId/.test(settingsSource),
+  "usage statistics commands derive a monotonic request id from the shared focus state",
 );
 ok(
   /case "deepseek-responses":\s*return t\("settings\.addProvider\.preset\.deepseekResponsesDesc"\)/.test(settingsSource),

--- a/desktop/frontend/src/__tests__/usage-stats-panel.test.tsx
+++ b/desktop/frontend/src/__tests__/usage-stats-panel.test.tsx
@@ -125,11 +125,21 @@ ok(rootEl.querySelectorAll("rect.usage-stats__heat-cell--5").length === 1, "init
 ok(rootEl.textContent?.includes("Completed turns") === true && !rootEl.textContent?.includes("Sessions"), "completed turns are not mislabeled as sessions");
 ok(rootEl.querySelectorAll("rect.usage-stats__bar-hit").length === 180, "long custom trends render at most 180 interactive columns");
 ok(rootEl.textContent?.includes("Showing the latest 180 days") === true, "bounded trends disclose the visible window");
-const modelSegments = rootEl.querySelectorAll("circle.usage-stats__donut-seg");
-const primaryColour = modelSegments[0]?.getAttribute("stroke") ?? "";
-ok(primaryColour.includes("var(--accent)") && primaryColour.includes("var(--fg)"), "model colours adapt to the active theme");
-const overflowColour = modelSegments[20]?.getAttribute("stroke") ?? "";
-ok(overflowColour.includes("var(--accent)") && overflowColour.includes("var(--fg)"), "overflow model colours also adapt to the active theme");
+  const modelSegments = rootEl.querySelectorAll("circle.usage-stats__donut-seg");
+  ok(modelSegments.length === 6, "21 models collapse into five steps plus Other");
+  // Model colours map to the fixed --chart-1..5 series (rank order) plus the
+  // gray --chart-other step; each series colour is mixed toward --bg-elev
+  // like the heatmap levels (light/dark hex variants live in styles.css), so
+  // the assertions only check the rank-to-variable mapping.
+  const seriesVar = (color: string) => color.match(/var\(--chart-\d+\)/)?.[0] ?? "";
+  const primaryColour = modelSegments[0]?.getAttribute("stroke") ?? "";
+  ok(seriesVar(primaryColour) === "var(--chart-1)" && primaryColour.includes("72%") && primaryColour.includes("var(--bg-elev)"), "most-used model keeps the first series colour softened toward the card background");
+  const lastTopColour = modelSegments[4]?.getAttribute("stroke") ?? "";
+  ok(seriesVar(lastTopColour) === "var(--chart-5)", "fifth model gets the fifth series colour");
+  const otherColour = modelSegments[modelSegments.length - 1]?.getAttribute("stroke") ?? "";
+  ok(otherColour === "var(--chart-other)", "models beyond the top five collapse into the gray Other step");
+  const series = [...modelSegments].slice(0, 5).map((seg) => seriesVar(seg.getAttribute("stroke") ?? ""));
+  ok(new Set(series).size === 5, "the five model steps each get a distinct series colour");
 
 const cliButton = [...rootEl.querySelectorAll("button")].find((button) => button.textContent === "CLI");
 if (!cliButton) throw new Error("missing CLI source button");

--- a/desktop/frontend/src/__tests__/usage-stats-panel.test.tsx
+++ b/desktop/frontend/src/__tests__/usage-stats-panel.test.tsx
@@ -79,9 +79,9 @@ const usageStats = (req: UsageStatsRequest): Promise<UsageStatsRange> => {
       tokens: 21,
       daily: Array.from({ length: 400 }, (_, index) => ({
         day: day(index - 399),
-        total: 1,
-        byModel: { "deepseek/model": 1 },
-        byProvider: { deepseek: 1 },
+        total: 21,
+        byModel: Object.fromEntries(Array.from({ length: 21 }, (_, modelIndex) => [`deepseek/model-${modelIndex + 1}`, 1])),
+        byProvider: { deepseek: 21 },
         requests: 1,
         turns: 1,
         cacheHit: 0,
@@ -140,6 +140,32 @@ ok(rootEl.textContent?.includes("Showing the latest 180 days") === true, "bounde
   ok(otherColour === "var(--chart-other)", "models beyond the top five collapse into the gray Other step");
   const series = [...modelSegments].slice(0, 5).map((seg) => seriesVar(seg.getAttribute("stroke") ?? ""));
   ok(new Set(series).size === 5, "the five model steps each get a distinct series colour");
+
+const otherToggle = rootEl.querySelector<HTMLButtonElement>("button.usage-stats__model-row--expandable");
+ok(otherToggle instanceof dom.window.HTMLButtonElement, "Other uses one native button for the whole expandable row");
+ok(otherToggle?.querySelector("button") === null, "Other does not nest an interactive button inside another button");
+ok(otherToggle?.getAttribute("aria-expanded") === "false", "Other exposes its collapsed state on the row button");
+await act(async () => {
+  otherToggle?.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+ok(otherToggle?.getAttribute("aria-expanded") === "true", "clicking the Other row exposes its expanded state");
+ok(rootEl.querySelector(".usage-stats__model-other-wrap--open") !== null, "clicking the Other row opens the detail list");
+
+await act(async () => {
+  modelSegments[modelSegments.length - 1]?.dispatchEvent(new dom.window.MouseEvent("mouseover", { bubbles: true, clientX: 120, clientY: 120 }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+ok(rootEl.querySelectorAll(".usage-stats__tip-breakdown .usage-stats__tip-row--other").length === 5, "donut tooltip caps the visible Other breakdown");
+ok(rootEl.querySelector(".usage-stats__tip-breakdown .usage-stats__tip-more") !== null, "donut tooltip discloses omitted Other models");
+await act(async () => {
+  modelSegments[modelSegments.length - 1]?.dispatchEvent(new dom.window.MouseEvent("mouseout", { bubbles: true }));
+  rootEl.querySelector("rect.usage-stats__bar-hit")?.dispatchEvent(new dom.window.MouseEvent("mouseover", { bubbles: true, clientX: 120, clientY: 120 }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+const trendTip = rootEl.querySelector(".usage-stats__tip--screen");
+ok(trendTip?.querySelectorAll(".usage-stats__tip-row--other").length === 5, "daily tooltip caps the visible Other breakdown");
+ok(trendTip?.querySelector(".usage-stats__tip-more") !== null, "daily tooltip discloses omitted Other models");
 
 const cliButton = [...rootEl.querySelectorAll("button")].find((button) => button.textContent === "CLI");
 if (!cliButton) throw new Error("missing CLI source button");

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -75,7 +75,8 @@ import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "remote", "skills", "subagents", "plugins", "memory", "hooks", "diagnostics", "shortcuts", "permissions", "sandbox", "network", "appearance", "updates"];
 export type SettingsInitialFocus =
   | { target: "bot-allowlist"; connectionId?: string }
-  | { target: "model-access" };
+  | { target: "model-access" }
+  | { target: "model-stats" };
 type DesktopPlatform = "darwin" | "windows" | "linux";
 
 const MCPServersSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.MCPServersSettingsPage })));
@@ -4086,8 +4087,23 @@ function botDraftWithDerivedGatewayState(draft: BotSettingsView): BotSettingsVie
 function ModelsSection({ s, busy, apply, backgroundApply, initialFocus }: ModelsSectionProps) {
   const t = useT();
   const [subtab, setSubtab] = useState<"usage" | "access" | "stats">(
-    initialFocus?.target === "model-access" ? "access" : "usage",
+    initialFocus?.target === "model-access"
+      ? "access"
+      : initialFocus?.target === "model-stats"
+        ? "stats"
+        : "usage",
   );
+  // The command palette may re-target this section while the settings panel is
+  // already open (the subtab state is not remounted by a tab change), so a
+  // fresh focus switches the subtab; each target is handled once, mirroring
+  // BotsSection's one-shot focus consumption.
+  const modelFocusHandledRef = useRef("");
+  useEffect(() => {
+    if (initialFocus?.target !== "model-access" && initialFocus?.target !== "model-stats") return;
+    if (modelFocusHandledRef.current === initialFocus.target) return;
+    modelFocusHandledRef.current = initialFocus.target;
+    setSubtab(initialFocus.target === "model-access" ? "access" : "stats");
+  }, [initialFocus]);
   const autoRefreshKeyRef = useRef("");
   const autoRefreshGenerationRef = useRef(0);
   const refs = useMemo(() => allRefs(s), [s.providers]);

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -74,9 +74,9 @@ import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "remote", "skills", "subagents", "plugins", "memory", "hooks", "diagnostics", "shortcuts", "permissions", "sandbox", "network", "appearance", "updates"];
 export type SettingsInitialFocus =
-  | { target: "bot-allowlist"; connectionId?: string }
-  | { target: "model-access" }
-  | { target: "model-stats" };
+  | { target: "bot-allowlist"; connectionId?: string; requestId?: number }
+  | { target: "model-access"; requestId?: number }
+  | { target: "model-stats"; requestId: number };
 type DesktopPlatform = "darwin" | "windows" | "linux";
 
 const MCPServersSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.MCPServersSettingsPage })));
@@ -4094,16 +4094,13 @@ function ModelsSection({ s, busy, apply, backgroundApply, initialFocus }: Models
         : "usage",
   );
   // The command palette may re-target this section while the settings panel is
-  // already open (the subtab state is not remounted by a tab change), so a
-  // fresh focus switches the subtab; each target is handled once, mirroring
-  // BotsSection's one-shot focus consumption.
-  const modelFocusHandledRef = useRef("");
+  // already open (the subtab state is not remounted by a tab change). Each
+  // freshly allocated focus request runs this effect once, including repeated
+  // requests for the same target after the user changes subtabs.
   useEffect(() => {
     if (initialFocus?.target !== "model-access" && initialFocus?.target !== "model-stats") return;
-    if (modelFocusHandledRef.current === initialFocus.target) return;
-    modelFocusHandledRef.current = initialFocus.target;
     setSubtab(initialFocus.target === "model-access" ? "access" : "stats");
-  }, [initialFocus]);
+  }, [initialFocus?.target, initialFocus?.requestId]);
   const autoRefreshKeyRef = useRef("");
   const autoRefreshGenerationRef = useRef(0);
   const refs = useMemo(() => allRefs(s), [s.providers]);

--- a/desktop/frontend/src/components/UsageStatsPanel.css
+++ b/desktop/frontend/src/components/UsageStatsPanel.css
@@ -377,14 +377,27 @@
   background: var(--bg-elev);
 }
 
-/* "Other" aggregate row: the entire row is clickable to expand/collapse the
-   detail list. The chevron button inside it stops propagation so double-firing
-   is avoided; both the row click and the button trigger the same toggle. */
+/* "Other" aggregate row: the entire row is one native button that toggles the
+   detail list. */
 .usage-stats__model-row--expandable {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: inherit;
   cursor: pointer;
 }
 
-/* "Other" row toggle (chevron) that expands the aggregated tail models. */
+.usage-stats__model-item {
+  list-style: none;
+}
+
+.usage-stats__model-row + .usage-stats__model-item {
+  border-top: 1px solid var(--border-soft);
+}
+
+/* Decorative chevron inside the "Other" row button. */
 .usage-stats__model-toggle {
   display: inline-flex;
   align-items: center;
@@ -394,7 +407,6 @@
   border: none;
   background: none;
   color: var(--fg-faint);
-  cursor: pointer;
   vertical-align: middle;
 }
 
@@ -505,6 +517,12 @@
   border-top: 1px solid var(--border-soft);
   margin-top: 4px;
   padding-top: 4px;
+}
+
+.usage-stats__tip-more {
+  padding-left: 8px;
+  color: var(--fg-faint);
+  font-style: italic;
 }
 
 .usage-stats__foot {

--- a/desktop/frontend/src/components/UsageStatsPanel.css
+++ b/desktop/frontend/src/components/UsageStatsPanel.css
@@ -1,24 +1,15 @@
 /* ── Usage statistics panel (UsageStatsPanel.tsx) ─────────────────────────
    Charts are hand-drawn SVG driven entirely by theme variables, so both stock
-   themes and theme packs adapt automatically. The heatmap's 5 levels and the
-   per-model palette derive from --accent / --fg via color-mix. */
+   themes and theme packs adapt automatically. The heatmap's 5 levels come from
+   --accent via color-mix; model colours are the fixed --chart-1..5 series
+   (rank order by token volume) plus the gray --chart-other step, with
+   light/dark variants defined in styles.css. */
 
 .usage-stats {
-  --stats-hue-l: 66%;
   display: flex;
   flex-direction: column;
   gap: 18px;
   min-width: 0;
-}
-
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme]) .usage-stats {
-    --stats-hue-l: 46%;
-  }
-}
-
-:root[data-theme="light"] .usage-stats {
-  --stats-hue-l: 42%;
 }
 
 .usage-stats__toolbar {
@@ -315,7 +306,7 @@
   width: 14px;
   height: 3px;
   border-radius: 2px;
-  background: var(--accent);
+  background: color-mix(in srgb, var(--accent) 80%, var(--fg));
 }
 
 /* per-model donut + list */
@@ -386,6 +377,55 @@
   background: var(--bg-elev);
 }
 
+/* "Other" aggregate row: the entire row is clickable to expand/collapse the
+   detail list. The chevron button inside it stops propagation so double-firing
+   is avoided; both the row click and the button trigger the same toggle. */
+.usage-stats__model-row--expandable {
+  cursor: pointer;
+}
+
+/* "Other" row toggle (chevron) that expands the aggregated tail models. */
+.usage-stats__model-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin-right: 4px;
+  border: none;
+  background: none;
+  color: var(--fg-faint);
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+/* Expanded "Other" detail rows: indented, slightly recessed, caption size. */
+.usage-stats__model-row--sub {
+  padding-left: 28px;
+  background: color-mix(in srgb, var(--bg-elev) 55%, transparent);
+  font-size: var(--font-caption);
+}
+
+/* "Other" details expand with an accordion: the wrapper is a grid whose
+   single track animates 0fr → 1fr, so the inner list slides open smoothly
+   instead of popping in. */
+.usage-stats__model-other-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease;
+}
+
+.usage-stats__model-other-wrap--open {
+  grid-template-rows: 1fr;
+}
+
+.usage-stats__model-other-list {
+  overflow: hidden;
+  min-height: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .usage-stats__model-name {
   color: var(--fg);
   overflow: hidden;
@@ -454,15 +494,29 @@
   gap: 5px;
 }
 
+/* Hover tooltip breakdown rows for the "Other" aggregate (trend + donut):
+   indented, muted, same gray swatch as the Other step. */
+.usage-stats__tip-row--other {
+  padding-left: 8px;
+  color: var(--fg-faint);
+}
+
+.usage-stats__tip-breakdown {
+  border-top: 1px solid var(--border-soft);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
 .usage-stats__foot {
   font-size: var(--font-caption);
   color: var(--fg-faint);
 }
 
-/* cache hit-rate trend curve: theme accent (like the heatmap), drawn above
-   the token bars. No point markers — the line alone reads the trend. */
+/* cache hit-rate trend curve: theme accent shifted slightly toward the
+   foreground so it stays distinct from the pure-accent top model bars; drawn
+   above the token bars. No point markers — the line alone reads the trend. */
 .usage-stats__trend {
-  stroke: var(--accent);
+  stroke: color-mix(in srgb, var(--accent) 80%, var(--fg));
   stroke-width: 2;
   opacity: 0.9;
   pointer-events: none;
@@ -485,7 +539,7 @@
 
 /* Marker that lights up on the hit-rate curve for the hovered day. */
 .usage-stats__trend-dot {
-  fill: var(--accent);
+  fill: color-mix(in srgb, var(--accent) 80%, var(--fg));
   stroke: var(--bg-elev);
   stroke-width: 2;
   pointer-events: none;

--- a/desktop/frontend/src/components/UsageStatsPanel.tsx
+++ b/desktop/frontend/src/components/UsageStatsPanel.tsx
@@ -11,7 +11,7 @@
 // "Other" step.
 // The component's styles live in UsageStatsPanel.css (loaded on demand with
 // this chunk), so the ~7 KB rule block never inflates the settings bundle.
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Activity, CalendarDays, ChevronDown, ChevronRight, Coins, Cpu, MessageSquare, MessagesSquare } from "lucide-react";
 import { useI18n } from "../lib/i18n";
 import { app } from "../lib/bridge";
@@ -71,6 +71,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.trendLimited": "Showing the latest 180 days",
     "settings.stats.modelUsage": "Model usage",
     "settings.stats.other": "Other",
+    "settings.stats.moreModels": "more models",
     "settings.stats.total": "Total",
     "settings.stats.percent": "Share",
     "settings.stats.asOf": "As of",
@@ -112,6 +113,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.trendLimited": "仅显示最近 180 天",
     "settings.stats.modelUsage": "模型用量",
     "settings.stats.other": "其他",
+    "settings.stats.moreModels": "个其他模型",
     "settings.stats.total": "总用量",
     "settings.stats.percent": "占比",
     "settings.stats.asOf": "统计截至",
@@ -153,6 +155,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.trendLimited": "僅顯示最近 180 天",
     "settings.stats.modelUsage": "模型用量",
     "settings.stats.other": "其他",
+    "settings.stats.moreModels": "個其他模型",
     "settings.stats.total": "總用量",
     "settings.stats.percent": "佔比",
     "settings.stats.asOf": "統計截至",
@@ -177,6 +180,7 @@ const TOP_MODELS = 5;
 const OTHER_MODEL = "\u0000other"; // sentinel; cannot collide with a real model ref
 const OTHER_COLOR = "var(--chart-other)";
 const MODEL_COLOR_MIX = 72; // percent of the series colour in the --bg-elev mix
+const MAX_TOOLTIP_OTHER_DETAILS = 5;
 // A grouped day carries the raw tail split so hover tooltips can expand the
 // "Other" step into its per-model detail without extra queries.
 type GroupedDaily = DailyTokenUsage & { otherByModel: Record<string, number> };
@@ -690,7 +694,12 @@ function DailyTrend({ daily, modelOrder, t, colorForModel }: { daily: GroupedDai
   const cBottom = contentRect?.bottom ?? window.innerHeight;
   const TIP_W = 260;
   const tipX = tip ? Math.max(cLeft + TIP_W / 2 + 8, Math.min(tip.cx, cRight - TIP_W / 2 - 8)) : 0;
-  const tipRows = tip ? Object.keys(tip.byModel).length + 1 + (tip.otherByModel ? Object.keys(tip.otherByModel).length : 0) : 0; // +1 cache ratio row; + the Other breakdown rows
+  const tipOtherEntries = tip?.otherByModel
+    ? Object.entries(tip.otherByModel).sort((a, b) => b[1] - a[1])
+    : [];
+  const tipOtherVisible = tipOtherEntries.slice(0, MAX_TOOLTIP_OTHER_DETAILS);
+  const tipOtherRemaining = Math.max(0, tipOtherEntries.length - tipOtherVisible.length);
+  const tipRows = tip ? Object.keys(tip.byModel).length + 1 + tipOtherVisible.length + (tipOtherRemaining > 0 ? 1 : 0) : 0; // +1 cache ratio row; + the bounded Other breakdown
   const tipH = 46 + 18 * tipRows;
   const tipAbove = tip ? tip.top - cTop >= tipH + 10 : true;
   let tipY = tip ? (tipAbove ? tip.top - 10 : tip.bottom + 10) : 0;
@@ -793,9 +802,10 @@ function DailyTrend({ daily, modelOrder, t, colorForModel }: { daily: GroupedDai
             {modelOrder.filter((m) => tip.byModel[m] !== undefined).map((m) => (
               <div key={m} className="usage-stats__tip-row"><i className="usage-stats__legend-swatch" style={{ background: colorForModel(m) }} />{m === OTHER_MODEL ? t("settings.stats.other") : m}: {formatTokens(tip.byModel[m])}</div>
             ))}
-            {tip.otherByModel && Object.entries(tip.otherByModel).sort((a, b) => b[1] - a[1]).map(([m, v]) => (
+            {tipOtherVisible.map(([m, v]) => (
               <div key={m} className="usage-stats__tip-row usage-stats__tip-row--other"><i className="usage-stats__legend-swatch" style={{ background: OTHER_COLOR }} />{m}: {formatTokens(v)}</div>
             ))}
+            {tipOtherRemaining > 0 && <div className="usage-stats__tip-more">+{tipOtherRemaining} {t("settings.stats.moreModels")}</div>}
             <div>{t("settings.stats.cacheHitRate")}: {cacheRateText(tip.cacheHit, tip.cacheMiss)}</div>
           </div>
         )}
@@ -826,6 +836,9 @@ function ModelUsage({ models, t, colorForModel }: { models: GroupedModel[]; t: U
 
   if (models.length === 0) return null;
   const other = models.find((m) => m.model === OTHER_MODEL);
+  const tipItems = tip?.items ?? [];
+  const tipItemsVisible = tipItems.slice(0, MAX_TOOLTIP_OTHER_DETAILS);
+  const tipItemsRemaining = Math.max(0, tipItems.length - tipItemsVisible.length);
 
   // The ring leaves a 6px margin inside the 240px viewBox at rest, so the
   // hover-grow of the stroke (+5px, half of it outward) keeps a 3.5px margin
@@ -887,11 +900,12 @@ function ModelUsage({ models, t, colorForModel }: { models: GroupedModel[]; t: U
               <div className="usage-stats__tip-title">{tip.model === OTHER_MODEL ? t("settings.stats.other") : tip.model}</div>
               <div>{t("settings.stats.total")}: {formatTokens(tip.tokens)}</div>
               <div>{t("settings.stats.percent")}: {formatPercent(tip.percent)}</div>
-              {tip.items && tip.items.length > 0 && (
+              {tipItems.length > 0 && (
                 <div className="usage-stats__tip-breakdown">
-                  {tip.items.map((it) => (
+                  {tipItemsVisible.map((it) => (
                     <div key={it.model} className="usage-stats__tip-row usage-stats__tip-row--other"><i className="usage-stats__legend-swatch" style={{ background: OTHER_COLOR }} />{it.model}: {formatTokens(it.tokens)}</div>
                   ))}
+                  {tipItemsRemaining > 0 && <div className="usage-stats__tip-more">+{tipItemsRemaining} {t("settings.stats.moreModels")}</div>}
                 </div>
               )}
             </div>
@@ -900,49 +914,46 @@ function ModelUsage({ models, t, colorForModel }: { models: GroupedModel[]; t: U
         <ul className="usage-stats__model-list">
           {models.map((m) => {
             const isOther = m.model === OTHER_MODEL;
-            return (
-              <li
-                key={m.model}
-                className={`usage-stats__model-row${isOther ? " usage-stats__model-row--expandable" : ""}`}
-                onMouseEnter={() => setHover(m.model)}
-                onMouseLeave={() => setHover(null)}
-                {...(isOther
-                  ? {
-                      role: "button",
-                      tabIndex: 0,
-                      onClick: () => setExpandedOther(!expandedOther),
-                      // Keyboard users can also toggle the whole row; the
-                      // chevron button inside stops propagation for the mouse
-                      // path, and this target check keeps Enter/Space on the
-                      // button from double-firing the toggle.
-                      onKeyDown: (e: ReactKeyboardEvent<HTMLLIElement>) => {
-                        if (e.target !== e.currentTarget) return;
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          setExpandedOther(!expandedOther);
-                        }
-                      },
-                    }
-                  : {})}
-              >
+            const rowContent = (
+              <>
                 <i className="usage-stats__legend-swatch" style={{ background: colorForModel(m.model) }} />
                 <span className="usage-stats__model-name">
                   {isOther && (
-                    <button
-                      type="button"
-                      className="usage-stats__model-toggle"
-                      onClick={(e) => { e.stopPropagation(); setExpandedOther(!expandedOther); }}
-                      aria-expanded={expandedOther}
-                      aria-label={t("settings.stats.other")}
-                    >
+                    <span className="usage-stats__model-toggle" aria-hidden="true">
                       {expandedOther ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    </button>
+                    </span>
                   )}
                   {isOther ? t("settings.stats.other") : m.model}
                 </span>
                 <span className="usage-stats__model-provider">{isOther ? "" : providerOf(m.model)}</span>
                 <span className="usage-stats__model-tokens">{formatTokens(m.tokens)}</span>
                 <span className="usage-stats__model-pct">{formatPercent(m.percent)}</span>
+              </>
+            );
+            if (isOther) {
+              return (
+                <li key={m.model} className="usage-stats__model-item">
+                  <button
+                    type="button"
+                    className="usage-stats__model-row usage-stats__model-row--expandable"
+                    onMouseEnter={() => setHover(m.model)}
+                    onMouseLeave={() => setHover(null)}
+                    onClick={() => setExpandedOther((open) => !open)}
+                    aria-expanded={expandedOther}
+                  >
+                    {rowContent}
+                  </button>
+                </li>
+              );
+            }
+            return (
+              <li
+                key={m.model}
+                className="usage-stats__model-row"
+                onMouseEnter={() => setHover(m.model)}
+                onMouseLeave={() => setHover(null)}
+              >
+                {rowContent}
               </li>
             );
           })}

--- a/desktop/frontend/src/components/UsageStatsPanel.tsx
+++ b/desktop/frontend/src/components/UsageStatsPanel.tsx
@@ -2,15 +2,20 @@
 // settings page. It reads aggregated stats from the Go backend (App.UsageStats)
 // and draws three charts by hand in SVG — a GitHub-style activity heatmap, a
 // stacked per-day token trend, and a per-model donut — so no chart library is
-// needed and theme variables (--accent, --fg, --bg-elev-*, --stats-hue-l) drive
-// the palette for both stock themes and theme packs.
+// needed and theme variables (--accent, --fg, --bg-elev-*) drive
+// the palette for both stock themes and theme packs. Model colours come from
+// a fixed two-set categorical palette (--chart-1..5 plus the gray
+// --chart-other, light/dark variants defined in styles.css from GitHub
+// Primer's data-viz tokens): a model's colour is its rank among the top five
+// by token volume, and everything beyond the top five collapses into one gray
+// "Other" step.
 // The component's styles live in UsageStatsPanel.css (loaded on demand with
 // this chunk), so the ~7 KB rule block never inflates the settings bundle.
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Activity, CalendarDays, Coins, Cpu, MessageSquare, MessagesSquare } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Activity, CalendarDays, ChevronDown, ChevronRight, Coins, Cpu, MessageSquare, MessagesSquare } from "lucide-react";
 import { useI18n } from "../lib/i18n";
 import { app } from "../lib/bridge";
-import type { DailyTokenUsage, UsageStatsRange, UsageStatsRequest } from "../lib/types";
+import type { DailyTokenUsage, ModelTokenUsage, UsageStatsRange, UsageStatsRequest } from "../lib/types";
 import { formatUsageTokens as formatTokens } from "../lib/usageStatsFormat";
 import "./UsageStatsPanel.css";
 
@@ -65,6 +70,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.dailyTrend": "Daily token trend",
     "settings.stats.trendLimited": "Showing the latest 180 days",
     "settings.stats.modelUsage": "Model usage",
+    "settings.stats.other": "Other",
     "settings.stats.total": "Total",
     "settings.stats.percent": "Share",
     "settings.stats.asOf": "As of",
@@ -105,6 +111,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.dailyTrend": "按天 Token 趋势",
     "settings.stats.trendLimited": "仅显示最近 180 天",
     "settings.stats.modelUsage": "模型用量",
+    "settings.stats.other": "其他",
     "settings.stats.total": "总用量",
     "settings.stats.percent": "占比",
     "settings.stats.asOf": "统计截至",
@@ -145,6 +152,7 @@ const USAGE_STATS_TRANSLATIONS = {
     "settings.stats.dailyTrend": "按天 Token 趨勢",
     "settings.stats.trendLimited": "僅顯示最近 180 天",
     "settings.stats.modelUsage": "模型用量",
+    "settings.stats.other": "其他",
     "settings.stats.total": "總用量",
     "settings.stats.percent": "佔比",
     "settings.stats.asOf": "統計截至",
@@ -155,56 +163,25 @@ const USAGE_STATS_TRANSLATIONS = {
 type UsageStatsKey = keyof typeof USAGE_STATS_TRANSLATIONS.en;
 type UsageStatsTranslator = (key: UsageStatsKey) => string;
 
-// Seed hues keep neighbouring models distinguishable. The final CSS colour
-// expression blends each seed with the live theme's accent and foreground, so
-// base-colour and light/dark changes need no React rerender.
-const PALETTE_SEEDS = [
-  "#0087be", "#78dcfa", "#00aadc", "#87a6bc", "#d54e21", "#f0821e",
-  "#4ab866", "#f0b849", "#d94f4f", "#e66760", "#8c88cd", "#69c5e4",
-  "#ffdf8b", "#61e064", "#bbd634", "#fdd666", "#a4dbdb", "#b51f29",
-  "#f58268", "#f4979c",
-];
-const themedModelColor = (seed: string): string =>
-  `color-mix(in srgb, color-mix(in srgb, var(--accent) 24%, ${seed}) 60%, var(--fg) 40%)`;
-const PALETTE = PALETTE_SEEDS.map(themedModelColor);
-// LCG-seeded Fisher–Yates: a fixed seed keeps the shuffle stable across
-// renders and ranges while still picking palette colours "at random".
-const PALETTE_ORDER = (() => {
-  const a = [...PALETTE];
-  let s = 42;
-  const rnd = () => {
-    s = (s * 1664525 + 1013904223) >>> 0;
-    return s / 4294967296;
-  };
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(rnd() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-})();
-function assignModelColors(ordered: string[]): Map<string, string> {
-  const map = new Map<string, string>();
-  let slot = 0;
-  for (const m of ordered) {
-    if (map.has(m)) continue;
-    if (slot < PALETTE_ORDER.length) {
-      map.set(m, PALETTE_ORDER[slot]);
-    } else {
-      // Beyond the curated palette: retain a stable hue, then blend it with
-      // the active accent and foreground for the same theme adaptation.
-      map.set(m, overflowModelColor(m));
-    }
-    slot++;
-  }
-  return map;
-}
-const hashHue = (key: string): number => {
-  let h = 0;
-  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
-  return h % 360;
-};
-const overflowModelColor = (model: string): string =>
-  `color-mix(in srgb, color-mix(in srgb, hsl(${hashHue(model)} 52% var(--stats-hue-l)) 76%, var(--accent) 24%) 60%, var(--fg) 40%)`;
+// Model colour palette: a fixed two-set categorical series (--chart-1..5 with
+// light/dark variants defined in styles.css, from GitHub Primer's data-viz
+// tokens). A model's colour is its rank among the top five; models beyond the
+// top five share one gray "Other" step (--chart-other). The palette is
+// deliberately independent of --accent so charts stay readable in every theme
+// style and theme pack, whose tokens only cover the app chrome.
+// Each series colour is mixed toward --bg-elev like the heatmap levels
+// (MODEL_COLOR_MIX% colour + the rest background), so the pure hexes sit
+// softly on the card instead of glaring; the two themes still get the same
+// hues, only the background differs.
+const TOP_MODELS = 5;
+const OTHER_MODEL = "\u0000other"; // sentinel; cannot collide with a real model ref
+const OTHER_COLOR = "var(--chart-other)";
+const MODEL_COLOR_MIX = 72; // percent of the series colour in the --bg-elev mix
+// A grouped day carries the raw tail split so hover tooltips can expand the
+// "Other" step into its per-model detail without extra queries.
+type GroupedDaily = DailyTokenUsage & { otherByModel: Record<string, number> };
+// A grouped model may carry the tail list that "Other" aggregates.
+type GroupedModel = ModelTokenUsage & { items?: ModelTokenUsage[] };
 
 // localDay returns today's date (plus/minus offsetDays) in the local calendar,
 // matching the backend's "2006-01-02" day keys.
@@ -291,25 +268,48 @@ export function UsageStatsPanel() {
     void load();
   }, [load]);
 
-  // Colours follow the order models were first used (walking the daily series
-  // chronologically); the hash hue is only a fallback for models that somehow
-  // escape the aggregate.
-  const modelOrder = useMemo(() => {
-    const seen: string[] = [];
-    for (const d of stats?.daily ?? []) {
-      for (const m of Object.keys(d.byModel).sort()) {
-        if (!seen.includes(m)) seen.push(m);
-      }
-    }
-    for (const m of stats?.models ?? []) {
-      if (!seen.includes(m.model)) seen.push(m.model);
-    }
-    return seen;
+  // Models rank by token volume (stats.models is already descending): the top
+  // five keep their own series colour and everything else aggregates into a
+  // single gray "Other" entry (carrying its tail list for expandable detail),
+  // so the palette stays distinguishable.
+  const groupedModels = useMemo<GroupedModel[]>(() => {
+    const list = stats?.models ?? [];
+    if (list.length <= TOP_MODELS) return list;
+    const top = list.slice(0, TOP_MODELS);
+    const rest = list.slice(TOP_MODELS);
+    return [
+      ...top,
+      {
+        model: OTHER_MODEL,
+        provider: "",
+        tokens: rest.reduce((sum, m) => sum + m.tokens, 0),
+        percent: rest.reduce((sum, m) => sum + m.percent, 0),
+        items: rest,
+      },
+    ];
   }, [stats]);
-  const palette = useMemo(() => assignModelColors(modelOrder), [modelOrder]);
+  const dailyGrouped = useMemo<GroupedDaily[]>(() => {
+    const topSet = new Set((stats?.models ?? []).slice(0, TOP_MODELS).map((m) => m.model));
+    return (stats?.daily ?? []).map((d) => {
+      const byModel: Record<string, number> = {};
+      const otherByModel: Record<string, number> = {};
+      for (const [model, tokens] of Object.entries(d.byModel)) {
+        if (topSet.has(model)) byModel[model] = (byModel[model] ?? 0) + tokens;
+        else otherByModel[model] = (otherByModel[model] ?? 0) + tokens;
+      }
+      const other = Object.values(otherByModel).reduce((sum, v) => sum + v, 0);
+      if (other > 0) byModel[OTHER_MODEL] = other;
+      return { ...d, byModel, otherByModel };
+    });
+  }, [stats]);
   const colorForModel = useCallback(
-    (model: string) => palette.get(model) ?? overflowModelColor(model || "unknown"),
-    [palette],
+    (model: string) => {
+      if (model === OTHER_MODEL) return OTHER_COLOR;
+      const slot = (stats?.models ?? []).findIndex((m) => m.model === model);
+      const rank = Math.min(slot < 0 ? 0 : slot, TOP_MODELS - 1) + 1;
+      return `color-mix(in srgb, var(--chart-${rank}) ${MODEL_COLOR_MIX}%, var(--bg-elev))`;
+    },
+    [stats],
   );
 
   return (
@@ -383,8 +383,8 @@ export function UsageStatsPanel() {
         <>
           <StatCards stats={stats} t={t} />
           <Heatmap daily={heatDaily} from={heatWindow.from} to={heatWindow.to} t={t} />
-          <DailyTrend stats={stats} t={t} colorForModel={colorForModel} />
-          <ModelUsage stats={stats} t={t} colorForModel={colorForModel} />
+          <DailyTrend daily={dailyGrouped} modelOrder={groupedModels.map((m) => m.model)} t={t} colorForModel={colorForModel} />
+          <ModelUsage models={groupedModels} t={t} colorForModel={colorForModel} />
           {stats.to && (
             <div className="usage-stats__foot">
               {t("settings.stats.asOf")} {stats.to}
@@ -594,11 +594,10 @@ function Heatmap({ daily, from, to, t }: { daily: DailyTokenUsage[]; from: strin
 
 // ── Section 5: stacked daily token trend ──────────────────────────────────
 
-function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: UsageStatsTranslator; colorForModel: (m: string) => string }) {
-  const daily = stats.daily;
+function DailyTrend({ daily, modelOrder, t, colorForModel }: { daily: GroupedDaily[]; modelOrder: string[]; t: UsageStatsTranslator; colorForModel: (m: string) => string }) {
   const trendDaily = daily.length > MAX_TREND_DAYS ? daily.slice(-MAX_TREND_DAYS) : daily;
   const trendLimited = trendDaily.length !== daily.length;
-  const [tip, setTip] = useState<{ day: string; total: number; byModel: Record<string, number>; cacheHit: number; cacheMiss: number; cx: number; top: number; bottom: number } | null>(null);
+  const [tip, setTip] = useState<{ day: string; total: number; byModel: Record<string, number>; otherByModel?: Record<string, number>; cacheHit: number; cacheMiss: number; cx: number; top: number; bottom: number } | null>(null);
   const [hover, setHover] = useState<string | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
 
@@ -674,6 +673,11 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
   const trendPath = smoothPath(trendPoints);
   const trendTipPt = tip ? trendPointByDay.get(tip.day) : undefined;
   const rateTicks = [0, 25, 50, 75, 100];
+  // Legend and bar stacks follow the overall usage ranking (not the per-day
+  // leader), so a model's colour stays in the same position every day and the
+  // aggregated "Other" step always sits on top.
+  const legendAgg = aggregateByModel(trendDaily);
+  const legendModels = modelOrder.filter((m) => legendAgg[m] !== undefined);
 
   // Tooltip is viewport-fixed and only clamped to the settings content pane
   // (left/right/top/bottom), so it may float over the chart freely but never
@@ -686,7 +690,7 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
   const cBottom = contentRect?.bottom ?? window.innerHeight;
   const TIP_W = 260;
   const tipX = tip ? Math.max(cLeft + TIP_W / 2 + 8, Math.min(tip.cx, cRight - TIP_W / 2 - 8)) : 0;
-  const tipRows = tip ? Object.keys(tip.byModel).length + 1 : 0; // +1 for the cache ratio row
+  const tipRows = tip ? Object.keys(tip.byModel).length + 1 + (tip.otherByModel ? Object.keys(tip.otherByModel).length : 0) : 0; // +1 cache ratio row; + the Other breakdown rows
   const tipH = 46 + 18 * tipRows;
   const tipAbove = tip ? tip.top - cTop >= tipH + 10 : true;
   let tipY = tip ? (tipAbove ? tip.top - 10 : tip.bottom + 10) : 0;
@@ -712,9 +716,10 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
           })}
           {visible.map((d, i) => {
             const x = padL + barHalf + i * step - barW / 2;
-            const modelOrder = Object.entries(d.byModel).sort((a, b) => b[1] - a[1]);
+            const dayOrder = modelOrder.filter((m) => d.byModel[m] !== undefined);
             let yBottom = padT + plotH;
-            const bars = modelOrder.map(([model, tokens]) => {
+            const bars = dayOrder.map((model) => {
+              const tokens = d.byModel[model];
               const h = (tokens / maxTotal) * plotH;
               const y = yBottom - h;
               yBottom = y;
@@ -754,7 +759,7 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
                   height={plotH}
                   onMouseEnter={(e) => {
                     const r = e.currentTarget.getBoundingClientRect();
-                    setTip({ day: d.day, total: d.total, byModel: d.byModel, cacheHit: d.cacheHit, cacheMiss: d.cacheMiss, cx: r.left + r.width / 2, top: r.top, bottom: r.bottom });
+                    setTip({ day: d.day, total: d.total, byModel: d.byModel, otherByModel: d.otherByModel, cacheHit: d.cacheHit, cacheMiss: d.cacheMiss, cx: r.left + r.width / 2, top: r.top, bottom: r.bottom });
                   }}
                   onMouseLeave={() => setTip(null)}
                 />
@@ -785,17 +790,20 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
           <div className="usage-stats__tip usage-stats__tip--chart usage-stats__tip--screen" style={{ transform: `translate(${tipX}px, ${tipY}px) translate(-50%, ${tipAbove ? "-100%" : "0"})` }}>
             <div className="usage-stats__tip-title">{tip.day}</div>
             <div>{t("settings.stats.total")}: {formatTokens(tip.total)}</div>
-            {Object.entries(tip.byModel).sort((a, b) => b[1] - a[1]).map(([m, v]) => (
-              <div key={m} className="usage-stats__tip-row"><i className="usage-stats__legend-swatch" style={{ background: colorForModel(m) }} />{m}: {formatTokens(v)}</div>
+            {modelOrder.filter((m) => tip.byModel[m] !== undefined).map((m) => (
+              <div key={m} className="usage-stats__tip-row"><i className="usage-stats__legend-swatch" style={{ background: colorForModel(m) }} />{m === OTHER_MODEL ? t("settings.stats.other") : m}: {formatTokens(tip.byModel[m])}</div>
+            ))}
+            {tip.otherByModel && Object.entries(tip.otherByModel).sort((a, b) => b[1] - a[1]).map(([m, v]) => (
+              <div key={m} className="usage-stats__tip-row usage-stats__tip-row--other"><i className="usage-stats__legend-swatch" style={{ background: OTHER_COLOR }} />{m}: {formatTokens(v)}</div>
             ))}
             <div>{t("settings.stats.cacheHitRate")}: {cacheRateText(tip.cacheHit, tip.cacheMiss)}</div>
           </div>
         )}
         <div className="usage-stats__legend">
-          {Object.keys(aggregateByModel(trendDaily)).map((model) => (
+          {legendModels.map((model) => (
             <span key={model} className="usage-stats__legend-item" onMouseEnter={() => setHover(model)} onMouseLeave={() => setHover(null)}>
               <i className="usage-stats__legend-swatch" style={{ background: colorForModel(model) }} />
-              {model}
+              {model === OTHER_MODEL ? t("settings.stats.other") : model}
             </span>
           ))}
           <span className="usage-stats__legend-item" aria-hidden="true">
@@ -810,23 +818,24 @@ function DailyTrend({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
 
 // ── Section 6: per-model donut + list ─────────────────────────────────────
 
-function ModelUsage({ stats, t, colorForModel }: { stats: UsageStatsRange; t: UsageStatsTranslator; colorForModel: (m: string) => string }) {
-  const models = stats.models;
-  const [tip, setTip] = useState<{ model: string; tokens: number; percent: number; x: number; y: number } | null>(null);
+function ModelUsage({ models, t, colorForModel }: { models: GroupedModel[]; t: UsageStatsTranslator; colorForModel: (m: string) => string }) {
+  const [tip, setTip] = useState<{ model: string; tokens: number; percent: number; x: number; y: number; items?: ModelTokenUsage[] } | null>(null);
   const [hover, setHover] = useState<string | null>(null);
+  const [expandedOther, setExpandedOther] = useState(false);
   const donutRef = useRef<HTMLDivElement>(null);
 
   if (models.length === 0) return null;
+  const other = models.find((m) => m.model === OTHER_MODEL);
 
-  // The ring's outer edge stays fixed; thickening the stroke only grows it
-  // inward (shrinking the hole), so the donut never overflows the svg viewport
-  // and gets clipped into a square.
-  const OUTER = 118; // ring outer radius
+  // The ring leaves a 6px margin inside the 240px viewBox at rest, so the
+  // hover-grow of the stroke (+5px, half of it outward) keeps a 3.5px margin
+  // and never overflows into a clipped square.
+  const OUTER = 114; // ring outer radius
   const SW = 36; // ring thickness
   const R = OUTER - SW / 2; // circle path radius
-  const CX = OUTER + 2; // svg centre (240x240 viewBox)
+  const CX = 120; // svg centre; the 240x240 viewBox stays fixed while the ring shrinks
   const CIRC = 2 * Math.PI * R;
-  const total = Math.max(1, stats.tokens);
+  const total = Math.max(1, models.reduce((sum, m) => sum + m.tokens, 0));
   let offset = 0;
 
   const tipX = tip ? Math.max(110, Math.min(tip.x, (donutRef.current?.clientWidth ?? 240) - 110)) : 0;
@@ -862,7 +871,7 @@ function ModelUsage({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
                     setHover(m.model);
                     if (!dw) return;
                     const dr = dw.getBoundingClientRect();
-                    setTip({ model: m.model, tokens: m.tokens, percent: m.percent, x: e.clientX - dr.left, y: e.clientY - dr.top });
+                    setTip({ model: m.model, tokens: m.tokens, percent: m.percent, x: e.clientX - dr.left, y: e.clientY - dr.top, items: m.items });
                   }}
                   onMouseLeave={() => { setHover(null); setTip(null); }}
                 />
@@ -870,32 +879,88 @@ function ModelUsage({ stats, t, colorForModel }: { stats: UsageStatsRange; t: Us
               offset += dash;
               return el;
             })}
-            <text className="usage-stats__donut-center" x={CX} y={CX + 8} textAnchor="middle">{formatCompact(stats.tokens)}</text>
+            <text className="usage-stats__donut-center" x={CX} y={CX + 8} textAnchor="middle">{formatCompact(total)}</text>
             <text className="usage-stats__donut-label" x={CX} y={CX + 26} textAnchor="middle">{t("settings.stats.tokens")}</text>
           </svg>
           {tip && (
             <div className="usage-stats__tip usage-stats__tip--chart" style={{ transform: `translate(${tipX}px, ${tipY}px) translate(-50%, ${tipAbove ? "-100%" : "0"})` }}>
-              <div className="usage-stats__tip-title">{tip.model}</div>
+              <div className="usage-stats__tip-title">{tip.model === OTHER_MODEL ? t("settings.stats.other") : tip.model}</div>
               <div>{t("settings.stats.total")}: {formatTokens(tip.tokens)}</div>
               <div>{t("settings.stats.percent")}: {formatPercent(tip.percent)}</div>
+              {tip.items && tip.items.length > 0 && (
+                <div className="usage-stats__tip-breakdown">
+                  {tip.items.map((it) => (
+                    <div key={it.model} className="usage-stats__tip-row usage-stats__tip-row--other"><i className="usage-stats__legend-swatch" style={{ background: OTHER_COLOR }} />{it.model}: {formatTokens(it.tokens)}</div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
         </div>
         <ul className="usage-stats__model-list">
-          {models.map((m) => (
-            <li
-              key={m.model}
-              className="usage-stats__model-row"
-              onMouseEnter={() => setHover(m.model)}
-              onMouseLeave={() => setHover(null)}
-            >
-              <i className="usage-stats__legend-swatch" style={{ background: colorForModel(m.model) }} />
-              <span className="usage-stats__model-name">{m.model}</span>
-              <span className="usage-stats__model-provider">{providerOf(m.model)}</span>
-              <span className="usage-stats__model-tokens">{formatTokens(m.tokens)}</span>
-              <span className="usage-stats__model-pct">{formatPercent(m.percent)}</span>
+          {models.map((m) => {
+            const isOther = m.model === OTHER_MODEL;
+            return (
+              <li
+                key={m.model}
+                className={`usage-stats__model-row${isOther ? " usage-stats__model-row--expandable" : ""}`}
+                onMouseEnter={() => setHover(m.model)}
+                onMouseLeave={() => setHover(null)}
+                {...(isOther
+                  ? {
+                      role: "button",
+                      tabIndex: 0,
+                      onClick: () => setExpandedOther(!expandedOther),
+                      // Keyboard users can also toggle the whole row; the
+                      // chevron button inside stops propagation for the mouse
+                      // path, and this target check keeps Enter/Space on the
+                      // button from double-firing the toggle.
+                      onKeyDown: (e: ReactKeyboardEvent<HTMLLIElement>) => {
+                        if (e.target !== e.currentTarget) return;
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setExpandedOther(!expandedOther);
+                        }
+                      },
+                    }
+                  : {})}
+              >
+                <i className="usage-stats__legend-swatch" style={{ background: colorForModel(m.model) }} />
+                <span className="usage-stats__model-name">
+                  {isOther && (
+                    <button
+                      type="button"
+                      className="usage-stats__model-toggle"
+                      onClick={(e) => { e.stopPropagation(); setExpandedOther(!expandedOther); }}
+                      aria-expanded={expandedOther}
+                      aria-label={t("settings.stats.other")}
+                    >
+                      {expandedOther ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    </button>
+                  )}
+                  {isOther ? t("settings.stats.other") : m.model}
+                </span>
+                <span className="usage-stats__model-provider">{isOther ? "" : providerOf(m.model)}</span>
+                <span className="usage-stats__model-tokens">{formatTokens(m.tokens)}</span>
+                <span className="usage-stats__model-pct">{formatPercent(m.percent)}</span>
+              </li>
+            );
+          })}
+          {other?.items && other.items.length > 0 && (
+            <li className={`usage-stats__model-other-wrap${expandedOther ? " usage-stats__model-other-wrap--open" : ""}`}>
+              <ul className="usage-stats__model-other-list">
+                {other.items.map((it) => (
+                  <li key={it.model} className="usage-stats__model-row usage-stats__model-row--sub">
+                    <i className="usage-stats__legend-swatch" style={{ background: OTHER_COLOR }} />
+                    <span className="usage-stats__model-name">{it.model}</span>
+                    <span className="usage-stats__model-provider">{providerOf(it.model)}</span>
+                    <span className="usage-stats__model-tokens">{formatTokens(it.tokens)}</span>
+                    <span className="usage-stats__model-pct">{formatPercent(it.percent)}</span>
+                  </li>
+                ))}
+              </ul>
             </li>
-          ))}
+          )}
         </ul>
       </div>
     </section>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2268,6 +2268,7 @@ export const en = {
   "palette.cmd.appearance": "Appearance",
   "palette.cmd.memory": "Memory",
   "palette.cmd.models": "Models",
+  "palette.cmd.usageStats": "Usage statistics",
   "palette.group.remote": "Remote SSH",
   "palette.remote.connect": "Connect to {host}",
   "palette.remote.open": "Open remote workspace on {host}",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2851,6 +2851,7 @@ export const zhTW: Record<DictKey, string> = {
   "palette.cmd.appearance": "外觀",
   "palette.cmd.memory": "記憶",
   "palette.cmd.models": "模型",
+  "palette.cmd.usageStats": "使用統計",
   "palette.group.remote": "遠端 SSH",
   "palette.remote.connect": "連線到 {host}",
   "palette.remote.open": "在 {host} 開啟遠端工作區",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2271,6 +2271,7 @@ export const zh: Record<DictKey, string> = {
   "palette.cmd.appearance": "外观",
   "palette.cmd.memory": "记忆",
   "palette.cmd.models": "模型",
+  "palette.cmd.usageStats": "使用统计",
   "palette.group.remote": "远程 SSH",
   "palette.remote.connect": "连接到 {host}",
   "palette.remote.open": "在 {host} 打开远程工作区",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -85,6 +85,20 @@
   --accent-soft: rgba(217, 119, 87, 0.14);
   --accent-strong: #e58a6b;
   --grad: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  /* Chart series colours for the usage-stats model charts (donut + stacked
+     trend). A fixed two-set palette taken from GitHub Primer's data-viz
+     tokens (data-blue/green/orange/purple/pink/gray emphasis, light + dark
+     variants; dark orange uses the palette's brighter .5 step #c46212
+     instead of the official #984b10 emphasis, which reads brownish on this
+     dark background); theme styles and theme packs deliberately do not
+     override these so charts keep the same readable sets in both
+     directions. */
+  --chart-1: #0576ff;
+  --chart-2: #2f6f37;
+  --chart-3: #c46212;
+  --chart-4: #975bf1;
+  --chart-5: #d34591;
+  --chart-other: #576270;
   --chat-user-bg: color-mix(in srgb, var(--accent) 16%, var(--bg-elev-2));
   --chat-user-border: color-mix(in srgb, var(--accent) 28%, var(--border-soft));
   --chat-user-fg: var(--fg);
@@ -335,6 +349,12 @@
     --accent-fg: #fff;
     --accent-soft: rgba(47, 95, 168, 0.12);
     --accent-strong: #244f91;
+    --chart-1: #006edb;
+    --chart-2: #30a147;
+    --chart-3: #eb670f;
+    --chart-4: #894ceb;
+    --chart-5: #ce2c85;
+    --chart-other: #808fa3;
     --chat-user-bg: color-mix(in srgb, var(--accent) 9%, var(--bg-elev));
     --chat-user-border: color-mix(in srgb, var(--accent) 22%, var(--border-soft));
     --chat-user-fg: var(--fg);
@@ -404,6 +424,12 @@
   --accent-fg: #fff;
   --accent-soft: rgba(47, 95, 168, 0.12);
   --accent-strong: #244f91;
+  --chart-1: #006edb;
+  --chart-2: #30a147;
+  --chart-3: #eb670f;
+  --chart-4: #894ceb;
+  --chart-5: #ce2c85;
+  --chart-other: #808fa3;
   --chat-user-bg: color-mix(in srgb, var(--accent) 9%, var(--bg-elev));
   --chat-user-border: color-mix(in srgb, var(--accent) 22%, var(--border-soft));
   --chat-user-fg: var(--fg);


### PR DESCRIPTION
### Summary

The model usage charts (per-model donut and stacked daily trend) previously drew every model in one monochrome accent ramp, which review feedback found too uniform — "all one colour". This PR replaces the ramp with a fixed two-set categorical palette sourced from **GitHub Primer's data-viz tokens** (`primer/primitives`, the official design-system palette explicitly intended "for charts, graphs, and diagrams"):

- Each of the top five models keeps its own series colour by rank (`--chart-1` … `--chart-5`), and everything beyond the top five collapses into one gray `--chart-other` step — exactly the "top 5 + Other" shape suggested in review.
- The palette is defined as CSS variables in `styles.css` with **official light and dark variants** (verified line-by-line against `primer.style` and the published `@primer/primitives` npm CSS), so the same two sets serve every theme style and theme pack without JS theme detection.
- Each series colour is mixed **72% toward `--bg-elev`** (like the heatmap levels), so the pure hexes sit softly on the card instead of glaring; the dark orange uses the palette's brighter `#c46212` step because the official `#984b10` emphasis reads brownish on the dark background.

Also fixed in the same pass:

- **Donut overflow on hover**: the ring was clipped when a hovered segment's stroke thickened. The ring now sits inside a fixed 240×240 viewBox (outer radius 114, centre 120), leaving a 6px margin at rest and 3.5px even when the hover stroke grows — no segment is ever cut off.
- The command-palette "usage statistics" entry now consumes its focus target once (one-shot subtab switch, mirroring `BotsSection`), and the expandable "Other" row is keyboard-accessible (`role="button"` + Enter/Space).

No data or storage format changes — the stats files stay append-only daily JSONL, so existing users' data renders unchanged; colours are computed at render time.

---

### Summary

模型用量图表（环形图与按天堆叠趋势图）此前将所有模型画成同一条 accent 单色渐变，评审反馈认为"太统一，全是一个颜色"。本 PR 将渐变替换为来自 **GitHub Primer 官方 data-viz 色板**（`primer/primitives`，官方设计系统中明确标注"用于 charts, graphs, and diagrams"的图表色板）的固定两套分类配色：

- 用量前五的模型按排名各占一个系列色（`--chart-1` … `--chart-5`），第五名之后全部并入一个灰色 `--chart-other` 台阶——即评审建议的"前 5 有颜色，其余归 Other"形态。
- 色板以 CSS 变量形式定义在 `styles.css`，带**官方浅色/深色两套变体**（已与 primer.style 官网及发布的 `@primer/primitives` npm CSS 逐项核对），无需 JS 主题检测即可适配所有主题风格与主题包。
- 每个系列色与 `--bg-elev` 按 **72%** 混合（同活跃热力图的档位做法），纯色在卡片上显得柔和不刺眼；深色档橙色改用同色板更亮的 `#c46212`，因为官方 emphasis 的 `#984b10` 在深色背景上偏棕。

同一轮一并修复：

- **环形图 hover 溢出**：hover 加粗分段描边时原先会被 SVG 裁切。现在环形固定在 240×240 viewBox 内（外径 114、圆心 120），静止时留 6px 边距，hover 加粗后仍有 3.5px 边距——任何分段都不会被裁掉。
- 命令面板"使用统计"入口改为一次性消费焦点目标（one-shot 切换子页签，与 `BotsSection` 一致）；可展开的 "Other" 行支持键盘操作（`role="button"` + Enter/Space）。

无任何数据或存储格式改动——统计文件仍是追加式每日 JSONL，旧用户数据照常渲染；颜色完全在渲染期计算。

### Issues

N/A

### Verification

- `pnpm pretest` (full frontend gate) — all suites pass, incl. usage-stats **18/18** (rank→`--chart-N` mapping, 72% mix, `--chart-other`), settings-responsive **6/6**
- `pnpm typecheck`, `eslint` on changed files — clean
- `pnpm check:css` (CSS syntax + z-index tokens) — pass
- `wails build` (windows/amd64) — builds clean; palette and donut geometry visually verified in both light and dark themes

### Documentation impact

Documentation-impact: none - colours are pure rendering; no CLI/config/provider behavior or user-facing docs change, and the usage panel has no docs under docs/* to update.

### Cache impact

Cache-impact: none - only desktop frontend render-layer CSS variables; no provider request serialization, system prompt, tool schema, or boot changes.
Cache-guard: the rank-to-variable mapping is pinned by the 18 usage-stats panel assertions (src/__tests__/usage-stats-panel.test.tsx); the palette lives outside scripts/check-cache-impact.sh paths.
System-prompt-review: N/A

---

### 效果展示

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/3a1cc3e9-e875-41c9-8a66-aad19aeb7664" />

<img width="1280" height="764" alt="image" src="https://github.com/user-attachments/assets/49d4fa34-f154-402a-910e-0e09ce15491f" />
