### PR TITLE
ci: make docs-impact coverage explicit and fix stale-sweep scheduled dry-run

### DIFF
--- a/.github/workflows/stale-report-sweep.yml
+++ b/.github/workflows/stale-report-sweep.yml
@@ -57,7 +57,9 @@ jobs:
           # Posting stays off until this repository variable is set to "true", so
           # merging the sweeper cannot start commenting on its own.
           ENABLED: ${{ vars.STALE_SWEEP_ENABLED }}
-          REQUESTED_DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          # Manual dispatch dry-runs by default (the input default above); only
+          # scheduled runs act for real, and only once ENABLED is "true".
+          REQUESTED_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           set -euo pipefail
           args=(--limit "$LIMIT")

--- a/scripts/check-docs-impact.sh
+++ b/scripts/check-docs-impact.sh
@@ -31,7 +31,11 @@ docs_changed=()
 while IFS= read -r file; do
 	[ -z "$file" ] && continue
 	case "$file" in
-		docs/*.md) docs_changed+=("$file") ;;
+		docs/*.md|\
+		docs/*/*.md|\
+		docs/*/*/*.md|\
+		docs/*/*/*/*.md|\
+		docs/*/*/*/*/*.md) docs_changed+=("$file") ;;
 	esac
 	case "$file" in
 		*_test.go|*.test.*|*.spec.*|*/__tests__/*|*/go.mod|*/go.sum|go.mod|go.sum|*/pnpm-lock.yaml|*/package-lock.json)
@@ -41,6 +45,12 @@ while IFS= read -r file; do
 	case "$file" in
 		cmd/reasonix/*|\
 		desktop/*|\
+		desktop/frontend/*|\
+		desktop/frontend/src/*|\
+		desktop/frontend/src/*/*|\
+		desktop/frontend/src/*/*/*|\
+		desktop/frontend/src/*/*/*/*|\
+		desktop/frontend/src/*/*/*/*/*|\
 		internal/agent/*|\
 		internal/boot/*|\
 		internal/cli/*|\

--- a/scripts/check-docs-impact.test.sh
+++ b/scripts/check-docs-impact.test.sh
@@ -7,6 +7,16 @@ check="$repo_root/scripts/check-docs-impact.sh"
 PR_BODY='Documentation-impact: updated - documented the new command' \
 	"$check" internal/cli/cli.go docs/CLI.md >/dev/null
 
+# Nested docs (any depth under docs/) count as a docs change.
+PR_BODY='Documentation-impact: updated - documented the nested design spec' \
+	"$check" internal/cli/cli.go docs/superpowers/specs/2026-06-29-autoresearch-runtime-design.md >/dev/null
+
+if PR_BODY='Documentation-impact: none - no docs changed' \
+	"$check" internal/cli/cli.go docs/superpowers/specs/2026-06-29-autoresearch-runtime-design.md >/dev/null 2>&1; then
+	echo "none declaration with a nested docs change unexpectedly passed" >&2
+	exit 1
+fi
+
 PR_BODY='Documentation-impact: none - internal behavior keeps the existing contract' \
 	"$check" internal/boot/boot.go >/dev/null
 
@@ -25,6 +35,15 @@ fi
 
 if PR_BODY='Documentation-impact: none' "$check" internal/cli/cli.go >/dev/null 2>&1; then
 	echo "empty none rationale unexpectedly passed" >&2
+	exit 1
+fi
+
+# desktop/frontend/src changes are user-visible and need a declaration.
+PR_BODY='Documentation-impact: none - no user-facing copy changed' \
+	"$check" desktop/frontend/src/components/editors/HljsCode.tsx >/dev/null
+
+if PR_BODY='' "$check" desktop/frontend/src/components/editors/HljsCode.tsx >/dev/null 2>&1; then
+	echo "frontend src change without a documentation declaration unexpectedly passed" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two CI guard fixes:

1. **`scripts/check-docs-impact.sh`** — audit finding: bash `case` patterns match `/` with `*`, so the existing `docs/*.md` and `desktop/*` patterns already covered nested docs (`docs/superpowers/specs/...`) and `desktop/frontend/src/**`. The patterns worked but were not explicit about it. This PR spells out the coverage (`docs/*.md|docs/*/*.md|...` and src-prefixed frontend patterns) and adds regression tests for nested-docs and frontend-src classification in `scripts/check-docs-impact.test.sh`. Behavior-preserving, verified case-for-case.

2. **`.github/workflows/stale-report-sweep.yml`** — real bug: `github.event.inputs` is empty on `schedule` events, so `${{ github.event.inputs.dry_run || 'true' }}` forced **every scheduled sweep into dry-run**, making the weekly "asks, waits, then closes" automation a permanent no-op even after `STALE_SWEEP_ENABLED` is set (the `ENABLED` gate was dead). Fixed to `|| 'false'` with an explanatory comment. Manual dispatch still dry-runs by default (input default `true`), and with `STALE_SWEEP_ENABLED` currently unset there is no behavior change today.

## Issues

None — found during a scripts/workflows audit, no issue report.

## Verification

- `bash -n` on both scripts — pass
- `scripts/check-docs-impact.test.sh` suite — pass (new cases included); exhaustive scan: 57/57 tracked docs `.md` files at all depths classified correctly, 222/222 non-test `desktop/frontend/src` files classified as user-visible
- stale-report-sweep evidence: workflow description says "asks, waits, then closes"; run history shows only dry-runs; the ask-marker search finds 0 posts ever

## Documentation impact

Documentation-impact: none - CI guard scripts and a scheduled workflow; no user-visible docs affected.

## Cache impact

Cache-impact: none - CI-only changes; `scripts/check-docs-impact.sh` and `stale-report-sweep.yml` are not cache-sensitive paths (not listed in `scripts/check-cache-impact.sh`); no prompt/tool surface touched.
Cache-guard: N/A - no prompt/tool or serialization change.
System-prompt-review: N/A
