### PR TITLE
feat(desktop): filter settings sections by name

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { lazy, memo, Suspense, startTransition, useCallback, useDeferredValue, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
-import { Bot as BotIcon, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, ExternalLink, GripVertical, KeyRound, Loader2, MessageCircle, Play, QrCode, RefreshCw, Send } from "lucide-react";
+import { Bot as BotIcon, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, ExternalLink, GripVertical, KeyRound, Loader2, MessageCircle, Play, QrCode, RefreshCw, Search, Send } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useDeferredClose } from "../lib/useMountTransition";
 import { app, openExternal } from "../lib/bridge";
@@ -126,6 +126,7 @@ export function SettingsPanel({
   const [customFontName, setCustomFontNameState] = useState<string>(getCustomFontName());
   const [customMonoFontName, setCustomMonoFontNameState] = useState<string>(getCustomMonoFontName());
   const [tab, setTab] = useState<SettingsTab>(initialTab === "providers" ? "models" : initialTab ?? "general");
+  const [sectionQuery, setSectionQuery] = useState("");
   const pendingSubagentCommandRef = useRef<string | null>(null);
   // Play the modal exit animation, then let the parent unmount us and focus
   // the composer with the selected slash command.
@@ -285,6 +286,14 @@ export function SettingsPanel({
   // load their own data and render regardless.
   const needsSettings = tab === "general" || tab === "models" || tab === "bots" || tab === "subagents" || tab === "network" || tab === "permissions" || tab === "sandbox" || tab === "appearance" || tab === "updates";
   const lazySettingsPageFallback = <div className="empty">{t("settings.loading")}</div>;
+  const normalizedSectionQuery = sectionQuery.trim().toLowerCase();
+  const filteredTabs = useMemo(
+    () =>
+      normalizedSectionQuery
+        ? SETTINGS_TABS.filter((id) => settingsTabLabel(id, t).toLowerCase().includes(normalizedSectionQuery))
+        : SETTINGS_TABS,
+    [normalizedSectionQuery, t],
+  );
 
   return (
     <div className="management-modal-backdrop settings-modal-backdrop" data-state={status} onMouseDown={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
@@ -296,16 +305,29 @@ export function SettingsPanel({
 
         <div className="settings-center">
           <nav className="settings-center__nav" aria-label={t("settings.title")}>
-            {SETTINGS_TABS.map((id) => (
-              <button
-                key={id}
-                className={`settings-center__navitem${tab === id ? " settings-center__navitem--active" : ""}`}
-                onClick={() => setTab(id)}
-              >
-                <span>{settingsTabLabel(id, t)}</span>
-                {s && <small>{settingsTabMeta(id, s, t)}</small>}
-              </button>
-            ))}
+            <label className="mem-search settings-nav-search">
+              <Search size={13} />
+              <input
+                value={sectionQuery}
+                onChange={(event) => setSectionQuery(event.target.value)}
+                placeholder={t("settings.searchPlaceholder")}
+                aria-label={t("settings.searchPlaceholder")}
+              />
+            </label>
+            {filteredTabs.length === 0 ? (
+              <div className="settings-nav-empty">{t("settings.noSectionMatch", { q: sectionQuery.trim() })}</div>
+            ) : (
+              filteredTabs.map((id) => (
+                <button
+                  key={id}
+                  className={`settings-center__navitem${tab === id ? " settings-center__navitem--active" : ""}`}
+                  onClick={() => setTab(id)}
+                >
+                  <span>{settingsTabLabel(id, t)}</span>
+                  {s && <small>{settingsTabMeta(id, s, t)}</small>}
+                </button>
+              ))
+            )}
           </nav>
           <main className="settings-center__content">
             {needsSettings && settingsLoadFailed && (

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2645,6 +2645,8 @@ export const en = {
   "settings.currency": "Pricing currency",
   "settings.currencyAuto": "Auto (language)",
   "settings.config": "config: {path}",
+  "settings.searchPlaceholder": "Filter settings…",
+  "settings.noSectionMatch": "No setting matches “{q}”.",
   "settings.configShadowed": "overridden by workspace config: {path} (changes here may not take effect)",
   "settings.generativeMusic": "Generative background music",
   "settings.generativeMusicHint": "Ambient music that loops during AI generation",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1808,6 +1808,8 @@ export const zhTW: Record<DictKey, string> = {
   "settings.currency": "計價幣別",
   "settings.currencyAuto": "自動（跟隨語言）",
   "settings.config": "設定檔：{path}",
+  "settings.searchPlaceholder": "篩選設定…",
+  "settings.noSectionMatch": "沒有符合 “{q}” 的設定。",
   "settings.configShadowed": "被工作區設定覆蓋：{path}（這裡的修改可能不會生效）",
 
   // 待辦欄

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2648,6 +2648,8 @@ export const zh: Record<DictKey, string> = {
   "settings.currency": "计价币种",
   "settings.currencyAuto": "自动（跟随语言）",
   "settings.config": "配置文件：{path}",
+  "settings.searchPlaceholder": "筛选设置…",
+  "settings.noSectionMatch": "没有匹配 “{q}” 的设置。",
   "settings.configShadowed": "被工作区配置覆盖：{path}（这里的修改可能不生效）",
   "settings.generativeMusic": "生成式背景音乐",
   "settings.generativeMusicHint": "对话生成过程中播放背景音乐",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14625,6 +14625,16 @@ body > .mermaid-diagram--fullscreen {
   font-family: inherit;
 }
 
+.settings-nav-search {
+  margin-bottom: 8px;
+}
+
+.settings-nav-empty {
+  padding: 10px 12px;
+  color: var(--fg-dim);
+  font-size: var(--text-xs);
+}
+
 .settings-center__content {
   min-width: 0;
   overflow-x: hidden;


### PR DESCRIPTION
## Background

The settings panel has grown to seventeen sections — general, models, bots, MCP, remote, skills, subagents, plugins, memory, hooks, diagnostics, shortcuts, permissions, sandbox, network, appearance, updates. The nav list now spans the whole panel height, and finding a specific section means scanning labels one by one. Search is already a first-class interaction everywhere else (history, memory, the project tree); settings was the odd one out.

## What this PR does

Adds a search box at the top of the settings navigation:

- Typing filters the section list by its label. Matching is case-insensitive and trimmed, so "models", "Models", and "  models " all find the Models section.
- The filter runs on the *localized* label, so the query matches in the user's current UI language — searching "模型" finds Models on a Chinese interface.
- When nothing matches, the nav shows a "No setting matches …" hint instead of collapsing to an empty panel, which makes a typo obvious rather than confusing.

## Outcome

"Where is the sandbox setting again?" becomes typing a word instead of scrolling. The input reuses the existing search styling used by the history and memory panels, so it does not add a new visual language.

Documentation-impact: none - a navigation filter that mirrors the existing history/memory search; the docs do not describe the settings nav structure.
