### PR TITLE
fix(agent): bill recovery retries separately so the context gauge sees clean usage / 重试尝试单独计费，上下文窗口与压缩判定不再被翻倍 usage 污染

### DIFF
--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -535,8 +535,27 @@ func TestRunSilentlyRecoversMissingToolCallReasoning(t *testing.T) {
 		t.Fatalf("tool dispatches = %d, want one adopted call", got)
 	}
 	usageEvents := sink.kinds(event.Usage)
-	if len(usageEvents) == 0 || usageEvents[0].Usage == nil || usageEvents[0].Usage.TotalTokens != 25 || usageEvents[0].Usage.CacheHitTokens != 10 || usageEvents[0].Usage.CacheMissTokens != 10 {
-		t.Fatalf("recovery usage was not merged truthfully: %+v", usageEvents)
+	// Billing stays truthful across two separate attempt events (12 + 13), no
+	// single record carries the old summed total, and the adopted retry's clean
+	// usage — not the doubled prompt — feeds lastUsage (#7620).
+	var usageTotal int
+	var sawHit, sawMiss bool
+	for _, e := range usageEvents {
+		if e.Usage == nil {
+			continue
+		}
+		usageTotal += e.Usage.TotalTokens
+		sawHit = sawHit || e.Usage.CacheHitTokens > 0
+		sawMiss = sawMiss || e.Usage.CacheMissTokens > 0
+		if e.Usage.TotalTokens == 25 {
+			t.Fatalf("recovery usage still merged into one record: %+v", usageEvents)
+		}
+	}
+	if usageTotal != 25 || !sawHit || !sawMiss {
+		t.Fatalf("recovery billing total = %d hit=%v miss=%v, want 25 across separate events: %+v", usageTotal, sawHit, sawMiss, usageEvents)
+	}
+	if u := a.LastUsage(); u == nil || u.PromptTokens != 10 {
+		t.Fatalf("lastUsage = %+v, want the retry's clean prompt (10), not the summed 20", u)
 	}
 	if sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted) != 1 || sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryRecovered) != 1 {
 		t.Fatalf("unexpected recovery audit: %+v", sink.recovery)
@@ -587,8 +606,16 @@ func TestMissingReasoningRecoveryAdoptsRetryWithoutToolCall(t *testing.T) {
 		t.Fatalf("discarded tool dispatches = %d, want 0", got)
 	}
 	usageEvents := sink.kinds(event.Usage)
-	if len(usageEvents) == 0 || usageEvents[0].Usage == nil || usageEvents[0].Usage.TotalTokens != 25 {
-		t.Fatalf("replacement usage was not merged truthfully: %+v", usageEvents)
+	// Billing stays truthful across two separate attempt events (12 + 13) while
+	// no single record carries the old summed total (#7620).
+	var usageTotal int
+	for _, e := range usageEvents {
+		if e.Usage != nil {
+			usageTotal += e.Usage.TotalTokens
+		}
+	}
+	if usageTotal != 25 {
+		t.Fatalf("replacement usage total = %d, want 25 across separate events: %+v", usageTotal, usageEvents)
 	}
 	if sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted) != 1 ||
 		sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryReplaced) != 1 ||
@@ -626,8 +653,20 @@ func TestMissingReasoningRecoveryFailureFallsBackBeforeToolExecution(t *testing.
 		t.Fatalf("tool results = %d, want the original call executed once", toolResults)
 	}
 	usageEvents := sink.kinds(event.Usage)
-	if len(usageEvents) == 0 || usageEvents[0].Usage == nil || usageEvents[0].Usage.TotalTokens != 23 {
-		t.Fatalf("failed recovery usage was not accounted for: %+v", usageEvents)
+	// The adopted first attempt (12) rides the turn's own usage event; the
+	// failed retry (11) is billed as its own separate event — no summed
+	// record (#7620).
+	var usageTotal int
+	for _, e := range usageEvents {
+		if e.Usage != nil {
+			usageTotal += e.Usage.TotalTokens
+		}
+	}
+	if usageTotal != 23 {
+		t.Fatalf("failed recovery usage total = %d, want 23 across separate events: %+v", usageTotal, usageEvents)
+	}
+	if u := a.LastUsage(); u == nil || u.PromptTokens != 10 {
+		t.Fatalf("lastUsage = %+v, want the adopted first attempt's clean prompt (10), not the summed 23", u)
 	}
 	if sink.recoveryCount(event.ProtocolRecoveryMissingReasoningFallback) != 1 {
 		t.Fatalf("fallback audit missing: %+v", sink.recovery)
@@ -659,8 +698,20 @@ func TestMissingReasoningRecoveryCancellationAccountsBothAttempts(t *testing.T) 
 		t.Fatalf("discarded tool dispatches = %d, want 0", got)
 	}
 	usages := sink.kinds(event.Usage)
-	if len(usages) != 1 || usages[0].Usage == nil || usages[0].Usage.TotalTokens != 23 || usages[0].Usage.FinishReason != "interrupted" {
-		t.Fatalf("recovery cancellation usage = %+v, want one merged interrupted total of 23", usages)
+	// The cancelled turn bills both attempts as separate events (12 + 11) — the
+	// first here, the interrupted retry via the returned usage — so the total
+	// stays truthful without a summed record (#7620).
+	var usageTotal int
+	var sawInterrupted bool
+	for _, e := range usages {
+		if e.Usage == nil {
+			continue
+		}
+		usageTotal += e.Usage.TotalTokens
+		sawInterrupted = sawInterrupted || e.Usage.FinishReason == "interrupted"
+	}
+	if len(usages) != 2 || usageTotal != 23 || !sawInterrupted {
+		t.Fatalf("recovery cancellation usage = %+v, want two attempts totaling 23 with one interrupted", usages)
 	}
 }
 

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -400,10 +400,24 @@ func (a *Agent) streamWithMissingReasoningRecovery(ctx context.Context, turn int
 			streamSink.Discard()
 			// The recovery stream was intentionally invisible, so do not persist
 			// partial retry text/reasoning as though the user had already seen it.
-			return streamedTurn{usage: mergeStreamUsage(first.usage, retry.usage), err: retry.err}
+			// The discarded first attempt is billed here; the failed retry's own
+			// usage rides the returned turn (emitTurnUsage emits it when present,
+			// and the request-only fallback below keeps the request count
+			// truthful when the retry produced no usage).
+			a.emitRecoveryAttemptUsage(first.usage)
+			if retry.usage == nil {
+				a.emitRecoveryAttemptUsage(nil)
+			}
+			return streamedTurn{usage: retry.usage, err: retry.err}
 		}
 		streamSink.Flush()
-		first.usage = mergeStreamUsage(first.usage, retry.usage)
+		// The retry failed and the first response is structurally valid, so it
+		// stays the adopted turn. The failed retry's call is billed here (a
+		// request-only record when it produced no usage); the adopted first
+		// attempt's clean usage rides the returned turn through emitTurnUsage,
+		// so the context gauge and compaction decision never see a summed
+		// prompt (#7620).
+		a.emitRecoveryAttemptUsage(retry.usage)
 		if first.usage != nil {
 			a.lastUsage.Store(first.usage)
 		}
@@ -413,10 +427,13 @@ func (a *Agent) streamWithMissingReasoningRecovery(ctx context.Context, turn int
 
 	streamSink.Discard()
 	retrySink.Flush()
-	retry.usage = mergeStreamUsage(first.usage, retry.usage)
-	if retry.usage != nil {
-		a.lastUsage.Store(retry.usage)
-	}
+	// The retry's usage alone describes the window: both attempts send the
+	// byte-identical prompt, so the retry's prompt tokens are the real context
+	// fill. The first attempt's tokens are billed as a separate event below;
+	// the old merged-sum record doubled the reported prompt and could trip
+	// auto-compaction at half the real usage (#7620). runToolLoop's
+	// emitTurnUsage stores this clean usage in lastUsage.
+	a.emitRecoveryAttemptUsage(first.usage)
 	retryMissing, _ := a.observeMissingToolCallReasoning(retry.calls, retry.reasoning)
 	if retryMissing {
 		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
@@ -442,42 +459,22 @@ func (a *Agent) streamTurn(ctx context.Context, turn int, sink event.Sink) strea
 	}
 }
 
-func mergeStreamUsage(first, retry *provider.Usage) *provider.Usage {
-	if first == nil && retry == nil {
-		return nil
+// emitRecoveryAttemptUsage bills one discarded recovery attempt as its own
+// usage event. The missing-reasoning retry discards the first attempt's stream
+// events, but the provider still billed that call, so session cost and request
+// totals must see it. A nil usage (no terminal usage chunk) still records the
+// request (request-only, RequestCount=1) that stats persist while frontends
+// ignore. Unlike emitTurnUsage this never writes lastUsage: the context gauge
+// and compaction decision must reflect the adopted attempt's real prompt, not
+// a billing sum (#7620).
+func (a *Agent) emitRecoveryAttemptUsage(usage *provider.Usage) {
+	if usage == nil || (usage.TotalTokens <= 0 && usage.RequestCount <= 0) {
+		a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef,
+			Usage: &provider.Usage{RequestCount: 1}, Pricing: a.pricing, UsageSource: a.usageSource})
+		return
 	}
-	if first == nil {
-		merged := *retry
-		// The first provider request still happened even if its terminal usage
-		// chunk was lost. Preserve the retry's known tokens and count both calls.
-		merged.RequestCount = 1 + usageRequestCount(retry)
-		return &merged
-	}
-	if retry == nil {
-		merged := *first
-		// Likewise, a failed recovery request without usage is still an API call.
-		merged.RequestCount = usageRequestCount(first) + 1
-		return &merged
-	}
-	merged := *retry
-	merged.PromptTokens += first.PromptTokens
-	merged.CompletionTokens += first.CompletionTokens
-	merged.TotalTokens += first.TotalTokens
-	merged.CacheHitTokens += first.CacheHitTokens
-	merged.CacheMissTokens += first.CacheMissTokens
-	merged.ReasoningTokens += first.ReasoningTokens
-	merged.RequestCount = usageRequestCount(first) + usageRequestCount(retry)
-	return &merged
-}
-
-func usageRequestCount(usage *provider.Usage) int {
-	if usage == nil {
-		return 0
-	}
-	if usage.RequestCount > 0 {
-		return usage.RequestCount
-	}
-	return 1
+	a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef,
+		Usage: usage, Pricing: a.pricing, UsageSource: a.usageSource})
 }
 
 func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiagnostics) {

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -37,33 +37,35 @@ func (failedRequestProvider) Stream(ctx context.Context, _ provider.Request) (<-
 	return nil, err
 }
 
-func TestMergeStreamUsageCountsProviderRequests(t *testing.T) {
-	first := &provider.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
-	retry := &provider.Usage{PromptTokens: 20, CompletionTokens: 8, TotalTokens: 28}
-	got := mergeStreamUsage(first, retry)
-	if got == nil || got.TotalTokens != 43 || got.RequestCount != 2 {
-		t.Fatalf("merged usage = %+v, want total=43 requests=2", got)
-	}
+func TestEmitRecoveryAttemptUsageAccountsBillingOnly(t *testing.T) {
+	var events []event.Event
+	sink := event.FuncSink(func(e event.Event) { events = append(events, e) })
+	a := New(failedRequestProvider{}, tool.NewRegistry(), NewSession(""), Options{ModelRef: "recovery/model"}, sink)
 
-	third := &provider.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2}
-	got = mergeStreamUsage(got, third)
-	if got.RequestCount != 3 {
-		t.Fatalf("nested merged request count = %d, want 3", got.RequestCount)
-	}
+	// An attempt with real tokens is billed as its own event and never touches
+	// lastUsage: the context gauge and compaction decision read the adopted
+	// attempt's clean numbers, not a billing sum (#7620).
+	a.emitRecoveryAttemptUsage(&provider.Usage{PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12, CacheMissTokens: 10})
+	// A nil attempt (no terminal usage chunk) still records the provider call
+	// as a request-only event; stats persist it while frontends ignore it.
+	a.emitRecoveryAttemptUsage(nil)
+	// An attempt whose stream failed before usage still billed the request.
+	a.emitRecoveryAttemptUsage(&provider.Usage{RequestCount: 1})
 
-	got = mergeStreamUsage(nil, retry)
-	if got == nil || got.TotalTokens != retry.TotalTokens || got.RequestCount != 2 {
-		t.Fatalf("missing first usage = %+v, want retry tokens and 2 requests", got)
+	if len(events) != 3 {
+		t.Fatalf("recovery attempt events = %d, want 3: %+v", len(events), events)
 	}
-	got = mergeStreamUsage(first, nil)
-	if got == nil || got.TotalTokens != first.TotalTokens || got.RequestCount != 2 {
-		t.Fatalf("missing retry usage = %+v, want first tokens and 2 requests", got)
+	if events[0].Kind != event.Usage || events[0].Usage == nil ||
+		events[0].Usage.TotalTokens != 12 || events[0].Usage.PromptTokens != 10 {
+		t.Fatalf("first attempt event = %+v, want the attempt's own tokens", events[0])
 	}
-
-	requestOnly := &provider.Usage{RequestCount: 3}
-	got = mergeStreamUsage(first, requestOnly)
-	if got == nil || got.TotalTokens != first.TotalTokens || got.RequestCount != 4 {
-		t.Fatalf("request-only retry usage = %+v, want first tokens and 4 requests", got)
+	for _, e := range events[1:] {
+		if e.Usage == nil || e.Usage.TotalTokens != 0 || e.Usage.RequestCount != 1 {
+			t.Fatalf("request-only event = %+v, want total=0 requests=1", e)
+		}
+	}
+	if a.LastUsage() != nil {
+		t.Fatalf("recovery accounting updated lastUsage to %+v, want untouched", a.LastUsage())
 	}
 }
 


### PR DESCRIPTION
## Summary

**Problem.** Reasonix can intermittently double-report the context window fill, and — worse — auto-compaction can fire at roughly half the real usage. Issue #7620 reports the context window value jumping from ~200K to 700K+ and sessions being compacted unexpectedly. Both symptoms trace back to one root cause: when the silent missing-reasoning recovery (introduced in v1.19.4 via #7259) replays the byte-identical request, `mergeStreamUsage` **summed** the two attempts' `PromptTokens`/`CompletionTokens`/`TotalTokens` into a single per-turn usage record. That record was then written into `lastUsage`, which feeds both:
- `ContextSnapshot` — the status bar / desktop gauge renders the doubled fill;
- `maybeCompact` — compaction triggers at `PromptTokens >= compact_ratio × window`, so a session at ~40% reports 80% and gets compacted (users in #7620 observed the exact "jump → prune ~10k tokens → compact → drop back to ~20%" sequence).

The sum was intentional for **billing** (both HTTP calls are billed by the provider; the original test asserted 12+13=25), but it was applied to the same per-turn record the window gauge and the compaction decision read.

**Fix.** Separate the billing view from the window view:
- The discarded attempt's usage is now emitted as its own `Usage` event (`emitRecoveryAttemptUsage`, with a request-only `RequestCount=1` record when the attempt produced no terminal usage), so session cost and request totals are preserved exactly — consumers (stats recorder, desktop telemetry, run metrics, pricing, cache deltas) accumulate the two events to the same totals as before (12+13=25, 2 requests, cache hit/miss preserved via the `cacheTokenDelta` fallback path).
- The adopted attempt's **clean** usage is the only thing that reaches `lastUsage` and `maybeCompact`. Both attempts send the byte-identical prompt, so the adopted attempt's prompt tokens are the real context fill.
- `mergeStreamUsage` and its sum-assertion test are deleted; new tests assert per-attempt billing and that `lastUsage` stays clean.

**Known, unfixed display-layer issue.** The same report shows a 3.5× value jump and an "other" breakdown bucket far above the prompt share (screenshot in #7620: used=546.9K with prompt=237.7K). Those numbers cannot come from a single usage record — the "other" bucket is `used − known`, which is always 0 for one record — so the desktop display is mixing records from different moments or tabs (async context fetch racing usage events, or cross-tab contamination while three sessions run concurrently). This display-layer mechanism is not yet localized and is intentionally out of scope here; it needs runtime logs to pin down. This PR fixes only the confirmed agent-side doubling.

## Issues

Refs #7620

This PR fixes the confirmed agent-side root cause of #7620: the recovery-retry
usage doubling that doubles the reported context fill and can trigger
auto-compaction at half the real usage. The display-layer issue described in
#7620 (3.5× jumps, inflated "other" breakdown) is not localized yet and stays
open for follow-up — see the Summary above. The issue should remain open until
the reporter verifies both symptoms are gone.

## Verification

- `go test ./internal/agent/` — full package, including the updated recovery e2e tests and the new `TestEmitRecoveryAttemptUsageAccountsBillingOnly`
- `go test ./internal/provider/ ./internal/stats/ ./internal/eventwire/ ./internal/control/ ./internal/cli/`
- `go test ./...` — one pre-existing environment flake in `internal/boot` (`TestBuildFoldsProjectMemoryIntoSystemPrompt` fails identically without this change; tool-trust detection reports nothing in this sandbox)
- `gofmt -l .` clean; `go vet ./...` clean

Documentation-impact: none - internal usage accounting only; no user-visible CLI/desktop/config behavior changes and no docs describe the merged-sum record

## Cache impact

Cache-impact: none - no provider-visible request, tool schema, or prompt construction changes; the recovery retry already sent the byte-identical request

Cache-guard: existing e2e tests keep the retry request byte-identical (loop_e2e_test.go asserts reflect.DeepEqual on the provider-visible requests)

System-prompt-review: N/A

## Summary

**问题。** Reasonix 会偶发地把上下文窗口占用显示为真实值的两倍，更严重的是——自动压缩可能在真实用量只有一半时就触发。Issue #7620 报告上下文窗口数值从约 20 万突变为 70 万+，会话被意外压缩。两个症状同源：v1.19.4 经 #7259 引入的 missing-reasoning 静默恢复会原样重放请求，而 `mergeStreamUsage` 把两次尝试的 `PromptTokens`/`CompletionTokens`/`TotalTokens` **相加**成一条单次 usage 记录，再写入 `lastUsage`，而后者同时驱动：
- `ContextSnapshot`——状态栏/桌面仪表盘渲染出翻倍的占用；
- `maybeCompact`——压缩判定为 `PromptTokens >= compact_ratio × window`，于是真实占用约 40% 的会话上报 80% 并被压缩（#7620 用户观察到的正是"跳高 → 裁剪约 10k → 压缩 → 回落到约 20%"的完整序列）。

求和是**计费**的刻意设计（两次 HTTP 调用都会被计费，原测试断言 12+13=25），但它被错误地作用在了窗口占用与压缩判定所读取的同一条单次记录上。

**修复。** 将计费口径与窗口口径分离：
- 被丢弃尝试的 usage 以独立的 `Usage` 事件发出（`emitRecoveryAttemptUsage`，无终态 usage 时发出 `RequestCount=1` 的 request-only 记录），会话费用与请求总数被精确保留——消费端（stats 记录器、桌面遥测、运行指标、定价、缓存增量）把两个事件累加后与原合并值完全等价（12+13=25、2 次请求、缓存命中/未命中经 `cacheTokenDelta` 回退路径保留）。
- 被采用尝试的**干净** usage 是唯一进入 `lastUsage` 与 `maybeCompact` 的值——两次尝试发送的是完全相同的 prompt，被采用尝试的 prompt tokens 就是真实的窗口占用。
- 删除 `mergeStreamUsage` 及其求和断言测试；新增测试断言按尝试计费且 `lastUsage` 保持干净。

**已知但未修复的显示层问题。** 同一报告中还有 3.5× 数值跳变与远高于提示词占比的"其他"分项（#7620 截图：used=546.9K 而 prompt=237.7K）。这些数值不可能来自同一条 usage 记录——"其他"分项是 `used − known`，对任何单条记录恒为 0——说明桌面端显示在混合不同时刻或不同标签页的记录（异步 context 抓取与 usage 事件竞态，或三个会话并发时的跨标签页污染）。该显示层机制尚未定位，刻意不在本次范围内；需要运行时日志才能锁定。本 PR 只修复已确认的 agent 侧翻倍。

## Issues

Refs #7620

本 PR 修复了 #7620 中已确认的 agent 侧根因：恢复重试的 usage 翻倍导致上下文占用显示翻倍、并可能在真实用量一半时触发自动压缩。#7620 中描述的显示层问题（3.5× 跳变、"其他"分项异常）尚未定位，保持打开以跟踪后续修复——详见上文 Summary。请保持 issue 打开，直至报告者确认两个症状都已消失。

## Verification

- `go test ./internal/agent/` —— 全量，含更新后的恢复 e2e 测试与新增 `TestEmitRecoveryAttemptUsageAccountsBillingOnly`
- `go test ./internal/provider/ ./internal/stats/ ./internal/eventwire/ ./internal/control/ ./internal/cli/`
- `go test ./...` —— 仅一个既有环境 flake（`internal/boot` 的 `TestBuildFoldsProjectMemoryIntoSystemPrompt`，无本改动时同样失败；沙箱中工具信任检测为空）
- `gofmt -l .` 干净；`go vet ./...` 干净

Documentation-impact: none - 仅内部 usage 记账；无用户可见的 CLI/桌面/配置行为变化，也无文档描述合并求和记录

## Cache impact

Cache-impact: none - 无 provider 可见请求、工具 schema 或 prompt 构造变化；恢复重试本就发送字节一致的请求

Cache-guard: 既有 e2e 测试保持重试请求字节一致（loop_e2e_test.go 对 provider 可见请求断言 reflect.DeepEqual）

System-prompt-review: N/A