### PR TITLE
test: stop the CLI and SSH suites from reaching the outside world

### DIFF
--- a/internal/cli/offline_provider_test.go
+++ b/internal/cli/offline_provider_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+// pinProviderOffline points the isolated home at a provider that can never be
+// reached, so a run under test fails at setup instead of dialling a real API.
+// Without it the default config targets api.deepseek.com and the assertion
+// silently depends on how that host rejects an unauthenticated call.
+func pinProviderOffline(t *testing.T) {
+	t.Helper()
+	path := config.UserConfigPath()
+	if path == "" {
+		t.Fatal("UserConfigPath() is empty under an isolated home")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := `default_model = "offline-test/model-a"
+
+[[providers]]
+name = "offline-test"
+kind = "openai"
+base_url = "https://reasonix-tests.invalid/v1"
+models = ["model-a"]
+default = "model-a"
+api_key_env = "REASONIX_TEST_ABSENT_KEY"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/session_lease_test.go
+++ b/internal/cli/session_lease_test.go
@@ -69,6 +69,7 @@ func TestRunCopyRequiresResumeTarget(t *testing.T) {
 // JSON object (the copy notice used to pollute it).
 func TestRunResumeCopyJSONKeepsStdoutClean(t *testing.T) {
 	isolateCLIConfigHome(t)
+	pinProviderOffline(t)
 
 	dir := t.TempDir()
 	src := filepath.Join(dir, "held-src.jsonl")
@@ -101,6 +102,7 @@ func TestRunResumeCopyJSONKeepsStdoutClean(t *testing.T) {
 
 func TestRunResumeCopyContinuesInDuplicate(t *testing.T) {
 	isolateCLIConfigHome(t)
+	pinProviderOffline(t)
 
 	dir := t.TempDir()
 	src := filepath.Join(dir, "held-src.jsonl")
@@ -167,6 +169,7 @@ func TestRunResumeCopyContinuesInDuplicate(t *testing.T) {
 
 func TestRunResumeReleasesLeaseOnExit(t *testing.T) {
 	isolateCLIConfigHome(t)
+	pinProviderOffline(t)
 
 	path := filepath.Join(t.TempDir(), "release-run.jsonl")
 	saveTestSession(t, path, "resume me")

--- a/internal/remote/sshconfig_test.go
+++ b/internal/remote/sshconfig_test.go
@@ -167,6 +167,10 @@ func TestSSHConfigAliasesIncludeImportedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Installed OpenSSH rejects config files whose ACL is wider than the owner,
+	// which t.TempDir() cannot guarantee on Windows. Include handling is the
+	// parser's contract here; the ssh -G path has its own stubbed tests.
+	src.resolveOpenSSH = nil
 	aliases := src.Aliases()
 	if len(aliases) != 2 || aliases[0].Alias != "included-box" || aliases[1].Alias != "direct-box" {
 		t.Fatalf("included aliases = %+v", aliases)


### PR DESCRIPTION
`go test ./...` did not pass on a clean local checkout, and the two failures had
been carried for weeks as "environment quirks". Both turned out to be tests
quietly depending on the outside world, and the recorded explanations for both
were wrong.

## The CLI tests were calling a real API

Three `runAgent` tests carry the same comment:

> The isolated home has no provider config, so the run itself fails after the copy

That is what they mean. It is not what they did. **"No config" means the
*default* config applies**, and the default provider is `api.deepseek.com`. So
`go test` was making real outbound HTTPS calls, and the assertions rode on how
that host happens to reject an unauthenticated request.

`HTTP 401` can only come from a real response — that was the proof:

```
error: authentication failed for provider "deepseek-flash" (HTTP 401):
DEEPSEEK_API_KEY from Reasonix credentials (.env) is invalid or expired
```

A probe confirmed the credential was in fact **empty** (`ResolveCredential` →
`Set:false` before and after isolation); the `.env` wording in that message is
guidance text, not provenance. The 401 is simply what the endpoint returns to
an unauthenticated caller.

Two of the three passed only because they never inspected the affected data.
The third compared message counts, saw the copy grow by the user turn plus a
tool message, and failed — locally. On CI it passes, because the run there
fails earlier. Same code, opposite result, decided by the network.

`pinProviderOffline` writes a provider pinned to an unresolvable `.invalid`
host with an absent `api_key_env`. The runs now fail at setup with
`missing env REASONIX_TEST_ABSENT_KEY` — deterministic, no network — which is
what the comments claimed all along. It is applied to all three tests that
actually start a run, not just the one that was failing.

## The SSH test was shelling out to the host's ssh

`TestSSHConfigAliasesIncludeImportedFiles` was the one test in its file that
did not stub `resolveOpenSSH`. Installed OpenSSH refuses config files whose ACL
is wider than the owner — which `t.TempDir()` cannot guarantee:

```
Bad owner or permissions on C:/Users/.../hosts.conf
```

so the `Include` never loaded and the alias resolved to itself. Include
handling is the parser's contract here, and the `ssh -G` path keeps its own
stubbed tests, so this one now uses the parser like its siblings.

## Result

`go test ./...` is green on a clean local checkout, verified twice.

The stale "known local failures" note this repo has been carrying listed five
root-module tests; only these two still failed — the other three were fixed
long ago and nobody updated it. A hand-maintained list of expected failures
rots, and a rotten one is worse than none: it makes real regressions look
familiar.

## Note on placement

The helper lives in its own file rather than `cli_test.go`. repolint refused
the first attempt because that file is already 2237 lines; the right answer was
to not grow it, not to raise the ceiling.

Documentation-impact: none - test-only change; no tool, contract, or behavior
changes.
