### PR TITLE
feat(serve): add @file autocomplete to the web UI

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -654,6 +654,9 @@ const __T = {
     'command_palette': 'Command palette',
     'command_empty': 'No commands match',
     'command_nav': '↑↓ navigate · Enter insert · Esc close',
+    'at_files': 'Files',
+    'at_file': 'File',
+    'at_folder': 'Folder',
     'danger': 'Danger',
     'tool_running': 'Running',
     'tool_done': 'Done',
@@ -795,6 +798,9 @@ const __T = {
     'command_palette': '命令面板',
     'command_empty': '没有匹配的命令',
     'command_nav': '↑↓ 选择 · Enter 插入 · Esc 关闭',
+    'at_files': '文件',
+    'at_file': '文件',
+    'at_folder': '文件夹',
     'danger': '危险',
     'tool_running': '运行中',
     'tool_done': '完成',
@@ -1444,6 +1450,87 @@ function renderSlashMenu() {
 function closeSlashMenu(){slashOpen=false;const m=$('#slash-menu');if(m)m.remove();}
 function acceptSlash(){if(!slashOpen)return;const c=slashFiltered[slashIndex];if(c){input.value='/'+c.cmd+' ';}closeSlashMenu();input.focus();}
 
+// ── @ file reference menu ──
+// Mirrors the desktop Composer @-token grammar (desktop/frontend/src/lib/refToken.ts):
+// a trailing "@token" after whitespace or at line start; a backslash-escaped
+// space/tab stays inside the token. The part after the last "/" is the search
+// fragment, the part before it the directory to list.
+let atOpen=false, atIndex=0, atItems=[], atQuery='';
+let atTimer=null, atFetchCtrl=null;
+function activeAtToken() {
+  const v=input.value.replace(/[\r\n]+$/,'');
+  const m=/(?:^|\s)@((?:\\[ \t]|[^\s])*)$/.exec(v);
+  if(!m)return null;
+  const raw=m[1];
+  const slash=raw.lastIndexOf('/');
+  // The token is anchored at the end, so '@' sits exactly rawLen+1 chars back
+  // (robust for both the line-start and whitespace-boundary forms).
+  return {atPos:v.length-raw.length-1, raw,
+    dir:slash>=0?raw.slice(0,slash+1):'',
+    frag:slash>=0?raw.slice(slash+1):raw};
+}
+function unescapeAtPath(s){return s.replace(/\\([ \t])/g,'$1');}
+function updateAtMenu() {
+  const tok=activeAtToken();
+  if(!tok){closeAtMenu();return;}
+  clearTimeout(atTimer);
+  if(atFetchCtrl){atFetchCtrl.abort();atFetchCtrl=null;}
+  const frag=tok.frag.toLowerCase();
+  const dir=unescapeAtPath(tok.dir);
+  // Debounce the fetch; aborted/stale responses never render. Failures and
+  // empty workspaces close the menu silently.
+  atTimer=setTimeout(()=>{
+    const ctrl=new AbortController();
+    atFetchCtrl=ctrl;
+    const url='/files?q='+encodeURIComponent(frag)+(dir?'&dir='+encodeURIComponent(dir):'');
+    fetch(url,{signal:ctrl.signal}).then(r=>{if(!r.ok)throw new Error('bad status');return r.json();}).then(items=>{
+      if(atFetchCtrl!==ctrl)return;
+      atItems=Array.isArray(items)?items:[];
+      atQuery='@'+tok.raw;
+      if(atItems.length===0){closeAtMenu();return;}
+      atOpen=true; atIndex=0;
+      renderAtMenu();
+    }).catch(()=>{if(atFetchCtrl===ctrl)closeAtMenu();});
+  },150);
+}
+function renderAtMenu() {
+  let menu=$('#at-menu');
+  if(!menu){menu=el('div','slash-menu');menu.id='at-menu';slashAnchor.appendChild(menu);}
+  menu.innerHTML='<div class="slash-menu__head"><span>'+escHtml(__('at_files'))+'</span><span class="slash-menu__query">'+escHtml(atQuery)+'</span></div><div class="slash-menu__list" id="at-menu-list" role="listbox"></div><div class="slash-menu__foot"><span>'+escHtml(__('command_nav'))+'</span><span>'+atItems.length+'</span></div>';
+  const list=$('#at-menu-list');
+  atItems.forEach((it,i)=>{
+    const name=String(it.path||'').split('/').pop();
+    const item=el('button','slash-menu__item'+(i===atIndex?' slash-menu__item--active':''));
+    item.type='button';
+    item.setAttribute('role','option');
+    item.setAttribute('aria-selected',i===atIndex?'true':'false');
+    item.innerHTML='<span class="slash-menu__name">@'+escHtml(name)+'</span><span class="slash-menu__desc">'+escHtml(it.path||'')+'</span><span class="slash-menu__pill">'+escHtml(it.isDir?__('at_folder'):__('at_file'))+'</span>';
+    item.onmouseenter=()=>{atIndex=i;renderAtMenu();};
+    item.onclick=()=>{atIndex=i;acceptAt();};
+    list.appendChild(item);
+  });
+  const active=menu.querySelector('.slash-menu__item--active');
+  if(active)active.scrollIntoView({block:'nearest'});
+}
+function closeAtMenu(){
+  atOpen=false;
+  clearTimeout(atTimer);atTimer=null;
+  if(atFetchCtrl){atFetchCtrl.abort();atFetchCtrl=null;}
+  const m=$('#at-menu');if(m)m.remove();
+}
+// Replace the typed "@token" with the picked path (whitespace backslash-escaped
+// so the reference survives @-token parsing on submit) plus "/" for folders so
+// the user can keep descending, or a space for files.
+function acceptAt(){
+  if(!atOpen)return;
+  const it=atItems[atIndex]; if(!it)return;
+  const tok=activeAtToken(); if(!tok)return;
+  const path=String(it.path||'').replace(/[ \t]/g,ws=>'\\'+ws);
+  input.value=input.value.slice(0,tok.atPos)+'@'+path+(it.isDir?'/':' ');
+  closeAtMenu();
+  input.focus();
+}
+
 // ── SSE ──
 const es=new EventSource('/events');
 es.onopen=()=>{setConnState('connected');fetchStatus();fetchTodos();};
@@ -1692,7 +1779,7 @@ async function syncModeBeforeSubmit(){
 async function send(){
   const v=input.value.trim(); if(!v)return;
   if(v==='/reload'){
-    input.value='';input.style.height='';closeSlashMenu();
+    input.value='';input.style.height='';closeSlashMenu();closeAtMenu();
     showNotice(__('extensions_reloading'));
     const response=await post('/extensions/reload',{});
     if(response.ok){showNotice(__('extensions_reloaded'));fetchStatus();}
@@ -1713,10 +1800,10 @@ async function send(){
   }
   addUserMsg(v);
   post('/submit',{input:submitInput}).then(r=>{if(r.ok&&r.status===204){fetchStatus();loadSessions();}});
-  input.value='';input.style.height='';closeSlashMenu();
+  input.value='';input.style.height='';closeSlashMenu();closeAtMenu();
 }
 
-input.addEventListener('input',()=>{input.style.height='auto';input.style.height=Math.min(input.scrollHeight,140)+'px';updateSlashMenu();});
+input.addEventListener('input',()=>{input.style.height='auto';input.style.height=Math.min(input.scrollHeight,140)+'px';updateSlashMenu();updateAtMenu();});
 input.addEventListener('keydown',e=>{
   // slash menu nav
   if(slashOpen){
@@ -1725,10 +1812,17 @@ input.addEventListener('keydown',e=>{
     if(e.key==='Tab'||e.key==='Enter'){e.preventDefault();acceptSlash();return;}
     if(e.key==='Escape'){e.preventDefault();closeSlashMenu();return;}
   }
+  // @ file menu nav
+  if(atOpen){
+    if(e.key==='ArrowDown'){e.preventDefault();atIndex=Math.min(atIndex+1,atItems.length-1);renderAtMenu();return;}
+    if(e.key==='ArrowUp'){e.preventDefault();atIndex=Math.max(atIndex-1,0);renderAtMenu();return;}
+    if(e.key==='Tab'||e.key==='Enter'){e.preventDefault();acceptAt();return;}
+    if(e.key==='Escape'){e.preventDefault();closeAtMenu();return;}
+  }
   // main keys
   if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send();return;}
   if(e.key==='Escape'){
-    if(goalMode&&!running){goalMode=false;updateGoalUI();input.value='';closeSlashMenu();return;}
+    if(goalMode&&!running){goalMode=false;updateGoalUI();input.value='';closeSlashMenu();closeAtMenu();return;}
     if(running){post('/cancel');return;}
     // double-Esc for rewind
     if(input.value===''){if(escTimer){clearTimeout(escTimer);escTimer=null;openRewindPicker();}else{escTimer=setInterval(()=>escTimer=null,600);}return;}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -12,11 +12,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +28,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/fileref"
 	"reasonix/internal/jobs"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
@@ -520,6 +523,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /sessions", s.sessions)
 	mux.HandleFunc("GET /skills", s.skills)
 	mux.HandleFunc("GET /todos", s.todos)
+	mux.HandleFunc("GET /files", s.files)
 	mux.HandleFunc("POST /delete-session", s.deleteSession)
 	return logMiddleware(s.auth.middleware(csrfGuard(mux)))
 }
@@ -1653,4 +1657,255 @@ func (s *Server) todos(w http.ResponseWriter, _ *http.Request) {
 		out[i] = todoItem{Content: t.Content, Status: t.Status, ActiveForm: t.ActiveForm, Level: t.Level}
 	}
 	writeJSON(w, out)
+}
+
+// fileRefEntry is one suggestion in the web UI "@" file-reference menu.
+type fileRefEntry struct {
+	Path  string `json:"path"`  // slash-normalized path relative to the workspace root
+	IsDir bool   `json:"isDir"` // directories append "/" on selection so the user can descend
+}
+
+// Bounds for the web "@" autocomplete walk. The desktop @-menu (internal/fileref
+// Search) bounds itself the same way, minus the explicit depth cap.
+const (
+	fileRefLimit    = 50    // max suggestions per response
+	fileRefMaxDepth = 20    // max directory depth walked from the root
+	fileRefMaxWalk  = 10000 // cap on visited entries, like fileref.Search
+	fileRefDirQuota = 5     // directory suggestions never fully crowd out file hits
+)
+
+// files serves the web UI's "@" file-reference autocomplete: GET /files?q=<frag>&dir=<rel>.
+//
+// Matching mirrors the desktop @-menu (desktop/frontend/src/lib/atMatches.ts and
+// internal/fileref.Search): q is matched case-insensitively as a SUBSTRING of an
+// entry's basename (preferred tier), of any slash-separated path segment
+// (fallback tier), or of a directory name (lowest tier) — not a strict prefix,
+// so "planind" surfaces "src/planind/index.tsx" and "ts" surfaces "index.ts".
+// Results are ordered directories first (up to fileRefDirQuota, so folders stay
+// navigable), then basename hits, then path-segment hits, capped at
+// fileRefLimit.
+//
+// The walk is bounded (fileRefMaxDepth, fileRefMaxWalk) and skips generated and
+// vendor entries (.git, node_modules, build/dist/target, ...) via
+// fileref.SkipEntry plus hidden dotfiles, unless q starts with "." — the same
+// visibility rules the desktop picker applies. dir scopes the search to one
+// directory level relative to the workspace root (slash-separated); when dir is
+// empty the whole tree is searched. The workspace root is the controller's
+// WorkspaceRoot (cwd fallback), the same base @-references resolve against on
+// submit. An empty response (no matches, unreadable directory) is a 200 with
+// an empty array so the frontend can close the menu silently; a dir that
+// escapes the root is a 400.
+func (s *Server) files(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	dir := r.URL.Query().Get("dir")
+	root := strings.TrimSpace(s.ctl().WorkspaceRoot())
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil || wd == "" {
+			writeJSON(w, []any{})
+			return
+		}
+		root = wd
+	}
+	// Open the root once per request: every read below goes through this
+	// *os.Root, which resolves symlinks with openat semantics, so a link
+	// inside the root that points outside it fails (EPERM) instead of
+	// escaping the workspace boundary. An unreadable root is the same silent
+	// empty response the endpoint uses for unreadable targets.
+	rootOS, err := os.OpenRoot(root)
+	if err != nil {
+		writeJSON(w, []any{})
+		return
+	}
+	defer rootOS.Close()
+	if dir != "" {
+		rel, ok := fileRefDirWithin(root, dir)
+		if !ok {
+			http.Error(w, "dir escapes workspace root", http.StatusBadRequest)
+			return
+		}
+		// Inside a directory the menu lists one level (navigating one level per
+		// pick, like the desktop ListDir) — never a recursive search.
+		writeJSON(w, listFileRefLevel(rootOS, rel, q))
+		return
+	}
+	if q == "" {
+		// Bare "@" with nothing typed yet: show the workspace root listing.
+		writeJSON(w, listFileRefLevel(rootOS, ".", ""))
+		return
+	}
+	writeJSON(w, searchFileRefs(rootOS, q))
+}
+
+// fileRefDirWithin validates dir (slash-separated, relative) against root and
+// rejects anything that escapes it: absolute paths and ".." segments. Mirrors
+// the desktop's workspacePathForBase confinement. On success it returns dir in
+// slash-separated form relative to root ("." for the root itself) — the form
+// the *os.Root opened on root expects.
+func fileRefDirWithin(root, dir string) (string, bool) {
+	if dir == "" || filepath.IsAbs(dir) {
+		return "", false
+	}
+	dir = filepath.FromSlash(strings.TrimRight(dir, "/"))
+	if dir == "" || dir == "." {
+		return ".", true
+	}
+	target := filepath.Join(root, dir)
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+// listFileRefLevel lists one directory level: directories first, then files,
+// each alphabetical, filtered by q (case-insensitive substring of the name),
+// capped at fileRefLimit. Unreadable or non-directory targets return an empty
+// list, matching the desktop ListDir behavior of silently showing nothing.
+// rel is read through root, which confines it to the workspace root: a
+// symlink escaping the root fails here and yields the same empty list.
+func listFileRefLevel(root *os.Root, rel, q string) []fileRefEntry {
+	f, err := root.Open(rel)
+	if err != nil {
+		return []fileRefEntry{}
+	}
+	defer f.Close()
+	es, err := f.ReadDir(-1)
+	if err != nil {
+		return []fileRefEntry{}
+	}
+	q = strings.ToLower(q)
+	showHidden := strings.HasPrefix(q, ".")
+	var dirs, files []fileRefEntry
+	for _, e := range es {
+		name := e.Name()
+		isDir := e.IsDir()
+		if fileref.SkipEntry(name, name, isDir) || (!showHidden && strings.HasPrefix(name, ".")) {
+			continue
+		}
+		if !isDir {
+			info, err := e.Info()
+			if err != nil || !info.Mode().IsRegular() {
+				continue
+			}
+		}
+		if q != "" && !strings.Contains(strings.ToLower(name), q) {
+			continue
+		}
+		if isDir {
+			dirs = append(dirs, fileRefEntry{Path: name, IsDir: true})
+		} else {
+			files = append(files, fileRefEntry{Path: name})
+		}
+	}
+	sort.Slice(dirs, func(i, j int) bool { return strings.ToLower(dirs[i].Path) < strings.ToLower(dirs[j].Path) })
+	sort.Slice(files, func(i, j int) bool { return strings.ToLower(files[i].Path) < strings.ToLower(files[j].Path) })
+	out := append(dirs, files...)
+	if len(out) > fileRefLimit {
+		out = out[:fileRefLimit]
+	}
+	return out
+}
+
+// searchFileRefs walks the tree under root (bounded by fileRefMaxDepth and
+// fileRefMaxWalk) and returns entries matching q as a substring of their
+// basename, of any path segment, or of a directory name — the same tiers and
+// ordering internal/fileref.Search applies for the desktop @-menu, with the
+// added depth bound. Directories are returned with IsDir set so the frontend
+// can offer to descend into them. The walk runs on the *os.Root's fs.FS
+// adapter, confining it to the workspace root (escaping symlinks fail
+// instead of being followed).
+func searchFileRefs(root *os.Root, q string) []fileRefEntry {
+	q = strings.ToLower(strings.TrimSpace(q))
+	if q == "" || strings.ContainsAny(q, `/\`) {
+		return []fileRefEntry{}
+	}
+	showHidden := strings.HasPrefix(q, ".")
+	var dirHits, basenameHits, segmentHits []fileRefEntry
+	visited := 0
+	_ = fs.WalkDir(root.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if path == "." {
+			return nil
+		}
+		visited++
+		if visited > fileRefMaxWalk {
+			return fs.SkipAll
+		}
+		// fs.WalkDir paths are already slash-separated and relative to the root.
+		relSlash := path
+		if strings.Count(relSlash, "/") > fileRefMaxDepth {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if fileref.SkipEntry(relSlash, name, true) || (!showHidden && strings.HasPrefix(name, ".")) {
+				return fs.SkipDir
+			}
+			if strings.Contains(strings.ToLower(name), q) {
+				dirHits = append(dirHits, fileRefEntry{Path: relSlash, IsDir: true})
+			}
+			return nil
+		}
+		if fileref.SkipEntry(relSlash, name, false) || (!showHidden && strings.HasPrefix(name, ".")) {
+			return nil
+		}
+		if info, err := d.Info(); err != nil || !info.Mode().IsRegular() {
+			return nil
+		}
+		switch {
+		case strings.Contains(strings.ToLower(name), q):
+			basenameHits = append(basenameHits, fileRefEntry{Path: relSlash})
+		case fileRefSegmentContains(relSlash, q):
+			segmentHits = append(segmentHits, fileRefEntry{Path: relSlash})
+		}
+		return nil
+	})
+	sort.Slice(dirHits, func(i, j int) bool { return dirHits[i].Path < dirHits[j].Path })
+	sort.Slice(basenameHits, func(i, j int) bool { return basenameHits[i].Path < basenameHits[j].Path })
+	sort.Slice(segmentHits, func(i, j int) bool { return segmentHits[i].Path < segmentHits[j].Path })
+	// Directories first so the user can navigate into them; then basename hits
+	// (most relevant file matches); then path-segment hits. Reserve up to
+	// fileRefDirQuota slots for directories so they are never fully crowded out.
+	out := make([]fileRefEntry, 0, fileRefLimit)
+	nDirs := len(dirHits)
+	if nDirs > fileRefDirQuota {
+		nDirs = fileRefDirQuota
+	}
+	out = append(out, dirHits[:nDirs]...)
+	remaining := fileRefLimit - len(out)
+	if remaining > 0 {
+		if len(basenameHits) > remaining {
+			basenameHits = basenameHits[:remaining]
+		}
+		out = append(out, basenameHits...)
+		remaining = fileRefLimit - len(out)
+	}
+	if remaining > 0 {
+		if len(segmentHits) > remaining {
+			segmentHits = segmentHits[:remaining]
+		}
+		out = append(out, segmentHits...)
+	}
+	return out
+}
+
+// fileRefSegmentContains reports whether q appears in any slash-separated
+// segment of the slash-normalized relative path (the basename is matched
+// independently by the caller). Mirrors fileref.pathSegmentContains.
+func fileRefSegmentContains(relSlash, q string) bool {
+	for _, seg := range strings.Split(relSlash, "/") {
+		if strings.Contains(strings.ToLower(seg), q) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1238,5 +1241,250 @@ func TestServeEventsReplaysPendingApprovalOnAttach(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("executor did not finish after approval")
+	}
+}
+
+// filesFixture builds a fake workspace tree for the /files endpoint tests and
+// a server whose controller reports it as the workspace root.
+func filesFixture(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	mk := func(rel string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkdir := func(rel string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(rel)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Root level: three visible files, plus entries that must be hidden.
+	mk("README.md")
+	mk("hello.txt")
+	mk("main.go")
+	mk(".hidden.txt")
+	mkdir(".git")
+	mkdir("node_modules")
+	mkdir("tmp")
+	mkdir("build") // skipDirNames
+	// Nested tree for segment/basename matches and dir scoping.
+	mk("src/util.go")
+	mk("src/planind/index.tsx")
+	mkdir("src/deep")
+	mk("src/deep/nested.txt")
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, WorkspaceRoot: root})
+	srv := httptest.NewServer(New(ctrl, bc, config.ServeConfig{}).Handler())
+	t.Cleanup(srv.Close)
+	return srv, root
+}
+
+func filesGet(t *testing.T, srv *httptest.Server, qs string) (int, []fileRefEntry) {
+	t.Helper()
+	resp, err := http.Get(srv.URL + "/files?" + qs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out []fileRefEntry
+	if resp.StatusCode == 200 {
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode /files: %v", err)
+		}
+	}
+	return resp.StatusCode, out
+}
+
+func filesPaths(entries []fileRefEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Path
+	}
+	return out
+}
+
+func TestServeFilesEmptyQueryListsRoot(t *testing.T) {
+	srv, _ := filesFixture(t)
+	status, out := filesGet(t, srv, "")
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	// Directories first, then files, alphabetical (case-insensitive, like the
+	// desktop ListDir); generated, vendor and hidden entries are skipped.
+	want := []string{"src", "hello.txt", "main.go", "README.md"}
+	got := filesPaths(out)
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("root listing = %v, want %v", got, want)
+	}
+	if !out[0].IsDir || out[1].IsDir {
+		t.Errorf("expected first entry to be a directory and files after, got %+v", out)
+	}
+}
+
+func TestServeFilesSubstringMatch(t *testing.T) {
+	srv, _ := filesFixture(t)
+	cases := []struct {
+		q    string
+		want []string
+	}{
+		{"hello", []string{"hello.txt"}},                              // basename substring
+		{"txt", []string{"hello.txt", "src/deep/nested.txt"}},         // substring, not prefix
+		{"util", []string{"src/util.go"}},                             // basename hit on a nested file
+		{"planind", []string{"src/planind", "src/planind/index.tsx"}}, // path-segment hit, matching dir first
+		{"index", []string{"src/planind/index.tsx"}},
+		{"zzz", nil},
+	}
+	for _, c := range cases {
+		_, out := filesGet(t, srv, "q="+url.QueryEscape(c.q))
+		if got := filesPaths(out); strings.Join(got, "|") != strings.Join(c.want, "|") {
+			t.Errorf("q=%q = %v, want %v", c.q, got, c.want)
+		}
+	}
+}
+
+func TestServeFilesHiddenRespectsDotPrefix(t *testing.T) {
+	srv, _ := filesFixture(t)
+	// Without a leading dot in q, hidden files are invisible.
+	if _, out := filesGet(t, srv, "q=hidden"); len(out) != 0 {
+		t.Errorf("q=hidden = %v, want no hidden matches", filesPaths(out))
+	}
+	// A q starting with "." opts into hidden entries, like the desktop picker.
+	_, out := filesGet(t, srv, "q="+url.QueryEscape(".h"))
+	if got := filesPaths(out); strings.Join(got, "|") != ".hidden.txt" {
+		t.Errorf("q=.h = %v, want [.hidden.txt]", got)
+	}
+}
+
+func TestServeFilesDirScoping(t *testing.T) {
+	srv, _ := filesFixture(t)
+	// One level inside src: directories first, then files.
+	_, out := filesGet(t, srv, "dir=src")
+	if got := filesPaths(out); strings.Join(got, "|") != "deep|planind|util.go" {
+		t.Errorf("dir=src = %v, want [deep planind util.go]", got)
+	}
+	// Filtered listing inside the directory.
+	_, out = filesGet(t, srv, "dir=src&q=util")
+	if got := filesPaths(out); strings.Join(got, "|") != "util.go" {
+		t.Errorf("dir=src&q=util = %v, want [util.go]", got)
+	}
+	// A directory match is selectable for descending.
+	_, out = filesGet(t, srv, "dir=src&q=plan")
+	if got := filesPaths(out); strings.Join(got, "|") != "planind" || !out[0].IsDir {
+		t.Errorf("dir=src&q=plan = %v (isDir=%v), want [planind] dir", got, out[0].IsDir)
+	}
+}
+
+func TestServeFilesRejectsTraversal(t *testing.T) {
+	srv, root := filesFixture(t)
+	// A marker outside the workspace root that must never leak into results.
+	if err := os.WriteFile(filepath.Join(filepath.Dir(root), "outside.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{"..", "../..", "..%2Fetc", "%2Fetc", "src%2F..%2F..%2F..", "src/../.."} {
+		status, _ := filesGet(t, srv, "q=outside&dir="+dir)
+		if status != http.StatusBadRequest {
+			t.Errorf("dir=%q status = %d, want 400", dir, status)
+		}
+	}
+}
+
+func TestServeFilesUnreadableDirIsEmpty(t *testing.T) {
+	srv, root := filesFixture(t)
+	// A dir that is a regular file reads as an empty listing (ENOTDIR).
+	status, out := filesGet(t, srv, "dir=README.md")
+	if status != 200 || len(out) != 0 {
+		t.Errorf("dir=README.md = %d %v, want 200 []", status, filesPaths(out))
+	}
+	// A permission-denied directory is likewise silently empty. Root can read
+	// anything, so skip the chmod probe when running as root.
+	if os.Geteuid() == 0 {
+		return
+	}
+	locked := filepath.Join(root, "src", "deep")
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	status, out = filesGet(t, srv, "dir=src%2Fdeep")
+	if status != 200 || len(out) != 0 {
+		t.Errorf("locked dir = %d %v, want 200 []", status, filesPaths(out))
+	}
+}
+
+func TestServeFilesDepthLimit(t *testing.T) {
+	srv, root := filesFixture(t)
+	// A chain one level deeper than fileRefMaxDepth: the file at exactly
+	// maxDepth is found, the one beyond it is not.
+	var chain []string
+	for i := 0; i <= fileRefMaxDepth+1; i++ {
+		chain = append(chain, "d"+fmt.Sprint(i))
+	}
+	okDir := filepath.Join(append(append([]string{}, chain[:fileRefMaxDepth]...), "f_at_depth.txt")...)
+	deepDir := filepath.Join(append(append([]string{}, chain[:fileRefMaxDepth+1]...), "f_too_deep.txt")...)
+	for _, p := range []string{okDir, deepDir} {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(root, p)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, p), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, out := filesGet(t, srv, "q=f_at_depth")
+	if got := filesPaths(out); strings.Join(got, "|") != "d0/d1/d2/d3/d4/d5/d6/d7/d8/d9/d10/d11/d12/d13/d14/d15/d16/d17/d18/d19/f_at_depth.txt" {
+		t.Errorf("depth-limit match = %v", got)
+	}
+	if _, out := filesGet(t, srv, "q=f_too_deep"); len(out) != 0 {
+		t.Errorf("file beyond depth %d leaked into results: %v", fileRefMaxDepth, filesPaths(out))
+	}
+}
+
+func TestServeFilesSymlinkEscapeIsEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on windows")
+	}
+	srv, root := filesFixture(t)
+	// A symlink inside the root pointing at a directory OUTSIDE it defeats
+	// the lexical fileRefDirWithin check, which cannot see through links.
+	// Reading it must fail inside the *os.Root (openat confinement) and come
+	// back as the same silent empty listing as any unreadable target.
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "leak.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	status, out := filesGet(t, srv, "dir=escape")
+	if status != 200 || len(out) != 0 {
+		t.Errorf("dir=escape = %d %v, want 200 [] (symlink must not escape the root)", status, filesPaths(out))
+	}
+}
+
+func TestServeFilesSymlinkInsideStillWorks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires privileges on windows")
+	}
+	srv, root := filesFixture(t)
+	// A symlink to a directory INSIDE the root is still resolvable: os.Root
+	// only rejects links that escape the root. Use a RELATIVE target — the
+	// absolute-target form is intentionally rejected on darwin (openat
+	// confinement treats absolute paths as escaping the root).
+	if err := os.Symlink("src", filepath.Join(root, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	status, out := filesGet(t, srv, "dir=alias")
+	if status != 200 {
+		t.Fatalf("dir=alias status = %d, want 200", status)
+	}
+	if got := filesPaths(out); strings.Join(got, "|") != "deep|planind|util.go" {
+		t.Errorf("dir=alias = %v, want [deep planind util.go]", got)
 	}
 }


### PR DESCRIPTION
## Summary

Implements [#7640](https://github.com/esengine/DeepSeek-Reasonix/issues/7640) — `@filename` autocomplete for the `reasonix serve` web UI (previously only slash commands existed; the desktop React app has a full @-menu).

**Backend — `GET /files?q=<frag>&dir=<rel>`** (`internal/serve/serve.go`, behind the same auth middleware chain):
- Workspace-root-bound walk: depth limit 20, 10k-entry cap, skips generated/vendor dirs via `fileref.SkipEntry`, hidden files skipped unless `q` starts with `.`
- Matching (mirrors `atMatches.ts` semantics): case-insensitive substring of basename (preferred), any path segment, or directory name; directories first, capped at 50; bare `@` returns the root listing; `dir` scopes one level (desktop `ListDir` parity)
- Traversal/absolute `dir` → 400; unreadable/non-directory → 200 `[]` (silent)

**Frontend** (`index.html`, self-contained, zero new tooling — reuses slash-menu popover markup + `escHtml`/`el` helpers):
- `@`-token detection mirroring the desktop grammar, 150ms debounce + `AbortController` + stale-guard, silent close on empty/error
- Keyboard nav (Up/Down/Tab/Enter/Esc), mouse hover/click, insertion with backslash-escaped spaces (`escapeRefPath` parity) + `/` descend for folders
- i18n keys added (en + zh); `closeAtMenu` wired into send/reload/goal-mode-Esc paths

## Verification

- `go test ./internal/serve/` — 118 pass (7 new `/files` tests: empty-query listing, substring match, hidden-dot-prefix, dir scoping, all 6 traversal forms → 400, unreadable dir → [], depth-limit boundary)
- `go vet` / `gofmt -l` — clean; `go build ./cmd/reasonix` — OK
- Frontend JS (not covered by Go harness): Node VM harness — 11 token-detection/insertion assertions + 12 async debounce/abort/stale-guard assertions, all pass

## Issues

Fixes #7640

## Documentation impact

Documentation-impact: none - web UI feature; the serve UI is a self-contained HTML, no docs describe its composer behavior.

## Cache impact

Cache-impact: none - `internal/serve` is not a cache-sensitive path (not listed in `scripts/check-cache-impact.sh`); no prompt/tool surface touched.
Cache-guard: N/A
System-prompt-review: N/A
