### PR TITLE
fix(cli): route --profile to interactive session to match docs

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,7 +188,7 @@ func isDoctorRepairCommand(args []string) bool {
 
 func isDefaultInteractiveFlag(arg string) bool {
 	switch arg {
-	case "--model", "--max-steps", "--continue", "-c", "--resume", "-r", "--copy", "--dangerously-skip-permissions", "--yolo", "--permission-mode", "--effort", "--dir", "--add-dir", "--allowed-tools", "--allowedTools":
+	case "--model", "--max-steps", "--continue", "-c", "--resume", "-r", "--copy", "--dangerously-skip-permissions", "--yolo", "--permission-mode", "--effort", "--dir", "--add-dir", "--allowed-tools", "--allowedTools", "--profile":
 		return true
 	}
 	if name, _, ok := strings.Cut(arg, "="); ok && isDefaultInteractiveFlag(name) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -334,6 +334,32 @@ func TestRunDefaultsToInteractiveSession(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesProfileFlagToInteractiveSession(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	prev := runInteractiveSession
+	prevInteractive := cliIsInteractive
+	t.Cleanup(func() {
+		runInteractiveSession = prev
+		cliIsInteractive = prevInteractive
+	})
+	cliIsInteractive = func() bool { return true }
+
+	var gotArgs []string
+	runInteractiveSession = func(args []string, _ string) int {
+		gotArgs = append([]string(nil), args...)
+		return 17
+	}
+
+	if rc := Run([]string{"--profile", "delivery"}, "test-version"); rc != 17 {
+		t.Fatalf("Run --profile delivery rc = %d, want 17 (interactive session dispatch)", rc)
+	}
+	want := []string{"--profile", "delivery"}
+	if !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("interactive args = %#v, want %#v", gotArgs, want)
+	}
+}
+
 func TestRunNoArgsNonInteractivePrintsUsage(t *testing.T) {
 	isolateCLIConfigHome(t)
 


### PR DESCRIPTION
## Summary

修复 `reasonix --profile delivery` 报 `unknown command "--profile"` 的问题，使 CLI 行为与文档记载一致。

根因：`Run` 的无子命令路由白名单 `isDefaultInteractiveFlag` 缺少 `--profile`。不带子命令启动时，`--profile` 被当作子命令名，落入 unknown command 分支；`chatREPL` 本身已支持 `--profile`（cli.go:999），文档也记载了该用法，属于路由白名单漏配，功能与文档不对齐。

改动：

- `internal/cli/cli.go`：`isDefaultInteractiveFlag` 白名单补上 `--profile`，`--profile=x` 等号形式经 `strings.Cut` 递归同样生效，无子命令的 `--profile` 正确路由到交互式会话。
- `internal/cli/cli_test.go`：新增回归测试 `TestRunDispatchesProfileFlagToInteractiveSession`，先复现 rc=2 的 unknown command 行为，再验证参数原样传递给交互式会话。

## Issues

无关联 issue。

## Verification

- `go test ./internal/cli/ -run TestRunDispatchesProfileFlagToInteractiveSession`：通过，新增回归测试即本修复的守卫。
- `go test ./internal/cli/`：全包通过（唯一失败为 `TestMiddleClickUsesPrimarySelectionOutsideTmux`，xclip 环境性失败，改动前后均失败，与本次无关）。
- `go vet ./internal/cli/`：无告警。

## Documentation impact

Documentation-impact: none - docs/CLI.zh-CN.md 与 docs/CLI.md 的「启动会话」章节已正确记载 `reasonix --profile delivery --effort high` 用法，本次修复让实现与文档对齐，无需更新文档。

## Cache impact

Cache-impact: none - 仅 `internal/cli` 参数路由白名单一行改动，未触及 boot/tool/provider 等缓存敏感路径（`scripts/check-cache-impact.sh` 确认 no cache-sensitive prompt/tool files changed）。
Cache-guard: `go test ./internal/cli/ -run TestRunDispatchesProfileFlagToInteractiveSession` 为本次改动新增的守卫测试，覆盖无子命令 `--profile` 路由。
System-prompt-review: N/A - 不涉及 provider 可见系统提示词、记忆前缀、输出风格或 skill 索引变更。
