### PR TITLE
fix(cli): account for wrapped working line in composer cursor offset

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3287,7 +3287,10 @@ func (m chatTUI) View() tea.View {
 	// prevents stale cells.
 	if working != "" {
 		parts = append(parts, workingStyle.Width(boxW).MaxWidth(boxW).Render(wrapStatusLine(working, boxW)))
-		rowsAboveBox++
+		// The working line wraps to multiple terminal rows on narrow terminals;
+		// rowsAboveBox must count the wrapped rows or the composer cursor is
+		// placed above the input box (see #7537).
+		rowsAboveBox += workingLineRows(working, boxW)
 	}
 	if footer := m.renderMainManagerFooter(); footer != "" {
 		parts = append(parts, footer)
@@ -3747,6 +3750,17 @@ func wrapStatusLine(s string, width int) string {
 	return ansi.Hardwrap(s, width, true)
 }
 
+// workingLineRows returns the number of terminal rows the working (spinner)
+// line occupies after wrapping to `width` (0 when the line is hidden). It
+// mirrors the wrapped render in View() so rowsAboveBox (cursor placement) and
+// computeStatusLineCount (bottomRows height) reserve the same row count.
+func workingLineRows(working string, width int) int {
+	if working == "" || width <= 0 {
+		return 0
+	}
+	return strings.Count(wrapStatusLine(working, width), "\n") + 1
+}
+
 // computeStatusLineCount returns the number of terminal rows the status block
 // (working line + first status line + optional data band) will occupy after
 // wrapping to `width`. It mirrors the construction in View() so the reserved
@@ -3777,7 +3791,7 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	var lines int
 	if m.state == tuiRunning {
 		// working (spinner) line — wraps independently of the status block below.
-		lines += strings.Count(wrapStatusLine(working, width), "\n") + 1
+		lines += workingLineRows(working, width)
 	}
 	lines += strings.Count(statusBlock, "\n") + 1
 	return lines

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -618,6 +618,71 @@ func TestSoftWrappedInputGrowsComposerAndShrinksTranscript(t *testing.T) {
 	}
 }
 
+// TestWorkingLineRowsWrapAccounting pins the pure wrap-count helper shared by
+// the composer cursor offset (rowsAboveBox) and the bottomRows height budget:
+// the working (spinner) line above the input box occupies more than one
+// terminal row on narrow terminals, and the helper must report the wrapped
+// count, not 1.
+func TestWorkingLineRowsWrapAccounting(t *testing.T) {
+	cases := []struct {
+		name  string
+		text  string
+		width int
+		want  int
+	}{
+		{name: "hidden line", text: "", width: 30, want: 0},
+		{name: "no width", text: "Thinking…", width: 0, want: 0},
+		{name: "fits one row", text: "  Thinking… 5s", width: 30, want: 1},
+		{name: "exact fit stays one row", text: strings.Repeat("x", 30), width: 30, want: 1},
+		{name: "wraps to two rows", text: strings.Repeat("x", 60), width: 30, want: 2},
+		{name: "wraps to three rows", text: strings.Repeat("x", 61), width: 30, want: 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workingLineRows(tc.text, tc.width); got != tc.want {
+				t.Fatalf("workingLineRows(%q, %d) = %d, want %d", tc.text, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWorkingLineWrapKeepsComposerCursorInBox is the #7537 regression test: on
+// a narrow terminal the working (spinner) line above the composer wraps to
+// multiple terminal rows, and View() must still anchor the real terminal
+// cursor inside the composer box instead of drifting above it.
+func TestWorkingLineWrapKeepsComposerCursorInBox(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 24)
+
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 24, Height: 12})
+	m = m0.(chatTUI)
+	m.state = tuiRunning
+	m.elapsed = 1000000
+	m.turnTokens = 9999999
+
+	// Precondition: the working line really wraps at this width, otherwise this
+	// test would not exercise the bug.
+	working := m.runningWorkingLine(false, false)
+	wrappedRows := workingLineRows(working, m.width)
+	if wrappedRows <= 1 {
+		t.Fatalf("test setup: working line %q at width %d must wrap, got %d row(s)", working, m.width, wrappedRows)
+	}
+
+	v := m.View()
+	if v.Cursor == nil {
+		t.Fatal("composer cursor should be set while the composer is visible")
+	}
+	// The composer box starts below the viewport and the wrapped working line;
+	// its top border sits one row above the textarea rows and the bottom border
+	// one row below them.
+	boxTop := m.viewport.Height() + wrappedRows
+	boxBottom := boxTop + m.input.Height() + 2
+	if v.Cursor.Y < boxTop+1 || v.Cursor.Y >= boxBottom {
+		t.Fatalf("composer cursor Y=%d outside composer box rows [%d,%d): viewport=%d wrappedWorkingRows=%d inputHeight=%d",
+			v.Cursor.Y, boxTop+1, boxBottom, m.viewport.Height(), wrappedRows, m.input.Height())
+	}
+}
+
 func TestComposerPromptReservesWidthAndOffsetsCJKCursor(t *testing.T) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 40)


### PR DESCRIPTION
## Summary

Fix #7537 (TUI composer cursor drifts outside the input box on narrow terminals while a turn is running):

**Root cause**: `View()` counted the working (spinner) line as exactly 1 row (`rowsAboveBox++`), but renders it with `wrapStatusLine(working, boxW)` — which wraps to 2+ rows on narrow terminals. The composer cursor math (`cur.Y += viewport.Height() + rowsAboveBox + 1`) then placed the cursor N−1 rows above the actual input box. The height budget (`bottomRows`/`computeStatusLineCount`) already counted wrapped rows — only `rowsAboveBox` was wrong.

**Fix** (3 hunks, no rendering change):
- New helper `workingLineRows(working, width)` — wrapped-row count via the same `wrapStatusLine`/width the bottomRows path uses
- `View()` uses it instead of the hardcoded 1; `computeStatusLineCount` now shares the helper (behavior identical)
- `composer_selection.go` verified clean (textarea-internal viewport only)

**Tests** (headless, narrow-terminal): `TestWorkingLineRowsWrapAccounting` (pure-helper table) + `TestWorkingLineWrapKeepsComposerCursorInBox` — asserts cursor Y lands inside the composer box with a 2+ row wrapped working line; fails pre-fix, passes post-fix.

## Issues

Fixes #7537

## Verification

- `go test ./internal/cli/` — full suite pass
- `go vet` / `gofmt -l` / `go build ./cmd/reasonix` — clean

## Documentation impact

Documentation-impact: none - cursor positioning; no docs affected.

## Cache impact

Cache-impact: none - TUI rendering only; no prompt/tool surface touched.
Cache-guard: N/A
System-prompt-review: N/A
