### PR TITLE
perf(frontend): parse streaming Markdown per completed block, not per tick

### DIFF
--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -9,7 +9,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown from "react-markdown";
-import { splitStableMarkdownSections, streamingMarkdownCommitInterval, useRenderedMarkdownText } from "../components/Markdown";
+import { splitStableMarkdownSections, streamingCommitTarget, streamingMarkdownCommitInterval, useRenderedMarkdownText } from "../components/Markdown";
 import MermaidDiagram from "../components/MermaidDiagram";
 import {
   __setMermaidPanZoomFactoryForTest,
@@ -194,6 +194,16 @@ console.log("\nmermaid rendering");
   eq(streamingMarkdownCommitInterval(1_000), 50, "short streaming Markdown uses the 50ms parse budget");
   eq(streamingMarkdownCommitInterval(8_000), 150, "medium streaming Markdown uses the 150ms parse budget");
   eq(streamingMarkdownCommitInterval(32_000), 300, "long streaming Markdown uses the 300ms parse budget");
+
+  eq(streamingCommitTarget("intro\n\npartial paragraph"), "intro\n\n", "commit target stops at the last completed block");
+  eq(streamingCommitTarget("no blank line yet"), "", "no completed block means nothing to parse yet");
+  eq(streamingCommitTarget("done\n\nalso done\n\n"), "done\n\nalso done\n\n", "trailing boundary commits everything");
+  eq(streamingCommitTarget("t\n\n```js\nstreaming code"), "t\n\n```js\nstreaming code", "an open fence keeps the whole text parsed for live highlighting");
+  eq(streamingCommitTarget("t\n\n$$\n\\int_0^1"), "t\n\n$$\n\\int_0^1", "open display math keeps the whole text parsed");
+  eq(streamingCommitTarget("t\n\n```\nc\n```\nafter"), "t\n\n```\nc\n```\n", "a closed fence promotes immediately without waiting for a blank line");
+  eq(streamingCommitTarget("t\n\n$$\nx\n$$\nafter"), "t\n\n$$\nx\n$$\n", "closed display math promotes immediately");
+  eq(streamingCommitTarget("para\n## Next sec"), "para\n", "a partial heading line completes the paragraph before it");
+  eq(streamingCommitTarget("para\n## Done\ntail"), "para\n## Done\n", "a terminated heading promotes itself as a complete block");
 }
 
 {
@@ -226,20 +236,26 @@ console.log("\nmermaid rendering");
     root.render(<MarkdownTextProbe text="start middle end" streaming />);
     await new Promise((resolve) => setTimeout(resolve, 60));
   });
-  eq(rootEl.textContent, "start", "streaming Markdown holds intermediate text until the animation frame");
+  eq(pendingFrame, undefined, "an in-progress block never schedules a parse commit");
+  eq(rootEl.textContent, "start", "the growing block rides the tail, not the parsed prefix");
+
+  await act(async () => {
+    root.render(<MarkdownTextProbe text={"start middle end\n\nnext block"} streaming />);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
   const frame = pendingFrame;
   await act(async () => {
     frame?.(performance.now());
     await flushTimers();
   });
-  eq(rootEl.textContent, "start middle end", "one animation frame commits the latest streamed text");
+  eq(rootEl.textContent, "start middle end\n\n", "a completed block commits up to its boundary");
 
   pendingFrame = undefined;
   await act(async () => {
-    root.render(<MarkdownTextProbe text="start middle end later" streaming />);
+    root.render(<MarkdownTextProbe text={"start middle end\n\nnext block grows"} streaming />);
     await flushTimers();
   });
-  eq(pendingFrame, undefined, "streaming Markdown waits for a fresh budget after the previous DOM commit");
+  eq(pendingFrame, undefined, "tail growth alone schedules no further parse");
 
   await act(async () => {
     root.render(<MarkdownTextProbe text="complete" streaming={false} />);

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -130,6 +130,46 @@ export function streamingMarkdownCommitInterval(textLength: number): number {
   return 50;
 }
 
+// streamingCommitTarget returns the prefix worth parsing while a stream is
+// live: everything up to the last completed block — a blank line, a closed
+// fence, closed display math, or the start of a heading, all on terminated
+// lines. The in-progress block rides the plain-text tail instead, so Markdown
+// re-parses once per completed block rather than once per commit interval. An
+// unclosed fence or $$ keeps the whole text parsed for live code highlighting.
+export function streamingCommitTarget(text: string): string {
+  let lineStart = 0;
+  let fence: { marker: string; length: number } | null = null;
+  let displayMath = false;
+  let boundary = 0;
+  while (lineStart < text.length) {
+    const newline = text.indexOf("\n", lineStart);
+    const lineEnd = newline === -1 ? text.length : newline + 1;
+    const line = text.slice(lineStart, newline === -1 ? text.length : newline).replace(/\r$/, "");
+    const terminated = newline !== -1;
+    if (fence) {
+      if (new RegExp(`^ {0,3}${fence.marker}{${fence.length},}[ \\t]*$`).test(line)) {
+        fence = null;
+        if (terminated) boundary = lineEnd;
+      }
+    } else if (displayMath) {
+      if (line.trim() === "$$") {
+        displayMath = false;
+        if (terminated) boundary = lineEnd;
+      }
+    } else {
+      const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+      if (fenceMatch) fence = { marker: fenceMatch[1][0], length: fenceMatch[1].length };
+      else if (line.trim() === "$$") displayMath = true;
+      else if (terminated && line.trim() === "") boundary = lineEnd;
+      // A heading interrupts a paragraph, so a partial heading line already
+      // completes everything before it; a terminated one is itself complete.
+      else if (/^ {0,3}#{1,6}[ \t]+/.test(line)) boundary = terminated ? lineEnd : lineStart;
+    }
+    lineStart = lineEnd;
+  }
+  return fence || displayMath ? text : text.slice(0, boundary);
+}
+
 export function useRenderedMarkdownText(text: string, streaming: boolean): string {
   const [renderedText, setRenderedText] = useState(text);
   const latestTextRef = useRef(text);
@@ -206,12 +246,15 @@ export function useRenderedMarkdownText(text: string, streaming: boolean): strin
   }, [renderedText, streaming]);
 
   useEffect(() => {
-    if (!streaming || renderedText === text || frameRef.current !== null || timeoutRef.current !== null) return;
+    if (!streaming || frameRef.current !== null || timeoutRef.current !== null) return;
+    if (streamingCommitTarget(text).length <= renderedText.length) return;
     const commit = () => {
       timeoutRef.current = null;
       frameRef.current = requestAnimationFrame(() => {
         frameRef.current = null;
-        setRenderedText(latestTextRef.current);
+        // Recompute at commit time: only ever advance to a newer boundary.
+        const target = streamingCommitTarget(latestTextRef.current);
+        setRenderedText((prev) => (target.length > prev.length ? target : prev));
       });
     };
     const now = performance.now();
@@ -261,7 +304,7 @@ export const Markdown = memo(function Markdown({
 }) {
   const renderedText = useRenderedMarkdownText(text, streaming);
   const sections = useMemo(() => splitStableMarkdownSections(renderedText), [renderedText]);
-  const pendingText = text.length >= STREAMING_TAIL_THRESHOLD && text.startsWith(renderedText)
+  const pendingText = (streaming || text.length >= STREAMING_TAIL_THRESHOLD) && text.startsWith(renderedText)
     ? text.slice(renderedText.length)
     : "";
   return (


### PR DESCRIPTION
Third layer of the streaming-pipeline work (#7889 Go-side coalescing, #7890 one reducer pass per frame). The existing Markdown streaming optimizations are real — tiered commit intervals (50/150/300ms), a plain-text `appendData` tail above 8KB, stable-section splitting above ~12KB — but they leave a counter-intuitive gap: **the most common 1–8KB answer re-parses the entire growing document through ReactMarkdown + remark/rehype/normalizeMath up to 20×/sec, and below the 8KB threshold the tail mechanism doesn't exist at all**, so small answers get the most parses and none of the cushioning. Parse count scales with stream duration (a 30s answer ≈ 600 full parses), not with content.

## Changes

- `streamingCommitTarget(text)`: the parsed prefix now advances only to the **last completed block** — a blank line outside fences and display math. The in-progress block rides the existing `StreamingMarkdownTail` (`appendData`, zero parsing) from byte zero, not just above 8KB.
- A stream now costs **one parse per completed block plus the existing single finalization pass**, instead of one full parse per interval tick for the stream's whole duration. Tail growth alone schedules nothing.
- **Code streams don't regress**: an unclosed ``` fence or `76479` keeps the whole text parsed, so streaming code keeps live highlighting exactly as today; a blank line inside a closed fence is not a boundary.
- The tier interval (50/150/300ms) remains as the cadence ceiling for boundary commits; the ≥8KB path also benefits (commits happen on block completion instead of unconditionally every 150/300ms). The prefix only ever advances monotonically, and end-of-stream finalization (immediate below 8KB, idle-scheduled above) is unchanged.

Fidelity tradeoff, stated: the in-progress block shows raw Markdown syntax until it completes — the same tradeoff the ≥8KB tail already made, now applied uniformly. In exchange, new tokens appear with **lower** latency than before (per-frame `appendData` instead of waiting for the next 50ms parse commit).

## Tests

`mermaid-rendering.test.tsx` (68 passing): `streamingCommitTarget` boundary/fence/math/closed-fence cases, the hook's new contract (in-progress block schedules no parse, completed block commits to its boundary, tail growth schedules nothing, short-stream finalization immediate), plus the existing interval-tier and section-splitting assertions. `tsc`, eslint, render-optimization and reasoning-display suites pass.

Cache-impact: none - frontend-only rendering path; nothing provider-visible changes
Cache-guard: tsx src/__tests__/mermaid-rendering.test.tsx (commit-target and hook-contract assertions)
Documentation-impact: none - internal frontend performance work; visible behavior change is limited to when in-flight markdown styling appears, which docs do not describe