### PR TITLE
Persist private temp files across Bash calls / 让 Bash 临时文件在会话内持久

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,15 @@ jobs:
           WINDOWS_SANDBOX_WAIT_MS: "20000"
         run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
+      # The general Windows PR smoke list intentionally omits internal/tool.
+      # Keep the session-temp portability contract covered without widening the
+      # leg to every tool test: two real PowerShell launches must share the
+      # injected TMPDIR/TMP/TEMP directory.
+      - name: test (Windows session temp)
+        if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
+        timeout-minutes: 3
+        run: go test -timeout=2m -run '^TestBashSharesSessionTempAcrossCalls$' ./internal/tool/builtin
+
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'
         timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ branch.
 
 ## Unreleased
 
+### Fixed
+
+- **Issue #7575:** Linux Bash under bubblewrap no longer mounts a fresh empty
+  `--tmpfs /tmp` on every call. Consecutive commands in the same logical session
+  now share a private temporary directory (bound at `/tmp` on Linux, exported via
+  `TMPDIR`/`TMP`/`TEMP` on all platforms) without exposing the host public
+  temporary root. `/new`, `/clear`, resume of another session, and branch
+  switches rotate the directory; model/settings hot rebuilds keep it. Sub-agent
+  runs get independent directories. Temporary files are not durable across process
+  restarts.
+
 ### Added
 
 - Added `[ui].show_turn_usage` so CLI/TUI users can hide per-request token and

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -54,12 +54,24 @@ import (
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/provider"
 	"reasonix/internal/repair"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/skill"
 	"reasonix/internal/stats"
 	"reasonix/internal/store"
 	"reasonix/internal/taskmonitor"
 	"reasonix/internal/tool"
 )
+
+// sessionTempFromController returns the logical-session private temporary
+// directory manager for a same-session controller rebuild. Nil when the
+// controller is missing or is not a *control.Controller.
+func sessionTempFromController(ctrl control.SessionAPI) *sessiontemp.Manager {
+	c, ok := ctrl.(*control.Controller)
+	if !ok || c == nil {
+		return nil
+	}
+	return c.SessionTemp()
+}
 
 // eventChannel is the Wails runtime event name the frontend subscribes to for the
 // agent's typed event stream. One channel carries every event kind; the payload's
@@ -10091,6 +10103,9 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		// Same logical session: keep the private temporary directory across
+		// model switches (Issue #7575).
+		SessionTemp: sessionTempFromController(oldCtrl),
 	})
 	if err != nil {
 		return err
@@ -10260,6 +10275,9 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		// Same logical session: keep the private temporary directory across
+		// effort switches (Issue #7575).
+		SessionTemp: sessionTempFromController(oldCtrl),
 	})
 	if err != nil {
 		return err
@@ -10397,6 +10415,9 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		SubagentParentLive:       a.subagentParentProbeForBuild(tab),
 		SessionRecoveryMeta:      a.tabSessionRecoveryMeta(tab),
 		OnSessionRecovered:       a.handleTabSessionRecovered(tab),
+		// Same logical session: keep the private temporary directory across
+		// token-mode switches (Issue #7575).
+		SessionTemp: sessionTempFromController(oldCtrl),
 	})
 	if err != nil {
 		return err

--- a/desktop/session_temp_rebuild_test.go
+++ b/desktop/session_temp_rebuild_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/control"
+)
+
+// TestDesktopHotRebuildPathsKeepSessionTemp covers the three same-session
+// rebuilds that use boot.Build directly (not boot.Rebuild): model, effort,
+// and token-mode switches. Each must pass the old Controller's SessionTemp so
+// temporary files survive (Issue #7575).
+func TestDesktopHotRebuildPathsKeepSessionTemp(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prepare func(*App, *WorkspaceTab)
+		rebuild func(*App, *WorkspaceTab) error
+	}{
+		{
+			name:    "model",
+			prepare: func(*App, *WorkspaceTab) {},
+			rebuild: func(app *App, tab *WorkspaceTab) error {
+				return app.SetModelForTab(tab.ID, "alt/alt-model")
+			},
+		},
+		{
+			name:    "effort",
+			prepare: func(*App, *WorkspaceTab) {},
+			rebuild: func(app *App, tab *WorkspaceTab) error {
+				return app.SetEffortForTab(tab.ID, "high")
+			},
+		},
+		{
+			name:    "token mode",
+			prepare: func(*App, *WorkspaceTab) {},
+			rebuild: func(app *App, tab *WorkspaceTab) error {
+				return app.SetTokenModeForTab(tab.ID, "delivery")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, tab, oldAPI, _ := newGoalDeliveryYoloTestApp(t, control.GoalStatusRunning)
+			oldCtrl, ok := oldAPI.(*control.Controller)
+			if !ok || oldCtrl == nil {
+				t.Fatal("old controller is not *control.Controller")
+			}
+			tc.prepare(app, tab)
+
+			// Plant a file in the session-private temporary directory.
+			lease, err := oldCtrl.SessionTemp().Acquire()
+			if err != nil {
+				t.Fatalf("acquire old session temp: %v", err)
+			}
+			oldMgr := oldCtrl.SessionTemp()
+			oldDir := lease.Dir()
+			marker := filepath.Join(oldDir, "desktop-hot-rebuild.txt")
+			if err := os.WriteFile(marker, []byte(tc.name), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			lease.Release()
+
+			if err := tc.rebuild(app, tab); err != nil {
+				t.Fatalf("rebuild: %v", err)
+			}
+
+			newAPI := app.controllerForTab(tab)
+			newCtrl, ok := newAPI.(*control.Controller)
+			if !ok || newCtrl == nil || newCtrl == oldCtrl {
+				t.Fatal("rebuild did not install a replacement *control.Controller")
+			}
+			if newCtrl.SessionTemp() != oldMgr {
+				t.Fatalf("%s rebuild did not reuse SessionTemp Manager (got %p want %p)",
+					tc.name, newCtrl.SessionTemp(), oldMgr)
+			}
+			if oldMgr.Sealed() {
+				t.Fatal("shared manager sealed after hot rebuild (replacement must retain first)")
+			}
+
+			again, err := newCtrl.SessionTemp().Acquire()
+			if err != nil {
+				t.Fatalf("acquire after rebuild: %v", err)
+			}
+			defer again.Release()
+			if again.Dir() != oldDir {
+				t.Fatalf("%s rebuild rotated temporary generation: got %q want %q",
+					tc.name, again.Dir(), oldDir)
+			}
+			body, err := os.ReadFile(marker)
+			if err != nil || string(body) != tc.name {
+				t.Fatalf("temp file lost across %s rebuild: %q %v", tc.name, body, err)
+			}
+		})
+	}
+}
+
+func TestSessionTempFromControllerHelper(t *testing.T) {
+	if sessionTempFromController(nil) != nil {
+		t.Fatal("nil controller should yield nil SessionTemp")
+	}
+	ctrl := control.New(control.Options{})
+	defer ctrl.Close()
+	if sessionTempFromController(ctrl) == nil {
+		t.Fatal("want non-nil SessionTemp from live controller")
+	}
+	if sessionTempFromController(ctrl) != ctrl.SessionTemp() {
+		t.Fatal("helper must return the controller's Manager")
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1948,6 +1948,11 @@ func (a *App) buildSettingReplacementController(tab *WorkspaceTab, snap tabRunti
 		}
 		return ctrl, restoredRuntime, path, nil
 	}
+	// Same-session rebuild without the full boot.Rebuild path still must keep
+	// the private temporary directory (Issue #7575).
+	if old, ok := oldCtrl.(*control.Controller); ok && old != nil && opts.SessionTemp == nil {
+		opts.SessionTemp = old.SessionTemp()
+	}
 	ctrl, err := boot.Build(a.bootContext(), opts)
 	if err != nil {
 		return nil, normalizedTabRuntime{}, "", err

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -694,17 +694,31 @@ workspace-scoped behavior.
 **Session-private temporary directory.** Within one logical chat session, Bash
 commands share a private temporary directory so consecutive calls can exchange
 files through `$TMPDIR` (and, on Linux under bubblewrap, through literal
-`/tmp`). The directory is created lazily, is never the host public temporary
-root, and is rotated on `/new`, `/clear`, resume of another session, and branch
-switches. Model/settings hot rebuilds keep the same directory. Temporary files
-are not durable storage: resume across process restarts does not restore them,
-and scripts that need long-lived data should write into the workspace or a
+`/tmp`). No user setup is required: Reasonix automatically exports `TMPDIR`,
+`TMP`, and `TEMP` for Bash and client-owned ACP terminals. The directory is
+created lazily, is never the host public temporary root, and is rotated on
+`/new`, `/clear`, resume of another session, and branch switches.
+Model/settings hot rebuilds keep the same directory. Temporary files are not
+durable storage: resume across process restarts does not restore them, and
+scripts that need long-lived data should write into the workspace or a
 user-specified path.
+
+Reasonix-generated and project scripts should use the standard temporary
+environment variables rather than hard-coding `/tmp`; users should not set
+these variables themselves. For example:
+
+```sh
+tmp_file="${TMPDIR:?}/result.json"
+```
+
+```powershell
+$tmpFile = Join-Path $env:TEMP "result.json"
+```
 
 | Platform | `$TMPDIR` / `$TMP` / `$TEMP` | Literal `/tmp` |
 | --- | --- | --- |
 | Linux + bubblewrap | Virtual `/tmp` (bound to the private dir) | Shared for the session (not a fresh empty tmpfs each call) |
-| macOS Seatbelt | Host path of the private dir (allowed by policy) | Host macOS temporary directory; prefer `$TMPDIR` |
+| macOS Seatbelt | Host path of the private dir (allowed by policy) | Host macOS temporary directory; scripts should use `$TMPDIR` |
 | Windows (no OS Bash sandbox) | Host path of the private dir | Not promised to match (e.g. Git Bash `/tmp`) |
 
 Independent sandboxes such as MCP servers keep their own isolation and do not

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -690,6 +690,28 @@ Reasonix always removes saved provider and bot credential variables from tool
 subprocess environments and automatically adds its global credential `.env` to
 the runtime read-deny boundary. Project `.env` files keep their existing
 workspace-scoped behavior.
+
+**Session-private temporary directory.** Within one logical chat session, Bash
+commands share a private temporary directory so consecutive calls can exchange
+files through `$TMPDIR` (and, on Linux under bubblewrap, through literal
+`/tmp`). The directory is created lazily, is never the host public temporary
+root, and is rotated on `/new`, `/clear`, resume of another session, and branch
+switches. Model/settings hot rebuilds keep the same directory. Temporary files
+are not durable storage: resume across process restarts does not restore them,
+and scripts that need long-lived data should write into the workspace or a
+user-specified path.
+
+| Platform | `$TMPDIR` / `$TMP` / `$TEMP` | Literal `/tmp` |
+| --- | --- | --- |
+| Linux + bubblewrap | Virtual `/tmp` (bound to the private dir) | Shared for the session (not a fresh empty tmpfs each call) |
+| macOS Seatbelt | Host path of the private dir (allowed by policy) | Host macOS temporary directory; prefer `$TMPDIR` |
+| Windows (no OS Bash sandbox) | Host path of the private dir | Not promised to match (e.g. Git Bash `/tmp`) |
+
+Independent sandboxes such as MCP servers keep their own isolation and do not
+inherit the chat session's temporary directory. An approved sandbox-escape
+command still receives the private temp environment variables, but on Linux its
+literal `/tmp` is no longer mapped by bubblewrap.
+
 **Windows note:** Reasonix does not ship an OS-level Bash sandbox on Windows.
 The effective mode is fixed to `off`; even an older config containing
 `bash = "enforce"` resolves to `off`, `reasonix doctor` flags the ignored value,

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -553,14 +553,27 @@ Reasonix 始终会从工具子进程环境中移除已保存的 provider 与 bot
 
 **会话私有标准临时目录。**同一逻辑会话内的多条 Bash 命令共享一个私有临时目录，
 因此连续调用可以通过 `$TMPDIR` 交换文件（在 Linux bubblewrap 下还可以通过字面
-`/tmp`）。目录按需创建，不会回退到宿主公共临时目录；在 `/new`、`/clear`、恢复
-另一会话、切换分支时旋转。模型或设置热重建会保留同一目录。临时文件不是持久存储：
-跨进程 resume 不会恢复其中内容；需要长期保留的数据应写入工作区或用户指定路径。
+`/tmp`）。用户不需要设置：Reasonix 会自动为 Bash 和客户端托管的 ACP 终端注入
+`TMPDIR`、`TMP`、`TEMP`。目录按需创建，不会回退到宿主公共临时目录；在 `/new`、
+`/clear`、恢复另一会话、切换分支时旋转。模型或设置热重建会保留同一目录。临时文件
+不是持久存储：跨进程 resume 不会恢复其中内容；需要长期保留的数据应写入工作区或
+用户指定路径。
+
+Reasonix 生成的脚本和项目脚本应使用标准临时目录变量，不要硬编码 `/tmp`；用户无需
+自行设置这些变量。例如：
+
+```sh
+tmp_file="${TMPDIR:?}/result.json"
+```
+
+```powershell
+$tmpFile = Join-Path $env:TEMP "result.json"
+```
 
 | 平台 | `$TMPDIR` / `$TMP` / `$TEMP` | 字面 `/tmp` |
 | --- | --- | --- |
 | Linux + bubblewrap | 虚拟 `/tmp`（绑定到私有目录） | 会话内共享（不再是每次新建的空 tmpfs） |
-| macOS Seatbelt | 私有宿主目录路径（Seatbelt 允许写入） | 仍是 macOS 宿主临时目录；脚本应优先用 `$TMPDIR` |
+| macOS Seatbelt | 私有宿主目录路径（Seatbelt 允许写入） | 仍是 macOS 宿主临时目录；脚本应使用 `$TMPDIR` |
 | Windows（无 OS 级 Bash 沙箱） | 私有宿主目录路径 | 不保证与该目录等价（例如 Git Bash 的 `/tmp`） |
 
 MCP 等独立沙盒继续使用自己的隔离规范，不继承父会话临时目录。获得批准后绕过沙盒的

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -550,6 +550,22 @@ Sandbox 是授权之后的第二层边界，不能替代命令解析，也不能
 OS 沙盒生效时也不能读取配置的 `forbid_read` roots，`[sandbox] network` 为真时才能联网。
 Reasonix 始终会从工具子进程环境中移除已保存的 provider 与 bot 凭据变量，并自动把
 全局凭据 `.env` 加入运行时禁读边界；项目 `.env` 仍保持现有的 workspace 范围行为。
+
+**会话私有标准临时目录。**同一逻辑会话内的多条 Bash 命令共享一个私有临时目录，
+因此连续调用可以通过 `$TMPDIR` 交换文件（在 Linux bubblewrap 下还可以通过字面
+`/tmp`）。目录按需创建，不会回退到宿主公共临时目录；在 `/new`、`/clear`、恢复
+另一会话、切换分支时旋转。模型或设置热重建会保留同一目录。临时文件不是持久存储：
+跨进程 resume 不会恢复其中内容；需要长期保留的数据应写入工作区或用户指定路径。
+
+| 平台 | `$TMPDIR` / `$TMP` / `$TEMP` | 字面 `/tmp` |
+| --- | --- | --- |
+| Linux + bubblewrap | 虚拟 `/tmp`（绑定到私有目录） | 会话内共享（不再是每次新建的空 tmpfs） |
+| macOS Seatbelt | 私有宿主目录路径（Seatbelt 允许写入） | 仍是 macOS 宿主临时目录；脚本应优先用 `$TMPDIR` |
+| Windows（无 OS 级 Bash 沙箱） | 私有宿主目录路径 | 不保证与该目录等价（例如 Git Bash 的 `/tmp`） |
+
+MCP 等独立沙盒继续使用自己的隔离规范，不继承父会话临时目录。获得批准后绕过沙盒的
+命令仍继承私有临时变量，但在 Linux 上其字面 `/tmp` 不再由 bwrap 映射。
+
 **Windows 说明：**Reasonix 不在 Windows 上提供 OS 级 Bash 沙箱，生效模式固定为
 `off`。旧配置即使写了 `bash = "enforce"` 也会解析为 `off`，`reasonix doctor`
 会提示该设置被忽略，桌面设置中的选择器也为只读。Bash 命令会在不受 OS 沙箱限制的

--- a/internal/acp/client_integration_test.go
+++ b/internal/acp/client_integration_test.go
@@ -107,7 +107,7 @@ func TestClientIORunCommandLifecycle(t *testing.T) {
 	req.results["terminal/release"] = struct{}{}
 	io := newClientIO(req, "sess-1", ClientCapabilities{Terminal: true})
 
-	out, ok, err := io.RunCommand(context.Background(), "echo hello", "/proj", time.Minute)
+	out, ok, err := io.RunCommand(context.Background(), "echo hello", "/proj", time.Minute, nil)
 	if !ok || err != nil || out != "hello from client" {
 		t.Fatalf("RunCommand = %q, %v, %v", out, ok, err)
 	}
@@ -119,20 +119,20 @@ func TestClientIORunCommandLifecycle(t *testing.T) {
 	// A nonzero exit surfaces as an error alongside the captured output.
 	exitOne := 1
 	req.results["terminal/output"] = TerminalOutputResult{Output: "boom", ExitStatus: &TerminalExitStatus{ExitCode: &exitOne}}
-	out, ok, err = io.RunCommand(context.Background(), "false", "/proj", time.Minute)
+	out, ok, err = io.RunCommand(context.Background(), "false", "/proj", time.Minute, nil)
 	if !ok || err == nil || !strings.Contains(err.Error(), "exit status 1") || out != "boom" {
 		t.Fatalf("RunCommand nonzero exit = %q, %v, %v", out, ok, err)
 	}
 
 	// No terminal capability → unhandled, local bash runs instead.
 	none := newClientIO(req, "sess-1", ClientCapabilities{})
-	if _, ok, _ := none.RunCommand(context.Background(), "echo", "/proj", time.Minute); ok {
+	if _, ok, _ := none.RunCommand(context.Background(), "echo", "/proj", time.Minute, nil); ok {
 		t.Fatal("RunCommand without capability must report ok=false")
 	}
 
 	// terminal/create failure degrades to unhandled rather than failing the call.
 	req.errs["terminal/create"] = fmt.Errorf("client rejected")
-	if _, ok, _ := io.RunCommand(context.Background(), "echo", "/proj", time.Minute); ok {
+	if _, ok, _ := io.RunCommand(context.Background(), "echo", "/proj", time.Minute, nil); ok {
 		t.Fatal("RunCommand with failed create must report ok=false")
 	}
 }

--- a/internal/acp/clientio.go
+++ b/internal/acp/clientio.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -93,7 +94,11 @@ const terminalOutputByteLimit = 1 << 20
 // so the user watches it live. ok=false when the client has no terminal
 // capability or creation fails — the bash tool then executes locally. A
 // timeout kills the terminal and returns what it printed.
-func (c *clientIO) RunCommand(ctx context.Context, command, cwd string, timeout time.Duration) (string, bool, error) {
+//
+// envOverrides are standard temporary-directory variables (TMPDIR/TMP/TEMP)
+// for the session-private temp directory. They are serialized as ACP v1
+// EnvVariable[] and never include the full host environment.
+func (c *clientIO) RunCommand(ctx context.Context, command, cwd string, timeout time.Duration, envOverrides map[string]string) (string, bool, error) {
 	if !c.caps.Terminal {
 		return "", false, nil
 	}
@@ -101,6 +106,7 @@ func (c *clientIO) RunCommand(ctx context.Context, command, cwd string, timeout 
 		SessionID:       c.sessionID,
 		Command:         command,
 		Cwd:             cwd,
+		Env:             envMapToVariables(envOverrides),
 		OutputByteLimit: terminalOutputByteLimit,
 	})
 	if err != nil {
@@ -139,6 +145,28 @@ func (c *clientIO) RunCommand(ctx context.Context, command, cwd string, timeout 
 		return output, true, fmt.Errorf("terminated by signal %s", *exit.Signal)
 	}
 	return output, true, nil
+}
+
+// envMapToVariables converts a small override map into ACP EnvVariable entries.
+// Empty or nil maps yield nil (omitted from JSON).
+func envMapToVariables(env map[string]string) []EnvVariable {
+	if len(env) == 0 {
+		return nil
+	}
+	// Stable order for tests and logs.
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		if strings.TrimSpace(k) == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]EnvVariable, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, EnvVariable{Name: k, Value: env[k]})
+	}
+	return out
 }
 
 func (c *clientIO) terminalOutput(ctx context.Context, id TerminalIDParams) (string, *TerminalExitStatus) {

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -667,12 +667,16 @@ type FSWriteTextFileParams struct {
 // --- terminal/* (agent → client requests) ---
 
 // TerminalCreateParams starts a command in a client-owned terminal.
+// Env follows ACP v1's official EnvVariable[] shape (same as MCP env): only
+// the overrides Reasonix owns (typically TMPDIR/TMP/TEMP) are sent — never a
+// full host environment dump.
 type TerminalCreateParams struct {
-	SessionID       string   `json:"sessionId"`
-	Command         string   `json:"command"`
-	Args            []string `json:"args,omitempty"`
-	Cwd             string   `json:"cwd,omitempty"`
-	OutputByteLimit int      `json:"outputByteLimit,omitempty"`
+	SessionID       string        `json:"sessionId"`
+	Command         string        `json:"command"`
+	Args            []string      `json:"args,omitempty"`
+	Cwd             string        `json:"cwd,omitempty"`
+	Env             []EnvVariable `json:"env,omitempty"`
+	OutputByteLimit int           `json:"outputByteLimit,omitempty"`
 }
 
 // TerminalCreateResult returns the id used by the other terminal methods.

--- a/internal/acp/terminal_env_test.go
+++ b/internal/acp/terminal_env_test.go
@@ -1,0 +1,65 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestTerminalCreateSerializesEnvOverrides(t *testing.T) {
+	req := newScriptedRequester()
+	req.results["terminal/create"] = TerminalCreateResult{TerminalID: "term-env"}
+	req.results["terminal/wait_for_exit"] = TerminalWaitResult{}
+	exitZero := 0
+	req.results["terminal/output"] = TerminalOutputResult{
+		Output:     "ok",
+		ExitStatus: &TerminalExitStatus{ExitCode: &exitZero},
+	}
+	req.results["terminal/release"] = struct{}{}
+	io := newClientIO(req, "sess-env", ClientCapabilities{Terminal: true})
+
+	env := map[string]string{
+		"TMPDIR": "/private/session-tmp",
+		"TMP":    "/private/session-tmp",
+		"TEMP":   "/private/session-tmp",
+	}
+	if _, ok, err := io.RunCommand(context.Background(), "echo hi", "/proj", time.Minute, env); !ok || err != nil {
+		t.Fatalf("RunCommand = ok=%v err=%v", ok, err)
+	}
+
+	raw, ok := req.params["terminal/create"]
+	if !ok {
+		t.Fatal("terminal/create params not recorded")
+	}
+	var params TerminalCreateParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		t.Fatal(err)
+	}
+	if len(params.Env) != 3 {
+		t.Fatalf("env entries = %d, want 3: %+v", len(params.Env), params.Env)
+	}
+	got := map[string]string{}
+	for _, e := range params.Env {
+		got[e.Name] = e.Value
+	}
+	for k, v := range env {
+		if got[k] != v {
+			t.Fatalf("env[%s] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestEnvMapToVariablesStableOrder(t *testing.T) {
+	got := envMapToVariables(map[string]string{"TMP": "a", "TEMP": "a", "TMPDIR": "a"})
+	if len(got) != 3 {
+		t.Fatalf("len = %d", len(got))
+	}
+	// TEMP < TMP < TMPDIR lexicographically.
+	if got[0].Name != "TEMP" || got[1].Name != "TMP" || got[2].Name != "TMPDIR" {
+		t.Fatalf("order = %v", got)
+	}
+	if envMapToVariables(nil) != nil {
+		t.Fatal("nil map should yield nil")
+	}
+}

--- a/internal/agent/session_temp_subagent_test.go
+++ b/internal/agent/session_temp_subagent_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/sessiontemp"
+)
+
+func TestWithSubagentSessionTempIsIndependent(t *testing.T) {
+	parent := sessiontemp.NewWithRoot(t.TempDir())
+	parent.Retain()
+	defer parent.Release()
+	parentLease, err := parent.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentDir := parentLease.Dir()
+	if err := os.WriteFile(filepath.Join(parentDir, "parent.txt"), []byte("p"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	parentLease.Release()
+
+	ctx := sessiontemp.WithManager(context.Background(), parent)
+	childCtx, releaseChild := withSubagentSessionTemp(ctx)
+	defer releaseChild()
+
+	child := sessiontemp.FromContext(childCtx)
+	if child == nil || child == parent {
+		t.Fatal("sub-agent must install a distinct SessionTemp Manager")
+	}
+	if sessiontemp.FromContext(childCtx) != child {
+		t.Fatal("FromContext should return child manager")
+	}
+
+	childLease, err := child.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childDir := childLease.Dir()
+	if childDir == parentDir {
+		t.Fatal("child temporary directory must not equal parent")
+	}
+	if _, err := os.Stat(filepath.Join(childDir, "parent.txt")); !os.IsNotExist(err) {
+		t.Fatalf("child must not see parent temp files: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(parentDir, "parent.txt")); err != nil {
+		t.Fatalf("parent temp lost: %v", err)
+	}
+	childLease.Release()
+
+	// Nested sibling also gets a fresh manager.
+	sibCtx, releaseSib := withSubagentSessionTemp(ctx)
+	defer releaseSib()
+	sib := sessiontemp.FromContext(sibCtx)
+	if sib == nil || sib == child || sib == parent {
+		t.Fatal("sibling sub-agent must get its own Manager")
+	}
+}
+
+func TestContinueFromGetsFreshTempDirectory(t *testing.T) {
+	// continue_from restores conversation only; each RunSubAgentWithSession
+	// call installs a new Manager via withSubagentSessionTemp.
+	ctx1, release1 := withSubagentSessionTemp(context.Background())
+	m1 := sessiontemp.FromContext(ctx1)
+	lease1, err := m1.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir1 := lease1.Dir()
+	lease1.Release()
+	release1() // seals m1
+
+	ctx2, release2 := withSubagentSessionTemp(context.Background())
+	defer release2()
+	m2 := sessiontemp.FromContext(ctx2)
+	if m2 == m1 {
+		t.Fatal("second run must not reuse first Manager")
+	}
+	lease2, err := m2.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease2.Release()
+	if lease2.Dir() == dir1 {
+		t.Fatal("second run must get a new temporary directory")
+	}
+	if !m1.Sealed() {
+		t.Fatal("first run's manager should be sealed after release")
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -21,9 +21,20 @@ import (
 	"reasonix/internal/permission"
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/tool"
 	"reasonix/internal/workspacelease"
 )
+
+// withSubagentSessionTemp installs a fresh session-private temporary directory
+// Manager for one sub-agent run. The returned release must be deferred by the
+// caller so the directory is retired when the run ends (including background
+// sub-agent completion).
+func withSubagentSessionTemp(ctx context.Context) (context.Context, func()) {
+	m := sessiontemp.New()
+	m.Retain()
+	return sessiontemp.WithManager(ctx, m), m.Release
+}
 
 // DefaultTaskSystemPrompt steers a sub-agent toward focused, terse delivery —
 // it doesn't see the parent's conversation so it must self-contain.
@@ -1854,10 +1865,18 @@ func reviewReportNudgePrompt(kind evidence.ReviewKind) string {
 // RunSubAgentWithSession continues an existing sub-agent session with prompt and
 // returns the latest final assistant answer. Fresh sub-agents pass a newly-created
 // session; continued sub-agents pass a loaded transcript session.
+//
+// Each call installs an independent session-private temporary directory Manager
+// so parent, sibling, and nested sub-agents never share temporary files.
+// continue_from restores conversation history only — a new run still gets a
+// fresh temporary directory.
 func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *tool.Registry, sess *Session, prompt string, opts Options, sink event.Sink) (string, error) {
 	if sess == nil {
 		return "", fmt.Errorf("sub-agent session is nil")
 	}
+	// Isolate temporary files for this run before any tool execution.
+	ctx, releaseTemp := withSubagentSessionTemp(ctx)
+	defer releaseTemp()
 	if opts.SubagentDepth > 0 {
 		ctx = WithSubagentDepth(ctx, opts.SubagentDepth)
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -56,6 +56,7 @@ import (
 	"reasonix/internal/recovery"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/skill"
 	"reasonix/internal/stats"
 	"reasonix/internal/tool"
@@ -189,6 +190,12 @@ type Options struct {
 	SandboxNetworkOverride *bool
 	SandboxBashOverride    string
 	WorkspaceOnly          bool
+	// SessionTemp is the logical-session private temporary directory manager.
+	// Rebuild passes the previous Controller's Manager so hot rebuilds keep
+	// temporary files. Empty creates a fresh Manager inside control.New.
+	// Frontends that build a replacement Controller without Rebuild must pass
+	// the same Manager for the same logical session.
+	SessionTemp *sessiontemp.Manager
 }
 
 func recoveryHeadlessMode(opts Options) bool {
@@ -650,11 +657,18 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		enabledBuiltins = tokenEconomyBuiltins(enabledBuiltins)
 	}
 	readPathResolver := builtin.NewPathResolver()
+	// Session-private temporary directory manager for Bash/grep. Rebuild
+	// reuses the previous Controller's Manager; a fresh build creates one
+	// here so tools and the Controller share the same instance from boot.
+	sessionTemp := opts.SessionTemp
+	if sessionTemp == nil {
+		sessionTemp = sessiontemp.New()
+	}
 	// An explicit Economy allowlist can contain only on-demand tools, leaving no
 	// startup built-ins. Do not pass that filtered empty slice to addBuiltins,
 	// where an empty list intentionally means "all built-ins".
 	if !tokenEconomy || len(cfg.Tools.Enabled) == 0 || len(enabledBuiltins) > 0 {
-		addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner)
+		addBuiltins(reg, enabledBuiltins, writeRoots, bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec, forbidReadRoots, readPathResolver, sessionGuard, managedConfig, opts.FileOverlay, opts.TerminalRunner, sessionTemp)
 	}
 	// Use the caller-supplied shared host when set, so controllers for the same
 	// workspace root reuse running MCP processes (e.g. one CodeGraph daemon
@@ -1537,6 +1551,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				ManagedConfig:   managedConfig,
 				FileOverlay:     opts.FileOverlay,
 				Terminal:        opts.TerminalRunner,
+				SessionTemp:     sessionTemp,
 			}.Tools(missing...))
 			return "enabled " + strings.Join(installed, ", ") + "."
 		}
@@ -1908,6 +1923,9 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		// The merged catalog (nil without provider-declaring sidecars) lets
 		// frontends enumerate plugin/... models through ProviderCatalog.
 		ProviderResolver: extensionResolver,
+		// Share the Manager already bound into bash/grep so tools and the
+		// Controller observe the same temporary generation across rebuilds.
+		SessionTemp: sessionTemp,
 	}
 	// Guardian: when guardian_model is configured, spawn an LLM safety reviewer
 	// that can auto-allow safe Ask decisions and annotate risky ones before
@@ -2613,12 +2631,12 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // and makes bash warn when a command references them. managedConfig names the
 // Reasonix-owned config files writable outside writeRoots after a fresh
 // per-write human approval.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths, overlay builtin.FileOverlay, terminal builtin.TerminalRunner) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec, forbidReadRoots []string, readPathResolver *builtin.PathResolver, sessionGuard builtin.SessionDataGuard, managedConfig builtin.ManagedConfigPaths, overlay builtin.FileOverlay, terminal builtin.TerminalRunner, sessionTemp *sessiontemp.Manager) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig, FileOverlay: overlay, Terminal: terminal}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, ForbidReadRoots: forbidReadRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec, ReadPaths: readPathResolver, SessionGuard: sessionGuard, ManagedConfig: managedConfig, FileOverlay: overlay, Terminal: terminal, SessionTemp: sessionTemp}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}
@@ -2642,9 +2660,17 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 	// preserved on replace): file-writers bound to the workspace, read tools
 	// bound to forbid-read roots, bash to the OS sandbox, web_fetch to the proxy.
 	// Only replace tools actually enabled/present.
+	bashTool := builtin.ConfineBash(bashSpec, sessionGuard, bashTimeout)
+	if rebound, ok := builtin.BindSessionTemp(bashTool, sessionTemp); ok {
+		bashTool = rebound
+	}
+	searchTool := builtin.ConfineSearch(searchSpec, bashSpec, forbidReadRoots)
+	if rebound, ok := builtin.BindSessionTemp(searchTool, sessionTemp); ok {
+		searchTool = rebound
+	}
 	confined := append(builtin.ConfineWriters(writeRoots, sessionGuard, managedConfig),
-		builtin.ConfineBash(bashSpec, sessionGuard, bashTimeout),
-		builtin.ConfineSearch(searchSpec, bashSpec, forbidReadRoots),
+		bashTool,
+		searchTool,
 		builtin.ConfineWebFetch(proxySpec))
 	confined = append(confined, builtin.ConfineReaders(forbidReadRoots)...)
 	for _, t := range confined {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3208,7 +3208,7 @@ model = "x"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil)
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{}, nil, nil, builtin.SessionDataGuard{}, builtin.ManagedConfigPaths{}, nil, nil, nil)
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/boot/reload.go
+++ b/internal/boot/reload.go
@@ -62,6 +62,11 @@ func Rebuild(ctx context.Context, old *control.Controller, opts Options) (*Build
 		goal:             old.Goal(),
 		goalRunning:      old.GoalStatus() == control.GoalStatusRunning,
 	}
+	// Reuse the previous Controller's session-private temporary directory so
+	// model/settings hot rebuilds do not wipe temporary files mid-session.
+	if opts.SessionTemp == nil {
+		opts.SessionTemp = old.SessionTemp()
+	}
 	res, err := BuildRuntime(ctx, opts)
 	if err != nil {
 		return nil, err

--- a/internal/boot/session_temp_rebuild_test.go
+++ b/internal/boot/session_temp_rebuild_test.go
@@ -1,0 +1,98 @@
+package boot
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/sessiontemp"
+)
+
+func TestRebuildReusesSessionTempManager(t *testing.T) {
+	// Isolate config/home so boot.Build does not touch the developer home.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, ".reasonix"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+
+	workspace := t.TempDir()
+	m := sessiontemp.New()
+	old := control.New(control.Options{
+		SessionTemp: m,
+		Sink:        event.Discard,
+		Label:       "test",
+	})
+	lease, err := old.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+
+	res, err := Rebuild(context.Background(), old, Options{
+		WorkspaceRoot: workspace,
+		Sink:          event.Discard,
+		RequireKey:    false,
+		Stderr:        os.Stderr,
+	})
+	if err != nil {
+		// Fail-atomic: old manager still works and is not sealed.
+		again, aerr := old.SessionTemp().Acquire()
+		if aerr != nil {
+			t.Fatalf("old session temp broken after failed rebuild: %v", aerr)
+		}
+		if again.Dir() != dir {
+			t.Fatalf("failed rebuild rotated old temp: got %q want %q", again.Dir(), dir)
+		}
+		body, rerr := os.ReadFile(filepath.Join(dir, "keep.txt"))
+		if rerr != nil || string(body) != "ok" {
+			t.Fatalf("temp file lost after failed rebuild: %q %v", body, rerr)
+		}
+		again.Release()
+		old.Close()
+		return
+	}
+
+	// Successful rebuild: replacement shares the Manager and the generation.
+	if res == nil || res.Controller == nil {
+		t.Fatal("Rebuild returned nil result without error")
+	}
+	newCtrl := res.Controller
+	if newCtrl.SessionTemp() != m {
+		t.Fatal("replacement controller must share the old SessionTemp Manager")
+	}
+	if old.SessionTemp() != m {
+		t.Fatal("old controller lost SessionTemp identity during rebuild")
+	}
+	again, err := newCtrl.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Dir() != dir {
+		t.Fatalf("rebuild changed generation: got %q want %q", again.Dir(), dir)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "keep.txt"))
+	if err != nil || string(body) != "ok" {
+		t.Fatalf("temp file lost across rebuild: %q %v", body, err)
+	}
+	again.Release()
+
+	// Publish-order: release old after replacement is live.
+	old.ReleaseResources()
+	if m.Sealed() {
+		t.Fatal("shared manager must not seal while replacement still owns it")
+	}
+	still, err := newCtrl.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatalf("replacement lost temp after old close: %v", err)
+	}
+	still.Release()
+	newCtrl.Close()
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,6 +39,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/provider/openai"
 	"reasonix/internal/serve"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/stats"
 	"reasonix/internal/telemetry"
 
@@ -265,6 +266,9 @@ type cliBuildOverrides struct {
 	Stderr               io.Writer
 	OnSessionRecovered   func(control.SessionRecoveryInfo) error
 	Ablation             ablation.Set
+	// SessionTemp carries the previous Controller's private temporary directory
+	// manager across model/profile rebuilds so temporary files survive.
+	SessionTemp *sessiontemp.Manager
 }
 
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
@@ -291,6 +295,7 @@ func cliProfileBuildOptions(modelName string, maxStepsOverride int, requireKey b
 		Stderr:               overrides.Stderr,
 		OnSessionRecovered:   overrides.OnSessionRecovered,
 		Ablation:             overrides.Ablation,
+		SessionTemp:          overrides.SessionTemp,
 	}
 }
 
@@ -1249,6 +1254,11 @@ func chatREPL(args []string, version string) int {
 		effectiveOverrides := overrides
 		if spec.EffortOverride != nil {
 			effectiveOverrides.Effort = spec.EffortOverride
+		}
+		// Keep the logical-session private temporary directory across model /
+		// profile switches (Issue #7575).
+		if prev, ok := oldCtrl.(*control.Controller); ok && prev != nil {
+			effectiveOverrides.SessionTemp = prev.SessionTemp()
 		}
 		c, err := setupQuietProfile(ctx, spec.ModelRef, *maxSteps, false, sink, spec.RuntimeProfile, effectiveOverrides)
 		if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -271,6 +271,17 @@ type cliBuildOverrides struct {
 	SessionTemp *sessiontemp.Manager
 }
 
+// sessionTempFromCLIController returns the logical-session private temporary
+// directory manager for a same-session CLI controller rebuild. Nil keeps fresh
+// builds on control.New's normal new-manager path.
+func sessionTempFromCLIController(ctrl control.SessionAPI) *sessiontemp.Manager {
+	prev, ok := ctrl.(*control.Controller)
+	if !ok || prev == nil {
+		return nil
+	}
+	return prev.SessionTemp()
+}
+
 func setupProfileWithOverrides(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink, profile string, overrides cliBuildOverrides) (*control.Controller, error) {
 	migrateMCPConfigForCLIWorkspace()
 	return boot.Build(ctx, cliProfileBuildOptions(modelName, maxStepsOverride, requireKey, sink, profile, overrides))
@@ -1257,9 +1268,7 @@ func chatREPL(args []string, version string) int {
 		}
 		// Keep the logical-session private temporary directory across model /
 		// profile switches (Issue #7575).
-		if prev, ok := oldCtrl.(*control.Controller); ok && prev != nil {
-			effectiveOverrides.SessionTemp = prev.SessionTemp()
-		}
+		effectiveOverrides.SessionTemp = sessionTempFromCLIController(oldCtrl)
 		c, err := setupQuietProfile(ctx, spec.ModelRef, *maxSteps, false, sink, spec.RuntimeProfile, effectiveOverrides)
 		if err != nil {
 			return nil, err

--- a/internal/cli/session_temp_rebuild_test.go
+++ b/internal/cli/session_temp_rebuild_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/boot"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+// TestCLIHotRebuildPathsKeepSessionTemp covers the CLI commands that replace a
+// Controller without changing the logical session. Every path must keep the
+// Manager identity, current generation, and files even after the outgoing
+// Controller releases its owner reference.
+func TestCLIHotRebuildPathsKeepSessionTemp(t *testing.T) {
+	for _, command := range []string{"model", "effort", "reload"} {
+		t.Run(command, func(t *testing.T) {
+			isolateUserConfig(t)
+
+			oldCtrl := control.New(control.Options{Label: "deepseek-flash"})
+			t.Cleanup(oldCtrl.Close)
+			oldManager := oldCtrl.SessionTemp()
+			lease, err := oldManager.Acquire()
+			if err != nil {
+				t.Fatalf("acquire old session temp: %v", err)
+			}
+			oldDir := lease.Dir()
+			marker := filepath.Join(oldDir, "cli-hot-rebuild.txt")
+			if err := os.WriteFile(marker, []byte(command), 0o600); err != nil {
+				lease.Release()
+				t.Fatal(err)
+			}
+			lease.Release()
+
+			m := newTestChatTUI()
+			m.ctrl = oldCtrl
+			m.modelRef = "deepseek-flash/deepseek-v4-flash"
+			m.runtimeProfile = boot.TokenModeFull
+			m.buildController = func(_ controllerBuildSpec, _ []provider.Message, _ string, outgoing control.SessionAPI) (*control.Controller, error) {
+				return control.New(control.Options{
+					Label:       "deepseek-flash",
+					SessionTemp: sessionTempFromCLIController(outgoing),
+				}), nil
+			}
+			m.rebuildRuntime = func(_ context.Context, _ controllerBuildSpec, outgoing *control.Controller) (*boot.BuildResult, error) {
+				// Production delegates this path to boot.Rebuild, whose owning test
+				// pins the same SessionTemp transfer. This seam exercises the CLI
+				// command/swap lifecycle without booting providers or plugins.
+				return &boot.BuildResult{Controller: control.New(control.Options{
+					Label:       "deepseek-flash",
+					SessionTemp: outgoing.SessionTemp(),
+				})}, nil
+			}
+
+			switch command {
+			case "model":
+				m.runModelSubcommand("/model deepseek-flash/another-model")
+				if m.pendingModelSwitch == nil {
+					t.Fatal("/model did not schedule a replacement")
+				}
+				msg := m.pendingModelSwitch()
+				next, _ := m.Update(msg)
+				m = next.(chatTUI)
+			case "effort":
+				effortCmd := m.runEffortCommand("/effort max")
+				if effortCmd == nil {
+					t.Fatal("/effort did not schedule a replacement")
+				}
+				next, _ := m.Update(effortCmd())
+				m = next.(chatTUI)
+			case "reload":
+				reloadCmd := m.runReloadCommand()
+				if reloadCmd == nil {
+					t.Fatal("/reload did not schedule a replacement")
+				}
+				next, _ := m.Update(reloadCmd())
+				m = next.(chatTUI)
+			}
+			newCtrl, ok := m.ctrl.(*control.Controller)
+			if !ok || newCtrl == nil || newCtrl == oldCtrl {
+				t.Fatal("CLI rebuild did not install a replacement Controller")
+			}
+			t.Cleanup(newCtrl.Close)
+			if newCtrl.SessionTemp() != oldManager {
+				t.Fatalf("%s rebuild changed SessionTemp Manager: got %p want %p", command, newCtrl.SessionTemp(), oldManager)
+			}
+
+			// Match the TUI's deferred retirement: the replacement must already
+			// own the shared Manager before the outgoing Controller releases it.
+			oldCtrl.ReleaseResources()
+			if oldManager.Sealed() {
+				t.Fatalf("%s rebuild sealed the shared Manager after old release", command)
+			}
+			again, err := newCtrl.SessionTemp().Acquire()
+			if err != nil {
+				t.Fatalf("acquire after %s rebuild: %v", command, err)
+			}
+			if again.Dir() != oldDir {
+				again.Release()
+				t.Fatalf("%s rebuild rotated temp generation: got %q want %q", command, again.Dir(), oldDir)
+			}
+			body, err := os.ReadFile(marker)
+			again.Release()
+			if err != nil || string(body) != command {
+				t.Fatalf("temp file lost across %s rebuild: %q %v", command, body, err)
+			}
+		})
+	}
+}
+
+func TestSessionTempFromCLIControllerHelper(t *testing.T) {
+	if sessionTempFromCLIController(nil) != nil {
+		t.Fatal("nil controller should yield nil SessionTemp")
+	}
+	ctrl := control.New(control.Options{})
+	defer ctrl.Close()
+	if got := sessionTempFromCLIController(ctrl); got == nil || got != ctrl.SessionTemp() {
+		t.Fatal("helper did not return the live Controller's SessionTemp")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -55,6 +55,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/recovery"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/skill"
 	"reasonix/internal/store"
 	"reasonix/internal/taskmonitor"
@@ -269,6 +270,10 @@ type Controller struct {
 	autosaveWG  sync.WaitGroup
 	planMode    bool
 	sessionPath string
+	// sessionTemp owns the logical-session private temporary directory shared
+	// by Bash calls. Retained for this Controller's lifetime; rotated on
+	// /new, /clear, resume of another session, and branch switches.
+	sessionTemp *sessiontemp.Manager
 	// recoveryDepthCapNotices records session paths that already surfaced the
 	// depth-cap recovery warning. Repeated saves on the same conflict copy are
 	// diagnostic noise for the UI; keep logging/diagnostics, but emit the user
@@ -521,6 +526,11 @@ type Options struct {
 	// Ablation switches subsystems off for a benchmark arm. The zero value runs
 	// everything.
 	Ablation ablation.Set
+	// SessionTemp is the logical-session private temporary directory manager
+	// shared by sandboxed Bash calls. Nil creates a fresh Manager owned by this
+	// Controller. Hot rebuilds pass the previous Controller's Manager so the
+	// temporary directory survives model/settings swaps.
+	SessionTemp *sessiontemp.Manager
 }
 
 // New builds a Controller. A nil Sink is replaced with event.Discard. When the
@@ -595,6 +605,16 @@ func New(opts Options) *Controller {
 		providerResolver:                  opts.ProviderResolver,
 		approval:                          newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
+	// Session-private temporary directory: reuse a shared Manager on hot
+	// rebuild, otherwise create one. Retain so ReleaseResources/Close drop the
+	// owner reference without racing a replacement Controller.
+	if opts.SessionTemp != nil {
+		c.sessionTemp = opts.SessionTemp
+	} else {
+		c.sessionTemp = sessiontemp.New()
+	}
+	c.sessionTemp.Retain()
+
 	if strings.TrimSpace(opts.WorkspaceRoot) != "" {
 		c.autoResearch = autoresearch.NewStore(opts.WorkspaceRoot)
 	}
@@ -3191,6 +3211,7 @@ func (c *Controller) NewSession() error {
 	freshPath := c.SessionPath()
 	c.rebindCheckpoints(freshPath)
 	c.resetRecoveryForNewSession(freshPath)
+	c.rotateSessionTemp()
 	c.snapshotMu.Unlock()
 	// A new session starts with no active goal: without this, a running goal's
 	// text kept injecting into the fresh session's first turns. The old
@@ -3274,6 +3295,7 @@ func (c *Controller) ClearSession() error {
 	freshPath := c.SessionPath()
 	c.rebindCheckpoints(freshPath)
 	c.resetRecoveryForNewSession(freshPath)
+	c.rotateSessionTemp()
 	c.snapshotMu.Unlock()
 	// Same contract as NewSession: the fresh session starts with no active goal.
 	c.ClearGoal()
@@ -3494,6 +3516,8 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		if c.guardianSess != nil {
 			c.guardianSess.Reset()
 		}
+		// Switching into the fork is a new logical session for temporary files.
+		c.rotateSessionTemp()
 		c.snapshotMu.Unlock()
 	}
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -3574,6 +3598,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		c.guardianSess.Reset()
 	}
 	c.carryRecoveryState(newPath)
+	c.rotateSessionTemp()
 	c.snapshotMu.Unlock()
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("created branch %s", agent.BranchID(newPath))})
@@ -3635,6 +3660,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	c.restoreTerminalGoalTodos(match.Path)
 	c.loadGuardianSession()
 	c.loadRecoveryState(match.Path)
+	c.rotateSessionTemp()
 	c.snapshotMu.Unlock()
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("switched to branch %s", branchDisplayName(match))})
@@ -3738,10 +3764,16 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 
 // Resume seeds the session from a loaded transcript and pins the active file to
 // its path so auto-save keeps appending there.
+//
+// When the controller already has a different non-empty session path, Resume
+// rotates the private temporary generation so the loaded conversation cannot
+// see the previous session's temporary files. Same-path Resume (hot rebuild
+// migration via AdoptHistory) keeps the generation.
 func (c *Controller) Resume(s *agent.Session, path string) {
 	// See snapshotMu: the swap must not interleave with an in-flight save.
 	// recoverInterruptedTurn and maybeColdResumePrune snapshot on their own,
 	// so they stay outside the locked section (snapshotMu is not reentrant).
+	prevPath := c.SessionPath()
 	c.snapshotMu.Lock()
 	if c.executor != nil {
 		c.executor.SetSession(s)
@@ -3760,6 +3792,9 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.restoreTerminalGoalTodos(path)
 	c.loadGuardianSession()
 	c.loadRecoveryState(path)
+	if shouldRotateSessionTempOnResume(prevPath, path) {
+		c.rotateSessionTemp()
+	}
 	c.snapshotMu.Unlock()
 	c.recoverCheckpointTransactions()
 	c.recoverInterruptedTurn(path)
@@ -3771,6 +3806,15 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	if err := c.extensionSessionPhase(context.Background(), extension.PointSessionLoad, dispatch.PhaseLoad, path); err != nil {
 		c.extensionWarn("session policy failed at session.load", err)
 	}
+}
+
+func shouldRotateSessionTempOnResume(prevPath, nextPath string) bool {
+	prevPath = strings.TrimSpace(prevPath)
+	nextPath = strings.TrimSpace(nextPath)
+	if prevPath == "" || nextPath == "" {
+		return false
+	}
+	return filepath.Clean(prevPath) != filepath.Clean(nextPath)
 }
 
 func (c *Controller) loadGuardianSession() {
@@ -4844,6 +4888,10 @@ func (c *Controller) setSessionPath(p string, fresh bool) {
 	c.rebindCheckpoints(p)
 	if fresh {
 		c.resetRecoveryForNewSession(p)
+		// A newly-created conversation must not share the previous logical
+		// session's temporary files (e.g. after EnsureSessionPath on a
+		// controller that already ran commands).
+		c.rotateSessionTemp()
 	} else {
 		c.loadRecoveryState(p)
 	}
@@ -5661,7 +5709,33 @@ func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 		if c.cleanup != nil {
 			c.cleanup()
 		}
+		// Drop the Controller owner reference last so background job leases
+		// that outlive close still pin retired generations until they exit.
+		if c.sessionTemp != nil {
+			c.sessionTemp.Release()
+		}
 	})
+}
+
+// SessionTemp returns the logical-session private temporary directory manager.
+// Hot rebuilds pass this to the replacement Controller so the directory survives
+// model/settings swaps. Nil only when the Controller was constructed without one
+// (should not happen after New).
+func (c *Controller) SessionTemp() *sessiontemp.Manager {
+	if c == nil {
+		return nil
+	}
+	return c.sessionTemp
+}
+
+// rotateSessionTemp advances the private temporary generation so a new logical
+// session cannot see the previous session's temporary files. In-flight command
+// leases keep the old generation alive until they release.
+func (c *Controller) rotateSessionTemp() {
+	if c == nil || c.sessionTemp == nil {
+		return
+	}
+	c.sessionTemp.Rotate()
 }
 
 // Jobs returns the still-running background jobs for the status bar (nil when

--- a/internal/control/session_temp_test.go
+++ b/internal/control/session_temp_test.go
@@ -1,0 +1,196 @@
+package control
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/sessiontemp"
+)
+
+func TestSessionTempSurvivesHotRebuildStyleRetain(t *testing.T) {
+	m := sessiontemp.New()
+	old := New(Options{SessionTemp: m, Sink: event.Discard})
+	lease, err := old.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("alive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+
+	// Hot rebuild: replacement retains the same Manager before old closes.
+	replacement := New(Options{SessionTemp: old.SessionTemp(), Sink: event.Discard})
+	old.ReleaseResources()
+
+	again, err := replacement.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer again.Release()
+	if again.Dir() != dir {
+		t.Fatalf("hot rebuild changed generation: got %q want %q", again.Dir(), dir)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "keep.txt"))
+	if err != nil || string(body) != "alive" {
+		t.Fatalf("temp file lost across rebuild: %q %v", body, err)
+	}
+	replacement.ReleaseResources()
+}
+
+func TestNewSessionRotatesSessionTemp(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{
+		Executor:   exec,
+		SessionDir: dir,
+		Label:      "test",
+		Sink:       event.Discard,
+	})
+	defer c.Close()
+
+	lease, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := lease.Dir()
+	if err := os.WriteFile(filepath.Join(oldDir, "old.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lease.Release()
+
+	if err := c.NewSession(); err != nil {
+		t.Fatal(err)
+	}
+	fresh, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	if fresh.Dir() == oldDir {
+		t.Fatal("NewSession should rotate the private temporary directory")
+	}
+	if _, err := os.Stat(filepath.Join(fresh.Dir(), "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("new session must not see old temp files: %v", err)
+	}
+}
+
+func TestSetSessionPathDoesNotRotateSessionTemp(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c := New(Options{
+		Executor:   exec,
+		SessionDir: dir,
+		Label:      "test",
+		Sink:       event.Discard,
+	})
+	defer c.Close()
+
+	lease, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := lease.Dir()
+	lease.Release()
+
+	c.SetSessionPath(filepath.Join(dir, "rebind.jsonl"))
+	again, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer again.Release()
+	if again.Dir() != oldDir {
+		t.Fatalf("SetSessionPath must not rotate temp: got %q want %q", again.Dir(), oldDir)
+	}
+}
+
+func TestResumeOtherSessionRotatesSessionTemp(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	pathA := agent.NewSessionPath(dir, "a")
+	pathB := agent.NewSessionPath(dir, "b")
+	c := New(Options{
+		Executor:    exec,
+		SessionDir:  dir,
+		SessionPath: pathA,
+		Label:       "test",
+		Sink:        event.Discard,
+	})
+	defer c.Close()
+
+	lease, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := lease.Dir()
+	lease.Release()
+
+	// Same-path resume (rebuild style) keeps generation.
+	c.Resume(agent.NewSession("sys"), pathA)
+	same, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same.Dir() != oldDir {
+		t.Fatalf("same-path Resume rotated temp: got %q want %q", same.Dir(), oldDir)
+	}
+	same.Release()
+
+	// Different path (user /resume) rotates.
+	c.Resume(agent.NewSession("sys"), pathB)
+	other, err := c.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer other.Release()
+	if other.Dir() == oldDir {
+		t.Fatal("resume of another session should rotate private temp")
+	}
+}
+
+func TestShouldRotateSessionTempOnResume(t *testing.T) {
+	cases := []struct {
+		prev, next string
+		want       bool
+	}{
+		{"", "/a", false},
+		{"/a", "", false},
+		{"/a", "/a", false},
+		{"/a", "/b", true},
+		{"/a/../b", "/b", false},
+	}
+	for _, c := range cases {
+		if got := shouldRotateSessionTempOnResume(c.prev, c.next); got != c.want {
+			t.Errorf("shouldRotate(%q, %q) = %v, want %v", c.prev, c.next, got, c.want)
+		}
+	}
+}
+
+func TestFailedReplacementDoesNotDropOldSessionTemp(t *testing.T) {
+	m := sessiontemp.New()
+	old := New(Options{SessionTemp: m, Sink: event.Discard})
+	lease, err := old.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+	lease.Release()
+
+	// Simulate a failed rebuild: retain then release the replacement only.
+	m.Retain()
+	m.Release()
+	// Old controller still owns the Manager.
+	again, err := old.SessionTemp().Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer again.Release()
+	if again.Dir() != dir {
+		t.Fatalf("failed rebuild affected old session temp: got %q want %q", again.Dir(), dir)
+	}
+	old.Close()
+}

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -18,8 +18,13 @@ const retryInterval = 20 * time.Millisecond
 // Callers normally see their context error after Acquire's bounded retry loop.
 var ErrHeld = errors.New("file lock held")
 
+// localLock serializes goroutines in this process for one canonical path.
+// refs counts acquirers currently between registry entry and release/timeout
+// so the registry can reclaim entries when no one is waiting or holding —
+// important for short-lived paths such as session-temp owner locks.
 type localLock struct {
 	token chan struct{}
+	refs  int
 }
 
 var localRegistry = struct {
@@ -38,21 +43,11 @@ func Acquire(ctx context.Context, path string) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	localRegistry.Lock()
-	local := localRegistry.locks[key]
-	if local == nil {
-		local = &localLock{token: make(chan struct{}, 1)}
-		local.token <- struct{}{}
-		localRegistry.locks[key] = local
+	local, releaseLocal, err := acquireLocal(ctx, key)
+	if err != nil {
+		return nil, err
 	}
-	localRegistry.Unlock()
-
-	select {
-	case <-local.token:
-	case <-ctx.Done():
-		return nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
-	}
-	releaseLocal := func() { local.token <- struct{}{} }
+	_ = local
 
 	for {
 		releaseFile, err := tryLockFile(key)
@@ -83,6 +78,108 @@ func Acquire(ctx context.Context, path string) (func(), error) {
 			return nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
 		}
 	}
+}
+
+// TryAcquire attempts a non-blocking exclusive lock. It returns ErrHeld when
+// another holder (in this process or another) currently owns the lock.
+func TryAcquire(path string) (func(), error) {
+	key, err := canonicalLockPath(path)
+	if err != nil {
+		return nil, err
+	}
+	local, releaseLocal, ok := tryAcquireLocal(key)
+	if !ok {
+		return nil, ErrHeld
+	}
+	_ = local
+
+	releaseFile, err := tryLockFile(key)
+	if err != nil {
+		releaseLocal()
+		if errors.Is(err, ErrHeld) {
+			return nil, ErrHeld
+		}
+		return nil, fmt.Errorf("try acquire file lock: %w", err)
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			releaseFile()
+			releaseLocal()
+		})
+	}, nil
+}
+
+func acquireLocal(ctx context.Context, key string) (*localLock, func(), error) {
+	localRegistry.Lock()
+	local := localRegistry.locks[key]
+	if local == nil {
+		local = &localLock{token: make(chan struct{}, 1)}
+		local.token <- struct{}{}
+		localRegistry.locks[key] = local
+	}
+	local.refs++
+	localRegistry.Unlock()
+
+	select {
+	case <-local.token:
+		return local, releaseLocalFunc(key, local), nil
+	case <-ctx.Done():
+		localRegistry.Lock()
+		local.refs--
+		if local.refs == 0 {
+			delete(localRegistry.locks, key)
+		}
+		localRegistry.Unlock()
+		return nil, nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
+	}
+}
+
+func tryAcquireLocal(key string) (*localLock, func(), bool) {
+	localRegistry.Lock()
+	defer localRegistry.Unlock()
+
+	local := localRegistry.locks[key]
+	if local == nil {
+		local = &localLock{token: make(chan struct{}, 1)}
+		local.token <- struct{}{}
+		localRegistry.locks[key] = local
+	}
+	select {
+	case <-local.token:
+		local.refs++
+		return local, releaseLocalFunc(key, local), true
+	default:
+		// A newly created entry always succeeds above while the registry lock
+		// is held, so this is an existing lock held by another goroutine.
+		return nil, nil, false
+	}
+}
+
+func releaseLocalFunc(key string, local *localLock) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			localRegistry.Lock()
+			select {
+			case local.token <- struct{}{}:
+			default:
+			}
+			local.refs--
+			if local.refs <= 0 {
+				local.refs = 0
+				delete(localRegistry.locks, key)
+			}
+			localRegistry.Unlock()
+		})
+	}
+}
+
+// RegistrySizeForTest returns the number of live local-lock entries (tests).
+func RegistrySizeForTest() int {
+	localRegistry.Lock()
+	defer localRegistry.Unlock()
+	return len(localRegistry.locks)
 }
 
 func canonicalLockPath(path string) (string, error) {

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -28,3 +28,29 @@ func TestAcquireHonorsDeadlineAndRecoversAfterRelease(t *testing.T) {
 	}
 	secondRelease()
 }
+
+func TestLocalRegistryReclaimsReleasedEntries(t *testing.T) {
+	before := RegistrySizeForTest()
+	path := filepath.Join(t.TempDir(), "ephemeral.lock")
+	release, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if RegistrySizeForTest() <= before {
+		t.Fatal("registry should grow while lock is held")
+	}
+	release()
+	if got := RegistrySizeForTest(); got != before {
+		t.Fatalf("registry size after release = %d, want %d (reclaimed)", got, before)
+	}
+
+	// Re-acquire still works after reclaim.
+	release2, err := Acquire(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release2()
+	if got := RegistrySizeForTest(); got != before {
+		t.Fatalf("registry size after second cycle = %d, want %d", got, before)
+	}
+}

--- a/internal/sandbox/prepare.go
+++ b/internal/sandbox/prepare.go
@@ -1,0 +1,58 @@
+package sandbox
+
+// Prepared is the unified launch plan for a sandboxed (or unconfined) command
+// that may hold a session-private temporary directory lease. Callers must
+// Release the lease after the process exits — including when Start fails.
+type Prepared struct {
+	// Argv is the final process argv (possibly wrapped by bwrap/sandbox-exec).
+	Argv []string
+	// Wrapped reports whether an OS sandbox wrapper was applied.
+	Wrapped bool
+	// SessionTemp is the absolute host path of the private temporary directory
+	// (empty when the launch has no session temp).
+	SessionTemp string
+	// EnvOverrides are KEY=value pairs to merge into the child environment
+	// (TMPDIR/TMP/TEMP). Nil when no session temp is bound.
+	EnvOverrides []string
+	// LinuxSandboxed is true when SessionTemp is mapped at virtual /tmp under
+	// Linux bubblewrap; env overrides then point at /tmp.
+	LinuxSandboxed bool
+}
+
+// PrepareShell builds argv for a shell command string. When sessionTemp is
+// non-empty it is attached to a copy of spec so the platform wrapper can bind
+// or allow that directory.
+func PrepareShell(spec Spec, sh Shell, command, sessionTemp string) Prepared {
+	spec = withSessionTemp(spec, sessionTemp)
+	argv, wrapped := Command(spec, sh, command)
+	linuxSB := wrapped && sessionTemp != "" && isLinux()
+	return Prepared{
+		Argv:           argv,
+		Wrapped:        wrapped,
+		SessionTemp:    sessionTemp,
+		EnvOverrides:   SessionTempEnv(sessionTemp, linuxSB),
+		LinuxSandboxed: linuxSB,
+	}
+}
+
+// PrepareArgs builds argv for a raw argument vector (e.g. ripgrep).
+func PrepareArgs(spec Spec, args []string, sessionTemp string) Prepared {
+	spec = withSessionTemp(spec, sessionTemp)
+	argv, wrapped := CommandArgs(spec, args)
+	linuxSB := wrapped && sessionTemp != "" && isLinux()
+	return Prepared{
+		Argv:           argv,
+		Wrapped:        wrapped,
+		SessionTemp:    sessionTemp,
+		EnvOverrides:   SessionTempEnv(sessionTemp, linuxSB),
+		LinuxSandboxed: linuxSB,
+	}
+}
+
+func withSessionTemp(spec Spec, sessionTemp string) Spec {
+	if sessionTemp == "" {
+		return spec
+	}
+	spec.SessionTemp = sessionTemp
+	return spec
+}

--- a/internal/sandbox/prepare_linux.go
+++ b/internal/sandbox/prepare_linux.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package sandbox
+
+func isLinux() bool { return true }

--- a/internal/sandbox/prepare_other.go
+++ b/internal/sandbox/prepare_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package sandbox
+
+func isLinux() bool { return false }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -57,6 +57,13 @@ type Spec struct {
 	// Path) means the tool resolves one itself; the composition root sets it from
 	// [tools.shell] so the configured choice rides along with the spec.
 	Shell Shell
+	// SessionTemp is the absolute path of the logical-session private temporary
+	// directory for this command. When set, Linux bubblewrap binds it at /tmp
+	// (instead of a fresh tmpfs), and all platforms export TMPDIR/TMP/TEMP so
+	// consecutive Bash calls in the same session share temporary files. Empty
+	// keeps the platform default (ephemeral tmpfs on Linux bwrap, host temp
+	// elsewhere). MCP and other independent sandboxes leave this empty.
+	SessionTemp string
 }
 
 // Enforce reports whether the spec asks for confinement.

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -75,6 +75,11 @@ func writeAllowDirsForSpec(spec Spec) []string {
 	roots := spec.WriteRoots
 	dirs := append([]string{}, roots...)
 	dirs = append(dirs, "/dev")
+	if dir := strings.TrimSpace(spec.SessionTemp); dir != "" {
+		// Session-private temporary directory must be writable under Seatbelt
+		// even when MinimalWrites omits the broad host temp allowances.
+		dirs = append(dirs, dir)
+	}
 	if !spec.MinimalWrites {
 		dirs = append(dirs, "/tmp", "/private/tmp", "/private/var/folders", os.TempDir())
 	}

--- a/internal/sandbox/seatbelt_darwin_test.go
+++ b/internal/sandbox/seatbelt_darwin_test.go
@@ -74,6 +74,22 @@ func TestWriteAllowDirsIncludesTemp(t *testing.T) {
 	}
 }
 
+func TestWriteAllowDirsIncludesSessionTemp(t *testing.T) {
+	private := t.TempDir()
+	dirs := writeAllowDirsForSpec(Spec{SessionTemp: private, MinimalWrites: true})
+	real, _ := filepath.EvalSymlinks(private)
+	found := false
+	for _, d := range dirs {
+		if d == real {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("SessionTemp must be allowed under Seatbelt even with MinimalWrites: %v", dirs)
+	}
+}
+
 func TestWriteAllowDirsSkipsEmpty(t *testing.T) {
 	dirs := writeAllowDirs([]string{"", "", ""})
 	for _, d := range dirs {

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -80,13 +80,39 @@ func Available() bool {
 // forbid-read paths so directories appear empty and files read as empty. The
 // rest of the filesystem is mounted read-only (matching macOS Seatbelt).
 func bwrapArgs(spec Spec, sh Shell, command string) []string {
+	args := bwrapBaseArgs(spec)
+	return append(args, sh.argv(command)...)
+}
+
+// bwrapArgsForArgs is like bwrapArgs but accepts raw argv instead of a shell
+// command string. It builds the same sandbox prefix and appends the caller's
+// argv directly — no shell interpreter wrapping.
+func bwrapArgsForArgs(spec Spec, args []string) []string {
+	out := bwrapBaseArgs(spec)
+	// /tmp is replaced above (tmpfs or session-private bind) so MCP servers
+	// cannot inspect unrelated host temporary files. A configured executable
+	// may itself live below /tmp, though (for example a downloaded one-shot
+	// launcher or a Go test helper). Re-expose only that exact file, read-only,
+	// after every masking mount so the process can start without revealing its
+	// siblings. Session-private binds already contain the generation's files,
+	// so only host-/tmp executables need this re-mount.
+	out = append(out, bwrapExecutableMountArgs(args)...)
+	return append(out, args...)
+}
+
+// bwrapBaseArgs is the shared bubblewrap prefix for shell and raw-argv launches.
+// With Spec.SessionTemp set, the private directory is bind-mounted at /tmp so
+// consecutive Bash calls in the same logical session share temporary files.
+// Without it (MCP and other independent sandboxes), /tmp is a fresh empty
+// tmpfs as before.
+func bwrapBaseArgs(spec Spec) []string {
 	args := []string{
 		"--unshare-net", // deny network by default
 		"--ro-bind", "/", "/",
 		"--dev", "/dev",
 		"--proc", "/proc",
-		"--tmpfs", "/tmp",
 	}
+	args = append(args, bwrapTmpMountArgs(spec)...)
 	if spec.Network {
 		// Re-allow network by removing the network namespace.
 		args = args[1:] // drop --unshare-net
@@ -99,42 +125,14 @@ func bwrapArgs(spec Spec, sh Shell, command string) []string {
 			args = append(args, "--bind", root, root)
 		}
 	}
-	args = append(args, bwrapForbidReadArgs(spec.ForbidReadRoots)...)
-	return append(args, sh.argv(command)...)
+	return append(args, bwrapForbidReadArgs(spec.ForbidReadRoots)...)
 }
 
-// bwrapArgsForArgs is like bwrapArgs but accepts raw argv instead of a shell
-// command string. It builds the same sandbox prefix and appends the caller's
-// argv directly — no shell interpreter wrapping.
-func bwrapArgsForArgs(spec Spec, args []string) []string {
-	out := []string{
-		"--unshare-net", // deny network by default
-		"--ro-bind", "/", "/",
-		"--dev", "/dev",
-		"--proc", "/proc",
-		"--tmpfs", "/tmp",
+func bwrapTmpMountArgs(spec Spec) []string {
+	if dir := strings.TrimSpace(spec.SessionTemp); dir != "" {
+		return []string{"--bind", dir, "/tmp"}
 	}
-	if spec.Network {
-		// Re-allow network by removing the network namespace.
-		out = out[1:] // drop --unshare-net
-	}
-	for _, root := range spec.WriteRoots {
-		out = append(out, "--bind", root, root)
-	}
-	if !spec.MinimalWrites {
-		for _, root := range linuxWriteDirs() {
-			out = append(out, "--bind", root, root)
-		}
-	}
-	out = append(out, bwrapForbidReadArgs(spec.ForbidReadRoots)...)
-	// /tmp is intentionally replaced with an empty filesystem above so MCP
-	// servers cannot inspect unrelated host temporary files. A configured
-	// executable may itself live below /tmp, though (for example a downloaded
-	// one-shot launcher or a Go test helper). Re-expose only that exact file,
-	// read-only, after every masking mount so the process can start without
-	// revealing its siblings.
-	out = append(out, bwrapExecutableMountArgs(args)...)
-	return append(out, args...)
+	return []string{"--tmpfs", "/tmp"}
 }
 
 // bwrapForbidReadArgs returns mounts suitable for both configured directory

--- a/internal/sandbox/seatbelt_other_test.go
+++ b/internal/sandbox/seatbelt_other_test.go
@@ -57,6 +57,35 @@ func TestBwrapArgsForArgsMountsTemporaryExecutableAfterMasks(t *testing.T) {
 	}
 }
 
+func TestBwrapArgsBindsSessionTempAtTmp(t *testing.T) {
+	private := t.TempDir()
+	argv := bwrapArgs(Spec{
+		Mode:        "enforce",
+		SessionTemp: private,
+		WriteRoots:  []string{t.TempDir()},
+	}, Shell{Kind: ShellBash, Path: "bash"}, "true")
+	bind := indexArgs(argv, "--bind", private, "/tmp")
+	if bind < 0 {
+		t.Fatalf("expected --bind %s /tmp in %v", private, argv)
+	}
+	if indexArgs(argv, "--tmpfs", "/tmp") >= 0 {
+		t.Fatalf("session temp must not use tmpfs /tmp: %v", argv)
+	}
+	// Must not bind the host public temporary root as /tmp.
+	if host := os.TempDir(); host != private {
+		if indexArgs(argv, "--bind", host, "/tmp") >= 0 {
+			t.Fatalf("must not bind host temp %s at /tmp: %v", host, argv)
+		}
+	}
+}
+
+func TestBwrapArgsWithoutSessionTempKeepsTmpfs(t *testing.T) {
+	argv := bwrapArgs(Spec{Mode: "enforce"}, Shell{Kind: ShellBash, Path: "bash"}, "true")
+	if indexArgs(argv, "--tmpfs", "/tmp") < 0 {
+		t.Fatalf("independent sandbox should keep tmpfs /tmp: %v", argv)
+	}
+}
+
 func TestBwrapForbidReadArgsMasksFilesAndDirectories(t *testing.T) {
 	dir := t.TempDir()
 	nested := filepath.Join(dir, "nested")

--- a/internal/sandbox/session_temp_env.go
+++ b/internal/sandbox/session_temp_env.go
@@ -1,0 +1,46 @@
+package sandbox
+
+import "runtime"
+
+// SessionTempEnvKeys are the standard temporary-directory environment variables
+// Reasonix overrides for session-private temporary directories.
+var SessionTempEnvKeys = []string{"TMPDIR", "TMP", "TEMP"}
+
+// SessionTempEnv returns KEY=value overrides for the session-private temporary
+// directory. When linuxSandboxed is true (Linux bwrap with SessionTemp bound at
+// /tmp), the variables point at the virtual /tmp path so scripts using $TMPDIR
+// and /tmp agree. Otherwise they point at the host private directory.
+//
+// An empty sessionTemp yields nil (no overrides).
+func SessionTempEnv(sessionTemp string, linuxSandboxed bool) []string {
+	if sessionTemp == "" {
+		return nil
+	}
+	value := sessionTemp
+	if linuxSandboxed && runtime.GOOS == "linux" {
+		value = "/tmp"
+	}
+	out := make([]string, 0, len(SessionTempEnvKeys))
+	for _, key := range SessionTempEnvKeys {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+// SessionTempEnvMap is SessionTempEnv as a name→value map for ACP terminal/create.
+func SessionTempEnvMap(sessionTemp string, linuxSandboxed bool) map[string]string {
+	pairs := SessionTempEnv(sessionTemp, linuxSandboxed)
+	if len(pairs) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(pairs))
+	for _, kv := range pairs {
+		for i := 0; i < len(kv); i++ {
+			if kv[i] == '=' {
+				out[kv[:i]] = kv[i+1:]
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/sandbox/session_temp_env_test.go
+++ b/internal/sandbox/session_temp_env_test.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSessionTempEnvLinuxSandboxedPointsAtVirtualTmp(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux sandbox mapping only")
+	}
+	env := SessionTempEnv("/private/session-tmp", true)
+	for _, kv := range env {
+		if !strings.HasSuffix(kv, "=/tmp") {
+			t.Fatalf("linux sandboxed env %q should point at /tmp", kv)
+		}
+	}
+}
+
+func TestSessionTempEnvHostPrivate(t *testing.T) {
+	dir := "/tmp/reasonix-session-tmp-test"
+	env := SessionTempEnv(dir, false)
+	if len(env) != 3 {
+		t.Fatalf("env count = %d, want 3", len(env))
+	}
+	m := SessionTempEnvMap(dir, false)
+	for _, key := range SessionTempEnvKeys {
+		if m[key] != dir {
+			t.Fatalf("%s = %q, want %q", key, m[key], dir)
+		}
+	}
+}
+
+func TestSessionTempEnvEmpty(t *testing.T) {
+	if SessionTempEnv("", true) != nil {
+		t.Fatal("empty session temp must not emit overrides")
+	}
+	if SessionTempEnvMap("", false) != nil {
+		t.Fatal("empty session temp map must be nil")
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -312,12 +312,17 @@ func (s *Server) build(ctx context.Context, ref string) (*control.Controller, er
 	if s.buildController != nil {
 		return s.buildController(ctx, ref)
 	}
-	return boot.Build(ctx, boot.Options{
+	opts := boot.Options{
 		Model:       ref,
 		Sink:        s.bc,
 		Stderr:      os.Stderr,
 		StatsSource: "serve",
-	})
+	}
+	// Keep the logical-session private temporary directory across model switches.
+	if cur, ok := s.ctl().(*control.Controller); ok && cur != nil {
+		opts.SessionTemp = cur.SessionTemp()
+	}
+	return boot.Build(ctx, opts)
 }
 
 // reloadExtensions fail-atomically rebuilds the active controller generation

--- a/internal/sessiontemp/context.go
+++ b/internal/sessiontemp/context.go
@@ -1,0 +1,27 @@
+package sessiontemp
+
+import "context"
+
+type ctxKey struct{}
+
+// WithManager attaches m to ctx so tool executions in this scope (for example
+// one sub-agent run) share a private temporary directory distinct from the
+// parent agent and from sibling runs.
+func WithManager(ctx context.Context, m *Manager) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, m)
+}
+
+// FromContext returns the Manager attached by WithManager, or nil.
+func FromContext(ctx context.Context) *Manager {
+	if ctx == nil {
+		return nil
+	}
+	m, _ := ctx.Value(ctxKey{}).(*Manager)
+	return m
+}

--- a/internal/sessiontemp/context_deadline.go
+++ b/internal/sessiontemp/context_deadline.go
@@ -1,0 +1,10 @@
+package sessiontemp
+
+import "context"
+
+// nilContext returns a non-nil background context for lock acquisition that
+// waits indefinitely. Owner locks for live generations must not time out while
+// the process holds them; stale cleanup uses TryAcquire instead.
+func nilContext() context.Context {
+	return context.Background()
+}

--- a/internal/sessiontemp/manager.go
+++ b/internal/sessiontemp/manager.go
@@ -1,0 +1,465 @@
+// Package sessiontemp provides a logical-session private temporary directory
+// manager. Bash and related sandboxed helpers share one directory for the
+// duration of a logical chat session, while each bwrap/sandbox-exec invocation
+// still enters its own namespace.
+//
+// The manager is intentionally invisible to models and users: no settings,
+// tool parameters, or prompt surface is added. Hot rebuilds retain the same
+// Manager; /new, /clear, resume of another session, and branch switches rotate
+// to a fresh generation.
+package sessiontemp
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"reasonix/internal/filelock"
+)
+
+const (
+	dirPrefix     = "reasonix-session-tmp-"
+	ownerLockName = ".owner.lock"
+	staleAge      = 24 * time.Hour
+)
+
+// ErrUnavailable reports that a session-private temporary directory could not
+// be created or the manager is no longer accepting leases. Callers must fail
+// the command rather than fall back to the host public temporary directory.
+var ErrUnavailable = errors.New("session temporary directory unavailable")
+
+// Manager owns one logical session's temporary generations. Controllers
+// Retain/Release it so hot rebuilds share the directory; Acquire/Release
+// leases keep retired generations alive while foreground or background
+// commands still run.
+//
+// After the last Controller owner Releases, the Manager is irreversibly
+// sealed: further Acquire calls fail closed so a late tool goroutine cannot
+// recreate a generation with no owner (directory/lock leak).
+type Manager struct {
+	mu     sync.Mutex
+	owners int
+	// sealed is set irreversibly when owners drops to zero. Hot rebuilds
+	// always Retain the replacement before ReleaseResources on the old
+	// Controller, so they never seal the shared Manager.
+	sealed bool
+	gen    *generation
+	// root is the OS temporary parent used for lazy creation and stale
+	// cleanup. Empty means os.TempDir() at the moment of use.
+	root string
+	// now is injectable for tests.
+	now func() time.Time
+	// mkDir is injectable for failure tests.
+	mkDir func(parent string) (string, error)
+}
+
+type generation struct {
+	id     uint64
+	dir    string
+	leases int
+	// releaseOwner drops the cross-process owner lock; nil when the lock was
+	// not acquired (should not happen for a live generation).
+	releaseOwner func()
+}
+
+// Lease is a running-process claim on one generation. Release must be called
+// exactly once after the process exits (or fails to start).
+type Lease struct {
+	m    *Manager
+	gen  *generation
+	dir  string
+	once sync.Once
+}
+
+var nextGenID atomic.Uint64
+
+// processCleanup tracks which canonical temp roots have already been swept
+// in this process. Sub-agent Managers must not re-scan the whole temp tree.
+var processCleanup struct {
+	sync.Mutex
+	done map[string]struct{}
+}
+
+// New returns a Manager with zero controller owners. Callers must Retain
+// before use (Controller.New does this). The first New for each distinct
+// temporary root in a process also sweeps stale directories left by crashed peers.
+func New() *Manager {
+	m := &Manager{
+		now:   time.Now,
+		mkDir: defaultMkDir,
+	}
+	cleanupStaleOnce(m.tempRoot(), m.now)
+	return m
+}
+
+// newForTest builds a Manager that writes under root and skips process-level
+// stale cleanup (tests own the root).
+func newForTest(root string) *Manager {
+	return &Manager{
+		root:  root,
+		now:   time.Now,
+		mkDir: defaultMkDir,
+	}
+}
+
+// NewWithRoot is like New but forces generations under root (tests). It does
+// not run process-level stale cleanup against root.
+func NewWithRoot(root string) *Manager {
+	return newForTest(root)
+}
+
+// SetMkDirForTest overrides directory creation (tests only).
+func (m *Manager) SetMkDirForTest(fn func(parent string) (string, error)) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.mkDir = fn
+	m.mu.Unlock()
+}
+
+// Retain adds a Controller owner reference. Hot rebuilds call Retain on the
+// shared Manager before publishing the replacement Controller.
+// Retain on a sealed Manager is a no-op that leaves it sealed (fail closed).
+func (m *Manager) Retain() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if !m.sealed {
+		m.owners++
+	}
+	m.mu.Unlock()
+}
+
+// Release drops a Controller owner reference. When the last owner leaves, the
+// Manager is sealed and the current generation is retired (deleted once its
+// process leases drain).
+func (m *Manager) Release() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.owners > 0 {
+		m.owners--
+	}
+	if m.owners == 0 {
+		m.sealed = true
+		m.retireLocked(m.gen)
+		m.gen = nil
+	}
+	m.mu.Unlock()
+}
+
+// Sealed reports whether the last Controller owner has released the Manager.
+func (m *Manager) Sealed() bool {
+	if m == nil {
+		return true
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sealed
+}
+
+// Owners returns the current Controller reference count (tests).
+func (m *Manager) Owners() int {
+	if m == nil {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.owners
+}
+
+// Dir returns the current generation directory without acquiring a lease.
+// Empty when no generation has been created yet. Intended for diagnostics.
+func (m *Manager) Dir() string {
+	if m == nil {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.gen == nil {
+		return ""
+	}
+	return m.gen.dir
+}
+
+// Rotate retires the current generation and prepares a fresh one on the next
+// Acquire. In-flight leases keep the old directory alive until they release.
+// Rotate on a sealed Manager is a no-op.
+func (m *Manager) Rotate() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if !m.sealed {
+		m.retireLocked(m.gen)
+		m.gen = nil
+	}
+	m.mu.Unlock()
+}
+
+// Acquire pins the current generation (creating it lazily) and increments the
+// process lease count. The returned Lease must be released after the process
+// exits; failing to start still requires Release.
+//
+// Acquire fails closed when the Manager is sealed or has no Controller owners,
+// so a late Bash goroutine after Close cannot recreate a leaked generation.
+func (m *Manager) Acquire() (*Lease, error) {
+	if m == nil {
+		return nil, fmt.Errorf("%w: manager is nil", ErrUnavailable)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.sealed || m.owners == 0 {
+		return nil, fmt.Errorf("%w: manager closed", ErrUnavailable)
+	}
+
+	if m.gen == nil {
+		gen, err := m.createGenerationLocked()
+		if err != nil {
+			return nil, err
+		}
+		m.gen = gen
+	}
+	m.gen.leases++
+	return &Lease{m: m, gen: m.gen, dir: m.gen.dir}, nil
+}
+
+// Dir is the absolute path of the leased temporary directory.
+func (l *Lease) Dir() string {
+	if l == nil {
+		return ""
+	}
+	return l.dir
+}
+
+// Release decrements the process lease. When a retired generation reaches
+// zero leases it is deleted. Safe to call multiple times.
+func (l *Lease) Release() {
+	if l == nil || l.m == nil || l.gen == nil {
+		return
+	}
+	l.once.Do(func() {
+		l.m.mu.Lock()
+		defer l.m.mu.Unlock()
+		if l.gen.leases > 0 {
+			l.gen.leases--
+		}
+		if l.gen.leases == 0 && l.m.gen != l.gen {
+			// Retired generation with no remaining process claims.
+			l.m.deleteGenerationLocked(l.gen)
+		}
+	})
+}
+
+func (m *Manager) createGenerationLocked() (*generation, error) {
+	parent := m.tempRoot()
+	mk := m.mkDir
+	if mk == nil {
+		mk = defaultMkDir
+	}
+	dir, err := mk(parent)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnavailable, err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("%w: chmod: %v", ErrUnavailable, err)
+	}
+	lockPath := filepath.Join(dir, ownerLockName)
+	release, err := filelock.Acquire(nilContext(), lockPath)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("%w: owner lock: %v", ErrUnavailable, err)
+	}
+	return &generation{
+		id:           nextGenID.Add(1),
+		dir:          dir,
+		releaseOwner: release,
+	}, nil
+}
+
+// Prefix is the directory name prefix used for session temporary directories.
+// Exported for tests and diagnostics.
+func Prefix() string { return dirPrefix }
+
+func (m *Manager) retireLocked(gen *generation) {
+	if gen == nil {
+		return
+	}
+	if m.gen == gen {
+		m.gen = nil
+	}
+	if gen.leases == 0 {
+		m.deleteGenerationLocked(gen)
+	}
+}
+
+func (m *Manager) deleteGenerationLocked(gen *generation) {
+	if gen == nil {
+		return
+	}
+	if gen.releaseOwner != nil {
+		gen.releaseOwner()
+		gen.releaseOwner = nil
+	}
+	if gen.dir == "" {
+		return
+	}
+	if err := safeRemoveDir(gen.dir, m.tempRoot()); err != nil {
+		slog.Warn("sessiontemp: remove generation", "dir", gen.dir, "err", err)
+	}
+	gen.dir = ""
+}
+
+func (m *Manager) tempRoot() string {
+	if m != nil && m.root != "" {
+		return m.root
+	}
+	return os.TempDir()
+}
+
+func defaultMkDir(parent string) (string, error) {
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(parent, dirPrefix)
+}
+
+// cleanupStaleOnce runs cleanupStale at most once per canonical temp root per
+// process. Sub-agent Managers share the same root and must not re-scan.
+func cleanupStaleOnce(root string, now func() time.Time) {
+	if root == "" {
+		return
+	}
+	key := canonicalTempRoot(root)
+	processCleanup.Lock()
+	if processCleanup.done == nil {
+		processCleanup.done = map[string]struct{}{}
+	}
+	if _, ok := processCleanup.done[key]; ok {
+		processCleanup.Unlock()
+		return
+	}
+	processCleanup.done[key] = struct{}{}
+	processCleanup.Unlock()
+	cleanupStale(root, now)
+}
+
+func canonicalTempRoot(root string) string {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return filepath.Clean(root)
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = real
+	}
+	return filepath.Clean(abs)
+}
+
+// resetProcessCleanupForTest clears the process-level cleanup map (tests only).
+func resetProcessCleanupForTest() {
+	processCleanup.Lock()
+	processCleanup.done = nil
+	processCleanup.Unlock()
+}
+
+// cleanupStale removes reasonix-session-tmp-* direct children of root that are
+// older than 24h and whose owner lock is free. Failures are logged only.
+func cleanupStale(root string, now func() time.Time) {
+	if root == "" {
+		return
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		slog.Warn("sessiontemp: list temp root for stale cleanup", "root", root, "err", err)
+		return
+	}
+	cutoff := now().Add(-staleAge)
+	for _, ent := range entries {
+		name := ent.Name()
+		if !strings.HasPrefix(name, dirPrefix) {
+			continue
+		}
+		path := filepath.Join(root, name)
+		// Do not follow a top-level symlink out of the temp root.
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&fs.ModeSymlink != 0 {
+			// Try to remove the symlink entry itself only when old enough.
+			if info.ModTime().Before(cutoff) {
+				if err := os.Remove(path); err != nil {
+					slog.Warn("sessiontemp: remove stale symlink", "path", path, "err", err)
+				}
+			}
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		lockPath := filepath.Join(path, ownerLockName)
+		release, err := filelock.TryAcquire(lockPath)
+		if err != nil {
+			// Still held by a live process (or lock error) — skip.
+			continue
+		}
+		release()
+		if err := safeRemoveDir(path, root); err != nil {
+			slog.Warn("sessiontemp: remove stale dir", "path", path, "err", err)
+		}
+	}
+}
+
+// safeRemoveDir deletes path only when it is a direct child of parent, has the
+// expected name prefix, and is not a symlink. It never follows a top-level
+// symlink to a foreign target.
+func safeRemoveDir(path, parent string) error {
+	path = filepath.Clean(path)
+	parent = filepath.Clean(parent)
+	if realParent, err := filepath.EvalSymlinks(parent); err == nil {
+		parent = realParent
+	}
+	base := filepath.Base(path)
+	if !strings.HasPrefix(base, dirPrefix) {
+		return fmt.Errorf("refusing to remove non-session-temp path %q", path)
+	}
+	if filepath.Dir(path) != parent {
+		// Also accept when path's parent resolves to the same canonical parent.
+		dirParent := filepath.Dir(path)
+		if real, err := filepath.EvalSymlinks(dirParent); err == nil {
+			dirParent = real
+		}
+		if dirParent != parent {
+			return fmt.Errorf("refusing to remove path outside temp root: %q", path)
+		}
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		return os.Remove(path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("refusing to remove non-directory %q", path)
+	}
+	return os.RemoveAll(path)
+}

--- a/internal/sessiontemp/manager_test.go
+++ b/internal/sessiontemp/manager_test.go
@@ -1,0 +1,335 @@
+package sessiontemp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAcquireSharesGeneration(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+	defer m.Release()
+
+	a, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Dir() == "" || a.Dir() != b.Dir() {
+		t.Fatalf("dirs = %q, %q; want same non-empty dir", a.Dir(), b.Dir())
+	}
+	info, err := os.Stat(a.Dir())
+	if err != nil || !info.IsDir() {
+		t.Fatalf("dir stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("dir perm = %o, want 0700", perm)
+	}
+	a.Release()
+	b.Release()
+	if _, err := os.Stat(a.Dir()); err != nil {
+		t.Fatalf("active generation should remain while manager owned: %v", err)
+	}
+}
+
+func TestRotateIsolatesNewCommands(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+	defer m.Release()
+
+	old, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := old.Dir()
+	if err := os.WriteFile(filepath.Join(oldDir, "keep.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m.Rotate()
+	fresh, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Dir() == oldDir {
+		t.Fatal("rotate should create a new directory")
+	}
+	if _, err := os.Stat(filepath.Join(fresh.Dir(), "keep.txt")); !os.IsNotExist(err) {
+		t.Fatalf("new generation must not see old files: %v", err)
+	}
+	// Old generation remains while leased.
+	if _, err := os.Stat(filepath.Join(oldDir, "keep.txt")); err != nil {
+		t.Fatalf("leased old generation deleted early: %v", err)
+	}
+	old.Release()
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old generation should be removed after last lease: %v", err)
+	}
+	fresh.Release()
+}
+
+func TestLastLeaseDeletesRetiredGeneration(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+
+	lease, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+	m.Release() // last controller owner retires current generation
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("retired generation with live lease must remain: %v", err)
+	}
+	lease.Release()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("directory should be deleted after last lease: %v", err)
+	}
+}
+
+func TestHotRebuildRetainRelease(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain() // old controller
+	lease, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+	lease.Release()
+
+	m.Retain()  // replacement controller
+	m.Release() // old controller closes — must not delete while new owns
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("hot rebuild must keep generation: %v", err)
+	}
+
+	again, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Dir() != dir {
+		t.Fatalf("hot rebuild should reuse generation: got %q want %q", again.Dir(), dir)
+	}
+	again.Release()
+	m.Release()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("final release should delete: %v", err)
+	}
+}
+
+func TestAcquireCreateFailureDoesNotFallback(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+	defer m.Release()
+	m.mkDir = func(string) (string, error) {
+		return "", os.ErrPermission
+	}
+	if _, err := m.Acquire(); err == nil {
+		t.Fatal("want create failure")
+	}
+}
+
+func TestAcquireAfterLastOwnerReleaseIsSealed(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+	lease, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := lease.Dir()
+
+	// Force Release → delayed Acquire ordering with a channel barrier.
+	released := make(chan struct{})
+	acquired := make(chan error, 1)
+	go func() {
+		<-released
+		_, err := m.Acquire()
+		acquired <- err
+	}()
+
+	m.Release() // last owner — seals
+	close(released)
+	err = <-acquired
+	if err == nil {
+		t.Fatal("Acquire after last Release must fail closed")
+	}
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("error = %v, want ErrUnavailable", err)
+	}
+	if !m.Sealed() {
+		t.Fatal("manager should be sealed")
+	}
+
+	// Live lease still pins the directory until it releases.
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("leased generation deleted while sealed: %v", err)
+	}
+	lease.Release()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("generation should delete after last lease on sealed manager: %v", err)
+	}
+
+	// Retain after seal must not reopen.
+	m.Retain()
+	if _, err := m.Acquire(); err == nil {
+		t.Fatal("Retain after seal must not reopen Acquire")
+	}
+}
+
+func TestAcquireWithoutOwnerFailsClosed(t *testing.T) {
+	m := newForTest(t.TempDir())
+	if _, err := m.Acquire(); err == nil {
+		t.Fatal("Acquire with zero owners must fail")
+	}
+}
+
+func TestProcessCleanupRunsOncePerRoot(t *testing.T) {
+	resetProcessCleanupForTest()
+	root := t.TempDir()
+	// Plant a stale dir that would be eligible if cleanup ran with an old now.
+	// We only count whether cleanupStaleOnce marks the root done.
+	cleanupStaleOnce(root, time.Now)
+	cleanupStaleOnce(root, time.Now)
+	processCleanup.Lock()
+	key := canonicalTempRoot(root)
+	_, ok := processCleanup.done[key]
+	n := len(processCleanup.done)
+	processCleanup.Unlock()
+	if !ok {
+		t.Fatal("root not marked cleaned")
+	}
+	if n != 1 {
+		t.Fatalf("cleanup map size = %d, want 1 entry for one root", n)
+	}
+	// A second New against the real TempDir should not panic; first process
+	// New still uses process-level once.
+	_ = New()
+	_ = New()
+}
+
+func TestConcurrentAcquireRotateReleaseRace(t *testing.T) {
+	m := newForTest(t.TempDir())
+	m.Retain()
+	defer m.Release()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				lease, err := m.Acquire()
+				if err != nil {
+					t.Errorf("acquire: %v", err)
+					return
+				}
+				_ = os.WriteFile(filepath.Join(lease.Dir(), "x"), []byte("1"), 0o600)
+				if j%7 == 0 {
+					m.Rotate()
+				}
+				lease.Release()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestStaleCleanup(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+
+	// Fresh dir — skip.
+	fresh, err := os.MkdirTemp(root, dirPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Active locked dir older than 24h — skip.
+	active, err := os.MkdirTemp(root, dirPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release, err := filelockAcquire(filepath.Join(active, ownerLockName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	// Chtimes after lock creation: writing the lock file refreshes dir mtime.
+	if err := os.Chtimes(active, now.Add(-48*time.Hour), now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale unlocked dir — delete.
+	stale, err := os.MkdirTemp(root, dirPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create and release lock file so TryAcquire can succeed, then age the dir.
+	lockPath := filepath.Join(stale, ownerLockName)
+	r, err := filelockAcquire(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r()
+	if err := os.Chtimes(stale, now.Add(-48*time.Hour), now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unrelated directory — skip.
+	other := filepath.Join(root, "not-reasonix")
+	if err := os.Mkdir(other, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(other, now.Add(-48*time.Hour), now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Symlink to a foreign target — remove only the symlink entry, not the target.
+	foreign := filepath.Join(t.TempDir(), "foreign-target")
+	if err := os.Mkdir(foreign, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(foreign, "marker")
+	if err := os.WriteFile(marker, []byte("safe"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, dirPrefix+"link")
+	if err := os.Symlink(foreign, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(link, now.Add(-48*time.Hour), now.Add(-48*time.Hour)); err != nil {
+		// Some platforms cannot chtimes symlinks; fall back to cleaning with a
+		// forced old now so age check uses Lstat mtime of the link when set.
+		_ = err
+	}
+
+	cleanupStale(root, func() time.Time { return now })
+
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh dir removed: %v", err)
+	}
+	if _, err := os.Stat(active); err != nil {
+		t.Fatalf("active locked dir removed: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale dir should be removed: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Fatalf("unrelated dir removed: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("symlink cleanup deleted foreign target: %v", err)
+	}
+}
+
+func filelockAcquire(path string) (func(), error) {
+	// Local import shim for tests in this package.
+	return tryLockForTest(path)
+}

--- a/internal/sessiontemp/manager_test_helpers.go
+++ b/internal/sessiontemp/manager_test_helpers.go
@@ -1,0 +1,7 @@
+package sessiontemp
+
+import "reasonix/internal/filelock"
+
+func tryLockForTest(path string) (func(), error) {
+	return filelock.Acquire(nilContext(), path)
+}

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/proc"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/shellparse"
 	"reasonix/internal/tool"
 )
@@ -76,6 +77,9 @@ func cachedBashShellPATH(ctx context.Context) string {
 // zero or negative means no tool-local cap, while parent context cancellation
 // still kills the process tree. guard appends a warning to the output of
 // commands that reference Reasonix's own session stores (see SessionDataGuard).
+// sessionTemp, when non-nil, supplies the logical-session private temporary
+// directory shared across Bash calls (see package sessiontemp). A Manager on
+// the execution context overrides this for sub-agent isolation.
 type bash struct {
 	sb      sandbox.Spec
 	shell   sandbox.Shell
@@ -86,7 +90,8 @@ type bash struct {
 	// (ACP terminal/*). Only consulted when the local OS sandbox is not
 	// enforcing — a host terminal cannot honor the confinement configuration —
 	// and never for background jobs, which need the local job manager.
-	terminal TerminalRunner
+	terminal    TerminalRunner
+	sessionTemp *sessiontemp.Manager
 }
 
 type bashParams struct {
@@ -167,6 +172,22 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			"conditional chaining, or issue the commands as separate calls")
 	}
 
+	// Pin the session-private temporary generation before any launch path so
+	// foreground, background, and host-terminal runs share one directory, and
+	// so a failed start still releases the lease.
+	prepared, lease, err := b.prepareLaunch(ctx, sh, p.Command, args)
+	if err != nil {
+		return "", err
+	}
+	// Background jobs take ownership of the lease until the job goroutine ends.
+	// Foreground/terminal paths release after the process exits.
+	releaseLease := true
+	defer func() {
+		if releaseLease && lease != nil {
+			lease.Release()
+		}
+	}()
+
 	// A host-owned terminal runs the command where the user watches it live.
 	// Never when the OS sandbox is enforcing (the host cannot honor the local
 	// confinement config), never when [secrets].filter_subprocess_env is on
@@ -174,30 +195,14 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	// would leak the credentials the user asked to strip), and never for
 	// background jobs. ok=false falls back to local execution unchanged.
 	if b.terminal != nil && !p.RunInBackground && !b.sb.Enforce() && !secrets.FilterSubprocessEnv() {
-		if out, ok, err := b.terminal.RunCommand(ctx, p.Command, b.workDir, b.timeout); ok {
-			return appendSessionDataHint(out, b.guard.CommandHint(b.workDir, p.Command)), err
+		envMap := sandbox.SessionTempEnvMap(prepared.SessionTemp, prepared.LinuxSandboxed)
+		if out, ok, termErr := b.terminal.RunCommand(ctx, p.Command, b.workDir, b.timeout, envMap); ok {
+			return appendSessionDataHint(out, b.guard.CommandHint(b.workDir, p.Command)), termErr
 		}
 	}
 
-	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
-	argv, wrapped := bashSandboxCommand(b.sb, sh, p.Command)
-	if b.sb.Enforce() && bashSandboxEscapeSessionAllowed(ctx, p.Command, args) {
-		argv = unconfinedShellArgv(sh, p.Command)
-		wrapped = false
-	} else if b.sb.Enforce() && !wrapped {
-		allow, reason, err := approveBashSandboxEscape(ctx, p.Command, args, i18n.M.SandboxEscapeWrapReason)
-		if err != nil {
-			return "", err
-		}
-		if !allow {
-			if reason != "" {
-				return "", fmt.Errorf("%s", reason)
-			}
-			return "", fmt.Errorf("%s", sandbox.UnavailableMessage())
-		}
-		argv = unconfinedShellArgv(sh, p.Command)
-	}
-	cmdEnv := bashCommandEnv(ctx)
+	argv, wrapped := prepared.Argv, prepared.Wrapped
+	cmdEnv := applyEnvOverrides(bashCommandEnv(ctx), prepared.EnvOverrides)
 
 	if p.RunInBackground {
 		jm, ok := jobs.FromContext(ctx)
@@ -205,9 +210,16 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			return "", fmt.Errorf("background execution is not available in this context")
 		}
 		workDir := b.workDir
+		// Transfer lease ownership to the job closure; it releases when the
+		// background process ends (including start failures inside the job).
+		jobLease := lease
+		releaseLease = false
 		// The job runs under the manager's session context (no foreground timeout), so it
 		// survives this turn; its combined output streams to the job buffer.
 		job := jm.StartForSession(jobs.SessionFromContext(ctx), "bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
+			if jobLease != nil {
+				defer jobLease.Release()
+			}
 			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
 			cmd.Dir = workDir
 			cmd.Env = cmdEnv
@@ -226,6 +238,85 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	out, err := b.runForeground(ctx, p, sh, argv, wrapped, cmdEnv)
 	return appendSessionDataHint(out, b.guard.CommandHint(b.workDir, p.Command)), err
+}
+
+// prepareLaunch acquires a session-temp lease (when a Manager is available),
+// builds the sandboxed argv, and applies sandbox-escape approval. The caller
+// owns the returned lease and must Release it after the process exits.
+func (b bash) prepareLaunch(ctx context.Context, sh sandbox.Shell, command string, rawArgs json.RawMessage) (sandbox.Prepared, *sessiontemp.Lease, error) {
+	var lease *sessiontemp.Lease
+	sessionDir := ""
+	if m := b.sessionTempManager(ctx); m != nil {
+		l, err := m.Acquire()
+		if err != nil {
+			return sandbox.Prepared{}, nil, fmt.Errorf("session temporary directory: %w", err)
+		}
+		lease = l
+		sessionDir = l.Dir()
+	}
+
+	// bashSandboxCommand is injectable for tests; production points at
+	// sandbox.Command. Attach SessionTemp so Linux bwrap binds the private dir.
+	spec := b.sb
+	spec.SessionTemp = sessionDir
+	argv, wrapped := bashSandboxCommand(spec, sh, command)
+	linuxSB := wrapped && sessionDir != "" && runtime.GOOS == "linux"
+	prepared := sandbox.Prepared{
+		Argv:           argv,
+		Wrapped:        wrapped,
+		SessionTemp:    sessionDir,
+		EnvOverrides:   sandbox.SessionTempEnv(sessionDir, linuxSB),
+		LinuxSandboxed: linuxSB,
+	}
+
+	if b.sb.Enforce() && bashSandboxEscapeSessionAllowed(ctx, command, rawArgs) {
+		prepared.Argv = unconfinedShellArgv(sh, command)
+		prepared.Wrapped = false
+		// Escaped commands still inherit private temp env vars pointing at the
+		// host private directory (no virtual /tmp mapping).
+		prepared.LinuxSandboxed = false
+		prepared.EnvOverrides = sandbox.SessionTempEnv(sessionDir, false)
+	} else if b.sb.Enforce() && !prepared.Wrapped {
+		allow, reason, err := approveBashSandboxEscape(ctx, command, rawArgs, i18n.M.SandboxEscapeWrapReason)
+		if err != nil {
+			if lease != nil {
+				lease.Release()
+			}
+			return sandbox.Prepared{}, nil, err
+		}
+		if !allow {
+			if lease != nil {
+				lease.Release()
+			}
+			if reason != "" {
+				return sandbox.Prepared{}, nil, fmt.Errorf("%s", reason)
+			}
+			return sandbox.Prepared{}, nil, fmt.Errorf("%s", sandbox.UnavailableMessage())
+		}
+		prepared.Argv = unconfinedShellArgv(sh, command)
+		prepared.Wrapped = false
+		prepared.LinuxSandboxed = false
+		prepared.EnvOverrides = sandbox.SessionTempEnv(sessionDir, false)
+	}
+	return prepared, lease, nil
+}
+
+func (b bash) sessionTempManager(ctx context.Context) *sessiontemp.Manager {
+	if m := sessiontemp.FromContext(ctx); m != nil {
+		return m
+	}
+	return b.sessionTemp
+}
+
+func applyEnvOverrides(env, overrides []string) []string {
+	for _, kv := range overrides {
+		key, value, ok := strings.Cut(kv, "=")
+		if !ok || key == "" {
+			continue
+		}
+		env = setEnvValue(env, key, value)
+	}
+	return env
 }
 
 // appendSessionDataHint appends the session-data guard warning to command

--- a/internal/tool/builtin/bash_session_temp_test.go
+++ b/internal/tool/builtin/bash_session_temp_test.go
@@ -15,45 +15,69 @@ import (
 )
 
 func TestBashSharesSessionTempAcrossCalls(t *testing.T) {
-	m := sessiontemp.NewWithRoot(t.TempDir())
-	m.Retain()
-	defer m.Release()
-
-	work := t.TempDir()
-	b := bash{
-		sb:          sandbox.Spec{Mode: "off"},
-		workDir:     work,
-		sessionTemp: m,
+	type shellCase struct {
+		name  string
+		shell sandbox.Shell
 	}
-
-	marker := "reasonix-session-temp-share"
-	writeCmd := `test "$TMPDIR" = "$TMP" && test "$TMPDIR" = "$TEMP" && printf '%s' shared > "${TMPDIR:?}/` + marker + `"`
+	shells := []shellCase{
+		{name: "default"},
+	}
 	if runtime.GOOS == "windows" {
-		writeCmd = `if (($env:TMPDIR -ne $env:TMP) -or ($env:TMPDIR -ne $env:TEMP)) { throw 'temporary environment variables differ' }; Set-Content -Path (Join-Path $env:TEMP '` + marker + `') -Value 'shared' -NoNewline`
-	}
-	if _, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": writeCmd})); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	readCmd := `cat "${TMPDIR:?}/` + marker + `"`
-	if runtime.GOOS == "windows" {
-		readCmd = `Get-Content -Raw (Join-Path $env:TEMP '` + marker + `')`
-	}
-	out, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": readCmd}))
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if !strings.Contains(out, "shared") {
-		t.Fatalf("second bash call did not see first temp file: %q", out)
+		// The default on Windows prefers Git Bash when installed. Exercise native
+		// PowerShell explicitly as well so both supported shell modes prove the
+		// same session-temp contract.
+		powerShell := sandbox.ResolveShell("powershell", "", nil)
+		if powerShell.Kind != sandbox.ShellPowerShell {
+			t.Fatal("PowerShell is required for the Windows session-temp regression")
+		}
+		shells = append(shells, shellCase{name: "powershell", shell: powerShell})
 	}
 
-	dir := m.Dir()
-	if dir == "" {
-		t.Fatal("manager has no generation after use")
-	}
-	body, err := os.ReadFile(filepath.Join(dir, marker))
-	if err != nil || string(body) != "shared" {
-		t.Fatalf("host private dir content = %q err=%v", body, err)
+	for _, tc := range shells {
+		t.Run(tc.name, func(t *testing.T) {
+			m := sessiontemp.NewWithRoot(t.TempDir())
+			m.Retain()
+			defer m.Release()
+
+			b := bash{
+				sb:          sandbox.Spec{Mode: "off"},
+				shell:       tc.shell,
+				workDir:     t.TempDir(),
+				sessionTemp: m,
+			}
+			// Pin the lazily resolved default so command syntax follows the shell
+			// actually selected, rather than assuming every Windows host uses
+			// PowerShell (Git Bash is preferred when present).
+			b.shell = b.resolved()
+
+			marker := "reasonix-session-temp-share"
+			writeCmd := `test "$TMPDIR" = "$TMP" && test "$TMPDIR" = "$TEMP" && printf '%s' shared > "${TMPDIR:?}/` + marker + `"`
+			readCmd := `cat "${TMPDIR:?}/` + marker + `"`
+			if b.shell.Kind == sandbox.ShellPowerShell {
+				writeCmd = `if (($env:TMPDIR -ne $env:TMP) -or ($env:TMPDIR -ne $env:TEMP)) { throw 'temporary environment variables differ' }; Set-Content -Path (Join-Path $env:TEMP '` + marker + `') -Value 'shared' -NoNewline`
+				readCmd = `Get-Content -Raw (Join-Path $env:TEMP '` + marker + `')`
+			}
+			if _, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": writeCmd})); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			out, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": readCmd}))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if !strings.Contains(out, "shared") {
+				t.Fatalf("second bash call did not see first temp file: %q", out)
+			}
+
+			dir := m.Dir()
+			if dir == "" {
+				t.Fatal("manager has no generation after use")
+			}
+			body, err := os.ReadFile(filepath.Join(dir, marker))
+			if err != nil || string(body) != "shared" {
+				t.Fatalf("host private dir content = %q err=%v", body, err)
+			}
+		})
 	}
 }
 

--- a/internal/tool/builtin/bash_session_temp_test.go
+++ b/internal/tool/builtin/bash_session_temp_test.go
@@ -1,0 +1,144 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+	"reasonix/internal/sessiontemp"
+)
+
+func TestBashSharesSessionTempAcrossCalls(t *testing.T) {
+	m := sessiontemp.NewWithRoot(t.TempDir())
+	m.Retain()
+	defer m.Release()
+
+	work := t.TempDir()
+	b := bash{
+		sb:          sandbox.Spec{Mode: "off"},
+		workDir:     work,
+		sessionTemp: m,
+	}
+
+	marker := "reasonix-session-temp-share"
+	writeCmd := `printf '%s' shared > "$TMPDIR/` + marker + `"`
+	if runtime.GOOS == "windows" {
+		writeCmd = `Set-Content -Path (Join-Path $env:TMPDIR '` + marker + `') -Value 'shared' -NoNewline`
+	}
+	if _, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": writeCmd})); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	readCmd := `cat "$TMPDIR/` + marker + `"`
+	if runtime.GOOS == "windows" {
+		readCmd = `Get-Content -Raw (Join-Path $env:TMPDIR '` + marker + `')`
+	}
+	out, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": readCmd}))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(out, "shared") {
+		t.Fatalf("second bash call did not see first temp file: %q", out)
+	}
+
+	dir := m.Dir()
+	if dir == "" {
+		t.Fatal("manager has no generation after use")
+	}
+	body, err := os.ReadFile(filepath.Join(dir, marker))
+	if err != nil || string(body) != "shared" {
+		t.Fatalf("host private dir content = %q err=%v", body, err)
+	}
+}
+
+func TestBashSchemaUnchangedWithSessionTemp(t *testing.T) {
+	plain := bash{}.Schema()
+	withTemp := bash{sessionTemp: sessiontemp.New()}.Schema()
+	if string(plain) != string(withTemp) {
+		t.Fatalf("session temp must not change bash schema\nplain=%s\nwith=%s", plain, withTemp)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(plain, &schema); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := schema["required"].([]any)
+	if len(req) != 1 || req[0] != "command" {
+		t.Fatalf("required = %v", req)
+	}
+}
+
+func TestBashFailsWhenSessionTempUnavailable(t *testing.T) {
+	// Create-failure path: manager is owned but cannot create the directory.
+	m := sessiontemp.NewWithRoot(t.TempDir())
+	m.Retain()
+	defer m.Release()
+	m.SetMkDirForTest(func(string) (string, error) {
+		return "", os.ErrPermission
+	})
+	b := bash{
+		sb:          sandbox.Spec{Mode: "off"},
+		workDir:     t.TempDir(),
+		sessionTemp: m,
+	}
+	_, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": "true"}))
+	if err == nil {
+		t.Fatal("want command failure when session temp cannot be created")
+	}
+	if !errors.Is(err, sessiontemp.ErrUnavailable) && !strings.Contains(err.Error(), "session temporary") {
+		t.Fatalf("error = %v, want session temporary failure", err)
+	}
+
+	// Sealed manager (last owner released) must fail closed, not fall back.
+	sealed := sessiontemp.NewWithRoot(t.TempDir())
+	sealed.Retain()
+	sealed.Release()
+	b2 := bash{
+		sb:          sandbox.Spec{Mode: "off"},
+		workDir:     t.TempDir(),
+		sessionTemp: sealed,
+	}
+	_, err = b2.Execute(context.Background(), argsJSON(t, map[string]any{"command": "true"}))
+	if err == nil {
+		t.Fatal("want failure against sealed session temp manager")
+	}
+}
+
+func TestBashBackgroundLeaseSurvivesRotate(t *testing.T) {
+	m := sessiontemp.NewWithRoot(t.TempDir())
+	m.Retain()
+	defer m.Release()
+
+	// Pin the old generation with a lease (simulates a running background job).
+	oldLease, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := oldLease.Dir()
+	if err := os.WriteFile(filepath.Join(oldDir, "bg.txt"), []byte("still-here"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m.Rotate()
+	fresh, err := m.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.Dir() == oldDir {
+		t.Fatal("rotate should yield a new generation for new commands")
+	}
+	// Background job's generation remains until its lease is released.
+	if _, err := os.Stat(filepath.Join(oldDir, "bg.txt")); err != nil {
+		t.Fatalf("old generation deleted while background lease held: %v", err)
+	}
+	oldLease.Release()
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatalf("old generation should delete after background lease release: %v", err)
+	}
+	fresh.Release()
+}

--- a/internal/tool/builtin/bash_session_temp_test.go
+++ b/internal/tool/builtin/bash_session_temp_test.go
@@ -27,17 +27,17 @@ func TestBashSharesSessionTempAcrossCalls(t *testing.T) {
 	}
 
 	marker := "reasonix-session-temp-share"
-	writeCmd := `printf '%s' shared > "$TMPDIR/` + marker + `"`
+	writeCmd := `test "$TMPDIR" = "$TMP" && test "$TMPDIR" = "$TEMP" && printf '%s' shared > "${TMPDIR:?}/` + marker + `"`
 	if runtime.GOOS == "windows" {
-		writeCmd = `Set-Content -Path (Join-Path $env:TMPDIR '` + marker + `') -Value 'shared' -NoNewline`
+		writeCmd = `if (($env:TMPDIR -ne $env:TMP) -or ($env:TMPDIR -ne $env:TEMP)) { throw 'temporary environment variables differ' }; Set-Content -Path (Join-Path $env:TEMP '` + marker + `') -Value 'shared' -NoNewline`
 	}
 	if _, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": writeCmd})); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
-	readCmd := `cat "$TMPDIR/` + marker + `"`
+	readCmd := `cat "${TMPDIR:?}/` + marker + `"`
 	if runtime.GOOS == "windows" {
-		readCmd = `Get-Content -Raw (Join-Path $env:TMPDIR '` + marker + `')`
+		readCmd = `Get-Content -Raw (Join-Path $env:TEMP '` + marker + `')`
 	}
 	out, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": readCmd}))
 	if err != nil {

--- a/internal/tool/builtin/clientio.go
+++ b/internal/tool/builtin/clientio.go
@@ -28,6 +28,11 @@ type FileOverlay interface {
 // locally; err is only meaningful when ok is true. Runners are only consulted
 // when the local OS sandbox is not enforcing — a host terminal cannot honor
 // the local confinement configuration.
+//
+// envOverrides, when non-nil, is a small map of environment variables the host
+// terminal should set for the command (typically TMPDIR/TMP/TEMP for the
+// session-private temporary directory). Callers must not pass a full host
+// environment dump — only the overrides Reasonix owns.
 type TerminalRunner interface {
-	RunCommand(ctx context.Context, command, cwd string, timeout time.Duration) (output string, ok bool, err error)
+	RunCommand(ctx context.Context, command, cwd string, timeout time.Duration, envOverrides map[string]string) (output string, ok bool, err error)
 }

--- a/internal/tool/builtin/clientio_test.go
+++ b/internal/tool/builtin/clientio_test.go
@@ -130,7 +130,7 @@ type fakeTerminal struct {
 	called []string
 }
 
-func (f *fakeTerminal) RunCommand(_ context.Context, command, _ string, _ time.Duration) (string, bool, error) {
+func (f *fakeTerminal) RunCommand(_ context.Context, command, _ string, _ time.Duration, _ map[string]string) (string, bool, error) {
 	f.called = append(f.called, command)
 	return f.out, f.ok, f.err
 }

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/netclient"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/tool"
 )
 
@@ -20,6 +21,10 @@ import (
 // each command through the sandbox (see package sandbox). guard appends a
 // warning to command output when the command references Reasonix's own session
 // stores (see SessionDataGuard).
+//
+// Session-private temporary directories are bound separately via
+// BindSessionTemp (or Workspace.SessionTemp) so the timeout variadic form stays
+// stable for existing callers.
 func ConfineBash(spec sandbox.Spec, guard SessionDataGuard, timeout ...time.Duration) tool.Tool {
 	shell := spec.Shell
 	if shell.Path == "" {
@@ -30,6 +35,22 @@ func ConfineBash(spec sandbox.Spec, guard SessionDataGuard, timeout ...time.Dura
 		b.timeout = timeout[0]
 	}
 	return b
+}
+
+// BindSessionTemp attaches a session-private temporary directory manager to a
+// confined bash (and, when present, grep) tool. ok is false when tl is not a
+// bash tool (including wrappers that do not unwrap).
+func BindSessionTemp(tl tool.Tool, m *sessiontemp.Manager) (tool.Tool, bool) {
+	switch t := tl.(type) {
+	case bash:
+		t.sessionTemp = m
+		return t, true
+	case grepTool:
+		t.sessionTemp = m
+		return t, true
+	default:
+		return nil, false
+	}
 }
 
 // RebindBashWriteRoots returns a copy of bash with its complete write surface
@@ -55,6 +76,8 @@ func RebindBashWriteRoots(tl tool.Tool, roots []string) (tool.Tool, bool) {
 	// confinement — the claim roots are the only allowed write surface.
 	spec.AppContainerWriteRoots = append([]string(nil), rs...)
 	b.sb = spec
+	// sessionTemp is preserved: sub-agent write-root rebinding must not drop
+	// the session-private temporary directory manager.
 	return b, true
 }
 

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -20,6 +20,7 @@ import (
 	"reasonix/internal/proc"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/secrets"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/tool"
 )
 
@@ -74,6 +75,7 @@ type grepTool struct {
 	rg          string
 	forbidRoots []string
 	sb          sandbox.Spec
+	sessionTemp *sessiontemp.Manager
 }
 
 func (grepTool) Name() string { return "grep" }
@@ -292,13 +294,26 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 		)
 	}
 	args = append(args, "--regexp", pattern, "--", path)
-	argv, wrapped := sandbox.CommandArgs(g.sb, args)
+
+	var lease *sessiontemp.Lease
+	sessionDir := ""
+	if m := g.sessionTempManager(ctx); m != nil {
+		l, err := m.Acquire()
+		if err != nil {
+			return "", false, fmt.Errorf("session temporary directory: %w", err)
+		}
+		lease = l
+		sessionDir = l.Dir()
+		defer lease.Release()
+	}
+	prepared := sandbox.PrepareArgs(g.sb, args, sessionDir)
+	argv, wrapped := prepared.Argv, prepared.Wrapped
 	if len(g.forbidRoots) > 0 && !wrapped {
 		return "", wrapped, nil
 	}
 
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	cmd.Env = secrets.ProcessEnv()
+	cmd.Env = applyEnvOverrides(secrets.ProcessEnv(), prepared.EnvOverrides)
 	proc.HideWindow(cmd)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -338,6 +353,13 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string, to time.
 		}
 	}
 	return formatGrep(ctx, out, truncated, to), wrapped, nil
+}
+
+func (g grepTool) sessionTempManager(ctx context.Context) *sessiontemp.Manager {
+	if m := sessiontemp.FromContext(ctx); m != nil {
+		return m
+	}
+	return g.sessionTemp
 }
 
 func displayRipgrepLine(line string, rp ResolvedPath) string {
@@ -402,6 +424,8 @@ func ResolveSearch(engine, rgPath string, warn io.Writer) SearchSpec {
 // ConfineSearch returns the grep built-in bound to a resolved search engine,
 // os sandbox spec for the ripgrep subprocess, and forbid-read roots for the
 // native scanner, overriding the native instance registered at init.
+// Session-private temporary directories are bound via BindSessionTemp or
+// Workspace.SessionTemp.
 func ConfineSearch(spec SearchSpec, sb sandbox.Spec, forbidRoots []string) tool.Tool {
 	return grepTool{rg: spec.RgPath, sb: sb, forbidRoots: forbidRoots}
 }

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -8,6 +8,7 @@ import (
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/sandbox"
+	"reasonix/internal/sessiontemp"
 	"reasonix/internal/tool"
 )
 
@@ -45,6 +46,10 @@ type Workspace struct {
 	// sandbox is not enforcing. Both are nil outside host transports like ACP.
 	FileOverlay FileOverlay
 	Terminal    TerminalRunner
+	// SessionTemp is the logical-session private temporary directory manager
+	// shared by bash and ripgrep-backed grep. Nil leaves those tools without a
+	// session-private temp (platform defaults apply).
+	SessionTemp *sessiontemp.Manager
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -70,10 +75,10 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"delete_range":  deleteRange{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"delete_symbol": deleteSymbol{workDir: w.Dir, roots: roots, guard: w.SessionGuard, managed: w.ManagedConfig},
 		"code_index":    codeIndex{workDir: w.Dir, forbidRoots: forbidRoots},
-		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout, guard: w.SessionGuard, terminal: w.Terminal},
+		"bash":          bash{workDir: w.Dir, sb: w.Bash, timeout: w.BashTimeout, guard: w.SessionGuard, terminal: w.Terminal, sessionTemp: w.SessionTemp},
 		"ls":            listDir{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
 		"glob":          globTool{workDir: w.Dir, paths: w.ReadPaths, forbidRoots: forbidRoots},
-		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash},
+		"grep":          grepTool{workDir: w.Dir, paths: w.ReadPaths, rg: w.Search.RgPath, forbidRoots: forbidRoots, sb: w.Bash, sessionTemp: w.SessionTemp},
 		"web_fetch":     webFetch{proxySpec: w.ProxySpec},
 	}
 	all := tool.Builtins()


### PR DESCRIPTION
## Summary

- Keep Bash temporary files available across commands within one logical session while preserving per-command OS sandboxing.
- Mount a private session directory at `/tmp` for Linux bubblewrap and propagate `TMPDIR`/`TMP`/`TEMP` on macOS, Windows, and ACP terminals.
- Rotate and clean temporary generations safely across session changes, background work, controller rebuilds, and sub-agent runs.

## Issues

Refs #7575

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `go test -race ./internal/sessiontemp ./internal/filelock`
- CLI hot-rebuild regression for `/model`, `/effort`, and `/reload`
- Windows CI regression exercises both the selected default shell and native PowerShell
- Ubuntu 24.04 ARM64 Parallels VM with real bubblewrap: two independent invocations share literal `/tmp`; rotation hides the old generation; the host `/tmp` sentinel stays hidden; no-SessionTemp sandboxes retain an isolated tmpfs
- `git diff --check`

## Documentation impact

Documentation-impact: updated - documented session-private temporary directories, zero-configuration behavior, and platform-specific `/tmp` usage in both English and Chinese guides.

## Cache impact

Cache-impact: none - provider-visible prompts, tool names, schemas, descriptions, and ordering are unchanged.
Cache-guard: `TestBashSchemaUnchangedWithSessionTemp`
System-prompt-review: Author-side review completed by the PR submitter; the touched agent and boot paths only wire SessionTemp lifecycle and do not alter prompt text or composition.
