### PR TITLE
fix(doctor): resolve global hooks from Reasonix home

### DIFF
--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -62,7 +62,7 @@ func Collect(opts Options) Report {
 		})
 	}
 
-	disp := func(p string) string { return displayPath(p, root, home) }
+	disp := func(p string) string { return displayPath(p, root, home, reasonixHome) }
 
 	instr, instructionIssues := collectInstructions(root, home, disp)
 	skillsR, skillIssues := collectSkills(root, home, reasonixHome, cfg, disp)
@@ -287,14 +287,12 @@ func collectCommands(root string, disp func(string) string) (AssetReport, []Issu
 
 func collectHooks(root, home, reasonixHome string, cfg *config.Config, disp func(string) string) (HookReport, []Issue) {
 	var issues []Issue
-	// Prefer explicit home for settings when tests isolate HOME.
-	homeDir := home
-	if reasonixHome != "" && home == "" {
-		homeDir = filepath.Dir(reasonixHome)
-	}
+	// Prefer the Collect-resolved Reasonix home. Passing the OS user home as
+	// hook.LoadOptions.HomeDir incorrectly resolves global settings to
+	// <home>/.reasonix and skips %APPDATA%/reasonix on Windows (#7411).
 	insp := hook.Inspect(hook.LoadOptions{
-		ProjectRoot: root,
-		HomeDir:     homeDir,
+		ProjectRoot:  root,
+		ReasonixHome: reasonixHome,
 	})
 	runtimeOptions := hook.RuntimeOptions{}
 	if cfg != nil {
@@ -783,7 +781,7 @@ func redactAbsolutePaths(s, workspace, home string) string {
 		token := s[start:j]
 		// Only rewrite if it looks like a path with a directory separator beyond root.
 		if strings.ContainsAny(token, `/\`) && len(token) > 1 {
-			b.WriteString(displayPath(token, workspace, home))
+			b.WriteString(displayPath(token, workspace, home, ""))
 		} else {
 			b.WriteString(token)
 		}
@@ -802,7 +800,7 @@ func redactCommandDisplay(cmd, root, home string) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	return displayPath(fields[0], root, home)
+	return displayPath(fields[0], root, home, "")
 }
 
 // ioDiscard avoids importing io in every call site for skill.Options.Stderr.

--- a/internal/capdiag/collect_test.go
+++ b/internal/capdiag/collect_test.go
@@ -255,6 +255,56 @@ func TestCollectIgnoresMatchersOnNonToolHookEvents(t *testing.T) {
 	}
 }
 
+// Regression for #7411: doctor must load global hooks from Reasonix home
+// (e.g. %APPDATA%/reasonix), not from <OS home>/.reasonix.
+func TestCollectHooksFromReasonixHomeNotOSHomeDotReasonix(t *testing.T) {
+	root := t.TempDir()
+	osHome := t.TempDir()
+	reasonixHome := filepath.Join(t.TempDir(), "AppData", "Roaming", "reasonix")
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("REASONIX_HOME", reasonixHome)
+
+	write(t, filepath.Join(osHome, ".reasonix", "settings.json"), `{
+  "hooks": {
+    "SessionStart": [{"command": "echo legacy-home"}]
+  }
+}`)
+	write(t, filepath.Join(reasonixHome, "settings.json"), `{
+  "hooks": {
+    "SessionStart": [{"command": "echo reasonix-home"}]
+  }
+}`)
+
+	r := capdiag.Collect(capdiag.Options{
+		Root: root, HomeDir: osHome, ReasonixHomeDir: reasonixHome,
+	})
+	if len(r.Hooks.Entries) != 1 {
+		t.Fatalf("hook entries = %+v, want one SessionStart from Reasonix home", r.Hooks.Entries)
+	}
+	if got := r.Hooks.Entries[0].Source; !strings.Contains(got, "<reasonix-home>") {
+		t.Fatalf("hook source = %q, want <reasonix-home>/... (not ~/.reasonix)", got)
+	}
+	if strings.Contains(r.Hooks.Entries[0].Source, ".reasonix") {
+		t.Fatalf("hook source still points at legacy ~/.reasonix: %q", r.Hooks.Entries[0].Source)
+	}
+	found := false
+	for _, s := range r.Hooks.Sources {
+		if s.Scope == "global" {
+			found = true
+			if !strings.Contains(s.Path, "<reasonix-home>") {
+				t.Fatalf("global hook source path = %q, want <reasonix-home>/...", s.Path)
+			}
+			if strings.Contains(s.Path, ".reasonix") {
+				t.Fatalf("global hook source still points at legacy ~/.reasonix: %q", s.Path)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a global hook source, got %+v", r.Hooks.Sources)
+	}
+}
+
 func TestCollectRejectsNonRegularPluginContextFile(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()

--- a/internal/capdiag/paths.go
+++ b/internal/capdiag/paths.go
@@ -9,9 +9,10 @@ import (
 
 // displayPath rewrites absolute paths for safe reports:
 //   - under workspace → <workspace>/...
-//   - under home → ~/...
+//   - under Reasonix home → <reasonix-home>/...
+//   - under OS home → ~/...
 //   - elsewhere → <external>/basename (no full external path, no username)
-func displayPath(p, workspace, home string) string {
+func displayPath(p, workspace, home, reasonixHome string) string {
 	p = strings.TrimSpace(p)
 	if p == "" {
 		return ""
@@ -34,6 +35,18 @@ func displayPath(p, workspace, home string) string {
 		}
 		if rel, err := filepath.Rel(ws, clean); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 			return "<workspace>/" + filepath.ToSlash(rel)
+		}
+	}
+	if reasonixHome != "" {
+		rh := filepath.Clean(reasonixHome)
+		if abs, err := filepath.Abs(rh); err == nil {
+			rh = abs
+		}
+		if clean == rh {
+			return "<reasonix-home>"
+		}
+		if rel, err := filepath.Rel(rh, clean); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return "<reasonix-home>/" + filepath.ToSlash(rel)
 		}
 	}
 	if home == "" {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -215,6 +215,11 @@ func ContextFileUsable(path string) bool {
 type LoadOptions struct {
 	ProjectRoot string
 	HomeDir     string
+	// ReasonixHome is an absolute Reasonix home directory (settings.json lives
+	// directly under it). When set, it wins over HomeDir and
+	// config.ReasonixHomeDir(). HomeDir remains an OS-home override that
+	// resolves to <home>/.reasonix for legacy tests.
+	ReasonixHome string
 	// Trusted is retained for source compatibility. Project hooks are enabled
 	// automatically now, so callers no longer need to set it.
 	Trusted bool
@@ -225,14 +230,18 @@ type LoadOptions struct {
 // — a typo shouldn't take down the CLI).
 func Load(opts LoadOptions) []ResolvedHook {
 	var out []ResolvedHook
+	home := resolveReasonixHome(opts)
 	if opts.ProjectRoot != "" {
 		p := ProjectSettingsPath(opts.ProjectRoot)
 		if s := readSettings(p); s != nil {
 			appendResolved(&out, s, ScopeProject, p)
 		}
 	}
-	appendPluginHooks(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
-	g := GlobalSettingsPath(opts.HomeDir)
+	appendPluginHooks(&out, home, opts.ProjectRoot)
+	g := filepath.Join(home, SettingsFilename)
+	if home == "" {
+		g = GlobalSettingsPath(opts.HomeDir)
+	}
 	if s := readSettings(g); s != nil {
 		appendResolved(&out, s, ScopeGlobal, g)
 	} else if !pathExists(g) {
@@ -1578,6 +1587,13 @@ func reasonixHome(override string) string {
 		return filepath.Join(h, SettingsDirname)
 	}
 	return ""
+}
+
+func resolveReasonixHome(opts LoadOptions) string {
+	if home := strings.TrimSpace(opts.ReasonixHome); home != "" {
+		return filepath.Clean(home)
+	}
+	return reasonixHome(opts.HomeDir)
 }
 
 func legacyGlobalSettingsPath(homeDir string) string {

--- a/internal/hook/inspect.go
+++ b/internal/hook/inspect.go
@@ -67,9 +67,13 @@ func Inspect(opts LoadOptions) Inspection {
 	}
 
 	// Plugin hooks (enabled packages only — same as Load).
-	appendPluginInspect(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
+	home := resolveReasonixHome(opts)
+	appendPluginInspect(&out, home, opts.ProjectRoot)
 
-	g := GlobalSettingsPath(opts.HomeDir)
+	g := filepath.Join(home, SettingsFilename)
+	if home == "" {
+		g = GlobalSettingsPath(opts.HomeDir)
+	}
 	st := inspectSettingsFile(g, ScopeGlobal)
 	if st.Status == "missing" {
 		if legacy := legacyGlobalSettingsPath(opts.HomeDir); legacy != "" {


### PR DESCRIPTION
## Summary

- `doctor capabilities` was resolving global hooks via `<OS home>/.reasonix` because `collectHooks` passed the OS user home as `hook.LoadOptions.HomeDir`.
- Pass the Collect-resolved Reasonix home through `hook.LoadOptions.ReasonixHome` instead, matching runtime hook loading (`config.ReasonixHomeDir()`, e.g. `%APPDATA%/reasonix` on Windows).
- Display paths under Reasonix home as `<reasonix-home>/...` in the report.

## Issues

Fixes #7411

## Verification

```
go test ./internal/hook/ ./internal/capdiag/ -count=1
```

## Documentation impact

Documentation-impact: none - doctor report paths now match the documented Reasonix home; CONFIG_PATHS already describes the platform home.

## Cache impact

Cache-impact: none - diagnostics-only path resolution; no provider prompt or tool schema change.
Cache-guard: N/A
System-prompt-review: N/A