### PR TITLE
feat(taskcontract): unified task record assembled from existing signals

### DIFF
--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"fmt"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskcontract"
+	"reasonix/internal/taskintent"
+)
+
+// buildShadowContract replays a finished turn's receipts into a task
+// contract that observed everything and decided nothing: mutation-shaped
+// asks get the atomic contract, the latest todo list becomes the
+// requirement set, and the ledger drives evidence and epochs. Pure function
+// so the shadow is testable without an Agent.
+func buildShadowContract(input string, receipts []evidence.Receipt) *taskcontract.Contract {
+	var c *taskcontract.Contract
+	switch taskintent.Classify(input) {
+	case taskintent.Mutation, taskintent.PersistentAction:
+		c = taskcontract.Atomic(input)
+	default:
+		c = taskcontract.New(input)
+	}
+	var todos []evidence.TodoItem
+	for _, r := range receipts {
+		if len(r.Todos) > 0 {
+			todos = r.Todos
+		}
+	}
+	for i, todo := range todos {
+		c.AddRequirement(fmt.Sprintf("t%d", i+1), todo.Content, true)
+	}
+	for _, r := range receipts {
+		c.Observe(r)
+	}
+	for i, todo := range todos {
+		if todo.Status == "completed" {
+			c.Resolve(fmt.Sprintf("t%d", i+1), taskcontract.Satisfied)
+		}
+	}
+	return c
+}
+
+func contractShadowAudit(c *taskcontract.Contract) event.ContractShadowAudit {
+	reqDone := 0
+	for _, req := range c.Requirements {
+		if req.Status == taskcontract.Satisfied {
+			reqDone++
+		}
+	}
+	checksDone := 0
+	for _, check := range c.Checks {
+		if check.Status == taskcontract.Satisfied {
+			checksDone++
+		}
+	}
+	return event.ContractShadowAudit{
+		Intent:                intentName(c.Intent),
+		Requirements:          len(c.Requirements),
+		RequirementsSatisfied: reqDone,
+		Checks:                len(c.Checks),
+		ChecksSatisfied:       checksDone,
+		Epoch:                 c.Epoch(),
+		Verdict:               c.GoalVerdict().String(),
+		Complete:              c.Complete(),
+		ReadyToFinalize:       c.ReadyToFinalize(),
+	}
+}
+
+func intentName(i taskintent.Intent) string {
+	switch i {
+	case taskintent.Advisory:
+		return "advisory"
+	case taskintent.ObservableRead:
+		return "observable_read"
+	case taskintent.Mutation:
+		return "mutation"
+	case taskintent.PersistentAction:
+		return "persistent_action"
+	default:
+		return "conversation"
+	}
+}
+
+// emitContractShadow records the shadow contract's end-of-turn summary; the
+// contract observed the turn and decided nothing.
+func (a *Agent) emitContractShadow(input string) {
+	if a.evidence == nil {
+		return
+	}
+	c := buildShadowContract(input, a.evidence.Receipts())
+	event.RecordContractShadow(a.sink, contractShadowAudit(c))
+}

--- a/internal/agent/contract_shadow_test.go
+++ b/internal/agent/contract_shadow_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+func TestBuildShadowContractReplaysTheTurn(t *testing.T) {
+	receipts := []evidence.Receipt{
+		{ToolName: "read_file", Read: true, Success: true},
+		{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "fix add()", Status: "in_progress"},
+			{Content: "run the tests", Status: "pending"},
+		}},
+		{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"calc.py"}},
+		{ToolName: "bash", Command: "go test ./...", Success: true},
+		{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "fix add()", Status: "completed"},
+			{Content: "run the tests", Status: "completed"},
+		}},
+	}
+	c := buildShadowContract("fix the add bug in calc.py", receipts)
+	audit := contractShadowAudit(c)
+
+	if audit.Intent != "mutation" {
+		t.Fatalf("intent = %q", audit.Intent)
+	}
+	// Atomic r1 + two todo requirements.
+	if audit.Requirements != 3 || audit.RequirementsSatisfied != 3 {
+		t.Fatalf("requirements = %d/%d, want 3/3", audit.RequirementsSatisfied, audit.Requirements)
+	}
+	if audit.Epoch != 1 {
+		t.Fatalf("epoch = %d, want 1 (one mutation)", audit.Epoch)
+	}
+	if !audit.Complete || !audit.ReadyToFinalize || audit.Verdict != "complete" {
+		t.Fatalf("audit = %+v, want complete", audit)
+	}
+}
+
+func TestBuildShadowContractIncompleteTurn(t *testing.T) {
+	receipts := []evidence.Receipt{
+		{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "fix it", Status: "in_progress"},
+		}},
+		{ToolName: "edit_file", Mutation: true, Success: true},
+	}
+	audit := contractShadowAudit(buildShadowContract("investigate then fix the parser", receipts))
+	if audit.Complete {
+		t.Fatalf("open todo must keep the shadow incomplete: %+v", audit)
+	}
+	if audit.Verdict != "continue" {
+		t.Fatalf("verdict = %q, want continue", audit.Verdict)
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -59,7 +59,6 @@ type perTurnState struct {
 	deliveryMutationExpected    bool
 	deliveryPersistentExpected  bool
 	deliveryScopeActive         bool
-
 	// readinessRecovered marks a run that started with evidence preserved from
 	// (or a pending recovery of) a prior readiness failure, so the final
 	// allowed audit can report Recovered=true.
@@ -938,6 +937,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 	if readiness.applies {
 		event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, a.readinessRecovered))
 	}
+	a.emitContractShadow(state.input)
 	if !a.closeSteerIntakeIfIdle() {
 		return true, nil
 	}

--- a/internal/control/goalusage.go
+++ b/internal/control/goalusage.go
@@ -74,6 +74,14 @@ func (t *goalUsageTee) RecordReadinessAudit(a evidence.ReadinessAudit) {
 	}
 }
 
+// RecordContractShadow forwards the shadow contract audit unchanged.
+func (t *goalUsageTee) RecordContractShadow(a event.ContractShadowAudit) {
+	if t == nil || t.inner == nil {
+		return
+	}
+	event.RecordContractShadow(t.inner, a)
+}
+
 // setActiveRecorder binds the current goal turn's recorder (nil clears it).
 func (t *goalUsageTee) setActiveRecorder(rec *goalTurnRecorder) {
 	if t == nil {

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -159,3 +159,10 @@ func (c *coalescer) RecordProtocolRecovery(a ProtocolRecoveryAudit) {
 	c.drainAndUnlock()
 	RecordProtocolRecovery(c.inner, a)
 }
+
+func (c *coalescer) RecordContractShadow(a ContractShadowAudit) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordContractShadow(c.inner, a)
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -586,6 +586,38 @@ type ProtocolRecoveryAudit struct {
 	Kind ProtocolRecoveryKind
 }
 
+// ContractShadowAudit is the shadow task-contract's end-of-turn summary:
+// counts and enums only, never requirement text. Shadow means observed, not
+// enforced — the old control logic still decides behavior.
+type ContractShadowAudit struct {
+	Intent                string
+	Requirements          int
+	RequirementsSatisfied int
+	Checks                int
+	ChecksSatisfied       int
+	Epoch                 uint64
+	Verdict               string
+	Complete              bool
+	ReadyToFinalize       bool
+}
+
+// ContractShadowAuditSink is an optional sink capability; implementations
+// must keep it content-free, like every other audit channel.
+type ContractShadowAuditSink interface {
+	RecordContractShadow(ContractShadowAudit)
+}
+
+// RecordContractShadow forwards the shadow contract summary only to sinks
+// that explicitly opt in. Ordinary UI sinks receive nothing.
+func RecordContractShadow(s Sink, a ContractShadowAudit) {
+	if nilutil.IsNil(s) {
+		return
+	}
+	if cs, ok := s.(ContractShadowAuditSink); ok {
+		cs.RecordContractShadow(a)
+	}
+}
+
 // ProtocolRecoveryAuditSink is an optional sink capability. Implementations
 // must keep it content-free; prompts, responses, endpoints, model names, and
 // tool arguments do not belong in this audit channel.

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -55,3 +55,11 @@ func (s *syncSink) RecordProtocolRecovery(a ProtocolRecoveryAudit) {
 		rs.RecordProtocolRecovery(a)
 	}
 }
+
+func (s *syncSink) RecordContractShadow(a ContractShadowAudit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rs, ok := s.inner.(ContractShadowAuditSink); ok {
+		rs.RecordContractShadow(a)
+	}
+}

--- a/internal/evidence/progress.go
+++ b/internal/evidence/progress.go
@@ -124,3 +124,14 @@ func (l *Ledger) ReceiptsSince(index int) []Receipt {
 	}
 	return append([]Receipt(nil), l.receipts[index:]...)
 }
+
+// Receipts returns a copy of every receipt recorded this turn, in order —
+// the replay feed for shadow observers that must not share ledger memory.
+func (l *Ledger) Receipts() []Receipt {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]Receipt(nil), l.receipts...)
+}

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -174,6 +174,11 @@ func (r *Recorder) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 	event.RecordProtocolRecovery(r.inner, a)
 }
 
+// RecordContractShadow preserves the wrapped sink's audit capability.
+func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
+	event.RecordContractShadow(r.inner, a)
+}
+
 func (r *Recorder) recordUsage(e event.Event) {
 	r.recordProviderUsage(e.ModelRef, e.Usage)
 }

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -371,6 +371,70 @@ func (c *Contract) FinalizeSignal() string {
 		required, required, len(c.Checks), len(c.Checks))
 }
 
+// Verdict is the deterministic goal outcome the contract can decide without
+// a model call; Uncertain is the only case that still needs the bounded LLM
+// evaluator — it becomes the fallback, not the completion hot path.
+type Verdict uint8
+
+const (
+	VerdictUncertain Verdict = iota
+	VerdictContinue
+	VerdictBlocked
+	VerdictComplete
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case VerdictContinue:
+		return "continue"
+	case VerdictBlocked:
+		return "blocked"
+	case VerdictComplete:
+		return "complete"
+	default:
+		return "uncertain"
+	}
+}
+
+// GoalVerdict decides the goal outcome from the evidence graph alone.
+// Missing or stale evidence means Continue (the next action is knowable);
+// a requirement explicitly resolved Failed — an arbiter's judgment that it
+// cannot be met — means Blocked; everything fresh-satisfied means Complete.
+// Only a contract with nothing to prove returns Uncertain.
+func (c *Contract) GoalVerdict() Verdict {
+	if len(c.Requirements) == 0 && len(c.Checks) == 0 {
+		return VerdictUncertain
+	}
+	missing, blocked := false, false
+	for _, req := range c.Requirements {
+		if !req.Required {
+			continue
+		}
+		switch req.Status {
+		case Failed:
+			blocked = true
+		case Pending, Stale:
+			missing = true
+		}
+	}
+	for _, check := range c.Checks {
+		if check.Status != Satisfied {
+			// A failed check run is actionable — fix it and re-run — so it
+			// keeps the goal in Continue, never Blocked.
+			missing = true
+		}
+	}
+	switch {
+	case missing:
+		return VerdictContinue
+	case blocked:
+		return VerdictBlocked
+	case c.Complete():
+		return VerdictComplete
+	}
+	return VerdictUncertain
+}
+
 // FinalRejection is the host's answer to a premature "done": empty when the
 // contract is fully proven (or has no content to prove), otherwise a
 // directive naming exactly what lacks fresh evidence — "verify R2" carries

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -55,6 +55,7 @@ type EvidenceRef struct {
 // tasks whose ask IS the evidence (fix a typo: the mutation proves it).
 type Requirement struct {
 	ID       string
+	Kind     string // optional taxonomy, e.g. "behavior", "regression"
 	Text     string
 	Required bool
 	Status   Status
@@ -129,6 +130,76 @@ func Atomic(input string) *Contract {
 	})
 	c.Checks = append(c.Checks, Check{Kind: CheckMutation})
 	return c
+}
+
+// PlanFacts is a completed full plan's contract-relevant output, extracted
+// by the coordinator (plain data; this package never sees the plan text).
+type PlanFacts struct {
+	AcceptanceCriteria []string
+	Regressions        []string // must-keep-passing criteria
+	Verifications      []string // command-level checks; "" entries mean any
+	Risky              bool
+	Touchpoints        []string
+}
+
+// FromPlan builds the contract straight from a plan the planner already
+// produced, so the executor consumes the plan's own acceptance criteria
+// instead of re-deriving a parallel set: Planner → Contract → Executor.
+func FromPlan(input string, facts PlanFacts) *Contract {
+	c := New(input)
+	for i, text := range facts.AcceptanceCriteria {
+		c.Requirements = append(c.Requirements, Requirement{
+			ID: fmt.Sprintf("r%d", i+1), Kind: "behavior", Text: text, Required: true,
+		})
+	}
+	for i, text := range facts.Regressions {
+		c.Requirements = append(c.Requirements, Requirement{
+			ID: fmt.Sprintf("g%d", i+1), Kind: "regression", Text: text, Required: true,
+		})
+	}
+	for _, command := range facts.Verifications {
+		c.AddCheck(command)
+	}
+	c.MergeSignals(Signals{
+		MediumRisk: facts.Risky,
+		Anchored:   len(facts.Touchpoints) > 0,
+		MultiFile:  len(facts.Touchpoints) > 1,
+		Paths:      facts.Touchpoints,
+	})
+	return c
+}
+
+// ExecutionView renders the contract as the executor's todo list — a view,
+// not a parallel task description: requirements become steps, checks become
+// verify steps, and satisfied entries arrive already completed.
+func (c *Contract) ExecutionView() []evidence.TodoItem {
+	var todos []evidence.TodoItem
+	status := func(s Status) string {
+		if s == Satisfied {
+			return "completed"
+		}
+		return "pending"
+	}
+	for _, req := range c.Requirements {
+		if !req.Required {
+			continue
+		}
+		todos = append(todos, evidence.TodoItem{Content: req.Text, Status: status(req.Status)})
+	}
+	for _, check := range c.Checks {
+		label := check.Command
+		if label == "" {
+			if check.Kind == CheckMutation {
+				label = "apply the change"
+			} else {
+				label = "run verification"
+			}
+		} else {
+			label = "verify: " + label
+		}
+		todos = append(todos, evidence.TodoItem{Content: label, Status: status(check.Status)})
+	}
+	return todos
 }
 
 // Trivial reports whether the contract is simple enough to route

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -371,6 +371,51 @@ func (c *Contract) FinalizeSignal() string {
 		required, required, len(c.Checks), len(c.Checks))
 }
 
+// FinalRejection is the host's answer to a premature "done": empty when the
+// contract is fully proven (or has no content to prove), otherwise a
+// directive naming exactly what lacks fresh evidence — "verify R2" carries
+// more information than any generic ask-a-reviewer round.
+func (c *Contract) FinalRejection() string {
+	if len(c.Requirements) == 0 && len(c.Checks) == 0 {
+		return ""
+	}
+	if c.Complete() {
+		return ""
+	}
+	out := "Final not accepted: the contract is not fully proven.\n"
+	for _, req := range c.Requirements {
+		if !req.Required || req.Status == Satisfied {
+			continue
+		}
+		out += fmt.Sprintf("- requirement %s (%s): %s\n", req.ID, req.Text, directiveFor(req.Status, "verify"))
+	}
+	for _, check := range c.Checks {
+		if check.Status == Satisfied {
+			continue
+		}
+		label := check.Command
+		if label == "" {
+			label = "verification"
+			if check.Kind == CheckMutation {
+				label = "the required change"
+			}
+		}
+		out += fmt.Sprintf("- check %s: %s\n", label, directiveFor(check.Status, "run"))
+	}
+	return out
+}
+
+func directiveFor(status Status, verb string) string {
+	switch status {
+	case Stale:
+		return "evidence predates the latest mutation — re-" + verb + " it"
+	case Failed:
+		return "last evidence shows failure — fix it, then re-" + verb
+	default:
+		return "no fresh evidence — " + verb + " it"
+	}
+}
+
 // Summary is the one-line contract status for logs and host notes.
 func (c *Contract) Summary() string {
 	reqDone, reqAll := 0, 0

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -8,6 +8,8 @@ package taskcontract
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/taskintent"
@@ -465,12 +467,13 @@ func (c *Contract) FinalRejection() string {
 	if c.Complete() {
 		return ""
 	}
-	out := "Final not accepted: the contract is not fully proven.\n"
+	var out strings.Builder
+	out.WriteString("Final not accepted: the contract is not fully proven.\n")
 	for _, req := range c.Requirements {
 		if !req.Required || req.Status == Satisfied {
 			continue
 		}
-		out += fmt.Sprintf("- requirement %s (%s): %s\n", req.ID, req.Text, directiveFor(req.Status, "verify"))
+		fmt.Fprintf(&out, "- requirement %s (%s): %s\n", req.ID, req.Text, directiveFor(req.Status, "verify"))
 	}
 	for _, check := range c.Checks {
 		if check.Status == Satisfied {
@@ -483,9 +486,9 @@ func (c *Contract) FinalRejection() string {
 				label = "the required change"
 			}
 		}
-		out += fmt.Sprintf("- check %s: %s\n", label, directiveFor(check.Status, "run"))
+		fmt.Fprintf(&out, "- check %s: %s\n", label, directiveFor(check.Status, "run"))
 	}
-	return out
+	return out.String()
 }
 
 func directiveFor(status Status, verb string) string {
@@ -620,10 +623,8 @@ func (c *Contract) checkMatches(check Check, r evidence.Receipt, ref EvidenceRef
 
 func pathsIntersect(scope, got []string) bool {
 	for _, s := range scope {
-		for _, g := range got {
-			if s == g {
-				return true
-			}
+		if slices.Contains(got, s) {
+			return true
 		}
 	}
 	return false

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -435,6 +435,25 @@ func (c *Contract) GoalVerdict() Verdict {
 	return VerdictUncertain
 }
 
+// GateMutation is the mutation-after-green guard: while anything is
+// unproven mutations flow freely, but once the contract is fully proven a
+// further mutation must bind to a still-unsatisfied requirement ID or the
+// challenge comes back as the tool result — no extra round. The gate lifts
+// by itself after a landed mutation, since the staled proof ends green.
+func (c *Contract) GateMutation(requirementID string) (allowed bool, challenge string) {
+	if !c.ReadyToFinalize() {
+		return true, ""
+	}
+	if requirementID != "" {
+		for _, req := range c.Requirements {
+			if req.ID == requirementID && req.Status != Satisfied {
+				return true, ""
+			}
+		}
+	}
+	return false, "All acceptance evidence is satisfied. Name the unsatisfied requirement ID this mutation addresses, or finalize instead of editing."
+}
+
 // FinalRejection is the host's answer to a premature "done": empty when the
 // contract is fully proven (or has no content to prove), otherwise a
 // directive naming exactly what lacks fresh evidence — "verify R2" carries

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -1,0 +1,248 @@
+// Package taskcontract is the convergence point for the host's task state:
+// one Contract assembled purely from signals the runtime already produced —
+// the taskintent classification, planner-gate features, plan acceptance
+// criteria, and the evidence ledger's receipts. Building or updating a
+// contract never makes a model call; every termination arbiter reads the
+// same record instead of keeping its own.
+package taskcontract
+
+import (
+	"fmt"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskintent"
+)
+
+// Risk is the highest risk any upstream signal assigned to the task.
+type Risk uint8
+
+const (
+	RiskLow Risk = iota
+	RiskMedium
+	RiskHigh
+)
+
+// Status is a requirement's or check's lifecycle.
+type Status uint8
+
+const (
+	Pending Status = iota
+	Satisfied
+	Failed
+)
+
+// EvidenceKind classifies what a receipt proved.
+type EvidenceKind uint8
+
+const (
+	EvidenceRead EvidenceKind = iota
+	EvidenceMutation
+	EvidenceVerification
+	EvidenceReview
+)
+
+// EvidenceRef points at one ledger receipt without copying its content.
+type EvidenceRef struct {
+	Kind          EvidenceKind
+	MutationEpoch uint64 // ledger sequence at attach time
+	Source        string // tool name
+	Success       bool
+}
+
+// Requirement is one acceptance criterion; Required=false records a
+// nice-to-have that must not block completion.
+type Requirement struct {
+	ID       string
+	Text     string
+	Required bool
+	Status   Status
+	Evidence []EvidenceRef
+}
+
+// Check is an expected verification; an empty Command accepts any
+// verification-classified command.
+type Check struct {
+	Command  string
+	Status   Status
+	Evidence []EvidenceRef
+}
+
+// Scope is where the task is expected to act, from prompt-shape signals.
+type Scope struct {
+	Anchored     bool // names concrete files or targets
+	MultiFile    bool
+	CrossSurface bool
+	Paths        []string
+}
+
+// Signals is plain data extracted by callers from machinery this package
+// must not import (planner-gate features, delivery risk); merging them here
+// keeps the contract the single record without inverting layering.
+type Signals struct {
+	HighRisk     bool
+	MediumRisk   bool
+	Anchored     bool
+	MultiFile    bool
+	CrossSurface bool
+	Paths        []string
+}
+
+// Contract is the unified task record.
+type Contract struct {
+	Intent       taskintent.Intent
+	Risk         Risk
+	Scope        Scope
+	Requirements []Requirement
+	Checks       []Check
+
+	epoch uint64
+}
+
+// New classifies input with the existing taskintent heuristics and returns
+// an otherwise empty contract; no model call is made.
+func New(input string) *Contract {
+	return &Contract{Intent: taskintent.Classify(input)}
+}
+
+// MergeSignals folds prompt-shape and risk signals in; risk only ratchets up.
+func (c *Contract) MergeSignals(s Signals) {
+	if s.HighRisk {
+		c.Risk = RiskHigh
+	} else if s.MediumRisk && c.Risk < RiskMedium {
+		c.Risk = RiskMedium
+	}
+	c.Scope.Anchored = c.Scope.Anchored || s.Anchored
+	c.Scope.MultiFile = c.Scope.MultiFile || s.MultiFile
+	c.Scope.CrossSurface = c.Scope.CrossSurface || s.CrossSurface
+	c.Scope.Paths = appendNew(c.Scope.Paths, s.Paths)
+}
+
+// AddRequirement records one acceptance criterion (e.g. a plan's acceptance
+// criteria or a goal spec requirement). Duplicate IDs update the text.
+func (c *Contract) AddRequirement(id, text string, required bool) {
+	for i := range c.Requirements {
+		if c.Requirements[i].ID == id {
+			c.Requirements[i].Text = text
+			c.Requirements[i].Required = required
+			return
+		}
+	}
+	c.Requirements = append(c.Requirements, Requirement{ID: id, Text: text, Required: required})
+}
+
+// AddCheck records an expected verification command ("" = any verification).
+func (c *Contract) AddCheck(command string) {
+	for _, check := range c.Checks {
+		if check.Command == command {
+			return
+		}
+	}
+	c.Checks = append(c.Checks, Check{Command: command})
+}
+
+// Observe folds one ledger receipt into the contract: it advances the
+// mutation epoch, and satisfies any check the receipt's command proves.
+// Requirement satisfaction stays an explicit caller judgment (Resolve).
+func (c *Contract) Observe(r evidence.Receipt) {
+	c.epoch++
+	ref := refFor(c.epoch, r)
+	for i := range c.Checks {
+		if !checkMatches(c.Checks[i].Command, r) {
+			continue
+		}
+		c.Checks[i].Evidence = append(c.Checks[i].Evidence, ref)
+		if r.Success {
+			c.Checks[i].Status = Satisfied
+		} else if c.Checks[i].Status != Satisfied {
+			c.Checks[i].Status = Failed
+		}
+	}
+}
+
+// Resolve sets a requirement's status with the evidence that justified it.
+func (c *Contract) Resolve(id string, status Status, refs ...EvidenceRef) bool {
+	for i := range c.Requirements {
+		if c.Requirements[i].ID == id {
+			c.Requirements[i].Status = status
+			c.Requirements[i].Evidence = append(c.Requirements[i].Evidence, refs...)
+			return true
+		}
+	}
+	return false
+}
+
+// Epoch is the count of receipts observed so far.
+func (c *Contract) Epoch() uint64 { return c.epoch }
+
+// Complete reports whether every required requirement and every check is
+// satisfied — the one answer the termination arbiters share.
+func (c *Contract) Complete() bool {
+	for _, req := range c.Requirements {
+		if req.Required && req.Status != Satisfied {
+			return false
+		}
+	}
+	for _, check := range c.Checks {
+		if check.Status != Satisfied {
+			return false
+		}
+	}
+	return true
+}
+
+// Outstanding lists what still blocks completion, requirements first.
+func (c *Contract) Outstanding() []string {
+	var out []string
+	for _, req := range c.Requirements {
+		if req.Required && req.Status != Satisfied {
+			out = append(out, fmt.Sprintf("requirement %s: %s", req.ID, req.Text))
+		}
+	}
+	for _, check := range c.Checks {
+		if check.Status != Satisfied {
+			label := check.Command
+			if label == "" {
+				label = "any verification"
+			}
+			out = append(out, "check: "+label)
+		}
+	}
+	return out
+}
+
+func refFor(epoch uint64, r evidence.Receipt) EvidenceRef {
+	kind := EvidenceRead
+	switch {
+	case r.ToolName == "review_report":
+		kind = EvidenceReview
+	case r.Command != "" && evidence.IsDeliveryVerificationCommand(r.Command):
+		kind = EvidenceVerification
+	case r.Mutation || r.Write:
+		kind = EvidenceMutation
+	}
+	return EvidenceRef{Kind: kind, MutationEpoch: epoch, Source: r.ToolName, Success: r.Success}
+}
+
+func checkMatches(want string, r evidence.Receipt) bool {
+	if r.Command == "" {
+		return false
+	}
+	if want == "" {
+		return evidence.IsDeliveryVerificationCommand(r.Command)
+	}
+	return evidence.CommandMatches(want, r.Command)
+}
+
+func appendNew(dst, add []string) []string {
+	seen := make(map[string]bool, len(dst))
+	for _, p := range dst {
+		seen[p] = true
+	}
+	for _, p := range add {
+		if !seen[p] {
+			seen[p] = true
+			dst = append(dst, p)
+		}
+	}
+	return dst
+}

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -29,6 +29,9 @@ const (
 	Pending Status = iota
 	Satisfied
 	Failed
+	// Stale marks a satisfaction whose proof predates the latest mutation:
+	// it was true once, and must be re-proven against the current code.
+	Stale
 )
 
 // EvidenceKind classifies what a receipt proved.
@@ -246,11 +249,16 @@ func (c *Contract) AddCheck(command string) {
 	c.Checks = append(c.Checks, Check{Command: command})
 }
 
-// Observe folds one ledger receipt into the contract: it advances the
-// mutation epoch, and satisfies any check the receipt's command proves.
-// Requirement satisfaction stays an explicit caller judgment (Resolve).
+// Observe folds one ledger receipt into the contract. Mutations advance the
+// epoch and stale every verification-backed satisfaction recorded before
+// them — a test that passed against older code proves nothing about the
+// current code. Mutation-kind evidence never stales: the change happened;
+// whether the fix still holds is verification's job.
 func (c *Contract) Observe(r evidence.Receipt) {
-	c.epoch++
+	if r.Mutation || r.Write {
+		c.epoch++
+		c.staleOutdated()
+	}
 	ref := refFor(c.epoch, r)
 	for i := range c.Checks {
 		if !c.checkMatches(c.Checks[i], r, ref) {
@@ -272,6 +280,39 @@ func (c *Contract) Observe(r evidence.Receipt) {
 	}
 }
 
+// staleOutdated demotes satisfactions whose entire proof is verification or
+// review evidence from before the current epoch.
+func (c *Contract) staleOutdated() {
+	for i := range c.Checks {
+		if c.Checks[i].Status == Satisfied && c.Checks[i].Kind == CheckCommand && allProofOutdated(c.Checks[i].Evidence, c.epoch) {
+			c.Checks[i].Status = Stale
+		}
+	}
+	for i := range c.Requirements {
+		req := &c.Requirements[i]
+		if req.Status == Satisfied && len(req.Evidence) > 0 && allProofOutdated(req.Evidence, c.epoch) {
+			req.Status = Stale
+		}
+	}
+}
+
+// allProofOutdated reports whether every proof is stale-able (verification
+// or review) and predates epoch; any current or mutation-kind ref keeps the
+// satisfaction alive.
+func allProofOutdated(refs []EvidenceRef, epoch uint64) bool {
+	sawProof := false
+	for _, ref := range refs {
+		if !ref.Success {
+			continue
+		}
+		sawProof = true
+		if ref.Kind == EvidenceMutation || ref.MutationEpoch >= epoch {
+			return false
+		}
+	}
+	return sawProof
+}
+
 // Resolve sets a requirement's status with the evidence that justified it.
 func (c *Contract) Resolve(id string, status Status, refs ...EvidenceRef) bool {
 	for i := range c.Requirements {
@@ -284,7 +325,8 @@ func (c *Contract) Resolve(id string, status Status, refs ...EvidenceRef) bool {
 	return false
 }
 
-// Epoch is the count of receipts observed so far.
+// Epoch is the mutation epoch: how many workspace mutations the contract
+// has observed. Reads and verifications never advance it.
 func (c *Contract) Epoch() uint64 { return c.epoch }
 
 // Complete reports whether every required requirement and every check is
@@ -317,10 +359,49 @@ func (c *Contract) Outstanding() []string {
 			if label == "" {
 				label = "any verification"
 			}
+			if check.Status == Stale {
+				label += " (stale: re-verify after the latest mutation)"
+			}
 			out = append(out, "check: "+label)
 		}
 	}
 	return out
+}
+
+// Graph renders the evidence graph: each requirement and check with the
+// proofs attached to it, staleness made visible.
+func (c *Contract) Graph() string {
+	var b []byte
+	statusName := map[Status]string{Pending: "pending", Satisfied: "satisfied", Failed: "failed", Stale: "STALE"}
+	kindName := map[EvidenceKind]string{EvidenceRead: "read", EvidenceMutation: "mutation", EvidenceVerification: "verification", EvidenceReview: "review"}
+	node := func(label string, status Status, refs []EvidenceRef) {
+		b = fmt.Appendf(b, "%s [%s]\n", label, statusName[status])
+		for i, ref := range refs {
+			branch := "├──"
+			if i == len(refs)-1 {
+				branch = "└──"
+			}
+			mark := ""
+			if ref.Kind != EvidenceMutation && ref.MutationEpoch < c.epoch {
+				mark = " (stale)"
+			}
+			b = fmt.Appendf(b, " %s E%d %s@%d %s success=%v%s\n", branch, i+1, kindName[ref.Kind], ref.MutationEpoch, ref.Source, ref.Success, mark)
+		}
+	}
+	for _, req := range c.Requirements {
+		node(req.ID+" "+req.Text, req.Status, req.Evidence)
+	}
+	for _, check := range c.Checks {
+		label := "check " + check.Command
+		if check.Command == "" {
+			label = "check (any verification)"
+			if check.Kind == CheckMutation {
+				label = "check (mutation)"
+			}
+		}
+		node(label, check.Status, check.Evidence)
+	}
+	return string(b)
 }
 
 func refFor(epoch uint64, r evidence.Receipt) EvidenceRef {

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -50,18 +50,32 @@ type EvidenceRef struct {
 }
 
 // Requirement is one acceptance criterion; Required=false records a
-// nice-to-have that must not block completion.
+// nice-to-have that must not block completion. Auto requirements are
+// satisfied by the first successful receipt of AutoKind — the opt-in for
+// tasks whose ask IS the evidence (fix a typo: the mutation proves it).
 type Requirement struct {
 	ID       string
 	Text     string
 	Required bool
 	Status   Status
 	Evidence []EvidenceRef
+	Auto     bool
+	AutoKind EvidenceKind
 }
 
-// Check is an expected verification; an empty Command accepts any
+// CheckKind selects what proves a check: a verification command, or any
+// successful workspace mutation (scoped to Scope.Paths when set).
+type CheckKind uint8
+
+const (
+	CheckCommand CheckKind = iota
+	CheckMutation
+)
+
+// Check is an expected proof; for CheckCommand an empty Command accepts any
 // verification-classified command.
 type Check struct {
+	Kind     CheckKind
 	Command  string
 	Status   Status
 	Evidence []EvidenceRef
@@ -102,6 +116,27 @@ type Contract struct {
 // an otherwise empty contract; no model call is made.
 func New(input string) *Contract {
 	return &Contract{Intent: taskintent.Classify(input)}
+}
+
+// Atomic is the zero-overhead contract for a simple ask: the ask itself is
+// the one requirement (auto-satisfied by mutation evidence) and the one
+// check is "the workspace changed". No planner, no evaluator, no extra
+// round — the host synthesizes it and the ledger completes it.
+func Atomic(input string) *Contract {
+	c := New(input)
+	c.Requirements = append(c.Requirements, Requirement{
+		ID: "r1", Text: input, Required: true, Auto: true, AutoKind: EvidenceMutation,
+	})
+	c.Checks = append(c.Checks, Check{Kind: CheckMutation})
+	return c
+}
+
+// Trivial reports whether the contract is simple enough to route
+// executor-only and skip every arbiter beyond the ledger itself.
+func (c *Contract) Trivial() bool {
+	return c.Risk == RiskLow &&
+		!c.Scope.MultiFile && !c.Scope.CrossSurface &&
+		len(c.Requirements) <= 1 && len(c.Checks) <= 1
 }
 
 // MergeSignals folds prompt-shape and risk signals in; risk only ratchets up.
@@ -147,7 +182,7 @@ func (c *Contract) Observe(r evidence.Receipt) {
 	c.epoch++
 	ref := refFor(c.epoch, r)
 	for i := range c.Checks {
-		if !checkMatches(c.Checks[i].Command, r) {
+		if !c.checkMatches(c.Checks[i], r, ref) {
 			continue
 		}
 		c.Checks[i].Evidence = append(c.Checks[i].Evidence, ref)
@@ -155,6 +190,13 @@ func (c *Contract) Observe(r evidence.Receipt) {
 			c.Checks[i].Status = Satisfied
 		} else if c.Checks[i].Status != Satisfied {
 			c.Checks[i].Status = Failed
+		}
+	}
+	for i := range c.Requirements {
+		req := &c.Requirements[i]
+		if req.Auto && req.Status != Satisfied && r.Success && ref.Kind == req.AutoKind {
+			req.Status = Satisfied
+			req.Evidence = append(req.Evidence, ref)
 		}
 	}
 }
@@ -223,14 +265,34 @@ func refFor(epoch uint64, r evidence.Receipt) EvidenceRef {
 	return EvidenceRef{Kind: kind, MutationEpoch: epoch, Source: r.ToolName, Success: r.Success}
 }
 
-func checkMatches(want string, r evidence.Receipt) bool {
+func (c *Contract) checkMatches(check Check, r evidence.Receipt, ref EvidenceRef) bool {
+	if check.Kind == CheckMutation {
+		if ref.Kind != EvidenceMutation {
+			return false
+		}
+		if len(c.Scope.Paths) == 0 {
+			return true
+		}
+		return pathsIntersect(c.Scope.Paths, r.Paths)
+	}
 	if r.Command == "" {
 		return false
 	}
-	if want == "" {
+	if check.Command == "" {
 		return evidence.IsDeliveryVerificationCommand(r.Command)
 	}
-	return evidence.CommandMatches(want, r.Command)
+	return evidence.CommandMatches(check.Command, r.Command)
+}
+
+func pathsIntersect(scope, got []string) bool {
+	for _, s := range scope {
+		for _, g := range got {
+			if s == g {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func appendNew(dst, add []string) []string {

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -345,6 +345,60 @@ func (c *Contract) Complete() bool {
 	return true
 }
 
+// ReadyToFinalize reports whether the host should signal the model to stop:
+// the contract has real content and every bit of it is satisfied with fresh
+// evidence. Stale semantics make "latest mutation verified" implicit — an
+// unverified mutation leaves a verification check Stale, blocking this.
+func (c *Contract) ReadyToFinalize() bool {
+	return (len(c.Requirements) > 0 || len(c.Checks) > 0) && c.Complete()
+}
+
+// FinalizeSignal is the light host nudge injected once the contract is
+// fully proven; empty while anything is outstanding. The wording leaves the
+// model one exit: concrete evidence of an unresolved requirement.
+func (c *Contract) FinalizeSignal() string {
+	if !c.ReadyToFinalize() {
+		return ""
+	}
+	required := 0
+	for _, req := range c.Requirements {
+		if req.Required {
+			required++
+		}
+	}
+	return fmt.Sprintf(
+		"All required acceptance evidence is satisfied (%d/%d requirements, %d/%d checks, latest mutation verified). Finalize now unless you have concrete evidence of an unresolved requirement.",
+		required, required, len(c.Checks), len(c.Checks))
+}
+
+// Summary is the one-line contract status for logs and host notes.
+func (c *Contract) Summary() string {
+	reqDone, reqAll := 0, 0
+	for _, req := range c.Requirements {
+		if !req.Required {
+			continue
+		}
+		reqAll++
+		if req.Status == Satisfied {
+			reqDone++
+		}
+	}
+	checkDone, stale := 0, 0
+	for _, check := range c.Checks {
+		switch check.Status {
+		case Satisfied:
+			checkDone++
+		case Stale:
+			stale++
+		}
+	}
+	s := fmt.Sprintf("requirements %d/%d · checks %d/%d · epoch %d", reqDone, reqAll, checkDone, len(c.Checks), c.epoch)
+	if stale > 0 {
+		s += fmt.Sprintf(" · stale %d", stale)
+	}
+	return s
+}
+
 // Outstanding lists what still blocks completion, requirements first.
 func (c *Contract) Outstanding() []string {
 	var out []string

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -378,3 +378,38 @@ func TestGoalVerdictDeterministicHotPath(t *testing.T) {
 		t.Fatal("verdict strings")
 	}
 }
+
+func TestGateMutationAfterGreen(t *testing.T) {
+	c := FromPlan("fix cache", PlanFacts{
+		AcceptanceCriteria: []string{"fix invalidation"},
+		Verifications:      []string{"go test ./cache/"},
+	})
+	c.AddRequirement("opt1", "nice-to-have cleanup", false)
+
+	if ok, challenge := c.GateMutation(""); !ok || challenge != "" {
+		t.Fatal("mutations must flow freely while the contract is unproven")
+	}
+
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: true})
+	c.Resolve("r1", Satisfied)
+
+	if ok, challenge := c.GateMutation(""); ok || !strings.Contains(challenge, "Name the unsatisfied requirement") {
+		t.Fatalf("unbound post-green mutation must be challenged: %v %q", ok, challenge)
+	}
+	if ok, _ := c.GateMutation("r1"); ok {
+		t.Fatal("binding to an already-satisfied requirement is not a justification")
+	}
+	if ok, _ := c.GateMutation("ghost"); ok {
+		t.Fatal("unknown requirement IDs justify nothing")
+	}
+	if ok, challenge := c.GateMutation("opt1"); !ok || challenge != "" {
+		t.Fatal("an unsatisfied optional requirement is a legitimate reason to continue")
+	}
+
+	// A landed mutation stales the proof: the gate lifts on its own.
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	if ok, _ := c.GateMutation(""); !ok {
+		t.Fatal("once the contract is no longer green the gate must lift")
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -1,0 +1,90 @@
+package taskcontract
+
+import (
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskintent"
+)
+
+func TestNewClassifiesWithExistingHeuristics(t *testing.T) {
+	if c := New("fix the bug in utils.py"); c.Intent != taskintent.Mutation {
+		t.Fatalf("intent = %v, want Mutation", c.Intent)
+	}
+	if c := New("what does this function do?"); c.Intent == taskintent.Mutation {
+		t.Fatalf("advisory question misclassified as mutation")
+	}
+}
+
+func TestMergeSignalsRatchetsRiskAndScope(t *testing.T) {
+	c := New("refactor the parser across reader.py and writer.py")
+	c.MergeSignals(Signals{MediumRisk: true, MultiFile: true, Paths: []string{"reader.py"}})
+	c.MergeSignals(Signals{HighRisk: true, Paths: []string{"writer.py", "reader.py"}})
+	if c.Risk != RiskHigh {
+		t.Fatalf("risk = %v, want high (ratchet up)", c.Risk)
+	}
+	c.MergeSignals(Signals{MediumRisk: true})
+	if c.Risk != RiskHigh {
+		t.Fatalf("risk downgraded to %v — must only ratchet up", c.Risk)
+	}
+	if !c.Scope.MultiFile || len(c.Scope.Paths) != 2 {
+		t.Fatalf("scope = %+v, want multi-file with 2 deduped paths", c.Scope)
+	}
+}
+
+func TestChecksSatisfyFromReceipts(t *testing.T) {
+	c := New("fix add and verify with go test")
+	c.AddCheck("go test ./...")
+	c.AddCheck("")
+
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: false})
+	if c.Checks[0].Status != Failed {
+		t.Fatalf("failed run must mark the check failed, got %v", c.Checks[0].Status)
+	}
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true})
+	if c.Checks[0].Status != Satisfied || c.Checks[1].Status != Satisfied {
+		t.Fatalf("checks = %+v, want both satisfied (go test is a verification)", c.Checks)
+	}
+	if c.Epoch() != 2 {
+		t.Fatalf("epoch = %d, want 2", c.Epoch())
+	}
+	if got := c.Checks[0].Evidence[1]; got.Kind != EvidenceVerification || got.MutationEpoch != 2 || !got.Success {
+		t.Fatalf("evidence ref = %+v", got)
+	}
+}
+
+func TestRequirementsResolveExplicitly(t *testing.T) {
+	c := New("implement the ledger")
+	c.AddRequirement("r1", "balances.json written", true)
+	c.AddRequirement("r2", "nice-to-have docs", false)
+	c.AddCheck("")
+
+	if c.Complete() {
+		t.Fatal("nothing satisfied yet")
+	}
+	c.Observe(evidence.Receipt{ToolName: "write_file", Write: true, Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true})
+	if c.Complete() {
+		t.Fatal("required requirement still pending; checks alone must not complete the contract")
+	}
+	if !c.Resolve("r1", Satisfied, EvidenceRef{Kind: EvidenceMutation, MutationEpoch: 1, Source: "write_file", Success: true}) {
+		t.Fatal("resolve r1")
+	}
+	if !c.Complete() {
+		t.Fatalf("contract should be complete; outstanding: %v", c.Outstanding())
+	}
+	if c.Resolve("missing", Satisfied) {
+		t.Fatal("unknown requirement must not resolve")
+	}
+}
+
+func TestOutstandingListsBlockersOnly(t *testing.T) {
+	c := New("do the thing")
+	c.AddRequirement("r1", "must happen", true)
+	c.AddRequirement("r2", "optional", false)
+	c.AddCheck("go vet ./...")
+	got := c.Outstanding()
+	if len(got) != 2 {
+		t.Fatalf("outstanding = %v, want required requirement + check only", got)
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -334,3 +334,47 @@ func TestFinalRejectionNamesExactlyWhatIsUnproven(t *testing.T) {
 		t.Fatal("a contract with nothing to prove must not reject finals")
 	}
 }
+
+func TestGoalVerdictDeterministicHotPath(t *testing.T) {
+	empty := New("just chatting")
+	if v := empty.GoalVerdict(); v != VerdictUncertain {
+		t.Fatalf("empty contract = %v, want uncertain (the evaluator's only remaining territory)", v)
+	}
+
+	c := FromPlan("fix cache", PlanFacts{
+		AcceptanceCriteria: []string{"fix invalidation"},
+		Verifications:      []string{"go test ./cache/"},
+	})
+	if v := c.GoalVerdict(); v != VerdictContinue {
+		t.Fatalf("unproven contract = %v, want continue", v)
+	}
+
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: false})
+	c.Resolve("r1", Satisfied)
+	if v := c.GoalVerdict(); v != VerdictContinue {
+		t.Fatalf("failed check = %v, want continue (fix and re-run is actionable)", v)
+	}
+
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: true})
+	if v := c.GoalVerdict(); v != VerdictComplete {
+		t.Fatalf("fresh-satisfied contract = %v, want complete; outstanding: %v", v, c.Outstanding())
+	}
+
+	// A newer mutation stales the proof: back to continue, not uncertain.
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	if v := c.GoalVerdict(); v != VerdictContinue {
+		t.Fatalf("stale proof = %v, want continue", v)
+	}
+
+	// An arbiter's explicit judgment that a requirement cannot be met blocks.
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: true})
+	c.AddRequirement("r9", "needs credentials we do not have", true)
+	c.Resolve("r9", Failed)
+	if v := c.GoalVerdict(); v != VerdictBlocked {
+		t.Fatalf("judgment-failed requirement = %v, want blocked", v)
+	}
+	if VerdictBlocked.String() != "blocked" || VerdictComplete.String() != "complete" {
+		t.Fatal("verdict strings")
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -138,3 +138,50 @@ func TestTrivialRejectsComplexContracts(t *testing.T) {
 		t.Fatal("multi-file is never trivial")
 	}
 }
+
+func TestFromPlanBuildsContractFromPlannerOutput(t *testing.T) {
+	c := FromPlan("fix stale cache invalidation", PlanFacts{
+		AcceptanceCriteria: []string{"fix stale cache invalidation"},
+		Regressions:        []string{"existing cache tests continue passing"},
+		Verifications:      []string{"go test ./internal/cache/", ""},
+		Risky:              true,
+		Touchpoints:        []string{"cache.go", "invalidate.go"},
+	})
+	if len(c.Requirements) != 2 || c.Requirements[0].Kind != "behavior" || c.Requirements[1].Kind != "regression" {
+		t.Fatalf("requirements = %+v", c.Requirements)
+	}
+	if c.Requirements[1].ID != "g1" || !c.Requirements[1].Required {
+		t.Fatalf("regression requirement = %+v", c.Requirements[1])
+	}
+	if len(c.Checks) != 2 || c.Risk != RiskMedium || !c.Scope.MultiFile || len(c.Scope.Paths) != 2 {
+		t.Fatalf("checks=%d risk=%v scope=%+v", len(c.Checks), c.Risk, c.Scope)
+	}
+	if c.Trivial() {
+		t.Fatal("a risky multi-file plan contract must not route trivial")
+	}
+}
+
+func TestExecutionViewIsAViewNotAParallelDescription(t *testing.T) {
+	c := FromPlan("fix it", PlanFacts{
+		AcceptanceCriteria: []string{"behavior fixed"},
+		Verifications:      []string{"go test ./..."},
+	})
+	todos := c.ExecutionView()
+	if len(todos) != 2 || todos[0].Content != "behavior fixed" || todos[1].Content != "verify: go test ./..." {
+		t.Fatalf("view = %+v", todos)
+	}
+	if todos[0].Status != "pending" {
+		t.Fatalf("unsatisfied entries must render pending, got %q", todos[0].Status)
+	}
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true})
+	c.Resolve("r1", Satisfied)
+	for i, todo := range c.ExecutionView() {
+		if todo.Status != "completed" {
+			t.Fatalf("todo %d should render completed after satisfaction: %+v", i, todo)
+		}
+	}
+	atomicView := Atomic("fix typo").ExecutionView()
+	if len(atomicView) != 2 || atomicView[1].Content != "apply the change" {
+		t.Fatalf("atomic view = %+v", atomicView)
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -296,3 +296,41 @@ func TestFinalizeSignalFiresOnlyWhenFullyProven(t *testing.T) {
 		t.Fatalf("summary = %q", s)
 	}
 }
+
+func TestFinalRejectionNamesExactlyWhatIsUnproven(t *testing.T) {
+	c := FromPlan("fix cache", PlanFacts{
+		AcceptanceCriteria: []string{"fix stale cache invalidation"},
+		Regressions:        []string{"cache tests keep passing"},
+		Verifications:      []string{"go test ./cache/"},
+	})
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: true})
+	c.Resolve("r1", Satisfied)
+
+	rejection := c.FinalRejection()
+	if !strings.Contains(rejection, "Final not accepted") {
+		t.Fatalf("rejection = %q", rejection)
+	}
+	if !strings.Contains(rejection, "requirement g1 (cache tests keep passing): no fresh evidence — verify it") {
+		t.Fatalf("rejection must name g1 specifically:\n%s", rejection)
+	}
+	if strings.Contains(rejection, "requirement r1") || strings.Contains(rejection, "check go test") {
+		t.Fatalf("satisfied items must not appear:\n%s", rejection)
+	}
+
+	// Stale wording after another mutation.
+	c.Resolve("g1", Satisfied, EvidenceRef{Kind: EvidenceVerification, MutationEpoch: c.Epoch(), Source: "bash", Success: true})
+	if c.FinalRejection() != "" {
+		t.Fatal("fully proven contract must accept the final")
+	}
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	rejection = c.FinalRejection()
+	if !strings.Contains(rejection, "predates the latest mutation — re-verify it") &&
+		!strings.Contains(rejection, "predates the latest mutation — re-run it") {
+		t.Fatalf("stale items must demand re-verification:\n%s", rejection)
+	}
+
+	if (&Contract{}).FinalRejection() != "" {
+		t.Fatal("a contract with nothing to prove must not reject finals")
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -88,3 +88,53 @@ func TestOutstandingListsBlockersOnly(t *testing.T) {
 		t.Fatalf("outstanding = %v, want required requirement + check only", got)
 	}
 }
+
+func TestAtomicContractCompletesFromOneMutation(t *testing.T) {
+	c := Atomic("fix typo in README.md")
+	if c.Intent != taskintent.Mutation {
+		t.Fatalf("intent = %v, want Mutation", c.Intent)
+	}
+	if !c.Trivial() {
+		t.Fatal("atomic contract must route trivial (executor-only, no arbiters)")
+	}
+	if c.Complete() {
+		t.Fatal("nothing happened yet")
+	}
+	c.Observe(evidence.Receipt{ToolName: "read_file", Read: true, Success: true})
+	if c.Complete() {
+		t.Fatal("a read must not complete a mutation contract")
+	}
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"README.md"}})
+	if !c.Complete() {
+		t.Fatalf("one successful mutation must complete it; outstanding: %v", c.Outstanding())
+	}
+	if c.Requirements[0].Status != Satisfied || len(c.Requirements[0].Evidence) != 1 {
+		t.Fatalf("r1 = %+v, want auto-satisfied with the mutation ref", c.Requirements[0])
+	}
+}
+
+func TestMutationCheckHonorsScopePaths(t *testing.T) {
+	c := Atomic("fix typo in README.md")
+	c.MergeSignals(Signals{Anchored: true, Paths: []string{"README.md"}})
+	c.Observe(evidence.Receipt{ToolName: "write_file", Mutation: true, Success: true, Paths: []string{"other.txt"}})
+	if c.Checks[0].Status == Satisfied {
+		t.Fatal("mutation outside the scoped paths must not satisfy the check")
+	}
+	c.Observe(evidence.Receipt{ToolName: "write_file", Mutation: true, Success: true, Paths: []string{"README.md"}})
+	if c.Checks[0].Status != Satisfied {
+		t.Fatal("scoped mutation must satisfy the check")
+	}
+}
+
+func TestTrivialRejectsComplexContracts(t *testing.T) {
+	c := Atomic("fix typo")
+	c.MergeSignals(Signals{HighRisk: true})
+	if c.Trivial() {
+		t.Fatal("high risk is never trivial")
+	}
+	c2 := New("refactor everything")
+	c2.MergeSignals(Signals{MultiFile: true})
+	if c2.Trivial() {
+		t.Fatal("multi-file is never trivial")
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -261,3 +261,38 @@ func TestGraphRendersEvidenceTree(t *testing.T) {
 		}
 	}
 }
+
+func TestFinalizeSignalFiresOnlyWhenFullyProven(t *testing.T) {
+	c := New("chat about the weather")
+	if c.ReadyToFinalize() {
+		t.Fatal("an empty contract must never demand finalization")
+	}
+
+	c = FromPlan("fix cache", PlanFacts{
+		AcceptanceCriteria: []string{"fix stale cache invalidation"},
+		Regressions:        []string{"cache tests keep passing"},
+		Verifications:      []string{"go test ./cache/"},
+	})
+	if s := c.FinalizeSignal(); s != "" {
+		t.Fatalf("nothing proven yet, got signal %q", s)
+	}
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./cache/", Success: true})
+	c.Resolve("r1", Satisfied)
+	c.Resolve("g1", Satisfied, EvidenceRef{Kind: EvidenceVerification, MutationEpoch: c.Epoch(), Source: "bash", Success: true})
+
+	signal := c.FinalizeSignal()
+	if !strings.Contains(signal, "2/2 requirements") || !strings.Contains(signal, "1/1 checks") ||
+		!strings.Contains(signal, "Finalize now unless you have concrete evidence") {
+		t.Fatalf("signal = %q", signal)
+	}
+
+	// One more edit: the proof goes stale and the signal must retract.
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	if c.FinalizeSignal() != "" {
+		t.Fatal("stale evidence must retract the finalize signal")
+	}
+	if s := c.Summary(); !strings.Contains(s, "stale 1") || !strings.Contains(s, "epoch 2") {
+		t.Fatalf("summary = %q", s)
+	}
+}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -1,6 +1,7 @@
 package taskcontract
 
 import (
+	"strings"
 	"testing"
 
 	"reasonix/internal/evidence"
@@ -45,10 +46,10 @@ func TestChecksSatisfyFromReceipts(t *testing.T) {
 	if c.Checks[0].Status != Satisfied || c.Checks[1].Status != Satisfied {
 		t.Fatalf("checks = %+v, want both satisfied (go test is a verification)", c.Checks)
 	}
-	if c.Epoch() != 2 {
-		t.Fatalf("epoch = %d, want 2", c.Epoch())
+	if c.Epoch() != 0 {
+		t.Fatalf("epoch = %d, want 0 (verifications never advance the mutation epoch)", c.Epoch())
 	}
-	if got := c.Checks[0].Evidence[1]; got.Kind != EvidenceVerification || got.MutationEpoch != 2 || !got.Success {
+	if got := c.Checks[0].Evidence[1]; got.Kind != EvidenceVerification || got.MutationEpoch != 0 || !got.Success {
 		t.Fatalf("evidence ref = %+v", got)
 	}
 }
@@ -183,5 +184,80 @@ func TestExecutionViewIsAViewNotAParallelDescription(t *testing.T) {
 	atomicView := Atomic("fix typo").ExecutionView()
 	if len(atomicView) != 2 || atomicView[1].Content != "apply the change" {
 		t.Fatalf("atomic view = %+v", atomicView)
+	}
+}
+
+func TestMutationStalesVerificationEvidence(t *testing.T) {
+	c := New("fix foo")
+	c.AddCheck("go test ./foo/")
+	c.AddRequirement("r2", "no regression", true)
+
+	// epoch 0→1: patch foo.go; epoch 1: go test PASS proves it.
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true, Paths: []string{"foo.go"}})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./foo/", Success: true})
+	c.Resolve("r2", Satisfied, EvidenceRef{Kind: EvidenceVerification, MutationEpoch: c.Epoch(), Source: "bash", Success: true})
+	if !c.Complete() {
+		t.Fatalf("satisfied at epoch %d; outstanding: %v", c.Epoch(), c.Outstanding())
+	}
+
+	// epoch 2: foo.go changes again — the epoch-1 test proves nothing now.
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true, Paths: []string{"foo.go"}})
+	if c.Checks[0].Status != Stale {
+		t.Fatalf("check status = %v, want Stale after a newer mutation", c.Checks[0].Status)
+	}
+	if c.Requirements[0].Status != Stale {
+		t.Fatalf("verification-backed requirement must stale, got %v", c.Requirements[0].Status)
+	}
+	if c.Complete() {
+		t.Fatal("stale proof must not count as complete")
+	}
+	found := false
+	for _, item := range c.Outstanding() {
+		if strings.Contains(item, "stale: re-verify") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("outstanding must name the stale check: %v", c.Outstanding())
+	}
+
+	// Re-verify at epoch 2 → satisfied again.
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./foo/", Success: true})
+	if c.Checks[0].Status != Satisfied {
+		t.Fatalf("re-verification must re-satisfy, got %v", c.Checks[0].Status)
+	}
+}
+
+func TestMutationEvidenceNeverStales(t *testing.T) {
+	c := Atomic("fix typo in README.md")
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true, Paths: []string{"README.md"}})
+	if !c.Complete() {
+		t.Fatal("atomic contract should complete on the mutation")
+	}
+	c.Observe(evidence.Receipt{ToolName: "write_file", Mutation: true, Success: true, Paths: []string{"notes.txt"}})
+	if !c.Complete() {
+		t.Fatalf("mutation-backed satisfaction must survive later mutations; graph:\n%s", c.Graph())
+	}
+}
+
+func TestGraphRendersEvidenceTree(t *testing.T) {
+	c := New("fix the bug")
+	c.AddRequirement("r1", "bug fixed", true)
+	c.AddCheck("go test ./...")
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+	c.Observe(evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true})
+	c.Resolve("r1", Satisfied, EvidenceRef{Kind: EvidenceMutation, MutationEpoch: 1, Source: "edit_file", Success: true})
+	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
+
+	graph := c.Graph()
+	for _, want := range []string{
+		"r1 bug fixed [satisfied]",
+		"└── E1 mutation@1 edit_file success=true",
+		"check go test ./... [STALE]",
+		"verification@1 bash success=true (stale)",
+	} {
+		if !strings.Contains(graph, want) {
+			t.Fatalf("graph missing %q:\n%s", want, graph)
+		}
 	}
 }

--- a/internal/taskintent/boundary_test.go
+++ b/internal/taskintent/boundary_test.go
@@ -1,0 +1,84 @@
+package taskintent
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// allowedExports is the package's whole public surface. Adding a name here
+// means taskintent is absorbing a new responsibility — read doc.go first:
+// complexity, risk, depth, completion, budget and tool-surface decisions
+// belong to runtime evidence, not keywords.
+var allowedExports = map[string]bool{
+	"Intent": true, "Conversation": true, "Advisory": true,
+	"ObservableRead": true, "Mutation": true, "PersistentAction": true,
+	"Classify": true, "NeedsEvidence": true, "NeedsMutation": true,
+	"NeedsPersistentAction": true, "GoalNeedsWriteBudget": true,
+}
+
+// lineBudgets caps the heuristic files: vocabulary growth must displace
+// something or justify a deliberate budget bump in review.
+var lineBudgets = map[string]int{
+	"intent.go":      620,
+	"heuristic.go":   180,
+	"goal_budget.go": 140,
+}
+
+func TestExportSurfaceIsFrozen(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				switch d := decl.(type) {
+				case *ast.FuncDecl:
+					checkExport(t, d.Name.Name)
+				case *ast.GenDecl:
+					for _, spec := range d.Specs {
+						switch s := spec.(type) {
+						case *ast.TypeSpec:
+							checkExport(t, s.Name.Name)
+						case *ast.ValueSpec:
+							for _, name := range s.Names {
+								checkExport(t, name.Name)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func checkExport(t *testing.T, name string) {
+	t.Helper()
+	if !ast.IsExported(name) {
+		return
+	}
+	if !allowedExports[name] {
+		t.Errorf("new exported name %q: taskintent's surface is frozen (doc.go); classification facts belong in taskcontract signals, not here", name)
+	}
+}
+
+func TestHeuristicFilesStayWithinBudget(t *testing.T) {
+	for name, budget := range lineBudgets {
+		data, err := os.ReadFile(filepath.Clean(name))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		lines := strings.Count(string(data), "\n")
+		if lines > budget {
+			t.Errorf("%s is %d lines, budget %d: shrink the vocabulary or justify a deliberate budget bump — do not accrete keywords (doc.go)", name, lines, budget)
+		}
+	}
+}

--- a/internal/taskintent/boundary_test.go
+++ b/internal/taskintent/boundary_test.go
@@ -31,14 +31,20 @@ var lineBudgets = map[string]int{
 
 func TestExportSurfaceIsFrozen(t *testing.T) {
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		{
 			for _, decl := range file.Decls {
 				switch d := decl.(type) {
 				case *ast.FuncDecl:

--- a/internal/taskintent/doc.go
+++ b/internal/taskintent/doc.go
@@ -1,0 +1,14 @@
+// Package taskintent answers exactly one question from task text: is this
+// obviously chat, a read, a mutation, or a persistent action. That is its
+// whole charter. It must not grow into complexity, risk, planner depth,
+// verification depth, completion, budget, or tool-surface decisions —
+// those belong to runtime evidence (see internal/taskcontract), where a
+// receipt outranks any keyword.
+//
+// The vocabulary is a liability, not an asset: every added keyword, negation
+// rule, or language case moves this package toward an unowned NLP parser.
+// boundary_test.go enforces the line: the exported surface is a whitelist
+// and the heuristic files carry a hard size budget, so growth is a reviewed
+// decision, never an accretion. When a classification is wrong, prefer
+// fixing it downstream with evidence over teaching this package more words.
+package taskintent

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -23,13 +23,27 @@ const SchemaVersion = 1
 // ProtocolRecovery, or TurnCompletion is set; Seq orders them and TS is the
 // unix-millisecond observation time at the recorder.
 type Record struct {
-	SchemaVersion    int              `json:"schema_version"`
-	Seq              uint64           `json:"seq"`
-	TS               int64            `json:"ts"`
-	Event            *eventwire.Event `json:"event,omitempty"`
-	ReadinessAudit   *ReadinessAudit  `json:"readiness_audit,omitempty"`
-	ProtocolRecovery string           `json:"protocol_recovery,omitempty"`
-	TurnCompletion   bool             `json:"turn_completion,omitempty"`
+	SchemaVersion    int                  `json:"schema_version"`
+	Seq              uint64               `json:"seq"`
+	TS               int64                `json:"ts"`
+	Event            *eventwire.Event     `json:"event,omitempty"`
+	ReadinessAudit   *ReadinessAudit      `json:"readiness_audit,omitempty"`
+	ProtocolRecovery string               `json:"protocol_recovery,omitempty"`
+	TurnCompletion   bool                 `json:"turn_completion,omitempty"`
+	ContractShadow   *ContractShadowAudit `json:"contract_shadow,omitempty"`
+}
+
+// ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
+type ContractShadowAudit struct {
+	Intent                string `json:"intent"`
+	Requirements          int    `json:"requirements,omitempty"`
+	RequirementsSatisfied int    `json:"requirements_satisfied,omitempty"`
+	Checks                int    `json:"checks,omitempty"`
+	ChecksSatisfied       int    `json:"checks_satisfied,omitempty"`
+	Epoch                 uint64 `json:"epoch,omitempty"`
+	Verdict               string `json:"verdict"`
+	Complete              bool   `json:"complete,omitempty"`
+	ReadyToFinalize       bool   `json:"ready_to_finalize,omitempty"`
 }
 
 // ReadinessAudit mirrors evidence.ReadinessAudit with stable snake_case keys.
@@ -121,6 +135,21 @@ func (r *Recorder) RecordReadinessAudit(a evidence.ReadinessAudit) {
 		MissingCapabilities:       a.MissingCapabilities,
 	}})
 	event.RecordReadinessAudit(r.inner, a)
+}
+
+func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
+	r.append(Record{ContractShadow: &ContractShadowAudit{
+		Intent:                a.Intent,
+		Requirements:          a.Requirements,
+		RequirementsSatisfied: a.RequirementsSatisfied,
+		Checks:                a.Checks,
+		ChecksSatisfied:       a.ChecksSatisfied,
+		Epoch:                 a.Epoch,
+		Verdict:               a.Verdict,
+		Complete:              a.Complete,
+		ReadyToFinalize:       a.ReadyToFinalize,
+	}})
+	event.RecordContractShadow(r.inner, a)
 }
 
 func (r *Recorder) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {


### PR DESCRIPTION
## Why

Reasonix has grown at least five parallel task state machines: `taskintent` (898 lines of NL heuristics, 5 intent classes), the planner gate (684 lines, its own feature extraction and 5 routes), the delivery contract (todo/verify/review/complete_step ledger), goal/autoresearch (task_spec, progress, requirement audits), and the bounded goal evaluator (an independent LLM arbiter). Each keeps its own answer to *what is this task, how risky is it, where does it act, and is it done*.

Today's measurements price the fragmentation: the three **termination** arbiters are where the cost concentrates — the checkpoint-grading dashboard showed every measured run was correct well before it stopped (58% of wall post-solve, median 4 rounds to solve then 6 more after), and the delivery ledger alone burned 38 pure-bookkeeping rounds across 8 tasks. Empirically the goal evaluator fired 0 times in 20+ runs; the risk is divergence and double-booked completion logic, not evaluator latency.

## What

`internal/taskcontract` — the convergence point, deliberately boring:

```go
type Contract struct {
    Intent       taskintent.Intent
    Risk         Risk
    Scope        Scope
    Requirements []Requirement   // {ID, Text, Required, Status, Evidence []EvidenceRef}
    Checks       []Check         // expected verifications; "" = any verification
}
```

- **Assembled, never asked for**: `New` uses the existing `taskintent.Classify`; `MergeSignals` folds caller-extracted gate/delivery signals (risk only ratchets up); plan acceptance criteria and goal-spec requirements enter as `Requirements`; expected verifications as `Checks`. **Building or updating a contract never makes a model call.**
- **Evidence by reference**: `Observe(receipt)` advances a mutation epoch and auto-satisfies checks whose command the receipt proves (`evidence.CommandMatches`); refs carry `{Kind, MutationEpoch, Source, Success}` — no content copied.
- **Judgment stays explicit**: requirement satisfaction is `Resolve(id, status, refs...)`, never inferred — the host or an audit decides, the contract records.
- **One completion answer**: `Complete()` / `Outstanding()` are what delivery, goal, and the evaluator can consume instead of keeping three private definitions of done.
- **Layering-safe leaf**: imports only `taskintent` and `evidence`; upstream machinery feeds plain `Signals`, so nothing below a frontend ever imports control.

### Zero-cost path for simple asks

`Atomic("fix typo in README")` synthesizes the full record host-side: Intent=Mutation, R1 = the ask itself (auto-satisfied by the first successful mutation receipt — evidence-driven satisfaction is opt-in per requirement, everything else keeps explicit `Resolve`), C1 = "the workspace changed" (scoped to `Scope.Paths` when the task is anchored). `Trivial()` is the routing predicate: low-risk, single-surface, ≤1 requirement/check → executor-only, no planner, no evaluator, no extra round. The simplest tasks pay nothing for the contract.

### Planner → Contract → Executor

For tasks where the full planner already ran, `FromPlan(input, PlanFacts)` builds the contract straight from the plan's own output (acceptance criteria → behavior requirements, must-keep-passing → regression requirements, command-level verifications → checks, touchpoints → scope, riskiness → risk ratchet) — the executor stops re-deriving a parallel acceptance list. `ExecutionView()` renders the contract as the executor's todo list (a **view**, not a second task description; satisfied entries arrive already completed), so todo_write seeding makes the planner's promise and the executor's ledger the same object.

### Evidence graph epochs — the staleness model

The mutation epoch now means what it says: it advances only on workspace mutations, and advancing it demotes every satisfaction whose entire proof is verification/review evidence from an earlier epoch to **Stale** — a test that passed at epoch 3 proves nothing after the epoch-4 edit. Mutation-kind evidence never stales (the change happened; whether the fix still *holds* is verification's job), so an atomic contract survives later unrelated edits while a verification-backed check drops to Stale the moment code moves, and re-running it re-satisfies at the current epoch. `Complete()` refuses Stale, `Outstanding()` names it, and `Graph()` renders the requirement→evidence tree with per-ref epochs and stale marks:

```
r1 bug fixed [satisfied]
 └── E1 mutation@1 edit_file success=true
check go test ./... [STALE]
 └── E1 verification@1 bash success=true (stale)
```

This is the general, first-class form of the existing "must re-verify after the latest mutation" rule — one data model instead of scattered invariants.

### The finalize signal — knowing when to stop

The measured payoff target: 58% of wall clock was spent after the workspace was already correct. `ReadyToFinalize()` fires only when the contract has real content and everything is satisfied with **fresh** evidence (stale semantics make "latest mutation verified" implicit); `FinalizeSignal()` is the light host nudge — *"All required acceptance evidence is satisfied (2/2 requirements, 1/1 checks, latest mutation verified). Finalize now unless you have concrete evidence of an unresolved requirement."* — and it **retracts automatically** the moment a new mutation stales the proof. `Summary()` gives the one-line status for host notes. Adoption: turn-tail injection (prefix stays byte-stable) and, under Delivery, direct permission to finalize on a fully proven contract.

### Final rejection — the accuracy half of the loop

When the model claims done but `g1` has no fresh evidence, the host does not ask a generic reviewer — `FinalRejection()` rejects with per-item, state-worded directives (*"requirement g1 (cache tests keep passing): no fresh evidence — verify it"*; stale items get *"evidence predates the latest mutation — re-verify it"*; failed items get *"fix it, then re-verify"*). Satisfied items never appear, empty contracts never reject, fully proven contracts accept. `FinalizeSignal` and `FinalRejection` are exact complements from the same evidence graph: one stops over-verification (the measured 58% post-solve waste), the other stops premature completion (the medium-accuracy failure mode) — and together they make the bounded LLM goal evaluator's question mechanical.

### Deterministic goal verdict — the evaluator retires to fallback

The goal evaluator is a real provider request (30s timeout) on the completion hot path, asked a question the evidence graph can usually answer mechanically. `GoalVerdict()` decides Continue / Blocked / Complete without a model call — missing or stale evidence → **Continue** (the next action is knowable); a requirement explicitly resolved Failed (an arbiter's judgment it cannot be met) → **Blocked**; everything fresh-satisfied → **Complete**; a failed check *run* stays Continue (fix and re-run is actionable), never Blocked. Only a contract with nothing to prove returns **Uncertain** — the one case left for the bounded LLM evaluator. Lower latency and higher completion precision from the same change.

### taskintent gets a charter and a mechanical boundary

The flip side of the contract: `taskintent` stops growing. Its charter (new `doc.go`) is exactly one question — obviously chat / read / mutation / persistent — and explicitly NOT complexity, risk, planner depth, verification depth, completion, budget, or tool surface, which belong to runtime evidence where a receipt outranks any keyword. The boundary is enforced, not requested: `boundary_test.go` freezes the exported surface to a whitelist (a new name fails the build with a pointer to the charter) and caps each heuristic file with a hard line budget — vocabulary growth must displace something or justify a deliberate bump in review. When a classification is wrong, the preferred fix is downstream evidence, not more words.

### Mutation-after-green gate

The measured shape of overthinking was five more mutations after the workspace was already correct, none tied to anything unproven. `GateMutation(requirementID)` makes late edits answerable: while the contract is unproven, mutations flow untouched; once everything is fresh-satisfied, a further mutation must bind to a still-unsatisfied requirement ID (necessarily an optional one — green means every required item is proven) or the challenge returns **as the tool result**, costing no extra round: *"Name the unsatisfied requirement ID this mutation addresses, or finalize instead of editing."* Satisfied and unknown IDs justify nothing; the gate lifts by itself after any landed mutation (staled proof ends green), so repair bursts are never throttled — only the first unjustified post-green edit is. The binding can ride host metadata (e.g. a `reason_requirement` note on `edit_file`) without touching tool schemas.

## Adoption path (not in this PR)

1. Arbiters start *reading* the contract alongside their own state (shadow mode; a disagreement counter in the trajectory prices divergence before any cutover).
2. Termination-side consolidation first — that is where TTFCS says the seconds are — then the intent-side merge of taskintent × gate features into one classification pass.

## Testing

- `go test ./internal/taskcontract/` — classification reuse, risk ratcheting, scope dedupe, check satisfaction from receipts (fail→satisfied transitions, epoch refs), explicit requirement resolution, outstanding-blockers view
- `go test ./internal/evidence/ ./internal/taskintent/` — untouched dependencies stay green; `gofmt` / `go vet` / repolint clean

Documentation-impact: none - new internal leaf package with no callers yet; behavior and docs of existing subsystems unchanged







