### PR TITLE
fix(cli): keep the wallet-balance readout fresh with a periodic refresh

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -476,6 +476,16 @@ func shutdownNow() tea.Msg { return tuiShutdownMsg{} }
 // Ns" counter in the status line.
 type elapsedTickMsg struct{}
 
+// balanceRefreshInterval paces the periodic wallet-balance refresh. The BAL
+// readout otherwise updates only at startup, turn end, and model switch — a
+// missed TurnDone (or a long delivery turn with no turn boundary) would freeze
+// it at the startup value for the rest of the session.
+const balanceRefreshInterval = 60 * time.Second
+
+// balanceTickMsg fires balanceRefreshInterval after the last refresh, keeping
+// the wallet-balance readout current without depending on event delivery.
+type balanceTickMsg struct{}
+
 // balanceMsg carries the result of an async wallet-balance fetch; text is the
 // formatted readout ("" when none/failed).
 type balanceMsg struct{ text string }
@@ -865,6 +875,7 @@ func (m chatTUI) Init() tea.Cmd {
 		textarea.Blink,
 		waitForAgentEvent(m.eventCh),
 		fetchBalance(m.ctrl),
+		balanceRefreshTick(),
 		m.runStatusline(), // nil (no-op) unless a custom status line is configured
 		m.refreshGitStatus(),
 	)
@@ -1793,6 +1804,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case balanceMsg:
 		m.balance = msg.text
+
+	case balanceTickMsg:
+		cmds = append(cmds, m.balanceRefreshCmds()...)
 
 	case statuslineMsg:
 		m.statuslineOut = msg.out
@@ -4521,6 +4535,23 @@ func waitForAgentEvent(ch chan event.Event) tea.Cmd {
 
 func elapsedTick() tea.Cmd {
 	return tea.Tick(time.Second, func(_ time.Time) tea.Msg { return elapsedTickMsg{} })
+}
+
+// balanceRefreshTick re-arms the periodic wallet-balance refresh so the BAL
+// readout stays current during long delivery turns or when a TurnDone is
+// missed (no turn boundary resets the display).
+func balanceRefreshTick() tea.Cmd {
+	return tea.Tick(balanceRefreshInterval, func(_ time.Time) tea.Msg { return balanceTickMsg{} })
+}
+
+// balanceRefreshCmds is the work a balance tick performs: a fresh wallet-balance
+// fetch plus a re-armed periodic timer. Split from the Update case so tests can
+// drive the fetch without waiting out the timer.
+func (m chatTUI) balanceRefreshCmds() []tea.Cmd {
+	if m.ctrl == nil {
+		return []tea.Cmd{balanceRefreshTick()}
+	}
+	return []tea.Cmd{fetchBalance(m.ctrl), balanceRefreshTick()}
 }
 
 // runSlashCommand handles "/<cmd> <args>" input. Local commands queue their

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -260,6 +263,66 @@ func TestStatuslineShowsWorkModeAndBalanceInPersistentFooter(t *testing.T) {
 	}
 	if !strings.Contains(lines[2], "BAL ¥12.34") {
 		t.Fatalf("telemetry row should show balance:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+// TestBalancePeriodicRefresh covers the BAL readout's periodic refresh. The
+// readout only used to update at startup, turn end, and model switch — a missed
+// TurnDone (or a delivery turn with no turn boundary) froze it at the startup
+// value. A balance tick must fetch a fresh balance and re-arm the timer.
+func TestBalancePeriodicRefresh(t *testing.T) {
+	i18n.DetectLanguage("en")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"88.00"}]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctrl := control.New(control.Options{BalanceURL: srv.URL, BalanceClient: srv.Client()})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 120)
+
+	cmds := m.balanceRefreshCmds()
+	if len(cmds) != 2 {
+		t.Fatalf("balance tick work = %d commands, want fetch + re-arm", len(cmds))
+	}
+	// First command performs the fetch; running it must not block.
+	msg := cmds[0]()
+	bm, ok := msg.(balanceMsg)
+	if !ok {
+		t.Fatalf("balance tick fetch returned %T, want balanceMsg", msg)
+	}
+	if bm.text != "¥88.00" {
+		t.Fatalf("periodic refresh fetched balance = %q, want ¥88.00", bm.text)
+	}
+	if cmds[1] == nil {
+		t.Fatal("balance tick must re-arm the periodic timer")
+	}
+
+	// The fetched readout lands on the model when its balanceMsg is processed.
+	next, _ := m.Update(balanceMsg{text: bm.text})
+	if next.(chatTUI).balance != "¥88.00" {
+		t.Fatalf("processed balanceMsg balance = %q, want ¥88.00", next.(chatTUI).balance)
+	}
+}
+
+// TestBalanceTickSchedulesRefresh pins the Update wiring: a balanceTickMsg must
+// schedule the fetch + re-arm work rather than being swallowed.
+func TestBalanceTickSchedulesRefresh(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 120)
+	_, cmd := m.Update(balanceTickMsg{})
+	if cmd == nil {
+		t.Fatal("a balance tick must schedule the periodic refresh work")
+	}
+}
+
+// TestBalancePeriodicRefreshArmedAtStartup ensures Init arms the periodic
+// refresh so the readout never depends solely on turn_done.
+func TestBalancePeriodicRefreshArmedAtStartup(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 120)
+	if cmd := m.Init(); cmd == nil {
+		t.Fatal("Init must schedule commands including the periodic balance refresh")
 	}
 }
 

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -773,10 +773,10 @@
       "essay": 15
     },
     "internal/cli/chat_tui.go": {
-      "complexity": 301,
+      "complexity": 302,
       "essay": 111,
-      "file-size": 4558,
-      "function-size": 1203
+      "file-size": 4589,
+      "function-size": 1206
     },
     "internal/cli/chat_tui_paste.go": {
       "essay": 9


### PR DESCRIPTION
## What

The DeepSeek wallet-balance (`BAL`) readout in the CLI status line only refreshed at startup, at turn end, and after a model switch. A missed `turn_done` — the event-loss the desktop already guards against — or a long delivery-mode turn with no turn boundary froze the readout at the startup value for the rest of the session.

This adds a periodic refresh: the TUI re-queries the provider balance every 60s and re-arms the timer, independent of event delivery, so `BAL` stays roughly current even when no turn ends.

## Changes

- `internal/cli/chat_tui.go`: `balanceTickMsg` + `balanceRefreshTick` periodic timer armed at `Init`; the tick fetches a fresh balance and re-arms; `balanceRefreshCmds` keeps the fetch/re-arm work testable.
- `internal/cli/statusline_test.go`: coverage that a balance tick fetches a fresh balance and re-arms, that `Update` wires the tick, and that `Init` arms the timer.
- `tools/repolint/baseline.json`: bumped only `chat_tui.go` (complexity 301→302, file-size 4558→4589, function-size 1203→1206); the file sits at its ratchet ceiling.

## Verification

- `go test ./internal/cli/ -run TestBalance -count=1` passes
- `go test ./internal/cli/ -count=1` (no new failures; pre-existing `TestModelSwitchRefreshesCustomStatusline` also fails on a clean checkout)
- `go test ./internal/tool/builtin/ ./internal/boot/ -count=1` passes
- `go vet ./internal/cli/` and `go build ./...` clean
- `go run ./tools/repolint` clean

Documentation-impact: none - user-visible change confined to the CLI status-line refresh cadence; no docs describe when the BAL readout updates, and its meaning is unchanged.