### PR TITLE
fix(cli): show renamed titles in startup --resume picker

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1581,9 +1581,9 @@ func interactiveSetup(configPath, envPath string) int {
 }
 
 // pickSessionToResume scans the session dir, takes the 10 most recent, and
-// shows a single-choice menu with timestamp + turn count + first user
-// message so the user can pick one. Returns the chosen path and a process
-// exit code (non-zero when there's nothing to pick or the user cancelled).
+// shows a single-choice menu. Renamed titles (and topic titles / previews) are
+// the primary label — matching in-TUI /resume — with the timestamp as the
+// secondary hint (#7052).
 func pickSessionToResume() (string, int) {
 	sessionDir := resolveCLISessionDir()
 	reclaimCLIRecoveryBranches(sessionDir)
@@ -1596,19 +1596,27 @@ func pickSessionToResume() (string, int) {
 		fmt.Fprintln(os.Stderr, i18n.M.ResumeRequiresTTY)
 		return "", 1
 	}
-	items := make([]menuItem, len(sessions))
-	for i, s := range sessions {
-		when := s.ModTime.Local().Format("01-02 15:04")
-		items[i] = menuItem{
-			name: when,
-			desc: sessionSummary(s),
-		}
-	}
+	items := resumeStartupPickerItems(sessions)
 	idx, err := selectOne(i18n.M.PickSessionLabel, items)
 	if err != nil {
 		return "", 1
 	}
 	return sessions[idx].Path, 0
+}
+
+// resumeStartupPickerItems builds the startup --resume menu rows. Primary
+// label prefers CustomTitle / TopicTitle / Preview (via sessionSummary); the
+// timestamp stays secondary so renames are visible at a glance.
+func resumeStartupPickerItems(sessions []agent.SessionInfo) []menuItem {
+	items := make([]menuItem, len(sessions))
+	for i, s := range sessions {
+		when := s.ModTime.Local().Format("01-02 15:04")
+		items[i] = menuItem{
+			name: sessionSummary(s),
+			desc: when,
+		}
+	}
+	return items
 }
 
 // selectLanguage is the wizard's first prompt: it shows the two UI languages

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -488,3 +488,27 @@ func TestRunResumeSwitchesSession(t *testing.T) {
 		t.Fatalf("history not loaded from target: %+v", hist)
 	}
 }
+
+// TestResumeStartupPickerItemsPreferRenamedTitle proves bare `reasonix --resume`
+// surfaces CustomTitle / TopicTitle as the primary menu label (matching in-TUI
+// /resume), not the timestamp (#7052).
+func TestResumeStartupPickerItemsPreferRenamedTitle(t *testing.T) {
+	when := time.Date(2026, 3, 15, 14, 30, 0, 0, time.Local)
+	sessions := []agent.SessionInfo{
+		{Path: "a.jsonl", Preview: "old preview", Turns: 4, ModTime: when, CustomTitle: "My renamed chat"},
+		{Path: "b.jsonl", Preview: "preview only", Turns: 2, ModTime: when, TopicTitle: "Desktop topic"},
+	}
+	items := resumeStartupPickerItems(sessions)
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	if items[0].name != "4 turns · My renamed chat" {
+		t.Fatalf("custom title primary = %q, want renamed title", items[0].name)
+	}
+	if items[0].desc != "03-15 14:30" {
+		t.Fatalf("timestamp secondary = %q, want 03-15 14:30", items[0].desc)
+	}
+	if items[1].name != "2 turns · Desktop topic" {
+		t.Fatalf("topic title primary = %q, want topic title", items[1].name)
+	}
+}


### PR DESCRIPTION
## Summary
Bare `reasonix --resume` listed sessions with the **timestamp as the primary label** and put `sessionSummary` (CustomTitle / TopicTitle / Preview) in the dim secondary line. In-TUI `/resume` already surfaces the renamed title prominently, so users who renamed chats saw the old timestamp-first picker and thought renames were missing.

This flips the startup picker layout to match `/resume`: title summary first, timestamp as the secondary hint.

## Issues
Fixes #7052

## Verification
- [x] `GOPROXY=https://proxy.golang.org,direct go test ./internal/cli/ -run 'TestResumeStartupPickerItemsPreferRenamedTitle|TestSessionSummary|TestSessionPickerLabel' -count=1`
- [ ] Manual: rename a session in TUI (`/rename` or desktop), quit, run `reasonix --resume` — renamed title should be the primary menu label

## Documentation-impact
None — behavior alignment only; no user-facing docs change required.

## Cache-impact
None.