### PR TITLE
Improve prompt-cache hit rate: adaptive Anthropic TTL, accurate diagnostics, latch fix / 提升 prompt 缓存命中率:自适应 Anthropic TTL、诊断归因修正、压缩闩锁修复

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -30,14 +30,18 @@ type task struct {
 }
 
 type runMetrics struct {
-	PromptTokens     int     `json:"prompt_tokens"`
-	CompletionTokens int     `json:"completion_tokens"`
-	CacheHitTokens   int     `json:"cache_hit_tokens"`
-	CacheMissTokens  int     `json:"cache_miss_tokens"`
-	Steps            int     `json:"steps"`
-	Cost             float64 `json:"cost"`
-	Currency         string  `json:"currency"`
-	Compactions      int     `json:"compactions"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	CacheHitTokens   int `json:"cache_hit_tokens"`
+	CacheMissTokens  int `json:"cache_miss_tokens"`
+	// PrefixChangeReasonCounts mirrors internal/cli.RunMetrics's field of the
+	// same name: per-run tallies of why the cache prefix changed (e.g.
+	// "compact_auto", "snip", "tools"), omitempty for older metrics files.
+	PrefixChangeReasonCounts map[string]int `json:"prefix_change_reason_counts,omitempty"`
+	Steps                    int            `json:"steps"`
+	Cost                     float64        `json:"cost"`
+	Currency                 string         `json:"currency"`
+	Compactions              int            `json:"compactions"`
 
 	// Optional Delivery capability counters (omitempty for baseline/old metrics).
 	ReadinessChecks            int     `json:"readiness_checks,omitempty"`
@@ -394,6 +398,7 @@ func renderBody(results []result) string {
 	var walls []int64
 	currency := ""
 	classes := map[string]int{}
+	prefixChangeReasons := map[string]int{}
 	for _, r := range results {
 		if r.Skipped {
 			continue
@@ -428,6 +433,9 @@ func renderBody(results []result) string {
 		cost += r.Cost
 		if r.Currency != "" {
 			currency = r.Currency
+		}
+		for reason, n := range r.PrefixChangeReasonCounts {
+			prefixChangeReasons[reason] += n
 		}
 	}
 
@@ -471,6 +479,9 @@ func renderBody(results []result) string {
 
 	if breakdown := failureBreakdown(classes); breakdown != "" {
 		fmt.Fprintf(&b, "\n**Failures by class:** %s\n", breakdown)
+	}
+	if breakdown := reasonBreakdown(prefixChangeReasons); breakdown != "" {
+		fmt.Fprintf(&b, "\n**Cache resets by cause:** %s\n", breakdown)
 	}
 
 	notes := false
@@ -544,6 +555,25 @@ func failureBreakdown(classes map[string]int) string {
 	parts := make([]string, 0, len(names))
 	for _, name := range names {
 		parts = append(parts, fmt.Sprintf("%s ×%d", name, classes[name]))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// reasonBreakdown renders cache-prefix-change reason counts (compact_auto,
+// snip, prune, tools, ...) the same way failureBreakdown renders failure
+// classes, so a hit-rate regression in a PR shows which operation caused it.
+func reasonBreakdown(reasons map[string]int) string {
+	names := make([]string, 0, len(reasons))
+	for name := range reasons {
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%s ×%d", name, reasons[name]))
 	}
 	return strings.Join(parts, " · ")
 }

--- a/cmd/e2ebench/report_test.go
+++ b/cmd/e2ebench/report_test.go
@@ -77,6 +77,27 @@ func TestUnaccountedSolvesDoNotDeflateCostPerSolved(t *testing.T) {
 	}
 }
 
+func TestRenderShowsCacheResetsByCause(t *testing.T) {
+	out := render([]result{
+		{task: task{ID: "a"}, Passed: true, WallMs: 1000,
+			runMetrics: runMetrics{Outcome: "success", PrefixChangeReasonCounts: map[string]int{"compact_auto": 1, "tools": 2}}},
+		{task: task{ID: "b"}, Passed: true, WallMs: 1000,
+			runMetrics: runMetrics{Outcome: "success", PrefixChangeReasonCounts: map[string]int{"snip": 3}}},
+	})
+	if want := "**Cache resets by cause:** compact_auto ×1 · snip ×3 · tools ×2"; !strings.Contains(out, want) {
+		t.Errorf("report missing %q:\n%s", want, out)
+	}
+}
+
+func TestRenderOmitsCacheResetsLineWhenNoReasonsReported(t *testing.T) {
+	out := render([]result{
+		{task: task{ID: "a"}, Passed: true, WallMs: 1000, runMetrics: runMetrics{Outcome: "success"}},
+	})
+	if strings.Contains(out, "Cache resets by cause") {
+		t.Errorf("report should omit the cache-resets line when no run reported any reasons:\n%s", out)
+	}
+}
+
 func TestDurFormatsSubMinuteAndMinuteScale(t *testing.T) {
 	if got := dur(4500); got != "4.5s" {
 		t.Errorf("dur(4500) = %q, want 4.5s", got)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -282,6 +282,15 @@ type Agent struct {
 	// run loop writes it while a frontend's status line reads it, so it is atomic.
 	lastUsage atomic.Pointer[provider.Usage]
 
+	// lastRequestSentAt is the wall-clock moment (unix millis) the most recent
+	// provider request was sent. stream() reads-and-resets it via Swap each time
+	// it builds the next request, so it can tell the provider how long the gap
+	// since the previous request was (adaptive prompt-cache TTL, e.g. Anthropic's
+	// 1h vs default 5m ephemeral breakpoint). Zero means no request sent yet — a
+	// fresh process or sub-agent naturally starts here and gets the provider's
+	// cheaper default TTL.
+	lastRequestSentAt atomic.Int64
+
 	// sessCacheHit/sessCacheMiss accumulate cache tokens across every API call
 	// this session, so frontends can show the aggregate hit-rate (Σhit/Σ(hit+miss))
 	// — a steadier, cost-oriented number than the single-turn rate. They are NOT
@@ -2916,6 +2925,19 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 	if err != nil {
 		return "", "", "", "", "", nil, nil, nil, false, false, nil, err
 	}
+	// Stamp at send time (not response-received time), so the measured gap is
+	// the true idle time since the previous request went out — not undercounted
+	// by that request's own generation duration. A missing-reasoning recovery
+	// retry (streamWithMissingReasoningRecovery) calls stream() again right
+	// away and correctly measures ~0 gap against its own just-set stamp.
+	// The gap travels via context (WithCacheGapHint) and never enters
+	// provider.Request, so non-Anthropic providers and request equality stay clean.
+	sentAt := time.Now()
+	if priorMs := a.lastRequestSentAt.Swap(sentAt.UnixMilli()); priorMs != 0 {
+		ctx = provider.WithCacheGapHint(ctx, sentAt.Sub(time.UnixMilli(priorMs)))
+	}
+	// After #7725 Goal token request admission was removed; stream goes
+	// directly to the provider while still carrying the cache-gap hint.
 	ch, err := a.prov.Stream(ctx, req)
 	if err != nil {
 		return "", "", "", "", "", nil, nil, provider.UsageWithRequestAttemptCount(ctx, nil), false, false, nil, err

--- a/internal/agent/cache_gap_hint_test.go
+++ b/internal/agent/cache_gap_hint_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// gapCaptureProvider records whether/what cache-gap hint arrived on each
+// Stream call, so the test can prove Agent.stream actually threads it through
+// provider.StreamWithRequestBudgetEstimate into Provider.Stream.
+type gapCaptureProvider struct {
+	gaps []time.Duration
+	ok   []bool
+}
+
+func (p *gapCaptureProvider) Name() string { return "gap-capture" }
+
+func (p *gapCaptureProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	gap, ok := provider.CacheGapHintFromContext(ctx)
+	p.gaps = append(p.gaps, gap)
+	p.ok = append(p.ok, ok)
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 10, CompletionTokens: 1, TotalTokens: 11}}
+	close(ch)
+	return ch, nil
+}
+
+func TestStreamCarriesCacheGapHintAfterFirstTurn(t *testing.T) {
+	prov := &gapCaptureProvider{}
+	a := New(prov, tool.NewRegistry(), NewSession("sys"), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "one"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	if err := a.Run(context.Background(), "two"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	if len(prov.ok) != 2 {
+		t.Fatalf("got %d Stream calls, want 2", len(prov.ok))
+	}
+	if prov.ok[0] {
+		t.Fatalf("first request should carry no gap hint, got gap=%v", prov.gaps[0])
+	}
+	if !prov.ok[1] || prov.gaps[1] <= 0 {
+		t.Fatalf("second request should carry a positive gap hint, got ok=%v gap=%v", prov.ok[1], prov.gaps[1])
+	}
+}

--- a/internal/agent/cache_shape.go
+++ b/internal/agent/cache_shape.go
@@ -64,7 +64,14 @@ func normalizeToolSchemas(schemas []provider.ToolSchema) []provider.ToolSchema {
 }
 
 // CompareShape returns diagnostics describing what changed between two shapes.
-func CompareShape(prev, cur PrefixShape, usage *provider.Usage) CacheDiagnostics {
+// contentReasons is the set of provider-visible rewrite reasons (e.g.
+// "compact_auto", "snip", "rewind_truncate") drained from the Session since
+// prev was captured — see Session.DrainContentRewriteReasons. It is the sole
+// source of rewrite-caused reasons: a bare LogRewriteVersion change with no
+// drained reason means only local-only metadata was touched (a decision
+// receipt, tool-call preview/resolution, or an Edited-message replace), which
+// never reaches the provider and so must not be reported as a cache change.
+func CompareShape(prev, cur PrefixShape, usage *provider.Usage, contentReasons []string) CacheDiagnostics {
 	reasons := []string{}
 	if prev.SystemHash != "" && prev.SystemHash != cur.SystemHash {
 		reasons = append(reasons, "system")
@@ -72,9 +79,7 @@ func CompareShape(prev, cur PrefixShape, usage *provider.Usage) CacheDiagnostics
 	if prev.ToolsHash != "" && prev.ToolsHash != cur.ToolsHash {
 		reasons = append(reasons, "tools")
 	}
-	if prev.LogRewriteVersion != cur.LogRewriteVersion {
-		reasons = append(reasons, "log_rewrite")
-	}
+	reasons = append(reasons, contentReasons...)
 	var miss, hit int
 	if usage != nil {
 		miss = usage.CacheMissTokens

--- a/internal/agent/cache_shape_test.go
+++ b/internal/agent/cache_shape_test.go
@@ -35,3 +35,19 @@ func TestCaptureShapeNormalizesToolSchemaOrder(t *testing.T) {
 		t.Fatalf("CaptureShape mutated caller schema order: got [%s %s]", schemas[0].Name, schemas[1].Name)
 	}
 }
+
+func TestCompareShapeIgnoresBareLogRewriteVersionDrift(t *testing.T) {
+	before := CaptureShape("system", nil, 5)
+	// Simulates AddDecisionReceipt/UpdateToolCallPreview/UpdateToolCallResolution/
+	// ReplaceLocalMetadata bumping rewriteVersion alone, with no drained content
+	// reason: none of those touch provider-visible bytes, so this must not be
+	// reported as a cache-prefix change.
+	after := CaptureShape("system", nil, 9)
+	if diag := CompareShape(before, after, nil, nil); diag.PrefixChanged {
+		t.Fatalf("LogRewriteVersion drift with no drained reason must not report a change: %+v", diag)
+	}
+
+	if diag := CompareShape(before, after, nil, []string{"compact_auto"}); !diag.PrefixChanged || len(diag.PrefixChangeReasons) != 1 || diag.PrefixChangeReasons[0] != "compact_auto" {
+		t.Fatalf("a real drained reason must be reported: %+v", diag)
+	}
+}

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -102,6 +102,17 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		return
 	}
 	soft, snip, high := a.compactThresholds()
+	// A turn that sits under the trigger is the breathing room a healthy
+	// compaction buys; it clears the stuck latch and the run counter. This has to
+	// happen before the soft/snip branches return, because a compaction that
+	// settles the prompt anywhere in [snip, high) is working exactly as intended:
+	// leaving a stale run count behind there would latch the *next* compaction as
+	// "the window is too small" and silently disable auto-compaction for the rest
+	// of the session.
+	if u.PromptTokens < high {
+		a.consecutiveCompacts = 0
+		a.compactStuck = false
+	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
 	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {
@@ -120,11 +131,7 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		return
 	}
 	if u.PromptTokens < high {
-		// A turn that sits under the trigger is the breathing room a healthy
-		// compaction buys; it clears the stuck latch and the run counter.
-		a.consecutiveCompacts = 0
-		a.compactStuck = false
-		return
+		return // the latch was already cleared above
 	}
 	if a.compactStuck {
 		return

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -326,7 +326,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 			summaryTagClose,
 	})
 	compacted = append(compacted, msgs[start:]...)
-	a.session.Rewrite(compacted)
+	a.session.Rewrite(compacted, "compact_"+trigger)
 
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
@@ -369,7 +369,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 		Content: "Summary of the later conversation (compacted from here on):\n" + summary,
 	})
 	next = append(next, localOnly...)
-	a.session.Rewrite(next)
+	a.session.Rewrite(next, "summarize_from")
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d later messages → summary", len(region))})
 	return nil
@@ -406,7 +406,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	})
 	next = append(next, localOnly...)
 	next = append(next, msgs[toIdx:]...)
-	a.session.Rewrite(next)
+	a.session.Rewrite(next, "summarize_up_to")
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("summarized %d earlier messages → summary", len(region))})
 	return nil

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -948,3 +948,55 @@ func TestSummarizeToolArgs(t *testing.T) {
 		})
 	}
 }
+
+// TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger pins the documented
+// contract that any turn under the compact trigger is "breathing room" that
+// clears the stuck latch. The snip band ([snip, high)) is the regression: it
+// returned before the reset ran, so a compaction that healthily settled the
+// prompt at, say, 70% of the window left a stale consecutive-run count behind
+// and the next compaction latched the session as "window too small" — silently
+// disabling auto-compaction for the rest of the run.
+func TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger(t *testing.T) {
+	// contextWindow 20000 => soft 10000, snip 12000, high (trigger) 16000.
+	for _, tc := range []struct {
+		name   string
+		prompt int
+	}{
+		{"below soft", 8000},
+		{"soft band", 11000},
+		{"snip band", 14000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := NewSession("sys")
+			sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+			a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+			a.consecutiveCompacts = 1
+			a.compactStuck = true
+
+			a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: tc.prompt})
+
+			if a.consecutiveCompacts != 0 || a.compactStuck {
+				t.Fatalf("prompt %d sits under the trigger; want the latch cleared, got consecutiveCompacts=%d compactStuck=%v",
+					tc.prompt, a.consecutiveCompacts, a.compactStuck)
+			}
+		})
+	}
+}
+
+// TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger proves the safety
+// valve survives the fix above: a genuinely too-small window (the prompt never
+// drops under the trigger between compactions) must still pause auto-compaction.
+func TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger(t *testing.T) {
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
+	if a.compactStuck {
+		t.Fatalf("a single over-trigger compaction must not latch: consecutiveCompacts=%d", a.consecutiveCompacts)
+	}
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
+	if !a.compactStuck {
+		t.Fatalf("two consecutive over-trigger compactions must still latch: consecutiveCompacts=%d", a.consecutiveCompacts)
+	}
+}

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -570,12 +570,13 @@ func TestCompactRewriteVersionFeedsCacheDiagnostics(t *testing.T) {
 	}
 
 	after := CaptureShape("sys", nil, sess.RewriteVersion())
-	diag := CompareShape(before, after, &provider.Usage{CacheMissTokens: 10})
+	reasons := sess.DrainContentRewriteReasons()
+	diag := CompareShape(before, after, &provider.Usage{CacheMissTokens: 10}, reasons)
 	if !diag.PrefixChanged {
 		t.Fatalf("diagnostics should report prefix change: %+v", diag)
 	}
-	if len(diag.PrefixChangeReasons) != 1 || diag.PrefixChangeReasons[0] != "log_rewrite" {
-		t.Fatalf("change reasons = %v, want [log_rewrite]", diag.PrefixChangeReasons)
+	if len(diag.PrefixChangeReasons) != 1 || diag.PrefixChangeReasons[0] != "compact_auto" {
+		t.Fatalf("change reasons = %v, want [compact_auto]", diag.PrefixChangeReasons)
 	}
 }
 

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -110,7 +110,11 @@ func (a *Agent) maintainStaleToolResults(mode toolResultMaintenanceMode) (PruneS
 	if st.Results == 0 {
 		return st, nil
 	}
-	a.session.Rewrite(next)
+	reason := "prune"
+	if mode == toolResultSnip {
+		reason = "snip"
+	}
+	a.session.Rewrite(next, reason)
 	return st, nil
 }
 

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -288,10 +288,17 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 			prevPrefixShape = prefixShape
 		}
 
+		// Drain reasons queued since the previous capture (compaction,
+		// snip/prune, rewind, guardian merge) so CompareShape can attribute
+		// any prefix change to the operation that actually caused it, instead
+		// of a generic rewrite signal that also fires on local-only metadata
+		// edits.
+		contentReasons := a.session.DrainContentRewriteReasons()
+
 		streamed := a.streamWithMissingReasoningRecovery(ctx, step+1)
 		text, reasoning, signature, calls, responsesItems, usage := streamed.text, streamed.reasoning, streamed.signature, streamed.calls, streamed.responsesItems, streamed.usage
 		interrupted, partialToolStarted, partialCalls, err := streamed.interrupted, streamed.partialToolStarted, streamed.partialCalls, streamed.err
-		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage)
+		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage, contentReasons)
 		if err != nil {
 			a.emitTurnUsage(usage, &cacheDiagnostics)
 			if msg, ok := finishReasonMessage(usage); ok {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -43,6 +43,15 @@ type Session struct {
 	// what is actually on disk, and the repaired view no longer represents
 	// those bytes — a session that kept running extends the raw transcript.
 	rawMessages []provider.Message
+	// pendingContentReasons accumulates a reason string each time Rewrite()
+	// actually replaces provider-visible message bytes (compact, prune/snip,
+	// summarize, rewind, guardian merge). ReplaceLocalMetadata bumps
+	// rewriteVersion for the same save-path (NeedsRewriteSave) purpose without
+	// appending here, because ModelMessages strips or never serializes the
+	// local-only metadata it changes — so that path must never report a
+	// cache-prefix change. DrainContentRewriteReasons (run_loop.go, once per
+	// provider request) is the sole consumer.
+	pendingContentReasons []string
 }
 
 // NewSession initializes a session with an optional system prompt.
@@ -190,12 +199,48 @@ func (s *Session) Replace(msgs []provider.Message) {
 // atomic classification matters when a periodic snapshot races compaction,
 // pruning, or local metadata edits: a later autosave must use owned-rewrite
 // conflict checks instead of mistaking the modified prefix for another writer.
-func (s *Session) Rewrite(msgs []provider.Message) {
+//
+// reason names the provider-visible change (e.g. "compact_auto", "snip",
+// "rewind_truncate") and is queued for the next DrainContentRewriteReasons
+// call, which feeds cache-diagnostics attribution. Callers whose msgs only
+// change local-only display metadata (never serialized to the provider) must
+// use ReplaceLocalMetadata instead, so they don't misreport a cache-prefix
+// change that never happened.
+func (s *Session) Rewrite(msgs []provider.Message, reason string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = msgs
 	s.rewriteVersion++
 	s.version++
+	if reason != "" {
+		s.pendingContentReasons = append(s.pendingContentReasons, reason)
+	}
+}
+
+// ReplaceLocalMetadata atomically replaces the message log exactly like
+// Rewrite (including the rewriteVersion bump that forces the next save to use
+// owned-rewrite conflict checks), for callers that only changed local-only
+// display metadata (e.g. marking a resubmitted message Edited) rather than any
+// provider-visible byte. Unlike Rewrite, it never queues a cache-prefix-change
+// reason, since ModelMessages strips or never serializes what changed.
+func (s *Session) ReplaceLocalMetadata(msgs []provider.Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Messages = msgs
+	s.rewriteVersion++
+	s.version++
+}
+
+// DrainContentRewriteReasons returns and clears the reasons queued by Rewrite
+// since the last drain. Called once per provider request (run_loop.go) so
+// CompareShape can attribute a cache-prefix change to the operation that
+// actually caused it.
+func (s *Session) DrainContentRewriteReasons() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	reasons := s.pendingContentReasons
+	s.pendingContentReasons = nil
+	return reasons
 }
 
 // Snapshot returns a copy of the messages, safe to read from another goroutine
@@ -239,6 +284,7 @@ func (s *Session) CloneWithMessages(msgs []provider.Message) *Session {
 		persisted:               s.persisted,
 		normalizedDirty:         s.normalizedDirty,
 		eventLogDamaged:         s.eventLogDamaged,
+		pendingContentReasons:   append([]string(nil), s.pendingContentReasons...),
 	}
 }
 
@@ -267,6 +313,7 @@ func (s *Session) CloneWithMessagesIfCompatible(msgs []provider.Message) (*Sessi
 		persisted:               s.persisted,
 		normalizedDirty:         s.normalizedDirty,
 		eventLogDamaged:         s.eventLogDamaged,
+		pendingContentReasons:   append([]string(nil), s.pendingContentReasons...),
 	}, true
 }
 

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -26,35 +26,40 @@ type SourceUsage struct {
 // RunMetrics is the machine-readable token/cache/cost summary `run --metrics`
 // writes, so a benchmark harness can read a run's cost without scraping stdout.
 type RunMetrics struct {
-	PromptTokens                   int     `json:"prompt_tokens"`
-	CompletionTokens               int     `json:"completion_tokens"`
-	CacheHitTokens                 int     `json:"cache_hit_tokens"`
-	CacheMissTokens                int     `json:"cache_miss_tokens"`
-	Steps                          int     `json:"steps"` // model calls (one per stream, incl. tool rounds)
-	Cost                           float64 `json:"cost"`
-	Currency                       string  `json:"currency"`
-	Estimated                      bool    `json:"estimated,omitempty"`
-	Compactions                    int     `json:"compactions"`
-	ReadinessChecks                int     `json:"readiness_checks"`
-	ReadinessAllowed               int     `json:"readiness_allowed"`
-	ReadinessBlocks                int     `json:"readiness_blocks"`
-	ReadinessRecoveries            int     `json:"readiness_recoveries"`
-	ReadinessErrors                int     `json:"readiness_errors"`
-	ReadinessMissingProjectChecks  int     `json:"readiness_missing_project_checks"`
-	ReadinessIncompleteTodos       int     `json:"readiness_incomplete_todos"`
-	ReadinessCommandMismatches     int     `json:"readiness_command_mismatches"`
-	ReadinessMissingAcceptance     int     `json:"readiness_missing_acceptance_criteria"`
-	ReadinessMissingVerification   int     `json:"readiness_missing_verification"`
-	ReadinessMissingReview         int     `json:"readiness_missing_review"`
-	ReadinessMissingSignoff        int     `json:"readiness_missing_signoff"`
-	ReadinessMissingActionEvidence int     `json:"readiness_missing_action_evidence"`
-	ReadinessMissingMutation       int     `json:"readiness_missing_mutation"`
-	MissingReasoningDetected       int     `json:"missing_reasoning_detected,omitempty"`
-	MissingReasoningRetries        int     `json:"missing_reasoning_retries,omitempty"`
-	MissingReasoningRecovered      int     `json:"missing_reasoning_recovered,omitempty"`
-	MissingReasoningReplaced       int     `json:"missing_reasoning_retry_replaced_response,omitempty"`
-	MissingReasoningSuppressed     int     `json:"missing_reasoning_retry_suppressed,omitempty"`
-	MissingReasoningFallbacks      int     `json:"missing_reasoning_fallbacks,omitempty"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	CacheHitTokens   int `json:"cache_hit_tokens"`
+	CacheMissTokens  int `json:"cache_miss_tokens"`
+	// PrefixChangeReasonCounts tallies how many usage events reported each
+	// cache-prefix-change reason (e.g. "compact_auto", "snip", "tools") across
+	// the run, so a regression in cache-reset frequency shows which operation
+	// is responsible instead of just a dropped hit-rate percentage.
+	PrefixChangeReasonCounts       map[string]int `json:"prefix_change_reason_counts,omitempty"`
+	Steps                          int            `json:"steps"` // model calls (one per stream, incl. tool rounds)
+	Cost                           float64        `json:"cost"`
+	Currency                       string         `json:"currency"`
+	Estimated                      bool           `json:"estimated,omitempty"`
+	Compactions                    int            `json:"compactions"`
+	ReadinessChecks                int            `json:"readiness_checks"`
+	ReadinessAllowed               int            `json:"readiness_allowed"`
+	ReadinessBlocks                int            `json:"readiness_blocks"`
+	ReadinessRecoveries            int            `json:"readiness_recoveries"`
+	ReadinessErrors                int            `json:"readiness_errors"`
+	ReadinessMissingProjectChecks  int            `json:"readiness_missing_project_checks"`
+	ReadinessIncompleteTodos       int            `json:"readiness_incomplete_todos"`
+	ReadinessCommandMismatches     int            `json:"readiness_command_mismatches"`
+	ReadinessMissingAcceptance     int            `json:"readiness_missing_acceptance_criteria"`
+	ReadinessMissingVerification   int            `json:"readiness_missing_verification"`
+	ReadinessMissingReview         int            `json:"readiness_missing_review"`
+	ReadinessMissingSignoff        int            `json:"readiness_missing_signoff"`
+	ReadinessMissingActionEvidence int            `json:"readiness_missing_action_evidence"`
+	ReadinessMissingMutation       int            `json:"readiness_missing_mutation"`
+	MissingReasoningDetected       int            `json:"missing_reasoning_detected,omitempty"`
+	MissingReasoningRetries        int            `json:"missing_reasoning_retries,omitempty"`
+	MissingReasoningRecovered      int            `json:"missing_reasoning_recovered,omitempty"`
+	MissingReasoningReplaced       int            `json:"missing_reasoning_retry_replaced_response,omitempty"`
+	MissingReasoningSuppressed     int            `json:"missing_reasoning_retry_suppressed,omitempty"`
+	MissingReasoningFallbacks      int            `json:"missing_reasoning_fallbacks,omitempty"`
 	// Capability / Delivery routing counters (optional; zero for older readers).
 	CapabilityRoutes               int     `json:"capability_routes,omitempty"`
 	CapabilityRoutedCandidates     int     `json:"capability_routed_candidates,omitempty"`
@@ -214,6 +219,14 @@ func (s *metricsSink) record(e event.Event) {
 			s.m.CapabilityRouterPromptTokens += u.PromptTokens
 			s.m.CapabilityRouterCompletionTok += u.CompletionTokens
 			s.m.CapabilityRouterCost += stepCost
+		}
+		if e.CacheDiagnostics != nil && len(e.CacheDiagnostics.PrefixChangeReasons) > 0 {
+			if s.m.PrefixChangeReasonCounts == nil {
+				s.m.PrefixChangeReasonCounts = map[string]int{}
+			}
+			for _, reason := range e.CacheDiagnostics.PrefixChangeReasons {
+				s.m.PrefixChangeReasonCounts[reason]++
+			}
 		}
 	}
 	if e.Kind == event.CompactionStarted {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -794,10 +794,12 @@ func (c *Controller) markEditedForNewUser(startMessages int, original string) {
 		msgs[i].Edited = true
 		msgs[i].Original = original
 		// A periodic autosave may already contain this user message without its
-		// local edit metadata. Classify the prefix mutation atomically so the
-		// turn-end save performs an owned rewrite instead of forking a bogus
-		// same-revision recovery branch.
-		s.Rewrite(msgs)
+		// local edit metadata. Classify the mutation atomically so the turn-end
+		// save performs an owned rewrite instead of forking a bogus
+		// same-revision recovery branch. Edited/Original are local-only display
+		// metadata (provider requests ignore them), so this must not report a
+		// cache-prefix change — ReplaceLocalMetadata, not Rewrite.
+		s.ReplaceLocalMetadata(msgs)
 		return
 	}
 }

--- a/internal/control/rewind.go
+++ b/internal/control/rewind.go
@@ -48,7 +48,7 @@ func (a conversationApplier) ApplyConversationTruncate(boundary int, forward []b
 			return err
 		}
 	}
-	s.Rewrite(msgs[:boundary])
+	s.Rewrite(msgs[:boundary], "rewind_truncate")
 	if err := c.SnapshotRewrite(); err != nil {
 		_ = a.RestoreConversation(forward)
 		return fmt.Errorf("persist conversation after rewind: %w", err)
@@ -65,7 +65,7 @@ func (a conversationApplier) RestoreConversation(forward []byte) error {
 	if err := json.Unmarshal(forward, &msgs); err != nil {
 		return err
 	}
-	c.executor.Session().Rewrite(msgs)
+	c.executor.Session().Rewrite(msgs, "rewind_restore")
 	if err := c.SnapshotRewrite(); err != nil {
 		return fmt.Errorf("restore conversation: %w", err)
 	}

--- a/internal/guardian/guardian.go
+++ b/internal/guardian/guardian.go
@@ -347,7 +347,7 @@ func (gs *Session) normalizeAlternation() {
 	if !merged {
 		return
 	}
-	gs.sess.Rewrite(out)
+	gs.sess.Rewrite(out, "guardian_merge")
 }
 
 // Load replaces the guardian's internal agent session with the one at path,

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -261,7 +261,7 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	requestCtx := provider.WithRequestAttemptCounter(ctx)
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
-	if err := json.NewEncoder(buf).Encode(c.buildRequest(req)); err != nil {
+	if err := json.NewEncoder(buf).Encode(c.buildRequest(requestCtx, req)); err != nil {
 		bufPool.Put(buf)
 		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
 	}
@@ -301,7 +301,7 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 // become `tool_use` blocks; RoleTool results become `tool_result` blocks in a user
 // turn. Consecutive same-role messages are coalesced because the API requires
 // alternating user/assistant turns (tool results are user turns).
-func (c *client) buildRequest(req provider.Request) anthRequest {
+func (c *client) buildRequest(ctx context.Context, req provider.Request) anthRequest {
 	var system []textBlock
 	var msgs []anthMessage
 
@@ -394,16 +394,23 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 	// tools → system → messages, so a marker on the last system block caches
 	// tools+system together; with no system, mark the last tool. A marker on the
 	// last block of the last message caches the conversation prefix, accruing hits
-	// incrementally as turns are appended. Max 4 breakpoints; we use ≤2.
+	// incrementally as turns are appended. Max 4 breakpoints; we use ≤2. One TTL
+	// decision (default 5m, or 1h when the previous request was long enough ago
+	// that the 5m window would likely already have expired) applies to all of
+	// them — this is a single "extend this prefix" choice, not per-block.
 	if !c.deepseek {
+		ttl := ""
+		if useLongCacheTTL(ctx) {
+			ttl = cacheTTL1Hour
+		}
 		if n := len(system); n > 0 {
-			system[n-1].CacheControl = ephemeral()
+			system[n-1].CacheControl = ephemeral(ttl)
 		} else if n := len(tools); n > 0 {
-			tools[n-1].CacheControl = ephemeral()
+			tools[n-1].CacheControl = ephemeral(ttl)
 		}
 		if n := len(msgs); n > 0 {
 			if k := len(msgs[n-1].Content); k > 0 {
-				msgs[n-1].Content[k-1].CacheControl = ephemeral()
+				msgs[n-1].Content[k-1].CacheControl = ephemeral(ttl)
 			}
 		}
 	}
@@ -744,10 +751,33 @@ func formatWebSearchResults(raw json.RawMessage) string {
 
 // --- Messages API wire protocol ---
 
-func ephemeral() *cacheControl { return &cacheControl{Type: "ephemeral"} }
+// cacheGapLongTTLThreshold is how long the gap since the previous request must
+// be before the 1h cache breakpoint (2x write cost) is worth it over the
+// default 5m one (1.25x write cost). Comfortably under Anthropic's 5-minute
+// expiry so the switch happens before that window would actually go cold, but
+// high enough that one ordinary ~60-90s tool round (a build, a test run)
+// doesn't flip it: an unneeded 1h choice costs proportionally more (2.1x) than
+// an unneeded 5m one (1.35x) would have, so this errs conservative.
+const cacheGapLongTTLThreshold = 120 * time.Second
+
+// cacheTTL1Hour is the opt-in extended cache_control TTL value (GA, no beta
+// header required). An empty TTL string omits the field entirely, which is
+// Anthropic's default 5-minute window.
+const cacheTTL1Hour = "1h"
+
+// useLongCacheTTL reports whether the gap since the previous request (see
+// provider.WithCacheGapHint) is large enough that the default 5-minute
+// prompt-cache window would likely already have expired.
+func useLongCacheTTL(ctx context.Context) bool {
+	gap, ok := provider.CacheGapHintFromContext(ctx)
+	return ok && gap >= cacheGapLongTTLThreshold
+}
+
+func ephemeral(ttl string) *cacheControl { return &cacheControl{Type: "ephemeral", TTL: ttl} }
 
 type cacheControl struct {
 	Type string `json:"type"`
+	TTL  string `json:"ttl,omitempty"`
 }
 
 type anthRequest struct {

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 )
@@ -31,7 +32,7 @@ func TestBuildRequest(t *testing.T) {
 		},
 		Tools: []provider.ToolSchema{{Name: "get_weather", Description: "w", Parameters: json.RawMessage(`{"type":"object"}`)}},
 	}
-	r := c.buildRequest(req)
+	r := c.buildRequest(context.Background(), req)
 
 	if r.Model != "claude-opus-4-8" {
 		t.Fatalf("model = %q", r.Model)
@@ -82,7 +83,7 @@ func TestBuildRequest(t *testing.T) {
 // there is no system message.
 func TestBuildRequestNoSystem(t *testing.T) {
 	c := &client{model: "claude-opus-4-8"}
-	r := c.buildRequest(provider.Request{
+	r := c.buildRequest(context.Background(), provider.Request{
 		Messages:  []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
 		Tools:     []provider.ToolSchema{{Name: "a"}, {Name: "b"}},
 		MaxTokens: 1000,
@@ -99,6 +100,79 @@ func TestBuildRequestNoSystem(t *testing.T) {
 	}
 }
 
+func lastBlockCacheControl(r anthRequest) *cacheControl {
+	last := r.Messages[len(r.Messages)-1]
+	return last.Content[len(last.Content)-1].CacheControl
+}
+
+func TestBuildRequestDefaultsToShortCacheTTL(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"}
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	got := lastBlockCacheControl(r)
+	if got == nil || got.TTL != "" {
+		t.Fatalf("cache_control = %+v, want empty TTL with no gap hint", got)
+	}
+}
+
+func TestBuildRequestUsesLongCacheTTLOnLargeGap(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"}
+	ctx := provider.WithCacheGapHint(context.Background(), 3*time.Minute)
+	r := c.buildRequest(ctx, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	got := lastBlockCacheControl(r)
+	if got == nil || got.TTL != "1h" {
+		t.Fatalf("cache_control = %+v, want ttl=1h for a 3-minute gap", got)
+	}
+}
+
+func TestBuildRequestKeepsShortCacheTTLBelowThreshold(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"}
+	ctx := provider.WithCacheGapHint(context.Background(), 10*time.Second)
+	r := c.buildRequest(ctx, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	got := lastBlockCacheControl(r)
+	if got == nil || got.TTL != "" {
+		t.Fatalf("cache_control = %+v, want default ttl for a 10s gap", got)
+	}
+}
+
+func TestCacheControlOmitsTTLByDefault(t *testing.T) {
+	b, err := json.Marshal(ephemeral(""))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `{"type":"ephemeral"}` {
+		t.Fatalf("default cache_control = %s, want byte-identical to every prior release", b)
+	}
+	b, err = json.Marshal(ephemeral("1h"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != `{"type":"ephemeral","ttl":"1h"}` {
+		t.Fatalf("1h cache_control = %s", b)
+	}
+}
+
+func TestUseLongCacheTTL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		gap  time.Duration
+		hint bool
+		want bool
+	}{
+		{"no hint", 0, false, false},
+		{"below threshold", cacheGapLongTTLThreshold - time.Second, true, false},
+		{"at threshold", cacheGapLongTTLThreshold, true, true},
+		{"above threshold", cacheGapLongTTLThreshold + time.Minute, true, true},
+	} {
+		ctx := context.Background()
+		if tc.hint {
+			ctx = provider.WithCacheGapHint(ctx, tc.gap)
+		}
+		if got := useLongCacheTTL(ctx); got != tc.want {
+			t.Errorf("%s: useLongCacheTTL = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestConfiguredMaxOutputTokensRespectsMandatoryAnthropicFallback(t *testing.T) {
 	configured, err := New(provider.Config{
 		Name: "anthropic", Model: "claude-opus-4-8",
@@ -107,7 +181,7 @@ func TestConfiguredMaxOutputTokensRespectsMandatoryAnthropicFallback(t *testing.
 	if err != nil {
 		t.Fatalf("New configured provider: %v", err)
 	}
-	if got := configured.(*client).buildRequest(provider.Request{}).MaxTokens; got != 8192 {
+	if got := configured.(*client).buildRequest(context.Background(), provider.Request{}).MaxTokens; got != 8192 {
 		t.Fatalf("configured max_tokens = %d, want 8192", got)
 	}
 
@@ -118,7 +192,7 @@ func TestConfiguredMaxOutputTokensRespectsMandatoryAnthropicFallback(t *testing.
 	if err != nil {
 		t.Fatalf("New disabled provider: %v", err)
 	}
-	if got := disabled.(*client).buildRequest(provider.Request{}).MaxTokens; got != defaultMaxTokens {
+	if got := disabled.(*client).buildRequest(context.Background(), provider.Request{}).MaxTokens; got != defaultMaxTokens {
 		t.Fatalf("mandatory max_tokens fallback = %d, want %d", got, defaultMaxTokens)
 	}
 }
@@ -151,12 +225,12 @@ func TestBuildRequestScopesLegacyTupleMigrationToMiMo(t *testing.T) {
 	legacy := json.RawMessage(`{"type":"object","properties":{"pair":{"type":"array","items":[{"type":"string"},{"type":"number"}]}}}`)
 	req := provider.Request{Tools: []provider.ToolSchema{{Name: "tuple", Parameters: legacy}}}
 
-	mimo := (&client{mimo: true}).buildRequest(req)
+	mimo := (&client{mimo: true}).buildRequest(context.Background(), req)
 	if got := string(mimo.Tools[0].InputSchema); !strings.Contains(got, `"prefixItems"`) || strings.Contains(got, `"items":[`) {
 		t.Fatalf("MiMo parameters = %s, want Draft 2020-12 tuple keywords", got)
 	}
 
-	other := (&client{}).buildRequest(req)
+	other := (&client{}).buildRequest(context.Background(), req)
 	if got := string(other.Tools[0].InputSchema); got != string(legacy) {
 		t.Fatalf("non-MiMo parameters changed:\n got: %s\nwant: %s", got, legacy)
 	}
@@ -375,7 +449,7 @@ func TestReadStreamError(t *testing.T) {
 // thinking block is replayed first (before its tool_use).
 func TestBuildRequestThinking(t *testing.T) {
 	c := &client{model: "claude-opus-4-8", thinking: "adaptive", effort: "high"}
-	r := c.buildRequest(provider.Request{
+	r := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "weather?"},
 			{Role: provider.RoleAssistant, ReasoningContent: "Let me check.", ReasoningSignature: "sig-abc",
@@ -404,7 +478,7 @@ func TestBuildRequestThinking(t *testing.T) {
 func TestBuildRequestOmitsResolvedToolCallMetadata(t *testing.T) {
 	readOnly := false
 	c := &client{model: "claude-opus-4-8"}
-	req := c.buildRequest(provider.Request{Messages: []provider.Message{{
+	req := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleAssistant,
 		ToolCalls: []provider.ToolCall{{
 			ID: "call_1", Name: "use_capability", Arguments: `{}`,
@@ -428,7 +502,7 @@ func TestBuildRequestOmitsResolvedToolCallMetadata(t *testing.T) {
 
 func TestBuildRequestThinkingEnabledGateway(t *testing.T) {
 	c := &client{model: "LongCat-2.0", thinking: "enabled", effort: "disabled"}
-	r := c.buildRequest(provider.Request{
+	r := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "hi"},
 			{Role: provider.RoleAssistant, Content: "ok", ReasoningContent: "signed reasoning", ReasoningSignature: "sig"},
@@ -449,7 +523,7 @@ func TestBuildRequestThinkingEnabledGateway(t *testing.T) {
 
 func TestBuildRequestDeepSeekThinking(t *testing.T) {
 	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "max"}
-	r := c.buildRequest(provider.Request{
+	r := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleSystem, Content: "stable system"},
 			{Role: provider.RoleUser, Content: "weather?"},
@@ -515,7 +589,7 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: tc.thinking, effort: tc.effort}
-			r := c.buildRequest(provider.Request{Messages: toolTurn})
+			r := c.buildRequest(context.Background(), provider.Request{Messages: toolTurn})
 			if len(r.Tools) != 0 {
 				t.Fatalf("current request tools = %+v, want none", r.Tools)
 			}
@@ -531,7 +605,7 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 
 	t.Run("reasoning without a tool call stays omitted", func(t *testing.T) {
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
-		r := c.buildRequest(provider.Request{
+		r := c.buildRequest(context.Background(), provider.Request{
 			Messages: []provider.Message{
 				{Role: provider.RoleUser, Content: "hello"},
 				{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "private scratchpad"},
@@ -559,14 +633,14 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 		{name: "unknown model falls back to Flash", model: "unknown-model", input: "xhigh", want: "high"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			r := (&client{model: tc.model, deepseek: true, effort: tc.input}).buildRequest(provider.Request{})
+			r := (&client{model: tc.model, deepseek: true, effort: tc.input}).buildRequest(context.Background(), provider.Request{})
 			if r.Thinking == nil || r.Thinking.Type != "enabled" || r.OutputConfig == nil || r.OutputConfig.Effort != tc.want {
 				t.Fatalf("DeepSeek thinking = %+v / %+v, want enabled/%s", r.Thinking, r.OutputConfig, tc.want)
 			}
 		})
 	}
 	t.Run("provider default", func(t *testing.T) {
-		r := (&client{model: "deepseek-v4-flash", deepseek: true}).buildRequest(provider.Request{})
+		r := (&client{model: "deepseek-v4-flash", deepseek: true}).buildRequest(context.Background(), provider.Request{})
 		if r.Thinking == nil || r.Thinking.Type != "enabled" || r.OutputConfig != nil {
 			t.Fatalf("default DeepSeek thinking = %+v / %+v, want enabled/provider-default effort", r.Thinking, r.OutputConfig)
 		}
@@ -574,7 +648,7 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 
 	t.Run("disabled", func(t *testing.T) {
 		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "disabled"}
-		r := c.buildRequest(provider.Request{
+		r := c.buildRequest(context.Background(), provider.Request{
 			Messages: []provider.Message{{Role: provider.RoleAssistant, ReasoningContent: "do not replay"}},
 			Tools:    []provider.ToolSchema{{Name: "tool"}},
 		})
@@ -592,7 +666,7 @@ func TestBuildRequestDeepSeekThinkingModes(t *testing.T) {
 
 func TestBuildRequestDeepSeekPreservesCallerTemperature(t *testing.T) {
 	zero := provider.TemperaturePtr(0)
-	r := (&client{model: "deepseek-v4-flash", deepseek: true}).buildRequest(provider.Request{Temperature: zero})
+	r := (&client{model: "deepseek-v4-flash", deepseek: true}).buildRequest(context.Background(), provider.Request{Temperature: zero})
 	if r.Temperature == nil || *r.Temperature != 0 {
 		t.Fatalf("DeepSeek temperature = %v, want explicit zero", r.Temperature)
 	}
@@ -604,7 +678,7 @@ func TestBuildRequestDeepSeekPreservesCallerTemperature(t *testing.T) {
 		t.Fatalf("DeepSeek request omitted explicit temperature: %s", b)
 	}
 
-	native := (&client{model: "claude-opus-4-8"}).buildRequest(provider.Request{Temperature: provider.TemperaturePtr(0.5)})
+	native := (&client{model: "claude-opus-4-8"}).buildRequest(context.Background(), provider.Request{Temperature: provider.TemperaturePtr(0.5)})
 	if native.Temperature != nil {
 		t.Fatalf("native Anthropic temperature = %v, want omitted", native.Temperature)
 	}
@@ -621,7 +695,7 @@ func TestBuildRequestDeepSeekPreservesCallerTemperature(t *testing.T) {
 // NOT replayed (even with a signature present) since the model wasn't asked to think.
 func TestBuildRequestThinkingOff(t *testing.T) {
 	c := &client{model: "claude-opus-4-8"}
-	r := c.buildRequest(provider.Request{Messages: []provider.Message{
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{
 		{Role: provider.RoleUser, Content: "hi"},
 		{Role: provider.RoleAssistant, Content: "ok", ReasoningContent: "x", ReasoningSignature: "sig"},
 	}})
@@ -637,7 +711,7 @@ func TestBuildRequestThinkingOff(t *testing.T) {
 
 func TestBuildRequestDropsLocalMetadata(t *testing.T) {
 	c := &client{model: "claude-opus-4-8"}
-	r := c.buildRequest(provider.Request{Messages: []provider.Message{
+	r := c.buildRequest(context.Background(), provider.Request{Messages: []provider.Message{
 		{Role: provider.RoleUser, Content: "continue"},
 		{Role: provider.RoleUser, Content: "edited prompt", Edited: true, Original: "original prompt"},
 		{Role: provider.RoleAssistant, Content: "done", WorkDurationMs: 24_000, MemoryCitations: []provider.MemoryCitation{{

--- a/internal/provider/anthropic/image_test.go
+++ b/internal/provider/anthropic/image_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 
 func TestBuildRequestEmbedsImageBlockForVisionModel(t *testing.T) {
 	c := &client{model: "claude-opus-4-8", vision: true}
-	req := c.buildRequest(provider.Request{
+	req := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
 		},
@@ -26,7 +27,7 @@ func TestBuildRequestEmbedsImageBlockForVisionModel(t *testing.T) {
 
 func TestBuildRequestSkipsImageBlockWithoutVision(t *testing.T) {
 	c := &client{model: "claude-opus-4-8"} // vision unset
-	req := c.buildRequest(provider.Request{
+	req := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
 		},
@@ -49,7 +50,7 @@ func toolMessages(images []string) []provider.Message {
 
 func TestBuildRequestEmbedsToolResultImagesForVisionModel(t *testing.T) {
 	c := &client{model: "claude-opus-4-8", vision: true}
-	req := c.buildRequest(provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
+	req := c.buildRequest(context.Background(), provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
 	last := req.Messages[len(req.Messages)-1]
 	if last.Role != "user" || len(last.Content) != 1 || last.Content[0].Type != "tool_result" {
 		t.Fatalf("last message = %+v, want a single tool_result block", last)
@@ -72,7 +73,7 @@ func TestBuildRequestEmbedsToolResultImagesForVisionModel(t *testing.T) {
 
 func TestBuildRequestDropsToolResultImagesWithoutVision(t *testing.T) {
 	c := &client{model: "claude-opus-4-8"} // vision unset
-	req := c.buildRequest(provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
+	req := c.buildRequest(context.Background(), provider.Request{Messages: toolMessages([]string{"data:image/png;base64,QUFB"})})
 	last := req.Messages[len(req.Messages)-1]
 	if s, ok := last.Content[0].Content.(string); !ok || s != "[image: image/png]" {
 		t.Fatalf("non-vision tool_result content = %#v, want the plain placeholder string", last.Content[0].Content)
@@ -90,7 +91,7 @@ func TestBuildRequestToolResultTextOnlyKeepsStringContent(t *testing.T) {
 	// and takes the cache breakpoint, so the tool_result block keeps its
 	// pre-image-channel bytes.
 	msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: "next"})
-	req := c.buildRequest(provider.Request{Messages: msgs})
+	req := c.buildRequest(context.Background(), provider.Request{Messages: msgs})
 	last := req.Messages[len(req.Messages)-1]
 	if len(last.Content) != 2 || last.Content[0].Type != "tool_result" {
 		t.Fatalf("last message blocks = %+v, want [tool_result, text]", last.Content)

--- a/internal/provider/anthropic/web_search_test.go
+++ b/internal/provider/anthropic/web_search_test.go
@@ -16,7 +16,7 @@ import (
 // without an input_schema, and named tools keep their schema untouched.
 func TestBuildRequestWebSearchServerTool(t *testing.T) {
 	c := &client{name: "deepseek", model: "deepseek-v4-flash", webSearch: true}
-	r := c.buildRequest(provider.Request{
+	r := c.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
 		Tools:    []provider.ToolSchema{{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)}},
 	})
@@ -35,7 +35,7 @@ func TestBuildRequestWebSearchServerTool(t *testing.T) {
 
 	// Disabled (default) ⇒ no server tool is injected.
 	off := &client{name: "deepseek", model: "deepseek-v4-flash"}
-	r = off.buildRequest(provider.Request{
+	r = off.buildRequest(context.Background(), provider.Request{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
 		Tools:    []provider.ToolSchema{{Name: "read_file", Parameters: json.RawMessage(`{"type":"object"}`)}},
 	})

--- a/internal/provider/cache_hint.go
+++ b/internal/provider/cache_hint.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"context"
+	"time"
+)
+
+type cacheGapHintKey struct{}
+
+// WithCacheGapHint attaches how long it has been since this Agent last sent a
+// provider request, so a provider with an opt-in longer cache TTL (Anthropic's
+// 1h ephemeral breakpoint, versus its cheaper default 5m one) can decide
+// whether the default window would likely already have expired. Mirrors the
+// WithRetryNotify/WithRequestAttemptCounter context-key idiom in retry.go: a
+// side channel for per-request signals that must never enter the request body
+// or the cacheable prefix itself.
+func WithCacheGapHint(ctx context.Context, gap time.Duration) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, cacheGapHintKey{}, gap)
+}
+
+// CacheGapHintFromContext returns the gap since the previous request and
+// whether one was set. No value — the first request of an Agent's lifetime, a
+// fresh sub-agent session, or a caller that never wired the hint — means
+// default to the provider's cheaper, shorter cache TTL.
+func CacheGapHintFromContext(ctx context.Context) (time.Duration, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	gap, ok := ctx.Value(cacheGapHintKey{}).(time.Duration)
+	return gap, ok
+}


### PR DESCRIPTION
Three related prompt-cache improvements, found while auditing Reasonix's cache architecture against current provider documentation. Each is independent and separately tested.

Rebased onto latest `main-v2` after #7725 removed Goal request-budget admission: the adaptive TTL path keeps `WithCacheGapHint` on the context and streams via `a.prov.Stream` (no `StreamWithRequestBudgetEstimate`).

## 1. Adaptive Anthropic `cache_control` TTL

`cache_control` only ever sent the default 5-minute ephemeral window. Anthropic also supports an opt-in 1-hour window (GA, no beta header): cache **reads** cost 0.1x base either way, while **writes** cost 1.25x (5m) vs 2x (1h). Any Anthropic-backed session idle longer than 5 minutes — waiting on a build, reading a long diff, switching tasks — paid a full cache-miss rewrite that the longer window would have avoided.

`Agent.stream` now stamps the wall-clock gap since the previous request and passes it via a new `provider.WithCacheGapHint` context key (mirroring the existing `WithRetryNotify` / `WithRequestAttemptCounter` idiom, so `provider.Request` stays byte-stable). `anthropic.go` upgrades to `ttl:"1h"` only when that gap is >= 120s, so rapid turns keep paying the cheaper 5m write and only genuinely idle gaps get the longer window — before it would have expired anyway.

The default path is byte-identical to every prior release (`ttl` is `omitempty`), pinned by a test that marshals the struct and compares exact bytes.

## 2. Cache-diagnostics reason granularity + false-positive fix

`Session.rewriteVersion` is bumped both by provider-visible rewrites (compact, snip/prune, summarize, rewind, guardian merge) and by local-only metadata edits (decision receipts, tool-call preview/resolution, marking a message `Edited`) that `ModelMessages` strips or never serializes. `CompareShape` used a bare `rewriteVersion` diff as its only signal, so a local-only edit could report "cache prefix changed" even though the bytes sent to the provider never moved.

`Rewrite` now takes an explicit reason and queues it on the session; a new `ReplaceLocalMetadata` covers the one call site that only touches local metadata, so it no longer contributes a reason. Diagnostics report the specific cause (`compact_auto`, `compact_manual`, `snip`, `prune`, `summarize_from`, `summarize_up_to`, `rewind_truncate`, `rewind_restore`, `guardian_merge`) instead of one generic `log_rewrite`, and a bare `rewriteVersion` drift with nothing drained no longer reports a change at all.

The e2e benchmark aggregates these into a **Cache resets by cause** line next to the existing failures-by-class breakdown, so a hit-rate regression in a PR shows which operation caused it.

## 3. Compaction latch fix (found while measuring #2)

**Problem:** auto-compaction could switch itself off permanently mid-session and tell the user their context window was too small when it was not. After the latch fired, every later turn returned early from `maybeCompact`, so the prompt grew unbounded until the provider rejected it.

**Root cause:** `maybeCompact` cleared `consecutiveCompacts`/`compactStuck` inside the `PromptTokens < high` branch, but that branch is unreachable for the whole `[snip, high)` band — the snip branch above it returns first. A healthy compaction that settles the prompt at ~70% of the window therefore left the run counter at 1, and the next legitimate compaction incremented it to 2 and latched the session. The reset's own comment states the intended contract ("a turn that sits under the trigger is the breathing room a healthy compaction buys"), so the code contradicted its documented intent.

**Fix:** hoist the reset to run for any prompt under the trigger, before the soft/snip branches return. Nothing else about the tiering changes.

## Verification

- `go build ./...` and `go vet` clean.
- New `TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger` fails on the parent commit for the soft and snip bands and passes after the fix; `TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger` pins that a genuinely too-small window still pauses auto-compaction, so the safety valve is not disabled. All 8 pre-existing `TestMaybeCompact*` tests unchanged.
- 8 new/updated tests cover the TTL and diagnostics work, including a byte-exact check that the default `cache_control` payload is unchanged.
- The adaptive TTL was additionally exercised against a live Anthropic-compatible endpoint: a cold call, a 3s-gap call (cache hit on the default window), and a forced `ttl:"1h"` call, confirming the new field is accepted rather than rejected by a non-official gateway.
- Rebased onto `main-v2` after #7725; focused packages `go test ./internal/agent ./internal/provider/anthropic ./cmd/e2ebench` pass.

## Documentation impact

Documentation-impact: none - no user-facing CLI, Desktop, configuration, provider settings, permission, or tool surface changed; adaptive TTL and diagnostics are host-internal, and the compaction latch fix restores the already-documented auto-compaction behavior without new user steps.

## Cache impact

Cache-impact: medium — Anthropic requests may upgrade `cache_control` to `ttl:"1h"` after idle gaps >= 120s; default 5m path remains byte-identical (`ttl` omitempty). Provider-visible Request structure is unchanged (gap travels only via context). Diagnostics no longer false-positive on local metadata rewrites; rewrite-cause attribution improves cache regression analysis without changing tool schemas or stable prompt prefix content.

Cache-guard: `go test ./internal/agent -run 'TestMaybeCompact|CacheGap|CacheShape|Rewrite'`; `go test ./internal/provider/anthropic -run 'Cache|TTL|cache_control'`; `go test ./cmd/e2ebench -run 'Cache|Report'`; existing byte-exact default `cache_control` marshal test pins the no-idle path.

System-prompt-review: N/A — system prompt, memory prefix, skill index, and tool schema content/order are unchanged.
