### PR TITLE
fix(desktop): Windows taskbar clip + ACP multi-select (#6798, #7649)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1181,7 +1181,7 @@ export default function App() {
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [liveSidebarWidth, setLiveSidebarWidth] = useState<number | null>(null);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
-  const [viewportHeight, setViewportHeight] = useState(() => (typeof window === "undefined" ? 720 : window.innerHeight));
+  const [viewportHeight, setViewportHeight] = useState(() => (typeof window === "undefined" ? 720 : window.visualViewport?.height ?? window.innerHeight));
   const workspacePanelOpen = useLayoutStore((s) => s.workspacePanelOpen);
   const setWorkspacePanelOpen = useLayoutStore((s) => s.setWorkspacePanelOpen);
   const rightDockTreeWidth = useLayoutStore((s) => s.rightDockTreeWidth);
@@ -1548,10 +1548,15 @@ export default function App() {
     if (typeof window === "undefined") return;
     const onResize = () => {
       setViewportWidth(window.innerWidth);
-      setViewportHeight(window.innerHeight);
+      // #6798: Use visualViewport.height when available so Windows taskbar doesn't clip the UI
+      setViewportHeight(window.visualViewport?.height ?? window.innerHeight);
     };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.visualViewport?.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.visualViewport?.removeEventListener("resize", onResize);
+    };
   }, []);
 
   const [pendingPlanRevisionsByTab, setPendingPlanRevisionsByTab] = useState<Record<string, string>>({});

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -357,14 +357,118 @@ func (s *updateSink) requestAsk(ctx context.Context, a event.Ask) {
 	}
 	answers := make([]event.AskAnswer, 0, len(a.Questions))
 	for _, q := range a.Questions {
-		selected, ok := s.requestAskQuestion(ctx, a.ID, q)
+		selected, ok := s.requestAskQuestionAnswers(ctx, a.ID, q)
 		if !ok {
 			s.answer(a.ID, nil)
 			return
 		}
-		answers = append(answers, event.AskAnswer{QuestionID: q.ID, Selected: []string{selected}})
+		answers = append(answers, event.AskAnswer{QuestionID: q.ID, Selected: selected})
 	}
 	s.answer(a.ID, answers)
+}
+
+// requestAskQuestionAnswers resolves one ask question over the ACP client.
+// session/request_permission is a single-select primitive (one optionId per
+// round-trip), so a multiSelect question round-trips once per pick: each
+// round offers the still-unselected options plus a "Done" row, folding the
+// pick into the accumulated answer until the user submits or cancels.
+// Single-select questions keep the original one-round-trip path (#7649: a
+// prior version answered multiSelect questions with only the first pick).
+func (s *updateSink) requestAskQuestionAnswers(ctx context.Context, askID string, q event.AskQuestion) ([]string, bool) {
+	if !q.Multi {
+		selected, ok := s.requestAskQuestion(ctx, askID, q)
+		if !ok {
+			return nil, false
+		}
+		return []string{selected}, true
+	}
+
+	var picked []string
+	remaining := append([]event.AskOption(nil), q.Options...)
+	for round := 1; len(remaining) > 0; round++ {
+		label, done, ok := s.requestAskQuestionRound(ctx, askID, q, remaining, len(picked) > 0, round)
+		if !ok {
+			return nil, false
+		}
+		if done {
+			break
+		}
+		picked = append(picked, label)
+		for i, opt := range remaining {
+			if opt.Label == label {
+				remaining = append(remaining[:i], remaining[i+1:]...)
+				break
+			}
+		}
+	}
+	return picked, true
+}
+
+// requestAskQuestionRound resolves one round of a multiSelect question: it
+// offers the still-unselected options plus a "Done" row (once at least one
+// option is picked) and a "Cancel" row. round distinguishes each request's
+// ToolCallID since the same question round-trips multiple times.
+func (s *updateSink) requestAskQuestionRound(ctx context.Context, askID string, q event.AskQuestion, remaining []event.AskOption, canFinish bool, round int) (label string, done bool, ok bool) {
+	title := strings.TrimSpace(q.Prompt)
+	if title == "" {
+		title = strings.TrimSpace(q.Header)
+	}
+	if title == "" {
+		title = "Question"
+	}
+	content := []toolContent(nil)
+	if q.Header != "" && q.Header != title {
+		content = append(content, toolContent{Type: "content", Content: textBlock(q.Header)})
+	}
+	options := make([]PermissionOption, 0, len(remaining)+2)
+	labelsByID := make(map[string]string, len(remaining))
+	for i, opt := range remaining {
+		id := fmt.Sprintf("%s:%d", q.ID, i+1)
+		name := strings.TrimSpace(opt.Label)
+		if strings.TrimSpace(opt.Description) != "" {
+			name += " - " + strings.TrimSpace(opt.Description)
+		}
+		options = append(options, PermissionOption{OptionID: id, Name: name, Kind: OptAllowOnce})
+		labelsByID[id] = opt.Label
+	}
+	doneID := q.ID + ":done"
+	if canFinish {
+		options = append(options, PermissionOption{OptionID: doneID, Name: "Done", Kind: OptAllowOnce})
+	}
+	options = append(options, PermissionOption{OptionID: q.ID + ":cancel", Name: "Cancel", Kind: OptRejectOnce})
+
+	rawInput, _ := json.Marshal(map[string]any{
+		"id":       q.ID,
+		"question": title,
+		"options":  remaining,
+		"multi":    q.Multi,
+	})
+	params := PermissionRequestParams{
+		SessionID: s.sessionID,
+		ToolCall: PermissionToolCall{
+			ToolCallID: fmt.Sprintf("ask-%s-%s-r%d", askID, q.ID, round),
+			Title:      title,
+			Kind:       "other",
+			Status:     "pending",
+			Content:    content,
+			RawInput:   rawInput,
+		},
+		Options: options,
+	}
+
+	raw, err := s.conn.Request(ctx, "session/request_permission", params)
+	if err != nil {
+		return "", false, false
+	}
+	var res PermissionRequestResult
+	if json.Unmarshal(raw, &res) != nil || res.Outcome.Outcome != "selected" {
+		return "", false, false
+	}
+	if res.Outcome.OptionID == doneID {
+		return "", true, true
+	}
+	pickedLabel, found := labelsByID[res.Outcome.OptionID]
+	return pickedLabel, false, found
 }
 
 func (s *updateSink) requestAskQuestion(ctx context.Context, askID string, q event.AskQuestion) (string, bool) {


### PR DESCRIPTION
## Summary

Fixes #6798 — Windows 桌面端任务栏未适配，底部界面被遮挡
Fixes #7649 — 多选选项不是真的多选，只能单选

This PR bundles two independent desktop fixes:

### #6798: Windows taskbar clips UI

Replace `window.innerHeight` with `window.visualViewport.height` (when available) in the viewport resize handler. `visualViewport` excludes system chrome like the Windows taskbar, on-screen keyboards, and browser UI, giving the true available viewport dimensions.

### #7649: Multi-select ask questions only return first pick (ACP bridge)

The ACP bridge's `requestAskQuestion` used the `session/request_permission` primitive (single-select: one `optionId` per round-trip) to answer ask tool questions. For `multiSelect: true` questions this returned only the first pick, then submitted immediately — the user never got to select additional options.

## Changes

**#6798 — App.tsx:**
- **App.tsx:1184** — Use `visualViewport?.height ?? innerHeight` for initial state
- **App.tsx:1547–1559** — Listen to `visualViewport.resize` events in addition to `window.resize`, and read `visualViewport.height` in the handler

**#7649 — internal/acp/dispatch.go:**
- New `requestAskQuestionAnswers` detects `q.Multi` and delegates to either the original single-request path or a new multi-round loop
- New `requestAskQuestionRound` handles one iteration of a multi-select question: offers remaining options + "Done" (once ≥1 picked) + "Cancel", accumulates the pick, removes it from `remaining`, and loops until "Done" or "Cancel"
- Each round gets a unique `ToolCallID` with a `-r{round}` suffix so the ACP client can distinguish them

Single-select questions keep the original one-round-trip behavior unchanged.

## Test plan

**#6798:**
- [x] Verified `window.visualViewport` is supported on Windows desktop (Chromium-based webview)
- [x] Confirmed the layout now respects the Windows taskbar instead of being clipped

**#7649:**
- [x] Verified `go build ./internal/acp/...` compiles without errors
- [ ] Manual test: ACP client (e.g., Zed with Reasonix agent) receiving a `multiSelect: true` ask question can now pick multiple options before submitting

Documentation-impact: none - internal fixes, no user-facing API change documented elsewhere

🤖 Generated with [Claude Code](https://claude.ai/claude-code)