### PR TITLE
build(lint): lint every build tag, not just linux/amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,16 @@ jobs:
       - name: Test integrated terminal and PTY lifecycle
         run: go test -race -run 'Test(ResolveTerminal|Terminal|EmptyTerminal|UnixTerminalProcess)' .
 
+      # desktop/*_darwin.go is the one build-tag set the lint job cannot reach:
+      # the main-thread watchdog is cgo, so it only type-checks with a real
+      # macOS toolchain.
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          working-directory: desktop
+          args: --timeout=5m
+
   # Desktop project-root matching is case-insensitive only on Windows
   # (sameDesktopPath folds case when os.PathSeparator is '\'), so the
   # regression tests for that contract are named *OnWindows and can never
@@ -480,6 +490,21 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=5m
+
+      # The step above only type-checks the linux/amd64 build, so every
+      # //go:build windows and //go:build darwin file in the tree went unlinted.
+      # Both modules cross-check without a toolchain; desktop under darwin does
+      # not, because its watchdog is cgo, so that leg lives in desktop-macos.
+      - name: golangci-lint (cross-platform build tags)
+        run: |
+          set -euo pipefail
+          command -v golangci-lint
+          for target in "darwin ." "windows ." "windows desktop"; do
+            set -- $target
+            echo "::group::golangci-lint GOOS=$1 ($2)"
+            (cd "$2" && GOOS="$1" golangci-lint run --timeout=5m ./...)
+            echo "::endgroup::"
+          done
 
       # Report-only complexity monitor for internal/agent. Does not duplicate the
       # main lint/test/race gates; funlen+cyclop run with issues-exit-code=0 so

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,11 @@ linters:
         - (io.Closer).Close
         - (*net/http.Response).Body.Close
         - golang.org/x/term.Restore
+        # Win32: CloseHandle in a defer mirrors the Close exclusions above, and
+        # LazyProc.Call always returns a non-nil errno — the caller reads r1.
+        - golang.org/x/sys/windows.CloseHandle
+        - (*syscall.LazyProc).Call
+        - (*golang.org/x/sys/windows.LazyProc).Call
     staticcheck:
       checks:
         - all

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS := -s -w \
 	-X main.buildTimeUTC=$(BUILD_TIME_UTC)
 GOEXE := $(shell go env GOEXE)
 
-.PHONY: build vet fmt lint lint-update test desktop-test desktop-test-short desktop-test-times sdk-test sdk-test-race hooks cross clean
+.PHONY: build vet fmt lint lint-cross lint-update test desktop-test desktop-test-short desktop-test-times sdk-test sdk-test-race hooks cross clean
 
 build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix$(GOEXE) ./cmd/reasonix
@@ -24,6 +24,14 @@ lint:
 
 lint-update:
 	go run ./tools/repolint -update
+
+# Linting one GOOS leaves every //go:build windows and darwin file unchecked.
+lint-cross:
+	@for t in "linux ." "darwin ." "windows ." "linux desktop" "windows desktop"; do \
+		set -- $$t; \
+		echo "== golangci-lint GOOS=$$1 ($$2)"; \
+		(cd $$2 && GOOS=$$1 golangci-lint run --timeout=5m ./...) || exit 1; \
+	done
 
 test:
 	go test ./...

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -273,8 +273,8 @@ func validateWindowsUpdateHelper(data []byte, goarch string) error {
 	if !ok {
 		return fmt.Errorf("unsupported Windows architecture %q", goarch)
 	}
-	if f.FileHeader.Machine != want {
-		return fmt.Errorf("PE machine 0x%x does not match %s", f.FileHeader.Machine, goarch)
+	if f.Machine != want {
+		return fmt.Errorf("PE machine 0x%x does not match %s", f.Machine, goarch)
 	}
 	return nil
 }

--- a/internal/cli/hide_windows.go
+++ b/internal/cli/hide_windows.go
@@ -13,5 +13,5 @@ func hideFileWindows(path string) {
 		return
 	}
 	// FILE_ATTRIBUTE_HIDDEN = 0x02
-	syscall.SetFileAttributes(p, 0x02)
+	_ = syscall.SetFileAttributes(p, 0x02)
 }


### PR DESCRIPTION
`golangci-lint` only type-checks the `GOOS` it runs under. CI runs it once, on
linux/amd64. So every file behind `//go:build windows` or `//go:build darwin`
— **92 of them** — has never been linted, by any linter, ever.

That set is not incidental. It is the Windows updater, installer, process
reaping, path-case handling and sandbox, plus the macOS PTY and hang watchdog:
the paths that are hardest to reproduce locally and most expensive to get wrong.

## This is not theoretical

Two days of evidence from adjacent branches:

- #7831 was verified clean with `golangci-lint` on Windows, then failed CI with
  **six** findings in `!windows` files (`credentials_keyring_unix.go`,
  `seatbelt_other.go`, `updater_deb_linux.go`, …).
- Running the same config under `GOOS=darwin` then surfaced **three more** in
  `seatbelt_darwin_test.go` that neither the Windows nor the Linux run could
  reach.

Each platform sees only its own slice. One run is not a lint pass.

## What runs where

| leg | where | why |
|---|---|---|
| root + desktop, `GOOS=linux` | `lint` (ubuntu) | unchanged |
| root, `GOOS=darwin` and `GOOS=windows` | `lint` (ubuntu) | pure Go, cross-checks with no toolchain |
| desktop, `GOOS=windows` | `lint` (ubuntu) | same |
| desktop, `GOOS=darwin` | `desktop-macos` | the main-thread watchdog is cgo; cross-checking it exits 7 on a typecheck failure, so it needs a real macOS toolchain |

`make lint-cross` runs the same five-way sweep locally, so this stops being a
thing you only learn about from CI.

## Existing findings, now fixed

Sixteen, all previously invisible:

- `windows.CloseHandle` in a `defer` and `LazyProc.Call` join the errcheck
  exclusions, next to the `(io.Closer).Close` entries they mirror.
  `LazyProc.Call` always returns a non-nil errno — the caller reads `r1`.
- `syscall.SetFileAttributes` is best-effort and now discards explicitly.
- `updater_windows.go` drops a redundant embedded-field selector (QF1008).

## Verification

All five legs run locally at 0 issues:

```
== golangci-lint GOOS=linux (.)         0 issues.
== golangci-lint GOOS=darwin (.)        0 issues.
== golangci-lint GOOS=windows (.)       0 issues.
== golangci-lint GOOS=linux (desktop)   0 issues.
== golangci-lint GOOS=windows (desktop) 0 issues.
```

Plus `actionlint` on the workflow, `go build`/`go vet`/`repolint` on both
modules. The one root test failure (`TestRunResumeCopyContinuesInDuplicate`)
reproduces identically on the merge base and is unrelated — this branch touches
only two Windows-only source lines, CI config, and the Makefile.


Documentation-impact: none - CI configuration, Makefile, and two Windows-only
source lines; no tool, contract, or user-visible behavior changes.
