### PR TITLE
test: cover underRoot and DescribeList

### DIFF
--- a/internal/history/underroot_test.go
+++ b/internal/history/underroot_test.go
@@ -1,0 +1,40 @@
+package history
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestUnderRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	parent := filepath.Dir(root)
+
+	tests := []struct {
+		name string
+		path string
+		root string
+		want bool
+	}{
+		{"empty path", "", root, false},
+		{"empty root", filepath.Join(root, "a.jsonl"), "", false},
+		{"direct child", filepath.Join(root, "a.jsonl"), root, true},
+		{"nested descendant", filepath.Join(root, "sub", "deep", "a.jsonl"), root, true},
+		{"equal to root", root, root, true},
+		{"root with trailing separator", filepath.Join(root, "a.jsonl"), root + string(filepath.Separator), true},
+		{"sibling", filepath.Join(parent, "sessions2", "a.jsonl"), root, false},
+		{"parent directory", parent, root, false},
+		{"leading .. escape", filepath.Join(root, "..", "a.jsonl"), root, false},
+		{"trailing .. resolves to root", filepath.Join(root, "sub", ".."), root, true},
+		{"middle .. stays under root", filepath.Join(root, "a", "..", "b.jsonl"), root, true},
+		{"middle .. escapes", filepath.Join(root, "..", "x", "a.jsonl"), root, false},
+		{"relative path under relative root", filepath.Join("rel-root", "a.jsonl"), "rel-root", true},
+		{"relative path escaping relative root", filepath.Join("rel-root", "..", "a.jsonl"), "rel-root", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := underRoot(tt.path, tt.root); got != tt.want {
+				t.Errorf("underRoot(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/outputstyle/describelist_test.go
+++ b/internal/outputstyle/describelist_test.go
@@ -1,0 +1,61 @@
+package outputstyle
+
+import (
+	"testing"
+)
+
+func TestDescribeList(t *testing.T) {
+	style := func(name, desc string, builtin bool) OutputStyle {
+		return OutputStyle{Name: name, Description: desc, Builtin: builtin}
+	}
+
+	tests := []struct {
+		name   string
+		styles []OutputStyle
+		active string
+		want   string
+	}{
+		{
+			name: "empty list",
+			want: "",
+		},
+		{
+			name:   "single builtin",
+			styles: []OutputStyle{style("explanatory", "Explain choices", true)},
+			want:   "  explanatory (builtin) — Explain choices",
+		},
+		{
+			name: "multiple items no trailing newline",
+			styles: []OutputStyle{
+				style("concise", "Terse replies", true),
+				style("pirate", "Arrr", false),
+			},
+			want: "  concise (builtin) — Terse replies\n  pirate (custom) — Arrr",
+		},
+		{
+			name:   "active item marked with asterisk",
+			styles: []OutputStyle{style("learning", "Learn", true), style("pirate", "Arrr", false)},
+			active: "learning",
+			want:   "* learning (builtin) — Learn\n  pirate (custom) — Arrr",
+		},
+		{
+			name:   "active match is case-insensitive",
+			styles: []OutputStyle{style("concise", "Terse", true)},
+			active: "CONCISE",
+			want:   "* concise (builtin) — Terse",
+		},
+		{
+			name:   "empty description",
+			styles: []OutputStyle{style("ghost", "", false)},
+			active: "ghost",
+			want:   "* ghost (custom) — ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DescribeList(tt.styles, tt.active); got != tt.want {
+				t.Errorf("DescribeList() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add unit tests for two more untested helpers:

- **`underRoot`** (`internal/history/search.go:563`, unexported → `package history`) — 14 table-driven cases: direct child/nested/equal-to-root, root trailing separator, sibling, `..` escapes (leading/trailing/middle), relative root/path pairs, empty paths. Uses `t.TempDir()` + `filepath.Join` (portable, cwd-independent).
- **`DescribeList`** (`internal/outputstyle/outputstyle.go:187`, unexported → `package outputstyle`) — 6 cases locking the `— ` separator, `(builtin)`/`(custom)` scope labels, `* ` active marker, case-insensitive active match, and no-trailing-newline behavior (currently dead code — behavior lock).

## Issues

None — coverage gap, no issue report.

## Verification

- `go test ./internal/history/ ./internal/outputstyle/` — pass
- `go vet ./internal/history/ ./internal/outputstyle/` — clean
- `gofmt -l internal/history/ internal/outputstyle/` — clean

## Documentation impact

Documentation-impact: none - test-only addition; no user-visible behavior or docs affected.

## Cache impact

Cache-impact: none - test-only additions; `internal/outputstyle/*` is a listed cache-sensitive path but only `_test.go` files are added (production untouched, verified).
Cache-guard: `go test ./internal/outputstyle/` passes; production outputstyle.go untouched.
System-prompt-review: innocarpe (author) - test-only addition, no system-prompt behavior change; production outputstyle.go untouched.
