### PR TITLE
feat(cli): version metadata, shell completion, MCP source display / 版本元信息、Shell 补全与 MCP 来源展示

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{ .Tag }} -X reasonix/internal/productdocs.linkedVersion={{ .Tag }} -X reasonix/internal/productdocs.linkedRevision={{ .Commit }}
+      # Inject version identity for `reasonix version --verbose/--json` (Integration D/E).
+      # buildTimeUTC is the goreleaser run time (UTC), not vcs.time.
+      - -s -w -X main.version={{ .Tag }} -X main.gitCommit={{ .ShortCommit }} -X main.buildTimeUTC={{ .Date }} -X reasonix/internal/productdocs.linkedVersion={{ .Tag }} -X reasonix/internal/productdocs.linkedRevision={{ .Commit }}
     goos: [darwin, linux, windows]
     goarch: [amd64, arm64]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
-LDFLAGS := -s -w -X main.version=$(VERSION)
+BUILD_TIME_UTC := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GIT_COMMIT := $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
+LDFLAGS := -s -w \
+	-X main.version=$(VERSION) \
+	-X main.gitCommit=$(GIT_COMMIT) \
+	-X main.buildTimeUTC=$(BUILD_TIME_UTC)
 GOEXE := $(shell go env GOEXE)
 
 .PHONY: build vet fmt test desktop-test desktop-test-short desktop-test-times sdk-test sdk-test-race hooks cross clean

--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -16,10 +16,24 @@ import (
 	_ "reasonix/internal/tool/builtin"
 )
 
-// version is injected at build time via -ldflags "-X main.version=...".
-var version = "dev"
+// Build identity injected via -ldflags (see Makefile). version remains the
+// single-line contract for `reasonix --version`; gitCommit/buildTimeUTC feed
+// `reasonix version --verbose` / `--json` without embedding config paths.
+var (
+	version      = "dev"
+	gitCommit    = ""
+	buildTimeUTC = ""
+)
 
-var runCLI = cli.Run
+// runCLI is the CLI entry; tests may stub it. Production routes through
+// RunWithBuildInfo so ldflags metadata is available to version --verbose/--json.
+var runCLI = func(args []string, buildVersion string) int {
+	return cli.RunWithBuildInfo(args, cli.BuildInfo{
+		Version:      buildVersion,
+		GitCommit:    gitCommit,
+		BuildTimeUTC: buildTimeUTC,
+	})
+}
 
 func main() {
 	os.Exit(runWithCrashCapture(os.Args[1:], version))

--- a/desktop/build_identity_packaging_test.go
+++ b/desktop/build_identity_packaging_test.go
@@ -19,8 +19,9 @@ func TestDesktopBuildLinksSharedSourceRevision(t *testing.T) {
 		`SOURCE_REVISION="$(git -C "$ROOT" rev-parse --verify HEAD)"`,
 		`SOURCE_REVISION="$SOURCE_REVISION+dirty"`,
 		`product_docs_ldflags="-X reasonix/internal/productdocs.linkedVersion=$VERSION -X reasonix/internal/productdocs.linkedRevision=$SOURCE_REVISION"`,
+		`cli_identity_ldflags="-X main.version=$VERSION -X main.gitCommit=$GIT_COMMIT -X main.buildTimeUTC=$BUILD_TIME_UTC $product_docs_ldflags"`,
 		`ldflags="-X main.version=$VERSION -X main.channel=$CHANNEL $product_docs_ldflags"`,
-		`-X main.version=$VERSION $product_docs_ldflags`,
+		`cli_identity_ldflags`,
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("desktop-build.sh does not preserve the shared build identity %q", want)

--- a/internal/cli/buildinfo.go
+++ b/internal/cli/buildinfo.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// BuildInfo is the machine- and human-readable build identity for
+// `reasonix version` / `reasonix --version`. Release builds may only fill
+// Version; source and CI builds inject the rest via -ldflags so the binary is
+// traceable without shelling out to git.
+//
+// Plan contract (Integration D/E):
+//   - `reasonix --version` / `-v` stay single-line: "reasonix <version>"
+//   - `reasonix version --verbose` prints structured fields
+//   - `reasonix version --json` prints a JSON object
+//   - Fields are limited to version, commit, build time, target (and go runtime);
+//     no config paths and no fixed CST conversion.
+type BuildInfo struct {
+	Version      string
+	GitCommit    string
+	BuildTimeUTC string
+	BuildTarget  string
+}
+
+// versionCommand handles `reasonix version [flags]`. When allowFlags is false
+// (top-level --version / -v), output is always the single-line form.
+func versionCommand(args []string, info BuildInfo, allowFlags bool) int {
+	info = info.withDefaults()
+	if !allowFlags {
+		fmt.Println(info.singleLine())
+		return 0
+	}
+	verbose := false
+	jsonOut := false
+	for _, arg := range args {
+		switch arg {
+		case "--verbose", "-verbose":
+			verbose = true
+		case "--json":
+			jsonOut = true
+		case "--help", "-h":
+			versionUsage(os.Stdout)
+			return 0
+		default:
+			fmt.Fprintf(os.Stderr, "unknown version flag %q\n", arg)
+			versionUsage(os.Stderr)
+			return 2
+		}
+	}
+	if jsonOut && verbose {
+		fmt.Fprintln(os.Stderr, "error: --json and --verbose are mutually exclusive")
+		return 2
+	}
+	if jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(info.jsonPayload()); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			return 1
+		}
+		return 0
+	}
+	if verbose {
+		fmt.Print(info.verboseText())
+		return 0
+	}
+	fmt.Println(info.singleLine())
+	return 0
+}
+
+func versionUsage(w *os.File) {
+	fmt.Fprintln(w, `Usage:
+  reasonix version
+  reasonix version --verbose
+  reasonix version --json
+  reasonix --version
+  reasonix -v
+
+--version / -v always print a single line (reasonix <version>).
+version --verbose prints build metadata; version --json prints the same as JSON.`)
+}
+
+func (b BuildInfo) singleLine() string {
+	return "reasonix " + strings.TrimSpace(b.withDefaults().Version)
+}
+
+func (b BuildInfo) verboseText() string {
+	b = b.withDefaults()
+	var lines []string
+	appendField := func(k, v string) {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			lines = append(lines, k+": "+v)
+		}
+	}
+	lines = append(lines, b.singleLine())
+	appendField("git_commit", b.GitCommit)
+	appendField("build_time_utc", b.BuildTimeUTC)
+	appendField("build_target", b.BuildTarget)
+	appendField("go", fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH))
+	return strings.Join(lines, "\n") + "\n"
+}
+
+type versionJSON struct {
+	Version      string `json:"version"`
+	GitCommit    string `json:"git_commit,omitempty"`
+	BuildTimeUTC string `json:"build_time_utc,omitempty"`
+	BuildTarget  string `json:"build_target,omitempty"`
+	Go           string `json:"go"`
+}
+
+func (b BuildInfo) jsonPayload() versionJSON {
+	b = b.withDefaults()
+	return versionJSON{
+		Version:      b.Version,
+		GitCommit:    omitUnknown(b.GitCommit),
+		BuildTimeUTC: omitUnknown(b.BuildTimeUTC),
+		BuildTarget:  b.BuildTarget,
+		Go:           fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func omitUnknown(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "unknown" {
+		return ""
+	}
+	return v
+}
+
+func (b BuildInfo) withDefaults() BuildInfo {
+	if strings.TrimSpace(b.Version) == "" {
+		b.Version = "dev"
+	}
+	if strings.TrimSpace(b.BuildTarget) == "" {
+		b.BuildTarget = defaultBuildTarget()
+	}
+	if strings.TrimSpace(b.GitCommit) == "" {
+		if rev, ok := buildSetting("vcs.revision"); ok {
+			b.GitCommit = shortGitRevision(rev)
+		}
+	}
+	if strings.TrimSpace(b.BuildTimeUTC) == "" {
+		if mod, ok := buildSetting("vcs.time"); ok {
+			if t, err := time.Parse(time.RFC3339, mod); err == nil {
+				b.BuildTimeUTC = t.UTC().Format(time.RFC3339)
+			}
+		}
+	}
+	if strings.TrimSpace(b.GitCommit) == "" {
+		b.GitCommit = "unknown"
+	}
+	if strings.TrimSpace(b.BuildTimeUTC) == "" {
+		b.BuildTimeUTC = "unknown"
+	}
+	return b
+}
+
+func buildSetting(key string) (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == key && strings.TrimSpace(setting.Value) != "" {
+			return setting.Value, true
+		}
+	}
+	return "", false
+}
+
+func shortGitRevision(revision string) string {
+	revision = strings.TrimSpace(revision)
+	if len(revision) > 12 {
+		return revision[:12]
+	}
+	return revision
+}
+
+func defaultBuildTarget() string {
+	if runtime.GOOS == "" || runtime.GOARCH == "" {
+		return ""
+	}
+	return runtime.GOOS + "/" + runtime.GOARCH
+}

--- a/internal/cli/buildinfo.go
+++ b/internal/cli/buildinfo.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
-	"time"
 )
 
 // BuildInfo is the machine- and human-readable build identity for
@@ -141,16 +140,13 @@ func (b BuildInfo) withDefaults() BuildInfo {
 	if strings.TrimSpace(b.BuildTarget) == "" {
 		b.BuildTarget = defaultBuildTarget()
 	}
+	// Commit may fall back to the embedded VCS revision from `go build` when
+	// ldflags were not set (local `go run` / untagged builds). Build time must
+	// NOT use vcs.time — that is commit timestamp, not the binary's build clock.
+	// Official release/npm/desktop/Makefile paths inject buildTimeUTC explicitly.
 	if strings.TrimSpace(b.GitCommit) == "" {
 		if rev, ok := buildSetting("vcs.revision"); ok {
 			b.GitCommit = shortGitRevision(rev)
-		}
-	}
-	if strings.TrimSpace(b.BuildTimeUTC) == "" {
-		if mod, ok := buildSetting("vcs.time"); ok {
-			if t, err := time.Parse(time.RFC3339, mod); err == nil {
-				b.BuildTimeUTC = t.UTC().Format(time.RFC3339)
-			}
 		}
 	}
 	if strings.TrimSpace(b.GitCommit) == "" {

--- a/internal/cli/buildinfo_test.go
+++ b/internal/cli/buildinfo_test.go
@@ -94,3 +94,32 @@ func TestVersionCommandFlags(t *testing.T) {
 		t.Fatalf("json output = %q", out)
 	}
 }
+
+func TestBuildInfoDoesNotUseVCSTimeAsBuildTime(t *testing.T) {
+	// Empty BuildTimeUTC must stay "unknown" rather than silently adopting
+	// vcs.time (commit timestamp) from the Go build info.
+	info := BuildInfo{Version: "vdev", GitCommit: "deadbeef"}.withDefaults()
+	if info.BuildTimeUTC != "unknown" {
+		t.Fatalf("BuildTimeUTC without ldflags = %q, want unknown", info.BuildTimeUTC)
+	}
+}
+
+func TestReleaseStyleLdflagsAppearInVerbose(t *testing.T) {
+	// Simulates official release injection of commit + real UTC build time.
+	info := BuildInfo{
+		Version:      "vtest",
+		GitCommit:    "cafebabef00d",
+		BuildTimeUTC: "2026-08-06T12:34:56Z",
+		BuildTarget:  "linux/amd64",
+	}
+	text := info.verboseText()
+	if !strings.Contains(text, "git_commit: cafebabef00d") {
+		t.Fatalf("missing injected commit:\n%s", text)
+	}
+	if !strings.Contains(text, "build_time_utc: 2026-08-06T12:34:56Z") {
+		t.Fatalf("missing injected build time:\n%s", text)
+	}
+	if strings.Contains(text, "unknown") {
+		t.Fatalf("injected identity still unknown:\n%s", text)
+	}
+}

--- a/internal/cli/buildinfo_test.go
+++ b/internal/cli/buildinfo_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildInfoSingleLine(t *testing.T) {
+	info := BuildInfo{Version: "v1.2.3"}
+	if got, want := info.singleLine(), "reasonix v1.2.3"; got != want {
+		t.Fatalf("singleLine = %q, want %q", got, want)
+	}
+}
+
+func TestBuildInfoVerboseOmitsConfigAndCST(t *testing.T) {
+	info := BuildInfo{
+		Version:      "v9.9.9",
+		GitCommit:    "abcdef0123456789",
+		BuildTimeUTC: "2026-08-06T12:00:00Z",
+		BuildTarget:  "darwin/arm64",
+	}
+	text := info.verboseText()
+	if !strings.Contains(text, "reasonix v9.9.9") {
+		t.Fatalf("verbose missing version line:\n%s", text)
+	}
+	if !strings.Contains(text, "git_commit: abcdef012345") {
+		t.Fatalf("verbose missing short commit:\n%s", text)
+	}
+	if !strings.Contains(text, "build_time_utc: 2026-08-06T12:00:00Z") {
+		t.Fatalf("verbose missing utc time:\n%s", text)
+	}
+	if !strings.Contains(text, "build_target: darwin/arm64") {
+		t.Fatalf("verbose missing target:\n%s", text)
+	}
+	if strings.Contains(text, "config_path") || strings.Contains(text, "build_time_cst") || strings.Contains(text, "CST") {
+		t.Fatalf("verbose must not include config path or CST:\n%s", text)
+	}
+}
+
+func TestBuildInfoJSONShape(t *testing.T) {
+	info := BuildInfo{
+		Version:      "v1.0.0",
+		GitCommit:    "deadbeefcafebabe",
+		BuildTimeUTC: "2026-01-02T03:04:05Z",
+		BuildTarget:  "linux/amd64",
+	}
+	raw, err := json.Marshal(info.jsonPayload())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"version", "git_commit", "build_time_utc", "build_target", "go"} {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("json missing %q: %s", key, raw)
+		}
+	}
+	for _, key := range []string{"config_path", "build_time_cst", "build_number"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("json must not include %q: %s", key, raw)
+		}
+	}
+}
+
+func TestVersionCommandFlags(t *testing.T) {
+	info := BuildInfo{Version: "v2.0.0", GitCommit: "abc", BuildTimeUTC: "2026-08-06T00:00:00Z", BuildTarget: "test/arch"}
+	out := captureStdout(t, func() {
+		if code := versionCommand(nil, info, false); code != 0 {
+			t.Fatalf("code = %d", code)
+		}
+	})
+	if strings.TrimSpace(out) != "reasonix v2.0.0" {
+		t.Fatalf("--version line = %q", out)
+	}
+
+	out = captureStdout(t, func() {
+		if code := versionCommand([]string{"--verbose"}, info, true); code != 0 {
+			t.Fatalf("verbose code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "git_commit:") {
+		t.Fatalf("verbose output = %q", out)
+	}
+
+	out = captureStdout(t, func() {
+		if code := versionCommand([]string{"--json"}, info, true); code != 0 {
+			t.Fatalf("json code = %d", code)
+		}
+	})
+	if !strings.Contains(out, `"version": "v2.0.0"`) && !strings.Contains(out, `"version":"v2.0.0"`) {
+		t.Fatalf("json output = %q", out)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -54,7 +54,16 @@ var (
 )
 
 // Run is the CLI entry point; it returns a process exit code.
+// Prefer RunWithBuildInfo when git commit / build time are available from ldflags.
 func Run(args []string, version string) int {
+	return RunWithBuildInfo(args, BuildInfo{Version: version})
+}
+
+// RunWithBuildInfo is the full CLI entry with optional build metadata for
+// `reasonix version --verbose` / `--json`.
+func RunWithBuildInfo(args []string, info BuildInfo) int {
+	info = info.withDefaults()
+	version := info.Version
 	// Usage recording is asynchronous so provider/UI paths never wait on disk.
 	// Drain records accepted by this process before a normal CLI exit.
 	defer func() {
@@ -169,9 +178,14 @@ func Run(args []string, version string) int {
 	case "upgrade", "update":
 		configureCLIThemeFromConfig()
 		return upgradeCommand(rest, version)
-	case "version", "--version", "-v":
-		fmt.Println("reasonix", version)
-		return 0
+	case "version":
+		// Detailed identity: version --verbose / --json. Top-level --version/-v
+		// stay single-line for script compatibility (Integration D/E).
+		return versionCommand(rest, info, true)
+	case "--version", "-v":
+		return versionCommand(nil, info, false)
+	case "completion":
+		return completionCommand(rest)
 	case "docs-manifest":
 		return docsManifestCommand(rest, version)
 	case "help", "--help", "-h":

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -464,6 +464,21 @@ func TestRenderMCPStatusShowsQuarantinedTools(t *testing.T) {
 	}
 }
 
+func TestRenderMCPStatusShowsConfigSource(t *testing.T) {
+	got := renderMCPStatus(120,
+		[]plugin.ServerStatus{{
+			Name: "docs", Transport: "stdio", ConfigSource: "project_config", Tools: 1,
+			ToolList: []plugin.ToolInfo{{Name: "search", Description: "find docs"}},
+		}},
+		nil, nil, nil,
+	)
+	for _, want := range []string{"docs", "source=project_config", "tools", "search", "source=project_config"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered MCP status missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestMCPCapabilitiesTextUsesAdvertisedTools(t *testing.T) {
 	if got := mcpCapabilitiesText(mcpServerView{HasTools: true}); got != "tools" {
 		t.Fatalf("mcpCapabilitiesText = %q, want tools", got)

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -479,6 +479,57 @@ func TestRenderMCPStatusShowsConfigSource(t *testing.T) {
 	}
 }
 
+func TestRenderMCPStatusStripsControlSequencesFromExternalText(t *testing.T) {
+	// Malicious MCP description with CSI clear + OSC clipboard poke must not
+	// survive into the TUI payload.
+	evil := "safe\x1b[2J\x1b]52;c;AAAA\x07 payload"
+	got := renderMCPStatus(160,
+		[]plugin.ServerStatus{{
+			Name: "evil\x1b[31m", Transport: "stdio", ConfigSource: "user\x1b[0m",
+			Tools: 1,
+			ToolList: []plugin.ToolInfo{
+				{Name: "ok", Description: evil},
+				{Name: "bad", SchemaError: "schema\x1b[1merr"},
+			},
+		}},
+		[]plugin.Prompt{{Server: "evil", Name: "p", Description: "prompt\x1b[2J"}},
+		[]plugin.Resource{{Server: "evil", URI: "file:///x", Name: "res\x1b]0;x\x07"}},
+		[]plugin.Failure{{Name: "fail", Error: "boom\x1b[2J"}},
+	)
+	for _, ban := range []string{"\x1b", "\x07", "]52;", "[2J", "[31m", "[1m"} {
+		if strings.Contains(got, ban) {
+			t.Fatalf("control sequence %q leaked into MCP status:\n%q", ban, got)
+		}
+	}
+	if !strings.Contains(got, "safe") || !strings.Contains(got, "payload") {
+		t.Fatalf("sanitized description lost content:\n%s", got)
+	}
+	// Invalid tools must not appear under the ordinary tools list.
+	toolsIdx := strings.Index(got, "tools")
+	unavailIdx := strings.Index(got, "unavailable tools")
+	if toolsIdx < 0 || unavailIdx < 0 {
+		t.Fatalf("expected tools and unavailable sections:\n%s", got)
+	}
+	toolsSection := got[toolsIdx:unavailIdx]
+	if strings.Contains(toolsSection, "bad") {
+		t.Fatalf("invalid tool listed under tools:\n%s", toolsSection)
+	}
+	if !strings.Contains(got[unavailIdx:], "bad") {
+		t.Fatalf("invalid tool missing from unavailable:\n%s", got)
+	}
+}
+
+func TestSanitizeExternalDisplayText(t *testing.T) {
+	in := "hello\x1b[2J\x1b]52;c;QQ\x07 world\n\t!"
+	got := sanitizeExternalDisplayText(in)
+	if strings.ContainsAny(got, "\x1b\x07\n\t") {
+		t.Fatalf("controls remain: %q", got)
+	}
+	if got != "hello world !" {
+		t.Fatalf("sanitize = %q", got)
+	}
+}
+
 func TestMCPCapabilitiesTextUsesAdvertisedTools(t *testing.T) {
 	if got := mcpCapabilitiesText(mcpServerView{HasTools: true}); got != "tools" {
 		t.Fatalf("mcpCapabilitiesText = %q, want tools", got)

--- a/internal/cli/mcp_view.go
+++ b/internal/cli/mcp_view.go
@@ -63,12 +63,18 @@ func writeMCPServer(b *strings.Builder, width int, s plugin.ServerStatus, prompt
 		transport = "unknown"
 	}
 	meta := fmt.Sprintf("(%s)  %s · %s · %s", transport, countText(s.Tools, "tool"), countText(len(prompts), "prompt"), countText(len(resources), "resource"))
+	if src := strings.TrimSpace(s.ConfigSource); src != "" {
+		meta += " · source=" + src
+	}
 	invalidTools := invalidMCPTools(s.ToolList)
 	if len(invalidTools) > 0 {
 		meta += " · " + countText(len(invalidTools), "unavailable tool")
 	}
 	name := viewCompactText(s.Name, viewBudget(width, 4+2+1+visibleWidth(meta)))
 	fmt.Fprintf(b, "    %s %s %s\n", accent("✓"), bold(name), viewMeta(meta))
+	if len(s.ToolList) > 0 {
+		writeMCPToolList(b, width, s)
+	}
 	if len(prompts) > 0 {
 		writeMCPPromptList(b, width, prompts)
 	}
@@ -87,6 +93,36 @@ func writeMCPServer(b *strings.Builder, width int, s plugin.ServerStatus, prompt
 		if extra := len(invalidTools) - limit; extra > 0 {
 			fmt.Fprintf(b, "    %s\n", viewMore(extra, "unavailable tools"))
 		}
+	}
+}
+
+// writeMCPToolList lists connected tools under the server, tagging the
+// config-plane source when known so operators can trace a tool back to its
+// registration (#6578 / Integration D/E).
+func writeMCPToolList(b *strings.Builder, width int, s plugin.ServerStatus) {
+	tools := s.ToolList
+	if len(tools) == 0 {
+		return
+	}
+	b.WriteString(viewSubhead("    tools") + "\n")
+	limit := len(tools)
+	if limit > mcpMaxItemsPerSection {
+		limit = mcpMaxItemsPerSection
+	}
+	src := strings.TrimSpace(s.ConfigSource)
+	for _, t := range tools[:limit] {
+		detail := strings.TrimSpace(t.Description)
+		if src != "" {
+			if detail != "" {
+				detail = detail + " · source=" + src
+			} else {
+				detail = "source=" + src
+			}
+		}
+		writeMCPItem(b, width, "      ", t.Name, detail)
+	}
+	if extra := len(tools) - limit; extra > 0 {
+		fmt.Fprintf(b, "    %s\n", viewMore(extra, "tools"))
 	}
 }
 

--- a/internal/cli/mcp_view.go
+++ b/internal/cli/mcp_view.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/plugin"
 )
@@ -63,17 +66,18 @@ func writeMCPServer(b *strings.Builder, width int, s plugin.ServerStatus, prompt
 		transport = "unknown"
 	}
 	meta := fmt.Sprintf("(%s)  %s · %s · %s", transport, countText(s.Tools, "tool"), countText(len(prompts), "prompt"), countText(len(resources), "resource"))
-	if src := strings.TrimSpace(s.ConfigSource); src != "" {
+	if src := sanitizeExternalDisplayText(s.ConfigSource); src != "" {
 		meta += " · source=" + src
 	}
 	invalidTools := invalidMCPTools(s.ToolList)
+	availableTools := validMCPTools(s.ToolList)
 	if len(invalidTools) > 0 {
 		meta += " · " + countText(len(invalidTools), "unavailable tool")
 	}
-	name := viewCompactText(s.Name, viewBudget(width, 4+2+1+visibleWidth(meta)))
+	name := viewCompactText(sanitizeExternalDisplayText(s.Name), viewBudget(width, 4+2+1+visibleWidth(meta)))
 	fmt.Fprintf(b, "    %s %s %s\n", accent("✓"), bold(name), viewMeta(meta))
-	if len(s.ToolList) > 0 {
-		writeMCPToolList(b, width, s)
+	if len(availableTools) > 0 {
+		writeMCPToolList(b, width, s, availableTools)
 	}
 	if len(prompts) > 0 {
 		writeMCPPromptList(b, width, prompts)
@@ -88,7 +92,7 @@ func writeMCPServer(b *strings.Builder, width int, s plugin.ServerStatus, prompt
 			limit = mcpMaxItemsPerSection
 		}
 		for _, t := range invalidTools[:limit] {
-			writeMCPItem(b, width, "      ", t.Name, t.SchemaError)
+			writeMCPItem(b, width, "      ", sanitizeExternalDisplayText(t.Name), sanitizeExternalDisplayText(t.SchemaError))
 		}
 		if extra := len(invalidTools) - limit; extra > 0 {
 			fmt.Fprintf(b, "    %s\n", viewMore(extra, "unavailable tools"))
@@ -96,11 +100,11 @@ func writeMCPServer(b *strings.Builder, width int, s plugin.ServerStatus, prompt
 	}
 }
 
-// writeMCPToolList lists connected tools under the server, tagging the
+// writeMCPToolList lists valid connected tools under the server, tagging the
 // config-plane source when known so operators can trace a tool back to its
-// registration (#6578 / Integration D/E).
-func writeMCPToolList(b *strings.Builder, width int, s plugin.ServerStatus) {
-	tools := s.ToolList
+// registration (#6578 / Integration D/E). Callers pass pre-filtered tools
+// (SchemaError == "") so quarantined tools only appear under unavailable.
+func writeMCPToolList(b *strings.Builder, width int, s plugin.ServerStatus, tools []plugin.ToolInfo) {
 	if len(tools) == 0 {
 		return
 	}
@@ -109,9 +113,9 @@ func writeMCPToolList(b *strings.Builder, width int, s plugin.ServerStatus) {
 	if limit > mcpMaxItemsPerSection {
 		limit = mcpMaxItemsPerSection
 	}
-	src := strings.TrimSpace(s.ConfigSource)
+	src := sanitizeExternalDisplayText(s.ConfigSource)
 	for _, t := range tools[:limit] {
-		detail := strings.TrimSpace(t.Description)
+		detail := sanitizeExternalDisplayText(t.Description)
 		if src != "" {
 			if detail != "" {
 				detail = detail + " · source=" + src
@@ -119,7 +123,7 @@ func writeMCPToolList(b *strings.Builder, width int, s plugin.ServerStatus) {
 				detail = "source=" + src
 			}
 		}
-		writeMCPItem(b, width, "      ", t.Name, detail)
+		writeMCPItem(b, width, "      ", sanitizeExternalDisplayText(t.Name), detail)
 	}
 	if extra := len(tools) - limit; extra > 0 {
 		fmt.Fprintf(b, "    %s\n", viewMore(extra, "tools"))
@@ -136,13 +140,23 @@ func invalidMCPTools(tools []plugin.ToolInfo) []plugin.ToolInfo {
 	return out
 }
 
+func validMCPTools(tools []plugin.ToolInfo) []plugin.ToolInfo {
+	out := make([]plugin.ToolInfo, 0, len(tools))
+	for _, t := range tools {
+		if t.SchemaError == "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 func writeMCPFailure(b *strings.Builder, width int, f plugin.Failure) {
 	transport := f.Transport
 	if transport == "" {
 		transport = "unknown"
 	}
-	meta := fmt.Sprintf("(%s)  %s", transport, oneLineText(f.Error))
-	name := viewCompactText(f.Name, viewBudget(width, 4+2+1+visibleWidth(meta)))
+	meta := fmt.Sprintf("(%s)  %s", transport, sanitizeExternalDisplayText(f.Error))
+	name := viewCompactText(sanitizeExternalDisplayText(f.Name), viewBudget(width, 4+2+1+visibleWidth(meta)))
 	fmt.Fprintf(b, "    %s %s %s\n", yellow("!"), bold(name), viewMeta(viewCompactText(meta, viewBudget(width, 10+visibleWidth(name)))))
 }
 
@@ -153,7 +167,7 @@ func writeMCPPromptList(b *strings.Builder, width int, prompts []plugin.Prompt) 
 		limit = mcpMaxItemsPerSection
 	}
 	for _, p := range prompts[:limit] {
-		writeMCPItem(b, width, "      ", "/"+p.Name, p.Description)
+		writeMCPItem(b, width, "      ", "/"+sanitizeExternalDisplayText(p.Name), sanitizeExternalDisplayText(p.Description))
 	}
 	if extra := len(prompts) - limit; extra > 0 {
 		fmt.Fprintf(b, "    %s\n", viewMore(extra, "prompts"))
@@ -167,18 +181,19 @@ func writeMCPResourceList(b *strings.Builder, width int, resources []plugin.Reso
 		limit = mcpMaxItemsPerSection
 	}
 	for _, r := range resources[:limit] {
-		label := strings.TrimSpace(r.Name)
+		label := sanitizeExternalDisplayText(r.Name)
 		if label == "" {
-			label = strings.TrimSpace(r.Description)
+			label = sanitizeExternalDisplayText(r.Description)
 		}
 		if r.MimeType != "" {
+			mime := sanitizeExternalDisplayText(r.MimeType)
 			if label == "" {
-				label = r.MimeType
+				label = mime
 			} else {
-				label += " [" + r.MimeType + "]"
+				label += " [" + mime + "]"
 			}
 		}
-		writeMCPItem(b, width, "      ", "@"+r.Server+":"+r.URI, label)
+		writeMCPItem(b, width, "      ", "@"+sanitizeExternalDisplayText(r.Server)+":"+sanitizeExternalDisplayText(r.URI), label)
 	}
 	if extra := len(resources) - limit; extra > 0 {
 		fmt.Fprintf(b, "    %s\n", viewMore(extra, "resources"))
@@ -186,8 +201,8 @@ func writeMCPResourceList(b *strings.Builder, width int, resources []plugin.Reso
 }
 
 func writeMCPItem(b *strings.Builder, width int, indent, ref, desc string) {
-	desc = oneLineText(desc)
-	ref = oneLineText(ref)
+	desc = sanitizeExternalDisplayText(desc)
+	ref = sanitizeExternalDisplayText(ref)
 	available := viewBudget(width, visibleWidth(indent))
 	if desc == "" || available < 30 {
 		b.WriteString(indent + compactMiddle(ref, available))
@@ -208,8 +223,34 @@ func writeMCPItem(b *strings.Builder, width int, indent, ref, desc string) {
 	b.WriteByte('\n')
 }
 
+// sanitizeExternalDisplayText strips ANSI/OSC/C0 control sequences from text
+// that originated outside Reasonix (MCP tool/prompt/resource fields, source
+// labels, failure messages) before it is rendered into the TUI. TrimSpace and
+// Fields alone leave CSI sequences intact and would let a malicious MCP rewrite
+// the terminal, spoof chrome, or poke the clipboard.
+func sanitizeExternalDisplayText(s string) string {
+	s = ansi.Strip(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			b.WriteByte(' ')
+		case r < 0x20 || r == 0x7f:
+			// Drop remaining C0 controls and DEL.
+		case r >= 0x80 && r <= 0x9f:
+			// Drop C1 controls (including after partial decode).
+		case unicode.Is(unicode.Cc, r):
+			// Other control categories.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
 func oneLineText(s string) string {
-	return strings.Join(strings.Fields(s), " ")
+	return sanitizeExternalDisplayText(s)
 }
 
 func countText(n int, noun string) string {

--- a/internal/cli/shell_completion.go
+++ b/internal/cli/shell_completion.go
@@ -113,7 +113,9 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			model, profile,
 			completionFlag("--max-steps", cliCompletionStaticValue),
 			completionFlag("--addr", cliCompletionStaticValue),
-			completionFlag("--resume", cliCompletionSessionValue), // required session file/ID
+			// serve loads the path with open/loadResumableSession — file path only,
+			// not branch IDs (SessionValue would complete IDs that fail at runtime).
+			completionFlag("--resume", cliCompletionPathValue),
 			completionFlag("--auth", cliCompletionStaticValue, "none", "token", "password"),
 			completionFlag("--token --password --port-file --token-file --pid-file", cliCompletionStaticValue),
 			completionFlag("--hash-password --behind-proxy", cliCompletionNoValue), help,

--- a/internal/cli/shell_completion.go
+++ b/internal/cli/shell_completion.go
@@ -14,6 +14,8 @@ type cliCompletionValueKind uint8
 const (
 	cliCompletionNoValue cliCompletionValueKind = iota
 	cliCompletionStaticValue
+	cliCompletionOptionalValue // next token may be a value or another flag (--resume [QUERY])
+	cliCompletionPathValue     // path/file; backend returns empty so shells use default file completion
 	cliCompletionModelValue
 	cliCompletionSessionValue
 )
@@ -46,7 +48,7 @@ func completionSpecWithAliases(name string, aliases []string, flags []cliComplet
 func cliCompletionRootSpec() cliCompletionSpec {
 	profile := completionFlag("--profile", cliCompletionStaticValue, "economy", "balanced", "delivery")
 	model := completionFlag("--model", cliCompletionModelValue)
-	resume := completionFlag("--resume -r", cliCompletionSessionValue)
+	resume := completionFlag("--resume -r", cliCompletionOptionalValue) // optional QUERY
 	effort := completionFlag("--effort", cliCompletionStaticValue, "auto", "low", "medium", "high", "max")
 	permissionMode := completionFlag("--permission-mode", cliCompletionStaticValue,
 		"manual", "ask", "auto", "acceptEdits", "dontAsk", "plan", "bypassPermissions")
@@ -59,9 +61,9 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		resume,
 		completionFlag("--copy", cliCompletionNoValue),
 		completionFlag("--dangerously-skip-permissions --yolo", cliCompletionNoValue),
-		completionFlag("--dir", cliCompletionStaticValue),
+		completionFlag("--dir", cliCompletionPathValue),
 		effort, permissionMode,
-		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--add-dir", cliCompletionPathValue),
 		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
 		help,
 	}
@@ -69,18 +71,19 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		model, profile,
 		completionFlag("--max-steps", cliCompletionStaticValue),
 		completionFlag("--show-thinking", cliCompletionNoValue),
-		completionFlag("--metrics", cliCompletionStaticValue),
-		completionFlag("--dir", cliCompletionStaticValue),
+		completionFlag("--metrics", cliCompletionPathValue),
+		completionFlag("--dir", cliCompletionPathValue),
 		completionFlag("--continue -c", cliCompletionNoValue),
-		completionFlag("--resume", cliCompletionSessionValue),
+		completionFlag("--resume", cliCompletionOptionalValue),
 		completionFlag("--copy", cliCompletionNoValue),
 		effort, permissionMode,
 		completionFlag("--auto -y", cliCompletionNoValue),
 		completionFlag("--print -p", cliCompletionNoValue),
 		completionFlag("--events-jsonl", cliCompletionNoValue),
 		completionFlag("--output-format", cliCompletionStaticValue, "text", "json", "stream-json"),
-		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--add-dir", cliCompletionPathValue),
 		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
+		completionFlag("--ablate", cliCompletionStaticValue, "none", "all", "evidence", "planner", "subagent", "retrieval", "compaction"),
 		help,
 	}
 
@@ -94,8 +97,8 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		completionFlag("--dangerously-skip-permissions --yolo", cliCompletionNoValue),
 		permissionMode,
 		effort,
-		completionFlag("--dir", cliCompletionStaticValue),
-		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--dir", cliCompletionPathValue),
+		completionFlag("--add-dir", cliCompletionPathValue),
 		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
 		completionFlag("--acp", cliCompletionNoValue),
 		completionFlag("--version -v", cliCompletionNoValue),
@@ -108,7 +111,7 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			model, profile,
 			completionFlag("--max-steps", cliCompletionStaticValue),
 			completionFlag("--addr", cliCompletionStaticValue),
-			completionFlag("--resume", cliCompletionSessionValue),
+			completionFlag("--resume", cliCompletionOptionalValue),
 			completionFlag("--auth", cliCompletionStaticValue, "none", "token", "password"),
 			completionFlag("--token --password --port-file --token-file --pid-file", cliCompletionStaticValue),
 			completionFlag("--hash-password --behind-proxy", cliCompletionNoValue), help,
@@ -191,11 +194,11 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			completionSpec("doctor", []cliCompletionFlag{help}),
 		),
 		completionSpec("subagent", []cliCompletionFlag{help},
-			completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{completionFlag("--dir", cliCompletionStaticValue), help}),
+			completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{completionFlag("--dir", cliCompletionPathValue), help}),
 			completionSpecWithAliases("create", []string{"new"}, append(subagentCompletionFlags(model, effort, help), completionFlag("--scope", cliCompletionStaticValue, "project", "global"))),
 			completionSpecWithAliases("edit", []string{"update"}, subagentCompletionFlags(model, effort, help)),
 			completionSpecWithAliases("delete", []string{"remove", "rm"}, []cliCompletionFlag{
-				completionFlag("--yes", cliCompletionNoValue), completionFlag("--dir", cliCompletionStaticValue), help,
+				completionFlag("--yes", cliCompletionNoValue), completionFlag("--dir", cliCompletionPathValue), help,
 			}),
 			completionSpec("try", []cliCompletionFlag{model, completionFlag("--max-steps --dir", cliCompletionStaticValue), help}),
 			completionSpec("run", []cliCompletionFlag{model, completionFlag("--max-steps --dir", cliCompletionStaticValue), help}),
@@ -206,7 +209,7 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			}),
 			completionSpec("quality", []cliCompletionFlag{completionFlag("--json", cliCompletionNoValue), help}),
 			completionSpec("session", []cliCompletionFlag{completionFlag("--zip", cliCompletionNoValue), completionFlag("--out", cliCompletionStaticValue), help}),
-			completionSpec("redact-sessions", []cliCompletionFlag{completionFlag("--dry-run --json", cliCompletionNoValue), completionFlag("--dir", cliCompletionStaticValue), help}),
+			completionSpec("redact-sessions", []cliCompletionFlag{completionFlag("--dry-run --json", cliCompletionNoValue), completionFlag("--dir", cliCompletionPathValue), help}),
 			completionSpec("capabilities", []cliCompletionFlag{
 				completionFlag("--root --timeout", cliCompletionStaticValue), completionFlag("--json --live", cliCompletionNoValue), help,
 			}),
@@ -230,6 +233,27 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		completionSpec("task", []cliCompletionFlag{help},
 			completionSpec("list", taskCompletionFlags(help)),
 			completionSpec("show", taskCompletionFlags(help)),
+			completionSpec("monitor", []cliCompletionFlag{help},
+				completionSpec("list", taskCompletionFlags(help)),
+				completionSpec("status", taskCompletionFlags(help)),
+				completionSpec("events", taskCompletionFlags(help)),
+				completionSpec("stop", taskCompletionFlags(help)),
+				completionSpec("cancel", taskCompletionFlags(help)),
+				completionSpec("requeue", taskCompletionFlags(help)),
+				completionSpec("open-session", taskCompletionFlags(help)),
+			),
+			completionSpec("status", taskCompletionFlags(help)),
+			completionSpec("events", taskCompletionFlags(help)),
+			completionSpec("stop", taskCompletionFlags(help)),
+			completionSpec("cancel", taskCompletionFlags(help)),
+			completionSpec("requeue", taskCompletionFlags(help)),
+			completionSpec("open-session", taskCompletionFlags(help)),
+			completionSpec("tmux", []cliCompletionFlag{help},
+				completionSpec("attach", nil),
+				completionSpec("status", nil),
+				completionSpec("open", nil),
+				completionSpec("detach", nil),
+			),
 		),
 		completionSpec("review", []cliCompletionFlag{
 			completionFlag("--base --commit --instructions", cliCompletionStaticValue), model, help,
@@ -370,8 +394,15 @@ func cliCompletionCandidatesWithValues(root cliCompletionSpec, cword int, words 
 	for i := 1; i < limit; i++ {
 		token := words[i]
 		if awaiting != nil {
-			awaiting = nil
-			continue
+			// Optional values may be omitted: a following flag-looking token is
+			// treated as the next flag rather than the optional value.
+			if awaiting.kind == cliCompletionOptionalValue && strings.HasPrefix(token, "-") && !strings.HasPrefix(token, "---") {
+				awaiting = nil
+				// fall through and parse token as a flag/subcommand
+			} else {
+				awaiting = nil
+				continue
+			}
 		}
 		if flag, inline := cliCompletionLookupFlag(ctx, token); flag != nil {
 			if flag.kind != cliCompletionNoValue && !inline {
@@ -392,7 +423,24 @@ func cliCompletionCandidatesWithValues(root cliCompletionSpec, cword int, words 
 	}
 
 	if awaiting != nil {
-		return filterCompletionPrefix(completionFlagValues(*awaiting, dynamic), current)
+		if awaiting.kind == cliCompletionPathValue {
+			// Empty candidates → shell default file completion (bash -o default, zsh _default, fish without -f).
+			return nil
+		}
+		if awaiting.kind == cliCompletionOptionalValue && strings.HasPrefix(current, "-") {
+			// Completing another flag after optional-value flag with no value typed.
+			var out []string
+			for _, flag := range ctx.flags {
+				out = append(out, flag.names...)
+			}
+			return filterCompletionPrefix(stableUniqueCompletionValues(out), current)
+		}
+		values := completionFlagValues(*awaiting, dynamic)
+		if awaiting.kind == cliCompletionOptionalValue {
+			// Also offer session IDs for --resume optional QUERY.
+			values = append(values, dynamic(cliCompletionSessionValue)...)
+		}
+		return filterCompletionPrefix(stableUniqueCompletionValues(values), current)
 	}
 	if name, value, ok := strings.Cut(current, "="); ok {
 		if flag, _ := cliCompletionLookupFlag(ctx, name); flag != nil && flag.kind != cliCompletionNoValue {
@@ -457,6 +505,11 @@ func completionFlagValues(flag cliCompletionFlag, dynamic func(cliCompletionValu
 	switch flag.kind {
 	case cliCompletionStaticValue:
 		return stableUniqueCompletionValues(flag.values)
+	case cliCompletionOptionalValue:
+		// Static optional values if declared; sessions are merged by the caller for --resume.
+		return stableUniqueCompletionValues(flag.values)
+	case cliCompletionPathValue:
+		return nil
 	case cliCompletionModelValue, cliCompletionSessionValue:
 		return stableUniqueCompletionValues(dynamic(flag.kind))
 	default:
@@ -541,5 +594,5 @@ const fishCompletionScript = `function __reasonix_completion
     set -l current_index (math (count $tokens) - 1)
     command reasonix completion __complete $current_index $tokens 2>/dev/null
 end
-complete -c reasonix -f -a '(__reasonix_completion)'
+complete -c reasonix -a '(__reasonix_completion)'
 `

--- a/internal/cli/shell_completion.go
+++ b/internal/cli/shell_completion.go
@@ -1,0 +1,545 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+type cliCompletionValueKind uint8
+
+const (
+	cliCompletionNoValue cliCompletionValueKind = iota
+	cliCompletionStaticValue
+	cliCompletionModelValue
+	cliCompletionSessionValue
+)
+
+type cliCompletionFlag struct {
+	names  []string
+	kind   cliCompletionValueKind
+	values []string
+}
+
+type cliCompletionSpec struct {
+	name        string
+	aliases     []string
+	flags       []cliCompletionFlag
+	subcommands []cliCompletionSpec
+}
+
+func completionFlag(names string, kind cliCompletionValueKind, values ...string) cliCompletionFlag {
+	return cliCompletionFlag{names: strings.Fields(names), kind: kind, values: values}
+}
+
+func completionSpec(name string, flags []cliCompletionFlag, subcommands ...cliCompletionSpec) cliCompletionSpec {
+	return cliCompletionSpec{name: name, flags: flags, subcommands: subcommands}
+}
+
+func completionSpecWithAliases(name string, aliases []string, flags []cliCompletionFlag, subcommands ...cliCompletionSpec) cliCompletionSpec {
+	return cliCompletionSpec{name: name, aliases: aliases, flags: flags, subcommands: subcommands}
+}
+
+func cliCompletionRootSpec() cliCompletionSpec {
+	profile := completionFlag("--profile", cliCompletionStaticValue, "economy", "balanced", "delivery")
+	model := completionFlag("--model", cliCompletionModelValue)
+	resume := completionFlag("--resume -r", cliCompletionSessionValue)
+	effort := completionFlag("--effort", cliCompletionStaticValue, "auto", "low", "medium", "high", "max")
+	permissionMode := completionFlag("--permission-mode", cliCompletionStaticValue,
+		"manual", "ask", "auto", "acceptEdits", "dontAsk", "plan", "bypassPermissions")
+	help := completionFlag("--help -h", cliCompletionNoValue)
+
+	interactiveFlags := []cliCompletionFlag{
+		model, profile,
+		completionFlag("--max-steps", cliCompletionStaticValue),
+		completionFlag("--continue -c", cliCompletionNoValue),
+		resume,
+		completionFlag("--copy", cliCompletionNoValue),
+		completionFlag("--dangerously-skip-permissions --yolo", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionStaticValue),
+		effort, permissionMode,
+		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
+		help,
+	}
+	runFlags := []cliCompletionFlag{
+		model, profile,
+		completionFlag("--max-steps", cliCompletionStaticValue),
+		completionFlag("--show-thinking", cliCompletionNoValue),
+		completionFlag("--metrics", cliCompletionStaticValue),
+		completionFlag("--dir", cliCompletionStaticValue),
+		completionFlag("--continue -c", cliCompletionNoValue),
+		completionFlag("--resume", cliCompletionSessionValue),
+		completionFlag("--copy", cliCompletionNoValue),
+		effort, permissionMode,
+		completionFlag("--auto -y", cliCompletionNoValue),
+		completionFlag("--print -p", cliCompletionNoValue),
+		completionFlag("--events-jsonl", cliCompletionNoValue),
+		completionFlag("--output-format", cliCompletionStaticValue, "text", "json", "stream-json"),
+		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
+		help,
+	}
+
+	root := cliCompletionSpec{name: "reasonix", flags: append([]cliCompletionFlag{
+		model,
+		completionFlag("--max-steps", cliCompletionStaticValue),
+		completionFlag("--print -p", cliCompletionNoValue),
+		completionFlag("--continue -c", cliCompletionNoValue),
+		resume,
+		completionFlag("--copy", cliCompletionNoValue),
+		completionFlag("--dangerously-skip-permissions --yolo", cliCompletionNoValue),
+		permissionMode,
+		effort,
+		completionFlag("--dir", cliCompletionStaticValue),
+		completionFlag("--add-dir", cliCompletionStaticValue),
+		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
+		completionFlag("--acp", cliCompletionNoValue),
+		completionFlag("--version -v", cliCompletionNoValue),
+	}, help)}
+
+	root.subcommands = []cliCompletionSpec{
+		completionSpec("run", runFlags),
+		completionSpecWithAliases("chat", []string{"code"}, interactiveFlags),
+		completionSpec("serve", []cliCompletionFlag{
+			model, profile,
+			completionFlag("--max-steps", cliCompletionStaticValue),
+			completionFlag("--addr", cliCompletionStaticValue),
+			completionFlag("--resume", cliCompletionSessionValue),
+			completionFlag("--auth", cliCompletionStaticValue, "none", "token", "password"),
+			completionFlag("--token --password --port-file --token-file --pid-file", cliCompletionStaticValue),
+			completionFlag("--hash-password --behind-proxy", cliCompletionNoValue), help,
+		}),
+		completionSpec("setup", []cliCompletionFlag{completionFlag("--local -l", cliCompletionNoValue), help}),
+		completionSpec("config", []cliCompletionFlag{help},
+			completionSpec("auto-plan", []cliCompletionFlag{completionFlag("--local", cliCompletionNoValue), help}),
+			completionSpec("reasoning-language", []cliCompletionFlag{completionFlag("--local", cliCompletionNoValue), help}),
+			completionSpec("compact-ratio", []cliCompletionFlag{completionFlag("--local", cliCompletionNoValue), help}),
+			completionSpec("currency", []cliCompletionFlag{completionFlag("--local", cliCompletionNoValue), help}),
+			completionSpec("telemetry", []cliCompletionFlag{help}),
+		),
+		completionSpec("init", []cliCompletionFlag{help}),
+		completionSpec("acp", []cliCompletionFlag{
+			model, profile,
+			completionFlag("--planner", cliCompletionStaticValue, "auto", "off"),
+			completionFlag("--sandbox-network", cliCompletionStaticValue, "auto", "on", "off"),
+			completionFlag("--sandbox-bash", cliCompletionStaticValue, "auto", "enforce"),
+			completionFlag("--workspace-only", cliCompletionNoValue), help,
+		}),
+		completionSpec("mcp", []cliCompletionFlag{help},
+			completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{help}),
+			completionSpec("get", []cliCompletionFlag{help}),
+			completionSpec("add", []cliCompletionFlag{
+				completionFlag("--http --streamable-http --sse --env --header", cliCompletionStaticValue), help,
+			}),
+			completionSpec("enable", []cliCompletionFlag{help}),
+			completionSpec("disable", []cliCompletionFlag{help}),
+			completionSpecWithAliases("retry", []string{"connect"}, []cliCompletionFlag{help}),
+			completionSpec("update", []cliCompletionFlag{help}),
+			completionSpec("import", []cliCompletionFlag{help}),
+			completionSpecWithAliases("browse", []string{"search"}, []cliCompletionFlag{
+				completionFlag("--limit", cliCompletionStaticValue), completionFlag("--json", cliCompletionNoValue), help,
+			}),
+			completionSpec("install", []cliCompletionFlag{completionFlag("--as", cliCompletionStaticValue), help}),
+			completionSpecWithAliases("remove", []string{"rm"}, []cliCompletionFlag{help}),
+		),
+		completionSpec("remote", []cliCompletionFlag{help},
+			completionSpec("add", []cliCompletionFlag{
+				completionFlag("--identity --jump --workspace --serve-install --passphrase-env --password-env", cliCompletionStaticValue),
+				completionFlag("--use-ssh-config", cliCompletionNoValue), help,
+			}),
+			completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{help}),
+			completionSpecWithAliases("remove", []string{"rm"}, []cliCompletionFlag{help}),
+			completionSpec("import", []cliCompletionFlag{completionFlag("--all", cliCompletionNoValue), help}),
+			completionSpec("test", []cliCompletionFlag{help}),
+			completionSpecWithAliases("connect", []string{"open"}, []cliCompletionFlag{
+				completionFlag("--workspace --local-port", cliCompletionStaticValue),
+				completionFlag("--no-serve --open --forward-only", cliCompletionNoValue), help,
+			}),
+			completionSpec("status", []cliCompletionFlag{help}),
+			completionSpec("forward", []cliCompletionFlag{help},
+				completionSpec("add", []cliCompletionFlag{help}),
+				completionSpecWithAliases("remove", []string{"rm"}, []cliCompletionFlag{help}),
+				completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{help}),
+			),
+			completionSpec("serve", []cliCompletionFlag{help},
+				completionSpec("start", []cliCompletionFlag{completionFlag("--workspace -n", cliCompletionStaticValue), help}),
+				completionSpec("stop", []cliCompletionFlag{completionFlag("--workspace -n", cliCompletionStaticValue), help}),
+				completionSpec("status", []cliCompletionFlag{completionFlag("--workspace -n", cliCompletionStaticValue), help}),
+				completionSpec("logs", []cliCompletionFlag{completionFlag("--workspace -n", cliCompletionStaticValue), help}),
+			),
+			completionSpec("fs", []cliCompletionFlag{help},
+				completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{help}),
+				completionSpec("get", []cliCompletionFlag{help}),
+				completionSpec("put", []cliCompletionFlag{help}),
+			),
+			completionSpec("attach-workspace", []cliCompletionFlag{completionFlag("--stdio", cliCompletionNoValue), completionFlag("--workspace", cliCompletionStaticValue), help}),
+		),
+		completionSpec("plugin", []cliCompletionFlag{help},
+			completionSpec("install", []cliCompletionFlag{
+				completionFlag("--yes --dry-run --link --replace", cliCompletionNoValue),
+				completionFlag("--name", cliCompletionStaticValue), help,
+			}),
+			completionSpec("list", []cliCompletionFlag{help}),
+			completionSpec("show", []cliCompletionFlag{help}),
+			completionSpecWithAliases("remove", []string{"uninstall"}, []cliCompletionFlag{completionFlag("--yes", cliCompletionNoValue), help}),
+			completionSpec("enable", []cliCompletionFlag{help}),
+			completionSpec("disable", []cliCompletionFlag{help}),
+			completionSpec("doctor", []cliCompletionFlag{help}),
+		),
+		completionSpec("subagent", []cliCompletionFlag{help},
+			completionSpecWithAliases("list", []string{"ls"}, []cliCompletionFlag{completionFlag("--dir", cliCompletionStaticValue), help}),
+			completionSpecWithAliases("create", []string{"new"}, append(subagentCompletionFlags(model, effort, help), completionFlag("--scope", cliCompletionStaticValue, "project", "global"))),
+			completionSpecWithAliases("edit", []string{"update"}, subagentCompletionFlags(model, effort, help)),
+			completionSpecWithAliases("delete", []string{"remove", "rm"}, []cliCompletionFlag{
+				completionFlag("--yes", cliCompletionNoValue), completionFlag("--dir", cliCompletionStaticValue), help,
+			}),
+			completionSpec("try", []cliCompletionFlag{model, completionFlag("--max-steps --dir", cliCompletionStaticValue), help}),
+			completionSpec("run", []cliCompletionFlag{model, completionFlag("--max-steps --dir", cliCompletionStaticValue), help}),
+		),
+		completionSpec("doctor", []cliCompletionFlag{completionFlag("--json", cliCompletionNoValue), help},
+			completionSpec("repair", []cliCompletionFlag{
+				completionFlag("--root", cliCompletionStaticValue), completionFlag("--apply --project --json", cliCompletionNoValue), help,
+			}),
+			completionSpec("quality", []cliCompletionFlag{completionFlag("--json", cliCompletionNoValue), help}),
+			completionSpec("session", []cliCompletionFlag{completionFlag("--zip", cliCompletionNoValue), completionFlag("--out", cliCompletionStaticValue), help}),
+			completionSpec("redact-sessions", []cliCompletionFlag{completionFlag("--dry-run --json", cliCompletionNoValue), completionFlag("--dir", cliCompletionStaticValue), help}),
+			completionSpec("capabilities", []cliCompletionFlag{
+				completionFlag("--root --timeout", cliCompletionStaticValue), completionFlag("--json --live", cliCompletionNoValue), help,
+			}),
+		),
+		completionSpec("report", []cliCompletionFlag{help},
+			completionSpec("list", []cliCompletionFlag{help}),
+			completionSpec("show", []cliCompletionFlag{help}),
+			completionSpec("send", []cliCompletionFlag{help}),
+			completionSpec("delete", []cliCompletionFlag{help}),
+		),
+		completionSpec("session", []cliCompletionFlag{help},
+			completionSpec("list", machineSessionCompletionFlags(help)),
+			completionSpec("show", machineSessionCompletionFlags(help)),
+			completionSpec("status", machineSessionCompletionFlags(help)),
+			completionSpec("recovery", machineSessionCompletionFlags(help)),
+		),
+		completionSpecWithAliases("hook", []string{"hooks"}, []cliCompletionFlag{help},
+			completionSpec("list", hookCompletionFlags(help)),
+			completionSpec("status", hookCompletionFlags(help)),
+		),
+		completionSpec("task", []cliCompletionFlag{help},
+			completionSpec("list", taskCompletionFlags(help)),
+			completionSpec("show", taskCompletionFlags(help)),
+		),
+		completionSpec("review", []cliCompletionFlag{
+			completionFlag("--base --commit --instructions", cliCompletionStaticValue), model, help,
+		}),
+		completionSpec("bot", []cliCompletionFlag{help},
+			completionSpec("start", []cliCompletionFlag{completionFlag("--channels --dir", cliCompletionStaticValue), model, help}),
+			completionSpec("doctor", []cliCompletionFlag{completionFlag("--json --deep", cliCompletionNoValue), help}),
+			completionSpec("pairing", []cliCompletionFlag{help},
+				completionSpec("list", []cliCompletionFlag{help}),
+				completionSpec("approve", []cliCompletionFlag{help}),
+				completionSpecWithAliases("reject", []string{"deny"}, []cliCompletionFlag{help}),
+			),
+			completionSpec("weixin-login", []cliCompletionFlag{completionFlag("--timeout", cliCompletionStaticValue), help}),
+		),
+		completionSpecWithAliases("upgrade", []string{"update"}, []cliCompletionFlag{
+			completionFlag("--check --force", cliCompletionNoValue), completionFlag("--channel", cliCompletionStaticValue), help,
+		}),
+		completionSpec("completion", []cliCompletionFlag{help},
+			completionSpec("bash", nil),
+			completionSpec("zsh", nil),
+			completionSpec("fish", nil),
+		),
+		completionSpec("version", []cliCompletionFlag{
+			completionFlag("--verbose --json", cliCompletionNoValue), help,
+		}),
+		completionSpec("docs-manifest", []cliCompletionFlag{help}),
+		completionSpec("help", []cliCompletionFlag{help}),
+	}
+	return root
+}
+
+func subagentCompletionFlags(model, effort, help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--description --prompt --prompt-file --tools --color --dir", cliCompletionStaticValue),
+		model, effort, help,
+	}
+}
+
+func machineSessionCompletionFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir --project-root", cliCompletionStaticValue), help,
+	}
+}
+
+func hookCompletionFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir --project-root --home-dir", cliCompletionStaticValue), help,
+	}
+}
+
+func taskCompletionFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir --project-root --session", cliCompletionStaticValue), help,
+	}
+}
+
+func completionCommand(args []string) int {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" || args[0] == "help" {
+		completionUsage(os.Stdout)
+		if len(args) == 0 {
+			return 2
+		}
+		return 0
+	}
+	if args[0] == "__complete" {
+		return completionCandidateCommand(args[1:])
+	}
+	if len(args) != 1 {
+		completionUsage(os.Stderr)
+		return 2
+	}
+	var script string
+	switch args[0] {
+	case "bash":
+		script = bashCompletionScript
+	case "zsh":
+		script = zshCompletionScript
+	case "fish":
+		script = fishCompletionScript
+	default:
+		fmt.Fprintf(os.Stderr, "unknown shell %q (want bash, zsh, or fish)\n", args[0])
+		return 2
+	}
+	fmt.Print(script)
+	return 0
+}
+
+func completionUsage(w *os.File) {
+	fmt.Fprintln(w, `Usage:
+  reasonix completion bash
+  reasonix completion zsh
+  reasonix completion fish
+
+The command prints a completion script to stdout. Source it directly or save it
+in your shell's completion directory.`)
+}
+
+func completionCandidateCommand(args []string) int {
+	if len(args) < 1 {
+		return 2
+	}
+	cword, err := strconv.Atoi(args[0])
+	if err != nil || cword < 0 {
+		return 2
+	}
+	for _, candidate := range cliCompletionCandidates(cword, args[1:]) {
+		if candidate == "" || strings.ContainsAny(candidate, "\r\n") {
+			continue
+		}
+		fmt.Println(candidate)
+	}
+	return 0
+}
+
+func cliCompletionCandidates(cword int, words []string) []string {
+	return cliCompletionCandidatesWithValues(cliCompletionRootSpec(), cword, words, runtimeCompletionValues)
+}
+
+func cliCompletionCandidatesWithValues(root cliCompletionSpec, cword int, words []string, dynamic func(cliCompletionValueKind) []string) []string {
+	if cword < 0 {
+		return nil
+	}
+	current := ""
+	if cword < len(words) {
+		current = words[cword]
+	}
+	limit := cword
+	if limit > len(words) {
+		limit = len(words)
+	}
+
+	ctx := &root
+	positionalSeen := false
+	var awaiting *cliCompletionFlag
+	for i := 1; i < limit; i++ {
+		token := words[i]
+		if awaiting != nil {
+			awaiting = nil
+			continue
+		}
+		if flag, inline := cliCompletionLookupFlag(ctx, token); flag != nil {
+			if flag.kind != cliCompletionNoValue && !inline {
+				awaiting = flag
+			}
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			continue
+		}
+		if !positionalSeen {
+			if child := cliCompletionLookupSubcommand(ctx, token); child != nil {
+				ctx = child
+				continue
+			}
+		}
+		positionalSeen = true
+	}
+
+	if awaiting != nil {
+		return filterCompletionPrefix(completionFlagValues(*awaiting, dynamic), current)
+	}
+	if name, value, ok := strings.Cut(current, "="); ok {
+		if flag, _ := cliCompletionLookupFlag(ctx, name); flag != nil && flag.kind != cliCompletionNoValue {
+			values := completionFlagValues(*flag, dynamic)
+			out := make([]string, 0, len(values))
+			for _, candidate := range filterCompletionPrefix(values, value) {
+				out = append(out, name+"="+candidate)
+			}
+			return out
+		}
+	}
+	if strings.HasPrefix(current, "-") {
+		var out []string
+		for _, flag := range ctx.flags {
+			out = append(out, flag.names...)
+		}
+		return filterCompletionPrefix(stableUniqueCompletionValues(out), current)
+	}
+	if positionalSeen {
+		return nil
+	}
+	var out []string
+	for i := range ctx.subcommands {
+		out = append(out, ctx.subcommands[i].name)
+	}
+	return filterCompletionPrefix(stableUniqueCompletionValues(out), current)
+}
+
+func cliCompletionLookupFlag(spec *cliCompletionSpec, token string) (*cliCompletionFlag, bool) {
+	name := token
+	inline := false
+	if before, _, ok := strings.Cut(token, "="); ok {
+		name = before
+		inline = true
+	}
+	for i := range spec.flags {
+		for _, candidate := range spec.flags[i].names {
+			if candidate == name {
+				return &spec.flags[i], inline
+			}
+		}
+	}
+	return nil, inline
+}
+
+func cliCompletionLookupSubcommand(spec *cliCompletionSpec, token string) *cliCompletionSpec {
+	for i := range spec.subcommands {
+		child := &spec.subcommands[i]
+		if child.name == token {
+			return child
+		}
+		for _, alias := range child.aliases {
+			if alias == token {
+				return child
+			}
+		}
+	}
+	return nil
+}
+
+func completionFlagValues(flag cliCompletionFlag, dynamic func(cliCompletionValueKind) []string) []string {
+	switch flag.kind {
+	case cliCompletionStaticValue:
+		return stableUniqueCompletionValues(flag.values)
+	case cliCompletionModelValue, cliCompletionSessionValue:
+		return stableUniqueCompletionValues(dynamic(flag.kind))
+	default:
+		return nil
+	}
+}
+
+func runtimeCompletionValues(kind cliCompletionValueKind) []string {
+	switch kind {
+	case cliCompletionModelValue:
+		return modelRefs()
+	case cliCompletionSessionValue:
+		return completionSessionIDs()
+	default:
+		return nil
+	}
+}
+
+func completionSessionIDs() []string {
+	ordered, err := agent.ListSessionOrder(resolveCLISessionDir())
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(ordered))
+	for _, session := range ordered {
+		out = append(out, agent.BranchID(session.Path))
+	}
+	return stableUniqueCompletionValues(out)
+}
+
+func filterCompletionPrefix(values []string, prefix string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func stableUniqueCompletionValues(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+const bashCompletionScript = `# bash completion for reasonix
+_reasonix_completion() {
+  local line
+  COMPREPLY=()
+  while IFS= read -r line; do
+    COMPREPLY+=("$line")
+  done < <(command reasonix completion __complete "$COMP_CWORD" "${COMP_WORDS[@]}" 2>/dev/null)
+}
+complete -o default -F _reasonix_completion reasonix
+`
+
+const zshCompletionScript = `#compdef reasonix
+_reasonix_completion() {
+  local -a candidates
+  candidates=("${(@f)$(command reasonix completion __complete "$((CURRENT - 1))" "${words[@]}" 2>/dev/null)}")
+  if (( ${#candidates[@]} )); then
+    compadd -- "${candidates[@]}"
+  else
+    _default
+  fi
+}
+compdef _reasonix_completion reasonix
+`
+
+const fishCompletionScript = `function __reasonix_completion
+    set -l tokens (commandline -opc)
+    set -a tokens (commandline -ct)
+    set -l current_index (math (count $tokens) - 1)
+    command reasonix completion __complete $current_index $tokens 2>/dev/null
+end
+complete -c reasonix -f -a '(__reasonix_completion)'
+`

--- a/internal/cli/shell_completion.go
+++ b/internal/cli/shell_completion.go
@@ -67,6 +67,8 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		completionFlag("--allowed-tools --allowedTools", cliCompletionStaticValue),
 		help,
 	}
+	// run/serve --resume require a value; only interactive root --resume [QUERY] is optional.
+	runResume := completionFlag("--resume", cliCompletionSessionValue)
 	runFlags := []cliCompletionFlag{
 		model, profile,
 		completionFlag("--max-steps", cliCompletionStaticValue),
@@ -74,7 +76,7 @@ func cliCompletionRootSpec() cliCompletionSpec {
 		completionFlag("--metrics", cliCompletionPathValue),
 		completionFlag("--dir", cliCompletionPathValue),
 		completionFlag("--continue -c", cliCompletionNoValue),
-		completionFlag("--resume", cliCompletionOptionalValue),
+		runResume,
 		completionFlag("--copy", cliCompletionNoValue),
 		effort, permissionMode,
 		completionFlag("--auto -y", cliCompletionNoValue),
@@ -111,7 +113,7 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			model, profile,
 			completionFlag("--max-steps", cliCompletionStaticValue),
 			completionFlag("--addr", cliCompletionStaticValue),
-			completionFlag("--resume", cliCompletionOptionalValue),
+			completionFlag("--resume", cliCompletionSessionValue), // required session file/ID
 			completionFlag("--auth", cliCompletionStaticValue, "none", "token", "password"),
 			completionFlag("--token --password --port-file --token-file --pid-file", cliCompletionStaticValue),
 			completionFlag("--hash-password --behind-proxy", cliCompletionNoValue), help,
@@ -231,28 +233,30 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			completionSpec("status", hookCompletionFlags(help)),
 		),
 		completionSpec("task", []cliCompletionFlag{help},
-			completionSpec("list", taskCompletionFlags(help)),
-			completionSpec("show", taskCompletionFlags(help)),
+			// Machine list/show: --json --dir --project-root --session (task_machine.go).
+			completionSpec("list", completionTaskMachineListFlags(help)),
+			completionSpec("show", completionTaskMachineShowFlags(help)),
+			// Live monitor surface (task.go FlagSets).
 			completionSpec("monitor", []cliCompletionFlag{help},
-				completionSpec("list", taskCompletionFlags(help)),
-				completionSpec("status", taskCompletionFlags(help)),
-				completionSpec("events", taskCompletionFlags(help)),
-				completionSpec("stop", taskCompletionFlags(help)),
-				completionSpec("cancel", taskCompletionFlags(help)),
-				completionSpec("requeue", taskCompletionFlags(help)),
-				completionSpec("open-session", taskCompletionFlags(help)),
+				completionSpec("list", completionTaskListFlags(help)),
+				completionSpec("status", completionTaskStatusFlags(help)),
+				completionSpec("events", completionTaskEventsFlags(help)),
+				completionSpec("stop", completionTaskControlFlags(help)),
+				completionSpec("cancel", completionTaskControlFlags(help)),
+				completionSpec("requeue", completionTaskRequeueFlags(help)),
+				completionSpec("open-session", completionTaskOpenSessionFlags(help)),
 			),
-			completionSpec("status", taskCompletionFlags(help)),
-			completionSpec("events", taskCompletionFlags(help)),
-			completionSpec("stop", taskCompletionFlags(help)),
-			completionSpec("cancel", taskCompletionFlags(help)),
-			completionSpec("requeue", taskCompletionFlags(help)),
-			completionSpec("open-session", taskCompletionFlags(help)),
+			completionSpec("status", completionTaskStatusFlags(help)),
+			completionSpec("events", completionTaskEventsFlags(help)),
+			completionSpec("stop", completionTaskControlFlags(help)),
+			completionSpec("cancel", completionTaskControlFlags(help)),
+			completionSpec("requeue", completionTaskRequeueFlags(help)),
+			completionSpec("open-session", completionTaskOpenSessionFlags(help)),
 			completionSpec("tmux", []cliCompletionFlag{help},
-				completionSpec("attach", nil),
-				completionSpec("status", nil),
-				completionSpec("open", nil),
-				completionSpec("detach", nil),
+				completionSpec("attach", completionTaskTmuxAttachFlags(help)),
+				completionSpec("status", completionTaskTmuxFlags(help)),
+				completionSpec("open", completionTaskTmuxFlags(help)),
+				completionSpec("detach", completionTaskTmuxFlags(help)),
 			),
 		),
 		completionSpec("review", []cliCompletionFlag{
@@ -306,10 +310,69 @@ func hookCompletionFlags(help cliCompletionFlag) []cliCompletionFlag {
 	}
 }
 
-func taskCompletionFlags(help cliCompletionFlag) []cliCompletionFlag {
+// completionTask*Flags mirror the real FlagSets in task.go / task_machine.go.
+// Names are prefixed with completion to avoid clashing with task.go helpers.
+
+func completionTaskMachineListFlags(help cliCompletionFlag) []cliCompletionFlag {
 	return []cliCompletionFlag{
 		completionFlag("--json", cliCompletionNoValue),
-		completionFlag("--dir --project-root --session", cliCompletionStaticValue), help,
+		completionFlag("--dir --project-root", cliCompletionPathValue),
+		completionFlag("--session", cliCompletionStaticValue), help,
+	}
+}
+
+func completionTaskMachineShowFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return completionTaskMachineListFlags(help)
+}
+
+func completionTaskListFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionPathValue), help,
+	}
+}
+
+func completionTaskStatusFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return completionTaskListFlags(help)
+}
+
+func completionTaskEventsFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json --jsonl --follow", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionPathValue),
+		completionFlag("--after", cliCompletionStaticValue), help,
+	}
+}
+
+func completionTaskControlFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionPathValue),
+		completionFlag("--expected-version --reason --idempotency-key", cliCompletionStaticValue), help,
+	}
+}
+
+func completionTaskRequeueFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionPathValue),
+		completionFlag("--expected-version --idempotency-key", cliCompletionStaticValue), help,
+	}
+}
+
+func completionTaskOpenSessionFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return completionTaskListFlags(help)
+}
+
+func completionTaskTmuxFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return completionTaskListFlags(help)
+}
+
+func completionTaskTmuxAttachFlags(help cliCompletionFlag) []cliCompletionFlag {
+	return []cliCompletionFlag{
+		completionFlag("--json", cliCompletionNoValue),
+		completionFlag("--dir", cliCompletionPathValue),
+		completionFlag("--session", cliCompletionStaticValue), help,
 	}
 }
 
@@ -435,12 +498,7 @@ func cliCompletionCandidatesWithValues(root cliCompletionSpec, cword int, words 
 			}
 			return filterCompletionPrefix(stableUniqueCompletionValues(out), current)
 		}
-		values := completionFlagValues(*awaiting, dynamic)
-		if awaiting.kind == cliCompletionOptionalValue {
-			// Also offer session IDs for --resume optional QUERY.
-			values = append(values, dynamic(cliCompletionSessionValue)...)
-		}
-		return filterCompletionPrefix(stableUniqueCompletionValues(values), current)
+		return filterCompletionPrefix(stableUniqueCompletionValues(completionFlagValues(*awaiting, dynamic)), current)
 	}
 	if name, value, ok := strings.Cut(current, "="); ok {
 		if flag, _ := cliCompletionLookupFlag(ctx, name); flag != nil && flag.kind != cliCompletionNoValue {
@@ -506,8 +564,11 @@ func completionFlagValues(flag cliCompletionFlag, dynamic func(cliCompletionValu
 	case cliCompletionStaticValue:
 		return stableUniqueCompletionValues(flag.values)
 	case cliCompletionOptionalValue:
-		// Static optional values if declared; sessions are merged by the caller for --resume.
-		return stableUniqueCompletionValues(flag.values)
+		// Interactive --resume [QUERY]: static values (if any) plus dynamic session IDs.
+		// Used for both separated and --resume=QUERY forms.
+		out := append([]string{}, flag.values...)
+		out = append(out, dynamic(cliCompletionSessionValue)...)
+		return stableUniqueCompletionValues(out)
 	case cliCompletionPathValue:
 		return nil
 	case cliCompletionModelValue, cliCompletionSessionValue:

--- a/internal/cli/shell_completion_test.go
+++ b/internal/cli/shell_completion_test.go
@@ -190,10 +190,99 @@ func TestCLICompletionOptionalResumeThenFlag(t *testing.T) {
 		}
 		return nil
 	}
-	// --resume with no QUERY, then completing --m must offer --model (optional value).
+	// Interactive root --resume [QUERY] is optional: after --resume, --m offers --model.
 	got := cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "--resume", "--m"}, values)
 	if !containsCompletionValue(got, "--model") {
 		t.Fatalf("optional --resume then --m = %v, want --model", got)
+	}
+	// Inline optional --resume=QUERY still completes sessions.
+	got = cliCompletionCandidatesWithValues(root, 1, []string{"reasonix", "--resume=a"}, values)
+	if !containsCompletionValue(got, "--resume=alpha-session") {
+		t.Fatalf("inline optional --resume= = %v, want --resume=alpha-session", got)
+	}
+}
+
+func TestCLICompletionRunServeResumeRequiresValue(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(kind cliCompletionValueKind) []string {
+		if kind == cliCompletionSessionValue {
+			return []string{"alpha-session", "beta-session"}
+		}
+		return nil
+	}
+	// run --resume is required: completing after --resume must offer sessions, not --model.
+	got := cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "run", "--resume", "--m"}, values)
+	if containsCompletionValue(got, "--model") {
+		t.Fatalf("run --resume must not treat next flag as free: %v", got)
+	}
+	if !containsCompletionValue(got, "alpha-session") && len(got) > 0 {
+		// Prefix "--m" filters sessions; empty is OK if no session starts with --m.
+	}
+	// Separated form with prefix "b" completes sessions.
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "run", "--resume", "b"}, values)
+	if want := []string{"beta-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("run --resume b = %v, want %v", got, want)
+	}
+	// serve --resume is also required.
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "serve", "--resume", "a"}, values)
+	if want := []string{"alpha-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("serve --resume a = %v, want %v", got, want)
+	}
+	// Inline required session form.
+	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "run", "--resume=b"}, values)
+	if want := []string{"--resume=beta-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("run --resume=b = %v, want %v", got, want)
+	}
+}
+
+func TestCLICompletionTaskPerOperationFlags(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(cliCompletionValueKind) []string { return nil }
+
+	// status must not advertise machine-only --project-root.
+	got := cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--p"}, values)
+	if containsCompletionValue(got, "--project-root") {
+		t.Fatalf("task status must not offer --project-root: %v", got)
+	}
+	if !containsCompletionValue(got, "--json") && containsCompletionValue(
+		cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--j"}, values),
+		"--json") {
+		// prefix --p won't match --json; check --j
+	}
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--j"}, values)
+	if !containsCompletionValue(got, "--json") {
+		t.Fatalf("task status missing --json: %v", got)
+	}
+
+	// events has --jsonl/--after/--follow.
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "events", "--"}, values)
+	for _, want := range []string{"--json", "--jsonl", "--after", "--follow", "--dir"} {
+		if !containsCompletionValue(got, want) {
+			t.Fatalf("task events missing %q: %v", want, got)
+		}
+	}
+	if containsCompletionValue(got, "--project-root") {
+		t.Fatalf("task events must not offer --project-root: %v", got)
+	}
+
+	// stop has control flags.
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "stop", "--"}, values)
+	for _, want := range []string{"--expected-version", "--reason", "--idempotency-key", "--json", "--dir"} {
+		if !containsCompletionValue(got, want) {
+			t.Fatalf("task stop missing %q: %v", want, got)
+		}
+	}
+
+	// machine list still has --project-root.
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "list", "--p"}, values)
+	if !containsCompletionValue(got, "--project-root") {
+		t.Fatalf("task list missing --project-root: %v", got)
+	}
+
+	// tmux attach has --session.
+	got = cliCompletionCandidatesWithValues(root, 4, []string{"reasonix", "task", "tmux", "attach", "--s"}, values)
+	if !containsCompletionValue(got, "--session") {
+		t.Fatalf("task tmux attach missing --session: %v", got)
 	}
 }
 

--- a/internal/cli/shell_completion_test.go
+++ b/internal/cli/shell_completion_test.go
@@ -215,20 +215,25 @@ func TestCLICompletionRunServeResumeRequiresValue(t *testing.T) {
 	if containsCompletionValue(got, "--model") {
 		t.Fatalf("run --resume must not treat next flag as free: %v", got)
 	}
-	if !containsCompletionValue(got, "alpha-session") && len(got) > 0 {
-		// Prefix "--m" filters sessions; empty is OK if no session starts with --m.
+	// Prefix "--m" matches no configured session IDs.
+	if len(got) != 0 {
+		t.Fatalf("run --resume --m = %v, want empty (no session starts with --m)", got)
 	}
 	// Separated form with prefix "b" completes sessions.
 	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "run", "--resume", "b"}, values)
 	if want := []string{"beta-session"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("run --resume b = %v, want %v", got, want)
 	}
-	// serve --resume is also required.
+	// serve --resume is a required file path: empty candidates for shell path fallback,
+	// never dynamic session branch IDs that fail open/loadResumableSession.
 	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "serve", "--resume", "a"}, values)
-	if want := []string{"alpha-session"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("serve --resume a = %v, want %v", got, want)
+	if len(got) != 0 {
+		t.Fatalf("serve --resume path value = %v, want empty for file fallback", got)
 	}
-	// Inline required session form.
+	if containsCompletionValue(got, "alpha-session") {
+		t.Fatalf("serve --resume must not complete session IDs: %v", got)
+	}
+	// Inline required session form (run only).
 	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "run", "--resume=b"}, values)
 	if want := []string{"--resume=beta-session"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("run --resume=b = %v, want %v", got, want)
@@ -243,11 +248,6 @@ func TestCLICompletionTaskPerOperationFlags(t *testing.T) {
 	got := cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--p"}, values)
 	if containsCompletionValue(got, "--project-root") {
 		t.Fatalf("task status must not offer --project-root: %v", got)
-	}
-	if !containsCompletionValue(got, "--json") && containsCompletionValue(
-		cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--j"}, values),
-		"--json") {
-		// prefix --p won't match --json; check --j
 	}
 	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "status", "--j"}, values)
 	if !containsCompletionValue(got, "--json") {

--- a/internal/cli/shell_completion_test.go
+++ b/internal/cli/shell_completion_test.go
@@ -151,7 +151,58 @@ func TestCompletionCommandPrintsShellScripts(t *testing.T) {
 			if !strings.Contains(out, "reasonix completion __complete") {
 				t.Fatalf("completion %s script does not route to the shared registry:\n%s", shell, out)
 			}
+			if shell == "fish" && strings.Contains(out, "complete -c reasonix -f ") {
+				t.Fatal("fish completion must not use -f so path flags can fall back to files")
+			}
 		})
+	}
+}
+
+func TestCLICompletionTaskNestedAndRunAblate(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(cliCompletionValueKind) []string { return nil }
+
+	got := cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "task", "st"}, values)
+	for _, want := range []string{"status", "stop"} {
+		if !containsCompletionValue(got, want) {
+			t.Fatalf("task prefix st missing %q: %v", want, got)
+		}
+	}
+	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "task", "mon"}, values)
+	if !containsCompletionValue(got, "monitor") {
+		t.Fatalf("task monitor missing: %v", got)
+	}
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "task", "monitor", "st"}, values)
+	if !containsCompletionValue(got, "status") || !containsCompletionValue(got, "stop") {
+		t.Fatalf("task monitor st = %v", got)
+	}
+	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "run", "--a"}, values)
+	if !containsCompletionValue(got, "--ablate") {
+		t.Fatalf("run --a missing --ablate: %v", got)
+	}
+}
+
+func TestCLICompletionOptionalResumeThenFlag(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(kind cliCompletionValueKind) []string {
+		if kind == cliCompletionSessionValue {
+			return []string{"alpha-session"}
+		}
+		return nil
+	}
+	// --resume with no QUERY, then completing --m must offer --model (optional value).
+	got := cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "--resume", "--m"}, values)
+	if !containsCompletionValue(got, "--model") {
+		t.Fatalf("optional --resume then --m = %v, want --model", got)
+	}
+}
+
+func TestCLICompletionPathFlagReturnsEmptyForShellFallback(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(cliCompletionValueKind) []string { return []string{"should-not-appear"} }
+	got := cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "run", "--dir", "do"}, values)
+	if len(got) != 0 {
+		t.Fatalf("path flag value candidates = %v, want empty for shell file fallback", got)
 	}
 }
 

--- a/internal/cli/shell_completion_test.go
+++ b/internal/cli/shell_completion_test.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCLICompletionCoversRunDispatch(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "cli.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Dispatch lives in RunWithBuildInfo (Run is a thin BuildInfo wrapper).
+	var dispatch *ast.SwitchStmt
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Name.Name != "RunWithBuildInfo" {
+			continue
+		}
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			switchStatement, ok := node.(*ast.SwitchStmt)
+			if !ok {
+				return true
+			}
+			identifier, ok := switchStatement.Tag.(*ast.Ident)
+			if ok && identifier.Name == "cmd" {
+				dispatch = switchStatement
+				return false
+			}
+			return true
+		})
+	}
+	if dispatch == nil {
+		t.Fatal("RunWithBuildInfo cmd dispatch switch not found")
+	}
+
+	root := cliCompletionRootSpec()
+	for _, statement := range dispatch.Body.List {
+		clause, ok := statement.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, expression := range clause.List {
+			literal, ok := expression.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				continue
+			}
+			command, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !completionRegistryKnowsRootToken(&root, command) {
+				t.Errorf("Run dispatch command %q is missing from the shell completion registry", command)
+			}
+		}
+	}
+}
+
+func TestCLICompletionListsRootAndNestedCommands(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(cliCompletionValueKind) []string { return nil }
+
+	got := cliCompletionCandidatesWithValues(root, 1, []string{"reasonix", "co"}, values)
+	if want := []string{"config", "completion"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("root completion = %v, want %v", got, want)
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "mcp", "b"}, values)
+	if want := []string{"browse"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("mcp subcommand completion = %v, want %v", got, want)
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "remote", "serve", "st"}, values)
+	// "st" prefix matches start, stop, and status (registry order).
+	if want := []string{"start", "stop", "status"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("remote serve completion = %v, want %v", got, want)
+	}
+}
+
+func TestCLICompletionListsCommandFlags(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(cliCompletionValueKind) []string { return nil }
+
+	got := cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "run", "--m"}, values)
+	for _, want := range []string{"--model", "--max-steps", "--metrics"} {
+		if !containsCompletionValue(got, want) {
+			t.Errorf("run flag completion missing %q: %v", want, got)
+		}
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 1, []string{"reasonix", "--d"}, values)
+	for _, want := range []string{"--dir", "--dangerously-skip-permissions"} {
+		if !containsCompletionValue(got, want) {
+			t.Errorf("root flag completion missing %q: %v", want, got)
+		}
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "mcp", "add", "--h"}, values)
+	for _, want := range []string{"--http", "--header", "--help"} {
+		if !containsCompletionValue(got, want) {
+			t.Errorf("mcp add flag completion missing %q: %v", want, got)
+		}
+	}
+}
+
+func TestCLICompletionUsesConfiguredModelsAndSessionIDs(t *testing.T) {
+	root := cliCompletionRootSpec()
+	values := func(kind cliCompletionValueKind) []string {
+		switch kind {
+		case cliCompletionModelValue:
+			return []string{"deepseek/deepseek-chat", "mimo/mimo-v2"}
+		case cliCompletionSessionValue:
+			return []string{"alpha-session", "beta-session"}
+		default:
+			return nil
+		}
+	}
+
+	got := cliCompletionCandidatesWithValues(root, 3, []string{"reasonix", "run", "--model", "deep"}, values)
+	if want := []string{"deepseek/deepseek-chat"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("model completion = %v, want %v", got, want)
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 1, []string{"reasonix", "--model=mi"}, values)
+	if want := []string{"--model=mimo/mimo-v2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("inline model completion = %v, want %v", got, want)
+	}
+
+	got = cliCompletionCandidatesWithValues(root, 2, []string{"reasonix", "--resume", "b"}, values)
+	if want := []string{"beta-session"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("session completion = %v, want %v", got, want)
+	}
+}
+
+func TestCompletionCommandPrintsShellScripts(t *testing.T) {
+	isolateCLIConfigHome(t)
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				if code := Run([]string{"completion", shell}, "test-version"); code != 0 {
+					t.Fatalf("completion %s exit code = %d", shell, code)
+				}
+			})
+			if !strings.Contains(out, "reasonix completion __complete") {
+				t.Fatalf("completion %s script does not route to the shared registry:\n%s", shell, out)
+			}
+		})
+	}
+}
+
+func containsCompletionValue(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func completionRegistryKnowsRootToken(root *cliCompletionSpec, token string) bool {
+	if strings.HasPrefix(token, "-") {
+		flag, _ := cliCompletionLookupFlag(root, token)
+		return flag != nil
+	}
+	return cliCompletionLookupSubcommand(root, token) != nil
+}

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -593,10 +593,13 @@ Usage:
   reasonix session show|status <machine-session-id> --json [--dir PATH]  query one redacted session
   reasonix session recovery [<machine-session-id>] --json [--dir PATH]  query redacted recovery state
   reasonix hook list|status --json [--dir PATH]         inspect redacted hook state
-  reasonix task list|show --json [--dir PATH]           inspect redacted task state
+  reasonix task list|show|status|events|stop|cancel|monitor|tmux --json [--dir PATH]
+                                                         inspect or control redacted tasks
   reasonix bot start|doctor|weixin-login                multi-channel IM bot gateway
   reasonix upgrade [--check] [--force]                   update to the latest official release (also: reasonix update)
-  reasonix version
+  reasonix completion bash|zsh|fish                     print a shell completion script to stdout
+  reasonix version [--verbose|--json]                   print version (single line) or build metadata
+  reasonix --version | -v                               single-line version (script-safe)
   reasonix help
 
 Examples:

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -594,10 +594,13 @@ var Chinese = Messages{
   reasonix session show|status <machine-session-id> --json [--dir PATH]  查询单个脱敏会话
   reasonix session recovery [<machine-session-id>] --json [--dir PATH]  查询脱敏恢复状态
   reasonix hook list|status --json [--dir PATH]         查看脱敏 Hook 状态
-  reasonix task list|show --json [--dir PATH]           查看脱敏 Task 状态
+  reasonix task list|show|status|events|stop|cancel|monitor|tmux --json [--dir PATH]
+                                                         查看或控制脱敏 Task
   reasonix bot start|doctor|weixin-login                多渠道 IM bot 网关
   reasonix upgrade [--check] [--force]                   更新到最新正式版（别名：reasonix update）
-  reasonix version
+  reasonix completion bash|zsh|fish                     打印 shell 补全脚本到 stdout
+  reasonix version [--verbose|--json]                   打印版本（单行）或构建元信息
+  reasonix --version | -v                               单行版本（脚本安全）
   reasonix help
 
 示例：

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -533,10 +533,13 @@ var ChineseTraditional = Messages{
   reasonix session show|status <machine-session-id> --json [--dir PATH]  查詢單一脫敏會話
   reasonix session recovery [<machine-session-id>] --json [--dir PATH]  查詢脫敏復原狀態
   reasonix hook list|status --json [--dir PATH]         檢視脫敏 Hook 狀態
-  reasonix task list|show --json [--dir PATH]           檢視脫敏 Task 狀態
+  reasonix task list|show|status|events|stop|cancel|monitor|tmux --json [--dir PATH]
+                                                         檢視或控制脫敏 Task
   reasonix bot start|doctor|weixin-login                多管道 IM bot 閘道
   reasonix upgrade [--check] [--force]                   更新到最新正式版（別名：reasonix update）
-  reasonix version
+  reasonix completion bash|zsh|fish                     列印 shell 補全腳本到 stdout
+  reasonix version [--verbose|--json]                   列印版本（單行）或建置元資訊
+  reasonix --version | -v                               單行版本（腳本安全）
   reasonix help
 
 範例：

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -647,11 +647,15 @@ type ToolInfo struct {
 type ServerStatus struct {
 	Name      string
 	Transport string
-	Tools     int
-	Prompts   int
-	Resources int
-	HasTools  bool
-	ToolList  []ToolInfo
+	// ConfigSource is the config plane that registered this server
+	// (user_config, project_config, workspace, built-in, …). Empty when unknown.
+	// Surfaced in /mcp status so operators can tell where a tool came from (#6578).
+	ConfigSource string
+	Tools        int
+	Prompts      int
+	Resources    int
+	HasTools     bool
+	ToolList     []ToolInfo
 }
 
 // AuthorizeSpecLaunch records durable consent for an explicitly user-installed
@@ -741,10 +745,11 @@ func (h *Host) Servers() []ServerStatus {
 	out := make([]ServerStatus, 0, len(h.clients))
 	for _, c := range h.clients {
 		s := ServerStatus{
-			Name:      c.name,
-			Transport: c.transport,
-			Tools:     c.toolCount,
-			HasTools:  c.hasTools,
+			Name:         c.name,
+			Transport:    c.transport,
+			ConfigSource: strings.TrimSpace(c.spec.ConfigSource),
+			Tools:        c.toolCount,
+			HasTools:     c.hasTools,
 		}
 		c.toolsMu.Lock()
 		s.ToolList = append([]ToolInfo(nil), c.tools...)

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -30,6 +30,9 @@ const candidateSha = execFileSync("git", ["rev-parse", "HEAD"], {
   cwd: ROOT,
   encoding: "utf8",
 }).trim();
+const gitCommit = candidateSha.slice(0, 12);
+// Real UTC build clock for version --verbose/--json (not VCS commit time).
+const buildTimeUTC = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 
 rmSync(STAGE, { recursive: true, force: true });
 mkdirSync(STAGE, { recursive: true });
@@ -48,7 +51,7 @@ for (const t of TARGETS) {
       "build",
       "-trimpath",
       "-ldflags",
-      `-s -w -X main.version=${binaryVersion} -X reasonix/internal/productdocs.linkedVersion=${binaryVersion} -X reasonix/internal/productdocs.linkedRevision=${candidateSha}`,
+      `-s -w -X main.version=${binaryVersion} -X main.gitCommit=${gitCommit} -X main.buildTimeUTC=${buildTimeUTC} -X reasonix/internal/productdocs.linkedVersion=${binaryVersion} -X reasonix/internal/productdocs.linkedRevision=${candidateSha}`,
       "-o",
       join(dir, "bin", exe),
       "./cmd/reasonix",

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -41,8 +41,12 @@ SOURCE_REVISION="$(git -C "$ROOT" rev-parse --verify HEAD)"
 if ! git -C "$ROOT" diff-index --quiet HEAD --; then
 	SOURCE_REVISION="$SOURCE_REVISION+dirty"
 fi
+# Short commit + real UTC build clock for CLI `version --verbose/--json`.
+GIT_COMMIT="$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+BUILD_TIME_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # The remote protocol source-revision ldflag was removed with Remote Workbench.
 product_docs_ldflags="-X reasonix/internal/productdocs.linkedVersion=$VERSION -X reasonix/internal/productdocs.linkedRevision=$SOURCE_REVISION"
+cli_identity_ldflags="-X main.version=$VERSION -X main.gitCommit=$GIT_COMMIT -X main.buildTimeUTC=$BUILD_TIME_UTC $product_docs_ldflags"
 
 cleanup() {
 	if [ -n "$windows_resource_tool_dir" ]; then
@@ -75,12 +79,12 @@ build_cli() {
 	mkdir -p "$(dirname "$cli_out")"
 	if [ "$arch" = universal ]; then
 		cli_tmp=$(mktemp -d)
-		(cd "$ROOT" && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$VERSION $product_docs_ldflags" -o "$cli_tmp/amd64" ./cmd/reasonix)
-		(cd "$ROOT" && GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$VERSION $product_docs_ldflags" -o "$cli_tmp/arm64" ./cmd/reasonix)
+		(cd "$ROOT" && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w $cli_identity_ldflags" -o "$cli_tmp/amd64" ./cmd/reasonix)
+		(cd "$ROOT" && GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w $cli_identity_ldflags" -o "$cli_tmp/arm64" ./cmd/reasonix)
 		lipo -create "$cli_tmp/amd64" "$cli_tmp/arm64" -output "$cli_out"
 		rm -rf "$cli_tmp"
 	else
-		(cd "$ROOT" && GOOS="$os" GOARCH="$arch" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$VERSION $product_docs_ldflags" -o "$cli_out" ./cmd/reasonix)
+		(cd "$ROOT" && GOOS="$os" GOARCH="$arch" CGO_ENABLED=0 go build -trimpath -ldflags="-s -w $cli_identity_ldflags" -o "$cli_out" ./cmd/reasonix)
 	fi
 }
 

--- a/scripts/verify-embedded-docs.sh
+++ b/scripts/verify-embedded-docs.sh
@@ -37,7 +37,9 @@ cleanup() {
 trap cleanup EXIT
 
 binary="$tmp_dir/reasonix"
-ldflags="-s -w -X main.version=$version -X reasonix/internal/productdocs.linkedVersion=$version -X reasonix/internal/productdocs.linkedRevision=$revision"
+build_time_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+git_commit="$(printf '%s' "$revision" | cut -c1-12)"
+ldflags="-s -w -X main.version=$version -X main.gitCommit=$git_commit -X main.buildTimeUTC=$build_time_utc -X reasonix/internal/productdocs.linkedVersion=$version -X reasonix/internal/productdocs.linkedRevision=$revision"
 (
 	cd "$repo_root"
 	CGO_ENABLED=0 go build -trimpath -ldflags="$ldflags" -o "$binary" ./cmd/reasonix


### PR DESCRIPTION
## Summary

Integration PR **D/E** for the 30-day CLI feedback plan: command contracts, shell completion, and MCP source observability — after Integration C (#7706).

### Addresses

| Issue / source | Mechanism |
| --- | --- |
| #6476 (adapted) | `reasonix version --verbose` / `--json`; `--version`/`-v` single-line; release ldflags inject commit + UTC build time |
| #7425 (adapted) | Shell completion registry aligned with real parsers (resume optional only on interactive; task per-op flags) |
| #6175 / #6578 (display only) | MCP `source=` + ANSI/C0 sanitize |
| Refs #6833 | Not adopted — no `--home` |

### Audit rounds

- **R2**: release ldflags, task surface, MCP sanitize, help
- **R3 (`this head`)**: run/serve required `--resume`; per-operation task flags; inline `--resume=` session IDs; docs-impact `none`

### Verification

- `go test ./internal/cli -count=1`
- `go test ./cmd/reasonix ./internal/plugin -count=1`
- Completion: `run --resume b` → sessions only; interactive `--resume --m` → `--model`; task events/stop/tmux attach flag sets

## Cache impact

Cache-impact: none - CLI metadata, shell scripts, and MCP status rendering only.
Cache-guard: N/A
System-prompt-review: not required

Documentation-impact: none - this restores shell completion accuracy and CLI help already covers completion/version; no docs/*.md content or install workflow changes; REASONIX_HOME remains as documented in CONFIG_PATHS.

## Compatibility

- `reasonix --version` single-line contract preserved
- Default TUI/slash behaviour unchanged