### PR TITLE
feat(mcp): choose tool exposure automatically / 自动选择 MCP 工具暴露模式

### DIFF
--- a/docs/COLLABORATION_MODES.zh-CN.md
+++ b/docs/COLLABORATION_MODES.zh-CN.md
@@ -107,7 +107,7 @@ Delivery 使用与 Balanced 相同的完整工具面，额外增加稳定的能�
 - 对明确要求实现、修复或修改的任务，如果没有观察到真实变更，宿主会拒绝“已经完成”的纯文本声明；只读分析仍可凭读取/检查证据正常结束。
 - Skill/MCP 的 `require`/`prefer` 路由由宿主门禁强制：`require` 必须成功调用（宿主确认不可用时可带真实 blocker 结束），`prefer` 缺失会提醒一次，之后必须调用或 `use_capability(action="decline")` 提交非空理由。
 - 中/高风险改动会强制运行结构化 `review` / `security_review`（通过审查子 Agent 的 `review_report`）；`task`/`run_skill` 等元工具本身不算 mutation，子 Agent 的真实写入会回传父级证据账本。
-- Delivery 的 system contract 与 `use_capability` Schema 是每个该 Profile 会话固定的 provider 前缀；按需连接 MCP 不会改变该固定代理 Schema。Balanced 双模型中的 Planner 代理同样稳定；Executor 刻意保留直接 `mcp__*` 工具，因此这些直接工具安装、连接或刷新时，Executor 的整体 provider 前缀仍可能变化。升级到本版本或从其他 Profile 切换过来会产生一次新的缓存前缀。
+- Delivery 的 system contract 与 `use_capability` Schema 是每个该 Profile 会话固定的 provider 前缀；按需连接 MCP 不会改变该固定代理 Schema。Balanced 双模型中的 Planner 代理同样稳定；配置 MCP 会在启动时自动选择暴露模式：小型且缓存命中的面继续直接暴露，较大或缓存未知的面使用固定代理，因此只有小型直接工具在安装、连接或刷新时可能改变 Executor 的整体 provider 前缀。升级到本版本或从其他 Profile 切换过来会产生一次新的缓存前缀。
 
 ### 怎么选择
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1307,10 +1307,12 @@ read/bash/edit/write, background-shell lifecycle controls, `ask`, and
 session history, memory mutation, slash commands, Skills, MCP, LSP, web access,
 installation, and subagents are connected only when the task needs them.
 Balanced is the default with the complete tool surface; when a distinct Planner is configured, both
-Planner and Executor add the fixed `use_capability` proxy. The proxy schema is
-stable, but the Balanced Executor deliberately retains direct `mcp__*` tools,
-so its overall provider tool prefix may still change when those direct tools
-are installed, connected, or refreshed. Delivery keeps that complete surface,
+Planner and Executor add the fixed `use_capability` proxy. Configured MCP
+exposure is also selected automatically at session boot: small surfaces with a
+matching cache remain direct, while large or unknown surfaces use only the
+stable proxy for that session. The proxy schema is stable; only the intentionally
+small direct MCP surfaces can change the overall provider tool prefix when
+their tools are installed, connected, or refreshed. Delivery keeps that complete surface,
 adds one stable proxy tool (`use_capability`) for on-demand MCP inspect/call
 without schema churn, and adds a stable contract to establish acceptance
 criteria, fix root causes, verify the result, and review the final diff. The

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -1009,8 +1009,9 @@ workflow 工具、session history、memory 写入、slash command、Skills、MCP
 subagent 都在任务需要时才连接。
 Balanced（均衡）是提供完整工具面的默认档；配置独立 Planner 时，Planner 与 Executor 都会获得各自的
 `use_capability` frontend，规划阶段发现的 capability 可在 handoff 后按同一 ID 直接执行，同时保留
-Executor 的完整直接 MCP 工具面。固定代理自身的 schema 保持稳定，但由于 Balanced Executor 刻意保留
-直接 `mcp__*`，安装、连接或刷新这些直接工具时，Executor 的整体 provider 工具前缀仍可能变化。Delivery（交付优先）
+Executor 的完整直接 MCP 工具面。配置中的 MCP 暴露模式也会在会话启动时自动选择：匹配缓存且工具面较小
+的服务器继续直接暴露，工具面较大或缓存未知的服务器在该会话只使用稳定代理。代理自身的 schema 保持稳定；
+只有刻意保留的小型直接 MCP 工具可能在安装、连接或刷新时改变整体 provider 工具前缀。Delivery（交付优先）
 保留完整工具面，额外增加稳定能力代理 `use_capability`（list/inspect/call MCP，包括
 `auto_start=false`，且不改变主工具 Schema），并增加“明确验收标准、修复根因、运行验证、复审最终
 diff”的稳定交付合约。该合约由宿主运行时强制执行：没有具体 `todo_write` 验收清单时会阻止变更和验证

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -95,6 +95,16 @@ not change when MCP inventory changes. Balanced Executor deliberately retains
 its direct `mcp__*` tools, so its overall provider prefix may still change when
 those direct tools are installed, connected, or refreshed.
 
+Configured MCP exposure is selected automatically at session boot; it adds no
+user-facing setting. A small server surface with a matching schema cache stays
+direct for the lower-latency concrete tool call. When the cached surface is
+large (at least 16 tools or an estimated schema payload at or above 16 KiB, scaled
+to the model context window), or any configured server has a missing/stale
+schema cache, Reasonix exposes only the stable `use_capability` proxy for that
+configured MCP set. The choice is frozen for the session, so a background
+handshake cannot change the provider-visible tool prefix. Explicit
+host-session MCP servers remain direct and scoped to that session.
+
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,
 `lsp_references`, `memory`, `parallel_tasks`, `read_only_skill`,

--- a/docs/TOOL_CONTRACT.zh-CN.md
+++ b/docs/TOOL_CONTRACT.zh-CN.md
@@ -75,6 +75,13 @@ read/diff 证据。
 Executor 刻意保留直接 `mcp__*` 工具，因此安装、连接或刷新这些直接工具时，Executor 的整体 provider
 前缀仍可能变化。
 
+配置中的 MCP 暴露模式在会话启动时自动选择，不增加用户设置项。工具面较小且 schema cache
+匹配的服务器继续直接暴露，以保留具体工具调用的低延迟；当缓存工具面较大（至少 16 个工具，或估算
+schema 达到 16 KiB，并按模型上下文窗口缩放），或任一配置服务器缺少/持有过期 schema cache 时，
+Reasonix 会对这组配置 MCP 只暴露稳定的 `use_capability` 代理。选择结果在整个会话内固定，后台
+握手完成不会改变 provider 可见工具前缀。显式传入的 host-session MCP 仍保持直接暴露，并且只作用于
+当前会话。
+
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,
 `lsp_references`, `memory`, `parallel_tasks`, `read_only_skill`,

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2080,10 +2080,11 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		ctrl.SetCapabilityProxyRouting(true)
 	} else if tokenEconomy {
 		ctrl.WireCapabilityRouting(cfg.Plugins, capSpecs, nil, nil)
-	} else if dualModelPlanner {
-		// Balanced dual-model: load plugin config + schema cache so not-yet-
-		// started MCP can route through the stable Planner/Executor proxy.
-		// No semantic router — deterministic route only.
+	} else if dualModelPlanner || mcpExposure.useCapability() {
+		// Balanced dual-model and automatic large/unknown MCP surfaces: load
+		// plugin config + schema cache so not-yet-started MCP can route through
+		// the stable use_capability proxy. No semantic router — deterministic
+		// route only.
 		ctrl.WireCapabilityRouting(cfg.Plugins, capSpecs, nil, capAudit)
 		ctrl.SetCapabilityProxyRouting(true)
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -843,6 +843,23 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			}
 		}
 	}
+	// Capability mode still performs the existing cache-miss catalog discovery,
+	// but keeps its placeholders in a private registry. This preserves startup
+	// failure diagnostics and warms the schema cache without allowing a live
+	// handshake to add dynamic mcp__* tools to the provider-visible registry.
+	discoverMCPInBackground := func(specs []plugin.Spec) {
+		for _, s := range specs {
+			if pluginHost.HasClient(s.Name) {
+				continue
+			}
+			cs, cacheOK := plugin.LoadCachedSchemaForSpec(s)
+			if cacheOK && cs != nil && len(cs.Tools) > 0 {
+				continue
+			}
+			privateReg := tool.NewRegistry()
+			_ = plugin.LazyToolset(s, cs, pluginHost, privateReg, ctx, true)
+		}
+	}
 	// eagerSpecs already includes extraSpecs when !tokenEconomy; avoid double
 	// registration of host-session servers that connected above.
 	configSpecs := append(append([]plugin.Spec{}, eagerSpecs...), bgSpecs...)
@@ -860,7 +877,18 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 		configSpecs = filtered
 	}
-	registerEnabledMCP(configSpecs)
+	// Select the configured MCP exposure once for this session. Small surfaces
+	// keep their concrete per-tool schemas; large or insufficiently-known
+	// surfaces stay behind the stable use_capability proxy. This is automatic —
+	// users do not need another config toggle — and freezing it here prevents a
+	// later background handshake from changing the provider-cache prefix.
+	exposureCachedTools, exposureCacheKeyOK := capability.LoadCachedToolsForSpecs(configSpecs)
+	mcpExposure := chooseMCPExposure(configSpecs, exposureCachedTools, exposureCacheKeyOK, entry.ContextWindow)
+	if mcpExposure.useCapability() {
+		discoverMCPInBackground(configSpecs)
+	} else {
+		registerEnabledMCP(configSpecs)
+	}
 
 	for _, msg := range demoteMessages {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg})
@@ -1722,17 +1750,25 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	}
 	// Always build the runtime when a plugin host exists so task/fleet children
 	// can use the stable proxy even in Balanced/Economy without Delivery.
-	if pluginHost != nil || len(capSpecs) > 0 || tokenDelivery || dualModelPlanner {
+	if pluginHost != nil || len(capSpecs) > 0 || tokenDelivery || dualModelPlanner || mcpExposure.useCapability() {
 		capRuntime = agent.NewMCPCapabilityRuntime(ctx, pluginHost, capSpecs, reg, catalogFn)
 		capRuntime.ConfigureServers(cfg.Plugins, capSpecs, enabledMCPNames)
 	}
-	if tokenDelivery || dualModelPlanner {
+	if tokenDelivery || dualModelPlanner || mcpExposure.useCapability() {
 		capLedger = capability.NewLedger()
 		capAudit = &capability.Audit{}
 		if capRuntime != nil {
 			capProxy = capRuntime.NewFrontend(capLedger, capAudit)
 			reg.Add(capProxy)
 		}
+	}
+	if notice := mcpExposure.notice(); notice != "" {
+		sink.Emit(event.Event{
+			Kind:   event.Notice,
+			Level:  event.LevelInfo,
+			Text:   notice,
+			Detail: mcpExposure.Reason + "; the provider-visible MCP surface is fixed for this session to preserve prompt-cache stability",
+		})
 	}
 	skillStore.ConfigureInvocationPolicy(string(runtimeProfile), func(requires []string) []string {
 		connected := map[string]bool{}

--- a/internal/boot/mcp_exposure.go
+++ b/internal/boot/mcp_exposure.go
@@ -1,0 +1,128 @@
+package boot
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/plugin"
+)
+
+// mcpExposureMode is deliberately an internal boot decision rather than a
+// user-facing setting. The provider-visible tool list must be chosen once per
+// session so connecting a server later cannot churn the prompt-cache prefix.
+type mcpExposureMode string
+
+const (
+	mcpExposurePerTool    mcpExposureMode = "per-tool"
+	mcpExposureCapability mcpExposureMode = "use-capability"
+)
+
+const (
+	// Keep small MCP setups direct: the model already benefits from seeing the
+	// concrete schema and avoids an extra list/inspect round trip.
+	autoMCPToolThreshold = 16
+
+	// A schema payload larger than 16 KiB is already a material fraction of the
+	// tools prefix for the small/medium context windows Reasonix supports. Larger
+	// context windows scale this budget proportionally below.
+	autoMCPMinSchemaBytes             = 16 * 1024
+	autoMCPContextFractionDenominator = 20 // 5% of context bytes
+
+	// A cache miss hides the eventual tool count. Keep a bounded estimate for
+	// diagnostics, but always use the proxy for an unknown server: exposing it
+	// directly would let its background handshake mutate the provider-visible
+	// schema after boot.
+	autoMCPUnknownToolsEstimate  = 8
+	autoMCPUnknownSchemaEstimate = 2 * 1024
+)
+
+type mcpExposureDecision struct {
+	Mode                 mcpExposureMode
+	KnownTools           int
+	EstimatedTools       int
+	KnownSchemaBytes     int
+	EstimatedSchemaBytes int
+	UnknownServers       int
+	SchemaBudget         int
+	Reason               string
+}
+
+func (d mcpExposureDecision) useCapability() bool {
+	return d.Mode == mcpExposureCapability
+}
+
+func (d mcpExposureDecision) notice() string {
+	if !d.useCapability() {
+		return ""
+	}
+	return fmt.Sprintf(
+		"MCP tool surface is large or not yet known; using use_capability automatically (%d known tools, %d estimated tools, %d estimated schema bytes, %d-byte budget, %d uncached servers).",
+		d.KnownTools, d.EstimatedTools, d.EstimatedSchemaBytes, d.SchemaBudget, d.UnknownServers,
+	)
+}
+
+// chooseMCPExposure decides the provider-visible MCP surface from boot-time
+// schema information. It never consults a user setting: the ordinary path is
+// zero-configuration and the result is captured for the whole session.
+//
+// cachedTools and cacheKeyOK come from capability.LoadCachedToolsForSpecs. A
+// mismatched or missing cache is not trusted as a concrete schema, but it still
+// contributes a bounded estimate for diagnostics and threshold explanations.
+func chooseMCPExposure(specs []plugin.Spec, cachedTools map[string][]plugin.CachedTool, cacheKeyOK map[string]bool, contextWindow int) mcpExposureDecision {
+	decision := mcpExposureDecision{
+		Mode:         mcpExposurePerTool,
+		SchemaBudget: mcpSchemaBudget(contextWindow),
+	}
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		name := strings.TrimSpace(spec.Name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		tools := cachedTools[name]
+		if len(tools) == 0 || !cacheKeyOK[name] {
+			decision.UnknownServers++
+			continue
+		}
+		decision.KnownTools += len(tools)
+		for _, cached := range tools {
+			decision.KnownSchemaBytes += mcpCachedToolBytes(cached)
+		}
+	}
+	decision.EstimatedTools = decision.KnownTools + decision.UnknownServers*autoMCPUnknownToolsEstimate
+	decision.EstimatedSchemaBytes = decision.KnownSchemaBytes + decision.UnknownServers*autoMCPUnknownSchemaEstimate
+	if decision.UnknownServers > 0 {
+		decision.Mode = mcpExposureCapability
+		decision.Reason = "one or more MCP schema caches are unavailable or stale"
+	} else if decision.EstimatedTools >= autoMCPToolThreshold {
+		decision.Mode = mcpExposureCapability
+		decision.Reason = "estimated MCP tool count exceeds the automatic threshold"
+	} else if decision.EstimatedSchemaBytes >= decision.SchemaBudget {
+		decision.Mode = mcpExposureCapability
+		decision.Reason = "estimated MCP schema size exceeds the automatic budget"
+	}
+	return decision
+}
+
+func mcpSchemaBudget(contextWindow int) int {
+	budget := autoMCPMinSchemaBytes
+	if contextWindow <= 0 {
+		return budget
+	}
+	// Schema bytes are a rough proxy for the serialized tools prefix. Scale the
+	// automatic budget with the provider context window, but never lower the
+	// conservative floor above.
+	scaled := int64(contextWindow) * 4 / autoMCPContextFractionDenominator
+	if scaled > int64(budget) {
+		budget = int(scaled)
+	}
+	return budget
+}
+
+func mcpCachedToolBytes(cached plugin.CachedTool) int {
+	// Include the fields that materially appear in provider tool definitions,
+	// plus framing for name/description/JSON properties. This is intentionally
+	// an estimate; the mode only needs a stable, conservative threshold.
+	return len(cached.Name) + len(cached.Description) + len(cached.Schema) + 64
+}

--- a/internal/boot/mcp_exposure_test.go
+++ b/internal/boot/mcp_exposure_test.go
@@ -11,6 +11,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
+	"reasonix/internal/provider"
 )
 
 func TestChooseMCPExposureKeepsSmallKnownSurfaceDirect(t *testing.T) {
@@ -171,6 +172,54 @@ command = "reasonix-missing-beta"
 	}
 }
 
+func TestBuildAutomaticMCPProxyRoutesThroughCapability(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	prov := testutil.NewMock("auto-mcp-route", testutil.Turn{Text: "done"})
+	setBootTokenProfileTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+
+[[plugins]]
+name = "alpha"
+command = "reasonix-missing-alpha"
+`)
+	seedMCPExposureCaches(t, dir, autoMCPToolThreshold)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "use alpha mcp"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := prov.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %d, want 1", len(reqs))
+	}
+	if !requestHasTool(reqs[0], "use_capability") {
+		t.Fatalf("automatic MCP proxy must expose use_capability; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	if requestHasTool(reqs[0], "connect_tool_source") {
+		t.Fatalf("Balanced automatic MCP proxy must not expose connect_tool_source; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	if !requestMessageContains(reqs[0].Messages, provider.RoleUser, "use_capability(action=\"call\"") {
+		t.Fatalf("automatic MCP route must direct the model to use_capability:\n%s", requestUserContent(reqs[0]))
+	}
+	if requestMessageContains(reqs[0].Messages, provider.RoleUser, "connect_tool_source") {
+		t.Fatalf("automatic MCP route must not direct the model to connect_tool_source:\n%s", requestUserContent(reqs[0]))
+	}
+}
+
 func TestBuildKeepsSmallMCPSurfaceDirect(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)
@@ -245,4 +294,18 @@ func cachedMCPTools(count, schemaBytes int) []plugin.CachedTool {
 		})
 	}
 	return tools
+}
+
+func requestUserContent(req provider.Request) string {
+	var content strings.Builder
+	for _, message := range req.Messages {
+		if message.Role != provider.RoleUser {
+			continue
+		}
+		if content.Len() > 0 {
+			content.WriteString("\n\n")
+		}
+		content.WriteString(message.Content)
+	}
+	return content.String()
 }

--- a/internal/boot/mcp_exposure_test.go
+++ b/internal/boot/mcp_exposure_test.go
@@ -1,0 +1,248 @@
+package boot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/plugin"
+)
+
+func TestChooseMCPExposureKeepsSmallKnownSurfaceDirect(t *testing.T) {
+	specs := []plugin.Spec{{Name: "one"}}
+	cached := map[string][]plugin.CachedTool{"one": cachedMCPTools(15, 32)}
+	decision := chooseMCPExposure(specs, cached, map[string]bool{"one": true}, 128_000)
+	if decision.Mode != mcpExposurePerTool {
+		t.Fatalf("mode = %q, want %q: %+v", decision.Mode, mcpExposurePerTool, decision)
+	}
+	if decision.KnownTools != 15 || decision.EstimatedTools != 15 || decision.UnknownServers != 0 {
+		t.Fatalf("unexpected decision metrics: %+v", decision)
+	}
+}
+
+func TestChooseMCPExposureCollapsesLargeKnownToolSurface(t *testing.T) {
+	specs := []plugin.Spec{{Name: "one"}}
+	cached := map[string][]plugin.CachedTool{"one": cachedMCPTools(autoMCPToolThreshold, 32)}
+	decision := chooseMCPExposure(specs, cached, map[string]bool{"one": true}, 128_000)
+	if decision.Mode != mcpExposureCapability {
+		t.Fatalf("mode = %q, want %q: %+v", decision.Mode, mcpExposureCapability, decision)
+	}
+	if !strings.Contains(decision.Reason, "tool count") {
+		t.Fatalf("reason = %q, want tool-count explanation", decision.Reason)
+	}
+}
+
+func TestChooseMCPExposureCollapsesLargeSchemaSurface(t *testing.T) {
+	specs := []plugin.Spec{{Name: "one"}}
+	cached := map[string][]plugin.CachedTool{"one": cachedMCPTools(1, autoMCPMinSchemaBytes)}
+	decision := chooseMCPExposure(specs, cached, map[string]bool{"one": true}, 0)
+	if decision.Mode != mcpExposureCapability {
+		t.Fatalf("mode = %q, want %q: %+v", decision.Mode, mcpExposureCapability, decision)
+	}
+	if !strings.Contains(decision.Reason, "schema size") {
+		t.Fatalf("reason = %q, want schema-size explanation", decision.Reason)
+	}
+}
+
+func TestChooseMCPExposureEstimatesColdServersWithoutTrustingStaleCache(t *testing.T) {
+	specs := []plugin.Spec{{Name: "cold-a"}, {Name: "cold-b"}, {Name: "cold-a"}}
+	cached := map[string][]plugin.CachedTool{
+		"cold-a": cachedMCPTools(1, 32),
+		"cold-b": cachedMCPTools(1, 32),
+	}
+	decision := chooseMCPExposure(specs, cached, map[string]bool{
+		"cold-a": false, // stale spec hash: do not trust the concrete tool count
+		"cold-b": false,
+	}, 128_000)
+	if decision.Mode != mcpExposureCapability {
+		t.Fatalf("mode = %q, want %q: %+v", decision.Mode, mcpExposureCapability, decision)
+	}
+	if decision.KnownTools != 0 || decision.UnknownServers != 2 || decision.EstimatedTools != autoMCPToolThreshold {
+		t.Fatalf("unexpected cold-surface metrics: %+v", decision)
+	}
+}
+
+func TestChooseMCPExposureCollapsesColdServerToKeepSurfaceStable(t *testing.T) {
+	decision := chooseMCPExposure([]plugin.Spec{{Name: "cold"}}, nil, nil, 128_000)
+	if decision.Mode != mcpExposureCapability {
+		t.Fatalf("mode = %q, want %q: %+v", decision.Mode, mcpExposureCapability, decision)
+	}
+	if decision.EstimatedTools != autoMCPUnknownToolsEstimate || decision.UnknownServers != 1 {
+		t.Fatalf("unexpected cold-server estimate: %+v", decision)
+	}
+	if !strings.Contains(decision.Reason, "unavailable or stale") {
+		t.Fatalf("reason = %q, want cache-stability explanation", decision.Reason)
+	}
+}
+
+func TestMCPSchemaBudgetScalesWithLargeContextWindows(t *testing.T) {
+	if got := mcpSchemaBudget(0); got != autoMCPMinSchemaBytes {
+		t.Fatalf("zero-window budget = %d, want %d", got, autoMCPMinSchemaBytes)
+	}
+	if got := mcpSchemaBudget(32_000); got != autoMCPMinSchemaBytes {
+		t.Fatalf("small-window budget = %d, want floor %d", got, autoMCPMinSchemaBytes)
+	}
+	if got := mcpSchemaBudget(1_000_000); got != 200_000 {
+		t.Fatalf("large-window budget = %d, want 200000", got)
+	}
+}
+
+func TestMCPExposureNoticeContainsOnlyBoundedMetrics(t *testing.T) {
+	decision := mcpExposureDecision{
+		Mode:                 mcpExposureCapability,
+		KnownTools:           20,
+		EstimatedTools:       20,
+		EstimatedSchemaBytes: 30_000,
+		SchemaBudget:         16_384,
+	}
+	notice := decision.notice()
+	for _, want := range []string{"using use_capability automatically", "20 known tools", "30000 estimated schema bytes"} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("notice %q missing %q", notice, want)
+		}
+	}
+}
+
+func TestBuildAutomaticallyUsesCapabilityForLargeMCPSurface(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	prov := testutil.NewMock("auto-mcp-large", testutil.Turn{Text: "done"})
+	setBootTokenProfileTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+
+[[plugins]]
+name = "alpha"
+command = "reasonix-missing-alpha"
+
+[[plugins]]
+name = "beta"
+command = "reasonix-missing-beta"
+`)
+	seedMCPExposureCaches(t, dir, autoMCPToolThreshold/2)
+
+	var notices []event.Event
+	ctrl, err := Build(context.Background(), Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	})})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "capture automatic MCP surface"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %d, want 1", len(reqs))
+	}
+	if !requestHasTool(reqs[0], "use_capability") {
+		t.Fatalf("large MCP surface must expose use_capability; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	if requestHasToolPrefix(reqs[0], "mcp__") {
+		t.Fatalf("large MCP surface must hide concrete mcp__ tools; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	if failures := ctrl.Host().Failures(); len(failures) != 0 {
+		t.Fatalf("automatic proxy mode must not start missing MCP processes at boot; failures=%v", failures)
+	}
+	foundNotice := false
+	for _, notice := range notices {
+		if strings.Contains(notice.Text, "using use_capability automatically") {
+			foundNotice = true
+			break
+		}
+	}
+	if !foundNotice {
+		t.Fatalf("automatic proxy decision notice missing: %+v", notices)
+	}
+}
+
+func TestBuildKeepsSmallMCPSurfaceDirect(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	registerBootTokenProfileTestProvider()
+	prov := testutil.NewMock("auto-mcp-small", testutil.Turn{Text: "done"})
+	setBootTokenProfileTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+
+[[plugins]]
+name = "small"
+command = "reasonix-missing-small"
+`)
+	seedMCPExposureCaches(t, dir, 2)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "capture direct MCP surface"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %d, want 1", len(reqs))
+	}
+	if requestHasTool(reqs[0], "use_capability") {
+		t.Fatalf("small MCP surface should stay direct; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	for _, want := range []string{"mcp__small__tool_0", "mcp__small__tool_1"} {
+		if !requestHasTool(reqs[0], want) {
+			t.Fatalf("small MCP surface missing %q; tools=%v", want, toolSchemaNames(reqs[0].Tools))
+		}
+	}
+}
+
+func seedMCPExposureCaches(t *testing.T, root string, toolsPerServer int) {
+	t.Helper()
+	cfg, err := config.LoadForRoot(root)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	specs := PluginSpecsForRootWithOptions(cfg.Plugins, root, PluginSpecOptions{})
+	if len(specs) == 0 {
+		t.Fatal("expected configured MCP specs")
+	}
+	for _, spec := range specs {
+		if err := plugin.SaveCachedSchema(spec.Name, plugin.CachedSchema{
+			CacheKey:     plugin.SchemaCacheKey(spec),
+			Capabilities: map[string]bool{"tools": true},
+			Tools:        cachedMCPTools(toolsPerServer, 32),
+		}); err != nil {
+			t.Fatalf("SaveCachedSchema(%s): %v", spec.Name, err)
+		}
+	}
+}
+
+func cachedMCPTools(count, schemaBytes int) []plugin.CachedTool {
+	tools := make([]plugin.CachedTool, 0, count)
+	for i := 0; i < count; i++ {
+		tools = append(tools, plugin.CachedTool{
+			Name:        fmt.Sprintf("tool_%d", i),
+			Description: "cached MCP tool",
+			Schema:      json.RawMessage(`{"type":"object","description":"` + strings.Repeat("x", schemaBytes) + `"}`),
+		})
+	}
+	return tools
+}


### PR DESCRIPTION
## Summary / 摘要

- Choose configured MCP exposure automatically at session boot; no new config or environment option.
- Keep small, cache-valid surfaces direct for low-latency concrete calls.
- Route large surfaces (at least 16 cached tools), oversized schema surfaces (16 KiB floor, scaled with the model context window), and missing/stale caches through the existing stable `use_capability` proxy.
- Freeze the choice for the session. Cache-miss discovery still runs in the background through a private registry, so it warms diagnostics and cache state without adding dynamic `mcp__*` tools to the provider-visible registry.

在会话启动时自动决定配置 MCP 使用直接工具还是 `use_capability` 代理，不增加用户设置项；小型且缓存命中的工具面保持直连，大型、schema 过大或缓存未知的工具面自动使用稳定代理，并在整个会话内固定选择。

## Required impact declarations

Documentation-impact: updated - documented automatic MCP exposure selection in English and Chinese.

Cache-impact: medium - large or unknown MCP surfaces receive a one-time stable proxy prefix; the decision is fixed for the session.

Cache-guard: go test ./internal/boot -run 'TestChooseMCPExposure|TestBuildAutomaticallyUsesCapabilityForLargeMCPSurface|TestBuildKeepsSmallMCPSurfaceDirect'

System-prompt-review: Codex review completed - no system-prompt text changes; only boot-time provider tool selection changes.

## Why

Large MCP catalogs can consume a substantial provider tool prefix. A cache miss can also complete its handshake after boot and mutate the visible tool list. The automatic boundary keeps the ordinary path zero-configuration while preserving direct calls where their schema cost is small.

This adapts the MCP surface-collapse direction proposed by @bfxh in #7743. It intentionally does not include the user-facing meta-tool toggle or the unrelated long-horizon/navigation changes from that PR.

Refs #7743

## Compatibility and cache impact

- Small configured MCP surfaces with matching caches keep the existing direct `mcp__*` behavior.
- Large or unknown configured surfaces receive one stable `use_capability` schema instead of many MCP schemas.
- The exposure decision is boot-scoped, so reconnects cannot change it mid-session.
- Explicit host-session MCP servers remain direct and session-scoped.
- Economy mode keeps its existing on-demand connector behavior.
- Upgrading can cause a one-time provider cache-prefix change when an existing MCP setup crosses the automatic boundary.

## Verification

- `go test ./...`
- `go test -race ./internal/boot`
- `go vet ./internal/boot ./internal/capability ./internal/plugin ./internal/agent`
- Integration coverage verifies large surfaces expose only `use_capability`, small surfaces retain direct tools, and cold/stale caches choose the stable proxy while preserving background discovery diagnostics.