### PR TITLE
perf(event): coalesce streaming deltas before they reach a frontend

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -531,10 +531,9 @@ type Options struct {
 	SessionTemp *sessiontemp.Manager
 }
 
-// New builds a Controller. A nil Sink is replaced with event.Discard. When the
-// caller did not already provide a goalUsageTee (see NewGoalUsageTee), the
-// public sink is wrapped in one so billable usage can be accounted to Goal
-// budgets; frontends observe the same forwarded stream either way.
+// New builds a Controller. A nil Sink becomes event.Discard; unless the caller
+// already provided a goalUsageTee (NewGoalUsageTee), the sink is wrapped in one
+// so billable usage can be accounted to Goal budgets.
 func New(opts Options) *Controller {
 	sink := opts.Sink
 	if nilutil.IsNil(sink) {
@@ -545,6 +544,7 @@ func New(opts Options) *Controller {
 		usageTee = NewGoalUsageTee(sink).(*goalUsageTee)
 		sink = usageTee
 	}
+	sink = event.Coalesce(sink, event.DefaultStreamDeltaWindow)
 	pluginCtx := opts.PluginCtx
 	if pluginCtx == nil {
 		pluginCtx = context.Background()

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -1,0 +1,161 @@
+package event
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/nilutil"
+)
+
+// coalesceMaxBytes bounds a merged delta so one event never carries an
+// unbounded payload across a frontend bridge.
+const coalesceMaxBytes = 16 << 10
+
+// DefaultStreamDeltaWindow caps how often coalesced streaming deltas cross
+// into a frontend: at most one merged event per window under load — about one
+// per display frame — so a fast provider (hundreds of chunks/sec) cannot
+// flood a webview bridge, an SSE stream, or a terminal redraw loop.
+const DefaultStreamDeltaWindow = 16 * time.Millisecond
+
+// Coalesce wraps inner so bursts of consecutive streaming deltas — Text or
+// Reasoning events carrying nothing but a Text payload — merge into one event.
+// The first delta of a burst forwards immediately (time-to-first-token is
+// unchanged); later deltas buffer at most window, flushing earlier on any
+// other event (total order preserved), a kind switch, or coalesceMaxBytes.
+func Coalesce(inner Sink, window time.Duration) Sink {
+	if nilutil.IsNil(inner) {
+		return Discard
+	}
+	if window <= 0 {
+		return inner
+	}
+	return &coalescer{inner: inner, window: window}
+}
+
+type coalescer struct {
+	inner  Sink
+	window time.Duration
+
+	// mu guards buffering state and the outbound queue; inner.Emit is never
+	// called under mu. A single drainer forwards FIFO, so a sink that
+	// synchronously re-enters Emit enqueues and returns instead of deadlocking.
+	mu          sync.Mutex
+	kind        Kind
+	buf         strings.Builder
+	pending     bool
+	timer       *time.Timer
+	lastForward time.Time
+	queue       []Event
+	draining    bool
+}
+
+// isStreamDelta reports whether e is a pure streaming delta: merging is only
+// safe when no other field carries meaning. The zero-probe comparison keeps
+// this true by construction as Event grows fields.
+func isStreamDelta(e Event) bool {
+	if (e.Kind != Text && e.Kind != Reasoning) || e.Text == "" {
+		return false
+	}
+	probe := e
+	probe.Text = ""
+	return reflect.DeepEqual(probe, Event{Kind: e.Kind})
+}
+
+func (c *coalescer) Emit(e Event) {
+	c.mu.Lock()
+	if !isStreamDelta(e) {
+		c.enqueueFlushLocked()
+		c.queue = append(c.queue, e)
+		c.drainAndUnlock()
+		return
+	}
+	if c.pending && c.kind != e.Kind {
+		c.enqueueFlushLocked()
+	}
+	if !c.pending && time.Since(c.lastForward) >= c.window {
+		c.lastForward = time.Now()
+		c.queue = append(c.queue, e)
+		c.drainAndUnlock()
+		return
+	}
+	if !c.pending {
+		c.pending = true
+		c.kind = e.Kind
+		if c.timer == nil {
+			c.timer = time.AfterFunc(c.window, c.flush)
+		} else {
+			c.timer.Reset(c.window)
+		}
+	}
+	c.buf.WriteString(e.Text)
+	if c.buf.Len() >= coalesceMaxBytes {
+		c.enqueueFlushLocked()
+	}
+	c.drainAndUnlock()
+}
+
+func (c *coalescer) flush() {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+}
+
+// enqueueFlushLocked moves the buffered delta (if any) onto the outbound queue.
+func (c *coalescer) enqueueFlushLocked() {
+	if !c.pending {
+		return
+	}
+	c.timer.Stop()
+	c.queue = append(c.queue, Event{Kind: c.kind, Text: c.buf.String()})
+	c.buf.Reset()
+	c.pending = false
+	c.lastForward = time.Now()
+}
+
+// drainAndUnlock forwards queued events in FIFO order and releases mu. Exactly
+// one goroutine drains at a time; others enqueue and return.
+func (c *coalescer) drainAndUnlock() {
+	if c.draining || len(c.queue) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	c.draining = true
+	for len(c.queue) > 0 {
+		batch := c.queue
+		c.queue = nil
+		c.mu.Unlock()
+		for _, e := range batch {
+			c.inner.Emit(e)
+		}
+		c.mu.Lock()
+	}
+	c.draining = false
+	c.mu.Unlock()
+}
+
+// Optional sink capabilities flush first so audits never overtake a buffered
+// delta, then forward to inner sinks that opt in.
+
+func (c *coalescer) RecordReadinessAudit(a evidence.ReadinessAudit) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordReadinessAudit(c.inner, a)
+}
+
+func (c *coalescer) RecordTurnCompletion() {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordTurnCompletion(c.inner)
+}
+
+func (c *coalescer) RecordProtocolRecovery(a ProtocolRecoveryAudit) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordProtocolRecovery(c.inner, a)
+}

--- a/internal/event/coalesce_test.go
+++ b/internal/event/coalesce_test.go
@@ -1,0 +1,227 @@
+package event
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/evidence"
+)
+
+type coalesceRecordSink struct {
+	mu        sync.Mutex
+	events    []Event
+	readiness int
+	turns     int
+	recovery  int
+}
+
+func (s *coalesceRecordSink) Emit(e Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *coalesceRecordSink) RecordReadinessAudit(evidence.ReadinessAudit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readiness++
+}
+
+func (s *coalesceRecordSink) RecordTurnCompletion() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.turns++
+}
+
+func (s *coalesceRecordSink) RecordProtocolRecovery(ProtocolRecoveryAudit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recovery++
+}
+
+func (s *coalesceRecordSink) snapshot() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Event(nil), s.events...)
+}
+
+func TestCoalesceFirstDeltaForwardsImmediately(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Text, Text: "hello"})
+	got := inner.snapshot()
+	if len(got) != 1 || got[0].Text != "hello" {
+		t.Fatalf("first delta must forward immediately, got %+v", got)
+	}
+}
+
+func TestCoalesceMergesBurstAndFlushesOnBarrier(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Reasoning, Text: "a"}) // leading edge
+	c.Emit(Event{Kind: Reasoning, Text: "b"})
+	c.Emit(Event{Kind: Reasoning, Text: "c"})
+	c.Emit(Event{Kind: ToolDispatch, Tool: Tool{ID: "t1", Name: "bash"}}) // barrier
+
+	got := inner.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("got %d events, want 3 (leading delta, merged burst, barrier): %+v", len(got), got)
+	}
+	if got[0].Text != "a" || got[1].Kind != Reasoning || got[1].Text != "bc" {
+		t.Fatalf("burst not merged: %+v", got)
+	}
+	if got[2].Kind != ToolDispatch {
+		t.Fatalf("barrier must arrive after the flushed burst, got %+v", got[2])
+	}
+}
+
+func TestCoalesceKindSwitchFlushes(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Reasoning, Text: "think"}) // leading edge
+	c.Emit(Event{Kind: Reasoning, Text: "ing"})
+	c.Emit(Event{Kind: Text, Text: "answer"}) // switches kind: flush + buffer
+	c.Emit(Event{Kind: TurnDone})
+
+	got := inner.snapshot()
+	if len(got) != 4 {
+		t.Fatalf("got %d events, want 4: %+v", len(got), got)
+	}
+	if got[1].Kind != Reasoning || got[1].Text != "ing" {
+		t.Fatalf("reasoning tail = %+v", got[1])
+	}
+	if got[2].Kind != Text || got[2].Text != "answer" {
+		t.Fatalf("text after kind switch = %+v", got[2])
+	}
+}
+
+func TestCoalesceWindowFlushesBufferedTail(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, 20*time.Millisecond)
+	c.Emit(Event{Kind: Text, Text: "lead"})
+	c.Emit(Event{Kind: Text, Text: "tail"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := inner.snapshot()
+		if len(got) == 2 {
+			if got[1].Text != "tail" {
+				t.Fatalf("timer flush = %+v", got[1])
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("buffered tail never flushed: %+v", got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestCoalesceByteCapFlushes(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Text, Text: "lead"})
+	c.Emit(Event{Kind: Text, Text: strings.Repeat("x", coalesceMaxBytes)})
+	got := inner.snapshot()
+	if len(got) != 2 || len(got[1].Text) != coalesceMaxBytes {
+		t.Fatalf("byte cap must flush synchronously, got %d events", len(got))
+	}
+}
+
+func TestCoalesceCapabilitiesFlushFirstAndForward(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Text, Text: "lead"})
+	c.Emit(Event{Kind: Text, Text: "tail"})
+	c.(ReadinessAuditSink).RecordReadinessAudit(evidence.ReadinessAudit{})
+	c.(TurnCompletionSink).RecordTurnCompletion()
+	c.(ProtocolRecoveryAuditSink).RecordProtocolRecovery(ProtocolRecoveryAudit{})
+
+	got := inner.snapshot()
+	if len(got) != 2 || got[1].Text != "tail" {
+		t.Fatalf("capability call must flush the buffered delta first: %+v", got)
+	}
+	if inner.readiness != 1 || inner.turns != 1 || inner.recovery != 1 {
+		t.Fatalf("capabilities not forwarded: %d/%d/%d", inner.readiness, inner.turns, inner.recovery)
+	}
+}
+
+func TestCoalesceNonPureDeltaPassesThrough(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	c := Coalesce(inner, time.Hour)
+	c.Emit(Event{Kind: Text, Text: "lead"})
+	c.Emit(Event{Kind: Text, Text: "buffered"})
+	// A Text event carrying any extra field is not a pure delta: it must not
+	// merge, and it must flush the buffer ahead of itself.
+	c.Emit(Event{Kind: Text, Text: "detailed", Detail: "diag"})
+
+	got := inner.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("got %d events, want 3: %+v", len(got), got)
+	}
+	if got[1].Text != "buffered" || got[2].Detail != "diag" {
+		t.Fatalf("non-pure delta ordering broken: %+v", got)
+	}
+}
+
+// reentrantSink re-enters the wrapping sink from inside Emit, the way a
+// frontend callback can synchronously call back into the controller (e.g. a
+// recovery resolution emitting a decision receipt).
+type reentrantSink struct {
+	outer  Sink
+	events []Event
+	fired  bool
+}
+
+func (s *reentrantSink) Emit(e Event) {
+	s.events = append(s.events, e)
+	if e.Kind == ApprovalRequest && !s.fired {
+		s.fired = true
+		s.outer.Emit(Event{Kind: Notice, Text: "receipt"})
+	}
+}
+
+func TestCoalesceReentrantEmitDoesNotDeadlock(t *testing.T) {
+	inner := &reentrantSink{}
+	c := Coalesce(inner, time.Hour)
+	inner.outer = c
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.Emit(Event{Kind: Text, Text: "lead"})
+		c.Emit(Event{Kind: Text, Text: "buffered"})
+		c.Emit(Event{Kind: ApprovalRequest})
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("re-entrant Emit deadlocked the coalescer")
+	}
+
+	kinds := make([]Kind, 0, len(inner.events))
+	for _, e := range inner.events {
+		kinds = append(kinds, e.Kind)
+	}
+	want := []Kind{Text, Text, ApprovalRequest, Notice}
+	if len(kinds) != len(want) {
+		t.Fatalf("events = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("order broken: %v, want %v", kinds, want)
+		}
+	}
+}
+
+func TestCoalesceDisabledOrNil(t *testing.T) {
+	inner := &coalesceRecordSink{}
+	if s := Coalesce(inner, 0); s != Sink(inner) {
+		t.Fatalf("window<=0 must return inner unchanged")
+	}
+	if _, ok := Coalesce(nil, time.Second).(*coalescer); ok {
+		t.Fatalf("nil inner must not be wrapped")
+	}
+}


### PR DESCRIPTION
Targets the front half of the streaming pipeline (provider chunk → Go agent → event.Sink → Wails EventsEmit → WebView): the agent emitted one sink event per provider chunk, so a 100–300 chunk/sec stream became 100–300 EventsEmit/sec across the Go→WebView bridge (and equally many SSE frames / terminal redraw triggers). The desktop's `asyncRuntimeEmitter` already prevents the bridge from blocking the agent, but every chunk still paid serialization + IPC + a JS event dispatch. The frontend's rAF batching only absorbs the back half.

## Design

`event.Coalesce(inner, window)` — a sink decorator installed by `control.New` around every frontend sink, so desktop, CLI, serve, and ACP inherit it (behavior in the controller, not a frontend, per REASONIX conventions). It also covers the desktop rebuild paths that pass a raw `tabEventSink` without going through `desktopControllerSink`.

- **Merges only pure deltas**: consecutive `Text`/`Reasoning` events whose only payload is `Text`. The purity check compares against a zero probe via `reflect.DeepEqual`, so a future field added to `event.Event` can never be silently merged away; a companion test pins the ordering behavior.
- **Latency**: the first delta of a burst forwards immediately — time-to-first-token is unchanged. Under load the rate caps at one merged event per 25ms (`event.DefaultStreamDeltaWindow`, ~40Hz — above display refresh perception, an order of magnitude below fast-provider chunk rates).
- **Ordering**: any non-delta event (tool dispatch, message, usage, stream_attempt, …) flushes the buffer ahead of itself; kind switches flush; a 16KB cap bounds merged payload size. The coalescer's mutex serializes timer flushes with passthroughs, so downstream sinks keep the serial-Emit contract.
- **Capabilities**: readiness audits, protocol recovery, and turn completion flush-then-forward, so wrapping never severs the optional-capability chain.

Frontend contract is unchanged: consumers already treat text/reasoning as appendable deltas (`base.text + delta`), so a merged delta is indistinguishable from a fast provider sending bigger chunks.

Placed outside the `goalUsageTee` so a caller-provided tee is never double-wrapped; Usage events pass through untouched either way.

## Tests

`internal/event`: leading-edge immediacy, burst merge + barrier flush ordering, kind-switch flush, timer flush, byte-cap flush, capability flush-then-forward, non-pure delta passthrough, disabled/nil construction. Full `internal/event` + `internal/control` + `internal/agent` suites pass.

Cache-impact: none - sink-side event shaping only; provider requests and the prompt prefix are untouched
Cache-guard: go test ./internal/event/ -run TestCoalesce; deltas merge after the agent has already accumulated the full text for session/provider state
Documentation-impact: none - internal event pipeline behavior; the delta contract observed by consumers is unchanged