### PR TITLE
feat(serve): multi-tab host and Electron loopback PoC / serve 多 Tab 与 Electron 实验壳

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -45,7 +45,7 @@ import { asArray } from "./lib/array";
 import { createBoundedRefreshCoordinator, sameTabMetaLists, shouldRefreshTabMetaForEvent, TAB_META_MAX_IN_FLIGHT, tabMetaFallbackDelay } from "./lib/tabMetaRefresh";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT, type Translator } from "./lib/i18n";
 import { localizedNoticeText, useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
+import { app, isElectronServeShell, onEvent, onProjectTreeChanged, onReady, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
 import { NoticeCard, Transcript } from "./components/Transcript";
@@ -1165,7 +1165,13 @@ export default function App() {
   const settingsFocus = useOverlayStore((s) => s.settingsFocus);
   const setSettingsFocus = useOverlayStore((s) => s.setSettingsFocus);
   const [desktopLayoutStyle, setDesktopLayoutStyle] = useState<DesktopLayoutStyle>("workbench");
-  const singleSurfaceLayout = desktopLayoutStyle === "workbench" || desktopLayoutStyle === "creation";
+  // Electron multi-tab host keeps one Controller per project tab. Workbench/
+  // creation "single surface" mode would route sidebar clicks through
+  // activateTopic, which prunes every other tab's transcript cache and can leave
+  // the previous conversation on screen. Keep multi-surface navigation there.
+  const singleSurfaceLayout =
+    !isElectronServeShell() &&
+    (desktopLayoutStyle === "workbench" || desktopLayoutStyle === "creation");
   const [configLoadWarnings, setConfigLoadWarnings] = useState<string[]>([]);
   const [startupUpdateChecksEnabled, setStartupUpdateChecksEnabled] = useState<boolean | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
@@ -1345,7 +1351,7 @@ export default function App() {
 
   const refreshBackgroundRuntimes = useCallback(async () => {
     try {
-      setBackgroundRuntimes(await app.BackgroundRuntimes());
+      setBackgroundRuntimes(asArray(await app.BackgroundRuntimes()));
     } catch {
       // The global recovery entry is supplementary; the active-tab job list
       // remains available even when the detached-runtime list is unavailable.
@@ -2652,12 +2658,12 @@ export default function App() {
     let cancelled = false;
     void app.RemoteHosts()
       .then((hosts) => {
-        if (!cancelled) setRemoteHosts(hosts);
+        if (!cancelled) setRemoteHosts(asArray(hosts));
       })
       .catch(() => {});
     void app.RemoteConnectionStatuses()
       .then((statuses) => {
-        if (!cancelled) hydrateRemoteStatuses(statuses);
+        if (!cancelled) hydrateRemoteStatuses(asArray(statuses));
       })
       .catch(() => {});
     return () => {
@@ -4208,13 +4214,18 @@ export default function App() {
   // Workspace: open the folder chooser and switch projects. The hook resets the
   // transcript and refreshes meta on a pick. A cancel is a no-op.
   const switchFolder = useCallback(async (path?: string) => {
-    const picked = path === undefined ? await pickWorkspace() : await switchWorkspace(path);
-    if (picked) {
-      setProjectRevision((value) => value + 1);
-      await refreshTabMetas(undefined, { afterMutation: true });
+    try {
+      const picked = path === undefined ? await pickWorkspace() : await switchWorkspace(path);
+      if (picked) {
+        setProjectRevision((value) => value + 1);
+        await refreshTabMetas(undefined, { afterMutation: true });
+      }
+      return picked;
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : String(err), "error");
+      return "";
     }
-    return picked;
-  }, [pickWorkspace, switchWorkspace, refreshTabMetas]);
+  }, [pickWorkspace, switchWorkspace, refreshTabMetas, showToast]);
 
   const refreshProjectsAndTabs = useCallback(async () => {
     setProjectRevision((value) => value + 1);

--- a/desktop/frontend/src/__tests__/host-http-sse.test.ts
+++ b/desktop/frontend/src/__tests__/host-http-sse.test.ts
@@ -1,0 +1,245 @@
+// Run: tsx src/__tests__/host-http-sse.test.ts
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createHttpSseHost } from "../lib/host/httpSseHost";
+import { mapServeEventToWire, parseSseChunk } from "../lib/host/mapEvent";
+import { SERVE_ROUTES } from "../lib/host/routes";
+import { POC_CAPABILITIES, unsupportedDesktopFeatures } from "../lib/host/capabilities";
+import { makeElectronHttpApp } from "../lib/host/electronAppBindings";
+
+/** Real eventwire-shaped samples (internal/eventwire ToWire). */
+const WIRE_TEXT = { kind: "text", text: "ts" };
+const WIRE_APPROVAL = {
+  kind: "approval_request",
+  approval: { id: "a1", tool: "shell", subject: "echo hi", kind: "tool" },
+};
+
+function startFake(): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  posts: { path: string; body: string }[];
+}> {
+  const posts: { path: string; body: string }[] = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const token = url.searchParams.get("token") || "";
+    if (token !== "t") {
+      res.writeHead(401);
+      res.end("no");
+      return;
+    }
+    if (req.method === "POST") {
+      const ct = String(req.headers["content-type"] ?? "");
+      if (!ct.includes("application/json")) {
+        res.writeHead(415);
+        res.end("need json");
+        return;
+      }
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        posts.push({ path: url.pathname, body });
+        res.writeHead(url.pathname === "/submit" ? 202 : 204);
+        res.end();
+      });
+      return;
+    }
+    if (url.pathname === "/status") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, via: "ts-host" }));
+      return;
+    }
+    if (url.pathname === "/events") {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write(`data: ${JSON.stringify(WIRE_TEXT)}\n\n`);
+      res.write(`data: ${JSON.stringify(WIRE_APPROVAL)}\n\n`);
+      setTimeout(() => res.end(), 30);
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end("{}");
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}`,
+        posts,
+        close: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+async function main() {
+  console.log("\nhost http-sse");
+
+  assert.equal(POC_CAPABILITIES.multiTab, true);
+  assert.ok(!unsupportedDesktopFeatures().includes("multiTab"));
+  assert.ok(unsupportedDesktopFeatures().includes("terminal"));
+  process.stdout.write("  PASS  capability gate multiTab enabled\n");
+
+  const state = { pending: "" };
+  const parts = parseSseChunk(
+    `: ping\n\ndata: ${JSON.stringify({ kind: "notice", text: "n", level: "info" })}\n\n`,
+    state,
+  );
+  assert.equal(parts.length, 1);
+  const w = mapServeEventToWire(parts[0]);
+  assert.equal(w?.kind, "notice");
+  assert.equal((w as { type?: string }).type, undefined);
+  process.stdout.write("  PASS  parseSseChunk + mapServeEventToWire kind-based\n");
+
+  const appr = mapServeEventToWire(WIRE_APPROVAL);
+  assert.equal(appr?.kind, "approval_request");
+  assert.equal((appr?.approval as { id: string }).id, "a1");
+  process.stdout.write("  PASS  nested approval.id survives mapping\n");
+
+  const fake = await startFake();
+  try {
+    const host = createHttpSseHost({ baseUrl: fake.baseUrl, token: "t" });
+    const st = (await host.status()) as { ok: boolean; via: string };
+    assert.equal(st.ok, true);
+    assert.equal(st.via, "ts-host");
+    await host.submit("from-ts");
+    assert.ok(fake.posts.some((p) => p.path === SERVE_ROUTES.submit.path));
+    assert.equal(JSON.parse(fake.posts.find((p) => p.path === "/submit")!.body).input, "from-ts");
+    process.stdout.write("  PASS  status + submit over real HTTP\n");
+
+    const events: Record<string, unknown>[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error("timeout")), 3000);
+      host.onEvent((e) => {
+        events.push(e);
+        if (events.length >= 2) {
+          clearTimeout(t);
+          resolve();
+        }
+      });
+    });
+    assert.equal(events[0].kind, "text");
+    assert.equal(events[0].text, "ts");
+    assert.equal(events[0]._transport, "http-sse");
+    assert.equal(events[1].kind, "approval_request");
+    assert.equal((events[1].approval as { id: string }).id, "a1");
+    process.stdout.write("  PASS  SSE eventwire kind + approval.id\n");
+    host.dispose();
+  } finally {
+    await fake.close();
+  }
+
+  // Electron multi-tab AppBindings must never hand App.tsx undefined arrays /
+  // incomplete bot snapshots — that was the Phase-3 ErrorBoundary crash
+  // (undefined.length / undefined.trim during DesktopStartupSettings hydrate).
+  {
+    const host = createHttpSseHost({ baseUrl: "http://127.0.0.1:9", token: "t" });
+    const app = makeElectronHttpApp(host, {
+      baseUrl: "http://127.0.0.1:9",
+      token: "t",
+      workspace: "/tmp",
+    });
+    const startup = await app.DesktopStartupSettings();
+    assert.ok(Array.isArray(startup.statusBarItems));
+    assert.ok(Array.isArray(startup.configWarnings));
+    assert.ok(Array.isArray(startup.bot.connections));
+    assert.ok(Array.isArray(startup.bot.allowlist.feishuUsers));
+    assert.equal(typeof startup.bot.qq.appId, "string");
+    assert.ok(Array.isArray(await app.BackgroundRuntimes()));
+    assert.ok(Array.isArray(await app.RemoteHosts()));
+    assert.ok(Array.isArray(await app.RemoteConnectionStatuses()));
+    assert.ok(Array.isArray(await app.Models()));
+    assert.ok(Array.isArray(await app.Jobs()));
+    const settings = await app.Settings();
+    assert.ok(Array.isArray(settings.providers));
+    assert.ok(Array.isArray(settings.officialProviders));
+    // Proxy fallback for unknown List* / *s array methods.
+    const unknownList = await (app as unknown as { ListSomethingUnknown: () => Promise<unknown> }).ListSomethingUnknown();
+    assert.ok(Array.isArray(unknownList));
+    host.dispose();
+    process.stdout.write("  PASS  electron AppBindings startup arrays are never undefined\n");
+  }
+
+  // ListProjectTree must reflect open multi-tab Controllers so "添加新项目"
+  // after PickWorkspace is visible in the sidebar (was always []).
+  {
+    const tabs = [
+      {
+        id: "tab_a",
+        scope: "project",
+        workspaceRoot: "/Users/me/proj-a",
+        workspaceName: "proj-a",
+        topicId: "main",
+        topicTitle: "Session",
+        label: "model",
+        ready: true,
+        running: false,
+        active: true,
+        cwd: "/Users/me/proj-a",
+        mode: "agent",
+        collaborationMode: "default",
+        toolApprovalMode: "ask",
+        tokenMode: "auto",
+      },
+      {
+        id: "tab_b",
+        scope: "project",
+        workspaceRoot: "/Users/me/proj-b",
+        workspaceName: "proj-b",
+        topicId: "main",
+        topicTitle: "Session",
+        label: "model",
+        ready: true,
+        running: false,
+        active: false,
+        cwd: "/Users/me/proj-b",
+        mode: "agent",
+        collaborationMode: "default",
+        toolApprovalMode: "ask",
+        tokenMode: "auto",
+      },
+    ];
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/tabs") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(tabs));
+        return;
+      }
+      res.writeHead(404);
+      res.end("no");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    try {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const host = createHttpSseHost({ baseUrl: `http://127.0.0.1:${port}`, token: "t" });
+      const app = makeElectronHttpApp(host, {
+        baseUrl: `http://127.0.0.1:${port}`,
+        token: "t",
+        workspace: "/tmp",
+      });
+      const tree = await app.ListProjectTree();
+      assert.ok(Array.isArray(tree));
+      assert.equal(tree.length, 2);
+      assert.equal(tree[0].kind, "project");
+      assert.ok(tree.some((n) => n.root === "/Users/me/proj-a"));
+      assert.ok(tree.some((n) => n.root === "/Users/me/proj-b"));
+      for (const n of tree) {
+        assert.ok(Array.isArray(n.children) && n.children!.length >= 1);
+        assert.equal(n.children![0].kind, "topic");
+      }
+      host.dispose();
+      process.stdout.write("  PASS  ListProjectTree builds nodes from open tabs\n");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  console.log("host http-sse: all passed\n");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -17,6 +17,7 @@ import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems } from "./statusBarIt
 import { registerTrustedThemeBackgroundURLs } from "./themePack";
 import { modeHasAutoApproveTools, modeWithAutoApproveTools, modeWithPlan, normalizeCollaborationMode, normalizeMode, normalizeTokenMode, normalizeToolApprovalMode } from "./types";
 import { decisionSurfaceMockFromInput, isLongDecisionOptionsMockInput } from "./decisionSurfaceMock";
+import { createElectronHttpAppBundle, type ElectronHttpAppBundle } from "./host/electronAppBindings";
 
 import type {
   AutoResearchFindingView,
@@ -609,6 +610,8 @@ export type _CheckGenToApp = AssertNever<
 
 interface WailsRuntime {
   EventsOn(name: string, cb: (...data: unknown[]) => void): () => void;
+  EventsOff?(name?: string, ...additional: unknown[]): void;
+  EventsEmit?(name: string, ...data: unknown[]): void;
   BrowserOpenURL(url: string): void;
   WindowSetSystemDefaultTheme?(): void;
   WindowSetLightTheme?(): void;
@@ -628,6 +631,34 @@ declare global {
   interface Window {
     runtime?: WailsRuntime;
     go?: { main?: { App?: AppBindings } };
+    reasonixPoc?: {
+      getEndpoint: () => Promise<{
+        baseUrl: string;
+        token: string;
+        uiUrl?: string;
+        port?: number;
+        logFile?: string;
+        workspace?: string;
+      } | null>;
+      getEndpointSync?: () => {
+        baseUrl: string;
+        token: string;
+        uiUrl?: string;
+        port?: number;
+        logFile?: string;
+        workspace?: string;
+      } | null;
+      getCapabilities?: () => Promise<unknown>;
+      pickWorkspace?: () => Promise<{ workspace?: string; baseUrl?: string } | null>;
+      openLog?: () => Promise<boolean>;
+      restartServe?: () => Promise<unknown>;
+      onServeRestarted?: (cb: (payload: unknown) => void) => () => void;
+    };
+    __REASONIX_SERVE__?: {
+      baseUrl: string;
+      token: string;
+      workspace?: string;
+    };
   }
 }
 
@@ -643,7 +674,71 @@ const WAILS_IPC_NULL_SEND_RE = /Cannot read properties of null \(reading 'send'\
 // runtime can inject window.go AFTER this module first evaluates, so snapshotting
 // once would pin the browser mock for the whole session (and show fake data — the
 // dev mock's model list leaking into the real app was exactly this bug).
+
+let electronBundle: ElectronHttpAppBundle | null = null;
+
+/** True when running inside the Electron + serve PoC shell. */
+export function isElectronServeShell(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.reasonixPoc) return true;
+  if (window.__REASONIX_SERVE__?.baseUrl && window.__REASONIX_SERVE__?.token) return true;
+  return false;
+}
+
+function resolveElectronEndpoint(): { baseUrl: string; token: string; workspace?: string } | null {
+  if (typeof window === "undefined") return null;
+  if (window.__REASONIX_SERVE__?.baseUrl && window.__REASONIX_SERVE__?.token) {
+    return window.__REASONIX_SERVE__;
+  }
+  if (window.reasonixPoc?.getEndpointSync) {
+    const ep = window.reasonixPoc.getEndpointSync();
+    if (ep?.baseUrl && ep?.token) return ep;
+  }
+  // Query injection (desktop shell proxy may stamp these)
+  try {
+    const q = new URLSearchParams(window.location.search);
+    const baseUrl = q.get("rx_base") || q.get("baseUrl");
+    const token = q.get("rx_token") || q.get("token");
+    if (baseUrl && token) return { baseUrl, token, workspace: q.get("workspace") || undefined };
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function ensureElectronBundle(): ElectronHttpAppBundle | null {
+  if (electronBundle) return electronBundle;
+  const ep = resolveElectronEndpoint();
+  if (!ep) return null;
+  electronBundle = createElectronHttpAppBundle(ep);
+  // Install a minimal runtime so code paths checking window.runtime still work
+  // (context menu suppression, etc.) without Wails.
+  if (typeof window !== "undefined" && !window.runtime) {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    window.runtime = {
+      EventsOn(channel: string, callback: (...data: unknown[]) => void) {
+        if (!listeners.has(channel)) listeners.set(channel, new Set());
+        listeners.get(channel)!.add(callback);
+        return () => listeners.get(channel)?.delete(callback);
+      },
+      EventsOff() {},
+      EventsEmit(channel: string, ...data: unknown[]) {
+        for (const cb of listeners.get(channel) ?? []) cb(...data);
+      },
+    } as WailsRuntime;
+    // Fan host SSE into the same agent:event channel the desktop UI expects.
+    electronBundle.host.onEvent((e) => {
+      window.runtime?.EventsEmit?.(EVENT_CHANNEL, e);
+    });
+  }
+  return electronBundle;
+}
+
 function realApp(): AppBindings | undefined {
+  if (isElectronServeShell()) {
+    const bundle = ensureElectronBundle();
+    if (bundle) return bundle.app;
+  }
   return typeof window !== "undefined" ? window.go?.main?.App : undefined;
 }
 
@@ -655,6 +750,12 @@ function getMock(): AppBindings {
 
 // onEvent subscribes to the agent's typed event stream; returns an unsubscribe.
 export function onEvent(cb: (e: WireEvent) => void): () => void {
+  if (isElectronServeShell()) {
+    const bundle = ensureElectronBundle();
+    if (bundle) {
+      return bundle.host.onEvent((e) => cb(e as unknown as WireEvent));
+    }
+  }
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn(EVENT_CHANNEL, (payload) => cb(payload as WireEvent));
   }
@@ -846,6 +947,12 @@ export function onRuntimeRebuilt(cb: (tabId?: string, runtimeEpoch?: string) => 
 }
 
 export function onReady(cb: (tabId?: string) => void): () => void {
+  // Electron+serve: host is ready as soon as the endpoint is known.
+  if (isElectronServeShell()) {
+    ensureElectronBundle();
+    queueMicrotask(() => cb("serve-main"));
+    return () => {};
+  }
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn("agent:ready", (tabId?: unknown) => cb(typeof tabId === "string" ? tabId : undefined));
   }

--- a/desktop/frontend/src/lib/host/capabilities.ts
+++ b/desktop/frontend/src/lib/host/capabilities.ts
@@ -1,0 +1,82 @@
+/**
+ * Capability bitmap for host implementations.
+ * Keep in sync with electron-poc/lib/capabilities.mjs (PoC source of truth for gating).
+ */
+
+export const POC_CAPABILITIES = {
+  multiTab: true,
+  terminal: false,
+  remote: false,
+  bot: false,
+  heartbeat: false,
+  themePackStore: false,
+  productionUpdater: false,
+  steer: false,
+  submitDisplay: false,
+  historyPagination: false,
+  workspacePicker: "shell" as const,
+  singleSession: false,
+  httpSse: true,
+  serveBuiltinUi: true,
+  providerSetup: true,
+  toolApproval: true,
+  planMode: true,
+  goal: true,
+  rewind: true,
+  fork: true,
+  summarize: true,
+  sessions: true,
+  models: true,
+  todos: true,
+  skills: true,
+} as const;
+
+export const WAILS_DESKTOP_CAPABILITIES = {
+  multiTab: true,
+  terminal: true,
+  remote: true,
+  bot: true,
+  heartbeat: true,
+  themePackStore: true,
+  productionUpdater: true,
+  steer: true,
+  submitDisplay: true,
+  historyPagination: true,
+  workspacePicker: "native" as const,
+  singleSession: false,
+  httpSse: false,
+  serveBuiltinUi: false,
+  providerSetup: true,
+  toolApproval: true,
+  planMode: true,
+  goal: true,
+  rewind: true,
+  fork: true,
+  summarize: true,
+  sessions: true,
+  models: true,
+  todos: true,
+  skills: true,
+} as const;
+
+export function isCapabilityEnabled(
+  caps: Record<string, unknown>,
+  feature: string,
+): boolean {
+  const v = caps[feature];
+  if (typeof v === "boolean") return v;
+  if (typeof v === "string") return v.length > 0;
+  return false;
+}
+
+/** Features present on full Wails desktop but disabled in the PoC host. */
+export function unsupportedDesktopFeatures(
+  caps: Record<string, unknown> = POC_CAPABILITIES,
+): string[] {
+  const deferred: string[] = [];
+  for (const [key, full] of Object.entries(WAILS_DESKTOP_CAPABILITIES)) {
+    const poc = caps[key];
+    if (full === true && poc !== true) deferred.push(key);
+  }
+  return deferred;
+}

--- a/desktop/frontend/src/lib/host/electronAppBindings.ts
+++ b/desktop/frontend/src/lib/host/electronAppBindings.ts
@@ -1,0 +1,957 @@
+/**
+ * AppBindings for Electron + multi-tab reasonix serve (--multi-tab).
+ * ListTabs / *ForTab map to /tabs APIs. Terminal/remote remain stubs.
+ */
+import type { AppBindings } from "../bridge";
+import type {
+  BotSettingsView,
+  ContextInfo,
+  DesktopStartupSettingsView,
+  EffortInfo,
+  HistoryMessage,
+  HistoryPage,
+  Meta,
+  ProjectNode,
+  SettingsView,
+  TabMeta,
+  WorkspaceView,
+} from "../types";
+import { HttpSseHost } from "./httpSseHost";
+import { POC_CAPABILITIES } from "./capabilities";
+import { DEFAULT_STATUS_BAR_ITEMS } from "../statusBarItems";
+
+export type ElectronServeEndpoint = {
+  baseUrl: string;
+  token: string;
+  uiUrl?: string;
+  port?: number;
+  logFile?: string;
+  workspace?: string;
+};
+
+function historyToPage(raw: unknown): HistoryPage {
+  const messages = Array.isArray(raw) ? (raw as HistoryMessage[]) : [];
+  const userTurns = messages.filter((m) => m.role === "user").length;
+  return {
+    messages,
+    startTurn: 0,
+    endTurn: Math.max(0, userTurns),
+    totalTurns: Math.max(0, userTurns),
+    hasOlder: false,
+  };
+}
+
+function asTabMeta(raw: unknown): TabMeta | null {
+  if (!raw || typeof raw !== "object") return null;
+  const t = raw as TabMeta;
+  if (typeof t.id !== "string" || !t.id) return null;
+  return {
+    ...t,
+    tabType: t.tabType ?? "session",
+    scope: t.scope || "project",
+    workspaceRoot: t.workspaceRoot || t.cwd || "",
+    workspaceName: t.workspaceName || "workspace",
+    topicId: t.topicId || "main",
+    topicTitle: t.topicTitle || "Session",
+    label: t.label || "tab",
+    ready: t.ready !== false,
+    running: !!t.running,
+    mode: t.mode || "agent",
+    collaborationMode: t.collaborationMode || "default",
+    toolApprovalMode: t.toolApprovalMode || "ask",
+    tokenMode: t.tokenMode || "auto",
+    active: !!t.active,
+    cwd: t.cwd || t.workspaceRoot || "",
+  } as TabMeta;
+}
+
+function metaFromTab(t: TabMeta): Meta {
+  return {
+    label: t.label,
+    ready: t.ready,
+    eventChannel: "agent:event",
+    cwd: t.cwd || t.workspaceRoot,
+    workspaceRoot: t.workspaceRoot,
+    workspaceName: t.workspaceName,
+    workspacePath: t.workspacePath || t.workspaceRoot,
+    sessionPath: t.sessionPath,
+    collaborationMode: t.collaborationMode,
+    toolApprovalMode: t.toolApprovalMode,
+    tokenMode: t.tokenMode,
+    goal: t.goal || "",
+    goalStatus: t.goalStatus || "stopped",
+  };
+}
+
+/**
+ * Build a sidebar project tree from open multi-tab Controllers.
+ * Serve has no Wails ListProjectTree; without this the UI always shows
+ * "还没有项目" even after a successful PickWorkspace / open-project.
+ */
+function projectTreeFromTabs(tabs: TabMeta[]): ProjectNode[] {
+  type Acc = {
+    root: string;
+    label: string;
+    topics: Map<string, { topicId: string; title: string; sessionPath?: string; running: boolean; open: boolean }>;
+  };
+  const projects = new Map<string, Acc>();
+  for (const t of tabs) {
+    if (t.scope === "global") continue;
+    const root = (t.workspaceRoot || t.cwd || "").trim();
+    if (!root) continue;
+    let acc = projects.get(root);
+    if (!acc) {
+      acc = {
+        root,
+        label: t.workspaceName || root.split(/[/\\]/).filter(Boolean).pop() || root,
+        topics: new Map(),
+      };
+      projects.set(root, acc);
+    }
+    const topicId = (t.topicId || "main").trim() || "main";
+    const prev = acc.topics.get(topicId);
+    acc.topics.set(topicId, {
+      topicId,
+      title: (t.topicTitle || prev?.title || "Session").trim() || "Session",
+      sessionPath: t.sessionPath || prev?.sessionPath,
+      running: !!(t.running || prev?.running),
+      open: true,
+    });
+  }
+  const out: ProjectNode[] = [];
+  for (const acc of projects.values()) {
+    const children: ProjectNode[] = [];
+    for (const topic of acc.topics.values()) {
+      children.push({
+        key: `topic_${topic.topicId}`,
+        kind: "topic",
+        label: topic.title,
+        root: acc.root,
+        topicId: topic.topicId,
+        sessionPath: topic.sessionPath,
+        open: topic.open,
+        running: topic.running,
+      });
+    }
+    // Ensure at least one topic so the folder is expandable / clickable.
+    if (children.length === 0) {
+      children.push({
+        key: "topic_main",
+        kind: "topic",
+        label: "Session",
+        root: acc.root,
+        topicId: "main",
+        open: true,
+        running: false,
+      });
+    }
+    out.push({
+      key: `project_${acc.root}`,
+      kind: "project",
+      label: acc.label,
+      root: acc.root,
+      open: true,
+      children,
+    });
+  }
+  // Stable order by label then root.
+  out.sort((a, b) => {
+    const la = (a.label || a.root || "").toLowerCase();
+    const lb = (b.label || b.root || "").toLowerCase();
+    if (la !== lb) return la < lb ? -1 : 1;
+    return (a.root || "").localeCompare(b.root || "");
+  });
+  return out;
+}
+
+function contextFromRaw(raw: unknown): ContextInfo {
+  if (!raw || typeof raw !== "object") {
+    return { used: 0, window: 0, sessionTokens: 0 } as ContextInfo;
+  }
+  const o = raw as Record<string, number>;
+  return {
+    used: o.used ?? 0,
+    window: o.window ?? 0,
+    sessionTokens: o.sessionTokens ?? o.used ?? 0,
+  } as ContextInfo;
+}
+
+/** Full bot snapshot so sidebar/IM helpers never hit undefined.trim / undefined.length. */
+function emptyBotSettings(): BotSettingsView {
+  return {
+    enabled: false,
+    model: "",
+    toolApprovalMode: "ask",
+    maxSteps: 0,
+    debounceMs: 0,
+    queueMode: "",
+    queueCap: 0,
+    queueDrop: "",
+    ignoreSelfMessages: true,
+    selfUserIds: { qq: [], feishu: [], weixin: [] },
+    control: {
+      enabled: false,
+      addr: "127.0.0.1:0",
+      tokenEnv: "REASONIX_BOT_CONTROL_TOKEN",
+    },
+    pairing: {
+      enabled: false,
+      requestTtlMinutes: 60,
+      maxPendingPerPlatform: 3,
+    },
+    routes: [],
+    allowlist: {
+      enabled: false,
+      allowAll: false,
+      qqUsers: [],
+      feishuUsers: [],
+      weixinUsers: [],
+      qqApprovers: [],
+      feishuApprovers: [],
+      weixinApprovers: [],
+      qqAdmins: [],
+      feishuAdmins: [],
+      weixinAdmins: [],
+      qqGroups: [],
+      feishuGroups: [],
+      weixinGroups: [],
+    },
+    qq: {
+      enabled: false,
+      appId: "",
+      appSecretEnv: "QQ_BOT_APP_SECRET",
+      secretSet: false,
+      sandbox: false,
+      model: "",
+      toolApprovalMode: "ask",
+      workspaceRoot: "",
+      access: {
+        enabled: false,
+        allowAll: false,
+        pairingEnabled: false,
+        users: [],
+        groups: [],
+        approvers: [],
+        admins: [],
+      },
+    },
+    feishu: {
+      enabled: false,
+      domain: "feishu",
+      appId: "",
+      appSecretEnv: "FEISHU_BOT_APP_SECRET",
+      secretSet: false,
+      verificationToken: "",
+      mode: "webhook",
+      webhookPort: 8080,
+      requireMention: true,
+    },
+    weixin: {
+      enabled: false,
+      accountId: "",
+      tokenEnv: "WEIXIN_BOT_TOKEN",
+      tokenSet: false,
+      apiBase: "",
+    },
+    connections: [],
+  };
+}
+
+function emptyDesktopStartupSettings(): DesktopStartupSettingsView {
+  return {
+    bot: emptyBotSettings(),
+    desktopLanguage: "",
+    desktopLayoutStyle: "classic",
+    desktopTheme: "auto",
+    desktopThemeStyle: "",
+    desktopTerminalTheme: "auto",
+    displayMode: "standard",
+    statusBarStyle: "icon",
+    statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
+    checkUpdates: false,
+    updateChannel: "stable",
+    conversationWidth: "standard",
+    configWarnings: [],
+  };
+}
+
+/**
+ * Full SettingsView stub for Electron PoC (settings panel may open even when
+ * serve has no Wails settings surface). Every array field is a real array.
+ */
+function emptySettings(): SettingsView {
+  const bot = emptyBotSettings();
+  return {
+    defaultModel: "",
+    plannerModel: "",
+    subagentModel: "",
+    subagentEffort: "",
+    autoPlan: "off",
+    providers: [],
+    officialProviders: [],
+    providerPresets: [],
+    permissions: { mode: "ask", allow: [], ask: [], deny: [] },
+    sandbox: {
+      bash: "workspace",
+      network: true,
+      workspaceRoot: "",
+      allowWrite: [],
+      effectiveWorkspaceRoot: "",
+      effectiveWriteRoots: [],
+      shell: "auto",
+      effectiveShell: "",
+    },
+    network: {
+      proxyMode: "auto",
+      proxyUrl: "",
+      noProxy: "",
+      proxy: { type: "", server: "", port: 0, username: "", password: "" },
+    },
+    agent: {
+      temperature: 0,
+      maxSteps: 0,
+      plannerMaxSteps: 0,
+      maxSubagentDepth: 2,
+      maxSubagentConcurrency: 1,
+      maxParallelWriters: 1,
+      systemPrompt: "",
+      coldResumePrune: false,
+      reasoningLanguage: "auto",
+      compactRatio: 0.8,
+    },
+    bot,
+    desktopLanguage: "",
+    desktopLayoutStyle: "classic",
+    desktopTheme: "auto",
+    desktopThemeStyle: "",
+    desktopTerminalTheme: "auto",
+    closeBehavior: "background",
+    displayMode: "standard",
+    statusBarStyle: "icon",
+    statusBarItems: [...DEFAULT_STATUS_BAR_ITEMS],
+    defaultToolApprovalMode: "ask",
+    checkUpdates: false,
+    updateChannel: "stable",
+    telemetry: false,
+    metrics: false,
+    configPath: "",
+    providerKinds: [],
+    autoApproveTools: false,
+    bypass: false,
+    conversationWidth: "standard",
+  };
+}
+
+function emptyBotRuntimeStatus() {
+  return {
+    running: false,
+    status: "stopped",
+    message: "",
+    connections: 0,
+    startedAt: "",
+  };
+}
+
+const ARRAY_METHOD_NAMES = new Set([
+  "BackgroundRuntimes",
+  "RemoteHosts",
+  "RemoteConnectionStatuses",
+  "ListProjectTree",
+  "ListTabs",
+  "ListSessions",
+  "ListSessionsForTab",
+  "ListTrashedSessions",
+  "ListSkills",
+  "ListWorkspaces",
+  "ExtensionActions",
+  "Checkpoints",
+  "CheckpointsForTab",
+  "Jobs",
+  "JobsForTab",
+  "Models",
+  "History",
+  "HistoryForTab",
+  "HistoryCheckpointTurnsForTab",
+]);
+
+function looksLikeArrayMethod(key: string): boolean {
+  if (ARRAY_METHOD_NAMES.has(key)) return true;
+  if (key.startsWith("List")) return true;
+  if (
+    key.endsWith("s") &&
+    (key.includes("Host") ||
+      key.includes("Runtime") ||
+      key.includes("Status") ||
+      key.includes("Tree") ||
+      key.includes("Topic") ||
+      key.includes("Session") ||
+      key.includes("Skill") ||
+      key.includes("Job") ||
+      key.includes("Warning") ||
+      key.includes("Item") ||
+      key.includes("Provider") ||
+      key.includes("Model") ||
+      key.includes("Checkpoint") ||
+      key.includes("Action"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Heuristic: methods that App always treats as arrays must never return undefined. */
+function defaultForUnknownMethod(key: string): unknown {
+  if (looksLikeArrayMethod(key)) return [];
+  if (key.startsWith("Is") || key.startsWith("Has") || key.startsWith("Can") || key === "NeedsOnboarding") {
+    return false;
+  }
+  if (key.includes("Count")) return 0;
+  if (key === "DesktopStartupSettings" || key === "GetDesktopStartupSettings") {
+    return emptyDesktopStartupSettings();
+  }
+  if (key === "Settings" || key === "GetSettings") {
+    return emptySettings();
+  }
+  if (key === "BotRuntimeStatus") {
+    return emptyBotRuntimeStatus();
+  }
+  if (key.startsWith("Get") || key.endsWith("View") || key.includes("Status")) {
+    return null;
+  }
+  return undefined;
+}
+
+/**
+ * Build AppBindings that drive multi-tab HttpSseHost.
+ */
+export function makeElectronHttpApp(
+  host: HttpSseHost,
+  endpoint: ElectronServeEndpoint,
+): AppBindings {
+  let multiTabAvailable: boolean | null = null;
+
+  async function detectMultiTab(): Promise<boolean> {
+    if (multiTabAvailable != null) return multiTabAvailable;
+    try {
+      await host.listTabs();
+      multiTabAvailable = true;
+    } catch {
+      multiTabAvailable = false;
+    }
+    return multiTabAvailable;
+  }
+
+  async function listTabMetas(): Promise<TabMeta[]> {
+    if (!(await detectMultiTab())) return [];
+    const raw = await host.listTabs();
+    if (!Array.isArray(raw)) return [];
+    return raw.map(asTabMeta).filter((t): t is TabMeta => t != null);
+  }
+
+  async function activeTabId(): Promise<string | undefined> {
+    const tabs = await listTabMetas();
+    return tabs.find((t) => t.active)?.id ?? tabs[0]?.id;
+  }
+
+  async function resolveTabId(tabID?: unknown): Promise<string> {
+    if (typeof tabID === "string" && tabID) return tabID;
+    const id = await activeTabId();
+    if (!id) throw new Error("no open tab");
+    return id;
+  }
+
+  async function getTab(tabID?: unknown): Promise<TabMeta> {
+    const id = await resolveTabId(tabID);
+    const tabs = await listTabMetas();
+    const found = tabs.find((t) => t.id === id);
+    if (!found) throw new Error(`tab not found: ${id}`);
+    return found;
+  }
+
+  const handlers: Record<string, (...args: unknown[]) => unknown> = {
+    Platform: async () => {
+      const p = navigator.platform || "";
+      if (/Win/i.test(p)) return "windows";
+      if (/Mac/i.test(p)) return "darwin";
+      return "linux";
+    },
+    MinimiseMainWindow: async () => {},
+    ToggleMaximiseMainWindow: async () => {},
+    IsMainWindowMaximised: async () => false,
+    CloseMainWindow: async () => {
+      window.close();
+    },
+
+    ListTabs: async () => listTabMetas(),
+    SetActiveTab: async (id: unknown) => {
+      await host.activateTab(String(id));
+    },
+    EnsureBlankTab: async (scope: unknown, workspaceRoot: unknown) => {
+      const root = String(workspaceRoot || endpoint.workspace || "");
+      const meta = await host.createTab({
+        scope: String(scope || "project"),
+        workspaceRoot: root,
+      });
+      const t = asTabMeta(meta);
+      if (!t) throw new Error("create tab failed");
+      return t;
+    },
+    EnsureBlankSurface: async (scope: unknown, workspaceRoot: unknown) => {
+      return handlers.EnsureBlankTab(scope, workspaceRoot);
+    },
+    OpenProjectTab: async (workspaceRoot: unknown, topicId?: unknown) => {
+      const root = String(workspaceRoot || "");
+      if (!root) throw new Error("workspaceRoot required");
+      // Prefer an already-open tab for this workspace so UI can switch without
+      // treating every sidebar click as a brand-new surface.
+      const existing = (await listTabMetas()).find(
+        (t) => t.scope === "project" && t.workspaceRoot === root,
+      );
+      if (existing) {
+        await host.activateTab(existing.id);
+        const refreshed = (await listTabMetas()).find((t) => t.id === existing.id);
+        return refreshed ?? existing;
+      }
+      const meta = await host.openProject(root, String(topicId || "main"));
+      const t = asTabMeta(meta);
+      if (!t) throw new Error("open project failed");
+      return t;
+    },
+    OpenGlobalTab: async () => {
+      // Global scope: create tab with empty root if server allows; else reuse active.
+      try {
+        const meta = await host.createTab({ scope: "global", workspaceRoot: endpoint.workspace || "." });
+        const t = asTabMeta(meta);
+        if (t) return t;
+      } catch {
+        /* fallthrough */
+      }
+      return getTab();
+    },
+    OpenTopicSession: async (_scope: unknown, workspaceRoot: unknown, topicId: unknown) => {
+      // Serve has no separate topic-session open; map to open-project / activate.
+      const root = String(workspaceRoot || "");
+      if (root) return handlers.OpenProjectTab(root, topicId);
+      return getTab();
+    },
+    ActivateTopic: async (_scope: unknown, workspaceRoot: unknown, topicId: unknown, _sessionPath: unknown) => {
+      const root = String(workspaceRoot || endpoint.workspace || "");
+      return handlers.OpenProjectTab(root, topicId);
+    },
+    CloseTab: async (id: unknown) => {
+      await host.closeTab(String(id));
+    },
+    CloseTabWithPolicy: async (id: unknown) => {
+      await host.closeTab(String(id));
+    },
+    ReorderTabs: async () => {
+      // Tab order is UI-local for serve multi-tab; no-op on host is fine.
+    },
+    CreateTopic: async (scope: unknown, workspaceRoot: unknown, title: unknown) => {
+      const meta = await host.createTopic(String(scope || "project"), String(workspaceRoot || ""), String(title || ""));
+      if (!meta || typeof meta !== "object") throw new Error("create topic failed");
+      return meta;
+    },
+    RenameTopic: async (topicId: unknown, title: unknown) => {
+      // Bridge only passes topicId+title; serve resolves workspace ownership.
+      await host.renameTopic("", String(topicId || ""), String(title || ""));
+    },
+    DeleteTopic: async (topicId: unknown) => {
+      await host.deleteTopic("", String(topicId || ""));
+    },
+    TrashTopic: async (topicId: unknown) => {
+      await host.trashTopic("", String(topicId || ""));
+    },
+    RenameProject: async (workspaceRoot: unknown, title: unknown) => {
+      await host.renameProject(String(workspaceRoot || ""), String(title || ""));
+    },
+    ReorderProjects: async (workspaceRoots: unknown) => {
+      const roots = Array.isArray(workspaceRoots) ? workspaceRoots.map(String) : [];
+      await host.reorderProjects(roots);
+    },
+
+    Submit: async (input: unknown) => {
+      const id = await activeTabId();
+      await host.submitPreferTab(id, String(input ?? ""));
+    },
+    SubmitToTab: async (tabID: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    SubmitDisplay: async (_display: unknown, input: unknown) => {
+      const id = await activeTabId();
+      await host.submitPreferTab(id, String(input ?? ""));
+    },
+    SubmitDisplayToTab: async (tabID: unknown, _display: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    SubmitDeliveryRecoveryToTab: async (tabID: unknown, _display: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    SubmitInvocationsToTab: async (tabID: unknown, _display: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    SubmitInitialGoalToTab: async (tabID: unknown, _display: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    SubmitEditedDisplayToTab: async (tabID: unknown, _display: unknown, input: unknown) => {
+      await host.submitPreferTab(String(tabID), String(input ?? ""));
+    },
+    Cancel: async () => {
+      const id = await activeTabId();
+      if (id) await host.cancelTab(id).catch(() => host.cancel());
+      else await host.cancel();
+    },
+    CancelTab: async (tabID: unknown) => {
+      await host.cancelTab(String(tabID)).catch(() => host.cancel());
+    },
+    Approve: async (id: unknown, allow: unknown, session: unknown, persist: unknown) => {
+      const tabId = await activeTabId();
+      if (tabId) await host.approveTab(tabId, String(id), !!allow, !!session, !!persist);
+      else await host.approve(String(id), !!allow, !!session, !!persist);
+    },
+    ApproveTab: async (tabID: unknown, id: unknown, allow: unknown, session: unknown, persist: unknown) => {
+      await host.approveTab(String(tabID), String(id), !!allow, !!session, !!persist);
+    },
+    AnswerQuestion: async (id: unknown, answers: unknown) => {
+      const tabId = await activeTabId();
+      if (tabId) await host.answerTab(tabId, String(id), answers);
+      else await host.answer(String(id), answers);
+    },
+    AnswerQuestionForTab: async (tabID: unknown, id: unknown, answers: unknown) => {
+      await host.answerTab(String(tabID), String(id), answers);
+    },
+    ReplayPendingPrompts: async () => {
+      // SSE attach triggers ReplayPendingPrompts server-side for multi-tab.
+    },
+    SetPlanMode: async (on: unknown) => {
+      const id = await activeTabId();
+      if (id) await host.setPlanModeTab(id, !!on);
+      else await host.setPlanMode(!!on);
+    },
+    SetMode: async () => {},
+    SetModeForTab: async () => [],
+    SetAutoApproveTools: async (on: unknown) => {
+      await host.setAutoApproveTools(!!on);
+    },
+    SetCollaborationMode: async () => {},
+    SetCollaborationModeForTab: async () => {},
+    SetToolApprovalMode: async (mode: unknown) => {
+      const id = await activeTabId();
+      if (id) await host.setToolApprovalModeTab(id, String(mode ?? "ask"));
+      else await host.setToolApprovalMode(String(mode ?? "ask"));
+    },
+    SetToolApprovalModeForTab: async (tabID: unknown, mode: unknown) => {
+      await host.setToolApprovalModeTab(String(tabID), String(mode ?? "ask"));
+      return [];
+    },
+    SetComposerProfileForTab: async () => [],
+    SetGoal: async (goal: unknown) => {
+      const id = await activeTabId();
+      if (id) await host.setGoalTab(id, String(goal ?? ""));
+      else await host.setGoal(String(goal ?? ""));
+    },
+    SetGoalForTab: async (tabID: unknown, goal: unknown) => {
+      await host.setGoalTab(String(tabID), String(goal ?? ""));
+    },
+    ClearGoal: async () => {
+      const id = await activeTabId();
+      if (id) await host.setGoalTab(id, "");
+      else await host.clearGoal();
+    },
+    ClearGoalForTab: async (tabID: unknown) => {
+      await host.setGoalTab(String(tabID), "");
+    },
+    ResumeGoalForTab: async () => false,
+    PauseGoalForTab: async () => false,
+    Compact: async () => {
+      const id = await activeTabId();
+      if (id) await host.compactTab(id);
+      else await host.compact();
+    },
+    CompactForTab: async (tabID: unknown) => {
+      await host.compactTab(String(tabID));
+    },
+    NewSession: async () => {
+      const id = await activeTabId();
+      if (id) await host.newSessionTab(id);
+      else await host.newSession();
+    },
+    NewSessionForTab: async (tabID: unknown) => {
+      await host.newSessionTab(String(tabID));
+    },
+    ClearSession: async () => handlers.NewSession(),
+    ClearSessionForTab: async (tabID: unknown) => handlers.NewSessionForTab(tabID),
+    History: async () => {
+      const id = await activeTabId();
+      const raw = id ? await host.historyTab(id) : await host.history();
+      return Array.isArray(raw) ? raw : [];
+    },
+    HistoryForTab: async (tabID: unknown) => {
+      const raw = await host.historyTab(String(tabID));
+      return Array.isArray(raw) ? raw : [];
+    },
+    HistoryPage: async () => historyToPage(await handlers.History()),
+    HistoryPageForTab: async (tabID: unknown) => historyToPage(await handlers.HistoryForTab(tabID)),
+    HistoryCheckpointTurnsForTab: async () => [],
+    Checkpoints: async () => {
+      try {
+        const cps = await host.checkpoints();
+        return Array.isArray(cps) ? cps : [];
+      } catch {
+        return [];
+      }
+    },
+    CheckpointsForTab: async () => handlers.Checkpoints(),
+    Rewind: async (turn: unknown, scope: unknown) => {
+      await host.rewind(Number(turn) || 0, String(scope || "both"));
+    },
+    RewindForTab: async (_tab: unknown, turn: unknown, scope: unknown) => {
+      await host.rewind(Number(turn) || 0, String(scope || "both"));
+    },
+    Fork: async (turn: unknown) => {
+      await host.fork(Number(turn) || 0);
+      return getTab();
+    },
+    ForkForTab: async (tabID: unknown, turn: unknown) => {
+      await host.fork(Number(turn) || 0);
+      return getTab(tabID);
+    },
+    SummarizeFrom: async (turn: unknown) => {
+      await host.summarize(Number(turn) || 0);
+    },
+    SummarizeFromForTab: async (_tab: unknown, turn: unknown) => {
+      await host.summarize(Number(turn) || 0);
+    },
+    SummarizeUpTo: async (turn: unknown) => {
+      await host.summarize(Number(turn) || 0);
+    },
+    SummarizeUpToForTab: async (_tab: unknown, turn: unknown) => {
+      await host.summarize(Number(turn) || 0);
+    },
+    ListSessions: async () => {
+      try {
+        const s = await host.sessions();
+        return Array.isArray(s) ? s : [];
+      } catch {
+        return [];
+      }
+    },
+    ListSessionsForTab: async () => handlers.ListSessions(),
+    ListTrashedSessions: async () => [],
+    ResumeSession: async (path: unknown) => {
+      await host.resume(String(path));
+      return handlers.History();
+    },
+    ResumeSessionForTab: async (_tab: unknown, path: unknown) => {
+      await host.resume(String(path));
+      return handlers.HistoryForTab(_tab);
+    },
+    ResumeSessionPage: async (path: unknown) => {
+      await host.resume(String(path));
+      return historyToPage(await handlers.History());
+    },
+    ResumeSessionPageForTab: async (tabID: unknown, path: unknown) => {
+      await host.resume(String(path));
+      return historyToPage(await handlers.HistoryForTab(tabID));
+    },
+    DeleteSession: async (path: unknown) => {
+      await host.deleteSession(String(path));
+    },
+    ListWorkspaces: async (): Promise<WorkspaceView[]> => {
+      const tabs = await listTabMetas();
+      const seen = new Map<string, WorkspaceView>();
+      for (const t of tabs) {
+        const p = t.workspaceRoot;
+        if (!p || seen.has(p)) continue;
+        seen.set(p, {
+          path: p,
+          name: t.workspaceName || p.split(/[/\\]/).filter(Boolean).pop() || p,
+          current: !!t.active,
+        });
+      }
+      return Array.from(seen.values());
+    },
+    PickWorkspace: async () => {
+      const poc = (
+        window as unknown as {
+          reasonixPoc?: { pickWorkspace: () => Promise<{ workspace?: string } | null> };
+        }
+      ).reasonixPoc;
+      if (!poc?.pickWorkspace) {
+        throw new Error("Workspace picker is unavailable in this shell");
+      }
+      const res = await poc.pickWorkspace();
+      const path = (res?.workspace || "").trim();
+      if (!path) return ""; // user cancelled
+      // Must open a Controller tab; otherwise the sidebar refresh still has no project.
+      const meta = await host.openProject(path);
+      if (!asTabMeta(meta)) {
+        throw new Error(`Failed to open project: ${path}`);
+      }
+      return path;
+    },
+    SwitchWorkspace: async (path: unknown) => {
+      const p = String(path ?? "").trim();
+      if (!p) return "";
+      const meta = await host.openProject(p);
+      if (!asTabMeta(meta)) {
+        throw new Error(`Failed to switch workspace: ${p}`);
+      }
+      return p;
+    },
+    Meta: async () => metaFromTab(await getTab()),
+    MetaForTab: async (tabID: unknown) => metaFromTab(await getTab(tabID)),
+    ContextUsage: async () => {
+      const id = await activeTabId();
+      if (!id) return { used: 0, window: 0, sessionTokens: 0 } as ContextInfo;
+      return contextFromRaw(await host.contextTab(id).catch(() => host.context()));
+    },
+    ContextUsageForTab: async (tabID: unknown) => {
+      return contextFromRaw(await host.contextTab(String(tabID)));
+    },
+    ContextPanel: async () => ({}),
+    ContextPanelForTab: async () => ({}),
+    Effort: async (): Promise<EffortInfo> => ({ level: "", options: [] } as unknown as EffortInfo),
+    EffortForTab: async (): Promise<EffortInfo> => ({ level: "", options: [] } as unknown as EffortInfo),
+    Jobs: async () => {
+      try {
+        const st = (await host.status()) as { jobs?: unknown };
+        return Array.isArray(st?.jobs) ? st.jobs : [];
+      } catch {
+        return [];
+      }
+    },
+    JobsForTab: async () => handlers.Jobs(),
+    Balance: async () => {
+      try {
+        const st = (await host.status()) as { balance?: unknown };
+        return st?.balance ?? null;
+      } catch {
+        return null;
+      }
+    },
+    BalanceForTab: async () => handlers.Balance(),
+    Models: async () => {
+      try {
+        const m = await host.models();
+        return Array.isArray(m) ? m : [];
+      } catch {
+        return [];
+      }
+    },
+    GetSkillsSettings: async () => ({ skills: [], roots: [] }),
+    ListSkills: async () => {
+      try {
+        const s = await host.skills();
+        return Array.isArray(s) ? s : [];
+      } catch {
+        return [];
+      }
+    },
+    ListProjectTree: async () => {
+      try {
+        const tree = await host.projectTree();
+        if (Array.isArray(tree) && tree.length > 0) return tree;
+      } catch {
+        /* fall back to open-tabs tree */
+      }
+      return projectTreeFromTabs(await listTabMetas());
+    },
+    BackgroundRuntimes: async () => [],
+    RemoteHosts: async () => [],
+    RemoteConnectionStatuses: async () => [],
+    ExtensionActions: async () => [],
+    ExternalOpeners: async () => ({ openers: [], preferred: "" }),
+    NeedsOnboarding: async () => false,
+    BotRuntimeStatus: async () => emptyBotRuntimeStatus(),
+    DesktopStartupSettings: async () => {
+      try {
+        const raw = await host.desktopStartupSettings();
+        if (raw && typeof raw === "object") {
+          return { ...emptyDesktopStartupSettings(), ...(raw as object) };
+        }
+      } catch {
+        /* fall through */
+      }
+      return emptyDesktopStartupSettings();
+    },
+    GetDesktopStartupSettings: async () => handlers.DesktopStartupSettings(),
+    Settings: async () => {
+      try {
+        const raw = await host.desktopSettings();
+        if (raw && typeof raw === "object") {
+          return { ...emptySettings(), ...(raw as object) };
+        }
+      } catch {
+        /* fall through */
+      }
+      return emptySettings();
+    },
+    GetSettings: async () => handlers.Settings(),
+    ReloadUserConfig: async () => handlers.Settings(),
+    MigrateDesktopPreferences: async () => {},
+    SetTrayLocale: async () => {},
+    GetActiveThemePack: async () => null,
+    RemoveWorkspace: async (path: unknown) => {
+      await host.removeProject(String(path || ""));
+    },
+    ReloadExtensions: async () => {
+      await host.reloadExtensions().catch(() => {});
+    },
+    ResolvePlanDecision: async () => {},
+    ResolvePlanDecisionTab: async () => {},
+    ResolveRecovery: async () => {},
+    ResolveRecoveryTab: async () => {},
+    ActiveWorkForTab: async () => ({ running: false, pendingPrompt: false, jobs: [] }),
+    WorkspaceConflictForTab: async () => null,
+    RunShell: async () => {
+      throw new Error("Shell is unavailable over HTTP serve (Electron multi-tab)");
+    },
+    RunShellForTab: async () => {
+      throw new Error("Shell is unavailable over HTTP serve (Electron multi-tab)");
+    },
+    Steer: async () => {
+      throw new Error("Steer is not exposed on reasonix serve");
+    },
+    SteerForTab: async () => {
+      throw new Error("Steer is not exposed on reasonix serve");
+    },
+  };
+
+  (handlers as Record<string, unknown>).__pocCapabilities = {
+    ...POC_CAPABILITIES,
+    multiTab: true,
+    singleSession: false,
+  };
+  (handlers as Record<string, unknown>).__httpHost = host;
+
+  return new Proxy({} as AppBindings, {
+    get(_t, prop) {
+      const key = String(prop);
+      if (key in handlers) return handlers[key];
+      return async (..._args: unknown[]) => defaultForUnknownMethod(key);
+    },
+  });
+}
+
+export type ElectronHttpAppBundle = {
+  app: AppBindings;
+  host: HttpSseHost;
+  endpoint: ElectronServeEndpoint;
+};
+
+export function createElectronHttpAppBundle(endpoint: ElectronServeEndpoint): ElectronHttpAppBundle {
+  const host = new HttpSseHost({
+    baseUrl: endpoint.baseUrl,
+    token: endpoint.token,
+    capabilities: { ...POC_CAPABILITIES, multiTab: true, singleSession: false },
+  });
+  return {
+    app: makeElectronHttpApp(host, endpoint),
+    host,
+    endpoint,
+  };
+}
+
+// Deprecated alias kept so older imports of SERVE_TAB_ID still typecheck if any remain.
+export const SERVE_TAB_ID = "";

--- a/desktop/frontend/src/lib/host/httpSseHost.ts
+++ b/desktop/frontend/src/lib/host/httpSseHost.ts
@@ -1,0 +1,420 @@
+import type { ReasonixHost, HostCapabilities } from "./types";
+import { POC_CAPABILITIES } from "./capabilities";
+import { SERVE_ROUTES, tabPath } from "./routes";
+import { mapServeEventToWire, parseSseChunk } from "./mapEvent";
+
+/**
+ * HTTP JSON + SSE host talking to reasonix serve.
+ * Mirrors electron-poc/lib/httpSseHost.mjs (keep behavior aligned).
+ */
+export class HttpSseHost implements ReasonixHost {
+  private baseUrl: string;
+  private token: string;
+  private fetchImpl: typeof fetch;
+  private capabilities: HostCapabilities;
+  private abort: AbortController | null = null;
+  private handlers = new Set<(e: Record<string, unknown>) => void>();
+  private sseTask: Promise<void> | null = null;
+
+  constructor(opts: {
+    baseUrl: string;
+    token: string;
+    fetchImpl?: typeof fetch;
+    capabilities?: HostCapabilities;
+  }) {
+    if (!opts.baseUrl) throw new Error("baseUrl required");
+    if (!opts.token) throw new Error("token required");
+    this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.token = opts.token;
+    this.fetchImpl = opts.fetchImpl ?? fetch.bind(globalThis);
+    this.capabilities = opts.capabilities ?? POC_CAPABILITIES;
+  }
+
+  getCapabilities(): HostCapabilities {
+    return this.capabilities;
+  }
+
+  private async request(path: string, init: RequestInit & { json?: unknown } = {}): Promise<Response> {
+    const url = new URL(path, this.baseUrl + "/");
+    // Token query is a fallback for non-browser clients. Electron shell proxies
+    // should auth via cookie they inject; attaching ?token= can trigger serve's
+    // 302 strip-token redirect which becomes 401 when Cookie is a forbidden
+    // header in Chromium and a stale cookie is present on the shell origin.
+    if (!url.searchParams.has("token")) url.searchParams.set("token", this.token);
+    const headers = new Headers(init.headers ?? {});
+    // Best-effort: Node hosts honor this; Chromium silently drops Cookie.
+    headers.set("Cookie", `reasonix_token=${this.token}`);
+    let body = init.body;
+    if (init.json !== undefined) {
+      headers.set("Content-Type", "application/json");
+      body = JSON.stringify(init.json);
+    }
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && !headers.get("Content-Type")?.includes("application/json")) {
+      headers.set("Content-Type", "application/json");
+      if (body === undefined) body = "{}";
+    }
+    // Do not follow auth redirects (302 strip ?token= → unauthenticated retry).
+    return this.fetchImpl(url.toString(), {
+      ...init,
+      method,
+      headers,
+      body,
+      redirect: init.redirect ?? "manual",
+    });
+  }
+
+  private async jsonOrEmpty(res: Response): Promise<unknown> {
+    if (res.status === 204 || res.status === 202) return { ok: true, status: res.status };
+    const text = await res.text();
+    if (!res.ok) {
+      const err = new Error(text || res.statusText || `HTTP ${res.status}`) as Error & {
+        status?: number;
+        body?: string;
+      };
+      err.status = res.status;
+      err.body = text;
+      throw err;
+    }
+    if (!text) return { ok: true, status: res.status };
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { ok: true, status: res.status, raw: text };
+    }
+  }
+
+  status() {
+    return this.request(SERVE_ROUTES.status.path).then((r) => this.jsonOrEmpty(r));
+  }
+  history() {
+    return this.request(SERVE_ROUTES.history.path).then((r) => this.jsonOrEmpty(r));
+  }
+  context() {
+    return this.request(SERVE_ROUTES.context.path).then((r) => this.jsonOrEmpty(r));
+  }
+  sessions() {
+    return this.request(SERVE_ROUTES.sessions.path).then((r) => this.jsonOrEmpty(r));
+  }
+  skills() {
+    return this.request(SERVE_ROUTES.skills.path).then((r) => this.jsonOrEmpty(r));
+  }
+  todos() {
+    return this.request(SERVE_ROUTES.todos.path).then((r) => this.jsonOrEmpty(r));
+  }
+  checkpoints() {
+    return this.request(SERVE_ROUTES.checkpoints.path).then((r) => this.jsonOrEmpty(r));
+  }
+  models() {
+    return this.request(SERVE_ROUTES.models.path).then((r) => this.jsonOrEmpty(r));
+  }
+  providerSetup() {
+    return this.request(SERVE_ROUTES.providerSetup.path).then((r) => this.jsonOrEmpty(r));
+  }
+
+  submit(input: string, format?: string) {
+    const json: Record<string, string> = { input };
+    if (format) json.format = format;
+    return this.request(SERVE_ROUTES.submit.path, { method: "POST", json }).then((r) => this.jsonOrEmpty(r));
+  }
+  cancel() {
+    return this.request(SERVE_ROUTES.cancel.path, { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  approve(id: string, allow: boolean, session = false, persist = false) {
+    return this.request(SERVE_ROUTES.approve.path, {
+      method: "POST",
+      json: { id, allow, session, persist },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  answer(id: string, answers: unknown) {
+    return this.request(SERVE_ROUTES.answer.path, {
+      method: "POST",
+      json: { id, answers },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  setPlanMode(on: boolean) {
+    return this.request(SERVE_ROUTES.plan.path, { method: "POST", json: { on: !!on } }).then((r) =>
+      this.jsonOrEmpty(r),
+    );
+  }
+  setToolApprovalMode(mode: string) {
+    return this.request(SERVE_ROUTES.toolApprovalMode.path, {
+      method: "POST",
+      json: { mode },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  setAutoApproveTools(on: boolean) {
+    return this.request(SERVE_ROUTES.autoApproveTools.path, {
+      method: "POST",
+      json: { on: !!on },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  compact() {
+    return this.request(SERVE_ROUTES.compact.path, { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  newSession() {
+    return this.request(SERVE_ROUTES.newSession.path, { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  rewind(turn: number, scope: string) {
+    return this.request(SERVE_ROUTES.rewind.path, {
+      method: "POST",
+      json: { turn, scope },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  fork(turn: number) {
+    return this.request(SERVE_ROUTES.fork.path, { method: "POST", json: { turn } }).then((r) => this.jsonOrEmpty(r));
+  }
+  summarize(turn: number) {
+    return this.request(SERVE_ROUTES.summarize.path, {
+      method: "POST",
+      json: { turn },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  setGoal(goal: string) {
+    return this.request(SERVE_ROUTES.goal.path, {
+      method: "POST",
+      json: { goal: goal ?? "" },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  clearGoal() {
+    return this.setGoal("");
+  }
+  resume(path: string) {
+    return this.request(SERVE_ROUTES.resume.path, {
+      method: "POST",
+      json: { path },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  deleteSession(path: string) {
+    return this.request(SERVE_ROUTES.deleteSession.path, {
+      method: "POST",
+      json: { path },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  reloadExtensions() {
+    return this.request(SERVE_ROUTES.reloadExtensions.path, {
+      method: "POST",
+      json: {},
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+
+  // ── Multi-tab (--multi-tab) ────────────────────────────────
+
+  listTabs() {
+    return this.request(SERVE_ROUTES.tabs.path).then((r) => this.jsonOrEmpty(r));
+  }
+  createTab(body: {
+    workspaceRoot?: string;
+    scope?: string;
+    topicId?: string;
+    topicTitle?: string;
+    sessionPath?: string;
+    label?: string;
+  }) {
+    return this.request(SERVE_ROUTES.tabsCreate.path, { method: "POST", json: body ?? {} }).then((r) =>
+      this.jsonOrEmpty(r),
+    );
+  }
+  openProject(workspaceRoot: string, topicId?: string, topicTitle?: string) {
+    return this.request(SERVE_ROUTES.tabsOpenProject.path, {
+      method: "POST",
+      json: { workspaceRoot, topicId, topicTitle },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+
+  // ── Desktop sidebar / settings ─────────────────────────────
+  projectTree() {
+    return this.request(SERVE_ROUTES.desktopProjectTree.path).then((r) => this.jsonOrEmpty(r));
+  }
+  createTopic(scope: string, workspaceRoot: string, title: string) {
+    return this.request(SERVE_ROUTES.desktopCreateTopic.path, {
+      method: "POST",
+      json: { scope, workspaceRoot, title },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  renameTopic(workspaceRoot: string, topicId: string, title: string) {
+    return this.request(SERVE_ROUTES.desktopRenameTopic.path, {
+      method: "POST",
+      json: { workspaceRoot, topicId, title },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  deleteTopic(workspaceRoot: string, topicId: string) {
+    return this.request(SERVE_ROUTES.desktopDeleteTopic.path, {
+      method: "POST",
+      json: { workspaceRoot, topicId },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  trashTopic(workspaceRoot: string, topicId: string) {
+    return this.request(SERVE_ROUTES.desktopTrashTopic.path, {
+      method: "POST",
+      json: { workspaceRoot, topicId },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  removeProject(workspaceRoot: string) {
+    return this.request(SERVE_ROUTES.desktopRemoveProject.path, {
+      method: "POST",
+      json: { workspaceRoot },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  renameProject(workspaceRoot: string, title: string) {
+    return this.request(SERVE_ROUTES.desktopRenameProject.path, {
+      method: "POST",
+      json: { workspaceRoot, title },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  reorderProjects(workspaceRoots: string[]) {
+    return this.request(SERVE_ROUTES.desktopReorderProjects.path, {
+      method: "POST",
+      json: { workspaceRoots },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  desktopStartupSettings() {
+    return this.request(SERVE_ROUTES.desktopStartupSettings.path).then((r) => this.jsonOrEmpty(r));
+  }
+  desktopSettings() {
+    return this.request(SERVE_ROUTES.desktopSettings.path).then((r) => this.jsonOrEmpty(r));
+  }
+  activateTab(id: string) {
+    return this.request(tabPath(id, "activate"), { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  closeTab(id: string) {
+    return this.request(tabPath(id, "close"), { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  submitTab(id: string, input: string, format?: string) {
+    const json: Record<string, string> = { input };
+    if (format) json.format = format;
+    return this.request(tabPath(id, "submit"), { method: "POST", json }).then((r) => this.jsonOrEmpty(r));
+  }
+  cancelTab(id: string) {
+    return this.request(tabPath(id, "cancel"), { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  approveTab(tabId: string, id: string, allow: boolean, session = false, persist = false) {
+    return this.request(tabPath(tabId, "approve"), {
+      method: "POST",
+      json: { id, allow, session, persist },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  answerTab(tabId: string, id: string, answers: unknown) {
+    return this.request(tabPath(tabId, "answer"), {
+      method: "POST",
+      json: { id, answers },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  setPlanModeTab(id: string, on: boolean) {
+    return this.request(tabPath(id, "plan"), { method: "POST", json: { on: !!on } }).then((r) =>
+      this.jsonOrEmpty(r),
+    );
+  }
+  compactTab(id: string) {
+    return this.request(tabPath(id, "compact"), { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  newSessionTab(id: string) {
+    return this.request(tabPath(id, "new"), { method: "POST", json: {} }).then((r) => this.jsonOrEmpty(r));
+  }
+  setGoalTab(id: string, goal: string) {
+    return this.request(tabPath(id, "goal"), { method: "POST", json: { goal: goal ?? "" } }).then((r) =>
+      this.jsonOrEmpty(r),
+    );
+  }
+  setToolApprovalModeTab(id: string, mode: string) {
+    return this.request(tabPath(id, "tool-approval-mode"), {
+      method: "POST",
+      json: { mode },
+    }).then((r) => this.jsonOrEmpty(r));
+  }
+  historyTab(id: string) {
+    return this.request(tabPath(id, "history")).then((r) => this.jsonOrEmpty(r));
+  }
+  contextTab(id: string) {
+    return this.request(tabPath(id, "context")).then((r) => this.jsonOrEmpty(r));
+  }
+  statusTab(id: string) {
+    return this.request(tabPath(id, "status")).then((r) => this.jsonOrEmpty(r));
+  }
+
+  /** Prefer tab-scoped submit when multi-tab is available; fall back to legacy. */
+  async submitPreferTab(tabId: string | undefined, input: string, format?: string) {
+    if (tabId) {
+      try {
+        return await this.submitTab(tabId, input, format);
+      } catch (e) {
+        const err = e as { status?: number };
+        if (err.status !== 404) throw e;
+      }
+    }
+    return this.submit(input, format);
+  }
+
+  onEvent(handler: (e: Record<string, unknown>) => void): () => void {
+    this.handlers.add(handler);
+    if (!this.sseTask) this.sseTask = this.runSseLoop();
+    return () => {
+      this.handlers.delete(handler);
+      if (this.handlers.size === 0) this.dispose();
+    };
+  }
+
+  private async runSseLoop(): Promise<void> {
+    this.abort = new AbortController();
+    const state: { pending?: string } = { pending: "" };
+    let backoff = 250;
+    while (this.handlers.size > 0 && !this.abort.signal.aborted) {
+      try {
+        const url = new URL(SERVE_ROUTES.events.path, this.baseUrl + "/");
+        url.searchParams.set("token", this.token);
+        const res = await this.fetchImpl(url.toString(), {
+          headers: {
+            Accept: "text/event-stream",
+            Cookie: `reasonix_token=${this.token}`,
+          },
+          signal: this.abort.signal,
+          redirect: "manual",
+        });
+        if (!res.ok || !res.body) throw new Error(`SSE HTTP ${res.status}`);
+        backoff = 250;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        while (this.handlers.size > 0) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const text = decoder.decode(value, { stream: true });
+          for (const data of parseSseChunk(text, state)) {
+            const wire = mapServeEventToWire(data);
+            if (!wire) continue;
+            for (const h of this.handlers) {
+              try {
+                h(wire);
+              } catch {
+                /* ignore */
+              }
+            }
+          }
+        }
+      } catch {
+        if (this.abort?.signal.aborted) break;
+        await new Promise((r) => setTimeout(r, backoff));
+        backoff = Math.min(backoff * 2, 8_000);
+      }
+    }
+    this.sseTask = null;
+  }
+
+  dispose(): void {
+    this.handlers.clear();
+    try {
+      this.abort?.abort();
+    } catch {
+      /* ignore */
+    }
+    this.abort = null;
+    this.sseTask = null;
+  }
+}
+
+export function createHttpSseHost(opts: {
+  baseUrl: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): HttpSseHost {
+  return new HttpSseHost(opts);
+}

--- a/desktop/frontend/src/lib/host/index.ts
+++ b/desktop/frontend/src/lib/host/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Pluggable Reasonix hosts.
+ * - Wails remains the default product path via bridge.ts (unchanged).
+ * - HttpSseHost is for Electron PoC / serve clients.
+ */
+export type { ReasonixHost, HostCapabilities } from "./types";
+export {
+  POC_CAPABILITIES,
+  WAILS_DESKTOP_CAPABILITIES,
+  isCapabilityEnabled,
+  unsupportedDesktopFeatures,
+} from "./capabilities";
+export { SERVE_ROUTES } from "./routes";
+export { mapServeEventToWire, parseSseChunk } from "./mapEvent";
+export { HttpSseHost, createHttpSseHost } from "./httpSseHost";
+export { DEFAULT_DESKTOP_HOST, ALTERNATE_HOSTS, isHttpSseHostMode } from "./wailsDefault";

--- a/desktop/frontend/src/lib/host/mapEvent.ts
+++ b/desktop/frontend/src/lib/host/mapEvent.ts
@@ -1,0 +1,73 @@
+/**
+ * Map serve SSE JSON into the desktop WireEvent shape (eventwire contract).
+ * Serve emits top-level `kind` with nested approval/ask/tool — preserve them.
+ */
+
+const KNOWN_KINDS = new Set([
+  "turn_started",
+  "reasoning",
+  "text",
+  "message",
+  "tool_dispatch",
+  "tool_result",
+  "usage",
+  "notice",
+  "phase",
+  "approval_request",
+  "ask_request",
+  "turn_done",
+  "compaction_started",
+  "compaction_done",
+  "tool_progress",
+  "retrying",
+  "steer",
+  "stream_attempt",
+]);
+
+export function mapServeEventToWire(raw: unknown): Record<string, unknown> | null {
+  if (raw == null) return null;
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    const s = raw.trim();
+    if (!s) return null;
+    try {
+      obj = JSON.parse(s);
+    } catch {
+      return { kind: "notice", text: s, level: "info", _transport: "http-sse" };
+    }
+  }
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return { kind: "notice", text: String(obj), level: "info", _transport: "http-sse" };
+  }
+  const e: Record<string, unknown> = { ...(obj as Record<string, unknown>) };
+
+  // Preserve kind. Do not invent type or force type:"unknown".
+  if ((e.kind == null || e.kind === "") && typeof e.type === "string" && e.type) {
+    if (KNOWN_KINDS.has(e.type)) {
+      e.kind = e.type;
+    }
+  }
+
+  e._transport = "http-sse";
+  return e;
+}
+
+export function parseSseChunk(
+  chunk: string,
+  state: { pending?: string },
+): string[] {
+  state.pending = (state.pending ?? "") + chunk;
+  const events: string[] = [];
+  let idx: number;
+  while ((idx = state.pending.indexOf("\n\n")) >= 0) {
+    const block = state.pending.slice(0, idx);
+    state.pending = state.pending.slice(idx + 2);
+    const dataLines: string[] = [];
+    for (const line of block.split(/\r?\n/)) {
+      if (line.startsWith(":")) continue;
+      if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+    }
+    if (dataLines.length) events.push(dataLines.join("\n"));
+  }
+  return events;
+}

--- a/desktop/frontend/src/lib/host/routes.ts
+++ b/desktop/frontend/src/lib/host/routes.ts
@@ -1,0 +1,53 @@
+/** Serve routes — must match internal/serve and electron-poc/lib/routes.mjs */
+export const SERVE_ROUTES = {
+  events: { method: "GET", path: "/events" },
+  history: { method: "GET", path: "/history" },
+  context: { method: "GET", path: "/context" },
+  status: { method: "GET", path: "/status" },
+  sessions: { method: "GET", path: "/sessions" },
+  skills: { method: "GET", path: "/skills" },
+  todos: { method: "GET", path: "/todos" },
+  checkpoints: { method: "GET", path: "/checkpoints" },
+  branches: { method: "GET", path: "/branches" },
+  models: { method: "GET", path: "/models" },
+  providerSetup: { method: "GET", path: "/provider-setup" },
+  submit: { method: "POST", path: "/submit" },
+  cancel: { method: "POST", path: "/cancel" },
+  approve: { method: "POST", path: "/approve" },
+  answer: { method: "POST", path: "/answer" },
+  plan: { method: "POST", path: "/plan" },
+  compact: { method: "POST", path: "/compact" },
+  newSession: { method: "POST", path: "/new" },
+  rewind: { method: "POST", path: "/rewind" },
+  fork: { method: "POST", path: "/fork" },
+  summarize: { method: "POST", path: "/summarize" },
+  toolApprovalMode: { method: "POST", path: "/tool-approval-mode" },
+  autoApproveTools: { method: "POST", path: "/auto-approve-tools" },
+  bypass: { method: "POST", path: "/bypass" },
+  goal: { method: "POST", path: "/goal" },
+  resume: { method: "POST", path: "/resume" },
+  forget: { method: "POST", path: "/forget" },
+  deleteSession: { method: "POST", path: "/delete-session" },
+  reloadExtensions: { method: "POST", path: "/extensions/reload" },
+  providerSetupSave: { method: "POST", path: "/provider-setup" },
+  // Multi-tab (serve --multi-tab)
+  tabs: { method: "GET", path: "/tabs" },
+  tabsCreate: { method: "POST", path: "/tabs" },
+  tabsOpenProject: { method: "POST", path: "/tabs/open-project" },
+  // Desktop sidebar / settings shared with Electron
+  desktopProjectTree: { method: "GET", path: "/desktop/project-tree" },
+  desktopCreateTopic: { method: "POST", path: "/desktop/topics" },
+  desktopRenameTopic: { method: "POST", path: "/desktop/topics/rename" },
+  desktopDeleteTopic: { method: "POST", path: "/desktop/topics/delete" },
+  desktopTrashTopic: { method: "POST", path: "/desktop/topics/trash" },
+  desktopRemoveProject: { method: "POST", path: "/desktop/projects/remove" },
+  desktopRenameProject: { method: "POST", path: "/desktop/projects/rename" },
+  desktopReorderProjects: { method: "POST", path: "/desktop/projects/reorder" },
+  desktopStartupSettings: { method: "GET", path: "/desktop/startup-settings" },
+  desktopSettings: { method: "GET", path: "/desktop/settings" },
+} as const;
+
+export function tabPath(id: string, suffix: string): string {
+  const clean = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `/tabs/${encodeURIComponent(id)}${clean}`;
+}

--- a/desktop/frontend/src/lib/host/types.ts
+++ b/desktop/frontend/src/lib/host/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Pluggable host surface shared by Wails desktop and HTTP/SSE (serve) clients.
+ * Default product path remains Wails; Electron PoC uses HttpSseHost.
+ */
+
+import type { POC_CAPABILITIES } from "./capabilities";
+
+export type HostCapabilities = typeof POC_CAPABILITIES;
+
+export interface ReasonixHost {
+  getCapabilities(): HostCapabilities;
+  dispose(): void;
+
+  status(): Promise<unknown>;
+  history(): Promise<unknown>;
+  context(): Promise<unknown>;
+  sessions(): Promise<unknown>;
+  skills(): Promise<unknown>;
+  todos(): Promise<unknown>;
+  checkpoints(): Promise<unknown>;
+  models(): Promise<unknown>;
+  providerSetup(): Promise<unknown>;
+
+  submit(input: string, format?: string): Promise<unknown>;
+  cancel(): Promise<unknown>;
+  approve(id: string, allow: boolean, session?: boolean, persist?: boolean): Promise<unknown>;
+  answer(id: string, answers: unknown): Promise<unknown>;
+  setPlanMode(on: boolean): Promise<unknown>;
+  setToolApprovalMode(mode: string): Promise<unknown>;
+  setAutoApproveTools(on: boolean): Promise<unknown>;
+  compact(): Promise<unknown>;
+  newSession(): Promise<unknown>;
+  rewind(turn: number, scope: string): Promise<unknown>;
+  fork(turn: number): Promise<unknown>;
+  summarize(turn: number): Promise<unknown>;
+  setGoal(goal: string): Promise<unknown>;
+  clearGoal(): Promise<unknown>;
+  resume(path: string): Promise<unknown>;
+  deleteSession(path: string): Promise<unknown>;
+  reloadExtensions(): Promise<unknown>;
+
+  onEvent(handler: (e: Record<string, unknown>) => void): () => void;
+}

--- a/desktop/frontend/src/lib/host/wailsDefault.ts
+++ b/desktop/frontend/src/lib/host/wailsDefault.ts
@@ -1,0 +1,18 @@
+/**
+ * Documents that the default desktop product path remains Wails (`bridge.ts`).
+ * HttpSseHost is opt-in for Electron PoC / serve clients and does not replace
+ * window.go.main.App bindings.
+ */
+export const DEFAULT_DESKTOP_HOST = "wails" as const;
+export const ALTERNATE_HOSTS = ["http-sse"] as const;
+
+/** True when Vite/build injects HTTP host mode (Electron PoC). */
+export function isHttpSseHostMode(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const env = (import.meta as any)?.env;
+    return env?.VITE_REASONIX_HOST === "http-sse";
+  } catch {
+    return false;
+  }
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2675,6 +2675,15 @@ export function useController() {
         if (reason === "switch-tab") {
           addBreadcrumb("tab.switch", `history-done ${tabId} skipped ms=${Date.now() - historyStartedAt}`);
         }
+      } else if (!skipHistory && historyPage === undefined) {
+        // History fetch failed. Clear any cross-tab placeholder so the UI does
+        // not keep showing the previous project's transcript under this tab id.
+        dispatchTo(tabId, {
+          type: "history_page",
+          page: { messages: [], startTurn: 0, endTurn: 0, totalTurns: 0, hasOlder: false },
+          mode: "replace",
+        });
+        addBreadcrumb("tab.hydrate", `history missing ${tabId} cleared-placeholder ms=${Date.now() - historyStartedAt}`);
       }
 
       dispatchTo(tabId, { type: "hydrate_done" });
@@ -3635,12 +3644,14 @@ export function useController() {
 
   const pickWorkspace = useCallback(async (): Promise<string> => {
     beginActiveNavigation();
-    const path = await app.PickWorkspace().catch(() => "");
+    // Do not swallow errors: Electron open-project failures must surface to the UI
+    // (silent catch made "添加新项目" look like a no-op after the folder dialog).
+    const path = await app.PickWorkspace();
     return refreshWorkspaceState(path);
   }, [beginActiveNavigation, refreshWorkspaceState]);
   const switchWorkspace = useCallback(async (path: string): Promise<string> => {
     beginActiveNavigation();
-    const next = await app.SwitchWorkspace(path).catch(() => "");
+    const next = await app.SwitchWorkspace(path);
     return refreshWorkspaceState(next);
   }, [beginActiveNavigation, refreshWorkspaceState]);
 
@@ -3939,9 +3950,12 @@ export function useController() {
         if (!activated || !isNavigationIntentCurrent(navigationSeq)) return undefined;
         const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false });
         if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
+        // Only skip history when this tab already has a live in-flight turn.
+        // Reusing another project's transcript as "cached" made multi-tab look
+        // stuck on the first conversation after a sidebar/project click.
         void loadSessionDataForTab(tabId, false, "switch-tab", {
           skipHistory: hasCachedLiveTurn(statesRef.current.get(tabId)),
-          preserveCachedHistory,
+          preserveCachedHistory: Boolean(targetSessionPath?.trim()) && preserveCachedHistory,
           sessionPath: targetSessionPath,
         });
         return tabs;
@@ -3963,18 +3977,27 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-project", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
+    const prevTabId = activeTabIdRef.current;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
+    // Only reuse the previous transcript as a loading placeholder when we stay
+    // on the same tab id (true re-open). Cross-project multi-tab must not paint
+    // project A's messages under project B while history loads.
+    const prevItems =
+      isNewTab && prevTabId && prevTabId === meta.id
+        ? statesRef.current.get(prevTabId)?.items
+        : undefined;
     const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath);
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
+    // Always force a history read when switching to an existing multi-tab
+    // controller so the transcript cannot stay stuck on the previous project.
     const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
+      placeholderItems: prevItems,
+      preserveCachedHistory: isNewTab ? false : preserveCachedHistory,
       sessionPath: meta.sessionPath,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
@@ -3990,7 +4013,6 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-global", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
     const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath);
@@ -4000,8 +4022,7 @@ export function useController() {
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
     const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
+      preserveCachedHistory: isNewTab ? false : preserveCachedHistory,
       sessionPath: meta.sessionPath,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
@@ -4017,7 +4038,6 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-session", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
     const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath);
@@ -4027,8 +4047,7 @@ export function useController() {
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
     const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
+      preserveCachedHistory: isNewTab ? false : preserveCachedHistory,
       sessionPath: meta.sessionPath,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});

--- a/docs/TABHOST_CONTRACT.md
+++ b/docs/TABHOST_CONTRACT.md
@@ -1,0 +1,112 @@
+# Tabhost contract (route C · MVP-B)
+
+Transport-agnostic multi-Controller runtime shared by multi-tab `reasonix serve`
+and the Electron shell. Tab semantics align with Wails desktop `WorkspaceTab` /
+`TabMeta` (`desktop/tabs.go`).
+
+**Status:** Phase 0–3 landed. `internal/tabhost` Host + `reasonix serve --multi-tab`
+HTTP/SSE routes (`/tabs`, `/tabs/{id}/…`) + desktop sidebar metadata
+(`internal/desktopsidebar` + `/desktop/*`) + Electron multi-tab UI (project open,
+tab switch, per-tab transcript).
+
+## Goals
+
+| Goal | Notes |
+| --- | --- |
+| Multi-project concurrent agents | Distinct `workspaceRoot` per tab, independent `control.SessionAPI` |
+| Multi-session concurrent agents | Distinct session paths; cancel/approve do not cross tabs |
+| Event routing | Every wire event carries `tabId` (+ optional `runtimeEpoch`) |
+| Electron UI | Existing `desktop/frontend` multi-tab reducer works without rewrite |
+| Shared sidebar metadata | `desktop-projects.json` + topic title maps shared with Wails |
+
+## Non-goals (MVP-B)
+
+- Replacing official Wails packaging
+- Full Terminal / Remote / Bot / theme pack / production updater parity
+- Per-tab OS processes
+- Moving all of `desktop` App onto tabhost
+
+## TabMeta JSON (frozen for serve + Electron)
+
+Aligned with `desktop.TabMeta` and `desktop/frontend/src/lib/types.ts`:
+
+```json
+{
+  "id": "string",
+  "scope": "project|global",
+  "workspaceRoot": "string",
+  "workspaceName": "string",
+  "workspacePath": "string?",
+  "topicId": "string",
+  "topicTitle": "string",
+  "sessionPath": "string?",
+  "label": "string",
+  "ready": "bool",
+  "runtime": "SessionRuntimeView",
+  "running": "bool",
+  "cancellable": "bool",
+  "mode": "string",
+  "collaborationMode": "string",
+  "toolApprovalMode": "string",
+  "tokenMode": "string",
+  "goal": "string?",
+  "goalStatus": "string?",
+  "active": "bool",
+  "cwd": "string"
+}
+```
+
+## HTTP routes
+
+### Multi-tab (`--multi-tab`)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/tabs` | List tabs |
+| POST | `/tabs` | Create tab |
+| POST | `/tabs/{id}/activate` | Activate |
+| POST | `/tabs/{id}/close` | Close |
+| POST | `/tabs/{id}/submit` | Submit turn |
+| POST | `/tabs/{id}/cancel` | Cancel |
+| POST | `/tabs/{id}/approve` | Approve tool |
+| POST | `/tabs/{id}/answer` | Answer ask |
+| POST | `/tabs/{id}/plan` | Plan mode |
+| POST | `/tabs/{id}/compact` | Compact |
+| POST | `/tabs/{id}/new` | New session |
+| POST | `/tabs/{id}/goal` | Goal |
+| POST | `/tabs/{id}/tool-approval-mode` | Tool approval mode |
+| GET | `/tabs/{id}/history` | History |
+| GET | `/tabs/{id}/context` | Context usage |
+| GET | `/tabs/{id}/status` | Runtime status |
+| POST | `/tabs/open-project` | Open/focus project workspace tab |
+| GET | `/events` | Multiplex SSE |
+
+### Desktop sidebar / settings (always registered)
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/desktop/project-tree` | Sidebar `ProjectNode[]` |
+| POST | `/desktop/topics` | CreateTopic |
+| POST | `/desktop/topics/rename` | RenameTopic |
+| POST | `/desktop/topics/delete` | DeleteTopic |
+| POST | `/desktop/topics/trash` | TrashTopic |
+| POST | `/desktop/projects/remove` | RemoveWorkspace |
+| POST | `/desktop/projects/rename` | RenameProject |
+| POST | `/desktop/projects/reorder` | ReorderProjects |
+| GET | `/desktop/startup-settings` | DesktopStartupSettings |
+| GET | `/desktop/settings` | Lightweight Settings |
+
+## Package / layering
+
+- Package: `reasonix/internal/tabhost`
+- Package: `reasonix/internal/desktopsidebar` (shared project/topic metadata)
+- Frontend layer (may import `control`, `boot`, `event`, `eventwire`)
+- Registered in `tools/repolint/layers.go` `frontends` for tabhost/serve
+
+## Success criteria (MVP-B)
+
+User can run **two workspace tabs** in Electron concurrently: streaming and approvals do not cross-talk; `GET /tabs` shows both; active switch does not stop the background turn; sidebar project tree and topic create work via `/desktop/*`.
+
+## Still deferred
+
+Terminal, Remote, Bot runtime, Heartbeat, Steer over HTTP, production updater, full Wails Settings write surface.

--- a/electron-poc/.gitignore
+++ b/electron-poc/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+desktop-ui/
+*.log
+.DS_Store

--- a/electron-poc/README.md
+++ b/electron-poc/README.md
@@ -1,0 +1,111 @@
+# Reasonix Electron PoC (loopback `reasonix serve`)
+
+Experimental **Electron shell** that supervises a local **`reasonix serve`** on
+`127.0.0.1` with **token-file auth**. This is **not** the official desktop
+product (that remains the Wails app under `desktop/`).
+
+## What this proves
+
+1. Electron can start/stop a trusted `reasonix` binary with:
+   - `--addr 127.0.0.1:0`
+   - `--auth token`
+   - `--token-file` / `--port-file` / `--pid-file` (token **not** on argv)
+2. Core agent I/O works over **HTTP JSON + SSE** via `lib/httpSseHost.mjs`
+   (P0 serve surface).
+3. Unsupported Wails-only surfaces are **capability-gated** (see
+   `docs/CAPABILITY_GAP.md`).
+
+## Prerequisites
+
+- Node.js ≥ 20
+- A `reasonix` binary:
+  - `export REASONIX_BIN=/path/to/reasonix`, or
+  - `make build` in the repo root (`bin/reasonix`), or
+  - `reasonix` on `PATH`
+- Provider configured (`reasonix setup`) for live chat; `/status` works without a turn
+
+## Quick start
+
+```bash
+cd electron-poc
+npm install                 # installs deps
+npm run ensure-electron     # download/extract Electron binary if postinstall was skipped
+npm run build:ui            # build Wails-style desktop React UI → desktop-ui/
+npm test                    # unit/integration tests (no display required)
+npm start                   # opens Electron → desktop React UI over loopback serve
+# npm run start:fast        # skip rebuild if desktop-ui/ already exists
+```
+
+If `npm install` blocked install scripts (npm allow-scripts policy), run
+`npm run ensure-electron` once so `path.txt` + `Electron.app` Frameworks exist.
+
+### UI mode
+
+The window loads the **same React app as Wails desktop** (`desktop/frontend`),
+wired through `HttpSseHost` + a same-origin reverse proxy (`lib/desktopShell.mjs`).
+It is **not** the lightweight `reasonix serve` HTML client.
+
+**Multi-tab (Phase 3):** the supervisor starts `reasonix serve --multi-tab`.
+`ListTabs` / `SubmitToTab` / `OpenProjectTab` call `/tabs…`. Sidebar topics /
+project tree use `/desktop/*` (`internal/desktopsidebar`, shared with Wails
+`desktop-projects.json`). Use a binary built from this repo
+(`REASONIX_BIN=./bin/reasonix`) so `--multi-tab` and `/desktop/*` exist.
+
+Still deferred (not full Wails parity): terminal PTY, remote SSH, bot IM runtime,
+heartbeat automation, theme pack store, production updater, full Settings write-back.
+
+```bash
+npm run smoke:dual-project   # two workspaces + project-tree + create topic
+```
+
+Environment:
+
+| Variable | Meaning |
+| --- | --- |
+| `REASONIX_BIN` | Absolute path to reasonix binary |
+| `REASONIX_WORKSPACE` | cwd for serve (default: process cwd) |
+| `REASONIX_POC_CRASH_RESTART=0` | disable one-shot crash restart |
+| `REASONIX_POC_SCRATCH` | directory for smoke log capture |
+| `REASONIX_POC_SUBMIT=1` | allow live `/submit` in HTTP smoke |
+| `REASONIX_POC_ELECTRON=1` | dual-launch script also spawns Electron |
+
+## Smoke scripts
+
+```bash
+export REASONIX_POC_SCRATCH=/path/to/scratch
+npm run smoke:http      # supervisor + HttpSseHost against real serve
+npm run smoke:launch    # dual serial launches + GET /status
+```
+
+## Layout
+
+```text
+electron-poc/
+  electron/main.mjs       # single-instance, window, workspace picker, quit→stop
+  electron/preload.cjs    # contextIsolation whitelist
+  lib/serveSupervisor.mjs # token/port/pid lifecycle (testable without Electron)
+  lib/httpSseHost.mjs     # P0 HTTP+SSE host
+  lib/capabilities.mjs    # feature gates
+  docs/CAPABILITY_GAP.md
+  docs/GO_NO_GO.md
+```
+
+Frontend host mirror (Wails default unchanged):
+
+- `desktop/frontend/src/lib/host/*` — TypeScript `HttpSseHost` + capabilities
+
+## Security defaults
+
+- Loopback bind only
+- Token in `0600` file; never `--token` on argv under supervision
+- Renderer: `contextIsolation: true`, `nodeIntegration: false`, `sandbox: true`
+- Trusted binary basename must be `reasonix` / `reasonix.exe`
+
+## Menu / shell actions (IPC)
+
+Via `window.reasonixPoc` (preload):
+
+- `getEndpoint()` — baseUrl, token, log path, capabilities
+- `pickWorkspace()` — dialog + restart serve in chosen directory
+- `openLog()` — open serve log in OS
+- `restartServe()` — manual restart

--- a/electron-poc/docs/CAPABILITY_GAP.md
+++ b/electron-poc/docs/CAPABILITY_GAP.md
@@ -1,0 +1,71 @@
+# Capability gap matrix — Electron + `reasonix serve` PoC
+
+Comparison of the **official Wails desktop** (~389 bridge methods, multi-tab)
+versus this **PoC host** (single session, ~30 serve routes).
+
+## Legend
+
+| Symbol | Meaning |
+| --- | --- |
+| ✅ | Supported in PoC (HTTP/SSE or shell) |
+| ⚠️ | Partial / degraded |
+| ❌ | Out of PoC scope (capability-gated) |
+
+## Core agent path (P0)
+
+| Capability | Wails desktop | PoC (serve + Electron) | Notes |
+| --- | --- | --- | --- |
+| Submit text turn | ✅ | ✅ `POST /submit` | |
+| Cancel | ✅ | ✅ `POST /cancel` | |
+| Tool approval | ✅ | ✅ `POST /approve` | |
+| Ask / answer | ✅ | ✅ `POST /answer` | |
+| Event stream | ✅ Wails events | ✅ `GET /events` SSE | Mapped via `mapServeEventToWire` |
+| History | ✅ | ✅ `GET /history` | Full list; no page API |
+| Context panel | ✅ | ✅ `GET /context` | |
+| Status / ready | ✅ | ✅ `GET /status` | |
+| New session | ✅ | ✅ `POST /new` | |
+| Compact | ✅ | ✅ `POST /compact` | |
+| Rewind + checkpoints | ✅ | ✅ `/rewind` `/checkpoints` | Advanced preview/commit chain may differ |
+| Fork / summarize | ✅ | ✅ | |
+| Plan mode | ✅ | ✅ `POST /plan` | |
+| Tool approval mode | ✅ | ✅ `/tool-approval-mode` | |
+| Goal | ✅ | ✅ `POST /goal` | Subset of Goal FSM UI |
+| Sessions list/delete/resume | ✅ | ✅ | |
+| Models list / switch | ✅ | ✅ list; switch via `/model` submit intercept | |
+| Todos / skills | ✅ | ✅ | |
+| Provider setup | ✅ | ✅ `/provider-setup` (loopback) | |
+| Extensions reload | ✅ | ✅ | |
+
+## Desktop shell
+
+| Capability | Wails | PoC |
+| --- | --- | --- |
+| Native window | ✅ | ✅ Electron |
+| Single-instance | ✅ | ✅ |
+| Workspace pick | ✅ in-process switch | ⚠️ dialog + **restart serve** in new cwd |
+| Serve log open | n/a | ✅ |
+| Crash restart serve once | n/a | ✅ |
+| Production auto-update | ✅ | ❌ |
+
+## Explicitly deferred (capability = false)
+
+| Feature | Reason |
+| --- | --- |
+| `multiTab` | **Enabled (Phase 3):** serve `--multi-tab` + Electron `ListTabs`/`SubmitToTab`/`OpenProjectTab` via `/tabs`; sidebar topics/projects via `/desktop/*` |
+| `projectTree` | **Enabled:** `GET /desktop/project-tree` + topic CRUD |
+| `desktopSettings` | **Partial:** read-only startup/settings from user config; full Settings write remains Wails |
+| `terminal` | No PTY in serve |
+| `remote` | Separate remote bootstrap product path |
+| `bot` | Bot bridge is desktop Go |
+| `heartbeat` | Desktop-only panel |
+| `themePackStore` | Wails theme system |
+| `productionUpdater` | Not a release product |
+| `steer` | No `/steer` route in serve today |
+| `submitDisplay` / edit-replay / invocations | Submit body is plain `input` |
+| `historyPagination` | Serve returns full history |
+
+## Source of truth
+
+- Runtime flags: `electron-poc/lib/capabilities.mjs`
+- TS mirror: `desktop/frontend/src/lib/host/capabilities.ts`
+- Routes: `electron-poc/lib/routes.mjs` ↔ `internal/serve` handlers

--- a/electron-poc/docs/GO_NO_GO.md
+++ b/electron-poc/docs/GO_NO_GO.md
@@ -1,0 +1,47 @@
+# Go / No-Go decision artifact — Electron serve PoC
+
+**Date:** 2026-08-08  
+**Scope:** Phases 0–3 of 方案 A (loopback `reasonix serve` + Electron shell +
+HttpSseHost + multi-tab UI + `/desktop/*` sidebar metadata)  
+**Official desktop:** remains **Wails** (`desktop/`). This tree is **additive/experimental**.
+
+## Decision
+
+### **GO — experimental shell only**
+
+Ship and maintain `electron-poc/` as a **community/experimental** path for:
+
+- validating dual-process supervision (`token-file` / `port-file` / `pid-file`)
+- validating HTTP+SSE host against the P0 serve surface
+- optional local use when Chromium/Electron is preferred for debugging
+
+### **NO-GO — product replacement**
+
+Do **not**:
+
+- replace Wails as the official desktop release line
+- promise multi-tab / terminal / remote / bot parity via Electron
+- add Electron to the official release matrix, signing, or auto-update channel
+- rewrite agent/provider/tools in Node
+
+## Evidence used
+
+| Check | Result |
+| --- | --- |
+| Supervisor args loopback + token-file only | Covered by unit tests + smoke |
+| HttpSseHost P0 routes + JSON CSRF + SSE wire map | Unit/integration tests against real HTTP |
+| Dual launch GET `/status` | `scripts/dual-launch-smoke.mjs` |
+| Capability gap written | `docs/CAPABILITY_GAP.md` |
+| Wails path unchanged as default product | No removal of `desktop/` Wails bindings; host is opt-in |
+
+## Revisit triggers (would re-open product discussion)
+
+1. Serve gains first-class multi-session API and Desktop parity closes gap to &lt;20% of bridge surface.
+2. Wails/WebView becomes an unfixable support burden on target platforms.
+3. Explicit product requirement for an Electron distribution with staffing for dual-shell CI.
+
+## Recommendation to maintainers
+
+Keep investing in **Wails desktop + shared `control.Controller`**. Treat Electron+serve as a **thin host proof**, reusing Remote’s supervision contract, not as a second full desktop.
+
+**Status: GO for experimental PoC · NO-GO for replacing Wails.**

--- a/electron-poc/electron/main.mjs
+++ b/electron-poc/electron/main.mjs
@@ -1,0 +1,255 @@
+/**
+ * Electron main: supervise reasonix serve + serve Wails-style desktop UI dist
+ * through a same-origin reverse proxy (lib/desktopShell.mjs).
+ */
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  shell,
+} from "electron";
+import { ServeSupervisor } from "../lib/serveSupervisor.mjs";
+import { resolveReasonixBin } from "../lib/resolveReasonixBin.mjs";
+import { POC_CAPABILITIES } from "../lib/capabilities.mjs";
+import { startDesktopShell, defaultDesktopUiDir } from "../lib/desktopShell.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(packageRoot, "..");
+
+/** @type {ServeSupervisor | null} */
+let supervisor = null;
+/** @type {BrowserWindow | null} */
+let mainWindow = null;
+/** @type {Awaited<ReturnType<ServeSupervisor['start']>> | null} */
+let lastStart = null;
+/** @type {Awaited<ReturnType<typeof startDesktopShell>> | null} */
+let desktopShell = null;
+let quitting = false;
+
+const gotLock = app.requestSingleInstanceLock();
+if (!gotLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+}
+
+function logLine(msg) {
+  const line = `[electron-poc] ${msg}\n`;
+  process.stderr.write(line);
+  if (lastStart?.logFile) {
+    try {
+      fs.appendFileSync(lastStart.logFile, line);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function endpointPayload() {
+  if (!lastStart) return null;
+  // Prefer shell same-origin base so renderer avoids CORS.
+  const baseUrl = desktopShell?.baseUrl || lastStart.baseUrl;
+  return {
+    baseUrl,
+    token: lastStart.token,
+    uiUrl: desktopShell?.uiUrl || lastStart.uiUrl,
+    port: desktopShell?.port || lastStart.port,
+    logFile: lastStart.logFile,
+    workspace: lastStart.workspace,
+    serveBaseUrl: lastStart.baseUrl,
+    capabilities: POC_CAPABILITIES,
+  };
+}
+
+async function startDesktopUiShell() {
+  if (desktopShell) {
+    await desktopShell.close().catch(() => {});
+    desktopShell = null;
+  }
+  if (!lastStart) throw new Error("serve not started");
+  const staticDir = process.env.REASONIX_DESKTOP_UI_DIR || defaultDesktopUiDir();
+  logLine(`desktop UI dir: ${staticDir}`);
+  desktopShell = await startDesktopShell({
+    staticDir,
+    serveBaseUrl: lastStart.baseUrl,
+    token: lastStart.token,
+    workspace: lastStart.workspace,
+  });
+  logLine(`desktop shell at ${desktopShell.uiUrl}`);
+  return desktopShell;
+}
+
+/**
+ * @param {Awaited<ReturnType<ServeSupervisor['start']>>} info
+ */
+async function applyServeReady(info) {
+  lastStart = info;
+  logLine(
+    `serve ready at ${info.baseUrl} pid=${info.pid}${info.fromCrashRestart ? " (crash-restart)" : ""}`,
+  );
+  try {
+    await startDesktopUiShell();
+  } catch (err) {
+    logLine(`desktop shell failed: ${err}`);
+    // Fall back to built-in serve UI so the window is never blank.
+  }
+  const loadUrl = desktopShell?.uiUrl || info.uiUrl;
+  if (mainWindow && !mainWindow.isDestroyed() && loadUrl) {
+    await mainWindow.loadURL(loadUrl);
+    mainWindow.webContents.send("poc:serve-restarted", endpointPayload());
+  }
+}
+
+async function startSupervisor(workspace) {
+  const bin = resolveReasonixBin({
+    env: process.env,
+    repoRoot,
+  });
+  logLine(`using reasonix binary: ${bin}`);
+  supervisor = new ServeSupervisor({
+    bin,
+    repoRoot,
+    workspace: workspace || process.env.REASONIX_WORKSPACE || process.cwd(),
+    crashRestartOnce: process.env.REASONIX_POC_CRASH_RESTART !== "0",
+    onExit: (code, signal) => {
+      logLine(`serve exited code=${code} signal=${signal}`);
+      if (!quitting && mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents
+          .executeJavaScript(
+            `console.warn(${JSON.stringify(`reasonix serve exited (${code}/${signal})`)})`,
+          )
+          .catch(() => {});
+      }
+    },
+    onCrashRestarted: async (info) => {
+      try {
+        await applyServeReady(info);
+      } catch (err) {
+        logLine(`crash-restart UI refresh failed: ${err}`);
+      }
+    },
+  });
+  const info = await supervisor.start();
+  await applyServeReady(info);
+  return info;
+}
+
+function createWindow(uiUrl) {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 840,
+    title: "Reasonix Desktop (Electron PoC)",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.cjs"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    try {
+      const u = new URL(url);
+      if (u.hostname === "127.0.0.1" || u.hostname === "localhost") {
+        return { action: "allow" };
+      }
+    } catch {
+      /* fallthrough */
+    }
+    shell.openExternal(url);
+    return { action: "deny" };
+  });
+
+  mainWindow.loadURL(uiUrl);
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
+}
+
+function registerIpc() {
+  ipcMain.handle("poc:get-endpoint", async () => endpointPayload());
+  ipcMain.on("poc:get-endpoint-sync", (event) => {
+    event.returnValue = endpointPayload();
+  });
+  ipcMain.handle("poc:get-capabilities", async () => POC_CAPABILITIES);
+  ipcMain.handle("poc:pick-workspace", async () => {
+    // Multi-tab: only pick a directory; frontend OpenProjectTab / host.openProject
+    // opens a new Controller tab without restarting serve.
+    const res = await dialog.showOpenDialog(mainWindow ?? undefined, {
+      properties: ["openDirectory", "createDirectory"],
+    });
+    if (res.canceled || !res.filePaths[0]) return null;
+    const ws = res.filePaths[0];
+    return {
+      workspace: ws,
+      baseUrl: desktopShell?.baseUrl || lastStart?.baseUrl,
+    };
+  });
+  ipcMain.handle("poc:open-log", async () => {
+    if (!lastStart?.logFile) return false;
+    await shell.openPath(lastStart.logFile);
+    return true;
+  });
+  ipcMain.handle("poc:restart-serve", async () => {
+    if (!supervisor) return null;
+    const info = await supervisor.restartInWorkspace(
+      lastStart?.workspace ?? process.cwd(),
+    );
+    await applyServeReady(info);
+    return endpointPayload();
+  });
+}
+
+async function boot() {
+  registerIpc();
+  try {
+    await startSupervisor();
+    const loadUrl = desktopShell?.uiUrl || lastStart?.uiUrl;
+    if (!loadUrl) throw new Error("no UI URL");
+    createWindow(loadUrl);
+  } catch (err) {
+    logLine(`failed to start: ${err}`);
+    dialog.showErrorBox(
+      "Reasonix Electron PoC",
+      `Failed to start:\n\n${err instanceof Error ? err.message : String(err)}\n\n` +
+        `Build the desktop UI first:\n  cd electron-poc && npm run build:ui\n` +
+        `And ensure reasonix is on PATH or set REASONIX_BIN.`,
+    );
+    app.quit();
+  }
+}
+
+app.whenReady().then(boot);
+
+app.on("before-quit", async (e) => {
+  if (quitting) return;
+  if (supervisor?.pid || desktopShell) {
+    e.preventDefault();
+    quitting = true;
+    try {
+      if (desktopShell) await desktopShell.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await supervisor?.stop();
+    } catch (err) {
+      logLine(`stop error: ${err}`);
+    }
+    app.exit(0);
+  }
+});
+
+app.on("window-all-closed", () => {
+  app.quit();
+});

--- a/electron-poc/electron/preload.cjs
+++ b/electron-poc/electron/preload.cjs
@@ -1,0 +1,21 @@
+"use strict";
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+/**
+ * Minimal, whitelist-only bridge for the PoC renderer.
+ * Sync endpoint lets the React bridge init HttpSseHost before first paint.
+ */
+contextBridge.exposeInMainWorld("reasonixPoc", {
+  getEndpoint: () => ipcRenderer.invoke("poc:get-endpoint"),
+  getEndpointSync: () => ipcRenderer.sendSync("poc:get-endpoint-sync"),
+  getCapabilities: () => ipcRenderer.invoke("poc:get-capabilities"),
+  pickWorkspace: () => ipcRenderer.invoke("poc:pick-workspace"),
+  openLog: () => ipcRenderer.invoke("poc:open-log"),
+  restartServe: () => ipcRenderer.invoke("poc:restart-serve"),
+  onServeRestarted: (cb) => {
+    const listener = (_e, payload) => cb(payload);
+    ipcRenderer.on("poc:serve-restarted", listener);
+    return () => ipcRenderer.removeListener("poc:serve-restarted", listener);
+  },
+});

--- a/electron-poc/lib/capabilities.mjs
+++ b/electron-poc/lib/capabilities.mjs
@@ -1,0 +1,89 @@
+/**
+ * Host capability bitmap for the Electron + serve PoC.
+ * Unsupported desktop surfaces are gated off so UI can hide them.
+ */
+export const POC_CAPABILITIES = Object.freeze({
+  multiTab: true,
+  terminal: false,
+  remote: false,
+  bot: false,
+  heartbeat: false,
+  themePackStore: false,
+  productionUpdater: false,
+  steer: false,
+  submitDisplay: false,
+  historyPagination: false,
+  workspacePicker: "shell", // dialog + open-project tab (no full serve restart)
+  singleSession: false,
+  httpSse: true,
+  serveBuiltinUi: true,
+  providerSetup: true,
+  toolApproval: true,
+  planMode: true,
+  goal: true,
+  rewind: true,
+  fork: true,
+  summarize: true,
+  sessions: true,
+  models: true,
+  todos: true,
+  skills: true,
+});
+
+/**
+ * Full Wails desktop (for contrast / docs).
+ */
+export const WAILS_DESKTOP_CAPABILITIES = Object.freeze({
+  multiTab: true,
+  terminal: true,
+  remote: true,
+  bot: true,
+  heartbeat: true,
+  themePackStore: true,
+  productionUpdater: true,
+  steer: true,
+  submitDisplay: true,
+  historyPagination: true,
+  workspacePicker: "native",
+  singleSession: false,
+  httpSse: false,
+  serveBuiltinUi: false,
+  providerSetup: true,
+  toolApproval: true,
+  planMode: true,
+  goal: true,
+  rewind: true,
+  fork: true,
+  summarize: true,
+  sessions: true,
+  models: true,
+  todos: true,
+  skills: true,
+});
+
+/**
+ * @param {typeof POC_CAPABILITIES} caps
+ * @param {string} feature
+ */
+export function isCapabilityEnabled(caps, feature) {
+  if (!caps || typeof caps !== "object") return false;
+  const v = caps[feature];
+  if (typeof v === "boolean") return v;
+  if (typeof v === "string") return v.length > 0;
+  return false;
+}
+
+/**
+ * Features that UI should hide in the PoC shell.
+ * @param {typeof POC_CAPABILITIES} [caps]
+ */
+export function unsupportedDesktopFeatures(caps = POC_CAPABILITIES) {
+  const deferred = [];
+  for (const [key, full] of Object.entries(WAILS_DESKTOP_CAPABILITIES)) {
+    const poc = caps[key];
+    if (full === true && poc !== true) {
+      deferred.push(key);
+    }
+  }
+  return deferred;
+}

--- a/electron-poc/lib/desktopShell.mjs
+++ b/electron-poc/lib/desktopShell.mjs
@@ -1,0 +1,259 @@
+/**
+ * Local shell: serve the Wails desktop React dist on loopback and reverse-proxy
+ * reasonix serve API routes onto the same origin (avoids CORS).
+ */
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".map": "application/json",
+  ".ico": "image/x-icon",
+};
+
+/** Paths handled by reasonix serve (not static assets). */
+const API_PREFIXES = [
+  "/events",
+  "/history",
+  "/context",
+  "/status",
+  "/sessions",
+  "/skills",
+  "/todos",
+  "/checkpoints",
+  "/branches",
+  "/models",
+  "/provider-setup",
+  "/submit",
+  "/cancel",
+  "/approve",
+  "/answer",
+  "/plan",
+  "/compact",
+  "/new",
+  "/rewind",
+  "/fork",
+  "/summarize",
+  "/tool-approval-mode",
+  "/auto-approve-tools",
+  "/bypass",
+  "/goal",
+  "/resume",
+  "/forget",
+  "/delete-session",
+  "/extensions/",
+  "/login",
+  "/tabs",
+  "/desktop/",
+];
+
+function isApiPath(pathname) {
+  return API_PREFIXES.some((p) => pathname === p || pathname.startsWith(p));
+}
+
+function safeJoin(root, reqPath) {
+  const decoded = decodeURIComponent(reqPath.split("?")[0]);
+  const rel = decoded === "/" ? "/index.html" : decoded;
+  const full = path.normalize(path.join(root, rel));
+  if (!full.startsWith(path.normalize(root + path.sep)) && full !== path.normalize(root)) {
+    return null;
+  }
+  return full;
+}
+
+/**
+ * @param {{
+ *   staticDir: string,
+ *   serveBaseUrl: string,
+ *   token: string,
+ *   workspace?: string,
+ * }} opts
+ */
+export function startDesktopShell(opts) {
+  const staticDir = path.resolve(opts.staticDir);
+  if (!fs.existsSync(path.join(staticDir, "index.html"))) {
+    throw new Error(
+      `desktop UI not built: missing ${path.join(staticDir, "index.html")}. Run: npm run build:ui`,
+    );
+  }
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || "/", "http://127.0.0.1");
+      if (isApiPath(url.pathname)) {
+        await proxyToServe(req, res, url, opts.serveBaseUrl, opts.token);
+        return;
+      }
+      await serveStatic(req, res, url, staticDir, opts);
+    } catch (err) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end(String(err?.message || err));
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const baseUrl = `http://127.0.0.1:${port}`;
+      resolve({
+        server,
+        port,
+        baseUrl,
+        uiUrl: `${baseUrl}/`,
+        close: () =>
+          new Promise((r) => {
+            server.close(() => r(undefined));
+          }),
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+async function serveStatic(req, res, url, staticDir, opts) {
+  let filePath = safeJoin(staticDir, url.pathname);
+  if (!filePath) {
+    res.writeHead(403);
+    res.end("forbidden");
+    return;
+  }
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+    filePath = path.join(filePath, "index.html");
+  }
+  if (!fs.existsSync(filePath)) {
+    // SPA fallback
+    filePath = path.join(staticDir, "index.html");
+  }
+  if (!fs.existsSync(filePath)) {
+    res.writeHead(404);
+    res.end("not found");
+    return;
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  let body = fs.readFileSync(filePath);
+  if (ext === ".html") {
+    const shellOrigin = `http://127.0.0.1`; // filled below via Host header
+    const host = req.headers.host || "127.0.0.1";
+    const inject = `<script>window.__REASONIX_SERVE__=${JSON.stringify({
+      baseUrl: `http://${host}`,
+      token: opts.token,
+      workspace: opts.workspace || "",
+    })};</script>`;
+    let html = body.toString("utf8");
+    if (html.includes("</head>")) {
+      html = html.replace("</head>", `${inject}</head>`);
+    } else {
+      html = inject + html;
+    }
+    body = Buffer.from(html, "utf8");
+  }
+  res.writeHead(200, {
+    "Content-Type": MIME[ext] || "application/octet-stream",
+    "Cache-Control": ext === ".html" ? "no-cache" : "public, max-age=3600",
+  });
+  res.end(body);
+}
+
+async function proxyToServe(req, res, url, serveBaseUrl, token) {
+  // Drop client query token noise; authenticate upstream with the live cookie only.
+  // serve token-mode: valid cookie → 200; ?token= alone → 302 strip (which we never follow).
+  const target = new URL(url.pathname, serveBaseUrl.replace(/\/$/, "") + "/");
+  // Preserve non-token query params (if any future API needs them).
+  for (const [k, v] of url.searchParams.entries()) {
+    if (k === "token") continue;
+    target.searchParams.append(k, v);
+  }
+
+  const headers = { ...req.headers, host: target.host };
+  // Always overwrite reasonix_token — browser may still send a stale shell cookie
+  // after serve restart (old mergeCookie kept it → 401 Unauthorized toast).
+  headers.cookie = withReasonixTokenCookie(headers.cookie, token);
+  delete headers["accept-encoding"];
+  delete headers["connection"];
+  delete headers["keep-alive"];
+  delete headers["transfer-encoding"];
+  delete headers["content-length"];
+
+  const init = {
+    method: req.method,
+    headers,
+    // Never follow auth redirects; cookie on the first hop must succeed.
+    redirect: "manual",
+    duplex: "half",
+  };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    init.body = Buffer.concat(chunks);
+    if (!headers["content-type"] && req.method === "POST") {
+      headers["content-type"] = "application/json";
+    }
+  }
+
+  const upstream = await fetch(target.toString(), init);
+  const outHeaders = {};
+  upstream.headers.forEach((v, k) => {
+    const key = k.toLowerCase();
+    // Do not leak serve Set-Cookie onto the shell origin (stale token trap).
+    if (key === "transfer-encoding" || key === "set-cookie" || key === "content-encoding") return;
+    outHeaders[k] = v;
+  });
+  res.writeHead(upstream.status, outHeaders);
+  if (!upstream.body) {
+    res.end();
+    return;
+  }
+  const reader = upstream.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+    }
+  } catch {
+    /* client aborted */
+  }
+  res.end();
+}
+
+/**
+ * Force `reasonix_token=<token>` into the Cookie header, replacing any prior value.
+ * @param {string | string[] | undefined} existing
+ * @param {string} token
+ */
+export function withReasonixTokenCookie(existing, token) {
+  const raw = Array.isArray(existing) ? existing.join("; ") : String(existing || "");
+  const parts = raw
+    .split(";")
+    .map((p) => p.trim())
+    .filter((p) => p && !/^reasonix_token=/i.test(p));
+  parts.push(`reasonix_token=${token}`);
+  return parts.join("; ");
+}
+
+export function defaultDesktopUiDir() {
+  // Prefer electron-poc/desktop-ui (built copy), then desktop/frontend/dist
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    path.resolve(here, "../desktop-ui"),
+    path.resolve(here, "../../desktop/frontend/dist"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(path.join(c, "index.html"))) return c;
+  }
+  return candidates[0];
+}

--- a/electron-poc/lib/httpSseHost.mjs
+++ b/electron-poc/lib/httpSseHost.mjs
@@ -1,0 +1,395 @@
+import { SERVE_ROUTES, tabPath } from "./routes.mjs";
+import { POC_CAPABILITIES } from "./capabilities.mjs";
+import { mapServeEventToWire, parseSseChunk } from "./mapEvent.mjs";
+
+/**
+ * Pluggable ReasonixHost over HTTP JSON + SSE (reasonix serve).
+ * Auth: cookie reasonix_token (serve token mode). Also supports ?token= on first request.
+ */
+export class HttpSseHost {
+  /**
+   * @param {{
+   *   baseUrl: string,
+   *   token: string,
+   *   fetchImpl?: typeof fetch,
+   *   capabilities?: typeof POC_CAPABILITIES,
+   * }} opts
+   */
+  constructor(opts) {
+    if (!opts?.baseUrl) throw new Error("baseUrl required");
+    if (!opts?.token) throw new Error("token required");
+    this.baseUrl = opts.baseUrl.replace(/\/$/, "");
+    this.token = opts.token;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.capabilities = opts.capabilities ?? POC_CAPABILITIES;
+    this._abort = null;
+    this._handlers = new Set();
+    this._sseTask = null;
+  }
+
+  /** @returns {typeof POC_CAPABILITIES} */
+  getCapabilities() {
+    return this.capabilities;
+  }
+
+  /**
+   * @param {string} path
+   * @param {RequestInit & { json?: unknown }} [init]
+   */
+  async request(path, init = {}) {
+    const url = new URL(path, this.baseUrl + "/");
+    // Prefer cookie auth for browser-like clients; also attach query for APIs without cookie jar
+    if (!url.searchParams.has("token")) {
+      url.searchParams.set("token", this.token);
+    }
+    const headers = new Headers(init.headers ?? {});
+    headers.set("Cookie", `reasonix_token=${this.token}`);
+    let body = init.body;
+    if (init.json !== undefined) {
+      headers.set("Content-Type", "application/json");
+      body = JSON.stringify(init.json);
+    }
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && !headers.get("Content-Type")?.includes("application/json")) {
+      // Serve csrfGuard requires application/json on POST
+      headers.set("Content-Type", "application/json");
+      if (body === undefined) body = "{}";
+    }
+    const res = await this.fetchImpl(url.toString(), {
+      ...init,
+      method,
+      headers,
+      body,
+      // Avoid following serve auth 302 (token strip) into an unauthenticated hop.
+      redirect: init.redirect ?? "manual",
+    });
+    return res;
+  }
+
+  async _jsonOrEmpty(res) {
+    if (res.status === 204 || res.status === 202) {
+      return { ok: true, status: res.status };
+    }
+    const text = await res.text();
+    if (!res.ok) {
+      const err = new Error(text || res.statusText || `HTTP ${res.status}`);
+      // @ts-ignore
+      err.status = res.status;
+      // @ts-ignore
+      err.body = text;
+      throw err;
+    }
+    if (!text) return { ok: true, status: res.status };
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { ok: true, status: res.status, raw: text };
+    }
+  }
+
+  // ── P0 queries ──────────────────────────────────────────
+
+  async status() {
+    const res = await this.request(SERVE_ROUTES.status.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async history() {
+    const res = await this.request(SERVE_ROUTES.history.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async context() {
+    const res = await this.request(SERVE_ROUTES.context.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async sessions() {
+    const res = await this.request(SERVE_ROUTES.sessions.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async skills() {
+    const res = await this.request(SERVE_ROUTES.skills.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async todos() {
+    const res = await this.request(SERVE_ROUTES.todos.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async checkpoints() {
+    const res = await this.request(SERVE_ROUTES.checkpoints.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async branches() {
+    const res = await this.request(SERVE_ROUTES.branches.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async models() {
+    const res = await this.request(SERVE_ROUTES.models.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  async providerSetup() {
+    const res = await this.request(SERVE_ROUTES.providerSetup.path);
+    return this._jsonOrEmpty(res);
+  }
+
+  // ── P0 commands ─────────────────────────────────────────
+
+  async submit(input, format) {
+    const json = { input };
+    if (format) json.format = format;
+    const res = await this.request(SERVE_ROUTES.submit.path, { method: "POST", json });
+    return this._jsonOrEmpty(res);
+  }
+
+  async cancel() {
+    const res = await this.request(SERVE_ROUTES.cancel.path, { method: "POST", json: {} });
+    return this._jsonOrEmpty(res);
+  }
+
+  async approve(id, allow, session = false, persist = false) {
+    const res = await this.request(SERVE_ROUTES.approve.path, {
+      method: "POST",
+      json: { id, allow, session, persist },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async answer(id, answers) {
+    const res = await this.request(SERVE_ROUTES.answer.path, {
+      method: "POST",
+      json: { id, answers },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async setPlanMode(on) {
+    const res = await this.request(SERVE_ROUTES.plan.path, { method: "POST", json: { on: !!on } });
+    return this._jsonOrEmpty(res);
+  }
+
+  async setToolApprovalMode(mode) {
+    const res = await this.request(SERVE_ROUTES.toolApprovalMode.path, {
+      method: "POST",
+      json: { mode },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async setAutoApproveTools(on) {
+    const res = await this.request(SERVE_ROUTES.autoApproveTools.path, {
+      method: "POST",
+      json: { on: !!on },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async compact() {
+    const res = await this.request(SERVE_ROUTES.compact.path, { method: "POST", json: {} });
+    return this._jsonOrEmpty(res);
+  }
+
+  async newSession() {
+    const res = await this.request(SERVE_ROUTES.newSession.path, { method: "POST", json: {} });
+    return this._jsonOrEmpty(res);
+  }
+
+  async rewind(turn, scope) {
+    const res = await this.request(SERVE_ROUTES.rewind.path, {
+      method: "POST",
+      json: { turn, scope },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async fork(turn) {
+    const res = await this.request(SERVE_ROUTES.fork.path, { method: "POST", json: { turn } });
+    return this._jsonOrEmpty(res);
+  }
+
+  async summarize(turn) {
+    const res = await this.request(SERVE_ROUTES.summarize.path, {
+      method: "POST",
+      json: { turn },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async setGoal(goal) {
+    const res = await this.request(SERVE_ROUTES.goal.path, {
+      method: "POST",
+      json: { goal: goal ?? "" },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async clearGoal() {
+    return this.setGoal("");
+  }
+
+  async resume(path) {
+    const res = await this.request(SERVE_ROUTES.resume.path, {
+      method: "POST",
+      json: { path },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async deleteSession(path) {
+    const res = await this.request(SERVE_ROUTES.deleteSession.path, {
+      method: "POST",
+      json: { path },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  // Multi-tab
+  async listTabs() {
+    return this._jsonOrEmpty(await this.request(SERVE_ROUTES.tabs.path));
+  }
+  async createTab(body = {}) {
+    return this._jsonOrEmpty(await this.request(SERVE_ROUTES.tabsCreate.path, { method: "POST", json: body }));
+  }
+  async openProject(workspaceRoot, topicId, topicTitle) {
+    return this._jsonOrEmpty(
+      await this.request(SERVE_ROUTES.tabsOpenProject.path, {
+        method: "POST",
+        json: { workspaceRoot, topicId, topicTitle },
+      }),
+    );
+  }
+  async activateTab(id) {
+    return this._jsonOrEmpty(await this.request(tabPath(id, "activate"), { method: "POST", json: {} }));
+  }
+  async closeTab(id) {
+    return this._jsonOrEmpty(await this.request(tabPath(id, "close"), { method: "POST", json: {} }));
+  }
+  async submitTab(id, input, format) {
+    const json = { input };
+    if (format) json.format = format;
+    return this._jsonOrEmpty(await this.request(tabPath(id, "submit"), { method: "POST", json }));
+  }
+  async cancelTab(id) {
+    return this._jsonOrEmpty(await this.request(tabPath(id, "cancel"), { method: "POST", json: {} }));
+  }
+  async historyTab(id) {
+    return this._jsonOrEmpty(await this.request(tabPath(id, "history")));
+  }
+  async statusTab(id) {
+    return this._jsonOrEmpty(await this.request(tabPath(id, "status")));
+  }
+
+  async forget(path) {
+    const res = await this.request(SERVE_ROUTES.forget.path, {
+      method: "POST",
+      json: { path },
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async reloadExtensions() {
+    const res = await this.request(SERVE_ROUTES.reloadExtensions.path, {
+      method: "POST",
+      json: {},
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  async saveProviderSetup(body) {
+    const res = await this.request(SERVE_ROUTES.providerSetupSave.path, {
+      method: "POST",
+      json: body,
+    });
+    return this._jsonOrEmpty(res);
+  }
+
+  // ── Events ──────────────────────────────────────────────
+
+  /**
+   * @param {(e: Record<string, unknown>) => void} handler
+   * @returns {() => void} unsubscribe
+   */
+  onEvent(handler) {
+    this._handlers.add(handler);
+    if (!this._sseTask) {
+      this._sseTask = this._runSseLoop();
+    }
+    return () => {
+      this._handlers.delete(handler);
+      if (this._handlers.size === 0) {
+        this.dispose();
+      }
+    };
+  }
+
+  async _runSseLoop() {
+    this._abort = new AbortController();
+    const state = { pending: "" };
+    let backoff = 250;
+    while (this._handlers.size > 0 && !this._abort.signal.aborted) {
+      try {
+        const url = new URL(SERVE_ROUTES.events.path, this.baseUrl + "/");
+        url.searchParams.set("token", this.token);
+        const res = await this.fetchImpl(url.toString(), {
+          headers: {
+            Accept: "text/event-stream",
+            Cookie: `reasonix_token=${this.token}`,
+          },
+          signal: this._abort.signal,
+        });
+        if (!res.ok || !res.body) {
+          throw new Error(`SSE HTTP ${res.status}`);
+        }
+        backoff = 250;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        while (this._handlers.size > 0) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const text = decoder.decode(value, { stream: true });
+          for (const data of parseSseChunk(text, state)) {
+            const wire = mapServeEventToWire(data);
+            if (!wire) continue;
+            for (const h of this._handlers) {
+              try {
+                h(wire);
+              } catch {
+                /* handler errors must not kill the loop */
+              }
+            }
+          }
+        }
+      } catch (e) {
+        if (this._abort?.signal.aborted) break;
+        await new Promise((r) => setTimeout(r, backoff));
+        backoff = Math.min(backoff * 2, 8_000);
+      }
+    }
+    this._sseTask = null;
+  }
+
+  dispose() {
+    this._handlers.clear();
+    try {
+      this._abort?.abort();
+    } catch {
+      /* ignore */
+    }
+    this._abort = null;
+    this._sseTask = null;
+  }
+}
+
+/**
+ * Factory for scripts/tests.
+ * @param {{ baseUrl: string, token: string, fetchImpl?: typeof fetch }} opts
+ */
+export function createHttpSseHost(opts) {
+  return new HttpSseHost(opts);
+}

--- a/electron-poc/lib/mapEvent.mjs
+++ b/electron-poc/lib/mapEvent.mjs
@@ -1,0 +1,95 @@
+/**
+ * Map serve SSE JSON payloads into the desktop wire event shape.
+ *
+ * Serve broadcaster emits eventwire.ToWire JSON: top-level `kind` (not `type`),
+ * with nested `approval` / `ask` / `tool` objects. Preserve that contract so
+ * useController-style consumers work without inventing alternate keys.
+ *
+ * @param {unknown} raw
+ * @returns {Record<string, unknown> | null}
+ */
+export function mapServeEventToWire(raw) {
+  if (raw == null) return null;
+  let obj = raw;
+  if (typeof raw === "string") {
+    const s = raw.trim();
+    if (!s) return null;
+    try {
+      obj = JSON.parse(s);
+    } catch {
+      // Non-JSON SSE data: surface as notice without inventing a false kind name
+      // for structured events. Plain text is rare on the serve stream.
+      return { kind: "notice", text: s, level: "info", _transport: "http-sse" };
+    }
+  }
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return { kind: "notice", text: String(obj), level: "info", _transport: "http-sse" };
+  }
+  // Shallow clone only — nested approval/ask/tool objects stay intact.
+  const e = /** @type {Record<string, unknown>} */ ({ ...obj });
+
+  // Preserve kind. Never force type:"unknown" or invent type aliases.
+  // If a payload already has kind, leave it. Missing kind is left missing so
+  // callers can detect malformed frames rather than mis-routing as "unknown".
+  if (typeof e.kind === "string") {
+    e.kind = e.kind; // keep
+  }
+
+  // Real edge cases only: drop accidental dual type/kind inventing nothing.
+  // Some older mocks used `type`; if kind is absent but type is a known wire
+  // kind name, promote type → kind without inventing new names.
+  if ((e.kind == null || e.kind === "") && typeof e.type === "string" && e.type) {
+    const known = new Set([
+      "turn_started",
+      "reasoning",
+      "text",
+      "message",
+      "tool_dispatch",
+      "tool_result",
+      "usage",
+      "notice",
+      "phase",
+      "approval_request",
+      "ask_request",
+      "turn_done",
+      "compaction_started",
+      "compaction_done",
+      "tool_progress",
+      "retrying",
+      "steer",
+      "stream_attempt",
+    ]);
+    if (known.has(e.type)) {
+      e.kind = e.type;
+    }
+  }
+
+  e._transport = "http-sse";
+  return e;
+}
+
+/**
+ * Parse an SSE buffer chunk stream into data payloads.
+ * Handles multi-line data: fields and ignores comment lines.
+ * @param {string} chunk
+ * @param {{ pending?: string }} state mutable parse state
+ * @returns {string[]} complete data payload strings
+ */
+export function parseSseChunk(chunk, state) {
+  state.pending = (state.pending ?? "") + chunk;
+  const events = [];
+  let idx;
+  while ((idx = state.pending.indexOf("\n\n")) >= 0) {
+    const block = state.pending.slice(0, idx);
+    state.pending = state.pending.slice(idx + 2);
+    const dataLines = [];
+    for (const line of block.split(/\r?\n/)) {
+      if (line.startsWith(":")) continue; // comment / keepalive
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).replace(/^ /, ""));
+      }
+    }
+    if (dataLines.length) events.push(dataLines.join("\n"));
+  }
+  return events;
+}

--- a/electron-poc/lib/resolveReasonixBin.mjs
+++ b/electron-poc/lib/resolveReasonixBin.mjs
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Resolve a trusted reasonix binary path.
+ * Order: REASONIX_BIN env → candidates relative to repo → PATH `reasonix`.
+ * Rejects empty / non-file paths. Does not accept arbitrary UI-supplied paths
+ * unless they pass through this resolver with allowlist checks.
+ *
+ * @param {{
+ *   env?: NodeJS.ProcessEnv,
+ *   repoRoot?: string,
+ *   which?: (name: string) => string | null,
+ *   existsSync?: (p: string) => boolean,
+ *   isFile?: (p: string) => boolean,
+ * }} [opts]
+ * @returns {string}
+ */
+export function resolveReasonixBin(opts = {}) {
+  const env = opts.env ?? process.env;
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const isFile =
+    opts.isFile ??
+    ((p) => {
+      try {
+        return fs.statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+  const which =
+    opts.which ??
+    ((name) => {
+      try {
+        const out = execFileSync("which", [name], { encoding: "utf8" }).trim();
+        return out || null;
+      } catch {
+        return null;
+      }
+    });
+
+  const candidates = [];
+  if (env.REASONIX_BIN && String(env.REASONIX_BIN).trim()) {
+    candidates.push(path.resolve(String(env.REASONIX_BIN).trim()));
+  }
+  if (opts.repoRoot) {
+    const root = path.resolve(opts.repoRoot);
+    candidates.push(path.join(root, "bin", "reasonix"));
+    candidates.push(path.join(root, "bin", "reasonix.exe"));
+  }
+  // Default: walk up from this package to find repo bin/
+  const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const repoGuess = path.resolve(packageRoot, "..");
+  candidates.push(path.join(repoGuess, "bin", "reasonix"));
+  candidates.push(path.join(repoGuess, "bin", "reasonix.exe"));
+
+  const fromPath = which("reasonix");
+  if (fromPath) candidates.push(fromPath);
+
+  const seen = new Set();
+  for (const c of candidates) {
+    if (!c || seen.has(c)) continue;
+    seen.add(c);
+    if (!existsSync(c) || !isFile(c)) continue;
+    // Basic trust: basename must be reasonix or reasonix.exe
+    const base = path.basename(c).toLowerCase();
+    if (base !== "reasonix" && base !== "reasonix.exe") {
+      throw new Error(`refusing untrusted binary name: ${base}`);
+    }
+    return c;
+  }
+  throw new Error(
+    "reasonix binary not found; set REASONIX_BIN or build with `make build` / install reasonix on PATH",
+  );
+}
+
+/**
+ * Ensure a candidate path is acceptable if supplied explicitly (e.g. tests).
+ * @param {string} binPath
+ */
+export function assertTrustedReasonixBin(binPath) {
+  const base = path.basename(binPath).toLowerCase();
+  if (base !== "reasonix" && base !== "reasonix.exe") {
+    throw new Error(`refusing untrusted binary name: ${base}`);
+  }
+  if (!fs.existsSync(binPath) || !fs.statSync(binPath).isFile()) {
+    throw new Error(`reasonix binary not found at ${binPath}`);
+  }
+  return path.resolve(binPath);
+}

--- a/electron-poc/lib/routes.mjs
+++ b/electron-poc/lib/routes.mjs
@@ -1,0 +1,47 @@
+/**
+ * P0 serve route map used by HttpSseHost.
+ * Paths match internal/serve handler registration.
+ */
+export const SERVE_ROUTES = Object.freeze({
+  events: { method: "GET", path: "/events" },
+  history: { method: "GET", path: "/history" },
+  context: { method: "GET", path: "/context" },
+  status: { method: "GET", path: "/status" },
+  sessions: { method: "GET", path: "/sessions" },
+  skills: { method: "GET", path: "/skills" },
+  todos: { method: "GET", path: "/todos" },
+  checkpoints: { method: "GET", path: "/checkpoints" },
+  branches: { method: "GET", path: "/branches" },
+  models: { method: "GET", path: "/models" },
+  providerSetup: { method: "GET", path: "/provider-setup" },
+  submit: { method: "POST", path: "/submit" },
+  cancel: { method: "POST", path: "/cancel" },
+  approve: { method: "POST", path: "/approve" },
+  answer: { method: "POST", path: "/answer" },
+  plan: { method: "POST", path: "/plan" },
+  compact: { method: "POST", path: "/compact" },
+  newSession: { method: "POST", path: "/new" },
+  rewind: { method: "POST", path: "/rewind" },
+  fork: { method: "POST", path: "/fork" },
+  summarize: { method: "POST", path: "/summarize" },
+  toolApprovalMode: { method: "POST", path: "/tool-approval-mode" },
+  autoApproveTools: { method: "POST", path: "/auto-approve-tools" },
+  bypass: { method: "POST", path: "/bypass" },
+  goal: { method: "POST", path: "/goal" },
+  resume: { method: "POST", path: "/resume" },
+  forget: { method: "POST", path: "/forget" },
+  deleteSession: { method: "POST", path: "/delete-session" },
+  reloadExtensions: { method: "POST", path: "/extensions/reload" },
+  providerSetupSave: { method: "POST", path: "/provider-setup" },
+  tabs: { method: "GET", path: "/tabs" },
+  tabsCreate: { method: "POST", path: "/tabs" },
+  tabsOpenProject: { method: "POST", path: "/tabs/open-project" },
+});
+
+export function tabPath(id, suffix) {
+  const clean = suffix.startsWith("/") ? suffix : `/${suffix}`;
+  return `/tabs/${encodeURIComponent(id)}${clean}`;
+}
+
+/** Ordered list of P0 command names for docs/tests. */
+export const P0_COMMANDS = Object.freeze(Object.keys(SERVE_ROUTES));

--- a/electron-poc/lib/serveSupervisor.mjs
+++ b/electron-poc/lib/serveSupervisor.mjs
@@ -1,0 +1,347 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { assertTrustedReasonixBin, resolveReasonixBin } from "./resolveReasonixBin.mjs";
+
+/**
+ * Build argv for supervised reasonix serve (token never on argv).
+ * @param {{
+ *   tokenFile: string,
+ *   portFile: string,
+ *   pidFile: string,
+ *   addr?: string,
+ * }} files
+ * @returns {string[]}
+ */
+export function buildServeArgs(files) {
+  const addr = files.addr ?? "127.0.0.1:0";
+  if (!addr.startsWith("127.0.0.1:") && addr !== "127.0.0.1") {
+    // PoC hard-constraint: loopback only.
+    throw new Error(`serve addr must be loopback 127.0.0.1, got ${addr}`);
+  }
+  const args = [
+    "serve",
+    "--addr",
+    addr,
+    "--auth",
+    "token",
+    "--token-file",
+    files.tokenFile,
+    "--port-file",
+    files.portFile,
+    "--pid-file",
+    files.pidFile,
+  ];
+  // Electron PoC prefers multi-Controller tabs when the binary supports it.
+  if (files.multiTab !== false) {
+    args.push("--multi-tab");
+  }
+  return args;
+}
+
+/**
+ * @param {string} dir
+ * @param {{ mode?: number, tokenBytes?: number }} [opts]
+ */
+export function prepareStateDir(dir, opts = {}) {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tokenFile = path.join(dir, "token");
+  const portFile = path.join(dir, "port");
+  const pidFile = path.join(dir, "pid");
+  const logFile = path.join(dir, "serve.log");
+  const token = crypto.randomBytes(opts.tokenBytes ?? 32).toString("hex");
+  fs.writeFileSync(tokenFile, token + "\n", { mode: opts.mode ?? 0o600 });
+  // Clear stale discovery files
+  for (const f of [portFile, pidFile]) {
+    try {
+      fs.unlinkSync(f);
+    } catch {
+      /* missing ok */
+    }
+  }
+  return { dir, tokenFile, portFile, pidFile, logFile, token };
+}
+
+/**
+ * Parse host:port from port-file contents (may include trailing newline).
+ * Normalizes IPv6-style :port from Go's listener if needed.
+ * @param {string} raw
+ * @returns {{ host: string, port: number, display: string, baseUrl: string }}
+ */
+export function parsePortFileContents(raw) {
+  const line = String(raw).trim().split(/\r?\n/)[0]?.trim() ?? "";
+  if (!line) throw new Error("empty port file");
+  // Go may write 127.0.0.1:12345
+  const m = line.match(/^(127\.0\.0\.1|localhost|\[::1\]|::1):(\d+)$/i);
+  if (!m) {
+    // Also accept bare host:port if host is loopback after normalize
+    const idx = line.lastIndexOf(":");
+    if (idx <= 0) throw new Error(`invalid port file contents: ${line}`);
+    const host = line.slice(0, idx).replace(/^\[|\]$/g, "");
+    const port = Number(line.slice(idx + 1));
+    if (!Number.isFinite(port) || port <= 0) throw new Error(`invalid port: ${line}`);
+    if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") {
+      throw new Error(`non-loopback address in port file: ${line}`);
+    }
+    const displayHost = host === "::1" ? "127.0.0.1" : host === "localhost" ? "127.0.0.1" : host;
+    return {
+      host: displayHost,
+      port,
+      display: `${displayHost}:${port}`,
+      baseUrl: `http://${displayHost}:${port}`,
+    };
+  }
+  const host = m[1] === "localhost" || m[1] === "[::1]" || m[1] === "::1" ? "127.0.0.1" : m[1];
+  const port = Number(m[2]);
+  return {
+    host,
+    port,
+    display: `${host}:${port}`,
+    baseUrl: `http://${host}:${port}`,
+  };
+}
+
+/**
+ * Poll until port file is non-empty and parseable.
+ * @param {string} portFile
+ * @param {{ timeoutMs?: number, intervalMs?: number, now?: () => number, sleep?: (ms: number) => Promise<void>, readFileSync?: typeof fs.readFileSync }} [opts]
+ */
+export async function waitForPortFile(portFile, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const intervalMs = opts.intervalMs ?? 50;
+  const now = opts.now ?? Date.now;
+  const sleep =
+    opts.sleep ??
+    ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const readFileSync = opts.readFileSync ?? fs.readFileSync;
+  const start = now();
+  let lastErr = new Error("port file not ready");
+  while (now() - start < timeoutMs) {
+    try {
+      if (fs.existsSync(portFile)) {
+        const raw = readFileSync(portFile, "utf8");
+        return parsePortFileContents(raw);
+      }
+    } catch (e) {
+      lastErr = e instanceof Error ? e : new Error(String(e));
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`timed out waiting for port file ${portFile}: ${lastErr.message}`);
+}
+
+/**
+ * Build the UI URL with token query (serve sets cookie and redirects).
+ * @param {string} baseUrl
+ * @param {string} token
+ * @param {string} [pathName]
+ */
+export function buildAuthenticatedUiUrl(baseUrl, token, pathName = "/") {
+  const u = new URL(pathName, baseUrl.endsWith("/") ? baseUrl : baseUrl + "/");
+  u.searchParams.set("token", token);
+  return u.toString();
+}
+
+/**
+ * Supervises one reasonix serve child.
+ */
+export class ServeSupervisor {
+  /**
+   * @param {{
+   *   bin?: string,
+   *   stateDir?: string,
+   *   workspace?: string,
+   *   repoRoot?: string,
+   *   env?: NodeJS.ProcessEnv,
+   *   spawnImpl?: typeof spawn,
+   *   crashRestartOnce?: boolean,
+   *   onExit?: (code: number | null, signal: NodeJS.Signals | null) => void,
+   *   onCrashRestarted?: (info: Awaited<ReturnType<ServeSupervisor['start']>>) => void | Promise<void>,
+   *   onLog?: (chunk: string) => void,
+   * }} [opts]
+   */
+  constructor(opts = {}) {
+    this.opts = opts;
+    this.child = null;
+    this.state = null;
+    this.endpoint = null;
+    this._stopping = false;
+    this._didCrashRestart = false;
+    this._exitHandlers = [];
+    this._lastInfo = null;
+  }
+
+  get token() {
+    return this.state?.token ?? null;
+  }
+
+  get baseUrl() {
+    return this.endpoint?.baseUrl ?? null;
+  }
+
+  get uiUrl() {
+    if (!this.endpoint || !this.state) return null;
+    return buildAuthenticatedUiUrl(this.endpoint.baseUrl, this.state.token);
+  }
+
+  get logFile() {
+    return this.state?.logFile ?? null;
+  }
+
+  get pid() {
+    return this.child?.pid ?? null;
+  }
+
+  /**
+   * Start serve in workspace (cwd).
+   * Reuses a fixed stateDir (and thus discovery paths) across crash restarts so
+   * the host can reload the new uiUrl/token without leaking orphan dirs.
+   * @param {{ workspace?: string, fromCrashRestart?: boolean }} [override]
+   */
+  async start(override = {}) {
+    if (this.child) {
+      throw new Error("serve already running");
+    }
+    this._stopping = false;
+    const env = this.opts.env ?? process.env;
+    const bin = this.opts.bin
+      ? assertTrustedReasonixBin(this.opts.bin)
+      : resolveReasonixBin({ env, repoRoot: this.opts.repoRoot });
+    // Pin stateDir on first start so crash restart reuses the same directory.
+    if (!this.opts.stateDir) {
+      this.opts.stateDir = path.join(
+        os.tmpdir(),
+        `reasonix-electron-${process.pid}-${crypto.randomBytes(4).toString("hex")}`,
+      );
+    }
+    const stateDir = this.opts.stateDir;
+    this.state = prepareStateDir(stateDir);
+    const args = buildServeArgs({
+      tokenFile: this.state.tokenFile,
+      portFile: this.state.portFile,
+      pidFile: this.state.pidFile,
+    });
+    // Security: never put token on argv
+    if (args.includes(this.state.token) || args.some((a) => a.includes(this.state.token))) {
+      throw new Error("internal error: token leaked onto argv");
+    }
+    if (args.includes("--token")) {
+      throw new Error("must use --token-file only, not --token");
+    }
+
+    const workspace = override.workspace ?? this.opts.workspace ?? process.cwd();
+    const logFd = fs.openSync(this.state.logFile, "a");
+    const spawnImpl = this.opts.spawnImpl ?? spawn;
+    this.child = spawnImpl(bin, args, {
+      cwd: workspace,
+      env: { ...env },
+      stdio: ["ignore", logFd, logFd],
+      detached: false,
+    });
+    fs.closeSync(logFd);
+
+    this.child.on("exit", (code, signal) => {
+      const wasStopping = this._stopping;
+      this.child = null;
+      if (this.opts.onExit) this.opts.onExit(code, signal);
+      for (const h of this._exitHandlers) h(code, signal);
+      if (!wasStopping && this.opts.crashRestartOnce && !this._didCrashRestart) {
+        this._didCrashRestart = true;
+        // Restart once, then notify host so lastStart/UI can follow the new endpoint.
+        this.start({ workspace, fromCrashRestart: true })
+          .then((info) => {
+            if (typeof this.opts.onCrashRestarted === "function") {
+              return this.opts.onCrashRestarted(info);
+            }
+          })
+          .catch((err) => {
+            if (this.opts.onLog) this.opts.onLog(`crash restart failed: ${err}\n`);
+          });
+      }
+    });
+
+    try {
+      this.endpoint = await waitForPortFile(this.state.portFile, {
+        timeoutMs: Number(env.REASONIX_SERVE_READY_MS) || 45_000,
+      });
+    } catch (e) {
+      await this.stop();
+      throw e;
+    }
+    this.opts.workspace = workspace;
+    const info = {
+      baseUrl: this.endpoint.baseUrl,
+      uiUrl: this.uiUrl,
+      token: this.state.token,
+      port: this.endpoint.port,
+      pid: this.pid,
+      logFile: this.state.logFile,
+      stateDir: this.state.dir,
+      args,
+      bin,
+      workspace,
+      fromCrashRestart: !!override.fromCrashRestart,
+    };
+    this._lastInfo = info;
+    return info;
+  }
+
+  /**
+   * Restart serve with a new workspace directory.
+   * @param {string} workspace
+   */
+  async restartInWorkspace(workspace) {
+    await this.stop();
+    this._didCrashRestart = false;
+    this.opts.workspace = workspace;
+    return this.start({ workspace });
+  }
+
+  /**
+   * Graceful stop: SIGTERM then SIGKILL.
+   * @param {{ termTimeoutMs?: number }} [opts]
+   */
+  async stop(opts = {}) {
+    this._stopping = true;
+    const child = this.child;
+    if (!child || child.killed) {
+      this.child = null;
+      return;
+    }
+    const termTimeoutMs = opts.termTimeoutMs ?? 5_000;
+    await new Promise((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        resolve();
+      };
+      child.once("exit", finish);
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        finish();
+        return;
+      }
+      const t = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+        finish();
+      }, termTimeoutMs);
+      child.once("exit", () => clearTimeout(t));
+    });
+    this.child = null;
+  }
+}
+
+/**
+ * Create a default state directory under os.tmpdir or XDG.
+ */
+export function defaultStateDir() {
+  return path.join(os.tmpdir(), `reasonix-electron-${process.pid}`);
+}

--- a/electron-poc/package-lock.json
+++ b/electron-poc/package-lock.json
@@ -1,0 +1,874 @@
+{
+  "name": "reasonix-electron-serve-poc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reasonix-electron-serve-poc",
+      "version": "0.1.0",
+      "devDependencies": {
+        "electron": "^37.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "37.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.0.tgz",
+      "integrity": "sha512-dE6+qeg6SBUVd5d8CD2+GH82kh+gF1v40+hs+U+UOno681NMSGmBtgqwldQRpbvtnQDD7V2M9Cpfr3+Abw7aBg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/electron-poc/package.json
+++ b/electron-poc/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "reasonix-electron-serve-poc",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Experimental Electron shell over loopback reasonix serve (PoC, not the official desktop).",
+  "type": "module",
+  "main": "electron/main.mjs",
+  "scripts": {
+    "postinstall": "node scripts/ensure-electron.mjs || true",
+    "ensure-electron": "node scripts/ensure-electron.mjs",
+    "build:ui": "node scripts/build-desktop-ui.mjs",
+    "start": "node scripts/ensure-electron.mjs && node scripts/build-desktop-ui.mjs --if-missing && electron .",
+    "start:fast": "node scripts/ensure-electron.mjs && electron .",
+    "test": "node --test test/*.test.mjs",
+    "smoke:http": "node scripts/http-sse-smoke.mjs",
+    "smoke:launch": "node scripts/dual-launch-smoke.mjs",
+    "smoke:dual-project": "node scripts/dual-project-smoke.mjs",
+    "smoke:all": "node scripts/http-sse-smoke.mjs && node scripts/dual-launch-smoke.mjs && node scripts/dual-project-smoke.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "electron": "^37.2.0"
+  },
+  "allowScripts": {
+    "electron@37.2.0": true
+  }
+}

--- a/electron-poc/scripts/build-desktop-ui.mjs
+++ b/electron-poc/scripts/build-desktop-ui.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Build desktop/frontend into electron-poc/desktop-ui for the Electron shell.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(root, "..");
+const frontendDir = path.join(repoRoot, "desktop", "frontend");
+const outDir = path.join(root, "desktop-ui");
+const ifMissing = process.argv.includes("--if-missing");
+
+if (ifMissing && fs.existsSync(path.join(outDir, "index.html"))) {
+  console.log("desktop-ui already present, skip build");
+  process.exit(0);
+}
+
+if (!fs.existsSync(frontendDir)) {
+  console.error("desktop/frontend not found at", frontendDir);
+  process.exit(1);
+}
+
+console.log("building desktop frontend → electron-poc/desktop-ui …");
+// vite build only (skip full lint suite) for PoC iteration speed
+const r = spawnSync(
+  "pnpm",
+  ["exec", "vite", "build", "--outDir", outDir, "--emptyOutDir"],
+  {
+    cwd: frontendDir,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      REASONIX_CHANNEL: "electron-poc",
+    },
+  },
+);
+if (r.status !== 0) {
+  // fallback npm exec
+  const r2 = spawnSync(
+    "npx",
+    ["vite", "build", "--outDir", outDir, "--emptyOutDir"],
+    {
+      cwd: frontendDir,
+      stdio: "inherit",
+      env: { ...process.env, REASONIX_CHANNEL: "electron-poc" },
+    },
+  );
+  if (r2.status !== 0) process.exit(r2.status || 1);
+}
+
+if (!fs.existsSync(path.join(outDir, "index.html"))) {
+  console.error("build finished but index.html missing in", outDir);
+  process.exit(1);
+}
+console.log("desktop-ui ready:", outDir);

--- a/electron-poc/scripts/dual-launch-smoke.mjs
+++ b/electron-poc/scripts/dual-launch-smoke.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Dual launch smoke for Electron PoC supervision path (without requiring a display).
+ * Starts serve twice serially via ServeSupervisor (same code path as Electron main),
+ * asserts GET /status on discovered loopback URL with token.
+ * If Electron is available and REASONIX_POC_ELECTRON=1, also spawns electron briefly.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { ServeSupervisor } from "../lib/serveSupervisor.mjs";
+import { resolveReasonixBin } from "../lib/resolveReasonixBin.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const scratch = process.env.REASONIX_POC_SCRATCH || process.env.SCRATCH || "";
+
+function write(name, body) {
+  const text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+  if (scratch) {
+    fs.mkdirSync(scratch, { recursive: true });
+    const p = path.join(scratch, name);
+    fs.writeFileSync(p, text.endsWith("\n") ? text : text + "\n");
+    process.stdout.write(`wrote ${p}\n`);
+  } else {
+    process.stdout.write(text + (text.endsWith("\n") ? "" : "\n"));
+  }
+}
+
+async function oneLaunch(label) {
+  const lines = [`=== ${label} ===`];
+  let bin;
+  try {
+    bin = resolveReasonixBin({
+      env: process.env,
+      repoRoot: path.resolve(packageRoot, ".."),
+    });
+  } catch (e) {
+    lines.push(`UNAVAILABLE: ${e}`);
+    return { ok: false, unavailable: true, lines };
+  }
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), `rx-launch-${label}-`));
+  const sup = new ServeSupervisor({
+    bin,
+    stateDir,
+    workspace: process.env.REASONIX_WORKSPACE || process.cwd(),
+    crashRestartOnce: false,
+  });
+  try {
+    const info = await sup.start();
+    lines.push(`baseUrl=${info.baseUrl}`);
+    lines.push(`uiUrl=${info.uiUrl.replace(info.token, "<redacted>")}`);
+    lines.push(`loopback=${info.baseUrl.startsWith("http://127.0.0.1:")}`);
+    lines.push(`token_on_argv=${info.args.some((a) => a.includes(info.token))}`);
+    lines.push(`has_token_file_flag=${info.args.includes("--token-file")}`);
+
+    const statusUrl = `${info.baseUrl}/status?token=${encodeURIComponent(info.token)}`;
+    const res = await fetch(statusUrl, {
+      headers: { Cookie: `reasonix_token=${info.token}` },
+    });
+    const body = await res.text();
+    lines.push(`GET /status status=${res.status}`);
+    lines.push(`GET /status body=${body.slice(0, 400)}`);
+    const ok = res.ok && body.length > 0;
+    lines.push(`RESULT=${ok ? "OK" : "FAIL"}`);
+    return { ok, unavailable: false, lines, info };
+  } catch (e) {
+    lines.push(`RESULT=FAIL ${e instanceof Error ? e.stack || e.message : e}`);
+    return { ok: false, unavailable: false, lines };
+  } finally {
+    await sup.stop();
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+async function tryElectronOnce() {
+  const lines = ["=== electron-spawn ==="];
+  const electronPkg = path.join(packageRoot, "node_modules", "electron");
+  if (!fs.existsSync(electronPkg)) {
+    lines.push("UNAVAILABLE: electron package not installed (run pnpm/npm install in electron-poc)");
+    return { ok: false, unavailable: true, lines };
+  }
+  // Headless environments often cannot open a window; still try with short timeout.
+  const env = {
+    ...process.env,
+    ELECTRON_ENABLE_LOGGING: "1",
+  };
+  // Prefer a dry path: use ServeSupervisor only when DISPLAY missing and skip electron UI
+  if (!process.env.DISPLAY && process.platform === "linux" && process.env.REASONIX_POC_ELECTRON !== "force") {
+    lines.push("UNAVAILABLE: no DISPLAY for Electron UI on Linux");
+    return { ok: false, unavailable: true, lines };
+  }
+  const child = spawn(
+    process.platform === "win32" ? "npx.cmd" : "npx",
+    ["electron", packageRoot],
+    {
+      cwd: packageRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let out = "";
+  child.stdout.on("data", (d) => (out += d));
+  child.stderr.on("data", (d) => (out += d));
+  const result = await new Promise((resolve) => {
+    const t = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* ignore */
+      }
+      setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+        resolve({ timedOut: true });
+      }, 2000);
+    }, 8000);
+    child.on("exit", (code, signal) => {
+      clearTimeout(t);
+      resolve({ code, signal, timedOut: false });
+    });
+  });
+  lines.push(out.slice(0, 2000));
+  lines.push(`exit=${JSON.stringify(result)}`);
+  // If serve became ready, main logs "serve ready"
+  const ready = out.includes("serve ready") || out.includes("reasonix serve");
+  lines.push(`RESULT=${ready ? "OK" : result.timedOut ? "TIMEOUT_PARTIAL" : "FAIL"}`);
+  return { ok: ready || result.timedOut, unavailable: false, lines };
+}
+
+async function main() {
+  const a = await oneLaunch("launch-1");
+  write("electron-serve-launch-1.log", a.lines.join("\n"));
+  const b = await oneLaunch("launch-2");
+  write("electron-serve-launch-2.log", b.lines.join("\n"));
+
+  if (a.unavailable && b.unavailable) {
+    write(
+      "electron-serve-launch-unavailable.log",
+      ["reasonix binary unavailable for dual launch", ...a.lines, ...b.lines].join("\n"),
+    );
+    process.exitCode = 0;
+    return;
+  }
+
+  if (process.env.REASONIX_POC_ELECTRON === "1") {
+    const el = await tryElectronOnce();
+    write(
+      el.unavailable ? "electron-serve-launch-unavailable.log" : "electron-ui-spawn.log",
+      el.lines.join("\n"),
+    );
+  }
+
+  if (!a.ok || !b.ok) process.exitCode = 1;
+}
+
+main();

--- a/electron-poc/scripts/dual-project-smoke.mjs
+++ b/electron-poc/scripts/dual-project-smoke.mjs
@@ -1,0 +1,109 @@
+/**
+ * Dual-project multi-tab smoke: open two workspaces, list tree, activate each.
+ * Requires REASONIX_BIN (or repo bin/reasonix) with --multi-tab support.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ServeSupervisor } from "../lib/serveSupervisor.mjs";
+import { resolveReasonixBin } from "../lib/resolveReasonixBin.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(packageRoot, "..");
+
+async function request(baseUrl, token, p, init = {}) {
+  const url = new URL(p, baseUrl.endsWith("/") ? baseUrl : baseUrl + "/");
+  url.searchParams.set("token", token);
+  const headers = { ...(init.headers || {}), Cookie: `reasonix_token=${token}` };
+  if (init.json !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(init.json);
+  }
+  const res = await fetch(url.toString(), { ...init, headers, redirect: "manual" });
+  const text = await res.text();
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`${init.method || "GET"} ${p} -> ${res.status} ${text.slice(0, 200)}`);
+  }
+  if (!text || res.status === 204) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function main() {
+  const bin = resolveReasonixBin({ env: process.env, repoRoot });
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "rx-dual-home-"));
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), "rx-dual-a-"));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), "rx-dual-b-"));
+  fs.writeFileSync(path.join(wsA, "a.txt"), "a");
+  fs.writeFileSync(path.join(wsB, "b.txt"), "b");
+  process.env.REASONIX_HOME = home;
+  process.env.HOME = home;
+
+  const supervisor = new ServeSupervisor({
+    bin,
+    repoRoot,
+    workspace: wsA,
+    crashRestartOnce: false,
+  });
+  const info = await supervisor.start();
+  const base = info.baseUrl;
+  const token = info.token;
+  console.log("serve", base);
+
+  try {
+    const tabA = await request(base, token, "/tabs/open-project", {
+      method: "POST",
+      json: { workspaceRoot: wsA, topicId: "main", topicTitle: "A" },
+    });
+    const tabB = await request(base, token, "/tabs/open-project", {
+      method: "POST",
+      json: { workspaceRoot: wsB, topicId: "main", topicTitle: "B" },
+    });
+    if (!tabA?.id || !tabB?.id) throw new Error("open-project missing id");
+    if (tabA.id === tabB.id) throw new Error("expected distinct tabs");
+
+    const tabs = await request(base, token, "/tabs");
+    if (!Array.isArray(tabs) || tabs.length < 2) throw new Error(`tabs=${JSON.stringify(tabs)}`);
+
+    await request(base, token, `/tabs/${tabA.id}/activate`, { method: "POST", json: {} });
+    await request(base, token, `/tabs/${tabB.id}/activate`, { method: "POST", json: {} });
+
+    const topic = await request(base, token, "/desktop/topics", {
+      method: "POST",
+      json: { scope: "project", workspaceRoot: wsA, title: "Smoke Topic" },
+    });
+    if (!topic?.id) throw new Error("create topic failed");
+
+    const tree = await request(base, token, "/desktop/project-tree");
+    if (!Array.isArray(tree) || tree.length < 2) {
+      throw new Error(`project-tree too small: ${JSON.stringify(tree)}`);
+    }
+
+    const startup = await request(base, token, "/desktop/startup-settings");
+    if (!startup || typeof startup !== "object") throw new Error("startup-settings missing");
+
+    console.log("PASS dual-project smoke", {
+      tabs: tabs.length,
+      tree: tree.length,
+      topic: topic.id,
+      workspaces: [wsA, wsB],
+    });
+  } finally {
+    await supervisor.stop?.().catch(() => {});
+    try {
+      process.kill(info.pid, "SIGTERM");
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("FAIL", e);
+  process.exit(1);
+});

--- a/electron-poc/scripts/ensure-electron.mjs
+++ b/electron-poc/scripts/ensure-electron.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Ensure Electron dist + path.txt exist (npm allow-scripts can skip postinstall).
+ * Extracts from @electron/get cache when present, otherwise downloads.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const electronDir = path.join(root, "node_modules", "electron");
+const distDir = path.join(electronDir, "dist");
+const pathTxt = path.join(electronDir, "path.txt");
+
+function platformPath() {
+  if (process.platform === "darwin") return "Electron.app/Contents/MacOS/Electron";
+  if (process.platform === "win32") return "electron.exe";
+  return "electron";
+}
+
+function isReady() {
+  if (!fs.existsSync(pathTxt)) return false;
+  const rel = fs.readFileSync(pathTxt, "utf8").trim();
+  const abs = path.join(distDir, rel);
+  return fs.existsSync(abs);
+}
+
+async function main() {
+  if (!fs.existsSync(electronDir)) {
+    console.error("electron package missing; run npm install in electron-poc first");
+    process.exit(1);
+  }
+  if (isReady()) {
+    console.log("electron dist ready:", fs.readFileSync(pathTxt, "utf8").trim());
+    return;
+  }
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(electronDir, "package.json"), "utf8"));
+  const version = pkg.version;
+  let zipPath;
+  try {
+    const { downloadArtifact } = require(path.join(electronDir, "node_modules", "@electron/get"));
+    // @electron/get may live at top-level node_modules
+    zipPath = await downloadArtifact({
+      version,
+      artifactName: "electron",
+      platform: process.platform,
+      arch: process.arch,
+    });
+  } catch {
+    const { downloadArtifact } = require("@electron/get");
+    zipPath = await downloadArtifact({
+      version,
+      artifactName: "electron",
+      platform: process.platform,
+      arch: process.arch,
+    });
+  }
+  console.log("downloaded", zipPath);
+  fs.rmSync(distDir, { recursive: true, force: true });
+  fs.mkdirSync(distDir, { recursive: true });
+  const unzip = spawnSync("unzip", ["-q", zipPath, "-d", distDir], { encoding: "utf8" });
+  if (unzip.status !== 0) {
+    // Windows fallback: powershell Expand-Archive not handled; try node extract via unzip error
+    console.error(unzip.stderr || unzip.stdout);
+    process.exit(1);
+  }
+  fs.writeFileSync(pathTxt, platformPath());
+  if (!isReady()) {
+    console.error("electron still not ready after extract");
+    process.exit(1);
+  }
+  console.log("electron dist ready:", platformPath());
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/electron-poc/scripts/http-sse-smoke.mjs
+++ b/electron-poc/scripts/http-sse-smoke.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Live smoke: supervise real reasonix serve (if available) and exercise HttpSseHost P0 calls.
+ * Writes a machine-readable summary to SCRATCH when REASONIX_POC_SCRATCH is set.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { ServeSupervisor } from "../lib/serveSupervisor.mjs";
+import { HttpSseHost } from "../lib/httpSseHost.mjs";
+import { resolveReasonixBin } from "../lib/resolveReasonixBin.mjs";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(packageRoot, "..");
+
+const scratch =
+  process.env.REASONIX_POC_SCRATCH ||
+  process.env.SCRATCH ||
+  "";
+
+function writeLog(name, body) {
+  if (!scratch) {
+    process.stdout.write(body);
+    return;
+  }
+  fs.mkdirSync(scratch, { recursive: true });
+  const p = path.join(scratch, name);
+  fs.writeFileSync(p, body);
+  process.stdout.write(`wrote ${p}\n`);
+}
+
+async function main() {
+  let bin;
+  try {
+    bin = resolveReasonixBin({
+      env: process.env,
+      repoRoot,
+    });
+  } catch (e) {
+    const msg = `UNAVAILABLE: reasonix binary not found: ${e}\n`;
+    writeLog("http-sse-smoke.log", msg);
+    process.exitCode = 0; // honest unavailability is OK for criterion 5
+    return;
+  }
+
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-smoke-"));
+  const workspace = process.env.REASONIX_WORKSPACE || process.cwd();
+  const sup = new ServeSupervisor({
+    bin,
+    stateDir,
+    workspace,
+    crashRestartOnce: false,
+  });
+
+  const lines = [];
+  lines.push(`bin=${bin}`);
+  lines.push(`workspace=${workspace}`);
+  try {
+    const info = await sup.start();
+    lines.push(`baseUrl=${info.baseUrl}`);
+    lines.push(`pid=${info.pid}`);
+    lines.push(`uiUrl_has_token=${info.uiUrl.includes("token=")}`);
+    lines.push(`argv_has_--token=${info.args.includes("--token")}`);
+    lines.push(`argv_has_token_value=${info.args.some((a) => a.includes(info.token))}`);
+
+    const host = new HttpSseHost({ baseUrl: info.baseUrl, token: info.token });
+    try {
+      const status = await host.status();
+      lines.push(`status_ok=${JSON.stringify(status).slice(0, 200)}`);
+      const hist = await host.history();
+      lines.push(`history_type=${Array.isArray(hist) ? "array" : typeof hist}`);
+      // cancel is always safe
+      await host.cancel();
+      lines.push("cancel=ok");
+      // new session may succeed
+      try {
+        await host.newSession();
+        lines.push("newSession=ok");
+      } catch (e) {
+        lines.push(`newSession=err:${e instanceof Error ? e.message : e}`);
+      }
+      // events: wait for connected stream (may be quiet)
+      let sawEvent = false;
+      await new Promise((resolve) => {
+        const t = setTimeout(resolve, 1500);
+        const unsub = host.onEvent((e) => {
+          sawEvent = true;
+          lines.push(`event_type=${e.type}`);
+          clearTimeout(t);
+          unsub();
+          resolve();
+        });
+      });
+      lines.push(`sse_event_seen=${sawEvent}`);
+      // optional submit only if REASONIX_POC_SUBMIT=1 (avoids burning API)
+      if (process.env.REASONIX_POC_SUBMIT === "1") {
+        await host.submit("ping from electron-poc smoke");
+        lines.push("submit=ok");
+      } else {
+        lines.push("submit=skipped (set REASONIX_POC_SUBMIT=1 to enable)");
+      }
+    } finally {
+      host.dispose();
+    }
+    lines.push("RESULT=OK");
+    writeLog("http-sse-smoke.log", lines.join("\n") + "\n");
+  } catch (e) {
+    lines.push(`RESULT=FAIL ${e instanceof Error ? e.stack || e.message : e}`);
+    writeLog("http-sse-smoke.log", lines.join("\n") + "\n");
+    process.exitCode = 1;
+  } finally {
+    await sup.stop();
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+main();

--- a/electron-poc/test/capabilities.test.mjs
+++ b/electron-poc/test/capabilities.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  POC_CAPABILITIES,
+  isCapabilityEnabled,
+  unsupportedDesktopFeatures,
+} from "../lib/capabilities.mjs";
+
+test("PoC enables multi-tab/httpSse and disables terminal/remote/bot", () => {
+  assert.equal(POC_CAPABILITIES.multiTab, true);
+  assert.equal(POC_CAPABILITIES.singleSession, false);
+  assert.equal(POC_CAPABILITIES.terminal, false);
+  assert.equal(POC_CAPABILITIES.remote, false);
+  assert.equal(POC_CAPABILITIES.bot, false);
+  assert.equal(POC_CAPABILITIES.httpSse, true);
+  assert.equal(isCapabilityEnabled(POC_CAPABILITIES, "toolApproval"), true);
+  assert.equal(isCapabilityEnabled(POC_CAPABILITIES, "terminal"), false);
+});
+
+test("unsupportedDesktopFeatures lists deferred Wails-only surfaces", () => {
+  const deferred = unsupportedDesktopFeatures();
+  for (const f of ["terminal", "remote", "bot", "heartbeat", "steer"]) {
+    assert.ok(deferred.includes(f), `expected ${f} deferred`);
+  }
+  assert.ok(!deferred.includes("multiTab"), "multiTab is enabled in PoC");
+  assert.ok(!deferred.includes("httpSse"));
+});

--- a/electron-poc/test/desktopShell.test.mjs
+++ b/electron-poc/test/desktopShell.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { describe, it } from "node:test";
+import { withReasonixTokenCookie, startDesktopShell } from "../lib/desktopShell.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("withReasonixTokenCookie", () => {
+  it("sets token when cookie missing", () => {
+    assert.equal(withReasonixTokenCookie(undefined, "abc"), "reasonix_token=abc");
+    assert.equal(withReasonixTokenCookie("", "abc"), "reasonix_token=abc");
+  });
+
+  it("overwrites a stale reasonix_token instead of keeping it", () => {
+    const stale = "reasonix_token=deadbeef; other=1";
+    assert.equal(withReasonixTokenCookie(stale, "live"), "other=1; reasonix_token=live");
+  });
+
+  it("preserves unrelated cookies", () => {
+    assert.equal(
+      withReasonixTokenCookie("foo=bar; baz=qux", "t1"),
+      "foo=bar; baz=qux; reasonix_token=t1",
+    );
+  });
+});
+
+describe("desktopShell proxy auth", () => {
+  it("returns 200 for API even when browser sends a stale reasonix_token cookie", async () => {
+    const serveToken = "correct-serve-token-32chars-xxxxxx";
+    let sawCookie = "";
+    const serve = http.createServer((req, res) => {
+      sawCookie = String(req.headers.cookie || "");
+      // Mimic reasonix serve token-mode: only exact cookie works.
+      if (sawCookie.includes(`reasonix_token=${serveToken}`)) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      // Query-token path would 302; we assert shell uses cookie instead.
+      res.writeHead(401, { "Content-Type": "text/plain" });
+      res.end("Unauthorized\n");
+    });
+    await new Promise((r) => serve.listen(0, "127.0.0.1", r));
+    const servePort = serve.address().port;
+
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rx-shell-ui-"));
+    fs.writeFileSync(path.join(tmp, "index.html"), "<!doctype html><html><head></head><body>ok</body></html>");
+
+    const shell = await startDesktopShell({
+      staticDir: tmp,
+      serveBaseUrl: `http://127.0.0.1:${servePort}`,
+      token: serveToken,
+      workspace: tmp,
+    });
+
+    try {
+      // Browser-like: stale cookie + wrong/old query token (HttpSseHost still attaches both).
+      const res = await fetch(`${shell.baseUrl}/status?token=stale-client-token`, {
+        headers: {
+          Cookie: "reasonix_token=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        },
+      });
+      const body = await res.text();
+      assert.equal(res.status, 200, `status=${res.status} body=${body}`);
+      assert.match(body, /"ok"\s*:\s*true/);
+      assert.match(sawCookie, new RegExp(`reasonix_token=${serveToken}`));
+      assert.doesNotMatch(sawCookie, /deadbeef/);
+
+      // Set-Cookie from serve must not leak to the shell origin.
+      assert.equal(res.headers.get("set-cookie"), null);
+    } finally {
+      await shell.close();
+      await new Promise((r) => serve.close(() => r()));
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("POST /tabs/open-project succeeds with stale browser cookie", async () => {
+    const serveToken = "correct-serve-token-32chars-yyyyyy";
+    const serve = http.createServer((req, res) => {
+      const cookie = String(req.headers.cookie || "");
+      if (!cookie.includes(`reasonix_token=${serveToken}`)) {
+        res.writeHead(401);
+        res.end("Unauthorized\n");
+        return;
+      }
+      if (req.method === "POST" && req.url?.startsWith("/tabs/open-project")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "tab_1", scope: "project", workspaceRoot: "/tmp/p", ready: true }));
+        return;
+      }
+      res.writeHead(404);
+      res.end("no");
+    });
+    await new Promise((r) => serve.listen(0, "127.0.0.1", r));
+    const servePort = serve.address().port;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rx-shell-ui-"));
+    fs.writeFileSync(path.join(tmp, "index.html"), "<!doctype html><html></html>");
+    const shell = await startDesktopShell({
+      staticDir: tmp,
+      serveBaseUrl: `http://127.0.0.1:${servePort}`,
+      token: serveToken,
+    });
+    try {
+      const res = await fetch(`${shell.baseUrl}/tabs/open-project`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: "reasonix_token=stale-stale-stale-stale-stale-stale-stale-stale",
+        },
+        body: JSON.stringify({ workspaceRoot: "/tmp/p" }),
+      });
+      assert.equal(res.status, 200, await res.clone().text());
+      const json = await res.json();
+      assert.equal(json.id, "tab_1");
+    } finally {
+      await shell.close();
+      await new Promise((r) => serve.close(() => r()));
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/electron-poc/test/httpSseHost.test.mjs
+++ b/electron-poc/test/httpSseHost.test.mjs
@@ -1,0 +1,352 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { HttpSseHost } from "../lib/httpSseHost.mjs";
+import { SERVE_ROUTES, P0_COMMANDS } from "../lib/routes.mjs";
+import { mapServeEventToWire, parseSseChunk } from "../lib/mapEvent.mjs";
+
+/**
+ * eventwire-shaped samples as emitted by serve Broadcaster (json.Marshal(ToWire)).
+ * See internal/eventwire/wire.go — kind top-level, nested approval/ask.
+ */
+const WIRE_TEXT = { kind: "text", text: "hello" };
+const WIRE_APPROVAL = {
+  kind: "approval_request",
+  approval: {
+    id: "a1",
+    tool: "shell",
+    subject: "ls -la",
+    reason: "ask",
+    kind: "tool",
+  },
+};
+const WIRE_ASK = {
+  kind: "ask_request",
+  ask: {
+    id: "q1",
+    questions: [{ id: "q", prompt: "continue?", options: ["yes", "no"] }],
+  },
+};
+
+/**
+ * Minimal fake reasonix serve surface for host tests.
+ * Exercises the real HttpSseHost against real HTTP — not a stub of the host.
+ */
+function startFakeServe() {
+  const posts = [];
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const token = url.searchParams.get("token") || cookieToken(req.headers.cookie);
+    if (token !== "secret-token") {
+      res.writeHead(401);
+      res.end("unauthorized");
+      return;
+    }
+    if (req.method === "POST") {
+      const ct = req.headers["content-type"] ?? "";
+      if (!ct.includes("application/json")) {
+        res.writeHead(415);
+        res.end("Content-Type must be application/json");
+        return;
+      }
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        posts.push({ path: url.pathname, body, method: req.method });
+        if (url.pathname === "/submit") {
+          res.writeHead(202);
+          res.end();
+          return;
+        }
+        res.writeHead(204);
+        res.end();
+      });
+      return;
+    }
+    if (url.pathname === "/status") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ label: "fake", ok: true }));
+      return;
+    }
+    if (url.pathname === "/tabs" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify([
+          {
+            id: "tab_a",
+            scope: "project",
+            workspaceRoot: "/a",
+            workspaceName: "a",
+            topicId: "main",
+            topicTitle: "Session",
+            label: "A",
+            ready: true,
+            running: false,
+            cancellable: false,
+            mode: "agent",
+            collaborationMode: "default",
+            toolApprovalMode: "ask",
+            tokenMode: "auto",
+            active: true,
+            cwd: "/a",
+          },
+          {
+            id: "tab_b",
+            scope: "project",
+            workspaceRoot: "/b",
+            workspaceName: "b",
+            topicId: "main",
+            topicTitle: "Session",
+            label: "B",
+            ready: true,
+            running: false,
+            cancellable: false,
+            mode: "agent",
+            collaborationMode: "default",
+            toolApprovalMode: "ask",
+            tokenMode: "auto",
+            active: false,
+            cwd: "/b",
+          },
+        ]),
+      );
+      return;
+    }
+    if (url.pathname.startsWith("/tabs/") && url.pathname.endsWith("/submit") && req.method === "POST") {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        posts.push({ path: url.pathname, body, method: req.method });
+        res.writeHead(202);
+        res.end();
+      });
+      return;
+    }
+    if (url.pathname === "/history") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify([{ role: "user", content: "hi" }]));
+      return;
+    }
+    if (url.pathname === "/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write(": connected\n\n");
+      // Real serve wire shape (kind + nested approval), not fictional type/request_id
+      res.write(`data: ${JSON.stringify(WIRE_TEXT)}\n\n`);
+      res.write(`data: ${JSON.stringify(WIRE_APPROVAL)}\n\n`);
+      res.write(`data: ${JSON.stringify(WIRE_ASK)}\n\n`);
+      setTimeout(() => res.end(), 50);
+      return;
+    }
+    if (
+      [
+        "/context",
+        "/sessions",
+        "/skills",
+        "/todos",
+        "/checkpoints",
+        "/branches",
+        "/models",
+        "/provider-setup",
+      ].includes(url.pathname)
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ path: url.pathname, ok: true }));
+      return;
+    }
+    res.writeHead(404);
+    res.end("nope");
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({
+        server,
+        port,
+        baseUrl: `http://127.0.0.1:${port}`,
+        posts,
+        close: () => new Promise((r) => server.close(() => r(undefined))),
+      });
+    });
+  });
+}
+
+function cookieToken(cookieHeader) {
+  if (!cookieHeader) return "";
+  const m = String(cookieHeader).match(/reasonix_token=([^;]+)/);
+  return m ? m[1] : "";
+}
+
+test("P0 route table covers required serve paths", () => {
+  const paths = new Set(Object.values(SERVE_ROUTES).map((r) => r.path));
+  for (const need of [
+    "/events",
+    "/submit",
+    "/cancel",
+    "/approve",
+    "/answer",
+    "/history",
+    "/context",
+    "/status",
+    "/new",
+    "/compact",
+    "/rewind",
+    "/checkpoints",
+    "/fork",
+    "/summarize",
+    "/plan",
+    "/tool-approval-mode",
+    "/goal",
+    "/sessions",
+    "/delete-session",
+    "/resume",
+    "/models",
+    "/todos",
+    "/skills",
+    "/provider-setup",
+  ]) {
+    assert.ok(paths.has(need), `missing route ${need}`);
+  }
+  assert.ok(P0_COMMANDS.length >= 20);
+});
+
+test("HttpSseHost status/history/submit/cancel/approve hit real HTTP with JSON Content-Type", async () => {
+  const fake = await startFakeServe();
+  try {
+    const host = new HttpSseHost({ baseUrl: fake.baseUrl, token: "secret-token" });
+    const st = await host.status();
+    assert.equal(st.ok, true);
+    assert.equal(st.label, "fake");
+
+    const hist = await host.history();
+    assert.ok(Array.isArray(hist));
+    assert.equal(hist[0].content, "hi");
+
+    await host.submit("hello world");
+    await host.cancel();
+    await host.approve("id1", true, false, false);
+    await host.answer("q1", [{ id: "a", values: ["x"] }]);
+    await host.setPlanMode(true);
+    await host.setToolApprovalMode("ask");
+    await host.newSession();
+    await host.compact();
+    await host.setGoal("ship it");
+
+    assert.ok(fake.posts.some((p) => p.path === "/submit"));
+    const submit = fake.posts.find((p) => p.path === "/submit");
+    assert.equal(JSON.parse(submit.body).input, "hello world");
+    assert.ok(fake.posts.some((p) => p.path === "/cancel"));
+    assert.ok(fake.posts.some((p) => p.path === "/approve"));
+    assert.ok(fake.posts.some((p) => p.path === "/answer"));
+    assert.ok(fake.posts.some((p) => p.path === "/plan"));
+    assert.ok(fake.posts.some((p) => p.path === "/tool-approval-mode"));
+    assert.ok(fake.posts.some((p) => p.path === "/new"));
+    assert.ok(fake.posts.some((p) => p.path === "/compact"));
+    assert.ok(fake.posts.some((p) => p.path === "/goal"));
+    host.dispose();
+  } finally {
+    await fake.close();
+  }
+});
+
+test("HttpSseHost rejects non-JSON POST at server (csrf) when Content-Type wrong", async () => {
+  const fake = await startFakeServe();
+  try {
+    const url = `${fake.baseUrl}/submit?token=secret-token`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain", Cookie: "reasonix_token=secret-token" },
+      body: '{"input":"x"}',
+    });
+    assert.equal(res.status, 415);
+  } finally {
+    await fake.close();
+  }
+});
+
+test("HttpSseHost SSE preserves eventwire kind and nested approval.id/ask.id", async () => {
+  const fake = await startFakeServe();
+  try {
+    const host = new HttpSseHost({ baseUrl: fake.baseUrl, token: "secret-token" });
+    const events = [];
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error("sse timeout")), 3000);
+      const unsub = host.onEvent((e) => {
+        events.push(e);
+        if (events.length >= 3) {
+          clearTimeout(t);
+          unsub();
+          resolve();
+        }
+      });
+    });
+    // text
+    assert.equal(events[0].kind, "text");
+    assert.equal(events[0].text, "hello");
+    assert.equal(events[0].type, undefined); // do not invent type
+    assert.equal(events[0]._transport, "http-sse");
+    // approval_request with nested approval.id
+    assert.equal(events[1].kind, "approval_request");
+    assert.ok(events[1].approval && typeof events[1].approval === "object");
+    assert.equal(events[1].approval.id, "a1");
+    assert.equal(events[1].approval.tool, "shell");
+    assert.equal(events[1].id, undefined); // id is nested, not top-level
+    // ask_request with nested ask.id
+    assert.equal(events[2].kind, "ask_request");
+    assert.equal(events[2].ask.id, "q1");
+    host.dispose();
+  } finally {
+    await fake.close();
+  }
+});
+
+test("HttpSseHost listTabs and submitTab hit multi-tab routes", async () => {
+  const fake = await startFakeServe();
+  try {
+    const host = new HttpSseHost({ baseUrl: fake.baseUrl, token: "secret-token" });
+    const tabs = await host.listTabs();
+    assert.ok(Array.isArray(tabs));
+    assert.equal(tabs.length, 2);
+    assert.equal(tabs[0].id, "tab_a");
+    await host.submitTab("tab_a", "hello multi");
+    assert.ok(fake.posts.some((p) => p.path === "/tabs/tab_a/submit"));
+    const submit = fake.posts.find((p) => p.path === "/tabs/tab_a/submit");
+    assert.equal(JSON.parse(submit.body).input, "hello multi");
+    host.dispose();
+  } finally {
+    await fake.close();
+  }
+});
+
+test("mapServeEventToWire preserves kind-based eventwire payloads", () => {
+  const state = { pending: "" };
+  const payloads = parseSseChunk(
+    `: ping\n\ndata: ${JSON.stringify(WIRE_TEXT)}\n\ndata: ${JSON.stringify(WIRE_APPROVAL)}\n\n partial`,
+    state,
+  );
+  assert.equal(payloads.length, 2);
+  assert.ok(state.pending.includes("partial"));
+
+  const text = mapServeEventToWire(payloads[0]);
+  assert.equal(text.kind, "text");
+  assert.equal(text.text, "hello");
+  assert.equal(text.type, undefined);
+  assert.equal(text._transport, "http-sse");
+
+  const appr = mapServeEventToWire(payloads[1]);
+  assert.equal(appr.kind, "approval_request");
+  assert.equal(appr.approval.id, "a1");
+  assert.equal(appr.approval.tool, "shell");
+  // Must not force type:"unknown" or flatten id to top-level
+  assert.notEqual(appr.type, "unknown");
+  assert.equal(appr.id, undefined);
+
+  // Object form (already parsed)
+  const direct = mapServeEventToWire(WIRE_ASK);
+  assert.equal(direct.kind, "ask_request");
+  assert.equal(direct.ask.id, "q1");
+});

--- a/electron-poc/test/resolveReasonixBin.test.mjs
+++ b/electron-poc/test/resolveReasonixBin.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { resolveReasonixBin, assertTrustedReasonixBin } from "../lib/resolveReasonixBin.mjs";
+
+test("resolveReasonixBin prefers REASONIX_BIN when file exists", () => {
+  const fake = path.join("/tmp", "reasonix");
+  const bin = resolveReasonixBin({
+    env: { REASONIX_BIN: fake },
+    existsSync: (p) => p === fake,
+    isFile: (p) => p === fake,
+    which: () => null,
+  });
+  assert.equal(bin, path.resolve(fake));
+});
+
+test("resolveReasonixBin rejects untrusted basename even if REASONIX_BIN set", () => {
+  assert.throws(
+    () =>
+      resolveReasonixBin({
+        env: { REASONIX_BIN: "/evil/malware" },
+        existsSync: () => true,
+        isFile: () => true,
+        which: () => null,
+      }),
+    /untrusted binary name/,
+  );
+});
+
+test("resolveReasonixBin falls back to PATH which()", () => {
+  const fromPath = "/usr/local/bin/reasonix";
+  const bin = resolveReasonixBin({
+    env: {},
+    existsSync: (p) => p === fromPath,
+    isFile: (p) => p === fromPath,
+    which: (name) => (name === "reasonix" ? fromPath : null),
+  });
+  assert.equal(bin, fromPath);
+});
+
+test("assertTrustedReasonixBin rejects non-reasonix names", () => {
+  assert.throws(() => assertTrustedReasonixBin("/bin/sh"), /untrusted/);
+});

--- a/electron-poc/test/serveSupervisor.test.mjs
+++ b/electron-poc/test/serveSupervisor.test.mjs
@@ -1,0 +1,217 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+import {
+  buildServeArgs,
+  prepareStateDir,
+  parsePortFileContents,
+  waitForPortFile,
+  buildAuthenticatedUiUrl,
+  ServeSupervisor,
+} from "../lib/serveSupervisor.mjs";
+
+test("buildServeArgs uses loopback, token-file, port-file, pid-file; no --token", () => {
+  const args = buildServeArgs({
+    tokenFile: "/state/token",
+    portFile: "/state/port",
+    pidFile: "/state/pid",
+  });
+  assert.deepEqual(args, [
+    "serve",
+    "--addr",
+    "127.0.0.1:0",
+    "--auth",
+    "token",
+    "--token-file",
+    "/state/token",
+    "--port-file",
+    "/state/port",
+    "--pid-file",
+    "/state/pid",
+    "--multi-tab",
+  ]);
+  assert.ok(!args.includes("--token"));
+  assert.ok(args.includes("--multi-tab"));
+  assert.ok(!args.some((a) => a === "token" && args[args.indexOf(a) - 1] === "--token"));
+});
+
+test("buildServeArgs rejects non-loopback addr", () => {
+  assert.throws(
+    () =>
+      buildServeArgs({
+        tokenFile: "t",
+        portFile: "p",
+        pidFile: "i",
+        addr: "0.0.0.0:0",
+      }),
+    /loopback/,
+  );
+});
+
+test("prepareStateDir writes token with restricted mode and clears port/pid", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-sup-"));
+  const st = prepareStateDir(dir);
+  assert.ok(fs.existsSync(st.tokenFile));
+  const tok = fs.readFileSync(st.tokenFile, "utf8").trim();
+  assert.ok(tok.length >= 32);
+  assert.equal(st.token, tok);
+  const mode = fs.statSync(st.tokenFile).mode & 0o777;
+  // On some CI umask may soften mode; require owner-read at least and not world-writable
+  assert.ok((mode & 0o400) !== 0);
+  assert.ok((mode & 0o002) === 0);
+  fs.writeFileSync(st.portFile, "stale");
+  fs.writeFileSync(st.pidFile, "1");
+  const st2 = prepareStateDir(dir);
+  assert.ok(!fs.existsSync(st2.portFile));
+  assert.ok(!fs.existsSync(st2.pidFile));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("parsePortFileContents accepts 127.0.0.1:port", () => {
+  const p = parsePortFileContents("127.0.0.1:54321\n");
+  assert.equal(p.port, 54321);
+  assert.equal(p.baseUrl, "http://127.0.0.1:54321");
+});
+
+test("parsePortFileContents rejects non-loopback", () => {
+  assert.throws(() => parsePortFileContents("8.8.8.8:80"), /non-loopback|invalid/);
+});
+
+test("waitForPortFile reads file written after start", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-port-"));
+  const portFile = path.join(dir, "port");
+  const p = waitForPortFile(portFile, { timeoutMs: 2000, intervalMs: 20 });
+  setTimeout(() => fs.writeFileSync(portFile, "127.0.0.1:19090\n"), 40);
+  const got = await p;
+  assert.equal(got.port, 19090);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("buildAuthenticatedUiUrl includes token query", () => {
+  const u = buildAuthenticatedUiUrl("http://127.0.0.1:9", "abc");
+  assert.ok(u.includes("token=abc"));
+  assert.ok(u.startsWith("http://127.0.0.1:9"));
+});
+
+test("ServeSupervisor.start spawns with correct args and waits for port-file", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-child-"));
+  const fakeBin = path.join(dir, "reasonix");
+  fs.writeFileSync(fakeBin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  /** @type {string[] | null} */
+  let seenArgs = null;
+  let childRef = null;
+
+  const spawnImpl = (bin, args) => {
+    seenArgs = args;
+    const ee = new EventEmitter();
+    ee.pid = 4242;
+    ee.killed = false;
+    ee.kill = () => {
+      ee.killed = true;
+      process.nextTick(() => ee.emit("exit", 0, null));
+      return true;
+    };
+    childRef = ee;
+    // Simulate serve writing port-file shortly after spawn
+    const portIdx = args.indexOf("--port-file");
+    const portFile = args[portIdx + 1];
+    setTimeout(() => fs.writeFileSync(portFile, "127.0.0.1:18787\n"), 30);
+    return ee;
+  };
+
+  const sup = new ServeSupervisor({
+    bin: fakeBin,
+    stateDir: path.join(dir, "state"),
+    workspace: dir,
+    spawnImpl,
+    crashRestartOnce: false,
+  });
+  const info = await sup.start();
+  assert.ok(seenArgs);
+  assert.equal(seenArgs[0], "serve");
+  assert.ok(seenArgs.includes("--token-file"));
+  assert.ok(seenArgs.includes("--port-file"));
+  assert.ok(seenArgs.includes("--pid-file"));
+  assert.ok(!seenArgs.includes("--token"));
+  // token must not appear on argv
+  const token = info.token;
+  assert.ok(!seenArgs.some((a) => a.includes(token)));
+  assert.equal(info.port, 18787);
+  assert.equal(info.baseUrl, "http://127.0.0.1:18787");
+  assert.ok(info.uiUrl.includes("token="));
+  assert.ok(fs.existsSync(info.logFile));
+
+  await sup.stop({ termTimeoutMs: 500 });
+  assert.equal(sup.pid, null);
+  assert.ok(childRef.killed || childRef.listenerCount("exit") >= 0);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("crash-restart reuses stateDir and invokes onCrashRestarted with new endpoint", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-crash-"));
+  const fakeBin = path.join(dir, "reasonix");
+  fs.writeFileSync(fakeBin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+  let spawnCount = 0;
+  let portSeq = 19000;
+  /** @type {import('node:events').EventEmitter[]} */
+  const children = [];
+
+  const spawnImpl = (_bin, args) => {
+    spawnCount += 1;
+    const ee = new EventEmitter();
+    ee.pid = 5000 + spawnCount;
+    ee.killed = false;
+    ee.kill = () => {
+      ee.killed = true;
+      process.nextTick(() => ee.emit("exit", 0, null));
+      return true;
+    };
+    children.push(ee);
+    const portFile = args[args.indexOf("--port-file") + 1];
+    const port = portSeq++;
+    setTimeout(() => fs.writeFileSync(portFile, `127.0.0.1:${port}\n`), 20);
+    return ee;
+  };
+
+  /** @type {object | null} */
+  let restartedInfo = null;
+  const stateDir = path.join(dir, "state");
+  const sup = new ServeSupervisor({
+    bin: fakeBin,
+    stateDir,
+    workspace: dir,
+    spawnImpl,
+    crashRestartOnce: true,
+    onCrashRestarted: (info) => {
+      restartedInfo = info;
+    },
+  });
+
+  const first = await sup.start();
+  assert.equal(first.stateDir, stateDir);
+  assert.equal(spawnCount, 1);
+
+  // Simulate unexpected crash (not stop())
+  const firstChild = children[0];
+  firstChild.emit("exit", 1, null);
+
+  // Wait for crash restart + callback
+  const deadline = Date.now() + 3000;
+  while (!restartedInfo && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 30));
+  }
+  assert.ok(restartedInfo, "onCrashRestarted must fire with new start info");
+  assert.equal(restartedInfo.fromCrashRestart, true);
+  assert.equal(restartedInfo.stateDir, stateDir, "must reuse fixed stateDir");
+  assert.notEqual(restartedInfo.port, first.port, "new port after restart");
+  assert.ok(restartedInfo.uiUrl.includes("token="));
+  assert.equal(spawnCount, 2);
+
+  await sup.stop({ termTimeoutMs: 500 });
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/electron-poc/test/structural.test.mjs
+++ b/electron-poc/test/structural.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+test("Electron main enforces isolation and single-instance", () => {
+  const main = fs.readFileSync(path.join(root, "electron/main.mjs"), "utf8");
+  assert.match(main, /contextIsolation:\s*true/);
+  assert.match(main, /nodeIntegration:\s*false/);
+  assert.match(main, /requestSingleInstanceLock/);
+  assert.match(main, /pick-workspace|pickWorkspace|showOpenDialog/);
+  assert.match(main, /crashRestartOnce/);
+  assert.match(main, /openPath|open-log/);
+  // Crash-restart must refresh lastStart + loadURL (not leave dead endpoint)
+  assert.match(main, /onCrashRestarted/);
+  assert.match(main, /applyServeReady/);
+  assert.match(main, /loadURL/);
+});
+
+test("supervisor buildServeArgs contract embedded in source", () => {
+  const sup = fs.readFileSync(path.join(root, "lib/serveSupervisor.mjs"), "utf8");
+  assert.match(sup, /127\.0\.0\.1:0/);
+  assert.match(sup, /--token-file/);
+  assert.match(sup, /--port-file/);
+  assert.match(sup, /--pid-file/);
+  assert.match(sup, /--auth[\s\S]*token/);
+  // Must refuse putting secrets on argv via --token flag in builder
+  assert.match(sup, /must use --token-file only/);
+});
+
+test("capability gap and go/no-go artifacts exist", () => {
+  assert.ok(fs.existsSync(path.join(root, "docs/CAPABILITY_GAP.md")));
+  assert.ok(fs.existsSync(path.join(root, "docs/GO_NO_GO.md")));
+  const gap = fs.readFileSync(path.join(root, "docs/CAPABILITY_GAP.md"), "utf8");
+  assert.match(gap, /multiTab/);
+  assert.match(gap, /terminal/);
+  const gng = fs.readFileSync(path.join(root, "docs/GO_NO_GO.md"), "utf8");
+  assert.match(gng, /NO-GO/);
+  assert.match(gng, /Wails/);
+});
+
+test("preload exposes whitelist only", () => {
+  const pre = fs.readFileSync(path.join(root, "electron/preload.cjs"), "utf8");
+  assert.match(pre, /contextBridge\.exposeInMainWorld/);
+  assert.match(pre, /getEndpoint/);
+  assert.doesNotMatch(pre, /child_process/);
+  assert.doesNotMatch(pre, /require\(['\"]fs['\"]\)/);
+});

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,6 +42,7 @@ import (
 	"reasonix/internal/serve"
 	"reasonix/internal/sessiontemp"
 	"reasonix/internal/stats"
+	"reasonix/internal/tabhost"
 	"reasonix/internal/telemetry"
 
 	tea "charm.land/bubbletea/v2"
@@ -813,6 +814,7 @@ func runServe(args []string) int {
 	portFile := fs.String("port-file", "", "write the actual bound listen address (host:port) to this file after binding")
 	tokenFile := fs.String("token-file", "", "read the auth=token pre-shared token from this file (overrides --token; keeps the secret out of argv)")
 	pidFile := fs.String("pid-file", "", "write the server process id to this file")
+	multiTab := fs.Bool("multi-tab", false, "enable multi-Controller tabs (GET/POST /tabs; events include tabId)")
 	if code, ok := parseCommandFlags(fs, args); !ok {
 		return code
 	}
@@ -908,33 +910,84 @@ func runServe(args []string) int {
 	// ignoring project-level default_model overrides. Explicit flags and
 	// resumable session models remain strict and are preserved verbatim.
 	*model = resolveServeModel(*model)
-	// Keep the browser reachable when the selected provider has no saved key.
-	// The loopback-only provider setup surface stores the missing credential and
-	// rebuilds this controller in place before the normal web UI is exposed.
-	ctrl, err := setupProfileWithOverrides(ctx, *model, *maxSteps, false, bc, profile, cliBuildOverrides{
-		OnSessionRecovered: cliSessionRecoveredHandler(leases),
-	})
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 1
-	}
-	defer ctrl.Close()
-	SetTaskJobKiller(ctrlKillerAdapter{ctrl})
 
-	// Auto-save target: reuse the resumed file, else a fresh one — same as chat.
-	if *resume != "" {
-		ctrl.Resume(resumeSession, *resume)
-	}
-	ctrl.EnsureSessionPath()
-	// Fresh sessions take the lease too (defensive: the path is brand new); a
-	// resumed path is already held, making this a no-op.
-	if err := leases.Rebind(ctrl.SessionPath()); err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
-		return 1
+	var (
+		ctrl *control.Controller
+		th   *tabhost.Host
+	)
+	if *multiTab {
+		// Multi-tab: tabhost owns Controllers and per-tab leases. The legacy
+		// single leases keeper is unused for path binding (tabhost holds them).
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		th = tabhost.New(tabhost.DefaultBuilder(tabhost.BootBuilderOptions{
+			Model:       *model,
+			RequireKey:  false,
+			StatsSource: "serve",
+			Context:     ctx,
+		}))
+		defer th.CloseAll()
+		meta, err := th.CreateTab(tabhost.CreateTabOpts{
+			Scope:         tabhost.ScopeProject,
+			WorkspaceRoot: cwd,
+			SessionPath:   *resume,
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		api, _, err := th.Get(meta.ID)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		var ok bool
+		ctrl, ok = api.(*control.Controller)
+		if !ok {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "tabhost did not return a Controller")
+			return 1
+		}
+		// resumeSession path: DefaultBuilder does not auto-Resume; if --resume set,
+		// SessionPath was passed into CreateTab opts and leased there when possible.
+		_ = resumeSession
+		SetTaskJobKiller(ctrlKillerAdapter{ctrl})
+	} else {
+		// Keep the browser reachable when the selected provider has no saved key.
+		// The loopback-only provider setup surface stores the missing credential and
+		// rebuilds this controller in place before the normal web UI is exposed.
+		var err error
+		ctrl, err = setupProfileWithOverrides(ctx, *model, *maxSteps, false, bc, profile, cliBuildOverrides{
+			OnSessionRecovered: cliSessionRecoveredHandler(leases),
+		})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		defer ctrl.Close()
+		SetTaskJobKiller(ctrlKillerAdapter{ctrl})
+
+		// Auto-save target: reuse the resumed file, else a fresh one — same as chat.
+		if *resume != "" {
+			ctrl.Resume(resumeSession, *resume)
+		}
+		ctrl.EnsureSessionPath()
+		// Fresh sessions take the lease too (defensive: the path is brand new); a
+		// resumed path is already held, making this a no-op.
+		if err := leases.Rebind(ctrl.SessionPath()); err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, control.SessionInUseMessage(err)+"; "+control.SessionLeaseCloseHint)
+			return 1
+		}
 	}
 
 	srv := serve.New(ctrl, bc, serveCfg)
-	srv.SetSessionLeases(leases)
+	if th != nil {
+		srv.SetTabHost(th)
+	} else {
+		srv.SetSessionLeases(leases)
+	}
 
 	// With --port-file the supervisor needs the real bound port (--addr may be
 	// 127.0.0.1:0), so listen first, record the address, then serve on the
@@ -968,7 +1021,11 @@ func runServe(args []string) int {
 	}
 	srv.EnableProviderSetupForListener(displayAddr)
 
-	fmt.Printf("reasonix serve — %s on http://%s\n", ctrl.Label(), displayAddr)
+	if th != nil {
+		fmt.Printf("reasonix serve — multi-tab (%d tab) on http://%s\n", len(th.ListTabs()), displayAddr)
+	} else {
+		fmt.Printf("reasonix serve — %s on http://%s\n", ctrl.Label(), displayAddr)
+	}
 	if srv.AuthMode() == "token" {
 		fmt.Printf("  auth: token\n")
 		// Under --port-file the process is supervised (e.g. remote bootstrap):

--- a/internal/cli/shell_completion.go
+++ b/internal/cli/shell_completion.go
@@ -118,7 +118,7 @@ func cliCompletionRootSpec() cliCompletionSpec {
 			// not branch IDs (SessionValue would complete IDs that fail at runtime).
 			completionFlag("--resume", cliCompletionPathValue),
 			completionFlag("--auth", cliCompletionStaticValue, "none", "token", "password"),
-			completionFlag("--token --password --port-file --token-file --pid-file", cliCompletionStaticValue),
+			completionFlag("--token --password --port-file --token-file --pid-file --multi-tab", cliCompletionStaticValue),
 			completionFlag("--hash-password --behind-proxy", cliCompletionNoValue), help,
 		}),
 		completionSpec("setup", []cliCompletionFlag{completionFlag("--local -l", cliCompletionNoValue), help}),

--- a/internal/desktopsidebar/store.go
+++ b/internal/desktopsidebar/store.go
@@ -1,0 +1,603 @@
+// Package desktopsidebar reads/writes the same desktop project-tree metadata
+// files used by the Wails app (desktop-projects.json + topic title maps), so
+// Electron multi-tab and Wails share sidebar state.
+package desktopsidebar
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/fileutil"
+)
+
+const (
+	desktopProjectsFile = "desktop-projects.json"
+	topicTitlesFile     = "desktop-topic-titles.json"
+	defaultTopicTitle   = "新的会话"
+)
+
+// Project is one workspace entry in desktop-projects.json.
+type Project struct {
+	Root         string   `json:"root"`
+	Title        string   `json:"title,omitempty"`
+	Color        string   `json:"color,omitempty"`
+	Topics       []string `json:"topics"`
+	PinnedTopics []string `json:"pinnedTopics,omitempty"`
+}
+
+// File is the on-disk desktop-projects.json document.
+type File struct {
+	GlobalTitle        string    `json:"globalTitle,omitempty"`
+	GlobalColor        string    `json:"globalColor,omitempty"`
+	GlobalTopics       []string  `json:"globalTopics,omitempty"`
+	GlobalPinnedTopics []string  `json:"globalPinnedTopics,omitempty"`
+	DeletedTopics      []string  `json:"deletedTopics,omitempty"`
+	PinnedProjects     []string  `json:"pinnedProjects,omitempty"`
+	SidebarOrder       []string  `json:"sidebarOrder,omitempty"`
+	Projects           []Project `json:"projects"`
+}
+
+// TopicMeta is returned by CreateTopic.
+type TopicMeta struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+// Node is a ProjectTree node compatible with desktop.frontend ProjectNode.
+type Node struct {
+	Key            string  `json:"key"`
+	Kind           string  `json:"kind"`
+	Label          string  `json:"label"`
+	Root           string  `json:"root,omitempty"`
+	TopicID        string  `json:"topicId,omitempty"`
+	SessionPath    string  `json:"sessionPath,omitempty"`
+	ProjectColor   string  `json:"projectColor,omitempty"`
+	Turns          int     `json:"turns,omitempty"`
+	CreatedAt      int64   `json:"createdAt,omitempty"`
+	LastActivityAt int64   `json:"lastActivityAt,omitempty"`
+	Open           bool    `json:"open,omitempty"`
+	Running        bool    `json:"running,omitempty"`
+	Pinned         bool    `json:"pinned,omitempty"`
+	Children       []Node  `json:"children,omitempty"`
+}
+
+// SessionHint is a lightweight session row used when building the tree.
+type SessionHint struct {
+	Path           string
+	WorkspaceRoot  string
+	TopicID        string
+	TopicTitle     string
+	Turns          int
+	LastActivityAt int64
+	Running        bool
+}
+
+var mu sync.Mutex
+
+func configDir() string { return config.ReasonixHomeDir() }
+
+func projectsPath() string {
+	return filepath.Join(configDir(), desktopProjectsFile)
+}
+
+func topicTitlesPath(workspaceRoot string) string {
+	if strings.TrimSpace(workspaceRoot) == "" {
+		return filepath.Join(configDir(), "global", topicTitlesFile)
+	}
+	return filepath.Join(workspaceRoot, ".reasonix", topicTitlesFile)
+}
+
+func normalizeRoot(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		return abs
+	}
+	return root
+}
+
+func sameRoot(a, b string) bool {
+	return filepath.Clean(normalizeRoot(a)) == filepath.Clean(normalizeRoot(b))
+}
+
+// LoadProjects reads desktop-projects.json (empty file on missing).
+func LoadProjects() File {
+	mu.Lock()
+	defer mu.Unlock()
+	return loadProjectsLocked()
+}
+
+func loadProjectsLocked() File {
+	b, err := os.ReadFile(projectsPath())
+	if err != nil {
+		return File{}
+	}
+	var f File
+	_ = json.Unmarshal(b, &f)
+	return f
+}
+
+func saveProjectsLocked(f File) error {
+	if err := os.MkdirAll(configDir(), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := projectsPath()
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return fileutil.ReplaceFile(tmp, path)
+}
+
+func updateProjects(mutator func(*File) (bool, error)) error {
+	mu.Lock()
+	defer mu.Unlock()
+	f := loadProjectsLocked()
+	changed, err := mutator(&f)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return saveProjectsLocked(f)
+}
+
+func loadTopicTitles(workspaceRoot string) map[string]string {
+	b, err := os.ReadFile(topicTitlesPath(workspaceRoot))
+	if err != nil {
+		return map[string]string{}
+	}
+	var m map[string]string
+	if json.Unmarshal(b, &m) != nil || m == nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+func saveTopicTitles(workspaceRoot string, m map[string]string) error {
+	path := topicTitlesPath(workspaceRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return fileutil.ReplaceFile(tmp, path)
+}
+
+func newTopicID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "topic_" + hex.EncodeToString(b[:])
+}
+
+// EnsureProject registers workspaceRoot in desktop-projects.json if missing.
+func EnsureProject(workspaceRoot string) error {
+	root := normalizeRoot(workspaceRoot)
+	if root == "" {
+		return fmt.Errorf("workspaceRoot required")
+	}
+	return updateProjects(func(f *File) (bool, error) {
+		for _, p := range f.Projects {
+			if sameRoot(p.Root, root) {
+				return false, nil
+			}
+		}
+		f.Projects = append(f.Projects, Project{Root: root, Topics: []string{"main"}})
+		return true, nil
+	})
+}
+
+// CreateTopic creates a topic id under a project (or global) and returns metadata.
+func CreateTopic(scope, workspaceRoot, title string) (TopicMeta, error) {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		title = defaultTopicTitle
+	}
+	root := ""
+	if scope != "global" {
+		root = normalizeRoot(workspaceRoot)
+		if root == "" {
+			return TopicMeta{}, fmt.Errorf("workspaceRoot required for project topic")
+		}
+		if err := EnsureProject(root); err != nil {
+			return TopicMeta{}, err
+		}
+	}
+	id := newTopicID()
+	createdAt := time.Now().UnixMilli()
+	titles := loadTopicTitles(root)
+	titles[id] = title
+	if err := saveTopicTitles(root, titles); err != nil {
+		return TopicMeta{}, err
+	}
+	err := updateProjects(func(f *File) (bool, error) {
+		if root == "" {
+			f.GlobalTopics = prependUnique(f.GlobalTopics, id)
+			return true, nil
+		}
+		for i := range f.Projects {
+			if sameRoot(f.Projects[i].Root, root) {
+				f.Projects[i].Topics = prependUnique(f.Projects[i].Topics, id)
+				return true, nil
+			}
+		}
+		f.Projects = append(f.Projects, Project{Root: root, Topics: []string{id}})
+		return true, nil
+	})
+	if err != nil {
+		return TopicMeta{}, err
+	}
+	return TopicMeta{ID: id, Title: title, CreatedAt: createdAt}, nil
+}
+
+// findTopicRoot locates which workspace (or global "") owns topicID.
+func findTopicRoot(topicID string) string {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return ""
+	}
+	f := LoadProjects()
+	for _, id := range f.GlobalTopics {
+		if id == topicID {
+			return ""
+		}
+	}
+	for _, p := range f.Projects {
+		for _, id := range p.Topics {
+			if id == topicID {
+				return normalizeRoot(p.Root)
+			}
+		}
+		// Title maps may still hold topics not listed (open-tab created).
+		titles := loadTopicTitles(p.Root)
+		if _, ok := titles[topicID]; ok {
+			return normalizeRoot(p.Root)
+		}
+	}
+	if _, ok := loadTopicTitles("")[topicID]; ok {
+		return ""
+	}
+	return ""
+}
+
+// RenameTopic updates a topic display title. workspaceRoot may be empty; the
+// store then resolves the owning project from desktop-projects.json.
+func RenameTopic(workspaceRoot, topicID, title string) error {
+	topicID = strings.TrimSpace(topicID)
+	title = strings.TrimSpace(title)
+	if topicID == "" || title == "" {
+		return fmt.Errorf("topicId and title required")
+	}
+	root := normalizeRoot(workspaceRoot)
+	if root == "" {
+		root = findTopicRoot(topicID)
+	}
+	titles := loadTopicTitles(root)
+	titles[topicID] = title
+	return saveTopicTitles(root, titles)
+}
+
+// DeleteTopic marks a topic deleted and removes it from project topic lists.
+func DeleteTopic(workspaceRoot, topicID string) error {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return fmt.Errorf("topicId required")
+	}
+	root := normalizeRoot(workspaceRoot)
+	if root == "" && findTopicRoot(topicID) != "" {
+		root = findTopicRoot(topicID)
+	}
+	// When findTopicRoot returns "" it may mean global OR unknown — still mark deleted.
+	return updateProjects(func(f *File) (bool, error) {
+		f.DeletedTopics = prependUnique(f.DeletedTopics, topicID)
+		if root == "" {
+			f.GlobalTopics = removeString(f.GlobalTopics, topicID)
+			f.GlobalPinnedTopics = removeString(f.GlobalPinnedTopics, topicID)
+			for i := range f.Projects {
+				f.Projects[i].Topics = removeString(f.Projects[i].Topics, topicID)
+				f.Projects[i].PinnedTopics = removeString(f.Projects[i].PinnedTopics, topicID)
+			}
+			return true, nil
+		}
+		for i := range f.Projects {
+			if sameRoot(f.Projects[i].Root, root) {
+				f.Projects[i].Topics = removeString(f.Projects[i].Topics, topicID)
+				f.Projects[i].PinnedTopics = removeString(f.Projects[i].PinnedTopics, topicID)
+				return true, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+// TrashTopic is an alias of DeleteTopic for the desktop bridge name.
+func TrashTopic(workspaceRoot, topicID string) error {
+	return DeleteTopic(workspaceRoot, topicID)
+}
+
+// RemoveWorkspace drops a project from the sidebar registry (does not delete files).
+func RemoveWorkspace(workspaceRoot string) error {
+	root := normalizeRoot(workspaceRoot)
+	if root == "" {
+		return fmt.Errorf("workspaceRoot required")
+	}
+	return updateProjects(func(f *File) (bool, error) {
+		next := make([]Project, 0, len(f.Projects))
+		for _, p := range f.Projects {
+			if !sameRoot(p.Root, root) {
+				next = append(next, p)
+			}
+		}
+		if len(next) == len(f.Projects) {
+			return false, nil
+		}
+		f.Projects = next
+		f.PinnedProjects = removeString(f.PinnedProjects, root)
+		f.SidebarOrder = removeString(f.SidebarOrder, root)
+		return true, nil
+	})
+}
+
+// RenameProject sets a display title override for a project folder.
+func RenameProject(workspaceRoot, title string) error {
+	root := normalizeRoot(workspaceRoot)
+	if root == "" {
+		return fmt.Errorf("workspaceRoot required")
+	}
+	return updateProjects(func(f *File) (bool, error) {
+		for i := range f.Projects {
+			if sameRoot(f.Projects[i].Root, root) {
+				f.Projects[i].Title = strings.TrimSpace(title)
+				return true, nil
+			}
+		}
+		f.Projects = append(f.Projects, Project{Root: root, Title: strings.TrimSpace(title), Topics: []string{"main"}})
+		return true, nil
+	})
+}
+
+// ReorderProjects persists a user-defined project order.
+func ReorderProjects(workspaceRoots []string) error {
+	return updateProjects(func(f *File) (bool, error) {
+		order := make([]string, 0, len(workspaceRoots))
+		for _, r := range workspaceRoots {
+			r = normalizeRoot(r)
+			if r != "" {
+				order = append(order, r)
+			}
+		}
+		f.SidebarOrder = order
+		return true, nil
+	})
+}
+
+// BuildTree merges desktop-projects.json, topic titles, open-tab hints, and
+// session listings into a ProjectNode tree for the sidebar.
+func BuildTree(openTabs []SessionHint, sessions []SessionHint) []Node {
+	f := LoadProjects()
+	// Index sessions by workspace + topic.
+	type topicAgg struct {
+		title      string
+		session    string
+		turns      int
+		lastAct    int64
+		running    bool
+	}
+	byRoot := map[string]map[string]*topicAgg{}
+	ensure := func(root, topicID string) *topicAgg {
+		root = normalizeRoot(root)
+		if byRoot[root] == nil {
+			byRoot[root] = map[string]*topicAgg{}
+		}
+		if byRoot[root][topicID] == nil {
+			byRoot[root][topicID] = &topicAgg{title: "Session"}
+		}
+		return byRoot[root][topicID]
+	}
+	for _, s := range append(append([]SessionHint{}, sessions...), openTabs...) {
+		root := normalizeRoot(s.WorkspaceRoot)
+		if root == "" {
+			continue
+		}
+		tid := strings.TrimSpace(s.TopicID)
+		if tid == "" {
+			tid = "main"
+		}
+		agg := ensure(root, tid)
+		if s.TopicTitle != "" {
+			agg.title = s.TopicTitle
+		}
+		if s.Path != "" {
+			agg.session = s.Path
+		}
+		if s.Turns > agg.turns {
+			agg.turns = s.Turns
+		}
+		if s.LastActivityAt > agg.lastAct {
+			agg.lastAct = s.LastActivityAt
+		}
+		if s.Running {
+			agg.running = true
+		}
+	}
+	// Ensure registered projects appear even without sessions.
+	for _, p := range f.Projects {
+		root := normalizeRoot(p.Root)
+		_ = ensure(root, "main")
+		titles := loadTopicTitles(root)
+		for _, tid := range p.Topics {
+			agg := ensure(root, tid)
+			if t := titles[tid]; t != "" {
+				agg.title = t
+			}
+		}
+	}
+	// Register open-tab / session roots so they appear even if never pinned.
+	for root := range byRoot {
+		_ = EnsureProject(root)
+	}
+	f = LoadProjects()
+	// Rebuild byRoot topic titles from refreshed project registry after EnsureProject.
+	for _, p := range f.Projects {
+		root := normalizeRoot(p.Root)
+		titles := loadTopicTitles(root)
+		for _, tid := range p.Topics {
+			agg := ensure(root, tid)
+			if t := titles[tid]; t != "" {
+				agg.title = t
+			}
+		}
+	}
+
+	deleted := map[string]bool{}
+	for _, d := range f.DeletedTopics {
+		deleted[d] = true
+	}
+	pinnedSet := map[string]bool{}
+	for _, r := range f.PinnedProjects {
+		pinnedSet[normalizeRoot(r)] = true
+	}
+
+	// Order projects: sidebar order, then pinned, then remaining.
+	order := make([]string, 0, len(f.Projects)+len(byRoot))
+	seen := map[string]bool{}
+	addRoot := func(r string) {
+		r = normalizeRoot(r)
+		if r == "" || seen[r] {
+			return
+		}
+		seen[r] = true
+		order = append(order, r)
+	}
+	for _, r := range f.SidebarOrder {
+		addRoot(r)
+	}
+	for _, r := range f.PinnedProjects {
+		addRoot(r)
+	}
+	for _, p := range f.Projects {
+		addRoot(p.Root)
+	}
+	for r := range byRoot {
+		addRoot(r)
+	}
+
+	out := make([]Node, 0, len(order))
+	for _, root := range order {
+		pTitle := filepath.Base(root)
+		var color string
+		var topicIDs []string
+		pinnedTopics := map[string]bool{}
+		for _, p := range f.Projects {
+			if sameRoot(p.Root, root) {
+				if p.Title != "" {
+					pTitle = p.Title
+				}
+				color = p.Color
+				topicIDs = append(topicIDs, p.Topics...)
+				for _, t := range p.PinnedTopics {
+					pinnedTopics[t] = true
+				}
+				break
+			}
+		}
+		topics := byRoot[root]
+		if topics == nil {
+			topics = map[string]*topicAgg{}
+		}
+		// Union topic IDs from registry + sessions.
+		for tid := range topics {
+			topicIDs = prependUnique(topicIDs, tid)
+		}
+		if len(topicIDs) == 0 {
+			topicIDs = []string{"main"}
+		}
+		titles := loadTopicTitles(root)
+		children := make([]Node, 0, len(topicIDs))
+		for _, tid := range topicIDs {
+			if deleted[tid] {
+				continue
+			}
+			agg := topics[tid]
+			if agg == nil {
+				agg = &topicAgg{title: "Session"}
+			}
+			label := agg.title
+			if t := titles[tid]; t != "" {
+				label = t
+			}
+			children = append(children, Node{
+				Key:            "topic_" + tid,
+				Kind:           "topic",
+				Label:          label,
+				Root:           root,
+				TopicID:        tid,
+				SessionPath:    agg.session,
+				ProjectColor:   color,
+				Turns:          agg.turns,
+				LastActivityAt: agg.lastAct,
+				Open:           true,
+				Running:        agg.running,
+				Pinned:         pinnedTopics[tid],
+			})
+		}
+		out = append(out, Node{
+			Key:          "project_" + root,
+			Kind:         "project",
+			Label:        pTitle,
+			Root:         root,
+			ProjectColor: color,
+			Open:         true,
+			Pinned:       pinnedSet[root],
+			Children:     children,
+		})
+	}
+	return out
+}
+
+func prependUnique(list []string, v string) []string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return list
+	}
+	out := make([]string, 0, len(list)+1)
+	out = append(out, v)
+	for _, x := range list {
+		if x != v {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+func removeString(list []string, v string) []string {
+	out := make([]string, 0, len(list))
+	for _, x := range list {
+		if x != v {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/internal/desktopsidebar/store_test.go
+++ b/internal/desktopsidebar/store_test.go
@@ -1,0 +1,59 @@
+package desktopsidebar
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateTopicAndBuildTree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("REASONIX_HOME", filepath.Join(home, ".reasonix"))
+
+	root := filepath.Join(home, "proj")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureProject(root); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := CreateTopic("project", root, "设计稿")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.ID == "" || meta.Title != "设计稿" {
+		t.Fatalf("meta=%+v", meta)
+	}
+	tree := BuildTree(nil, []SessionHint{{
+		WorkspaceRoot: root,
+		TopicID:       meta.ID,
+		TopicTitle:    "设计稿",
+		Turns:         2,
+		Path:          filepath.Join(home, "s.jsonl"),
+	}})
+	if len(tree) != 1 {
+		t.Fatalf("tree len=%d", len(tree))
+	}
+	if tree[0].Kind != "project" || tree[0].Root != root {
+		t.Fatalf("project node=%+v", tree[0])
+	}
+	found := false
+	for _, c := range tree[0].Children {
+		if c.TopicID == meta.ID && c.Label == "设计稿" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("topic not in children: %+v", tree[0].Children)
+	}
+	if err := RenameTopic(root, meta.ID, "新标题"); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteTopic(root, meta.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveWorkspace(root); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/serve/desktop_api.go
+++ b/internal/serve/desktop_api.go
@@ -1,0 +1,286 @@
+package serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/desktopsidebar"
+)
+
+// registerDesktopAPIRoutes adds Electron/Wails-shared desktop metadata routes
+// that do not require multi-tab (but are most useful with it).
+func (s *Server) registerDesktopAPIRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /desktop/project-tree", s.desktopProjectTree)
+	mux.HandleFunc("POST /desktop/topics", s.desktopCreateTopic)
+	mux.HandleFunc("POST /desktop/topics/rename", s.desktopRenameTopic)
+	mux.HandleFunc("POST /desktop/topics/delete", s.desktopDeleteTopic)
+	mux.HandleFunc("POST /desktop/topics/trash", s.desktopTrashTopic)
+	mux.HandleFunc("POST /desktop/projects/remove", s.desktopRemoveProject)
+	mux.HandleFunc("POST /desktop/projects/rename", s.desktopRenameProject)
+	mux.HandleFunc("POST /desktop/projects/reorder", s.desktopReorderProjects)
+	mux.HandleFunc("GET /desktop/startup-settings", s.desktopStartupSettings)
+	mux.HandleFunc("GET /desktop/settings", s.desktopSettings)
+}
+
+func (s *Server) desktopProjectTree(w http.ResponseWriter, _ *http.Request) {
+	openHints := make([]desktopsidebar.SessionHint, 0)
+	if h := s.tabHost(); h != nil {
+		for _, t := range h.ListTabs() {
+			openHints = append(openHints, desktopsidebar.SessionHint{
+				Path:          t.SessionPath,
+				WorkspaceRoot: t.WorkspaceRoot,
+				TopicID:       t.TopicID,
+				TopicTitle:    t.TopicTitle,
+				Running:       t.Running,
+			})
+		}
+	}
+	sessions := s.sessionHints()
+	writeJSON(w, desktopsidebar.BuildTree(openHints, sessions))
+}
+
+func (s *Server) sessionHints() []desktopsidebar.SessionHint {
+	// Prefer multi-tab session dirs via active controller SessionDir, then ListSessions.
+	dir := ""
+	if c := s.ctl(); c != nil {
+		dir = c.SessionDir()
+	}
+	if dir == "" {
+		return nil
+	}
+	infos, err := agent.ListSessions(dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]desktopsidebar.SessionHint, 0, len(infos))
+	for _, info := range infos {
+		out = append(out, desktopsidebar.SessionHint{
+			Path:           info.Path,
+			WorkspaceRoot:  info.WorkspaceRoot,
+			TopicID:        info.TopicID,
+			TopicTitle:     firstNonEmpty(info.TopicTitle, info.CustomTitle),
+			Turns:          info.Turns,
+			LastActivityAt: info.LastActivityAt.UnixMilli(),
+		})
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func (s *Server) desktopCreateTopic(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Scope         string `json:"scope"`
+		WorkspaceRoot string `json:"workspaceRoot"`
+		Title         string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	meta, err := desktopsidebar.CreateTopic(body.Scope, body.WorkspaceRoot, body.Title)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, meta)
+}
+
+func (s *Server) desktopRenameTopic(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+		TopicID       string `json:"topicId"`
+		Title         string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if err := desktopsidebar.RenameTopic(body.WorkspaceRoot, body.TopicID, body.Title); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) desktopDeleteTopic(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+		TopicID       string `json:"topicId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if err := desktopsidebar.DeleteTopic(body.WorkspaceRoot, body.TopicID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) desktopTrashTopic(w http.ResponseWriter, r *http.Request) {
+	s.desktopDeleteTopic(w, r)
+}
+
+func (s *Server) desktopRemoveProject(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if err := desktopsidebar.RemoveWorkspace(body.WorkspaceRoot); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) desktopRenameProject(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+		Title         string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if err := desktopsidebar.RenameProject(body.WorkspaceRoot, body.Title); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) desktopReorderProjects(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		WorkspaceRoots []string `json:"workspaceRoots"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if err := desktopsidebar.ReorderProjects(body.WorkspaceRoots); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) desktopStartupSettings(w http.ResponseWriter, _ *http.Request) {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		cfg = &config.Config{}
+	}
+	writeJSON(w, map[string]any{
+		"bot": map[string]any{
+			"enabled":            false,
+			"model":              "",
+			"toolApprovalMode":   "ask",
+			"maxSteps":           0,
+			"debounceMs":         0,
+			"queueMode":          "",
+			"queueCap":           0,
+			"queueDrop":          "",
+			"ignoreSelfMessages": true,
+			"selfUserIds":        map[string]any{"qq": []any{}, "feishu": []any{}, "weixin": []any{}},
+			"control":            map[string]any{"enabled": false, "addr": "", "tokenEnv": ""},
+			"pairing":            map[string]any{"enabled": false, "requestTtlMinutes": 60, "maxPendingPerPlatform": 3},
+			"routes":             []any{},
+			"allowlist": map[string]any{
+				"enabled": false, "allowAll": false,
+				"qqUsers": []any{}, "feishuUsers": []any{}, "weixinUsers": []any{},
+				"qqApprovers": []any{}, "feishuApprovers": []any{}, "weixinApprovers": []any{},
+				"qqAdmins": []any{}, "feishuAdmins": []any{}, "weixinAdmins": []any{},
+				"qqGroups": []any{}, "feishuGroups": []any{}, "weixinGroups": []any{},
+			},
+			"qq": map[string]any{
+				"enabled": false, "appId": "", "appSecretEnv": "", "secretSet": false, "sandbox": false,
+				"model": "", "toolApprovalMode": "ask", "workspaceRoot": "",
+				"access": map[string]any{"enabled": false, "allowAll": false, "pairingEnabled": false, "users": []any{}, "groups": []any{}, "approvers": []any{}, "admins": []any{}},
+			},
+			"feishu": map[string]any{
+				"enabled": false, "domain": "feishu", "appId": "", "appSecretEnv": "", "secretSet": false,
+				"verificationToken": "", "mode": "webhook", "webhookPort": 8080, "requireMention": true,
+			},
+			"weixin": map[string]any{"enabled": false, "accountId": "", "tokenEnv": "", "tokenSet": false, "apiBase": ""},
+			"connections": []any{},
+		},
+		"desktopLanguage":      cfg.DesktopLanguage(),
+		"desktopLayoutStyle":   cfg.DesktopLayoutStyle(),
+		"desktopTheme":         cfg.DesktopTheme(),
+		"desktopThemeStyle":    cfg.DesktopThemeStyle(),
+		"desktopTerminalTheme": cfg.DesktopTerminalTheme(),
+		"displayMode":          "standard",
+		"statusBarStyle":       "icon",
+		"statusBarItems": []string{
+			"model", "workspace", "git_branch", "cache", "cache_avg", "session_tokens",
+			"turn_tokens", "turn_cost", "session_turns", "context", "compact", "cost", "balance",
+		},
+		"checkUpdates":       false,
+		"updateChannel":      "stable",
+		"conversationWidth":  "standard",
+		"configWarnings":     []any{},
+		"configPath":         config.UserConfigPath(),
+	})
+}
+
+func (s *Server) desktopSettings(w http.ResponseWriter, _ *http.Request) {
+	// Lightweight settings surface for Electron: providers/models from /models shape
+	// plus desktop prefs. Full Wails Settings write path remains desktop-owned.
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		cfg = &config.Config{}
+	}
+	models := []any{}
+	// Callers that need the live model list should still hit GET /models.
+	writeJSON(w, map[string]any{
+		"defaultModel":         cfg.DefaultModel,
+		"plannerModel":         "",
+		"subagentModel":        "",
+		"subagentEffort":       "",
+		"autoPlan":             "off",
+		"providers":            models,
+		"officialProviders":    models,
+		"providerPresets":      []any{},
+		"permissions":          map[string]any{"mode": "ask", "allow": []any{}, "ask": []any{}, "deny": []any{}},
+		"sandbox":              map[string]any{"bash": "workspace", "network": true, "workspaceRoot": "", "allowWrite": []any{}, "effectiveWorkspaceRoot": "", "effectiveWriteRoots": []any{}, "shell": "auto", "effectiveShell": ""},
+		"network":              map[string]any{"proxyMode": "auto", "proxyUrl": "", "noProxy": "", "proxy": map[string]any{"type": "", "server": "", "port": 0, "username": "", "password": ""}},
+		"agent":                map[string]any{"temperature": 0, "maxSteps": 0, "plannerMaxSteps": 0, "maxSubagentDepth": 2, "maxSubagentConcurrency": 1, "maxParallelWriters": 1, "systemPrompt": "", "coldResumePrune": false, "reasoningLanguage": "auto", "compactRatio": 0.8},
+		"bot":                  map[string]any{"enabled": false, "connections": []any{}, "routes": []any{}, "allowlist": map[string]any{"enabled": false, "allowAll": false, "qqUsers": []any{}, "feishuUsers": []any{}, "weixinUsers": []any{}, "qqApprovers": []any{}, "feishuApprovers": []any{}, "weixinApprovers": []any{}, "qqAdmins": []any{}, "feishuAdmins": []any{}, "weixinAdmins": []any{}, "qqGroups": []any{}, "feishuGroups": []any{}, "weixinGroups": []any{}}, "selfUserIds": map[string]any{"qq": []any{}, "feishu": []any{}, "weixin": []any{}}, "control": map[string]any{"enabled": false, "addr": "", "tokenEnv": ""}, "pairing": map[string]any{"enabled": false, "requestTtlMinutes": 60, "maxPendingPerPlatform": 3}, "qq": map[string]any{"enabled": false, "appId": "", "appSecretEnv": "", "secretSet": false, "sandbox": false, "model": "", "toolApprovalMode": "ask", "workspaceRoot": "", "access": map[string]any{"enabled": false, "allowAll": false, "pairingEnabled": false, "users": []any{}, "groups": []any{}, "approvers": []any{}, "admins": []any{}}}, "feishu": map[string]any{"enabled": false, "domain": "feishu", "appId": "", "appSecretEnv": "", "secretSet": false, "verificationToken": "", "mode": "webhook", "webhookPort": 8080, "requireMention": true}, "weixin": map[string]any{"enabled": false, "accountId": "", "tokenEnv": "", "tokenSet": false, "apiBase": ""}},
+		"desktopLanguage":      cfg.DesktopLanguage(),
+		"desktopLayoutStyle":   cfg.DesktopLayoutStyle(),
+		"desktopTheme":         cfg.DesktopTheme(),
+		"desktopThemeStyle":    cfg.DesktopThemeStyle(),
+		"desktopTerminalTheme": cfg.DesktopTerminalTheme(),
+		"closeBehavior":        "background",
+		"displayMode":          "standard",
+		"statusBarStyle":       "icon",
+		"statusBarItems": []string{
+			"model", "workspace", "git_branch", "cache", "cache_avg", "session_tokens",
+			"turn_tokens", "turn_cost", "session_turns", "context", "compact", "cost", "balance",
+		},
+		"defaultToolApprovalMode": "ask",
+		"checkUpdates":            false,
+		"updateChannel":           "stable",
+		"telemetry":               false,
+		"metrics":                 false,
+		"configPath":              config.UserConfigPath(),
+		"providerKinds":           []any{},
+		"autoApproveTools":        false,
+		"bypass":                  false,
+		"conversationWidth":       "standard",
+	})
+}

--- a/internal/serve/multi.go
+++ b/internal/serve/multi.go
@@ -1,0 +1,428 @@
+package serve
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"reasonix/internal/control"
+	"reasonix/internal/desktopsidebar"
+	"reasonix/internal/event"
+	"reasonix/internal/tabhost"
+)
+
+// SetTabHost enables multi-Controller mode. Legacy single-controller routes
+// target the active tab; preferred clients use /tabs/{id}/….
+func (s *Server) SetTabHost(h *tabhost.Host) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tabs = h
+}
+
+// MultiTab reports whether multi-tab mode is enabled.
+func (s *Server) MultiTab() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tabs != nil
+}
+
+func (s *Server) tabHost() *tabhost.Host {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tabs
+}
+
+// resolveController returns the controller for tabID, or the active tab when
+// tabID is empty (legacy routes in multi-tab mode).
+func (s *Server) resolveController(tabID string) (control.SessionAPI, string, *sync.Mutex, error) {
+	h := s.tabHost()
+	if h == nil {
+		return s.ctl(), "", nil, nil
+	}
+	id := strings.TrimSpace(tabID)
+	if id == "" {
+		id = h.ActiveTabID()
+	}
+	if id == "" {
+		return nil, "", nil, fmt.Errorf("no active tab")
+	}
+	ctrl, bindMu, err := h.Get(id)
+	if err != nil {
+		return nil, id, nil, err
+	}
+	return ctrl, id, bindMu, nil
+}
+
+func (s *Server) registerMultiTabRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /tabs", s.listTabs)
+	mux.HandleFunc("POST /tabs", s.createTab)
+	mux.HandleFunc("POST /tabs/{id}/activate", s.activateTab)
+	mux.HandleFunc("POST /tabs/{id}/close", s.closeTab)
+	mux.HandleFunc("POST /tabs/{id}/submit", s.submitTab)
+	mux.HandleFunc("POST /tabs/{id}/cancel", s.cancelTab)
+	mux.HandleFunc("POST /tabs/{id}/approve", s.approveTab)
+	mux.HandleFunc("POST /tabs/{id}/answer", s.answerTab)
+	mux.HandleFunc("POST /tabs/{id}/plan", s.planTab)
+	mux.HandleFunc("POST /tabs/{id}/compact", s.compactTab)
+	mux.HandleFunc("POST /tabs/{id}/new", s.newSessionTab)
+	mux.HandleFunc("POST /tabs/{id}/goal", s.goalTab)
+	mux.HandleFunc("POST /tabs/{id}/tool-approval-mode", s.toolApprovalModeTab)
+	mux.HandleFunc("GET /tabs/{id}/history", s.historyTab)
+	mux.HandleFunc("GET /tabs/{id}/context", s.contextTab)
+	mux.HandleFunc("GET /tabs/{id}/status", s.statusTab)
+	mux.HandleFunc("POST /tabs/open-project", s.openProjectTab)
+}
+
+func (s *Server) listTabs(w http.ResponseWriter, _ *http.Request) {
+	h := s.tabHost()
+	if h == nil {
+		http.Error(w, "multi-tab disabled", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, h.ListTabs())
+}
+
+func (s *Server) createTab(w http.ResponseWriter, r *http.Request) {
+	h := s.tabHost()
+	if h == nil {
+		http.Error(w, "multi-tab disabled", http.StatusNotFound)
+		return
+	}
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+		Scope         string `json:"scope"`
+		TopicID       string `json:"topicId"`
+		TopicTitle    string `json:"topicTitle"`
+		SessionPath   string `json:"sessionPath"`
+		Label         string `json:"label"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if body.WorkspaceRoot == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			http.Error(w, "workspaceRoot required", http.StatusBadRequest)
+			return
+		}
+		body.WorkspaceRoot = cwd
+	}
+	meta, err := h.CreateTab(tabhost.CreateTabOpts{
+		Scope:         body.Scope,
+		WorkspaceRoot: body.WorkspaceRoot,
+		TopicID:       body.TopicID,
+		TopicTitle:    body.TopicTitle,
+		SessionPath:   body.SessionPath,
+		Label:         body.Label,
+	})
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, tabhost.ErrSessionPathInUse) {
+			status = http.StatusConflict
+		}
+		http.Error(w, err.Error(), status)
+		return
+	}
+	writeJSON(w, meta)
+}
+
+func (s *Server) activateTab(w http.ResponseWriter, r *http.Request) {
+	h := s.tabHost()
+	if h == nil {
+		http.Error(w, "multi-tab disabled", http.StatusNotFound)
+		return
+	}
+	if err := h.SetActiveTab(r.PathValue("id")); err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) closeTab(w http.ResponseWriter, r *http.Request) {
+	h := s.tabHost()
+	if h == nil {
+		http.Error(w, "multi-tab disabled", http.StatusNotFound)
+		return
+	}
+	if err := h.CloseTab(r.PathValue("id")); err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) submitTab(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var body struct {
+		Input  string `json:"input"`
+		Format string `json:"format"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Input == "" {
+		http.Error(w, "missing input", http.StatusBadRequest)
+		return
+	}
+	if strings.HasPrefix(strings.TrimSpace(body.Input), "!") {
+		http.Error(w, "shell commands are unavailable over HTTP", http.StatusForbidden)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(id)
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	if c, ok := ctrl.(*control.Controller); ok {
+		if strings.TrimSpace(body.Format) != "" {
+			c.SubmitHTTPFormat(body.Input, body.Format)
+		} else {
+			c.SubmitHTTP(body.Input)
+		}
+	} else {
+		ctrl.Submit(body.Input)
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *Server) cancelTab(w http.ResponseWriter, r *http.Request) {
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	ctrl.Cancel()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) approveTab(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID      string `json:"id"`
+		Allow   bool   `json:"allow"`
+		Session bool   `json:"session"`
+		Persist bool   `json:"persist"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	ctrl.Approve(body.ID, body.Allow, body.Session, body.Persist)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) answerTab(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID      string            `json:"id"`
+		Answers []event.AskAnswer `json:"answers"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	ctrl.AnswerQuestion(body.ID, body.Answers)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) planTab(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		On bool `json:"on"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	ctrl.SetPlanMode(body.On)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) compactTab(w http.ResponseWriter, r *http.Request) {
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	if err := ctrl.Compact(r.Context(), ""); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = ctrl.Snapshot()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) newSessionTab(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	ctrl, _, bindMu, err := s.resolveController(id)
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	if bindMu != nil {
+		bindMu.Lock()
+		defer bindMu.Unlock()
+	}
+	if err := ctrl.NewSession(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if h := s.tabHost(); h != nil {
+		_ = h.RebindSessionLease(id, ctrl.SessionPath())
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) goalTab(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Goal string `json:"goal"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	goal := strings.TrimSpace(body.Goal)
+	if goal == "" {
+		ctrl.ClearGoal()
+	} else {
+		ctrl.SetPlanMode(false)
+		ctrl.SetGoal(goal)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) toolApprovalModeTab(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Mode string `json:"mode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(body.Mode)) {
+	case control.ToolApprovalAsk, control.ToolApprovalAuto, control.ToolApprovalYolo:
+		ctrl.SetToolApprovalMode(body.Mode)
+	default:
+		http.Error(w, "mode must be ask, auto, or yolo", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) historyTab(w http.ResponseWriter, r *http.Request) {
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	writeJSON(w, historyMessages(ctrl.History()))
+}
+
+func (s *Server) contextTab(w http.ResponseWriter, r *http.Request) {
+	ctrl, _, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	used, window := ctrl.ContextSnapshot()
+	writeJSON(w, map[string]int{"used": used, "window": window})
+}
+
+func (s *Server) statusTab(w http.ResponseWriter, r *http.Request) {
+	ctrl, id, _, err := s.resolveController(r.PathValue("id"))
+	if err != nil {
+		writeTabErr(w, err)
+		return
+	}
+	used, window := ctrl.ContextSnapshot()
+	hit, miss := ctrl.SessionCache()
+	writeJSON(w, map[string]any{
+		"tabId":            id,
+		"label":            ctrl.Label(),
+		"running":          ctrl.Running(),
+		"plan":             ctrl.PlanMode(),
+		"autoApproveTools": ctrl.AutoApproveTools(),
+		"toolApprovalMode": ctrl.ToolApprovalMode(),
+		"goal":             ctrl.Goal(),
+		"goalStatus":       ctrl.GoalStatus(),
+		"cwd":              ctrl.SessionDir(),
+		"sessionPath":      ctrl.SessionPath(),
+		"used":             used,
+		"window":           window,
+		"cacheHit":         hit,
+		"cacheMiss":        miss,
+	})
+}
+
+func (s *Server) openProjectTab(w http.ResponseWriter, r *http.Request) {
+	h := s.tabHost()
+	if h == nil {
+		http.Error(w, "multi-tab disabled", http.StatusNotFound)
+		return
+	}
+	var body struct {
+		WorkspaceRoot string `json:"workspaceRoot"`
+		TopicID       string `json:"topicId"`
+		TopicTitle    string `json:"topicTitle"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.WorkspaceRoot == "" {
+		http.Error(w, "workspaceRoot required", http.StatusBadRequest)
+		return
+	}
+	for _, t := range h.ListTabs() {
+		if t.WorkspaceRoot == body.WorkspaceRoot && t.Scope == tabhost.ScopeProject {
+			_ = h.SetActiveTab(t.ID)
+			// refresh active flag
+			for _, x := range h.ListTabs() {
+				if x.ID == t.ID {
+					writeJSON(w, x)
+					return
+				}
+			}
+			writeJSON(w, t)
+			return
+		}
+	}
+	_ = desktopsidebar.EnsureProject(body.WorkspaceRoot)
+	meta, err := h.CreateTab(tabhost.CreateTabOpts{
+		Scope:         tabhost.ScopeProject,
+		WorkspaceRoot: body.WorkspaceRoot,
+		TopicID:       body.TopicID,
+		TopicTitle:    body.TopicTitle,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, meta)
+}
+
+func writeTabErr(w http.ResponseWriter, err error) {
+	if errors.Is(err, tabhost.ErrTabNotFound) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}

--- a/internal/serve/multi_test.go
+++ b/internal/serve/multi_test.go
@@ -1,0 +1,200 @@
+package serve_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/serve"
+	"reasonix/internal/tabhost"
+	"reasonix/internal/tool"
+)
+
+type multiScripted struct {
+	mu    sync.Mutex
+	turns [][]provider.Chunk
+	i     int
+}
+
+func (s *multiScripted) Name() string { return "multi-scripted" }
+func (s *multiScripted) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch := make(chan provider.Chunk, 4)
+	var chunks []provider.Chunk
+	if s.i < len(s.turns) {
+		chunks = s.turns[s.i]
+		s.i++
+	} else {
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "ok"}, {Type: provider.ChunkDone}}
+	}
+	go func() {
+		defer close(ch)
+		for _, c := range chunks {
+			ch <- c
+		}
+	}()
+	return ch, nil
+}
+
+func multiTextTurn(s string) []provider.Chunk {
+	return []provider.Chunk{{Type: provider.ChunkText, Text: s}, {Type: provider.ChunkDone}}
+}
+
+func testMultiServer(t *testing.T) (*serve.Server, *tabhost.Host, string, string) {
+	t.Helper()
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	build := func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		prov := &multiScripted{turns: [][]provider.Chunk{
+			multiTextTurn("from-" + filepath.Base(opts.WorkspaceRoot)),
+		}}
+		ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, sink)
+		c := control.New(control.Options{
+			Runner:        ag,
+			Executor:      ag,
+			Sink:          sink,
+			Label:         "test",
+			SessionDir:    filepath.Join(opts.WorkspaceRoot, "sessions"),
+			WorkspaceRoot: opts.WorkspaceRoot,
+		})
+		c.EnableInteractiveApproval()
+		c.EnsureSessionPath()
+		return c, nil
+	}
+	h := tabhost.New(build)
+	t.Cleanup(func() {
+		h.CloseAll()
+		// Allow in-flight turn goroutines to finish snapshot attempts.
+		time.Sleep(50 * time.Millisecond)
+	})
+	a, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirA, Label: "A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirB, Label: "B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl, _, err := h.Get(a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bc := serve.NewBroadcaster()
+	srv := serve.New(ctrl.(*control.Controller), bc, config.ServeConfig{AuthMode: "none"})
+	srv.SetTabHost(h)
+	return srv, h, a.ID, b.ID
+}
+
+func TestMultiTabListAndSubmit(t *testing.T) {
+	srv, _, idA, idB := testMultiServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// List tabs
+	res, err := http.Get(ts.URL + "/tabs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+	var tabs []tabhost.TabMeta
+	if err := json.NewDecoder(res.Body).Decode(&tabs); err != nil {
+		t.Fatal(err)
+	}
+	if len(tabs) != 2 {
+		t.Fatalf("tabs=%d", len(tabs))
+	}
+
+	// Submit to A and B
+	for _, id := range []string{idA, idB} {
+		body := `{"input":"hello"}`
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/tabs/"+id+"/submit", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusAccepted {
+			t.Fatalf("submit %s status=%d", id, resp.StatusCode)
+		}
+	}
+	// Let async turns settle before assertions/cleanup.
+	time.Sleep(150 * time.Millisecond)
+
+	// Per-tab history endpoints exist
+	for _, id := range []string{idA, idB} {
+		r, err := http.Get(ts.URL + "/tabs/" + id + "/history")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if r.StatusCode != 200 {
+			b, _ := io.ReadAll(r.Body)
+			r.Body.Close()
+			t.Fatalf("history %s: %d %s", id, r.StatusCode, b)
+		}
+		r.Body.Close()
+	}
+
+	// Activate A
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/tabs/"+idA+"/activate", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("activate status=%d", resp.StatusCode)
+	}
+}
+
+func TestMultiTabOpenProject(t *testing.T) {
+	srv, h, _, _ := testMultiServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	dir := t.TempDir()
+	body := `{"workspaceRoot":` + jsonString(dir) + `}`
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/tabs/open-project", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+	}
+	var meta tabhost.TabMeta
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.WorkspaceRoot != dir {
+		t.Fatalf("root=%q", meta.WorkspaceRoot)
+	}
+	if len(h.ListTabs()) != 3 {
+		t.Fatalf("want 3 tabs got %d", len(h.ListTabs()))
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -31,6 +31,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/stats"
 	"reasonix/internal/store"
+	"reasonix/internal/tabhost"
 )
 
 //go:embed index.html
@@ -75,6 +76,9 @@ type Server struct {
 	// already holds the startup session's lease; nil (tests, embedded use)
 	// disables lease gating.
 	leases *control.SessionLeaseKeeper
+	// tabs is set in multi-tab mode (opt-in --multi-tab). Each tab owns an
+	// independent Controller; legacy routes target the active tab.
+	tabs *tabhost.Host
 }
 
 // New builds a Server. bc must be the controller's event sink.
@@ -92,10 +96,20 @@ func New(ctrl control.SessionAPI, bc *Broadcaster, serveCfg config.ServeConfig) 
 
 // ctl returns the current controller. Handlers must read it through here, never
 // the field directly, because switchModel replaces it under the write lock.
+// In multi-tab mode this is the active tab's controller (legacy route target).
 func (s *Server) ctl() control.SessionAPI {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.ctrl
+	h := s.tabs
+	legacy := s.ctrl
+	s.mu.RUnlock()
+	if h != nil {
+		if id := h.ActiveTabID(); id != "" {
+			if c, _, err := h.Get(id); err == nil {
+				return c
+			}
+		}
+	}
+	return legacy
 }
 
 // SetSessionLeases hands the server the session-lease keeper that guards its
@@ -521,6 +535,10 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /skills", s.skills)
 	mux.HandleFunc("GET /todos", s.todos)
 	mux.HandleFunc("POST /delete-session", s.deleteSession)
+	s.registerDesktopAPIRoutes(mux)
+	if s.tabHost() != nil {
+		s.registerMultiTabRoutes(mux)
+	}
 	return logMiddleware(s.auth.middleware(csrfGuard(mux)))
 }
 
@@ -558,7 +576,17 @@ func csrfGuard(next http.Handler) http.Handler {
 // Run serves until the process is killed. Interactive approval is enabled so
 // "ask" decisions surface as approval_request events answered via POST /approve.
 func (s *Server) Run(addr string) error {
-	s.ctl().EnableInteractiveApproval()
+	if h := s.tabHost(); h != nil {
+		for _, meta := range h.ListTabs() {
+			if ctrl, _, err := h.Get(meta.ID); err == nil {
+				if c, ok := ctrl.(*control.Controller); ok {
+					c.EnableInteractiveApproval()
+				}
+			}
+		}
+	} else {
+		s.ctl().EnableInteractiveApproval()
+	}
 	return http.ListenAndServe(addr, s.Handler())
 }
 
@@ -643,6 +671,7 @@ const sseKeepaliveInterval = 15 * time.Second
 
 // events streams the controller's event flow as SSE until the client
 // disconnects. Each event is one `data:` frame of the JSON wire form.
+// In multi-tab mode, frames come from tabhost.Bus (already stamped with tabId).
 func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -655,14 +684,24 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 
 	var ch <-chan []byte
 	var unsubscribe func()
-	// Subscribe and replay as one handoff. Prompt producers are serialized with
-	// this operation, so no original event can land between the two steps.
-	s.ctl().ReplayPendingPromptsWith(func() event.Sink {
-		ch, unsubscribe = s.bc.Subscribe()
-		return event.FuncSink(func(e event.Event) {
-			s.bc.EmitTo(ch, e)
+	if h := s.tabHost(); h != nil {
+		ch, unsubscribe = h.Bus().Subscribe()
+		// Replay pending prompts on every open tab so late SSE clients recover gates.
+		for _, meta := range h.ListTabs() {
+			if ctrl, _, err := h.Get(meta.ID); err == nil {
+				ctrl.ReplayPendingPrompts()
+			}
+		}
+	} else {
+		// Subscribe and replay as one handoff. Prompt producers are serialized with
+		// this operation, so no original event can land between the two steps.
+		s.ctl().ReplayPendingPromptsWith(func() event.Sink {
+			ch, unsubscribe = s.bc.Subscribe()
+			return event.FuncSink(func(e event.Event) {
+				s.bc.EmitTo(ch, e)
+			})
 		})
-	})
+	}
 	defer unsubscribe()
 
 	fmt.Fprint(w, ": connected\n\n") // open the stream immediately

--- a/internal/tabhost/boot_builder.go
+++ b/internal/tabhost/boot_builder.go
@@ -1,0 +1,52 @@
+package tabhost
+
+import (
+	"context"
+	"fmt"
+
+	"reasonix/internal/boot"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+// BootBuilderOptions configures DefaultBuilder (production path).
+type BootBuilderOptions struct {
+	// Model is the provider model ref; empty uses config default.
+	Model string
+	// StatsSource labels usage (e.g. "serve", "electron"). Empty disables stats.
+	StatsSource string
+	// RequireKey fails build when API key is missing. Electron/serve UI usually false.
+	RequireKey bool
+	// Context bounds boot; nil uses Background.
+	Context context.Context
+}
+
+// DefaultBuilder returns a Builder that constructs a real control.Controller via boot.Build.
+// Each tab gets WorkspaceRoot isolation and the tab's event sink.
+func DefaultBuilder(opts BootBuilderOptions) Builder {
+	return func(create CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		ctx := opts.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		ctrl, err := boot.Build(ctx, boot.Options{
+			Model:         opts.Model,
+			RequireKey:    opts.RequireKey,
+			Sink:          sink,
+			WorkspaceRoot: create.WorkspaceRoot,
+			StatsSource:   opts.StatsSource,
+			// Interactive serve/electron: leave approval open until user answers.
+		})
+		if err != nil {
+			return nil, fmt.Errorf("tabhost boot.Build: %w", err)
+		}
+		if create.SessionPath != "" {
+			// Resume is caller-driven after Create; Builder only constructs fresh by default.
+			// Production open-topic paths can Resume after CreateTab when needed.
+			_ = create.SessionPath
+		}
+		ctrl.EnableInteractiveApproval()
+		ctrl.EnsureSessionPath()
+		return ctrl, nil
+	}
+}

--- a/internal/tabhost/controller_race_test.go
+++ b/internal/tabhost/controller_race_test.go
@@ -1,0 +1,283 @@
+package tabhost_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tabhost"
+	"reasonix/internal/tool"
+)
+
+// scriptedTurns replays fixed chunk sets per Stream call (same pattern as control tests).
+type scriptedTurns struct {
+	mu    sync.Mutex
+	turns [][]provider.Chunk
+	i     int
+}
+
+func (s *scriptedTurns) Name() string { return "scripted-tabhost" }
+
+func (s *scriptedTurns) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch := make(chan provider.Chunk, 8)
+	var chunks []provider.Chunk
+	if s.i < len(s.turns) {
+		chunks = s.turns[s.i]
+		s.i++
+	} else {
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "fallback"}, {Type: provider.ChunkDone}}
+	}
+	go func() {
+		defer close(ch)
+		for _, c := range chunks {
+			ch <- c
+		}
+	}()
+	return ch, nil
+}
+
+func textTurn(s string) []provider.Chunk {
+	return []provider.Chunk{
+		{Type: provider.ChunkText, Text: s},
+		{Type: provider.ChunkDone},
+	}
+}
+
+// realControllerBuilder builds a genuine control.Controller with a scripted provider.
+// Each tab gets its own session dir under workspace and independent agent/controller.
+func realControllerBuilder(t *testing.T, turnText string) tabhost.Builder {
+	t.Helper()
+	return func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		sessionDir := filepath.Join(opts.WorkspaceRoot, ".reasonix-sessions")
+		prov := &scriptedTurns{turns: [][]provider.Chunk{
+			textTurn(turnText + ":" + filepath.Base(opts.WorkspaceRoot)),
+			textTurn(turnText + "-again"),
+		}}
+		ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, sink)
+		c := control.New(control.Options{
+			Runner:        ag,
+			Executor:      ag,
+			Sink:          sink,
+			Label:         opts.Label,
+			SessionDir:    sessionDir,
+			WorkspaceRoot: opts.WorkspaceRoot,
+		})
+		c.EnableInteractiveApproval()
+		c.EnsureSessionPath()
+		return c, nil
+	}
+}
+
+func TestParallelSubmitTwoWorkspacesRace(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	h := tabhost.New(realControllerBuilder(t, "reply"))
+	defer h.CloseAll()
+
+	a, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirA, Label: "A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirB, Label: "B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.SessionPath == "" || b.SessionPath == "" {
+		t.Fatalf("missing session paths a=%q b=%q", a.SessionPath, b.SessionPath)
+	}
+	if a.SessionPath == b.SessionPath {
+		t.Fatalf("tabs must not share session path: %s", a.SessionPath)
+	}
+
+	ch, unsub := h.Bus().Subscribe()
+	defer unsub()
+
+	var (
+		doneA, doneB atomic.Bool
+		textA, textB atomic.Value
+	)
+
+	// Drain events until both tabs finish a turn.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deadline := time.After(15 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				return
+			case raw, ok := <-ch:
+				if !ok {
+					return
+				}
+				var w tabhost.WireEvent
+				if err := json.Unmarshal(raw, &w); err != nil {
+					continue
+				}
+				switch w.Kind {
+				case "text":
+					if w.TabID == a.ID {
+						textA.Store(w.Text)
+					}
+					if w.TabID == b.ID {
+						textB.Store(w.Text)
+					}
+				case "turn_done":
+					if w.TabID == a.ID {
+						doneA.Store(true)
+					}
+					if w.TabID == b.ID {
+						doneB.Store(true)
+					}
+				}
+				if doneA.Load() && doneB.Load() {
+					return
+				}
+			}
+		}
+	}()
+
+	// Concurrent Submit must not cancel or mis-route the sibling tab.
+	var submitWG sync.WaitGroup
+	submitWG.Add(2)
+	go func() {
+		defer submitWG.Done()
+		if err := h.SubmitHTTP(a.ID, "task-A"); err != nil {
+			t.Errorf("submit A: %v", err)
+		}
+	}()
+	go func() {
+		defer submitWG.Done()
+		if err := h.SubmitHTTP(b.ID, "task-B"); err != nil {
+			t.Errorf("submit B: %v", err)
+		}
+	}()
+	submitWG.Wait()
+	wg.Wait()
+
+	if !doneA.Load() || !doneB.Load() {
+		t.Fatalf("turn_done missing A=%v B=%v textA=%v textB=%v",
+			doneA.Load(), doneB.Load(), textA.Load(), textB.Load())
+	}
+	// Text should reference each workspace basename, proving distinct controllers.
+	ta, _ := textA.Load().(string)
+	tb, _ := textB.Load().(string)
+	if ta == "" || tb == "" {
+		t.Fatalf("empty text A=%q B=%q", ta, tb)
+	}
+	// Active switch mid-flight must not cancel either turn (already done here;
+	// exercise API concurrency still).
+	if err := h.SetActiveTab(a.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.SetActiveTab(b.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDuplicateSessionPathRejected(t *testing.T) {
+	// Force both builders to use the same SessionPath so host uniqueness/lease fires.
+	sharedPath := filepath.Join(t.TempDir(), "shared.jsonl")
+	buildFixed := func(label string) tabhost.Builder {
+		return func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+			prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn(label)}}
+			ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, sink)
+			return control.New(control.Options{
+				Runner:        ag,
+				Executor:      ag,
+				Sink:          sink,
+				Label:         label,
+				SessionDir:    filepath.Dir(sharedPath),
+				SessionPath:   sharedPath,
+				WorkspaceRoot: opts.WorkspaceRoot,
+			}), nil
+		}
+	}
+
+	h := tabhost.New(buildFixed("first"))
+	defer h.CloseAll()
+	m1, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir(), Label: "1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m1.SessionPath == "" {
+		t.Fatal("expected session path")
+	}
+
+	// Same host + predeclared path: rejected before/at create.
+	_, err = h.CreateTab(tabhost.CreateTabOpts{
+		WorkspaceRoot: t.TempDir(),
+		Label:         "2",
+		SessionPath:   m1.SessionPath,
+	})
+	if err == nil {
+		t.Fatal("expected session path in use on same host")
+	}
+
+	// Separate host trying the same path: lease acquire must fail.
+	h2 := tabhost.New(buildFixed("second"))
+	defer h2.CloseAll()
+	if _, err := h2.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir(), Label: "x"}); err == nil {
+		t.Fatal("expected lease held when second host opens same session path")
+	}
+}
+
+func TestCancelDoesNotCrossTabs(t *testing.T) {
+	// Slow-ish scripted turn: first chunk delayed via multi-turn stream is hard;
+	// instead start two tabs, cancel A, ensure B can still complete.
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	h := tabhost.New(realControllerBuilder(t, "ok"))
+	defer h.CloseAll()
+
+	a, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirA, Label: "A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dirB, Label: "B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrlA, _, err := h.Get(a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrlA.Cancel() // must not affect B
+
+	ch, unsub := h.Bus().Subscribe()
+	defer unsub()
+	if err := h.SubmitHTTP(b.ID, "only-B"); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timeout waiting for B turn_done")
+		case raw := <-ch:
+			var w tabhost.WireEvent
+			if json.Unmarshal(raw, &w) != nil {
+				continue
+			}
+			if w.Kind == "turn_done" && w.TabID == b.ID {
+				return
+			}
+			if w.Kind == "turn_done" && w.TabID == a.ID {
+				// A was cancelled idle; if a done arrives without submit it's fine to ignore
+			}
+		}
+	}
+}

--- a/internal/tabhost/doc.go
+++ b/internal/tabhost/doc.go
@@ -1,0 +1,15 @@
+// Package tabhost is a transport-agnostic multi-Controller session host.
+//
+// It owns many independent control.SessionAPI instances (one per Tab), stamps
+// tabId/runtimeEpoch onto eventwire payloads, and is the shared runtime behind
+// multi-tab reasonix serve and the Electron desktop shell.
+//
+// Design constraints (see docs/TABHOST_CONTRACT.md):
+//
+//   - Tab semantics align with desktop WorkspaceTab / TabMeta, not a new slang.
+//   - This package is a frontend-layer package (may import control); leaves must not.
+//   - Wails desktop is not required to migrate onto tabhost in MVP-B.
+//   - Single-session serve remains the default; multi-tab is opt-in.
+//
+// Layering: listed in tools/repolint/layers.go frontends.
+package tabhost

--- a/internal/tabhost/eventbus.go
+++ b/internal/tabhost/eventbus.go
@@ -1,0 +1,95 @@
+package tabhost
+
+import (
+	"encoding/json"
+	"sync"
+
+	"reasonix/internal/event"
+	"reasonix/internal/eventwire"
+)
+
+// WireEvent is eventwire.Event plus tab routing fields (desktop wireEventTab).
+type WireEvent struct {
+	eventwire.Event
+	TabID        string `json:"tabId"`
+	RuntimeEpoch string `json:"runtimeEpoch,omitempty"`
+}
+
+// EventBus fans stamped wire events to subscribers (SSE / host adapters).
+type EventBus struct {
+	mu   sync.Mutex
+	subs map[chan []byte]struct{}
+}
+
+// NewEventBus builds an empty bus.
+func NewEventBus() *EventBus {
+	return &EventBus{subs: make(map[chan []byte]struct{})}
+}
+
+// Subscribe registers a buffered subscriber. Caller must Unsubscribe.
+func (b *EventBus) Subscribe() (<-chan []byte, func()) {
+	ch := make(chan []byte, 64)
+	b.mu.Lock()
+	b.subs[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		if _, ok := b.subs[ch]; ok {
+			delete(b.subs, ch)
+			close(ch)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// PublishJSON broadcasts a pre-marshaled payload; drops if a subscriber is full.
+func (b *EventBus) PublishJSON(data []byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		select {
+		case ch <- data:
+		default:
+			// drop — same class of tradeoff as serve.Broadcaster
+		}
+	}
+}
+
+// PublishEvent stamps tab metadata and publishes.
+func (b *EventBus) PublishEvent(tabID, runtimeEpoch string, e event.Event) error {
+	w := WireEvent{
+		Event:        eventwire.ToWire(e),
+		TabID:        tabID,
+		RuntimeEpoch: runtimeEpoch,
+	}
+	data, err := json.Marshal(w)
+	if err != nil {
+		return err
+	}
+	b.PublishJSON(data)
+	return nil
+}
+
+// tabSink implements event.Sink and stamps tabId onto the bus.
+type tabSink struct {
+	bus          *EventBus
+	tabID        string
+	runtimeEpoch string
+	mu           sync.RWMutex
+}
+
+func (s *tabSink) Emit(e event.Event) {
+	s.mu.RLock()
+	id, epoch, bus := s.tabID, s.runtimeEpoch, s.bus
+	s.mu.RUnlock()
+	if bus == nil || id == "" {
+		return
+	}
+	_ = bus.PublishEvent(id, epoch, e)
+}
+
+func (s *tabSink) setEpoch(epoch string) {
+	s.mu.Lock()
+	s.runtimeEpoch = epoch
+	s.mu.Unlock()
+}

--- a/internal/tabhost/eventbus_test.go
+++ b/internal/tabhost/eventbus_test.go
@@ -1,0 +1,26 @@
+package tabhost_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/tabhost"
+)
+
+func TestEventBusPublishSubscribe(t *testing.T) {
+	bus := tabhost.NewEventBus()
+	ch, unsub := bus.Subscribe()
+	defer unsub()
+	if err := bus.PublishEvent("tab_1", "epoch-a", event.Event{Kind: event.Text, Text: "hi"}); err != nil {
+		t.Fatal(err)
+	}
+	raw := <-ch
+	var w tabhost.WireEvent
+	if err := json.Unmarshal(raw, &w); err != nil {
+		t.Fatal(err)
+	}
+	if w.TabID != "tab_1" || w.RuntimeEpoch != "epoch-a" || w.Kind != "text" || w.Text != "hi" {
+		t.Fatalf("wire=%+v", w)
+	}
+}

--- a/internal/tabhost/host.go
+++ b/internal/tabhost/host.go
@@ -1,0 +1,397 @@
+package tabhost
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+// ErrTabNotFound is returned when a tab id is unknown.
+var ErrTabNotFound = errors.New("tabhost: tab not found")
+
+// ErrSessionPathInUse is returned when another tab already holds the session path.
+var ErrSessionPathInUse = errors.New("tabhost: session path already open")
+
+// Builder constructs a SessionAPI for a new tab. Tests inject fakes; production
+// uses DefaultBuilder (boot.Build).
+type Builder func(opts CreateTabOpts, sink event.Sink) (control.SessionAPI, error)
+
+// Host owns many independent Controllers (one per Tab).
+type Host struct {
+	mu     sync.Mutex
+	tabs   map[string]*Tab
+	order  []string
+	active string
+	build  Builder
+	bus    *EventBus
+	max    int // 0 = unlimited
+}
+
+// Tab is one open conversation with its own controller.
+type Tab struct {
+	meta   TabMeta
+	ctrl   control.SessionAPI
+	sink   *tabSink
+	leases *control.SessionLeaseKeeper
+	// bindMu serializes path-changing operations on this tab only.
+	bindMu sync.Mutex
+}
+
+// Option configures Host construction.
+type Option func(*Host)
+
+// WithMaxTabs caps concurrent tabs (0 = unlimited).
+func WithMaxTabs(n int) Option {
+	return func(h *Host) { h.max = n }
+}
+
+// New builds a Host. build must be non-nil.
+func New(build Builder, opts ...Option) *Host {
+	if build == nil {
+		panic("tabhost: Builder is required")
+	}
+	h := &Host{
+		tabs:  make(map[string]*Tab),
+		build: build,
+		bus:   NewEventBus(),
+	}
+	for _, o := range opts {
+		o(h)
+	}
+	return h
+}
+
+// Bus returns the multiplexed event bus (SSE attaches here).
+func (h *Host) Bus() *EventBus { return h.bus }
+
+// CreateTab opens a new tab. The created tab becomes active.
+// Controller construction runs outside the host lock so long boot.Build calls
+// do not block ListTabs; session-path uniqueness is re-checked after build.
+func (h *Host) CreateTab(opts CreateTabOpts) (TabMeta, error) {
+	if opts.Scope == "" {
+		opts.Scope = ScopeProject
+	}
+	if opts.Scope == ScopeProject && opts.WorkspaceRoot == "" {
+		return TabMeta{}, fmt.Errorf("tabhost: workspaceRoot required for project scope")
+	}
+	if opts.TopicID == "" {
+		opts.TopicID = "main"
+	}
+	if opts.TopicTitle == "" {
+		opts.TopicTitle = "Session"
+	}
+
+	h.mu.Lock()
+	if h.max > 0 && len(h.tabs) >= h.max {
+		h.mu.Unlock()
+		return TabMeta{}, fmt.Errorf("tabhost: tab limit %d reached", h.max)
+	}
+	if opts.SessionPath != "" {
+		if id := h.tabIDForSessionPathLocked(opts.SessionPath); id != "" {
+			h.mu.Unlock()
+			return TabMeta{}, fmt.Errorf("%w: %s", ErrSessionPathInUse, opts.SessionPath)
+		}
+	}
+	// Reserve a slot id before unlocking so concurrent creates don't share ids.
+	id := newTabID()
+	// Placeholder prevents double-use of id; filled after build.
+	h.tabs[id] = &Tab{meta: TabMeta{ID: id, Scope: opts.Scope, WorkspaceRoot: opts.WorkspaceRoot}}
+	h.order = append(h.order, id)
+	h.mu.Unlock()
+
+	sink := &tabSink{bus: h.bus, tabID: id}
+	ctrl, buildErr := h.build(opts, sink)
+
+	leases := control.NewSessionLeaseKeeper()
+	meta := TabMeta{
+		ID:                id,
+		Scope:             opts.Scope,
+		WorkspaceRoot:     opts.WorkspaceRoot,
+		WorkspaceName:     workspaceName(opts.WorkspaceRoot),
+		WorkspacePath:     opts.WorkspaceRoot,
+		TopicID:           opts.TopicID,
+		TopicTitle:        opts.TopicTitle,
+		SessionPath:       opts.SessionPath,
+		ReadOnly:          opts.ReadOnly,
+		Label:             opts.Label,
+		Ready:             buildErr == nil && ctrl != nil,
+		Running:           false,
+		Cancellable:       false,
+		Mode:              "agent",
+		CollaborationMode: "default",
+		ToolApprovalMode:  "ask",
+		TokenMode:         "auto",
+		Active:            true,
+		Cwd:               opts.WorkspaceRoot,
+		Runtime:           map[string]any{"phase": "ready"},
+	}
+	if buildErr != nil {
+		meta.Ready = false
+		meta.StartupErr = buildErr.Error()
+		meta.Runtime = map[string]any{"phase": "failed"}
+	}
+
+	if ctrl != nil {
+		// Prefer EnsureSessionPath so every tab has a durable transcript path.
+		if c, ok := ctrl.(*control.Controller); ok {
+			c.EnableInteractiveApproval()
+			if c.SessionPath() == "" {
+				c.EnsureSessionPath()
+			}
+		}
+		if p := ctrl.SessionPath(); p != "" {
+			meta.SessionPath = p
+			if err := leases.Rebind(p); err != nil {
+				ctrl.Close()
+				h.mu.Lock()
+				h.removeTabLocked(id)
+				h.mu.Unlock()
+				return TabMeta{}, fmt.Errorf("tabhost: session lease: %w", err)
+			}
+		}
+		if opts.Label == "" {
+			meta.Label = ctrl.Label()
+		}
+	}
+
+	// Re-check path uniqueness after build (EnsureSessionPath minted a path).
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if meta.SessionPath != "" {
+		if other := h.tabIDForSessionPathLocked(meta.SessionPath); other != "" && other != id {
+			if ctrl != nil {
+				leases.Release()
+				ctrl.Close()
+			}
+			h.removeTabLocked(id)
+			return TabMeta{}, fmt.Errorf("%w: %s", ErrSessionPathInUse, meta.SessionPath)
+		}
+	}
+	// Mark previous active false
+	for _, t := range h.tabs {
+		if t != nil {
+			t.meta.Active = false
+		}
+	}
+	tab := &Tab{meta: meta, ctrl: ctrl, sink: sink, leases: leases}
+	h.tabs[id] = tab
+	h.active = id
+	return meta, nil
+}
+
+// ListTabs returns tab metadata in open order.
+func (h *Host) ListTabs() []TabMeta {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]TabMeta, 0, len(h.order))
+	for _, id := range h.order {
+		t := h.tabs[id]
+		if t == nil {
+			continue
+		}
+		m := t.meta
+		m.Active = id == h.active
+		if t.ctrl != nil {
+			st := t.ctrl.RuntimeStatus()
+			m.Running = st.Running || st.PendingPrompt || st.BackgroundJobs > 0
+			m.PendingPrompt = st.PendingPrompt
+			m.BackgroundJobs = st.BackgroundJobs
+			m.CancelRequested = st.CancelRequested
+			m.Cancellable = st.Cancellable
+			if p := t.ctrl.SessionPath(); p != "" {
+				m.SessionPath = p
+			}
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// SetActiveTab focuses a tab without cancelling others.
+func (h *Host) SetActiveTab(id string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.tabs[id]; !ok {
+		return ErrTabNotFound
+	}
+	h.active = id
+	return nil
+}
+
+// ActiveTabID returns the focused tab id (empty if none).
+func (h *Host) ActiveTabID() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.active
+}
+
+// Get returns a tab's SessionAPI and a per-tab bind mutex for path rebinds.
+func (h *Host) Get(id string) (control.SessionAPI, *sync.Mutex, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	t, ok := h.tabs[id]
+	if !ok {
+		return nil, nil, ErrTabNotFound
+	}
+	if t.ctrl == nil {
+		return nil, nil, fmt.Errorf("tabhost: tab %s has no controller: %s", id, t.meta.StartupErr)
+	}
+	return t.ctrl, &t.bindMu, nil
+}
+
+// SubmitHTTP runs a user turn on tab id via SubmitHTTP (serve/Electron path).
+// It does not wait for completion; callers observe Bus events.
+func (h *Host) SubmitHTTP(id, input string) error {
+	ctrl, _, err := h.Get(id)
+	if err != nil {
+		return err
+	}
+	// Prefer HTTP submit when available (blocks shell bang-path).
+	type httpSubmitter interface {
+		SubmitHTTP(input string)
+	}
+	if hs, ok := ctrl.(httpSubmitter); ok {
+		hs.SubmitHTTP(input)
+		return nil
+	}
+	type submitter interface {
+		Submit(input string)
+	}
+	if s, ok := ctrl.(submitter); ok {
+		s.Submit(input)
+		return nil
+	}
+	return fmt.Errorf("tabhost: controller does not support Submit")
+}
+
+// RebindSessionLease moves the tab's lease to a new session path (after resume/new).
+func (h *Host) RebindSessionLease(id, path string) error {
+	h.mu.Lock()
+	t, ok := h.tabs[id]
+	if !ok {
+		h.mu.Unlock()
+		return ErrTabNotFound
+	}
+	leases := t.leases
+	if path != "" {
+		if other := h.tabIDForSessionPathLocked(path); other != "" && other != id {
+			h.mu.Unlock()
+			return fmt.Errorf("%w: %s", ErrSessionPathInUse, path)
+		}
+	}
+	h.mu.Unlock()
+	if leases == nil {
+		return nil
+	}
+	if err := leases.Rebind(path); err != nil {
+		return err
+	}
+	h.mu.Lock()
+	if t2 := h.tabs[id]; t2 != nil {
+		t2.meta.SessionPath = path
+	}
+	h.mu.Unlock()
+	return nil
+}
+
+// CloseTab tears down a tab.
+func (h *Host) CloseTab(id string) error {
+	h.mu.Lock()
+	t, ok := h.tabs[id]
+	if !ok {
+		h.mu.Unlock()
+		return ErrTabNotFound
+	}
+	h.removeTabLocked(id)
+	ctrl := t.ctrl
+	leases := t.leases
+	h.mu.Unlock()
+
+	if ctrl != nil {
+		_ = ctrl.Snapshot()
+		ctrl.Close()
+	}
+	if leases != nil {
+		leases.Release()
+	}
+	return nil
+}
+
+// CloseAll closes every tab (process shutdown).
+func (h *Host) CloseAll() {
+	h.mu.Lock()
+	ids := append([]string(nil), h.order...)
+	h.mu.Unlock()
+	for _, id := range ids {
+		_ = h.CloseTab(id)
+	}
+}
+
+func (h *Host) removeTabLocked(id string) {
+	delete(h.tabs, id)
+	next := h.order[:0]
+	for _, x := range h.order {
+		if x != id {
+			next = append(next, x)
+		}
+	}
+	h.order = next
+	if h.active == id {
+		h.active = ""
+		if len(h.order) > 0 {
+			h.active = h.order[len(h.order)-1]
+		}
+	}
+}
+
+func (h *Host) tabIDForSessionPathLocked(path string) string {
+	want, err := filepath.Abs(path)
+	if err != nil {
+		want = path
+	}
+	for id, t := range h.tabs {
+		if t == nil {
+			continue
+		}
+		sp := t.meta.SessionPath
+		if t.ctrl != nil {
+			if p := t.ctrl.SessionPath(); p != "" {
+				sp = p
+			}
+		}
+		if sp == "" {
+			continue
+		}
+		got, err := filepath.Abs(sp)
+		if err != nil {
+			got = sp
+		}
+		if got == want {
+			return id
+		}
+	}
+	return ""
+}
+
+func newTabID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "tab_" + hex.EncodeToString(b[:])
+}
+
+func workspaceName(root string) string {
+	if root == "" {
+		return "global"
+	}
+	base := filepath.Base(root)
+	if base == "." || base == string(filepath.Separator) {
+		return root
+	}
+	return base
+}

--- a/internal/tabhost/host_test.go
+++ b/internal/tabhost/host_test.go
@@ -1,0 +1,195 @@
+package tabhost_test
+
+import (
+	"encoding/json"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/tabhost"
+)
+
+// Tests inject nil SessionAPI; Host still tracks TabMeta and event stamping.
+
+func TestDefaultBuilderConstructs(t *testing.T) {
+	b := tabhost.DefaultBuilder(tabhost.BootBuilderOptions{RequireKey: false, StatsSource: "test"})
+	if b == nil {
+		t.Fatal("DefaultBuilder returned nil")
+	}
+}
+
+func TestTabMetaFixtureJSONShape(t *testing.T) {
+	raw, err := os.ReadFile("testdata/tabmeta_minimal.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m tabhost.TabMeta
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.ID == "" || m.Scope != "project" || !m.Ready || !m.Active {
+		t.Fatalf("unexpected meta: %+v", m)
+	}
+	// Round-trip must keep camelCase keys used by the frontend.
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe map[string]any
+	if err := json.Unmarshal(out, &probe); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"workspaceRoot", "topicId", "toolApprovalMode", "tokenMode"} {
+		if _, ok := probe[key]; !ok {
+			t.Fatalf("missing json key %q in %s", key, out)
+		}
+	}
+}
+
+func TestCreateListActivateClose(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	var builds atomic.Int32
+	h := tabhost.New(func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		builds.Add(1)
+		// Return nil controller: host still tracks tabs; Get will error.
+		_ = sink
+		_ = opts
+		return nil, nil
+	})
+	defer h.CloseAll()
+
+	a, err := h.CreateTab(tabhost.CreateTabOpts{Scope: tabhost.ScopeProject, WorkspaceRoot: dirA, Label: "A"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := h.CreateTab(tabhost.CreateTabOpts{Scope: tabhost.ScopeProject, WorkspaceRoot: dirB, Label: "B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if builds.Load() != 2 {
+		t.Fatalf("builds=%d", builds.Load())
+	}
+	tabs := h.ListTabs()
+	if len(tabs) != 2 {
+		t.Fatalf("tabs=%d", len(tabs))
+	}
+	// Last created is active
+	if !tabs[1].Active || tabs[0].Active {
+		t.Fatalf("active flags: %+v %+v", tabs[0], tabs[1])
+	}
+	if err := h.SetActiveTab(a.ID); err != nil {
+		t.Fatal(err)
+	}
+	tabs = h.ListTabs()
+	var activeID string
+	for _, tm := range tabs {
+		if tm.Active {
+			activeID = tm.ID
+		}
+	}
+	if activeID != a.ID {
+		t.Fatalf("active=%s want %s", activeID, a.ID)
+	}
+	if err := h.CloseTab(a.ID); err != nil {
+		t.Fatal(err)
+	}
+	tabs = h.ListTabs()
+	if len(tabs) != 1 || tabs[0].ID != b.ID {
+		t.Fatalf("after close: %+v", tabs)
+	}
+}
+
+func TestEventBusStampsTabID(t *testing.T) {
+	h := tabhost.New(func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		// Immediately emit so subscribers see tab-stamped events.
+		go func() {
+			sink.Emit(event.Event{Kind: event.Text, Text: "hello-" + opts.WorkspaceRoot})
+		}()
+		return nil, nil
+	})
+	defer h.CloseAll()
+
+	ch, unsub := h.Bus().Subscribe()
+	defer unsub()
+
+	dir := t.TempDir()
+	meta, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: dir, Label: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got tabhost.WireEvent
+	select {
+	case raw := <-ch:
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		// allow async emit
+		raw := <-ch
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got.TabID != meta.ID {
+		t.Fatalf("tabId=%q want %q", got.TabID, meta.ID)
+	}
+	if got.Kind != "text" {
+		t.Fatalf("kind=%q", got.Kind)
+	}
+	if got.Text == "" {
+		t.Fatal("expected text payload")
+	}
+}
+
+func TestTwoTabsEmitDistinctTabIDs(t *testing.T) {
+	h := tabhost.New(func(opts tabhost.CreateTabOpts, sink event.Sink) (control.SessionAPI, error) {
+		sink.Emit(event.Event{Kind: event.Notice, Text: opts.Label})
+		return nil, nil
+	})
+	defer h.CloseAll()
+	ch, unsub := h.Bus().Subscribe()
+	defer unsub()
+
+	a, _ := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir(), Label: "A"})
+	b, _ := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir(), Label: "B"})
+
+	seen := map[string]string{}
+	for len(seen) < 2 {
+		raw := <-ch
+		var w tabhost.WireEvent
+		if err := json.Unmarshal(raw, &w); err != nil {
+			t.Fatal(err)
+		}
+		seen[w.TabID] = w.Text
+	}
+	if seen[a.ID] != "A" || seen[b.ID] != "B" {
+		t.Fatalf("seen=%v a=%s b=%s", seen, a.ID, b.ID)
+	}
+}
+
+func TestCreateTabRequiresWorkspace(t *testing.T) {
+	h := tabhost.New(func(tabhost.CreateTabOpts, event.Sink) (control.SessionAPI, error) {
+		return nil, nil
+	})
+	_, err := h.CreateTab(tabhost.CreateTabOpts{Scope: tabhost.ScopeProject})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMaxTabs(t *testing.T) {
+	h := tabhost.New(func(tabhost.CreateTabOpts, event.Sink) (control.SessionAPI, error) {
+		return nil, nil
+	}, tabhost.WithMaxTabs(1))
+	defer h.CloseAll()
+	if _, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.CreateTab(tabhost.CreateTabOpts{WorkspaceRoot: t.TempDir()}); err == nil {
+		t.Fatal("expected limit error")
+	}
+}

--- a/internal/tabhost/meta.go
+++ b/internal/tabhost/meta.go
@@ -1,0 +1,52 @@
+package tabhost
+
+// TabMeta is the frontend-facing shape of one tab.
+// JSON tags match desktop.TabMeta / desktop frontend types.TabMeta.
+type TabMeta struct {
+	ID                string         `json:"id"`
+	Scope             string         `json:"scope"`
+	WorkspaceRoot     string         `json:"workspaceRoot"`
+	WorkspaceName     string         `json:"workspaceName"`
+	WorkspacePath     string         `json:"workspacePath,omitempty"`
+	GitBranch         string         `json:"gitBranch,omitempty"`
+	IsolatedWorktree  bool           `json:"isolatedWorktree,omitempty"`
+	TopicID           string         `json:"topicId"`
+	TopicTitle        string         `json:"topicTitle"`
+	SessionPath       string         `json:"sessionPath,omitempty"`
+	ReadOnly          bool           `json:"readOnly,omitempty"`
+	ProjectColor      string         `json:"projectColor,omitempty"`
+	Label             string         `json:"label"`
+	Ready             bool           `json:"ready"`
+	Runtime           map[string]any `json:"runtime,omitempty"`
+	Running           bool           `json:"running"`
+	PendingPrompt     bool           `json:"pendingPrompt,omitempty"`
+	BackgroundJobs    int            `json:"backgroundJobs,omitempty"`
+	CancelRequested   bool           `json:"cancelRequested,omitempty"`
+	Cancellable       bool           `json:"cancellable"`
+	Mode              string         `json:"mode"`
+	CollaborationMode string         `json:"collaborationMode"`
+	ToolApprovalMode  string         `json:"toolApprovalMode"`
+	TokenMode         string         `json:"tokenMode"`
+	Goal              string         `json:"goal,omitempty"`
+	GoalStatus        string         `json:"goalStatus,omitempty"`
+	StartupErr        string         `json:"startupErr,omitempty"`
+	Active            bool           `json:"active"`
+	Cwd               string         `json:"cwd"`
+}
+
+// CreateTabOpts configures a new tab.
+type CreateTabOpts struct {
+	Scope         string // "project" | "global"
+	WorkspaceRoot string
+	TopicID       string
+	TopicTitle    string
+	SessionPath   string // optional resume path
+	ReadOnly      bool
+	Label         string
+}
+
+// ScopeProject and ScopeGlobal match desktop tab scopes.
+const (
+	ScopeProject = "project"
+	ScopeGlobal  = "global"
+)

--- a/internal/tabhost/testdata/tabmeta_minimal.json
+++ b/internal/tabhost/testdata/tabmeta_minimal.json
@@ -1,0 +1,22 @@
+{
+  "id": "tab_example_01",
+  "scope": "project",
+  "workspaceRoot": "/tmp/example-project",
+  "workspaceName": "example-project",
+  "workspacePath": "/tmp/example-project",
+  "topicId": "main",
+  "topicTitle": "Session",
+  "label": "model",
+  "ready": true,
+  "runtime": {
+    "phase": "ready"
+  },
+  "running": false,
+  "cancellable": false,
+  "mode": "agent",
+  "collaborationMode": "default",
+  "toolApprovalMode": "ask",
+  "tokenMode": "auto",
+  "active": true,
+  "cwd": "/tmp/example-project"
+}

--- a/tools/repolint/layers.go
+++ b/tools/repolint/layers.go
@@ -17,6 +17,7 @@ var frontends = []string{
 	"internal/botruntime",
 	"internal/cli",
 	"internal/serve",
+	"internal/tabhost", // multi-Controller session host for serve/Electron (route C)
 }
 
 // Utility layer: these packages carry no knowledge of the kernel and must


### PR DESCRIPTION
## Summary

- Add `internal/tabhost` multi-Controller runtime and `reasonix serve --multi-tab` `/tabs…` HTTP+SSE routes for concurrent project tabs.
- Add `internal/desktopsidebar` + `/desktop/*` APIs so Electron and Wails share `desktop-projects.json` / topic metadata for project tree and topic CRUD.
- Ship experimental `electron-poc/` shell (loopback serve supervision, same-origin proxy, HttpSseHost, multi-tab desktop UI wiring). Official product remains Wails.

## Scope / non-goals

- **In:** multi-tab chat, open project, tab switch, sidebar tree/topics, shell auth cookie pin, dual-project smoke.
- **Out / deferred:** Terminal PTY, Remote SSH, Bot IM runtime, Heartbeat, full Settings write-back, production Electron packaging/updater.

## Test plan

- [x] `go test ./internal/tabhost/ ./internal/desktopsidebar/ ./internal/serve/`
- [x] `cd electron-poc && npm test`
- [x] `npm run smoke:dual-project` (with local `REASONIX_BIN`)
- [x] Manual Electron: add project, multi-tab switch, transcript isolation
- [ ] CI green on draft PR