### PR TITLE
fix(cli): stop metricsSink double-forwarding every event

### DIFF
--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -234,7 +234,6 @@ func (s *metricsSink) record(e event.Event) {
 	if e.Kind == event.Retrying {
 		s.m.Retries++
 	}
-	s.inner.Emit(e)
 }
 
 // recordSource buckets one model call by its origin. An empty source means the

--- a/internal/cli/run_metrics_test.go
+++ b/internal/cli/run_metrics_test.go
@@ -11,6 +11,15 @@ import (
 	"reasonix/internal/provider"
 )
 
+func TestMetricsSinkForwardsEachEventOnce(t *testing.T) {
+	forwarded := 0
+	s := &metricsSink{inner: event.FuncSink(func(event.Event) { forwarded++ })}
+	s.Emit(event.Event{Kind: event.Text, Text: "x"})
+	if forwarded != 1 {
+		t.Fatalf("inner sink saw %d emissions for one event, want 1", forwarded)
+	}
+}
+
 func TestMetricsSinkUsesProviderCacheWriteCost(t *testing.T) {
 	s := &metricsSink{inner: event.Discard}
 	s.Emit(event.Event{


### PR DESCRIPTION
Since #7733 restructured `metricsSink.Emit` around the snapshot lock, `record()` kept its old trailing `s.inner.Emit(e)`, so every event on a `--metrics` run was forwarded to the inner sink twice — doubling run output/notifications and inflating any downstream event consumer — with the second forward running under `mu`.

The fix removes the stale forward inside `record()`; `Emit` remains the single forwarding point, outside the lock. Regression test: `TestMetricsSinkForwardsEachEventOnce`.

Cache-impact: none - CLI-local event fan-out fix; nothing provider-visible changes
Cache-guard: go test ./internal/cli/ -run TestMetricsSinkForwardsEachEventOnce
Documentation-impact: none - restores the documented single-forward sink behavior; docs never described the duplication