### PR TITLE
refactor(agent): return streamedTurn from streamWithFrozen

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2965,11 +2965,11 @@ func freezeProviderRequest(req provider.Request) provider.Request {
 //
 // When frozen is non-nil, the request is not rebuilt from session — retries
 // must replay the same provider-visible body.
-func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) (string, string, string, string, string, []provider.ToolCall, []json.RawMessage, *provider.Usage, bool, bool, []provider.ToolCall, int, error) {
+func (a *Agent) stream(ctx context.Context, turn int, sink event.Sink) streamedTurn {
 	return a.streamWithFrozen(ctx, turn, sink, nil, "")
 }
 
-func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink, frozen *samplingRequest, attemptID string) (string, string, string, string, string, []provider.ToolCall, []json.RawMessage, *provider.Usage, bool, bool, []provider.ToolCall, int, error) {
+func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink, frozen *samplingRequest, attemptID string) streamedTurn {
 	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
 		sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max, RetryScope: event.RetryScopeHeaders})
 	})
@@ -2990,7 +2990,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	} else {
 		prepared, perr := a.prepareSamplingRequest(ctx)
 		if perr != nil {
-			return "", "", "", "", "", nil, nil, nil, false, false, nil, 0, perr
+			return streamedTurn{err: perr}
 		}
 		req = prepared.req
 	}
@@ -2999,7 +2999,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	// across retries and request timing because they are derived from req alone.
 	ch, err := a.prov.Stream(ctx, req)
 	if err != nil {
-		return "", "", "", "", "", nil, nil, provider.UsageWithRequestAttemptCount(ctx, nil), false, false, nil, 0, err
+		return streamedTurn{usage: provider.UsageWithRequestAttemptCount(ctx, nil), err: err}
 	}
 
 	// A PostLLMCall hook rewrites the whole reasoning block, so when one is wired
@@ -3018,6 +3018,17 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	var partialToolStarted bool
 	var maxArgChars int
 	var lastArgProgress time.Time
+	// collect packages the stream state accumulated so far; stored is the
+	// finishReasoning output that becomes the round-tripped reasoning.
+	collect := func(stored string, err error) streamedTurn {
+		return streamedTurn{
+			text: text.String(), reasoning: stored, signature: signature,
+			reasoningID: reasoningID, reasoningStatus: reasoningStatus,
+			calls: calls, responsesItems: responsesItems, usage: usage,
+			partialToolStarted: partialToolStarted, partialCalls: partialCalls,
+			maxArgChars: maxArgChars, err: err,
+		}
+	}
 	finishReasoning := func() (stored, display string) {
 		original := reasoning.String()
 		display = original
@@ -3041,14 +3052,14 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 			stored, _ := finishReasoning()
 			usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 			usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, ctx.Err()
+			return collect(stored, ctx.Err())
 		case c, ok := <-ch:
 			if !ok {
 				if err := ctx.Err(); err != nil {
 					stored, _ := finishReasoning()
 					usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 					usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-					return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, err
+					return collect(stored, err)
 				}
 				stored, display := finishReasoning()
 				// provider.response: extensions rule on the assembled terminal
@@ -3059,7 +3070,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 				finalText, finalReasoning, signature, calls, usage, err := a.interceptProviderResponse(
 					ctx, text.String(), stored, signature, calls, usage)
 				if err != nil {
-					return "", "", "", "", "", nil, nil, nil, false, partialToolStarted, partialCalls, maxArgChars, err
+					return streamedTurn{partialToolStarted: partialToolStarted, partialCalls: partialCalls, maxArgChars: maxArgChars, err: err}
 				}
 				// Responses reasoning IDs/status and Anthropic signatures are
 				// provider-bound metadata. Never attach the provider's metadata
@@ -3080,7 +3091,14 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 					})
 				}
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-				return finalText, finalReasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, false, partialCalls, maxArgChars, nil
+				// A clean terminal never reports partialToolStarted: the calls
+				// slice is now authoritative and the partial cards were merged.
+				return streamedTurn{
+					text: finalText, reasoning: finalReasoning, signature: signature,
+					reasoningID: reasoningID, reasoningStatus: reasoningStatus,
+					calls: calls, responsesItems: responsesItems, usage: usage,
+					partialCalls: partialCalls, maxArgChars: maxArgChars,
+				}
 			}
 			chunk = c
 		}
@@ -3106,7 +3124,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), finishReasonClientReasoningLimit)
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
 				a.lastUsage.Store(usage)
-				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, errReasoningByteLimitExceeded
+				return collect(stored, errReasoningByteLimitExceeded)
 			}
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)
@@ -3162,14 +3180,16 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 				stored, _ := finishReasoning()
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-				return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, true, partialToolStarted, partialCalls, maxArgChars, chunk.Err
+				st := collect(stored, chunk.Err)
+				st.interrupted = true
+				return st
 			}
 			stored, _ := finishReasoning()
 			if errors.Is(chunk.Err, context.Canceled) || errors.Is(chunk.Err, context.DeadlineExceeded) {
 				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), "interrupted")
 			}
 			usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-			return text.String(), stored, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, false, partialToolStarted, partialCalls, maxArgChars, chunk.Err
+			return collect(stored, chunk.Err)
 		}
 	}
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -377,7 +377,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 
 	runAttempt := func(attemptID string, sink event.Sink) streamedTurn {
 		before := provider.RequestAttemptCount(ctx)
-		result := a.streamTurnFrozen(ctx, turn, sink, &frozen, attemptID)
+		result := a.streamWithFrozen(ctx, turn, sink, &frozen, attemptID)
 		after := provider.RequestAttemptCount(ctx)
 		delta := after - before
 		if delta < 0 {
@@ -498,17 +498,6 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		return result
 	}
 	return last
-}
-
-func (a *Agent) streamTurnFrozen(ctx context.Context, turn int, sink event.Sink, frozen *samplingRequest, attemptID string) streamedTurn {
-	text, reasoning, signature, reasoningID, reasoningStatus, calls, responsesItems, usage, interrupted, partialToolStarted, partialCalls, maxArgChars, err := a.streamWithFrozen(ctx, turn, sink, frozen, attemptID)
-	return streamedTurn{
-		text: text, reasoning: reasoning, signature: signature,
-		reasoningID: reasoningID, reasoningStatus: reasoningStatus,
-		calls: calls, responsesItems: responsesItems, usage: usage,
-		interrupted: interrupted, partialToolStarted: partialToolStarted, partialCalls: partialCalls,
-		maxArgChars: maxArgChars, err: err,
-	}
 }
 
 func (a *Agent) emitStreamAttempt(id string, action event.StreamAttemptAction, attempt int, reason string, err error) {

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -164,14 +164,14 @@ func TestStreamReturnsRequestOnlyUsageOnProviderFailure(t *testing.T) {
 	sink := event.FuncSink(func(e event.Event) { events = append(events, e) })
 	a := New(failedRequestProvider{}, tool.NewRegistry(), NewSession(""), Options{ModelRef: "failed/model"}, sink)
 
-	_, _, _, _, _, _, _, usage, _, _, _, _, err := a.stream(context.Background(), 1, sink)
-	if err == nil {
+	st := a.stream(context.Background(), 1, sink)
+	if st.err == nil {
 		t.Fatal("expected provider failure")
 	}
-	if usage == nil || usage.TotalTokens != 0 || usage.RequestCount != 1 {
-		t.Fatalf("failed stream usage = %+v, want tokens=0 requests=1", usage)
+	if st.usage == nil || st.usage.TotalTokens != 0 || st.usage.RequestCount != 1 {
+		t.Fatalf("failed stream usage = %+v, want tokens=0 requests=1", st.usage)
 	}
-	a.emitTurnUsage(usage, nil)
+	a.emitTurnUsage(st.usage, nil)
 	if len(events) != 1 || events[0].Kind != event.Usage || events[0].Usage.RequestCount != 1 {
 		t.Fatalf("request-only usage event = %+v", events)
 	}


### PR DESCRIPTION
Part of the agent god-object cleanup series (agent.go grew to 4.7k LOC / Agent to 99 fields over the last 6 weeks).

## What

- `streamWithFrozen` returned **13 positional values**; its only consumers were `stream` (same tuple) and `streamTurnFrozen`, whose sole purpose was to repack the tuple into the existing `streamedTurn` struct. It now returns `streamedTurn` directly.
- Deleted the `streamTurnFrozen` wrapper; `streamWithSamplingRecovery` calls `streamWithFrozen` directly.
- The six mid-stream exit paths (ctx cancel, channel close on cancel, reasoning byte limit, stream interrupt, chunk error ×2) share a `collect` helper; the clean-terminal and intercept-error paths keep explicit literals because they run under the `interceptProviderResponse` shadowed scope and override fields (`partialToolStarted` forced false on clean terminal, now stated in a comment instead of an anonymous positional `false`).

Pure mechanical repack — no behavior change.

## Verification

- `gofmt` clean, `go vet ./internal/agent/...` clean
- `go test ./internal/agent/` and `go test -race ./internal/agent/` green
- Full `go test ./...` green (English locale)

Cache-impact: none - pure mechanical repack of streamWithFrozen return values into the existing streamedTurn struct; no request building, cache_control placement, or usage accounting logic changes.
Cache-guard: existing coverage - internal/agent cache_shape_test.go and usage_accounting_test.go pass unchanged (go test -race ./internal/agent/).
Documentation-impact: none - internal refactor with no user-visible behavior change; no docs describe these internals.
