### PR TITLE
fix(cli): let run --resume accept machine session IDs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,7 +138,7 @@ echo "explain this code" | reasonix run
 
 `reasonix run` keeps the normal streamed terminal presentation unless `-p` or a
 structured output format is selected. It also accepts `--model`, `--profile`,
-`--max-steps`, `--effort`, `--dir`, `--add-dir`, `--continue`, `--resume PATH`,
+`--max-steps`, `--effort`, `--dir`, `--add-dir`, `--continue`, `--resume QUERY`,
 `--copy`, `--allowed-tools`, `--permission-mode`, and `--auto` / `-y` (an alias
 for `--permission-mode auto`).
 
@@ -283,9 +283,10 @@ reasonix --resume provider-config --copy
 - `--copy` leaves the original transcript untouched and continues in a new
   writable session. Use it when another Reasonix process owns the original.
 
-For one-shot runs, `reasonix run --resume PATH "task"` accepts a session file
-path. Session leases prevent the desktop app and CLI from writing the same
-transcript concurrently.
+For one-shot runs, `reasonix run --resume QUERY "task"` accepts a session file
+path, a session ID, or an opaque machine session ID from `--events-jsonl` /
+`reasonix session show --json`. Session leases prevent the desktop app and CLI
+from writing the same transcript concurrently.
 
 ## Permissions
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -125,7 +125,7 @@ echo "解释这段代码" | reasonix run
 
 未使用 `-p` 或结构化输出格式时，`reasonix run` 保持正常的终端流式展示。它也接受
 `--model`、`--profile`、`--max-steps`、`--effort`、`--dir`、`--add-dir`、
-`--continue`、`--resume PATH`、`--copy`、`--allowed-tools` 和
+`--continue`、`--resume QUERY`、`--copy`、`--allowed-tools` 和
 `--permission-mode`，以及作为 `--permission-mode auto` 别名的 `--auto` / `-y`。
 
 ### 基准对照组
@@ -257,8 +257,9 @@ reasonix --resume provider-config --copy
 - `--copy` 不修改原 transcript，而是在新的可写会话中继续。原会话已被另一个
   Reasonix 进程占用时可以使用它。
 
-一次性运行可用 `reasonix run --resume PATH "任务"` 指定 session 文件路径。Session
-lease 会阻止桌面端和 CLI 同时写入同一个 transcript。
+一次性运行可用 `reasonix run --resume QUERY "任务"`，支持 session 文件路径、
+session ID，或来自 `--events-jsonl` / `reasonix session show --json` 的不透明
+machine session ID。Session lease 会阻止桌面端和 CLI 同时写入同一个 transcript。
 
 ## 权限
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -470,7 +470,7 @@ func runAgent(args []string, version string) int {
 	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
-	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
+	resume := fs.String("resume", "", "resume by session file path, session ID, or machine session ID (takes precedence over --continue)")
 	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	effort := fs.String("effort", "", "session reasoning effort override")
 	permissionMode := fs.String("permission-mode", "ask", "permission mode: manual | ask | auto | acceptEdits | dontAsk | plan | bypassPermissions")
@@ -559,8 +559,17 @@ func runAgent(args []string, version string) int {
 
 	// Resolve the resume target up front so --copy and the session lease can be
 	// handled before any heavy assembly. --resume takes precedence over
-	// --continue, matching the Resume call below.
+	// --continue, matching the Resume call below. Accept file paths, branch
+	// IDs, preview text, and opaque machine session IDs (#7429).
 	resumePath := strings.TrimSpace(*resume)
+	if resumePath != "" {
+		resolved, err := resolveSessionQuery(resolveCLISessionDir(), resumePath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		resumePath = resolved
+	}
 	if resumePath == "" && *cont {
 		sessionDir := resolveCLISessionDir()
 		reclaimCLIRecoveryBranches(sessionDir)

--- a/internal/cli/cli_flags.go
+++ b/internal/cli/cli_flags.go
@@ -143,6 +143,21 @@ func resolveSessionQuery(dir, query string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("list sessions: %w", err)
 	}
+	// Opaque machine session IDs (session_<hex>) are what --events-jsonl and
+	// `session show --json` expose. Match them before preview/partial search so
+	// one-shot `run --resume` can resume without scanning private paths (#7429).
+	if looksLikeMachineSessionID(query) {
+		key, keyErr := loadMachineIdentityKey()
+		if keyErr != nil {
+			return "", fmt.Errorf("machine identity is unavailable: %w", keyErr)
+		}
+		for _, session := range sessions {
+			if machineSessionIDWithKey(agent.BranchID(session.Path), key) == query {
+				return session.Path, nil
+			}
+		}
+		return "", fmt.Errorf("no session matches %q", query)
+	}
 	lower := strings.ToLower(query)
 	var exact []string
 	var partial []string
@@ -170,4 +185,24 @@ func resolveSessionQuery(dir, query string) (string, error) {
 	default:
 		return "", fmt.Errorf("session query %q is ambiguous (%d matches)", query, len(matches))
 	}
+}
+
+// looksLikeMachineSessionID reports whether query is the opaque HMAC form
+// emitted by machineSessionIDWithKey (`session_` + 32 lowercase hex chars).
+func looksLikeMachineSessionID(query string) bool {
+	const prefix = "session_"
+	if !strings.HasPrefix(query, prefix) {
+		return false
+	}
+	hexPart := query[len(prefix):]
+	if len(hexPart) != 32 {
+		return false
+	}
+	for i := 0; i < len(hexPart); i++ {
+		c := hexPart[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/cli_flags_test.go
+++ b/internal/cli/cli_flags_test.go
@@ -143,6 +143,25 @@ func TestResolveSessionQueryByIDAndPreview(t *testing.T) {
 	}
 }
 
+func TestResolveSessionQueryByMachineSessionID(t *testing.T) {
+	identityKey := installMachineTestIdentity(t)
+	dir := t.TempDir()
+	path := saveQueryTestSession(t, dir, "opaque-branch.jsonl", "resume by machine id")
+	machineID := machineSessionIDWithKey(agent.BranchID(path), identityKey)
+	if machineID == "" || !looksLikeMachineSessionID(machineID) {
+		t.Fatalf("machine session id = %q", machineID)
+	}
+
+	got, err := resolveSessionQuery(dir, machineID)
+	if err != nil || got != path {
+		t.Fatalf("resolve by machine id = (%q, %v), want %q", got, err, path)
+	}
+	missing := "session_" + strings.Repeat("0", 32)
+	if _, err := resolveSessionQuery(dir, missing); err == nil || !strings.Contains(err.Error(), "no session") {
+		t.Fatalf("missing machine id error = %v", err)
+	}
+}
+
 func saveQueryTestSession(t *testing.T, dir, name, prompt string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
## Summary

- One-shot `reasonix run --resume` treated its value as a filesystem path only, so opaque machine session IDs (`session_<hex>` from `--events-jsonl` / `session show --json`) failed with `open …: no such file or directory`.
- Route `run --resume` through `resolveSessionQuery`, and teach that helper to map machine session IDs with the same HMAC identity used by the machine session API (interactive `--resume` benefits too).
- Update CLI docs so one-shot resume is no longer documented as PATH-only.

## Issues

Fixes #7429

## Verification

```
go test ./internal/cli/ -count=1 -run 'TestResolveSessionQuery'
```

## Documentation impact

Documentation-impact: updated - `docs/CLI.md` and `docs/CLI.zh-CN.md` now document that `run --resume` accepts a path, session ID, or machine session ID.

## Cache impact

Cache-impact: none - CLI resume path resolution only; no provider prompt or tool schema change.
Cache-guard: N/A
System-prompt-review: N/A