### PR TITLE
fix(agent): keep the session concurrency test inside the -race budget

### DIFF
--- a/internal/agent/session_concurrency_test.go
+++ b/internal/agent/session_concurrency_test.go
@@ -12,6 +12,16 @@ import (
 // goroutine. Snapshot must copy under the lock; before it, an append racing the
 // copy could tear the slice header and crash.
 func TestSessionConcurrentAddAndRead(t *testing.T) {
+	// Every Snapshot copies the whole log, so the work is readers*reads*appends.
+	// -race instruments each of those accesses and the package shares one
+	// 10-minute timeout; overlap is what detects the race, volume only buys
+	// wall-clock.
+	const (
+		appends = 1000
+		readers = 8
+		reads   = 500
+	)
+
 	s := NewSession("sys")
 
 	var wg sync.WaitGroup
@@ -19,16 +29,16 @@ func TestSessionConcurrentAddAndRead(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 5000; i++ {
+		for i := 0; i < appends; i++ {
 			s.Add(provider.Message{Role: provider.RoleUser, Content: "msg"})
 		}
 	}()
 	// Many readers mimicking frontends polling history.
-	for r := 0; r < 16; r++ {
+	for r := 0; r < readers; r++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for i := 0; i < 5000; i++ {
+			for i := 0; i < reads; i++ {
 				snap := s.Snapshot()
 				for _, m := range snap { // iterate the copy: must never tear
 					_ = m.Content
@@ -39,7 +49,7 @@ func TestSessionConcurrentAddAndRead(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := len(s.Snapshot()); got != 5001 { // 5000 + the system prompt
-		t.Fatalf("final message count = %d, want 5001", got)
+	if got := len(s.Snapshot()); got != appends+1 { // appends + the system prompt
+		t.Fatalf("final message count = %d, want %d", got, appends+1)
 	}
 }


### PR DESCRIPTION
`main-v2` is red on the `race` job. It is not a data race and not a deadlock —
`internal/agent` hits Go's default 10-minute package timeout, and the dump names
a single culprit:

```
panic: test timed out after 10m0s
	running tests:
		TestSessionConcurrentAddAndRead (9m48s)
```

`Snapshot` copies the whole message log under the lock. The test ran 16 readers
× 5000 snapshots while the log grew to 5000 messages, so it performed on the
order of 200M `provider.Message` copies plus a full `HasContent` scan per
iteration. `-race` instruments every one of those accesses. Measured locally
without `-race` the test alone takes ~32s; the ~18x race amplification puts it
at the 9m48s CI observed, leaving nothing for the rest of the package.

## Why shrinking it does not weaken the test

Overlap is what lets the detector see the race; volume only buys wall-clock. The
old shape actually wasted most of its overlap — the writer finished long before
the readers, which then spun on a static log.

Instrumented at the new numbers (1000 appends, 8 readers, 500 reads each):

```
snapshot lengths seen: min=1 max=583 ; reads landing mid-append: 3268 / 4000
```

82% of reads now land while the writer is still appending, against a log that
grows the whole time. The final `len(Snapshot()) == appends+1` assertion is
unchanged.

## Effect

`TestSessionConcurrentAddAndRead`: ~32s → ~2.6s without `-race` (12.4x), which
projects to roughly 47s under `-race` instead of 588s.

I left the package timeout alone deliberately — raising it would hide the next
test that drifts into the same shape.
