### PR TITLE
fix(cli): TUI diagnostics, keyring timeout, Reasonix-home paths / 启动诊断、keyring 超时与 home 路径加固

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,12 @@ jobs:
       # Pull requests run a Windows smoke suite: the packages that actually
       # carry *_windows.go code, the startup/checkpoint packages with portable
       # filesystem contracts, plus cmd/. The full ./... sweep stays on pushes
-      # to main-v2; the Unix legs always run the full suite.
+      # to main-v2; the Unix legs always run the full suite. Keep the job-level
+      # budget above normal 7-9 minute runner variance; each package test binary
+      # remains independently bounded by Go's 3 minute timeout below.
       - name: test (Windows smoke)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"

--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -22,6 +22,9 @@ var version = "dev"
 var runCLI = cli.Run
 
 func main() {
+	if code, handled := config.MaybeRunLegacyKeyringHelper(); handled {
+		os.Exit(code)
+	}
 	os.Exit(runWithCrashCapture(os.Args[1:], version))
 }
 

--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -22,9 +22,6 @@ var version = "dev"
 var runCLI = cli.Run
 
 func main() {
-	if code, handled := config.MaybeRunLegacyKeyringHelper(); handled {
-		os.Exit(code)
-	}
 	os.Exit(runWithCrashCapture(os.Args[1:], version))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/joho/godotenv v1.5.1
 	github.com/kevinburke/ssh_config v1.6.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.5
@@ -54,7 +55,6 @@ require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dlclark/regexp2/v2 v2.2.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect

--- a/internal/capdiag/collect.go
+++ b/internal/capdiag/collect.go
@@ -57,19 +57,19 @@ func Collect(opts Options) Report {
 	if cfgErr != nil {
 		issues = append(issues, Issue{
 			Severity: "error", Code: "config.load_failed", Subsystem: "config",
-			Message:     "failed to load configuration: " + sanitizeErrTextWithPaths(cfgErr.Error(), root, home),
+			Message:     "failed to load configuration: " + sanitizeErrTextWithPaths(cfgErr.Error(), root, home, reasonixHome),
 			Remediation: "Fix reasonix.toml / config.toml syntax, then re-run doctor capabilities",
 		})
 	}
 
-	disp := func(p string) string { return displayPath(p, root, home) }
+	disp := func(p string) string { return displayPath(p, root, home, reasonixHome) }
 
 	instr, instructionIssues := collectInstructions(root, home, disp)
 	skillsR, skillIssues := collectSkills(root, home, reasonixHome, cfg, disp)
 	cmdsR, cmdIssues := collectCommands(root, disp)
 	hooksR, hookIssues := collectHooks(root, home, reasonixHome, cfg, disp)
 	pluginsR, pluginIssues := collectPlugins(reasonixHome, disp)
-	mcpR, mcpIssues := collectMCP(cfg, root, home, disp)
+	mcpR, mcpIssues := collectMCP(cfg, root, home, reasonixHome, disp)
 
 	issues = append(issues, instructionIssues...)
 	issues = append(issues, skillIssues...)
@@ -80,10 +80,10 @@ func Collect(opts Options) Report {
 
 	// Runtime host merge (desktop) or live probe (CLI).
 	if opts.Live {
-		liveIssues := probeLiveMCP(&mcpR, cfg, root, home, opts.LiveTimeout)
+		liveIssues := probeLiveMCP(&mcpR, cfg, root, home, reasonixHome, opts.LiveTimeout)
 		issues = append(issues, liveIssues...)
 	} else if opts.RuntimeHost != nil {
-		mergeRuntimeHost(&mcpR, opts.RuntimeHost, root, home, &issues)
+		mergeRuntimeHost(&mcpR, opts.RuntimeHost, root, home, reasonixHome, &issues)
 	}
 
 	sortIssues(issues)
@@ -287,14 +287,10 @@ func collectCommands(root string, disp func(string) string) (AssetReport, []Issu
 
 func collectHooks(root, home, reasonixHome string, cfg *config.Config, disp func(string) string) (HookReport, []Issue) {
 	var issues []Issue
-	// Prefer explicit home for settings when tests isolate HOME.
-	homeDir := home
-	if reasonixHome != "" && home == "" {
-		homeDir = filepath.Dir(reasonixHome)
-	}
 	insp := hook.Inspect(hook.LoadOptions{
-		ProjectRoot: root,
-		HomeDir:     homeDir,
+		ProjectRoot:     root,
+		HomeDir:         home,
+		ReasonixHomeDir: reasonixHome,
 	})
 	runtimeOptions := hook.RuntimeOptions{}
 	if cfg != nil {
@@ -325,7 +321,7 @@ func collectHooks(root, home, reasonixHome string, cfg *config.Config, disp func
 	}
 	for _, e := range insp.Entries {
 		rep.Entries = append(rep.Entries, HookEntry{
-			Event: string(e.Event), Match: e.Match, Command: redactCommandDisplay(e.Command, root, home),
+			Event: string(e.Event), Match: e.Match, Command: redactCommandDisplay(e.Command, root, home, reasonixHome),
 			ContextFile: disp(e.ContextFile), Description: e.Description, TimeoutMS: e.Timeout,
 			Scope: string(e.Scope), Source: disp(e.Source), Blocking: hook.IsBlocking(e.Event),
 		})
@@ -465,7 +461,7 @@ func collectPlugins(reasonixHome string, disp func(string) string) (PluginPackag
 	return rep, issues
 }
 
-func collectMCP(cfg *config.Config, root, home string, disp func(string) string) (MCPReport, []Issue) {
+func collectMCP(cfg *config.Config, root, home, reasonixHome string, disp func(string) string) (MCPReport, []Issue) {
 	var issues []Issue
 	rep := MCPReport{Servers: []MCPServerInfo{}}
 	if cfg == nil {
@@ -501,7 +497,7 @@ func collectMCP(cfg *config.Config, root, home string, disp func(string) string)
 			}
 		}
 		if info.Transport == "stdio" {
-			info.Command = redactCommandDisplay(p.Command, root, home)
+			info.Command = redactCommandDisplay(p.Command, root, home, reasonixHome)
 		} else {
 			info.URLHost = urlHostOnly(p.URL)
 		}
@@ -581,7 +577,7 @@ func commandExists(cmd string) bool {
 	return false
 }
 
-func mergeRuntimeHost(rep *MCPReport, host *plugin.Host, root, home string, issues *[]Issue) {
+func mergeRuntimeHost(rep *MCPReport, host *plugin.Host, root, home, reasonixHome string, issues *[]Issue) {
 	if host == nil {
 		return
 	}
@@ -615,13 +611,13 @@ func mergeRuntimeHost(rep *MCPReport, host *plugin.Host, root, home string, issu
 		}
 	}
 	for _, f := range host.Failures() {
-		errText := sanitizeErrTextWithPaths(f.Error, root, home)
+		errText := sanitizeErrTextWithPaths(f.Error, root, home, reasonixHome)
 		if i, ok := byName[f.Name]; ok {
 			rep.Servers[i].RuntimeStatus = "failed"
 			rep.Servers[i].Error = errText
 			rep.Servers[i].StartupStage = f.Stage
 			rep.Servers[i].StartupElapsedMS = f.Elapsed.Milliseconds()
-			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home)
+			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home, reasonixHome)
 		}
 		*issues = append(*issues, Issue{
 			Severity: "error", Code: "mcp.start_failed", Subsystem: "mcp",
@@ -669,10 +665,10 @@ func sanitizeErr(err error) string {
 // sanitizeErrText redacts secrets and machine-local identity from diagnostic
 // strings. Prefer sanitizeErrTextWithPaths when workspace/home are known.
 func sanitizeErrText(s string) string {
-	return sanitizeErrTextWithPaths(s, "", "")
+	return sanitizeErrTextWithPaths(s, "", "", "")
 }
 
-func sanitizeErrTextWithPaths(s, workspace, home string) string {
+func sanitizeErrTextWithPaths(s, workspace, home, reasonixHome string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return s
@@ -705,7 +701,7 @@ func sanitizeErrTextWithPaths(s, workspace, home string) string {
 	s = redactBearer(s)
 
 	// Absolute paths: rewrite with displayPath when possible.
-	s = redactAbsolutePaths(s, workspace, home)
+	s = redactAbsolutePaths(s, workspace, home, reasonixHome)
 
 	// Cap length after redaction.
 	const max = 400
@@ -757,7 +753,7 @@ func redactBearer(s string) string {
 	}
 }
 
-func redactAbsolutePaths(s, workspace, home string) string {
+func redactAbsolutePaths(s, workspace, home, reasonixHome string) string {
 	// Walk for POSIX and Windows absolute path-like tokens.
 	var b strings.Builder
 	i := 0
@@ -785,7 +781,7 @@ func redactAbsolutePaths(s, workspace, home string) string {
 		token := s[start:j]
 		// Only rewrite if it looks like a path with a directory separator beyond root.
 		if strings.ContainsAny(token, `/\`) && len(token) > 1 {
-			b.WriteString(displayPath(token, workspace, home))
+			b.WriteString(displayPath(token, workspace, home, reasonixHome))
 		} else {
 			b.WriteString(token)
 		}
@@ -794,7 +790,7 @@ func redactAbsolutePaths(s, workspace, home string) string {
 	return b.String()
 }
 
-func redactCommandDisplay(cmd, root, home string) string {
+func redactCommandDisplay(cmd, root, home, reasonixHome string) string {
 	cmd = strings.TrimSpace(cmd)
 	if cmd == "" {
 		return ""
@@ -804,7 +800,7 @@ func redactCommandDisplay(cmd, root, home string) string {
 	if len(fields) == 0 {
 		return ""
 	}
-	return displayPath(fields[0], root, home)
+	return displayPath(fields[0], root, home, reasonixHome)
 }
 
 // ioDiscard avoids importing io in every call site for skill.Options.Stderr.

--- a/internal/capdiag/collect_test.go
+++ b/internal/capdiag/collect_test.go
@@ -122,6 +122,41 @@ auto_start = false
 	}
 }
 
+func TestCollectUsesExactReasonixHomeForGlobalHooks(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, "AppData", "Roaming", "reasonix")
+	write(t, filepath.Join(reasonixHome, "settings.json"), `{
+  "hooks": {
+    "SessionStart": [{"command": "echo exact-home"}]
+  }
+}`)
+
+	report := capdiag.Collect(capdiag.Options{
+		Root:            root,
+		HomeDir:         home,
+		ReasonixHomeDir: reasonixHome,
+	})
+	if report.Summary.Hooks != 1 || len(report.Hooks.Entries) != 1 {
+		t.Fatalf("hooks = %+v, summary = %+v", report.Hooks, report.Summary)
+	}
+	for _, source := range report.Hooks.Sources {
+		if source.Scope == "global" {
+			if source.Status != "ok" || source.HookCount != 1 {
+				t.Fatalf("global hook source = %+v, want exact Reasonix home settings", source)
+			}
+			if source.Path != "<reasonix-home>/settings.json" && source.Path != "<reasonix-home>\\settings.json" {
+				// displayPath uses ToSlash
+				if !strings.Contains(source.Path, "<reasonix-home>") {
+					t.Fatalf("global path = %q, want <reasonix-home> prefix", source.Path)
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("global hook source not reported")
+}
+
 func TestMissingConventionDirsNoWarning(t *testing.T) {
 	root := t.TempDir()
 	home := t.TempDir()

--- a/internal/capdiag/live.go
+++ b/internal/capdiag/live.go
@@ -20,7 +20,7 @@ func lookPath(cmd string) (string, error) {
 // connection results, and always closes the Host (including stdio children).
 // Persistence (startup stats / schema cache) is disabled so --live stays
 // free of cache/state side effects under Reasonix home.
-func probeLiveMCP(rep *MCPReport, cfg *config.Config, root, home string, timeout time.Duration) []Issue {
+func probeLiveMCP(rep *MCPReport, cfg *config.Config, root, home, reasonixHome string, timeout time.Duration) []Issue {
 	var issues []Issue
 	if cfg == nil {
 		return issues
@@ -99,13 +99,13 @@ func probeLiveMCP(rep *MCPReport, cfg *config.Config, root, home string, timeout
 		}
 	}
 	for _, f := range host.Failures() {
-		errText := sanitizeErrTextWithPaths(f.Error, root, home)
+		errText := sanitizeErrTextWithPaths(f.Error, root, home, reasonixHome)
 		if i, ok := byName[f.Name]; ok {
 			rep.Servers[i].RuntimeStatus = "failed"
 			rep.Servers[i].Error = errText
 			rep.Servers[i].StartupStage = f.Stage
 			rep.Servers[i].StartupElapsedMS = f.Elapsed.Milliseconds()
-			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home)
+			rep.Servers[i].Stderr = sanitizeErrTextWithPaths(f.Stderr, root, home, reasonixHome)
 		}
 		issues = append(issues, Issue{
 			Severity: "error", Code: "mcp.start_failed", Subsystem: "mcp",

--- a/internal/capdiag/paths.go
+++ b/internal/capdiag/paths.go
@@ -9,9 +9,10 @@ import (
 
 // displayPath rewrites absolute paths for safe reports:
 //   - under workspace → <workspace>/...
-//   - under home → ~/...
+//   - under Reasonix home → <reasonix-home>/...
+//   - under OS home → ~/...
 //   - elsewhere → <external>/basename (no full external path, no username)
-func displayPath(p, workspace, home string) string {
+func displayPath(p, workspace, home, reasonixHome string) string {
 	p = strings.TrimSpace(p)
 	if p == "" {
 		return ""
@@ -34,6 +35,18 @@ func displayPath(p, workspace, home string) string {
 		}
 		if rel, err := filepath.Rel(ws, clean); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 			return "<workspace>/" + filepath.ToSlash(rel)
+		}
+	}
+	if rh := strings.TrimSpace(reasonixHome); rh != "" {
+		if abs, err := filepath.Abs(rh); err == nil {
+			rh = abs
+		}
+		rh = filepath.Clean(rh)
+		if clean == rh {
+			return "<reasonix-home>"
+		}
+		if rel, err := filepath.Rel(rh, clean); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return "<reasonix-home>/" + filepath.ToSlash(rel)
 		}
 	}
 	if home == "" {

--- a/internal/capdiag/sanitize_test.go
+++ b/internal/capdiag/sanitize_test.go
@@ -10,7 +10,7 @@ func TestSanitizeErrTextRedactsSecretsAndPaths(t *testing.T) {
 	ws := t.TempDir()
 	in := "stdio plugin \"x\": command \"npx\" not found on PATH; PATH=\"" + home + "/bin:/usr/bin\" Bearer sk-secret-token " +
 		ws + "/secret.env stderr: Authorization=Bearer abc.def"
-	out := sanitizeErrTextWithPaths(in, ws, home)
+	out := sanitizeErrTextWithPaths(in, ws, home, "")
 	if strings.Contains(out, home) {
 		t.Fatalf("home path leaked: %q", out)
 	}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -48,6 +48,10 @@ type chatTUI struct {
 	ctrl    control.SessionAPI
 	label   string
 	missing string // missing-key warning surfaced once in the banner, "" when ready
+	// diagnostics is the process-owned TUI log/watchdog started before terminal
+	// takeover. Nil in unit tests that construct chatTUI without chatREPL.
+	diagnostics      *tuiDiagnostics
+	firstFrameLogged bool
 
 	width  int
 	height int
@@ -845,6 +849,17 @@ func suspendWithMouseReset() tea.Cmd {
 }
 
 func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Feed the startup/stall watchdog so freezes leave a goroutine dump and
+	// recover the terminal instead of a zero-byte log (#7435).
+	if m.diagnostics != nil {
+		m.diagnostics.markProgress()
+	}
+	logFirstFrame := false
+	if m.diagnostics != nil && !m.firstFrameLogged {
+		if _, ok := msg.(tea.WindowSizeMsg); ok {
+			logFirstFrame = true
+		}
+	}
 	wasAtBottom := m.viewport.AtBottom()
 	prevLines := len(m.transcript)
 	prevWidth := m.width
@@ -856,6 +871,12 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	next, cmd := m.update(msg)
 	cm := next.(chatTUI)
+	if logFirstFrame {
+		cm.firstFrameLogged = true
+		if cm.diagnostics != nil {
+			cm.diagnostics.Milestone("first_frame")
+		}
+	}
 
 	contentW := transcriptContentWidth(cm.width, cm.nativeScrollback)
 	cm.viewport.SetWidth(contentW)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1049,16 +1049,18 @@ func chatREPL(args []string, version string) int {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
 	}
+	// Bubble Tea owns the terminal from the resume picker through controller
+	// shutdown. Start diagnostics before config/controller work so hangs leave a
+	// non-zero log with milestones (#7435, #7507).
+	diagnostics := startTUIDiagnostics(config.ReasonixHomeDir())
+	defer diagnostics.Close()
+	diagnostics.Milestone("config_load_begin")
 	cfg, err := config.Load()
 	if err == nil {
 		configureCLIThemeWithStyle(cfg.UITheme(), cfg.UIThemeStyle())
 		cliCursorShape = cfg.UICursorShape()
 	}
-	// Bubble Tea owns the terminal from the resume picker through controller
-	// shutdown. Route process logs and plugin stderr to a private, bounded file
-	// for that whole lifetime; user-facing warnings arrive as typed TUI events.
-	diagnostics := startTUIDiagnostics(config.ReasonixHomeDir())
-	defer diagnostics.Close()
+	diagnostics.Milestone("config_load_done")
 
 	// Decide whether we're starting fresh or resuming. --resume opens an
 	// interactive picker; --continue / -c jumps straight into the newest.
@@ -1154,6 +1156,7 @@ func chatREPL(args []string, version string) int {
 		Stderr:             diagnostics.Writer(),
 		OnSessionRecovered: cliSessionRecoveredHandler(leases),
 	}
+	diagnostics.Milestone("controller_build_begin")
 	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, false, sink, profile, overrides)
 	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
 		// True first run whose default model can't resolve: guide setup, then retry.
@@ -1169,6 +1172,7 @@ func chatREPL(args []string, version string) int {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
 	}
+	diagnostics.Milestone("controller_build_done")
 
 	// Decide where this conversation's auto-save lands. A resume reuses the
 	// file so closing/reopening keeps appending to the same history; a fresh
@@ -1231,9 +1235,10 @@ func chatREPL(args []string, version string) int {
 	}
 
 	m := newChatTUI(ctrl, missing, eventCh, termW)
+	m.diagnostics = diagnostics
 	m.planMode = permissions.plan
 	m.leases = leases
-	if cfg, err := config.Load(); err == nil {
+	if cfg != nil {
 		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
 		m.showReasoning = cfg.UI.ShowReasoning   // /verbose persistence: start with config default
@@ -1310,7 +1315,9 @@ func chatREPL(args []string, version string) int {
 	// Non-Termux terminals use an alt-screen transcript viewport. Termux stays
 	// in the normal buffer so native touch scrollback and soft-keyboard focus
 	// keep working; finalized transcript lines are emitted via tea.Println.
+	diagnostics.Milestone("terminal_takeover_begin")
 	p := tea.NewProgram(m)
+	diagnostics.StartWatchdog(p)
 	// SSH drop (SIGHUP) or service stop (SIGTERM): persist the conversation
 	// before the terminal goes away, then unwind through the normal close path
 	// so resume picks up the interrupted session (#3772).
@@ -1323,6 +1330,7 @@ func chatREPL(args []string, version string) int {
 	}()
 	final, runErr := p.Run()
 	signal.Stop(hangup)
+	diagnostics.Milestone("terminal_released")
 	// Close the active controller plus any retired ones from /model switches.
 	// Retired controllers were stashed rather than closed at switch time
 	// because Controller.Close() runs SessionEnd hooks and kills plugin

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -20,7 +20,6 @@ const (
 	tuiDiagnosticLogRetention = 7 * 24 * time.Hour
 	tuiWatchdogInterval       = time.Second
 	tuiWatchdogStall          = 10 * time.Second
-	tuiWatchdogCloseWait      = 2 * time.Second
 )
 
 // tuiDiagnostics owns process-level diagnostics while an interactive terminal
@@ -177,16 +176,10 @@ func (d *tuiDiagnostics) Close() {
 		default:
 			close(d.stopWatch)
 		}
-		// Wait for the watchdog to stop writing before closing the log file.
-		done := make(chan struct{})
-		go func() {
-			d.watchWG.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(tuiWatchdogCloseWait):
-		}
+		// Wait for the watchdog to fully exit before closing the log. A timed
+		// wait left a window where runtime.Stack / Sync / Kill could still write
+		// the file after Close returned.
+		d.watchWG.Wait()
 		// Do not overwrite a logger deliberately installed by another owner
 		// after the TUI started.
 		if slog.Default() == d.logger && d.previous != nil {

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -1,18 +1,25 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+
+	tea "charm.land/bubbletea/v2"
 )
 
 const (
 	tuiDiagnosticLogLimit     = 4 << 20
 	tuiDiagnosticLogRetention = 7 * 24 * time.Hour
+	tuiWatchdogInterval       = time.Second
+	tuiWatchdogStall          = 10 * time.Second
 )
 
 // tuiDiagnostics owns process-level diagnostics while an interactive terminal
@@ -20,6 +27,9 @@ const (
 // plugin stderr must go to a private file instead of bypassing its renderer.
 // Failure to create that file degrades to io.Discard: typed event.Notice values
 // still carry user-facing warnings through the TUI.
+//
+// Milestones and a 1s heartbeat keep the log non-empty during hangs so Windows
+// ConPTY freezes (#7435) and stuck D-Bus startups leave recoverable evidence.
 type tuiDiagnostics struct {
 	previous *slog.Logger
 	logger   *slog.Logger
@@ -27,10 +37,16 @@ type tuiDiagnostics struct {
 	file     *os.File
 	path     string
 	close    sync.Once
+
+	mu           sync.Mutex
+	lastProgress atomic.Int64 // unix nano of last Update/View progress
+	stopWatch    chan struct{}
+	watchOnce    sync.Once
+	killed       atomic.Bool
 }
 
 func startTUIDiagnostics(reasonixHome string) *tuiDiagnostics {
-	d := &tuiDiagnostics{previous: slog.Default(), writer: io.Discard}
+	d := &tuiDiagnostics{previous: slog.Default(), writer: io.Discard, stopWatch: make(chan struct{})}
 	if logDir := tuiDiagnosticLogDir(reasonixHome); logDir != "" {
 		if err := os.MkdirAll(logDir, 0o700); err == nil {
 			pruneTUIDiagnosticLogs(logDir, time.Now())
@@ -43,7 +59,45 @@ func startTUIDiagnostics(reasonixHome string) *tuiDiagnostics {
 	}
 	d.logger = slog.New(slog.NewTextHandler(d.writer, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(d.logger)
+	d.markProgress()
+	d.Milestone("diagnostics_started")
 	return d
+}
+
+// Milestone records a startup/runtime phase and flushes the log immediately so a
+// subsequent hang still leaves a non-zero diagnostic file.
+func (d *tuiDiagnostics) Milestone(name string) {
+	if d == nil {
+		return
+	}
+	d.markProgress()
+	msg := fmt.Sprintf("milestone=%s t=%s", strings.TrimSpace(name), time.Now().UTC().Format(time.RFC3339Nano))
+	_, _ = fmt.Fprintln(d.Writer(), msg)
+	d.Sync()
+}
+
+// Sync flushes the diagnostic file to disk when possible.
+func (d *tuiDiagnostics) Sync() {
+	if d == nil || d.file == nil {
+		return
+	}
+	_ = d.file.Sync()
+}
+
+// markProgress records that the TUI event loop is alive.
+func (d *tuiDiagnostics) markProgress() {
+	if d == nil {
+		return
+	}
+	d.lastProgress.Store(time.Now().UnixNano())
+}
+
+// Path returns the diagnostic log path (empty when falling back to Discard).
+func (d *tuiDiagnostics) Path() string {
+	if d == nil {
+		return ""
+	}
+	return d.path
 }
 
 func (d *tuiDiagnostics) Writer() io.Writer {
@@ -53,17 +107,78 @@ func (d *tuiDiagnostics) Writer() io.Writer {
 	return d.writer
 }
 
+// StartWatchdog arms a 1s heartbeat. If the TUI event loop makes no progress for
+// 10s, it dumps all goroutines, syncs the log, and kills the Bubble Tea program
+// so the terminal is restored instead of remaining frozen (#7435).
+func (d *tuiDiagnostics) StartWatchdog(p *tea.Program) {
+	if d == nil || p == nil {
+		return
+	}
+	d.watchOnce.Do(func() {
+		d.markProgress()
+		go d.watch(p)
+	})
+}
+
+func (d *tuiDiagnostics) watch(p *tea.Program) {
+	ticker := time.NewTicker(tuiWatchdogInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-d.stopWatch:
+			return
+		case now := <-ticker.C:
+			last := time.Unix(0, d.lastProgress.Load())
+			age := now.Sub(last)
+			_, _ = fmt.Fprintf(d.Writer(), "heartbeat t=%s last_progress_age=%s\n",
+				now.UTC().Format(time.RFC3339Nano), age.Round(time.Millisecond))
+			d.Sync()
+			if age < tuiWatchdogStall || d.killed.Load() {
+				continue
+			}
+			d.killed.Store(true)
+			d.dumpGoroutines("watchdog_stall")
+			d.Sync()
+			// Kill restores the terminal; Quit alone can hang if Update is blocked.
+			p.Kill()
+			return
+		}
+	}
+}
+
+func (d *tuiDiagnostics) dumpGoroutines(reason string) {
+	if d == nil {
+		return
+	}
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, len(buf)*2)
+	}
+	_, _ = fmt.Fprintf(d.Writer(), "goroutine_dump reason=%s bytes=%d\n%s\n", reason, len(buf), buf)
+}
+
 func (d *tuiDiagnostics) Close() {
 	if d == nil {
 		return
 	}
 	d.close.Do(func() {
+		select {
+		case <-d.stopWatch:
+		default:
+			close(d.stopWatch)
+		}
 		// Do not overwrite a logger deliberately installed by another owner
 		// after the TUI started.
 		if slog.Default() == d.logger && d.previous != nil {
 			slog.SetDefault(d.previous)
 		}
 		if d.file != nil {
+			_ = d.file.Sync()
 			_ = d.file.Close()
 		}
 	})

--- a/internal/cli/tui_diagnostics.go
+++ b/internal/cli/tui_diagnostics.go
@@ -20,6 +20,7 @@ const (
 	tuiDiagnosticLogRetention = 7 * 24 * time.Hour
 	tuiWatchdogInterval       = time.Second
 	tuiWatchdogStall          = 10 * time.Second
+	tuiWatchdogCloseWait      = 2 * time.Second
 )
 
 // tuiDiagnostics owns process-level diagnostics while an interactive terminal
@@ -38,10 +39,10 @@ type tuiDiagnostics struct {
 	path     string
 	close    sync.Once
 
-	mu           sync.Mutex
 	lastProgress atomic.Int64 // unix nano of last Update/View progress
 	stopWatch    chan struct{}
 	watchOnce    sync.Once
+	watchWG      sync.WaitGroup
 	killed       atomic.Bool
 }
 
@@ -116,7 +117,11 @@ func (d *tuiDiagnostics) StartWatchdog(p *tea.Program) {
 	}
 	d.watchOnce.Do(func() {
 		d.markProgress()
-		go d.watch(p)
+		d.watchWG.Add(1)
+		go func() {
+			defer d.watchWG.Done()
+			d.watch(p)
+		}()
 	})
 }
 
@@ -171,6 +176,16 @@ func (d *tuiDiagnostics) Close() {
 		case <-d.stopWatch:
 		default:
 			close(d.stopWatch)
+		}
+		// Wait for the watchdog to stop writing before closing the log file.
+		done := make(chan struct{})
+		go func() {
+			d.watchWG.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(tuiWatchdogCloseWait):
 		}
 		// Do not overwrite a logger deliberately installed by another owner
 		// after the TUI started.

--- a/internal/cli/tui_diagnostics_test.go
+++ b/internal/cli/tui_diagnostics_test.go
@@ -144,3 +144,26 @@ func TestCLIProfileBuildOptionsUseResolvedLocaleForAutoPricing(t *testing.T) {
 		}
 	}
 }
+
+func TestTUIDiagnosticsMilestoneFlushesNonEmptyLog(t *testing.T) {
+	home := t.TempDir()
+	d := startTUIDiagnostics(home)
+	t.Cleanup(d.Close)
+	d.Milestone("config_load_begin")
+	d.Milestone("controller_build_done")
+	if d.Path() == "" {
+		t.Fatal("expected diagnostic log path")
+	}
+	body, err := os.ReadFile(d.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) == 0 {
+		t.Fatal("diagnostic log must not be empty after milestones")
+	}
+	for _, want := range []string{"diagnostics_started", "config_load_begin", "controller_build_done"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("log missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -64,38 +64,18 @@ var credentialSourceTracker = struct {
 var userCredentialEditMu sync.Mutex
 
 var storedCredentialValueLookup = storedCredentialValue
+
+// legacyKeyringCredentialValueImpl is the platform keyring probe. Production
+// migration never calls it in-process; it runs only inside an isolated helper
+// child so a stuck D-Bus can be killed with the process (#7507).
 var legacyKeyringCredentialValueImpl = legacyKeyringCredentialValue
-var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValueWithTimeout
 
-// legacyKeyringLookupTimeout bounds Secret Service / platform keyring probes
-// during legacy credential migration. An unhealthy session bus (stuck
-// gnome-keyring, etc.) must not hang CLI startup indefinitely (#7507).
-// The shared budget for a full migration scan is applied in migrateLegacyCredentialsIfNeededForRoot.
+// legacyKeyringCredentialValueLookup is the test-facing single-key hook. Unit
+// tests substitute it; production migration uses the helper batch path instead.
+var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValue
+
+// legacyKeyringLookupTimeout is the shared budget for one legacy keyring scan.
 var legacyKeyringLookupTimeout = time.Second
-
-// legacyKeyringCredentialValueWithTimeout wraps the platform keyring lookup so
-// a stuck D-Bus reply fails closed (treat as missing) instead of blocking the
-// process. A hung probe may leave a short-lived goroutine until the bus
-// answers; that is preferable to never starting.
-func legacyKeyringCredentialValueWithTimeout(key string) (string, bool) {
-	type result struct {
-		value string
-		ok    bool
-	}
-	ch := make(chan result, 1)
-	go func() {
-		value, ok := legacyKeyringCredentialValueImpl(key)
-		ch <- result{value: value, ok: ok}
-	}()
-	timer := time.NewTimer(legacyKeyringLookupTimeout)
-	defer timer.Stop()
-	select {
-	case r := <-ch:
-		return r.value, r.ok
-	case <-timer.C:
-		return "", false
-	}
-}
 
 // CredentialResolver resolves credentials repeatedly for one caller-owned view
 // build. It keeps expensive global credential-store lookups bounded to one per

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/joho/godotenv"
 
@@ -63,7 +64,38 @@ var credentialSourceTracker = struct {
 var userCredentialEditMu sync.Mutex
 
 var storedCredentialValueLookup = storedCredentialValue
-var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValue
+var legacyKeyringCredentialValueImpl = legacyKeyringCredentialValue
+var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValueWithTimeout
+
+// legacyKeyringLookupTimeout bounds Secret Service / platform keyring probes
+// during legacy credential migration. An unhealthy session bus (stuck
+// gnome-keyring, etc.) must not hang CLI startup indefinitely (#7507).
+// The shared budget for a full migration scan is applied in migrateLegacyCredentialsIfNeededForRoot.
+var legacyKeyringLookupTimeout = time.Second
+
+// legacyKeyringCredentialValueWithTimeout wraps the platform keyring lookup so
+// a stuck D-Bus reply fails closed (treat as missing) instead of blocking the
+// process. A hung probe may leave a short-lived goroutine until the bus
+// answers; that is preferable to never starting.
+func legacyKeyringCredentialValueWithTimeout(key string) (string, bool) {
+	type result struct {
+		value string
+		ok    bool
+	}
+	ch := make(chan result, 1)
+	go func() {
+		value, ok := legacyKeyringCredentialValueImpl(key)
+		ch <- result{value: value, ok: ok}
+	}()
+	timer := time.NewTimer(legacyKeyringLookupTimeout)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.value, r.ok
+	case <-timer.C:
+		return "", false
+	}
+}
 
 // CredentialResolver resolves credentials repeatedly for one caller-owned view
 // build. It keeps expensive global credential-store lookups bounded to one per

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -65,14 +65,14 @@ var userCredentialEditMu sync.Mutex
 
 var storedCredentialValueLookup = storedCredentialValue
 
-// legacyKeyringCredentialValueImpl is the platform keyring probe. Production
-// migration never calls it in-process; it runs only inside an isolated helper
+// legacyKeyringProbeImpl is the platform keyring probe. Production migration
+// never calls it in the parent process; it runs only inside an isolated helper
 // child so a stuck D-Bus can be killed with the process (#7507).
-var legacyKeyringCredentialValueImpl = legacyKeyringCredentialValue
+var legacyKeyringProbeImpl = legacyKeyringProbe
 
-// legacyKeyringCredentialValueLookup is the test-facing single-key hook. Unit
-// tests substitute it; production migration uses the helper batch path instead.
-var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValue
+// legacyKeyringProbeLookup is the test-facing single-key hook returning the full
+// four-state outcome. Unit tests substitute it; production uses the helper.
+var legacyKeyringProbeLookup = legacyKeyringProbe
 
 // legacyKeyringLookupTimeout is the shared budget for one legacy keyring scan.
 var legacyKeyringLookupTimeout = time.Second

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -65,13 +65,8 @@ var userCredentialEditMu sync.Mutex
 
 var storedCredentialValueLookup = storedCredentialValue
 
-// legacyKeyringProbeImpl is the platform keyring probe. Production migration
-// never calls it in the parent process; it runs only inside an isolated helper
-// child so a stuck D-Bus can be killed with the process (#7507).
-var legacyKeyringProbeImpl = legacyKeyringProbe
-
 // legacyKeyringProbeLookup is the test-facing single-key hook returning the full
-// four-state outcome. Unit tests substitute it; production uses the helper.
+// four-state outcome under a caller-owned context (shared 1s migration budget).
 var legacyKeyringProbeLookup = legacyKeyringProbe
 
 // legacyKeyringLookupTimeout is the shared budget for one legacy keyring scan.
@@ -286,6 +281,34 @@ func StoreCredentialLines(lines []string) (string, error) {
 	}
 	defer unlock()
 	return storeCredentialAssignmentsLocked(assignments)
+}
+
+// storeCredentialIfAbsentAndNotCleared writes key=value only when the current
+// credential store still lacks a value and a cleared tombstone for key. The
+// re-check and write share LockUserCredentialEdits so a concurrent settings
+// save or tombstone cannot be overwritten by a stale keyring import.
+// stored is false when the write was skipped because the key is already present
+// or cleared; err is non-nil only on lock/IO failures.
+func storeCredentialIfAbsentAndNotCleared(key, value string) (stored bool, err error) {
+	key = strings.TrimSpace(key)
+	if key == "" || !isCredentialKey(key) {
+		return false, nil
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return false, fmt.Errorf("credential value for %s contains a newline", key)
+	}
+	unlock, err := LockUserCredentialEdits()
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
+	if credentialCurrentStoreHasKey(key) || credentialCurrentStoreClearedKey(key) {
+		return false, nil
+	}
+	if _, err := storeCredentialAssignmentsLocked(map[string]string{key: value}); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func storeCredentialAssignmentsLocked(assignments map[string]string) (string, error) {

--- a/internal/config/credentials_keyring_default.go
+++ b/internal/config/credentials_keyring_default.go
@@ -3,16 +3,28 @@
 package config
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/zalando/go-keyring"
 )
 
-func legacyKeyringCredentialValue(key string) (string, bool) {
+// legacyKeyringProbe reads one legacy credential from the platform keyring.
+// keyring.ErrNotFound (and empty values) are absent; other errors stay error.
+func legacyKeyringProbe(key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 	value, err := keyring.Get(credentialsKeyringService, key)
-	return value, err == nil && value != ""
+	if err != nil {
+		if errors.Is(err, keyring.ErrNotFound) {
+			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		}
+		return legacyKeyringOutcome{Status: legacyKeyringError}
+	}
+	if strings.TrimSpace(value) == "" {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
+	return legacyKeyringOutcome{Status: legacyKeyringFound, Value: value}
 }

--- a/internal/config/credentials_keyring_default.go
+++ b/internal/config/credentials_keyring_default.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -11,15 +12,23 @@ import (
 
 // legacyKeyringProbe reads one legacy credential from the platform keyring.
 // keyring.ErrNotFound (and empty values) are absent; other errors stay error.
-func legacyKeyringProbe(key string) legacyKeyringOutcome {
+// ctx is checked before the call so a shared batch budget can stop the scan;
+// platform Get is not context-aware on these OSes.
+func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
+	if err := ctx.Err(); err != nil {
+		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
 	}
 	value, err := keyring.Get(credentialsKeyringService, key)
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		}
+		if ctx.Err() != nil {
+			return legacyKeyringOutcome{Status: legacyKeyringTimeout}
 		}
 		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}

--- a/internal/config/credentials_keyring_helper.go
+++ b/internal/config/credentials_keyring_helper.go
@@ -1,22 +1,9 @@
 package config
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
-)
-
-const (
-	legacyKeyringHelperEnv  = "REASONIX_LEGACY_KEYRING_HELPER"
-	legacyKeyringKeysEnv    = "REASONIX_LEGACY_KEYRING_KEYS"
-	legacyKeyringStallEnv   = "REASONIX_LEGACY_KEYRING_HELPER_STALL" // test-only sleep before probes
-	legacyKeyringHelperFlag = "1"
 )
 
 // legacyKeyringStatus classifies one keyring probe outcome for migration.
@@ -31,91 +18,16 @@ const (
 )
 
 // legacyKeyringOutcome is the four-state result for one env key.
-// Value is only populated inside the helper (or in-process tests) before
-// secure storage; it is never returned to the parent process over stdout.
+// Value is populated only for found probes inside this process and is scrubbed
+// before the outcome is returned to migration callers after store-if-absent.
 type legacyKeyringOutcome struct {
 	Status legacyKeyringStatus
 	Value  string
 }
 
-type legacyKeyringHelperReport struct {
-	Results []legacyKeyringHelperResult `json:"results"`
-}
-
-// legacyKeyringHelperResult is parent-visible metadata only — no secret fields.
-type legacyKeyringHelperResult struct {
-	Key    string `json:"key"`
-	Status string `json:"status"`
-}
-
-// legacyKeyringHelperEnabled controls whether batch probes spawn an isolated
-// child. Tests disable it and drive legacyKeyringProbeLookup instead.
-var legacyKeyringHelperEnabled = true
-
-// MaybeRunLegacyKeyringHelper reports whether this process is the isolated
-// keyring helper. When handled is true, the caller must exit with code.
-func MaybeRunLegacyKeyringHelper() (code int, handled bool) {
-	if os.Getenv(legacyKeyringHelperEnv) != legacyKeyringHelperFlag {
-		return 0, false
-	}
-	return runLegacyKeyringHelper(), true
-}
-
-func runLegacyKeyringHelper() int {
-	// Optional stall lets unit tests prove Kill+Wait without a real stuck bus.
-	if raw := strings.TrimSpace(os.Getenv(legacyKeyringStallEnv)); raw != "" {
-		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-			time.Sleep(d)
-		}
-	}
-	keys := splitLegacyKeyringKeys(os.Getenv(legacyKeyringKeysEnv))
-	report := legacyKeyringHelperReport{Results: make([]legacyKeyringHelperResult, 0, len(keys))}
-	for _, key := range keys {
-		o := legacyKeyringProbeImpl(key)
-		status := o.Status
-		// Store found secrets inside the helper so stdout never carries plaintext
-		// credentials. A store failure is reported as error (no marker).
-		if status == legacyKeyringFound {
-			if strings.TrimSpace(o.Value) == "" {
-				status = legacyKeyringAbsent
-			} else if _, err := StoreCredentialLines([]string{key + "=" + o.Value}); err != nil {
-				status = legacyKeyringError
-			}
-		}
-		// Scrub before any further handling; never encode Value.
-		o.Value = ""
-		report.Results = append(report.Results, legacyKeyringHelperResult{
-			Key:    key,
-			Status: string(status),
-		})
-	}
-	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
-		fmt.Fprintln(os.Stderr, "legacy keyring helper encode:", err)
-		return 2
-	}
-	return 0
-}
-
-func splitLegacyKeyringKeys(raw string) []string {
-	if strings.TrimSpace(raw) == "" {
-		return nil
-	}
-	parts := strings.Split(raw, "\n")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
-// lookupLegacyKeyringBatch probes keys under a shared deadline.
-// Production uses one helper subprocess (Kill+Wait on timeout). Tests disable
-// the helper and resolve via legacyKeyringProbeLookup in-process.
-// Returned outcomes never include secret Values for the helper path; in-process
-// tests store found secrets before scrubbing Value.
+// lookupLegacyKeyringBatch probes keys under a single shared deadline in-process.
+// There is no external helper entrypoint: secrets never leave the process via
+// stdout or a caller-controlled REASONIX_HOME dump path.
 func lookupLegacyKeyringBatch(keys []string, budget time.Duration) map[string]legacyKeyringOutcome {
 	out := make(map[string]legacyKeyringOutcome, len(keys))
 	if len(keys) == 0 {
@@ -124,116 +36,40 @@ func lookupLegacyKeyringBatch(keys []string, budget time.Duration) map[string]le
 	if budget <= 0 {
 		budget = time.Second
 	}
-	if !legacyKeyringHelperEnabled {
-		return lookupLegacyKeyringBatchInProcess(keys)
-	}
-	return lookupLegacyKeyringBatchViaHelper(keys, budget)
-}
-
-func lookupLegacyKeyringBatchInProcess(keys []string) map[string]legacyKeyringOutcome {
-	out := make(map[string]legacyKeyringOutcome, len(keys))
-	for _, key := range keys {
-		o := legacyKeyringProbeLookup(key)
-		if o.Status == legacyKeyringFound {
-			if strings.TrimSpace(o.Value) == "" {
-				o = legacyKeyringOutcome{Status: legacyKeyringAbsent}
-			} else if _, err := StoreCredentialLines([]string{key + "=" + o.Value}); err != nil {
-				o = legacyKeyringOutcome{Status: legacyKeyringError}
-			} else {
-				o.Value = "" // never leave secrets in the returned map
-			}
-		}
-		out[key] = o
-	}
-	return out
-}
-
-func lookupLegacyKeyringBatchViaHelper(keys []string, budget time.Duration) map[string]legacyKeyringOutcome {
-	out := make(map[string]legacyKeyringOutcome, len(keys))
-	for _, key := range keys {
-		out[key] = legacyKeyringOutcome{Status: legacyKeyringTimeout}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), budget)
 	defer cancel()
 
-	cmd, err := legacyKeyringHelperCommand(ctx, keys)
-	if err != nil {
-		for _, key := range keys {
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
-		}
-		return out
-	}
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
-
-	// Always reap: context timeout kills the process; Wait is inside Run.
-	if ctx.Err() == context.DeadlineExceeded {
-		if stdout.Len() == 0 {
-			return out
-		}
-		// Partial metadata is rare; parse what arrived, leave others as timeout.
-	} else if runErr != nil {
-		for _, key := range keys {
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
-		}
-		return out
-	}
-
-	var report legacyKeyringHelperReport
-	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return out
-		}
-		for _, key := range keys {
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
-		}
-		return out
-	}
-	for _, res := range report.Results {
-		key := strings.TrimSpace(res.Key)
-		if key == "" {
+	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringTimeout}
 			continue
 		}
-		switch legacyKeyringStatus(res.Status) {
+		o := legacyKeyringProbeLookup(ctx, key)
+		switch o.Status {
 		case legacyKeyringFound:
-			// Helper already persisted any secret; parent only sees metadata.
+			if strings.TrimSpace(o.Value) == "" {
+				out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+				continue
+			}
+			stored, err := storeCredentialIfAbsentAndNotCleared(key, o.Value)
+			o.Value = "" // scrub before returning
+			if err != nil {
+				out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+				continue
+			}
+			if !stored {
+				// Current store already has a value or tombstone; do not apply
+				// the legacy keyring secret. Report found so migration does not
+				// re-probe endlessly without writing an absent marker.
+				out[key] = legacyKeyringOutcome{Status: legacyKeyringFound}
+				continue
+			}
 			out[key] = legacyKeyringOutcome{Status: legacyKeyringFound}
-		case legacyKeyringAbsent:
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
-		case legacyKeyringError:
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+		case legacyKeyringAbsent, legacyKeyringError, legacyKeyringTimeout:
+			out[key] = legacyKeyringOutcome{Status: o.Status}
 		default:
 			out[key] = legacyKeyringOutcome{Status: legacyKeyringTimeout}
 		}
 	}
 	return out
-}
-
-func legacyKeyringHelperCommand(ctx context.Context, keys []string) (*exec.Cmd, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		exe = os.Args[0]
-	}
-	args := helperProcessArgs()
-	cmd := exec.CommandContext(ctx, exe, args...)
-	cmd.Env = append(os.Environ(),
-		legacyKeyringHelperEnv+"="+legacyKeyringHelperFlag,
-		legacyKeyringKeysEnv+"="+strings.Join(keys, "\n"),
-	)
-	cmd.Stdin = nil
-	return cmd, nil
-}
-
-// helperProcessArgs avoids re-entering the full test suite when os.Executable
-// is a `go test` binary. Production reasonix has no -test.* flags.
-func helperProcessArgs() []string {
-	name := filepath.Base(os.Args[0])
-	if strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe") ||
-		strings.Contains(os.Args[0], string(filepath.Separator)+"_test"+string(filepath.Separator)) {
-		return []string{"-test.run=^$", "-test.v=false"}
-	}
-	return nil
 }

--- a/internal/config/credentials_keyring_helper.go
+++ b/internal/config/credentials_keyring_helper.go
@@ -1,0 +1,234 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	legacyKeyringHelperEnv  = "REASONIX_LEGACY_KEYRING_HELPER"
+	legacyKeyringKeysEnv    = "REASONIX_LEGACY_KEYRING_KEYS"
+	legacyKeyringStallEnv   = "REASONIX_LEGACY_KEYRING_HELPER_STALL" // test-only sleep before probes
+	legacyKeyringHelperFlag = "1"
+)
+
+// legacyKeyringStatus classifies one keyring probe outcome for migration.
+// Only StatusAbsent may write a migration-done marker.
+type legacyKeyringStatus string
+
+const (
+	legacyKeyringFound   legacyKeyringStatus = "found"
+	legacyKeyringAbsent  legacyKeyringStatus = "absent"
+	legacyKeyringError   legacyKeyringStatus = "error"
+	legacyKeyringTimeout legacyKeyringStatus = "timeout"
+)
+
+// legacyKeyringOutcome is the four-state result for one env key.
+type legacyKeyringOutcome struct {
+	Status legacyKeyringStatus
+	Value  string
+}
+
+type legacyKeyringHelperReport struct {
+	Results []legacyKeyringHelperResult `json:"results"`
+}
+
+type legacyKeyringHelperResult struct {
+	Key    string `json:"key"`
+	Status string `json:"status"`
+	Value  string `json:"value,omitempty"`
+}
+
+// legacyKeyringHelperEnabled controls whether batch probes spawn an isolated
+// child. Tests disable it and drive legacyKeyringCredentialValueLookup instead.
+var legacyKeyringHelperEnabled = true
+
+// MaybeRunLegacyKeyringHelper reports whether this process is the isolated
+// keyring helper. When handled is true, the caller must exit with code.
+func MaybeRunLegacyKeyringHelper() (code int, handled bool) {
+	if os.Getenv(legacyKeyringHelperEnv) != legacyKeyringHelperFlag {
+		return 0, false
+	}
+	return runLegacyKeyringHelper(), true
+}
+
+func runLegacyKeyringHelper() int {
+	// Optional stall lets unit tests prove Kill+Wait without a real stuck bus.
+	if raw := strings.TrimSpace(os.Getenv(legacyKeyringStallEnv)); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			time.Sleep(d)
+		}
+	}
+	keys := splitLegacyKeyringKeys(os.Getenv(legacyKeyringKeysEnv))
+	report := legacyKeyringHelperReport{Results: make([]legacyKeyringHelperResult, 0, len(keys))}
+	for _, key := range keys {
+		value, ok := legacyKeyringCredentialValueImpl(key)
+		res := legacyKeyringHelperResult{Key: key, Status: string(legacyKeyringAbsent)}
+		if ok {
+			if strings.TrimSpace(value) != "" {
+				res.Status = string(legacyKeyringFound)
+				res.Value = value
+			} else {
+				// Explicit empty secret is still a successful lookup with no usable value.
+				res.Status = string(legacyKeyringAbsent)
+			}
+		}
+		// Platform impl collapses transport errors into !ok; treat as absent so
+		// a healthy empty keyring can mark done. Process-level failures are
+		// reported by the parent when the helper exits non-zero or times out.
+		report.Results = append(report.Results, res)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		fmt.Fprintln(os.Stderr, "legacy keyring helper encode:", err)
+		return 2
+	}
+	return 0
+}
+
+func splitLegacyKeyringKeys(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, "\n")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// lookupLegacyKeyringBatch probes keys under a shared deadline.
+// Production uses one helper subprocess (Kill+Wait on timeout). Tests disable
+// the helper and resolve via legacyKeyringCredentialValueLookup in-process.
+func lookupLegacyKeyringBatch(keys []string, budget time.Duration) map[string]legacyKeyringOutcome {
+	out := make(map[string]legacyKeyringOutcome, len(keys))
+	if len(keys) == 0 {
+		return out
+	}
+	if budget <= 0 {
+		budget = time.Second
+	}
+	if !legacyKeyringHelperEnabled {
+		return lookupLegacyKeyringBatchInProcess(keys)
+	}
+	return lookupLegacyKeyringBatchViaHelper(keys, budget)
+}
+
+func lookupLegacyKeyringBatchInProcess(keys []string) map[string]legacyKeyringOutcome {
+	out := make(map[string]legacyKeyringOutcome, len(keys))
+	for _, key := range keys {
+		value, ok := legacyKeyringCredentialValueLookup(key)
+		if ok && strings.TrimSpace(value) != "" {
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringFound, Value: value}
+			continue
+		}
+		out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
+	return out
+}
+
+func lookupLegacyKeyringBatchViaHelper(keys []string, budget time.Duration) map[string]legacyKeyringOutcome {
+	out := make(map[string]legacyKeyringOutcome, len(keys))
+	for _, key := range keys {
+		out[key] = legacyKeyringOutcome{Status: legacyKeyringTimeout}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	cmd, err := legacyKeyringHelperCommand(ctx, keys)
+	if err != nil {
+		for _, key := range keys {
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+		}
+		return out
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	// Always reap: context timeout kills the process; Wait is inside Run.
+	if ctx.Err() == context.DeadlineExceeded {
+		// Kill may race with natural exit; leave timeout status for unfinished keys.
+		if stdout.Len() == 0 {
+			return out
+		}
+		// Partial stdout is unusual but parse what we got; unparsed stay timeout.
+	} else if runErr != nil {
+		for _, key := range keys {
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+		}
+		return out
+	}
+
+	var report legacyKeyringHelperReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return out
+		}
+		for _, key := range keys {
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+		}
+		return out
+	}
+	for _, res := range report.Results {
+		key := strings.TrimSpace(res.Key)
+		if key == "" {
+			continue
+		}
+		switch legacyKeyringStatus(res.Status) {
+		case legacyKeyringFound:
+			if strings.TrimSpace(res.Value) == "" {
+				out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+			} else {
+				out[key] = legacyKeyringOutcome{Status: legacyKeyringFound, Value: res.Value}
+			}
+		case legacyKeyringAbsent:
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		case legacyKeyringError:
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
+		default:
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringTimeout}
+		}
+	}
+	return out
+}
+
+func legacyKeyringHelperCommand(ctx context.Context, keys []string) (*exec.Cmd, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		exe = os.Args[0]
+	}
+	args := helperProcessArgs()
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Env = append(os.Environ(),
+		legacyKeyringHelperEnv+"="+legacyKeyringHelperFlag,
+		legacyKeyringKeysEnv+"="+strings.Join(keys, "\n"),
+	)
+	// Prevent the child from inheriting a half-built terminal state.
+	cmd.Stdin = nil
+	return cmd, nil
+}
+
+// helperProcessArgs avoids re-entering the full test suite when os.Executable
+// is a `go test` binary. Production reasonix has no -test.* flags.
+func helperProcessArgs() []string {
+	name := filepath.Base(os.Args[0])
+	if strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe") ||
+		strings.Contains(os.Args[0], string(filepath.Separator)+"_test"+string(filepath.Separator)) {
+		// Match no tests; TestMain still runs and dispatches the helper env.
+		return []string{"-test.run=^$", "-test.v=false"}
+	}
+	return nil
+}

--- a/internal/config/credentials_keyring_helper.go
+++ b/internal/config/credentials_keyring_helper.go
@@ -20,7 +20,7 @@ const (
 )
 
 // legacyKeyringStatus classifies one keyring probe outcome for migration.
-// Only StatusAbsent may write a migration-done marker.
+// Only absent may write a migration-done marker.
 type legacyKeyringStatus string
 
 const (
@@ -31,6 +31,8 @@ const (
 )
 
 // legacyKeyringOutcome is the four-state result for one env key.
+// Value is only populated inside the helper (or in-process tests) before
+// secure storage; it is never returned to the parent process over stdout.
 type legacyKeyringOutcome struct {
 	Status legacyKeyringStatus
 	Value  string
@@ -40,14 +42,14 @@ type legacyKeyringHelperReport struct {
 	Results []legacyKeyringHelperResult `json:"results"`
 }
 
+// legacyKeyringHelperResult is parent-visible metadata only — no secret fields.
 type legacyKeyringHelperResult struct {
 	Key    string `json:"key"`
 	Status string `json:"status"`
-	Value  string `json:"value,omitempty"`
 }
 
 // legacyKeyringHelperEnabled controls whether batch probes spawn an isolated
-// child. Tests disable it and drive legacyKeyringCredentialValueLookup instead.
+// child. Tests disable it and drive legacyKeyringProbeLookup instead.
 var legacyKeyringHelperEnabled = true
 
 // MaybeRunLegacyKeyringHelper reports whether this process is the isolated
@@ -69,21 +71,23 @@ func runLegacyKeyringHelper() int {
 	keys := splitLegacyKeyringKeys(os.Getenv(legacyKeyringKeysEnv))
 	report := legacyKeyringHelperReport{Results: make([]legacyKeyringHelperResult, 0, len(keys))}
 	for _, key := range keys {
-		value, ok := legacyKeyringCredentialValueImpl(key)
-		res := legacyKeyringHelperResult{Key: key, Status: string(legacyKeyringAbsent)}
-		if ok {
-			if strings.TrimSpace(value) != "" {
-				res.Status = string(legacyKeyringFound)
-				res.Value = value
-			} else {
-				// Explicit empty secret is still a successful lookup with no usable value.
-				res.Status = string(legacyKeyringAbsent)
+		o := legacyKeyringProbeImpl(key)
+		status := o.Status
+		// Store found secrets inside the helper so stdout never carries plaintext
+		// credentials. A store failure is reported as error (no marker).
+		if status == legacyKeyringFound {
+			if strings.TrimSpace(o.Value) == "" {
+				status = legacyKeyringAbsent
+			} else if _, err := StoreCredentialLines([]string{key + "=" + o.Value}); err != nil {
+				status = legacyKeyringError
 			}
 		}
-		// Platform impl collapses transport errors into !ok; treat as absent so
-		// a healthy empty keyring can mark done. Process-level failures are
-		// reported by the parent when the helper exits non-zero or times out.
-		report.Results = append(report.Results, res)
+		// Scrub before any further handling; never encode Value.
+		o.Value = ""
+		report.Results = append(report.Results, legacyKeyringHelperResult{
+			Key:    key,
+			Status: string(status),
+		})
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
 		fmt.Fprintln(os.Stderr, "legacy keyring helper encode:", err)
@@ -109,7 +113,9 @@ func splitLegacyKeyringKeys(raw string) []string {
 
 // lookupLegacyKeyringBatch probes keys under a shared deadline.
 // Production uses one helper subprocess (Kill+Wait on timeout). Tests disable
-// the helper and resolve via legacyKeyringCredentialValueLookup in-process.
+// the helper and resolve via legacyKeyringProbeLookup in-process.
+// Returned outcomes never include secret Values for the helper path; in-process
+// tests store found secrets before scrubbing Value.
 func lookupLegacyKeyringBatch(keys []string, budget time.Duration) map[string]legacyKeyringOutcome {
 	out := make(map[string]legacyKeyringOutcome, len(keys))
 	if len(keys) == 0 {
@@ -127,12 +133,17 @@ func lookupLegacyKeyringBatch(keys []string, budget time.Duration) map[string]le
 func lookupLegacyKeyringBatchInProcess(keys []string) map[string]legacyKeyringOutcome {
 	out := make(map[string]legacyKeyringOutcome, len(keys))
 	for _, key := range keys {
-		value, ok := legacyKeyringCredentialValueLookup(key)
-		if ok && strings.TrimSpace(value) != "" {
-			out[key] = legacyKeyringOutcome{Status: legacyKeyringFound, Value: value}
-			continue
+		o := legacyKeyringProbeLookup(key)
+		if o.Status == legacyKeyringFound {
+			if strings.TrimSpace(o.Value) == "" {
+				o = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+			} else if _, err := StoreCredentialLines([]string{key + "=" + o.Value}); err != nil {
+				o = legacyKeyringOutcome{Status: legacyKeyringError}
+			} else {
+				o.Value = "" // never leave secrets in the returned map
+			}
 		}
-		out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		out[key] = o
 	}
 	return out
 }
@@ -160,11 +171,10 @@ func lookupLegacyKeyringBatchViaHelper(keys []string, budget time.Duration) map[
 
 	// Always reap: context timeout kills the process; Wait is inside Run.
 	if ctx.Err() == context.DeadlineExceeded {
-		// Kill may race with natural exit; leave timeout status for unfinished keys.
 		if stdout.Len() == 0 {
 			return out
 		}
-		// Partial stdout is unusual but parse what we got; unparsed stay timeout.
+		// Partial metadata is rare; parse what arrived, leave others as timeout.
 	} else if runErr != nil {
 		for _, key := range keys {
 			out[key] = legacyKeyringOutcome{Status: legacyKeyringError}
@@ -189,11 +199,8 @@ func lookupLegacyKeyringBatchViaHelper(keys []string, budget time.Duration) map[
 		}
 		switch legacyKeyringStatus(res.Status) {
 		case legacyKeyringFound:
-			if strings.TrimSpace(res.Value) == "" {
-				out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
-			} else {
-				out[key] = legacyKeyringOutcome{Status: legacyKeyringFound, Value: res.Value}
-			}
+			// Helper already persisted any secret; parent only sees metadata.
+			out[key] = legacyKeyringOutcome{Status: legacyKeyringFound}
 		case legacyKeyringAbsent:
 			out[key] = legacyKeyringOutcome{Status: legacyKeyringAbsent}
 		case legacyKeyringError:
@@ -216,7 +223,6 @@ func legacyKeyringHelperCommand(ctx context.Context, keys []string) (*exec.Cmd, 
 		legacyKeyringHelperEnv+"="+legacyKeyringHelperFlag,
 		legacyKeyringKeysEnv+"="+strings.Join(keys, "\n"),
 	)
-	// Prevent the child from inheriting a half-built terminal state.
 	cmd.Stdin = nil
 	return cmd, nil
 }
@@ -227,7 +233,6 @@ func helperProcessArgs() []string {
 	name := filepath.Base(os.Args[0])
 	if strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe") ||
 		strings.Contains(os.Args[0], string(filepath.Separator)+"_test"+string(filepath.Separator)) {
-		// Match no tests; TestMain still runs and dispatches the helper env.
 		return []string{"-test.run=^$", "-test.v=false"}
 	}
 	return nil

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -1,80 +1,118 @@
 package config
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
 
-func TestLegacyKeyringCredentialValueWithTimeout(t *testing.T) {
-	oldImpl := legacyKeyringCredentialValueImpl
-	oldTimeout := legacyKeyringLookupTimeout
+func TestLookupLegacyKeyringBatchInProcessFourState(t *testing.T) {
+	oldHelper := legacyKeyringHelperEnabled
+	oldLookup := legacyKeyringCredentialValueLookup
+	legacyKeyringHelperEnabled = false
 	t.Cleanup(func() {
-		legacyKeyringCredentialValueImpl = oldImpl
-		legacyKeyringLookupTimeout = oldTimeout
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringCredentialValueLookup = oldLookup
 	})
 
-	t.Run("returns value", func(t *testing.T) {
-		legacyKeyringCredentialValueImpl = func(key string) (string, bool) {
-			return "secret-" + key, true
+	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+		switch key {
+		case "FOUND":
+			return "secret", true
+		case "EMPTY":
+			return "", true
+		default:
+			return "", false
 		}
-		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
-		if !ok || value != "secret-DEEPSEEK_API_KEY" {
-			t.Fatalf("got (%q, %v), want (secret-DEEPSEEK_API_KEY, true)", value, ok)
-		}
-	})
-
-	t.Run("times out on stuck keyring", func(t *testing.T) {
-		legacyKeyringLookupTimeout = 40 * time.Millisecond
-		started := make(chan struct{})
-		legacyKeyringCredentialValueImpl = func(string) (string, bool) {
-			close(started)
-			time.Sleep(500 * time.Millisecond)
-			return "late", true
-		}
-		start := time.Now()
-		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
-		elapsed := time.Since(start)
-		if ok || value != "" {
-			t.Fatalf("got (%q, %v), want fail-closed timeout", value, ok)
-		}
-		if elapsed < 40*time.Millisecond {
-			t.Fatalf("elapsed %v, want at least the timeout", elapsed)
-		}
-		if elapsed > 250*time.Millisecond {
-			t.Fatalf("elapsed %v, want fail-fast near the timeout", elapsed)
-		}
-		select {
-		case <-started:
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("stuck keyring probe was never started")
-		}
-	})
+	}
+	got := lookupLegacyKeyringBatch([]string{"FOUND", "EMPTY", "MISSING"}, time.Second)
+	if got["FOUND"].Status != legacyKeyringFound || got["FOUND"].Value != "secret" {
+		t.Fatalf("FOUND = %+v", got["FOUND"])
+	}
+	if got["EMPTY"].Status != legacyKeyringAbsent {
+		t.Fatalf("EMPTY = %+v, want absent", got["EMPTY"])
+	}
+	if got["MISSING"].Status != legacyKeyringAbsent {
+		t.Fatalf("MISSING = %+v, want absent", got["MISSING"])
+	}
 }
 
-func TestLookupLegacyKeyringBatchSharedBudget(t *testing.T) {
-	oldImpl := legacyKeyringCredentialValueImpl
-	t.Cleanup(func() { legacyKeyringCredentialValueImpl = oldImpl })
+func TestLookupLegacyKeyringBatchHelperTimeoutKillsChild(t *testing.T) {
+	oldHelper := legacyKeyringHelperEnabled
+	oldTimeout := legacyKeyringLookupTimeout
+	legacyKeyringHelperEnabled = true
+	legacyKeyringLookupTimeout = 80 * time.Millisecond
+	t.Cleanup(func() {
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringLookupTimeout = oldTimeout
+		_ = os.Unsetenv(legacyKeyringStallEnv)
+	})
+	// Stall the helper before any keyring work so the parent deadline kills it.
+	t.Setenv(legacyKeyringStallEnv, "500ms")
 
-	legacyKeyringCredentialValueImpl = func(key string) (string, bool) {
-		if key == "FAST" {
-			return "ok", true
-		}
-		time.Sleep(200 * time.Millisecond)
-		return "slow", true
+	start := time.Now()
+	got := lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, legacyKeyringLookupTimeout)
+	elapsed := time.Since(start)
+	if got["DEEPSEEK_API_KEY"].Status != legacyKeyringTimeout {
+		t.Fatalf("status = %q, want timeout (got %+v)", got["DEEPSEEK_API_KEY"].Status, got["DEEPSEEK_API_KEY"])
 	}
-	// Drive the batch through the package lookup hook.
+	if elapsed < 60*time.Millisecond {
+		t.Fatalf("elapsed %v, want near the budget", elapsed)
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Fatalf("elapsed %v, helper was not killed promptly", elapsed)
+	}
+}
+
+func TestLegacyKeyringMarkerOnlyOnAbsent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	oldHelper := legacyKeyringHelperEnabled
 	oldLookup := legacyKeyringCredentialValueLookup
-	legacyKeyringCredentialValueLookup = legacyKeyringCredentialValueImpl
-	t.Cleanup(func() { legacyKeyringCredentialValueLookup = oldLookup })
+	legacyKeyringHelperEnabled = false
+	t.Cleanup(func() {
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringCredentialValueLookup = oldLookup
+	})
 
-	values, completed, timedOut := lookupLegacyKeyringBatch([]string{"FAST", "SLOW"}, 50*time.Millisecond)
-	if !timedOut {
-		t.Fatal("expected shared budget timeout")
+	// Timeout path must not create a marker.
+	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
+	// Force timeout status via direct mark API coverage:
+	if err := markLegacyKeyringMigrationDone("NEVER"); err != nil {
+		t.Fatal(err)
 	}
-	if !completed["FAST"] || values["FAST"] != "ok" {
-		t.Fatalf("partial FAST = (%q, completed=%v), want ok", values["FAST"], completed["FAST"])
+	if !legacyKeyringMigrationDone("NEVER") {
+		t.Fatal("marker should exist after explicit mark")
 	}
-	if completed["SLOW"] {
-		t.Fatal("SLOW should not complete within the shared budget")
+
+	// File import must still work even when a keyring marker exists.
+	legacy := filepathJoinMarkerTestLegacyCreds(t, home, "MARKED_KEY=from-file\n")
+	_ = legacy
+	// Mark MARKED_KEY as keyring-checked-absent, then ensure file still imports.
+	if err := markLegacyKeyringMigrationDone("MARKED_KEY"); err != nil {
+		t.Fatal(err)
 	}
+	// Write a fake legacy credentials path by using migrate with mocked paths is hard;
+	// instead assert skip logic: marker alone does not imply store has key.
+	if credentialCurrentStoreHasKey("MARKED_KEY") {
+		t.Fatal("marker must not create a store entry")
+	}
+	if !legacyKeyringMigrationDone("MARKED_KEY") {
+		t.Fatal("expected keyring marker")
+	}
+	// sanitize name is readable, not a hash
+	path := legacyKeyringMigrationMarkerPath("MARKED_KEY")
+	if !strings.Contains(path, "legacy-keyring-checked") || !strings.HasSuffix(path, "MARKED_KEY") {
+		t.Fatalf("marker path = %q", path)
+	}
+}
+
+// filepathJoinMarkerTestLegacyCreds is a tiny helper name to avoid pulling more
+// migrate path setup into this unit test file for the marker path assertion.
+func filepathJoinMarkerTestLegacyCreds(t *testing.T, home, _ string) string {
+	t.Helper()
+	return home
 }

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -1,24 +1,19 @@
 package config
 
 import (
+	"context"
 	"encoding/base64"
-	"encoding/json"
-	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
 func TestLookupLegacyKeyringBatchInProcessFourState(t *testing.T) {
-	oldHelper := legacyKeyringHelperEnabled
 	oldLookup := legacyKeyringProbeLookup
-	legacyKeyringHelperEnabled = false
-	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
-		legacyKeyringProbeLookup = oldLookup
-	})
+	t.Cleanup(func() { legacyKeyringProbeLookup = oldLookup })
 
-	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(_ context.Context, key string) legacyKeyringOutcome {
 		switch key {
 		case "FOUND":
 			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "secret"}
@@ -35,7 +30,7 @@ func TestLookupLegacyKeyringBatchInProcessFourState(t *testing.T) {
 		t.Fatalf("FOUND = %+v, want found with scrubbed value", got["FOUND"])
 	}
 	if !credentialCurrentStoreHasKey("FOUND") {
-		t.Fatal("FOUND secret should have been stored in-process")
+		t.Fatal("FOUND secret should have been stored via store-if-absent")
 	}
 	if got["EMPTY"].Status != legacyKeyringAbsent {
 		t.Fatalf("EMPTY = %+v, want absent", got["EMPTY"])
@@ -53,26 +48,16 @@ func TestLegacyKeyringErrorDoesNotWriteMarker(t *testing.T) {
 	t.Setenv("REASONIX_HOME", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
-	oldHelper := legacyKeyringHelperEnabled
 	oldLookup := legacyKeyringProbeLookup
-	legacyKeyringHelperEnabled = false
-	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
-		legacyKeyringProbeLookup = oldLookup
-	})
+	t.Cleanup(func() { legacyKeyringProbeLookup = oldLookup })
 
-	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(context.Context, string) legacyKeyringOutcome {
 		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
-	// Drive only the keyring branch via batch + mark logic used by migrate.
 	outcomes := lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, time.Second)
 	if outcomes["DEEPSEEK_API_KEY"].Status != legacyKeyringError {
 		t.Fatalf("status = %+v", outcomes["DEEPSEEK_API_KEY"])
 	}
-	if outcomes["DEEPSEEK_API_KEY"].Status == legacyKeyringAbsent {
-		t.Fatal("error must not be treated as absent")
-	}
-	// Migrate-style: only mark absent
 	if outcomes["DEEPSEEK_API_KEY"].Status == legacyKeyringAbsent {
 		_ = markLegacyKeyringMigrationDone("DEEPSEEK_API_KEY")
 	}
@@ -81,51 +66,124 @@ func TestLegacyKeyringErrorDoesNotWriteMarker(t *testing.T) {
 	}
 }
 
-func TestLookupLegacyKeyringBatchHelperTimeoutKillsChild(t *testing.T) {
-	oldHelper := legacyKeyringHelperEnabled
+func TestLookupLegacyKeyringBatchSharedContextTimeout(t *testing.T) {
+	oldLookup := legacyKeyringProbeLookup
 	oldTimeout := legacyKeyringLookupTimeout
-	legacyKeyringHelperEnabled = true
-	legacyKeyringLookupTimeout = 80 * time.Millisecond
+	legacyKeyringLookupTimeout = 40 * time.Millisecond
 	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringProbeLookup = oldLookup
 		legacyKeyringLookupTimeout = oldTimeout
 	})
-	t.Setenv(legacyKeyringStallEnv, "500ms")
+
+	legacyKeyringProbeLookup = func(ctx context.Context, key string) legacyKeyringOutcome {
+		if key == "FAST" {
+			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		}
+		// Block until the shared budget cancels; must not leave a hung goroutine
+		// after the batch returns (probe returns when ctx is done).
+		<-ctx.Done()
+		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
+	}
 
 	start := time.Now()
-	got := lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, legacyKeyringLookupTimeout)
+	got := lookupLegacyKeyringBatch([]string{"FAST", "SLOW"}, legacyKeyringLookupTimeout)
 	elapsed := time.Since(start)
-	if got["DEEPSEEK_API_KEY"].Status != legacyKeyringTimeout {
-		t.Fatalf("status = %q, want timeout (got %+v)", got["DEEPSEEK_API_KEY"].Status, got["DEEPSEEK_API_KEY"])
+	if got["FAST"].Status != legacyKeyringAbsent {
+		t.Fatalf("FAST = %+v", got["FAST"])
 	}
-	if elapsed < 60*time.Millisecond {
-		t.Fatalf("elapsed %v, want near the budget", elapsed)
+	if got["SLOW"].Status != legacyKeyringTimeout {
+		t.Fatalf("SLOW = %+v, want timeout", got["SLOW"])
 	}
-	if elapsed > 400*time.Millisecond {
-		t.Fatalf("elapsed %v, helper was not killed promptly", elapsed)
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("elapsed %v, shared budget did not bound the scan", elapsed)
 	}
 }
 
-func TestLegacyKeyringHelperStdoutHasNoSecrets(t *testing.T) {
-	// Unit-level contract: helper report type has no Value field and encode
-	// path only emits key+status. Platform probe is stubbed for determinism.
-	oldImpl := legacyKeyringProbeImpl
-	legacyKeyringProbeImpl = func(key string) legacyKeyringOutcome {
-		return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-must-not-leak"}
-	}
-	t.Cleanup(func() { legacyKeyringProbeImpl = oldImpl })
+func TestStoreCredentialIfAbsentDoesNotClobberNewerValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
-	// Capture helper main path by calling the report builder logic via run with
-	// a redirected stdout is heavy; assert the public JSON schema instead.
-	report := legacyKeyringHelperReport{Results: []legacyKeyringHelperResult{{
-		Key: "DEEPSEEK_API_KEY", Status: string(legacyKeyringFound),
-	}}}
-	raw, err := json.Marshal(report)
-	if err != nil {
+	// Force interleaving without sleep:
+	// 1) parent path has already decided the key is missing (outside lock)
+	// 2) user writes a new value
+	// 3) store-if-absent re-checks under lock and skips the stale keyring value
+	parentChecked := make(chan struct{})
+	userDone := make(chan struct{})
+	result := make(chan bool, 1)
+
+	go func() {
+		<-parentChecked
+		<-userDone
+		stored, err := storeCredentialIfAbsentAndNotCleared("DEEPSEEK_API_KEY", "sk-old-keyring")
+		if err != nil {
+			t.Errorf("store-if-absent: %v", err)
+		}
+		result <- stored
+	}()
+
+	close(parentChecked)
+	if _, err := SetCredential("DEEPSEEK_API_KEY", "sk-user-new"); err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(raw), "sk-") || strings.Contains(string(raw), "value") {
-		t.Fatalf("helper report must not include secrets or value fields: %s", raw)
+	close(userDone)
+
+	if stored := <-result; stored {
+		t.Fatal("store-if-absent must not overwrite a concurrent user write")
+	}
+	if !credentialCurrentStoreHasKey("DEEPSEEK_API_KEY") {
+		t.Fatal("user value missing")
+	}
+	// Ensure the stored value is the user write, not the keyring secret.
+	val, ok := envFileValue(UserCredentialsPath(), "DEEPSEEK_API_KEY")
+	if !ok || val != "sk-user-new" {
+		t.Fatalf("credential = (%q, %v), want sk-user-new", val, ok)
+	}
+}
+
+func TestStoreCredentialIfAbsentDoesNotClobberTombstone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	if _, err := SetCredential("DEEPSEEK_API_KEY", "sk-temp"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveCredential("DEEPSEEK_API_KEY"); err != nil {
+		t.Fatal(err)
+	}
+	if !credentialCurrentStoreClearedKey("DEEPSEEK_API_KEY") {
+		t.Fatal("expected cleared tombstone")
+	}
+
+	parentChecked := make(chan struct{})
+	userDone := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var stored bool
+	var storeErr error
+	go func() {
+		defer wg.Done()
+		<-parentChecked
+		<-userDone
+		stored, storeErr = storeCredentialIfAbsentAndNotCleared("DEEPSEEK_API_KEY", "sk-old-keyring")
+	}()
+
+	close(parentChecked)
+	// Tombstone already present; signal and join.
+	close(userDone)
+	wg.Wait()
+	if storeErr != nil {
+		t.Fatal(storeErr)
+	}
+	if stored {
+		t.Fatal("store-if-absent must not revive a cleared key from keyring")
+	}
+	if credentialCurrentStoreHasKey("DEEPSEEK_API_KEY") {
+		t.Fatal("tombstone was overwritten with a keyring value")
+	}
+	if !credentialCurrentStoreClearedKey("DEEPSEEK_API_KEY") {
+		t.Fatal("tombstone missing after store-if-absent")
 	}
 }
 
@@ -138,10 +196,8 @@ func TestLegacyKeyringMarkerUsesRawURLBase64(t *testing.T) {
 	if !strings.HasSuffix(path, wantName) {
 		t.Fatalf("marker path = %q, want suffix %q", path, wantName)
 	}
-	// Distinct keys that would collapse under char-folding stay distinct.
 	other := legacyKeyringMigrationMarkerPath("A_B_C_")
 	if path == other {
 		t.Fatalf("marker collision between %q and A_B_C_", key)
 	}
-	_ = os.RemoveAll(home)
 }

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -99,53 +99,96 @@ func TestLookupLegacyKeyringBatchSharedContextTimeout(t *testing.T) {
 	}
 }
 
-func TestStoreCredentialIfAbsentDoesNotClobberNewerValue(t *testing.T) {
+// TestLookupLegacyKeyringBatchDoesNotClobberUserWrite forces the production
+// probe→store window: the batch has already decided the key needs import
+// (probe returns found), then the user writes a new value before store-if-absent.
+func TestLookupLegacyKeyringBatchDoesNotClobberUserWrite(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("REASONIX_HOME", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
-	// Force interleaving without sleep:
-	// 1) parent path has already decided the key is missing (outside lock)
-	// 2) user writes a new value
-	// 3) store-if-absent re-checks under lock and skips the stale keyring value
-	parentChecked := make(chan struct{})
-	userDone := make(chan struct{})
-	result := make(chan bool, 1)
+	oldLookup := legacyKeyringProbeLookup
+	t.Cleanup(func() { legacyKeyringProbeLookup = oldLookup })
 
-	go func() {
-		<-parentChecked
-		<-userDone
-		stored, err := storeCredentialIfAbsentAndNotCleared("DEEPSEEK_API_KEY", "sk-old-keyring")
-		if err != nil {
-			t.Errorf("store-if-absent: %v", err)
+	probeReached := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	var once sync.Once
+	legacyKeyringProbeLookup = func(ctx context.Context, key string) legacyKeyringOutcome {
+		if key != "DEEPSEEK_API_KEY" {
+			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 		}
-		result <- stored
+		once.Do(func() { close(probeReached) })
+		select {
+		case <-releaseProbe:
+		case <-ctx.Done():
+			return legacyKeyringOutcome{Status: legacyKeyringTimeout}
+		}
+		return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-old-keyring"}
+	}
+
+	done := make(chan map[string]legacyKeyringOutcome, 1)
+	go func() {
+		done <- lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, time.Second)
 	}()
 
-	close(parentChecked)
+	select {
+	case <-probeReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe did not reach the interleaving checkpoint")
+	}
 	if _, err := SetCredential("DEEPSEEK_API_KEY", "sk-user-new"); err != nil {
 		t.Fatal(err)
 	}
-	close(userDone)
+	close(releaseProbe)
 
-	if stored := <-result; stored {
-		t.Fatal("store-if-absent must not overwrite a concurrent user write")
+	got := <-done
+	if got["DEEPSEEK_API_KEY"].Status != legacyKeyringFound {
+		t.Fatalf("batch status = %+v, want found (store skipped)", got["DEEPSEEK_API_KEY"])
 	}
-	if !credentialCurrentStoreHasKey("DEEPSEEK_API_KEY") {
-		t.Fatal("user value missing")
-	}
-	// Ensure the stored value is the user write, not the keyring secret.
 	val, ok := envFileValue(UserCredentialsPath(), "DEEPSEEK_API_KEY")
 	if !ok || val != "sk-user-new" {
-		t.Fatalf("credential = (%q, %v), want sk-user-new", val, ok)
+		t.Fatalf("credential = (%q, %v), want sk-user-new (keyring must not clobber)", val, ok)
 	}
 }
 
-func TestStoreCredentialIfAbsentDoesNotClobberTombstone(t *testing.T) {
+// TestLookupLegacyKeyringBatchDoesNotReviveTombstone forces the same production
+// probe→store window against a cleared tombstone written after the probe starts.
+func TestLookupLegacyKeyringBatchDoesNotReviveTombstone(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("REASONIX_HOME", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
+	// Start empty: no value and no tombstone so the batch will probe.
+	oldLookup := legacyKeyringProbeLookup
+	t.Cleanup(func() { legacyKeyringProbeLookup = oldLookup })
+
+	probeReached := make(chan struct{})
+	releaseProbe := make(chan struct{})
+	var once sync.Once
+	legacyKeyringProbeLookup = func(ctx context.Context, key string) legacyKeyringOutcome {
+		if key != "DEEPSEEK_API_KEY" {
+			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+		}
+		once.Do(func() { close(probeReached) })
+		select {
+		case <-releaseProbe:
+		case <-ctx.Done():
+			return legacyKeyringOutcome{Status: legacyKeyringTimeout}
+		}
+		return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-old-keyring"}
+	}
+
+	done := make(chan map[string]legacyKeyringOutcome, 1)
+	go func() {
+		done <- lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, time.Second)
+	}()
+
+	select {
+	case <-probeReached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("probe did not reach the interleaving checkpoint")
+	}
+	// Write then clear while probe is blocked: tombstone must win.
 	if _, err := SetCredential("DEEPSEEK_API_KEY", "sk-temp"); err != nil {
 		t.Fatal(err)
 	}
@@ -153,37 +196,20 @@ func TestStoreCredentialIfAbsentDoesNotClobberTombstone(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !credentialCurrentStoreClearedKey("DEEPSEEK_API_KEY") {
-		t.Fatal("expected cleared tombstone")
+		t.Fatal("expected cleared tombstone before releasing probe")
 	}
+	close(releaseProbe)
 
-	parentChecked := make(chan struct{})
-	userDone := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var stored bool
-	var storeErr error
-	go func() {
-		defer wg.Done()
-		<-parentChecked
-		<-userDone
-		stored, storeErr = storeCredentialIfAbsentAndNotCleared("DEEPSEEK_API_KEY", "sk-old-keyring")
-	}()
-
-	close(parentChecked)
-	// Tombstone already present; signal and join.
-	close(userDone)
-	wg.Wait()
-	if storeErr != nil {
-		t.Fatal(storeErr)
-	}
-	if stored {
-		t.Fatal("store-if-absent must not revive a cleared key from keyring")
+	got := <-done
+	if got["DEEPSEEK_API_KEY"].Status != legacyKeyringFound {
+		// store-if-absent skipped → still reported found (already handled)
+		t.Fatalf("batch status = %+v", got["DEEPSEEK_API_KEY"])
 	}
 	if credentialCurrentStoreHasKey("DEEPSEEK_API_KEY") {
-		t.Fatal("tombstone was overwritten with a keyring value")
+		t.Fatal("keyring import revived a tombstoned credential")
 	}
 	if !credentialCurrentStoreClearedKey("DEEPSEEK_API_KEY") {
-		t.Fatal("tombstone missing after store-if-absent")
+		t.Fatal("tombstone missing after batch")
 	}
 }
 

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -9,32 +11,73 @@ import (
 
 func TestLookupLegacyKeyringBatchInProcessFourState(t *testing.T) {
 	oldHelper := legacyKeyringHelperEnabled
-	oldLookup := legacyKeyringCredentialValueLookup
+	oldLookup := legacyKeyringProbeLookup
 	legacyKeyringHelperEnabled = false
 	t.Cleanup(func() {
 		legacyKeyringHelperEnabled = oldHelper
-		legacyKeyringCredentialValueLookup = oldLookup
+		legacyKeyringProbeLookup = oldLookup
 	})
 
-	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
 		switch key {
 		case "FOUND":
-			return "secret", true
+			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "secret"}
 		case "EMPTY":
-			return "", true
+			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: ""}
+		case "ERR":
+			return legacyKeyringOutcome{Status: legacyKeyringError}
 		default:
-			return "", false
+			return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 		}
 	}
-	got := lookupLegacyKeyringBatch([]string{"FOUND", "EMPTY", "MISSING"}, time.Second)
-	if got["FOUND"].Status != legacyKeyringFound || got["FOUND"].Value != "secret" {
-		t.Fatalf("FOUND = %+v", got["FOUND"])
+	got := lookupLegacyKeyringBatch([]string{"FOUND", "EMPTY", "MISSING", "ERR"}, time.Second)
+	if got["FOUND"].Status != legacyKeyringFound || got["FOUND"].Value != "" {
+		t.Fatalf("FOUND = %+v, want found with scrubbed value", got["FOUND"])
+	}
+	if !credentialCurrentStoreHasKey("FOUND") {
+		t.Fatal("FOUND secret should have been stored in-process")
 	}
 	if got["EMPTY"].Status != legacyKeyringAbsent {
 		t.Fatalf("EMPTY = %+v, want absent", got["EMPTY"])
 	}
 	if got["MISSING"].Status != legacyKeyringAbsent {
 		t.Fatalf("MISSING = %+v, want absent", got["MISSING"])
+	}
+	if got["ERR"].Status != legacyKeyringError {
+		t.Fatalf("ERR = %+v, want error", got["ERR"])
+	}
+}
+
+func TestLegacyKeyringErrorDoesNotWriteMarker(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+
+	oldHelper := legacyKeyringHelperEnabled
+	oldLookup := legacyKeyringProbeLookup
+	legacyKeyringHelperEnabled = false
+	t.Cleanup(func() {
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringProbeLookup = oldLookup
+	})
+
+	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+		return legacyKeyringOutcome{Status: legacyKeyringError}
+	}
+	// Drive only the keyring branch via batch + mark logic used by migrate.
+	outcomes := lookupLegacyKeyringBatch([]string{"DEEPSEEK_API_KEY"}, time.Second)
+	if outcomes["DEEPSEEK_API_KEY"].Status != legacyKeyringError {
+		t.Fatalf("status = %+v", outcomes["DEEPSEEK_API_KEY"])
+	}
+	if outcomes["DEEPSEEK_API_KEY"].Status == legacyKeyringAbsent {
+		t.Fatal("error must not be treated as absent")
+	}
+	// Migrate-style: only mark absent
+	if outcomes["DEEPSEEK_API_KEY"].Status == legacyKeyringAbsent {
+		_ = markLegacyKeyringMigrationDone("DEEPSEEK_API_KEY")
+	}
+	if legacyKeyringMigrationDone("DEEPSEEK_API_KEY") {
+		t.Fatal("error outcome must not write a migration marker")
 	}
 }
 
@@ -46,9 +89,7 @@ func TestLookupLegacyKeyringBatchHelperTimeoutKillsChild(t *testing.T) {
 	t.Cleanup(func() {
 		legacyKeyringHelperEnabled = oldHelper
 		legacyKeyringLookupTimeout = oldTimeout
-		_ = os.Unsetenv(legacyKeyringStallEnv)
 	})
-	// Stall the helper before any keyring work so the parent deadline kills it.
 	t.Setenv(legacyKeyringStallEnv, "500ms")
 
 	start := time.Now()
@@ -65,54 +106,42 @@ func TestLookupLegacyKeyringBatchHelperTimeoutKillsChild(t *testing.T) {
 	}
 }
 
-func TestLegacyKeyringMarkerOnlyOnAbsent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("REASONIX_HOME", home)
-	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+func TestLegacyKeyringHelperStdoutHasNoSecrets(t *testing.T) {
+	// Unit-level contract: helper report type has no Value field and encode
+	// path only emits key+status. Platform probe is stubbed for determinism.
+	oldImpl := legacyKeyringProbeImpl
+	legacyKeyringProbeImpl = func(key string) legacyKeyringOutcome {
+		return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-must-not-leak"}
+	}
+	t.Cleanup(func() { legacyKeyringProbeImpl = oldImpl })
 
-	oldHelper := legacyKeyringHelperEnabled
-	oldLookup := legacyKeyringCredentialValueLookup
-	legacyKeyringHelperEnabled = false
-	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
-		legacyKeyringCredentialValueLookup = oldLookup
-	})
-
-	// Timeout path must not create a marker.
-	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
-	// Force timeout status via direct mark API coverage:
-	if err := markLegacyKeyringMigrationDone("NEVER"); err != nil {
+	// Capture helper main path by calling the report builder logic via run with
+	// a redirected stdout is heavy; assert the public JSON schema instead.
+	report := legacyKeyringHelperReport{Results: []legacyKeyringHelperResult{{
+		Key: "DEEPSEEK_API_KEY", Status: string(legacyKeyringFound),
+	}}}
+	raw, err := json.Marshal(report)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !legacyKeyringMigrationDone("NEVER") {
-		t.Fatal("marker should exist after explicit mark")
-	}
-
-	// File import must still work even when a keyring marker exists.
-	legacy := filepathJoinMarkerTestLegacyCreds(t, home, "MARKED_KEY=from-file\n")
-	_ = legacy
-	// Mark MARKED_KEY as keyring-checked-absent, then ensure file still imports.
-	if err := markLegacyKeyringMigrationDone("MARKED_KEY"); err != nil {
-		t.Fatal(err)
-	}
-	// Write a fake legacy credentials path by using migrate with mocked paths is hard;
-	// instead assert skip logic: marker alone does not imply store has key.
-	if credentialCurrentStoreHasKey("MARKED_KEY") {
-		t.Fatal("marker must not create a store entry")
-	}
-	if !legacyKeyringMigrationDone("MARKED_KEY") {
-		t.Fatal("expected keyring marker")
-	}
-	// sanitize name is readable, not a hash
-	path := legacyKeyringMigrationMarkerPath("MARKED_KEY")
-	if !strings.Contains(path, "legacy-keyring-checked") || !strings.HasSuffix(path, "MARKED_KEY") {
-		t.Fatalf("marker path = %q", path)
+	if strings.Contains(string(raw), "sk-") || strings.Contains(string(raw), "value") {
+		t.Fatalf("helper report must not include secrets or value fields: %s", raw)
 	}
 }
 
-// filepathJoinMarkerTestLegacyCreds is a tiny helper name to avoid pulling more
-// migrate path setup into this unit test file for the marker path assertion.
-func filepathJoinMarkerTestLegacyCreds(t *testing.T, home, _ string) string {
-	t.Helper()
-	return home
+func TestLegacyKeyringMarkerUsesRawURLBase64(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	key := "A/B+C="
+	path := legacyKeyringMigrationMarkerPath(key)
+	wantName := base64.RawURLEncoding.EncodeToString([]byte(key))
+	if !strings.HasSuffix(path, wantName) {
+		t.Fatalf("marker path = %q, want suffix %q", path, wantName)
+	}
+	// Distinct keys that would collapse under char-folding stay distinct.
+	other := legacyKeyringMigrationMarkerPath("A_B_C_")
+	if path == other {
+		t.Fatalf("marker collision between %q and A_B_C_", key)
+	}
+	_ = os.RemoveAll(home)
 }

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLegacyKeyringCredentialValueWithTimeout(t *testing.T) {
+	oldImpl := legacyKeyringCredentialValueImpl
+	oldTimeout := legacyKeyringLookupTimeout
+	t.Cleanup(func() {
+		legacyKeyringCredentialValueImpl = oldImpl
+		legacyKeyringLookupTimeout = oldTimeout
+	})
+
+	t.Run("returns value", func(t *testing.T) {
+		legacyKeyringCredentialValueImpl = func(key string) (string, bool) {
+			return "secret-" + key, true
+		}
+		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
+		if !ok || value != "secret-DEEPSEEK_API_KEY" {
+			t.Fatalf("got (%q, %v), want (secret-DEEPSEEK_API_KEY, true)", value, ok)
+		}
+	})
+
+	t.Run("times out on stuck keyring", func(t *testing.T) {
+		legacyKeyringLookupTimeout = 40 * time.Millisecond
+		started := make(chan struct{})
+		legacyKeyringCredentialValueImpl = func(string) (string, bool) {
+			close(started)
+			time.Sleep(500 * time.Millisecond)
+			return "late", true
+		}
+		start := time.Now()
+		value, ok := legacyKeyringCredentialValueWithTimeout("DEEPSEEK_API_KEY")
+		elapsed := time.Since(start)
+		if ok || value != "" {
+			t.Fatalf("got (%q, %v), want fail-closed timeout", value, ok)
+		}
+		if elapsed < 40*time.Millisecond {
+			t.Fatalf("elapsed %v, want at least the timeout", elapsed)
+		}
+		if elapsed > 250*time.Millisecond {
+			t.Fatalf("elapsed %v, want fail-fast near the timeout", elapsed)
+		}
+		select {
+		case <-started:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("stuck keyring probe was never started")
+		}
+	})
+}
+
+func TestLookupLegacyKeyringBatchSharedBudget(t *testing.T) {
+	oldImpl := legacyKeyringCredentialValueImpl
+	t.Cleanup(func() { legacyKeyringCredentialValueImpl = oldImpl })
+
+	legacyKeyringCredentialValueImpl = func(key string) (string, bool) {
+		if key == "FAST" {
+			return "ok", true
+		}
+		time.Sleep(200 * time.Millisecond)
+		return "slow", true
+	}
+	// Drive the batch through the package lookup hook.
+	oldLookup := legacyKeyringCredentialValueLookup
+	legacyKeyringCredentialValueLookup = legacyKeyringCredentialValueImpl
+	t.Cleanup(func() { legacyKeyringCredentialValueLookup = oldLookup })
+
+	values, completed, timedOut := lookupLegacyKeyringBatch([]string{"FAST", "SLOW"}, 50*time.Millisecond)
+	if !timedOut {
+		t.Fatal("expected shared budget timeout")
+	}
+	if !completed["FAST"] || values["FAST"] != "ok" {
+		t.Fatalf("partial FAST = (%q, completed=%v), want ok", values["FAST"], completed["FAST"])
+	}
+	if completed["SLOW"] {
+		t.Fatal("SLOW should not complete within the shared budget")
+	}
+}

--- a/internal/config/credentials_keyring_unix.go
+++ b/internal/config/credentials_keyring_unix.go
@@ -104,9 +104,17 @@ func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 }
 
 // openPrivateSessionBus dials a private session-bus connection (Auth+Hello)
-// without using the process-global SessionBus cache. Dial/Auth/Hello are not
-// context-aware in godbus, so the whole connect is raced against ctx and any
-// late connection is closed to reclaim godbus worker goroutines.
+// without using the process-global SessionBus cache.
+//
+// Connection lifecycle is bound to ctx via dbus.WithContext(ctx): when the
+// migration budget expires, godbus closes the transport so Auth/Hello that have
+// already obtained a *Conn unblock instead of hanging forever. We never call
+// dbus-launch (NoAutoStartup): missing session address fails closed as error,
+// which is correct for headless/CI and avoids an uncancellable CombinedOutput.
+//
+// Dial itself is still not fully context-cancellable in godbus before newConn
+// installs WithContext; the outer select bounds the caller's wait, and any late
+// *Conn is always closed.
 func openPrivateSessionBus(ctx context.Context) (*dbus.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -117,13 +125,13 @@ func openPrivateSessionBus(ctx context.Context) (*dbus.Conn, error) {
 	}
 	ch := make(chan result, 1)
 	go func() {
-		// Private connection: ConnectSessionBus = Dial + Auth + Hello, not shared.
-		conn, err := dbus.ConnectSessionBus()
+		conn, err := connectPrivateSessionBus(ctx)
 		ch <- result{conn: conn, err: err}
 	}()
 	select {
 	case <-ctx.Done():
-		// Reap a late success so workers cannot leak past the deadline.
+		// Drain so the connect goroutine is reaped when WithContext causes
+		// Auth/Hello to return; always Close a late *Conn.
 		go func() {
 			r := <-ch
 			if r.conn != nil {
@@ -133,10 +141,40 @@ func openPrivateSessionBus(ctx context.Context) (*dbus.Conn, error) {
 		return nil, ctx.Err()
 	case r := <-ch:
 		if r.err != nil {
+			if r.conn != nil {
+				_ = r.conn.Close()
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			return nil, r.err
+		}
+		if err := ctx.Err(); err != nil {
+			_ = r.conn.Close()
+			return nil, err
 		}
 		return r.conn, nil
 	}
+}
+
+// connectPrivateSessionBus opens a private, context-bound session bus and
+// completes Auth+Hello. Prefer NoAutoStartup so we never block in dbus-launch.
+func connectPrivateSessionBus(ctx context.Context) (*dbus.Conn, error) {
+	// WithContext: parent cancel → conn.Close → unblocks Auth transport I/O and
+	// Hello Call waiters once the *Conn exists.
+	conn, err := dbus.SessionBusPrivateNoAutoStartup(dbus.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Auth(nil); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err := conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
 }
 
 func ssResolveLoginCollection(ctx context.Context, svc dbus.BusObject) (dbus.ObjectPath, error) {

--- a/internal/config/credentials_keyring_unix.go
+++ b/internal/config/credentials_keyring_unix.go
@@ -4,14 +4,15 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	dbus "github.com/godbus/dbus/v5"
 )
 
 // Secret Service constants (same service Reasonix historically used via
-// zalando/go-keyring). We call CallWithContext so a shared migration budget can
-// cancel stuck D-Bus replies without an external helper process.
+// zalando/go-keyring). Every D-Bus call uses the shared migration context so a
+// stuck bus cannot hang CLI startup past the batch deadline.
 const (
 	ssServiceName         = "org.freedesktop.secrets"
 	ssServicePath         = "/org/freedesktop/secrets"
@@ -19,9 +20,11 @@ const (
 	ssCollectionInterface = "org.freedesktop.Secret.Collection"
 	ssItemInterface       = "org.freedesktop.Secret.Item"
 	ssSessionInterface    = "org.freedesktop.Secret.Session"
-	ssCollectionsProp     = "org.freedesktop.Secret.Service.Collections"
+	ssCollectionsIface    = "org.freedesktop.Secret.Service"
+	ssCollectionsProp     = "Collections"
 	ssLoginCollection     = "/org/freedesktop/secrets/collection/login"
 	ssLoginAlias          = "/org/freedesktop/secrets/aliases/default"
+	ssPropertiesInterface = "org.freedesktop.DBus.Properties"
 )
 
 type ssSecret struct {
@@ -32,8 +35,10 @@ type ssSecret struct {
 }
 
 // legacyKeyringProbe reads one legacy credential from Secret Service under ctx.
-// ctx cancellation maps to timeout; transport/unlock failures map to error;
-// empty search / empty secret map to absent.
+// It opens a private, caller-owned session-bus connection (never dbus.SessionBus),
+// bounds Dial/Auth/Hello by ctx, routes every method/property call through
+// CallWithContext(ctx), and always closes the connection before returning so
+// godbus worker goroutines cannot leak into goleak-checked tests.
 func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -43,14 +48,14 @@ func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
 	}
 
-	conn, err := dbus.SessionBus()
+	conn, err := openPrivateSessionBus(ctx)
 	if err != nil {
 		return mapKeyringCtxErr(ctx, err)
 	}
-	// Do not close SessionBus: it is a shared process connection.
+	defer func() { _ = conn.Close() }()
 
 	svc := conn.Object(ssServiceName, ssServicePath)
-	collectionPath, err := ssResolveLoginCollection(ctx, conn, svc)
+	collectionPath, err := ssResolveLoginCollection(ctx, svc)
 	if err != nil {
 		return mapKeyringCtxErr(ctx, err)
 	}
@@ -76,8 +81,12 @@ func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	if err := svc.CallWithContext(ctx, ssServiceInterface+".OpenSession", 0, "plain", dbus.MakeVariant("")).Store(&disregard, &sessionPath); err != nil {
 		return mapKeyringCtxErr(ctx, err)
 	}
-	session := conn.Object(ssServiceName, sessionPath)
-	defer func() { _ = session.CallWithContext(context.Background(), ssSessionInterface+".Close", 0).Err }()
+	// Always close the Secret Service session with the remaining budget (never
+	// context.Background) so a stuck Close still respects the migration deadline.
+	defer func() {
+		session := conn.Object(ssServiceName, sessionPath)
+		_ = session.CallWithContext(ctx, ssSessionInterface+".Close", 0).Err
+	}()
 
 	if err := ssUnlock(ctx, svc, results[0]); err != nil {
 		return mapKeyringCtxErr(ctx, err)
@@ -94,14 +103,49 @@ func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	return legacyKeyringOutcome{Status: legacyKeyringFound, Value: string(secret.Value)}
 }
 
-func ssResolveLoginCollection(ctx context.Context, conn *dbus.Conn, svc dbus.BusObject) (dbus.ObjectPath, error) {
+// openPrivateSessionBus dials a private session-bus connection (Auth+Hello)
+// without using the process-global SessionBus cache. Dial/Auth/Hello are not
+// context-aware in godbus, so the whole connect is raced against ctx and any
+// late connection is closed to reclaim godbus worker goroutines.
+func openPrivateSessionBus(ctx context.Context) (*dbus.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	type result struct {
+		conn *dbus.Conn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		// Private connection: ConnectSessionBus = Dial + Auth + Hello, not shared.
+		conn, err := dbus.ConnectSessionBus()
+		ch <- result{conn: conn, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		// Reap a late success so workers cannot leak past the deadline.
+		go func() {
+			r := <-ch
+			if r.conn != nil {
+				_ = r.conn.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case r := <-ch:
+		if r.err != nil {
+			return nil, r.err
+		}
+		return r.conn, nil
+	}
+}
+
+func ssResolveLoginCollection(ctx context.Context, svc dbus.BusObject) (dbus.ObjectPath, error) {
 	path := dbus.ObjectPath(ssLoginCollection)
-	val, err := svc.GetProperty(ssCollectionsProp)
+	val, err := ssGetProperty(ctx, svc, ssCollectionsIface, ssCollectionsProp)
 	if err != nil {
 		// Fall back to the default alias when Collections is unavailable.
 		return dbus.ObjectPath(ssLoginAlias), nil
 	}
-	_ = ctx
 	paths, _ := val.Value().([]dbus.ObjectPath)
 	for _, p := range paths {
 		if p == path {
@@ -109,6 +153,17 @@ func ssResolveLoginCollection(ctx context.Context, conn *dbus.Conn, svc dbus.Bus
 		}
 	}
 	return dbus.ObjectPath(ssLoginAlias), nil
+}
+
+// ssGetProperty is CallWithContext-based Properties.Get. BusObject.GetProperty
+// uses a non-context Call and would escape the migration deadline.
+func ssGetProperty(ctx context.Context, obj dbus.BusObject, iface, name string) (dbus.Variant, error) {
+	var val dbus.Variant
+	err := obj.CallWithContext(ctx, ssPropertiesInterface+".Get", 0, iface, name).Store(&val)
+	if err != nil {
+		return dbus.Variant{}, err
+	}
+	return val, nil
 }
 
 func ssUnlock(ctx context.Context, svc dbus.BusObject, target dbus.ObjectPath) error {
@@ -119,13 +174,12 @@ func ssUnlock(ctx context.Context, svc dbus.BusObject, target dbus.ObjectPath) e
 	}
 	// Migration must not wait on an interactive prompt (would hang CLI startup).
 	if prompt != "/" && prompt != "" {
-		// If Unlock already returned the object, accept it; otherwise fail closed.
 		for _, p := range unlocked {
 			if p == target || target == dbus.ObjectPath(ssLoginAlias) {
 				return nil
 			}
 		}
-		return context.Canceled // surfaces as error unless ctx already timed out
+		return fmt.Errorf("secret service unlock requires interactive prompt")
 	}
 	return nil
 }

--- a/internal/config/credentials_keyring_unix.go
+++ b/internal/config/credentials_keyring_unix.go
@@ -8,15 +8,18 @@ import (
 	ss "github.com/zalando/go-keyring/secret_service"
 )
 
-func legacyKeyringCredentialValue(key string) (string, bool) {
+// legacyKeyringProbe reads one legacy credential from Secret Service.
+// Connection/Unlock/Search/session failures return error (no marker).
+// Empty search results or empty secret values return absent (marker OK).
+func legacyKeyringProbe(key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 
 	svc, err := ss.NewSecretService()
 	if err != nil {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
 	defer svc.Conn.Close()
 
@@ -26,25 +29,31 @@ func legacyKeyringCredentialValue(key string) (string, bool) {
 		"service":  credentialsKeyringService,
 	}
 	if err := svc.Unlock(collection.Path()); err != nil {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
 	results, err := svc.SearchItems(collection, search)
-	if err != nil || len(results) == 0 {
-		return "", false
+	if err != nil {
+		return legacyKeyringOutcome{Status: legacyKeyringError}
+	}
+	if len(results) == 0 {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 
 	session, err := svc.OpenSession()
 	if err != nil {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
 	defer svc.Close(session)
 
 	if err := svc.Unlock(results[0]); err != nil {
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
 	secret, err := svc.GetSecret(results[0], session.Path())
-	if err != nil || secret == nil || len(secret.Value) == 0 {
-		return "", false
+	if err != nil {
+		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
-	return string(secret.Value), true
+	if secret == nil || len(secret.Value) == 0 {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
+	return legacyKeyringOutcome{Status: legacyKeyringFound, Value: string(secret.Value)}
 }

--- a/internal/config/credentials_keyring_unix.go
+++ b/internal/config/credentials_keyring_unix.go
@@ -3,57 +3,139 @@
 package config
 
 import (
+	"context"
 	"strings"
 
-	ss "github.com/zalando/go-keyring/secret_service"
+	dbus "github.com/godbus/dbus/v5"
 )
 
-// legacyKeyringProbe reads one legacy credential from Secret Service.
-// Connection/Unlock/Search/session failures return error (no marker).
-// Empty search results or empty secret values return absent (marker OK).
-func legacyKeyringProbe(key string) legacyKeyringOutcome {
+// Secret Service constants (same service Reasonix historically used via
+// zalando/go-keyring). We call CallWithContext so a shared migration budget can
+// cancel stuck D-Bus replies without an external helper process.
+const (
+	ssServiceName         = "org.freedesktop.secrets"
+	ssServicePath         = "/org/freedesktop/secrets"
+	ssServiceInterface    = "org.freedesktop.Secret.Service"
+	ssCollectionInterface = "org.freedesktop.Secret.Collection"
+	ssItemInterface       = "org.freedesktop.Secret.Item"
+	ssSessionInterface    = "org.freedesktop.Secret.Session"
+	ssCollectionsProp     = "org.freedesktop.Secret.Service.Collections"
+	ssLoginCollection     = "/org/freedesktop/secrets/collection/login"
+	ssLoginAlias          = "/org/freedesktop/secrets/aliases/default"
+)
+
+type ssSecret struct {
+	Session     dbus.ObjectPath
+	Parameters  []byte
+	Value       []byte
+	ContentType string `dbus:"content_type"`
+}
+
+// legacyKeyringProbe reads one legacy credential from Secret Service under ctx.
+// ctx cancellation maps to timeout; transport/unlock failures map to error;
+// empty search / empty secret map to absent.
+func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
-
-	svc, err := ss.NewSecretService()
-	if err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
+	if err := ctx.Err(); err != nil {
+		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
 	}
-	defer svc.Conn.Close()
 
-	collection := svc.GetLoginCollection()
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return mapKeyringCtxErr(ctx, err)
+	}
+	// Do not close SessionBus: it is a shared process connection.
+
+	svc := conn.Object(ssServiceName, ssServicePath)
+	collectionPath, err := ssResolveLoginCollection(ctx, conn, svc)
+	if err != nil {
+		return mapKeyringCtxErr(ctx, err)
+	}
+	if err := ssUnlock(ctx, svc, collectionPath); err != nil {
+		return mapKeyringCtxErr(ctx, err)
+	}
+
+	collection := conn.Object(ssServiceName, collectionPath)
 	search := map[string]string{
 		"username": key,
 		"service":  credentialsKeyringService,
 	}
-	if err := svc.Unlock(collection.Path()); err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
-	}
-	results, err := svc.SearchItems(collection, search)
-	if err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
+	var results []dbus.ObjectPath
+	if err := collection.CallWithContext(ctx, ssCollectionInterface+".SearchItems", 0, search).Store(&results); err != nil {
+		return mapKeyringCtxErr(ctx, err)
 	}
 	if len(results) == 0 {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 
-	session, err := svc.OpenSession()
-	if err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
+	var disregard dbus.Variant
+	var sessionPath dbus.ObjectPath
+	if err := svc.CallWithContext(ctx, ssServiceInterface+".OpenSession", 0, "plain", dbus.MakeVariant("")).Store(&disregard, &sessionPath); err != nil {
+		return mapKeyringCtxErr(ctx, err)
 	}
-	defer svc.Close(session)
+	session := conn.Object(ssServiceName, sessionPath)
+	defer func() { _ = session.CallWithContext(context.Background(), ssSessionInterface+".Close", 0).Err }()
 
-	if err := svc.Unlock(results[0]); err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
+	if err := ssUnlock(ctx, svc, results[0]); err != nil {
+		return mapKeyringCtxErr(ctx, err)
 	}
-	secret, err := svc.GetSecret(results[0], session.Path())
-	if err != nil {
-		return legacyKeyringOutcome{Status: legacyKeyringError}
+
+	var secret ssSecret
+	item := conn.Object(ssServiceName, results[0])
+	if err := item.CallWithContext(ctx, ssItemInterface+".GetSecret", 0, sessionPath).Store(&secret); err != nil {
+		return mapKeyringCtxErr(ctx, err)
 	}
-	if secret == nil || len(secret.Value) == 0 {
+	if len(secret.Value) == 0 {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 	return legacyKeyringOutcome{Status: legacyKeyringFound, Value: string(secret.Value)}
+}
+
+func ssResolveLoginCollection(ctx context.Context, conn *dbus.Conn, svc dbus.BusObject) (dbus.ObjectPath, error) {
+	path := dbus.ObjectPath(ssLoginCollection)
+	val, err := svc.GetProperty(ssCollectionsProp)
+	if err != nil {
+		// Fall back to the default alias when Collections is unavailable.
+		return dbus.ObjectPath(ssLoginAlias), nil
+	}
+	_ = ctx
+	paths, _ := val.Value().([]dbus.ObjectPath)
+	for _, p := range paths {
+		if p == path {
+			return path, nil
+		}
+	}
+	return dbus.ObjectPath(ssLoginAlias), nil
+}
+
+func ssUnlock(ctx context.Context, svc dbus.BusObject, target dbus.ObjectPath) error {
+	var unlocked []dbus.ObjectPath
+	var prompt dbus.ObjectPath
+	if err := svc.CallWithContext(ctx, ssServiceInterface+".Unlock", 0, []dbus.ObjectPath{target}).Store(&unlocked, &prompt); err != nil {
+		return err
+	}
+	// Migration must not wait on an interactive prompt (would hang CLI startup).
+	if prompt != "/" && prompt != "" {
+		// If Unlock already returned the object, accept it; otherwise fail closed.
+		for _, p := range unlocked {
+			if p == target || target == dbus.ObjectPath(ssLoginAlias) {
+				return nil
+			}
+		}
+		return context.Canceled // surfaces as error unless ctx already timed out
+	}
+	return nil
+}
+
+func mapKeyringCtxErr(ctx context.Context, err error) legacyKeyringOutcome {
+	if err == nil {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
+	if ctx.Err() != nil {
+		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
+	}
+	return legacyKeyringOutcome{Status: legacyKeyringError}
 }

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -8,13 +8,18 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	if code, handled := MaybeRunLegacyKeyringHelper(); handled {
+		os.Exit(code)
+	}
 	if os.Getenv("REASONIX_CONFIG_LOCK_HELPER") == "1" {
 		os.Exit(m.Run())
 	}
 	// RunWithIsolatedUserState redirects every path-shaped location, but the OS
 	// keyring has no environment variable in front of it, so legacy migration
 	// would read the credentials of whoever is running the tests. Cases that
-	// exercise the lookup substitute their own.
+	// exercise the lookup substitute their own. Disable the helper so unit
+	// tests stay in-process with the stub below.
+	legacyKeyringHelperEnabled = false
 	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
 	testenv.RunWithIsolatedUserState(m)
 }

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -20,7 +20,9 @@ func TestMain(m *testing.M) {
 	// exercise the lookup substitute their own. Disable the helper so unit
 	// tests stay in-process with the stub below.
 	legacyKeyringHelperEnabled = false
-	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
+	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
 	testenv.RunWithIsolatedUserState(m)
 }
 
@@ -28,8 +30,9 @@ func TestMain(m *testing.M) {
 // stay green either way, so the substitution itself is what gets asserted.
 func TestKeyringLookupStaysOutOfTheRealStore(t *testing.T) {
 	for _, key := range []string{"DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
-		if value, ok := legacyKeyringCredentialValueLookup(key); ok || value != "" {
-			t.Fatalf("%s resolved through the real keyring in tests (ok=%v, %d bytes)", key, ok, len(value))
+		o := legacyKeyringProbeLookup(key)
+		if o.Status != legacyKeyringAbsent || o.Value != "" {
+			t.Fatalf("%s resolved through the real keyring in tests: %+v", key, o)
 		}
 	}
 }

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -8,19 +9,14 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if code, handled := MaybeRunLegacyKeyringHelper(); handled {
-		os.Exit(code)
-	}
 	if os.Getenv("REASONIX_CONFIG_LOCK_HELPER") == "1" {
 		os.Exit(m.Run())
 	}
 	// RunWithIsolatedUserState redirects every path-shaped location, but the OS
 	// keyring has no environment variable in front of it, so legacy migration
 	// would read the credentials of whoever is running the tests. Cases that
-	// exercise the lookup substitute their own. Disable the helper so unit
-	// tests stay in-process with the stub below.
-	legacyKeyringHelperEnabled = false
-	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+	// exercise the lookup substitute their own.
+	legacyKeyringProbeLookup = func(context.Context, string) legacyKeyringOutcome {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 	testenv.RunWithIsolatedUserState(m)
@@ -30,7 +26,7 @@ func TestMain(m *testing.M) {
 // stay green either way, so the substitution itself is what gets asserted.
 func TestKeyringLookupStaysOutOfTheRealStore(t *testing.T) {
 	for _, key := range []string{"DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
-		o := legacyKeyringProbeLookup(key)
+		o := legacyKeyringProbeLookup(context.Background(), key)
 		if o.Status != legacyKeyringAbsent || o.Value != "" {
 			t.Fatalf("%s resolved through the real keyring in tests: %+v", key, o)
 		}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
@@ -414,9 +414,8 @@ func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 			o := outcomes[key]
 			switch o.Status {
 			case legacyKeyringFound:
-				if v := strings.TrimSpace(o.Value); v != "" {
-					missing[key] = v
-				}
+				// Secret was stored by the probe path (helper or in-process).
+				// Do not trust Value from the parent-visible outcome map.
 			case legacyKeyringAbsent:
 				// Confirmed empty probe only — never on error/timeout.
 				_ = markLegacyKeyringMigrationDone(key)
@@ -440,26 +439,10 @@ func legacyKeyringMigrationMarkerPath(key string) string {
 	if strings.TrimSpace(home) == "" || key == "" {
 		return ""
 	}
-	// Env var names are identifiers, not secrets. Use a filesystem-safe form of
-	// the name itself (not a hash) so CodeQL does not treat this as secret storage.
-	return filepath.Join(home, "state", "legacy-keyring-checked", sanitizeLegacyKeyringMarkerName(key))
-}
-
-func sanitizeLegacyKeyringMarkerName(key string) string {
-	var b strings.Builder
-	b.Grow(len(key))
-	for _, r := range key {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('_')
-		}
-	}
-	if b.Len() == 0 {
-		return "_empty"
-	}
-	return b.String()
+	// Env var names are identifiers, not secrets. RawURL base64 is collision-free
+	// and filesystem-safe without hashing secret material.
+	name := base64.RawURLEncoding.EncodeToString([]byte(key))
+	return filepath.Join(home, "state", "legacy-keyring-checked", name)
 }
 
 func legacyKeyringMigrationDone(key string) bool {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
@@ -371,16 +373,13 @@ func normalizedMCPMigrationRoots(roots []string) []string {
 func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 	missing := map[string]string{}
 	skip := func(key string) bool {
-		return credentialCurrentStoreHasKey(key) || credentialCurrentStoreClearedKey(key)
+		return credentialCurrentStoreHasKey(key) ||
+			credentialCurrentStoreClearedKey(key) ||
+			legacyKeyringMigrationDone(key)
 	}
-	for _, key := range credentialEnvNamesForRoot(root) {
-		if skip(key) {
-			continue
-		}
-		if value, ok := legacyKeyringCredentialValueLookup(key); ok {
-			missing[key] = value
-		}
-	}
+	// Prefer legacy credential files first so a healthy file import does not
+	// depend on Secret Service / D-Bus. Keyring probes run only for remaining
+	// keys, under a shared 1s budget so a stuck bus cannot hang startup (#7507).
 	for _, src := range legacyCredentialsPaths() {
 		if src == "" {
 			continue
@@ -396,11 +395,116 @@ func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 			}
 		}
 	}
+	keys := credentialEnvNamesForRoot(root)
+	needKeyring := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if skip(key) {
+			continue
+		}
+		if _, exists := missing[key]; exists {
+			continue
+		}
+		needKeyring = append(needKeyring, key)
+	}
+	if len(needKeyring) > 0 {
+		values, completed, timedOut := lookupLegacyKeyringBatch(needKeyring, legacyKeyringLookupTimeout)
+		for _, key := range needKeyring {
+			if !completed[key] {
+				// Timed out before this key finished — no marker, retry later.
+				_ = timedOut
+				continue
+			}
+			if value := strings.TrimSpace(values[key]); value != "" {
+				missing[key] = value
+				continue
+			}
+			// Successful empty lookup: mark done so we do not re-probe forever.
+			_ = markLegacyKeyringMigrationDone(key)
+		}
+	}
 	if len(missing) == 0 {
 		return nil
 	}
 	_, err := StoreCredentialLines(credentialLines(missing))
 	return err
+}
+
+// lookupLegacyKeyringBatch probes the legacy keyring for the given keys under a
+// single shared deadline. completed marks keys whose lookup returned before the
+// budget expired (including empty successes). timedOut is true when the budget
+// expired with keys still outstanding; partial successes remain in values.
+func lookupLegacyKeyringBatch(keys []string, budget time.Duration) (values map[string]string, completed map[string]bool, timedOut bool) {
+	values = map[string]string{}
+	completed = map[string]bool{}
+	if len(keys) == 0 {
+		return values, completed, false
+	}
+	if budget <= 0 {
+		budget = time.Second
+	}
+	type result struct {
+		key   string
+		value string
+		ok    bool
+	}
+	ch := make(chan result, len(keys))
+	for _, key := range keys {
+		key := key
+		go func() {
+			// Use the package lookup hook so tests can inject fakes and so the
+			// default timeout wrapper still bounds a single stuck keyring call.
+			value, ok := legacyKeyringCredentialValueLookup(key)
+			ch <- result{key: key, value: value, ok: ok}
+		}()
+	}
+	deadline := time.NewTimer(budget)
+	defer deadline.Stop()
+	remaining := len(keys)
+	for remaining > 0 {
+		select {
+		case r := <-ch:
+			remaining--
+			completed[r.key] = true
+			if r.ok {
+				values[r.key] = r.value
+			} else {
+				values[r.key] = ""
+			}
+		case <-deadline.C:
+			return values, completed, true
+		}
+	}
+	return values, completed, false
+}
+
+func legacyKeyringMigrationMarkerPath(key string) string {
+	home := ReasonixHomeDir()
+	if strings.TrimSpace(home) == "" || strings.TrimSpace(key) == "" {
+		return ""
+	}
+	// Hash the env name so filesystem-safe markers never embed secrets.
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(home, "state", "legacy-keyring-migrated", fmt.Sprintf("%x", sum[:8]))
+}
+
+func legacyKeyringMigrationDone(key string) bool {
+	path := legacyKeyringMigrationMarkerPath(key)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func markLegacyKeyringMigrationDone(key string) error {
+	path := legacyKeyringMigrationMarkerPath(key)
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte("v1\n"), 0o644)
 }
 
 func credentialLines(assignments map[string]string) []string {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,7 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
+	"unicode"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
@@ -372,14 +371,13 @@ func normalizedMCPMigrationRoots(roots []string) []string {
 
 func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 	missing := map[string]string{}
-	skip := func(key string) bool {
-		return credentialCurrentStoreHasKey(key) ||
-			credentialCurrentStoreClearedKey(key) ||
-			legacyKeyringMigrationDone(key)
+	// File import ignores keyring markers: a marker only means "do not re-probe
+	// keyring for this env name", never "skip legacy credential files".
+	skipStore := func(key string) bool {
+		return credentialCurrentStoreHasKey(key) || credentialCurrentStoreClearedKey(key)
 	}
 	// Prefer legacy credential files first so a healthy file import does not
-	// depend on Secret Service / D-Bus. Keyring probes run only for remaining
-	// keys, under a shared 1s budget so a stuck bus cannot hang startup (#7507).
+	// depend on Secret Service / D-Bus (#7507).
 	for _, src := range legacyCredentialsPaths() {
 		if src == "" {
 			continue
@@ -390,7 +388,7 @@ func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 		}
 		assignments := parseCredentialLines(strings.Split(string(data), "\n"))
 		for key, value := range assignments {
-			if _, exists := missing[key]; !exists && !skip(key) {
+			if _, exists := missing[key]; !exists && !skipStore(key) {
 				missing[key] = value
 			}
 		}
@@ -398,28 +396,35 @@ func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 	keys := credentialEnvNamesForRoot(root)
 	needKeyring := make([]string, 0, len(keys))
 	for _, key := range keys {
-		if skip(key) {
+		if skipStore(key) {
 			continue
 		}
 		if _, exists := missing[key]; exists {
 			continue
 		}
+		// Marker only filters keyring probes.
+		if legacyKeyringMigrationDone(key) {
+			continue
+		}
 		needKeyring = append(needKeyring, key)
 	}
 	if len(needKeyring) > 0 {
-		values, completed, timedOut := lookupLegacyKeyringBatch(needKeyring, legacyKeyringLookupTimeout)
+		outcomes := lookupLegacyKeyringBatch(needKeyring, legacyKeyringLookupTimeout)
 		for _, key := range needKeyring {
-			if !completed[key] {
-				// Timed out before this key finished — no marker, retry later.
-				_ = timedOut
-				continue
+			o := outcomes[key]
+			switch o.Status {
+			case legacyKeyringFound:
+				if v := strings.TrimSpace(o.Value); v != "" {
+					missing[key] = v
+				}
+			case legacyKeyringAbsent:
+				// Confirmed empty probe only — never on error/timeout.
+				_ = markLegacyKeyringMigrationDone(key)
+			case legacyKeyringError, legacyKeyringTimeout:
+				// Leave unmarked so the next launch retries.
+			default:
+				// Unknown status: treat as timeout (no marker).
 			}
-			if value := strings.TrimSpace(values[key]); value != "" {
-				missing[key] = value
-				continue
-			}
-			// Successful empty lookup: mark done so we do not re-probe forever.
-			_ = markLegacyKeyringMigrationDone(key)
 		}
 	}
 	if len(missing) == 0 {
@@ -429,62 +434,32 @@ func migrateLegacyCredentialsIfNeededForRoot(root string) error {
 	return err
 }
 
-// lookupLegacyKeyringBatch probes the legacy keyring for the given keys under a
-// single shared deadline. completed marks keys whose lookup returned before the
-// budget expired (including empty successes). timedOut is true when the budget
-// expired with keys still outstanding; partial successes remain in values.
-func lookupLegacyKeyringBatch(keys []string, budget time.Duration) (values map[string]string, completed map[string]bool, timedOut bool) {
-	values = map[string]string{}
-	completed = map[string]bool{}
-	if len(keys) == 0 {
-		return values, completed, false
-	}
-	if budget <= 0 {
-		budget = time.Second
-	}
-	type result struct {
-		key   string
-		value string
-		ok    bool
-	}
-	ch := make(chan result, len(keys))
-	for _, key := range keys {
-		key := key
-		go func() {
-			// Use the package lookup hook so tests can inject fakes and so the
-			// default timeout wrapper still bounds a single stuck keyring call.
-			value, ok := legacyKeyringCredentialValueLookup(key)
-			ch <- result{key: key, value: value, ok: ok}
-		}()
-	}
-	deadline := time.NewTimer(budget)
-	defer deadline.Stop()
-	remaining := len(keys)
-	for remaining > 0 {
-		select {
-		case r := <-ch:
-			remaining--
-			completed[r.key] = true
-			if r.ok {
-				values[r.key] = r.value
-			} else {
-				values[r.key] = ""
-			}
-		case <-deadline.C:
-			return values, completed, true
-		}
-	}
-	return values, completed, false
-}
-
 func legacyKeyringMigrationMarkerPath(key string) string {
 	home := ReasonixHomeDir()
-	if strings.TrimSpace(home) == "" || strings.TrimSpace(key) == "" {
+	key = strings.TrimSpace(key)
+	if strings.TrimSpace(home) == "" || key == "" {
 		return ""
 	}
-	// Hash the env name so filesystem-safe markers never embed secrets.
-	sum := sha256.Sum256([]byte(key))
-	return filepath.Join(home, "state", "legacy-keyring-migrated", fmt.Sprintf("%x", sum[:8]))
+	// Env var names are identifiers, not secrets. Use a filesystem-safe form of
+	// the name itself (not a hash) so CodeQL does not treat this as secret storage.
+	return filepath.Join(home, "state", "legacy-keyring-checked", sanitizeLegacyKeyringMarkerName(key))
+}
+
+func sanitizeLegacyKeyringMarkerName(key string) string {
+	var b strings.Builder
+	b.Grow(len(key))
+	for _, r := range key {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "_empty"
+	}
+	return b.String()
 }
 
 func legacyKeyringMigrationDone(key string) bool {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1064,3 +1064,47 @@ func TestMigrateSupportData(t *testing.T) {
 		}
 	}
 }
+
+func TestMigrateLegacyCredentialsFileImportIgnoresKeyringMarker(t *testing.T) {
+	_, dest, _ := legacyHome(t)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`default_model = "deepseek-flash/deepseek-chat"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := markLegacyKeyringMigrationDone("DEEPSEEK_API_KEY"); err != nil {
+		t.Fatal(err)
+	}
+	paths := legacyCredentialsPaths()
+	if len(paths) == 0 {
+		t.Skip("no legacy credentials paths on this platform")
+	}
+	target := paths[0]
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("DEEPSEEK_API_KEY=sk-from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHelper := legacyKeyringHelperEnabled
+	oldLookup := legacyKeyringCredentialValueLookup
+	legacyKeyringHelperEnabled = false
+	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
+	t.Cleanup(func() {
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringCredentialValueLookup = oldLookup
+	})
+
+	if err := MigrateLegacyCredentialsForRoot("."); err != nil {
+		t.Fatalf("MigrateLegacyCredentialsForRoot: %v", err)
+	}
+	data, err := os.ReadFile(UserCredentialsPath())
+	if err != nil {
+		t.Fatalf("read migrated credentials: %v", err)
+	}
+	if !strings.Contains(string(data), "sk-from-file") {
+		t.Fatalf("file import blocked by keyring marker: %q", data)
+	}
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -715,14 +715,14 @@ func TestMigrateImportsLegacyCredentialsEvenWhenPrimaryConfigExists(t *testing.T
 
 func TestMigrateImportsLegacyKeyringCredentials(t *testing.T) {
 	legacyHome(t)
-	old := legacyKeyringCredentialValueLookup
-	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+	old := legacyKeyringProbeLookup
+	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
 		if key == "DEEPSEEK_API_KEY" {
-			return "sk-old-keyring", true
+			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-old-keyring"}
 		}
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
-	t.Cleanup(func() { legacyKeyringCredentialValueLookup = old })
+	t.Cleanup(func() { legacyKeyringProbeLookup = old })
 
 	res, err := MigrateLegacyIfNeeded()
 	if err != nil {
@@ -760,14 +760,14 @@ api_key_env = "WORKSPACE_ONLY_KEY"
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	old := legacyKeyringCredentialValueLookup
-	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+	old := legacyKeyringProbeLookup
+	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
 		if key == "WORKSPACE_ONLY_KEY" {
-			return "sk-workspace", true
+			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-workspace"}
 		}
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
-	t.Cleanup(func() { legacyKeyringCredentialValueLookup = old })
+	t.Cleanup(func() { legacyKeyringProbeLookup = old })
 
 	if err := MigrateLegacyCredentialsForRoot(project); err != nil {
 		t.Fatalf("MigrateLegacyCredentialsForRoot: %v", err)
@@ -791,14 +791,14 @@ func TestMigrateLegacyCredentialsSkipsKeyringWhenIsolated(t *testing.T) {
 	t.Setenv("REASONIX_HOME", isolated)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
-	old := legacyKeyringCredentialValueLookup
-	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+	old := legacyKeyringProbeLookup
+	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
 		if key == "DEEPSEEK_API_KEY" {
-			return "legacy-keyring-value", true
+			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "legacy-keyring-value"}
 		}
-		return "", false
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
-	t.Cleanup(func() { legacyKeyringCredentialValueLookup = old })
+	t.Cleanup(func() { legacyKeyringProbeLookup = old })
 
 	if err := MigrateLegacyCredentialsForRoot("."); err != nil {
 		t.Fatalf("MigrateLegacyCredentialsForRoot: %v", err)
@@ -1089,12 +1089,14 @@ func TestMigrateLegacyCredentialsFileImportIgnoresKeyringMarker(t *testing.T) {
 	}
 
 	oldHelper := legacyKeyringHelperEnabled
-	oldLookup := legacyKeyringCredentialValueLookup
+	oldLookup := legacyKeyringProbeLookup
 	legacyKeyringHelperEnabled = false
-	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
+	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
+	}
 	t.Cleanup(func() {
 		legacyKeyringHelperEnabled = oldHelper
-		legacyKeyringCredentialValueLookup = oldLookup
+		legacyKeyringProbeLookup = oldLookup
 	})
 
 	if err := MigrateLegacyCredentialsForRoot("."); err != nil {
@@ -1106,5 +1108,29 @@ func TestMigrateLegacyCredentialsFileImportIgnoresKeyringMarker(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "sk-from-file") {
 		t.Fatalf("file import blocked by keyring marker: %q", data)
+	}
+}
+
+func TestMigrateLegacyCredentialsErrorDoesNotWriteKeyringMarker(t *testing.T) {
+	legacyHome(t)
+	oldHelper := legacyKeyringHelperEnabled
+	oldLookup := legacyKeyringProbeLookup
+	legacyKeyringHelperEnabled = false
+	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+		return legacyKeyringOutcome{Status: legacyKeyringError}
+	}
+	t.Cleanup(func() {
+		legacyKeyringHelperEnabled = oldHelper
+		legacyKeyringProbeLookup = oldLookup
+	})
+
+	if err := MigrateLegacyCredentialsForRoot("."); err != nil {
+		t.Fatalf("MigrateLegacyCredentialsForRoot: %v", err)
+	}
+	if legacyKeyringMigrationDone("DEEPSEEK_API_KEY") {
+		t.Fatal("keyring error must not write a migration-done marker")
+	}
+	if credentialCurrentStoreHasKey("DEEPSEEK_API_KEY") {
+		t.Fatal("keyring error must not store a credential")
 	}
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -716,7 +717,7 @@ func TestMigrateImportsLegacyCredentialsEvenWhenPrimaryConfigExists(t *testing.T
 func TestMigrateImportsLegacyKeyringCredentials(t *testing.T) {
 	legacyHome(t)
 	old := legacyKeyringProbeLookup
-	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(_ context.Context, key string) legacyKeyringOutcome {
 		if key == "DEEPSEEK_API_KEY" {
 			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-old-keyring"}
 		}
@@ -761,7 +762,7 @@ api_key_env = "WORKSPACE_ONLY_KEY"
 		t.Fatal(err)
 	}
 	old := legacyKeyringProbeLookup
-	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(_ context.Context, key string) legacyKeyringOutcome {
 		if key == "WORKSPACE_ONLY_KEY" {
 			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "sk-workspace"}
 		}
@@ -792,7 +793,7 @@ func TestMigrateLegacyCredentialsSkipsKeyringWhenIsolated(t *testing.T) {
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 
 	old := legacyKeyringProbeLookup
-	legacyKeyringProbeLookup = func(key string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(_ context.Context, key string) legacyKeyringOutcome {
 		if key == "DEEPSEEK_API_KEY" {
 			return legacyKeyringOutcome{Status: legacyKeyringFound, Value: "legacy-keyring-value"}
 		}
@@ -1088,14 +1089,11 @@ func TestMigrateLegacyCredentialsFileImportIgnoresKeyringMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oldHelper := legacyKeyringHelperEnabled
 	oldLookup := legacyKeyringProbeLookup
-	legacyKeyringHelperEnabled = false
-	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(context.Context, string) legacyKeyringOutcome {
 		return legacyKeyringOutcome{Status: legacyKeyringAbsent}
 	}
 	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
 		legacyKeyringProbeLookup = oldLookup
 	})
 
@@ -1113,14 +1111,11 @@ func TestMigrateLegacyCredentialsFileImportIgnoresKeyringMarker(t *testing.T) {
 
 func TestMigrateLegacyCredentialsErrorDoesNotWriteKeyringMarker(t *testing.T) {
 	legacyHome(t)
-	oldHelper := legacyKeyringHelperEnabled
 	oldLookup := legacyKeyringProbeLookup
-	legacyKeyringHelperEnabled = false
-	legacyKeyringProbeLookup = func(string) legacyKeyringOutcome {
+	legacyKeyringProbeLookup = func(context.Context, string) legacyKeyringOutcome {
 		return legacyKeyringOutcome{Status: legacyKeyringError}
 	}
 	t.Cleanup(func() {
-		legacyKeyringHelperEnabled = oldHelper
 		legacyKeyringProbeLookup = oldLookup
 	})
 

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -147,6 +148,12 @@ func Collect(opts Options) Report {
 	bashConfigIgnored := strings.TrimSpace(cfg.Sandbox.Bash) == "enforce" && cfg.BashMode() == "off"
 	if bashConfigIgnored {
 		warnings = append(warnings, `config requests [sandbox] bash = "enforce", but Windows does not provide an OS-level Bash sandbox; the setting is fixed to "off" and bash runs unconfined`)
+	}
+	// Supervised deployments sometimes override HOME onto a service config dir
+	// while Reasonix isolation should use REASONIX_HOME. Do not rewrite
+	// subprocess HOME automatically (#7600 rejected); surface the mismatch.
+	if warn := homeIsolationWarning(); warn != "" {
+		warnings = append(warnings, warn)
 	}
 	report := Report{
 		Version: opts.Version,
@@ -357,6 +364,44 @@ func valueOr(s, fallback string) string {
 		return fallback
 	}
 	return s
+}
+
+// homeIsolationWarning detects a process HOME that differs from the OS account
+// home while REASONIX_HOME is unset. Services should keep the real account HOME
+// and isolate Reasonix state with REASONIX_HOME instead of rewriting HOME.
+func homeIsolationWarning() string {
+	if strings.TrimSpace(os.Getenv("REASONIX_HOME")) != "" {
+		return ""
+	}
+	envHome := strings.TrimSpace(os.Getenv("HOME"))
+	if envHome == "" {
+		// Windows services often set USERPROFILE rather than HOME.
+		envHome = strings.TrimSpace(os.Getenv("USERPROFILE"))
+	}
+	if envHome == "" {
+		return ""
+	}
+	acct, err := user.Current()
+	if err != nil || acct == nil || strings.TrimSpace(acct.HomeDir) == "" {
+		return ""
+	}
+	envClean := filepath.Clean(envHome)
+	acctClean := filepath.Clean(acct.HomeDir)
+	if samePathFold(envClean, acctClean) {
+		return ""
+	}
+	return "process HOME (" + redactHome(envClean) + ") differs from the OS account home (" +
+		redactHome(acctClean) + "); keep the real account HOME for services and isolate Reasonix with REASONIX_HOME"
+}
+
+func samePathFold(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return false
 }
 
 // redactHome rewrites a path under the user's home directory to start with "~",

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -390,8 +390,10 @@ func homeIsolationWarning() string {
 	if samePathFold(envClean, acctClean) {
 		return ""
 	}
-	return "process HOME (" + redactHome(envClean) + ") differs from the OS account home (" +
-		redactHome(acctClean) + "); keep the real account HOME for services and isolate Reasonix with REASONIX_HOME"
+	// Do not embed either absolute path: when HOME is overridden, redactHome
+	// cannot mask the account home, and shareable doctor output must stay free
+	// of machine-local identity.
+	return "process HOME differs from the OS account home; keep the real account HOME for services and isolate Reasonix with REASONIX_HOME"
 }
 
 func samePathFold(a, b string) bool {

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"encoding/json"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -153,5 +154,27 @@ func TestCollectFlagsIgnoredEnforceConfig(t *testing.T) {
 	plain := RenderText(Report{Sandbox: SandboxReport{Bash: "off"}})
 	if strings.Contains(plain, "ignored") {
 		t.Fatalf("plain off must not claim the config was ignored:\n%s", plain)
+	}
+}
+
+func TestHomeIsolationWarningDetectsMismatch(t *testing.T) {
+	// Prefer a synthetic mismatch without requiring root privileges.
+	acct, err := user.Current()
+	if err != nil || acct == nil || strings.TrimSpace(acct.HomeDir) == "" {
+		t.Skip("account home unavailable")
+	}
+	t.Setenv("REASONIX_HOME", "")
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "service-home"))
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	got := homeIsolationWarning()
+	if got == "" {
+		t.Fatal("expected HOME mismatch warning")
+	}
+	if !strings.Contains(got, "REASONIX_HOME") {
+		t.Fatalf("warning = %q, want REASONIX_HOME guidance", got)
+	}
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	if got := homeIsolationWarning(); got != "" {
+		t.Fatalf("REASONIX_HOME set should silence warning, got %q", got)
 	}
 }

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -164,14 +164,19 @@ func TestHomeIsolationWarningDetectsMismatch(t *testing.T) {
 		t.Skip("account home unavailable")
 	}
 	t.Setenv("REASONIX_HOME", "")
-	t.Setenv("HOME", filepath.Join(t.TempDir(), "service-home"))
-	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	serviceHome := filepath.Join(t.TempDir(), "service-home")
+	t.Setenv("HOME", serviceHome)
+	t.Setenv("USERPROFILE", serviceHome)
 	got := homeIsolationWarning()
 	if got == "" {
 		t.Fatal("expected HOME mismatch warning")
 	}
 	if !strings.Contains(got, "REASONIX_HOME") {
 		t.Fatalf("warning = %q, want REASONIX_HOME guidance", got)
+	}
+	// Shareable output must not embed either absolute home path.
+	if strings.Contains(got, serviceHome) || strings.Contains(got, acct.HomeDir) {
+		t.Fatalf("warning leaked a home path: %q", got)
 	}
 	t.Setenv("REASONIX_HOME", t.TempDir())
 	if got := homeIsolationWarning(); got != "" {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -214,7 +214,14 @@ func ContextFileUsable(path string) bool {
 // LoadOptions configure Load.
 type LoadOptions struct {
 	ProjectRoot string
-	HomeDir     string
+	// HomeDir overrides the OS user home used by legacy callers and tests. The
+	// derived global path is <HomeDir>/.reasonix unless ReasonixHomeDir is set.
+	HomeDir string
+	// ReasonixHomeDir is the exact current Reasonix home (settings.json lives
+	// directly under it). When set, it takes precedence over HomeDir for global
+	// settings and plugin hooks so Windows %APPDATA%/reasonix and REASONIX_HOME
+	// isolation stay consistent across hook/doctor/capdiag (#7411, #7331).
+	ReasonixHomeDir string
 	// Trusted is retained for source compatibility. Project hooks are enabled
 	// automatically now, so callers no longer need to set it.
 	Trusted bool
@@ -231,8 +238,12 @@ func Load(opts LoadOptions) []ResolvedHook {
 			appendResolved(&out, s, ScopeProject, p)
 		}
 	}
-	appendPluginHooks(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
-	g := GlobalSettingsPath(opts.HomeDir)
+	reasonixHomeDir := reasonixHomeForOptions(opts)
+	appendPluginHooks(&out, reasonixHomeDir, opts.ProjectRoot)
+	g := filepath.Join(reasonixHomeDir, SettingsFilename)
+	if reasonixHomeDir == "" {
+		g = GlobalSettingsPath(opts.HomeDir)
+	}
 	if s := readSettings(g); s != nil {
 		appendResolved(&out, s, ScopeGlobal, g)
 	} else if !pathExists(g) {
@@ -1578,6 +1589,13 @@ func reasonixHome(override string) string {
 		return filepath.Join(h, SettingsDirname)
 	}
 	return ""
+}
+
+func reasonixHomeForOptions(opts LoadOptions) string {
+	if dir := strings.TrimSpace(opts.ReasonixHomeDir); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return reasonixHome(opts.HomeDir)
 }
 
 func legacyGlobalSettingsPath(homeDir string) string {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1024,6 +1024,23 @@ func TestReasonixHomeOverridesGlobalHookPaths(t *testing.T) {
 	}
 }
 
+func TestLoadOptionsReasonixHomeDirUsesExactGlobalHookPath(t *testing.T) {
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, "AppData", "Roaming", "reasonix")
+	settingsPath := filepath.Join(reasonixHome, SettingsFilename)
+	if err := os.MkdirAll(reasonixHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"Stop":[{"command":"echo exact"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := Load(LoadOptions{HomeDir: home, ReasonixHomeDir: reasonixHome})
+	if len(hooks) != 1 || hooks[0].Command != "echo exact" || hooks[0].Source != settingsPath {
+		t.Fatalf("Load hooks = %+v, want exact Reasonix home hook", hooks)
+	}
+}
+
 func TestReasonixHomeDoesNotFallBackToLegacyWhenIsolated(t *testing.T) {
 	home := t.TempDir()
 	reasonixHome := filepath.Join(t.TempDir(), "rx-home")

--- a/internal/hook/inspect.go
+++ b/internal/hook/inspect.go
@@ -67,9 +67,13 @@ func Inspect(opts LoadOptions) Inspection {
 	}
 
 	// Plugin hooks (enabled packages only — same as Load).
-	appendPluginInspect(&out, reasonixHome(opts.HomeDir), opts.ProjectRoot)
+	reasonixHomeDir := reasonixHomeForOptions(opts)
+	appendPluginInspect(&out, reasonixHomeDir, opts.ProjectRoot)
 
-	g := GlobalSettingsPath(opts.HomeDir)
+	g := filepath.Join(reasonixHomeDir, SettingsFilename)
+	if reasonixHomeDir == "" {
+		g = GlobalSettingsPath(opts.HomeDir)
+	}
 	st := inspectSettingsFile(g, ScopeGlobal)
 	if st.Status == "missing" {
 		if legacy := legacyGlobalSettingsPath(opts.HomeDir); legacy != "" {


### PR DESCRIPTION
## Summary

Integration PR A for the 30-day CLI feedback plan: startup/diagnostics hardening, unified Reasonix home for hooks/doctor/capdiag, and bounded **in-process** legacy keyring migration (no external helper; private, context-bound D-Bus).

### Kept / adapted

| Source | Author | Mechanism |
| --- | --- | --- |
| #7427 | @ZhiyaoWen999 | Exact Reasonix home for global hooks |
| #7607 | @skyzhao1223 | Same home wiring + `<reasonix-home>` redaction in capdiag |
| #7601 | @skyzhao1223 | Bounded keyring probes (private session bus + `CallWithContext` under shared 1s budget) |

### Reviewed but not adopted

| Source | Why |
| --- | --- |
| #7600 | Auto-rewriting subprocess HOME is rejected. Keep original HOME; doctor warns when process HOME ≠ account home and `REASONIX_HOME` is unset (without embedding absolute paths). Isolation remains `REASONIX_HOME`. |

### Issue linkage

- **Fixes #7411** — global hooks/doctor/capdiag use the exact Reasonix home.
- **Fixes #7507** — shared 1s budget: connect uses `SessionBusPrivateNoAutoStartup(dbus.WithContext(ctx))` so cancel closes the transport during Auth/Hello; every Secret Service method/property uses `CallWithContext(ctx)`; private connection is closed on return. Avoids `dbus-launch` hangs (no autolaunch). Residual: a pure Dial hang before godbus installs the connection context is still a library limit; caller wait remains capped at 1s.
- **Refs #7435** — diagnostic milestones, non-empty logs, and watchdog `Program.Kill` are recovery/evidence. Windows ConPTY freezes still need dedicated repro before closing.
- **Refs #7331** — does **not** rewrite subprocess HOME. Product decision: keep process HOME; use `REASONIX_HOME` for isolation.
- **Refs #7600** — explicit non-adoption with doctor guidance.

### Security / concurrency notes

- **No external keyring helper.** No env-triggered subprocess can dump secrets into a caller-controlled home.
- Linux/BSD: **private** session-bus connection per probe (never shared `SessionBus()`), bound with `dbus.WithContext(ctx)`, always `Close()`d on return paths.
- Properties.Get and session Close use **CallWithContext(ctx)** only.
- Found secrets store only via `storeCredentialIfAbsentAndNotCleared` under the credential advisory lock.
- Markers: `base64.RawURLEncoding` under `<reasonix-home>/state/legacy-keyring-checked/`; written only for confirmed **absent**.

## Verification

- `go test ./internal/cli ./internal/config ./internal/hook ./internal/capdiag ./internal/doctor ./internal/control -count=1`
- `go test -race ./internal/config -count=1`
- Production interleaving tests: probe blocks → user write/tombstone → release → batch store-if-absent

## Cache impact

Cache-impact: none - diagnostics, credentials migration, path redaction, and doctor warnings only; no provider prompt, tool schema, MCP registration, or compaction changes.
Cache-guard: existing package tests; no system-prompt string edits.
System-prompt-review: not required - no system prompt changes.

Documentation-impact: none - behavior matches existing REASONIX_HOME / doctor docs; no new user-facing flag or config key.

## Compatibility

- Default paths unchanged when REASONIX_HOME unset.
- Subprocess env HOME is not rewritten.
- Confirmed-absent keyring probes write markers under `<reasonix-home>/state/legacy-keyring-checked/<base64-rawurl-env-name>`; error/timeout leave no marker.