### PR TITLE
fix(frontend): add custom provider name placeholder text

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2575,7 +2575,7 @@ export const en = {
   "settings.addProvider.resetPreset": "Reset to preset",
   "settings.addProvider.confirmResetPreset": "Confirm reset",
   "settings.customProviderName": "Custom provider name",
-  "settings.customProviderNamePlaceholder": "",
+  "settings.customProviderNamePlaceholder": "e.g. my-proxy",
   "settings.providerNamePlaceholder": "Provider name (e.g. deepseek-proxy)",
   "settings.providerProtocol": "Connection protocol",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1761,7 +1761,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.resetPreset": "重設為預設",
   "settings.addProvider.confirmResetPreset": "確認重設",
   "settings.customProviderName": "自訂供應商名稱",
-  "settings.customProviderNamePlaceholder": "",
+  "settings.customProviderNamePlaceholder": "例如 my-proxy",
   "settings.providerNamePlaceholder": "供應商名稱（如 deepseek-proxy）",
   "settings.providerProtocol": "接入協定",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2578,7 +2578,7 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.resetPreset": "重置为预设",
   "settings.addProvider.confirmResetPreset": "确认重置",
   "settings.customProviderName": "自定义供应商名称",
-  "settings.customProviderNamePlaceholder": "",
+  "settings.customProviderNamePlaceholder": "例如 my-proxy",
   "settings.providerNamePlaceholder": "供应商名称（如 deepseek-proxy）",
   "settings.providerProtocol": "接入协议",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",


### PR DESCRIPTION
## Summary

`settings.customProviderNamePlaceholder` was an **empty string in all three locales** (`en.ts:2578`, `zh.ts:2581`, `zh-TW.ts:1764`), used as the input placeholder at `SettingsPanel.tsx:6509` — `translate()` only falls back on null/undefined, so no placeholder text rendered in any language.

Add values matching the surrounding settings copy style:
- en: `"e.g. my-proxy"` (matches `settings.providerNamePlaceholder` "Provider name (e.g. deepseek-proxy)" and `settings.providerChatUrlPlaceholder`)
- zh: `"例如 my-proxy"` · zh-TW: `"例如 my-proxy"`

Audit confirmed no other `settings.*Placeholder` key is empty — diff stays at 3 lines.

## Issues

None — audit finding, no issue report.

## Verification

- `tsc --noEmit` — clean (locale files are typed `Record<DictKey, string>`)

## Documentation impact

Documentation-impact: none - placeholder copy only; no docs affected.

## Cache impact

Cache-impact: none - desktop frontend locales only; not a cache-sensitive path (only `desktop/session_prompt.go` is listed in `scripts/check-cache-impact.sh`).
Cache-guard: N/A - no prompt/tool or serialization change.
System-prompt-review: N/A
