### PR TITLE
fix(desktop): run heartbeat tasks on configured default_model

### DIFF
--- a/desktop/heartbeat.go
+++ b/desktop/heartbeat.go
@@ -351,6 +351,10 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 	t.ApprovalMode = mode
 	e.app.SetToolApprovalModeForTab(tabMeta.ID, mode)
 
+	// Automation should follow the user's configured default_model, not a
+	// sticky session/provider-access fallback left on a reused topic (#7481).
+	e.app.applyHeartbeatDefaultModel(tabMeta.ID, scope, workspaceRoot)
+
 	// Attach bot event forwarding if the bot runtime is active and has
 	// session-mapped targets. The forwarder is set on the tab's event sink
 	// so AI output events are streamed to connected bot channels in
@@ -383,6 +387,46 @@ func (e *HeartbeatEngine) executeTask(t HeartbeatTask) HeartbeatTask {
 		t.CreatedAt = t.LastRunAt
 	}
 	return t
+}
+
+// applyHeartbeatDefaultModel switches the tab onto the configured desktop
+// default_model before a scheduled prompt runs. Reused heartbeat topics can
+// otherwise keep a stale session model (often the built-in DeepSeek flash ref)
+// from an earlier build that never saw tab.model seeded (#7481).
+func (a *App) applyHeartbeatDefaultModel(tabID, scope, workspaceRoot string) {
+	if a == nil {
+		return
+	}
+	want, _ := desktopNewSessionDefaults(scope, workspaceRoot)
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return
+	}
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return
+	}
+	a.mu.RLock()
+	current := strings.TrimSpace(tab.model)
+	removed := tab.removed
+	a.mu.RUnlock()
+	if current == want {
+		return
+	}
+	// Live desktop runtime: rebuild the controller onto the default. Tests that
+	// inject stub controllers mark the tab removed and only need tab.model.
+	if a.ctx != nil && !removed {
+		if err := a.SetModelForTab(tabID, want); err != nil {
+			log.Printf("[heartbeat] SetModelForTab(%q): %s", want, secrets.RedactError(err))
+		}
+		return
+	}
+	a.mu.Lock()
+	if tab := a.tabs[tabID]; tab != nil {
+		tab.model = want
+		tab.Label = want
+	}
+	a.mu.Unlock()
 }
 
 // ListTasks returns a copy of the current tasks (in-memory).

--- a/desktop/heartbeat_test.go
+++ b/desktop/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -525,5 +526,161 @@ func TestHeartbeatTickAdoptsExternalFileEdits(t *testing.T) {
 	tasks := engine.ListTasks()
 	if len(tasks) != 2 || tasks[1].ID != "b" {
 		t.Fatalf("tick did not adopt the external edit: %+v", tasks)
+	}
+}
+
+func TestOpenGlobalTabInactiveSeedsDefaultModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_HEARTBEAT_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers = append(cfg.Providers, config.ProviderEntry{
+		Name:      "custom-flash",
+		Kind:      "openai",
+		BaseURL:   "https://example.com/v1",
+		Model:     "deepseek-v4-flash",
+		APIKeyEnv: "REASONIX_TEST_HEARTBEAT_KEY",
+	})
+	if err := cfg.SetDefaultModel("custom-flash/deepseek-v4-flash"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.runtimeEvents.emit = func(context.Context, string, ...interface{}) {}
+
+	topic, err := app.CreateTopic("global", "", "Heartbeat seed")
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	meta, err := app.openGlobalTabInactive(topic.ID)
+	if err != nil {
+		t.Fatalf("openGlobalTabInactive: %v", err)
+	}
+	tab := app.tabByID(meta.ID)
+	if tab == nil {
+		t.Fatal("expected tab for inactive global open")
+	}
+	// Cancel the async build so the test does not leak a live controller boot.
+	app.mu.Lock()
+	cancel := tab.buildCancel
+	tab.removed = true
+	app.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if got := strings.TrimSpace(tab.model); got != "custom-flash/deepseek-v4-flash" {
+		t.Fatalf("inactive open tab model = %q, want configured default_model", got)
+	}
+}
+
+func TestHeartbeatExecuteTaskAppliesConfiguredDefaultModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	seedUserCredentials(t, "REASONIX_TEST_HEARTBEAT_KEY=test-key\n")
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.Providers = append(cfg.Providers, config.ProviderEntry{
+		Name:      "custom-flash",
+		Kind:      "openai",
+		BaseURL:   "https://example.com/v1",
+		Model:     "deepseek-v4-flash",
+		APIKeyEnv: "REASONIX_TEST_HEARTBEAT_KEY",
+	})
+	if err := cfg.SetDefaultModel("custom-flash/deepseek-v4-flash"); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	app.runtimeEvents.emit = func(context.Context, string, ...interface{}) {}
+	engine := &HeartbeatEngine{
+		app:           app,
+		pendingTopics: map[string]heartbeatPendingTopic{},
+	}
+	ctrl := &heartbeatExecuteTaskCtrlStub{}
+	injected := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-injected:
+				return
+			case <-ticker.C:
+				var cancel context.CancelFunc
+				var tabToInject *WorkspaceTab
+				app.mu.Lock()
+				for _, tab := range app.tabs {
+					if tab == nil {
+						continue
+					}
+					// Simulate a reused topic that still carries the official
+					// DeepSeek flash ref from an earlier controller build.
+					tab.model = "deepseek-flash/deepseek-v4-flash"
+					tab.Label = tab.model
+					tab.removed = true
+					cancel = tab.buildCancel
+					tabToInject = tab
+					break
+				}
+				app.mu.Unlock()
+				if tabToInject == nil {
+					continue
+				}
+				if cancel != nil {
+					cancel()
+				}
+				app.mu.Lock()
+				if tabToInject.Ctrl == nil {
+					tabToInject.Ctrl = ctrl
+					tabToInject.Ready = true
+					tabToInject.StartupErr = ""
+					app.advanceSessionRuntimeEpochLocked(tabToInject)
+					app.mu.Unlock()
+					close(injected)
+					return
+				}
+				app.mu.Unlock()
+			}
+		}
+	}()
+
+	got := engine.executeTask(HeartbeatTask{
+		ID:                     "model-fix",
+		Title:                  "Model fix",
+		Prompt:                 "ping",
+		NewConversationEachRun: true,
+		ApprovalMode:           "auto",
+	})
+	if got.LastRunAt == 0 {
+		t.Fatal("heartbeat run should complete after submit")
+	}
+
+	tab := app.tabByID(got.TopicID)
+	if tab == nil {
+		// TopicID is the topic id, not tab id — find the only tab.
+		app.mu.RLock()
+		for _, candidate := range app.tabs {
+			if candidate != nil {
+				tab = candidate
+				break
+			}
+		}
+		app.mu.RUnlock()
+	}
+	if tab == nil {
+		t.Fatal("expected heartbeat tab")
+	}
+	if got := strings.TrimSpace(tab.model); got != "custom-flash/deepseek-v4-flash" {
+		t.Fatalf("heartbeat tab model = %q, want configured default_model", got)
 	}
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2403,9 +2403,16 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 		_ = setTopicTitleWithSource(workspaceRoot, topicID, t, source)
 	}
 
+	// Match createTabEntry / New Session: seed the configured desktop default
+	// model before the async controller build. Heartbeat and other inactive
+	// openers previously left tab.model empty, so the first build fell through
+	// session-meta / provider-access fallbacks and could stamp the official
+	// DeepSeek flash ref instead of the user's default_model (#7481).
+	defaultModel, _ := desktopNewSessionDefaults(scope, actualRoot)
+
 	if sessionPath == "" {
 		var err error
-		sessionPath, err = createEmptySessionFile(desktopSessionDir(actualRoot), "")
+		sessionPath, err = createEmptySessionFile(desktopSessionDir(actualRoot), defaultModel)
 		if err != nil {
 			a.mu.Unlock()
 			return TabMeta{}, err
@@ -2424,6 +2431,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 		TopicTitle:       topicTitle,
 		topicTitleSource: loadTopicTitleSource(topicTitleRoot(scope, workspaceRoot), topicID),
 		SessionPath:      sessionPath,
+		model:            defaultModel,
 		disabledMCP:      map[string]ServerView{},
 	}
 	applyTabSessionProfile(tab, profile)


### PR DESCRIPTION
## Summary

- Heartbeat/automation opened topics via `openTopicTabWithActivation`, which left `tab.model` empty (unlike New Session / `createTabEntry`).
- The async controller build then fell through session-meta / provider-access fallbacks and could stamp the official DeepSeek flash ref; reused topics kept that sticky model.
- Seed `desktopNewSessionDefaults` when opening inactive tabs, and re-apply the configured `default_model` before each heartbeat submit.

## Issues

Fixes #7481

## Verification

```
cd desktop && go test . -count=1 -run 'TestHeartbeat|TestOpenGlobalTabInactiveSeedsDefaultModel|TestDesktopNewSessionDefaults'
```

## Documentation impact

Documentation-impact: none - automation already implied to use the user default model; no docs claimed a different contract.

## Cache impact

Cache-impact: none - desktop tab/model selection only; no provider prompt or tool schema change.
Cache-guard: N/A
System-prompt-review: N/A