### PR TITLE
fix(ci): hard-kill hung Windows go test process trees / 硬杀卡住的 Windows go test 进程树

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
   test:
     needs: changes
     if: always()
+    # Hard ceiling for the whole leg. Without this, a Windows process-tree hang
+    # that survives step cancel can pin the job for the default 6h Actions limit
+    # (observed ~40-52m zombies during v1.21.2 notes pushes). 25m is above the
+    # normal 7-10m Windows full suite and the 15m smoke budget.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -139,13 +144,30 @@ jobs:
       # to main-v2; the Unix legs always run the full suite. Keep the job-level
       # budget above normal 7-9 minute runner variance; each package test binary
       # remains independently bounded by Go's 3 minute timeout below.
+      #
+      # Windows suites run under scripts/ci-windows-go-test.ps1 so a hung child
+      # cannot outlive the wall-clock budget. Actions step timeout alone is soft
+      # on Windows and left main-v2 legs in_progress for 40-52m (v1.21.2 notes).
+      # The retired WINDOWS_SANDBOX_WAIT_MS env is intentionally not reintroduced:
+      # the native Windows sandbox backend was removed and nothing reads it.
       - name: test (Windows smoke)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 15
+        shell: powershell
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
-          WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./internal/agent/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: |
+          $goArgs = @(
+            '-p', '4', '-timeout=3m',
+            './internal/agent/...', './internal/boot/...', './internal/checkpoint/...',
+            './internal/cli/...', './internal/control/...', './internal/desktoplauncher/...',
+            './internal/filelock/...', './internal/fileutil/...', './internal/hook/...',
+            './internal/instruction/...', './internal/mcplaunch/...', './internal/notify/...',
+            './internal/proc/...', './internal/remote/...', './internal/repair/...',
+            './internal/sandbox/...', './internal/sysproxy/...', './internal/workspacelease/...',
+            './cmd/...'
+          )
+          .\scripts\ci-windows-go-test.ps1 -TimeoutSeconds 720 -GoTestArgs $goArgs
 
       # The general Windows PR smoke list intentionally omits internal/tool.
       # Keep the session-temp portability contract covered without widening the
@@ -154,7 +176,10 @@ jobs:
       - name: test (Windows session temp)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 3
-        run: go test -timeout=2m -run '^TestBashSharesSessionTempAcrossCalls$' ./internal/tool/builtin
+        shell: powershell
+        run: |
+          $goArgs = @('-timeout=2m', '-run', '^TestBashSharesSessionTempAcrossCalls$', './internal/tool/builtin')
+          .\scripts\ci-windows-go-test.ps1 -TimeoutSeconds 120 -GoTestArgs $goArgs
 
       # Shell execution contract: PowerShell identity, Chinese workspace paths,
       # UTF-8 output, and ExitCode retention must gate PRs on native Windows.
@@ -162,20 +187,32 @@ jobs:
       - name: test (Windows shell execution contract)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 5
-        run: go test -timeout=3m -run '^TestBashPowerShellExecuteDetailedContract$|^TestBashPowerShell51PreflightRejectsAndAndDetailed$|^TestBashPowerShellOutputIsUTF8$|^TestBashPowerShellSurfacesNonZeroExit$|^TestBashPowerShellRejectsChaining$' ./internal/tool/builtin
+        shell: powershell
+        run: |
+          $goArgs = @(
+            '-timeout=3m',
+            '-run', '^TestBashPowerShellExecuteDetailedContract$|^TestBashPowerShell51PreflightRejectsAndAndDetailed$|^TestBashPowerShellOutputIsUTF8$|^TestBashPowerShellSurfacesNonZeroExit$|^TestBashPowerShellRejectsChaining$',
+            './internal/tool/builtin'
+          )
+          .\scripts\ci-windows-go-test.ps1 -TimeoutSeconds 180 -GoTestArgs $goArgs
 
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'
-        timeout-minutes: 10
+        # Step soft timeout stays slightly above the hard wrapper budget so the
+        # wrapper's taskkill path is what normally ends a hang; Actions cancel
+        # remains a second fence.
+        timeout-minutes: 14
+        shell: powershell
         env:
           # Run the prompt-cache prefix-stability guard (TestCacheHit*) in CI: a
           # regression there silently tanks the cache hit rate the project is
           # built around.
           REASONIX_RELEASE_CACHE_GUARD: "1"
-          # Bound sandbox helper children in Windows tests so a failed OS-level
-          # launch cannot pin the Actions step after Go's package timeout fires.
-          WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./...
+        run: |
+          # 12m hard wall-clock: healthy full suites finish in ~7-9m of go test
+          # time; hang past that is a process-tree leak, not normal variance.
+          $goArgs = @('-p', '4', '-timeout=3m', './...')
+          .\scripts\ci-windows-go-test.ps1 -TimeoutSeconds 720 -GoTestArgs $goArgs
 
       - name: test (Scoop desktop launch)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows'

--- a/scripts/ci-windows-go-test.ps1
+++ b/scripts/ci-windows-go-test.ps1
@@ -1,0 +1,110 @@
+#Requires -Version 5.1
+# Run `go test` under a hard wall-clock budget and kill the entire process
+# tree if the budget is exceeded.
+#
+# Why this exists
+# ---------------
+# GitHub Actions step `timeout-minutes` is a soft cancel on Windows. When a
+# package test leaves a child (PowerShell, helper, stuck pipe) that does not
+# exit on Ctrl+C / job cancel, the step stays `in_progress` for tens of
+# minutes even after the configured 10-minute budget. That pinned main-v2
+# push CI during the v1.21.2 notes window and stranded release candidates.
+#
+# Go's `-timeout` is per package only, so it cannot bound the whole suite
+# wall-clock either. This wrapper is the process-tree ceiling: after
+# TimeoutSeconds it runs `taskkill /T /F` on the go.exe root, which is the
+# reliable Windows way to reap the tree.
+#
+# Exit codes
+# ----------
+# - go test's exit code on normal completion
+# - 124 on hard timeout (same convention as GNU coreutils `timeout`)
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateRange(1, 86400)]
+    [int]$TimeoutSeconds,
+
+    # Pass go-test flags as an explicit array so PowerShell does not treat
+    # `-p` / `-timeout=...` as parameters of this wrapper script.
+    # Example: -GoTestArgs @('-p','4','-timeout=3m','./...')
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]$GoTestArgs
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-ProcessArgumentString {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$Arguments
+    )
+
+    $parts = foreach ($arg in $Arguments) {
+        if ($null -eq $arg) {
+            continue
+        }
+        if ($arg -match '[\s"]') {
+            '"' + ($arg -replace '(\\*)"', '$1$1\"') + '"'
+        }
+        else {
+            $arg
+        }
+    }
+    return ($parts -join ' ')
+}
+
+function Stop-ProcessTree {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$ProcessId
+    )
+
+    # /T = tree, /F = force. taskkill is the durable Windows process-tree API;
+    # Stop-Process alone leaves grandchildren that keep the Actions step open.
+    & taskkill.exe /PID $ProcessId /T /F 2>$null | Out-Null
+    Start-Sleep -Milliseconds 500
+}
+
+$go = Get-Command go -ErrorAction Stop
+$argList = @('test') + $GoTestArgs
+$argString = ConvertTo-ProcessArgumentString -Arguments $argList
+
+$startInfo = New-Object System.Diagnostics.ProcessStartInfo
+$startInfo.FileName = $go.Source
+$startInfo.Arguments = $argString
+$startInfo.WorkingDirectory = (Get-Location).Path
+$startInfo.UseShellExecute = $false
+$startInfo.RedirectStandardOutput = $false
+$startInfo.RedirectStandardError = $false
+$startInfo.CreateNoWindow = $true
+
+$proc = New-Object System.Diagnostics.Process
+$proc.StartInfo = $startInfo
+[void]$proc.Start()
+
+$budgetMs = $TimeoutSeconds * 1000
+if ($proc.WaitForExit($budgetMs)) {
+    exit $proc.ExitCode
+}
+
+Write-Host ("::error::go test exceeded hard wall-clock budget of {0}s (pid={1}); killing process tree" -f $TimeoutSeconds, $proc.Id)
+Stop-ProcessTree -ProcessId $proc.Id
+
+# Wait briefly for the tree to disappear so the Actions step can close.
+$graceMs = 15000
+if (-not $proc.WaitForExit($graceMs)) {
+    try {
+        $proc.Kill()
+    }
+    catch {
+        # Best-effort; taskkill already ran.
+    }
+    [void]$proc.WaitForExit(5000)
+}
+
+exit 124

--- a/scripts/ci-windows-go-test.test.sh
+++ b/scripts/ci-windows-go-test.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/ci-windows-go-test.ps1 (no Windows runner required).
+set -euo pipefail
+
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$root/scripts/ci-windows-go-test.ps1"
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+[[ -f "$script" ]] || fail "missing $script"
+
+# Must hard-kill the process tree; soft Stop-Process is insufficient on Windows.
+grep -q 'taskkill.exe /PID \$ProcessId /T /F' "$script" ||
+	grep -q 'taskkill.exe /PID $ProcessId /T /F' "$script" ||
+	grep -q 'taskkill.exe /PID' "$script" ||
+	fail "expected taskkill process-tree kill"
+
+grep -q 'exit 124' "$script" || fail "expected GNU-timeout-style exit 124 on hard timeout"
+grep -q 'WaitForExit' "$script" || fail "expected WaitForExit wall-clock wait"
+grep -q 'TimeoutSeconds' "$script" || fail "expected TimeoutSeconds parameter"
+grep -q 'GoTestArgs' "$script" || fail "expected GoTestArgs parameter for go test flags"
+
+# Must not reintroduce the retired Windows sandbox wait env as a real dependency.
+if grep -q 'WINDOWS_SANDBOX_WAIT_MS' "$script"; then
+	fail "wrapper must not depend on retired WINDOWS_SANDBOX_WAIT_MS"
+fi
+
+echo "ok: ci-windows-go-test.ps1 contracts"

--- a/scripts/release-workflows.test.sh
+++ b/scripts/release-workflows.test.sh
@@ -1576,6 +1576,19 @@ node --test "$repo_root/npm/publish.test.mjs"
 node --test "$repo_root/scripts/finalize-npm-official-release.test.mjs"
 bash "$repo_root/scripts/release-stable.test.sh"
 bash "$repo_root/scripts/check-docs-impact.test.sh"
+bash "$repo_root/scripts/ci-windows-go-test.test.sh"
+
+# Windows full-suite hangs that survive Actions soft step cancel pin main-v2
+# push CI (v1.21.2 notes window: 40-52m zombies). Require the hard ceiling.
+ci_workflow="$repo_root/.github/workflows/ci.yml"
+grep -Fq 'scripts/ci-windows-go-test.ps1' "$ci_workflow"
+grep -Fq 'timeout-minutes: 25' "$ci_workflow"
+grep -Fq 'TimeoutSeconds 720' "$ci_workflow"
+# Dead env left after the native Windows sandbox retirement must not return.
+if grep -v '^\s*#' "$ci_workflow" | grep -Fq 'WINDOWS_SANDBOX_WAIT_MS'; then
+	echo "ci.yml still injects retired WINDOWS_SANDBOX_WAIT_MS" >&2
+	exit 1
+fi
 
 # Every current publisher must gate on the same compiled docs identity, and
 # each build path must stamp that identity into its shipped binary.


### PR DESCRIPTION
## Summary

Fix the root cause of main-v2 push CI zombies that blocked the v1.21.2 release window: Windows `test (full)` stayed `in_progress` for 40–52 minutes after Actions soft step cancel failed to reap the process tree.

### Root cause

1. `go test -timeout` is **per package**, not suite wall-clock.
2. GitHub Actions `timeout-minutes` on a step is a **soft cancel** on Windows; orphaned children keep the job open.
3. The `test` matrix job had **no job-level** `timeout-minutes` (default ~6h).
4. `WINDOWS_SANDBOX_WAIT_MS` was still injected after the native Windows sandbox backend was **retired**, so it bounded nothing.

### Fix

- New `scripts/ci-windows-go-test.ps1`: hard wall-clock budget + `taskkill /T /F` process-tree kill (exit `124` on timeout).
- Route Windows smoke / session-temp / shell-contract / full suites through the wrapper.
- `test` job `timeout-minutes: 25` as a final fence.
- Remove dead `WINDOWS_SANDBOX_WAIT_MS` injection.
- Contract tests in `ci-windows-go-test.test.sh` + `release-workflows.test.sh`.

### Verification

- `bash scripts/ci-windows-go-test.test.sh`
- `bash scripts/release-workflows.test.sh` → PASS

### Cache / docs

Cache-impact: none — CI workflow and scripts only.
Documentation-impact: none.

## Test plan

- [ ] PR CI: Windows smoke path uses the wrapper and stays within budget
- [ ] After merge to main-v2: push `test (full)` either finishes green in ~7–12m or fails hard ≤12m (no 40m+ zombie)
- [ ] Confirm required check names unchanged (`test (windows-latest)`, etc.)