### PR TITLE
site: lead with what the agent does, not what it caches

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,7 @@
       "name": "reasonix-site",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.3",
+        "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.1.0",
         "@fontsource-variable/outfit": "^5.1.0",
         "astro": "^7.1.3"
@@ -923,6 +924,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource-variable/jetbrains-mono": {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,6 @@
         "@astrojs/sitemap": "^3.7.3",
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.1.0",
-        "@fontsource-variable/outfit": "^5.1.0",
         "astro": "^7.1.3"
       },
       "devDependencies": {
@@ -939,15 +938,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource-variable/outfit": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/outfit/-/outfit-5.2.8.tgz",
-      "integrity": "sha512-4oUDCZx/Tcz6HZP423w/niqEH31Gks5IsqHV2ZZz1qKHaVIZdj2f0/S1IK2n8jl6Xo0o3N+3RjNHlV9R73ozQA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,6 @@
     "@astrojs/sitemap": "^3.7.3",
     "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.1.0",
-    "@fontsource-variable/outfit": "^5.1.0",
     "astro": "^7.1.3"
   },
   "devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
+    "@fontsource-variable/inter": "^5.3.0",
     "@fontsource-variable/jetbrains-mono": "^5.1.0",
     "@fontsource-variable/outfit": "^5.1.0",
     "astro": "^7.1.3"

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,5 +1,5 @@
 ---
-type ActiveItem = 'features' | 'how' | 'skills' | 'community' | 'docs' | 'changelog';
+type ActiveItem = 'features' | 'surfaces' | 'skills' | 'community' | 'docs' | 'changelog';
 
 const {
   active,
@@ -21,7 +21,7 @@ const items: Array<{
   secondary?: boolean;
 }> = [
   { id: 'features', href: `${base}/#features`, en: 'Features', zh: '特性' },
-  { id: 'how', href: `${base}/#how`, en: 'How it works', zh: '工作原理', secondary: true },
+  { id: 'surfaces', href: `${base}/#surfaces`, en: 'Surfaces', zh: '使用形态', secondary: true },
   { id: 'skills', href: `${base}/skills/`, en: 'Skills', zh: '技能市场' },
   { id: 'community', href: `${base}/#community`, en: 'Community', zh: '社区', secondary: true },
   { id: 'docs', href: `${base}/docs/`, en: 'Docs', zh: '文档' },

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -28,7 +28,7 @@ const ogImage = new URL(`${base}/og.png`, Astro.site).href;
   <meta property="og:image" content={ogImage} />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
-  <meta property="og:image:alt" content="Reasonix — a DeepSeek-native coding agent for your terminal" />
+  <meta property="og:image:alt" content="Reasonix — a coding agent you can leave running" />
   <meta property="og:locale" content="en_US" />
   <meta property="og:locale:alternate" content="zh_CN" />
   <meta name="twitter:card" content="summary_large_image" />

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -204,7 +204,7 @@ DEEPSEEK_API_KEY=sk-...</div>
 
       <h2 id="cache"><span class="l-en">Prefix cache</span><span class="l-zh">前缀缓存</span></h2>
       <p><span class="l-en">DeepSeek bills cached prefix tokens at a fraction of fresh computation. Most agents waste this: they reorder messages, rewrite summaries mid-session, or inject volatile timestamps — every change invalidates the cache from that point on.</span><span class="l-zh">DeepSeek 对缓存前缀 token 的计费远低于新计算。多数智能体浪费了这一点:重排消息、会话中改写摘要、注入易变的时间戳——任何改动都会让其后的缓存全部失效。</span></p>
-      <p><span class="l-en">Reasonix serializes context deterministically and only ever appends. The practical effect: hours-long sessions where 90%+ of every request replays from cache, and input-token cost collapses to ~1/5. See the <a href={`${base}/#how`}>animated walkthrough</a> on the home page.</span><span class="l-zh">Reasonix 以确定性方式序列化上下文,并且永远只追加。实际效果:数小时的会话中每次请求 90% 以上从缓存重放,输入 token 成本降到约 1/5。可在首页查看<a href={`${base}/#how`}>动态演示</a>。</span></p>
+      <p><span class="l-en">Reasonix serializes context deterministically and only ever appends. The practical effect: hours-long sessions where 90%+ of every request replays from cache, and input-token cost collapses to ~1/5.</span><span class="l-zh">Reasonix 以确定性方式序列化上下文,并且永远只追加。实际效果:数小时的会话中每次请求 90% 以上从缓存重放,输入 token 成本降到约 1/5。</span></p>
       <p><span class="l-en">Automatic compaction starts at 80% of the model context by default. Desktop Settings and <code>reasonix config compact-ratio</code> share the user-level value; choose 65–85%, or use <code>--local</code> for a project override. Lower values compact earlier and can reduce prefix-cache reuse.</span><span class="l-zh">自动压缩默认在模型上下文达到 80% 时启动。桌面端设置与 <code>reasonix config compact-ratio</code> 共用用户级设置；可在 65–85% 之间选择，也可用 <code>--local</code> 添加项目覆盖。阈值越低越早压缩，也可能降低前缀缓存复用率。</span></p>
 
       <h2 id="permissions"><span class="l-en">Permissions &amp; sandbox</span><span class="l-zh">权限与沙箱</span></h2>
@@ -335,9 +335,9 @@ call_timeout_seconds = 600</div>
       <p><span class="l-en">From <strong>Settings -> Bots</strong>, connect Feishu, Lark, or WeChat, then send Reasonix messages from IM. The local desktop runtime handles model calls, tools, approvals, and sandboxing, while IM receives progress, approval cards or text commands, and final results. Headless gateways can be started with <code>reasonix bot start --channels feishu,lark,weixin --dir /path/to/project</code>.</span><span class="l-zh">在 <strong>Settings -> Bots</strong> 中连接飞书、Lark 或微信后,即可从 IM 给 Reasonix 发消息。本地桌面运行时负责模型调用、工具、审批和沙箱,IM 侧接收进度、审批卡片或文本命令以及最终结果。也可以用 <code>reasonix bot start --channels feishu,lark,weixin --dir /path/to/project</code> 启动 headless gateway。</span></p>
 
       <div class="doc-cards">
-        <a class="doc-card" href={`${base}/#how`}>
-          <h3><span class="l-en">See the cache in action →</span><span class="l-zh">看缓存如何工作 →</span></h3>
-          <p><span class="l-en">Scroll-driven walkthrough of prefix replay on the home page.</span><span class="l-zh">首页的滚动演示:前缀重放的每一轮。</span></p>
+        <a class="doc-card" href={`${base}/#surfaces`}>
+          <h3><span class="l-en">One engine, four surfaces →</span><span class="l-zh">一个引擎,四个入口 →</span></h3>
+          <p><span class="l-en">Terminal, desktop app, browser, and ACP editors share this config.</span><span class="l-zh">终端、桌面端、浏览器与 ACP 编辑器共用这套配置。</span></p>
         </a>
         <a class="doc-card" href={`${repo}/blob/main-v2/docs/CONFIG_PATHS.md`}>
           <h3><span class="l-en">Configuration paths →</span><span class="l-zh">配置路径 →</span></h3>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -22,7 +22,7 @@ const half = Math.ceil(community.list.length / 2);
 const rowA = community.list.slice(0, half);
 const rowB = community.list.slice(half);
 
-const desc = "Open-source AI coding agent for your terminal, browser, and ACP-compatible editor, engineered around DeepSeek's byte-stable prefix cache. Long sessions hold 90%+ cache hit and input-token cost collapses to ~1/5. A single Go binary. npm · Homebrew · desktop · web UI. MIT.";
+const desc = "Open-source AI coding agent you can leave running. One local engine, four ways in — terminal, desktop app, browser, or your editor over ACP. Plan mode, permissions, a workspace sandbox and checkpoints keep long autonomous runs reviewable. A single Go binary, no runtime to install. MIT.";
 const ld = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareApplication',
@@ -37,9 +37,9 @@ const ld = {
 };
 ---
 <Base
-  title="Reasonix — DeepSeek-native coding agent for your terminal"
-  titleEn="Reasonix — DeepSeek-native coding agent for your terminal"
-  titleZh="Reasonix — DeepSeek 原生的终端编码 Agent"
+  title="Reasonix — a coding agent you can leave running"
+  titleEn="Reasonix — a coding agent you can leave running"
+  titleZh="Reasonix — 可以一直开着跑的编码 Agent"
   description={desc}>
 
   <script type="application/ld+json" set:html={JSON.stringify(ld)} slot="head" is:inline />
@@ -48,16 +48,15 @@ const ld = {
 
   <main>
   <section class="hero">
-    <canvas class="hero-dots"></canvas>
     <div class="wrap">
-      <div class="eyebrow reveal"><span class="dot"></span><span class="l-en">DeepSeek-native · built for your terminal · MIT</span><span class="l-zh">DeepSeek 原生 · 为终端而生 · MIT</span></div>
+      <div class="eyebrow reveal"><span class="dot"></span><span class="l-en">Open source · MIT · a single Go binary</span><span class="l-zh">开源 · MIT · 单个 Go 二进制</span></div>
       <h1 class="reveal" style="--d:0.06s">
-        <span class="l-en">A <span class="grad">DeepSeek</span>-native agent<br />for your <span class="tt">terminal</span>.</span>
-        <span class="l-zh"><span class="grad">DeepSeek</span> 原生的<br />终端编码 <span class="tt">Agent</span>。</span>
+        <span class="l-en">A coding agent you can<br /><span class="tt">leave running</span>.</span>
+        <span class="l-zh">可以<span class="tt">一直开着跑</span>的<br />编码 Agent。</span>
       </h1>
       <p class="sub reveal" style="--d:0.12s">
-        <span class="l-en">The loop is append-only, aligned to DeepSeek's byte-stable prefix cache — so long sessions hold <b>90%+ cache hit</b> and input-token cost collapses to <b>~1/5</b>. Use the same engine from the CLI/TUI, desktop app, local browser UI, or an ACP-compatible editor.</span>
-        <span class="l-zh">运行循环 append-only,对齐 DeepSeek 字节稳定的 prefix-cache —— 长会话缓存命中 <b>90%+</b>,输入 token 成本降到 <b>约 1/5</b>。CLI/TUI、桌面端、本地浏览器 UI 和兼容 ACP 的编辑器共用同一引擎。</span>
+        <span class="l-en">One local engine, four ways in — terminal, desktop app, browser, or your editor over ACP. Plan mode, permissions, a workspace sandbox and per-turn checkpoints keep a long autonomous run something you can still read and undo.</span>
+        <span class="l-zh">一套本地引擎,四个入口——终端、桌面端、浏览器,或通过 ACP 接入你的编辑器。计划模式、权限、工作区沙箱与逐轮 checkpoint,让长时间自治运行始终可读、可撤销。</span>
       </p>
       <div class="hero-install reveal" style="--d:0.18s" aria-label="Reasonix install options">
         <div class="install-option install-option--desktop">
@@ -100,11 +99,11 @@ const ld = {
       </nav>
 
       <div class="term-stage reveal" style="--d:0.26s">
-        <div class="fig"><span class="l-en">fig. 01 — a live session, cache still warm</span><span class="l-zh">图 01 —— 一场实时会话,缓存依然温热</span></div>
+        <div class="fig"><span class="l-en">fig. 01 — one task, start to finish</span><span class="l-zh">图 01 —— 一个任务,从开始到结束</span></div>
         <div class="term">
           <div class="term-bar"><i></i><i></i><i></i><span class="title">~/app — reasonix</span></div>
-          <div class="term-body"><span class="tl"><span class="t-acc">◆</span> reasonix <span class="t-dim"><span class="rxv">{goVer}</span> · deepseek-v4-flash · ~/app</span></span><span class="tl"><span class="t-vio">›</span> add retry with backoff to the http client</span><span class="tl"><span class="t-ok">✓</span> edit <span class="t-dim">internal/net/client.go</span>  <span class="t-add">+24 −3</span></span><span class="tl"><span class="t-ok">✓</span> edit <span class="t-dim">internal/net/client_test.go</span>  <span class="t-add">+41 −0</span></span><span class="tl"><span class="t-ok">✓</span> run <span class="t-dim">go test ./internal/net/</span>  <span class="t-ok">ok</span> <span class="t-dim">(0.21s)</span></span><span class="tl"><span class="t-warm">●</span> <span class="t-dim">2 files · cache 94.2% → 95.1%</span></span><span class="tl"><span class="t-vio">›</span> <span class="caret"></span></span></div>
-          <div class="term-stat"><span>cache <b data-cnt="95.1" data-dec="1" data-suf="% hit">95.1% hit</b></span><span>session <b data-cnt="18" data-suf="m">18m</b></span><span>model <b>deepseek-v4-flash</b></span><span>cost <b data-cnt="0.043" data-dec="3" data-pre="$">$0.043</b></span></div>
+          <div class="term-body"><span class="tl"><span class="t-acc">◆</span> reasonix <span class="t-dim"><span class="rxv">{goVer}</span> · deepseek-v4-flash · ~/app</span></span><span class="tl"><span class="t-vio">›</span> add retry with backoff to the http client</span><span class="tl"><span class="t-acc">◇</span> plan <span class="t-dim">3 steps · 2 files · 1 test run</span></span><span class="tl"><span class="t-warm">●</span> allow <span class="t-dim">edit internal/net/client.go</span>  <span class="t-ok">yes</span></span><span class="tl"><span class="t-ok">✓</span> edit <span class="t-dim">internal/net/client.go</span>  <span class="t-add">+24 −3</span></span><span class="tl"><span class="t-ok">✓</span> edit <span class="t-dim">internal/net/client_test.go</span>  <span class="t-add">+41 −0</span></span><span class="tl"><span class="t-ok">✓</span> run <span class="t-dim">go test ./internal/net/</span>  <span class="t-ok">ok</span> <span class="t-dim">(0.21s)</span></span><span class="tl"><span class="t-acc">◆</span> checkpoint <span class="t-dim">#14 — revert this turn anytime</span></span><span class="tl"><span class="t-vio">›</span> <span class="caret"></span></span></div>
+          <div class="term-stat"><span>surface <b>cli</b></span><span>tools <b data-cnt="9" data-suf=" calls">9 calls</b></span><span>session <b data-cnt="18" data-suf="m">18m</b></span><span>cost <b data-cnt="0.043" data-dec="3" data-pre="$">$0.043</b></span></div>
         </div>
       </div>
     </div>
@@ -114,42 +113,99 @@ const ld = {
     <div class="wrap">
       <div class="sec-head split reveal">
         <span class="kicker"><span class="l-en">Features</span><span class="l-zh">特性</span></span>
-        <h2><span class="l-en">Built for long, <span class="em">cheap</span> sessions.</span><span class="l-zh">为长会话、<span class="em">低成本</span>而生。</span></h2>
-        <p><span class="l-en">Most agents pay full price for the same growing prompt every turn. Reasonix keeps the prefix byte-identical so DeepSeek's cache does the heavy lifting — and everything else follows.</span><span class="l-zh">多数 agent 每回合都为同一段不断增长的 prompt 付全价。Reasonix 让前缀逐字节稳定,让 DeepSeek 的缓存替你扛下来——其余一切由此而来。</span></p>
+        <h2><span class="l-en">Autonomy you can <span class="em">actually audit.</span></span><span class="l-zh">可以<span class="em">真正审阅</span>的自治。</span></h2>
+        <p><span class="l-en">Letting an agent run for hours is only useful if you can see what it did and undo the parts you don't want. Every layer here exists for that: plan first, gate each tool call, checkpoint every turn.</span><span class="l-zh">让 agent 跑上几个小时,前提是你能看清它做了什么、并撤销你不想要的部分。这里的每一层都为此存在:先规划、逐次工具调用受控、逐轮 checkpoint。</span></p>
       </div>
       <div class="feat-grid">
         <div class="feat reveal">
-          <span class="tag">01 / cache-first</span>
-          <h3><span class="l-en">Cache-first loop</span><span class="l-zh">缓存优先循环</span></h3>
-          <p><span class="l-en">Append-only history aligned to DeepSeek's prefix cache. 90%+ hit on long sessions; input tokens bill at ~1/5.</span><span class="l-zh">append-only 历史对齐 DeepSeek prefix-cache。长会话 90%+ 命中,输入 token 约 1/5 计费。</span></p>
-          <div class="feat-viz" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i class="n"></i><i class="n"></i><i class="n"></i></div>
+          <span class="tag">01 / permissions</span>
+          <h3><span class="l-en">Every tool call is gated</span><span class="l-zh">每次工具调用都受控</span></h3>
+          <p><span class="l-en">Reads, writes, and shell commands each ask separately, and the workspace sandbox bounds what a command can touch even after you say yes.</span><span class="l-zh">读取、写入、shell 命令分别询问；即便你放行,工作区沙箱仍限定命令能触碰的范围。</span></p>
+          <code class="feat-chip">$ allow edit internal/net/client.go? [y/n/always]</code>
         </div>
         <div class="feat reveal" style="--d:0.06s">
-          <span class="tag">02 / single binary</span>
-          <h3><span class="l-en">Single Go binary</span><span class="l-zh">单个 Go 二进制</span></h3>
-          <p><span class="l-en">CGO-free, cross-compiled for darwin/linux/windows × amd64/arm64. No Node runtime to install or babysit.</span><span class="l-zh">无 CGO,交叉编译覆盖 darwin/linux/windows × amd64/arm64。运行不需要 Node。</span></p>
+          <span class="tag">02 / checkpoints</span>
+          <h3><span class="l-en">Undo any turn</span><span class="l-zh">任意一轮都可回退</span></h3>
+          <p><span class="l-en">Each turn writes a checkpoint outside git, so a six-hour run rewinds to any point without touching your commit history.</span><span class="l-zh">每轮在 git 之外写入 checkpoint,六小时的运行可回退到任意一点,且不污染你的提交历史。</span></p>
         </div>
         <div class="feat reveal" style="--d:0.04s">
-          <span class="tag">03 / mcp</span>
-          <h3>MCP first-class</h3>
-          <p><span class="l-en">stdio, SSE, streamable HTTP. External servers merge their tools into one registry under a prefix.</span><span class="l-zh">stdio、SSE、streamable HTTP。外部服务器的工具以前缀合并进同一 registry。</span></p>
+          <span class="tag">03 / plan mode</span>
+          <h3><span class="l-en">Plan before it touches anything</span><span class="l-zh">动手前先给出计划</span></h3>
+          <p><span class="l-en"><code>/plan</code> holds every write until you've read the plan and approved it.</span><span class="l-zh"><code>/plan</code> 会先给出计划,在你读过并批准前不写入任何东西。</span></p>
         </div>
         <div class="feat reveal" style="--d:0.1s">
-          <span class="tag">04 / plan + sandbox</span>
-          <h3><span class="l-en">Plan mode &amp; sandbox</span><span class="l-zh">计划模式 + 沙箱</span></h3>
-          <p><span class="l-en"><code>/plan</code> asks the model to plan first; Permissions and the workspace sandbox still govern every tool call.</span><span class="l-zh"><code>/plan</code> 要求模型先规划；每次工具调用仍由权限与工作区沙箱控制。</span></p>
-          <code class="feat-chip">$ /plan → plan first · permissions still apply</code>
+          <span class="tag">04 / mcp + skills</span>
+          <h3><span class="l-en">Extend it without forking it</span><span class="l-zh">不用 fork 就能扩展</span></h3>
+          <p><span class="l-en">MCP over stdio, SSE, and streamable HTTP merges external tools into one registry. Markdown skills and subagents — explore, research, review, security-review — run with their own isolated tool sets.</span><span class="l-zh">MCP 支持 stdio、SSE 与 streamable HTTP,把外部工具合并进同一 registry。Markdown 技能与子智能体(explore / research / review / security-review)各自持有隔离的工具集。</span></p>
+          <code class="feat-chip">$ reasonix mcp add · ~/.reasonix/skills/</code>
         </div>
         <div class="feat reveal" style="--d:0.06s">
-          <span class="tag">05 / subagents</span>
-          <h3><span class="l-en">Subagents &amp; skills</span><span class="l-zh">子智能体与技能</span></h3>
-          <p><span class="l-en">explore / research / review / security-review agents, plus Markdown skill scripts with isolated tools.</span><span class="l-zh">explore / research / review / security-review 子智能体,加 Markdown 技能脚本与隔离工具。</span></p>
+          <span class="tag">05 / single binary</span>
+          <h3><span class="l-en">One file, no runtime</span><span class="l-zh">一个文件,零运行时</span></h3>
+          <p><span class="l-en">CGO-free Go, cross-compiled for darwin/linux/windows × amd64/arm64. Nothing to install underneath it.</span><span class="l-zh">无 CGO 的 Go,交叉编译覆盖 darwin/linux/windows × amd64/arm64。底下不需要装任何东西。</span></p>
         </div>
         <div class="feat reveal" style="--d:0.1s">
-          <span class="tag">06 / cli + web + acp</span>
-          <h3><span class="l-en">Terminal, browser, or editor</span><span class="l-zh">终端、浏览器或编辑器</span></h3>
-          <p><span class="l-en">Use the full-screen TUI, run <code>reasonix serve</code> for a local browser UI, <a href="?download=vscode#start" data-goto="vscode">install the Reasonix VS Code extension</a>, or connect another ACP-compatible editor through <code>reasonix acp</code>. Every surface uses the same local engine.</span><span class="l-zh">使用全屏 TUI、通过 <code>reasonix serve</code> 打开本地浏览器 UI、<a href="?download=vscode#start" data-goto="vscode">安装 Reasonix VS Code 扩展</a>，或通过 <code>reasonix acp</code> 连接其他兼容 ACP 的编辑器；所有入口都使用同一套本地引擎。</span></p>
-          <code class="feat-chip">$ reasonix acp</code>
+          <span class="tag">06 / local-first</span>
+          <h3><span class="l-en">Your key, your machine</span><span class="l-zh">你的 Key,你的机器</span></h3>
+          <p><span class="l-en">Bring your own DeepSeek key. The engine runs locally — your code goes to the model you configured and nowhere else. MIT licensed, developed in public.</span><span class="l-zh">使用你自己的 DeepSeek Key。引擎在本地运行——代码只发往你配置的模型,不去别处。MIT 许可,公开开发。</span></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="divider" aria-hidden="true"><span class="line"></span></div>
+
+  <section id="surfaces">
+    <div class="wrap">
+      <div class="sec-head split reveal">
+        <span class="kicker"><span class="l-en">Surfaces</span><span class="l-zh">使用形态</span></span>
+        <h2><span class="l-en">One engine. <span class="em">Four ways in.</span></span><span class="l-zh">同一个引擎。<span class="em">四个入口。</span></span></h2>
+        <p><span class="l-en">Not four products — one local engine behind four front ends. Sessions, permissions, skills and MCP servers are shared, so a task you start in the terminal is waiting for you in the desktop app.</span><span class="l-zh">不是四个产品,而是一个本地引擎配四个前端。会话、权限、技能与 MCP 服务器都共享——在终端起的任务,打开桌面端就在那儿等着。</span></p>
+      </div>
+      <div class="surf-grid">
+        <div class="surf reveal">
+          <div class="surf-art" aria-hidden="true">
+            <span class="surf-win cli">
+              <i class="bar"></i>
+              <span class="body"><i class="l" style="--w:62%"></i><i class="l" style="--w:44%"></i><i class="l ok" style="--w:70%"></i><i class="l" style="--w:38%"></i><i class="cur"></i></span>
+            </span>
+          </div>
+          <h3><span class="l-en">Terminal</span><span class="l-zh">终端</span></h3>
+          <p><span class="l-en">Full-screen TUI — diff review, approvals, slash commands.</span><span class="l-zh">全屏 TUI——diff 审阅、审批、斜杠命令。</span></p>
+          <code>reasonix</code>
+        </div>
+        <div class="surf reveal" style="--d:0.06s">
+          <div class="surf-art" aria-hidden="true">
+            <span class="surf-win app">
+              <i class="bar"></i>
+              <span class="body"><span class="side"><i></i><i></i><i></i></span><span class="main"><i class="l" style="--w:80%"></i><i class="l" style="--w:55%"></i><i class="l ok" style="--w:66%"></i></span></span>
+            </span>
+          </div>
+          <h3><span class="l-en">Desktop app</span><span class="l-zh">桌面端</span></h3>
+          <p><span class="l-en">Sessions side by side, settings, approvals, auto-update.</span><span class="l-zh">多会话并列、设置、审批与自动更新。</span></p>
+          <code><span class="l-en">macOS · Windows · Linux</span><span class="l-zh">macOS · Windows · Linux</span></code>
+        </div>
+        <div class="surf reveal" style="--d:0.12s">
+          <div class="surf-art" aria-hidden="true">
+            <span class="surf-win web">
+              <i class="bar url"></i>
+              <span class="body"><i class="l" style="--w:72%"></i><i class="l" style="--w:48%"></i><i class="l ok" style="--w:60%"></i><i class="l" style="--w:36%"></i></span>
+            </span>
+          </div>
+          <h3><span class="l-en">Browser</span><span class="l-zh">浏览器</span></h3>
+          <p><span class="l-en">A local web UI on your own machine. Add auth before you expose it.</span><span class="l-zh">跑在你自己机器上的本地 Web UI。对外暴露前先开认证。</span></p>
+          <code>reasonix serve</code>
+        </div>
+        <div class="surf reveal" style="--d:0.18s">
+          <div class="surf-art" aria-hidden="true">
+            <span class="surf-win ide">
+              <i class="bar"></i>
+              <span class="body"><span class="tree"><i></i><i></i><i></i><i></i></span><span class="main"><i class="l" style="--w:70%"></i><i class="l add" style="--w:52%"></i><i class="l add" style="--w:44%"></i><i class="l" style="--w:64%"></i></span></span>
+            </span>
+          </div>
+          <h3><span class="l-en">Your editor</span><span class="l-zh">你的编辑器</span></h3>
+          <p><span class="l-en">VS Code and VSCodium via the extension; anything else that speaks ACP.</span><span class="l-zh">通过扩展接入 VS Code 与 VSCodium；其他支持 ACP 的编辑器同样可用。</span></p>
+          <code>reasonix acp</code>
         </div>
       </div>
     </div>
@@ -162,9 +218,9 @@ const ld = {
       <div class="how-stage">
         <div class="wrap">
           <div class="sec-head center reveal">
-            <span class="kicker"><span class="l-en">How it works</span><span class="l-zh">工作原理</span></span>
-            <h2><span class="l-en">Every turn reuses <span class="em">the last.</span></span><span class="l-zh">每一轮都复用<span class="em">上一轮。</span></span></h2>
-            <p><span class="l-en">Each request replays the exact same byte-for-byte prefix, so the model only computes what's new. Long sessions get cheaper per turn — not more expensive.</span><span class="l-zh">每次请求都逐字节重放完全相同的前缀,模型只计算新增部分。会话越长,每轮越便宜——而不是越贵。</span></p>
+            <span class="kicker"><span class="l-en">Under the hood</span><span class="l-zh">技术细节</span></span>
+            <h2><span class="l-en">Hour six costs about what <span class="em">hour one did.</span></span><span class="l-zh">跑到第六小时,成本和<span class="em">第一小时差不多。</span></span></h2>
+            <p><span class="l-en">The history is append-only, so each request replays a byte-identical prefix and the model only computes what's new. It's an implementation detail — it just happens to be the one that decides whether leaving the agent running is something you can afford.</span><span class="l-zh">历史是 append-only 的,每次请求重放逐字节相同的前缀,模型只计算新增部分。这只是一个实现细节——只不过它恰好决定了「让 agent 一直跑着」你负不负担得起。</span></p>
           </div>
           <div class="cache-panel reveal">
             <div class="cache-grid">
@@ -205,7 +261,7 @@ const ld = {
         <div class="step reveal" style="--d:0.08s">
           <span class="num">02</span>
           <h3><span class="l-en">Point it at a repo</span><span class="l-zh">指向你的仓库</span></h3>
-          <p><span class="l-en">Reasonix maps the codebase once, then keeps that map in the warm prefix.</span><span class="l-zh">Reasonix 只做一次代码库测绘,然后把这份地图常驻在温热的前缀缓存里。</span></p>
+          <p><span class="l-en">It maps the codebase once and keeps that map for the rest of the session.</span><span class="l-zh">只做一次代码库测绘,这份地图在整场会话里一直有效。</span></p>
           <code>cd your-project &amp;&amp; reasonix</code>
         </div>
         <div class="step reveal" style="--d:0.16s">
@@ -404,7 +460,7 @@ const ld = {
       </nav>
     </div>
     <div class="foot-sub">
-      <span><span class="l-en">Engineered around DeepSeek's prefix cache.</span><span class="l-zh">围绕 DeepSeek 前缀缓存而设计。</span></span>
+      <span><span class="l-en">Built to be left running.</span><span class="l-zh">为长时间常驻运行而造。</span></span>
       <span class="ver"><span class="rxv">{goVer}</span> · official</span>
     </div>
   </footer>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -213,42 +213,6 @@ const ld = {
 
   <div class="divider" aria-hidden="true"><span class="line"></span></div>
 
-  <section id="how">
-    <div class="how-track">
-      <div class="how-stage">
-        <div class="wrap">
-          <div class="sec-head center reveal">
-            <span class="kicker"><span class="l-en">Under the hood</span><span class="l-zh">技术细节</span></span>
-            <h2><span class="l-en">Hour six costs about what <span class="em">hour one did.</span></span><span class="l-zh">跑到第六小时,成本和<span class="em">第一小时差不多。</span></span></h2>
-            <p><span class="l-en">The history is append-only, so each request replays a byte-identical prefix and the model only computes what's new. It's an implementation detail — it just happens to be the one that decides whether leaving the agent running is something you can afford.</span><span class="l-zh">历史是 append-only 的,每次请求重放逐字节相同的前缀,模型只计算新增部分。这只是一个实现细节——只不过它恰好决定了「让 agent 一直跑着」你负不负担得起。</span></p>
-          </div>
-          <div class="cache-panel reveal">
-            <div class="cache-grid">
-              <div class="cache-steps">
-                <span class="cap" data-step="1"><span class="n">01</span><span class="l-en">Cold start — everything is computed</span><span class="l-zh">冷启动——全部需要计算</span></span>
-                <span class="cap" data-step="2"><span class="n">02</span><span class="l-en">The previous turn replays from cache</span><span class="l-zh">上一轮全部从缓存重放</span></span>
-                <span class="cap" data-step="3"><span class="n">03</span><span class="l-en">Only the new request is computed</span><span class="l-zh">只计算新增的请求</span></span>
-                <span class="cap" data-step="4"><span class="n">04</span><span class="l-en">90%+ cache hit — cheaper every turn</span><span class="l-zh">命中 90%+——越跑越便宜</span></span>
-              </div>
-              <div class="cache-rows-wrap">
-                <div class="cache-row"><span class="lbl">turn 1</span><span class="blk new"></span><span class="blk new"></span><span class="blk new"></span></div>
-                <div class="cache-row"><span class="lbl">turn 2</span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk new"></span><span class="blk new"></span></div>
-                <div class="cache-row"><span class="lbl">turn 3</span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk new"></span><span class="blk new"></span><span class="blk new"></span></div>
-                <div class="cache-row"><span class="lbl">turn 4</span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk hit"></span><span class="blk new"></span><span class="blk new"></span></div>
-                <div class="cache-legend">
-                  <span><i style="background: var(--accent);"></i><span class="l-en">new tokens — computed</span><span class="l-zh">新 token——需要计算</span></span>
-                  <span><i style="background: color-mix(in oklch, var(--accent) 12%, transparent); border: 1px solid color-mix(in oklch, var(--accent) 40%, transparent);"></i><span class="l-en">cached prefix — replayed, billed at ~1/5</span><span class="l-zh">缓存前缀——重放,约 1/5 计费</span></span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="divider" aria-hidden="true"><span class="line"></span></div>
-
   <section>
     <div class="wrap">
       <div class="steps">

--- a/site/src/scripts/fx.js
+++ b/site/src/scripts/fx.js
@@ -2,45 +2,6 @@
 (function () {
   const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const rich = () => document.body.dataset.motion === "rich" && !reduced;
-  const lerp = (a, b, t) => a + (b - a) * t;
-
-  /* run a rAF loop only while `el` is on screen — no idle spinning */
-  const rafWhileVisible = (el, fn) => {
-    let rafId = 0, running = false;
-    const loop = () => {
-      if (!running) return;
-      fn();
-      rafId = requestAnimationFrame(loop);
-    };
-    const setRunning = (on) => {
-      if (on === running) return;
-      running = on;
-      if (on) rafId = requestAnimationFrame(loop);
-      else cancelAnimationFrame(rafId);
-    };
-    new IntersectionObserver((entries) => {
-      setRunning(entries[entries.length - 1].isIntersecting);
-    }).observe(el);
-  };
-
-  /* terminal 3D tilt toward cursor */
-  const term = document.querySelector(".term");
-  if (term && matchMedia("(pointer: fine)").matches) {
-    const stage = term.parentElement;
-    let rx = 0, ry = 0, trx = 0, try_ = 0;
-    stage.addEventListener("mousemove", (e) => {
-      const r = stage.getBoundingClientRect();
-      try_ = ((e.clientX - r.left) / r.width - 0.5) * 5;
-      trx = (0.5 - (e.clientY - r.top) / r.height) * 4;
-    });
-    stage.addEventListener("mouseleave", () => { trx = 0; try_ = 0; });
-    rafWhileVisible(stage, () => {
-      if (!rich()) { term.style.transform = ""; return; }
-      rx = lerp(rx, trx, 0.08);
-      ry = lerp(ry, try_, 0.08);
-      term.style.transform = `rotateX(${rx.toFixed(2)}deg) rotateY(${ry.toFixed(2)}deg)`;
-    });
-  }
 
   /* spotlight border on cards */
   document.querySelectorAll(".feat, .os-card, .doc-card").forEach((card) => {

--- a/site/src/scripts/fx.js
+++ b/site/src/scripts/fx.js
@@ -37,34 +37,4 @@
     });
   };
   document.addEventListener("rx:term-played", runCounters);
-
-  /* scroll-driven cache narrative (sticky) */
-  const track = document.querySelector(".how-track");
-  if (track) {
-    const rows = Array.from(track.querySelectorAll(".cache-row"));
-    const caps = Array.from(track.querySelectorAll(".cap"));
-    rows.forEach((row) =>
-      row.querySelectorAll(".blk").forEach((b, i) => b.style.setProperty("--i", i)));
-    const stickyOK = () => rich() && innerWidth > 900;
-    const setStep = (n) => {
-      rows.forEach((r, i) => r.classList.toggle("row-on", i < n));
-      caps.forEach((c) => c.classList.toggle("on", +c.dataset.step === n));
-    };
-    const onScroll = () => {
-      if (!stickyOK()) {
-        document.body.classList.add("how-flat");
-        setStep(4);
-        return;
-      }
-      document.body.classList.remove("how-flat");
-      const r = track.getBoundingClientRect();
-      const total = r.height - innerHeight;
-      const p = Math.min(1, Math.max(0, -r.top / total));
-      if (r.top > innerHeight) { setStep(0); return; }
-      setStep(Math.min(4, 1 + Math.floor(p * 4)));
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onScroll);
-    onScroll();
-  }
 })();

--- a/site/src/scripts/fx.js
+++ b/site/src/scripts/fx.js
@@ -3,10 +3,6 @@
   const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const rich = () => document.body.dataset.motion === "rich" && !reduced;
   const lerp = (a, b, t) => a + (b - a) * t;
-  const mouse = { x: innerWidth / 2, y: innerHeight / 2, active: false };
-  window.addEventListener("mousemove", (e) => {
-    mouse.x = e.clientX; mouse.y = e.clientY; mouse.active = true;
-  }, { passive: true });
 
   /* run a rAF loop only while `el` is on screen — no idle spinning */
   const rafWhileVisible = (el, fn) => {
@@ -26,54 +22,6 @@
       setRunning(entries[entries.length - 1].isIntersecting);
     }).observe(el);
   };
-
-  /* particle grid (hero canvas) */
-  const canvas = document.querySelector(".hero-dots");
-  if (canvas) {
-    const ctx = canvas.getContext("2d");
-    const hero = canvas.parentElement;
-    let w = 0, h = 0, dpr = 1, dots = [];
-    const SP = 36;
-    const build = () => {
-      dpr = Math.min(devicePixelRatio || 1, 2);
-      const r = hero.getBoundingClientRect();
-      w = r.width; h = r.height;
-      canvas.width = w * dpr; canvas.height = h * dpr;
-      canvas.style.width = w + "px"; canvas.style.height = h + "px";
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      dots = [];
-      for (let y = SP; y < h - 8; y += SP)
-        for (let x = SP / 2 + ((y / SP) % 2 ? SP / 2 : 0); x < w - 8; x += SP)
-          dots.push({ x, y, a: 0 });
-    };
-    build();
-    window.addEventListener("resize", build);
-    let mx = -9999, my = -9999;
-    const accent = () =>
-      getComputedStyle(document.documentElement).getPropertyValue("--accent").trim() || "#3a5fd0";
-    rafWhileVisible(hero, () => {
-      const r = hero.getBoundingClientRect();
-      ctx.clearRect(0, 0, w, h);
-      if (!rich()) return;
-      const tx = mouse.active ? mouse.x - r.left : -9999;
-      const ty = mouse.active ? mouse.y - r.top : -9999;
-      mx = lerp(mx < -999 ? tx : mx, tx, 0.14);
-      my = lerp(my < -999 ? ty : my, ty, 0.14);
-      const col = accent();
-      for (const d of dots) {
-        const dist = Math.hypot(d.x - mx, d.y - my);
-        const target = dist < 150 ? 1 - dist / 150 : 0;
-        d.a = lerp(d.a, target, 0.12);
-        const base = 0.13;
-        ctx.beginPath();
-        ctx.arc(d.x, d.y, 1.1 + d.a * 1.3, 0, 7);
-        if (d.a > 0.02) { ctx.globalAlpha = base + d.a * 0.65; ctx.fillStyle = col; }
-        else { ctx.globalAlpha = base; ctx.fillStyle = "#9aa0a6"; }
-        ctx.fill();
-      }
-      ctx.globalAlpha = 1;
-    });
-  }
 
   /* terminal 3D tilt toward cursor */
   const term = document.querySelector(".term");

--- a/site/src/scripts/header-contract.test.mjs
+++ b/site/src/scripts/header-contract.test.mjs
@@ -22,7 +22,7 @@ test("primary site pages share the same header component", async () => {
 test("the shared header owns the complete global navigation", async () => {
   const header = await source("../components/SiteHeader.astro");
 
-  for (const id of ["features", "how", "skills", "community", "docs", "changelog"]) {
+  for (const id of ["features", "surfaces", "skills", "community", "docs", "changelog"]) {
     assert.match(header, new RegExp(`id: '${id}'`));
   }
 

--- a/site/src/styles/community.css
+++ b/site/src/styles/community.css
@@ -1,6 +1,6 @@
 /* Reasonix Community — self-hosted fonts + the reasonix.io token values, so the
    forum shares the site's visual language without depending on its marketing CSS. */
-@import "@fontsource-variable/outfit";
+@import "@fontsource-variable/inter";
 @import "@fontsource-variable/jetbrains-mono";
 
 :root {
@@ -12,21 +12,21 @@
   --bg: #ffffff;
   --bg-soft: oklch(0.977 0.0025 247);
   --card: #ffffff;
-  --ink: oklch(0.25 0.006 260);
-  --ink-2: oklch(0.47 0.008 260);
-  --ink-3: oklch(0.62 0.008 260);
-  --line: oklch(0.925 0.004 247);
+  --ink: oklch(0.21 0.006 260);
+  --ink-2: oklch(0.45 0.008 260);
+  --ink-3: oklch(0.6 0.008 260);
+  --line: oklch(0.905 0.004 247);
   --ok: oklch(0.6 0.14 155);
   --ok-soft: color-mix(in oklch, var(--ok) 12%, var(--bg));
   --err: oklch(0.5 0.19 25);
   --warm: oklch(0.72 0.13 66);
   --violet: oklch(0.58 0.17 300);
   --rose: oklch(0.62 0.19 15);
-  --radius: 20px;
-  --radius-sm: 12px;
-  --shadow-1: 0 1px 2px oklch(0.4 0.02 260 / 0.16), 0 1px 3px 1px oklch(0.4 0.02 260 / 0.07);
-  --shadow-2: 0 2px 6px oklch(0.4 0.02 260 / 0.12), 0 12px 30px -6px oklch(0.4 0.02 260 / 0.18);
-  --font-sans: "Outfit Variable", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --radius: 13px;
+  --radius-sm: 9px;
+  --shadow-1: 0 1px 2px oklch(0.4 0.02 260 / 0.08);
+  --shadow-2: 0 1px 2px oklch(0.4 0.02 260 / 0.06), 0 12px 32px -16px oklch(0.4 0.02 260 / 0.24);
+  --font-sans: "Inter Variable", "Inter", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
   --font-mono: "JetBrains Mono Variable", "SF Mono", Menlo, monospace;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -38,14 +38,14 @@
   --accent-soft: color-mix(in oklch, var(--accent) 16%, var(--bg));
   --bg: oklch(0.19 0.006 260);
   --bg-soft: oklch(0.225 0.008 260);
-  --card: oklch(0.255 0.009 260);
+  --card: oklch(0.222 0.008 260);
   --ink: oklch(0.93 0.004 260);
   --ink-2: oklch(0.78 0.008 260);
   --ink-3: oklch(0.63 0.008 260);
-  --line: oklch(0.33 0.008 260);
+  --line: oklch(0.31 0.008 260);
   --ok-soft: color-mix(in oklch, var(--ok) 18%, var(--bg));
-  --shadow-1: 0 1px 2px oklch(0 0 0 / 0.42), 0 1px 3px 1px oklch(0 0 0 / 0.24);
-  --shadow-2: 0 2px 6px oklch(0 0 0 / 0.35), 0 12px 30px -6px oklch(0 0 0 / 0.5);
+  --shadow-1: 0 1px 2px oklch(0 0 0 / 0.3);
+  --shadow-2: 0 1px 2px oklch(0 0 0 / 0.28), 0 12px 32px -16px oklch(0 0 0 / 0.6);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -59,8 +59,8 @@ a { color: inherit; text-decoration: none; }
 /* bilingual toggle — mirrors the main site (shared reasonix-lang choice) */
 body[data-lang="en"] .l-zh { display: none !important; }
 body[data-lang="zh"] .l-en { display: none !important; }
-.lang-switch, .theme-switch { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
-.lang-switch button, .theme-switch button { font-family: var(--font-sans); font-size: 12.5px; font-weight: 500; color: var(--ink-2); background: transparent; border: none; cursor: pointer; padding: 6px 12px; border-radius: 999px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
+.lang-switch, .theme-switch { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 9px; }
+.lang-switch button, .theme-switch button { font-family: var(--font-sans); font-size: 12.5px; font-weight: 500; color: var(--ink-2); background: transparent; border: none; cursor: pointer; padding: 6px 12px; border-radius: 6px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
 .lang-switch button:hover, .theme-switch button:hover { color: var(--ink); }
 .lang-switch button.active, .theme-switch button.active { background: var(--card); color: var(--accent); box-shadow: var(--shadow-1); }
 .theme-switch button { display: inline-flex; align-items: center; justify-content: center; }
@@ -72,16 +72,16 @@ body[data-lang="zh"] .l-en { display: none !important; }
 .brand .mark { width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center; background: linear-gradient(140deg, var(--accent), var(--violet)); color: #fff; font-weight: 700; font-size: 15px; }
 .brand .ctag { font-size: 12px; font-weight: 600; color: var(--accent); background: var(--accent-soft); padding: 3px 9px; border-radius: 999px; }
 .nav-links { display: flex; gap: 4px; margin-left: 12px; }
-.nav-links a { color: var(--ink-2); font-size: 14.5px; font-weight: 500; padding: 8px 14px; border-radius: 999px; transition: color 0.2s, background 0.2s; }
+.nav-links a { color: var(--ink-2); font-size: 14.5px; font-weight: 500; padding: 8px 14px; border-radius: 7px; transition: color 0.2s, background 0.2s; }
 .nav-links a:hover { color: var(--ink); background: var(--bg-soft); }
 .nav-links a.here { color: var(--accent); background: var(--accent-soft); }
 .nav-right { margin-left: auto; display: flex; align-items: center; gap: 12px; }
-.nav-search { display: flex; align-items: center; gap: 8px; background: var(--bg-soft); border: 1px solid transparent; border-radius: 999px; padding: 8px 14px; width: 220px; transition: border-color 0.2s, background 0.2s, box-shadow 0.2s; }
+.nav-search { display: flex; align-items: center; gap: 8px; background: var(--bg-soft); border: 1px solid transparent; border-radius: 9px; padding: 8px 14px; width: 220px; transition: border-color 0.2s, background 0.2s, box-shadow 0.2s; }
 .nav-search:focus-within { background: var(--card); border-color: var(--accent-line); box-shadow: 0 0 0 4px var(--accent-soft); }
 .nav-search input { border: none; outline: none; background: none; font-family: var(--font-sans); font-size: 14px; color: var(--ink); width: 100%; }
 .nav-search .ico { color: var(--ink-3); }
 
-.btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--font-sans); font-size: 14.5px; font-weight: 600; white-space: nowrap; padding: 10px 20px; border-radius: 999px; border: none; cursor: pointer; transition: background 0.2s, box-shadow 0.25s, color 0.2s, border-color 0.2s, transform 0.15s var(--ease); }
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; font-family: var(--font-sans); font-size: 14.5px; font-weight: 600; white-space: nowrap; padding: 10px 20px; border-radius: 9px; border: none; cursor: pointer; transition: background 0.2s, box-shadow 0.25s, color 0.2s, border-color 0.2s, transform 0.15s var(--ease); }
 .btn:active { transform: translateY(1px); }
 .btn-primary { background: var(--accent); color: #fff; }
 .btn-primary:hover { background: var(--accent-deep); box-shadow: var(--shadow-1); }
@@ -114,8 +114,8 @@ a.tag:hover { color: var(--accent); background: var(--accent-soft); }
 .side { position: sticky; top: 88px; display: flex; flex-direction: column; gap: 18px; }
 .sec-title { display: flex; align-items: center; justify-content: space-between; margin: 4px 2px 14px; }
 .sec-title h2 { font-size: 15px; font-weight: 600; }
-.tabs { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
-.tabs button { font-family: var(--font-sans); font-size: 13.5px; font-weight: 500; color: var(--ink-2); background: none; border: none; cursor: pointer; padding: 7px 15px; border-radius: 999px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
+.tabs { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 9px; }
+.tabs button { font-family: var(--font-sans); font-size: 13.5px; font-weight: 500; color: var(--ink-2); background: none; border: none; cursor: pointer; padding: 7px 15px; border-radius: 6px; transition: background 0.2s, color 0.2s, box-shadow 0.2s; }
 .tabs button.on { background: var(--card); color: var(--accent); box-shadow: var(--shadow-1); }
 .tabs button:hover:not(.on) { color: var(--ink); }
 
@@ -183,10 +183,10 @@ a.tag:hover { color: var(--accent); background: var(--accent-soft); }
 .post .body code { font-family: var(--font-mono); font-size: 13px; background: var(--bg-soft); padding: 2px 7px; border-radius: 6px; }
 .post .body pre { background: oklch(0.25 0.006 260); color: oklch(0.9 0.004 260); border-radius: var(--radius-sm); padding: 16px 18px; overflow-x: auto; font-family: var(--font-mono); font-size: 13px; line-height: 1.7; margin: 4px 0 12px; }
 .post .actions { display: flex; align-items: center; gap: 6px; margin-top: 16px; }
-.react { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-sans); font-size: 13px; font-weight: 500; color: var(--ink-2); background: var(--bg-soft); border: 1px solid transparent; border-radius: 999px; padding: 6px 13px; cursor: pointer; transition: background 0.2s, border-color 0.2s, color 0.2s; }
+.react { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-sans); font-size: 13px; font-weight: 500; color: var(--ink-2); background: var(--bg-soft); border: 1px solid transparent; border-radius: 7px; padding: 6px 13px; cursor: pointer; transition: background 0.2s, border-color 0.2s, color 0.2s; }
 .react:hover { border-color: var(--accent-line); color: var(--accent); }
 .react.on { background: var(--accent-soft); color: var(--accent); }
-.link-act { font-size: 13px; font-weight: 500; color: var(--ink-3); padding: 6px 10px; border-radius: 999px; cursor: pointer; background: none; border: none; font-family: var(--font-sans); }
+.link-act { font-size: 13px; font-weight: 500; color: var(--ink-3); padding: 6px 10px; border-radius: 7px; cursor: pointer; background: none; border: none; font-family: var(--font-sans); }
 .link-act:hover { color: var(--accent); background: var(--accent-soft); }
 
 .composer { border: 1px solid var(--line); border-radius: var(--radius); padding: 8px; margin-top: 24px; background: var(--card); transition: border-color 0.2s, box-shadow 0.2s; }
@@ -195,7 +195,7 @@ a.tag:hover { color: var(--accent); background: var(--accent-soft); }
 .composer textarea { width: 100%; border: none; outline: none; resize: vertical; min-height: 96px; padding: 12px 14px; font-family: var(--font-sans); font-size: 15px; color: var(--ink); background: none; line-height: 1.6; }
 .composer .foot { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px 6px; gap: 12px; flex-wrap: wrap; }
 .composer .foot .hint { font-size: 12px; color: var(--ink-3); }
-.composer select { font-family: var(--font-sans); font-size: 13px; color: var(--ink-2); background: var(--bg-soft); border: none; border-radius: 999px; padding: 8px 12px; cursor: pointer; }
+.composer select { font-family: var(--font-sans); font-size: 13px; color: var(--ink-2); background: var(--bg-soft); border: none; border-radius: 7px; padding: 8px 12px; cursor: pointer; }
 .gate { text-align: center; padding: 22px; }
 .gate p { font-size: 14px; color: var(--ink-2); margin-bottom: 14px; }
 
@@ -208,7 +208,7 @@ a.tag:hover { color: var(--accent); background: var(--accent-soft); }
 .foot { border-top: 1px solid var(--line); }
 .foot-inner { max-width: 1180px; margin: 0 auto; padding: 28px 32px; display: flex; align-items: center; gap: 20px; flex-wrap: wrap; font-size: 13.5px; color: var(--ink-3); }
 .foot-inner .links { display: flex; gap: 4px; margin-left: auto; flex-wrap: wrap; }
-.foot-inner .links a { padding: 6px 12px; border-radius: 999px; color: var(--ink-2); font-weight: 500; transition: background 0.2s, color 0.2s; }
+.foot-inner .links a { padding: 6px 12px; border-radius: 7px; color: var(--ink-2); font-weight: 500; transition: background 0.2s, color 0.2s; }
 .foot-inner .links a:hover { background: var(--bg-soft); color: var(--ink); }
 
 @media (max-width: 940px) {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -71,7 +71,7 @@ body[data-lang="zh"] .l-en { display: none !important; }
 body[data-lang="zh"] h1,
 body[data-lang="zh"] h2,
 body[data-lang="zh"] h3 { letter-spacing: 0; }
-body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height: 1.22; }
+body[data-lang="zh"] .hero h1 { font-size: clamp(38px, 4.6vw, 62px); line-height: 1.24; }
 
 .lang-switch, .theme-switch {
   display: inline-flex; gap: 2px; padding: 3px;
@@ -168,7 +168,7 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .hero h1 em { font-style: italic; color: var(--accent); }
 .hero h1 .tt {
   color: var(--accent);
-  box-shadow: inset 0 -0.12em 0 color-mix(in oklch, var(--accent) 22%, transparent);
+  box-shadow: inset 0 -0.06em 0 color-mix(in oklch, var(--accent) 30%, transparent);
 }
 .hero .sub {
   margin: 26px auto 0; max-width: 640px;
@@ -178,8 +178,8 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .hero .sub b { color: var(--ink); font-weight: 600; }
 
 .hero-install {
-  --hero-action-height: 48px;
-  --hero-action-width: 160px;
+  --hero-action-height: 46px;
+  --hero-action-width: 178px;
   width: min(850px, 100%); margin: 40px auto 0;
   display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px;
 }
@@ -322,8 +322,8 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .term-stat b { color: oklch(0.86 0.02 260); font-weight: 500; }
 
 /* sections */
-section { padding: 150px 0 0; }
-.sec-head { max-width: 680px; margin: 0 auto 64px; text-align: center; }
+section { padding: 118px 0 0; }
+.sec-head { max-width: 680px; margin: 0 auto 56px; text-align: center; }
 .sec-head.center { margin-left: auto; margin-right: auto; text-align: center; }
 .kicker {
   font-family: var(--font-mono); font-size: 13.5px; font-weight: 500; letter-spacing: 0.02em;
@@ -582,8 +582,8 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .os-card:hover::after, .doc-card:hover::after { opacity: 1; }
 
 /* dividers */
-.divider { position: relative; height: 40px; margin-top: 110px; pointer-events: none; }
-.divider + section { padding-top: 70px; }
+.divider { position: relative; height: 24px; margin-top: 84px; pointer-events: none; }
+.divider + section { padding-top: 52px; }
 .divider .line {
   position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
   width: min(1100px, calc(100% - 80px)); height: 1px;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -146,7 +146,6 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 
 /* hero */
 .hero { position: relative; padding: 150px 0 0; text-align: center; }
-.hero-dots { position: absolute; inset: 0; z-index: -1; pointer-events: none; }
 
 .eyebrow {
   display: inline-flex; align-items: center; gap: 9px;
@@ -383,6 +382,64 @@ section { padding: 150px 0 0; }
 .feat h3 { font-size: 22px; letter-spacing: -0.01em; font-weight: 600; margin-bottom: 12px; }
 .feat p { font-size: 15.5px; line-height: 1.68; color: var(--ink-2); text-wrap: pretty; }
 .feat code { font-family: var(--font-mono); font-size: 12.5px; color: var(--ink); }
+
+/* surfaces */
+.surf-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 18px; }
+.surf {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 20px 20px 24px;
+  border: 1px solid var(--line); border-radius: var(--radius);
+  background: var(--card);
+  transition: border-color 0.25s, transform 0.25s var(--ease);
+}
+.surf:hover { border-color: color-mix(in oklch, var(--accent) 38%, var(--line)); transform: translateY(-2px); }
+.surf h3 { font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
+.surf p { flex: 1; font-size: 14px; line-height: 1.6; color: var(--ink-2); text-wrap: pretty; }
+.surf code {
+  align-self: flex-start;
+  font-family: var(--font-mono); font-size: 12px; color: var(--ink-2);
+  background: var(--bg-soft); border: 1px solid var(--line);
+  border-radius: 7px; padding: 6px 10px;
+}
+.surf-art {
+  display: grid; place-items: center;
+  height: 132px; margin-bottom: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-soft); overflow: hidden;
+}
+.surf-win {
+  display: grid; grid-template-rows: auto 1fr;
+  width: 78%; height: 88px;
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--card); overflow: hidden;
+}
+.surf-win .bar { height: 12px; border-bottom: 1px solid var(--line); background: var(--bg-soft); }
+.surf-win .bar.url { position: relative; }
+.surf-win .bar.url::after {
+  content: ""; position: absolute; left: 8px; top: 3px;
+  width: 58%; height: 6px; border-radius: 999px;
+  background: color-mix(in oklch, var(--ink) 12%, transparent);
+}
+.surf-win .body { display: flex; flex-direction: column; gap: 6px; padding: 9px 10px; }
+.surf-win .l { height: 5px; width: var(--w, 60%); border-radius: 999px; background: color-mix(in oklch, var(--ink) 14%, transparent); }
+.surf-win .l.ok { background: color-mix(in oklch, var(--accent) 55%, transparent); }
+.surf-win .l.add { background: color-mix(in oklch, oklch(0.65 0.15 155) 62%, transparent); }
+.surf-win .cur { width: 5px; height: 8px; background: var(--accent); }
+.surf-win.app .body, .surf-win.ide .body { flex-direction: row; gap: 8px; }
+.surf-win .side, .surf-win .tree {
+  display: flex; flex-direction: column; gap: 5px;
+  width: 24px; flex: none; padding-right: 7px;
+  border-right: 1px solid var(--line);
+}
+.surf-win .side i, .surf-win .tree i { height: 5px; width: 100%; border-radius: 999px; background: color-mix(in oklch, var(--ink) 12%, transparent); }
+.surf-win .side i:first-child { background: color-mix(in oklch, var(--accent) 50%, transparent); }
+.surf-win .tree i:nth-child(2) { width: 68%; }
+.surf-win .tree i:nth-child(3) { width: 86%; }
+.surf-win .main { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 0; }
+.surf-win.cli { background: var(--term-bg); border-color: var(--term-edge); }
+.surf-win.cli .bar { background: color-mix(in oklch, #fff 6%, var(--term-bg)); border-bottom-color: var(--term-edge); }
+.surf-win.cli .l { background: color-mix(in oklch, #fff 22%, transparent); }
+.surf-win.cli .l.ok { background: oklch(0.72 0.13 160); }
 
 /* cache diagram */
 .cache-panel {
@@ -984,6 +1041,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .divider { display: none; }
   .divider + section { padding-top: 100px; }
   .feat-grid, .os-grid, .steps { grid-template-columns: 1fr; }
+  .surf-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .feat, .feat:nth-child(1), .feat:nth-child(2), .feat:nth-child(3),
   .feat:nth-child(4), .feat:nth-child(5), .feat:nth-child(6) { grid-column: auto; }
   .sec-head.split { grid-template-columns: 1fr; align-items: start; }
@@ -1009,6 +1067,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .nav .brand span { display: none; }
   .theme-switch button { padding: 6px 9px; }
   .docs-path-grid { grid-template-columns: 1fr; }
+  .surf-grid { grid-template-columns: 1fr; }
   .docs-main h1 { font-size: 34px; }
   .dl-tabs {
     display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,7 +1,6 @@
-/* Reasonix marketing site — visual language:
-   one blue accent, soft-gray surfaces, large radii, pill buttons.
-   Light/dark themes via [data-theme] on <html>; every color is a token. */
-@import '@fontsource-variable/outfit';
+/* Reasonix site — one accent, hairline borders, tight radii, flat surfaces.
+   Light/dark via [data-theme] on <html>; every color is a token. */
+@import '@fontsource-variable/inter';
 @import '@fontsource-variable/jetbrains-mono';
 
 :root {
@@ -14,18 +13,18 @@
   --accent-soft: color-mix(in oklch, var(--accent) 8%, var(--bg));
   --bg: #ffffff;
   --bg-soft: oklch(0.976 0.0025 247);
-  --ink: oklch(0.25 0.006 260);
-  --ink-2: oklch(0.47 0.008 260);
+  --ink: oklch(0.21 0.006 260);
+  --ink-2: oklch(0.45 0.008 260);
   --ink-3: oklch(0.6 0.008 260);
-  --line: oklch(0.925 0.004 247);
+  --line: oklch(0.905 0.004 247);
   --card: #ffffff;
-  --term-bg: oklch(0.25 0.006 260);
-  --term-edge: oklch(0.35 0.008 260);
-  --radius: 24px;
-  --radius-sm: 12px;
-  --shadow-1: 0 1px 2px oklch(0.35 0.01 260 / 0.18), 0 1px 3px 1px oklch(0.35 0.01 260 / 0.08);
-  --shadow-2: 0 1px 3px oklch(0.35 0.01 260 / 0.15), 0 8px 24px -4px oklch(0.35 0.01 260 / 0.16);
-  --font-sans: "Outfit Variable", "Outfit", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --term-bg: oklch(0.21 0.006 260);
+  --term-edge: oklch(0.31 0.008 260);
+  --radius: 13px;
+  --radius-sm: 9px;
+  --shadow-1: 0 1px 2px oklch(0.35 0.01 260 / 0.08);
+  --shadow-2: 0 1px 2px oklch(0.35 0.01 260 / 0.06), 0 12px 32px -16px oklch(0.35 0.01 260 / 0.24);
+  --font-sans: "Inter Variable", "Inter", "Helvetica Neue", "PingFang SC", "Microsoft YaHei", sans-serif;
   --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "SF Mono", Menlo, monospace;
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -40,12 +39,12 @@
   --ink: oklch(0.93 0.004 260);
   --ink-2: oklch(0.78 0.008 260);
   --ink-3: oklch(0.63 0.008 260);
-  --line: oklch(0.33 0.008 260);
-  --card: oklch(0.255 0.009 260);
-  --term-bg: oklch(0.15 0.005 260);
-  --term-edge: oklch(0.29 0.008 260);
-  --shadow-1: 0 1px 2px oklch(0 0 0 / 0.42), 0 1px 3px 1px oklch(0 0 0 / 0.24);
-  --shadow-2: 0 1px 3px oklch(0 0 0 / 0.4), 0 8px 24px -4px oklch(0 0 0 / 0.5);
+  --line: oklch(0.31 0.008 260);
+  --card: oklch(0.222 0.008 260);
+  --term-bg: oklch(0.155 0.005 260);
+  --term-edge: oklch(0.28 0.008 260);
+  --shadow-1: 0 1px 2px oklch(0 0 0 / 0.3);
+  --shadow-2: 0 1px 2px oklch(0 0 0 / 0.28), 0 12px 32px -16px oklch(0 0 0 / 0.6);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -54,6 +53,8 @@ html { scroll-behavior: smooth; background: var(--bg); }
 
 body {
   font-family: var(--font-sans);
+  font-optical-sizing: auto;
+  font-feature-settings: "cv11", "ss01";
   background: var(--bg);
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
@@ -72,11 +73,14 @@ body[data-lang="zh"] h2,
 body[data-lang="zh"] h3 { letter-spacing: 0; }
 body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height: 1.22; }
 
-.lang-switch, .theme-switch { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-soft); border-radius: 999px; }
+.lang-switch, .theme-switch {
+  display: inline-flex; gap: 2px; padding: 3px;
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: 9px;
+}
 .lang-switch button, .theme-switch button {
   font-family: var(--font-sans); font-size: 12.5px; font-weight: 500;
   color: var(--ink-2); background: transparent; border: none; cursor: pointer;
-  padding: 6px 13px; border-radius: 999px;
+  padding: 6px 12px; border-radius: 6px;
   transition: background 0.2s, color 0.2s, box-shadow 0.2s;
 }
 .theme-switch button { display: inline-flex; align-items: center; justify-content: center; }
@@ -105,8 +109,8 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .nav-links { display: flex; min-width: 0; gap: 6px; margin-right: auto; margin-left: 18px; }
 .nav-links a {
   flex: none; white-space: nowrap;
-  color: var(--ink-2); text-decoration: none; font-size: 14.5px; font-weight: 500;
-  padding: 8px 14px; border-radius: 999px;
+  color: var(--ink-2); text-decoration: none; font-size: 14px; font-weight: 500;
+  padding: 8px 12px; border-radius: 7px;
   transition: color 0.2s, background 0.2s;
 }
 .nav-links a:hover { color: var(--ink); background: var(--bg-soft); }
@@ -114,7 +118,7 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .nav-github {
   display: inline-flex; flex: none; align-items: center; gap: 8px;
   color: var(--ink-2); text-decoration: none; font-size: 14px; font-weight: 500;
-  padding: 8px 10px; border-radius: 999px;
+  padding: 8px 10px; border-radius: 7px;
   transition: color 0.2s, background 0.2s;
 }
 .nav-github svg { width: 18px; height: 18px; display: block; }
@@ -123,14 +127,14 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 
 .btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 8px;
-  font-family: var(--font-sans); font-size: 15px; font-weight: 500;
-  padding: 12px 26px; border-radius: 999px; text-decoration: none; cursor: pointer;
+  font-family: var(--font-sans); font-size: 14.5px; font-weight: 550; letter-spacing: -0.005em;
+  padding: 11px 20px; border-radius: 9px; text-decoration: none; cursor: pointer;
   border: none; transition: background 0.2s, box-shadow 0.25s, color 0.2s, border-color 0.2s;
 }
 .btn-dark { background: var(--accent); color: #fff; }
-.btn-dark:hover { background: var(--accent-deep); box-shadow: var(--shadow-1); }
-.btn-ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); }
-.btn-ghost:hover { background: var(--accent-soft); border-color: transparent; }
+.btn-dark:hover { background: var(--accent-deep); }
+.btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+.btn-ghost:hover { border-color: color-mix(in oklch, var(--accent) 45%, var(--line)); color: var(--accent); }
 .nav .btn { padding: 9px 20px; font-size: 14px; }
 .nav .btn, .nav .lang-switch, .nav .theme-switch, .nav-acct { flex: none; }
 
@@ -155,24 +159,20 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .eyebrow .dot { width: 7px; height: 7px; border-radius: 50%; background: oklch(0.7 0.16 150); box-shadow: 0 0 0 3px oklch(0.7 0.16 150 / 0.18); }
 
 .hero h1 {
-  max-width: 14em; margin: 0 auto;
-  font-size: clamp(48px, 6.6vw, 92px);
-  line-height: 1.04; letter-spacing: -0.025em; font-weight: 600;
+  max-width: 13em; margin: 0 auto;
+  font-size: clamp(44px, 5.4vw, 76px);
+  line-height: 1.06; letter-spacing: -0.035em; font-weight: 600;
   text-wrap: balance;
 }
 .hero h1 .grad { color: var(--accent); }
 .hero h1 em { font-style: italic; color: var(--accent); }
-/* mono keyword styled like a warm cache block */
 .hero h1 .tt {
-  font-family: var(--font-mono); font-weight: 500; font-size: 0.8em;
-  letter-spacing: -0.01em; white-space: nowrap;
-  background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 26%, transparent);
-  border-radius: 0.16em; padding: 0.05em 0.24em;
+  color: var(--accent);
+  box-shadow: inset 0 -0.12em 0 color-mix(in oklch, var(--accent) 22%, transparent);
 }
 .hero .sub {
-  margin: 28px auto 0; max-width: 620px;
-  font-size: 19px; line-height: 1.6; color: var(--ink-2); font-weight: 400;
+  margin: 26px auto 0; max-width: 640px;
+  font-size: 17.5px; line-height: 1.62; color: var(--ink-2); font-weight: 400;
   text-wrap: pretty;
 }
 .hero .sub b { color: var(--ink); font-weight: 600; }
@@ -191,13 +191,13 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
   text-align: left;
 }
 .install-option--desktop {
-  background: linear-gradient(180deg, color-mix(in oklch, var(--accent) 11%, var(--bg)), var(--bg) 78%);
-  border-color: color-mix(in oklch, var(--accent) 22%, var(--line));
+  background: var(--accent-soft);
+  border-color: color-mix(in oklch, var(--accent) 30%, var(--line));
 }
 .install-kicker {
   display: inline-flex; align-items: center; gap: 7px;
   min-height: 16px; line-height: 16px;
-  font-size: 12px; font-weight: 700; letter-spacing: 0.06em;
+  font-family: var(--font-mono); font-size: 11.5px; font-weight: 500; letter-spacing: 0.04em;
   text-transform: uppercase; color: var(--accent);
 }
 .install-kicker::before {
@@ -219,29 +219,30 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 
 .install {
   display: inline-flex; align-items: center; gap: 14px; min-width: 0;
-  font-family: var(--font-mono); font-size: 14px; color: var(--ink);
-  background: var(--bg-soft); border-radius: 999px;
-  padding: 12px 10px 12px 22px;
+  font-family: var(--font-mono); font-size: 13.5px; color: var(--ink);
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 10px 8px 10px 16px;
   white-space: nowrap;
 }
 .install .ps1 { color: var(--accent); user-select: none; }
 .install button {
   flex: none;
-  font-family: var(--font-sans); font-size: 13px; font-weight: 600;
-  background: var(--card); color: var(--accent); border: none; cursor: pointer;
-  padding: 7px 16px; border-radius: 999px; box-shadow: var(--shadow-1);
-  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+  font-family: var(--font-sans); font-size: 12.5px; font-weight: 600;
+  background: var(--card); color: var(--ink-2); border: 1px solid var(--line); cursor: pointer;
+  padding: 6px 13px; border-radius: 6px;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
 }
-.install button:hover { box-shadow: var(--shadow-2); }
+.install button:hover { color: var(--accent); border-color: color-mix(in oklch, var(--accent) 45%, var(--line)); }
 .hero-install .install {
   height: var(--hero-action-height);
-  padding: 0 0 0 22px;
+  padding: 0 6px 0 16px;
 }
 .hero-install .install button {
-  background: var(--accent); color: #fff; box-shadow: none;
+  width: auto; min-width: 92px; height: 34px;
+  background: var(--accent); color: #fff; border-color: transparent;
 }
 .hero-install .install button:hover {
-  background: var(--accent-deep); box-shadow: var(--shadow-1);
+  background: var(--accent-deep); color: #fff; border-color: transparent;
 }
 .install button.copied { background: oklch(0.55 0.14 155); color: #fff; }
 
@@ -273,17 +274,17 @@ body[data-lang="zh"] .hero h1 { font-size: clamp(42px, 5.6vw, 72px); line-height
 .cold-blocks i.new { background: var(--accent); box-shadow: none; }
 
 /* terminal */
-.term-stage { position: relative; margin: 64px auto 0; max-width: 880px; perspective: 1200px; }
+.term-stage { position: relative; margin: 58px auto 0; max-width: 880px; }
 .fig {
   font-family: var(--font-mono); font-size: 12px; color: var(--ink-3);
-  margin-bottom: 14px; text-align: left;
+  margin-bottom: 12px; text-align: left;
 }
 .term {
   position: relative; text-align: left;
   background: var(--term-bg);
+  border: 1px solid var(--term-edge);
   border-radius: var(--radius); overflow: hidden;
   box-shadow: var(--shadow-2);
-  will-change: transform;
 }
 .term-bar {
   display: flex; align-items: center; gap: 8px;
@@ -362,25 +363,25 @@ section { padding: 150px 0 0; }
 }
 .feat-viz i.n { background: var(--accent); box-shadow: none; }
 .feat-chip {
-  display: inline-block; margin-top: 30px;
-  font-family: var(--font-mono); font-size: 12.5px;
-  background: var(--card); border-radius: 999px; box-shadow: inset 0 0 0 1px var(--line);
-  padding: 9px 16px; color: var(--ink-2);
+  display: inline-block; margin-top: 26px;
+  font-family: var(--font-mono); font-size: 12px;
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: 7px;
+  padding: 8px 12px; color: var(--ink-2);
 }
 .feat {
   position: relative; overflow: hidden;
-  background: var(--bg-soft); border-radius: var(--radius);
-  padding: 38px 38px 40px;
-  transition: box-shadow 0.3s, transform 0.3s var(--ease);
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 30px 30px 32px;
+  transition: border-color 0.25s;
 }
-.feat:hover { box-shadow: var(--shadow-2); transform: translateY(-3px); }
+.feat:hover { border-color: color-mix(in oklch, var(--accent) 38%, var(--line)); }
 .feat .tag {
   font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3);
-  letter-spacing: 0.05em; display: block; margin-bottom: 20px; text-transform: uppercase;
+  letter-spacing: 0.04em; display: block; margin-bottom: 18px;
 }
 .feat:hover .tag { color: var(--accent); }
-.feat h3 { font-size: 22px; letter-spacing: -0.01em; font-weight: 600; margin-bottom: 12px; }
-.feat p { font-size: 15.5px; line-height: 1.68; color: var(--ink-2); text-wrap: pretty; }
+.feat h3 { font-size: 20px; letter-spacing: -0.018em; font-weight: 600; margin-bottom: 10px; }
+.feat p { font-size: 15px; line-height: 1.65; color: var(--ink-2); text-wrap: pretty; }
 .feat code { font-family: var(--font-mono); font-size: 12.5px; color: var(--ink); }
 
 /* surfaces */
@@ -443,8 +444,8 @@ section { padding: 150px 0 0; }
 
 /* cache diagram */
 .cache-panel {
-  background: var(--bg-soft); border-radius: var(--radius);
-  padding: 56px 60px 50px; overflow: hidden;
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 48px 52px 44px; overflow: hidden;
 }
 .cache-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 14px; }
 .cache-row .lbl {
@@ -454,7 +455,7 @@ section { padding: 150px 0 0; }
 }
 .cache-row.row-on .lbl { color: var(--ink); }
 .blk {
-  width: 34px; height: 34px; border-radius: 9px; flex: none;
+  width: 32px; height: 32px; border-radius: 6px; flex: none;
   background: var(--card); box-shadow: inset 0 0 0 1px var(--line);
   opacity: 0; transform: scale(0.7);
   transition: opacity 0.45s var(--ease), transform 0.45s var(--ease);
@@ -480,7 +481,7 @@ section { padding: 150px 0 0; }
   transition: background 0.3s, color 0.3s, box-shadow 0.3s;
 }
 .cap .n { font-family: var(--font-mono); font-size: 12px; margin-right: 12px; color: var(--ink-3); }
-.cap.on { background: var(--card); color: var(--ink); box-shadow: var(--shadow-1); }
+.cap.on { background: var(--card); color: var(--ink); box-shadow: inset 0 0 0 1px var(--line); }
 .cap.on .n { color: var(--accent); }
 
 .how-track { height: 280vh; }
@@ -496,17 +497,17 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .step + .step { padding-left: 40px; border-left: 1px solid var(--line); }
 .step .num {
   display: inline-flex; align-items: center; justify-content: center;
-  width: 38px; height: 38px; border-radius: 50%;
+  width: 30px; height: 30px; border-radius: 7px;
   background: var(--accent-soft);
-  font-size: 14px; font-weight: 600; color: var(--accent);
-  margin-bottom: 20px;
+  font-family: var(--font-mono); font-size: 12.5px; font-weight: 500; color: var(--accent);
+  margin-bottom: 18px;
 }
-.step h3 { font-size: 19px; font-weight: 600; letter-spacing: -0.01em; margin-bottom: 10px; }
-.step p { font-size: 15px; line-height: 1.62; color: var(--ink-2); }
+.step h3 { font-size: 18px; font-weight: 600; letter-spacing: -0.018em; margin-bottom: 10px; }
+.step p { font-size: 14.5px; line-height: 1.62; color: var(--ink-2); }
 .step code {
-  display: inline-block; margin-top: 18px; font-family: var(--font-mono); font-size: 13px;
-  background: var(--bg-soft); border-radius: 999px;
-  padding: 9px 16px; color: var(--ink);
+  display: inline-block; margin-top: 16px; font-family: var(--font-mono); font-size: 12.5px;
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: 7px;
+  padding: 7px 12px; color: var(--ink);
 }
 
 /* contributors marquee */
@@ -560,8 +561,8 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 /* reveal on scroll */
 @media (prefers-reduced-motion: no-preference) {
   body[data-motion="rich"] .reveal {
-    opacity: 0; transform: translateY(26px);
-    transition: opacity 0.8s var(--ease), transform 0.8s var(--ease);
+    opacity: 0; transform: translateY(10px);
+    transition: opacity 0.45s var(--ease), transform 0.45s var(--ease);
     transition-delay: var(--d, 0s);
   }
   body[data-motion="rich"] .reveal.in { opacity: 1; transform: none; }
@@ -580,22 +581,15 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 }
 .os-card:hover::after, .doc-card:hover::after { opacity: 1; }
 
-/* dividers — section break as a row of cache blocks: solid center, fading edges */
-.divider { position: relative; height: 80px; margin-top: 110px; pointer-events: none; }
+/* dividers */
+.divider { position: relative; height: 40px; margin-top: 110px; pointer-events: none; }
 .divider + section { padding-top: 70px; }
 .divider .line {
   position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
-  width: min(1100px, calc(100% - 80px)); height: 12px;
-  background: repeating-linear-gradient(90deg,
-    color-mix(in oklch, var(--accent) 20%, transparent) 0 12px,
-    transparent 12px 26px);
-  -webkit-mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent);
-  mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent);
-}
-.divider .line::before {
-  content: ""; position: absolute; left: 50%; top: 0; transform: translateX(-50%);
-  width: 102px; height: 12px;
-  background: repeating-linear-gradient(90deg, var(--accent) 0 12px, transparent 12px 26px);
+  width: min(1100px, calc(100% - 80px)); height: 1px;
+  background: var(--line);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 22%, #000 78%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 22%, #000 78%, transparent);
 }
 
 /* CTA band */
@@ -615,13 +609,13 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 /* download tabs */
 .dl { margin-top: 44px; }
 .dl-tabs {
-  display: inline-flex; gap: 2px; padding: 4px;
-  background: color-mix(in oklch, var(--ink) 5%, var(--bg)); border-radius: 999px;
+  display: inline-flex; gap: 2px; padding: 3px;
+  background: var(--bg-soft); border: 1px solid var(--line); border-radius: 9px;
 }
 .dl-tab {
-  font-family: var(--font-sans); font-size: 14px; font-weight: 500;
+  font-family: var(--font-sans); font-size: 13.5px; font-weight: 500;
   color: var(--ink-2); background: transparent; border: none; cursor: pointer;
-  padding: 9px 22px; border-radius: 999px;
+  padding: 8px 18px; border-radius: 6px;
   transition: background 0.25s, color 0.25s, box-shadow 0.25s;
 }
 .dl-tab:hover { color: var(--ink); }
@@ -669,7 +663,7 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 /* npm release channels */
 .chan {
   max-width: 660px; margin: 26px auto 0; text-align: left;
-  background: var(--card); border-radius: var(--radius-sm); box-shadow: var(--shadow-1); overflow: hidden;
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); overflow: hidden;
 }
 .chan-row {
   display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
@@ -684,9 +678,9 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .chan-row.rec code { color: var(--accent); font-weight: 500; }
 .chan-row.rec .s { color: var(--ink-2); }
 .chan-badge {
-  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+  font-size: 11px; font-weight: 600; letter-spacing: 0.02em;
   color: #fff; background: var(--accent);
-  padding: 4px 11px; border-radius: 999px; flex: none;
+  padding: 4px 9px; border-radius: 5px; flex: none;
 }
 .chan-badge.pre { color: var(--ink-3); background: var(--bg-soft); box-shadow: inset 0 0 0 1px var(--line); }
 .chan-row:not(.rec) code, .chan-row:not(.rec) .v { text-decoration: line-through; text-decoration-color: var(--ink-3); }
@@ -697,12 +691,12 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 }
 .os-card {
   position: relative; display: flex; flex-direction: column; gap: 10px;
-  background: var(--card); border-radius: var(--radius);
-  padding: 30px 28px 28px; box-shadow: var(--shadow-1);
-  transition: box-shadow 0.3s, transform 0.3s var(--ease);
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 26px 24px 24px;
+  transition: border-color 0.25s;
 }
-.os-card:hover { box-shadow: var(--shadow-2); transform: translateY(-3px); }
-.os-card h4 { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); }
+.os-card:hover { border-color: color-mix(in oklch, var(--accent) 38%, var(--line)); }
+.os-card h4 { font-size: 19px; font-weight: 600; letter-spacing: -0.018em; color: var(--ink); }
 .os-card .meta { font-family: var(--font-mono); font-size: 11.5px; line-height: 1.7; color: var(--ink-3); }
 .os-card .btn { margin-top: 16px; }
 .os-options {
@@ -754,7 +748,7 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .dl-help button {
   font-family: var(--font-sans); font-size: 12.5px; font-weight: 600;
   color: var(--accent); background: var(--accent-soft);
-  border: none; border-radius: 999px; padding: 7px 13px; cursor: pointer;
+  border: none; border-radius: 7px; padding: 7px 13px; cursor: pointer;
 }
 .dl-help button.copied { background: oklch(0.55 0.14 155); color: #fff; }
 .dl-help a { color: var(--accent); text-decoration: none; font-weight: 600; }
@@ -766,10 +760,10 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 }
 .os-card.flash { animation: cardFlash 2s var(--ease); }
 .os-chip {
-  position: absolute; top: -12px; right: 18px;
+  position: absolute; top: -11px; right: 16px;
   font-size: 11.5px; font-weight: 600; letter-spacing: 0.02em;
   color: #fff; background: var(--accent);
-  padding: 4px 13px; border-radius: 999px;
+  padding: 4px 10px; border-radius: 5px;
 }
 
 /* docs page */
@@ -892,7 +886,7 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
   position: absolute; top: 12px; right: 12px;
   font-family: var(--font-sans); font-size: 12.5px; font-weight: 600;
   background: oklch(0.34 0.008 260); color: oklch(0.85 0.005 260);
-  border: none; border-radius: 999px; padding: 6px 14px; cursor: pointer;
+  border: none; border-radius: 7px; padding: 6px 12px; cursor: pointer;
   transition: background 0.2s, color 0.2s;
 }
 .codeblock button:hover { background: oklch(0.4 0.01 260); color: #fff; }
@@ -997,10 +991,10 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .doc-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 22px; }
 .doc-card {
   position: relative; display: block; text-decoration: none;
-  background: var(--bg-soft); border-radius: var(--radius-sm);
-  padding: 24px 26px; transition: box-shadow 0.3s, transform 0.3s var(--ease);
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm);
+  padding: 22px 24px; transition: border-color 0.25s;
 }
-.doc-card:hover { box-shadow: var(--shadow-2); transform: translateY(-2px); text-decoration: none; }
+.doc-card:hover { border-color: color-mix(in oklch, var(--accent) 38%, var(--line)); text-decoration: none; }
 .doc-card h3 { font-size: 17px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); margin: 0 0 6px; }
 .doc-card p { font-size: 13.5px; line-height: 1.6; color: var(--ink-2); margin: 0; }
 
@@ -1023,7 +1017,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
 .foot-links { display: flex; gap: 8px; margin-left: auto; flex-wrap: wrap; }
 .foot-links a {
   color: var(--ink-2); text-decoration: none; font-weight: 500;
-  padding: 7px 13px; border-radius: 999px;
+  padding: 7px 11px; border-radius: 7px;
   transition: color 0.2s, background 0.2s;
 }
 .foot-links a:hover { color: var(--ink); background: var(--bg-soft); }
@@ -1155,7 +1149,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
 .acct-email { margin-top: 3px; font-size: 13.5px; color: var(--ink-3); }
 .acct-role {
   font-family: var(--font-mono); font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.04em;
-  color: var(--accent); background: var(--accent-soft); padding: 5px 12px; border-radius: 999px;
+  color: var(--accent); background: var(--accent-soft); padding: 5px 10px; border-radius: 6px;
 }
 .acct-h2 {
   font-size: 15px; font-weight: 600; color: var(--ink);

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -442,55 +442,6 @@ section { padding: 118px 0 0; }
 .surf-win.cli .l { background: color-mix(in oklch, #fff 22%, transparent); }
 .surf-win.cli .l.ok { background: oklch(0.72 0.13 160); }
 
-/* cache diagram */
-.cache-panel {
-  background: var(--bg-soft); border: 1px solid var(--line); border-radius: var(--radius);
-  padding: 48px 52px 44px; overflow: hidden;
-}
-.cache-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-bottom: 14px; }
-.cache-row .lbl {
-  font-family: var(--font-mono); font-size: 12px; color: var(--ink-3);
-  width: 104px; flex: none;
-  transition: color 0.35s;
-}
-.cache-row.row-on .lbl { color: var(--ink); }
-.blk {
-  width: 32px; height: 32px; border-radius: 6px; flex: none;
-  background: var(--card); box-shadow: inset 0 0 0 1px var(--line);
-  opacity: 0; transform: scale(0.7);
-  transition: opacity 0.45s var(--ease), transform 0.45s var(--ease);
-  transition-delay: calc(var(--i, 0) * 55ms);
-}
-.cache-row.row-on .blk { opacity: 1; transform: none; }
-.blk.hit {
-  background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--accent) 30%, transparent);
-}
-.blk.new { background: var(--accent); box-shadow: none; }
-.cache-legend {
-  display: flex; gap: 28px; margin-top: 34px; padding-top: 26px; border-top: 1px solid var(--line);
-  font-size: 13.5px; color: var(--ink-2); flex-wrap: wrap;
-}
-.cache-legend i { width: 14px; height: 14px; border-radius: 4px; display: inline-block; vertical-align: -2px; margin-right: 9px; }
-
-.cache-grid { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 52px; align-items: center; }
-.cache-steps { display: flex; flex-direction: column; gap: 8px; }
-.cap {
-  text-align: left; font-size: 14.5px; font-weight: 500; color: var(--ink-3);
-  padding: 13px 18px; border-radius: var(--radius-sm);
-  transition: background 0.3s, color 0.3s, box-shadow 0.3s;
-}
-.cap .n { font-family: var(--font-mono); font-size: 12px; margin-right: 12px; color: var(--ink-3); }
-.cap.on { background: var(--card); color: var(--ink); box-shadow: inset 0 0 0 1px var(--line); }
-.cap.on .n { color: var(--accent); }
-
-.how-track { height: 280vh; }
-.how-stage { position: sticky; top: 0; min-height: 100vh; display: flex; align-items: center; width: 100%; }
-.how-stage > .wrap { width: 100%; }
-.how-stage .sec-head { margin-bottom: 44px; }
-body.how-flat .how-track { height: auto; }
-body.how-flat .how-stage { position: static; min-height: 0; display: block; }
-
 /* steps */
 .steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0; }
 .step { padding: 6px 40px 6px 0; }
@@ -1039,7 +990,6 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .feat, .feat:nth-child(1), .feat:nth-child(2), .feat:nth-child(3),
   .feat:nth-child(4), .feat:nth-child(5), .feat:nth-child(6) { grid-column: auto; }
   .sec-head.split { grid-template-columns: 1fr; align-items: start; }
-  .cache-grid { grid-template-columns: 1fr; gap: 32px; }
   .steps { gap: 28px; }
   .step { padding: 0; }
   .step + .step { padding-left: 0; border-left: none; border-top: 1px solid var(--line); padding-top: 28px; }
@@ -1047,7 +997,6 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .dl-help { grid-template-columns: 1fr; }
   .dl-help code { grid-column: auto; white-space: normal; overflow-wrap: anywhere; }
   .dl-help button { justify-self: start; }
-  .cache-panel { padding: 36px 24px; }
   .hero { padding-top: 130px; }
   .hero-install { grid-template-columns: 1fr; max-width: 560px; }
   .install-option { min-height: 0; }


### PR DESCRIPTION
The landing page had drifted into arguing a single point. The hero, one
feature card, an entire sticky screen and the footer tagline were all about
the prefix cache, and every number we quoted was a billing metric — 90%+ hit,
~1/5 cost, $0.043. Nothing on the page said what the agent can actually do.

That framing has stopped working. Competing agents hit comparable cache rates
now, so leading with it reads as a pitch rather than a differentiator, and a
page whose only quantified claims are about your bill reads as marketing
regardless of whether the numbers are true.

## What changed

**Narrative.** The headline is now "a coding agent you can leave running" —
the promise the CTA and footer were already making. The hero terminal replays
a real task instead of a cache counter: `plan` → permission prompt → two edits
→ `go test` → checkpoint. Its status bar reports surface / tools / session /
cost instead of a single hit-rate figure.

**Features.** All six cards rewritten around what is ours: gated tool calls,
per-turn checkpoints, plan mode, MCP + skills, single binary, local-first.

**New Surfaces section.** One engine behind four front ends — terminal,
desktop, browser, ACP editors — with CSS-drawn wireframes rather than
screenshots, so they cannot go stale. This is the differentiator that was
never on the page. Nav trades "How it works" for it.

**The cache explainer is gone.** It was first demoted to an Under-the-hood
section, but keeping a full 280vh sticky screen to argue for the mechanism is
itself defensive. The docs cover it under `#cache`, which is where a mechanism
belongs. The home page is ~2500px shorter and `fx.js` has no scroll handlers
or rAF loops left.

**Visual language.** Rounded display type, 24px radii, pill buttons, floating
shadow cards and a hero particle canvas are the grammar of a marketing page,
and that grammar undercut the copy. Inter replaces Outfit, radii drop to
13/9px, cards carry a hairline border, the cache-block divider becomes a plain
rule, reveal travel halves. The forum shipped its own copy of the tokens and
is synced in the last commit — before it, one domain served two typefaces.

## Notes

- Five commits, split so the visual pass can be reverted without losing the
  narrative rewrite.
- Two docs links pointed at the deleted `#how` anchor and are repointed.
- Site tests (52) and `astro build` pass; checked in the browser across
  EN/ZH × light/dark.
- No `/benchmarks` page yet. The 90%/1/5 figures still have no public
  methodology behind them, and I would rather leave them understated in the
  docs than build an evidence page on data we cannot reproduce.
