### PR TITLE
fix(cli): land independent CLI feedback PRs / 合入可独立验证的 CLI 反馈小 PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ branch.
 
 ### Added
 
+- Added `[ui].show_turn_usage` so CLI/TUI users can hide per-request token and
+  cost receipts from transcript scrollback without disabling usage accounting.
 - Added Extension Protocol v1 and the unified extension kernel: installed or
   linked sidecars can contribute tools, skills, commands, hooks, MCP servers,
   providers, interceptors, and structured UI surfaces through a versioned

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,7 +138,7 @@ echo "explain this code" | reasonix run
 
 `reasonix run` keeps the normal streamed terminal presentation unless `-p` or a
 structured output format is selected. It also accepts `--model`, `--profile`,
-`--max-steps`, `--effort`, `--dir`, `--add-dir`, `--continue`, `--resume PATH`,
+`--max-steps`, `--effort`, `--dir`, `--add-dir`, `--continue`, `--resume QUERY`,
 `--copy`, `--allowed-tools`, `--permission-mode`, and `--auto` / `-y` (an alias
 for `--permission-mode auto`).
 
@@ -286,9 +286,10 @@ reasonix --resume provider-config --copy
 - `--copy` leaves the original transcript untouched and continues in a new
   writable session. Use it when another Reasonix process owns the original.
 
-For one-shot runs, `reasonix run --resume PATH "task"` accepts a session file
-path. Session leases prevent the desktop app and CLI from writing the same
-transcript concurrently.
+For one-shot runs, `reasonix run --resume QUERY "task"` accepts a session file
+path, a session ID, or an opaque machine session ID from `--events-jsonl` /
+`reasonix session show --json`. Session leases prevent the desktop app and CLI
+from writing the same transcript concurrently.
 
 ## Permissions
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -125,7 +125,7 @@ echo "解释这段代码" | reasonix run
 
 未使用 `-p` 或结构化输出格式时，`reasonix run` 保持正常的终端流式展示。它也接受
 `--model`、`--profile`、`--max-steps`、`--effort`、`--dir`、`--add-dir`、
-`--continue`、`--resume PATH`、`--copy`、`--allowed-tools` 和
+`--continue`、`--resume QUERY`、`--copy`、`--allowed-tools` 和
 `--permission-mode`，以及作为 `--permission-mode auto` 别名的 `--auto` / `-y`。
 
 ### 基准对照组
@@ -260,8 +260,9 @@ reasonix --resume provider-config --copy
 - `--copy` 不修改原 transcript，而是在新的可写会话中继续。原会话已被另一个
   Reasonix 进程占用时可以使用它。
 
-一次性运行可用 `reasonix run --resume PATH "任务"` 指定 session 文件路径。Session
-lease 会阻止桌面端和 CLI 同时写入同一个 transcript。
+一次性运行可用 `reasonix run --resume QUERY "任务"`，支持 session 文件路径、
+session ID，或来自 `--events-jsonl` / `reasonix session show --json` 的不透明
+machine session ID。Session lease 会阻止桌面端和 CLI 同时写入同一个 transcript。
 
 ## 权限
 

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -74,6 +74,7 @@ credentials_store = "auto"   # legacy compatibility; provider keys are in .env
 [ui]
 theme = "auto"
 cursor_shape = "bar"         # CLI/TUI text cursor: underline|block|bar
+show_turn_usage = false       # hide per-request token/cost receipts in the TUI; default true
 
 [desktop]
 provider_access = ["deepseek"]
@@ -98,6 +99,10 @@ redaction. Secrets belong in the global `.env` below.
 `[ui].cursor_shape` affects only the CLI/TUI composer. The default `bar` stays
 visible without covering double-width CJK characters; use `block` or
 `underline` if you prefer those cursor shapes.
+
+`[ui].show_turn_usage = false` hides the token and cost receipt appended to the
+TUI transcript after each model request. Accounting and live status updates
+remain active. The default is `true`.
 
 ### Custom provider `api_key_env` names
 

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -62,6 +62,7 @@ credentials_store = "auto"   # 旧兼容字段；provider key 保存在 .env
 [ui]
 theme = "auto"
 cursor_shape = "bar"         # CLI/TUI 输入光标：underline|block|bar
+show_turn_usage = false       # 隐藏 TUI 每轮 token/费用回执；默认 true
 
 [desktop]
 provider_access = ["deepseek"]
@@ -84,6 +85,9 @@ command = "example-mcp-server"
 
 `[ui].cursor_shape` 只影响 CLI/TUI 的输入框。默认值 `bar` 清晰可见，同时不会覆盖
 CJK 双宽字符；如果偏好其它形状，可以设为 `block` 或 `underline`。
+
+`[ui].show_turn_usage = false` 会隐藏 TUI transcript 中每次模型请求完成后的 token 与
+费用回执；统计和运行中状态仍正常更新。默认值为 `true`。
 
 ### 自定义 provider 的 `api_key_env` 命名
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -57,6 +57,7 @@ default_model = "deepseek-flash"   # executor; set [agent].planner_model to add 
 [ui]
 # shortcut_layout = "desktop"      # classic|desktop; compatibility setting
 # cursor_shape = "bar"             # block|underline|bar; CLI/TUI text cursor
+show_turn_usage = false             # hide per-request token/cost receipts in the TUI; default true
 
 [agent]
 reasoning_language = "auto"      # visible reasoning text: auto|zh|en

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -51,6 +51,7 @@ default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可�
 [ui]
 # shortcut_layout = "desktop"      # classic|desktop；兼容旧配置
 # cursor_shape = "bar"             # block|underline|bar；CLI/TUI 输入光标
+show_turn_usage = false             # 隐藏 TUI 每轮 token/费用回执；默认 true
 
 [agent]
 reasoning_language = "auto"      # 可见思考过程语言：auto|zh|en

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -677,6 +677,7 @@ default_model = "deepseek"   # provider name (→ its default model) or "provide
 [ui]
 # shortcut_layout = "desktop"       # classic|desktop; compatibility setting
 # cursor_shape = "bar"              # CLI/TUI textarea cursor: underline|block|bar
+show_turn_usage = false              # hide per-request token/cost receipts in the TUI; default true
 
 [agent]
 system_prompt = "You are Reasonix, a coding agent..."  # or system_prompt_file = "..."

--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -41,6 +41,7 @@ func newTestChatTUI() chatTUI {
 		toolLineCountByID:    map[string]int{},
 		subagentProgressIdx:  map[string]int{},
 		subagentProgress:     map[string]*cliSubagentProgress{},
+		showTurnUsage:        true,
 	}
 }
 
@@ -136,6 +137,23 @@ func TestTurnReceiptLeavesOneBlankRowAfterAssistantAnswer(t *testing.T) {
 	}
 	if !strings.Contains(ansi.Strip(m.transcript[2]), "TURN") {
 		t.Fatalf("last block should be the turn receipt, got %q", m.transcript[2])
+	}
+}
+
+func TestTurnReceiptCanBeHiddenWithoutDisablingUsageAccounting(t *testing.T) {
+	m := newTestChatTUI()
+	m.showTurnUsage = false
+	m.ingestEvent(event.Event{Kind: event.Text, Text: "Answer"})
+	m.ingestEvent(event.Event{Kind: event.Message})
+	m.ingestEvent(event.Event{Kind: event.Usage, Usage: &provider.Usage{
+		PromptTokens: 10, CompletionTokens: 2, TotalTokens: 12,
+	}})
+
+	if len(m.transcript) != 1 {
+		t.Fatalf("hidden turn receipt should not add transcript blocks, got %d: %v", len(m.transcript), m.transcript)
+	}
+	if m.turnTokens != 2 {
+		t.Fatalf("hidden turn receipt should still account for completion tokens, got %d", m.turnTokens)
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -92,6 +92,9 @@ type chatTUI struct {
 	// turnTokens accumulates this turn's output tokens (summed from per-step Usage
 	// events) for the live "↓N" readout in the running status line.
 	turnTokens int
+	// showTurnUsage controls whether completed per-request token/cost receipts are
+	// retained in transcript scrollback. Usage accounting remains active either way.
+	showTurnUsage bool
 
 	// balance is the last-fetched wallet-balance readout (e.g. "¥110.00"), "" when
 	// the provider declares no balance_url or a fetch failed. Refreshed async on
@@ -609,6 +612,7 @@ func newChatTUI(ctrl control.SessionAPI, missing string, eventCh chan event.Even
 		pendingCommit:        &commitBuf,
 		diffMaxLines:         diffFoldLimit,
 		showReasoning:        nativeScrollback,
+		showTurnUsage:        true,
 		shellOutputs:         make(map[string]string),
 		shellExpanded:        make(map[string]bool),
 		shellTranscriptIdx:   make(map[string]int),
@@ -676,6 +680,9 @@ func configureChatTextarea(ti *textarea.Model) {
 	// Linux terminals send Ctrl+arrows for the same intent.
 	ti.KeyMap.WordForward = key.NewBinding(key.WithKeys("alt+right", "alt+f", "ctrl+right"))
 	ti.KeyMap.WordBackward = key.NewBinding(key.WithKeys("alt+left", "alt+b", "ctrl+left"))
+	// mirrors the word-motion convention: macOS uses Alt+Backspace, Windows and
+	// Linux terminals send Ctrl+Backspace to delete the word behind the cursor.
+	ti.KeyMap.DeleteWordBackward = key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w", "ctrl+backspace"))
 	ti.Focus()
 }
 
@@ -1125,14 +1132,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		// Any keystroke dismisses a finished selection (copy is a right-click),
-		// with a few exceptions: Ctrl/Super/Meta+C copies the selection, the
-		// paste shortcuts keep it so the async clipboard result can replace
-		// it, and Left/Right collapse it to its ordered start/end.
+		// with a few exceptions: Ctrl/Super/Meta+C and Ctrl+Insert copy the
+		// selection, the paste shortcuts keep it so the async clipboard result
+		// can replace it, and Left/Right collapse it to its ordered start/end.
 		sel := m.sel
 		m.sel = selection{}
 		if m.validComposerSelection() && !m.composerSel.empty() {
 			switch {
-			case msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c":
+			case msg.String() == "ctrl+c" || msg.String() == "super+c" || msg.String() == "meta+c" || msg.String() == "ctrl+insert":
 				cmds = append(cmds, m.copySelectionWithNotice(m.selectedComposerText()))
 				return m, finalize(m, cmds)
 			case imagePasteShortcut(msg.String(), runtime.GOOS):
@@ -1331,6 +1338,17 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, finalize(m, cmds)
 		}
+		// Shift+Insert is the classic terminal paste key. Most terminals
+		// intercept it themselves and deliver the clipboard text as bracketed
+		// paste (tea.PasteMsg); some forward the key sequence instead (e.g. via
+		// the kitty keyboard protocol). Bind it explicitly so paste works
+		// either way — same native-clipboard read path as right-click, so SSH
+		// sessions get the same remote hint and never read the remote host's
+		// clipboard.
+		if msg.String() == "shift+insert" {
+			cmds = append(cmds, pasteClipboardText())
+			return m, finalize(m, cmds)
+		}
 		switch msg.String() {
 		case "esc":
 			// "Back out" of the most specific in-progress state: un-send a just-sent
@@ -1368,6 +1386,21 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.input.Reset()
 					m.pastedBlocks = nil
 				}
+			}
+			return m, nil
+		case "ctrl+insert":
+			// Terminal-convention copy without Ctrl+C's destructive side
+			// effects: copy an active selection if there is one, otherwise do
+			// nothing (no clear-input, no cancel, no quit). The selection lives
+			// in-app because Reasonix owns the mouse, so the terminal's own
+			// Ctrl+Insert (which copies the terminal selection) would see an
+			// empty one.
+			if sel.active && !sel.empty() {
+				m.sel = sel // restore so selectedText() can read it
+				text := m.selectedText()
+				m.sel = selection{}
+				cmds = append(cmds, m.copySelectionWithNotice(text))
+				return m, finalize(m, cmds)
 			}
 			return m, nil
 		case "ctrl+c", "super+c", "meta+c":
@@ -4176,10 +4209,12 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		if e.Usage != nil {
 			m.turnTokens += e.Usage.CompletionTokens
 		}
-		if line := renderTurnReceipt(e.Usage, e.Pricing, e.CacheDiagnostics); line != "" {
-			m.finalizeStreamed()
-			m.commitSpacer()
-			m.commitTranscriptSource(transcriptSource{kind: transcriptSourceTurnReceipt, raw: line})
+		if m.showTurnUsage {
+			if line := renderTurnReceipt(e.Usage, e.Pricing, e.CacheDiagnostics); line != "" {
+				m.finalizeStreamed()
+				m.commitSpacer()
+				m.commitTranscriptSource(transcriptSource{kind: transcriptSourceTurnReceipt, raw: line})
+			}
 		}
 
 	case event.Notice:

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -940,6 +940,60 @@ func TestModalPanelsHideComposerBox(t *testing.T) {
 	}
 }
 
+// TestRewindPickerWindowsLongSession verifies the Esc-Esc turn list windows
+// long sessions (one row per turn) so the overlay cannot outgrow the terminal:
+// at most quickPickerMaxVisible rows render, with ↑/↓ more markers pointing at
+// the hidden turns and the window following the selection.
+func TestRewindPickerWindowsLongSession(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+
+	metas := make([]checkpoint.Meta, 12)
+	for i := range metas {
+		metas[i] = checkpoint.Meta{Turn: i, Prompt: fmt.Sprintf("turn %d", i)}
+	}
+
+	// Newest turn selected (default): window shows rows 4..11.
+	m.rewind = &rewindPicker{metas: metas, sel: 11}
+	card := m.renderRewind()
+	if !strings.Contains(card, "↑ more") {
+		t.Fatalf("newest selection should show ↑ more: %q", card)
+	}
+	if strings.Contains(card, "↓ more") {
+		t.Fatalf("newest selection must not show ↓ more: %q", card)
+	}
+	if !strings.Contains(card, "turn 11") || strings.Contains(card, "turn 0") {
+		t.Fatalf("window must cover rows 4..11, got: %q", card)
+	}
+
+	// Oldest turn selected: window shows rows 0..7.
+	m.rewind = &rewindPicker{metas: metas, sel: 0}
+	card = m.renderRewind()
+	if !strings.Contains(card, "↓ more") {
+		t.Fatalf("oldest selection should show ↓ more: %q", card)
+	}
+	if strings.Contains(card, "↑ more") {
+		t.Fatalf("oldest selection must not show ↑ more: %q", card)
+	}
+	if !strings.Contains(card, "turn 0") || strings.Contains(card, "turn 11") {
+		t.Fatalf("window must cover rows 0..7, got: %q", card)
+	}
+
+	// Short session (≤8 turns): every row visible, no markers.
+	m.rewind = &rewindPicker{metas: metas[:4], sel: 0}
+	card = m.renderRewind()
+	if strings.Contains(card, "more") {
+		t.Fatalf("short session must not show more markers: %q", card)
+	}
+	for i := 0; i < 4; i++ {
+		if !strings.Contains(card, fmt.Sprintf("turn %d", i)) {
+			t.Fatalf("short session row %d missing: %q", i, card)
+		}
+	}
+}
+
 func TestApprovalChoicesPreserveDecisionSemantics(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1691,6 +1745,58 @@ func setLocalClipboardSession(t *testing.T) {
 	t.Setenv("SSH_TTY", "")
 }
 
+func TestShiftInsertPastesClipboardText(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before ")
+
+	previous := readNativeClipboardText
+	t.Cleanup(func() { readNativeClipboardText = previous })
+	readNativeClipboardText = func() (string, error) { return "pasted text", nil }
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModShift})
+	m = next.(chatTUI)
+	if got := m.input.Value(); got != "before " {
+		t.Fatalf("Shift+Insert changed the composer before the async read: %q", got)
+	}
+	result := clipboardTextPasteResultFromCmd(t, cmd)
+	next, _ = m.Update(result)
+	m = next.(chatTUI)
+
+	if got := m.input.Value(); got != "before pasted text" {
+		t.Fatalf("Shift+Insert paste produced %q, want %q", got, "before pasted text")
+	}
+}
+
+func TestShiftInsertPasteOverSSHDoesNotReadRemoteClipboard(t *testing.T) {
+	t.Setenv("SSH_CONNECTION", "host 22 client 1234")
+	t.Setenv("SSH_CLIENT", "")
+	t.Setenv("SSH_TTY", "")
+
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("before ")
+
+	previous := readNativeClipboardText
+	t.Cleanup(func() { readNativeClipboardText = previous })
+	readNativeClipboardText = func() (string, error) {
+		t.Fatal("SSH Shift+Insert paste must not read the remote host clipboard")
+		return "", nil
+	}
+
+	next, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModShift})
+	m = next.(chatTUI)
+	result := clipboardTextPasteResultFromCmd(t, cmd)
+	if !result.remote {
+		t.Fatalf("SSH Shift+Insert paste result = %+v, want remote hint", result)
+	}
+
+	next, _ = m.Update(result)
+	m = next.(chatTUI)
+	if got := m.input.Value(); got != "before " {
+		t.Fatalf("SSH Shift+Insert paste changed composer to %q", got)
+	}
+}
+
 func TestMouseRightClickWithoutSelectionPastesClipboardText(t *testing.T) {
 	setLocalClipboardSession(t)
 	m := newComposerMouseTestTUI(t, 60, 16)
@@ -1993,6 +2099,85 @@ func TestMouseDragReleaseAutoCopies(t *testing.T) {
 	m3 := out.(chatTUI)
 	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
 		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertCopiesTranscriptSelection verifies the terminal-convention
+// Ctrl+Insert copy key copies an active transcript selection to the clipboard
+// and arms the copied notice, without Ctrl+C's destructive side effects.
+func TestCtrlInsertCopiesTranscriptSelection(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newTestChatTUI()
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 0}, head: selPos{line: 0, col: 5}}
+
+	previous := writeNativeClipboardText
+	t.Cleanup(func() { writeNativeClipboardText = previous })
+	writeNativeClipboardText = func(text string) error {
+		if text != "hello" {
+			t.Fatalf("native clipboard text = %q, want hello", text)
+		}
+		return nil
+	}
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	if m2.input.Value() != "" {
+		t.Fatalf("Ctrl+Insert must not touch the composer, got %q", m2.input.Value())
+	}
+	result := clipboardCopyResultFromCmd(t, cmd)
+	out, _ = m2.Update(result)
+	m3 := out.(chatTUI)
+	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
+		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertCopiesComposerSelection verifies Ctrl+Insert also copies an
+// active selection inside the composer, mirroring the Ctrl+C handling.
+func TestCtrlInsertCopiesComposerSelection(t *testing.T) {
+	setLocalClipboardSession(t)
+	m := newComposerMouseTestTUI(t, 60, 16)
+	m.input.SetValue("hello world")
+	m.composerSel = composerSelection{active: true, anchor: 0, head: 5, value: m.input.Value()}
+
+	previous := writeNativeClipboardText
+	t.Cleanup(func() { writeNativeClipboardText = previous })
+	writeNativeClipboardText = func(text string) error {
+		if text != "hello" {
+			t.Fatalf("native clipboard text = %q, want hello", text)
+		}
+		return nil
+	}
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	result := clipboardCopyResultFromCmd(t, cmd)
+	out, _ = m2.Update(result)
+	m3 := out.(chatTUI)
+	if m3.copyNoticeText != i18n.M.MouseCopiedHint {
+		t.Errorf("completed native copy notice = %q, want %q", m3.copyNoticeText, i18n.M.MouseCopiedHint)
+	}
+}
+
+// TestCtrlInsertWithoutSelectionIsNoOp verifies Ctrl+Insert with no active
+// selection leaves the composer and the session state untouched — unlike
+// Ctrl+C, it must never clear input or quit.
+func TestCtrlInsertWithoutSelectionIsNoOp(t *testing.T) {
+	m := newTestChatTUI()
+	m.input.SetValue("draft text")
+
+	out, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyInsert, Mod: tea.ModCtrl})
+	m2 := out.(chatTUI)
+	if cmd != nil {
+		t.Fatalf("Ctrl+Insert without a selection should be a no-op, got cmd %T", cmd)
+	}
+	if got := m2.input.Value(); got != "draft text" {
+		t.Fatalf("Ctrl+Insert without a selection changed the composer to %q", got)
+	}
+	if m2.state != tuiIdle {
+		t.Fatalf("Ctrl+Insert without a selection changed state to %v, want idle", m2.state)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -189,7 +189,7 @@ func isDoctorRepairCommand(args []string) bool {
 
 func isDefaultInteractiveFlag(arg string) bool {
 	switch arg {
-	case "--model", "--max-steps", "--continue", "-c", "--resume", "-r", "--copy", "--dangerously-skip-permissions", "--yolo", "--permission-mode", "--effort", "--dir", "--add-dir", "--allowed-tools", "--allowedTools":
+	case "--model", "--max-steps", "--continue", "-c", "--resume", "-r", "--copy", "--dangerously-skip-permissions", "--yolo", "--permission-mode", "--effort", "--dir", "--add-dir", "--allowed-tools", "--allowedTools", "--profile":
 		return true
 	}
 	if name, _, ok := strings.Cut(arg, "="); ok && isDefaultInteractiveFlag(name) {
@@ -471,7 +471,7 @@ func runAgent(args []string, version string) int {
 	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
-	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
+	resume := fs.String("resume", "", "resume by session file path, session ID, or machine session ID (takes precedence over --continue)")
 	copySession := fs.Bool("copy", false, "with --resume/--continue: duplicate the session and continue in the copy (escape hatch when the original is held by another Reasonix process)")
 	effort := fs.String("effort", "", "session reasoning effort override")
 	permissionMode := fs.String("permission-mode", "ask", "permission mode: manual | ask | auto | acceptEdits | dontAsk | plan | bypassPermissions")
@@ -560,8 +560,17 @@ func runAgent(args []string, version string) int {
 
 	// Resolve the resume target up front so --copy and the session lease can be
 	// handled before any heavy assembly. --resume takes precedence over
-	// --continue, matching the Resume call below.
+	// --continue, matching the Resume call below. Accept file paths, branch
+	// IDs, preview text, and opaque machine session IDs (#7429).
 	resumePath := strings.TrimSpace(*resume)
+	if resumePath != "" {
+		resolved, err := resolveSessionQuery(resolveCLISessionDir(), resumePath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		resumePath = resolved
+	}
 	if resumePath == "" && *cont {
 		sessionDir := resolveCLISessionDir()
 		reclaimCLIRecoveryBranches(sessionDir)
@@ -1228,6 +1237,7 @@ func chatREPL(args []string, version string) int {
 		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
 		m.showReasoning = cfg.UI.ShowReasoning   // /verbose persistence: start with config default
+		m.showTurnUsage = cfg.UI.ShowTurnUsage   // retain usage accounting even when transcript receipts are hidden
 		m.cfg = cfg
 	}
 

--- a/internal/cli/cli_flags.go
+++ b/internal/cli/cli_flags.go
@@ -143,6 +143,21 @@ func resolveSessionQuery(dir, query string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("list sessions: %w", err)
 	}
+	// Opaque machine session IDs (session_<hex>) are what --events-jsonl and
+	// `session show --json` expose. Match them before preview/partial search so
+	// one-shot `run --resume` can resume without scanning private paths (#7429).
+	if looksLikeMachineSessionID(query) {
+		key, keyErr := loadMachineIdentityKey()
+		if keyErr != nil {
+			return "", fmt.Errorf("machine identity is unavailable: %w", keyErr)
+		}
+		for _, session := range sessions {
+			if machineSessionIDWithKey(agent.BranchID(session.Path), key) == query {
+				return session.Path, nil
+			}
+		}
+		return "", fmt.Errorf("no session matches %q", query)
+	}
 	lower := strings.ToLower(query)
 	var exact []string
 	var partial []string
@@ -170,4 +185,24 @@ func resolveSessionQuery(dir, query string) (string, error) {
 	default:
 		return "", fmt.Errorf("session query %q is ambiguous (%d matches)", query, len(matches))
 	}
+}
+
+// looksLikeMachineSessionID reports whether query is the opaque HMAC form
+// emitted by machineSessionIDWithKey (`session_` + 32 lowercase hex chars).
+func looksLikeMachineSessionID(query string) bool {
+	const prefix = "session_"
+	if !strings.HasPrefix(query, prefix) {
+		return false
+	}
+	hexPart := query[len(prefix):]
+	if len(hexPart) != 32 {
+		return false
+	}
+	for i := 0; i < len(hexPart); i++ {
+		c := hexPart[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/cli_flags_test.go
+++ b/internal/cli/cli_flags_test.go
@@ -122,6 +122,25 @@ func TestStripLeadingPrintFlag(t *testing.T) {
 	}
 }
 
+func TestResolveSessionQueryByMachineSessionID(t *testing.T) {
+	identityKey := installMachineTestIdentity(t)
+	dir := t.TempDir()
+	path := saveQueryTestSession(t, dir, "opaque-branch.jsonl", "resume by machine id")
+	machineID := machineSessionIDWithKey(agent.BranchID(path), identityKey)
+	if machineID == "" || !looksLikeMachineSessionID(machineID) {
+		t.Fatalf("machine session id = %q", machineID)
+	}
+
+	got, err := resolveSessionQuery(dir, machineID)
+	if err != nil || got != path {
+		t.Fatalf("resolve by machine id = (%q, %v), want %q", got, err, path)
+	}
+	missing := "session_" + strings.Repeat("0", 32)
+	if _, err := resolveSessionQuery(dir, missing); err == nil || !strings.Contains(err.Error(), "no session") {
+		t.Fatalf("missing machine id error = %v", err)
+	}
+}
+
 func TestResolveSessionQueryByIDAndPreview(t *testing.T) {
 	dir := t.TempDir()
 	first := saveQueryTestSession(t, dir, "alpha-session.jsonl", "fix provider configuration")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -334,6 +334,32 @@ func TestRunDefaultsToInteractiveSession(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesProfileFlagToInteractiveSession(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	prev := runInteractiveSession
+	prevInteractive := cliIsInteractive
+	t.Cleanup(func() {
+		runInteractiveSession = prev
+		cliIsInteractive = prevInteractive
+	})
+	cliIsInteractive = func() bool { return true }
+
+	var gotArgs []string
+	runInteractiveSession = func(args []string, _ string) int {
+		gotArgs = append([]string(nil), args...)
+		return 17
+	}
+
+	if rc := Run([]string{"--profile", "delivery"}, "test-version"); rc != 17 {
+		t.Fatalf("Run --profile delivery rc = %d, want 17 (interactive session dispatch)", rc)
+	}
+	want := []string{"--profile", "delivery"}
+	if !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("interactive args = %#v, want %#v", gotArgs, want)
+	}
+}
+
 func TestRunNoArgsNonInteractivePrintsUsage(t *testing.T) {
 	isolateCLIConfigHome(t)
 

--- a/internal/cli/composer_word_motion_test.go
+++ b/internal/cli/composer_word_motion_test.go
@@ -19,6 +19,7 @@ func TestComposerWordMotionAcceptsCtrlArrows(t *testing.T) {
 	}{
 		{"forward", ti.KeyMap.WordForward.Keys(), "ctrl+right", "alt+right"},
 		{"backward", ti.KeyMap.WordBackward.Keys(), "ctrl+left", "alt+left"},
+		{"delete-backward", ti.KeyMap.DeleteWordBackward.Keys(), "ctrl+backspace", "alt+backspace"},
 	} {
 		if !slices.Contains(tc.keys, tc.ctrl) {
 			t.Errorf("word %s is missing %s: %v", tc.motion, tc.ctrl, tc.keys)

--- a/internal/cli/rewind.go
+++ b/internal/cli/rewind.go
@@ -219,8 +219,18 @@ func (m chatTUI) renderRewind() string {
 	var b strings.Builder
 	if r.stage == 0 {
 		b.WriteString(accent(i18n.M.RewindPickTitle) + "\n")
-		for i, meta := range r.metas {
+		// Long sessions list one row per turn; window it like quickPicker so
+		// the overlay never outgrows the terminal (no scrolling viewport).
+		start, end := quickPickerWindow(len(r.metas), r.sel)
+		if start > 0 {
+			b.WriteString(dim("  ↑ more") + "\n")
+		}
+		for i := start; i < end; i++ {
+			meta := r.metas[i]
 			b.WriteString(rowLine(i == r.sel, meta.Turn+1, "", turnLabel(meta, w), false) + "\n")
+		}
+		if end < len(r.metas) {
+			b.WriteString(dim("  ↓ more") + "\n")
 		}
 		b.WriteString(dim(i18n.M.RewindPickHint))
 		return choicePanelStyle.Width(w).Render(b.String())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,7 @@ type UIConfig struct {
 	ShortcutLayout string `toml:"shortcut_layout"` // classic|desktop; accepted for compatibility
 	CloseBehavior  string `toml:"close_behavior"`  // legacy desktop close behavior; prefer desktop.close_behavior
 	ShowReasoning  bool   `toml:"show_reasoning"`  // Ctrl+O / /verbose: show thinking text in CLI; false = collapsed
+	ShowTurnUsage  bool   `toml:"show_turn_usage"` // show per-request token/cost receipts in the CLI/TUI transcript
 	CursorShape    string `toml:"cursor_shape"`    // block|underline|bar; empty defaults to bar
 }
 
@@ -1827,7 +1828,7 @@ func Default() *Config {
 		ConfigVersion:    5,
 		DefaultModel:     "deepseek-flash",
 		CredentialsStore: CredentialsStoreAuto,
-		UI:               UIConfig{Theme: "auto"},
+		UI:               UIConfig{Theme: "auto", ShowTurnUsage: true},
 		Desktop:          DesktopConfig{DefaultToolApprovalMode: "auto", ConversationWidth: "standard"},
 		Notifications: NotificationsConfig{
 			Enabled:         false,

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -87,6 +87,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		} else {
 			b.WriteString("# show_reasoning = true   # CLI: show thinking text by default; false = collapsed (toggle with Ctrl+O)\n")
 		}
+		fmt.Fprintf(&b, "show_turn_usage = %v   # CLI/TUI: show per-request token and cost receipts in the transcript\n", c.UI.ShowTurnUsage)
 		b.WriteString("\n")
 	}
 
@@ -851,6 +852,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 		}
 		if c.UI.ShowReasoning != d.UI.ShowReasoning {
 			fmt.Fprintf(&b, "show_reasoning = %v\n", c.UI.ShowReasoning)
+		}
+		if c.UI.ShowTurnUsage != d.UI.ShowTurnUsage {
+			fmt.Fprintf(&b, "show_turn_usage = %v\n", c.UI.ShowTurnUsage)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -342,6 +342,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.UICursorShape() != "bar" {
 		t.Errorf("ui.cursor_shape = %q, want bar", got.UICursorShape())
 	}
+	if !got.UI.ShowTurnUsage {
+		t.Error("ui.show_turn_usage = false, want true")
+	}
 	if got.Desktop.Language != "en" {
 		t.Errorf("desktop.language = %q, want en", got.Desktop.Language)
 	}
@@ -945,6 +948,29 @@ func TestProjectDeltaRendersUICursorShape(t *testing.T) {
 	}
 	if got.UICursorShape() != "block" {
 		t.Fatalf("ui.cursor_shape = %q, want block", got.UICursorShape())
+	}
+}
+
+func TestShowTurnUsageDefaultsOnAndRendersFalseOverride(t *testing.T) {
+	c := Default()
+	if !c.UI.ShowTurnUsage {
+		t.Fatal("ui.show_turn_usage should default to true")
+	}
+
+	c.UI.ShowTurnUsage = false
+	delta := RenderTOMLProjectDelta(c)
+	for _, want := range []string{"[ui]", "show_turn_usage = false"} {
+		if !strings.Contains(delta, want) {
+			t.Fatalf("project delta missing %q:\n%s", want, delta)
+		}
+	}
+
+	got := Default()
+	if _, err := toml.Decode(delta, got); err != nil {
+		t.Fatalf("decode project delta: %v\n%s", err, delta)
+	}
+	if got.UI.ShowTurnUsage {
+		t.Fatal("ui.show_turn_usage false override did not round-trip")
 	}
 }
 

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -125,7 +125,11 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	defer c.recordDisplayForNewUser(startMessages, display)
-	c.beginCheckpoint(input)
+	// The checkpoint prompt labels the turn in the rewind picker (and is
+	// prefilled into the composer after a conversation rewind), so it must be
+	// the user's own text — never the composed provider input with its
+	// transient <response-language>/<reasoning-language>/memory/hook blocks.
+	c.beginCheckpoint(firstNonEmpty(raw, task))
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}
@@ -235,9 +239,12 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	// appended, so the recorded message boundary precedes it and pre-edit
 	// snapshots land here. Synthetic continuations stay attached to the visible
 	// turn that spawned them; otherwise hidden user-role messages would advance
-	// backend checkpoint turns without a matching frontend turn.
+	// backend checkpoint turns without a matching frontend turn. The label is
+	// the user's own text (raw, falling back to the expanded input) — the
+	// composed provider input carries transient prefab blocks that must never
+	// surface in the rewind picker or be prefilled into the composer.
 	if !turn.synthetic {
-		c.beginCheckpoint(input)
+		c.beginCheckpoint(firstNonEmpty(turn.raw, turn.input))
 	}
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -744,6 +744,46 @@ func TestTurnOrchestratorCheckpointBoundaryPrecedesUserMessage(t *testing.T) {
 	}
 }
 
+// TestTurnOrchestratorCheckpointPromptIsRawUserInput verifies the rewind picker
+// label records the user's own text, not the composed provider input. compose()
+// prefixes the turn with transient blocks (<response-language>,
+// <reasoning-language>, plan marker, memory, hook context, …); storing that
+// string as checkpoint.Prompt made the Esc-Esc picker show a wall of prefab
+// prompt text instead of the user's messages.
+func TestTurnOrchestratorCheckpointPromptIsRawUserInput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &recordingSessionRunner{session: sess}
+	c := New(Options{
+		Runner:            runner,
+		Executor:          exec,
+		SessionDir:        dir,
+		SessionPath:       path,
+		Label:             "test",
+		ResponseLanguage:  "zh",
+		ReasoningLanguage: "en",
+	})
+	o := newTurnOrchestrator(c)
+	const raw = "fix the parser"
+	if err := o.runTurnWithRawDisplay(context.Background(), raw, raw, ""); err != nil {
+		t.Fatal(err)
+	}
+	cps := c.Checkpoints()
+	if len(cps) != 1 {
+		t.Fatalf("checkpoints = %+v, want exactly one", cps)
+	}
+	if got := cps[0].Prompt; got != raw {
+		t.Fatalf("checkpoint prompt = %q, want raw user input %q (composed text leaked into the rewind picker)", got, raw)
+	}
+	for _, prefab := range []string{"<response-language>", "<reasoning-language>"} {
+		if strings.Contains(cps[0].Prompt, prefab) {
+			t.Fatalf("checkpoint prompt contains %q: %q", prefab, cps[0].Prompt)
+		}
+	}
+}
+
 func TestTurnOrchestratorSyntheticTurnDoesNotCreateCheckpoint(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -12,6 +12,7 @@ theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 # shortcut_layout = "desktop"   # classic|desktop; compatibility setting; Shift+Tab toggles Plan, Ctrl+Y toggles YOLO
 # cursor_shape = "bar"   # block|underline|bar; text input cursor shape; slim default avoids covering CJK characters
+show_turn_usage = true   # CLI/TUI: show per-request token and cost receipts in transcript scrollback
 
 [desktop]
 # language = "auto"   # auto|en|zh; auto follows the browser/OS locale


### PR DESCRIPTION
## Summary

Rebases and lands the six independently-testable CLI contributor PRs onto latest `main-v2`, with focused regression tests re-run against current HEAD (old green checks are not reused).

### Kept / adapted from source PRs

| Source | Author | Mechanism |
| --- | --- | --- |
| #7621 | @Hezi-crypto | Bare `reasonix --profile …` dispatches to the interactive session path |
| #7608 | @skyzhao1223 | `reasonix run --resume` accepts opaque machine session IDs; docs use QUERY |
| #7587 | @azhonglee | `[ui].show_turn_usage` (default true) hides transcript receipts without disabling accounting |
| #7605 | @rixzkiye | Ctrl+Backspace deletes the previous word (with Alt+Backspace / Ctrl+W) |
| #7262 | @rongbc | Ctrl+Insert copies selection without Ctrl+C side effects; Shift+Insert pastes via native clipboard |
| #7202 | @mife-user | Checkpoint labels store raw user text; rewind picker windows long sessions |

Commit co-authors use the public Git identities from the source PR commits.

### Not in this PR

Larger integration work from the 30-day feedback plan remains separate:
- Integration A: startup / diagnostics / keyring / ConPTY
- Integration B: input / completion / hotkeys
- Integration C: viewport / render / mouse
- Integration D/E: completion / version / session broker / MCP source display

After this lands, the six source PRs will be closed as superseded with a link to this merge.

## Verification

- `go test ./internal/cli ./internal/config ./internal/control -count=1`
- Focused coverage:
  - `TestRunDispatchesProfileFlagToInteractiveSession`
  - `TestResolveSessionQueryByMachineSessionID`
  - `TestTurnReceiptCanBeHiddenWithoutDisablingUsageAccounting`
  - `TestShowTurnUsageDefaultsOnAndRendersFalseOverride`
  - `TestComposerWordMotionAcceptsCtrlArrows` (Ctrl+Backspace)
  - `TestShiftInsert*` / `TestCtrlInsert*`
  - `TestRewindPickerWindowsLongSession`
  - `TestTurnOrchestratorCheckpointPromptIsRawUserInput`

## Cache impact

Cache-impact: none - only UI/config field `show_turn_usage`, CLI flag routing, resume ID matching, TUI keybindings, and checkpoint label storage; no provider prompt construction, tool schema, MCP registration, or compaction changes.
Cache-guard: existing `go test ./internal/control -run TestCheckpointsReturnUserPromptWithoutComposedPrefixes` plus new checkpoint raw-prompt test; no system-prompt string edits.
System-prompt-review: not required - `internal/config/config.go` only adds `UI.ShowTurnUsage` default/struct field; no system prompt or tool schema strings changed.

Documentation-impact: updated - CLI resume QUERY docs (EN/ZH), CONFIG_PATHS/GUIDE/SPEC for `[ui].show_turn_usage`, example.toml and CHANGELOG entry.

## Compatibility

- Default UI behavior unchanged (`show_turn_usage` defaults to true).
- Existing `--version`, `-c`, `-p`, exit codes, and resume-by-path / resume-by-id paths preserved.
- Machine session ID resume is additive.