### PR TITLE
fix(errors): compare errors through the unwrap chain, and gate it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ version: "2"
 linters:
   enable:
     - errcheck
+    - errorlint
     - govet
     - ineffassign
     - staticcheck

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -10888,7 +10888,7 @@ func (a *App) ReadFileForTab(tabID, rel string) FilePreview {
 
 	buf := make([]byte, filePreviewLimit+1)
 	n, err := f.Read(buf)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		out.Err = err.Error()
 		return out
 	}
@@ -11422,7 +11422,7 @@ func removeExportFileIfSame(path string, created os.FileInfo) {
 func exportOperationError(operation, path string, err error) error {
 	var pathErr *os.PathError
 	if errors.As(err, &pathErr) {
-		return fmt.Errorf("%s %s: %v", operation, filepath.Base(path), pathErr.Err)
+		return fmt.Errorf("%s %s: %w", operation, filepath.Base(path), pathErr.Err)
 	}
 	return fmt.Errorf("%s %s: %w", operation, filepath.Base(path), err)
 }

--- a/desktop/bot_bridge.go
+++ b/desktop/bot_bridge.go
@@ -660,7 +660,7 @@ func (h *botBridgeHub) DriveInput(route bot.DesktopWatchRoute, text string) (str
 		if errors.Is(err, errDriveBusy) {
 			return "", h.busyError(tabID)
 		}
-		return "", fmt.Errorf("驱动失败: %v", err)
+		return "", fmt.Errorf("驱动失败: %w", err)
 	}
 	return "", nil
 }

--- a/desktop/bot_bridge_app.go
+++ b/desktop/bot_bridge_app.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -114,7 +115,7 @@ func (a *App) bridgeAnnounce(tabID, text string) {
 func (a *App) bridgeDrive(tabID, text string, route bot.DesktopWatchRoute) error {
 	admission, ctrl, err := a.beginTabTurn(tabID, false)
 	if err != nil {
-		if err == control.ErrTurnRunning {
+		if errors.Is(err, control.ErrTurnRunning) {
 			return errDriveBusy
 		}
 		return err

--- a/desktop/cmd/update-helper/authenticode_windows.go
+++ b/desktop/cmd/update-helper/authenticode_windows.go
@@ -83,7 +83,7 @@ func readVerifiedWindowsStagedPayload(path string) ([]byte, error) {
 	)
 	if verifyErr != nil {
 		if closeErr != nil {
-			return nil, fmt.Errorf("Authenticode verification failed: %v (release trust state: %w)", verifyErr, closeErr)
+			return nil, fmt.Errorf("Authenticode verification failed: %w (release trust state: %w)", verifyErr, closeErr)
 		}
 		return nil, fmt.Errorf("Authenticode verification failed: %w", verifyErr)
 	}

--- a/desktop/cmd/update-helper/main_windows.go
+++ b/desktop/cmd/update-helper/main_windows.go
@@ -5,6 +5,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -499,7 +500,7 @@ func newLogger() *log.Logger {
 func waitForProcessExit(pid uint32, timeout time.Duration) error {
 	h, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
 	if err != nil {
-		if err == windows.ERROR_INVALID_PARAMETER {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
 			return nil
 		}
 		return err

--- a/desktop/remote_hosts.go
+++ b/desktop/remote_hosts.go
@@ -353,10 +353,10 @@ func (s *RemoteHostStore) loadLocked() ([]RemoteHostEntry, error) {
 	decoder.DisallowUnknownFields()
 	var document remoteHostStoreDocument
 	if err := decoder.Decode(&document); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrRemoteHostStoreCorrupt, err)
+		return nil, fmt.Errorf("%w: %w", ErrRemoteHostStoreCorrupt, err)
 	}
 	if err := requireJSONEOF(decoder); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrRemoteHostStoreCorrupt, err)
+		return nil, fmt.Errorf("%w: %w", ErrRemoteHostStoreCorrupt, err)
 	}
 	if document.Version != remoteHostStoreVersion && document.Version != remoteHostStoreVersion1 {
 		return nil, fmt.Errorf("%w: unsupported version %d", ErrRemoteHostStoreCorrupt, document.Version)
@@ -373,7 +373,7 @@ func (s *RemoteHostStore) loadLocked() ([]RemoteHostEntry, error) {
 	seenConnections := make(map[string]struct{}, len(document.Hosts))
 	for _, host := range document.Hosts {
 		if err := validateRemoteHostEntry(host); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrRemoteHostStoreCorrupt, err)
+			return nil, fmt.Errorf("%w: %w", ErrRemoteHostStoreCorrupt, err)
 		}
 		if _, exists := seenIDs[host.ID]; exists {
 			return nil, fmt.Errorf("%w: duplicate Host entry id %q", ErrRemoteHostStoreCorrupt, host.ID)

--- a/desktop/remote_markdown_image.go
+++ b/desktop/remote_markdown_image.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -383,7 +384,7 @@ func sanitizeRemoteMarkdownSVG(body []byte) ([]byte, bool) {
 
 	for {
 		token, err := decoder.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/desktop/remote_markdown_image_test.go
+++ b/desktop/remote_markdown_image_test.go
@@ -182,7 +182,7 @@ func TestRemoteMarkdownImageTraversesConfiguredSOCKSProxyWithVettedIP(t *testing
 		}
 		requestHeader := make([]byte, 4)
 		if _, err := io.ReadFull(reader, requestHeader); err != nil || requestHeader[0] != 5 || requestHeader[1] != 1 || requestHeader[3] != 1 {
-			proxyResult <- fmt.Errorf("SOCKS target was not an IPv4 CONNECT: header=%v err=%v", requestHeader, err)
+			proxyResult <- fmt.Errorf("SOCKS target was not an IPv4 CONNECT: header=%v err=%w", requestHeader, err)
 			return
 		}
 		ipBytes := make([]byte, net.IPv4len)

--- a/desktop/session_errors_test.go
+++ b/desktop/session_errors_test.go
@@ -51,7 +51,7 @@ func TestFriendlySessionFileErrorMapsBlockedFileErrors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := friendlySessionFileError(tc.err)
-			if got != tc.want {
+			if !errors.Is(got, tc.want) {
 				t.Fatalf("friendlySessionFileError() = %v, want %v", got, tc.want)
 			}
 			if strings.Contains(got.Error(), secret) {
@@ -66,14 +66,14 @@ func TestFriendlySessionFileErrorPassesThroughOtherErrors(t *testing.T) {
 		t.Fatalf("nil should stay nil, got %v", err)
 	}
 	plain := errors.New("plain failure")
-	if got := friendlySessionFileError(plain); got != plain {
+	if got := friendlySessionFileError(plain); !errors.Is(got, plain) {
 		t.Fatalf("plain error rewritten to %v", got)
 	}
-	if got := friendlySessionFileError(errSessionBusyElsewhere); got != errSessionBusyElsewhere {
+	if got := friendlySessionFileError(errSessionBusyElsewhere); !errors.Is(got, errSessionBusyElsewhere) {
 		t.Fatalf("sanitized busy error rewritten to %v", got)
 	}
 	notExist := &os.PathError{Op: "lstat", Path: "gone.jsonl", Err: syscall.ENOENT}
-	if got := friendlySessionFileError(notExist); got != error(notExist) {
+	if got := friendlySessionFileError(notExist); !errors.Is(got, error(notExist)) {
 		t.Fatalf("not-exist error rewritten to %v", got)
 	}
 }
@@ -83,7 +83,7 @@ func TestFriendlySessionLoadErrorPreservesBudgetAndSanitizesDecoderDetails(t *te
 	limitErr := &agent.SessionReplayLimitError{
 		Path: path, Resource: "encoded_bytes", Value: 200, Limit: 100,
 	}
-	if got := friendlySessionLoadError(limitErr); got != limitErr {
+	if got := friendlySessionLoadError(limitErr); !errors.Is(got, limitErr) {
 		t.Fatalf("budget error = %v, want original path-free error", got)
 	}
 	if strings.Contains(limitErr.Error(), path) {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -646,12 +646,14 @@ func isRenameCrossDeviceOrBusy(err error) bool {
 		return false
 	}
 	// Cross-device link.
-	if le, ok := err.(*os.LinkError); ok {
-		if le.Err == syscall.EXDEV {
+	le := &os.LinkError{}
+	if errors.As(err, &le) {
+		if errors.Is(le.Err, syscall.EXDEV) {
 			return true
 		}
 		// Windows: "The process cannot access the file because it is being used by another process."
-		if errno, ok := le.Err.(syscall.Errno); ok {
+		var errno syscall.Errno
+		if errors.As(le.Err, &errno) {
 			return errno == 32 // ERROR_SHARING_VIOLATION
 		}
 	}
@@ -999,7 +1001,7 @@ func loadSessionPlannerDisplaysForUpdate(dir string) (sessionPlannerDisplayMap, 
 		return nil, err
 	}
 	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, fmt.Errorf("%w: %v", errCorruptSessionPlannerDisplay, err)
+		return nil, fmt.Errorf("%w: %w", errCorruptSessionPlannerDisplay, err)
 	}
 	if m == nil {
 		m = sessionPlannerDisplayMap{}

--- a/desktop/theme_image.go
+++ b/desktop/theme_image.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"image"
 	_ "image/jpeg"
@@ -45,7 +46,7 @@ func validateThemeImageFile(path string) error {
 
 	head := make([]byte, 512)
 	n, err := io.ReadFull(f, head)
-	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return err
 	}
 	head = head[:n]

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -1047,7 +1047,7 @@ func extractLinuxReleaseUnit(targz []byte) (map[string][]byte, error) {
 	tr := tar.NewReader(gz)
 	for {
 		h, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/desktop/updater_deb_linux.go
+++ b/desktop/updater_deb_linux.go
@@ -58,7 +58,7 @@ func applyDebLinux(packagePath, signaturePath string, onPhase func(phase string)
 
 	if err := cmd.Start(); err != nil {
 		_ = stderrW.Close()
-		return fmt.Errorf("%w: %v", errUpdateAuthFailed, err)
+		return fmt.Errorf("%w: %w", errUpdateAuthFailed, err)
 	}
 
 	// Drain stderr concurrently so phase lines arrive while apt still runs.

--- a/desktop/updater_mac.go
+++ b/desktop/updater_mac.go
@@ -112,7 +112,7 @@ func applyMac(zipPath, targetVersion string) error {
 	readyReader, readyWriter, err := os.Pipe()
 	if err != nil {
 		if _, cancelErr := cancelMacUpdateHandoff(tx, macUpdateHandoffLockTimeout); cancelErr != nil {
-			return fmt.Errorf("create macOS update readiness pipe: %w; cancel prepared update: %v", err, cancelErr)
+			return fmt.Errorf("create macOS update readiness pipe: %w; cancel prepared update: %w", err, cancelErr)
 		}
 		return fmt.Errorf("create macOS update readiness pipe: %w", err)
 	}
@@ -121,7 +121,7 @@ func applyMac(zipPath, targetVersion string) error {
 		_ = readyReader.Close()
 		_ = readyWriter.Close()
 		if _, cancelErr := cancelMacUpdateHandoff(tx, macUpdateHandoffLockTimeout); cancelErr != nil {
-			return fmt.Errorf("create macOS update proceed pipe: %w; cancel prepared update: %v", err, cancelErr)
+			return fmt.Errorf("create macOS update proceed pipe: %w; cancel prepared update: %w", err, cancelErr)
 		}
 		return fmt.Errorf("create macOS update proceed pipe: %w", err)
 	}
@@ -143,7 +143,7 @@ func applyMac(zipPath, targetVersion string) error {
 		_ = readyWriter.Close()
 		_ = proceedReader.Close()
 		if _, cancelErr := cancelMacUpdateHandoff(tx, macUpdateHandoffLockTimeout); cancelErr != nil {
-			return fmt.Errorf("%w; cancel prepared update: %v", err, cancelErr)
+			return fmt.Errorf("%w; cancel prepared update: %w", err, cancelErr)
 		}
 		return err
 	}
@@ -155,10 +155,10 @@ func applyMac(zipPath, targetVersion string) error {
 		_ = cmd.Wait()
 		cancelled, cancelErr := cancelMacUpdateHandoff(tx, macUpdateHandoffLockTimeout)
 		if cancelErr != nil {
-			return fmt.Errorf("%w; cancel prepared update: %v", cause, cancelErr)
+			return fmt.Errorf("%w; cancel prepared update: %w", cause, cancelErr)
 		}
 		if cleanupErr := cleanupMacHandoffStaging(cancelled); cleanupErr != nil {
-			return fmt.Errorf("%w; cleanup prepared update: %v", cause, cleanupErr)
+			return fmt.Errorf("%w; cleanup prepared update: %w", cause, cleanupErr)
 		}
 		return cause
 	}
@@ -436,10 +436,10 @@ func runMacUpdateHandoff(cfg macUpdateHandoffConfig) int {
 		if err := macHandoffRename(backupApp, oldApp); err != nil {
 			if retainedFailedApp && failedAppVerified {
 				if verifyErr := repair.VerifyAppBundleUpdateHandoffReplacement(claimed, failedApp); verifyErr != nil {
-					return fmt.Errorf("restore backup bundle: %w (retained replacement changed: %v)", err, verifyErr)
+					return fmt.Errorf("restore backup bundle: %w (retained replacement changed: %w)", err, verifyErr)
 				}
 				if compensateErr := macHandoffRename(failedApp, oldApp); compensateErr != nil {
-					return fmt.Errorf("restore backup bundle: %w (failed to restore replacement bundle: %v)", err, compensateErr)
+					return fmt.Errorf("restore backup bundle: %w (failed to restore replacement bundle: %w)", err, compensateErr)
 				}
 			}
 			return fmt.Errorf("restore backup bundle: %w", err)
@@ -447,14 +447,14 @@ func runMacUpdateHandoff(cfg macUpdateHandoffConfig) int {
 		if err := repair.VerifyAppBundleUpdateHandoffOriginal(claimed); err != nil {
 			rejected, retainErr := retainMacHandoffNode(oldApp, "reasonix-update-rejected")
 			if retainErr != nil {
-				return fmt.Errorf("restored backup bundle changed: %w (retain rejected bundle: %v)", err, retainErr)
+				return fmt.Errorf("restored backup bundle changed: %w (retain rejected bundle: %w)", err, retainErr)
 			}
 			if retainedFailedApp && failedAppVerified {
 				if verifyErr := repair.VerifyAppBundleUpdateHandoffReplacement(claimed, failedApp); verifyErr != nil {
-					return fmt.Errorf("restored backup bundle changed: %w (rejected bundle retained at %s; prior live bundle changed: %v)", err, rejected, verifyErr)
+					return fmt.Errorf("restored backup bundle changed: %w (rejected bundle retained at %s; prior live bundle changed: %w)", err, rejected, verifyErr)
 				}
 				if compensateErr := macHandoffRename(failedApp, oldApp); compensateErr != nil {
-					return fmt.Errorf("restored backup bundle changed: %w (rejected bundle retained at %s; restore prior live bundle: %v)", err, rejected, compensateErr)
+					return fmt.Errorf("restored backup bundle changed: %w (rejected bundle retained at %s; restore prior live bundle: %w)", err, rejected, compensateErr)
 				}
 			}
 			return fmt.Errorf("restored backup bundle changed: %w (rejected bundle retained at %s)", err, rejected)

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -331,7 +331,7 @@ func windowsUpdateHelperStartError(err error) error {
 	}
 	var errno syscall.Errno
 	if errors.As(err, &errno) {
-		return fmt.Errorf("start Windows update helper: Windows error %d (%s)", errno, errno.Error())
+		return fmt.Errorf("start Windows update helper: Windows error %w (%s)", errno, errno.Error())
 	}
 	return fmt.Errorf("start Windows update helper: process creation failed")
 }

--- a/internal/acp/reload_extensions_test.go
+++ b/internal/acp/reload_extensions_test.go
@@ -61,8 +61,8 @@ func marshalReloadParams(t *testing.T, sessionID string) json.RawMessage {
 func TestSessionReloadExtensionsUnknownSession(t *testing.T) {
 	svc := &service{factory: &configurableFactory{}, sessions: map[string]*acpSession{}}
 	_, err := svc.sessionReloadExtensions(context.Background(), marshalReloadParams(t, "nope"))
-	rpcErr, ok := err.(*RPCError)
-	if !ok {
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
 		t.Fatalf("err = %T %v, want *RPCError", err, err)
 	}
 	if rpcErr.Code != ErrInvalidParams {
@@ -81,8 +81,8 @@ func TestSessionReloadExtensionsUnavailableWithoutRebuilder(t *testing.T) {
 	sess := reloadExtensionsSession(t, "sess-reload-noseam", control.New(control.Options{}), notifier)
 	svc := &service{factory: &configurableFactory{}, sessions: map[string]*acpSession{sess.id: sess}}
 	_, err := svc.sessionReloadExtensions(context.Background(), marshalReloadParams(t, sess.id))
-	rpcErr, ok := err.(*RPCError)
-	if !ok {
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
 		t.Fatalf("err = %T %v, want *RPCError", err, err)
 	}
 	if rpcErr.Code != ErrInvalidRequest {

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -170,7 +170,7 @@ func readLine(br *bufio.Reader) ([]byte, error) {
 		if len(buf) > maxMessageBytes {
 			return nil, errors.New("acp: message exceeds size limit")
 		}
-		if err == bufio.ErrBufferFull {
+		if errors.Is(err, bufio.ErrBufferFull) {
 			continue
 		}
 		// Trim the trailing newline (and CR) if present.

--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -999,7 +999,7 @@ func (a *adapter) runWebhook(ctx context.Context) {
 
 	go func() {
 		<-ctx.Done()
-		if err := server.Shutdown(context.Background()); err != nil && err != http.ErrServerClosed {
+		if err := server.Shutdown(context.Background()); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			a.logger.Error("feishu webhook shutdown error", "err", err)
 		}
 	}()

--- a/internal/cli/setup_manager.go
+++ b/internal/cli/setup_manager.go
@@ -539,7 +539,7 @@ func addProviderToSession(s *providerSetupSession, anthropic bool) bool {
 		result, err = promptCustomProvider()
 	}
 	if err != nil {
-		if err != errCancelled {
+		if !errors.Is(err, errCancelled) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 		return false

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -545,7 +545,7 @@ func fetchLatestRelease(c *http.Client, channel cliReleaseChannel) (*ghRelease, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("release gateway: %v; GitHub API: %s%s", pointerErr, resp.Status, githubRateLimitHint(resp))
+		return nil, fmt.Errorf("release gateway: %w; GitHub API: %s%s", pointerErr, resp.Status, githubRateLimitHint(resp))
 	}
 
 	var rels []ghRelease
@@ -556,7 +556,7 @@ func fetchLatestRelease(c *http.Client, channel cliReleaseChannel) (*ghRelease, 
 	if rel := pickCLIRelease(rels, channel); rel != nil {
 		return rel, nil
 	}
-	return nil, fmt.Errorf("release gateway: %v; no %s CLI release found in recent GitHub releases", pointerErr, channel)
+	return nil, fmt.Errorf("release gateway: %w; no %s CLI release found in recent GitHub releases", pointerErr, channel)
 }
 
 func fetchCLIReleasePointer(c *http.Client, pointerURL string, channel cliReleaseChannel) (*ghRelease, error) {
@@ -746,7 +746,7 @@ func commitWindows(target, newPath, base, dir string) error {
 	if err := os.Rename(newPath, target); err != nil {
 		// Rollback: try to restore the old binary.
 		if rerr := os.Rename(oldPath, target); rerr != nil {
-			return fmt.Errorf("replace failed (%v); rollback also failed: %w", err, rerr)
+			return fmt.Errorf("replace failed (%w); rollback also failed: %w", err, rerr)
 		}
 		return fmt.Errorf("rename new binary: %w", err)
 	}

--- a/internal/control/admission_test.go
+++ b/internal/control/admission_test.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -215,7 +216,7 @@ func TestRunTurnRefusedDuringFinishingWindow(t *testing.T) {
 	go func() { errCh <- c.RunTurn(context.Background(), "sync input") }()
 	select {
 	case err := <-errCh:
-		if err != ErrTurnRunning {
+		if !errors.Is(err, ErrTurnRunning) {
 			t.Fatalf("RunTurn during finishing window = %v, want ErrTurnRunning", err)
 		}
 	case <-time.After(time.Second):
@@ -230,7 +231,7 @@ func TestRunTurnRefusedDuringFinishingWindow(t *testing.T) {
 func TestRunTurnRefusedAfterClose(t *testing.T) {
 	c := New(Options{})
 	c.Close()
-	if err := c.RunTurn(context.Background(), "late"); err != ErrTurnRunning {
+	if err := c.RunTurn(context.Background(), "late"); !errors.Is(err, ErrTurnRunning) {
 		t.Fatalf("RunTurn after Close = %v, want ErrTurnRunning", err)
 	}
 }

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -250,7 +251,8 @@ $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
 	proc.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && len(ee.Stderr) > 0 {
 			return "", fmt.Errorf("read clipboard image: %s", strings.TrimSpace(string(ee.Stderr)))
 		}
 		return "", fmt.Errorf("read clipboard image: %w", err)

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -4567,7 +4567,7 @@ func TestRunTurnReportsErrTurnRunning(t *testing.T) {
 	}()
 	waitForRunning(t, c)
 
-	if err := c.RunTurn(context.Background(), "second"); err != ErrTurnRunning {
+	if err := c.RunTurn(context.Background(), "second"); !errors.Is(err, ErrTurnRunning) {
 		t.Fatalf("RunTurn while running error = %v, want ErrTurnRunning", err)
 	}
 

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -150,6 +150,7 @@ func TestExplainError(t *testing.T) {
 	}
 
 	plain := errors.New("some other failure")
+	//nolint:errorlint // identity check: explainError must return the same error, unwrapped.
 	if explainError(plain) != plain {
 		t.Error("unknown errors should pass through unchanged")
 	}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -1017,7 +1018,7 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 
 	buf := make([]byte, maxFileRefBytes+1)
 	n, rerr := io.ReadFull(f, buf)
-	if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
+	if rerr != nil && !errors.Is(rerr, io.ErrUnexpectedEOF) && !errors.Is(rerr, io.EOF) {
 		return "", false, rerr
 	}
 	data := buf[:n]
@@ -1096,7 +1097,7 @@ func readFileRefUnscoped(path string) (content string, isDir bool, err error) {
 
 	buf := make([]byte, maxFileRefBytes+1)
 	n, rerr := io.ReadFull(f, buf)
-	if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
+	if rerr != nil && !errors.Is(rerr, io.ErrUnexpectedEOF) && !errors.Is(rerr, io.EOF) {
 		return "", false, rerr
 	}
 	data := buf[:n]
@@ -1230,14 +1231,14 @@ func extractPDFTextDefault(path string) (pdfExtractResult, error) {
 	python, err := findPython()
 	if err != nil {
 		if firstErr != nil {
-			return pdfExtractResult{}, fmt.Errorf("pdftotext failed (%v), and Python PDF libraries are not available", firstErr)
+			return pdfExtractResult{}, fmt.Errorf("pdftotext failed (%w), and Python PDF libraries are not available", firstErr)
 		}
 		return pdfExtractResult{}, fmt.Errorf("pdftotext and Python PDF libraries are not available")
 	}
 	text, truncated, err := runPDFTextCommand(python, []string{"-c", pythonPDFExtractScript, path})
 	if err != nil {
 		if firstErr != nil {
-			return pdfExtractResult{}, fmt.Errorf("pdftotext failed (%v), Python PDF extraction failed (%w)", firstErr, err)
+			return pdfExtractResult{}, fmt.Errorf("pdftotext failed (%w), Python PDF extraction failed (%w)", firstErr, err)
 		}
 		return pdfExtractResult{}, err
 	}

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -797,7 +797,7 @@ func TestTurnOrchestratorStopFailureHookCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	o := newTurnOrchestrator(c)
-	if err := o.runTurnWithRawDisplay(ctx, "test", "test", ""); err != nil && err != context.Canceled {
+	if err := o.runTurnWithRawDisplay(ctx, "test", "test", ""); err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 	if stopCalls != 1 {

--- a/internal/desktoplauncher/launcher.go
+++ b/internal/desktoplauncher/launcher.go
@@ -3,6 +3,7 @@
 package desktoplauncher
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,7 +55,8 @@ func Run(args []string, buildVersion string) int {
 		return 0
 	}
 	if err := cmd.Run(); err != nil {
-		if exit, ok := err.(*exec.ExitError); ok {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
 			return exit.ExitCode()
 		}
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/internal/extension/dispatch/payloads.go
+++ b/internal/extension/dispatch/payloads.go
@@ -340,7 +340,7 @@ func decodePayload(point extension.InterceptorPoint, raw json.RawMessage) (any, 
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(fresh); err != nil {
-		return nil, fmt.Errorf("replacement does not match the %s payload: %v", point, err)
+		return nil, fmt.Errorf("replacement does not match the %s payload: %w", point, err)
 	}
 	var extra any
 	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {

--- a/internal/installsource/apply.go
+++ b/internal/installsource/apply.go
@@ -243,7 +243,7 @@ func (t *installSourceTool) applyInstallMCP(ctx context.Context, req request, ac
 		if err != nil {
 			if oldDisconnected {
 				if rbErr := t.restoreMCP(previous); rbErr != nil {
-					return fmt.Errorf("%w; reconnect previous server failed: %v", err, rbErr)
+					return fmt.Errorf("%w; reconnect previous server failed: %w", err, rbErr)
 				}
 			}
 			return err
@@ -257,7 +257,7 @@ func (t *installSourceTool) applyInstallMCP(ctx context.Context, req request, ac
 	probe := config.Default()
 	if err := probe.UpsertPlugin(act.entry); err != nil {
 		if rbErr := t.rollbackMCPReplace(act, previous, oldDisconnected, connected); rbErr != nil {
-			return fmt.Errorf("%w; rollback failed: %v", err, rbErr)
+			return fmt.Errorf("%w; rollback failed: %w", err, rbErr)
 		}
 		return err
 	}
@@ -274,7 +274,7 @@ func (t *installSourceTool) applyInstallMCP(ctx context.Context, req request, ac
 		return fresh.UpsertPlugin(act.entry)
 	}); err != nil {
 		if rbErr := t.rollbackMCPReplace(act, previous, oldDisconnected, connected); rbErr != nil {
-			return fmt.Errorf("%w; rollback failed: %v", err, rbErr)
+			return fmt.Errorf("%w; rollback failed: %w", err, rbErr)
 		}
 		return err
 	}

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -598,11 +598,11 @@ func verifyCopiedCapabilities(src pluginpkg.Package, target string) error {
 func checkoutPluginCommit(ctx context.Context, cloneRoot, commit string) error {
 	fetch := pluginGitCommand(ctx, "-C", cloneRoot, "fetch", "--depth=1", "origin", commit)
 	if out, err := fetch.CombinedOutput(); err != nil {
-		return fmt.Errorf("fetch approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("fetch approved commit %s: %w: %s", commit, err, strings.TrimSpace(string(out)))
 	}
 	co := pluginGitCommand(ctx, "-C", cloneRoot, "checkout", "--detach", commit)
 	if out, err := co.CombinedOutput(); err != nil {
-		return fmt.Errorf("checkout approved commit %s: %v: %s", commit, err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("checkout approved commit %s: %w: %s", commit, err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/mcplaunch/process_windows.go
+++ b/internal/mcplaunch/process_windows.go
@@ -18,7 +18,7 @@ func launchLockProcessAlive(pid int) bool {
 	if err != nil {
 		// Access denied still proves the process exists. Treating it as stale
 		// would let a less-privileged waiter steal a live writer's lock.
-		return err == windows.ERROR_ACCESS_DENIED
+		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
 	}
 	defer windows.CloseHandle(handle)
 	var code uint32

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1565,7 +1565,7 @@ func (c *Client) callTransport(ctx context.Context, method string, params any) (
 		return res, err
 	}
 	if initErr := c.initializeSession(ctx, false); initErr != nil {
-		return nil, fmt.Errorf("%w; reinitialize failed: %v", err, initErr)
+		return nil, fmt.Errorf("%w; reinitialize failed: %w", err, initErr)
 	}
 	return c.t.call(ctx, method, params)
 }

--- a/internal/plugin/stdio_cancel_test.go
+++ b/internal/plugin/stdio_cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -95,7 +96,7 @@ func TestStdioCallCancelReturnsContextCanceled(t *testing.T) {
 		if err == nil {
 			t.Fatal("cancelled call returned nil error")
 		}
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected context.Canceled, got: %v", err)
 		}
 	case <-time.After(2 * time.Second):

--- a/internal/pluginpkg/manifest_v1.go
+++ b/internal/pluginpkg/manifest_v1.go
@@ -675,14 +675,14 @@ func validateV1Paths(root string, m *Manifest) ([]string, error) {
 func checkThemeFile(resolvedRoot, abs, pattern string) error {
 	resolved, err := filepath.EvalSymlinks(abs)
 	if err != nil {
-		return fmt.Errorf("theme %q cannot be resolved: %v", pattern, err)
+		return fmt.Errorf("theme %q cannot be resolved: %w", pattern, err)
 	}
 	if !pathWithinRoot(resolvedRoot, resolved) {
 		return fmt.Errorf("theme %q escapes the plugin root through a symlink", pattern)
 	}
 	info, err := os.Stat(abs)
 	if err != nil {
-		return fmt.Errorf("theme %q is not readable: %v", pattern, err)
+		return fmt.Errorf("theme %q is not readable: %w", pattern, err)
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("theme %q is not a regular file", pattern)
@@ -708,7 +708,7 @@ func globThemePattern(root, pattern string) ([]string, error) {
 	for _, seg := range segs {
 		if hasGlobMeta(seg) {
 			if _, err := path.Match(seg, ""); err != nil {
-				return nil, fmt.Errorf("invalid theme glob %q: %v", pattern, err)
+				return nil, fmt.Errorf("invalid theme glob %q: %w", pattern, err)
 			}
 		}
 	}

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -753,7 +754,8 @@ func TestFailedEventSurfacesAuthenticationError(t *testing.T) {
 	chunks := collect(t, New(Config{Name: "test", APIKey: "key", KeyEnv: "TEST_API_KEY", BaseURL: server.URL, Model: "m"}), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
 	for _, chunk := range chunks {
 		if chunk.Type == provider.ChunkError {
-			if _, ok := chunk.Err.(*provider.AuthError); !ok || !strings.Contains(chunk.Err.Error(), "TEST_API_KEY") {
+			var authErr *provider.AuthError
+			if !errors.As(chunk.Err, &authErr) || !strings.Contains(chunk.Err.Error(), "TEST_API_KEY") {
 				t.Fatalf("error = %T %v", chunk.Err, chunk.Err)
 			}
 			return

--- a/internal/provider/schema_error_test.go
+++ b/internal/provider/schema_error_test.go
@@ -38,6 +38,7 @@ func TestAnnotateToolSchemaErrorLeavesUnrelatedErrorsUnchanged(t *testing.T) {
 	}
 	tools := []ToolSchema{{Name: "read_file"}}
 	for _, err := range tests {
+		//nolint:errorlint // identity check: unrelated errors must come back unchanged, not wrapped.
 		if got := AnnotateToolSchemaError(err, tools); got != err {
 			t.Errorf("AnnotateToolSchemaError(%v) changed unrelated error to %v", err, got)
 		}

--- a/internal/remote/auth.go
+++ b/internal/remote/auth.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -231,7 +232,7 @@ func identityPublicKeys(path string) []ssh.PublicKey {
 			continue
 		} else {
 			var missing *ssh.PassphraseMissingError
-			if isPassphraseMissing(err, &missing) && missing.PublicKey != nil {
+			if errors.As(err, &missing) && missing.PublicKey != nil {
 				key := missing.PublicKey
 				id := string(normalizePublicKey(key).Marshal())
 				if !seen[id] {
@@ -277,7 +278,7 @@ func keyAuth(ctx context.Context, h ResolvedHost, opts *AuthOptions, path string
 		return nil, nil
 	}
 	var missing *ssh.PassphraseMissingError
-	if !isPassphraseMissing(err, &missing) {
+	if !errors.As(err, &missing) {
 		return nil, fmt.Errorf("parse key %s: %w", path, err)
 	}
 	// Encrypted key: return a lazy method so the passphrase is only resolved
@@ -401,12 +402,4 @@ func defaultIdentityFiles() []string {
 		out = append(out, filepath.Join(home, ".ssh", n))
 	}
 	return out
-}
-
-func isPassphraseMissing(err error, target **ssh.PassphraseMissingError) bool {
-	if pe, ok := err.(*ssh.PassphraseMissingError); ok {
-		*target = pe
-		return true
-	}
-	return false
 }

--- a/internal/remote/forward/set_test.go
+++ b/internal/remote/forward/set_test.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -136,7 +137,7 @@ func TestDuplicateForwardRejected(t *testing.T) {
 	if _, err := set.Add(spec); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := set.Add(spec); err != ErrDuplicateForward {
+	if _, err := set.Add(spec); !errors.Is(err, ErrDuplicateForward) {
 		t.Fatalf("second add err = %v, want ErrDuplicateForward", err)
 	}
 }
@@ -211,7 +212,7 @@ func TestReplaceWhileDetachedPreservesExistingForward(t *testing.T) {
 	if _, err := set.Add(old); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := set.Replace(Spec{Name: "serve", Direction: Local, BindAddr: "127.0.0.1:0", TargetAddr: "new:80"}); err != ErrNotAttached {
+	if _, err := set.Replace(Spec{Name: "serve", Direction: Local, BindAddr: "127.0.0.1:0", TargetAddr: "new:80"}); !errors.Is(err, ErrNotAttached) {
 		t.Fatalf("Replace error = %v, want ErrNotAttached", err)
 	}
 	entries := set.List()
@@ -240,7 +241,7 @@ func TestBindBusyReported(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected bind-busy error")
 	}
-	if err != ErrBindBusy && !containsErr(err, ErrBindBusy) {
+	if !errors.Is(err, ErrBindBusy) {
 		t.Fatalf("err = %v, want ErrBindBusy", err)
 	}
 }
@@ -294,22 +295,6 @@ func TestRemoteForwardEndToEnd(t *testing.T) {
 	if string(buf) != "rrrr" {
 		t.Fatalf("echo = %q", buf)
 	}
-}
-
-func containsErr(err, target error) bool {
-	type wrapper interface{ Unwrap() []error }
-	if w, ok := err.(wrapper); ok {
-		for _, e := range w.Unwrap() {
-			if e == target || containsErr(e, target) {
-				return true
-			}
-		}
-	}
-	type single interface{ Unwrap() error }
-	if s, ok := err.(single); ok {
-		return containsErr(s.Unwrap(), target)
-	}
-	return err == target
 }
 
 var _ = fmt.Sprintf

--- a/internal/remote/knownhosts.go
+++ b/internal/remote/knownhosts.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -98,7 +99,7 @@ func (p *HostKeyPolicy) Callback(ctx context.Context, host string) (ssh.HostKeyC
 				return nil
 			}
 			var keyErr *knownhosts.KeyError
-			if !asKeyError(err, &keyErr) {
+			if !errors.As(err, &keyErr) {
 				return err
 			}
 			if len(keyErr.Want) > 0 {
@@ -144,7 +145,7 @@ func (p *HostKeyPolicy) HostKeyAlgorithms(hostname string, remote net.Addr) ([]s
 		return nil, nil
 	}
 	var keyErr *knownhosts.KeyError
-	if !asKeyError(err, &keyErr) {
+	if !errors.As(err, &keyErr) {
 		return nil, err
 	}
 	if len(keyErr.Want) == 0 {
@@ -368,22 +369,6 @@ func newHostKeyMismatchError(host, presented string, e *knownhosts.KeyError) err
 		locations = append(locations, KnownHostLocation{Filename: k.Filename, Line: k.Line})
 	}
 	return &HostKeyMismatchError{Host: host, PresentedFingerprint: presented, Locations: locations}
-}
-
-func asKeyError(err error, target **knownhosts.KeyError) bool {
-	for err != nil {
-		if ke, ok := err.(*knownhosts.KeyError); ok {
-			*target = ke
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		u, ok := err.(unwrapper)
-		if !ok {
-			return false
-		}
-		err = u.Unwrap()
-	}
-	return false
 }
 
 func fileExists(path string) bool {

--- a/internal/repair/apply_failure.go
+++ b/internal/repair/apply_failure.go
@@ -206,7 +206,7 @@ func clearUpdateApplyFailureExact(expected *UpdateApplyFailure) error {
 	updateCleanupAfterRename(path, cleanup)
 	restore := func(cause error) error {
 		if restoreErr := renameRepairNodeNoReplace(cleanup, path); restoreErr != nil {
-			return fmt.Errorf("%w; update failure marker retained at %s: %v", cause, cleanup, restoreErr)
+			return fmt.Errorf("%w; update failure marker retained at %s: %w", cause, cleanup, restoreErr)
 		}
 		return cause
 	}

--- a/internal/repair/config.go
+++ b/internal/repair/config.go
@@ -137,7 +137,7 @@ func inspectAndRepairConfigUnlocked(opts ConfigOptions) (ConfigReport, error) {
 		if expected := opts.expectedStates[item.path]; expected != "" {
 			if err := verifyRepairPlanStateIDFor(quarantine, item.path, expected); err != nil {
 				if restoreErr := restoreRepairNodeIfAbsent(quarantine, item.path); restoreErr != nil {
-					return report, fmt.Errorf("quarantine %s config changed after confirmation and restore failed: %v: %w", item.scope, restoreErr, err)
+					return report, fmt.Errorf("quarantine %s config changed after confirmation and restore failed: %w: %w", item.scope, restoreErr, err)
 				}
 				return report, err
 			}
@@ -148,7 +148,7 @@ func inspectAndRepairConfigUnlocked(opts ConfigOptions) (ConfigReport, error) {
 			}
 			restoreErr := restoreRepairNodeIfAbsent(quarantine, item.path)
 			if restoreErr != nil {
-				return report, fmt.Errorf("commit quarantine %s config undo state: %w; confirmed config retained at %s: %v", item.scope, err, quarantine, restoreErr)
+				return report, fmt.Errorf("commit quarantine %s config undo state: %w; confirmed config retained at %s: %w", item.scope, err, quarantine, restoreErr)
 			}
 			return report, fmt.Errorf("commit quarantine %s config undo state: %w", item.scope, err)
 		}

--- a/internal/repair/derived.go
+++ b/internal/repair/derived.go
@@ -92,7 +92,7 @@ func rebuildDerivedStateBoundUnlocked(
 		if expected := expectedStates[path]; expected != "" {
 			if err := verifyRepairPlanStateIDFor(quarantine, path, expected); err != nil {
 				if restoreErr := restoreRepairNodeIfAbsent(quarantine, path); restoreErr != nil {
-					return applied, fmt.Errorf("derived state changed after confirmation and restore failed: %v: %w", restoreErr, err)
+					return applied, fmt.Errorf("derived state changed after confirmation and restore failed: %w: %w", restoreErr, err)
 				}
 				return applied, err
 			}
@@ -103,7 +103,7 @@ func rebuildDerivedStateBoundUnlocked(
 			}
 			restoreErr := restoreRepairNodeIfAbsent(quarantine, path)
 			if restoreErr != nil {
-				return applied, fmt.Errorf("commit derived-state undo state: %w; confirmed state retained at %s: %v", err, quarantine, restoreErr)
+				return applied, fmt.Errorf("commit derived-state undo state: %w; confirmed state retained at %s: %w", err, quarantine, restoreErr)
 			}
 			return applied, fmt.Errorf("commit derived-state undo state: %w", err)
 		}

--- a/internal/repair/transaction.go
+++ b/internal/repair/transaction.go
@@ -217,7 +217,7 @@ func clearPreparedRepairTransaction(expected *RepairTransaction) error {
 	repairPendingAfterMove(path, cleanup)
 	restoreUnknown := func(cause error) error {
 		if restoreErr := renameRepairNodeNoReplace(cleanup, path); restoreErr != nil {
-			return fmt.Errorf("%w; displaced pending repair retained at %s: %v", cause, cleanup, restoreErr)
+			return fmt.Errorf("%w; displaced pending repair retained at %s: %w", cause, cleanup, restoreErr)
 		}
 		return cause
 	}
@@ -685,7 +685,7 @@ func UndoLastRepair() (*RepairTransaction, error) {
 		if restoreErr != nil {
 			if redo != "" {
 				if compensateErr := restoreRepairNodeIfAbsent(redo, change.TargetPath); compensateErr != nil {
-					return nil, fmt.Errorf("undo repair: restore %s: %w (current state retained at %s: %v)", change.TargetPath, restoreErr, redo, compensateErr)
+					return nil, fmt.Errorf("undo repair: restore %s: %w (current state retained at %s: %w)", change.TargetPath, restoreErr, redo, compensateErr)
 				}
 			}
 			return nil, fmt.Errorf("undo repair: restore %s: %w", change.TargetPath, restoreErr)

--- a/internal/repair/update.go
+++ b/internal/repair/update.go
@@ -763,7 +763,7 @@ func PublishClaimedFileUpdateMemberExact(
 		fileUpdateAfterRetain(member.TargetPath, retained)
 		if err := verifyRepairPlanReleaseNodeStateFor(retained, member.TargetPath, preparedState); err != nil {
 			if restoreErr := restoreRepairNodeIfAbsent(retained, member.TargetPath); restoreErr != nil {
-				return FileUpdateInstallReceipt{}, fmt.Errorf("%w; verified prior release file retained at %s: %v", err, retained, restoreErr)
+				return FileUpdateInstallReceipt{}, fmt.Errorf("%w; verified prior release file retained at %s: %w", err, retained, restoreErr)
 			}
 			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: prepared release file changed during retain: %w", err)
 		}
@@ -771,7 +771,7 @@ func PublishClaimedFileUpdateMemberExact(
 	if err := renameRepairNodeNoReplace(stage, member.TargetPath); err != nil {
 		if retained != "" {
 			if restoreErr := restoreRepairNodeIfAbsent(retained, member.TargetPath); restoreErr != nil {
-				return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: publish %s: %w; verified prior release file retained at %s: %v", filepath.Base(member.TargetPath), err, retained, restoreErr)
+				return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: publish %s: %w; verified prior release file retained at %s: %w", filepath.Base(member.TargetPath), err, retained, restoreErr)
 			}
 		}
 		return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: publish %s: %w", filepath.Base(member.TargetPath), err)
@@ -781,7 +781,7 @@ func PublishClaimedFileUpdateMemberExact(
 		rejected, retainErr := moveRepairNodeToUniqueCleanup(member.TargetPath)
 		if retainErr != nil || rejected == "" {
 			if retainErr != nil {
-				return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; retain rejected file: %v", filepath.Base(member.TargetPath), err, retainErr)
+				return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; retain rejected file: %w", filepath.Base(member.TargetPath), err, retainErr)
 			}
 			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file disappeared before compensation", filepath.Base(member.TargetPath), err)
 		}
@@ -789,10 +789,10 @@ func PublishClaimedFileUpdateMemberExact(
 			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s", filepath.Base(member.TargetPath), err, rejected)
 		}
 		if verifyErr := verifyRepairPlanReleaseNodeStateFor(retained, member.TargetPath, preparedState); verifyErr != nil {
-			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s; prepared file changed at %s: %v", filepath.Base(member.TargetPath), err, rejected, retained, verifyErr)
+			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s; prepared file changed at %s: %w", filepath.Base(member.TargetPath), err, rejected, retained, verifyErr)
 		}
 		if restoreErr := restoreRepairNodeIfAbsent(retained, member.TargetPath); restoreErr != nil {
-			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s; restore prepared file: %v", filepath.Base(member.TargetPath), err, rejected, restoreErr)
+			return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s; restore prepared file: %w", filepath.Base(member.TargetPath), err, rejected, restoreErr)
 		}
 		return FileUpdateInstallReceipt{}, fmt.Errorf("publish file update: installed %s changed: %w; rejected file retained at %s and prepared file restored", filepath.Base(member.TargetPath), err, rejected)
 	}
@@ -1476,10 +1476,10 @@ func quarantineExistingAppBundleUpdateBackup(tx *UpdateTransaction) (string, str
 			if _, statErr := os.Lstat(tx.BackupPath); statErr == nil {
 				return fmt.Errorf("%w; preserved quarantined backup at %s because the public path was recreated", cause, quarantine)
 			} else if !os.IsNotExist(statErr) {
-				return fmt.Errorf("%w; inspect recreated handoff backup: %v", cause, statErr)
+				return fmt.Errorf("%w; inspect recreated handoff backup: %w", cause, statErr)
 			}
 			if restoreErr := renameRepairNodeNoReplace(quarantine, tx.BackupPath); restoreErr != nil {
-				return fmt.Errorf("%w; preserved quarantined backup at %s: %v", cause, quarantine, restoreErr)
+				return fmt.Errorf("%w; preserved quarantined backup at %s: %w", cause, quarantine, restoreErr)
 			}
 			return cause
 		}
@@ -1648,7 +1648,7 @@ func removePendingUpdateExactVerified(expected *UpdateTransaction, verify func()
 	updateCleanupAfterRename(path, cleanup)
 	restore := func(cause error) error {
 		if restoreErr := renameRepairNodeNoReplace(cleanup, path); restoreErr != nil {
-			return fmt.Errorf("%w; pending transaction retained at %s: %v", cause, cleanup, restoreErr)
+			return fmt.Errorf("%w; pending transaction retained at %s: %w", cause, cleanup, restoreErr)
 		}
 		return cause
 	}
@@ -2428,7 +2428,7 @@ func removeUpdateNodeMatching(path string, verify func(string) error, directory 
 	updateCleanupAfterRename(path, cleanup)
 	restore := func(cause error) error {
 		if restoreErr := renameRepairNodeNoReplace(cleanup, path); restoreErr != nil {
-			return fmt.Errorf("%w; changed update node retained at %s: %v", cause, cleanup, restoreErr)
+			return fmt.Errorf("%w; changed update node retained at %s: %w", cause, cleanup, restoreErr)
 		}
 		return cause
 	}
@@ -2696,7 +2696,7 @@ func rollbackPendingUpdateMatchingLocked(
 			if verifyErr := verifyRepairPlanReleaseNodeStateFor(failed, tx.TargetPath, retainedFailedState); verifyErr != nil {
 				if restoreErr := rollbackSwapRename(failed, tx.TargetPath); restoreErr != nil {
 					result.MixedInstall = true
-					return result, fmt.Errorf("%w; preserve moved live bundle at %s: %v", verifyErr, failed, restoreErr)
+					return result, fmt.Errorf("%w; preserve moved live bundle at %s: %w", verifyErr, failed, restoreErr)
 				}
 				return result, verifyErr
 			}
@@ -2707,7 +2707,7 @@ func rollbackPendingUpdateMatchingLocked(
 				if verifyErr := verifyRepairPlanReleaseNodeStateFor(failed, tx.TargetPath, expected); verifyErr != nil {
 					if restoreErr := rollbackSwapRename(failed, tx.TargetPath); restoreErr != nil {
 						result.MixedInstall = true
-						return result, fmt.Errorf("%w; preserve moved live bundle at %s: %v", verifyErr, failed, restoreErr)
+						return result, fmt.Errorf("%w; preserve moved live bundle at %s: %w", verifyErr, failed, restoreErr)
 					}
 					return result, verifyErr
 				}
@@ -2727,11 +2727,11 @@ func rollbackPendingUpdateMatchingLocked(
 			if retainedFailed {
 				if verifyErr := verifyRepairPlanReleaseNodeStateFor(failed, tx.TargetPath, retainedFailedState); verifyErr != nil {
 					result.MixedInstall = true
-					return result, fmt.Errorf("rollback update: restore bundle: %w (retained live bundle changed at %s: %v)", err, failed, verifyErr)
+					return result, fmt.Errorf("rollback update: restore bundle: %w (retained live bundle changed at %s: %w)", err, failed, verifyErr)
 				}
 				if restoreErr := rollbackSwapRename(failed, tx.TargetPath); restoreErr != nil {
 					result.MixedInstall = true
-					return result, fmt.Errorf("rollback update: restore bundle: %w (preserve replacement at %s: %v)", err, failed, restoreErr)
+					return result, fmt.Errorf("rollback update: restore bundle: %w (preserve replacement at %s: %w)", err, failed, restoreErr)
 				}
 			}
 			return result, fmt.Errorf("rollback update: restore bundle: %w", err)
@@ -2753,7 +2753,7 @@ func rollbackPendingUpdateMatchingLocked(
 			if moveErr != nil || rejected == "" {
 				result.MixedInstall = true
 				if moveErr != nil {
-					return result, fmt.Errorf("%w; retain rejected bundle: %v", mismatchErr, moveErr)
+					return result, fmt.Errorf("%w; retain rejected bundle: %w", mismatchErr, moveErr)
 				}
 				return result, fmt.Errorf("%w; rejected bundle disappeared before compensation", mismatchErr)
 			}
@@ -2763,15 +2763,15 @@ func rollbackPendingUpdateMatchingLocked(
 			}
 			if verifyErr := verifyRepairPlanReleaseNodeStateFor(failed, tx.TargetPath, retainedFailedState); verifyErr != nil {
 				result.MixedInstall = true
-				return result, fmt.Errorf("%w; rejected bundle retained at %s; prior live bundle changed at %s: %v", mismatchErr, rejected, failed, verifyErr)
+				return result, fmt.Errorf("%w; rejected bundle retained at %s; prior live bundle changed at %s: %w", mismatchErr, rejected, failed, verifyErr)
 			}
 			if restoreErr := rollbackSwapRename(failed, tx.TargetPath); restoreErr != nil {
 				result.MixedInstall = true
-				return result, fmt.Errorf("%w; rejected bundle retained at %s; restore prior live bundle: %v", mismatchErr, rejected, restoreErr)
+				return result, fmt.Errorf("%w; rejected bundle retained at %s; restore prior live bundle: %w", mismatchErr, rejected, restoreErr)
 			}
 			if verifyErr := verifyRepairPlanReleaseNodeStateFor(tx.TargetPath, tx.TargetPath, retainedFailedState); verifyErr != nil {
 				result.MixedInstall = true
-				return result, fmt.Errorf("%w; rejected bundle retained at %s; restored prior live bundle changed: %v", mismatchErr, rejected, verifyErr)
+				return result, fmt.Errorf("%w; rejected bundle retained at %s; restored prior live bundle changed: %w", mismatchErr, rejected, verifyErr)
 			}
 			return result, fmt.Errorf("%w; rejected bundle retained at %s and prior live bundle restored", mismatchErr, rejected)
 		}
@@ -2988,7 +2988,7 @@ func restoreReleaseUnit(
 				swapErr = verifyErr
 				if restoreErr := restoreRepairNodeIfAbsent(aside, f.TargetPath); restoreErr != nil {
 					preserveAside[i] = true
-					swapErr = fmt.Errorf("%w; preserve moved live target at %s: %v", verifyErr, aside, restoreErr)
+					swapErr = fmt.Errorf("%w; preserve moved live target at %s: %w", verifyErr, aside, restoreErr)
 				} else {
 					asides[i] = ""
 				}
@@ -3001,7 +3001,7 @@ func restoreReleaseUnit(
 					swapErr = fmt.Errorf("installed release file %s changed before rollback: %w", filepath.Base(f.TargetPath), verifyErr)
 					if restoreErr := restoreRepairNodeIfAbsent(aside, f.TargetPath); restoreErr != nil {
 						preserveAside[i] = true
-						swapErr = fmt.Errorf("%w; preserve moved live target at %s: %v", swapErr, aside, restoreErr)
+						swapErr = fmt.Errorf("%w; preserve moved live target at %s: %w", swapErr, aside, restoreErr)
 					} else {
 						asides[i] = ""
 					}
@@ -3016,7 +3016,7 @@ func restoreReleaseUnit(
 				swapErr = verifyErr
 				if restoreErr := restoreRepairNodeIfAbsent(aside, f.TargetPath); restoreErr != nil {
 					preserveAside[i] = true
-					swapErr = fmt.Errorf("%w; preserve moved live target at %s: %v", verifyErr, aside, restoreErr)
+					swapErr = fmt.Errorf("%w; preserve moved live target at %s: %w", verifyErr, aside, restoreErr)
 				} else {
 					asides[i] = ""
 				}

--- a/internal/repair/update_legacy.go
+++ b/internal/repair/update_legacy.go
@@ -85,10 +85,10 @@ func ArchiveSupersededPendingAppBundleUpdate(runningVersion string) (bool, error
 		if _, statErr := os.Lstat(tx.BackupPath); statErr == nil {
 			return fmt.Errorf("%w; preserved archived backup at %s because the public path was recreated", cause, backupArchive)
 		} else if !os.IsNotExist(statErr) {
-			return fmt.Errorf("%w; inspect backup restore path: %v", cause, statErr)
+			return fmt.Errorf("%w; inspect backup restore path: %w", cause, statErr)
 		}
 		if restoreErr := renameRepairNodeNoReplace(backupArchive, tx.BackupPath); restoreErr != nil {
-			return fmt.Errorf("%w; preserved archived backup at %s: %v", cause, backupArchive, restoreErr)
+			return fmt.Errorf("%w; preserved archived backup at %s: %w", cause, backupArchive, restoreErr)
 		}
 		return cause
 	}
@@ -107,7 +107,7 @@ func ArchiveSupersededPendingAppBundleUpdate(runningVersion string) (bool, error
 	}
 	restoreMarker := func(cause error) error {
 		if restoreErr := renameRepairNodeNoReplace(archivePath, PendingUpdatePath()); restoreErr != nil {
-			cause = fmt.Errorf("%w; preserved moved transaction at %s: %v", cause, archivePath, restoreErr)
+			cause = fmt.Errorf("%w; preserved moved transaction at %s: %w", cause, archivePath, restoreErr)
 		}
 		return restoreBackup(cause)
 	}
@@ -202,7 +202,7 @@ func archiveSupersededAppBundleBackup(tx *UpdateTransaction, transactionID strin
 		}
 		cause := fmt.Errorf("archive superseded app update: rollback backup changed during archival")
 		if restoreErr := renameRepairNodeNoReplace(archive, tx.BackupPath); restoreErr != nil {
-			return "", "", fmt.Errorf("%w; preserved moved backup at %s: %v", cause, archive, restoreErr)
+			return "", "", fmt.Errorf("%w; preserved moved backup at %s: %w", cause, archive, restoreErr)
 		}
 		return "", "", cause
 	}
@@ -233,7 +233,7 @@ func archiveSupersededPendingMarker(tx *UpdateTransaction, transactionID, kind s
 		}
 		restore := func(cause error) error {
 			if restoreErr := renameRepairNodeNoReplace(archivePath, pendingPath); restoreErr != nil {
-				return fmt.Errorf("%w; preserved moved transaction at %s: %v", cause, archivePath, restoreErr)
+				return fmt.Errorf("%w; preserved moved transaction at %s: %w", cause, archivePath, restoreErr)
 			}
 			return cause
 		}
@@ -316,7 +316,7 @@ func ArchiveSupersededPendingFileUpdate(runningVersion, installRoot string) (boo
 		}
 		restore := func(cause error) error {
 			if restoreErr := renameRepairNodeNoReplace(archivePath, pendingPath); restoreErr != nil {
-				return fmt.Errorf("%w; preserved moved transaction at %s: %v", cause, archivePath, restoreErr)
+				return fmt.Errorf("%w; preserved moved transaction at %s: %w", cause, archivePath, restoreErr)
 			}
 			return cause
 		}

--- a/internal/sessiontemp/manager.go
+++ b/internal/sessiontemp/manager.go
@@ -270,17 +270,17 @@ func (m *Manager) createGenerationLocked() (*generation, error) {
 	}
 	dir, err := mk(parent)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrUnavailable, err)
+		return nil, fmt.Errorf("%w: %w", ErrUnavailable, err)
 	}
 	if err := os.Chmod(dir, 0o700); err != nil {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("%w: chmod: %v", ErrUnavailable, err)
+		return nil, fmt.Errorf("%w: chmod: %w", ErrUnavailable, err)
 	}
 	lockPath := filepath.Join(dir, ownerLockName)
 	release, err := filelock.Acquire(nilContext(), lockPath)
 	if err != nil {
 		_ = os.RemoveAll(dir)
-		return nil, fmt.Errorf("%w: owner lock: %v", ErrUnavailable, err)
+		return nil, fmt.Errorf("%w: owner lock: %w", ErrUnavailable, err)
 	}
 	return &generation{
 		id:           nextGenID.Add(1),

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -128,7 +128,7 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	hostVerified, manualUnverified, err := verifyStepEvidence(ctx, p.Evidence)
 	if err != nil {
 		if hasTodo && todoMatch.Status == "in_progress" {
-			return "", fmt.Errorf("%v; todo %d %q remains in_progress — repair the evidence and retry this step before moving on", err, todoMatch.Index, todoMatch.Content)
+			return "", fmt.Errorf("%w; todo %d %q remains in_progress — repair the evidence and retry this step before moving on", err, todoMatch.Index, todoMatch.Content)
 		}
 		return "", err
 	}

--- a/internal/tool/builtin/confine_test.go
+++ b/internal/tool/builtin/confine_test.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -442,7 +443,8 @@ func TestConfineReadBlocksReadFile(t *testing.T) {
 	if err == nil {
 		t.Error("read_file should refuse a forbid-read path")
 	}
-	if _, ok := err.(*os.PathError); !ok {
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
 		t.Errorf("read_file forbid-read error should be *os.PathError, got %T: %v", err, err)
 	}
 	// Unconfined (nil forbidRoots) should work.
@@ -549,7 +551,8 @@ func TestConfineReadBlocksGrepFile(t *testing.T) {
 	if err == nil {
 		t.Error("grep on a forbid-read file should error, not return (no matches)")
 	}
-	if _, ok := err.(*os.PathError); !ok {
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
 		t.Errorf("grep forbid-read error should be *os.PathError, got %T: %v", err, err)
 	}
 	// Unconfined (nil forbidRoots) should work.

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -255,7 +256,7 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 			if ig.skip(path, d.Name(), false) {
 				return nil
 			}
-			if searchFile(path) == io.EOF {
+			if errors.Is(searchFile(path), io.EOF) {
 				return filepath.SkipAll
 			}
 			return nil

--- a/internal/tool/builtin/movefile.go
+++ b/internal/tool/builtin/movefile.go
@@ -123,13 +123,13 @@ func renameSameFileDestination(src, dst string) error {
 	}
 	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
 		if restoreErr := renameFile(tmpName, src); restoreErr != nil {
-			return fmt.Errorf("%w; restore %s: %v", err, src, restoreErr)
+			return fmt.Errorf("%w; restore %s: %w", err, src, restoreErr)
 		}
 		return err
 	}
 	if err := renameFile(tmpName, dst); err != nil {
 		if restoreErr := renameFile(tmpName, src); restoreErr != nil {
-			return fmt.Errorf("%w; restore %s: %v", err, src, restoreErr)
+			return fmt.Errorf("%w; restore %s: %w", err, src, restoreErr)
 		}
 		return err
 	}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -3,11 +3,11 @@
     "banner": 0,
     "commented-code": 0,
     "essay": 4111,
-    "file-size": 73751,
+    "file-size": 73754,
     "layering": 1,
     "marker": 0,
     "narrative": 66,
-    "test-file-size": 64805
+    "test-file-size": 64807
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -156,7 +156,7 @@
     },
     "desktop/sessions.go": {
       "essay": 5,
-      "file-size": 509
+      "file-size": 511
     },
     "desktop/sessions_lease_guard_test.go": {
       "essay": 3
@@ -940,7 +940,7 @@
     },
     "internal/control/refs.go": {
       "essay": 5,
-      "file-size": 560
+      "file-size": 561
     },
     "internal/control/refs_test.go": {
       "test-file-size": 141
@@ -1344,7 +1344,7 @@
     },
     "internal/provider/responses/responses_test.go": {
       "essay": 6,
-      "test-file-size": 349
+      "test-file-size": 351
     },
     "internal/provider/responses/vendor.go": {
       "essay": 21


### PR DESCRIPTION
Every `err == Sentinel` and `err.(*T)` in this tree works **today** — I checked
all 27 of them, and each compares against an error the stdlib or an x/ package
returns directly, or a local sentinel that is never wrapped.

That is the problem. Nothing maintains that property. The moment anyone adds a
single `%w` between the producer and the check, the branch silently stops
firing — no compile error, no vet warning, no test failure unless one happens to
cover that path. **And this same change adds 54 of them.**

So the ordering matters: all 27 comparisons are converted to `errors.Is`/
`errors.As` first, and only then are the 54 `fmt.Errorf("%v")` turned into `%w`.
Doing the second half alone would have manufactured 27 real bugs.

## Three hand-rolled reimplementations of the standard library

These were not patched, they were deleted:

- `remote.isPassphraseMissing` — a type assertion helper
- `remote.asKeyError` — open-coded the `Unwrap() error` walk
- `forward.containsErr` — open-coded **both** the `Unwrap() error` and
  `Unwrap() []error` walks, recursively

All three are `errors.As`/`errors.Is`. Call sites now use the stdlib.

## Two assertions that deliberately keep `!=`

`explainError` and `AnnotateToolSchemaError` must return the *same* error object
when they have nothing to add. `errors.Is` would still pass if they started
wrapping it, so converting these would quietly weaken the test. Both keep `!=`
behind a `//nolint:errorlint` naming the reason.

## Gate

`errorlint` is enabled in `.golangci.yml`. Both modules are clean under it.

## Verification

`gofmt`, `go build`, `go vet`, and `golangci-lint` under **GOOS=linux, darwin,
and windows** — 0 issues on linux and darwin; windows reports only the four
pre-existing `defer windows.CloseHandle` errcheck findings that predate this
branch and that CI has never compiled.

Full `go test ./...` on both modules. Three root failures, none from this
change: two reproduce identically on the merge base (local `~/.ssh` and session
fixtures leaking into test isolation) and the third,
`TestConcurrentResumesKeepControllerAndLeaseAligned`, is a load-dependent timing
flake in `internal/serve` — a package this branch does not touch at all — which
passes on rerun.

`repolint` flagged three files gaining a line or two, all from the `var x *T`
declaration and import that `errors.As` requires; the baseline was regenerated
for exactly those.

Cache-impact: low — the touched files under `internal/plugin`, `internal/provider`,
`internal/tool`, and `internal/installsource` change only error comparison and
wrapping; no prompt, tool-definition, or memory bytes move.
Cache-guard: `REASONIX_RELEASE_CACHE_GUARD=1 go test -count=1 -run TestCacheHit
./internal/agent/` passes on a forced (non-cached) run.
Documentation-impact: none - no tool name, argument, or contract changes; only
the error values callers receive become unwrappable, which the docs do not
describe.
