### PR TITLE
fix(desktop): bound pasted-block and attachment stacks in the composer footer

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -20450,6 +20450,10 @@ body > .mermaid-diagram--fullscreen {
   align-items: flex-start;
   gap: 8px;
   margin-bottom: 8px;
+  /* Many attachments (images/refs) stack rows without bound and squeeze the
+     transcript viewport (see #7578). Cap the area and scroll internally. */
+  max-height: min(30vh, 200px);
+  overflow-y: auto;
 }
 .composer-context__item {
   display: inline-flex;
@@ -20646,12 +20650,20 @@ body > .mermaid-diagram--fullscreen {
   flex-direction: column;
   gap: 6px;
   margin-bottom: 8px;
+  /* Pasting many long texts stacks fold blocks without bound and squeezes the
+     transcript viewport (see #7578). Cap the list and scroll internally. */
+  max-height: min(30vh, 240px);
+  overflow-y: auto;
 }
 .composer__pasted-block {
   border: 1px solid var(--border);
   border-radius: 7px;
   background: var(--panel);
   overflow: hidden;
+  /* The capped .composer__pasted list is a column flex container; without
+     this, flex-shrink would crush every block to a few px instead of
+     scrolling (#7578). */
+  flex-shrink: 0;
 }
 .composer__pasted-head {
   display: flex;


### PR DESCRIPTION
Fixes #7578

---

### English

**Problem:** Pasting many long texts into the composer folds each into a `[Pasted text #N · N lines]` block. The `.composer__pasted` list has no `max-height`/`overflow`, so after ~10–20 pastes the block stack grows the footer unbounded, squeezes the transcript viewport to zero, and the outer `overflow: hidden` hard-clips the content with no way to scroll it back.

**Root cause:** Layout chain in `main-v2`: (1) `Composer.tsx` `onPaste` → `shouldFoldPaste` renders each paste as a `.composer__pasted-block` (~48 px each); (2) `.composer__pasted` has no `max-height`/`overflow` — grows unbounded; (3) `.footer` is `flex: 0 0 auto` with no height cap — cannot shrink, so `.main` (`flex: 1 1 auto; min-height: 0; overflow: hidden`) and the transcript viewport get squeezed toward zero; (4) `body`/`.app` are `overflow: hidden` — overflow beyond the window is hard-clipped and unreachable; (5) amplifier: the footer ResizeObserver → `repinIfWasPinned` → GSAP `scrollTo` triggers an animated scroll on every paste once overflow exists. Same root cause, second exit: `.composer-context` (attachment chips) is also unbounded.

**Fix:** Pure CSS, footer height bounded, no scroll-logic changes:
- `.composer__pasted`: add `max-height: min(30vh, 240px)` + `overflow-y: auto` — the block list scrolls internally.
- `.composer__pasted-block`: add `flex-shrink: 0` — without it the capped column flex list crushes every block to a few px instead of scrolling (verified in a rendered reproduction).
- `.composer-context`: add `max-height: min(30vh, 200px)` + `overflow-y: auto` — closes the attachment exit.

The `repinIfWasPinned` compensation and `.footer` layout are untouched; `overflow` is scoped to child containers (not the footer), so this follows the existing #7030 pattern (`.footer--decision` caps and scrolls) without triggering the slashmenu clipping warning documented there.

Documentation-impact: none - the change is a pure CSS layout bound for two composer footer containers; no CLI flags, config keys, commands, or user-visible behavior surfaces are added or changed, so existing docs remain correct.
Cache-impact: low - no persisted format changes, no provider-visible changes, no request serialization changes
Cache-guard: existing composer CSS/state tests

**Verification:** `node scripts/check-css-syntax.mjs` ✅ · `node scripts/check-z-index-tokens.mjs` ✅ · `composer-resized-input-css.test.ts` 7/7 ✅ · `footer-decision-overflow.test.ts` 14/14 ✅ (includes the guard: no footer rule except `.footer--decision` clips or caps the footer) · `message-pasted-blocks.test.ts` 9/9 ✅ · `composer-session-draft.test.tsx` 130/130 ✅ · `composer-goal-toggle.test.tsx` 228/228 ✅ · `git diff --check` clean (no CRLF warnings) ✅. Additionally, a standalone reproduction of the real footer/composer layout (real CSS extracted from `main-v2`) confirmed: base → footer 3220 px / transcript 0 px; fixed → footer 485 px, transcript visible, block list scrolls internally with normal block heights (flex-shrink regression caught by this check).

**Screenshots (bug on the current release, before this fix):**

Pasted blocks push the whole chat view up and the transcript gets squeezed away:

![Before - pasted blocks push the view up](https://raw.githubusercontent.com/erphenheimer/DeepSeek-Reasonix/screenshots/7578/before.png)

After pasting and pressing Backspace, the stack fills the window and the transcript is no longer reachable:

![Before - pressing Backspace after pasting](https://raw.githubusercontent.com/erphenheimer/DeepSeek-Reasonix/screenshots/7578/before-after-backspace.png)

---

### 中文

**问题：** 在输入框连续粘贴多个长文本时，每次粘贴会被折叠成 `[已粘贴文本 #N · N 行]` 块。`.composer__pasted` 列表没有 `max-height`/`overflow`，粘贴约 10–20 个后块堆叠会无界撑高 footer，把对话视口压到零，而外层 `overflow: hidden` 会把超出内容硬裁剪、无法滚回。

**根因：** `main-v2` 中的布局链：(1) `Composer.tsx` 的 `onPaste` → `shouldFoldPaste` 把每次粘贴渲染为一个 `.composer__pasted-block`（每块约 48 px）；(2) `.composer__pasted` 没有 `max-height`/`overflow`——无界增长；(3) `.footer` 是 `flex: 0 0 auto` 且无高度上限——不能收缩，所以 `.main`（`flex: 1 1 auto; min-height: 0; overflow: hidden`）和对话视口被逐步压到接近零；(4) `body` 与 `.app` 均为 `overflow: hidden`——超出窗口的内容被硬裁剪且无法到达；(5) 放大器：footer ResizeObserver → `repinIfWasPinned` → GSAP `scrollTo`，一旦出现溢出，每次粘贴都会触发一次自动滚动把对话内容往上顶。同一根因的第二个出口：`.composer-context`（附件区）同样无界。

**修复：** 纯 CSS 让 footer 高度有界，不改任何滚动逻辑：
- `.composer__pasted`：加 `max-height: min(30vh, 240px)` + `overflow-y: auto`——块列表内部滚动。
- `.composer__pasted-block`：加 `flex-shrink: 0`——否则限高的纵向 flex 列表会把每个块压缩成几像素而不是滚动（已在渲染复现中验证）。
- `.composer-context`：加 `max-height: min(30vh, 200px)` + `overflow-y: auto`——封住附件出口。

`repinIfWasPinned` 补偿与 `.footer` 布局均未触碰；`overflow` 只加在子容器上（不加在 footer 上），沿用了 #7030（`.footer--decision` 限高滚动）的既有模式，同时规避了该 PR 注释中警告的 slashmenu 裁剪问题。

**验证：** `node scripts/check-css-syntax.mjs` ✅ · `node scripts/check-z-index-tokens.mjs` ✅ · `composer-resized-input-css.test.ts` 7/7 ✅ · `footer-decision-overflow.test.ts` 14/14 ✅（含关键守卫：除 `.footer--decision` 外没有任何 footer 规则裁剪或限制 footer 高度）· `message-pasted-blocks.test.ts` 9/9 ✅ · `composer-session-draft.test.tsx` 130/130 ✅ · `composer-goal-toggle.test.tsx` 228/228 ✅ · `git diff --check` 干净（无 CRLF 警告）✅。另外用独立复现页（从 `main-v2` 提取的真实 CSS 复刻 footer/composer 布局）确认：原版 → footer 3220 px / transcript 0 px；修复后 → footer 485 px、对话可见、块列表内部滚动且块高度正常（flex-shrink 回归正是被此复现抓到的）。

**截图（当前发布版中的 bug 表现，修复前）：**

粘贴块把整个对话视图往上顶，对话区域被逐步挤没：

![修复前 - 粘贴块把视图顶上去](https://raw.githubusercontent.com/erphenheimer/DeepSeek-Reasonix/screenshots/7578/before.png)

粘贴完毕后按 backspace 键，块堆叠占满窗口，对话内容不再可达：

![修复前 - 粘贴完毕后按 backspace 键的画面](https://raw.githubusercontent.com/erphenheimer/DeepSeek-Reasonix/screenshots/7578/before-after-backspace.png)