### PR TITLE
refactor(control): extract autoResearchManager collaborator

### DIFF
--- a/internal/control/autoresearch_manager.go
+++ b/internal/control/autoresearch_manager.go
@@ -1,0 +1,405 @@
+package control
+
+// AutoResearch task lifecycle: creating/resuming tasks for research-mode
+// goals, recording per-turn evidence and direction, and reporting readiness.
+// autoResearchManager is a strict leaf over the workspace autoresearch.Store —
+// it never touches Controller state; the Controller wrappers below resolve the
+// active task from the goal machine and own notices.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/autoresearch"
+)
+
+type autoResearchSetup struct {
+	taskID      string
+	createToken string
+	blockReason string
+	notice      string
+	created     bool
+}
+
+// autoResearchManager wraps the optional workspace autoresearch.Store. The
+// zero value (no store) disables the subsystem; every method is nil-safe.
+type autoResearchManager struct {
+	store *autoresearch.Store
+}
+
+func (m autoResearchManager) enabled() bool {
+	return m.store != nil
+}
+
+// prepare resumes the task matching goal text or creates a fresh one. The
+// caller has already decided AutoResearch applies and that no running goal
+// owns the task.
+func (m autoResearchManager) prepare(goal, createToken string) autoResearchSetup {
+	if m.store == nil {
+		return autoResearchSetup{}
+	}
+	if task, ok, err := m.store.ResumeFromGoalText(goal); err != nil {
+		slog.Warn("controller: resume autoresearch task", "err", err)
+		if ok {
+			return autoResearchSetup{blockReason: err.Error()}
+		}
+	} else if ok {
+		return autoResearchSetup{taskID: task.ID, notice: "autoresearch task resumed: " + task.ID}
+	}
+	task, err := m.store.CreateTask(goal, autoresearch.CreateOptions{
+		CreateToken: createToken,
+		AllowedOperations: autoresearch.AllowedOperations{
+			Write:   true,
+			Network: false,
+			Publish: false,
+		},
+		SuccessCriteria: defaultAutoResearchSuccessCriteria(),
+	})
+	if err != nil {
+		slog.Warn("controller: create autoresearch task", "err", err)
+		return autoResearchSetup{}
+	}
+	return autoResearchSetup{
+		taskID:      task.ID,
+		createToken: task.CreateToken,
+		notice:      "autoresearch task created: " + task.ID,
+		created:     true,
+	}
+}
+
+func (m autoResearchManager) removeTask(taskID, createToken string) error {
+	if m.store == nil {
+		return nil
+	}
+	return m.store.RemoveTask(taskID, createToken)
+}
+
+func (m autoResearchManager) heartbeat(taskID, status, message string) {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return
+	}
+	iteration := 0
+	if summary, err := m.store.Summary(taskID); err == nil {
+		iteration = summary.Iteration
+	}
+	if err := m.store.AppendHeartbeat(taskID, autoresearch.Heartbeat{
+		Status:    status,
+		Iteration: iteration,
+		Message:   message,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		slog.Warn("controller: append autoresearch heartbeat", "task_id", taskID, "status", status, "err", err)
+	}
+}
+
+func (m autoResearchManager) acceptedEvidenceIDs(taskID string) map[string]bool {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return nil
+	}
+	findings, err := m.store.Findings(taskID, 0)
+	if err != nil {
+		slog.Warn("controller: read autoresearch findings", "task_id", taskID, "err", err)
+		return nil
+	}
+	accepted := make(map[string]bool, len(findings))
+	for _, finding := range findings {
+		if finding.Accepted {
+			accepted[finding.ID] = true
+		}
+	}
+	return accepted
+}
+
+// recordTurnProgress records the turn's direction: which evidence IDs became
+// accepted since acceptedBefore, summarized from the assistant's final text.
+func (m autoResearchManager) recordTurnProgress(taskID string, acceptedBefore map[string]bool, assistantText string) {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return
+	}
+	acceptedAfter := m.acceptedEvidenceIDs(taskID)
+	newAccepted := make([]string, 0)
+	for id := range acceptedAfter {
+		if acceptedBefore == nil || !acceptedBefore[id] {
+			newAccepted = append(newAccepted, id)
+		}
+	}
+	sort.Strings(newAccepted)
+	if _, err := m.store.RecordDirection(taskID, autoresearch.Direction{
+		Summary:             autoResearchDirectionSummary(assistantText),
+		AcceptedEvidenceIDs: newAccepted,
+		Now:                 time.Now().UTC(),
+	}); err != nil {
+		slog.Warn("controller: record autoresearch direction", "task_id", taskID, "err", err)
+	}
+}
+
+func (m autoResearchManager) recordEvidenceFromAssistant(taskID, text string) {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return
+	}
+	for _, item := range parseAutoResearchEvidenceBlocks(text) {
+		if err := m.recordEvidence(taskID, item.CriterionID, AutoResearchEvidenceInput{
+			ID:       item.ID,
+			Kind:     item.Kind,
+			Summary:  item.Summary,
+			Source:   item.Source,
+			Command:  item.Command,
+			Paths:    append([]string(nil), item.Paths...),
+			Accepted: item.Accepted,
+		}); err != nil {
+			slog.Warn("controller: record autoresearch evidence block", "task_id", taskID, "criterion_id", item.CriterionID, "err", err)
+		}
+	}
+}
+
+func (m autoResearchManager) recordEvidence(taskID, criterionID string, input AutoResearchEvidenceInput) error {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return errors.New("autoresearch: no active task")
+	}
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		id = m.nextFindingID(taskID)
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = autoresearch.FindingKindManual
+	}
+	source := strings.TrimSpace(input.Source)
+	if source == "" {
+		source = autoresearch.FindingSourceManual
+	}
+	finding := autoresearch.Finding{
+		ID:        id,
+		Kind:      kind,
+		Summary:   strings.TrimSpace(input.Summary),
+		Source:    source,
+		Command:   strings.TrimSpace(input.Command),
+		Paths:     append([]string(nil), input.Paths...),
+		Accepted:  input.Accepted,
+		CreatedAt: time.Now().UTC(),
+	}
+	return m.store.RecordEvidence(taskID, criterionID, finding)
+}
+
+func (m autoResearchManager) nextFindingID(taskID string) string {
+	findings, err := m.store.Findings(taskID, 0)
+	if err != nil {
+		return fmt.Sprintf("f%d", time.Now().UTC().UnixNano())
+	}
+	used := make(map[string]bool, len(findings))
+	for _, finding := range findings {
+		used[finding.ID] = true
+	}
+	for i := 1; ; i++ {
+		id := fmt.Sprintf("f%d", len(findings)+i)
+		if !used[id] {
+			return id
+		}
+	}
+}
+
+func (m autoResearchManager) readinessFailure(taskID string) string {
+	if m.store == nil || strings.TrimSpace(taskID) == "" {
+		return ""
+	}
+	report, err := m.store.Readiness(taskID)
+	if err != nil {
+		return "AutoResearch readiness check failed: " + err.Error()
+	}
+	if report.Ready {
+		return ""
+	}
+	var parts []string
+	if len(report.MissingCriteria) > 0 {
+		parts = append(parts, "missing criteria: "+strings.Join(report.MissingCriteria, ", "))
+	}
+	if report.BlockedReason != "" {
+		parts = append(parts, "blocked: "+report.BlockedReason)
+	}
+	if len(report.Errors) > 0 {
+		parts = append(parts, "state errors: "+strings.Join(report.Errors, "; "))
+	}
+	if len(parts) == 0 {
+		parts = append(parts, "task is not ready")
+	}
+	return "AutoResearch readiness check failed: " + strings.Join(parts, "; ")
+}
+
+func (m autoResearchManager) summary(taskID string) (*autoresearch.Summary, error) {
+	if m.store == nil {
+		return nil, errors.New("autoresearch: disabled")
+	}
+	return m.store.Summary(taskID)
+}
+
+func (m autoResearchManager) listSummaries() ([]autoresearch.Summary, error) {
+	if m.store == nil {
+		return nil, errors.New("autoresearch: disabled")
+	}
+	return m.store.ListSummaries()
+}
+
+func (m autoResearchManager) findings(taskID string, limit int) ([]autoresearch.Finding, error) {
+	if m.store == nil {
+		return nil, errors.New("autoresearch: disabled")
+	}
+	return m.store.Findings(taskID, limit)
+}
+
+func (m autoResearchManager) updateProgress(taskID string, patch autoresearch.ProgressPatch) error {
+	if m.store == nil {
+		return nil
+	}
+	_, err := m.store.UpdateProgress(taskID, patch)
+	return err
+}
+
+func defaultAutoResearchSuccessCriteria() []autoresearch.SuccessCriterion {
+	return []autoresearch.SuccessCriterion{
+		{
+			ID:          "objective_evidence",
+			Description: "The goal outcome is supported by direct evidence, such as inspected code, reproduced behavior, source material, or concrete findings.",
+			Required:    true,
+		},
+		{
+			ID:          "verification",
+			Description: "The result has relevant verification evidence, such as tests, commands, benchmarks, manual checks, or a documented reason why verification is not applicable.",
+			Required:    true,
+		},
+	}
+}
+
+type autoResearchEvidenceBlock struct {
+	CriterionID string   `json:"criterion_id"`
+	ID          string   `json:"id"`
+	Kind        string   `json:"kind"`
+	Summary     string   `json:"summary"`
+	Source      string   `json:"source"`
+	Command     string   `json:"command"`
+	Paths       []string `json:"paths"`
+	Accepted    bool     `json:"accepted"`
+}
+
+const (
+	autoResearchEvidenceOpen  = "<autoresearch-evidence>"
+	autoResearchEvidenceClose = "</autoresearch-evidence>"
+)
+
+func parseAutoResearchEvidenceBlocks(text string) []autoResearchEvidenceBlock {
+	var out []autoResearchEvidenceBlock
+	rest := text
+	for {
+		start := strings.Index(rest, autoResearchEvidenceOpen)
+		if start < 0 {
+			return out
+		}
+		rest = rest[start+len(autoResearchEvidenceOpen):]
+		end := strings.Index(rest, autoResearchEvidenceClose)
+		if end < 0 {
+			return out
+		}
+		raw := strings.TrimSpace(rest[:end])
+		rest = rest[end+len(autoResearchEvidenceClose):]
+		if raw == "" {
+			continue
+		}
+		var many []autoResearchEvidenceBlock
+		if err := json.Unmarshal([]byte(raw), &many); err == nil {
+			out = append(out, many...)
+			continue
+		}
+		var one autoResearchEvidenceBlock
+		if err := json.Unmarshal([]byte(raw), &one); err == nil {
+			out = append(out, one)
+		}
+	}
+}
+
+func autoResearchDirectionSummary(text string) string {
+	text = agent.StripAutoResearchEvidenceBlocks(text)
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		lower := strings.ToLower(line)
+		if line == "" || strings.HasPrefix(lower, "[goal:") {
+			continue
+		}
+		if len(line) > 160 {
+			line = line[:160]
+		}
+		return line
+	}
+	return "turn completed"
+}
+
+// Controller-side glue: resolve the active task via the goal machine, then
+// delegate to the leaf manager.
+
+func (c *Controller) prepareAutoResearchTask(goal string, researchMode GoalResearchMode, createToken string) autoResearchSetup {
+	goal = strings.TrimSpace(goal)
+	if goal == "" || !c.autoResearch.enabled() || !shouldUseAutoResearch(goal, researchMode) {
+		return autoResearchSetup{}
+	}
+	currentGoal, currentStatus, _, currentTaskID := c.goals.snapshot()
+	if strings.TrimSpace(currentGoal) == goal && currentStatus == GoalStatusRunning && strings.TrimSpace(currentTaskID) != "" {
+		return autoResearchSetup{taskID: currentTaskID}
+	}
+	return c.autoResearch.prepare(goal, createToken)
+}
+
+func (c *Controller) autoResearchReadinessFailure() string {
+	return c.autoResearch.readinessFailure(c.goals.currentAutoResearchTaskID())
+}
+
+func (c *Controller) AutoResearchSummary() (*autoresearch.Summary, bool) {
+	taskID := c.goals.currentAutoResearchTaskID()
+	if !c.autoResearch.enabled() || strings.TrimSpace(taskID) == "" {
+		return nil, false
+	}
+	summary, err := c.autoResearch.summary(taskID)
+	if err != nil {
+		return &autoresearch.Summary{
+			TaskID:  taskID,
+			Status:  autoresearch.StatusInvalid,
+			Blocker: err.Error(),
+		}, true
+	}
+	return summary, true
+}
+
+func (c *Controller) AutoResearchList() ([]autoresearch.Summary, bool) {
+	if !c.autoResearch.enabled() {
+		return nil, false
+	}
+	summaries, err := c.autoResearch.listSummaries()
+	if err != nil {
+		slog.Warn("controller: list autoresearch tasks", "err", err)
+		return nil, true
+	}
+	return summaries, true
+}
+
+func (c *Controller) AutoResearchFindings(limit int) ([]autoresearch.Finding, bool) {
+	taskID := c.goals.currentAutoResearchTaskID()
+	if !c.autoResearch.enabled() || strings.TrimSpace(taskID) == "" {
+		return nil, false
+	}
+	findings, err := c.autoResearch.findings(taskID, limit)
+	if err != nil {
+		return nil, true
+	}
+	return findings, true
+}
+
+func (c *Controller) RecordAutoResearchEvidence(criterionID string, input AutoResearchEvidenceInput) error {
+	taskID := c.goals.currentAutoResearchTaskID()
+	if !c.autoResearch.enabled() || strings.TrimSpace(taskID) == "" {
+		return errors.New("autoresearch: no active task")
+	}
+	return c.autoResearch.recordEvidence(taskID, criterionID, input)
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -202,8 +202,11 @@ type Controller struct {
 	// goals owns the active goal's FSM (status, intercepts, idle/turn counters)
 	// and its persistence, behind its own mutex so a per-turn goal save never
 	// stalls an approval or status poll on c.mu. See goal.go.
-	goals        goalMachine
-	autoResearch *autoresearch.Store
+	goals goalMachine
+	// autoResearch wraps the workspace autoresearch.Store as a strict-leaf
+	// collaborator; goal/task resolution stays on Controller. See
+	// autoresearch_manager.go.
+	autoResearch autoResearchManager
 
 	// workspaceRoot is the workspace root: the base for resolving @-refs and slash
 	// path refs, the working directory for user "!" shell commands and custom
@@ -613,7 +616,7 @@ func New(opts Options) *Controller {
 	c.sessionTemp.Retain()
 
 	if strings.TrimSpace(opts.WorkspaceRoot) != "" {
-		c.autoResearch = autoresearch.NewStore(opts.WorkspaceRoot)
+		c.autoResearch = autoResearchManager{store: autoresearch.NewStore(opts.WorkspaceRoot)}
 	}
 	if opts.Extensions != nil {
 		c.extensions = opts.Extensions
@@ -2713,8 +2716,8 @@ func (c *Controller) SetGoalDurable(goal, autoResearchCreateToken string) error 
 	if persist {
 		if err := c.goals.writeStateErr(path, data); err != nil {
 			c.goals.restore(snapshot)
-			if setup.created && c.autoResearch != nil {
-				if removeErr := c.autoResearch.RemoveTask(setup.taskID, setup.createToken); removeErr != nil {
+			if setup.created && c.autoResearch.enabled() {
+				if removeErr := c.autoResearch.removeTask(setup.taskID, setup.createToken); removeErr != nil {
 					slog.Warn("controller: rollback autoresearch task", "task_id", setup.taskID, "err", removeErr)
 				}
 			}
@@ -2806,8 +2809,8 @@ func (c *Controller) goalEvaluatorEvidence() goaleval.GoalEvidence {
 		}
 		ev.TodoSummary = fmt.Sprintf("todos: %d total, %d incomplete; delivery readiness: %s", len(todos), incomplete, readinessText)
 	}
-	if c.autoResearch != nil && strings.TrimSpace(taskID) != "" {
-		if summary, err := c.autoResearch.Summary(taskID); err == nil {
+	if c.autoResearch.enabled() && strings.TrimSpace(taskID) != "" {
+		if summary, err := c.autoResearch.summary(taskID); err == nil {
 			ev.AutoResearchSummary = fmt.Sprintf("task %s: iteration %d, %d open success criteria, next required action: %s",
 				summary.TaskID, summary.Iteration, len(summary.OpenCriteria), summary.NextRequiredAction)
 		}
@@ -2834,328 +2837,6 @@ func (c *Controller) persistGoalDeliveryCheckpoint() {
 	checkpoint := c.executor.DeliveryCheckpoint()
 	path, data, ok := c.goals.setDeliveryCheckpoint(checkpoint, c.goalTodos())
 	c.persistGoalState(path, data, ok)
-}
-
-type autoResearchSetup struct {
-	taskID      string
-	createToken string
-	blockReason string
-	notice      string
-	created     bool
-}
-
-func (c *Controller) prepareAutoResearchTask(goal string, researchMode GoalResearchMode, createToken string) autoResearchSetup {
-	goal = strings.TrimSpace(goal)
-	if goal == "" || c.autoResearch == nil || !shouldUseAutoResearch(goal, researchMode) {
-		return autoResearchSetup{}
-	}
-	currentGoal, currentStatus, _, currentTaskID := c.goals.snapshot()
-	if strings.TrimSpace(currentGoal) == goal && currentStatus == GoalStatusRunning && strings.TrimSpace(currentTaskID) != "" {
-		return autoResearchSetup{taskID: currentTaskID}
-	}
-	if task, ok, err := c.autoResearch.ResumeFromGoalText(goal); err != nil {
-		slog.Warn("controller: resume autoresearch task", "err", err)
-		if ok {
-			return autoResearchSetup{blockReason: err.Error()}
-		}
-	} else if ok {
-		return autoResearchSetup{taskID: task.ID, notice: "autoresearch task resumed: " + task.ID}
-	}
-	task, err := c.autoResearch.CreateTask(goal, autoresearch.CreateOptions{
-		CreateToken: createToken,
-		AllowedOperations: autoresearch.AllowedOperations{
-			Write:   true,
-			Network: false,
-			Publish: false,
-		},
-		SuccessCriteria: defaultAutoResearchSuccessCriteria(),
-	})
-	if err != nil {
-		slog.Warn("controller: create autoresearch task", "err", err)
-		return autoResearchSetup{}
-	}
-	return autoResearchSetup{
-		taskID:      task.ID,
-		createToken: task.CreateToken,
-		notice:      "autoresearch task created: " + task.ID,
-		created:     true,
-	}
-}
-
-func defaultAutoResearchSuccessCriteria() []autoresearch.SuccessCriterion {
-	return []autoresearch.SuccessCriterion{
-		{
-			ID:          "objective_evidence",
-			Description: "The goal outcome is supported by direct evidence, such as inspected code, reproduced behavior, source material, or concrete findings.",
-			Required:    true,
-		},
-		{
-			ID:          "verification",
-			Description: "The result has relevant verification evidence, such as tests, commands, benchmarks, manual checks, or a documented reason why verification is not applicable.",
-			Required:    true,
-		},
-	}
-}
-
-func (c *Controller) appendAutoResearchHeartbeat(taskID, status, message string) {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return
-	}
-	iteration := 0
-	if summary, err := c.autoResearch.Summary(taskID); err == nil {
-		iteration = summary.Iteration
-	}
-	if err := c.autoResearch.AppendHeartbeat(taskID, autoresearch.Heartbeat{
-		Status:    status,
-		Iteration: iteration,
-		Message:   message,
-		CreatedAt: time.Now().UTC(),
-	}); err != nil {
-		slog.Warn("controller: append autoresearch heartbeat", "task_id", taskID, "status", status, "err", err)
-	}
-}
-
-func (c *Controller) autoResearchAcceptedEvidenceIDs(taskID string) map[string]bool {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return nil
-	}
-	findings, err := c.autoResearch.Findings(taskID, 0)
-	if err != nil {
-		slog.Warn("controller: read autoresearch findings", "task_id", taskID, "err", err)
-		return nil
-	}
-	accepted := make(map[string]bool, len(findings))
-	for _, finding := range findings {
-		if finding.Accepted {
-			accepted[finding.ID] = true
-		}
-	}
-	return accepted
-}
-
-func (c *Controller) recordAutoResearchTurnProgress(taskID string, acceptedBefore map[string]bool) {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return
-	}
-	acceptedAfter := c.autoResearchAcceptedEvidenceIDs(taskID)
-	newAccepted := make([]string, 0)
-	for id := range acceptedAfter {
-		if acceptedBefore == nil || !acceptedBefore[id] {
-			newAccepted = append(newAccepted, id)
-		}
-	}
-	sort.Strings(newAccepted)
-	summary := autoResearchDirectionSummary(lastAssistantText(c.History()))
-	if _, err := c.autoResearch.RecordDirection(taskID, autoresearch.Direction{
-		Summary:             summary,
-		AcceptedEvidenceIDs: newAccepted,
-		Now:                 time.Now().UTC(),
-	}); err != nil {
-		slog.Warn("controller: record autoresearch direction", "task_id", taskID, "err", err)
-	}
-}
-
-func (c *Controller) recordAutoResearchEvidenceFromAssistant(taskID, text string) {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return
-	}
-	for _, item := range parseAutoResearchEvidenceBlocks(text) {
-		if err := c.recordAutoResearchEvidenceForTask(taskID, item.CriterionID, AutoResearchEvidenceInput{
-			ID:       item.ID,
-			Kind:     item.Kind,
-			Summary:  item.Summary,
-			Source:   item.Source,
-			Command:  item.Command,
-			Paths:    append([]string(nil), item.Paths...),
-			Accepted: item.Accepted,
-		}); err != nil {
-			slog.Warn("controller: record autoresearch evidence block", "task_id", taskID, "criterion_id", item.CriterionID, "err", err)
-		}
-	}
-}
-
-type autoResearchEvidenceBlock struct {
-	CriterionID string   `json:"criterion_id"`
-	ID          string   `json:"id"`
-	Kind        string   `json:"kind"`
-	Summary     string   `json:"summary"`
-	Source      string   `json:"source"`
-	Command     string   `json:"command"`
-	Paths       []string `json:"paths"`
-	Accepted    bool     `json:"accepted"`
-}
-
-const (
-	autoResearchEvidenceOpen  = "<autoresearch-evidence>"
-	autoResearchEvidenceClose = "</autoresearch-evidence>"
-)
-
-func parseAutoResearchEvidenceBlocks(text string) []autoResearchEvidenceBlock {
-	var out []autoResearchEvidenceBlock
-	rest := text
-	for {
-		start := strings.Index(rest, autoResearchEvidenceOpen)
-		if start < 0 {
-			return out
-		}
-		rest = rest[start+len(autoResearchEvidenceOpen):]
-		end := strings.Index(rest, autoResearchEvidenceClose)
-		if end < 0 {
-			return out
-		}
-		raw := strings.TrimSpace(rest[:end])
-		rest = rest[end+len(autoResearchEvidenceClose):]
-		if raw == "" {
-			continue
-		}
-		var many []autoResearchEvidenceBlock
-		if err := json.Unmarshal([]byte(raw), &many); err == nil {
-			out = append(out, many...)
-			continue
-		}
-		var one autoResearchEvidenceBlock
-		if err := json.Unmarshal([]byte(raw), &one); err == nil {
-			out = append(out, one)
-		}
-	}
-}
-
-func autoResearchDirectionSummary(text string) string {
-	text = agent.StripAutoResearchEvidenceBlocks(text)
-	for _, line := range strings.Split(text, "\n") {
-		line = strings.TrimSpace(line)
-		lower := strings.ToLower(line)
-		if line == "" || strings.HasPrefix(lower, "[goal:") {
-			continue
-		}
-		if len(line) > 160 {
-			line = line[:160]
-		}
-		return line
-	}
-	return "turn completed"
-}
-
-func (c *Controller) autoResearchReadinessFailure() string {
-	taskID := c.goals.currentAutoResearchTaskID()
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return ""
-	}
-	report, err := c.autoResearch.Readiness(taskID)
-	if err != nil {
-		return "AutoResearch readiness check failed: " + err.Error()
-	}
-	if report.Ready {
-		return ""
-	}
-	var parts []string
-	if len(report.MissingCriteria) > 0 {
-		parts = append(parts, "missing criteria: "+strings.Join(report.MissingCriteria, ", "))
-	}
-	if report.BlockedReason != "" {
-		parts = append(parts, "blocked: "+report.BlockedReason)
-	}
-	if len(report.Errors) > 0 {
-		parts = append(parts, "state errors: "+strings.Join(report.Errors, "; "))
-	}
-	if len(parts) == 0 {
-		parts = append(parts, "task is not ready")
-	}
-	return "AutoResearch readiness check failed: " + strings.Join(parts, "; ")
-}
-
-func (c *Controller) AutoResearchSummary() (*autoresearch.Summary, bool) {
-	taskID := c.goals.currentAutoResearchTaskID()
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return nil, false
-	}
-	summary, err := c.autoResearch.Summary(taskID)
-	if err != nil {
-		return &autoresearch.Summary{
-			TaskID:  taskID,
-			Status:  autoresearch.StatusInvalid,
-			Blocker: err.Error(),
-		}, true
-	}
-	return summary, true
-}
-
-func (c *Controller) AutoResearchList() ([]autoresearch.Summary, bool) {
-	if c.autoResearch == nil {
-		return nil, false
-	}
-	summaries, err := c.autoResearch.ListSummaries()
-	if err != nil {
-		slog.Warn("controller: list autoresearch tasks", "err", err)
-		return nil, true
-	}
-	return summaries, true
-}
-
-func (c *Controller) AutoResearchFindings(limit int) ([]autoresearch.Finding, bool) {
-	taskID := c.goals.currentAutoResearchTaskID()
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return nil, false
-	}
-	findings, err := c.autoResearch.Findings(taskID, limit)
-	if err != nil {
-		return nil, true
-	}
-	return findings, true
-}
-
-func (c *Controller) RecordAutoResearchEvidence(criterionID string, input AutoResearchEvidenceInput) error {
-	taskID := c.goals.currentAutoResearchTaskID()
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return errors.New("autoresearch: no active task")
-	}
-	return c.recordAutoResearchEvidenceForTask(taskID, criterionID, input)
-}
-
-func (c *Controller) recordAutoResearchEvidenceForTask(taskID, criterionID string, input AutoResearchEvidenceInput) error {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
-		return errors.New("autoresearch: no active task")
-	}
-	id := strings.TrimSpace(input.ID)
-	if id == "" {
-		id = c.nextAutoResearchFindingID(taskID)
-	}
-	kind := strings.TrimSpace(input.Kind)
-	if kind == "" {
-		kind = autoresearch.FindingKindManual
-	}
-	source := strings.TrimSpace(input.Source)
-	if source == "" {
-		source = autoresearch.FindingSourceManual
-	}
-	finding := autoresearch.Finding{
-		ID:        id,
-		Kind:      kind,
-		Summary:   strings.TrimSpace(input.Summary),
-		Source:    source,
-		Command:   strings.TrimSpace(input.Command),
-		Paths:     append([]string(nil), input.Paths...),
-		Accepted:  input.Accepted,
-		CreatedAt: time.Now().UTC(),
-	}
-	return c.autoResearch.RecordEvidence(taskID, criterionID, finding)
-}
-
-func (c *Controller) nextAutoResearchFindingID(taskID string) string {
-	findings, err := c.autoResearch.Findings(taskID, 0)
-	if err != nil {
-		return fmt.Sprintf("f%d", time.Now().UTC().UnixNano())
-	}
-	used := make(map[string]bool, len(findings))
-	for _, finding := range findings {
-		used[finding.ID] = true
-	}
-	for i := 1; ; i++ {
-		id := fmt.Sprintf("f%d", len(findings)+i)
-		if !used[id] {
-			return id
-		}
-	}
 }
 
 func (c *Controller) ClearGoal() {

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -480,7 +480,7 @@ func TestResearchGoalTurnAppendsAutoResearchHeartbeats(t *testing.T) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		t.Fatalf("unmarshal goal state: %v", err)
 	}
-	heartbeats, err := c.autoResearch.Heartbeats(state.AutoResearchTaskID, 10)
+	heartbeats, err := c.autoResearch.store.Heartbeats(state.AutoResearchTaskID, 10)
 	if err != nil {
 		t.Fatalf("Heartbeats: %v", err)
 	}
@@ -527,7 +527,7 @@ func TestResearchGoalTurnUpdatesAutoResearchStaleProgress(t *testing.T) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		t.Fatalf("unmarshal goal state: %v", err)
 	}
-	summary, err := c.autoResearch.Summary(state.AutoResearchTaskID)
+	summary, err := c.autoResearch.store.Summary(state.AutoResearchTaskID)
 	if err != nil {
 		t.Fatalf("Summary: %v", err)
 	}
@@ -619,7 +619,7 @@ func TestControllerRecordsAutoResearchEvidence(t *testing.T) {
 		t.Fatalf("RecordAutoResearchEvidence verification: %v", err)
 	}
 
-	report, err := c.autoResearch.Readiness(taskID)
+	report, err := c.autoResearch.store.Readiness(taskID)
 	if err != nil {
 		t.Fatalf("Readiness: %v", err)
 	}
@@ -687,7 +687,7 @@ func TestResearchGoalCompletionMarksAutoResearchTaskComplete(t *testing.T) {
 		t.Fatalf("runGoalLoopWithRawDisplay: %v", err)
 	}
 
-	summary, err := c.autoResearch.Summary(taskID)
+	summary, err := c.autoResearch.store.Summary(taskID)
 	if err != nil {
 		t.Fatalf("Summary: %v", err)
 	}
@@ -697,7 +697,7 @@ func TestResearchGoalCompletionMarksAutoResearchTaskComplete(t *testing.T) {
 	if summary.StaleCount != 0 {
 		t.Fatalf("AutoResearch stale_count = %d, want 0 after accepted evidence", summary.StaleCount)
 	}
-	findings, err := c.autoResearch.Findings(taskID, 0)
+	findings, err := c.autoResearch.store.Findings(taskID, 0)
 	if err != nil {
 		t.Fatalf("Findings: %v", err)
 	}
@@ -741,7 +741,7 @@ func TestResearchGoalBlockedMarksAutoResearchTaskBlocked(t *testing.T) {
 		t.Fatalf("runGoalLoopWithRawDisplay: %v", err)
 	}
 
-	summary, err := c.autoResearch.Summary(taskID)
+	summary, err := c.autoResearch.store.Summary(taskID)
 	if err != nil {
 		t.Fatalf("Summary: %v", err)
 	}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -292,10 +292,10 @@ func escapeHookContext(s string) string {
 }
 
 func (c *Controller) autoResearchRuntimeBlock(taskID string) string {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
+	if !c.autoResearch.enabled() || strings.TrimSpace(taskID) == "" {
 		return ""
 	}
-	summary, err := c.autoResearch.Summary(taskID)
+	summary, err := c.autoResearch.summary(taskID)
 	if err != nil {
 		return "<autoresearch-runtime>\nstatus: invalid\nerror: " + strings.ReplaceAll(err.Error(), autoResearchRuntimeClose, "<\\/autoresearch-runtime>") + "\n</autoresearch-runtime>"
 	}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -265,8 +265,8 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	} else {
 		autoResearchTaskID = c.goals.currentAutoResearchTaskID()
 	}
-	autoResearchAcceptedBefore := c.autoResearchAcceptedEvidenceIDs(autoResearchTaskID)
-	c.appendAutoResearchHeartbeat(autoResearchTaskID, autoresearch.HeartbeatStartingTurn, "")
+	autoResearchAcceptedBefore := c.autoResearch.acceptedEvidenceIDs(autoResearchTaskID)
+	c.autoResearch.heartbeat(autoResearchTaskID, autoresearch.HeartbeatStartingTurn, "")
 	if continuation != nil {
 		ctx = agent.WithDeliveryExecutionScope(ctx, agent.DeliveryExecutionScope{
 			ID:       continuation.scopeID,
@@ -302,12 +302,13 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	err = c.runner.Run(ctx, modelInput)
 	c.persistGoalDeliveryCheckpoint()
 	if err == nil {
-		c.recordAutoResearchEvidenceFromAssistant(autoResearchTaskID, lastAssistantText(c.History()))
-		c.recordAutoResearchTurnProgress(autoResearchTaskID, autoResearchAcceptedBefore)
-		c.appendAutoResearchHeartbeat(autoResearchTaskID, autoresearch.HeartbeatTurnDone, "")
+		assistantText := lastAssistantText(c.History())
+		c.autoResearch.recordEvidenceFromAssistant(autoResearchTaskID, assistantText)
+		c.autoResearch.recordTurnProgress(autoResearchTaskID, autoResearchAcceptedBefore, assistantText)
+		c.autoResearch.heartbeat(autoResearchTaskID, autoresearch.HeartbeatTurnDone, "")
 		c.clearInFlightTurn()
 	} else {
-		c.appendAutoResearchHeartbeat(autoResearchTaskID, autoresearch.HeartbeatWarning, err.Error())
+		c.autoResearch.heartbeat(autoResearchTaskID, autoresearch.HeartbeatWarning, err.Error())
 		// When the user explicitly cancels, keep the real prompt and any fully
 		// paired tool work. Partial reasoning/output remains durable for display
 		// but is marked local-only, and a bounded recovery summary is folded into
@@ -576,13 +577,13 @@ func (o *turnOrchestrator) advanceGoalAfterTurn(ctx context.Context, expectedCon
 }
 
 func (c *Controller) finalizeAutoResearchTask(taskID, notice string) {
-	if c.autoResearch == nil || strings.TrimSpace(taskID) == "" {
+	if !c.autoResearch.enabled() || strings.TrimSpace(taskID) == "" {
 		return
 	}
 	switch {
 	case notice == goalCompleteNotice:
 		status := autoresearch.StatusComplete
-		if _, err := c.autoResearch.UpdateProgress(taskID, autoresearch.ProgressPatch{Status: &status}); err != nil {
+		if err := c.autoResearch.updateProgress(taskID, autoresearch.ProgressPatch{Status: &status}); err != nil {
 			c.noticeDetail("AutoResearch status update failed.", "autoresearch task completion update failed: "+err.Error())
 			return
 		}
@@ -593,7 +594,7 @@ func (c *Controller) finalizeAutoResearchTask(taskID, notice string) {
 		if reason == "" {
 			reason = notice
 		}
-		if _, err := c.autoResearch.UpdateProgress(taskID, autoresearch.ProgressPatch{Status: &status, BlockedReason: &reason}); err != nil {
+		if err := c.autoResearch.updateProgress(taskID, autoresearch.ProgressPatch{Status: &status, BlockedReason: &reason}); err != nil {
 			c.noticeDetail("AutoResearch status update failed.", "autoresearch task blocked update failed: "+err.Error())
 			return
 		}


### PR DESCRIPTION
Continues the controller god-object cleanup (#7787). The AutoResearch subsystem (~320 lines) lived inline on Controller with 13 methods and direct `*autoresearch.Store` access scattered across controller.go, turn_orchestrator.go, and input.go.

## What

- New `autoResearchManager` (autoresearch_manager.go) per the established leaf-collaborator playbook: wraps the optional workspace `autoresearch.Store`, zero-value disabled, every method nil-safe. It never touches Controller state — task IDs and assistant text are passed in by the caller.
- Orchestration with side effects stays on Controller as thin glue in the same file: `prepareAutoResearchTask` (goal-machine fast-path), `finalizeAutoResearchTask` (notices), and the `AutoResearch*` port methods (task resolution via `c.goals`).
- Pure helpers (evidence-block parsing, direction summary, default criteria) move with the manager.
- Call sites in turn_orchestrator.go/input.go now go through the manager; tests reach the raw store via `c.autoResearch.store`.
- controller.go: 6498 → 6179 lines (was 6818 before #7787).

## Verification

- `gofmt` clean, `go vet ./internal/control/...` clean
- `go test -race ./internal/control/` green
- Full `go test ./...` green (English locale)

Cache-impact: none - control-plane code motion; no provider request shaping or cache logic involved.
Cache-guard: existing coverage - goal_test.go AutoResearch integration tests pass unchanged under -race.
Documentation-impact: none - internal reorganization; AutoResearch behavior and public API unchanged.