### PR TITLE
perf(memory): cap oversized bodies in turn-tail memory notes

### DIFF
--- a/internal/control/memory.go
+++ b/internal/control/memory.go
@@ -199,7 +199,7 @@ func (m *memoryManager) saveMemory(fact memory.Memory) (string, error) {
 		return "", err
 	}
 	m.applyWrite(mem,
-		"Saved memory \""+fact.Name+"\": "+strings.Join(strings.Fields(fact.Description), " ")+"\n"+strings.TrimSpace(fact.Body))
+		"Saved memory \""+fact.Name+"\": "+strings.Join(strings.Fields(fact.Description), " ")+"\n"+memory.TrimMemoryNoteBody(fact.Body))
 	return path, nil
 }
 

--- a/internal/control/memory_test.go
+++ b/internal/control/memory_test.go
@@ -74,6 +74,42 @@ func TestSaveMemoryQueuesFullBodyForCurrentSession(t *testing.T) {
 	}
 }
 
+func TestSaveMemoryTrimsOversizedBodyForCurrentSession(t *testing.T) {
+	root := t.TempDir()
+	userDir := filepath.Join(root, "user")
+	cwd := filepath.Join(root, "project")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	c := New(Options{Memory: memory.Load(memory.Options{CWD: cwd, UserDir: userDir})})
+
+	// A max-size body must not ride the next turn in full: the note keeps a
+	// capped prefix plus ellipsis, and the full content stays one memory read
+	// away. Only oversized bodies are trimmed — short ones keep the legacy
+	// full-body behavior (see TestSaveMemoryQueuesFullBodyForCurrentSession).
+	body := strings.Repeat("数据", 300) // 600 runes, well over the 400-rune cap
+	if _, err := c.SaveMemory(memory.Memory{
+		Name:        "big-fact",
+		Description: "a large fact",
+		Type:        memory.TypeProject,
+		Scope:       memory.FactScopeProject,
+		Body:        body,
+	}); err != nil {
+		t.Fatalf("SaveMemory: %v", err)
+	}
+
+	composed := c.Compose("hello")
+	if !strings.Contains(composed, "Saved memory \"big-fact\"") {
+		t.Fatalf("saved memory name should ride the next turn:\n%s", composed)
+	}
+	if strings.Contains(composed, body) {
+		t.Fatal("oversized body must not ride the turn in full")
+	}
+	if !strings.Contains(composed, "…") {
+		t.Fatalf("trimmed body should end with ellipsis:\n%s", composed)
+	}
+}
+
 func TestForgetMemoryRevokesLoadedGlobalGuidanceForCurrentSession(t *testing.T) {
 	root := t.TempDir()
 	userDir := filepath.Join(root, "user")

--- a/internal/memory/queue.go
+++ b/internal/memory/queue.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"encoding/json"
+	"strings"
 )
 
 // Queue receives a one-line note about a memory change a tool just made, so the
@@ -11,6 +12,25 @@ import (
 // read it from their call context the same way background tools read the job
 // manager.
 type Queue interface{ QueueMemory(note string) }
+
+// maxNoteBodyRunes caps how much of a fact's body may ride the turn tail inside
+// <memory-update> after a save. The body is already visible to the model as the
+// content it just wrote (remember tool) or is one `memory` read away (desktop
+// save), so beyond this point the note only needs enough to identify the fact.
+// Short bodies are kept whole — the pre-existing behavior — so this only trims
+// the pathological case where a max-size auto-memory (6000 runes) would
+// otherwise inflate the next user turn by thousands of tokens.
+const maxNoteBodyRunes = 400
+
+// TrimMemoryNoteBody returns the portion of a fact body safe to embed in a
+// turn-tail memory note. Rune-safe for CJK and other multi-byte text.
+func TrimMemoryNoteBody(body string) string {
+	runes := []rune(strings.TrimSpace(body))
+	if len(runes) <= maxNoteBodyRunes {
+		return string(runes)
+	}
+	return string(runes[:maxNoteBodyRunes]) + "…"
+}
 
 type autoMemoryWriteClaimer interface {
 	ClaimAutoMemoryWrite(args json.RawMessage) bool

--- a/internal/memory/queue_test.go
+++ b/internal/memory/queue_test.go
@@ -1,0 +1,53 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTrimMemoryNoteBodyKeepsShortBodiesWhole(t *testing.T) {
+	body := "Always answer in Chinese unless the user explicitly asks for English."
+	if got := TrimMemoryNoteBody(body); got != body {
+		t.Fatalf("TrimMemoryNoteBody(%q) = %q, want unchanged body", body, got)
+	}
+}
+
+func TestTrimMemoryNoteBodyTrimsLongBodies(t *testing.T) {
+	body := strings.Repeat("x", maxNoteBodyRunes+100)
+	got := TrimMemoryNoteBody(body)
+	if len([]rune(got)) != maxNoteBodyRunes+1 { // 400 runes + "…"
+		t.Fatalf("TrimMemoryNoteBody length = %d runes, want %d", len([]rune(got)), maxNoteBodyRunes+1)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("TrimMemoryNoteBody result %q should end with ellipsis", got)
+	}
+	if strings.Contains(got, "x") == false || strings.Count(got, "x") != maxNoteBodyRunes {
+		t.Fatalf("TrimMemoryNoteBody should keep exactly the first %d runes", maxNoteBodyRunes)
+	}
+}
+
+func TestTrimMemoryNoteBodyBoundaryExactLimit(t *testing.T) {
+	body := strings.Repeat("y", maxNoteBodyRunes)
+	if got := TrimMemoryNoteBody(body); got != body {
+		t.Fatalf("body of exactly maxNoteBodyRunes runes should be unchanged, got %d runes", len([]rune(got)))
+	}
+}
+
+func TestTrimMemoryNoteBodyRuneSafeForCJK(t *testing.T) {
+	// 中文字符是多字节的；截断必须按 rune 切，不能切出半个字符。
+	body := strings.Repeat("记忆", maxNoteBodyRunes/2+50) // 每个"记忆"2 runes
+	got := TrimMemoryNoteBody(body)
+	runes := []rune(got)
+	if len(runes) != maxNoteBodyRunes+1 {
+		t.Fatalf("CJK body trimmed to %d runes, want %d", len(runes), maxNoteBodyRunes+1)
+	}
+	if string(runes[len(runes)-1]) != "…" {
+		t.Fatalf("CJK trimmed body should end with ellipsis, got %q", runes[len(runes)-1])
+	}
+}
+
+func TestTrimMemoryNoteBodyStripsWhitespace(t *testing.T) {
+	if got := TrimMemoryNoteBody("  \n short body \t "); got != "short body" {
+		t.Fatalf("TrimMemoryNoteBody should trim surrounding whitespace, got %q", got)
+	}
+}

--- a/internal/memory/remember.go
+++ b/internal/memory/remember.go
@@ -103,7 +103,7 @@ func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string
 		factScope = t.store.scopeForPath(path)
 	}
 	if q, ok := QueueFromContext(ctx); ok {
-		q.QueueMemory("Saved memory \"" + result.Memory.Name + "\" (" + string(factScope) + "): " + oneLine(result.Memory.Description) + "\n" + strings.TrimSpace(result.Memory.Body))
+		q.QueueMemory("Saved memory \"" + result.Memory.Name + "\" (" + string(factScope) + "): " + oneLine(result.Memory.Description) + "\n" + TrimMemoryNoteBody(result.Memory.Body))
 	}
 	return fmt.Sprintf("Saved memory id=%s revision=%d (%s background) as %s (it applies now and its derived index loads automatically in future sessions).", result.Memory.ID, result.Memory.Revision, factScope, providerMemoryReference(result.Memory)), nil
 }


### PR DESCRIPTION
## Summary

- 当前行为：`remember` 工具 / 桌面保存路径保存记忆时，**完整正文**会被注入下一轮用户回合的 `<memory-update>`（turn-tail）。保存一条 6000 runes 的最大记忆，下一轮就多花 ~4k token——而内容要么是模型自己刚写的（remember 工具），要么一个 `memory` read 就能按需读到（桌面保存）。
- 本 PR：新增 `TrimMemoryNoteBody`（`internal/memory/queue.go`），**只对超长正文（>400 runes）**截断到 400 runes + 省略号，CJK 按 rune 安全切分；短正文保持原有全文注入（行为不变，现有测试未动）。
- 两个注入点同时生效：`remember` 工具（`remember.go`）与桌面 `saveMemory`（`control/memory.go`）。

## Issues

（可留空）

## Verification

- 新增 5 个单元测试（`queue_test.go`）：短正文保留 / 长正文截断 / 400 边界 / CJK rune 安全 / 空白处理
- 新增 1 个集成测试（`control/memory_test.go`）：桌面保存超长正文 → 下一轮只注入截断前缀 + 省略号
- 现有 `TestSaveMemoryQueuesFullBodyForCurrentSession` 未改动且通过（短正文行为保留）
- `go test ./internal/memory/ ./internal/control/` 全通过；`gofmt -l` 无输出；`go vet` 通过
- 全量 `go test -count=1 ./...`：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 #7807）

## Documentation impact

Documentation-impact: none - 只优化 turn-tail 注人的 token 开销，不改变记忆模型、命令或配置契约；docs/SESSION_MEMORY_RETRIEVAL.md 的"动态召回和会话中途改动只追加到当前 user turn"描述仍成立。

## Cache impact

Cache-impact: none - 动态 turn-tail note 从不进入 cache-stable system prefix（docs 契约），截断只减少注入字符量，不改前缀字节，不影响 prompt cache 命中。
Cache-guard: 现有 guard 覆盖——`TestSaveMemoryQueuesFullBodyForCurrentSession`（短正文行为锁定）+ 新增 `TestSaveMemoryTrimsOversizedBodyForCurrentSession`；无前缀结构改动，无需新增 cache guard。
System-prompt-review: esengine — turn-tail 注入字符量减少，cache-stable system prefix 无结构变化，memory prefix 字节不变；请维护者确认后合并。