### PR TITLE
feat(desktop): scale workbench side panels with the window width

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -148,14 +148,11 @@ import {
   CREATION_RIGHT_DOCK_MIN_RENDER_WIDTH,
   CREATION_RIGHT_DOCK_TREE_MIN_WIDTH,
   CREATION_SIDEBAR_MIN_WIDTH,
-  RIGHT_DOCK_MAX_WIDTH,
   RIGHT_DOCK_MIN_RENDER_WIDTH,
   RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH,
   RIGHT_DOCK_PREVIEW_MIN_WIDTH,
-  RIGHT_DOCK_TREE_MAX_WIDTH,
   RIGHT_DOCK_TREE_MIN_WIDTH,
   type RightDockMode,
-  SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
   TERMINAL_DEFAULT_HEIGHT,
   TERMINAL_MIN_HEIGHT,
@@ -170,6 +167,8 @@ import {
   defaultCreationSidebarWidth,
   defaultRightDockTreeWidth,
   defaultSidebarWidth,
+  rightDockMaxWidth,
+  rightDockTreeMaxWidth,
   saveRightDockPreviewWidth,
   saveRightDockTreeWidth,
   saveSidebarCollapsed,
@@ -178,6 +177,7 @@ import {
   saveTerminalPanelOpen,
   terminalMaxHeight,
   saveWorkspacePanelOpen,
+  sidebarMaxWidth,
   useLayoutStore,
 } from "./store/layout";
 import { useOverlayStore } from "./store/overlays";
@@ -290,8 +290,9 @@ const RemotePanel = lazy(() => import("./components/RemotePanel").then((module) 
 const TerminalPanel = lazy(() => import("./components/TerminalPanel").then((module) => ({ default: module.TerminalPanel })));
 const WorkspacePanel = lazy(() => import("./components/WorkspacePanel").then((module) => ({ default: module.WorkspacePanel })));
 
+// Hard floor for the chat column whether the dock is open or closed: the
+// user stretching a panel is an explicit choice to give the chat less room.
 const CHAT_MIN_WIDTH = 400;
-const CHAT_COMFORT_MIN_WIDTH = 560;
 const WORKSPACE_RESIZER_WIDTH = 8;
 
 function stripGoalResearchFlags(arg: string): string {
@@ -1611,17 +1612,20 @@ export default function App() {
   const rightDockDetailActive = rightDockMode !== "context" && workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const rightDockTreeMinWidth = desktopLayoutStyle === "creation" ? CREATION_RIGHT_DOCK_TREE_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
-  const rightDockTreeWidthClamp = desktopLayoutStyle === "creation" ? clampCreationRightDockTreeWidth : clampRightDockTreeWidth;
+  const rightDockTreeWidthClamp = useCallback(
+    (width: number) =>
+      (desktopLayoutStyle === "creation" ? clampCreationRightDockTreeWidth : clampRightDockTreeWidth)(width, viewportWidth),
+    [desktopLayoutStyle, viewportWidth],
+  );
   const rightDockMinRenderWidth = desktopLayoutStyle === "creation" && !rightDockDetailActive
     ? CREATION_RIGHT_DOCK_MIN_RENDER_WIDTH
     : RIGHT_DOCK_MIN_RENDER_WIDTH;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : rightDockTreeMinWidth;
-  const chatReservedWidth = workspacePanelOpen && !workspacePanelMaximized ? CHAT_COMFORT_MIN_WIDTH : CHAT_MIN_WIDTH;
   const workspacePanelAvailableWidth = availableWorkspacePanelWidth({
     viewportWidth,
     sidebarCollapsed,
     sidebarWidth,
-    chatMinWidth: chatReservedWidth,
+    chatMinWidth: CHAT_MIN_WIDTH,
     resizerWidth: WORKSPACE_RESIZER_WIDTH,
   });
 
@@ -1649,14 +1653,14 @@ export default function App() {
         viewportWidth,
         sidebarCollapsed,
         sidebarWidth: nextSidebarWidth,
-        chatMinWidth: chatReservedWidth,
+        chatMinWidth: CHAT_MIN_WIDTH,
         resizerWidth: WORKSPACE_RESIZER_WIDTH,
         open: workspacePanelOpen,
         maximized: workspacePanelMaximized,
         preferredWidth,
         minWidth: workspacePanelMinWidth,
       }),
-    [chatReservedWidth, sidebarCollapsed, sidebarWidth, viewportWidth, workspacePanelMaximized, workspacePanelMinWidth, workspacePanelOpen],
+    [sidebarCollapsed, sidebarWidth, viewportWidth, workspacePanelMaximized, workspacePanelMinWidth, workspacePanelOpen],
   );
   const activeTab = useMemo(
     () => tabMetas.find((tab) => tab.id === activeTabId) ?? tabMetas.find((tab) => tab.active),
@@ -2636,7 +2640,11 @@ export default function App() {
     saveSidebarCollapsed(nextCollapsed);
   }, [anchorAppScrollToChat, closeTransientOverlays, pulseSidebarToggle, sidebarCollapsed]);
 
-  const sidebarWidthClamp = desktopLayoutStyle === "creation" ? clampCreationSidebarWidth : clampSidebarWidth;
+  const sidebarWidthClamp = useCallback(
+    (width: number) =>
+      (desktopLayoutStyle === "creation" ? clampCreationSidebarWidth : clampSidebarWidth)(width, viewportWidth),
+    [desktopLayoutStyle, viewportWidth],
+  );
   const sidebarRenderWidth = liveSidebarWidth ?? sidebarWidth;
   const sidebarResizeMinWidth = desktopLayoutStyle === "creation" ? CREATION_SIDEBAR_MIN_WIDTH : SIDEBAR_MIN_WIDTH;
 
@@ -2732,17 +2740,17 @@ export default function App() {
         setExpandedSidebarWidth(sidebarResizeMinWidth);
       } else if (event.key === "End") {
         event.preventDefault();
-        setExpandedSidebarWidth(SIDEBAR_MAX_WIDTH);
+        setExpandedSidebarWidth(sidebarMaxWidth(viewportWidth));
       }
     },
-    [setExpandedSidebarWidth, sidebarCollapsed, sidebarWidth, sidebarResizeMinWidth],
+    [setExpandedSidebarWidth, sidebarCollapsed, sidebarWidth, sidebarResizeMinWidth, viewportWidth],
   );
 
   const setSavedWorkspacePanelWidth = useCallback(
     (width: number) => {
       closeTransientOverlays();
       if (rightDockDetailActive) {
-        const next = clampRightDockPreviewWidth(width);
+        const next = clampRightDockPreviewWidth(width, viewportWidth);
         setRightDockPreviewWidth(next);
         saveRightDockPreviewWidth(next);
         return;
@@ -2751,18 +2759,18 @@ export default function App() {
       setRightDockTreeWidth(next);
       saveRightDockTreeWidth(next);
     },
-    [closeTransientOverlays, rightDockDetailActive, rightDockTreeWidthClamp],
+    [closeTransientOverlays, rightDockDetailActive, rightDockTreeWidthClamp, viewportWidth],
   );
 
   const ensureWorkspacePanelWidth = useCallback(
     (width: number) => {
       closeTransientOverlays();
       if (rightDockMode === "context") return;
-      const next = clampRightDockPreviewWidth(width);
+      const next = clampRightDockPreviewWidth(width, viewportWidth);
       setRightDockPreviewWidth(next);
       saveRightDockPreviewWidth(next);
     },
-    [closeTransientOverlays, rightDockMode],
+    [closeTransientOverlays, rightDockMode, viewportWidth],
   );
 
   const startWorkspacePanelResize = useCallback(
@@ -2786,7 +2794,7 @@ export default function App() {
         const delta = moveEvent.clientX - startX;
         nextDockWidth = startDockWidth - delta;
         if (rightDockDetailActive) {
-          nextDockWidth = clampRightDockPreviewWidth(nextDockWidth);
+          nextDockWidth = clampRightDockPreviewWidth(nextDockWidth, viewportWidth);
         } else {
           nextDockWidth = rightDockTreeWidthClamp(nextDockWidth);
         }
@@ -2809,7 +2817,7 @@ export default function App() {
       window.addEventListener("pointerup", onDone);
       window.addEventListener("pointercancel", onDone);
     },
-    [closeTransientOverlays, resolveLiveWorkspacePanelRenderWidth, rightDockDetailActive, rightDockTreeWidthClamp, setSavedWorkspacePanelWidth, workspacePanelOpen, workspacePanelRenderWidth],
+    [closeTransientOverlays, resolveLiveWorkspacePanelRenderWidth, rightDockDetailActive, rightDockTreeWidthClamp, setSavedWorkspacePanelWidth, viewportWidth, workspacePanelOpen, workspacePanelRenderWidth],
   );
 
   const resizeWorkspacePanelWithKeyboard = useCallback(
@@ -2822,10 +2830,10 @@ export default function App() {
         setSavedWorkspacePanelWidth(rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : rightDockTreeMinWidth);
       } else if (event.key === "End") {
         event.preventDefault();
-        setSavedWorkspacePanelWidth(rightDockDetailActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH);
+        setSavedWorkspacePanelWidth(rightDockDetailActive ? rightDockMaxWidth(viewportWidth) : rightDockTreeMaxWidth(viewportWidth));
       }
     },
-    [rightDockDetailActive, rightDockTreeMinWidth, setSavedWorkspacePanelWidth, workspacePanelRenderWidth],
+    [rightDockDetailActive, rightDockTreeMinWidth, setSavedWorkspacePanelWidth, viewportWidth, workspacePanelRenderWidth],
   );
 
   const terminalRenderHeight = clampTerminalHeight(terminalHeight, viewportHeight);
@@ -3095,12 +3103,12 @@ export default function App() {
     () =>
       ({
         "--sidebar-expanded-width": `${sidebarRenderWidth}px`,
-        "--chat-min-width": `${chatReservedWidth}px`,
+        "--chat-min-width": `${CHAT_MIN_WIDTH}px`,
         "--workspace-width": `${workspacePanelRenderWidth}px`,
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
         "--terminal-height": `${liveTerminalHeight ?? (terminalPanelOpen ? terminalRenderHeight : 0)}px`,
       }) as CSSProperties,
-    [chatReservedWidth, liveTerminalHeight, sidebarRenderWidth, terminalPanelOpen, terminalRenderHeight, workspacePanelRenderWidth],
+    [liveTerminalHeight, sidebarRenderWidth, terminalPanelOpen, terminalRenderHeight, workspacePanelRenderWidth],
   );
 
   const setWorkspacePanel = useCallback((open: boolean) => {
@@ -4108,7 +4116,7 @@ export default function App() {
       ? defaultCreationRightDockTreeWidth()
       : defaultRightDockTreeWidth();
   const workspacePanelResizeMinWidth = workspacePanelAriaMinWidth(workspacePanelMinWidth, workspacePanelRenderWidth);
-  const workspacePanelMaxWidth = rightDockDetailActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH;
+  const workspacePanelMaxWidth = rightDockDetailActive ? rightDockMaxWidth(viewportWidth) : rightDockTreeMaxWidth(viewportWidth);
   const sidebarCreation = desktopLayoutStyle === "creation";
   const topicbarTitle = sidebarImDetailConnection ? t("botDetail.title", { name: sidebarImDetailConnection.title }) : topicDisplayTitle(activeTab);
   const topicbarWorkspaceLabel = sidebarImDetailConnection ? t("botDetail.subtitle") : activeTab ? tabWorkspaceTitle(activeTab) : "";
@@ -4437,7 +4445,7 @@ export default function App() {
           aria-orientation="vertical"
           aria-label={t("sidebar.resize")}
           aria-valuemin={sidebarResizeMinWidth}
-          aria-valuemax={SIDEBAR_MAX_WIDTH}
+          aria-valuemax={sidebarMaxWidth(viewportWidth)}
           aria-valuenow={sidebarRenderWidth}
           onPointerDown={startSidebarResize}
           onKeyDown={resizeSidebarWithKeyboard}

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -10,7 +10,16 @@ import {
   workspacePanelAriaMinWidth,
 } from "../lib/workspaceLayout";
 import {
+  clampCreationRightDockTreeWidth,
+  clampCreationSidebarWidth,
+  clampRightDockPreviewWidth,
+  clampRightDockTreeWidth,
+  clampSidebarWidth,
   clampTerminalHeight,
+  defaultSidebarWidth,
+  rightDockMaxWidth,
+  rightDockTreeMaxWidth,
+  sidebarMaxWidth,
   terminalMaxHeight,
 } from "../store/layout";
 
@@ -157,6 +166,72 @@ eq(terminalMaxHeight(480), 240, "terminal maximum follows half of the current vi
 eq(terminalMaxHeight(180), 120, "terminal maximum never falls below the accessible minimum");
 eq(clampTerminalHeight(680, 480), 240, "restored terminal height clamps after the window shrinks");
 eq(clampTerminalHeight(80, 720), 120, "terminal height clamps to its minimum");
+
+console.log("\nviewport-proportional panel maxima");
+
+// Manual-resize limits scale with the window but never drop below the
+// legacy fixed caps (300 sidebar / 560 tree / 860 preview).
+eq(sidebarMaxWidth(1280), 300, "sidebar max keeps the legacy cap on small viewports");
+eq(sidebarMaxWidth(1600), 300, "sidebar max stays at the legacy cap until the viewport ratio exceeds it");
+eq(sidebarMaxWidth(1920), 346, "sidebar max grows with the window");
+eq(sidebarMaxWidth(3440), 420, "sidebar max hard-caps on ultrawide");
+eq(rightDockTreeMaxWidth(1000), 560, "dock tree max keeps the legacy cap on small viewports");
+eq(rightDockTreeMaxWidth(1920), 960, "dock tree max grows with the window");
+eq(rightDockTreeMaxWidth(3440), 1720, "dock tree max follows the viewport ratio on ultrawide");
+eq(rightDockTreeMaxWidth(5120), 2560, "dock tree max keeps scaling past the former hard cap");
+eq(rightDockMaxWidth(1700), 860, "dock preview max keeps the legacy cap until the ratio exceeds it");
+eq(rightDockMaxWidth(2560), 1280, "dock preview max grows with the window");
+eq(rightDockMaxWidth(3440), 1720, "dock preview max follows the viewport ratio on ultrawide");
+eq(rightDockMaxWidth(5120), 2560, "dock preview max keeps scaling past the former hard cap");
+
+// Resize clamps stay inside [min, viewport-relative max].
+eq(clampSidebarWidth(100, 1920), 264, "sidebar clamp keeps the minimum floor");
+eq(clampSidebarWidth(500, 1920), 346, "sidebar clamp follows the viewport-relative max");
+eq(clampSidebarWidth(500, 1024), 300, "sidebar clamp falls back to the legacy cap on narrow windows");
+eq(clampCreationSidebarWidth(500, 3440), 420, "creation sidebar clamp follows the viewport-relative max");
+eq(clampRightDockTreeWidth(2000, 1920), 960, "dock tree clamp follows the viewport-relative max");
+eq(clampCreationRightDockTreeWidth(2000, 2560), 1280, "creation dock tree clamp follows the viewport-relative max");
+eq(clampRightDockPreviewWidth(2000, 2560), 1280, "dock preview clamp follows the viewport-relative max");
+eq(clampRightDockPreviewWidth(400, 1280), 420, "dock preview clamp keeps the preview minimum floor");
+eq(defaultSidebarWidth(), 264, "first-launch sidebar default falls back without a window");
+
+// App wires the resizers and ARIA bounds to the viewport-relative maxima.
+eq(
+  /aria-valuemax=\{sidebarMaxWidth\(viewportWidth\)\}/.test(appSource)
+    && /setExpandedSidebarWidth\(sidebarMaxWidth\(viewportWidth\)\)/.test(appSource),
+  true,
+  "sidebar resizer ARIA max and End shortcut use the viewport-relative max",
+);
+eq(
+  /aria-valuemax=\{Math\.max\(workspacePanelMaxWidth, workspacePanelRenderWidth\)\}/.test(appSource)
+    && /const workspacePanelMaxWidth = rightDockDetailActive \? rightDockMaxWidth\(viewportWidth\) : rightDockTreeMaxWidth\(viewportWidth\)/.test(appSource),
+  true,
+  "dock resizer ARIA max follows the viewport-relative dock maximum",
+);
+eq(
+  /setSavedWorkspacePanelWidth\(rightDockDetailActive \? rightDockMaxWidth\(viewportWidth\) : rightDockTreeMaxWidth\(viewportWidth\)\)/.test(appSource),
+  true,
+  "dock End shortcut uses the viewport-relative maximum",
+);
+eq(
+  /clampRightDockPreviewWidth\(width, viewportWidth\)/.test(appSource)
+    && /clampRightDockPreviewWidth\(nextDockWidth, viewportWidth\)/.test(appSource),
+  true,
+  "dock preview resize paths pass the current viewport width",
+);
+eq(
+  !/RIGHT_DOCK_MAX_WIDTH|RIGHT_DOCK_TREE_MAX_WIDTH|SIDEBAR_MAX_WIDTH/.test(appSource),
+  true,
+  "fixed panel max constants are gone from the app shell",
+);
+eq(
+  /const CHAT_MIN_WIDTH = 400/.test(appSource)
+    && !/CHAT_COMFORT_MIN_WIDTH/.test(appSource)
+    && /chatMinWidth: CHAT_MIN_WIDTH/.test(appSource)
+    && !/chatReservedWidth/.test(appSource),
+  true,
+  "chat floor is the shared 400px minimum whether the dock is open or closed",
+);
 eq(
   /const closeWorkspacePanel = useCallback\(\(\) => \{[\s\S]*?setLiveWorkspacePanelRenderWidth\(null\);[\s\S]*?setWorkspacePanelOpen\(false\);[\s\S]*?saveWorkspacePanelOpen\(false\);/.test(appSource),
   true,

--- a/desktop/frontend/src/store/layout.ts
+++ b/desktop/frontend/src/store/layout.ts
@@ -24,7 +24,12 @@ export const SIDEBAR_MIN_WIDTH = 264;
 export const CREATION_SIDEBAR_MIN_WIDTH = 236;
 // Creation keeps the expanded rail at the narrow floor by default.
 export const CREATION_SIDEBAR_DEFAULT_WIDTH = CREATION_SIDEBAR_MIN_WIDTH;
-export const SIDEBAR_MAX_WIDTH = 300;
+// Fixed cap for the first-launch default width. The manual resize limit is
+// viewport-proportional (sidebarMaxWidth) and never drops below this floor,
+// so defaults stay unchanged while manual resizing may go wider.
+const SIDEBAR_DEFAULT_MAX_WIDTH = 300;
+// Manual resize may grow the sidebar with the window, up to this hard ceiling.
+const SIDEBAR_HARD_MAX_WIDTH = 420;
 const SIDEBAR_VIEWPORT_RATIO = 0.18;
 
 const RIGHT_DOCK_TREE_DEFAULT_WIDTH = 300;
@@ -33,48 +38,84 @@ export const RIGHT_DOCK_TREE_MIN_WIDTH = 300;
 // narrower Windows caption strip (~108px), 252 is enough for icon+label tabs.
 export const CREATION_RIGHT_DOCK_TREE_MIN_WIDTH = 252;
 export const CREATION_RIGHT_DOCK_TREE_DEFAULT_WIDTH = CREATION_RIGHT_DOCK_TREE_MIN_WIDTH;
-export const RIGHT_DOCK_TREE_MAX_WIDTH = 560;
+// The old fixed caps become the floor of the viewport-proportional resize
+// limits (rightDockTreeMaxWidth / rightDockMaxWidth), so existing behavior is
+// unchanged until the window is wide enough for the proportional max to win.
+const RIGHT_DOCK_TREE_LEGACY_MAX_WIDTH = 560;
 export const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
 export const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 export const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 // Creation tree mode may render below the classic 280 floor when the viewport squeezes.
 export const CREATION_RIGHT_DOCK_MIN_RENDER_WIDTH = 236;
-export const RIGHT_DOCK_MAX_WIDTH = 860;
+const RIGHT_DOCK_LEGACY_MAX_WIDTH = 860;
+// Every dock mode — tree, context, remote, preview — shares the same
+// viewport ratio with no hard cap: the dock is bounded only by the chat
+// minimum at render time, so all modes can reach the same maximum width.
+const RIGHT_DOCK_MAX_RATIO = 0.5;
+
+// Viewport used by the width clamps when callers do not pass one explicitly.
+// Falls back to a laptop-ish width outside the browser (unit tests / SSR).
+function currentViewportWidth(): number {
+  return typeof window === "undefined" ? 1280 : window.innerWidth;
+}
+
+// Manual-resize limits scale with the window: never below the legacy fixed
+// cap (non-regressive). The sidebar is proportional to the viewport and
+// hard-capped so a project tree cannot swallow the screen; the right dock has
+// no hard cap — it is bounded only by the chat minimum at render time.
+export function sidebarMaxWidth(viewportWidth: number = currentViewportWidth()): number {
+  return Math.max(SIDEBAR_DEFAULT_MAX_WIDTH, Math.min(Math.round(viewportWidth * SIDEBAR_VIEWPORT_RATIO), SIDEBAR_HARD_MAX_WIDTH));
+}
+
+export function rightDockTreeMaxWidth(viewportWidth: number = currentViewportWidth()): number {
+  return Math.max(RIGHT_DOCK_TREE_LEGACY_MAX_WIDTH, Math.round(viewportWidth * RIGHT_DOCK_MAX_RATIO));
+}
+
+export function rightDockMaxWidth(viewportWidth: number = currentViewportWidth()): number {
+  return Math.max(RIGHT_DOCK_LEGACY_MAX_WIDTH, Math.round(viewportWidth * RIGHT_DOCK_MAX_RATIO));
+}
+
 const WORKSPACE_PANEL_OPEN_KEY = "reasonix.workspacePanel.open";
 // First-launch default when no preference is stored (matches post-#6371 UX).
 const WORKSPACE_PANEL_DEFAULT_OPEN = true;
 
-export function clampSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+export function clampSidebarWidth(width: number, viewportWidth: number = currentViewportWidth()): number {
+  return Math.min(sidebarMaxWidth(viewportWidth), Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
 }
 
-export function clampCreationSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
+export function clampCreationSidebarWidth(width: number, viewportWidth: number = currentViewportWidth()): number {
+  return Math.min(sidebarMaxWidth(viewportWidth), Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
 }
 
 function clampStoredSidebarWidth(width: number): number {
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(CREATION_SIDEBAR_MIN_WIDTH, Math.round(width)));
+  return clampCreationSidebarWidth(width);
 }
 
-export function clampRightDockPreviewWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_MAX_WIDTH, Math.max(RIGHT_DOCK_PREVIEW_MIN_WIDTH, Math.round(width)));
+export function clampRightDockPreviewWidth(width: number, viewportWidth: number = currentViewportWidth()): number {
+  return Math.min(rightDockMaxWidth(viewportWidth), Math.max(RIGHT_DOCK_PREVIEW_MIN_WIDTH, Math.round(width)));
 }
 
-export function clampRightDockTreeWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_TREE_MAX_WIDTH, Math.max(RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
+export function clampRightDockTreeWidth(width: number, viewportWidth: number = currentViewportWidth()): number {
+  return Math.min(rightDockTreeMaxWidth(viewportWidth), Math.max(RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
 }
 
-export function clampCreationRightDockTreeWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_TREE_MAX_WIDTH, Math.max(CREATION_RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
+export function clampCreationRightDockTreeWidth(width: number, viewportWidth: number = currentViewportWidth()): number {
+  return Math.min(rightDockTreeMaxWidth(viewportWidth), Math.max(CREATION_RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
 }
 
 function clampStoredRightDockTreeWidth(width: number): number {
-  return Math.min(RIGHT_DOCK_TREE_MAX_WIDTH, Math.max(CREATION_RIGHT_DOCK_TREE_MIN_WIDTH, Math.round(width)));
+  return clampCreationRightDockTreeWidth(width);
+}
+
+// First-launch default stays under the legacy fixed cap: responsive up to
+// SIDEBAR_DEFAULT_MAX_WIDTH, then frozen — only manual resize may go wider.
+function clampDefaultSidebarWidth(width: number): number {
+  return Math.min(SIDEBAR_DEFAULT_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
 }
 
 export function defaultSidebarWidth(): number {
   if (typeof window !== "undefined") {
-    return clampSidebarWidth(window.innerWidth * SIDEBAR_VIEWPORT_RATIO);
+    return clampDefaultSidebarWidth(window.innerWidth * SIDEBAR_VIEWPORT_RATIO);
   }
   return SIDEBAR_DEFAULT_WIDTH;
 }


### PR DESCRIPTION
The left sidebar and right dock were capped at fixed maximum widths (300px sidebar, 560px tree / 860px preview dock), leaving most of a widescreen window unused while the panels stayed cramped.

Resize limits are now viewport-proportional:
- sidebar: 18% of the viewport, capped at 420px
- right dock: 50% of the viewport in every mode (files, changes, overview, remote, preview), floored at the legacy 560/860px caps
- chat column keeps a shared 400px minimum whether the dock is open or closed, so stretching a panel is always an explicit choice

## Summary

- `store/layout.ts`: the fixed max-width constants become the floor of viewport-proportional limits — `sidebarMaxWidth(viewport)` (0.18 ratio, 420px cap), `rightDockTreeMaxWidth(viewport)` and `rightDockMaxWidth(viewport)` (shared 0.5 ratio, no hard cap, legacy floors 560/860). All five resize clamps plus the load/save persistence clamps accept the current viewport width.
- `App.tsx`: every resize path (pointer drag, keyboard `End`, `aria-valuemax` on both resizers, `workspacePanelMaxWidth`) now uses the viewport-relative maxima; `CHAT_COMFORT_MIN_WIDTH` (560px) is removed — the chat column shares the 400px `CHAT_MIN_WIDTH` floor whether the dock is open or closed, so the dock can reach 50% of the window on any screen where the layout physically allows it.
- All dock modes behave identically: files/changes without an open file, Overview and Remote reach the same maximum as the diff/preview view.
- First-launch defaults are unchanged (sidebar 300 / dock tree 300 / preview 660).
- `workspace-layout.test.ts`: 18 new checks — proportional growth, legacy floors, no hard cap on ultrawide (5120px case), clamp bounds, default fallback, and source contracts for the resizer wiring.

## Issues

Fixes #7479

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — full frontend suite passes (exit 0), including `workspace-layout.test.ts` (67/67), `layout-style-defaults.test.ts` (10/10) and `workspace-split.test.ts`
- `pnpm lint:hooks` + `pnpm check:css` — clean
- `gofmt -l .` — clean; `go vet ./...` — clean; `go test ./internal/tool/builtin/` — pass
- Note: `go test ./internal/boot/` shows one pre-existing macOS sandbox-exec failure (`TestBuildAdditionalDirsReachSandboxedBashWriteRoots`, reproduced in isolation, sandboxed file missing under `/var/folders`) — unrelated to this frontend-only diff (no Go files changed)
- Manual: on a 3440×1440 ultrawide, both panels drag up to ~50% of the window width in every dock mode; chat never goes below 400px

## Documentation impact

Documentation-impact: none - embedded docs do not document panel width caps; this is a UX change to the desktop shell only, with no documented contract or user-facing setting altered

## Cache impact

Cache-impact: none - touches only `desktop/frontend/src` (layout constants, resize wiring, tests); no files under `internal/`, `internal/boot/`, `internal/tool/` or other cache-sensitive paths
Cache-guard: existing guard - `workspace-layout.test.ts` (67/67 in `pnpm test`) covers the width/clamp logic; no cache-sensitive code paths are reachable from this change
System-prompt-review: N/A