### PR TITLE
fix(release): restore v1.20.0 cross-platform gates / 恢复 v1.20.0 跨平台门禁

### DIFF
--- a/internal/agent/subagent_progress_test.go
+++ b/internal/agent/subagent_progress_test.go
@@ -896,7 +896,7 @@ func TestParallelTasksGroupLifecycleEvents(t *testing.T) {
 func TestParallelTasksGroupLifecycleCancelled(t *testing.T) {
 	rec := &recordSink{}
 	started := make(chan struct{})
-	task := newTestTaskTool(t, &blockingProvider{started: started}, tool.NewRegistry(), "sys", "", "", nil)
+	task := newTestTaskTool(t, &cancelBlockingProvider{started: started}, tool.NewRegistry(), "sys", "", "", nil)
 	parallel := NewParallelTasksTool(task, tool.NewRegistry())
 	ctx, cancel := context.WithCancel(withCallContext(context.Background(), "parallel-call", rec, nil, false))
 	defer cancel()
@@ -926,6 +926,19 @@ func TestParallelTasksGroupLifecycleCancelled(t *testing.T) {
 	if terminals != 1 {
 		t.Fatalf("group terminals = %d, want exactly one", terminals)
 	}
+}
+
+type cancelBlockingProvider struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (p *cancelBlockingProvider) Name() string { return "cancel-blocking" }
+
+func (p *cancelBlockingProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.once.Do(func() { close(p.started) })
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 // TestParallelTasksGroupLifecycleFailedOnValidation proves validation failures

--- a/internal/extension/sidecar/content.go
+++ b/internal/extension/sidecar/content.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"reasonix/internal/extension/protocol"
 )
@@ -27,17 +26,18 @@ const storeMaxEntries = 64
 type ExternalizedField = protocol.ExternalizedField
 
 type contentObject struct {
-	data      []byte
-	sha256    string
-	createdAt time.Time
+	data   []byte
+	sha256 string
+	order  uint64
 }
 
 // Store holds externalized content for exactly one sidecar connection. It is
 // session-scoped in memory only: refs expire with the connection, which is
 // why a read of an unknown ref answers content_ref_expired.
 type Store struct {
-	mu       sync.Mutex
-	contents map[string]contentObject
+	mu        sync.Mutex
+	contents  map[string]contentObject
+	nextOrder uint64
 }
 
 // NewStore returns an empty content store.
@@ -59,16 +59,17 @@ func (s *Store) Put(data []byte) (ref string, digest string, totalBytes int64, e
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.contents[ref] = contentObject{data: append([]byte(nil), data...), sha256: digest, createdAt: time.Now()}
+	s.nextOrder++
+	s.contents[ref] = contentObject{data: append([]byte(nil), data...), sha256: digest, order: s.nextOrder}
 	if len(s.contents) > storeMaxEntries {
 		var oldestRef string
-		var oldest time.Time
+		var oldestOrder uint64
 		for candidate, object := range s.contents {
 			if candidate == ref {
 				continue
 			}
-			if oldestRef == "" || object.createdAt.Before(oldest) {
-				oldestRef, oldest = candidate, object.createdAt
+			if oldestRef == "" || object.order < oldestOrder {
+				oldestRef, oldestOrder = candidate, object.order
 			}
 		}
 		delete(s.contents, oldestRef)

--- a/internal/pluginpkg/manifest_v1_test.go
+++ b/internal/pluginpkg/manifest_v1_test.go
@@ -398,13 +398,25 @@ func TestManifestV1PathSafety(t *testing.T) {
 			t.Fatalf("error = %v, want the traversal refusal", err)
 		}
 	})
-	t.Run("absolute path rejected", func(t *testing.T) {
-		root := t.TempDir()
-		writeV1Plugin(t, root, `{"apiVersion": "reasonix.io/plugin/v1", "name": "abs", "contributes": {"prompts": ["/etc/passwd"]}}`)
-		if _, _, err := ParseDir(root); err == nil || !strings.Contains(err.Error(), "must be relative and stay inside the plugin root") {
-			t.Fatalf("error = %v, want the absolute-path refusal", err)
-		}
-	})
+	for name, absolute := range map[string]string{
+		"unix":          "/etc/passwd",
+		"windows drive": `C:\Windows\System32\drivers\etc\hosts`,
+		"windows UNC":   `\\server\share\secret.txt`,
+	} {
+		t.Run(name+" absolute path rejected", func(t *testing.T) {
+			root := t.TempDir()
+			writeV1Plugin(t, root, jsonText(map[string]any{
+				"apiVersion": ManifestAPIVersionV1,
+				"name":       "abs",
+				"contributes": map[string]any{
+					"prompts": []string{absolute},
+				},
+			}))
+			if _, _, err := ParseDir(root); err == nil || !strings.Contains(err.Error(), "must be relative and stay inside the plugin root") {
+				t.Fatalf("error = %v, want the absolute-path refusal", err)
+			}
+		})
+	}
 	t.Run("symlink escape rejected", func(t *testing.T) {
 		outside := t.TempDir()
 		writeTestFile(t, filepath.Join(outside, "evil.md"), "evil")

--- a/internal/pluginpkg/pluginpkg.go
+++ b/internal/pluginpkg/pluginpkg.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -33,6 +34,7 @@ const (
 )
 
 var validName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`)
+var windowsAbsolutePath = regexp.MustCompile(`^[A-Za-z]:/`)
 
 // Package is one parsed plugin package rooted on disk.
 type Package struct {
@@ -742,15 +744,11 @@ func parseSkillPaths(raw json.RawMessage) ([]string, error) {
 func cleanPathList(paths []string) ([]string, error) {
 	var out []string
 	seen := map[string]bool{}
-	for _, p := range paths {
-		p = filepath.Clean(strings.TrimSpace(p))
-		if p == "." || p == "" {
-			p = "."
+	for _, raw := range paths {
+		slash, err := cleanPortableRelativePath(raw)
+		if err != nil {
+			return nil, err
 		}
-		if filepath.IsAbs(p) || strings.HasPrefix(p, ".."+string(filepath.Separator)) || p == ".." {
-			return nil, fmt.Errorf("plugin path %q must be relative and stay inside the plugin root", p)
-		}
-		slash := filepath.ToSlash(p)
 		if !seen[slash] {
 			seen[slash] = true
 			out = append(out, slash)
@@ -862,14 +860,28 @@ func validHookShell(shell string) bool {
 }
 
 func validateRelativePath(p string) error {
-	p = filepath.Clean(strings.TrimSpace(p))
-	if p == "" {
+	if strings.TrimSpace(p) == "" {
 		return fmt.Errorf("plugin path is required")
 	}
-	if filepath.IsAbs(p) || strings.HasPrefix(p, ".."+string(filepath.Separator)) || p == ".." {
-		return fmt.Errorf("plugin path %q must be relative and stay inside the plugin root", p)
+	_, err := cleanPortableRelativePath(p)
+	return err
+}
+
+// cleanPortableRelativePath applies the same manifest path contract on every
+// host OS. A plugin prepared on Windows must not turn a drive/UNC path into a
+// harmless-looking relative path on Unix, and a Unix-rooted path must remain
+// absolute when the same package is parsed on Windows.
+func cleanPortableRelativePath(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	normalized := strings.ReplaceAll(trimmed, `\`, "/")
+	if filepath.IsAbs(trimmed) || path.IsAbs(normalized) || windowsAbsolutePath.MatchString(normalized) {
+		return "", fmt.Errorf("plugin path %q must be relative and stay inside the plugin root", trimmed)
 	}
-	return nil
+	cleaned := path.Clean(normalized)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("plugin path %q must be relative and stay inside the plugin root", trimmed)
+	}
+	return cleaned, nil
 }
 
 func (p Package) SkillRoots() []string {

--- a/internal/serve/provider_setup_test.go
+++ b/internal/serve/provider_setup_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -101,7 +102,7 @@ func TestProviderSetupStoresRemoteCredentialAndRebuildsController(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("credential file mode = %o, want 600", info.Mode().Perm())
 	}
 

--- a/internal/taskmonitor/jsonstore_test.go
+++ b/internal/taskmonitor/jsonstore_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -262,6 +263,9 @@ func TestFileStore_WritablePathsUsePrivateModes(t *testing.T) {
 	}
 	if err := store.AppendAuditEvent(context.Background(), project, TaskEvent{TaskID: "t1", SessionID: "s", EventType: "state_change", State: TaskStateRunning, Timestamp: now}); err != nil {
 		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		return // Windows does not expose POSIX permission bits through os.FileMode.
 	}
 	checks := map[string]os.FileMode{
 		filepath.Join(project, ".reasonix", "tasks"):                        0o700,

--- a/internal/taskmonitor/tmux_test.go
+++ b/internal/taskmonitor/tmux_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -324,8 +325,11 @@ func TestTmuxAdapterReplacesLegacyMappingWithoutTrustingIt(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	legacy := `{"schema_version":1,"task_id":"t1","project_dir":"` + project + `","session":"legacy","window":"task","pane":"legacy:task.0"}`
-	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+	legacy, err := json.Marshal(TmuxMapping{SchemaVersion: 1, TaskID: "t1", ProjectDir: project, Session: "legacy", Window: "task", Pane: "legacy:task.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	mock := &tmuxMock{}
@@ -349,6 +353,9 @@ func TestTmuxAdapterWritesPrivateMappingFiles(t *testing.T) {
 	a := NewTmuxAdapterWithRunner(s, ".reasonix/tasks", &tmuxMock{})
 	if result := a.Attach(context.Background(), project, "t1", "demo"); result.Error != nil {
 		t.Fatal(result.Error)
+	}
+	if runtime.GOOS == "windows" {
+		return // Windows does not expose POSIX permission bits through os.FileMode.
 	}
 
 	for path, want := range map[string]os.FileMode{

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -163,6 +163,20 @@
         {
           "kind": "fixed",
           "title": {
+            "en": "Cross-platform Extension and Task Monitor Reliability",
+            "zh": "Extension 与任务监视器跨平台可靠性"
+          },
+          "body": {
+            "en": "Make content-reference eviction deterministic, reject Unix and Windows absolute plugin paths consistently, stabilize parallel-task cancellation, and restore reliable Windows validation for Task Monitor and remote provider setup.",
+            "zh": "让内容引用淘汰顺序保持确定，一致拒绝 Unix 与 Windows 绝对插件路径，稳定并行任务取消流程，并恢复任务监视器与远程提供者设置的可靠 Windows 验证。"
+          },
+          "refs": [
+            7625
+          ]
+        },
+        {
+          "kind": "fixed",
+          "title": {
             "en": "MiMo and DashScope Responses Wire Alignment",
             "zh": "MiMo 与 DashScope Responses 协议对齐"
           },
@@ -331,6 +345,19 @@
           }
         ],
         "fixed": [
+          {
+            "title": {
+              "en": "Cross-platform Extension and Task Monitor Reliability",
+              "zh": "Extension 与任务监视器跨平台可靠性"
+            },
+            "body": {
+              "en": "Make content-reference eviction deterministic, reject Unix and Windows absolute plugin paths consistently, stabilize parallel-task cancellation, and restore reliable Windows validation for Task Monitor and remote provider setup.",
+              "zh": "让内容引用淘汰顺序保持确定，一致拒绝 Unix 与 Windows 绝对插件路径，稳定并行任务取消流程，并恢复任务监视器与远程提供者设置的可靠 Windows 验证。"
+            },
+            "refs": [
+              7625
+            ]
+          },
           {
             "title": {
               "en": "MiMo and DashScope Responses Wire Alignment",


### PR DESCRIPTION
## Summary / 摘要

- Make Extension content-store eviction deterministic instead of relying on equal-resolution timestamps.
- Reject Unix, Windows drive, and UNC absolute plugin paths consistently on every host OS.
- Stabilize the parallel-task cancellation coverage test.
- Preserve functional Windows coverage while limiting POSIX mode assertions to platforms that expose those bits; serialize the legacy tmux fixture as valid JSON.

- 让 Extension 内容存储淘汰顺序保持确定，不再依赖可能同精度的时间戳。
- 在所有宿主系统上一致拒绝 Unix、Windows 盘符和 UNC 绝对插件路径。
- 稳定 parallel_tasks 取消场景的 Coverage 测试。
- Windows 继续覆盖功能路径，仅将 POSIX 权限位断言限制在可表达的平台，并用合法 JSON 序列化旧版 tmux fixture。

## Release blocker / 发布阻断

The exact v1.20.0 candidate CI exposed deterministic Windows failures after the Task Monitor and Extension merges, plus a coverage-only cancellation race. This PR clears those gates; the stable release remains blocked until the merged candidate is fully green.

v1.20.0 精确候选 CI 在 Task Monitor 与 Extension 合入后暴露出确定性的 Windows 失败，以及仅在 Coverage 调度下出现的取消竞态。本 PR 用于清除这些门禁；合并后候选全绿之前仍不发布稳定版。

## Verification / 验证

- `go test -covermode=atomic ./...`
- `go test -race` for agent, extension sidecar, plugin package, Task Monitor, and Serve
- `go vet ./...`
- Cancellation test: 100 consecutive passes
- FIFO eviction test: 1,000 consecutive passes
- Windows test-binary cross-compilation for every changed package