### PR TITLE
fix(desktop): restore edit after cancelled turns

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1157,7 +1157,7 @@ func (admission *tabTurnAdmission) abort() {
 
 // beginTabTurn locks the tab's foreground-turn admission gate and reserves the
 // event sink until TurnDone has completed all of its fan-out.
-func (a *App) beginTabTurn(tabID string, reclaim bool) (*tabTurnAdmission, control.SessionAPI, error) {
+func (a *App) beginTabTurn(tabID string, reclaim bool, submissionID ...string) (*tabTurnAdmission, control.SessionAPI, error) {
 	tab, ctrl := a.tabAndCtrlByID(tabID)
 	if a.tabIsReadOnly(tab) {
 		return nil, nil, readOnlyChannelErr()
@@ -1197,7 +1197,7 @@ func (a *App) beginTabTurn(tabID string, reclaim bool) (*tabTurnAdmission, contr
 		abort()
 		return nil, nil, err
 	}
-	if ctrl.RuntimeStatus().Running || (tab.sink != nil && !tab.sink.tryBeginTurn()) {
+	if ctrl.RuntimeStatus().Running || (tab.sink != nil && !tab.sink.tryBeginTurn(submissionID...)) {
 		abort()
 		return nil, nil, control.ErrTurnRunning
 	}
@@ -1207,7 +1207,7 @@ func (a *App) beginTabTurn(tabID string, reclaim bool) (*tabTurnAdmission, contr
 // submitToTab is the shared submit body. fromBridge marks submissions driven
 // by the IM takeover bridge; local (frontend) submissions on a taken-over tab
 // reclaim remote control first — typing locally is the grab-back gesture.
-func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
+func (a *App) submitToTab(tabID, input string, fromBridge bool, submissionID ...string) error {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		tab, _ := a.tabAndCtrlByID(tabID)
@@ -1223,7 +1223,7 @@ func (a *App) submitToTab(tabID, input string, fromBridge bool) error {
 		a.runEffortCommandForTab(tabID, trimmed)
 		return nil
 	}
-	admission, ctrl, err := a.beginTabTurn(tabID, !fromBridge)
+	admission, ctrl, err := a.beginTabTurn(tabID, !fromBridge, submissionID...)
 	if err != nil {
 		return err
 	}
@@ -1281,35 +1281,11 @@ func (a *App) SubmitDisplay(display, input string) error {
 }
 
 func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
-	if err := validateTurnInput(input); err != nil {
-		return err
-	}
-	admission, ctrl, err := a.beginTabTurn(tabID, true)
-	if err != nil {
-		return err
-	}
-	defer admission.abort()
-	tab := admission.tab
-	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitDisplay(display, input)
-	admission.finish(ctrl)
-	return nil
+	return a.submitDisplayToTab(tabID, display, input, "")
 }
 
 func (a *App) SubmitDeliveryRecoveryToTab(tabID, display, input string) error {
-	if err := validateTurnInput(input); err != nil {
-		return err
-	}
-	admission, ctrl, err := a.beginTabTurn(tabID, true)
-	if err != nil {
-		return err
-	}
-	defer admission.abort()
-	tab := admission.tab
-	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitDeliveryRecovery(display, input)
-	admission.finish(ctrl)
-	return nil
+	return a.submitDeliveryRecoveryToTab(tabID, display, input, "")
 }
 
 // InvocationRequest is the Wails-bound form of a composer invocation entity.
@@ -1330,19 +1306,7 @@ func controlInvocationRequests(invocations []InvocationRequest) []control.Invoca
 }
 
 func (a *App) SubmitInvocationsToTab(tabID, display, input string, invocations []InvocationRequest) error {
-	if err := validateInvocationTurnInput(input, invocations); err != nil {
-		return err
-	}
-	admission, ctrl, err := a.beginTabTurn(tabID, true)
-	if err != nil {
-		return err
-	}
-	defer admission.abort()
-	tab := admission.tab
-	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitInvocationDisplay(display, input, controlInvocationRequests(invocations))
-	admission.finish(ctrl)
-	return nil
+	return a.submitInvocationsToTab(tabID, display, input, invocations, "")
 }
 
 func validateInvocationTurnInput(input string, invocations []InvocationRequest) error {
@@ -1358,8 +1322,9 @@ func validateInvocationTurnInput(input string, invocations []InvocationRequest) 
 func (a *App) submitInitialGoalToLocalTab(
 	tabID, toolApprovalMode, goal, display, input string,
 	invocations []InvocationRequest,
+	submissionID ...string,
 ) ([]string, error) {
-	admission, ctrl, err := a.beginTabTurn(tabID, true)
+	admission, ctrl, err := a.beginTabTurn(tabID, true, submissionID...)
 	if err != nil {
 		return []string{}, err
 	}
@@ -1411,19 +1376,7 @@ func (a *App) SubmitInitialGoalToTab(
 }
 
 func (a *App) SubmitEditedDisplayToTab(tabID, display, input, original string) error {
-	if err := validateTurnInput(input); err != nil {
-		return err
-	}
-	admission, ctrl, err := a.beginTabTurn(tabID, true)
-	if err != nil {
-		return err
-	}
-	defer admission.abort()
-	tab := admission.tab
-	a.ensureTabTopicIndexedForUserTurn(tab)
-	ctrl.SubmitEditedDisplay(display, input, original)
-	admission.finish(ctrl)
-	return nil
+	return a.submitEditedDisplayToTab(tabID, display, input, original, "")
 }
 
 func (a *App) bindControllerDisplayRecorder(ctrl control.SessionAPI) {

--- a/desktop/frontend/src/__tests__/checkpoint-turn-event.test.ts
+++ b/desktop/frontend/src/__tests__/checkpoint-turn-event.test.ts
@@ -1,0 +1,260 @@
+// Run: tsx src/__tests__/checkpoint-turn-event.test.ts
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTurnSubmissionId, initialState, reducer } from "../lib/useController";
+
+type ReducerState = ReturnType<typeof reducer>;
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+function submit(state: ReducerState, text: string, seq: number): ReducerState {
+  return reducer(state, { type: "user", text, seq, submissionId: `s${seq}` });
+}
+
+function userById(state: ReducerState, id: string) {
+  const item = state.items.find((candidate) => candidate.kind === "user" && candidate.id === id);
+  return item?.kind === "user" ? item : undefined;
+}
+
+function checkpoint(state: ReducerState, id: string): number | undefined {
+  return userById(state, id)?.checkpointTurn;
+}
+
+console.log("\nturn checkpoint submission binding");
+
+{
+  const base = createTurnSubmissionId("tab-a", 0, 0, "runtime-a");
+  eq(createTurnSubmissionId("tab-b", 0, 0, "runtime-a") === base, false, "submission correlation is tab-scoped");
+  eq(createTurnSubmissionId("tab-a", 1, 0, "runtime-a") === base, false, "submission correlation changes across session reset");
+  eq(createTurnSubmissionId("tab-a", 0, 0, "runtime-b") === base, false, "submission correlation changes across runtime epoch");
+  eq(createTurnSubmissionId("tab-a", 0, 1, "runtime-a") === base, false, "submission correlation changes across local sequence");
+}
+
+{
+  let state = submit(initialState, "turn zero", 0);
+  eq(userById(state, "u0")?.submissionId, "s0", "render item id and opaque submission correlation stay distinct");
+  state = reducer(state, { type: "event", e: { kind: "turn_started" } });
+  state = reducer(state, { type: "event", e: { kind: "notice", level: "info", text: "runtime notice" } });
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s0", checkpointTurn: 0 } });
+
+  eq(checkpoint(state, "u0"), 0, "turn zero is assigned by exact submission id");
+  eq(userById(state, "u0")?.submissionId, undefined, "TurnDone clears the settled item's correlation");
+  eq(state.pendingSubmissionId, undefined, "matching TurnDone confirms the optimistic submit");
+  eq(state.items.some((item) => item.kind === "notice" && item.text === "runtime notice"), true, "intervening items cannot change the target");
+}
+
+{
+  let state = submit(initialState, "legacy turn", 1);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", checkpointTurn: 9 } });
+  eq(checkpoint(state, "u1"), undefined, "TurnDone without submission id cannot stamp a local user");
+  eq(state.pendingSubmissionId, "s1", "id-less TurnDone cannot confirm a pending submission");
+
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "missing", checkpointTurn: 10 } });
+  eq(checkpoint(state, "u1"), undefined, "unknown submission id cannot rewrite another user");
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s1" } });
+  eq(userById(state, "u1")?.submissionId, undefined, "matching checkpoint-less TurnDone still settles the correlation");
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s1", checkpointTurn: 11 } });
+  eq(checkpoint(state, "u1"), undefined, "duplicate TurnDone cannot backfill a settled checkpoint-less turn");
+}
+
+{
+  let state = submit(initialState, "/effort max", 10);
+  state = reducer(state, { type: "send_confirmed", submissionId: "s10" });
+  eq(state.pendingSubmissionId, undefined, "successful local command Promise confirms its exact correlation");
+  state = reducer(state, { type: "controller_rebuilt" });
+
+  state = submit(state, "normal after effort", 11);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s11", checkpointTurn: 1 } });
+  eq(checkpoint(state, "u10"), undefined, "management command stays non-rewindable");
+  eq(checkpoint(state, "u11"), 1, "the next normal turn maps independently after a no-TurnDone command");
+}
+
+{
+  let state = submit(initialState, "activity A", 15);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "activity B", 16);
+  state = reducer(state, { type: "event", e: { kind: "turn_started", submissionId: "s15" } });
+  eq(state.pendingSubmissionId, "s16", "old-id runtime activity cannot confirm the new pending user");
+  state = reducer(state, { type: "event", e: { kind: "notice", submissionId: "s16", level: "info", text: "admitted" } });
+  eq(state.pendingSubmissionId, undefined, "matching non-TurnDone activity confirms the pending user");
+}
+
+{
+  let state = submit(initialState, "extension activity", 17);
+  const extension = { pluginId: "demo", surfaceId: "status", kind: "status" as const, status: { label: "working" } };
+  state = reducer(state, { type: "event", e: { kind: "extension_status", extension } });
+  eq(state.pendingSubmissionId, "s17", "uncorrelated extension activity cannot confirm a pending user");
+  state = reducer(state, { type: "event", e: { kind: "extension_status", submissionId: "s17", extension } });
+  eq(state.pendingSubmissionId, undefined, "exactly correlated extension activity confirms the pending user");
+}
+
+{
+  let state = submit(initialState, "lost A", 20);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "B after lost A", 21);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s21", checkpointTurn: 2 } });
+
+  eq(checkpoint(state, "u20"), undefined, "a missing A TurnDone does not consume B ownership");
+  eq(checkpoint(state, "u21"), 2, "B maps by id even when A TurnDone never arrives");
+}
+
+{
+  let state = submit(initialState, "cancelled A", 30);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "pending B", 31);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s30", checkpointTurn: 3 } });
+
+  eq(checkpoint(state, "u30"), 3, "late A TurnDone still maps exact A");
+  eq(checkpoint(state, "u31"), undefined, "late A TurnDone cannot stamp B");
+  eq(state.pendingSubmissionId, "s31", "late A TurnDone cannot confirm B pending state");
+  eq(state.pendingUser, "pending B", "late A TurnDone cannot flush B pending text");
+
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s31", checkpointTurn: 4 } });
+  eq(checkpoint(state, "u31"), 4, "B later receives its own checkpoint");
+}
+
+{
+  let state = submit(initialState, "A before failed B", 40);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "failed B", 41);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s40", checkpointTurn: 5 } });
+  state = reducer(state, { type: "send_failed", submissionId: "s41", error: "turn already running" });
+  state = submit(state, "C after failed B", 42);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s42", checkpointTurn: 6 } });
+
+  eq(checkpoint(state, "u40"), 5, "A maps before B rejection");
+  eq(userById(state, "u41")?.failed, true, "B rejection marks only B");
+  eq(checkpoint(state, "u41"), undefined, "failed B remains non-rewindable");
+  eq(checkpoint(state, "u42"), 6, "C maps normally after the rejected B gap");
+}
+
+{
+  let state = submit(initialState, "rapid A", 50);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "rapid B", 51);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s51", checkpointTurn: 8 } });
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s50", checkpointTurn: 7 } });
+
+  eq(checkpoint(state, "u50"), 7, "out-of-order A completion still maps A");
+  eq(checkpoint(state, "u51"), 8, "out-of-order B completion still maps B");
+}
+
+{
+  let state = submit(initialState, "!pwd", 60);
+  state = reducer(state, { type: "event", e: { kind: "turn_done" } });
+  eq(checkpoint(state, "u60"), undefined, "shell TurnDone without submission id stays non-rewindable");
+
+  state = submit(state, "after shell", 61);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s61", checkpointTurn: 9 } });
+  eq(checkpoint(state, "u61"), 9, "shell completion cannot offset the following normal turn");
+}
+
+{
+  let state = submit(initialState, "provider error", 70);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s70", checkpointTurn: 10, err: "provider unavailable" } });
+  eq(checkpoint(state, "u70"), 10, "error TurnDone maps an admitted checkpoint by id");
+  eq(state.items.some((item) => item.kind === "notice" && item.text === "provider unavailable"), true, "error TurnDone still surfaces its warning");
+}
+
+{
+  let state = submit(initialState, "same text", 80);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s80", checkpointTurn: 11 } });
+  state = submit(state, "same text", 81);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s81", checkpointTurn: 12 } });
+  eq(checkpoint(state, "u80"), 11, "first equal-text user keeps its checkpoint");
+  eq(checkpoint(state, "u81"), 12, "second equal-text user maps independently by id");
+}
+
+{
+  let state = submit(initialState, "old pending", 90);
+  state = reducer(state, { type: "unsend" });
+  state = submit(state, "new pending", 91);
+  const unchanged = state;
+  state = reducer(state, { type: "send_failed", submissionId: "s90", error: "late old rejection" });
+  eq(state, unchanged, "stale send_failed is a complete no-op for a newer pending id");
+  state = reducer(state, { type: "send_failed", submissionId: "s91", error: "current rejection" });
+  eq(userById(state, "u91")?.failed, true, "current send_failed marks the exact pending user");
+  eq(userById(state, "u91")?.submissionId, undefined, "send_failed clears the rejected item's correlation");
+  eq(userById(state, "u90")?.failed, undefined, "current send_failed cannot mark an older user");
+}
+
+{
+  let state = submit(initialState, "confirmed delivery", 100);
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s100", checkpointTurn: 13 } });
+  const confirmed = state;
+  state = reducer(state, { type: "send_failed", submissionId: "s100", error: "late bridge rejection" });
+  eq(state, confirmed, "send_failed after matching TurnDone is a complete no-op");
+  eq(checkpoint(state, "u100"), 13, "late failure cannot erase an assigned checkpoint");
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s100", checkpointTurn: 99 } });
+  eq(checkpoint(state, "u100"), 13, "duplicate TurnDone cannot overwrite an existing checkpoint");
+}
+
+{
+  let state = submit(initialState, "reset prompt", 110);
+  state = reducer(state, { type: "reset" });
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s110", checkpointTurn: 14 } });
+  eq(state.items.length, 0, "session reset removes the old optimistic id target");
+
+  state = submit(state, "new runtime prompt", 111);
+  state = reducer(state, { type: "controller_rebuilt" });
+  eq(userById(state, "u111")?.submissionId, undefined, "controller rebuild retires the old item correlation");
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s111", checkpointTurn: 99 } });
+  eq(checkpoint(state, "u111"), undefined, "late pre-rebuild TurnDone cannot stamp the retired item");
+  state = submit(state, "post-rebuild prompt", 112);
+  state = reducer(state, { type: "send_failed", submissionId: "s111", error: "old runtime rejection" });
+  eq(state.pendingSubmissionId, "s112", "old-runtime failure cannot clear the rebuilt runtime pending correlation");
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s112", checkpointTurn: 15 } });
+  eq(checkpoint(state, "u112"), 15, "post-rebuild submission maps normally");
+}
+
+{
+  let state = reducer(initialState, {
+    type: "history_page",
+    mode: "replace",
+    page: { messages: [{ role: "user", content: "recent", checkpointTurn: 60 }], startTurn: 60, endTurn: 61, totalTurns: 61, hasOlder: true },
+  });
+  state = submit(state, "live after pagination", 120);
+  state = reducer(state, {
+    type: "history_page",
+    mode: "prepend",
+    page: { messages: [{ role: "user", content: "older", checkpointTurn: 5 }], startTurn: 5, endTurn: 6, totalTurns: 61, hasOlder: true },
+  });
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "s120", checkpointTurn: 61 } });
+  eq(checkpoint(state, "u120"), 61, "history prepend preserves the exact live item target");
+  eq(state.items.some((item) => item.kind === "user" && item.text === "recent" && item.checkpointTurn === 60), true, "recent history keeps authoritative metadata");
+  eq(state.items.some((item) => item.kind === "user" && item.text === "older" && item.checkpointTurn === 5), true, "prepended history keeps authoritative metadata");
+}
+
+{
+  let state = reducer(initialState, {
+    type: "history_page",
+    mode: "replace",
+    page: { messages: [{ role: "user", content: "authoritative", checkpointTurn: 7 }], startTurn: 7, endTurn: 8, totalTurns: 8, hasOlder: false },
+  });
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "u999", checkpointTurn: 99 } });
+  eq(state.items[0].kind === "user" && state.items[0].checkpointTurn, 7, "unknown local id cannot rewrite hydrated history");
+}
+
+{
+  const source = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "../lib/useController.ts"), "utf8");
+  eq(source.includes("turnUserItemIds"), false, "FIFO ownership state is completely removed");
+  eq(source.includes("HistoryCheckpointTurnsForTab(targetTabId)"), false, "TurnDone hot path does not refresh full checkpoint history");
+  eq(source.includes('type: "history_checkpoint_turns"'), false, "positional checkpoint merge action remains removed");
+  eq(source.includes("void refreshCheckpoints(targetTabId)"), true, "TurnDone still refreshes checkpoint metadata");
+}
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/checkpoint-turn-transcript.test.tsx
+++ b/desktop/frontend/src/__tests__/checkpoint-turn-transcript.test.tsx
@@ -1,0 +1,147 @@
+// Run: tsx src/__tests__/checkpoint-turn-transcript.test.tsx
+
+import { JSDOM } from "jsdom";
+import { register } from "node:module";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import gsap from "gsap";
+import { LocaleProvider } from "../lib/i18n";
+import { initialState, reducer } from "../lib/useController";
+
+register(new URL("../../scripts/svg-loader.mjs", import.meta.url));
+const { Transcript } = await import("../components/Transcript");
+
+type GsapOptions = { onComplete?: () => void };
+const gsapForTests = gsap as unknown as {
+  to: (_target: unknown, options: GsapOptions) => unknown;
+  fromTo: (_target: unknown, _from: unknown, options: GsapOptions) => unknown;
+  set: () => unknown;
+  killTweensOf: () => void;
+};
+gsapForTests.to = (_target, options) => { options.onComplete?.(); return {}; };
+gsapForTests.fromTo = (_target, _from, options) => { options.onComplete?.(); return {}; };
+gsapForTests.set = () => ({});
+gsapForTests.killTweensOf = () => {};
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  ok(actual === expected, `${label}${actual === expected ? "" : `: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`}`);
+}
+
+function flushTimers(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+console.log("\nturn checkpoint transcript integration");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.Element = dom.window.Element;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+globalThis.Event = dom.window.Event;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.MutationObserver = dom.window.MutationObserver;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+globalThis.ResizeObserver = TestResizeObserver;
+Object.defineProperty(dom.window.HTMLElement.prototype, "attachEvent", { configurable: true, value: () => {} });
+Object.defineProperty(dom.window.HTMLElement.prototype, "detachEvent", { configurable: true, value: () => {} });
+Object.defineProperty(dom.window.HTMLElement.prototype, "scrollIntoView", { configurable: true, value: () => {} });
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  value: () => ({ matches: true, media: "(prefers-reduced-motion: reduce)", addEventListener() {}, removeEventListener() {} }),
+});
+
+let state = reducer(initialState, {
+  type: "history_page",
+  mode: "replace",
+  page: {
+    messages: [
+      { role: "user", content: "existing prompt", checkpointTurn: 0 },
+    ],
+    startTurn: 0,
+    endTurn: 1,
+    totalTurns: 1,
+    hasOlder: false,
+  },
+});
+const cancelledSubmissionId = "transcript-cancelled-submission";
+state = reducer(state, { type: "user", text: "cancelled prompt", seq: state.seq, submissionId: cancelledSubmissionId });
+state = reducer(state, { type: "unsend" });
+state = reducer(state, { type: "event", e: { kind: "turn_done", err: "context canceled", checkpointTurn: 1, submissionId: cancelledSubmissionId } });
+state = reducer(state, {
+  type: "checkpoints",
+  checkpoints: [
+    { turn: 0, prompt: "existing prompt", files: [], time: 1, canConversation: true },
+    { turn: 1, prompt: "cancelled prompt", files: [], time: 2, canConversation: true },
+  ],
+});
+
+const editTargets: number[] = [];
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <Transcript
+        items={state.items}
+        checkpoints={state.checkpoints}
+        questionNavigator={false}
+        onPrompt={() => {}}
+        onEditPrompt={(turn) => { editTargets.push(turn); return true; }}
+      />
+    </LocaleProvider>,
+  );
+  await flushTimers();
+});
+
+const cancelledMessage = Array.from(document.querySelectorAll<HTMLElement>(".msg--user"))
+  .find((element) => element.textContent?.includes("cancelled prompt"));
+eq(cancelledMessage?.dataset.turn, "1", "Transcript maps the cancelled user to checkpoint turn 1");
+const editButton = cancelledMessage?.querySelector<HTMLButtonElement>('button[aria-label="Edit"]');
+eq(editButton?.disabled, false, "checkpoint metadata enables Edit for the cancelled turn");
+
+await act(async () => {
+  editButton?.click();
+  await flushTimers();
+});
+const editForm = cancelledMessage?.querySelector<HTMLFormElement>("form.msg-edit");
+await act(async () => {
+  editForm?.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
+  await flushTimers();
+});
+eq(editTargets[0], 1, "inline resend targets the authoritative checkpoint turn 1");
+
+await act(async () => root.unmount());
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/extension-surface.test.tsx
+++ b/desktop/frontend/src/__tests__/extension-surface.test.tsx
@@ -148,7 +148,7 @@ ok(acceptsExtensionGeneration(5, undefined), "events without a generation always
 
 {
   let s: ControllerState = { ...initialState };
-  s = reducer(s, { type: "user", text: "hello", seq: 0 });
+  s = reducer(s, { type: "user", text: "hello", seq: 0, submissionId: "extension-submit" });
   ok(s.pendingUser === "hello", "optimistic user bubble pending");
   s = reducer(s, { type: "event", e: surfaceEvent({ kind: "card", card: { title: "bg" } }) });
   ok(s.pendingUser === "hello", "extension events never flush the optimistic user bubble");

--- a/desktop/frontend/src/__tests__/goal-activation-tab-routing.test.tsx
+++ b/desktop/frontend/src/__tests__/goal-activation-tab-routing.test.tsx
@@ -143,7 +143,7 @@ window.go = {
             : tab,
         );
       },
-      SubmitInitialGoalToTab: async (
+      SubmitInitialGoalToTabWithID: async (
         tabID: string,
         goal: string,
         display: string,
@@ -151,6 +151,7 @@ window.go = {
         invocations: { name: string }[],
         collaborationMode: string,
         toolApprovalMode: string,
+        _submissionID: string,
       ): Promise<string[]> => {
         await goalGate;
         initialGoalCalls.push(
@@ -166,8 +167,14 @@ window.go = {
       SubmitInvocationsToTab: async () => {
         throw new Error("split SubmitInvocationsToTab must not be used for initial Goals");
       },
+      SubmitInvocationsToTabWithID: async () => {
+        throw new Error("split SubmitInvocationsToTabWithID must not be used for initial Goals");
+      },
       SubmitToTab: async () => {
         throw new Error("plain SubmitToTab must not be used for structured first Goal turns");
+      },
+      SubmitToTabWithID: async () => {
+        throw new Error("plain SubmitToTabWithID must not be used for structured first Goal turns");
       },
     } as Partial<AppBindings> as AppBindings,
   },
@@ -238,7 +245,7 @@ eq(initialGoalCalls.length, 1, "atomic Goal submit ran once");
 // structured submit.
 const failedInitialGoalCalls: string[] = [];
 const failInvokeCalls: string[] = [];
-(window.go.main.App as AppBindings).SubmitInitialGoalToTab = async (tabID: string) => {
+(window.go.main.App as AppBindings).SubmitInitialGoalToTabWithID = async (tabID: string) => {
   failedInitialGoalCalls.push(tabID);
   throw new Error("workbench target changed");
 };

--- a/desktop/frontend/src/__tests__/pending-prompt-stale-status.test.tsx
+++ b/desktop/frontend/src/__tests__/pending-prompt-stale-status.test.tsx
@@ -278,7 +278,7 @@ eq(replayed.promptArrivedId, "plan-1", "same-id replay keeps the anchor id");
 {
   const armed = reducer({ ...initialState }, { type: "event", e: planApprovalEvent });
   const answeredEarly = reducer(armed, { type: "clearApproval" });
-  const nextTurn = reducer(answeredEarly, { type: "user", text: "continue", seq: 0 });
+  const nextTurn = reducer(answeredEarly, { type: "user", text: "continue", seq: 0, submissionId: "pending-prompt-next-turn" });
   eq(nextTurn.promptArrivedId, undefined, "a new user message drops the prompt anchor id");
   eq(nextTurn.promptArrivedAt, undefined, "a new user message drops the prompt arrival time");
 }

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -127,22 +127,22 @@ eq(acceptsRuntimeEventEpoch("e2", "e2"), true, "current runtime epoch is accepte
 eq(acceptsRuntimeEventEpoch(undefined, "e1"), true, "first runtime epoch can establish the fence");
 eq(acceptsRuntimeEventEpoch("e2", undefined), true, "legacy events remain compatible");
 
-const sent = reducer({ ...initialState }, { type: "user", text: "hello", seq: 0 });
+const sent = reducer({ ...initialState }, { type: "user", text: "hello", seq: 0, submissionId: "send-0" });
 eq(sent.items.length, 1, "submit appends the user bubble immediately");
 eq(sent.items[0].kind === "user" && sent.items[0].text, "hello", "bubble carries the submitted text");
 eq(sent.running, true, "submit marks the turn running");
 eq(sent.pendingUser, "hello", "submit tracks the optimistic bubble");
 
-const hiddenSubmit = reducer({ ...initialState }, { type: "user", text: "display prompt", submitText: "hidden context\ndisplay prompt", seq: 0 });
+const hiddenSubmit = reducer({ ...initialState }, { type: "user", text: "display prompt", submitText: "hidden context\ndisplay prompt", seq: 0, submissionId: "hidden-0" });
 eq(
   hiddenSubmit.items[0].kind === "user" && hiddenSubmit.items[0].submitText,
   "hidden context\ndisplay prompt",
   "optimistic user bubble preserves submit-only context",
 );
 
-const confirmed = reducer(sent, { type: "event", e: { kind: "text", text: "hi" } as WireEvent });
-eq(confirmed.items.filter((it) => it.kind === "user").length, 1, "first backend event confirms without duplicating");
-eq(confirmed.pendingUser, undefined, "confirmation clears the pending marker");
+const confirmed = reducer(sent, { type: "event", e: { kind: "turn_done", submissionId: "send-0" } as WireEvent });
+eq(confirmed.items.filter((it) => it.kind === "user").length, 1, "matching TurnDone confirms without duplicating");
+eq(confirmed.pendingUser, undefined, "matching submission id clears the pending marker");
 
 const memoryCitationMessage = {
   kind: "message",
@@ -157,7 +157,7 @@ const citedAssistant = textThenCitationFinal.items.find((it) => it.kind === "ass
 eq(citedAssistant?.kind === "assistant" && citedAssistant.text, "done", "memory citations preserve existing assistant text");
 eq(citedAssistant?.kind === "assistant" && citedAssistant.memoryCitations?.length, 1, "memory citations attach to real assistant content");
 
-const failedState = reducer(sent, { type: "send_failed", error: "Send failed: bridge unavailable" });
+const failedState = reducer(sent, { type: "send_failed", submissionId: "send-0", error: "Send failed: bridge unavailable" });
 const failedBubble = failedState.items.find((it) => it.kind === "user");
 eq(failedBubble?.kind === "user" && failedBubble.failed, true, "send_failed marks the bubble failed");
 const notice = failedState.items[failedState.items.length - 1];
@@ -173,6 +173,7 @@ const readinessState = reducer(readinessStarted, {
     kind: "turn_done",
 		outcome: "final_readiness",
 		err: "final-answer readiness failed 3 times: missing verification",
+		submissionId: "send-0",
 		readiness: { attempts: 3, missing: ["verification", "review"] },
   } as WireEvent,
 });
@@ -188,13 +189,13 @@ eq(readinessUser?.kind === "user" && Boolean(readinessUser.failed), false, "fina
 eq(readinessState.running, false, "an unclicked continue-check action does not keep the turn running");
 eq(readinessState.pendingPrompt, false, "an unclicked continue-check action does not create a pending prompt");
 
-const recovering = reducer(readinessState, { type: "user", text: "Continue checks", seq: readinessState.seq, deliveryRecovery: true });
-const recovered = reducer(recovering, { type: "event", e: { kind: "turn_done" } as WireEvent });
+const recovering = reducer(readinessState, { type: "user", text: "Continue checks", seq: readinessState.seq, submissionId: "recovery-submit", deliveryRecovery: true });
+const recovered = reducer(recovering, { type: "event", e: { kind: "turn_done", submissionId: "recovery-submit" } as WireEvent });
 eq(recovered.items.some((it) => it.kind === "notice" && it.variant === "delivery"), false, "successful explicit recovery removes the stale delivery card");
 
 const ordinaryTurnError = reducer(readinessStarted, {
   type: "event",
-  e: { kind: "turn_done", err: "provider failed" } as WireEvent,
+  e: { kind: "turn_done", err: "provider failed", submissionId: "send-0" } as WireEvent,
 });
 const ordinaryTurnNotice = ordinaryTurnError.items[ordinaryTurnError.items.length - 1];
 eq(ordinaryTurnNotice.kind === "notice" && ordinaryTurnNotice.level, "warn", "ordinary turn errors remain warnings");
@@ -204,6 +205,7 @@ const recoveryPaused = reducer(readinessStarted, {
   type: "event",
   e: {
     kind: "turn_done",
+    submissionId: "send-0",
     outcome: "recovery_paused",
     err: "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send \"continue\" to start a fresh attempt, or add instructions to change direction.",
   } as WireEvent,
@@ -225,21 +227,22 @@ const recoveryUser = recoveryPaused.items.find((it) => it.kind === "user");
 eq(recoveryUser?.kind === "user" && Boolean(recoveryUser.failed), false, "recovery_paused does not mark the user message as failed");
 eq(recoveryPaused.running, false, "recovery_paused frees the composer");
 
-const shellSent = reducer({ ...initialState }, { type: "user", text: "!ls", seq: 0 });
-const shellFailed = reducer(shellSent, { type: "send_failed", error: "Command failed: workspace is still starting" });
+const shellSent = reducer({ ...initialState }, { type: "user", text: "!ls", seq: 0, submissionId: "shell-0" });
+const shellFailed = reducer(shellSent, { type: "send_failed", submissionId: "shell-0", error: "Command failed: workspace is still starting" });
 const shellNotice = shellFailed.items[shellFailed.items.length - 1];
 eq(shellNotice.kind, "notice", "rejected shell command appends a visible notice");
 eq(shellNotice.kind === "notice" && shellNotice.text.includes("workspace is still starting"), true, "shell rejection notice includes the backend error");
 
-const lateFailure = reducer(confirmed, { type: "send_failed", error: "Send failed: late" });
+const lateFailure = reducer(confirmed, { type: "send_failed", submissionId: "send-0", error: "Send failed: late" });
 eq(lateFailure, confirmed, "send_failed after backend confirmation is a no-op");
+eq(lateFailure.items, confirmed.items, "late send_failed leaves the confirmed transcript untouched");
 
 const beforeMcpReady = { ...initialState };
 const mcpReady = reducer(beforeMcpReady, { type: "event", e: { kind: "mcp_surface_ready" } as WireEvent });
 eq(mcpReady, beforeMcpReady, "mcp_surface_ready is accepted as a deliberate no-op");
 const pendingMcpReady = reducer(sent, { type: "event", e: { kind: "mcp_surface_ready" } as WireEvent });
 eq(pendingMcpReady, sent, "mcp_surface_ready does not confirm a pending submit");
-const failedAfterMcpReady = reducer(pendingMcpReady, { type: "send_failed", error: "Send failed: bridge unavailable" });
+const failedAfterMcpReady = reducer(pendingMcpReady, { type: "send_failed", submissionId: "send-0", error: "Send failed: bridge unavailable" });
 const failedAfterMcpReadyBubble = failedAfterMcpReady.items.find((it) => it.kind === "user");
 eq(
   failedAfterMcpReadyBubble?.kind === "user" && failedAfterMcpReadyBubble.failed,
@@ -328,7 +331,7 @@ eq(
   "delivery recovery routes through continueDelivery with the backend Goal state",
 );
 eq(
-  controllerSource.includes("app.SubmitInitialGoalToTab(") &&
+  controllerSource.includes("app.SubmitInitialGoalToTabWithID(") &&
     appSource.includes("patchActivatedGoalForTab(sourceTabId, trimmed)"),
   true,
   "the first Goal turn uses the atomic target-scoped backend contract",

--- a/desktop/frontend/src/__tests__/submission-id-bridge-mock.test.ts
+++ b/desktop/frontend/src/__tests__/submission-id-bridge-mock.test.ts
@@ -1,0 +1,35 @@
+// Run: tsx src/__tests__/submission-id-bridge-mock.test.ts
+
+import { app, onEvent } from "../lib/bridge";
+import type { WireEvent } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nsubmission id browser mock contract");
+
+const events: WireEvent[] = [];
+const off = onEvent((event) => events.push(event));
+const submit = app.SubmitToTabWithID("mock-correlation-tab", "mock correlation turn", "opaque-correlation");
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+const started = events.find((event) => event.kind === "turn_started");
+eq(started?.tabId, "mock-correlation-tab", "mock TurnStarted keeps the submitted tab scope");
+eq(started?.submissionId, "opaque-correlation", "mock TurnStarted carries the local submission correlation");
+
+await app.CancelTab("mock-correlation-tab");
+await submit;
+off();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -148,6 +148,7 @@ const setActiveFGate = deferred<void>();
 const staleSwitchFGate = deferred<void>();
 const staleSwitchReassertGGate = deferred<void>();
 const submitTabCGate = deferred<void>();
+let tabCSubmissionId = "";
 const forkResultGate = deferred<void>();
 const staleForkResultGate = deferred<void>();
 const staleForkReassertGGate = deferred<void>();
@@ -319,7 +320,15 @@ window.go = {
         runningTabs.add(tabID);
         if (tabID === "tab-c") await submitTabCGate.promise;
       },
+      SubmitToTabWithID: async (tabID: string, _input: string, submissionID: string) => {
+        runningTabs.add(tabID);
+        if (tabID === "tab-c") tabCSubmissionId = submissionID;
+        if (tabID === "tab-c") await submitTabCGate.promise;
+      },
       SubmitDisplayToTab: async (tabID: string) => {
+        runningTabs.add(tabID);
+      },
+      SubmitDisplayToTabWithID: async (tabID: string) => {
         runningTabs.add(tabID);
       },
     } as Partial<AppBindings> as AppBindings,
@@ -550,6 +559,9 @@ await act(async () => {
 });
 eq(controller?.activeTabId, "tab-c", "switching to a cached running tab still updates the active tab");
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "streaming C") ?? false, "cached running tab keeps its optimistic transcript");
+const tabCUser = controller?.state.items.find((item) => item.kind === "user" && item.text === "streaming C");
+eq(tabCUser?.kind === "user" && tabCUser.submissionId, tabCSubmissionId, "Wails receives the same opaque correlation stored on the optimistic user");
+ok(Boolean(tabCSubmissionId) && tabCSubmissionId !== tabCUser?.id, "opaque submission correlation is distinct from the render item id");
 ok(!historyCalls.includes("tab-c"), "cached running tab skips history hydration");
 await act(async () => {
   submitTabCGate.resolve();

--- a/desktop/frontend/src/__tests__/ui-perf-scenarios.test.ts
+++ b/desktop/frontend/src/__tests__/ui-perf-scenarios.test.ts
@@ -147,7 +147,7 @@ const scenario = (id: string): UIPerfScenario => {
 {
   let long = reducer({ ...initialState }, { type: "event", e: { kind: "turn_started" } as WireEvent });
   for (let turn = 0; turn < 100; turn += 1) {
-    long = reducer(long, { type: "user", text: `question ${turn}`, seq: long.seq });
+    long = reducer(long, { type: "user", text: `question ${turn}`, seq: long.seq, submissionId: `perf-${turn}` });
     if (turn < 30) {
       const id = `tool-${turn}`;
       long = reducer(long, { type: "event", e: { kind: "tool_dispatch", tool: { id, name: "edit_file", readOnly: false, args: "{}" } } as WireEvent });

--- a/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
@@ -103,6 +103,7 @@ const eventHandlers: Array<(e: WireEvent) => void> = [];
 let backendRunning = false;
 let cancelCalls = 0;
 let effortCalls = 0;
+let checkpointHistoryCalls = 0;
 const context: ContextInfo = { used: 0, window: 100, sessionTokens: 0 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 
@@ -129,7 +130,10 @@ window.go = {
       CheckpointsForTab: async () => [],
       HistoryForTab: async () => [],
       HistoryPageForTab: async () => ({ messages: [], startTurn: 0, endTurn: 0, totalTurns: 0, hasOlder: false }),
-      HistoryCheckpointTurnsForTab: async () => [],
+      HistoryCheckpointTurnsForTab: async () => {
+        checkpointHistoryCalls += 1;
+        return [];
+      },
       ReplayPendingPrompts: async () => {},
       CancelTab: async () => {
         cancelCalls += 1;
@@ -182,6 +186,12 @@ for (let attempt = 0; attempt < 20 && controller?.state.running; attempt += 1) {
 eq(controller?.state.running, false, "cancel reconciliation clears the running state");
 eq(cancelCalls, 1, "CancelTab is called once");
 eq(controller?.state.cancelRequested, false, "cancel reconciliation clears cancelRequested");
+
+await act(async () => {
+  for (const handler of eventHandlers) handler({ kind: "turn_done", tabId: "tab-a", checkpointTurn: 0 });
+  await flushPromises();
+});
+eq(checkpointHistoryCalls, 0, "TurnDone does not request the full checkpoint-turn history");
 
 await act(async () => {
   await controller?.setEffort("max");

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -644,18 +644,14 @@ console.log("\nuse controller meta");
 }
 
 {
-  let s = reducer(initialState, { type: "user", text: "first", seq: 0 });
+  let s = reducer(initialState, { type: "user", text: "first", seq: 0, submissionId: "meta-submission" });
   s = reducer(s, { type: "event", e: { kind: "turn_started" } });
   s = reducer(s, { type: "event", e: { kind: "notice", level: "info", text: "runtime notice" } });
-  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
-  const merged = reducer(s, {
-    type: "history_checkpoint_turns",
-    turns: [0],
-  });
-  const user = merged.items.find((item) => item.kind === "user");
-  const notice = merged.items.find((item) => item.kind === "notice" && item.text === "runtime notice");
-  eq(user?.kind === "user" && user.checkpointTurn, 0, "turn_done checkpoint merge stamps user turn zero");
-  eq(Boolean(notice), true, "turn_done checkpoint merge preserves runtime notices");
+  s = reducer(s, { type: "event", e: { kind: "turn_done", checkpointTurn: 0, submissionId: "meta-submission" } });
+  const user = s.items.find((item) => item.kind === "user");
+  const notice = s.items.find((item) => item.kind === "notice" && item.text === "runtime notice");
+  eq(user?.kind === "user" && user.checkpointTurn, 0, "turn_done stamps the exact user with checkpoint turn zero");
+  eq(Boolean(notice), true, "turn_done checkpoint assignment preserves runtime notices");
 }
 
 {
@@ -670,7 +666,7 @@ console.log("\nuse controller meta");
     mode: "replace",
     page: {
       messages: [
-        { role: "user", content: "recent prompt" },
+        { role: "user", content: "recent prompt", checkpointTurn: 1060 },
         { role: "assistant", content: "recent answer" },
       ],
       startTurn: 60,
@@ -682,12 +678,8 @@ console.log("\nuse controller meta");
   eq(s.items.some((item) => item.kind === "user" && item.text === "recent prompt"), true, "history page replace renders the latest window");
   eq(s.historyStartTurn, 60, "history page stores the older cursor");
   eq(s.historyHasOlder, true, "history page records older availability");
-  const checkpointed = reducer(s, {
-    type: "history_checkpoint_turns",
-    turns: Array.from({ length: 61 }, (_, index) => index + 1000),
-  });
-  const recentUser = checkpointed.items.find((item) => item.kind === "user" && item.text === "recent prompt");
-  eq(recentUser?.kind === "user" && recentUser.checkpointTurn, 1060, "paged checkpoint merge uses the window start turn");
+  const recentUser = s.items.find((item) => item.kind === "user" && item.text === "recent prompt");
+  eq(recentUser?.kind === "user" && recentUser.checkpointTurn, 1060, "paged history hydrates its authoritative checkpoint turn");
   s = reducer(s, { type: "history_older_start" });
   eq(s.historyOlderLoading, true, "older history request marks loading");
   s = reducer(s, {

--- a/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-send-fallback.test.tsx
@@ -121,6 +121,9 @@ window.go = {
       SubmitToTab: async (tabId: string) => {
         submitCalls += tabId === "tab-send" ? 1 : 0;
       },
+      SubmitToTabWithID: async (tabId: string) => {
+        submitCalls += tabId === "tab-send" ? 1 : 0;
+      },
     } as Partial<AppBindings> as AppBindings,
   },
 };

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -172,10 +172,14 @@ export interface AppBindings {
   HeartbeatGenerateID(): Promise<string>;
   Submit(input: string): Promise<void>;
   SubmitToTab(tabID: string, input: string): Promise<void>;
+  SubmitToTabWithID(tabID: string, input: string, submissionID: string): Promise<void>;
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
+  SubmitDisplayToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;
   SubmitDeliveryRecoveryToTab(tabID: string, display: string, input: string): Promise<void>;
+  SubmitDeliveryRecoveryToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;
   SubmitInvocationsToTab(tabID: string, display: string, input: string, invocations: InvocationRequest[]): Promise<void>;
+  SubmitInvocationsToTabWithID(tabID: string, display: string, input: string, invocations: InvocationRequest[], submissionID: string): Promise<void>;
   SubmitInitialGoalToTab(
     tabID: string,
     goal: string,
@@ -185,7 +189,9 @@ export interface AppBindings {
     collaborationMode: string,
     toolApprovalMode: string,
   ): Promise<string[]>;
+  SubmitInitialGoalToTabWithID(tabID: string, goal: string, display: string, input: string, invocations: InvocationRequest[], collaborationMode: string, toolApprovalMode: string, submissionID: string): Promise<string[]>;
   SubmitEditedDisplayToTab(tabID: string, display: string, input: string, original: string): Promise<void>;
+  SubmitEditedDisplayToTabWithID(tabID: string, display: string, input: string, original: string, submissionID: string): Promise<void>;
   RunShell(command: string): Promise<void>;
   RunShellForTab(tabID: string, command: string): Promise<void>;
   Steer(text: string): Promise<void>;
@@ -2006,13 +2012,13 @@ function makeMockApp(): AppBindings {
     if (!tabId) return;
     mockTabs = mockTabs.map((tab) => (tab.id === tabId ? { ...tab, running } : tab));
   };
-  const emitMockTurnStarted = () => {
+  const emitMockTurnStarted = (submissionId?: string) => {
     setMockTabRunning(currentMockTurnTabId(), true);
-    emit({ kind: "turn_started" });
+    emit({ kind: "turn_started", submissionId });
   };
-  const emitMockTurnDone = () => {
+  const emitMockTurnDone = (submissionId?: string) => {
     setMockTabRunning(currentMockTurnTabId(), false);
-    emit({ kind: "turn_done" });
+    emit({ kind: "turn_done", submissionId });
   };
   // Fresh user decisions never auto-allow on a posture switch (mirrors the
   // backend's requiresFreshApprovalTool set).
@@ -2205,9 +2211,9 @@ function makeMockApp(): AppBindings {
       if (/Mac/i.test(ua)) return "darwin";
       return "linux";
     },
-        async Submit(input) {
+        async Submit(input, submissionID?: string) {
           cancelled = false;
-      emitMockTurnStarted();
+      emitMockTurnStarted(submissionID);
       const trimmedInput = input.trim().toLowerCase();
       const decisionSurfaceMock = decisionSurfaceMockFromInput(trimmedInput);
       const goalMatch = /^\/goal(?:\s+([\s\S]*))?$/.exec(input.trim());
@@ -2217,13 +2223,13 @@ function makeMockApp(): AppBindings {
         const active = mockTabs.find((tab) => tab.active);
         if (!arg || lowered === "status") {
           emit({ kind: "notice", level: "info", text: active?.goal ? `goal: ${active.goal}` : "goal: none" });
-          emitMockTurnDone();
+          emitMockTurnDone(submissionID);
           return;
         }
         if (["clear", "off", "stop", "done"].includes(lowered)) {
           mockTabs = mockTabs.map((tab) => (tab.active ? { ...tab, goal: "", goalStatus: "stopped", collaborationMode: "normal" } : tab));
           emit({ kind: "notice", level: "info", text: "goal cleared" });
-          emitMockTurnDone();
+          emitMockTurnDone(submissionID);
           return;
         }
         mockTabs = mockTabs.map((tab) => (tab.active ? { ...tab, goal: arg, goalStatus: "running", collaborationMode: "goal" } : tab));
@@ -2234,7 +2240,7 @@ function makeMockApp(): AppBindings {
         emit({ kind: "message", text: reply });
         mockTabs = mockTabs.map((tab) => (tab.active ? { ...tab, goal: "", goalStatus: "complete", collaborationMode: "normal" } : tab));
         emit({ kind: "notice", level: "info", text: "goal complete" });
-        emitMockTurnDone();
+        emitMockTurnDone(submissionID);
         return;
       }
       if (decisionSurfaceMock === "tool_approval") {
@@ -2470,7 +2476,7 @@ function makeMockApp(): AppBindings {
             durationMs: 150,
           },
         });
-        emitMockTurnDone();
+        emitMockTurnDone(submissionID);
         return;
       }
       if (trimmedInput === "/process-preview" || trimmedInput === "process preview" || trimmedInput === "过程预览") {
@@ -2493,7 +2499,7 @@ function makeMockApp(): AppBindings {
           },
         });
         emit({ kind: "message", text: "Process card preview complete." });
-        emitMockTurnDone();
+        emitMockTurnDone(submissionID);
         return;
       }
       if (trimmedInput === "/nested-preview" || trimmedInput === "nested preview" || trimmedInput === "嵌套预览") {
@@ -2554,7 +2560,7 @@ function makeMockApp(): AppBindings {
           kind: "message",
           text: "Mock nested tool preview complete. The explore row now shows the compass count marker.",
         });
-        emitMockTurnDone();
+        emitMockTurnDone(submissionID);
         return;
       }
       // Simulate the server's pre-first-token latency so the deferred user bubble
@@ -2611,23 +2617,17 @@ function makeMockApp(): AppBindings {
           sessionCacheMissTokens: 256,
         },
       });
-          emitMockTurnDone();
+          emitMockTurnDone(submissionID);
         },
-        async SubmitToTab(_tabID, input) {
-          await withMockTabScope(_tabID, () => this.Submit(input));
-        },
-        async SubmitDisplay(_display, input) {
-          await this.Submit(input);
-        },
-        async SubmitDisplayToTab(_tabID, display, input) {
-          await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input));
-        },
-        async SubmitDeliveryRecoveryToTab(_tabID, display, input) {
-          await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input));
-        },
-        async SubmitInvocationsToTab(_tabID, display, input, _invocations) {
-          await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input));
-        },
+        async SubmitToTab(_tabID, input) { await withMockTabScope(_tabID, () => this.Submit(input)); },
+        async SubmitToTabWithID(_tabID, input, submissionID) { const submit = this.Submit as (value: string, id?: string) => Promise<void>; await withMockTabScope(_tabID, () => submit(input, submissionID)); },
+        async SubmitDisplay(_display, input) { await this.Submit(input); },
+        async SubmitDisplayToTab(_tabID, display, input) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
+        async SubmitDisplayToTabWithID(_tabID, _display, input, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
+        async SubmitDeliveryRecoveryToTab(_tabID, display, input) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
+        async SubmitDeliveryRecoveryToTabWithID(_tabID, _display, input, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
+        async SubmitInvocationsToTab(_tabID, display, input, _invocations) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
+        async SubmitInvocationsToTabWithID(_tabID, _display, input, _invocations, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
         async SubmitInitialGoalToTab(
           _tabID,
           goal,
@@ -2647,9 +2647,9 @@ function makeMockApp(): AppBindings {
             return [];
           });
         },
-        async SubmitEditedDisplayToTab(_tabID, display, input, _original) {
-          await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input));
-        },
+        async SubmitInitialGoalToTabWithID(_tabID, goal, display, input, invocations, _collaborationMode, _toolApprovalMode, submissionID) { await this.SetGoalForTab(_tabID, goal); if (invocations.length > 0) await this.SubmitInvocationsToTabWithID(_tabID, display, input, invocations, submissionID); else await this.SubmitDisplayToTabWithID(_tabID, display, input, submissionID); return []; },
+        async SubmitEditedDisplayToTab(_tabID, display, input, _original) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
+        async SubmitEditedDisplayToTabWithID(_tabID, display, input, _original, submissionID) { await this.SubmitDisplayToTabWithID(_tabID, display, input, submissionID); },
         async RunShell(command) {
           cancelled = false;
           emitMockTurnStarted();

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -296,6 +296,8 @@ export interface WireEvent {
   decisionReceipt?: WireDecisionReceipt;
   extension?: WireExtensionSurface;
   err?: string;
+  checkpointTurn?: number; // Authoritative TurnDone rewind target; zero is valid.
+  submissionId?: string; // Opaque correlation for the exact optimistic user submission.
   outcome?: "final_readiness" | "recovery_paused";
   readiness?: WireFinalReadiness;
   retryAttempt?: number;
@@ -303,9 +305,7 @@ export interface WireEvent {
   /** Optional: "headers" | "stream". Older clients ignore unknown fields. */
   retryScope?: "headers" | "stream";
   streamAttempt?: WireStreamAttempt;
-  // Tab routing: set by the Go-side tabEventSink so multi-tab frontends
-  // route each event to the correct per-tab reducer.
-  tabId?: string;
+  tabId?: string; // Go's tabEventSink tags events for the correct per-tab reducer.
   runtimeEpoch?: string;
   sessionHitTokens?: number;
   sessionMissTokens?: number;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -229,7 +229,7 @@ type ModelSwitchQueueState = {
 const HISTORY_PAGE_TURNS = 60;
 
 export type Item =
-  | { kind: "user"; id: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number }
+  | { kind: "user"; id: string; submissionId?: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; reasoningComplete?: boolean; reasoningDurationMs?: number; workDurationMs?: number; memoryCitations?: MemoryCitation[] }
   | { kind: "phase"; id: string; text: string }
   | { kind: "notice"; id: string; level: "info" | "warn"; text: string; detail?: string; title?: string; variant?: "delivery"; action?: "continue_delivery"; decisionReceipt?: WireDecisionReceipt }
@@ -366,6 +366,7 @@ interface State {
   currentAssistant?: string;
   live?: LiveStream;
   pendingUser?: string;
+  pendingSubmissionId?: string;
   deliveryRecoveryActive: boolean;
   discardTurn?: boolean;
   turnStartAt: number;
@@ -620,6 +621,13 @@ export function normalizeTurnSubmit(displayText: string, submitText: string): {
   return { display, submit };
 }
 
+const frontendSubmissionEpoch = typeof globalThis.crypto?.randomUUID === "function"
+  ? globalThis.crypto.randomUUID()
+  : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+export function createTurnSubmissionId(tabId: string, sessionGen: number, seq: number, runtimeEpoch?: string): string {
+  return JSON.stringify([frontendSubmissionEpoch, tabId, sessionGen, runtimeEpoch ?? "", seq]);
+}
+
 export function acceptsRuntimeEventEpoch(acceptedEpoch: string | undefined, eventEpoch: string | undefined): boolean {
   return !eventEpoch || !acceptedEpoch || acceptedEpoch === eventEpoch;
 }
@@ -730,9 +738,10 @@ function compactArchivedToolItems(items: Item[]): Item[] {
 type Action =
   | { type: "event"; e: WireEvent }
   | { type: "stream_batch"; segments: StreamSegment[] }
-  | { type: "user"; text: string; submitText?: string; seq: number; deliveryRecovery?: boolean }
+  | { type: "user"; text: string; submitText?: string; seq: number; submissionId: string; deliveryRecovery?: boolean }
   | { type: "unsend" }
-  | { type: "send_failed"; error: string }
+  | { type: "send_confirmed"; submissionId: string }
+  | { type: "send_failed"; submissionId: string; error: string }
   | { type: "backend_status"; running: boolean; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; snapshotAt?: number }
   | { type: "cancel_requested" }
   | { type: "meta"; meta: Meta }
@@ -753,7 +762,6 @@ type Action =
   | { type: "history_page"; page: HistoryPage; mode: "replace" | "prepend" }
   | { type: "history_older_start" }
   | { type: "history_older_error" }
-  | { type: "history_checkpoint_turns"; turns: number[] }
   | { type: "local_notice"; level: "info" | "warn"; text: string }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
@@ -900,18 +908,14 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
   return { items, seq };
 }
 
-function mergeHistoryCheckpointTurns(items: Item[], turns: number[], startTurn = 0): Item[] {
-  if (!turns.some((turn) => turn >= 0)) return items;
-  const offset = Math.max(0, Math.floor(startTurn));
-  let userIndex = 0;
+function applyTurnCheckpoint(items: Item[], submissionId: string | undefined, turn: number | undefined): Item[] {
+  if (!submissionId) return items;
+  const validTurn = turn !== undefined && Number.isInteger(turn) && turn >= 0;
   let changed = false;
   const next = items.map((item) => {
-    if (item.kind !== "user") return item;
-    const turn = turns[offset + userIndex];
-    userIndex += 1;
-    if (turn == null || turn < 0 || item.checkpointTurn === turn) return item;
+    if (item.kind !== "user" || item.submissionId !== submissionId) return item;
     changed = true;
-    return { ...item, checkpointTurn: turn };
+    return { ...item, submissionId: undefined, checkpointTurn: item.checkpointTurn ?? (validTurn ? turn : undefined) };
   });
   return changed ? next : items;
 }
@@ -994,7 +998,6 @@ function applyDeltaSegments(s: State, segments: StreamSegment[]): State {
 // pass, one notification. Mirrors applyEvent's preamble for delta events.
 function applyStreamBatch(s: State, segments: StreamSegment[]): State {
   if (s.discardTurn) return s;
-  if (s.pendingUser !== undefined) s = flushPendingUser(s);
   if (s.retry) s = { ...s, retry: undefined };
   return applyDeltaSegments(s, segments);
 }
@@ -1053,18 +1056,9 @@ function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnWai
   };
 }
 
-function flushPendingUser(s: State): State {
-  if (s.pendingUser === undefined) return s;
-  const lastItem = s.items[s.items.length - 1];
-  if (lastItem?.kind === "user" && lastItem.text === s.pendingUser) {
-    return { ...s, pendingUser: undefined };
-  }
-  return {
-    ...s,
-    seq: s.seq + 1,
-    items: [...s.items, { kind: "user", id: `u${s.seq}`, text: s.pendingUser, createdAt: Date.now() }],
-    pendingUser: undefined,
-  };
+function confirmPendingUser(s: State, submissionId: string | undefined): State {
+  if (!submissionId || s.pendingSubmissionId !== submissionId) return s;
+  return { ...s, pendingUser: undefined, pendingSubmissionId: undefined };
 }
 
 // applyExtensionSurfaceEvent reduces one extension_surface / extension_status
@@ -1278,20 +1272,32 @@ function applyExtensionNotification(s: State, surface: WireExtensionSurface): St
 
 function applyEvent(s: State, e: WireEvent): State {
   if (s.discardTurn) {
-    if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, live: undefined };
+    if (e.kind === "turn_done") {
+      return {
+        ...s,
+        items: applyTurnCheckpoint(s.items, e.submissionId, e.checkpointTurn),
+        discardTurn: false,
+        running: false,
+        turnActive: false,
+        pendingPrompt: false,
+        cancelRequested: false,
+        cancellable: false,
+        currentAssistant: undefined,
+        live: undefined,
+      };
+    }
     return s;
   }
+  s = confirmPendingUser(s, e.submissionId);
   if (e.kind === "mcp_surface_ready") {
-    // Background-only events must not confirm an optimistic user bubble.
+    // Background readiness remains a no-op unless the sink explicitly
+    // correlates it to this submit in the common preamble above.
     return s;
   }
   if (e.kind === "extension_surface" || e.kind === "extension_status") {
-    // Sidecar surface publications are background-only too: they must neither
-    // confirm an optimistic user bubble nor clear the retry indicator.
+    // Sidecar publications without exact sink correlation remain background-
+    // only and must not clear the retry indicator.
     return applyExtensionSurfaceEvent(s, e.extension);
-  }
-  if (s.pendingUser !== undefined && e.kind !== "turn_done") {
-    s = flushPendingUser(s);
   }
   if (e.kind === "retrying") {
     // Retrying is emitted synchronously from inside the foreground provider
@@ -1320,15 +1326,13 @@ function applyEvent(s: State, e: WireEvent): State {
   if (s.retry) s = { ...s, retry: undefined };
   switch (e.kind) {
     case "turn_started": {
-      // Flush the user message and pre-create an empty assistant bubble
+      // Pre-create an empty assistant bubble
       // immediately so the user sees their message + a blinking cursor the
       // instant the backend acknowledges the turn — no dead gap waiting for
       // the first text/reasoning token.
-      let cur: State = s;
-      if (cur.pendingUser !== undefined) cur = flushPendingUser(cur);
-      const { items, id, seq } = ensureAssistant(cur);
+      const { items, id, seq } = ensureAssistant(s);
       return {
-        ...cur,
+        ...s,
         items,
         currentAssistant: id,
         seq,
@@ -1609,7 +1613,6 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `g${s.seq}`, level, text: formatGuardianAssessmentNotice(e.guardian) }] };
     }
     case "turn_done": {
-      if (s.pendingUser !== undefined) s = flushPendingUser(s);
       const now = Date.now();
       const workDurationMs = currentTurnDurationMs(s, now);
       let lastUserIndex = -1;
@@ -1683,7 +1686,7 @@ function applyEvent(s: State, e: WireEvent): State {
       const keepPlanApproval = s.approval?.tool === "exit_plan_mode";
       let next: State = {
         ...s,
-        items,
+        items: applyTurnCheckpoint(items, e.submissionId, e.checkpointTurn),
         live: undefined,
         streamAttemptJournal: undefined,
         running: keepPlanApproval,
@@ -1709,10 +1712,11 @@ export function reducer(s: State, a: Action): State {
   switch (a.type) {
     case "user": {
       const seq = a.seq !== undefined ? a.seq : s.seq;
+      const userItemId = `u${seq}`;
       return {
         ...s,
         seq: seq + 1,
-        items: [...s.items, { kind: "user", id: `u${seq}`, text: a.text, submitText: a.submitText, createdAt: Date.now() }],
+        items: [...s.items, { kind: "user", id: userItemId, submissionId: a.submissionId, text: a.text, submitText: a.submitText, createdAt: Date.now() }],
         running: true,
         pendingPrompt: false,
         cancelRequested: false,
@@ -1723,6 +1727,7 @@ export function reducer(s: State, a: Action): State {
         promptArrivedAt: undefined,
         promptArrivedId: undefined,
         pendingUser: a.text,
+        pendingSubmissionId: a.submissionId,
         deliveryRecoveryActive: Boolean(a.deliveryRecovery),
         discardTurn: false,
       };
@@ -1731,6 +1736,7 @@ export function reducer(s: State, a: Action): State {
       const cleared = endPromptWait({
         ...s,
         pendingUser: undefined,
+        pendingSubmissionId: undefined,
         discardTurn: true,
         running: false,
         pendingPrompt: false,
@@ -1756,16 +1762,13 @@ export function reducer(s: State, a: Action): State {
         cancellable: s.running || s.turnActive,
       });
     }
+    case "send_confirmed": return confirmPendingUser(s, a.submissionId);
     case "send_failed": {
-      if (s.pendingUser === undefined) return s;
-      let idx = -1;
-      for (let i = s.items.length - 1; i >= 0; i--) {
-        const it = s.items[i];
-        if (it.kind === "user" && it.text === s.pendingUser) { idx = i; break; }
-      }
-      const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, failed: true } : it)) : s.items;
+      if (s.pendingSubmissionId !== a.submissionId) return s;
+      const idx = s.items.findIndex((it) => it.kind === "user" && it.submissionId === a.submissionId);
+      const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, submissionId: undefined, failed: true } : it)) : s.items;
       const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
-      return { ...s, pendingUser: undefined, deliveryRecoveryActive: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
+      return { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
     }
     case "backend_status": {
       // A snapshot fetched before the live approval/ask event arrived cannot
@@ -1890,7 +1893,7 @@ export function reducer(s: State, a: Action): State {
     case "message_action_done": return { ...s, messageAction: undefined };
     case "history": {
       const { items, seq } = historyMessagesToItems(a.messages, "h", s.seq);
-      return { ...s, items: compactArchivedToolItems(items), seq, hydrateHistoryLoaded: true, hydratePlaceholderItems: undefined, historyStartTurn: 0, historyTotalTurns: 0, historyHasOlder: false, historyOlderLoading: false };
+      return { ...s, items: compactArchivedToolItems(items), pendingSubmissionId: undefined, seq, hydrateHistoryLoaded: true, hydratePlaceholderItems: undefined, historyStartTurn: 0, historyTotalTurns: 0, historyHasOlder: false, historyOlderLoading: false };
     }
     case "history_page": {
       const { items, seq } = historyPageItems(a.page);
@@ -1898,6 +1901,7 @@ export function reducer(s: State, a: Action): State {
       return {
         ...s,
         items: compactArchivedToolItems(nextItems),
+        pendingSubmissionId: a.mode === "replace" ? undefined : s.pendingSubmissionId,
         seq: Math.max(s.seq, seq),
         hydrateHistoryLoaded: true,
         hydratePlaceholderItems: undefined,
@@ -1909,8 +1913,6 @@ export function reducer(s: State, a: Action): State {
     }
     case "history_older_start": return s.historyOlderLoading ? s : { ...s, historyOlderLoading: true };
     case "history_older_error": return s.historyOlderLoading ? { ...s, historyOlderLoading: false } : s;
-    case "history_checkpoint_turns":
-      return { ...s, items: mergeHistoryCheckpointTurns(s.items, a.turns, s.historyStartTurn) };
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": {
       const next = { ...s, approval: undefined, pendingPrompt: Boolean(s.ask), resolvedPromptId: s.approval?.id ?? s.resolvedPromptId };
@@ -1956,7 +1958,9 @@ export function reducer(s: State, a: Action): State {
       // the id-anchored bookkeeping.
       return {
         ...s,
+        items: s.items.map((item) => item.kind === "user" && item.submissionId ? { ...item, submissionId: undefined } : item),
         promptEpoch: s.promptEpoch + 1,
+        pendingSubmissionId: undefined,
         resolvedPromptId: undefined,
         promptArrivedId: undefined,
         promptArrivedAt: undefined,
@@ -2937,17 +2941,13 @@ export function useController() {
       uiPerfTracker.onWireEvent(targetTabId, e.kind);
       if (TURN_ACTIVITY_KINDS.has(e.kind)) lastTurnActivityAtByTab.current.set(targetTabId, Date.now());
       if (e.kind === "text" || e.kind === "reasoning") {
+        if (e.submissionId) dispatchTo(targetTabId, { type: "send_confirmed", submissionId: e.submissionId });
         textBatch.push({ tabId: targetTabId, e });
       } else {
         textBatch.drain();
         dispatchTo(targetTabId, { type: "event", e });
       }
       if (e.kind === "turn_done") {
-        if (!e.err) {
-          app.HistoryCheckpointTurnsForTab(targetTabId)
-            .then((turns) => dispatchTo(targetTabId, { type: "history_checkpoint_turns", turns: asArray(turns) }))
-            .catch(() => {});
-        }
         app
           .ContextUsageForTab(targetTabId)
           .then((context) => dispatchTo(targetTabId, { type: "context", context }))
@@ -3132,14 +3132,15 @@ export function useController() {
       throw new Error(runtime?.issue?.message || currentState.meta.startupErr || t("composer.workspaceStarting"));
     }
     const seq = currentState.seq;
+    const submissionId = createTurnSubmissionId(tabId, currentState.sessionGen, seq, runtimeEpochByTabRef.current.get(tabId) ?? runtime?.epoch);
     const promptEpoch = currentState.promptEpoch;
     const { display, submit } = normalizeTurnSubmit(displayText, submitText);
     const original = originalText?.trim() ?? "";
-    dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq });
+    dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq, submissionId });
     invalidateCache();
     try {
       const submitPromise = initialGoal
-        ? app.SubmitInitialGoalToTab(
+        ? app.SubmitInitialGoalToTabWithID(
             tabId,
             initialGoal.goal,
             structured?.display.trim() || display,
@@ -3147,23 +3148,26 @@ export function useController() {
             structured?.invocations ?? [],
             initialGoal.collaborationMode,
             initialGoal.toolApprovalMode,
+            submissionId,
           )
         : structured
-        ? app.SubmitInvocationsToTab(tabId, structured.display.trim(), structured.input.trim(), structured.invocations)
+        ? app.SubmitInvocationsToTabWithID(tabId, structured.display.trim(), structured.input.trim(), structured.invocations, submissionId)
         : original
-        ? app.SubmitEditedDisplayToTab(tabId, display, submit, original)
-        : display !== submit ? app.SubmitDisplayToTab(tabId, display, submit) : app.SubmitToTab(tabId, submit);
+        ? app.SubmitEditedDisplayToTabWithID(tabId, display, submit, original, submissionId)
+        : display !== submit ? app.SubmitDisplayToTabWithID(tabId, display, submit, submissionId) : app.SubmitToTabWithID(tabId, submit, submissionId);
       if (initialGoal) {
         const drained = await submitPromise;
+        dispatchTo(tabId, { type: "send_confirmed", submissionId });
         const ids = Array.isArray(drained) ? drained : [];
         if (ids.length) dispatchTo(tabId, { type: "approval_drained", ids, epoch: promptEpoch });
         return;
       }
-      void submitPromise.catch((error) => {
-        dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
-      });
+      void submitPromise.then(
+        () => dispatchTo(tabId, { type: "send_confirmed", submissionId }),
+        (error) => dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` }),
+      );
     } catch (error) {
-      dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
+      dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
       throw error;
     }
   }, [dispatchTo]);
@@ -3176,16 +3180,18 @@ export function useController() {
       throw new Error(runtime?.issue?.message || currentState.meta.startupErr || t("composer.workspaceStarting"));
     }
     const seq = currentState.seq;
+    const submissionId = createTurnSubmissionId(tabId, currentState.sessionGen, seq, runtimeEpochByTabRef.current.get(tabId) ?? runtime?.epoch);
     const display = displayText.trim();
     const submit = submitText.trim();
-    dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq, deliveryRecovery: true });
+    dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq, submissionId, deliveryRecovery: true });
     invalidateCache();
     try {
-      void app.SubmitDeliveryRecoveryToTab(tabId, display, submit).catch((error) => {
-        dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
-      });
+      void app.SubmitDeliveryRecoveryToTabWithID(tabId, display, submit, submissionId).then(
+        () => dispatchTo(tabId, { type: "send_confirmed", submissionId }),
+        (error) => dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` }),
+      );
     } catch (error) {
-      dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
+      dispatchTo(tabId, { type: "send_failed", submissionId, error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
       throw error;
     }
   }, [dispatchTo]);
@@ -3208,11 +3214,14 @@ export function useController() {
 
   const runShellForTab = useCallback(async (tabId: string, command: string) => {
     if (!tabId) throw new Error(t("composer.workspaceStarting"));
-    dispatchTo(tabId, { type: "user", text: `!${command}`, seq: getOrCreateState(statesRef.current, tabId).seq });
+    const currentState = getOrCreateState(statesRef.current, tabId);
+    const submissionId = createTurnSubmissionId(tabId, currentState.sessionGen, currentState.seq, runtimeEpochByTabRef.current.get(tabId) ?? currentState.meta?.runtime?.epoch);
+    dispatchTo(tabId, { type: "user", text: `!${command}`, seq: currentState.seq, submissionId });
     try {
       await app.RunShellForTab(tabId, command);
+      dispatchTo(tabId, { type: "send_confirmed", submissionId });
     } catch (error) {
-      dispatchTo(tabId, { type: "send_failed", error: `Command failed: ${error instanceof Error ? error.message : String(error)}` });
+      dispatchTo(tabId, { type: "send_failed", submissionId, error: `Command failed: ${error instanceof Error ? error.message : String(error)}` });
       throw error;
     }
   }, [dispatchTo]);

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1535,7 +1535,7 @@ type tabEventSink struct {
 	runtimeEvents asyncRuntimeEmitter
 	botSink       event.Sink // optional: when set, events are also forwarded here
 	botSinkGen    uint64
-	turnInFlight  bool // stays true through the end of TurnDone fan-out
+	turn          turnSubmissionState // stays reserved through the end of TurnDone fan-out
 }
 
 type closeableEventSink interface {
@@ -1547,26 +1547,6 @@ func (s *tabEventSink) binding() (string, *App) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.tabID, s.app
-}
-
-// setBinding reroutes the sink to another tab. A nil app keeps the current
-// App pointer (detach/close paths only change the tab id).
-func (s *tabEventSink) setBinding(tabID string, app *App) {
-	s.mu.Lock()
-	s.tabID = tabID
-	if app != nil {
-		s.app = app
-	}
-	s.mu.Unlock()
-}
-
-func (s *tabEventSink) setRuntimeEpoch(epoch string) {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	s.runtimeEpoch = epoch
-	s.mu.Unlock()
 }
 
 func (s *tabEventSink) runtimeEpochSnapshot() string {
@@ -1581,7 +1561,7 @@ func (s *tabEventSink) runtimeEpochSnapshot() string {
 func (s *tabEventSink) Emit(e event.Event) {
 	if e.Kind == event.TurnStarted {
 		s.mu.Lock()
-		s.turnInFlight = true
+		s.turn.inFlight = true
 		s.mu.Unlock()
 	}
 	tabID, app := s.binding()
@@ -1609,7 +1589,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.flushDisplay(e.Cancelled)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTab(e, tabID, s.runtimeEpochSnapshot()))
+	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot()))
 	if app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update {
 			changed := app.setTabActivityStatus(tabID, status)
@@ -1649,7 +1629,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 	}
 	if e.Kind == event.TurnDone {
 		s.mu.Lock()
-		s.turnInFlight = false
+		s.turn = turnSubmissionState{}
 		s.mu.Unlock()
 	}
 }
@@ -1698,19 +1678,19 @@ func (s *tabEventSink) clearBotSink(generation uint64) {
 // controller clears RuntimeStatus().Running before it emits TurnDone, so the
 // controller status alone leaves a window where a new turn can inherit the old
 // turn's forwarder or have its replacement cleared by the old completion.
-func (s *tabEventSink) tryBeginTurn() bool {
+func (s *tabEventSink) tryBeginTurn(submissionID ...string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.turnInFlight {
+	if s.turn.inFlight {
 		return false
 	}
-	s.turnInFlight = true
+	s.turn = turnSubmissionState{inFlight: true, submissionID: firstSubmissionID(submissionID)}
 	return true
 }
 
 func (s *tabEventSink) cancelTurnStart() {
 	s.mu.Lock()
-	s.turnInFlight = false
+	s.turn = turnSubmissionState{}
 	s.mu.Unlock()
 }
 
@@ -1718,13 +1698,6 @@ func (s *tabEventSink) setContext(ctx context.Context) {
 	s.mu.Lock()
 	s.ctx = ctx
 	s.mu.Unlock()
-}
-
-func (s *tabEventSink) clearContext() {
-	s.mu.Lock()
-	s.ctx = nil
-	s.mu.Unlock()
-	s.runtimeEvents.Clear()
 }
 
 func (s *tabEventSink) context() context.Context {

--- a/desktop/turn_submission_app.go
+++ b/desktop/turn_submission_app.go
@@ -1,0 +1,173 @@
+package main
+
+import "reasonix/internal/event"
+
+type turnSubmissionState struct {
+	inFlight     bool
+	submissionID string
+}
+
+// setBinding reroutes the sink while invalidating correlations that were
+// created for a different frontend tab.
+func (s *tabEventSink) setBinding(tabID string, app *App) {
+	s.mu.Lock()
+	if s.tabID != tabID {
+		s.turn.submissionID = ""
+	}
+	s.tabID = tabID
+	if app != nil {
+		s.app = app
+	}
+	s.mu.Unlock()
+}
+
+func (s *tabEventSink) setRuntimeEpoch(epoch string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.runtimeEpoch != epoch {
+		s.turn.submissionID = ""
+	}
+	s.runtimeEpoch = epoch
+	s.mu.Unlock()
+}
+
+func (s *tabEventSink) clearContext() {
+	s.mu.Lock()
+	s.ctx = nil
+	s.turn.submissionID = ""
+	s.mu.Unlock()
+	s.runtimeEvents.Clear()
+}
+
+func firstSubmissionID(ids []string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	return ids[0]
+}
+
+func (s *tabEventSink) submissionIDSnapshot() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.turn.submissionID
+}
+
+type correlatedWireEventTab struct {
+	wireEventTab
+	SubmissionID string `json:"submissionId,omitempty"`
+}
+
+func toWireTabWithSubmission(e event.Event, tabID, runtimeEpoch, submissionID string) any {
+	wire := toWireTab(e, tabID, runtimeEpoch)
+	if submissionID == "" {
+		return wire
+	}
+	return correlatedWireEventTab{wireEventTab: wire, SubmissionID: submissionID}
+}
+
+// The WithID entry points correlate one optimistic desktop user item with the
+// raw TurnDone produced by the turn that this call actually admits.
+func (a *App) SubmitToTabWithID(tabID, input, submissionID string) error {
+	if err := validateTurnInput(input); err != nil {
+		return err
+	}
+	return a.submitToTab(tabID, input, false, submissionID)
+}
+
+func (a *App) SubmitDisplayToTabWithID(tabID, display, input, submissionID string) error {
+	return a.submitDisplayToTab(tabID, display, input, submissionID)
+}
+
+func (a *App) submitDisplayToTab(tabID, display, input, submissionID string) error {
+	if err := validateTurnInput(input); err != nil {
+		return err
+	}
+	admission, ctrl, err := a.beginTabTurn(tabID, true, submissionID)
+	if err != nil {
+		return err
+	}
+	defer admission.abort()
+	tab := admission.tab
+	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.SubmitDisplay(display, input)
+	admission.finish(ctrl)
+	return nil
+}
+
+func (a *App) SubmitDeliveryRecoveryToTabWithID(tabID, display, input, submissionID string) error {
+	return a.submitDeliveryRecoveryToTab(tabID, display, input, submissionID)
+}
+
+func (a *App) submitDeliveryRecoveryToTab(tabID, display, input, submissionID string) error {
+	if err := validateTurnInput(input); err != nil {
+		return err
+	}
+	admission, ctrl, err := a.beginTabTurn(tabID, true, submissionID)
+	if err != nil {
+		return err
+	}
+	defer admission.abort()
+	tab := admission.tab
+	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.SubmitDeliveryRecovery(display, input)
+	admission.finish(ctrl)
+	return nil
+}
+
+func (a *App) SubmitInvocationsToTabWithID(tabID, display, input string, invocations []InvocationRequest, submissionID string) error {
+	return a.submitInvocationsToTab(tabID, display, input, invocations, submissionID)
+}
+
+func (a *App) submitInvocationsToTab(tabID, display, input string, invocations []InvocationRequest, submissionID string) error {
+	if err := validateInvocationTurnInput(input, invocations); err != nil {
+		return err
+	}
+	admission, ctrl, err := a.beginTabTurn(tabID, true, submissionID)
+	if err != nil {
+		return err
+	}
+	defer admission.abort()
+	tab := admission.tab
+	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.SubmitInvocationDisplay(display, input, controlInvocationRequests(invocations))
+	admission.finish(ctrl)
+	return nil
+}
+
+func (a *App) SubmitInitialGoalToTabWithID(
+	tabID, goal, display, input string,
+	invocations []InvocationRequest,
+	collaborationMode, toolApprovalMode, submissionID string,
+) ([]string, error) {
+	if err := validateInvocationTurnInput(input, invocations); err != nil {
+		return []string{}, err
+	}
+	return a.submitInitialGoalToLocalTab(
+		tabID, toolApprovalMode, goal, display, input, invocations, submissionID,
+	)
+}
+
+func (a *App) SubmitEditedDisplayToTabWithID(tabID, display, input, original, submissionID string) error {
+	return a.submitEditedDisplayToTab(tabID, display, input, original, submissionID)
+}
+
+func (a *App) submitEditedDisplayToTab(tabID, display, input, original, submissionID string) error {
+	if err := validateTurnInput(input); err != nil {
+		return err
+	}
+	admission, ctrl, err := a.beginTabTurn(tabID, true, submissionID)
+	if err != nil {
+		return err
+	}
+	defer admission.abort()
+	tab := admission.tab
+	a.ensureTabTopicIndexedForUserTurn(tab)
+	ctrl.SubmitEditedDisplay(display, input, original)
+	admission.finish(ctrl)
+	return nil
+}

--- a/desktop/turn_submission_correlation_test.go
+++ b/desktop/turn_submission_correlation_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func correlatedSubmissionID(t *testing.T, payload any) (string, *int) {
+	t.Helper()
+	wire, ok := payload.(correlatedWireEventTab)
+	if !ok {
+		t.Fatalf("payload type = %T, want correlatedWireEventTab", payload)
+	}
+	return wire.SubmissionID, wire.CheckpointTurn
+}
+
+func TestTabEventSinkCorrelatesDelayedTurnDoneBySubmission(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	delivered := make(chan any, 2)
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	sink.runtimeEvents.emit = func(_ context.Context, _ string, payload ...any) {
+		delivered <- payload[0]
+		if len(delivered) == 1 {
+			close(entered)
+			<-release
+		}
+	}
+
+	firstTurn := 0
+	if !sink.tryBeginTurn("u-first") {
+		t.Fatal("failed to reserve first turn")
+	}
+	sink.Emit(event.Event{Kind: event.TurnDone, CheckpointTurn: &firstTurn})
+	select {
+	case <-entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first runtime delivery did not start")
+	}
+
+	secondTurn := 1
+	if !sink.tryBeginTurn("u-second") {
+		t.Fatal("delayed frontend delivery blocked the next raw turn")
+	}
+	sink.Emit(event.Event{Kind: event.TurnDone, CheckpointTurn: &secondTurn})
+	close(release)
+
+	first := <-delivered
+	second := <-delivered
+	if id, turn := correlatedSubmissionID(t, first); id != "u-first" || turn == nil || *turn != 0 {
+		t.Fatalf("first correlation = (%q, %v), want (u-first, 0)", id, turn)
+	}
+	if id, turn := correlatedSubmissionID(t, second); id != "u-second" || turn == nil || *turn != 1 {
+		t.Fatalf("second correlation = (%q, %v), want (u-second, 1)", id, turn)
+	}
+}
+
+func TestTabEventSinkClearsRejectedSubmissionCorrelation(t *testing.T) {
+	delivered := make(chan any, 2)
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	sink.runtimeEvents.emit = func(_ context.Context, _ string, payload ...any) {
+		delivered <- payload[0]
+	}
+
+	if !sink.tryBeginTurn("u-local-command") {
+		t.Fatal("failed to reserve local command")
+	}
+	sink.Emit(event.Event{Kind: event.Notice, Text: "local result"})
+	sink.cancelTurnStart()
+	if id, gotTurn := correlatedSubmissionID(t, <-delivered); id != "u-local-command" || gotTurn != nil {
+		t.Fatalf("local command correlation = (%q, %v), want (u-local-command, nil)", id, gotTurn)
+	}
+	sink.Emit(event.Event{Kind: event.Notice, Text: "late local notice"})
+	if _, ok := (<-delivered).(wireEventTab); !ok {
+		t.Fatal("event after rejected submission retained its correlation")
+	}
+
+	turn := 4
+	if !sink.tryBeginTurn("u-model-turn") {
+		t.Fatal("rejected local command left the sink reserved")
+	}
+	sink.Emit(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn})
+	if id, gotTurn := correlatedSubmissionID(t, <-delivered); id != "u-model-turn" || gotTurn == nil || *gotTurn != turn {
+		t.Fatalf("model correlation = (%q, %v), want (u-model-turn, %d)", id, gotTurn, turn)
+	}
+}
+
+func TestSubmitToTabWithIDCorrelatesOnlyAdmittedGuardedTurn(t *testing.T) {
+	delivered := make(chan any, 8)
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	sink.runtimeEvents.emit = func(_ context.Context, _ string, payload ...any) {
+		delivered <- payload[0]
+	}
+	ctrl := control.New(control.Options{Sink: sink})
+	defer ctrl.Close()
+	tab := &WorkspaceTab{ID: "tab", Scope: "global", Ready: true, Ctrl: ctrl, sink: sink}
+	app := &App{tabs: map[string]*WorkspaceTab{tab.ID: tab}, activeTabID: tab.ID}
+
+	if err := app.SubmitToTabWithID(tab.ID, "/tree", "u-local"); err != nil {
+		t.Fatalf("local command: %v", err)
+	}
+	local := <-delivered
+	if id, turn := correlatedSubmissionID(t, local); id != "u-local" || turn != nil {
+		t.Fatalf("local correlation = (%q, %v), want (u-local, nil)", id, turn)
+	}
+
+	if err := app.SubmitToTabWithID(tab.ID, "/mcp__definitely_missing", "u-guarded"); err != nil {
+		t.Fatalf("guarded command: %v", err)
+	}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case payload := <-delivered:
+			wire, ok := payload.(correlatedWireEventTab)
+			if !ok || wire.Kind != "turn_done" {
+				continue
+			}
+			if wire.SubmissionID != "u-guarded" {
+				t.Fatalf("guarded TurnDone submission = %q, want u-guarded", wire.SubmissionID)
+			}
+			return
+		case <-deadline:
+			t.Fatal("timed out waiting for guarded TurnDone")
+		}
+	}
+}
+
+func TestTabEventSinkDropsCorrelationWhenFrontendBindingChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*tabEventSink)
+	}{
+		{name: "tab", change: func(s *tabEventSink) { s.setBinding("replacement", nil) }},
+		{name: "runtime epoch", change: func(s *tabEventSink) { s.setRuntimeEpoch("runtime-2") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			delivered := make(chan any, 1)
+			sink := &tabEventSink{tabID: "original", ctx: context.Background(), runtimeEpoch: "runtime-1"}
+			sink.runtimeEvents.emit = func(_ context.Context, _ string, payload ...any) {
+				delivered <- payload[0]
+			}
+			if !sink.tryBeginTurn("u-original") {
+				t.Fatal("failed to reserve original turn")
+			}
+			tc.change(sink)
+			turn := 7
+			sink.Emit(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn})
+			payload := <-delivered
+			if _, ok := payload.(correlatedWireEventTab); ok {
+				t.Fatal("changed frontend binding received the old submission correlation")
+			}
+			wire, ok := payload.(wireEventTab)
+			if !ok || wire.CheckpointTurn == nil || *wire.CheckpointTurn != turn {
+				t.Fatalf("uncorrelated payload = %#v, want checkpoint turn %d", payload, turn)
+			}
+		})
+	}
+}

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -21,3 +21,16 @@ func TestWireEventTabPreservesSharedRetryingFields(t *testing.T) {
 		}
 	}
 }
+
+func TestWireEventTabPreservesTurnDoneCheckpointZero(t *testing.T) {
+	turn := 0
+	b, err := json.Marshal(toWireTabWithSubmission(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn}, "tab-1", "runtime-1", "submission-1"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"kind":"turn_done"`, `"checkpointTurn":0`, `"tabId":"tab-1"`, `"runtimeEpoch":"runtime-1"`, `"submissionId":"submission-1"`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("tab TurnDone JSON = %s, want it to contain %s", b, want)
+		}
+	}
+}

--- a/internal/control/checkpoint.go
+++ b/internal/control/checkpoint.go
@@ -1,10 +1,15 @@
 package control
 
 import (
+	"context"
 	"sync"
+	"sync/atomic"
+	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/diff"
+	"reasonix/internal/provider"
 )
 
 // checkpointManager owns the snapshot-based rewind bookkeeping: the per-session
@@ -58,12 +63,12 @@ func (m *checkpointManager) enabled() bool {
 
 // beginWithObserver opens a checkpoint and updates the mutation observer's
 // ownership turn for subsequent captures.
-func (m *checkpointManager) beginWithObserver(input string, msgIndex int, obs *checkpoint.MutationObserver) {
+func (m *checkpointManager) beginWithObserver(input string, msgIndex int, obs *checkpoint.MutationObserver) (int, *checkpoint.Store, bool) {
 	m.mu.Lock()
 	store := m.store
 	if store == nil {
 		m.mu.Unlock()
-		return
+		return 0, nil, false
 	}
 	turn := m.turn
 	m.turn++
@@ -74,6 +79,83 @@ func (m *checkpointManager) beginWithObserver(input string, msgIndex int, obs *c
 		obs.SetOwnershipTurn(turn)
 	}
 	store.Begin(turn, input, msgIndex)
+	return turn, store, true
+}
+
+type guardedTurnCheckpoint struct {
+	session      *agent.Session
+	store        *checkpoint.Store
+	turn         int
+	messageIndex int
+	openedAt     int64
+}
+
+type guardedTurnCompletion struct {
+	checkpoint *guardedTurnCheckpoint
+}
+
+type guardedTurnCompletionKey struct{}
+
+func withGuardedTurnCompletion(ctx context.Context) (context.Context, *guardedTurnCompletion) {
+	completion := &guardedTurnCompletion{}
+	return context.WithValue(ctx, guardedTurnCompletionKey{}, completion), completion
+}
+
+// beginCheckpoint opens a rewind checkpoint before the visible user message is
+// appended. Guarded turns retain the exact boundary so TurnDone can identify
+// the corresponding optimistic frontend item without positional guessing.
+func (c *Controller) beginCheckpoint(ctx context.Context, input string) {
+	if c.executor == nil || c.executor.Session() == nil {
+		return
+	}
+	session := c.executor.Session()
+	messageIndex := session.Len()
+	openedAt := time.Now().UnixMilli()
+	atomic.AddInt64(&c.sessionRevision, 1)
+	turn, store, ok := c.checkpoints.beginWithObserver(input, messageIndex, c.mutationObserver)
+	if !ok {
+		return
+	}
+	if completion, _ := ctx.Value(guardedTurnCompletionKey{}).(*guardedTurnCompletion); completion != nil {
+		completion.checkpoint = &guardedTurnCheckpoint{
+			session: session, store: store, turn: turn, messageIndex: messageIndex, openedAt: openedAt,
+		}
+	}
+}
+
+// validatedCheckpointTurn returns the checkpoint only while its original
+// boundary still names the real user message committed by this guarded turn.
+// Stale or synthetic candidates fail closed rather than being relocated.
+func (c *Controller) validatedCheckpointTurn(completion *guardedTurnCompletion) *int {
+	if completion == nil || completion.checkpoint == nil || c.executor == nil {
+		return nil
+	}
+	candidate := completion.checkpoint
+	if c.executor.Session() != candidate.session {
+		return nil
+	}
+	if !c.checkpoints.matchesBoundary(candidate.store, candidate.turn, candidate.messageIndex) {
+		return nil
+	}
+	messages := candidate.session.Snapshot()
+	if candidate.messageIndex < 0 || candidate.messageIndex >= len(messages) {
+		return nil
+	}
+	message := messages[candidate.messageIndex]
+	if message.Role != provider.RoleUser || message.LocalOnly ||
+		!agent.IsUserAuthoredTurn(agent.UserMessageText(message)) ||
+		(message.CreatedAt > 0 && candidate.openedAt > 0 && message.CreatedAt < candidate.openedAt) {
+		return nil
+	}
+	turn := candidate.turn
+	return &turn
+}
+
+func (m *checkpointManager) matchesBoundary(store *checkpoint.Store, turn, messageIndex int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	boundary, ok := m.bound[turn]
+	return ok && m.store == store && boundary == messageIndex
 }
 
 // turnsByMessageIndex returns message-log index -> checkpoint turn over live

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -819,17 +819,6 @@ func (c *Controller) rebindCheckpoints(sessionPath string) {
 	}
 }
 
-// beginCheckpoint opens a checkpoint for the turn about to run, recording the
-// current message count as the conversation-rewind boundary. Called at the top of
-// runTurn, before the user message is appended.
-func (c *Controller) beginCheckpoint(input string) {
-	if c.executor == nil {
-		return
-	}
-	atomic.AddInt64(&c.sessionRevision, 1)
-	c.checkpoints.beginWithObserver(input, len(c.executor.Session().Messages), c.mutationObserver)
-}
-
 // commands (frontend → controller)
 
 // admissionResult classifies what runGuarded did with a turn body.
@@ -921,6 +910,7 @@ func (c *Controller) admitGuardedTurn(body func(ctx context.Context) error, park
 // spawnGuardedTurn launches an admitted turn body plus its autosave companion.
 // The caller must already have claimed admission (running=true) under c.mu.
 func (c *Controller) spawnGuardedTurn(ctx context.Context, cancel context.CancelFunc, body func(ctx context.Context) error) {
+	ctx, completion := withGuardedTurnCompletion(ctx)
 	c.autosaveWG.Go(func() {
 		c.autosaveWhileRunning(ctx)
 	})
@@ -928,11 +918,11 @@ func (c *Controller) spawnGuardedTurn(ctx context.Context, cancel context.Cancel
 		defer cancel()
 		defer func() {
 			if r := recover(); r != nil {
-				c.finishGuardedTurn(fmt.Errorf("internal error: %v", r))
+				c.finishGuardedTurn(fmt.Errorf("internal error: %v", r), completion)
 			}
 		}()
 		err := body(ctx)
-		c.finishGuardedTurn(explainError(err))
+		c.finishGuardedTurn(explainError(err), completion)
 	}()
 }
 
@@ -948,7 +938,7 @@ func (c *Controller) spawnGuardedTurn(ctx context.Context, cancel context.Cancel
 // finishGuardedTurn, preserving FIFO order. Rotation cannot interleave here:
 // beginRotation refuses while running or finishing, and the drain flips
 // finishing directly into running.
-func (c *Controller) finishGuardedTurn(err error) {
+func (c *Controller) finishGuardedTurn(err error, completion *guardedTurnCompletion) {
 	c.memory.clearAutoRemember()
 	c.mu.Lock()
 	cancelRequested := c.canceling
@@ -980,7 +970,7 @@ func (c *Controller) finishGuardedTurn(err error) {
 		c.mu.Unlock()
 		c.spawnGuardedTurn(ctx, cancel, next)
 	}()
-	done := event.Event{Kind: event.TurnDone, Err: err, Cancelled: cancelRequested, Outcome: turnOutcome(err)}
+	done := event.Event{Kind: event.TurnDone, Err: err, Cancelled: cancelRequested, Outcome: turnOutcome(err), CheckpointTurn: c.validatedCheckpointTurn(completion)}
 	var readinessErr *agent.FinalReadinessError
 	if errors.As(err, &readinessErr) {
 		done.Readiness = &event.FinalReadiness{Attempts: readinessErr.Attempts, Missing: append([]string(nil), readinessErr.Missing...)}
@@ -1947,7 +1937,7 @@ func (c *Controller) Run(ctx context.Context, input string) (err error) {
 	}
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
-	c.beginCheckpoint(input)
+	c.beginCheckpoint(ctx, input)
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}

--- a/internal/control/rewind_e2e_test.go
+++ b/internal/control/rewind_e2e_test.go
@@ -34,7 +34,7 @@ func TestCompatibilityRewindRequiresConfirmationForPartialCoverage(t *testing.T)
 		WorkspaceRoot: root,
 		Sink:          event.Discard,
 	})
-	c.beginCheckpoint("edit partial.txt")
+	c.beginCheckpoint(context.Background(), "edit partial.txt")
 	c.mutationObserver.BeforeMutation("partial.txt", "write_file", checkpoint.CaptureBeforeMutation)
 	if err := os.WriteFile(path, []byte("after"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -69,6 +69,9 @@ func TestRunShell_EmitsEvents(t *testing.T) {
 	if td.Kind != event.TurnDone {
 		t.Errorf("last event: want TurnDone, got %v", td.Kind)
 	}
+	if td.CheckpointTurn != nil {
+		t.Errorf("shell TurnDone checkpoint = %d, want nil", *td.CheckpointTurn)
+	}
 
 	// Penultimate event: ToolResult
 	last := (*events)[len(*events)-2]

--- a/internal/control/turn_checkpoint_event_test.go
+++ b/internal/control/turn_checkpoint_event_test.go
@@ -1,0 +1,247 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type checkpointEventRunner struct {
+	session   *agent.Session
+	err       error
+	started   chan struct{}
+	wait      bool
+	skipUser  bool
+	localOnly bool
+}
+
+func (r *checkpointEventRunner) Run(ctx context.Context, input string) error {
+	if !r.skipUser {
+		r.session.Add(provider.Message{
+			Role: provider.RoleUser, Content: input, LocalOnly: r.localOnly,
+			CreatedAt: time.Now().UnixMilli(),
+		})
+	}
+	if r.started != nil {
+		close(r.started)
+	}
+	if r.wait {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return r.err
+}
+
+func newCheckpointEventController(runner *checkpointEventRunner) (*Controller, <-chan event.Event) {
+	events := make(chan event.Event, 8)
+	executor := agent.New(nil, tool.NewRegistry(), runner.session, agent.Options{}, event.Discard)
+	controller := New(Options{
+		Runner: runner, Executor: executor,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.TurnDone {
+				events <- e
+			}
+		}),
+	})
+	return controller, events
+}
+
+func receiveCheckpointTurnDone(t *testing.T, events <-chan event.Event) event.Event {
+	t.Helper()
+	select {
+	case e := <-events:
+		return e
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for TurnDone")
+		return event.Event{}
+	}
+}
+
+func requireCheckpointTurn(t *testing.T, e event.Event, want int) {
+	t.Helper()
+	if e.CheckpointTurn == nil || *e.CheckpointTurn != want {
+		t.Fatalf("TurnDone checkpoint = %v, want %d", e.CheckpointTurn, want)
+	}
+}
+
+func TestTurnDoneCarriesValidatedCheckpointAcrossSuccessAndError(t *testing.T) {
+	session := agent.NewSession("system")
+	runner := &checkpointEventRunner{session: session}
+	controller, events := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.Send("first prompt")
+	first := receiveCheckpointTurnDone(t, events)
+	if first.Err != nil {
+		t.Fatalf("successful TurnDone error = %v", first.Err)
+	}
+	requireCheckpointTurn(t, first, 0)
+
+	runner.err = errors.New("provider failed")
+	controller.Send("second prompt")
+	second := receiveCheckpointTurnDone(t, events)
+	if second.Err == nil {
+		t.Fatal("provider failure TurnDone must retain its error")
+	}
+	requireCheckpointTurn(t, second, 1)
+}
+
+func TestCancelledTurnDoneCarriesRetainedUserCheckpoint(t *testing.T) {
+	session := agent.NewSession("system")
+	started := make(chan struct{})
+	runner := &checkpointEventRunner{session: session, started: started, wait: true}
+	controller, events := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.Send("cancel this prompt")
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not start")
+	}
+	controller.Cancel()
+	done := receiveCheckpointTurnDone(t, events)
+	if !done.Cancelled || done.Err == nil {
+		t.Fatalf("cancelled TurnDone = %+v, want cancelled error", done)
+	}
+	requireCheckpointTurn(t, done, 0)
+}
+
+func TestCancelBeforeRunnerAddsUserCarriesFallbackCheckpoint(t *testing.T) {
+	session := agent.NewSession("system")
+	started := make(chan struct{})
+	runner := &checkpointEventRunner{session: session, started: started, wait: true, skipUser: true}
+	controller, events := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.Send("cancel before user append")
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner did not start")
+	}
+	controller.Cancel()
+	done := receiveCheckpointTurnDone(t, events)
+	requireCheckpointTurn(t, done, 0)
+	messages := session.Snapshot()
+	if len(messages) < 2 || messages[1].Role != provider.RoleUser ||
+		!agent.IsUserAuthoredTurn(agent.UserMessageText(messages[1])) {
+		t.Fatalf("cancel fallback messages = %+v, want a retained user prompt at the checkpoint boundary", messages)
+	}
+}
+
+func TestTurnDoneOmitsUncommittedOrNonVisibleCheckpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		skipUser  bool
+		localOnly bool
+	}{
+		{name: "no user committed", skipUser: true},
+		{name: "local-only user", localOnly: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := agent.NewSession("system")
+			runner := &checkpointEventRunner{session: session, skipUser: tc.skipUser, localOnly: tc.localOnly}
+			controller, events := newCheckpointEventController(runner)
+			defer controller.Close()
+
+			controller.Send("blocked prompt")
+			if done := receiveCheckpointTurnDone(t, events); done.CheckpointTurn != nil {
+				t.Fatalf("uncommitted checkpoint leaked into TurnDone: %d", *done.CheckpointTurn)
+			}
+		})
+	}
+}
+
+func TestTurnDoneRejectsCheckpointAfterSessionSwap(t *testing.T) {
+	oldSession := agent.NewSession("system")
+	completion := &guardedTurnCompletion{}
+	ctx := context.WithValue(context.Background(), guardedTurnCompletionKey{}, completion)
+	runner := &checkpointEventRunner{session: oldSession}
+	controller, _ := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.beginCheckpoint(ctx, "old prompt")
+	oldSession.Add(provider.Message{Role: provider.RoleUser, Content: "old prompt", CreatedAt: time.Now().UnixMilli()})
+	controller.executor.SetSession(agent.NewSession("replacement"))
+	if got := controller.validatedCheckpointTurn(completion); got != nil {
+		t.Fatalf("session-swapped checkpoint = %d, want nil", *got)
+	}
+}
+
+func TestTurnDoneRejectsSameSessionCheckpointStoreCollision(t *testing.T) {
+	session := agent.NewSession("system")
+	completion := &guardedTurnCompletion{}
+	ctx := context.WithValue(context.Background(), guardedTurnCompletionKey{}, completion)
+	runner := &checkpointEventRunner{session: session}
+	controller, _ := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.beginCheckpoint(ctx, "original prompt")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "original prompt", CreatedAt: time.Now().UnixMilli()})
+	controller.checkpoints.rebind("", "")
+	if turn, _, ok := controller.checkpoints.beginWithObserver("collision", 1, nil); !ok || turn != 0 {
+		t.Fatalf("replacement checkpoint = (%d, %v), want colliding turn zero", turn, ok)
+	}
+	if got := controller.validatedCheckpointTurn(completion); got != nil {
+		t.Fatalf("store-rebound checkpoint = %d, want nil", *got)
+	}
+}
+
+func TestBlockedCandidateDoesNotLeakIntoNextTurn(t *testing.T) {
+	session := agent.NewSession("system")
+	runner := &checkpointEventRunner{session: session, skipUser: true}
+	controller, events := newCheckpointEventController(runner)
+	defer controller.Close()
+
+	controller.Send("blocked before user append")
+	if done := receiveCheckpointTurnDone(t, events); done.CheckpointTurn != nil {
+		t.Fatalf("blocked TurnDone checkpoint = %d, want nil", *done.CheckpointTurn)
+	}
+
+	runner.skipUser = false
+	controller.Send("next real prompt")
+	requireCheckpointTurn(t, receiveCheckpointTurnDone(t, events), 1)
+}
+
+func TestParkedTurnsKeepIndependentCheckpointCandidates(t *testing.T) {
+	session := agent.NewSession("system")
+	runner := &checkpointEventRunner{session: session}
+	events := make(chan event.Event, 2)
+	firstDelivery := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var deliveries atomic.Int32
+	executor := agent.New(nil, tool.NewRegistry(), session, agent.Options{}, event.Discard)
+	controller := New(Options{
+		Runner: runner, Executor: executor,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind != event.TurnDone {
+				return
+			}
+			if deliveries.Add(1) == 1 {
+				close(firstDelivery)
+				<-releaseFirst
+			}
+			events <- e
+		}),
+	})
+	defer controller.Close()
+
+	controller.Send("first prompt")
+	select {
+	case <-firstDelivery:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first TurnDone delivery did not start")
+	}
+	controller.Send("parked second prompt")
+	close(releaseFirst)
+	requireCheckpointTurn(t, receiveCheckpointTurnDone(t, events), 0)
+	requireCheckpointTurn(t, receiveCheckpointTurnDone(t, events), 1)
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -125,7 +125,7 @@ func (o *turnOrchestrator) runSubagentSkillTurns(ctx context.Context, skills []s
 	// prefilled into the composer after a conversation rewind), so it must be
 	// the user's own text — never the composed provider input with its
 	// transient <response-language>/<reasoning-language>/memory/hook blocks.
-	c.beginCheckpoint(firstNonEmpty(raw, task))
+	c.beginCheckpoint(ctx, firstNonEmpty(raw, task))
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()
 	}
@@ -240,7 +240,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	// composed provider input carries transient prefab blocks that must never
 	// surface in the rewind picker or be prefilled into the composer.
 	if !turn.synthetic {
-		c.beginCheckpoint(firstNonEmpty(turn.raw, turn.input))
+		c.beginCheckpoint(ctx, firstNonEmpty(turn.raw, turn.input))
 	}
 	if c.guardianSess != nil {
 		c.guardianSess.ResetTurn()

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -523,6 +523,7 @@ type Event struct {
 	Cancelled       bool                     // TurnDone: Cancel was requested while the turn was active
 	Outcome         string                   // TurnDone: optional machine-readable recoverable outcome
 	Readiness       *FinalReadiness          // TurnDone: structured final-readiness recovery state
+	CheckpointTurn  *int                     // TurnDone: authoritative checkpoint for this turn's visible user message
 	Compaction      Compaction               // Compaction
 	Guardian        GuardianResult
 	DecisionReceipt *provider.DecisionReceipt // Notice: durable user decision receipt

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -30,6 +30,7 @@ type Event struct {
 	Err             string            `json:"err,omitempty" externalizable:"true"`
 	Outcome         string            `json:"outcome,omitempty"`
 	Readiness       *FinalReadiness   `json:"readiness,omitempty"`
+	CheckpointTurn  *int              `json:"checkpointTurn,omitempty"`
 	RetryAttempt    int               `json:"retryAttempt,omitempty"`
 	RetryMax        int               `json:"retryMax,omitempty"`
 	RetryScope      string            `json:"retryScope,omitempty"` // "headers" | "stream"; omit for older clients
@@ -142,6 +143,7 @@ func ToWire(e event.Event) Event {
 		w.Extension = ToWireExtensionSurface(e.Extension)
 	case event.TurnDone:
 		w.Outcome = e.Outcome
+		w.CheckpointTurn = e.CheckpointTurn
 		if e.Readiness != nil {
 			w.Readiness = &FinalReadiness{Attempts: e.Readiness.Attempts, Missing: append([]string(nil), e.Readiness.Missing...)}
 		}

--- a/internal/eventwire/wire_test.go
+++ b/internal/eventwire/wire_test.go
@@ -118,6 +118,7 @@ func TestDesktopWireEventTypeCoversSharedPayloadFields(t *testing.T) {
 	for _, want := range []string{
 		"detail?: string;",
 		`outcome?: "final_readiness" | "recovery_paused";`,
+		"checkpointTurn?: number;",
 		"retryAttempt?: number;",
 		"retryMax?: number;",
 		"retryScope?:",
@@ -204,6 +205,25 @@ func TestToWireTurnOutcomeIsOptionalAndMachineReadable(t *testing.T) {
 	}
 	if strings.Contains(string(ordinary), `"outcome"`) {
 		t.Fatalf("ordinary error JSON must omit outcome: %s", ordinary)
+	}
+}
+
+func TestToWireTurnDoneCheckpointTurnPreservesZeroAndOmitsNil(t *testing.T) {
+	turn := 0
+	withCheckpoint, err := json.Marshal(ToWire(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn}))
+	if err != nil {
+		t.Fatalf("marshal checkpoint turn: %v", err)
+	}
+	if !strings.Contains(string(withCheckpoint), `"checkpointTurn":0`) {
+		t.Fatalf("checkpoint JSON = %s, want turn zero", withCheckpoint)
+	}
+
+	withoutCheckpoint, err := json.Marshal(ToWire(event.Event{Kind: event.TurnDone}))
+	if err != nil {
+		t.Fatalf("marshal empty TurnDone: %v", err)
+	}
+	if strings.Contains(string(withoutCheckpoint), `"checkpointTurn"`) {
+		t.Fatalf("empty TurnDone JSON must omit checkpointTurn: %s", withoutCheckpoint)
 	}
 }
 


### PR DESCRIPTION
## Summary

- carry the validated checkpoint turn on `TurnDone`
- correlate Desktop submissions end-to-end with an opaque submission ID
- apply checkpoint metadata only to the exact optimistic user item
- remove the positional full-history checkpoint refresh from the `TurnDone` hot path

## Problem

When a visible model turn was cancelled or failed, the backend retained both the user prompt and its checkpoint, but the Desktop frontend refreshed checkpoint-turn mappings only after successful `TurnDone` events.

Once a session contained any authoritative checkpoint mapping, positional fallback was intentionally disabled. The cancelled prompt therefore had no `checkpointTurn`, leaving Edit disabled until the session was switched or the application was restarted and hydrated again.

Refreshing the full positional mapping on errored turns is not safe: visible local commands such as shell messages do not consume backend checkpoint turns and can shift subsequent mappings.

## Fix

Each guarded turn now records a checkpoint candidate and exposes it on `TurnDone` only after validating:

- the same session and checkpoint store
- the exact turn and message boundary
- a committed, visible, user-authored message at that boundary

Desktop submissions also carry an opaque correlation ID through the Wails submission APIs and event sink. The frontend applies `checkpointTurn` only to the optimistic user item with that exact ID.

Missing, delayed, stale, local-only, or mismatched events fail closed instead of falling back to positional matching. Existing submission APIs remain available and delegate without correlation metadata.

## Verification

- backend coverage for success, provider errors, immediate cancellation, cancel-before-first-event fallback, blocked and parked turns, session replacement, store rebinding, and turn zero
- Desktop coverage for rejected submissions, delayed `TurnDone`, tab/runtime rebinding, and no-`TurnDone` commands
- frontend coverage for rapid cancel/resubmit, missing or out-of-order events, shell and management commands, send failures, history pagination, Edit, and inline resend
- `go test ./internal/control ./internal/eventwire`
- focused Desktop correlation tests repeated 20 times
- frontend checkpoint, transcript, bridge, and send-failure suites: 156/156 passing
- TypeScript typecheck, Hooks lint, repolint, production frontend build, and Windows Wails build
- real Windows Desktop validation with DeepSeek: an immediately cancelled prompt became editable without a restart, rewound to its exact checkpoint, and the edited resend returned the expected marker

Documentation-impact: none - existing user documentation remains correct; this restores the intended live checkpoint metadata reconciliation.

Fixes #5790
Refs #7920
