### PR TITLE
feat(cli): record a run's event trajectory with --trajectory

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -157,6 +157,22 @@ reasonix run --ablate evidence,planner --metrics run.json "fix the failing test"
 This is a measurement tool, not a tuning knob: switching a subsystem off makes
 Reasonix worse at the work it was added for.
 
+### Trajectory recording
+
+`--trajectory PATH` appends the run's full event stream — tool dispatches and
+results with absolute start/end times, reasoning, retries, readiness and
+recovery decisions — as one timestamped, sequenced JSONL record per event, so
+a run can be replayed and its time attributed offline (tool execution vs. the
+model thinking between calls). Records reuse the shared `eventwire` JSON
+contract under an `event` key, wrapped in `schema_version`, `seq`, and `ts`
+(unix ms). Every completed line survives a killed run. Unlike `--events-jsonl`,
+the file contains prompts, tool arguments, and reasoning: treat it with the
+same care as a session transcript.
+
+```sh
+reasonix run --metrics run.json --trajectory run.trajectory.jsonl "fix the failing test"
+```
+
 ### Output formats
 
 | Format | Behavior |

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -141,6 +141,20 @@ reasonix run --ablate evidence,planner --metrics run.json "修复失败的测试
 
 这是测量工具，不是调优开关：关掉某个子系统只会让 Reasonix 在它本来负责的工作上变差。
 
+### 轨迹记录
+
+`--trajectory PATH` 会把整次运行的完整事件流——带绝对起止时间的工具调用与结果、
+思考内容、重试、就绪与恢复决策——按每个事件一行的方式追加为带时间戳和序号的
+JSONL 记录，便于离线回放并归因时间去向（工具执行 vs. 两次调用之间的模型思考）。
+记录复用共享的 `eventwire` JSON 契约（放在 `event` 键下），外层包
+`schema_version`、`seq` 和 `ts`（unix 毫秒）。运行被杀死时已写完的行全部保留。
+与 `--events-jsonl` 不同，该文件包含提示词、工具参数和思考内容：请像对待会话
+转录一样谨慎处理。
+
+```sh
+reasonix run --metrics run.json --trajectory run.trajectory.jsonl "修复失败的测试"
+```
+
 ### 输出格式
 
 | 格式 | 行为 |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -499,6 +499,7 @@ func runAgent(args []string, version string) int {
 	maxSteps := fs.Int("max-steps", 0, "one-off max tool-call rounds (0 = automatic)")
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
+	trajectoryPath := fs.String("trajectory", "", "append a timestamped JSONL trajectory of the run's full event stream (tool calls, reasoning, decisions) to this path")
 	ablateFlag := fs.String("ablate", "", "benchmark arm: comma-separated subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	cont := registerContinueFlag(fs)
@@ -665,38 +666,12 @@ func runAgent(args []string, version string) int {
 	defer stop()
 	started := time.Now()
 
-	// Live run: render the agent's event stream to stdout. Markdown post-stream
-	// redraw (cursor moves) is enabled only on a TTY; piped / captured output
-	// keeps the raw stream.
-	var sink event.Sink
-	var resultOutput *runOutputSink
-	if *printOnly || format != runOutputText {
-		resultOutput = newRunOutputSink(os.Stdout, format)
-		sink = resultOutput
-	} else {
-		var renderer agent.Renderer
-		termW := 80
-		if isTTY(os.Stdout) {
-			if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
-				termW = w
-			}
-			renderer = newMarkdownRenderer(termW)
-		}
-		textSink := agent.NewTextSink(os.Stdout, renderer, termW)
-		textSink.SetShowReasoning(*showThinking)
-		sink = textSink
+	chain, err := buildRunSink(format, *printOnly, *showThinking, *metricsPath, *trajectoryPath, cfg, reporter)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 1
 	}
-	var metrics *metricsSink
-	if *metricsPath != "" {
-		metrics = &metricsSink{
-			inner:         sink,
-			partialPath:   partialMetricsPath(*metricsPath),
-			snapshotEvery: 2 * time.Second,
-		}
-		sink = metrics
-	}
-	sink = withNotifications(sink, cfg)
-	sink = reporter.Wrap(sink)
+	sink, resultOutput, metrics := chain.sink, chain.resultOutput, chain.metrics
 	if resumePath != "" {
 		*model = modelForResumePath(*model, resumePath, cfg)
 	}
@@ -789,6 +764,11 @@ func runAgent(args []string, version string) int {
 			}
 		}
 		if err := writeMetrics(*metricsPath, final); err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		}
+	}
+	if chain.trajectory != nil {
+		if err := chain.trajectory.Close(); err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
 		}
 	}

--- a/internal/cli/run_sink.go
+++ b/internal/cli/run_sink.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/term"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/telemetry"
+	"reasonix/internal/trajectory"
+)
+
+// runSinkChain is the assembled event pipeline for one `run` invocation, with
+// handles to the decorators the command must finalize after the run.
+type runSinkChain struct {
+	sink         event.Sink
+	resultOutput *runOutputSink
+	metrics      *metricsSink
+	trajectory   *trajectory.Recorder
+}
+
+// buildRunSink assembles `run`'s sink chain: stdout rendering innermost, then
+// metrics accumulation, then trajectory recording, then notifications and the
+// telemetry reporter outermost. Markdown post-stream redraw (cursor moves) is
+// enabled only on a TTY; piped / captured output keeps the raw stream.
+func buildRunSink(format runOutputFormat, printOnly, showThinking bool, metricsPath, trajectoryPath string, cfg *config.Config, reporter *telemetry.Reporter) (runSinkChain, error) {
+	var chain runSinkChain
+	if printOnly || format != runOutputText {
+		chain.resultOutput = newRunOutputSink(os.Stdout, format)
+		chain.sink = chain.resultOutput
+	} else {
+		var renderer agent.Renderer
+		termW := 80
+		if isTTY(os.Stdout) {
+			if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+				termW = w
+			}
+			renderer = newMarkdownRenderer(termW)
+		}
+		textSink := agent.NewTextSink(os.Stdout, renderer, termW)
+		textSink.SetShowReasoning(showThinking)
+		chain.sink = textSink
+	}
+	if metricsPath != "" {
+		chain.metrics = &metricsSink{
+			inner:         chain.sink,
+			partialPath:   partialMetricsPath(metricsPath),
+			snapshotEvery: 2 * time.Second,
+		}
+		chain.sink = chain.metrics
+	}
+	if trajectoryPath != "" {
+		rec, err := trajectory.New(chain.sink, trajectoryPath, nil)
+		if err != nil {
+			return runSinkChain{}, err
+		}
+		chain.trajectory = rec
+		chain.sink = rec
+	}
+	chain.sink = withNotifications(chain.sink, cfg)
+	chain.sink = reporter.Wrap(chain.sink)
+	return chain, nil
+}

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -1,0 +1,152 @@
+// Package trajectory appends a run's typed event stream to a JSONL file so a
+// run's sequence, timing, and decisions can be replayed and analyzed offline.
+// Records reuse the eventwire JSON contract and include content (prompts, tool
+// arguments, reasoning) — the file is as sensitive as a session transcript.
+package trajectory
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/eventwire"
+	"reasonix/internal/evidence"
+)
+
+// SchemaVersion identifies the record layout; bump on breaking changes.
+const SchemaVersion = 1
+
+// Record is one observed occurrence. Exactly one of Event, ReadinessAudit,
+// ProtocolRecovery, or TurnCompletion is set; Seq orders them and TS is the
+// unix-millisecond observation time at the recorder.
+type Record struct {
+	SchemaVersion    int              `json:"schema_version"`
+	Seq              uint64           `json:"seq"`
+	TS               int64            `json:"ts"`
+	Event            *eventwire.Event `json:"event,omitempty"`
+	ReadinessAudit   *ReadinessAudit  `json:"readiness_audit,omitempty"`
+	ProtocolRecovery string           `json:"protocol_recovery,omitempty"`
+	TurnCompletion   bool             `json:"turn_completion,omitempty"`
+}
+
+// ReadinessAudit mirrors evidence.ReadinessAudit with stable snake_case keys.
+type ReadinessAudit struct {
+	Result                    string `json:"result"`
+	Recovered                 bool   `json:"recovered,omitempty"`
+	MissingProjectChecks      int    `json:"missing_project_checks,omitempty"`
+	IncompleteTodos           int    `json:"incomplete_todos,omitempty"`
+	CommandMismatchMissing    int    `json:"command_mismatch_missing,omitempty"`
+	MissingAcceptanceCriteria int    `json:"missing_acceptance_criteria,omitempty"`
+	MissingVerification       int    `json:"missing_verification,omitempty"`
+	MissingReview             int    `json:"missing_review,omitempty"`
+	MissingSignoff            int    `json:"missing_signoff,omitempty"`
+	MissingActionEvidence     int    `json:"missing_action_evidence,omitempty"`
+	MissingMutation           int    `json:"missing_mutation,omitempty"`
+	MissingCapabilities       int    `json:"missing_capabilities,omitempty"`
+}
+
+// Recorder is an event.Sink decorator: every event (and optional-capability
+// audit) is appended as one JSONL record, then forwarded to the inner sink.
+// Recording failures never block forwarding — the first error is kept and
+// returned by Close.
+type Recorder struct {
+	inner event.Sink
+	clock func() time.Time
+
+	mu     sync.Mutex
+	file   *os.File
+	buf    *bufio.Writer
+	enc    *json.Encoder
+	seq    uint64
+	err    error
+	closed bool
+}
+
+// New opens (or truncates) path and returns a Recorder forwarding to inner.
+// A nil clock means time.Now.
+func New(inner event.Sink, path string, clock func() time.Time) (*Recorder, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	buf := bufio.NewWriter(f)
+	return &Recorder{inner: inner, clock: clock, file: f, buf: buf, enc: json.NewEncoder(buf)}, nil
+}
+
+func (r *Recorder) append(rec Record) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed || r.err != nil {
+		return
+	}
+	r.seq++
+	rec.SchemaVersion = SchemaVersion
+	rec.Seq = r.seq
+	rec.TS = r.clock().UnixMilli()
+	if err := r.enc.Encode(rec); err != nil {
+		r.err = err
+		return
+	}
+	// Flush per record so a killed run still leaves every completed line.
+	if err := r.buf.Flush(); err != nil {
+		r.err = err
+	}
+}
+
+func (r *Recorder) Emit(e event.Event) {
+	w := eventwire.ToWire(e)
+	r.append(Record{Event: &w})
+	r.inner.Emit(e)
+}
+
+func (r *Recorder) RecordReadinessAudit(a evidence.ReadinessAudit) {
+	r.append(Record{ReadinessAudit: &ReadinessAudit{
+		Result:                    string(a.Result),
+		Recovered:                 a.Recovered,
+		MissingProjectChecks:      a.MissingProjectChecks,
+		IncompleteTodos:           a.IncompleteTodos,
+		CommandMismatchMissing:    a.CommandMismatchMissing,
+		MissingAcceptanceCriteria: a.MissingAcceptanceCriteria,
+		MissingVerification:       a.MissingVerification,
+		MissingReview:             a.MissingReview,
+		MissingSignoff:            a.MissingSignoff,
+		MissingActionEvidence:     a.MissingActionEvidence,
+		MissingMutation:           a.MissingMutation,
+		MissingCapabilities:       a.MissingCapabilities,
+	}})
+	event.RecordReadinessAudit(r.inner, a)
+}
+
+func (r *Recorder) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
+	r.append(Record{ProtocolRecovery: string(a.Kind)})
+	event.RecordProtocolRecovery(r.inner, a)
+}
+
+func (r *Recorder) RecordTurnCompletion() {
+	r.append(Record{TurnCompletion: true})
+	event.RecordTurnCompletion(r.inner)
+}
+
+// Close flushes and closes the file, returning the first error seen. Events
+// arriving after Close (late background jobs) are forwarded but not recorded.
+func (r *Recorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return r.err
+	}
+	r.closed = true
+	if err := r.buf.Flush(); err != nil && r.err == nil {
+		r.err = err
+	}
+	if err := r.file.Close(); err != nil && r.err == nil {
+		r.err = err
+	}
+	return r.err
+}

--- a/internal/trajectory/recorder_test.go
+++ b/internal/trajectory/recorder_test.go
@@ -1,0 +1,155 @@
+package trajectory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+)
+
+type capabilitySink struct {
+	events     []event.Event
+	readiness  []evidence.ReadinessAudit
+	recoveries []event.ProtocolRecoveryAudit
+	turns      int
+}
+
+func (s *capabilitySink) Emit(e event.Event) { s.events = append(s.events, e) }
+func (s *capabilitySink) RecordReadinessAudit(a evidence.ReadinessAudit) {
+	s.readiness = append(s.readiness, a)
+}
+func (s *capabilitySink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
+	s.recoveries = append(s.recoveries, a)
+}
+func (s *capabilitySink) RecordTurnCompletion() { s.turns++ }
+
+func readRecords(t *testing.T, path string) []Record {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read trajectory: %v", err)
+	}
+	var out []Record
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		var r Record
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("bad record %q: %v", line, err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func TestRecorderAppendsOrderedTimestampedRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.trajectory.jsonl")
+	inner := &capabilitySink{}
+	now := time.UnixMilli(1754500000000)
+	r, err := New(inner, path, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "c1", Name: "bash", Args: `{"command":"ls"}`}})
+	now = now.Add(120 * time.Millisecond)
+	r.Emit(event.Event{Kind: event.ToolResult, Tool: event.Tool{
+		ID: "c1", Name: "bash", Output: "ok", DurationMs: 100,
+		StartedAt: 1754500000010, EndedAt: 1754500000110,
+	}})
+	r.Emit(event.Event{Kind: event.Reasoning, Text: "thinking about the next step"})
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	recs := readRecords(t, path)
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3", len(recs))
+	}
+	for i, rec := range recs {
+		if rec.Seq != uint64(i+1) {
+			t.Errorf("record %d seq = %d, want %d", i, rec.Seq, i+1)
+		}
+		if rec.SchemaVersion != SchemaVersion {
+			t.Errorf("record %d schema = %d, want %d", i, rec.SchemaVersion, SchemaVersion)
+		}
+		if rec.Event == nil {
+			t.Fatalf("record %d has no event payload", i)
+		}
+	}
+	if recs[0].TS != 1754500000000 || recs[1].TS != 1754500000120 {
+		t.Errorf("timestamps = %d, %d, want recorder-clock values", recs[0].TS, recs[1].TS)
+	}
+	if recs[1].Event.Tool == nil || recs[1].Event.Tool.StartedAt != 1754500000010 || recs[1].Event.Tool.EndedAt != 1754500000110 {
+		t.Errorf("tool result record lost execution bounds: %+v", recs[1].Event.Tool)
+	}
+	if recs[2].Event.Kind != "reasoning" || recs[2].Event.Text != "thinking about the next step" {
+		t.Errorf("reasoning record = %+v", recs[2].Event)
+	}
+	if len(inner.events) != 3 {
+		t.Errorf("inner sink saw %d events, want 3", len(inner.events))
+	}
+}
+
+func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.trajectory.jsonl")
+	inner := &capabilitySink{}
+	r, err := New(inner, path, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	r.RecordReadinessAudit(evidence.ReadinessAudit{Result: evidence.ReadinessBlocked, MissingVerification: 2})
+	r.RecordProtocolRecovery(event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+	r.RecordTurnCompletion()
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	recs := readRecords(t, path)
+	if len(recs) != 3 {
+		t.Fatalf("got %d records, want 3", len(recs))
+	}
+	if recs[0].ReadinessAudit == nil || recs[0].ReadinessAudit.Result != "blocked" || recs[0].ReadinessAudit.MissingVerification != 2 {
+		t.Errorf("readiness record = %+v", recs[0].ReadinessAudit)
+	}
+	if recs[1].ProtocolRecovery != string(event.ProtocolRecoveryMissingReasoningDetected) {
+		t.Errorf("protocol recovery record = %q", recs[1].ProtocolRecovery)
+	}
+	if !recs[2].TurnCompletion {
+		t.Errorf("turn completion record = %+v", recs[2])
+	}
+	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 {
+		t.Errorf("inner capabilities = %d/%d/%d, want 1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns)
+	}
+}
+
+func TestRecorderForwardsAfterCloseWithoutRecording(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.trajectory.jsonl")
+	inner := &capabilitySink{}
+	r, err := New(inner, path, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.Emit(event.Event{Kind: event.Text, Text: "before"})
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	r.Emit(event.Event{Kind: event.Text, Text: "after"})
+
+	if len(readRecords(t, path)) != 1 {
+		t.Fatalf("post-close event must not be recorded")
+	}
+	if len(inner.events) != 2 {
+		t.Fatalf("inner sink saw %d events, want 2 (forwarding survives Close)", len(inner.events))
+	}
+}
+
+func TestNewFailsOnUnwritablePath(t *testing.T) {
+	if _, err := New(event.Discard, filepath.Join(t.TempDir(), "missing", "run.jsonl"), nil); err == nil {
+		t.Fatal("New must fail when the parent directory does not exist")
+	}
+}


### PR DESCRIPTION
Implements the trajectory recorder proposed in #7492: an opt-in, per-run JSONL log of the full typed event stream, so a run's tool selection, timing, thinking, and decision points can be replayed and analyzed offline instead of judging only the outcome. Stacked on #7882 (tool-result `StartedAt`/`EndedAt`), whose bounds flow straight into the records.

## Design

- **`internal/trajectory.Recorder`** — an `event.Sink` decorator modeled on `metricsSink`: every event is appended as one record `{schema_version, seq, ts, event}` where `event` reuses the shared `eventwire` contract (one serialization surface for desktop/ACP/serve/trajectory), `seq` orders records, and `ts` is the recorder's unix-ms observation clock (injectable for tests). Optional sink capabilities are recorded *and* forwarded, so wrapping never severs the chain: readiness audits (snake_case mirror), protocol-recovery observations, turn completions.
- **Durability** — flushed per line: a killed run keeps every completed record; a partially written last line is skippable. Recording failures never block forwarding — the first error is kept and reported by `Close`; late background-job events after `Close` are forwarded but not recorded.
- **`reasonix run --trajectory PATH`** — wired between metrics accumulation and notifications. Unlike `--events-jsonl` (deliberately content-free), the trajectory includes prompts, tool arguments, and reasoning — documented as transcript-equivalent in sensitivity. The run-sink assembly moved out of `runAgent` into `buildRunSink` (`run_sink.go`) to keep `cli.go` inside the file-size ratchet.

With #7882's bounds plus per-record `ts`, the gaps between a `tool_result` and the next `tool_dispatch` attribute wall-clock to model thinking/streaming vs. tool execution.

## Tests

`internal/trajectory`: ordered/timestamped records with tool bounds intact round-trip; capability records forward to the inner sink; post-Close events forward without recording; unwritable path fails `New`. Docs updated (CLI.md + zh-CN).

Cache-impact: none - local-only sink decoration and CLI wiring; nothing enters provider requests
Cache-guard: go test ./internal/trajectory/ ./internal/cli/; recorder only observes events already emitted
Documentation-impact: updated - docs/CLI.md and docs/CLI.zh-CN.md gain a Trajectory recording section for --trajectory
