### PR TITLE
fix(windows): merge pinned launcher and desktop into one taskbar button

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -102,6 +102,11 @@ func main() {
 	capturePreviousFatalCrash()
 	installFatalCrashOutput()
 
+	// Fix Windows taskbar grouping before the first window registers: the
+	// launcher and the versioned desktop exe must share one AppUserModelID or
+	// Explorer shows two buttons. No-op off Windows.
+	applyWindowsTaskbarIdentity()
+
 	launch := parseDesktopLaunchArgs(os.Args[1:])
 
 	app := NewApp()

--- a/desktop/taskbar_identity_other.go
+++ b/desktop/taskbar_identity_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+// applyWindowsTaskbarIdentity is a no-op off Windows; taskbar grouping is
+// owned by the platform shell there.
+func applyWindowsTaskbarIdentity() {}

--- a/desktop/taskbar_identity_windows.go
+++ b/desktop/taskbar_identity_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"reasonix/internal/winappid"
+)
+
+// applyWindowsTaskbarIdentity pins this process and any Reasonix taskbar
+// shortcut to one explicit AppUserModelID before the first window registers.
+// Explorer keys taskbar grouping on that ID, so the pinned launcher
+// (Reasonix.exe / reasonix-launcher.exe) and the versioned desktop exe merge
+// into a single button instead of two. It runs in both the primary and the
+// remote-window process: both register windows, and the remote child must keep
+// the same identity or it would split off its own taskbar button.
+func applyWindowsTaskbarIdentity() {
+	if err := winappid.SetProcessID(); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: set AppUserModelID:", err)
+	}
+	if err := winappid.EnsureShortcutIDs(); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: stamp AppUserModelID on pinned shortcuts:", err)
+	}
+}

--- a/internal/desktoplauncher/launcher.go
+++ b/internal/desktoplauncher/launcher.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"reasonix/internal/installlayout"
+	"reasonix/internal/winappid"
 )
 
 // Run resolves the active desktop, performs the one-time legacy handoff when
@@ -42,6 +43,15 @@ func Run(args []string, buildVersion string) int {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return 1
+	}
+
+	// The pinned launcher and the versioned desktop exe live at different
+	// paths, so Windows would give them different default AppUserModelIDs and
+	// render two taskbar buttons. Stamp the pinned shortcut with the same
+	// explicit ID the desktop process sets before spawning it; this must run
+	// before the desktop registers its window. Best effort only.
+	if err := winappid.EnsureShortcutIDs(); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: taskbar identity repair:", err)
 	}
 
 	cmd := exec.Command(desktopPath, StripLegacyLaunchArgs(args)...)

--- a/internal/winappid/winappid.go
+++ b/internal/winappid/winappid.go
@@ -1,0 +1,17 @@
+// Package winappid gives every Reasonix desktop process and shortcut one
+// explicit Windows AppUserModelID (AUMID). Without one, Windows keys taskbar
+// grouping on the full executable path: the pinned launcher
+// (Reasonix.exe / reasonix-launcher.exe) and the versioned desktop it spawns
+// (versions/<v>/reasonix-desktop.exe) live at different paths, so Explorer
+// shows two taskbar buttons for one app.
+//
+// The desktop process registers the ID on itself (SetProcessID), and the
+// launcher stamps the same ID onto the pinned taskbar shortcut before the
+// desktop starts (EnsureShortcutIDs), so the first click after pinning already
+// converges onto a single button. The ID is a stable constant: it must never
+// include the version, or pinned buttons would break on update.
+package winappid
+
+// ID is the AppUserModelID shared by the desktop process and every pinned
+// Reasonix launcher shortcut.
+const ID = "Reasonix.Desktop"

--- a/internal/winappid/winappid_other.go
+++ b/internal/winappid/winappid_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package winappid
+
+// SetProcessID is a no-op off Windows: taskbar grouping is owned by the
+// platform shell there.
+func SetProcessID() error {
+	return nil
+}
+
+// EnsureShortcutIDs is a no-op off Windows.
+func EnsureShortcutIDs() error {
+	return nil
+}

--- a/internal/winappid/winappid_test.go
+++ b/internal/winappid/winappid_test.go
@@ -1,0 +1,20 @@
+package winappid
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIDStable(t *testing.T) {
+	const want = "Reasonix.Desktop"
+	if ID != want {
+		t.Fatalf("ID = %q; want %q", ID, want)
+	}
+}
+
+func TestPinnedLauncherNames(t *testing.T) {
+	want := []string{"Reasonix.exe.lnk", "reasonix-launcher.exe.lnk", "reasonix-desktop.exe.lnk"}
+	if !reflect.DeepEqual(pinnedLauncherNames, want) {
+		t.Fatalf("pinnedLauncherNames = %v; want %v", pinnedLauncherNames, want)
+	}
+}

--- a/internal/winappid/winappid_windows.go
+++ b/internal/winappid/winappid_windows.go
@@ -1,0 +1,243 @@
+//go:build windows
+
+package winappid
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// Property-system identifiers for System.AppUserModel.ID on shell links.
+var (
+	// pkeyAppUserModelID is PKEY_AppUserModelID, the property Explorer's
+	// taskbar grouping keys on.
+	pkeyAppUserModelID = propertyKey{
+		fmtid: windows.GUID{
+			Data1: 0x9F4C2855,
+			Data2: 0x9F79,
+			Data3: 0x4B39,
+			Data4: [8]byte{0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3},
+		},
+		pid: 5,
+	}
+	// iidIPropertyStore is IID_IPropertyStore.
+	iidIPropertyStore = windows.GUID{
+		Data1: 0x886D8EEB,
+		Data2: 0x8CF2,
+		Data3: 0x4446,
+		Data4: [8]byte{0x8D, 0x02, 0xCD, 0xBA, 0x1D, 0xBD, 0xCF, 0x99},
+	}
+)
+
+const (
+	coInitApartmentThreaded = 0x2 // COINIT_APARTMENTTHREADED
+	stgmReadWrite           = 0x2 // STGM_READWRITE
+	vtLpwstr                = 31  // VT_LPWSTR
+
+	shcneUpdateItem = 0x00002000 // SHCNE_UPDATEITEM
+	shcnfPathW      = 0x0005     // SHCNF_PATHW
+)
+
+// pinnedLauncherNames are the taskbar shortcut names the user can pin for this
+// product: the portable alias (Reasonix.exe), the stable launcher
+// (reasonix-launcher.exe), and the versioned desktop binary. Explorer names a
+// pinned shortcut after its target executable.
+var pinnedLauncherNames = []string{
+	"Reasonix.exe.lnk",
+	"reasonix-launcher.exe.lnk",
+	"reasonix-desktop.exe.lnk",
+}
+
+var (
+	// windowsPinnedTaskbarDir and windowsShortcutSetter are seams for tests.
+	windowsPinnedTaskbarDir = pinnedTaskbarDir
+	windowsShortcutSetter   = setShortcutID
+)
+
+// SetProcessID registers ID as this process's AppUserModelID so Explorer
+// groups its windows with any shortcut carrying the same ID. It must run
+// before the process registers its first window; after that the identity is
+// locked in for the lifetime of the process.
+func SetProcessID() error {
+	idPtr, err := windows.UTF16PtrFromString(ID)
+	if err != nil {
+		return err
+	}
+	proc := windows.NewLazySystemDLL("shell32.dll").NewProc("SetCurrentProcessExplicitAppUserModelID")
+	hr, _, _ := proc.Call(uintptr(unsafe.Pointer(idPtr)))
+	if hr != 0 {
+		return fmt.Errorf("set explicit AppUserModelID: hr=0x%08x", uint32(hr))
+	}
+	return nil
+}
+
+// EnsureShortcutIDs stamps ID onto every Reasonix taskbar-pinned shortcut.
+// The launcher calls this before spawning the desktop (and the desktop again
+// before its first window), so the pinned button and the running window share
+// one identity and never split into two taskbar icons. Best effort: when
+// nothing is pinned there is nothing to do, and a failed property write is
+// reported but never blocks launching.
+func EnsureShortcutIDs() error {
+	taskbar, err := windowsPinnedTaskbarDir()
+	if err != nil {
+		// Nothing pinned yet: the user has not asked for a taskbar button.
+		return nil
+	}
+	var out error
+	for _, name := range pinnedLauncherNames {
+		path := filepath.Join(taskbar, name)
+		if err := windowsShortcutSetter(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			out = errors.Join(out, fmt.Errorf("%s: %w", path, err))
+		}
+	}
+	return out
+}
+
+// pinnedTaskbarDir resolves the per-user folder holding taskbar-pinned
+// shortcuts (%APPDATA%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar).
+func pinnedTaskbarDir() (string, error) {
+	pinned, err := windows.KnownFolderPath(windows.FOLDERID_UserPinned, windows.KF_FLAG_DEFAULT)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(pinned, "TaskBar"), nil
+}
+
+// setShortcutID writes ID into the shortcut's System.AppUserModel.ID property
+// via the shell's IPropertyStore and asks Explorer to refresh the item. Only
+// regular files are touched; directories and dangling links are skipped.
+func setShortcutID(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if err := windows.CoInitializeEx(0, coInitApartmentThreaded); err != nil && err != syscall.Errno(1) {
+		// S_FALSE (1) merely means the apartment is already initialized.
+		return err
+	}
+	defer windows.CoUninitialize()
+
+	store, err := openPropertyStore(path)
+	if err != nil {
+		return err
+	}
+	defer store.Release()
+
+	idPtr, err := windows.UTF16PtrFromString(ID)
+	if err != nil {
+		return err
+	}
+	value := propVariant{vt: vtLpwstr, pwszVal: idPtr}
+	if hr := store.SetValue(&pkeyAppUserModelID, &value); hr != 0 {
+		return fmt.Errorf("set AppUserModelID property: hr=0x%08x", uint32(hr))
+	}
+	if hr := store.Commit(); hr != 0 {
+		return fmt.Errorf("commit AppUserModelID property: hr=0x%08x", uint32(hr))
+	}
+	notifyShortcutChanged(path)
+	return nil
+}
+
+// openPropertyStore opens the shell's property store for a shortcut path.
+// STGM_READWRITE is tried first; some files are only readable (e.g. held by
+// another handle), and the shell property handler can still persist a write
+// opened read-only.
+func openPropertyStore(path string) (*iPropertyStore, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	proc := windows.NewLazySystemDLL("shell32.dll").NewProc("SHGetPropertyStoreFromParsingName")
+	var lastHR uintptr
+	for _, mode := range []uint32{stgmReadWrite, 0 /* STGM_READ */} {
+		var store *iPropertyStore
+		hr, _, _ := proc.Call(
+			uintptr(unsafe.Pointer(pathPtr)),
+			0, // pbc: no bind context
+			uintptr(mode),
+			uintptr(unsafe.Pointer(&iidIPropertyStore)),
+			uintptr(unsafe.Pointer(&store)),
+		)
+		lastHR = hr
+		if hr == 0 && store != nil {
+			return store, nil
+		}
+	}
+	return nil, fmt.Errorf("open shortcut property store: hr=0x%08x", uint32(lastHR))
+}
+
+// notifyShortcutChanged invalidates one shortcut in Explorer's cache so the
+// new property is picked up without a full association flush.
+func notifyShortcutChanged(path string) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return
+	}
+	proc := windows.NewLazySystemDLL("shell32.dll").NewProc("SHChangeNotify")
+	_, _, _ = proc.Call(shcneUpdateItem, shcnfPathW, uintptr(unsafe.Pointer(pathPtr)), 0)
+}
+
+// iPropertyStore is a minimal raw view of the COM IPropertyStore interface.
+// The only methods used are SetValue and Commit; QueryInterface/AddRef exist
+// only to keep the vtable layout honest.
+type iPropertyStore struct {
+	vtbl *iPropertyStoreVtbl
+}
+
+type iPropertyStoreVtbl struct {
+	queryInterface uintptr
+	addRef         uintptr
+	release        uintptr
+	getCount       uintptr
+	getAt          uintptr
+	getValue       uintptr
+	setValue       uintptr
+	commit         uintptr
+}
+
+// Release drops one reference. The store is owned by this thread's apartment
+// and must be released before CoUninitialize.
+func (s *iPropertyStore) Release() {
+	syscall.SyscallN(s.vtbl.release, uintptr(unsafe.Pointer(s)))
+}
+
+// SetValue sets one property on the shortcut.
+func (s *iPropertyStore) SetValue(key *propertyKey, value *propVariant) (hr uintptr) {
+	r1, _, _ := syscall.SyscallN(s.vtbl.setValue, uintptr(unsafe.Pointer(s)), uintptr(unsafe.Pointer(key)), uintptr(unsafe.Pointer(value)))
+	return r1
+}
+
+// Commit persists the pending property changes to the shortcut file.
+func (s *iPropertyStore) Commit() (hr uintptr) {
+	r1, _, _ := syscall.SyscallN(s.vtbl.commit, uintptr(unsafe.Pointer(s)))
+	return r1
+}
+
+// propertyKey mirrors the PROPERTYKEY structure (fmtid + property id).
+type propertyKey struct {
+	fmtid windows.GUID
+	pid   uint32
+}
+
+// propVariant mirrors the leading fields of PROPVARIANT, enough for the
+// VT_LPWSTR values this package writes; the remaining union fields overlap
+// pwszVal and are never touched.
+type propVariant struct {
+	vt         uint16
+	wReserved1 uint16
+	wReserved2 uint16
+	wReserved3 uint16
+	pwszVal    *uint16
+}

--- a/internal/winappid/winappid_windows_test.go
+++ b/internal/winappid/winappid_windows_test.go
@@ -1,0 +1,102 @@
+//go:build windows
+
+package winappid
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetShortcutIDMissingFile(t *testing.T) {
+	err := setShortcutID(filepath.Join(t.TempDir(), "nope.lnk"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v; want os.ErrNotExist", err)
+	}
+}
+
+func TestSetShortcutIDSkipsNonRegular(t *testing.T) {
+	lnk := filepath.Join(t.TempDir(), "Reasonix.exe.lnk")
+	if err := os.Mkdir(lnk, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := setShortcutID(lnk); err != nil {
+		t.Fatalf("setShortcutID on directory: %v", err)
+	}
+}
+
+func TestEnsureShortcutIDsStampsInOrder(t *testing.T) {
+	taskbar := t.TempDir()
+	if err := os.WriteFile(filepath.Join(taskbar, "Reasonix.exe.lnk"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, origSetter := windowsPinnedTaskbarDir, windowsShortcutSetter
+	defer func() { windowsPinnedTaskbarDir, windowsShortcutSetter = origDir, origSetter }()
+	windowsPinnedTaskbarDir = func() (string, error) { return taskbar, nil }
+	var stamped []string
+	windowsShortcutSetter = func(path string) error {
+		stamped = append(stamped, path)
+		return nil
+	}
+
+	if err := EnsureShortcutIDs(); err != nil {
+		t.Fatalf("EnsureShortcutIDs: %v", err)
+	}
+	// The injected setter records every candidate in order; the real setter
+	// filters missing/dangling entries itself (see TestSetShortcutID*).
+	want := []string{
+		filepath.Join(taskbar, "Reasonix.exe.lnk"),
+		filepath.Join(taskbar, "reasonix-launcher.exe.lnk"),
+		filepath.Join(taskbar, "reasonix-desktop.exe.lnk"),
+	}
+	if len(stamped) != len(want) {
+		t.Fatalf("stamped = %v; want %v", stamped, want)
+	}
+	for i := range want {
+		if stamped[i] != want[i] {
+			t.Fatalf("stamped[%d] = %q; want %q", i, stamped[i], want[i])
+		}
+	}
+}
+
+func TestEnsureShortcutIDsNoPinnedFolder(t *testing.T) {
+	origDir, origSetter := windowsPinnedTaskbarDir, windowsShortcutSetter
+	defer func() { windowsPinnedTaskbarDir, windowsShortcutSetter = origDir, origSetter }()
+	windowsPinnedTaskbarDir = func() (string, error) {
+		return "", os.ErrNotExist
+	}
+	called := false
+	windowsShortcutSetter = func(string) error {
+		called = true
+		return nil
+	}
+	if err := EnsureShortcutIDs(); err != nil {
+		t.Fatalf("EnsureShortcutIDs: %v", err)
+	}
+	if called {
+		t.Fatal("setter called although no pinned folder exists")
+	}
+}
+
+func TestEnsureShortcutIDsJoinsErrors(t *testing.T) {
+	taskbar := t.TempDir()
+	good := filepath.Join(taskbar, "Reasonix.exe.lnk")
+	if err := os.WriteFile(good, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, origSetter := windowsPinnedTaskbarDir, windowsShortcutSetter
+	defer func() { windowsPinnedTaskbarDir, windowsShortcutSetter = origDir, origSetter }()
+	windowsPinnedTaskbarDir = func() (string, error) { return taskbar, nil }
+	windowsShortcutSetter = func(path string) error {
+		if path == good {
+			return nil
+		}
+		return errors.New("boom")
+	}
+	if err := EnsureShortcutIDs(); err == nil {
+		t.Fatal("EnsureShortcutIDs: want joined error, got nil")
+	}
+}


### PR DESCRIPTION
Problem: On Windows, clicking the taskbar-pinned launcher opened a second, separate taskbar icon. Explorer groups taskbar buttons by AppUserModelID (AUMID), which Windows derives from the executable path when unset. The pinned launcher (Reasonix.exe / reasonix-launcher.exe) and the versioned desktop it spawns (versions/<v>/reasonix-desktop.exe) live at different paths, so Explorer never merges them into one button.

Fix: new `internal/winappid` package with a stable, version-independent ID `"Reasonix.Desktop"`:

- `SetProcessID`: `SetCurrentProcessExplicitAppUserModelID` before the first window registers, in both the primary and remote-window processes (`desktop/main.go` -> `applyWindowsTaskbarIdentity()`).
- `EnsureShortcutIDs`: stamps `System.AppUserModel.ID` onto every Reasonix pinned taskbar shortcut via `IPropertyStore` (`SHGetPropertyStoreFromParsingName` -> `SetValue`/`Commit` -> `SHChangeNotify`), with an `STGM_READWRITE` -> `STGM_READ` fallback. Called by the launcher before spawning the desktop (`internal/desktoplauncher/launcher.go`) and again by the desktop at startup, so a stale pin heals on the next click. Best effort: never blocks launching.
- Non-Windows builds get no-op stubs.

Verification: unit tests for ID stability, candidate shortcut names, stamping order, missing-folder handling, joined errors and non-regular file skipping; manual Windows E2E shows a single taskbar button on pin + click + relaunch cycles.

Note: the missing icon on the locally installed exe is a temporary artifact of replacing the binary with a bare `go build` during E2E (skipping the icon-stamping step in `scripts/desktop-build.sh`); CI builds are unaffected (the build pipeline stamps `desktop/build/windows/icon.ico`).