### PR TITLE
PR: feat(config): per-model extra_body and thinking overrides

### DIFF
--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -146,6 +146,43 @@ If a gateway requires vendor-specific top-level request body fields, set
 are merged into the OpenAI-compatible chat JSON request body without allowing
 core fields such as `model`, `messages`, `tools`, or `stream` to be overridden.
 
+### Per-model overrides
+
+Multi-model providers may need different request body fields or thinking
+configuration per model. Use `model_overrides` to set per-model `context_window`,
+`max_output_tokens`, `reasoning_protocol`, `vision`, `extra_body`, and `thinking`.
+Model-level values override or merge with the provider-level values for that
+model only.
+
+```toml
+[[providers]]
+name     = "nvidia"
+kind     = "openai"
+base_url = "https://integrate.api.nvidia.com/v1"
+models   = ["minimaxai/minimax-m3", "z-ai/glm-5.2"]
+# No provider-level extra_body — each model opts in.
+
+[providers.model_overrides]
+"minimaxai/minimax-m3" = {
+  context_window   = 262000,
+  max_output_tokens = 16384,
+  extra_body       = { chat_template_kwargs = { thinking_mode = "enabled" } },
+}
+"z-ai/glm-5.2" = {
+  context_window   = 1000000,
+  max_output_tokens = 16384,
+  extra_body       = { chat_template_kwargs = { enable_thinking = true, clear_thinking = false } },
+}
+```
+
+**Merge rules for `extra_body`**: model-level keys are shallow-merged into
+provider-level keys. Model keys win on conflict; omitted keys inherit the
+provider value. Setting `extra_body = {}` on a model clears all provider-level
+keys for that model.
+
+**Merge rules for `thinking`**: a non-empty model-level value replaces the
+provider-level value; empty or omitted inherits the provider value.
+
 ## Global `.env`
 
 `<Reasonix home>/.env` is the single runtime source for provider API keys saved

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -476,6 +476,53 @@ extra_body  = { enable_thinking = true }
 fields such as `model`, `messages`, `tools`, `stream`, and `thinking` under its
 own control.
 
+### Per-model overrides
+
+Multi-model providers may host models with incompatible reasoning wires under
+a single base URL. For example, on NVIDIA NIM one model may need
+`chat_template_kwargs.thinking_mode` while another needs
+`chat_template_kwargs.enable_thinking`, and a third needs neither.
+
+Use `model_overrides` to set per-model values for `context_window`,
+`max_output_tokens`, `reasoning_protocol`, `supported_efforts`, `default_effort`,
+`vision`, `extra_body`, and `thinking`. Model-level values override or merge with
+the provider-level values for that model only.
+
+```toml
+[[providers]]
+name        = "nvidia"
+kind        = "openai"
+base_url    = "https://integrate.api.nvidia.com/v1"
+models      = ["minimaxai/minimax-m3", "z-ai/glm-5.2", "deepseek-ai/deepseek-v4-flash"]
+api_key_env = "NVIDIA_API_KEY"
+# No provider-level extra_body or thinking — each model opts in.
+
+[providers.model_overrides]
+"minimaxai/minimax-m3" = {
+  context_window   = 262000,
+  max_output_tokens = 16384,
+  extra_body       = { chat_template_kwargs = { thinking_mode = "enabled" } },
+}
+"z-ai/glm-5.2" = {
+  context_window   = 1000000,
+  max_output_tokens = 16384,
+  extra_body       = { chat_template_kwargs = { enable_thinking = true, clear_thinking = false } },
+}
+"deepseek-ai/deepseek-v4-flash" = {
+  context_window   = 1000000,
+  max_output_tokens = 128000,
+  extra_body       = { chat_template_kwargs = { thinking = true, reasoning_effort = "max" } },
+}
+```
+
+**Merge rules for `extra_body`**: model-level keys are shallow-merged into
+provider-level keys. Model keys win on conflict; omitted keys inherit the
+provider value. Setting `extra_body = {}` on a model clears all provider-level
+keys for that model.
+
+**Merge rules for `thinking`**: a non-empty model-level value replaces the
+provider-level value; empty or omitted inherits the provider value.
+
 ## Desktop hooks
 
 Desktop hooks run local commands at lifecycle events such as `SessionStart`,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1396,6 +1396,13 @@ type ProviderModelOverride struct {
 	// MaxOutputTokens overrides the provider-wide output budget. Zero inherits;
 	// positive values set a cap and negative values omit optional wire limits.
 	MaxOutputTokens int `toml:"max_output_tokens"`
+	// ExtraBody merges per-model extra top-level JSON request body fields into
+	// the provider-level extra_body for this model. Model-level keys win over
+	// provider-level keys; omitted keys inherit the provider value.
+	ExtraBody map[string]any `toml:"extra_body"`
+	// Thinking overrides the provider-level thinking toggle for this model
+	// ("enabled" / "disabled"). Empty inherits the provider value.
+	Thinking string `toml:"thinking"`
 }
 
 // ModelList returns the models this provider exposes: the explicit `models` list,
@@ -1546,6 +1553,19 @@ func (e *ProviderEntry) applyModelOverride() {
 	}
 	if ov.MaxOutputTokens != 0 {
 		e.MaxOutputTokens = ov.MaxOutputTokens
+	}
+	if ov.Thinking != "" {
+		e.Thinking = ov.Thinking
+	}
+	if len(ov.ExtraBody) > 0 {
+		merged := make(map[string]any, len(e.ExtraBody)+len(ov.ExtraBody))
+		for k, v := range e.ExtraBody {
+			merged[k] = v
+		}
+		for k, v := range ov.ExtraBody {
+			merged[k] = v
+		}
+		e.ExtraBody = merged
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -1598,11 +1598,17 @@ func renderModelOverride(ov ProviderModelOverride) string {
 	if ov.MaxOutputTokens != 0 {
 		parts = append(parts, fmt.Sprintf("max_output_tokens = %d", ov.MaxOutputTokens))
 	}
+	if ov.Thinking != "" {
+		parts = append(parts, fmt.Sprintf("thinking = %q", ov.Thinking))
+	}
+	if len(ov.ExtraBody) > 0 {
+		parts = append(parts, "extra_body = "+renderAnyMap(ov.ExtraBody))
+	}
 	return "{ " + strings.Join(parts, ", ") + " }"
 }
 
 func modelOverrideEmpty(ov ProviderModelOverride) bool {
-	return ov.ReasoningProtocol == "" && len(ov.SupportedEfforts) == 0 && ov.DefaultEffort == "" && ov.Vision == nil && ov.ContextWindow <= 0 && ov.MaxOutputTokens == 0
+	return ov.ReasoningProtocol == "" && len(ov.SupportedEfforts) == 0 && ov.DefaultEffort == "" && ov.Vision == nil && ov.ContextWindow <= 0 && ov.MaxOutputTokens == 0 && ov.Thinking == "" && len(ov.ExtraBody) == 0
 }
 
 func hasPositiveIntMap(m map[string]int) bool {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1169,6 +1169,145 @@ func TestRenderTOMLRoundTripsProviderHeadersAndModelOverrides(t *testing.T) {
 	}
 }
 
+func TestRenderModelOverrideExtraBodyAndThinking(t *testing.T) {
+	cfg := &Config{
+		Providers: []ProviderEntry{{
+			Name:      "nvidia",
+			Kind:      "openai",
+			BaseURL:   "https://integrate.api.nvidia.com/v1",
+			Models:    []string{"minimax-m3", "nemotron-super", "gemma4"},
+			APIKeyEnv: "NVIDIA_API_KEY",
+			Effort:    "high",
+			Vision:    true,
+			ModelOverrides: map[string]ProviderModelOverride{
+				"minimax-m3": {
+					ContextWindow:   262_000,
+					MaxOutputTokens: 16_384,
+					ExtraBody: map[string]any{
+						"chat_template_kwargs": map[string]any{"thinking_mode": "enabled"},
+					},
+				},
+				"nemotron-super": {
+					ContextWindow:   1_000_000,
+					MaxOutputTokens: 32_768,
+					ExtraBody: map[string]any{
+						"chat_template_kwargs": map[string]any{"enable_thinking": true},
+					},
+				},
+				"gemma4": {
+					ContextWindow:   256_000,
+					MaxOutputTokens: 32_768,
+					Thinking:        "enabled",
+					ExtraBody: map[string]any{
+						"chat_template_kwargs": map[string]any{"thinking": true},
+					},
+				},
+			},
+		}},
+	}
+
+	rendered := RenderTOML(cfg)
+	if !strings.Contains(rendered, `thinking = "enabled"`) {
+		t.Fatalf("rendered TOML missing thinking override:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `extra_body`) || !strings.Contains(rendered, `thinking_mode`) {
+		t.Fatalf("rendered TOML missing per-model extra_body:\n%s", rendered)
+	}
+
+	var got Config
+	if _, err := toml.Decode(rendered, &got); err != nil {
+		t.Fatalf("rendered TOML does not parse: %v\n%s", err, rendered)
+	}
+	p, ok := got.Provider("nvidia")
+	if !ok {
+		t.Fatal("nvidia provider missing after round trip")
+	}
+	gemma4 := p.ModelOverrides["gemma4"]
+	if gemma4.Thinking != "enabled" {
+		t.Fatalf("gemma4 thinking = %q, want %q", gemma4.Thinking, "enabled")
+	}
+	minimax := p.ModelOverrides["minimax-m3"]
+	kwargs, ok := minimax.ExtraBody["chat_template_kwargs"].(map[string]any)
+	if !ok || kwargs["thinking_mode"] != "enabled" {
+		t.Fatalf("minimax-m3 extra_body chat_template_kwargs = %v", minimax.ExtraBody)
+	}
+	nemotron := p.ModelOverrides["nemotron-super"]
+	nkwargs, ok := nemotron.ExtraBody["chat_template_kwargs"].(map[string]any)
+	if !ok || nkwargs["enable_thinking"] != true {
+		t.Fatalf("nemotron-super extra_body chat_template_kwargs = %v", nemotron.ExtraBody)
+	}
+
+	// Verify legacy struct (no extra_body/thinking) still reads without error.
+	type legacyModelOverride struct {
+		ReasoningProtocol string   `toml:"reasoning_protocol"`
+		SupportedEfforts  []string `toml:"supported_efforts"`
+		DefaultEffort     string   `toml:"default_effort"`
+		Vision            *bool    `toml:"vision"`
+		ContextWindow     int      `toml:"context_window"`
+		MaxOutputTokens   int      `toml:"max_output_tokens"`
+	}
+	type legacyProvider struct {
+		ModelOverrides map[string]legacyModelOverride `toml:"model_overrides"`
+	}
+	var legacy struct {
+		Providers []legacyProvider `toml:"providers"`
+	}
+	if _, err := toml.Decode(rendered, &legacy); err != nil {
+		t.Fatalf("legacy config shape cannot read per-model extra_body/thinking: %v", err)
+	}
+}
+
+func TestApplyModelOverrideMergesExtraBody(t *testing.T) {
+	e := &ProviderEntry{
+		Thinking: "enabled",
+		ExtraBody: map[string]any{
+			"min_p":          0.01,
+			"parallel_calls": true,
+		},
+		ModelOverrides: map[string]ProviderModelOverride{
+			"model-a": {
+				Thinking: "disabled",
+				ExtraBody: map[string]any{
+					"min_p":     0.05,
+					"custom_fn": "hello",
+				},
+			},
+			"model-b": {}, // no override — inherits provider
+		},
+	}
+
+	// model-a: thinking overridden, extra_body merged (model keys win)
+	e.Model = "model-a"
+	e.applyModelOverride()
+	if e.Thinking != "disabled" {
+		t.Fatalf("model-a thinking = %q, want %q", e.Thinking, "disabled")
+	}
+	if mp, ok := e.ExtraBody["min_p"]; !ok || mp != 0.05 {
+		t.Fatalf("model-a min_p = %v, want 0.05 (model wins)", mp)
+	}
+	if v, ok := e.ExtraBody["parallel_calls"]; !ok || v != true {
+		t.Fatalf("model-a parallel_calls = %v, want true (inherited from provider)", v)
+	}
+	if v, ok := e.ExtraBody["custom_fn"]; !ok || v != "hello" {
+		t.Fatalf("model-a custom_fn = %v, want hello (added by override)", v)
+	}
+
+	// model-b: no override — provider values intact
+	e.Model = "model-b"
+	e.Thinking = "enabled"
+	e.ExtraBody = map[string]any{
+		"min_p":          0.01,
+		"parallel_calls": true,
+	}
+	e.applyModelOverride()
+	if e.Thinking != "enabled" {
+		t.Fatalf("model-b thinking = %q, want %q (unchanged)", e.Thinking, "enabled")
+	}
+	if mp, ok := e.ExtraBody["min_p"]; !ok || mp != 0.01 {
+		t.Fatalf("model-b min_p = %v, want 0.01 (unchanged)", mp)
+	}
+}
+
 func TestRenderStringMapQuotesNonBareTOMLKeys(t *testing.T) {
 	rendered := renderStringMap(map[string]string{
 		"github:gh-fix-ci": "deepseek-pro",


### PR DESCRIPTION
Summary
Multi-model providers like NVIDIA NIM host models with incompatible reasoning wires under a single base URL. Today extra_body and thinking are provider-scoped: every model on the provider receives the same body parameters. This breaks providers where Model A needs chat_template_kwargs.thinking_mode while Model B needs chat_template_kwargs.enable_thinking and Model C needs neither.
Splitting a multi-model provider into N single-model entries works around the limitation but duplicates base URL, API key, and headers — configuration that is identical across models.
This adds two fields to ProviderModelOverride:
- ExtraBody map[string]any — per-model extra top-level JSON request body fields, merged into (and overriding) the provider-level extra_body for that model only.
- Thinking string — per-model thinking toggle ("enabled" / "disabled"), overriding the provider-level thinking field for that model only. The merge happens in applyModelOverride(), which already handles every other per-model override. Model-level keys win over provider-level keys; omitted keys inherit the provider value unchanged.
Files changed
File	Change
internal/config/config.go	Add ExtraBody and Thinking fields to ProviderModelOverride; extend applyModelOverride() with merge + override logic internal/config/render.go	Include new fields in renderModelOverride() and renderAnyMap() TOML output; update modelOverrideEmpty() internal/config/render_test.go	Round-trip test with nested maps; legacy struct compatibility test; merge semantics test Config example (NVIDIA NIM)
[[providers]]
name        = "nvidia"
kind        = "openai"
base_url    = "https://integrate.api.nvidia.com/v1"
models      = [
  "minimaxai/minimax-m3",
  "nvidia/nemotron-3-super-120b-a12b",
  "z-ai/glm-5.2",
  "google/gemma-4-31b-it",
  "deepseek-ai/deepseek-v4-flash",
]
api_key_env = "NVIDIA_API_KEY"

[providers.model_overrides]
"minimaxai/minimax-m3" = {
  context_window     = 262000,
  max_output_tokens  = 16384,
  extra_body         = { chat_template_kwargs = { thinking_mode = "enabled" } },
}
"nvidia/nemotron-3-super-120b-a12b" = {
  context_window     = 1000000,
  max_output_tokens  = 32768,
  extra_body         = { chat_template_kwargs = { enable_thinking = true } },
}
"z-ai/glm-5.2" = {
  context_window     = 1000000,
  max_output_tokens  = 16384,
  thinking           = "enabled",
  extra_body         = { chat_template_kwargs = { enable_thinking = true, clear_thinking = false } },
}
Merge semantics
Model overrides are applied after the provider entry is fully constructed.
For extra_body: the provider-level map is shallow-cloned, then model-level
keys are written on top. A model override with extra_body = {} clears all
provider-level keys for that model. A model without extra_body in its override
inherits the provider value unchanged.
For thinking: a non-empty string replaces the provider-level value. An empty
or omitted string inherits the provider value.
Provider:  thinking = "enabled",  extra_body = { min_p = 0.01, stream = true }
Override:  thinking = "disabled", extra_body = { chat_template_kwargs = { enable_thinking = true } }
Result:    thinking = "disabled", extra_body = { min_p = 0.01, stream = true, chat_template_kwargs = { enable_thinking = true } }
What this does NOT do
- No new provider kind or wire protocol.
- No new vendor detection heuristics.
- No changes to buildRequest() — the merged extra_body and resolved
thinking flow through the existing OpenAI-compatible request serialization.
- No impact on system prompt, tool schemas, or prefix construction.
Backward compatibility
BurntSushi/toml ignores unknown fields when decoding. Older Reasonix releases
reading a config with the new fields will silently skip them — no parse error.
The existing TestRenderTOMLModelOverrides legacy compatibility test
(render_test.go:1127) already validates this pattern for context_window /
max_output_tokens; the new fields follow the same convention.
Cache-impact: low
Only touches request body serialization for providers that use model overrides.
The prefix (system prompt + tools) is unaffected. Guard: verify that a
non-overridden model's marshalled request body is byte-identical before and
after the change.
Testing
1. go test ./internal/config/ -run TestRenderModelOverrideExtraBodyAndThinking —
round-trip TOML encode/decode with nested maps, plus legacy struct
compatibility
2. go test ./internal/config/ -run TestApplyModelOverrideMergesExtraBody —
merge semantics: model wins over provider for conflicting keys, provider
values inherit for missing keys, thinking override works
3. go test ./... — full suite regression

## Issues

<!--
If this resolves a report, put `Fixes #123` on its own line — GitHub only
auto-closes from a bare line, so `- Fixes #123` in a list does nothing and the
report stays open. If it only relates to one, use `Refs #123` instead: the
release workflow then asks that reporter to verify once the fix ships.
-->

## Verification

-

## Documentation impact

Documentation-impact: TODO

For changes to user-visible CLI, Desktop, configuration, provider, permission,
or tool behavior, use one of:

Documentation-impact: updated - added model_overrides section with per-model extra_body/thinking docs to CONFIG_PATHS.md and GUIDE.md
:
## Cache impact

Cache-impact: none — changes only apply when a specific model is selected via model_overrides; provider request serialization for non-overridden models is byte-identical before and after.
Cache-guard: existing TestRenderTOMLModelOverrides round-trip test + new TestRenderModelOverrideExtraBodyAndThinking cover the changed surface.
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
