### PR TITLE
fix(agent): replay interrupted streams atomically / 原子重放中断的模型流

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,7 +1,8 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
-import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSessionCache, contextSourceRows, contextUsageRefreshKey, contextWindowStatus, formatCacheHitRate, formatMetricTokens } from "../components/ContextPanel";
+import { cacheHitTone, contextBreakdown, contextCostDisplay, contextSessionCache, contextSourceRows, contextUsageRefreshKey, contextWindowStatus, formatCacheHitRate, formatMetricTokens, liveTurnUsageBreakdown } from "../components/ContextPanel";
 import { currencySymbol, formatMoney, formatMoneyLocalized } from "../lib/money";
+import type { WireUsage } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -75,6 +76,76 @@ eq(
   "oversized provider breakdown is normalized to used context tokens",
 );
 eq(Math.round(oversized.otherPct * 10) / 10, 6.1, "oversized provider breakdown does not fill the ring");
+
+// Multi-attempt stream recovery: billable aggregates vs latest Context* shape.
+// Ring uses used=30002; panel breakdown must not show 60000/5 from aggregates.
+const multiAttemptUsage = {
+  promptTokens: 60_000,
+  completionTokens: 5,
+  totalTokens: 60_005,
+  cacheHitTokens: 0,
+  cacheMissTokens: 60_000,
+  reasoningTokens: 3,
+  sessionCacheHitTokens: 0,
+  sessionCacheMissTokens: 0,
+  contextPromptTokens: 30_000,
+  contextCompletionTokens: 2,
+  contextReasoningTokens: 1,
+} as WireUsage;
+const multiAttemptTurn = liveTurnUsageBreakdown(multiAttemptUsage, {
+  promptTokens: 30_000,
+  completionTokens: 2,
+  reasoningTokens: 1,
+});
+eq(
+  multiAttemptTurn,
+  { promptTokens: 30_000, completionTokens: 2, reasoningTokens: 1 },
+  "live turn breakdown prefers Context* over billable aggregates",
+);
+const multiAttemptRing = contextBreakdown(
+  30_002,
+  200_000,
+  multiAttemptTurn.promptTokens,
+  multiAttemptTurn.completionTokens,
+  multiAttemptTurn.reasoningTokens,
+);
+eq(
+  {
+    promptTokens: multiAttemptRing.promptTokens,
+    completionTokens: multiAttemptRing.completionTokens,
+    reasoningTokens: multiAttemptRing.reasoningTokens,
+  },
+  { promptTokens: 30_000, completionTokens: 1, reasoningTokens: 1 },
+  "2×30K recovery: panel segments match latest attempt, not 60000/5",
+);
+const legacyLive = liveTurnUsageBreakdown(
+  {
+    promptTokens: 100,
+    completionTokens: 20,
+    totalTokens: 120,
+    cacheHitTokens: 0,
+    cacheMissTokens: 100,
+    reasoningTokens: 8,
+    sessionCacheHitTokens: 0,
+    sessionCacheMissTokens: 0,
+  } as WireUsage,
+  null,
+);
+eq(
+  legacyLive,
+  { promptTokens: 100, completionTokens: 20, reasoningTokens: 8 },
+  "legacy usage without Context* falls back to billable fields",
+);
+const rebindFallback = liveTurnUsageBreakdown(null, {
+  promptTokens: 30_000,
+  completionTokens: 2,
+  reasoningTokens: 1,
+});
+eq(
+  rebindFallback,
+  { promptTokens: 30_000, completionTokens: 2, reasoningTokens: 1 },
+  "without live usage, panel uses backend rebind snapshot",
+);
 
 const unknownWindow = contextBreakdown(42_124, 0, 22_134, 12_345, 7_521);
 eq(

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -106,6 +106,48 @@ function ev(s: typeof initialState, e: WireEvent) {
   eq(only?.kind === "tool" ? only.id : "", "c1", "surviving card carries the real call ID");
 }
 
+// --- 1c. stream_attempt discard rolls back partial tool cards and text ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-1", action: "begin", attempt: 1, max: 6 } } as WireEvent);
+  s = ev(s, { kind: "text", text: "partial half" } as WireEvent);
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c1", name: "edit_file", readOnly: false, partial: true, argChars: 6000, attemptId: "sa-1" } } as WireEvent);
+  // Concurrent background sub-agent tool must not be journaled.
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "child-1", name: "read_file", readOnly: true, partial: true, parentId: "task-1", attemptId: "sa-1" } } as WireEvent);
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "c1").length, 1, "partial edit_file card appears during attempt");
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "child-1").length, 1, "sub-agent partial is still shown");
+  eq(s.live?.text, "partial half", "partial text is live during attempt");
+  eq(s.turnArgChars, 6000, "arg progress tracked during attempt");
+
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-1", action: "discard", attempt: 1, max: 6, reason: "premature_eof" } } as WireEvent);
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "c1").length, 0, "discard removes uncommitted parent tool card");
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "child-1").length, 1, "discard keeps concurrent sub-agent tool card");
+  eq(s.live?.text ?? "", "", "discard clears attempt text (not concatenate)");
+  eq(s.turnArgChars, 0, "discard restores turnArgChars baseline");
+
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-2", action: "begin", attempt: 2, max: 6 } } as WireEvent);
+  s = ev(s, { kind: "text", text: "full answer" } as WireEvent);
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c2", name: "edit_file", readOnly: false, partial: true, argChars: 12000, attemptId: "sa-2" } } as WireEvent);
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-2", action: "commit", attempt: 2, max: 6 } } as WireEvent);
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c2", name: "edit_file", args: '{"path":"a"}', readOnly: false } } as WireEvent);
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "c2").length, 1, "final success has committed parent tool card");
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "child-1").length, 1, "sub-agent card still present after commit");
+  eq(s.live?.text, "full answer", "final text is the committed attempt only");
+}
+
+// --- 1d. stale discard must not clear a newer attempt journal ---
+{
+  let s = { ...initialState, running: true, turnActive: true };
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-new", action: "begin", attempt: 2, max: 6 } } as WireEvent);
+  s = ev(s, { kind: "tool_dispatch", tool: { id: "c-new", name: "edit_file", readOnly: false, partial: true, attemptId: "sa-new" } } as WireEvent);
+  eq(s.streamAttemptJournal?.id, "sa-new", "journal tracks current attempt");
+  s = ev(s, { kind: "stream_attempt", streamAttempt: { id: "sa-old", action: "discard", attempt: 1, max: 6, reason: "premature_eof" } } as WireEvent);
+  eq(s.streamAttemptJournal?.id, "sa-new", "stale discard leaves current journal");
+  eq(s.items.filter((it) => it.kind === "tool" && it.id === "c-new").length, 1, "stale discard does not remove current partial card");
+  s = ev(s, { kind: "turn_done" } as WireEvent);
+  eq(s.streamAttemptJournal, undefined, "turn_done clears stream attempt journal");
+}
+
 // --- 2. usageSeq bumps for every source ---
 {
   let s = { ...initialState, running: true, turnActive: true };

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -174,6 +174,34 @@ function nonNegativeTokenCount(value: number): number {
   return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
+/** Prefer Context* (latest attempt) over billable aggregates for turn panels. */
+export function liveTurnUsageBreakdown(
+  usage?: WireUsage | null,
+  info?: Pick<ContextPanelInfo, "promptTokens" | "completionTokens" | "reasoningTokens"> | null,
+): { promptTokens: number; completionTokens: number; reasoningTokens: number } {
+  if (usage) {
+    const hasContext =
+      (usage.contextPromptTokens ?? 0) > 0 || (usage.contextCompletionTokens ?? 0) > 0;
+    if (hasContext) {
+      return {
+        promptTokens: usage.contextPromptTokens ?? 0,
+        completionTokens: usage.contextCompletionTokens ?? 0,
+        reasoningTokens: usage.contextReasoningTokens ?? 0,
+      };
+    }
+    return {
+      promptTokens: usage.promptTokens ?? 0,
+      completionTokens: usage.completionTokens ?? 0,
+      reasoningTokens: usage.reasoningTokens ?? 0,
+    };
+  }
+  return {
+    promptTokens: info?.promptTokens ?? 0,
+    completionTokens: info?.completionTokens ?? 0,
+    reasoningTokens: info?.reasoningTokens ?? 0,
+  };
+}
+
 export function contextBreakdown(
   usedTokens: number,
   windowTokens: number,
@@ -363,9 +391,12 @@ export function ContextPanel({
   const usedTokens = context?.used && context.used > 0 ? context.used : info?.usedTokens ?? 0;
   const windowTokens = context?.window && context.window > 0 ? context.window : info?.windowTokens ?? 0;
   // Prefer live usage props (updated in real-time by the reducer during streaming)
-  // over the async-fetched info snapshot (only refreshed on turn_done).
-  const promptTokens = usage?.promptTokens ?? info?.promptTokens ?? 0;
-  const completionTokens = usage?.completionTokens ?? info?.completionTokens ?? 0;
+  // over the async-fetched info snapshot (only refreshed on turn_done). Multi-
+  // attempt stream recovery reports billable aggregates on prompt/completion
+  // and latest-attempt shape on Context* — use the latter for turn breakdown.
+  const turnBreakdown = liveTurnUsageBreakdown(usage, info);
+  const promptTokens = turnBreakdown.promptTokens;
+  const completionTokens = turnBreakdown.completionTokens;
   const totalTokens = info?.totalTokens && info.totalTokens > 0
     ? info.totalTokens
     : sessionTokens && sessionTokens > 0
@@ -373,7 +404,7 @@ export function ContextPanel({
       : usage?.totalTokens && usage.totalTokens > 0
         ? usage.totalTokens
         : promptTokens + completionTokens;
-  const reasoningTokens = usage?.reasoningTokens ?? info?.reasoningTokens ?? 0;
+  const reasoningTokens = turnBreakdown.reasoningTokens;
   // Session-cumulative cache tokens for the top summary: all-sources telemetry
   // first (matching the session cost and per-source rows in this panel — the
   // wire session counters are executor-only), with the live counters bridging

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -24,7 +24,19 @@ export type EventKind =
   | "steer"
   | "guardian_assessment"
   | "extension_surface"
-  | "extension_status";
+  | "extension_status"
+  | "stream_attempt";
+
+export type StreamAttemptAction = "begin" | "discard" | "commit";
+
+export interface WireStreamAttempt {
+  id: string;
+  action: StreamAttemptAction;
+  attempt?: number;
+  max?: number;
+  /** Fixed enum only: connection_reset | premature_eof | idle_timeout */
+  reason?: string;
+}
 
 export interface WireCompaction {
   trigger?: string; // "auto" | "manual"
@@ -53,6 +65,8 @@ export interface WireTool {
   argChars?: number; // partial only: cumulative argument chars streamed so far
   refreshed?: boolean; // same-ID full dispatch with a preview recomputed after an earlier write
   parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
+  /** Host-local stream_attempt id for speculative parent partials only. */
+  attemptId?: string;
   diff?: string;
   added?: number;
   removed?: number;
@@ -85,6 +99,8 @@ export interface WireUsage {
   // hit-rate (Σhit/Σ(hit+miss)), steadier than the single-turn cacheHitTokens.
   sessionCacheHitTokens: number;
   sessionCacheMissTokens: number;
+  /** Latest single-request prompt size for context gauges; omit → use promptTokens. */
+  contextPromptTokens?: number;
   cost?: number;
   currency?: string;
   // Deprecated compatibility alias. Prefer cost + currency.
@@ -264,6 +280,9 @@ export interface WireEvent {
   readiness?: WireFinalReadiness;
   retryAttempt?: number;
   retryMax?: number;
+  /** Optional: "headers" | "stream". Older clients ignore unknown fields. */
+  retryScope?: "headers" | "stream";
+  streamAttempt?: WireStreamAttempt;
   // Tab routing: set by the Go-side tabEventSink so multi-tab frontends
   // route each event to the correct per-tab reducer.
   tabId?: string;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -99,8 +99,12 @@ export interface WireUsage {
   // hit-rate (Σhit/Σ(hit+miss)), steadier than the single-turn cacheHitTokens.
   sessionCacheHitTokens: number;
   sessionCacheMissTokens: number;
-  /** Latest single-request prompt size for context gauges; omit → use promptTokens. */
+  /** Latest single-request shape for context gauges; omit → use billable totals. */
   contextPromptTokens?: number;
+  contextCompletionTokens?: number;
+  contextReasoningTokens?: number;
+  contextCacheHitTokens?: number;
+  contextCacheMissTokens?: number;
   cost?: number;
   currency?: string;
   // Deprecated compatibility alias. Prefer cost + currency.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1524,12 +1524,17 @@ function applyEvent(s: State, e: WireEvent): State {
     case "usage": {
       if (!countsTowardCurrentTurn(s)) return s;
       const updateContextGauge = updatesContextGauge(e.usage);
-      // Prefer contextPromptTokens (latest request) over billable promptTokens
-      // when multi-attempt sampling recovery aggregates input cost.
-      const contextPrompt = e.usage?.contextPromptTokens && e.usage.contextPromptTokens > 0
-        ? e.usage.contextPromptTokens
-        : e.usage?.promptTokens;
-      const used = e.usage && s.context.window && updateContextGauge ? (contextPrompt ?? s.context.used) : s.context.used;
+      // Prefer Context* (latest attempt) over billable aggregates when multi-
+      // attempt sampling recovery folds several provider calls into one Usage.
+      // Matches Controller.ContextSnapshot: latest prompt + completion.
+      let used = s.context.used;
+      if (e.usage && s.context.window && updateContextGauge) {
+        const hasContext =
+          (e.usage.contextPromptTokens ?? 0) > 0 || (e.usage.contextCompletionTokens ?? 0) > 0;
+        used = hasContext
+          ? (e.usage.contextPromptTokens ?? 0) + (e.usage.contextCompletionTokens ?? 0)
+          : (e.usage.promptTokens ?? 0) + (e.usage.completionTokens ?? 0);
+      }
       const turnTokens = s.turnTokens + (e.usage?.completionTokens ?? 0);
       const usageTokens = usageTotalTokens(e.usage);
       const turnTotalTokens = s.turnTotalTokens + usageTokens;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -186,6 +186,17 @@ export type LiveStream = {
   reasoningStartedAt?: number;
   reasoningCompletedAt?: number;
 };
+
+/** Speculative journal for one sampling attempt — rolled back on discard. */
+type StreamAttemptJournal = {
+  id: string;
+  baselineLive?: LiveStream;
+  baselineTurnArgChars: number;
+  /** Tool cards created by this attempt (running, no result yet). */
+  createdToolIds: string[];
+  /** Prior state of tools that existed before this attempt and were patched. */
+  priorTools: Record<string, Extract<Item, { kind: "tool" }>>;
+};
 export type ControllerLiveStore = {
   subscribe: (tabId: string | undefined, listener: () => void) => () => void;
   getSnapshot: (tabId: string | undefined) => LiveStream | undefined;
@@ -413,6 +424,9 @@ interface State {
   // Last accepted generation per extension surface key; guards against
   // re-ordered publications (acceptsExtensionGeneration).
   extensionGenerations: Record<string, number>;
+  // Speculative sampling-attempt journal for Codex-style stream replay.
+  // Host-local only; never hydrated from history.
+  streamAttemptJournal?: StreamAttemptJournal;
 }
 
 export const initialState: State = {
@@ -1119,6 +1133,122 @@ function applyExtensionForm(s: State, surface: WireExtensionSurface): State {
   };
 }
 
+function applyStreamAttempt(s: State, e: WireEvent): State {
+  const sa = e.streamAttempt;
+  if (!sa?.id || !sa.action) return s;
+  switch (sa.action) {
+    case "begin": {
+      // Snapshot only what this attempt may mutate: live text/reasoning and
+      // turnArgChars. Concurrent non-sampling events remain outside the journal.
+      const baselineLive = s.live
+        ? {
+            id: s.live.id,
+            text: s.live.text,
+            reasoning: s.live.reasoning,
+            reasoningComplete: s.live.reasoningComplete,
+            reasoningStartedAt: s.live.reasoningStartedAt,
+            reasoningCompletedAt: s.live.reasoningCompletedAt,
+          }
+        : undefined;
+      return {
+        ...s,
+        running: true,
+        turnActive: true,
+        cancellable: true,
+        turnStartAt: s.turnStartAt || Date.now(),
+        streamAttemptJournal: {
+          id: sa.id,
+          baselineLive,
+          baselineTurnArgChars: s.turnArgChars,
+          createdToolIds: [],
+          priorTools: {},
+        },
+      };
+    }
+    case "discard": {
+      const journal = s.streamAttemptJournal;
+      if (!journal || journal.id !== sa.id) {
+        // Stale/out-of-order discard for an older attempt — leave the current
+        // journal (and live speculative UI) untouched.
+        return s;
+      }
+      const remove = new Set(journal.createdToolIds);
+      const items = s.items
+        .filter((it) => !(it.kind === "tool" && remove.has(it.id)))
+        .map((it) => {
+          if (it.kind !== "tool") return it;
+          const prior = journal.priorTools[it.id];
+          return prior ? { ...prior } : it;
+        });
+      // Restore live to the pre-attempt snapshot so partial text/reasoning is
+      // replaced, not concatenated with the next attempt.
+      const live = journal.baselineLive
+        ? { ...journal.baselineLive }
+        : s.live
+          ? { ...s.live, text: "", reasoning: "", reasoningComplete: false, reasoningStartedAt: undefined, reasoningCompletedAt: undefined }
+          : undefined;
+      return {
+        ...s,
+        items,
+        live,
+        turnArgChars: journal.baselineTurnArgChars,
+        streamAttemptJournal: undefined,
+        running: true,
+        turnActive: true,
+        cancellable: true,
+      };
+    }
+    case "commit": {
+      // Commit clears bookkeeping only; subsequent tool_dispatch/result are real.
+      if (s.streamAttemptJournal && s.streamAttemptJournal.id !== sa.id) {
+        return s;
+      }
+      return { ...s, streamAttemptJournal: undefined };
+    }
+    default:
+      return s;
+  }
+}
+
+/** Record a tool card mutation against the active sampling-attempt journal.
+ * Only parent-sampling partials with a matching attemptId are journaled —
+ * background sub-agent tools (parentId) and committed full dispatches are not.
+ */
+function noteToolInJournal(
+  s: State,
+  toolId: string,
+  existedBefore: boolean,
+  prior: Extract<Item, { kind: "tool" }> | undefined,
+  meta?: { attemptId?: string; parentId?: string; partial?: boolean },
+): State {
+  const journal = s.streamAttemptJournal;
+  if (!journal || !toolId) return s;
+  // Require explicit attempt membership — do not journal by arrival time alone.
+  if (!meta?.attemptId || meta.attemptId !== journal.id) return s;
+  if (meta.parentId) return s;
+  if (meta.partial === false) return s;
+  if (!existedBefore) {
+    if (journal.createdToolIds.includes(toolId)) return s;
+    return {
+      ...s,
+      streamAttemptJournal: {
+        ...journal,
+        createdToolIds: [...journal.createdToolIds, toolId],
+      },
+    };
+  }
+  if (prior && !journal.priorTools[toolId] && !journal.createdToolIds.includes(toolId)) {
+    return {
+      ...s,
+      streamAttemptJournal: {
+        ...journal,
+        priorTools: { ...journal.priorTools, [toolId]: { ...prior } },
+      },
+    };
+  }
+  return s;
+}
+
 function applyExtensionNotification(s: State, surface: WireExtensionSurface): State {
   const notification = surface.notification;
   if (!notification) return s;
@@ -1169,6 +1299,9 @@ function applyEvent(s: State, e: WireEvent): State {
       cancellable: true,
       turnStartAt: s.turnStartAt || Date.now(),
     };
+  }
+  if (e.kind === "stream_attempt") {
+    return applyStreamAttempt(s, e);
   }
   if (s.retry) s = { ...s, retry: undefined };
   switch (e.kind) {
@@ -1272,17 +1405,20 @@ function applyEvent(s: State, e: WireEvent): State {
           const next = [...s.items];
           const it = next[idx];
           if (it.kind === "tool" && it.status === "running" && !it.args) {
+            const prior = it;
             next[idx] = { ...it, argChars: t.argChars || it.argChars };
-            return { ...s, items: next, turnArgChars };
+            return noteToolInJournal({ ...s, items: next, turnArgChars }, id, true, prior, {
+              attemptId: t.attemptId, parentId: t.parentId, partial: true,
+            });
           }
           return { ...s, turnArgChars };
         }
-        return {
+        return noteToolInJournal({
           ...s,
           turnArgChars,
           seq: s.seq + 1,
           items: [...s.items, { kind: "tool", id, name: t.name, args: "", readOnly: t.readOnly, resolvedName: t.resolvedName, capabilityId: t.capabilityId, status: "running", argChars: t.argChars || undefined, parentId: t.parentId, subagentProgress: SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined }],
-        };
+        }, id, false, undefined, { attemptId: t.attemptId, parentId: t.parentId, partial: true });
       }
       const id = t.id || `tool${s.seq}`;
       const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === id);
@@ -1296,6 +1432,7 @@ function applyEvent(s: State, e: WireEvent): State {
           next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, resolvedName: t.resolvedName ?? it.resolvedName, capabilityId: t.capabilityId ?? it.capabilityId, profile: t.profile ?? it.profile, summary, fileDiff, argChars: undefined, subagentProgress: it.subagentProgress ?? (SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined) };
         }
         if (t.parentId) touchSubagentParent(next, t.parentId);
+        // Full dispatches are committed work — never journal them as speculative.
         return { ...s, items: next };
       }
       const args = t.args ?? "";
@@ -1387,7 +1524,12 @@ function applyEvent(s: State, e: WireEvent): State {
     case "usage": {
       if (!countsTowardCurrentTurn(s)) return s;
       const updateContextGauge = updatesContextGauge(e.usage);
-      const used = e.usage && s.context.window && updateContextGauge ? e.usage.promptTokens : s.context.used;
+      // Prefer contextPromptTokens (latest request) over billable promptTokens
+      // when multi-attempt sampling recovery aggregates input cost.
+      const contextPrompt = e.usage?.contextPromptTokens && e.usage.contextPromptTokens > 0
+        ? e.usage.contextPromptTokens
+        : e.usage?.promptTokens;
+      const used = e.usage && s.context.window && updateContextGauge ? (contextPrompt ?? s.context.used) : s.context.used;
       const turnTokens = s.turnTokens + (e.usage?.completionTokens ?? 0);
       const usageTokens = usageTotalTokens(e.usage);
       const turnTotalTokens = s.turnTotalTokens + usageTokens;
@@ -1537,6 +1679,7 @@ function applyEvent(s: State, e: WireEvent): State {
         ...s,
         items,
         live: undefined,
+        streamAttemptJournal: undefined,
         running: keepPlanApproval,
         turnActive: keepPlanApproval,
         pendingPrompt: keepPlanApproval,

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -930,6 +930,25 @@ func (t *WorkspaceTab) recordTurnDone(now int64) {
 	t.telemMu.Unlock()
 }
 
+// contextTelemetryFromUsage returns the latest-attempt context shape for
+// rebind-surviving Last* telemetry fields. Prefer Context* when set (multi-
+// attempt sampling recovery); otherwise fall back to billable totals / the
+// per-event cache delta already computed for this Usage event.
+//
+// When a Context shape is present, ContextCacheHit/Miss are kept even if both
+// are zero — many providers omit cache splits, and falling back to the
+// event's aggregated cache would re-inflate multi-attempt totals.
+func contextTelemetryFromUsage(u *provider.Usage, eventCacheHit, eventCacheMiss int) (prompt, completion, reasoning, hit, miss int) {
+	if u == nil {
+		return 0, 0, 0, eventCacheHit, eventCacheMiss
+	}
+	if u.ContextPromptTokens > 0 || u.ContextCompletionTokens > 0 {
+		return u.ContextPromptTokens, u.ContextCompletionTokens, u.ContextReasoningTokens,
+			u.ContextCacheHitTokens, u.ContextCacheMissTokens
+	}
+	return u.PromptTokens, u.CompletionTokens, u.ReasoningTokens, eventCacheHit, eventCacheMiss
+}
+
 func (t *WorkspaceTab) recordUsage(e event.Event) {
 	if e.Usage == nil {
 		return
@@ -954,12 +973,17 @@ func (t *WorkspaceTab) recordUsage(e event.Event) {
 	}
 	t.usageTelemetry.RequestCount += requestCount
 	if source == event.UsageSourceExecutor {
-		t.usageTelemetry.LastUsedTokens = u.PromptTokens + u.CompletionTokens
-		t.usageTelemetry.LastPromptTokens = u.PromptTokens
-		t.usageTelemetry.LastCompletionTokens = u.CompletionTokens
-		t.usageTelemetry.LastReasoningTokens = u.ReasoningTokens
-		t.usageTelemetry.LastCacheHitTokens = cacheHitTokens
-		t.usageTelemetry.LastCacheMissTokens = cacheMissTokens
+		// Persist the latest-attempt context shape for rebind fallback — never
+		// the multi-attempt billable aggregate (PromptTokens/CompletionTokens
+		// after stream recovery). ContextSnapshot semantics are latest
+		// prompt+completion; Context* fields carry that shape.
+		prompt, completion, reasoning, hit, miss := contextTelemetryFromUsage(u, cacheHitTokens, cacheMissTokens)
+		t.usageTelemetry.LastUsedTokens = prompt + completion
+		t.usageTelemetry.LastPromptTokens = prompt
+		t.usageTelemetry.LastCompletionTokens = completion
+		t.usageTelemetry.LastReasoningTokens = reasoning
+		t.usageTelemetry.LastCacheHitTokens = hit
+		t.usageTelemetry.LastCacheMissTokens = miss
 		t.usageTelemetry.LastEstimated = u.Estimated
 	}
 	if t.usageTelemetry.Sources == nil {

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -361,6 +361,96 @@ func TestContextFallbackUsesPersistedExecutorUsageAfterRebind(t *testing.T) {
 	}
 }
 
+// TestContextFallbackUsesLatestAttemptAfterMultiAttemptUsage locks the stream-
+// recovery telemetry contract: billable Prompt/Completion may be 2×30K, but
+// Last* fields (and rebind fallback) must use Context* from the latest attempt.
+func TestContextFallbackUsesLatestAttemptAfterMultiAttemptUsage(t *testing.T) {
+	ag := agent.New(
+		usageProvider{usage: nil},
+		tool.NewRegistry(),
+		agent.NewSession("system"),
+		agent.Options{ContextWindow: 200_000},
+		event.Discard,
+	)
+	tab := &WorkspaceTab{
+		ID:    "tab",
+		Ctrl:  control.New(control.Options{Executor: ag, Sink: event.Discard}),
+		Scope: "global",
+		Ready: true,
+	}
+	// Two 30K prompt attempts: billable sum 60K+5, latest context 30K+2.
+	tab.recordUsage(event.Event{
+		Usage: &provider.Usage{
+			PromptTokens:            60_000,
+			CompletionTokens:        5,
+			TotalTokens:             60_005,
+			CacheMissTokens:         60_000,
+			ContextPromptTokens:     30_000,
+			ContextCompletionTokens: 2,
+			ContextReasoningTokens:  1,
+			ContextCacheMissTokens:  30_000,
+		},
+		UsageSource: event.UsageSourceExecutor,
+	})
+	got := tab.telemetrySnapshot().Usage
+	if got.LastUsedTokens != 30_002 ||
+		got.LastPromptTokens != 30_000 ||
+		got.LastCompletionTokens != 2 ||
+		got.LastReasoningTokens != 1 ||
+		got.LastCacheMissTokens != 30_000 {
+		t.Fatalf("last context from multi-attempt usage = %+v, want latest 30000+2", got)
+	}
+	// Session billable totals still accumulate the full aggregate.
+	if got.PromptTokens != 60_000 || got.CompletionTokens != 5 {
+		t.Fatalf("session billable totals = prompt %d completion %d, want 60000/5", got.PromptTokens, got.CompletionTokens)
+	}
+
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+	context := app.ContextUsageForTab("tab")
+	if context.Used != 30_002 {
+		t.Fatalf("rebind context Used = %d, want latest fill 30002 (not billable 60005)", context.Used)
+	}
+	panel := app.ContextPanel("tab")
+	if panel.UsedTokens != 30_002 ||
+		panel.PromptTokens != 30_000 ||
+		panel.CompletionTokens != 2 ||
+		panel.ReasoningTokens != 1 ||
+		panel.CacheMissTokens != 30_000 {
+		t.Fatalf("rebind context panel = %+v, want latest-attempt breakdown", panel)
+	}
+}
+
+// Providers that omit cache split report ContextCache 0/0 with a valid Context
+// prompt/completion shape. Last* cache must stay 0/0 — not fall back to the
+// multi-attempt billable cache aggregate.
+func TestContextTelemetryKeepsZeroCacheWhenContextShapePresent(t *testing.T) {
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true}
+	tab.recordUsage(event.Event{
+		Usage: &provider.Usage{
+			PromptTokens:            60_000,
+			CompletionTokens:        5,
+			TotalTokens:             60_005,
+			CacheMissTokens:         60_000, // billable aggregate from retries
+			ContextPromptTokens:     30_000,
+			ContextCompletionTokens: 2,
+			// ContextCache* intentionally zero: provider did not report a split.
+		},
+		UsageSource: event.UsageSourceExecutor,
+		SessionHit:  0,
+		SessionMiss: 60_000,
+	})
+	got := tab.telemetrySnapshot().Usage
+	if got.LastPromptTokens != 30_000 || got.LastCompletionTokens != 2 {
+		t.Fatalf("last context tokens = prompt %d completion %d, want 30000/2", got.LastPromptTokens, got.LastCompletionTokens)
+	}
+	if got.LastCacheHitTokens != 0 || got.LastCacheMissTokens != 0 {
+		t.Fatalf("last cache = hit %d miss %d, want 0/0 (unreported), not aggregate 60000", got.LastCacheHitTokens, got.LastCacheMissTokens)
+	}
+	if got.LastUsedTokens != 30_002 {
+		t.Fatalf("LastUsedTokens = %d, want 30002", got.LastUsedTokens)
+	}
+}
+
 func TestContextPanelUsesLastUsageBreakdownWithTelemetryTotal(t *testing.T) {
 	lastUsage := &provider.Usage{
 		PromptTokens:     10,

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -61,8 +61,13 @@ type updateSink struct {
 	// reasonix.extensionSurface support: structured surfaces go out as vendor
 	// session/update payloads on top of the always-sent text fallback.
 	extensionSurface bool
-	mu               sync.Mutex
-	turnCtx          context.Context
+	// speculativeToolIDs tracks parent-sampling tool IDs published under the
+	// active stream_attempt (attempt-scoped partials only). Guarded by mu —
+	// parent sampling and background sub-agents may Emit concurrently.
+	speculativeToolIDs map[string]struct{}
+	activeAttemptID    string
+	mu                 sync.Mutex
+	turnCtx            context.Context
 }
 
 func newUpdateSink(conn notifier, sessionID string) *updateSink {
@@ -137,12 +142,30 @@ func (s *updateSink) Emit(e event.Event) {
 		}
 		s.send(messageChunk{SessionUpdate: "agent_message_chunk", Content: textBlock(e.Text)})
 
+	case event.StreamAttempt:
+		// Attempt bookkeeping only. ACP still skips partial ToolDispatch (no
+		// pending card until full args arrive after commit), so discard must not
+		// invent failures for unpublished IDs. Full dispatches and parentId
+		// nested tools are real work and are never speculative.
+		s.mu.Lock()
+		switch e.StreamAttempt.Action {
+		case event.StreamAttemptBegin:
+			s.activeAttemptID = e.StreamAttempt.ID
+			s.speculativeToolIDs = nil
+		case event.StreamAttemptCommit, event.StreamAttemptDiscard:
+			s.activeAttemptID = ""
+			s.speculativeToolIDs = nil
+		}
+		s.mu.Unlock()
+
 	case event.ToolDispatch:
 		// Skip the early (Partial) dispatch and later same-ID preview refresh: ACP
 		// expects one pending tool_call and has no file-diff update payload.
 		if e.Tool.Partial || e.Tool.Refreshed {
 			return
 		}
+		// Full dispatches only arrive after a committed sampling attempt (or from
+		// nested sub-agents). Never mark them speculative.
 		// todo_write is the agent's task list; mirror it as an ACP plan update so
 		// the client renders structured progress alongside the tool_call.
 		if e.Tool.Name == "todo_write" {
@@ -166,6 +189,11 @@ func (s *updateSink) Emit(e event.Event) {
 		if e.Tool.Err != "" {
 			status = "failed"
 			text = e.Tool.Err
+		}
+		if e.Tool.ID != "" {
+			s.mu.Lock()
+			delete(s.speculativeToolIDs, e.Tool.ID)
+			s.mu.Unlock()
 		}
 		s.send(toolCallUpdateMsg{
 			SessionUpdate: "tool_call_update",

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -40,7 +40,11 @@ import (
 const maxToolOutputBytes = 32 * 1024
 
 const maxEmptyFinalBlocks = 3
-const maxStreamRecoveries = 3
+
+// maxStreamRecoveries is the number of body-phase stream retries after the
+// initial sampling attempt (Codex-aligned default: 1 + 5 = 6 attempts total).
+const maxStreamRecoveries = 5
+const maxSamplingAttempts = maxStreamRecoveries + 1
 const maxExecutorHandoffNudges = 1
 
 const defaultReasoningByteLimit = 128 * 1024
@@ -283,12 +287,10 @@ type Agent struct {
 	lastUsage atomic.Pointer[provider.Usage]
 
 	// lastRequestSentAt is the wall-clock moment (unix millis) the most recent
-	// provider request was sent. stream() reads-and-resets it via Swap each time
-	// it builds the next request, so it can tell the provider how long the gap
-	// since the previous request was (adaptive prompt-cache TTL, e.g. Anthropic's
-	// 1h vs default 5m ephemeral breakpoint). Zero means no request sent yet — a
-	// fresh process or sub-agent naturally starts here and gets the provider's
-	// cheaper default TTL.
+	// provider attempt was sent. Each attempt updates it, while all attempts in
+	// one frozen sampling round reuse the first attempt's gap hint so adaptive
+	// cache TTL cannot change the provider-visible replay body. Zero means no
+	// request sent yet — a fresh process or sub-agent gets the cheaper default TTL.
 	lastRequestSentAt atomic.Int64
 
 	// sessCacheHit/sessCacheMiss accumulate cache tokens across every API call
@@ -2870,33 +2872,20 @@ func toolBudgetNoticeText() string {
 	return "Tool round limit reached; asking the assistant to summarize progress."
 }
 
-func streamRecoveryMessage(hasPartialText, hadPartialTool bool) string {
-	switch {
-	case hadPartialTool:
-		return "The previous assistant response was interrupted while a tool call was streaming. Continue the same task now. If a tool is still needed, issue a fresh complete tool call from scratch; do not rely on any partial tool-call arguments from the interrupted stream."
-	case hasPartialText:
-		return "The previous assistant response was interrupted during streaming. Continue the same task now. Partial text remains visible to the user but was excluded from model context; avoid needlessly repeating it, and do not assume it was complete."
-	default:
-		return "The previous assistant response was interrupted during streaming before visible answer text was completed. Continue the same task now and provide the next useful response."
-	}
+// samplingRequest is a once-prepared, frozen provider request for one model
+// round. All stream retries replay this exact payload — no synthetic recovery
+// messages, no schema reorder, no previous_response_id drift from failed attempts.
+type samplingRequest struct {
+	req             provider.Request
+	cacheGap        time.Duration
+	cacheGapKnown   bool
+	cacheGapPresent bool
 }
 
-// stream runs one completion, emitting reasoning and text deltas as typed
-// events and collecting complete tool calls. A Message event closes the text
-// stream so a sink can re-render the streamed raw text as styled markdown. The
-// accumulated text and reasoning are also returned so the caller can round-trip
-// reasoning on the next turn.
-func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, string, string, string, string, []provider.ToolCall, []json.RawMessage, *provider.Usage, bool, bool, []provider.ToolCall, error) {
-	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
-		sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max})
-	})
-	ctx = provider.WithRequestAttemptCounter(ctx)
-	// A stream can terminate locally before the provider channel closes (for
-	// example when the client-side reasoning guard fires). Own a child context
-	// here so every return path aborts the HTTP request and releases the provider
-	// reader instead of leaving generation and billing running in the background.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+// prepareSamplingRequest runs interceptors and schema fetch once per model
+// round. Callers deep-copy via freezeProviderRequest before each Stream so
+// providers cannot mutate the shared freeze across retries.
+func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, error) {
 	// CreatedAt is durable UI metadata, not model input. Strip it from the
 	// transport copy so wall-clock differences never invalidate the provider's
 	// prompt-cache prefix (and custom providers cannot accidentally send it).
@@ -2910,7 +2899,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 	// the prompt-cache prefix stays intact across turns.
 	requestMessages, err := a.interceptContextPrepare(ctx, requestMessages)
 	if err != nil {
-		return "", "", "", "", "", nil, nil, nil, false, false, nil, err
+		return samplingRequest{}, err
 	}
 	req := provider.Request{
 		Messages:       requestMessages,
@@ -2923,24 +2912,117 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 	// (revalidated by the payload registry) before it goes on the wire.
 	req, err = a.interceptProviderRequest(ctx, req)
 	if err != nil {
-		return "", "", "", "", "", nil, nil, nil, false, false, nil, err
+		return samplingRequest{}, err
 	}
-	// Stamp at send time (not response-received time), so the measured gap is
-	// the true idle time since the previous request went out — not undercounted
-	// by that request's own generation duration. A missing-reasoning recovery
-	// retry (streamWithMissingReasoningRecovery) calls stream() again right
-	// away and correctly measures ~0 gap against its own just-set stamp.
-	// The gap travels via context (WithCacheGapHint) and never enters
-	// provider.Request, so non-Anthropic providers and request equality stay clean.
+	return samplingRequest{req: freezeProviderRequest(req)}, nil
+}
+
+// freezeProviderRequest deep-copies the provider-visible request surface so
+// retries share identical messages, tools order, temperature, and format.
+func freezeProviderRequest(req provider.Request) provider.Request {
+	out := req
+	if len(req.Messages) > 0 {
+		out.Messages = append([]provider.Message(nil), req.Messages...)
+		for i := range out.Messages {
+			if len(out.Messages[i].ToolCalls) > 0 {
+				out.Messages[i].ToolCalls = append([]provider.ToolCall(nil), out.Messages[i].ToolCalls...)
+			}
+			if len(out.Messages[i].Images) > 0 {
+				out.Messages[i].Images = append([]string(nil), out.Messages[i].Images...)
+			}
+			if len(out.Messages[i].ResponsesItems) > 0 {
+				items := make([]json.RawMessage, len(out.Messages[i].ResponsesItems))
+				for j, item := range out.Messages[i].ResponsesItems {
+					items[j] = append(json.RawMessage(nil), item...)
+				}
+				out.Messages[i].ResponsesItems = items
+			}
+		}
+	}
+	if len(req.Tools) > 0 {
+		out.Tools = make([]provider.ToolSchema, len(req.Tools))
+		for i, schema := range req.Tools {
+			out.Tools[i] = schema
+			if len(schema.Parameters) > 0 {
+				out.Tools[i].Parameters = append(json.RawMessage(nil), schema.Parameters...)
+			}
+		}
+	}
+	if req.Temperature != nil {
+		t := *req.Temperature
+		out.Temperature = &t
+	}
+	if req.ResponseFormat != nil {
+		rf := *req.ResponseFormat
+		out.ResponseFormat = &rf
+	}
+	return out
+}
+
+// stream runs one completion, emitting reasoning and text deltas as typed
+// events and collecting complete tool calls. A Message event closes the text
+// stream so a sink can re-render the streamed raw text as styled markdown. The
+// accumulated text and reasoning are also returned so the caller can round-trip
+// reasoning on the next turn.
+//
+// When frozen is non-nil, the request is not rebuilt from session — retries
+// must replay the same provider-visible body.
+func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, string, string, string, string, []provider.ToolCall, []json.RawMessage, *provider.Usage, bool, bool, []provider.ToolCall, int, error) {
+	return a.streamWithFrozen(ctx, turn, sink, nil, "")
+}
+
+func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink, frozen *samplingRequest, attemptID string) (string, string, string, string, string, []provider.ToolCall, []json.RawMessage, *provider.Usage, bool, bool, []provider.ToolCall, int, error) {
+	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
+		sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max, RetryScope: event.RetryScopeHeaders})
+	})
+	// Reuse a parent attempt counter when present so stream retries accumulate
+	// into one RequestCount; otherwise install a fresh counter for this call.
+	ctx = provider.WithRequestAttemptCounter(ctx)
+	// A stream can terminate locally before the provider channel closes (for
+	// example when the client-side reasoning guard fires). Own a child context
+	// here so every return path aborts the HTTP request and releases the provider
+	// reader instead of leaving generation and billing running in the background.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var req provider.Request
+	var err error
+	if frozen != nil {
+		req = freezeProviderRequest(frozen.req)
+	} else {
+		prepared, perr := a.prepareSamplingRequest(ctx)
+		if perr != nil {
+			return "", "", "", "", "", nil, nil, nil, false, false, nil, 0, perr
+		}
+		req = prepared.req
+	}
+	// Stamp every actual attempt at send time, but freeze the first attempt's
+	// cache-gap hint for the entire sampling lifecycle. Anthropic derives an
+	// ephemeral-cache TTL from this context value, so recomputing it on an
+	// immediate retry would change the HTTP body despite an identical Request.
 	sentAt := time.Now()
-	if priorMs := a.lastRequestSentAt.Swap(sentAt.UnixMilli()); priorMs != 0 {
-		ctx = provider.WithCacheGapHint(ctx, sentAt.Sub(time.UnixMilli(priorMs)))
+	priorMs := a.lastRequestSentAt.Swap(sentAt.UnixMilli())
+	if frozen == nil {
+		if priorMs != 0 {
+			ctx = provider.WithCacheGapHint(ctx, sentAt.Sub(time.UnixMilli(priorMs)))
+		}
+	} else {
+		if !frozen.cacheGapKnown {
+			frozen.cacheGapKnown = true
+			if priorMs != 0 {
+				frozen.cacheGap = sentAt.Sub(time.UnixMilli(priorMs))
+				frozen.cacheGapPresent = true
+			}
+		}
+		if frozen.cacheGapPresent {
+			ctx = provider.WithCacheGapHint(ctx, frozen.cacheGap)
+		}
 	}
 	// After #7725 Goal token request admission was removed; stream goes
 	// directly to the provider while still carrying the cache-gap hint.
 	ch, err := a.prov.Stream(ctx, req)
 	if err != nil {
-		return "", "", "", "", "", nil, nil, provider.UsageWithRequestAttemptCount(ctx, nil), false, false, nil, err
+		return "", "", "", "", "", nil, nil, provider.UsageWithRequestAttemptCount(ctx, nil), false, false, nil, 0, err
 	}
 
 	// A PostLLMCall hook rewrites the whole reasoning block, so when one is wired
@@ -2957,6 +3039,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 	var partialCalls []provider.ToolCall
 	var usage *provider.Usage
 	var partialToolStarted bool
+	var maxArgChars int
 	var lastArgProgress time.Time
 	finishReasoning := func() (stored, display string) {
 		original := reasoning.String()
@@ -2981,14 +3064,14 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 			stored, _ := finishReasoning()
 			usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 			usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, ctx.Err()
+			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, ctx.Err()
 		case c, ok := <-ch:
 			if !ok {
 				if err := ctx.Err(); err != nil {
 					stored, _ := finishReasoning()
 					usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 					usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-					return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, err
+					return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, err
 				}
 				stored, display := finishReasoning()
 				// provider.response: extensions rule on the assembled terminal
@@ -2999,7 +3082,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 				finalText, finalReasoning, signature, calls, usage, err := a.interceptProviderResponse(
 					ctx, text.String(), stored, signature, calls, usage)
 				if err != nil {
-					return "", "", "", "", "", nil, nil, nil, false, partialToolStarted, partialCalls, err
+					return "", "", "", "", "", nil, nil, nil, false, partialToolStarted, partialCalls, maxArgChars, err
 				}
 				// Responses reasoning IDs/status and Anthropic signatures are
 				// provider-bound metadata. Never attach the provider's metadata
@@ -3020,7 +3103,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 					})
 				}
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-				return finalText, finalReasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, false, partialCalls, nil
+				return finalText, finalReasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, false, partialCalls, maxArgChars, nil
 			}
 			chunk = c
 		}
@@ -3046,7 +3129,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), finishReasonClientReasoningLimit)
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
 				a.lastUsage.Store(usage)
-				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, errReasoningByteLimitExceeded
+				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, errReasoningByteLimitExceeded
 			}
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)
@@ -3060,7 +3143,7 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 			if tc := chunk.ToolCall; tc != nil {
 				partialCalls = upsertPartialToolCall(partialCalls, *tc)
 				sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
-					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true,
+					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true, AttemptID: attemptID,
 				}})
 			}
 		case provider.ChunkToolCallArgsDelta:
@@ -3069,11 +3152,14 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 			// partial dispatch with the cumulative size (time-throttled) so the
 			// UI can show progress instead of a dead counter for the duration of
 			// a 30KB write_file body.
+			if chunk.ArgChars > maxArgChars {
+				maxArgChars = chunk.ArgChars
+			}
 			if tc := chunk.ToolCall; tc != nil && time.Since(lastArgProgress) >= 250*time.Millisecond {
 				partialCalls = upsertPartialToolCall(partialCalls, *tc)
 				lastArgProgress = time.Now()
 				sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
-					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true, ArgChars: chunk.ArgChars,
+					ID: tc.ID, Name: tc.Name, ReadOnly: a.toolReadOnly(tc.Name), Partial: true, ArgChars: chunk.ArgChars, AttemptID: attemptID,
 				}})
 			}
 		case provider.ChunkToolCall:
@@ -3081,6 +3167,9 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 			if chunk.ToolCall != nil {
 				calls = append(calls, *chunk.ToolCall)
 				partialCalls = upsertPartialToolCall(partialCalls, *chunk.ToolCall)
+				if n := len(chunk.ToolCall.Arguments); n > maxArgChars {
+					maxArgChars = n
+				}
 			}
 		case provider.ChunkResponsesItem:
 			if len(chunk.ResponsesItem) > 0 {
@@ -3096,14 +3185,14 @@ func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, 
 				stored, _ := finishReasoning()
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, true, partialToolStarted, partialCalls, chunk.Err
+				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, true, partialToolStarted, partialCalls, maxArgChars, chunk.Err
 			}
 			stored, _ := finishReasoning()
 			if errors.Is(chunk.Err, context.Canceled) || errors.Is(chunk.Err, context.DeadlineExceeded) {
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 			}
 			usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, chunk.Err
+			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, chunk.Err
 		}
 	}
 }

--- a/internal/agent/cache_gap_hint_test.go
+++ b/internal/agent/cache_gap_hint_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 // gapCaptureProvider records whether/what cache-gap hint arrived on each
-// Stream call, so the test can prove Agent.stream actually threads it through
-// provider.StreamWithRequestBudgetEstimate into Provider.Stream.
+// Stream call, so tests can prove Agent.stream threads it into Provider.Stream
+// and freezes it across body retries.
 type gapCaptureProvider struct {
-	gaps []time.Duration
-	ok   []bool
+	gaps          []time.Duration
+	ok            []bool
+	interruptNext bool
 }
 
 func (p *gapCaptureProvider) Name() string { return "gap-capture" }
@@ -25,10 +26,39 @@ func (p *gapCaptureProvider) Stream(ctx context.Context, _ provider.Request) (<-
 	p.gaps = append(p.gaps, gap)
 	p.ok = append(p.ok, ok)
 	ch := make(chan provider.Chunk, 2)
+	if p.interruptNext {
+		p.interruptNext = false
+		ch <- provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(context.Canceled, provider.StreamInterruptConnectionReset)}
+		close(ch)
+		return ch, nil
+	}
 	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
 	ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 10, CompletionTokens: 1, TotalTokens: 11}}
 	close(ch)
 	return ch, nil
+}
+
+func TestStreamRecoveryFreezesCacheGapHint(t *testing.T) {
+	prov := &gapCaptureProvider{}
+	a := New(prov, tool.NewRegistry(), NewSession("sys"), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "prime"); err != nil {
+		t.Fatalf("prime Run: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	prov.interruptNext = true
+	if err := a.Run(context.Background(), "retry"); err != nil {
+		t.Fatalf("recovered Run: %v", err)
+	}
+
+	if len(prov.gaps) != 3 {
+		t.Fatalf("Stream calls = %d, want prime + failed attempt + retry", len(prov.gaps))
+	}
+	if !prov.ok[1] || !prov.ok[2] || prov.gaps[1] <= 0 {
+		t.Fatalf("retry round hints = ok %v/%v gaps %v/%v", prov.ok[1], prov.ok[2], prov.gaps[1], prov.gaps[2])
+	}
+	if prov.gaps[2] != prov.gaps[1] {
+		t.Fatalf("retry cache gap changed provider-visible TTL input: first=%v retry=%v", prov.gaps[1], prov.gaps[2])
+	}
 }
 
 func TestStreamCarriesCacheGapHintAfterFirstTurn(t *testing.T) {

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -231,7 +231,7 @@ func TestRunCancelledMidStreamLeavesResumableSession(t *testing.T) {
 }
 
 func TestRunRecoversInterruptedStreamAfterPartialText(t *testing.T) {
-	interrupted := &provider.StreamInterruptedError{Err: errors.New("deepseek-flash: read stream: unexpected EOF")}
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("deepseek-flash: read stream: unexpected EOF"), Reason: provider.StreamInterruptPrematureEOF}
 	mp := testutil.NewMock("m",
 		testutil.Turn{Text: "partial ", ChunkError: interrupted},
 		testutil.Turn{Text: "continued"},
@@ -250,35 +250,57 @@ func TestRunRecoversInterruptedStreamAfterPartialText(t *testing.T) {
 	if len(reqs) != 2 {
 		t.Fatalf("recorded requests = %d, want 2", len(reqs))
 	}
-	second := reqs[1].Messages
-	for _, message := range second {
+	// Codex-style: exact original request replay — no synthetic recovery user
+	// message, no partial assistant in the provider body.
+	if !providerRequestBodiesEqual(reqs[0], reqs[1]) {
+		t.Fatalf("retry must replay the identical provider request\nfirst=%+v\nsecond=%+v", reqs[0], reqs[1])
+	}
+	for _, message := range reqs[1].Messages {
 		if message.LocalOnly || message.Content == "partial " {
-			t.Fatalf("partial assistant leaked into provider recovery request: %+v", second)
+			t.Fatalf("partial assistant leaked into provider recovery request: %+v", reqs[1].Messages)
+		}
+		if strings.Contains(message.Content, "interrupted") && message.Role == provider.RoleUser {
+			t.Fatalf("synthetic stream recovery must not be injected: %+v", message)
 		}
 	}
-	if second[len(second)-1].Role != provider.RoleUser || !strings.Contains(second[len(second)-1].Content, "excluded from model context") {
-		t.Fatalf("recovery prompt missing duplicate guard: %+v", second[len(second)-1])
-	}
-	var local provider.Message
+	// Successful recovery never persists a LocalOnly interrupted record.
 	for _, message := range a.Session().Messages {
 		if message.LocalOnly {
-			local = message
+			t.Fatalf("successful recovery must not leave LocalOnly interrupt records: %+v", message)
 		}
-	}
-	if local.Content != "partial " || local.InterruptedTurn == nil || local.InterruptedTurn.Pending {
-		t.Fatalf("partial assistant was not retained as consumed display-only history: %+v", local)
 	}
 
 	var streamed strings.Builder
 	for _, e := range sink.kinds(event.Text) {
 		streamed.WriteString(e.Text)
 	}
-	if streamed.String() != "partial continued" {
-		t.Fatalf("streamed text = %q, want %q", streamed.String(), "partial continued")
+	// Both attempts emit text to the sink; Desktop discards the first via
+	// stream_attempt. Agent still emits both for non-journal sinks.
+	if !strings.Contains(streamed.String(), "continued") {
+		t.Fatalf("streamed text = %q, want final continued answer", streamed.String())
 	}
 	retries := sink.kinds(event.Retrying)
-	if len(retries) != 1 || retries[0].RetryAttempt != 1 || retries[0].RetryMax != maxStreamRecoveries {
+	if len(retries) != 1 || retries[0].RetryAttempt != 1 || retries[0].RetryMax != maxStreamRecoveries || retries[0].RetryScope != event.RetryScopeStream {
 		t.Fatalf("retry events = %+v, want one stream recovery retry", retries)
+	}
+	attempts := sink.kinds(event.StreamAttempt)
+	if len(attempts) < 3 {
+		t.Fatalf("stream_attempt events = %d, want begin/discard/begin/commit at least", len(attempts))
+	}
+	var sawDiscard, sawCommit bool
+	for _, e := range attempts {
+		if e.StreamAttempt.Action == event.StreamAttemptDiscard {
+			sawDiscard = true
+			if e.StreamAttempt.Reason != provider.StreamInterruptPrematureEOF {
+				t.Fatalf("discard reason = %q", e.StreamAttempt.Reason)
+			}
+		}
+		if e.StreamAttempt.Action == event.StreamAttemptCommit {
+			sawCommit = true
+		}
+	}
+	if !sawDiscard || !sawCommit {
+		t.Fatalf("stream attempts missing discard/commit: %+v", attempts)
 	}
 }
 
@@ -298,21 +320,25 @@ func TestRunRecoversRepeatedInterruptedStreams(t *testing.T) {
 	if mp.CallCount() != 3 {
 		t.Fatalf("provider calls = %d, want 3", mp.CallCount())
 	}
+	reqs := mp.Requests()
+	if !providerRequestBodiesEqual(reqs[0], reqs[1]) || !providerRequestBodiesEqual(reqs[0], reqs[2]) {
+		t.Fatalf("all retries must replay the same frozen provider request")
+	}
 
 	var streamed strings.Builder
 	for _, e := range sink.kinds(event.Text) {
 		streamed.WriteString(e.Text)
 	}
-	if streamed.String() != "first second done" {
-		t.Fatalf("streamed text = %q, want repeated partials plus final text", streamed.String())
+	if !strings.Contains(streamed.String(), "done") {
+		t.Fatalf("streamed text = %q, want final done", streamed.String())
 	}
 	retries := sink.kinds(event.Retrying)
 	if len(retries) != 2 || retries[0].RetryAttempt != 1 || retries[1].RetryAttempt != 2 {
 		t.Fatalf("retry events = %+v, want attempts 1 and 2", retries)
 	}
 	for _, retry := range retries {
-		if retry.RetryMax != maxStreamRecoveries {
-			t.Fatalf("retry max = %d, want %d", retry.RetryMax, maxStreamRecoveries)
+		if retry.RetryMax != maxStreamRecoveries || retry.RetryScope != event.RetryScopeStream {
+			t.Fatalf("retry = %+v, want max=%d scope=stream", retry, maxStreamRecoveries)
 		}
 	}
 }
@@ -332,24 +358,253 @@ func TestRunRecoversInterruptedPartialToolCallWithoutExecutingIt(t *testing.T) {
 		t.Fatalf("Run should recover the interrupted tool-call stream, got %v", err)
 	}
 
-	var displayOnly provider.Message
 	for _, m := range a.Session().Messages {
 		if m.Role == provider.RoleTool && !m.LocalOnly {
 			t.Fatalf("partial tool call should not have executed or produced a tool result: %+v", m)
 		}
 		if m.LocalOnly {
-			displayOnly = m
+			t.Fatalf("successful recovery must not leave LocalOnly interrupt: %+v", m)
 		}
 	}
-	if len(displayOnly.ToolCalls) != 1 || displayOnly.ToolCalls[0].Name != "echo" || displayOnly.ToolCalls[0].Arguments != "" {
-		t.Fatalf("partial tool call was not retained safely for display: %+v", displayOnly)
-	}
 	reqs := mp.Requests()
-	second := reqs[1].Messages
-	last := second[len(second)-1]
-	if last.Role != provider.RoleUser || !strings.Contains(last.Content, "fresh complete tool call") {
-		t.Fatalf("partial-tool recovery prompt missing fresh-call instruction: %+v", last)
+	if len(reqs) != 2 || !providerRequestBodiesEqual(reqs[0], reqs[1]) {
+		t.Fatalf("partial-tool interrupt must exact-replay without synthetic recovery")
 	}
+}
+
+// failExactBudget rejects the second exact admission while allowing the first
+// (and the prepare probe). Models the interrupt-then-local-budget-reject path.
+type failExactBudget struct {
+	exactCalls int
+}
+
+func (b *failExactBudget) ReserveProviderRequest(estimatedInput, maxOutputTokens int) (int, provider.RequestBudgetReservation, error) {
+	// prepareSamplingRequest probe only.
+	if maxOutputTokens <= 0 {
+		maxOutputTokens = 1
+	}
+	return maxOutputTokens, noopReservation{}, nil
+}
+
+func (b *failExactBudget) ReserveExactProviderRequest(estimatedInput, maxOutputTokens int) (provider.RequestBudgetReservation, error) {
+	b.exactCalls++
+	if b.exactCalls >= 2 {
+		return nil, &provider.RequestBudgetError{
+			Used: 100, Limit: 200, Remaining: 20, EstimatedInput: estimatedInput,
+		}
+	}
+	return noopReservation{}, nil
+}
+
+type noopReservation struct{}
+
+func (noopReservation) Commit(int) {}
+func (noopReservation) Cancel()    {}
+
+func TestRunInterruptThenExactBudgetRejectDoesNotDoubleCharge(t *testing.T) {
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "partial",
+			Usage: &provider.Usage{
+				PromptTokens: 100, CompletionTokens: 0, TotalTokens: 100,
+				CacheMissTokens: 100, BudgetAccounted: true, RequestCount: 1,
+			},
+			ChunkError: interrupted,
+		},
+		// Must never be consumed: second attempt dies at exact admission.
+		testutil.Turn{Text: "should-not-run"},
+	)
+	sink := &recordSink{}
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, sink)
+	budget := &failExactBudget{}
+	ctx := provider.WithRequestBudget(context.Background(), budget)
+
+	err := a.Run(ctx, "go")
+	var budgetErr *provider.RequestBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Run error = %v, want RequestBudgetError after interrupt", err)
+	}
+	if mp.CallCount() != 1 {
+		t.Fatalf("provider calls = %d, want 1 (second attempt never reached Stream)", mp.CallCount())
+	}
+	usages := sink.kinds(event.Usage)
+	if len(usages) != 1 || usages[0].Usage == nil {
+		t.Fatalf("usage events = %+v, want one aggregate", usages)
+	}
+	u := usages[0].Usage
+	if !u.BudgetAccounted {
+		t.Fatalf("usage = %+v, want BudgetAccounted so Goal does not re-charge", u)
+	}
+	if u.RequestCount != 1 {
+		t.Fatalf("RequestCount = %d, want 1 (no invented pre-body request)", u.RequestCount)
+	}
+	if u.PromptTokens != 100 {
+		t.Fatalf("PromptTokens = %d, want only the first settled attempt (100)", u.PromptTokens)
+	}
+	// Completion may include best-effort partial text from the first attempt only.
+	if u.TotalTokens < 100 {
+		t.Fatalf("TotalTokens = %d, want at least first-attempt 100", u.TotalTokens)
+	}
+}
+
+func TestRunStreamRetryRequestCountIsLinearNotTriangular(t *testing.T) {
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "a", Usage: &provider.Usage{PromptTokens: 30, CompletionTokens: 1, TotalTokens: 31, CacheMissTokens: 30}, ChunkError: interrupted},
+		testutil.Turn{Text: "b", Usage: &provider.Usage{PromptTokens: 30, CompletionTokens: 1, TotalTokens: 31, CacheMissTokens: 30}, ChunkError: interrupted},
+		testutil.Turn{Text: "ok", Usage: &provider.Usage{PromptTokens: 30, CompletionTokens: 2, TotalTokens: 32, CacheMissTokens: 30}},
+	)
+	sink := &recordSink{}
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, sink)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if mp.CallCount() != 3 {
+		t.Fatalf("provider calls = %d, want 3", mp.CallCount())
+	}
+	usages := sink.kinds(event.Usage)
+	if len(usages) != 1 || usages[0].Usage == nil {
+		t.Fatalf("usage events = %d, want one aggregate", len(usages))
+	}
+	u := usages[0].Usage
+	if u.RequestCount != 3 {
+		t.Fatalf("RequestCount = %d, want 3 (linear, not triangular 6)", u.RequestCount)
+	}
+	// Billable input is summed; context gauge uses ContextPromptTokens.
+	if u.PromptTokens != 90 {
+		t.Fatalf("PromptTokens = %d, want billable sum 90", u.PromptTokens)
+	}
+	if u.ContextPromptTokens != 30 {
+		t.Fatalf("ContextPromptTokens = %d, want latest 30", u.ContextPromptTokens)
+	}
+	if u.CacheHitTokens+u.CacheMissTokens != u.PromptTokens {
+		t.Fatalf("cache split %d+%d must align with PromptTokens %d", u.CacheHitTokens, u.CacheMissTokens, u.PromptTokens)
+	}
+	if u.CompletionTokens != 4 {
+		t.Fatalf("CompletionTokens = %d, want billable sum 4", u.CompletionTokens)
+	}
+	// Next-turn floor / ContextSnapshot use latest full attempt shape.
+	if last := a.lastUsage.Load(); last == nil || last.PromptTokens != 30 {
+		t.Fatalf("lastUsage prompt = %+v, want 30 for next inputFloor", last)
+	}
+}
+
+func TestRunExhaustedStreamRetriesPersistPendingLocalOnly(t *testing.T) {
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
+	turns := make([]testutil.Turn, 0, maxSamplingAttempts)
+	for i := 0; i < maxSamplingAttempts; i++ {
+		turns = append(turns, testutil.Turn{Text: "half", ChunkError: interrupted})
+	}
+	mp := testutil.NewMock("m", turns...)
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, event.Discard)
+
+	err := a.Run(context.Background(), "go")
+	if !provider.IsStreamInterrupted(err) {
+		t.Fatalf("Run error = %v, want StreamInterruptedError after exhausting retries", err)
+	}
+	if mp.CallCount() != maxSamplingAttempts {
+		t.Fatalf("provider calls = %d, want %d", mp.CallCount(), maxSamplingAttempts)
+	}
+	var pending *provider.InterruptedTurnRecovery
+	var local provider.Message
+	for _, m := range a.Session().Messages {
+		if m.LocalOnly && m.InterruptedTurn != nil && m.InterruptedTurn.Pending {
+			pending = m.InterruptedTurn
+			local = m
+		}
+	}
+	if pending == nil || local.Content != "half" {
+		t.Fatalf("exhausted retries must leave one pending LocalOnly record: local=%+v pending=%+v", local, pending)
+	}
+	// No synthetic recovery user messages mid-turn.
+	for _, m := range a.Session().Messages {
+		if m.Role == provider.RoleUser && strings.Contains(m.Content, "previous assistant response was interrupted") {
+			t.Fatalf("must not inject synthetic stream recovery: %+v", m)
+		}
+	}
+}
+
+func TestRunCompleteUncommittedToolCallNeverExecutes(t *testing.T) {
+	// Full tool block arrived, but the stream was interrupted before a clean
+	// terminal — the call stays speculative and must never reach executeBatch.
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
+	writer := &countingWriterTool{}
+	reg := tool.NewRegistry()
+	reg.Add(writer)
+	mp := testutil.NewMock("m",
+		testutil.Turn{Chunks: []provider.Chunk{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "w1", Name: "write_file", Arguments: `{"path":"x.txt","content":"from-writer"}`}},
+			{Type: provider.ChunkError, Err: interrupted},
+		}},
+		testutil.Turn{Text: "recovered without write"},
+	)
+	a := New(mp, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "write it"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if writer.calls.Load() != 0 {
+		t.Fatalf("writer executed %d times, want 0 (uncommitted tool call)", writer.calls.Load())
+	}
+}
+
+type countingWriterTool struct{ calls atomic.Int32 }
+
+func (c *countingWriterTool) Name() string        { return "write_file" }
+func (c *countingWriterTool) Description() string { return "count writes" }
+func (c *countingWriterTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}}}`)
+}
+func (c *countingWriterTool) ReadOnly() bool { return false }
+func (c *countingWriterTool) Execute(context.Context, json.RawMessage) (string, error) {
+	c.calls.Add(1)
+	return "wrote", nil
+}
+
+// providerRequestBodiesEqual compares the provider-visible request surface
+// (messages, tools order/bytes, temperature, token limit, response format).
+func providerRequestBodiesEqual(a, b provider.Request) bool {
+	if a.MaxTokens != b.MaxTokens {
+		return false
+	}
+	if (a.Temperature == nil) != (b.Temperature == nil) {
+		return false
+	}
+	if a.Temperature != nil && b.Temperature != nil && *a.Temperature != *b.Temperature {
+		return false
+	}
+	if (a.ResponseFormat == nil) != (b.ResponseFormat == nil) {
+		return false
+	}
+	if a.ResponseFormat != nil && b.ResponseFormat != nil && a.ResponseFormat.Type != b.ResponseFormat.Type {
+		return false
+	}
+	if len(a.Messages) != len(b.Messages) || len(a.Tools) != len(b.Tools) {
+		return false
+	}
+	for i := range a.Messages {
+		am, bm := a.Messages[i], b.Messages[i]
+		if am.Role != bm.Role || am.Content != bm.Content || am.ReasoningContent != bm.ReasoningContent ||
+			am.Name != bm.Name || am.ToolCallID != bm.ToolCallID || am.LocalOnly != bm.LocalOnly {
+			return false
+		}
+		if len(am.ToolCalls) != len(bm.ToolCalls) {
+			return false
+		}
+		for j := range am.ToolCalls {
+			if am.ToolCalls[j].ID != bm.ToolCalls[j].ID || am.ToolCalls[j].Name != bm.ToolCalls[j].Name ||
+				am.ToolCalls[j].Arguments != bm.ToolCalls[j].Arguments {
+				return false
+			}
+		}
+	}
+	for i := range a.Tools {
+		if a.Tools[i].Name != b.Tools[i].Name || a.Tools[i].Description != b.Tools[i].Description ||
+			string(a.Tools[i].Parameters) != string(b.Tools[i].Parameters) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestRunGenericStreamErrorPersistsLocalDisplayAndInjectsBoundedRecovery(t *testing.T) {

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -372,82 +372,6 @@ func TestRunRecoversInterruptedPartialToolCallWithoutExecutingIt(t *testing.T) {
 	}
 }
 
-// failExactBudget rejects the second exact admission while allowing the first
-// (and the prepare probe). Models the interrupt-then-local-budget-reject path.
-type failExactBudget struct {
-	exactCalls int
-}
-
-func (b *failExactBudget) ReserveProviderRequest(estimatedInput, maxOutputTokens int) (int, provider.RequestBudgetReservation, error) {
-	// prepareSamplingRequest probe only.
-	if maxOutputTokens <= 0 {
-		maxOutputTokens = 1
-	}
-	return maxOutputTokens, noopReservation{}, nil
-}
-
-func (b *failExactBudget) ReserveExactProviderRequest(estimatedInput, maxOutputTokens int) (provider.RequestBudgetReservation, error) {
-	b.exactCalls++
-	if b.exactCalls >= 2 {
-		return nil, &provider.RequestBudgetError{
-			Used: 100, Limit: 200, Remaining: 20, EstimatedInput: estimatedInput,
-		}
-	}
-	return noopReservation{}, nil
-}
-
-type noopReservation struct{}
-
-func (noopReservation) Commit(int) {}
-func (noopReservation) Cancel()    {}
-
-func TestRunInterruptThenExactBudgetRejectDoesNotDoubleCharge(t *testing.T) {
-	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
-	mp := testutil.NewMock("m",
-		testutil.Turn{
-			Text: "partial",
-			Usage: &provider.Usage{
-				PromptTokens: 100, CompletionTokens: 0, TotalTokens: 100,
-				CacheMissTokens: 100, BudgetAccounted: true, RequestCount: 1,
-			},
-			ChunkError: interrupted,
-		},
-		// Must never be consumed: second attempt dies at exact admission.
-		testutil.Turn{Text: "should-not-run"},
-	)
-	sink := &recordSink{}
-	a := New(mp, echoRegistry(), NewSession(""), Options{}, sink)
-	budget := &failExactBudget{}
-	ctx := provider.WithRequestBudget(context.Background(), budget)
-
-	err := a.Run(ctx, "go")
-	var budgetErr *provider.RequestBudgetError
-	if !errors.As(err, &budgetErr) {
-		t.Fatalf("Run error = %v, want RequestBudgetError after interrupt", err)
-	}
-	if mp.CallCount() != 1 {
-		t.Fatalf("provider calls = %d, want 1 (second attempt never reached Stream)", mp.CallCount())
-	}
-	usages := sink.kinds(event.Usage)
-	if len(usages) != 1 || usages[0].Usage == nil {
-		t.Fatalf("usage events = %+v, want one aggregate", usages)
-	}
-	u := usages[0].Usage
-	if !u.BudgetAccounted {
-		t.Fatalf("usage = %+v, want BudgetAccounted so Goal does not re-charge", u)
-	}
-	if u.RequestCount != 1 {
-		t.Fatalf("RequestCount = %d, want 1 (no invented pre-body request)", u.RequestCount)
-	}
-	if u.PromptTokens != 100 {
-		t.Fatalf("PromptTokens = %d, want only the first settled attempt (100)", u.PromptTokens)
-	}
-	// Completion may include best-effort partial text from the first attempt only.
-	if u.TotalTokens < 100 {
-		t.Fatalf("TotalTokens = %d, want at least first-attempt 100", u.TotalTokens)
-	}
-}
-
 func TestRunStreamRetryRequestCountIsLinearNotTriangular(t *testing.T) {
 	interrupted := &provider.StreamInterruptedError{Err: errors.New("eof"), Reason: provider.StreamInterruptPrematureEOF}
 	mp := testutil.NewMock("m",
@@ -484,9 +408,9 @@ func TestRunStreamRetryRequestCountIsLinearNotTriangular(t *testing.T) {
 	if u.CompletionTokens != 4 {
 		t.Fatalf("CompletionTokens = %d, want billable sum 4", u.CompletionTokens)
 	}
-	// Next-turn floor / ContextSnapshot use latest full attempt shape.
+	// ContextSnapshot and compaction use the latest full attempt shape.
 	if last := a.lastUsage.Load(); last == nil || last.PromptTokens != 30 {
-		t.Fatalf("lastUsage prompt = %+v, want 30 for next inputFloor", last)
+		t.Fatalf("lastUsage prompt = %+v, want latest attempt prompt 30", last)
 	}
 }
 

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -1,11 +1,17 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {
+	// Stream body retries use multi-second backoff in production; collapse it
+	// in package tests so recovery suites stay deterministic and fast.
+	streamRetrySleep = func(ctx context.Context, _ int) bool {
+		return ctx.Err() == nil
+	}
 	goleak.VerifyTestMain(m)
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -375,7 +375,6 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 
 	var billable *provider.Usage
 	var last streamedTurn
-	missingReasoningTried := false
 
 	runAttempt := func(attemptID string, sink event.Sink) streamedTurn {
 		before := provider.RequestAttemptCount(ctx)
@@ -448,8 +447,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		missing, shouldRetry := a.observeMissingToolCallReasoning(result.calls, result.reasoning)
 		if missing {
 			event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
-			if !missingReasoningTried && shouldRetry && strings.TrimSpace(result.text) == "" {
-				missingReasoningTried = true
+			if shouldRetry && strings.TrimSpace(result.text) == "" {
 				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryAttempted})
 				retrySink := newDeferredStreamSink(a.sink)
 				retry := runAttempt(attemptID, retrySink)
@@ -748,16 +746,6 @@ func (a *Agent) storeLatestRequestUsage(attempt *provider.Usage) {
 	a.lastUsage.Store(&clone)
 }
 
-// contextUsageFromAttempt is retained for tests that need a prompt-only view.
-func contextUsageFromAttempt(attempt *provider.Usage) *provider.Usage {
-	if attempt == nil {
-		return nil
-	}
-	ctx := *attempt
-	ctx.RequestCount = 0
-	return &ctx
-}
-
 // finalizeSamplingUsage builds the Usage event payload for consumers that
 // expect one coherent billable record:
 //   - PromptTokens / cache hit+miss / Completion / Total / RequestCount: billable aggregate
@@ -804,11 +792,6 @@ func applyLatestContextShape(dst, latest *provider.Usage) {
 	dst.ContextReasoningTokens = latest.ReasoningTokens
 	dst.ContextCacheHitTokens = latest.CacheHitTokens
 	dst.ContextCacheMissTokens = latest.CacheMissTokens
-	// When the latest attempt only has request bookkeeping, keep any prior
-	// context already on dst (e.g. previous successful attempt in the merge).
-	if dst.ContextPromptTokens <= 0 && dst.ContextCompletionTokens <= 0 {
-		// leave zeros; consumers fall back to billable fields
-	}
 }
 
 // mergeStreamUsage remains for missing-reasoning style single-repair merges that

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -761,7 +761,7 @@ func contextUsageFromAttempt(attempt *provider.Usage) *provider.Usage {
 // finalizeSamplingUsage builds the Usage event payload for consumers that
 // expect one coherent billable record:
 //   - PromptTokens / cache hit+miss / Completion / Total / RequestCount: billable aggregate
-//   - ContextPromptTokens: latest attempt prompt (context gauge only)
+//   - Context* fields: latest attempt only (context gauges + rebind telemetry)
 //   - BudgetAccounted: every attempt was middleware-settled or zero-token
 func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	if billable == nil && latest == nil {
@@ -769,22 +769,13 @@ func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	}
 	if billable == nil {
 		out := *latest
-		if out.ContextPromptTokens <= 0 {
-			out.ContextPromptTokens = out.PromptTokens
-		}
+		applyLatestContextShape(&out, latest)
 		out.BudgetAccounted = budgetAccountedOrZero(&out)
 		return &out
 	}
 	out := *billable
 	if latest != nil {
-		out.ContextPromptTokens = latest.PromptTokens
-		if out.ContextPromptTokens <= 0 {
-			// Latest may only carry request-count bookkeeping; keep prior context
-			// from a previous attempt if the aggregate already held one.
-			if billable.ContextPromptTokens > 0 {
-				out.ContextPromptTokens = billable.ContextPromptTokens
-			}
-		}
+		applyLatestContextShape(&out, latest)
 		out.FinishReason = latest.FinishReason
 	}
 	// Ensure PromptTokens matches billable input (hit+miss) for CLI/ACP/Desktop
@@ -800,6 +791,24 @@ func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	// last attempt is a request-only shell or an un-flagged raw mock usage.
 	out.BudgetAccounted = budgetAccountedOrZero(billable)
 	return &out
+}
+
+// applyLatestContextShape copies the latest single-request shape into Context*
+// fields for gauges and Desktop rebind telemetry.
+func applyLatestContextShape(dst, latest *provider.Usage) {
+	if dst == nil || latest == nil {
+		return
+	}
+	dst.ContextPromptTokens = latest.PromptTokens
+	dst.ContextCompletionTokens = latest.CompletionTokens
+	dst.ContextReasoningTokens = latest.ReasoningTokens
+	dst.ContextCacheHitTokens = latest.CacheHitTokens
+	dst.ContextCacheMissTokens = latest.CacheMissTokens
+	// When the latest attempt only has request bookkeeping, keep any prior
+	// context already on dst (e.g. previous successful attempt in the merge).
+	if dst.ContextPromptTokens <= 0 && dst.ContextCompletionTokens <= 0 {
+		// leave zeros; consumers fall back to billable fields
+	}
 }
 
 // mergeStreamUsage remains for missing-reasoning style single-repair merges that

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -384,12 +383,12 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		if delta < 0 {
 			delta = 0
 		}
-		// httpRequests=0 means either (a) local admission never reached Stream,
-		// or (b) a provider that does not use SendWithRetry (extension/custom).
+		// httpRequests=0 means the provider does not use SendWithRetry
+		// (extension/custom), or it failed before issuing an HTTP request.
 		// Only overwrite RequestCount when the built-in counter observed POSTs;
 		// otherwise keep the provider-reported count (zero still means one via
-		// usageRequestCount compatibility). estimateFailedAttemptUsage already
-		// returns nil for pre-body budget rejects so no invented request appears.
+		// usageRequestCount compatibility). estimateFailedAttemptUsage returns nil
+		// for zero-output local failures so no invented request appears.
 		result.usage = estimateFailedAttemptUsage(result.usage, frozen, result, delta)
 		if result.usage != nil {
 			if delta > 0 {
@@ -416,7 +415,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		billable = mergeSamplingUsage(billable, result.usage)
 		// lastUsage is the latest single-request shape (prompt+completion+cache
 		// for that attempt only). Never the multi-attempt billable aggregate —
-		// that would inflate the next inputFloor and ContextSnapshot.
+		// that would inflate ContextSnapshot and compaction decisions.
 		a.storeLatestRequestUsage(result.usage)
 		last = result
 		last.usage = finalizeSamplingUsage(billable, result.usage)
@@ -557,14 +556,15 @@ func sleepStreamRetryBackoff(ctx context.Context, attempt int) bool {
 }
 
 // estimateFailedAttemptUsage fills Estimated usage when a body attempt ends
-// without a terminal provider usage record, so Goal budgets still charge the
-// issued request plus any observed speculative output. Non-interrupt failures
-// that already carry usage (e.g. client reasoning limit) are left intact.
+// without a terminal provider usage record, so billing and observational Goal
+// usage still include the issued request plus any observed speculative output.
+// Non-interrupt failures that already carry usage (e.g. client reasoning limit)
+// are left intact.
 //
 // httpRequests is the SendWithRetry attempt-counter delta for this body attempt.
-// When it is 0 the failure never reached Provider.Stream (local admission /
-// exact-budget reject) — return nil or the existing zero-token usage without
-// inventing PromptTokens that would clear BudgetAccounted on the aggregate.
+// When it is 0 and there was no speculative output, the failure was local or
+// came from a provider without observable transport accounting; return nil or
+// its existing usage rather than inventing billable tokens.
 func estimateFailedAttemptUsage(usage *provider.Usage, frozen samplingRequest, result streamedTurn, httpRequests int) *provider.Usage {
 	if result.err == nil {
 		return usage
@@ -573,17 +573,10 @@ func estimateFailedAttemptUsage(usage *provider.Usage, frozen samplingRequest, r
 	if usage != nil && usage.FinishReason != "" && usage.FinishReason != "interrupted" {
 		return usage
 	}
-	// Middleware already settled this attempt — never rewrite it into a larger
-	// estimate that could change Goal accounting semantics.
-	if usage != nil && usage.BudgetAccounted {
-		return usage
-	}
-	// Pre-body local failures (exact budget admission, etc.) never issued an HTTP
-	// request. Do not invent PromptTokens — that would clear aggregate
-	// BudgetAccounted and make Goal re-charge prior settled attempts.
-	var budgetErr *provider.RequestBudgetError
-	preBodyLocal := httpRequests <= 0 && (errors.As(result.err, &budgetErr) ||
-		(!result.interrupted && !provider.IsStreamInterrupted(result.err) && !sawSpeculativeSamplingOutput(result)))
+	// A zero-output, non-interrupted failure with no observed HTTP request is a
+	// local/provider validation failure. It is not a billable sampling attempt.
+	preBodyLocal := httpRequests <= 0 && !result.interrupted &&
+		!provider.IsStreamInterrupted(result.err) && !sawSpeculativeSamplingOutput(result)
 	if preBodyLocal {
 		if usage != nil && usageTotalTokens(usage) > 0 {
 			return usage
@@ -624,10 +617,7 @@ func estimateFailedAttemptUsage(usage *provider.Usage, frozen samplingRequest, r
 		est = &provider.Usage{Estimated: true, FinishReason: finish}
 	}
 	if est.PromptTokens <= 0 {
-		est.PromptTokens = provider.EstimateRequestInputTokens(frozen.req)
-		if frozen.inputFloor > est.PromptTokens {
-			est.PromptTokens = frozen.inputFloor
-		}
+		est.PromptTokens = estimateSamplingRequestInputTokens(frozen.req)
 		est.Estimated = true
 	}
 	// Estimated failed attempts without cache split still need Cost() to see
@@ -654,14 +644,34 @@ func sawSpeculativeSamplingOutput(result streamedTurn) bool {
 		result.partialToolStarted || len(result.calls) > 0 || len(result.partialCalls) > 0
 }
 
-// budgetAccountedOrZero reports whether an attempt is already settled for Goal
-// event accounting: middleware committed it, or it spent no billable tokens
-// (pre-body failure / cancel with reservation Cancel — nothing to charge again).
-func budgetAccountedOrZero(u *provider.Usage) bool {
-	if u == nil {
-		return true
+// estimateSamplingRequestInputTokens reconstructs a conservative input count
+// only when an interrupted attempt closed before terminal provider usage. It is
+// accounting telemetry, not request admission: the estimate never changes the
+// frozen provider request or imposes a token ceiling.
+func estimateSamplingRequestInputTokens(req provider.Request) int {
+	total := 3
+	for _, msg := range provider.ModelMessages(req.Messages) {
+		total += 4
+		total += estimateTextTokens(msg.Content)
+		total += estimateTextTokens(msg.ReasoningContent)
+		total += estimateTextTokens(msg.ReasoningSignature)
+		total += estimateTextTokens(msg.Name)
+		total += estimateTextTokens(msg.ToolCallID)
+		for _, image := range msg.Images {
+			total += estimateTextTokens(image)
+		}
+		for _, call := range msg.ToolCalls {
+			total += 8 + estimateTextTokens(call.ID) + estimateTextTokens(call.Name) + estimateTextTokens(call.Arguments)
+		}
+		for _, item := range msg.ResponsesItems {
+			total += estimateTextTokens(string(item))
+		}
 	}
-	return u.BudgetAccounted || usageTotalTokens(u) == 0
+	for _, schema := range req.Tools {
+		encoded, _ := json.Marshal(schema)
+		total += 8 + estimateTextTokens(string(encoded))
+	}
+	return max(total, 1)
 }
 
 // mergeSamplingUsage accumulates billable counters across body attempts.
@@ -696,7 +706,6 @@ func mergeSamplingUsage(acc, attempt *provider.Usage) *provider.Usage {
 		merged.CacheHitTokens = hit
 		merged.CacheMissTokens = miss
 		merged.PromptTokens = billablePrompt(hit, miss, attempt.PromptTokens)
-		merged.BudgetAccounted = budgetAccountedOrZero(attempt)
 		return &merged
 	}
 	merged := *acc
@@ -721,9 +730,6 @@ func mergeSamplingUsage(acc, attempt *provider.Usage) *provider.Usage {
 	if attempt.Estimated {
 		merged.Estimated = true
 	}
-	// Zero-token attempts (header failure / cancelled reservation) do not
-	// invalidate prior middleware commits.
-	merged.BudgetAccounted = budgetAccountedOrZero(acc) && budgetAccountedOrZero(attempt)
 	if attempt.FinishReason != "" {
 		merged.FinishReason = attempt.FinishReason
 	}
@@ -731,8 +737,8 @@ func mergeSamplingUsage(acc, attempt *provider.Usage) *provider.Usage {
 }
 
 // storeLatestRequestUsage records the most recent single-request usage for
-// inputFloor (PromptTokens) and ContextSnapshot (Prompt+Completion). It must
-// never receive a multi-attempt billable aggregate.
+// ContextSnapshot and compaction. It must never receive a multi-attempt
+// billable aggregate.
 func (a *Agent) storeLatestRequestUsage(attempt *provider.Usage) {
 	if a == nil || attempt == nil {
 		return
@@ -750,7 +756,6 @@ func (a *Agent) storeLatestRequestUsage(attempt *provider.Usage) {
 // expect one coherent billable record:
 //   - PromptTokens / cache hit+miss / Completion / Total / RequestCount: billable aggregate
 //   - Context* fields: latest attempt only (context gauges + rebind telemetry)
-//   - BudgetAccounted: every attempt was middleware-settled or zero-token
 func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	if billable == nil && latest == nil {
 		return nil
@@ -758,7 +763,6 @@ func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	if billable == nil {
 		out := *latest
 		applyLatestContextShape(&out, latest)
-		out.BudgetAccounted = budgetAccountedOrZero(&out)
 		return &out
 	}
 	out := *billable
@@ -774,10 +778,6 @@ func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
 	if out.TotalTokens < out.PromptTokens+out.CompletionTokens {
 		out.TotalTokens = out.PromptTokens + out.CompletionTokens
 	}
-	// billable already AND-ed every attempt (treating zero-token as settled).
-	// Do not re-AND against latest alone — that would clear the flag when the
-	// last attempt is a request-only shell or an un-flagged raw mock usage.
-	out.BudgetAccounted = budgetAccountedOrZero(billable)
 	return &out
 }
 
@@ -826,7 +826,7 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	}
 	// lastUsage must stay as the latest single-request shape (set during
 	// sampling recovery). Never overwrite it with a multi-attempt billable
-	// aggregate — that would inflate inputFloor and ContextSnapshot.
+	// aggregate — that would inflate ContextSnapshot and compaction decisions.
 	if a.lastUsage.Load() == nil && usage.PromptTokens > 0 {
 		a.storeLatestRequestUsage(usage)
 	}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -25,7 +27,6 @@ type runLoopState struct {
 	emptyFinalBlocks   int
 	handoffNudges      int
 	usedAnyTool        bool
-	streamRecoveries   int
 	goalToolRepairs    int
 	graceRound         bool
 	recoveryGraceRound bool
@@ -60,6 +61,7 @@ type streamedTurn struct {
 	interrupted        bool
 	partialToolStarted bool
 	partialCalls       []provider.ToolCall
+	maxArgChars        int // peak streaming tool-arg size for failed-attempt estimates
 	err                error
 }
 
@@ -252,7 +254,6 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 		emptyFinalBlocks:   0,
 		handoffNudges:      0,
 		usedAnyTool:        false,
-		streamRecoveries:   0,
 		graceRound:         false,
 		recoveryGraceRound: false,
 		todoStallRounds:    0,
@@ -295,30 +296,24 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		// edits.
 		contentReasons := a.session.DrainContentRewriteReasons()
 
-		streamed := a.streamWithMissingReasoningRecovery(ctx, step+1)
+		// Prefix shape is captured once before sampling and frozen for the
+		// whole attempt lifecycle — stream retries must not rewrite session
+		// history mid-round, so the shape stays stable across body replays.
+		streamed := a.streamWithSamplingRecovery(ctx, step+1)
 		text, reasoning, signature, calls, responsesItems, usage := streamed.text, streamed.reasoning, streamed.signature, streamed.calls, streamed.responsesItems, streamed.usage
-		interrupted, partialToolStarted, partialCalls, err := streamed.interrupted, streamed.partialToolStarted, streamed.partialCalls, streamed.err
+		partialCalls, err := streamed.partialCalls, streamed.err
 		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage, contentReasons)
 		if err != nil {
 			a.emitTurnUsage(usage, &cacheDiagnostics)
 			if msg, ok := finishReasonMessage(usage); ok {
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
 			}
-			if interrupted && state.streamRecoveries < maxStreamRecoveries {
-				state.streamRecoveries++
-				a.recordInterruptedDisplay(text, reasoning, partialCalls, false, state.workDurationMs())
-				a.session.Add(provider.Message{
-					Role:    provider.RoleUser,
-					Content: a.withTurnPreferences(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
-				})
-				a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: state.streamRecoveries, RetryMax: maxStreamRecoveries})
-				step-- // recovery retries do not consume the tool-round maxSteps budget
-				continue
-			}
+			// Exhausted stream retries (or a non-retryable error): persist one
+			// bounded LocalOnly recovery record for the next real user message.
+			// Intermediate failed attempts never wrote session state.
 			a.recordInterruptedDisplay(text, reasoning, partialCalls, true, state.workDurationMs())
 			return err
 		}
-		state.streamRecoveries = 0
 		a.lastPrefixShape = prefixShape
 		a.haveLastPrefixShape = true
 		a.emitTurnUsage(usage, &cacheDiagnostics)
@@ -326,6 +321,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
 		}
 
+		// Commit boundary: only a clean terminal attempt reaches here.
 		// Keep reasoning_content on the assistant turn for display and session
 		// archive. Most OpenAI-compatible backends do not replay it; providers
 		// with an explicit round-trip contract retain the raw provider text.
@@ -350,6 +346,8 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 			continue
 		}
 
+		// Invariant: executeBatch only ever receives tool calls from a
+		// committed sampling attempt (clean terminal + response intercept).
 		cont, terr := a.handleToolRound(ctx, state, step, text, reasoning, calls, usage)
 		if !cont {
 			return terr
@@ -361,120 +359,463 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 	return &maxStepsPause{steps: state.runMaxSteps, key: state.runMaxStepsKey}
 }
 
-// streamWithMissingReasoningRecovery silently repairs an isolated DeepSeek
-// thinking-mode tool-call response that omitted reasoning_content. It replays
-// the exact same provider request at most once, before any tool is executed and
-// without injecting a synthetic prompt. A configuration-scoped cooldown keeps
-// a gateway that persistently strips reasoning from doubling every request; the
-// existing explicit-empty reasoning_content wire fallback remains the final
-// compatibility path.
-func (a *Agent) streamWithMissingReasoningRecovery(ctx context.Context, turn int) streamedTurn {
-	var streamSink *deferredStreamSink
-	attemptSink := a.sink
-	if provider.WarnOnMissingToolCallReasoning(a.prov) {
-		streamSink = newReasoningAwareStreamSink(a.sink)
-		attemptSink = streamSink
+// streamWithSamplingRecovery coordinates Codex-style original-request replay
+// for one model round: prepare once, freeze the provider request, run up to
+// maxSamplingAttempts body attempts, and only commit after a clean terminal.
+// Failed attempts never write Session state or execute tools. missing-reasoning
+// repair shares this lifecycle (at most one extra exact replay).
+func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) streamedTurn {
+	frozen, err := a.prepareSamplingRequest(ctx)
+	if err != nil {
+		return streamedTurn{err: err}
 	}
-	first := a.streamTurn(ctx, turn, attemptSink)
-	if first.err != nil {
-		streamSink.Flush()
-		return first
-	}
+	// One request counter spans every body attempt; each attempt records only
+	// its delta so RequestCount equals real HTTP POSTs (no triangular growth).
+	ctx = provider.WithRequestAttemptCounter(ctx)
 
-	missing, shouldRetry := a.observeMissingToolCallReasoning(first.calls, first.reasoning)
-	if !missing {
-		streamSink.Flush()
-		return first
-	}
-	event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+	var billable *provider.Usage
+	var last streamedTurn
+	missingReasoningTried := false
 
-	// Non-empty visible output was already streamed from the first response.
-	// Replaying it would duplicate user-visible text, so keep the structurally
-	// valid empty-key fallback and let the cooldown suppress repeated attempts.
-	if !shouldRetry || strings.TrimSpace(first.text) != "" {
-		streamSink.Flush()
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-		return first
-	}
-
-	event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryAttempted})
-	retrySink := newDeferredStreamSink(a.sink)
-	retry := a.streamTurn(ctx, turn, retrySink)
-	if retry.err != nil {
-		retrySink.Discard()
-		if ctx.Err() != nil {
-			streamSink.Discard()
-			// The recovery stream was intentionally invisible, so do not persist
-			// partial retry text/reasoning as though the user had already seen it.
-			return streamedTurn{usage: mergeStreamUsage(first.usage, retry.usage), err: retry.err}
+	runAttempt := func(attemptID string, sink event.Sink) streamedTurn {
+		before := provider.RequestAttemptCount(ctx)
+		result := a.streamTurnFrozen(ctx, turn, sink, &frozen, attemptID)
+		after := provider.RequestAttemptCount(ctx)
+		delta := after - before
+		if delta < 0 {
+			delta = 0
 		}
-		streamSink.Flush()
-		first.usage = mergeStreamUsage(first.usage, retry.usage)
-		if first.usage != nil {
-			a.lastUsage.Store(first.usage)
+		// httpRequests=0 means either (a) local admission never reached Stream,
+		// or (b) a provider that does not use SendWithRetry (extension/custom).
+		// Only overwrite RequestCount when the built-in counter observed POSTs;
+		// otherwise keep the provider-reported count (zero still means one via
+		// usageRequestCount compatibility). estimateFailedAttemptUsage already
+		// returns nil for pre-body budget rejects so no invented request appears.
+		result.usage = estimateFailedAttemptUsage(result.usage, frozen, result, delta)
+		if result.usage != nil {
+			if delta > 0 {
+				result.usage.RequestCount = delta
+			}
+		} else if delta > 0 {
+			result.usage = &provider.Usage{RequestCount: delta}
 		}
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-		return first
+		return result
 	}
 
-	streamSink.Discard()
-	retrySink.Flush()
-	retry.usage = mergeStreamUsage(first.usage, retry.usage)
-	if retry.usage != nil {
-		a.lastUsage.Store(retry.usage)
+	for attempt := 1; attempt <= maxSamplingAttempts; attempt++ {
+		attemptID := newStreamAttemptID(attempt)
+		a.emitStreamAttempt(attemptID, event.StreamAttemptBegin, attempt, "", nil)
+
+		var streamSink *deferredStreamSink
+		attemptSink := a.sink
+		if provider.WarnOnMissingToolCallReasoning(a.prov) {
+			streamSink = newReasoningAwareStreamSink(a.sink)
+			attemptSink = streamSink
+		}
+
+		result := runAttempt(attemptID, attemptSink)
+		billable = mergeSamplingUsage(billable, result.usage)
+		// lastUsage is the latest single-request shape (prompt+completion+cache
+		// for that attempt only). Never the multi-attempt billable aggregate —
+		// that would inflate the next inputFloor and ContextSnapshot.
+		a.storeLatestRequestUsage(result.usage)
+		last = result
+		last.usage = finalizeSamplingUsage(billable, result.usage)
+
+		if result.err != nil {
+			if provider.IsStreamInterrupted(result.err) && attempt < maxSamplingAttempts {
+				streamSink.Discard()
+				reason := provider.StreamInterruptReason(result.err)
+				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, reason, result.err)
+				a.sink.Emit(event.Event{
+					Kind: event.Retrying, RetryAttempt: attempt, RetryMax: maxStreamRecoveries,
+					RetryScope: event.RetryScopeStream,
+				})
+				if !streamRetrySleep(ctx, attempt) {
+					return streamedTurn{usage: finalizeSamplingUsage(billable, result.usage), interrupted: true, err: ctx.Err()}
+				}
+				continue
+			}
+			// Exhausted retries or non-retryable error: leave the last
+			// speculative UI visible (no discard) so LocalOnly can mirror it.
+			streamSink.Flush()
+			last.usage = finalizeSamplingUsage(billable, result.usage)
+			return last
+		}
+
+		// Clean terminal. Optionally repair missing reasoning with one extra
+		// exact replay of the same frozen request (no synthetic prompt).
+		missing, shouldRetry := a.observeMissingToolCallReasoning(result.calls, result.reasoning)
+		if missing {
+			event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+			if !missingReasoningTried && shouldRetry && strings.TrimSpace(result.text) == "" {
+				missingReasoningTried = true
+				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryAttempted})
+				retrySink := newDeferredStreamSink(a.sink)
+				retry := runAttempt(attemptID, retrySink)
+				billable = mergeSamplingUsage(billable, retry.usage)
+				if retry.err != nil {
+					retrySink.Discard()
+					if ctx.Err() != nil {
+						streamSink.Discard()
+						a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, provider.StreamInterruptReason(retry.err), retry.err)
+						// Use the cancelled retry as the "latest" shape so
+						// FinishReason=interrupted is preserved for accounting.
+						return streamedTurn{usage: finalizeSamplingUsage(billable, retry.usage), err: retry.err}
+					}
+					// Fall back to the first complete response; no tool ran.
+					streamSink.Flush()
+					a.storeLatestRequestUsage(result.usage)
+					result.usage = finalizeSamplingUsage(billable, result.usage)
+					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+					a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
+					return result
+				}
+				streamSink.Discard()
+				retrySink.Flush()
+				a.storeLatestRequestUsage(retry.usage)
+				retry.usage = finalizeSamplingUsage(billable, retry.usage)
+				retryMissing, _ := a.observeMissingToolCallReasoning(retry.calls, retry.reasoning)
+				if retryMissing {
+					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+				} else if len(retry.calls) == 0 {
+					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryReplaced})
+				} else {
+					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryRecovered})
+				}
+				a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
+				return retry
+			}
+			if !shouldRetry || strings.TrimSpace(result.text) != "" {
+				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
+				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+			} else {
+				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+			}
+		}
+
+		streamSink.Flush()
+		a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
+		result.usage = finalizeSamplingUsage(billable, result.usage)
+		return result
 	}
-	retryMissing, _ := a.observeMissingToolCallReasoning(retry.calls, retry.reasoning)
-	if retryMissing {
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
-	} else if len(retry.calls) == 0 {
-		// An exact replay can legitimately choose a different completion shape.
-		// Adopt it wholesale because no tool from the discarded response ran, but
-		// do not misreport the disappearance of tool calls as recovered reasoning.
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryReplaced})
-	} else {
-		event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryRecovered})
-	}
-	return retry
+	return last
 }
 
-func (a *Agent) streamTurn(ctx context.Context, turn int, sink event.Sink) streamedTurn {
-	text, reasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, interrupted, partialToolStarted, partialCalls, err := a.stream(ctx, turn, sink)
+func (a *Agent) streamTurnFrozen(ctx context.Context, turn int, sink event.Sink, frozen *samplingRequest, attemptID string) streamedTurn {
+	text, reasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, interrupted, partialToolStarted, partialCalls, maxArgChars, err := a.streamWithFrozen(ctx, turn, sink, frozen, attemptID)
 	return streamedTurn{
 		text: text, reasoning: reasoning, signature: signature,
 		reasoningID: reasoningID, reasoningStatus: reasoningStatus,
 		calls: calls, responsesItems: responsesItems, usage: usage,
-		interrupted: interrupted, partialToolStarted: partialToolStarted, partialCalls: partialCalls, err: err,
+		interrupted: interrupted, partialToolStarted: partialToolStarted, partialCalls: partialCalls,
+		maxArgChars: maxArgChars, err: err,
 	}
 }
 
-func mergeStreamUsage(first, retry *provider.Usage) *provider.Usage {
-	if first == nil && retry == nil {
+func (a *Agent) emitStreamAttempt(id string, action event.StreamAttemptAction, attempt int, reason string, err error) {
+	if reason == "" && err != nil {
+		reason = provider.StreamInterruptReason(err)
+	}
+	a.sink.Emit(event.Event{
+		Kind: event.StreamAttempt,
+		StreamAttempt: event.StreamAttemptInfo{
+			ID: id, Action: action, Attempt: attempt, Max: maxSamplingAttempts, Reason: reason,
+		},
+	})
+}
+
+func newStreamAttemptID(attempt int) string {
+	// Host-local only: never persisted, never sent to the model.
+	return fmt.Sprintf("sa-%d-%d", attempt, time.Now().UnixNano())
+}
+
+// streamRetrySleep is the body-retry backoff. Tests replace it with a no-op so
+// recovery suites stay fast while production keeps the Codex-shaped delays.
+var streamRetrySleep = sleepStreamRetryBackoff
+
+// sleepStreamRetryBackoff waits ~0.5s, 1s, 2s, 4s, 8s with small jitter.
+// Returns false when ctx is cancelled during the wait.
+func sleepStreamRetryBackoff(ctx context.Context, attempt int) bool {
+	// attempt is 1-based for the failed attempt about to be retried.
+	shift := attempt - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > 4 {
+		shift = 4
+	}
+	base := time.Duration(1<<shift) * 500 * time.Millisecond
+	jitter := time.Duration(rand.Intn(250)) * time.Millisecond
+	timer := time.NewTimer(base + jitter)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// estimateFailedAttemptUsage fills Estimated usage when a body attempt ends
+// without a terminal provider usage record, so Goal budgets still charge the
+// issued request plus any observed speculative output. Non-interrupt failures
+// that already carry usage (e.g. client reasoning limit) are left intact.
+//
+// httpRequests is the SendWithRetry attempt-counter delta for this body attempt.
+// When it is 0 the failure never reached Provider.Stream (local admission /
+// exact-budget reject) — return nil or the existing zero-token usage without
+// inventing PromptTokens that would clear BudgetAccounted on the aggregate.
+func estimateFailedAttemptUsage(usage *provider.Usage, frozen samplingRequest, result streamedTurn, httpRequests int) *provider.Usage {
+	if result.err == nil {
+		return usage
+	}
+	// Preserve exact client-side finish reasons that already computed usage.
+	if usage != nil && usage.FinishReason != "" && usage.FinishReason != "interrupted" {
+		return usage
+	}
+	// Middleware already settled this attempt — never rewrite it into a larger
+	// estimate that could change Goal accounting semantics.
+	if usage != nil && usage.BudgetAccounted {
+		return usage
+	}
+	// Pre-body local failures (exact budget admission, etc.) never issued an HTTP
+	// request. Do not invent PromptTokens — that would clear aggregate
+	// BudgetAccounted and make Goal re-charge prior settled attempts.
+	var budgetErr *provider.RequestBudgetError
+	preBodyLocal := httpRequests <= 0 && (errors.As(result.err, &budgetErr) ||
+		(!result.interrupted && !provider.IsStreamInterrupted(result.err) && !sawSpeculativeSamplingOutput(result)))
+	if preBodyLocal {
+		if usage != nil && usageTotalTokens(usage) > 0 {
+			return usage
+		}
 		return nil
 	}
-	if first == nil {
-		merged := *retry
-		// The first provider request still happened even if its terminal usage
-		// chunk was lost. Preserve the retry's known tokens and count both calls.
-		merged.RequestCount = 1 + usageRequestCount(retry)
+	if !provider.IsStreamInterrupted(result.err) && !result.interrupted {
+		// Auth/cancel/decode/limit paths keep their own accounting.
+		if usage != nil {
+			return usage
+		}
+		if httpRequests <= 0 {
+			return nil
+		}
+	}
+	textBytes := len(result.text)
+	reasoningBytes := len(result.reasoning)
+	maxArg := result.maxArgChars
+	for _, call := range result.partialCalls {
+		if n := len(call.Arguments); n > maxArg {
+			maxArg = n
+		}
+	}
+	for _, call := range result.calls {
+		if n := len(call.Arguments); n > maxArg {
+			maxArg = n
+		}
+	}
+	if usage != nil && !usage.Estimated && usage.TotalTokens > 0 {
+		return usage
+	}
+	finish := "interrupted"
+	if usage != nil && usage.FinishReason != "" {
+		finish = usage.FinishReason
+	}
+	est := bestEffortStreamUsage(usage, textBytes, reasoningBytes, finish)
+	if est == nil {
+		est = &provider.Usage{Estimated: true, FinishReason: finish}
+	}
+	if est.PromptTokens <= 0 {
+		est.PromptTokens = provider.EstimateRequestInputTokens(frozen.req)
+		if frozen.inputFloor > est.PromptTokens {
+			est.PromptTokens = frozen.inputFloor
+		}
+		est.Estimated = true
+	}
+	// Estimated failed attempts without cache split still need Cost() to see
+	// billable input — Price falls back to PromptTokens only when hit+miss=0.
+	if est.CacheHitTokens+est.CacheMissTokens == 0 && est.PromptTokens > 0 {
+		est.CacheMissTokens = est.PromptTokens
+	}
+	if maxArg > 0 {
+		argTokens := (maxArg + 3) / 4
+		if est.CompletionTokens < argTokens+estimateTokensFromBytes(textBytes)+estimateTokensFromBytes(reasoningBytes) {
+			est.CompletionTokens = argTokens + estimateTokensFromBytes(textBytes) + estimateTokensFromBytes(reasoningBytes)
+			est.Estimated = true
+		}
+	}
+	if minTotal := est.PromptTokens + est.CompletionTokens; est.TotalTokens < minTotal {
+		est.TotalTokens = minTotal
+		est.Estimated = true
+	}
+	return est
+}
+
+func sawSpeculativeSamplingOutput(result streamedTurn) bool {
+	return result.text != "" || result.reasoning != "" || result.maxArgChars > 0 ||
+		result.partialToolStarted || len(result.calls) > 0 || len(result.partialCalls) > 0
+}
+
+// budgetAccountedOrZero reports whether an attempt is already settled for Goal
+// event accounting: middleware committed it, or it spent no billable tokens
+// (pre-body failure / cancel with reservation Cancel — nothing to charge again).
+func budgetAccountedOrZero(u *provider.Usage) bool {
+	if u == nil {
+		return true
+	}
+	return u.BudgetAccounted || usageTotalTokens(u) == 0
+}
+
+// mergeSamplingUsage accumulates billable counters across body attempts.
+// PromptTokens is the billable input total (aligned with cache hit+miss).
+// ContextPromptTokens is set later by finalizeSamplingUsage from the latest attempt.
+func mergeSamplingUsage(acc, attempt *provider.Usage) *provider.Usage {
+	if attempt == nil {
+		return acc
+	}
+	billableHitMiss := func(u *provider.Usage) (hit, miss int) {
+		if u == nil {
+			return 0, 0
+		}
+		if u.CacheHitTokens+u.CacheMissTokens > 0 {
+			return u.CacheHitTokens, u.CacheMissTokens
+		}
+		// No cache split: treat PromptTokens as uncached billable input.
+		return 0, u.PromptTokens
+	}
+	billablePrompt := func(hit, miss, prompt int) int {
+		if hit+miss > 0 {
+			return hit + miss
+		}
+		return prompt
+	}
+	if acc == nil {
+		merged := *attempt
+		if merged.RequestCount <= 0 {
+			merged.RequestCount = 1
+		}
+		hit, miss := billableHitMiss(attempt)
+		merged.CacheHitTokens = hit
+		merged.CacheMissTokens = miss
+		merged.PromptTokens = billablePrompt(hit, miss, attempt.PromptTokens)
+		merged.BudgetAccounted = budgetAccountedOrZero(attempt)
 		return &merged
 	}
-	if retry == nil {
-		merged := *first
-		// Likewise, a failed recovery request without usage is still an API call.
-		merged.RequestCount = usageRequestCount(first) + 1
-		return &merged
+	merged := *acc
+	// Billable input for Cost: sum hit/miss (prompt when no cache split).
+	ah, am := billableHitMiss(acc)
+	bh, bm := billableHitMiss(attempt)
+	// If acc was previously merged, CacheHit+Miss already holds the sum and
+	// PromptTokens may still be the first attempt's value — prefer stored sums.
+	if acc.CacheHitTokens+acc.CacheMissTokens > 0 {
+		ah, am = acc.CacheHitTokens, acc.CacheMissTokens
 	}
-	merged := *retry
-	merged.PromptTokens += first.PromptTokens
-	merged.CompletionTokens += first.CompletionTokens
-	merged.TotalTokens += first.TotalTokens
-	merged.CacheHitTokens += first.CacheHitTokens
-	merged.CacheMissTokens += first.CacheMissTokens
-	merged.ReasoningTokens += first.ReasoningTokens
-	merged.RequestCount = usageRequestCount(first) + usageRequestCount(retry)
+	merged.CacheHitTokens = ah + bh
+	merged.CacheMissTokens = am + bm
+	merged.PromptTokens = billablePrompt(merged.CacheHitTokens, merged.CacheMissTokens, 0)
+	if merged.PromptTokens == 0 {
+		merged.PromptTokens = acc.PromptTokens + attempt.PromptTokens
+	}
+	merged.CompletionTokens += attempt.CompletionTokens
+	merged.ReasoningTokens += attempt.ReasoningTokens
+	merged.TotalTokens += usageTotalTokens(attempt)
+	merged.RequestCount = usageRequestCount(acc) + usageRequestCount(attempt)
+	if attempt.Estimated {
+		merged.Estimated = true
+	}
+	// Zero-token attempts (header failure / cancelled reservation) do not
+	// invalidate prior middleware commits.
+	merged.BudgetAccounted = budgetAccountedOrZero(acc) && budgetAccountedOrZero(attempt)
+	if attempt.FinishReason != "" {
+		merged.FinishReason = attempt.FinishReason
+	}
 	return &merged
+}
+
+// storeLatestRequestUsage records the most recent single-request usage for
+// inputFloor (PromptTokens) and ContextSnapshot (Prompt+Completion). It must
+// never receive a multi-attempt billable aggregate.
+func (a *Agent) storeLatestRequestUsage(attempt *provider.Usage) {
+	if a == nil || attempt == nil {
+		return
+	}
+	// Skip request-only shells with no token shape.
+	if attempt.PromptTokens <= 0 && attempt.CompletionTokens <= 0 && attempt.TotalTokens <= 0 {
+		return
+	}
+	clone := *attempt
+	// RequestCount on lastUsage is not used for context; keep per-attempt value.
+	a.lastUsage.Store(&clone)
+}
+
+// contextUsageFromAttempt is retained for tests that need a prompt-only view.
+func contextUsageFromAttempt(attempt *provider.Usage) *provider.Usage {
+	if attempt == nil {
+		return nil
+	}
+	ctx := *attempt
+	ctx.RequestCount = 0
+	return &ctx
+}
+
+// finalizeSamplingUsage builds the Usage event payload for consumers that
+// expect one coherent billable record:
+//   - PromptTokens / cache hit+miss / Completion / Total / RequestCount: billable aggregate
+//   - ContextPromptTokens: latest attempt prompt (context gauge only)
+//   - BudgetAccounted: every attempt was middleware-settled or zero-token
+func finalizeSamplingUsage(billable, latest *provider.Usage) *provider.Usage {
+	if billable == nil && latest == nil {
+		return nil
+	}
+	if billable == nil {
+		out := *latest
+		if out.ContextPromptTokens <= 0 {
+			out.ContextPromptTokens = out.PromptTokens
+		}
+		out.BudgetAccounted = budgetAccountedOrZero(&out)
+		return &out
+	}
+	out := *billable
+	if latest != nil {
+		out.ContextPromptTokens = latest.PromptTokens
+		if out.ContextPromptTokens <= 0 {
+			// Latest may only carry request-count bookkeeping; keep prior context
+			// from a previous attempt if the aggregate already held one.
+			if billable.ContextPromptTokens > 0 {
+				out.ContextPromptTokens = billable.ContextPromptTokens
+			}
+		}
+		out.FinishReason = latest.FinishReason
+	}
+	// Ensure PromptTokens matches billable input (hit+miss) for CLI/ACP/Desktop
+	// telemetry that requires cache totals to align with PromptTokens.
+	if hitMiss := out.CacheHitTokens + out.CacheMissTokens; hitMiss > 0 {
+		out.PromptTokens = hitMiss
+	}
+	if out.TotalTokens < out.PromptTokens+out.CompletionTokens {
+		out.TotalTokens = out.PromptTokens + out.CompletionTokens
+	}
+	// billable already AND-ed every attempt (treating zero-token as settled).
+	// Do not re-AND against latest alone — that would clear the flag when the
+	// last attempt is a request-only shell or an un-flagged raw mock usage.
+	out.BudgetAccounted = budgetAccountedOrZero(billable)
+	return &out
+}
+
+// mergeStreamUsage remains for missing-reasoning style single-repair merges that
+// need a simple sum. Sampling recovery uses mergeSamplingUsage instead.
+func mergeStreamUsage(first, retry *provider.Usage) *provider.Usage {
+	return mergeSamplingUsage(first, retry)
+}
+
+func usageTotalTokens(u *provider.Usage) int {
+	if u == nil {
+		return 0
+	}
+	if u.TotalTokens > 0 {
+		return u.TotalTokens
+	}
+	return u.PromptTokens + u.CompletionTokens
 }
 
 func usageRequestCount(usage *provider.Usage) int {
@@ -491,8 +832,11 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	if usage == nil || (usage.TotalTokens <= 0 && usage.RequestCount <= 0) {
 		return
 	}
-	if usage.TotalTokens > 0 {
-		a.lastUsage.Store(usage)
+	// lastUsage must stay as the latest single-request shape (set during
+	// sampling recovery). Never overwrite it with a multi-attempt billable
+	// aggregate — that would inflate inputFloor and ContextSnapshot.
+	if a.lastUsage.Load() == nil && usage.PromptTokens > 0 {
+		a.storeLatestRequestUsage(usage)
 	}
 	a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing,
 		UsageSource:      a.usageSource,

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -74,7 +75,7 @@ func TestMergeStreamUsageCountsProviderRequests(t *testing.T) {
 func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
 	billable := &provider.Usage{
 		PromptTokens: 90000, CompletionTokens: 30, TotalTokens: 90030,
-		CacheMissTokens: 90000, RequestCount: 3, BudgetAccounted: true,
+		CacheMissTokens: 90000, RequestCount: 3,
 	}
 	latest := &provider.Usage{PromptTokens: 30000, CompletionTokens: 10, TotalTokens: 30010, CacheMissTokens: 30000, RequestCount: 1}
 	got := finalizeSamplingUsage(billable, latest)
@@ -87,8 +88,8 @@ func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
 	if got.ContextFillTokens() != 30010 {
 		t.Fatalf("ContextFillTokens = %d, want 30010", got.ContextFillTokens())
 	}
-	if got.CompletionTokens != 30 || got.RequestCount != 3 || !got.BudgetAccounted {
-		t.Fatalf("billable fields = %+v, want summed completion/requests and BudgetAccounted", got)
+	if got.CompletionTokens != 30 || got.RequestCount != 3 {
+		t.Fatalf("billable fields = %+v, want summed completion/requests", got)
 	}
 	// lastUsage stores the latest attempt wholesale (prompt+completion of that
 	// request), never the billable aggregate.
@@ -97,26 +98,19 @@ func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
 	}
 }
 
-func TestMergeSamplingUsageZeroTokenDoesNotClearBudgetAccounted(t *testing.T) {
+func TestMergeSamplingUsageKeepsBillableTokensAcrossRequestOnlyAttempt(t *testing.T) {
 	first := &provider.Usage{
 		PromptTokens: 100, CompletionTokens: 0, TotalTokens: 100,
-		CacheMissTokens: 100, RequestCount: 1, BudgetAccounted: true,
+		CacheMissTokens: 100, RequestCount: 1,
 	}
-	// Pre-body failure / cancel: only RequestCount, reservation Cancelled.
-	second := &provider.Usage{RequestCount: 1, BudgetAccounted: false}
+	second := &provider.Usage{RequestCount: 1}
 	got := mergeSamplingUsage(first, second)
-	if got == nil || !got.BudgetAccounted {
-		t.Fatalf("merged = %+v, want BudgetAccounted=true (zero-token attempt is settled)", got)
-	}
 	if got.PromptTokens != 100 || got.TotalTokens != 100 || got.RequestCount != 2 {
 		t.Fatalf("merged billable = %+v, want first tokens + 2 requests", got)
 	}
 	final := finalizeSamplingUsage(got, second)
-	if final == nil || !final.BudgetAccounted {
-		t.Fatalf("finalized = %+v, want BudgetAccounted so Goal sink does not double-count", final)
-	}
-	if final.PromptTokens != 100 {
-		t.Fatalf("final prompt = %d, want billable 100", final.PromptTokens)
+	if final == nil || final.PromptTokens != 100 {
+		t.Fatalf("final usage = %+v, want billable prompt 100", final)
 	}
 }
 
@@ -143,23 +137,22 @@ func TestEstimateFailedAttemptUsageIncludesArgChars(t *testing.T) {
 	}
 }
 
-func TestEstimateFailedAttemptUsageSkipsPreBodyLocalReject(t *testing.T) {
+func TestEstimateFailedAttemptUsageSkipsZeroHTTPLocalFailure(t *testing.T) {
 	frozen := samplingRequest{
 		req: provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}},
 	}
 	result := streamedTurn{
-		err: &provider.RequestBudgetError{Used: 90, Limit: 100, Remaining: 10, EstimatedInput: 20},
+		err: errors.New("local request validation failed"),
 	}
-	// httpRequests=0: exact admission rejected before Provider.Stream.
+	// No HTTP request and no speculative output: do not invent billable usage.
 	got := estimateFailedAttemptUsage(nil, frozen, result, 0)
 	if got != nil {
 		t.Fatalf("pre-body local reject usage = %+v, want nil (no invented billable tokens)", got)
 	}
-	// Aggregate must stay BudgetAccounted when first attempt was settled.
-	first := &provider.Usage{PromptTokens: 100, TotalTokens: 100, CacheMissTokens: 100, RequestCount: 1, BudgetAccounted: true}
+	first := &provider.Usage{PromptTokens: 100, TotalTokens: 100, CacheMissTokens: 100, RequestCount: 1}
 	merged := mergeSamplingUsage(first, got)
-	if merged == nil || !merged.BudgetAccounted || merged.PromptTokens != 100 || merged.RequestCount != 1 {
-		t.Fatalf("merged after pre-body reject = %+v, want first attempt only + BudgetAccounted", merged)
+	if merged == nil || merged.PromptTokens != 100 || merged.RequestCount != 1 {
+		t.Fatalf("merged after local reject = %+v, want first attempt only", merged)
 	}
 }
 

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -38,32 +38,125 @@ func (failedRequestProvider) Stream(ctx context.Context, _ provider.Request) (<-
 }
 
 func TestMergeStreamUsageCountsProviderRequests(t *testing.T) {
-	first := &provider.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}
-	retry := &provider.Usage{PromptTokens: 20, CompletionTokens: 8, TotalTokens: 28}
+	first := &provider.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15, RequestCount: 1}
+	retry := &provider.Usage{PromptTokens: 20, CompletionTokens: 8, TotalTokens: 28, RequestCount: 1}
 	got := mergeStreamUsage(first, retry)
-	if got == nil || got.TotalTokens != 43 || got.RequestCount != 2 {
-		t.Fatalf("merged usage = %+v, want total=43 requests=2", got)
+	if got == nil || got.TotalTokens != 43 || got.RequestCount != 2 || got.CompletionTokens != 13 {
+		t.Fatalf("merged usage = %+v, want total=43 requests=2 completion=13", got)
+	}
+	// Billable PromptTokens align with summed cache hit+miss.
+	if got.CacheMissTokens != 30 || got.PromptTokens != 30 {
+		t.Fatalf("billable input = prompt %d miss %d, want 30/30", got.PromptTokens, got.CacheMissTokens)
 	}
 
-	third := &provider.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2}
+	third := &provider.Usage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2, RequestCount: 1}
 	got = mergeStreamUsage(got, third)
 	if got.RequestCount != 3 {
 		t.Fatalf("nested merged request count = %d, want 3", got.RequestCount)
 	}
 
 	got = mergeStreamUsage(nil, retry)
-	if got == nil || got.TotalTokens != retry.TotalTokens || got.RequestCount != 2 {
-		t.Fatalf("missing first usage = %+v, want retry tokens and 2 requests", got)
+	if got == nil || got.TotalTokens != retry.TotalTokens || got.RequestCount != 1 {
+		t.Fatalf("missing first usage = %+v, want retry tokens and 1 request", got)
 	}
 	got = mergeStreamUsage(first, nil)
-	if got == nil || got.TotalTokens != first.TotalTokens || got.RequestCount != 2 {
-		t.Fatalf("missing retry usage = %+v, want first tokens and 2 requests", got)
+	if got == nil || got.TotalTokens != first.TotalTokens || got.RequestCount != 1 {
+		t.Fatalf("missing retry usage = %+v, want first tokens and 1 request", got)
 	}
 
 	requestOnly := &provider.Usage{RequestCount: 3}
 	got = mergeStreamUsage(first, requestOnly)
-	if got == nil || got.TotalTokens != first.TotalTokens || got.RequestCount != 4 {
-		t.Fatalf("request-only retry usage = %+v, want first tokens and 4 requests", got)
+	if got == nil || got.RequestCount != 4 {
+		t.Fatalf("request-only retry usage = %+v, want 4 requests", got)
+	}
+}
+
+func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
+	billable := &provider.Usage{
+		PromptTokens: 90000, CompletionTokens: 30, TotalTokens: 90030,
+		CacheMissTokens: 90000, RequestCount: 3, BudgetAccounted: true,
+	}
+	latest := &provider.Usage{PromptTokens: 30000, CompletionTokens: 10, TotalTokens: 30010, CacheMissTokens: 30000, RequestCount: 1}
+	got := finalizeSamplingUsage(billable, latest)
+	if got == nil || got.PromptTokens != 90000 {
+		t.Fatalf("prompt tokens = %+v, want billable total 90000", got)
+	}
+	if got.ContextPromptTokens != 30000 {
+		t.Fatalf("context prompt = %d, want latest 30000", got.ContextPromptTokens)
+	}
+	if got.CompletionTokens != 30 || got.RequestCount != 3 || !got.BudgetAccounted {
+		t.Fatalf("billable fields = %+v, want summed completion/requests and BudgetAccounted", got)
+	}
+	// lastUsage stores the latest attempt wholesale (prompt+completion of that
+	// request), never the billable aggregate.
+	if latest.PromptTokens != 30000 || latest.CompletionTokens != 10 {
+		t.Fatalf("latest attempt shape mutated: %+v", latest)
+	}
+}
+
+func TestMergeSamplingUsageZeroTokenDoesNotClearBudgetAccounted(t *testing.T) {
+	first := &provider.Usage{
+		PromptTokens: 100, CompletionTokens: 0, TotalTokens: 100,
+		CacheMissTokens: 100, RequestCount: 1, BudgetAccounted: true,
+	}
+	// Pre-body failure / cancel: only RequestCount, reservation Cancelled.
+	second := &provider.Usage{RequestCount: 1, BudgetAccounted: false}
+	got := mergeSamplingUsage(first, second)
+	if got == nil || !got.BudgetAccounted {
+		t.Fatalf("merged = %+v, want BudgetAccounted=true (zero-token attempt is settled)", got)
+	}
+	if got.PromptTokens != 100 || got.TotalTokens != 100 || got.RequestCount != 2 {
+		t.Fatalf("merged billable = %+v, want first tokens + 2 requests", got)
+	}
+	final := finalizeSamplingUsage(got, second)
+	if final == nil || !final.BudgetAccounted {
+		t.Fatalf("finalized = %+v, want BudgetAccounted so Goal sink does not double-count", final)
+	}
+	if final.PromptTokens != 100 {
+		t.Fatalf("final prompt = %d, want billable 100", final.PromptTokens)
+	}
+}
+
+func TestEstimateFailedAttemptUsageIncludesArgChars(t *testing.T) {
+	frozen := samplingRequest{
+		req: provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "write a large file"}}},
+	}
+	// ~8KB of streamed tool args with no terminal usage.
+	result := streamedTurn{
+		maxArgChars: 8192,
+		err:         &provider.StreamInterruptedError{Err: io.ErrUnexpectedEOF, Reason: provider.StreamInterruptPrematureEOF},
+		interrupted: true,
+	}
+	got := estimateFailedAttemptUsage(nil, frozen, result, 1)
+	if got == nil || !got.Estimated {
+		t.Fatalf("usage = %+v, want estimated failed-attempt record", got)
+	}
+	argTokens := (8192 + 3) / 4
+	if got.CompletionTokens < argTokens {
+		t.Fatalf("completion tokens = %d, want at least arg estimate %d", got.CompletionTokens, argTokens)
+	}
+	if got.PromptTokens <= 0 {
+		t.Fatalf("prompt tokens = %d, want request input estimate", got.PromptTokens)
+	}
+}
+
+func TestEstimateFailedAttemptUsageSkipsPreBodyLocalReject(t *testing.T) {
+	frozen := samplingRequest{
+		req: provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}},
+	}
+	result := streamedTurn{
+		err: &provider.RequestBudgetError{Used: 90, Limit: 100, Remaining: 10, EstimatedInput: 20},
+	}
+	// httpRequests=0: exact admission rejected before Provider.Stream.
+	got := estimateFailedAttemptUsage(nil, frozen, result, 0)
+	if got != nil {
+		t.Fatalf("pre-body local reject usage = %+v, want nil (no invented billable tokens)", got)
+	}
+	// Aggregate must stay BudgetAccounted when first attempt was settled.
+	first := &provider.Usage{PromptTokens: 100, TotalTokens: 100, CacheMissTokens: 100, RequestCount: 1, BudgetAccounted: true}
+	merged := mergeSamplingUsage(first, got)
+	if merged == nil || !merged.BudgetAccounted || merged.PromptTokens != 100 || merged.RequestCount != 1 {
+		t.Fatalf("merged after pre-body reject = %+v, want first attempt only + BudgetAccounted", merged)
 	}
 }
 
@@ -72,7 +165,7 @@ func TestStreamReturnsRequestOnlyUsageOnProviderFailure(t *testing.T) {
 	sink := event.FuncSink(func(e event.Event) { events = append(events, e) })
 	a := New(failedRequestProvider{}, tool.NewRegistry(), NewSession(""), Options{ModelRef: "failed/model"}, sink)
 
-	_, _, _, _, _, _, _, usage, _, _, _, err := a.stream(context.Background(), 1, sink)
+	_, _, _, _, _, _, _, usage, _, _, _, _, err := a.stream(context.Background(), 1, sink)
 	if err == nil {
 		t.Fatal("expected provider failure")
 	}

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -81,8 +81,11 @@ func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
 	if got == nil || got.PromptTokens != 90000 {
 		t.Fatalf("prompt tokens = %+v, want billable total 90000", got)
 	}
-	if got.ContextPromptTokens != 30000 {
-		t.Fatalf("context prompt = %d, want latest 30000", got.ContextPromptTokens)
+	if got.ContextPromptTokens != 30000 || got.ContextCompletionTokens != 10 {
+		t.Fatalf("context shape = prompt %d completion %d, want latest 30000/10", got.ContextPromptTokens, got.ContextCompletionTokens)
+	}
+	if got.ContextFillTokens() != 30010 {
+		t.Fatalf("ContextFillTokens = %d, want 30010", got.ContextFillTokens())
 	}
 	if got.CompletionTokens != 30 || got.RequestCount != 3 || !got.BudgetAccounted {
 		t.Fatalf("billable fields = %+v, want summed completion/requests and BudgetAccounted", got)

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4253,6 +4253,18 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.retryMax = e.RetryMax
 		return
 	}
+	if e.Kind == event.StreamAttempt {
+		// Body-phase replay: clear any in-progress tool presentation and surface
+		// a reconnect marker. Text already in terminal scrollback is left as-is.
+		if e.StreamAttempt.Action == event.StreamAttemptDiscard {
+			m.toolPartial = ""
+			m.toolTail = nil
+			m.toolStreamIdx = -1
+			m.toolLineCount = 0
+			m.commitLine(dim("  ↻ stream interrupted — reconnecting…"))
+		}
+		return
+	}
 	// Any other event means the connection got past the retry window (or the turn
 	// ended), so the transient "retrying" indicator clears.
 	m.retryAttempt = 0

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -102,10 +102,43 @@ const (
 	// extension sidecar (Extension payload with Status set). Appended last to
 	// keep the Kind values before it wire-stable.
 	ExtensionStatus
+	// StreamAttempt marks the local lifecycle of one sampling attempt within a
+	// model round (StreamAttempt payload: begin | discard | commit). IDs are
+	// host-local only — never persisted or sent to the model. Appended last to
+	// keep earlier Kind values wire-stable; older clients ignore unknown kinds.
+	StreamAttempt
 	// KindCount is a sentinel one past the last real Kind. New event kinds must
 	// be inserted above it so completeness tests cover them automatically.
 	KindCount
 )
+
+// StreamAttemptAction is the lifecycle phase of a local sampling attempt.
+type StreamAttemptAction string
+
+const (
+	StreamAttemptBegin   StreamAttemptAction = "begin"
+	StreamAttemptDiscard StreamAttemptAction = "discard"
+	StreamAttemptCommit  StreamAttemptAction = "commit"
+)
+
+// RetryScope distinguishes connection+header retries from body-phase stream
+// retries. Older clients ignore the empty/unknown value.
+type RetryScope string
+
+const (
+	RetryScopeHeaders RetryScope = "headers"
+	RetryScopeStream  RetryScope = "stream"
+)
+
+// StreamAttemptInfo carries host-local bookkeeping for one sampling attempt.
+// Reason is a fixed enum (connection_reset | premature_eof | idle_timeout).
+type StreamAttemptInfo struct {
+	ID      string
+	Action  StreamAttemptAction
+	Attempt int // 1-based attempt number
+	Max     int // total attempts including the first (typically 6)
+	Reason  string
+}
 
 const TurnOutcomeFinalReadiness = "final_readiness"
 
@@ -175,6 +208,11 @@ type Tool struct {
 	// sub-agent's calls carry the parent `task` call's ID so a frontend can nest
 	// them under it. Empty for top-level calls.
 	ParentID string
+	// AttemptID is the host-local stream_attempt id that produced a speculative
+	// partial ToolDispatch. Empty for committed/full dispatches and for nested
+	// sub-agent tools. Frontends must only journal partial events whose
+	// AttemptID matches the active stream_attempt begin.
+	AttemptID string
 	FileDiff
 	Profile *Profile // ToolDispatch: subagent model/effort (set for task/skill calls)
 }
@@ -465,6 +503,8 @@ type Event struct {
 	DecisionReceipt *provider.DecisionReceipt // Notice: durable user decision receipt
 	RetryAttempt    int                       // Retrying: 1-based attempt about to be made
 	RetryMax        int                       // Retrying: total attempts before giving up
+	RetryScope      RetryScope                // Retrying: optional "headers" | "stream"; empty for older emitters
+	StreamAttempt   StreamAttemptInfo         // StreamAttempt lifecycle
 }
 
 // ReadinessAuditSink is an optional sink capability. Sinks that do not care

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -32,6 +32,17 @@ type Event struct {
 	Readiness       *FinalReadiness   `json:"readiness,omitempty"`
 	RetryAttempt    int               `json:"retryAttempt,omitempty"`
 	RetryMax        int               `json:"retryMax,omitempty"`
+	RetryScope      string            `json:"retryScope,omitempty"` // "headers" | "stream"; omit for older clients
+	StreamAttempt   *StreamAttempt    `json:"streamAttempt,omitempty"`
+}
+
+// StreamAttempt is the JSON form of event.StreamAttemptInfo.
+type StreamAttempt struct {
+	ID      string `json:"id"`
+	Action  string `json:"action"` // begin | discard | commit
+	Attempt int    `json:"attempt,omitempty"`
+	Max     int    `json:"max,omitempty"`
+	Reason  string `json:"reason,omitempty"` // connection_reset | premature_eof | idle_timeout
 }
 
 // ToWire converts a typed runtime event into the shared frontend JSON contract.
@@ -59,8 +70,8 @@ func ToWire(e event.Event) Event {
 			ReadOnly: e.Tool.ReadOnly, Truncated: e.Tool.Truncated,
 			DurationMs: e.Tool.DurationMs, Partial: e.Tool.Partial,
 			ArgChars: e.Tool.ArgChars, Refreshed: e.Tool.Refreshed,
-			ParentID: e.Tool.ParentID,
-			Diff:     e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
+			ParentID: e.Tool.ParentID, AttemptID: e.Tool.AttemptID,
+			Diff: e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
 		}
 		if e.Tool.Profile != nil {
 			wt.Profile = &Profile{Model: e.Tool.Profile.Model, Effort: e.Tool.Profile.Effort}
@@ -74,6 +85,7 @@ func ToWire(e event.Event) Event {
 				CacheMissTokens: u.CacheMissTokens, ReasoningTokens: u.ReasoningTokens,
 				Estimated:             u.Estimated,
 				Source:                e.UsageSource,
+				ContextPromptTokens:   u.ContextPromptTokens,
 				SessionCacheHitTokens: e.SessionHit, SessionCacheMissTokens: e.SessionMiss,
 			}
 			if e.CacheDiagnostics != nil {
@@ -131,6 +143,17 @@ func ToWire(e event.Event) Event {
 	case event.Retrying:
 		w.RetryAttempt = e.RetryAttempt
 		w.RetryMax = e.RetryMax
+		if e.RetryScope != "" {
+			w.RetryScope = string(e.RetryScope)
+		}
+	case event.StreamAttempt:
+		w.StreamAttempt = &StreamAttempt{
+			ID:      e.StreamAttempt.ID,
+			Action:  string(e.StreamAttempt.Action),
+			Attempt: e.StreamAttempt.Attempt,
+			Max:     e.StreamAttempt.Max,
+			Reason:  e.StreamAttempt.Reason,
+		}
 	}
 	return w
 }
@@ -236,6 +259,7 @@ type Tool struct {
 	ArgChars     int      `json:"argChars,omitempty"`
 	Refreshed    bool     `json:"refreshed,omitempty"`
 	ParentID     string   `json:"parentId,omitempty"`
+	AttemptID    string   `json:"attemptId,omitempty"` // host-local stream_attempt id for speculative partials
 	Diff         string   `json:"diff,omitempty" externalizable:"true"`
 	Added        int      `json:"added,omitempty"`
 	Removed      int      `json:"removed,omitempty"`
@@ -256,8 +280,11 @@ type Usage struct {
 	// Session-cumulative cache tokens keep status displays steadier than one-turn values.
 	SessionCacheHitTokens  int     `json:"sessionCacheHitTokens"`
 	SessionCacheMissTokens int     `json:"sessionCacheMissTokens"`
-	Cost                   float64 `json:"cost,omitempty"`
-	Currency               string  `json:"currency,omitempty"`
+	// ContextPromptTokens is the latest single-request prompt size for gauges.
+	// When omitted, clients fall back to promptTokens (billable input total).
+	ContextPromptTokens int     `json:"contextPromptTokens,omitempty"`
+	Cost                float64 `json:"cost,omitempty"`
+	Currency            string  `json:"currency,omitempty"`
 	// CostUSD is a compatibility alias for older consumers; it mirrors Cost.
 	CostUSD float64 `json:"costUsd,omitempty"`
 }
@@ -415,6 +442,7 @@ var kindNames = map[event.Kind]string{
 	event.GuardianAssessment: "guardian_assessment",
 	event.ExtensionSurface:   "extension_surface",
 	event.ExtensionStatus:    "extension_status",
+	event.StreamAttempt:      "stream_attempt",
 }
 
 // ExtensionSurface is the JSON form of an event.ExtensionSurfacePayload.

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -83,10 +83,14 @@ func ToWire(e event.Event) Event {
 				PromptTokens: u.PromptTokens, CompletionTokens: u.CompletionTokens,
 				TotalTokens: u.TotalTokens, CacheHitTokens: u.CacheHitTokens,
 				CacheMissTokens: u.CacheMissTokens, ReasoningTokens: u.ReasoningTokens,
-				Estimated:             u.Estimated,
-				Source:                e.UsageSource,
-				ContextPromptTokens:   u.ContextPromptTokens,
-				SessionCacheHitTokens: e.SessionHit, SessionCacheMissTokens: e.SessionMiss,
+				Estimated:               u.Estimated,
+				Source:                  e.UsageSource,
+				ContextPromptTokens:     u.ContextPromptTokens,
+				ContextCompletionTokens: u.ContextCompletionTokens,
+				ContextReasoningTokens:  u.ContextReasoningTokens,
+				ContextCacheHitTokens:   u.ContextCacheHitTokens,
+				ContextCacheMissTokens:  u.ContextCacheMissTokens,
+				SessionCacheHitTokens:   e.SessionHit, SessionCacheMissTokens: e.SessionMiss,
 			}
 			if e.CacheDiagnostics != nil {
 				w.Usage.CacheDiagnostics = ToWireCacheDiagnostics(e.CacheDiagnostics)
@@ -278,13 +282,17 @@ type Usage struct {
 	Source           string            `json:"source,omitempty"`
 	CacheDiagnostics *CacheDiagnostics `json:"cacheDiagnostics,omitempty"`
 	// Session-cumulative cache tokens keep status displays steadier than one-turn values.
-	SessionCacheHitTokens  int     `json:"sessionCacheHitTokens"`
-	SessionCacheMissTokens int     `json:"sessionCacheMissTokens"`
-	// ContextPromptTokens is the latest single-request prompt size for gauges.
-	// When omitted, clients fall back to promptTokens (billable input total).
-	ContextPromptTokens int     `json:"contextPromptTokens,omitempty"`
-	Cost                float64 `json:"cost,omitempty"`
-	Currency            string  `json:"currency,omitempty"`
+	SessionCacheHitTokens  int `json:"sessionCacheHitTokens"`
+	SessionCacheMissTokens int `json:"sessionCacheMissTokens"`
+	// Context* fields are the latest single-request shape for gauges/rebind.
+	// When omitted, clients fall back to the billable prompt/completion totals.
+	ContextPromptTokens     int     `json:"contextPromptTokens,omitempty"`
+	ContextCompletionTokens int     `json:"contextCompletionTokens,omitempty"`
+	ContextReasoningTokens  int     `json:"contextReasoningTokens,omitempty"`
+	ContextCacheHitTokens   int     `json:"contextCacheHitTokens,omitempty"`
+	ContextCacheMissTokens  int     `json:"contextCacheMissTokens,omitempty"`
+	Cost                    float64 `json:"cost,omitempty"`
+	Currency                string  `json:"currency,omitempty"`
 	// CostUSD is a compatibility alias for older consumers; it mirrors Cost.
 	CostUSD float64 `json:"costUsd,omitempty"`
 }

--- a/internal/eventwire/wire_test.go
+++ b/internal/eventwire/wire_test.go
@@ -14,15 +14,34 @@ import (
 )
 
 func TestToWireRetryingJSON(t *testing.T) {
-	w := ToWire(event.Event{Kind: event.Retrying, RetryAttempt: 3, RetryMax: 10})
+	w := ToWire(event.Event{Kind: event.Retrying, RetryAttempt: 3, RetryMax: 10, RetryScope: event.RetryScopeStream})
 	b, err := json.Marshal(w)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	s := string(b)
-	for _, want := range []string{`"kind":"retrying"`, `"retryAttempt":3`, `"retryMax":10`} {
+	for _, want := range []string{`"kind":"retrying"`, `"retryAttempt":3`, `"retryMax":10`, `"retryScope":"stream"`} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("retrying JSON = %s, want it to contain %s", s, want)
+		}
+	}
+}
+
+func TestToWireStreamAttemptJSON(t *testing.T) {
+	w := ToWire(event.Event{
+		Kind: event.StreamAttempt,
+		StreamAttempt: event.StreamAttemptInfo{
+			ID: "sa-1", Action: event.StreamAttemptDiscard, Attempt: 2, Max: 6, Reason: "connection_reset",
+		},
+	})
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, want := range []string{`"kind":"stream_attempt"`, `"id":"sa-1"`, `"action":"discard"`, `"attempt":2`, `"max":6`, `"reason":"connection_reset"`} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("stream_attempt JSON = %s, want it to contain %s", s, want)
 		}
 	}
 }
@@ -101,6 +120,11 @@ func TestDesktopWireEventTypeCoversSharedPayloadFields(t *testing.T) {
 		`outcome?: "final_readiness" | "recovery_paused";`,
 		"retryAttempt?: number;",
 		"retryMax?: number;",
+		"retryScope?:",
+		"streamAttempt?: WireStreamAttempt;",
+		"export interface WireStreamAttempt",
+		"attemptId?: string;",
+		"contextPromptTokens?: number;",
 		"memoryCitations?: MemoryCitation[];",
 		"export interface MemoryCitation",
 		"resolvedName?: string;",

--- a/internal/eventwire/wire_test.go
+++ b/internal/eventwire/wire_test.go
@@ -125,6 +125,7 @@ func TestDesktopWireEventTypeCoversSharedPayloadFields(t *testing.T) {
 		"export interface WireStreamAttempt",
 		"attemptId?: string;",
 		"contextPromptTokens?: number;",
+		"contextCompletionTokens?: number;",
 		"memoryCitations?: MemoryCitation[];",
 		"export interface MemoryCitation",
 		"resolvedName?: string;",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -526,7 +526,6 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	var inTok, outTok, cacheCreate, cacheRead int
 	var stopReason string
 	haveUsage := false
-	sawMessageStop := false
 	mergeUsage := func(usage *wireUsage) {
 		if usage == nil {
 			return
@@ -650,7 +649,6 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 			// without this, the attempt stays speculative and is not committed.
 			// Stop reading immediately so a post-terminal connection reset cannot
 			// reclassify a complete response as interrupted.
-			sawMessageStop = true
 			goto finalize
 		case "error":
 			msg := "stream error"
@@ -681,11 +679,11 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	}
 	// EOF / clean close before message_stop is an uncommitted attempt. Complete
 	// ChunkToolCall blocks that arrived earlier remain speculative.
-	if !sawMessageStop {
-		err := fmt.Errorf("%s: stream ended before message_stop: %w", c.name, io.ErrUnexpectedEOF)
-		send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, provider.StreamInterruptPrematureEOF)})
-		return
-	}
+	send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(
+		fmt.Errorf("%s: stream ended before message_stop: %w", c.name, io.ErrUnexpectedEOF),
+		provider.StreamInterruptPrematureEOF,
+	)})
+	return
 
 finalize:
 	if haveUsage {

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -525,6 +526,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	var inTok, outTok, cacheCreate, cacheRead int
 	var stopReason string
 	haveUsage := false
+	sawMessageStop := false
 	mergeUsage := func(usage *wireUsage) {
 		if usage == nil {
 			return
@@ -644,7 +646,12 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 			}
 			mergeUsage(ev.Usage)
 		case "message_stop":
-			// Stream complete; fall through to finalize below.
+			// Anthropic's terminal event. Tool blocks may already have closed;
+			// without this, the attempt stays speculative and is not committed.
+			// Stop reading immediately so a post-terminal connection reset cannot
+			// reclassify a complete response as interrupted.
+			sawMessageStop = true
+			goto finalize
 		case "error":
 			msg := "stream error"
 			if ev.Error != nil && ev.Error.Message != "" {
@@ -659,14 +666,28 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		return
 	}
 	if stalled.Load() {
-		send(provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)})
+		err := fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)
+		send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, provider.StreamInterruptIdleTimeout)})
 		return
 	}
 	if err := scanner.Err(); err != nil {
-		send(provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: read stream: %w", c.name, err)})
+		wrapped := fmt.Errorf("%s: read stream: %w", c.name, err)
+		if provider.IsConnReset(err) {
+			send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(wrapped, provider.ClassifyStreamInterrupt(err))})
+			return
+		}
+		send(provider.Chunk{Type: provider.ChunkError, Err: wrapped})
+		return
+	}
+	// EOF / clean close before message_stop is an uncommitted attempt. Complete
+	// ChunkToolCall blocks that arrived earlier remain speculative.
+	if !sawMessageStop {
+		err := fmt.Errorf("%s: stream ended before message_stop: %w", c.name, io.ErrUnexpectedEOF)
+		send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, provider.StreamInterruptPrematureEOF)})
 		return
 	}
 
+finalize:
 	if haveUsage {
 		usage := &provider.Usage{
 			PromptTokens:     inTok + cacheCreate + cacheRead,

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -381,6 +381,92 @@ func TestReadStream(t *testing.T) {
 	}
 }
 
+// TestReadStreamIgnoresTransportErrorAfterMessageStop: a complete stream that
+// already received message_stop must finalize successfully even if the
+// connection resets while draining the rest of the body.
+func TestReadStreamIgnoresTransportErrorAfterMessageStop(t *testing.T) {
+	// message_stop arrives; the body then ends abruptly. We must not surface
+	// StreamInterruptedError after a clean terminal.
+	pr, pw := io.Pipe()
+	go func() {
+		_, _ = io.WriteString(pw, `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":5}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`)
+		// Simulate a post-terminal reset while the client might still be reading.
+		_ = pw.CloseWithError(io.ErrUnexpectedEOF)
+	}()
+	c := &client{name: "anthropic"}
+	resp := &http.Response{Body: pr}
+	ch := make(chan provider.Chunk)
+	go c.readStream(context.Background(), resp, ch)
+
+	var text strings.Builder
+	var sawDone, sawErr bool
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkText:
+			text.WriteString(ck.Text)
+		case provider.ChunkDone:
+			sawDone = true
+		case provider.ChunkError:
+			sawErr = true
+			t.Fatalf("post-terminal transport error must not surface: %v", ck.Err)
+		}
+	}
+	if text.String() != "ok" || !sawDone || sawErr {
+		t.Fatalf("text=%q done=%v err=%v", text.String(), sawDone, sawErr)
+	}
+}
+
+// TestReadStreamRequiresMessageStop: EOF after a complete tool block but before
+// message_stop must surface StreamInterruptedError so the attempt stays
+// uncommitted (tool calls remain speculative).
+func TestReadStreamRequiresMessageStop(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"bash"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"ls\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+`
+	c := &client{name: "anthropic"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sse))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(context.Background(), resp, ch)
+
+	var gotInterrupted bool
+	var sawDone bool
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkDone:
+			sawDone = true
+		case provider.ChunkError:
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(ck.Err, &interrupted)
+		}
+	}
+	if sawDone {
+		t.Fatal("must not emit ChunkDone without message_stop")
+	}
+	if !gotInterrupted {
+		t.Fatal("EOF before message_stop must surface StreamInterruptedError")
+	}
+}
+
 // LongCat's Anthropic-compatible SSE stream can omit message_start.usage and
 // report the complete usage object in message_delta. Those input/cache counters
 // must not disappear from Reasonix metrics and billing estimates.

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -519,7 +520,10 @@ func (c *client) openStream(ctx context.Context, targetURL string, wireReq chatR
 	c.authed.Store(true)
 
 	out := make(chan provider.Chunk)
-	go c.streamWithReconnect(requestCtx, resp, newReq, out)
+	// Body-phase stream cuts surface as StreamInterruptedError so the Agent
+	// can replay the exact frozen request. Connection+header retries stay in
+	// SendWithRetry; providers must not stack a second body-retry budget.
+	go c.streamOnce(requestCtx, resp, out)
 	return out, nil
 }
 
@@ -645,41 +649,24 @@ func usageRequestCount(usage *provider.Usage) int {
 	return 1
 }
 
-// maxStreamReconnects bounds how many times a mid-stream connection drop is
-// replayed from scratch before the error is surfaced — each replay re-runs the
-// whole request (cheap under prompt caching, but not free).
-const maxStreamReconnects = 3
-
-// streamWithReconnect drives readStream and, when the connection is cut before
-// any model output has been forwarded, replays the request rather than failing
-// the turn. Once a token (reasoning/text/tool-call) has been emitted, a replay
-// would duplicate output, so the error is surfaced instead.
-func (c *client) streamWithReconnect(ctx context.Context, resp *http.Response, newReq func(context.Context) (*http.Request, error), out chan<- provider.Chunk) {
+// streamOnce drives a single body read. Mid-stream transport cuts become
+// StreamInterruptedError so the Agent can commit-or-replay; providers no longer
+// replay the body themselves (that would stack retry budgets with the Agent).
+func (c *client) streamOnce(ctx context.Context, resp *http.Response, out chan<- provider.Chunk) {
 	defer close(out)
-	for attempt := 0; ; attempt++ {
-		emitted, err := c.readStream(ctx, resp, out)
-		if err == nil {
-			return
-		}
-		if !provider.IsConnReset(err) {
-			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
-			return
-		}
-		if emitted {
-			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: &provider.StreamInterruptedError{Err: err}})
-			return
-		}
-		if attempt >= maxStreamReconnects {
-			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
-			return
-		}
-		next, rerr := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
-		if rerr != nil {
-			sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: rerr})
-			return
-		}
-		resp = next
+	_, err := c.readStream(ctx, resp, out)
+	if err == nil {
+		return
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
+		return
+	}
+	if provider.IsConnReset(err) {
+		sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, provider.ClassifyStreamInterrupt(err))})
+		return
+	}
+	sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: err})
 }
 
 func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Chunk) bool {
@@ -1083,12 +1070,8 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		return emitted, err
 	}
 	if stalled.Load() {
-		// Wrap io.ErrUnexpectedEOF so streamWithReconnect treats a half-open
-		// stall — a proxy that drops silently mid-stream with no FIN/RST, the
-		// watchdog's primary target — as recoverable, identical to the clean-FIN
-		// idle-close just below. Without it the stall bypasses reconnect and
-		// hard-fails the turn instead of replaying (pre-output) or surfacing a
-		// retryable StreamInterruptedError (post-output).
+		// Idle stall is a body-phase cut: wrap so the Agent can replay the
+		// frozen request. Providers no longer reconnect here.
 		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped: %w", c.name, idleTimeout, io.ErrUnexpectedEOF)
 	}
 	if err := scanner.Err(); err != nil {
@@ -1096,7 +1079,8 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	}
 	// A proxy that idle-closes with a clean FIN ends the scan with no error. Without
 	// this check the turn would be committed as complete — including half-streamed
-	// tool-call arguments, which then 400 on every replay (#3953).
+	// tool-call arguments, which then 400 on every replay (#3953). OpenAI Chat
+	// accepts either [DONE] or a legal finish_reason as a complete terminal.
 	if !sawDone && lastFinishReason == "" {
 		return emitted, fmt.Errorf("%s: stream ended before completion: %w", c.name, io.ErrUnexpectedEOF)
 	}

--- a/internal/provider/openai/reconnect_test.go
+++ b/internal/provider/openai/reconnect_test.go
@@ -37,22 +37,14 @@ func rstAfter(t *testing.T, w http.ResponseWriter, prelude string) {
 	_ = conn.Close()
 }
 
-// TestStreamReconnectsOnEarlyConnReset reproduces issue #3148: a local proxy
-// (v2rayN/sing-box) forcibly closes the idle SSE connection during a reasoner's
-// first-token gap, before any token is emitted. The drop must be replayed
-// transparently — the caller sees one clean stream, never an error.
-func TestStreamReconnectsOnEarlyConnReset(t *testing.T) {
+// TestStreamSurfacesEarlyConnResetAsInterrupt moves body-phase replay to the
+// Agent: a pre-output connection reset is StreamInterruptedError, not an
+// in-provider transparent reconnect (avoids stacked retry budgets).
+func TestStreamSurfacesEarlyConnResetAsInterrupt(t *testing.T) {
 	var reqs int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqs++
-		if reqs == 1 {
-			rstAfter(t, w, ": keep-alive\n\n") // a comment line, zero model output
-			return
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n")
-		_, _ = io.WriteString(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":2,\"completion_tokens\":1,\"total_tokens\":3}}\n\n")
-		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		rstAfter(t, w, ": keep-alive\n\n") // a comment line, zero model output
 	}))
 	defer srv.Close()
 
@@ -65,27 +57,18 @@ func TestStreamReconnectsOnEarlyConnReset(t *testing.T) {
 		t.Fatalf("Stream: %v", err)
 	}
 
-	var text strings.Builder
-	var usage *provider.Usage
+	var gotInterrupted bool
 	for chunk := range ch {
 		if chunk.Type == provider.ChunkError {
-			t.Fatalf("early conn reset should be replayed, not surfaced: %v", chunk.Err)
-		}
-		if chunk.Type == provider.ChunkText {
-			text.WriteString(chunk.Text)
-		}
-		if chunk.Type == provider.ChunkUsage {
-			usage = chunk.Usage
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(chunk.Err, &interrupted)
 		}
 	}
-	if text.String() != "recovered" {
-		t.Errorf("text = %q, want %q", text.String(), "recovered")
+	if !gotInterrupted {
+		t.Error("early conn reset must surface as StreamInterruptedError for Agent replay")
 	}
-	if reqs != 2 {
-		t.Errorf("server saw %d requests, want 2 (one reset + one replay)", reqs)
-	}
-	if usage == nil || usage.RequestCount != 2 {
-		t.Errorf("usage request count = %+v, want 2", usage)
+	if reqs != 1 {
+		t.Errorf("server saw %d requests, want 1 (no provider body replay)", reqs)
 	}
 }
 
@@ -139,20 +122,14 @@ func TestStreamCancelDoesNotReconnect(t *testing.T) {
 
 // TestStreamTreatsCleanEOFWithoutDoneAsCut reproduces issue #3953: a proxy that
 // idle-closes the SSE connection with a clean FIN ends the scan with no error,
-// which used to commit the turn as complete — including half-streamed tool-call
-// arguments that then 400 on every replay. Before output, the cut must be
-// replayed; the caller sees one clean stream with the full tool call.
+// which used to commit the turn as complete. Body-phase cuts surface as
+// StreamInterruptedError so the Agent can replay the frozen request.
 func TestStreamTreatsCleanEOFWithoutDoneAsCut(t *testing.T) {
 	var reqs int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqs++
 		w.Header().Set("Content-Type", "text/event-stream")
-		if reqs == 1 {
-			_, _ = io.WriteString(w, ": keep-alive\n\n") // clean close, no [DONE], no finish_reason
-			return
-		}
-		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"cmd\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n")
-		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		_, _ = io.WriteString(w, ": keep-alive\n\n") // clean close, no [DONE], no finish_reason
 	}))
 	defer srv.Close()
 
@@ -165,20 +142,21 @@ func TestStreamTreatsCleanEOFWithoutDoneAsCut(t *testing.T) {
 		t.Fatalf("Stream: %v", err)
 	}
 
-	var call *provider.ToolCall
+	var gotInterrupted bool
 	for chunk := range ch {
 		switch chunk.Type {
-		case provider.ChunkError:
-			t.Fatalf("clean EOF before output should be replayed, not surfaced: %v", chunk.Err)
 		case provider.ChunkToolCall:
-			call = chunk.ToolCall
+			t.Fatalf("incomplete stream must not emit tool calls: %+v", chunk.ToolCall)
+		case provider.ChunkError:
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(chunk.Err, &interrupted)
 		}
 	}
-	if call == nil || call.Arguments != `{"cmd": "ls"}` {
-		t.Errorf("tool call = %+v, want complete arguments from the replay", call)
+	if !gotInterrupted {
+		t.Error("clean EOF before terminal must surface as StreamInterruptedError")
 	}
-	if reqs != 2 {
-		t.Errorf("server saw %d requests, want 2 (one cut + one replay)", reqs)
+	if reqs != 1 {
+		t.Errorf("server saw %d requests, want 1 (no provider body replay)", reqs)
 	}
 }
 

--- a/internal/provider/openai/stall_recover_test.go
+++ b/internal/provider/openai/stall_recover_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,32 +14,24 @@ import (
 	"reasonix/internal/provider"
 )
 
-// TestStreamStallRecoversViaReconnect exercises the watchdog's primary target:
+// TestStreamStallSurfacesAsInterrupt exercises the watchdog's primary target:
 // a proxy that drops a long-lived SSE connection silently mid-stream (no FIN,
-// no RST) during a reasoner's first-token gap, before any model output. The
-// stall must be treated as recoverable and replayed — like a clean idle-close —
-// not surfaced as a hard failure. Before the fix the stall error was plain and
-// bypassed streamWithReconnect, so this test would fail with a "stalled" error.
-func TestStreamStallRecoversViaReconnect(t *testing.T) {
+// no RST) during a reasoner's first-token gap. Body-phase cuts surface as
+// StreamInterruptedError so the Agent can replay the frozen request — providers
+// no longer stack a second reconnect budget.
+func TestStreamStallSurfacesAsInterrupt(t *testing.T) {
 	release := make(chan struct{})
 	var reqs atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if reqs.Add(1) == 1 {
-			// First connection: one keep-alive comment (resets the watchdog
-			// once) then total silence — a half-open connection that never
-			// delivers data and never closes.
-			w.Header().Set("Content-Type", "text/event-stream")
-			w.WriteHeader(http.StatusOK)
-			flush(w)
-			_, _ = io.WriteString(w, ": keep-alive\n\n")
-			flush(w)
-			<-release
-			return
-		}
-		// Reconnect serves a complete stream.
+		reqs.Add(1)
+		// One keep-alive comment (resets the watchdog once) then total silence —
+		// a half-open connection that never delivers data and never closes.
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n")
-		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		w.WriteHeader(http.StatusOK)
+		flush(w)
+		_, _ = io.WriteString(w, ": keep-alive\n\n")
+		flush(w)
+		<-release
 	}))
 	defer srv.Close()
 	defer close(release)
@@ -53,20 +46,18 @@ func TestStreamStallRecoversViaReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stream: %v", err)
 	}
-	var text strings.Builder
+	var gotInterrupted bool
 	for chunk := range ch {
 		if chunk.Type == provider.ChunkError {
-			t.Fatalf("a pre-output half-open stall should reconnect, not surface: %v", chunk.Err)
-		}
-		if chunk.Type == provider.ChunkText {
-			text.WriteString(chunk.Text)
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(chunk.Err, &interrupted)
 		}
 	}
-	if got := text.String(); got != "recovered" {
-		t.Errorf("text = %q, want %q (stall should have triggered a reconnect)", got, "recovered")
+	if !gotInterrupted {
+		t.Error("half-open stall must surface as StreamInterruptedError for Agent replay")
 	}
-	if got := reqs.Load(); got != 2 {
-		t.Errorf("server saw %d requests, want 2 (one stall + one replay)", got)
+	if got := reqs.Load(); got != 1 {
+		t.Errorf("server saw %d requests, want 1 (no provider body replay)", got)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -699,11 +699,41 @@ type Usage struct {
 	// aggregate. Zero means one request for backward compatibility. Recovery
 	// paths that merge multiple attempts set the exact count.
 	RequestCount int
-	// ContextPromptTokens is the latest single-request prompt size used for
-	// context gauges. When zero, consumers fall back to PromptTokens. Multi-
-	// attempt sampling recovery sets PromptTokens to the billable input sum
-	// and ContextPromptTokens to the final attempt's prompt.
-	ContextPromptTokens int
+	// Context* fields describe the latest single-request shape for context
+	// gauges and rebind telemetry. When zero, consumers fall back to the
+	// billable Prompt/Completion/… fields. Multi-attempt sampling recovery
+	// sets PromptTokens (etc.) to the billable aggregate and fills Context*
+	// from the final attempt only.
+	ContextPromptTokens     int
+	ContextCompletionTokens int
+	ContextReasoningTokens  int
+	ContextCacheHitTokens   int
+	ContextCacheMissTokens  int
+}
+
+// ContextFillTokens returns the latest-attempt context fill (prompt+completion)
+// used by status bars and context panels. Falls back to billable totals when
+// no Context* fields were set (single-attempt / legacy usage events).
+func (u *Usage) ContextFillTokens() int {
+	if u == nil {
+		return 0
+	}
+	if u.ContextPromptTokens > 0 || u.ContextCompletionTokens > 0 {
+		return u.ContextPromptTokens + u.ContextCompletionTokens
+	}
+	return u.PromptTokens + u.CompletionTokens
+}
+
+// ContextPromptForGauge returns the latest-attempt prompt size for context
+// displays. Falls back to PromptTokens when ContextPromptTokens is unset.
+func (u *Usage) ContextPromptForGauge() int {
+	if u == nil {
+		return 0
+	}
+	if u.ContextPromptTokens > 0 {
+		return u.ContextPromptTokens
+	}
+	return u.PromptTokens
 }
 
 // Pricing is a provider's per-1M-token rates, used to estimate spend. Currency

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,8 +11,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"sort"
 	"strings"
+	"syscall"
 	"unicode"
 
 	"reasonix/internal/nilutil"
@@ -696,6 +699,11 @@ type Usage struct {
 	// aggregate. Zero means one request for backward compatibility. Recovery
 	// paths that merge multiple attempts set the exact count.
 	RequestCount int
+	// ContextPromptTokens is the latest single-request prompt size used for
+	// context gauges. When zero, consumers fall back to PromptTokens. Multi-
+	// attempt sampling recovery sets PromptTokens to the billable input sum
+	// and ContextPromptTokens to the final attempt's prompt.
+	ContextPromptTokens int
 }
 
 // Pricing is a provider's per-1M-token rates, used to estimate spend. Currency
@@ -798,12 +806,24 @@ type Chunk struct {
 	Err             error           // ChunkError
 }
 
-// StreamInterruptedError marks a recoverable transport cut that happened after
-// the caller had already received model output. Providers must not replay these
-// requests themselves because doing so could duplicate visible text or tool
-// calls; the agent can append a tail recovery prompt instead.
+// Fixed stream-interrupt reasons for observability. Values are a closed enum
+// and must never carry URLs, tool arguments, file paths, or raw error text.
+const (
+	StreamInterruptConnectionReset = "connection_reset"
+	StreamInterruptPrematureEOF    = "premature_eof"
+	StreamInterruptIdleTimeout     = "idle_timeout"
+)
+
+// StreamInterruptedError marks that the current sampling attempt never reached
+// a clean provider terminal event and is therefore uncommitted. The Agent may
+// replay the exact same provider request. Providers must not perform body-phase
+// request replay themselves — that lives at the Agent layer so retry budgets,
+// UI rollback, and tool execution stay single-owner. context.Canceled, auth,
+// 4xx/schema errors, and unparseable complete protocol payloads must not use
+// this type.
 type StreamInterruptedError struct {
-	Err error
+	Err    error
+	Reason string // one of the StreamInterrupt* constants; may be empty for older callers
 }
 
 func (e *StreamInterruptedError) Error() string {
@@ -818,6 +838,50 @@ func (e *StreamInterruptedError) Unwrap() error {
 		return nil
 	}
 	return e.Err
+}
+
+// StreamInterrupt wraps err as a StreamInterruptedError with a fixed reason.
+func StreamInterrupt(err error, reason string) error {
+	if err == nil {
+		return nil
+	}
+	return &StreamInterruptedError{Err: err, Reason: reason}
+}
+
+// StreamInterruptReason returns the fixed reason when err is a stream
+// interruption, or empty otherwise.
+func StreamInterruptReason(err error) string {
+	var interrupted *StreamInterruptedError
+	if !errors.As(err, &interrupted) || interrupted == nil {
+		return ""
+	}
+	if interrupted.Reason != "" {
+		return interrupted.Reason
+	}
+	return ClassifyStreamInterrupt(interrupted.Err)
+}
+
+// ClassifyStreamInterrupt maps a transport error onto a fixed reason enum.
+// Prefer attaching Reason at the emit site; this is a best-effort fallback.
+func ClassifyStreamInterrupt(err error) string {
+	if err == nil {
+		return StreamInterruptPrematureEOF
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "stalled") || strings.Contains(msg, "idle timeout") || strings.Contains(msg, "no data for"):
+		return StreamInterruptIdleTimeout
+	case errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) || strings.Contains(msg, "before completion") || strings.Contains(msg, "unexpected eof"):
+		return StreamInterruptPrematureEOF
+	case errors.Is(err, net.ErrClosed) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) ||
+		strings.Contains(msg, "connection reset") || strings.Contains(msg, "forcibly closed") || strings.Contains(msg, "broken pipe"):
+		return StreamInterruptConnectionReset
+	default:
+		if IsConnReset(err) {
+			return StreamInterruptConnectionReset
+		}
+		return StreamInterruptPrematureEOF
+	}
 }
 
 func IsStreamInterrupted(err error) bool {

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -722,7 +722,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		return
 	}
 	if err := scanner.Err(); err != nil {
-		reason := provider.StreamInterruptConnectionReset
+		var reason string
 		if stalled.Load() {
 			err = fmt.Errorf("responses: stream idle timeout after %s", idle)
 			reason = provider.StreamInterruptIdleTimeout

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -722,14 +722,21 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		return
 	}
 	if err := scanner.Err(); err != nil {
+		reason := provider.StreamInterruptConnectionReset
 		if stalled.Load() {
 			err = fmt.Errorf("responses: stream idle timeout after %s", idle)
+			reason = provider.StreamInterruptIdleTimeout
+		} else {
+			reason = provider.ClassifyStreamInterrupt(err)
 		}
-		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: &provider.StreamInterruptedError{Err: err}})
+		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, reason)})
 		return
 	}
+	// Protocol-defined terminal response events are required. Connection close
+	// before a terminal event leaves the attempt uncommitted — including any
+	// complete tool calls already forwarded as speculative output.
 	if !terminal {
-		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: &provider.StreamInterruptedError{Err: io.ErrUnexpectedEOF}})
+		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(io.ErrUnexpectedEOF, provider.StreamInterruptPrematureEOF)})
 		return
 	}
 	if completedResponseID != "" {


### PR DESCRIPTION
## Summary

- Move body-phase stream recovery into an Agent-owned sampling-attempt lifecycle: freeze one provider request, replay it up to five times after an interrupt, and commit only after a clean terminal event.
- Require explicit stream completion from OpenAI Chat, Anthropic, and Responses providers so premature EOF, connection reset, and idle timeout cannot commit partial assistant/tool output.
- Add `stream_attempt` begin/discard/commit events so Desktop, CLI, and ACP can roll back speculative text, reasoning, and tool cards without executing partial tool calls.
- Separate multi-attempt billable usage from the latest-attempt context shape, preserve accurate Desktop gauges/rebind telemetry, and keep Goal token usage observational as required by #7725 (no request admission or hard token ceiling).

### Behavior and trade-offs

- The normal, uninterrupted path makes no additional provider request and does not change Session persistence or tool schemas.
- An interrupted round can issue up to five additional byte-identical provider requests, so it may incur additional request/output cost and the resampled answer may differ.
- Failed attempts never persist assistant messages or execute tools. When the retry budget is exhausted, Reasonix records one local pending recovery marker for the next real user turn.
- Failed-attempt input/output estimates are accounting telemetry only: they do not change `MaxTokens`, reject a provider request, or restore the Goal token hard limit removed by #7725.

### Related work and integration

- This PR supersedes #7631 by @HaoyueQin as the primary implementation for the confirmed recovery-usage problem. That PR's diagnosis and alternative per-attempt accounting design were reviewed, but no commits or code were directly adopted; this PR extends the fix to provider terminal contracts, exact-request replay, speculative UI rollback, multi-attempt accounting, and Desktop rebind telemetry.
- #7706 merged as `5509b36d`; its CLI state-machine changes are integrated and covered by the root/CLI tests.
- #7725 merged as `6af8d1f5`; this branch intentionally removes all dependencies on the deleted `RequestBudget`/exact-admission interfaces while retaining frozen request replay and observational usage totals.
- The branch is rebased through current `main-v2` `74f26c88`. The adaptive Anthropic cache-TTL work is integrated by freezing the first attempt's cache-gap hint for the whole sampling lifecycle, so an immediate retry cannot change the real provider body from a 1h to 5m breakpoint; each actual attempt still updates the timestamp used by the next model round.

## Issues

Refs #7620

The issue should remain open until the reporter verifies the original multi-session display symptoms after release.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/agent ./internal/control ./internal/acp -count=1`
- `golangci-lint run --timeout=5m` with v2.12.2 — 0 issues
- `go test ./internal/cli -count=1`, `staticcheck ./internal/cli`, and focused CLI race tests after integrating #7706
- `TestStreamRecoveryFreezesCacheGapHint` verifies cache-TTL input remains identical across body replay attempts
- `pnpm exec tsx src/__tests__/context-panel-breakdown.test.ts` — 50/50 passed
- `pnpm exec tsx src/__tests__/use-controller-stream-progress.test.ts` — 56/56 passed
- `pnpm exec tsc --noEmit`
- Focused Desktop latest-attempt/rebind telemetry tests passed
- Full local Desktop sweep reached its 10-minute timeout in the unrelated `TestWorkspaceGitBranchNonGitDirectory` while waiting on a `git` subprocess; that test passed immediately in isolation. The prior remote-head Desktop CI passed on Linux, macOS, and Windows; current-head CI remains authoritative.
- Root-module `gofmt` and `git diff --check` clean

## Documentation impact

Documentation-impact: none - this is transparent recovery and telemetry correction with no new command, configuration, permission, or manual workflow; existing user documentation remains accurate.

## Cache impact

Cache-impact: none - the normal provider-visible request is unchanged, and interrupted attempts replay the frozen request plus its context-derived cache-TTL choice without changing the stable prompt prefix or tool schema ordering.
Cache-guard: `TestRunRecoversInterruptedStreamAfterPartialText`, `TestRunRecoversRepeatedInterruptedStreams`, `TestRunSilentlyRecoversMissingToolCallReasoning`, and `TestStreamRecoveryFreezesCacheGapHint` verify identical provider-visible replay inputs.
System-prompt-review: N/A
