### PR TITLE
test(installlayout): cover path-traversal and naming helpers

### DIFF
--- a/internal/installlayout/activate_test.go
+++ b/internal/installlayout/activate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -211,6 +212,30 @@ func TestActivateVersionRejectsSymlinkSource(t *testing.T) {
 	}
 	if HasCurrent(root) {
 		t.Fatal("current.json must not be written after failed activation")
+	}
+}
+
+func TestNormalizeMemberName(t *testing.T) {
+	// Windows lowercases member names so the case-insensitive filesystem
+	// matches the whitelist; other platforms preserve case. Leading/trailing
+	// whitespace is always trimmed.
+	cases := []struct{ in string }{
+		{"reasonix-desktop"},
+		{"  reasonix-cli  "},
+		{"\treasonix-update-helper\n"},
+		{""},
+		{"   "},
+		{"Reasonix.exe"},
+		{"  Reasonix-Desktop.Exe  "},
+	}
+	for _, tc := range cases {
+		want := strings.TrimSpace(tc.in)
+		if runtime.GOOS == "windows" {
+			want = strings.ToLower(want)
+		}
+		if got := normalizeMemberName(tc.in); got != want {
+			t.Errorf("normalizeMemberName(%q) = %q, want %q", tc.in, got, want)
+		}
 	}
 }
 

--- a/internal/installlayout/current_test.go
+++ b/internal/installlayout/current_test.go
@@ -96,6 +96,72 @@ func TestValidateVersionName(t *testing.T) {
 		}
 	}
 }
+func TestValidateActiveDirRelative(t *testing.T) {
+	// Shape-only validation: no filesystem access, so symlink enforcement is
+	// deliberately not tested here (ValidateActiveDir handles it, see
+	// TestValidateActiveDirRejectsSymlinkVersionDir). activeDir must equal
+	// versions/<version> exactly after trimming and separator normalization.
+	cases := []struct {
+		version   string
+		activeDir string
+		wantErr   bool
+	}{
+		// In-bounds relatives.
+		{"v1.20.0", "versions/v1.20.0", false},
+		{"v1.20.0", "  versions/v1.20.0  ", false}, // trimmed
+		{"v1.20.0-preview.1", "versions/v1.20.0-preview.1", false},
+		// Version label problems.
+		{"", "versions/v1.20.0", true},
+		{"1.20.0", "versions/v1.20.0", true},
+		{"../evil", "versions/v1.20.0", true},
+		// Empty activeDir.
+		{"v1.20.0", "", true},
+		{"v1.20.0", "   ", true},
+		// Absolute paths.
+		{"v1.20.0", "/abs/path", true},
+		// ".." escapes: leading, middle, trailing, bare.
+		{"v1.20.0", "../versions/v1.20.0", true},
+		{"v1.20.0", "versions/../v1.20.0", true},
+		{"v1.20.0", "versions/v1.20.0/..", true},
+		{"v1.20.0", "..", true},
+		{"v1.20.0", "versions/..", true},
+		{"v1.20.0", "../../etc", true},
+		// Separators and exact-match requirement.
+		{"v1.20.0", "versions\\v1.20.0", runtime.GOOS != "windows"}, // ToSlash on Windows only
+		{"v1.20.0", "versions/v1.19.0", true},                       // wrong version dir
+		{"v1.20.0", "versions/v1.20.0/", true},                      // trailing separator
+		{"v1.20.0", "versions//v1.20.0", true},                      // doubled separator
+	}
+	for _, tc := range cases {
+		err := ValidateActiveDirRelative(tc.version, tc.activeDir)
+		if tc.wantErr && err == nil {
+			t.Errorf("ValidateActiveDirRelative(%q, %q): expected error", tc.version, tc.activeDir)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("ValidateActiveDirRelative(%q, %q): unexpected error %v", tc.version, tc.activeDir, err)
+		}
+	}
+}
+
+func TestPortableAliasName(t *testing.T) {
+	cases := []struct {
+		goos string
+		want string
+	}{
+		{"windows", "Reasonix.exe"},
+		{"linux", ""},
+		{"darwin", ""},
+	}
+	for _, tc := range cases {
+		if tc.goos != runtime.GOOS {
+			continue
+		}
+		if got := PortableAliasName(); got != tc.want {
+			t.Fatalf("PortableAliasName() on %s = %q, want %q", tc.goos, got, tc.want)
+		}
+	}
+}
+
 func TestResolveInstallRootFromVersionedDesktop(t *testing.T) {
 	root := t.TempDir()
 	version := "v1.20.0"


### PR DESCRIPTION
## Summary

Add tests for `internal/installlayout/` helpers (29 cases, security-relevant path-traversal validation previously untested):

- `ValidateActiveDirRelative` (current.go:159, 19) — in-bounds relatives, `..` escapes in every position (leading/middle/trailing/bare), absolute paths, empty/whitespace, Windows separator handling (GOOS-conditional), wrong-version dirs
- `normalizeMemberName` (activate.go:329, 7) — trim/case-folding (Windows-conditional), tab/newline, empty
- `PortableAliasName` (current.go:377, 3) — GOOS table (windows → `Reasonix.exe`, unix → empty)

## Issues

None — coverage gap, no issue report.

## Verification

- `go test ./internal/installlayout/` — pass
- `go vet` / `gofmt -l` — clean

## Documentation impact

Documentation-impact: none - test-only addition.

## Cache impact

Cache-impact: none - test-only; not a cache-sensitive path.
Cache-guard: N/A
System-prompt-review: N/A
