### PR TITLE
fix(desktop): refresh todo panel from live todo_write events

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -39,14 +39,27 @@ const activeTodos = [
 ];
 
 assert.deepEqual(
-  resolveTodoPanelTodos([], activeTodos),
+  resolveTodoPanelTodos([], undefined),
   [],
-  "an authoritative empty canonical list clears the transcript fallback",
+  "an authoritative empty canonical list with no live tool clears the panel",
+);
+assert.deepEqual(
+  resolveTodoPanelTodos(
+    [{ content: "Inspect the report", status: "in_progress" }, { content: "Ship the fix", status: "pending" }],
+    [{ content: "Inspect the report", status: "completed" }, { content: "Ship the fix", status: "in_progress" }],
+  ),
+  [{ content: "Inspect the report", status: "completed" }, { content: "Ship the fix", status: "in_progress" }],
+  "a live todo_write snapshot advances mid-turn status past a stale meta snapshot",
 );
 assert.deepEqual(
   resolveTodoPanelTodos(undefined, activeTodos),
   activeTodos,
   "an unavailable canonical list falls back to the transcript snapshot",
+);
+assert.deepEqual(
+  resolveTodoPanelTodos(activeTodos, undefined),
+  activeTodos,
+  "without a live tool the panel keeps the meta snapshot",
 );
 assert.equal(
   sameTodoList(activeTodos, activeTodos.map((todo) => ({ ...todo }))),

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2152,7 +2152,7 @@ export default function App() {
   const todoItem = todoEntry?.item ?? null;
   const metaTodos = state.meta?.canonicalTodos;
   const todos = useMemo(
-    () => resolveTodoPanelTodos(metaTodos, todoItem ? parseTodos(todoItem.args) : []),
+    () => resolveTodoPanelTodos(metaTodos, todoItem ? parseTodos(todoItem.args) : undefined),
     [metaTodos, todoItem],
   );
   const [dismissedTodoKeys, setDismissedTodoKeys] = useState<Set<string>>(loadDismissedTodoKeys);

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,8 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
 import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, shouldReconcileStaleTurn, tokenModeSwitchNoticeText } from "../lib/useController";
+import { parseTodos } from "../lib/tools";
+import { resolveTodoPanelTodos } from "../lib/todoVisibility";
 import type { HistoryMessage, Meta, TabMeta, WireUsage } from "../lib/types";
 
 type LooseTabMeta = Omit<TabMeta, "toolApprovalMode"> & { toolApprovalMode?: TabMeta["toolApprovalMode"] | "" };
@@ -412,6 +414,50 @@ console.log("\nuse controller meta");
 
   const cleared = reducer(reset, { type: "meta", meta: meta({ canonicalTodos: [] }) });
   eq(cleared.meta?.canonicalTodos?.length, 0, "authoritative empty canonical todos survive meta refresh");
+}
+
+{
+  const delayedLiveMeta = meta({
+    canonicalTodos: [
+      { content: "Inspect the report", status: "completed" },
+      { content: "Ship the fix", status: "in_progress" },
+    ],
+  });
+  const hydrated = reducer({ ...initialState, meta: delayedLiveMeta }, { type: "meta", meta: delayedLiveMeta });
+  const noLiveTodo = hydrated.items.find((item) => item.kind === "tool" && item.name === "todo_write");
+  eq(
+    resolveTodoPanelTodos(hydrated.meta?.canonicalTodos, noLiveTodo ? parseTodos(noLiveTodo.args) : undefined),
+    delayedLiveMeta.canonicalTodos,
+    "panel uses fresh Meta todos while the live todo_write event is delayed",
+  );
+
+  const staleMeta = meta({
+    canonicalTodos: [
+      { content: "Inspect the report", status: "in_progress" },
+      { content: "Ship the fix", status: "pending" },
+    ],
+  });
+  const liveArgs = JSON.stringify({
+    todos: [
+      { content: "Inspect the report", status: "completed" },
+      { content: "Ship the fix", status: "in_progress" },
+    ],
+  });
+  let liveState = reducer({ ...initialState, meta: staleMeta }, { type: "event", e: { kind: "turn_started" } });
+  liveState = reducer(liveState, {
+    type: "event",
+    e: { kind: "tool_dispatch", tool: { id: "todo-live", name: "todo_write", args: liveArgs, readOnly: true } },
+  });
+  liveState = reducer(liveState, {
+    type: "event",
+    e: { kind: "tool_result", tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated" } },
+  });
+  const liveTodo = liveState.items.find((item) => item.kind === "tool" && item.name === "todo_write");
+  eq(
+    JSON.stringify(resolveTodoPanelTodos(liveState.meta?.canonicalTodos, liveTodo ? parseTodos(liveTodo.args) : undefined)),
+    JSON.stringify(JSON.parse(liveArgs).todos),
+    "panel switches to the live todo_write snapshot after it arrives",
+  );
 }
 
 {

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -12,8 +12,15 @@ export interface TodoPanelScopeInput {
   eventChannel?: string | null;
 }
 
-export function resolveTodoPanelTodos(canonical: Todo[] | null | undefined, fallback: Todo[]): Todo[] {
-  return Array.isArray(canonical) ? canonical : fallback;
+export function resolveTodoPanelTodos(
+  canonical: Todo[] | null | undefined,
+  live?: Todo[] | null,
+): Todo[] {
+  // `live` is set only when the transcript has a completed top-level todo_write.
+  // Prefer it over MetaForTab — meta only refreshes on turn_done / focus change,
+  // so mid-turn status flips otherwise freeze until the user switches tabs (#7642).
+  if (live !== undefined && live !== null) return live;
+  return Array.isArray(canonical) ? canonical : [];
 }
 
 export function sameTodoList(a: Todo[] | null | undefined, b: Todo[] | null | undefined): boolean {


### PR DESCRIPTION
## Summary
The desktop todo panel preferred `meta.canonicalTodos` from `MetaForTab` over the latest completed `todo_write` in the transcript. Meta only refreshes on turn completion / tab focus, so during a long turn every item could stay "In Progress" until the user switched away and back.

When a live top-level `todo_write` snapshot exists, the panel now uses that event-driven list so statuses update in place.

## Issues
Fixes #7642

## Verification
- [x] `cd desktop/frontend && pnpm test:todo-visibility`
- [x] `cd desktop/frontend && pnpm exec tsx src/__tests__/use-controller-meta.test.ts`

## Documentation impact
Documentation-impact: none - UI refresh behavior only; embedded docs remain correct.

## Cache impact
Cache-impact: none
Cache-guard: N/A — frontend panel selection only
System-prompt-review: N/A