### PR TITLE
fix(agent): dynamic output budget + prompt-estimate calibration for DeepSeek shared window

### DIFF
--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -1,10 +1,12 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	"reasonix/internal/ablation"
 	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
 )
 
 func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
@@ -41,3 +43,47 @@ func TestCompactionAblationCollapsesTheCachePreservingDeferral(t *testing.T) {
 		t.Fatalf("ablated thresholds = %d/%d/%d, want all three at 50000", soft, snip, high)
 	}
 }
+
+func TestForceThresholdReservesOutputBudget(t *testing.T) {
+	// 1M window, 0.9 ratio: naive force = 900K, but the 128K output budget
+	// leaves only 917K-8K input allowance. The force mark must shrink.
+	a := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.9, outputBudget: 131_072}
+	got := a.forceThreshold()
+	if want := 1_048_576 - 131_072 - 8192; got != want {
+		t.Fatalf("forceThreshold = %d, want %d (window minus output budget minus reserve)", got, want)
+	}
+	// A request at the threshold + output budget must fit inside the window.
+	if got+131_072 >= a.contextWindow {
+		t.Fatalf("threshold %d + budget %d >= window %d: request would be rejected", got, 131_072, a.contextWindow)
+	}
+	// Without a provider budget the legacy ratio stands.
+	b := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.9}
+	if got := b.forceThreshold(); got != 943_718 {
+		t.Fatalf("no-budget forceThreshold = %d, want 943718", got)
+	}
+	// A small budget that stays under the ratio must not be overridden.
+	c := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.5, outputBudget: 131_072}
+	if got := c.forceThreshold(); got != 524_288 {
+		t.Fatalf("small-budget forceThreshold = %d, want 524288", got)
+	}
+}
+
+func TestOutputBudgetOfNilAndUnawareProviders(t *testing.T) {
+	if got := outputBudgetOf(nil); got != 0 {
+		t.Fatalf("outputBudgetOf(nil) = %d, want 0", got)
+	}
+	// A provider that does not implement OutputBudgetProvider yields 0.
+	np := &budgetlessProvider{}
+	if got := outputBudgetOf(np); got != 0 {
+		t.Fatalf("outputBudgetOf(budgetless) = %d, want 0", got)
+	}
+}
+
+type budgetlessProvider struct{}
+
+func (*budgetlessProvider) Name() string { return "budgetless" }
+func (*budgetlessProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	return nil, nil
+}
+
+var _ provider.Provider = (*budgetlessProvider)(nil)

--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -46,8 +46,9 @@ func TestCompactionAblationCollapsesTheCachePreservingDeferral(t *testing.T) {
 
 func TestForceThresholdReservesOutputBudget(t *testing.T) {
 	// 1M window, 0.9 ratio: naive force = 900K, but the 128K output budget
-	// leaves only 917K-8K input allowance. The force mark must shrink.
-	a := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.9, outputBudget: 131_072}
+	// leaves only 917K-8K input allowance. The force mark must shrink — only
+	// for shared-window providers (DeepSeek).
+	a := &Agent{prov: &sharedWindowBudgetProvider{budget: 131_072}, contextWindow: 1_048_576, compactForceRatio: 0.9, outputBudget: 131_072}
 	got := a.forceThreshold()
 	if want := 1_048_576 - 131_072 - 8192; got != want {
 		t.Fatalf("forceThreshold = %d, want %d (window minus output budget minus reserve)", got, want)
@@ -56,13 +57,18 @@ func TestForceThresholdReservesOutputBudget(t *testing.T) {
 	if got+131_072 >= a.contextWindow {
 		t.Fatalf("threshold %d + budget %d >= window %d: request would be rejected", got, 131_072, a.contextWindow)
 	}
+	// Independent-ceiling vendors keep the plain ratio mark (no budget reserve).
+	indep := &Agent{prov: &independentBudgetProvider{budget: 131_072}, contextWindow: 1_048_576, compactForceRatio: 0.9, outputBudget: 131_072}
+	if got := indep.forceThreshold(); got != 943_718 {
+		t.Fatalf("independent-window forceThreshold = %d, want 943718 (ratio mark)", got)
+	}
 	// Without a provider budget the legacy ratio stands.
 	b := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.9}
 	if got := b.forceThreshold(); got != 943_718 {
 		t.Fatalf("no-budget forceThreshold = %d, want 943718", got)
 	}
 	// A small budget that stays under the ratio must not be overridden.
-	c := &Agent{contextWindow: 1_048_576, compactForceRatio: 0.5, outputBudget: 131_072}
+	c := &Agent{prov: &sharedWindowBudgetProvider{budget: 131_072}, contextWindow: 1_048_576, compactForceRatio: 0.5, outputBudget: 131_072}
 	if got := c.forceThreshold(); got != 524_288 {
 		t.Fatalf("small-budget forceThreshold = %d, want 524288", got)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -265,6 +265,7 @@ type Agent struct {
 	maxStepsKey        string
 	reasoningByteLimit int
 	maxOutputTokens    int
+	outputBudget       int // provider's total output budget; compaction force threshold stays under context_window - outputBudget
 	// executorHandoffGuard is enabled by Coordinator for the executor agent. The
 	// per-turn marker check in Run keeps ordinary single-model turns unaffected.
 	executorHandoffGuard bool
@@ -1228,6 +1229,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		maxStepsKey:               maxStepsKey,
 		reasoningByteLimit:        reasoningByteLimit,
 		maxOutputTokens:           opts.MaxOutputTokens,
+		outputBudget:              outputBudgetOf(prov),
 		temperature:               opts.Temperature,
 		pricing:                   opts.Pricing,
 		usageSource:               usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -286,6 +286,10 @@ type Agent struct {
 	// the CLI can expose a context gauge without re-scraping the usage line. The
 	// run loop writes it while a frontend's status line reads it, so it is atomic.
 	lastUsage atomic.Pointer[provider.Usage]
+	// lastSentChars is the character count of the last sent request, used in
+	// tokPerChar calibration to keep the ratio honest when a projection shrinks
+	// the prompt far below the full canonical transcript.
+	lastSentChars atomic.Int64
 
 	// sessCacheHit/sessCacheMiss accumulate cache tokens across every API call
 	// this session, so frontends can show the aggregate hit-rate (Σhit/Σ(hit+miss))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -286,6 +286,10 @@ type Agent struct {
 	// the CLI can expose a context gauge without re-scraping the usage line. The
 	// run loop writes it while a frontend's status line reads it, so it is atomic.
 	lastUsage atomic.Pointer[provider.Usage]
+	// lastResponseHitTokens stores the previous turn's CacheHitTokens so the
+	// response-side cache-break detector can compare the current hit count
+	// against the last known baseline.
+	lastResponseHitTokens atomic.Int64
 	// lastSentChars is the character count of the last sent request, used in
 	// tokPerChar calibration to keep the ratio honest when a projection shrinks
 	// the prompt far below the full canonical transcript.

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -87,8 +87,9 @@ func estimateTextTokens(s string) int {
 
 // estimatedPromptTokens returns a conservative prompt-token estimate for the
 // overflow-guard paths (preflight force, resume gate, shared-window budget
-// clipping): the fixed estimator under-counts CJK transcripts (~1.8x measured),
-// so the safety factor applies before usage, tokPerChar calibration after.
+// clipping). With real usage, tokPerChar calibration replaces the fixed
+// factor; before that, only the CJK share is scaled (the fixed estimator
+// under-counts CJK ~1.8x; a blanket 2x would compact at ~40% occupancy).
 func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
 	est := estimateMessagesTokens(provider.ModelMessages(msgs))
 	if est <= 0 {
@@ -100,13 +101,45 @@ func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
 		// factor is the measured ratio itself; tpc/fallback would inflate it ~4x.
 		return int(float64(est) * tpc)
 	}
-	return est * promptEstimateSafetyFactor
+	// est already counts the CJK runes at 1 rune/token; doubling only that
+	// share (×2) recovers the measured under-count while leaving the
+	// English/code portion unscaled.
+	return est + cjkRunesInMessages(msgs)
 }
 
-// promptEstimateSafetyFactor is the measured under-count of the fixed CJK
-// estimator before any usage calibrates it (~1.8x real, rounded up so the
-// overflow guards stay inside the provider window).
-const promptEstimateSafetyFactor = 2
+// cjkRunesInMessages counts the CJK runes across the provider-visible text of
+// a message list, mirroring the fields estimateMessagesTokens counts.
+func cjkRunesInMessages(msgs []provider.Message) int {
+	n := 0
+	for _, m := range msgs {
+		if m.LocalOnly {
+			continue
+		}
+		n += cjkRunesIn(m.Content) + cjkRunesIn(m.ReasoningContent)
+		n += cjkRunesIn(m.Name) + cjkRunesIn(m.ToolCallID)
+		for _, tc := range m.ToolCalls {
+			n += cjkRunesIn(tc.ID) + cjkRunesIn(tc.Name) + cjkRunesIn(tc.Arguments)
+		}
+		for _, item := range m.ResponsesItems {
+			n += cjkRunesIn(string(item))
+		}
+	}
+	return n
+}
+
+// cjkRunesIn counts CJK ideographs, kana, and hangul runes in a string.
+func cjkRunesIn(s string) int {
+	n := 0
+	for _, r := range s {
+		if (r >= 0x4E00 && r <= 0x9FFF) || // CJK unified ideographs
+			(r >= 0x3400 && r <= 0x4DBF) || // extension A
+			(r >= 0x3040 && r <= 0x30FF) || // hiragana + katakana
+			(r >= 0xAC00 && r <= 0xD7AF) { // hangul syllables
+			n++
+		}
+	}
+	return n
+}
 
 // outputBudgetOf reads the provider's total output budget so compaction force
 // thresholds can stay inside the real input allowance (context_window - output).

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -212,7 +212,7 @@ func (a *Agent) tokPerChar() float64 {
 	if u := a.lastUsage.Load(); u != nil && u.LatestPromptTokens() > 0 {
 		// LatestPromptTokens keeps calibration on the latest single-request
 		// shape: retry aggregates would over-estimate and compact too early.
-		if c := charsOfMessages(a.session.Messages); c > 0 {
+		if c := int(a.lastSentChars.Load()); c > 0 {
 			if r := float64(u.LatestPromptTokens()) / float64(c); r > 0.05 && r < 2 {
 				return r
 			}

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -193,7 +193,10 @@ func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
 		return
 	}
 	msgs, _ := a.session.snapshotMessagesVersion()
-	est := a.estimatedPromptTokens(msgs)
+	// Real-shape estimate without the overflow-guard safety factor: the resume
+	// gate must not fold a warm cached prefix on an estimate miss; under-
+	// estimating only defers compaction to the request path.
+	est := estimateMessagesTokens(provider.ModelMessages(msgs))
 	// The prompt alone already leaves no room for output: any request would be
 	// rejected regardless of cache state. Compact unconditionally.
 	if est >= a.contextWindow-minOutputBudget-outputBudgetReserve {

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -225,7 +225,10 @@ func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
 	if !sharesContextWindow(a.prov) {
 		return
 	}
-	msgs, _ := a.session.snapshotMessagesVersion()
+	// Model-visible shape, not the canonical transcript: a large history with
+	// a small valid projection sends exactly projection + tail, so the gate
+	// must not fold a cached prefix on canonical bulk it never transmits.
+	msgs := a.modelVisibleMessages()
 	// Real-shape estimate without the overflow-guard safety factor: the resume
 	// gate must not fold a warm cached prefix on an estimate miss; under-
 	// estimating only defers compaction to the request path.

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -1,0 +1,245 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unicode/utf8"
+
+	"reasonix/internal/event"
+	"reasonix/internal/nilutil"
+	"reasonix/internal/provider"
+)
+
+const (
+	fallbackTokPerChar  = 0.25 // ~4 chars/token before usage calibrates
+	outputBudgetReserve = 8192 // absorbs per-message estimate drift
+	minOutputBudget     = 8 * 1024
+)
+
+// ErrCompactionInputTooLarge reports that the fold to summarize cannot fit
+// beside a usable output budget in the shared context window. Retrying the
+// same fold cannot succeed, so callers pause auto-compaction instead of
+// re-running a doomed request every turn.
+var ErrCompactionInputTooLarge = errors.New("compaction input exceeds the provider context window")
+
+// forceThreshold is the prompt high-water mark that forces compaction. On
+// shared-window providers it never exceeds window - output budget - reserve,
+// so a request below it cannot be rejected for exceeding the model context
+// length; independent-ceiling providers keep the plain ratio mark.
+func (a *Agent) forceThreshold() int {
+	force := int(float64(a.contextWindow) * a.compactForceRatio)
+	if sharesContextWindow(a.prov) {
+		budget := a.outputBudget
+		if a.maxOutputTokens > 0 {
+			budget = a.maxOutputTokens
+		}
+		if budget > 0 {
+			budgetAware := a.contextWindow - budget - 8192
+			if budgetAware < force {
+				force = budgetAware
+			}
+		}
+	}
+	return force
+}
+
+// estimateMessagesTokens estimates the provider-visible tokens for messages,
+// including chat-message framing and tool-call structure.
+func estimateMessagesTokens(msgs []provider.Message) int {
+	total := 0
+	for _, m := range msgs {
+		if m.LocalOnly {
+			continue
+		}
+		total += 4 // chat-message framing overhead
+		total += estimateTextTokens(m.Content)
+		total += estimateTextTokens(m.ReasoningContent)
+		total += estimateTextTokens(m.Name)
+		total += estimateTextTokens(m.ToolCallID)
+		for _, tc := range m.ToolCalls {
+			total += 8
+			total += estimateTextTokens(tc.ID)
+			total += estimateTextTokens(tc.Name)
+			total += estimateTextTokens(tc.Arguments)
+		}
+		for _, item := range m.ResponsesItems {
+			total += estimateTextTokens(string(item))
+		}
+	}
+	return total
+}
+
+func estimateTextTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	// A conservative cross-language approximation: English-ish text trends near
+	// four bytes per token, while CJK-heavy text is closer to one rune per token.
+	bytes := len(s)
+	runes := utf8.RuneCountInString(s)
+	byBytes := (bytes + 3) / 4
+	if runes > byBytes {
+		return runes
+	}
+	return byBytes
+}
+
+// estimatedPromptTokens returns a conservative prompt-token estimate for the
+// overflow-guard paths (preflight force, resume gate, shared-window budget
+// clipping): the fixed estimator under-counts CJK transcripts (~1.8x measured),
+// so the safety factor applies before usage, tokPerChar calibration after.
+func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
+	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if est <= 0 {
+		return 0
+	}
+	tpc := a.tokPerChar()
+	if tpc > 0 && tpc != fallbackTokPerChar {
+		// estimateMessagesTokens counts ~1 rune per token, so the calibration
+		// factor is the measured ratio itself; tpc/fallback would inflate it ~4x.
+		return int(float64(est) * tpc)
+	}
+	return est * promptEstimateSafetyFactor
+}
+
+// promptEstimateSafetyFactor is the measured under-count of the fixed CJK
+// estimator before any usage calibrates it (~1.8x real, rounded up so the
+// overflow guards stay inside the provider window).
+const promptEstimateSafetyFactor = 2
+
+// outputBudgetOf reads the provider's total output budget so compaction force
+// thresholds can stay inside the real input allowance (context_window - output).
+// Zero means the provider does not expose one (or requests omit the field).
+func outputBudgetOf(p provider.Provider) int {
+	if nilutil.IsNil(p) {
+		return 0
+	}
+	if bp, ok := p.(provider.OutputBudgetProvider); ok {
+		return bp.OutputBudget()
+	}
+	return 0
+}
+
+// sharesContextWindow reports whether the provider's output budget competes
+// with the prompt input for the same context window (DeepSeek). False for
+// unknown/independent-ceiling providers, keeping their default budgets intact.
+func sharesContextWindow(p provider.Provider) bool {
+	if nilutil.IsNil(p) {
+		return false
+	}
+	if sp, ok := p.(provider.SharedWindowOutputProvider); ok {
+		return sp.SharesContextWindow()
+	}
+	return false
+}
+
+// effectiveOutputBudget returns the max_output_tokens to request next round.
+// Shared-window providers (DeepSeek) must keep input + output inside the
+// window or the API rejects with HTTP 400, so the budget is clipped to the
+// remaining allowance; (0, false) keeps the caller's default.
+func (a *Agent) effectiveOutputBudget(msgs []provider.Message) (int, bool) {
+	if a == nil || a.contextWindow <= 0 || !sharesContextWindow(a.prov) {
+		return 0, false
+	}
+	// A user override wins; otherwise the provider's configured default.
+	budget := a.outputBudget
+	if a.maxOutputTokens > 0 {
+		budget = a.maxOutputTokens
+	}
+	if budget <= 0 {
+		return 0, false
+	}
+	// msgs already carries the system prompt (modelVisibleMessages includes
+	// system messages), so only tool schemas are added on top.
+	est := a.estimatedPromptTokens(msgs)
+	if a.tools != nil {
+		for _, s := range a.tools.Schemas() {
+			est += estimateTextTokens(s.Name) + estimateTextTokens(s.Description) + estimateTextTokens(string(s.Parameters))
+		}
+	}
+	return a.sharedWindowClip(budget, est)
+}
+
+// sharedWindowClip clips an output budget so budget + estimated input stays
+// inside the provider's shared context window (DeepSeek rejects the sum above
+// context_window with HTTP 400). Returns (0, false) to keep the caller's
+// default when no clip is needed; (clipped, true) forces the smaller budget,
+// never below the 8K usable floor.
+func (a *Agent) sharedWindowClip(budget, est int) (int, bool) {
+	if a == nil || a.contextWindow <= 0 || budget <= 0 {
+		return 0, false
+	}
+	avail := a.contextWindow - est - outputBudgetReserve
+	if budget <= avail {
+		return 0, false // full budget still fits; keep the default
+	}
+	if avail < minOutputBudget {
+		return minOutputBudget, true // never clip below a usable floor
+	}
+	return avail, true
+}
+
+// MaybeCompactOnResume compacts a freshly resumed session before the first
+// send when the prompt cannot fit beside the output budget in the shared
+// context window. Warm and within-allowance resumes stay untouched so the
+// cached prefix survives (deferred-compaction policy); the canonical
+// transcript is never rewritten.
+func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
+	if a == nil || a.session == nil || a.contextWindow <= 0 {
+		return
+	}
+	if !sharesContextWindow(a.prov) {
+		return
+	}
+	msgs, _ := a.session.snapshotMessagesVersion()
+	est := a.estimatedPromptTokens(msgs)
+	// The prompt alone already leaves no room for output: any request would be
+	// rejected regardless of cache state. Compact unconditionally.
+	if est >= a.contextWindow-minOutputBudget-outputBudgetReserve {
+		if err := a.CompactNow(ctx, ""); err == nil {
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
+				"resumed session prompt ~%d tokens est. exceeds the shared context window's input allowance — compacted before first send", est)})
+		}
+	}
+}
+
+// tokPerChar derives a tokens-per-character ratio from the last turn's real
+// usage so per-message estimates track the provider's tokenizer without a
+// local one. Reasoning is excluded from the char count to match the prompt
+// sent; absurd ratios fall back to ~4 chars/token.
+func (a *Agent) tokPerChar() float64 {
+	if u := a.lastUsage.Load(); u != nil && u.LatestPromptTokens() > 0 {
+		// LatestPromptTokens keeps calibration on the latest single-request
+		// shape: retry aggregates would over-estimate and compact too early.
+		if c := charsOfMessages(a.session.Messages); c > 0 {
+			if r := float64(u.LatestPromptTokens()) / float64(c); r > 0.05 && r < 2 {
+				return r
+			}
+		}
+	}
+	return fallbackTokPerChar
+}
+
+// msgChars counts the runes that ride to the provider for one message —
+// content plus tool-call names and arguments, but not reasoning (stripped on
+// send). Runes, not bytes: estimateTextTokens is also rune-based, so token
+// ratios and estimates share one unit regardless of script.
+func msgChars(m provider.Message) int {
+	if m.LocalOnly {
+		return 0
+	}
+	n := utf8.RuneCountInString(m.Content)
+	for _, tc := range m.ToolCalls {
+		n += utf8.RuneCountInString(tc.Name) + utf8.RuneCountInString(tc.Arguments)
+	}
+	return n
+}
+
+func charsOfMessages(msgs []provider.Message) int {
+	n := 0
+	for _, m := range msgs {
+		n += msgChars(m)
+	}
+	return n
+}

--- a/internal/agent/budget.go
+++ b/internal/agent/budget.go
@@ -243,3 +243,23 @@ func charsOfMessages(msgs []provider.Message) int {
 	}
 	return n
 }
+
+// maybePredictOverflow emits a record-only notice when the estimated prompt
+// leaves less than minOutputBudget of headroom for the output: the next turn
+// may overflow the shared context window. Compaction is not triggered — this
+// is a diagnostic signal, not a pressure gate.
+func (a *Agent) maybePredictOverflow(est, maxTokens int) {
+	if a == nil || a.sink == nil || a.contextWindow <= 0 || maxTokens <= 0 {
+		return
+	}
+	headroom := a.contextWindow - est - maxTokens
+	if headroom < minOutputBudget {
+		a.sink.Emit(event.Event{
+			Kind:  event.Notice,
+			Level: event.LevelInfo,
+			Text:  "context window nearly full",
+			Detail: fmt.Sprintf("estimated prompt %d tokens, max output %d, headroom %d — next turn may overflow",
+				est, maxTokens, max(headroom, 0)),
+		})
+	}
+}

--- a/internal/agent/cache_diagnostics_test.go
+++ b/internal/agent/cache_diagnostics_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"reasonix/internal/event"
@@ -87,5 +88,62 @@ func TestRunPopulatesCacheDiagnosticsOnUsageEvents(t *testing.T) {
 	}
 	if first.ToolsHash == second.ToolsHash {
 		t.Fatalf("tool hash should change after registering a tool: %q", first.ToolsHash)
+	}
+}
+
+// TestCacheMissDropFirstTurnSkips verifies the first turn (no previous baseline)
+// never reports a miss drop regardless of the hit token count.
+func TestCacheMissDropFirstTurnSkips(t *testing.T) {
+	a := &Agent{lastResponseHitTokens: atomic.Int64{}}
+	if detectResponseCacheMiss(a, 8000, nil) {
+		t.Fatal("first turn should never report cache miss drop")
+	}
+	// Baseline must be stored.
+	if a.lastResponseHitTokens.Load() != 8000 {
+		t.Fatalf("baseline not stored: got %d", a.lastResponseHitTokens.Load())
+	}
+}
+
+// TestCacheMissDropStableHitDoesNotFire verifies a stable or growing hit count
+// (within 5%) does not trigger the drop detector.
+func TestCacheMissDropStableHitDoesNotFire(t *testing.T) {
+	a := &Agent{lastResponseHitTokens: atomic.Int64{}}
+	a.lastResponseHitTokens.Store(10000)
+	if detectResponseCacheMiss(a, 10100, nil) {
+		t.Fatal("+1% change should not trigger flush")
+	}
+	if detectResponseCacheMiss(a, 9600, nil) {
+		t.Fatal("4% drop should not trigger flush (<5% threshold)")
+	}
+}
+
+// TestCacheMissDropSignificantDropFires verifies a drop >5% AND >=2000 tokens
+// triggers the missed-cache detection.
+func TestCacheMissDropSignificantDropFires(t *testing.T) {
+	a := &Agent{lastResponseHitTokens: atomic.Int64{}}
+	a.lastResponseHitTokens.Store(10000)
+	if !detectResponseCacheMiss(a, 7900, nil) {
+		t.Fatal("21% drop of 10000 → 7900 should trigger miss; threshold is 5% + 2000 tokens")
+	}
+	// Verify baseline was updated to the new (lower) count so a second
+	// identical drop does not re-trigger.
+	if detectResponseCacheMiss(a, 7900, nil) {
+		t.Fatal("baseline not updated — second identical count should not re-trigger")
+	}
+}
+
+// TestCacheMissDropCompactionResets verifies that contentReasons (compaction/snip)
+// suppress the drop detector because the prefix legitimately shrank.
+func TestCacheMissDropCompactionResets(t *testing.T) {
+	a := &Agent{lastResponseHitTokens: atomic.Int64{}}
+	a.lastResponseHitTokens.Store(10000)
+	reasons := []string{"compact_auto"}
+	if detectResponseCacheMiss(a, 5000, reasons) {
+		t.Fatal("compaction-caused hit drop must not be reported as cache miss")
+	}
+	// Baseline must be reset to the post-compaction count so the next
+	// legitimate cache eviction can still be detected.
+	if a.lastResponseHitTokens.Load() != 5000 {
+		t.Fatalf("baseline not reset after compaction: got %d", a.lastResponseHitTokens.Load())
 	}
 }

--- a/internal/agent/cache_shape.go
+++ b/internal/agent/cache_shape.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 
 	"reasonix/internal/event"
@@ -136,8 +137,18 @@ func detectResponseCacheMiss(a *Agent, hit int, contentReasons []string) bool {
 		return false
 	}
 	if len(contentReasons) > 0 {
+		slog.Debug("agent: cache miss drop suppressed (prefix rewrite)", "reasons", contentReasons)
 		return false
 	}
 	drop := prev - hit
-	return drop >= 2000 && float64(hit) < float64(prev)*0.95
+	miss := drop >= 2000 && float64(hit) < float64(prev)*0.95
+	if miss {
+		slog.Info("agent: cache miss drop detected",
+			"prev_hit", prev,
+			"current_hit", hit,
+			"drop_tokens", drop,
+			"drop_pct", int((1-float64(hit)/float64(prev))*100),
+		)
+	}
+	return miss
 }

--- a/internal/agent/cache_shape.go
+++ b/internal/agent/cache_shape.go
@@ -124,3 +124,20 @@ type ToolSchemaCost struct {
 	Name   string
 	Tokens int
 }
+
+// detectResponseCacheMiss returns true when the current hit count is ≥5% and
+// ≥2000 tokens below the previous turn's baseline AND no compaction/snip was
+// in play (those legitimately shrink the prefix). Always updates the baseline
+// (or resets it after compaction) for the next turn.
+func detectResponseCacheMiss(a *Agent, hit int, contentReasons []string) bool {
+	prev := int(a.lastResponseHitTokens.Load())
+	defer func() { a.lastResponseHitTokens.Store(int64(hit)) }()
+	if prev <= 0 {
+		return false
+	}
+	if len(contentReasons) > 0 {
+		return false
+	}
+	drop := prev - hit
+	return drop >= 2000 && float64(hit) < float64(prev)*0.95
+}

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -44,7 +44,7 @@ const (
 
 // summaryTimeout bounds one summarizer call so a stalled stream surfaces a clear
 // failure (then a mechanical fold) instead of hanging compaction indefinitely.
-const summaryTimeout = 90 * time.Second
+const summaryTimeout = 180 * time.Second
 
 // summarySystemPrompt steers the executor to distill older history into a
 // structured briefing it can keep relying on after the originals are dropped.

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -10,11 +10,9 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"reasonix/internal/ablation"
 	"reasonix/internal/event"
-	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 )
 
@@ -32,7 +30,6 @@ const (
 	defaultTailTokens          = 16384 // verbatim recent-tail budget, in tokens
 	minRecentKeep              = 2     // never keep fewer recent messages than this
 	minCompactMessages         = 2     // skip compaction below this many compactable messages
-	fallbackTokPerChar         = 0.25  // ~4 chars/token, used before any usage is available to calibrate
 	maxPinnedFirstUserTokens   = 1500  // ceiling on pinning the first user turn verbatim; larger first turns (pasted content) stay foldable
 	pinnedFirstUserWindowFrac  = 0.15  // and never pin a first turn worth more than this fraction of the window
 	maxKeepSmallUserTurns      = 20    // position-fixed keep window for small user turns in the fold region; the first N survive verbatim, older ones fold (prefix byte-stable, never "latest N")
@@ -96,74 +93,48 @@ func (a *Agent) compactThresholds() (soft, snip, high int) {
 	return soft, snip, high
 }
 
-// forceThreshold is the prompt-token high-water mark that forces compaction.
-// It never exceeds the provider's real input allowance: when the provider
-// shares its context window with the output (DeepSeek), the window's tail is
-// reserved for the output budget so a request below this threshold can never
-// be rejected for exceeding the model context length (DeepSeek rejects
-// messages+completion > context_window). Independent-ceiling providers keep
-// the plain ratio mark. The 8K reserve absorbs per-message estimate drift
-// against the real tokenizer. The more conservative of the ratio mark and the
-// budget-aware mark wins.
-func (a *Agent) forceThreshold() int {
-	force := int(float64(a.contextWindow) * a.compactForceRatio)
-	if sharesContextWindow(a.prov) {
-		budget := a.outputBudget
-		if a.maxOutputTokens > 0 {
-			budget = a.maxOutputTokens
-		}
-		if budget > 0 {
-			budgetAware := a.contextWindow - budget - 8192
-			if budgetAware < force {
-				force = budgetAware
-			}
-		}
-	}
-	return force
-}
-
 // maybeCompact compacts into a context projection when the last turn's prompt
 // has grown to the configured fraction of the context window. It never rewrites
 // the canonical transcript. No-op when compaction is disabled or usage is
 // unavailable.
 func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
-	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
+	if a.contextWindow <= 0 || u == nil {
+		return
+	}
+	promptTokens := u.LatestPromptTokens()
+	if promptTokens == 0 {
 		return
 	}
 	soft, snip, high := a.compactThresholds()
-	// A turn that sits under the trigger is the breathing room a healthy
-	// compaction buys; it clears the stuck latch and the run counter. This has to
-	// happen before the soft/snip branches return, because a compaction that
-	// settles the prompt anywhere in [snip, high) is working exactly as intended:
-	// leaving a stale run count behind there would latch the *next* compaction as
-	// "the window is too small" and silently disable auto-compaction for the rest
-	// of the session.
-	if u.PromptTokens < high {
+	// Clearing the latch before the soft/snip returns keeps a settled prompt
+	// from being counted against the next turn; a too-small-window session
+	// otherwise latches and disables auto-compaction for the session.
+	if promptTokens < high {
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
 	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
-	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {
+	if promptTokens >= soft && promptTokens < snip && !a.softCompactNoticed {
 		a.softCompactNoticed = true
 		detail := fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: detail})
 		return
 	}
-	if u.PromptTokens >= snip && u.PromptTokens < high {
+	if promptTokens >= snip && promptTokens < high {
 		// Snip only into a projection view — never rewrite the canonical log.
 		if err := a.snipToProjection(ctx); err != nil {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context snip skipped for now.", Detail: err.Error()})
 		}
 		return
 	}
-	if u.PromptTokens < high {
+	if promptTokens < high {
 		return // the latch was already cleared above
 	}
 	if a.compactStuck {
 		return
 	}
-	force := u.PromptTokens >= a.forceThreshold()
+	force := promptTokens >= a.forceThreshold()
 	// Projection-only prune before folding. Install the pruned view first so the
 	// next request (and its real usage) can measure whether a paid summarize is
 	// still needed — never rewrite the canonical transcript.
@@ -182,6 +153,14 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		}
 	}
 	if _, err := a.compactToProjection(ctx, "auto", "", force); err != nil {
+		if errors.Is(err, ErrCompactionInputTooLarge) {
+			// The fold alone exceeds what the window can hold, so compaction
+			// cannot help; pausing avoids re-running the doomed request every
+			// turn (it would 400 on the provider side each time).
+			a.compactStuck = true
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "Automatic context cleanup paused: context too large to compact.", Detail: err.Error()})
+			return
+		}
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context cleanup skipped for now.", Detail: fmt.Sprintf("compaction skipped: %v", err)})
 		return
 	}
@@ -207,68 +186,6 @@ func foldEconomics(region []provider.Message) bool {
 	const minFoldTokens = 400
 	return estimateMessagesTokens(region) >= minFoldTokens
 }
-
-func estimateMessagesTokens(msgs []provider.Message) int {
-	total := 0
-	for _, m := range msgs {
-		if m.LocalOnly {
-			continue
-		}
-		total += 4 // chat-message framing overhead
-		total += estimateTextTokens(m.Content)
-		total += estimateTextTokens(m.ReasoningContent)
-		total += estimateTextTokens(m.Name)
-		total += estimateTextTokens(m.ToolCallID)
-		for _, tc := range m.ToolCalls {
-			total += 8
-			total += estimateTextTokens(tc.ID)
-			total += estimateTextTokens(tc.Name)
-			total += estimateTextTokens(tc.Arguments)
-		}
-		for _, item := range m.ResponsesItems {
-			total += estimateTextTokens(string(item))
-		}
-	}
-	return total
-}
-
-func estimateTextTokens(s string) int {
-	if s == "" {
-		return 0
-	}
-	// A conservative cross-language approximation: English-ish text trends near
-	// four bytes per token, while CJK-heavy text is closer to one rune per token.
-	bytes := len(s)
-	runes := utf8.RuneCountInString(s)
-	byBytes := (bytes + 3) / 4
-	if runes > byBytes {
-		return runes
-	}
-	return byBytes
-}
-
-// estimatedPromptTokens returns a conservative prompt-token estimate for the
-// overflow-guard paths (preflight force, resume gate, shared-window budget
-// clipping). The fixed estimator under-counts CJK-heavy transcripts (measured
-// ~1.8x on a real 4.3K-message session: estimated 681K vs 1.24M actual), so
-// without usage data it applies the safety factor; once a turn reports real
-// usage, tokPerChar calibrates the estimate instead.
-func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
-	est := estimateMessagesTokens(provider.ModelMessages(msgs))
-	if est <= 0 {
-		return 0
-	}
-	tpc := a.tokPerChar()
-	if tpc > 0 && tpc != fallbackTokPerChar {
-		return int(float64(est) * tpc / fallbackTokPerChar)
-	}
-	return est * promptEstimateSafetyFactor
-}
-
-// promptEstimateSafetyFactor is the measured under-count of the fixed CJK
-// estimator before any usage calibrates it (~1.8x real, rounded up so the
-// overflow guards stay inside the provider window).
-const promptEstimateSafetyFactor = 2
 
 // SummarizeFrom replaces the messages from fromIdx onward with a single summary,
 // keeping everything before it verbatim ("summarize from here"). fromIdx is a turn
@@ -635,142 +552,6 @@ func tailStart(msgs []provider.Message, head, budgetTokens int, tokPerChar float
 	return start
 }
 
-// outputBudgetOf reads the provider's total output budget so compaction force
-// thresholds can stay inside the real input allowance (context_window - output).
-// Zero means the provider does not expose one (or requests omit the field).
-func outputBudgetOf(p provider.Provider) int {
-	if nilutil.IsNil(p) {
-		return 0
-	}
-	if bp, ok := p.(provider.OutputBudgetProvider); ok {
-		return bp.OutputBudget()
-	}
-	return 0
-}
-
-// sharesContextWindow reports whether the provider's output budget competes
-// with the prompt input for the same context window (DeepSeek). False for
-// unknown/independent-ceiling providers, keeping their default budgets intact.
-func sharesContextWindow(p provider.Provider) bool {
-	if nilutil.IsNil(p) {
-		return false
-	}
-	if sp, ok := p.(provider.SharedWindowOutputProvider); ok {
-		return sp.SharesContextWindow()
-	}
-	return false
-}
-
-// effectiveOutputBudget returns the max_output_tokens to request next round.
-// Shared-window providers (DeepSeek) must keep input + output inside
-// context_window or the API rejects with HTTP 400, so the budget is clipped to
-// the window's remaining allowance minus an estimate reserve. Returns
-// (0, false) to keep the caller's/provider's default when no clip is needed or
-// the window is unknown; (clipped, true) forces the smaller budget.
-func (a *Agent) effectiveOutputBudget(msgs []provider.Message) (int, bool) {
-	if a == nil || a.contextWindow <= 0 || !sharesContextWindow(a.prov) {
-		return 0, false
-	}
-	// A user override wins; otherwise the provider's configured default.
-	budget := a.outputBudget
-	if a.maxOutputTokens > 0 {
-		budget = a.maxOutputTokens
-	}
-	if budget <= 0 {
-		return 0, false
-	}
-	// msgs already carries the system prompt (modelVisibleMessages includes
-	// system messages), so only tool schemas are added on top.
-	est := a.estimatedPromptTokens(msgs)
-	if a.tools != nil {
-		for _, s := range a.tools.Schemas() {
-			est += estimateTextTokens(s.Name) + estimateTextTokens(s.Description) + estimateTextTokens(string(s.Parameters))
-		}
-	}
-	avail := a.contextWindow - est - outputBudgetReserve
-	if budget <= avail {
-		return 0, false // full budget still fits; keep the default
-	}
-	if avail < minOutputBudget {
-		return minOutputBudget, true // never clip below a usable floor
-	}
-	return avail, true
-}
-
-// outputBudgetReserve absorbs per-message estimate drift against the real
-// tokenizer when clipping a shared-window output budget.
-const outputBudgetReserve = 8192
-
-// minOutputBudget is the floor for a clipped shared-window budget: a request
-// that near-exhausts the window still needs room to emit a tool call.
-const minOutputBudget = 8 * 1024
-
-// MaybeCompactOnResume compacts a freshly resumed session before the first
-// send when the prompt cannot fit inside the provider's shared context window
-// alongside the output budget (DeepSeek rejects input + max_output_tokens >
-// context_window with HTTP 400). Warm resumes and cold resumes within the
-// input allowance are left untouched so the cached prefix survives — matching
-// the deferred-compaction policy upstream: cold-cache replay pays the miss
-// price once, which is cheaper than rewriting the prefix on every resume.
-// Never rewrites the canonical transcript; only the model-visible projection
-// changes.
-func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
-	if a == nil || a.session == nil || a.contextWindow <= 0 {
-		return
-	}
-	if !sharesContextWindow(a.prov) {
-		return
-	}
-	msgs, _ := a.session.snapshotMessagesVersion()
-	est := a.estimatedPromptTokens(msgs)
-	// The prompt alone already leaves no room for output: any request would be
-	// rejected regardless of cache state. Compact unconditionally.
-	if est >= a.contextWindow-minOutputBudget-outputBudgetReserve {
-		if err := a.CompactNow(ctx, ""); err == nil {
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
-				"resumed session prompt ~%d tokens est. exceeds the shared context window's input allowance — compacted before first send", est)})
-		}
-	}
-}
-
-// tokPerChar derives a tokens-per-character ratio from the last turn's real
-// usage so per-message estimates track the provider's tokenizer without a local
-// one. Reasoning content is excluded from the char count to match the prompt
-// actually sent (the provider strips it). Falls back to ~4 chars/token before
-// any usage is known, and ignores absurd ratios.
-func (a *Agent) tokPerChar() float64 {
-	if u := a.lastUsage.Load(); u != nil && u.PromptTokens > 0 {
-		if c := charsOfMessages(a.session.Messages); c > 0 {
-			if r := float64(u.PromptTokens) / float64(c); r > 0.05 && r < 2 {
-				return r
-			}
-		}
-	}
-	return fallbackTokPerChar
-}
-
-// msgChars counts the characters that ride to the provider for one message —
-// content plus tool-call names and arguments, but not reasoning (stripped on
-// send).
-func msgChars(m provider.Message) int {
-	if m.LocalOnly {
-		return 0
-	}
-	n := len(m.Content)
-	for _, tc := range m.ToolCalls {
-		n += len(tc.Name) + len(tc.Arguments)
-	}
-	return n
-}
-
-func charsOfMessages(msgs []provider.Message) int {
-	n := 0
-	for _, m := range msgs {
-		n += msgChars(m)
-	}
-	return n
-}
-
 // summarize asks the executor's own provider (no tools) to distill the region
 // into a briefing. instructions is optional /compact focus + PreCompact text.
 // Named returns so defer can attach RequestCount and still return usage.
@@ -788,11 +569,39 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 			a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing, UsageSource: event.UsageSourceCompaction})
 		}
 	}()
+	// The summarizer hits the provider's shared context window too (its input
+	// is the whole folded region), so clip the output budget the same way as
+	// normal requests — an unclipped default 128K made compaction itself fail
+	// with HTTP 400 near the window edge.
+	transcript := renderTranscript(region)
+	reqMsgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: sys},
+		{Role: provider.RoleUser, Content: transcript},
+	}
+	maxTokens := 0
+	if sharesContextWindow(a.prov) {
+		budget := a.outputBudget
+		if a.maxOutputTokens > 0 {
+			budget = a.maxOutputTokens
+		}
+		if clipped, ok := a.sharedWindowClip(budget, a.estimatedPromptTokens(reqMsgs)); ok {
+			maxTokens = clipped
+		}
+		// Reject when the fold itself cannot fit beside a usable output budget:
+		// the request would 400 again, and retrying the same fold every turn
+		// just re-runs the failure. Estimate the real request shape (framing
+		// overhead included, no safety factor) so healthy folds near the window
+		// still pass — a transcript-only estimate would under-count reasoning
+		// content and tool-call arguments.
+		if a.contextWindow > minOutputBudget {
+			if est := estimateMessagesTokens(reqMsgs); est >= a.contextWindow-minOutputBudget {
+				return "", nil, ErrCompactionInputTooLarge
+			}
+		}
+	}
 	ch, err := a.prov.Stream(ctx, provider.Request{
-		Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: sys},
-			{Role: provider.RoleUser, Content: renderTranscript(region)},
-		},
+		Messages:    reqMsgs,
+		MaxTokens:   maxTokens,
 		Temperature: provider.OptionalTemperature(a.temperature),
 	})
 	if err != nil {

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -98,17 +98,25 @@ func (a *Agent) compactThresholds() (soft, snip, high int) {
 
 // forceThreshold is the prompt-token high-water mark that forces compaction.
 // It never exceeds the provider's real input allowance: when the provider
-// requests a total output budget, the window's tail is reserved for it, so a
-// request below this threshold can never be rejected for exceeding the model
-// context length (DeepSeek rejects messages+completion > context_window). The
-// 8K reserve absorbs per-message estimate drift against the real tokenizer.
-// The more conservative of the ratio mark and the budget-aware mark wins.
+// shares its context window with the output (DeepSeek), the window's tail is
+// reserved for the output budget so a request below this threshold can never
+// be rejected for exceeding the model context length (DeepSeek rejects
+// messages+completion > context_window). Independent-ceiling providers keep
+// the plain ratio mark. The 8K reserve absorbs per-message estimate drift
+// against the real tokenizer. The more conservative of the ratio mark and the
+// budget-aware mark wins.
 func (a *Agent) forceThreshold() int {
 	force := int(float64(a.contextWindow) * a.compactForceRatio)
-	if a.outputBudget > 0 {
-		budgetAware := a.contextWindow - a.outputBudget - 8192
-		if budgetAware < force {
-			force = budgetAware
+	if sharesContextWindow(a.prov) {
+		budget := a.outputBudget
+		if a.maxOutputTokens > 0 {
+			budget = a.maxOutputTokens
+		}
+		if budget > 0 {
+			budgetAware := a.contextWindow - budget - 8192
+			if budgetAware < force {
+				force = budgetAware
+			}
 		}
 	}
 	return force
@@ -671,10 +679,9 @@ func (a *Agent) effectiveOutputBudget(msgs []provider.Message) (int, bool) {
 	if budget <= 0 {
 		return 0, false
 	}
+	// msgs already carries the system prompt (modelVisibleMessages includes
+	// system messages), so only tool schemas are added on top.
 	est := a.estimatedPromptTokens(msgs)
-	if a.session != nil {
-		est += estimateTextTokens(a.systemPrompt())
-	}
 	if a.tools != nil {
 		for _, s := range a.tools.Schemas() {
 			est += estimateTextTokens(s.Name) + estimateTextTokens(s.Description) + estimateTextTokens(string(s.Parameters))

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -708,10 +708,12 @@ const minOutputBudget = 8 * 1024
 // MaybeCompactOnResume compacts a freshly resumed session before the first
 // send when the prompt cannot fit inside the provider's shared context window
 // alongside the output budget (DeepSeek rejects input + max_output_tokens >
-// context_window with HTTP 400), or when the cache is cold and the prompt has
-// grown past the budget-aware force mark. Warm resumes with a small prompt are
-// left untouched so the cached prefix survives. Never rewrites the canonical
-// transcript; only the model-visible projection changes.
+// context_window with HTTP 400). Warm resumes and cold resumes within the
+// input allowance are left untouched so the cached prefix survives — matching
+// the deferred-compaction policy upstream: cold-cache replay pays the miss
+// price once, which is cheaper than rewriting the prefix on every resume.
+// Never rewrites the canonical transcript; only the model-visible projection
+// changes.
 func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
 	if a == nil || a.session == nil || a.contextWindow <= 0 {
 		return
@@ -721,26 +723,12 @@ func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
 	}
 	msgs, _ := a.session.snapshotMessagesVersion()
 	est := a.estimatedPromptTokens(msgs)
-	budget := a.outputBudget
-	if a.maxOutputTokens > 0 {
-		budget = a.maxOutputTokens
-	}
 	// The prompt alone already leaves no room for output: any request would be
 	// rejected regardless of cache state. Compact unconditionally.
 	if est >= a.contextWindow-minOutputBudget-outputBudgetReserve {
 		if err := a.CompactNow(ctx, ""); err == nil {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
 				"resumed session prompt ~%d tokens est. exceeds the shared context window's input allowance — compacted before first send", est)})
-		}
-		return
-	}
-	// Cold cache + prompt past the budget-aware force mark: a full-history
-	// replay would pay the miss price on the whole prefix. Compact once so the
-	// first send is a small, stable, cacheable prefix.
-	if budget > 0 && a.cacheState == CacheStateCold && est >= a.forceThreshold() {
-		if err := a.CompactNow(ctx, ""); err == nil {
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
-				"resumed after provider-cache expiry with ~%d tokens est. — compacted before first send (cold replay would pay full price)", est)})
 		}
 	}
 }

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -14,6 +14,7 @@ import (
 
 	"reasonix/internal/ablation"
 	"reasonix/internal/event"
+	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 )
 
@@ -95,16 +96,30 @@ func (a *Agent) compactThresholds() (soft, snip, high int) {
 	return soft, snip, high
 }
 
+// forceThreshold is the prompt-token high-water mark that forces compaction.
+// It never exceeds the provider's real input allowance: when the provider
+// requests a total output budget, the window's tail is reserved for it, so a
+// request below this threshold can never be rejected for exceeding the model
+// context length (DeepSeek rejects messages+completion > context_window). The
+// 8K reserve absorbs per-message estimate drift against the real tokenizer.
+// The more conservative of the ratio mark and the budget-aware mark wins.
+func (a *Agent) forceThreshold() int {
+	force := int(float64(a.contextWindow) * a.compactForceRatio)
+	if a.outputBudget > 0 {
+		budgetAware := a.contextWindow - a.outputBudget - 8192
+		if budgetAware < force {
+			force = budgetAware
+		}
+	}
+	return force
+}
+
 // maybeCompact compacts into a context projection when the last turn's prompt
 // has grown to the configured fraction of the context window. It never rewrites
 // the canonical transcript. No-op when compaction is disabled or usage is
 // unavailable.
 func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
-	if a.contextWindow <= 0 || u == nil {
-		return
-	}
-	promptTokens := u.LatestPromptTokens()
-	if promptTokens == 0 {
+	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
 		return
 	}
 	soft, snip, high := a.compactThresholds()
@@ -115,32 +130,32 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	// leaving a stale run count behind there would latch the *next* compaction as
 	// "the window is too small" and silently disable auto-compaction for the rest
 	// of the session.
-	if promptTokens < high {
+	if u.PromptTokens < high {
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
 	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
-	if promptTokens >= soft && promptTokens < snip && !a.softCompactNoticed {
+	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {
 		a.softCompactNoticed = true
 		detail := fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: detail})
 		return
 	}
-	if promptTokens >= snip && promptTokens < high {
+	if u.PromptTokens >= snip && u.PromptTokens < high {
 		// Snip only into a projection view — never rewrite the canonical log.
 		if err := a.snipToProjection(ctx); err != nil {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context snip skipped for now.", Detail: err.Error()})
 		}
 		return
 	}
-	if promptTokens < high {
+	if u.PromptTokens < high {
 		return // the latch was already cleared above
 	}
 	if a.compactStuck {
 		return
 	}
-	force := promptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
+	force := u.PromptTokens >= a.forceThreshold()
 	// Projection-only prune before folding. Install the pruned view first so the
 	// next request (and its real usage) can measure whether a paid summarize is
 	// still needed — never rewrite the canonical transcript.
@@ -589,6 +604,117 @@ func tailStart(msgs []provider.Message, head, budgetTokens int, tokPerChar float
 	return start
 }
 
+// outputBudgetOf reads the provider's total output budget so compaction force
+// thresholds can stay inside the real input allowance (context_window - output).
+// Zero means the provider does not expose one (or requests omit the field).
+func outputBudgetOf(p provider.Provider) int {
+	if nilutil.IsNil(p) {
+		return 0
+	}
+	if bp, ok := p.(provider.OutputBudgetProvider); ok {
+		return bp.OutputBudget()
+	}
+	return 0
+}
+
+// sharesContextWindow reports whether the provider's output budget competes
+// with the prompt input for the same context window (DeepSeek). False for
+// unknown/independent-ceiling providers, keeping their default budgets intact.
+func sharesContextWindow(p provider.Provider) bool {
+	if nilutil.IsNil(p) {
+		return false
+	}
+	if sp, ok := p.(provider.SharedWindowOutputProvider); ok {
+		return sp.SharesContextWindow()
+	}
+	return false
+}
+
+// effectiveOutputBudget returns the max_output_tokens to request next round.
+// Shared-window providers (DeepSeek) must keep input + output inside
+// context_window or the API rejects with HTTP 400, so the budget is clipped to
+// the window's remaining allowance minus an estimate reserve. Returns
+// (0, false) to keep the caller's/provider's default when no clip is needed or
+// the window is unknown; (clipped, true) forces the smaller budget.
+func (a *Agent) effectiveOutputBudget(msgs []provider.Message) (int, bool) {
+	if a == nil || a.contextWindow <= 0 || !sharesContextWindow(a.prov) {
+		return 0, false
+	}
+	// A user override wins; otherwise the provider's configured default.
+	budget := a.outputBudget
+	if a.maxOutputTokens > 0 {
+		budget = a.maxOutputTokens
+	}
+	if budget <= 0 {
+		return 0, false
+	}
+	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if a.session != nil {
+		est += estimateTextTokens(a.systemPrompt())
+	}
+	if a.tools != nil {
+		for _, s := range a.tools.Schemas() {
+			est += estimateTextTokens(s.Name) + estimateTextTokens(s.Description) + estimateTextTokens(string(s.Parameters))
+		}
+	}
+	avail := a.contextWindow - est - outputBudgetReserve
+	if budget <= avail {
+		return 0, false // full budget still fits; keep the default
+	}
+	if avail < minOutputBudget {
+		return minOutputBudget, true // never clip below a usable floor
+	}
+	return avail, true
+}
+
+// outputBudgetReserve absorbs per-message estimate drift against the real
+// tokenizer when clipping a shared-window output budget.
+const outputBudgetReserve = 8192
+
+// minOutputBudget is the floor for a clipped shared-window budget: a request
+// that near-exhausts the window still needs room to emit a tool call.
+const minOutputBudget = 8 * 1024
+
+// MaybeCompactOnResume compacts a freshly resumed session before the first
+// send when the prompt cannot fit inside the provider's shared context window
+// alongside the output budget (DeepSeek rejects input + max_output_tokens >
+// context_window with HTTP 400), or when the cache is cold and the prompt has
+// grown past the budget-aware force mark. Warm resumes with a small prompt are
+// left untouched so the cached prefix survives. Never rewrites the canonical
+// transcript; only the model-visible projection changes.
+func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
+	if a == nil || a.session == nil || a.contextWindow <= 0 {
+		return
+	}
+	if !sharesContextWindow(a.prov) {
+		return
+	}
+	msgs, _ := a.session.snapshotMessagesVersion()
+	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	budget := a.outputBudget
+	if a.maxOutputTokens > 0 {
+		budget = a.maxOutputTokens
+	}
+	// The prompt alone already leaves no room for output: any request would be
+	// rejected regardless of cache state. Compact unconditionally.
+	if est >= a.contextWindow-minOutputBudget-outputBudgetReserve {
+		if err := a.CompactNow(ctx, ""); err == nil {
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
+				"resumed session prompt ~%d tokens est. exceeds the shared context window's input allowance — compacted before first send", est)})
+		}
+		return
+	}
+	// Cold cache + prompt past the budget-aware force mark: a full-history
+	// replay would pay the miss price on the whole prefix. Compact once so the
+	// first send is a small, stable, cacheable prefix.
+	if budget > 0 && a.cacheState == CacheStateCold && est >= a.forceThreshold() {
+		if err := a.CompactNow(ctx, ""); err == nil {
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
+				"resumed after provider-cache expiry with ~%d tokens est. — compacted before first send (cold replay would pay full price)", est)})
+		}
+	}
+}
+
 // tokPerChar derives a tokens-per-character ratio from the last turn's real
 // usage so per-message estimates track the provider's tokenizer without a local
 // one. Reasoning content is excluded from the char count to match the prompt
@@ -644,7 +770,6 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 			a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing, UsageSource: event.UsageSourceCompaction})
 		}
 	}()
-	defer trackPublishedHostStream(ctx, cancel)()
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleSystem, Content: sys},
@@ -656,7 +781,6 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 		return "", usage, err
 	}
 
-	// Unblock on timeout if the stream stalls while open.
 	var b strings.Builder
 	for {
 		select {

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -498,11 +498,7 @@ func toolCallIDs(m provider.Message) map[string]bool {
 func (a *Agent) planCompaction(msgs []provider.Message, min int) (head, start int, ok bool) {
 	head = a.pinnedPrefixLen(msgs)
 	if a.contextWindow > 0 {
-		budget := defaultTailTokens
-		if maxByWin := int(float64(a.contextWindow) * defaultCompactTarget); maxByWin < budget {
-			budget = maxByWin
-		}
-		start = tailStart(msgs, head, budget, a.tokPerChar(), a.tailFloor())
+		start = tailStart(msgs, head, a.compactionTailBudget(), a.tokPerChar(), a.tailFloor())
 	} else {
 		// No window to budget against (manual /compact on an unconfigured
 		// provider): keep a fixed count of recent messages, aligned off any tool.
@@ -525,6 +521,16 @@ func (a *Agent) tailFloor() int {
 		return a.recentKeep
 	}
 	return minRecentKeep
+}
+
+// compactionTailBudget is the token budget for the verbatim recent tail kept
+// out of a fold. Shared by the full and incremental compaction paths.
+func (a *Agent) compactionTailBudget() int {
+	budget := defaultTailTokens
+	if maxByWin := int(float64(a.contextWindow) * defaultCompactTarget); maxByWin < budget {
+		budget = maxByWin
+	}
+	return budget
 }
 
 // tailStart walks newest→oldest, growing the verbatim tail until the next

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -239,6 +239,29 @@ func estimateTextTokens(s string) int {
 	return byBytes
 }
 
+// estimatedPromptTokens returns a conservative prompt-token estimate for the
+// overflow-guard paths (preflight force, resume gate, shared-window budget
+// clipping). The fixed estimator under-counts CJK-heavy transcripts (measured
+// ~1.8x on a real 4.3K-message session: estimated 681K vs 1.24M actual), so
+// without usage data it applies the safety factor; once a turn reports real
+// usage, tokPerChar calibrates the estimate instead.
+func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
+	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if est <= 0 {
+		return 0
+	}
+	tpc := a.tokPerChar()
+	if tpc > 0 && tpc != fallbackTokPerChar {
+		return int(float64(est) * tpc / fallbackTokPerChar)
+	}
+	return est * promptEstimateSafetyFactor
+}
+
+// promptEstimateSafetyFactor is the measured under-count of the fixed CJK
+// estimator before any usage calibrates it (~1.8x real, rounded up so the
+// overflow guards stay inside the provider window).
+const promptEstimateSafetyFactor = 2
+
 // SummarizeFrom replaces the messages from fromIdx onward with a single summary,
 // keeping everything before it verbatim ("summarize from here"). fromIdx is a turn
 // boundary (a user message), so the split never severs a tool_call/result pair —
@@ -648,7 +671,7 @@ func (a *Agent) effectiveOutputBudget(msgs []provider.Message) (int, bool) {
 	if budget <= 0 {
 		return 0, false
 	}
-	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	est := a.estimatedPromptTokens(msgs)
 	if a.session != nil {
 		est += estimateTextTokens(a.systemPrompt())
 	}
@@ -690,7 +713,7 @@ func (a *Agent) MaybeCompactOnResume(ctx context.Context) {
 		return
 	}
 	msgs, _ := a.session.snapshotMessagesVersion()
-	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	est := a.estimatedPromptTokens(msgs)
 	budget := a.outputBudget
 	if a.maxOutputTokens > 0 {
 		budget = a.maxOutputTokens

--- a/internal/agent/compact_incremental_test.go
+++ b/internal/agent/compact_incremental_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestIncrementalFoldRangeBoundsFoldToAppendedMessages(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "u1"},
+		{Role: provider.RoleAssistant, Content: "a1"},
+		{Role: provider.RoleUser, Content: "u2"},
+		{Role: provider.RoleAssistant, Content: "a2"},
+		{Role: provider.RoleUser, Content: strings.Repeat("x ", 5000)}, // appended large
+		{Role: provider.RoleAssistant, Content: "a3"},
+		{Role: provider.RoleUser, Content: "u4"},
+		{Role: provider.RoleAssistant, Content: "a4"},
+	}
+	a := &Agent{contextWindow: 100000}
+	head, start, ok := a.incrementalFoldRange(msgs, 5)
+	if !ok {
+		t.Fatal("expected a foldable range after the covered prefix")
+	}
+	if head != 5 {
+		t.Fatalf("head = %d, want the covered boundary 5", head)
+	}
+	if start <= head || start > len(msgs) {
+		t.Fatalf("start = %d out of (5, %d]", start, len(msgs))
+	}
+	if fold := msgs[head:start]; len(fold) == 0 {
+		t.Fatal("fold is empty")
+	}
+	// An orphan tool message at the boundary is skipped backward, never folded.
+	withTool := append(append([]provider.Message(nil), msgs[:5]...),
+		provider.Message{Role: provider.RoleTool, Content: "orphan result"})
+	withTool = append(withTool, msgs[5:]...)
+	head, _, ok = a.incrementalFoldRange(withTool, 5)
+	if ok && head > 5 {
+		t.Fatalf("orphan tool at boundary not skipped: head=%d", head)
+	}
+}
+
+func TestIncrementalFoldKeepsPriorProjectionBytes(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
+		{Role: provider.RoleAssistant, Content: "b"},
+		{Role: provider.RoleUser, Content: "c"},
+		{Role: provider.RoleAssistant, Content: "d"},
+		{Role: provider.RoleUser, Content: "e"},
+		{Role: provider.RoleAssistant, Content: "f"},
+	}}
+	ctx := context.Background()
+	prov := &fakeProvider{reply: "s"}
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 20000,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+
+	// First compaction (no projection) installs a full fold. Manual trigger
+	// always degrades to the full path, so this exercises the baseline.
+	if _, err := a.compactToProjection(ctx, CompactionTriggerManual, "", true); err != nil {
+		t.Fatalf("first compact: %v", err)
+	}
+	proj1 := a.compactionState.Projection
+	if len(proj1.Messages) == 0 {
+		t.Fatal("first compaction installed no projection")
+	}
+	if proj1.CoveredCount != len(sess.Messages) {
+		t.Fatalf("first compaction covered %d, want %d", proj1.CoveredCount, len(sess.Messages))
+	}
+
+	// Append enough new content to overflow the recent-tail budget (10K tokens
+	// at 20K window), so a foldable slice exists after the covered boundary.
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("x ", 5000)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "h"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("y ", 5000)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "j"})
+
+	// Auto-triggered compaction must take the incremental path: fold only the
+	// appended messages and append the digest to the existing projection.
+	prov.got = nil
+	if _, err := a.compactToProjection(ctx, CompactionTriggerPressure, "", false); err != nil {
+		t.Fatalf("incremental compact: %v", err)
+	}
+	proj2 := a.compactionState.Projection
+
+	if len(proj2.Messages) < len(proj1.Messages) {
+		t.Fatalf("incremental projection shrank: %d < %d", len(proj2.Messages), len(proj1.Messages))
+	}
+	for i := range proj1.Messages {
+		if !reflect.DeepEqual(proj2.Messages[i], proj1.Messages[i]) {
+			t.Fatalf("prior projection message %d changed under incremental fold", i)
+		}
+	}
+	if proj2.CoveredCount != len(sess.Messages) {
+		t.Fatalf("incremental covered = %d, want %d", proj2.CoveredCount, len(sess.Messages))
+	}
+	if prov.got == nil {
+		t.Fatal("incremental fold never reached the summarizer")
+	}
+	var joined []string
+	for _, m := range prov.got {
+		joined = append(joined, m.Content)
+	}
+	joinedAll := strings.Join(joined, "|")
+	if strings.Contains(joinedAll, strings.Repeat("a ", 500)) {
+		t.Fatalf("incremental fold re-folded covered history: %s", joinedAll[:min(len(joinedAll), 160)])
+	}
+}
+
+func TestManualCompactDegradesToFullFold(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
+		{Role: provider.RoleAssistant, Content: "b"},
+	}}
+	ctx := context.Background()
+	prov := &fakeProvider{reply: "s"}
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 20000,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+
+	if _, err := a.compactToProjection(ctx, CompactionTriggerManual, "", true); err != nil {
+		t.Fatalf("first compact: %v", err)
+	}
+	proj1 := a.compactionState.Projection
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "extra turn"})
+
+	// Manual compaction re-folds from the pinned prefix, not from the covered
+	// boundary, so the digest chain is merged instead of appended.
+	if _, err := a.compactToProjection(ctx, CompactionTriggerManual, "", true); err != nil {
+		t.Fatalf("manual compact: %v", err)
+	}
+	proj2 := a.compactionState.Projection
+	if len(proj2.Messages) >= len(proj1.Messages) && reflect.DeepEqual(proj2.Messages[:min(len(proj1.Messages), len(proj2.Messages))], proj1.Messages) {
+		// A full re-fold may coincidentally keep the same bytes; the invariant
+		// that matters is the projection was rebuilt from the canonical prefix.
+		t.Log("manual re-fold kept prior bytes (legitimate full-path result)")
+	}
+	if proj2.CoveredCount != len(sess.Messages) {
+		t.Fatalf("manual covered = %d, want %d", proj2.CoveredCount, len(sess.Messages))
+	}
+}

--- a/internal/agent/compact_incremental_test.go
+++ b/internal/agent/compact_incremental_test.go
@@ -37,13 +37,77 @@ func TestIncrementalFoldRangeBoundsFoldToAppendedMessages(t *testing.T) {
 	if fold := msgs[head:start]; len(fold) == 0 {
 		t.Fatal("fold is empty")
 	}
-	// An orphan tool message at the boundary is skipped backward, never folded.
+	// An orphan tool result at the boundary belongs to a turn whose tool_calls
+	// live before covered; folding it would duplicate base content, so the
+	// incremental range must decline and let the caller fall back to full.
 	withTool := append(append([]provider.Message(nil), msgs[:5]...),
 		provider.Message{Role: provider.RoleTool, Content: "orphan result"})
 	withTool = append(withTool, msgs[5:]...)
-	head, _, ok = a.incrementalFoldRange(withTool, 5)
-	if ok && head > 5 {
-		t.Fatalf("orphan tool at boundary not skipped: head=%d", head)
+	if _, _, ok := a.incrementalFoldRange(withTool, 5); ok {
+		t.Fatal("orphan tool at the covered boundary must degrade, not fold")
+	}
+	// Degenerate transcripts: a tool run at the very front must degrade
+	// (no panic, head clamped), while a single appended message after covered
+	// is still a valid one-message fold.
+	allTool := []provider.Message{
+		{Role: provider.RoleTool, Content: "t1"},
+		{Role: provider.RoleTool, Content: "t2"},
+		{Role: provider.RoleUser, Content: "u"},
+	}
+	if _, _, ok := a.incrementalFoldRange(allTool, 0); ok {
+		t.Fatal("tool run at the very front must degrade")
+	}
+	if _, _, ok := a.incrementalFoldRange(allTool, 2); !ok {
+		t.Fatal("single appended message after covered must be foldable")
+	}
+}
+
+func TestIncrementalFoldKeepsAppendedSmallUserTurns(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
+		{Role: provider.RoleAssistant, Content: "b"},
+		{Role: provider.RoleUser, Content: "c"},
+		{Role: provider.RoleAssistant, Content: "d"},
+		{Role: provider.RoleUser, Content: "e"},
+		{Role: provider.RoleAssistant, Content: "f"},
+	}}
+	ctx := context.Background()
+	prov := &fakeProvider{reply: "s"}
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 20000,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+	if _, err := a.compactToProjection(ctx, CompactionTriggerManual, "", true); err != nil {
+		t.Fatalf("first compact: %v", err)
+	}
+	proj1 := a.compactionState.Projection
+
+	// Append large content (needs a fold) followed by a small user turn that
+	// lands in the recent tail; it must survive into the projection, and the
+	// incremental path must not skip appended turns like full-path early ones.
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("x ", 5000)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "a2"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("y ", 5000)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "b2"})
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "important fact"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "z"})
+
+	if _, err := a.compactToProjection(ctx, CompactionTriggerPressure, "", false); err != nil {
+		t.Fatalf("incremental compact: %v", err)
+	}
+	proj2 := a.compactionState.Projection
+	if len(proj2.Messages) <= len(proj1.Messages) {
+		t.Fatalf("incremental projection did not grow: %d -> %d", len(proj1.Messages), len(proj2.Messages))
+	}
+	var contents []string
+	for _, m := range proj2.Messages {
+		contents = append(contents, m.Content)
+	}
+	joined := strings.Join(contents, "|")
+	if !strings.Contains(joined, "important fact") {
+		t.Fatalf("appended small user turn was dropped from the projection: %s", joined[:min(len(joined), 200)])
 	}
 }
 

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"reasonix/internal/event"
@@ -607,8 +608,25 @@ func (a *Agent) installPruneProjection(view []provider.Message, st PruneStats) e
 }
 
 // emitCompactionTelemetry records structured compaction observability without
-// logging sensitive transcript content.
+// logging sensitive transcript content. The slog record persists to the
+// session's log file (CLI binds the default logger to ~/.reasonix/logs), so a
+// later cache-miss window can be attributed to a specific compaction.
 func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
+	attrs := []any{
+		"trigger", t.Trigger, "mode", t.Mode, "cache", t.CacheState,
+		"src", t.SourceTokens, "proj", t.ProjectionTokens,
+		"in", t.InputTokens, "out", t.OutputTokens,
+		"hit", t.CacheHitTokens, "miss", t.CacheMissTokens,
+		"write", t.CacheWriteTokens, "reqs", t.RequestCount,
+	}
+	if t.ProviderRequestID != "" {
+		attrs = append(attrs, "provider_request_id", t.ProviderRequestID)
+	}
+	if t.Error != "" {
+		slog.Warn("agent: compaction", append(attrs, "err", t.Error)...)
+	} else {
+		slog.Info("agent: compaction", attrs...)
+	}
 	detail := fmt.Sprintf("trigger=%s mode=%s cache=%s src=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d",
 		t.Trigger, t.Mode, t.CacheState, t.SourceTokens, t.ProjectionTokens,
 		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount)

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -153,6 +153,12 @@ func (a *Agent) tryIncrementalFold(ctx context.Context, trigger, instructions st
 	if err != nil || outcome != CompactionInstalled {
 		return outcome, err
 	}
+	// Chain invariant: an incremental step must strictly advance coverage. A
+	// projection that does not move is a stale chain link — fail closed rather
+	// than keep riding it (Sovereign chainAssoc analog: every step well-defined).
+	if got := a.compactionState.Projection.CoveredCount; got <= base.CoveredCount {
+		return CompactionNoop, fmt.Errorf("incremental fold did not advance coverage (%d → %d)", base.CoveredCount, got)
+	}
 	// The incremental fold keeps prior bytes (prefix hit) but may leave the
 	// projection too close to the trigger; converge with one full re-fold (the
 	// recursive call takes the full path — the new projection covers all).
@@ -214,9 +220,10 @@ func (a *Agent) incrementalFoldRange(msgs []provider.Message, covered int) (head
 	return head, start, true
 }
 
-// projectionCompactBudget is the projection-size ceiling. A projection above
-// this stops being extended incrementally and is re-folded wholesale instead,
-// so the digest chain is merged (A1) rather than grown unbounded.
+// projectionCompactBudget is the projection-size ceiling before a wholesale
+// re-fold (digest merge): below it the incremental path extends the projection,
+// at or above it only the full path applies. Half the window keeps the view
+// comfortably under the 80% fold trigger even with a fresh tail.
 func (a *Agent) projectionCompactBudget() int {
 	if a.contextWindow <= 0 {
 		return 0

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -23,6 +23,12 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // as a hard failure rather than sending the oversized canonical prompt.
 func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
 	msgs, transcriptVersion := a.session.snapshotMessagesVersion()
+	// Incremental fold: with a valid projection, fold only the appended
+	// messages and append the digest — prior bytes keep hitting. Manual/
+	// overflow or an oversized projection degrades to a full re-fold.
+	if base, head, start, ok := a.incrementalFoldTarget(msgs, transcriptVersion, trigger); ok {
+		return a.compactIncremental(ctx, trigger, instructions, force, base, msgs, transcriptVersion, head, start)
+	}
 	head, start, ok := a.planCompaction(msgs, minCompactMessages)
 	if !ok {
 		head, start, ok = a.planCompaction(msgs, 1)
@@ -130,6 +136,81 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	a.emitCompactionTelemetry(tele)
 
 	projVersion := a.compactionState.Projection.ProjectionVersion + 1
+	st := a.buildCompactionState(projMsgs, msgs, transcriptVersion, summary, mode, usage, sourceTokens, projTokens, projVersion, trigger)
+	if err := a.installProjection(st); err != nil {
+		a.emitCompactionAborted(trigger)
+		return CompactionNoop, fmt.Errorf("persist projection: %w", err)
+	}
+	a.session.NoteContentRewrite("compact_" + trigger)
+
+	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
+		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
+	}})
+	return CompactionInstalled, nil
+}
+
+// incrementalFoldTarget picks the incremental path (append to the existing
+// projection) over a full re-fold: a valid projection with un-covered messages
+// under the projection budget, not a manual/overflow trigger, and no trailing
+// user run that appending would coalesce across.
+func (a *Agent) incrementalFoldTarget(msgs []provider.Message, transcriptVersion uint64, trigger string) (baseProj ContextProjection, head, start int, ok bool) {
+	st := a.compactionState
+	if !projectionValid(st, msgs, transcriptVersion, a.currentPromptCacheKey()) {
+		return ContextProjection{}, 0, 0, false
+	}
+	covered := st.Projection.CoveredCount
+	if covered <= 0 || covered >= len(msgs) {
+		return ContextProjection{}, 0, 0, false
+	}
+	if st.Projection.ProjectionTokens >= a.projectionCompactBudget() {
+		return ContextProjection{}, 0, 0, false
+	}
+	if trigger == CompactionTriggerManual || trigger == CompactionTriggerOverflow {
+		return ContextProjection{}, 0, 0, false
+	}
+	if a.strictAlternatingRoles && len(st.Projection.Messages) > 0 &&
+		st.Projection.Messages[len(st.Projection.Messages)-1].Role == provider.RoleUser {
+		return ContextProjection{}, 0, 0, false
+	}
+	head, start, ok = a.incrementalFoldRange(msgs, covered)
+	if !ok {
+		return ContextProjection{}, 0, 0, false
+	}
+	return st.Projection, head, start, true
+}
+
+// incrementalFoldRange returns the canonical range [head,start) a fold should
+// cover when a projection already covers the earlier history: only the messages
+// appended since that projection, aligned off any tool message so the fold never
+// begins with an orphan tool result. ok is false when there is nothing new.
+func (a *Agent) incrementalFoldRange(msgs []provider.Message, covered int) (head, start int, ok bool) {
+	head = covered
+	for head < len(msgs) && msgs[head].Role == provider.RoleTool {
+		head--
+	}
+	if head < covered-4 || head < 0 {
+		return covered, covered, false
+	}
+	start = tailStart(msgs, head, a.compactionTailBudget(), a.tokPerChar(), a.tailFloor())
+	if start <= head {
+		return head, start, false
+	}
+	return head, start, true
+}
+
+// projectionCompactBudget is the projection-size ceiling. A projection above
+// this stops being extended incrementally and is re-folded wholesale instead,
+// so the digest chain is merged (A1) rather than grown unbounded.
+func (a *Agent) projectionCompactBudget() int {
+	if a.contextWindow <= 0 {
+		return 0
+	}
+	return int(float64(a.contextWindow) * 0.5)
+}
+
+// buildCompactionState assembles the sidecar payload shared by the full and
+// incremental fold paths.
+func (a *Agent) buildCompactionState(projMsgs []provider.Message, msgs []provider.Message, transcriptVersion uint64, summary, mode string, usage *provider.Usage, sourceTokens, projTokens int, projVersion uint64, trigger string) CompactionState {
 	st := CompactionState{
 		SchemaVersion:     compactionStateSchemaV1,
 		TranscriptVersion: transcriptVersion,
@@ -155,6 +236,110 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	if a.pricing != nil && usage != nil {
 		st.LastCompactionCost = a.pricing.Cost(usage)
 	}
+	return st
+}
+
+// compactIncremental folds only the canonical messages appended since the last
+// projection, then appends the new digest to the existing projection messages.
+// The prior projection bytes are untouched (the server prefix keeps hitting);
+// only the newly added segment is re-shaped. Canonical history is never
+// rewritten; dropped originals are archived as in the full path.
+func (a *Agent) compactIncremental(ctx context.Context, trigger, instructions string, force bool, baseProj ContextProjection, msgs []provider.Message, transcriptVersion uint64, head, start int) (CompactionOutcome, error) {
+	region := msgs[head:start]
+	kept, fold := a.partitionFoldForProjection(region)
+	if len(fold) == 0 {
+		return CompactionNoop, nil
+	}
+	if !force && !foldEconomics(fold) {
+		return CompactionNoop, nil
+	}
+
+	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
+
+	if a.hooks != nil {
+		if hookInstr := a.hooks.PreCompact(ctx, trigger); hookInstr != "" {
+			if instructions != "" {
+				instructions += "\n"
+			}
+			instructions += hookInstr
+		}
+	}
+
+	var err error
+	fold, instructions, err = a.interceptCompactionPrepare(ctx, fold, instructions)
+	if err != nil {
+		a.emitCompactionAborted(trigger)
+		return CompactionNoop, err
+	}
+	if len(fold) == 0 {
+		a.emitCompactionAborted(trigger)
+		return CompactionNoop, nil
+	}
+
+	archived := ""
+	if a.archiveDir != "" {
+		path, aerr := archiveMessages(a.archiveDir, fold)
+		if aerr != nil {
+			a.emitCompactionAborted(trigger)
+			return CompactionNoop, fmt.Errorf("archive: %w", aerr)
+		}
+		archived = path
+	}
+
+	sourceTokens := estimateMessagesTokens(provider.ModelMessages(msgs))
+	summary, mode, usage, providerReqID, err := a.runCompactionSummary(ctx, fold, instructions)
+	tele := CompactionTelemetry{
+		Trigger:           trigger,
+		CacheState:        a.CacheState(),
+		Mode:              mode,
+		Native:            mode == CompactionModeNative,
+		SourceTokens:      sourceTokens,
+		ProviderRequestID: providerReqID,
+	}
+	if usage != nil {
+		tele.InputTokens = usage.PromptTokens
+		tele.OutputTokens = usage.CompletionTokens
+		tele.CacheHitTokens = usage.CacheHitTokens
+		tele.CacheMissTokens = usage.CacheMissTokens
+		tele.CacheWriteTokens = usage.CacheWriteTokens
+		tele.RequestCount = usage.RequestCount
+		if tele.RequestCount <= 0 {
+			tele.RequestCount = 1
+		}
+	}
+	if err != nil {
+		tele.Error = err.Error()
+		a.emitCompactionTelemetry(tele)
+		a.emitCompactionAborted(trigger)
+		return CompactionNoop, err
+	}
+
+	summary, err = a.interceptCompactionComplete(ctx, summary)
+	if err != nil {
+		tele.Error = err.Error()
+		a.emitCompactionTelemetry(tele)
+		a.emitCompactionAborted(trigger)
+		return CompactionNoop, err
+	}
+
+	// Append-only rebuild: prior bytes verbatim; coalescing only the added
+	// segment (the caller degraded to a full fold when the boundary touches a
+	// trailing user run).
+	base := append([]provider.Message(nil), baseProj.Messages...)
+	added := append([]provider.Message{formatSummaryMessage(summary)}, kept...)
+	added = append(added, msgs[start:]...)
+	added = provider.ModelMessages(added)
+	if a.strictAlternatingRoles {
+		added = coalesceProjectionUserRuns(added)
+	}
+	projMsgs := append(base, added...)
+
+	projTokens := estimateMessagesTokens(projMsgs)
+	tele.ProjectionTokens = projTokens
+	a.emitCompactionTelemetry(tele)
+
+	projVersion := baseProj.ProjectionVersion + 1
+	st := a.buildCompactionState(projMsgs, msgs, transcriptVersion, summary, mode, usage, sourceTokens, projTokens, projVersion, trigger)
 	if err := a.installProjection(st); err != nil {
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, fmt.Errorf("persist projection: %w", err)

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -22,11 +22,20 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // installed (nothing to fold); callers at the force threshold must treat that
 // as a hard failure rather than sending the oversized canonical prompt.
 func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
-	msgs, transcriptVersion := a.session.snapshotMessagesVersion()
+	canonical, transcriptVersion := a.session.snapshotMessagesVersion()
+	// Fold against the current model-visible view when a projection is valid:
+	// an installed prune/snip projection already collapsed stale tool results.
+	// Coverage still maps to the canonical transcript below.
+	msgs := canonical
+	if st := a.compactionState; projectionValid(st, canonical, transcriptVersion, a.currentPromptCacheKey()) {
+		if visible := modelVisibleFromProjection(st.Projection, canonical); len(visible) > 0 {
+			msgs = visible
+		}
+	}
 	// Incremental fold: with a valid projection, fold only the appended
 	// messages and append the digest — prior bytes keep hitting; otherwise a
 	// full re-fold (digest merge) is a rare prefix rewrite.
-	if outcome, err := a.tryIncrementalFold(ctx, trigger, instructions, force, msgs, transcriptVersion); err != nil || outcome != CompactionNoop {
+	if outcome, err := a.tryIncrementalFold(ctx, trigger, instructions, force, canonical, transcriptVersion); err != nil || outcome != CompactionNoop {
 		return outcome, err
 	}
 	head, start, kept, fold, ok := a.planFold(msgs, force)
@@ -119,7 +128,7 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	a.emitCompactionTelemetry(tele)
 
 	projVersion := a.compactionState.Projection.ProjectionVersion + 1
-	st := a.buildCompactionState(projMsgs, msgs, transcriptVersion, summary, mode, usage, sourceTokens, projTokens, projVersion, trigger)
+	st := a.buildCompactionState(projMsgs, canonical, transcriptVersion, summary, mode, usage, sourceTokens, projTokens, projVersion, trigger)
 	if err := a.installProjection(st); err != nil {
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, fmt.Errorf("persist projection: %w", err)
@@ -253,6 +262,14 @@ func (a *Agent) buildCompactionState(projMsgs []provider.Message, msgs []provide
 func (a *Agent) compactIncremental(ctx context.Context, trigger, instructions string, force bool, baseProj ContextProjection, msgs []provider.Message, transcriptVersion uint64, head, start int) (CompactionOutcome, error) {
 	region := msgs[head:start]
 	kept, fold := a.partitionFoldForProjectionIncremental(region)
+	if len(fold) == 0 {
+		return CompactionNoop, nil
+	}
+	// Same bound as the full path: a huge appended block must not make one
+	// summarize call blow past summaryTimeout or overflow the window.
+	headTokens := estimateMessagesTokens(provider.ModelMessages(msgs[:head]))
+	tailTokens := estimateMessagesTokens(provider.ModelMessages(msgs[start:]))
+	fold, kept = a.fitFoldToWindow(fold, kept, headTokens, tailTokens)
 	if len(fold) == 0 {
 		return CompactionNoop, nil
 	}
@@ -427,7 +444,9 @@ func (a *Agent) planFold(msgs []provider.Message, force bool) (head, start int, 
 	}
 	region := msgs[head:start]
 	kept, fold = a.partitionFoldForProjection(region)
-	fold, kept = a.fitFoldToWindow(fold, kept)
+	headTokens := estimateMessagesTokens(provider.ModelMessages(msgs[:head]))
+	tailTokens := estimateMessagesTokens(provider.ModelMessages(msgs[start:]))
+	fold, kept = a.fitFoldToWindow(fold, kept, headTokens, tailTokens)
 	if len(fold) == 0 {
 		return 0, 0, nil, nil, false
 	}
@@ -437,42 +456,61 @@ func (a *Agent) planFold(msgs []provider.Message, force bool) (head, start int, 
 	return head, start, kept, fold, true
 }
 
-// fitFoldToWindow shrinks the fold from its newer end when the summarize
-// request would overflow the shared window: a rebuild on an invalidated
-// sidecar starts from canonical (possibly far over the window), so the first
-// fold must still succeed. The conservative message-level estimate guarantees
-// the exact transcript estimate inside summarize is strictly smaller.
-func (a *Agent) fitFoldToWindow(fold, kept []provider.Message) ([]provider.Message, []provider.Message) {
+// maxCompactFoldTokens caps one summarizer fold so a single call finishes
+// within summaryTimeout. The effective cap is the smaller of this and the
+// projection budget (window - head - tail - kept - summary).
+const maxCompactFoldTokens = 600_000
+
+// summaryTokensBudget reserves space for the distilled summary inside the new
+// projection, so the fold budget keeps the projection inside the window.
+const summaryTokensBudget = 12_000
+
+// fitFoldToWindow bounds the fold so the rebuilt projection (head + summary +
+// kept + tail) fits the shared window: fold at least foldTokens - avail but no
+// more than maxCompactFoldTokens per call; the deferred tail folds later.
+func (a *Agent) fitFoldToWindow(fold, kept []provider.Message, headTokens, tailTokens int) ([]provider.Message, []provider.Message) {
 	if a.contextWindow <= minOutputBudget || !sharesContextWindow(a.prov) || len(fold) == 0 {
 		return fold, kept
 	}
-	limit := a.contextWindow - minOutputBudget - estimateTextTokens(summarySystemPrompt)
-	if limit <= 0 {
-		return fold, kept
+	keptTokens := estimateMessagesTokens(provider.ModelMessages(kept))
+	foldTokens := estimateMessagesTokens(provider.ModelMessages(fold))
+	avail := a.contextWindow - minOutputBudget - headTokens - tailTokens - keptTokens - summaryTokensBudget
+	minFold := foldTokens - avail
+	if minFold <= 0 {
+		return fold, kept // the projection already fits; nothing to trim
 	}
+	if minFold > maxCompactFoldTokens {
+		minFold = maxCompactFoldTokens // single-round limit; the rest folds later
+	}
+	// Move the newer tail back into kept until the remaining fold fits the
+	// projection budget; when even maxCompactFoldTokens cannot reach it, fold
+	// the cap and defer the rest to later turns (window may exceed this round).
 	sizes := make([]int, len(fold))
-	total := 0
-	for i, m := range fold {
-		sizes[i] = estimateMessagesTokens([]provider.Message{m})
-		total += sizes[i]
-	}
-	if total < limit {
-		return fold, kept
-	}
-	acc := 0
-	cut := 0
-	for i, s := range sizes {
-		if acc+s >= limit {
-			cut = i
+	remaining := foldTokens
+	cut := len(fold)
+	for i := len(fold) - 1; i >= 0; i-- {
+		sizes[i] = estimateMessagesTokens([]provider.Message{fold[i]})
+		remaining -= sizes[i]
+		cut = i
+		if remaining <= avail {
 			break
 		}
-		acc += s
 	}
-	if cut == 0 {
-		return fold, kept // even one message overflows; let summarize reject
+	if cut == len(fold) || cut == 0 {
+		return fold, kept // nothing to move, or a single message exceeds the budget
 	}
-	moved := append([]provider.Message(nil), fold[cut:]...)
-	return fold[:cut], append(moved, kept...)
+	if folded := foldTokens - remaining; folded > maxCompactFoldTokens {
+		for i := cut - 1; i >= 0; i-- {
+			sizes[i] = estimateMessagesTokens([]provider.Message{fold[i]})
+			remaining -= sizes[i]
+			cut = i
+			if foldTokens-remaining <= maxCompactFoldTokens || cut == 0 {
+				break
+			}
+		}
+	}
+	movedMsgs := append([]provider.Message(nil), fold[cut:]...)
+	return fold[:cut], append(movedMsgs, kept...)
 }
 
 // runCompactionSummary tries native compaction first, then summarizeWithRetry.

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -24,10 +24,10 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
 	msgs, transcriptVersion := a.session.snapshotMessagesVersion()
 	// Incremental fold: with a valid projection, fold only the appended
-	// messages and append the digest — prior bytes keep hitting. Manual/
-	// overflow or an oversized projection degrades to a full re-fold.
-	if base, head, start, ok := a.incrementalFoldTarget(msgs, transcriptVersion, trigger); ok {
-		return a.compactIncremental(ctx, trigger, instructions, force, base, msgs, transcriptVersion, head, start)
+	// messages and append the digest — prior bytes keep hitting; otherwise a
+	// full re-fold (digest merge) is a rare prefix rewrite.
+	if outcome, err := a.tryIncrementalFold(ctx, trigger, instructions, force, msgs, transcriptVersion); err != nil || outcome != CompactionNoop {
+		return outcome, err
 	}
 	head, start, ok := a.planCompaction(msgs, minCompactMessages)
 	if !ok {
@@ -149,6 +149,27 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	return CompactionInstalled, nil
 }
 
+// tryIncrementalFold runs the incremental path when a valid projection covers
+// the earlier history. Returns CompactionNoop when no incremental fold applies.
+func (a *Agent) tryIncrementalFold(ctx context.Context, trigger, instructions string, force bool, msgs []provider.Message, transcriptVersion uint64) (CompactionOutcome, error) {
+	base, head, start, ok := a.incrementalFoldTarget(msgs, transcriptVersion, trigger)
+	if !ok {
+		return CompactionNoop, nil
+	}
+	outcome, err := a.compactIncremental(ctx, trigger, instructions, force, base, msgs, transcriptVersion, head, start)
+	if err != nil || outcome != CompactionInstalled {
+		return outcome, err
+	}
+	// The incremental fold keeps prior bytes (prefix hit) but may leave the
+	// projection too close to the trigger; converge with one full re-fold (the
+	// recursive call takes the full path — the new projection covers all).
+	_, _, high := a.compactThresholds()
+	if a.estimatedPromptTokens(a.compactionState.Projection.Messages) >= high-a.compactionTailBudget() {
+		return a.compactToProjection(ctx, trigger, instructions, force)
+	}
+	return CompactionInstalled, nil
+}
+
 // incrementalFoldTarget picks the incremental path (append to the existing
 // projection) over a full re-fold: a valid projection with un-covered messages
 // under the projection budget, not a manual/overflow trigger, and no trailing
@@ -162,7 +183,7 @@ func (a *Agent) incrementalFoldTarget(msgs []provider.Message, transcriptVersion
 	if covered <= 0 || covered >= len(msgs) {
 		return ContextProjection{}, 0, 0, false
 	}
-	if st.Projection.ProjectionTokens >= a.projectionCompactBudget() {
+	if a.estimatedPromptTokens(st.Projection.Messages) >= a.projectionCompactBudget() {
 		return ContextProjection{}, 0, 0, false
 	}
 	if trigger == CompactionTriggerManual || trigger == CompactionTriggerOverflow {
@@ -185,10 +206,12 @@ func (a *Agent) incrementalFoldTarget(msgs []provider.Message, transcriptVersion
 // begins with an orphan tool result. ok is false when there is nothing new.
 func (a *Agent) incrementalFoldRange(msgs []provider.Message, covered int) (head, start int, ok bool) {
 	head = covered
-	for head < len(msgs) && msgs[head].Role == provider.RoleTool {
+	for head >= 0 && head < len(msgs) && msgs[head].Role == provider.RoleTool {
 		head--
 	}
-	if head < covered-4 || head < 0 {
+	// A tool result at the boundary belongs to a pre-covered turn; folding it
+	// would duplicate base content, so degrade and let the caller use full.
+	if head < covered {
 		return covered, covered, false
 	}
 	start = tailStart(msgs, head, a.compactionTailBudget(), a.tokPerChar(), a.tailFloor())
@@ -246,7 +269,7 @@ func (a *Agent) buildCompactionState(projMsgs []provider.Message, msgs []provide
 // rewritten; dropped originals are archived as in the full path.
 func (a *Agent) compactIncremental(ctx context.Context, trigger, instructions string, force bool, baseProj ContextProjection, msgs []provider.Message, transcriptVersion uint64, head, start int) (CompactionOutcome, error) {
 	region := msgs[head:start]
-	kept, fold := a.partitionFoldForProjection(region)
+	kept, fold := a.partitionFoldForProjectionIncremental(region)
 	if len(fold) == 0 {
 		return CompactionNoop, nil
 	}
@@ -357,6 +380,18 @@ func (a *Agent) compactIncremental(ctx context.Context, trigger, instructions st
 // turns are excluded from both kept and fold — the caller re-inserts them from
 // the full transcript so their bytes stay position-stable.
 func (a *Agent) partitionFoldForProjection(region []provider.Message) (kept, fold []provider.Message) {
+	return a.partitionFoldForProjectionMode(region, true)
+}
+
+// partitionFoldForProjectionIncremental is the incremental-path variant: the
+// fixed early-window skip is disabled because the fold region starts at the
+// covered boundary — there is no early user prefix to re-insert, and skipping
+// would silently drop freshly appended small user turns from the projection.
+func (a *Agent) partitionFoldForProjectionIncremental(region []provider.Message) (kept, fold []provider.Message) {
+	return a.partitionFoldForProjectionMode(region, false)
+}
+
+func (a *Agent) partitionFoldForProjectionMode(region []provider.Message, skipEarly bool) (kept, fold []provider.Message) {
 	policyKeep := keepIndexes(region, a.keepPolicy)
 	earlySeen := 0
 	const maxEarly = 3
@@ -366,7 +401,7 @@ func (a *Agent) partitionFoldForProjection(region []provider.Message) (kept, fol
 		}
 		// Skip the fixed early small user turns — they are re-added from the
 		// full transcript after the summary so the prefix stays byte-stable.
-		if m.Role == provider.RoleUser && !isCompactionSummary(m) && a.fixedPinnableUserTurn(m) && earlySeen < maxEarly {
+		if skipEarly && m.Role == provider.RoleUser && !isCompactionSummary(m) && a.fixedPinnableUserTurn(m) && earlySeen < maxEarly {
 			earlySeen++
 			continue
 		}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -29,25 +29,8 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	if outcome, err := a.tryIncrementalFold(ctx, trigger, instructions, force, msgs, transcriptVersion); err != nil || outcome != CompactionNoop {
 		return outcome, err
 	}
-	head, start, ok := a.planCompaction(msgs, minCompactMessages)
+	head, start, kept, fold, ok := a.planFold(msgs, force)
 	if !ok {
-		head, start, ok = a.planCompaction(msgs, 1)
-	}
-	if !ok {
-		return CompactionNoop, nil
-	}
-	if active := a.activeTurnStart(msgs); active >= head && active < start {
-		start = active
-		if start <= head {
-			return CompactionNoop, nil
-		}
-	}
-	region := msgs[head:start]
-	kept, fold := a.partitionFoldForProjection(region)
-	if len(fold) == 0 {
-		return CompactionNoop, nil
-	}
-	if !force && !foldEconomics(fold) {
 		return CompactionNoop, nil
 	}
 
@@ -422,6 +405,74 @@ func (a *Agent) partitionFoldForProjectionMode(region []provider.Message, skipEa
 		fold = append(fold, m)
 	}
 	return kept, fold
+}
+
+// planFold picks the fold region and applies bounded folding: when the fold
+// alone cannot fit the shared window (an invalidated sidecar rebuild starts
+// from canonical, possibly far over the window), the newer tail drops back
+// into kept instead of failing — later turns fold it.
+func (a *Agent) planFold(msgs []provider.Message, force bool) (head, start int, kept, fold []provider.Message, ok bool) {
+	head, start, ok = a.planCompaction(msgs, minCompactMessages)
+	if !ok {
+		head, start, ok = a.planCompaction(msgs, 1)
+	}
+	if !ok {
+		return 0, 0, nil, nil, false
+	}
+	if active := a.activeTurnStart(msgs); active >= head && active < start {
+		start = active
+		if start <= head {
+			return 0, 0, nil, nil, false
+		}
+	}
+	region := msgs[head:start]
+	kept, fold = a.partitionFoldForProjection(region)
+	fold, kept = a.fitFoldToWindow(fold, kept)
+	if len(fold) == 0 {
+		return 0, 0, nil, nil, false
+	}
+	if !force && !foldEconomics(fold) {
+		return 0, 0, nil, nil, false
+	}
+	return head, start, kept, fold, true
+}
+
+// fitFoldToWindow shrinks the fold from its newer end when the summarize
+// request would overflow the shared window: a rebuild on an invalidated
+// sidecar starts from canonical (possibly far over the window), so the first
+// fold must still succeed. The conservative message-level estimate guarantees
+// the exact transcript estimate inside summarize is strictly smaller.
+func (a *Agent) fitFoldToWindow(fold, kept []provider.Message) ([]provider.Message, []provider.Message) {
+	if a.contextWindow <= minOutputBudget || !sharesContextWindow(a.prov) || len(fold) == 0 {
+		return fold, kept
+	}
+	limit := a.contextWindow - minOutputBudget - estimateTextTokens(summarySystemPrompt)
+	if limit <= 0 {
+		return fold, kept
+	}
+	sizes := make([]int, len(fold))
+	total := 0
+	for i, m := range fold {
+		sizes[i] = estimateMessagesTokens([]provider.Message{m})
+		total += sizes[i]
+	}
+	if total < limit {
+		return fold, kept
+	}
+	acc := 0
+	cut := 0
+	for i, s := range sizes {
+		if acc+s >= limit {
+			cut = i
+			break
+		}
+		acc += s
+	}
+	if cut == 0 {
+		return fold, kept // even one message overflows; let summarize reject
+	}
+	moved := append([]provider.Message(nil), fold[cut:]...)
+	return fold[:cut], append(moved, kept...)
 }
 
 // runCompactionSummary tries native compaction first, then summarizeWithRetry.

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -264,6 +264,9 @@ func (a *Agent) snipToProjection(ctx context.Context) error {
 // installPruneProjection stores a projection whose messages are a snipped/pruned
 // view of the canonical transcript (no summarizer call).
 func (a *Agent) installPruneProjection(view []provider.Message, st PruneStats) error {
+	// Let the response-side cache-break detector know the prefix intentionally
+	// shrank (snip/prune) — without this, hit-token drops would be misreported.
+	a.session.NoteContentRewrite("snip")
 	msgs, version := a.session.snapshotMessagesVersion()
 	view = provider.ModelMessages(view)
 	src := estimateMessagesTokens(provider.ModelMessages(msgs))

--- a/internal/agent/compaction_telemetry_log_test.go
+++ b/internal/agent/compaction_telemetry_log_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestEmitCompactionTelemetryLogsStructuredAttrs guards the log persistence of
+// compaction telemetry: a later cache-miss window (DeepSeek usage report)
+// must be attributable to a specific compaction via the session log file.
+func TestEmitCompactionTelemetryLogsStructuredAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(orig)
+
+	a := &Agent{sink: event.Discard}
+	a.emitCompactionTelemetry(CompactionTelemetry{
+		Trigger:           "auto",
+		Mode:              "summarized",
+		CacheState:        "warm",
+		SourceTokens:      490272,
+		ProjectionTokens:  374912,
+		InputTokens:       491000,
+		OutputTokens:      3000,
+		CacheHitTokens:    0,
+		CacheMissTokens:   488000,
+		CacheWriteTokens:  0,
+		RequestCount:      1,
+		ProviderRequestID: "req-abc",
+	})
+
+	out := buf.String()
+	for _, want := range []string{"agent: compaction", "trigger=auto", "mode=summarized",
+		"src=490272", "miss=488000", "reqs=1", "provider_request_id=req-abc"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// TestEmitCompactionTelemetryErrorLevelsWarn guards that failed compactions
+// are recorded at Warn level (they are the ones that precede cache misses).
+func TestEmitCompactionTelemetryErrorLevelsWarn(t *testing.T) {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(orig)
+
+	a := &Agent{sink: event.Discard}
+	a.emitCompactionTelemetry(CompactionTelemetry{
+		Trigger: "pressure",
+		Mode:    "summarized",
+		Error:   "context deadline exceeded",
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("failed compaction must log at WARN level\n%s", out)
+	}
+	if !strings.Contains(out, `err="context deadline exceeded"`) && !strings.Contains(out, "err=context") {
+		t.Errorf("log output missing error attr\n%s", out)
+	}
+}

--- a/internal/agent/estimated_tokens_test.go
+++ b/internal/agent/estimated_tokens_test.go
@@ -40,11 +40,8 @@ func TestEstimatedPromptTokensCalibratesWithUsage(t *testing.T) {
 		t.Fatalf("calibrated = %d must exceed raw %d (CJK under-count)", calibrated, raw)
 	}
 	// Both the calibration path and the safety-factor path are conservative;
-	// calibration is allowed to land above the fixed 2x when the real ratio
-	// is tighter than 4 chars/token.
-	if calibrated < raw {
-		t.Fatalf("calibrated = %d must stay positive and above raw %d", calibrated, raw)
-	}
+	// calibration may land above the fixed 2x when the real ratio is tighter
+	// than 4 chars/token — that is still a safe, conservative clip.
 }
 
 // TestEstimatedPromptTokensEmptyIsZero guards the zero-input edge.

--- a/internal/agent/estimated_tokens_test.go
+++ b/internal/agent/estimated_tokens_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestEstimatedPromptTokensSafetyFactor verifies the no-usage conservative
+// factor: the fixed estimator under-counts CJK-heavy transcripts (~1.8x
+// measured), so the overflow guards must see the scaled-up value.
+func TestEstimatedPromptTokensSafetyFactor(t *testing.T) {
+	a := &Agent{}
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: "中文内容" + "的重复内容测试"}}
+	est := a.estimatedPromptTokens(msgs)
+	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if est != raw*promptEstimateSafetyFactor {
+		t.Fatalf("estimatedPromptTokens = %d, want raw %d × factor %d", est, raw, promptEstimateSafetyFactor)
+	}
+	if est <= 0 {
+		t.Fatal("estimate must stay positive")
+	}
+}
+
+// TestEstimatedPromptTokensCalibratesWithUsage verifies tokPerChar calibration
+// replaces the safety factor once a turn reports real usage.
+func TestEstimatedPromptTokensCalibratesWithUsage(t *testing.T) {
+	// CJK-heavy content with a real ratio tighter than the 4 chars/token
+	// fallback: calibration must scale the raw estimate up (toward reality)
+	// without applying the fixed 2x factor on top.
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "中文测试"})
+	a := &Agent{session: sess}
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: "中文测试"}}
+	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
+	// Real usage: 15 chars (3 sys + 12 CJK) at 2 chars/token ≈ 8 prompt tokens.
+	a.lastUsage.Store(&provider.Usage{PromptTokens: 8})
+	calibrated := a.estimatedPromptTokens(msgs)
+	if calibrated <= raw {
+		t.Fatalf("calibrated = %d must exceed raw %d (CJK under-count)", calibrated, raw)
+	}
+	// Both the calibration path and the safety-factor path are conservative;
+	// calibration is allowed to land above the fixed 2x when the real ratio
+	// is tighter than 4 chars/token.
+	if calibrated < raw {
+		t.Fatalf("calibrated = %d must stay positive and above raw %d", calibrated, raw)
+	}
+}
+
+// TestEstimatedPromptTokensEmptyIsZero guards the zero-input edge.
+func TestEstimatedPromptTokensEmptyIsZero(t *testing.T) {
+	a := &Agent{}
+	if got := a.estimatedPromptTokens(nil); got != 0 {
+		t.Fatalf("empty estimate = %d, want 0", got)
+	}
+}

--- a/internal/agent/estimated_tokens_test.go
+++ b/internal/agent/estimated_tokens_test.go
@@ -1,47 +1,74 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"reasonix/internal/provider"
 )
 
 // TestEstimatedPromptTokensSafetyFactor verifies the no-usage conservative
-// factor: the fixed estimator under-counts CJK-heavy transcripts (~1.8x
-// measured), so the overflow guards must see the scaled-up value.
+// factor scales only the CJK share: the fixed estimator under-counts CJK
+// transcripts (~1.8x measured), so the overflow guards must see the
+// CJK-scaled value while English/code stays unscaled.
 func TestEstimatedPromptTokensSafetyFactor(t *testing.T) {
 	a := &Agent{}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: "中文内容" + "的重复内容测试"}}
 	est := a.estimatedPromptTokens(msgs)
 	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
-	if est != raw*promptEstimateSafetyFactor {
-		t.Fatalf("estimatedPromptTokens = %d, want raw %d × factor %d", est, raw, promptEstimateSafetyFactor)
+	want := raw + cjkRunesInMessages(msgs)
+	if est != want {
+		t.Fatalf("estimatedPromptTokens = %d, want raw %d + cjk %d", est, raw, cjkRunesInMessages(msgs))
 	}
 	if est <= 0 {
 		t.Fatal("estimate must stay positive")
 	}
 }
 
+// TestEstimatedPromptTokensEnglishColdStartNotScaled guards the reported
+// regression: an English/code session at ~40% real occupancy must not be
+// doubled into the compaction threshold on a cold start (no usage yet).
+func TestEstimatedPromptTokensEnglishColdStartNotScaled(t *testing.T) {
+	a := &Agent{}
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("the quick brown fox ", 200)}}
+	est := a.estimatedPromptTokens(msgs)
+	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if est != raw {
+		t.Fatalf("English cold-start estimate = %d, want raw %d (no 2x)", est, raw)
+	}
+}
+
+// TestEstimatedPromptTokensMixedScalesByCJKShare verifies a mixed transcript
+// scales only its CJK portion, landing between ×1 and ×2.
+func TestEstimatedPromptTokensMixedScalesByCJKShare(t *testing.T) {
+	a := &Agent{}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: strings.Repeat("english code text ", 100)},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("中文回复内容", 100)},
+	}
+	est := a.estimatedPromptTokens(msgs)
+	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
+	if est <= raw {
+		t.Fatalf("mixed estimate %d must exceed raw %d (CJK under-count)", est, raw)
+	}
+	if est >= raw*2 {
+		t.Fatalf("mixed estimate %d must stay below raw×2 %d (English unscaled)", est, raw*2)
+	}
+}
+
 // TestEstimatedPromptTokensCalibratesWithUsage verifies tokPerChar calibration
 // replaces the safety factor once a turn reports real usage.
 func TestEstimatedPromptTokensCalibratesWithUsage(t *testing.T) {
-	// CJK-heavy content with a real ratio tighter than the 4 chars/token
-	// fallback: calibration must scale the raw estimate up (toward reality)
-	// without applying the fixed 2x factor on top.
 	sess := NewSession("sys")
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "中文测试"})
 	a := &Agent{session: sess}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: "中文测试"}}
 	raw := estimateMessagesTokens(provider.ModelMessages(msgs))
-	// Real usage: 15 chars (3 sys + 12 CJK) at 2 chars/token ≈ 8 prompt tokens.
 	a.lastUsage.Store(&provider.Usage{PromptTokens: 8})
 	calibrated := a.estimatedPromptTokens(msgs)
 	if calibrated <= raw {
 		t.Fatalf("calibrated = %d must exceed raw %d (CJK under-count)", calibrated, raw)
 	}
-	// Both the calibration path and the safety-factor path are conservative;
-	// calibration may land above the fixed 2x when the real ratio is tighter
-	// than 4 chars/token — that is still a safe, conservative clip.
 }
 
 // TestEstimatedPromptTokensEmptyIsZero guards the zero-input edge.

--- a/internal/agent/fit_fold_test.go
+++ b/internal/agent/fit_fold_test.go
@@ -33,7 +33,7 @@ func TestFitFoldToWindowShrinksOversizedFold(t *testing.T) {
 			estimateMessagesTokens(provider.ModelMessages(fold)), limit)
 	}
 
-	gotFold, gotKept := a.fitFoldToWindow(fold, kept)
+	gotFold, gotKept := a.fitFoldToWindow(fold, kept, 0, 0)
 	if len(gotFold) == 0 {
 		t.Fatal("fold must not be emptied by fitting")
 	}
@@ -63,7 +63,7 @@ func TestFitFoldToWindowUnderLimitUntouched(t *testing.T) {
 	}
 	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 1000)}}
 	kept := []provider.Message{{Role: provider.RoleUser, Content: "tail"}}
-	gotFold, gotKept := a.fitFoldToWindow(fold, kept)
+	gotFold, gotKept := a.fitFoldToWindow(fold, kept, 0, 0)
 	if len(gotFold) != 1 || len(gotKept) != 1 {
 		t.Fatalf("small fold must pass through untouched: fold=%d kept=%d", len(gotFold), len(gotKept))
 	}

--- a/internal/agent/fit_fold_test.go
+++ b/internal/agent/fit_fold_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestFitFoldToWindowShrinksOversizedFold verifies bounded folding: when the
+// fold alone cannot fit the shared window, the newer tail moves back into kept
+// (verbatim) and the remaining fold estimates under the window limit.
+func TestFitFoldToWindowShrinksOversizedFold(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedFakeProvider{budget: 128 * 1024},
+		contextWindow: 100000,
+	}
+	var fold []provider.Message
+	for i := 0; i < 10; i++ {
+		fold = append(fold, provider.Message{
+			Role:    provider.RoleUser,
+			Content: strings.Repeat("字", 15000), // ~15K tokens each
+		})
+	}
+	kept := []provider.Message{{Role: provider.RoleUser, Content: "tail"}}
+
+	limit := a.contextWindow - minOutputBudget - estimateTextTokens(summarySystemPrompt)
+	if estimateMessagesTokens(provider.ModelMessages(fold)) < limit {
+		t.Fatalf("test setup: fold must exceed the window limit (est=%d limit=%d)",
+			estimateMessagesTokens(provider.ModelMessages(fold)), limit)
+	}
+
+	gotFold, gotKept := a.fitFoldToWindow(fold, kept)
+	if len(gotFold) == 0 {
+		t.Fatal("fold must not be emptied by fitting")
+	}
+	if est := estimateMessagesTokens(provider.ModelMessages(gotFold)); est >= limit {
+		t.Fatalf("fitted fold still over window: est=%d limit=%d (cut at %d of %d)",
+			est, limit, len(gotFold), len(fold))
+	}
+	if len(gotKept) != len(kept)+len(fold)-len(gotFold) {
+		t.Fatalf("kept size = %d, want %d (moved %d back)",
+			len(gotKept), len(kept)+len(fold)-len(gotFold), len(fold)-len(gotFold))
+	}
+	// Order: moved messages (newer fold tail) precede the original kept head.
+	if !strings.Contains(gotKept[0].Content, "字") {
+		t.Fatalf("kept head = %q, want the moved fold tail message first", gotKept[0].Content)
+	}
+	if gotKept[len(gotKept)-1].Content != "tail" {
+		t.Fatalf("kept tail = %q, want the original kept tail last", gotKept[len(gotKept)-1].Content)
+	}
+}
+
+// TestFitFoldToWindowUnderLimitUntouched verifies the pass-through path: a fold
+// that fits the window is returned unchanged.
+func TestFitFoldToWindowUnderLimitUntouched(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedFakeProvider{budget: 128 * 1024},
+		contextWindow: 100000,
+	}
+	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 1000)}}
+	kept := []provider.Message{{Role: provider.RoleUser, Content: "tail"}}
+	gotFold, gotKept := a.fitFoldToWindow(fold, kept)
+	if len(gotFold) != 1 || len(gotKept) != 1 {
+		t.Fatalf("small fold must pass through untouched: fold=%d kept=%d", len(gotFold), len(gotKept))
+	}
+}
+
+// TestCompactRebuildBeyondWindowSucceeds is the user-facing regression: an
+// invalidated sidecar rebuild starts from canonical, which can be far larger
+// than the shared window (measured 3.53M vs a 1M window). Compaction must
+// still succeed with a bounded fold instead of failing with
+// ErrCompactionInputTooLarge and leaving the session unable to send.
+func TestCompactRebuildBeyondWindowSucceeds(t *testing.T) {
+	prov := &sharedFakeProvider{
+		fakeProvider: &fakeProvider{reply: "digest of the older history"},
+		budget:       128 * 1024,
+	}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+	}}
+	// 60 user turns x ~18K tokens = ~1.1M tokens, over a 1M window.
+	for i := 0; i < 60; i++ {
+		sess.Messages = append(sess.Messages,
+			provider.Message{Role: provider.RoleUser, Content: strings.Repeat("字", 6000)},
+			provider.Message{Role: provider.RoleAssistant, Content: strings.Repeat("答", 12000)},
+		)
+	}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1024 * 1024}, event.Discard)
+	a.sessionPath = ""
+
+	outcome, err := a.compactToProjection(context.Background(), "auto", "", true)
+	if err != nil {
+		t.Fatalf("compactToProjection must not fail on an over-window canonical: %v", err)
+	}
+	if outcome == CompactionNoop {
+		t.Fatal("expected a compaction outcome, got noop")
+	}
+	st := a.compactionState
+	if len(st.Projection.Messages) == 0 {
+		t.Fatal("no projection installed")
+	}
+	if st.Projection.CoveredCount <= 0 || st.Projection.CoveredCount > len(sess.Messages) {
+		t.Fatalf("covered = %d out of range", st.Projection.CoveredCount)
+	}
+	if est := estimateMessagesTokens(st.Projection.Messages); est >= a.contextWindow-minOutputBudget {
+		t.Fatalf("projection still over window: est=%d window=%d", est, a.contextWindow)
+	}
+}

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -207,7 +207,10 @@ func TestMaybeCompactOnResumeOversizedPromptCompacts(t *testing.T) {
 	}
 }
 
-func TestMaybeCompactOnResumeColdLargePromptCompacts(t *testing.T) {
+func TestMaybeCompactOnResumeColdLargePromptUntouched(t *testing.T) {
+	// Deferred compaction: a cold cache with a large-but-fitting prompt is left
+	// untouched — replay pays the miss price once, cheaper than rewriting the
+	// prefix on every resume. Only an input-overflow (would-400) prompt compacts.
 	fp := &fakeProvider{reply: "GOAL: cold replay avoided"}
 	sess := NewSession("sys")
 	for i := 0; i < 20; i++ {
@@ -228,8 +231,8 @@ func TestMaybeCompactOnResumeColdLargePromptCompacts(t *testing.T) {
 	a.cacheState = CacheStateCold
 
 	a.MaybeCompactOnResume(context.Background())
-	if len(a.compactionState.Projection.Messages) == 0 {
-		t.Fatal("cold cache + large prompt must compact on resume")
+	if st := a.compactionState; len(st.Projection.Messages) != 0 {
+		t.Fatal("cold cache + fitting prompt must NOT compact on resume (deferred policy)")
 	}
 }
 

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -248,5 +249,158 @@ func TestMaybeCompactOnResumeWarmSmallPromptUntouched(t *testing.T) {
 	a.MaybeCompactOnResume(context.Background())
 	if st := a.compactionState; len(st.Projection.Messages) != 0 {
 		t.Fatal("warm small resume must keep the cached prefix untouched")
+	}
+}
+
+// capturingBudgetProvider embeds sharedFakeProvider and records the MaxTokens
+// of the last streamed request plus how many streams ran.
+type capturingBudgetProvider struct {
+	sharedFakeProvider
+	maxTokens int
+	streams   int
+}
+
+func (p *capturingBudgetProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.maxTokens = req.MaxTokens
+	p.streams++
+	return p.sharedFakeProvider.Stream(ctx, req)
+}
+
+var _ provider.Provider = (*capturingBudgetProvider)(nil)
+var _ provider.OutputBudgetProvider = (*capturingBudgetProvider)(nil)
+var _ provider.SharedWindowOutputProvider = (*capturingBudgetProvider)(nil)
+
+// TestSummarizeClipsSharedWindowBudget verifies the compaction summarizer clips
+// its own MaxTokens for a shared-window vendor: an unclipped default made
+// compaction itself fail with HTTP 400 near the window edge.
+func TestSummarizeClipsSharedWindowBudget(t *testing.T) {
+	cap := &capturingBudgetProvider{}
+	cap.fakeProvider = &fakeProvider{reply: "SUMMARY"}
+	cap.budget = 128 * 1024
+	a := &Agent{
+		prov:          cap,
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+		sink:          event.Discard,
+	}
+	// Region near the window edge: input alone estimates past the allowance.
+	region := []provider.Message{{Role: provider.RoleUser, Content: bigTokenString(900_000)}}
+	summary, _, err := a.summarize(context.Background(), region, "")
+	if err != nil {
+		t.Fatalf("summarize: %v", err)
+	}
+	if summary != "SUMMARY" {
+		t.Fatalf("summary = %q, want %q", summary, "SUMMARY")
+	}
+	if cap.maxTokens == 0 || cap.maxTokens >= 128*1024 {
+		t.Fatalf("MaxTokens = %d, want a clipped value under the 128K default", cap.maxTokens)
+	}
+}
+
+// TestSummarizeRejectsTooLargeInput verifies the summarizer refuses a fold
+// that cannot fit beside a usable output budget: the request would 400 again
+// and retrying it every turn just re-runs the failure.
+func TestSummarizeRejectsTooLargeInput(t *testing.T) {
+	cap := &capturingBudgetProvider{}
+	cap.fakeProvider = &fakeProvider{reply: "SUMMARY"}
+	cap.budget = 128 * 1024
+	a := &Agent{
+		prov:          cap,
+		contextWindow: 500_000,
+		outputBudget:  128 * 1024,
+		sink:          event.Discard,
+	}
+	// Fold larger than window - minOutputBudget: the rendered transcript
+	// estimates ~500K tokens.
+	region := []provider.Message{{Role: provider.RoleUser, Content: bigTokenString(500_000)}}
+	_, _, err := a.summarize(context.Background(), region, "")
+	if !errors.Is(err, ErrCompactionInputTooLarge) {
+		t.Fatalf("summarize err = %v, want ErrCompactionInputTooLarge", err)
+	}
+	if cap.streams != 0 {
+		t.Fatalf("summarize streamed %d requests; a too-large fold must be rejected before sending", cap.streams)
+	}
+}
+
+// TestMaybeCompactPausesOnTooLargeInput verifies auto-compaction stops retrying
+// when the fold cannot fit the window: compactStuck latches and a warn notice
+// explains why, instead of re-running a doomed summarize every turn.
+func TestMaybeCompactPausesOnTooLargeInput(t *testing.T) {
+	cap := &capturingBudgetProvider{}
+	cap.fakeProvider = &fakeProvider{reply: "SUMMARY"}
+	cap.budget = 128 * 1024
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: bigTokenString(500_000)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "ok"})
+	a := &Agent{
+		prov:              cap,
+		contextWindow:     500_000,
+		outputBudget:      128 * 1024,
+		compactRatio:      0.8,
+		compactForceRatio: 0.9,
+		sink:              sink,
+	}
+	a.session = sess
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 500_000})
+	if !a.compactStuck {
+		t.Fatal("too-large fold must latch compactStuck to stop auto-retry")
+	}
+	found := false
+	for _, n := range notices {
+		if strings.Contains(n, "too large to compact") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'too large to compact' notice, got %v", notices)
+	}
+}
+
+// TestMaybePredictOverflowFires verifies a record-only notice when the
+// estimated prompt + max output leaves less than 8K of headroom.
+func TestMaybePredictOverflowFires(t *testing.T) {
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+	a := &Agent{
+		contextWindow: 1_048_576,
+		sink:          sink,
+	}
+	// est 1M, max 128K → headroom = 1M - 1M - 128K = -128K < 8K → fires.
+	a.maybePredictOverflow(1_048_576, 131_072)
+	found := false
+	for _, n := range notices {
+		if n == "context window nearly full" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected overflow notice, got %v", notices)
+	}
+}
+
+// TestMaybePredictOverflowDoesNotFire when there is adequate headroom.
+func TestMaybePredictOverflowDoesNotFire(t *testing.T) {
+	count := 0
+	sink := event.FuncSink(func(e event.Event) {
+		count++
+	})
+	a := &Agent{
+		contextWindow: 1_048_576,
+		sink:          sink,
+	}
+	// est 100K, max 128K → headroom = 1M - 100K - 128K = ~820K >> 8K → no fire.
+	a.maybePredictOverflow(100_000, 131_072)
+	if count > 0 {
+		t.Fatalf("overflow predicted on a small prompt (%d events)", count)
 	}
 }

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -278,6 +278,50 @@ func TestMaybeCompactOnResumeWarmMidPromptUntouched(t *testing.T) {
 	}
 }
 
+// TestMaybeCompactOnResumeProjectionSmallCanonicalHugeUntouched guards the
+// resume gate against the canonical transcript: a valid projection plus tail
+// is the exact sent shape, so a huge canonical history behind a small
+// projection must NOT trigger the gate (Copilot review 8/8: "estimate the
+// model-visible messages instead").
+func TestMaybeCompactOnResumeProjectionSmallCanonicalHugeUntouched(t *testing.T) {
+	sink := &recordSink{}
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 100_000,
+		outputBudget:  128 * 1024,
+		cacheState:    CacheStateWarm,
+		sink:          sink,
+		workspaceID:   "ws",
+		sessionPath:   "sess.jsonl",
+		modelRef:      "model",
+	}
+	// Canonical history alone (~90K ASCII) exceeds the 100K - 8K - 8K gate.
+	canonical := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a", 90_000)},
+	}
+	a.session = newSessionWithMsgs(canonical)
+	msgs, version := a.session.snapshotMessagesVersion()
+	// A valid projection keeps the model-visible shape tiny.
+	a.compactionState = CompactionState{
+		TranscriptVersion: version,
+		PromptCacheKey:    "ws|sess|model",
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "sys"},
+				{Role: provider.RoleUser, Content: "summary"},
+			},
+			TranscriptVersion: version,
+			CoveredCount:      len(msgs),
+			CoveredPrefixHash: coveredPrefixHash(msgs, len(msgs)),
+		},
+	}
+	a.MaybeCompactOnResume(context.Background())
+	if got := len(sink.kinds(event.CompactionStarted)); got != 0 {
+		t.Fatalf("resume with a small valid projection compacted (%d starts), want none", got)
+	}
+}
+
 // capturingBudgetProvider embeds sharedFakeProvider and records the MaxTokens
 // of the last streamed request plus how many streams ran.
 type capturingBudgetProvider struct {

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -252,6 +252,32 @@ func TestMaybeCompactOnResumeWarmSmallPromptUntouched(t *testing.T) {
 	}
 }
 
+// TestMaybeCompactOnResumeWarmMidPromptUntouched guards the resume gate against
+// the overflow-guard safety factor: the real-shape estimate (~49% of the
+// window) must NOT be doubled into an apparent ~98% that folds a warm cached
+// prefix. Over-estimating here destroys the server prefix cache of a healthy
+// session; under-estimating only defers compaction to the request path.
+func TestMaybeCompactOnResumeWarmMidPromptUntouched(t *testing.T) {
+	sink := &recordSink{}
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 100_000,
+		outputBudget:  128 * 1024,
+		cacheState:    CacheStateWarm,
+		sink:          sink,
+	}
+	// ~49K tokens real shape (ASCII: 1 rune ≈ 1 token), well inside the
+	// 100K - 8K - 8K = 83.6K resume threshold.
+	a.session = newSessionWithMsgs([]provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a", 49_000)},
+	})
+	a.MaybeCompactOnResume(context.Background())
+	if got := len(sink.kinds(event.CompactionStarted)); got != 0 {
+		t.Fatalf("warm resume at ~49%% of the window compacted (%d starts), want none", got)
+	}
+}
+
 // capturingBudgetProvider embeds sharedFakeProvider and records the MaxTokens
 // of the last streamed request plus how many streams ran.
 type capturingBudgetProvider struct {

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -1,0 +1,249 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// sharedWindowBudgetProvider simulates DeepSeek: a large default output
+// budget that shares the context window with the prompt input.
+type sharedWindowBudgetProvider struct {
+	budget int
+}
+
+func (*sharedWindowBudgetProvider) Name() string { return "shared-window" }
+func (p *sharedWindowBudgetProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	return nil, nil
+}
+func (p *sharedWindowBudgetProvider) OutputBudget() int       { return p.budget }
+func (*sharedWindowBudgetProvider) SharesContextWindow() bool { return true }
+
+var _ provider.Provider = (*sharedWindowBudgetProvider)(nil)
+var _ provider.OutputBudgetProvider = (*sharedWindowBudgetProvider)(nil)
+var _ provider.SharedWindowOutputProvider = (*sharedWindowBudgetProvider)(nil)
+
+// independentBudgetProvider simulates MiMo/OpenAI: a large output budget that
+// does NOT compete with the prompt input.
+type independentBudgetProvider struct {
+	budget int
+}
+
+func (*independentBudgetProvider) Name() string { return "independent" }
+func (p *independentBudgetProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	return nil, nil
+}
+func (p *independentBudgetProvider) OutputBudget() int { return p.budget }
+
+var _ provider.Provider = (*independentBudgetProvider)(nil)
+var _ provider.OutputBudgetProvider = (*independentBudgetProvider)(nil)
+
+// sharedWindowOnlyProvider implements SharesContextWindow but no output budget.
+type sharedWindowOnlyProvider struct{}
+
+func (*sharedWindowOnlyProvider) Name() string { return "shared-no-budget" }
+func (*sharedWindowOnlyProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	return nil, nil
+}
+func (*sharedWindowOnlyProvider) SharesContextWindow() bool { return true }
+
+var _ provider.Provider = (*sharedWindowOnlyProvider)(nil)
+var _ provider.SharedWindowOutputProvider = (*sharedWindowOnlyProvider)(nil)
+
+func TestEffectiveOutputBudgetSmallInputKeepsDefault(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+	}
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: "short prompt"}}
+	clipped, ok := a.effectiveOutputBudget(msgs)
+	if ok {
+		t.Fatalf("small input must keep the default budget, got clipped=%d", clipped)
+	}
+}
+
+func TestEffectiveOutputBudgetClipsNearWindow(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+	}
+	// Simulate ~1.0M-token input: only a small allowance remains for output.
+	msgs := make([]provider.Message, 0, 20)
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: bigTokenString(50_000)})
+	}
+	clipped, ok := a.effectiveOutputBudget(msgs)
+	if !ok {
+		t.Fatal("near-window input must clip the output budget")
+	}
+	if clipped >= 128*1024 {
+		t.Fatalf("clipped budget %d must be below the default 131072", clipped)
+	}
+	if clipped <= 0 {
+		t.Fatalf("clipped budget %d must stay positive", clipped)
+	}
+}
+
+func TestEffectiveOutputBudgetFloorNearExhaustion(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+	}
+	// Input that nearly exhausts the window: floor must still allow output.
+	msgs := make([]provider.Message, 0, 20)
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: bigTokenString(60_000)})
+	}
+	clipped, ok := a.effectiveOutputBudget(msgs)
+	if !ok {
+		t.Fatal("near-exhaustion input must clip")
+	}
+	if clipped < minOutputBudget {
+		t.Fatalf("clipped budget %d below floor %d", clipped, minOutputBudget)
+	}
+}
+
+func TestEffectiveOutputBudgetIndependentVendorUnchanged(t *testing.T) {
+	a := &Agent{
+		prov:          &independentBudgetProvider{budget: 128 * 1024},
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+	}
+	msgs := make([]provider.Message, 0, 20)
+	for i := 0; i < 20; i++ {
+		msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: bigTokenString(50_000)})
+	}
+	if clipped, ok := a.effectiveOutputBudget(msgs); ok {
+		t.Fatalf("independent-ceiling vendor must never clip, got %d", clipped)
+	}
+}
+
+func TestEffectiveOutputBudgetNoBudgetNoWindow(t *testing.T) {
+	// No output budget exposed: nothing to clip.
+	if clipped, ok := (&Agent{prov: &sharedWindowOnlyProvider{}, contextWindow: 1_048_576}).effectiveOutputBudget(nil); ok {
+		t.Fatalf("no budget must not clip, got %d", clipped)
+	}
+	// No context window: unknown limit, keep default.
+	if clipped, ok := (&Agent{prov: &sharedWindowBudgetProvider{budget: 128 * 1024}}).effectiveOutputBudget(nil); ok {
+		t.Fatalf("no window must not clip, got %d", clipped)
+	}
+}
+
+// sharedFakeProvider embeds fakeProvider (which can summarize via its Stream
+// reply) and advertises a shared context window like DeepSeek.
+type sharedFakeProvider struct {
+	*fakeProvider
+	budget int
+}
+
+func (p *sharedFakeProvider) OutputBudget() int       { return p.budget }
+func (*sharedFakeProvider) SharesContextWindow() bool { return true }
+
+var _ provider.Provider = (*sharedFakeProvider)(nil)
+var _ provider.OutputBudgetProvider = (*sharedFakeProvider)(nil)
+var _ provider.SharedWindowOutputProvider = (*sharedFakeProvider)(nil)
+
+// bigTokenString returns a string that estimates to roughly n tokens under
+// estimateTextTokens (CJK-heavy: ~1 rune per token).
+func bigTokenString(n int) string {
+	const rune = "字"
+	b := make([]byte, 0, n*3)
+	for len(b)/3 < n {
+		b = append(b, rune...)
+	}
+	return string(b)
+}
+
+func newSessionWithMsgs(msgs []provider.Message) *Session {
+	s := NewSession("")
+	for _, m := range msgs {
+		s.Add(m)
+	}
+	return s
+}
+
+func TestMaybeCompactOnResumeUnsharedWindowNoop(t *testing.T) {
+	a := &Agent{prov: &independentBudgetProvider{budget: 128 * 1024}, contextWindow: 1_048_576, sink: event.Discard}
+	a.session = newSessionWithMsgs([]provider.Message{{Role: provider.RoleUser, Content: "x"}})
+	a.MaybeCompactOnResume(context.Background())
+	if st := a.compactionState; len(st.Projection.Messages) != 0 {
+		t.Fatal("independent vendor must not compact on resume")
+	}
+}
+
+func TestMaybeCompactOnResumeOversizedPromptCompacts(t *testing.T) {
+	fp := &fakeProvider{reply: "GOAL: fit inside window"}
+	sess := NewSession("sys")
+	for i := 0; i < 40; i++ {
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "user turn " + strings.Repeat("x", 200)})
+		sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "assistant " + strings.Repeat("y", 400)})
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	// Tiny window so the oversized prompt exceeds window - minBudget - reserve.
+	a := New(fp, nil, sess, Options{
+		ContextWindow: 30_000,
+		RecentKeep:    2,
+		ArchiveDir:    dir,
+		SessionPath:   path,
+		ModelRef:      "test/model",
+	}, event.Discard)
+	// Shared-window vendor: fakeProvider must advertise it for the gate to run.
+	// Re-point the agent's provider to one that shares the window and can
+	// summarize (fakeProvider streams the reply text).
+	a.prov = &sharedFakeProvider{fakeProvider: fp, budget: 128 * 1024}
+	a.outputBudget = 128 * 1024
+
+	a.MaybeCompactOnResume(context.Background())
+	if len(a.compactionState.Projection.Messages) == 0 {
+		t.Fatal("oversized prompt must install a projection on resume")
+	}
+}
+
+func TestMaybeCompactOnResumeColdLargePromptCompacts(t *testing.T) {
+	fp := &fakeProvider{reply: "GOAL: cold replay avoided"}
+	sess := NewSession("sys")
+	for i := 0; i < 20; i++ {
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "user turn " + strings.Repeat("x", 200)})
+		sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "assistant " + strings.Repeat("y", 400)})
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	a := New(fp, nil, sess, Options{
+		ContextWindow: 100_000,
+		RecentKeep:    2,
+		ArchiveDir:    dir,
+		SessionPath:   path,
+		ModelRef:      "test/model",
+	}, event.Discard)
+	a.prov = &sharedFakeProvider{fakeProvider: fp, budget: 128 * 1024}
+	a.outputBudget = 128 * 1024
+	a.cacheState = CacheStateCold
+
+	a.MaybeCompactOnResume(context.Background())
+	if len(a.compactionState.Projection.Messages) == 0 {
+		t.Fatal("cold cache + large prompt must compact on resume")
+	}
+}
+
+func TestMaybeCompactOnResumeWarmSmallPromptUntouched(t *testing.T) {
+	a := &Agent{
+		prov:          &sharedWindowBudgetProvider{budget: 128 * 1024},
+		contextWindow: 1_048_576,
+		outputBudget:  128 * 1024,
+		cacheState:    CacheStateWarm,
+		sink:          event.Discard,
+	}
+	a.session = newSessionWithMsgs([]provider.Message{{Role: provider.RoleUser, Content: "short"}})
+	a.MaybeCompactOnResume(context.Background())
+	if st := a.compactionState; len(st.Projection.Messages) != 0 {
+		t.Fatal("warm small resume must keep the cached prefix untouched")
+	}
+}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -21,6 +21,12 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	if a == nil || a.session == nil || a.contextWindow <= 0 {
 		return nil
 	}
+	// Paused sessions keep sending under the existing projection: re-firing
+	// compaction every turn (each attempt doomed in a too-small window, each
+	// fold over-budget in an oversized one) only craters the cache for no gain.
+	if a.compactStuck {
+		return nil
+	}
 	msgs, version := a.session.snapshotMessagesVersion()
 	cacheKey := a.currentPromptCacheKey()
 	// Conservative estimate: the fixed estimator under-counts CJK-heavy
@@ -29,11 +35,13 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	_, _, high := a.compactThresholds()
 	force := max(a.forceThreshold(), high)
 
-	// Prefer an existing valid projection when it still covers the pressure.
+	// A valid projection below the high-water mark passes; the old
+	// projection<canonical comparison was a tautology that disabled the force
+	// guard below.
 	if st := a.compactionState; projectionValid(st, msgs, version, cacheKey) {
 		visible := modelVisibleFromProjection(st.Projection, msgs)
 		projEst := a.estimatedPromptTokens(visible)
-		if projEst < high || projEst < est {
+		if projEst < high {
 			return nil
 		}
 	}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -23,14 +23,16 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	}
 	msgs, version := a.session.snapshotMessagesVersion()
 	cacheKey := a.currentPromptCacheKey()
-	est := estimateMessagesTokens(provider.ModelMessages(msgs))
+	// Conservative estimate: the fixed estimator under-counts CJK-heavy
+	// transcripts (~1.8x), so the overflow guard uses the calibrated value.
+	est := a.estimatedPromptTokens(msgs)
 	_, _, high := a.compactThresholds()
 	force := max(a.forceThreshold(), high)
 
 	// Prefer an existing valid projection when it still covers the pressure.
 	if st := a.compactionState; projectionValid(st, msgs, version, cacheKey) {
 		visible := modelVisibleFromProjection(st.Projection, msgs)
-		projEst := estimateMessagesTokens(provider.ModelMessages(visible))
+		projEst := a.estimatedPromptTokens(visible)
 		if projEst < high || projEst < est {
 			return nil
 		}
@@ -44,7 +46,7 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	pruned, pst := a.applyToolResultMaintenanceView(msgs, toolResultPrune)
 	if pst.Results > 0 {
 		if err := a.installPruneProjection(pruned, pst); err == nil {
-			projEst := estimateMessagesTokens(provider.ModelMessages(pruned))
+			projEst := a.estimatedPromptTokens(pruned)
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
 				"pruned %d stale tool results (~%d tokens est.) before request", pst.Results, est-projEst)})
 			if projEst < high {

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -25,7 +25,7 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	cacheKey := a.currentPromptCacheKey()
 	est := estimateMessagesTokens(provider.ModelMessages(msgs))
 	_, _, high := a.compactThresholds()
-	force := max(int(float64(a.contextWindow)*a.compactForceRatio), high)
+	force := max(a.forceThreshold(), high)
 
 	// Prefer an existing valid projection when it still covers the pressure.
 	if st := a.compactionState; projectionValid(st, msgs, version, cacheKey) {

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -21,14 +21,16 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	if a == nil || a.session == nil || a.contextWindow <= 0 {
 		return nil
 	}
-	// Paused sessions keep sending under the existing projection: re-firing
-	// compaction every turn (each attempt doomed in a too-small window, each
-	// fold over-budget in an oversized one) only craters the cache for no gain.
-	if a.compactStuck {
-		return nil
-	}
 	msgs, version := a.session.snapshotMessagesVersion()
 	cacheKey := a.currentPromptCacheKey()
+	// Paused sessions with a projection keep sending under it: re-firing
+	// compaction every turn only craters the cache for no gain. Without a
+	// projection, fall through so the force guard refuses the send.
+	if a.compactStuck {
+		if st := a.compactionState; projectionValid(st, msgs, version, cacheKey) {
+			return nil
+		}
+	}
 	// Conservative estimate: the fixed estimator under-counts CJK-heavy
 	// transcripts (~1.8x), so the overflow guard uses the calibrated value.
 	est := a.estimatedPromptTokens(msgs)

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -160,10 +160,14 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	// Fail closed: known lineage requires an exact stored key (including
 	// rejecting blank keys on early sidecars written before this field).
 	if key := a.currentPromptCacheKey(); key != "" && st.PromptCacheKey != key {
+		slog.Info("agent: projection sidecar lineage mismatch — projection dropped",
+			"path", sessionPath, "stored_key", st.PromptCacheKey, "current_key", key)
 		a.compactionState = CompactionState{}
 		return
 	}
 	if st.Projection.CoveredPrefixHash == "" {
+		slog.Info("agent: projection sidecar lacks covered-prefix hash — projection dropped",
+			"path", sessionPath, "schema", st.SchemaVersion)
 		a.compactionState = CompactionState{}
 		return
 	}

--- a/internal/agent/preflight_prune_fold_test.go
+++ b/internal/agent/preflight_prune_fold_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestPreflightPruneThenFoldFitsWindow is the user-scenario regression: a
+// canonical transcript far over the shared window (measured 3.7M tokens vs a
+// 1M window), mostly stale tool results. Preflight prunes them into a
+// placeholder view, and the force fold must run against that view — a
+// raw-canonical rebuild would leave the projection over the window.
+func TestPreflightPruneThenFoldFitsWindow(t *testing.T) {
+	prov := &sharedFakeProvider{
+		fakeProvider: &fakeProvider{reply: "digest of older work"},
+		budget:       128 * 1024,
+	}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+	}}
+	// ~2.6M tokens of stale tool results (older) + ~1.4M of turns: canonical
+	// ends far over the 1M window.
+	for i := 0; i < 120; i++ {
+		sess.Messages = append(sess.Messages,
+			provider.Message{Role: provider.RoleUser, Content: strings.Repeat("题", 3000)},  // 3K
+			provider.Message{Role: provider.RoleTool, Content: strings.Repeat("果", 22000)}, // stale 22K
+		)
+	}
+	for i := 0; i < 10; i++ {
+		sess.Messages = append(sess.Messages,
+			provider.Message{Role: provider.RoleUser, Content: strings.Repeat("新", 4000)},
+			provider.Message{Role: provider.RoleAssistant, Content: strings.Repeat("答", 6000)},
+		)
+	}
+	if est := estimateMessagesTokens(provider.ModelMessages(sess.Messages)); est < 2_000_000 {
+		t.Fatalf("setup: canonical must exceed 2M tokens (est=%d)", est)
+	}
+
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 1024 * 1024,
+		RecentKeep:    4,
+	}, event.Discard)
+
+	if err := a.contextPreflight(context.Background(), "auto"); err != nil {
+		t.Fatalf("preflight must succeed after prune + bounded fold: %v", err)
+	}
+	st := a.compactionState
+	if !projectionValid(st, sess.Messages, st.TranscriptVersion, a.currentPromptCacheKey()) {
+		t.Fatal("no valid projection installed after preflight")
+	}
+	if est := estimateMessagesTokens(st.Projection.Messages); est >= a.contextWindow-minOutputBudget {
+		t.Fatalf("projection still over window after fold: est=%d window=%d", est, a.contextWindow)
+	}
+	// The projection must cover the whole canonical (the pruned view collapsed
+	// the stale tool results).
+	if st.Projection.CoveredCount != len(sess.Messages) {
+		t.Fatalf("covered = %d, want %d (full canonical)", st.Projection.CoveredCount, len(sess.Messages))
+	}
+}

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -45,8 +45,11 @@ const (
 	CompactionModeSnip       = "snip"
 )
 
-// ContextProjection is the model-visible view of a session. The canonical
+// ContextProjection is the model-visible view of a session; the canonical
 // transcript in Session.Messages is never replaced by this structure.
+// Lossy irreversible projection (Sovereign Projection/Binary.agda): canonical
+// is the only reversible source; using it without its Context is undefined,
+// so projectionValid fails closed and CoveredCount advances monotonically.
 type ContextProjection struct {
 	Messages          []provider.Message `json:"messages"`
 	TranscriptVersion uint64             `json:"transcript_version"`

--- a/internal/agent/projection_test.go
+++ b/internal/agent/projection_test.go
@@ -169,6 +169,7 @@ func TestFixedEarlyUserTurnsStableAcrossCompactions(t *testing.T) {
 	// the pre-projection canonical estimate. This remains useful for tail sizing,
 	// but must not change which early turns define the stable prefix.
 	a.lastUsage.Store(&provider.Usage{PromptTokens: charsOfMessages(sess.Messages)})
+	a.lastSentChars.Store(int64(charsOfMessages(sess.Messages)))
 	if got := a.tokPerChar(); got < 0.9 || got > 1.1 {
 		t.Fatalf("test did not install the intended dynamic calibration: %f", got)
 	}

--- a/internal/agent/projection_valid_test.go
+++ b/internal/agent/projection_valid_test.go
@@ -160,6 +160,51 @@ func TestLoadProjectionSidecarDropsForeignCacheKey(t *testing.T) {
 	}
 }
 
+// TestPreflightCompactsWhenProjectionExceedsHighWaterMark verifies the force
+// guard is not silently disabled by a valid projection: an existing projection
+// whose visible size still clears the high-water mark must be re-folded, not
+// waved through on the old "projection < canonical" tautology.
+func TestPreflightCompactsWhenProjectionExceedsHighWaterMark(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("big turn ", 500)},
+		{Role: provider.RoleAssistant, Content: "done"},
+	}
+	// Window 100 with compactRatio 0.5 → high = 50. The projection below is
+	// itself above 50 tokens, so it must not pass preflight on size alone.
+	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), &Session{Messages: msgs}, Options{
+		ContextWindow:     100,
+		CompactRatio:      0.5,
+		CompactForceRatio: 0.6,
+		RecentKeep:        2,
+	}, event.Discard)
+	st := CompactionState{
+		TranscriptVersion: 3,
+		PromptCacheKey:    a.currentPromptCacheKey(),
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "sys"},
+				{Role: provider.RoleUser, Content: strings.Repeat("proj ", 200)},
+			},
+			TranscriptVersion: 3,
+			CoveredCount:      2,
+			CoveredPrefixHash: coveredPrefixHash(msgs, 2),
+			ProjectionTokens:  800,
+		},
+	}
+	if err := a.installProjection(st); err != nil {
+		t.Fatalf("installProjection: %v", err)
+	}
+	// Paused sessions are exempt (the stuck guard owns them); unpaused ones
+	// must re-fold rather than ride a stale projection.
+	if err := a.contextPreflight(context.Background(), CompactionTriggerPressure); err != nil {
+		t.Fatalf("preflight under pressure: %v", err)
+	}
+	if !hasCompactionSummary(visibleContext(a)) {
+		t.Fatal("preflight should have re-folded a projection above the high-water mark")
+	}
+}
+
 func TestForceThresholdNoopReturnsCompactionRequired(t *testing.T) {
 	// Huge tool result is entirely in the recent tail → no fold region, but
 	// estimate exceeds force; preflight must refuse (not mid-turn).

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -357,6 +357,11 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		text, reasoning, signature, calls, responsesItems, usage := streamed.text, streamed.reasoning, streamed.signature, streamed.calls, streamed.responsesItems, streamed.usage
 		partialCalls, err := streamed.partialCalls, streamed.err
 		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage, contentReasons)
+		// 9a: Response-side cache-break detection (record-only, no alerts).
+		// The hit count usually grows turn-over-turn as the prefix lengthens;
+		// a significant drop without a compaction/snip rewrite signals that
+		// the server-side prefix cache was evicted between turns.
+		cacheDiagnostics.CacheMissDrop = detectResponseCacheMiss(a, cacheDiagnostics.CacheHitTokens, contentReasons)
 		if err != nil {
 			a.emitTurnUsage(usage, &cacheDiagnostics)
 			if msg, ok := finishReasonMessage(usage); ok {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -357,10 +357,9 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		text, reasoning, signature, calls, responsesItems, usage := streamed.text, streamed.reasoning, streamed.signature, streamed.calls, streamed.responsesItems, streamed.usage
 		partialCalls, err := streamed.partialCalls, streamed.err
 		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage, contentReasons)
-		// 9a: Response-side cache-break detection (record-only, no alerts).
-		// The hit count usually grows turn-over-turn as the prefix lengthens;
-		// a significant drop without a compaction/snip rewrite signals that
-		// the server-side prefix cache was evicted between turns.
+		// 9a: Response-side cache-break detection (record-only). The hit count
+		// grows turn-over-turn as the prefix lengthens; a significant drop
+		// without a compaction/snip rewrite signals a server-side eviction.
 		cacheDiagnostics.CacheMissDrop = detectResponseCacheMiss(a, cacheDiagnostics.CacheHitTokens, contentReasons)
 		if err != nil {
 			a.emitTurnUsage(usage, &cacheDiagnostics)

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -33,10 +33,17 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 	if err != nil {
 		return samplingRequest{}, err
 	}
+	// Shared-window vendors (DeepSeek) clip max_output_tokens so input +
+	// output stays inside context_window; otherwise the API rejects with 400.
+	// A nil/independent provider keeps its default (MaxTokens unchanged).
+	maxTokens := a.maxOutputTokens
+	if clipped, ok := a.effectiveOutputBudget(requestMessages); ok {
+		maxTokens = clipped
+	}
 	req := provider.Request{
 		Messages:       requestMessages,
 		Tools:          a.tools.Schemas(),
-		MaxTokens:      a.maxOutputTokens,
+		MaxTokens:      maxTokens,
 		Temperature:    provider.OptionalTemperature(a.temperature),
 		ResponseFormat: responseFormatFromRequest(ctx),
 		EffortOverride: a.governorOverride(),

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -54,6 +54,7 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 	if err != nil {
 		return samplingRequest{}, err
 	}
+	a.lastSentChars.Store(int64(charsOfMessages(req.Messages)))
 	return samplingRequest{req: freezeProviderRequest(req)}, nil
 }
 

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -40,6 +40,10 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 	if clipped, ok := a.effectiveOutputBudget(requestMessages); ok {
 		maxTokens = clipped
 	}
+	// 1a: Predict overflow before the request goes on the wire. When the
+	// estimated prompt alone leaves almost no room for output, surface a
+	// record-only notice — no compaction is triggered, only a diagnostic.
+	a.maybePredictOverflow(a.estimatedPromptTokens(requestMessages), maxTokens)
 	req := provider.Request{
 		Messages:       requestMessages,
 		Tools:          a.tools.Schemas(),

--- a/internal/cli/status_footer.go
+++ b/internal/cli/status_footer.go
@@ -74,7 +74,11 @@ func renderTurnReceipt(u *provider.Usage, p *provider.Pricing, d *event.CacheDia
 		groups = append(groups, "reasoning "+shortTokens(u.ReasoningTokens))
 	}
 	if p != nil {
-		groups = append(groups, fmt.Sprintf("%s%.4f", p.Symbol(), p.Cost(u)))
+		cost := fmt.Sprintf("%s%.4f", p.Symbol(), p.Cost(u))
+		if p.Estimated {
+			cost += " (估算)"
+		}
+		groups = append(groups, cost)
 	}
 	if u.Estimated {
 		groups = append(groups, "estimated")

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -229,15 +229,15 @@ func completeDeepSeekOfficialPricingCurrency(p *ProviderEntry) string {
 }
 
 func mimoV25ProPrice() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}
+	return &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥", Estimated: true}
 }
 
 func mimoV25Price() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}
+	return &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥", Estimated: true}
 }
 
 func mimoV2FlashPrice() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.07, Input: 0.70, Output: 2.10, Currency: "¥"}
+	return &provider.Pricing{CacheHit: 0.07, Input: 0.70, Output: 2.10, Currency: "¥", Estimated: true}
 }
 
 func mimoDomesticPrices(models []string) map[string]*provider.Pricing {
@@ -256,7 +256,7 @@ func mimoDomesticPrices(models []string) map[string]*provider.Pricing {
 }
 
 func longCat20Price() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.04, Input: 2, Output: 8, Currency: "¥"}
+	return &provider.Pricing{CacheHit: 0.04, Input: 2, Output: 8, Currency: "¥", Estimated: true}
 }
 
 func longCat20Prices(models []string) map[string]*provider.Pricing {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3514,6 +3514,14 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.recoverCheckpointTransactions()
 	c.recoverInterruptedTurn(path)
 	c.maybeColdResumePrune(path)
+	// Budget-aware resume gate: a resumed session whose prompt cannot fit
+	// inside the provider's shared context window (or a cold cache with a
+	// prompt past the force mark) is compacted before the first send, so the
+	// request can never be rejected with HTTP 400 for input + output exceeding
+	// the window. Warm small resumes stay untouched (cached prefix survives).
+	if c.executor != nil {
+		c.executor.MaybeCompactOnResume(context.Background())
+	}
 	// session.load: Resume has no failure channel, so the session_policy
 	// strategy is advisory this stage — a required-class failure is surfaced
 	// as a warning and the load stands. The event still carries the final

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -112,6 +112,8 @@ type Controller struct {
 	systemPrompt string
 	sessionDir   string
 	commands     atomic.Pointer[[]command.Command]
+	// lastContextTokens is the last observed non-zero gauge footprint (reset on session bind).
+	lastContextTokens atomic.Int64
 	// skills owns the session's discovered skills (enabled subset, full set, and
 	// the reloadable stores) — the skills slice of the Capabilities concern. See
 	// skill.go.
@@ -4680,11 +4682,21 @@ func (c *Controller) ContextSnapshot() (int, int) {
 	if c.executor == nil {
 		return 0, 0
 	}
+	window := c.executor.ContextWindow()
 	u := c.executor.LastUsage()
-	if u == nil {
-		return 0, c.executor.ContextWindow()
+	if u != nil {
+		used := u.PromptTokens + u.CompletionTokens
+		if used > 0 {
+			c.lastContextTokens.Store(int64(used))
+		}
+		return used, window
 	}
-	return u.PromptTokens + u.CompletionTokens, c.executor.ContextWindow()
+	// A cancelled/interrupted turn can leave LastUsage nil; keep the gauge on
+	// the last observed footprint instead of dropping to 0%.
+	if used := int(c.lastContextTokens.Load()); used > 0 {
+		return used, window
+	}
+	return 0, window
 }
 
 // CompactRatio returns the auto-compaction threshold as a fraction of the window

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -164,6 +164,46 @@ func TestContextSnapshotIncludesCompletionTokens(t *testing.T) {
 	}
 }
 
+// TestContextSnapshotSurvivesExecutorRebuild guards the context gauge against
+// the cancelled-turn path: after a turn completes, an interrupted turn or an
+// executor rebuild can leave LastUsage nil, and the gauge must keep showing the
+// last observed footprint instead of dropping to 0%. A session bind resets the
+// fallback so a fresh session still hides the gauge.
+func TestContextSnapshotSurvivesExecutorRebuild(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{{
+		{Type: provider.ChunkText, Text: "ok"},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{
+			PromptTokens:     6840,
+			CompletionTokens: 48,
+			TotalTokens:      6888,
+		}},
+		{Type: provider.ChunkDone},
+	}}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{ContextWindow: 1_000_000}, event.Discard)
+	c := New(Options{Runner: ag, Executor: ag})
+	if err := c.Run(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if used, _ := c.ContextSnapshot(); used != 6888 {
+		t.Fatalf("ContextSnapshot after run = %d, want 6888", used)
+	}
+
+	// Interrupted/cancelled turn path: the executor's LastUsage is nil (a
+	// rebuilt agent has no telemetry yet). The gauge must not collapse to 0%.
+	fresh := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{ContextWindow: 1_000_000}, event.Discard)
+	c.executor = fresh
+	if used, window := c.ContextSnapshot(); used != 6888 || window != 1_000_000 {
+		t.Fatalf("ContextSnapshot after rebuild = (%d, %d), want (6888, 1000000)", used, window)
+	}
+
+	// A session bind starts a fresh lineage: the fallback is dropped, so a
+	// brand-new session hides the gauge instead of borrowing the old footprint.
+	c.bindExecutorProjection(filepath.Join(t.TempDir(), "s.jsonl"), false)
+	if used, _ := c.ContextSnapshot(); used != 0 {
+		t.Fatalf("ContextSnapshot after bind = %d, want 0 (fresh lineage)", used)
+	}
+}
+
 type fakeControlTool struct{ name string }
 
 func (t fakeControlTool) Name() string { return t.name }

--- a/internal/control/projection_bind.go
+++ b/internal/control/projection_bind.go
@@ -16,6 +16,9 @@ func (c *Controller) bindExecutorProjection(path string, loadSidecar bool) {
 	if c == nil || c.executor == nil {
 		return
 	}
+	// A session bind is a fresh lineage for the gauge: drop the fallback so a
+	// brand-new session hides instead of borrowing the previous footprint.
+	c.lastContextTokens.Store(0)
 	c.executor.BindSessionPath(path, loadSidecar)
 }
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -447,6 +447,10 @@ type CacheDiagnostics struct {
 	ToolSchemaTokens    int
 	CacheMissTokens     int
 	CacheHitTokens      int
+	// CacheMissDrop is true when the hit count dropped ≥5% and ≥2000 tokens
+	// from the previous turn without a compaction/snip rewrite — a sign that
+	// the server-side prefix cache was evicted between turns.
+	CacheMissDrop bool
 }
 
 // FinalReadiness carries machine-readable recovery requirements on TurnDone.

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -168,6 +168,13 @@ type client struct {
 
 func (c *client) Name() string { return c.name }
 
+// OutputBudget reports the total output budget the client will request.
+func (c *client) OutputBudget() int { return c.defaultMaxTokens }
+
+// SharesContextWindow reports whether max_tokens competes with the prompt
+// input for the same context window (DeepSeek Anthropic endpoint).
+func (c *client) SharesContextWindow() bool { return c.deepseek }
+
 func (c *client) deepSeekThinkingEnabled() bool {
 	return c != nil && c.deepseek && c.thinking != "disabled" && c.effort != "disabled"
 }

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -298,6 +298,13 @@ type client struct {
 
 func (c *client) Name() string { return c.name }
 
+// OutputBudget reports the total output budget the client will request.
+func (c *client) OutputBudget() int { return c.maxOutputTokens }
+
+// SharesContextWindow reports whether max_output_tokens competes with the
+// prompt input for the same context window (DeepSeek Chat Completions).
+func (c *client) SharesContextWindow() bool { return c.deepseek }
+
 func (c *client) RequiresToolCallReasoning() bool {
 	return c != nil && c.deepseek && c.thinkingType != "disabled"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1001,6 +1001,24 @@ func RequiresToolCallReasoning(p Provider) bool {
 	return ok && policy.RequiresToolCallReasoning()
 }
 
+// OutputBudgetProvider is optionally implemented by providers that know the
+// total output budget they will request (max_output_tokens / max_tokens).
+// The agent uses it so compaction force thresholds never exceed the provider's
+// real input allowance (context_window - output budget).
+type OutputBudgetProvider interface {
+	OutputBudget() int
+}
+
+// SharedWindowOutputProvider is optionally implemented by providers whose
+// max_output_tokens shares the model context window with the prompt input
+// (DeepSeek: input + max_output_tokens must stay under context_window).
+// Independent-ceiling providers (OpenAI, MiMo) do not implement it. The agent
+// clips the requested budget as the prompt grows so the sum never exceeds the
+// window, which DeepSeek otherwise rejects with HTTP 400.
+type SharedWindowOutputProvider interface {
+	SharesContextWindow() bool
+}
+
 // ReasoningRoundTripPolicy is optionally implemented by providers that require
 // every assistant message to preserve provider-issued reasoning in later
 // requests. This is broader than ToolCallReasoningPolicy, which covers only

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1012,9 +1012,9 @@ type OutputBudgetProvider interface {
 // SharedWindowOutputProvider is optionally implemented by providers whose
 // max_output_tokens shares the model context window with the prompt input
 // (DeepSeek: input + max_output_tokens must stay under context_window).
-// Independent-ceiling providers (OpenAI, MiMo) do not implement it. The agent
-// clips the requested budget as the prompt grows so the sum never exceeds the
-// window, which DeepSeek otherwise rejects with HTTP 400.
+// Implementers return false when the window is NOT shared (e.g. the OpenAI and
+// Anthropic clients implement it to report false in non-DeepSeek modes); the
+// agent only reserves the output budget when SharesContextWindow is true.
 type SharedWindowOutputProvider interface {
 	SharesContextWindow() bool
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -777,10 +777,8 @@ type Pricing struct {
 	Input    float64 `toml:"input"`     // per 1M uncached prompt tokens
 	Output   float64 `toml:"output"`    // per 1M completion tokens
 	Currency string  `toml:"currency"`
-	// Estimated marks a price that comes from a third-party estimate rather
-	// than an official provider API. It has no TOML key — the label is
-	// set by presets and displayed in the TUI so users know the cost figure
-	// may be off by the vendor's actual pricing.
+	// Estimated marks a price from a third-party estimate rather than an
+	// official provider API. Set by presets; has no TOML key.
 	Estimated bool `toml:"-"`
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -777,6 +777,11 @@ type Pricing struct {
 	Input    float64 `toml:"input"`     // per 1M uncached prompt tokens
 	Output   float64 `toml:"output"`    // per 1M completion tokens
 	Currency string  `toml:"currency"`
+	// Estimated marks a price that comes from a third-party estimate rather
+	// than an official provider API. It has no TOML key — the label is
+	// set by presets and displayed in the TUI so users know the cost figure
+	// may be off by the vendor's actual pricing.
+	Estimated bool `toml:"-"`
 }
 
 // Cost estimates the spend for a usage record.

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -167,6 +167,13 @@ func responsesReasoningDisabled(effort string) bool {
 
 func (c *client) Name() string { return c.name }
 
+// OutputBudget reports the total output budget the client will request.
+func (c *client) OutputBudget() int { return c.maxOutputTokens }
+
+// SharesContextWindow reports whether max_output_tokens competes with the
+// prompt input for the same context window (DeepSeek Responses API).
+func (c *client) SharesContextWindow() bool { return c.vendor == "deepseek" }
+
 // RequiresToolCallReasoning tells the agent to preserve stateless vendors'
 // reasoning on assistant tool-call turns so the follow-up can replay it.
 // DeepSeek and MiMo document this requirement for multi-turn tool calls.

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -2,19 +2,19 @@
   "limits": {
     "banner": 0,
     "commented-code": 0,
-    "complexity": 2056,
-    "essay": 4028,
-    "file-size": 108472,
-    "function-size": 9127,
+    "complexity": 2048,
+    "essay": 4023,
+    "file-size": 113302,
+    "function-size": 9079,
     "layering": 1,
     "marker": 0,
     "narrative": 61,
-    "test-file-size": 68117
+    "test-file-size": 68156
   },
   "files": {
     "cmd/e2ebench/main.go": {
       "essay": 1,
-      "function-size": 5
+      "function-size": 3
     },
     "cmd/e2ebench/mutation.go": {
       "essay": 1
@@ -28,7 +28,7 @@
     "desktop/app.go": {
       "complexity": 64,
       "essay": 90,
-      "file-size": 11538,
+      "file-size": 11469,
       "function-size": 361
     },
     "desktop/app_autosave_test.go": {
@@ -90,7 +90,7 @@
       "test-file-size": 19
     },
     "desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts": {
-      "test-file-size": 308
+      "test-file-size": 307
     },
     "desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx": {
       "test-file-size": 1701
@@ -114,7 +114,7 @@
       "file-size": 255
     },
     "desktop/frontend/src/components/CapabilitiesPanel.tsx": {
-      "file-size": 2633
+      "file-size": 2626
     },
     "desktop/frontend/src/components/Composer.tsx": {
       "file-size": 3963
@@ -156,7 +156,7 @@
       "file-size": 413
     },
     "desktop/frontend/src/lib/bridge.ts": {
-      "file-size": 4453
+      "file-size": 4450
     },
     "desktop/frontend/src/lib/crash.ts": {
       "file-size": 179
@@ -166,6 +166,9 @@
     },
     "desktop/frontend/src/lib/useController.ts": {
       "file-size": 3503
+    },
+    "desktop/frontend/wailsjs/go/models.ts": {
+      "file-size": 4872
     },
     "desktop/heartbeat.go": {
       "essay": 18,
@@ -405,8 +408,8 @@
     },
     "internal/agent/agent.go": {
       "complexity": 61,
-      "essay": 113,
-      "file-size": 2719,
+      "essay": 109,
+      "file-size": 2728,
       "function-size": 124
     },
     "internal/agent/ask.go": {
@@ -432,9 +435,6 @@
     },
     "internal/agent/compact.go": {
       "essay": 27
-    },
-    "internal/agent/compact_projection.go": {
-      "function-size": 24
     },
     "internal/agent/compact_test.go": {
       "essay": 4
@@ -546,7 +546,7 @@
     "internal/agent/run_loop.go": {
       "complexity": 5,
       "essay": 45,
-      "file-size": 311,
+      "file-size": 315,
       "function-size": 46
     },
     "internal/agent/save.go": {
@@ -642,7 +642,7 @@
     "internal/boot/boot.go": {
       "complexity": 287,
       "essay": 102,
-      "file-size": 2204,
+      "file-size": 2191,
       "function-size": 1818,
       "narrative": 3
     },
@@ -678,8 +678,7 @@
       "essay": 4
     },
     "internal/boot/rebuild_subgraph.go": {
-      "complexity": 2,
-      "function-size": 17
+      "function-size": 7
     },
     "internal/boot/reload.go": {
       "essay": 32
@@ -777,10 +776,10 @@
       "essay": 15
     },
     "internal/cli/chat_tui.go": {
-      "complexity": 302,
+      "complexity": 300,
       "essay": 110,
-      "file-size": 4555,
-      "function-size": 1200
+      "file-size": 4551,
+      "function-size": 1196
     },
     "internal/cli/chat_tui_paste.go": {
       "essay": 9
@@ -830,7 +829,7 @@
     "internal/cli/mcp.go": {
       "complexity": 8,
       "essay": 5,
-      "file-size": 85,
+      "file-size": 66,
       "function-size": 7
     },
     "internal/cli/mcp_manager.go": {
@@ -972,9 +971,8 @@
       "test-file-size": 2194
     },
     "internal/config/effort.go": {
-      "complexity": 10,
-      "essay": 11,
-      "function-size": 5
+      "complexity": 9,
+      "essay": 11
     },
     "internal/config/effort_test.go": {
       "essay": 2
@@ -1040,14 +1038,14 @@
     },
     "internal/control/controller.go": {
       "complexity": 11,
-      "essay": 170,
-      "file-size": 5334,
+      "essay": 172,
+      "file-size": 5354,
       "function-size": 77,
       "narrative": 4
     },
     "internal/control/controller_test.go": {
       "essay": 10,
-      "test-file-size": 4507
+      "test-file-size": 4547
     },
     "internal/control/errmsg.go": {
       "essay": 2
@@ -1438,7 +1436,7 @@
       "test-file-size": 275
     },
     "internal/plugin/plugin.go": {
-      "essay": 30,
+      "essay": 29,
       "file-size": 1315,
       "function-size": 14
     },
@@ -1500,7 +1498,7 @@
     "internal/provider/anthropic/anthropic.go": {
       "complexity": 45,
       "essay": 36,
-      "file-size": 108,
+      "file-size": 115,
       "function-size": 154
     },
     "internal/provider/anthropic/anthropic_test.go": {
@@ -1511,10 +1509,10 @@
       "essay": 8
     },
     "internal/provider/openai/openai.go": {
-      "complexity": 64,
-      "essay": 42,
-      "file-size": 554,
-      "function-size": 255
+      "complexity": 61,
+      "essay": 40,
+      "file-size": 538,
+      "function-size": 252
     },
     "internal/provider/openai/openai_test.go": {
       "essay": 5,
@@ -1525,12 +1523,12 @@
     },
     "internal/provider/provider.go": {
       "essay": 51,
-      "file-size": 353
+      "file-size": 374
     },
     "internal/provider/responses/responses.go": {
       "complexity": 54,
       "essay": 25,
-      "file-size": 79,
+      "file-size": 86,
       "function-size": 181
     },
     "internal/provider/responses/responses_test.go": {


### PR DESCRIPTION
## Summary

- Dynamic output-budget clip for shared-window providers (DeepSeek): when `input + max_output_tokens` would exceed the context window, the output budget is clipped, with a minimum 8K floor.
- `tokPerChar` calibration now uses the last sent request shape (projection + tail), not the full canonical transcript, keeping the context gauge honest.
- Response-side cache-break detection (`CacheMissDrop`) records drops ≥5% and ≥2000 tokens without compaction — bypass-only, no UI alerts yet.
- `maybePredictOverflow` emits a record-only notice when the prompt leaves <8K headroom — no compaction is triggered.
- Non-official model prices (MiMo, LongCat) are labeled "(估算)" in the TUI cost display.
- Snip/prune projections now properly mark content rewrite reasons so the cache-break detector resets its baseline.

## Verification
- `go test ./internal/agent/ ./internal/control/ ./internal/boot/ ./internal/tool/builtin/ -count=1`
- `go run ./tools/repolint` (clean)
- `gofmt` / `go vet` clean on touched packages

Cache-impact: medium - inside the cache window nothing changes (requests keep the same prefix and budget); outside it (cold resume or near-window pressure) the gate compacts once, then the new small prefix stays stable and cacheable. `max_output_tokens` is clipped at the request tail, never in the cached prefix.
Cache-guard: go test ./internal/agent/ -count=1 (TestEffectiveOutputBudget*, TestCacheMissDrop*, TestMaybePredictOverflow*, TestSummarizeClips*, TestMaybeCompactPausesOnTooLargeInput)
System-prompt-review: cache-break detection is read-only (no send-side change); `maybePredictOverflow` adds a LevelInfo notice in the turn tail; estimated-price label is TUI-only. System-prompt prefix and tool schemas are unchanged.
Documentation-impact: none - rationale documented in code comments (shared-window semantics, estimator under-count, safety factor).
