### PR TITLE
test: cover previously untested pure helpers

### DIFF
--- a/internal/event/fanout_test.go
+++ b/internal/event/fanout_test.go
@@ -1,0 +1,68 @@
+package event
+
+import (
+	"reflect"
+	"testing"
+)
+
+// recordingSink captures every event it receives, in order, for assertions.
+type recordingSink struct {
+	events []Event
+}
+
+func (r *recordingSink) Emit(e Event) {
+	r.events = append(r.events, e)
+}
+
+func TestFanOutLen(t *testing.T) {
+	if got := NewFanOut().Len(); got != 0 {
+		t.Errorf("Len() with no sinks = %d, want 0", got)
+	}
+	if got := NewFanOut(&recordingSink{}, &recordingSink{}).Len(); got != 2 {
+		t.Errorf("Len() with two sinks = %d, want 2", got)
+	}
+	// Nil sinks still count as registered.
+	if got := NewFanOut(nil, nil).Len(); got != 2 {
+		t.Errorf("Len() with two nil sinks = %d, want 2", got)
+	}
+}
+
+func TestFanOutZeroSinksIsNoop(t *testing.T) {
+	// Emitting to a fan-out with no registered sinks must not panic.
+	NewFanOut().Emit(Event{Kind: Text, Text: "hello"})
+}
+
+func TestFanOutSkipsNilSinks(t *testing.T) {
+	rec := &recordingSink{}
+	f := NewFanOut(nil, rec, nil)
+	f.Emit(Event{Kind: Text, Text: "hello"})
+	if len(rec.events) != 1 {
+		t.Fatalf("sink received %d events, want 1 (nil sinks skipped)", len(rec.events))
+	}
+	if got := rec.events[0]; got.Kind != Text || got.Text != "hello" {
+		t.Errorf("event = %+v, want Text/hello", got)
+	}
+}
+
+func TestFanOutDeliversToEverySinkInOrder(t *testing.T) {
+	first, second := &recordingSink{}, &recordingSink{}
+	f := NewFanOut(first, second)
+
+	events := []Event{
+		{Kind: TurnStarted},
+		{Kind: Text, Text: "first"},
+		{Kind: ToolDispatch, Tool: Tool{Name: "bash"}},
+		{Kind: ToolResult, Tool: Tool{Output: "ok"}},
+		{Kind: TurnDone},
+	}
+	for _, e := range events {
+		f.Emit(e)
+	}
+
+	if !reflect.DeepEqual(first.events, events) {
+		t.Errorf("first sink got %+v, want %+v", first.events, events)
+	}
+	if !reflect.DeepEqual(second.events, events) {
+		t.Errorf("second sink got %+v, want %+v", second.events, events)
+	}
+}

--- a/internal/fileref/pathsegment_test.go
+++ b/internal/fileref/pathsegment_test.go
@@ -1,0 +1,29 @@
+package fileref
+
+import "testing"
+
+// TestPathSegmentContains covers the slash-separated path-segment matcher
+// behind Search's fallback tier. The path is case-folded per segment; the
+// query is expected to arrive already lowercased (Search lowercases it).
+func TestPathSegmentContains(t *testing.T) {
+	for _, tc := range []struct {
+		rel   string
+		query string
+		want  bool
+	}{
+		{rel: "src/planind/index.tsx", query: "planind", want: true},
+		{rel: "src/planind/index.tsx", query: "src", want: true},       // first segment
+		{rel: "src/planind/index.tsx", query: "index", want: true},     // last segment (basename)
+		{rel: "src/planind/index.tsx", query: "plan", want: true},      // substring within a segment
+		{rel: "Src/PlanInd/Index.tsx", query: "planind", want: true},   // path is case-folded
+		{rel: "src/planind/index.tsx", query: "zzz", want: false},      // no segment matches
+		{rel: "src/planind/index.tsx", query: "SRC", want: false},      // query must be pre-lowercased
+		{rel: "src/planind/index.tsx", query: "src/plan", want: false}, // never spans segments
+		{rel: "src/x", query: "", want: true},                          // empty query matches any segment
+		{rel: "", query: "", want: true},
+	} {
+		if got := pathSegmentContains(tc.rel, tc.query); got != tc.want {
+			t.Errorf("pathSegmentContains(%q, %q) = %v, want %v", tc.rel, tc.query, got, tc.want)
+		}
+	}
+}

--- a/internal/goaleval/parseverdict_test.go
+++ b/internal/goaleval/parseverdict_test.go
@@ -1,0 +1,124 @@
+package goaleval
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestParseVerdict covers extracting the {…} JSON object from a model
+// response (tolerating code fences and prose wrappers) and validating the
+// outcome enum. Every error is fail-closed: the host pauses the goal.
+func TestParseVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		text    string
+		want    Verdict
+		wantErr string // substring of the expected error; "" means success
+	}{
+		{name: "empty", text: "", wantErr: "empty goal evaluator response"},
+		{name: "whitespace only", text: "  \n\t ", wantErr: "empty goal evaluator response"},
+		{name: "pure json", text: `{"outcome":"complete","reason":"the goal is done"}`, want: Verdict{Outcome: OutcomeComplete, Reason: "the goal is done"}},
+		{name: "fenced json", text: "```json\n{\"outcome\":\"continue\",\"reason\":\"more work\"}\n```", want: Verdict{Outcome: OutcomeContinue, Reason: "more work"}},
+		{name: "prose wrapped", text: "Here is my judgment: {\"outcome\":\"blocked\",\"reason\":\"needs user input\"}", want: Verdict{Outcome: OutcomeBlocked, Reason: "needs user input"}},
+		{name: "prose before and after", text: "Sure: {\"outcome\":\"uncertain\",\"reason\":\"cannot judge\"} done.", want: Verdict{Outcome: OutcomeUncertain, Reason: "cannot judge"}},
+		{name: "malformed json", text: "{not json", wantErr: "invalid goal evaluator JSON"},
+		{name: "no json object", text: "no json here", wantErr: "invalid goal evaluator JSON"},
+		{name: "missing outcome", text: `{"reason":"x"}`, wantErr: "invalid outcome"},
+		{name: "invalid outcome", text: `{"outcome":"maybe","reason":"x"}`, wantErr: "invalid outcome"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseVerdict(tc.text)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseVerdict(%q) error = nil, want error containing %q", tc.text, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("parseVerdict(%q) error = %v, want containing %q", tc.text, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseVerdict(%q) error = %v", tc.text, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseVerdict(%q) = %+v, want %+v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseVerdictClipsReason(t *testing.T) {
+	long := strings.Repeat("x", MaxReasonBytes+200)
+	got, err := parseVerdict(`{"outcome":"complete","reason":"` + long + `"}`)
+	if err != nil {
+		t.Fatalf("parseVerdict() error = %v", err)
+	}
+	if len(got.Reason) != MaxReasonBytes {
+		t.Errorf("reason length = %d, want %d", len(got.Reason), MaxReasonBytes)
+	}
+	if got.Reason != strings.Repeat("x", MaxReasonBytes) {
+		t.Errorf("reason = prefix mismatch, want %d x's", MaxReasonBytes)
+	}
+}
+
+func TestParseVerdictClipsReasonAtRuneBoundary(t *testing.T) {
+	reason := strings.Repeat("é", MaxReasonBytes) // 2 bytes per rune → 1000 bytes
+	got, err := parseVerdict(`{"outcome":"continue","reason":"` + reason + `"}`)
+	if err != nil {
+		t.Fatalf("parseVerdict() error = %v", err)
+	}
+	if len(got.Reason) > MaxReasonBytes {
+		t.Errorf("reason length = %d, want <= %d", len(got.Reason), MaxReasonBytes)
+	}
+	if !utf8.ValidString(got.Reason) {
+		t.Errorf("clipped reason is not valid UTF-8: %q", got.Reason)
+	}
+	if got.Reason != strings.Repeat("é", MaxReasonBytes/2) {
+		t.Errorf("clipped reason = %d runes, want %d", utf8.RuneCountInString(got.Reason), MaxReasonBytes/2)
+	}
+}
+
+func TestClip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{name: "empty", in: "", max: 10, want: ""},
+		{name: "under budget", in: "hello", max: 10, want: "hello"},
+		{name: "exact fit", in: "hello", max: 5, want: "hello"},
+		{name: "truncates ascii", in: "hello world", max: 5, want: "hello"},
+		{name: "zero budget", in: "hello", max: 0, want: ""},
+		{name: "cut lands after multi-byte rune", in: "héllo", max: 3, want: "hé"},
+		{name: "cut splits multi-byte rune", in: "héllo", max: 2, want: "h"},
+		{name: "all multi-byte", in: "日本語", max: 5, want: "日"},
+		{name: "all multi-byte exact", in: "日本語", max: 6, want: "日本"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clip(tc.in, tc.max); got != tc.want {
+				t.Errorf("clip(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUTF8RuneStart(t *testing.T) {
+	for _, tc := range []struct {
+		b    byte
+		want bool
+	}{
+		{b: 'a', want: true},
+		{b: 0xC3, want: true}, // 2-byte lead byte
+		{b: 0xE2, want: true}, // 3-byte lead byte
+		{b: 0xF0, want: true}, // 4-byte lead byte
+		{b: 0x80, want: false},
+		{b: 0xA9, want: false},
+		{b: 0xBF, want: false},
+	} {
+		if got := utf8RuneStart(tc.b); got != tc.want {
+			t.Errorf("utf8RuneStart(%#x) = %v, want %v", tc.b, got, tc.want)
+		}
+	}
+}

--- a/internal/history/strip_test.go
+++ b/internal/history/strip_test.go
@@ -1,0 +1,38 @@
+package history
+
+import "testing"
+
+// TestStripComposePrefixes covers the compose-block stripper used before
+// indexing/rendering user messages: <memory-update>, <background-jobs>,
+// <active-goal>, and <hook-context> blocks are removed from the start of the
+// content (repeatedly, for stacked blocks), and anything after a leading
+// "[Plan mode ...]" marker is kept.
+func TestStripComposePrefixes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "plain text", in: "hello world", want: "hello world"},
+		{name: "plain text with whitespace", in: "  hello world\n", want: "hello world"},
+		{name: "memory-update block", in: "<memory-update>\ncontext\n</memory-update>\nreal content", want: "real content"},
+		{name: "background-jobs block", in: "<background-jobs>\njob list\n</background-jobs>\nreal content", want: "real content"},
+		{name: "active-goal block", in: "<active-goal>\ngoal\n</active-goal>\nreal content", want: "real content"},
+		{name: "hook-context block", in: "<hook-context>\nctx\n</hook-context>\nreal content", want: "real content"},
+		{name: "block with attributes", in: "<memory-update id=\"42\">\nctx\n</memory-update>\nreal content", want: "real content"},
+		{name: "single-line block", in: "<memory-update>x</memory-update>\nreal", want: "real"},
+		{name: "multiple stacked blocks", in: "<memory-update>\na\n</memory-update>\n<background-jobs>\nb\n</background-jobs>\nreal content", want: "real content"},
+		{name: "plan mode marker", in: "[Plan mode] real content", want: "real content"},
+		{name: "plan mode marker with label", in: "[Plan mode: active] plan notes", want: "plan notes"},
+		{name: "blocks then plan mode marker", in: "<memory-update>\nctx\n</memory-update>\n[Plan mode] real content", want: "real content"},
+		{name: "leftover after marker", in: "[Plan mode]\n\n  leftover here  ", want: "leftover here"},
+		{name: "non-prefix block is kept", in: "intro <memory-update>x</memory-update>\nreal", want: "intro <memory-update>x</memory-update>\nreal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripComposePrefixes(tc.in); got != tc.want {
+				t.Errorf("stripComposePrefixes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/outputstyle/isFalse_test.go
+++ b/internal/outputstyle/isFalse_test.go
@@ -1,0 +1,46 @@
+package outputstyle
+
+import "testing"
+
+// TestIsFalse covers the boolean-string parser used for
+// keep-coding-instructions frontmatter: false/no/0/off are falsy,
+// case-insensitively and with surrounding whitespace tolerated.
+func TestIsFalse(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		// Falsy spellings.
+		{in: "false", want: true},
+		{in: "no", want: true},
+		{in: "0", want: true},
+		{in: "off", want: true},
+		// Case-insensitive.
+		{in: "FALSE", want: true},
+		{in: "No", want: true},
+		{in: "Off", want: true},
+		{in: "fAlSe", want: true},
+		// Surrounding whitespace is trimmed.
+		{in: "  false  ", want: true},
+		{in: "\tno\n", want: true},
+		{in: " 0 ", want: true},
+		// Truthy spellings are not false.
+		{in: "true", want: false},
+		{in: "yes", want: false},
+		{in: "1", want: false},
+		{in: "on", want: false},
+		{in: "TRUE", want: false},
+		{in: " ON ", want: false},
+		// Empty and unknown values are not false (keep the default).
+		{in: "", want: false},
+		{in: "   ", want: false},
+		{in: "maybe", want: false},
+		{in: "falsey", want: false},
+		{in: "0.0", want: false},
+		{in: "nope", want: false},
+	} {
+		if got := isFalse(tc.in); got != tc.want {
+			t.Errorf("isFalse(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add unit tests for 5 previously untested pure helpers across `internal/` packages (verified: zero references in any `_test.go` before this PR):

| Package | Helper | Tests |
|---|---|---|
| `internal/outputstyle` | `isFalse` (bool-string parser) | 23 cases — all falsy spellings (`false`/`no`/`0`/`off`), case/whitespace variants, truthy + empty/unknown values |
| `internal/event` | `NewFanOut` / `FanOut.Emit` / `FanOut.Len` | 4 tests — zero sinks no-op, nil-sink skipping, delivery order to multiple sinks, Len |
| `internal/history` | `stripComposePrefixes` | 15 subtests — each compose block type, attributes, stacked blocks, plan-mode markers, leftover text |
| `internal/goaleval` | `parseVerdict` + `clip` + `utf8RuneStart` | 10 + 4 subtests — empty/pure/fenced/prose-wrapped JSON, malformed JSON, invalid outcome, UTF-8 rune-boundary clipping |
| `internal/fileref` | `pathSegmentContains` | 10 cases — segment matching, case folding, empty query, first/last segment |

Unexported helpers use internal test packages (`package <pkg>`), matching each package's existing test style.

## Issues

None — coverage gap, no issue report.

## Verification

- `go test ./internal/outputstyle/ ./internal/event/ ./internal/history/ ./internal/goaleval/ ./internal/fileref/` — all pass
- `gofmt -l internal/` — clean
- `go vet` on all 5 packages — clean

## Documentation impact

Documentation-impact: none - test-only addition; no user-visible behavior or docs affected.

## Cache impact

Cache-impact: low - test-only addition to internal/outputstyle (a listed cache-sensitive path) plus 4 non-sensitive packages; no production prompt/tool surface or serialization changed.
Cache-guard: `go test ./internal/outputstyle/` passes; production outputstyle.go untouched so existing guard behavior is unaffected.
System-prompt-review: innocarpe (author) - test-only addition, no system-prompt behavior change; production outputstyle.go untouched.
