### PR TITLE
fix(provider): replay reasoning_content on thinking-enabled gateway tool calls

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -320,7 +320,22 @@ type client struct {
 func (c *client) Name() string { return c.name }
 
 func (c *client) RequiresToolCallReasoning() bool {
-	return c != nil && c.deepseek && c.thinkingType != "disabled"
+	if c == nil {
+		return false
+	}
+	if c.thinkingType == "disabled" {
+		return false
+	}
+	if c.deepseek {
+		return true
+	}
+	// A generic OpenAI-compatible gateway the user opted into DeepSeek-style
+	// thinking via the `thinking=enabled` escape hatch (e.g. opencode.ai zen
+	// serving DeepSeek models) inherits the DeepSeek replay contract: the
+	// upstream 400s an assistant tool_calls turn whose reasoning_content key
+	// is absent (#7748, #7520). GLM and Kimi K3 keep their own round-trip
+	// policy (RequiresReasoningRoundTrip) and stay out of DeepSeek recovery.
+	return !c.zhipu && !c.kimiK3 && c.thinkingType == "enabled"
 }
 
 func (c *client) RequiresReasoningRoundTrip() bool {
@@ -749,7 +764,11 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 				// Kimi K3 requires the complete assistant message on multi-turn
 				// and tool-call requests, including provider-issued reasoning.
 				cm.ReasoningContent = &m.ReasoningContent
-			case c.deepseek && len(m.ToolCalls) > 0:
+			case (c.deepseek || c.RequiresToolCallReasoning()) && len(m.ToolCalls) > 0:
+				// DeepSeek and thinking-enabled generic gateways require the
+				// reasoning_content key on assistant tool_calls turns (empty
+				// included — #7748); keep the empty-key emission even when
+				// thinking is off if a value was captured earlier.
 				if c.RequiresToolCallReasoning() || m.ReasoningContent != "" {
 					cm.ReasoningContent = &m.ReasoningContent
 				}

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -2353,3 +2353,51 @@ func TestNormaliseUsageAnthropicStyleFallback(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildRequestThinkingEnabledGatewayRoundTripsToolCallReasoning pins the
+// #7748/#7520 fix: `thinking=enabled` on a non-auto-detected OpenAI-compatible
+// gateway (opencode.ai zen serving DeepSeek models) must activate the DeepSeek
+// reasoning_content replay contract on assistant tool_calls turns, or the
+// upstream 400s ("The `reasoning_content` in the thinking mode must be passed
+// back to the API"). Plain assistant turns still omit the field.
+func TestBuildRequestThinkingEnabledGatewayRoundTripsToolCallReasoning(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "opencode-zen",
+		BaseURL: "https://opencode.ai/zen/v1",
+		Model:   "ds4-flash-free",
+		APIKey:  "k",
+		Extra:   map[string]any{"thinking": "enabled"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !provider.RequiresToolCallReasoning(p) {
+		t.Fatal("thinking-enabled gateway must replay reasoning on tool-call turns")
+	}
+	if !provider.WarnOnMissingToolCallReasoning(p) {
+		t.Fatal("thinking-enabled gateway must diagnose missing tool-call reasoning like DeepSeek")
+	}
+
+	req := p.(*client).buildRequest(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "inspect"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "read_file", Arguments: `{"path":"main.go"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+		{Role: provider.RoleAssistant, ReasoningContent: "read main.go first", ToolCalls: []provider.ToolCall{{ID: "call_2", Name: "read_file", Arguments: `{"path":"go.mod"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call_2", Name: "read_file", Content: "module demo"},
+		{Role: provider.RoleUser, Content: "continue"},
+		{Role: provider.RoleAssistant, Content: "done", ReasoningContent: "SECRET-CHAIN-OF-THOUGHT"},
+	}})
+	body, err := json.Marshal(req.Messages)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := req.Messages[1].ReasoningContent; got == nil || *got != "" {
+		t.Fatalf("tool_calls turn without captured reasoning must serialize the empty key, got %v", got)
+	}
+	if got := req.Messages[3].ReasoningContent; got == nil || *got != "read main.go first" {
+		t.Fatalf("tool_calls turn reasoning_content = %v, want provider-issued reasoning", got)
+	}
+	if strings.Contains(string(body), "SECRET-CHAIN-OF-THOUGHT") {
+		t.Fatalf("plain assistant turn must not replay reasoning: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Fix #7748 (and duplicates #7520/#7648/#7564/#7396): an OpenAI-compatible gateway opted into DeepSeek-style thinking via the `thinking=enabled` escape hatch (e.g. opencode.ai zen serving DeepSeek models) never replayed `reasoning_content` on assistant tool_calls turns, so the DeepSeek-flavored upstream 400'd every turn after the first tool call ("The `reasoning_content` in the thinking mode must be passed back to the API").

Changes in `internal/provider/openai/`:
- `RequiresToolCallReasoning()` now also returns true for generic gateways with `thinking=enabled` (GLM/Kimi K3 keep their own round-trip policy; `thinking=disabled` still opts out)
- `buildRequest` tool_calls-turn case widened from `c.deepseek` to `(c.deepseek || c.RequiresToolCallReasoning())` — always emits the `reasoning_content` key (empty included) on tool_calls turns; plain assistant turns still omit it
- Regression test pins the wire shape: empty-key emission, captured-reasoning replay, and no replay on plain assistant turns

Byte-identical for every existing path (DeepSeek official, thinking off, GLM, Kimi K3); the only new wire output is the generic-gateway + `thinking=enabled` case.

## Issues

Fixes #7748 (Refs #7520 #7648 #7564 #7396)

## Verification

- `go test ./internal/provider/...` — pass (4 packages)
- New test: `TestBuildRequestThinkingEnabledGatewayRoundTripsToolCallReasoning`
- `go vet` — clean

## Documentation impact

Documentation-impact: none - wire behavior for an opt-in escape hatch; no docs affected.

## Cache impact

Cache-impact: medium - `internal/provider/*` is a listed cache-sensitive path; the change alters request serialization for the `thinking=enabled`-on-generic-gateway configuration only (byte-identical for all existing configs), so prompt-cache prefixes are unchanged for existing setups.
Cache-guard: `go test ./internal/provider/openai/` full suite passes (incl. the existing reasoning-serialization pins); no cache-guard script change needed for an opt-in path.
System-prompt-review: N/A
