### PR TITLE
fix(cli): accept Ctrl+Backspace to delete the previous word

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -658,6 +658,9 @@ func configureChatTextarea(ti *textarea.Model) {
 	// Linux terminals send Ctrl+arrows for the same intent.
 	ti.KeyMap.WordForward = key.NewBinding(key.WithKeys("alt+right", "alt+f", "ctrl+right"))
 	ti.KeyMap.WordBackward = key.NewBinding(key.WithKeys("alt+left", "alt+b", "ctrl+left"))
+	// mirrors the word-motion convention: macOS uses Alt+Backspace, Windows and
+	// Linux terminals send Ctrl+Backspace to delete the word behind the cursor.
+	ti.KeyMap.DeleteWordBackward = key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w", "ctrl+backspace"))
 	ti.Focus()
 }
 

--- a/internal/cli/composer_word_motion_test.go
+++ b/internal/cli/composer_word_motion_test.go
@@ -19,6 +19,7 @@ func TestComposerWordMotionAcceptsCtrlArrows(t *testing.T) {
 	}{
 		{"forward", ti.KeyMap.WordForward.Keys(), "ctrl+right", "alt+right"},
 		{"backward", ti.KeyMap.WordBackward.Keys(), "ctrl+left", "alt+left"},
+		{"delete-backward", ti.KeyMap.DeleteWordBackward.Keys(), "ctrl+backspace", "alt+backspace"},
 	} {
 		if !slices.Contains(tc.keys, tc.ctrl) {
 			t.Errorf("word %s is missing %s: %v", tc.motion, tc.ctrl, tc.keys)


### PR DESCRIPTION
bubbles binds `DeleteWordBackward` to `alt+backspace` and `ctrl+w` (macOS
convention). Windows and Linux terminals send `Ctrl+Backspace` for the
same intent, so without rebinding it the composer treats `Ctrl+Backspace`
as a plain backspace.

This mirrors the `Ctrl+arrow` rebinding from #7390: keep both the macOS
and Windows/Linux variants on `DeleteWordBackward`, and extend the
existing `TestComposerWordMotionAcceptsCtrlArrows` table to assert the
binding includes `ctrl+backspace` alongside `alt+backspace`.

### Diff

```diff
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -657,6 +657,9 @@ func configureChatTextarea(ti *textarea.Model) {
 	ti.KeyMap.WordForward = key.NewBinding(key.WithKeys("alt+right", "alt+f", "ctrl+right"))
 	ti.KeyMap.WordBackward = key.NewBinding(key.WithKeys("alt+left", "alt+b", "ctrl+left"))
+	// mirrors the word-motion convention: macOS uses Alt+Backspace, Windows and
+	// Linux terminals send Ctrl+Backspace to delete the word behind the cursor.
+	ti.KeyMap.DeleteWordBackward = key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w", "ctrl+backspace"))
 	ti.Focus()
 }
```

```diff
--- a/internal/cli/composer_word_motion_test.go
+++ b/internal/cli/composer_word_motion_test.go
@@ -19,6 +19,7 @@ func TestComposerWordMotionAcceptsCtrlArrows(t *testing.T) {
 		{"forward",  ti.KeyMap.WordForward.Keys(),  "ctrl+right",   "alt+right"},
 		{"backward", ti.KeyMap.WordBackward.Keys(), "ctrl+left",    "alt+left"},
+		{"delete-backward", ti.KeyMap.DeleteWordBackward.Keys(), "ctrl+backspace", "alt+backspace"},
 	} {
```

### Verification

- `go build ./internal/cli/...`
- `go vet ./internal/cli/...`
- `go test ./internal/cli/ -run TestComposerWordMotionAcceptsCtrlArrows -v` → PASS
