### PR TITLE
fix(site): exclude auth pages from sitemap and add noindex

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig({
   build: { assets: 'static' },
   integrations: [sitemap({
     filter: (page) => !/\/changelog\/(?:stable|preview)\/?$/.test(page) &&
-      !/\/changelog\/v\d+\.\d+\.\d+-/.test(page),
+      !/\/changelog\/v\d+\.\d+\.\d+-/.test(page) &&
+      !/\/(?:login|register|forgot|reset|account|device|u)\/?$/.test(page),
   })],
 });

--- a/site/src/layouts/Account.astro
+++ b/site/src/layouts/Account.astro
@@ -5,6 +5,7 @@ const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 const { title, description, titleEn, titleZh, wide } = Astro.props;
 ---
 <Base title={title} description={description} titleEn={titleEn} titleZh={titleZh}>
+  <Fragment slot="head"><meta name="robots" content="noindex" /></Fragment>
   <header class="nav auth-nav scrolled">
     <div class="nav-inner">
       <a class="brand" href={`${base}/`}><img src={`${base}/logo.svg`} alt="Reasonix logo" /><span>Reasonix</span></a>


### PR DESCRIPTION
## Summary

SEO fix for the site/ Astro app:

1. **Sitemap filter** (`site/astro.config.mjs`) — auth/account routes (`/login/`, `/register/`, `/forgot/`, `/reset/`, `/account/`, `/device/`, `/u/`) now excluded alongside the existing changelog exclusions. Verified against all 15 actual routes: public routes still included, all 7 auth routes excluded.
2. **noindex** (`site/src/layouts/Account.astro`) — audit found the 7 auth pages all render through the `Account` layout, which had no `head` slot; a per-page `<Fragment slot="head">` would be silently dropped (dead code). Added the byte-identical 404.astro pattern as a direct child of `<Base>` inside `Account.astro` — one line covers all 7 non-public routes, guaranteed to land in `<head>` (verified `Base.astro:38` `<slot name="head" />` inside `<head>`).

## Issues

None — audit finding, no issue report.

## Verification

- `node --check site/astro.config.mjs` — syntax OK
- Filter executed against all 15 routes — include/exclude matrix correct
- Line-exact review of the Fragment placement chain (Account.astro → Base.astro head slot)

## Documentation impact

Documentation-impact: none - SEO metadata and sitemap only.

## Cache impact

Cache-impact: none - static site only.
Cache-guard: N/A
System-prompt-review: N/A
