### PR TITLE
fix(frontend): narrow tool items in todo metadata tests / 收窄待办元数据测试中的工具项类型

### DIFF
--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
-import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, shouldReconcileStaleTurn, tokenModeSwitchNoticeText } from "../lib/useController";
+import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, shouldReconcileStaleTurn, tokenModeSwitchNoticeText, type Item } from "../lib/useController";
 import { parseTodos } from "../lib/tools";
 import { resolveTodoPanelTodos } from "../lib/todoVisibility";
 import type { HistoryMessage, Meta, TabMeta, WireUsage } from "../lib/types";
@@ -424,7 +424,9 @@ console.log("\nuse controller meta");
     ],
   });
   const hydrated = reducer({ ...initialState, meta: delayedLiveMeta }, { type: "meta", meta: delayedLiveMeta });
-  const noLiveTodo = hydrated.items.find((item) => item.kind === "tool" && item.name === "todo_write");
+  const noLiveTodo = hydrated.items.find(
+    (item): item is Extract<Item, { kind: "tool" }> => item.kind === "tool" && item.name === "todo_write",
+  );
   eq(
     resolveTodoPanelTodos(hydrated.meta?.canonicalTodos, noLiveTodo ? parseTodos(noLiveTodo.args) : undefined),
     delayedLiveMeta.canonicalTodos,
@@ -452,7 +454,9 @@ console.log("\nuse controller meta");
     type: "event",
     e: { kind: "tool_result", tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated" } },
   });
-  const liveTodo = liveState.items.find((item) => item.kind === "tool" && item.name === "todo_write");
+  const liveTodo = liveState.items.find(
+    (item): item is Extract<Item, { kind: "tool" }> => item.kind === "tool" && item.name === "todo_write",
+  );
   eq(
     JSON.stringify(resolveTodoPanelTodos(liveState.meta?.canonicalTodos, liveTodo ? parseTodos(liveTodo.args) : undefined)),
     JSON.stringify(JSON.parse(liveArgs).todos),

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -348,7 +348,22 @@
           }
         ]
       },
-      "upgrade": [],
+      "upgrade": [
+        {
+          "level": "info",
+          "title": {
+            "en": "No manual migration is required",
+            "zh": "无需手动迁移"
+          },
+          "body": {
+            "en": "Upgrade to v1.21.0 normally; existing configuration and sessions remain compatible.",
+            "zh": "可直接升级到 v1.21.0；现有配置与会话保持兼容。"
+          },
+          "refs": [
+            7773
+          ]
+        }
+      ],
       "risks": [],
       "contributors": [
         "SivanCola",


### PR DESCRIPTION
## Summary

- Fix the frontend test-config TypeScript failure caused by accessing `args` through the broad `Item` union.
- Add explicit tool-item predicates for the live `todo_write` lookups.
- Record the reviewed v1.21.0 upgrade note that no manual migration is required.

## Problem

`pnpm --dir desktop/frontend test:all` failed during `test:typecheck` because the new todo metadata tests did not express the discriminated-union narrowing before reading tool args.

## Root cause

`Array.prototype.find` returned the broad `Item` union even though the callback checked `kind === "tool"`.

## Fix

Use `Extract<Item, { kind: "tool" }>` type predicates for both `todo_write` lookups.

## Verification

- `pnpm --dir desktop/frontend test:all`
- `node scripts/release-notes.mjs validate`
- `node --test scripts/release-notes.test.mjs`
- `git diff --check`

## Release impact

Test-only TypeScript narrowing; no runtime or provider/cache behavior changes.