### PR TITLE
fix(web): harden account verification and community flows / 修复账号验证与社区流程

### DIFF
--- a/.github/workflows/deploy-accounts-worker.yml
+++ b/.github/workflows/deploy-accounts-worker.yml
@@ -35,6 +35,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           pnpm install --frozen-lockfile
+          pnpm test
+          pnpm typecheck
           npx wrangler deploy
       - name: Sync RESEND_API_KEY to the worker
         working-directory: workers/accounts

--- a/.github/workflows/deploy-forum-worker.yml
+++ b/.github/workflows/deploy-forum-worker.yml
@@ -35,4 +35,6 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           pnpm install --frozen-lockfile
+          pnpm test
+          pnpm typecheck
           npx wrangler deploy

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -11,6 +11,15 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
   <Fragment slot="head"><meta name="robots" content="noindex" /></Fragment>
 
+  <script is:inline>
+    // Preserve the documented /u/<handle> shape on static hosting by moving it
+    // to the client-rendered public profile page.
+    try {
+      const match = location.pathname.match(/^\/u\/([^/]+)\/?$/);
+      if (match) location.replace(`/u/?handle=${encodeURIComponent(decodeURIComponent(match[1]))}`);
+    } catch {}
+  </script>
+
   <SiteHeader scrolled />
 
   <main class="hero" style="padding-bottom:150px">

--- a/site/src/pages/account.astro
+++ b/site/src/pages/account.astro
@@ -16,8 +16,16 @@ import Account from '../layouts/Account.astro';
       <div>
         <div id="acct-handle" class="acct-handle"></div>
         <div id="acct-email" class="acct-email"></div>
+        <a id="acct-profile-link" class="auth-small" href="/u/"><span class="l-en">View public profile</span><span class="l-zh">查看公开主页</span></a>
       </div>
       <span id="acct-role" class="acct-role"></span>
+    </div>
+
+    <div id="verification-wrap" hidden>
+      <h2 class="acct-h2"><span class="l-en">Email verification</span><span class="l-zh">邮箱验证</span></h2>
+      <div id="verification-msg" class="auth-msg" hidden></div>
+      <p class="hint"><span class="l-en">Your email is not confirmed. Some community actions remain locked.</span><span class="l-zh">你的邮箱尚未验证，部分社区操作仍不可用。</span></p>
+      <button id="resend-verification-btn" type="button" class="btn btn-ghost"><span class="l-en">Resend verification email</span><span class="l-zh">重新发送验证邮件</span></button>
     </div>
 
     <h2 class="acct-h2"><span class="l-en">Profile</span><span class="l-zh">资料</span></h2>
@@ -30,7 +38,7 @@ import Account from '../layouts/Account.astro';
       <div class="field">
         <label for="f-handle"><span class="l-en">Handle</span><span class="l-zh">用户名</span></label>
         <input id="f-handle" type="text" minlength="3" maxlength="30" />
-        <span class="hint"><span class="l-en">Your public profile lives at /u/&lt;handle&gt;.</span><span class="l-zh">你的公开主页地址是 /u/&lt;用户名&gt;。</span></span>
+        <span class="hint"><span class="l-en">Your public profile is linked above.</span><span class="l-zh">你的公开主页链接显示在上方。</span></span>
       </div>
       <div class="field">
         <label for="f-bio"><span class="l-en">Bio</span><span class="l-zh">简介</span></label>

--- a/site/src/pages/u/index.astro
+++ b/site/src/pages/u/index.astro
@@ -1,0 +1,23 @@
+---
+import Account from '../../layouts/Account.astro';
+---
+<Account
+  wide
+  title="Public profile — Reasonix"
+  titleEn="Public profile — Reasonix"
+  titleZh="公开主页 — Reasonix"
+  description="View a Reasonix community profile.">
+  <div id="public-profile-gate" class="auth-msg">Loading profile…</div>
+
+  <div id="public-profile" hidden>
+    <div class="acct-id">
+      <img id="public-profile-avatar" hidden width="72" height="72" alt="" style="border-radius:18px;object-fit:cover" />
+      <div>
+        <h1 id="public-profile-name" class="acct-handle"></h1>
+        <div id="public-profile-handle" class="acct-email"></div>
+      </div>
+    </div>
+    <p id="public-profile-bio" style="white-space:pre-wrap;line-height:1.7"></p>
+    <p class="hint"><span class="l-en">Joined </span><span class="l-zh">加入于 </span><span id="public-profile-joined"></span></p>
+  </div>
+</Account>

--- a/site/src/scripts/account-community-contract.test.mjs
+++ b/site/src/scripts/account-community-contract.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const auth = readFileSync(new URL("./auth.js", import.meta.url), "utf8");
+const community = readFileSync(new URL("./community.js", import.meta.url), "utf8");
+const account = readFileSync(new URL("../pages/account.astro", import.meta.url), "utf8");
+const profile = readFileSync(new URL("../pages/u/index.astro", import.meta.url), "utf8");
+
+test("unverified accounts can request a fresh verification email", () => {
+  assert.match(account, /resend-verification-btn/);
+  assert.match(auth, /\/auth\/resend-verification/);
+});
+
+test("public profiles have a generated site route backed by the public account API", () => {
+  assert.match(profile, /public-profile/);
+  assert.match(auth, /api\("\/u\/" \+ encodeURIComponent\(handle\)\)/);
+});
+
+test("community renders public handles and wires reactions", () => {
+  assert.doesNotMatch(community, /split\(["']@["']\)/);
+  assert.match(community, /\/posts\/\$\{like\.dataset\.like\}\/likes/);
+  assert.match(community, /aria-pressed/);
+});

--- a/site/src/scripts/auth.js
+++ b/site/src/scripts/auth.js
@@ -156,10 +156,14 @@ if (resetForm) {
 const accountView = $("account-view");
 if (accountView) {
   const gate = $("account-gate");
+  let accountUser = null;
   const fill = (user) => {
+    accountUser = user;
     $("acct-handle").textContent = "@" + user.handle;
     $("acct-email").textContent = user.email + (user.emailVerified ? "" : " · unconfirmed");
     $("acct-role").textContent = user.role;
+    $("acct-profile-link").href = withBase("/u/?handle=" + encodeURIComponent(user.handle));
+    $("verification-wrap").hidden = user.emailVerified;
     $("f-displayName").value = user.displayName || "";
     $("f-handle").value = user.handle || "";
     $("f-bio").value = user.bio || "";
@@ -227,6 +231,22 @@ if (accountView) {
     location.href = withBase("/login/");
   });
 
+  $("resend-verification-btn")?.addEventListener("click", async () => {
+    if (!accountUser || accountUser.emailVerified) return;
+    const btn = $("resend-verification-btn");
+    const box = $("verification-msg");
+    clearMsg(box);
+    busy(btn, true);
+    try {
+      await api("/auth/resend-verification", { method: "POST", body: { email: accountUser.email } });
+      msg(box, "ok", "A new verification email is on its way.");
+    } catch (err) {
+      msg(box, "error", err.message);
+    } finally {
+      busy(btn, false);
+    }
+  });
+
   $("delete-btn")?.addEventListener("click", async () => {
     if (!confirm("Delete your account? This cannot be undone.")) return;
     try {
@@ -236,6 +256,38 @@ if (accountView) {
       msg(pBox, "error", err.message);
     }
   });
+}
+
+// public profile — the static site uses a query parameter while the accounts
+// API keeps its canonical /u/:handle endpoint.
+const publicProfile = $("public-profile");
+if (publicProfile) {
+  const gate = $("public-profile-gate");
+  const handle = (qp.get("handle") || "").trim().toLowerCase();
+  if (!/^[a-z0-9](?:[a-z0-9_]*[a-z0-9])?$/.test(handle) || handle.length < 3 || handle.length > 30) {
+    msg(gate, "error", "That public profile address is invalid.");
+  } else {
+    api("/u/" + encodeURIComponent(handle))
+      .then(({ user }) => {
+        $("public-profile-handle").textContent = "@" + user.handle;
+        $("public-profile-name").textContent = user.displayName || user.handle;
+        $("public-profile-bio").textContent = user.bio || "No bio yet.";
+        $("public-profile-joined").textContent = new Date(user.joinedAt).toLocaleDateString();
+        const avatar = $("public-profile-avatar");
+        if (user.avatarUrl) {
+          try {
+            const url = new URL(user.avatarUrl);
+            if (url.protocol === "https:" || url.protocol === "http:") {
+              avatar.src = url.href;
+              avatar.hidden = false;
+            }
+          } catch {}
+        }
+        gate.hidden = true;
+        publicProfile.hidden = false;
+      })
+      .catch((err) => msg(gate, "error", err.status === 404 ? "That profile doesn't exist." : err.message));
+  }
 }
 
 // device — the human-facing half of the CLI/desktop device-authorization flow.

--- a/site/src/scripts/community.js
+++ b/site/src/scripts/community.js
@@ -63,6 +63,7 @@ const ERR = {
   rate_limited: ["You're posting too fast — take a short break.", "发帖太快了——稍微歇一会儿。"],
   daily_limit: ["You've hit today's posting limit for your trust level.", "你已达到当前信任等级的每日发帖上限。"],
   closed: ["This topic is closed to new replies.", "该话题已关闭，不能再回复。"],
+  self_flag: ["You can't report your own post.", "不能举报自己的帖子。"],
   unauthorized: ["Sign in to continue.", "请先登录。"],
 };
 const errText = (err) => (ERR[err.code] ? t(ERR[err.code][0], ERR[err.code][1]) : err.message);
@@ -161,14 +162,14 @@ function renderHome() {
       if (!d.topics.length) { topicBox.innerHTML = `<div class="empty">${L("No topics yet —", "还没有话题 ——")} <a class="tag" href="/community/new/">${L("start the first one", "来发第一个")}</a>.</div>`; return; }
       topicBox.innerHTML = d.topics.map((tp) => `
         <div class="topic">
-          ${avatar(tp.author.split("@")[0])}
+          ${avatar(tp.author)}
           <div class="main">
             <div class="title">
               ${tp.pinned ? `<span class="badge pinned">📌 ${L("Pinned", "置顶")}</span>` : ""}
               ${tp.status === "solved" ? `<span class="badge solved">✓ ${L("Solved", "已解决")}</span>` : ""}
               <a href="/community/topic/?id=${tp.id}">${esc(tp.title)}</a>
             </div>
-            <div class="sub"><span class="cat-tag">${catName(tp.category, tp.categoryName)}</span> <span class="who">${esc(tp.author.split("@")[0])}</span> · ${ago(tp.createdAt)}</div>
+            <div class="sub"><span class="cat-tag">${catName(tp.category, tp.categoryName)}</span> <span class="who">${esc(tp.author)}</span> · ${ago(tp.createdAt)}</div>
           </div>
           <div class="stat"><div class="n">${tp.replyCount}</div><div class="l">${L("replies", "回复")}</div></div>
           <div class="last">${ago(tp.lastPostAt)}</div>
@@ -193,13 +194,13 @@ function postHtml(p, topic) {
   const roleWord = ROLES[p.role] ? L(ROLES[p.role][0], ROLES[p.role][1]) : "";
   const role = roleWord ? `<span class="badge role ${esc(p.role)}">${roleWord}</span>` : "";
   return `<article class="${cls}">
-    ${avatar(p.handle || p.author.split("@")[0], "lg")}
+    ${avatar(p.handle || p.author, "lg")}
     <div>
       ${answer ? `<div class="answer-flag">✓ ${L("Accepted answer", "已采纳回答")}</div>` : ""}
-      <div class="who"><span class="name">${esc(p.handle || p.author.split("@")[0])}</span>${role}<span class="when">${ago(p.createdAt)}</span></div>
+      <div class="who"><span class="name">${esc(p.handle || p.author)}</span>${role}<span class="when">${ago(p.createdAt)}</span></div>
       <div class="body">${md(p.body)}</div>
       <div class="actions">
-        <button class="react" data-like="${p.id}">👍 <span>${p.likeCount || 0}</span></button>
+        <button class="react${p.liked ? " on" : ""}" data-like="${p.id}" data-liked="${p.liked ? "1" : "0"}" aria-pressed="${p.liked ? "true" : "false"}">👍 <span>${p.likeCount || 0}</span></button>
         <button class="link-act" data-flag="${p.id}">${L("Report", "举报")}</button>
       </div>
     </div>
@@ -225,9 +226,26 @@ async function renderThread() {
   el("posts").innerHTML = posts.map((p) => postHtml(p, topic)).join("");
 
   const seen = new Set();
-  el("parti").innerHTML = posts.filter((p) => !seen.has(p.author) && seen.add(p.author)).slice(0, 8).map((p) => avatar(p.handle || p.author.split("@")[0])).join("");
+  el("parti").innerHTML = posts.filter((p) => !seen.has(p.author) && seen.add(p.author)).slice(0, 8).map((p) => avatar(p.handle || p.author)).join("");
 
   el("posts").addEventListener("click", async (e) => {
+    const like = e.target.closest("[data-like]");
+    if (like && account) {
+      const wasLiked = like.dataset.liked === "1";
+      like.disabled = true;
+      try {
+        const out = await forum(`/posts/${like.dataset.like}/likes`, { method: wasLiked ? "DELETE" : "POST" });
+        like.dataset.liked = out.liked ? "1" : "0";
+        like.setAttribute("aria-pressed", out.liked ? "true" : "false");
+        like.classList.toggle("on", out.liked);
+        like.querySelector("span").textContent = out.likeCount;
+      } catch (err) { alert(errText(err)); }
+      finally { like.disabled = false; }
+      return;
+    } else if (like) {
+      location.href = loginUrl();
+      return;
+    }
     const flag = e.target.closest("[data-flag]");
     if (flag && account) {
       if (!confirm(t("Report this post as spam or abuse?", "举报该帖为垃圾/滥用内容？"))) return;

--- a/workers/accounts/README.md
+++ b/workers/accounts/README.md
@@ -69,7 +69,8 @@ Errors are `{ "error": { "code": "...", "message": "..." } }` with a matching HT
 
 ## Configuration
 
-`wrangler.toml` `[vars]` (non-secret): `APP_ORIGIN`, `ALLOWED_ORIGINS`,
+`wrangler.toml` `[vars]` (non-secret): `APP_ORIGIN` (web frontend),
+`ACCOUNT_ORIGIN` (this Worker's canonical public origin), `ALLOWED_ORIGINS`,
 `COOKIE_DOMAIN`, `EMAIL_PROVIDER` (`stub` | `resend`), `MAIL_FROM`, `ADMIN_EMAILS`.
 
 Secrets (`wrangler secret put NAME`): `SESSION_PEPPER` (any long random string),
@@ -86,7 +87,13 @@ pnpm db:apply:local                 # create local D1 tables
 pnpm dev                            # wrangler dev on http://localhost:8787
 ```
 
-Put local secrets in `.dev.vars` (git-ignored), e.g. `SESSION_PEPPER="dev-pepper"`.
+Put local overrides and secrets in `.dev.vars` (git-ignored), e.g.:
+
+```dotenv
+ACCOUNT_ORIGIN="http://localhost:8787"
+SESSION_PEPPER="dev-pepper"
+```
+
 Register a user, then read the verification link from the `wrangler dev` console.
 
 ## Deploy

--- a/workers/accounts/package.json
+++ b/workers/accounts/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "db:apply:local": "wrangler d1 migrations apply reasonix-accounts --local",
     "db:apply:remote": "wrangler d1 migrations apply reasonix-accounts --remote"
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260724.1",
     "typescript": "^5.8.0",
+    "vitest": "^3.2.0",
     "wrangler": "^4.114.0"
   },
   "overrides": {

--- a/workers/accounts/pnpm-lock.yaml
+++ b/workers/accounts/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7
       wrangler:
         specifier: ^4.114.0
         version: 4.114.0(@cloudflare/workers-types@5.20260724.1)
@@ -411,6 +414,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -420,6 +430,144 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -427,12 +575,79 @@ packages:
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -441,10 +656,29 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -455,13 +689,30 @@ packages:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   miniflare@4.20260722.0:
     resolution: {integrity: sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   path-to-regexp@6.3.0:
@@ -469,6 +720,26 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -479,9 +750,47 @@ packages:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
     engines: {node: '>=20.9.0'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -497,6 +806,84 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   workerd@1.20260722.1:
     resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
@@ -763,6 +1150,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -775,17 +1165,165 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6)':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
   blake3-wasm@2.1.5: {}
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
   cookie@1.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   detect-libc@2.1.2: {}
 
   error-stack-parser-es@1.0.5: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -816,12 +1354,30 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fsevents@2.3.3:
     optional: true
 
   hono@4.13.0: {}
 
+  js-tokens@9.0.1: {}
+
   kleur@4.1.5: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   miniflare@4.20260722.0:
     dependencies:
@@ -835,9 +1391,57 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ms@2.1.3: {}
+
+  nanoid@3.3.17: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
 
   semver@7.8.5: {}
 
@@ -873,7 +1477,34 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@10.2.2: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tslib@2.8.1:
     optional: true
@@ -885,6 +1516,82 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6:
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.7:
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6)
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260722.1:
     optionalDependencies:

--- a/workers/accounts/src/db/users.test.ts
+++ b/workers/accounts/src/db/users.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { UserRepo } from "./users";
+
+describe("UserRepo.updateProfile", () => {
+  it("claims a new handle atomically and reports a conflict without a read-then-write race", async () => {
+    let sql = "";
+    let binds: unknown[] = [];
+    const statement = {
+      bind(...values: unknown[]) { binds = values; return this; },
+      async run() { return { meta: { changes: 0 } }; },
+    };
+    const db = {
+      prepare(query: string) {
+        sql = query;
+        return statement;
+      },
+    } as unknown as D1Database;
+
+    const row = await new UserRepo(db).updateProfile(7, { handle: "claimed" });
+    expect(row).toBeNull();
+    expect(sql).toContain("NOT EXISTS");
+    expect(sql).toContain("other.id !=");
+    expect(binds).toContain("claimed");
+    expect(binds).toContain(7);
+  });
+});

--- a/workers/accounts/src/db/users.ts
+++ b/workers/accounts/src/db/users.ts
@@ -63,7 +63,7 @@ export class UserRepo {
       .run();
   }
 
-  async updateProfile(id: number, patch: ProfilePatch): Promise<UserRow> {
+  async updateProfile(id: number, patch: ProfilePatch): Promise<UserRow | null> {
     const sets: string[] = [];
     const binds: unknown[] = [];
     const add = (col: string, value: unknown): void => {
@@ -76,7 +76,14 @@ export class UserRepo {
     if (patch.avatarUrl !== undefined) add("avatar_url", patch.avatarUrl);
     add("updated_at", new Date().toISOString());
     binds.push(id);
-    await this.db.prepare(`UPDATE users SET ${sets.join(", ")} WHERE id = ?${binds.length}`).bind(...binds).run();
+    const idParam = binds.length;
+    let where = `id = ?${idParam}`;
+    if (patch.handle !== undefined) {
+      binds.push(patch.handle);
+      where += ` AND NOT EXISTS (SELECT 1 FROM users other WHERE other.handle = ?${binds.length} AND other.id != ?${idParam})`;
+    }
+    const result = await this.db.prepare(`UPDATE users SET ${sets.join(", ")} WHERE ${where}`).bind(...binds).run();
+    if (result.meta.changes === 0) return null;
     const row = await this.byId(id);
     if (!row) throw new Error("user row missing after profile update");
     return row;

--- a/workers/accounts/src/env.ts
+++ b/workers/accounts/src/env.ts
@@ -11,6 +11,7 @@ export interface Bindings {
 
   // Plain vars (wrangler.toml [vars]).
   APP_ORIGIN: string;
+  ACCOUNT_ORIGIN: string;
   ALLOWED_ORIGINS: string;
   COOKIE_DOMAIN: string;
   EMAIL_PROVIDER: string;

--- a/workers/accounts/src/routes/auth.test.ts
+++ b/workers/accounts/src/routes/auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { verifyLink } from "./auth";
+
+describe("verifyLink", () => {
+  it("uses the configured account origin instead of the web app origin", () => {
+    expect(verifyLink("https://id.reasonix.io", "test-token")).toBe(
+      "https://id.reasonix.io/auth/verify?token=test-token",
+    );
+  });
+
+  it("normalizes a trailing slash and encodes the token", () => {
+    expect(verifyLink("https://id.reasonix.io/", "token+/=?")).toBe(
+      "https://id.reasonix.io/auth/verify?token=token%2B%2F%3D%3F",
+    );
+  });
+});

--- a/workers/accounts/src/routes/auth.ts
+++ b/workers/accounts/src/routes/auth.ts
@@ -37,11 +37,11 @@ async function uniqueHandle(users: UserRepo, base: string): Promise<string> {
   return `user${randomSuffix(8)}`;
 }
 
-// Built from the configured APP_ORIGIN, never the request origin: the Host
+// Built from the configured ACCOUNT_ORIGIN, never the request origin: the Host
 // header is caller-controlled, so a request-derived origin would let emailed
 // verification links point at an attacker-chosen host (#5550).
-function verifyLink(c: { env: { APP_ORIGIN: string } }, token: string): string {
-  const base = c.env.APP_ORIGIN.replace(/\/+$/, "");
+export function verifyLink(accountOrigin: string, token: string): string {
+  const base = accountOrigin.replace(/\/+$/, "");
   return `${base}/auth/verify?token=${encodeURIComponent(token)}`;
 }
 
@@ -59,11 +59,11 @@ auth.post("/register", async (c) => {
     const role: Role = isAdminEmail(c.env, email) ? "admin" : "member";
     const user = await users.create({ handle, email, passwordHash: await hashPassword(password), displayName: displayName ?? "", role });
     const token = await emailTokens.issue(user.id, "verify", VERIFY_TTL_MS);
-    await mailer.send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+    await mailer.send({ to: email, ...verifyEmail(verifyLink(c.env.ACCOUNT_ORIGIN, token)) });
   } else if (existing.email_verified === 0) {
     await emailTokens.invalidateForUser(existing.id, "verify");
     const token = await emailTokens.issue(existing.id, "verify", VERIFY_TTL_MS);
-    await mailer.send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+    await mailer.send({ to: email, ...verifyEmail(verifyLink(c.env.ACCOUNT_ORIGIN, token)) });
   } else {
     await mailer.send({ to: email, ...accountExistsEmail(`${c.env.APP_ORIGIN}/login`, `${c.env.APP_ORIGIN}/forgot`) });
   }
@@ -136,7 +136,7 @@ auth.post("/resend-verification", async (c) => {
   if (user && user.email_verified === 0) {
     await emailTokens.invalidateForUser(user.id, "verify");
     const token = await emailTokens.issue(user.id, "verify", VERIFY_TTL_MS);
-    await buildMailer(c.env).send({ to: email, ...verifyEmail(verifyLink(c, token)) });
+    await buildMailer(c.env).send({ to: email, ...verifyEmail(verifyLink(c.env.ACCOUNT_ORIGIN, token)) });
   }
   return c.json({ ok: true, message: "If that address needs confirming, a new link is on its way." });
 });

--- a/workers/accounts/src/routes/me.ts
+++ b/workers/accounts/src/routes/me.ts
@@ -29,7 +29,6 @@ me.patch("/", async (c) => {
       throw new ApiError(422, "invalid_handle", "Handles are 3–30 chars: letters, numbers, and underscores.");
     }
     if (handle !== user.handle) {
-      if (await users.handleTaken(handle)) throw new ApiError(409, "handle_taken", "That handle is already taken.");
       update.handle = handle;
     }
   }
@@ -38,6 +37,7 @@ me.patch("/", async (c) => {
   if (patch.avatarUrl !== undefined) update.avatarUrl = patch.avatarUrl;
 
   const row = await users.updateProfile(user.id, update);
+  if (!row) throw new ApiError(409, "handle_taken", "That handle is already taken.");
   return c.json({ user: toAccountUser(row) });
 });
 

--- a/workers/accounts/wrangler.toml
+++ b/workers/accounts/wrangler.toml
@@ -12,8 +12,11 @@ compatibility_date = "2026-06-01"
 routes = [{ pattern = "id.reasonix.io", custom_domain = true }]
 
 [vars]
-# Where the web frontend lives — used for email links and post-verify redirects.
+# Where the web frontend lives — used for pages and post-action redirects.
 APP_ORIGIN = "https://reasonix.io"
+# Canonical public origin of this Worker — used for backend email actions.
+# Override with http://localhost:8787 in .dev.vars when exercising email flows locally.
+ACCOUNT_ORIGIN = "https://id.reasonix.io"
 # Browsers that may call this API with credentials (comma-separated).
 ALLOWED_ORIGINS = "https://reasonix.io,https://www.reasonix.io"
 # Cookie scope. ".reasonix.io" lets the apex + any subdomain (and the future CLI)

--- a/workers/forum/package.json
+++ b/workers/forum/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "db:apply:local": "wrangler d1 execute reasonix-forum --local --file=schema.sql",
     "db:apply:remote": "wrangler d1 execute reasonix-forum --remote --file=schema.sql"
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260724.1",
     "typescript": "^5.8.0",
+    "vitest": "^3.2.0",
     "wrangler": "^4.114.0"
   },
   "overrides": {

--- a/workers/forum/pnpm-lock.yaml
+++ b/workers/forum/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7
       wrangler:
         specifier: ^4.114.0
         version: 4.114.0(@cloudflare/workers-types@5.20260724.1)
@@ -411,6 +414,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -420,6 +430,144 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -427,12 +575,79 @@ packages:
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -441,10 +656,29 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -455,13 +689,30 @@ packages:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   miniflare@4.20260722.0:
     resolution: {integrity: sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
   path-to-regexp@6.3.0:
@@ -469,6 +720,26 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -479,9 +750,47 @@ packages:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
     engines: {node: '>=20.9.0'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -497,6 +806,84 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   workerd@1.20260722.1:
     resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
@@ -763,6 +1150,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -775,17 +1165,165 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6)':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
   blake3-wasm@2.1.5: {}
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
   cookie@1.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   detect-libc@2.1.2: {}
 
   error-stack-parser-es@1.0.5: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -816,12 +1354,30 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fsevents@2.3.3:
     optional: true
 
   hono@4.13.0: {}
 
+  js-tokens@9.0.1: {}
+
   kleur@4.1.5: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   miniflare@4.20260722.0:
     dependencies:
@@ -835,9 +1391,57 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ms@2.1.3: {}
+
+  nanoid@3.3.17: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
 
   semver@7.8.5: {}
 
@@ -873,7 +1477,34 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@10.2.2: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   tslib@2.8.1:
     optional: true
@@ -885,6 +1516,82 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6:
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.7:
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6)
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260722.1:
     optionalDependencies:

--- a/workers/forum/src/antispam.test.ts
+++ b/workers/forum/src/antispam.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { Member } from "./env";
+import { assertCanFlag, assertCanInteract } from "./antispam";
+
+function member(overrides: Partial<Member> = {}): Member {
+  return {
+    email: "alice@example.test",
+    handle: "alice",
+    emailVerified: true,
+    trust: 0,
+    role: "member",
+    silencedUntil: null,
+    ...overrides,
+  };
+}
+
+describe("community interaction gates", () => {
+  it("rejects reactions and reports from unverified identities", () => {
+    expect(() => assertCanInteract(member({ emailVerified: false }))).toThrowError(/Confirm your email/);
+    expect(() => assertCanFlag(member({ emailVerified: false }), "bob@example.test")).toThrowError(/Confirm your email/);
+  });
+
+  it("rejects self-reporting", () => {
+    expect(() => assertCanFlag(member(), "alice@example.test")).toThrowError(/own post/);
+  });
+});

--- a/workers/forum/src/antispam.ts
+++ b/workers/forum/src/antispam.ts
@@ -29,18 +29,31 @@ export function containsLink(body: string): boolean {
 // Throws an HttpError when the member may not post. `minTrust` is the category
 // gate; `body` enables the new-member link block.
 export function assertCanPost(member: Member, opts: { minTrust: number; body: string }): void {
-  if (!member.emailVerified) {
-    throw new HttpError(403, "email_unverified", "Confirm your email address before posting.");
-  }
-  if (member.silencedUntil && member.silencedUntil > new Date().toISOString()) {
-    throw new HttpError(403, "silenced", "Your account is temporarily restricted from posting.");
-  }
+  assertCanInteract(member);
   if (isStaff(member)) return;
   if (member.trust < opts.minTrust) {
     throw new HttpError(403, "insufficient_trust", "You don't have access to post in this category yet.");
   }
   if (member.trust < TRUST.BASIC && containsLink(opts.body)) {
     throw new HttpError(403, "links_restricted", "New members can't post links yet — this unlocks once you've participated a little.");
+  }
+}
+
+// Reactions and reports affect other people's content and moderation state, so
+// they require the same verified, unsilenced identity as content creation.
+export function assertCanInteract(member: Member): void {
+  if (!member.emailVerified) {
+    throw new HttpError(403, "email_unverified", "Confirm your email address before participating.");
+  }
+  if (member.silencedUntil && member.silencedUntil > new Date().toISOString()) {
+    throw new HttpError(403, "silenced", "Your account is temporarily restricted from participating.");
+  }
+}
+
+export function assertCanFlag(member: Member, postAuthor: string): void {
+  assertCanInteract(member);
+  if (member.email === postAuthor) {
+    throw new HttpError(422, "self_flag", "You can't report your own post.");
   }
 }
 

--- a/workers/forum/src/index.test.ts
+++ b/workers/forum/src/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import app from "./index";
+import type { Bindings } from "./env";
+
+function bindings(db: D1Database): Bindings {
+  return {
+    DB: db,
+    APP_ORIGIN: "https://reasonix.io",
+    ALLOWED_ORIGINS: "https://reasonix.io",
+    ID_ORIGIN: "https://id.reasonix.io",
+  };
+}
+
+describe("forum public API", () => {
+  it("maps invalid query input to a client error", async () => {
+    const db = { prepare: () => { throw new Error("database should not be reached"); } } as unknown as D1Database;
+    const response = await app.request("https://forum.reasonix.io/topics?sort=invalid", {}, bindings(db));
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "invalid_input" } });
+  });
+
+  it("selects public handles instead of stored author emails", async () => {
+    const queries: string[] = [];
+    const rows = [{
+      id: 1,
+      title: "Safe public topic",
+      slug: "safe-public-topic",
+      status: "open",
+      pinned: 0,
+      replyCount: 0,
+      viewCount: 0,
+      author: "alice",
+      createdAt: "2026-08-05T00:00:00.000Z",
+      lastPostAt: "2026-08-05T00:00:00.000Z",
+      category: "help",
+      categoryName: "Help & Support",
+    }];
+    const statement = {
+      bind() { return this; },
+      async all() { return { results: rows }; },
+    };
+    const db = {
+      prepare(query: string) {
+        queries.push(query);
+        return statement;
+      },
+    } as unknown as D1Database;
+
+    const response = await app.request("https://forum.reasonix.io/topics", {}, bindings(db));
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toEqual({ topics: rows });
+    expect(queries[0]).toContain("m.handle, 'deleted') AS author");
+    expect(queries[0]).not.toMatch(/\bt\.author\s*,/);
+    expect(JSON.stringify(payload)).not.toContain("example.test");
+  });
+});

--- a/workers/forum/src/index.ts
+++ b/workers/forum/src/index.ts
@@ -1,16 +1,27 @@
 // Reasonix Community forum API. Identity from id.reasonix.io; content + anti-abuse
 // state in D1. The Hono app is itself the Workers fetch handler.
 import { Hono } from "hono";
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { cors } from "hono/cors";
 import { z } from "zod";
 import type { AppEnv } from "./env";
 import { loadMember, currentMember, HttpError } from "./identity";
-import { assertCanPost, dailyPostCap, rateLimited, AUTO_HIDE_FLAGS } from "./antispam";
+import { assertCanFlag, assertCanInteract, assertCanPost, dailyPostCap, rateLimited, AUTO_HIDE_FLAGS } from "./antispam";
 
 const app = new Hono<AppEnv>();
 
 app.onError((err, c) => {
-  if (err instanceof HttpError) return c.json({ error: { code: err.code, message: err.message } }, err.status as 400);
+  if (err instanceof HttpError) return c.json({ error: { code: err.code, message: err.message } }, err.status as ContentfulStatusCode);
+  if (err instanceof z.ZodError) {
+    const issue = err.issues[0];
+    const path = issue?.path.join(".");
+    const message = issue ? (path ? `${path}: ${issue.message}` : issue.message) : "Some fields are invalid.";
+    return c.json({ error: { code: "invalid_input", message } }, 422);
+  }
+  if (err instanceof SyntaxError) {
+    return c.json({ error: { code: "invalid_json", message: "Request body must be valid JSON." } }, 400);
+  }
   console.error("forum error:", err);
   return c.json({ error: { code: "internal", message: "Something went wrong." } }, 500);
 });
@@ -37,7 +48,7 @@ async function postsToday(c: { env: AppEnv["Bindings"] }, email: string): Promis
   return row?.n ?? 0;
 }
 
-async function enforceRate(c: { env: AppEnv["Bindings"]; req: { header: (k: string) => string | undefined } }, member: Parameters<typeof rateLimited>[0]): Promise<void> {
+async function enforceBurstRate(c: { env: AppEnv["Bindings"]; req: { header: (k: string) => string | undefined } }, member: Parameters<typeof rateLimited>[0]): Promise<void> {
   if (!rateLimited(member)) return;
   const limiter = c.env.POST_LIMITER;
   if (limiter) {
@@ -45,6 +56,10 @@ async function enforceRate(c: { env: AppEnv["Bindings"]; req: { header: (k: stri
     const { success } = await limiter.limit({ key: ip });
     if (!success) throw new HttpError(429, "rate_limited", "You're posting too fast — take a short break.");
   }
+}
+
+async function enforcePostRate(c: { env: AppEnv["Bindings"]; req: { header: (k: string) => string | undefined } }, member: Parameters<typeof rateLimited>[0]): Promise<void> {
+  await enforceBurstRate(c, member);
   if ((await postsToday(c, member.email)) >= dailyPostCap(member.trust)) {
     throw new HttpError(429, "daily_limit", "You've hit today's posting limit for your trust level.");
   }
@@ -69,8 +84,10 @@ app.get("/topics", async (c) => {
   const where = q.category ? "WHERE cat.slug = ?1 AND t.status != 'hidden'" : "WHERE t.status != 'hidden'";
   const stmt = c.env.DB.prepare(
     `SELECT t.id, t.title, t.slug, t.status, t.pinned, t.reply_count AS replyCount, t.view_count AS viewCount,
-            t.author, t.created_at AS createdAt, t.last_post_at AS lastPostAt, cat.slug AS category, cat.name AS categoryName
-     FROM topics t JOIN categories cat ON cat.id = t.category_id ${where} ORDER BY ${order} LIMIT 50`,
+            COALESCE(m.handle, 'deleted') AS author, t.created_at AS createdAt, t.last_post_at AS lastPostAt,
+            cat.slug AS category, cat.name AS categoryName
+     FROM topics t JOIN categories cat ON cat.id = t.category_id
+     LEFT JOIN members m ON m.email = t.author ${where} ORDER BY ${order} LIMIT 50`,
   );
   const rows = await (q.category ? stmt.bind(q.category) : stmt).all();
   return c.json({ topics: rows.results });
@@ -78,19 +95,25 @@ app.get("/topics", async (c) => {
 
 app.get("/topics/:id", async (c) => {
   const id = Number(c.req.param("id"));
+  const viewer = c.get("member")?.email ?? "";
   const topic = await c.env.DB.prepare(
-    `SELECT t.id, t.title, t.slug, t.status, t.pinned, t.author, t.accepted_post_id AS acceptedPostId,
+    `SELECT t.id, t.title, t.slug, t.status, t.pinned, COALESCE(m.handle, 'deleted') AS author,
+            t.accepted_post_id AS acceptedPostId,
             t.reply_count AS replyCount, t.view_count AS viewCount, t.created_at AS createdAt, cat.slug AS category
-     FROM topics t JOIN categories cat ON cat.id = t.category_id WHERE t.id = ?1 AND t.status != 'hidden'`,
+     FROM topics t JOIN categories cat ON cat.id = t.category_id
+     LEFT JOIN members m ON m.email = t.author WHERE t.id = ?1 AND t.status != 'hidden'`,
   ).bind(id).first();
   if (!topic) throw new HttpError(404, "not_found", "That topic doesn't exist.");
   await c.env.DB.prepare("UPDATE topics SET view_count = view_count + 1 WHERE id = ?1").bind(id).run();
   const posts = await c.env.DB.prepare(
-    `SELECT p.id, p.author, p.body, p.status, p.like_count AS likeCount, p.created_at AS createdAt, p.edited_at AS editedAt,
-            m.handle, m.trust, m.role
+    `SELECT p.id, COALESCE(m.handle, 'deleted') AS author, p.body, p.status, p.like_count AS likeCount,
+            p.created_at AS createdAt, p.edited_at AS editedAt, COALESCE(m.handle, 'deleted') AS handle, m.trust, m.role,
+            CASE WHEN ?2 != '' AND EXISTS (
+              SELECT 1 FROM reactions r WHERE r.post_id = p.id AND r.member = ?2 AND r.emoji = 'like'
+            ) THEN 1 ELSE 0 END AS liked
      FROM posts p LEFT JOIN members m ON m.email = p.author
      WHERE p.topic_id = ?1 AND p.status IN ('visible') ORDER BY p.created_at`,
-  ).bind(id).all();
+  ).bind(id, viewer).all();
   return c.json({ topic, posts: posts.results });
 });
 
@@ -107,19 +130,21 @@ app.post("/topics", async (c) => {
     .first<{ id: number; minTrust: number }>();
   if (!cat) throw new HttpError(404, "no_category", "That category doesn't exist.");
   assertCanPost(member, { minTrust: cat.minTrust, body: input.body });
-  await enforceRate(c, member);
+  await enforcePostRate(c, member);
 
   const now = new Date().toISOString();
-  const topicRes = await c.env.DB.prepare(
-    `INSERT INTO topics (category_id, author, title, slug, created_at, last_post_at) VALUES (?1, ?2, ?3, ?4, ?5, ?5)`,
-  )
-    .bind(cat.id, member.email, input.title, slugify(input.title), now)
-    .run();
+  const [topicRes] = await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO topics (category_id, author, title, slug, created_at, last_post_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?5)`,
+    ).bind(cat.id, member.email, input.title, slugify(input.title), now),
+    c.env.DB.prepare(
+      `INSERT INTO posts (topic_id, author, body, created_at)
+       VALUES (last_insert_rowid(), ?1, ?2, ?3)`,
+    ).bind(member.email, input.body, now),
+    c.env.DB.prepare("UPDATE members SET post_count = post_count + 1 WHERE email = ?1").bind(member.email),
+  ]);
   const topicId = Number(topicRes.meta.last_row_id);
-  await c.env.DB.prepare("INSERT INTO posts (topic_id, author, body, created_at) VALUES (?1, ?2, ?3, ?4)")
-    .bind(topicId, member.email, input.body, now)
-    .run();
-  await c.env.DB.prepare("UPDATE members SET post_count = post_count + 1 WHERE email = ?1").bind(member.email).run();
   return c.json({ topic: { id: topicId, slug: slugify(input.title) } }, 201);
 });
 
@@ -136,16 +161,16 @@ app.post("/topics/:id/posts", async (c) => {
   if (!topic || topic.status === "hidden") throw new HttpError(404, "not_found", "That topic doesn't exist.");
   if (topic.status === "closed") throw new HttpError(403, "closed", "This topic is closed to new replies.");
   assertCanPost(member, { minTrust: topic.minTrust, body: input.body });
-  await enforceRate(c, member);
+  await enforcePostRate(c, member);
 
   const now = new Date().toISOString();
-  const res = await c.env.DB.prepare("INSERT INTO posts (topic_id, author, body, created_at) VALUES (?1, ?2, ?3, ?4)")
-    .bind(topicId, member.email, input.body, now)
-    .run();
-  await c.env.DB.prepare("UPDATE topics SET reply_count = reply_count + 1, last_post_at = ?2 WHERE id = ?1")
-    .bind(topicId, now)
-    .run();
-  await c.env.DB.prepare("UPDATE members SET post_count = post_count + 1 WHERE email = ?1").bind(member.email).run();
+  const [res] = await c.env.DB.batch([
+    c.env.DB.prepare("INSERT INTO posts (topic_id, author, body, created_at) VALUES (?1, ?2, ?3, ?4)")
+      .bind(topicId, member.email, input.body, now),
+    c.env.DB.prepare("UPDATE topics SET reply_count = reply_count + 1, last_post_at = ?2 WHERE id = ?1")
+      .bind(topicId, now),
+    c.env.DB.prepare("UPDATE members SET post_count = post_count + 1 WHERE email = ?1").bind(member.email),
+  ]);
   return c.json({ post: { id: Number(res.meta.last_row_id) } }, 201);
 });
 
@@ -154,25 +179,62 @@ app.post("/posts/:id/flags", async (c) => {
   const member = currentMember(c);
   const postId = Number(c.req.param("id"));
   const input = Flag.parse(await c.req.json());
-  const post = await c.env.DB.prepare("SELECT id, status FROM posts WHERE id = ?1").bind(postId).first<{ id: number; status: string }>();
+  const post = await c.env.DB.prepare("SELECT id, status, author FROM posts WHERE id = ?1")
+    .bind(postId)
+    .first<{ id: number; status: string; author: string }>();
   if (!post) throw new HttpError(404, "not_found", "That post doesn't exist.");
+  assertCanFlag(member, post.author);
+  await enforceBurstRate(c, member);
 
   const now = new Date().toISOString();
-  await c.env.DB.prepare(
-    "INSERT INTO flags (post_id, reporter, reason, note, created_at) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(post_id, reporter) DO NOTHING",
-  )
-    .bind(postId, member.email, input.reason, input.note ?? "", now)
-    .run();
-  const count = await c.env.DB.prepare("SELECT COUNT(*) AS n FROM flags WHERE post_id = ?1").bind(postId).first<{ n: number }>();
-  const flagCount = count?.n ?? 0;
-  await c.env.DB.prepare("UPDATE posts SET flag_count = ?2 WHERE id = ?1").bind(postId, flagCount).run();
-  if (flagCount >= AUTO_HIDE_FLAGS && post.status === "visible") {
-    await c.env.DB.prepare("UPDATE posts SET status = 'hidden' WHERE id = ?1").bind(postId).run();
-    await c.env.DB.prepare("INSERT INTO mod_log (at, actor, action, target, detail) VALUES (?1, 'system', 'auto_hide_post', ?2, ?3)")
-      .bind(now, String(postId), `${flagCount} flags`)
-      .run();
-  }
-  return c.json({ ok: true, flagCount, hidden: flagCount >= AUTO_HIDE_FLAGS });
+  const results = await c.env.DB.batch([
+    c.env.DB.prepare(
+      "INSERT INTO flags (post_id, reporter, reason, note, created_at) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(post_id, reporter) DO NOTHING",
+    ).bind(postId, member.email, input.reason, input.note ?? "", now),
+    c.env.DB.prepare(
+      "UPDATE posts SET flag_count = (SELECT COUNT(*) FROM flags WHERE post_id = ?1) WHERE id = ?1",
+    ).bind(postId),
+    c.env.DB.prepare(
+      "UPDATE posts SET status = 'hidden' WHERE id = ?1 AND status = 'visible' AND flag_count >= ?2",
+    ).bind(postId, AUTO_HIDE_FLAGS),
+    c.env.DB.prepare(
+      `INSERT INTO mod_log (at, actor, action, target, detail)
+       SELECT ?1, 'system', 'auto_hide_post', ?2, 'flag threshold reached' WHERE changes() = 1`,
+    ).bind(now, String(postId)),
+    c.env.DB.prepare("SELECT flag_count AS flagCount, status FROM posts WHERE id = ?1").bind(postId),
+  ]);
+  const state = results[4]?.results[0] as { flagCount?: number; status?: string } | undefined;
+  return c.json({ ok: true, flagCount: state?.flagCount ?? 0, hidden: state?.status === "hidden" });
 });
+
+async function setLike(c: Context<AppEnv>, liked: boolean): Promise<Response> {
+  const member = currentMember(c);
+  assertCanInteract(member);
+  await enforceBurstRate(c, member);
+  const postId = Number(c.req.param("id"));
+  const post = await c.env.DB.prepare("SELECT id FROM posts WHERE id = ?1 AND status = 'visible'")
+    .bind(postId)
+    .first<{ id: number }>();
+  if (!post) throw new HttpError(404, "not_found", "That post doesn't exist.");
+
+  const mutation = liked
+    ? c.env.DB.prepare(
+      "INSERT INTO reactions (post_id, member, emoji, created_at) VALUES (?1, ?2, 'like', ?3) ON CONFLICT(post_id, member, emoji) DO NOTHING",
+    ).bind(postId, member.email, new Date().toISOString())
+    : c.env.DB.prepare("DELETE FROM reactions WHERE post_id = ?1 AND member = ?2 AND emoji = 'like'").bind(postId, member.email);
+  const [, updated] = await c.env.DB.batch([
+    mutation,
+    c.env.DB.prepare(
+      `UPDATE posts SET like_count = (
+         SELECT COUNT(*) FROM reactions WHERE post_id = ?1 AND emoji = 'like'
+       ) WHERE id = ?1 RETURNING like_count AS likeCount`,
+    ).bind(postId),
+  ]);
+  const state = updated?.results[0] as { likeCount?: number } | undefined;
+  return c.json({ ok: true, liked, likeCount: state?.likeCount ?? 0 });
+}
+
+app.post("/posts/:id/likes", (c) => setLike(c, true));
+app.delete("/posts/:id/likes", (c) => setLike(c, false));
 
 export default app;


### PR DESCRIPTION
## Summary

- Fix verification-email links by using the canonical account-worker origin `https://id.reasonix.io` while preserving the website redirect after verification.
- Return public handles instead of stored email addresses from forum endpoints.
- Require verified, unsilenced identities for likes and reports; reject self-reports and rate-limit interactions.
- Add idempotent likes, a public profile route, and a resend-verification control.
- Map invalid forum input to 400/422, make related D1 writes transactional, claim handles atomically, and run worker checks before deployment.
- No D1 schema migration is required.

修复邮箱验证链接 404，并同步加固账号与社区的身份隐私、互动权限、输入错误处理和写入一致性。

## Root cause

Verification URLs were derived from the public website origin even though `/auth/verify` is served by the accounts worker. The surrounding account and forum flows also lacked several integrity boundaries: public responses could expose the stored identity value, reaction/report permissions were incomplete, and related writes were not atomic.

## Issues

No linked issue.

## Verification

- `cd workers/accounts && pnpm test && pnpm typecheck`
- `cd workers/accounts && pnpm exec wrangler deploy --dry-run`
- `cd workers/forum && pnpm test && pnpm typecheck`
- `cd workers/forum && pnpm exec wrangler deploy --dry-run`
- `cd site && npm test && npm exec astro build`
- Not run: live Chrome UI verification because the browser-control extension was unavailable in the current session.

## Documentation impact

Documentation-impact: updated - documented `ACCOUNT_ORIGIN` and local email-flow configuration in `workers/accounts/README.md`.

## Cache impact

Cache-impact: none - changes are limited to the website and Cloudflare workers; prompt composition and memory behavior are unchanged.
Cache-guard: N/A - no prompt-cache path changed.
System-prompt-review: N/A