### PR TITLE
fix(config): timeout legacy keyring lookups on startup

### DIFF
--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/joho/godotenv"
 
@@ -63,7 +64,37 @@ var credentialSourceTracker = struct {
 var userCredentialEditMu sync.Mutex
 
 var storedCredentialValueLookup = storedCredentialValue
-var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValue
+var legacyKeyringCredentialValueImpl = legacyKeyringCredentialValue
+var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValueWithTimeout
+
+// legacyKeyringLookupTimeout bounds Secret Service / platform keyring probes
+// during legacy credential migration. An unhealthy session bus (stuck
+// gnome-keyring, etc.) must not hang CLI startup indefinitely (#7507).
+var legacyKeyringLookupTimeout = 2 * time.Second
+
+// legacyKeyringCredentialValueWithTimeout wraps the platform keyring lookup so
+// a stuck D-Bus reply fails closed (treat as missing) instead of blocking the
+// process. A hung probe may leave a short-lived goroutine until the bus
+// answers; that is preferable to never starting.
+func legacyKeyringCredentialValueWithTimeout(key string) (string, bool) {
+	type result struct {
+		value string
+		ok    bool
+	}
+	ch := make(chan result, 1)
+	go func() {
+		value, ok := legacyKeyringCredentialValueImpl(key)
+		ch <- result{value: value, ok: ok}
+	}()
+	timer := time.NewTimer(legacyKeyringLookupTimeout)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.value, r.ok
+	case <-timer.C:
+		return "", false
+	}
+}
 
 // CredentialResolver resolves credentials repeatedly for one caller-owned view
 // build. It keeps expensive global credential-store lookups bounded to one per

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLegacyKeyringCredentialValueWithTimeout(t *testing.T) {
+	oldImpl := legacyKeyringCredentialValueImpl
+	oldTimeout := legacyKeyringLookupTimeout
+	t.Cleanup(func() {
+		legacyKeyringCredentialValueImpl = oldImpl
+		legacyKeyringLookupTimeout = oldTimeout
+	})
+
+	t.Run("returns value", func(t *testing.T) {
+		legacyKeyringCredentialValueImpl = func(key string) (string, bool) {
+			return "secret-" + key, true
+		}
+		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
+		if !ok || value != "secret-DEEPSEEK_API_KEY" {
+			t.Fatalf("got (%q, %v), want (secret-DEEPSEEK_API_KEY, true)", value, ok)
+		}
+	})
+
+	t.Run("times out on stuck keyring", func(t *testing.T) {
+		legacyKeyringLookupTimeout = 40 * time.Millisecond
+		started := make(chan struct{})
+		legacyKeyringCredentialValueImpl = func(string) (string, bool) {
+			close(started)
+			time.Sleep(500 * time.Millisecond)
+			return "late", true
+		}
+		start := time.Now()
+		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
+		elapsed := time.Since(start)
+		if ok || value != "" {
+			t.Fatalf("got (%q, %v), want fail-closed timeout", value, ok)
+		}
+		if elapsed < 40*time.Millisecond {
+			t.Fatalf("elapsed %v, want at least the timeout", elapsed)
+		}
+		if elapsed > 250*time.Millisecond {
+			t.Fatalf("elapsed %v, want fail-fast near the timeout", elapsed)
+		}
+		select {
+		case <-started:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("stuck keyring probe was never started")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Startup legacy-credential migration calls into the OS keyring / Secret Service with no deadline.
- An unhealthy D-Bus session bus (stuck gnome-keyring, etc.) could hang every \`reasonix\` execution path with zero output.
- Bound each legacy keyring probe with a short timeout and fail closed (treat as missing) so the CLI can start.

## Issues

Fixes #7507

## Verification

- \`go test ./internal/config/ -run TestLegacyKeyringCredentialValueWithTimeout\`

## Documentation impact

Documentation-impact: none - internal startup resilience; no user-facing CLI/config surface change.

## Cache impact

Cache-impact: none — credential migration path only.
Cache-guard: N/A
System-prompt-review: N/A