### PR TITLE
feat(config): compose user- and project-level system_prompt_file layers

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -526,17 +526,19 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	}
 	shell := sandbox.ResolveShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path, stderr)
 
-	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
+	layered, err := cfg.ResolveLayeredSystemPromptForRoot(root)
 	if err != nil {
-		if !config.IsMissingSystemPromptFile(err) {
-			return nil, err
-		}
-		// A stale missing prompt file must not block startup: warn and fall back
-		// to the inline (or built-in default) system prompt. Other read failures
-		// stay fatal so Reasonix never runs without explicitly configured policy.
-		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: err.Error() + "; falling back to inline/default system prompt"})
-		sysPrompt = cfg.InlineSystemPrompt()
+		return nil, err
 	}
+	// A stale missing user-level prompt file must not block startup: warn and
+	// fall back to the inline (or built-in default) system prompt. Other read
+	// failures stay fatal so Reasonix never runs without explicitly configured
+	// policy. A project-level file missing from the workspace is skipped
+	// silently inside the layered resolution.
+	if layered.UserFileMissing != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: layered.UserFileMissing.Error() + "; falling back to inline/default system prompt"})
+	}
+	sysPrompt := layered.Prompt
 	// Output style: fold the selected persona/tone block into the base prompt
 	// before language/memory/skills append, so a "replace" style (keep-coding
 	// false) still keeps those. Applied once, into the cache-stable prefix.

--- a/internal/boot/system_prompt_file_test.go
+++ b/internal/boot/system_prompt_file_test.go
@@ -10,11 +10,37 @@ import (
 	"reasonix/internal/event"
 )
 
-func TestBuildMissingSystemPromptFileFallsBackToInlinePrompt(t *testing.T) {
+func TestBuildMissingProjectSystemPromptFileSkipsSilently(t *testing.T) {
 	isolateConfigHome(t)
 	root := robustTempDir(t)
 	t.Setenv("REASONIX_HOME", robustTempDir(t))
 	writeFile(t, root, "reasonix.toml", systemPromptFileTestConfig("prompts/missing.md"))
+
+	ctrl, err := Build(context.Background(), Options{
+		WorkspaceRoot: root,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice && e.Level == event.LevelWarn &&
+				strings.Contains(e.Text, "falling back to inline/default system prompt") {
+				t.Fatalf("project-scope missing prompt file must skip silently, got warning: %s", e.Text)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	// The inline default remains the prompt: the absent project layer is skipped.
+	if got := systemMessage(ctrl.History()); !strings.Contains(got, "INLINE FALLBACK") {
+		t.Fatalf("system prompt did not use inline fallback:\n%s", got)
+	}
+}
+
+func TestBuildMissingUserSystemPromptFileWarnsAndFallsBack(t *testing.T) {
+	isolateConfigHome(t)
+	userHome := robustTempDir(t)
+	t.Setenv("REASONIX_HOME", userHome)
+	writeFile(t, userHome, "config.toml", systemPromptFileTestConfig("prompts/missing.md"))
+	root := robustTempDir(t) // no project reasonix.toml
 
 	var notices []event.Event
 	ctrl, err := Build(context.Background(), Options{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,16 +66,22 @@ type Config struct {
 	Secrets          SecretsConfig       `toml:"secrets"`
 	Remote           RemoteConfig        `toml:"remote"`
 
-	systemPromptFileSource     promptFileSource
-	providerSources            map[string]providerSourceScope
-	shadowedProjectProviders   []ProviderEntry
-	ignoredProjectDefaultModel string
-	ignoredLegacyStepLimits    bool
-	expansionEnv               map[string]string
-	pluginPackageOwners        map[string]string
-	pluginPackageSkillOwners   map[string][]string
-	pluginPackageAgentOwners   map[string][]string
-	editLoadErr                error
+	systemPromptFileSource promptFileSource
+	// systemPromptFileUserValue / systemPromptFileProjectValue retain the raw
+	// system_prompt_file value from each config scope so the layered resolver
+	// can read both, even though the merged Agent.SystemPromptFile holds only
+	// the winning one.
+	systemPromptFileUserValue    string
+	systemPromptFileProjectValue string
+	providerSources              map[string]providerSourceScope
+	shadowedProjectProviders     []ProviderEntry
+	ignoredProjectDefaultModel   string
+	ignoredLegacyStepLimits      bool
+	expansionEnv                 map[string]string
+	pluginPackageOwners          map[string]string
+	pluginPackageSkillOwners     map[string][]string
+	pluginPackageAgentOwners     map[string][]string
+	editLoadErr                  error
 	// loadWarnings are non-fatal issues observed while loading config (corrupt
 	// user/project files recovered via last-known-good or defaults). They never
 	// rewrite the original file; the UI may surface them for doctor repair.
@@ -2179,17 +2185,31 @@ func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 	}
 
 	if c.systemPromptFileSource == promptFileSourceProject {
-		if filepath.IsAbs(path) || !filepath.IsLocal(filepath.Clean(path)) {
-			return "", fmt.Errorf("project system_prompt_file %q must be a relative path within the workspace", path)
-		}
-		candidate := filepath.Join(resolveRoot(root), path)
-		b, err := readProjectSystemPromptFile(root, path)
-		if err != nil {
-			return "", newSystemPromptFileError(path, []string{candidate}, []error{err})
-		}
-		return strings.TrimSpace(string(b)), nil
+		return c.resolveProjectSystemPromptFileConfined(root, path)
 	}
 
+	return c.resolveUserSystemPromptFile(root, path)
+}
+
+// resolveProjectSystemPromptFileConfined reads a project-scope prompt file: the
+// path must be workspace-relative and is opened under os.Root so neither ".." nor
+// symlinks can escape the workspace.
+func (c *Config) resolveProjectSystemPromptFileConfined(root, path string) (string, error) {
+	if filepath.IsAbs(path) || !filepath.IsLocal(filepath.Clean(path)) {
+		return "", fmt.Errorf("project system_prompt_file %q must be a relative path within the workspace", path)
+	}
+	candidate := filepath.Join(resolveRoot(root), path)
+	b, err := readProjectSystemPromptFile(root, path)
+	if err != nil {
+		return "", newSystemPromptFileError(path, []string{candidate}, []error{err})
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// resolveUserSystemPromptFile reads a trusted user-scope prompt file: absolute
+// paths directly, relative paths probed under the workspace root first, then the
+// Reasonix home.
+func (c *Config) resolveUserSystemPromptFile(root, path string) (string, error) {
 	if filepath.IsAbs(path) {
 		b, err := fileencoding.ReadFileUTF8(path)
 		if err != nil {
@@ -2214,6 +2234,86 @@ func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 		readErrors = append(readErrors, fmt.Errorf("%s: %w", candidate, err))
 	}
 	return "", newSystemPromptFileError(path, candidates, readErrors)
+}
+
+// Layer and precedence headers prepended when user- and project-level prompt
+// files are composed. With only a user-level file the content stays bare
+// (unchanged single-file behavior).
+const (
+	systemPromptUserLayerHeader    = "以下为系统级规则："
+	systemPromptProjectLayerHeader = "以下为项目级规则，假如跟系统级规则冲突，在本项目范围内以项目级规则为准："
+)
+
+// LayeredSystemPrompt is the composed system prompt from the user- and
+// project-level system_prompt_file layers.
+type LayeredSystemPrompt struct {
+	// Prompt is the composed text: the user-level file (or the inline/default
+	// fallback) as the base, plus the project-level file appended with an
+	// explicit precedence note when present.
+	Prompt string
+	// UserFileMissing is non-nil when a user-level prompt file was configured
+	// but absent at every allowed location; the caller should warn and the
+	// base already fell back to the inline/default prompt. A project-level
+	// file missing from the workspace is skipped silently by design.
+	UserFileMissing error
+}
+
+// ResolveLayeredSystemPromptForRoot composes the system prompt from up to two
+// system_prompt_file layers. The trusted user-level file replaces the built-in
+// default as before; the workspace-confined project-level file is appended with
+// a header stating that project rules win within this project. Only missing
+// user files degrade (with UserFileMissing set); containment or permission
+// errors from either layer stay fatal.
+func (c *Config) ResolveLayeredSystemPromptForRoot(root string) (LayeredSystemPrompt, error) {
+	var out LayeredSystemPrompt
+
+	userValue := c.systemPromptFileUserValue
+	if userValue == "" && c.systemPromptFileSource != promptFileSourceProject {
+		// Single-source configuration (no project file involved): the merged
+		// value is the user layer.
+		userValue = c.Agent.SystemPromptFile
+	}
+
+	base := ""
+	userFromFile := false
+	if userValue != "" {
+		content, err := c.resolveUserSystemPromptFile(root, userValue)
+		if err != nil {
+			if !IsMissingSystemPromptFile(err) {
+				return out, err
+			}
+			out.UserFileMissing = err
+			base = c.InlineSystemPrompt()
+		} else {
+			base = content
+			userFromFile = true
+		}
+	} else {
+		base = c.InlineSystemPrompt()
+	}
+
+	projectContent := ""
+	if c.systemPromptFileProjectValue != "" {
+		content, err := c.resolveProjectSystemPromptFileConfined(root, c.systemPromptFileProjectValue)
+		if err != nil {
+			if !IsMissingSystemPromptFile(err) {
+				return out, err
+			}
+			// Project prompt file absent from the workspace: skip silently.
+		} else {
+			projectContent = content
+		}
+	}
+
+	if projectContent == "" {
+		out.Prompt = base
+		return out, nil
+	}
+	if userFromFile {
+		base = systemPromptUserLayerHeader + "\n" + base
+	}
+	out.Prompt = base + "\n\n" + systemPromptProjectLayerHeader + "\n" + projectContent
+	return out, nil
 }
 
 func readProjectSystemPromptFile(root, path string) ([]byte, error) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -56,6 +56,7 @@ func LoadUserConfigReadOnly() (*Config, error) {
 		}
 		if meta.IsDefined("agent", "system_prompt_file") {
 			cfg.systemPromptFileSource = promptFileSourceUser
+			cfg.systemPromptFileUserValue = cfg.Agent.SystemPromptFile
 		}
 	}
 	normalizeConfigForEdit(cfg)
@@ -123,6 +124,9 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	if cfg.systemPromptFileSource == promptFileSourceUnknown && cfg.Agent.SystemPromptFile != "" {
 		cfg.systemPromptFileSource = promptFileSourceUser
 	}
+	if cfg.systemPromptFileSource == promptFileSourceUser {
+		cfg.systemPromptFileUserValue = cfg.Agent.SystemPromptFile
+	}
 	userDefaultModel := cfg.DefaultModel
 	globalCLI := cfg.CLI
 	globalSecrets := cfg.Secrets
@@ -145,6 +149,7 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 		tomlSources = tomlSources[:len(tomlSources)-1]
 	} else if projectMeta.IsDefined("agent", "system_prompt_file") {
 		cfg.systemPromptFileSource = promptFileSourceProject
+		cfg.systemPromptFileProjectValue = cfg.Agent.SystemPromptFile
 	}
 	// The native CLI update channel controls the one user-installed binary.
 	// A repository-local reasonix.toml must never switch that global choice.

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -370,3 +370,163 @@ func TestResolveSystemPromptForRootDecodesGB18030(t *testing.T) {
 		t.Fatalf("system prompt = %q, want decoded Chinese prompt", got)
 	}
 }
+
+// ── Layered system prompt (user layer + project layer) ──
+
+func TestLayeredSystemPromptUserFileOnly(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "u.md"), []byte(" 用户规则：必须中文回答 \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.systemPromptFileSource = promptFileSourceUser
+	cfg.Agent.SystemPromptFile = "prompts/u.md"
+	cfg.systemPromptFileUserValue = cfg.Agent.SystemPromptFile
+
+	out, err := cfg.ResolveLayeredSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveLayeredSystemPromptForRoot: %v", err)
+	}
+	if out.UserFileMissing != nil {
+		t.Fatalf("unexpected UserFileMissing: %v", out.UserFileMissing)
+	}
+	// A lone user-level file stays bare — no layer headers.
+	if out.Prompt != "用户规则：必须中文回答" {
+		t.Fatalf("Prompt = %q, want bare user content", out.Prompt)
+	}
+}
+
+func TestLayeredSystemPromptComposesUserAndProject(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "u.md"), []byte("系统级：做完必须 commit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "prompts", "p.md"), []byte("项目级：本仓库不 commit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.systemPromptFileSource = promptFileSourceProject
+	cfg.systemPromptFileUserValue = "prompts/u.md"
+	cfg.systemPromptFileProjectValue = "prompts/p.md"
+	cfg.Agent.SystemPromptFile = cfg.systemPromptFileProjectValue
+
+	out, err := cfg.ResolveLayeredSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveLayeredSystemPromptForRoot: %v", err)
+	}
+	if out.UserFileMissing != nil {
+		t.Fatalf("unexpected UserFileMissing: %v", out.UserFileMissing)
+	}
+	want := systemPromptUserLayerHeader + "\n" + "系统级：做完必须 commit" +
+		"\n\n" + systemPromptProjectLayerHeader + "\n" + "项目级：本仓库不 commit"
+	if out.Prompt != want {
+		t.Fatalf("Prompt = %q, want composed layers:\n%s", out.Prompt, want)
+	}
+}
+
+func TestLayeredSystemPromptUserMissingWarnsAndFallsBack(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+
+	cfg := Default()
+	cfg.systemPromptFileSource = promptFileSourceUser
+	cfg.Agent.SystemPromptFile = "prompts/nope.md"
+	cfg.systemPromptFileUserValue = cfg.Agent.SystemPromptFile
+
+	out, err := cfg.ResolveLayeredSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("missing user file should degrade, got fatal: %v", err)
+	}
+	if out.UserFileMissing == nil || !IsMissingSystemPromptFile(out.UserFileMissing) {
+		t.Fatalf("UserFileMissing = %v, want a missing-file marker", out.UserFileMissing)
+	}
+	if out.Prompt != DefaultSystemPrompt {
+		t.Fatalf("Prompt = %q, want built-in default fallback", out.Prompt)
+	}
+}
+
+func TestLayeredSystemPromptProjectMissingSkipsSilently(t *testing.T) {
+	root := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "prompts", "u.md"), []byte("用户规则"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	cfg.systemPromptFileSource = promptFileSourceProject
+	cfg.systemPromptFileUserValue = "prompts/u.md"
+	cfg.systemPromptFileProjectValue = "prompts/absent.md" // not present in workspace
+	cfg.Agent.SystemPromptFile = cfg.systemPromptFileProjectValue
+
+	out, err := cfg.ResolveLayeredSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("missing project file should be silent, got: %v", err)
+	}
+	if out.UserFileMissing != nil {
+		t.Fatalf("unexpected UserFileMissing: %v", out.UserFileMissing)
+	}
+	// Project layer absent → user content stays bare, no headers.
+	if out.Prompt != "用户规则" {
+		t.Fatalf("Prompt = %q, want bare user content", out.Prompt)
+	}
+}
+
+func TestLayeredSystemPromptProjectEscapeStaysFatal(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
+
+	cfg := Default()
+	cfg.systemPromptFileSource = promptFileSourceProject
+	cfg.systemPromptFileProjectValue = "../escape.md"
+	cfg.Agent.SystemPromptFile = cfg.systemPromptFileProjectValue
+
+	if _, err := cfg.ResolveLayeredSystemPromptForRoot(root); err == nil || IsMissingSystemPromptFile(err) ||
+		!strings.Contains(err.Error(), "relative path within the workspace") {
+		t.Fatalf("escape attempt err = %v, want fatal relative-path error", err)
+	}
+}
+
+func TestLayeredSystemPromptProjectOnlyAppendsToDefault(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "prompts", "p.md"), []byte("项目级规则"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default() // no user-level file at all
+	cfg.systemPromptFileSource = promptFileSourceProject
+	cfg.systemPromptFileProjectValue = "prompts/p.md"
+	cfg.Agent.SystemPromptFile = cfg.systemPromptFileProjectValue
+
+	out, err := cfg.ResolveLayeredSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveLayeredSystemPromptForRoot: %v", err)
+	}
+	want := DefaultSystemPrompt + "\n\n" + systemPromptProjectLayerHeader + "\n" + "项目级规则"
+	if out.Prompt != want {
+		t.Fatalf("Prompt = %q, want default + project layer:\n%s", out.Prompt, want)
+	}
+}


### PR DESCRIPTION
## Summary

Today `system_prompt_file` is a single winning value: a project `reasonix.toml` either owns the prompt or is absent. This PR makes it **two layers**:

1. The **trusted user-level file** (user config; absolute path, or workspace → Reasonix home probing — unchanged) forms the base prompt, replacing the built-in default as before.
2. The **workspace-confined project-level file** (os.Root containment, relative-path-only, no `..` escapes — unchanged) is **appended** after the base, each layer introduced by a header:

```
以下为系统级规则：
<user-level prompt file>

以下为项目级规则，假如跟系统级规则冲突，在本项目范围内以项目级规则为准：
<project-level prompt file>
```

Precedence between natural-language rules is **resolved by the model** — the same convention as the AGENTS.md hierarchy ("the more specific one wins"), no text-level dedup in code.

Error policy follows the source:

- user-level file missing at every allowed location → warn and fall back to the inline/default prompt (boot, as before);
- project-level file absent from the workspace → **skipped silently** (it is an optional overlay);
- containment / permission errors in either layer → **fatal** (unchanged).

When only a user-level file exists, the prompt is unchanged (bare content, no headers), so existing single-file setups see zero prompt drift.

## Safety analysis (please review)

The obvious concern: *"project rules win" lets an untrusted checkout override my global rules — e.g. a repo whose prompt says "ignore the above restrictions".* We believe the change is safe **because of where the real guardrails live**:

- **Command-level hard limits are not in prompts.** `[permissions].deny/.ask` rules (`Bash(rm -rf*)`, `Bash(git push --force*)`, …) are pattern-matched in code on every tool call, and the OS bash sandbox (bubblewrap/Seatbelt write confinement, `forbid_read`, network toggles) is enforced by the kernel. **No prompt text — user or project — can reach these layers.**
- What a project prompt *can* override is only **soft behavioral conventions**: answer language, commit style, test discipline, output tone. The worst realistic outcome of a malicious overlay is "the agent ignores my style rules inside this workspace", bounded by the same sandbox that already applies today.
- The residual soft-security rule ("don't exfiltrate secrets") is itself only model self-restraint today — a single-value project prompt can already replace the whole prompt. Layering does not widen that surface; the explicit 系统级/项目级 headers arguably *strengthen* the model's source awareness.
- Project-file **containment is unchanged**: os.Root + relative-path-only + symlink-escape rejection, so the overlay cannot even *read* outside the workspace, let alone read credential files into the prompt.

## Issues

Refs #7330 (the provenance foundation this builds on). No existing report for layered composition.

## Verification

- New config tests (6): user-only bare content, user+project composition with both headers, user-missing warns + inline fallback, project-missing silent skip, project escape stays fatal, project-only appends to default.
- New boot tests (2): user-scope missing warns and falls back; project-scope missing builds silently with the inline default.
- Live e2e: workspace with `reasonix.toml` → `prompts/p.md` ("append LAYER-OK to every reply") and a user-level prompt file configured — the model's answer ends with `LAYER-OK`, proving the project layer reaches the model through composition.
- `go test ./internal/config ./internal/boot/` passes; upstream single-value `ResolveSystemPromptForRoot` semantics unchanged (its full test suite untouched and green).

## Cache impact

Cache-impact: low — single-user-file setups produce a byte-identical prompt; only configurations that *also* set a project `system_prompt_file` get the composed prefix (headers add ~40 tokens) in that workspace, which is the intended behavior change.
Cache-guard: `go test ./internal/config/ -run 'TestLayeredSystemPrompt|TestResolveSystemPrompt'` (19 tests), `go test ./internal/boot/ -run 'SystemPromptFile'`.
System-prompt-review: yes — this changes system prompt *composition* (append a project layer with provenance headers); no change to default prompt content or to single-file resolution.
