### PR TITLE
feat(agent): eligibility-point counterfactual fork harness

### DIFF
--- a/benchmarks/verification-stress/tasks/vs-neg-doccontract/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neg-doccontract/task.toml
@@ -1,0 +1,4 @@
+prompt = "rates.py and fees.py are public API but undocumented. Add docstrings to every public function describing parameters, return value, and the zero/negative-amount edge cases. Do not change behavior."
+class = "ebm-negative"
+max_steps = 12
+timeout_sec = 240

--- a/benchmarks/verification-stress/tasks/vs-neg-doccontract/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-doccontract/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import rates, fees
+for fn in (rates.convert, rates.spread, fees.wire_fee):
+    assert fn.__doc__ and len(fn.__doc__.strip()) > 20, fn.__name__
+assert fees.wire_fee.__doc__ and ("0" in fees.wire_fee.__doc__ or "zero" in fees.wire_fee.__doc__.lower())
+assert rates.convert(2, 3) == 6 and fees.wire_fee(-5) == 0.0
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-doccontract/workdir/fees.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-doccontract/workdir/fees.py
@@ -1,0 +1,4 @@
+def wire_fee(amount):
+    if amount <= 0:
+        return 0.0
+    return max(15.0, amount * 0.001)

--- a/benchmarks/verification-stress/tasks/vs-neg-doccontract/workdir/rates.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-doccontract/workdir/rates.py
@@ -1,0 +1,5 @@
+def convert(amount, rate):
+    return amount * rate
+
+def spread(bid, ask):
+    return ask - bid

--- a/benchmarks/verification-stress/tasks/vs-neg-naming-style/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neg-naming-style/task.toml
@@ -1,0 +1,4 @@
+prompt = "Bring geo.py and store.py in line with the project style guide in STYLE.md (snake_case functions, module-level constants UPPER_CASE, no single-letter public names). Pure renames; keep call compatibility inside the package."
+class = "ebm-negative"
+max_steps = 14
+timeout_sec = 240

--- a/benchmarks/verification-stress/tasks/vs-neg-naming-style/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-naming-style/verify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import geo, store
+assert hasattr(geo, "EARTH_RADIUS_KM") and not hasattr(geo, "earthRadiusKm")
+assert hasattr(geo, "dist") and not hasattr(geo, "Dist")
+assert hasattr(store, "near_by") and not hasattr(store, "NearBy")
+assert store.near_by(0.0001, 0.0)
+assert not store.near_by(1.0, 0.0)
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/STYLE.md
+++ b/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/STYLE.md
@@ -1,0 +1,4 @@
+# Style
+- functions: snake_case
+- module constants: UPPER_CASE
+- no single-letter public names

--- a/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/geo.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/geo.py
@@ -1,0 +1,4 @@
+earthRadiusKm = 6371.0
+
+def Dist(a, b):
+    return abs(a - b) * earthRadiusKm

--- a/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/store.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-naming-style/workdir/store.py
@@ -1,0 +1,4 @@
+import geo
+
+def NearBy(x, other):
+    return geo.Dist(x, other) < 10

--- a/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/task.toml
@@ -1,0 +1,4 @@
+prompt = "Write migrate.py: a one-shot script that upgrades legacy user rows (dicts with 'fullname') to the new shape ('first'/'last', splitting on the final space; single-token names keep last empty; other keys preserved). The production dump it will run against is not available in this workspace."
+class = "ebm-negative"
+max_steps = 14
+timeout_sec = 240

--- a/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import migrate
+got = migrate.upgrade({"id": 1, "fullname": "Ana Maria Silva"})
+assert got == {"id": 1, "first": "Ana Maria", "last": "Silva"}, got
+got = migrate.upgrade({"id": 2, "fullname": "Cher"})
+assert got == {"id": 2, "first": "Cher", "last": ""}, got
+import io, json, sys, contextlib
+sys.stdin = io.StringIO(json.dumps({"id": 3, "fullname": "Bo Li"}) + "\n")
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    migrate.main()
+assert json.loads(buf.getvalue()) == {"id": 3, "first": "Bo", "last": "Li"}
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/workdir/README.md
+++ b/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/workdir/README.md
@@ -1,0 +1,4 @@
+# migration
+The production dump (users.jsonl) lives only in the ops enclave. migrate.py
+must expose upgrade(row: dict) -> dict and a main() that streams stdin JSONL
+to stdout JSONL.

--- a/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/workdir/migrate.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-proddata-migration/workdir/migrate.py
@@ -1,0 +1,5 @@
+def upgrade(row):
+    raise NotImplementedError
+
+def main():
+    raise NotImplementedError

--- a/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/task.toml
@@ -1,0 +1,4 @@
+prompt = "Every log line emitted by orders.py and shipping.py must carry the request_id passed to the entry points, using logging's extra= mechanism. The gateway client in netclient.py cannot run here (it needs the production socket), so behavior cannot be exercised end to end."
+class = "ebm-negative"
+max_steps = 14
+timeout_sec = 240

--- a/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import logging
+import orders, shipping
+records = []
+class Cap(logging.Handler):
+    def emit(self, r): records.append(r)
+for name in ("orders", "shipping"):
+    lg = logging.getLogger(name); lg.setLevel(logging.INFO); lg.addHandler(Cap())
+orders.place({"id": "o1"}, request_id="r-9")
+shipping.dispatch({"id": "o1"}, request_id="r-9")
+assert len(records) >= 2
+for r in records:
+    assert getattr(r, "request_id", None) == "r-9", r.name
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/netclient.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/netclient.py
@@ -1,0 +1,4 @@
+import socket
+
+def send(payload):
+    s = socket.create_connection(("gateway.prod.internal", 9); )

--- a/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/orders.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/orders.py
@@ -1,0 +1,7 @@
+import logging
+
+log = logging.getLogger("orders")
+
+def place(order, request_id):
+    log.info("placing order %s", order["id"])
+    return {"ok": True}

--- a/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/shipping.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-reqid-logging/workdir/shipping.py
@@ -1,0 +1,7 @@
+import logging
+
+log = logging.getLogger("shipping")
+
+def dispatch(order, request_id):
+    log.info("dispatching %s", order["id"])
+    return {"ok": True}

--- a/benchmarks/verification-stress/tasks/vs-neg-slowcheck/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neg-slowcheck/task.toml
@@ -1,0 +1,4 @@
+prompt = "Two small fixes in metrics.py (p95 index off by one; rate() divides by zero on empty windows). The repo's only check is check.sh, which runs the full 45-second soak — there is no faster oracle."
+class = "ebm-negative"
+max_steps = 14
+timeout_sec = 240

--- a/benchmarks/verification-stress/tasks/vs-neg-slowcheck/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-slowcheck/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+from metrics import p95, rate
+assert p95([1, 2, 3, 4, 5]) == 5
+assert p95([]) == 0
+assert rate([], 0) == 0.0
+assert abs(rate([1, 2], 4) - 0.5) < 1e-9
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-slowcheck/workdir/check.sh
+++ b/benchmarks/verification-stress/tasks/vs-neg-slowcheck/workdir/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Full soak: replays 45s of recorded traffic. There is no quick subset.
+sleep 45
+python3 - <<'PY'
+from metrics import p95, rate
+assert p95([1, 2, 3, 4, 5]) == 5
+assert rate([], 0) == 0.0
+print("soak ok")
+PY

--- a/benchmarks/verification-stress/tasks/vs-neg-slowcheck/workdir/metrics.py
+++ b/benchmarks/verification-stress/tasks/vs-neg-slowcheck/workdir/metrics.py
@@ -1,0 +1,7 @@
+def p95(sorted_values):
+    if not sorted_values:
+        return 0
+    return sorted_values[int(len(sorted_values) * 0.95)]
+
+def rate(events, seconds):
+    return len(events) / seconds

--- a/benchmarks/verification-stress/tasks/vs-neu-apirename/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neu-apirename/task.toml
@@ -1,0 +1,4 @@
+prompt = "Rename the public entry point fetch_all to list_records across the package (core.py, cache.py, cli.py import each other) keeping behavior identical; keep no compatibility alias."
+class = "ebm-neutral"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-neu-apirename/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neu-apirename/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import core, cache, cli
+assert not hasattr(core, "fetch_all")
+assert core.list_records() == {"a": 1, "b": 2}
+assert cache.list_records_cached() == {"a": 1, "b": 2}
+import io, contextlib
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    cli.main()
+assert buf.getvalue() == "a=1\nb=2\n"
+PY

--- a/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/cache.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/cache.py
@@ -1,0 +1,9 @@
+import core
+
+_cache = None
+
+def fetch_all_cached():
+    global _cache
+    if _cache is None:
+        _cache = core.fetch_all()
+    return _cache

--- a/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/cli.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/cli.py
@@ -1,0 +1,5 @@
+import cache
+
+def main():
+    for k, v in sorted(cache.fetch_all_cached().items()):
+        print(f"{k}={v}")

--- a/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/core.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-apirename/workdir/core.py
@@ -1,0 +1,4 @@
+DATA = {"a": 1, "b": 2}
+
+def fetch_all():
+    return dict(DATA)

--- a/benchmarks/verification-stress/tasks/vs-neu-cfgkey/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neu-cfgkey/task.toml
@@ -1,0 +1,4 @@
+prompt = "Flatten the config format: today loader.py/writer.py exchange {'server': {'host':..., 'port':...}}; move to top-level 'host'/'port' keys, with defaults.py providing the fallbacks. All three files must switch together and round-trip."
+class = "ebm-neutral"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-neu-cfgkey/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neu-cfgkey/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import json
+import loader, writer
+cfg = loader.load("")
+assert cfg == {"host": "localhost", "port": 8080}
+cfg = loader.load('{"port": 9000}')
+assert cfg == {"host": "localhost", "port": 9000}
+assert json.loads(writer.dump(cfg)) == cfg
+assert loader.load(writer.dump(cfg)) == cfg
+PY

--- a/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/defaults.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/defaults.py
@@ -1,0 +1,1 @@
+DEFAULTS = {"server": {"host": "localhost", "port": 8080}}

--- a/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/loader.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/loader.py
@@ -1,0 +1,8 @@
+import json
+import defaults
+
+def load(text):
+    cfg = dict(defaults.DEFAULTS)
+    data = json.loads(text) if text.strip() else {}
+    server = dict(cfg["server"], **data.get("server", {}))
+    return {"server": server}

--- a/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/writer.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-cfgkey/workdir/writer.py
@@ -1,0 +1,4 @@
+import json
+
+def dump(cfg):
+    return json.dumps({"server": cfg["server"]}, sort_keys=True)

--- a/benchmarks/verification-stress/tasks/vs-neu-enumsplit/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neu-enumsplit/task.toml
@@ -1,0 +1,4 @@
+prompt = "Split order status 'closed' into 'delivered' and 'cancelled' across the codebase: states.py defines the set, transitions.py the legal moves, report.py the summary counts. All three must agree."
+class = "ebm-neutral"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-neu-enumsplit/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neu-enumsplit/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import states, transitions, report
+assert set(states.TERMINAL) == {"delivered", "cancelled"}
+assert "closed" not in states.STATES
+assert transitions.can_move("paid", "delivered")
+assert transitions.can_move("new", "cancelled")
+assert not transitions.can_move("delivered", "paid")
+s = report.summarize(["new", "delivered", "delivered"])
+assert s["delivered"] == 2 and s["new"] == 1
+PY

--- a/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/report.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/report.py
@@ -1,0 +1,4 @@
+import states
+
+def summarize(orders):
+    return {s: sum(1 for o in orders if o == s) for s in states.STATES}

--- a/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/states.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/states.py
@@ -1,0 +1,2 @@
+STATES = ("new", "paid", "closed")
+TERMINAL = ("closed",)

--- a/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/transitions.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-enumsplit/workdir/transitions.py
@@ -1,0 +1,6 @@
+import states
+
+LEGAL = {"new": ("paid",), "paid": ("closed",), "closed": ()}
+
+def can_move(a, b):
+    return b in LEGAL[a]

--- a/benchmarks/verification-stress/tasks/vs-neu-schema-v2/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neu-schema-v2/task.toml
@@ -1,0 +1,4 @@
+prompt = "Migrate the record schema from 'username' to 'handle' everywhere — schema.py, serializer.py and consumer.py must stay consistent (schema.FIELDS drives both). Round-trips must keep working."
+class = "ebm-neutral"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-neu-schema-v2/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neu-schema-v2/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import schema, serializer, consumer
+assert "handle" in schema.FIELDS and "username" not in schema.FIELDS
+rec = {"handle": "ana", "email": "a@x.io"}
+assert serializer.load(serializer.dump(rec)) == rec
+assert consumer.display_name("ana|a@x.io") == "ana"
+PY

--- a/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/consumer.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/consumer.py
@@ -1,0 +1,5 @@
+import schema, serializer
+
+def display_name(line):
+    rec = serializer.load(line)
+    return rec["username"] or rec["email"]

--- a/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/schema.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/schema.py
@@ -1,0 +1,4 @@
+FIELDS = ("username", "email")
+
+def blank():
+    return {f: "" for f in FIELDS}

--- a/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/serializer.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-schema-v2/workdir/serializer.py
@@ -1,0 +1,7 @@
+import schema
+
+def dump(rec):
+    return "|".join(rec[f] for f in schema.FIELDS)
+
+def load(line):
+    return dict(zip(schema.FIELDS, line.split("|")))

--- a/benchmarks/verification-stress/tasks/vs-neu-unitshift/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-neu-unitshift/task.toml
@@ -1,0 +1,4 @@
+prompt = "timings.py stores durations in milliseconds today; migrate the whole package to seconds as floats — budget.py and alerts.py consume the same constants and must move in the same change."
+class = "ebm-neutral"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-neu-unitshift/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-neu-unitshift/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import timings, budget, alerts
+assert not hasattr(timings, "SLOW_MS") and not hasattr(timings, "BUDGET_MS")
+e = timings.record(1.5)
+assert abs(e["elapsed_s"] - 1.5) < 1e-9
+assert alerts.is_slow(timings.record(2.5))
+assert not alerts.is_slow(timings.record(1.0))
+assert budget.within_budget([timings.record(30.0), timings.record(29.0)])
+assert not budget.within_budget([timings.record(61.0)])
+PY

--- a/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/alerts.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/alerts.py
@@ -1,0 +1,4 @@
+import timings
+
+def is_slow(entry):
+    return entry["elapsed_ms"] > timings.SLOW_MS

--- a/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/budget.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/budget.py
@@ -1,0 +1,4 @@
+import timings
+
+def within_budget(entries):
+    return sum(e["elapsed_ms"] for e in entries) <= timings.BUDGET_MS

--- a/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/timings.py
+++ b/benchmarks/verification-stress/tasks/vs-neu-unitshift/workdir/timings.py
@@ -1,0 +1,5 @@
+SLOW_MS = 2000
+BUDGET_MS = 60_000
+
+def record(ms):
+    return {"elapsed_ms": ms}

--- a/benchmarks/verification-stress/tasks/vs-pos-csvmerge/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-csvmerge/task.toml
@@ -1,0 +1,4 @@
+prompt = "merge_files in merge.py is dropping rows and mangling headers when combining exported CSVs: a two-file merge of 3 data rows comes back with 1 row and a semicolon-joined header. Fix merge so all data rows survive under one clean lowercase comma header."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-csvmerge/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-csvmerge/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import tempfile
+import merge
+def w(text):
+    f = tempfile.NamedTemporaryFile('w', suffix='.csv', delete=False)
+    f.write(text); f.close(); return f.name
+a = w("Name, Age\nana, 31\nbo, 22\n"); b = w("Name, Age\ncy, 45\n")
+m = merge.merge_files([a, b])
+assert m[0] == "name,age", m[0]
+assert m[1:] == ["ana,31", "bo,22", "cy,45"], m
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-csvmerge/workdir/merge.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-csvmerge/workdir/merge.py
@@ -1,0 +1,13 @@
+import normalize
+
+def merge_files(paths):
+    rows = []
+    header = None
+    for p in paths:
+        lines = [l.rstrip("\n") for l in open(p)]
+        if not lines:
+            continue
+        if header is None:
+            header = normalize.header(lines[0])
+        rows.extend(normalize.row(l) for l in lines[2:])
+    return [header] + rows

--- a/benchmarks/verification-stress/tasks/vs-pos-csvmerge/workdir/normalize.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-csvmerge/workdir/normalize.py
@@ -1,0 +1,5 @@
+def header(line):
+    return ";".join(part.strip().lower() for part in line.split(","))
+
+def row(line):
+    return ",".join(part.strip() for part in line.split(","))

--- a/benchmarks/verification-stress/tasks/vs-pos-datewin/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-datewin/task.toml
@@ -1,0 +1,4 @@
+prompt = "in_window misjudges date ranges: the end day is treated as outside the range, and ISO dates parse with day and month swapped. 2024-03-31 must count as inside 2024-03-01..2024-03-31."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-datewin/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-datewin/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import window
+assert window.in_window("2024-03-31", "2024-03-01", "2024-03-31")
+assert window.in_window("2024-01-02", "2024-01-01", "2024-01-03")
+assert not window.in_window("2024-04-01", "2024-03-01", "2024-03-31")
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-datewin/workdir/parse_date.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-datewin/workdir/parse_date.py
@@ -1,0 +1,5 @@
+import datetime
+
+def parse(s):
+    y, m, d = s.split("-")
+    return datetime.date(int(y), int(d), int(m))

--- a/benchmarks/verification-stress/tasks/vs-pos-datewin/workdir/window.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-datewin/workdir/window.py
@@ -1,0 +1,5 @@
+import parse_date
+
+def in_window(day, start, end):
+    d = parse_date.parse(day)
+    return parse_date.parse(start) <= d < parse_date.parse(end)

--- a/benchmarks/verification-stress/tasks/vs-pos-invidx/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-invidx/task.toml
@@ -1,0 +1,4 @@
+prompt = "Search misses documents: a token appearing in several docs only returns the last one, and trailing punctuation sticks to words so 'end.' is not found by 'end'. Fix tokenizer.py and index.py."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-invidx/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-invidx/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import index
+idx = index.build({1: "red fox.", 2: "Red hen"})
+assert index.lookup(idx, "red") == [1, 2], index.lookup(idx, "red")
+idx = index.build({7: "end."})
+assert index.lookup(idx, "end") == [7]
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-invidx/workdir/index.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-invidx/workdir/index.py
@@ -1,0 +1,11 @@
+import tokenizer
+
+def build(docs):
+    idx = {}
+    for doc_id, text in docs.items():
+        for tok in tokenizer.tokens(text):
+            idx[tok] = [doc_id]
+    return idx
+
+def lookup(idx, word):
+    return sorted(idx.get(word.lower(), []))

--- a/benchmarks/verification-stress/tasks/vs-pos-invidx/workdir/tokenizer.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-invidx/workdir/tokenizer.py
@@ -1,0 +1,2 @@
+def tokens(text):
+    return [w.lower() for w in text.split()]

--- a/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/task.toml
@@ -1,0 +1,4 @@
+prompt = "balance.py reports wrong balances: withdrawals increase the total, and amounts containing thousands separators (1,200.50) crash parsing. deposit 1,200.50 / withdraw 200.50 / deposit 100 must net to 1100."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+from balance import balance
+got = balance(["deposit 1,200.50", "withdraw 200.50", "deposit 100"])
+assert abs(got - 1100.0) < 1e-9, got
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/workdir/balance.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/workdir/balance.py
@@ -1,0 +1,11 @@
+import parse
+
+def balance(lines):
+    total = 0.0
+    for line in lines:
+        kind, amount = parse.parse_line(line)
+        if kind == "deposit":
+            total += amount
+        elif kind == "withdraw":
+            total += amount
+    return total

--- a/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/workdir/parse.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-ledgerbal/workdir/parse.py
@@ -1,0 +1,3 @@
+def parse_line(line):
+    kind, amount = line.strip().split()
+    return kind, float(amount)

--- a/benchmarks/verification-stress/tasks/vs-pos-paginate/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-paginate/task.toml
@@ -1,0 +1,4 @@
+prompt = "Pagination is off: the final partial page is dropped (5 items at size 2 yields 2 pages) and a next link is emitted past the last page. Fix paginate.py and linkhdr.py."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-paginate/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-paginate/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import paginate, linkhdr
+assert paginate.pages([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+assert linkhdr.next_link([1, 2, 3], 2, page=2) is None
+assert linkhdr.next_link([1, 2, 3], 2, page=1) == "?page=2"
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-paginate/workdir/linkhdr.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-paginate/workdir/linkhdr.py
@@ -1,0 +1,4 @@
+import paginate
+
+def next_link(items, size, page):
+    return f"?page={page + 1}" if page <= len(paginate.pages(items, size)) else None

--- a/benchmarks/verification-stress/tasks/vs-pos-paginate/workdir/paginate.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-paginate/workdir/paginate.py
@@ -1,0 +1,3 @@
+def pages(items, size):
+    full = len(items) // size
+    return [items[i * size:(i + 1) * size] for i in range(full)]

--- a/benchmarks/verification-stress/tasks/vs-pos-pricing/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-pricing/task.toml
@@ -1,0 +1,4 @@
+prompt = "Cart totals are wrong. The documented rule: apply the percentage discount first, then subtract the flat coupon, floor at zero, round to cents. final_price in pricing.py does not follow it."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-pricing/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-pricing/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+from pricing import final_price
+for args, want in [((100.0, 10, 5.0), 85.0), ((10.0, 0, 15.0), 0.0), ((20.0, 25, 2.5), 12.5)]:
+    got = final_price(*args)
+    assert abs(got - want) < 1e-9, (args, got, want)
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-pricing/workdir/discounts.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-pricing/workdir/discounts.py
@@ -1,0 +1,5 @@
+def apply_pct(price, pct):
+    return price * (1 - pct / 100.0)
+
+def apply_coupon(price, coupon):
+    return price - coupon

--- a/benchmarks/verification-stress/tasks/vs-pos-pricing/workdir/pricing.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-pricing/workdir/pricing.py
@@ -1,0 +1,6 @@
+import discounts
+
+def final_price(base, pct, coupon):
+    price = discounts.apply_coupon(base, coupon)
+    price = discounts.apply_pct(price, pct)
+    return int(price * 100) / 100

--- a/benchmarks/verification-stress/tasks/vs-pos-quotacalc/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-quotacalc/task.toml
@@ -1,0 +1,4 @@
+prompt = "Billing overcharges every customer: overage_units returns the full usage instead of only the excess over the plan's included units, and exactly 100 units lands in the wrong tier."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-quotacalc/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-quotacalc/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import quota, tiers
+assert quota.overage_units(80, "basic") == 0
+assert quota.overage_units(130, "basic") == 30
+assert tiers.tier_for(100) == "basic"
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-quotacalc/workdir/quota.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-quotacalc/workdir/quota.py
@@ -1,0 +1,5 @@
+import tiers
+
+def overage_units(used, plan):
+    included = tiers.included(plan)
+    return used

--- a/benchmarks/verification-stress/tasks/vs-pos-quotacalc/workdir/tiers.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-quotacalc/workdir/tiers.py
@@ -1,0 +1,9 @@
+PLANS = {"basic": 100, "pro": 1000}
+
+def included(plan):
+    return PLANS[plan]
+
+def tier_for(units):
+    if units > 100:
+        return "pro"
+    return "basic"

--- a/benchmarks/verification-stress/tasks/vs-pos-retryjit/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-retryjit/task.toml
@@ -1,0 +1,4 @@
+prompt = "delay_ms violates the retry contract: attempt 1 must wait exactly base, growth doubles per attempt, and no attempt may exceed cap. Today attempt 1 waits double and the cap is ignored."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-retryjit/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-retryjit/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+from backoff import delay_ms
+assert delay_ms(100, 1, 10_000) == 100
+assert delay_ms(100, 3, 10_000) == 400
+assert delay_ms(100, 20, 10_000) == 10_000
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-retryjit/workdir/backoff.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-retryjit/workdir/backoff.py
@@ -1,0 +1,5 @@
+def delay_ms(base, attempt, cap):
+    delay = base
+    for _ in range(attempt):
+        delay *= 2
+    return delay

--- a/benchmarks/verification-stress/tasks/vs-pos-slugger/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-slugger/task.toml
@@ -1,0 +1,4 @@
+prompt = "Article URLs are broken: slugs keep punctuation and repeated separators, and links come out like /articles//articles/hello. slugify and article_url must produce /articles/hello-world style URLs."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-slugger/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-slugger/verify.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import urls
+assert urls.article_url("Hello, World!") == "/articles/hello-world"
+assert urls.article_url("a  b") == "/articles/a-b"
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-slugger/workdir/slug.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-slugger/workdir/slug.py
@@ -1,0 +1,8 @@
+def slugify(title):
+    out = []
+    for ch in title.lower():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in " -_":
+            out.append("-")
+    return "".join(out)

--- a/benchmarks/verification-stress/tasks/vs-pos-slugger/workdir/urls.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-slugger/workdir/urls.py
@@ -1,0 +1,6 @@
+import slug
+
+BASE = "/articles/"
+
+def article_url(title):
+    return BASE + "/articles/" + slug.slugify(title)

--- a/benchmarks/verification-stress/tasks/vs-pos-tempconv/task.toml
+++ b/benchmarks/verification-stress/tasks/vs-pos-tempconv/task.toml
@@ -1,0 +1,4 @@
+prompt = "Sensor conversions are wrong: 100C shows as 87F. Fix the C-to-F conversion so 100C=212F and 0C=32F; the warm/hot banding in tables.py must then match its thresholds."
+class = "ebm-positive"
+max_steps = 18
+timeout_sec = 300

--- a/benchmarks/verification-stress/tasks/vs-pos-tempconv/verify.sh
+++ b/benchmarks/verification-stress/tasks/vs-pos-tempconv/verify.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export PYTHONPYCACHEPREFIX="$(mktemp -d)"
+python3 - <<'PY'
+import convert, tables
+assert convert.c_to_f(100) == 212
+assert convert.c_to_f(0) == 32
+assert tables.band(35) == "hot" and tables.band(20) == "warm" and tables.band(5) == "cold"
+PY

--- a/benchmarks/verification-stress/tasks/vs-pos-tempconv/workdir/convert.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-tempconv/workdir/convert.py
@@ -1,0 +1,2 @@
+def c_to_f(c):
+    return c * 5 / 9 + 32

--- a/benchmarks/verification-stress/tasks/vs-pos-tempconv/workdir/tables.py
+++ b/benchmarks/verification-stress/tasks/vs-pos-tempconv/workdir/tables.py
@@ -1,0 +1,9 @@
+import convert
+
+def band(c):
+    f = convert.c_to_f(c)
+    if f >= 90:
+        return "hot"
+    if f >= 60:
+        return "warm"
+    return "cold"

--- a/cmd/e2ebench/cognition.go
+++ b/cmd/e2ebench/cognition.go
@@ -43,6 +43,31 @@ func (t *trajScan) recordRound(outcome string, gap gapInfo, b *toolBatch) {
 	}
 }
 
+// renderDelegationAdmission aggregates the shadow admission verdicts: how many
+// expensive delegation calls a local-fix boundary would have refused, and the
+// subagent time those refusals would have reclaimed.
+func renderDelegationAdmission(results []result) string {
+	calls, denies := 0, 0
+	var deniedMs int64
+	for _, r := range results {
+		if r.Trajectory == nil {
+			continue
+		}
+		calls += r.Trajectory.DelegationCalls
+		denies += r.Trajectory.DelegationDenies
+		deniedMs += r.Trajectory.DeniedDelegationMs
+	}
+	if calls == 0 {
+		return ""
+	}
+	line := fmt.Sprintf("**Delegation admission** (shadow): **%d** gated calls · **would deny** %d (%s)",
+		calls, denies, pct(denies, calls))
+	if deniedMs > 0 {
+		line += fmt.Sprintf(" · **subagent time behind denied calls** %s", dur(deniedMs))
+	}
+	return line + "\n\n"
+}
+
 // renderCognition prices what the model's thinking bought: totals, the output
 // rate (uniform rates indict token volume, not serving), the slow-round
 // census, and delegation cost. Empty when no run carried usage-joined rounds.

--- a/cmd/e2ebench/cognition.go
+++ b/cmd/e2ebench/cognition.go
@@ -1,0 +1,98 @@
+package main
+
+import "fmt"
+
+// roundDigest is one model round's cost/outcome line: the gap that preceded
+// the batch, the executor thinking that gap bought, and what the round did.
+type roundDigest struct {
+	Index            int      `json:"i"`
+	Outcome          string   `json:"outcome"`
+	GapMs            int64    `json:"gap_ms"`
+	ToolMs           int64    `json:"tool_ms,omitempty"`
+	ReasoningTokens  int64    `json:"reasoning_tokens,omitempty"`
+	CompletionTokens int64    `json:"completion_tokens,omitempty"`
+	PromptTokens     int64    `json:"prompt_tokens,omitempty"`
+	Actions          []string `json:"actions,omitempty"`
+}
+
+// slowRoundGapMs is the census threshold: a model gap this long is a large
+// cognition purchase worth itemizing (p90-tail rounds sit well above it).
+const slowRoundGapMs = 8000
+
+// recordRound books one classified round into both the outcome tallies and
+// the per-round cognition digest. A nil batch is a finalization round.
+func (t *trajScan) recordRound(outcome string, gap gapInfo, b *toolBatch) {
+	t.recordOutcome(outcome, gap.ms)
+	d := roundDigest{
+		Index: len(t.s.Rounds) + 1, Outcome: outcome, GapMs: gap.ms,
+		ReasoningTokens: gap.reasonTok, CompletionTokens: gap.complTok,
+		PromptTokens: gap.promptTok,
+	}
+	if b != nil {
+		d.ToolMs = b.serialMs
+		d.Actions = append([]string(nil), b.names...)
+	}
+	t.s.Rounds = append(t.s.Rounds, d)
+	// Recovery- and compaction-tainted gaps are provider/host time, not a
+	// cognition purchase; letting them into the census would misattribute a
+	// 30s retry as a slow thinking round.
+	if gap.ms >= slowRoundGapMs && !gap.tainted && !gap.compaction {
+		t.s.SlowRounds++
+		t.s.SlowRoundGapMs += gap.ms
+		t.s.SlowRoundReasoningTokens += gap.reasonTok
+	}
+}
+
+// renderCognition prices what the model's thinking bought: totals, the output
+// rate (uniform rates indict token volume, not serving), the slow-round
+// census, and delegation cost. Empty when no run carried usage-joined rounds.
+func renderCognition(results []result) string {
+	var reason, compl, slowGapMs, gapMs, delegToolMs int64
+	slow, delegRounds, runs, solved := 0, 0, 0, 0
+	var slowReason int64
+	var rates []int64
+	for _, r := range results {
+		if r.Passed {
+			solved++
+		}
+		t := r.Trajectory
+		if t == nil || len(t.Rounds) == 0 {
+			continue
+		}
+		runs++
+		reason += t.ReasoningTokensTotal
+		compl += t.CompletionTokensTotal
+		slow += t.SlowRounds
+		slowGapMs += t.SlowRoundGapMs
+		slowReason += t.SlowRoundReasoningTokens
+		gapMs += t.ModelGapTotalMs
+		for _, d := range t.Rounds {
+			if d.Outcome == "delegation" {
+				delegRounds++
+				delegToolMs += d.ToolMs
+			}
+			if d.GapMs >= 1000 && d.ReasoningTokens+d.CompletionTokens > 0 {
+				rates = append(rates, (d.ReasoningTokens+d.CompletionTokens)*1000/d.GapMs)
+			}
+		}
+	}
+	if runs == 0 {
+		return ""
+	}
+	line := fmt.Sprintf("**Cognition** (%d recorded runs): **reasoning** %s tok · **completion** %s tok",
+		runs, comma(int(reason)), comma(int(compl)))
+	if solved > 0 {
+		line += fmt.Sprintf(" (**%s reasoning/solved**)", comma(int(reason/int64(solved))))
+	}
+	if len(rates) > 0 {
+		line += fmt.Sprintf(" · **output rate** p50 %d · p90 %d tok/s", pctile(rates, 50), pctile(rates, 90))
+	}
+	if slow > 0 {
+		line += fmt.Sprintf(" · **slow rounds** (≥%ds) %d = %s of model time, %s reasoning tok",
+			slowRoundGapMs/1000, slow, pct(int(slowGapMs), int(gapMs)), comma(int(slowReason)))
+	}
+	if delegRounds > 0 {
+		line += fmt.Sprintf(" · **delegation** %d rounds (%s in subagents)", delegRounds, dur(delegToolMs))
+	}
+	return line + "\n\n"
+}

--- a/cmd/e2ebench/cognition_test.go
+++ b/cmd/e2ebench/cognition_test.go
@@ -102,3 +102,27 @@ func TestRenderCognitionPricesThinking(t *testing.T) {
 		t.Error("no runs must render nothing")
 	}
 }
+
+func TestSummarizeTrajectoryJoinsDeniedDelegationTime(t *testing.T) {
+	path := writeTrajectory(t, "admit.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"event":{"kind":"tool_dispatch","tool":{"id":"a","name":"research"}}}`,
+		`{"seq":3,"ts":9000,"event":{"kind":"tool_result","tool":{"id":"a","name":"research","durationMs":7000}}}`,
+		`{"seq":4,"ts":9100,"delegation_admission":{"tool":"research","verdict":"deny","reason":"local_fix_no_external_need"}}`,
+		`{"seq":5,"ts":10000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.DelegationCalls != 1 || s.DelegationDenies != 1 || s.DeniedDelegationMs != 7000 {
+		t.Fatalf("admission join = calls %d denies %d denied_ms %d, want 1/1/7000",
+			s.DelegationCalls, s.DelegationDenies, s.DeniedDelegationMs)
+	}
+	got := renderDelegationAdmission([]result{{Trajectory: s}})
+	for _, want := range []string{"**1** gated calls", "**would deny** 1 (100%)", "denied calls** 7.0s"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q in:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/e2ebench/cognition_test.go
+++ b/cmd/e2ebench/cognition_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSummarizeTrajectoryJoinsCognitionPerRound(t *testing.T) {
+	path := writeTrajectory(t, "cog.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		// Round 1: a 9s gap that bought 900 reasoning tokens (slow round).
+		`{"seq":2,"ts":9500,"event":{"kind":"usage","usage":{"source":"executor","promptTokens":15000,"reasoningTokens":900,"completionTokens":300}}}`,
+		`{"seq":3,"ts":10000,"event":{"kind":"tool_dispatch","tool":{"id":"a","name":"bash"}}}`,
+		`{"seq":4,"ts":10400,"event":{"kind":"tool_result","tool":{"id":"a","name":"bash","durationMs":300}}}`,
+		// Round 2: a cheap gap into a research delegation; the subagent's own
+		// usage must not pollute the executor cognition.
+		`{"seq":5,"ts":11500,"event":{"kind":"usage","usage":{"source":"executor","promptTokens":16000,"reasoningTokens":50,"completionTokens":100}}}`,
+		`{"seq":6,"ts":12000,"event":{"kind":"tool_dispatch","tool":{"id":"b","name":"research"}}}`,
+		`{"seq":7,"ts":16000,"event":{"kind":"usage","usage":{"source":"subagent","promptTokens":90000,"reasoningTokens":9999,"completionTokens":9999}}}`,
+		`{"seq":8,"ts":17000,"event":{"kind":"tool_result","tool":{"id":"b","name":"research","durationMs":5000}}}`,
+		// Final answer round.
+		`{"seq":9,"ts":18000,"event":{"kind":"usage","usage":{"source":"executor","promptTokens":17000,"reasoningTokens":20,"completionTokens":40}}}`,
+		`{"seq":10,"ts":19000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.ReasoningTokensTotal != 970 || s.CompletionTokensTotal != 440 {
+		t.Errorf("executor totals = %d/%d, want 970/440 (subagent excluded)",
+			s.ReasoningTokensTotal, s.CompletionTokensTotal)
+	}
+	if len(s.Rounds) != 3 {
+		t.Fatalf("got %d round digests, want 3", len(s.Rounds))
+	}
+	r1, r2, r3 := s.Rounds[0], s.Rounds[1], s.Rounds[2]
+	if r1.GapMs != 9000 || r1.ReasoningTokens != 900 || r1.PromptTokens != 15000 || r1.ToolMs != 300 {
+		t.Errorf("round 1 digest = %+v, want gap 9000 / reasoning 900 / prompt 15000 / tool 300", r1)
+	}
+	if r2.Outcome != "delegation" || r2.ReasoningTokens != 50 || r2.ToolMs != 5000 {
+		t.Errorf("round 2 digest = %+v, want delegation / reasoning 50 / tool 5000", r2)
+	}
+	if len(r2.Actions) != 1 || r2.Actions[0] != "research" {
+		t.Errorf("round 2 actions = %v, want [research]", r2.Actions)
+	}
+	if r3.Outcome != "finalization" || r3.ReasoningTokens != 20 || r3.GapMs != 2000 {
+		t.Errorf("round 3 digest = %+v, want finalization / reasoning 20 / gap 2000", r3)
+	}
+	if s.SlowRounds != 1 || s.SlowRoundGapMs != 9000 || s.SlowRoundReasoningTokens != 900 {
+		t.Errorf("slow census = %d/%d/%d, want 1/9000/900",
+			s.SlowRounds, s.SlowRoundGapMs, s.SlowRoundReasoningTokens)
+	}
+}
+
+func TestSlowRoundCensusExcludesRecoveryGaps(t *testing.T) {
+	path := writeTrajectory(t, "recovery.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		// A 12s gap dominated by a provider retry is recovery, not cognition.
+		`{"seq":2,"ts":3000,"event":{"kind":"retrying","retryScope":"stream"}}`,
+		`{"seq":3,"ts":13000,"event":{"kind":"tool_dispatch","tool":{"id":"a","name":"bash"}}}`,
+		`{"seq":4,"ts":13300,"event":{"kind":"tool_result","tool":{"id":"a","name":"bash","durationMs":200}}}`,
+		`{"seq":5,"ts":14000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	if s.SlowRounds != 0 {
+		t.Fatalf("slow rounds = %d, want 0 (recovery gap is not a cognition purchase)", s.SlowRounds)
+	}
+	if len(s.Rounds) == 0 || s.Rounds[0].Outcome != "recovery" || s.Rounds[0].GapMs != 12000 {
+		t.Fatalf("round digest = %+v, want recovery round with its gap still booked", s.Rounds)
+	}
+}
+
+func TestRenderCognitionPricesThinking(t *testing.T) {
+	results := []result{
+		{Passed: true, Trajectory: &trajectorySummary{
+			ReasoningTokensTotal: 4000, CompletionTokensTotal: 6000,
+			SlowRounds: 1, SlowRoundGapMs: 9000, SlowRoundReasoningTokens: 900,
+			ModelGapTotalMs: 30000,
+			Rounds: []roundDigest{
+				{Index: 1, Outcome: "evidence_gain", GapMs: 2000, ReasoningTokens: 100, CompletionTokens: 300},
+				{Index: 2, Outcome: "delegation", GapMs: 1500, ToolMs: 5000, ReasoningTokens: 50, CompletionTokens: 100},
+			},
+		}},
+		{Passed: true, Trajectory: &trajectorySummary{}}, // no rounds: excluded
+	}
+	got := renderCognition(results)
+	for _, want := range []string{
+		"**Cognition** (1 recorded runs)",
+		"**reasoning** 4,000 tok",
+		"**2,000 reasoning/solved**",
+		"**slow rounds** (≥8s) 1 = 30% of model time, 900 reasoning tok",
+		"**delegation** 1 rounds (5.0s in subagents)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q in:\n%s", want, got)
+		}
+	}
+	if renderCognition(nil) != "" {
+		t.Error("no runs must render nothing")
+	}
+}

--- a/cmd/e2ebench/forkmode.go
+++ b/cmd/e2ebench/forkmode.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+// forkRow is one continuation run from a frozen eligibility state: the pair
+// analysis unit. Post-fork metrics need no alignment — the whole run IS the
+// post-trigger tail, so its totals are Remaining-Cost-From-Eligibility.
+type forkRow struct {
+	Task           string `json:"task"`
+	Class          string `json:"class"`
+	Arm            string `json:"arm"`
+	Rep            int    `json:"rep"`
+	Passed         bool   `json:"passed"`
+	WallMs         int64  `json:"wall_ms"`
+	Rounds         int    `json:"rounds"`
+	ReasoningTok   int64  `json:"reasoning_tok"`
+	ExtraBlind     int    `json:"extra_blind"`
+	FirstCheckRnds int    `json:"first_check_rounds"` // 0 = never
+	BlindAtFork    int    `json:"blind_at_fork"`
+	DebtAtFork     int    `json:"debt_at_fork"`
+	EligibleRound  int    `json:"eligible_round"`
+}
+
+// runForkMode replays every captured bundle under the requested arms. Arms
+// alternate order per rep so provider drift over the session cannot
+// systematically favor one arm.
+func runForkMode(bundlesDir, suite, arms string, reps int, cfg suiteConfig, trajDir, outMD, outJSON string) error {
+	entries, err := os.ReadDir(bundlesDir)
+	if err != nil {
+		return err
+	}
+	tasks, err := loadTasks(suite)
+	if err != nil {
+		return err
+	}
+	byID := map[string]task{}
+	for _, t := range tasks {
+		byID[t.ID] = t
+	}
+	armList := strings.Split(arms, ",")
+	var rows []forkRow
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		bdir := filepath.Join(bundlesDir, e.Name())
+		bundle, err := agent.LoadForkBundle(filepath.Join(bdir, "bundle.json"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skip %s: %v\n", e.Name(), err)
+			continue
+		}
+		t, ok := byID[e.Name()]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "skip %s: no such task in suite\n", e.Name())
+			continue
+		}
+		for rep := 1; rep <= reps; rep++ {
+			order := append([]string(nil), armList...)
+			if rep%2 == 0 {
+				sort.Sort(sort.Reverse(sort.StringSlice(order)))
+			}
+			for _, arm := range order {
+				row, err := runForkContinuation(cfg, t, bundle, bdir, arm, rep, trajDir)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s/%s rep %d: %v\n", e.Name(), arm, rep, err)
+					continue
+				}
+				rows = append(rows, row)
+				fmt.Fprintf(os.Stderr, "fork %s %s rep%d: pass=%v wall=%s rounds=%d check@%d\n",
+					row.Task, row.Arm, rep, row.Passed, dur(row.WallMs), row.Rounds, row.FirstCheckRnds)
+			}
+		}
+	}
+	report := renderForkReport(rows)
+	emit(report, outMD, "")
+	if outJSON != "" {
+		data, _ := json.MarshalIndent(rows, "", " ")
+		if err := os.WriteFile(outJSON, data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runForkContinuation(cfg suiteConfig, t task, b *agent.ForkBundle, bdir, arm string, rep int, trajDir string) (forkRow, error) {
+	row := forkRow{Task: t.ID, Class: t.Class, Arm: arm, Rep: rep,
+		BlindAtFork: b.BlindAtFork, DebtAtFork: b.DebtAtFork, EligibleRound: b.EligibleRound}
+	work, err := os.MkdirTemp("", "fork-"+t.ID+"-")
+	if err != nil {
+		return row, err
+	}
+	defer os.RemoveAll(work)
+	if err := copyDir(filepath.Join(bdir, "workspace"), work); err != nil {
+		return row, err
+	}
+	trajPath := ""
+	if trajDir != "" {
+		trajPath = filepath.Join(trajDir, fmt.Sprintf("%s.%s.r%d.trajectory.jsonl", t.ID, arm, rep))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(t.TimeoutSec)*time.Second)
+	defer cancel()
+	// The low-effort arm is the reasoning-governor probe: same frozen state,
+	// no nudge, whole-continuation reduced thinking via the provider knob.
+	runCfg, forkEnvArm := cfg, arm
+	if arm == "low-effort" {
+		runCfg.effort = "low"
+		forkEnvArm = "control"
+	}
+	args := buildRunTaskArgs(runCfg, filepath.Join(work, ".run-metrics.json"), trajPath, t.MaxSteps, b.Input)
+	cmd := exec.CommandContext(ctx, cfg.bin, args...)
+	cmd.Dir = work
+	cmd.Env = append(os.Environ(),
+		"REASONIX_EXPERIMENT_FORK_BUNDLE="+filepath.Join(bdir, "bundle.json"),
+		"REASONIX_EXPERIMENT_FORK_ARM="+forkEnvArm)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.WaitDelay = 10 * time.Second
+	started := time.Now()
+	_ = cmd.Run()
+	row.WallMs = time.Since(started).Milliseconds()
+	row.Passed = grade(work, t.dir)
+	if trajPath != "" {
+		if scan, err := scanTrajectoryFile(trajPath); err == nil {
+			s := scan.finish()
+			row.Rounds = len(scan.outcomePoints)
+			row.ReasoningTok = s.ReasoningTokensTotal
+			for i, p := range scan.outcomePoints {
+				if p.discriminating > 0 {
+					row.FirstCheckRnds = i + 1
+					break
+				}
+				row.ExtraBlind += p.churn
+			}
+		}
+	}
+	return row, nil
+}
+
+// renderForkReport is deliberately per-pair first, per-class second, and never
+// one blended score: the arms answer different questions per class.
+func renderForkReport(rows []forkRow) string {
+	var b strings.Builder
+	b.WriteString("## Fork continuation report\n\n")
+	b.WriteString("| task | class | arm | rep | pass | wall | rounds | reasoning | extra blind | check@ |\n")
+	b.WriteString("|---|---|---|---|---|---|---|---|---|---|\n")
+	for _, r := range rows {
+		check := "never"
+		if r.FirstCheckRnds > 0 {
+			check = fmt.Sprint(r.FirstCheckRnds)
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %d | %v | %s | %d | %s | %d | %s |\n",
+			r.Task, r.Class, r.Arm, r.Rep, r.Passed, dur(r.WallMs), r.Rounds,
+			comma(int(r.ReasoningTok)), r.ExtraBlind, check)
+	}
+	type agg struct {
+		n, pass, checks, extraBlind int
+		wall, reasoning             int64
+	}
+	byClassArm := map[string]*agg{}
+	for _, r := range rows {
+		key := r.Class + "/" + r.Arm
+		a := byClassArm[key]
+		if a == nil {
+			a = &agg{}
+			byClassArm[key] = a
+		}
+		a.n++
+		if r.Passed {
+			a.pass++
+		}
+		if r.FirstCheckRnds > 0 {
+			a.checks++
+		}
+		a.extraBlind += r.ExtraBlind
+		a.wall += r.WallMs
+		a.reasoning += r.ReasoningTok
+	}
+	keys := make([]string, 0, len(byClassArm))
+	for k := range byClassArm {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	b.WriteString("\n| class/arm | n | pass | checked | avg wall | avg reasoning | avg extra blind |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, k := range keys {
+		a := byClassArm[k]
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s | %s | %.1f |\n",
+			k, a.n, pct(a.pass, a.n), pct(a.checks, a.n),
+			dur(a.wall/int64(a.n)), comma(int(a.reasoning/int64(a.n))), float64(a.extraBlind)/float64(a.n))
+	}
+	return b.String()
+}

--- a/cmd/e2ebench/intervals.go
+++ b/cmd/e2ebench/intervals.go
@@ -1,0 +1,93 @@
+package main
+
+import "slices"
+
+// Interval math shared by the trajectory summarizer: wall-clock spans,
+// overlap-free unions, and subtraction for the disjoint wall decomposition.
+
+// intervalSpan returns the batch's wall clock (max end − min start) and
+// whether any two intervals actually overlapped (true parallelism).
+func intervalSpan(intervals [][2]int64) (wall int64, overlapped bool) {
+	sorted := append([][2]int64(nil), intervals...)
+	slices.SortFunc(sorted, func(a, b [2]int64) int {
+		switch {
+		case a[0] != b[0]:
+			return int(a[0] - b[0])
+		default:
+			return int(a[1] - b[1])
+		}
+	})
+	minStart, maxEnd := sorted[0][0], sorted[0][1]
+	for _, iv := range sorted[1:] {
+		if iv[0] < maxEnd {
+			overlapped = true
+		}
+		maxEnd = max(maxEnd, iv[1])
+	}
+	return maxEnd - minStart, overlapped
+}
+
+// intervalUnion is the merged length of all intervals, so concurrent tool
+// executions count wall-clock once.
+func intervalUnion(intervals [][2]int64) int64 {
+	return ivsLen(mergeIntervals(intervals))
+}
+
+// mergeIntervals returns a sorted, overlap-free copy of intervals.
+func mergeIntervals(intervals [][2]int64) [][2]int64 {
+	if len(intervals) == 0 {
+		return nil
+	}
+	sorted := append([][2]int64(nil), intervals...)
+	slices.SortFunc(sorted, func(a, b [2]int64) int {
+		switch {
+		case a[0] != b[0]:
+			return int(a[0] - b[0])
+		default:
+			return int(a[1] - b[1])
+		}
+	})
+	out := [][2]int64{sorted[0]}
+	for _, iv := range sorted[1:] {
+		if last := &out[len(out)-1]; iv[0] <= last[1] {
+			last[1] = max(last[1], iv[1])
+			continue
+		}
+		out = append(out, iv)
+	}
+	return out
+}
+
+// clipIntervals returns base minus covered; both are merged internally.
+func clipIntervals(base, covered [][2]int64) [][2]int64 {
+	base = mergeIntervals(base)
+	covered = mergeIntervals(covered)
+	var out [][2]int64
+	j := 0
+	for _, iv := range base {
+		lo := iv[0]
+		for j < len(covered) && covered[j][1] <= lo {
+			j++
+		}
+		for k := j; k < len(covered) && covered[k][0] < iv[1]; k++ {
+			if covered[k][0] > lo {
+				out = append(out, [2]int64{lo, covered[k][0]})
+			}
+			if lo = max(lo, covered[k][1]); lo >= iv[1] {
+				break
+			}
+		}
+		if lo < iv[1] {
+			out = append(out, [2]int64{lo, iv[1]})
+		}
+	}
+	return out
+}
+
+func ivsLen(intervals [][2]int64) int64 {
+	var total int64
+	for _, iv := range intervals {
+		total += iv[1] - iv[0]
+	}
+	return total
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -188,7 +188,8 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -profile delivery\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
 	}
 
-	mode := flag.String("mode", "suite", "suite | diff | swebench | compare | traj")
+	mode := flag.String("mode", "suite", "suite | diff | swebench | compare | traj | serve")
+	addr := flag.String("addr", "127.0.0.1:7480", "serve mode: live dashboard listen address")
 	subset := flag.String("subset", "benchmarks/swebench/subset.json", "swebench mode: instance subset file")
 	namespace := flag.String("namespace", "swebench", "swebench mode: registry namespace holding the evaluation images")
 	runID := flag.String("run-id", "reasonix", "swebench mode: run id passed to the official harness")
@@ -255,6 +256,12 @@ func main() {
 		return
 	case "traj":
 		emitTrajMode(*trajDir, *outMD)
+		return
+	case "serve":
+		if err := runServeMode(*trajDir, *suite, *addr); err != nil {
+			fmt.Fprintln(os.Stderr, "serve mode:", err)
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -205,6 +205,7 @@ func main() {
 	cacheArm := flag.String("cache", "cold", "suite mode: cold (fresh session per task) | warm (prefix-warming one-step run in the same workdir before the graded run)")
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
+	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge)")
 	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
 	model := flag.String("model", "", "provider/model name (default: config default)")
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
@@ -277,7 +278,7 @@ func main() {
 	runSuiteMode(suiteConfig{
 		bin: *bin, model: *model, profile: profile, arm: arm, budget: *budget,
 		trajDir: *trajDir, forcePlanner: *forcePlanner, attempts: *attempts,
-		cacheArm: cache, effort: *effort, checkpoints: *checkpoints,
+		cacheArm: cache, effort: *effort, checkpoints: *checkpoints, policy: *policyFlag,
 	}, *suite, *taskFilter, *outMD, *outJSON)
 }
 
@@ -409,6 +410,7 @@ func filterTasks(tasks []task, filter string) ([]task, error) {
 type suiteConfig struct {
 	bin, model, profile, cacheArm, effort string
 	arm                                   ablation.Set
+	policy                                string
 	trajDir                               string
 	forcePlanner, checkpoints             bool
 	attempts, budget                      int
@@ -494,6 +496,9 @@ func runTask(cfg suiteConfig, t task) result {
 
 	cmd := exec.CommandContext(ctx, cfg.bin, args...)
 	cmd.Dir = work
+	if cfg.policy == "ebm" {
+		cmd.Env = append(os.Environ(), "REASONIX_EXPERIMENT_EBM=1")
+	}
 	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
 	cmd.Stderr = os.Stderr
 	cmd.WaitDelay = 10 * time.Second // bound the wait for a stuck child after ctx timeout

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -188,7 +188,7 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "  %[1]s -profile delivery\n", strings.Replace(flag.CommandLine.Name(), "e2ebench", "go run ./cmd/e2ebench", 1))
 	}
 
-	mode := flag.String("mode", "suite", "suite | diff | swebench | compare | traj | serve")
+	mode := flag.String("mode", "suite", "suite | diff | swebench | compare | traj | serve | fork")
 	addr := flag.String("addr", "127.0.0.1:7480", "serve mode: live dashboard listen address")
 	subset := flag.String("subset", "benchmarks/swebench/subset.json", "swebench mode: instance subset file")
 	namespace := flag.String("namespace", "swebench", "swebench mode: registry namespace holding the evaluation images")
@@ -206,6 +206,10 @@ func main() {
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
 	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge)")
+	forkCapture := flag.String("fork-capture", "", "suite mode: capture a fork bundle per task at first EBM eligibility into <dir>/<task-id>")
+	bundles := flag.String("bundles", "", "fork mode: directory of captured bundles (<task-id>/bundle.json)")
+	forkArms := flag.String("arm", "control,treatment", "fork mode: comma-separated continuation arms (control | treatment)")
+	forkReps := flag.Int("reps", 1, "fork mode: continuation repetitions per bundle per arm")
 	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
 	model := flag.String("model", "", "provider/model name (default: config default)")
 	profileFlag := flag.String("profile", benchmarkProfileBaseline, "prompt profile: baseline | delivery")
@@ -264,6 +268,14 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	case "fork":
+		cfg := suiteConfig{bin: *bin, model: *model, profile: profile, arm: arm,
+			cacheArm: cache, effort: *effort, policy: *policyFlag}
+		if err := runForkMode(*bundles, *suite, *forkArms, *forkReps, cfg, *trajDir, *outMD, *outJSON); err != nil {
+			fmt.Fprintln(os.Stderr, "fork mode:", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	if *mode == "diff" {
@@ -279,6 +291,7 @@ func main() {
 		bin: *bin, model: *model, profile: profile, arm: arm, budget: *budget,
 		trajDir: *trajDir, forcePlanner: *forcePlanner, attempts: *attempts,
 		cacheArm: cache, effort: *effort, checkpoints: *checkpoints, policy: *policyFlag,
+		forkCapture: *forkCapture,
 	}, *suite, *taskFilter, *outMD, *outJSON)
 }
 
@@ -410,7 +423,7 @@ func filterTasks(tasks []task, filter string) ([]task, error) {
 type suiteConfig struct {
 	bin, model, profile, cacheArm, effort string
 	arm                                   ablation.Set
-	policy                                string
+	policy, forkCapture                   string
 	trajDir                               string
 	forcePlanner, checkpoints             bool
 	attempts, budget                      int
@@ -496,8 +509,15 @@ func runTask(cfg suiteConfig, t task) result {
 
 	cmd := exec.CommandContext(ctx, cfg.bin, args...)
 	cmd.Dir = work
-	if cfg.policy == "ebm" {
-		cmd.Env = append(os.Environ(), "REASONIX_EXPERIMENT_EBM=1")
+	if cfg.policy == "ebm" || cfg.forkCapture != "" {
+		env := os.Environ()
+		if cfg.policy == "ebm" {
+			env = append(env, "REASONIX_EXPERIMENT_EBM=1")
+		}
+		if cfg.forkCapture != "" {
+			env = append(env, "REASONIX_EXPERIMENT_FORK_CAPTURE_DIR="+filepath.Join(cfg.forkCapture, t.ID))
+		}
+		cmd.Env = env
 	}
 	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
 	cmd.Stderr = os.Stderr

--- a/cmd/e2ebench/outcome.go
+++ b/cmd/e2ebench/outcome.go
@@ -22,13 +22,34 @@ type outcomeSummary struct {
 	TTFDCMs    int64 `json:"ttfdc_ms,omitempty"`
 	DebtAgeMax int   `json:"debt_age_max,omitempty"`
 	Backfilled bool  `json:"backfilled,omitempty"`
+
+	// EBM chain: when the Evidence-Before-More-Mutation trigger held, when its
+	// nudge fired, and what followed — compliance is the mechanism-health
+	// readout that separates "nudge ignored" from "early evidence useless".
+	DebtArea            int   `json:"debt_area,omitempty"`
+	BlindPeak           int   `json:"blind_peak,omitempty"`
+	EBMEligibleRound    int   `json:"ebm_eligible_round,omitempty"`
+	EBMFiredRound       int   `json:"ebm_fired_round,omitempty"`
+	EBMBlindAtFire      int   `json:"ebm_blind_at_fire,omitempty"`
+	EBMDebtAgeAtFire    int   `json:"ebm_debt_age_at_fire,omitempty"`
+	EBMRoundsToCheck    int   `json:"ebm_rounds_to_check,omitempty"`
+	EBMMsToCheck        int64 `json:"ebm_ms_to_check,omitempty"`
+	EBMReasoningToCheck int64 `json:"ebm_reasoning_to_check,omitempty"`
+	EBMCheckWithin1     bool  `json:"ebm_check_within_1,omitempty"`
+	EBMCheckWithin2     bool  `json:"ebm_check_within_2,omitempty"`
+	// EBMExtraBlind counts mutations between the nudge and the first
+	// discriminating check: 0 = strong compliance, 1 = finishing the minimum
+	// coherent patch the copy permits, >=2 = real non-compliance.
+	EBMExtraBlind   int    `json:"ebm_extra_blind_mutations"`
+	EBMPostSequence string `json:"ebm_post_sequence,omitempty"`
 }
 
 // outcomePoint is one recorded shadow sample plus its observation time.
 type outcomePoint struct {
 	ts                                                      int64
 	exploration, verification, objective, regression, churn int
-	legacyGain, discriminating, debtAge                     int
+	legacyGain, discriminating, debtAge, blindMutations     int
+	ebmEligible, ebmFired                                   bool
 }
 
 // verifyPoint is one backfilled verification-transition observation.
@@ -65,7 +86,9 @@ func (t *trajScan) observeVerification(key string, passed bool, ts int64) {
 // to the verification backfill, which cannot price legacy-scorer claims.
 func (t *trajScan) summarizeOutcome() *outcomeSummary {
 	if len(t.outcomePoints) > 0 {
-		return summarizeOutcomePoints(t.outcomePoints, t.firstTS, t.lastTS)
+		o := summarizeOutcomePoints(t.outcomePoints, t.firstTS, t.lastTS)
+		t.attachEBMChain(o)
+		return o
 	}
 	if len(t.verifyPoints) > 0 {
 		return summarizeVerifyBackfill(t.verifyPoints, t.lastTS)
@@ -129,6 +152,60 @@ func summarizeOutcomePoints(points []outcomePoint, firstTS, lastTS int64) *outco
 	}
 	finishScore(o, score, best, bestTS, lastTS)
 	return o
+}
+
+// attachEBMChain condenses the per-round EBM shadow into the run's chain
+// facts; rounds-to-check joins the cognition digests for the tokens spent
+// between fire and first discriminating observation.
+func (t *trajScan) attachEBMChain(o *outcomeSummary) {
+	pts := t.outcomePoints
+	fire := -1
+	for i, p := range pts {
+		o.DebtArea += p.debtAge
+		o.BlindPeak = max(o.BlindPeak, p.blindMutations)
+		if o.EBMEligibleRound == 0 && p.ebmEligible {
+			o.EBMEligibleRound = i + 1
+		}
+		if fire < 0 && p.ebmFired {
+			fire = i
+		}
+	}
+	if fire < 0 {
+		return
+	}
+	o.EBMFiredRound = fire + 1
+	o.EBMBlindAtFire = pts[fire].blindMutations
+	o.EBMDebtAgeAtFire = pts[fire].debtAge
+	for j := fire + 1; j < len(pts); j++ {
+		o.EBMPostSequence += postEBMCategory(pts[j])
+		if pts[j].discriminating == 0 {
+			o.EBMExtraBlind += pts[j].churn
+			continue
+		}
+		o.EBMRoundsToCheck = j - fire
+		o.EBMMsToCheck = pts[j].ts - pts[fire].ts
+		o.EBMCheckWithin1 = j-fire <= 1
+		o.EBMCheckWithin2 = j-fire <= 2
+		for k := fire + 1; k <= j && k < len(t.s.Rounds); k++ {
+			o.EBMReasoningToCheck += t.s.Rounds[k].ReasoningTokens
+		}
+		return
+	}
+}
+
+// postEBMCategory letters the rounds after a nudge: V discriminating check,
+// M mutation, R new information, "." quiet.
+func postEBMCategory(p outcomePoint) string {
+	switch {
+	case p.discriminating > 0:
+		return "V"
+	case p.churn > 0:
+		return "M"
+	case p.exploration > 0:
+		return "R"
+	default:
+		return "."
+	}
 }
 
 func summarizeVerifyBackfill(points []verifyPoint, lastTS int64) *outcomeSummary {
@@ -209,6 +286,35 @@ func renderOutcomeProgress(results []result) string {
 	}
 	if debtMax > 0 {
 		line += fmt.Sprintf(" · **verification debt max** %d rounds", debtMax)
+	}
+	elig, fired, comply := 0, 0, 0
+	var toCheck []int64
+	for _, r := range results {
+		if r.Trajectory == nil || r.Trajectory.Outcome == nil {
+			continue
+		}
+		o := r.Trajectory.Outcome
+		if o.EBMEligibleRound > 0 {
+			elig++
+		}
+		if o.EBMFiredRound > 0 {
+			fired++
+			// Compliance judges behavior, not speed: at most one mutation
+			// between nudge and check — the coherent-patch allowance.
+			if o.EBMRoundsToCheck > 0 && o.EBMExtraBlind <= 1 {
+				comply++
+			}
+			if o.EBMRoundsToCheck > 0 {
+				toCheck = append(toCheck, int64(o.EBMRoundsToCheck))
+			}
+		}
+	}
+	if elig > 0 {
+		line += fmt.Sprintf(" · **EBM** eligible %d · fired %d", elig, fired)
+		if fired > 0 {
+			line += fmt.Sprintf(" (compliance ≤1 extra mutation %s, median rounds-to-check %d)",
+				pct(comply, fired), median(toCheck))
+		}
 	}
 	if progress > 0 {
 		line += fmt.Sprintf(" · **false progress** %d/%d (%s)", falseProgress, progress, pct(falseProgress, progress))

--- a/cmd/e2ebench/outcome.go
+++ b/cmd/e2ebench/outcome.go
@@ -17,14 +17,18 @@ type outcomeSummary struct {
 	FinalScore          int   `json:"final_score"`
 	RegressedFromBest   bool  `json:"regressed_from_best,omitempty"`
 	SearchRegretMs      int64 `json:"search_regret_ms,omitempty"`
-	Backfilled          bool  `json:"backfilled,omitempty"`
+	// TTFDCMs is run start to the first discriminating observation (zero =
+	// never); DebtAgeMax the worst stretch of rounds with an unverified mutation.
+	TTFDCMs    int64 `json:"ttfdc_ms,omitempty"`
+	DebtAgeMax int   `json:"debt_age_max,omitempty"`
+	Backfilled bool  `json:"backfilled,omitempty"`
 }
 
 // outcomePoint is one recorded shadow sample plus its observation time.
 type outcomePoint struct {
 	ts                                                      int64
 	exploration, verification, objective, regression, churn int
-	legacyGain                                              int
+	legacyGain, discriminating, debtAge                     int
 }
 
 // verifyPoint is one backfilled verification-transition observation.
@@ -61,7 +65,7 @@ func (t *trajScan) observeVerification(key string, passed bool, ts int64) {
 // to the verification backfill, which cannot price legacy-scorer claims.
 func (t *trajScan) summarizeOutcome() *outcomeSummary {
 	if len(t.outcomePoints) > 0 {
-		return summarizeOutcomePoints(t.outcomePoints, t.lastTS)
+		return summarizeOutcomePoints(t.outcomePoints, t.firstTS, t.lastTS)
 	}
 	if len(t.verifyPoints) > 0 {
 		return summarizeVerifyBackfill(t.verifyPoints, t.lastTS)
@@ -69,7 +73,7 @@ func (t *trajScan) summarizeOutcome() *outcomeSummary {
 	return nil
 }
 
-func summarizeOutcomePoints(points []outcomePoint, lastTS int64) *outcomeSummary {
+func summarizeOutcomePoints(points []outcomePoint, firstTS, lastTS int64) *outcomeSummary {
 	o := &outcomeSummary{Rounds: len(points)}
 	verifying, solution, stall := false, false, 0
 	score, best := 0, 0
@@ -78,6 +82,10 @@ func summarizeOutcomePoints(points []outcomePoint, lastTS int64) *outcomeSummary
 		if p.verification > 0 {
 			verifying = true
 		}
+		if p.discriminating > 0 && o.TTFDCMs == 0 && p.ts > firstTS {
+			o.TTFDCMs = p.ts - firstTS
+		}
+		o.DebtAgeMax = max(o.DebtAgeMax, p.debtAge)
 		o.Objective += p.objective
 		o.Regression += p.regression
 		if p.legacyGain > 0 {
@@ -180,8 +188,28 @@ func renderOutcomeProgress(results []result) string {
 	if runs == 0 {
 		return ""
 	}
+	discRuns, debtMax := 0, 0
+	var ttfdcs []int64
+	for _, r := range results {
+		if r.Trajectory == nil || r.Trajectory.Outcome == nil {
+			continue
+		}
+		o := r.Trajectory.Outcome
+		debtMax = max(debtMax, o.DebtAgeMax)
+		if o.TTFDCMs > 0 {
+			discRuns++
+			ttfdcs = append(ttfdcs, o.TTFDCMs)
+		}
+	}
 	line := fmt.Sprintf("**Outcome shadow** (%d runs): **objective transitions** %d · **regressions** %d · **regressed from best** %d (%s)",
 		runs, objective, regression, regressed, pct(regressed, runs))
+	if discRuns > 0 {
+		line += fmt.Sprintf(" · **discriminating checks** in %d/%d runs (TTFDC p50 %s)",
+			discRuns, runs, dur(median(ttfdcs)))
+	}
+	if debtMax > 0 {
+		line += fmt.Sprintf(" · **verification debt max** %d rounds", debtMax)
+	}
 	if progress > 0 {
 		line += fmt.Sprintf(" · **false progress** %d/%d (%s)", falseProgress, progress, pct(falseProgress, progress))
 	}

--- a/cmd/e2ebench/outcome_test.go
+++ b/cmd/e2ebench/outcome_test.go
@@ -126,6 +126,42 @@ func TestSummarizeOutcomeTracksDebtAndTTFDC(t *testing.T) {
 	}
 }
 
+func TestSummarizeOutcomeDerivesEBMChain(t *testing.T) {
+	path := writeTrajectory(t, "ebm.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"outcome_progress":{"round":1,"churn":2,"debt_age":1,"blind_mutations":2}}`,
+		`{"seq":3,"ts":3000,"outcome_progress":{"round":2,"churn":1,"debt_age":2,"blind_mutations":3,"ebm_eligible":true,"ebm_fired":true}}`,
+		`{"seq":4,"ts":4000,"outcome_progress":{"round":3,"exploration":1,"debt_age":3,"blind_mutations":3}}`,
+		`{"seq":5,"ts":9000,"outcome_progress":{"round":4,"discriminating":1,"verification":1}}`,
+		`{"seq":6,"ts":10000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	o := s.Outcome
+	if o == nil || o.EBMFiredRound != 2 || o.EBMEligibleRound != 2 {
+		t.Fatalf("outcome = %+v, want EBM fired/eligible at round 2", o)
+	}
+	if o.EBMBlindAtFire != 3 || o.EBMDebtAgeAtFire != 2 {
+		t.Errorf("at-fire = blind %d debt %d, want 3/2", o.EBMBlindAtFire, o.EBMDebtAgeAtFire)
+	}
+	if o.EBMRoundsToCheck != 2 || o.EBMMsToCheck != 6000 || o.EBMCheckWithin1 || !o.EBMCheckWithin2 {
+		t.Errorf("chain = rounds %d ms %d w1 %v w2 %v, want 2/6000/false/true",
+			o.EBMRoundsToCheck, o.EBMMsToCheck, o.EBMCheckWithin1, o.EBMCheckWithin2)
+	}
+	if o.DebtArea != 6 || o.BlindPeak != 3 {
+		t.Errorf("debt area %d blind peak %d, want 6/3", o.DebtArea, o.BlindPeak)
+	}
+	if o.EBMPostSequence != "RV" || o.EBMExtraBlind != 0 {
+		t.Errorf("post sequence %q extra %d, want RV/0", o.EBMPostSequence, o.EBMExtraBlind)
+	}
+	got := renderOutcomeProgress([]result{{Trajectory: s}})
+	if !strings.Contains(got, "**EBM** eligible 1 · fired 1 (compliance ≤1 extra mutation 100%, median rounds-to-check 2)") {
+		t.Errorf("render missing EBM segment:\n%s", got)
+	}
+}
+
 func TestRenderOutcomeProgressAggregatesRuns(t *testing.T) {
 	results := []result{
 		{Trajectory: &trajectorySummary{Outcome: &outcomeSummary{

--- a/cmd/e2ebench/outcome_test.go
+++ b/cmd/e2ebench/outcome_test.go
@@ -98,6 +98,34 @@ func TestSummarizeOutcomeBackfillsFromVerificationReceipts(t *testing.T) {
 	}
 }
 
+func TestSummarizeOutcomeTracksDebtAndTTFDC(t *testing.T) {
+	path := writeTrajectory(t, "debt.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"outcome_progress":{"round":1,"churn":1,"legacy_gain":3,"debt_age":1}}`,
+		`{"seq":3,"ts":3000,"outcome_progress":{"round":2,"exploration":1,"legacy_gain":1,"debt_age":2}}`,
+		`{"seq":4,"ts":4000,"outcome_progress":{"round":3,"churn":1,"legacy_gain":3,"debt_age":3}}`,
+		`{"seq":5,"ts":9000,"outcome_progress":{"round":4,"discriminating":1,"verification":1}}`,
+		`{"seq":6,"ts":10000,"event":{"kind":"turn_done"}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	o := s.Outcome
+	if o == nil || o.DebtAgeMax != 3 {
+		t.Fatalf("outcome = %+v, want debt age max 3", o)
+	}
+	if o.TTFDCMs != 8000 {
+		t.Fatalf("TTFDC = %d, want 8000 (run start 1000 → first discriminating 9000)", o.TTFDCMs)
+	}
+	got := renderOutcomeProgress([]result{{Trajectory: s}})
+	for _, want := range []string{"**discriminating checks** in 1/1 runs (TTFDC p50 8.0s)", "**verification debt max** 3 rounds"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderOutcomeProgressAggregatesRuns(t *testing.T) {
 	results := []result{
 		{Trajectory: &trajectorySummary{Outcome: &outcomeSummary{

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -195,6 +195,7 @@ func renderBody(results []result) string {
 	b.WriteString(renderContractShadow(results))
 	b.WriteString(renderOutcomeProgress(results))
 	b.WriteString(renderCognition(results))
+	b.WriteString(renderDelegationAdmission(results))
 	b.WriteString(renderMechanismLedger(results))
 	if s.unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -194,6 +194,7 @@ func renderBody(results []result) string {
 	b.WriteString(renderToolSurface(results))
 	b.WriteString(renderContractShadow(results))
 	b.WriteString(renderOutcomeProgress(results))
+	b.WriteString(renderCognition(results))
 	b.WriteString(renderMechanismLedger(results))
 	if s.unaccounted > 0 {
 		fmt.Fprintf(&b, "> **Accounting incomplete for %d of %d instances** (%d of them solved): the agent was killed before it wrote any metrics, so their cost and tokens are unknown. Totals above cover the %d accounted instances only, and per-solved figures divide by the %d accounted solves — the true totals are higher.\n\n",

--- a/cmd/e2ebench/rounds.go
+++ b/cmd/e2ebench/rounds.go
@@ -90,6 +90,9 @@ type trajScan struct {
 	verifyPoints           []verifyPoint
 
 	gapReason, gapCompl, gapPrompt int64
+
+	denyDelegations  map[string]bool
+	delegationToolMs map[string]int64
 }
 
 // modelAttempt is one sampling attempt's wall interval; planner marks attempts

--- a/cmd/e2ebench/rounds.go
+++ b/cmd/e2ebench/rounds.go
@@ -88,6 +88,8 @@ type trajScan struct {
 	outcomePoints          []outcomePoint
 	verifySeen, verifyPass map[string]bool
 	verifyPoints           []verifyPoint
+
+	gapReason, gapCompl, gapPrompt int64
 }
 
 // modelAttempt is one sampling attempt's wall interval; planner marks attempts
@@ -101,6 +103,13 @@ type modelAttempt struct {
 // is the wasted/questionable bucket the report itemizes.
 var productiveOutcomes = map[string]bool{
 	"evidence_gain": true, "mutation": true, "verification": true, "finalization": true,
+	"delegation": true,
+}
+
+// delegationTools are calls whose cost story is the delegation itself, not the
+// local mutation/verification the batch would otherwise classify as.
+var delegationTools = map[string]bool{
+	"task": true, "parallel_tasks": true, "fleet": true, "research": true,
 }
 
 // bookkeepingTools are ledger tools whose rounds cost a full round-trip
@@ -127,11 +136,14 @@ func classifyRound(gap gapInfo, b *toolBatch) string {
 	if b == nil {
 		return "finalization"
 	}
-	verification, mutation := false, false
+	verification, mutation, delegation := false, false, false
 	allBookkeeping, allDup := true, true
 	for _, c := range b.infos {
 		if c.verification == "passed" || c.verification == "failed" {
 			verification = true
+		}
+		if delegationTools[c.name] {
+			delegation = true
 		}
 		if c.resolved && !c.readOnly && !c.errored && !bookkeepingTools[c.name] {
 			mutation = true
@@ -144,6 +156,8 @@ func classifyRound(gap gapInfo, b *toolBatch) string {
 		}
 	}
 	switch {
+	case delegation:
+		return "delegation"
 	case verification:
 		return "verification"
 	case mutation:

--- a/cmd/e2ebench/serve.go
+++ b/cmd/e2ebench/serve.go
@@ -34,7 +34,7 @@ type serveTask struct {
 }
 
 type serveRound struct {
-	Ts           int64 `json:"t,omitempty"`
+	TS           int64 `json:"t,omitempty"`
 	Exploration  int   `json:"e,omitempty"`
 	Verification int   `json:"v,omitempty"`
 	Objective    int   `json:"o,omitempty"`
@@ -103,7 +103,7 @@ func collectServeState(dir string) (*serveState, error) {
 		}
 		for _, p := range scan.outcomePoints {
 			t.Rounds = append(t.Rounds, serveRound{
-				Ts:          p.ts,
+				TS:          p.ts,
 				Exploration: p.exploration, Verification: p.verification,
 				Objective: p.objective, Regression: p.regression,
 				Churn: p.churn, Legacy: p.legacyGain,

--- a/cmd/e2ebench/serve.go
+++ b/cmd/e2ebench/serve.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// serveState is one /api/state response: the per-task live digest the
+// dashboard polls while a bench run is still writing trajectories.
+type serveState struct {
+	Dir   string      `json:"dir"`
+	Now   int64       `json:"now"`
+	Suite []string    `json:"suite,omitempty"`
+	Tasks []serveTask `json:"tasks"`
+}
+
+type serveTask struct {
+	ID          string          `json:"id"`
+	Records     int             `json:"records"`
+	SpanMs      int64           `json:"span_ms"`
+	ModelRounds int             `json:"model_rounds"`
+	ToolMs      int64           `json:"tool_ms"`
+	AgoMs       int64           `json:"ago_ms"`
+	NoProgress  int             `json:"no_progress"`
+	Outcome     *outcomeSummary `json:"outcome,omitempty"`
+	Rounds      []serveRound    `json:"rounds"`
+}
+
+type serveRound struct {
+	Ts           int64 `json:"t,omitempty"`
+	Exploration  int   `json:"e,omitempty"`
+	Verification int   `json:"v,omitempty"`
+	Objective    int   `json:"o,omitempty"`
+	Regression   int   `json:"r,omitempty"`
+	Churn        int   `json:"c,omitempty"`
+	Legacy       int   `json:"g,omitempty"`
+}
+
+func runServeMode(dir, suite, addr string) error {
+	if dir == "" {
+		return fmt.Errorf("serve mode needs -trajectories <dir>")
+	}
+	var suiteIDs []string
+	if tasks, err := loadTasks(suite); err == nil {
+		for _, t := range tasks {
+			suiteIDs = append(suiteIDs, t.ID)
+		}
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/state", func(w http.ResponseWriter, _ *http.Request) {
+		state, err := collectServeState(dir)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		state.Suite = suiteIDs
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(state)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, serveHTML)
+	})
+	fmt.Printf("e2ebench live dashboard: http://%s (watching %s)\n", addr, dir)
+	return http.ListenAndServe(addr, mux)
+}
+
+// collectServeState re-summarizes every trajectory on each poll. Files are
+// small and flushed per record, so live reads see every completed line.
+func collectServeState(dir string) (*serveState, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.trajectory.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	state := &serveState{Dir: dir, Now: time.Now().UnixMilli(), Tasks: []serveTask{}}
+	for _, path := range paths {
+		scan, err := scanTrajectoryFile(path)
+		if err != nil {
+			continue
+		}
+		s := scan.finish()
+		t := serveTask{
+			ID:          strings.TrimSuffix(filepath.Base(path), ".trajectory.jsonl"),
+			Records:     s.Records,
+			SpanMs:      s.SpanMs,
+			ModelRounds: s.ModelRounds,
+			ToolMs:      s.toolWall(),
+			AgoMs:       -1,
+			NoProgress:  s.NoProgressSignals,
+			Outcome:     s.Outcome,
+			Rounds:      make([]serveRound, 0, len(scan.outcomePoints)),
+		}
+		if fi, err := os.Stat(path); err == nil {
+			t.AgoMs = time.Since(fi.ModTime()).Milliseconds()
+		}
+		for _, p := range scan.outcomePoints {
+			t.Rounds = append(t.Rounds, serveRound{
+				Ts:          p.ts,
+				Exploration: p.exploration, Verification: p.verification,
+				Objective: p.objective, Regression: p.regression,
+				Churn: p.churn, Legacy: p.legacyGain,
+			})
+		}
+		state.Tasks = append(state.Tasks, t)
+	}
+	return state, nil
+}

--- a/cmd/e2ebench/serve_html.go
+++ b/cmd/e2ebench/serve_html.go
@@ -1,0 +1,538 @@
+package main
+
+// The dashboard page: dark flight-recorder instrument panel, all-monospace
+// type, recessed trace screens. The renderer is incremental (keyed DOM,
+// in-place updates) so cells animate, numbers tween, and hover survives
+// polling; a replay engine scrubs the run by wall-clock timestamp. Win/break
+// polarity is carried by geometry, never by the green/red pair alone.
+const serveHTML = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#0d0d0d">
+<title>e2ebench · live</title>
+<style>
+:root {
+  color-scheme: dark;
+  --page: #0d0d0d; --panel: #1a1a19; --screen: #141413;
+  --ink: #f2f1ec; --ink-2: #c3c2b7; --muted: #898781; --faint: #55544f;
+  --hairline: rgba(255,255,255,0.08); --tick: rgba(255,255,255,0.05);
+  --grid: #2c2c2a;
+  --explore: #3987e5; --attempt: #d95926;
+  --win: #0ca30c; --break: #d03b3b;
+  --accent: #86b6ef;
+}
+* { box-sizing: border-box; margin: 0; }
+html { background: var(--page); scroll-behavior: smooth; }
+body { color: var(--ink);
+  font: 13px/1.55 ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+  padding: 34px clamp(18px, 4.5vw, 56px) 80px; max-width: 1280px; margin: 0 auto;
+  font-variant-numeric: tabular-nums; }
+section, .rule, header, #runseg, #deck, #cluster { animation: rise .5s ease-out backwards; }
+#runseg { animation-delay: .05s; } #deck { animation-delay: .1s; }
+#cluster { animation-delay: .15s; }
+@keyframes rise { from { opacity: 0; transform: translateY(8px); } }
+
+.rule { border: 0; border-top: 1px solid var(--hairline); margin: 40px 0 0; }
+.eyebrow { font-size: 10px; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--muted); margin: 10px 0 14px; }
+.eyebrow b { color: var(--ink-2); font-weight: 600; }
+.caption { color: var(--muted); font-size: 12px; max-width: 72ch; margin: -6px 0 18px; }
+.caption b { color: var(--ink-2); font-weight: 600; }
+
+header { display: flex; align-items: baseline; }
+.wordmark { font-size: 13px; font-weight: 700; letter-spacing: 0.08em; }
+.wordmark em { font-style: normal; color: var(--accent); }
+.wordmark span { color: var(--muted); font-weight: 400; }
+#clock { margin-left: auto; color: var(--muted); font-size: 12px; }
+
+#runseg { display: flex; gap: 3px; margin-top: 22px; }
+#runseg i { flex: 1 1 0; max-width: 22px; height: 14px; border-radius: 2px;
+  background: var(--grid); cursor: pointer;
+  transition: background .3s, box-shadow .3s, transform .12s; }
+#runseg i:hover { transform: translateY(-2px); }
+#runseg i.done { background: var(--accent); opacity: 0.85; }
+#runseg i.live { background: var(--attempt);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--attempt) 55%, transparent);
+  animation: pulse 1.1s ease-in-out infinite; }
+
+#deck { display: flex; align-items: center; gap: 14px; margin-top: 16px;
+  padding: 10px 14px; background: var(--panel); border: 1px solid var(--hairline);
+  border-radius: 10px; }
+#deck button, #deck select { font: inherit; color: var(--ink-2); background: transparent;
+  border: 1px solid var(--hairline); border-radius: 6px; padding: 4px 12px;
+  cursor: pointer; transition: color .15s, border-color .15s, background .15s; }
+#deck button:hover { color: var(--ink); border-color: var(--muted); }
+#deck button.hot { color: var(--attempt); border-color: var(--attempt); }
+#ptime { color: var(--muted); font-size: 12px; min-width: 15ch; }
+#scrub { flex: 1 1 auto; -webkit-appearance: none; appearance: none; height: 4px;
+  background: var(--grid); border-radius: 2px; cursor: pointer; }
+#scrub::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px;
+  border-radius: 50%; background: var(--ink-2); border: 2px solid var(--page);
+  transition: transform .12s; }
+#scrub::-webkit-slider-thumb:hover { transform: scale(1.25); }
+
+#cluster { display: flex; gap: 48px; margin-top: 20px; flex-wrap: wrap; }
+.gauge b { display: block; font-size: 30px; font-weight: 300; letter-spacing: -0.01em;
+  line-height: 1.1; }
+.gauge b small { font-size: 15px; color: var(--muted); font-weight: 300; }
+.gauge span { display: block; font-size: 10px; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--muted); margin-top: 5px; }
+
+#now { display: flex; gap: 36px; align-items: stretch; min-height: 118px; }
+#now .main { flex: 1 1 auto; min-width: 0; }
+#now .head { display: flex; align-items: baseline; gap: 16px; }
+#now .name { font-size: 17px; font-weight: 700; letter-spacing: 0.02em; cursor: pointer; }
+#now .name:hover { color: var(--accent); }
+#now .rec { color: var(--attempt); font-size: 11px; letter-spacing: 0.2em;
+  animation: pulse 1.1s ease-in-out infinite; }
+#now .doing { color: var(--ink-2); font-size: 12px; transition: color .3s; }
+#now .side { display: flex; flex-direction: column; gap: 14px; padding-left: 32px;
+  border-left: 1px solid var(--hairline); }
+#now .side .gauge b { font-size: 22px; }
+#now.idle { color: var(--muted); font-size: 12px; display: block; min-height: 0; }
+
+.screen { background: var(--screen); border: 1px solid var(--hairline);
+  border-radius: 8px; padding: 0 12px; margin-top: 14px; position: relative;
+  background-image: repeating-linear-gradient(90deg, var(--tick) 0 1px, transparent 1px 75px);
+  background-origin: content-box; transition: border-color .3s, box-shadow .3s; }
+.trace { display: flex; align-items: center; height: 56px; position: relative; }
+.trace::before { content: ""; position: absolute; left: 0; right: 0; top: 50%;
+  border-top: 1px solid var(--grid); }
+.cells { display: flex; align-items: center; height: 100%; overflow-x: auto; flex: 1; }
+.cell { flex: 0 0 12px; height: 12px; border-radius: 2px; margin-right: 3px;
+  background: var(--grid); align-self: center; position: relative;
+  transition: transform .12s; }
+.cell:hover { transform: scale(1.4); z-index: 2; }
+.cell.e { background: var(--explore); }
+.cell.a { background: var(--attempt); }
+.cell.o { background: var(--win); height: 44px; align-self: flex-start;
+  border-radius: 3px 3px 0 0;
+  box-shadow: 0 0 12px color-mix(in srgb, var(--win) 50%, transparent); }
+.cell.r { background: var(--break); height: 44px; align-self: flex-end;
+  border-radius: 0 0 3px 3px;
+  box-shadow: 0 0 12px color-mix(in srgb, var(--break) 50%, transparent); }
+.cell.new { animation: pop .3s cubic-bezier(.2,.9,.3,1.35); }
+.cell.o.new, .cell.r.new { animation: pop .3s cubic-bezier(.2,.9,.3,1.35),
+  flare .9s ease-out; }
+@keyframes pop { from { transform: scale(.2); opacity: 0; } }
+@keyframes flare { 0% { box-shadow: 0 0 2px 8px color-mix(in srgb, currentColor 40%, transparent); }
+  100% { } }
+.cell.cursor { background: transparent; border: 1px dashed var(--muted);
+  animation: pulse 1.1s ease-in-out infinite; flex: none; }
+.mini .cell { flex-basis: 7px; height: 7px; margin-right: 2px; border-radius: 1.5px; }
+.mini .cell.o, .mini .cell.r { height: 21px; box-shadow: none; }
+.mini.trace { height: 30px; }
+
+#kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.kpi { padding: 4px 28px 6px 0; }
+.kpi + .kpi { border-left: 1px solid var(--hairline); padding-left: 28px; }
+.kpi b { font-size: 38px; font-weight: 300; line-height: 1.05; letter-spacing: -0.01em;
+  transition: color .3s; }
+.kpi b small { font-size: 14px; color: var(--muted); font-weight: 400; }
+.kpi.win b { color: var(--win); text-shadow: 0 0 18px color-mix(in srgb, var(--win) 35%, transparent); }
+.kpi.break b { color: var(--break); }
+.kpi.zero b { color: var(--faint); text-shadow: none; }
+.kpi .label { font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase;
+  color: var(--ink-2); margin-top: 8px; }
+.kpi .why { color: var(--muted); font-size: 11.5px; margin-top: 6px; line-height: 1.5;
+  font-family: system-ui, sans-serif; }
+.kpi .bar { height: 3px; background: var(--grid); margin-top: 12px; border-radius: 2px;
+  overflow: hidden; }
+.kpi .bar i { display: block; height: 100%; background: var(--attempt);
+  transition: width .6s ease; }
+
+#legend { display: flex; flex-wrap: wrap; gap: 10px 30px; }
+#legend span { display: inline-flex; align-items: center; gap: 9px; font-size: 12px;
+  color: var(--ink-2); }
+#legend i { width: 10px; height: 10px; border-radius: 2px; flex: none; }
+#legend .up, #legend .down { height: 26px; }
+#legend .up i { height: 20px; border-radius: 3px 3px 0 0; align-self: flex-start; }
+#legend .down i { height: 20px; border-radius: 0 0 3px 3px; align-self: flex-end; }
+
+#wall { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 26px 30px; }
+.task { transition: opacity .4s; }
+.task .top { display: flex; align-items: baseline; gap: 8px; }
+.task .name { font-size: 12px; font-weight: 700; letter-spacing: 0.02em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.task .badges { margin-left: auto; display: flex; gap: 8px; font-size: 11px; flex: none; }
+.badge.win { color: var(--win); } .badge.break { color: var(--break); }
+.badge.guard { color: var(--attempt); }
+.task .screen { margin-top: 8px; padding: 0 8px;
+  background-image: repeating-linear-gradient(90deg, var(--tick) 0 1px, transparent 1px 45px); }
+.task:hover .screen { border-color: var(--muted); }
+.task.live .screen { border-color: var(--attempt);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--attempt) 25%, transparent); }
+.task.flash .screen { animation: flashring 1.2s ease-out; }
+@keyframes flashring { 0% { border-color: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 45%, transparent); } }
+.task .meta { color: var(--muted); font-size: 11px; margin-top: 7px; }
+.task .meta b { color: var(--ink-2); font-weight: 600; }
+.task.queued { opacity: .55; }
+.task.queued .name { color: var(--faint); font-weight: 400; }
+.task.queued .screen { border-style: dashed; background-image: none; }
+.qnote { color: var(--faint); font-size: 11px; letter-spacing: 0.18em;
+  text-transform: uppercase; margin: auto; }
+
+#tip { position: fixed; z-index: 10; pointer-events: none; background: var(--panel);
+  border: 1px solid var(--hairline); border-radius: 8px; padding: 8px 12px;
+  font-size: 12px; color: var(--ink-2); max-width: 320px; line-height: 1.5;
+  box-shadow: 0 8px 30px rgba(0,0,0,.5); opacity: 0; transform: translateY(4px) scale(.97);
+  transition: opacity .15s, transform .15s; }
+#tip.on { opacity: 1; transform: none; }
+#tip b { color: var(--ink); }
+
+@keyframes pulse { 50% { opacity: 0.3; } }
+@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; }
+  html { scroll-behavior: auto; } }
+</style></head>
+<body>
+<header>
+  <div class="wordmark"><em>reasonix</em> e2ebench <span>· flight recorder</span></div>
+  <span id="clock"></span>
+</header>
+<div id="runseg"></div>
+<div id="deck">
+  <button id="play" title="replay the run from its trajectories">▶ replay</button>
+  <input id="scrub" type="range" min="0" max="1000" value="1000">
+  <span id="ptime"></span>
+  <select id="speed"><option value="30">30×</option><option value="120" selected>120×</option><option value="600">600×</option></select>
+  <button id="golive">● live</button>
+</div>
+<div id="cluster"></div>
+
+<hr class="rule"><div class="eyebrow">now running</div>
+<div id="now" class="idle">waiting for the first task…</div>
+
+<hr class="rule"><div class="eyebrow">shadow scorer verdicts</div>
+<p class="caption">A second scorer watches every tool round and only credits <b>verified</b> progress — a recognized check going from fail to pass. Everything else is motion.</p>
+<section id="kpis"></section>
+
+<hr class="rule"><div class="eyebrow">how to read a trace</div>
+<div id="legend">
+  <span><i style="background:var(--grid)"></i>quiet — nothing new</span>
+  <span><i style="background:var(--explore)"></i>exploring — new files or commands</span>
+  <span><i style="background:var(--attempt)"></i>working — edits or checks, unverified</span>
+  <span class="up"><i style="background:var(--win)"></i>verified win — failing check turned green</span>
+  <span class="down"><i style="background:var(--break)"></i>broke something — passing check failed</span>
+</div>
+
+<hr class="rule"><div class="eyebrow" id="walllabel">all tasks</div>
+<section id="wall"></section>
+<div id="tip"></div>
+
+<script>
+"use strict";
+var $ = function (id) { return document.getElementById(id); };
+var LIVE_MS = 15000;
+var state = null, fetchedAt = 0, suite = [], byID = {};
+var segs = {}, cards = {};
+var R = { on: false, playing: false, t: 0, speed: 120, t0: 0, t1: 0, last: 0 };
+var nowShown = null;
+
+function fmtDur(ms) {
+  if (!ms || ms < 0) return "0s";
+  if (ms < 90000) return (ms / 1000).toFixed(0) + "s";
+  return Math.floor(ms / 60000) + "m" + String(Math.round((ms % 60000) / 1000)).padStart(2, "0") + "s";
+}
+function fmtOff(ms) {
+  var s = Math.max(0, Math.round(ms / 1000));
+  return "T+" + String(Math.floor(s / 60)).padStart(2, "0") + ":" + String(s % 60).padStart(2, "0");
+}
+function catOf(r) { return r.r ? "r" : r.o ? "o" : (r.c || r.v) ? "a" : r.e ? "e" : ""; }
+function nameOf(r) {
+  return r.r ? "broke something" : r.o ? "verified win" :
+    (r.c || r.v) ? "working" : r.e ? "exploring" : "quiet";
+}
+function tipOf(i, r) {
+  var p = [];
+  if (r.o) p.push(r.o + " check(s) turned green");
+  if (r.r) p.push(r.r + " check(s) broke");
+  if (r.v) p.push(r.v + " check runs");
+  if (r.c) p.push(r.c + " edits");
+  if (r.e) p.push(r.e + " new files/commands");
+  if (!p.length) p.push("repeat of earlier work");
+  return "<b>round " + (i + 1) + " — " + nameOf(r) + "</b><br>" + p.join(", ");
+}
+function cellNode(i, r, animate) {
+  var d = document.createElement("div");
+  d.className = "cell " + catOf(r) + (animate ? " new" : "");
+  d.dataset.tip = tipOf(i, r);
+  return d;
+}
+function countVis(rounds, cut) {
+  var n = 0;
+  while (n < rounds.length && (rounds[n].t || 0) <= cut) n++;
+  return n;
+}
+function goTo(id) {
+  var c = cards[id];
+  if (!c) return;
+  c.el.scrollIntoView({ behavior: "smooth", block: "center" });
+  c.el.classList.remove("flash");
+  void c.el.offsetWidth;
+  c.el.classList.add("flash");
+}
+
+function ensure() {
+  suite.forEach(function (id) {
+    if (!segs[id]) {
+      var i = document.createElement("i");
+      i.dataset.tip = "<b>" + id + "</b><br>click to jump to its card";
+      i.addEventListener("click", function () { goTo(id); });
+      $("runseg").appendChild(i);
+      segs[id] = i;
+    }
+    if (!cards[id]) {
+      var el = document.createElement("div");
+      el.className = "task queued";
+      el.innerHTML = '<div class="top"><span class="name">' + id +
+        '</span><div class="badges"></div></div>' +
+        '<div class="screen"><div class="trace mini"><div class="cells"></div>' +
+        '<span class="qnote">queued</span></div></div><div class="meta"></div>';
+      $("wall").appendChild(el);
+      cards[id] = { el: el, cells: el.querySelector(".cells"), badges: el.querySelector(".badges"),
+        meta: el.querySelector(".meta"), qnote: el.querySelector(".qnote"), built: 0, queued: true };
+    }
+  });
+}
+
+function updateCard(id, t, cut, liveNow) {
+  var c = cards[id];
+  var rounds = t ? t.rounds : [];
+  var vis = t ? (cut === Infinity ? rounds.length : countVis(rounds, cut)) : 0;
+  if (!t || vis === 0) {
+    c.el.classList.add("queued"); c.el.classList.remove("live");
+    c.qnote.style.display = ""; c.cells.innerHTML = ""; c.built = 0;
+    c.badges.innerHTML = ""; c.meta.textContent = "";
+    return { o: 0, r: 0 };
+  }
+  c.el.classList.remove("queued");
+  c.qnote.style.display = "none";
+  if (vis < c.built) { c.cells.innerHTML = ""; c.built = 0; }
+  var animate = vis - c.built <= 12;
+  for (var i = c.built; i < vis; i++) c.cells.appendChild(cellNode(i, rounds[i], animate));
+  c.built = vis;
+  var o = 0, rg = 0;
+  for (var j = 0; j < vis; j++) { o += rounds[j].o || 0; rg += rounds[j].r || 0; }
+  c.badges.innerHTML =
+    (o ? '<span class="badge win" data-tip="verified wins">↑' + o + "</span>" : "") +
+    (rg ? '<span class="badge break" data-tip="regressions">↓' + rg + "</span>" : "") +
+    (t.no_progress ? '<span class="badge guard" data-tip="progress guard interventions">g' + t.no_progress + "</span>" : "");
+  var span = cut === Infinity ? t.span_ms
+    : Math.max(0, (rounds[vis - 1].t || 0) - ((rounds[0].t || 0)));
+  c.meta.innerHTML = "<b>" + vis + "</b> rounds · " + fmtDur(span) +
+    (liveNow ? ' · <span class="badge guard">running</span>' : "");
+  c.el.classList.toggle("live", liveNow);
+  return { o: o, r: rg };
+}
+
+function updateNow(liveIDs, cut) {
+  var el = $("now");
+  if (!liveIDs.length) {
+    nowShown = null;
+    el.className = "idle";
+    var complete = suite.length > 0 && suite.every(function (id) { return byID[id]; });
+    el.textContent = R.on ? "…" :
+      complete ? "run complete — press ▶ replay to watch it back" :
+        "between tasks — grading the last one or starting the next…";
+    return;
+  }
+  var id = liveIDs[liveIDs.length - 1];
+  var t = byID[id];
+  var rounds = t.rounds;
+  var vis = cut === Infinity ? rounds.length : countVis(rounds, cut);
+  if (nowShown !== id) {
+    nowShown = id;
+    el.className = "";
+    el.innerHTML = '<div class="main"><div class="head"><span class="rec">● rec</span>' +
+      '<span class="name" data-goto="' + id + '">' + id + "</span>" +
+      '<span class="doing"></span></div>' +
+      '<div class="screen"><div class="trace"><div class="cells"></div>' +
+      '<div class="cell cursor" data-tip="next round"></div></div></div></div>' +
+      '<div class="side"><div class="gauge"><b class="g-round"></b><span>round</span></div>' +
+      '<div class="gauge"><b class="g-elapsed"></b><span>elapsed</span></div>' +
+      '<div class="gauge"><b class="g-tools"></b><span>in tools</span></div></div>';
+    el.querySelector(".name").addEventListener("click", function () { goTo(id); });
+    el._built = 0;
+  }
+  var cells = el.querySelector(".cells");
+  if (vis < el._built) { cells.innerHTML = ""; el._built = 0; }
+  var animate = vis - el._built <= 12;
+  for (var i = el._built; i < vis; i++) cells.appendChild(cellNode(i, rounds[i], animate));
+  el._built = vis;
+  var last = rounds[vis - 1] || {};
+  el.querySelector(".doing").textContent = nameOf(last) + "…";
+  el.querySelector(".g-round").textContent = vis;
+  var elapsed = cut === Infinity
+    ? t.span_ms + (state ? Date.now() - fetchedAt : 0)
+    : Math.max(0, (last.t || 0) - (rounds[0] ? rounds[0].t || 0 : 0));
+  el.querySelector(".g-elapsed").textContent = fmtDur(elapsed);
+  el.querySelector(".g-tools").textContent = fmtDur(t.tool_ms);
+}
+
+function gauge(v, label) {
+  return '<div class="gauge"><b>' + v + "</b><span>" + label + "</span></div>";
+}
+function kpiHTML(cls, value, unit, label, why, ratio) {
+  return '<div class="kpi ' + cls + '"><b>' + value + (unit ? "<small> " + unit + "</small>" : "") +
+    '</b><div class="label">' + label + '</div><div class="why">' + why + "</div>" +
+    (ratio !== undefined ? '<div class="bar"><i style="width:' + Math.min(100, ratio) + '%"></i></div>' : "") +
+    "</div>";
+}
+
+function applyAll() {
+  if (!state) return;
+  var cut = R.on ? R.t : Infinity;
+  ensure();
+  var doneN = 0, liveIDs = [], obj = 0, reg = 0;
+  suite.forEach(function (id) {
+    var t = byID[id];
+    var liveNow = false, isDone = false;
+    if (t) {
+      if (R.on) {
+        var vis = countVis(t.rounds, cut);
+        liveNow = vis > 0 && vis < t.rounds.length;
+        isDone = t.rounds.length > 0 && vis >= t.rounds.length;
+      } else {
+        liveNow = t.ago_ms >= 0 && t.ago_ms < LIVE_MS;
+        isDone = !liveNow;
+      }
+    }
+    if (isDone) doneN++;
+    if (liveNow) liveIDs.push(id);
+    segs[id].className = liveNow ? "live" : isDone ? "done" : "";
+    var c = updateCard(id, t, cut, liveNow);
+    obj += c.o; reg += c.r;
+  });
+
+  var spans = [];
+  suite.forEach(function (id) {
+    var t = byID[id];
+    if (t && t.span_ms && (!R.on || countVis(t.rounds, cut) >= t.rounds.length)) spans.push(t.span_ms);
+  });
+  var avg = spans.length ? spans.reduce(function (a, b) { return a + b; }, 0) / spans.length : 0;
+  var left = suite.length - doneN - liveIDs.length;
+  $("cluster").innerHTML =
+    gauge(doneN + "<small> / " + suite.length + "</small>", "tasks recorded") +
+    (avg ? gauge(fmtDur(avg), "per task") : "") +
+    (R.on ? gauge(fmtOff(R.t - R.t0), "playhead") :
+      left + liveIDs.length > 0 && avg
+        ? gauge("~" + fmtDur(avg * (left + liveIDs.length * 0.5)), "time left")
+        : gauge("done", "status")) +
+    (liveIDs.length ? gauge(liveIDs.length, R.on ? "on screen" : "running now") : "") +
+    (left > 0 ? gauge(left, "queued") : "");
+
+  updateNow(liveIDs, cut);
+
+  var atEnd = !R.on || R.t >= R.t1;
+  var fp = 0, pr = 0, stall = 0, regressed = 0;
+  state.tasks.forEach(function (t) {
+    var o = t.outcome; if (!o) return;
+    fp += o.false_progress_rounds || 0; pr += o.progress_rounds || 0;
+    stall = Math.max(stall, o.solution_stall_max || 0);
+    if (o.regressed_from_best) regressed++;
+  });
+  $("kpis").innerHTML =
+    kpiHTML(obj ? "win" : "zero", obj, "", "verified wins",
+      "Rounds where a failing check turned green — the only progress the shadow scorer trusts.") +
+    kpiHTML(reg ? "break" : "zero", reg + (regressed && atEnd ? " / " + regressed : ""), "",
+      "regressions" + (regressed && atEnd ? " / peaked early" : ""),
+      "A previously passing check broke" + (regressed && atEnd ? "; some runs ended below their best state." : ".")) +
+    kpiHTML("", atEnd && pr ? Math.round(100 * fp / pr) + "%" : "–", atEnd && pr ? fp + " of " + pr : "",
+      "false progress",
+      "Rounds the current scorer counted as progress that never turned into a verified win.",
+      atEnd && pr ? 100 * fp / pr : 0) +
+    kpiHTML("", atEnd && stall ? stall : "–", atEnd && stall ? "rounds" : "", "longest stall",
+      "Most consecutive rounds of work with no verified win — where an agent burns time.");
+
+  $("walllabel").innerHTML = "all tasks · <b>" + suite.length + "</b>";
+  $("scrub").value = R.on && R.t1 > R.t0 ? Math.round(1000 * (R.t - R.t0) / (R.t1 - R.t0)) : 1000;
+  $("ptime").textContent = R.on
+    ? fmtOff(R.t - R.t0) + " / " + fmtOff(R.t1 - R.t0)
+    : "live tail";
+  $("play").textContent = R.playing ? "⏸ pause" : "▶ replay";
+  $("play").classList.toggle("hot", R.playing);
+}
+
+function bounds() {
+  var t0 = Infinity, t1 = 0;
+  state.tasks.forEach(function (t) {
+    if (t.rounds.length) {
+      t0 = Math.min(t0, t.rounds[0].t || Infinity);
+      t1 = Math.max(t1, t.rounds[t.rounds.length - 1].t || 0);
+    }
+  });
+  R.t0 = t0 === Infinity ? 0 : t0;
+  R.t1 = t1;
+}
+
+function frame(now) {
+  if (!R.playing) return;
+  var dt = R.last ? now - R.last : 16;
+  R.last = now;
+  R.t += dt * R.speed;
+  if (R.t >= R.t1) { R.t = R.t1; R.playing = false; }
+  applyAll();
+  if (R.playing) requestAnimationFrame(frame);
+}
+$("play").addEventListener("click", function () {
+  if (!state) return;
+  bounds();
+  if (R.playing) { R.playing = false; applyAll(); return; }
+  if (!R.on || R.t >= R.t1) { R.on = true; R.t = R.t0; resetBuilt(); }
+  R.playing = true; R.last = 0;
+  requestAnimationFrame(frame);
+});
+$("golive").addEventListener("click", function () {
+  R.on = false; R.playing = false; resetBuilt(); applyAll();
+});
+$("scrub").addEventListener("input", function () {
+  if (!state) return;
+  bounds();
+  R.on = true;
+  R.t = R.t0 + (R.t1 - R.t0) * (this.value / 1000);
+  applyAll();
+});
+$("speed").addEventListener("change", function () { R.speed = +this.value; });
+function resetBuilt() {
+  Object.keys(cards).forEach(function (id) { cards[id].cells.innerHTML = ""; cards[id].built = 0; });
+  nowShown = null;
+}
+
+var tip = $("tip");
+document.addEventListener("mouseover", function (e) {
+  var n = e.target.closest ? e.target.closest("[data-tip]") : null;
+  if (n) { tip.innerHTML = n.dataset.tip; tip.classList.add("on"); }
+  else tip.classList.remove("on");
+});
+document.addEventListener("mousemove", function (e) {
+  if (!tip.classList.contains("on")) return;
+  var x = Math.min(e.clientX + 14, window.innerWidth - tip.offsetWidth - 10);
+  var y = e.clientY + 16;
+  if (y + tip.offsetHeight > window.innerHeight - 8) y = e.clientY - tip.offsetHeight - 10;
+  tip.style.left = x + "px"; tip.style.top = y + "px";
+});
+
+setInterval(function () {
+  if (state && !R.on) applyAll();
+}, 1000);
+
+function tick() {
+  fetch("/api/state").then(function (r) { return r.json(); }).then(function (st) {
+    state = st; fetchedAt = Date.now();
+    byID = {};
+    st.tasks.forEach(function (t) { byID[t.id] = t; });
+    suite = st.suite && st.suite.length ? st.suite : st.tasks.map(function (t) { return t.id; });
+    $("clock").textContent = new Date(st.now).toLocaleTimeString();
+    if (!R.on) applyAll();
+    if (location.hash === "#replay" && !R.on) { location.hash = ""; $("play").click(); }
+  }).catch(function () {
+    $("clock").textContent = "poll failed — is the server still up?";
+  });
+}
+tick();
+setInterval(tick, 2000);
+</script>
+</body></html>
+`

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -144,14 +144,17 @@ type trajectoryRecord struct {
 		Complete bool   `json:"complete"`
 	} `json:"contract_shadow"`
 	OutcomeProgress *struct {
-		Exploration    int `json:"exploration"`
-		Verification   int `json:"verification"`
-		Objective      int `json:"objective"`
-		Regression     int `json:"regression"`
-		Churn          int `json:"churn"`
-		LegacyGain     int `json:"legacy_gain"`
-		Discriminating int `json:"discriminating"`
-		DebtAge        int `json:"debt_age"`
+		Exploration    int  `json:"exploration"`
+		Verification   int  `json:"verification"`
+		Objective      int  `json:"objective"`
+		Regression     int  `json:"regression"`
+		Churn          int  `json:"churn"`
+		LegacyGain     int  `json:"legacy_gain"`
+		Discriminating int  `json:"discriminating"`
+		DebtAge        int  `json:"debt_age"`
+		BlindMutations int  `json:"blind_mutations"`
+		EBMEligible    bool `json:"ebm_eligible"`
+		EBMFired       bool `json:"ebm_fired"`
 	} `json:"outcome_progress"`
 	DelegationAdmission *struct {
 		Tool    string `json:"tool"`
@@ -355,6 +358,7 @@ func (t *trajScan) record(rec trajectoryRecord) {
 			ts: rec.TS, exploration: op.Exploration, verification: op.Verification,
 			objective: op.Objective, regression: op.Regression, churn: op.Churn,
 			legacyGain: op.LegacyGain, discriminating: op.Discriminating, debtAge: op.DebtAge,
+			blindMutations: op.BlindMutations, ebmEligible: op.EBMEligible, ebmFired: op.EBMFired,
 		})
 	}
 	if da := rec.DelegationAdmission; da != nil {

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -108,6 +108,15 @@ type trajectorySummary struct {
 	// Outcome shadow: the runtime outcome scorer's per-round series condensed,
 	// or a verification-receipt backfill for recordings that predate it.
 	Outcome *outcomeSummary `json:"outcome,omitempty"`
+
+	// Cognition: executor reasoning/completion joined per model round, plus a
+	// census of slow rounds — gaps that bought unusually large thinking.
+	ReasoningTokensTotal     int64         `json:"reasoning_tokens_total,omitempty"`
+	CompletionTokensTotal    int64         `json:"completion_tokens_total,omitempty"`
+	SlowRounds               int           `json:"slow_rounds,omitempty"`
+	SlowRoundGapMs           int64         `json:"slow_round_gap_ms,omitempty"`
+	SlowRoundReasoningTokens int64         `json:"slow_round_reasoning_tokens,omitempty"`
+	Rounds                   []roundDigest `json:"rounds,omitempty"`
 }
 
 // toolWall is the best available tool wall-clock: interval union when the
@@ -147,6 +156,8 @@ type trajectoryRecord struct {
 		Usage *struct {
 			Source           string `json:"source"`
 			PromptTokens     int64  `json:"promptTokens"`
+			CompletionTokens int64  `json:"completionTokens"`
+			ReasoningTokens  int64  `json:"reasoningTokens"`
 			CacheHitTokens   int64  `json:"cacheHitTokens"`
 			CacheMissTokens  int64  `json:"cacheMissTokens"`
 			CacheDiagnostics *struct {
@@ -180,15 +191,19 @@ type roundCall struct {
 }
 
 // gapInfo carries one model gap until its batch closes and can classify it.
+// The cognition fields are the executor tokens streamed during the gap — what
+// the round's thinking actually bought.
 type gapInfo struct {
 	ms                                    int64
 	tainted, planner, compaction, handoff bool
+	reasonTok, complTok, promptTok        int64
 }
 
 // toolBatch accumulates one round's top-level calls between model gaps.
 type toolBatch struct {
 	dispatchTS map[string]int64
 	infos      map[string]*roundCall
+	names      []string
 	calls      int
 	results    int
 	readOnly   int
@@ -392,8 +407,10 @@ func (t *trajScan) closeGap(gap int64) {
 	t.pendingGaps = append(t.pendingGaps, gapInfo{
 		ms: gap, tainted: t.taint != "",
 		planner: t.gapPlanner, compaction: t.gapCompact, handoff: t.gapHandoff,
+		reasonTok: t.gapReason, complTok: t.gapCompl, promptTok: t.gapPrompt,
 	})
 	t.gapPlanner, t.gapCompact, t.gapHandoff = false, false, false
+	t.gapReason, t.gapCompl, t.gapPrompt = 0, 0, 0
 	if t.taint != "" {
 		t.s.RecoveryRounds++
 		t.s.RecoveryGapMs += gap
@@ -452,6 +469,11 @@ func (t *trajScan) recordModelPhase(rec trajectoryRecord) {
 			t.gapPlanner = true
 		case "executor":
 			t.s.ExecutorRequests++
+			t.s.ReasoningTokensTotal += u.ReasoningTokens
+			t.s.CompletionTokensTotal += u.CompletionTokens
+			t.gapReason += u.ReasoningTokens
+			t.gapCompl += u.CompletionTokens
+			t.gapPrompt = max(t.gapPrompt, u.PromptTokens)
 		case "subagent":
 			t.s.SubagentRequests++
 			return
@@ -506,6 +528,7 @@ func (t *trajScan) recordDispatch(rec trajectoryRecord) {
 		if info == nil {
 			info = &roundCall{}
 			t.batch.infos[tl.ID] = info
+			t.batch.names = append(t.batch.names, tl.Name)
 			if tl.Name == "connect_tool_source" {
 				t.s.ConnectCalls++
 			}
@@ -559,7 +582,7 @@ func (t *trajScan) closeBatch() {
 		gap := t.pendingGaps[0]
 		t.pendingGaps = t.pendingGaps[1:]
 		if len(b.infos) > 0 {
-			t.recordOutcome(classifyRound(gap, b), gap.ms)
+			t.recordRound(classifyRound(gap, b), gap, b)
 		}
 	}
 	s.ToolBatches++
@@ -593,7 +616,7 @@ func (t *trajScan) finish() *trajectorySummary {
 	t.closeBatch()
 	if t.sawCallIDs {
 		for _, gap := range t.pendingGaps {
-			t.recordOutcome(classifyRound(gap, nil), gap.ms)
+			t.recordRound(classifyRound(gap, nil), gap, nil)
 		}
 	}
 	t.pendingGaps = nil
@@ -665,93 +688,6 @@ func newToolBatch() *toolBatch {
 func (b *toolBatch) seen(id string) bool {
 	_, ok := b.dispatchTS[id]
 	return ok
-}
-
-// intervalSpan returns the batch's wall clock (max end − min start) and
-// whether any two intervals actually overlapped (true parallelism).
-func intervalSpan(intervals [][2]int64) (wall int64, overlapped bool) {
-	sorted := append([][2]int64(nil), intervals...)
-	slices.SortFunc(sorted, func(a, b [2]int64) int {
-		switch {
-		case a[0] != b[0]:
-			return int(a[0] - b[0])
-		default:
-			return int(a[1] - b[1])
-		}
-	})
-	minStart, maxEnd := sorted[0][0], sorted[0][1]
-	for _, iv := range sorted[1:] {
-		if iv[0] < maxEnd {
-			overlapped = true
-		}
-		maxEnd = max(maxEnd, iv[1])
-	}
-	return maxEnd - minStart, overlapped
-}
-
-// intervalUnion is the merged length of all intervals, so concurrent tool
-// executions count wall-clock once.
-func intervalUnion(intervals [][2]int64) int64 {
-	return ivsLen(mergeIntervals(intervals))
-}
-
-// mergeIntervals returns a sorted, overlap-free copy of intervals.
-func mergeIntervals(intervals [][2]int64) [][2]int64 {
-	if len(intervals) == 0 {
-		return nil
-	}
-	sorted := append([][2]int64(nil), intervals...)
-	slices.SortFunc(sorted, func(a, b [2]int64) int {
-		switch {
-		case a[0] != b[0]:
-			return int(a[0] - b[0])
-		default:
-			return int(a[1] - b[1])
-		}
-	})
-	out := [][2]int64{sorted[0]}
-	for _, iv := range sorted[1:] {
-		if last := &out[len(out)-1]; iv[0] <= last[1] {
-			last[1] = max(last[1], iv[1])
-			continue
-		}
-		out = append(out, iv)
-	}
-	return out
-}
-
-// clipIntervals returns base minus covered; both are merged internally.
-func clipIntervals(base, covered [][2]int64) [][2]int64 {
-	base = mergeIntervals(base)
-	covered = mergeIntervals(covered)
-	var out [][2]int64
-	j := 0
-	for _, iv := range base {
-		lo := iv[0]
-		for j < len(covered) && covered[j][1] <= lo {
-			j++
-		}
-		for k := j; k < len(covered) && covered[k][0] < iv[1]; k++ {
-			if covered[k][0] > lo {
-				out = append(out, [2]int64{lo, covered[k][0]})
-			}
-			if lo = max(lo, covered[k][1]); lo >= iv[1] {
-				break
-			}
-		}
-		if lo < iv[1] {
-			out = append(out, [2]int64{lo, iv[1]})
-		}
-	}
-	return out
-}
-
-func ivsLen(intervals [][2]int64) int64 {
-	var total int64
-	for _, iv := range intervals {
-		total += iv[1] - iv[0]
-	}
-	return total
 }
 
 // durMs renders small durations without the sub-second floor dur applies.

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -144,12 +144,14 @@ type trajectoryRecord struct {
 		Complete bool   `json:"complete"`
 	} `json:"contract_shadow"`
 	OutcomeProgress *struct {
-		Exploration  int `json:"exploration"`
-		Verification int `json:"verification"`
-		Objective    int `json:"objective"`
-		Regression   int `json:"regression"`
-		Churn        int `json:"churn"`
-		LegacyGain   int `json:"legacy_gain"`
+		Exploration    int `json:"exploration"`
+		Verification   int `json:"verification"`
+		Objective      int `json:"objective"`
+		Regression     int `json:"regression"`
+		Churn          int `json:"churn"`
+		LegacyGain     int `json:"legacy_gain"`
+		Discriminating int `json:"discriminating"`
+		DebtAge        int `json:"debt_age"`
 	} `json:"outcome_progress"`
 	DelegationAdmission *struct {
 		Tool    string `json:"tool"`
@@ -352,7 +354,7 @@ func (t *trajScan) record(rec trajectoryRecord) {
 		t.outcomePoints = append(t.outcomePoints, outcomePoint{
 			ts: rec.TS, exploration: op.Exploration, verification: op.Verification,
 			objective: op.Objective, regression: op.Regression, churn: op.Churn,
-			legacyGain: op.LegacyGain,
+			legacyGain: op.LegacyGain, discriminating: op.Discriminating, debtAge: op.DebtAge,
 		})
 	}
 	if da := rec.DelegationAdmission; da != nil {

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -265,6 +265,16 @@ func renderTimeAttribution(results []result) string {
 // summarizeTrajectory reads a run's JSONL trajectory. A truncated final line
 // (killed run) is skipped, matching the recorder's durability contract.
 func summarizeTrajectory(path string) (*trajectorySummary, error) {
+	scan, err := scanTrajectoryFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return scan.finish(), nil
+}
+
+// scanTrajectoryFile runs the record pass without finishing, so callers that
+// need the raw series (the live dashboard) can read it before finish folds it.
+func scanTrajectoryFile(path string) (*trajScan, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -290,7 +300,7 @@ func summarizeTrajectory(path string) (*trajectorySummary, error) {
 	if err := sc.Err(); err != nil {
 		return nil, err
 	}
-	return scan.finish(), nil
+	return scan, nil
 }
 
 func (t *trajScan) record(rec trajectoryRecord) {

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -117,6 +117,12 @@ type trajectorySummary struct {
 	SlowRoundGapMs           int64         `json:"slow_round_gap_ms,omitempty"`
 	SlowRoundReasoningTokens int64         `json:"slow_round_reasoning_tokens,omitempty"`
 	Rounds                   []roundDigest `json:"rounds,omitempty"`
+
+	// Delegation admission shadow: verdicts recorded by the runtime, and the
+	// subagent time spent by tools the shadow would have denied.
+	DelegationCalls    int   `json:"delegation_calls,omitempty"`
+	DelegationDenies   int   `json:"delegation_denies,omitempty"`
+	DeniedDelegationMs int64 `json:"denied_delegation_ms,omitempty"`
 }
 
 // toolWall is the best available tool wall-clock: interval union when the
@@ -145,6 +151,11 @@ type trajectoryRecord struct {
 		Churn        int `json:"churn"`
 		LegacyGain   int `json:"legacy_gain"`
 	} `json:"outcome_progress"`
+	DelegationAdmission *struct {
+		Tool    string `json:"tool"`
+		Verdict string `json:"verdict"`
+		Reason  string `json:"reason"`
+	} `json:"delegation_admission"`
 	Event *struct {
 		Kind          string `json:"kind"`
 		Code          string `json:"code"`
@@ -297,11 +308,13 @@ func scanTrajectoryFile(path string) (*trajScan, error) {
 	defer f.Close()
 
 	scan := &trajScan{
-		s:            &trajectorySummary{Path: path},
-		batch:        newToolBatch(),
-		attemptBegin: map[string]int64{},
-		lastAttempt:  -1,
-		seen:         map[string]bool{},
+		s:                &trajectorySummary{Path: path},
+		batch:            newToolBatch(),
+		attemptBegin:     map[string]int64{},
+		lastAttempt:      -1,
+		seen:             map[string]bool{},
+		denyDelegations:  map[string]bool{},
+		delegationToolMs: map[string]int64{},
 	}
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 1<<20), 16<<20)
@@ -341,6 +354,13 @@ func (t *trajScan) record(rec trajectoryRecord) {
 			objective: op.Objective, regression: op.Regression, churn: op.Churn,
 			legacyGain: op.LegacyGain,
 		})
+	}
+	if da := rec.DelegationAdmission; da != nil {
+		t.s.DelegationCalls++
+		if da.Verdict == "deny" {
+			t.s.DelegationDenies++
+			t.denyDelegations[da.Tool] = true
+		}
 	}
 	if rec.Event == nil {
 		return
@@ -557,6 +577,9 @@ func (t *trajScan) recordResult(rec trajectoryRecord) {
 	if ex := tl.Execution; ex != nil && (ex.Verification == "passed" || ex.Verification == "failed") {
 		t.observeVerification(tl.Name+"\x00"+tl.Args, ex.Verification == "passed", rec.TS)
 	}
+	if delegationTools[tl.Name] {
+		t.delegationToolMs[tl.Name] += tl.DurationMs
+	}
 	t.batch.serialMs += tl.DurationMs
 	if tl.StartedAt > 0 && tl.EndedAt >= tl.StartedAt {
 		t.batch.intervals = append(t.batch.intervals, [2]int64{tl.StartedAt, tl.EndedAt})
@@ -644,6 +667,11 @@ func (t *trajScan) finish() *trajectorySummary {
 		s.ModelMs = 0
 	}
 	s.Outcome = t.summarizeOutcome()
+	// The admission verdict lands after the tool's result in the stream, so
+	// denied time joins by tool name once the whole file is folded.
+	for name := range t.denyDelegations {
+		s.DeniedDelegationMs += t.delegationToolMs[name]
+	}
 	t.decompose()
 	return s
 }

--- a/cmd/e2ebench/trajmode.go
+++ b/cmd/e2ebench/trajmode.go
@@ -37,7 +37,7 @@ func runTrajMode(dir string) (string, error) {
 		}
 		fmt.Fprintf(&b, "### `%s`\n\n```json\n%s\n```\n\n", id, enc)
 	}
-	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderOutcomeProgress(results) + renderMechanismLedger(results) + b.String(), nil
+	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderOutcomeProgress(results) + renderCognition(results) + renderMechanismLedger(results) + b.String(), nil
 }
 
 func emitTrajMode(dir, outMD string) {

--- a/cmd/e2ebench/trajmode.go
+++ b/cmd/e2ebench/trajmode.go
@@ -37,7 +37,7 @@ func runTrajMode(dir string) (string, error) {
 		}
 		fmt.Fprintf(&b, "### `%s`\n\n```json\n%s\n```\n\n", id, enc)
 	}
-	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderOutcomeProgress(results) + renderCognition(results) + renderMechanismLedger(results) + b.String(), nil
+	return "## Trajectory digest\n\n" + renderTimeAttribution(results) + renderToolSurface(results) + renderOutcomeProgress(results) + renderCognition(results) + renderDelegationAdmission(results) + renderMechanismLedger(results) + b.String(), nil
 }
 
 func emitTrajMode(dir, outMD string) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -571,6 +571,10 @@ type Agent struct {
 	// ebm is the Evidence-Before-More-Mutation nudge's once-per-turn state.
 	ebm ebmState
 
+	// forkRestore, when armed, swaps the frozen fork-bundle conversation in
+	// right after beginRunTurn — the counterfactual-continuation seam.
+	forkRestore func(*runLoopState)
+
 	// repeatFailureCounts tracks semantically identical write-like calls that
 	// keep failing with the same failure class. Unlike stormSig, successful
 	// reads do not blindly clear this state: re-reading a file and then
@@ -1267,6 +1271,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	}
 	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
+	a.maybeArmForkFromEnv()
+	a.maybeWrapForkCaptureProvider()
 	return a
 }
 
@@ -1371,6 +1377,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	}
 
 	_, state := a.beginRunTurn(ctx, input)
+	if a.forkRestore != nil {
+		a.forkRestore(state)
+	}
 	state.runMaxSteps = runMaxSteps
 	state.runMaxStepsKey = runMaxStepsKey
 	state.runLimitHostOwned = runLimitHostOwned

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -568,6 +568,9 @@ type Agent struct {
 	// only feed trajectory recording; it never influences guard behavior.
 	outcome *evidence.OutcomeTracker
 
+	// ebm is the Evidence-Before-More-Mutation nudge's once-per-turn state.
+	ebm ebmState
+
 	// repeatFailureCounts tracks semantically identical write-like calls that
 	// keep failing with the same failure class. Unlike stormSig, successful
 	// reads do not blindly clear this state: re-reading a file and then

--- a/internal/agent/delegation_admission.go
+++ b/internal/agent/delegation_admission.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"strings"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/taskintent"
+)
+
+// admissionGatedDelegations are the delegation tools expensive enough to need
+// an admission reason on local-fix turns. Research first: one call cost 65% of
+// the worst benchmark task's wall clock.
+var admissionGatedDelegations = map[string]bool{"research": true}
+
+// researchRequestMarkers is the V1 shadow heuristic for "the user explicitly
+// asked for external research"; deliberately narrow — a miss records a deny
+// verdict, it never blocks the call.
+var researchRequestMarkers = []string{"research", "调研", "查资料", "查文档", "search the web", "look up online"}
+
+// delegationAdmission is the shadow verdict for one gated delegation call:
+// local mutation-shaped turns get no expensive external research unless the
+// user asked for it or the call cites an external source. Pure function.
+func delegationAdmission(input, args string) (verdict, reason string, intent taskintent.Intent) {
+	intent = taskintent.Classify(input)
+	if intent != taskintent.Mutation && intent != taskintent.PersistentAction {
+		return "allow", "non_local_intent", intent
+	}
+	lower := strings.ToLower(input)
+	for _, marker := range researchRequestMarkers {
+		if strings.Contains(lower, marker) {
+			return "allow", "user_requested", intent
+		}
+	}
+	if strings.Contains(args, "http://") || strings.Contains(args, "https://") {
+		return "allow", "external_source_cited", intent
+	}
+	return "deny", "local_fix_no_external_need", intent
+}
+
+// observeDelegationAdmission records a shadow admission verdict for every
+// gated delegation call in the batch. Observed, never enforced. The turn text
+// is the bounded classifier source the delivery gates already store, so the
+// shadow and the gates judge the same words.
+func (a *Agent) observeDelegationAdmission(calls []provider.ToolCall) {
+	for _, call := range calls {
+		if !admissionGatedDelegations[call.Name] {
+			continue
+		}
+		verdict, reason, intent := delegationAdmission(a.recoveryTaskSummary, call.Arguments)
+		event.RecordDelegationAdmission(a.sink, event.DelegationAdmissionAudit{
+			Tool: call.Name, Verdict: verdict, Reason: reason, Intent: intentName(intent),
+		})
+	}
+}

--- a/internal/agent/delegation_admission_test.go
+++ b/internal/agent/delegation_admission_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func TestDelegationAdmissionVerdicts(t *testing.T) {
+	cases := []struct {
+		name, input, args, verdict, reason string
+	}{
+		{"local fix, plain query", "fix the config serializer bug in parser.go",
+			`{"prompt":"how does the serializer format keys"}`, "deny", "local_fix_no_external_need"},
+		{"user asked for research", "research the best TOML library and fix the loader",
+			`{"prompt":"compare toml libraries"}`, "allow", "user_requested"},
+		{"external source cited", "fix the retry logic to match the upstream spec",
+			`{"prompt":"read https://example.com/spec and summarize backoff rules"}`, "allow", "external_source_cited"},
+		{"advisory turn", "how does our retry budget compare to industry practice?",
+			`{"prompt":"survey retry budget conventions"}`, "allow", "non_local_intent"},
+	}
+	for _, c := range cases {
+		verdict, reason, _ := delegationAdmission(c.input, c.args)
+		if verdict != c.verdict || reason != c.reason {
+			t.Errorf("%s: got %s/%s, want %s/%s", c.name, verdict, reason, c.verdict, c.reason)
+		}
+	}
+}
+
+type admissionSink struct {
+	audits []event.DelegationAdmissionAudit
+}
+
+func (s *admissionSink) Emit(event.Event) {}
+func (s *admissionSink) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	s.audits = append(s.audits, a)
+}
+
+func TestObserveDelegationAdmissionRecordsOnlyGatedTools(t *testing.T) {
+	sink := &admissionSink{}
+	a := &Agent{sink: sink}
+	a.recoveryTaskSummary = "fix the failing date parser"
+	a.observeDelegationAdmission([]provider.ToolCall{
+		{Name: "read_file", Arguments: `{"path":"a.go"}`},
+		{Name: "research", Arguments: `{"prompt":"date formats"}`},
+		{Name: "task", Arguments: `{"prompt":"sub work"}`},
+	})
+	if len(sink.audits) != 1 {
+		t.Fatalf("got %d audits, want 1 (research only)", len(sink.audits))
+	}
+	got := sink.audits[0]
+	if got.Tool != "research" || got.Verdict != "deny" || got.Reason != "local_fix_no_external_need" || got.Intent != "mutation" {
+		t.Fatalf("audit = %+v, want deny/local_fix_no_external_need on mutation intent", got)
+	}
+}

--- a/internal/agent/ebm.go
+++ b/internal/agent/ebm.go
@@ -25,7 +25,10 @@ const ebmNudge = "[evidence nudge] You have made several unverified mutations. B
 var ebmEnabled = os.Getenv("REASONIX_EXPERIMENT_EBM") == "1"
 
 type ebmState struct {
-	fired bool
+	fired        bool
+	captureArmed bool
+	captured     bool
+	captureRound int
 }
 
 // applyEBM stamps eligibility on the round's sample and, when the experiment
@@ -35,10 +38,12 @@ func (a *Agent) applyEBM(sample *evidence.OutcomeSample, results []string, outco
 		return
 	}
 	sample.EBMEligible = true
+	a.armForkCapture(*sample)
 	if !ebmEnabled || a.ebm.fired || len(results) == 0 || len(outcomes) == 0 {
 		return
 	}
 	a.ebm.fired = true
+	a.ebm.captureArmed = false
 	sample.EBMFired = true
 	results[0] = outcomes[0].output + "\n\n" + ebmNudge
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEvidenceNudge,

--- a/internal/agent/ebm.go
+++ b/internal/agent/ebm.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"os"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+)
+
+// ebmBlindThreshold is the Evidence-Before-More-Mutation trigger: three
+// mutations since the last discriminating observation. Healthy trajectories
+// peak at two (edit, edit, check); the one recorded failure peaked at five.
+const ebmBlindThreshold = 3
+
+// ebmNudge deliberately permits finishing a coherent multi-file change first —
+// the goal is discriminating feedback, not a mechanical test-after-every-edit.
+const ebmNudge = "[evidence nudge] You have made several unverified mutations. Before making further " +
+	"changes, obtain the cheapest discriminating evidence available for the current hypothesis. " +
+	"If the workspace is not yet in a verifiable state, finish only the minimum coherent change " +
+	"needed to make such a check possible."
+
+// ebmEnabled gates enforcement for the A/B experiment; eligibility is always
+// recorded so baseline arms carry the same shadow. Env-scoped on purpose —
+// graduation to config waits on the experiment's verdict.
+var ebmEnabled = os.Getenv("REASONIX_EXPERIMENT_EBM") == "1"
+
+type ebmState struct {
+	fired bool
+}
+
+// applyEBM stamps eligibility on the round's sample and, when the experiment
+// arm is active, injects the nudge once per turn through the guard channel.
+func (a *Agent) applyEBM(sample *evidence.OutcomeSample, results []string, outcomes []toolOutcome) {
+	if sample.DebtAge == 0 || sample.BlindMutations < ebmBlindThreshold {
+		return
+	}
+	sample.EBMEligible = true
+	if !ebmEnabled || a.ebm.fired || len(results) == 0 || len(outcomes) == 0 {
+		return
+	}
+	a.ebm.fired = true
+	sample.EBMFired = true
+	results[0] = outcomes[0].output + "\n\n" + ebmNudge
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEvidenceNudge,
+		Text:   "Several mutations are unverified; asking for the cheapest discriminating check.",
+		Detail: "evidence nudge: verification debt open with blind mutations at threshold"})
+}

--- a/internal/agent/ebm_test.go
+++ b/internal/agent/ebm_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+)
+
+type ebmSink struct {
+	notices []event.Event
+}
+
+func (s *ebmSink) Emit(e event.Event) { s.notices = append(s.notices, e) }
+
+func ebmRound() ([]string, []toolOutcome) {
+	return []string{"tool output"}, []toolOutcome{{output: "tool output"}}
+}
+
+func TestApplyEBMStampsEligibilityWithoutFiringByDefault(t *testing.T) {
+	a := &Agent{sink: &ebmSink{}}
+	sample := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
+	results, outcomes := ebmRound()
+	a.applyEBM(&sample, results, outcomes)
+	if !sample.EBMEligible || sample.EBMFired {
+		t.Fatalf("sample = %+v, want eligible without firing (experiment off)", sample)
+	}
+	if results[0] != "tool output" {
+		t.Fatalf("baseline arm must not touch results, got %q", results[0])
+	}
+}
+
+func TestApplyEBMFiresOncePerTurnWhenEnabled(t *testing.T) {
+	old := ebmEnabled
+	ebmEnabled = true
+	defer func() { ebmEnabled = old }()
+
+	sink := &ebmSink{}
+	a := &Agent{sink: sink}
+
+	below := evidence.OutcomeSample{DebtAge: 1, BlindMutations: 2}
+	results, outcomes := ebmRound()
+	a.applyEBM(&below, results, outcomes)
+	if below.EBMEligible || below.EBMFired {
+		t.Fatalf("below threshold = %+v, want untouched", below)
+	}
+
+	sample := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
+	a.applyEBM(&sample, results, outcomes)
+	if !sample.EBMFired || !strings.Contains(results[0], "[evidence nudge]") {
+		t.Fatalf("sample = %+v results = %q, want fired with nudge appended", sample, results[0])
+	}
+	if len(sink.notices) != 1 || sink.notices[0].Code != event.NoticeCodeEvidenceNudge {
+		t.Fatalf("notices = %+v, want one evidence_nudge", sink.notices)
+	}
+
+	again := evidence.OutcomeSample{DebtAge: 3, BlindMutations: 4}
+	results2, outcomes2 := ebmRound()
+	a.applyEBM(&again, results2, outcomes2)
+	if again.EBMFired || !again.EBMEligible || results2[0] != "tool output" {
+		t.Fatalf("second trigger = %+v results = %q, want eligible only (once per turn)", again, results2[0])
+	}
+
+	a.resetTurnEvidence()
+	fresh := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
+	results3, outcomes3 := ebmRound()
+	a.applyEBM(&fresh, results3, outcomes3)
+	if !fresh.EBMFired {
+		t.Fatalf("new turn = %+v, want the pass reset by resetTurnEvidence", fresh)
+	}
+}

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -1,0 +1,215 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+)
+
+// ForkBundle freezes the full turn state at a policy's first eligibility so a
+// control and a treatment continuation can start from the identical point.
+// Versioned from day one: this format is shared infrastructure for every
+// policy experiment (EBM, reasoning governor, delegation admission, rollback).
+type ForkBundle struct {
+	Version       int                `json:"version"`
+	Policy        string             `json:"policy"`
+	Input         string             `json:"input"`
+	EligibleRound int                `json:"eligible_round"`
+	BlindAtFork   int                `json:"blind_at_fork"`
+	DebtAtFork    int                `json:"debt_at_fork"`
+	MutatedBases  []string           `json:"mutated_bases,omitempty"`
+	Messages      []provider.Message `json:"messages"`
+}
+
+const forkBundleVersion = 1
+
+// armForkCapture marks first EBM eligibility for capture. The bundle is
+// written by the provider wrapper right before the NEXT request — only then
+// does the session hold the eligible round's tool results. Arming refuses
+// under live enforcement: a treated state must never become a bundle.
+func (a *Agent) armForkCapture(sample evidence.OutcomeSample) {
+	if os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR") == "" || ebmEnabled || a.ebm.captured || a.ebm.captureArmed {
+		return
+	}
+	a.ebm.captureArmed = true
+	a.ebm.captureRound = sample.Round
+}
+
+// forkCaptureProvider snapshots the session at the next Stream call after
+// eligibility was armed — the exact state the uninterrupted run sends.
+type forkCaptureProvider struct {
+	inner provider.Provider
+	a     *Agent
+}
+
+func (p *forkCaptureProvider) Name() string { return p.inner.Name() }
+
+func (p *forkCaptureProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	a := p.a
+	if a.ebm.captureArmed && !a.ebm.captured {
+		a.ebm.captured = true
+		messages := a.session.Snapshot()
+		bases, debt, blind := a.outcome.ForkSeed()
+		b := ForkBundle{
+			Version: forkBundleVersion, Policy: "ebm",
+			Input:         forkTurnInput(messages),
+			EligibleRound: a.ebm.captureRound, BlindAtFork: blind,
+			DebtAtFork: debt, MutatedBases: bases, Messages: messages,
+		}
+		if err := writeForkBundle(os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR"), b); err != nil {
+			fmt.Fprintln(os.Stderr, "fork capture:", err)
+		}
+	}
+	return p.inner.Stream(ctx, req)
+}
+
+// forkTurnInput recovers the turn's raw input from the frozen conversation:
+// the first user message's authored form. Single-turn scope (the bench runs
+// one turn per task); multi-turn capture would need the active turn's index.
+func forkTurnInput(messages []provider.Message) string {
+	for _, m := range messages {
+		if m.Role == provider.RoleUser {
+			if m.RawContent != "" {
+				return m.RawContent
+			}
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func writeForkBundle(dir string, b ForkBundle) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bundle.json"), data, 0o644); err != nil {
+		return err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return copyWorkspace(cwd, filepath.Join(dir, "workspace"))
+}
+
+// copyWorkspace mirrors the task workdir minus harness artifacts, so a
+// continuation starts from byte-identical files.
+func copyWorkspace(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, path)
+		if rerr != nil || rel == "." {
+			return rerr
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if name == "__pycache__" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return os.MkdirAll(filepath.Join(dst, rel), 0o755)
+		}
+		if name == ".run-metrics.json" {
+			return nil
+		}
+		in, oerr := os.Open(path)
+		if oerr != nil {
+			return oerr
+		}
+		defer in.Close()
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(dst, rel)), 0o755); err != nil {
+			return err
+		}
+		out, cerr := os.Create(filepath.Join(dst, rel))
+		if cerr != nil {
+			return cerr
+		}
+		defer out.Close()
+		_, err = io.Copy(out, in)
+		return err
+	})
+}
+
+// LoadForkBundle reads and version-checks a bundle.
+func LoadForkBundle(path string) (*ForkBundle, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var b ForkBundle
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, err
+	}
+	if b.Version != forkBundleVersion {
+		return nil, fmt.Errorf("fork bundle version %d, this build replays %d", b.Version, forkBundleVersion)
+	}
+	return &b, nil
+}
+
+// armForkContinuation makes the next Run continue from the bundle: turn-local
+// classification still runs on the same input, then the appended user message
+// is replaced wholesale by the frozen conversation. Treatment differs from
+// control by exactly one thing — the nudge in the live policy's slot — and
+// the single dose disarms the runtime policy.
+func (a *Agent) armForkContinuation(b *ForkBundle, treatment bool) {
+	a.forkRestore = func(_ *runLoopState) {
+		messages := append([]provider.Message(nil), b.Messages...)
+		if treatment {
+			applyForkTreatment(messages)
+		}
+		a.session.Replace(messages)
+		a.outcome = evidence.RestoreOutcomeTracker(b.MutatedBases, b.DebtAtFork, b.BlindAtFork)
+		a.ebm = ebmState{fired: true, captured: true, captureRound: b.EligibleRound}
+	}
+}
+
+// applyForkTreatment appends the nudge to the eligible batch's first tool
+// result — the same slot the live policy writes to.
+func applyForkTreatment(messages []provider.Message) {
+	lastAssistant := -1
+	for i, m := range messages {
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
+			lastAssistant = i
+		}
+	}
+	for i := lastAssistant + 1; lastAssistant >= 0 && i < len(messages); i++ {
+		if messages[i].Role == provider.RoleTool {
+			messages[i].Content += "\n\n" + ebmNudge
+			return
+		}
+	}
+}
+
+// maybeWrapForkCaptureProvider interposes the capture wrapper when the
+// experiment env asks for bundles; inert otherwise.
+func (a *Agent) maybeWrapForkCaptureProvider() {
+	if os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR") != "" && a.prov != nil {
+		a.prov = &forkCaptureProvider{inner: a.prov, a: a}
+	}
+}
+
+// maybeArmForkFromEnv wires the experiment from the environment so the bench
+// can fork without new public plumbing. Control is the default arm.
+func (a *Agent) maybeArmForkFromEnv() {
+	path := os.Getenv("REASONIX_EXPERIMENT_FORK_BUNDLE")
+	if path == "" {
+		return
+	}
+	b, err := LoadForkBundle(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "fork continuation:", err)
+		return
+	}
+	a.armForkContinuation(b, os.Getenv("REASONIX_EXPERIMENT_FORK_ARM") == "treatment")
+}

--- a/internal/agent/fork_test.go
+++ b/internal/agent/fork_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+	_ "reasonix/internal/tool/builtin"
+)
+
+func forkScriptTurns() [][]provider.Chunk {
+	return [][]provider.Chunk{
+		{toolCallChunk("c1", "write_file", `{"path":"a.py","content":"x"}`)},
+		{toolCallChunk("c2", "write_file", `{"path":"b.py","content":"x"}`)},
+		{toolCallChunk("c3", "write_file", `{"path":"c.py","content":"x"}`)},
+		{{Type: provider.ChunkText, Text: "done"}},
+	}
+}
+
+func forkRegistry() *tool.Registry {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	return reg
+}
+
+func captureForkFixture(t *testing.T) (*ForkBundle, *scriptedProvider) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR", dir)
+	prov := &scriptedProvider{name: "p", turns: forkScriptTurns()}
+	a := New(prov, forkRegistry(), NewSession("sys"), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "fix the widget"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	b, err := LoadForkBundle(filepath.Join(dir, "bundle.json"))
+	if err != nil {
+		t.Fatalf("LoadForkBundle: %v", err)
+	}
+	return b, prov
+}
+
+func TestForkControlContinuationMatchesOriginalRequest(t *testing.T) {
+	b, orig := captureForkFixture(t)
+	if len(orig.requests) != 4 {
+		t.Fatalf("original run made %d requests, want 4", len(orig.requests))
+	}
+	if b.BlindAtFork != 3 || b.DebtAtFork == 0 || b.EligibleRound != 3 {
+		t.Fatalf("bundle = blind %d debt %d round %d, want 3/>0/3", b.BlindAtFork, b.DebtAtFork, b.EligibleRound)
+	}
+	if b.Input != "fix the widget" {
+		t.Fatalf("bundle input = %q", b.Input)
+	}
+
+	os.Unsetenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR")
+	cont := &scriptedProvider{name: "p", turns: [][]provider.Chunk{{{Type: provider.ChunkText, Text: "done"}}}}
+	a := New(cont, forkRegistry(), NewSession("sys"), Options{}, event.Discard)
+	a.armForkContinuation(b, false)
+	if err := a.Run(context.Background(), b.Input); err != nil {
+		t.Fatalf("continuation Run: %v", err)
+	}
+	if len(cont.requests) == 0 {
+		t.Fatal("continuation made no requests")
+	}
+	// The invariant: the control fork's first provider request equals the one
+	// the uninterrupted run made after the eligible round. Any drift is fork
+	// contamination (re-classification, duplicate injection, state leakage).
+	want, got := orig.requests[3], cont.requests[0]
+	if !reflect.DeepEqual(want.Messages, got.Messages) {
+		t.Fatalf("control fork payload diverged from original continuation:\nwant %d messages\ngot  %d messages", len(want.Messages), len(got.Messages))
+	}
+}
+
+func TestForkTreatmentDiffersOnlyByNudge(t *testing.T) {
+	b, orig := captureForkFixture(t)
+	os.Unsetenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR")
+	cont := &scriptedProvider{name: "p", turns: [][]provider.Chunk{{{Type: provider.ChunkText, Text: "done"}}}}
+	a := New(cont, forkRegistry(), NewSession("sys"), Options{}, event.Discard)
+	a.armForkContinuation(b, true)
+	if err := a.Run(context.Background(), b.Input); err != nil {
+		t.Fatalf("treatment Run: %v", err)
+	}
+	want, got := orig.requests[3], cont.requests[0]
+	if len(want.Messages) != len(got.Messages) {
+		t.Fatalf("treatment changed message count: %d vs %d", len(want.Messages), len(got.Messages))
+	}
+	diffs := 0
+	for i := range want.Messages {
+		if reflect.DeepEqual(want.Messages[i], got.Messages[i]) {
+			continue
+		}
+		diffs++
+		if got.Messages[i].Role != provider.RoleTool ||
+			got.Messages[i].Content != want.Messages[i].Content+"\n\n"+ebmNudge {
+			t.Fatalf("message %d changed beyond the nudge:\nwant %q\ngot  %q", i, want.Messages[i].Content, got.Messages[i].Content)
+		}
+	}
+	if diffs != 1 {
+		t.Fatalf("treatment touched %d messages, want exactly 1", diffs)
+	}
+}
+
+func TestForkCaptureRefusesTreatedState(t *testing.T) {
+	old := ebmEnabled
+	ebmEnabled = true
+	defer func() { ebmEnabled = old }()
+
+	dir := t.TempDir()
+	t.Setenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR", dir)
+	prov := &scriptedProvider{name: "p", turns: forkScriptTurns()}
+	a := New(prov, forkRegistry(), NewSession("sys"), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "fix the widget"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The live run nudged (treatment applied)…
+	nudged := false
+	for _, m := range prov.requests[len(prov.requests)-1].Messages {
+		if m.Role == provider.RoleTool && strings.Contains(m.Content, "[evidence nudge]") {
+			nudged = true
+		}
+	}
+	if !nudged {
+		t.Fatal("enforcement-on run never nudged; refusal test proved nothing")
+	}
+	// …so no bundle may exist: a treated state must never become a fork origin.
+	if _, err := os.Stat(filepath.Join(dir, "bundle.json")); !os.IsNotExist(err) {
+		t.Fatal("capture wrote a bundle under live enforcement")
+	}
+}
+
+func TestForkWorkspaceCopyExcludesHarnessArtifacts(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	os.WriteFile(filepath.Join(src, "code.py"), []byte("v"), 0o644)
+	os.WriteFile(filepath.Join(src, ".run-metrics.json"), []byte("{}"), 0o644)
+	if err := copyWorkspace(src, filepath.Join(dst, "ws")); err != nil {
+		t.Fatalf("copyWorkspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "ws", "code.py")); err != nil {
+		t.Fatal("workspace file missing from copy")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "ws", ".run-metrics.json")); !os.IsNotExist(err) {
+		t.Fatal("harness sidecar must not enter the bundle workspace")
+	}
+}

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -55,6 +55,7 @@ func (a *Agent) applyBatchGuards(calls []provider.ToolCall, outcomes []toolOutco
 	a.applyStormBreaker(calls, outcomes, results, receiptMark)
 	a.applyProgressGuard(results, outcomes, receiptMark)
 	a.observeOutcomeShadow(receiptMark)
+	a.observeDelegationAdmission(calls)
 }
 
 // resetTurnEvidence clears the ledger and both progress scorers together.

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -54,7 +54,7 @@ type Receipt = evidence.Receipt
 func (a *Agent) applyBatchGuards(calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) {
 	a.applyStormBreaker(calls, outcomes, results, receiptMark)
 	a.applyProgressGuard(results, outcomes, receiptMark)
-	a.observeOutcomeShadow(receiptMark)
+	a.observeOutcomeShadow(receiptMark, results, outcomes)
 	a.observeDelegationAdmission(calls)
 }
 
@@ -63,19 +63,22 @@ func (a *Agent) resetTurnEvidence() {
 	a.evidence.Reset()
 	a.progress.reset()
 	a.outcome = evidence.NewOutcomeTracker()
+	a.ebm = ebmState{}
 }
 
 // observeOutcomeShadow scores the round's receipts through the shadow outcome
-// tracker and records the sample for trajectory analysis. Unlike the guards it
-// observes every round, including all-failure ones — regressions live there.
-func (a *Agent) observeOutcomeShadow(receiptMark int) {
+// tracker, lets the EBM policy stamp (and under its arm, act on) the sample,
+// then records it. Unlike the guards it observes every round.
+func (a *Agent) observeOutcomeShadow(receiptMark int, results []string, outcomes []toolOutcome) {
 	if a.evidence == nil {
 		return
 	}
 	if a.outcome == nil {
 		a.outcome = evidence.NewOutcomeTracker()
 	}
-	event.RecordOutcomeProgress(a.sink, a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark)))
+	sample := a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark))
+	a.applyEBM(&sample, results, outcomes)
+	event.RecordOutcomeProgress(a.sink, sample)
 }
 
 // applyProgressGuard escalates when consecutive rounds stop producing new

--- a/internal/control/goalusage.go
+++ b/internal/control/goalusage.go
@@ -79,6 +79,11 @@ func (t *goalUsageTee) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(t.inner, sample)
 }
 
+// RecordDelegationAdmission forwards the shadow admission verdict unchanged.
+func (t *goalUsageTee) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	event.RecordDelegationAdmission(t.inner, a)
+}
+
 // RecordContractShadow forwards the shadow contract audit unchanged.
 func (t *goalUsageTee) RecordContractShadow(a event.ContractShadowAudit) {
 	if t == nil || t.inner == nil {

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -173,3 +173,10 @@ func (c *coalescer) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	c.drainAndUnlock()
 	RecordOutcomeProgress(c.inner, sample)
 }
+
+func (c *coalescer) RecordDelegationAdmission(a DelegationAdmissionAudit) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordDelegationAdmission(c.inner, a)
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -483,6 +483,7 @@ const (
 	NoticeCodeToolBudget                    = "tool_budget"
 	NoticeCodeLoopGuard                     = "loop_guard"
 	NoticeCodeProgressGuard                 = "progress_guard"
+	NoticeCodeEvidenceNudge                 = "evidence_nudge"
 	NoticeCodeWorkspaceLease                = "workspace_lease"
 	NoticeCodeCancelledTurn                 = "cancelled_turn_display"
 	NoticeCodeUnappliedSteer                = "unapplied_steer"

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -618,6 +618,33 @@ func RecordContractShadow(s Sink, a ContractShadowAudit) {
 	}
 }
 
+// DelegationAdmissionAudit is the shadow admission verdict for one expensive
+// delegation call: tool name and enums only, never the query or prompt text.
+// Shadow means observed, not enforced — no call is blocked.
+type DelegationAdmissionAudit struct {
+	Tool    string
+	Verdict string // "allow" | "deny"
+	Reason  string // e.g. "local_fix_no_external_need"
+	Intent  string // taskintent class of the turn
+}
+
+// DelegationAdmissionSink is an optional sink capability; implementations
+// must keep it content-free, like every other audit channel.
+type DelegationAdmissionSink interface {
+	RecordDelegationAdmission(DelegationAdmissionAudit)
+}
+
+// RecordDelegationAdmission forwards a shadow admission verdict only to sinks
+// that explicitly opt in. Ordinary UI sinks receive nothing.
+func RecordDelegationAdmission(s Sink, a DelegationAdmissionAudit) {
+	if nilutil.IsNil(s) {
+		return
+	}
+	if da, ok := s.(DelegationAdmissionSink); ok {
+		da.RecordDelegationAdmission(a)
+	}
+}
+
 // OutcomeProgressSink is an optional sink capability for the shadow outcome
 // scorer's per-round samples: counts only, never paths or commands. Shadow
 // means observed, not enforced — the novelty guard still decides behavior.

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -71,3 +71,11 @@ func (s *syncSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 		op.RecordOutcomeProgress(sample)
 	}
 }
+
+func (s *syncSink) RecordDelegationAdmission(a DelegationAdmissionAudit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if da, ok := s.inner.(DelegationAdmissionSink); ok {
+		da.RecordDelegationAdmission(a)
+	}
+}

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -2,6 +2,7 @@ package evidence
 
 import (
 	"path"
+	"sort"
 	"strings"
 
 	"reasonix/internal/shellsafe"
@@ -54,6 +55,30 @@ type OutcomeTracker struct {
 	debt         bool
 	debtAge      int
 	blind        int
+}
+
+// ForkSeed exports the debt-relevant state a counterfactual fork must carry so
+// post-fork discriminating detection stays continuous with the original run.
+func (t *OutcomeTracker) ForkSeed() (mutatedBases []string, debtAge, blindMutations int) {
+	for base := range t.mutatedBases {
+		mutatedBases = append(mutatedBases, base)
+	}
+	sort.Strings(mutatedBases)
+	return mutatedBases, t.debtAge, t.blind
+}
+
+// RestoreOutcomeTracker rebuilds a tracker from a fork seed. Novelty maps
+// start empty — post-fork exploration novelty is intentionally relative to the
+// fork point, while debt state continues from the original trajectory.
+func RestoreOutcomeTracker(mutatedBases []string, debtAge, blindMutations int) *OutcomeTracker {
+	t := NewOutcomeTracker()
+	for _, base := range mutatedBases {
+		t.mutatedBases[base] = true
+	}
+	t.debtAge = debtAge
+	t.blind = blindMutations
+	t.debt = debtAge > 0 || blindMutations > 0
+	return t
 }
 
 func NewOutcomeTracker() *OutcomeTracker {

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -1,6 +1,11 @@
 package evidence
 
-import "strings"
+import (
+	"path"
+	"strings"
+
+	"reasonix/internal/shellsafe"
+)
 
 // OutcomeSample decomposes one tool round's receipts by outcome: information
 // gathered (Exploration), verification attempts run, and verification-command
@@ -16,31 +21,42 @@ type OutcomeSample struct {
 	// LegacyGain is the live novelty scorer's verdict on the same receipts, so
 	// offline analysis can compare the two policies without replaying.
 	LegacyGain int
+	// Discriminating counts observations able to falsify the working
+	// hypothesis: verification commands, or commands exercising a mutated
+	// file — deliberately broader than delivery verification (repro scripts).
+	Discriminating int
+	// DebtAge counts consecutive rounds carrying an unverified mutation with
+	// no discriminating observation; 0 while no verification debt is open.
+	DebtAge int
 }
 
 // OutcomeTracker is the shadow counterpart of ProgressTracker: same per-round
 // receipts, scored by outcome instead of novelty. It never influences guard
 // behavior — samples exist only for trajectory recording and offline analysis.
 type OutcomeTracker struct {
-	legacy     *ProgressTracker
-	round      int
-	readPaths  map[string]bool
-	commands   map[string]bool
-	failures   map[string]bool
-	actions    map[string]bool
-	verifySeen map[string]bool
-	verifyPass map[string]bool
+	legacy       *ProgressTracker
+	round        int
+	readPaths    map[string]bool
+	commands     map[string]bool
+	failures     map[string]bool
+	actions      map[string]bool
+	verifySeen   map[string]bool
+	verifyPass   map[string]bool
+	mutatedBases map[string]bool
+	debt         bool
+	debtAge      int
 }
 
 func NewOutcomeTracker() *OutcomeTracker {
 	return &OutcomeTracker{
-		legacy:     NewProgressTracker(),
-		readPaths:  map[string]bool{},
-		commands:   map[string]bool{},
-		failures:   map[string]bool{},
-		actions:    map[string]bool{},
-		verifySeen: map[string]bool{},
-		verifyPass: map[string]bool{},
+		legacy:       NewProgressTracker(),
+		readPaths:    map[string]bool{},
+		commands:     map[string]bool{},
+		failures:     map[string]bool{},
+		actions:      map[string]bool{},
+		verifySeen:   map[string]bool{},
+		verifyPass:   map[string]bool{},
+		mutatedBases: map[string]bool{},
 	}
 }
 
@@ -56,7 +72,45 @@ func (t *OutcomeTracker) ScoreRound(receipts []Receipt) OutcomeSample {
 		t.scoreReceipt(r, &s)
 	}
 	s.LegacyGain = t.legacy.ScoreRound(receipts)
+	// Verification debt: a discriminating observation settles it; otherwise a
+	// mutation opens it and every silent round ages it, mutation round included.
+	if s.Discriminating > 0 {
+		t.debt, t.debtAge = false, 0
+	} else {
+		if s.Churn > 0 {
+			t.debt = true
+		}
+		if t.debt {
+			t.debtAge++
+		}
+	}
+	s.DebtAge = t.debtAge
 	return s
+}
+
+// noteMutatedPaths remembers mutated file basenames so a later command that
+// mentions one (running a repro script, a targeted test file) reads as a
+// discriminating observation even when it is not delivery verification.
+func (t *OutcomeTracker) noteMutatedPaths(paths []string) {
+	for _, p := range paths {
+		if base := path.Base(strings.ReplaceAll(p, "\\", "/")); len(base) >= 3 {
+			t.mutatedBases[base] = true
+		}
+	}
+}
+
+func (t *OutcomeTracker) commandExercisesMutation(command string) bool {
+	// Inspecting a mutated file (cat/grep/head) cannot falsify anything; only
+	// a command that can execute it discriminates.
+	if _, _, readOnly := shellsafe.CommandIsReadOnly(command); readOnly {
+		return false
+	}
+	for base := range t.mutatedBases {
+		if strings.Contains(command, base) {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *OutcomeTracker) scoreReceipt(r Receipt, s *OutcomeSample) {
@@ -69,6 +123,7 @@ func (t *OutcomeTracker) scoreReceipt(r Receipt, s *OutcomeSample) {
 		// A mutation is a state transition, not proof of progress: it counts
 		// as churn until a verification transition vouches for it.
 		s.Churn++
+		t.noteMutatedPaths(r.Paths)
 	case r.Success && (r.ToolName == "task" || r.ToolName == "parallel_tasks" || r.ToolName == "fleet"):
 		// A delegation return is new information at best — never objective
 		// progress on its own.
@@ -95,8 +150,12 @@ func (t *OutcomeTracker) scoreReceipt(r Receipt, s *OutcomeSample) {
 func (t *OutcomeTracker) scoreCommand(command string, r Receipt, s *OutcomeSample) {
 	if r.Success && (r.Mutation || r.Write) {
 		s.Churn++
+		t.noteMutatedPaths(r.Paths)
 	}
 	verify := IsDeliveryVerificationCommand(command)
+	if verify || t.commandExercisesMutation(command) {
+		s.Discriminating++
+	}
 	if verify {
 		s.Verification++
 		seen, wasPass := t.verifySeen[command], t.verifyPass[command]

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -28,6 +28,14 @@ type OutcomeSample struct {
 	// DebtAge counts consecutive rounds carrying an unverified mutation with
 	// no discriminating observation; 0 while no verification debt is open.
 	DebtAge int
+	// BlindMutations counts mutations since the last discriminating
+	// observation — the EBM policy's trigger input.
+	BlindMutations int
+	// EBMEligible/EBMFired mark the Evidence-Before-More-Mutation trigger
+	// holding and its nudge firing; the agent stamps both so every arm —
+	// baseline included — carries the eligibility shadow.
+	EBMEligible bool
+	EBMFired    bool
 }
 
 // OutcomeTracker is the shadow counterpart of ProgressTracker: same per-round
@@ -45,6 +53,7 @@ type OutcomeTracker struct {
 	mutatedBases map[string]bool
 	debt         bool
 	debtAge      int
+	blind        int
 }
 
 func NewOutcomeTracker() *OutcomeTracker {
@@ -75,16 +84,18 @@ func (t *OutcomeTracker) ScoreRound(receipts []Receipt) OutcomeSample {
 	// Verification debt: a discriminating observation settles it; otherwise a
 	// mutation opens it and every silent round ages it, mutation round included.
 	if s.Discriminating > 0 {
-		t.debt, t.debtAge = false, 0
+		t.debt, t.debtAge, t.blind = false, 0, 0
 	} else {
 		if s.Churn > 0 {
 			t.debt = true
+			t.blind += s.Churn
 		}
 		if t.debt {
 			t.debtAge++
 		}
 	}
 	s.DebtAge = t.debtAge
+	s.BlindMutations = t.blind
 	return s
 }
 

--- a/internal/evidence/outcome_test.go
+++ b/internal/evidence/outcome_test.go
@@ -98,10 +98,15 @@ func TestOutcomeTrackerVerificationDebtLifecycle(t *testing.T) {
 	if s := tr.ScoreRound([]Receipt{bashReceipt("cat pkg/repro.py", true)}); s.Discriminating != 0 || s.DebtAge != 4 {
 		t.Fatalf("read-only inspection = %+v, want no discrimination, debt age 4", s)
 	}
+	// A second mutation raises the blind count; the counter tracks mutations,
+	// not rounds.
+	if s := tr.ScoreRound([]Receipt{ReceiptFromToolCall("write_file", json.RawMessage(`{"path":"pkg/b.py","content":"y"}`), true, false)}); s.BlindMutations != 2 {
+		t.Fatalf("second mutation = %+v, want blind 2", s)
+	}
 	// Running the mutated file is a discriminating observation even though it
-	// is not delivery verification: debt settles.
-	if s := tr.ScoreRound([]Receipt{bashReceipt("python3 pkg/repro.py", false)}); s.Discriminating != 1 || s.DebtAge != 0 {
-		t.Fatalf("repro run = %+v, want discriminating 1, debt settled", s)
+	// is not delivery verification: debt and the blind count settle.
+	if s := tr.ScoreRound([]Receipt{bashReceipt("python3 pkg/repro.py", false)}); s.Discriminating != 1 || s.DebtAge != 0 || s.BlindMutations != 0 {
+		t.Fatalf("repro run = %+v, want discriminating 1, debt and blind settled", s)
 	}
 	// Debt stays settled until the next mutation; delivery verification also
 	// counts as discriminating without any mutated-path match.

--- a/internal/evidence/outcome_test.go
+++ b/internal/evidence/outcome_test.go
@@ -76,3 +76,36 @@ func TestOutcomeTrackerDelegationAndRepeatsAreExplorationAtBest(t *testing.T) {
 		t.Fatalf("nil tracker sample = %+v, want zero", got)
 	}
 }
+
+func TestOutcomeTrackerVerificationDebtLifecycle(t *testing.T) {
+	tr := NewOutcomeTracker()
+
+	// A mutation opens debt; silent rounds age it.
+	write := ReceiptFromToolCall("write_file", json.RawMessage(`{"path":"pkg/repro.py","content":"x"}`), true, false)
+	if s := tr.ScoreRound([]Receipt{write}); s.DebtAge != 1 || s.Discriminating != 0 {
+		t.Fatalf("mutation round = %+v, want debt age 1", s)
+	}
+	read := readReceipt("other.go")
+	read.OutputBytes = 5
+	if s := tr.ScoreRound([]Receipt{read}); s.DebtAge != 2 {
+		t.Fatalf("silent round = %+v, want debt age 2", s)
+	}
+	// An unrelated command does not discriminate.
+	if s := tr.ScoreRound([]Receipt{bashReceipt("ls -la", true)}); s.DebtAge != 3 || s.Discriminating != 0 {
+		t.Fatalf("unrelated command = %+v, want debt age 3", s)
+	}
+	// Reading the mutated file is inspection, not discrimination: debt ages on.
+	if s := tr.ScoreRound([]Receipt{bashReceipt("cat pkg/repro.py", true)}); s.Discriminating != 0 || s.DebtAge != 4 {
+		t.Fatalf("read-only inspection = %+v, want no discrimination, debt age 4", s)
+	}
+	// Running the mutated file is a discriminating observation even though it
+	// is not delivery verification: debt settles.
+	if s := tr.ScoreRound([]Receipt{bashReceipt("python3 pkg/repro.py", false)}); s.Discriminating != 1 || s.DebtAge != 0 {
+		t.Fatalf("repro run = %+v, want discriminating 1, debt settled", s)
+	}
+	// Debt stays settled until the next mutation; delivery verification also
+	// counts as discriminating without any mutated-path match.
+	if s := tr.ScoreRound([]Receipt{bashReceipt("go test ./pkg", true)}); s.Discriminating != 1 || s.DebtAge != 0 {
+		t.Fatalf("verification round = %+v, want discriminating 1, no debt", s)
+	}
+}

--- a/internal/notify/sink.go
+++ b/internal/notify/sink.go
@@ -57,6 +57,10 @@ func (s *Sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(s.inner, sample)
 }
 
+func (s *Sink) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	event.RecordDelegationAdmission(s.inner, a)
+}
+
 // SendEvent applies the same notification rules for paths that do not emit through Sink.
 func SendEvent(sender Sender, cfg config.NotificationsConfig, e event.Event) {
 	if !cfg.Enabled || sender == nil {

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -184,6 +184,11 @@ func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(r.inner, sample)
 }
 
+// RecordDelegationAdmission preserves the wrapped sink's audit capability.
+func (r *Recorder) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	event.RecordDelegationAdmission(r.inner, a)
+}
+
 func (r *Recorder) recordUsage(e event.Event) {
 	r.recordProviderUsage(e.ModelRef, e.Usage)
 }

--- a/internal/telemetry/sink.go
+++ b/internal/telemetry/sink.go
@@ -139,6 +139,10 @@ func (s *sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(s.inner, sample)
 }
 
+func (s *sink) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	event.RecordDelegationAdmission(s.inner, a)
+}
+
 func (s *sink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 	add(s.counts, "tool_call_reasoning_recovery", string(a.Kind), 1)
 	event.RecordProtocolRecovery(s.inner, a)

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -44,15 +44,18 @@ type DelegationAdmission struct {
 
 // OutcomeProgress mirrors evidence.OutcomeSample with stable snake_case keys.
 type OutcomeProgress struct {
-	Round          int `json:"round"`
-	Exploration    int `json:"exploration,omitempty"`
-	Verification   int `json:"verification,omitempty"`
-	Objective      int `json:"objective,omitempty"`
-	Regression     int `json:"regression,omitempty"`
-	Churn          int `json:"churn,omitempty"`
-	LegacyGain     int `json:"legacy_gain,omitempty"`
-	Discriminating int `json:"discriminating,omitempty"`
-	DebtAge        int `json:"debt_age,omitempty"`
+	Round          int  `json:"round"`
+	Exploration    int  `json:"exploration,omitempty"`
+	Verification   int  `json:"verification,omitempty"`
+	Objective      int  `json:"objective,omitempty"`
+	Regression     int  `json:"regression,omitempty"`
+	Churn          int  `json:"churn,omitempty"`
+	LegacyGain     int  `json:"legacy_gain,omitempty"`
+	Discriminating int  `json:"discriminating,omitempty"`
+	DebtAge        int  `json:"debt_age,omitempty"`
+	BlindMutations int  `json:"blind_mutations,omitempty"`
+	EBMEligible    bool `json:"ebm_eligible,omitempty"`
+	EBMFired       bool `json:"ebm_fired,omitempty"`
 }
 
 // ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
@@ -185,6 +188,9 @@ func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 		LegacyGain:     sample.LegacyGain,
 		Discriminating: sample.Discriminating,
 		DebtAge:        sample.DebtAge,
+		BlindMutations: sample.BlindMutations,
+		EBMEligible:    sample.EBMEligible,
+		EBMFired:       sample.EBMFired,
 	}})
 	event.RecordOutcomeProgress(r.inner, sample)
 }

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -22,15 +22,24 @@ const SchemaVersion = 1
 // Record is one observed occurrence. Exactly one payload field is set; Seq
 // orders them and TS is the unix-millisecond observation time at the recorder.
 type Record struct {
-	SchemaVersion    int                  `json:"schema_version"`
-	Seq              uint64               `json:"seq"`
-	TS               int64                `json:"ts"`
-	Event            *eventwire.Event     `json:"event,omitempty"`
-	ReadinessAudit   *ReadinessAudit      `json:"readiness_audit,omitempty"`
-	ProtocolRecovery string               `json:"protocol_recovery,omitempty"`
-	TurnCompletion   bool                 `json:"turn_completion,omitempty"`
-	ContractShadow   *ContractShadowAudit `json:"contract_shadow,omitempty"`
-	OutcomeProgress  *OutcomeProgress     `json:"outcome_progress,omitempty"`
+	SchemaVersion       int                  `json:"schema_version"`
+	Seq                 uint64               `json:"seq"`
+	TS                  int64                `json:"ts"`
+	Event               *eventwire.Event     `json:"event,omitempty"`
+	ReadinessAudit      *ReadinessAudit      `json:"readiness_audit,omitempty"`
+	ProtocolRecovery    string               `json:"protocol_recovery,omitempty"`
+	TurnCompletion      bool                 `json:"turn_completion,omitempty"`
+	ContractShadow      *ContractShadowAudit `json:"contract_shadow,omitempty"`
+	OutcomeProgress     *OutcomeProgress     `json:"outcome_progress,omitempty"`
+	DelegationAdmission *DelegationAdmission `json:"delegation_admission,omitempty"`
+}
+
+// DelegationAdmission mirrors event.DelegationAdmissionAudit with stable keys.
+type DelegationAdmission struct {
+	Tool    string `json:"tool"`
+	Verdict string `json:"verdict"`
+	Reason  string `json:"reason,omitempty"`
+	Intent  string `json:"intent,omitempty"`
 }
 
 // OutcomeProgress mirrors evidence.OutcomeSample with stable snake_case keys.
@@ -174,6 +183,13 @@ func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 		LegacyGain:   sample.LegacyGain,
 	}})
 	event.RecordOutcomeProgress(r.inner, sample)
+}
+
+func (r *Recorder) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
+	r.append(Record{DelegationAdmission: &DelegationAdmission{
+		Tool: a.Tool, Verdict: a.Verdict, Reason: a.Reason, Intent: a.Intent,
+	}})
+	event.RecordDelegationAdmission(r.inner, a)
 }
 
 func (r *Recorder) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -44,13 +44,15 @@ type DelegationAdmission struct {
 
 // OutcomeProgress mirrors evidence.OutcomeSample with stable snake_case keys.
 type OutcomeProgress struct {
-	Round        int `json:"round"`
-	Exploration  int `json:"exploration,omitempty"`
-	Verification int `json:"verification,omitempty"`
-	Objective    int `json:"objective,omitempty"`
-	Regression   int `json:"regression,omitempty"`
-	Churn        int `json:"churn,omitempty"`
-	LegacyGain   int `json:"legacy_gain,omitempty"`
+	Round          int `json:"round"`
+	Exploration    int `json:"exploration,omitempty"`
+	Verification   int `json:"verification,omitempty"`
+	Objective      int `json:"objective,omitempty"`
+	Regression     int `json:"regression,omitempty"`
+	Churn          int `json:"churn,omitempty"`
+	LegacyGain     int `json:"legacy_gain,omitempty"`
+	Discriminating int `json:"discriminating,omitempty"`
+	DebtAge        int `json:"debt_age,omitempty"`
 }
 
 // ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
@@ -174,13 +176,15 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 
 func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	r.append(Record{OutcomeProgress: &OutcomeProgress{
-		Round:        sample.Round,
-		Exploration:  sample.Exploration,
-		Verification: sample.Verification,
-		Objective:    sample.Objective,
-		Regression:   sample.Regression,
-		Churn:        sample.Churn,
-		LegacyGain:   sample.LegacyGain,
+		Round:          sample.Round,
+		Exploration:    sample.Exploration,
+		Verification:   sample.Verification,
+		Objective:      sample.Objective,
+		Regression:     sample.Regression,
+		Churn:          sample.Churn,
+		LegacyGain:     sample.LegacyGain,
+		Discriminating: sample.Discriminating,
+		DebtAge:        sample.DebtAge,
 	}})
 	event.RecordOutcomeProgress(r.inner, sample)
 }

--- a/internal/trajectory/recorder_test.go
+++ b/internal/trajectory/recorder_test.go
@@ -110,13 +110,14 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	r.RecordProtocolRecovery(event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
 	r.RecordTurnCompletion()
 	r.RecordOutcomeProgress(evidence.OutcomeSample{Round: 3, Exploration: 2, Objective: 1, LegacyGain: 4})
+	r.RecordDelegationAdmission(event.DelegationAdmissionAudit{Tool: "research", Verdict: "deny", Reason: "local_fix_no_external_need", Intent: "mutation"})
 	if err := r.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
 	recs := readRecords(t, path)
-	if len(recs) != 4 {
-		t.Fatalf("got %d records, want 4", len(recs))
+	if len(recs) != 5 {
+		t.Fatalf("got %d records, want 5", len(recs))
 	}
 	if recs[0].ReadinessAudit == nil || recs[0].ReadinessAudit.Result != "blocked" || recs[0].ReadinessAudit.MissingVerification != 2 {
 		t.Errorf("readiness record = %+v", recs[0].ReadinessAudit)
@@ -129,6 +130,9 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	}
 	if recs[3].OutcomeProgress == nil || recs[3].OutcomeProgress.Round != 3 || recs[3].OutcomeProgress.Objective != 1 || recs[3].OutcomeProgress.LegacyGain != 4 {
 		t.Errorf("outcome progress record = %+v", recs[3].OutcomeProgress)
+	}
+	if recs[4].DelegationAdmission == nil || recs[4].DelegationAdmission.Verdict != "deny" || recs[4].DelegationAdmission.Tool != "research" {
+		t.Errorf("delegation admission record = %+v", recs[4].DelegationAdmission)
 	}
 	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 || len(inner.outcomes) != 1 {
 		t.Errorf("inner capabilities = %d/%d/%d/%d, want 1/1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns, len(inner.outcomes))


### PR DESCRIPTION
Stacked on #7953. The intervention phase's core infrastructure: policy evaluation as a local causal experiment.

## Why

Policy triggering is a function of the stochastic trajectory - the same task reaches `blind>=3` on one run and peaks at 2 on the next (measured twice on this corpus). Whole-task A/B therefore mixes "did the trigger arise at all" variance into every treatment estimate. Forking control and treatment from the identical eligible state removes that layer entirely, and post-fork totals ARE Remaining-Cost-From-Eligibility - no alignment arithmetic.

## Hard constraints implemented

1. **True same-state fork**: one versioned `ForkBundle` (conversation snapshot, workspace copy, turn input, outcome-tracker seed); both arms boot from it with identical config.
2. **Pre-treatment capture**: capture arms at first eligibility and refuses under live enforcement - a treated state can never become a fork origin (test-pinned).
3. **No fake new turn**: continuation runs the normal Run path; turn-local classification computes from the same input, then the appended user message is replaced wholesale by the frozen conversation via one restore hook.
4. **Versioned bundle** from day one - the same primitive will serve the reasoning governor, delegation admission, rollback and stop-policy experiments.
5. **No deterministic-replay pretension**: pair identity (task x rep x arm) is preserved through the report; analysis is per-pair, per-class.
6. **The payload invariant, as a test**: the control fork's first provider request deep-equals the request the uninterrupted run made after the eligible round; the treatment payload differs in exactly one message by exactly the nudge suffix. This test caught a real contamination during development - an in-round capture missed the eligible round's tool results (8-vs-7 messages) - which is precisely the class of silent drift it exists to catch. Capture therefore moved to the provider wrapper, freezing the state right before the next request.

## Usage

```
# capture bundles during a baseline (arm-A) suite run
e2ebench -suite benchmarks/verification-stress -fork-capture bundles/

# control/control sanity, then control/treatment
e2ebench -mode fork -bundles bundles/ -suite benchmarks/verification-stress -arm control,control -reps 2
e2ebench -mode fork -bundles bundles/ -suite benchmarks/verification-stress -arm control,treatment -reps 3
```

Arms alternate order per rep so provider drift cannot systematically favor one arm. The report is per-pair rows plus per-class aggregation; no blended overall score by design.

## Verification

- Four new agent tests: request-payload invariant (control), single-diff treatment, enforcement-refuses-capture, workspace-copy hygiene; all existing suites (agent, evidence, e2ebench, cli, boot) pass; gofmt/vet/repolint clean.

Cache-impact: none - capture and continuation are env-gated experiment paths; with the env unset no code path changes and no prompt bytes move
Cache-guard: TestForkControlContinuationMatchesOriginalRequest pins the payload byte-contract; default-off is pinned by every existing agent test running without the env
Documentation-impact: none - env-gated experiment infrastructure plus developer-tool flags; user-facing docs are untouched until a policy graduates
