### PR TITLE
feat(bench): report cost per solved task, not cost per run

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -53,6 +53,14 @@ type runMetrics struct {
 	CapabilityReviewBlocks     int     `json:"capability_review_blocks,omitempty"`
 	CapabilityRouterCost       float64 `json:"capability_router_cost,omitempty"`
 	CapabilityRouterLatencyMs  int64   `json:"capability_router_latency_ms,omitempty"`
+
+	Outcome            string         `json:"outcome,omitempty"`
+	ToolCalls          int            `json:"tool_calls,omitempty"`
+	ToolFailures       int            `json:"tool_failures,omitempty"`
+	SubagentToolCalls  int            `json:"subagent_tool_calls,omitempty"`
+	Retries            int            `json:"retries,omitempty"`
+	ToolCallsByName    map[string]int `json:"tool_calls_by_name,omitempty"`
+	ToolFailuresByName map[string]int `json:"tool_failures_by_name,omitempty"`
 }
 
 type result struct {
@@ -62,6 +70,27 @@ type result struct {
 	Passed  bool
 	Skipped bool
 	Note    string
+	// WallMs is the harness's own clock, not the agent's self-report, so the
+	// number stays comparable when the same suite runs against another harness.
+	WallMs int64 `json:"wall_ms"`
+}
+
+// class is the published failure taxonomy: solved, the guard that stopped the
+// run, or wrong_patch when the agent finished cleanly and the grader still
+// failed. outcome carries the agent's own classification when it wrote metrics.
+func (r result) class() string {
+	switch {
+	case r.Skipped:
+		return "skipped"
+	case r.Passed:
+		return "solved"
+	case r.Outcome != "" && r.Outcome != "success":
+		return r.Outcome
+	case r.Outcome == "":
+		return "no_metrics"
+	default:
+		return "wrong_patch"
+	}
 }
 
 const defaultSuiteTokenBudget = 800_000
@@ -233,10 +262,17 @@ func runTask(bin, model, profile string, t task) result {
 	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
 	cmd.Stderr = os.Stderr
 	cmd.WaitDelay = 10 * time.Second // bound the wait for a stuck child after ctx timeout
+	startedAt := time.Now()
 	runErr := cmd.Run()
+	r.WallMs = time.Since(startedAt).Milliseconds()
 
 	if m, err := readMetrics(metricsPath); err == nil {
 		r.runMetrics = m
+	}
+	// A killed child never writes metrics, so the deadline is the only place
+	// this failure mode is still observable.
+	if ctx.Err() == context.DeadlineExceeded {
+		r.Outcome = "timeout"
 	}
 	if runErr != nil {
 		r.Note = "run: " + runErr.Error()
@@ -280,9 +316,11 @@ func grade(work, taskDir string) bool {
 func render(results []result) string {
 	var b strings.Builder
 	passed, ran := 0, 0
-	var pTok, cTok, hit, miss, compacts int
+	var pTok, cTok, hit, miss, compacts, tools, toolFails int
 	var cost float64
+	var walls []int64
 	currency := ""
+	classes := map[string]int{}
 	for _, r := range results {
 		if r.Skipped {
 			continue
@@ -291,12 +329,16 @@ func render(results []result) string {
 		if r.Passed {
 			passed++
 		}
+		classes[r.class()]++
 		pTok += r.PromptTokens
 		cTok += r.CompletionTokens
 		hit += r.CacheHitTokens
 		miss += r.CacheMissTokens
 		compacts += r.Compactions
+		tools += r.ToolCalls
+		toolFails += r.ToolFailures
 		cost += r.Cost
+		walls = append(walls, r.WallMs)
 		if r.Currency != "" {
 			currency = r.Currency
 		}
@@ -307,28 +349,36 @@ func render(results []result) string {
 		profile = results[0].Profile
 	}
 	fmt.Fprintf(&b, "## 🤖 Reasonix e2e benchmark (%s)\n\n", profile)
-	fmt.Fprintf(&b, "**Accuracy:** %d/%d (%s) · **Cache hit:** %s · **Tokens:** %s (prompt %s / completion %s) · **Compactions:** %d · **Cost:** %s%.4f\n\n",
-		passed, ran, pct(passed, ran), pct(hit, hit+miss),
-		comma(pTok+cTok), comma(pTok), comma(cTok), compacts, currencySym(currency), cost)
+	fmt.Fprintf(&b, "**Solved:** %d/%d (%s) · **Cost per solved:** %s · **Tokens per solved:** %s · **Median wall time:** %s\n\n",
+		passed, ran, pct(passed, ran),
+		costPerSolved(cost, passed, currency), tokensPerSolved(pTok+cTok, passed), dur(median(walls)))
+	fmt.Fprintf(&b, "**Cache hit:** %s · **Tokens:** %s (prompt %s / completion %s) · **Tool calls:** %s (%s failed) · **Compactions:** %d · **Cost:** %s%.4f\n\n",
+		pct(hit, hit+miss), comma(pTok+cTok), comma(pTok), comma(cTok),
+		comma(tools), comma(toolFails), compacts, currencySym(currency), cost)
 
-	fmt.Fprintf(&b, "| Task | Result | Steps | Prompt | Completion | Cache hit | Compact | Cost |\n")
-	fmt.Fprintf(&b, "|------|--------|------:|-------:|-----------:|----------:|--------:|-----:|\n")
+	fmt.Fprintf(&b, "| Task | Result | Class | Steps | Tools | Time | Prompt | Completion | Cache hit | Cost |\n")
+	fmt.Fprintf(&b, "|------|--------|-------|------:|------:|-----:|-------:|-----------:|----------:|-----:|\n")
 	for _, r := range results {
 		switch {
 		case r.Skipped:
-			fmt.Fprintf(&b, "| `%s` | ⏭️ skipped | — | — | — | — | — | — |\n", r.ID)
+			fmt.Fprintf(&b, "| `%s` | ⏭️ skipped | — | — | — | — | — | — | — | — |\n", r.ID)
 		default:
 			res := "❌ fail"
 			if r.Passed {
 				res = "✅ pass"
 			}
-			fmt.Fprintf(&b, "| `%s` | %s | %d | %s | %s | %s | %d | %s%.4f |\n",
-				r.ID, res, r.Steps, comma(r.PromptTokens), comma(r.CompletionTokens),
+			fmt.Fprintf(&b, "| `%s` | %s | %s | %d | %d | %s | %s | %s | %s | %s%.4f |\n",
+				r.ID, res, r.class(), r.Steps, r.ToolCalls, dur(r.WallMs),
+				comma(r.PromptTokens), comma(r.CompletionTokens),
 				pct(r.CacheHitTokens, r.CacheHitTokens+r.CacheMissTokens),
-				r.Compactions, currencySym(r.Currency), r.Cost)
+				currencySym(r.Currency), r.Cost)
 		}
 	}
-	fmt.Fprintf(&b, "\n<sub>Real provider run. Cache-hit %% is cached prompt tokens / total prompt tokens.</sub>\n")
+	fmt.Fprintf(&b, "\n<sub>Real provider run. Cache-hit %% is cached prompt tokens / total prompt tokens. Wall time is measured by the harness and includes process startup.</sub>\n")
+
+	if breakdown := failureBreakdown(classes); breakdown != "" {
+		fmt.Fprintf(&b, "\n**Failures by class:** %s\n", breakdown)
+	}
 
 	notes := false
 	for _, r := range results {
@@ -351,6 +401,58 @@ func pct(n, d int) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.0f%%", 100*float64(n)/float64(d))
+}
+
+func costPerSolved(cost float64, solved int, currency string) string {
+	if solved == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%s%.4f", currencySym(currency), cost/float64(solved))
+}
+
+func tokensPerSolved(tokens, solved int) string {
+	if solved == 0 {
+		return "n/a"
+	}
+	return comma(tokens / solved)
+}
+
+func median(ms []int64) int64 {
+	if len(ms) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), ms...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted[len(sorted)/2]
+}
+
+func dur(ms int64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+func failureBreakdown(classes map[string]int) string {
+	names := make([]string, 0, len(classes))
+	for name := range classes {
+		if name != "solved" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%s ×%d", name, classes[name]))
+	}
+	return strings.Join(parts, " · ")
 }
 
 func comma(n int) string {

--- a/cmd/e2ebench/report_test.go
+++ b/cmd/e2ebench/report_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResultClassSeparatesGuardStopsFromWrongPatches(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		r    result
+		want string
+	}{
+		{"solved", result{Passed: true, runMetrics: runMetrics{Outcome: "success"}}, "solved"},
+		{"grader failed after a clean run", result{runMetrics: runMetrics{Outcome: "success"}}, "wrong_patch"},
+		{"guard stop", result{runMetrics: runMetrics{Outcome: "max_steps"}}, "max_steps"},
+		{"killed before writing metrics", result{}, "no_metrics"},
+		{"skipped", result{Skipped: true}, "skipped"},
+	} {
+		if got := tc.r.class(); got != tc.want {
+			t.Errorf("%s: class = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCostPerSolvedIsNotAnAverageOverAttempts(t *testing.T) {
+	if got := costPerSolved(0.4, 2, "CNY"); got != "CNY 0.2000" {
+		t.Fatalf("cost per solved = %q, want CNY 0.2000", got)
+	}
+	if got := costPerSolved(0.4, 0, "CNY"); got != "n/a" {
+		t.Fatalf("zero solved = %q, want n/a", got)
+	}
+	if got := tokensPerSolved(1000, 0); got != "n/a" {
+		t.Fatalf("zero solved tokens = %q, want n/a", got)
+	}
+}
+
+func TestRenderLeadsWithCostPerSolvedAndFailureClasses(t *testing.T) {
+	out := render([]result{
+		{task: task{ID: "solved-one"}, Passed: true, WallMs: 4000,
+			runMetrics: runMetrics{Outcome: "success", Cost: 0.02, Currency: "CNY", PromptTokens: 1000, CacheHitTokens: 900, CacheMissTokens: 100, ToolCalls: 6}},
+		{task: task{ID: "stopped"}, WallMs: 9000,
+			runMetrics: runMetrics{Outcome: "max_steps", Cost: 0.02, Currency: "CNY", PromptTokens: 1000, ToolCalls: 40, ToolFailures: 3}},
+	})
+
+	for _, want := range []string{
+		"**Cost per solved:** CNY 0.0400",
+		"**Failures by class:** max_steps ×1",
+		"| Task | Result | Class |",
+		"| `stopped` | ❌ fail | max_steps |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDurFormatsSubMinuteAndMinuteScale(t *testing.T) {
+	if got := dur(4500); got != "4.5s" {
+		t.Errorf("dur(4500) = %q, want 4.5s", got)
+	}
+	if got := dur(125000); got != "2m05s" {
+		t.Errorf("dur(125000) = %q, want 2m05s", got)
+	}
+	if got := dur(0); got != "—" {
+		t.Errorf("dur(0) = %q, want an em dash", got)
+	}
+}
+
+func TestMedianPicksTheMiddleWallTime(t *testing.T) {
+	if got := median([]int64{9000, 1000, 4000}); got != 4000 {
+		t.Fatalf("median = %d, want 4000", got)
+	}
+	if got := median(nil); got != 0 {
+		t.Fatalf("empty median = %d, want 0", got)
+	}
+}

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -1,9 +1,33 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// PauseClass names the guard that deliberately ended a run, so a host can
+// classify an outcome without reaching into the unexported pause types.
+// Empty for ordinary provider/tool failures.
+func PauseClass(err error) string {
+	var maxSteps *maxStepsPause
+	if errors.As(err, &maxSteps) {
+		return "max_steps"
+	}
+	var stall *todoStallPause
+	if errors.As(err, &stall) {
+		return "todo_stall"
+	}
+	var readiness *FinalReadinessError
+	if errors.As(err, &readiness) {
+		return "final_readiness"
+	}
+	var recovery *RecoveryPauseError
+	if errors.As(err, &recovery) {
+		return "recovery_paused"
+	}
+	return ""
+}
 
 // FinalReadinessError reports that the model exhausted its recovery attempts
 // before satisfying the host-observed delivery checks.

--- a/internal/agent/errors_test.go
+++ b/internal/agent/errors_test.go
@@ -1,11 +1,34 @@
 package agent
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
 
 func TestFinalReadinessErrorPreservesDiagnosticText(t *testing.T) {
 	err := (&FinalReadinessError{Attempts: 3, Reason: "missing verification"}).Error()
 	want := "final-answer readiness failed 3 times: missing verification"
 	if err != want {
 		t.Fatalf("Error() = %q, want %q", err, want)
+	}
+}
+
+func TestPauseClassNamesEachGuard(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{&maxStepsPause{steps: 40, key: "max_steps"}, "max_steps"},
+		{&todoStallPause{rounds: 12}, "todo_stall"},
+		{&FinalReadinessError{Attempts: 3}, "final_readiness"},
+		{&RecoveryPauseError{Message: "paused"}, "recovery_paused"},
+		{fmt.Errorf("wrapped: %w", &maxStepsPause{steps: 5}), "max_steps"},
+		{errors.New("provider 500"), ""},
+		{nil, ""},
+	} {
+		if got := PauseClass(tc.err); got != tc.want {
+			t.Errorf("PauseClass(%v) = %q, want %q", tc.err, got, tc.want)
+		}
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -711,6 +711,8 @@ func runAgent(args []string, version string) int {
 		})
 	}
 	if metrics != nil {
+		metrics.m.DurationMs = time.Since(started).Milliseconds()
+		metrics.m.Outcome = completion.class
 		if exec := ctrl.Executor(); exec != nil {
 			if audit := exec.CapabilityAudit(); audit != nil {
 				snap := audit.Snapshot()

--- a/internal/cli/run_completion.go
+++ b/internal/cli/run_completion.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 
 	"reasonix/internal/agent"
@@ -8,27 +9,45 @@ import (
 )
 
 type runCompletion struct {
-	outcome  string
-	subtype  string
+	outcome string
+	subtype string
+	// class is the benchmark-facing failure taxonomy. It names which guard or
+	// transport ended the run and never affects the exit code or wire outcome.
+	class    string
 	isError  bool
 	exitCode int
 }
 
 func classifyRunCompletion(err error) runCompletion {
 	if err == nil {
-		return runCompletion{subtype: "success"}
+		return runCompletion{subtype: "success", class: "success"}
 	}
 	var pauseErr *agent.RecoveryPauseError
 	if errors.As(err, &pauseErr) {
 		return runCompletion{
 			outcome:  event.TurnOutcomeRecoveryPaused,
 			subtype:  event.TurnOutcomeRecoveryPaused,
+			class:    event.TurnOutcomeRecoveryPaused,
 			exitCode: 0,
 		}
 	}
 	return runCompletion{
 		subtype:  "error_during_execution",
+		class:    runFailureClass(err),
 		isError:  true,
 		exitCode: 1,
 	}
+}
+
+func runFailureClass(err error) string {
+	if class := agent.PauseClass(err); class != "" {
+		return class
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "cancelled"
+	}
+	return "error_during_execution"
 }

--- a/internal/cli/run_completion_test.go
+++ b/internal/cli/run_completion_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestClassifyRunCompletionNamesTheFailureClass(t *testing.T) {
+	for _, tc := range []struct {
+		err  error
+		want string
+	}{
+		{nil, "success"},
+		{&agent.FinalReadinessError{Attempts: 3, Reason: "incomplete todos"}, "final_readiness"},
+		{&agent.RecoveryPauseError{Message: "paused"}, "recovery_paused"},
+		{fmt.Errorf("run: %w", context.DeadlineExceeded), "timeout"},
+		{context.Canceled, "cancelled"},
+		{errors.New("provider 500"), "error_during_execution"},
+	} {
+		if got := classifyRunCompletion(tc.err).class; got != tc.want {
+			t.Errorf("class for %v = %q, want %q", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestFailureClassDoesNotChangeExitBehaviour(t *testing.T) {
+	readiness := classifyRunCompletion(&agent.FinalReadinessError{Attempts: 3})
+	if !readiness.isError || readiness.exitCode != 1 || readiness.outcome != "" {
+		t.Fatalf("final-readiness completion = %+v, want the unchanged error exit", readiness)
+	}
+	if readiness.subtype != "error_during_execution" {
+		t.Fatalf("subtype = %q, want the unchanged wire subtype", readiness.subtype)
+	}
+}

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"os"
+	"strings"
 
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
@@ -65,6 +66,18 @@ type RunMetrics struct {
 	CapabilityRouterCompletionTok  int     `json:"capability_router_completion_tokens,omitempty"`
 	CapabilityRouterCost           float64 `json:"capability_router_cost,omitempty"`
 	CapabilityRouterLatencyMs      int64   `json:"capability_router_latency_ms,omitempty"`
+
+	// Run accounting: what a benchmark needs to price one solved task and name
+	// the guard that ended a failed one.
+	DurationMs         int64          `json:"duration_ms"`
+	Outcome            string         `json:"outcome"`
+	ToolCalls          int            `json:"tool_calls"`
+	ToolFailures       int            `json:"tool_failures"`
+	ToolDurationMs     int64          `json:"tool_duration_ms"`
+	SubagentToolCalls  int            `json:"subagent_tool_calls"`
+	Retries            int            `json:"retries"`
+	ToolCallsByName    map[string]int `json:"tool_calls_by_name,omitempty"`
+	ToolFailuresByName map[string]int `json:"tool_failures_by_name,omitempty"`
 }
 
 // metricsSink forwards every event to the real sink and accumulates the per-call
@@ -101,7 +114,40 @@ func (s *metricsSink) Emit(e event.Event) {
 	if e.Kind == event.CompactionStarted {
 		s.m.Compactions++
 	}
+	if e.Kind == event.ToolResult {
+		s.recordToolResult(e.Tool)
+	}
+	if e.Kind == event.Retrying {
+		s.m.Retries++
+	}
 	s.inner.Emit(e)
+}
+
+// recordToolResult attributes a finished call by the name the model emitted,
+// not Tool.ResolvedName — a wasted call is a wrong model decision, and the
+// proxy target it resolved to would hide which name was picked.
+func (s *metricsSink) recordToolResult(t event.Tool) {
+	name := strings.TrimSpace(t.Name)
+	if name == "" {
+		name = "unknown"
+	}
+	s.m.ToolCalls++
+	s.m.ToolDurationMs += t.DurationMs
+	if t.ParentID != "" {
+		s.m.SubagentToolCalls++
+	}
+	if s.m.ToolCallsByName == nil {
+		s.m.ToolCallsByName = map[string]int{}
+	}
+	s.m.ToolCallsByName[name]++
+	if t.Err == "" {
+		return
+	}
+	s.m.ToolFailures++
+	if s.m.ToolFailuresByName == nil {
+		s.m.ToolFailuresByName = map[string]int{}
+	}
+	s.m.ToolFailuresByName[name]++
 }
 
 func (s *metricsSink) RecordReadinessAudit(a evidence.ReadinessAudit) {

--- a/internal/cli/run_metrics_test.go
+++ b/internal/cli/run_metrics_test.go
@@ -83,6 +83,42 @@ func TestMetricsSinkAccumulatesSilentReasoningRecovery(t *testing.T) {
 	}
 }
 
+func TestMetricsSinkAccountsToolCallsAndRetries(t *testing.T) {
+	s := &metricsSink{inner: event.Discard}
+
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{Name: "read_file"}})
+	s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{Name: "read_file", DurationMs: 12}})
+	s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{Name: "read_file", DurationMs: 8}})
+	s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{Name: "bash", Err: "exit status 1", DurationMs: 30}})
+	s.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{Name: "grep", ParentID: "task-1", DurationMs: 5}})
+	s.Emit(event.Event{Kind: event.Retrying, RetryAttempt: 1, RetryMax: 3})
+
+	if s.m.ToolCalls != 4 {
+		t.Fatalf("tool calls = %d, want 4 (dispatch must not count)", s.m.ToolCalls)
+	}
+	if s.m.ToolFailures != 1 {
+		t.Fatalf("tool failures = %d, want 1", s.m.ToolFailures)
+	}
+	if s.m.ToolDurationMs != 55 {
+		t.Fatalf("tool duration = %dms, want 55", s.m.ToolDurationMs)
+	}
+	if s.m.SubagentToolCalls != 1 {
+		t.Fatalf("subagent tool calls = %d, want 1", s.m.SubagentToolCalls)
+	}
+	if s.m.Retries != 1 {
+		t.Fatalf("retries = %d, want 1", s.m.Retries)
+	}
+	if s.m.ToolCallsByName["read_file"] != 2 || s.m.ToolCallsByName["bash"] != 1 {
+		t.Fatalf("calls by name = %v", s.m.ToolCallsByName)
+	}
+	if s.m.ToolFailuresByName["bash"] != 1 {
+		t.Fatalf("failures by name = %v, want bash 1", s.m.ToolFailuresByName)
+	}
+	if _, ok := s.m.ToolFailuresByName["read_file"]; ok {
+		t.Fatalf("a successful tool must not appear in failures: %v", s.m.ToolFailuresByName)
+	}
+}
+
 func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "metrics.json")
 	if err := writeMetrics(path, RunMetrics{


### PR DESCRIPTION
## Why

The e2e report can say what a suite cost. It cannot say what one *solved task* cost — which is the only number that survives a comparison against another harness on the same model, temperature and budget.

Failures had the same problem: every one rendered as a bare ❌. A wrong patch and a guard that deliberately stopped the run were indistinguishable, so there was no way to tell whether a change made the model worse at the task or just made one of our own guards fire earlier.

## What

- `--metrics` now records wall time, tool-call accounting (total, failures, per-tool-name, subagent-initiated), retries, and the outcome class.
- New `agent.PauseClass()` names the four control-flow stops — `max_steps`, `todo_stall`, `final_readiness`, `recovery_paused` — so hosts classify a run without reaching into the unexported pause types.
- `runCompletion` gains a `class` field. It is metrics-only: the exit code, wire outcome and subtype are untouched, and there is a test pinning that.
- The e2e report leads with **cost per solved**, **tokens per solved** and **median wall time**, and prints a failure-class breakdown.

Wall time is measured by the harness rather than read from the agent's own metrics, so the same suite stays comparable when it runs against a harness that cannot write our metrics file.

## Failure classes

`solved` · `wrong_patch` (ran clean, grader failed) · `max_steps` · `todo_stall` · `final_readiness` · `recovery_paused` · `timeout` · `no_metrics`

## Notes

- JSON report fields are additive; the `/e2e` bot reads only `Passed` / `Skipped` and is unaffected.
- Known gap, deliberately left: on the planner path a `maxStepsPause` is absorbed by the coordinator and degrades to the executor, returning a plain string error that classifies as `error_during_execution`. Closing that means changing control flow, which belongs with the guard extraction work, not here.



Documentation-impact: none - the metrics JSON gains additive machine-readable fields and the e2e report is a PR comment; no documented CLI flag, config key or behaviour changes, so docs/CLI.md stays correct.
