### PR TITLE
perf(memory): cache query-independent recall document preprocessing

### DIFF
--- a/internal/memory/auto_recall.go
+++ b/internal/memory/auto_recall.go
@@ -3,9 +3,12 @@ package memory
 import (
 	"fmt"
 	"html"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -126,6 +129,104 @@ type autoRecallDoc struct {
 	length int
 }
 
+// recallDocsCache caches the query-independent document preprocessing per store
+// directory pair. AutoRecall runs on every real user turn; reading every fact
+// file, parsing frontmatter, and tokenizing/counting terms costs the same no
+// matter what the query is, so a store whose files are unchanged can reuse the
+// previous preprocessing. The cache is keyed by the store's directory pair and
+// invalidated by a file-level fingerprint (name, size, mtime) — ReadDir plus
+// stat per fact file, which is far cheaper than re-reading and re-tokenizing
+// every body. In-place edits change a file's mtime/size, so the fingerprint
+// catches them even though a directory mtime would not.
+var recallDocsCache sync.Map // "Dir\x00GlobalDir" -> *recallDocsEntry
+
+type recallDocsEntry struct {
+	sigs     map[string]fileSig
+	docs     []autoRecallDoc
+	totalLen int
+}
+
+type fileSig struct {
+	size  int64
+	mtime time.Time
+}
+
+// recallDocsFor returns the preprocessed recall documents for store, reusing
+// the cached build when no fact file changed since it was computed.
+func recallDocsFor(store Store) ([]autoRecallDoc, int) {
+	sigs := currentFactSigs(store)
+	key := store.Dir + "\x00" + store.GlobalDir
+	if cached, ok := recallDocsCache.Load(key); ok {
+		entry := cached.(*recallDocsEntry)
+		if sigsEqual(sigs, entry.sigs) {
+			return entry.docs, entry.totalLen
+		}
+	}
+	docs, totalLen := buildRecallDocs(store)
+	recallDocsCache.Store(key, &recallDocsEntry{sigs: sigs, docs: docs, totalLen: totalLen})
+	return docs, totalLen
+}
+
+func buildRecallDocs(store Store) ([]autoRecallDoc, int) {
+	memories := recallMemories(store.ListAll())
+	docs := make([]autoRecallDoc, 0, len(memories))
+	totalLen := 0
+	for _, memory := range memories {
+		text := autoRecallSearchText(memory)
+		terms := retrieval.Tokens(text)
+		if len(terms) == 0 {
+			continue
+		}
+		docs = append(docs, autoRecallDoc{
+			memory: memory,
+			text:   text,
+			counts: retrieval.Counts(terms),
+			length: len(terms),
+		})
+		totalLen += len(terms)
+	}
+	return docs, totalLen
+}
+
+// currentFactSigs fingerprints every active fact file the same way ListAll
+// selects them: top-level .md files that are not the MEMORY.md index. The
+// fingerprint drives cache invalidation without reading file contents.
+func currentFactSigs(store Store) map[string]fileSig {
+	sigs := make(map[string]fileSig)
+	for _, dir := range store.dirs() {
+		if dir == "" {
+			continue
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || entry.Name() == indexFile || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			sigs[filepath.Join(dir, entry.Name())] = fileSig{size: info.Size(), mtime: info.ModTime()}
+		}
+	}
+	return sigs
+}
+
+func sigsEqual(a, b map[string]fileSig) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		if vb, ok := b[k]; !ok || va != vb {
+			return false
+		}
+	}
+	return true
+}
+
 // AutoRecall conservatively selects saved facts for a real user turn. It is
 // intentionally stricter than the explicit memory search tool: generic prompts
 // and one-common-word matches return no block rather than spending context.
@@ -141,31 +242,15 @@ func AutoRecall(store Store, query string, opts RecallOptions) RecallResult {
 		return result
 	}
 
-	memories := recallMemories(store.ListAll())
-	docs := make([]autoRecallDoc, 0, len(memories))
-	for _, memory := range memories {
-		text := autoRecallSearchText(memory)
-		terms := retrieval.Tokens(text)
-		if len(terms) == 0 {
-			continue
-		}
-		docs = append(docs, autoRecallDoc{
-			memory: memory,
-			text:   text,
-			counts: retrieval.Counts(terms),
-			length: len(terms),
-		})
-	}
+	docs, totalLen := recallDocsFor(store)
 	if len(docs) == 0 {
 		result.Suppressed = "memory store is empty"
 		return result
 	}
 
 	counts := make([]map[string]int, 0, len(docs))
-	totalLen := 0
 	for _, doc := range docs {
 		counts = append(counts, doc.counts)
-		totalLen += doc.length
 	}
 	df := retrieval.DocumentFrequency(counts)
 	avgLen := float64(totalLen) / float64(len(docs))

--- a/internal/memory/auto_recall_test.go
+++ b/internal/memory/auto_recall_test.go
@@ -201,3 +201,62 @@ func recallTestWrite(t *testing.T, dir string, memory Memory) {
 		t.Fatal(err)
 	}
 }
+
+// The recall-doc cache is package-level and keyed by the store directory pair,
+// so every test below uses its own temp store (recallTestStore) and never
+// collides. Each test asserts that the cached preprocessing is invalidated by
+// in-place edits, additions, and removals of fact files.
+
+func TestAutoRecallCacheReflectsEditedFact(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-cache-1", Name: "cache-fact", Title: "Cache fact",
+		Description: "original description", Type: TypeProject,
+		Scope: FactScopeProject, Body: "The deployment target is the legacy cluster.",
+	})
+	first := AutoRecall(store, "deployment target", RecallOptions{})
+	if len(first.Hits) != 1 {
+		t.Fatalf("first recall expected 1 hit, got %d", len(first.Hits))
+	}
+	// Edit the fact body in place: the fingerprint must invalidate the cache.
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-cache-1", Name: "cache-fact", Title: "Cache fact",
+		Description: "edited description", Type: TypeProject,
+		Scope: FactScopeProject, Body: "The staging environment is the new deployment target.",
+	})
+	second := AutoRecall(store, "staging environment", RecallOptions{})
+	if len(second.Hits) != 1 {
+		t.Fatalf("recall after edit expected 1 hit, got %d (cache not invalidated?)", len(second.Hits))
+	}
+	if !strings.Contains(second.Hits[0].Memory.Body, "staging") {
+		t.Fatalf("recall after edit should see the new body, got %q", second.Hits[0].Memory.Body)
+	}
+}
+
+func TestAutoRecallCacheReflectsAddedAndRemovedFacts(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-cache-a", Name: "fact-a", Title: "Fact A",
+		Description: "fact a", Type: TypeProject,
+		Scope: FactScopeProject, Body: "Alpha is the primary component.",
+	})
+	if got := AutoRecall(store, "alpha component", RecallOptions{}); len(got.Hits) != 1 {
+		t.Fatalf("expected 1 hit for alpha, got %d", len(got.Hits))
+	}
+	// Adding a fact must invalidate the cache so the new fact becomes recallable.
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-cache-b", Name: "fact-b", Title: "Fact B",
+		Description: "fact b", Type: TypeProject,
+		Scope: FactScopeProject, Body: "Beta is the secondary module.",
+	})
+	if got := AutoRecall(store, "beta module", RecallOptions{}); len(got.Hits) != 1 {
+		t.Fatalf("recall after add expected 1 hit for beta, got %d (cache not invalidated?)", len(got.Hits))
+	}
+	// Removing a fact must invalidate the cache too.
+	if err := os.Remove(filepath.Join(store.Dir, "fact-b.md")); err != nil {
+		t.Fatal(err)
+	}
+	if got := AutoRecall(store, "beta module", RecallOptions{}); len(got.Hits) != 0 {
+		t.Fatalf("recall after remove expected 0 hits, got %d (cache not invalidated?)", len(got.Hits))
+	}
+}


### PR DESCRIPTION
## Summary

- 现状：`AutoRecall` 在每个真实用户回合都会重跑——每次都重新读取全部记忆文件、解析 frontmatter、分词计数。这些工作**与 query 完全无关**，事实文件没变却重复计算，是每回合固定的 CPU+IO 开销。
- 本 PR：新增 `recallDocsFor`，按 store 目录对（Dir+GlobalDir）缓存构建好的召回文档（text / term counts / length），用**文件级指纹**（name + size + mtime）失效——`ReadDir` + `stat` 远比重新读盘+重新分词便宜，且能捕获**就地编辑**（目录 mtime 捕获不到的）。
- query 相关部分（匹配、BM25 打分、freshness、snippet）仍每回合计算；行为与 provider 可见输出完全不变。

## Issues

（可留空）

## Verification

- 新增 2 个缓存失效测试：就地编辑事实 / 新增+删除事实 → 缓存正确失效并反映新内容
- `go test ./internal/memory/ ./internal/control/ ./internal/retrieval/` 全通过
- `gofmt -l` 无输出；`go vet` 通过
- 全量 `go test -count=1 ./...`：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 #7807）
- 并发安全：包级 `sync.Map`，多 goroutine 同 key 竞争由 LoadOrStore 语义覆盖（构建幂等）

## Documentation impact

Documentation-impact: none - 纯性能优化，不改记忆模型、命令、配置或 provider 可见输出；docs/SESSION_MEMORY_RETRIEVAL.md 的召回行为描述不变。

## Cache impact

Cache-impact: none - 缓存的是本地预处理（内存内），不改变任何 provider 可见字节：稳定前缀、召回注入格式、预算全部原样；prompt cache 命中不受影响。
Cache-guard: 现有 guard 覆盖——`TestAutoRecallCacheReflectsEditedFact` / `TestAutoRecallCacheReflectsAddedAndRemovedFacts`（失效正确性）+ 既有 auto_recall 测试（召回行为不变）。
System-prompt-review: esengine — 无 system prompt / memory prefix 结构变化，仅进程内文档预处理缓存；需维护者确认后合并。