### PR TITLE
refactor(agent): group per-turn host flags into an embedded perTurnState

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -368,10 +368,6 @@ type Agent struct {
 	// recoveryTaskID isolates recovery state across concurrent top-level tasks.
 	// Empty shares the root task bucket.
 	recoveryTaskID string
-	// recoveryTaskSummary is the bounded task text for this Agent.Run. It lets a
-	// shared recovery gate review sub-agent mutations against the child task,
-	// rather than the root controller transcript.
-	recoveryTaskSummary string
 	// recoveryRunSeq gives ordinary (non-goal) runs a collision-free host scope.
 	// Goal runs use their stable delivery scope instead.
 	recoveryRunSeq atomic.Uint64
@@ -466,16 +462,18 @@ type Agent struct {
 
 	// deliveryProfile enables the runtime-enforced delivery contract. The stable
 	// profile prompt explains intent; these fields are host state and never enter
-	// the provider-cached prefix. deliveryCriteriaEstablished resets per user turn
-	// but may inherit an unfinished canonical task list on continuation.
-	deliveryProfile             bool
-	deliveryCriteriaEstablished bool
-	deliveryTaskExpected        bool
-	deliveryMutationExpected    bool
-	deliveryPersistentExpected  bool
-	deliveryScopeID             string
-	deliveryScopeActive         bool
-	deliveryCheckpoint          evidence.DeliveryCheckpoint
+	// the provider-cached prefix. deliveryScopeID and deliveryCheckpoint survive
+	// turns while a stable delivery scope continues; the per-turn expectations
+	// live in perTurnState.
+	deliveryProfile    bool
+	deliveryScopeID    string
+	deliveryCheckpoint evidence.DeliveryCheckpoint
+
+	// perTurnState groups the host flags that are valid for exactly one
+	// Agent.Run. beginRunTurn zeroes the whole struct in one assignment, so a
+	// field added here can never be forgotten in the reset; state that must
+	// survive turns stays directly on Agent.
+	perTurnState
 
 	// ablation names the subsystems a benchmark arm switched off. The zero value
 	// is the control arm.
@@ -495,10 +493,6 @@ type Agent struct {
 	// readiness. An explicit host recovery action can consume it to preserve the
 	// failed turn's receipts once; an ordinary user turn still resets evidence.
 	deliveryRecoveryPending bool
-	// readinessRecovered marks a run that started with evidence preserved from
-	// (or a pending recovery of) a prior readiness failure, so the final allowed
-	// audit can report Recovered=true. Set per turn in beginRunTurn.
-	readinessRecovered bool
 
 	// capabilityLedger tracks require/prefer outcomes for this user turn only.
 	// Never serialized into prompts or session state.
@@ -561,34 +555,6 @@ type Agent struct {
 	// See applyStormBreaker.
 	stormSig   string
 	stormCount int
-
-	// blockedTurnStreak counts consecutive turns in which every tool call was
-	// blocked by the host (permission, plan mode, hook, or loop guard).
-	// stormSig catches a model fixated on one call shape; this catches a model
-	// rotating between blocked shapes — alternating tools, reordering a batch,
-	// or blockers whose text varies per attempt — which is zero progress all
-	// the same. Reset by any turn containing a non-blocked outcome and at the
-	// start of each user turn. See applyStormBreaker.
-	blockedTurnStreak int
-
-	// loopGuardArmed / loopGuardReceiptMark let final readiness stand down
-	// after a loop guard fired this user turn: once the host has told the model
-	// to stop retrying and report the blocker, demanding the receipts that the
-	// blocker prevents would restart the loop the guard just broke. The mark is
-	// the evidence-ledger receipt count from just before the guarded batch, so
-	// real progress — a successful write or command receipt landing after it —
-	// revokes the pass, while the bookkeeping the guard itself recommends
-	// (ask, todo_write, complete_step) keeps it. Host state, not message text:
-	// tool output that merely quotes "[loop guard]" must not unlock readiness.
-	// Reset at the start of each user turn. See loopGuardAllowsFinal.
-	loopGuardArmed       bool
-	loopGuardReceiptMark int
-
-	// repeatSuccessCounts tracks write-like tool calls that have already
-	// succeeded in this user turn. This catches the complementary loop shape to
-	// stormSig: a model keeps doing the same successful write, so there is no
-	// error for the failure-only storm breaker to see.
-	repeatSuccessCounts map[string]int
 
 	// repeatFailureCounts tracks semantically identical write-like calls that
 	// keep failing with the same failure class. Unlike stormSig, successful

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -44,6 +44,61 @@ type runLoopState struct {
 	workDurationMs func() int64
 }
 
+// perTurnState is the host state valid for exactly one Agent.Run, embedded in
+// Agent so field access stays flat while the lifetime is explicit. beginRunTurn
+// zeroes it in a single assignment before computing the new turn's values; a
+// field added here can never be forgotten in the reset. Anything that must
+// survive turns (delivery checkpoint/scope, failure budgets, storm counters)
+// stays directly on Agent.
+type perTurnState struct {
+	// Delivery expectations classified from the task text (see taskintent).
+	// deliveryCriteriaEstablished may inherit an unfinished canonical task
+	// list on continuation, but the flag itself is recomputed every turn.
+	deliveryCriteriaEstablished bool
+	deliveryTaskExpected        bool
+	deliveryMutationExpected    bool
+	deliveryPersistentExpected  bool
+	deliveryScopeActive         bool
+
+	// readinessRecovered marks a run that started with evidence preserved from
+	// (or a pending recovery of) a prior readiness failure, so the final
+	// allowed audit can report Recovered=true.
+	readinessRecovered bool
+
+	// recoveryTaskSummary is the bounded task text for this Agent.Run. It lets
+	// a shared recovery gate review sub-agent mutations against the child
+	// task, rather than the root controller transcript.
+	recoveryTaskSummary string
+
+	// blockedTurnStreak counts consecutive turns in which every tool call was
+	// blocked by the host (permission, plan mode, hook, or loop guard).
+	// stormSig catches a model fixated on one call shape; this catches a model
+	// rotating between blocked shapes — alternating tools, reordering a batch,
+	// or blockers whose text varies per attempt — which is zero progress all
+	// the same. Reset by any turn containing a non-blocked outcome and at the
+	// start of each user turn. See applyStormBreaker.
+	blockedTurnStreak int
+
+	// loopGuardArmed / loopGuardReceiptMark let final readiness stand down
+	// after a loop guard fired this user turn: once the host has told the model
+	// to stop retrying and report the blocker, demanding the receipts that the
+	// blocker prevents would restart the loop the guard just broke. The mark is
+	// the evidence-ledger receipt count from just before the guarded batch, so
+	// real progress — a successful write or command receipt landing after it —
+	// revokes the pass, while the bookkeeping the guard itself recommends
+	// (ask, todo_write, complete_step) keeps it. Host state, not message text:
+	// tool output that merely quotes "[loop guard]" must not unlock readiness.
+	// See loopGuardAllowsFinal.
+	loopGuardArmed       bool
+	loopGuardReceiptMark int
+
+	// repeatSuccessCounts tracks write-like tool calls that have already
+	// succeeded in this user turn. This catches the complementary loop shape to
+	// stormSig: a model keeps doing the same successful write, so there is no
+	// error for the failure-only storm breaker to see.
+	repeatSuccessCounts map[string]int
+}
+
 // streamedTurn is one provider completion collected by stream. Keeping the
 // result together makes the missing-reasoning recovery path explicit: the
 // first, malformed completion is never committed before a safe replacement is
@@ -138,6 +193,10 @@ func (s *deferredStreamSink) Discard() {
 func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string, state *runLoopState) {
 	rawInput = RawUserInput(ctx, input)
 	providerInput := input
+	// A fresh user turn starts from zeroed per-turn host state; the new turn's
+	// values are computed below. Cross-turn state (checkpoint, scope, failure
+	// budgets) lives directly on Agent and is reconciled field by field.
+	a.perTurnState = perTurnState{}
 	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
 	preserveEvidence := a.preserveEvidenceOnce
 	// A run that starts with a pending readiness recovery (or an explicit
@@ -216,7 +275,6 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// transcript tail. Fold its bounded facts into this new user turn exactly
 	// once; the user's raw text remains the classifier source above.
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
-	a.repeatSuccessCounts = nil
 	if !scoped || a.repeatFailureScope != scope.ID {
 		a.repeatFailureCounts = nil
 	} else {
@@ -234,9 +292,6 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	} else {
 		a.repeatFailureScope = ""
 	}
-	a.blockedTurnStreak = 0
-	a.loopGuardArmed = false
-	a.loopGuardReceiptMark = 0
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
 	input = a.withTurnPreferences(providerInput)
 	userCreatedAt := time.Now().UnixMilli()


### PR DESCRIPTION
Continues the agent god-object cleanup (#7786, #7788). Agent had ~99 flat fields; eleven of them are host state valid for exactly one Agent.Run, reset one by one in beginRunTurn — adding such a field meant remembering to reset it by hand.

## What

- New `perTurnState` struct (run_loop.go) embedded in Agent: delivery expectations (`deliveryCriteriaEstablished/TaskExpected/MutationExpected/PersistentExpected/ScopeActive`), `readinessRecovered`, `recoveryTaskSummary`, `blockedTurnStreak`, `loopGuardArmed`/`loopGuardReceiptMark`, `repeatSuccessCounts`.
- beginRunTurn zeroes the whole struct in a single assignment before computing the new turn's values; the scattered hand-resets are deleted. A field added to perTurnState can never be forgotten in the reset.
- Field promotion keeps every existing access site (`a.deliveryTaskExpected` etc.) unchanged — the diff is ±60 lines of declarations, no call-graph changes.
- Deliberately NOT moved (cross-turn by design): `deliveryScopeID`, `deliveryCheckpoint`, `deliveryRecoveryPending`, `preserveEvidenceOnce`, `repeatFailureCounts/Scope`, `stormSig/stormCount`, `missingReasoning*`.

## Verification

- `gofmt` clean, `go vet ./internal/agent/...` clean
- `go test -race ./internal/agent/` green
- Full `go test ./...` green (English locale)

Cache-impact: none - host-side field grouping; no provider request shaping, cache_control, or usage accounting paths touched.
Cache-guard: existing coverage - cache_shape_test.go and the full agent race suite pass unchanged.
Documentation-impact: none - internal state reorganization with identical behavior; no docs describe these fields.