### PR TITLE
fix(bot): honor persisted session_mappings when resolving chat sessions

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -214,6 +214,12 @@ type sessionState struct {
 	workspaceRoot    string
 	toolApprovalMode string
 	sessionPath      string
+	// mappingDegraded records that this state intentionally runs on a fresh
+	// session because its session_mappings target could not be used at build
+	// time. It keeps later messages (whose profile re-resolves the mapping)
+	// from tearing the state down every turn; convergence back onto the
+	// mapped file happens on the next gateway restart.
+	mappingDegraded  bool
 	cancel           context.CancelFunc
 	pendingAsks      map[string][]event.AskQuestion
 	pendingApprovals map[string]event.Approval
@@ -230,6 +236,11 @@ type sessionRuntimeProfile struct {
 	workspaceRoot    string
 	toolApprovalMode string
 	sessionPath      string
+	// sessionPathOptional marks sessionPath as a persisted session_mappings
+	// binding rather than an explicit /attach: when the mapped file cannot be
+	// loaded or leased, the session degrades to a fresh path instead of
+	// dropping the message (#6917).
+	sessionPathOptional bool
 }
 
 type sessionRuntimeOverride struct {
@@ -2253,24 +2264,40 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	}
 	state.ctrl = ctrl
 	if profile.sessionPath != "" {
-		if err := leases.Rebind(profile.sessionPath); err != nil {
-			ctrl.Close()
-			leases.Release()
-			gw.logger.Error("attached bot session is in use", "err", control.SessionInUseMessage(err))
-			return nil
-		}
-		loaded, err := agent.LoadSession(profile.sessionPath)
-		if err != nil {
-			ctrl.Close()
-			leases.Release()
-			if os.IsNotExist(err) {
-				gw.logger.Error("attached bot session missing", "session_path", profile.sessionPath)
-			} else {
-				gw.logger.Error("attached bot session load failed", "session_path", profile.sessionPath, "err", err)
+		// A mapped binding degrades to a fresh session on failure; only an
+		// explicit /attach is allowed to hard-fail the message, because the
+		// user named that exact session.
+		degrade := func(reason string, err error) bool {
+			if !profile.sessionPathOptional {
+				return false
 			}
-			return nil
+			gw.logger.Warn("mapped bot session unavailable; starting fresh", "reason", reason, "session_path", profile.sessionPath, "err", err)
+			profile.sessionPath = ""
+			state.sessionPath = ""
+			state.mappingDegraded = true
+			return true
 		}
-		ctrl.Resume(loaded, profile.sessionPath)
+		if err := leases.Rebind(profile.sessionPath); err != nil {
+			if !degrade("lease held elsewhere", err) {
+				ctrl.Close()
+				leases.Release()
+				gw.logger.Error("attached bot session is in use", "err", control.SessionInUseMessage(err))
+				return nil
+			}
+		} else if loaded, err := agent.LoadSession(profile.sessionPath); err != nil {
+			if !degrade("load failed", err) {
+				ctrl.Close()
+				leases.Release()
+				if os.IsNotExist(err) {
+					gw.logger.Error("attached bot session missing", "session_path", profile.sessionPath)
+				} else {
+					gw.logger.Error("attached bot session load failed", "session_path", profile.sessionPath, "err", err)
+				}
+				return nil
+			}
+		} else {
+			ctrl.Resume(loaded, profile.sessionPath)
+		}
 	}
 	ctrl.EnableInteractiveApproval()
 	ctrl.SetToolApprovalMode(profile.toolApprovalMode)
@@ -2328,15 +2355,63 @@ func updateSessionStateRuntime(state *sessionState, msg InboundMessage, profile 
 func (gw *BotGateway) sessionProfileForMessage(msg InboundMessage) sessionRuntimeProfile {
 	model, workspaceRoot, toolApprovalMode := gw.sessionOptionsForMessage(msg)
 	var sessionPath string
+	sessionPathOptional := false
 	if override, ok := gw.sessionRuntimeOverrideForMessage(msg); ok {
 		sessionPath = override.sessionPath
 	}
-	return sessionRuntimeProfile{
-		model:            strings.TrimSpace(model),
-		workspaceRoot:    strings.TrimSpace(workspaceRoot),
-		toolApprovalMode: normalizeBotToolApprovalMode(toolApprovalMode),
-		sessionPath:      canonicalBotPath(sessionPath),
+	// A persisted session_mappings binding is the durable chat→session link
+	// the desktop writes into the connection config. Without consuming it
+	// here, every gateway restart or runtime rebuild opened a brand-new
+	// session file for the chat and the configured binding was display-only
+	// (#6917, #6934).
+	if sessionPath == "" {
+		if mapped := gw.sessionMappingPathForMessage(msg); mapped != "" {
+			sessionPath = mapped
+			sessionPathOptional = true
+		}
 	}
+	return sessionRuntimeProfile{
+		model:               strings.TrimSpace(model),
+		workspaceRoot:       strings.TrimSpace(workspaceRoot),
+		toolApprovalMode:    normalizeBotToolApprovalMode(toolApprovalMode),
+		sessionPath:         canonicalBotPath(sessionPath),
+		sessionPathOptional: sessionPathOptional,
+	}
+}
+
+// sessionMappingPathForMessage resolves the persisted session_mappings entry
+// for a message to an existing session file. Only bindings that resolve to a
+// present, readable file participate — a moved or deleted target quietly
+// degrades to normal session creation rather than blocking the chat.
+func (gw *BotGateway) sessionMappingPathForMessage(msg InboundMessage) string {
+	gw.mu.Lock()
+	var mappings []SessionMapping
+	if msg.ConnectionID != "" {
+		if channel, ok := gw.cfg.ConnectionChannels[msg.ConnectionID]; ok {
+			mappings = channel.SessionMappings
+		}
+	}
+	if len(mappings) == 0 {
+		if channel, ok := gw.cfg.Channels[msg.Platform]; ok {
+			mappings = channel.SessionMappings
+		}
+	}
+	gw.mu.Unlock()
+	mapping, ok := matchingSessionMapping(mappings, msg)
+	if !ok {
+		return ""
+	}
+	path := botSessionPathFromTarget(mapping.SessionID)
+	if path == "" {
+		path = botSessionPathFromTarget(mapping.SessionSource)
+	}
+	if path == "" {
+		return ""
+	}
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		return ""
+	}
+	return path
 }
 
 func sessionStateMatchesRuntime(state *sessionState, profile sessionRuntimeProfile) bool {
@@ -2358,6 +2433,13 @@ func sessionStateMatchesRuntime(state *sessionState, profile sessionRuntimeProfi
 	}
 	if stateRoot != wantRoot {
 		return false
+	}
+	// A state that already degraded off its mapped session keeps running on
+	// its fresh path even though the profile re-resolves the mapping each
+	// message; rebuilding here would spawn a new session per message while the
+	// mapped file stays unavailable.
+	if profile.sessionPathOptional && state.mappingDegraded {
+		return true
 	}
 	if canonicalBotPath(state.sessionPath) != canonicalBotPath(profile.sessionPath) {
 		return false

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -2430,3 +2430,71 @@ func TestBotSessionDirUsesProjectWorkspaceRoot(t *testing.T) {
 		t.Fatalf("project session dir = %q, want project-specific dir", got)
 	}
 }
+
+// A persisted session_mappings binding must resolve to the mapped session file
+// at session-profile time — before this, the binding was display-only and every
+// gateway restart opened a fresh session for the chat (#6917, #6934).
+func TestSessionProfileConsumesPersistedMapping(t *testing.T) {
+	dir := t.TempDir()
+	mapped := filepath.Join(dir, "chat.jsonl")
+	if err := os.WriteFile(mapped, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gw := &BotGateway{
+		cfg: GatewayConfig{
+			ConnectionChannels: map[string]ChannelConfig{
+				"conn-1": {SessionMappings: []SessionMapping{{
+					RemoteID:  "chat-42",
+					SessionID: "path:" + mapped,
+				}}},
+			},
+		},
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		sessionOverrides: map[string]sessionRuntimeOverride{},
+	}
+	msg := InboundMessage{ConnectionID: "conn-1", ChatID: "chat-42", ChatType: ChatDM}
+
+	profile := gw.sessionProfileForMessage(msg)
+	if canonicalBotPath(profile.sessionPath) != canonicalBotPath(mapped) {
+		t.Fatalf("profile.sessionPath = %q, want mapped %q", profile.sessionPath, mapped)
+	}
+	if !profile.sessionPathOptional {
+		t.Fatal("mapping-derived path must be optional (degradable), not an attach-style hard binding")
+	}
+
+	// A missing target quietly degrades to normal creation.
+	if err := os.Remove(mapped); err != nil {
+		t.Fatal(err)
+	}
+	profile = gw.sessionProfileForMessage(msg)
+	if profile.sessionPath != "" {
+		t.Fatalf("missing mapped file should resolve to empty path, got %q", profile.sessionPath)
+	}
+
+	// An /attach override outranks the mapping.
+	gw.sessionOverrides[BuildSessionKey(msg.Session())] = sessionRuntimeOverride{sessionPath: filepath.Join(dir, "attached.jsonl")}
+	profile = gw.sessionProfileForMessage(msg)
+	if profile.sessionPathOptional {
+		t.Fatal("attach override must stay a hard binding")
+	}
+}
+
+// A state that degraded off its unavailable mapped session must not be torn
+// down by the next message re-resolving the mapping — that would spawn a new
+// session file per message.
+func TestDegradedMappingStateStaysStable(t *testing.T) {
+	s := &sessionState{mappingDegraded: true, sessionPath: "", ctrl: stubPathController{}}
+	profile := sessionRuntimeProfile{sessionPath: "/some/mapped.jsonl", sessionPathOptional: true}
+	if !sessionStateMatchesRuntime(s, profile) {
+		t.Fatal("degraded state must keep matching an optional mapped profile")
+	}
+	hard := sessionRuntimeProfile{sessionPath: "/some/mapped.jsonl"}
+	if sessionStateMatchesRuntime(s, hard) {
+		t.Fatal("an explicit attach must still force a rebuild")
+	}
+}
+
+type stubPathController struct{ botController }
+
+func (stubPathController) SessionPath() string   { return "" }
+func (stubPathController) WorkspaceRoot() string { return "" }


### PR DESCRIPTION
## Summary

Fixes #6917, #6934 — the oldest unfixed bug cluster (bot chats fragmenting into one-turn sessions; `session_mappings` having no effect).

## Root cause

`session_mappings` persist a remote-chat→session binding in the connection config, the desktop writes and displays them — but the gateway's session resolution (`sessionProfileForMessage`) only ever consulted the **in-memory /attach override**. The persisted binding was consumed solely by the display index (`project_index.go`). Result: every gateway restart or runtime rebuild opened a brand-new session file for the chat; with any per-message runtime churn, that became a new session per message — exactly the session-file evidence in #6917.

## Fix

- `sessionProfileForMessage` falls back to the matching mapping's target (`SessionID`, then `SessionSource`, resolved through the existing `botSessionPathFromTarget`) when no attach override is present. Resolution pre-validates the file exists.
- Mapped bindings are **soft**: if the target can't be leased or loaded, the session degrades to a fresh path with a warning instead of dropping the message (explicit `/attach` keeps its hard-fail semantics — the user named that exact session).
- A degraded state is sticky (`mappingDegraded`): later messages that re-resolve the mapping don't tear the state down each turn — otherwise an unavailable target would spawn a new session per message. Convergence back onto the mapped file happens on the next gateway restart.

## Scope note (cluster follow-up)

This is the read side. The write side — persisting a mapping automatically when a chat's first session is created, so bindings are durable without hand-editing config and the desktop index correlates bot sessions (#4822/#4481/#6329 visibility family) — crosses the config-ownership boundary (#6913) and comes as a follow-up design.

## Tests

- `TestSessionProfileConsumesPersistedMapping` (mapping resolves; missing file degrades; /attach outranks and stays hard)
- `TestDegradedMappingStateStaysStable` (no per-message rebuild while degraded; explicit attach still forces rebuild)
- `go test ./internal/bot/` green; vet + gofmt clean

Documentation-impact: none - makes the already-documented session_mappings setting actually effective; no new configuration surface.

Cache-impact: none - session routing only; no prompt or provider surface touched.