### PR TITLE
feat(remote): support SSH ProxyCommand

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -313,8 +313,11 @@ reasonix remote fs ls gpu-box:'~/projects/app'
 
 Hosts with `use_ssh_config` enabled resolve the final effective configuration
 through the local OpenSSH `ssh -G`, including `Include`, wildcard `Host`,
-`Match` (including `Match exec`), repeated `IdentityFile`, `ProxyJump`, and
-`IdentitiesOnly`. Import stores the original alias instead of a stale snapshot.
+`Match` (including `Match exec`), repeated `IdentityFile`, `ProxyJump`,
+`ProxyCommand`, and `IdentitiesOnly`. `ProxyCommand` supplies the first
+transport hop through its standard input/output and supports OpenSSH's `%%`,
+`%h`, `%n`, `%p`, and `%r` substitutions. Import stores the original alias
+instead of a stale snapshot.
 
 `connect` is a foreground supervisor (like `ssh -N` plus the serve bootstrap):
 it keeps the tunnel and configured forwards alive, auto-reconnects with

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -276,8 +276,10 @@ reasonix remote fs ls gpu-box:'~/projects/app'
 ```
 
 启用 `use_ssh_config` 的主机会通过本机 OpenSSH `ssh -G` 获取最终有效配置，因此支持
-`Include`、通配 `Host`、`Match`（包括 `Match exec`）、多个 `IdentityFile`、`ProxyJump` 和
-`IdentitiesOnly`。导入时只保存原始别名，不复制一份容易过期的解析结果。
+`Include`、通配 `Host`、`Match`（包括 `Match exec`）、多个 `IdentityFile`、`ProxyJump`、
+`ProxyCommand` 和 `IdentitiesOnly`。`ProxyCommand` 通过标准输入/输出提供第一段传输，并支持
+OpenSSH 的 `%%`、`%h`、`%n`、`%p` 和 `%r` 替换。导入时只保存原始别名，不复制一份容易过期的
+解析结果。
 
 `connect` 是前台守护(相当于 `ssh -N` 加上 serve 引导):它保持隧道与已配置的转发存活,断线时
 以指数退避自动重连,并在重连后重新挂载转发。Ctrl-C 只断开本地一侧 —— 远端 serve 继续运行,

--- a/internal/remote/dial.go
+++ b/internal/remote/dial.go
@@ -61,15 +61,18 @@ func dialSSH(ctx context.Context, cfg dialConfig) (*ssh.Client, []*ssh.Client, e
 	}
 
 	var hops []*ssh.Client
-	// dialThrough dials addr using either the base transport (first hop) or the
+	// dialThrough dials a host using either the base transport (first hop) or the
 	// previous SSH hop's context-aware Dial.
-	dialThrough := func(prev *ssh.Client, addr string) (net.Conn, error) {
+	dialThrough := func(prev *ssh.Client, host ResolvedHost) (net.Conn, error) {
 		dctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		if prev == nil {
-			return base.DialContext(dctx, "tcp", addr)
+			if host.ProxyCommand != "" {
+				return dialProxyCommand(dctx, host)
+			}
+			return base.DialContext(dctx, "tcp", host.Addr())
 		}
-		return prev.DialContext(dctx, "tcp", addr)
+		return prev.DialContext(dctx, "tcp", host.Addr())
 	}
 
 	var prev *ssh.Client
@@ -80,7 +83,7 @@ func dialSSH(ctx context.Context, cfg dialConfig) (*ssh.Client, []*ssh.Client, e
 			closeAll(hops)
 			return nil, nil, fmt.Errorf("proxy jump %q: %w", jump, err)
 		}
-		conn, derr := dialThrough(prev, hop.Addr())
+		conn, derr := dialThrough(prev, hop)
 		if derr != nil {
 			closeAll(hops)
 			return nil, nil, fmt.Errorf("proxy jump %d (%s): %w", i+1, hop.Label(), derr)
@@ -96,7 +99,7 @@ func dialSSH(ctx context.Context, cfg dialConfig) (*ssh.Client, []*ssh.Client, e
 		prev = client
 	}
 
-	conn, err := dialThrough(prev, cfg.host.Addr())
+	conn, err := dialThrough(prev, cfg.host)
 	if err != nil {
 		closeAll(hops)
 		return nil, nil, fmt.Errorf("dial %s: %w", cfg.host.Label(), err)
@@ -161,8 +164,9 @@ func newSSHClient(ctx context.Context, conn net.Conn, host ResolvedHost, auth *A
 	<-watchDone
 	cancel()
 	if err != nil {
+		err = proxyCommandHandshakeError(conn, classifyDialError(err))
 		conn.Close()
-		return nil, classifyDialError(err)
+		return nil, err
 	}
 	_ = conn.SetDeadline(time.Time{})
 	return ssh.NewClient(c, chans, reqs), nil

--- a/internal/remote/host.go
+++ b/internal/remote/host.go
@@ -25,6 +25,8 @@ type ResolvedHost struct {
 	PassphraseEnv    string   // credential env var name for the key passphrase
 	PasswordEnv      string   // credential env var name for password auth
 	ProxyJump        []string // resolved jump chain, in dial order
+	ProxyCommand     string   // effective ssh_config command for the first transport hop
+	SSHConfigAlias   string   // original ssh_config host token used by ProxyCommand %n
 	Workspace        string   // default remote workspace directory
 	ServeInstall     string   // auto|npm|upload|never
 	Forwards         []config.RemoteForwardEntry
@@ -210,6 +212,10 @@ func applySSHConfig(r *ResolvedHost, alias string, sshCfg *SSHConfigSource) erro
 		if j := effective.ProxyJump; j != "" {
 			r.ProxyJump = splitJumpChain(j)
 		}
+	}
+	if effective.ProxyCommand != "" {
+		r.ProxyCommand = effective.ProxyCommand
+		r.SSHConfigAlias = alias
 	}
 	r.IdentitiesOnly = effective.IdentitiesOnly
 	return nil

--- a/internal/remote/proxycommand.go
+++ b/internal/remote/proxycommand.go
@@ -1,0 +1,250 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"reasonix/internal/proc"
+)
+
+const proxyCommandStderrLimit = 8 * 1024
+
+type proxyCommandConn struct {
+	cmd        *exec.Cmd
+	job        uintptr
+	stdin      io.WriteCloser
+	stdout     io.ReadCloser
+	stderr     *proxyCommandStderr
+	remoteAddr net.Addr
+	done       chan struct{}
+
+	closeOnce sync.Once
+	jobOnce   sync.Once
+	waitMu    sync.Mutex
+	waitErr   error
+}
+
+func dialProxyCommand(ctx context.Context, host ResolvedHost) (net.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	command, err := expandProxyCommand(host.ProxyCommand, host)
+	if err != nil {
+		return nil, err
+	}
+	cmd := newProxyCommandProcess(command)
+	proc.HideWindow(cmd)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ProxyCommand stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("ProxyCommand stdout: %w", err)
+	}
+	stderr := &proxyCommandStderr{}
+	cmd.Stderr = stderr
+	job, err := proc.StartTracked(cmd)
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("start ProxyCommand: %w", err)
+	}
+	conn := &proxyCommandConn{
+		cmd:        cmd,
+		job:        job,
+		stdin:      stdin,
+		stdout:     stdout,
+		stderr:     stderr,
+		remoteAddr: proxyCommandAddr(host.Addr()),
+		done:       make(chan struct{}),
+	}
+	go conn.wait()
+	if err := ctx.Err(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func expandProxyCommand(command string, host ResolvedHost) (string, error) {
+	alias := host.SSHConfigAlias
+	if alias == "" {
+		alias = host.Name
+	}
+	tokens := map[byte]string{
+		'%': "%",
+		'h': host.HostName,
+		'n': alias,
+		'p': strconv.Itoa(host.Port),
+		'r': host.User,
+	}
+	var expanded strings.Builder
+	for i := 0; i < len(command); i++ {
+		if command[i] != '%' {
+			expanded.WriteByte(command[i])
+			continue
+		}
+		i++
+		if i == len(command) {
+			return "", fmt.Errorf("ProxyCommand ends with incomplete token")
+		}
+		value, ok := tokens[command[i]]
+		if !ok {
+			return "", fmt.Errorf("ProxyCommand contains unsupported token %%%c", command[i])
+		}
+		if !validProxyCommandToken(command[i], value) {
+			return "", fmt.Errorf("ProxyCommand token %%%c contains invalid characters", command[i])
+		}
+		expanded.WriteString(value)
+	}
+	return expanded.String(), nil
+}
+
+func validProxyCommandToken(token byte, value string) bool {
+	switch token {
+	case 'h', 'n':
+		return validProxyCommandHostname(value)
+	case 'r':
+		return validProxyCommandUser(value)
+	default:
+		return true
+	}
+}
+
+// These checks mirror OpenSSH's guards for values expanded into shell commands.
+func validProxyCommandHostname(value string) bool {
+	if strings.HasPrefix(value, "-") {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || strings.ContainsRune("'`\"$\\;&<>|(){},", r) {
+			return false
+		}
+	}
+	return true
+}
+
+func validProxyCommandUser(value string) bool {
+	if strings.HasPrefix(value, "-") {
+		return false
+	}
+	runes := []rune(value)
+	for i, r := range runes {
+		if unicode.IsControl(r) || strings.ContainsRune("'`\";&<>|(){}", r) {
+			return false
+		}
+		if unicode.IsSpace(r) && i+1 < len(runes) && runes[i+1] == '-' {
+			return false
+		}
+	}
+	return len(runes) == 0 || runes[len(runes)-1] != '\\'
+}
+
+func (c *proxyCommandConn) Read(p []byte) (int, error)  { return c.stdout.Read(p) }
+func (c *proxyCommandConn) Write(p []byte) (int, error) { return c.stdin.Write(p) }
+
+func (c *proxyCommandConn) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.stdin.Close()
+		_ = c.stdout.Close()
+		select {
+		case <-c.done:
+			return
+		default:
+			proc.KillTracked(c.cmd, c.job)
+			c.finishJob()
+		}
+		select {
+		case <-c.done:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}
+
+func (c *proxyCommandConn) LocalAddr() net.Addr  { return proxyCommandAddr("proxy-command") }
+func (c *proxyCommandConn) RemoteAddr() net.Addr { return c.remoteAddr }
+
+func (c *proxyCommandConn) SetDeadline(time.Time) error      { return os.ErrNoDeadline }
+func (c *proxyCommandConn) SetReadDeadline(time.Time) error  { return os.ErrNoDeadline }
+func (c *proxyCommandConn) SetWriteDeadline(time.Time) error { return os.ErrNoDeadline }
+
+func (c *proxyCommandConn) wait() {
+	err := c.cmd.Wait()
+	c.waitMu.Lock()
+	c.waitErr = err
+	c.waitMu.Unlock()
+	c.finishJob()
+	close(c.done)
+}
+
+func (c *proxyCommandConn) finishJob() {
+	c.jobOnce.Do(func() { proc.FinishTracked(c.job) })
+}
+
+func (c *proxyCommandConn) failureDetail() string {
+	stderr := strings.TrimSpace(c.stderr.String())
+	select {
+	case <-c.done:
+		c.waitMu.Lock()
+		err := c.waitErr
+		c.waitMu.Unlock()
+		if stderr != "" {
+			return stderr
+		}
+		if err != nil {
+			return err.Error()
+		}
+		return "process exited before the SSH handshake completed"
+	default:
+		return stderr
+	}
+}
+
+func proxyCommandHandshakeError(conn net.Conn, err error) error {
+	proxy, ok := conn.(*proxyCommandConn)
+	if !ok {
+		return err
+	}
+	if detail := proxy.failureDetail(); detail != "" {
+		return fmt.Errorf("%w: ProxyCommand: %s", err, detail)
+	}
+	return err
+}
+
+type proxyCommandAddr string
+
+func (a proxyCommandAddr) Network() string { return "proxy-command" }
+func (a proxyCommandAddr) String() string  { return string(a) }
+
+type proxyCommandStderr struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (b *proxyCommandStderr) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	b.data = append(b.data, p...)
+	if len(b.data) > proxyCommandStderrLimit {
+		b.data = append([]byte(nil), b.data[len(b.data)-proxyCommandStderrLimit:]...)
+	}
+	b.mu.Unlock()
+	return len(p), nil
+}
+
+func (b *proxyCommandStderr) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.data)
+}

--- a/internal/remote/proxycommand_other.go
+++ b/internal/remote/proxycommand_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package remote
+
+import "os/exec"
+
+func newProxyCommandProcess(command string) *exec.Cmd {
+	return exec.Command("sh", "-c", "exec "+command)
+}

--- a/internal/remote/proxycommand_test.go
+++ b/internal/remote/proxycommand_test.go
@@ -1,0 +1,222 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/remote/sshtest"
+)
+
+const proxyCommandHelperEnv = "REASONIX_PROXY_COMMAND_HELPER"
+
+func TestExpandProxyCommand(t *testing.T) {
+	host := ResolvedHost{
+		Name: "display", HostName: "resolved.example", Port: 2207, User: "dev",
+		SSHConfigAlias: "original-alias",
+	}
+	got, err := expandProxyCommand("proxy --host %h --original %n --port %p --user %r --percent %%", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "proxy --host resolved.example --original original-alias --port 2207 --user dev --percent %"
+	if got != want {
+		t.Fatalf("expanded ProxyCommand = %q, want %q", got, want)
+	}
+	for _, command := range []string{"proxy %x", "proxy %"} {
+		if _, err := expandProxyCommand(command, host); err == nil {
+			t.Fatalf("expandProxyCommand(%q) accepted an invalid token", command)
+		}
+	}
+}
+
+func TestExpandProxyCommandRejectsUnsafeTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		host    ResolvedHost
+	}{
+		{name: "hostname", command: "proxy %h", host: ResolvedHost{HostName: "host;calc", Port: 22, User: "dev", SSHConfigAlias: "alias"}},
+		{name: "original host", command: "proxy %n", host: ResolvedHost{HostName: "host", Port: 22, User: "dev", SSHConfigAlias: "alias|calc"}},
+		{name: "user", command: "proxy %r", host: ResolvedHost{HostName: "host", Port: 22, User: "dev&calc", SSHConfigAlias: "alias"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := expandProxyCommand(tt.command, tt.host); err == nil {
+				t.Fatalf("expandProxyCommand(%q) accepted unsafe host %+v", tt.command, tt.host)
+			}
+		})
+	}
+}
+
+func TestExpandProxyCommandAcceptsOpenSSHHostAndUserForms(t *testing.T) {
+	host := ResolvedHost{
+		Name: "display", HostName: "fe80::1%12", Port: 22, User: `DOMAIN\dev user`,
+		SSHConfigAlias: "host.example",
+	}
+	got, err := expandProxyCommand("proxy %h %n %p %r", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `proxy fe80::1%12 host.example 22 DOMAIN\dev user` {
+		t.Fatalf("expanded ProxyCommand = %q", got)
+	}
+}
+
+func TestProxyCommandConnectsSSHTransport(t *testing.T) {
+	srv := sshtest.Start(t, sshtest.Options{Password: "hunter2"})
+	t.Setenv(proxyCommandHelperEnv, "1")
+	host := ResolvedHost{
+		Name: "friendly", HostName: "proxy-target.invalid", Port: 2207, User: "test",
+		SSHConfigAlias: "saved-alias",
+		ProxyCommand:   proxyCommandHelperCommand("bridge", srv.Addr) + " %h %n %p %r %%",
+	}
+	client, err := New(Options{
+		Host: host,
+		Auth: AuthOptions{DisableAgent: true, Password: func() (string, error) {
+			return "hunter2", nil
+		}},
+		HostKeys: managedOnlyPolicy(t, true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start through ProxyCommand: %v", err)
+	}
+	defer client.Close()
+	result, err := client.Exec(ctx, "echo proxy-command")
+	if err != nil {
+		t.Fatalf("Exec through ProxyCommand: %v", err)
+	}
+	if strings.TrimSpace(string(result.Stdout)) != "echo proxy-command" {
+		t.Fatalf("Exec stdout = %q", result.Stdout)
+	}
+}
+
+func TestProxyCommandStderrIsReported(t *testing.T) {
+	t.Setenv(proxyCommandHelperEnv, "1")
+	host := ResolvedHost{
+		Name: "broken", HostName: "proxy-target.invalid", Port: 22, User: "test",
+		ProxyCommand: proxyCommandHelperCommand("fail"),
+	}
+	client, err := New(Options{
+		Host: host, Auth: AuthOptions{DisableAgent: true}, HostKeys: managedOnlyPolicy(t, true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = client.Start(ctx)
+	if err == nil || !strings.Contains(err.Error(), "proxy helper failed") {
+		t.Fatalf("ProxyCommand failure = %v", err)
+	}
+}
+
+func TestProxyCommandStderrDoesNotReclassifyTransportFailure(t *testing.T) {
+	t.Setenv(proxyCommandHelperEnv, "1")
+	host := ResolvedHost{
+		Name: "broken", HostName: "proxy-target.invalid", Port: 22, User: "test",
+		ProxyCommand: proxyCommandHelperCommand("permission-denied"),
+	}
+	client, err := New(Options{
+		Host: host, Auth: AuthOptions{DisableAgent: true}, HostKeys: managedOnlyPolicy(t, true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = client.Start(ctx)
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("ProxyCommand failure = %v", err)
+	}
+	if errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("ProxyCommand transport failure was classified as SSH authentication: %v", err)
+	}
+}
+
+func TestProxyCommandDetailPreservesAuthenticationClassification(t *testing.T) {
+	proxy := &proxyCommandConn{stderr: &proxyCommandStderr{}}
+	_, _ = proxy.stderr.Write([]byte("proxy diagnostic"))
+	authErr := classifyDialError(errors.New("ssh: unable to authenticate"))
+	err := proxyCommandHandshakeError(proxy, authErr)
+	if !errors.Is(err, ErrAuthFailed) {
+		t.Fatalf("wrapped authentication failure = %v, want ErrAuthFailed", err)
+	}
+}
+
+func TestProxyCommandHelperProcess(t *testing.T) {
+	if os.Getenv(proxyCommandHelperEnv) != "1" {
+		return
+	}
+	runProxyCommandHelper()
+}
+
+func proxyCommandHelperCommand(args ...string) string {
+	parts := []string{shellQuoteProxyCommandArg(os.Args[0]), "-test.run=^TestProxyCommandHelperProcess$"}
+	parts = append(parts, "--")
+	for _, arg := range args {
+		parts = append(parts, shellQuoteProxyCommandArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuoteProxyCommandArg(value string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func runProxyCommandHelper() {
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "proxy helper missing mode")
+		os.Exit(2)
+	}
+	args = args[1:]
+	switch args[0] {
+	case "fail":
+		fmt.Fprintln(os.Stderr, "proxy helper failed")
+		os.Exit(42)
+	case "permission-denied":
+		fmt.Fprintln(os.Stderr, "permission denied")
+		os.Exit(43)
+	case "bridge":
+		if len(args) != 7 || args[2] != "proxy-target.invalid" || args[3] != "saved-alias" || args[4] != "2207" || args[5] != "test" || args[6] != "%" {
+			fmt.Fprintf(os.Stderr, "unexpected proxy helper args: %q\n", args)
+			os.Exit(2)
+		}
+		conn, err := net.Dial("tcp", args[1])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(3)
+		}
+		go func() {
+			_, _ = io.Copy(conn, os.Stdin)
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.CloseWrite()
+			}
+		}()
+		_, _ = io.Copy(os.Stdout, conn)
+		_ = conn.Close()
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown proxy helper mode: %s\n", args[0])
+		os.Exit(2)
+	}
+}

--- a/internal/remote/proxycommand_windows.go
+++ b/internal/remote/proxycommand_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package remote
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func newProxyCommandProcess(command string) *exec.Cmd {
+	cmd := exec.Command("cmd.exe")
+	cmd.Args = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: `cmd.exe /d /s /c "` + command + `"`}
+	return cmd
+}

--- a/internal/remote/sshconfig.go
+++ b/internal/remote/sshconfig.go
@@ -41,6 +41,7 @@ type EffectiveSSHConfig struct {
 	IdentityFiles    []string
 	IdentityFileNone bool
 	ProxyJump        string
+	ProxyCommand     string
 	IdentitiesOnly   bool
 }
 
@@ -225,6 +226,10 @@ func parseOpenSSHEffectiveConfig(output []byte, alias string) (EffectiveSSHConfi
 			if !strings.EqualFold(value, "none") {
 				effective.ProxyJump = value
 			}
+		case "proxycommand":
+			if !strings.EqualFold(value, "none") {
+				effective.ProxyCommand = value
+			}
 		case "identitiesonly":
 			effective.IdentitiesOnly = strings.EqualFold(value, "yes")
 		}
@@ -267,6 +272,8 @@ func (s *SSHConfigSource) parserEffective(alias string) EffectiveSSHConfig {
 			port = parsed
 		}
 	}
+	// ProxyCommand is intentionally omitted here: only ssh -G can resolve its
+	// first-set precedence against ProxyJump accurately enough to execute it.
 	return EffectiveSSHConfig{
 		HostName: hostName, User: s.get(alias, "User"), Port: port,
 		IdentityFiles: identities, IdentityFileNone: identityFileNone, ProxyJump: s.get(alias, "ProxyJump"),

--- a/internal/remote/sshconfig_test.go
+++ b/internal/remote/sshconfig_test.go
@@ -48,11 +48,11 @@ func TestEffectiveSSHConfigUsesOpenSSHOutputAndKeepsAllIdentities(t *testing.T) 
 		if path != src.Path() || alias != "gpu" {
 			t.Fatalf("ssh -G request = path %q alias %q", path, alias)
 		}
-		return []byte("hostname resolved.example\nuser effective-user\nport 2207\nidentityfile ~/.ssh/first\nidentityfile ~/.ssh/second\nproxyjump jump-a,jump-b\nidentitiesonly yes\n"), nil
+		return []byte("hostname resolved.example\nuser effective-user\nport 2207\nidentityfile ~/.ssh/first\nidentityfile ~/.ssh/second\nproxyjump jump-a,jump-b\nproxycommand cloudflared access ssh --hostname %h\nidentitiesonly yes\n"), nil
 	}
 
 	got := src.Effective("gpu")
-	if got.HostName != "resolved.example" || got.User != "effective-user" || got.Port != 2207 || got.ProxyJump != "jump-a,jump-b" || !got.IdentitiesOnly {
+	if got.HostName != "resolved.example" || got.User != "effective-user" || got.Port != 2207 || got.ProxyJump != "jump-a,jump-b" || got.ProxyCommand != "cloudflared access ssh --hostname %h" || !got.IdentitiesOnly {
 		t.Fatalf("effective config = %+v", got)
 	}
 	home, err := os.UserHomeDir()
@@ -238,6 +238,21 @@ func TestEmbeddedSSHConfigPreservesIdentityFileNone(t *testing.T) {
 	}
 }
 
+func TestEmbeddedSSHConfigDoesNotResolveProxyCommand(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte("Host tunnel-box\n  HostName tunnel.example\n  ProxyCommand cloudflared access ssh --hostname %h\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src, err := LoadSSHConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src.resolveOpenSSH = nil
+	if got := src.Effective("tunnel-box").ProxyCommand; got != "" {
+		t.Fatalf("embedded fallback resolved ProxyCommand = %q", got)
+	}
+}
+
 func TestEffectiveSSHConfigPropagatesInstalledOpenSSHErrors(t *testing.T) {
 	src, err := LoadSSHConfig(writeSampleConfig(t))
 	if err != nil {
@@ -358,6 +373,27 @@ func TestResolveHostLayersSSHConfig(t *testing.T) {
 	}
 	if h.Port != 2222 {
 		t.Errorf("Port not taken from ssh_config: %d", h.Port)
+	}
+}
+
+func TestResolveHostKeepsProxyCommandLookupAlias(t *testing.T) {
+	src, err := LoadSSHConfig(writeSampleConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src.resolveOpenSSH = func(context.Context, string, string) ([]byte, error) {
+		return []byte("hostname tunnel.example\nuser dev\nport 22\nproxycommand cloudflared access ssh --hostname %h --original %n\n"), nil
+	}
+	cfg := config.Default()
+	if err := cfg.UpsertRemoteHost(config.RemoteHostEntry{Name: "friendly", Host: "gpu", UseSSHConfig: true}); err != nil {
+		t.Fatal(err)
+	}
+	host, err := ResolveHost(cfg, "friendly", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if host.ProxyCommand == "" || host.SSHConfigAlias != "gpu" {
+		t.Fatalf("resolved ProxyCommand host = %+v", host)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve effective OpenSSH `ProxyCommand` entries through `ssh -G` for Remote SSH hosts
- run proxy commands as managed stdio transports with OpenSSH token expansion and shell-injection guards
- preserve direct, network-proxy, `ProxyJump`, authentication, and known-host behavior while tracking proxy process trees
- document the supported `%%`, `%h`, `%n`, `%p`, and `%r` substitutions in both guides

## Issues

None.

## Verification

- `go test ./internal/remote/...`
- ProxyCommand-focused Remote SSH tests repeated 5 times
- `go vet ./benchmarks/... ./cmd/... ./internal/... ./tools/...`
- `go test . -run '(Remote|SSH)'` in `desktop/`
- Linux amd64 cross-compile of the `internal/remote` tests
- `go run ./tools/repolint` on a clean tracked-source snapshot
- documentation-impact and cache-impact PR gates
- frontend production build, typecheck, lint, CSS checks, and bundle budgets
- Wails v2.12.0 Windows amd64 production build
- manual end-to-end connection through an external ProxyCommand transport

## Documentation impact

Documentation-impact: updated - documented ProxyCommand transport behavior and supported OpenSSH token substitutions in both guides.

## Cache impact

Cache-impact: none - the change only affects Remote SSH host resolution and transport.
Cache-guard: go test ./internal/remote/... plus a manual end-to-end ProxyCommand connection test.