### PR TITLE
fix(cli): slash catalog cache and input key contracts / 斜杠补全缓存与输入快捷键契约

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1376,6 +1376,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, pasteClipboardText())
 			return m, finalize(m, cmds)
 		}
+		// Shift+Tab encodings are recognized via modeToggleKey so both
+		// "shift+tab" and CSI-Z "backtab" stay covered by one helper (#6660).
+		if modeToggleKey(msg.String()) {
+			// Shift+Tab toggles Plan only. Tool approval stays on its own
+			// axis: Ask/Auto are explicit choices; YOLO is Ctrl+Y.
+			m.cycleMode()
+			return m, nil
+		}
 		switch msg.String() {
 		case "esc":
 			// "Back out" of the most specific in-progress state: un-send a just-sent
@@ -1518,13 +1526,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+b":
 			m.toggleShellOutput()
 			return m, finalize(m, cmds)
-		case "shift+tab", "backtab":
-			// Shift+Tab toggles Plan only. Some terminals encode it as
-			// "backtab" (CSI Z) rather than "shift+tab" (#6660).
-			// Tool approval stays on its own axis: Ask/Auto are explicit
-			// choices, and YOLO is a separate Ctrl+Y toggle.
-			m.cycleMode()
-			return m, nil
 		case "enter":
 			if m.state == tuiRunning {
 				line := strings.TrimSpace(m.input.Value())
@@ -1736,8 +1737,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.label = msg.label
 			m.commands = msg.commands
 			m.skills = msg.skills
-			m.invalidateSlashCatalog()
-			m.host = msg.host
+			m.setHostAndInvalidateSlashCatalog(msg.host)
 			m.modelRef = msg.ref
 			if msg.profile != "" {
 				m.runtimeProfile = msg.profile
@@ -3908,6 +3908,18 @@ func (m *chatTUI) growInputToFit() {
 	}
 }
 
+// modeToggleKey reports whether s is a recognized Shift+Tab encoding for the
+// plan/approval mode cycle. Terminals may emit either "shift+tab" or CSI-Z
+// "backtab" (#6660); both must hit cycleMode.
+func modeToggleKey(s string) bool {
+	switch s {
+	case "shift+tab", "backtab":
+		return true
+	default:
+		return false
+	}
+}
+
 // cycleMode handles the Shift+Tab gesture using the same three safe modes users
 // see in Claude Code: Ask → Auto → Plan → Ask. YOLO stays outside this cycle and
 // remains an explicit Ctrl+Y choice.
@@ -4358,9 +4370,9 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.chooser = newChooser(e.Ask)
 
 	case event.MCPSurfaceReady:
-		if m.ctrl != nil {
-			m.host = m.ctrl.Host()
-		}
+		// Prompts/resources may have arrived after connect; refresh host and
+		// drop the slash catalog so /prompt names reappear without a restart.
+		m.refreshHostAndInvalidateSlashCatalog()
 		m.refreshMCPManager()
 
 	case event.TurnDone:
@@ -5013,6 +5025,7 @@ func (m *chatTUI) runMCPSubcommand(input string) {
 			m.notice("mcp add: " + err.Error())
 			return
 		}
+		m.refreshHostAndInvalidateSlashCatalog()
 		m.notice(fmt.Sprintf("connected %s — %d tools, saved to global config (available next message)", entry.Name, n))
 	case "connect":
 		if len(args) < 3 {
@@ -5024,7 +5037,7 @@ func (m *chatTUI) runMCPSubcommand(input string) {
 			m.notice("mcp connect: " + err.Error())
 			return
 		}
-		m.host = m.ctrl.Host()
+		m.refreshHostAndInvalidateSlashCatalog()
 		m.notice(fmt.Sprintf("connected %s — %d tools (available next message)", args[2], n))
 	case "remove", "rm":
 		if len(args) < 3 {
@@ -5037,6 +5050,7 @@ func (m *chatTUI) runMCPSubcommand(input string) {
 			m.notice("mcp remove: " + err.Error())
 			return
 		}
+		m.refreshHostAndInvalidateSlashCatalog()
 		if disconnected {
 			m.notice("disconnected " + name + " and removed it from config")
 		} else {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -314,12 +314,11 @@ type chatTUI struct {
 	// in the slash menu as "/<name>" and managed via /skills.
 	skills []skill.Skill
 
-	// slashCatalog is an immutable completion list rebuilt only when
-	// commands/skills/host/controller identity change. Keystroke filtering
-	// never reconstructs skill descriptions or MCP prompt lists (#6417, #7090).
+	// slashCatalog is an immutable completion list rebuilt only on explicit
+	// invalidation (model switch, skill rescan, /reload-cmd, …). Ordinary
+	// keystrokes only filter this snapshot — no fingerprint walk (#6417, #7090).
 	slashCatalog     []compItem
-	slashCatalogKey  string
-	slashCatalogOnce bool // true when slashCatalog is valid for slashCatalogKey
+	slashCatalogOnce bool // true when slashCatalog holds a valid snapshot
 
 	// skillPick is the interactive skill picker overlay for /skills. nil when closed.
 	skillPick *skillPicker
@@ -1481,11 +1480,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice(i18n.M.CtrlCQuitHint)
 			return m, finalize(m, nil)
 		case "ctrl+d":
-			// Compatible Ctrl+D: forward-delete one character when the
-			// composer has content; only quit when idle with an empty
-			// composer (bash/readline-style EOF). Do not intercept a
-			// running turn's empty composer as quit (#7638-compatible).
-			if strings.TrimSpace(m.input.Value()) != "" {
+			// Compatible Ctrl+D: forward-delete when the composer has any
+			// raw content (including whitespace-only); only quit when idle
+			// with a truly empty composer (bash/readline-style EOF).
+			if m.input.Value() != "" {
 				// Delegate to textarea DeleteCharacterForward (bound to
 				// ctrl+d by default) so mid-line forward delete works.
 				var ic tea.Cmd

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -314,6 +314,13 @@ type chatTUI struct {
 	// in the slash menu as "/<name>" and managed via /skills.
 	skills []skill.Skill
 
+	// slashCatalog is an immutable completion list rebuilt only when
+	// commands/skills/host/controller identity change. Keystroke filtering
+	// never reconstructs skill descriptions or MCP prompt lists (#6417, #7090).
+	slashCatalog     []compItem
+	slashCatalogKey  string
+	slashCatalogOnce bool // true when slashCatalog is valid for slashCatalogKey
+
 	// skillPick is the interactive skill picker overlay for /skills. nil when closed.
 	skillPick *skillPicker
 
@@ -1474,7 +1481,26 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice(i18n.M.CtrlCQuitHint)
 			return m, finalize(m, nil)
 		case "ctrl+d":
-			return m, shutdownNow
+			// Compatible Ctrl+D: forward-delete one character when the
+			// composer has content; only quit when idle with an empty
+			// composer (bash/readline-style EOF). Do not intercept a
+			// running turn's empty composer as quit (#7638-compatible).
+			if strings.TrimSpace(m.input.Value()) != "" {
+				// Delegate to textarea DeleteCharacterForward (bound to
+				// ctrl+d by default) so mid-line forward delete works.
+				var ic tea.Cmd
+				m.input, ic = m.input.Update(msg)
+				if ic != nil {
+					cmds = append(cmds, ic)
+				}
+				m.growInputToFit()
+				m.updateCompletion()
+				return m, finalize(m, cmds)
+			}
+			if m.state == tuiIdle {
+				return m, shutdownNow
+			}
+			return m, nil
 		case "ctrl+l":
 			if m.state != tuiRunning {
 				m.finalizeStreamed()
@@ -1494,9 +1520,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+b":
 			m.toggleShellOutput()
 			return m, finalize(m, cmds)
-		case "shift+tab":
-			// Shift+Tab toggles Plan only. Tool approval stays on its own axis:
-			// Ask/Auto are explicit choices, and YOLO is a separate Ctrl+Y toggle.
+		case "shift+tab", "backtab":
+			// Shift+Tab toggles Plan only. Some terminals encode it as
+			// "backtab" (CSI Z) rather than "shift+tab" (#6660).
+			// Tool approval stays on its own axis: Ask/Auto are explicit
+			// choices, and YOLO is a separate Ctrl+Y toggle.
 			m.cycleMode()
 			return m, nil
 		case "enter":
@@ -1710,6 +1738,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.label = msg.label
 			m.commands = msg.commands
 			m.skills = msg.skills
+			m.invalidateSlashCatalog()
 			m.host = msg.host
 			m.modelRef = msg.ref
 			if msg.profile != "" {
@@ -4502,6 +4531,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		prev := len(m.commands)
 		err := m.ctrl.ReloadCommands(context.Background())
 		m.commands = m.ctrl.Commands()
+		m.invalidateSlashCatalog()
 		m.updateCompletion()
 		if err != nil {
 			m.notice("reload-cmd: " + err.Error())

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -4286,6 +4286,7 @@ func TestDesktopShortcutLayoutDoesNotStealCompletionTab(t *testing.T) {
 		kind:        compSlash,
 		items:       []compItem{{label: "/mcp", insert: "/mcp ", descend: true}},
 		replaceFrom: 0,
+		replaceTo:   len("/"),
 	}
 
 	out, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyTab})

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -36,14 +36,17 @@ type compItem struct {
 }
 
 // completion is the live autocomplete menu state. Empty value = inactive.
-// replaceFrom is the byte offset in the input where the completed token starts
-// (0 for a slash line, the '@' index for an @-reference).
+// replaceFrom/replaceTo are byte offsets of the token span that accept replaces
+// (half-open [replaceFrom, replaceTo)). For a bare slash name, replaceFrom is 0
+// and replaceTo is len(value). For @-refs, replaceFrom is the '@' and replaceTo
+// is the first unescaped whitespace after the token (or end of input).
 type completion struct {
 	active      bool
 	kind        compKind
 	items       []compItem
 	sel         int
 	replaceFrom int
+	replaceTo   int
 }
 
 const (
@@ -58,70 +61,27 @@ const (
 	maxFileSearchItems = 20
 )
 
-// slashItems returns the cached slash catalog, rebuilding it only when the
-// underlying commands/skills/prompts/extension sources change.
+// slashItems returns the cached slash catalog. Rebuilds only after
+// invalidateSlashCatalog — never on ordinary keystrokes.
 func (m *chatTUI) slashItems() []compItem {
-	key := m.slashCatalogFingerprint()
-	if m.slashCatalogOnce && m.slashCatalogKey == key && m.slashCatalog != nil {
+	if m.slashCatalogOnce && m.slashCatalog != nil {
 		return m.slashCatalog
 	}
 	items := m.buildSlashCatalog()
-	// Store an immutable snapshot so keystroke filtering never mutates shared state.
+	// Immutable snapshot so keystroke filtering never mutates shared state.
 	out := make([]compItem, len(items))
 	copy(out, items)
 	m.slashCatalog = out
-	m.slashCatalogKey = key
 	m.slashCatalogOnce = true
 	return m.slashCatalog
 }
 
-// invalidateSlashCatalog drops the cached catalog so the next keystroke rebuilds it.
+// invalidateSlashCatalog drops the cached catalog so the next slashItems call
+// rebuilds it. Call from model switch, skill rescan, /reload-cmd, and any path
+// that mutates commands/skills/host/extension actions.
 func (m *chatTUI) invalidateSlashCatalog() {
 	m.slashCatalogOnce = false
 	m.slashCatalog = nil
-	m.slashCatalogKey = ""
-}
-
-// slashCatalogFingerprint identifies the sources that contribute to slashItems.
-// It is intentionally name/description-based so slice identity alone is enough
-// and ordinary typing never rebuilds the catalog.
-func (m *chatTUI) slashCatalogFingerprint() string {
-	var b strings.Builder
-	b.Grow(256 + len(m.commands)*24 + len(m.skills)*48)
-	fmt.Fprintf(&b, "c=%d;", len(m.commands))
-	for _, c := range m.commands {
-		if c.Hidden {
-			continue
-		}
-		b.WriteString(c.Name)
-		b.WriteByte('|')
-		b.WriteString(c.Description)
-		b.WriteByte(';')
-	}
-	fmt.Fprintf(&b, "s=%d;", len(m.skills))
-	for _, s := range m.skills {
-		b.WriteString(s.SlashName())
-		b.WriteByte('|')
-		b.WriteString(s.Description)
-		b.WriteByte('|')
-		b.WriteString(string(s.RunAs))
-		b.WriteByte(';')
-	}
-	for _, p := range m.prompts() {
-		b.WriteString(p.Name)
-		b.WriteByte('|')
-		b.WriteString(p.Description)
-		b.WriteByte(';')
-	}
-	if m.ctrl != nil {
-		for _, a := range m.ctrl.ExtensionActions() {
-			b.WriteString(a.Slash)
-			b.WriteByte('|')
-			b.WriteString(a.Label)
-			b.WriteByte(';')
-		}
-	}
-	return b.String()
 }
 
 // buildSlashCatalog constructs the full slash menu from current sources.
@@ -192,9 +152,9 @@ func (m *chatTUI) updateCompletion() {
 
 	// An @-reference token under the cursor wins — it can appear mid-line, even
 	// inside a slash command's arguments (e.g. "/review @file").
-	if at, token, ok := activeAtToken(val, cursor); ok {
+	if at, end, token, ok := activeAtToken(val, cursor); ok {
 		if items := m.atItems(token); len(items) > 0 {
-			m.setCompletion(compAt, items, at)
+			m.setCompletion(compAt, items, at, end)
 			return
 		}
 	}
@@ -204,13 +164,13 @@ func (m *chatTUI) updateCompletion() {
 	// mid-token cursor still filters the catalog without rewriting the line.
 	if strings.HasPrefix(val, "/") {
 		if items, from, ok := m.explicitSubcommandItems(val); ok && len(items) > 0 {
-			m.setCompletion(compSlashArg, items, from)
+			m.setCompletion(compSlashArg, items, from, tokenEnd(val, from))
 			return
 		}
 		if !strings.ContainsAny(val, " \t\n") {
 			// Still naming the command itself. Catalog is cached; filter is cheap.
 			if items := fuzzyFilterSlash(m.slashItems(), val); len(items) > 0 {
-				m.setCompletion(compSlash, items, 0)
+				m.setCompletion(compSlash, items, 0, len(val))
 				return
 			}
 		} else if m.bareSubcommandSpace(val) {
@@ -218,7 +178,7 @@ func (m *chatTUI) updateCompletion() {
 			return
 		} else if items, from, ok := m.slashArgItems(val); ok && len(items) > 0 {
 			// Past the command word — complete its structured arguments.
-			m.setCompletion(compSlashArg, items, from)
+			m.setCompletion(compSlashArg, items, from, tokenEnd(val, from))
 			return
 		}
 	}
@@ -234,41 +194,55 @@ func (m *chatTUI) inputCursorByteOffset() int {
 	if val == "" {
 		return 0
 	}
-	// Prefer the visual-row model used by mouse selection: it already maps
-	// the caret to a stable rune offset into Value().
+	// Prefer the visual-row model used by mouse selection: it maps the caret
+	// to a stable rune offset into Value().
 	if m.width > 0 {
 		rows := m.composerRows()
 		if len(rows) > 0 {
-			// Reconstruct offset from textarea cursor row/column via caret helpers.
 			if cur := m.input.Cursor(); cur != nil {
-				// Absolute visual row inside the wrapped content.
 				absRow := m.input.ScrollYOffset() + cur.Y
 				if absRow >= 0 && absRow < len(rows) {
 					row := rows[absRow]
-					// Map screen column (prompt-adjusted) to cell offset.
-					// cur.X is relative to the textarea content origin.
-					col := cur.X
+					// cur.X is screen-relative and includes the "❯ " prompt
+					// gutter (composerPromptWidth columns). Subtract it so
+					// we measure content columns only.
+					col := cur.X - composerPromptWidth
 					if col < 0 {
 						col = 0
 					}
-					// Walk cells by visual width to find the caret byte offset.
 					visual := 0
 					for _, cell := range row.cells {
 						w := rw.RuneWidth(cell.r)
 						if visual+w > col {
-							if cell.offset >= 0 && cell.offset <= len(val) {
-								return cell.offset
+							if cell.offset >= 0 {
+								// cell.offset is a rune index into Value.
+								return runeOffsetToByte(val, cell.offset)
 							}
 							break
 						}
 						visual += w
 					}
-					if row.endOffset >= 0 && row.endOffset <= len(val) {
-						return row.endOffset
+					if row.endOffset >= 0 {
+						return runeOffsetToByte(val, row.endOffset)
 					}
 				}
 			}
 		}
+	}
+	return len(val)
+}
+
+// runeOffsetToByte converts a rune index into Value() into a byte index.
+func runeOffsetToByte(val string, runeOff int) int {
+	if runeOff <= 0 {
+		return 0
+	}
+	i := 0
+	for ri := range val {
+		if i == runeOff {
+			return ri
+		}
+		i++
 	}
 	return len(val)
 }
@@ -411,13 +385,20 @@ func (m *chatTUI) branchArgItems(val string) ([]compItem, int, bool) {
 }
 
 // setCompletion installs items, preserving the selection index only while the
-// same menu kind stays open.
-func (m *chatTUI) setCompletion(kind compKind, items []compItem, replaceFrom int) {
+// same menu kind stays open. replaceFrom/replaceTo form a half-open byte span
+// of the token that acceptCompletion will replace.
+func (m *chatTUI) setCompletion(kind compKind, items []compItem, replaceFrom, replaceTo int) {
 	sel := 0
 	if m.completion.active && m.completion.kind == kind && m.completion.sel < len(items) {
 		sel = m.completion.sel
 	}
-	m.completion = completion{active: true, kind: kind, items: items, sel: sel, replaceFrom: replaceFrom}
+	if replaceTo < replaceFrom {
+		replaceTo = replaceFrom
+	}
+	m.completion = completion{
+		active: true, kind: kind, items: items, sel: sel,
+		replaceFrom: replaceFrom, replaceTo: replaceTo,
+	}
 }
 
 // fuzzyFilterSlash returns the slash-menu items that match query as a
@@ -476,15 +457,17 @@ func subsequenceMatch(target, query string) bool {
 	return false
 }
 
-// activeAtToken finds the @-reference token ending at the cursor. cursor is a
-// byte offset into val; when out of range the scan uses the end of the string
-// (legacy behaviour). The '@' must start the line or follow whitespace, so
-// emails like "a@b" don't trigger it. A backslash-escaped space or tab is part
-// of the token (the form EscapeRefPath inserts for paths with spaces), so
-// completion can descend through such directories. Returns the '@' offset and
-// the text after it up to the cursor (not past it), so mid-line typing does
-// not jump the caret or complete trailing text (#6719).
-func activeAtToken(val string, cursor int) (int, string, bool) {
+// activeAtToken finds the @-reference token under the cursor. cursor is a byte
+// offset into val; when out of range the scan uses the end of the string.
+// The '@' must start the line or follow whitespace, so emails like "a@b" don't
+// trigger it. A backslash-escaped space or tab is part of the token.
+//
+// Returns (at, end, token, ok) where [at, end) is the full token span to
+// replace on accept (including '@') and token is the text after '@' for menu
+// filtering. The span extends past the cursor to the next unescaped whitespace
+// so accepting mid-token never leaves a dangling suffix (e.g. "@foo|bar" →
+// "@file.md " not "@file.mdbar").
+func activeAtToken(val string, cursor int) (at, end int, token string, ok bool) {
 	if cursor < 0 || cursor > len(val) {
 		cursor = len(val)
 	}
@@ -495,17 +478,37 @@ func activeAtToken(val string, cursor int) (int, string, bool) {
 				i-- // escaped whitespace stays inside the token
 				continue
 			}
-			return 0, "", false // hit whitespace before an '@' → no active token
+			return 0, 0, "", false
 		case '\n':
-			return 0, "", false
+			return 0, 0, "", false
 		case '@':
 			if i == 0 || val[i-1] == ' ' || val[i-1] == '\t' || val[i-1] == '\n' {
-				return i, val[i+1 : cursor], true
+				end = tokenEnd(val, i+1)
+				// Filter with the full token so mid-token accepts still match
+				// the path being edited; replace span is always [at, end).
+				return i, end, val[i+1 : end], true
 			}
-			return 0, "", false
+			return 0, 0, "", false
 		}
 	}
-	return 0, "", false
+	return 0, 0, "", false
+}
+
+// tokenEnd returns the exclusive byte end of a path/ref token starting at from
+// (just after '@'). Stops at unescaped whitespace or newline.
+func tokenEnd(val string, from int) int {
+	for i := from; i < len(val); i++ {
+		switch val[i] {
+		case ' ', '\t':
+			if i > 0 && val[i-1] == '\\' {
+				continue
+			}
+			return i
+		case '\n':
+			return i
+		}
+	}
+	return len(val)
 }
 
 // atItems builds the @-reference menu for a token. A "server:uri" token whose
@@ -710,17 +713,21 @@ func (m *chatTUI) completionSelectedInsertPresent() bool {
 		return false
 	}
 	val := m.input.Value()
-	if m.completion.replaceFrom > len(val) {
+	rf, rt := m.completion.replaceFrom, m.completion.replaceTo
+	if rf < 0 || rf > len(val) {
 		return false
 	}
-	return val[m.completion.replaceFrom:] == m.completion.items[m.completion.sel].insert
+	if rt < rf || rt > len(val) {
+		rt = len(val)
+	}
+	return val[rf:rt] == m.completion.items[m.completion.sel].insert
 }
 
 // acceptCompletion applies the selected item to the input, then recomputes the
 // menu from the new value: it re-opens one level deeper (a descended directory
 // or a freshly completed command's arguments) or closes when nothing applies.
 // Cursor moves to the end of the inserted token only on accept — ordinary
-// keystrokes never call this path, so mid-line typing keeps its caret (#6719).
+// keystrokes never call this path, so mid-line typing keeps its caret.
 func (m *chatTUI) acceptCompletion() {
 	if m.completion.sel >= len(m.completion.items) {
 		m.completion = completion{}
@@ -729,25 +736,22 @@ func (m *chatTUI) acceptCompletion() {
 	it := m.completion.items[m.completion.sel]
 	val := m.input.Value()
 	rf := m.completion.replaceFrom
-	if rf > len(val) {
-		rf = len(val)
+	rt := m.completion.replaceTo
+	if rf < 0 || rf > len(val) {
+		rf = 0
 	}
-	// Replace only the token under completion; keep any suffix after the old
-	// token so accepting mid-line does not drop trailing text.
-	// When the menu was opened with cursor mid-token, replaceFrom..cursor was
-	// the active span; after accept we rebuild as prefix + insert + remainder
-	// past the original token end (best-effort: remainder is anything after
-	// the previously typed fragment starting at replaceFrom).
-	oldFragEnd := len(val)
-	if m.completion.kind == compAt {
-		// For @ tokens the active fragment is replaceFrom..cursor; remainder
-		// after cursor is preserved.
-		cursor := m.inputCursorByteOffset()
-		if cursor >= rf && cursor <= len(val) {
-			oldFragEnd = cursor
-		}
+	// replaceTo must be set by setCompletion. Hand-built test completions may
+	// leave it at 0; treat inverted/empty whole-line spans as "to end".
+	if rt < rf || rt > len(val) {
+		rt = len(val)
+	} else if rt == rf && rf == 0 && len(val) > 0 {
+		// Bare slash replace with unset replaceTo: replace the whole line.
+		rt = len(val)
 	}
-	newVal := val[:rf] + it.insert + val[oldFragEnd:]
+	// Replace the full token span [rf, rt); keep any suffix after the token
+	// so "see @foo and more" + accept @foobar.md becomes
+	// "see @foobar.md and more" (not "@foobar.mdand" or "@foobar.mdfoo").
+	newVal := val[:rf] + it.insert + val[rt:]
 	insertEnd := rf + len(it.insert)
 	m.input.SetValue(newVal)
 	// Place caret at the end of the inserted completion only. Fall back to
@@ -766,9 +770,12 @@ func (m *chatTUI) acceptCompletion() {
 	// selected (i.e. the token was already typed), close it so the next Enter
 	// submits the command rather than being captured again by acceptCompletion.
 	if m.completion.active && len(m.completion.items) == 1 {
-		tok := m.input.Value()[m.completion.replaceFrom:]
-		if tok == m.completion.items[0].insert {
-			m.completion = completion{}
+		rf, rt := m.completion.replaceFrom, m.completion.replaceTo
+		val := m.input.Value()
+		if rf >= 0 && rf <= len(val) && rt >= rf && rt <= len(val) {
+			if val[rf:rt] == m.completion.items[0].insert {
+				m.completion = completion{}
+			}
 		}
 	}
 }

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	rw "github.com/mattn/go-runewidth"
 
 	"reasonix/internal/control"
 	"reasonix/internal/fileref"
@@ -57,9 +58,74 @@ const (
 	maxFileSearchItems = 20
 )
 
-// slashItems is the full set of slash commands offered for completion: the
-// built-in verbs, custom commands, skills (each as "/<name>"), and MCP prompts.
+// slashItems returns the cached slash catalog, rebuilding it only when the
+// underlying commands/skills/prompts/extension sources change.
 func (m *chatTUI) slashItems() []compItem {
+	key := m.slashCatalogFingerprint()
+	if m.slashCatalogOnce && m.slashCatalogKey == key && m.slashCatalog != nil {
+		return m.slashCatalog
+	}
+	items := m.buildSlashCatalog()
+	// Store an immutable snapshot so keystroke filtering never mutates shared state.
+	out := make([]compItem, len(items))
+	copy(out, items)
+	m.slashCatalog = out
+	m.slashCatalogKey = key
+	m.slashCatalogOnce = true
+	return m.slashCatalog
+}
+
+// invalidateSlashCatalog drops the cached catalog so the next keystroke rebuilds it.
+func (m *chatTUI) invalidateSlashCatalog() {
+	m.slashCatalogOnce = false
+	m.slashCatalog = nil
+	m.slashCatalogKey = ""
+}
+
+// slashCatalogFingerprint identifies the sources that contribute to slashItems.
+// It is intentionally name/description-based so slice identity alone is enough
+// and ordinary typing never rebuilds the catalog.
+func (m *chatTUI) slashCatalogFingerprint() string {
+	var b strings.Builder
+	b.Grow(256 + len(m.commands)*24 + len(m.skills)*48)
+	fmt.Fprintf(&b, "c=%d;", len(m.commands))
+	for _, c := range m.commands {
+		if c.Hidden {
+			continue
+		}
+		b.WriteString(c.Name)
+		b.WriteByte('|')
+		b.WriteString(c.Description)
+		b.WriteByte(';')
+	}
+	fmt.Fprintf(&b, "s=%d;", len(m.skills))
+	for _, s := range m.skills {
+		b.WriteString(s.SlashName())
+		b.WriteByte('|')
+		b.WriteString(s.Description)
+		b.WriteByte('|')
+		b.WriteString(string(s.RunAs))
+		b.WriteByte(';')
+	}
+	for _, p := range m.prompts() {
+		b.WriteString(p.Name)
+		b.WriteByte('|')
+		b.WriteString(p.Description)
+		b.WriteByte(';')
+	}
+	if m.ctrl != nil {
+		for _, a := range m.ctrl.ExtensionActions() {
+			b.WriteString(a.Slash)
+			b.WriteByte('|')
+			b.WriteString(a.Label)
+			b.WriteByte(';')
+		}
+	}
+	return b.String()
+}
+
+// buildSlashCatalog constructs the full slash menu from current sources.
+func (m *chatTUI) buildSlashCatalog() []compItem {
 	docsOwner := control.ResolveSlashCommandOwner(control.DocsSlashName, m.commands, m.skills)
 	docsBuiltin := "/" + control.ResolvedBuiltinSlashName(control.DocsSlashName, m.commands, m.skills)
 	items := renameSlashItem(builtinSlashItems(), "/docs", docsBuiltin)
@@ -122,23 +188,27 @@ func removeSlashItems(items []compItem, label string) []compItem {
 // token under the cursor is "@…".
 func (m *chatTUI) updateCompletion() {
 	val := m.input.Value()
+	cursor := m.inputCursorByteOffset()
 
 	// An @-reference token under the cursor wins — it can appear mid-line, even
 	// inside a slash command's arguments (e.g. "/review @file").
-	if at, token, ok := activeAtToken(val); ok {
+	if at, token, ok := activeAtToken(val, cursor); ok {
 		if items := m.atItems(token); len(items) > 0 {
 			m.setCompletion(compAt, items, at)
 			return
 		}
 	}
 
+	// Slash completion only when the line is a pure slash command being typed
+	// from the start (not mid-line after free text). Use the full value so a
+	// mid-token cursor still filters the catalog without rewriting the line.
 	if strings.HasPrefix(val, "/") {
 		if items, from, ok := m.explicitSubcommandItems(val); ok && len(items) > 0 {
 			m.setCompletion(compSlashArg, items, from)
 			return
 		}
 		if !strings.ContainsAny(val, " \t\n") {
-			// Still naming the command itself.
+			// Still naming the command itself. Catalog is cached; filter is cheap.
 			if items := fuzzyFilterSlash(m.slashItems(), val); len(items) > 0 {
 				m.setCompletion(compSlash, items, 0)
 				return
@@ -154,6 +224,53 @@ func (m *chatTUI) updateCompletion() {
 	}
 
 	m.completion = completion{}
+}
+
+// inputCursorByteOffset returns the byte offset of the insertion caret in
+// input.Value(). Falls back to len(Value) when layout is unavailable so
+// completion still works in unit tests that never size the window.
+func (m *chatTUI) inputCursorByteOffset() int {
+	val := m.input.Value()
+	if val == "" {
+		return 0
+	}
+	// Prefer the visual-row model used by mouse selection: it already maps
+	// the caret to a stable rune offset into Value().
+	if m.width > 0 {
+		rows := m.composerRows()
+		if len(rows) > 0 {
+			// Reconstruct offset from textarea cursor row/column via caret helpers.
+			if cur := m.input.Cursor(); cur != nil {
+				// Absolute visual row inside the wrapped content.
+				absRow := m.input.ScrollYOffset() + cur.Y
+				if absRow >= 0 && absRow < len(rows) {
+					row := rows[absRow]
+					// Map screen column (prompt-adjusted) to cell offset.
+					// cur.X is relative to the textarea content origin.
+					col := cur.X
+					if col < 0 {
+						col = 0
+					}
+					// Walk cells by visual width to find the caret byte offset.
+					visual := 0
+					for _, cell := range row.cells {
+						w := rw.RuneWidth(cell.r)
+						if visual+w > col {
+							if cell.offset >= 0 && cell.offset <= len(val) {
+								return cell.offset
+							}
+							break
+						}
+						visual += w
+					}
+					if row.endOffset >= 0 && row.endOffset <= len(val) {
+						return row.endOffset
+					}
+				}
+			}
+		}
+	}
+	return len(val)
 }
 
 // slashArgItems completes the arguments of a slash command (everything after the
@@ -359,14 +476,19 @@ func subsequenceMatch(target, query string) bool {
 	return false
 }
 
-// activeAtToken finds the @-reference token ending at the cursor (assumed at the
-// input's end). The '@' must start the line or follow whitespace, so emails
-// like "a@b" don't trigger it. A backslash-escaped space or tab is part of the
-// token (the form EscapeRefPath inserts for paths with spaces), so completion
-// can descend through such directories. Returns the '@' offset and the text
-// after it.
-func activeAtToken(val string) (int, string, bool) {
-	for i := len(val) - 1; i >= 0; i-- {
+// activeAtToken finds the @-reference token ending at the cursor. cursor is a
+// byte offset into val; when out of range the scan uses the end of the string
+// (legacy behaviour). The '@' must start the line or follow whitespace, so
+// emails like "a@b" don't trigger it. A backslash-escaped space or tab is part
+// of the token (the form EscapeRefPath inserts for paths with spaces), so
+// completion can descend through such directories. Returns the '@' offset and
+// the text after it up to the cursor (not past it), so mid-line typing does
+// not jump the caret or complete trailing text (#6719).
+func activeAtToken(val string, cursor int) (int, string, bool) {
+	if cursor < 0 || cursor > len(val) {
+		cursor = len(val)
+	}
+	for i := cursor - 1; i >= 0; i-- {
 		switch val[i] {
 		case ' ', '\t':
 			if i > 0 && val[i-1] == '\\' {
@@ -378,7 +500,7 @@ func activeAtToken(val string) (int, string, bool) {
 			return 0, "", false
 		case '@':
 			if i == 0 || val[i-1] == ' ' || val[i-1] == '\t' || val[i-1] == '\n' {
-				return i, val[i+1:], true
+				return i, val[i+1 : cursor], true
 			}
 			return 0, "", false
 		}
@@ -597,6 +719,8 @@ func (m *chatTUI) completionSelectedInsertPresent() bool {
 // acceptCompletion applies the selected item to the input, then recomputes the
 // menu from the new value: it re-opens one level deeper (a descended directory
 // or a freshly completed command's arguments) or closes when nothing applies.
+// Cursor moves to the end of the inserted token only on accept — ordinary
+// keystrokes never call this path, so mid-line typing keeps its caret (#6719).
 func (m *chatTUI) acceptCompletion() {
 	if m.completion.sel >= len(m.completion.items) {
 		m.completion = completion{}
@@ -608,8 +732,31 @@ func (m *chatTUI) acceptCompletion() {
 	if rf > len(val) {
 		rf = len(val)
 	}
-	m.input.SetValue(val[:rf] + it.insert)
-	m.input.CursorEnd()
+	// Replace only the token under completion; keep any suffix after the old
+	// token so accepting mid-line does not drop trailing text.
+	// When the menu was opened with cursor mid-token, replaceFrom..cursor was
+	// the active span; after accept we rebuild as prefix + insert + remainder
+	// past the original token end (best-effort: remainder is anything after
+	// the previously typed fragment starting at replaceFrom).
+	oldFragEnd := len(val)
+	if m.completion.kind == compAt {
+		// For @ tokens the active fragment is replaceFrom..cursor; remainder
+		// after cursor is preserved.
+		cursor := m.inputCursorByteOffset()
+		if cursor >= rf && cursor <= len(val) {
+			oldFragEnd = cursor
+		}
+	}
+	newVal := val[:rf] + it.insert + val[oldFragEnd:]
+	insertEnd := rf + len(it.insert)
+	m.input.SetValue(newVal)
+	// Place caret at the end of the inserted completion only. Fall back to
+	// CursorEnd when the layout has no width yet (unit tests).
+	if m.width > 0 {
+		m.setComposerCursor(len([]rune(newVal[:min(insertEnd, len(newVal))])))
+	} else {
+		m.input.CursorEnd()
+	}
 	if it.descend || strings.HasSuffix(it.insert, " ") {
 		m.updateCompletion()
 		return

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/fileref"
 	"reasonix/internal/i18n"
+	"reasonix/internal/plugin"
 	"reasonix/internal/skill"
 )
 
@@ -82,6 +83,24 @@ func (m *chatTUI) slashItems() []compItem {
 func (m *chatTUI) invalidateSlashCatalog() {
 	m.slashCatalogOnce = false
 	m.slashCatalog = nil
+}
+
+// refreshHostAndInvalidateSlashCatalog reloads m.host from the controller and
+// drops the slash catalog so MCP prompts (and any host-backed menu entries)
+// rebuild on the next slashItems call. Use after connect/disconnect/remove/
+// import, MCPSurfaceReady, auth clear, and every other host mutation path.
+func (m *chatTUI) refreshHostAndInvalidateSlashCatalog() {
+	if m.ctrl != nil {
+		m.host = m.ctrl.Host()
+	}
+	m.invalidateSlashCatalog()
+}
+
+// setHostAndInvalidateSlashCatalog assigns a host pointer (e.g. from a model-
+// switch message) and invalidates the slash catalog.
+func (m *chatTUI) setHostAndInvalidateSlashCatalog(host *plugin.Host) {
+	m.host = host
+	m.invalidateSlashCatalog()
 }
 
 // buildSlashCatalog constructs the full slash menu from current sources.
@@ -462,12 +481,14 @@ func subsequenceMatch(target, query string) bool {
 // The '@' must start the line or follow whitespace, so emails like "a@b" don't
 // trigger it. A backslash-escaped space or tab is part of the token.
 //
-// Returns (at, end, token, ok) where [at, end) is the full token span to
-// replace on accept (including '@') and token is the text after '@' for menu
-// filtering. The span extends past the cursor to the next unescaped whitespace
-// so accepting mid-token never leaves a dangling suffix (e.g. "@foo|bar" →
-// "@file.md " not "@file.mdbar").
-func activeAtToken(val string, cursor int) (at, end int, token string, ok bool) {
+// Returns (at, end, query, ok):
+//   - [at, end) is the full token span to replace on accept (including '@'),
+//     extending past the caret to the next unescaped whitespace so mid-token
+//     accept never leaves a dangling suffix ("@foo|bar" → "@file.md ", not
+//     "@file.mdbar").
+//   - query is only the text after '@' up to the caret, used for menu filtering
+//     ("@fo|o" filters as "fo", not "foo").
+func activeAtToken(val string, cursor int) (at, end int, query string, ok bool) {
 	if cursor < 0 || cursor > len(val) {
 		cursor = len(val)
 	}
@@ -484,9 +505,14 @@ func activeAtToken(val string, cursor int) (at, end int, token string, ok bool) 
 		case '@':
 			if i == 0 || val[i-1] == ' ' || val[i-1] == '\t' || val[i-1] == '\n' {
 				end = tokenEnd(val, i+1)
-				// Filter with the full token so mid-token accepts still match
-				// the path being edited; replace span is always [at, end).
-				return i, end, val[i+1 : end], true
+				queryEnd := cursor
+				if queryEnd < i+1 {
+					queryEnd = i + 1
+				}
+				if queryEnd > end {
+					queryEnd = end
+				}
+				return i, end, val[i+1 : queryEnd], true
 			}
 			return 0, 0, "", false
 		}

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -227,9 +227,12 @@ func TestActiveAtToken(t *testing.T) {
 		{`see @my\ dir/`, `my\ dir/`, true, 4},
 	}
 	for _, c := range cases {
-		at, tok, ok := activeAtToken(c.val, len(c.val))
+		at, end, tok, ok := activeAtToken(c.val, len(c.val))
 		if ok != c.wantOK || (ok && (tok != c.wantTok || at != c.wantAt)) {
-			t.Errorf("activeAtToken(%q) = (%d,%q,%v), want (%d,%q,%v)", c.val, at, tok, ok, c.wantAt, c.wantTok, c.wantOK)
+			t.Errorf("activeAtToken(%q) = (%d,%d,%q,%v), want (%d,_,%q,%v)", c.val, at, end, tok, ok, c.wantAt, c.wantTok, c.wantOK)
+		}
+		if ok && (end < at || end > len(c.val) || c.val[at:end] != "@"+tok) {
+			t.Errorf("activeAtToken(%q) span [%d,%d) = %q, want @%s", c.val, at, end, c.val[at:end], c.wantTok)
 		}
 	}
 }
@@ -508,6 +511,7 @@ func TestEnterOnExactSlashArgSubmitsWhenPrefixAlsoMatches(t *testing.T) {
 		items:       []compItem{{label: "1", insert: "1"}, {label: "10", insert: "10"}},
 		sel:         0,
 		replaceFrom: len("/resume "),
+		replaceTo:   len("/resume 1"),
 	}
 
 	got, _ := m.update(tea.KeyPressMsg{Code: tea.KeyEnter})

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -227,7 +227,7 @@ func TestActiveAtToken(t *testing.T) {
 		{`see @my\ dir/`, `my\ dir/`, true, 4},
 	}
 	for _, c := range cases {
-		at, tok, ok := activeAtToken(c.val)
+		at, tok, ok := activeAtToken(c.val, len(c.val))
 		if ok != c.wantOK || (ok && (tok != c.wantTok || at != c.wantAt)) {
 			t.Errorf("activeAtToken(%q) = (%d,%q,%v), want (%d,%q,%v)", c.val, at, tok, ok, c.wantAt, c.wantTok, c.wantOK)
 		}

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -231,8 +231,15 @@ func TestActiveAtToken(t *testing.T) {
 		if ok != c.wantOK || (ok && (tok != c.wantTok || at != c.wantAt)) {
 			t.Errorf("activeAtToken(%q) = (%d,%d,%q,%v), want (%d,_,%q,%v)", c.val, at, end, tok, ok, c.wantAt, c.wantTok, c.wantOK)
 		}
-		if ok && (end < at || end > len(c.val) || c.val[at:end] != "@"+tok) {
-			t.Errorf("activeAtToken(%q) span [%d,%d) = %q, want @%s", c.val, at, end, c.val[at:end], c.wantTok)
+		if ok {
+			if end < at || end > len(c.val) || !strings.HasPrefix(c.val[at:end], "@") {
+				t.Errorf("activeAtToken(%q) span [%d,%d) invalid", c.val, at, end)
+			}
+			// At EOF, caret-limited query equals the full token after '@'.
+			fullTok := c.val[at+1 : end]
+			if !strings.HasPrefix(fullTok, tok) {
+				t.Errorf("activeAtToken(%q) query %q is not a prefix of full token %q", c.val, tok, fullTok)
+			}
 		}
 	}
 }

--- a/internal/cli/mcp_import_picker.go
+++ b/internal/cli/mcp_import_picker.go
@@ -70,7 +70,7 @@ func (m chatTUI) handleMCPImportKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.notice("mcp import: " + err.Error())
 			return m, nil
 		}
-		m.host = m.ctrl.Host()
+		m.refreshHostAndInvalidateSlashCatalog()
 		m.notice(fmt.Sprintf("imported %d selected MCP servers from cc-switch (%d added, %d updated, %d connected, %d failed, %d skipped)", total, added, updated, connected, failed, skipped))
 	}
 	return m, nil

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -62,7 +62,7 @@ func (m chatTUI) connectSelectedMCP(v mcpServerView) (tea.Model, tea.Cmd) {
 	if m.mcpDisabled != nil {
 		delete(m.mcpDisabled, v.Name)
 	}
-	m.host = m.ctrl.Host()
+	m.refreshHostAndInvalidateSlashCatalog()
 	m.refreshMCPManager()
 	if m.mcp != nil {
 		m.mcp.stage = mcpStageDetail
@@ -83,7 +83,7 @@ func (m chatTUI) disableSelectedMCP(v mcpServerView) (tea.Model, tea.Cmd) {
 	}
 	m.mcpDisabled[v.Name] = true
 	m.ctrl.DisconnectMCPServer(v.Name)
-	m.host = m.ctrl.Host()
+	m.refreshHostAndInvalidateSlashCatalog()
 	m.refreshMCPManager()
 	if m.mcp != nil {
 		m.mcp.stage = mcpStageDetail
@@ -116,7 +116,7 @@ func (m chatTUI) removeSelectedMCP() (tea.Model, tea.Cmd) {
 	if m.mcpDisabled != nil {
 		delete(m.mcpDisabled, v.Name)
 	}
-	m.host = m.ctrl.Host()
+	m.refreshHostAndInvalidateSlashCatalog()
 	m.refreshMCPManager()
 	if m.mcp != nil {
 		m.mcp.stage = mcpStageList
@@ -170,7 +170,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 			recordMCPModePluginFailure(m.ctrl, selected, err)
 			m.notice("saved connection mode, but connect failed: " + err.Error())
 		}
-		m.host = m.ctrl.Host()
+		m.refreshHostAndInvalidateSlashCatalog()
 	}
 	m.refreshMCPManager()
 	if m.mcp != nil {
@@ -261,7 +261,7 @@ func (m chatTUI) clearMCPAuthentication(v mcpServerView) (tea.Model, tea.Cmd) {
 		if h := m.ctrl.Host(); h != nil {
 			h.ClearFailure(v.Name)
 		}
-		m.host = m.ctrl.Host()
+		m.refreshHostAndInvalidateSlashCatalog()
 	}
 	m.refreshMCPManager()
 	if m.mcp != nil {

--- a/internal/cli/skill_picker.go
+++ b/internal/cli/skill_picker.go
@@ -348,6 +348,7 @@ func (m *chatTUI) refreshSkillPickerData() {
 	st := m.skillStore()
 	skills := st.List()
 	m.skills = skills
+	m.invalidateSlashCatalog()
 	if m.skillPick != nil {
 		sorted := sortedSkills(skills)
 		m.skillPick.skills = sorted

--- a/internal/cli/slash_catalog_test.go
+++ b/internal/cli/slash_catalog_test.go
@@ -79,14 +79,12 @@ func TestCtrlDForwardDeletesWhitespaceOnly(t *testing.T) {
 	m.input.SetValue("   ")
 	m.input.SetCursorColumn(0)
 	msg := tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
-	out, cmd := m.Update(msg)
+	out, _ := m.Update(msg)
 	m = out.(chatTUI)
-	if cmd != nil {
-		// shutdown cmd would be non-nil; forward-delete may still return nil cmd
-	}
 	if got := m.input.Value(); got == "   " {
 		// At least one space should be deleted; exact remainder depends on
-		// textarea delete-forward at col 0.
+		// textarea delete-forward at col 0. Unchanged value would mean quit
+		// (or no-op) rather than forward-delete.
 		t.Fatalf("ctrl+d on whitespace-only must forward-delete, not quit; value still %q", got)
 	}
 	if m.state != tuiIdle {
@@ -109,15 +107,28 @@ func TestCtrlDQuitsWhenIdleAndEmpty(t *testing.T) {
 
 func TestActiveAtTokenFullSpanAndMidCursor(t *testing.T) {
 	val := "see @foo and more"
-	// Cursor mid-token after "@fo"
+	// Cursor mid-token after "@fo" → query is caret-limited "fo", span is full "@foo".
 	cursor := strings.Index(val, "@fo") + len("@fo")
 	at, end, tok, ok := activeAtToken(val, cursor)
-	if !ok || at != strings.Index(val, "@") || tok != "foo" {
-		// Full token is "foo" even mid-token (extends past caret to space).
-		t.Fatalf("activeAtToken mid-token = (%d,%d,%q,%v), want full token foo", at, end, tok, ok)
+	if !ok || at != strings.Index(val, "@") || tok != "fo" {
+		t.Fatalf("activeAtToken mid-token = (%d,%d,%q,%v), want query fo", at, end, tok, ok)
 	}
 	if val[at:end] != "@foo" {
-		t.Fatalf("span = %q, want @foo", val[at:end])
+		t.Fatalf("replace span = %q, want @foo (full token past caret)", val[at:end])
+	}
+}
+
+func TestMCPSurfaceReadyInvalidatesSlashCatalog(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.skills = []skill.Skill{{Name: "warm", Description: "warm"}}
+	_ = m.slashItems()
+	if !m.slashCatalogOnce {
+		t.Fatal("expected warm catalog")
+	}
+	m.ingestEvent(event.Event{Kind: event.MCPSurfaceReady})
+	if m.slashCatalogOnce {
+		t.Fatal("MCPSurfaceReady must invalidate slash catalog")
 	}
 }
 
@@ -169,46 +180,37 @@ func TestShiftTabAndBacktabBothAccepted(t *testing.T) {
 		t.Fatal("expected controller")
 	}
 
-	// Exercise the string switch arms directly via synthetic msgs. Platforms
-	// may stringify KeyTab+Shift as either "shift+tab" or "backtab"; we force
-	// both paths by calling the handler logic through Update when possible and
-	// asserting the case labels exist by cycling twice with known strings.
-	//
-	// KeyTab+ModShift:
+	// Production uses modeToggleKey for both encodings before the key switch.
+	for _, key := range []string{"shift+tab", "backtab"} {
+		if !modeToggleKey(key) {
+			t.Fatalf("modeToggleKey(%q) = false, want true", key)
+		}
+	}
+	if modeToggleKey("tab") || modeToggleKey("shift+enter") {
+		t.Fatal("modeToggleKey must not accept unrelated keys")
+	}
+
+	// Platform form: KeyTab+ModShift (typically String() == "shift+tab").
 	msg := tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
 	s := msg.String()
-	if s != "shift+tab" && s != "backtab" {
-		t.Fatalf("KeyTab+ModShift String() = %q", s)
+	if !modeToggleKey(s) {
+		t.Fatalf("KeyTab+ModShift String() = %q is not a mode-toggle key", s)
 	}
 	before := m.ctrl.ToolApprovalMode()
 	out, _ := m.Update(msg)
 	m = out.(chatTUI)
 	if m.ctrl.ToolApprovalMode() == before && !m.planMode {
-		t.Fatalf("%q did not cycle mode", s)
+		t.Fatalf("%q did not cycle mode via Update", s)
 	}
 
-	// Second encoding: if the first was "shift+tab", still verify "backtab"
-	// is handled by re-entering the switch with a raw message after resetting
-	// mode. We can't construct a KeyPressMsg that String()s to the other form
-	// portably, so call cycleMode once more and assert "backtab" is listed in
-	// the case clause by scanning source... instead: use update path only for
-	// the platform form and unit-check that both strings are in the switch via
-	// a tiny helper.
-	for _, key := range []string{"shift+tab", "backtab"} {
-		if !modeToggleKey(key) {
-			t.Fatalf("%q must be a recognized mode-toggle key", key)
-		}
-	}
-}
-
-// modeToggleKey reports whether s is a recognized Shift+Tab encoding for the
-// mode cycle switch in chatTUI.update (both platform forms must be listed).
-func modeToggleKey(s string) bool {
-	switch s {
-	case "shift+tab", "backtab":
-		return true
-	default:
-		return false
+	// Explicit CSI-Z / legacy "backtab" text encoding through the production
+	// Update path (Key.String returns Text when non-empty).
+	before = m.ctrl.ToolApprovalMode()
+	planBefore := m.planMode
+	out, _ = m.Update(tea.KeyPressMsg{Text: "backtab"})
+	m = out.(chatTUI)
+	if m.ctrl.ToolApprovalMode() == before && m.planMode == planBefore {
+		t.Fatal(`Update(Text:"backtab") did not cycle mode — production path must honor modeToggleKey("backtab")`)
 	}
 }
 

--- a/internal/cli/slash_catalog_test.go
+++ b/internal/cli/slash_catalog_test.go
@@ -35,12 +35,17 @@ func TestSlashCatalogCachesAcrossKeystrokes(t *testing.T) {
 	if &first[0] != &second[0] || len(first) != len(second) {
 		t.Fatal("slashItems must return the cached catalog between keystrokes")
 	}
-	// Fingerprint change (skill list) invalidates.
+	// Explicit invalidation is required after source mutation.
 	m.skills = append(m.skills, skill.Skill{Name: "skill-extra", Description: "extra"})
+	// Without invalidate, cache must stay stale (no hot-path fingerprint).
+	stale := m.slashItems()
+	if len(stale) != len(first) {
+		t.Fatalf("without invalidate catalog mutated on keystroke path: %d → %d", len(first), len(stale))
+	}
 	m.invalidateSlashCatalog()
 	third := m.slashItems()
 	if len(third) != len(first)+1 {
-		t.Fatalf("after skill add catalog = %d, want %d", len(third), len(first)+1)
+		t.Fatalf("after invalidate catalog = %d, want %d", len(third), len(first)+1)
 	}
 }
 
@@ -50,7 +55,7 @@ func TestCtrlDForwardDeletesWhenComposerNonEmpty(t *testing.T) {
 	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = m0.(chatTUI)
 	m.input.SetValue("hello")
-	m.input.SetCursorColumn(0) // caret at start so forward-delete removes 'h'
+	m.input.SetCursorColumn(0)
 
 	msg := tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
 	if msg.String() != "ctrl+d" {
@@ -63,6 +68,29 @@ func TestCtrlDForwardDeletesWhenComposerNonEmpty(t *testing.T) {
 	}
 	if m.state != tuiIdle {
 		t.Fatalf("state = %v, want idle (must not quit)", m.state)
+	}
+}
+
+func TestCtrlDForwardDeletesWhitespaceOnly(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	m.input.SetValue("   ")
+	m.input.SetCursorColumn(0)
+	msg := tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
+	out, cmd := m.Update(msg)
+	m = out.(chatTUI)
+	if cmd != nil {
+		// shutdown cmd would be non-nil; forward-delete may still return nil cmd
+	}
+	if got := m.input.Value(); got == "   " {
+		// At least one space should be deleted; exact remainder depends on
+		// textarea delete-forward at col 0.
+		t.Fatalf("ctrl+d on whitespace-only must forward-delete, not quit; value still %q", got)
+	}
+	if m.state != tuiIdle {
+		t.Fatalf("must not quit on whitespace-only input")
 	}
 }
 
@@ -79,47 +107,114 @@ func TestCtrlDQuitsWhenIdleAndEmpty(t *testing.T) {
 	}
 }
 
-func TestActiveAtTokenRespectsCursor(t *testing.T) {
+func TestActiveAtTokenFullSpanAndMidCursor(t *testing.T) {
 	val := "see @foo and more"
-	// Cursor after "@fo"
+	// Cursor mid-token after "@fo"
 	cursor := strings.Index(val, "@fo") + len("@fo")
-	at, tok, ok := activeAtToken(val, cursor)
-	if !ok || at != strings.Index(val, "@") || tok != "fo" {
-		t.Fatalf("activeAtToken mid-token = (%d,%q,%v), want @ offset and fo", at, tok, ok)
+	at, end, tok, ok := activeAtToken(val, cursor)
+	if !ok || at != strings.Index(val, "@") || tok != "foo" {
+		// Full token is "foo" even mid-token (extends past caret to space).
+		t.Fatalf("activeAtToken mid-token = (%d,%d,%q,%v), want full token foo", at, end, tok, ok)
 	}
-	// Cursor before '@' (on the space): no active token
-	before := strings.Index(val, "@")
-	at, tok, ok = activeAtToken(val, before)
-	if ok {
-		t.Fatalf("cursor before @ should not open token, got (%d,%q,%v)", at, tok, ok)
+	if val[at:end] != "@foo" {
+		t.Fatalf("span = %q, want @foo", val[at:end])
 	}
 }
 
-func TestShiftTabAndBacktabCycleMode(t *testing.T) {
+func TestAcceptAtCompletionReplacesFullToken(t *testing.T) {
+	// Manual completion state: proves replaceFrom/replaceTo replace the whole
+	// token and preserve surrounding spaces (the audited "see @foo and more"
+	// regression).
+	m := newTestChatTUI()
+	m.input.SetValue("see @foo and more")
+	// "@foo" spans bytes [4, 8)
+	m.completion = completion{
+		active:      true,
+		kind:        compAt,
+		items:       []compItem{{label: "@foobar.md", insert: "@foobar.md"}},
+		sel:         0,
+		replaceFrom: 4,
+		replaceTo:   8,
+	}
+	m.acceptCompletion()
+	got := m.input.Value()
+	want := "see @foobar.md and more"
+	if got != want {
+		t.Fatalf("accept mid-token = %q, want %q", got, want)
+	}
+}
+
+func TestInputCursorByteOffsetSubtractsPrompt(t *testing.T) {
 	ctrl := control.New(control.Options{})
-	// New controllers default to Ask; Shift+Tab cycles Ask→Auto→Plan.
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	// Place "hello!!" and put caret after "hello" (rune index 5).
+	m.input.SetValue("hello!!")
+	m.setComposerCursor(5)
+	// Force layout cache used by inputCursorByteOffset.
+	_ = m.composerRows()
+	got := m.inputCursorByteOffset()
+	if got != 5 {
+		t.Fatalf("inputCursorByteOffset = %d, want 5 (prompt gutter must not add 2)", got)
+	}
+}
+
+func TestShiftTabAndBacktabBothAccepted(t *testing.T) {
+	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
 	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = m0.(chatTUI)
 	if m.ctrl == nil {
 		t.Fatal("expected controller")
 	}
-	before := m.ctrl.ToolApprovalMode()
+
+	// Exercise the string switch arms directly via synthetic msgs. Platforms
+	// may stringify KeyTab+Shift as either "shift+tab" or "backtab"; we force
+	// both paths by calling the handler logic through Update when possible and
+	// asserting the case labels exist by cycling twice with known strings.
+	//
+	// KeyTab+ModShift:
 	msg := tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
 	s := msg.String()
 	if s != "shift+tab" && s != "backtab" {
-		t.Fatalf("KeyTab+ModShift String() = %q, want shift+tab or backtab", s)
+		t.Fatalf("KeyTab+ModShift String() = %q", s)
 	}
+	before := m.ctrl.ToolApprovalMode()
 	out, _ := m.Update(msg)
 	m = out.(chatTUI)
 	if m.ctrl.ToolApprovalMode() == before && !m.planMode {
-		t.Fatalf("%q did not cycle mode (still %v, plan=%v)", s, before, m.planMode)
+		t.Fatalf("%q did not cycle mode", s)
+	}
+
+	// Second encoding: if the first was "shift+tab", still verify "backtab"
+	// is handled by re-entering the switch with a raw message after resetting
+	// mode. We can't construct a KeyPressMsg that String()s to the other form
+	// portably, so call cycleMode once more and assert "backtab" is listed in
+	// the case clause by scanning source... instead: use update path only for
+	// the platform form and unit-check that both strings are in the switch via
+	// a tiny helper.
+	for _, key := range []string{"shift+tab", "backtab"} {
+		if !modeToggleKey(key) {
+			t.Fatalf("%q must be a recognized mode-toggle key", key)
+		}
+	}
+}
+
+// modeToggleKey reports whether s is a recognized Shift+Tab encoding for the
+// mode cycle switch in chatTUI.update (both platform forms must be listed).
+func modeToggleKey(s string) bool {
+	switch s {
+	case "shift+tab", "backtab":
+		return true
+	default:
+		return false
 	}
 }
 
 // BenchmarkSlashCompletionKeystroke measures filter+menu update with a large
-// catalog (1000 skills). Cached catalog build should keep per-keystroke work
-// well under a frame budget on a typical laptop.
+// catalog (1000 skills). Catalog is warmed once; per-op cost must stay low and
+// allocation-stable (no fingerprint rebuild).
 func BenchmarkSlashCompletionKeystroke(b *testing.B) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
@@ -130,9 +225,8 @@ func BenchmarkSlashCompletionKeystroke(b *testing.B) {
 			Description: "benchmark skill description " + strings.Repeat("x", 80),
 		})
 	}
-	// Warm the catalog once.
-	_ = m.slashItems()
-	start := time.Now()
+	_ = m.slashItems() // warm catalog once
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m.input.SetValue("/be")
@@ -143,10 +237,7 @@ func BenchmarkSlashCompletionKeystroke(b *testing.B) {
 	}
 	b.StopTimer()
 	if b.N > 0 {
-		per := time.Since(start) / time.Duration(b.N)
-		// Soft gate for local CI laptops: 16ms frame budget.
-		if per > 16*time.Millisecond {
-			b.Logf("WARNING: slash completion keystroke p50-ish %v exceeds 16ms frame budget (n=%d)", per, b.N)
-		}
+		// Informational soft gate; CI machines vary.
+		_ = time.Millisecond
 	}
 }

--- a/internal/cli/slash_catalog_test.go
+++ b/internal/cli/slash_catalog_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/command"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/skill"
+)
+
+func TestSlashCatalogCachesAcrossKeystrokes(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.skills = make([]skill.Skill, 0, 50)
+	for i := 0; i < 50; i++ {
+		m.skills = append(m.skills, skill.Skill{
+			Name:        fmt.Sprintf("skill-%03d", i),
+			Description: strings.Repeat("description text for catalog build ", 20),
+		})
+	}
+	m.commands = []command.Command{{Name: "custom-cmd", Description: "custom"}}
+
+	first := m.slashItems()
+	if len(first) < 50 {
+		t.Fatalf("catalog size = %d, want at least 50 skills", len(first))
+	}
+	// Second call must reuse the same backing slice (immutable snapshot).
+	second := m.slashItems()
+	if &first[0] != &second[0] || len(first) != len(second) {
+		t.Fatal("slashItems must return the cached catalog between keystrokes")
+	}
+	// Fingerprint change (skill list) invalidates.
+	m.skills = append(m.skills, skill.Skill{Name: "skill-extra", Description: "extra"})
+	m.invalidateSlashCatalog()
+	third := m.slashItems()
+	if len(third) != len(first)+1 {
+		t.Fatalf("after skill add catalog = %d, want %d", len(third), len(first)+1)
+	}
+}
+
+func TestCtrlDForwardDeletesWhenComposerNonEmpty(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	m.input.SetValue("hello")
+	m.input.SetCursorColumn(0) // caret at start so forward-delete removes 'h'
+
+	msg := tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
+	if msg.String() != "ctrl+d" {
+		t.Fatalf("synthetic key String() = %q, want ctrl+d", msg.String())
+	}
+	out, _ := m.Update(msg)
+	m = out.(chatTUI)
+	if got := m.input.Value(); got != "ello" {
+		t.Fatalf("ctrl+d on non-empty = %q, want ello", got)
+	}
+	if m.state != tuiIdle {
+		t.Fatalf("state = %v, want idle (must not quit)", m.state)
+	}
+}
+
+func TestCtrlDQuitsWhenIdleAndEmpty(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	m.input.SetValue("")
+	msg := tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}
+	_, cmd := m.Update(msg)
+	if cmd == nil {
+		t.Fatal("ctrl+d on empty idle composer should request shutdown")
+	}
+}
+
+func TestActiveAtTokenRespectsCursor(t *testing.T) {
+	val := "see @foo and more"
+	// Cursor after "@fo"
+	cursor := strings.Index(val, "@fo") + len("@fo")
+	at, tok, ok := activeAtToken(val, cursor)
+	if !ok || at != strings.Index(val, "@") || tok != "fo" {
+		t.Fatalf("activeAtToken mid-token = (%d,%q,%v), want @ offset and fo", at, tok, ok)
+	}
+	// Cursor before '@' (on the space): no active token
+	before := strings.Index(val, "@")
+	at, tok, ok = activeAtToken(val, before)
+	if ok {
+		t.Fatalf("cursor before @ should not open token, got (%d,%q,%v)", at, tok, ok)
+	}
+}
+
+func TestShiftTabAndBacktabCycleMode(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	// New controllers default to Ask; Shift+Tab cycles Ask→Auto→Plan.
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	if m.ctrl == nil {
+		t.Fatal("expected controller")
+	}
+	before := m.ctrl.ToolApprovalMode()
+	msg := tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+	s := msg.String()
+	if s != "shift+tab" && s != "backtab" {
+		t.Fatalf("KeyTab+ModShift String() = %q, want shift+tab or backtab", s)
+	}
+	out, _ := m.Update(msg)
+	m = out.(chatTUI)
+	if m.ctrl.ToolApprovalMode() == before && !m.planMode {
+		t.Fatalf("%q did not cycle mode (still %v, plan=%v)", s, before, m.planMode)
+	}
+}
+
+// BenchmarkSlashCompletionKeystroke measures filter+menu update with a large
+// catalog (1000 skills). Cached catalog build should keep per-keystroke work
+// well under a frame budget on a typical laptop.
+func BenchmarkSlashCompletionKeystroke(b *testing.B) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.skills = make([]skill.Skill, 0, 1000)
+	for i := 0; i < 1000; i++ {
+		m.skills = append(m.skills, skill.Skill{
+			Name:        fmt.Sprintf("bench-skill-%04d", i),
+			Description: "benchmark skill description " + strings.Repeat("x", 80),
+		})
+	}
+	// Warm the catalog once.
+	_ = m.slashItems()
+	start := time.Now()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.input.SetValue("/be")
+		m.updateCompletion()
+		if !m.completion.active {
+			b.Fatal("expected completion menu")
+		}
+	}
+	b.StopTimer()
+	if b.N > 0 {
+		per := time.Since(start) / time.Duration(b.N)
+		// Soft gate for local CI laptops: 16ms frame budget.
+		if per > 16*time.Millisecond {
+			b.Logf("WARNING: slash completion keystroke p50-ish %v exceeds 16ms frame budget (n=%d)", per, b.N)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Integration PR B for the 30-day CLI feedback plan: input lag, completion cursor, and keyboard contracts.

### Addresses

| Issue | Mechanism |
| --- | --- |
| #6417 / #7090 | Immutable slash catalog rebuilt only on **explicit invalidation** (model switch, skill rescan, `/reload-cmd`, **all MCP host mutations** via `refreshHostAndInvalidateSlashCatalog`). Ordinary keystrokes only filter the cache — no fingerprint walk. |
| #6660 | Production `modeToggleKey` accepts terminal `backtab` **and** `shift+tab`; Update path uses the helper (tested with KeyTab+Shift and `Text:"backtab"`). |
| #7638-class / Ctrl+D | Any raw non-empty composer content (including whitespace-only) → forward delete; idle + truly empty → quit |
| #6739 / #7495 / #7000 / #7537 | Shared key priority path (completion overlay first); foundation for further overlay work |

### Related (not claimed fixed)

| Issue | Note |
| --- | --- |
| Refs #6719 | Caret-aware full-token `@` replace (`replaceFrom`/`replaceTo`) + prompt-gutter-corrected cursor offset + **caret-limited filter query**. Existing unit tests prove token math and accept span; a real slash-skill → move-caret-to-bol → mid-line input interactive regression is still missing, so this stays **Refs** only until that lands. |

### Audit follow-ups

**Round 1 (`437f3541b`)**

1. Cursor gutter + full token replace span
2. Catalog fingerprint removed from hot path
3. Ctrl+D raw emptiness

**Round 2 (`fd1217a74`)**

1. `activeAtToken`: query = text after `@` **up to caret**; `end` = full token for replace only (`@fo|o` → query `"fo"`, span `"@foo"`).
2. Unified `refreshHostAndInvalidateSlashCatalog` / `setHostAndInvalidateSlashCatalog` on MCPSurfaceReady, connect/disconnect/remove/import, auth clear, `/mcp add|connect|remove`, model switch.
3. Lint SA9003 empty branch removed.
4. Production `modeToggleKey`; dual-encoding covered through real Update path.

### Not in this PR

- Full 20k-line viewport work → Integration C
- Extracting only isolated tests from #7211 without adopting its 104-file product direction
- Real interactive regression for the original #6719 slash-skill mid-line caret scenario

## Verification

- `go test ./internal/cli -count=1`
- `TestMCPSurfaceReadyInvalidatesSlashCatalog`
- `TestActiveAtTokenFullSpanAndMidCursor` (query `fo`, span `@foo`)
- `TestShiftTabAndBacktabBothAccepted` (helper + Update for both encodings)
- `go test ./internal/cli -bench=BenchmarkSlashCompletionKeystroke -benchmem -benchtime=50x` (warm catalog filter-only path)

## Cache impact

Cache-impact: none - TUI input/completion only; no provider prompt, tool schema, MCP registration, or compaction changes.
Cache-guard: N/A
System-prompt-review: not required

Documentation-impact: none - keyboard behaviour matches documented Shift+Tab / composer conventions; no new config keys.

## Compatibility

- Default slash menu content unchanged (still lists skills as `/name`).
- Esc cancel semantics unchanged (does not adopt #7606).