### PR TITLE
build(lint): extend the file-size ceiling to TypeScript

### DIFF
--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -2,12 +2,12 @@
   "limits": {
     "banner": 0,
     "commented-code": 0,
-    "essay": 4115,
-    "file-size": 73588,
+    "essay": 4100,
+    "file-size": 108842,
     "layering": 1,
     "marker": 0,
     "narrative": 66,
-    "test-file-size": 64726
+    "test-file-size": 68123
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -75,6 +75,87 @@
     },
     "desktop/external_opener_windows_test.go": {
       "essay": 2
+    },
+    "desktop/frontend/src/App.tsx": {
+      "file-size": 4756
+    },
+    "desktop/frontend/src/__tests__/app-chrome-tabs.test.ts": {
+      "test-file-size": 19
+    },
+    "desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts": {
+      "test-file-size": 308
+    },
+    "desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx": {
+      "test-file-size": 1701
+    },
+    "desktop/frontend/src/__tests__/composer-session-draft.test.tsx": {
+      "test-file-size": 551
+    },
+    "desktop/frontend/src/__tests__/decision-surface.test.tsx": {
+      "test-file-size": 262
+    },
+    "desktop/frontend/src/__tests__/math-golden.test.ts": {
+      "test-file-size": 106
+    },
+    "desktop/frontend/src/__tests__/rich-composer-selection.test.tsx": {
+      "test-file-size": 352
+    },
+    "desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx": {
+      "test-file-size": 106
+    },
+    "desktop/frontend/src/components/ApprovalModal.tsx": {
+      "file-size": 255
+    },
+    "desktop/frontend/src/components/CapabilitiesPanel.tsx": {
+      "file-size": 2633
+    },
+    "desktop/frontend/src/components/Composer.tsx": {
+      "file-size": 3904
+    },
+    "desktop/frontend/src/components/MemoryPanel.tsx": {
+      "file-size": 1088
+    },
+    "desktop/frontend/src/components/Message.tsx": {
+      "file-size": 181
+    },
+    "desktop/frontend/src/components/ProjectTree.tsx": {
+      "file-size": 1587
+    },
+    "desktop/frontend/src/components/RichComposerInput.tsx": {
+      "file-size": 141
+    },
+    "desktop/frontend/src/components/SettingsPanel.tsx": {
+      "file-size": 6658
+    },
+    "desktop/frontend/src/components/ThemeGallery.tsx": {
+      "file-size": 489
+    },
+    "desktop/frontend/src/components/ThemeLibrary.tsx": {
+      "file-size": 158
+    },
+    "desktop/frontend/src/components/Transcript.tsx": {
+      "file-size": 992
+    },
+    "desktop/frontend/src/components/UsageStatsPanel.tsx": {
+      "file-size": 276
+    },
+    "desktop/frontend/src/components/WorkspacePanel.tsx": {
+      "file-size": 1356
+    },
+    "desktop/frontend/src/custom/features/heartbeat/HeartbeatPanel.tsx": {
+      "file-size": 413
+    },
+    "desktop/frontend/src/lib/bridge.ts": {
+      "file-size": 4437
+    },
+    "desktop/frontend/src/lib/crash.ts": {
+      "file-size": 179
+    },
+    "desktop/frontend/src/lib/types.ts": {
+      "file-size": 1355
+    },
+    "desktop/frontend/src/lib/useController.ts": {
+      "file-size": 3406
     },
     "desktop/heartbeat.go": {
       "essay": 18,
@@ -326,12 +407,11 @@
       "essay": 27
     },
     "internal/agent/compact_test.go": {
-      "essay": 4,
-      "test-file-size": 8
+      "essay": 4
     },
     "internal/agent/coordinator.go": {
-      "essay": 20,
-      "file-size": 292
+      "essay": 17,
+      "file-size": 264
     },
     "internal/agent/coordinator_test.go": {
       "essay": 3,
@@ -484,8 +564,8 @@
       "test-file-size": 250
     },
     "internal/agent/task.go": {
-      "essay": 65,
-      "file-size": 1407
+      "essay": 56,
+      "file-size": 1377
     },
     "internal/agent/task_test.go": {
       "essay": 4,
@@ -1138,11 +1218,11 @@
       "essay": 14
     },
     "internal/guardian/guardian.go": {
-      "essay": 28
+      "essay": 25
     },
     "internal/hook/hook.go": {
       "essay": 44,
-      "file-size": 829
+      "file-size": 792
     },
     "internal/hook/hook_test.go": {
       "essay": 8,
@@ -1651,6 +1731,12 @@
     },
     "sdk/go/wire.go": {
       "essay": 1
+    },
+    "workers/crash-report/src/index.ts": {
+      "file-size": 902
+    },
+    "workers/crash-report/src/stats.ts": {
+      "file-size": 183
     }
   }
 }

--- a/tools/repolint/main.go
+++ b/tools/repolint/main.go
@@ -114,8 +114,11 @@ func run(root string) ([]Finding, error) {
 		if src == nil {
 			continue
 		}
-		findings = append(findings, checkComments(src)...)
 		findings = append(findings, checkSize(src)...)
+		if src.file == nil {
+			continue
+		}
+		findings = append(findings, checkComments(src)...)
 		imports[rel] = src.importRefs()
 	}
 	return append(findings, checkLayering(imports)...), nil

--- a/tools/repolint/size.go
+++ b/tools/repolint/size.go
@@ -1,11 +1,30 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const maxFileLines = 800
 
+// Translation tables are data, not code: they grow one entry per UI string, so
+// a ceiling there fires on every new label without ever pointing at something
+// worth splitting.
+var sizeExemptPrefixes = []string{
+	"desktop/frontend/src/locales/",
+}
+
+func sizeExempt(rel string) bool {
+	for _, prefix := range sizeExemptPrefixes {
+		if strings.HasPrefix(rel, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func checkSize(s *sourceFile) []Finding {
-	if s.lines <= maxFileLines {
+	if s.lines <= maxFileLines || sizeExempt(s.rel) {
 		return nil
 	}
 	rule := ruleFileSize

--- a/tools/repolint/size_test.go
+++ b/tools/repolint/size_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func linesOf(n int) []byte { return []byte(strings.Repeat("x\n", n)) }
+
+func goLinesOf(n int) []byte {
+	return []byte("package a\n" + strings.Repeat("var _ = 1\n", n))
+}
+
+func TestSizeRuleCoversTypeScript(t *testing.T) {
+	for _, tc := range []struct {
+		name, rel string
+		data      []byte
+		wantRule  string
+	}{
+		{"tsx over the ceiling", "desktop/frontend/src/components/Big.tsx", linesOf(900), ruleFileSize},
+		{"ts over the ceiling", "desktop/frontend/src/lib/big.ts", linesOf(900), ruleFileSize},
+		{"tsx under the ceiling", "desktop/frontend/src/components/Small.tsx", linesOf(100), ""},
+		{"front-end test dir", "desktop/frontend/src/__tests__/big.test.ts", linesOf(900), ruleTestSize},
+		{"spec suffix", "desktop/frontend/src/lib/big.spec.ts", linesOf(900), ruleTestSize},
+		{"worker ts", "workers/crash-report/src/big.ts", linesOf(900), ruleFileSize},
+		{"go file keeps its rule", "internal/agent/big.go", goLinesOf(900), ruleFileSize},
+		{"locale table is exempt", "desktop/frontend/src/locales/zh.ts", linesOf(3000), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := parseBytes(tc.rel, tc.data)
+			if s == nil {
+				t.Fatal("parseBytes returned nil")
+			}
+			found := checkSize(s)
+			if tc.wantRule == "" {
+				if len(found) != 0 {
+					t.Fatalf("want no finding, got %+v", found)
+				}
+				return
+			}
+			if len(found) != 1 || found[0].Rule != tc.wantRule {
+				t.Fatalf("want one %s finding, got %+v", tc.wantRule, found)
+			}
+		})
+	}
+}
+
+// The comment and layering rules are written against the Go AST, so a
+// TypeScript file must reach checkSize without ever being handed to them.
+func TestTypeScriptCarriesNoGoAST(t *testing.T) {
+	src := "// ===== section banner =====\nimport { x } from './y'\nexport const a = x\n"
+	s := parseBytes("desktop/frontend/src/lib/a.ts", []byte(src))
+	if s == nil {
+		t.Fatal("a TypeScript file must still be read for the size rule")
+	}
+	if s.file != nil || s.fset != nil {
+		t.Fatal("a TypeScript file must not carry a Go AST")
+	}
+	if refs := s.importRefs(); len(refs) != 0 {
+		t.Fatalf("TypeScript imports must stay out of the layering graph: %v", refs)
+	}
+	if s.lines != 3 {
+		t.Fatalf("lines = %d, want 3", s.lines)
+	}
+}
+
+func TestLintableExtensions(t *testing.T) {
+	for name, want := range map[string]bool{
+		"a.go":         true,
+		"a.ts":         true,
+		"a.tsx":        true,
+		"a.js":         false,
+		"a.json":       false,
+		"a.css":        false,
+		"a.md":         false,
+		"tsconfig.tsx": true,
+	} {
+		if got := lintable(name); got != want {
+			t.Errorf("lintable(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/tools/repolint/source.go
+++ b/tools/repolint/source.go
@@ -62,7 +62,7 @@ func collect(root string) ([]string, error) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(name, ".go") || strings.Contains(name, "_generated.") {
+		if !lintable(name) || strings.Contains(name, "_generated.") {
 			return nil
 		}
 		rel, err := filepath.Rel(root, path)
@@ -84,21 +84,39 @@ func parseSource(root, rel string) (*sourceFile, error) {
 	return parseBytes(rel, data), nil
 }
 
+// lintable reports whether repolint reads this file at all. Go files take every
+// rule; TypeScript files take only the ones expressed on raw lines, since the
+// rest are written against the Go AST.
+func lintable(name string) bool {
+	return strings.HasSuffix(name, ".go") ||
+		strings.HasSuffix(name, ".ts") ||
+		strings.HasSuffix(name, ".tsx")
+}
+
 func parseBytes(rel string, data []byte) *sourceFile {
 	if isGenerated(data) {
 		return nil
+	}
+	lines := splitLines(data)
+	if !strings.HasSuffix(rel, ".go") {
+		// No fset/file: run() gives these the line-based rules only.
+		return &sourceFile{rel: rel, src: lines, lines: len(lines)}
 	}
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, rel, data, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		return nil
 	}
+	return &sourceFile{rel: rel, fset: fset, file: file, src: lines, lines: len(lines)}
+}
+
+func splitLines(data []byte) []string {
 	text := strings.ReplaceAll(string(data), "\r\n", "\n")
 	lines := strings.Split(text, "\n")
 	if n := len(lines); n > 0 && lines[n-1] == "" {
 		lines = lines[:n-1]
 	}
-	return &sourceFile{rel: rel, fset: fset, file: file, src: lines, lines: len(lines)}
+	return lines
 }
 
 func isGenerated(data []byte) bool {
@@ -113,7 +131,12 @@ func isGenerated(data []byte) bool {
 	return false
 }
 
-func (s *sourceFile) isTest() bool { return strings.HasSuffix(s.rel, "_test.go") }
+func (s *sourceFile) isTest() bool {
+	return strings.HasSuffix(s.rel, "_test.go") ||
+		strings.Contains(s.rel, "/__tests__/") ||
+		strings.Contains(s.rel, ".test.") ||
+		strings.Contains(s.rel, ".spec.")
+}
 
 func (s *sourceFile) line(p token.Pos) int { return s.fset.Position(p).Line }
 
@@ -123,7 +146,7 @@ type importRef struct {
 }
 
 func (s *sourceFile) importRefs() []importRef {
-	if s.isTest() {
+	if s.isTest() || s.file == nil {
 		return nil
 	}
 	out := make([]importRef, 0, len(s.file.Imports))


### PR DESCRIPTION
`REASONIX.md` has always said "one responsibility per file; 800 lines is the ceiling" without qualifying it to Go, but `repolint`'s `collect` only ever took `.go` files. So the rule has never once applied to the ~40k lines of front-end code.

It shows:

| File | Lines |
| --- | --- |
| `components/SettingsPanel.tsx` | 7458 |
| `App.tsx` | 5556 |
| `lib/bridge.ts` | 5237 |
| `components/Composer.tsx` | 4704 |
| `lib/useController.ts` | 4206 |
| `components/CapabilitiesPanel.tsx` | 3433 |
| `components/ProjectTree.tsx` | 2387 |

`ProjectTree.tsx` is the file that prompted this, and it turns out to be only tenth.

## Why it is a small change

`checkSize` reads `s.lines` and `s.rel` and nothing else — no AST. So covering TypeScript needs no TS parser:

- `collect` takes `.ts` / `.tsx` alongside `.go`.
- `parseBytes` skips the Go parser for them and fills line counts only, leaving `fset`/`file` nil.
- `run` hands a file without an AST to `checkSize` alone.

The comment and layering rules stay Go-only because they are written against `go/ast`; `importRefs` now returns nil for an AST-less file so a TypeScript import can never enter the layering graph. `isTest` also recognises `__tests__/`, `.test.` and `.spec.`, so the 8 oversized front-end test files land under `test-file-size` rather than `file-size`.

## Two judgement calls

**Locale tables are exempt.** `locales/{en,zh,zh-TW}.ts` are ~3150 lines each, but they grow one entry per UI string — a ceiling there fires on every new label and never points at anything worth splitting. They are data, not code.

**`bridge.ts` is deliberately not exempt.** A 5237-line hand-maintained binding contract is exactly the kind of file a size gate should keep visible.

## Baseline diff

`-update` adds 29 findings (1737 → 1766, 537 files). Per REASONIX.md that diff needs justifying, so: every one of them is a pre-existing oversized file that was previously invisible to the tool, not a carry-forward from a rename or an extraction. Nothing was split.

That is deliberate. This follows the same ratchet contract the 1737 Go findings already run under — existing debt is tolerated, new debt is refused. Splitting a file today would be splitting for its own sake; `ProjectTree.tsx` gets split when there is a reason to open it, and then the gate gives that work a finish line.

## Verification

`go test ./tools/repolint/` including a new `size_test.go` covering the extension set, the `__tests__` / `.spec.` classification, the locale exemption, and the guarantee that a TypeScript file carries no Go AST.

The function-level tests do not prove the gate actually bites, so that was checked against the real tree: dropping an 801-line `.tsx` into `desktop/frontend/src/components/` makes `go run ./tools/repolint` exit 1, and removing it returns the tree to clean. `gofmt` clean.
