### PR TITLE
test: cover notify and command helpers

### DIFF
--- a/internal/command/inspect_test.go
+++ b/internal/command/inspect_test.go
@@ -1,0 +1,158 @@
+package command
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGuessName covers the path → command-name derivation: relative to root,
+// trailing .md stripped, subdirectories turned into ":" namespaces.
+func TestGuessName(t *testing.T) {
+	root := t.TempDir()
+
+	cases := []struct {
+		name string
+		rel  string // path relative to root; "" means the root itself
+		want string
+	}{
+		{"top level markdown", "review.md", "review"},
+		{"nested namespace", filepath.Join("git", "commit.md"), "git:commit"},
+		{"deep nesting", filepath.Join("a", "b", "c", "deep.md"), "a:b:c:deep"},
+		{"non markdown extension", "notes.txt", "notes.txt"},
+		{"uppercase extension kept", "README.MD", "README.MD"},
+		{"md suffix inside directory kept", filepath.Join("foo.md", "bar.md"), "foo.md:bar"},
+		{"root itself", "", "."},
+		{"no extension", "readme", "readme"},
+		{"no extension nested", filepath.Join("git", "commit"), "git:commit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := root
+			if tc.rel != "" {
+				path = filepath.Join(root, tc.rel)
+			}
+			if got := guessName(root, path); got != tc.want {
+				t.Errorf("guessName(%q, %q) = %q, want %q", root, path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseFile covers reading one command file: name derivation, frontmatter
+// fields, body handling, and the error path for unreadable files.
+func TestParseFile(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "review.md", "---\ndescription: Review the diff\nargument-hint: [area]\n---\nReview, focus on $ARGUMENTS.")
+	write(t, dir, "plain.md", "No frontmatter, just $1.")
+	write(t, dir, "git/commit.md", "---\ndescription: Commit\n---\nWrite a commit message.")
+	write(t, dir, "crlf.md", "---\r\ndescription: CRLF\r\n---\r\nline one\r\nline two")
+	write(t, dir, "bom.md", string(rune(0xFEFF))+"---\ndescription: BOM\n---\nBody with BOM.")
+	write(t, dir, "pad.md", "\n\n  body text  \n\n")
+	write(t, dir, "empty.md", "")
+	write(t, dir, "upper.MD", "---\ndescription: Upper\n---\nUPPER BODY")
+
+	cases := []struct {
+		name    string
+		rel     string
+		wantCmd Command
+		wantErr bool
+	}{
+		{
+			name: "full frontmatter",
+			rel:  "review.md",
+			wantCmd: Command{
+				Name:        "review",
+				Description: "Review the diff",
+				ArgHint:     "[area]",
+				Body:        "Review, focus on $ARGUMENTS.",
+			},
+		},
+		{
+			name: "no frontmatter",
+			rel:  "plain.md",
+			wantCmd: Command{
+				Name: "plain",
+				Body: "No frontmatter, just $1.",
+			},
+		},
+		{
+			name: "nested namespaced name",
+			rel:  filepath.Join("git", "commit.md"),
+			wantCmd: Command{
+				Name:        "git:commit",
+				Description: "Commit",
+				Body:        "Write a commit message.",
+			},
+		},
+		{
+			name: "crlf normalised",
+			rel:  "crlf.md",
+			wantCmd: Command{
+				Name:        "crlf",
+				Description: "CRLF",
+				Body:        "line one\nline two",
+			},
+		},
+		{
+			name: "bom stripped",
+			rel:  "bom.md",
+			wantCmd: Command{
+				Name:        "bom",
+				Description: "BOM",
+				Body:        "Body with BOM.",
+			},
+		},
+		{
+			name: "body whitespace trimmed",
+			rel:  "pad.md",
+			wantCmd: Command{
+				Name: "pad",
+				Body: "body text",
+			},
+		},
+		{
+			name:    "empty file",
+			rel:     "empty.md",
+			wantCmd: Command{Name: "empty"},
+		},
+		{
+			name: "uppercase extension kept in name",
+			rel:  "upper.MD",
+			wantCmd: Command{
+				Name:        "upper.MD",
+				Description: "Upper",
+				Body:        "UPPER BODY",
+			},
+		},
+		{
+			name:    "missing file errors",
+			rel:     "missing.md",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.rel)
+			cmd, err := parseFile(dir, path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseFile(%q) succeeded, want error", path)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFile(%q): %v", path, err)
+			}
+			tc.wantCmd.Source = path
+			if cmd != tc.wantCmd {
+				t.Errorf("parseFile() = %+v, want %+v", cmd, tc.wantCmd)
+			}
+			if strings.Contains(cmd.Body, "\r") {
+				t.Errorf("body contains CR: %q", cmd.Body)
+			}
+		})
+	}
+}

--- a/internal/notify/message_test.go
+++ b/internal/notify/message_test.go
@@ -1,0 +1,120 @@
+package notify
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+// TestMessage covers the kind+flag → (Message, bool) mapping used by SendEvent.
+func TestMessage(t *testing.T) {
+	allOff := config.NotificationsConfig{}
+
+	cases := []struct {
+		name string
+		cfg  config.NotificationsConfig
+		ev   event.Event
+		want Message
+		ok   bool
+	}{
+		{
+			name: "turn done enabled no error",
+			cfg:  config.NotificationsConfig{TurnDone: true},
+			ev:   event.Event{Kind: event.TurnDone},
+			want: Message{Title: "Reasonix", Body: "Turn finished"},
+			ok:   true,
+		},
+		{
+			name: "turn done enabled with error",
+			cfg:  config.NotificationsConfig{TurnDone: true},
+			ev:   event.Event{Kind: event.TurnDone, Err: errTestFailure},
+			want: Message{Title: "Reasonix", Body: "Turn failed"},
+			ok:   true,
+		},
+		{
+			name: "turn done disabled",
+			cfg:  allOff,
+			ev:   event.Event{Kind: event.TurnDone},
+			ok:   false,
+		},
+		{
+			name: "approval request enabled",
+			cfg:  config.NotificationsConfig{ApprovalRequest: true},
+			ev:   event.Event{Kind: event.ApprovalRequest},
+			want: Message{Title: "Reasonix", Body: "Approval needed"},
+			ok:   true,
+		},
+		{
+			name: "approval request disabled",
+			cfg:  allOff,
+			ev:   event.Event{Kind: event.ApprovalRequest},
+			ok:   false,
+		},
+		{
+			name: "ask request enabled",
+			cfg:  config.NotificationsConfig{AskRequest: true},
+			ev:   event.Event{Kind: event.AskRequest},
+			want: Message{Title: "Reasonix", Body: "Question needs your answer"},
+			ok:   true,
+		},
+		{
+			name: "ask request disabled",
+			cfg:  allOff,
+			ev:   event.Event{Kind: event.AskRequest},
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, ok := message(tc.cfg, tc.ev)
+			if ok != tc.ok {
+				t.Fatalf("message() ok = %v, want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if msg != tc.want {
+				t.Errorf("message() = %+v, want %+v", msg, tc.want)
+			}
+		})
+	}
+}
+
+// TestMessageIgnoresOtherKinds: every kind that is not TurnDone, ApprovalRequest
+// or AskRequest maps to false even when all notification flags are on.
+func TestMessageIgnoresOtherKinds(t *testing.T) {
+	allOn := config.NotificationsConfig{TurnDone: true, ApprovalRequest: true, AskRequest: true}
+	otherKinds := []event.Kind{
+		event.TurnStarted,
+		event.Reasoning,
+		event.Text,
+		event.Message,
+		event.ToolDispatch,
+		event.ToolResult,
+		event.Usage,
+		event.Notice,
+		event.Phase,
+		event.CompactionStarted,
+		event.CompactionDone,
+		event.ToolProgress,
+		event.Retrying,
+		event.Steer,
+	}
+
+	for _, k := range otherKinds {
+		if msg, ok := message(allOn, event.Event{Kind: k}); ok {
+			t.Errorf("kind %v produced a notification (%+v), want none", k, msg)
+		}
+	}
+}
+
+// TestMessageUnknownKindValue guards against accidental notification of an
+// out-of-range Kind value (e.g. a future kind added before config wiring).
+func TestMessageUnknownKindValue(t *testing.T) {
+	allOn := config.NotificationsConfig{TurnDone: true, ApprovalRequest: true, AskRequest: true}
+	if msg, ok := message(allOn, event.Event{Kind: event.Kind(999)}); ok {
+		t.Errorf("unknown kind produced a notification (%+v), want none", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Add tests for untested helpers in two packages (31 tests):

**internal/notify** — `message` (sink.go:53): full kind+flag → (Message, bool) matrix — 7 table cases + 15 standalone (14 non-notifiable kinds → false with all flags, out-of-range kind → false).

**internal/command** — `guessName` (inspect.go:150, 9 cases: nested `a/b/c/deep.md` → `a:b:c:deep`, case-sensitive `.md`, mid-path `.md`) and `parseFile` (command.go:191, 9 cases: full frontmatter, no frontmatter, CRLF→LF, UTF-8 BOM strip, missing file → error).

## Issues

None — coverage gap, no issue report.

## Verification

- `go test ./internal/notify/ ./internal/command/` — pass
- `go vet` / `gofmt -l` — clean

## Documentation impact

Documentation-impact: none - test-only addition.

## Cache impact

Cache-impact: none - test-only; not a cache-sensitive path.
Cache-guard: N/A
System-prompt-review: N/A
