### PR TITLE
fix(desktop): cut idle CPU from tab-status animation and runtime polling

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1359,12 +1359,13 @@ export default function App() {
       await refreshBackgroundRuntimes();
     };
     void refresh();
-    const timer = window.setInterval(() => void refresh(), 1000);
+    const active = state.running || backgroundRuntimes.length > 0;
+    const timer = window.setInterval(() => void refresh(), active ? 1000 : 15000);
     return () => {
       disposed = true;
       window.clearInterval(timer);
     };
-  }, [refreshBackgroundRuntimes]);
+  }, [backgroundRuntimes.length, refreshBackgroundRuntimes, state.running]);
 
   useEffect(() => {
     if (!activeTabId || !state.running) {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -23113,10 +23113,10 @@ body > .mermaid-diagram--fullscreen {
 
 .tabbar__tab--active .tabbar__status {
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--project-accent, var(--accent)) 18%, transparent);
-  animation: tab-status-breathe 2.6s ease-in-out infinite;
 }
 
-.tabbar__status--running {
+.tabbar__status--running,
+.tabbar__tab--active .tabbar__status--running {
   box-shadow: 0 0 0 5px color-mix(in srgb, var(--project-accent, var(--accent)) 24%, transparent);
   animation: tab-status-breathe-running 1.8s ease-in-out infinite;
 }
@@ -23128,15 +23128,6 @@ body > .mermaid-diagram--fullscreen {
 
 .tabbar__tab--active .tabbar__file-icon {
   color: var(--fg-dim);
-}
-
-@keyframes tab-status-breathe {
-  0%, 100% {
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--project-accent, var(--accent)) 16%, transparent);
-  }
-  50% {
-    box-shadow: 0 0 0 6px color-mix(in srgb, var(--project-accent, var(--accent)) 24%, transparent);
-  }
 }
 
 @keyframes tab-status-breathe-running {


### PR DESCRIPTION
Closes #7619.

## Background

The desktop frontend did two things every second whether or not anything was happening, and one thing it did *always* even when idle. On a Windows WebView2 build both show up as sustained idle CPU (~35% of one core in the report).

1. **The active tab's status dot breathed forever.** `.tabbar__tab--active .tabbar__status` ran an infinite `box-shadow` animation (`tab-status-breathe 2.6s ease-in-out infinite`) at all times. Box-shadow repaints are among the most expensive a WebView2 compositor can do, and this one had no reason to run when no task was active — the dot's accent color and a static ring already identify the active tab.

2. **The background-runtimes list was polled every second, unconditionally.** The `useEffect` in `App.tsx` called `app.BackgroundRuntimes()` on a fixed 1000 ms timer regardless of activity — a bridge round-trip that wakes the Go side and re-renders the status bar even when the app is doing nothing.

## What this PR does

- **Animation:** the active (idle) tab's status dot is now a static ring. The breathe animation runs only for tabs whose task is actually running (`--running`), including the active running tab. The now-unused `@keyframes tab-status-breathe` is removed.
- **Polling:** the background-runtimes timer polls at 1 s while a task is running or a background runtime is attached, and falls back to 15 s at idle. The initial refresh still runs immediately, and the timer self-corrects as soon as the app becomes busy again, so the recovery/background indicator never goes stale — it just stops waking the backend when there is nothing to report.

Both changes are pure idle-time reduction: nothing about the running or streaming path changes.

## Verification

- `pnpm typecheck` — no new errors
- `pnpm lint:hooks` — clean
- `node scripts/check-css-syntax.mjs` / `check-z-index-tokens.mjs` — pass

Documentation-impact: none - a CSS animation cadence and a polling interval, no behavior described in the docs changes.
