### PR TITLE
fix(boot): coalesce the sink agents actually emit into

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -257,12 +257,11 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		sink = stats.NewRecorder(sink, config.StatsDir(), source)
 	}
 	// Goal token-budget accounting: the controller detects this tee and
-	// attributes billable usage events to the active goal turn's recorder, so
-	// executor/planner/subagent/compaction/classifier/router/reviewer/evaluator
-	// calls under one Goal scope accumulate into its observational token total.
-	// The tee must
-	// sit on the shared sink the agents emit into.
-	sink = control.NewGoalUsageTee(sink)
+	// attributes billable usage to the active goal turn's recorder. Both the
+	// tee and the delta coalescer must ride the shared sink agents emit into
+	// directly — wrapping only the controller's reference would leave the
+	// executor's per-chunk Text/Reasoning stream uncoalesced.
+	sink = control.NewGoalUsageTee(event.Coalesce(sink, event.DefaultStreamDeltaWindow))
 
 	// Extension preflight (stages 5b/7): start the installed, enabled v1 runtime
 	// packages ONCE, here, before model resolution, so plugin-namespaced refs

--- a/internal/boot/coalesce_wiring_test.go
+++ b/internal/boot/coalesce_wiring_test.go
@@ -1,0 +1,93 @@
+package boot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type coalesceWiringProvider struct{ deltas int }
+
+func (p *coalesceWiringProvider) Name() string { return "boot-coalesce-test" }
+
+func (p *coalesceWiringProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, p.deltas+1)
+	for i := range p.deltas {
+		ch <- provider.Chunk{Type: provider.ChunkText, Text: fmt.Sprintf("w%d ", i)}
+	}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+type coalesceRecordSink struct {
+	mu     sync.Mutex
+	texts  []string
+	events int
+}
+
+func (s *coalesceRecordSink) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e.Kind == event.Text {
+		s.events++
+		s.texts = append(s.texts, e.Text)
+	}
+}
+
+// TestBuildCoalescesAgentStreamDeltas pins the wiring, not the coalescer: the
+// executor emits into the shared boot sink directly, so coalescing must wrap
+// that sink — wrapping only the controller's reference leaves the per-chunk
+// stream untouched (the regression this test exists for).
+func TestBuildCoalescesAgentStreamDeltas(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	const deltas = 40
+	provider.Register("boot-coalesce-test", func(provider.Config) (provider.Provider, error) {
+		return &coalesceWiringProvider{deltas: deltas}, nil
+	})
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-coalesce-test"
+model = "x"
+`)
+
+	sink := &coalesceRecordSink{}
+	ctrl, err := Build(context.Background(), Options{Sink: sink})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "stream"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	sink.mu.Lock()
+	events := sink.events
+	joined := strings.Join(sink.texts, "")
+	sink.mu.Unlock()
+
+	var want strings.Builder
+	for i := range deltas {
+		fmt.Fprintf(&want, "w%d ", i)
+	}
+	if joined != want.String() {
+		t.Fatalf("concatenated deltas = %q, want %q", joined, want.String())
+	}
+	if events >= deltas/2 {
+		t.Fatalf("frontend sink saw %d text events for %d provider chunks — agent stream is not coalesced", events, deltas)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -544,7 +544,6 @@ func New(opts Options) *Controller {
 		usageTee = NewGoalUsageTee(sink).(*goalUsageTee)
 		sink = usageTee
 	}
-	sink = event.Coalesce(sink, event.DefaultStreamDeltaWindow)
 	pluginCtx := opts.PluginCtx
 	if pluginCtx == nil {
 		pluginCtx = context.Background()


### PR DESCRIPTION
Live trajectory recording exposed that #7889 shipped inert for the hot path: the coalescer wrapped the **controller's** sink reference, but `boot.go` hands the shared sink to the executor **directly** — per-token Text/Reasoning events were reaching the frontend untouched (verified: a real DeepSeek run recorded one event per token, same-millisecond clusters and all).

## Fix

The wrap moves into boot's shared sink assembly — the one sink every agent emitter (executor, planner, subagents, jobs) actually flows through — placed below the `goalUsageTee` so the controller still detects its tee (no double-tee). The controller-level wrap is removed.

## Verification

- `TestBuildCoalescesAgentStreamDeltas` pins the **wiring**, not the coalescer: a scripted provider bursts 40 text chunks through `boot.Build` + `ctrl.Run`; the frontend sink must see them merged. It **fails against the shipped placement** (verified by stashing the boot change) and passes with the fix.
- Live re-verification with a real provider: the same prompt that previously recorded per-token trajectory events now records merged reasoning deltas.
- `internal/boot`, `internal/control`, `internal/event` suites pass.

Cache-impact: none - sink-side event shaping after the agent has accumulated full text; provider requests and the prompt prefix are untouched
Cache-guard: go test ./internal/boot/ -run TestBuildCoalescesAgentStreamDeltas; prefix-shape guards unaffected
Documentation-impact: none - restores the behavior #7889 documented; no user-facing contract change
System-prompt-review: sink wiring only, no prompt-affecting surface — reviewer: esengine