### PR TITLE
feat(bench): model-round decomposition, per-solved efficiency, and A/B compare mode

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,6 +46,7 @@ decoder. The task ID is the directory name; tasks run in sorted ID order.
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `prompt` | string | yes | The task instruction handed to the agent. |
+| `class` | string | no | Task class label (e.g. `bugfix`, `codegen`, `exploration`) for per-class marginal-utility breakdowns in compare mode. |
 | `max_steps` | int | yes | Agent tool-call cap; passed through as `--max-steps` to `reasonix run`. |
 | `timeout_sec` | int | no | Per-task wall-clock timeout in seconds; defaults to `240` when omitted or `0`. |
 
@@ -114,6 +115,7 @@ own outcome).
 | `-out` | *(stdout)* | Write the markdown report here. |
 | `-json` | *(none)* | Write the JSON report here (optional). |
 | `-trajectories` | *(none)* | Suite mode: write one `<task-id>.trajectory.jsonl` per task into this directory (the agent's full event stream with timestamps — see `reasonix run --trajectory`). The report gains a time-attribution line (tools vs. model) and each JSON result a `trajectory` digest. |
+| `-force-planner` | `false` | Suite mode: prefix each prompt with a plan-first directive so the two-model turn engages regardless of the planner gate. Use for the "with planner" arm of an A/B; results carry `plan_forced` so arms are only comparable with equal forcing. |
 | `-budget` | `800000` | Abort once total tokens cross this (`0` = no cap). Remaining tasks are reported as skipped. |
 
 Diff-mode flags:
@@ -126,6 +128,22 @@ Diff-mode flags:
 | `-max-steps` | `80` | Agent tool-call cap for the diff task. |
 | `-timeout` | `1200` | Agent timeout in seconds (diff mode). |
 | `-attempts` | `1` | Diff mode: retry up to N times until a run passes (stochastic agent). |
+
+## A/B compare mode
+
+Run the same suite twice and let the harness judge the trade:
+
+```sh
+go run ./cmd/e2ebench -force-planner -trajectories t-a -json with.json
+go run ./cmd/e2ebench -ablate planner -trajectories t-b -json without.json
+go run ./cmd/e2ebench -mode compare with.json without.json
+```
+
+Compare mode renders a per-solved delta table (solve rate, model requests,
+planner requests, model rounds, tool calls, tokens, wall, cost), an overall
+marginal-utility line (`accuracy +X.Xpp · wall/task +Y.Ys`), and — when tasks
+carry `class` labels — a per-class breakdown, so a subsystem's uplift and
+latency cost can be judged per task class instead of globally.
 
 ## SWE-bench Verified mode
 

--- a/benchmarks/e2e/tasks/compaction/task.toml
+++ b/benchmarks/e2e/tasks/compaction/task.toml
@@ -1,3 +1,4 @@
 prompt = "Begin by reading the file story/chapter-1.md. Each chapter ends by telling you which chapter to read next; follow that trail one chapter at a time — read a chapter, find where it points you, then read that next chapter — until a chapter says the trail ends. You cannot know the next chapter without reading the current one, so do not guess or read ahead. In chapter 1 a river village is named; in the final chapter on the trail a noble House is named. When the trail ends, write a file answer.txt whose entire contents are the village name from chapter 1, a single hyphen, and the House name from the final chapter — for example Riverton-Stark — and nothing else."
+class = "exploration"
 max_steps = 40
 timeout_sec = 900

--- a/benchmarks/e2e/tasks/fix-add-bug/task.toml
+++ b/benchmarks/e2e/tasks/fix-add-bug/task.toml
@@ -1,3 +1,4 @@
 prompt = "The file calc.py has a bug: add(a, b) returns the wrong result. Fix add so it returns the sum of a and b. Keep the other functions unchanged."
+class = "bugfix"
 max_steps = 12
 timeout_sec = 180

--- a/benchmarks/e2e/tasks/fizzbuzz/task.toml
+++ b/benchmarks/e2e/tasks/fizzbuzz/task.toml
@@ -1,3 +1,4 @@
 prompt = "Create a file named fizzbuzz.py containing a function fizzbuzz(n) that returns the string 'Fizz' when n is divisible by 3, 'Buzz' when divisible by 5, 'FizzBuzz' when divisible by both 3 and 5, and otherwise the number as a string. Do not print anything at import time."
+class = "codegen"
 max_steps = 12
 timeout_sec = 180

--- a/benchmarks/e2e/tasks/palindrome/task.toml
+++ b/benchmarks/e2e/tasks/palindrome/task.toml
@@ -1,3 +1,4 @@
 prompt = "Create a file named palindrome.py with a function is_palindrome(s) that returns True if s reads the same forwards and backwards ignoring case, spaces, and punctuation, and False otherwise. Do not print anything at import time."
+class = "codegen"
 max_steps = 12
 timeout_sec = 180

--- a/benchmarks/e2e/tasks/subagent-delegation/task.toml
+++ b/benchmarks/e2e/tasks/subagent-delegation/task.toml
@@ -1,3 +1,4 @@
 prompt = "This directory contains a data/ folder with three files: alpha.txt, beta.txt, and gamma.txt. Each file holds a single line of the form name=number. You MUST delegate the reading to a sub-agent: call the `task` tool exactly once, instructing the sub-agent to read all three files under data/ and report the three numbers back to you. Do NOT read the files yourself with your own tools. After the sub-agent reports the numbers, add them together and write ONLY the resulting integer (no other text, no trailing label or newline-prefixed words) to a file named result.txt in the current directory."
+class = "delegation"
 max_steps = 15
 timeout_sec = 300

--- a/cmd/e2ebench/compare.go
+++ b/cmd/e2ebench/compare.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// requestsBySourceLine breaks total model requests down by origin so an
+// ablation arm shows exactly where its requests went (planner, subagents,
+// compaction) instead of one opaque total.
+func requestsBySourceLine(bySource map[string]sourceUsage) string {
+	if len(bySource) == 0 {
+		return ""
+	}
+	sources := make([]string, 0, len(bySource))
+	for source, usage := range bySource {
+		if usage.Calls > 0 {
+			sources = append(sources, source)
+		}
+	}
+	if len(sources) == 0 {
+		return ""
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		if bySource[sources[i]].Calls != bySource[sources[j]].Calls {
+			return bySource[sources[i]].Calls > bySource[sources[j]].Calls
+		}
+		return sources[i] < sources[j]
+	})
+	parts := make([]string, 0, len(sources))
+	for _, source := range sources {
+		usage := bySource[source]
+		parts = append(parts, fmt.Sprintf("%s %s (%s tok)", source, comma(usage.Calls), comma(usage.PromptTokens+usage.CompletionTokens)))
+	}
+	return "**Requests by source:** " + strings.Join(parts, " · ") + "\n\n"
+}
+
+// armStats is one arm's aggregate over a -json report, using the same
+// accounting conventions as renderBody: spend totals cover accounted runs
+// (failures included) and per-solved figures divide by accounted solves.
+type armStats struct {
+	Ran, Solved, AccountedSolved       int
+	Steps, Tools, Rounds, PlannerCalls int
+	Tokens                             int
+	Cost                               float64
+	WallMs                             int64
+}
+
+func aggregateArm(results []result) armStats {
+	var s armStats
+	for _, r := range results {
+		if r.Skipped {
+			continue
+		}
+		s.Ran++
+		if r.Passed {
+			s.Solved++
+		}
+		if r.Unaccounted {
+			continue
+		}
+		if r.Passed {
+			s.AccountedSolved++
+		}
+		s.Steps += r.Steps
+		s.Tools += r.ToolCalls
+		s.Tokens += r.PromptTokens + r.CompletionTokens
+		s.Cost += r.Cost
+		s.WallMs += r.WallMs
+		s.PlannerCalls += r.UsageBySource["planner"].Calls
+		if r.Trajectory != nil {
+			s.Rounds += r.Trajectory.ModelRounds
+		}
+	}
+	return s
+}
+
+func perSolved(total float64, solved int) string {
+	if solved == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.1f", total/float64(solved))
+}
+
+func runCompareMode(outMD string) {
+	if flag.NArg() != 2 {
+		fmt.Fprintln(os.Stderr, "compare mode wants two -json report files: e2ebench -mode compare a.json b.json")
+		os.Exit(2)
+	}
+	report, err := compareReports(flag.Arg(0), flag.Arg(1))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "compare:", err)
+		os.Exit(1)
+	}
+	emit(report, outMD, "")
+}
+
+// accumulateSources folds one run's per-origin usage into the suite totals.
+func accumulateSources(total map[string]sourceUsage, run map[string]sourceUsage) {
+	for source, usage := range run {
+		agg := total[source]
+		agg.Calls += usage.Calls
+		agg.PromptTokens += usage.PromptTokens
+		agg.CompletionTokens += usage.CompletionTokens
+		agg.Cost += usage.Cost
+		total[source] = agg
+	}
+}
+
+// compareReports renders an A/B delta table from two -json report files —
+// the readout for an ablation experiment (e.g. control vs -ablate planner).
+func compareReports(pathA, pathB string) (string, error) {
+	arms := make([]armStats, 0, 2)
+	labels := []string{pathA, pathB}
+	for _, path := range labels {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		var results []result
+		if err := json.Unmarshal(data, &results); err != nil {
+			return "", fmt.Errorf("%s: %w", path, err)
+		}
+		arms = append(arms, aggregateArm(results))
+	}
+	a, bStats := arms[0], arms[1]
+	var b strings.Builder
+	fmt.Fprintf(&b, "## e2ebench A/B: `%s` vs `%s`\n\n", pathA, pathB)
+	fmt.Fprintf(&b, "| Metric | A | B |\n|---|---:|---:|\n")
+	fmt.Fprintf(&b, "| Solved | %d/%d (%s) | %d/%d (%s) |\n", a.Solved, a.Ran, pct(a.Solved, a.Ran), bStats.Solved, bStats.Ran, pct(bStats.Solved, bStats.Ran))
+	fmt.Fprintf(&b, "| Model requests / solved | %s | %s |\n", perSolved(float64(a.Steps), a.AccountedSolved), perSolved(float64(bStats.Steps), bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Planner requests / solved | %s | %s |\n", perSolved(float64(a.PlannerCalls), a.AccountedSolved), perSolved(float64(bStats.PlannerCalls), bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Model rounds / solved | %s | %s |\n", perSolved(float64(a.Rounds), a.AccountedSolved), perSolved(float64(bStats.Rounds), bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Tool calls / solved | %s | %s |\n", perSolved(float64(a.Tools), a.AccountedSolved), perSolved(float64(bStats.Tools), bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Tokens / solved | %s | %s |\n", perSolved(float64(a.Tokens), a.AccountedSolved), perSolved(float64(bStats.Tokens), bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Wall seconds / solved | %s | %s |\n", perSolved(float64(a.WallMs)/1000, a.AccountedSolved), perSolved(float64(bStats.WallMs)/1000, bStats.AccountedSolved))
+	fmt.Fprintf(&b, "| Cost / solved | %s | %s |\n", perSolved(a.Cost, a.AccountedSolved), perSolved(bStats.Cost, bStats.AccountedSolved))
+	b.WriteString("\n<sub>Per-solved figures divide each arm's accounted totals (failures included) by its accounted solves.</sub>\n")
+	return b.String(), nil
+}

--- a/cmd/e2ebench/compare.go
+++ b/cmd/e2ebench/compare.go
@@ -48,10 +48,16 @@ type armStats struct {
 	Tokens                             int
 	Cost                               float64
 	WallMs                             int64
+	ByClass                            map[string]classStats
+}
+
+type classStats struct {
+	Ran, Solved int
+	WallMs      int64
 }
 
 func aggregateArm(results []result) armStats {
-	var s armStats
+	s := armStats{ByClass: map[string]classStats{}}
 	for _, r := range results {
 		if r.Skipped {
 			continue
@@ -60,6 +66,17 @@ func aggregateArm(results []result) armStats {
 		if r.Passed {
 			s.Solved++
 		}
+		label := r.Class
+		if label == "" {
+			label = "unclassified"
+		}
+		c := s.ByClass[label]
+		c.Ran++
+		if r.Passed {
+			c.Solved++
+		}
+		c.WallMs += r.WallMs
+		s.ByClass[label] = c
 		if r.Unaccounted {
 			continue
 		}
@@ -139,6 +156,56 @@ func compareReports(pathA, pathB string) (string, error) {
 	fmt.Fprintf(&b, "| Tokens / solved | %s | %s |\n", perSolved(float64(a.Tokens), a.AccountedSolved), perSolved(float64(bStats.Tokens), bStats.AccountedSolved))
 	fmt.Fprintf(&b, "| Wall seconds / solved | %s | %s |\n", perSolved(float64(a.WallMs)/1000, a.AccountedSolved), perSolved(float64(bStats.WallMs)/1000, bStats.AccountedSolved))
 	fmt.Fprintf(&b, "| Cost / solved | %s | %s |\n", perSolved(a.Cost, a.AccountedSolved), perSolved(bStats.Cost, bStats.AccountedSolved))
+	b.WriteString(marginalUtilitySection(a, bStats))
 	b.WriteString("\n<sub>Per-solved figures divide each arm's accounted totals (failures included) by its accounted solves.</sub>\n")
 	return b.String(), nil
+}
+
+func solveRate(solved, ran int) float64 {
+	if ran == 0 {
+		return 0
+	}
+	return float64(solved) * 100 / float64(ran)
+}
+
+func wallPerTask(wallMs int64, ran int) float64 {
+	if ran == 0 {
+		return 0
+	}
+	return float64(wallMs) / 1000 / float64(ran)
+}
+
+// marginalUtilitySection is the decision readout: not "does A help" but what
+// each accuracy point costs in latency, overall and per task class, so a
+// subsystem can be routed per class instead of globally defaulted.
+func marginalUtilitySection(a, b armStats) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "\n**Marginal utility (A − B):** accuracy %+.1fpp · wall/task %+.1fs\n\n",
+		solveRate(a.Solved, a.Ran)-solveRate(b.Solved, b.Ran),
+		wallPerTask(a.WallMs, a.Ran)-wallPerTask(b.WallMs, b.Ran))
+	classes := make([]string, 0, len(a.ByClass)+len(b.ByClass))
+	seen := map[string]bool{}
+	for _, m := range []map[string]classStats{a.ByClass, b.ByClass} {
+		for class := range m {
+			if !seen[class] {
+				seen[class] = true
+				classes = append(classes, class)
+			}
+		}
+	}
+	if len(classes) == 0 || (len(classes) == 1 && classes[0] == "unclassified") {
+		return out.String()
+	}
+	sort.Strings(classes)
+	out.WriteString("| Class | A solved | B solved | Δ accuracy | A wall/task | B wall/task | Δ wall |\n|---|---:|---:|---:|---:|---:|---:|\n")
+	for _, class := range classes {
+		ca, cb := a.ByClass[class], b.ByClass[class]
+		fmt.Fprintf(&out, "| %s | %d/%d | %d/%d | %+.1fpp | %.1fs | %.1fs | %+.1fs |\n",
+			class, ca.Solved, ca.Ran, cb.Solved, cb.Ran,
+			solveRate(ca.Solved, ca.Ran)-solveRate(cb.Solved, cb.Ran),
+			wallPerTask(ca.WallMs, ca.Ran), wallPerTask(cb.WallMs, cb.Ran),
+			wallPerTask(ca.WallMs, ca.Ran)-wallPerTask(cb.WallMs, cb.Ran))
+	}
+	out.WriteString("\n")
+	return out.String()
 }

--- a/cmd/e2ebench/compare_test.go
+++ b/cmd/e2ebench/compare_test.go
@@ -58,6 +58,39 @@ func TestCompareReportsRendersPerSolvedDeltas(t *testing.T) {
 	}
 }
 
+func TestCompareReportsMarginalUtilityByClass(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(id, class string, passed bool, wallMs int64) result {
+		r := result{task: task{ID: id, Class: class}, Passed: passed, WallMs: wallMs}
+		r.Steps = 1
+		return r
+	}
+	withPlanner := []result{
+		mk("bug1", "bugfix", true, 30_000), mk("bug2", "bugfix", true, 30_000),
+		mk("ref1", "refactor", true, 112_000),
+	}
+	without := []result{
+		mk("bug1", "bugfix", true, 18_000), mk("bug2", "bugfix", true, 18_000),
+		mk("ref1", "refactor", false, 74_000),
+	}
+	pathA := writeArm(t, dir, "with.json", withPlanner)
+	pathB := writeArm(t, dir, "without.json", without)
+
+	got, err := compareReports(pathA, pathB)
+	if err != nil {
+		t.Fatalf("compareReports: %v", err)
+	}
+	for _, want := range []string{
+		"**Marginal utility (A − B):** accuracy +33.3pp · wall/task +20.7s",
+		"| bugfix | 2/2 | 2/2 | +0.0pp | 30.0s | 18.0s | +12.0s |",
+		"| refactor | 1/1 | 0/1 | +100.0pp | 112.0s | 74.0s | +38.0s |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("marginal utility missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRequestsBySourceLineOrdersByCalls(t *testing.T) {
 	line := requestsBySourceLine(map[string]sourceUsage{
 		"planner":  {Calls: 3, PromptTokens: 300},

--- a/cmd/e2ebench/compare_test.go
+++ b/cmd/e2ebench/compare_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeArm(t *testing.T, dir, name string, results []result) string {
+	t.Helper()
+	data, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+func TestCompareReportsRendersPerSolvedDeltas(t *testing.T) {
+	dir := t.TempDir()
+	control := result{task: task{ID: "a"}, Passed: true, WallMs: 60_000}
+	control.Steps = 7
+	control.ToolCalls = 10
+	control.PromptTokens = 900
+	control.CompletionTokens = 100
+	control.UsageBySource = map[string]sourceUsage{"executor": {Calls: 6}, "planner": {Calls: 1}}
+	control.Trajectory = &trajectorySummary{ModelRounds: 5}
+
+	ablated := result{task: task{ID: "a"}, Passed: true, WallMs: 45_000}
+	ablated.Steps = 5
+	ablated.ToolCalls = 10
+	ablated.PromptTokens = 700
+	ablated.CompletionTokens = 100
+	ablated.UsageBySource = map[string]sourceUsage{"executor": {Calls: 5}}
+	ablated.Trajectory = &trajectorySummary{ModelRounds: 5}
+
+	pathA := writeArm(t, dir, "control.json", []result{control})
+	pathB := writeArm(t, dir, "ablated.json", []result{ablated})
+
+	got, err := compareReports(pathA, pathB)
+	if err != nil {
+		t.Fatalf("compareReports: %v", err)
+	}
+	for _, want := range []string{
+		"| Solved | 1/1 (100%) | 1/1 (100%) |",
+		"| Model requests / solved | 7.0 | 5.0 |",
+		"| Planner requests / solved | 1.0 | 0.0 |",
+		"| Wall seconds / solved | 60.0 | 45.0 |",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("compare table missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRequestsBySourceLineOrdersByCalls(t *testing.T) {
+	line := requestsBySourceLine(map[string]sourceUsage{
+		"planner":  {Calls: 3, PromptTokens: 300},
+		"executor": {Calls: 9, PromptTokens: 900, CompletionTokens: 100},
+		"title":    {Calls: 0},
+	})
+	if !strings.Contains(line, "executor 9 (1,000 tok) · planner 3 (300 tok)") {
+		t.Fatalf("source line = %q", line)
+	}
+	if strings.Contains(line, "title") {
+		t.Fatalf("zero-call sources must be omitted: %q", line)
+	}
+	if requestsBySourceLine(nil) != "" {
+		t.Fatal("no sources must render nothing")
+	}
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -416,15 +416,32 @@ func render(results []result) string {
 	return fmt.Sprintf("## 🤖 Reasonix e2e benchmark (%s · arm `%s`)\n\n", profile, arm) + renderBody(results)
 }
 
+// perSolvedLine is the efficiency-per-solve report line: total spend across
+// every accounted run (failures included) divided by accounted solves, so a
+// same-accuracy agent needing twice the rounds cannot hide behind averages.
+func perSolvedLine(steps, tools, modelRounds, accountedSolved int, wallAccountedMs int64) string {
+	if accountedSolved == 0 {
+		return ""
+	}
+	line := fmt.Sprintf("**Per solved task:** **model requests** %.1f · tool calls %.1f · wall %s",
+		float64(steps)/float64(accountedSolved), float64(tools)/float64(accountedSolved),
+		dur(wallAccountedMs/int64(accountedSolved)))
+	if modelRounds > 0 {
+		line += fmt.Sprintf(" · model rounds %.1f", float64(modelRounds)/float64(accountedSolved))
+	}
+	return line + "\n\n"
+}
+
 // renderBody is the report without a heading, so a caller that supplies its own
 // (SWE-bench mode) does not stack two titles.
 func renderBody(results []result) string {
 	var b strings.Builder
 	passed, ran := 0, 0
 	accounted, accountedSolved, unaccounted, unaccountedSolved, partial := 0, 0, 0, 0, 0
-	var pTok, cTok, hit, miss, compacts, tools, toolFails int
+	var pTok, cTok, hit, miss, compacts, tools, toolFails, steps, modelRounds int
 	var cost float64
 	var walls []int64
+	var wallAccountedMs int64
 	currency := ""
 	classes := map[string]int{}
 	prefixChangeReasons := map[string]int{}
@@ -459,6 +476,11 @@ func renderBody(results []result) string {
 		compacts += r.Compactions
 		tools += r.ToolCalls
 		toolFails += r.ToolFailures
+		steps += r.Steps
+		wallAccountedMs += r.WallMs
+		if r.Trajectory != nil {
+			modelRounds += r.Trajectory.ModelRounds
+		}
 		cost += r.Cost
 		if r.Currency != "" {
 			currency = r.Currency
@@ -477,6 +499,7 @@ func renderBody(results []result) string {
 	fmt.Fprintf(&b, "**Cache hit:** %s · **Tokens:** %s (prompt %s / completion %s) · **Tool calls:** %s (%s failed) · **Compactions:** %d · **Cost:** %s%.4f\n\n",
 		pct(hit, hit+miss), comma(pTok+cTok), comma(pTok), comma(cTok),
 		comma(tools), comma(toolFails), compacts, currencySym(currency), cost)
+	b.WriteString(perSolvedLine(steps, tools, modelRounds, accountedSolved, wallAccountedMs))
 	b.WriteString(renderTimeAttribution(results))
 	if unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -23,8 +23,12 @@ import (
 )
 
 type task struct {
-	ID         string
-	Prompt     string `toml:"prompt"`
+	ID     string
+	Prompt string `toml:"prompt"`
+	// Class buckets tasks for marginal-utility comparisons (e.g. "bugfix",
+	// "codegen", "exploration"): per-class uplift vs latency is what decides
+	// whether a subsystem earns its round-trips for that kind of work.
+	Class      string `toml:"class" json:"class,omitempty"`
 	MaxSteps   int    `toml:"max_steps"`
 	TimeoutSec int    `toml:"timeout_sec"`
 	dir        string
@@ -105,6 +109,9 @@ type result struct {
 	// Trajectory is the digest of the run's recorded event trajectory; nil
 	// unless the harness ran with -trajectories.
 	Trajectory *trajectorySummary `json:"trajectory,omitempty"`
+	// PlanForced marks a -force-planner run: the prompt carried an injected
+	// plan-first directive, so arms are only comparable with equal forcing.
+	PlanForced bool `json:"plan_forced,omitempty"`
 }
 
 // class is the published failure taxonomy: solved, the guard that stopped the
@@ -159,6 +166,7 @@ func main() {
 	ablateFlag := flag.String("ablate", "", "ablation arm: subsystems to switch off (evidence, planner, subagent, retrieval, compaction; none|all)")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
 	trajDir := flag.String("trajectories", "", "suite mode: write one <task-id>.trajectory.jsonl per task into this directory")
+	forcePlanner := flag.Bool("force-planner", false, "suite mode: prefix each prompt with a plan-first directive so the two-model turn engages regardless of the planner gate")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
 	budget := flag.Int("budget", defaultSuiteTokenBudget, "abort once total tokens cross this (0 = no cap)")
 	// diff-mode flags
@@ -229,7 +237,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	results := runSuite(*bin, *model, profile, arm, tasks, *budget, *trajDir)
+	results := runSuite(*bin, *model, profile, arm, tasks, *budget, *trajDir, *forcePlanner)
 
 	report := render(results)
 	if *outMD != "" {
@@ -297,7 +305,7 @@ func loadTasks(suite string) ([]task, error) {
 
 // runSuite runs each task in order until the token budget is exhausted;
 // remaining tasks are reported as skipped rather than silently dropped.
-func runSuite(bin, model, profile string, arm ablation.Set, tasks []task, budget int, trajDir string) []result {
+func runSuite(bin, model, profile string, arm ablation.Set, tasks []task, budget int, trajDir string, forcePlanner bool) []result {
 	var results []result
 	total := 0
 	for _, t := range tasks {
@@ -305,7 +313,7 @@ func runSuite(bin, model, profile string, arm ablation.Set, tasks []task, budget
 			results = append(results, result{task: t, Profile: profile, Skipped: true, Note: "skipped: token budget reached"})
 			continue
 		}
-		r := runTask(bin, model, profile, arm, t, trajDir)
+		r := runTask(bin, model, profile, arm, t, trajDir, forcePlanner)
 		total += r.PromptTokens + r.CompletionTokens
 		results = append(results, r)
 	}
@@ -315,9 +323,16 @@ func runSuite(bin, model, profile string, arm ablation.Set, tasks []task, budget
 // runTask copies the task's seed workdir into a temp dir, runs the agent there,
 // then drops in verify.sh and runs it as the grader. The grader is added only
 // after the run so the agent can't read the answer key.
-func runTask(bin, model, profile string, arm ablation.Set, t task, trajDir string) result {
+func runTask(bin, model, profile string, arm ablation.Set, t task, trajDir string, forcePlanner bool) result {
 	r := result{task: t, Profile: profile}
 	r.Arm = arm.Arm()
+	if forcePlanner {
+		// Leading directive matched by the planner gate's
+		// planAndExecuteDirectives, so the two-model turn engages even for
+		// prompts the gate would route ExecutorOnly.
+		t.Prompt = "Plan first, then implement the following task.\n\n" + t.Prompt
+		r.PlanForced = true
+	}
 
 	trajPath := ""
 	if trajDir != "" {

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -39,10 +39,13 @@ type runMetrics struct {
 	// same name: per-run tallies of why the cache prefix changed (e.g.
 	// "compact_auto", "snip", "tools"), omitempty for older metrics files.
 	PrefixChangeReasonCounts map[string]int `json:"prefix_change_reason_counts,omitempty"`
-	Steps                    int            `json:"steps"`
-	Cost                     float64        `json:"cost"`
-	Currency                 string         `json:"currency"`
-	Compactions              int            `json:"compactions"`
+	// UsageBySource mirrors cli.RunMetrics: per-origin model-call accounting,
+	// the denominator split behind planner/subagent A/B comparisons.
+	UsageBySource map[string]sourceUsage `json:"usage_by_source,omitempty"`
+	Steps         int                    `json:"steps"`
+	Cost          float64                `json:"cost"`
+	Currency      string                 `json:"currency"`
+	Compactions   int                    `json:"compactions"`
 
 	// Optional Delivery capability counters (omitempty for baseline/old metrics).
 	ReadinessChecks            int     `json:"readiness_checks,omitempty"`
@@ -68,6 +71,13 @@ type runMetrics struct {
 	Retries            int            `json:"retries,omitempty"`
 	ToolCallsByName    map[string]int `json:"tool_calls_by_name,omitempty"`
 	ToolFailuresByName map[string]int `json:"tool_failures_by_name,omitempty"`
+}
+
+type sourceUsage struct {
+	Calls            int     `json:"calls"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	Cost             float64 `json:"cost"`
 }
 
 type result struct {
@@ -131,7 +141,7 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -profile delivery\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
 	}
 
-	mode := flag.String("mode", "suite", "suite | diff | swebench")
+	mode := flag.String("mode", "suite", "suite | diff | swebench | compare")
 	subset := flag.String("subset", "benchmarks/swebench/subset.json", "swebench mode: instance subset file")
 	namespace := flag.String("namespace", "swebench", "swebench mode: registry namespace holding the evaluation images")
 	runID := flag.String("run-id", "reasonix", "swebench mode: run id passed to the official harness")
@@ -187,6 +197,11 @@ func main() {
 		if *outJSON != "" {
 			fmt.Fprintln(os.Stderr, "note: -json is not written in swebench mode; the harness report is authoritative")
 		}
+		return
+	}
+
+	if *mode == "compare" {
+		runCompareMode(*outMD)
 		return
 	}
 
@@ -445,6 +460,7 @@ func renderBody(results []result) string {
 	currency := ""
 	classes := map[string]int{}
 	prefixChangeReasons := map[string]int{}
+	bySource := map[string]sourceUsage{}
 	for _, r := range results {
 		if r.Skipped {
 			continue
@@ -478,6 +494,7 @@ func renderBody(results []result) string {
 		toolFails += r.ToolFailures
 		steps += r.Steps
 		wallAccountedMs += r.WallMs
+		accumulateSources(bySource, r.UsageBySource)
 		if r.Trajectory != nil {
 			modelRounds += r.Trajectory.ModelRounds
 		}
@@ -500,6 +517,7 @@ func renderBody(results []result) string {
 		pct(hit, hit+miss), comma(pTok+cTok), comma(pTok), comma(cTok),
 		comma(tools), comma(toolFails), compacts, currencySym(currency), cost)
 	b.WriteString(perSolvedLine(steps, tools, modelRounds, accountedSolved, wallAccountedMs))
+	b.WriteString(requestsBySourceLine(bySource))
 	b.WriteString(renderTimeAttribution(results))
 	if unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -143,9 +143,6 @@ func p95(values []int64) int64 {
 	}
 	sorted := append([]int64(nil), values...)
 	slices.Sort(sorted)
-	index := (len(sorted)*95 + 99) / 100
-	if index > len(sorted) {
-		index = len(sorted)
-	}
+	index := min((len(sorted)*95+99)/100, len(sorted))
 	return sorted[index-1]
 }

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 )
 
 // trajectorySummary is the harness-side digest of one run's trajectory file:
@@ -16,6 +17,14 @@ type trajectorySummary struct {
 	SpanMs  int64  `json:"span_ms"`
 	ToolMs  int64  `json:"tool_ms"`
 	ModelMs int64  `json:"model_ms"` // SpanMs − ToolMs, floored at zero
+	// Round decomposition: a round's gap runs from the turn start (or the
+	// batch's last tool_result) to the next top-level tool_dispatch; the
+	// final segment to the last record is the answer round.
+	ModelRounds     int   `json:"model_rounds"`
+	ModelGapTotalMs int64 `json:"model_gap_total_ms"`
+	ModelGapP95Ms   int64 `json:"model_gap_p95_ms"`
+	Retries         int   `json:"retries,omitempty"`
+	Compactions     int   `json:"compactions,omitempty"`
 }
 
 // trajectoryRecord is the subset of trajectory.Record the summary needs.
@@ -33,21 +42,27 @@ type trajectoryRecord struct {
 // renderTimeAttribution aggregates recorded runs into one report line; empty
 // when no run in the suite carried a trajectory.
 func renderTimeAttribution(results []result) string {
-	var toolMs, modelMs int64
-	runs := 0
+	var toolMs, modelMs, gapMs int64
+	runs, rounds := 0, 0
 	for _, r := range results {
 		if r.Trajectory != nil {
 			runs++
 			toolMs += r.Trajectory.ToolMs
 			modelMs += r.Trajectory.ModelMs
+			rounds += r.Trajectory.ModelRounds
+			gapMs += r.Trajectory.ModelGapTotalMs
 		}
 	}
 	if runs == 0 {
 		return ""
 	}
-	return fmt.Sprintf("**Time attribution** (%d recorded runs): **tools** %s (%s) · **model** %s (%s)\n\n",
+	line := fmt.Sprintf("**Time attribution** (%d recorded runs): **tools** %s (%s) · **model** %s (%s)",
 		runs, dur(toolMs), pct(int(toolMs), int(toolMs+modelMs)),
 		dur(modelMs), pct(int(modelMs), int(toolMs+modelMs)))
+	if rounds > 0 {
+		line += fmt.Sprintf(" · **model rounds** %d (avg gap %s)", rounds, dur(gapMs/int64(rounds)))
+	}
+	return line + "\n\n"
 }
 
 // summarizeTrajectory reads a run's JSONL trajectory. A truncated final line
@@ -61,6 +76,9 @@ func summarizeTrajectory(path string) (*trajectorySummary, error) {
 
 	s := &trajectorySummary{Path: path}
 	var firstTS, lastTS int64
+	var gaps []int64
+	var gapStart int64
+	inModel := false
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 1<<20), 16<<20)
 	for sc.Scan() {
@@ -71,23 +89,63 @@ func summarizeTrajectory(path string) (*trajectorySummary, error) {
 		s.Records++
 		if firstTS == 0 {
 			firstTS = rec.TS
+			gapStart = rec.TS
+			inModel = true
 		}
 		lastTS = rec.TS
-		if rec.Event == nil || rec.Event.Tool == nil {
+		if rec.Event == nil {
 			continue
 		}
-		// Subagent calls overlap the parent's wall clock; counting them would
-		// double-book the span.
-		if rec.Event.Kind == "tool_result" && rec.Event.Tool.ParentID == "" {
+		switch rec.Event.Kind {
+		case "retrying":
+			s.Retries++
+		case "compaction_started":
+			s.Compactions++
+		}
+		if rec.Event.Tool == nil || rec.Event.Tool.ParentID != "" {
+			// Subagent calls overlap the parent's wall clock; counting them
+			// would double-book the span and split the parent's rounds.
+			continue
+		}
+		switch rec.Event.Kind {
+		case "tool_dispatch":
+			if inModel {
+				gaps = append(gaps, rec.TS-gapStart)
+				inModel = false
+			}
+		case "tool_result":
 			s.ToolMs += rec.Event.Tool.DurationMs
+			gapStart = rec.TS
+			inModel = true
 		}
 	}
 	if err := sc.Err(); err != nil {
 		return nil, err
 	}
+	if inModel && lastTS > gapStart {
+		gaps = append(gaps, lastTS-gapStart) // final answer round
+	}
+	s.ModelRounds = len(gaps)
+	for _, g := range gaps {
+		s.ModelGapTotalMs += g
+	}
+	s.ModelGapP95Ms = p95(gaps)
 	s.SpanMs = lastTS - firstTS
 	if s.ModelMs = s.SpanMs - s.ToolMs; s.ModelMs < 0 {
 		s.ModelMs = 0
 	}
 	return s, nil
+}
+
+func p95(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	slices.Sort(sorted)
+	index := (len(sorted)*95 + 99) / 100
+	if index > len(sorted) {
+		index = len(sorted)
+	}
+	return sorted[index-1]
 }

--- a/cmd/e2ebench/trajectory_test.go
+++ b/cmd/e2ebench/trajectory_test.go
@@ -39,6 +39,44 @@ func TestSummarizeTrajectoryAttributesTimeAndSkipsTruncatedTail(t *testing.T) {
 	}
 }
 
+func TestSummarizeTrajectoryDecomposesModelRounds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rounds.trajectory.jsonl")
+	lines := []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":3000,"event":{"kind":"tool_dispatch","tool":{"name":"read_file","partial":true}}}`, // round 1 gap: 2000
+		`{"seq":3,"ts":3400,"event":{"kind":"tool_dispatch","tool":{"name":"read_file"}}}`,                // same batch: no new round
+		`{"seq":4,"ts":5000,"event":{"kind":"tool_result","tool":{"name":"read_file","durationMs":400}}}`,
+		`{"seq":5,"ts":5100,"event":{"kind":"tool_dispatch","tool":{"name":"grep","parentId":"task-1"}}}`, // subagent: ignored
+		`{"seq":6,"ts":5200,"event":{"kind":"tool_result","tool":{"name":"grep","durationMs":50,"parentId":"task-1"}}}`,
+		`{"seq":7,"ts":6000,"event":{"kind":"retrying"}}`,
+		`{"seq":8,"ts":9000,"event":{"kind":"tool_dispatch","tool":{"name":"bash"}}}`, // round 2 gap: 9000-5000=4000
+		`{"seq":9,"ts":9500,"event":{"kind":"tool_result","tool":{"name":"bash","durationMs":450}}}`,
+		`{"seq":10,"ts":12000,"event":{"kind":"turn_done"}}`, // final answer round gap: 2500
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.ModelRounds != 3 {
+		t.Errorf("model rounds = %d, want 3 (two tool rounds + final answer)", s.ModelRounds)
+	}
+	if s.ModelGapTotalMs != 8500 {
+		t.Errorf("model gap total = %d, want 8500", s.ModelGapTotalMs)
+	}
+	if s.ModelGapP95Ms != 4000 {
+		t.Errorf("model gap p95 = %d, want 4000", s.ModelGapP95Ms)
+	}
+	if s.Retries != 1 {
+		t.Errorf("retries = %d, want 1", s.Retries)
+	}
+	if s.ToolMs != 850 {
+		t.Errorf("tool ms = %d, want 850 (subagent excluded)", s.ToolMs)
+	}
+}
+
 func TestRenderBodyIncludesTimeAttributionOnlyForRecordedRuns(t *testing.T) {
 	plain := result{task: task{ID: "a"}, Passed: true}
 	if got := renderBody([]result{plain}); strings.Contains(got, "Time attribution") {

--- a/cmd/e2ebench/trajectory_test.go
+++ b/cmd/e2ebench/trajectory_test.go
@@ -77,6 +77,34 @@ func TestSummarizeTrajectoryDecomposesModelRounds(t *testing.T) {
 	}
 }
 
+func TestRenderBodyReportsPerSolvedEfficiency(t *testing.T) {
+	solved := result{task: task{ID: "a"}, Passed: true, WallMs: 60_000}
+	solved.Steps = 6
+	solved.ToolCalls = 9
+	solved.Trajectory = &trajectorySummary{ModelRounds: 5}
+	failed := result{task: task{ID: "b"}, WallMs: 40_000}
+	failed.Steps = 8
+	failed.ToolCalls = 3
+	failed.Trajectory = &trajectorySummary{ModelRounds: 7}
+
+	got := renderBody([]result{solved, failed})
+	for _, want := range []string{
+		"**Per solved task:**",
+		"**model requests** 14.0", // failures' spend charged to the solve
+		"tool calls 12.0",
+		"wall 1m40s",
+		"model rounds 12.0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("per-solved line missing %q:\n%s", want, got)
+		}
+	}
+
+	if got := renderBody([]result{failed}); strings.Contains(got, "Per solved task") {
+		t.Fatalf("no solves must mean no per-solved line:\n%s", got)
+	}
+}
+
 func TestRenderBodyIncludesTimeAttributionOnlyForRecordedRuns(t *testing.T) {
 	plain := result{task: task{ID: "a"}, Passed: true}
 	if got := renderBody([]result{plain}); strings.Contains(got, "Time attribution") {


### PR DESCRIPTION
Closes the measurement gap in the agent-latency equation: T_total ≈ T_planner + ΣT_model + ΣT_tool-critical-path + T_retry + T_compaction. For a coding agent the dominant term is usually **how many sequential model round-trips a task takes**, not local overhead — but the trajectory digest only reported tools vs model in aggregate.

## Changes

`summarizeTrajectory` now decomposes the model side:

- **`model_rounds`** — one round per gap from the turn start (or a batch's last top-level `tool_result`) to the next top-level `tool_dispatch` (the first, possibly partial, dispatch marks when thinking ends and the call starts streaming), plus the final answer segment. Same-batch dispatches don't split rounds; subagent calls (`parentId`) stay excluded so parent rounds aren't fragmented.
- **`model_gap_total_ms` / `model_gap_p95_ms`** — where ΣT_model actually goes, per round.
- **`retries` / `compactions`** — the T_retry / T_compaction terms, counted off the same stream.
- The markdown report's time-attribution line gains `**model rounds** N (avg gap X)`.

With this, a recorded suite answers directly: how many rounds did each solve take, how expensive is a round, and how much of the total was retry/compaction tax — the denominators needed before attacking the known round-trip taxes (serial `complete_step` sign-offs, final-readiness blocks, missing-reasoning retries, dependency-barrier redo rounds).

## Tests

`TestSummarizeTrajectoryDecomposesModelRounds`: two tool rounds + final answer from a fixture with a same-batch second dispatch (no round split), an interleaved subagent call (ignored), and a retry event; exact totals and P95 asserted.

Cache-impact: none - harness-side offline analysis of recorded trajectories
Cache-guard: go test ./cmd/e2ebench/ -run TestSummarizeTrajectory
Documentation-impact: none - report format addition on an opt-in benchmark flag documented at the flag level already