### PR TITLE
fix(release): tolerate npm registry visibility lag / 容忍 npm 注册表可见性延迟

### DIFF
--- a/npm/publish.mjs
+++ b/npm/publish.mjs
@@ -295,7 +295,10 @@ export function publishPackages({
   candidateSha,
   runner = defaultRunner,
   sleep = defaultSleep,
-  attempts = 6,
+  // npm's public registry can lag a successful immutable publish by several
+  // minutes. Keep this bounded, but allow enough time for normal replication
+  // before recovery treats the package as missing.
+  attempts = 31,
   log = console.log,
 }) {
   if (!Array.isArray(packages) || packages.length === 0) {

--- a/npm/publish.test.mjs
+++ b/npm/publish.test.mjs
@@ -16,7 +16,11 @@ function splitPackageSpec(spec) {
   return [spec.slice(0, separator), spec.slice(separator + 1)];
 }
 
-function fixture(t, version = "1.5.0-canary.42", { forbidCleanup = false } = {}) {
+function fixture(
+  t,
+  version = "1.5.0-canary.42",
+  { forbidCleanup = false, visibilityDelayReads = 0 } = {},
+) {
   const root = mkdtempSync(join(tmpdir(), "reasonix-npm-publish-test-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
 
@@ -33,6 +37,7 @@ function fixture(t, version = "1.5.0-canary.42", { forbidCleanup = false } = {})
     packages.map(({ name }) => [name, { versions: new Map(), tags: new Map() }]),
   );
   const calls = [];
+  const hiddenReads = new Map();
 
   function packageState(name) {
     if (!registry.has(name)) {
@@ -51,6 +56,12 @@ function fixture(t, version = "1.5.0-canary.42", { forbidCleanup = false } = {})
     }
     if (args[0] === "view") {
       const [name, requestedVersion] = splitPackageSpec(args[1]);
+      const packageSpec = `${name}@${requestedVersion}`;
+      const remainingHiddenReads = hiddenReads.get(packageSpec) ?? 0;
+      if (remainingHiddenReads > 0) {
+        hiddenReads.set(packageSpec, remainingHiddenReads - 1);
+        return missingOk ? null : "";
+      }
       const metadata = registry.get(name)?.versions.get(requestedVersion);
       return metadata ? JSON.stringify(metadata) : missingOk ? null : "";
     }
@@ -67,6 +78,7 @@ function fixture(t, version = "1.5.0-canary.42", { forbidCleanup = false } = {})
         gitHead: pkg.reasonixCandidateSha,
       });
       state.tags.set(args[args.indexOf("--tag") + 1], pkg.version);
+      hiddenReads.set(`${pkg.name}@${pkg.version}`, visibilityDelayReads);
       return "";
     }
     if (args[0] === "dist-tag" && args[1] === "add") {
@@ -85,16 +97,17 @@ function fixture(t, version = "1.5.0-canary.42", { forbidCleanup = false } = {})
     throw new Error(`unsupported fake npm invocation: ${args.join(" ")}`);
   }
 
-  function publish() {
-    return publishPackages({
+  function publish({ attempts = 2 } = {}) {
+    const options = {
       packages,
       version,
       candidateSha,
       runner,
       sleep: () => {},
-      attempts: 2,
       log: () => {},
-    });
+    };
+    if (attempts !== null) options.attempts = attempts;
+    return publishPackages(options);
   }
 
   function addVersion(name, publishedVersion = version, sha = candidateSha) {
@@ -138,6 +151,15 @@ test("fills a partially published package set before advancing canary", (t) => {
   for (const { name } of fx.packages) {
     assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.42");
     assert.equal(fx.registry.get(name).tags.has("canary-staging"), false);
+  }
+});
+
+test("waits through multi-minute npm registry visibility lag", (t) => {
+  const fx = fixture(t, "1.5.0-canary.42", { visibilityDelayReads: 18 });
+
+  assert.doesNotThrow(() => fx.publish({ attempts: null }));
+  for (const { name } of fx.packages) {
+    assert.equal(fx.registry.get(name).tags.get("canary"), "1.5.0-canary.42");
   }
 });
 


### PR DESCRIPTION
## Summary / 摘要

- Extend the bounded npm registry visibility window from 50 seconds to 5 minutes after a successful immutable package publish.
- Add regression coverage that simulates a 3-minute visibility delay.

## Why / 原因

The v1.20.0 publisher successfully uploaded its first platform package, but the registry did not expose it within the previous window, so publication stopped before the remaining packages. This control-plane fix leaves the immutable v1.20.0 candidate tags and product artifacts unchanged.

v1.20.0 的首个平台包已上传成功，但 npm 注册表未在原有窗口内变为可见，导致其余包未继续发布。此修复只调整受保护发布控制面，不移动 v1.20.0 的不可变候选标签，也不修改产品产物。

Documentation-impact: none - This changes only the internal release control-plane retry window; existing user-facing documentation remains correct.

## Validation / 验证

- `node --test npm/*.test.mjs`
- `git diff --check`