### PR TITLE
test: cover mcpregistry and store helpers

### DIFF
--- a/internal/mcpregistry/helpers_test.go
+++ b/internal/mcpregistry/helpers_test.go
@@ -1,0 +1,67 @@
+package mcpregistry
+
+import "testing"
+
+func TestNpmPackageVersion(t *testing.T) {
+	cases := []struct {
+		identifier, version, want string
+	}{
+		{"mcp-server", "", "mcp-server"},
+		{"mcp-server", "1.2.3", "mcp-server@1.2.3"},
+		{"@scope/mcp-server", "", "@scope/mcp-server"},
+		{"@scope/mcp-server", "2.0.0-beta.1", "@scope/mcp-server@2.0.0-beta.1"},
+	}
+	for _, c := range cases {
+		if got := npmPackageVersion(c.identifier, c.version); got != c.want {
+			t.Errorf("npmPackageVersion(%q, %q) = %q, want %q", c.identifier, c.version, got, c.want)
+		}
+	}
+}
+
+func TestPythonPackageVersion(t *testing.T) {
+	cases := []struct {
+		identifier, version, want string
+	}{
+		{"mcp-server", "", "mcp-server"},
+		{"mcp-server", "1.2.3", "mcp-server==1.2.3"},
+		{"mcp-server", "1.0.0rc1", "mcp-server==1.0.0rc1"},
+		{"mcp-server[postgres]", "0.9.0", "mcp-server[postgres]==0.9.0"},
+	}
+	for _, c := range cases {
+		if got := pythonPackageVersion(c.identifier, c.version); got != c.want {
+			t.Errorf("pythonPackageVersion(%q, %q) = %q, want %q", c.identifier, c.version, got, c.want)
+		}
+	}
+}
+
+func TestCacheKey(t *testing.T) {
+	// The key is the lowercased, trimmed query, a NUL separator, and the
+	// decimal limit, so the query and limit cannot be confused with each other.
+	if got, want := cacheKey("Demo", 10), "demo\x0010"; got != want {
+		t.Fatalf("cacheKey(\"Demo\", 10) = %q, want %q", got, want)
+	}
+
+	// Case and surrounding whitespace normalize to the same key.
+	for _, pair := range [][2]string{
+		{cacheKey("Demo", 10), cacheKey("  demo  ", 10)},
+		{cacheKey("MCP Registry", 20), cacheKey("mcp registry", 20)},
+	} {
+		if pair[0] != pair[1] {
+			t.Errorf("normalized inputs produced different keys: %q != %q", pair[0], pair[1])
+		}
+	}
+
+	// Distinct (query, limit) inputs must never share a key. The last three
+	// pairs would collide under naive query+limit concatenation, and an
+	// embedded NUL in a query must not be able to forge a limit.
+	for _, pair := range [][2]string{
+		{cacheKey("demo", 10), cacheKey("demo", 20)},
+		{cacheKey("demo", 10), cacheKey("demo1", 0)},
+		{cacheKey("demo\x0010", 5), cacheKey("demo", 105)},
+		{cacheKey("demo", 10), cacheKey("demo\x00", 10)},
+	} {
+		if pair[0] == pair[1] {
+			t.Errorf("distinct inputs collided: %q == %q", pair[0], pair[1])
+		}
+	}
+}

--- a/internal/store/helpers_test.go
+++ b/internal/store/helpers_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSessionStem(t *testing.T) {
+	cases := []struct {
+		path, want string
+	}{
+		{"/home/u/.reasonix/sessions/abc.jsonl", "/home/u/.reasonix/sessions/abc"},
+		{"abc.jsonl", "abc"},
+		{"abc.events.jsonl", "abc.events"},
+		{"abc.jsonl.jsonl", "abc.jsonl"}, // strips exactly one suffix
+		{"abc.json", "abc.json"},         // not a .jsonl suffix
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := sessionStem(c.path); got != c.want {
+			t.Errorf("sessionStem(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestRemoteServeLockName(t *testing.T) {
+	if got := RemoteServeLockName("home-dev-app"); got != "serve-home-dev-app.lock" {
+		t.Errorf("lock name = %q, want %q", got, "serve-home-dev-app.lock")
+	}
+	if got := RemoteServeLockName(""); got != "serve-.lock" {
+		t.Errorf("empty-slug lock name = %q, want %q", got, "serve-.lock")
+	}
+}
+
+func TestBoundRemoteComponent(t *testing.T) {
+	// At or under the budget the component passes through byte-identical.
+	if got := boundRemoteComponent("home-dev-app", 180); got != "home-dev-app" {
+		t.Errorf("short component = %q, want passthrough", got)
+	}
+	if got := boundRemoteComponent("", 180); got != "" {
+		t.Errorf("empty component = %q, want empty", got)
+	}
+	if got := boundRemoteComponent("anything", 0); got != "anything" {
+		t.Errorf("non-positive budget = %q, want passthrough", got)
+	}
+
+	// Over budget: truncated to a rune boundary with an FNV-1a hex suffix,
+	// landing exactly at the budget (ASCII input truncates cleanly).
+	long := strings.Repeat("verydeepdir/", 30) + "app"
+	got := boundRemoteComponent(long, 100)
+	if len(got) != 100 {
+		t.Fatalf("bounded length = %d, want 100", len(got))
+	}
+	if !strings.HasPrefix(got, long[:83]) {
+		t.Errorf("bounded component lost its readable prefix: %q", got)
+	}
+	for _, r := range got[len(got)-16:] {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Errorf("hash suffix not hex: %q", got)
+			break
+		}
+	}
+
+	// Multibyte input truncates on a rune boundary, never mid-rune.
+	wide := strings.Repeat("가", 100) // 300 bytes
+	got = boundRemoteComponent(wide, 100)
+	if len(got) > 100 || !utf8.ValidString(got) {
+		t.Fatalf("wide component = %q (len %d), not valid UTF-8 within budget", got, len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Add tests for untested helpers in two packages (28 cases):

**internal/mcpregistry** (15) — `npmPackageVersion`/`pythonPackageVersion` (bare, scoped, prerelease, extra-specifier forms), `cacheKey` (7: exact format, normalization pairs, 4 distinctness pairs — including the naive-concatenation collision `("demo",10)` vs `("demo1",0)` that the `\x00` separator prevents, and embedded-NUL safety).

**internal/store** (13) — `sessionStem` (6), `RemoteServeLockName` (2, was missing from existing filename tests), `boundRemoteComponent` (5: over-budget truncation landing exactly at budget, multibyte rune-boundary).

## Issues

None — coverage gap, no issue report.

## Verification

- `go test ./internal/mcpregistry/ ./internal/store/` — pass
- `go vet` / `gofmt -l` — clean

## Documentation impact

Documentation-impact: none - test-only addition.

## Cache impact

Cache-impact: none - test-only; not a cache-sensitive path.
Cache-guard: N/A
System-prompt-review: N/A
