### PR TITLE
feat(provider): per-request reasoning-effort override

### DIFF
--- a/internal/provider/openai/effort.go
+++ b/internal/provider/openai/effort.go
@@ -1,0 +1,105 @@
+// Effort vocabulary and per-request depth resolution: which reasoning levels
+// an endpoint accepts, and how a Request.EffortOverride maps onto them.
+package openai
+
+import (
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// configuredThinkingType reads the optional explicit `thinking` config field —
+// a vendor-agnostic escape hatch (credit @eghrhegpe, #5063) for OpenAI-
+// compatible providers we don't auto-detect (e.g. opencode.ai). Unknown values
+// are ignored so a typo never breaks a request.
+func configuredThinkingType(cfg provider.Config) string {
+	t, _ := cfg.Extra["thinking"].(string)
+	t = strings.ToLower(strings.TrimSpace(t))
+	if t != "enabled" && t != "disabled" {
+		return ""
+	}
+	return t
+}
+
+// effortEndpoint carries the protocol facts New resolved that decide which
+// depth levels a per-request override may take.
+type effortEndpoint struct {
+	protocol     string
+	thinkingType string
+	effort       string
+	deepseek     bool
+	flash        bool // deepseek-v4-flash — the only official DeepSeek model with effort=low
+	minimax      bool
+	zhipu        bool
+	longcat      bool
+	ollamaCloud  bool
+	explicit     bool
+	supported    []string
+}
+
+// requestEffortVocabulary lists exactly the depth levels New would accept as a
+// configured effort for this endpoint. Binary thinking knobs and disabled
+// thinking yield nil — an override adjusts depth, never whether thinking runs.
+func requestEffortVocabulary(e effortEndpoint) []string {
+	if e.thinkingType == "disabled" || e.protocol == "none" || e.minimax || e.zhipu || e.longcat {
+		return nil
+	}
+	var levels []string
+	switch {
+	case e.explicit:
+		levels = e.supported
+	case e.deepseek:
+		levels = []string{"high", "max"}
+		if e.flash {
+			levels = append(levels, "low")
+		}
+	case e.ollamaCloud:
+		levels = []string{"low", "medium", "high", "max"}
+	case e.effort != "":
+		levels = []string{"low", "medium", "high"}
+	}
+	return depthOnly(levels)
+}
+
+// depthOnly strips thinking on/off toggles from an effort vocabulary.
+func depthOnly(levels []string) []string {
+	var out []string
+	for _, level := range levels {
+		switch strings.ToLower(strings.TrimSpace(level)) {
+		case "", "auto", "enabled", "adaptive", "disabled", "none", "off":
+		default:
+			out = append(out, level)
+		}
+	}
+	return out
+}
+
+// requestEffort resolves one request's reasoning depth: a vocabulary-approved
+// EffortOverride wins, anything else falls back to the configured effort.
+func (c *client) requestEffort(req provider.Request) string {
+	want := strings.ToLower(strings.TrimSpace(req.EffortOverride))
+	if want == "" || !supportsEffort(c.requestEfforts, want) {
+		return c.effort
+	}
+	return want
+}
+
+func supportsEffort(levels []string, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	for _, level := range levels {
+		if strings.ToLower(strings.TrimSpace(level)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExplicitSupportedEfforts(levels []string) bool {
+	for _, level := range levels {
+		level = strings.ToLower(strings.TrimSpace(level))
+		if level != "" && level != "auto" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provider/openai/effort_override_test.go
+++ b/internal/provider/openai/effort_override_test.go
@@ -1,0 +1,91 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func newTestClient(t *testing.T, model string, extra map[string]any) *client {
+	t.Helper()
+	cfg := provider.Config{Name: "p", BaseURL: "https://api.deepseek.com", Model: model, APIKey: "k", Extra: extra}
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p.(*client)
+}
+
+func TestEffortOverrideDeepSeekFlash(t *testing.T) {
+	c := newTestClient(t, "deepseek-v4-flash", map[string]any{"reasoning_protocol": "deepseek"})
+	if got := c.buildRequest(provider.Request{}).ReasoningEffort; got != "high" {
+		t.Fatalf("default reasoning_effort = %q, want high", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "low"}).ReasoningEffort; got != "low" {
+		t.Fatalf("override low: reasoning_effort = %q, want low", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "medium"}).ReasoningEffort; got != "high" {
+		t.Fatalf("override outside DeepSeek vocabulary must keep the default, got %q", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
+		t.Fatalf("override must never toggle thinking off, got %q", got)
+	}
+}
+
+func TestEffortOverrideDeepSeekNonFlashRejectsLow(t *testing.T) {
+	c := newTestClient(t, "deepseek-v4", map[string]any{"reasoning_protocol": "deepseek"})
+	if got := c.buildRequest(provider.Request{EffortOverride: "low"}).ReasoningEffort; got != "high" {
+		t.Fatalf("low is flash-only; reasoning_effort = %q, want high", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "max"}).ReasoningEffort; got != "max" {
+		t.Fatalf("max is in the official DeepSeek vocabulary, got %q", got)
+	}
+}
+
+func TestEffortOverrideHonorsSupportedEfforts(t *testing.T) {
+	c := newTestClient(t, "deepseek-v4", map[string]any{
+		"reasoning_protocol": "deepseek",
+		"effort":             "high",
+		"supported_efforts":  []string{"low", "high", "disabled"},
+	})
+	if got := c.buildRequest(provider.Request{EffortOverride: "low"}).ReasoningEffort; got != "low" {
+		t.Fatalf("declared vocabulary must admit low, got %q", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "max"}).ReasoningEffort; got != "high" {
+		t.Fatalf("undeclared level must keep the default, got %q", got)
+	}
+	if got := c.buildRequest(provider.Request{EffortOverride: "disabled"}).ReasoningEffort; got != "high" {
+		t.Fatalf("disabled is a thinking toggle, not a depth; got %q", got)
+	}
+}
+
+func TestEffortOverrideIgnoredByBinaryThinkingKnobs(t *testing.T) {
+	for _, c := range []*client{
+		{model: "MiniMax-M3", minimax: true},
+		{model: "glm-4.5-air", zhipu: true},
+		{model: "LongCat-Flash", longcat: true},
+	} {
+		out := c.buildRequest(provider.Request{EffortOverride: "low"})
+		if out.ReasoningEffort != "" {
+			t.Errorf("%s: reasoning_effort = %q, want omitted", c.model, out.ReasoningEffort)
+		}
+		if out.Thinking != nil && strings.Contains(out.Thinking.Type, "low") {
+			t.Errorf("%s: override leaked into thinking.type %q", c.model, out.Thinking.Type)
+		}
+	}
+}
+
+func TestEffortOverrideIgnoredWithoutDepthVocabulary(t *testing.T) {
+	// A generic gateway with no configured effort and no supported_efforts has
+	// no evidence of a depth scale — the override must not invent wire fields.
+	c := &client{model: "mimo-v2"}
+	if got := c.buildRequest(provider.Request{EffortOverride: "low"}).ReasoningEffort; got != "" {
+		t.Fatalf("reasoning_effort = %q, want omitted", got)
+	}
+
+	disabled := newTestClient(t, "deepseek-v4", map[string]any{"reasoning_protocol": "deepseek", "thinking": "disabled"})
+	if got := disabled.buildRequest(provider.Request{EffortOverride: "high"}).ReasoningEffort; got != "" {
+		t.Fatalf("thinking-disabled provider must ignore overrides, got %q", got)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -110,15 +110,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	zhipu := protocol == "glm" || (protocol == "" && IsZhipu(cfg.BaseURL))
 	longcat := protocol == "" && IsLongCat(cfg.BaseURL)
 	ollamaCloud := protocol == "" && IsOllamaCloud(cfg.BaseURL)
-	// Optional explicit `thinking` config field — a vendor-agnostic escape hatch
-	// (credit @eghrhegpe, #5063) for OpenAI-compatible providers we don't
-	// auto-detect (e.g. opencode.ai). "enabled"/"disabled" drive thinking.type;
-	// anything else is ignored so an unknown value never breaks a request.
-	thinkingType, _ := cfg.Extra["thinking"].(string)
-	thinkingType = strings.ToLower(strings.TrimSpace(thinkingType))
-	if thinkingType != "enabled" && thinkingType != "disabled" {
-		thinkingType = ""
-	}
+	thinkingType := configuredThinkingType(cfg)
 	switch {
 	case protocol == "none":
 		effort = ""
@@ -224,6 +216,10 @@ func New(cfg provider.Config) (provider.Provider, error) {
 			return nil, fmt.Errorf("openai: provider %q: effort must be low, medium, or high", name)
 		}
 	}
+	requestEfforts := requestEffortVocabulary(effortEndpoint{protocol: protocol,
+		thinkingType: thinkingType, effort: effort, deepseek: deepseek, flash: deepseekV4Flash,
+		minimax: minimax, zhipu: zhipu, longcat: longcat, ollamaCloud: ollamaCloud,
+		explicit: hasExplicitEfforts, supported: supportedEfforts})
 	// The automatic cap protects DeepSeek reasoning, not ordinary long-form
 	// output. Preserve an explicit user budget in either mode, but leave a
 	// thinking-disabled request uncapped unless the user configured one.
@@ -256,29 +252,10 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		visionDetail:    visionDetail,
 		maxOutputTokens: maxOutputTokens,
 		effort:          effort,
+		requestEfforts:  requestEfforts,
 		http:            httpClient,
 		idleTimeout:     defaultStreamIdleTimeout,
 	}, nil
-}
-
-func supportsEffort(levels []string, want string) bool {
-	want = strings.ToLower(strings.TrimSpace(want))
-	for _, level := range levels {
-		if strings.ToLower(strings.TrimSpace(level)) == want {
-			return true
-		}
-	}
-	return false
-}
-
-func hasExplicitSupportedEfforts(levels []string) bool {
-	for _, level := range levels {
-		level = strings.ToLower(strings.TrimSpace(level))
-		if level != "" && level != "auto" {
-			return true
-		}
-	}
-	return false
 }
 
 func newHTTPClient(cfg provider.Config) (*http.Client, error) {
@@ -314,6 +291,7 @@ type client struct {
 	visionDetail    string        // image_url detail hint (low|high); "" = auto/omit
 	maxOutputTokens int           // configured/default total output budget; <=0 omits the optional field
 	effort          string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	requestEfforts  []string      // depth levels a per-request EffortOverride may take; empty = overrides ignored
 	idleTimeout     time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 	authed          atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
@@ -808,7 +786,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		StreamOptions:   &streamOptions{IncludeUsage: true},
 		Temperature:     req.Temperature,
 		MaxTokens:       maxOutputTokens,
-		ReasoningEffort: kimiK3ReasoningEffort(c.kimiK3, c.effort),
+		ReasoningEffort: kimiK3ReasoningEffort(c.kimiK3, c.requestEffort(req)),
 		ExtraBody:       c.extraBody,
 	}
 	switch {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,10 +56,9 @@ type Message struct {
 	ProviderContent  string   `json:"provider_content,omitempty"`
 	Images           []string `json:"images,omitempty"`            // data URLs (data:<mime>;base64,…) on user (attachments) and tool (MCP image results) messages; embedded only for vision-capable models
 	ReasoningContent string   `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
-	// ReasoningID is the provider-issued identifier of the reasoning item
-	// (OpenAI Responses schema: Reasoning.id is required on input items).
-	// Captured from the streamed output item and round-tripped back into
-	// the input on subsequent turns, matching the wire schema.
+	// ReasoningID is the provider-issued reasoning-item id (OpenAI Responses:
+	// Reasoning.id is required on input items), captured from the streamed
+	// output item and round-tripped back into later inputs.
 	ReasoningID string `json:"reasoning_id,omitempty"`
 	// ReasoningStatus is the final status of the reasoning item
 	// ("in_progress" | "completed") as issued by the server's done event,
@@ -221,6 +220,7 @@ type Request struct {
 	// output (Responses: text.format.type=json_object). Nil omits the field
 	// entirely — the common path must stay byte-stable for prompt caching.
 	ResponseFormat *ResponseFormat `json:"ResponseFormat,omitempty"`
+	EffortOverride string          `json:"EffortOverride,omitempty"` // per-call reasoning-depth override; adapters apply it only when the endpoint's effort vocabulary accepts it
 }
 
 // ResponseFormat asks a provider to constrain its output shape.


### PR DESCRIPTION
PR1 of the reasoning-governor runtime series (exploration-cell finding replicated on fresh frozen states: 6 states / 54 fork continuations, zero pass changes, reasoning tokens consistently down).

## What

- `provider.Request.EffortOverride`: a per-call reasoning-depth override. Empty means the configured effort stands; `omitempty` keeps the request struct's serialized form byte-identical when unused (golden baseline passes unchanged).
- The openai adapter resolves the override against a per-endpoint vocabulary computed at construction - exactly the depth levels `New` would accept as a configured effort (official DeepSeek: high/max, plus low on deepseek-v4-flash; `supported_efforts` wins when declared; Ollama Cloud gets its documented scale; generic gateways only when an effort was configured). Binary thinking knobs (MiniMax/Zhipu/LongCat) and thinking-disabled endpoints never see overrides: the knob adjusts depth, never whether thinking runs.
- Unsupported values fall back to the configured default instead of erroring - a mid-turn override can never break a live request.
- Effort concerns (explicit `thinking` config parsing, vocabulary, per-request resolution) move to `internal/provider/openai/effort.go`.

## Why

The low-effort governor arm preserved pass outcomes exactly across two independent fork rounds while cutting model time and reasoning tokens; runtime-izing it needs a request-scoped effort seam - today's `-effort` knob is provider-construction-scoped. PR2 wires the state-gated trigger (debt-free + no local exec + expensive previous round) behind `REASONIX_EXPERIMENT_GOVERNOR`.

Cache-impact: none - reasoning_effort/thinking are request-body parameters; the provider-visible prompt prefix stays byte-identical and the empty field marshals away (TestGoldenBaselineNoExtensions passes ungenerated)
Cache-guard: internal/boot golden baseline (provider_request.json unchanged) plus TestEffortOverride* asserting the override changes only the request-body reasoning_effort field
Documentation-impact: none - experiment-facing provider plumbing with no user-visible behavior; no config surface or CLI flag changes, docs stay correct
