### PR TITLE
docs: correct and complete the PR metadata gate rules

### DIFF
--- a/REASONIX.md
+++ b/REASONIX.md
@@ -84,19 +84,32 @@ Use `go test ./path/to/target/` to detect cycles **before** pushing. A `[setup f
 - **Keep the PR diff minimal.** Only the files relevant to the PR's purpose — no stray changes from other branches.
 - **Amend, don't add commits, for review feedback** — keeps the commit history clean.
 
-## Cache-impact PR metadata
+## PR metadata gates
 
-When PR changes touch files under `internal/boot/`, `internal/tool/`, `internal/provider/`, or other cache-sensitive paths (listed in `scripts/check-cache-impact.sh`), the PR body MUST include these lines at the end:
+Two CI guards read the PR body. The scripts are the source of truth and both
+run locally: `scripts/check-cache-impact.sh`, `scripts/check-docs-impact.sh`.
+Separators must be an ASCII `-` or `:` — an em dash fails the docs guard.
+
+Cache-sensitive diffs (`internal/tool/`, `internal/provider/`,
+`internal/boot/`, `internal/agent/agent.go`, and the rest of the list in the
+script) require:
 
 ```
-Cache-impact: <none|low|medium|high> — <reason>
+Cache-impact: <none|low|medium|high> - <reason>
 Cache-guard: <focused guard test/command or existing guard rationale>
 ```
 
-If the PR also touches files under `internal/config/`, `internal/memory/`, `internal/outputstyle/`, `internal/skill/`, or `internal/boot/`, add:
+`none` is a legitimate impact when the provider-visible prefix stays
+byte-identical; only an empty value, `todo`, or `tbd` is rejected. If the diff
+also touches `internal/config/`, `internal/memory/`, `internal/outputstyle/`,
+`internal/skill/`, or `internal/boot/`, add `System-prompt-review: <note>` —
+that field additionally rejects `none` and `n/a`, so it must name a reviewer.
+
+User-visible diffs (`cmd/reasonix/`, `desktop/`, `npm/`, and most of
+`internal/`; tests and lockfiles are exempt) require one of these, chosen by
+whether the same PR edited `docs/*.md`:
 
 ```
-System-prompt-review: <reviewer/approval note>
+Documentation-impact: updated - <what changed>            # docs/*.md edited
+Documentation-impact: none - <why the docs stay correct>  # not edited
 ```
-
-Values `n/a`, `none`, `todo`, `tbd` are rejected — use a descriptive reason instead.


### PR DESCRIPTION
Both problems here were hit while landing #7872.

## The `Documentation-impact` gate was undocumented

`REASONIX.md` described `Cache-impact` / `Cache-guard` / `System-prompt-review` but never mentioned `Documentation-impact`, which `.github/workflows/docs-impact.yml` enforces on any user-visible diff. Two things about it are easy to get wrong and neither was written down:

- It takes one of **two** forms, and which one is accepted depends on whether the same PR edited `docs/*.md`. `updated - <what>` when it did, `none - <why>` when it did not. Using the wrong one fails even though the field is present.
- The pattern is `^(updated|none)[[:space:]]*[-:][[:space:]]*.+`, so the separator must be an **ASCII** `-` or `:`. An em dash is rejected — and `REASONIX.md`'s own `Cache-impact` example used an em dash, so following the file's own formatting was enough to fail the neighbouring gate.

## The rejected-values line was attached to the wrong field

The file said:

> Values `n/a`, `none`, `todo`, `tbd` are rejected — use a descriptive reason instead.

`scripts/check-cache-impact.sh` does not do that for `Cache-impact` / `Cache-guard`. `require_field` rejects only an empty value, `todo`, or `tbd`. The stricter `require_review_field` — which also rejects `none` and `n/a` — is applied to `System-prompt-review` alone, and for a good reason: that field has to name a human reviewer, so "none" is never a real answer.

The practical cost of the mistake is that it pushes authors toward overstating cache impact. `none` is the truthful value whenever the provider-visible prefix stays byte-identical, and the gate accepts it; the docs said it would not.

## Verification

The rules were read off the two scripts rather than from CI output: `require_field` / `require_review_field` in `scripts/check-cache-impact.sh`, and the `user_visible` / `docs_changed` path sets plus the accepted-value regexes in `scripts/check-docs-impact.sh`. Both scripts run locally, which is now stated in the section so the next author can check a body before pushing instead of discovering it from a red check.

`REASONIX.md` is loaded into the session system prompt, so this edit does shift the cache-stable prefix once. That is inherent to changing the standing instructions and is not something a guard test can avoid; it is a one-time invalidation with no ongoing per-turn cost. The file is not on either guard's path list, so neither gate fires on this PR.
