### PR TITLE
feat(bench): record per-task trajectories and attribute wall time

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -113,6 +113,7 @@ own outcome).
 | `-ablate` | *(none)* | Ablation arm: comma-separated subsystems to switch off — `evidence`, `planner`, `subagent`, `retrieval`, `compaction`; `none` \| `all`. |
 | `-out` | *(stdout)* | Write the markdown report here. |
 | `-json` | *(none)* | Write the JSON report here (optional). |
+| `-trajectories` | *(none)* | Suite mode: write one `<task-id>.trajectory.jsonl` per task into this directory (the agent's full event stream with timestamps — see `reasonix run --trajectory`). The report gains a time-attribution line (tools vs. model) and each JSON result a `trajectory` digest. |
 | `-budget` | `800000` | Abort once total tokens cross this (`0` = no cap). Remaining tasks are reported as skipped. |
 
 Diff-mode flags:

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -92,6 +92,9 @@ type result struct {
 	// agent was killed. The numbers are real but stop at the last snapshot, so
 	// they are counted as lower bounds rather than dropped.
 	Partial bool `json:"partial"`
+	// Trajectory is the digest of the run's recorded event trajectory; nil
+	// unless the harness ran with -trajectories.
+	Trajectory *trajectorySummary `json:"trajectory,omitempty"`
 }
 
 // class is the published failure taxonomy: solved, the guard that stopped the
@@ -145,6 +148,7 @@ func main() {
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
 	ablateFlag := flag.String("ablate", "", "ablation arm: subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
+	trajDir := flag.String("trajectories", "", "suite mode: write one <task-id>.trajectory.jsonl per task into this directory")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
 	budget := flag.Int("budget", defaultSuiteTokenBudget, "abort once total tokens cross this (0 = no cap)")
 	// diff-mode flags
@@ -210,17 +214,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var results []result
-	total := 0
-	for _, t := range tasks {
-		if *budget > 0 && total >= *budget {
-			results = append(results, result{task: t, Profile: profile, Skipped: true, Note: "skipped: token budget reached"})
-			continue
-		}
-		r := runTask(*bin, *model, profile, arm, t)
-		total += r.PromptTokens + r.CompletionTokens
-		results = append(results, r)
-	}
+	results := runSuite(*bin, *model, profile, arm, tasks, *budget, *trajDir)
 
 	report := render(results)
 	if *outMD != "" {
@@ -286,12 +280,38 @@ func loadTasks(suite string) ([]task, error) {
 	return tasks, nil
 }
 
+// runSuite runs each task in order until the token budget is exhausted;
+// remaining tasks are reported as skipped rather than silently dropped.
+func runSuite(bin, model, profile string, arm ablation.Set, tasks []task, budget int, trajDir string) []result {
+	var results []result
+	total := 0
+	for _, t := range tasks {
+		if budget > 0 && total >= budget {
+			results = append(results, result{task: t, Profile: profile, Skipped: true, Note: "skipped: token budget reached"})
+			continue
+		}
+		r := runTask(bin, model, profile, arm, t, trajDir)
+		total += r.PromptTokens + r.CompletionTokens
+		results = append(results, r)
+	}
+	return results
+}
+
 // runTask copies the task's seed workdir into a temp dir, runs the agent there,
 // then drops in verify.sh and runs it as the grader. The grader is added only
 // after the run so the agent can't read the answer key.
-func runTask(bin, model, profile string, arm ablation.Set, t task) result {
+func runTask(bin, model, profile string, arm ablation.Set, t task, trajDir string) result {
 	r := result{task: t, Profile: profile}
 	r.Arm = arm.Arm()
+
+	trajPath := ""
+	if trajDir != "" {
+		if err := os.MkdirAll(trajDir, 0o755); err != nil {
+			r.Note = "trajectory dir: " + err.Error()
+			return r
+		}
+		trajPath = filepath.Join(trajDir, t.ID+".trajectory.jsonl")
+	}
 
 	work, err := os.MkdirTemp("", "e2ebench-"+t.ID+"-")
 	if err != nil {
@@ -311,7 +331,7 @@ func runTask(bin, model, profile string, arm ablation.Set, t task) result {
 	defer cancel()
 
 	metricsPath := filepath.Join(work, ".run-metrics.json")
-	args := buildRunTaskArgs(metricsPath, model, profile, arm, t.MaxSteps, t.Prompt)
+	args := buildRunTaskArgs(metricsPath, trajPath, model, profile, arm, t.MaxSteps, t.Prompt)
 
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = work
@@ -324,6 +344,11 @@ func runTask(bin, model, profile string, arm ablation.Set, t task) result {
 
 	if m, err := readMetrics(metricsPath); err == nil {
 		r.runMetrics = m
+	}
+	if trajPath != "" {
+		if summary, err := summarizeTrajectory(trajPath); err == nil {
+			r.Trajectory = summary
+		}
 	}
 	// A killed child never writes metrics, so the deadline is the only place
 	// this failure mode is still observable.
@@ -339,10 +364,13 @@ func runTask(bin, model, profile string, arm ablation.Set, t task) result {
 	return r
 }
 
-func buildRunTaskArgs(metricsPath, model, profile string, arm ablation.Set, maxSteps int, prompt string) []string {
+func buildRunTaskArgs(metricsPath, trajectoryPath, model, profile string, arm ablation.Set, maxSteps int, prompt string) []string {
 	// Benchmarks are unattended and their fixtures require ordinary workspace
 	// writes. Auto still honors explicit ask/deny rules and the sandbox boundary.
 	args := []string{"run", "--auto", "--metrics", metricsPath}
+	if trajectoryPath != "" {
+		args = append(args, "--trajectory", trajectoryPath)
+	}
 	if model != "" {
 		args = append(args, "--model", model)
 	}
@@ -449,6 +477,7 @@ func renderBody(results []result) string {
 	fmt.Fprintf(&b, "**Cache hit:** %s · **Tokens:** %s (prompt %s / completion %s) · **Tool calls:** %s (%s failed) · **Compactions:** %d · **Cost:** %s%.4f\n\n",
 		pct(hit, hit+miss), comma(pTok+cTok), comma(pTok), comma(cTok),
 		comma(tools), comma(toolFails), compacts, currencySym(currency), cost)
+	b.WriteString(renderTimeAttribution(results))
 	if unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",
 			unaccounted, ran, unaccountedSolved, accounted, accountedSolved)

--- a/cmd/e2ebench/profile_test.go
+++ b/cmd/e2ebench/profile_test.go
@@ -24,9 +24,10 @@ func TestAppendBenchmarkProfileArgsDeliveryUsesRealRuntimeProfile(t *testing.T) 
 }
 
 func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
-	got := buildRunTaskArgs("metrics.json", "e2e", benchmarkProfileDelivery, ablation.Set{}, 12, "fix it")
+	got := buildRunTaskArgs("metrics.json", "run.trajectory.jsonl", "e2e", benchmarkProfileDelivery, ablation.Set{}, 12, "fix it")
 	want := []string{
 		"run", "--auto", "--metrics", "metrics.json",
+		"--trajectory", "run.trajectory.jsonl",
 		"--model", "e2e", "--max-steps", "12",
 		"--profile", "delivery", "fix it",
 	}
@@ -36,7 +37,7 @@ func TestBuildRunTaskArgsEnablesUnattendedWorkspaceWrites(t *testing.T) {
 }
 
 func TestBuildRunTaskArgsPassesTheAblationArmThrough(t *testing.T) {
-	got := buildRunTaskArgs("m.json", "", benchmarkProfileBaseline, ablation.New(ablation.Evidence, ablation.Planner), 0, "fix it")
+	got := buildRunTaskArgs("m.json", "", "", benchmarkProfileBaseline, ablation.New(ablation.Evidence, ablation.Planner), 0, "fix it")
 	want := []string{"run", "--auto", "--metrics", "m.json", "--ablate", "evidence,planner", "fix it"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ablated args = %v, want %v", got, want)

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// trajectorySummary is the harness-side digest of one run's trajectory file:
+// where the wall clock went, split between tool execution and everything the
+// model spent between calls (thinking, streaming, provider latency).
+type trajectorySummary struct {
+	Path    string `json:"path"`
+	Records int    `json:"records"`
+	SpanMs  int64  `json:"span_ms"`
+	ToolMs  int64  `json:"tool_ms"`
+	ModelMs int64  `json:"model_ms"` // SpanMs − ToolMs, floored at zero
+}
+
+// trajectoryRecord is the subset of trajectory.Record the summary needs.
+type trajectoryRecord struct {
+	TS    int64 `json:"ts"`
+	Event *struct {
+		Kind string `json:"kind"`
+		Tool *struct {
+			DurationMs int64  `json:"durationMs"`
+			ParentID   string `json:"parentId"`
+		} `json:"tool"`
+	} `json:"event"`
+}
+
+// renderTimeAttribution aggregates recorded runs into one report line; empty
+// when no run in the suite carried a trajectory.
+func renderTimeAttribution(results []result) string {
+	var toolMs, modelMs int64
+	runs := 0
+	for _, r := range results {
+		if r.Trajectory != nil {
+			runs++
+			toolMs += r.Trajectory.ToolMs
+			modelMs += r.Trajectory.ModelMs
+		}
+	}
+	if runs == 0 {
+		return ""
+	}
+	return fmt.Sprintf("**Time attribution** (%d recorded runs): **tools** %s (%s) · **model** %s (%s)\n\n",
+		runs, dur(toolMs), pct(int(toolMs), int(toolMs+modelMs)),
+		dur(modelMs), pct(int(modelMs), int(toolMs+modelMs)))
+}
+
+// summarizeTrajectory reads a run's JSONL trajectory. A truncated final line
+// (killed run) is skipped, matching the recorder's durability contract.
+func summarizeTrajectory(path string) (*trajectorySummary, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	s := &trajectorySummary{Path: path}
+	var firstTS, lastTS int64
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1<<20), 16<<20)
+	for sc.Scan() {
+		var rec trajectoryRecord
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			continue
+		}
+		s.Records++
+		if firstTS == 0 {
+			firstTS = rec.TS
+		}
+		lastTS = rec.TS
+		if rec.Event == nil || rec.Event.Tool == nil {
+			continue
+		}
+		// Subagent calls overlap the parent's wall clock; counting them would
+		// double-book the span.
+		if rec.Event.Kind == "tool_result" && rec.Event.Tool.ParentID == "" {
+			s.ToolMs += rec.Event.Tool.DurationMs
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	s.SpanMs = lastTS - firstTS
+	if s.ModelMs = s.SpanMs - s.ToolMs; s.ModelMs < 0 {
+		s.ModelMs = 0
+	}
+	return s, nil
+}

--- a/cmd/e2ebench/trajectory_test.go
+++ b/cmd/e2ebench/trajectory_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSummarizeTrajectoryAttributesTimeAndSkipsTruncatedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task.trajectory.jsonl")
+	lines := []string{
+		`{"schema_version":1,"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"schema_version":1,"seq":2,"ts":1500,"event":{"kind":"tool_dispatch","tool":{"name":"bash"}}}`,
+		`{"schema_version":1,"seq":3,"ts":2000,"event":{"kind":"tool_result","tool":{"name":"bash","durationMs":400}}}`,
+		`{"schema_version":1,"seq":4,"ts":2500,"event":{"kind":"tool_result","tool":{"name":"grep","durationMs":300,"parentId":"task-1"}}}`,
+		`{"schema_version":1,"seq":5,"ts":4000,"event":{"kind":"turn_done"}}`,
+		`{"schema_version":1,"seq":6,"ts":4100,"event":{"kind":"tool_res`, // killed mid-write
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.Records != 5 {
+		t.Errorf("records = %d, want 5 (truncated tail skipped)", s.Records)
+	}
+	if s.SpanMs != 3000 {
+		t.Errorf("span = %d, want 3000", s.SpanMs)
+	}
+	if s.ToolMs != 400 {
+		t.Errorf("tool ms = %d, want 400 (subagent call must not double-book)", s.ToolMs)
+	}
+	if s.ModelMs != 2600 {
+		t.Errorf("model ms = %d, want 2600", s.ModelMs)
+	}
+}
+
+func TestRenderBodyIncludesTimeAttributionOnlyForRecordedRuns(t *testing.T) {
+	plain := result{task: task{ID: "a"}, Passed: true}
+	if got := renderBody([]result{plain}); strings.Contains(got, "Time attribution") {
+		t.Fatalf("unrecorded run must not report time attribution:\n%s", got)
+	}
+
+	recorded := plain
+	recorded.Trajectory = &trajectorySummary{Records: 5, SpanMs: 3000, ToolMs: 1000, ModelMs: 2000}
+	got := renderBody([]result{recorded})
+	if !strings.Contains(got, "Time attribution") || !strings.Contains(got, "(1 recorded runs)") {
+		t.Fatalf("recorded run missing time attribution:\n%s", got)
+	}
+}


### PR DESCRIPTION
Completes the #7492 chain (stacked on #7884, which stacks on #7882): the E2E suite can now keep one trajectory file per task and turn it into process-level statistics instead of judging outcome only.

## Changes

- `e2ebench -trajectories DIR` (suite mode, opt-in): each task run gets `--trajectory DIR/<task-id>.trajectory.jsonl`; the file outlives the task's temp workdir. When unset the child command line is byte-identical to before, preserving the control-arm comparability contract.
- `summarizeTrajectory` digests a file into `{records, span_ms, tool_ms, model_ms}` — `model_ms` is the span minus top-level tool execution, i.e. thinking/streaming/provider latency. Subagent tool calls (`parentId` set) overlap the parent's wall clock and are excluded; a truncated final line from a killed run is skipped, matching the recorder's durability contract.
- The markdown report gains a **Time attribution** line (tools vs. model, only when trajectories were recorded); the JSON report gains a per-result `trajectory` digest. `benchmarks/README.md` documents the flag.

## Tests

`TestSummarizeTrajectoryAttributesTimeAndSkipsTruncatedTail`, `TestRenderBodyIncludesTimeAttributionOnlyForRecordedRuns`, and the updated `buildRunTaskArgs` tests (trajectory arg present when set, absent otherwise).

Note: a live end-to-end smoke was blocked by an expired local `DEEPSEEK_API_KEY`; the recorder still correctly persisted every event emitted before the 401 (`turn_started`, `stream_attempt`), which exercises the durability path.

Cache-impact: none - harness-side flag plumbing and offline file digestion; nothing provider-visible changes
Cache-guard: go test ./cmd/e2ebench/; the control arm's child command line stays byte-identical when -trajectories is unset
Documentation-impact: updated - benchmarks/README.md documents the -trajectories flag and report additions