### PR TITLE
feat(evidence): shadow outcome scorer with trajectory recording and bench metrics

### DIFF
--- a/cmd/e2ebench/outcome.go
+++ b/cmd/e2ebench/outcome.go
@@ -1,0 +1,198 @@
+package main
+
+import "fmt"
+
+// outcomeSummary condenses one run's outcome-progress series: did claimed
+// progress become objective transitions, and did the run end below its best
+// verified state. Backfilled summaries derive from shell verification receipts
+// when the recording predates the runtime shadow scorer.
+type outcomeSummary struct {
+	Rounds              int   `json:"rounds,omitempty"`
+	ProgressRounds      int   `json:"progress_rounds,omitempty"`
+	FalseProgressRounds int   `json:"false_progress_rounds,omitempty"`
+	SolutionStallMax    int   `json:"solution_stall_max,omitempty"`
+	Objective           int   `json:"objective,omitempty"`
+	Regression          int   `json:"regression,omitempty"`
+	BestScore           int   `json:"best_score,omitempty"`
+	FinalScore          int   `json:"final_score"`
+	RegressedFromBest   bool  `json:"regressed_from_best,omitempty"`
+	SearchRegretMs      int64 `json:"search_regret_ms,omitempty"`
+	Backfilled          bool  `json:"backfilled,omitempty"`
+}
+
+// outcomePoint is one recorded shadow sample plus its observation time.
+type outcomePoint struct {
+	ts                                                      int64
+	exploration, verification, objective, regression, churn int
+	legacyGain                                              int
+}
+
+// verifyPoint is one backfilled verification-transition observation.
+type verifyPoint struct {
+	ts                    int64
+	objective, regression int
+}
+
+// falseProgressWindow bounds how many later rounds may redeem a legacy
+// progress claim with an objective transition before the round counts false.
+const falseProgressWindow = 3
+
+// observeVerification folds one verification-classified shell result into the
+// backfill series; key identity is the exact (name, args) announcement.
+func (t *trajScan) observeVerification(key string, passed bool, ts int64) {
+	if t.verifyPass == nil {
+		t.verifySeen = map[string]bool{}
+		t.verifyPass = map[string]bool{}
+	}
+	seen, was := t.verifySeen[key], t.verifyPass[key]
+	t.verifySeen[key] = true
+	t.verifyPass[key] = passed
+	p := verifyPoint{ts: ts}
+	if seen && passed && !was {
+		p.objective = 1
+	}
+	if seen && !passed && was {
+		p.regression = 1
+	}
+	t.verifyPoints = append(t.verifyPoints, p)
+}
+
+// summarizeOutcome prefers recorded shadow samples; older recordings fall back
+// to the verification backfill, which cannot price legacy-scorer claims.
+func (t *trajScan) summarizeOutcome() *outcomeSummary {
+	if len(t.outcomePoints) > 0 {
+		return summarizeOutcomePoints(t.outcomePoints, t.lastTS)
+	}
+	if len(t.verifyPoints) > 0 {
+		return summarizeVerifyBackfill(t.verifyPoints, t.lastTS)
+	}
+	return nil
+}
+
+func summarizeOutcomePoints(points []outcomePoint, lastTS int64) *outcomeSummary {
+	o := &outcomeSummary{Rounds: len(points)}
+	verifying, solution, stall := false, false, 0
+	score, best := 0, 0
+	var bestTS int64
+	for _, p := range points {
+		if p.verification > 0 {
+			verifying = true
+		}
+		o.Objective += p.objective
+		o.Regression += p.regression
+		if p.legacyGain > 0 {
+			o.ProgressRounds++
+		}
+		// The solution stall clock only starts once the run enters its solution
+		// phase (a verification attempt or a mutation); pure research runs with
+		// no verification would otherwise read as one long stall.
+		if p.verification > 0 || p.churn > 0 {
+			solution = true
+		}
+		if solution {
+			if p.objective > 0 {
+				stall = 0
+			} else {
+				stall++
+				o.SolutionStallMax = max(o.SolutionStallMax, stall)
+			}
+		}
+		score += p.objective - p.regression
+		if score > best {
+			best, bestTS = score, p.ts
+		}
+	}
+	if verifying {
+		for i, p := range points {
+			if p.legacyGain <= 0 {
+				continue
+			}
+			redeemed := false
+			for j := i; j < min(i+1+falseProgressWindow, len(points)); j++ {
+				if points[j].objective > 0 {
+					redeemed = true
+					break
+				}
+			}
+			if !redeemed {
+				o.FalseProgressRounds++
+			}
+		}
+	}
+	finishScore(o, score, best, bestTS, lastTS)
+	return o
+}
+
+func summarizeVerifyBackfill(points []verifyPoint, lastTS int64) *outcomeSummary {
+	o := &outcomeSummary{Backfilled: true}
+	score, best := 0, 0
+	var bestTS int64
+	for _, p := range points {
+		o.Objective += p.objective
+		o.Regression += p.regression
+		score += p.objective - p.regression
+		if score > best {
+			best, bestTS = score, p.ts
+		}
+	}
+	finishScore(o, score, best, bestTS, lastTS)
+	return o
+}
+
+func finishScore(o *outcomeSummary, score, best int, bestTS, lastTS int64) {
+	o.BestScore, o.FinalScore = best, score
+	if score < best {
+		o.RegressedFromBest = true
+		if lastTS > bestTS {
+			o.SearchRegretMs = lastTS - bestTS
+		}
+	}
+}
+
+// renderOutcomeProgress aggregates the shadow scorer's verdicts: how often the
+// live novelty scorer claimed progress that never became an objective
+// transition, and how many runs peaked above their final verified state.
+func renderOutcomeProgress(results []result) string {
+	runs, backfilled := 0, 0
+	progress, falseProgress := 0, 0
+	objective, regression, regressed := 0, 0, 0
+	var regretMs int64
+	stallMax := 0
+	for _, r := range results {
+		if r.Trajectory == nil || r.Trajectory.Outcome == nil {
+			continue
+		}
+		o := r.Trajectory.Outcome
+		runs++
+		if o.Backfilled {
+			backfilled++
+		}
+		progress += o.ProgressRounds
+		falseProgress += o.FalseProgressRounds
+		objective += o.Objective
+		regression += o.Regression
+		stallMax = max(stallMax, o.SolutionStallMax)
+		if o.RegressedFromBest {
+			regressed++
+			regretMs += o.SearchRegretMs
+		}
+	}
+	if runs == 0 {
+		return ""
+	}
+	line := fmt.Sprintf("**Outcome shadow** (%d runs): **objective transitions** %d · **regressions** %d · **regressed from best** %d (%s)",
+		runs, objective, regression, regressed, pct(regressed, runs))
+	if progress > 0 {
+		line += fmt.Sprintf(" · **false progress** %d/%d (%s)", falseProgress, progress, pct(falseProgress, progress))
+	}
+	if stallMax > 0 {
+		line += fmt.Sprintf(" · **solution stall max** %d rounds", stallMax)
+	}
+	if regressed > 0 {
+		line += fmt.Sprintf(" · **avg search regret** %s", dur(regretMs/int64(regressed)))
+	}
+	if backfilled > 0 {
+		line += fmt.Sprintf(" · backfilled %d", backfilled)
+	}
+	return line + "\n\n"
+}

--- a/cmd/e2ebench/outcome_test.go
+++ b/cmd/e2ebench/outcome_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTrajectory(t *testing.T, name string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestSummarizeOutcomeFromRecordedShadowSamples(t *testing.T) {
+	path := writeTrajectory(t, "shadow.trajectory.jsonl", []string{
+		`{"seq":1,"ts":500,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":1000,"outcome_progress":{"round":1,"exploration":1,"legacy_gain":1}}`,
+		`{"seq":3,"ts":2000,"outcome_progress":{"round":2,"verification":1,"legacy_gain":2}}`,
+		`{"seq":4,"ts":3000,"outcome_progress":{"round":3,"churn":1,"legacy_gain":3}}`,
+		`{"seq":5,"ts":4000,"outcome_progress":{"round":4,"verification":1,"objective":1,"legacy_gain":2}}`,
+		`{"seq":6,"ts":5000,"outcome_progress":{"round":5,"churn":1,"legacy_gain":3}}`,
+		`{"seq":7,"ts":6000,"outcome_progress":{"round":6,"verification":1,"regression":1}}`,
+		`{"seq":8,"ts":7000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	o := s.Outcome
+	if o == nil || o.Backfilled {
+		t.Fatalf("outcome = %+v, want recorded (not backfilled)", o)
+	}
+	if o.Rounds != 6 || o.ProgressRounds != 5 {
+		t.Errorf("rounds=%d progress=%d, want 6/5", o.Rounds, o.ProgressRounds)
+	}
+	// Round 5 claimed legacy progress (a mutation) with no objective transition
+	// inside the redemption window — the false-progress case.
+	if o.FalseProgressRounds != 1 {
+		t.Errorf("false progress = %d, want 1", o.FalseProgressRounds)
+	}
+	if o.SolutionStallMax != 2 {
+		t.Errorf("solution stall max = %d, want 2", o.SolutionStallMax)
+	}
+	if o.Objective != 1 || o.Regression != 1 || o.BestScore != 1 || o.FinalScore != 0 {
+		t.Errorf("objective=%d regression=%d best=%d final=%d, want 1/1/1/0",
+			o.Objective, o.Regression, o.BestScore, o.FinalScore)
+	}
+	if !o.RegressedFromBest || o.SearchRegretMs != 3000 {
+		t.Errorf("regressed=%v regret=%d, want true/3000 (best at ts 4000, end at 7000)",
+			o.RegressedFromBest, o.SearchRegretMs)
+	}
+}
+
+func TestSummarizeOutcomeBackfillsFromVerificationReceipts(t *testing.T) {
+	args := `{\"command\":\"go test ./x\"}`
+	path := writeTrajectory(t, "old.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"event":{"kind":"tool_result","tool":{"name":"bash","args":"` + args + `","err":"exit 1","execution":{"verification":"failed"}}}}`,
+		`{"seq":3,"ts":3000,"event":{"kind":"tool_result","tool":{"name":"bash","args":"` + args + `","execution":{"verification":"passed"}}}}`,
+		`{"seq":4,"ts":4000,"event":{"kind":"tool_result","tool":{"name":"bash","args":"` + args + `","err":"exit 1","execution":{"verification":"failed"}}}}`,
+		`{"seq":5,"ts":5000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	o := s.Outcome
+	if o == nil || !o.Backfilled {
+		t.Fatalf("outcome = %+v, want a backfilled summary", o)
+	}
+	if o.Objective != 1 || o.Regression != 1 || o.BestScore != 1 || o.FinalScore != 0 {
+		t.Errorf("objective=%d regression=%d best=%d final=%d, want 1/1/1/0",
+			o.Objective, o.Regression, o.BestScore, o.FinalScore)
+	}
+	if !o.RegressedFromBest || o.SearchRegretMs != 2000 {
+		t.Errorf("regressed=%v regret=%d, want true/2000", o.RegressedFromBest, o.SearchRegretMs)
+	}
+	if o.FalseProgressRounds != 0 || o.ProgressRounds != 0 {
+		t.Errorf("backfill cannot price legacy claims, got progress=%d false=%d",
+			o.ProgressRounds, o.FalseProgressRounds)
+	}
+	// A subagent's verification must not pollute the parent series.
+	sub := writeTrajectory(t, "sub.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"event":{"kind":"tool_result","tool":{"name":"bash","args":"` + args + `","parentId":"task-1","execution":{"verification":"failed"}}}}`,
+		`{"seq":3,"ts":3000,"event":{"kind":"turn_done"}}`,
+	})
+	if s, err = summarizeTrajectory(sub); err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.Outcome != nil {
+		t.Errorf("subagent-only verification must yield no outcome summary, got %+v", s.Outcome)
+	}
+}
+
+func TestRenderOutcomeProgressAggregatesRuns(t *testing.T) {
+	results := []result{
+		{Trajectory: &trajectorySummary{Outcome: &outcomeSummary{
+			Rounds: 8, ProgressRounds: 5, FalseProgressRounds: 2,
+			Objective: 2, BestScore: 2, FinalScore: 2,
+		}}},
+		{Trajectory: &trajectorySummary{Outcome: &outcomeSummary{
+			Objective: 1, Regression: 1, BestScore: 1, FinalScore: 0,
+			RegressedFromBest: true, SearchRegretMs: 4000, Backfilled: true,
+		}}},
+		{Trajectory: &trajectorySummary{}}, // no outcome data: excluded
+	}
+	got := renderOutcomeProgress(results)
+	for _, want := range []string{
+		"**Outcome shadow** (2 runs)",
+		"**objective transitions** 3",
+		"**regressed from best** 1 (50%)",
+		"**false progress** 2/5 (40%)",
+		"**avg search regret** 4.0s",
+		"backfilled 1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q in:\n%s", want, got)
+		}
+	}
+	if renderOutcomeProgress(nil) != "" {
+		t.Error("no runs must render nothing")
+	}
+}

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -193,6 +193,7 @@ func renderBody(results []result) string {
 	b.WriteString(renderSolveProfiles(results))
 	b.WriteString(renderToolSurface(results))
 	b.WriteString(renderContractShadow(results))
+	b.WriteString(renderOutcomeProgress(results))
 	b.WriteString(renderMechanismLedger(results))
 	if s.unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",

--- a/cmd/e2ebench/rounds.go
+++ b/cmd/e2ebench/rounds.go
@@ -84,6 +84,10 @@ type trajScan struct {
 	seen                               map[string]bool // (name, args) pairs already dispatched
 	gapPlanner, gapCompact, gapHandoff bool
 	sawCallIDs                         bool
+
+	outcomePoints          []outcomePoint
+	verifySeen, verifyPass map[string]bool
+	verifyPoints           []verifyPoint
 }
 
 // modelAttempt is one sampling attempt's wall interval; planner marks attempts

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -104,6 +104,10 @@ type trajectorySummary struct {
 	ShadowIntent   string `json:"shadow_intent,omitempty"`
 	ShadowVerdict  string `json:"shadow_verdict,omitempty"`
 	ShadowComplete bool   `json:"shadow_complete,omitempty"`
+
+	// Outcome shadow: the runtime outcome scorer's per-round series condensed,
+	// or a verification-receipt backfill for recordings that predate it.
+	Outcome *outcomeSummary `json:"outcome,omitempty"`
 }
 
 // toolWall is the best available tool wall-clock: interval union when the
@@ -124,6 +128,14 @@ type trajectoryRecord struct {
 		Verdict  string `json:"verdict"`
 		Complete bool   `json:"complete"`
 	} `json:"contract_shadow"`
+	OutcomeProgress *struct {
+		Exploration  int `json:"exploration"`
+		Verification int `json:"verification"`
+		Objective    int `json:"objective"`
+		Regression   int `json:"regression"`
+		Churn        int `json:"churn"`
+		LegacyGain   int `json:"legacy_gain"`
+	} `json:"outcome_progress"`
 	Event *struct {
 		Kind          string `json:"kind"`
 		Code          string `json:"code"`
@@ -297,6 +309,13 @@ func (t *trajScan) record(rec trajectoryRecord) {
 		t.s.ShadowIntent = cs.Intent
 		t.s.ShadowVerdict = cs.Verdict
 		t.s.ShadowComplete = cs.Complete
+	}
+	if op := rec.OutcomeProgress; op != nil {
+		t.outcomePoints = append(t.outcomePoints, outcomePoint{
+			ts: rec.TS, exploration: op.Exploration, verification: op.Verification,
+			objective: op.Objective, regression: op.Regression, churn: op.Churn,
+			legacyGain: op.LegacyGain,
+		})
 	}
 	if rec.Event == nil {
 		return
@@ -502,6 +521,9 @@ func (t *trajScan) recordResult(rec trajectoryRecord) {
 			info.verification = tl.Execution.Verification
 		}
 	}
+	if ex := tl.Execution; ex != nil && (ex.Verification == "passed" || ex.Verification == "failed") {
+		t.observeVerification(tl.Name+"\x00"+tl.Args, ex.Verification == "passed", rec.TS)
+	}
 	t.batch.serialMs += tl.DurationMs
 	if tl.StartedAt > 0 && tl.EndedAt >= tl.StartedAt {
 		t.batch.intervals = append(t.batch.intervals, [2]int64{tl.StartedAt, tl.EndedAt})
@@ -588,6 +610,7 @@ func (t *trajScan) finish() *trajectorySummary {
 	if s.ModelMs = s.SpanMs - s.toolWall(); s.ModelMs < 0 {
 		s.ModelMs = 0
 	}
+	s.Outcome = t.summarizeOutcome()
 	t.decompose()
 	return s
 }

--- a/cmd/e2ebench/trajmode.go
+++ b/cmd/e2ebench/trajmode.go
@@ -37,7 +37,7 @@ func runTrajMode(dir string) (string, error) {
 		}
 		fmt.Fprintf(&b, "### `%s`\n\n```json\n%s\n```\n\n", id, enc)
 	}
-	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderMechanismLedger(results) + b.String(), nil
+	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderOutcomeProgress(results) + renderMechanismLedger(results) + b.String(), nil
 }
 
 func emitTrajMode(dir, outMD string) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -564,6 +564,10 @@ type Agent struct {
 	// (see progress_guard.go); reset with the evidence ledger each turn.
 	progress progressGuard
 
+	// outcome shadows progress with an outcome-decomposed scorer whose samples
+	// only feed trajectory recording; it never influences guard behavior.
+	outcome *evidence.OutcomeTracker
+
 	// repeatFailureCounts tracks semantically identical write-like calls that
 	// keep failing with the same failure class. Unlike stormSig, successful
 	// reads do not blindly clear this state: re-reading a file and then

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -49,16 +49,32 @@ func (g *progressGuard) observe(receipts []Receipt) int {
 type Receipt = evidence.Receipt
 
 // applyBatchGuards runs both post-batch guards: the storm breaker (failure
-// fixation) and the progress guard (zero-gain repetition).
+// fixation) and the progress guard (zero-gain repetition). The outcome shadow
+// observes the same receipts afterwards without influencing either guard.
 func (a *Agent) applyBatchGuards(calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) {
 	a.applyStormBreaker(calls, outcomes, results, receiptMark)
 	a.applyProgressGuard(results, outcomes, receiptMark)
+	a.observeOutcomeShadow(receiptMark)
 }
 
-// resetTurnEvidence clears the ledger and the progress-guard state together.
+// resetTurnEvidence clears the ledger and both progress scorers together.
 func (a *Agent) resetTurnEvidence() {
 	a.evidence.Reset()
 	a.progress.reset()
+	a.outcome = evidence.NewOutcomeTracker()
+}
+
+// observeOutcomeShadow scores the round's receipts through the shadow outcome
+// tracker and records the sample for trajectory analysis. Unlike the guards it
+// observes every round, including all-failure ones — regressions live there.
+func (a *Agent) observeOutcomeShadow(receiptMark int) {
+	if a.evidence == nil {
+		return
+	}
+	if a.outcome == nil {
+		a.outcome = evidence.NewOutcomeTracker()
+	}
+	event.RecordOutcomeProgress(a.sink, a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark)))
 }
 
 // applyProgressGuard escalates when consecutive rounds stop producing new

--- a/internal/agent/progress_guard_test.go
+++ b/internal/agent/progress_guard_test.go
@@ -72,6 +72,40 @@ func TestProgressGuardEscalatesOnZeroGainRounds(t *testing.T) {
 	}
 }
 
+type outcomeSampleSink struct {
+	samples []evidence.OutcomeSample
+}
+
+func (s *outcomeSampleSink) Emit(event.Event) {}
+func (s *outcomeSampleSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	s.samples = append(s.samples, sample)
+}
+
+func TestOutcomeShadowRecordsEveryRoundWithoutTouchingGuards(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_probe", readOnly: true})
+	sink := &outcomeSampleSink{}
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+	a.resetTurnEvidence()
+
+	first := runRound(t, a, "a.go")
+	second := runRound(t, a, "a.go")
+	if len(sink.samples) != 2 {
+		t.Fatalf("got %d shadow samples, want one per round", len(sink.samples))
+	}
+	if s := sink.samples[0]; s.Round != 1 || s.Exploration != 1 || s.Objective != 0 {
+		t.Fatalf("round 1 sample = %+v, want exploration 1 objective 0", s)
+	}
+	if s := sink.samples[1]; s.Round != 2 || s.Exploration != 0 || s.LegacyGain != 0 {
+		t.Fatalf("round 2 repeat sample = %+v, want all-zero with legacy gain 0", s)
+	}
+	// The shadow observes; the guard alone decides. Round texts stay untouched
+	// below the nudge threshold exactly as before.
+	if strings.Contains(first[0], "[progress guard]") || strings.Contains(second[0], "[progress guard]") {
+		t.Fatalf("shadow must not change guard behavior: %q / %q", first[0], second[0])
+	}
+}
+
 func TestProgressGuardResetsOnNewEvidence(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "read_probe", readOnly: true})

--- a/internal/control/goalusage.go
+++ b/internal/control/goalusage.go
@@ -74,6 +74,11 @@ func (t *goalUsageTee) RecordReadinessAudit(a evidence.ReadinessAudit) {
 	}
 }
 
+// RecordOutcomeProgress forwards the shadow outcome sample unchanged.
+func (t *goalUsageTee) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	event.RecordOutcomeProgress(t.inner, sample)
+}
+
 // RecordContractShadow forwards the shadow contract audit unchanged.
 func (t *goalUsageTee) RecordContractShadow(a event.ContractShadowAudit) {
 	if t == nil || t.inner == nil {

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -166,3 +166,10 @@ func (c *coalescer) RecordContractShadow(a ContractShadowAudit) {
 	c.drainAndUnlock()
 	RecordContractShadow(c.inner, a)
 }
+
+func (c *coalescer) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordOutcomeProgress(c.inner, sample)
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -618,6 +618,24 @@ func RecordContractShadow(s Sink, a ContractShadowAudit) {
 	}
 }
 
+// OutcomeProgressSink is an optional sink capability for the shadow outcome
+// scorer's per-round samples: counts only, never paths or commands. Shadow
+// means observed, not enforced — the novelty guard still decides behavior.
+type OutcomeProgressSink interface {
+	RecordOutcomeProgress(evidence.OutcomeSample)
+}
+
+// RecordOutcomeProgress forwards a shadow outcome sample only to sinks that
+// explicitly opt in. Ordinary UI sinks receive nothing.
+func RecordOutcomeProgress(s Sink, sample evidence.OutcomeSample) {
+	if nilutil.IsNil(s) {
+		return
+	}
+	if op, ok := s.(OutcomeProgressSink); ok {
+		op.RecordOutcomeProgress(sample)
+	}
+}
+
 // ProtocolRecoveryAuditSink is an optional sink capability. Implementations
 // must keep it content-free; prompts, responses, endpoints, model names, and
 // tool arguments do not belong in this audit channel.

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -63,3 +63,11 @@ func (s *syncSink) RecordContractShadow(a ContractShadowAudit) {
 		rs.RecordContractShadow(a)
 	}
 }
+
+func (s *syncSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if op, ok := s.inner.(OutcomeProgressSink); ok {
+		op.RecordOutcomeProgress(sample)
+	}
+}

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -1,0 +1,123 @@
+package evidence
+
+import "strings"
+
+// OutcomeSample decomposes one tool round's receipts by outcome: information
+// gathered (Exploration), verification attempts run, and verification-command
+// state transitions (Objective fail→pass, Regression pass→fail). Counts are
+// unit-weighted; policy weighting is an offline concern.
+type OutcomeSample struct {
+	Round        int
+	Exploration  int
+	Verification int
+	Objective    int
+	Regression   int
+	Churn        int
+	// LegacyGain is the live novelty scorer's verdict on the same receipts, so
+	// offline analysis can compare the two policies without replaying.
+	LegacyGain int
+}
+
+// OutcomeTracker is the shadow counterpart of ProgressTracker: same per-round
+// receipts, scored by outcome instead of novelty. It never influences guard
+// behavior — samples exist only for trajectory recording and offline analysis.
+type OutcomeTracker struct {
+	legacy     *ProgressTracker
+	round      int
+	readPaths  map[string]bool
+	commands   map[string]bool
+	failures   map[string]bool
+	actions    map[string]bool
+	verifySeen map[string]bool
+	verifyPass map[string]bool
+}
+
+func NewOutcomeTracker() *OutcomeTracker {
+	return &OutcomeTracker{
+		legacy:     NewProgressTracker(),
+		readPaths:  map[string]bool{},
+		commands:   map[string]bool{},
+		failures:   map[string]bool{},
+		actions:    map[string]bool{},
+		verifySeen: map[string]bool{},
+		verifyPass: map[string]bool{},
+	}
+}
+
+// ScoreRound folds one round's receipts into the tracker and returns the
+// round's outcome decomposition.
+func (t *OutcomeTracker) ScoreRound(receipts []Receipt) OutcomeSample {
+	if t == nil {
+		return OutcomeSample{}
+	}
+	t.round++
+	s := OutcomeSample{Round: t.round}
+	for _, r := range receipts {
+		t.scoreReceipt(r, &s)
+	}
+	s.LegacyGain = t.legacy.ScoreRound(receipts)
+	return s
+}
+
+func (t *OutcomeTracker) scoreReceipt(r Receipt, s *OutcomeSample) {
+	if command := strings.TrimSpace(r.Command); command != "" {
+		t.scoreCommand(command, r, s)
+		return
+	}
+	switch {
+	case r.Success && (r.Mutation || r.Write):
+		// A mutation is a state transition, not proof of progress: it counts
+		// as churn until a verification transition vouches for it.
+		s.Churn++
+	case r.Success && (r.ToolName == "task" || r.ToolName == "parallel_tasks" || r.ToolName == "fleet"):
+		// A delegation return is new information at best — never objective
+		// progress on its own.
+		s.Exploration++
+	case r.Success && (r.StepProof || r.TodoStep != nil || len(r.Todos) > 0):
+		// Bookkeeping moves no outcome dimension.
+	case r.Success && r.Read && r.OutputBytes > 0 && len(r.Paths) > 0:
+		for _, path := range r.Paths {
+			if path == "" || t.readPaths[path] {
+				continue
+			}
+			t.readPaths[path] = true
+			s.Exploration++
+		}
+	case r.Success:
+		sig := r.ToolName + "\x00" + string(r.Args)
+		if !t.actions[sig] {
+			t.actions[sig] = true
+			s.Exploration++
+		}
+	}
+}
+
+func (t *OutcomeTracker) scoreCommand(command string, r Receipt, s *OutcomeSample) {
+	if r.Success && (r.Mutation || r.Write) {
+		s.Churn++
+	}
+	verify := IsDeliveryVerificationCommand(command)
+	if verify {
+		s.Verification++
+		seen, wasPass := t.verifySeen[command], t.verifyPass[command]
+		t.verifySeen[command] = true
+		t.verifyPass[command] = r.Success
+		if seen && r.Success && !wasPass {
+			s.Objective++
+		}
+		if seen && !r.Success && wasPass {
+			s.Regression++
+		}
+	}
+	if r.Success {
+		if !verify && !t.commands[command] {
+			s.Exploration++
+		}
+		t.commands[command] = true
+		return
+	}
+	if !t.failures[command] {
+		t.failures[command] = true
+		s.Exploration++
+	}
+}

--- a/internal/evidence/outcome_test.go
+++ b/internal/evidence/outcome_test.go
@@ -1,0 +1,78 @@
+package evidence
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOutcomeTrackerSeparatesExplorationFromObjective(t *testing.T) {
+	tr := NewOutcomeTracker()
+
+	read := readReceipt("a.go")
+	read.OutputBytes = 10
+	s := tr.ScoreRound([]Receipt{read})
+	if s.Exploration != 1 || s.Objective != 0 {
+		t.Fatalf("new read = %+v, want exploration 1 objective 0", s)
+	}
+
+	// First verification failure: an attempt plus localization, no objective.
+	s = tr.ScoreRound([]Receipt{bashReceipt("go test ./x", false)})
+	if s.Verification != 1 || s.Exploration != 1 || s.Objective != 0 {
+		t.Fatalf("first failing verify = %+v, want verification 1 exploration 1", s)
+	}
+
+	// A mutation is churn, not objective progress — the legacy scorer disagrees.
+	write := ReceiptFromToolCall("write_file", json.RawMessage(`{"path":"b.go","content":"x"}`), true, false)
+	s = tr.ScoreRound([]Receipt{write})
+	if s.Churn != 1 || s.Objective != 0 || s.Exploration != 0 {
+		t.Fatalf("mutation = %+v, want churn 1 only", s)
+	}
+	if s.LegacyGain != gainMutation {
+		t.Fatalf("mutation legacy gain = %d, want %d", s.LegacyGain, gainMutation)
+	}
+
+	// The failing verification turning green is the objective transition.
+	s = tr.ScoreRound([]Receipt{bashReceipt("go test ./x", true)})
+	if s.Objective != 1 || s.Verification != 1 || s.Regression != 0 {
+		t.Fatalf("fail→pass verify = %+v, want objective 1", s)
+	}
+
+	// The same verification breaking again is a regression.
+	s = tr.ScoreRound([]Receipt{bashReceipt("go test ./x", false)})
+	if s.Regression != 1 || s.Objective != 0 {
+		t.Fatalf("pass→fail verify = %+v, want regression 1", s)
+	}
+}
+
+func TestOutcomeTrackerDelegationAndRepeatsAreExplorationAtBest(t *testing.T) {
+	tr := NewOutcomeTracker()
+
+	task := ReceiptFromToolCall("task", json.RawMessage(`{"prompt":"dig"}`), true, false)
+	s := tr.ScoreRound([]Receipt{task})
+	if s.Exploration != 1 || s.Objective != 0 {
+		t.Fatalf("delegation = %+v, want exploration 1 objective 0", s)
+	}
+
+	// A first passing verification run establishes a baseline, not progress.
+	s = tr.ScoreRound([]Receipt{bashReceipt("go vet ./...", true)})
+	if s.Verification != 1 || s.Objective != 0 || s.Exploration != 0 {
+		t.Fatalf("baseline verify = %+v, want verification 1 only", s)
+	}
+	s = tr.ScoreRound([]Receipt{bashReceipt("go vet ./...", true)})
+	if s.Verification != 1 || s.Objective != 0 {
+		t.Fatalf("repeated passing verify = %+v, want no objective", s)
+	}
+
+	// A repeat delegation still returned content the host cannot judge — it
+	// stays exploration and can never move the objective dimension.
+	repeat := ReceiptFromToolCall("task", json.RawMessage(`{"prompt":"dig"}`), true, false)
+	s = tr.ScoreRound([]Receipt{repeat})
+	if s.Exploration != 1 || s.Objective != 0 {
+		t.Fatalf("repeated delegation = %+v, want exploration 1 objective 0", s)
+	}
+
+	var nilTracker *OutcomeTracker
+	if got := nilTracker.ScoreRound([]Receipt{task}); got != (OutcomeSample{}) {
+		t.Fatalf("nil tracker sample = %+v, want zero", got)
+	}
+}

--- a/internal/notify/sink.go
+++ b/internal/notify/sink.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 )
 
 // Message is the user-visible payload sent to the platform notifier.
@@ -38,6 +39,22 @@ func (s *Sink) Emit(e event.Event) {
 
 func (s *Sink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 	event.RecordProtocolRecovery(s.inner, a)
+}
+
+func (s *Sink) RecordReadinessAudit(a evidence.ReadinessAudit) {
+	event.RecordReadinessAudit(s.inner, a)
+}
+
+func (s *Sink) RecordTurnCompletion() {
+	event.RecordTurnCompletion(s.inner)
+}
+
+func (s *Sink) RecordContractShadow(a event.ContractShadowAudit) {
+	event.RecordContractShadow(s.inner, a)
+}
+
+func (s *Sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	event.RecordOutcomeProgress(s.inner, sample)
 }
 
 // SendEvent applies the same notification rules for paths that do not emit through Sink.

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -179,6 +179,11 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(r.inner, a)
 }
 
+// RecordOutcomeProgress preserves the wrapped sink's audit capability.
+func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	event.RecordOutcomeProgress(r.inner, sample)
+}
+
 func (r *Recorder) recordUsage(e event.Event) {
 	r.recordProviderUsage(e.ModelRef, e.Usage)
 }

--- a/internal/telemetry/sink.go
+++ b/internal/telemetry/sink.go
@@ -131,6 +131,14 @@ func (s *sink) RecordReadinessAudit(a evidence.ReadinessAudit) {
 	event.RecordReadinessAudit(s.inner, a)
 }
 
+func (s *sink) RecordContractShadow(a event.ContractShadowAudit) {
+	event.RecordContractShadow(s.inner, a)
+}
+
+func (s *sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	event.RecordOutcomeProgress(s.inner, sample)
+}
+
 func (s *sink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 	add(s.counts, "tool_call_reasoning_recovery", string(a.Kind), 1)
 	event.RecordProtocolRecovery(s.inner, a)

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -19,9 +19,8 @@ import (
 // SchemaVersion identifies the record layout; bump on breaking changes.
 const SchemaVersion = 1
 
-// Record is one observed occurrence. Exactly one of Event, ReadinessAudit,
-// ProtocolRecovery, or TurnCompletion is set; Seq orders them and TS is the
-// unix-millisecond observation time at the recorder.
+// Record is one observed occurrence. Exactly one payload field is set; Seq
+// orders them and TS is the unix-millisecond observation time at the recorder.
 type Record struct {
 	SchemaVersion    int                  `json:"schema_version"`
 	Seq              uint64               `json:"seq"`
@@ -31,6 +30,18 @@ type Record struct {
 	ProtocolRecovery string               `json:"protocol_recovery,omitempty"`
 	TurnCompletion   bool                 `json:"turn_completion,omitempty"`
 	ContractShadow   *ContractShadowAudit `json:"contract_shadow,omitempty"`
+	OutcomeProgress  *OutcomeProgress     `json:"outcome_progress,omitempty"`
+}
+
+// OutcomeProgress mirrors evidence.OutcomeSample with stable snake_case keys.
+type OutcomeProgress struct {
+	Round        int `json:"round"`
+	Exploration  int `json:"exploration,omitempty"`
+	Verification int `json:"verification,omitempty"`
+	Objective    int `json:"objective,omitempty"`
+	Regression   int `json:"regression,omitempty"`
+	Churn        int `json:"churn,omitempty"`
+	LegacyGain   int `json:"legacy_gain,omitempty"`
 }
 
 // ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
@@ -150,6 +161,19 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 		ReadyToFinalize:       a.ReadyToFinalize,
 	}})
 	event.RecordContractShadow(r.inner, a)
+}
+
+func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	r.append(Record{OutcomeProgress: &OutcomeProgress{
+		Round:        sample.Round,
+		Exploration:  sample.Exploration,
+		Verification: sample.Verification,
+		Objective:    sample.Objective,
+		Regression:   sample.Regression,
+		Churn:        sample.Churn,
+		LegacyGain:   sample.LegacyGain,
+	}})
+	event.RecordOutcomeProgress(r.inner, sample)
 }
 
 func (r *Recorder) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {

--- a/internal/trajectory/recorder_test.go
+++ b/internal/trajectory/recorder_test.go
@@ -16,6 +16,7 @@ type capabilitySink struct {
 	events     []event.Event
 	readiness  []evidence.ReadinessAudit
 	recoveries []event.ProtocolRecoveryAudit
+	outcomes   []evidence.OutcomeSample
 	turns      int
 }
 
@@ -27,6 +28,9 @@ func (s *capabilitySink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 	s.recoveries = append(s.recoveries, a)
 }
 func (s *capabilitySink) RecordTurnCompletion() { s.turns++ }
+func (s *capabilitySink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	s.outcomes = append(s.outcomes, sample)
+}
 
 func readRecords(t *testing.T, path string) []Record {
 	t.Helper()
@@ -105,13 +109,14 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	r.RecordReadinessAudit(evidence.ReadinessAudit{Result: evidence.ReadinessBlocked, MissingVerification: 2})
 	r.RecordProtocolRecovery(event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
 	r.RecordTurnCompletion()
+	r.RecordOutcomeProgress(evidence.OutcomeSample{Round: 3, Exploration: 2, Objective: 1, LegacyGain: 4})
 	if err := r.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
 	recs := readRecords(t, path)
-	if len(recs) != 3 {
-		t.Fatalf("got %d records, want 3", len(recs))
+	if len(recs) != 4 {
+		t.Fatalf("got %d records, want 4", len(recs))
 	}
 	if recs[0].ReadinessAudit == nil || recs[0].ReadinessAudit.Result != "blocked" || recs[0].ReadinessAudit.MissingVerification != 2 {
 		t.Errorf("readiness record = %+v", recs[0].ReadinessAudit)
@@ -122,8 +127,11 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	if !recs[2].TurnCompletion {
 		t.Errorf("turn completion record = %+v", recs[2])
 	}
-	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 {
-		t.Errorf("inner capabilities = %d/%d/%d, want 1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns)
+	if recs[3].OutcomeProgress == nil || recs[3].OutcomeProgress.Round != 3 || recs[3].OutcomeProgress.Objective != 1 || recs[3].OutcomeProgress.LegacyGain != 4 {
+		t.Errorf("outcome progress record = %+v", recs[3].OutcomeProgress)
+	}
+	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 || len(inner.outcomes) != 1 {
+		t.Errorf("inner capabilities = %d/%d/%d/%d, want 1/1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns, len(inner.outcomes))
 	}
 }
 


### PR DESCRIPTION
PR 1 of the outcome-progress series: pure measurement, no behavior change.

## Why

The adaptive progress guard (#7915) scores novelty - new reads, new commands, mutations. That conflates motion with progress: an agent editing a different file each round earns +3 forever while getting no closer to a passing check, and a delegation return earns +2 whether or not it produced usable evidence. Before changing the policy, this PR makes the gap measurable.

## What

- `evidence.OutcomeTracker`: a shadow scorer observing the same per-round receipts as the live `ProgressTracker`, decomposed by outcome instead of novelty:
  - **exploration** - first reads, first commands/actions, first failures (localization), delegation returns
  - **verification** - attempts of verification-classified commands (`IsDeliveryVerificationCommand`, the same single classifier readiness uses)
  - **objective** - a verification command turning fail->pass
  - **regression** - pass->fail
  - **churn** - successful mutations (a state transition, not proof of progress)
  - **legacy_gain** - the live scorer's verdict on the same receipts, so offline analysis can price its claims without replaying
- New optional sink capability `RecordOutcomeProgress` (mirrors the contract-shadow pattern from #7927); the trajectory recorder appends each sample as an `outcome_progress` record. Pass-through added to every capability-forwarding sink decorator.
- Fixed pre-existing pass-through gaps found while wiring: `notify.Sink` dropped readiness audits, turn completions and contract-shadow audits; the telemetry sink dropped contract-shadow audits. With notifications or telemetry enabled, those records never reached the trajectory recorder.
- e2ebench condenses the series per run into an `outcome` digest: `false_progress_rounds` (legacy gain never redeemed by an objective transition within 3 rounds), `solution_stall_max` (armed only once the run enters its solution phase, so research turns are not punished), best-vs-final verified state, `regressed_from_best`, and `search_regret_ms`. Suite reports and `-mode traj` gain one **Outcome shadow** aggregate line.
- Recordings that predate the shadow scorer backfill from shell verification receipts (`execution.verification` on tool results), so existing trajectory corpora can already answer how many runs peaked above their final verified state - the number that decides how much PR 2 (best-known-state) and PR 3 (conservative rollback) are worth.

## Verification

- `go test ./internal/evidence/ ./internal/event/ ./internal/trajectory/ ./internal/agent/ ./internal/notify/ ./internal/telemetry/ ./internal/stats/ ./internal/control/ ./internal/cli/ ./cmd/e2ebench/ ./internal/tool/builtin/ ./internal/boot/` - all pass
- `TestOutcomeShadowRecordsEveryRoundWithoutTouchingGuards` proves guard-visible round outputs stay byte-identical with the shadow active
- `gofmt`, `go vet`, `repolint` clean

Cache-impact: none - the provider-visible prefix and all injected guard texts are byte-identical; the agent change is a private struct field plus a sink capability call after each batch
Cache-guard: TestOutcomeShadowRecordsEveryRoundWithoutTouchingGuards plus the existing progress-guard tests pin the guard's injected texts; no prompt bytes are produced by the shadow path
Documentation-impact: none - shadow measurement is invisible in the product; the trajectory file gains an optional record type and e2ebench (a developer tool) one report line, neither covered by docs/*.md
