### PR TITLE
feat(ablation): switch subsystems off behind one shared vocabulary

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -11,11 +11,13 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/shellparse"
 )
 
 type diffOpts struct {
 	bin, model, repo, base, testCmd, profile string
+	ablate                                   ablation.Set
 	maxSteps, timeoutSec, attempts           int
 }
 
@@ -85,6 +87,9 @@ func runOnce(o diffOpts, srcFiles, pkgs []string, prompt string) diffReport {
 		args = append(args, "--model", o.model)
 	}
 	args = appendBenchmarkProfileArgs(args, o.profile)
+	if !o.ablate.Empty() {
+		args = append(args, "--ablate", o.ablate.String())
+	}
 	args = append(args, prompt)
 	cmd := exec.CommandContext(ctx, o.bin, args...)
 	cmd.Dir = o.repo

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"reasonix/internal/ablation"
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
 
@@ -67,6 +68,9 @@ type result struct {
 	task
 	runMetrics
 	Profile string `json:"profile"`
+	// Arm is the ablation arm the harness requested, not the arm the child
+	// reported, so a run that died before writing metrics is still attributable.
+	Arm     string `json:"arm"`
 	Passed  bool
 	Skipped bool
 	Note    string
@@ -114,6 +118,7 @@ func main() {
 	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
 	model := flag.String("model", "", "provider/model name (default: config default)")
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
+	ablateFlag := flag.String("ablate", "", "ablation arm: subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
 	budget := flag.Int("budget", defaultSuiteTokenBudget, "abort once total tokens cross this (0 = no cap)")
@@ -130,11 +135,16 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
+	arm, err := ablation.Parse(*ablateFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
 
 	if *mode == "diff" {
 		report := runDiff(diffOpts{
 			bin: *bin, model: *model, repo: *repo, base: *base,
-			testCmd: *testCmd, profile: profile, maxSteps: *maxSteps, timeoutSec: *timeoutSec, attempts: *attempts,
+			testCmd: *testCmd, profile: profile, ablate: arm, maxSteps: *maxSteps, timeoutSec: *timeoutSec, attempts: *attempts,
 		})
 		emit(report, *outMD, "")
 		return
@@ -162,7 +172,7 @@ func main() {
 			results = append(results, result{task: t, Profile: profile, Skipped: true, Note: "skipped: token budget reached"})
 			continue
 		}
-		r := runTask(*bin, *model, profile, t)
+		r := runTask(*bin, *model, profile, arm, t)
 		total += r.PromptTokens + r.CompletionTokens
 		results = append(results, r)
 	}
@@ -234,8 +244,9 @@ func loadTasks(suite string) ([]task, error) {
 // runTask copies the task's seed workdir into a temp dir, runs the agent there,
 // then drops in verify.sh and runs it as the grader. The grader is added only
 // after the run so the agent can't read the answer key.
-func runTask(bin, model, profile string, t task) result {
+func runTask(bin, model, profile string, arm ablation.Set, t task) result {
 	r := result{task: t, Profile: profile}
+	r.Arm = arm.Arm()
 
 	work, err := os.MkdirTemp("", "e2ebench-"+t.ID+"-")
 	if err != nil {
@@ -255,7 +266,7 @@ func runTask(bin, model, profile string, t task) result {
 	defer cancel()
 
 	metricsPath := filepath.Join(work, ".run-metrics.json")
-	args := buildRunTaskArgs(metricsPath, model, profile, t.MaxSteps, t.Prompt)
+	args := buildRunTaskArgs(metricsPath, model, profile, arm, t.MaxSteps, t.Prompt)
 
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = work
@@ -283,7 +294,7 @@ func runTask(bin, model, profile string, t task) result {
 	return r
 }
 
-func buildRunTaskArgs(metricsPath, model, profile string, maxSteps int, prompt string) []string {
+func buildRunTaskArgs(metricsPath, model, profile string, arm ablation.Set, maxSteps int, prompt string) []string {
 	// Benchmarks are unattended and their fixtures require ordinary workspace
 	// writes. Auto still honors explicit ask/deny rules and the sandbox boundary.
 	args := []string{"run", "--auto", "--metrics", metricsPath}
@@ -294,6 +305,11 @@ func buildRunTaskArgs(metricsPath, model, profile string, maxSteps int, prompt s
 		args = append(args, "--max-steps", fmt.Sprint(maxSteps))
 	}
 	args = appendBenchmarkProfileArgs(args, profile)
+	// The control arm must produce a byte-identical command line to the one the
+	// suite ran before ablation existed, so its numbers stay comparable.
+	if !arm.Empty() {
+		args = append(args, "--ablate", arm.String())
+	}
 	return append(args, prompt)
 }
 
@@ -345,10 +361,16 @@ func render(results []result) string {
 	}
 
 	profile := benchmarkProfileBaseline
-	if len(results) > 0 && results[0].Profile != "" {
-		profile = results[0].Profile
+	arm := "full"
+	if len(results) > 0 {
+		if results[0].Profile != "" {
+			profile = results[0].Profile
+		}
+		if results[0].Arm != "" {
+			arm = results[0].Arm
+		}
 	}
-	fmt.Fprintf(&b, "## 🤖 Reasonix e2e benchmark (%s)\n\n", profile)
+	fmt.Fprintf(&b, "## 🤖 Reasonix e2e benchmark (%s · arm `%s`)\n\n", profile, arm)
 	fmt.Fprintf(&b, "**Solved:** %d/%d (%s) · **Cost per solved:** %s · **Tokens per solved:** %s · **Median wall time:** %s\n\n",
 		passed, ran, pct(passed, ran),
 		costPerSolved(cost, passed, currency), tokensPerSolved(pTok+cTok, passed), dur(median(walls)))

--- a/cmd/e2ebench/profile_test.go
+++ b/cmd/e2ebench/profile_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"reasonix/internal/ablation"
 )
 
 func TestAppendBenchmarkProfileArgsBaselineIsByteIdentical(t *testing.T) {
@@ -22,7 +24,7 @@ func TestAppendBenchmarkProfileArgsDeliveryUsesRealRuntimeProfile(t *testing.T) 
 }
 
 func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
-	got := buildRunTaskArgs("metrics.json", "e2e", benchmarkProfileDelivery, 12, "fix it")
+	got := buildRunTaskArgs("metrics.json", "e2e", benchmarkProfileDelivery, ablation.Set{}, 12, "fix it")
 	want := []string{
 		"run", "--auto", "--metrics", "metrics.json",
 		"--model", "e2e", "--max-steps", "12",
@@ -30,6 +32,14 @@ func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("run task args = %v, want %v", got, want)
+	}
+}
+
+func TestBuildRunTaskArgsPassesTheAblationArmThrough(t *testing.T) {
+	got := buildRunTaskArgs("m.json", "", benchmarkProfileBaseline, ablation.New(ablation.Evidence, ablation.Planner), 0, "fix it")
+	want := []string{"run", "--auto", "--metrics", "m.json", "--ablate", "evidence,planner", "fix it"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ablated args = %v, want %v", got, want)
 	}
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -142,6 +142,21 @@ structured output format is selected. It also accepts `--model`, `--profile`,
 `--copy`, `--allowed-tools`, `--permission-mode`, and `--auto` / `-y` (an alias
 for `--permission-mode auto`).
 
+### Benchmark arms
+
+`--ablate` switches whole subsystems off so a benchmark can attribute a change
+in success rate to one of them. It accepts a comma-separated list of `evidence`,
+`planner`, `subagent`, `retrieval` and `compaction`, plus `none` (the default,
+everything on) and `all`. Sub-agents inherit the parent's arm, and the arm name
+is written to the `--metrics` file so a recorded run is self-describing.
+
+```sh
+reasonix run --ablate evidence,planner --metrics run.json "fix the failing test"
+```
+
+This is a measurement tool, not a tuning knob: switching a subsystem off makes
+Reasonix worse at the work it was added for.
+
 ### Output formats
 
 | Format | Behavior |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -128,6 +128,19 @@ echo "解释这段代码" | reasonix run
 `--continue`、`--resume PATH`、`--copy`、`--allowed-tools` 和
 `--permission-mode`，以及作为 `--permission-mode auto` 别名的 `--auto` / `-y`。
 
+### 基准对照组
+
+`--ablate` 用于整体关闭某个子系统，让基准测试能把成功率的变化归因到它身上。取值是
+`evidence`、`planner`、`subagent`、`retrieval`、`compaction` 的逗号分隔组合，另外还接受
+`none`（默认，全部启用）和 `all`。子代理继承父代理的对照组配置，对照组名称会写入
+`--metrics` 文件，因此记录下来的每次运行都能自证跑的是哪一组。
+
+```sh
+reasonix run --ablate evidence,planner --metrics run.json "修复失败的测试"
+```
+
+这是测量工具，不是调优开关：关掉某个子系统只会让 Reasonix 在它本来负责的工作上变差。
+
 ### 输出格式
 
 | 格式 | 行为 |

--- a/internal/ablation/ablation.go
+++ b/internal/ablation/ablation.go
@@ -1,0 +1,114 @@
+// Package ablation switches individual Reasonix subsystems off so a benchmark
+// can attribute a change in solve rate to one of them.
+package ablation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Module string
+
+const (
+	Evidence   Module = "evidence"
+	Planner    Module = "planner"
+	Subagent   Module = "subagent"
+	Retrieval  Module = "retrieval"
+	Compaction Module = "compaction"
+)
+
+// Modules returns every switchable module in the order arm names use.
+func Modules() []Module {
+	return []Module{Evidence, Planner, Subagent, Retrieval, Compaction}
+}
+
+// Set is the group of modules disabled for a run. The zero value is the
+// control arm: everything on.
+type Set struct {
+	off map[Module]bool
+}
+
+// Parse reads a spec such as "evidence,planner". "" and "none" mean the control
+// arm; "all" disables every module.
+func Parse(spec string) (Set, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" || strings.EqualFold(spec, "none") {
+		return Set{}, nil
+	}
+	if strings.EqualFold(spec, "all") {
+		return New(Modules()...), nil
+	}
+	known := map[Module]bool{}
+	for _, m := range Modules() {
+		known[m] = true
+	}
+	var mods []Module
+	for _, field := range strings.FieldsFunc(spec, func(r rune) bool { return r == ',' || r == ' ' }) {
+		m := Module(strings.ToLower(strings.TrimSpace(field)))
+		if !known[m] {
+			return Set{}, fmt.Errorf("unknown ablation module %q (want %s, or none/all)", field, joinModules(Modules(), ", "))
+		}
+		mods = append(mods, m)
+	}
+	return New(mods...), nil
+}
+
+// New returns a Set with the given modules disabled.
+func New(mods ...Module) Set {
+	if len(mods) == 0 {
+		return Set{}
+	}
+	off := make(map[Module]bool, len(mods))
+	for _, m := range mods {
+		off[m] = true
+	}
+	return Set{off: off}
+}
+
+func (s Set) Off(m Module) bool { return s.off[m] }
+
+func (s Set) Empty() bool { return len(s.off) == 0 }
+
+// Arm is the published name of this configuration: "full" for the control arm,
+// otherwise "no-evidence+no-planner". Stable across runs so results from
+// different machines group by the same key.
+func (s Set) Arm() string {
+	if s.Empty() {
+		return "full"
+	}
+	parts := make([]string, 0, len(s.off))
+	for _, m := range s.disabled() {
+		parts = append(parts, "no-"+string(m))
+	}
+	return strings.Join(parts, "+")
+}
+
+// String round-trips back through Parse.
+func (s Set) String() string {
+	if s.Empty() {
+		return "none"
+	}
+	return joinModules(s.disabled(), ",")
+}
+
+func (s Set) disabled() []Module {
+	order := map[Module]int{}
+	for i, m := range Modules() {
+		order[m] = i
+	}
+	out := make([]Module, 0, len(s.off))
+	for m := range s.off {
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool { return order[out[i]] < order[out[j]] })
+	return out
+}
+
+func joinModules(mods []Module, sep string) string {
+	parts := make([]string, len(mods))
+	for i, m := range mods {
+		parts[i] = string(m)
+	}
+	return strings.Join(parts, sep)
+}

--- a/internal/ablation/ablation_test.go
+++ b/internal/ablation/ablation_test.go
@@ -1,0 +1,67 @@
+package ablation
+
+import "testing"
+
+func TestParseAcceptsSpecFormsAndRejectsUnknownModules(t *testing.T) {
+	for _, tc := range []struct {
+		spec string
+		arm  string
+	}{
+		{"", "full"},
+		{"none", "full"},
+		{"NONE", "full"},
+		{"evidence", "no-evidence"},
+		{"planner,evidence", "no-evidence+no-planner"},
+		{"planner evidence", "no-evidence+no-planner"},
+		{" Evidence , Retrieval ", "no-evidence+no-retrieval"},
+		{"all", "no-evidence+no-planner+no-subagent+no-retrieval+no-compaction"},
+	} {
+		set, err := Parse(tc.spec)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", tc.spec, err)
+		}
+		if got := set.Arm(); got != tc.arm {
+			t.Errorf("Parse(%q).Arm() = %q, want %q", tc.spec, got, tc.arm)
+		}
+	}
+
+	if _, err := Parse("evidence,planer"); err == nil {
+		t.Fatal("a misspelled module must fail loudly, not silently run the control arm")
+	}
+}
+
+func TestArmNameIsIndependentOfSpecOrder(t *testing.T) {
+	a, _ := Parse("retrieval,evidence,planner")
+	b, _ := Parse("planner,retrieval,evidence")
+	if a.Arm() != b.Arm() {
+		t.Fatalf("arm names diverge by input order: %q vs %q", a.Arm(), b.Arm())
+	}
+}
+
+func TestStringRoundTripsThroughParse(t *testing.T) {
+	for _, spec := range []string{"none", "evidence", "evidence,compaction", "all"} {
+		set, err := Parse(spec)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", spec, err)
+		}
+		again, err := Parse(set.String())
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", set.String(), err)
+		}
+		if again.Arm() != set.Arm() {
+			t.Errorf("%q round-tripped to %q", set.Arm(), again.Arm())
+		}
+	}
+}
+
+func TestZeroValueIsTheControlArm(t *testing.T) {
+	var s Set
+	if !s.Empty() || s.Arm() != "full" {
+		t.Fatalf("zero Set = %q, want the full control arm", s.Arm())
+	}
+	for _, m := range Modules() {
+		if s.Off(m) {
+			t.Errorf("zero Set disabled %s", m)
+		}
+	}
+}

--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/ablation"
+	"reasonix/internal/evidence"
+)
+
+func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
+
+	gated := &Agent{evidence: readinessLedger(writer, todo)}
+	if gated.finalReadinessCheckFor().reason == "" {
+		t.Fatal("control arm must still gate an incomplete todo after a write")
+	}
+
+	off := &Agent{evidence: readinessLedger(writer, todo), ablation: ablation.New(ablation.Evidence)}
+	if got := off.finalReadinessCheckFor().reason; got != "" {
+		t.Fatalf("evidence ablation still gated the final answer: %q", got)
+	}
+
+	unrelated := &Agent{evidence: readinessLedger(writer, todo), ablation: ablation.New(ablation.Planner)}
+	if unrelated.finalReadinessCheckFor().reason == "" {
+		t.Fatal("an unrelated ablation must not disable the readiness gate")
+	}
+}
+
+func TestCompactionAblationCollapsesTheCachePreservingDeferral(t *testing.T) {
+	full := &Agent{contextWindow: 100_000, softCompactRatio: 0.5, toolResultSnipRatio: 0.7, compactRatio: 0.8}
+	soft, snip, high := full.compactThresholds()
+	if soft != 50_000 || snip != 70_000 || high != 80_000 {
+		t.Fatalf("control thresholds = %d/%d/%d, want 50000/70000/80000", soft, snip, high)
+	}
+
+	off := &Agent{contextWindow: 100_000, softCompactRatio: 0.5, toolResultSnipRatio: 0.7, compactRatio: 0.8,
+		ablation: ablation.New(ablation.Compaction)}
+	soft, snip, high = off.compactThresholds()
+	if soft != 50_000 || snip != soft || high != soft {
+		t.Fatalf("ablated thresholds = %d/%d/%d, want all three at 50000", soft, snip, high)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,6 +14,7 @@ import (
 
 	"mvdan.cc/sh/v3/syntax"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/capability"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/diff"
@@ -456,6 +457,10 @@ type Agent struct {
 	deliveryScopeID             string
 	deliveryScopeActive         bool
 	deliveryCheckpoint          evidence.DeliveryCheckpoint
+
+	// ablation names the subsystems a benchmark arm switched off. The zero value
+	// is the control arm.
+	ablation ablation.Set
 
 	// classifierTaskText is the host-trusted task text for delivery intent
 	// classification, set by sub-agent spawners whose Run input carries host
@@ -1069,6 +1074,10 @@ type Options struct {
 	// final answer. It changes host control flow, not tool schemas.
 	DeliveryProfile bool
 
+	// Ablation switches subsystems off for a benchmark arm. The zero value runs
+	// everything, so ordinary callers leave it unset.
+	Ablation ablation.Set
+
 	// ClassifierTaskText, when non-empty, is the pristine task text delivery
 	// intent classification should judge instead of the raw Run input. Sub-agent
 	// spawners set it before prepending host framing (subagent/workspace context,
@@ -1214,6 +1223,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		evidence:                  evidence.NewLedger(),
 		projectChecks:             append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		deliveryProfile:           opts.DeliveryProfile,
+		ablation:                  opts.Ablation,
 		classifierTaskText:        opts.ClassifierTaskText,
 		capabilityLedger:          opts.CapabilityLedger,
 		capabilityAudit:           opts.CapabilityAudit,
@@ -1571,7 +1581,7 @@ func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recover
 }
 
 func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
-	if a.evidence == nil {
+	if a.evidence == nil || a.ablation.Off(ablation.Evidence) {
 		return finalReadinessCheck{}
 	}
 	var missing []string

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
@@ -79,6 +80,20 @@ What is still in progress or unstarted, and the single most concrete next action
 
 Rules: be terse — bullet points and fragments, not prose. Preserve identifiers, paths, and numbers exactly. Do NOT invent anything not present in the messages; if something is unknown, leave it out rather than guessing.`
 
+// compactThresholds returns the prompt-token boundaries maybeCompact switches
+// on. The compaction ablation arm collapses the snip and fold triggers onto
+// soft, so the cache-preserving deferral branch is unreachable and the session
+// folds as soon as it grows — what a harness with no prompt-cache strategy does.
+func (a *Agent) compactThresholds() (soft, snip, high int) {
+	high = int(float64(a.contextWindow) * a.compactRatio)
+	snip = int(float64(a.contextWindow) * a.toolResultSnipRatio)
+	soft = int(float64(a.contextWindow) * a.softCompactRatio)
+	if a.ablation.Off(ablation.Compaction) {
+		high, snip = soft, soft
+	}
+	return soft, snip, high
+}
+
 // maybeCompact compacts the session when the last turn's prompt has grown to the
 // configured fraction of the context window. It is a no-op when compaction is
 // disabled (no window) or usage is unavailable.
@@ -86,9 +101,7 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
 		return
 	}
-	high := int(float64(a.contextWindow) * a.compactRatio)
-	snip := int(float64(a.contextWindow) * a.toolResultSnipRatio)
-	soft := int(float64(a.contextWindow) * a.softCompactRatio)
+	soft, snip, high := a.compactThresholds()
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
 	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
@@ -253,6 +254,7 @@ type TaskTool struct {
 	identityProfile     func(modelRef, effort string) (string, string)
 	maxSubagentDepth    int
 	deliveryProfile     bool
+	ablation            ablation.Set
 	workspaceLease      *workspacelease.Owner
 	// scheduler is the session-scoped concurrency + write-claim controller.
 	// nil falls back to the legacy jobs.ReserveStart cap for background tasks.
@@ -394,6 +396,13 @@ func (t *TaskTool) WithMaxSubagentDepth(depth int) *TaskTool {
 // the mutation gate remains dormant for them.
 func (t *TaskTool) WithDeliveryProfile(enabled bool) *TaskTool {
 	t.deliveryProfile = enabled
+	return t
+}
+
+// WithAblation propagates the parent's benchmark arm so a sub-agent runs with
+// the same subsystems switched off.
+func (t *TaskTool) WithAblation(set ablation.Set) *TaskTool {
+	t.ablation = set
 	return t
 }
 
@@ -1676,6 +1685,7 @@ func (t *TaskTool) subagentOptions(ctx context.Context, maxSteps int, pricing *p
 		SubagentDepth:       childDepth,
 		MaxSubagentDepth:    t.maxDepth(),
 		DeliveryProfile:     t.deliveryProfile,
+		Ablation:            t.ablation,
 		WorkspaceLease:      t.workspaceLease,
 		RecoveryGate:        t.recoveryGate,
 		RecoveryAgentID:     "subagent",

--- a/internal/boot/ablation_test.go
+++ b/internal/boot/ablation_test.go
@@ -1,0 +1,63 @@
+package boot
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/ablation"
+	"reasonix/internal/event"
+)
+
+func builtToolNames(t *testing.T, set ablation.Set) map[string]bool {
+	t.Helper()
+	ctrl, err := Build(context.Background(), Options{
+		SessionDir: filepath.Join(t.TempDir(), "sessions"),
+		TokenMode:  TokenModeFull,
+		Sink:       event.Discard,
+		Ablation:   set,
+	})
+	if err != nil {
+		t.Fatalf("Build(%s): %v", set.Arm(), err)
+	}
+	defer ctrl.Close()
+	names := map[string]bool{}
+	for _, e := range ctrl.ToolContractEntries() {
+		names[e.Name] = true
+	}
+	return names
+}
+
+func TestAblationRemovesOnlyTheTargetedToolSurfaces(t *testing.T) {
+	isolateConfigHome(t)
+	t.Chdir(robustTempDir(t))
+
+	full := builtToolNames(t, ablation.Set{})
+	for _, name := range []string{"task", "read_only_task", "history", "memory", "remember", "list_sessions"} {
+		if !full[name] {
+			t.Fatalf("control arm is missing %s; the ablation assertions below would be vacuous", name)
+		}
+	}
+
+	noSubagent := builtToolNames(t, ablation.New(ablation.Subagent))
+	for _, name := range []string{"task", "read_only_task", "parallel_tasks", "fleet"} {
+		if noSubagent[name] {
+			t.Errorf("subagent ablation left %s registered", name)
+		}
+	}
+	if !noSubagent["history"] || !noSubagent["memory"] {
+		t.Error("subagent ablation must not touch the retrieval surfaces")
+	}
+
+	noRetrieval := builtToolNames(t, ablation.New(ablation.Retrieval))
+	for _, name := range []string{"history", "memory"} {
+		if noRetrieval[name] {
+			t.Errorf("retrieval ablation left the BM25-backed %s registered", name)
+		}
+	}
+	for _, name := range []string{"remember", "forget", "list_sessions", "read_session", "task"} {
+		if !noRetrieval[name] {
+			t.Errorf("retrieval ablation dropped %s, which is not a retrieval surface", name)
+		}
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/agent"
 	"reasonix/internal/capability"
 	"reasonix/internal/command"
@@ -171,10 +172,12 @@ type Options struct {
 	// catalog. Remote Workbench injects a Broker resolver so no credential or
 	// provider endpoint has to exist on the Host. Nil preserves local behavior.
 	ProviderResolver provider.Resolver
-	// DisablePlanner is a process-local hard override used by supervised ACP
-	// workers. It wins over user/project planner_model configuration without
-	// mutating config or changing the provider-visible prompt/tool surface.
-	DisablePlanner bool
+	// Ablation switches subsystems off for a benchmark arm, and is also the
+	// process-local hard override supervised ACP workers use to force the planner
+	// off. It wins over user/project configuration without mutating config or
+	// changing the provider-visible prompt/tool surface. The zero value runs
+	// everything.
+	Ablation ablation.Set
 	// SandboxNetworkOverride and WorkspaceOnly are process-local hard bounds for
 	// supervised ACP workers. Nil/false preserve normal Reasonix config.
 	SandboxNetworkOverride *bool
@@ -903,6 +906,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			WithTranscriptIdentityResolver(subagentIdentity).
 			WithMaxSubagentDepth(maxSubagentDepth).
 			WithDeliveryProfile(tokenDelivery).
+			WithAblation(opts.Ablation).
 			WithWorkspaceLease(workspaceLease).
 			WithScheduler(subagentScheduler).
 			WithProfileLookup(profileLookup).
@@ -911,6 +915,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			WithCapabilityRuntime(capRuntime)
 	}
 	addTaskTool := func() string {
+		if opts.Ablation.Off(ablation.Subagent) {
+			return "task tool is disabled for this run."
+		}
 		if taskToolAdded {
 			return "task tool is already enabled."
 		}
@@ -928,6 +935,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return "enabled task."
 	}
 	addReadOnlyTaskTool := func() string {
+		if opts.Ablation.Off(ablation.Subagent) {
+			return "read_only_task tool is disabled for this run."
+		}
 		if readOnlyTaskToolAdded {
 			return "read_only_task tool is already enabled."
 		}
@@ -962,6 +972,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "sessions are already enabled."
 		}
 		sessionToolsAdded = true
+		// history and memory are the BM25-backed surfaces; the ablation arm drops
+		// only those two and leaves the direct-access tools alone, so a lost solve
+		// is attributable to retrieval and not to a missing session reader.
+		if opts.Ablation.Off(ablation.Retrieval) {
+			reg.Add(sessiontool.NewListSessionsTool(sessionDir))
+			reg.Add(sessiontool.NewReadSessionTool(sessionDir))
+			return "enabled list_sessions, read_session."
+		}
 		reg.Add(history.NewTool(history.Options{SessionDir: sessionDir, GlobalSessionDir: config.SessionDir(), ArchiveDir: config.ArchiveDir()}))
 		reg.Add(sessiontool.NewListSessionsTool(sessionDir))
 		reg.Add(sessiontool.NewReadSessionTool(sessionDir))
@@ -973,6 +991,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "memory tools are already enabled."
 		}
 		memoryToolsAdded = true
+		if opts.Ablation.Off(ablation.Retrieval) {
+			reg.Add(memory.NewRememberTool(mem.Store))
+			reg.Add(memory.NewForgetTool(mem.Store))
+			return "enabled remember, forget."
+		}
 		reg.Add(memory.NewRecallTool(mem.Store))
 		reg.Add(memory.NewRememberTool(mem.Store))
 		reg.Add(memory.NewForgetTool(mem.Store))
@@ -1020,6 +1043,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			SubagentDepth:       childDepth,
 			MaxSubagentDepth:    maxSubagentDepth,
 			DeliveryProfile:     tokenDelivery,
+			Ablation:            opts.Ablation,
 			WorkspaceLease:      workspaceLease,
 		}
 	}
@@ -1608,6 +1632,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		WriteWorkspaceRoot:           root,
 		ProjectChecks:                projectChecks,
 		DeliveryProfile:              tokenDelivery,
+		Ablation:                     opts.Ablation,
 		WorkspaceLease:               workspaceLease,
 		CapabilityLedger:             capLedger,
 		CapabilityAudit:              capAudit,
@@ -1737,6 +1762,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Shell:                  shell,
 		ApprovalTimeout:        opts.ApprovalTimeout,
 		RuntimeProfile:         runtimeProfile,
+		Ablation:               opts.Ablation,
 		OnRemember: func(rule string) control.RememberResult {
 			return rememberPermissionRule(root, rule)
 		},
@@ -1861,7 +1887,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 // override is checked before user/project config and cannot be reversed by a
 // later assembly branch.
 func effectivePlannerModel(cfg *config.Config, opts Options, tokenEconomy bool) string {
-	if cfg == nil || opts.DisablePlanner || tokenEconomy {
+	if cfg == nil || opts.Ablation.Off(ablation.Planner) || tokenEconomy {
 		return ""
 	}
 	return strings.TrimSpace(cfg.Agent.PlannerModel)

--- a/internal/boot/planner_override_test.go
+++ b/internal/boot/planner_override_test.go
@@ -3,6 +3,7 @@ package boot
 import (
 	"testing"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/config"
 )
 
@@ -12,8 +13,13 @@ func TestPlannerOffHasHighestPrecedence(t *testing.T) {
 	if got := effectivePlannerModel(cfg, Options{}, false); got != "configured-planner" {
 		t.Fatalf("ordinary planner model = %q", got)
 	}
-	if got := effectivePlannerModel(cfg, Options{DisablePlanner: true}, false); got != "" {
+	off := Options{Ablation: ablation.New(ablation.Planner)}
+	if got := effectivePlannerModel(cfg, off, false); got != "" {
 		t.Fatalf("planner-off returned %q, want disabled", got)
+	}
+	other := Options{Ablation: ablation.New(ablation.Evidence)}
+	if got := effectivePlannerModel(cfg, other, false); got != "configured-planner" {
+		t.Fatalf("an unrelated ablation disabled the planner: %q", got)
 	}
 	if got := effectivePlannerModel(cfg, Options{}, true); got != "" {
 		t.Fatalf("economy returned %q, want disabled", got)

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/acp"
 	"reasonix/internal/boot"
 	"reasonix/internal/config"
@@ -107,6 +108,15 @@ func (f *acpFactory) SessionDir() string {
 	return config.SessionDir()
 }
 
+// ablationSet maps the ACP --planner=off hard override onto the shared
+// subsystem switch boot consults.
+func (f *acpFactory) ablationSet() ablation.Set {
+	if f.plannerOff {
+		return ablation.New(ablation.Planner)
+	}
+	return ablation.Set{}
+}
+
 // NewSession assembles the per-session controller. Resources (MCP subprocesses)
 // are released via the controller's Cleanup, run on ctrl.Close().
 func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*control.Controller, error) {
@@ -137,7 +147,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		OnSessionRecovered:       p.OnSessionRecovered,
 		FileOverlay:              p.FileOverlay,
 		TerminalRunner:           p.Terminal,
-		DisablePlanner:           f.plannerOff,
+		Ablation:                 f.ablationSet(),
 		SandboxNetworkOverride:   f.networkOverride,
 		SandboxBashOverride:      bashOverride,
 		WorkspaceOnly:            f.workspaceOnly,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,6 +26,7 @@ import (
 	"time"
 	"unicode/utf16"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
 	"reasonix/internal/config"
@@ -262,6 +263,7 @@ type cliBuildOverrides struct {
 	HeadlessApprovalMode string
 	Stderr               io.Writer
 	OnSessionRecovered   func(control.SessionRecoveryInfo) error
+	Ablation             ablation.Set
 }
 
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
@@ -287,6 +289,7 @@ func cliProfileBuildOptions(modelName string, maxStepsOverride int, requireKey b
 		StatsSource:          "cli",
 		Stderr:               overrides.Stderr,
 		OnSessionRecovered:   overrides.OnSessionRecovered,
+		Ablation:             overrides.Ablation,
 	}
 }
 
@@ -464,6 +467,7 @@ func runAgent(args []string, version string) int {
 	maxSteps := fs.Int("max-steps", 0, "one-off max tool-call rounds (0 = automatic)")
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
+	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
 	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
@@ -506,6 +510,11 @@ func runAgent(args []string, version string) int {
 		format = runOutputEventsJSONL
 	}
 	profile, err := parseRuntimeProfile(*profileFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	ablated, err := ablation.Parse(*ablateFlag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 2
@@ -667,6 +676,7 @@ func runAgent(args []string, version string) int {
 		WorkspaceRoot:        workspaceRoot,
 		HeadlessApprovalMode: permissions.approval,
 		OnSessionRecovered:   cliSessionRecoveredHandler(leases),
+		Ablation:             ablated,
 	}
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, true, sink, profile, overrides)
 	if err != nil {
@@ -713,6 +723,7 @@ func runAgent(args []string, version string) int {
 	if metrics != nil {
 		metrics.m.DurationMs = time.Since(started).Milliseconds()
 		metrics.m.Outcome = completion.class
+		metrics.m.Arm = ablated.Arm()
 		if exec := ctrl.Executor(); exec != nil {
 			if audit := exec.CapabilityAudit(); audit != nil {
 				snap := audit.Snapshot()

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -69,6 +69,7 @@ type RunMetrics struct {
 
 	// Run accounting: what a benchmark needs to price one solved task and name
 	// the guard that ended a failed one.
+	Arm                string         `json:"arm"`
 	DurationMs         int64          `json:"duration_ms"`
 	Outcome            string         `json:"outcome"`
 	ToolCalls          int            `json:"tool_calls"`

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/agent"
 	"reasonix/internal/autoresearch"
 	"reasonix/internal/billing"
@@ -175,6 +176,7 @@ type Controller struct {
 	// entering the provider-visible registry (Balanced dual-model Planner).
 	proxyToolsFn   func() map[string][]plugin.CachedTool
 	runtimeProfile capability.Profile
+	ablation       ablation.Set
 
 	// goals owns the active goal's FSM (status, intercepts, idle/turn counters)
 	// and its persistence, behind its own mutex so a per-turn goal save never
@@ -480,6 +482,9 @@ type Options struct {
 	// RuntimeProfile selects capability routing/filtering behavior. Empty keeps
 	// the backward-compatible Balanced profile.
 	RuntimeProfile capability.Profile
+	// Ablation switches subsystems off for a benchmark arm. The zero value runs
+	// everything.
+	Ablation ablation.Set
 }
 
 // New builds a Controller. A nil Sink is replaced with event.Discard. When the
@@ -548,6 +553,7 @@ func New(opts Options) *Controller {
 		mcpConfigureSpec:                  opts.MCPConfigureSpec,
 		capabilityRuntime:                 opts.CapabilityRuntime,
 		runtimeProfile:                    runtimeProfile,
+		ablation:                          opts.Ablation,
 		workspaceRoot:                     opts.WorkspaceRoot,
 		externalFolderToolRefs:            opts.ExternalFolderToolRefs,
 		approval:                          newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/agent"
 	"reasonix/internal/memory"
 	"reasonix/internal/planmode"
@@ -206,11 +207,11 @@ func (c *Controller) composeWithGoal(
 		// Relevant facts ride only the real user-turn tail. This preserves the
 		// stable system/tool prefix and keeps synthetic recovery turns free of
 		// accidental recall. A just-written fact already arrives in memory-update.
-		if len(notes) == 0 {
+		if len(notes) == 0 && !c.ablation.Off(ablation.Retrieval) {
 			if block := c.memory.recall(source).Block(); block != "" {
 				text = strings.TrimRight(text, "\n") + "\n\n" + block
 			}
-		} else {
+		} else if len(notes) > 0 {
 			c.memory.recordRecall(memory.RecallResult{
 				Query:      strings.TrimSpace(source),
 				Suppressed: "memory update already supplies the new fact",


### PR DESCRIPTION
Stacked on #7546 — review that one first. GitHub retargets this to `main-v2` when #7546 merges.

## Why

Nothing could actually be ablated. The only variable axis was the runtime profile, which is a coarse bundle. That means a change in solve rate could never be attributed to evidence gating, the planner, subagents, retrieval or cache-preserving compaction — every claim about those subsystems rests on assertion rather than measurement.

## What

`internal/ablation` is the single vocabulary. One `Set` flows from the `--ablate` flag through `boot` into the agent, the controller and spawned sub-agents, and names the published arm (`full`, `no-evidence`, `no-evidence+no-planner`).

Each subsystem has exactly one switch point, not scattered conditionals:

| Module | Switch point | Effect when off |
|---|---|---|
| `planner` | `boot.effectivePlannerModel` | no planner model resolves; executor-only |
| `subagent` | `addTaskTool` / `addReadOnlyTaskTool` | `task`, `read_only_task`, `parallel_tasks`, `fleet` unregistered |
| `retrieval` | tool registration + `control` auto-recall | the two BM25-backed tools (`history`, `memory`) and auto-recall drop; `remember` / `forget` / `list_sessions` / `read_session` stay |
| `evidence` | `Agent.finalReadinessCheckFor` | readiness gate stands down |
| `compaction` | new `Agent.compactThresholds` | snip and fold triggers collapse onto soft, so the cache-preserving deferral never runs and the session folds as soon as it grows |

`boot.Options.DisablePlanner` folds into the same `Set` — ACP's `--planner=off` maps onto it instead of the codebase carrying a second switch for one subsystem.

## Attribution guarantees

- The arm is recorded in `--metrics` (`arm`) and heads the e2e report, so a trajectory is self-describing.
- The control arm produces a **byte-identical** command line to the pre-ablation one, pinned by a test, so numbers collected before this change stay comparable.
- Sub-agents inherit the parent's arm via `TaskTool.WithAblation`, so a nested run cannot quietly re-enable a subsystem.
- The boot test asserts the control arm actually registers the tools it then checks are gone, so the ablation assertions cannot pass vacuously.
- An unrelated ablation must not disable a neighbouring subsystem; there are tests for that on both the planner and evidence seams.

## Test notes

`internal/cli`'s `TestRunResumeCopyContinuesInDuplicate` fails on this machine at baseline (identically on an unmodified tree) and is unrelated. Everything else in `agent`, `boot`, `control`, `cli`, `ablation` and `e2ebench` passes.



Documentation-impact: updated - docs/CLI.md and docs/CLI.zh-CN.md gain a "Benchmark arms" section covering the new --ablate flag, its accepted values, sub-agent inheritance, and the arm name landing in the --metrics file.


Cache-impact: none - the control arm registers a byte-identical tool set and system prompt; no prompt text is touched anywhere in this diff. Only an explicit `--ablate` arm changes the registry, and each arm is a separate benchmark run that legitimately owns a different prefix.
Cache-guard: `go test ./internal/boot/ -run TestBuildComposesByteStableSystemPrompt` and `go test ./internal/agent/ -run TestCacheHitPrefixStable` both pass on this branch; the new `TestAblationRemovesOnlyTheTargetedToolSurfaces` additionally asserts the control arm still registers every tool it then checks is gone under an arm, and `TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites` pins the control arm's command line as byte-identical to the pre-ablation one.
System-prompt-review: not required - `git diff origin/main-v2...` contains no change to any prompt constant or composed prompt text. `internal/agent/task.go` is flagged only because it holds `DefaultTaskSystemPrompt`; the diff there adds a struct field, a `WithAblation` builder, and one options pass-through, leaving the constant untouched.
