### PR TITLE
fix(cli): only Ctrl+C aborts a running turn

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1267,10 +1267,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.acceptCompletion()
 				return m, nil
 			case "esc":
+				// Esc always dismisses the completion menu. Cancel/abort during a
+				// running turn is Ctrl+C's job (see the main Esc handler); the
+				// main handler intentionally no longer cancels a running turn
+				// so a stray Esc can't kill it.
 				m.completion = completion{}
-				if m.state == tuiRunning {
-					break // a turn is running — also cancel it via the main Esc handler
-				}
 				return m, nil
 			}
 		}
@@ -1315,41 +1316,33 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "esc":
-			// "Back out" of the most specific in-progress state: un-send a just-sent
-			// turn (server not yet replied), cancel a streaming turn, or clear
-			// typed-but-unsent input. Mode switches (normal/plan/YOLO) are
-			// exclusively driven by Shift+Tab — Esc must not silently flip a
-			// session from plan or YOLO back to a less-permissive mode. PR #3051
-			// removed the YOLO half of this; plan mode was missed and is fixed
-			// here. Scrollback is the terminal's now, so there's no viewport to
-			// dismiss.
-			switch {
-			case m.state == tuiRunning && m.bubblePending:
-				m.unsendPending()
-			case m.state == tuiRunning:
-				m.ctrl.Cancel()
-				// Defensive: if the controller is no longer running (cancel
-				// completed synchronously, e.g. for shell commands), transition
-				// to idle immediately instead of waiting for TurnDone.
-				if !m.ctrl.Running() {
-					m.state = tuiIdle
-					m.confirmBubbleSent()
+			// Esc cancels a running turn only at the moment the user hits it
+			// (un-send a just-sent bubble) — once the controller is actively
+			// running, aborting requires Ctrl+C so a stray Esc can't kill the
+			// turn. Mode switches (normal/plan/YOLO) are exclusively driven by
+			// Shift+Tab — Esc must not silently flip a session from plan or YOLO
+			// back to a less-permissive mode. PR #3051 removed the YOLO half of
+			// this; plan mode was missed and is fixed here. Scrollback is the
+			// terminal's now, so there's no viewport to dismiss.
+			if m.state == tuiRunning {
+				if m.bubblePending {
+					m.unsendPending()
 				}
-			default:
-				// Idle (any mode): a double-Esc on an empty composer opens the
-				// rewind picker (Claude Code's gesture); a first Esc just arms
-				// it. Non-empty input clears as before.
-				if strings.TrimSpace(m.input.Value()) == "" {
-					if !m.lastEsc.IsZero() && time.Since(m.lastEsc) < 600*time.Millisecond {
-						m.lastEsc = time.Time{}
-						m.openRewind()
-					} else {
-						m.lastEsc = time.Now()
-					}
+				return m, nil
+			}
+			// Idle (any mode): a double-Esc on an empty composer opens the
+			// rewind picker (Claude Code's gesture); a first Esc just arms it.
+			// Non-empty input clears as before.
+			if strings.TrimSpace(m.input.Value()) == "" {
+				if !m.lastEsc.IsZero() && time.Since(m.lastEsc) < 600*time.Millisecond {
+					m.lastEsc = time.Time{}
+					m.openRewind()
 				} else {
-					m.input.Reset()
-					m.pastedBlocks = nil
+					m.lastEsc = time.Now()
 				}
+			} else {
+				m.input.Reset()
+				m.pastedBlocks = nil
 			}
 			return m, nil
 		case "ctrl+c", "super+c", "meta+c":

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -156,27 +156,62 @@ func saveTestImageAttachment(t *testing.T, root string) string {
 	return path
 }
 
-// TestEscCancelsRunningTurnWithCompletionOpen reproduces the report that Esc
-// (unlike Ctrl+C) did not stop a running turn: an active completion menu
-// captured Esc to close itself and returned before reaching the running-turn
-// cancel branch, while Ctrl+C — not in the completion switch — fell through.
-func TestEscCancelsRunningTurnWithCompletionOpen(t *testing.T) {
+// TestEscDoesNotCancelRunningTurn ensures Esc stays a "dismiss the menu"
+// key while a turn is running — the user has to press Ctrl+C to actually
+// abort, so a stray Esc can't kill a streaming turn. When the completion
+// menu is open, Esc should close the menu and leave the turn running.
+// Regression for the earlier behavior where Esc (unlike Ctrl+C) cancelled
+// the turn only after the completion menu dropped it.
+func TestEscDoesNotCancelRunningTurn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		open bool
+	}{
+		{"completion menu open", true},
+		{"no completion menu", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &blockingTurnRunner{started: make(chan struct{})}
+			ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
+			ctrl.Send("hi")
+			<-r.started // the turn is in flight and cancellable
+
+			m := newTestChatTUI()
+			m.ctrl = ctrl
+			m.state = tuiRunning
+			m.completion.active = tc.open // e.g. a "/" typed into the composer while waiting
+
+			_, _ = m.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+			if !ctrl.Running() {
+				t.Fatal("Esc must not cancel a running turn; use Ctrl+C")
+			}
+			// clean up so the runner goroutine can exit before the test ends
+			ctrl.Cancel()
+		})
+	}
+}
+
+// TestCtrlCCancelsRunningTurnWithCompletionOpen is the Ctrl+C counterpart of
+// the prior Esc regression: completion menus capture Esc but not Ctrl+C, so
+// the main handler always runs and aborts the turn.
+func TestCtrlCCancelsRunningTurnWithCompletionOpen(t *testing.T) {
 	r := &blockingTurnRunner{started: make(chan struct{})}
 	ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
 	ctrl.Send("hi")
-	<-r.started // the turn is in flight and cancellable
+	<-r.started
 
 	m := newTestChatTUI()
 	m.ctrl = ctrl
 	m.state = tuiRunning
-	m.completion.active = true // e.g. a "/" typed into the composer while waiting
+	m.completion.active = true
 
-	_, _ = m.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, _ = m.update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
 
 	deadline := time.Now().Add(2 * time.Second)
 	for ctrl.Running() {
 		if time.Now().After(deadline) {
-			t.Fatal("Esc did not cancel the running turn (completion menu swallowed it)")
+			t.Fatal("Ctrl+C did not cancel the running turn")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -47,7 +47,7 @@ var English = Messages{
 
 	ChatThinking:                           "thinking…",
 	ChatThoughtForFmt:                      "thought for %ds",
-	ChatStatusThinkingFmt:                  "%s thinking… (%ds · Esc cancels)",
+	ChatStatusThinkingFmt:                  "%s thinking… (%ds · Ctrl+C cancels)",
 	ChatToolWorkingFmt:                     "%s working · %ds",
 	ChatSubagentPhaseQueued:                "queued",
 	ChatSubagentPhaseRunning:               "running",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -48,7 +48,7 @@ var Chinese = Messages{
 
 	ChatThinking:                           "思考中…",
 	ChatThoughtForFmt:                      "思考了 %d 秒",
-	ChatStatusThinkingFmt:                  "%s 思考中… (%d 秒 · Esc 取消)",
+	ChatStatusThinkingFmt:                  "%s 思考中… (%d 秒 · Ctrl+C 取消)",
 	ChatToolWorkingFmt:                     "%s 运行中 · %d 秒",
 	ChatSubagentPhaseQueued:                "排队中",
 	ChatSubagentPhaseRunning:               "运行中",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -44,7 +44,7 @@ var ChineseTraditional = Messages{
 
 	ChatThinking:                           "思考中…",
 	ChatThoughtForFmt:                      "思考了 %d 秒",
-	ChatStatusThinkingFmt:                  "%s 思考中… (%d 秒 · Esc 取消)",
+	ChatStatusThinkingFmt:                  "%s 思考中… (%d 秒 · Ctrl+C 取消)",
 	ChatToolWorkingFmt:                     "%s 執行中 · %d 秒",
 	ChatSubagentPhaseQueued:                "排隊中",
 	ChatSubagentPhaseRunning:               "執行中",


### PR DESCRIPTION
Esc was both "close the menu" and "cancel the run", so a stray Esc — easy
to bump while reaching for arrows or backspace — could kill a streaming
turn. Ctrl+C requires two keys by design, so it's the deliberate gesture
for abort.

This makes Esc abort nothing while a turn is running. The user has to
press Ctrl+C to actually cancel; a stray Esc can't kill the turn.

### Behavior

- Esc while a turn is running: only un-sends a just-sent bubble (server
  has not replied yet). Never calls `ctrl.Cancel()` on a streaming turn.
  The completion menu still swallows Esc to close itself, as before.
- Esc while idle: unchanged — clears non-empty input, double-Esc opens
  the rewind picker.
- Ctrl+C while running: unchanged — first press calls `ctrl.Cancel()`,
  second press within the timeout shuts down.
- Footer hint during a run switches from "Esc cancels" to "Ctrl+C
  cancels" in en, zh, and zh-tw.

### Diff stat

```
 internal/cli/chat_tui.go              | 28 ++++++++-------
 internal/cli/chat_tui_test.go         | 71 +++++++++++++++++++++++++++++-----
 internal/i18n/messages_en.go          |  2 +-
 internal/i18n/messages_zh.go          |  2 +-
 internal/i18n/messages_zh_tw.go       |  2 +-
```

### Tests

- `TestEscDoesNotCancelRunningTurn` (table-driven, completion menu
  open / no completion menu) asserts the turn survives Esc.
- `TestCtrlCCancelsRunningTurnWithCompletionOpen` replaces the prior Esc
  regression test with the Ctrl+C counterpart, so the original report
  (completion menu swallowed the cancel key) is still covered — just for
  the key that still cancels.

### Verification

- `go build ./...`
- `go vet ./internal/cli/... ./internal/i18n/...`
- `go test ./internal/cli/ -short -count=1` → PASS (5.1s)
