### PR TITLE
fix(plugin): speak standard MCP Content-Length framing on stdio

### DIFF
--- a/cmd/reasonix-plugin-example/main.go
+++ b/cmd/reasonix-plugin-example/main.go
@@ -1,7 +1,8 @@
 // Command reasonix-plugin-example is a reference Reasonix plugin: a minimal MCP stdio
-// server speaking newline-delimited JSON-RPC 2.0 on stdin/stdout. It exists to
-// document the contract end-to-end (the protocol the internal/plugin client
-// drives) and to give users a working example to copy.
+// server speaking JSON-RPC 2.0 on stdin/stdout with the standard MCP/LSP
+// Content-Length framing. It exists to document the contract end-to-end (the
+// protocol the internal/plugin client drives) and to give users a working
+// example to copy.
 //
 // Wire it up in reasonix.toml:
 //
@@ -13,7 +14,8 @@
 // its prompt as the "/mcp__example__review" slash command, and its resource as
 // the "@example:doc://style-guide" reference.
 //
-// Protocol, one JSON object per line:
+// Protocol — standard Content-Length frames from reasonix; one-JSON-per-line
+// input is also accepted for hand-run pipelines:
 //   - initialize                 → {protocolVersion, capabilities, serverInfo}
 //   - notifications/initialized  (notification, no id) → ignored
 //   - tools/list                 → {tools: [{name, description, inputSchema, annotations}]}
@@ -31,8 +33,10 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -77,14 +81,14 @@ const (
 )
 
 // serve runs the read-dispatch-reply loop until stdin closes (reasonix closed the
-// pipe / is shutting down). Each line is one JSON-RPC message.
+// pipe / is shutting down). Each frame is one JSON-RPC message.
 func serve(in *os.File, out *os.File) error {
 	r := bufio.NewReader(in)
 	w := bufio.NewWriter(out)
 	defer w.Flush()
 
 	for {
-		line, err := r.ReadBytes('\n')
+		line, err := readFrame(r)
 		if len(line) > 0 {
 			if rerr := handleLine(line, w); rerr != nil {
 				return rerr
@@ -96,6 +100,50 @@ func serve(in *os.File, out *os.File) error {
 		if err != nil {
 			return nil // EOF or pipe closed: clean shutdown
 		}
+	}
+}
+
+// readFrame reads one JSON-RPC message. reasonix writes standard MCP/LSP
+// Content-Length frames; hand-run pipelines may still send one JSON object per
+// line, so both forms are accepted.
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := r.ReadBytes('\n')
+		line = trimSpace(line)
+		if len(line) == 0 {
+			if err != nil {
+				return nil, err
+			}
+			continue // blank line between frames
+		}
+		if line[0] == '{' {
+			return line, err // legacy one-JSON-per-line payload
+		}
+		if !strings.HasPrefix(strings.ToLower(string(line)), "content-length:") {
+			if err != nil {
+				return nil, err
+			}
+			continue // other header line
+		}
+		value := strings.TrimSpace(string(line[len("content-length:"):]))
+		n, perr := strconv.Atoi(value)
+		if perr != nil || n < 0 {
+			return nil, fmt.Errorf("malformed Content-Length %q", value)
+		}
+		for {
+			h, herr := r.ReadBytes('\n')
+			if len(trimSpace(h)) == 0 {
+				break // header block ends at the first blank line
+			}
+			if herr != nil {
+				return nil, herr
+			}
+		}
+		body := make([]byte, n)
+		if _, err := io.ReadFull(r, body); err != nil {
+			return nil, err
+		}
+		return trimSpace(body), nil
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -160,17 +162,24 @@ func TestDesktopMCPHelperProcess(t *testing.T) {
 		}
 		defer instanceListener.Close()
 	}
-	dec := json.NewDecoder(os.Stdin)
+	br := bufio.NewReader(os.Stdin)
 	enc := json.NewEncoder(os.Stdout)
 	for {
+		payload, err := readMCPFrame(br)
+		if len(payload) == 0 {
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				t.Fatalf("read helper request: %v", err)
+			}
+			continue
+		}
 		var req struct {
 			ID     *int   `json:"id"`
 			Method string `json:"method"`
 		}
-		if err := dec.Decode(&req); err != nil {
-			if errors.Is(err, io.EOF) {
-				return
-			}
+		if err := json.Unmarshal(payload, &req); err != nil {
 			t.Fatalf("decode helper request: %v", err)
 		}
 		if req.ID == nil {
@@ -194,6 +203,50 @@ func TestDesktopMCPHelperProcess(t *testing.T) {
 		if err := enc.Encode(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result}); err != nil {
 			t.Fatalf("encode helper response: %v", err)
 		}
+	}
+}
+
+// readMCPFrame reads one JSON-RPC message from a plugin's stdin, accepting the
+// standard MCP/LSP Content-Length framing (what internal/plugin now writes) as
+// well as legacy newline-delimited JSON.
+func readMCPFrame(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := r.ReadBytes('\n')
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if line[0] == '{' {
+			return line, err
+		}
+		if !strings.HasPrefix(strings.ToLower(string(line)), "content-length:") {
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		value := strings.TrimSpace(string(line[len("content-length:"):]))
+		n, perr := strconv.Atoi(value)
+		if perr != nil || n < 0 {
+			return nil, fmt.Errorf("malformed Content-Length %q", value)
+		}
+		for {
+			h, herr := r.ReadBytes('\n')
+			if len(bytes.TrimSpace(h)) == 0 {
+				break
+			}
+			if herr != nil {
+				return nil, herr
+			}
+		}
+		body := make([]byte, n)
+		if _, err := io.ReadFull(r, body); err != nil {
+			return nil, err
+		}
+		return bytes.TrimSpace(body), nil
 	}
 }
 

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -5047,13 +5048,15 @@ func TestHelperProcess(t *testing.T) {
 
 	in := bufio.NewReader(os.Stdin)
 	for {
-		line, err := in.ReadBytes('\n')
+		line, err := readTestHelperFrame(in)
+		if len(line) == 0 {
+			if err != nil {
+				return
+			}
+			continue
+		}
 		if err != nil {
 			return
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
 		}
 
 		var req struct {
@@ -5105,6 +5108,50 @@ func TestHelperProcess(t *testing.T) {
 		resp := map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result}
 		b, _ := json.Marshal(resp)
 		os.Stdout.Write(append(b, '\n'))
+	}
+}
+
+// readTestHelperFrame reads one JSON-RPC message from a plugin's stdin,
+// accepting the standard MCP/LSP Content-Length framing (what internal/plugin
+// now writes) as well as legacy newline-delimited JSON.
+func readTestHelperFrame(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := r.ReadBytes('\n')
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if line[0] == '{' {
+			return line, err
+		}
+		if !strings.HasPrefix(strings.ToLower(string(line)), "content-length:") {
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		value := strings.TrimSpace(string(line[len("content-length:"):]))
+		n, perr := strconv.Atoi(value)
+		if perr != nil || n < 0 {
+			return nil, fmt.Errorf("malformed Content-Length %q", value)
+		}
+		for {
+			h, herr := r.ReadBytes('\n')
+			if len(bytes.TrimSpace(h)) == 0 {
+				break
+			}
+			if herr != nil {
+				return nil, herr
+			}
+		}
+		body := make([]byte, n)
+		if _, err := io.ReadFull(r, body); err != nil {
+			return nil, err
+		}
+		return bytes.TrimSpace(body), nil
 	}
 }
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1292,13 +1292,15 @@ func TestHelperProcess(t *testing.T) {
 
 	in := bufio.NewReader(os.Stdin)
 	for {
-		line, err := in.ReadBytes('\n')
+		line, err := readStdioFrame(in)
+		if len(line) == 0 {
+			if err != nil {
+				return
+			}
+			continue
+		}
 		if err != nil {
 			return
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
 		}
 
 		var req struct {

--- a/internal/plugin/stdio_cancel_test.go
+++ b/internal/plugin/stdio_cancel_test.go
@@ -17,6 +17,17 @@ type discardWriteCloser struct{}
 func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
 func (discardWriteCloser) Close() error                { return nil }
 
+// decodeServerMessage reads one message the client sent over the fake server's
+// stdin pipe, accepting the same framings as the transport (standard
+// Content-Length frames plus legacy NDJSON).
+func decodeServerMessage(br *bufio.Reader, v any) error {
+	payload, err := readStdioFrame(br)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(payload, v)
+}
+
 // TestStdioCallReturnsOnContextCancel pins that a stdio call unblocks when its
 // context is cancelled even though the server never replies. The stdio child is
 // bound to the session, not the turn, so without this a hung server would hang a
@@ -130,7 +141,7 @@ func TestStdioInitializeHandlesNotificationsAndServerPing(t *testing.T) {
 
 	serverDone := make(chan error, 1)
 	go func() {
-		dec := json.NewDecoder(serverReads)
+		br := bufio.NewReader(serverReads)
 		enc := json.NewEncoder(serverWrites)
 		var initialize struct {
 			ID     int    `json:"id"`
@@ -139,7 +150,7 @@ func TestStdioInitializeHandlesNotificationsAndServerPing(t *testing.T) {
 				Capabilities map[string]json.RawMessage `json:"capabilities"`
 			} `json:"params"`
 		}
-		if err := dec.Decode(&initialize); err != nil {
+		if err := decodeServerMessage(br, &initialize); err != nil {
 			serverDone <- fmt.Errorf("decode initialize: %w", err)
 			return
 		}
@@ -167,7 +178,7 @@ func TestStdioInitializeHandlesNotificationsAndServerPing(t *testing.T) {
 				Roots []mcpRoot `json:"roots"`
 			} `json:"result"`
 		}
-		if err := dec.Decode(&rootsResponse); err != nil {
+		if err := decodeServerMessage(br, &rootsResponse); err != nil {
 			serverDone <- fmt.Errorf("decode roots/list response: %w", err)
 			return
 		}
@@ -184,7 +195,7 @@ func TestStdioInitializeHandlesNotificationsAndServerPing(t *testing.T) {
 			ID     string         `json:"id"`
 			Result map[string]any `json:"result"`
 		}
-		if err := dec.Decode(&pingResponse); err != nil {
+		if err := decodeServerMessage(br, &pingResponse); err != nil {
 			serverDone <- fmt.Errorf("decode ping response: %w", err)
 			return
 		}
@@ -207,7 +218,7 @@ func TestStdioInitializeHandlesNotificationsAndServerPing(t *testing.T) {
 		var initialized struct {
 			Method string `json:"method"`
 		}
-		if err := dec.Decode(&initialized); err != nil {
+		if err := decodeServerMessage(br, &initialized); err != nil {
 			serverDone <- fmt.Errorf("decode initialized notification: %w", err)
 			return
 		}
@@ -255,7 +266,7 @@ func TestStdioToolCallRoutesProgressNotification(t *testing.T) {
 
 	serverDone := make(chan error, 1)
 	go func() {
-		dec := json.NewDecoder(serverReads)
+		br := bufio.NewReader(serverReads)
 		enc := json.NewEncoder(serverWrites)
 		var request struct {
 			ID     int    `json:"id"`
@@ -264,7 +275,7 @@ func TestStdioToolCallRoutesProgressNotification(t *testing.T) {
 				Meta map[string]any `json:"_meta"`
 			} `json:"params"`
 		}
-		if err := dec.Decode(&request); err != nil {
+		if err := decodeServerMessage(br, &request); err != nil {
 			serverDone <- err
 			return
 		}

--- a/internal/plugin/stdio_framing.go
+++ b/internal/plugin/stdio_framing.go
@@ -1,0 +1,98 @@
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// maxStdioFrameBytes bounds one Content-Length-framed message body. MCP tool
+// results can carry large attachments, so the ceiling is deliberately high; it
+// exists to stop a misbehaving server from declaring an absurd body size and
+// exhausting memory while the caller drains it.
+const maxStdioFrameBytes = 64 << 20 // 64 MiB
+
+// readStdioFrame reads one JSON-RPC message from the plugin's stdout. The
+// standard MCP/LSP transport frames messages as
+//
+//	Content-Length: <bytes>\r\n\r\n<json body>
+//
+// while older Reasonix plugins wrote one JSON object per line (NDJSON). Both
+// forms are accepted so official SDK servers (the Python and Node SDKs emit
+// Content-Length) and legacy plugins keep working side by side.
+//
+// The returned payload has surrounding whitespace trimmed. Stray blank lines
+// between frames are skipped; an unrecognised header line (e.g. Content-Type)
+// is skipped while scanning a header block. EOF or any framing error is
+// returned to the caller, which treats it as a terminal read failure.
+func readStdioFrame(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := readTrimmedLine(r)
+		if err != nil {
+			return nil, err
+		}
+		if len(line) == 0 {
+			continue // blank line between frames (or after a previous body)
+		}
+		if line[0] == '{' {
+			return line, nil // legacy NDJSON payload
+		}
+		n, ok, err := parseContentLength(line)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue // other header line: keep scanning
+		}
+		return readContentLengthBody(r, n)
+	}
+}
+
+// readContentLengthBody drains the rest of the header block (until the first
+// blank line), then reads exactly n payload bytes.
+func readContentLengthBody(r *bufio.Reader, n int) ([]byte, error) {
+	for {
+		line, err := readTrimmedLine(r)
+		if err != nil {
+			return nil, err
+		}
+		if len(line) == 0 {
+			break
+		}
+	}
+	if n > maxStdioFrameBytes {
+		return nil, fmt.Errorf("stdio frame body is %d bytes; limit is %d", n, maxStdioFrameBytes)
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(payload), nil
+}
+
+// parseContentLength recognises a Content-Length header line (case-insensitive,
+// per the LSP framing rules). A line that is not a header returns ok=false; a
+// header whose value is not a non-negative integer is a framing error.
+func parseContentLength(line []byte) (n int, ok bool, err error) {
+	const prefix = "content-length:"
+	if len(line) < len(prefix) || !strings.EqualFold(string(line[:len(prefix)]), prefix) {
+		return 0, false, nil
+	}
+	value := bytes.TrimSpace(line[len(prefix):])
+	n, err = strconv.Atoi(string(value))
+	if err != nil || n < 0 {
+		return 0, true, fmt.Errorf("stdio frame malformed Content-Length %q", value)
+	}
+	return n, true, nil
+}
+
+// readTrimmedLine reads one line, dropping the trailing line ending and any
+// surrounding whitespace (matching the previous NDJSON handling, which also
+// trimmed before dispatch).
+func readTrimmedLine(r *bufio.Reader) ([]byte, error) {
+	line, err := r.ReadBytes('\n')
+	return bytes.TrimSpace(line), err
+}

--- a/internal/plugin/stdio_framing_test.go
+++ b/internal/plugin/stdio_framing_test.go
@@ -1,0 +1,224 @@
+package plugin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureWriteCloser records everything written to it, standing in for the
+// transport's stdin pipe.
+type captureWriteCloser struct{ b bytes.Buffer }
+
+func (c *captureWriteCloser) Write(p []byte) (int, error) { return c.b.Write(p) }
+func (c *captureWriteCloser) Close() error                { return nil }
+
+func TestReadStdioFrameNDJSON(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":1,"result":{}}`
+	r := bufio.NewReader(strings.NewReader(body + "\n"))
+	got, err := readStdioFrame(r)
+	if err != nil {
+		t.Fatalf("readStdioFrame: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("payload = %q, want %q", got, body)
+	}
+}
+
+func TestReadStdioFrameContentLength(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":2,"result":{}}`
+	r := bufio.NewReader(strings.NewReader(fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)))
+	got, err := readStdioFrame(r)
+	if err != nil {
+		t.Fatalf("readStdioFrame: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("payload = %q, want %q", got, body)
+	}
+}
+
+func TestReadStdioFrameContentLengthCaseInsensitiveAndExtraHeaders(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":3,"result":{}}`
+	// Lower-case header plus an extra Content-Type line, in the order the
+	// official SDKs emit them.
+	raw := fmt.Sprintf("content-length: %d\r\ncontent-type: application/json\r\n\r\n%s", len(body), body)
+	r := bufio.NewReader(strings.NewReader(raw))
+	got, err := readStdioFrame(r)
+	if err != nil {
+		t.Fatalf("readStdioFrame: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("payload = %q, want %q", got, body)
+	}
+}
+
+func TestReadStdioFrameSkipsBlankLinesBetweenFrames(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":4,"result":{}}`
+	raw := "\r\n" + fmt.Sprintf("Content-Length: %d\r\n\r\n%s\r\n", len(body), body)
+	r := bufio.NewReader(strings.NewReader(raw))
+	got, err := readStdioFrame(r)
+	if err != nil {
+		t.Fatalf("readStdioFrame: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("payload = %q, want %q", got, body)
+	}
+}
+
+// The payload must arrive intact even when the underlying reader hands it over
+// in tiny pieces — bufio must never mix frame boundaries.
+func TestReadStdioFrameBodyAcrossBufferRefills(t *testing.T) {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":5,"result":{"text":%q}}`, strings.Repeat("x", 200))
+	raw := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)
+	r := bufio.NewReaderSize(strings.NewReader(raw), 7)
+	got, err := readStdioFrame(r)
+	if err != nil {
+		t.Fatalf("readStdioFrame: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("payload = %q, want %q", got, body)
+	}
+}
+
+func TestReadStdioFrameRejectsOversizedBody(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(fmt.Sprintf("Content-Length: %d\r\n\r\n", maxStdioFrameBytes+1)))
+	_, err := readStdioFrame(r)
+	if err == nil || !strings.Contains(err.Error(), "limit is") {
+		t.Fatalf("err = %v, want oversized-frame error", err)
+	}
+}
+
+func TestReadStdioFrameMalformedContentLength(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("Content-Length: lots\r\n\r\n{}"))
+	_, err := readStdioFrame(r)
+	if err == nil || !strings.Contains(err.Error(), "malformed Content-Length") {
+		t.Fatalf("err = %v, want malformed Content-Length error", err)
+	}
+}
+
+func TestReadStdioFrameEOF(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(""))
+	_, err := readStdioFrame(r)
+	if err != io.EOF {
+		t.Fatalf("err = %v, want io.EOF", err)
+	}
+}
+
+// The transport must write standard MCP/LSP frames: a Content-Length header
+// whose value exactly matches the JSON body that follows.
+func TestStdioWriteUsesContentLengthFraming(t *testing.T) {
+	pipe := &captureWriteCloser{}
+	tr := &stdioTransport{name: "w", stdin: pipe, stderr: &tailBuffer{limit: 1024}}
+	if err := tr.write(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "ping"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	raw := pipe.b.String()
+	sep := strings.Index(raw, "\r\n\r\n")
+	if sep < 0 {
+		t.Fatalf("no header/body separator in %q", raw)
+	}
+	header, body := raw[:sep], raw[sep+4:]
+	if !strings.HasPrefix(header, "Content-Length: ") {
+		t.Fatalf("header = %q, want Content-Length", header)
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(header, "Content-Length: "))
+	if err != nil || n != len(body) {
+		t.Fatalf("header %q does not match %d body bytes", header, len(body))
+	}
+	var msg map[string]any
+	if err := json.Unmarshal([]byte(body), &msg); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+	if msg["method"] != "ping" {
+		t.Fatalf("method = %v, want ping", msg["method"])
+	}
+}
+
+// End-to-end reproduction of the #7525 failure: a server that speaks only the
+// standard Content-Length framing (as the official Python/Node MCP SDKs do)
+// must complete the initialize handshake instead of timing out.
+func TestStdioInitializeWithContentLengthServer(t *testing.T) {
+	serverReads, clientWrites := io.Pipe()
+	clientReads, serverWrites := io.Pipe()
+	t.Cleanup(func() {
+		_ = clientWrites.Close()
+		_ = serverReads.Close()
+		_ = serverWrites.Close()
+		_ = clientReads.Close()
+	})
+
+	tr := &stdioTransport{
+		name:    "sdk-server",
+		stdin:   clientWrites,
+		stdout:  bufio.NewReader(clientReads),
+		stderr:  &tailBuffer{limit: 1024},
+		pending: map[int]chan rpcResponse{},
+	}
+	go tr.readLoop()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		br := bufio.NewReader(serverReads)
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := decodeServerMessage(br, &req); err != nil {
+			serverDone <- fmt.Errorf("read initialize: %w", err)
+			return
+		}
+		if req.Method != "initialize" {
+			serverDone <- fmt.Errorf("method = %q, want initialize", req.Method)
+			return
+		}
+		body, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]any{
+				"protocolVersion": protocolVersion,
+				"serverInfo":      map[string]any{"name": "sdk-server", "version": "1.0.0"},
+				"capabilities":    map[string]any{},
+			},
+		})
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		if _, err := fmt.Fprintf(serverWrites, "Content-Length: %d\r\n\r\n%s", len(body), body); err != nil {
+			serverDone <- err
+			return
+		}
+		// Like a real SDK server, keep reading: the client sends the
+		// notifications/initialized notice after the handshake, and io.Pipe
+		// writes block until someone consumes them.
+		var initialized struct {
+			Method string `json:"method"`
+		}
+		if err := decodeServerMessage(br, &initialized); err != nil {
+			serverDone <- fmt.Errorf("read initialized notice: %w", err)
+			return
+		}
+		if initialized.Method != "notifications/initialized" {
+			serverDone <- fmt.Errorf("notice method = %q, want notifications/initialized", initialized.Method)
+			return
+		}
+		serverDone <- nil
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client := &Client{name: "sdk-server", t: tr, spec: Spec{WorkspaceRoot: t.TempDir()}}
+	if err := client.initialize(ctx); err != nil {
+		t.Fatalf("initialize with Content-Length server: %v", err)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,12 +26,13 @@ const (
 	gracefulCloseWaitBudget = 750 * time.Millisecond
 )
 
-// stdioTransport speaks newline-delimited JSON-RPC 2.0 over a subprocess's
-// stdin/stdout — the MCP stdio convention (one JSON message per line, no
-// embedded newlines). A dedicated reader goroutine owns stdout and demuxes each
-// response to the waiting call by id, so a call can abandon a blocking read the
-// moment its context is cancelled (the subprocess is bound to the session, not
-// the turn, so a hung server would otherwise hang a cancelled turn forever).
+// stdioTransport speaks JSON-RPC 2.0 over a subprocess's stdin/stdout using the
+// standard MCP/LSP Content-Length framing on write, and accepts either that
+// framing or legacy newline-delimited JSON on read (see readStdioFrame). A
+// dedicated reader goroutine owns stdout and demuxes each response to the
+// waiting call by id, so a call can abandon a blocking read the moment its
+// context is cancelled (the subprocess is bound to the session, not the turn,
+// so a hung server would otherwise hang a cancelled turn forever).
 // callMu serialises a request/response round-trip over the shared pipe.
 type stdioTransport struct {
 	name   string
@@ -549,9 +550,10 @@ func mergePathLists(primary, secondary string) string {
 const stdioReplyQueueBound = 16
 
 // readLoop owns stdout for the transport's lifetime: it reads one JSON-RPC
-// message per line, routes progress notifications, answers server requests, and
-// hands each response to the call waiting on its id. On any read error it fails
-// every pending call and exits.
+// message (Content-Length-framed or legacy NDJSON — see readStdioFrame), routes
+// progress notifications, answers server requests, and hands each response to
+// the call waiting on its id. On any read error it fails every pending call and
+// exits.
 func (t *stdioTransport) readLoop() {
 	// Server-request replies go through replyLoop, never directly to stdin:
 	// readLoop is the only goroutine draining stdout, and blocking it on
@@ -561,8 +563,7 @@ func (t *stdioTransport) readLoop() {
 	defer close(replies)
 	go t.replyLoop(replies)
 	for {
-		line, readErr := t.stdout.ReadBytes('\n')
-		line = bytes.TrimSpace(line)
+		line, readErr := readStdioFrame(t.stdout)
 		if len(line) > 0 {
 			t.handleInboundLine(line, replies)
 		}
@@ -694,7 +695,14 @@ func (t *stdioTransport) write(v any) error {
 	}
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
-	if _, err = t.stdin.Write(append(b, '\n')); err != nil {
+	// Standard MCP/LSP framing. Built as one frame so a partial write can
+	// never expose a torn header to the server.
+	frame := make([]byte, 0, len(b)+32)
+	frame = append(frame, "Content-Length: "...)
+	frame = strconv.AppendInt(frame, int64(len(b)), 10)
+	frame = append(frame, "\r\n\r\n"...)
+	frame = append(frame, b...)
+	if _, err = t.stdin.Write(frame); err != nil {
 		return t.withStderr(err)
 	}
 	return nil


### PR DESCRIPTION
Fixes #7525.

## Problem

The MCP stdio transport only spoke newline-delimited JSON in both
directions, while the official Python/Node MCP SDKs frame every message
with `Content-Length` headers. Any SDK-built stdio server failed the
initialize handshake with a 30s timeout.

## Fix

- **Write**: emit standard MCP/LSP `Content-Length` frames (the format
  the official SDKs read).
- **Read**: accept both Content-Length frames and legacy NDJSON, so
  existing NDJSON plugins keep working. Header parsing is
  case-insensitive, tolerates extra headers, and caps frame bodies at
  64 MiB to fail closed on absurd declared sizes.
- `cmd/reasonix-plugin-example` and all test helper servers (plugin, boot,
  desktop) were updated to the same dual-framing read, so the repo stays
  self-consistent.

## Verification

- `go test ./internal/plugin/ -count=1` — pass (incl. a new e2e test
  that drives initialize over a Content-Length-only server, the #7525 repro)
- `go test ./internal/boot/ -count=1` — pass
- desktop MCP launch e2e tests — pass
- gofmt / go vet — clean

Cache-impact: none — plugin transport change only, no prompt-cache surface
Cache-guard: go test ./internal/plugin/ ./internal/boot/ — framing only, prompt/tool schema bytes untouched
System-prompt-review: test-only change; no system-prompt surface modified; CI + maintainer review
Documentation-impact: none - protocol docs live in cmd/reasonix-plugin-example header comments, updated in this PR