### PR TITLE
fix(desktop): contain macOS alias repair startup crashes / 修复 macOS 别名导致的启动崩溃

### DIFF
--- a/desktop/icon_repair_darwin.go
+++ b/desktop/icon_repair_darwin.go
@@ -12,6 +12,8 @@ int reasonix_write_alias(const char *target_path, const char *alias_path,
                          char **error_message);
 int reasonix_resolve_alias(const char *alias_path, char **target_path,
                            char **error_message);
+int reasonix_is_reasonix_bundle_url_string(const char *url_string,
+                                           char **error_message);
 */
 import "C"
 
@@ -127,4 +129,21 @@ func resolveMacAlias(aliasPath string) (string, error) {
 		return "", fmt.Errorf("%s", C.GoString(nativeErr))
 	}
 	return C.GoString(target), nil
+}
+
+func macURLReferencesReasonixBundle(rawURL string) (bool, error) {
+	urlCString := C.CString(rawURL)
+	defer C.free(unsafe.Pointer(urlCString))
+	var nativeErr *C.char
+	result := C.reasonix_is_reasonix_bundle_url_string(urlCString, &nativeErr)
+	if nativeErr != nil {
+		defer C.free(unsafe.Pointer(nativeErr))
+	}
+	if result < 0 {
+		if nativeErr == nil {
+			return false, fmt.Errorf("native bundle URL inspection failed")
+		}
+		return false, fmt.Errorf("%s", C.GoString(nativeErr))
+	}
+	return result == 1, nil
 }

--- a/desktop/icon_repair_darwin.m
+++ b/desktop/icon_repair_darwin.m
@@ -13,6 +13,14 @@ static void reasonix_set_error(char **output, NSError *error, NSString *fallback
     *output = strdup(message.UTF8String ?: "unknown macOS alias error");
 }
 
+static void reasonix_set_exception(char **output, NSException *exception, NSString *fallback) {
+    if (output == NULL) {
+        return;
+    }
+    NSString *message = exception.reason ?: exception.name ?: fallback;
+    *output = strdup(message.UTF8String ?: "unknown macOS alias exception");
+}
+
 static BOOL reasonix_is_alias(NSURL *url, NSError **error) {
     NSNumber *value = nil;
     if (![url getResourceValue:&value forKey:NSURLIsAliasFileKey error:error]) {
@@ -38,90 +46,166 @@ static int reasonix_create_alias(NSURL *targetURL, NSURL *aliasURL, char **error
     return 0;
 }
 
+// NSBundle requires a file URL and raises NSInvalidArgumentException for some
+// Finder aliases that resolve to other schemes. Objective-C exceptions cannot
+// cross the cgo boundary safely, so keep this classifier fail-closed and convert
+// any unexpected Foundation exception into a normal native error.
+static int reasonix_is_reasonix_bundle_url(NSURL *url, char **error_message) {
+    if (url == nil || !url.isFileURL) {
+        return 0;
+    }
+    @try {
+        NSBundle *bundle = [NSBundle bundleWithURL:url];
+        return [bundle.bundleIdentifier isEqualToString:@"com.wails.reasonix-desktop"] ? 1 : 0;
+    } @catch (NSException *exception) {
+        reasonix_set_exception(error_message, exception, @"inspect Finder alias target");
+        return -1;
+    }
+}
+
+// Kept as a narrow C entry point so Go regression tests exercise the exact
+// native URL classifier used by startup alias repair.
+int reasonix_is_reasonix_bundle_url_string(const char *url_string,
+                                           char **error_message) {
+    @autoreleasepool {
+        @try {
+            if (url_string == NULL) {
+                return 0;
+            }
+            NSString *value = [NSString stringWithUTF8String:url_string];
+            if (value == nil) {
+                return 0;
+            }
+            return reasonix_is_reasonix_bundle_url([NSURL URLWithString:value], error_message);
+        } @catch (NSException *exception) {
+            reasonix_set_exception(error_message, exception, @"parse Finder alias target");
+            return -1;
+        }
+    }
+}
+
+static int reasonix_write_alias_impl(const char *target_path, const char *alias_path,
+                                     char **error_message) {
+    NSURL *targetURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:target_path]];
+    NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+    return reasonix_create_alias(targetURL, aliasURL, error_message);
+}
+
 int reasonix_write_alias(const char *target_path, const char *alias_path,
                          char **error_message) {
     @autoreleasepool {
-        NSURL *targetURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:target_path]];
-        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
-        return reasonix_create_alias(targetURL, aliasURL, error_message);
+        @try {
+            return reasonix_write_alias_impl(target_path, alias_path, error_message);
+        } @catch (NSException *exception) {
+            reasonix_set_exception(error_message, exception, @"write Finder alias");
+            return -1;
+        }
     }
+}
+
+static int reasonix_resolve_alias_impl(const char *alias_path, char **target_path,
+                                       char **error_message) {
+    NSError *error = nil;
+    NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+    NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
+                                                 options:NSURLBookmarkResolutionWithoutUI |
+                                                         NSURLBookmarkResolutionWithoutMounting
+                                                   error:&error];
+    if (resolved == nil || !resolved.isFileURL) {
+        reasonix_set_error(error_message, error, @"resolve Finder alias to file URL");
+        return -1;
+    }
+    if (target_path != NULL) {
+        *target_path = strdup(resolved.path.UTF8String);
+    }
+    return 0;
 }
 
 int reasonix_resolve_alias(const char *alias_path, char **target_path,
                            char **error_message) {
     @autoreleasepool {
-        NSError *error = nil;
-        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
-        NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
-                                                     options:NSURLBookmarkResolutionWithoutUI |
-                                                             NSURLBookmarkResolutionWithoutMounting
-                                                       error:&error];
-        if (resolved == nil) {
-            reasonix_set_error(error_message, error, @"resolve Finder alias");
+        @try {
+            return reasonix_resolve_alias_impl(alias_path, target_path, error_message);
+        } @catch (NSException *exception) {
+            reasonix_set_exception(error_message, exception, @"resolve Finder alias");
             return -1;
         }
-        if (target_path != NULL) {
-            *target_path = strdup(resolved.path.UTF8String);
-        }
+    }
+}
+
+static int reasonix_repair_alias_impl(const char *alias_path, const char *current_app_path,
+                                      int allow_broken, char **error_message) {
+    NSError *error = nil;
+    NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
+    if (!reasonix_is_alias(aliasURL, &error)) {
+        // Missing metadata means this is an ordinary desktop file, not an
+        // owned integration failure. Never replace it merely by name.
         return 0;
     }
+
+    NSURL *currentURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:current_app_path]];
+    NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
+                                                 options:NSURLBookmarkResolutionWithoutUI |
+                                                         NSURLBookmarkResolutionWithoutMounting
+                                                   error:&error];
+    BOOL owned = NO;
+    if (resolved != nil) {
+        if (!resolved.isFileURL) {
+            // URL-backed and network aliases are unrelated desktop
+            // integrations. Skipping them also keeps NSBundle from
+            // raising for a non-file URL during application startup.
+            return 0;
+        }
+        NSString *resolvedPath = resolved.URLByResolvingSymlinksInPath.standardizedURL.path;
+        NSString *currentPath = currentURL.URLByResolvingSymlinksInPath.standardizedURL.path;
+        if ([resolvedPath isEqualToString:currentPath]) {
+            // The alias is already healthy. Avoid rewriting it on every
+            // launch so Finder metadata and any user customization remain.
+            return 0;
+        }
+        int ownership = reasonix_is_reasonix_bundle_url(resolved, error_message);
+        if (ownership < 0) {
+            return -1;
+        }
+        owned = ownership == 1;
+    } else if (allow_broken != 0) {
+        // A broken alias has no resolvable target to prove ownership. Only
+        // the exact historical installer names are admitted by Go.
+        owned = YES;
+    }
+    if (!owned) {
+        return 0;
+    }
+
+    NSURL *directory = [aliasURL URLByDeletingLastPathComponent];
+    NSString *temporaryName = [NSString stringWithFormat:@".reasonix-alias-%@", NSUUID.UUID.UUIDString];
+    NSURL *temporaryURL = [directory URLByAppendingPathComponent:temporaryName];
+    if (reasonix_create_alias(currentURL, temporaryURL, error_message) != 0) {
+        return -1;
+    }
+
+    NSURL *resultingURL = nil;
+    if (![[NSFileManager defaultManager] replaceItemAtURL:aliasURL
+                                            withItemAtURL:temporaryURL
+                                           backupItemName:nil
+                                                  options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                                         resultingItemURL:&resultingURL
+                                                    error:&error]) {
+        [[NSFileManager defaultManager] removeItemAtURL:temporaryURL error:nil];
+        reasonix_set_error(error_message, error, @"replace Finder alias");
+        return -1;
+    }
+    return 1;
 }
 
 int reasonix_repair_alias(const char *alias_path, const char *current_app_path,
                           int allow_broken, char **error_message) {
     @autoreleasepool {
-        NSError *error = nil;
-        NSURL *aliasURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:alias_path]];
-        if (!reasonix_is_alias(aliasURL, &error)) {
-            // Missing metadata means this is an ordinary desktop file, not an
-            // owned integration failure. Never replace it merely by name.
-            return 0;
-        }
-
-        NSURL *currentURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:current_app_path]];
-        NSURL *resolved = [NSURL URLByResolvingAliasFileAtURL:aliasURL
-                                                     options:NSURLBookmarkResolutionWithoutUI |
-                                                             NSURLBookmarkResolutionWithoutMounting
-                                                       error:&error];
-        BOOL owned = NO;
-        if (resolved != nil) {
-            NSString *resolvedPath = resolved.URLByResolvingSymlinksInPath.standardizedURL.path;
-            NSString *currentPath = currentURL.URLByResolvingSymlinksInPath.standardizedURL.path;
-            if ([resolvedPath isEqualToString:currentPath]) {
-                // The alias is already healthy. Avoid rewriting it on every
-                // launch so Finder metadata and any user customization remain.
-                return 0;
-            } else {
-                NSBundle *bundle = [NSBundle bundleWithURL:resolved];
-                owned = [bundle.bundleIdentifier isEqualToString:@"com.wails.reasonix-desktop"];
-            }
-        } else if (allow_broken != 0) {
-            // A broken alias has no resolvable target to prove ownership. Only
-            // the exact historical installer names are admitted by Go.
-            owned = YES;
-        }
-        if (!owned) {
-            return 0;
-        }
-
-        NSURL *directory = [aliasURL URLByDeletingLastPathComponent];
-        NSString *temporaryName = [NSString stringWithFormat:@".reasonix-alias-%@", NSUUID.UUID.UUIDString];
-        NSURL *temporaryURL = [directory URLByAppendingPathComponent:temporaryName];
-        if (reasonix_create_alias(currentURL, temporaryURL, error_message) != 0) {
+        @try {
+            return reasonix_repair_alias_impl(alias_path, current_app_path, allow_broken, error_message);
+        } @catch (NSException *exception) {
+            reasonix_set_exception(error_message, exception, @"repair Finder alias");
             return -1;
         }
-
-        NSURL *resultingURL = nil;
-        if (![[NSFileManager defaultManager] replaceItemAtURL:aliasURL
-                                                withItemAtURL:temporaryURL
-                                               backupItemName:nil
-                                                      options:NSFileManagerItemReplacementUsingNewMetadataOnly
-                                             resultingItemURL:&resultingURL
-                                                        error:&error]) {
-            [[NSFileManager defaultManager] removeItemAtURL:temporaryURL error:nil];
-            reasonix_set_error(error_message, error, @"replace Finder alias");
-            return -1;
-        }
-        return 1;
     }
 }

--- a/desktop/icon_repair_darwin_test.go
+++ b/desktop/icon_repair_darwin_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,6 +90,39 @@ func TestRepairMacDesktopAliasesPreservesUnrelatedBrokenAlias(t *testing.T) {
 	}
 }
 
+func TestRepairMacDesktopAliasesPreservesUnrelatedHealthyAlias(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherApp := filepath.Join(root, "Other.app")
+	currentApp := filepath.Join(root, "Reasonix.app")
+	if err := os.MkdirAll(filepath.Join(otherApp, "Contents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeReasonixTestBundle(t, currentApp)
+	alias := filepath.Join(desktop, "Other")
+	if err := writeMacAlias(otherApp, alias); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("unrelated healthy Finder alias was rewritten")
+	}
+}
+
 func TestRepairMacDesktopAliasesPreservesOrdinaryReasonixFile(t *testing.T) {
 	root := t.TempDir()
 	desktop := filepath.Join(root, "Desktop")
@@ -141,5 +175,89 @@ func TestRepairMacDesktopAliasesPreservesHealthyReasonixAlias(t *testing.T) {
 	}
 	if string(after) != string(before) {
 		t.Fatal("healthy Finder alias was rewritten")
+	}
+}
+
+func TestRepairMacDesktopAliasesRetargetsCustomNamedInstalledAlias(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldApp := filepath.Join(root, "Reasonix-old.app")
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, oldApp)
+	writeReasonixTestBundle(t, currentApp)
+	alias := filepath.Join(desktop, "My Reasonix")
+	if err := writeMacAlias(oldApp, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveMacAlias(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(currentApp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != want {
+		t.Fatalf("custom alias target = %q, want %q", resolved, want)
+	}
+}
+
+func TestMacBundleOwnershipRejectsNonFileURL(t *testing.T) {
+	owned, err := macURLReferencesReasonixBundle("https://example.com/Reasonix.app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owned {
+		t.Fatal("non-file URL was classified as a Reasonix application bundle")
+	}
+}
+
+func TestMacBundleOwnershipRecognizesInstalledReasonixBundle(t *testing.T) {
+	app := filepath.Join(t.TempDir(), "Reasonix.app")
+	writeReasonixTestBundle(t, app)
+	owned, err := macURLReferencesReasonixBundle((&url.URL{Scheme: "file", Path: app}).String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !owned {
+		t.Fatal("installed Reasonix application bundle was not recognized")
+	}
+}
+
+func TestRepairMacDesktopAliasesAllowsEmptyFirstInstallDesktop(t *testing.T) {
+	root := t.TempDir()
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, currentApp)
+
+	if err := repairMacDesktopAliases(desktop, currentApp); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(desktop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("first-install desktop gained unexpected entries: %v", entries)
+	}
+}
+
+func TestRepairMacDesktopAliasesAllowsMissingFirstInstallDesktop(t *testing.T) {
+	root := t.TempDir()
+	currentApp := filepath.Join(root, "Reasonix.app")
+	writeReasonixTestBundle(t, currentApp)
+
+	if err := repairMacDesktopAliases(filepath.Join(root, "Desktop"), currentApp); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- reject Finder alias targets that are not `file://` URLs before passing them to `NSBundle`
- catch and convert unexpected Objective-C exceptions at every macOS alias-repair cgo entry point so startup can continue
- preserve healthy aliases, unrelated aliases and files, custom-named Reasonix upgrade aliases, and empty or missing Desktop directories
- add native macOS regression coverage for affected and unaffected install paths

## Root cause

The startup icon repair inspected every resolved Finder alias with `+[NSBundle bundleWithURL:]`. Foundation raises `NSInvalidArgumentException` when the resolved URL is not a file URL. Because Objective-C exceptions cannot safely cross the cgo boundary, the process aborted before the desktop window opened.

The crash trace in #7485 identified the native call path, and #7596 independently reproduced the same startup failure across v1.19.5 and v1.19.7.

Fixes #7485
Fixes #7596

## User impact

Affected macOS users no longer crash when an unrelated Finder alias resolves to a URL or network scheme. Existing users keep automatic repair for genuine Reasonix aliases, while normal installs and first installs require no cleanup, migration, restart ritual, or new configuration.

## Compatibility and safety

- no installer, updater transaction, application bundle layout, or release-channel changes
- no persisted-data or Wails contract changes
- no prompt, memory, tool, provider, or cache-prefix changes
- no new network or filesystem access; non-file aliases are now skipped fail-closed
- ordinary files and unrelated healthy or broken aliases remain untouched

## Validation

- `cd desktop && go test . -run 'Test(RepairMacDesktopAliases|MacBundleOwnership)' -count=10`
- `cd desktop && go vet .`
- `cd desktop && go build -o /tmp/reasonix-desktop-icon-repair-check .`
- `git diff --check`
- full `cd desktop && go test ./...` completed all subpackages but the main package hit one transient `fork/exec /usr/bin/git: bad file descriptor` in `TestWorkspaceChangeDetailBoundsUntrackedFile`; that exact test passed when rerun in isolation
- a serial full-suite retry produced no terminal result and was stopped after an extended wait; CI remains the final full-suite gate

## Documentation impact

Documentation-impact: none - this restores internal native startup error handling without changing documented installation, update, or configuration behavior.

## Cache impact

None. System prompts, memory prefixes, tools, provider serialization, compaction, and skill indexes are unchanged.

## System-prompt review

No system-prompt or model-facing content changed.