### PR TITLE
test(boot): effect tests — boundary behavior through the real assembly

### DIFF
--- a/REASONIX.md
+++ b/REASONIX.md
@@ -18,6 +18,10 @@ agent. It is the Reasonix analog of Claude Code's CLAUDE.md.
 - Cache-first: the system-prompt prefix (base prompt + tools + memory) must stay
   byte-stable across turns so DeepSeek's automatic prefix cache stays warm. Never
   mutate it mid-session — ride the turn tail instead (see `control.Compose`).
+- Performance features land with an effect test at their final boundary
+  (`internal/boot/effect_test.go` pattern): assert what actually reaches the
+  provider request, frontend sink, or trajectory through the real `boot.Build`
+  assembly. Component correctness is not system effectiveness.
 
 ## Comments
 

--- a/internal/boot/effect_test.go
+++ b/internal/boot/effect_test.go
@@ -1,0 +1,124 @@
+package boot
+
+// Effect tests assert final-boundary behavior through the real Build stack:
+// a scripted provider records what actually reaches the provider boundary.
+// Component correctness is not system effectiveness (see REASONIX.md).
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"reasonix/internal/ablation"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type effectRecordingProvider struct {
+	mu   sync.Mutex
+	reqs []provider.Request
+}
+
+func (p *effectRecordingProvider) Name() string { return "boot-effect-test" }
+
+func (p *effectRecordingProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.reqs = append(p.reqs, req)
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func (p *effectRecordingProvider) requests() []provider.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]provider.Request(nil), p.reqs...)
+}
+
+// effectRun builds the real stack around a recording provider, runs one
+// prompt, and returns every request that reached the provider boundary.
+func effectRun(t *testing.T, kind, tokenMode string, arm ablation.Set) []provider.Request {
+	t.Helper()
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	rec := &effectRecordingProvider{}
+	provider.Register(kind, func(provider.Config) (provider.Provider, error) {
+		return rec, nil
+	})
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "`+kind+`"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard, TokenMode: tokenMode, Ablation: arm})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "reply ok"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := rec.requests()
+	if len(reqs) == 0 {
+		t.Fatal("no request reached the provider boundary")
+	}
+	return reqs
+}
+
+func toolNames(req provider.Request) map[string]bool {
+	names := make(map[string]bool, len(req.Tools))
+	for _, tool := range req.Tools {
+		names[tool.Name] = true
+	}
+	return names
+}
+
+// TestEffectEconomyShrinksProviderToolSurface pins the economy tier's whole
+// point at the boundary it must appear: the schema set the provider is
+// actually sent, not the registry the host assembles.
+func TestEffectEconomyShrinksProviderToolSurface(t *testing.T) {
+	full := effectRun(t, "boot-effect-full", "", ablation.Set{})
+	economy := effectRun(t, "boot-effect-economy", "economy", ablation.Set{})
+
+	fullTools := len(full[0].Tools)
+	economyTools := len(economy[0].Tools)
+	if economyTools >= fullTools {
+		t.Fatalf("economy sent %d tool schemas, full sent %d — the lean surface never reached the provider", economyTools, fullTools)
+	}
+	if economyTools > 15 {
+		t.Fatalf("economy sent %d tool schemas; the core surface contract is a small fixed set", economyTools)
+	}
+	if !toolNames(economy[0])["connect_tool_source"] {
+		t.Fatal("economy surface must still offer connect_tool_source to grow on demand")
+	}
+}
+
+// TestEffectSubagentAblationRemovesChildToolSchemas asserts the ablation at
+// the provider boundary: with subagents off the model cannot even see the
+// spawning tools, so no trajectory can ever contain a child request.
+func TestEffectSubagentAblationRemovesChildToolSchemas(t *testing.T) {
+	control := effectRun(t, "boot-effect-sub-on", "", ablation.Set{})
+	ablated := effectRun(t, "boot-effect-sub-off", "", ablation.New(ablation.Subagent))
+
+	if names := toolNames(control[0]); !names["task"] {
+		t.Fatal("control surface must offer the task tool; the ablation assertion below would be vacuous")
+	}
+	names := toolNames(ablated[0])
+	for _, spawn := range []string{"task", "parallel_tasks", "fleet"} {
+		if names[spawn] {
+			t.Fatalf("subagent-ablated surface still offers %q — the model can spawn children the arm claims to disable", spawn)
+		}
+	}
+}


### PR DESCRIPTION
## What

Institutionalizes the coalescer lesson (#7889 shipped correct-and-inert, fixed by #7905) as a test class: **effect tests** run the real `boot.Build` stack around a scripted provider that records what reaches the provider boundary, and assert a feature's effect where it must appear — not in the component that implements it.

Two exemplars land with the pattern:

- **Economy tool surface**: the economy tier really shrinks the provider-visible tool schema set (strictly fewer schemas than the full profile, bounded small, and `connect_tool_source` still offered so the surface can grow on demand). The unit-level registry could be right while the provider request stayed fat — this pins the request.
- **Subagent ablation**: with `-ablate subagent`, the spawning tools (`task`, `parallel_tasks`, `fleet`) are absent from the schema set the model sees — so no trajectory can ever contain a child request. The control arm asserts `task` is present, keeping the ablation assertion non-vacuous.

REASONIX.md gains the standing rule: performance features land with an effect test at their final boundary (provider request, frontend sink, or trajectory) — component correctness is not system effectiveness.

Follow-ups that belong in this file as their features stabilize: planner-off → zero planner-model requests (needs a two-model scripted config); stream coalescing chunk-count bound (already pinned by `coalesce_wiring_test.go`, the test this class generalizes).

## Testing

- `go test ./internal/boot/ -run TestEffect` — both tests pass; economy asserts strict inequality against the same-run full-profile count, so surface growth in either direction keeps the test honest
- `gofmt` / `go vet` / `go run ./tools/repolint` clean

Cache-impact: none - test-only Go diff plus a REASONIX.md convention line; the provider-visible prefix of a running session is byte-identical
Cache-guard: go test ./internal/boot/ -run TestEffect (the new tests themselves pin provider-visible surface shape per tier)
System-prompt-review: esengine - REASONIX.md adds one standing convention bullet (loaded into future sessions' prefix at merge); no runtime prompt assembly code touched
Documentation-impact: none - benchmarks/testing docs unaffected; the new convention lives in REASONIX.md itself