### PR TITLE
docs: correct extension-protocol -check CI claim

### DIFF
--- a/docs/EXTENSION_PROTOCOL.md
+++ b/docs/EXTENSION_PROTOCOL.md
@@ -137,8 +137,9 @@ Within major version 1, the only permitted evolutions are: new optional
 fields, new enum values, and new methods. Existing required fields,
 directions, limits, error reasons, and semantics never change. The canonical
 schema and its SHA-256 hash are produced by `cmd/extension-protocol-gen`;
-CI runs it with `-check` so any drift — including an accidental semantic
-change — fails the build.
+CI's `go test ./...` enforces this via the deterministic-generation test
+(`TestGeneratedArtifactsAreDeterministicAndCommitted`), so any drift —
+including an accidental semantic change — fails the build.
 
 ## Security model
 

--- a/docs/EXTENSION_PROTOCOL.zh-CN.md
+++ b/docs/EXTENSION_PROTOCOL.zh-CN.md
@@ -113,8 +113,10 @@ retryable、action）；`protocol_error`、`unknown_method`、
 
 major v1 内只允许：新增 optional 字段、新增枚举值、新增方法。既有
 必填字段、方向、限额、错误 reason 与语义永不改变。canonical Schema
-及其 SHA-256 hash 由 `cmd/extension-protocol-gen` 产生；CI 以
-`-check` 运行，任何漂移——包括意外语义变更——都会令构建失败。
+及其 SHA-256 hash 由 `cmd/extension-protocol-gen` 产生；CI 的
+`go test ./...` 会运行确定性生成测试（
+`TestGeneratedArtifactsAreDeterministicAndCommitted`），任何漂移——包括
+意外语义变更——都会令构建失败。
 
 ## 安全模型
 


### PR DESCRIPTION
## Summary

`docs/EXTENSION_PROTOCOL.md` claimed "CI runs it with `-check`", but no CI workflow invokes `extension-protocol-gen -check` — the flag exists only in `cmd/extension-protocol-gen/main.go:12`. The real protection is the deterministic-generation drift test (`TestGeneratedArtifactsAreDeterministicAndCommitted`), which CI runs via `go test ./...`.

Reworded the paragraph in both `docs/EXTENSION_PROTOCOL.md` and `docs/EXTENSION_PROTOCOL.zh-CN.md` to state the actual mechanism.

## Verification

- Claim cross-checked against `ci.yml` (go test jobs) and the drift test location
- Paragraph structure preserved; `.generated.md` untouched

## Documentation impact

Documentation-impact: updated - corrected the CI mechanism claim in EXTENSION_PROTOCOL.md (en + zh-CN).

## Cache impact

Cache-impact: none - docs-only change.
Cache-guard: N/A
System-prompt-review: N/A
