### PR TITLE
fix(desktop): keep reused blank sessions on the default provider / 修复复用空白会话选错默认供应商

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -881,6 +881,13 @@ func resolveNewSessionModel(cfg *config.Config) string {
 	def := strings.TrimSpace(cfg.DefaultModel)
 	config.NormalizeLegacyMimoCustomProvidersForRefs(cfg, def)
 	if resolved, _, ok := cfg.ResolveDesktopNewSessionModel(); ok {
+		// Keep provider identity explicit at the new-session boundary. A bare
+		// model id is ambiguous when two configured gateways expose the same
+		// model, and a provider-only ref otherwise compares unequal to the
+		// canonical ref stored on a running tab.
+		if entry, found := cfg.ResolveModel(resolved); found {
+			return entry.Name + "/" + entry.Model
+		}
 		return resolved
 	}
 	return ""

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9942,6 +9942,39 @@ func (a *App) SetModel(name string) error {
 	return a.SetModelForTab("", name)
 }
 
+// persistTabModelIfCurrent repairs stale model metadata without letting an
+// older default overwrite a newer explicit model switch. Model switches use
+// the same runtimeRebuildMu, so whichever operation acquires it last owns the
+// persisted provider identity.
+func (a *App) persistTabModelIfCurrent(tab *WorkspaceTab, model string) error {
+	model = strings.TrimSpace(model)
+	if tab == nil || model == "" {
+		return nil
+	}
+	a.runtimeRebuildMu.Lock()
+	defer a.runtimeRebuildMu.Unlock()
+
+	a.mu.RLock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.RUnlock()
+		return fmt.Errorf("tab %q changed while persisting model; retry", tab.ID)
+	}
+	if tab.Ctrl == nil || strings.TrimSpace(tab.model) != model {
+		a.mu.RUnlock()
+		return nil
+	}
+	a.mu.RUnlock()
+
+	path := a.currentSessionPathFor(tab)
+	if path == "" {
+		return nil
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, model); err != nil {
+		return fmt.Errorf("persist selected model: %w", err)
+	}
+	return nil
+}
+
 type modelSwitchTiming struct {
 	Total          time.Duration
 	LockWait       time.Duration
@@ -10160,6 +10193,17 @@ func (a *App) SetModelForTab(tabID, name string) (retErr error) {
 	// The runtime now reflects the on-disk config; drop any deferred refresh.
 	a.clearDeferredRebuild(tab.ID)
 	a.persistTabSessionPath(tab, path)
+	// Keep the provider identity in the session sidecar inside the same
+	// runtimeRebuildMu transaction as the controller swap. Empty sessions do
+	// not autosave a turn, so without this write a later startup can prefer the
+	// outgoing provider from stale metadata. Serializing it here also preserves
+	// last-click-wins when a new-session default switch overlaps an explicit
+	// model selection.
+	if path != "" {
+		if err := agent.SetBranchModelPreserveUpdated(path, name); err != nil {
+			return fmt.Errorf("persist selected model: %w", err)
+		}
+	}
 	a.notifyTabRuntimeRebuilt(tab)
 	timing.SwapAndPersist = time.Since(stageStarted)
 	return nil

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
@@ -192,6 +194,133 @@ func TestEnsureBlankTabRetargetsReusedSameNameModelToDefaultProvider(t *testing.
 	}
 	if current != defaultRef {
 		t.Fatalf("model switcher current ref = %q, want %q", current, defaultRef)
+	}
+}
+
+func TestEnsureBlankTabRepairsStaleStoredProviderWhenRuntimeAlreadyDefault(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	model, oldRef, defaultRef := configureSameNameModelProviders(t)
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), model)
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := testTab("stale-meta", globalRoot)
+	tab.Scope = "global"
+	tab.WorkspaceRoot = globalRoot
+	tab.SessionPath = path
+	tab.model = oldRef
+	tab.Ctrl.SetSessionPath(path)
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.SetModelForTab(tab.ID, defaultRef); err != nil {
+		t.Fatalf("seed default runtime: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed stale stored model: %v", err)
+	}
+
+	if _, err := app.EnsureBlankTab("global", ""); err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if tab.model != defaultRef || tab.Ctrl.ModelRef() != defaultRef {
+		t.Fatalf("runtime model = tab:%q controller:%q, want %q", tab.model, tab.Ctrl.ModelRef(), defaultRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != defaultRef {
+		t.Fatalf("stored session model = %q, %v, want repaired %q", stored, ok, defaultRef)
+	}
+}
+
+func TestEnsureBlankTabConcurrentModelSwitchKeepsLastSelection(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	model, oldRef, defaultRef := configureSameNameModelProviders(t)
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), model)
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := testTab("last-click", globalRoot)
+	tab.Scope = "global"
+	tab.WorkspaceRoot = globalRoot
+	tab.SessionPath = path
+	tab.model = oldRef
+	tab.Ctrl.SetSessionPath(path)
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	firstSwitchReturned := make(chan struct{})
+	releaseFirstSwitch := make(chan struct{})
+	var switchCount atomic.Int32
+	app.modelSwitchTimingHook = func(modelSwitchTiming) {
+		if switchCount.Add(1) == 1 {
+			close(firstSwitchReturned)
+			<-releaseFirstSwitch
+		}
+	}
+
+	ensureDone := make(chan error, 1)
+	go func() {
+		_, err := app.EnsureBlankTab("global", "")
+		ensureDone <- err
+	}()
+
+	select {
+	case <-firstSwitchReturned:
+	case <-time.After(5 * time.Second):
+		close(releaseFirstSwitch)
+		t.Fatal("timed out waiting for default model switch")
+	}
+
+	// Model selection remains available while EnsureBlankTab is completing.
+	// The explicit second switch is the user's last click and must own both the
+	// live runtime and the persisted provider identity.
+	lastSwitchErr := app.SetModelForTab(tab.ID, oldRef)
+	close(releaseFirstSwitch)
+	if lastSwitchErr != nil {
+		t.Fatalf("last model switch: %v", lastSwitchErr)
+	}
+	select {
+	case err := <-ensureDone:
+		if err != nil {
+			t.Fatalf("EnsureBlankTab: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for EnsureBlankTab")
+	}
+
+	if tab.model != oldRef || tab.Ctrl.ModelRef() != oldRef {
+		t.Fatalf("last selected runtime = tab:%q controller:%q, want %q (default was %q)", tab.model, tab.Ctrl.ModelRef(), oldRef, defaultRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != oldRef {
+		t.Fatalf("stored session model = %q, %v, want last selection %q", stored, ok, oldRef)
 	}
 }
 

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 )
@@ -131,6 +133,135 @@ func TestEnsureBlankTabUsesGlobalSessionDefaultsForModelAndToolApproval(t *testi
 	if !strings.Contains(filepath.Base(created.SessionPath), "deepseek-v4-pro") {
 		t.Fatalf("new session path = %q, want filename seeded by global default model", created.SessionPath)
 	}
+}
+
+func TestEnsureBlankTabRetargetsReusedSameNameModelToDefaultProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	model, oldRef, defaultRef := configureSameNameModelProviders(t)
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), model)
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := testTab("reused", globalRoot)
+	tab.Scope = "global"
+	tab.WorkspaceRoot = globalRoot
+	tab.SessionPath = path
+	tab.model = oldRef
+	tab.Ctrl.SetSessionPath(path)
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.ID != tab.ID {
+		t.Fatalf("reused tab = %q, want %q", meta.ID, tab.ID)
+	}
+	if tab.model != defaultRef || tab.Ctrl.ModelRef() != defaultRef {
+		t.Fatalf("reused runtime model = tab:%q controller:%q, want %q", tab.model, tab.Ctrl.ModelRef(), defaultRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != defaultRef {
+		t.Fatalf("stored session model = %q, %v, want %q", stored, ok, defaultRef)
+	}
+
+	current := ""
+	for _, info := range app.ModelsForTab(tab.ID) {
+		if info.Current {
+			if current != "" {
+				t.Fatalf("multiple current models: %q and %q", current, info.Ref)
+			}
+			current = info.Ref
+		}
+	}
+	if current != defaultRef {
+		t.Fatalf("model switcher current ref = %q, want %q", current, defaultRef)
+	}
+}
+
+func TestEnsureBlankTabRestartsStartingBlankWithDefaultProvider(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	model, oldRef, defaultRef := configureSameNameModelProviders(t)
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), model)
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+
+	cancelled := false
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:            "starting",
+		Scope:         "global",
+		WorkspaceRoot: globalRoot,
+		SessionPath:   path,
+		model:         oldRef,
+		buildCancel:   func() { cancelled = true },
+		disabledMCP:   map[string]ServerView{},
+	}
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	meta, err := app.EnsureBlankTab("global", "")
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.ID != tab.ID || !cancelled {
+		t.Fatalf("starting blank reuse = id:%q cancelled:%v, want %q and cancelled old build", meta.ID, cancelled, tab.ID)
+	}
+	if !tab.Ready || tab.Ctrl == nil || tab.model != defaultRef || tab.Ctrl.ModelRef() != defaultRef {
+		t.Fatalf("restarted blank runtime = ready:%v controller:%v tab:%q, want %q", tab.Ready, tab.Ctrl != nil, tab.model, defaultRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != defaultRef {
+		t.Fatalf("stored session model = %q, %v, want %q", stored, ok, defaultRef)
+	}
+}
+
+func configureSameNameModelProviders(t *testing.T) (model, oldRef, defaultRef string) {
+	t.Helper()
+	seedUserCredentials(t, "DUPLICATE_MODEL_KEY=test-key\n")
+	model = "deepseek-v4-flash-0731"
+	oldRef = "qwen/" + model
+	defaultRef = "token-rhythm/" + model
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.DefaultModel = defaultRef
+	cfg.Desktop.ProviderAccess = []string{"qwen", "token-rhythm"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "qwen", Kind: "openai", BaseURL: "https://qwen.example.invalid/v1", Model: model, APIKeyEnv: "DUPLICATE_MODEL_KEY"},
+		{Name: "token-rhythm", Kind: "openai", BaseURL: "https://token-rhythm.example.invalid/v1", Model: model, APIKeyEnv: "DUPLICATE_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return model, oldRef, defaultRef
 }
 
 func TestDesktopNewSessionDefaultsHonorExplicitAsk(t *testing.T) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2596,6 +2596,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 	defaultModel, defaultToolApprovalMode := desktopNewSessionDefaults(scope, actualRoot)
 
 	a.mu.Lock()
+	var reusable *WorkspaceTab
 	for _, id := range a.orderedTabIDsLocked() {
 		tab := a.tabs[id]
 		if a.blankTabMatchesTargetLocked(tab, scope, workspaceRoot) {
@@ -2603,12 +2604,25 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 				a.mu.Unlock()
 				return TabMeta{}, err
 			}
-			a.activeTabID = tab.ID
-			meta := a.tabMeta(tab, true)
-			a.saveTabsLocked()
-			a.mu.Unlock()
-			return enrichTabMeta(meta), nil
+			reusable = tab
+			break
 		}
+	}
+	if reusable != nil {
+		a.mu.Unlock()
+		if err := a.alignReusableBlankTabModel(reusable, defaultModel); err != nil {
+			return TabMeta{}, err
+		}
+		a.mu.Lock()
+		if reusable.removed || a.tabs[reusable.ID] != reusable {
+			a.mu.Unlock()
+			return TabMeta{}, fmt.Errorf("blank session changed while applying the default model; retry")
+		}
+		a.activeTabID = reusable.ID
+		meta := a.tabMeta(reusable, true)
+		a.saveTabsLocked()
+		a.mu.Unlock()
+		return enrichTabMeta(meta), nil
 	}
 
 	// New blank sessions start from global session defaults for model and
@@ -2741,6 +2755,83 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 	a.startTabControllerBuild(created)
 	a.emitProjectTreeChangedForSessionDirs(sessionListCacheDirForPath(prePath))
 	return enrichTabMeta(meta), nil
+}
+
+// alignReusableBlankTabModel makes a reused empty session obey the same
+// provider/model default as a newly-created session. Ready runtimes use the
+// normal failure-atomic model switch. A tab that is still starting has no
+// controller to swap, so invalidate its startup generation, update the empty
+// session's model metadata, and restart the build from the intended provider.
+func (a *App) alignReusableBlankTabModel(tab *WorkspaceTab, model string) error {
+	model = strings.TrimSpace(model)
+	if tab == nil || model == "" {
+		return nil
+	}
+
+	a.mu.RLock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.RUnlock()
+		return fmt.Errorf("blank session changed while applying the default model; retry")
+	}
+	currentModel := strings.TrimSpace(tab.model)
+	ctrl := tab.Ctrl
+	path := strings.TrimSpace(tab.SessionPath)
+	a.mu.RUnlock()
+
+	storedModel, hasStoredModel := agent.LoadSessionModel(path)
+	storedModelChanged := path != "" && (!hasStoredModel || strings.TrimSpace(storedModel) != model)
+
+	if ctrl != nil {
+		if currentModel != model {
+			if err := a.SetModelForTab(tab.ID, model); err != nil {
+				return err
+			}
+		}
+		// SetModelForTab carries an empty transcript without taking a turn, so
+		// persist the new model identity explicitly instead of waiting for the
+		// first autosave to refresh the branch metadata.
+		if currentPath := a.currentSessionPathFor(tab); currentPath != "" {
+			if err := agent.SetBranchModelPreserveUpdated(currentPath, model); err != nil {
+				return fmt.Errorf("persist default model for blank session: %w", err)
+			}
+		}
+		return nil
+	}
+
+	if currentModel == model && !storedModelChanged {
+		return nil
+	}
+	if storedModelChanged {
+		// With no published controller there is nothing to swap atomically. Fix
+		// the empty session metadata first so the replacement startup cannot
+		// prefer the outgoing provider over the corrected tab model.
+		if err := agent.SetBranchModelPreserveUpdated(path, model); err != nil {
+			return fmt.Errorf("persist default model for blank session: %w", err)
+		}
+	}
+
+	// A startup build may already have read the old sidecar model. Fence and
+	// cancel that generation before publishing the corrected tab model, then
+	// start a replacement build. The generation check prevents the cancelled
+	// build from overwriting the replacement if it completes late.
+	a.mu.Lock()
+	if tab.removed || a.tabs[tab.ID] != tab {
+		a.mu.Unlock()
+		return fmt.Errorf("blank session changed while applying the default model; retry")
+	}
+	if tab.Ctrl != nil {
+		a.mu.Unlock()
+		return a.alignReusableBlankTabModel(tab, model)
+	}
+	a.supersedeTabBuildLocked(tab)
+	tab.model = model
+	tab.Label = model
+	tab.Ready = false
+	clearTabStartupError(tab)
+	a.saveTabsLocked()
+	a.mu.Unlock()
+	a.startTabControllerBuild(tab)
+	return nil
 }
 
 // blankTabMatchesTargetLocked returns true if tab is a reusable blank tab

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2786,14 +2786,8 @@ func (a *App) alignReusableBlankTabModel(tab *WorkspaceTab, model string) error 
 			if err := a.SetModelForTab(tab.ID, model); err != nil {
 				return err
 			}
-		}
-		// SetModelForTab carries an empty transcript without taking a turn, so
-		// persist the new model identity explicitly instead of waiting for the
-		// first autosave to refresh the branch metadata.
-		if currentPath := a.currentSessionPathFor(tab); currentPath != "" {
-			if err := agent.SetBranchModelPreserveUpdated(currentPath, model); err != nil {
-				return fmt.Errorf("persist default model for blank session: %w", err)
-			}
+		} else if storedModelChanged {
+			return a.persistTabModelIfCurrent(tab, model)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Canonicalize desktop new-session model references as explicit `provider/model` values.
- Realign reused blank tabs with the current default through the existing failure-atomic model switch.
- Cancel and restart an in-progress blank-session startup when its stale provider differs from the default.
- Add regressions for duplicate model IDs exposed by Qwen and Token Rhythm.

## Issues

When multiple providers expose `deepseek-v4-flash-0731`, creating a new session can reuse an empty tab whose persisted model still belongs to Qwen, even though Token Rhythm is the configured default.

The root cause was an early return in `EnsureBlankTab`: reused blank tabs never applied `desktopNewSessionDefaults`, so stale tab/session metadata could win over the selected default provider.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go test -race . -run 'TestEnsureBlankTab(RetargetsReusedSameNameModelToDefaultProvider|RestartsStartingBlankWithDefaultProvider|UsesGlobalSessionDefaultsForModelAndToolApproval|ReusesExistingBlankTab|ReusesPrecreatedBlankBeforeControllerReady)' -count=1`
- `cd desktop && go vet ./...`
- `git diff --check`

## Documentation impact

Documentation-impact: none - this restores the documented/default model-selection behavior and adds no user-facing option or workflow.

## Cache impact

Cache-impact: none - the change is limited to desktop blank-session selection and does not alter prompts, memory, tools, or provider request serialization.
Cache-guard: duplicate-model regression tests cover ready and starting blank-session reuse; the focused suite also passes under the race detector.
System-prompt-review: N/A
