### PR TITLE
fix(bot/feishu): prefer open_id when resolving card action operator

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -473,12 +473,16 @@ func (a *adapter) handleCardAction(raw []byte) bool {
 		return true
 	}
 	chatType := cardActionChatType(payload.Event.Action.Value["chat_type"])
+	// 优先取 open_id：与 handleSDKMessage 的身份解析保持一致，也匹配
+	// access/allowlist 里通常以 open_id 记录的用户名单。此前 union_id
+	// 排在最前，当飞书回调同时携带 union_id 与 open_id 时，会拿 union_id
+	// 去匹配 open_id 名单导致准入失败，进而误触发配对码。
 	operatorID := firstNonEmpty(
-		payload.Event.Operator.OperatorID.UnionID,
 		payload.Event.Operator.OperatorID.OpenID,
+		payload.Event.Operator.OperatorID.UnionID,
 		payload.Event.Operator.OperatorID.UserID,
-		payload.Event.Operator.UnionID,
 		payload.Event.Operator.OpenID,
+		payload.Event.Operator.UnionID,
 		payload.Event.Operator.UserID,
 	)
 	routeUserID := firstNonEmpty(payload.Event.Action.Value["user_id"], operatorID)

--- a/internal/bot/feishu/feishu_test.go
+++ b/internal/bot/feishu/feishu_test.go
@@ -225,6 +225,48 @@ func TestHandleCardActionDoesNotTrustCardRequesterAsOperator(t *testing.T) {
 	}
 }
 
+func TestHandleCardActionPrefersOpenIDOverUnionID(t *testing.T) {
+	a := &adapter{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		msgCh:  make(chan bot.InboundMessage, 1),
+	}
+	// 真实飞书回调会同时携带 union_id 与 open_id；准入名单通常以 open_id
+	// 记录，因此 operator 必须优先解析 open_id（与普通消息身份解析一致），
+	// 否则按钮回调会被当成未知用户并误触发配对。
+	raw := []byte(`{
+		"event": {
+			"operator": {
+				"operator_id": {
+					"union_id": "on_union-user",
+					"open_id": "ou_open-user"
+				}
+			},
+			"context": {
+				"open_message_id": "msg-1",
+				"open_chat_id": "chat-1"
+			},
+			"action": {
+				"value": {
+					"command": "/approve approval-1",
+					"chat_type": "dm"
+				}
+			}
+		}
+	}`)
+
+	if !a.handleCardAction(raw) {
+		t.Fatal("handleCardAction returned false")
+	}
+
+	msg := <-a.msgCh
+	if msg.OperatorID != "ou_open-user" {
+		t.Fatalf("operator id = %q, want ou_open-user (open_id must win over union_id)", msg.OperatorID)
+	}
+	if msg.UserID != "ou_open-user" {
+		t.Fatalf("user id = %q, want ou_open-user", msg.UserID)
+	}
+}
+
 func TestHandleMessageTreatsTopicGroupAsGroup(t *testing.T) {
 	a := &adapter{
 		cfg:    config.FeishuBotConfig{RequireMention: true},


### PR DESCRIPTION
# PR: fix(bot/feishu): prefer open_id when resolving card action operator

## 标题
`fix(bot/feishu): prefer open_id when resolving card action operator`

## 问题描述
飞书/Lark 交互卡片按钮回调（card action callback）里，`operator.operator_id` 会同时携带 `union_id` 与 `open_id`。原实现按 `union_id` → `open_id` 的优先级解析操作者身份，而 access / allowlist 配置通常以 `open_id` 记录用户。当两个 ID 都返回时，拿 `union_id` 去匹配 `open_id` 名单必然失败：

- 合法用户点「允许一次」按钮被误判为未知用户
- `pairing_enabled` 时错误触发配对码流程，审批被阻断

## 修复
`internal/bot/feishu/feishu.go` 的 `handleCardAction`：把 `open_id` 提到解析优先级最前，与普通消息的 `handleSDKMessage` 身份解析保持一致（后者一直优先 `sender_id.open_id`）。

## 测试
`internal/bot/feishu/feishu_test.go` 新增 `TestHandleCardActionPrefersOpenIDOverUnionID`：构造同时携带 `union_id` + `open_id` 的回调，断言 `OperatorID` / `UserID` 解析为 `open_id`。现有 4 个 `TestHandleCardAction*` 测试全部保持通过。

## 验证
- `go build ./cmd/reasonix` 通过
- `go test ./internal/bot/...` 全绿（feishu / qq / weixin / gateway 无回归）
- 用户真机（飞书）实测：修复后点「允许一次」按钮不再弹配对码，审批直接通过

## 备注
- 未改动 gateway 层准入逻辑（`checkAllowlist` 优先 `OperatorID` 是防陌生人代点的既有安全设计，`TestGatewayAllowlistGatesOnOperatorNotCardRequester` 覆盖，不应放宽）
