### PR TITLE
fix(desktop): keep composer overflow stacks readable / 保持输入区溢出列表可读

### DIFF
--- a/desktop/frontend/src/__tests__/footer-decision-overflow.test.ts
+++ b/desktop/frontend/src/__tests__/footer-decision-overflow.test.ts
@@ -129,5 +129,14 @@ function footerClipOffenders(): string[] {
 
 eq(footerClipOffenders().join(", "), "", "no footer rule except .footer--decision clips or caps the footer");
 
+// AC7 — repeated pasted blocks and attachment rows stay bounded inside the
+// composer footer. Pasted blocks must not flex-shrink vertically, otherwise
+// the capped list compresses each block instead of becoming scrollable.
+eq(finalDeclaration(".composer__pasted", "max-height"), "min(30vh, 240px)", "pasted block list is viewport-bounded");
+eq(finalDeclaration(".composer__pasted", "overflow-y"), "auto", "pasted block list scrolls internally");
+eq(finalDeclaration(".composer__pasted-block", "flex-shrink"), "0", "pasted blocks keep their readable height");
+eq(finalDeclaration(".composer-context", "max-height"), "min(30vh, 200px)", "attachment list is viewport-bounded");
+eq(finalDeclaration(".composer-context", "overflow-y"), "auto", "attachment list scrolls internally");
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -20450,6 +20450,10 @@ body > .mermaid-diagram--fullscreen {
   align-items: flex-start;
   gap: 8px;
   margin-bottom: 8px;
+  /* Many attachments (images/refs) stack rows without bound and squeeze the
+     transcript viewport (see #7578). Cap the area and scroll internally. */
+  max-height: min(30vh, 200px);
+  overflow-y: auto;
 }
 .composer-context__item {
   display: inline-flex;
@@ -20646,12 +20650,20 @@ body > .mermaid-diagram--fullscreen {
   flex-direction: column;
   gap: 6px;
   margin-bottom: 8px;
+  /* Pasting many long texts stacks fold blocks without bound and squeezes the
+     transcript viewport (see #7578). Cap the list and scroll internally. */
+  max-height: min(30vh, 240px);
+  overflow-y: auto;
 }
 .composer__pasted-block {
   border: 1px solid var(--border);
   border-radius: 7px;
   background: var(--panel);
   overflow: hidden;
+  /* The capped .composer__pasted list is a column flex container; without
+     this, flex-shrink would crush every block to a few px instead of
+     scrolling (#7578). */
+  flex-shrink: 0;
 }
 .composer__pasted-head {
   display: flex;


### PR DESCRIPTION
## Summary

- Bound repeated pasted-text blocks and attachment/reference rows inside the composer footer so the transcript remains reachable.
- Keep pasted blocks non-shrinking inside the capped column, preventing the follow-up clipping regression caught during #7579 review.
- Add focused CSS contract coverage for both bounded overflow paths.

## Issues

Fixes #7578
Refs #7579

## Integration and contributor credit

- Kept and adapted the bug report, root-cause analysis, and bounded-list CSS from #7579 by @erphenheimer.
- Added the non-shrinking pasted-block guard, focused regression coverage, and current-`main-v2` integration.
- Repository co-contributor: @erphenheimer.

## Verification

- `pnpm exec tsx src/__tests__/footer-decision-overflow.test.ts` — 19/19
- `pnpm exec tsx src/__tests__/composer-resized-input-css.test.ts` — 7/7
- `pnpm exec tsx src/__tests__/message-pasted-blocks.test.ts` — 9/9
- `pnpm exec tsx src/__tests__/composer-session-draft.test.tsx` — 130/130
- `pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx` — 228/228
- `pnpm build`
- Browser at 720px: 20 pasted blocks retain readable height and scroll inside the capped list while the transcript remains visible.
- `git diff --check`

## Documentation impact

Documentation-impact: none - this is a bounded desktop layout correction; it adds no commands, settings, configuration, or documented workflow changes.

## Cache impact

Cache-impact: low - CSS and CSS contract tests only; no provider-visible bytes, persisted formats, tool schemas, or request serialization change.
Cache-guard: `footer-decision-overflow.test.ts` plus focused composer tests and `pnpm build`
System-prompt-review: N/A