### PR TITLE
feat(config): persist the new-session work mode via default_work_mode

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -52,6 +52,7 @@ For the desktop and CLI usage of visible reasoning language, see
 
 ```toml
 default_model = "deepseek-flash"   # executor; set [agent].planner_model to add a planner
+# default_work_mode = "delivery"   # economy|balanced|delivery; new-session default when no --profile flag is passed
 # language    = "zh"               # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
 
 [ui]

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -68,7 +68,7 @@ func acpCommand(args []string, version string) int {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "sandbox-bash must be auto or enforce")
 		return 2
 	}
-	profile, err := parseRuntimeProfile(*profileFlag)
+	profile, err := resolveRuntimeProfile(stdFlagChanged(fs, "profile"), profileFlag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 2

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -403,6 +403,34 @@ func parseRuntimeProfile(value string) (string, error) {
 	}
 }
 
+// stdFlagChanged reports whether name was explicitly set on a stdlib flag set.
+// The stdlib flag package has no Changed method, so Visit — which only visits
+// flags that were explicitly set — is the equivalent.
+func stdFlagChanged(fs *flag.FlagSet, name string) bool {
+	changed := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			changed = true
+		}
+	})
+	return changed
+}
+
+// resolveRuntimeProfile resolves the session runtime profile with
+// flag > config > default precedence: an explicit --profile wins, otherwise the
+// top-level default_work_mode config key (economy|balanced|delivery) applies,
+// otherwise the historical "balanced" default. A configured value that is not a
+// valid profile fails exactly like an invalid --profile value.
+func resolveRuntimeProfile(changed bool, profileFlag *string) (string, error) {
+	value := *profileFlag
+	if !changed {
+		if cfg, err := config.Load(); err == nil && cfg.DefaultWorkMode != "" {
+			value = cfg.DefaultWorkMode
+		}
+	}
+	return parseRuntimeProfile(value)
+}
+
 // chdirTo honours --dir: it switches the working directory before anything reads
 // it, so config discovery, the sandbox root, and file tools all resolve from the
 // chosen project root. Returns 2 (already reported) on failure, 0 otherwise.
@@ -526,11 +554,6 @@ func runAgent(args []string, version string) int {
 		}
 		format = runOutputEventsJSONL
 	}
-	profile, err := parseRuntimeProfile(*profileFlag)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 2
-	}
 	ablated, err := ablation.Parse(*ablateFlag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -553,6 +576,13 @@ func runAgent(args []string, version string) int {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
+	}
+	// Resolve the runtime profile after chdirTo so config discovery for
+	// default_work_mode follows the --dir project root.
+	profile, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
 	}
 	cfg, _ := config.Load()
 	configureCLIThemeFromConfigForTTYOutput()
@@ -821,11 +851,6 @@ func runServe(args []string) int {
 	if code, ok := parseCommandFlags(fs, args); !ok {
 		return code
 	}
-	profile, err := parseRuntimeProfile(*profileFlag)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 2
-	}
 
 	// --hash-password: generate a bcrypt hash and exit.
 	if *hashPassword {
@@ -840,6 +865,14 @@ func runServe(args []string) int {
 		}
 		fmt.Println(h)
 		return 0
+	}
+
+	// Resolve the runtime profile before building the controller; config
+	// discovery for default_work_mode runs from the current working directory.
+	profile, err := resolveRuntimeProfile(stdFlagChanged(fs, "profile"), profileFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
 	}
 
 	ctx := context.Background()
@@ -1053,11 +1086,6 @@ func chatREPL(args []string, version string) int {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 2
 	}
-	profile, err := parseRuntimeProfile(*profileFlag)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 2
-	}
 	permissions, err := parsePermissionMode(*permissionMode)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -1071,6 +1099,13 @@ func chatREPL(args []string, version string) int {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		return 1
+	}
+	// Resolve the runtime profile after chdirTo so config discovery for
+	// default_work_mode follows the --dir project root.
+	profile, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
 	}
 	// Bubble Tea owns the terminal from the resume picker through controller
 	// shutdown. Start diagnostics before config/controller work so hangs leave a

--- a/internal/cli/default_work_mode_test.go
+++ b/internal/cli/default_work_mode_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+
+	"reasonix/internal/config"
+)
+
+// writeDefaultWorkModeConfig writes a user config.toml that sets the top-level
+// default_work_mode key inside the isolated config home.
+func writeDefaultWorkModeConfig(t *testing.T, value string) {
+	t.Helper()
+	path := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "config_version = 2\n"
+	if value != "" {
+		body += "default_work_mode = " + quoteTOML(value) + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func quoteTOML(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}
+
+func TestResolveRuntimeProfileUsesConfigDefault(t *testing.T) {
+	isolateCLIConfigHome(t)
+	writeDefaultWorkModeConfig(t, "delivery")
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+
+	got, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		t.Fatalf("resolveRuntimeProfile: %v", err)
+	}
+	if got != "delivery" {
+		t.Fatalf("profile = %q, want delivery from default_work_mode", got)
+	}
+}
+
+func TestResolveRuntimeProfileDefaultsBalancedWithoutConfig(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+
+	got, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		t.Fatalf("resolveRuntimeProfile: %v", err)
+	}
+	if got != "full" {
+		t.Fatalf("profile = %q, want full (balanced default)", got)
+	}
+}
+
+func TestResolveRuntimeProfileExplicitFlagWinsOverConfig(t *testing.T) {
+	isolateCLIConfigHome(t)
+	writeDefaultWorkModeConfig(t, "delivery")
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+	if err := fs.Set("profile", "balanced"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		t.Fatalf("resolveRuntimeProfile: %v", err)
+	}
+	if got != "full" {
+		t.Fatalf("profile = %q, want full: explicit --profile must override default_work_mode", got)
+	}
+}
+
+func TestResolveRuntimeProfileStdlibFlagSet(t *testing.T) {
+	// runServe and acpCommand register --profile on the stdlib flag set; the
+	// same precedence must apply there.
+	isolateCLIConfigHome(t)
+	writeDefaultWorkModeConfig(t, "economy")
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+
+	got, err := resolveRuntimeProfile(stdFlagChanged(fs, "profile"), profileFlag)
+	if err != nil {
+		t.Fatalf("resolveRuntimeProfile: %v", err)
+	}
+	if got != "economy" {
+		t.Fatalf("profile = %q, want economy from default_work_mode", got)
+	}
+}
+
+func TestResolveRuntimeProfileInvalidConfigValueFails(t *testing.T) {
+	isolateCLIConfigHome(t)
+	writeDefaultWorkModeConfig(t, "bogus")
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+
+	if _, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag); err == nil {
+		t.Fatal("resolveRuntimeProfile succeeded with invalid default_work_mode, want error")
+	}
+}
+
+func TestResolveRuntimeProfileReadsProjectConfigAfterChdir(t *testing.T) {
+	// runAgent/chatREPL resolve the profile after chdirTo, so a project-level
+	// reasonix.toml (as --dir would land in) must feed default_work_mode.
+	isolateCLIConfigHome(t)
+	cwd := mustGetwd(t)
+	if err := os.WriteFile(filepath.Join(cwd, "reasonix.toml"), []byte("default_work_mode = \"delivery\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+
+	got, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag)
+	if err != nil {
+		t.Fatalf("resolveRuntimeProfile: %v", err)
+	}
+	if got != "delivery" {
+		t.Fatalf("profile = %q, want delivery from project reasonix.toml", got)
+	}
+}
+
+func TestResolveRuntimeProfileInvalidFlagValueStillFails(t *testing.T) {
+	isolateCLIConfigHome(t)
+	writeDefaultWorkModeConfig(t, "delivery")
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	profileFlag := fs.String("profile", "balanced", "runtime profile")
+	if err := fs.Set("profile", "bogus"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := resolveRuntimeProfile(fs.Changed("profile"), profileFlag); err == nil {
+		t.Fatal("resolveRuntimeProfile succeeded with invalid --profile, want error")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,8 @@ func SkillNameKey(name string) string {
 type Config struct {
 	ConfigVersion    int                 `toml:"config_version"`
 	DefaultModel     string              `toml:"default_model"`
-	Language         string              `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
+	DefaultWorkMode  string              `toml:"default_work_mode"` // economy|balanced|delivery; used when no --profile flag is passed
+	Language         string              `toml:"language"`          // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
 	CredentialsStore string              `toml:"credentials_store"`
 	UI               UIConfig            `toml:"ui"`
 	CLI              CLIConfig           `toml:"cli"`

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -51,6 +51,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 
 	fmt.Fprintf(&b, "config_version = %d   # schema marker for diagnostics; old versions may ignore it\n", configVersion(c))
 	fmt.Fprintf(&b, "default_model = %q\n", c.DefaultModel)
+	if c.DefaultWorkMode != "" {
+		fmt.Fprintf(&b, "default_work_mode = %q   # economy|balanced|delivery; used when no --profile flag is passed\n", c.DefaultWorkMode)
+	}
 	if c.Language != "" {
 		fmt.Fprintf(&b, "language      = %q   # ui/model language; empty = auto-detect from $LANG / $REASONIX_LANG\n", c.Language)
 	} else {
@@ -827,6 +830,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 	}
 	if c.DefaultModel != d.DefaultModel {
 		fmt.Fprintf(&b, "default_model = %q\n", c.DefaultModel)
+	}
+	if c.DefaultWorkMode != "" && c.DefaultWorkMode != d.DefaultWorkMode {
+		fmt.Fprintf(&b, "default_work_mode = %q\n", c.DefaultWorkMode)
 	}
 	if c.Language != "" && c.Language != d.Language {
 		fmt.Fprintf(&b, "language = %q\n", c.Language)

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -5,6 +5,7 @@
 # Reasonix's global <Reasonix home>/.env. Never put API key values here.
 
 default_model = "deepseek"   # a provider name (→ its default model) or "provider/model"
+# default_work_mode = "delivery"   # economy|balanced|delivery; new-session default when no --profile flag is passed (balanced = today's default)
 # language      = "zh"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
 
 [ui]


### PR DESCRIPTION
Adds the top-level default_work_mode key (economy|balanced|delivery) so new sessions start in the configured runtime profile when no --profile flag is passed, mirroring the existing default_model/default_effort persistence. Explicit --profile still wins (flag > config > balanced default); invalid configured values fail exactly like invalid --profile values.

Resolves #7658

Summary
- New Config.DefaultWorkMode field + TOML parsing (internal/config/config.go)
- Render the key in full and project-delta config output (internal/config/render.go)
- resolveRuntimeProfile: flag > config > default precedence, wired into runAgent / runServe / chatREPL after chdirTo so --dir project config is honored (internal/cli/cli.go)
- Same wiring for the ACP server (internal/cli/acp.go)
- 7 new tests covering config default, balanced fallback, explicit flag override, stdlib FlagSet path, invalid values, and project config after chdir (internal/cli/default_work_mode_test.go)
- Docs: reasonix.example.toml + docs/GUIDE.md

Issues
- Fixes #7658

Verification
- go test ./internal/cli/ ./internal/config/ — all pass
- gofmt / go vet — clean
- E2E against a local fake OpenAI provider: default_work_mode = "delivery" injects the <delivery-profile> prompt block (8207 vs 7700 chars); explicit --profile balanced overrides the config; invalid configured value fails at startup exactly like an invalid --profile value

Documentation impact
Documentation-impact: updated - documents the new default_work_mode key in docs/GUIDE.md and reasonix.example.toml.

Cache impact
Cache-impact: none - the new key only selects the pre-existing profile path at session start; no system-prompt prefix bytes, tool schemas, or cache behavior change.
Cache-guard: go test ./internal/cli/ ./internal/config/ - the change does not touch boot/tool/provider prompt construction.
System-prompt-review: author-verified against the cache-stable prefix contract - no system prompt, memory prefix, output style, or skill index bytes change; delivery/economy injection is the pre-existing --profile path, untouched; maintainer review welcome.
