### PR TITLE
fix(cli,desktop): make links in chat transcripts clickable (issue #7867)

### DIFF
--- a/desktop/frontend/src/__tests__/plain-text-links.test.tsx
+++ b/desktop/frontend/src/__tests__/plain-text-links.test.tsx
@@ -1,0 +1,91 @@
+// Run: tsx src/__tests__/plain-text-links.test.tsx
+
+import { Fragment, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { linkifyPlainText } from "../components/plainTextLinks";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: unknown, label: string) {
+  eq(Boolean(value), true, label);
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(
+      `  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`,
+    );
+    failed += 1;
+  }
+}
+
+function render(text: string): string {
+  return renderToStaticMarkup(createElement(Fragment, null, ...linkifyPlainText(text)));
+}
+
+console.log("\nplain text links");
+
+const simple = render("see https://example.com/x now");
+ok(
+  simple.includes('<a class="msg__text-link" href="https://example.com/x" title="https://example.com/x">https://example.com/x</a>'),
+  "bare URL becomes a clickable anchor",
+);
+ok(simple.includes("see ") && simple.includes(" now"), "surrounding text is preserved");
+
+eq(render("no links here"), "no links here", "plain text without URLs passes through untouched");
+eq(render(""), "", "empty text stays empty");
+
+// Trailing punctuation is trimmed from the destination while the visible
+// spelling keeps the original punctuation.
+const punct = render("visit https://example.com/a, and https://example.com/b!");
+ok(
+  punct.includes('href="https://example.com/a"'),
+  "comma is trimmed from the first destination",
+);
+ok(
+  punct.includes(">https://example.com/a,<"),
+  "comma stays visible in the label",
+);
+ok(
+  punct.includes('href="https://example.com/b"'),
+  "exclamation mark is trimmed from the second destination",
+);
+ok(
+  punct.includes(">https://example.com/b!<"),
+  "exclamation mark stays visible in the label",
+);
+
+// CJK full-width punctuation is trimmed too.
+const cjk = render("看 https://example.com/文档。");
+ok(
+  cjk.includes('href="https://example.com/文档"'),
+  "full-width period is trimmed from the destination",
+);
+ok(cjk.includes("。"), "full-width period stays visible in the label");
+
+// Multiple URLs, http and https.
+const multi = render("a https://a.com b http://b.com c");
+ok(
+  multi.includes('href="https://a.com"') && multi.includes('href="http://b.com"'),
+  "multiple URLs are all linkified",
+);
+
+// Quotes and angle brackets terminate a URL like the TUI regex.
+const quoted = render('say "https://x.com/y" ok');
+ok(quoted.includes('href="https://x.com/y"'), "quotes terminate the URL");
+ok(quoted.includes(">https://x.com/y<"), "quoted URL keeps its label");
+
+// Email addresses and bare domains are not linkified (keeps user bubbles plain).
+const noScheme = render("mail me at a@b.com or example.com");
+ok(!noScheme.includes("<a"), "emails and bare domains stay plain text");
+
+// Non-http schemes are not linkified.
+const ftp = render("ftp://example.com/file");
+ok(!ftp.includes("<a"), "ftp URLs stay plain text");
+
+console.log(`\nplain text links: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/MarkdownRenderer.tsx
+++ b/desktop/frontend/src/components/MarkdownRenderer.tsx
@@ -4,6 +4,7 @@ import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 import { CodeViewer } from "./CodeViewer";
 import { RichMarkdownLink } from "./githubLink";
+import { linkifyPlainText } from "./plainTextLinks";
 import { normalizeMath } from "./mathNormalize";
 import { reasonixRehypePlugins, reasonixRemarkPlugins } from "./markdownRemarkPlugins";
 import { markdownImageSource } from "../lib/markdownImage";
@@ -112,7 +113,10 @@ function createComponents(plainStatusBlocks: boolean): Components {
         if (!match && plainStatusBlocks) return <PlainMarkdownBlock text={text.replace(/\n$/, "")} />;
         return <CodeViewer value={value} language={lang} maxHeight={360} />;
       }
-      return <code className="md-code">{children}</code>;
+      // Inline code keeps its styled look, but bare http(s) URLs inside it
+      // become clickable links (models often wrap a destination in backticks,
+      // which would otherwise render it as dead "boxed" text).
+      return <code className="md-code">{linkifyPlainText(text)}</code>;
     },
     a: ({ href, children }) => <RichMarkdownLink href={href}>{children}</RichMarkdownLink>,
     img: ({ src, alt, title }) => (

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -2,6 +2,7 @@ import { createContext, memo, useCallback, useContext, useEffect, useMemo, useRe
 import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { BrainCircuit, ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, Pencil, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
+import { linkifyPlainText } from "./plainTextLinks";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon } from "./ProcessCard";
 import { ComposerContextCard } from "./ComposerContextCard";
@@ -503,7 +504,7 @@ export function UserMessage({
             {hasInvocationSegments && pasteBlocks.length === 0 && selectedTextBlocks.length === 0 ? (
               <div className="msg__text msg__rich-text">
                 {invocationSegments.map((segment, index) => segment.type === "text"
-                  ? <span key={`text:${segment.start}:${index}`}>{segment.content}</span>
+                  ? <span key={`text:${segment.start}:${index}`}>{linkifyPlainText(segment.content)}</span>
                   : (
                     <InvocationBadge
                       key={`invocation:${segment.invocation.name}:${segment.offset}:${index}`}
@@ -515,7 +516,9 @@ export function UserMessage({
               </div>
             ) : displaySegments.map((seg, i) => {
               if (seg.type === "text") {
-                return seg.content ? <div className="msg__text" key={`s${i}`}>{seg.content}</div> : null;
+                return seg.content ? (
+                  <div className="msg__text" key={`s${i}`}>{linkifyPlainText(seg.content)}</div>
+                ) : null;
               }
               const expanded = Boolean(expandedBlockKeys[seg.key]);
               return (

--- a/desktop/frontend/src/components/plainTextLinks.tsx
+++ b/desktop/frontend/src/components/plainTextLinks.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import { openExternal } from "../lib/bridge";
+
+// PlainTextLinks turns bare http(s) URLs inside plain-text user messages into
+// clickable links, mirroring the TUI behaviour. Unlike the markdown renderer
+// (which runs full GFM autolinks via RichMarkdownLink), user bubbles stay
+// plain text — only http(s) URLs are recognised, and trailing sentence
+// punctuation is trimmed from the destination while the visible text keeps
+// its original spelling.
+const PLAIN_URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+
+// Trailing punctuation trimmed from a matched URL, ASCII plus CJK full-width
+// forms, so "https://x.com." does not swallow the sentence period. Built via
+// new RegExp with an escaped "]": a literal /.../ containing "/>" would
+// confuse the TSX parser, and a bare "]" as the first class member trips up
+// V8's class parsing when "?" and ")" follow.
+const TRAILING_URL_PUNCT = new RegExp("[\\].,;:!?)}>”’」』】】，。；：！？）］｝]+$");
+
+function trimTrailingPunct(url: string): string {
+  return url.replace(TRAILING_URL_PUNCT, "");
+}
+
+/**
+ * linkifyPlainText splits plain text into React nodes, wrapping every bare
+ * http(s) URL in an anchor that opens the system browser via openExternal
+ * (never navigating the app itself). Non-URL text passes through untouched.
+ */
+export function linkifyPlainText(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  let last = 0;
+  let id = 0;
+  for (const match of text.matchAll(PLAIN_URL_RE)) {
+    const idx = match.index ?? 0;
+    const raw = match[0];
+    const url = trimTrailingPunct(raw);
+    if (url === "") continue;
+    if (idx > last) parts.push(text.slice(last, idx));
+    parts.push(
+      <a
+        key={`url:${id++}`}
+        className="msg__text-link"
+        href={url}
+        title={url}
+        onClick={(event) => {
+          event.preventDefault();
+          openExternal(url);
+        }}
+      >
+        {raw}
+      </a>,
+    );
+    last = idx + raw.length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4342,6 +4342,13 @@ a[href] {
   font-weight: 450;
   line-height: 1.65;
 }
+.msg--user .msg__text a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.msg--user .msg__text a:hover {
+  text-decoration: underline;
+}
 .msg--im-source .msg__body {
   min-width: min(520px, 82%);
   max-width: min(760px, 82%);

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -244,6 +244,12 @@ type chatTUI struct {
 	wantMouseReenable bool
 	viewport          viewport.Model
 	sel               selection
+	// lastLinkClickAt/lastLinkClickURL implement double-click-to-open for
+	// clickable links: the first click on a link records its time and URL, and
+	// a second click on the same URL within doubleClickWindow opens it in the
+	// browser. A single click still starts a selection as usual.
+	lastLinkClickAt time.Time
+	lastLinkClickURL string
 	// autoScroll drives edge-drag scrolling: -1 up, +1 down, 0 off. dragX is the
 	// column the drag is held at, so the ticker can extend the selection head.
 	autoScroll int
@@ -422,6 +428,11 @@ const (
 	tuiIdle tuiState = iota
 	tuiRunning
 )
+
+// doubleClickWindow is the max gap between two left-clicks on the same link
+// that counts as a double-click (and opens the link). 500ms matches the
+// Windows default double-click speed.
+const doubleClickWindow = 500 * time.Millisecond
 
 type controllerBuildSpec struct {
 	ModelRef         string
@@ -1115,6 +1126,25 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if strings.Contains(clicked, "more lines") && strings.Contains(clicked, "Ctrl+B") {
 					m.toggleShellOutput()
 					return m, finalize(m, cmds)
+				}
+				// Double-click on a clickable link opens it in the browser
+				// instead of starting a selection; a single click still
+				// selects, so text selection keeps working and only a
+				// deliberate second click on the same link triggers the open.
+				if url, ok := m.linkSpanAt(lineIdx, msg.X); ok {
+					now := time.Now()
+					if !m.lastLinkClickAt.IsZero() &&
+						now.Sub(m.lastLinkClickAt) <= doubleClickWindow &&
+						url == m.lastLinkClickURL {
+						m.lastLinkClickAt = time.Time{}
+						m.lastLinkClickURL = ""
+						m.sel = selection{}
+						m.autoScroll = 0
+						m.openLink(url)
+						return m, finalize(m, cmds)
+					}
+					m.lastLinkClickAt = now
+					m.lastLinkClickURL = url
 				}
 			}
 			at := m.transcriptCaret(msg.X, msg.Y)
@@ -5184,6 +5214,22 @@ func (m *chatTUI) notice(note string) {
 	m.commitLine(dim("  · " + note))
 }
 
+// openLink launches the system browser for a Ctrl+Clicked URL and reports the
+// outcome in the transcript notice area. openInBrowser is non-blocking
+// (exec.Start), so the TUI keeps running while the OS opens the browser. The
+// destination is re-validated here (not just at render time) so a forged
+// marker in the transcript can never reach the browser with an unsafe scheme.
+func (m *chatTUI) openLink(url string) {
+	if sanitizeLinkURL(url) == "" {
+		return
+	}
+	if err := openInBrowser(url); err != nil {
+		m.notice(fmt.Sprintf(i18n.M.LinkOpenFailedFmt, err))
+		return
+	}
+	m.notice(fmt.Sprintf(i18n.M.LinkOpenDoneFmt, url))
+}
+
 // showRemoteHosts renders a read-only summary of configured remote hosts. The
 // remote session lives in a `reasonix serve` on the remote host, so connecting
 // happens from a terminal (`reasonix remote connect`), not inside this chat.
@@ -5327,6 +5373,7 @@ func wrapForViewport(text string, width int, fg cliColor) string {
 // look like it has a second input box in the transcript.
 func renderUserBubble(line string, width int, planMode bool) string {
 	line = displayLineForImageRefs(line)
+	line = linkifyPlainURLs(line)
 	prefix := "› "
 	if planMode {
 		prefix = "› [plan] "
@@ -5335,6 +5382,31 @@ func renderUserBubble(line string, width int, planMode bool) string {
 		return "│ " + prefix + line
 	}
 	return "  " + accent(prefix+line)
+}
+
+// plainURLRe matches bare http(s) URLs in plain, non-markdown text such as the
+// user bubble. Trailing sentence punctuation is trimmed by
+// trimTrailingURLPunct so "https://x.com." does not swallow the period.
+var plainURLRe = regexp.MustCompile(`https?://[^\s<>"'` + "`" + `]+`)
+
+const trimTrailingURLPunct = ".!,;:?)]}>”’」』】》，。；：！？）］｝"
+
+// linkifyPlainURLs turns bare http(s) URLs in a plain-text line into OSC 8
+// hyperlinks bracketed by the zero-width click markers, exactly like the
+// markdown renderer does for [text](url) and autolinks. The visible text is
+// unchanged; sanitizeLinkURL still guards the destination.
+func linkifyPlainURLs(s string) string {
+	nextID := 0
+	return plainURLRe.ReplaceAllStringFunc(s, func(match string) string {
+		url := strings.TrimRight(match, trimTrailingURLPunct)
+		if url == "" {
+			return match
+		}
+		var b strings.Builder
+		writeLink(&b, match, url, nextID)
+		nextID++
+		return b.String()
+	})
 }
 
 var cliImageRefRe = regexp.MustCompile(`(?:^|\s)@\.reasonix/attachments/clipboard-\d{8}-\d{6}\.\d+(?:-(?:\d{6}|[a-f0-9]{8}))?\.(?:png|jpg|jpeg|gif|webp)`)

--- a/internal/cli/linkify_test.go
+++ b/internal/cli/linkify_test.go
@@ -1,0 +1,473 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+// TestRenderLinkEmitsClickableHyperlink verifies markdown [text](url) renders
+// as an OSC 8 hyperlink bracketed by zero-width click markers, with the
+// visible text byte-for-byte unchanged after stripping.
+func TestRenderLinkEmitsClickableHyperlink(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	rendered := r.Render("see [docs](https://example.com/docs) now")
+	if !strings.Contains(rendered, ansi.SetHyperlink("https://example.com/docs")) {
+		t.Fatalf("render lacks OSC 8 hyperlink: %q", rendered)
+	}
+	if !strings.Contains(rendered, linkStartPrefix) || !strings.Contains(rendered, linkEndPrefix) {
+		t.Fatalf("render lacks click markers: %q", rendered)
+	}
+	plain := strings.TrimRight(ansi.Strip(rendered), "\n")
+	want := "see docs (https://example.com/docs) now"
+	if plain != want {
+		t.Fatalf("stripped render = %q, want %q", plain, want)
+	}
+}
+
+// TestRenderBareURLBecomesClickable verifies the Linkify extension turns bare
+// http(s) URLs into clickable autolinks without changing their visible text.
+func TestRenderBareURLBecomesClickable(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	rendered := r.Render("visit https://example.com/x today")
+	if !strings.Contains(rendered, ansi.SetHyperlink("https://example.com/x")) {
+		t.Fatalf("bare URL was not hyperlinked: %q", rendered)
+	}
+	if !strings.Contains(rendered, linkStartPrefix) {
+		t.Fatalf("bare URL lacks click markers: %q", rendered)
+	}
+	if plain := ansi.Strip(rendered); !strings.Contains(plain, "visit https://example.com/x today") {
+		t.Fatalf("stripped render lost text: %q", plain)
+	}
+}
+
+// TestRenderCodeSpanURLClickable verifies a URL wrapped in backticks (the
+// "boxed, highlighted" form from the issue) is clickable too, while non-URL
+// code spans stay literal code.
+func TestRenderCodeSpanURLClickable(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	rendered := r.Render("use `https://example.com/x` here")
+	if !strings.Contains(rendered, ansi.SetHyperlink("https://example.com/x")) {
+		t.Fatalf("URL inside a code span was not hyperlinked: %q", rendered)
+	}
+	if !strings.Contains(rendered, linkStartPrefix) {
+		t.Fatalf("code-span URL lacks click markers: %q", rendered)
+	}
+	if plain := strings.TrimRight(ansi.Strip(rendered), "\n"); plain != "use https://example.com/x here" {
+		t.Fatalf("stripped render = %q, want literal text preserved", plain)
+	}
+
+	noURL := r.Render("run `go run main.go` now")
+	if strings.Contains(noURL, ansi.SetHyperlink("")) || strings.Contains(noURL, linkStartPrefix) {
+		t.Fatalf("plain code span must stay unlinked: %q", noURL)
+	}
+	if plain := strings.TrimRight(ansi.Strip(noURL), "\n"); plain != "run go run main.go now" {
+		t.Fatalf("stripped code span = %q", plain)
+	}
+}
+
+// TestRenderUnsafeSchemeStaysPlain verifies destinations that fail the scheme
+// whitelist render as plain text — no OSC 8, no markers — so a hostile model
+// cannot forge clickable javascript:/data: links.
+func TestRenderUnsafeSchemeStaysPlain(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	rendered := r.Render("[x](javascript:alert(1)) and [y](file:///etc/passwd)")
+	if strings.Contains(rendered, ansi.SetHyperlink("javascript:")) ||
+		strings.Contains(rendered, ansi.SetHyperlink("file:")) {
+		t.Fatalf("unsafe schemes must not be hyperlinked: %q", rendered)
+	}
+	if strings.Contains(rendered, linkStartPrefix) {
+		t.Fatalf("unsafe schemes must not carry click markers: %q", rendered)
+	}
+	plain := ansi.Strip(rendered)
+	if !strings.Contains(plain, "javascript:alert(1)") || !strings.Contains(plain, "file:///etc/passwd") {
+		t.Fatalf("plain text lost: %q", plain)
+	}
+}
+
+// TestRenderControlCharsStrippedFromURL verifies ESC/BEL/ST and friends are
+// scrubbed from link destinations so a model can't inject terminal sequences.
+func TestRenderControlCharsStrippedFromURL(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	evil := "https://example.com/\x1b]8;;http://evil.example\x1b\\\x07tail"
+	rendered := r.Render("[x](" + evil + ")")
+	// The injected OSC 8 start (ESC ] 8;;http://evil…) must not survive; the
+	// only OSC 8 pair in the output is the renderer's own, around the
+	// scrubbed destination.
+	if strings.Contains(rendered, "\x1b]8;;http://evil") {
+		t.Fatalf("injected OSC 8 survived sanitize: %q", rendered)
+	}
+	if strings.Count(rendered, "\x1b]8;;") != 2 {
+		t.Fatalf("expected exactly one OSC 8 pair (start+end), got: %q", rendered)
+	}
+	plain := ansi.Strip(rendered)
+	if strings.Contains(plain, "\x07") || strings.Contains(plain, "\x1b") {
+		t.Fatalf("control characters leaked into visible text: %q", plain)
+	}
+	if !strings.Contains(plain, "tail") {
+		t.Fatalf("trailing text after the stripped BEL must survive: %q", plain)
+	}
+}
+
+// TestRenderCopySkipsLinkSequences verifies the clipboard render path never
+// emits OSC 8 hyperlinks or click markers, so copies stay clean text.
+func TestRenderCopySkipsLinkSequences(t *testing.T) {
+	r := newMarkdownRenderer(80)
+	rendered := r.RenderCopy("see [docs](https://example.com/docs) and https://example.com/x", "b")
+	if strings.Contains(rendered, ansi.SetHyperlink("")) ||
+		strings.Contains(rendered, linkStartPrefix) ||
+		strings.Contains(rendered, linkEndPrefix) {
+		t.Fatalf("copy render must not carry link sequences: %q", rendered)
+	}
+	if plain := ansi.Strip(rendered); !strings.Contains(plain, "docs (https://example.com/docs)") {
+		t.Fatalf("copy render lost visible text: %q", plain)
+	}
+}
+
+func TestSanitizeLinkURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://example.com/a", "https://example.com/a"},
+		{"http://example.com", "http://example.com"},
+		{"mailto:a@b.com", "mailto:a@b.com"},
+		{"", ""},
+		{"javascript:alert(1)", ""},
+		{"data:text/html,x", ""},
+		{"file:///etc/passwd", ""},
+		{"ftp://example.com", ""},
+		{"example.com", ""},
+		{"https://ex.com/\x1b]8;x", "https://ex.com/]8;x"},
+		{"https://ex.com/\x07\x1c\x9c", "https://ex.com/"},
+	}
+	for _, c := range cases {
+		if got := sanitizeLinkURL(c.in); got != c.want {
+			t.Errorf("sanitizeLinkURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestLinkifyPlainURLs verifies bare URLs in plain text (user bubbles) get the
+// hyperlink + marker treatment and trailing sentence punctuation is trimmed
+// from the destination while the visible text keeps the original spelling.
+func TestLinkifyPlainURLs(t *testing.T) {
+	out := linkifyPlainURLs("see https://example.com/a, and https://example.com/b!")
+	if !strings.Contains(out, ansi.SetHyperlink("https://example.com/a")) {
+		t.Fatalf("first URL not hyperlinked: %q", out)
+	}
+	if !strings.Contains(out, ansi.SetHyperlink("https://example.com/b")) {
+		t.Fatalf("second URL not hyperlinked: %q", out)
+	}
+	if strings.Contains(out, ansi.SetHyperlink("https://example.com/b!")) {
+		t.Fatalf("trailing punctuation must be trimmed from destination: %q", out)
+	}
+	if !strings.Contains(out, "https://example.com/b!") {
+		t.Fatalf("visible text must keep the original spelling: %q", out)
+	}
+	if plain := ansi.Strip(out); !strings.Contains(plain, "see https://example.com/a, and https://example.com/b!") {
+		t.Fatalf("stripped output changed: %q", plain)
+	}
+	if got := ansi.Strip(linkifyPlainURLs("no links here")); got != "no links here" {
+		t.Fatalf("plain text must pass through untouched: %q", got)
+	}
+}
+
+// TestParseLinkSpansInLine covers single-line links, multiple links per line
+// and corrupted marker streams.
+func TestParseLinkSpansInLine(t *testing.T) {
+	line := "a " + linkStartMarker("0", "https://example.com/x") + "link" + linkEndMarker("0") + " b"
+	spans, next, ok := parseLinkSpansInLine(line, nil)
+	if !ok {
+		t.Fatal("parse failed on well-formed line")
+	}
+	if next != nil {
+		t.Fatal("well-formed line must not carry an open link")
+	}
+	if len(spans) != 1 || spans[0].start != 2 || spans[0].end != 6 || spans[0].url != "https://example.com/x" {
+		t.Fatalf("spans = %+v, want [{2 6 https://example.com/x}]", spans)
+	}
+
+	two := linkStartMarker("0", "https://a.com") + "aa" + linkEndMarker("0") +
+		" " + linkStartMarker("1", "https://b.com") + "bb" + linkEndMarker("1")
+	spans, _, ok = parseLinkSpansInLine(two, nil)
+	if !ok || len(spans) != 2 || spans[0].url != "https://a.com" || spans[1].url != "https://b.com" {
+		t.Fatalf("two-link line parsed as %+v ok=%v", spans, ok)
+	}
+
+	corrupt := linkEndMarker("0") // close without open
+	if _, _, ok := parseLinkSpansInLine(corrupt, nil); ok {
+		t.Fatal("close-without-open must fail")
+	}
+	truncated := "\x1b]1337;reasonix-link=0;c2FmZQ"
+	if _, _, ok := parseLinkSpansInLine(truncated, nil); ok {
+		t.Fatal("truncated marker payload must fail")
+	}
+}
+
+// TestParseLinkSpansAcrossWrap verifies a link wrapped across rows yields a
+// trailing span on the first row and a leading span on the next, both with the
+// same URL, and that a mid-link carry-over row is hit-testable from column 0.
+func TestParseLinkSpansAcrossWrap(t *testing.T) {
+	url := "https://example.com/very/long/path/with/many/segments"
+	rendered := newMarkdownRenderer(80).Render("[x](" + url + ")")
+	wrapped := strings.Split(wrapTranscript(rendered, 20), "\n")
+
+	var all []linkSpan
+	var active *openLink
+	for i, line := range wrapped {
+		spans, next, ok := parseLinkSpansInLine(line, active)
+		if !ok {
+			t.Fatalf("line %d failed to parse: %q", i, line)
+		}
+		for _, s := range spans {
+			all = append(all, s)
+		}
+		active = next
+	}
+	if len(all) == 0 {
+		t.Fatal("no spans found across wrapped lines")
+	}
+	for _, s := range all {
+		if s.url != url {
+			t.Errorf("span url = %q, want %q", s.url, url)
+		}
+	}
+	// First span must cover the first row from the link's start; the tail span
+	// on an intermediate row starts at column 0 (carry-over).
+	if all[0].start <= all[0].end && all[0].end == all[0].start {
+		t.Errorf("unexpected zero-width span: %+v", all[0])
+	}
+}
+
+// TestLinkSpanAtHitTesting drives the click hit-test against wrapped lines,
+// including a link that wraps across rows.
+func TestLinkSpanAtHitTesting(t *testing.T) {
+	m := newTestChatTUI()
+	url := "https://example.com/clickable"
+	rendered := newMarkdownRenderer(80).Render("hello [link](" + url + ") world")
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 80), "\n")
+
+	if got, ok := m.linkSpanAt(0, 7); !ok || got != url {
+		t.Fatalf("click on link label: got %q ok=%v, want %q", got, ok, url)
+	}
+	if got, ok := m.linkSpanAt(0, 45); ok {
+		t.Fatalf("click outside link must miss, got %q", got)
+	}
+	if _, ok := m.linkSpanAt(5, 0); ok {
+		t.Fatal("click beyond transcript must miss")
+	}
+
+	// Cross-row link: every row of the wrapped link must hit.
+	long := "https://example.com/" + strings.Repeat("segment/", 6)
+	rendered = newMarkdownRenderer(80).Render("pre [x](" + long + ") post")
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 30), "\n")
+	hitRows := 0
+	for i := range m.wrappedLines {
+		// Probe a few columns per row: the link body starts after "pre ".
+		for _, col := range []int{4, 12, 20, 28} {
+			if _, ok := m.linkSpanAt(i, col); ok {
+				hitRows = i + 1
+				break
+			}
+		}
+	}
+	if hitRows < 2 {
+		t.Fatalf("long link should be clickable on multiple wrapped rows, hitRows=%d lines=%d",
+			hitRows, len(m.wrappedLines))
+	}
+}
+
+// TestCtrlClickOpensLink verifies a Ctrl+Click on a link opens it in the
+// browser instead of starting a selection.
+// TestDoubleClickOpensLink verifies that two left-clicks on the same link
+// within the double-click window open it in the browser, and that the second
+// click clears the selection the first click started.
+func TestDoubleClickOpensLink(t *testing.T) {
+	prev := openInBrowser
+	t.Cleanup(func() { openInBrowser = prev })
+	opened := ""
+	openInBrowser = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	m := newChatTUI(ctrl, "", ch, 80)
+	m = advTUI(m, tea.WindowSizeMsg{Width: 80, Height: 10})
+	url := "https://example.com/open-me"
+	rendered := newMarkdownRenderer(80).Render("[x](" + url + ")")
+	m.transcript = []string{rendered}
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 80), "\n")
+
+	// First click: starts a selection and arms the double-click state.
+	first := advTUI(m, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if opened != "" {
+		t.Fatalf("single click must not open the link, got %q", opened)
+	}
+	if !first.sel.active {
+		t.Fatal("first click of a double-click must still start a selection")
+	}
+	if first.lastLinkClickURL != url {
+		t.Fatalf("first click should arm the link, got %q", first.lastLinkClickURL)
+	}
+
+	// Second click within the window: opens the link and clears the selection.
+	second := advTUI(first, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if opened != url {
+		t.Fatalf("double-click opened %q, want %q", opened, url)
+	}
+	if second.sel.active {
+		t.Fatal("double-click on a link must not leave a selection")
+	}
+	if !second.lastLinkClickAt.IsZero() {
+		t.Fatal("double-click should disarm the link state")
+	}
+	if !strings.Contains(strings.Join(second.transcript, "\n"), "opened "+url) {
+		t.Fatal("successful open should leave a notice in the transcript")
+	}
+}
+
+// TestDoubleClickOpensBareURL verifies double-click also opens a bare URL
+// (GFM autolink), not just explicit [text](url) links.
+func TestDoubleClickOpensBareURL(t *testing.T) {
+	prev := openInBrowser
+	t.Cleanup(func() { openInBrowser = prev })
+	opened := ""
+	openInBrowser = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	m := newChatTUI(ctrl, "", ch, 80)
+	m = advTUI(m, tea.WindowSizeMsg{Width: 80, Height: 10})
+	url := "https://example.com/bare"
+	rendered := newMarkdownRenderer(80).Render("visit " + url + " today")
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 80), "\n")
+
+	first := advTUI(m, tea.MouseClickMsg{X: 6, Y: 0, Button: tea.MouseLeft})
+	if opened != "" {
+		t.Fatalf("single click must not open, got %q", opened)
+	}
+	advTUI(first, tea.MouseClickMsg{X: 6, Y: 0, Button: tea.MouseLeft})
+	if opened != url {
+		t.Fatalf("double-click on bare URL opened %q, want %q", opened, url)
+	}
+}
+
+// TestSlowDoubleClickDoesNotOpen verifies that two clicks on the same link
+// farther apart than the double-click window keep the single-click behaviour
+// (selection only, no browser).
+func TestSlowDoubleClickDoesNotOpen(t *testing.T) {
+	prev := openInBrowser
+	t.Cleanup(func() { openInBrowser = prev })
+	openInBrowser = func(url string) error {
+		t.Fatal("clicks beyond the double-click window must not open a link")
+		return nil
+	}
+
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	m := newChatTUI(ctrl, "", ch, 80)
+	m = advTUI(m, tea.WindowSizeMsg{Width: 80, Height: 10})
+	url := "https://example.com/slow"
+	rendered := newMarkdownRenderer(80).Render("[x](" + url + ")")
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 80), "\n")
+
+	first := advTUI(m, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	// Age the armed state past the window, then click again.
+	first.lastLinkClickAt = time.Now().Add(-doubleClickWindow - time.Millisecond)
+	second := advTUI(first, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if !second.sel.active {
+		t.Fatal("slow second click must keep the selection behaviour")
+	}
+}
+
+// TestPlainClickStillSelects verifies a single left-click on a link keeps the
+// existing selection behaviour — only a deliberate double-click opens.
+func TestPlainClickStillSelects(t *testing.T) {
+	prev := openInBrowser
+	t.Cleanup(func() { openInBrowser = prev })
+	openInBrowser = func(url string) error {
+		t.Fatal("plain click must not open a link")
+		return nil
+	}
+
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	m := newChatTUI(ctrl, "", ch, 80)
+	m = advTUI(m, tea.WindowSizeMsg{Width: 80, Height: 10})
+	url := "https://example.com/no-open"
+	rendered := newMarkdownRenderer(80).Render("[x](" + url + ")")
+	m.wrappedLines = strings.Split(wrapTranscript(rendered, 80), "\n")
+
+	next := advTUI(m, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if !next.sel.active {
+		t.Fatal("plain left-click must still start a selection")
+	}
+}
+
+// TestDoubleClickUnsafeSchemeIgnored verifies the open-link path re-validates
+// the destination scheme at click time, so a forged marker carrying a
+// javascript:/data: URL can never reach the browser even if it somehow ends
+// up in the wrapped line cache.
+func TestDoubleClickUnsafeSchemeIgnored(t *testing.T) {
+	prev := openInBrowser
+	t.Cleanup(func() { openInBrowser = prev })
+	openInBrowser = func(url string) error {
+		t.Fatalf("unsafe scheme must not reach the browser: %q", url)
+		return nil
+	}
+
+	m := newChatTUI(control.New(control.Options{}), "", make(chan event.Event, 1), 80)
+	m = advTUI(m, tea.WindowSizeMsg{Width: 80, Height: 10})
+	forged := "\x1b]1337;reasonix-link=0;amF2YXNjcmlwdDphbGVydCgxKQ\x07" +
+		"x" + "\x1b]1337;reasonix-link-end=0\x07"
+	m.wrappedLines = strings.Split(wrapTranscript(forged, 80), "\n")
+
+	first := advTUI(m, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	next := advTUI(first, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	if next.sel.active {
+		t.Fatal("modifier click on non-clickable content must still select")
+	}
+	if strings.Contains(strings.Join(next.transcript, "\n"), "opened ") {
+		t.Fatal("unsafe scheme must not produce an opened notice")
+	}
+}
+
+// TestCopyStripsClickMarkers verifies the transcript copy path strips OSC 8
+// and click markers from fixed blocks (user bubbles) so clipboard text is
+// clean.
+func TestCopyStripsClickMarkers(t *testing.T) {
+	m := newTestChatTUI()
+	m.viewport.SetWidth(80)
+	m.transcript = []string{linkifyPlainURLs("see https://example.com/x")}
+	m.transcriptSources = []transcriptSource{{kind: transcriptSourceUser, raw: "see https://example.com/x"}}
+	m.wrappedLines = strings.Split(wrapTranscript(m.transcript[0], m.viewport.Width()), "\n")
+
+	lines, ok := m.copyTranscriptLines()
+	if !ok {
+		t.Fatal("copyTranscriptLines failed")
+	}
+	copied := selectedCopyText(lines, selPos{line: 0, col: 0}, selPos{line: 0, col: ansi.StringWidth(lines[0].text)})
+	if strings.Contains(copied, linkStartPrefix) || strings.Contains(copied, ansi.SetHyperlink("")) {
+		t.Fatalf("copy leaked click sequences: %q", copied)
+	}
+	if !strings.Contains(copied, "see https://example.com/x") {
+		t.Fatalf("copy lost visible text: %q", copied)
+	}
+}
+
+func advTUI(m chatTUI, msg tea.Msg) chatTUI {
+	n, _ := m.Update(msg)
+	return n.(chatTUI)
+}

--- a/internal/cli/md.go
+++ b/internal/cli/md.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -27,6 +29,8 @@ type mdRenderer struct {
 	copyMath       bool
 	copyMathPrefix string
 	nextCopyMathID int
+	links          bool
+	nextLinkID     int
 }
 
 func newMarkdownRenderer(width int) *mdRenderer {
@@ -37,7 +41,10 @@ func newMarkdownRenderer(width int) *mdRenderer {
 	// a Table node rather than falling through as a literal text block.
 	return &mdRenderer{
 		md: goldmark.New(
-			goldmark.WithExtensions(extension.Table),
+			// Table turns | header | rows | into a Table node instead of a
+			// literal text block; Linkify turns bare URLs and email addresses
+			// into AutoLink nodes so they render as clickable hyperlinks too.
+			goldmark.WithExtensions(extension.Table, extension.Linkify),
 			goldmark.WithParserOptions(
 				parser.WithInlineParsers(util.Prioritized(&mathParser{}, 150)),
 			),
@@ -64,7 +71,10 @@ func (r *mdRenderer) Render(input string) string {
 	src := []byte(input)
 	doc := r.md.Parser().Parse(text.NewReader(src))
 	var buf strings.Builder
+	r.links = true
+	r.nextLinkID = 0
 	r.renderBlocks(&buf, doc, src, 0)
+	r.links = false
 	out := strings.TrimRight(buf.String(), "\n")
 	if out == "" {
 		return ""
@@ -359,14 +369,32 @@ func (r *mdRenderer) appendInline(b *strings.Builder, n ast.Node, src []byte) {
 		case *ast.CodeSpan:
 			var inner strings.Builder
 			r.appendInline(&inner, v, src)
-			b.WriteString(accent(inner.String()))
+			text := inner.String()
+			if r.links {
+				text = r.linkifyCodeSpan(text)
+			}
+			b.WriteString(accent(text))
 		case *ast.Link:
 			var inner strings.Builder
 			r.appendInline(&inner, v, src)
-			b.WriteString(inner.String())
-			b.WriteString(dim(" (" + string(v.Destination) + ")"))
+			display := inner.String()
+			dest := stripControlChars(string(v.Destination))
+			if display == "" {
+				display = dest
+			}
+			if r.links {
+				r.linkify(b, display+dim(" ("+dest+")"), dest)
+			} else {
+				b.WriteString(display)
+				b.WriteString(dim(" (" + dest + ")"))
+			}
 		case *ast.AutoLink:
-			b.WriteString(string(v.URL(src)))
+			url := string(v.URL(src))
+			if r.links {
+				r.linkify(b, url, url)
+			} else {
+				b.WriteString(url)
+			}
 		case *ast.RawHTML:
 			// drop — rare in chat output and would print as literal escapes
 		case *mathNode:
@@ -390,6 +418,84 @@ func (r *mdRenderer) appendInline(b *strings.Builder, n ast.Node, src []byte) {
 			r.appendInline(b, c, src)
 		}
 	}
+}
+
+// linkify wraps display text in an OSC 8 hyperlink plus the zero-width marker
+// pair the TUI uses to hit-test clicks (see parseLinkSpansInLine). The visible
+// text is untouched; both sequences are zero-width and survive lipgloss
+// wrapping, which rebalances the OSC 8 pair across lines. Destinations that
+// fail sanitizeLinkURL fall back to plain text so hostile or malformed URLs
+// can never inject terminal sequences or marker forgeries.
+func (r *mdRenderer) linkify(b *strings.Builder, display, url string) {
+	writeLink(b, display, url, r.nextLinkID)
+	r.nextLinkID++
+}
+
+// linkifyCodeSpan turns bare http(s) URLs inside a code span into clickable
+// hyperlinks. Markdown parsers never autolink inside code, yet models commonly
+// wrap a destination in backticks to highlight it — without this, such a link
+// renders with the code styling (the "boxed" look from the issue) but stays
+// dead text. The rest of the span keeps its literal code rendering.
+func (r *mdRenderer) linkifyCodeSpan(s string) string {
+	return plainURLRe.ReplaceAllStringFunc(s, func(match string) string {
+		url := strings.TrimRight(match, trimTrailingURLPunct)
+		if url == "" {
+			return match
+		}
+		var b strings.Builder
+		writeLink(&b, match, url, r.nextLinkID)
+		r.nextLinkID++
+		return b.String()
+	})
+}
+
+// writeLink renders display as an OSC 8 hyperlink to url, bracketed by the
+// zero-width marker pair the TUI hit-tests against (parseLinkSpansInLine).
+// id must be unique within the surrounding render so markers stay paired.
+func writeLink(b *strings.Builder, display, url string, id int) {
+	url = sanitizeLinkURL(url)
+	if url == "" {
+		b.WriteString(display)
+		return
+	}
+	b.WriteString(ansi.SetHyperlink(url))
+	b.WriteString(linkStartMarker(strconv.Itoa(id), url))
+	b.WriteString(display)
+	b.WriteString(linkEndMarker(strconv.Itoa(id)))
+	b.WriteString(ansi.ResetHyperlink())
+}
+
+// safeLinkSchemeRe admits only schemes the open-in-browser path will actually
+// handle. Anything else (javascript:, data:, file:, bare words) renders as
+// plain text instead of a clickable link.
+var safeLinkSchemeRe = regexp.MustCompile(`^(https?|mailto):`)
+
+// stripControlChars removes C0/C1 control characters, DEL and the OSC/ST
+// bytes (0x9c/0x9d) from arbitrary text. It is byte-wise so invalid UTF-8
+// passes through untouched instead of being rewritten to U+FFFD.
+func stripControlChars(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == 0x7f || c == 0x9c || c == 0x9d {
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// sanitizeLinkURL returns url only when it is non-empty, uses a safe scheme
+// and contains no control characters. Control characters — ESC, BEL, ST, OSC
+// and friends — are stripped defensively so a model-supplied destination can
+// never smuggle ANSI sequences into the rendered hyperlink or forge marker
+// boundaries in the surrounding transcript.
+func sanitizeLinkURL(url string) string {
+	if url == "" || !safeLinkSchemeRe.MatchString(url) {
+		return ""
+	}
+	return stripControlChars(url)
 }
 
 // renderTable lays out a GFM table as terminal columns separated by dim

--- a/internal/cli/remote_connect.go
+++ b/internal/cli/remote_connect.go
@@ -722,14 +722,20 @@ func remoteFSPut(args []string) int {
 	})
 }
 
-func openInBrowser(url string) error {
+// openInBrowser launches the OS default browser for a URL without blocking.
+// It is a variable (not a function) so tests can stub it, mirroring
+// writeNativeClipboardText.
+var openInBrowser = func(url string) error {
 	var cmd string
 	var args []string
 	switch runtime.GOOS {
 	case "darwin":
 		cmd, args = "open", []string{url}
 	case "windows":
-		cmd, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+		// explorer.exe is the most reliable way to hand a URL to the default
+		// browser on Windows: rundll32 url.dll,FileProtocolHandler is silently
+		// blocked by some security policies and newer Windows 11 builds.
+		cmd, args = "explorer.exe", []string{url}
 	default:
 		cmd, args = "xdg-open", []string{url}
 	}

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -243,6 +243,17 @@ const (
 	copyMathStartPrefix = "\x1b]1337;reasonix-copy-math="
 	copyMathEndPrefix   = "\x1b]1337;reasonix-copy-math-end="
 	copyMathTerminator  = "\x07"
+
+	// linkStartPrefix/linkEndPrefix are zero-width OSC-style markers that
+	// bracket every clickable link in the rendered transcript. They mirror the
+	// copyMath marker scheme so the display wrapping and the click hit-testing
+	// share one source of truth: markers survive ansi/lipgloss wrapping and are
+	// stripped from copied text, while the wrapped line text stays byte-for-byte
+	// identical to what the viewport shows. The URL payload is base64-encoded
+	// so arbitrary link destinations can never forge a marker boundary.
+	linkStartPrefix = "\x1b]1337;reasonix-link="
+	linkEndPrefix   = "\x1b]1337;reasonix-link-end="
+	linkTerminator  = "\x07"
 )
 
 func copyMathStartMarker(id, source string) string {
@@ -252,6 +263,124 @@ func copyMathStartMarker(id, source string) string {
 
 func copyMathEndMarker(id string) string {
 	return copyMathEndPrefix + id + copyMathTerminator
+}
+
+func linkStartMarker(id, url string) string {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(url))
+	return linkStartPrefix + id + ";" + encoded + linkTerminator
+}
+
+func linkEndMarker(id string) string {
+	return linkEndPrefix + id + linkTerminator
+}
+
+// linkSpan is one clickable range within a single wrapped transcript line.
+// start/end are visible-column offsets (ansi width, zero-based, end exclusive).
+type linkSpan struct {
+	start, end int
+	url        string
+}
+
+// openLink tracks a link whose marker opened on an earlier wrapped line and is
+// still open when the current line ends (a long URL wrapped across rows). start
+// is the column where the link opened on the current line, or -1 when the link
+// carried over from a previous line and therefore covers the line from column 0.
+type openLink struct {
+	id    string
+	url   string
+	start int
+}
+
+// parseLinkSpansInLine scans one wrapped line for the zero-width link markers
+// emitted by the markdown renderer and returns every clickable range fully
+// visible on that line, including the tail of a link that wraps onto the next
+// line. open carries a link in progress from the previous line; the returned
+// open state must be passed to the next line's call. ok is false only when the
+// markers are corrupted (an unmatched close, a nested open, or a truncated
+// payload) — the renderer always emits balanced markers, so this is a canary
+// for internal bugs rather than a user-facing path.
+func parseLinkSpansInLine(raw string, open *openLink) (spans []linkSpan, next *openLink, ok bool) {
+	active := open
+	column := 0
+	position := 0
+
+	for position < len(raw) {
+		startAt := strings.Index(raw[position:], linkStartPrefix)
+		endAt := strings.Index(raw[position:], linkEndPrefix)
+		if startAt >= 0 {
+			startAt += position
+		}
+		if endAt >= 0 {
+			endAt += position
+		}
+
+		markerAt := -1
+		isStart := false
+		switch {
+		case startAt >= 0 && (endAt < 0 || startAt < endAt):
+			markerAt, isStart = startAt, true
+		case endAt >= 0:
+			markerAt = endAt
+		}
+		if markerAt < 0 {
+			column += ansi.StringWidth(raw[position:])
+			break
+		}
+
+		chunk := raw[position:markerAt]
+		column += ansi.StringWidth(chunk)
+
+		prefix := linkEndPrefix
+		if isStart {
+			prefix = linkStartPrefix
+		}
+		payloadStart := markerAt + len(prefix)
+		terminatorAt := strings.Index(raw[payloadStart:], linkTerminator)
+		if terminatorAt < 0 {
+			return nil, nil, false
+		}
+		terminatorAt += payloadStart
+		payload := raw[payloadStart:terminatorAt]
+		position = terminatorAt + len(linkTerminator)
+
+		if isStart {
+			if active != nil {
+				return nil, nil, false
+			}
+			parts := strings.SplitN(payload, ";", 2)
+			if len(parts) != 2 {
+				return nil, nil, false
+			}
+			decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+			if err != nil {
+				return nil, nil, false
+			}
+			active = &openLink{id: parts[0], url: string(decoded), start: column}
+			continue
+		}
+		if active == nil || payload != active.id {
+			return nil, nil, false
+		}
+		start := active.start
+		if start < 0 {
+			start = 0
+		}
+		spans = append(spans, linkSpan{start: start, end: column, url: active.url})
+		active = nil
+	}
+
+	if active != nil {
+		// The link continues onto the next line; everything from its start to
+		// the end of this line is still clickable.
+		start := active.start
+		if start < 0 {
+			start = 0
+		}
+		spans = append(spans, linkSpan{start: start, end: column, url: active.url})
+		active.start = -1
+		return spans, active, true
+	}
+	return spans, nil, true
 }
 
 // buildCopyTranscript renders semantic Markdown only when a copy is requested.
@@ -277,7 +406,12 @@ func (m chatTUI) buildCopyTranscript(contentWidth int) (string, int, bool) {
 			markers += strings.Count(rendered, copyMathStartPrefix)
 			b.WriteString(rendered)
 		default:
-			b.WriteString(m.transcript[i])
+			// Fixed blocks carry display-only zero-width sequences (OSC 8
+			// hyperlinks and click markers for user bubbles). Strip them so a
+			// copied selection pastes as clean text; ansi.Strip removes whole
+			// OSC sequences including their payload, and SGR codes, with zero
+			// width impact, so column accounting stays identical.
+			b.WriteString(ansi.Strip(m.transcript[i]))
 		}
 	}
 	return b.String(), markers, true
@@ -787,4 +921,30 @@ func (m chatTUI) transcriptCaret(x, y int) selPos {
 		x = cw
 	}
 	return selPos{line: m.viewport.YOffset() + y, col: x}
+}
+
+// linkSpanAt returns the clickable URL under the wrapped-line cell (lineIdx,
+// col), if any. Lines above the click are scanned so a link that wraps across
+// rows is hit-testable on every one of its rows; the scan is bounded by the
+// wrapped line cache and only runs on an explicit modifier-click, so the O(n)
+// walk is fine for interactive use.
+func (m chatTUI) linkSpanAt(lineIdx, col int) (string, bool) {
+	if lineIdx < 0 || lineIdx >= len(m.wrappedLines) {
+		return "", false
+	}
+	var active *openLink
+	var spans []linkSpan
+	for i := 0; i <= lineIdx; i++ {
+		var ok bool
+		spans, active, ok = parseLinkSpansInLine(m.wrappedLines[i], active)
+		if !ok {
+			return "", false
+		}
+	}
+	for _, s := range spans {
+		if col >= s.start && col < s.end {
+			return s.url, true
+		}
+	}
+	return "", false
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -260,6 +260,8 @@ type Messages struct {
 	CmdExport           string // /export
 	SlashCopyDone       string // "/copy" succeeded
 	SlashCopyEmpty      string // no assistant response to copy
+	LinkOpenDoneFmt     string // Ctrl+Click opened a link, %s = url
+	LinkOpenFailedFmt   string // Ctrl+Click link failed, %s = error
 	SlashCopyListHeader string // header shown before the numbered list
 	SlashExportDoneFmt  string // "/export" succeeded, %s = file path
 	SlashExportEmpty    string // no messages to export

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -267,6 +267,8 @@ var English = Messages{
 	CmdExport:           "export session as markdown",
 	SlashCopyDone:       "copied response to clipboard",
 	SlashCopyEmpty:      "no assistant response to copy",
+	LinkOpenDoneFmt:     "opened %s",
+	LinkOpenFailedFmt:   "failed to open link: %s",
 	SlashCopyListHeader: "pick a response to copy:",
 	SlashExportDoneFmt:  "session exported to %s",
 	SlashExportEmpty:    "no messages to export",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -268,6 +268,8 @@ var Chinese = Messages{
 	CmdExport:           "将会话导出为 Markdown",
 	SlashCopyDone:       "已复制到剪贴板",
 	SlashCopyEmpty:      "没有可复制的助手回复",
+	LinkOpenDoneFmt:     "已打开 %s",
+	LinkOpenFailedFmt:   "打开链接失败：%s",
 	SlashCopyListHeader: "选择要复制的回复：",
 	SlashExportDoneFmt:  "会话已导出到 %s",
 	SlashExportEmpty:    "没有可导出的消息",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -254,6 +254,8 @@ var ChineseTraditional = Messages{
 	CmdExport:           "將會話匯出為 Markdown",
 	SlashCopyDone:       "已複製到剪貼簿",
 	SlashCopyEmpty:      "沒有可複製的助手回覆",
+	LinkOpenDoneFmt:     "已開啟 %s",
+	LinkOpenFailedFmt:   "開啟連結失敗：%s",
 	SlashCopyListHeader: "選擇要複製的回覆：",
 	SlashExportDoneFmt:  "會話已匯出到 %s",
 	SlashExportEmpty:    "沒有可匯出的訊息",


### PR DESCRIPTION
## What
Fixes the second point of #7867: links in conversation transcripts could not be opened by clicking.

- **TUI** (`internal/cli`): markdown links, bare URLs, URLs inside backtick code spans (the boxed, highlighted form from the issue) and URLs in user messages now render as OSC 8 hyperlinks bracketed by zero-width markers, and open in the system browser on **double-click**. Single click keeps selection; long URLs split across wrapped rows stay clickable on every row; copied text stays clean (markers stripped); destinations are sanitized (scheme allowlist + control-character scrub + click-time re-validation).
- **Desktop** (`desktop/frontend`): assistant markdown links were already clickable; this adds the two missing cases - bare URLs in plain-text **user messages**, and bare URLs inside **inline code spans** - both opened via the same scheme-allowlisted openExternal path.
- **Windows open fix**: replaced `rundll32 url.dll,FileProtocolHandler` with `explorer.exe`, which newer Windows 11 builds do not silently block.

## Tests
- TUI: `internal/cli/linkify_test.go` (17 cases) - rendering, sanitization/injection, cross-row marker parsing, hit-testing, double-click / slow-click / plain-click, copy stripping.
- Desktop: `plain-text-links.test.tsx` (15 cases) - user-message and code-span linkification, punctuation trimming; existing local-path-links (51), github-link-rendering (28), local-path-click-e2e (10) stay green; tsc --noEmit and vite build pass.

Documentation-impact: none - user-facing behavior only (links become clickable); no documented interface, config, or workflow changes, so existing docs remain correct.