### PR TITLE
test(frontend): pin jsdom navigator so suites pass on zh-locale machines

### DIFF
--- a/desktop/frontend/src/__tests__/extension-surface.test.tsx
+++ b/desktop/frontend/src/__tests__/extension-surface.test.tsx
@@ -173,6 +173,9 @@ const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body>
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 globalThis.window = dom.window as unknown as Window & typeof globalThis;
 globalThis.document = dom.window.document;
+// Node's built-in navigator reflects the machine's ICU locale; pin jsdom's
+// en-US one so English-string assertions hold on zh-locale machines.
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
 globalThis.Node = dom.window.Node;
 globalThis.Element = dom.window.Element;
 globalThis.HTMLElement = dom.window.HTMLElement;

--- a/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
+++ b/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
@@ -197,6 +197,9 @@ console.log("\nstatus bar workspace");
   (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
   globalThis.window = dom.window as unknown as Window & typeof globalThis;
   globalThis.document = dom.window.document;
+  // Node's built-in navigator reflects the machine's ICU locale; pin jsdom's
+  // en-US one so English-string assertions hold on zh-locale machines.
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
   globalThis.Node = dom.window.Node;
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.HTMLButtonElement = dom.window.HTMLButtonElement;


### PR DESCRIPTION
Found by the discovery test runner: `extension-surface` and `statusbar-workspace` fail on any zh-locale machine because Node ≥21's built-in global `navigator.language` reflects the machine's ICU locale, and these two suites never replaced it with jsdom's `en-US` one — `LocaleProvider` renders 提交/取消 and every English-string assertion fails, while CI's en runners stay green. Same class as the repo convention of running `internal/cli` Go tests under `LANG=en_US.UTF-8`.

Fix: pin `globalThis.navigator` to the jsdom window's navigator in both suites' DOM setup, matching what the other jsdom suites already do. Both suites pass on a zh-CN machine without any environment override.

Cache-impact: none - test-only change
Cache-guard: tsx src/__tests__/extension-surface.test.tsx and statusbar-workspace.test.tsx on a zh-locale machine
Documentation-impact: none - test-only change with no user-facing behavior