### PR TITLE
fix(desktop/composer): don't cancel in-flight turn on ESC while IME is composing

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -2179,13 +2179,6 @@ console.log("\ncomposer goal toggle");
   const sessionSearch = document.querySelector(".slashmenu__search") as HTMLInputElement | null;
   if (!sessionSearch) throw new Error("recent-session search did not render");
   await act(async () => {
-    const imeEscape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
-    Object.defineProperty(imeEscape, "isComposing", { value: true });
-    sessionSearch.dispatchEvent(imeEscape);
-    await flushTimers();
-  });
-  ok(Boolean(document.querySelector(".slashmenu__search")), "IME Escape keeps the direct recent-session picker open");
-  await act(async () => {
     sessionSearch.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
     await flushTimers();
   });

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -2179,6 +2179,13 @@ console.log("\ncomposer goal toggle");
   const sessionSearch = document.querySelector(".slashmenu__search") as HTMLInputElement | null;
   if (!sessionSearch) throw new Error("recent-session search did not render");
   await act(async () => {
+    const imeEscape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    Object.defineProperty(imeEscape, "isComposing", { value: true });
+    sessionSearch.dispatchEvent(imeEscape);
+    await flushTimers();
+  });
+  ok(Boolean(document.querySelector(".slashmenu__search")), "IME Escape keeps the direct recent-session picker open");
+  await act(async () => {
     sessionSearch.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
     await flushTimers();
   });

--- a/desktop/frontend/src/__tests__/composer-keyboard.test.ts
+++ b/desktop/frontend/src/__tests__/composer-keyboard.test.ts
@@ -6,6 +6,7 @@ import {
   canUsePromptHistory,
   composerEscapeAction,
   composerEnterAction,
+  composerMenuKeyAction,
   insertComposerNewline,
   isFnKeyEvent,
   isImeKeyEvent,
@@ -103,6 +104,15 @@ eq(composerEscapeAction({ key: "Escape" }, true, true), "pass-through", "Escape 
 eq(composerEscapeAction({ key: "Escape" }, true, false), "cancel", "plain Escape cancels a running turn");
 eq(composerEscapeAction({ key: "Escape" }, false, false), "pass-through", "Escape does not cancel an idle composer");
 eq(composerEscapeAction({ key: "Enter" }, true, false), "pass-through", "non-Escape keys do not trigger cancellation");
+
+console.log("\ncomposerMenuKeyAction / IME gating");
+
+eq(composerMenuKeyAction({ key: "Escape" }, true), "pass-through", "IME Escape stays with the input");
+eq(composerMenuKeyAction({ key: "Enter" }, true), "pass-through", "IME Enter stays with the input");
+eq(composerMenuKeyAction({ key: "ArrowDown" }, true), "pass-through", "IME ArrowDown stays with the input");
+eq(composerMenuKeyAction({ key: "Escape" }, false), "handle", "plain Escape is handled by the menu");
+eq(composerMenuKeyAction({ key: "Enter" }, false), "handle", "plain Enter is handled by the menu");
+eq(composerMenuKeyAction({ key: "a" }, false), "pass-through", "typing keys pass through menu navigation");
 
 const now = 10_000;
 eq(

--- a/desktop/frontend/src/__tests__/composer-keyboard.test.ts
+++ b/desktop/frontend/src/__tests__/composer-keyboard.test.ts
@@ -4,9 +4,11 @@
 
 import {
   canUsePromptHistory,
+  composerEscapeAction,
   composerEnterAction,
   insertComposerNewline,
   isFnKeyEvent,
+  isImeKeyEvent,
   promptHistoryDirectionFromEvent,
   type PromptHistoryDirection,
 } from "../lib/composerKeyboard";
@@ -94,6 +96,45 @@ eq(composerEnterAction({ key: "Enter", altKey: true }, "linux"), "none", "a cust
 resetCustomShortcuts();
 eq(composerEnterAction({ key: "Enter" }, "darwin"), "send", "reset restores plain-Enter send");
 eq(composerEnterAction({ key: "Enter", shiftKey: true }, "darwin"), "newline-native", "reset restores the Shift+Enter default");
+
+console.log("\ncomposerEscapeAction / IME gating");
+
+eq(composerEscapeAction({ key: "Escape" }, true, true), "pass-through", "Escape passes through while composition is active");
+eq(composerEscapeAction({ key: "Escape" }, true, false), "cancel", "plain Escape cancels a running turn");
+eq(composerEscapeAction({ key: "Escape" }, false, false), "pass-through", "Escape does not cancel an idle composer");
+eq(composerEscapeAction({ key: "Enter" }, true, false), "pass-through", "non-Escape keys do not trigger cancellation");
+
+const now = 10_000;
+eq(
+  isImeKeyEvent({ key: "Escape", isComposing: true }, false, 0, now),
+  true,
+  "native isComposing protects IME Escape",
+);
+eq(
+  isImeKeyEvent({ key: "Escape", keyCode: 229 }, false, 0, now),
+  true,
+  "legacy keyCode 229 protects IME Escape",
+);
+eq(
+  isImeKeyEvent({ key: "Escape" }, true, 0, now),
+  true,
+  "composition ref protects IME Escape",
+);
+eq(
+  isImeKeyEvent({ key: "Escape" }, false, now - 99, now),
+  true,
+  "recent compositionend grace protects IME Escape",
+);
+eq(
+  isImeKeyEvent({ key: "Escape" }, false, now - 100, now),
+  false,
+  "compositionend grace expires at its boundary",
+);
+eq(
+  isImeKeyEvent({ key: "Escape" }, false, now - 101, now),
+  false,
+  "stale compositionend does not block plain Escape",
+);
 
 const boundaryInvocations: ComposerInvocation[] = [
   { id: "first", offset: 0, command: { name: "first", description: "First skill", kind: "skill" } },

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -754,6 +754,8 @@ export function Composer({
   const wasRunningByDraftRef = useRef<Record<string, boolean>>({ [draftKey]: running });
   const composingRef = useRef(false);
   const lastCompositionEndAt = useRef(0);
+  const pastChatSearchComposingRef = useRef(false);
+  const pastChatSearchLastCompositionEndAt = useRef(0);
   const lastSelectionRef = useRef({ start: 0, end: 0 });
   const consumedInsertIdByDraftRef = useRef<Record<string, number>>({});
   const consumedSelectedTextIdByDraftRef = useRef<Record<string, number>>({});
@@ -3487,6 +3489,15 @@ export function Composer({
   // menu logic. Regular typing keys (letters, Backspace, etc.) pass through
   // so the user can type a search query.
   const onPastChatSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (
+      isImeKeyEvent(
+        e.nativeEvent,
+        pastChatSearchComposingRef.current,
+        pastChatSearchLastCompositionEndAt.current,
+      )
+    ) {
+      return;
+    }
     if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === "Tab" || e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation();
@@ -4091,6 +4102,16 @@ export function Composer({
                     onChange={(ev) => {
                       setPastChatQuery(ev.target.value);
                       setActive(0);
+                    }}
+                    onCompositionStart={() => {
+                      pastChatSearchComposingRef.current = true;
+                    }}
+                    onCompositionEnd={() => {
+                      pastChatSearchComposingRef.current = false;
+                      pastChatSearchLastCompositionEndAt.current = Date.now();
+                    }}
+                    onBlur={() => {
+                      pastChatSearchComposingRef.current = false;
                     }}
                     onKeyDown={onPastChatSearchKeyDown}
                   />

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -5,7 +5,7 @@ import { asArray } from "../lib/array";
 import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
-import { canUsePromptHistory, composerEnterAction, composerEscapeAction, insertComposerNewline, isFnKeyEvent, isImeKeyEvent, promptHistoryDirectionFromEvent } from "../lib/composerKeyboard";
+import { canUsePromptHistory, composerEnterAction, composerEscapeAction, composerMenuKeyAction, insertComposerNewline, isFnKeyEvent, isImeKeyEvent, promptHistoryDirectionFromEvent } from "../lib/composerKeyboard";
 import { cacheGeneration, loadOlder } from "../lib/composerHistory";
 import { SPINNER_WORDS, useI18n, type Translator } from "../lib/i18n";
 import { detectShortcutPlatform, formatShortcutCombo, isReservedComposerHistoryShortcut, matchesShortcut, useShortcutComboLabel } from "../lib/keyboardShortcuts";
@@ -3489,16 +3489,12 @@ export function Composer({
   // menu logic. Regular typing keys (letters, Backspace, etc.) pass through
   // so the user can type a search query.
   const onPastChatSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (
-      isImeKeyEvent(
-        e.nativeEvent,
-        pastChatSearchComposingRef.current,
-        pastChatSearchLastCompositionEndAt.current,
-      )
-    ) {
-      return;
-    }
-    if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === "Tab" || e.key === "Escape") {
+    const composing = isImeKeyEvent(
+      e.nativeEvent,
+      pastChatSearchComposingRef.current,
+      pastChatSearchLastCompositionEndAt.current,
+    );
+    if (composerMenuKeyAction(e.nativeEvent, composing) === "handle") {
       e.preventDefault();
       e.stopPropagation();
       if (e.key === "ArrowDown" && count > 0) {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -5,7 +5,7 @@ import { asArray } from "../lib/array";
 import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
-import { canUsePromptHistory, composerEnterAction, insertComposerNewline, isFnKeyEvent, promptHistoryDirectionFromEvent } from "../lib/composerKeyboard";
+import { canUsePromptHistory, composerEnterAction, composerEscapeAction, insertComposerNewline, isFnKeyEvent, isImeKeyEvent, promptHistoryDirectionFromEvent } from "../lib/composerKeyboard";
 import { cacheGeneration, loadOlder } from "../lib/composerHistory";
 import { SPINNER_WORDS, useI18n, type Translator } from "../lib/i18n";
 import { detectShortcutPlatform, formatShortcutCombo, isReservedComposerHistoryShortcut, matchesShortcut, useShortcutComboLabel } from "../lib/keyboardShortcuts";
@@ -93,10 +93,6 @@ const COMPOSER_RUN_STRIP_RESERVED = 30;
 const COMPOSER_MAX_VIEWPORT_RATIO = 0.4;
 const COMPOSER_AUTO_RESERVED_HEIGHT = 58;
 const PROMPT_HISTORY_PREFETCH_REMAINING = 3;
-// Grace after compositionend to swallow a confirm-Enter that lands just after
-// it; the real gap is a few ms, so keep it short or a deliberate quick second
-// Enter (submit) gets eaten too.
-const IME_CONFIRM_GRACE_MS = 100;
 const FILE_REF_SEARCH_CACHE_TTL_MS = 5000;
 
 type PastedBlock = {
@@ -419,23 +415,6 @@ function useTick(on: boolean): number {
     return () => window.clearInterval(id);
   }, [on]);
   return Date.now();
-}
-
-function isImeKeyEvent(
-  e: KeyboardEvent<HTMLElement>,
-  composing: boolean,
-  lastCompositionEndAt: number,
-): boolean {
-  const native = e.nativeEvent as globalThis.KeyboardEvent & {
-    isComposing?: boolean;
-    keyCode?: number;
-  };
-  return (
-    composing ||
-    native.isComposing === true ||
-    native.keyCode === 229 ||
-    Date.now() - lastCompositionEndAt < IME_CONFIRM_GRACE_MS
-  );
 }
 
 // --- past:chats session reference → prompt context (PR-B) ---
@@ -3246,7 +3225,7 @@ export function Composer({
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) => {
-    const composing = isImeKeyEvent(e, composingRef.current, lastCompositionEndAt.current);
+    const composing = isImeKeyEvent(e.nativeEvent, composingRef.current, lastCompositionEndAt.current);
     const native = e.nativeEvent as globalThis.KeyboardEvent & {
       keyCode?: number;
       which?: number;
@@ -3445,10 +3424,7 @@ export function Composer({
     }
     // Esc interrupts the in-flight turn (matches the Stop button's hint), and
     // restores the text if the server hadn't replied yet.
-    // Skip when IME composition is active (composing folds in the same
-    // composingRef + isComposing + keyCode 229 + grace window the other
-    // branches use via isImeKeyEvent), so ESC only dismisses the candidate.
-    if (e.key === "Escape" && running && !composing) {
+    if (composerEscapeAction(e.nativeEvent, running, composing) === "cancel") {
       e.preventDefault();
       handleCancel();
     }

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -3445,7 +3445,10 @@ export function Composer({
     }
     // Esc interrupts the in-flight turn (matches the Stop button's hint), and
     // restores the text if the server hadn't replied yet.
-    if (e.key === "Escape" && running) {
+    // Skip when IME composition is active (composing folds in the same
+    // composingRef + isComposing + keyCode 229 + grace window the other
+    // branches use via isImeKeyEvent), so ESC only dismisses the candidate.
+    if (e.key === "Escape" && running && !composing) {
       e.preventDefault();
       handleCancel();
     }

--- a/desktop/frontend/src/lib/composerKeyboard.ts
+++ b/desktop/frontend/src/lib/composerKeyboard.ts
@@ -44,6 +44,25 @@ export function composerEscapeAction(
   return event.key === "Escape" && running && !composing ? "cancel" : "pass-through";
 }
 
+export type ComposerMenuKeyAction = "handle" | "pass-through";
+
+export function composerMenuKeyAction(
+  event: Pick<ComposerImeKeyLike, "key">,
+  composing: boolean,
+): ComposerMenuKeyAction {
+  if (composing) return "pass-through";
+  switch (event.key) {
+    case "ArrowDown":
+    case "ArrowUp":
+    case "Enter":
+    case "Tab":
+    case "Escape":
+      return "handle";
+    default:
+      return "pass-through";
+  }
+}
+
 // "newline-native" keeps the browser's own line-break insertion (only the
 // plain Shift+Enter chord, today's proven path); "newline-insert" means the
 // chord has no native insertion (e.g. Ctrl+Enter) so the composer must insert

--- a/desktop/frontend/src/lib/composerKeyboard.ts
+++ b/desktop/frontend/src/lib/composerKeyboard.ts
@@ -11,6 +11,39 @@ export interface ComposerEnterKeyLike {
   shiftKey?: boolean;
 }
 
+export interface ComposerImeKeyLike {
+  key?: string;
+  isComposing?: boolean;
+  keyCode?: number;
+}
+
+// Keep the post-composition window short enough that a deliberate second
+// shortcut remains responsive while covering browser IME event reordering.
+export const IME_CONFIRM_GRACE_MS = 100;
+
+export function isImeKeyEvent(
+  event: ComposerImeKeyLike,
+  composing: boolean,
+  lastCompositionEndAt: number,
+  now = Date.now(),
+): boolean {
+  const inGraceWindow =
+    lastCompositionEndAt > 0
+    && now >= lastCompositionEndAt
+    && now - lastCompositionEndAt < IME_CONFIRM_GRACE_MS;
+  return composing || event.isComposing === true || event.keyCode === 229 || inGraceWindow;
+}
+
+export type ComposerEscapeAction = "cancel" | "pass-through";
+
+export function composerEscapeAction(
+  event: Pick<ComposerImeKeyLike, "key">,
+  running: boolean,
+  composing: boolean,
+): ComposerEscapeAction {
+  return event.key === "Escape" && running && !composing ? "cancel" : "pass-through";
+}
+
 // "newline-native" keeps the browser's own line-break insertion (only the
 // plain Shift+Enter chord, today's proven path); "newline-insert" means the
 // chord has no native insertion (e.g. Ctrl+Enter) so the composer must insert


### PR DESCRIPTION
## Problem

The composer's ESC handler used to call `handleCancel()` whenever a turn was running, even when the ESC keydown was fired to dismiss a Chinese/Japanese IME candidate window. On macOS this is easy to hit while a reply is streaming:

1. Send a prompt and let the agent start replying.
2. Start typing a new message with a Chinese IME while the reply streams.
3. With the candidate list still open, press `ESC` to dismiss the candidate.
4. Expected: the candidate window closes and the agent keeps replying.
5. Actual: the agent turn is cancelled mid-reply.

## Root cause

`desktop/frontend/src/components/Composer.tsx` already computes a shared `composing` signal for send-Enter, menus, Shift+Tab, paste shortcuts, and prompt-history navigation, but the running-turn ESC branch was deciding cancellation inline. The past-chat search input is also a sibling of the textarea, so its keydown handler did not go through the main composer IME guard either.

## Fix

The first commit adds the missing IME guard to the running-turn ESC path.

The supplemental commits centralize and reuse the keyboard policy:

- `desktop/frontend/src/lib/composerKeyboard.ts` now owns `isImeKeyEvent()` for active composition ref, `nativeEvent.isComposing`, legacy `keyCode === 229`, and the short post-`compositionend` grace window.
- `composerEscapeAction()` decides whether Escape should cancel the running turn or pass through to the IME/browser.
- `composerMenuKeyAction()` decides whether menu navigation keys should be handled or pass through during IME composition.
- `Composer.tsx` now asks the helpers for the running-turn Escape action and past-chat search menu-key action instead of duplicating those conditions inline.
- The past-chat search input tracks its own composition state before handling Escape, Enter, Tab, or arrow navigation keys.

## Verification

Manual Wails check from the original PR:

1. Send a prompt; agent starts streaming a reply.
2. In the composer, start typing with a Chinese IME.
3. Press `ESC` while the candidate window is open.
4. Result: candidate window closes; agent continues streaming without interruption.

Automated checks added/rerun after the supplemental commits:

- `go run ./tools/repolint`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-keyboard.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/composer-goal-toggle.test.tsx`
- `pnpm --dir desktop/frontend exec tsc --noEmit`
- `pnpm --dir desktop/frontend exec eslint src/components/Composer.tsx src/lib/composerKeyboard.ts src/__tests__/composer-keyboard.test.ts src/__tests__/composer-goal-toggle.test.tsx`
- `git diff --check`

The regression coverage now includes:

- running turn + active composition + Escape passes through
- `nativeEvent.isComposing === true`
- legacy `keyCode === 229`
- ordinary non-IME Escape still cancels a running turn
- the 100ms post-`compositionend` grace-window boundary
- menu navigation keys pass through during IME composition while ordinary Escape/Enter still remain menu-handled

## Documentation impact

Documentation-impact: none - this is a chat-composer behavior guard and focused keyboard regression coverage. No public API, documented keybinding surface, or user-visible setting changes.

## Supersedes

This PR supersedes #6749, which was closed to restart the review queue. The original runtime fix was directionally correct; this version now also carries the maintainer-requested regression coverage and keyboard-policy cleanup.
