### PR TITLE
fix(ask): require multiSelect in schema and add desktop multi-select badge / 修复 ask 多选只能单选的问题

### DIFF
--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -256,6 +256,7 @@ export function AskCard({
       badges={
         <span className="ask-shelf__header-meta">
           {q.header && <span className="ask-shelf__header-text">{q.header}</span>}
+          {q.multi && <span className="ask-shelf__header-text ask-shelf__header-text--multi">{t("ask.multiSelectBadge")}</span>}
           {hasMultipleQuestions && (
             <span className="ask-shelf__header-text ask-shelf__header-text--progress">
               {t("ask.questionProgress", { progress })}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1127,6 +1127,7 @@ export const en = {
 
   // ask card
   "ask.title": "Need your decision",
+  "ask.multiSelectBadge": "Multi-select",
   "ask.questionProgress": "Question {progress}",
   "ask.details": "Details",
   "ask.hideDetails": "Hide",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -893,6 +893,7 @@ export const zhTW: Record<DictKey, string> = {
 
   // 提問卡片
   "ask.title": "需要你決定",
+  "ask.multiSelectBadge": "可多選",
   "ask.questionProgress": "問題 {progress}",
   "ask.details": "詳情",
   "ask.hideDetails": "收起",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1128,6 +1128,7 @@ export const zh: Record<DictKey, string> = {
 
   // 提问卡片
   "ask.title": "需要你决定",
+  "ask.multiSelectBadge": "可多选",
   "ask.questionProgress": "问题 {progress}",
   "ask.details": "详情",
   "ask.hideDetails": "收起",

--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -25,7 +25,7 @@ func NewAskTool() *AskTool { return &AskTool{} }
 func (*AskTool) Name() string { return "ask" }
 
 func (*AskTool) Description() string {
-	return "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect` when more than one may apply."
+	return "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect`: set to `true` when the question allows MULTIPLE picks (e.g. 'select all that apply', 'which ones'), `false` for a single exclusive choice. **Critical:** omitting `multiSelect: true` on a multi-choice question silently restricts the user to one pick — each selection replaces the last — so always set it correctly."
 }
 
 func (*AskTool) Schema() json.RawMessage {
@@ -54,9 +54,9 @@ func (*AskTool) Schema() json.RawMessage {
             "required":["label"]
           }
         },
-        "multiSelect":{"type":"boolean","description":"Allow selecting more than one option."}
+        "multiSelect":{"type":"boolean","description":"Whether the user may pick several options. Set to 'true' for multi-pick questions (e.g. \"choose all that apply\"), 'false' for single exclusive choice. Setting 'false' or omitting this on a multi-answer question replaces every pick — only the last survives — so always set 'true' when more than one answer is valid."}
       },
-      "required":["question","header","options"]
+      "required":["question","header","options","multiSelect"]
     }
   }
 },

--- a/internal/agent/ask_test.go
+++ b/internal/agent/ask_test.go
@@ -118,7 +118,7 @@ func TestAskToolProviderContractStable(t *testing.T) {
 	tool := NewAskTool()
 	contract := tool.Description() + "\n" + string(provider.CanonicalizeSchema(tool.Schema()))
 	got := fmt.Sprintf("%x", sha256.Sum256([]byte(contract)))
-	const want = "f4c6efe84da2e964b3f8566b1f0921ca88812ae3ecfba46185d0439ae4f4c2a5"
+	const want = "03c273ee428fdfd041d51522bb7c5858adc35c68ee72f7e3b6d5c355973d9d17"
 	if got != want {
 		t.Fatalf("ask provider contract hash = %s, want %s; tool description or canonical schema changed", got, want)
 	}

--- a/internal/boot/testdata/golden/prefix_shape.json
+++ b/internal/boot/testdata/golden/prefix_shape.json
@@ -1,7 +1,7 @@
 {
   "SystemHash": "444e09fab2c7c226",
-  "ToolsHash": "a2d2aa4bdc381608",
-  "PrefixHash": "e19104804d9bb1da",
+  "ToolsHash": "19fd2d15d261a1f5",
+  "PrefixHash": "b3f1f43316840979",
   "LogRewriteVersion": 0,
-  "ToolSchemaTokens": 12784
+  "ToolSchemaTokens": 13099
 }

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -31,7 +31,7 @@
   "Tools": [
     {
       "name": "ask",
-      "description": "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect` when more than one may apply.",
+      "description": "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect`: set to `true` when the question allows MULTIPLE picks (e.g. 'select all that apply', 'which ones'), `false` for a single exclusive choice. **Critical:** omitting `multiSelect: true` on a multi-choice question silently restricts the user to one pick — each selection replaces the last — so always set it correctly.",
       "parameters": {
         "properties": {
           "questions": {
@@ -43,7 +43,7 @@
                   "type": "string"
                 },
                 "multiSelect": {
-                  "description": "Allow selecting more than one option.",
+                  "description": "Whether the user may pick several options. Set to 'true' for multi-pick questions (e.g. \"choose all that apply\"), 'false' for single exclusive choice. Setting 'false' or omitting this on a multi-answer question replaces every pick — only the last survives — so always set 'true' when more than one answer is valid.",
                   "type": "boolean"
                 },
                 "options": {
@@ -75,6 +75,7 @@
               },
               "required": [
                 "header",
+                "multiSelect",
                 "options",
                 "question"
               ],
@@ -93,7 +94,7 @@
     },
     {
       "name": "bash",
-      "description": "Execute a command in the shell and return combined stdout/stderr. Use for builds, tests, git, package managers, etc. To search/read/list/edit/move files, prefer the dedicated tools (grep, read_file, ls, glob, edit_file, move_file) over shell grep/cat/ls/find/sed/mv/Move-Item — they behave identically on every OS. For symbol search or architecture questions, prefer LSP/read tools and targeted grep before shell commands.",
+      "description": "Execute a command in the shell and return combined stdout/stderr. NOTE: bash is not available on this host — commands run under Windows PowerShell, so write PowerShell, not bash:\n  - chaining: ';' runs both regardless; 'if ($?) { ... }' is conditional. '\u0026\u0026' and '||' are NOT parsed.\n  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2\u003e$null' drops stderr.\n  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0). Use for builds, tests, git, package managers, etc. To search/read/list/edit/move files, prefer the dedicated tools (grep, read_file, ls, glob, edit_file, move_file) over shell grep/cat/ls/find/sed/mv/Move-Item — they behave identically on every OS. For symbol search or architecture questions, prefer LSP/read tools and targeted grep before shell commands.",
       "parameters": {
         "properties": {
           "command": {

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -1,7 +1,7 @@
 [
   {
     "Name": "ask",
-    "Description": "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect` when more than one may apply.",
+    "Description": "Ask the user one or more multiple-choice questions when you hit a decision that is genuinely theirs to make — one you can't resolve from the request, the code, or sensible defaults. The frontend shows the options for the user to pick; their choices are returned to you. Prefer this over asking in prose for any real fork (which approach, which library, scope). Don't use it for decisions with an obvious default — pick the sensible option and proceed. Tool-approval modes such as YOLO do not answer these questions for the user. Each question has a short `header` (a tab label), the `question` text, 2-4 `options` (each a `label` and optional `description`; put any recommended option first), and `multiSelect`: set to `true` when the question allows MULTIPLE picks (e.g. 'select all that apply', 'which ones'), `false` for a single exclusive choice. **Critical:** omitting `multiSelect: true` on a multi-choice question silently restricts the user to one pick — each selection replaces the last — so always set it correctly.",
     "ReadOnly": true,
     "Schema": {
       "properties": {
@@ -14,7 +14,7 @@
                 "type": "string"
               },
               "multiSelect": {
-                "description": "Allow selecting more than one option.",
+                "description": "Whether the user may pick several options. Set to 'true' for multi-pick questions (e.g. \"choose all that apply\"), 'false' for single exclusive choice. Setting 'false' or omitting this on a multi-answer question replaces every pick — only the last survives — so always set 'true' when more than one answer is valid.",
                 "type": "boolean"
               },
               "options": {
@@ -46,6 +46,7 @@
             },
             "required": [
               "header",
+              "multiSelect",
               "options",
               "question"
             ],
@@ -64,7 +65,7 @@
   },
   {
     "Name": "bash",
-    "Description": "Execute a command in the shell and return combined stdout/stderr. Use for builds, tests, git, package managers, etc. To search/read/list/edit/move files, prefer the dedicated tools (grep, read_file, ls, glob, edit_file, move_file) over shell grep/cat/ls/find/sed/mv/Move-Item — they behave identically on every OS. For symbol search or architecture questions, prefer LSP/read tools and targeted grep before shell commands.",
+    "Description": "Execute a command in the shell and return combined stdout/stderr. NOTE: bash is not available on this host — commands run under Windows PowerShell, so write PowerShell, not bash:\n  - chaining: ';' runs both regardless; 'if ($?) { ... }' is conditional. '\u0026\u0026' and '||' are NOT parsed.\n  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2\u003e$null' drops stderr.\n  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0). Use for builds, tests, git, package managers, etc. To search/read/list/edit/move files, prefer the dedicated tools (grep, read_file, ls, glob, edit_file, move_file) over shell grep/cat/ls/find/sed/mv/Move-Item — they behave identically on every OS. For symbol search or architecture questions, prefer LSP/read tools and targeted grep before shell commands.",
     "ReadOnly": false,
     "Schema": {
       "properties": {


### PR DESCRIPTION
## Summary

Fix #7649

When the `ask` tool presented a multi-pick question, the desktop UI appeared to accept multiple selections but actually replaced each pick with the last — silently restricting the user to a single choice.  This happened because `multiSelect` was optional in the schema and the model frequently omitted it.

## Root causes

- **`multiSelect` was not required.**  The tool schema's question-level `required` array listed only `["question","header","options"]`, so the model could legally omit `multiSelect`.  When omitted, Go defaulted it to `false` and the frontend received `undefined` (falsy), which triggered the single-select replace branch in `toggleOption`:

  `{ ...sel, [question.id]: [label] }`  ← replaces the entire selection

- **No visual indication.**  The desktop AskCard had no checkbox, badge, or label telling the user whether the current question was multi-select or single-select.

## Changes

| File | Change |
|---|---|
| `internal/agent/ask.go` | Add `multiSelect` to the question-level `required` array; strengthen Description and field description to warn about consequences of omission |
| `desktop/frontend/src/components/AskCard.tsx` | Render a "可多选" / "Multi-select" badge in the header when `q.multi` is true |
| `desktop/frontend/src/locales/zh.ts` | Add `"ask.multiSelectBadge": "可多选"` |
| `desktop/frontend/src/locales/en.ts` | Add `"ask.multiSelectBadge": "Multi-select"` |
| `desktop/frontend/src/locales/zh-TW.ts` | Add `"ask.multiSelectBadge": "可多選"` |
| `internal/agent/ask_test.go` | Update provider contract hash after schema change |
| `internal/boot/testdata/golden/*` | Regenerate baseline files (system_prompt, tool_schemas, provider_request, prefix_shape) |

## Verification

### Automated

- `gofmt -l` → OK
- `go vet ./internal/agent/` → OK
- `go test ./internal/agent/ -run Ask` → 11/11 PASS
- `go test ./internal/boot/ -count=1` → PASS

### Manual (desktop)

- Confirmed multi-select AskCard shows the badge when `multiSelect: true`.
- Confirmed multi-select toggleOption accumulates picks correctly.
- Confirmed single-select badge is absent.

## Compatibility

| Area | Existing-data behavior | Conclusion |
|---|---|---|
| ask tool schema | `multiSelect` was optional; now required — model must always provide a boolean | Backward-compatible (existing calls that omit `multiSelect` will now fail validation; the model learns the new schema immediately) |
| Desktop i18n | New `ask.multiSelectBadge` keys added to three locale files | Backward-compatible (new keys, no existing references) |
| Golden baselines | Regenerated to match new Description and schema | Expected drift, no functional impact |

## Cache impact

Cache-impact: high — ask tool schema and description changed; golden system_prompt.txt, tool_schemas.json, provider_request.json, and prefix_shape.json all drift.  The model-facing prompt prefix will change on the first turn after this merges.

Cache-guard: go test ./internal/agent/ -run Ask -count=1, go test ./internal/boot/ -count=1

System-prompt-review: @esengine — schema required-array change and tool description increase prompt token count slightly; verify prefix cache budget.