### PR TITLE
fix(creation): restore AppearanceOverview hero theme swatches / 修复 Creation 外观概览主题色块

### DIFF
--- a/desktop/frontend/src/__tests__/theme-pack.test.ts
+++ b/desktop/frontend/src/__tests__/theme-pack.test.ts
@@ -531,6 +531,26 @@ ok(overviewSource.includes("appearance-overview__segmented--theme"), "theme-mode
 ok(overviewSource.includes("appearance-overview__segmented--text-size"), "text-size control uses its wider compact settings width");
 ok(stylesSource.includes("--appearance-segmented-width: 300px") && stylesSource.includes("--appearance-segmented-width: 420px"), "overview segmented controls use intentional widths");
 ok(stylesSource.includes(".appearance-overview__segmented { justify-self: stretch; width: 100%; }"), "overview segmented controls expand on narrow screens");
+const creationCardSwatchRule =
+  stylesSource.match(/:root\[data-theme-style\] \.app--creation \.theme-card \.theme-card__swatches \{([^}]*)\}/)?.[1] ?? "";
+const creationHeroRule =
+  stylesSource.match(/:root\[data-theme-style\] \.app--creation \.appearance-overview__thumb-base\.theme-card__swatches \{([^}]*)\}/)?.[1] ?? "";
+const creationHeroSwatchRule =
+  stylesSource.match(/:root\[data-theme-style\] \.app--creation \.appearance-overview__thumb-base \.theme-card__swatch \{([^}]*)\}/)?.[1] ?? "";
+const creationGraphiteAccentRule =
+  stylesSource.match(/:root\[data-theme-style\] \.app--creation \.theme-card__swatches\[data-theme-style-card="graphite"\] \.theme-card__swatch--accent \{([^}]*)\}/)?.[1] ?? "";
+ok(
+  creationCardSwatchRule.includes("height: 7px") && !/^\.app--creation \.theme-card__swatches,$/m.test(stylesSource),
+  "Creation compact swatches stay scoped to real theme cards",
+);
+ok(
+  creationHeroRule.includes("min-height: 108px") && creationHeroSwatchRule.includes("flex: 1"),
+  "Creation appearance hero keeps readable swatch dimensions",
+);
+ok(
+  creationGraphiteAccentRule.includes("linear-gradient(128deg, #604116") && creationGraphiteAccentRule.includes("#f3d77b"),
+  "Creation Graphite appearance hero keeps the gold accent palette",
+);
 ok(
   overviewSource.includes('fontFamily === "custom"') && overviewSource.includes("onCustomFontNameChange(e.target.value)"),
   "custom UI font selection exposes an editable font name",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30600,40 +30600,42 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
-:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+/* Creation Graphite swatch colors apply to both theme cards and
+   AppearanceOverview hero (do not nest under .theme-card). */
+:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
   background: #0c0d10;
 }
 
-:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
   background: #15161a;
 }
 
-:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
   background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
   background: #f4f3ef;
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
   background: #ffffff;
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
   background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
 }
 
 @media (prefers-color-scheme: light) {
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
     background: #f4f3ef;
   }
 
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
     background: #ffffff;
   }
 
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
     background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
   }
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30571,8 +30571,10 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
-.app--creation .theme-card__swatches,
-:root[data-theme-style] .app--creation .theme-card__swatches {
+/* Scope compact swatches to real theme cards only — do not crush
+   AppearanceOverview hero (.appearance-overview__thumb-base.theme-card__swatches). */
+.app--creation .theme-card .theme-card__swatches,
+:root[data-theme-style] .app--creation .theme-card .theme-card__swatches {
   width: 30px;
   height: 7px;
   gap: 0;
@@ -30580,8 +30582,8 @@ body > .mermaid-diagram--fullscreen {
   border-radius: 999px;
 }
 
-.app--creation .theme-card__swatch,
-:root[data-theme-style] .app--creation .theme-card__swatch {
+.app--creation .theme-card .theme-card__swatch,
+:root[data-theme-style] .app--creation .theme-card .theme-card__swatch {
   min-width: 0;
   height: 7px;
   border-radius: 0;
@@ -30598,42 +30600,177 @@ body > .mermaid-diagram--fullscreen {
   display: none;
 }
 
-:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
   background: #0c0d10;
 }
 
-:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
   background: #15161a;
 }
 
-:root[data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+:root[data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
   background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
   background: #f4f3ef;
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
   background: #ffffff;
 }
 
-:root[data-theme="light"][data-theme-style] .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+:root[data-theme="light"][data-theme-style] .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
   background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
 }
 
 @media (prefers-color-scheme: light) {
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--bg {
     background: #f4f3ef;
   }
 
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--surface {
     background: #ffffff;
   }
 
-  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
+  :root[data-theme-style]:not([data-theme]) .app--creation .theme-card .theme-card__swatches[data-theme-style-card="graphite"] .theme-card__swatch--accent {
     background: linear-gradient(128deg, #604116 0%, #9b7226 28%, #d8ad4f 48%, #f3d77b 57%, #b9872d 78%, #704d19 100%);
   }
+}
+
+/* AppearanceOverview (settings → 外观): glass cards + readable hero swatches */
+.app--creation .appearance-overview,
+:root[data-theme-style] .app--creation .appearance-overview {
+  gap: 14px;
+  max-width: 720px;
+}
+
+.app--creation .appearance-overview__title,
+:root[data-theme-style] .app--creation .appearance-overview__title {
+  font-size: calc(15px * var(--font-scale));
+  font-weight: 640;
+}
+
+.app--creation .appearance-overview__sub,
+:root[data-theme-style] .app--creation .appearance-overview__sub {
+  font-size: calc(11px * var(--font-scale));
+  color: color-mix(in srgb, var(--fg-dim) 84%, transparent);
+}
+
+.app--creation .appearance-overview__section-label,
+:root[data-theme-style] .app--creation .appearance-overview__section-label {
+  margin: 0 0 8px;
+  font-size: calc(11.5px * var(--font-scale));
+  font-weight: 600;
+  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
+}
+
+.app--creation .appearance-overview__hero,
+:root[data-theme-style] .app--creation .appearance-overview__hero {
+  gap: 12px;
+  padding: 12px;
+  border-color: color-mix(in srgb, var(--border-soft) 88%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
+  backdrop-filter: blur(12px) saturate(1.04);
+  -webkit-backdrop-filter: blur(12px) saturate(1.04);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.app--creation .appearance-overview__thumb,
+:root[data-theme-style] .app--creation .appearance-overview__thumb {
+  border-radius: 10px;
+  min-height: 108px;
+  background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
+}
+
+.app--creation .appearance-overview__thumb-base.theme-card__swatches,
+:root[data-theme-style] .app--creation .appearance-overview__thumb-base.theme-card__swatches {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  min-height: 108px;
+  padding: 16px;
+  overflow: visible;
+  border-radius: 0;
+}
+
+.app--creation .appearance-overview__thumb-base .theme-card__swatch,
+:root[data-theme-style] .app--creation .appearance-overview__thumb-base .theme-card__swatch {
+  flex: 1;
+  min-width: 28px;
+  height: 38px;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg-faint) 30%, transparent);
+}
+
+.app--creation .appearance-overview__hero-name,
+:root[data-theme-style] .app--creation .appearance-overview__hero-name {
+  font-size: calc(13px * var(--font-scale));
+  font-weight: 620;
+}
+
+.app--creation .appearance-overview__in-use,
+:root[data-theme-style] .app--creation .appearance-overview__in-use {
+  font-size: calc(11.5px * var(--font-scale));
+}
+
+.app--creation .appearance-overview__hero-actions .btn,
+:root[data-theme-style] .app--creation .appearance-overview__hero-actions .btn {
+  min-height: 30px;
+  padding: 5px 12px;
+  border-radius: 9px;
+  font-size: calc(11.5px * var(--font-scale));
+}
+
+.app--creation .appearance-overview__rows,
+:root[data-theme-style] .app--creation .appearance-overview__rows {
+  border-color: color-mix(in srgb, var(--border-soft) 88%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
+  backdrop-filter: blur(12px) saturate(1.04);
+  -webkit-backdrop-filter: blur(12px) saturate(1.04);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.app--creation .appearance-overview__row,
+:root[data-theme-style] .app--creation .appearance-overview__row {
+  gap: 14px;
+  padding: 10px 14px;
+  border-top-color: color-mix(in srgb, var(--border-soft) 72%, transparent);
+}
+
+.app--creation .appearance-overview__row-label,
+:root[data-theme-style] .app--creation .appearance-overview__row-label {
+  font-size: calc(11.5px * var(--font-scale));
+  font-weight: 600;
+  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
+}
+
+.app--creation .appearance-overview__row-note,
+:root[data-theme-style] .app--creation .appearance-overview__row-note {
+  font-size: calc(10px * var(--font-scale));
+}
+
+.app--creation .appearance-overview__select,
+:root[data-theme-style] .app--creation .appearance-overview__select {
+  min-height: 30px;
+  padding: 5px 10px;
+  border-radius: 9px;
+  border-color: color-mix(in srgb, var(--border-soft) 86%, transparent);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  font-size: calc(11.5px * var(--font-scale));
+}
+
+.app--creation .appearance-overview__lock-note,
+.app--creation .appearance-overview__reset-hint,
+:root[data-theme-style] .app--creation .appearance-overview__lock-note,
+:root[data-theme-style] .app--creation .appearance-overview__reset-hint {
+  font-size: calc(10px * var(--font-scale));
+  color: color-mix(in srgb, var(--fg-dim) 78%, transparent);
 }
 
 .app--creation .workspace-tree__icon--dir,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30640,139 +30640,15 @@ body > .mermaid-diagram--fullscreen {
   }
 }
 
-/* AppearanceOverview (settings → 外观): glass cards + readable hero swatches */
-.app--creation .appearance-overview,
-:root[data-theme-style] .app--creation .appearance-overview {
-  gap: 14px;
-  max-width: 720px;
-}
-
-.app--creation .appearance-overview__title,
-:root[data-theme-style] .app--creation .appearance-overview__title {
-  font-size: calc(15px * var(--font-scale));
-  font-weight: 640;
-}
-
-.app--creation .appearance-overview__sub,
-:root[data-theme-style] .app--creation .appearance-overview__sub {
-  font-size: calc(11px * var(--font-scale));
-  color: color-mix(in srgb, var(--fg-dim) 84%, transparent);
-}
-
-.app--creation .appearance-overview__section-label,
-:root[data-theme-style] .app--creation .appearance-overview__section-label {
-  margin: 0 0 8px;
-  font-size: calc(11.5px * var(--font-scale));
-  font-weight: 600;
-  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
-}
-
-.app--creation .appearance-overview__hero,
-:root[data-theme-style] .app--creation .appearance-overview__hero {
-  gap: 12px;
-  padding: 12px;
-  border-color: color-mix(in srgb, var(--border-soft) 88%, transparent);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
-  backdrop-filter: blur(12px) saturate(1.04);
-  -webkit-backdrop-filter: blur(12px) saturate(1.04);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.app--creation .appearance-overview__thumb,
-:root[data-theme-style] .app--creation .appearance-overview__thumb {
-  border-radius: 10px;
-  min-height: 108px;
-  background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
-}
-
+/* Keep the Creation hero readable without duplicating the shared overview skin. */
 .app--creation .appearance-overview__thumb-base.theme-card__swatches,
 :root[data-theme-style] .app--creation .appearance-overview__thumb-base.theme-card__swatches {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
   min-height: 108px;
-  padding: 16px;
-  overflow: visible;
-  border-radius: 0;
 }
 
 .app--creation .appearance-overview__thumb-base .theme-card__swatch,
 :root[data-theme-style] .app--creation .appearance-overview__thumb-base .theme-card__swatch {
   flex: 1;
-  min-width: 28px;
-  height: 38px;
-  border-radius: 8px;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg-faint) 30%, transparent);
-}
-
-.app--creation .appearance-overview__hero-name,
-:root[data-theme-style] .app--creation .appearance-overview__hero-name {
-  font-size: calc(13px * var(--font-scale));
-  font-weight: 620;
-}
-
-.app--creation .appearance-overview__in-use,
-:root[data-theme-style] .app--creation .appearance-overview__in-use {
-  font-size: calc(11.5px * var(--font-scale));
-}
-
-.app--creation .appearance-overview__hero-actions .btn,
-:root[data-theme-style] .app--creation .appearance-overview__hero-actions .btn {
-  min-height: 30px;
-  padding: 5px 12px;
-  border-radius: 9px;
-  font-size: calc(11.5px * var(--font-scale));
-}
-
-.app--creation .appearance-overview__rows,
-:root[data-theme-style] .app--creation .appearance-overview__rows {
-  border-color: color-mix(in srgb, var(--border-soft) 88%, transparent);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
-  backdrop-filter: blur(12px) saturate(1.04);
-  -webkit-backdrop-filter: blur(12px) saturate(1.04);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.app--creation .appearance-overview__row,
-:root[data-theme-style] .app--creation .appearance-overview__row {
-  gap: 14px;
-  padding: 10px 14px;
-  border-top-color: color-mix(in srgb, var(--border-soft) 72%, transparent);
-}
-
-.app--creation .appearance-overview__row-label,
-:root[data-theme-style] .app--creation .appearance-overview__row-label {
-  font-size: calc(11.5px * var(--font-scale));
-  font-weight: 600;
-  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
-}
-
-.app--creation .appearance-overview__row-note,
-:root[data-theme-style] .app--creation .appearance-overview__row-note {
-  font-size: calc(10px * var(--font-scale));
-}
-
-.app--creation .appearance-overview__select,
-:root[data-theme-style] .app--creation .appearance-overview__select {
-  min-height: 30px;
-  padding: 5px 10px;
-  border-radius: 9px;
-  border-color: color-mix(in srgb, var(--border-soft) 86%, transparent);
-  background: color-mix(in srgb, var(--bg) 72%, transparent);
-  font-size: calc(11.5px * var(--font-scale));
-}
-
-.app--creation .appearance-overview__lock-note,
-.app--creation .appearance-overview__reset-hint,
-:root[data-theme-style] .app--creation .appearance-overview__lock-note,
-:root[data-theme-style] .app--creation .appearance-overview__reset-hint {
-  font-size: calc(10px * var(--font-scale));
-  color: color-mix(in srgb, var(--fg-dim) 78%, transparent);
 }
 
 .app--creation .workspace-tree__icon--dir,


### PR DESCRIPTION
## 问题

Creation 桌面风格下，设置 → 外观页「当前外观」左侧预览几乎是纯黑块，看不出当前主题配色。

## 原因

上游外观页已换成 `AppearanceOverview`，hero 大预览复用了 `theme-card__swatches` class；Creation 旧规则仍把所有 `.theme-card__swatches` 压成 7px 色条，导致 hero 一并被压扁。

## 改动

1. 将 7px 紧凑色条规则限定到 `.theme-card .theme-card__swatches`，不再命中 AppearanceOverview hero。
2. 保留 Creation hero 必需的 108px 高度和色块横向填充，其余布局继续复用共享 AppearanceOverview 样式，避免重复 CSS。
3. 让 Creation Graphite 的 theme card 与 hero 共用金色配色规则，与实际 `#c99a3a` / `--grad` 保持一致。
4. 增加聚焦契约测试，覆盖真实 theme card 隔离、hero 可读尺寸和 Graphite 金色配色。

所有运行时覆盖均限定在 `.app--creation`；Classic / Workbench 不匹配这些规则。

## 验证

- [x] `pnpm --dir desktop/frontend build`
  - raw JS + CSS：`2248.9 KiB / 2251.0 KiB`
- [x] `pnpm --dir desktop/frontend exec tsx src/__tests__/theme-pack.test.ts`
  - `295 passed, 0 failed`
- [x] `git diff --check`
- [x] 浏览器深色 / 浅色计算样式：hero `210×108`，三个色块均为 `54×38`，Graphite 使用 Creation 金色渐变
- [x] Workbench 页面仍存在 AppearanceOverview，但 `.app--creation` selector 匹配数为 0

## Documentation impact

Documentation-impact: none - Creation-only AppearanceOverview CSS and regression-test fix; no CLI, configuration, API, or user-documentation contract changes.
