### PR TITLE
Fix retry-inflated compaction decisions / 修复重试累计量导致的提前压缩

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -100,7 +100,11 @@ func (a *Agent) compactThresholds() (soft, snip, high int) {
 // the canonical transcript. No-op when compaction is disabled or usage is
 // unavailable.
 func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
-	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
+	if a.contextWindow <= 0 || u == nil {
+		return
+	}
+	promptTokens := u.LatestPromptTokens()
+	if promptTokens == 0 {
 		return
 	}
 	soft, snip, high := a.compactThresholds()
@@ -111,32 +115,32 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	// leaving a stale run count behind there would latch the *next* compaction as
 	// "the window is too small" and silently disable auto-compaction for the rest
 	// of the session.
-	if u.PromptTokens < high {
+	if promptTokens < high {
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
 	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
-	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {
+	if promptTokens >= soft && promptTokens < snip && !a.softCompactNoticed {
 		a.softCompactNoticed = true
 		detail := fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: detail})
 		return
 	}
-	if u.PromptTokens >= snip && u.PromptTokens < high {
+	if promptTokens >= snip && promptTokens < high {
 		// Snip only into a projection view — never rewrite the canonical log.
 		if err := a.snipToProjection(ctx); err != nil {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context snip skipped for now.", Detail: err.Error()})
 		}
 		return
 	}
-	if u.PromptTokens < high {
+	if promptTokens < high {
 		return // the latch was already cleared above
 	}
 	if a.compactStuck {
 		return
 	}
-	force := u.PromptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
+	force := promptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
 	// Projection-only prune before folding. Install the pruned view first so the
 	// next request (and its real usage) can measure whether a paid summarize is
 	// still needed — never rewrite the canonical transcript.

--- a/internal/agent/compact_retry_test.go
+++ b/internal/agent/compact_retry_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestMaybeCompactIgnoresRetryAggregateBelowContextThreshold(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("large earlier request ", 500)},
+		{Role: provider.RoleAssistant, Content: "earlier answer"},
+		{Role: provider.RoleUser, Content: "current request"},
+		{Role: provider.RoleAssistant, Content: "current answer"},
+	}}
+	a := New(&fakeProvider{reply: "summary"}, tool.NewRegistry(), sess, Options{
+		ContextWindow: 100,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{
+		PromptTokens:        80,
+		ContextPromptTokens: 40,
+	})
+
+	if hasCompactionSummary(visibleContext(a)) {
+		t.Fatal("retry-aggregate prompt tokens triggered compaction below the latest context threshold")
+	}
+}
+
+func TestMaybeCompactStillTriggersAtLatestContextThreshold(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("large earlier request ", 500)},
+		{Role: provider.RoleAssistant, Content: "earlier answer"},
+		{Role: provider.RoleUser, Content: "current request"},
+		{Role: provider.RoleAssistant, Content: "current answer"},
+	}}
+	a := New(&fakeProvider{reply: "summary"}, tool.NewRegistry(), sess, Options{
+		ContextWindow: 100,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{
+		PromptTokens:        160,
+		ContextPromptTokens: 80,
+	})
+
+	if !hasCompactionSummary(visibleContext(a)) {
+		t.Fatal("latest prompt at the configured threshold did not trigger compaction")
+	}
+}
+
+func TestMissingReasoningRetryAggregateDoesNotTriggerEarlyCompaction(t *testing.T) {
+	mp := testutil.NewMock("deepseek-proxy",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}},
+			Usage:     &provider.Usage{PromptTokens: 4000, CompletionTokens: 2, TotalTokens: 4002, CacheMissTokens: 4000, FinishReason: "tool_calls"},
+		},
+		testutil.Turn{
+			Reasoning: "retry reasoning",
+			ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}},
+			Usage:     &provider.Usage{PromptTokens: 4000, CompletionTokens: 3, TotalTokens: 4003, CacheHitTokens: 4000, ReasoningTokens: 2, FinishReason: "tool_calls"},
+		},
+		testutil.Turn{
+			Text:  "done",
+			Usage: &provider.Usage{PromptTokens: 4100, CompletionTokens: 1, TotalTokens: 4101, CacheHitTokens: 4000, CacheMissTokens: 100},
+		},
+	)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "original task"},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("old analysis ", 100)},
+		{Role: provider.RoleUser, Content: "follow-up"},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("more old work ", 100)},
+	}}
+	sink := &recordSink{}
+	a := New(toolCallReasoningRequiredProvider{mp}, echoRegistry(), sess, Options{
+		ContextWindow: 10_000,
+		ArchiveDir:    t.TempDir(),
+	}, sink)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(sink.kinds(event.CompactionStarted)); got != 0 {
+		t.Fatalf("compactions = %d, want none while latest prompt is below threshold", got)
+	}
+	usageEvents := sink.kinds(event.Usage)
+	if len(usageEvents) == 0 || usageEvents[0].Usage == nil {
+		t.Fatalf("missing recovery usage event: %+v", usageEvents)
+	}
+	if got := usageEvents[0].Usage; got.PromptTokens != 8000 || got.ContextPromptTokens != 4000 {
+		t.Fatalf("recovery usage = %+v, want aggregate prompt 8000 and latest context prompt 4000", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -758,9 +758,9 @@ func (u *Usage) ContextFillTokens() int {
 	return u.PromptTokens + u.CompletionTokens
 }
 
-// ContextPromptForGauge returns the latest-attempt prompt size for context
-// displays. Falls back to PromptTokens when ContextPromptTokens is unset.
-func (u *Usage) ContextPromptForGauge() int {
+// LatestPromptTokens returns the latest-attempt prompt size for context-aware
+// runtime decisions. Falls back to PromptTokens for single-attempt legacy usage.
+func (u *Usage) LatestPromptTokens() int {
 	if u == nil {
 		return 0
 	}


### PR DESCRIPTION
## Summary

- Base automatic compaction decisions on the latest single-request prompt shape.
- Keep multi-attempt prompt totals intact for billing and cache accounting.
- Add direct threshold coverage and an end-to-end DeepSeek missing-reasoning retry regression.

## Problem

Sampling recovery can replay the same frozen provider request after a stream interruption or a DeepSeek tool-call response with missing reasoning content. Those attempts are correctly aggregated for billing, but auto-compaction also consumed the aggregate. Two requests at roughly 40% could therefore look like 80%, and three requests at roughly 30% could look like 90%, causing an early context fold while the UI still showed the latest real context.

## Root cause

`Usage.PromptTokens` is the multi-attempt billable input total after sampling recovery. `ContextPromptTokens` is the latest request shape used by the context gauge. `maybeCompact` read the former for soft cleanup, snipping, normal compaction, force compaction, and stuck-latch recovery.

## Fix

Use `LatestPromptTokens()`, which preserves the latest-request value and falls back to the legacy single-attempt prompt value, for every automatic compaction threshold decision.

The tests verify that:

- aggregate 80% with latest context 40% does not compact;
- latest context at 80% still compacts normally;
- a complete DeepSeek missing-reasoning replay keeps aggregate billing at 80% while avoiding premature compaction at a latest context of 40%.

## User impact

DeepSeek and other providers that recover interrupted streams no longer compact at roughly 30-40% merely because the same request was attempted multiple times. Correct 80% compaction behavior remains unchanged.

## Related work

Refs #7913. That PR addresses shared-window output-budget and prompt-estimation pressure. This PR addresses retry-aggregate accounting in runtime compaction decisions. The mechanisms are orthogonal, although both touch `internal/agent/compact.go`.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/agent -count=1`
- `go vet ./...`
- `go run ./tools/repolint`
- `git diff --check`

## Compatibility

No persisted format, session schema, provider request, or frontend contract changes.

Cache-impact: low - prevents erroneous early compactions and preserves the stable provider-visible prefix for longer.
Cache-guard: direct threshold tests plus an end-to-end DeepSeek retry regression verify that only the latest request shape drives compaction.
Documentation-impact: none - documented 80% threshold behavior is restored rather than changed.