### PR TITLE
ci(workers): apply D1 migrations in accounts deploy

### DIFF
--- a/.github/workflows/deploy-accounts-worker.yml
+++ b/.github/workflows/deploy-accounts-worker.yml
@@ -29,6 +29,13 @@ jobs:
           node-version: "24"
           cache: pnpm
           cache-dependency-path: workers/accounts/pnpm-lock.yaml
+      - name: Apply D1 migrations
+        working-directory: workers/accounts
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          pnpm install --frozen-lockfile
+          npx wrangler d1 migrations apply reasonix-accounts --remote
       - name: Deploy
         working-directory: workers/accounts
         env:


### PR DESCRIPTION
## Summary

`workers/accounts` has a second D1 migration (`migrations/0002_device_grants.sql`) that would silently never reach production: the deploy workflow (`deploy-accounts-worker.yml`) had no migration step, and `wrangler.toml` documents `d1 migrations apply --remote` only as a manual first-deploy step.

Added an **Apply D1 migrations** step before Deploy, reusing the existing `CLOUDFLARE_API_TOKEN` step-env pattern, with `pnpm install --frozen-lockfile` first so `npx wrangler` resolves the project-pinned version. `wrangler d1 migrations apply` is idempotent (tracks applied migrations), so re-runs are safe.

## Verification

- `python3 yaml.safe_load` — valid; step order: Apply D1 migrations → Deploy → Sync RESEND_API_KEY
- DB name `reasonix-accounts` matches wrangler.toml and the package.json `db:apply:remote` script

## Documentation impact

Documentation-impact: none - deploy workflow; no user-visible docs affected.

## Cache impact

Cache-impact: none - CI workflow only; not a cache-sensitive path.
Cache-guard: N/A
System-prompt-review: N/A
