### PR TITLE
fix(cli): make number keys hot-select in every numbered menu

### DIFF
--- a/internal/cli/chooser.go
+++ b/internal/cli/chooser.go
@@ -138,11 +138,16 @@ func (m chatTUI) handleChooserKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		return m.chooserActivate(c.cursor)
 	default:
-		// number keys 1..9 jump to / pick an option
-		if s := msg.String(); len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
-			if idx := int(s[0] - '1'); idx < len(q.Options) {
-				return m.chooserActivate(idx)
+		// number keys 1..9 pick an option: toggle it in a multi-select
+		// question, select-and-advance in a single-select one.
+		if idx, ok := numberKeyIndex(msg.String(), len(q.Options)); ok {
+			if q.Multi {
+				c.cursor = idx
+				c.sel[c.tab][idx] = !c.sel[c.tab][idx]
+				c.custom[c.tab] = ""
+				return m, nil
 			}
+			return m.chooserActivate(idx)
 		}
 	}
 	return m, nil

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -30,6 +30,13 @@ func (m chatTUI) handleClearConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 			return m.confirmClearContext()
 		}
 		m.clearConfirm = nil
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), 2); ok {
+			if idx == 0 {
+				return m.confirmClearContext()
+			}
+			m.clearConfirm = nil
+		}
 	}
 	return m, nil
 }

--- a/internal/cli/copy_picker.go
+++ b/internal/cli/copy_picker.go
@@ -48,6 +48,11 @@ func (m chatTUI) handleCopyPickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.applyCopyPick()
 	case "esc":
 		m.copyPick = nil
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), len(p.parts)); ok {
+			p.sel = idx
+			return m.applyCopyPick()
+		}
 	}
 	return m, nil
 }

--- a/internal/cli/digit_select_test.go
+++ b/internal/cli/digit_select_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/checkpoint"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func digitKey(d rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: d, Text: string(d)} }
+
+func newDigitTestAsk(multi bool) event.Ask {
+	return event.Ask{
+		ID: "ask-1",
+		Questions: []event.AskQuestion{{
+			ID:     "q1",
+			Prompt: "Pick",
+			Multi:  multi,
+			Options: []event.AskOption{
+				{Label: "Alpha"}, {Label: "Beta"}, {Label: "Gamma"},
+			},
+		}},
+	}
+}
+
+func TestNumberKeyIndex(t *testing.T) {
+	cases := []struct {
+		key   string
+		limit int
+		idx   int
+		ok    bool
+	}{
+		{"1", 3, 0, true},
+		{"3", 3, 2, true},
+		{"9", 9, 8, true},
+		{"4", 3, 0, false},
+		{"0", 3, 0, false},
+		{"a", 3, 0, false},
+		{"10", 3, 0, false},
+		{"ctrl+1", 3, 0, false},
+	}
+	for _, c := range cases {
+		idx, ok := numberKeyIndex(c.key, c.limit)
+		if ok != c.ok || (ok && idx != c.idx) {
+			t.Errorf("numberKeyIndex(%q, %d) = (%d, %v), want (%d, %v)", c.key, c.limit, idx, ok, c.idx, c.ok)
+		}
+	}
+}
+
+func TestChooserDigitSelectsAndSubmitsSingle(t *testing.T) {
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{})
+	m.chooser = newChooser(newDigitTestAsk(false))
+
+	next, _ := m.handleChooserKey(digitKey('2'))
+	got := next.(chatTUI)
+	if got.chooser != nil {
+		t.Fatal("digit on a single-question single-select prompt should submit and close it")
+	}
+}
+
+func TestChooserDigitTogglesMultiSelect(t *testing.T) {
+	m := newTestChatTUI()
+	m.chooser = newChooser(newDigitTestAsk(true))
+
+	next, _ := m.handleChooserKey(digitKey('2'))
+	got := next.(chatTUI)
+	if got.chooser == nil {
+		t.Fatal("digit on a multi-select question should not close the prompt")
+	}
+	if !got.chooser.sel[0][1] {
+		t.Fatal("digit 2 should toggle option 2 on")
+	}
+	if got.chooser.cursor != 1 {
+		t.Fatalf("digit 2 should move the cursor to the toggled row, got %d", got.chooser.cursor)
+	}
+
+	next, _ = got.handleChooserKey(digitKey('2'))
+	got = next.(chatTUI)
+	if got.chooser.sel[0][1] {
+		t.Fatal("pressing the digit again should toggle option 2 back off")
+	}
+}
+
+func TestChooserDigitOutOfRangeIsIgnored(t *testing.T) {
+	m := newTestChatTUI()
+	m.chooser = newChooser(newDigitTestAsk(false))
+
+	next, _ := m.handleChooserKey(digitKey('7'))
+	got := next.(chatTUI)
+	if got.chooser == nil {
+		t.Fatal("an out-of-range digit should leave the prompt open")
+	}
+}
+
+func TestClearConfirmDigitCancel(t *testing.T) {
+	m := newTestChatTUI()
+	m.clearConfirm = &clearConfirm{}
+
+	next, _ := m.handleClearConfirmKey(digitKey('2'))
+	if next.(chatTUI).clearConfirm != nil {
+		t.Fatal("digit 2 should cancel the /clear confirmation")
+	}
+}
+
+func TestCopyPickerDigitCopies(t *testing.T) {
+	m := newTestChatTUI()
+	m.copyPick = &copyPicker{parts: []string{"one", "two"}}
+
+	next, cmd := m.handleCopyPickerKey(digitKey('2'))
+	got := next.(chatTUI)
+	if got.copyPick != nil {
+		t.Fatal("digit 2 should pick the part and close the copy picker")
+	}
+	if cmd == nil {
+		t.Fatal("digit selection should return the clipboard command")
+	}
+}
+
+func TestRewindDigitJumpsToTurn(t *testing.T) {
+	m := newTestChatTUI()
+	m.rewind = &rewindPicker{
+		metas: []checkpoint.Meta{{Turn: 0}, {Turn: 1}, {Turn: 2}},
+		sel:   2,
+	}
+
+	next, _ := m.handleRewindKey(digitKey('2'))
+	r := next.(chatTUI).rewind
+	if r.sel != 1 {
+		t.Fatalf("digit 2 should select the row for turn 2, got sel %d", r.sel)
+	}
+	if r.stage != 1 {
+		t.Fatalf("digit selection should advance to the scope stage, got stage %d", r.stage)
+	}
+}
+
+func TestSkillPickerConfirmDeleteDigitCancel(t *testing.T) {
+	m := newTestChatTUI()
+	m.skillPick = &skillPicker{mode: pickerConfirmDelete}
+
+	next, _ := m.handleSkillPickerConfirmDeleteKey(digitKey('2'))
+	if got := next.(chatTUI).skillPick; got.mode != pickerDetail {
+		t.Fatalf("digit 2 should cancel back to the detail view, got mode %q", got.mode)
+	}
+}
+
+func TestMCPConfirmRemoveDigitCancel(t *testing.T) {
+	m := newTestChatTUI()
+	m.mcp = &mcpManager{stage: mcpStageConfirmRemove}
+
+	next, _ := m.handleMCPManagerKey(digitKey('2'))
+	if got := next.(chatTUI).mcp; got.stage != mcpStageDetail {
+		t.Fatalf("digit 2 should cancel back to the detail stage, got stage %v", got.stage)
+	}
+}

--- a/internal/cli/mcp_manager.go
+++ b/internal/cli/mcp_manager.go
@@ -225,6 +225,14 @@ func (m chatTUI) handleMCPManagerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m.removeSelectedMCP()
 			}
 			p.stage = mcpStageDetail
+		default:
+			if idx, ok := numberKeyIndex(msg.String(), 2); ok {
+				if idx == 0 {
+					p.confirm = 0
+					return m.removeSelectedMCP()
+				}
+				p.stage = mcpStageDetail
+			}
 		}
 	case mcpStageConfirmClearAuth:
 		switch msg.String() {
@@ -244,6 +252,14 @@ func (m chatTUI) handleMCPManagerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m.clearSelectedMCPAuthentication()
 			}
 			p.stage = mcpStageDetail
+		default:
+			if idx, ok := numberKeyIndex(msg.String(), 2); ok {
+				if idx == 0 {
+					p.confirm = 0
+					return m.clearSelectedMCPAuthentication()
+				}
+				p.stage = mcpStageDetail
+			}
 		}
 	}
 	return m, nil

--- a/internal/cli/resume_picker.go
+++ b/internal/cli/resume_picker.go
@@ -97,6 +97,11 @@ func (m chatTUI) handleResumePickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 		return m.applyResumePick()
 	case "esc":
 		m.resumePick = nil
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), len(r.sessions)); ok {
+			r.sel = idx
+			return m.applyResumePick()
+		}
 	}
 	return m, nil
 }

--- a/internal/cli/rewind.go
+++ b/internal/cli/rewind.go
@@ -121,6 +121,25 @@ func (m chatTUI) handleRewindKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			r.scope = 5
 			return m.applyRewind()
 		}
+	default:
+		if n, ok := numberKeyIndex(msg.String(), 9); ok {
+			switch r.stage {
+			case 0:
+				// Turn rows are numbered by turn (Turn+1), not list position.
+				for i, meta := range r.metas {
+					if meta.Turn == n {
+						r.sel = i
+						r.stage = 1
+						break
+					}
+				}
+			case 1:
+				if n < len(rewindActions) {
+					r.scope = n
+					return m.applyRewind()
+				}
+			}
+		}
 	}
 	return m, nil
 }

--- a/internal/cli/skill_picker.go
+++ b/internal/cli/skill_picker.go
@@ -204,6 +204,12 @@ func (m chatTUI) handleSkillPickerSourcesKey(msg tea.KeyPressMsg) (tea.Model, te
 		p.showDiagnostics = false
 	case "r":
 		m.rescanSkills()
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), len(visible)); ok {
+			p.sourceSel = idx
+			p.mode = pickerSourceSkills
+			p.sourceSkillSel = 0
+		}
 	}
 	return m, nil
 }
@@ -257,6 +263,11 @@ func (m chatTUI) handleSkillPickerDetailKey(msg tea.KeyPressMsg) (tea.Model, tea
 		}
 	case " ", "space":
 		p.toggleSkill(p.detailSkill.Name)
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), len(actions)); ok {
+			p.detailAction = idx
+			return m.applySkillAction(p.detailSkill, actions[idx])
+		}
 	}
 	p.detailAction = clampInt(p.detailAction, len(actions))
 	return m, nil
@@ -281,6 +292,14 @@ func (m chatTUI) handleSkillPickerConfirmDeleteKey(msg tea.KeyPressMsg) (tea.Mod
 			return m.deleteSkillPick(p.deleteSkill)
 		}
 		p.mode = pickerDetail
+	default:
+		if idx, ok := numberKeyIndex(msg.String(), 2); ok {
+			if idx == 0 {
+				p.confirm = 0
+				return m.deleteSkillPick(p.deleteSkill)
+			}
+			p.mode = pickerDetail
+		}
 	}
 	return m, nil
 }


### PR DESCRIPTION
Every modal menu in the chat TUI renders numbered rows (`❯ 1. …` via `rowLine`), but only the ask chooser and the tool-approval prompt actually accept digit presses. Everywhere else the numbers are painted on but dead — you have to arrow to the row and press Enter. The `numberKeyIndex` helper already exists, but it's only wired into the MCP manager's detail/mode stages.

This wires digit hot-select into every numbered menu, matching each menu's existing Enter semantics (same pattern Claude Code uses for its numbered prompts):

- **chooser**: digits on a multi-select question now toggle the option — previously `chooserActivate` treated a digit like Enter and committed the answer without selecting anything; single-select keeps select-and-advance. Note this deliberately revisits one line of #3530, which described "Enter (and number keys)" as confirm in multi-select — that wording predates digits carrying a row-specific meaning, and Enter fully keeps the confirm-and-advance role #3530 established.
- **/clear confirm**: `1` clears, `2` cancels
- **/copy picker**: digit copies that part
- **resume picker** (legacy list path): digit resumes that session
- **rewind**: stage 0 digit jumps to that turn; stage 1 digit applies that scope (parity with the existing `b/c/d/f/s/u` letter shortcuts)
- **skill picker**: sources list, detail actions, and delete confirm
- **MCP manager**: confirm-remove and confirm-clear-auth stages

Searchable pickers (quick picker, resume search, skill search) are deliberately untouched — digits there remain query text, matching Claude Code's searchable menus.

Out-of-range digits are ignored (no accidental activation). New tests in `internal/cli/digit_select_test.go` cover the helper, single/multi chooser behavior, and one representative menu per pattern.

Users already reach for digits on these prompts — #5278 asks for arrow keys on the desktop `/clear` popup precisely because digits and mouse are the only selection paths there; this PR closes the same expectation gap from the TUI side.

Documentation-impact: none - behavior change only makes already-rendered menu numbers interactive; no documented workflow, flag, or config changes, and docs/ describes none of these menus key-by-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
