### PR TITLE
fix(bash): restore OS account home as subprocess HOME

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -470,7 +471,7 @@ func commandPreview(cmd string) string {
 }
 
 func bashCommandEnv(ctx context.Context) []string {
-	env := secrets.ProcessEnv()
+	env := restoreHostHomeEnv(secrets.ProcessEnv())
 	if runtime.GOOS == "windows" {
 		return env
 	}
@@ -557,6 +558,40 @@ func isExecutableFile(path string) bool {
 		return false
 	}
 	return info.Mode().Perm()&0o111 != 0
+}
+
+// hostAccountHome resolves the OS account's home directory from the user
+// database (not $HOME), once. Empty when unresolvable.
+var hostAccountHome = sync.OnceValue(func() string {
+	u, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.HomeDir)
+})
+
+// restoreHostHomeEnv points the subprocess HOME at the OS account's real home
+// when the reasonix process itself runs with an overridden HOME (e.g. a
+// service launcher forcing HOME onto a config dir), so CLIs that resolve
+// credentials via $HOME (gh, arkcli, …) keep working. The inherited HOME is
+// kept untouched when the account home is unknown, not a directory, or
+// already the effective value.
+func restoreHostHomeEnv(env []string) []string {
+	return restoreHomeEnv(env, hostAccountHome())
+}
+
+func restoreHomeEnv(env []string, home string) []string {
+	if home == "" {
+		return env
+	}
+	current, ok := envValue(env, "HOME")
+	if !ok || current == home {
+		return env
+	}
+	if info, err := os.Stat(home); err != nil || !info.IsDir() {
+		return env
+	}
+	return setEnvValue(env, "HOME", home)
 }
 
 func setEnvValue(env []string, key, value string) []string {

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -142,3 +142,42 @@ func TestRunShellPATHCommandFiltersEnvWhenEnabled(t *testing.T) {
 		t.Fatalf("login-shell PATH probe leaked filtered env: %q", out)
 	}
 }
+
+func TestRestoreHomeEnvPrefersAccountHome(t *testing.T) {
+	home := t.TempDir()
+	got := restoreHomeEnv([]string{"HOME=/overridden", "PATH=/usr/bin"}, home)
+	if v, _ := envValue(got, "HOME"); v != home {
+		t.Fatalf("HOME = %q, want account home %q", v, home)
+	}
+	if v, _ := envValue(got, "PATH"); v != "/usr/bin" {
+		t.Fatalf("PATH = %q, want untouched", v)
+	}
+}
+
+func TestRestoreHomeEnvFallbacks(t *testing.T) {
+	// Account home missing on disk: inherited HOME stays.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	got := restoreHomeEnv([]string{"HOME=/overridden"}, missing)
+	if v, _ := envValue(got, "HOME"); v != "/overridden" {
+		t.Fatalf("HOME = %q, want inherited value kept for missing account home", v)
+	}
+
+	// Empty account home: inherited HOME stays.
+	got = restoreHomeEnv([]string{"HOME=/overridden"}, "")
+	if v, _ := envValue(got, "HOME"); v != "/overridden" {
+		t.Fatalf("HOME = %q, want inherited value kept for empty account home", v)
+	}
+
+	// No inherited HOME: do not invent one.
+	got = restoreHomeEnv([]string{"PATH=/usr/bin"}, t.TempDir())
+	if _, ok := envValue(got, "HOME"); ok {
+		t.Fatalf("HOME = %v, want it absent when the parent env has none", got)
+	}
+
+	// Already the account home: unchanged.
+	home := t.TempDir()
+	got = restoreHomeEnv([]string{"HOME=" + home}, home)
+	if v, _ := envValue(got, "HOME"); v != home {
+		t.Fatalf("HOME = %q, want %q", v, home)
+	}
+}


### PR DESCRIPTION
## Summary

- Service/supervised launches often set \`HOME\` to a config directory for Reasonix isolation.
- Bash tool subprocesses inherited that value, so CLIs like \`gh\` looked under the wrong home and reported \"not logged in\".
- Restore the OS account home from the user database for bash env when that directory exists; leave inherited \`HOME\` untouched otherwise. Reasonix's own \`REASONIX_HOME\` / config isolation is unchanged.

## Issues

Fixes #7331

## Verification

- \`go test ./internal/tool/builtin/ -run 'TestRestoreHomeEnv|TestBashCommandEnv'\`

## Documentation impact

Documentation-impact: none - subprocess environment fix; existing docs about REASONIX_HOME / config isolation remain correct.

## Cache impact

Cache-impact: none — bash subprocess environment only.
Cache-guard: N/A
System-prompt-review: N/A