### PR TITLE
feat(agent): adaptive no-progress guard driven by evidence gain

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -560,6 +560,10 @@ type Agent struct {
 	stormSig   string
 	stormCount int
 
+	// progress escalates adaptively on consecutive zero-evidence-gain rounds
+	// (see progress_guard.go); reset with the evidence ledger each turn.
+	progress progressGuard
+
 	// repeatFailureCounts tracks semantically identical write-like calls that
 	// keep failing with the same failure class. Unlike stormSig, successful
 	// reads do not blindly clear this state: re-reading a file and then
@@ -1811,34 +1815,6 @@ func (a *Agent) deliveryMutationCheckpointReady() bool {
 		a.evidence.HasSuccessfulDeliverySignoffAfter(mutation) &&
 		a.evidence.HasSuccessfulReviewAfter(mutation) &&
 		a.deliveryReviewGateFailure() == ""
-}
-
-// armLoopGuardPass records that a loop guard fired this user turn.
-// receiptMark is the evidence-ledger receipt count from just before the
-// guarded batch ran, so a successful write or command receipt recorded after
-// it counts as real progress and revokes the pass (see loopGuardAllowsFinal).
-func (a *Agent) armLoopGuardPass(receiptMark int) {
-	a.loopGuardArmed = true
-	a.loopGuardReceiptMark = receiptMark
-}
-
-// loopGuardAllowsFinal reports whether final readiness should stand down: a
-// loop guard fired this user turn and no host-observable progress — a
-// successful write or command receipt — has landed since. In that state the
-// missing receipts are exactly what the blocker prevents, so demanding them
-// would restart the retry loop the guard just broke; the model must be free to
-// report the blocker instead. The bookkeeping the guard recommends (ask,
-// todo_write, complete_step) produces neither write nor command receipts, so
-// it keeps the pass; real progress revokes it because receipts are obtainable
-// again and readiness should resume enforcing them.
-func (a *Agent) loopGuardAllowsFinal() bool {
-	if a == nil || !a.loopGuardArmed {
-		return false
-	}
-	if a.evidence == nil {
-		return true
-	}
-	return !a.evidence.HasWriteOrCommandSince(a.loopGuardReceiptMark)
 }
 
 func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -325,7 +325,7 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) bat
 		}
 	}
 	if !cancelled {
-		a.applyStormBreaker(calls, outcomes, results, receiptMark)
+		a.applyBatchGuards(calls, outcomes, results, receiptMark)
 	}
 	images := make([][]string, len(calls))
 	executions := make([]*tool.ShellExecution, len(calls))

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"fmt"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+)
+
+// The no-progress ladder is adaptive, not a fixed round count: rounds are
+// judged by evidence gain (new reads, new results, mutations) and only
+// consecutive zero-gain rounds escalate — nudge, then pivot, then stop.
+const (
+	progressNudgeStreak = 2
+	progressPivotStreak = 4
+	progressStopStreak  = 6
+)
+
+// progressGuard tracks consecutive tool rounds whose receipts produced no new
+// evidence. State lives per user turn, alongside the ledger it observes.
+type progressGuard struct {
+	tracker *evidence.ProgressTracker
+	streak  int
+}
+
+func (g *progressGuard) reset() {
+	g.tracker = evidence.NewProgressTracker()
+	g.streak = 0
+}
+
+// observe folds one round's receipts and returns the current zero-gain streak.
+func (g *progressGuard) observe(receipts []Receipt) int {
+	if g.tracker == nil {
+		g.reset()
+	}
+	if len(receipts) == 0 {
+		return g.streak
+	}
+	if g.tracker.ScoreRound(receipts) > 0 {
+		g.streak = 0
+	} else {
+		g.streak++
+	}
+	return g.streak
+}
+
+// Receipt aliases the evidence receipt for the guard's signature.
+type Receipt = evidence.Receipt
+
+// applyBatchGuards runs both post-batch guards: the storm breaker (failure
+// fixation) and the progress guard (zero-gain repetition).
+func (a *Agent) applyBatchGuards(calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) {
+	a.applyStormBreaker(calls, outcomes, results, receiptMark)
+	a.applyProgressGuard(results, outcomes, receiptMark)
+}
+
+// resetTurnEvidence clears the ledger and the progress-guard state together.
+func (a *Agent) resetTurnEvidence() {
+	a.evidence.Reset()
+	a.progress.reset()
+}
+
+// applyProgressGuard escalates when consecutive rounds stop producing new
+// evidence. It rides the same channel as the storm breaker: guidance appended
+// to the round's first tool result, a loop-guard notice for the frontend, and
+// at the stop tier the loop-guard pass so final readiness stands down and the
+// model can deliver its answer instead of being sent back for more receipts.
+func (a *Agent) applyProgressGuard(results []string, outcomes []toolOutcome, receiptMark int) {
+	if a.evidence == nil || len(results) == 0 || len(outcomes) == 0 {
+		return
+	}
+	receipts := a.evidence.ReceiptsSince(receiptMark)
+	// Rounds where nothing succeeded are the storm breaker's jurisdiction
+	// (same-failure fixation); this guard owns the storm-blind case — rounds
+	// that keep SUCCEEDING without producing anything new.
+	anySuccess := false
+	for _, r := range receipts {
+		if r.Success {
+			anySuccess = true
+			break
+		}
+	}
+	if !anySuccess {
+		return
+	}
+	streak := a.progress.observe(receipts)
+	var guard, detail string
+	warn := false
+	// Fire only when a threshold is crossed: repeating the injected guidance
+	// every round would inflate prompts (and can even tip compaction).
+	switch streak {
+	case progressStopStreak:
+		guard = fmt.Sprintf(
+			"[progress guard] %d tool rounds in a row produced no new evidence (no new files, results, or changes). Stop exploring: produce your final answer now, stating what was established and what remains unknown.",
+			streak)
+		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — demanding a final answer", streak)
+		warn = true
+		a.armLoopGuardPass(receiptMark)
+	case progressPivotStreak:
+		guard = fmt.Sprintf(
+			"[progress guard] still no new evidence after %d rounds. Change strategy now: take a different angle or tool, delegate a focused sub-task, or reduce the scope of what you are verifying.",
+			streak)
+		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — forcing a strategy change", streak)
+	case progressNudgeStreak:
+		guard = fmt.Sprintf(
+			"[progress guard] the last %d tool rounds repeated earlier reads or commands without new results. Narrow the investigation or adjust the plan before continuing.",
+			streak)
+		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — nudging to narrow", streak)
+	default:
+		return
+	}
+	results[0] = outcomes[0].output + "\n\n" + guard
+	level := event.LevelInfo
+	if warn {
+		level = event.LevelWarn
+	}
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: level, Code: event.NoticeCodeProgressGuard, Text: progressGuardNoticeText(), Detail: detail})
+}
+
+func progressGuardNoticeText() string {
+	return "The assistant keeps repeating work without new evidence; asking it to change approach."
+}
+
+// armLoopGuardPass records that a loop guard fired this user turn.
+// receiptMark is the evidence-ledger receipt count from just before the
+// guarded batch ran, so a successful write or command receipt recorded after
+// it counts as real progress and revokes the pass (see loopGuardAllowsFinal).
+func (a *Agent) armLoopGuardPass(receiptMark int) {
+	a.loopGuardArmed = true
+	a.loopGuardReceiptMark = receiptMark
+}
+
+// loopGuardAllowsFinal reports whether final readiness should stand down: a
+// guard fired this user turn and no successful write or command receipt has
+// landed since. The missing receipts are exactly what the blocker prevents —
+// demanding them would restart the loop the guard broke — while bookkeeping
+// (ask, todo_write, complete_step) keeps the pass and real progress revokes it.
+func (a *Agent) loopGuardAllowsFinal() bool {
+	if a == nil || !a.loopGuardArmed {
+		return false
+	}
+	if a.evidence == nil {
+		return true
+	}
+	return !a.evidence.HasWriteOrCommandSince(a.loopGuardReceiptMark)
+}

--- a/internal/agent/progress_guard_test.go
+++ b/internal/agent/progress_guard_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+	_ "reasonix/internal/tool/builtin"
+)
+
+func bashProgressReceipt(t *testing.T, command string, success bool) evidence.Receipt {
+	t.Helper()
+	args, err := json.Marshal(map[string]string{"command": command})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return evidence.ReceiptFromToolCall("bash", args, success, false)
+}
+
+// runRound executes one read-only batch and returns its result texts.
+func runRound(t *testing.T, a *Agent, path string) []string {
+	t.Helper()
+	batch := a.executeBatch(context.Background(), []provider.ToolCall{
+		{ID: "c", Name: "read_probe", Arguments: `{"path":"` + path + `"}`},
+	})
+	return batch.results
+}
+
+func TestProgressGuardEscalatesOnZeroGainRounds(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_probe", readOnly: true})
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.progress.reset()
+
+	if got := runRound(t, a, "same.go"); strings.Contains(got[0], "[progress guard]") {
+		t.Fatalf("round 1 (new read, +1 gain) must not trip the guard: %q", got[0])
+	}
+	// Every later round re-reads the same path: zero gain, streak +1 per round.
+	if got := runRound(t, a, "same.go"); strings.Contains(got[0], "[progress guard]") {
+		t.Fatalf("one zero-gain round must not trip the guard yet: %q", got[0])
+	}
+	got := runRound(t, a, "same.go")
+	if !strings.Contains(got[0], "[progress guard]") || !strings.Contains(got[0], "Narrow the investigation") {
+		t.Fatalf("streak %d must nudge: %q", progressNudgeStreak, got[0])
+	}
+	runRound(t, a, "same.go")
+	got = runRound(t, a, "same.go")
+	if !strings.Contains(got[0], "Change strategy now") {
+		t.Fatalf("streak %d must force a pivot: %q", progressPivotStreak, got[0])
+	}
+	runRound(t, a, "same.go")
+	got = runRound(t, a, "same.go")
+	if !strings.Contains(got[0], "produce your final answer now") {
+		t.Fatalf("streak %d must demand the final answer: %q", progressStopStreak, got[0])
+	}
+	if !a.loopGuardArmed {
+		t.Fatal("stop tier must arm the loop-guard pass so readiness stands down")
+	}
+	// Past the stop tier the loop-guard pass carries the pressure; repeating
+	// the injected text every round would only inflate prompts.
+	got = runRound(t, a, "same.go")
+	if strings.Contains(got[0], "[progress guard]") {
+		t.Fatalf("thresholds fire once, not every round: %q", got[0])
+	}
+	if !a.loopGuardArmed {
+		t.Fatal("loop-guard pass must remain armed past the stop tier")
+	}
+}
+
+func TestProgressGuardResetsOnNewEvidence(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_probe", readOnly: true})
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.progress.reset()
+
+	runRound(t, a, "a.go")
+	runRound(t, a, "a.go")
+	runRound(t, a, "a.go")
+	if a.progress.streak < progressNudgeStreak {
+		t.Fatalf("streak = %d, want >= %d before fresh evidence", a.progress.streak, progressNudgeStreak)
+	}
+	// A successful bash command receipt is fresh evidence: streak resets.
+	a.evidence.Record(bashProgressReceipt(t, "go test ./pkg", true))
+	mark := a.evidence.Len() - 1
+	a.progress.observe(a.evidence.ReceiptsSince(mark))
+	if a.progress.streak != 0 {
+		t.Fatalf("fresh evidence must reset the streak, got %d", a.progress.streak)
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -210,7 +210,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 		case scoped && a.deliveryScopeID == scope.ID:
 			a.evidence.ResetBackgroundLeases()
 		default:
-			a.evidence.Reset()
+			a.resetTurnEvidence()
 		}
 	}
 	a.preserveEvidenceOnce = false

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -38,7 +38,9 @@ func (o okTool) Execute(context.Context, json.RawMessage) (string, error) { retu
 func noticeRecorder() (event.Sink, *[]string) {
 	var notices []string
 	sink := event.FuncSink(func(e event.Event) {
-		if e.Kind == event.Notice {
+		// Storm tests assert on the storm breaker's own notices; the adaptive
+		// progress guard has its own code and cadence (progress_guard_test.go).
+		if e.Kind == event.Notice && e.Code == event.NoticeCodeLoopGuard {
 			notices = append(notices, e.Text)
 		}
 	})

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -482,6 +482,7 @@ const (
 	NoticeCodeExecutorHandoff               = "executor_handoff"
 	NoticeCodeToolBudget                    = "tool_budget"
 	NoticeCodeLoopGuard                     = "loop_guard"
+	NoticeCodeProgressGuard                 = "progress_guard"
 	NoticeCodeWorkspaceLease                = "workspace_lease"
 	NoticeCodeCancelledTurn                 = "cancelled_turn_display"
 	NoticeCodeUnappliedSteer                = "unapplied_steer"

--- a/internal/evidence/progress.go
+++ b/internal/evidence/progress.go
@@ -1,0 +1,126 @@
+package evidence
+
+import "strings"
+
+// Evidence-gain weights: what one tool round contributed beyond what the turn
+// already knew. Positive = the round moved the investigation; zero = motion
+// without information (repeats); negative = burning rounds on a known failure.
+const (
+	gainNewRead       = 1 // first successful read of a path
+	gainNewCommand    = 1 // first successful run of a command
+	gainNewAction     = 1 // first successful (tool, args) call — covers MCP/custom tools
+	gainNewFailure    = 2 // a command failing for the first time localizes an error
+	gainStateChange   = 2 // a previously failing command now passes (or vice versa)
+	gainMutation      = 3 // a successful write/mutation
+	gainTaskProgress  = 1 // todo/step bookkeeping that advances task state
+	gainDelegated     = 2 // a sub-agent round-trip that returned
+	gainRepeatFailure = -2
+)
+
+// ProgressTracker scores each tool round's receipts for new evidence so the
+// agent can react to stalled investigation adaptively instead of at a fixed
+// round count. State is per user turn, like the ledger it observes.
+type ProgressTracker struct {
+	readPaths   map[string]bool
+	commandRuns map[string]bool
+	commandFail map[string]bool
+	actionSigs  map[string]bool
+}
+
+func NewProgressTracker() *ProgressTracker {
+	return &ProgressTracker{
+		readPaths:   map[string]bool{},
+		commandRuns: map[string]bool{},
+		commandFail: map[string]bool{},
+		actionSigs:  map[string]bool{},
+	}
+}
+
+// ScoreRound folds one round's receipts into the tracker and returns the
+// round's evidence gain.
+func (t *ProgressTracker) ScoreRound(receipts []Receipt) int {
+	if t == nil {
+		return 0
+	}
+	gain := 0
+	for _, r := range receipts {
+		gain += t.scoreReceipt(r)
+	}
+	return gain
+}
+
+func (t *ProgressTracker) scoreReceipt(r Receipt) int {
+	if command := strings.TrimSpace(r.Command); command != "" {
+		return t.scoreCommand(command, r.Success)
+	}
+	switch {
+	case r.Success && (r.Mutation || r.Write):
+		return gainMutation
+	case r.Success && (r.ToolName == "task" || r.ToolName == "parallel_tasks" || r.ToolName == "fleet"):
+		return gainDelegated
+	case r.Success && (r.StepProof || r.TodoStep != nil || len(r.Todos) > 0):
+		return gainTaskProgress
+	case r.Success && r.Read && r.OutputBytes > 0 && len(r.Paths) > 0:
+		return t.scoreReads(r.Paths)
+	case r.Success:
+		// Unknown tools (MCP, custom): a first (tool, args) call is evidence;
+		// resending the identical call is not.
+		sig := r.ToolName + "\x00" + string(r.Args)
+		if t.actionSigs[sig] {
+			return 0
+		}
+		t.actionSigs[sig] = true
+		return gainNewAction
+	default:
+		return 0
+	}
+}
+
+func (t *ProgressTracker) scoreReads(paths []string) int {
+	gain := 0
+	for _, path := range paths {
+		if path == "" || t.readPaths[path] {
+			continue
+		}
+		t.readPaths[path] = true
+		gain += gainNewRead
+	}
+	return gain
+}
+
+func (t *ProgressTracker) scoreCommand(command string, success bool) int {
+	seen := t.commandRuns[command]
+	failedBefore := t.commandFail[command]
+	t.commandRuns[command] = true
+	if !success {
+		t.commandFail[command] = true
+		if failedBefore {
+			return gainRepeatFailure
+		}
+		return gainNewFailure
+	}
+	delete(t.commandFail, command)
+	if failedBefore {
+		return gainStateChange
+	}
+	if seen {
+		return 0
+	}
+	return gainNewCommand
+}
+
+// ReceiptsSince returns a copy of the receipts recorded at or after index.
+func (l *Ledger) ReceiptsSince(index int) []Receipt {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(l.receipts) {
+		return nil
+	}
+	return append([]Receipt(nil), l.receipts[index:]...)
+}

--- a/internal/evidence/progress_test.go
+++ b/internal/evidence/progress_test.go
@@ -1,0 +1,64 @@
+package evidence
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func readReceipt(path string) Receipt {
+	return ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"`+path+`"}`), true, true)
+}
+
+func bashReceipt(command string, success bool) Receipt {
+	args, _ := json.Marshal(map[string]string{"command": command})
+	return ReceiptFromToolCall("bash", args, success, false)
+}
+
+func TestProgressTrackerScoresNewVsRepeatedEvidence(t *testing.T) {
+	tr := NewProgressTracker()
+
+	first := readReceipt("a.go")
+	first.OutputBytes = 10
+	if got := tr.ScoreRound([]Receipt{first}); got != gainNewRead {
+		t.Fatalf("new read gain = %d, want %d", got, gainNewRead)
+	}
+	repeat := readReceipt("a.go")
+	repeat.OutputBytes = 10
+	if got := tr.ScoreRound([]Receipt{repeat}); got != 0 {
+		t.Fatalf("repeated read gain = %d, want 0", got)
+	}
+
+	if got := tr.ScoreRound([]Receipt{bashReceipt("go test ./x", false)}); got != gainNewFailure {
+		t.Fatalf("first failure gain = %d, want %d (a new error localizes)", got, gainNewFailure)
+	}
+	if got := tr.ScoreRound([]Receipt{bashReceipt("go test ./x", false)}); got != gainRepeatFailure {
+		t.Fatalf("same failure gain = %d, want %d", got, gainRepeatFailure)
+	}
+	if got := tr.ScoreRound([]Receipt{bashReceipt("go test ./x", true)}); got != gainStateChange {
+		t.Fatalf("failure→pass gain = %d, want %d", got, gainStateChange)
+	}
+	if got := tr.ScoreRound([]Receipt{bashReceipt("go test ./x", true)}); got != 0 {
+		t.Fatalf("repeated passing command gain = %d, want 0", got)
+	}
+
+	write := ReceiptFromToolCall("write_file", json.RawMessage(`{"path":"b.go","content":"x"}`), true, false)
+	if got := tr.ScoreRound([]Receipt{write}); got != gainMutation {
+		t.Fatalf("mutation gain = %d, want %d", got, gainMutation)
+	}
+}
+
+func TestLedgerReceiptsSince(t *testing.T) {
+	l := &Ledger{}
+	l.Record(bashReceipt("one", true))
+	l.Record(bashReceipt("two", true))
+	if got := len(l.ReceiptsSince(1)); got != 1 {
+		t.Fatalf("receipts since 1 = %d, want 1", got)
+	}
+	if got := l.ReceiptsSince(5); got != nil {
+		t.Fatalf("out-of-range mark must yield nil, got %v", got)
+	}
+	var nilLedger *Ledger
+	if got := nilLedger.ReceiptsSince(0); got != nil {
+		t.Fatalf("nil ledger must yield nil")
+	}
+}


### PR DESCRIPTION
Replaces "fixed round count" stall detection with the evidence-gain ladder: rounds are judged by what they *added*, not that they happened. Builds directly on the receipts the ledger already records (reads, commands, mutations, paths, success).

## Scoring (`evidence.ProgressTracker`)

| Signal | Gain |
|---|---:|
| first successful read of a path | +1 |
| first run of a command / first (tool, args) action (MCP/custom tools included) | +1 |
| a command failing for the first time (localizes an error) | +2 |
| a previously failing command turning green | +2 |
| successful mutation | +3 |
| repeated read / repeated command / identical re-call | 0 |
| resending a known-failing command | −2 |
| todo/step bookkeeping · a returned sub-agent | +1 / +2 |

## Escalation (`progressGuard`)

Consecutive **zero-gain** rounds escalate — any positive gain resets the streak:

- **2** → nudge: narrow the investigation or adjust the plan
- **4** → forced strategy change: different angle/tool, delegate, or reduce scope
- **6** → final-answer demand + the **loop-guard pass** is armed, so final readiness stands down (the pass machinery moved next to its new second caller) and the model can deliver instead of being sent back for more receipts

Each threshold fires once (repeating injected guidance measurably inflates prompts — enough to tip an extra compaction in the starved-window cache test). Distinct notice code `progress_guard` keeps it separable from the storm breaker in UI/telemetry.

## Division of labor with the storm breaker

Rounds where nothing succeeded stay the storm breaker's jurisdiction (same-failure fixation, threshold 3). This guard owns the storm-blind case: rounds that keep **succeeding** without producing anything new — repeated reads, re-run green commands, identical re-calls — which no failure-signature guard can see.

## Tests

Evidence scoring semantics (new/repeat/state-change/mutation), `ReceiptsSince`, and agent-level ladder behavior (nudge→pivot→stop wording, pass armed and persisting, thresholds firing once, streak reset on fresh evidence). Storm tests now filter on the storm notice code; full `internal/agent`, `evidence`, `event`, `control`, `boot` suites pass.

Cache-impact: low - guard text is injected into a tool result at most three times per stalled turn (thresholds fire once each); the prompt prefix is untouched and the turn tail rides normal append-only growth
Cache-guard: go test ./internal/agent/ -run 'TestCacheHitSurvivesTooSmallWindow' — the starved-window compaction regression stays capped at ≤2 collapses with the guard active
Documentation-impact: none - agent-internal behavior; the loop-guard UX surface is unchanged apart from a new notice code