### PR TITLE
feat(desktop): add a clickable session timeline above the transcript

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessio
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
 import { NoticeCard, Transcript } from "./components/Transcript";
+import { SessionTimeline } from "./components/SessionTimeline";
 import { Composer } from "./components/Composer";
 import { TranscriptSelectionMenu } from "./components/TranscriptSelectionMenu";
 import { TodoPanel } from "./components/TodoPanel";
@@ -4950,6 +4951,8 @@ export default function App() {
             ) : noticePreviewMockEnabled() ? (
               <NoticePreviewPanel />
             ) : (
+              <>
+              <SessionTimeline items={state.items} />
               <Transcript
                 items={displayItems}
                 live={state.live}
@@ -4977,6 +4980,7 @@ export default function App() {
                 onLoadOlderHistory={() => activeTabId && loadOlderHistory(activeTabId)}
                 invocationMetadata={activeTabId ? invocationMetadataByTab[activeTabId] : undefined}
               />
+              </>
             )}
           </main>
 

--- a/desktop/frontend/src/components/SessionTimeline.tsx
+++ b/desktop/frontend/src/components/SessionTimeline.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { GitBranch } from "lucide-react";
+import { compactQuestionText, questionAnchorId } from "../lib/transcriptGrouping";
+import type { Item } from "../lib/useController";
+
+type TimelineEntry =
+  | { kind: "turn"; key: string; turn: number; checkpoint: boolean; text: string }
+  | { kind: "compact"; key: string; trigger: string; messages: number };
+
+export function SessionTimeline({ items }: { items: Item[] }) {
+  const { entries, turnCount } = useMemo(() => {
+    const entries: TimelineEntry[] = [];
+    let turn = 0;
+    for (const item of items) {
+      if (item.kind === "user") {
+        turn++;
+        entries.push({ kind: "turn", key: item.id, turn, checkpoint: Boolean(item.checkpointTurn), text: item.text });
+      } else if (item.kind === "compaction" && !item.pending) {
+        entries.push({ kind: "compact", key: item.id, trigger: item.trigger, messages: item.messages });
+      }
+    }
+    return { entries, turnCount: turn };
+  }, [items]);
+
+  if (turnCount < 2) return null;
+
+  const scrollToTurn = (key: string) => {
+    document.getElementById(questionAnchorId(key))?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  return (
+    <div className="session-timeline" role="navigation" aria-label="Session timeline">
+      <div className="session-timeline__label">
+        <GitBranch size={12} />
+        <span>Map</span>
+      </div>
+      <div className="session-timeline__rail">
+        {entries.map((entry) =>
+          entry.kind === "turn" ? (
+            <button
+              key={entry.key}
+              type="button"
+              className={`session-timeline__node${entry.turn === turnCount ? " session-timeline__node--current" : ""}${entry.checkpoint ? " session-timeline__node--checkpoint" : ""}`}
+              title={compactQuestionText(entry.text)}
+              aria-label={`Turn ${entry.turn}`}
+              onClick={() => scrollToTurn(entry.key)}
+            >
+              {entry.turn}
+            </button>
+          ) : (
+            <div
+              key={entry.key}
+              className="session-timeline__compact"
+              title={`${entry.trigger} · ${entry.messages} messages compacted`}
+            />
+          ),
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3005,6 +3005,90 @@ a[href] {
   flex-direction: column;
 }
 
+.session-timeline {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.session-timeline__label {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--fg-faint);
+  font-size: 11px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.session-timeline__rail {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 4px 6px;
+}
+.session-timeline__rail::before {
+  content: "";
+  position: absolute;
+  left: 18px;
+  right: 18px;
+  top: 50%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--border);
+  transform: translateY(-50%);
+}
+.session-timeline__node {
+  --wails-draggable: no-drag;
+  position: relative;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 650;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: var(--z-app-content);
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.session-timeline__node:hover {
+  color: var(--fg);
+  border-color: var(--fg-faint);
+}
+.session-timeline__node--current {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+}
+.session-timeline__node--checkpoint {
+  box-shadow: 0 0 0 2px var(--bg-soft), 0 0 0 3.5px var(--accent-soft);
+}
+.session-timeline__compact {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  transform: rotate(45deg);
+  border-radius: 2px;
+  background: var(--fg-faint);
+  z-index: var(--z-app-content);
+  cursor: default;
+}
+
 /* loading screen shown while boot.Build runs in the background */
 .loading-screen {
   flex: 1;


### PR DESCRIPTION
## Background

Long conversations lose their shape. Once a session spans many turns and several compactions, there is no way to see *where you are in the conversation* — how many exchanges happened, where the context got compressed, or which turns are rewind checkpoints. You scroll, and scroll. The transcript already carries all of this structure (user turns, `compaction` items, rewind `checkpointTurn` markers), but nothing surfaces it.

## What this PR does

Adds a compact, clickable **session timeline** rail above the transcript:

- Each **user turn** is a numbered node. The current (latest) turn is filled with the accent color; turns that are **rewind checkpoints** get a ring.
- Each **compaction** is a diamond marker sitting on the connecting line, with a tooltip naming the trigger and how many messages were folded.
- Clicking a turn node smooth-scrolls the transcript to that exchange — long sessions become navigable instead of scrollable.
- Hovering a node shows the turn's prompt preview.
- The rail only appears once a session has two or more turns, so short sessions are unaffected.

It is derived entirely from the existing `items` array (user items + `compaction` items) and reuses the transcript's own `questionAnchorId` anchors, so nothing about the transcript or controller changes.

## Files changed

- `desktop/frontend/src/components/SessionTimeline.tsx` — new component
- `desktop/frontend/src/App.tsx` — render above the transcript
- `desktop/frontend/src/styles.css` — rail, node, and compaction-marker styles

## Verification

- `pnpm typecheck` — no new errors
- `pnpm lint:hooks` — clean
- `node scripts/check-css-syntax.mjs` / `check-z-index-tokens.mjs` — pass

Documentation-impact: none - a UI navigation aid derived from existing transcript data; no documented behavior changes.
