### PR TITLE
fix(cli): transcript scroll state, wrap cache, and mouse re-enable / 滚动状态机、wrap 缓存与鼠标重启用

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -233,7 +233,11 @@ type chatTUI struct {
 	wrapWidth      int
 	wrapBlockCount int
 	// lastMouseReenable rate-limits ConPTY mouse re-enable sequences (#7583).
-	lastMouseReenable time.Time
+	// mouseReenablePending + timer cover trailing-edge fires after a resize storm.
+	lastMouseReenable       time.Time
+	mouseReenablePending    bool
+	mouseReenableTimerArmed bool
+	mouseReenableSeq        int
 	// wantMouseReenable is set by TurnDone (and similar settle points) and
 	// consumed once in Update so the raw enable sequence is batched with the
 	// frame that paints the settled state.
@@ -451,10 +455,6 @@ const resetMouseTracking = ansi.ResetModeMouseX10 +
 	ansi.ResetModeMouseExtUtf8 +
 	ansi.ResetModeMouseExtUrxvt +
 	ansi.ResetModeMouseExtSgrPixel
-
-// resetThenEnableMouseTracking fully resets then re-enables cell-motion tracking.
-// Used when ConPTY has lost the mode after long output (#7583).
-const resetThenEnableMouseTracking = resetMouseTracking + enableMouseTracking
 
 // compactDoneMsg reports that an async /compact pass returned. The card was
 // already drawn from the CompactionDone event; this only surfaces a failure and
@@ -925,12 +925,14 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// semantic reflow without selecting unrelated text.
 		cm.sel = selection{}
 	}
-	// Rebuild wrap cache when content, width, or in-place dirty edits change.
-	// Append-only streaming is incremental; width/dirty/mid-history is full.
-	forceFullWrap := widthChanged || cm.transcriptDirty || len(cm.transcript) < prevLines
-	if len(cm.transcript) != prevLines || forceFullWrap || cm.wrapWidth != contentW {
+	// Wrap sync: full rebuild only on width change or history shrink. Streaming
+	// answer/tool rewrites use invalidateWrapFrom → suffix-only re-wrap; the
+	// transcriptDirty flag alone must never force a full-history rebuild (#6978).
+	forceFullWrap := widthChanged || len(cm.transcript) < prevLines
+	wrapBehind := cm.wrapWidth != contentW || cm.wrapBlockCount != len(cm.transcript)
+	if forceFullWrap || wrapBehind || len(cm.transcript) != prevLines {
 		if cm.syncWrappedLines(contentW, forceFullWrap) {
-			cm.viewport.SetContent(cm.wrappedContentString())
+			cm.feedViewportContent()
 		}
 		if followTail || cm.shouldFollowTail() {
 			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
@@ -950,17 +952,25 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	cm.transcriptDirty = false
 
-	// Rate-limited mouse re-enable after resize, focus regain, or turn settle
-	// so Windows ConPTY keeps wheel → MouseWheelMsg (#7583).
+	// Rate-limited mouse re-enable after real resize, focus regain, or turn
+	// settle so Windows ConPTY keeps wheel → MouseWheelMsg (#7583). Trailing
+	// timer msgs are handled here too. Same-size WindowSizeMsg (session-switch
+	// rebuilds) must not force a spurious Raw cmd.
 	var mouseCmd tea.Cmd
-	switch msg.(type) {
-	case tea.WindowSizeMsg, tea.FocusMsg:
+	switch v := msg.(type) {
+	case tea.WindowSizeMsg:
+		if cm.width != prevWidth || cm.height != prevHeight {
+			mouseCmd = cm.maybeReenableMouse()
+		}
+	case tea.FocusMsg:
 		mouseCmd = cm.maybeReenableMouse()
+	case mouseReenableMsg:
+		mouseCmd = cm.handleMouseReenableMsg(v)
 	}
 	if cm.wantMouseReenable {
 		cm.wantMouseReenable = false
 		if c := cm.maybeReenableMouse(); c != nil {
-			mouseCmd = tea.Batch(mouseCmd, c)
+			mouseCmd = batchCmds(mouseCmd, c)
 		}
 	}
 
@@ -970,10 +980,29 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// force a full clear+redraw whenever the offset actually moved.
 	if cm.viewport.YOffset() != prevYOff && !cm.nativeScrollback && !cm.sessionSwitch {
 		cm.sessionSwitch = false
-		return cm, tea.Batch(tea.ClearScreen, mouseCmd, cmd)
+		return cm, batchCmds(tea.ClearScreen, mouseCmd, cmd)
 	}
 	cm.sessionSwitch = false
-	return cm, tea.Batch(mouseCmd, cmd)
+	return cm, batchCmds(mouseCmd, cmd)
+}
+
+// batchCmds is tea.Batch that collapses an all-nil list to nil so callers can
+// assert "no work" without false positives from Batch(nil, nil).
+func batchCmds(cmds ...tea.Cmd) tea.Cmd {
+	var out []tea.Cmd
+	for _, c := range cmds {
+		if c != nil {
+			out = append(out, c)
+		}
+	}
+	switch len(out) {
+	case 0:
+		return nil
+	case 1:
+		return out[0]
+	default:
+		return tea.Batch(out...)
+	}
 }
 
 // update runs the model's message handling. Update wraps it to keep the
@@ -1133,6 +1162,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.viewport.ScrollUp(1)
 		}
+		m.syncScrollModeAfterGesture()
 		m.sel.head = m.transcriptCaret(m.dragX, edgeY)
 		// Stop at the boundary so a held edge can't run away to the very end.
 		if (m.autoScroll > 0 && m.viewport.AtBottom()) || (m.autoScroll < 0 && m.viewport.AtTop()) {
@@ -1163,10 +1193,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// "what's selected" cue and a right-click can still re-copy it. A plain
 		// click (no drag) clears any prior selection.
 		if m.scrollbarDrag {
-			m.dragScrollbar(msg.Y)
+			m.dragScrollbar(msg.Y) // already syncs scrollMode
 			m.scrollbarDrag = false
 			m.scrollbarGrabOffset = 0
-			m.syncScrollModeAfterGesture()
 			return m, nil
 		}
 		m.autoScroll = 0 // stop edge auto-scroll
@@ -2269,7 +2298,6 @@ func (m *chatTUI) streamReasoning(chunk string) {
 	m.setTranscriptBlock(m.reasoningTextIdx, reasoningBlock(raw, m.width, reasoningTailLines), transcriptSource{
 		kind: transcriptSourceReasoning, raw: raw, maxLines: reasoningTailLines,
 	})
-	m.transcriptDirty = true
 }
 
 // reasoningBlock renders raw thinking text as dim, width-wrapped lines under a
@@ -2381,8 +2409,7 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 	for i, ln := range vis {
 		lines[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
 	}
-	m.transcript[m.toolStreamIdx] = connectorBlock(lines)
-	m.transcriptDirty = true
+	m.rewriteTranscriptBlock(m.toolStreamIdx, connectorBlock(lines))
 }
 
 // pushToolLine appends a completed output line to the bounded tail, dropping the
@@ -2505,7 +2532,6 @@ func (m *chatTUI) renderSubagentProgress(id string) {
 		return
 	}
 	m.setTranscriptBlock(idx, m.subagentProgressBlock(id, sp), transcriptSource{kind: transcriptSourceSubagentProgress, raw: id})
-	m.transcriptDirty = true
 }
 
 // tickSubagentProgress refreshes the elapsed / recent-activity fields of live
@@ -2515,7 +2541,6 @@ func (m *chatTUI) tickSubagentProgress() {
 	if m.nativeScrollback {
 		return
 	}
-	changed := false
 	for id, sp := range m.subagentProgress {
 		if sp.terminal || sp.phase == "" {
 			continue
@@ -2525,10 +2550,6 @@ func (m *chatTUI) tickSubagentProgress() {
 			continue
 		}
 		m.setTranscriptBlock(idx, m.subagentProgressBlock(id, sp), transcriptSource{kind: transcriptSourceSubagentProgress, raw: id})
-		changed = true
-	}
-	if changed {
-		m.transcriptDirty = true
 	}
 }
 
@@ -2761,7 +2782,7 @@ func (m *chatTUI) collapseShellSlot(id string, idx int, resultOutput string) {
 	if n == 0 {
 		// Tool finished with no output: clear the "working…" placeholder but
 		// keep the slot (shellTranscriptIdx still points here for late progress).
-		m.transcript[idx] = ""
+		m.rewriteTranscriptBlock(idx, "")
 		return
 	}
 	if full, ok := m.shellOutputs[id]; ok {
@@ -2774,16 +2795,16 @@ func (m *chatTUI) collapseShellSlot(id string, idx int, resultOutput string) {
 				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
 			}
 			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
-			m.transcript[idx] = connectorBlock(preview)
+			m.rewriteTranscriptBlock(idx, connectorBlock(preview))
 		} else {
 			rendered := make([]string, total)
 			for i, ln := range lines {
 				rendered[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
 			}
-			m.transcript[idx] = connectorBlock(rendered)
+			m.rewriteTranscriptBlock(idx, connectorBlock(rendered))
 		}
 	} else {
-		m.transcript[idx] = connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))})
+		m.rewriteTranscriptBlock(idx, connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))}))
 	}
 	m.shellTranscriptIdx[id] = idx
 }
@@ -2824,7 +2845,7 @@ func (m *chatTUI) toggleShellOutput() {
 				preview[i] = dim(clampPlain(lines[i], innerW))
 			}
 			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
-			m.transcript[lastIdx] = connectorBlock(preview)
+			m.rewriteTranscriptBlock(lastIdx, connectorBlock(preview))
 		}
 	} else {
 		// Expand: show up to shellExpandMaxLines lines.
@@ -2840,9 +2861,8 @@ func (m *chatTUI) toggleShellOutput() {
 		if total > shellExpandMaxLines {
 			rendered = append(rendered, dim(fmt.Sprintf("… %d more lines", total-shellExpandMaxLines)))
 		}
-		m.transcript[lastIdx] = connectorBlock(rendered)
+		m.rewriteTranscriptBlock(lastIdx, connectorBlock(rendered))
 	}
-	m.transcriptDirty = true
 	if m.nativeScrollback {
 		m.commitLine(m.transcript[lastIdx])
 	}
@@ -2895,8 +2915,7 @@ func (m *chatTUI) tickToolRunning() {
 	m.toolStreamFrame++
 	frame := toolWorkingFrames[m.toolStreamFrame%len(toolWorkingFrames)]
 	secs := int(time.Since(m.toolStreamStart).Seconds())
-	m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf(i18n.M.ChatToolWorkingFmt, frame, secs))})
-	m.transcriptDirty = true
+	m.rewriteTranscriptBlock(m.toolStreamIdx, connectorBlock([]string{dim(fmt.Sprintf(i18n.M.ChatToolWorkingFmt, frame, secs))}))
 }
 
 // commitReasoning closes the live thinking block: the "▎ thinking…" marker is
@@ -2972,9 +2991,10 @@ func (m *chatTUI) streamAnswer() {
 		m.answerIdx = len(m.transcript)
 		m.commitTranscriptSource(source)
 	} else {
+		// setTranscriptBlock invalidates the wrap suffix from answerIdx so the
+		// next Update only re-wraps the live answer block — not the full history.
 		block := m.renderTranscriptSource(source, m.width)
 		m.setTranscriptBlock(m.answerIdx, block, source)
-		m.transcriptDirty = true
 	}
 }
 
@@ -2995,7 +3015,6 @@ func (m *chatTUI) commitPending() {
 	} else {
 		block := m.renderTranscriptSource(source, m.width)
 		m.setTranscriptBlock(m.answerIdx, block, source)
-		m.transcriptDirty = true
 	}
 	m.pending.Reset()
 	m.answerIdx = -1

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -237,7 +237,6 @@ type chatTUI struct {
 	lastMouseReenable       time.Time
 	mouseReenablePending    bool
 	mouseReenableTimerArmed bool
-	mouseReenableSeq        int
 	// wantMouseReenable is set by TurnDone (and similar settle points) and
 	// consumed once in Update so the raw enable sequence is batched with the
 	// frame that paints the settled state.

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -209,8 +209,12 @@ type chatTUI struct {
 	// pin the viewport to the bottom after a session / branch / clear switch
 	// regardless of the previous wasAtBottom state (#4584).
 	forceGotoBottom bool
-	eventCh         chan event.Event
-	started         bool // banner + resumed history committed once
+	// scrollMode is the explicit followTail / userScrolled state machine.
+	// Prefer this over a raw wasAtBottom snapshot so modal height changes
+	// (approval, chooser, pickers) never silently disable tail-follow (#6430).
+	scrollMode scrollFollowMode
+	eventCh    chan event.Event
+	started    bool // banner + resumed history committed once
 
 	// transcript holds every finalized line commitLine emits; the viewport
 	// renders a scrollable window of it (alt-screen owns the grid, so there's no
@@ -221,7 +225,19 @@ type chatTUI struct {
 	// keep their already-rendered text; markdown, user bubbles, reasoning, tool
 	// cards, and replay bundles are regenerated after a resize.
 	transcriptSources []transcriptSource
-	wrappedLines      []string // transcript wrapped to viewport width (rendered each frame)
+	// wrappedLines is the viewport line cache; wrapBlockLines / wrapWidth /
+	// wrapBlockCount support append-only updates without re-wrapping the full
+	// history on every streaming commit (#6978).
+	wrappedLines   []string
+	wrapBlockLines [][]string
+	wrapWidth      int
+	wrapBlockCount int
+	// lastMouseReenable rate-limits ConPTY mouse re-enable sequences (#7583).
+	lastMouseReenable time.Time
+	// wantMouseReenable is set by TurnDone (and similar settle points) and
+	// consumed once in Update so the raw enable sequence is batched with the
+	// frame that paints the settled state.
+	wantMouseReenable bool
 	viewport          viewport.Model
 	sel               selection
 	// autoScroll drives edge-drag scrolling: -1 up, +1 down, 0 off. dragX is the
@@ -435,6 +451,10 @@ const resetMouseTracking = ansi.ResetModeMouseX10 +
 	ansi.ResetModeMouseExtUtf8 +
 	ansi.ResetModeMouseExtUrxvt +
 	ansi.ResetModeMouseExtSgrPixel
+
+// resetThenEnableMouseTracking fully resets then re-enables cell-motion tracking.
+// Used when ConPTY has lost the mode after long output (#7583).
+const resetThenEnableMouseTracking = resetMouseTracking + enableMouseTracking
 
 // compactDoneMsg reports that an async /compact pass returned. The card was
 // already drawn from the CompactionDone event; this only surfaces a failure and
@@ -866,12 +886,15 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			logFirstFrame = true
 		}
 	}
-	wasAtBottom := m.viewport.AtBottom()
+	// Prefer explicit scrollMode over a raw AtBottom snapshot so opening an
+	// approval/chooser (height-only change) does not disable tail-follow (#6430).
+	followTail := m.shouldFollowTail()
 	prevLines := len(m.transcript)
 	prevWidth := m.width
+	prevHeight := m.height
 	prevYOff := m.viewport.YOffset()
 	var resizeAnchor transcriptResizeAnchor
-	if size, ok := msg.(tea.WindowSizeMsg); ok && size.Width != m.width && !wasAtBottom {
+	if size, ok := msg.(tea.WindowSizeMsg); ok && size.Width != m.width && !followTail {
 		resizeAnchor = captureTranscriptResizeAnchor(m.transcript, m.viewport.Width(), prevYOff)
 	}
 
@@ -895,38 +918,62 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// windows. Textarea remains the owner of the scroll offset and caret reveal.
 	cm.syncInputHeightLimit()
 	cm.viewport.SetHeight(cm.transcriptHeight())
-	if cm.width != prevWidth {
+	widthChanged := cm.width != prevWidth
+	if widthChanged {
 		cm.reflowTranscript(cm.width)
 		// Selection coordinates are visual-line based and cannot survive a
 		// semantic reflow without selecting unrelated text.
 		cm.sel = selection{}
 	}
-	// Re-feed only when the content grew or the width changed (re-wrapping is
-	// the expensive part); a bare scroll or spinner tick keeps the offset.
-	if len(cm.transcript) != prevLines || cm.width != prevWidth || cm.transcriptDirty {
-		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
-		cm.viewport.SetContent(wrapped)
-		cm.wrappedLines = strings.Split(wrapped, "\n")
-		if wasAtBottom {
+	// Rebuild wrap cache when content, width, or in-place dirty edits change.
+	// Append-only streaming is incremental; width/dirty/mid-history is full.
+	forceFullWrap := widthChanged || cm.transcriptDirty || len(cm.transcript) < prevLines
+	if len(cm.transcript) != prevLines || forceFullWrap || cm.wrapWidth != contentW {
+		if cm.syncWrappedLines(contentW, forceFullWrap) {
+			cm.viewport.SetContent(cm.wrappedContentString())
+		}
+		if followTail || cm.shouldFollowTail() {
 			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
-		} else if cm.width != prevWidth && resizeAnchor.valid {
+			cm.markFollowTail()
+		} else if widthChanged && resizeAnchor.valid {
 			cm.viewport.SetYOffset(resizeAnchor.yOffset(cm.transcript, contentW))
 		}
+	} else if followTail && (cm.forceGotoBottom || cm.height != prevHeight) {
+		// Height-only change (modal open/close, status wrap) must still pin
+		// when we are in followTail — without waiting for new transcript.
+		cm.viewport.GotoBottom()
 	}
 	if cm.forceGotoBottom {
 		cm.viewport.GotoBottom()
+		cm.markFollowTail()
 		cm.forceGotoBottom = false
 	}
 	cm.transcriptDirty = false
+
+	// Rate-limited mouse re-enable after resize, focus regain, or turn settle
+	// so Windows ConPTY keeps wheel → MouseWheelMsg (#7583).
+	var mouseCmd tea.Cmd
+	switch msg.(type) {
+	case tea.WindowSizeMsg, tea.FocusMsg:
+		mouseCmd = cm.maybeReenableMouse()
+	}
+	if cm.wantMouseReenable {
+		cm.wantMouseReenable = false
+		if c := cm.maybeReenableMouse(); c != nil {
+			mouseCmd = tea.Batch(mouseCmd, c)
+		}
+	}
+
 	// Any viewport scroll (wheel, PgUp/PgDn, edge auto-scroll, or tail-follow to
 	// newest output) shifts the whole window. Some terminals (Warp) mishandle
 	// the renderer's scroll/insert-line optimization and strand stale rows, so
 	// force a full clear+redraw whenever the offset actually moved.
 	if cm.viewport.YOffset() != prevYOff && !cm.nativeScrollback && !cm.sessionSwitch {
-		return cm, tea.Batch(tea.ClearScreen, cmd)
+		cm.sessionSwitch = false
+		return cm, tea.Batch(tea.ClearScreen, mouseCmd, cmd)
 	}
 	cm.sessionSwitch = false
-	return cm, cmd
+	return cm, tea.Batch(mouseCmd, cmd)
 }
 
 // update runs the model's message handling. Update wraps it to keep the
@@ -952,6 +999,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.history = nil
 		}
 
+	case tea.FocusMsg:
+		// Terminal regained focus — ConPTY may have dropped mouse tracking
+		// while the pane was unfocused (#7583). Re-enable is issued from Update.
+		return m, nil
+
 	case tea.MouseWheelMsg:
 		if m.mouseOverComposer(msg.X, msg.Y) {
 			delta := 0
@@ -974,6 +1026,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.MouseWheelDown:
 			m.viewport.ScrollDown(3)
 		}
+		m.syncScrollModeAfterGesture()
 		return m, nil
 
 	case tea.MouseClickMsg:
@@ -1113,6 +1166,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.dragScrollbar(msg.Y)
 			m.scrollbarDrag = false
 			m.scrollbarGrabOffset = 0
+			m.syncScrollModeAfterGesture()
 			return m, nil
 		}
 		m.autoScroll = 0 // stop edge auto-scroll
@@ -1204,15 +1258,19 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "pgup":
 			m.viewport.PageUp()
+			m.syncScrollModeAfterGesture()
 			return m, finalize(m, cmds)
 		case "pgdown":
 			m.viewport.PageDown()
+			m.syncScrollModeAfterGesture()
 			return m, finalize(m, cmds)
 		case "ctrl+home":
 			m.viewport.GotoTop()
+			m.markUserScrolled()
 			return m, finalize(m, cmds)
 		case "ctrl+end":
 			m.viewport.GotoBottom()
+			m.markFollowTail()
 			return m, finalize(m, cmds)
 		case "ctrl+z":
 			return m, suspendWithMouseReset()
@@ -1531,6 +1589,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				line := strings.TrimSpace(m.input.Value())
 				if line == "" {
 					m.viewport.GotoBottom()
+					m.markFollowTail()
 					return m, nil
 				}
 				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
@@ -1556,6 +1615,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			if line == "" {
 				m.viewport.GotoBottom()
+				m.markFollowTail()
 				return m, nil
 			}
 			if line == "exit" || line == "quit" || line == ":q" {
@@ -1951,7 +2011,7 @@ func (m *chatTUI) clearTranscriptDisplay() {
 	}
 	m.transcript = nil
 	m.transcriptSources = nil
-	m.wrappedLines = nil
+	m.clearWrapCache()
 	m.viewport.SetContent("")
 	m.shellOutputs = make(map[string]string)
 	m.shellExpanded = make(map[string]bool)
@@ -3357,7 +3417,7 @@ func (m chatTUI) View() tea.View {
 			if cur := m.composerCursor(); cur != nil {
 				cur.X += 1
 				cur.Y += rowsAboveBox + 1
-				v.Cursor = cur
+				v.Cursor = clampCursorToTerminal(cur, m.width, m.height)
 			}
 		}
 		return v
@@ -3383,15 +3443,40 @@ func (m chatTUI) View() tea.View {
 	// Anchor the real terminal cursor at the textarea's insertion point only when
 	// the composer is visible. input.Cursor() is relative to the textarea; offset
 	// by the viewport height + rows above + the box's top border row (+1 column
-	// for PaddingLeft).
+	// for PaddingLeft). Clamp to terminal bounds so VS Code fullscreen / resize
+	// storms cannot leave the caret off-grid (#6282, #7236).
 	if !hideComposer {
 		if cur := m.composerCursor(); cur != nil {
 			cur.X += 1
 			cur.Y += m.viewport.Height() + rowsAboveBox + 1
-			v.Cursor = cur
+			v.Cursor = clampCursorToTerminal(cur, m.width, m.height)
 		}
 	}
 	return v
+}
+
+// clampCursorToTerminal keeps the reported caret inside [0,w) × [0,h).
+func clampCursorToTerminal(cur *tea.Cursor, width, height int) *tea.Cursor {
+	if cur == nil {
+		return nil
+	}
+	if width > 0 {
+		if cur.X < 0 {
+			cur.X = 0
+		}
+		if cur.X >= width {
+			cur.X = width - 1
+		}
+	}
+	if height > 0 {
+		if cur.Y < 0 {
+			cur.Y = 0
+		}
+		if cur.Y >= height {
+			cur.Y = height - 1
+		}
+	}
+	return cur
 }
 
 // compactionCardLines renders a finished compaction as a titled card: a header
@@ -4395,6 +4480,9 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		} else if e.Err != nil && e.Err.Error() != "" && !strings.Contains(e.Err.Error(), "context canceled") {
 			m.commitLine(wrapForViewport(i18n.M.ErrorPrefix+" "+e.Err.Error(), m.width, activeCLITheme.warn))
 		}
+		// Long turns on Windows ConPTY often drop mouse tracking; re-arm on
+		// the next frame so wheel keeps scrolling the transcript (#7583).
+		m.wantMouseReenable = true
 		// Plan-mode approval is now driven by the controller (it emits an
 		// ApprovalRequest when a plan-mode turn produces a proposal), so there's
 		// nothing to detect here.

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -585,6 +585,7 @@ func TestTranscriptResizeKeepsScrolledReaderOnSameBlock(t *testing.T) {
 	contentWidth := transcriptContentWidth(m.width, false)
 	secondBlockStart := transcriptBlockLineCount(m.transcript[0], contentWidth)
 	m.viewport.SetYOffset(secondBlockStart)
+	m.markUserScrolled() // explicit leave-tail; production paths do this via wheel/PgUp
 	if m.viewport.AtBottom() {
 		t.Fatal("test reader anchor must be above the transcript bottom")
 	}

--- a/internal/cli/mouse_reenable.go
+++ b/internal/cli/mouse_reenable.go
@@ -11,26 +11,88 @@ import (
 // View() requests via tea.MouseModeCellMotion. Windows Terminal / ConPTY can
 // drop mouse tracking after long turns, resize storms, or focus loss (#7583);
 // re-sending this sequence restores wheel → MouseWheelMsg instead of bare
-// Up/Down history cycling. Rate-limited so resize spam does not flood the TTY.
-//
-// Defined in this file so chat_tui.go can concatenate resetThenEnableMouseTracking.
+// Up/Down history cycling.
 const enableMouseTracking = ansi.SetModeMouseButtonEvent + ansi.SetModeMouseExtSgr
 
 // mouseReenableMinInterval bounds how often we re-emit enableMouseTracking.
+// Requests inside the window set a pending flag and arm a trailing-edge timer
+// so the *last* resize/focus in a storm still re-enables after the quiet period.
 const mouseReenableMinInterval = 500 * time.Millisecond
 
+// mouseReenableMsg is delivered after the rate-limit quiet period so a pending
+// trailing re-enable can fire without sleeping in tests (inject the msg).
+type mouseReenableMsg struct {
+	seq int
+}
+
 // maybeReenableMouse returns a tea.Raw cmd that re-enables mouse tracking when
-// capture is on and the rate limit allows. No-op for Termux native scrollback
-// (mouse is intentionally off so the soft keyboard can focus) and when the
-// user has toggled capture off via /mouse.
+// capture is on and the rate limit allows. Inside the rate-limit window it
+// records a pending trailing request and arms a one-shot timer (if needed)
+// instead of dropping the request permanently.
+//
+// No-op for Termux native scrollback (mouse is intentionally off so the soft
+// keyboard can focus) and when the user has toggled capture off via /mouse.
 func (m *chatTUI) maybeReenableMouse() tea.Cmd {
 	if m.nativeScrollback || m.mouseCaptureOff {
+		m.mouseReenablePending = false
 		return nil
 	}
-	now := time.Now()
+	now := m.mouseNow()
 	if !m.lastMouseReenable.IsZero() && now.Sub(m.lastMouseReenable) < mouseReenableMinInterval {
+		m.mouseReenablePending = true
+		return m.armMouseReenableTimer(now)
+	}
+	return m.emitMouseReenable(now)
+}
+
+// armMouseReenableTimer schedules a trailing-edge fire for the remaining
+// rate-limit window. Only one timer is armed at a time; later requests just
+// set mouseReenablePending.
+func (m *chatTUI) armMouseReenableTimer(now time.Time) tea.Cmd {
+	if m.mouseReenableTimerArmed {
 		return nil
 	}
+	wait := mouseReenableMinInterval - now.Sub(m.lastMouseReenable)
+	if wait < 0 {
+		wait = 0
+	}
+	m.mouseReenableTimerArmed = true
+	seq := m.mouseReenableSeq
+	return tea.Tick(wait, func(time.Time) tea.Msg {
+		return mouseReenableMsg{seq: seq}
+	})
+}
+
+// emitMouseReenable sends the enable sequence and clears trailing state.
+func (m *chatTUI) emitMouseReenable(now time.Time) tea.Cmd {
 	m.lastMouseReenable = now
+	m.mouseReenablePending = false
+	m.mouseReenableTimerArmed = false
 	return tea.Raw(enableMouseTracking)
 }
+
+// handleMouseReenableMsg processes a trailing-edge timer. Stale seq values
+// (superseded by a later schedule) are ignored.
+func (m *chatTUI) handleMouseReenableMsg(msg mouseReenableMsg) tea.Cmd {
+	if msg.seq != m.mouseReenableSeq {
+		return nil
+	}
+	m.mouseReenableTimerArmed = false
+	if !m.mouseReenablePending {
+		return nil
+	}
+	// Pending request survived the quiet period — fire now (and allow another
+	// trailing cycle if more requests arrive inside the next window).
+	return m.maybeReenableMouse()
+}
+
+// mouseNow is the clock for rate limiting. Tests replace mouseNowFn.
+func (m *chatTUI) mouseNow() time.Time {
+	if mouseNowFn != nil {
+		return mouseNowFn()
+	}
+	return time.Now()
+}
+
+// mouseNowFn, when non-nil, overrides time.Now for mouse re-enable tests.
+var mouseNowFn func() time.Time

--- a/internal/cli/mouse_reenable.go
+++ b/internal/cli/mouse_reenable.go
@@ -21,9 +21,9 @@ const mouseReenableMinInterval = 500 * time.Millisecond
 
 // mouseReenableMsg is delivered after the rate-limit quiet period so a pending
 // trailing re-enable can fire without sleeping in tests (inject the msg).
-type mouseReenableMsg struct {
-	seq int
-}
+// Only one timer is armed at a time (mouseReenableTimerArmed); later requests
+// just set mouseReenablePending, so no generation/seq is required.
+type mouseReenableMsg struct{}
 
 // maybeReenableMouse returns a tea.Raw cmd that re-enables mouse tracking when
 // capture is on and the rate limit allows. Inside the rate-limit window it
@@ -57,9 +57,8 @@ func (m *chatTUI) armMouseReenableTimer(now time.Time) tea.Cmd {
 		wait = 0
 	}
 	m.mouseReenableTimerArmed = true
-	seq := m.mouseReenableSeq
 	return tea.Tick(wait, func(time.Time) tea.Msg {
-		return mouseReenableMsg{seq: seq}
+		return mouseReenableMsg{}
 	})
 }
 
@@ -71,12 +70,9 @@ func (m *chatTUI) emitMouseReenable(now time.Time) tea.Cmd {
 	return tea.Raw(enableMouseTracking)
 }
 
-// handleMouseReenableMsg processes a trailing-edge timer. Stale seq values
-// (superseded by a later schedule) are ignored.
-func (m *chatTUI) handleMouseReenableMsg(msg mouseReenableMsg) tea.Cmd {
-	if msg.seq != m.mouseReenableSeq {
-		return nil
-	}
+// handleMouseReenableMsg processes a trailing-edge timer. If a request was
+// still pending after the quiet period, emit enable now.
+func (m *chatTUI) handleMouseReenableMsg(_ mouseReenableMsg) tea.Cmd {
 	m.mouseReenableTimerArmed = false
 	if !m.mouseReenablePending {
 		return nil

--- a/internal/cli/mouse_reenable.go
+++ b/internal/cli/mouse_reenable.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// enableMouseTracking is the cell-motion + SGR enable sequence matching what
+// View() requests via tea.MouseModeCellMotion. Windows Terminal / ConPTY can
+// drop mouse tracking after long turns, resize storms, or focus loss (#7583);
+// re-sending this sequence restores wheel → MouseWheelMsg instead of bare
+// Up/Down history cycling. Rate-limited so resize spam does not flood the TTY.
+//
+// Defined in this file so chat_tui.go can concatenate resetThenEnableMouseTracking.
+const enableMouseTracking = ansi.SetModeMouseButtonEvent + ansi.SetModeMouseExtSgr
+
+// mouseReenableMinInterval bounds how often we re-emit enableMouseTracking.
+const mouseReenableMinInterval = 500 * time.Millisecond
+
+// maybeReenableMouse returns a tea.Raw cmd that re-enables mouse tracking when
+// capture is on and the rate limit allows. No-op for Termux native scrollback
+// (mouse is intentionally off so the soft keyboard can focus) and when the
+// user has toggled capture off via /mouse.
+func (m *chatTUI) maybeReenableMouse() tea.Cmd {
+	if m.nativeScrollback || m.mouseCaptureOff {
+		return nil
+	}
+	now := time.Now()
+	if !m.lastMouseReenable.IsZero() && now.Sub(m.lastMouseReenable) < mouseReenableMinInterval {
+		return nil
+	}
+	m.lastMouseReenable = now
+	return tea.Raw(enableMouseTracking)
+}

--- a/internal/cli/scroll_state.go
+++ b/internal/cli/scroll_state.go
@@ -1,0 +1,67 @@
+package cli
+
+// scrollFollowMode is an explicit transcript tail-follow state machine.
+//
+// Previously the post-Update path used a single wasAtBottom snapshot taken
+// before the message was applied. Opening an approval/chooser/todo overlay
+// shrinks the viewport (bottomRows grows) without any user scroll, which made
+// AtBottom() flip false and permanently disabled tail-follow until the user
+// manually returned to the bottom (#6430). Long sessions with frequent
+// height-changing panels then looked like "scroll is broken" (#6978).
+//
+// Rules:
+//   - Default is followTail: new content pins the viewport to the bottom.
+//   - Explicit user scroll away from the bottom → userScrolled (wheel-up,
+//     PgUp, scrollbar drag, Ctrl+Home, …).
+//   - Returning to the bottom (wheel/page to end, empty Enter, Ctrl+End,
+//     forceGotoBottom / session switch) restores followTail.
+//   - Modal overlays that only change bottomRows never flip the mode.
+type scrollFollowMode uint8
+
+const (
+	scrollFollowTail scrollFollowMode = iota
+	scrollUserScrolled
+)
+
+// markUserScrolled records that the user intentionally left the live tail.
+func (m *chatTUI) markUserScrolled() {
+	m.scrollMode = scrollUserScrolled
+}
+
+// markFollowTail restores live tail-follow after the user (or a session
+// switch) returns to the newest output.
+func (m *chatTUI) markFollowTail() {
+	m.scrollMode = scrollFollowTail
+}
+
+// shouldFollowTail reports whether new transcript content should pin the
+// viewport to the bottom. forceGotoBottom always wins for one frame.
+func (m chatTUI) shouldFollowTail() bool {
+	return m.scrollMode == scrollFollowTail || m.forceGotoBottom
+}
+
+// modalOpen is true while a panel that steals bottom rows (or the whole main
+// area) is active. Used so height-only layout changes never mark userScrolled.
+func (m chatTUI) modalOpen() bool {
+	if m.pendingApproval != nil || m.chooser != nil || m.rewind != nil {
+		return true
+	}
+	if m.mcp != nil || m.clearConfirm != nil || m.mcpImport != nil {
+		return true
+	}
+	if m.skillPick != nil || m.resumePick != nil || m.quickPick != nil || m.copyPick != nil {
+		return true
+	}
+	return false
+}
+
+// syncScrollModeAfterGesture updates follow state from the current viewport
+// position after an intentional scroll command. Landing on the bottom restores
+// followTail; any other offset marks userScrolled.
+func (m *chatTUI) syncScrollModeAfterGesture() {
+	if m.viewport.AtBottom() {
+		m.markFollowTail()
+		return
+	}
+	m.markUserScrolled()
+}

--- a/internal/cli/scroll_state_test.go
+++ b/internal/cli/scroll_state_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestModalOpenDoesNotDisableTailFollow(t *testing.T) {
+	// Opening an approval banner shrinks the transcript viewport. Without an
+	// explicit scroll state machine that used to make AtBottom() flip false and
+	// permanently stop tail-follow (#6430).
+	ctrl := control.New(control.Options{})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 12})
+	for i := 0; i < 20; i++ {
+		cur = adv(cur, notice)
+	}
+	if !cur.shouldFollowTail() || !cur.viewport.AtBottom() {
+		t.Fatal("expected followTail at bottom after streaming")
+	}
+
+	// Simulate approval popup (height-only change, no user scroll).
+	cur.pendingApproval = &event.Approval{Tool: "bash", Subject: "echo hi"}
+	cur = adv(cur, tea.WindowSizeMsg{Width: 80, Height: 12})
+	if !cur.shouldFollowTail() {
+		t.Fatal("modal open must not mark userScrolled")
+	}
+
+	cur = adv(cur, notice)
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("new output while modal open must keep followTail pin, YOffset=%d", cur.viewport.YOffset())
+	}
+}
+
+func TestUserScrollBreaksAndEmptyEnterRestoresFollow(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+	for i := 0; i < 30; i++ {
+		cur = adv(cur, notice)
+	}
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if cur.shouldFollowTail() {
+		t.Fatal("wheel-up must mark userScrolled")
+	}
+	cur = adv(cur, notice)
+	if cur.viewport.AtBottom() {
+		t.Fatal("output while userScrolled must not yank to bottom")
+	}
+	cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !cur.shouldFollowTail() || !cur.viewport.AtBottom() {
+		t.Fatal("empty Enter must restore followTail and pin bottom")
+	}
+}
+
+func TestWrapCacheAppendOnlyMatchesFullRebuild(t *testing.T) {
+	m := newTestChatTUI()
+	m.width = 40
+	cw := 40
+	// Seed several blocks via full rebuild.
+	for i := 0; i < 5; i++ {
+		m.transcript = append(m.transcript, fmt.Sprintf("block-%d %s", i, strings.Repeat("word ", 20)))
+	}
+	m.rebuildWrappedLinesFull(cw)
+	full := append([]string(nil), m.wrappedLines...)
+
+	// Reset and append one-by-one.
+	m2 := newTestChatTUI()
+	m2.width = 40
+	for i := 0; i < 5; i++ {
+		m2.transcript = append(m2.transcript, m.transcript[i])
+		m2.syncWrappedLines(cw, i == 0)
+	}
+	if len(m2.wrappedLines) != len(full) {
+		t.Fatalf("incremental lines=%d full=%d", len(m2.wrappedLines), len(full))
+	}
+	for i := range full {
+		if m2.wrappedLines[i] != full[i] {
+			t.Fatalf("line %d mismatch\ninc=%q\nfull=%q", i, m2.wrappedLines[i], full[i])
+		}
+	}
+}
+
+func TestClampCursorToTerminal(t *testing.T) {
+	cur := tea.NewCursor(100, -3)
+	got := clampCursorToTerminal(cur, 80, 24)
+	if got.X != 79 || got.Y != 0 {
+		t.Fatalf("clamp = (%d,%d), want (79,0)", got.X, got.Y)
+	}
+}
+
+func TestMouseReenableRateLimit(t *testing.T) {
+	m := newTestChatTUI()
+	m.nativeScrollback = false
+	m.mouseCaptureOff = false
+	cmd1 := m.maybeReenableMouse()
+	if cmd1 == nil {
+		t.Fatal("first re-enable should emit a raw cmd")
+	}
+	cmd2 := m.maybeReenableMouse()
+	if cmd2 != nil {
+		t.Fatal("second re-enable within interval must be rate-limited")
+	}
+	m.lastMouseReenable = time.Now().Add(-2 * mouseReenableMinInterval)
+	cmd3 := m.maybeReenableMouse()
+	if cmd3 == nil {
+		t.Fatal("re-enable after interval should emit again")
+	}
+}
+
+func TestLongTranscriptAppendKeepsFollowAndDoesNotFullRebuildEachTime(t *testing.T) {
+	// Smoke: 2k blocks streaming while followTail stays pinned; wrapBlockCount
+	// tracks growth (append path) rather than staying at 0 after first frame.
+	ctrl := control.New(control.Options{})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 20})
+	const n = 2000
+	for i := 0; i < n; i++ {
+		cur = adv(cur, agentEventMsg(event.Event{
+			Kind: event.Notice, Level: event.LevelInfo,
+			Text: fmt.Sprintf("line-%d-%s", i, strings.Repeat("x", 40)),
+		}))
+	}
+	if !cur.viewport.AtBottom() {
+		t.Fatal("long stream while followTail must stay at bottom")
+	}
+	if cur.wrapBlockCount != len(cur.transcript) {
+		t.Fatalf("wrapBlockCount=%d transcript=%d", cur.wrapBlockCount, len(cur.transcript))
+	}
+	if cur.wrapWidth <= 0 || len(cur.wrappedLines) == 0 {
+		t.Fatal("expected populated wrap cache after long stream")
+	}
+}

--- a/internal/cli/scroll_state_test.go
+++ b/internal/cli/scroll_state_test.go
@@ -180,9 +180,12 @@ func TestStreamAnswerSuffixInvalidationNotFullRebuild(t *testing.T) {
 		}
 	}
 	if cur.answerIdx < 0 {
-		// streamAnswer only opens a block after a flushable prefix; ensure we did.
-		// Empty pending without closed paragraph would leave answerIdx < 0.
-		// Our paragraphs end with \n\n so a block should exist after first Update.
+		// Paragraphs end with \n\n so streamAnswer must open a live answer block.
+		t.Fatal("streamAnswer never opened an answer block after flushable paragraphs")
+	}
+	// Prefix wrap lines must still match the joined content of history blocks.
+	if got := cur.wrappedContentString(); got == "" {
+		t.Fatal("wrappedContentString empty after streamed answer")
 	}
 }
 
@@ -197,8 +200,7 @@ func TestClampCursorToTerminal(t *testing.T) {
 func TestMouseReenableTrailingEdge(t *testing.T) {
 	// Controllable clock: first request emits; second inside the window arms
 	// trailing pending; timer msg after window emits again.
-	var fakeNow time.Time
-	fakeNow = time.Unix(1_700_000_000, 0)
+	fakeNow := time.Unix(1_700_000_000, 0)
 	mouseNowFn = func() time.Time { return fakeNow }
 	t.Cleanup(func() { mouseNowFn = nil })
 
@@ -238,8 +240,7 @@ func TestMouseReenableTrailingEdge(t *testing.T) {
 
 	// Advance clock past the interval and deliver the timer msg.
 	fakeNow = fakeNow.Add(mouseReenableMinInterval + time.Millisecond)
-	seq := m.mouseReenableSeq
-	cmd4 := m.handleMouseReenableMsg(mouseReenableMsg{seq: seq})
+	cmd4 := m.handleMouseReenableMsg(mouseReenableMsg{})
 	if cmd4 == nil {
 		t.Fatal("trailing timer must emit enable when pending")
 	}
@@ -249,8 +250,7 @@ func TestMouseReenableTrailingEdge(t *testing.T) {
 }
 
 func TestMouseReenableRateLimit(t *testing.T) {
-	var fakeNow time.Time
-	fakeNow = time.Unix(1_700_000_000, 0)
+	fakeNow := time.Unix(1_700_000_000, 0)
 	mouseNowFn = func() time.Time { return fakeNow }
 	t.Cleanup(func() { mouseNowFn = nil })
 
@@ -260,10 +260,9 @@ func TestMouseReenableRateLimit(t *testing.T) {
 	if m.maybeReenableMouse() == nil {
 		t.Fatal("first re-enable should emit a raw cmd")
 	}
-	// Second call is trailing schedule, not nil — pending path.
-	if !m.mouseReenablePending {
-		// Call again to enter window
-		_ = m.maybeReenableMouse()
+	// Second call is trailing schedule — pending path, not a silent drop.
+	if m.maybeReenableMouse() == nil && !m.mouseReenablePending {
+		t.Fatal("in-window call must arm trailing pending, not silently drop")
 	}
 	if !m.mouseReenablePending {
 		t.Fatal("in-window call must be pending, not silently dropped")

--- a/internal/cli/scroll_state_test.go
+++ b/internal/cli/scroll_state_test.go
@@ -33,6 +33,9 @@ func TestModalOpenDoesNotDisableTailFollow(t *testing.T) {
 
 	// Simulate approval popup (height-only change, no user scroll).
 	cur.pendingApproval = &event.Approval{Tool: "bash", Subject: "echo hi"}
+	if !cur.modalOpen() {
+		t.Fatal("pendingApproval must report modalOpen")
+	}
 	cur = adv(cur, tea.WindowSizeMsg{Width: 80, Height: 12})
 	if !cur.shouldFollowTail() {
 		t.Fatal("modal open must not mark userScrolled")
@@ -70,18 +73,57 @@ func TestUserScrollBreaksAndEmptyEnterRestoresFollow(t *testing.T) {
 	}
 }
 
+func TestScrollbarDragMotionSyncsBeforeRelease(t *testing.T) {
+	// Drag motion must leave followTail immediately so an interleaved agent
+	// event cannot GotoBottom before MouseRelease.
+	ctrl := control.New(control.Options{})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 10})
+	for i := 0; i < 40; i++ {
+		cur = adv(cur, notice)
+	}
+	if !cur.shouldFollowTail() {
+		t.Fatal("expected followTail before drag")
+	}
+	barX := cur.viewport.Width()
+	// Click thumb region near the top of the scrollbar.
+	cur = adv(cur, tea.MouseClickMsg{X: barX, Y: 0, Button: tea.MouseLeft})
+	if !cur.scrollbarDrag {
+		t.Fatal("expected scrollbar drag")
+	}
+	// First motion moves the offset — must mark userScrolled before release.
+	cur = adv(cur, tea.MouseMotionMsg{X: barX, Y: 0, Button: tea.MouseLeft})
+	if cur.shouldFollowTail() {
+		t.Fatal("drag motion must mark userScrolled before mouse release")
+	}
+	readOffset := cur.viewport.YOffset()
+	// Interleaved streaming event must not yank to bottom.
+	cur = adv(cur, notice)
+	if cur.viewport.AtBottom() {
+		t.Fatal("streaming during scrollbar drag must not jump to bottom")
+	}
+	if got := cur.viewport.YOffset(); got != readOffset {
+		// Offset may grow if content above expands; must not equal bottom.
+		if cur.viewport.AtBottom() {
+			t.Fatalf("YOffset jumped to bottom during drag: %d", got)
+		}
+	}
+}
+
 func TestWrapCacheAppendOnlyMatchesFullRebuild(t *testing.T) {
 	m := newTestChatTUI()
 	m.width = 40
 	cw := 40
-	// Seed several blocks via full rebuild.
 	for i := 0; i < 5; i++ {
 		m.transcript = append(m.transcript, fmt.Sprintf("block-%d %s", i, strings.Repeat("word ", 20)))
 	}
 	m.rebuildWrappedLinesFull(cw)
 	full := append([]string(nil), m.wrappedLines...)
 
-	// Reset and append one-by-one.
 	m2 := newTestChatTUI()
 	m2.width = 40
 	for i := 0; i < 5; i++ {
@@ -98,6 +140,52 @@ func TestWrapCacheAppendOnlyMatchesFullRebuild(t *testing.T) {
 	}
 }
 
+func TestStreamAnswerSuffixInvalidationNotFullRebuild(t *testing.T) {
+	// Real event.Text → streamAnswer path must only re-wrap from answerIdx,
+	// leaving wrapBlockCount of the prefix intact between flushes.
+	ctrl := control.New(control.Options{})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 20})
+	// Seed history blocks.
+	for i := 0; i < 50; i++ {
+		cur = adv(cur, agentEventMsg(event.Event{
+			Kind: event.Notice, Level: event.LevelInfo,
+			Text: fmt.Sprintf("hist-%d %s", i, strings.Repeat("x", 30)),
+		}))
+	}
+	prefixBlocks := cur.wrapBlockCount
+	if prefixBlocks < 50 {
+		t.Fatalf("prefix wrapBlockCount=%d, want >= 50", prefixBlocks)
+	}
+	// Stream a multi-paragraph answer that flushes more than once.
+	cur.state = tuiRunning
+	paras := []string{
+		"First paragraph of the answer that is long enough to wrap.\n\n",
+		"Second paragraph arrives later and rewrites the same block.\n\n",
+		"Third paragraph extends the live answer block again.\n\n",
+	}
+	for _, p := range paras {
+		cur = adv(cur, agentEventMsg(event.Event{Kind: event.Text, Text: p}))
+		// After each flush, the wrap cache should cover all blocks; the live
+		// answer is the last block so wrapBlockCount == len(transcript).
+		if cur.wrapBlockCount != len(cur.transcript) {
+			t.Fatalf("after stream wrapBlockCount=%d transcript=%d", cur.wrapBlockCount, len(cur.transcript))
+		}
+		// Prefix history blocks must still exist; answer is typically one block.
+		if len(cur.transcript) < prefixBlocks {
+			t.Fatal("history blocks disappeared during stream")
+		}
+	}
+	if cur.answerIdx < 0 {
+		// streamAnswer only opens a block after a flushable prefix; ensure we did.
+		// Empty pending without closed paragraph would leave answerIdx < 0.
+		// Our paragraphs end with \n\n so a block should exist after first Update.
+	}
+}
+
 func TestClampCursorToTerminal(t *testing.T) {
 	cur := tea.NewCursor(100, -3)
 	got := clampCursorToTerminal(cur, 80, 24)
@@ -106,48 +194,147 @@ func TestClampCursorToTerminal(t *testing.T) {
 	}
 }
 
-func TestMouseReenableRateLimit(t *testing.T) {
+func TestMouseReenableTrailingEdge(t *testing.T) {
+	// Controllable clock: first request emits; second inside the window arms
+	// trailing pending; timer msg after window emits again.
+	var fakeNow time.Time
+	fakeNow = time.Unix(1_700_000_000, 0)
+	mouseNowFn = func() time.Time { return fakeNow }
+	t.Cleanup(func() { mouseNowFn = nil })
+
 	m := newTestChatTUI()
 	m.nativeScrollback = false
 	m.mouseCaptureOff = false
+
 	cmd1 := m.maybeReenableMouse()
 	if cmd1 == nil {
-		t.Fatal("first re-enable should emit a raw cmd")
+		t.Fatal("first re-enable should emit")
 	}
+	if m.mouseReenablePending {
+		t.Fatal("first fire must clear pending")
+	}
+
+	// Immediate second request inside window → pending + timer.
 	cmd2 := m.maybeReenableMouse()
-	if cmd2 != nil {
-		t.Fatal("second re-enable within interval must be rate-limited")
+	if !m.mouseReenablePending {
+		t.Fatal("second request inside window must set pending")
 	}
-	m.lastMouseReenable = time.Now().Add(-2 * mouseReenableMinInterval)
+	if !m.mouseReenableTimerArmed {
+		t.Fatal("second request must arm trailing timer")
+	}
+	// tea.Tick cmd is non-nil (schedule).
+	if cmd2 == nil {
+		t.Fatal("expected timer cmd for trailing edge")
+	}
+
+	// Third request should not arm another timer.
 	cmd3 := m.maybeReenableMouse()
-	if cmd3 == nil {
-		t.Fatal("re-enable after interval should emit again")
+	if cmd3 != nil {
+		t.Fatal("already-armed timer must not schedule again")
+	}
+	if !m.mouseReenablePending {
+		t.Fatal("pending must stay set")
+	}
+
+	// Advance clock past the interval and deliver the timer msg.
+	fakeNow = fakeNow.Add(mouseReenableMinInterval + time.Millisecond)
+	seq := m.mouseReenableSeq
+	cmd4 := m.handleMouseReenableMsg(mouseReenableMsg{seq: seq})
+	if cmd4 == nil {
+		t.Fatal("trailing timer must emit enable when pending")
+	}
+	if m.mouseReenablePending {
+		t.Fatal("trailing fire must clear pending")
 	}
 }
 
-func TestLongTranscriptAppendKeepsFollowAndDoesNotFullRebuildEachTime(t *testing.T) {
-	// Smoke: 2k blocks streaming while followTail stays pinned; wrapBlockCount
-	// tracks growth (append path) rather than staying at 0 after first frame.
+func TestMouseReenableRateLimit(t *testing.T) {
+	var fakeNow time.Time
+	fakeNow = time.Unix(1_700_000_000, 0)
+	mouseNowFn = func() time.Time { return fakeNow }
+	t.Cleanup(func() { mouseNowFn = nil })
+
+	m := newTestChatTUI()
+	m.nativeScrollback = false
+	m.mouseCaptureOff = false
+	if m.maybeReenableMouse() == nil {
+		t.Fatal("first re-enable should emit a raw cmd")
+	}
+	// Second call is trailing schedule, not nil — pending path.
+	if !m.mouseReenablePending {
+		// Call again to enter window
+		_ = m.maybeReenableMouse()
+	}
+	if !m.mouseReenablePending {
+		t.Fatal("in-window call must be pending, not silently dropped")
+	}
+}
+
+func TestLongTranscriptStreamAnswerScalesSuffixOnly(t *testing.T) {
+	// 1k history + many streaming flushes: wrapBlockCount tracks transcript and
+	// the answer stays a single rewritten block (no full-history force).
 	ctrl := control.New(control.Options{})
 	adv := func(m chatTUI, msg tea.Msg) chatTUI {
 		n, _ := m.Update(msg)
 		return n.(chatTUI)
 	}
 	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 20})
-	const n = 2000
-	for i := 0; i < n; i++ {
+	const hist = 1000
+	for i := 0; i < hist; i++ {
 		cur = adv(cur, agentEventMsg(event.Event{
 			Kind: event.Notice, Level: event.LevelInfo,
-			Text: fmt.Sprintf("line-%d-%s", i, strings.Repeat("x", 40)),
+			Text: fmt.Sprintf("h-%d-%s", i, strings.Repeat("y", 40)),
 		}))
 	}
+	cur.state = tuiRunning
+	for i := 0; i < 30; i++ {
+		cur = adv(cur, agentEventMsg(event.Event{
+			Kind: event.Text,
+			Text: fmt.Sprintf("stream paragraph %d with enough text to flush.\n\n", i),
+		}))
+		if cur.wrapBlockCount != len(cur.transcript) {
+			t.Fatalf("iter %d wrapBlockCount=%d len=%d", i, cur.wrapBlockCount, len(cur.transcript))
+		}
+	}
 	if !cur.viewport.AtBottom() {
-		t.Fatal("long stream while followTail must stay at bottom")
+		t.Fatal("followTail stream must stay at bottom")
 	}
-	if cur.wrapBlockCount != len(cur.transcript) {
-		t.Fatalf("wrapBlockCount=%d transcript=%d", cur.wrapBlockCount, len(cur.transcript))
-	}
-	if cur.wrapWidth <= 0 || len(cur.wrappedLines) == 0 {
-		t.Fatal("expected populated wrap cache after long stream")
+}
+
+func BenchmarkStreamAnswerSuffixWrap(b *testing.B) {
+	// Benchmark real event.Text flushes against a large history. Suffix-only
+	// invalidation should keep per-op cost independent of history length.
+	for _, hist := range []int{500, 1000, 2000} {
+		b.Run(fmt.Sprintf("hist=%d", hist), func(b *testing.B) {
+			ctrl := control.New(control.Options{})
+			adv := func(m chatTUI, msg tea.Msg) chatTUI {
+				n, _ := m.Update(msg)
+				return n.(chatTUI)
+			}
+			base := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 24})
+			for i := 0; i < hist; i++ {
+				base = adv(base, agentEventMsg(event.Event{
+					Kind: event.Notice, Level: event.LevelInfo,
+					Text: fmt.Sprintf("h-%d-%s", i, strings.Repeat("z", 48)),
+				}))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m := base // copy model value (shallow; OK for bench of Update path)
+				m.state = tuiRunning
+				m.pending = &strings.Builder{}
+				m.answerIdx = -1
+				m.answerFlushed = 0
+				// One flushable paragraph per iteration.
+				m = adv(m, agentEventMsg(event.Event{
+					Kind: event.Text,
+					Text: fmt.Sprintf("bench paragraph %d with body text that closes.\n\n", i),
+				}))
+				if m.wrapBlockCount != len(m.transcript) {
+					b.Fatalf("wrapBlockCount=%d len=%d", m.wrapBlockCount, len(m.transcript))
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -56,6 +56,7 @@ func (m *chatTUI) appendTranscriptBlock(rendered string, source transcriptSource
 	m.ensureTranscriptSources()
 	m.transcript = append(m.transcript, rendered)
 	m.transcriptSources = append(m.transcriptSources, source)
+	// Wrap cache extends on next Update via append-only path.
 }
 
 func (m *chatTUI) setTranscriptBlock(index int, rendered string, source transcriptSource) {
@@ -65,6 +66,9 @@ func (m *chatTUI) setTranscriptBlock(index int, rendered string, source transcri
 	m.ensureTranscriptSources()
 	m.transcript[index] = rendered
 	m.transcriptSources[index] = source
+	// In-place rewrite: drop wrap from this block onward so the next sync
+	// re-wraps the mutated block and everything after it.
+	m.invalidateWrapFrom(index)
 }
 
 func (m *chatTUI) removeTranscriptBlock(index int) {
@@ -74,6 +78,7 @@ func (m *chatTUI) removeTranscriptBlock(index int) {
 	m.ensureTranscriptSources()
 	m.transcript = append(m.transcript[:index], m.transcript[index+1:]...)
 	m.transcriptSources = append(m.transcriptSources[:index], m.transcriptSources[index+1:]...)
+	m.invalidateWrapFrom(index)
 }
 
 func (m *chatTUI) truncateTranscriptBlocks(length int) {
@@ -81,6 +86,7 @@ func (m *chatTUI) truncateTranscriptBlocks(length int) {
 	m.ensureTranscriptSources()
 	m.transcript = m.transcript[:length]
 	m.transcriptSources = m.transcriptSources[:length]
+	m.invalidateWrapFrom(length)
 }
 
 func (m *chatTUI) renderTranscriptSource(source transcriptSource, terminalWidth int) string {

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -777,6 +777,9 @@ func (m chatTUI) scrollbarGrabRowOffset(row int) int {
 
 func (m *chatTUI) dragScrollbar(row int) {
 	m.viewport.SetYOffset(scrollbarYOffset(m.viewport.Height(), row, len(m.wrappedLines), m.scrollbarGrabOffset))
+	// Sync immediately so a streaming event between drag motions cannot see a
+	// stale followTail and yank the reader back to the bottom (#6430/#6978).
+	m.syncScrollModeAfterGesture()
 }
 
 // transcriptCaret maps a screen cell (x, y) in the transcript region to an

--- a/internal/cli/wrap_cache.go
+++ b/internal/cli/wrap_cache.go
@@ -3,18 +3,16 @@ package cli
 import "strings"
 
 // wrapCache keeps the viewport's wrapped line list in sync with transcript
-// blocks without re-wrapping the entire history on every streaming commit.
+// blocks without re-wrapping the entire history on every streaming update.
 //
 // Contract:
 //   - wrapWidth is the content width used for the cached lines.
-//   - wrapBlockCount is how many leading transcript blocks are already reflected.
-//   - wrappedLines is the full join of per-block wraps (equivalent to
-//     strings.Split(wrapTranscript(strings.Join(transcript, "\n"), width), "\n")
-//     because block boundaries are forced newlines).
-//
-// Full rebuild runs on width change, mid-history rewrite (block count shrinks
-// or transcriptDirty with non-append mutation), or when cache is empty.
-// Append-only growth wraps only the new suffix of blocks.
+//   - wrapBlockCount is how many leading transcript blocks are fully reflected
+//     in wrapBlockLines / the corresponding prefix of wrappedLines.
+//   - invalidateWrapFrom(i) drops the cache from block i onward so the next
+//     sync only re-wraps the suffix (streaming answer rewrites, tool tails).
+//   - Full rebuild is reserved for width change, history shrink, or an empty
+//     cache — never for a routine transcriptDirty flag alone.
 func (m *chatTUI) clearWrapCache() {
 	m.wrappedLines = nil
 	m.wrapWidth = 0
@@ -22,37 +20,38 @@ func (m *chatTUI) clearWrapCache() {
 	m.wrapBlockLines = nil
 }
 
-// syncWrappedLines ensures wrappedLines matches m.transcript at contentW.
-// Returns true when the viewport content string was rebuilt (caller should
-// SetContent). forceFull rebuilds every block (width/theme/reflow).
+// syncWrappedLines ensures wrapBlockLines/wrappedLines match m.transcript at
+// contentW. forceFull rebuilds every block; otherwise only blocks from
+// wrapBlockCount onward are wrapped (suffix path after invalidateWrapFrom).
+// Returns true when the flat line list changed and the viewport must be fed.
 func (m *chatTUI) syncWrappedLines(contentW int, forceFull bool) bool {
 	if contentW <= 0 {
 		contentW = 1
 	}
 	n := len(m.transcript)
-	// Mid-history rewrite or width change → full rebuild.
-	if forceFull || contentW != m.wrapWidth || n < m.wrapBlockCount || len(m.wrapBlockLines) != m.wrapBlockCount {
+	if forceFull || contentW != m.wrapWidth || n < m.wrapBlockCount {
 		return m.rebuildWrappedLinesFull(contentW)
 	}
+	// Heal a desynced block slice (should not happen if invalidate is used).
+	if len(m.wrapBlockLines) != m.wrapBlockCount {
+		if m.wrapBlockCount > len(m.wrapBlockLines) {
+			m.wrapBlockCount = len(m.wrapBlockLines)
+		} else {
+			m.wrapBlockLines = m.wrapBlockLines[:m.wrapBlockCount]
+		}
+		m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
+	}
 	if n == m.wrapBlockCount {
-		// No new blocks; content may still have been edited in place via
-		// setTranscriptBlock — those paths set transcriptDirty and forceFull
-		// through the caller. Append-only no-op.
 		return false
 	}
-	// Append-only: wrap each new block and extend the flat line list.
-	// Equivalent to re-wrapping join(prefix, new…) for blocks that already
-	// carry closed SGR and hard newlines (the streaming commit path).
+	// Suffix-only: re-wrap mutated/new blocks from wrapBlockCount..n.
 	for i := m.wrapBlockCount; i < n; i++ {
 		blockLines := wrapBlockLines(m.transcript[i], contentW)
 		m.wrapBlockLines = append(m.wrapBlockLines, blockLines)
-		if i == 0 && m.wrapBlockCount == 0 && len(m.wrappedLines) == 0 {
-			m.wrappedLines = append([]string(nil), blockLines...)
-			continue
-		}
-		// strings.Join inserts "\n" between blocks → concatenate line groups.
-		m.wrappedLines = append(m.wrappedLines, blockLines...)
 	}
+	// Rebuild the flat list from the (prefix-stable + new suffix) block wraps
+	// into a fresh slice so the viewport never aliases a growing backing array.
+	m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
 	m.wrapBlockCount = n
 	m.wrapWidth = contentW
 	return true
@@ -62,60 +61,60 @@ func (m *chatTUI) rebuildWrappedLinesFull(contentW int) bool {
 	if contentW <= 0 {
 		contentW = 1
 	}
-	// Join-then-wrap is the historical source of truth for viewport content
-	// (SGR balance across the full document). Per-block lines track append
-	// positions for incremental extension.
-	joined := strings.Join(m.transcript, "\n")
-	wrapped := wrapTranscript(joined, contentW)
-	m.wrappedLines = strings.Split(wrapped, "\n")
 	n := len(m.transcript)
 	m.wrapBlockLines = make([][]string, n)
 	for i := 0; i < n; i++ {
 		m.wrapBlockLines[i] = wrapBlockLines(m.transcript[i], contentW)
 	}
+	// Prefer per-block flatten over join-then-wrap so streaming suffix rebuilds
+	// stay consistent with append-only updates (both use wrapBlockLines).
+	m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
 	m.wrapBlockCount = n
 	m.wrapWidth = contentW
 	return true
+}
+
+// feedViewportContent pushes the wrap cache into the bubbles viewport without
+// re-joining the document to a single string. The line slice is cloned so later
+// cache growth cannot mutate storage the viewport still holds.
+func (m *chatTUI) feedViewportContent() {
+	if len(m.wrappedLines) == 0 {
+		m.viewport.SetContentLines(nil)
+		return
+	}
+	lines := make([]string, len(m.wrappedLines))
+	copy(lines, m.wrappedLines)
+	m.viewport.SetContentLines(lines)
 }
 
 // wrapBlockLines wraps one transcript block to width as a line slice.
 func wrapBlockLines(block string, width int) []string {
 	wrapped := wrapTranscript(block, width)
 	if wrapped == "" {
-		// Empty block is still one blank line in a Join(blocks, "\n") document
-		// when it sits between neighbors; as a sole empty document it is "".
 		return []string{""}
 	}
 	return strings.Split(wrapped, "\n")
 }
 
-// flattenBlockWraps joins per-block wrapped line slices the same way
-// strings.Split(wrapTranscript(strings.Join(blocks, "\n"), w), "\n") would for
-// already-hard-broken blocks: consecutive blocks become consecutive line groups.
+// flattenBlockWraps concatenates per-block wrapped line groups. Block boundaries
+// in the transcript are already forced newlines (strings.Join(blocks, "\n")), so
+// concatenating independent wraps matches the joined document for our content.
 func flattenBlockWraps(blocks [][]string) []string {
 	if len(blocks) == 0 {
 		return nil
 	}
-	// Estimate capacity.
 	n := 0
 	for _, b := range blocks {
 		n += len(b)
 	}
 	out := make([]string, 0, n)
-	for i, b := range blocks {
-		if i > 0 {
-			// strings.Join inserts "\n" between blocks. When both sides already
-			// end/start as separate wrap lines, concatenating line slices is
-			// enough — the join newline is the boundary between last line of
-			// block i-1 and first line of block i, which is already how the
-			// slices meet when we simply append.
-		}
+	for _, b := range blocks {
 		out = append(out, b...)
 	}
 	return out
 }
 
-// wrappedContentString returns the viewport SetContent payload for the cache.
+// wrappedContentString returns the viewport payload for tests/debug.
 func (m chatTUI) wrappedContentString() string {
 	if len(m.wrappedLines) == 0 {
 		return ""
@@ -123,19 +122,28 @@ func (m chatTUI) wrappedContentString() string {
 	return strings.Join(m.wrappedLines, "\n")
 }
 
-// invalidateWrapFrom marks that block index (and after) must be rebuilt.
-// Used after setTranscriptBlock / removeTranscriptBlock.
+// invalidateWrapFrom drops the wrap cache from block index onward so the next
+// syncWrappedLines only re-wraps the suffix. Used by setTranscriptBlock and any
+// in-place rewrite of a live stream slot (answer, tool tail, …).
 func (m *chatTUI) invalidateWrapFrom(index int) {
 	if index < 0 {
 		index = 0
 	}
 	if index >= m.wrapBlockCount {
-		// Only trailing unknown blocks; append path will wrap them.
 		return
 	}
-	// Truncate cache to the prefix before index so the next sync rebuilds
-	// from there via full rebuild when counts mismatch, or re-wrap suffix.
 	m.wrapBlockLines = m.wrapBlockLines[:index]
 	m.wrapBlockCount = index
 	m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
+}
+
+// rewriteTranscriptBlock updates a block's rendered text and invalidates the
+// wrap suffix from that index. Prefer this over bare transcript[i] = … so the
+// streaming hot path never forces a full-history rebuild.
+func (m *chatTUI) rewriteTranscriptBlock(index int, rendered string) {
+	if index < 0 || index >= len(m.transcript) {
+		return
+	}
+	m.transcript[index] = rendered
+	m.invalidateWrapFrom(index)
 }

--- a/internal/cli/wrap_cache.go
+++ b/internal/cli/wrap_cache.go
@@ -1,0 +1,141 @@
+package cli
+
+import "strings"
+
+// wrapCache keeps the viewport's wrapped line list in sync with transcript
+// blocks without re-wrapping the entire history on every streaming commit.
+//
+// Contract:
+//   - wrapWidth is the content width used for the cached lines.
+//   - wrapBlockCount is how many leading transcript blocks are already reflected.
+//   - wrappedLines is the full join of per-block wraps (equivalent to
+//     strings.Split(wrapTranscript(strings.Join(transcript, "\n"), width), "\n")
+//     because block boundaries are forced newlines).
+//
+// Full rebuild runs on width change, mid-history rewrite (block count shrinks
+// or transcriptDirty with non-append mutation), or when cache is empty.
+// Append-only growth wraps only the new suffix of blocks.
+func (m *chatTUI) clearWrapCache() {
+	m.wrappedLines = nil
+	m.wrapWidth = 0
+	m.wrapBlockCount = 0
+	m.wrapBlockLines = nil
+}
+
+// syncWrappedLines ensures wrappedLines matches m.transcript at contentW.
+// Returns true when the viewport content string was rebuilt (caller should
+// SetContent). forceFull rebuilds every block (width/theme/reflow).
+func (m *chatTUI) syncWrappedLines(contentW int, forceFull bool) bool {
+	if contentW <= 0 {
+		contentW = 1
+	}
+	n := len(m.transcript)
+	// Mid-history rewrite or width change → full rebuild.
+	if forceFull || contentW != m.wrapWidth || n < m.wrapBlockCount || len(m.wrapBlockLines) != m.wrapBlockCount {
+		return m.rebuildWrappedLinesFull(contentW)
+	}
+	if n == m.wrapBlockCount {
+		// No new blocks; content may still have been edited in place via
+		// setTranscriptBlock — those paths set transcriptDirty and forceFull
+		// through the caller. Append-only no-op.
+		return false
+	}
+	// Append-only: wrap each new block and extend the flat line list.
+	// Equivalent to re-wrapping join(prefix, new…) for blocks that already
+	// carry closed SGR and hard newlines (the streaming commit path).
+	for i := m.wrapBlockCount; i < n; i++ {
+		blockLines := wrapBlockLines(m.transcript[i], contentW)
+		m.wrapBlockLines = append(m.wrapBlockLines, blockLines)
+		if i == 0 && m.wrapBlockCount == 0 && len(m.wrappedLines) == 0 {
+			m.wrappedLines = append([]string(nil), blockLines...)
+			continue
+		}
+		// strings.Join inserts "\n" between blocks → concatenate line groups.
+		m.wrappedLines = append(m.wrappedLines, blockLines...)
+	}
+	m.wrapBlockCount = n
+	m.wrapWidth = contentW
+	return true
+}
+
+func (m *chatTUI) rebuildWrappedLinesFull(contentW int) bool {
+	if contentW <= 0 {
+		contentW = 1
+	}
+	// Join-then-wrap is the historical source of truth for viewport content
+	// (SGR balance across the full document). Per-block lines track append
+	// positions for incremental extension.
+	joined := strings.Join(m.transcript, "\n")
+	wrapped := wrapTranscript(joined, contentW)
+	m.wrappedLines = strings.Split(wrapped, "\n")
+	n := len(m.transcript)
+	m.wrapBlockLines = make([][]string, n)
+	for i := 0; i < n; i++ {
+		m.wrapBlockLines[i] = wrapBlockLines(m.transcript[i], contentW)
+	}
+	m.wrapBlockCount = n
+	m.wrapWidth = contentW
+	return true
+}
+
+// wrapBlockLines wraps one transcript block to width as a line slice.
+func wrapBlockLines(block string, width int) []string {
+	wrapped := wrapTranscript(block, width)
+	if wrapped == "" {
+		// Empty block is still one blank line in a Join(blocks, "\n") document
+		// when it sits between neighbors; as a sole empty document it is "".
+		return []string{""}
+	}
+	return strings.Split(wrapped, "\n")
+}
+
+// flattenBlockWraps joins per-block wrapped line slices the same way
+// strings.Split(wrapTranscript(strings.Join(blocks, "\n"), w), "\n") would for
+// already-hard-broken blocks: consecutive blocks become consecutive line groups.
+func flattenBlockWraps(blocks [][]string) []string {
+	if len(blocks) == 0 {
+		return nil
+	}
+	// Estimate capacity.
+	n := 0
+	for _, b := range blocks {
+		n += len(b)
+	}
+	out := make([]string, 0, n)
+	for i, b := range blocks {
+		if i > 0 {
+			// strings.Join inserts "\n" between blocks. When both sides already
+			// end/start as separate wrap lines, concatenating line slices is
+			// enough — the join newline is the boundary between last line of
+			// block i-1 and first line of block i, which is already how the
+			// slices meet when we simply append.
+		}
+		out = append(out, b...)
+	}
+	return out
+}
+
+// wrappedContentString returns the viewport SetContent payload for the cache.
+func (m chatTUI) wrappedContentString() string {
+	if len(m.wrappedLines) == 0 {
+		return ""
+	}
+	return strings.Join(m.wrappedLines, "\n")
+}
+
+// invalidateWrapFrom marks that block index (and after) must be rebuilt.
+// Used after setTranscriptBlock / removeTranscriptBlock.
+func (m *chatTUI) invalidateWrapFrom(index int) {
+	if index < 0 {
+		index = 0
+	}
+	if index >= m.wrapBlockCount {
+		// Only trailing unknown blocks; append path will wrap them.
+		return
+	}
+	// Truncate cache to the prefix before index so the next sync rebuilds
+	// from there via full rebuild when counts mismatch, or re-wrap suffix.
+	m.wrapBlockLines = m.wrapBlockLines[:index]
+	m.wrapBlockCount = index
+	m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
+}


### PR DESCRIPTION
## Summary

Integration PR **C** for the 30-day CLI feedback plan: viewport, render, and mouse contracts after Integration B (#7690).

### Addresses

| Issue | Mechanism |
| --- | --- |
| #6430 | Explicit `followTail` / `userScrolled`; drag/autoScroll sync on every YOffset change; modal height does not disable follow |
| #6978 | **Suffix invalidation** via `invalidateWrapFrom` / `rewriteTranscriptBlock`; full rebuild only on width change or history shrink — not `transcriptDirty` alone. Live `event.Text` rewrites only re-wrap from the answer block. Keep open: end-to-end time still grows with history via bubbles `SetContentLines`/`maxLineWidth`. |
| #7583 | Rate-limited mouse enable with **trailing-edge** timer (`mouseReenableMsg`); real size change / Focus / TurnDone. Keep open until Windows/ConPTY manual matrix. |
| Refs #6282 / #7236 | `clampCursorToTerminal` only; full VS Code fullscreen layout still needs evidence |
| Refs #7028 #7180 #7537 #6563 | Shared resize/reflow foundations |

### Audit follow-ups

**Round 2 (`ef8eb56a4`)** — streaming suffix wrap, drag mid-stream sync, trailing mouse re-enable.

**Round 3 (this head)** — CI lint (SA9003 / S1001 / unused), docs-impact rationale, remove ineffective `mouseReenableSeq`.

### Known residual

- `viewport.SetContentLines` still scans all lines for `maxLineWidth` (bubbles API). Wrap of history is no longer full-history on stream; viewport feed width scan remains O(lines).
- Windows ConPTY manual matrix still recommended before closing #7583.
- #6282/#7236 keep **Refs** until VS Code first-fullscreen layout is reproduced.
- #6978 stays open for end-to-end linear `SetContentLines` cost.

### Not in this PR

- Integration D/E
- Closing superseded contributor PRs
- No release this round

## Verification

- `go test ./internal/cli -count=1`
- `staticcheck ./internal/cli`
- `TestStreamAnswerSuffixInvalidationNotFullRebuild`
- `TestScrollbarDragMotionSyncsBeforeRelease`
- `TestMouseReenableTrailingEdge`
- `TestModalOpenDoesNotDisableTailFollow`
- `BenchmarkStreamAnswerSuffixWrap -benchmem` (hist=500/1000/2000)

## Cache impact

Cache-impact: none - TUI viewport/mouse only.
Cache-guard: N/A
System-prompt-review: not required

Documentation-impact: none - this restores existing TUI scroll, mouse, and cursor behavior without adding commands, flags, configuration, or documented workflows; existing docs remain accurate.