### PR TITLE
fix(npm): validate optionalDependencies match build targets

### DIFF
--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -97,6 +97,24 @@ mainPkg.reasonixCandidateSha = candidateSha;
 for (const key of Object.keys(mainPkg.optionalDependencies)) {
   mainPkg.optionalDependencies[key] = version;
 }
+// Guard against drift between the platform packages we build and the
+// optionalDependencies the main package declares: a typo would otherwise ship
+// a main package referencing a binary package that was never built.
+const expectedNames = TARGETS.map((t) => `@reasonix/cli-${t.node}`);
+const writtenNames = Object.keys(mainPkg.optionalDependencies);
+const missing = expectedNames.filter((name) => !writtenNames.includes(name));
+const unexpected = writtenNames.filter(
+  (key) => !/^@reasonix\/cli-/.test(key) || !expectedNames.includes(key),
+);
+if (missing.length > 0 || unexpected.length > 0) {
+  throw new Error(
+    [
+      "main package optionalDependencies do not match build targets:",
+      ...(missing.length > 0 ? [`missing: ${missing.join(", ")}`] : []),
+      ...(unexpected.length > 0 ? [`unexpected: ${unexpected.join(", ")}`] : []),
+    ].join("\n"),
+  );
+}
 writeFileSync(
   join(mainDir, "package.json"),
   `${JSON.stringify(mainPkg, null, 2)}\n`,


### PR DESCRIPTION
## Summary

`npm/build.mjs` generates per-platform binaries named `@reasonix/cli-<node>` and writes them as `optionalDependencies` into the main package.json, but nothing verified the two name sets match — a typo would silently ship a main package referencing a non-existent optional dep.

Added a validation block (before the package.json write) asserting set equality in both directions plus the `^@reasonix/cli-` pattern: missing target-derived names and unexpected/stray keys both fail the build loudly.

## Verification

- `node --check npm/build.mjs` — syntax OK
- Logic harness: matching set passes; missing key, typo key, and non-pattern key all rejected with clear messages
- Real package.json contains exactly the 6 expected keys, so the production path passes

## Documentation impact

Documentation-impact: none - npm build tooling; no user-visible docs affected.

## Cache impact

Cache-impact: none - npm build script only; not a cache-sensitive path.
Cache-guard: N/A
System-prompt-review: N/A
