### PR TITLE
fix(agent): let the planner conclude answer-only turns without an executor round

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -75,10 +75,14 @@ servers, then inspect or call a non-destructive capability. If a capability is
 destructive, do not treat that as missing configuration or an unavailable MCP:
 write the operation into the plan for the executor instead.
 
-If your research shows the task needs no changes and no actions at all (already
-implemented, already resolved), explain that briefly and end your reply with a
-final line containing exactly [no_changes]. Never emit that marker when any
-work, verification, or follow-up remains.`
+If the task needs no executor actions at all, end your reply with a final line
+containing exactly [no_changes]. That covers two cases: your research shows the
+work is already done (already implemented, already resolved — explain that
+briefly), and the task is a question, comparison, analysis, or explanation that
+your reply itself fully answers — write the complete answer, then the marker.
+The host then delivers your reply directly instead of starting the executor.
+Never emit that marker when any workspace change, command, verification, or
+follow-up action remains.`
 
 const executorHandoffMarker = "Reasonix executor handoff"
 
@@ -402,8 +406,9 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	if isNoOpPlan(plan) {
 		c.persistExecutorNoOp(ctx, input, plan)
 		// The relayed conclusion is planner text; keep its source so sinks
-		// attribute it like every other planner emission.
-		c.sink.Emit(event.Event{Kind: event.Text, Text: plan, Source: event.UsageSourcePlanner})
+		// attribute it like every other planner emission. Display goes through
+		// the standard filter so the [no_changes] contract line stays internal.
+		c.sink.Emit(event.Event{Kind: event.Text, Text: DisplayAssistantText(plan), Source: event.UsageSourcePlanner})
 		return nil
 	}
 	runExecutorWithPlan := func(ctx context.Context, planText string) error {

--- a/internal/agent/goal_display.go
+++ b/internal/agent/goal_display.go
@@ -18,6 +18,12 @@ func StripGoalMarkers(text string) string {
 		if trimmed == "[goal:complete]" || trimmed == "[goal:continue]" {
 			continue
 		}
+		// Planner conclusion markers are coordinator protocol, not prose: the
+		// relay path trusts them (isNoOpPlan / plan approval) but users should
+		// see the planner's words, not the contract.
+		if lower := strings.ToLower(trimmed); lower == "[no_changes]" || lower == "[planner_requires_approval]" {
+			continue
+		}
 		if strings.HasPrefix(trimmed, "[goal:blocked:") && strings.HasSuffix(trimmed, "]") {
 			reason := strings.TrimPrefix(trimmed, "[goal:blocked:")
 			reason = strings.TrimSuffix(reason, "]")

--- a/internal/agent/goal_display_test.go
+++ b/internal/agent/goal_display_test.go
@@ -40,3 +40,24 @@ func TestDisplayAssistantTextStripsAllProtocolArtifacts(t *testing.T) {
 		t.Errorf("DisplayAssistantText = %q, want %q", got, want)
 	}
 }
+
+// Planner conclusion markers are coordinator protocol; the display filter
+// removes the standalone lines while parsing keeps reading the raw text
+// (#6789: a relayed answer-only plan must not show "[no_changes]").
+func TestDisplayFilterStripsPlannerConclusionMarkers(t *testing.T) {
+	in := "The two agents differ mainly in orchestration.\n\n[no_changes]"
+	want := "The two agents differ mainly in orchestration."
+	if got := DisplayAssistantText(in); got != want {
+		t.Errorf("DisplayAssistantText = %q, want %q", got, want)
+	}
+	in = "Plan ready for review.\n[planner_requires_approval]"
+	want = "Plan ready for review."
+	if got := StripGoalMarkers(in); got != want {
+		t.Errorf("StripGoalMarkers = %q, want %q", got, want)
+	}
+	// Inline mentions survive — only standalone marker lines are protocol.
+	in = "The [no_changes] marker is emitted when done."
+	if got := DisplayAssistantText(in); got != in {
+		t.Errorf("inline mention altered: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #6789 (Planner→Executor double answer on pure Q&A tasks).

## Root cause (two layers)

1. **Contract gap**: `[no_changes]` was documented only as "the work is already done". A pure question/comparison/analysis task fits neither that description nor a plan — the planner (correctly following its prompt) wrote the full answer *without* the marker, so `isNoOpPlan` didn't take the relay path and the executor was started on an answer, producing a second full response.
2. **Amplifier**: the handoff text-only heuristic short-circuits on action vocabulary anywhere in the plan (`executorHandoffLocalActionTerms` — any architecture analysis mentions 代码/file/test), so the executor's text answer got nudged (`maxExecutorHandoffNudges`) into yet another restatement.

## Fix — extend the existing contract, no new protocol

- **Planner prompt**: `[no_changes]` now explicitly covers both conclusions — "already done" and "this reply itself fully answers the task (question/comparison/analysis/explanation)". The coordinator's existing relay path then shows the planner's answer once and never starts the executor. Same trusted-marker philosophy documented at `isNoOpPlan` (no phrase heuristics; a planner that forgets the marker just costs one executor round, and the executor's relay instruction still applies).
- **Display filter**: standalone `[no_changes]` / `[planner_requires_approval]` lines are stripped by `StripGoalMarkers` (same treatment as `[goal:*]`; inline mentions survive), and the relay emission goes through `DisplayAssistantText`. Parsing and session history keep the raw text.
- The nudge heuristic is deliberately left fail-closed (a wrong allow silently drops real work; a wrong nudge costs one duplicate answer, now rare).

## Tests

- New `TestDisplayFilterStripsPlannerConclusionMarkers` (standalone lines stripped, inline mentions survive).
- `go test ./internal/agent/` green; vet + gofmt clean.

Documentation-impact: none - internal planner contract; user-visible effect is the removal of duplicated answers, no documented behavior changes.

Cache-impact: low - DefaultPlannerPrompt text changes, so the planner's system-prefix cache misses once per session after upgrade and is stable again from the next turn; executor prompts and user-turn scaffolding are unchanged.
Cache-guard: prompt is a const assembled once at session start (PlannerPromptWithContext); no per-turn variance introduced — existing planner-session cache tests cover prefix stability.