### PR TITLE
feat(agent): store-P2 write-authority probe for unleased session saves

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -216,6 +216,7 @@ func (s *Session) save(path string, mode sessionSaveMode) error {
 		return fmt.Errorf("lock session file: %w", err)
 	}
 	defer unlockFile()
+	observeUnleasedSessionWrite(path, mode)
 	if mode == sessionSaveSnapshot && s.snapshotUpToDate(path) {
 		// Nothing changed since the last successful save to this exact path:
 		// skip the rest of the save — including the full transcript serialize

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,4 +307,31 @@ func SaveSessionLeaseInfo(path string, info SessionLeaseInfo) error {
 
 func sessionLeaseInfoPath(path string) string {
 	return store.SessionLeaseInfo(canonicalSessionSavePath(path))
+}
+
+// unleasedWriteObserved dedupes the write-authority probe below to one report
+// per canonical path per process.
+var unleasedWriteObserved sync.Map
+
+// observeUnleasedSessionWrite is the store-P2 write-authority probe: the target
+// model is "the lease holder is the only writer of a session's content", but
+// enforcement can't land before we know every writer that currently saves
+// without holding the lease (fresh-session creation saves before the first
+// Rebind, headless runs, recovery tooling, ...). Until then this only records
+// evidence: one structured warning per path per process, never a failure. The
+// snapshot-conflict machinery stays the safety net for the writers this
+// surfaces.
+func observeUnleasedSessionWrite(path string, mode sessionSaveMode) {
+	canonical := canonicalSessionSavePath(path)
+	if _, ok := sessionLeaseOwners.Load(canonical); ok {
+		return
+	}
+	if _, seen := unleasedWriteObserved.LoadOrStore(canonical, struct{}{}); seen {
+		return
+	}
+	slog.Warn("session: save without a held lease (write-authority probe, store P2)",
+		"path", filepath.Base(path),
+		"mode", int(mode),
+		"writer", SessionWriterID(),
+	)
 }

--- a/internal/agent/session_lease_probe_test.go
+++ b/internal/agent/session_lease_probe_test.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The store-P2 write-authority probe must record an unleased save once per
+// path and stay silent for the lease holder — it is evidence collection, not
+// enforcement.
+func TestUnleasedWriteProbe(t *testing.T) {
+	dir := t.TempDir()
+
+	unleased := filepath.Join(dir, "unleased.jsonl")
+	observeUnleasedSessionWrite(unleased, sessionSaveSnapshot)
+	if _, ok := unleasedWriteObserved.Load(canonicalSessionSavePath(unleased)); !ok {
+		t.Fatal("unleased save should be recorded by the probe")
+	}
+
+	leased := filepath.Join(dir, "leased.jsonl")
+	lease, err := TryAcquireSessionLease(leased)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+	observeUnleasedSessionWrite(leased, sessionSaveSnapshot)
+	if _, ok := unleasedWriteObserved.Load(canonicalSessionSavePath(leased)); ok {
+		t.Fatal("lease-holder save must not be recorded by the probe")
+	}
+}


### PR DESCRIPTION
## Summary

First increment of the store-P2 campaign against the snapshot-conflict data-loss cluster (#6370, #6443, #6451, #6452, #6475, #6181, #7323, #7333).

## Why a probe first

The cluster's root is architectural: the lease system (ownership) and the snapshot-conflict system (detection/fork/adopt) are two parallel models — `Session.save` takes per-write file locks but never asks who *owns* the path, so any runtime holding a Session object is a legitimate writer and conflicts are inevitable by design. The unified target model is **the lease holder is the single writer; everyone else reads**.

Enforcement cannot land blind: known-legitimate unleased writers exist (fresh-session creation saves before the first `Rebind`; headless `reasonix run`; recovery/GC tooling). Turning on refusal before mapping them would break real flows in exactly the safety-critical path.

## What this does

`observeUnleasedSessionWrite` runs inside `save()` after the save locks: if the canonical path has no in-process lease owner, log one structured warning (per path per process, deduped) with save mode + writer id. No behavior change; the conflict fork/adopt machinery stays the safety net. Field logs then give the complete writer map that the enforcement increment needs.

## Roadmap (recorded in the campaign notes)

1. **This PR** — observe.
2. Classify surfaced writers: bind-late creators get lease-first ordering; headless runs get an explicit ephemeral-writer identity; tooling gets scoped guards (the `SessionRemovalGuard` pattern).
3. Enforce: unleased snapshot saves route through the conflict path as a policy violation instead of racing, and the desktop/CLI/bot lease keepers become the only mutation entry.

## Tests

- `TestUnleasedWriteProbe` (records unleased once; silent for the lease holder)
- `go test ./internal/agent/` green; vet + gofmt clean

Documentation-impact: none - internal observability; no behavior or configuration changes.

Cache-impact: none - persistence layer only; no prompt or provider surface touched.
Cache-guard: probe runs post-lock in save() and writes only to slog; session bytes and revisions unchanged (full agent test suite).