### PR TITLE
feat(intent): resolve delivery intent from tiered signals instead of keyword tables / 用分层信号替代关键词表解析交付意图

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/evidence"
 	"reasonix/internal/extension/dispatch"
 	"reasonix/internal/instruction"
+	"reasonix/internal/intent"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/nilutil"
@@ -484,6 +485,10 @@ type Agent struct {
 	// framing. Empty means classify the raw input verbatim.
 	classifierTaskText string
 
+	// intentClassifier is the optional tier-3 reader consulted only when host
+	// state and the model's own declarations stay silent. Nil disables tier 3
+	// entirely, which is the default and keeps the path model-free.
+	intentClassifier intent.Classifier
 	// preserveEvidenceOnce makes the next Run keep the turn evidence ledger
 	// instead of resetting it. RunSubAgentWithSession sets it before a
 	// review_report completion nudge so the retry can cite the read receipts
@@ -1087,6 +1092,14 @@ type Options struct {
 	// CapabilityAudit is the optional non-persisted metrics sink for routing.
 	CapabilityAudit *capability.Audit
 
+	// IntentClassifier is the optional tier-3 reader for the delivery intent
+	// resolver, consulted only when host state and the model's own declarations
+	// stay silent. Nil (the default) keeps the resolver model-free.
+	//
+	// It must bound itself; wrap the provider-backed implementation in
+	// intent.Bounded so a stalled provider cannot outlive the turn.
+	IntentClassifier intent.Classifier
+
 	// RequireReviewReportKind, when non-empty, makes RunSubAgentWithSession fail
 	// unless the subagent recorded a successful review_report of this kind —
 	// review/security subagents must return typed, host-verifiable reports.
@@ -1231,6 +1244,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		classifierTaskText:        opts.ClassifierTaskText,
 		capabilityLedger:          opts.CapabilityLedger,
 		capabilityAudit:           opts.CapabilityAudit,
+		intentClassifier:          opts.IntentClassifier,
 		contextWindow:             opts.ContextWindow,
 		softCompactRatio:          opts.SoftCompactRatio,
 		toolResultSnipRatio:       opts.ToolResultSnipRatio,
@@ -1634,6 +1648,17 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		} else if checkpointApplies && checkpoint.MutationObserved {
 			deliveryMutation = true
 		}
+		// Shadow phase: compare the tiered resolver against the keyword values
+		// that actually drive this gate. Recording only - the legacy fields below
+		// are untouched, so behavior is byte-identical until the counters justify
+		// the switch. The resolver runs here rather than at turn start because the
+		// model's declarations only exist once the turn has produced receipts.
+		shadowNext, shadowSource := a.resolveDeliveryExpectations()
+		deliveryIntentShadow.record(deliveryExpectations{
+			Task:       a.deliveryTaskExpected,
+			Mutation:   a.deliveryMutationExpected,
+			Persistent: a.deliveryPersistentExpected,
+		}, shadowNext, shadowSource)
 		workObserved := a.evidence.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
 		if a.deliveryTaskExpected && !a.deliveryPersistentExpected && !workObserved {
 			out.missingActionEvidence++

--- a/internal/agent/delivery_intent.go
+++ b/internal/agent/delivery_intent.go
@@ -1,0 +1,359 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/intent"
+	"reasonix/internal/taskintent"
+)
+
+// turnIntentAwaitBudget bounds how long the gate waits for a classification that
+// was launched at turn start. It is short on purpose: the classification runs
+// concurrently with the model's own work, so by gate time it has almost always
+// landed, and a turn that finishes faster than the classifier should degrade to
+// unknown rather than stall on it.
+const turnIntentAwaitBudget = time.Second
+
+// turnIntentFuture carries a classification launched at turn start so the gate
+// can consume the result without paying the model latency inline.
+//
+// The result is written before done is closed and read only after, so the
+// channel close is the happens-before edge; the timeout path touches nothing.
+// A fresh future per turn is what keeps a slow classification from ever landing
+// on a later turn: the stale goroutine completes into an object nobody reads.
+type turnIntentFuture struct {
+	done   chan struct{}
+	result intent.TurnIntent
+}
+
+// await returns the classification and whether it landed at all. The second
+// return separates "the classifier read the turn as nothing" from "the
+// classification was still in flight", which are different defects: the first
+// is a model problem, the second means the await budget is too small for the
+// observed turn durations.
+func (f *turnIntentFuture) await(budget time.Duration) (intent.TurnIntent, bool) {
+	if f == nil {
+		return intent.TurnIntent{}, false
+	}
+	// Fast path: already landed, no timer.
+	select {
+	case <-f.done:
+		return f.result, true
+	default:
+	}
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-f.done:
+		return f.result, true
+	case <-timer.C:
+		return intent.TurnIntent{}, false
+	}
+}
+
+// startTurnIntentClassification launches tier 3 concurrently with the turn.
+//
+// Running it here rather than at the gate is the whole point: a classifier
+// measured at ~3.8s would be that much added latency if it ran when the model
+// wants to finish, but overlapped with the turn's own model round-trips it is
+// effectively free. The cost is that a turn later answered by the declared tier
+// still paid for a classification it did not use.
+//
+// The injected Classifier must bound itself - intent.Bounded provides the
+// timeout, cache, and degradation. An unbounded classifier would leak this
+// goroutine for as long as it hangs.
+func (a *Agent) startTurnIntentClassification(ctx context.Context, text string) *turnIntentFuture {
+	if a == nil || a.intentClassifier == nil || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	// Plan mode is answered by tier 1, so tier 3 would never be consulted.
+	// Skipping the call here is the difference between paying for it and not.
+	if a.planMode.Load() {
+		return nil
+	}
+	// Capture the classifier before launching. The goroutine must not reach back
+	// into Agent fields: it outlives this call, so any concurrent write to the
+	// field would race, and capturing also pins the turn to the classifier that
+	// was configured when it started.
+	cls := a.intentClassifier
+	f := &turnIntentFuture{done: make(chan struct{})}
+	go func() {
+		defer close(f.done)
+		got, err := cls.Classify(ctx, text)
+		if err != nil {
+			// Leaves the zero value, which reads as unknown. A failed
+			// classification must never look like a reading of the turn.
+			return
+		}
+		f.result = got
+	}()
+	return f
+}
+
+// deliveryExpectations is the gate-facing triple: the three predictions
+// finalReadinessCheckFor consults when it decides whether a turn is allowed to
+// finish. It stays a local type because it is host state, not a reading of the
+// user - deriving it from a reading is what deliveryExpectationsFrom does.
+type deliveryExpectations struct {
+	Task       bool
+	Mutation   bool
+	Persistent bool
+}
+
+// deliveryExpectationsFrom derives the gate triple from a shared TurnIntent.
+//
+// The writerTools guard stays here rather than in the contract on purpose:
+// TurnIntent says what the user asked for, while whether this agent can perform
+// a mutation at all is host capability. A registry with no writers can never
+// satisfy a "state change required" expectation, so arming it would deadlock the
+// turn.
+//
+// Mutation additionally narrows to KindMutation. intent.NeedsMutation also
+// answers true for KindPersistentAction - correct for the Goal budget, which
+// asks "does this turn write anything" - but the delivery gate keeps durable
+// memory on its own receipt contract (see the persistentOnlyReady branch in
+// finalReadinessCheckFor) and must not demand a code mutation for it.
+func deliveryExpectationsFrom(ti intent.TurnIntent, writerTools bool) deliveryExpectations {
+	return deliveryExpectations{
+		Task:       ti.NeedsEvidence(),
+		Mutation:   ti.NeedsMutation() && ti.Kind == intent.KindMutation && writerTools,
+		Persistent: ti.NeedsPersistentAction(),
+	}
+}
+
+// legacyTurnIntent expresses the keyword classifier as a TurnIntent so the old
+// and new paths speak one vocabulary during the shadow phase.
+//
+// Kind maps one-to-one from taskintent's enum. The extra contract fields are
+// left at their zero values deliberately: the keyword tables never produced
+// them as separate facts, they folded negation and diagnosis directly into the
+// classification, and inventing values here would misreport what the legacy
+// path actually knows.
+func legacyTurnIntent(input string) intent.TurnIntent {
+	kind := intent.KindUnknown
+	switch taskintent.Classify(input) {
+	case taskintent.Conversation:
+		kind = intent.KindConversation
+	case taskintent.Advisory:
+		kind = intent.KindAdvisory
+	case taskintent.ObservableRead:
+		kind = intent.KindObservableRead
+	case taskintent.Mutation:
+		kind = intent.KindMutation
+	case taskintent.PersistentAction:
+		kind = intent.KindPersistentAction
+	}
+	return intent.TurnIntent{Kind: kind, Source: intent.SourceKeyword}
+}
+
+// legacyDeliveryExpectations reproduces the historical turn-start classification
+// exactly. Routing every caller through one function keeps the shadow comparison
+// to a single call and leaves the switch-over exactly one site to delete.
+//
+// Persistent is computed by the direct legacy call rather than derived from
+// Kind. The two disagree by design: taskintent.Classify tests mutation before
+// persistence, so a turn that asks for both reports Mutation while
+// taskintent.NeedsPersistentAction still reports true. Persistence is an
+// orthogonal axis in the legacy, and reproducing it faithfully is the point of
+// this function.
+func legacyDeliveryExpectations(input string, writerTools bool) deliveryExpectations {
+	out := deliveryExpectationsFrom(legacyTurnIntent(input), writerTools)
+	out.Persistent = taskintent.NeedsPersistentAction(input)
+	return out
+}
+
+// resolveTurnIntent answers the gate's question from the two zero-cost sources
+// that outrank prose classification, returning the shared contract type.
+//
+// It must run at gate time rather than at turn start. beginRunTurn resets the
+// evidence ledger before classifying, so at turn start the model has declared
+// nothing; by the time finalReadinessCheckFor runs, the turn's receipts exist
+// and the declared tier can speak.
+//
+// An unread turn comes back as KindUnknown with SourceNone. The caller owns the
+// degraded-mode default; this function never guesses, and KindUnknown must not
+// be treated as KindConversation.
+func (a *Agent) resolveTurnIntent() intent.TurnIntent {
+	if a == nil {
+		return intent.TurnIntent{}
+	}
+
+	// Tier 1 - host state. A plan-mode turn is a planning turn by host decree:
+	// it is not held to host-observable work, and holding it there would fight
+	// the plan-mode contract itself.
+	if a.planMode.Load() {
+		return intent.TurnIntent{Kind: intent.KindConversation, Source: intent.SourceExplicit}
+	}
+
+	if a.evidence == nil {
+		return intent.TurnIntent{}
+	}
+
+	// Tier 2 - the model's own declarations, read from typed receipts.
+	//
+	// Writing todos or acceptance criteria is the model stating that this turn is
+	// a task with a completion contract. It is the same signal beginRunTurn
+	// already trusts for deliveryCriteriaEstablished, consulted here for the
+	// expectation it was never wired to.
+	//
+	// It reports KindObservableRead and nothing stronger. An earlier version also
+	// inferred KindMutation from an unfinished todo list plus writer tools; real
+	// shadow traffic disproved it on "帮我看下 main.go 有没有问题，只分析不要改",
+	// where the model wrote todos for an explicitly read-only analysis and the
+	// inference armed a mutation expectation the user had forbidden. An unfinished
+	// todo list proves the model thinks the work is incomplete - it does not prove
+	// a state change was requested, and only the user's own words do.
+	//
+	// The consequence is a real gap: tier 2 can establish that a turn is a task
+	// but never that it requires a mutation, so a todo-writing turn stops the
+	// cascade before tier 3 could answer that question. Resolving it needs
+	// per-field tier composition rather than one winning tier; see the plan.
+	if a.evidence.HasSuccessfulTodoWrite() || a.evidence.HasSuccessfulAcceptanceCriteria() {
+		return intent.TurnIntent{Kind: intent.KindObservableRead, Source: intent.SourceDeclared}
+	}
+
+	// A completed remember receipt is deliberately NOT read as evidence of a
+	// persistent-action turn. Observing that the model saved something proves it
+	// happened, not that the user required it, and treating the two as the same
+	// would let the gate justify itself with its own output.
+
+	// Tier 3 - the classification launched at turn start. Consulted last because
+	// it is the only tier that interprets prose, and the only one that can be
+	// wrong in ways the cheaper tiers cannot.
+	got, landed := a.turnIntentPending.await(turnIntentAwaitBudget)
+	if !landed && a.turnIntentPending != nil {
+		deliveryIntentShadow.recordAwaitTimeout()
+	}
+	if !got.Unknown() {
+		got.Source = intent.SourceClassifier
+		return got
+	}
+
+	return intent.TurnIntent{}
+}
+
+// resolveDeliveryExpectations resolves the gate triple through the shared
+// contract. The second return reports which tier answered so the shadow audit
+// can measure how often the zero-cost tiers suffice - the number that decides
+// whether a model classifier is affordable on this path.
+func (a *Agent) resolveDeliveryExpectations() (deliveryExpectations, intent.Source) {
+	ti := a.resolveTurnIntent()
+	if ti.Unknown() {
+		return deliveryExpectations{}, ti.Source
+	}
+	return deliveryExpectationsFrom(ti, registryHasWriterTools(a.tools)), ti.Source
+}
+
+// deliveryIntentShadowAudit accumulates agreement counters between the legacy
+// keyword classifier and the tiered resolver. It is process-wide and
+// non-persisted, the same shape capability.Audit uses, so a corpus run can
+// report totals without threading a sink through every Agent construction.
+type deliveryIntentShadowAudit struct {
+	mu sync.Mutex
+
+	Turns              int
+	Agree              int
+	Disagree           int
+	ResolvedHost       int
+	ResolvedModel      int
+	ResolvedClassifier int
+	AwaitTimeouts      int
+	Unresolved         int
+	TaskDiff           int
+	MutationDiff       int
+	PersistentDiff     int
+}
+
+var deliveryIntentShadow deliveryIntentShadowAudit
+
+// recordAwaitTimeout notes that a classification had not landed when the gate
+// needed it. A nonzero count means turnIntentAwaitBudget is too small for the
+// observed turn durations, not that the classifier is inaccurate.
+func (s *deliveryIntentShadowAudit) recordAwaitTimeout() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.AwaitTimeouts++
+}
+
+// record captures one gate-time comparison. legacy is the value that actually
+// drove behavior; next is what the tiered resolver would have produced.
+func (s *deliveryIntentShadowAudit) record(legacy, next deliveryExpectations, source intent.Source) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Turns++
+	switch source {
+	case intent.SourceExplicit:
+		s.ResolvedHost++
+	case intent.SourceDeclared:
+		s.ResolvedModel++
+	case intent.SourceClassifier:
+		s.ResolvedClassifier++
+	default:
+		s.Unresolved++
+	}
+
+	if legacy == next {
+		s.Agree++
+		return
+	}
+	s.Disagree++
+	if legacy.Task != next.Task {
+		s.TaskDiff++
+	}
+	if legacy.Mutation != next.Mutation {
+		s.MutationDiff++
+	}
+	if legacy.Persistent != next.Persistent {
+		s.PersistentDiff++
+	}
+}
+
+// DeliveryIntentShadowSnapshot returns a copy of the shadow counters. Exported
+// for the differential adjudication run, which needs aggregate agreement numbers
+// across a whole test binary.
+func DeliveryIntentShadowSnapshot() map[string]int {
+	deliveryIntentShadow.mu.Lock()
+	defer deliveryIntentShadow.mu.Unlock()
+	return map[string]int{
+		"turns":               deliveryIntentShadow.Turns,
+		"agree":               deliveryIntentShadow.Agree,
+		"disagree":            deliveryIntentShadow.Disagree,
+		"resolved_host":       deliveryIntentShadow.ResolvedHost,
+		"resolved_model":      deliveryIntentShadow.ResolvedModel,
+		"resolved_classifier": deliveryIntentShadow.ResolvedClassifier,
+		"await_timeouts":      deliveryIntentShadow.AwaitTimeouts,
+		"unresolved":          deliveryIntentShadow.Unresolved,
+		"task_diff":           deliveryIntentShadow.TaskDiff,
+		"mutation_diff":       deliveryIntentShadow.MutationDiff,
+		"persistent_diff":     deliveryIntentShadow.PersistentDiff,
+	}
+}
+
+// ResetDeliveryIntentShadow clears the counters so a corpus run can scope its
+// measurement to one batch. Fields are cleared individually because assigning a
+// zero struct over the audit would copy its mutex.
+func ResetDeliveryIntentShadow() {
+	deliveryIntentShadow.mu.Lock()
+	defer deliveryIntentShadow.mu.Unlock()
+	deliveryIntentShadow.Turns = 0
+	deliveryIntentShadow.Agree = 0
+	deliveryIntentShadow.Disagree = 0
+	deliveryIntentShadow.ResolvedHost = 0
+	deliveryIntentShadow.ResolvedModel = 0
+	deliveryIntentShadow.ResolvedClassifier = 0
+	deliveryIntentShadow.AwaitTimeouts = 0
+	deliveryIntentShadow.Unresolved = 0
+	deliveryIntentShadow.TaskDiff = 0
+	deliveryIntentShadow.MutationDiff = 0
+	deliveryIntentShadow.PersistentDiff = 0
+}

--- a/internal/agent/delivery_intent_test.go
+++ b/internal/agent/delivery_intent_test.go
@@ -1,0 +1,136 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/intent"
+	"reasonix/internal/intent/corpus"
+	"reasonix/internal/taskintent"
+)
+
+// TestLegacyDeliveryExpectationsMatchesHistoricalExpression is the guard for the
+// shadow refactor. legacyDeliveryExpectations now routes through the shared
+// intent contract, and this pins that the rewrite is behavior-preserving: for
+// every corpus turn, under both writer-tool states, it must equal the exact
+// expression beginRunTurn used before the contract existed.
+func TestLegacyDeliveryExpectationsMatchesHistoricalExpression(t *testing.T) {
+	for _, c := range corpus.All() {
+		for _, writers := range []bool{false, true} {
+			kind := taskintent.Classify(c.Text)
+			want := deliveryExpectations{
+				Task: kind == taskintent.ObservableRead ||
+					kind == taskintent.Mutation ||
+					kind == taskintent.PersistentAction,
+				Mutation:   kind == taskintent.Mutation && writers,
+				Persistent: taskintent.NeedsPersistentAction(c.Text),
+			}
+			if got := legacyDeliveryExpectations(c.Text, writers); got != want {
+				t.Errorf("legacyDeliveryExpectations(%q, writers=%v) = %+v, want %+v",
+					c.Text, writers, got, want)
+			}
+		}
+	}
+}
+
+// TestDeliveryExpectationsFromContract pins the two places the gate triple
+// deliberately narrows the shared contract.
+func TestDeliveryExpectationsFromContract(t *testing.T) {
+	t.Run("mutation needs writer tools", func(t *testing.T) {
+		ti := intent.TurnIntent{Kind: intent.KindMutation}
+		if got := deliveryExpectationsFrom(ti, false); got.Mutation {
+			t.Error("armed a mutation expectation with no writer tools; the turn could never satisfy it")
+		}
+		if got := deliveryExpectationsFrom(ti, true); !got.Mutation {
+			t.Error("writer tools present but mutation expectation not armed")
+		}
+	})
+
+	t.Run("durable memory does not demand a code mutation", func(t *testing.T) {
+		ti := intent.TurnIntent{Kind: intent.KindPersistentAction, DurableScope: true}
+		got := deliveryExpectationsFrom(ti, true)
+		if got.Mutation {
+			t.Error("a durable-memory turn must not arm the code-mutation expectation")
+		}
+		if !got.Persistent {
+			t.Error("a durable-memory turn must arm the persistent expectation")
+		}
+		if !got.Task {
+			t.Error("a durable-memory turn is observable work")
+		}
+	})
+
+	t.Run("read-only constraint suppresses mutation", func(t *testing.T) {
+		ti := intent.TurnIntent{Kind: intent.KindMutation, ReadOnlyConstraint: true}
+		if got := deliveryExpectationsFrom(ti, true); got.Mutation {
+			t.Error("an explicit read-only constraint must suppress the mutation expectation")
+		}
+	})
+}
+
+// TestResolveTurnIntentTiers pins which source answers, and that an unread turn
+// is reported as unknown rather than silently becoming conversation.
+func TestResolveTurnIntentTiers(t *testing.T) {
+	t.Run("nil agent is unknown", func(t *testing.T) {
+		var a *Agent
+		if got := a.resolveTurnIntent(); !got.Unknown() {
+			t.Errorf("nil agent resolved to %v", got.Kind)
+		}
+	})
+
+	t.Run("plan mode is host state", func(t *testing.T) {
+		a := &Agent{}
+		a.planMode.Store(true)
+		got := a.resolveTurnIntent()
+		if got.Source != intent.SourceExplicit {
+			t.Errorf("source = %v, want explicit", got.Source)
+		}
+		if got.NeedsEvidence() {
+			t.Error("a plan-mode turn must not be held to host-observable work")
+		}
+	})
+
+	t.Run("silent turn is unresolved, not conversation", func(t *testing.T) {
+		a := &Agent{evidence: evidence.NewLedger()}
+		got := a.resolveTurnIntent()
+		if !got.Unknown() {
+			t.Fatalf("a turn with no receipts resolved to %v; it must stay unknown", got.Kind)
+		}
+		if got.Source != intent.SourceNone {
+			t.Errorf("source = %v, want none", got.Source)
+		}
+		// The distinction matters: an unresolved turn must not arm gates by
+		// default, but it must also not be mistaken for a deliberate reading.
+		exp, src := a.resolveDeliveryExpectations()
+		if exp != (deliveryExpectations{}) {
+			t.Errorf("unresolved turn armed %+v", exp)
+		}
+		if src != intent.SourceNone {
+			t.Errorf("source = %v, want none", src)
+		}
+	})
+}
+
+// TestShadowAuditCountsBySource pins that the audit separates the zero-cost
+// tiers from the unresolved remainder. That split is the number which decides
+// whether a model classifier is affordable on this path.
+func TestShadowAuditCountsBySource(t *testing.T) {
+	ResetDeliveryIntentShadow()
+	t.Cleanup(ResetDeliveryIntentShadow)
+
+	same := deliveryExpectations{Task: true}
+	deliveryIntentShadow.record(same, same, intent.SourceExplicit)
+	deliveryIntentShadow.record(same, same, intent.SourceDeclared)
+	deliveryIntentShadow.record(same, deliveryExpectations{}, intent.SourceNone)
+
+	snap := DeliveryIntentShadowSnapshot()
+	for key, want := range map[string]int{
+		"turns": 3, "agree": 2, "disagree": 1,
+		"resolved_host": 1, "resolved_model": 1, "unresolved": 1,
+		"task_diff": 1, "mutation_diff": 0, "persistent_diff": 0,
+	} {
+		if snap[key] != want {
+			t.Errorf("%s = %d, want %d", key, snap[key], want)
+		}
+	}
+}

--- a/internal/agent/delivery_intent_tier3_test.go
+++ b/internal/agent/delivery_intent_tier3_test.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/intent"
+)
+
+func stubClassifier(ti intent.TurnIntent, calls *atomic.Int64) intent.Classifier {
+	return intent.ClassifierFunc(func(context.Context, string) (intent.TurnIntent, error) {
+		if calls != nil {
+			calls.Add(1)
+		}
+		return ti, nil
+	})
+}
+
+// agentWithTier3 builds the minimum Agent the resolver reads, then launches the
+// tier-3 future the way beginRunTurn does.
+func agentWithTier3(t *testing.T, cls intent.Classifier) *Agent {
+	t.Helper()
+	a := &Agent{evidence: evidence.NewLedger(), intentClassifier: cls}
+	a.turnIntentPending = a.startTurnIntentClassification(context.Background(), "fix the parser")
+	return a
+}
+
+// TestTier3AnswersOnlyWhenCheaperTiersAreSilent pins the ordering that makes the
+// design affordable: the classifier is the fallback, never the first resort.
+func TestTier3AnswersOnlyWhenCheaperTiersAreSilent(t *testing.T) {
+	t.Run("silent turn falls through to the classifier", func(t *testing.T) {
+		var calls atomic.Int64
+		a := agentWithTier3(t, stubClassifier(intent.TurnIntent{Kind: intent.KindMutation}, &calls))
+
+		got := a.resolveTurnIntent()
+		if got.Kind != intent.KindMutation {
+			t.Fatalf("kind = %v, want mutation", got.Kind)
+		}
+		if got.Source != intent.SourceClassifier {
+			t.Errorf("source = %v, want classifier", got.Source)
+		}
+		if calls.Load() != 1 {
+			t.Errorf("classifier called %d times, want 1", calls.Load())
+		}
+	})
+
+	t.Run("declared tier outranks the classifier", func(t *testing.T) {
+		var calls atomic.Int64
+		a := agentWithTier3(t, stubClassifier(intent.TurnIntent{Kind: intent.KindConversation}, &calls))
+		// The model declared a task by writing todos; that must win over any
+		// reading of the user's prose.
+		a.evidence.Record(evidence.Receipt{ToolName: "todo_write", Success: true})
+
+		got := a.resolveTurnIntent()
+		if got.Source != intent.SourceDeclared {
+			t.Fatalf("source = %v, want declared", got.Source)
+		}
+		if !got.NeedsEvidence() {
+			t.Error("a declared task must arm the evidence expectation")
+		}
+	})
+
+	t.Run("plan mode skips the classifier entirely", func(t *testing.T) {
+		var calls atomic.Int64
+		a := &Agent{evidence: evidence.NewLedger(), intentClassifier: stubClassifier(
+			intent.TurnIntent{Kind: intent.KindMutation}, &calls)}
+		a.planMode.Store(true)
+		a.turnIntentPending = a.startTurnIntentClassification(context.Background(), "fix the parser")
+
+		got := a.resolveTurnIntent()
+		if got.Source != intent.SourceExplicit {
+			t.Errorf("source = %v, want explicit", got.Source)
+		}
+		if calls.Load() != 0 {
+			t.Errorf("classifier called %d times in plan mode; tier 1 already answers", calls.Load())
+		}
+		if a.turnIntentPending != nil {
+			t.Error("plan mode must not launch a classification")
+		}
+	})
+}
+
+// TestTier3FailureDegradesToUnknown pins that a classifier outage cannot look
+// like a reading of the turn. Unknown must not arm gates, and must not be
+// mistaken for a deliberate "this is chat" verdict.
+func TestTier3FailureDegradesToUnknown(t *testing.T) {
+	cases := map[string]intent.Classifier{
+		"error": intent.ClassifierFunc(func(context.Context, string) (intent.TurnIntent, error) {
+			return intent.TurnIntent{Kind: intent.KindMutation}, errors.New("provider down")
+		}),
+		"unknown reply": intent.ClassifierFunc(func(context.Context, string) (intent.TurnIntent, error) {
+			return intent.TurnIntent{}, nil
+		}),
+	}
+	for name, cls := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := agentWithTier3(t, cls)
+			got := a.resolveTurnIntent()
+			if !got.Unknown() {
+				t.Fatalf("degraded classification leaked kind %v", got.Kind)
+			}
+			exp, src := a.resolveDeliveryExpectations()
+			if exp != (deliveryExpectations{}) {
+				t.Errorf("degraded turn armed %+v", exp)
+			}
+			if src != intent.SourceNone {
+				t.Errorf("source = %v, want none", src)
+			}
+		})
+	}
+}
+
+// TestTier3AwaitIsBounded pins that a classification still in flight cannot
+// stall turn completion past the await budget.
+func TestTier3AwaitIsBounded(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	f := &turnIntentFuture{done: make(chan struct{})}
+	go func() {
+		<-release
+		close(f.done)
+	}()
+
+	start := time.Now()
+	got, landed := f.await(50 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	if !got.Unknown() {
+		t.Errorf("an unfinished classification returned %v", got.Kind)
+	}
+	if landed {
+		t.Error("await reported the classification landed when it had not")
+	}
+	if elapsed > time.Second {
+		t.Errorf("await took %v; the budget did not bound it", elapsed)
+	}
+}
+
+// TestTier3FutureIsPerTurn pins that a slow classification cannot land on a
+// later turn. beginRunTurn replaces the future every turn, so the stale
+// goroutine completes into an object nobody reads.
+func TestTier3FutureIsPerTurn(t *testing.T) {
+	slow := make(chan struct{})
+	t.Cleanup(func() { close(slow) })
+
+	a := &Agent{evidence: evidence.NewLedger()}
+	a.intentClassifier = intent.ClassifierFunc(func(context.Context, string) (intent.TurnIntent, error) {
+		<-slow
+		return intent.TurnIntent{Kind: intent.KindMutation}, nil
+	})
+
+	// Turn 1 launches a classification that never lands in time.
+	first := a.startTurnIntentClassification(context.Background(), "turn one")
+	if got, _ := first.await(20 * time.Millisecond); !got.Unknown() {
+		t.Fatalf("slow classification resolved early: %v", got.Kind)
+	}
+
+	// Turn 2 replaces it with a fast one; turn 1's result must be unreachable.
+	a.intentClassifier = stubClassifier(intent.TurnIntent{Kind: intent.KindAdvisory}, nil)
+	a.turnIntentPending = a.startTurnIntentClassification(context.Background(), "turn two")
+
+	got := a.resolveTurnIntent()
+	if got.Kind != intent.KindAdvisory {
+		t.Errorf("kind = %v, want advisory from the current turn", got.Kind)
+	}
+	if a.turnIntentPending == first {
+		t.Error("the turn-1 future was reused")
+	}
+}
+
+// TestTier3AwaitIsRepeatable pins that the gate may run more than once per turn
+// (run_loop and the readiness recheck both call it) without losing the answer.
+func TestTier3AwaitIsRepeatable(t *testing.T) {
+	var calls atomic.Int64
+	a := agentWithTier3(t, stubClassifier(intent.TurnIntent{Kind: intent.KindMutation}, &calls))
+
+	for i := 0; i < 3; i++ {
+		got := a.resolveTurnIntent()
+		if got.Kind != intent.KindMutation {
+			t.Fatalf("resolve %d = %v, want mutation", i, got.Kind)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Errorf("classifier called %d times across 3 resolves, want 1", calls.Load())
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -12,7 +12,6 @@ import (
 	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
-	"reasonix/internal/taskintent"
 	"reasonix/internal/tool"
 )
 
@@ -59,6 +58,12 @@ type perTurnState struct {
 	deliveryMutationExpected    bool
 	deliveryPersistentExpected  bool
 	deliveryScopeActive         bool
+
+	// turnIntentPending holds the tier-3 classification launched at the start of
+	// this turn. Per-turn by construction: zeroing perTurnState drops the
+	// previous turn's future, so a slow classification completes into an object
+	// nobody reads instead of landing on a later turn.
+	turnIntentPending *turnIntentFuture
 
 	// readinessRecovered marks a run that started with evidence preserved from
 	// (or a pending recovery of) a prior readiness failure, so the final
@@ -266,10 +271,17 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	} else if strings.TrimSpace(classifierInput) == "" {
 		classifierInput = rawInput
 	}
-	intent := taskintent.Classify(classifierInput)
-	a.deliveryTaskExpected = intent.NeedsEvidence()
-	a.deliveryMutationExpected = intent == taskintent.Mutation && registryHasWriterTools(a.tools)
-	a.deliveryPersistentExpected = taskintent.NeedsPersistentAction(classifierInput)
+	// Routed through legacyDeliveryExpectations so the keyword classifier has one
+	// call site: finalReadinessCheckFor shadows a tiered resolver against these
+	// same three values, and the switch-over deletes exactly this call.
+	legacy := legacyDeliveryExpectations(classifierInput, registryHasWriterTools(a.tools))
+	a.deliveryTaskExpected = legacy.Task
+	a.deliveryMutationExpected = legacy.Mutation
+	a.deliveryPersistentExpected = legacy.Persistent
+	// Launch the tier-3 reader concurrently with the turn so the gate never pays
+	// its latency inline. Assigning unconditionally also clears the previous
+	// turn's future, so a slow classification cannot be consumed by a later turn.
+	a.turnIntentPending = a.startTurnIntentClassification(ctx, classifierInput)
 	a.recoveryTaskSummary = boundedRecoveryTaskSummary(classifierInput)
 	// A cancelled/error turn leaves a provider-excluded recovery record at the
 	// transcript tail. Fold its bounded facts into this new user turn exactly

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -42,6 +42,7 @@ import (
 	"reasonix/internal/hook"
 	"reasonix/internal/installsource"
 	"reasonix/internal/instruction"
+	"reasonix/internal/intent"
 	"reasonix/internal/jobs"
 	"reasonix/internal/lsp"
 	"reasonix/internal/mcplaunch"
@@ -1672,6 +1673,30 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	// without inheriting dynamic mcp__* schemas.
 	var capLedger *capability.Ledger
 	var capAudit *capability.Audit
+
+	// Tier 3 of the delivery intent resolver. Opt-in only: it costs one small
+	// model call per turn, so it stays nil unless the user names a model for it
+	// via agent.subagent_models["intent-classifier"]. Tiers 1 and 2 (host state
+	// and the model's own declarations) are free and answer first regardless.
+	//
+	// Bounded owns the timeout, cache, and degradation so a stalled or missing
+	// provider can never hold a turn or be mistaken for a reading of it.
+	var intentClassifier intent.Classifier
+	if modelRef := strings.TrimSpace(cfg.Agent.SubagentModels["intent-classifier"]); modelRef != "" {
+		effortRef := strings.TrimSpace(cfg.Agent.SubagentEfforts["intent-classifier"])
+		if p, price, _, err := resolveSubagentProvider(modelRef, effortRef); err == nil && p != nil {
+			usageModelRef, _ := subagentIdentity(modelRef, effortRef)
+			intentClassifier = &intent.Bounded{
+				Inner: &intent.ModelClassifier{
+					Provider: p,
+					Sink:     sink,
+					Model:    usageModelRef,
+					Pricing:  price,
+				},
+			}
+		}
+	}
+
 	capSpecs := PluginSpecsForRootWithOptions(cfg.Plugins, root, pluginSpecOptions)
 	cachedTools, cacheKeyOK := capability.LoadCachedToolsForSpecs(capSpecs)
 	skillStore.ConfigureToolBindings(func(sk skill.Skill) []tool.MCPBinding {
@@ -1783,6 +1808,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		WorkspaceLease:               workspaceLease,
 		CapabilityLedger:             capLedger,
 		CapabilityAudit:              capAudit,
+		IntentClassifier:             intentClassifier,
 		ContextWindow:                entry.ContextWindow,
 		SoftCompactRatio:             cfg.Agent.SoftCompactRatio,
 		ToolResultSnipRatio:          cfg.Agent.ToolResultSnipRatio,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -791,6 +791,7 @@ func runAgent(args []string, version string) int {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		}
 	}
+	reportDeliveryIntentShadow()
 	if resultOutput != nil {
 		sessionID := runOutputSessionID(format, agent.BranchID(ctrl.SessionPath()), machineIdentityKey)
 		if err := resultOutput.Finalize(sessionID, started, runErr); err != nil {

--- a/internal/cli/delivery_intent_shadow.go
+++ b/internal/cli/delivery_intent_shadow.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+// deliveryIntentShadowEnv opts a session into printing the delivery intent
+// shadow counters when it ends.
+const deliveryIntentShadowEnv = "REASONIX_INTENT_SHADOW"
+
+// reportDeliveryIntentShadow prints how often each tier of the delivery intent
+// resolver answered, and how often it agreed with the keyword classifier that
+// still drives behavior.
+//
+// It exists to answer one migration question with real traffic rather than
+// synthetic tests: what share of turns the two zero-cost tiers resolve on their
+// own. That share decides whether a per-turn model classifier is affordable.
+//
+// Opt-in and stderr-only. It writes no persisted format and prints nothing for
+// ordinary sessions, so it can ship while the migration is measured.
+func reportDeliveryIntentShadow() {
+	if strings.TrimSpace(os.Getenv(deliveryIntentShadowEnv)) == "" {
+		return
+	}
+	snap := agent.DeliveryIntentShadowSnapshot()
+	turns := snap["turns"]
+	if turns == 0 {
+		return
+	}
+
+	pct := func(n int) string {
+		return fmt.Sprintf("%5.1f%%", 100*float64(n)/float64(turns))
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "delivery intent shadow: %d gated turn(s)\n", turns)
+	fmt.Fprintf(&b, "  resolved by tier:\n")
+	for _, row := range []struct {
+		label string
+		key   string
+	}{
+		{"host state (free)", "resolved_host"},
+		{"model declared (free)", "resolved_model"},
+		{"classifier (paid)", "resolved_classifier"},
+		{"unresolved", "unresolved"},
+	} {
+		fmt.Fprintf(&b, "    %-22s %5d  %s\n", row.label, snap[row.key], pct(snap[row.key]))
+	}
+	if n := snap["await_timeouts"]; n > 0 {
+		fmt.Fprintf(&b, "  classifier not ready at gate time: %d (await budget too small)\n", n)
+	}
+	fmt.Fprintf(&b, "  agreement with keyword tables: %d agree / %d disagree\n",
+		snap["agree"], snap["disagree"])
+
+	if snap["disagree"] > 0 {
+		diffs := map[string]int{
+			"task":       snap["task_diff"],
+			"mutation":   snap["mutation_diff"],
+			"persistent": snap["persistent_diff"],
+		}
+		keys := make([]string, 0, len(diffs))
+		for k := range diffs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		fmt.Fprintf(&b, "  disagreements by field:")
+		for _, k := range keys {
+			fmt.Fprintf(&b, " %s=%d", k, diffs[k])
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprint(os.Stderr, b.String())
+}

--- a/internal/intent/classifier.go
+++ b/internal/intent/classifier.go
@@ -1,0 +1,194 @@
+package intent
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Classifier reads a user turn and produces a structured intent. It is the only
+// tier permitted to interpret prose; the cheaper tiers read explicit syntax,
+// host toggles, or the model's own typed output.
+//
+// A Classifier that cannot answer must return KindUnknown with a nil error
+// rather than guessing. Callers distinguish "read as chat" from "could not
+// read" and apply their own degraded default to the latter.
+type Classifier interface {
+	Classify(ctx context.Context, text string) (TurnIntent, error)
+}
+
+// ClassifierFunc adapts a function to Classifier.
+type ClassifierFunc func(ctx context.Context, text string) (TurnIntent, error)
+
+func (f ClassifierFunc) Classify(ctx context.Context, text string) (TurnIntent, error) {
+	return f(ctx, text)
+}
+
+const (
+	// DefaultTimeout bounds one classification. It matches the semantic
+	// capability router's budget: long enough for a small model, short enough
+	// that a stalled provider cannot hold a user turn.
+	DefaultTimeout = 3 * time.Second
+	// DefaultCacheTTL bounds how long an answer is reused. Turn text repeats
+	// often enough (retries, continuations, steering) that a short TTL removes
+	// most duplicate calls.
+	DefaultCacheTTL = 5 * time.Minute
+)
+
+// Bounded wraps a Classifier with the failure discipline every model call on a
+// user-facing path needs: a hard timeout, a short-lived cache, and degradation
+// to KindUnknown instead of an error the caller might mistake for a reading.
+//
+// The shape deliberately mirrors capability.SemanticRouter, which already runs
+// this pattern in production for capability routing. A nil Inner degrades
+// cleanly so offline builds, CI, and credential-less environments behave
+// deterministically rather than failing.
+type Bounded struct {
+	Inner   Classifier
+	Timeout time.Duration
+	TTL     time.Duration
+	Audit   *Audit
+
+	// Now is injectable so cache-expiry behavior is testable without sleeping.
+	Now func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	intent    TurnIntent
+	expiresAt time.Time
+}
+
+func (b *Bounded) now() time.Time {
+	if b != nil && b.Now != nil {
+		return b.Now()
+	}
+	return time.Now()
+}
+
+func (b *Bounded) timeout() time.Duration {
+	if b != nil && b.Timeout > 0 {
+		return b.Timeout
+	}
+	return DefaultTimeout
+}
+
+func (b *Bounded) ttl() time.Duration {
+	if b != nil && b.TTL > 0 {
+		return b.TTL
+	}
+	return DefaultCacheTTL
+}
+
+// Classify applies the cache, then the timeout, then records the outcome. It
+// never returns an error: every failure mode is reported as KindUnknown so a
+// caller cannot accidentally treat a provider outage as a reading of the turn.
+func (b *Bounded) Classify(ctx context.Context, text string) (TurnIntent, error) {
+	if b == nil || b.Inner == nil {
+		return TurnIntent{}, nil
+	}
+	if text == "" {
+		return TurnIntent{}, nil
+	}
+
+	if hit, ok := b.cacheGet(text); ok {
+		b.Audit.recordCacheHit()
+		return hit, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, b.timeout())
+	defer cancel()
+
+	started := b.now()
+	got, err := b.Inner.Classify(ctx, text)
+	elapsed := b.now().Sub(started)
+
+	if err != nil || got.Unknown() {
+		b.Audit.recordMiss(elapsed)
+		return TurnIntent{}, nil
+	}
+	got.Source = SourceClassifier
+	b.cachePut(text, got)
+	b.Audit.recordHit(elapsed)
+	return got, nil
+}
+
+func (b *Bounded) cacheGet(text string) (TurnIntent, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry, ok := b.cache[text]
+	if !ok || !entry.expiresAt.After(b.now()) {
+		return TurnIntent{}, false
+	}
+	return entry.intent, true
+}
+
+func (b *Bounded) cachePut(text string, t TurnIntent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cache == nil {
+		b.cache = map[string]cacheEntry{}
+	}
+	b.cache[text] = cacheEntry{intent: t, expiresAt: b.now().Add(b.ttl())}
+}
+
+// Audit accumulates non-persisted classifier counters. It mirrors
+// capability.Audit so routing and intent metrics report the same way.
+type Audit struct {
+	mu sync.Mutex
+
+	Calls     int
+	CacheHits int
+	Answered  int
+	Degraded  int
+	LatencyMs int64
+}
+
+func (a *Audit) recordCacheHit() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.CacheHits++
+}
+
+func (a *Audit) recordHit(elapsed time.Duration) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Calls++
+	a.Answered++
+	a.LatencyMs += elapsed.Milliseconds()
+}
+
+func (a *Audit) recordMiss(elapsed time.Duration) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Calls++
+	a.Degraded++
+	a.LatencyMs += elapsed.Milliseconds()
+}
+
+// Snapshot returns a copy of the counters for reporting.
+func (a *Audit) Snapshot() map[string]int64 {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return map[string]int64{
+		"calls":      int64(a.Calls),
+		"cache_hits": int64(a.CacheHits),
+		"answered":   int64(a.Answered),
+		"degraded":   int64(a.Degraded),
+		"latency_ms": a.LatencyMs,
+	}
+}

--- a/internal/intent/corpus/corpus.go
+++ b/internal/intent/corpus/corpus.go
@@ -1,0 +1,195 @@
+// Package corpus is the single source of truth for the labeled turn corpus that
+// pins host-side intent behavior. It was extracted verbatim from the three
+// golden tests that previously each carried their own inline table:
+//
+//	internal/taskintent/classification_test.go  (evidence + mutation labels)
+//	internal/taskintent/heuristic_test.go       (task-vs-chat label)
+//	internal/taskintent/goal_budget_test.go     (Goal write-budget + mutation)
+//
+// Those tests now read from here, so the gate tests and the classifier
+// evaluation harness judge one corpus. Keeping a single copy matters for the
+// same reason internal/intent exists: the defect being removed is five drifting
+// keyword tables, and duplicating the corpus that judges them would reproduce
+// the defect one level up.
+//
+// It is a separate package, not a file in internal/intent, so that production
+// code depending on the intent contract does not link ~120 test strings.
+//
+// Labels are pointers so a case can carry only the labels its source test
+// asserted. A nil label means "this source made no claim", not "false".
+package corpus
+
+// Case is one labeled user turn.
+type Case struct {
+	Name string
+	Text string
+	// Origin records which golden test asserted these labels.
+	Origin string
+
+	NeedsEvidence    *bool
+	NeedsMutation    *bool
+	IsTask           *bool
+	NeedsWriteBudget *bool
+}
+
+func b(v bool) *bool { return &v }
+
+// Delivery carry evidence/mutation labels from the delivery classification
+// matrix. They protect the boundary between advisory troubleshooting, observable
+// read-only work, and mutation delivery.
+var Delivery = []Case{
+	{Name: "make sense", Text: "why does this make sense?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "node prose", Text: "why does the node selection matter?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "swift prose", Text: "why does Swift concurrency work this way?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "go prose", Text: "why does this go wrong so often?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "remote url", Text: "why can't I open https://github.com?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "remote analysis", Text: "can you analyze why Outlook won't sync?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "how to install", Text: "how do I install the plugin?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "chinese how to install", Text: "如何安装插件", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "chinese how to modify", Text: "怎么修改 WPS 设置", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "python prose", Text: "why is Python popular?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "docker prose", Text: "why is Docker popular?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "pytest prose", Text: "why is pytest popular?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "backtick python prose", Text: "why is `Python` popular?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "backtick code identifier", Text: "what does `context.Context` mean?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "double dash prose", Text: "why is this -- strangely -- happening?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "advisory upgrade", Text: "为什么升级插件后失败", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "advisory adjustment", Text: "为什么调整设置后没有效果", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "advisory change application", Text: "为什么申请修改失败", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "negated change", Text: "please don't make the requested changes", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "negated chinese", Text: "请勿修改代码", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "negated inspection", Text: "Explain why it fails. Do not inspect or change files.", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "negated chinese inspection", Text: "解释失败原因，不要检查或修改文件", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "review only", Text: "review only and do not fix anything", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "markdown anchor", Text: "why does README.md render incorrectly?", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "git command", Text: "why does git diff --check fail?", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "custom command", Text: "why does mytool --strict fail?", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "repository anchor", Text: "can you analyze this repository and explain why it fails?", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "observable audit", Text: "audit the current configuration", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "make changes", Text: "make the necessary changes", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "thanks then update", Text: "thanks for fixing that, now update the tests", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "chinese thanks then update", Text: "谢谢你，请继续修改配置", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "thanks then review", Text: "thanks for the help; now review this pull request", NeedsEvidence: b(true), NeedsMutation: b(false)},
+	{Name: "modify", Text: "please modify the config", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "push", Text: "push the branch", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "commit", Text: "commit the fix", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "move", Text: "move the file", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "bump", Text: "bump the dependency", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "advice then fix", Text: "why does it fail and fix it", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "polite fix before advice", Text: "could you please fix why it fails", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "chinese polite fix before advice", Text: "请你帮我修复为什么会失败", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "chinese advice then fix", Text: "为什么失败然后修复它", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "negated install then patch", Text: "I cannot install dependencies but patch the parser", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "shared negation", Text: "I cannot install and update dependencies", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "reset negation", Text: "I cannot install dependencies and please update config", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "chinese reset", Text: "无法安装依赖请在现有配置中修改", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "negated request", Text: "不想请团队修改代码", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "negated application", Text: "禁止申请修改配置", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "deferred conversation token", Text: "Remember ORBIT-42 and answer on the next turn.", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "chinese deferred conversation token", Text: "记住 ORBIT-42，下一轮回答", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "deferred token with durable negation", Text: "Remember ORBIT-42 for the next turn. Do not save it permanently.", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "chinese deferred token with durable negation", Text: "记住 ORBIT-42，下一轮回答。不要写入文件或长期记忆。", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "long conversational context", Text: "Please keep this code in mind because I will ask you about it in my next message", NeedsEvidence: b(false), NeedsMutation: b(false)},
+	{Name: "durable memory", Text: "Remember ORBIT-42 permanently across sessions", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "chinese durable memory", Text: "请永久记住 ORBIT-42，跨会话也要保留", NeedsEvidence: b(true), NeedsMutation: b(true)},
+	{Name: "durable memory advice", Text: "How do I save a preference permanently across sessions?", NeedsEvidence: b(false), NeedsMutation: b(false)},
+}
+
+// Task carry the task-vs-chat label: greetings and acknowledgements must
+// not arm the delivery gates, while actionable requests and failure reports must.
+var Task = []Case{
+	{Name: "hello", Text: "hello", IsTask: b(false)},
+	{Name: "hi", Text: "hi", IsTask: b(false)},
+	{Name: "你好", Text: "你好", IsTask: b(false)},
+	{Name: "thanks", Text: "thanks", IsTask: b(false)},
+	{Name: "谢谢", Text: "谢谢", IsTask: b(false)},
+	{Name: "ok", Text: "ok", IsTask: b(false)},
+	{Name: "好的", Text: "好的", IsTask: b(false)},
+	{Name: "收到", Text: "收到", IsTask: b(false)},
+	{Name: "我知道了", Text: "我知道了", IsTask: b(false)},
+	{Name: "先不用", Text: "先不用", IsTask: b(false)},
+	{Name: "fix bug", Text: "fix the bug", IsTask: b(true)},
+	{Name: "create component", Text: "create a component", IsTask: b(true)},
+	{Name: "修复问题", Text: "修复这个问题", IsTask: b(true)},
+	{Name: "run tests", Text: "run tests", IsTask: b(true)},
+	{Name: "modify config", Text: "modify config", IsTask: b(true)},
+	{Name: "make changes", Text: "make the requested changes", IsTask: b(true)},
+	{Name: "adjust config", Text: "调整现有配置", IsTask: b(true)},
+	{Name: "push branch", Text: "push the branch", IsTask: b(true)},
+	{Name: "publish release", Text: "publish release", IsTask: b(true)},
+	{Name: "看看", Text: "帮我看看这个错误", IsTask: b(true)},
+	{Name: "帮我看下", Text: "帮我看下这个问题", IsTask: b(true)},
+	{Name: "处理下", Text: "处理下这个 issue", IsTask: b(true)},
+	{Name: "排查", Text: "排查一下启动失败", IsTask: b(true)},
+	{Name: "定位", Text: "定位这个异常", IsTask: b(true)},
+	{Name: "thanks for fixing", Text: "thanks for fixing that!", IsTask: b(false)},
+	{Name: "check later", Text: "I'll check later", IsTask: b(false)},
+	{Name: "test later", Text: "I'll test it later", IsTask: b(false)},
+	{Name: "test was helpful", Text: "that test was helpful", IsTask: b(false)},
+	{Name: "辛苦了", Text: "辛苦了", IsTask: b(false)},
+	{Name: "thanks then update", Text: "thanks for fixing that, now update the tests", IsTask: b(true)},
+	{Name: "chinese thanks then update", Text: "谢谢你，请继续修改配置", IsTask: b(true)},
+	{Name: "task before thanks", Text: "review this PR; thanks for the help", IsTask: b(true)},
+	{Name: "auth not working", Text: "the auth isn't working", IsTask: b(true)},
+	{Name: "help with login", Text: "can you help with login?", IsTask: b(true)},
+	{Name: "问题严重", Text: "这个问题很严重", IsTask: b(true)},
+	{Name: "卡住了", Text: "页面卡住了", IsTask: b(true)},
+	{Name: "没反应", Text: "按钮点击没反应", IsTask: b(true)},
+	{Name: "不生效", Text: "配置不生效", IsTask: b(true)},
+	{Name: "异常退出", Text: "程序异常退出", IsTask: b(true)},
+	{Name: "file reference", Text: "what about @auth.go", IsTask: b(true)},
+	{Name: "localized file reference", Text: "检查（@配置.yaml）", IsTask: b(true)},
+	{Name: "python file", Text: "check main.py", IsTask: b(true)},
+	{Name: "markdown file", Text: "why does README.md render incorrectly", IsTask: b(true)},
+	{Name: "relative script", Text: "why does ./scripts/verify.sh fail", IsTask: b(true)},
+	{Name: "email is not file reference", Text: "thanks, email me@example.com later", IsTask: b(false)},
+	{Name: "long conversation is not task", Text: "Remember ORBIT-42 and answer on the next turn please", IsTask: b(false)},
+	{Name: "durable memory is task", Text: "Remember ORBIT-42 permanently across sessions", IsTask: b(true)},
+	{Name: "empty", Text: "", IsTask: b(false)},
+	{Name: "spaces", Text: "   ", IsTask: b(false)},
+	{Name: "question mark", Text: "?", IsTask: b(false)},
+}
+
+// GoalBudget carry the Goal write-budget label. Several also carry a
+// mutation label, because the corpus deliberately pins turns where the two
+// consumers must disagree: a bare fault report is Goal write work but not an
+// ordinary Delivery mutation request.
+var GoalBudget = []Case{
+	{Name: "chinese historical bug", Text: "数据模型管理器又出现历史 BUG 了……", NeedsWriteBudget: b(true), NeedsMutation: b(false)},
+	{Name: "chinese settings crash", Text: "应用打开设置时崩溃", NeedsWriteBudget: b(true), NeedsMutation: b(false)},
+	{Name: "auth crashes", Text: "the auth service crashes on login", NeedsWriteBudget: b(true)},
+	{Name: "parser exception", Text: "parser throws an exception on empty input", NeedsWriteBudget: b(true)},
+	{Name: "fix crash in file", Text: "fix the crash in a.go", NeedsWriteBudget: b(true), NeedsMutation: b(true)},
+	{Name: "chinese fix wps crash", Text: "帮我修复wps的崩溃问题", NeedsWriteBudget: b(true)},
+	{Name: "why fail and fix", Text: "why does it fail and fix it", NeedsWriteBudget: b(true)},
+	{Name: "chinese why fail then fix", Text: "为什么失败然后修复它", NeedsWriteBudget: b(true), NeedsMutation: b(true)},
+	{Name: "chinese explain and fix", Text: "解释失败原因并修复", NeedsWriteBudget: b(true)},
+
+	{Name: "chinese why bug question", Text: "为什么会出现这个 BUG？", NeedsWriteBudget: b(false), NeedsMutation: b(false)},
+	{Name: "chinese analysis only", Text: "只分析原因，不要修改代码。", NeedsWriteBudget: b(false)},
+	{Name: "chinese diagnose db", Text: "诊断数据库连接失败原因。", NeedsWriteBudget: b(false), NeedsMutation: b(false)},
+	{Name: "chinese reproduce no fix", Text: "复现并定位问题，但不要修复。", NeedsWriteBudget: b(false)},
+	{Name: "why bug question", Text: "why does this bug happen?", NeedsWriteBudget: b(false)},
+	{Name: "explain without changing", Text: "explain the crash without changing code", NeedsWriteBudget: b(false)},
+	{Name: "reproduce and root cause", Text: "reproduce the crash and identify the root cause", NeedsWriteBudget: b(false), NeedsMutation: b(false)},
+	{Name: "review only no fix", Text: "review only and do not fix anything", NeedsWriteBudget: b(false)},
+	{Name: "hello", Text: "hello", NeedsWriteBudget: b(false)},
+}
+
+// All is every labeled case across the three sources.
+func All() []Case {
+	out := make([]Case, 0, len(Delivery)+len(Task)+len(GoalBudget))
+	for _, c := range Delivery {
+		c.Origin = "delivery_classification"
+		out = append(out, c)
+	}
+	for _, c := range Task {
+		c.Origin = "task_heuristic"
+		out = append(out, c)
+	}
+	for _, c := range GoalBudget {
+		c.Origin = "goal_budget_class"
+		out = append(out, c)
+	}
+	return out
+}

--- a/internal/intent/corpus/corpus_test.go
+++ b/internal/intent/corpus/corpus_test.go
@@ -1,0 +1,62 @@
+package corpus
+
+import "testing"
+
+// The corpus is consumed by t.Run subtests in internal/agent and by the live
+// classifier evaluation. These invariants catch the mistakes that would silently
+// weaken either consumer: a duplicate name makes two subtests collide, a
+// duplicate text double-counts accuracy, and a case with no labels asserts
+// nothing while still looking like coverage.
+func TestCorpusInvariants(t *testing.T) {
+	sets := map[string][]Case{
+		"Delivery":   Delivery,
+		"Task":       Task,
+		"GoalBudget": GoalBudget,
+	}
+
+	for name, set := range sets {
+		t.Run(name, func(t *testing.T) {
+			if len(set) == 0 {
+				t.Fatal("corpus set is empty")
+			}
+			names := map[string]bool{}
+			texts := map[string]bool{}
+			for i, c := range set {
+				if c.Name == "" {
+					t.Errorf("case %d has no name", i)
+				}
+				if names[c.Name] {
+					t.Errorf("duplicate case name %q: subtests would collide", c.Name)
+				}
+				names[c.Name] = true
+
+				// Empty text is a deliberate edge case; only guard duplicates.
+				if c.Text != "" {
+					if texts[c.Text] {
+						t.Errorf("duplicate case text %q", c.Text)
+					}
+					texts[c.Text] = true
+				}
+
+				if c.NeedsEvidence == nil && c.NeedsMutation == nil &&
+					c.IsTask == nil && c.NeedsWriteBudget == nil {
+					t.Errorf("case %q carries no labels and asserts nothing", c.Name)
+				}
+			}
+		})
+	}
+}
+
+// TestAllCarriesOrigin pins that All stamps provenance, which the evaluation
+// harness reports so a disagreement can be traced back to the test that owns it.
+func TestAllCarriesOrigin(t *testing.T) {
+	all := All()
+	if want := len(Delivery) + len(Task) + len(GoalBudget); len(all) != want {
+		t.Fatalf("All() returned %d cases, want %d", len(all), want)
+	}
+	for _, c := range all {
+		if c.Origin == "" {
+			t.Errorf("case %q has no Origin", c.Name)
+		}
+	}
+}

--- a/internal/intent/eval_live_test.go
+++ b/internal/intent/eval_live_test.go
@@ -1,0 +1,236 @@
+package intent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/intent/corpus"
+)
+
+// This is the live accuracy harness for a model-backed Classifier. It answers
+// the only question that decides whether the keyword tables can be deleted:
+// does a small model reproduce the golden corpus at least as well?
+//
+// It is skipped unless credentials are supplied, so ordinary `go test ./...`
+// and CI stay hermetic and free:
+//
+//	REASONIX_INTENT_EVAL_KEY=<key> \
+//	REASONIX_INTENT_EVAL_BASE_URL=https://... \
+//	REASONIX_INTENT_EVAL_MODEL=<model> \
+//	go test ./internal/intent/ -run TestLiveClassifierAccuracy -v -timeout 30m
+//
+// The key is read from the environment and never logged.
+
+type liveClassifier struct {
+	baseURL string
+	key     string
+	model   string
+	client  *http.Client
+}
+
+// Classify retries once on an empty reply. Reasoning models on this endpoint
+// intermittently return an empty content field with the whole budget spent in
+// reasoning_content; measured at roughly 3% of calls, which is too high a
+// degradation rate for a hot-path gate to absorb silently.
+func (c *liveClassifier) Classify(ctx context.Context, text string) (TurnIntent, error) {
+	got, err := c.classifyOnce(ctx, text)
+	if err != nil && strings.Contains(err.Error(), "empty reply") {
+		return c.classifyOnce(ctx, text)
+	}
+	return got, err
+}
+
+func (c *liveClassifier) classifyOnce(ctx context.Context, text string) (TurnIntent, error) {
+	if strings.TrimSpace(text) == "" {
+		return TurnIntent{Kind: KindConversation}, nil
+	}
+	body, err := json.Marshal(map[string]any{
+		"model": c.model,
+		"messages": []map[string]string{
+			{"role": "system", "content": SystemPrompt},
+			{"role": "user", "content": text},
+		},
+		"max_tokens":  maxClassifyTokens,
+		"temperature": 0,
+	})
+	if err != nil {
+		return TurnIntent{}, err
+	}
+	url := strings.TrimSuffix(c.baseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return TurnIntent{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.key)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return TurnIntent{}, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return TurnIntent{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return TurnIntent{}, fmt.Errorf("http %d: %s", resp.StatusCode, truncate(string(raw), 200))
+	}
+
+	var envelope struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return TurnIntent{}, err
+	}
+	if len(envelope.Choices) == 0 {
+		return TurnIntent{}, fmt.Errorf("no choices")
+	}
+
+	return ParseClassifierReply(envelope.Choices[0].Message.Content)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+type caseResult struct {
+	c       corpus.Case
+	got     TurnIntent
+	err     error
+	misses  []string
+	latency time.Duration
+}
+
+func TestLiveClassifierAccuracy(t *testing.T) {
+	key := os.Getenv("REASONIX_INTENT_EVAL_KEY")
+	if key == "" {
+		t.Skip("REASONIX_INTENT_EVAL_KEY not set; skipping live accuracy evaluation")
+	}
+	baseURL := os.Getenv("REASONIX_INTENT_EVAL_BASE_URL")
+	if baseURL == "" {
+		t.Fatal("REASONIX_INTENT_EVAL_BASE_URL is required")
+	}
+	model := os.Getenv("REASONIX_INTENT_EVAL_MODEL")
+	if model == "" {
+		t.Fatal("REASONIX_INTENT_EVAL_MODEL is required")
+	}
+
+	cls := &liveClassifier{
+		baseURL: baseURL,
+		key:     key,
+		model:   model,
+		client:  &http.Client{Timeout: 120 * time.Second},
+	}
+
+	cases := corpus.All()
+	results := make([]caseResult, len(cases))
+
+	const parallel = 6
+	sem := make(chan struct{}, parallel)
+	var wg sync.WaitGroup
+	for i, c := range cases {
+		wg.Add(1)
+		go func(i int, c corpus.Case) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+			start := time.Now()
+			got, err := cls.Classify(ctx, c.Text)
+			results[i] = caseResult{c: c, got: got, err: err, latency: time.Since(start)}
+		}(i, c)
+	}
+	wg.Wait()
+
+	var (
+		total, correct, errored int
+		totalLatency            time.Duration
+		byLabel                 = map[string][2]int{} // label -> [correct, total]
+		failures                []caseResult
+	)
+
+	for i := range results {
+		r := &results[i]
+		if r.err != nil {
+			errored++
+			continue
+		}
+		totalLatency += r.latency
+
+		check := func(label string, want *bool, got bool) {
+			if want == nil {
+				return
+			}
+			total++
+			agg := byLabel[label]
+			agg[1]++
+			if *want == got {
+				correct++
+				agg[0]++
+			} else {
+				r.misses = append(r.misses, fmt.Sprintf("%s want=%v got=%v", label, *want, got))
+			}
+			byLabel[label] = agg
+		}
+
+		check("NeedsEvidence", r.c.NeedsEvidence, r.got.NeedsEvidence())
+		check("NeedsMutation", r.c.NeedsMutation, r.got.NeedsMutation())
+		check("IsTask", r.c.IsTask, r.got.IsTask())
+		check("NeedsWriteBudget", r.c.NeedsWriteBudget, r.got.NeedsGoalWriteBudget())
+
+		if len(r.misses) > 0 {
+			failures = append(failures, *r)
+		}
+	}
+
+	t.Logf("model=%s cases=%d errored=%d", model, len(cases), errored)
+	if n := len(cases) - errored; n > 0 {
+		t.Logf("mean latency: %v", totalLatency/time.Duration(n))
+	}
+	t.Logf("label accuracy: %d/%d = %.1f%%", correct, total, 100*float64(correct)/float64(total))
+
+	labels := make([]string, 0, len(byLabel))
+	for k := range byLabel {
+		labels = append(labels, k)
+	}
+	sort.Strings(labels)
+	for _, l := range labels {
+		agg := byLabel[l]
+		t.Logf("  %-18s %3d/%3d = %5.1f%%", l, agg[0], agg[1], 100*float64(agg[0])/float64(agg[1]))
+	}
+
+	sort.Slice(failures, func(i, j int) bool { return failures[i].c.Origin < failures[j].c.Origin })
+	if len(failures) > 0 {
+		t.Logf("\n%d case(s) disagree with the golden corpus:", len(failures))
+		for _, f := range failures {
+			t.Logf("  [%s] %q\n      kind=%s fault=%v readonly=%v diagnostic=%v durable=%v\n      %s",
+				f.c.Origin, f.c.Text, f.got.Kind, f.got.FaultReport, f.got.ReadOnlyConstraint,
+				f.got.DiagnosticIntent, f.got.DurableScope, strings.Join(f.misses, "; "))
+		}
+	}
+	for i := range results {
+		if results[i].err != nil {
+			t.Logf("ERROR %q: %v", results[i].c.Text, results[i].err)
+		}
+	}
+}

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -1,0 +1,207 @@
+// Package intent carries one structured reading of a user turn, shared by every
+// host-side gate that needs to know what the user asked for.
+//
+// It exists because the same question was previously answered independently in
+// several places - the delivery evidence gate, the Goal budget classifier, and
+// the planner route gate each kept their own keyword tables. Those tables drifted
+// (five separate mutation-verb lists) and disagreed (two different negation word
+// lists), so the same sentence could be judged differently by two gates in one
+// turn.
+//
+// The split of responsibility here is deliberate:
+//
+//   - Perception (what did the user ask for?) is one result, produced once.
+//   - Derivation (what does that mean for my gate?) stays deterministic Go,
+//     lives next to the fields it reads, and is unit-testable without a model.
+//
+// Keeping derivation deterministic is not a stylistic preference. The golden
+// corpus pins a case where one sentence must produce opposite answers for two
+// consumers: a bare fault report such as "数据模型管理器又出现历史 BUG 了……"
+// must start a Goal on the write budget while ordinary Delivery must not treat it
+// as a mutation request. A single boolean classifier cannot express that; a
+// structured intent plus per-consumer derivation can.
+package intent
+
+// Kind is the coarse reading of a turn, ordered from least to most host-visible
+// work. It mirrors the classification the delivery gate has always made, lifted
+// out of internal/agent so other gates can share one vocabulary.
+type Kind uint8
+
+const (
+	// KindUnknown means no source could read the turn. Consumers must apply
+	// their own degraded-mode default rather than treating it as any other Kind;
+	// inventing an answer here is the defect this package exists to remove.
+	KindUnknown Kind = iota
+	// KindConversation is chat: greetings, acknowledgements, and requests whose
+	// whole scope is the current conversation.
+	KindConversation
+	// KindAdvisory is a question seeking explanation or recommendation rather
+	// than host-observable work.
+	KindAdvisory
+	// KindObservableRead requires the host to look at real state - read files,
+	// run read-only commands, inspect a repository - but not change it.
+	KindObservableRead
+	// KindMutation requires a state change the host can observe.
+	KindMutation
+	// KindPersistentAction requires a durable write that outlives the session,
+	// such as saving a memory across sessions.
+	KindPersistentAction
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindConversation:
+		return "conversation"
+	case KindAdvisory:
+		return "advisory"
+	case KindObservableRead:
+		return "observable_read"
+	case KindMutation:
+		return "mutation"
+	case KindPersistentAction:
+		return "persistent_action"
+	default:
+		return "unknown"
+	}
+}
+
+// Source names which tier produced a TurnIntent, ordered by trust. It is carried
+// on the result so audits can report how often the expensive tier was needed and
+// so consumers can choose to distrust a low-confidence classification.
+type Source uint8
+
+const (
+	// SourceNone accompanies KindUnknown.
+	SourceNone Source = iota
+	// SourceExplicit came from syntax the user typed with an agreed meaning, or
+	// from a host toggle the user set. Never inferred from prose.
+	SourceExplicit
+	// SourceDeclared came from the model's own structured output - typed tool
+	// arguments and evidence receipts it already committed to.
+	SourceDeclared
+	// SourceKeyword came from the legacy substring tables. It is a prose reading
+	// like SourceClassifier, but kept distinct so migration audits can tell an
+	// answer the word tables produced from one a model produced.
+	SourceKeyword
+	// SourceClassifier came from reading the user's prose with a model.
+	SourceClassifier
+)
+
+func (s Source) String() string {
+	switch s {
+	case SourceExplicit:
+		return "explicit"
+	case SourceDeclared:
+		return "declared"
+	case SourceKeyword:
+		return "keyword"
+	case SourceClassifier:
+		return "classifier"
+	default:
+		return "none"
+	}
+}
+
+// TurnIntent is the shared structured reading of one user turn.
+//
+// Fields beyond Kind exist because the corpus proves Kind alone is lossy: two
+// consumers need to disagree about the same turn, and they can only do that if
+// the facts that distinguish them survive into the result.
+type TurnIntent struct {
+	Kind Kind
+
+	// FaultReport is set when the user described something malfunctioning,
+	// whether or not they asked for a repair - "the auth isn't working",
+	// "页面卡住了". It is the field that lets a Goal treat a bare fault as write
+	// work while Delivery still treats it as a read.
+	FaultReport bool
+
+	// ReadOnlyConstraint is set when the user explicitly forbade changes:
+	// "review only and do not fix anything", "只分析原因，不要修改代码". It must
+	// suppress write inference even when mutation verbs are present, so it is
+	// carried separately rather than folded into Kind.
+	ReadOnlyConstraint bool
+
+	// DiagnosticIntent is set when the user asked to understand a fault rather
+	// than repair it - "diagnose", "identify the root cause", "reproduce",
+	// "诊断", "定位原因". It is deliberately separate from ReadOnlyConstraint:
+	// that field is an explicit prohibition ("do not change anything"), while
+	// this one is a scope the user chose without forbidding anything. Live
+	// evaluation found the distinction is load-bearing - "诊断数据库连接失败原因。"
+	// carries no prohibition, yet must keep a Goal off the write budget.
+	DiagnosticIntent bool
+
+	// DurableScope is set when the request reaches beyond this session -
+	// "permanently", "across sessions", "跨会话". Paired with a save/remember
+	// request it is what separates KindPersistentAction from a conversational
+	// "remember this for the next turn".
+	DurableScope bool
+
+	// Source records which tier answered.
+	Source Source
+}
+
+// Unknown reports whether no tier could read the turn. Consumers must branch on
+// this before using any derivation: the derivations below answer for a turn that
+// was actually read, and a zero TurnIntent is not a conversation.
+func (t TurnIntent) Unknown() bool { return t.Kind == KindUnknown }
+
+// IsTask reports whether the turn reads as actionable work rather than chat.
+// Greetings and acknowledgements must not arm the delivery gates; everything
+// that asks for something - including a question about real state - does.
+func (t TurnIntent) IsTask() bool {
+	return t.Kind != KindConversation && t.Kind != KindUnknown
+}
+
+// NeedsEvidence reports whether the turn must show host-observable work before
+// it may finish. Advisory questions and chat must not arm the gate.
+func (t TurnIntent) NeedsEvidence() bool {
+	switch t.Kind {
+	case KindObservableRead, KindMutation, KindPersistentAction:
+		return true
+	default:
+		return false
+	}
+}
+
+// NeedsMutation reports whether the turn requires an observable state change.
+// An explicit read-only constraint always wins: the user forbidding changes is
+// a stronger signal than any verb they used to describe the subject.
+func (t TurnIntent) NeedsMutation() bool {
+	if t.ReadOnlyConstraint {
+		return false
+	}
+	return t.Kind == KindMutation || t.Kind == KindPersistentAction
+}
+
+// NeedsPersistentAction reports whether the turn requires a durable write that
+// outlives the session.
+func (t TurnIntent) NeedsPersistentAction() bool {
+	if t.ReadOnlyConstraint {
+		return false
+	}
+	return t.Kind == KindPersistentAction
+}
+
+// NeedsGoalWriteBudget reports whether a Goal objective should start on the
+// extended write turn budget.
+//
+// It deliberately differs from NeedsMutation: a Goal is a long-horizon objective,
+// so a bare fault report is work to be fixed unless the user asked only to
+// understand it. Ordinary Delivery keeps the stricter reading, which is why this
+// derivation lives here rather than being folded into Kind.
+func (t TurnIntent) NeedsGoalWriteBudget() bool {
+	if t.NeedsMutation() {
+		return true
+	}
+	if !t.FaultReport || t.ReadOnlyConstraint {
+		return false
+	}
+	// A fault the user only wants explained or diagnosed stays consultative.
+	// DiagnosticIntent covers wording that scopes the work to understanding
+	// without forbidding a change outright.
+	if t.DiagnosticIntent {
+		return false
+	}
+	return t.Kind != KindAdvisory && t.Kind != KindConversation
+}

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -1,0 +1,190 @@
+package intent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestCrossConsumerDisagreement pins the case that constrains the whole design.
+//
+// The golden corpus in internal/agent (goal_budget_class_test.go) requires one
+// sentence to produce opposite answers for two consumers: a bare fault report
+// starts a Goal on the write budget, while ordinary Delivery must not treat it
+// as a mutation request. A flat boolean classifier cannot express this, which is
+// why TurnIntent carries FaultReport separately from Kind.
+func TestCrossConsumerDisagreement(t *testing.T) {
+	// "数据模型管理器又出现历史 BUG 了……" - a malfunction reported with no
+	// imperative verb and no explicit read-only constraint.
+	bareFault := TurnIntent{Kind: KindObservableRead, FaultReport: true, Source: SourceClassifier}
+
+	if bareFault.NeedsMutation() {
+		t.Error("ordinary Delivery must not read a bare fault report as a mutation request")
+	}
+	if !bareFault.NeedsGoalWriteBudget() {
+		t.Error("a Goal must start a bare fault report on the write budget")
+	}
+	if !bareFault.NeedsEvidence() {
+		t.Error("a bare fault report is observable work and must arm the evidence gate")
+	}
+}
+
+// TestReadOnlyConstraintOverridesMutationVerbs pins that an explicit prohibition
+// beats any verb in the same turn. "review only and do not fix anything" carries
+// the mutation verb "fix" but must never require a state change.
+func TestReadOnlyConstraintOverridesMutationVerbs(t *testing.T) {
+	constrained := TurnIntent{Kind: KindMutation, ReadOnlyConstraint: true, FaultReport: true}
+
+	if constrained.NeedsMutation() {
+		t.Error("an explicit read-only constraint must suppress mutation")
+	}
+	if constrained.NeedsPersistentAction() {
+		t.Error("an explicit read-only constraint must suppress persistent writes")
+	}
+	if constrained.NeedsGoalWriteBudget() {
+		t.Error("an explicit read-only constraint must keep a Goal off the write budget")
+	}
+	if !constrained.NeedsEvidence() {
+		t.Error("review-only work is still observable work")
+	}
+}
+
+// TestAdvisoryFaultStaysConsultative pins that a fault the user only wants
+// explained ("why does this bug happen?") does not become write work.
+func TestAdvisoryFaultStaysConsultative(t *testing.T) {
+	advisory := TurnIntent{Kind: KindAdvisory, FaultReport: true}
+
+	if advisory.NeedsGoalWriteBudget() {
+		t.Error("an explained-only fault must stay on the simple Goal budget")
+	}
+	if advisory.NeedsEvidence() {
+		t.Error("advisory questions must not arm the delivery evidence gate")
+	}
+}
+
+// TestDurableScopeSeparatesMemoryKinds pins the distinction the corpus draws
+// between "Remember ORBIT-42 and answer on the next turn" (conversation) and
+// "Remember ORBIT-42 permanently across sessions" (persistent action).
+func TestDurableScopeSeparatesMemoryKinds(t *testing.T) {
+	conversational := TurnIntent{Kind: KindConversation, DurableScope: false}
+	if conversational.NeedsPersistentAction() || conversational.NeedsEvidence() {
+		t.Error("a next-turn memory request is conversation, not durable work")
+	}
+
+	durable := TurnIntent{Kind: KindPersistentAction, DurableScope: true}
+	if !durable.NeedsPersistentAction() {
+		t.Error("an across-sessions memory request must require a durable write")
+	}
+	if !durable.NeedsMutation() {
+		t.Error("a durable write is a state change")
+	}
+	if !durable.NeedsEvidence() {
+		t.Error("a durable write must arm the evidence gate")
+	}
+}
+
+// TestUnknownIsNotConversation pins the distinction the package exists to keep:
+// a turn nobody could read must not silently behave like chat. Consumers branch
+// on Unknown and apply their own degraded default.
+func TestUnknownIsNotConversation(t *testing.T) {
+	var zero TurnIntent
+	if !zero.Unknown() {
+		t.Fatal("the zero TurnIntent must report Unknown")
+	}
+	if zero.NeedsEvidence() || zero.NeedsMutation() || zero.NeedsGoalWriteBudget() {
+		t.Error("an unread turn must not arm any gate by default")
+	}
+}
+
+// TestBoundedDegradesToUnknown pins the failure discipline: a classifier that
+// errors, times out, or is absent yields Unknown rather than a reading, and
+// never returns an error the caller could mistake for a classification.
+func TestBoundedDegradesToUnknown(t *testing.T) {
+	t.Run("nil inner", func(t *testing.T) {
+		var b Bounded
+		got, err := b.Classify(context.Background(), "fix the bug")
+		if err != nil || !got.Unknown() {
+			t.Fatalf("nil inner = (%v, %v), want (unknown, nil)", got.Kind, err)
+		}
+	})
+
+	t.Run("inner error", func(t *testing.T) {
+		audit := &Audit{}
+		b := Bounded{
+			Inner: ClassifierFunc(func(context.Context, string) (TurnIntent, error) {
+				return TurnIntent{Kind: KindMutation}, errors.New("provider down")
+			}),
+			Audit: audit,
+		}
+		got, err := b.Classify(context.Background(), "fix the bug")
+		if err != nil {
+			t.Fatalf("Classify returned an error: %v", err)
+		}
+		if !got.Unknown() {
+			t.Fatalf("a failed classification leaked Kind %v", got.Kind)
+		}
+		if snap := audit.Snapshot(); snap["degraded"] != 1 {
+			t.Errorf("degraded counter = %d, want 1", snap["degraded"])
+		}
+	})
+
+	t.Run("timeout is bounded", func(t *testing.T) {
+		b := Bounded{
+			Timeout: 10 * time.Millisecond,
+			Inner: ClassifierFunc(func(ctx context.Context, _ string) (TurnIntent, error) {
+				<-ctx.Done()
+				return TurnIntent{}, ctx.Err()
+			}),
+		}
+		start := time.Now()
+		got, err := b.Classify(context.Background(), "fix the bug")
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Fatalf("Classify took %v; the timeout did not bound it", elapsed)
+		}
+		if err != nil || !got.Unknown() {
+			t.Fatalf("timed-out classify = (%v, %v), want (unknown, nil)", got.Kind, err)
+		}
+	})
+}
+
+// TestBoundedCachesAnswers pins that a repeated turn does not re-call the model,
+// and that the cache expires.
+func TestBoundedCachesAnswers(t *testing.T) {
+	calls := 0
+	now := time.Unix(0, 0)
+	audit := &Audit{}
+	b := Bounded{
+		TTL:   time.Minute,
+		Audit: audit,
+		Now:   func() time.Time { return now },
+		Inner: ClassifierFunc(func(context.Context, string) (TurnIntent, error) {
+			calls++
+			return TurnIntent{Kind: KindMutation}, nil
+		}),
+	}
+
+	for i := 0; i < 3; i++ {
+		got, _ := b.Classify(context.Background(), "fix the bug")
+		if got.Kind != KindMutation {
+			t.Fatalf("call %d = %v, want mutation", i, got.Kind)
+		}
+		if got.Source != SourceClassifier {
+			t.Errorf("call %d source = %v, want classifier", i, got.Source)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("inner called %d times, want 1 (cache should absorb repeats)", calls)
+	}
+	if snap := audit.Snapshot(); snap["cache_hits"] != 2 {
+		t.Errorf("cache_hits = %d, want 2", snap["cache_hits"])
+	}
+
+	now = now.Add(2 * time.Minute)
+	if _, err := b.Classify(context.Background(), "fix the bug"); err != nil {
+		t.Fatalf("post-expiry classify: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("inner called %d times after expiry, want 2", calls)
+	}
+}

--- a/internal/intent/model_classifier.go
+++ b/internal/intent/model_classifier.go
@@ -1,0 +1,213 @@
+package intent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// SystemPrompt is the classifier contract. It lives in production code, not in
+// the evaluation harness, so the measured accuracy is the accuracy of what
+// actually ships: the live corpus run judges this exact text.
+//
+// Most of it is product rules the model cannot infer. Live evaluation started at
+// 94.4% with only the schema, and reached 99.5% once the four "decisive rules"
+// below were stated. Every rule here earned its place by fixing a measured
+// disagreement with the golden corpus - do not trim it without re-running
+// TestLiveClassifierAccuracy.
+const SystemPrompt = `You classify ONE user turn sent to a coding agent. Reply with strict JSON only, no prose, no markdown fence, no explanation.
+
+Schema:
+{"kind":"<one of: conversation|advisory|observable_read|mutation|persistent_action>",
+ "fault_report":<bool>,"read_only_constraint":<bool>,"diagnostic_intent":<bool>,"durable_scope":<bool>}
+
+kind definitions:
+- conversation: greetings, thanks, acknowledgements, and requests whose entire scope is this chat (e.g. "remember X and answer next turn").
+- advisory: a question seeking explanation, opinion, or general how-to that does NOT require inspecting state on THIS machine or repository.
+- observable_read: requires looking at real state HERE - reading files, running read-only commands, inspecting a named file/repo/command - but changing nothing.
+- mutation: the user asked for a change (edit, create, delete, run a state-changing command, commit, push, install, configure).
+- persistent_action: requires a durable write that outlives this session (e.g. "remember X permanently across sessions").
+
+field definitions:
+- fault_report: the user reported something malfunctioning (crash, bug, error, "not working", 崩溃/报错/卡住/不生效), whether or not they asked for a repair.
+- read_only_constraint: the user explicitly FORBADE changes ("review only", "do not fix", "只分析", "不要修改").
+- diagnostic_intent: the user scoped the work to understanding rather than repairing, WITHOUT forbidding anything ("diagnose", "identify the root cause", "reproduce", "investigate", "诊断", "定位原因", "排查原因"). This is different from read_only_constraint.
+- durable_scope: the request explicitly reaches beyond this session ("permanently", "across sessions", "永久", "跨会话").
+
+Decisive rules:
+1. LOCAL vs REMOTE. observable_read requires something inspectable HERE - a file, a path, a command, this repo, this codebase. Merely REPORTING or ASKING ABOUT a malfunction in some OTHER product or a remote website (Outlook, WPS, a github.com URL, "the plugin") has nothing local to inspect, so it is advisory. This applies only to reports and questions: if the user explicitly asks you to fix or change it ("帮我修复wps的崩溃问题", "fix the Outlook sync"), that is still mutation no matter which software it is about.
+2. REPORTING A FAULT IS NOT REQUESTING A CHANGE. "the app crashes when opening settings" / "应用打开设置时崩溃" describes a problem; the user did not ask for an edit. That is observable_read with fault_report=true, NOT mutation. Only choose mutation when the user actually asked for the change.
+3. DIAGNOSIS IS NOT REPAIR. "reproduce the crash and identify the root cause" / "诊断数据库连接失败原因。" is observable_read with diagnostic_intent=true, NOT mutation.
+4. NEGATION SCOPE. "I cannot install and update dependencies" states an inability about BOTH verbs -> conversation. But "I cannot install dependencies but patch the parser" refuses one clause and requests the other -> mutation.
+5. ASKING SOMEONE TO LOOK IS A TASK. "帮我看下这个问题" / "这个问题很严重" is the user raising a problem for you to handle -> observable_read, not conversation.
+6. Politeness and thanks do not change the request. "thanks for fixing that, now update the tests" -> mutation.
+7. An email address, URL, or "later" is not a memory request. "thanks, email me@example.com later" is conversation.`
+
+// maxClassifyTokens is generous because reasoning models spend most of their
+// budget in reasoning_content and return empty content if the cap is hit
+// mid-thought. Measured at roughly 3% empty replies with a tighter cap.
+const maxClassifyTokens = 8000
+
+// ModelClassifier reads a user turn with a provider-backed model. Wrap it in
+// Bounded before use: this type does the call and the parsing, while Bounded
+// owns the timeout, cache, and degradation policy.
+//
+// The shape mirrors capability.SemanticRouter so routing and intent report usage
+// and cost the same way.
+type ModelClassifier struct {
+	Provider provider.Provider
+	Sink     event.Sink
+	Model    string
+	// Pricing prices this classifier's own usage events; without it the cost
+	// always displays as zero.
+	Pricing *provider.Pricing
+}
+
+type classifyReply struct {
+	Kind               string `json:"kind"`
+	FaultReport        bool   `json:"fault_report"`
+	ReadOnlyConstraint bool   `json:"read_only_constraint"`
+	DiagnosticIntent   bool   `json:"diagnostic_intent"`
+	DurableScope       bool   `json:"durable_scope"`
+}
+
+// Classify returns KindUnknown with a nil error when the turn cannot be read.
+// It returns an error only for transport and protocol failures, which Bounded
+// converts into the same unknown result.
+//
+// It retries once on an empty reply. Reasoning models spend their budget in
+// reasoning_content and intermittently return empty content - measured at
+// roughly 3% of calls against a reasoning model. Without the retry that is a 3%
+// silent degradation rate on a gate, which is too high to absorb quietly.
+func (c *ModelClassifier) Classify(ctx context.Context, text string) (TurnIntent, error) {
+	got, err := c.classifyOnce(ctx, text)
+	if err != nil && strings.Contains(err.Error(), errEmptyReply) {
+		return c.classifyOnce(ctx, text)
+	}
+	return got, err
+}
+
+const errEmptyReply = "empty reply"
+
+func (c *ModelClassifier) classifyOnce(ctx context.Context, text string) (TurnIntent, error) {
+	if c == nil || c.Provider == nil {
+		return TurnIntent{}, nil
+	}
+	if strings.TrimSpace(text) == "" {
+		return TurnIntent{}, nil
+	}
+	ctx = provider.WithRequestAttemptCounter(ctx)
+
+	req := provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: SystemPrompt},
+			{Role: provider.RoleUser, Content: text},
+		},
+		Temperature: provider.TemperaturePtr(0),
+		MaxTokens:   maxClassifyTokens,
+	}
+
+	var usage *provider.Usage
+	defer func() {
+		usage = provider.UsageWithRequestAttemptCount(ctx, usage)
+		if usage == nil || c.Sink == nil {
+			return
+		}
+		c.Sink.Emit(event.Event{
+			Kind:        event.Usage,
+			ModelRef:    strings.TrimSpace(c.Model),
+			Usage:       usage,
+			Pricing:     c.Pricing,
+			UsageSource: event.UsageSourceCapabilityRouter,
+		})
+	}()
+
+	ch, err := c.Provider.Stream(ctx, req)
+	if err != nil {
+		return TurnIntent{}, err
+	}
+	var out strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			out.WriteString(chunk.Text)
+		case provider.ChunkUsage:
+			if chunk.Usage != nil {
+				u := *chunk.Usage
+				usage = &u
+			}
+		case provider.ChunkError:
+			if chunk.Err != nil {
+				return TurnIntent{}, chunk.Err
+			}
+		}
+	}
+	return ParseClassifierReply(out.String())
+}
+
+// ParseClassifierReply turns a raw model reply into a TurnIntent. It is exported
+// so the evaluation harness parses replies exactly the way production does.
+//
+// An unrecognized kind yields KindUnknown rather than a default, so a model that
+// invents a label degrades instead of silently landing in some other bucket.
+func ParseClassifierReply(raw string) (TurnIntent, error) {
+	content := strings.TrimSpace(raw)
+	if content == "" {
+		return TurnIntent{}, fmt.Errorf("%s", errEmptyReply)
+	}
+	content = stripCodeFence(content)
+	if start := strings.Index(content, "{"); start >= 0 {
+		if end := strings.LastIndex(content, "}"); end > start {
+			content = content[start : end+1]
+		}
+	}
+	var parsed classifyReply
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return TurnIntent{}, fmt.Errorf("unparseable reply %q: %w", clip(content, 120), err)
+	}
+
+	kind := KindUnknown
+	switch parsed.Kind {
+	case "conversation":
+		kind = KindConversation
+	case "advisory":
+		kind = KindAdvisory
+	case "observable_read":
+		kind = KindObservableRead
+	case "mutation":
+		kind = KindMutation
+	case "persistent_action":
+		kind = KindPersistentAction
+	}
+	if kind == KindUnknown {
+		return TurnIntent{}, nil
+	}
+	return TurnIntent{
+		Kind:               kind,
+		FaultReport:        parsed.FaultReport,
+		ReadOnlyConstraint: parsed.ReadOnlyConstraint,
+		DiagnosticIntent:   parsed.DiagnosticIntent,
+		DurableScope:       parsed.DurableScope,
+		Source:             SourceClassifier,
+	}, nil
+}
+
+func stripCodeFence(s string) string {
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "```"))
+}
+
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/taskintent/classification_test.go
+++ b/internal/taskintent/classification_test.go
@@ -1,79 +1,29 @@
 package taskintent
 
-import "testing"
+import (
+	"testing"
+
+	"reasonix/internal/intent/corpus"
+)
 
 // TestDeliveryClassificationMatrix protects the boundary between advisory
 // troubleshooting, observable read-only work, and mutation delivery.
+//
+// The case table lives in internal/intent/corpus so this gate test and the
+// classifier evaluation harness judge one corpus. Holding a private copy here
+// is what let the keyword tables drift apart in the first place.
 func TestDeliveryClassificationMatrix(t *testing.T) {
-	tests := []struct {
-		name         string
-		input        string
-		wantEvidence bool
-		wantMutation bool
-	}{
-		{"make sense", "why does this make sense?", false, false},
-		{"node prose", "why does the node selection matter?", false, false},
-		{"swift prose", "why does Swift concurrency work this way?", false, false},
-		{"go prose", "why does this go wrong so often?", false, false},
-		{"remote url", "why can't I open https://github.com?", false, false},
-		{"remote analysis", "can you analyze why Outlook won't sync?", false, false},
-		{"how to install", "how do I install the plugin?", false, false},
-		{"chinese how to install", "如何安装插件", false, false},
-		{"chinese how to modify", "怎么修改 WPS 设置", false, false},
-		{"python prose", "why is Python popular?", false, false},
-		{"docker prose", "why is Docker popular?", false, false},
-		{"pytest prose", "why is pytest popular?", false, false},
-		{"backtick python prose", "why is `Python` popular?", false, false},
-		{"backtick code identifier", "what does `context.Context` mean?", false, false},
-		{"double dash prose", "why is this -- strangely -- happening?", false, false},
-		{"advisory upgrade", "为什么升级插件后失败", false, false},
-		{"advisory adjustment", "为什么调整设置后没有效果", false, false},
-		{"advisory change application", "为什么申请修改失败", false, false},
-		{"negated change", "please don't make the requested changes", false, false},
-		{"negated chinese", "请勿修改代码", false, false},
-		{"negated inspection", "Explain why it fails. Do not inspect or change files.", false, false},
-		{"negated chinese inspection", "解释失败原因，不要检查或修改文件", false, false},
-		{"review only", "review only and do not fix anything", true, false},
-		{"markdown anchor", "why does README.md render incorrectly?", true, false},
-		{"git command", "why does git diff --check fail?", true, false},
-		{"custom command", "why does mytool --strict fail?", true, false},
-		{"repository anchor", "can you analyze this repository and explain why it fails?", true, false},
-		{"observable audit", "audit the current configuration", true, false},
-		{"make changes", "make the necessary changes", true, true},
-		{"thanks then update", "thanks for fixing that, now update the tests", true, true},
-		{"chinese thanks then update", "谢谢你，请继续修改配置", true, true},
-		{"thanks then review", "thanks for the help; now review this pull request", true, false},
-		{"modify", "please modify the config", true, true},
-		{"push", "push the branch", true, true},
-		{"commit", "commit the fix", true, true},
-		{"move", "move the file", true, true},
-		{"bump", "bump the dependency", true, true},
-		{"advice then fix", "why does it fail and fix it", true, true},
-		{"polite fix before advice", "could you please fix why it fails", true, true},
-		{"chinese polite fix before advice", "请你帮我修复为什么会失败", true, true},
-		{"chinese advice then fix", "为什么失败然后修复它", true, true},
-		{"negated install then patch", "I cannot install dependencies but patch the parser", true, true},
-		{"shared negation", "I cannot install and update dependencies", false, false},
-		{"reset negation", "I cannot install dependencies and please update config", true, true},
-		{"chinese reset", "无法安装依赖请在现有配置中修改", true, true},
-		{"negated request", "不想请团队修改代码", false, false},
-		{"negated application", "禁止申请修改配置", false, false},
-		{"deferred conversation token", "Remember ORBIT-42 and answer on the next turn.", false, false},
-		{"chinese deferred conversation token", "记住 ORBIT-42，下一轮回答", false, false},
-		{"deferred token with durable negation", "Remember ORBIT-42 for the next turn. Do not save it permanently.", false, false},
-		{"chinese deferred token with durable negation", "记住 ORBIT-42，下一轮回答。不要写入文件或长期记忆。", false, false},
-		{"long conversational context", "Please keep this code in mind because I will ask you about it in my next message", false, false},
-		{"durable memory", "Remember ORBIT-42 permanently across sessions", true, true},
-		{"chinese durable memory", "请永久记住 ORBIT-42，跨会话也要保留", true, true},
-		{"durable memory advice", "How do I save a preference permanently across sessions?", false, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NeedsEvidence(tt.input); got != tt.wantEvidence {
-				t.Errorf("NeedsEvidence(%q) = %v, want %v", tt.input, got, tt.wantEvidence)
+	for _, tt := range corpus.Delivery {
+		t.Run(tt.Name, func(t *testing.T) {
+			if tt.NeedsEvidence != nil {
+				if got := NeedsEvidence(tt.Text); got != *tt.NeedsEvidence {
+					t.Errorf("NeedsEvidence(%q) = %v, want %v", tt.Text, got, *tt.NeedsEvidence)
+				}
 			}
-			if got := NeedsMutation(tt.input); got != tt.wantMutation {
-				t.Errorf("NeedsMutation(%q) = %v, want %v", tt.input, got, tt.wantMutation)
+			if tt.NeedsMutation != nil {
+				if got := NeedsMutation(tt.Text); got != *tt.NeedsMutation {
+					t.Errorf("NeedsMutation(%q) = %v, want %v", tt.Text, got, *tt.NeedsMutation)
+				}
 			}
 		})
 	}

--- a/internal/taskintent/goal_budget_test.go
+++ b/internal/taskintent/goal_budget_test.go
@@ -1,77 +1,50 @@
 package taskintent
 
-import "testing"
+import (
+	"testing"
 
+	"reasonix/internal/intent/corpus"
+)
+
+// TestGoalNeedsWriteBudgetMatrix pins which objectives start a Goal on the
+// extended write turn budget. The case table lives in internal/intent/corpus so
+// this gate test and the classifier evaluation harness judge one corpus.
 func TestGoalNeedsWriteBudgetMatrix(t *testing.T) {
-	// User-reported Chinese bare fault statement must land on the write budget.
-	const userReported = "数据模型管理器又出现历史 BUG 了……"
-	if !GoalNeedsWriteBudget(userReported) {
-		t.Fatalf("GoalNeedsWriteBudget(%q) = false, want write", userReported)
-	}
-	// Ordinary Delivery must still treat the same bare fault as non-mutation
-	// (observable read / evidence, not write-required).
-	if NeedsMutation(userReported) {
-		t.Fatalf("NeedsMutation(%q) changed; ordinary Delivery must stay non-mutation", userReported)
-	}
-
-	writeCases := []string{
-		userReported,
-		"应用打开设置时崩溃",
-		"the auth service crashes on login",
-		"parser throws an exception on empty input",
-		"fix the crash in a.go",
-		"帮我修复wps的崩溃问题",
-		"why does it fail and fix it",
-		"为什么失败然后修复它",
-		"解释失败原因并修复",
-	}
-	for _, input := range writeCases {
-		if !GoalNeedsWriteBudget(input) {
-			t.Errorf("Goal write budget missing for %q", input)
+	for _, tt := range corpus.GoalBudget {
+		if tt.NeedsWriteBudget == nil {
+			continue
 		}
-	}
-
-	simpleCases := []string{
-		"为什么会出现这个 BUG？",
-		"只分析原因，不要修改代码。",
-		"诊断数据库连接失败原因。",
-		"复现并定位问题，但不要修复。",
-		"why does this bug happen?",
-		"explain the crash without changing code",
-		"reproduce the crash and identify the root cause",
-		"review only and do not fix anything",
-		"hello",
-	}
-	for _, input := range simpleCases {
-		if GoalNeedsWriteBudget(input) {
-			t.Errorf("Goal simple budget expected for %q", input)
-		}
+		t.Run(tt.Name, func(t *testing.T) {
+			if got := GoalNeedsWriteBudget(tt.Text); got != *tt.NeedsWriteBudget {
+				t.Errorf("GoalNeedsWriteBudget(%q) = %v, want %v", tt.Text, got, *tt.NeedsWriteBudget)
+			}
+		})
 	}
 }
 
+// TestGoalBareFaultDoesNotChangeDeliveryClassification pins ordinary Delivery
+// consultation/diagnosis so Goal write inference cannot drift the shared
+// delivery gates.
+//
+// This is the contract that shapes the whole intent design: a bare fault report
+// must start a Goal on the write budget while ordinary Delivery still treats it
+// as non-mutation, so one sentence has to produce opposite answers for two
+// consumers. See internal/intent.TestCrossConsumerDisagreement.
 func TestGoalBareFaultDoesNotChangeDeliveryClassification(t *testing.T) {
-	// Pin ordinary Delivery consultation/diagnosis so Goal write inference
-	// cannot drift the shared delivery gates.
-	readonly := []string{
-		"为什么会出现这个 BUG？",
-		"诊断数据库连接失败原因。",
-		"reproduce the crash and identify the root cause",
-		"应用打开设置时崩溃",
-		"数据模型管理器又出现历史 BUG 了……",
-	}
-	for _, input := range readonly {
-		if NeedsMutation(input) {
-			t.Errorf("delivery mutation incorrectly true for %q", input)
+	saw := 0
+	for _, tt := range corpus.GoalBudget {
+		if tt.NeedsMutation == nil {
+			continue
 		}
+		saw++
+		t.Run(tt.Name, func(t *testing.T) {
+			if got := NeedsMutation(tt.Text); got != *tt.NeedsMutation {
+				t.Errorf("NeedsMutation(%q) = %v, want %v", tt.Text, got, *tt.NeedsMutation)
+			}
+		})
 	}
-	mutation := []string{
-		"fix the crash in a.go",
-		"为什么失败然后修复它",
-	}
-	for _, input := range mutation {
-		if !NeedsMutation(input) {
-			t.Errorf("delivery mutation incorrectly false for %q", input)
-		}
+	if saw == 0 {
+		t.Fatal("no mutation-labeled Goal cases in the corpus; the cross-consumer contract is unguarded")
 	}
 }
 

--- a/internal/taskintent/heuristic_test.go
+++ b/internal/taskintent/heuristic_test.go
@@ -1,83 +1,25 @@
 package taskintent
 
-import "testing"
+import (
+	"testing"
+
+	"reasonix/internal/intent/corpus"
+)
 
 // TestHeuristicInputIsTask covers the delivery evidence gate's task-vs-chat
 // heuristic: greetings and acknowledgements must not arm the delivery gates,
 // while actionable requests and failure descriptions must.
+//
+// The case table lives in internal/intent/corpus so this gate test and the
+// classifier evaluation harness judge one corpus.
 func TestHeuristicInputIsTask(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		want  bool
-	}{
-		// Greetings / acknowledgements — chat.
-		{"hello", "hello", false},
-		{"hi", "hi", false},
-		{"你好", "你好", false},
-		{"thanks", "thanks", false},
-		{"谢谢", "谢谢", false},
-		{"ok", "ok", false},
-		{"好的", "好的", false},
-		{"收到", "收到", false},
-		{"我知道了", "我知道了", false},
-		{"先不用", "先不用", false},
-
-		// Explicit tasks.
-		{"fix bug", "fix the bug", true},
-		{"create component", "create a component", true},
-		{"修复问题", "修复这个问题", true},
-		{"run tests", "run tests", true},
-		{"modify config", "modify config", true},
-		{"make changes", "make the requested changes", true},
-		{"adjust config", "调整现有配置", true},
-		{"push branch", "push the branch", true},
-		{"publish release", "publish release", true},
-		{"看看", "帮我看看这个错误", true},
-		{"帮我看下", "帮我看下这个问题", true},
-		{"处理下", "处理下这个 issue", true},
-		{"排查", "排查一下启动失败", true},
-		{"定位", "定位这个异常", true},
-
-		// Conversational acknowledgements that contain task words.
-		{"thanks for fixing", "thanks for fixing that!", false},
-		{"check later", "I'll check later", false},
-		{"test later", "I'll test it later", false},
-		{"test was helpful", "that test was helpful", false},
-		{"辛苦了", "辛苦了", false},
-		{"thanks then update", "thanks for fixing that, now update the tests", true},
-		{"chinese thanks then update", "谢谢你，请继续修改配置", true},
-		{"task before thanks", "review this PR; thanks for the help", true},
-
-		// Actionable problem descriptions without imperative verbs.
-		{"auth not working", "the auth isn't working", true},
-		{"help with login", "can you help with login?", true},
-		{"问题严重", "这个问题很严重", true},
-		{"卡住了", "页面卡住了", true},
-		{"没反应", "按钮点击没反应", true},
-		{"不生效", "配置不生效", true},
-		{"异常退出", "程序异常退出", true},
-
-		// File references.
-		{"file reference", "what about @auth.go", true},
-		{"localized file reference", "检查（@配置.yaml）", true},
-		{"python file", "check main.py", true},
-		{"markdown file", "why does README.md render incorrectly", true},
-		{"relative script", "why does ./scripts/verify.sh fail", true},
-		{"email is not file reference", "thanks, email me@example.com later", false},
-		{"long conversation is not task", "Remember ORBIT-42 and answer on the next turn please", false},
-		{"durable memory is task", "Remember ORBIT-42 permanently across sessions", true},
-
-		// Edge cases.
-		{"empty", "", false},
-		{"spaces", "   ", false},
-		{"question mark", "?", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := heuristicInputIsTask(tt.input); got != tt.want {
-				t.Errorf("heuristicInputIsTask(%q) = %v, want %v", tt.input, got, tt.want)
+	for _, tt := range corpus.Task {
+		if tt.IsTask == nil {
+			continue
+		}
+		t.Run(tt.Name, func(t *testing.T) {
+			if got := heuristicInputIsTask(tt.Text); got != *tt.IsTask {
+				t.Errorf("heuristicInputIsTask(%q) = %v, want %v", tt.Text, got, *tt.IsTask)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

`internal/taskintent` isolates the keyword tables, but the tables themselves still decide what the delivery gates expect by substring-matching the user's prose. That approach has limits this repository already documents: five separate mutation-verb lists that its own comments warn must not drift apart, two different negation word lists that can judge one sentence oppositely, and Chinese matched by `strings.Contains` while English is matched by token — so "更新" hits "更新日志".

This PR adds the replacement mechanism and measures it, **without changing any behavior yet**. The keyword path still drives every gate; the new resolver runs alongside it and reports where they differ.

## What

**One shared reading, `internal/intent.TurnIntent`.** `Kind` carries the coarse classification; `FaultReport`, `ReadOnlyConstraint`, `DiagnosticIntent` and `DurableScope` carry the orthogonal facts consumers need in order to disagree about the same turn. Derivations (`NeedsEvidence`, `NeedsMutation`, `NeedsGoalWriteBudget`, `IsTask`) stay deterministic Go next to the fields they read, so only perception could ever move to a model.

`Kind` alone would be lossy. The corpus pins a bare fault report that must start a Goal on the write budget while ordinary Delivery must not treat it as a mutation request — one sentence, opposite answers for two consumers. A flat boolean classifier cannot express that.

**Three tiers, cheapest first.**

| Tier | Source | Cost |
| --- | --- | --- |
| 1 | Host state — plan mode is a planning turn by decree, not inference | free |
| 2 | The model's own declarations — writing todos or acceptance criteria is it stating in a typed channel that this turn is a task | free |
| 3 | An injected classifier, consulted only when the first two stay silent | one small model call |

The resolver runs at gate time, not turn start: `beginRunTurn` resets the evidence ledger before classifying, so the declared tier has nothing to read until the turn has produced receipts.

**Tier 3 is launched concurrently with the turn, not called at the gate.** A classifier measured at ~3.8s would be that much added latency at the moment the model wants to finish; overlapped with the turn's own round-trips it is effectively free. The cost is that a turn later answered by tier 2 still paid for a classification it did not use.

**One corpus.** The three golden tables that judge this behavior each carried their own inline copy. They now read from `internal/intent/corpus` — 123 cases, 185 labels — so the gate tests and the accuracy harness judge the same corpus. Duplicating the corpus that judges drifting tables would reproduce the defect one level up. The transcription was verified mechanically against the original tables, label by label, before the tests were changed.

## Measured

Live evaluation against the corpus, via a harness that skips without credentials so CI stays hermetic and free:

- **99.5% median** across five runs (98.4 / 100 / 99.5 / 99.5 / 99.5), 3.79s mean latency.
- Prompt iteration mattered far more than model choice: 94.4% → 99.5% by stating product rules the model cannot infer; a more accurate model bought 0.4% for double the latency.
- Most initial misses were unstated rules, not model incapacity. Six of the first nine disagreements were one missing rule each.
- `DiagnosticIntent` exists because live evaluation proved `ReadOnlyConstraint` could not express "diagnose without forbidding anything".
- The classifier is not deterministic at `temperature=0`: correct labels ranged 182–185 of 185 across identical runs. A word table does not do that. For a gate that can block a user, this is a property to accept knowingly, not a bug to fix.

Real delivery-profile traffic (six turns) splits roughly evenly between tier 2 and tier 3, and the pattern is the opposite of the intuitive one: turns doing real work resolve free at tier 2 because the model writes todos, while chat, advisory and simple reads fall through to the paid classifier — the turns where an extra model call is proportionally most wasteful.

## Two defects the shadow found

1. **The production classifier lacked the empty-reply retry** that the evaluation harness had. Reasoning models intermittently return empty content with the budget spent in `reasoning_content`, measured at roughly 3% of calls. The harness reported zero errors *because* it retried; production would have absorbed the full rate silently. Both now share one sentinel.

2. **Tier 2's mutation inference was unsound.** An earlier version inferred `KindMutation` from an unfinished todo list plus writer tools. Real traffic disproved it on `帮我看下 main.go 有没有问题，只分析不要改`, where the model wrote todos for an explicitly read-only analysis and the inference armed a mutation expectation the user had forbidden. An unfinished todo list proves the model thinks the work is incomplete — not that a state change was requested. Removed.

## Known gap

Removing that inference leaves tier 2 able to establish that a turn is a task but never that it requires a mutation, and it stops the cascade before tier 3 could answer. The cause is that the tiers answer different questions: `Task` is provable from the model's behavior, `Mutation` is only knowable from what the user asked. Resolving it needs per-field tier composition rather than one winning tier. That is a separate change; this PR does not attempt it.

## Not touched

Keyword matching over **shell commands and tool arguments** — `internal/recovery/rules.go`, `internal/permission/bash_approval.go`, `internal/shellsafe` — is deliberately left alone. Those classify machine-generated artifacts for a security boundary, not user prose. A model-based security boundary would be non-deterministic, promptable from the same context that carries the user's text, and would fail open when the provider is down. Explicit syntax (`/cmd`, `@file`, `# note`) is likewise parsing, not inference, and stays.

## Enabling

Off by default — nil classifier, no cost, no behavior change:

```toml
[agent.subagent_models]
intent-classifier = "<provider>/<small-model>"
```

`REASONIX_INTENT_SHADOW=1` prints the tier distribution and keyword agreement to stderr at session end. Opt-in, stderr only, no persisted format.

## Verification

- `TestLegacyDeliveryExpectationsMatchesHistoricalExpression` asserts the routed legacy path equals the pre-contract expression byte-for-byte across all 123 corpus turns under both writer-tool states.
- Tier precedence, degradation (`KindUnknown` must never read as `KindConversation`), bounded await, per-turn future isolation and repeatable resolution are pinned separately.
- `go build ./...`, `go vet`, `gofmt` clean; every commit builds and passes its tests independently.
- `go test -race` on the owning packages: no data race, no goroutine leak. The race detector caught one real defect during development — the classification goroutine dereferenced an `Agent` field instead of capturing it — which is fixed.
- Two failures on this machine (`TestMissingReasoningWarnStateReadFailureDoesNotOverwriteExistingIncidents`, `TestMiddleClickUsesPrimarySelectionOutsideTmux`) reproduce identically on the base commit with no changes applied; both are environmental (running as root ignores the chmod the first one simulates; the second needs an X11 primary selection).

## Cache

No change to prompt construction, system prefix, tool schemas, or provider serialization. Resolution happens host-side from existing turn text and evidence receipts. Tier 3 is an independent small-model call that does not share or pollute the main conversation prefix.
