### PR TITLE
refactor(evidence): make the session-transcript context capability lazy

### DIFF
--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -634,7 +634,7 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	cctx = WithSubagentDepth(cctx, a.subagentDepth)
 	if a.evidence != nil {
 		cctx = evidence.WithLedger(cctx, a.evidence)
-		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot())
+		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot)
 		if a.deliveryProfile {
 			cctx = evidence.WithDeliveryProfile(cctx)
 		}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1511,18 +1511,24 @@ func DeliveryProfileFromContext(ctx context.Context) bool {
 	return enabled
 }
 
-// WithSessionMessages attaches the full conversation history so verifyStepEvidence
-// can fall back to scanning the transcript when the per-turn ledger misses a
-// command (cross-turn references, non-bash tool calls, truncated command strings).
-func WithSessionMessages(ctx context.Context, msgs []provider.Message) context.Context {
-	return context.WithValue(ctx, sessionMessagesKey{}, msgs)
+// WithSessionMessages attaches a lazy transcript accessor so verifyStepEvidence
+// can fall back to scanning the conversation when the per-turn ledger misses a
+// command (cross-turn references, non-bash tool calls, truncated command
+// strings). The context carries the capability, not the data: snapshot is
+// called only when a consumer (complete_step) actually needs the history, so
+// ordinary tool calls never pay for a full transcript copy.
+func WithSessionMessages(ctx context.Context, snapshot func() []provider.Message) context.Context {
+	return context.WithValue(ctx, sessionMessagesKey{}, snapshot)
 }
 
-// SessionMessagesFromContext retrieves the conversation history attached by
-// WithSessionMessages.
+// SessionMessagesFromContext resolves the transcript accessor attached by
+// WithSessionMessages, taking the snapshot at call time.
 func SessionMessagesFromContext(ctx context.Context) ([]provider.Message, bool) {
-	msgs, ok := ctx.Value(sessionMessagesKey{}).([]provider.Message)
-	return msgs, ok
+	snapshot, ok := ctx.Value(sessionMessagesKey{}).(func() []provider.Message)
+	if !ok || snapshot == nil {
+		return nil, false
+	}
+	return snapshot(), true
 }
 
 // WithTodoState attaches the host's canonical task list to a tool call. The

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -637,7 +637,7 @@ func TestCompleteStepSessionFallbackUsesNormalizedMatching(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "c1", Name: "bash", Content: "ok\nPASS"},
 	}
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
-	ctx = evidence.WithSessionMessages(ctx, msgs)
+	ctx = evidence.WithSessionMessages(ctx, func() []provider.Message { return msgs })
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
 		"step":"x","result":"y",
@@ -654,7 +654,7 @@ func TestCompleteStepSessionFallbackSkipsFailedCalls(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "c1", Name: "bash", Content: "error: command exited: exit status 1\nFAIL"},
 	}
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
-	ctx = evidence.WithSessionMessages(ctx, msgs)
+	ctx = evidence.WithSessionMessages(ctx, func() []provider.Message { return msgs })
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
 		"step":"x","result":"y",
@@ -695,7 +695,7 @@ func TestCompleteStepSessionFallbackResolvesDiffPaths(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "w1", Name: "write_file", Content: "wrote 10 lines"},
 	}
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
-	ctx = evidence.WithSessionMessages(ctx, msgs)
+	ctx = evidence.WithSessionMessages(ctx, func() []provider.Message { return msgs })
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
 		"step":"x","result":"y",
@@ -712,7 +712,7 @@ func TestCompleteStepSessionFallbackSkipsFailedWrite(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "w1", Name: "write_file", Content: "error: permission denied"},
 	}
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
-	ctx = evidence.WithSessionMessages(ctx, msgs)
+	ctx = evidence.WithSessionMessages(ctx, func() []provider.Message { return msgs })
 
 	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
 		"step":"x","result":"y",


### PR DESCRIPTION
Part of the core cleanup series (#7786-#7796). The most-flagged architecture violation from the August review: `executeOne` eagerly copied the FULL session transcript (`a.session.Snapshot()`) into the call context on every tool execution, though only `complete_step`'s verification fallback ever reads it — bulk data smuggled through ctx, paid for by every tool call.

## What

- `evidence.WithSessionMessages` now takes a `func() []provider.Message` instead of the materialized slice; `SessionMessagesFromContext` resolves it at call time. The context carries the capability (matching the package's WithLedger/WithTodoState idiom), not the data.
- `executeOne` passes `a.session.Snapshot` as the accessor — ordinary tool calls no longer copy the transcript at all; `complete_step` snapshots only when it actually verifies.
- Consumer call sites in completestep.go are unchanged.

## Verification

- `gofmt` clean, `go vet` clean on evidence/agent/tool
- `go test` green for internal/evidence, internal/tool/builtin, internal/agent
- Full `go test ./...` green (English locale)

Cache-impact: none - host-side tool-context plumbing; no provider request or cache logic involved.
Cache-guard: existing coverage - completestep verification tests pass unchanged.
Documentation-impact: none - internal mechanism; complete_step behavior is identical.