### PR TITLE
feat(config): load .reasonix/reasonix.toml as project fallback

### DIFF
--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -200,10 +200,14 @@ Runtime configuration is resolved in this order:
 ```text
 command-line flags
 > project ./reasonix.toml
+> project .reasonix/reasonix.toml (fallback when the root file is absent)
 > global <Reasonix home>/config.toml
 > compatible legacy global config
 > built-in defaults
 ```
+
+When both project files exist, `./reasonix.toml` wins. New project configs
+are still created at `./reasonix.toml` unless a nested file is already in use.
 
 Writes always target the new global path:
 

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -161,10 +161,13 @@ Linux 的 `$XDG_CACHE_HOME/reasonix` 或 `~/.cache/reasonix`、Windows 的
 ```text
 命令行参数
 > 项目 ./reasonix.toml
+> 项目 .reasonix/reasonix.toml（根文件不存在时的备选）
 > 全局 <Reasonix home>/config.toml
 > 兼容读取的旧全局配置
 > 内置默认值
 ```
+
+两个项目文件同时存在时，以 `./reasonix.toml` 为准。新建项目配置仍写入 `./reasonix.toml`，除非已经在使用嵌套路径。
 
 写配置时始终写入新的全局路径：
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -657,7 +657,7 @@ type Chunk struct {
 
 ## 5. Configuration (TOML)
 
-Resolution order: **flag > project `./reasonix.toml` > the user config file
+Resolution order: **flag > project `./reasonix.toml` > project `.reasonix/reasonix.toml` (fallback) > the user config file
 > built-in defaults**. Starting with **Reasonix v1.8.1**, the user config lives
 at `~/.reasonix/config.toml` on macOS/Linux and
 `%AppData%\reasonix\config.toml` on Windows. See

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -224,7 +224,7 @@ provider 层的核心类型包括 `Role`、`Message`、`ToolCall`、`ToolSchema`
 配置优先级：
 
 ```text
-flag > ./reasonix.toml > 用户 config.toml > 内置默认值
+flag > ./reasonix.toml > .reasonix/reasonix.toml（根文件不存在时的备选）> 用户 config.toml > 内置默认值
 ```
 
 从 v1.8.1 起，用户配置位于 macOS/Linux 的 `~/.reasonix/config.toml` 或 Windows 的 `%AppData%\reasonix\config.toml`。provider key 保存在 Reasonix home 的 `.env`；项目 `.env` 只用于 workspace 范围的非 provider 变量展开。完整路径见[配置路径](./CONFIG_PATHS.zh-CN.md)。

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -147,10 +147,7 @@ func credentialEnvNamesForRoot(root string) []string {
 	root = resolveRoot(root)
 	cfg := Default()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := projectTOMLPath(root)
 	if uc := userConfigLoadPath(); uc != "" {
 		_ = mergeFile(cfg, uc)
 	}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -2376,13 +2376,16 @@ func (c *Config) Save() error {
 // are edited from their own TOML only, never from a runtime user+project merge.
 func (c *Config) SaveForRoot(root string) error {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
-	if _, err := os.Stat(projectTOML); err == nil {
+	projectTOML := projectTOMLPath(root)
+	if info, err := os.Stat(projectTOML); err == nil && !info.IsDir() {
 		projectCfg := LoadForEditWithoutCredentials(projectTOML)
 		return projectCfg.SaveTo(projectTOML)
+	}
+	// Neither project file exists yet — create the conventional root path.
+	if root != "." {
+		projectTOML = filepath.Join(root, "reasonix.toml")
+	} else {
+		projectTOML = "reasonix.toml"
 	}
 	if uc := userConfigPath(); uc != "" {
 		if err := os.MkdirAll(filepath.Dir(uc), 0o755); err != nil {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -69,10 +69,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	cfg.setExpansionEnv(expansionEnv)
 	cfg.CredentialsStore = credentialsStoreMode()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := projectTOMLPath(root)
 	if primary := userConfigPath(); primary != "" {
 		if _, err := resolveConfigAccessPath(primary, true); err != nil {
 			return nil, err
@@ -892,10 +889,7 @@ func MigrateLegacyAgentStepLimitsForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
+	projectPath := projectTOMLPath(root)
 	paths = append(paths, projectPath)
 
 	changedAny := false
@@ -937,10 +931,7 @@ func MigrateLegacyRedactToolOutputForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
+	projectPath := projectTOMLPath(root)
 	paths = append(paths, projectPath)
 
 	changedAny := false
@@ -979,10 +970,7 @@ func MigrateLegacyMemoryCompilerForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
+	projectPath := projectTOMLPath(root)
 	paths = append(paths, projectPath)
 
 	changedAny := false

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -620,15 +620,36 @@ func SourcePath() string {
 	return SourcePathForRoot(".")
 }
 
+// projectTOMLPath returns the project-level reasonix.toml to load for root.
+// Prefer <root>/reasonix.toml when present; otherwise fall back to
+// <root>/.reasonix/reasonix.toml so teams can keep project settings out of the
+// repository root (#6007). When neither exists, return the conventional root
+// path so first-time writers still create ./reasonix.toml.
+func projectTOMLPath(root string) string {
+	root = resolveRoot(root)
+	primary := "reasonix.toml"
+	if root != "." {
+		primary = filepath.Join(root, "reasonix.toml")
+	}
+	if info, err := os.Stat(primary); err == nil && !info.IsDir() {
+		return primary
+	}
+	nested := filepath.Join(".reasonix", "reasonix.toml")
+	if root != "." {
+		nested = filepath.Join(root, ".reasonix", "reasonix.toml")
+	}
+	if info, err := os.Stat(nested); err == nil && !info.IsDir() {
+		return nested
+	}
+	return primary
+}
+
 // SourcePathForRoot returns the highest-priority config file that exists under
 // root, or "" if none. Equivalent to SourcePath() when root is ".".
 func SourcePathForRoot(root string) string {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
-	if _, err := os.Stat(projectTOML); err == nil {
+	projectTOML := projectTOMLPath(root)
+	if info, err := os.Stat(projectTOML); err == nil && !info.IsDir() {
 		return projectTOML
 	}
 	if uc := userConfigLoadPath(); uc != "" {

--- a/internal/config/project_toml_path_test.go
+++ b/internal/config/project_toml_path_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProjectTOMLPathPrefersRootThenNested(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, ".reasonix", "reasonix.toml")
+	primary := filepath.Join(root, "reasonix.toml")
+
+	if got := projectTOMLPath(root); got != primary {
+		t.Fatalf("missing both: projectTOMLPath = %q, want conventional %q", got, primary)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nested, []byte("default_model = \"nested/model\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := projectTOMLPath(root); got != nested {
+		t.Fatalf("nested only: projectTOMLPath = %q, want %q", got, nested)
+	}
+
+	if err := os.WriteFile(primary, []byte("default_model = \"root/model\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := projectTOMLPath(root); got != primary {
+		t.Fatalf("both present: projectTOMLPath = %q, want root %q", got, primary)
+	}
+}
+
+func TestLoadForRootReadsNestedProjectTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, "rx-home"))
+	t.Setenv("REASONIX_STATE_HOME", "")
+
+	root := t.TempDir()
+	nested := filepath.Join(root, ".reasonix", "reasonix.toml")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nested, []byte("default_model = \"nested/flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	if got := cfg.DefaultModel; got != "nested/flash" {
+		t.Fatalf("DefaultModel = %q, want nested/flash from .reasonix/reasonix.toml", got)
+	}
+	if got := SourcePathForRoot(root); got != nested {
+		t.Fatalf("SourcePathForRoot = %q, want %q", got, nested)
+	}
+}
+
+func TestLoadForRootRootTOMLWinsOverNested(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, "rx-home"))
+	t.Setenv("REASONIX_STATE_HOME", "")
+
+	root := t.TempDir()
+	nested := filepath.Join(root, ".reasonix", "reasonix.toml")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nested, []byte("default_model = \"nested/flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("default_model = \"root/flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRootReadOnly(root)
+	if err != nil {
+		t.Fatalf("LoadForRootReadOnly: %v", err)
+	}
+	if got := cfg.DefaultModel; got != "root/flash" {
+		t.Fatalf("DefaultModel = %q, want root/flash", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Project config loading only looked at \`./reasonix.toml\`, so teams that want VCS-excluded local settings had to pollute the repo root \`.gitignore\`.
- Prefer \`./reasonix.toml\` when present; otherwise load \`.reasonix/reasonix.toml\`. New project configs still create the root file unless a nested file is already in use.
- Document the fallback in CONFIG_PATHS / SPEC.

## Issues

Fixes #6007

## Verification

```
go test ./internal/config/ -count=1 -run 'TestProjectTOMLPath|TestLoadForRootReadsNested|TestLoadForRootRootTOML'
```

## Documentation impact

Documentation-impact: updated - \`docs/CONFIG_PATHS.md\`, \`docs/CONFIG_PATHS.zh-CN.md\`, \`docs/SPEC.md\`, and \`docs/SPEC.zh-CN.md\` document the nested project config fallback.

## Cache impact

Cache-impact: none - config path resolution only; no provider prompt or tool schema change.
Cache-guard: N/A
System-prompt-review: N/A