### PR TITLE
Fix transcript selection release / 修复聊天选区无法释放

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-selection-menu.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-selection-menu.test.tsx
@@ -158,6 +158,11 @@ console.log("\ntranscript selection menu");
   const addButton = document.querySelector(".transcript-selection-action button") as HTMLButtonElement | null;
   eq(addButton?.textContent?.includes("Add to Chat"), true, "pointer selection exposes Add to Chat");
   await act(async () => {
+    addButton?.dispatchEvent(new window.MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    await flushTimers();
+  });
+  eq(document.getSelection()?.isCollapsed, false, "clicking Add to Chat keeps the captured selection until activation");
+  await act(async () => {
     addButton?.click();
     await flushTimers();
   });
@@ -202,6 +207,22 @@ console.log("\ntranscript selection menu");
     await drainFrame();
   });
   ok(document.querySelector(".transcript-selection-action") != null, "a fresh pointer gesture re-opens the dismissed action");
+
+  // A new left-click must release the previous browser range before the
+  // WebView's selectionchange event arrives. This keeps a stale selection from
+  // surviving a click elsewhere in the chat area.
+  selectNodeText(msgBody.firstChild as Node);
+  await act(async () => {
+    document.dispatchEvent(new window.MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    await flushTimers();
+  });
+  eq(document.getSelection()?.isCollapsed, true, "a new left-click clears the previous transcript selection");
+  eq(document.querySelector(".transcript-selection-action"), null, "clearing the selection closes the floating action");
+  selectNodeText(msgBody.firstChild as Node);
+  await act(async () => {
+    msgBody.dispatchEvent(new window.MouseEvent("pointerup", { bubbles: true, button: 0 }));
+    await drainFrame();
+  });
 
   // Rebinding selection.addToChat through the shared shortcut registry remaps
   // both the handler and the visible hint; the old combo stops firing.
@@ -249,6 +270,7 @@ console.log("\ntranscript selection menu");
     await flushTimers();
   });
   eq(document.querySelector(".transcript-selection-action"), null, "a tab switch discards the captured selection action");
+  eq(document.getSelection()?.isCollapsed, true, "a tab switch clears the native transcript selection");
   await act(async () => {
     root.render(
       <LocaleProvider>
@@ -262,6 +284,10 @@ console.log("\ntranscript selection menu");
     await drainFrame();
   });
   eq(document.querySelector(".transcript-selection-action"), null, "keyup over a hydration placeholder cannot re-summon the action");
+  selectNodeText(msgBody.firstChild as Node);
+  const disabledContextEvent = await dispatchContextMenu(msgBody);
+  eq(disabledContextEvent.defaultPrevented, false, "disabled selection handling leaves the native context menu alone");
+  eq(document.querySelector(".context-menu"), null, "disabled selection handling does not open a copy menu");
 
   selectNodeText(msgBody.firstChild as Node);
   await act(async () => {
@@ -274,6 +300,15 @@ console.log("\ntranscript selection menu");
   });
   await dispatchContextMenu(msgBody);
   ok(document.querySelector(".context-menu") != null, "the copy menu opens before a tab switch");
+  await act(async () => {
+    root.render(
+      <LocaleProvider>
+        <TranscriptSelectionMenu onAddToChat={(text) => additions.push(text)} resetKey="tab-b" enabled={false} />
+      </LocaleProvider>,
+    );
+    await flushTimers();
+  });
+  eq(document.querySelector(".context-menu"), null, "disabling selection handling closes an already-open copy menu");
   await act(async () => {
     root.render(
       <LocaleProvider>

--- a/desktop/frontend/src/components/TranscriptSelectionMenu.tsx
+++ b/desktop/frontend/src/components/TranscriptSelectionMenu.tsx
@@ -76,6 +76,7 @@ export function TranscriptSelectionMenu({
     setPoint(null);
     setText("");
     closeAction();
+    document.getSelection()?.removeAllRanges();
   }, [closeAction, resetKey]);
 
   const addSelectionToChat = useCallback(() => {
@@ -120,7 +121,7 @@ export function TranscriptSelectionMenu({
 
   useEffect(() => {
     const onContextMenu = (event: MouseEvent) => {
-      if (typeof window === "undefined" || !window.runtime) return;
+      if (!enabled || typeof window === "undefined" || !window.runtime) return;
       const selected = messageSelectionContextText(document, event.target);
       if (selected == null) return;
       event.preventDefault();
@@ -129,7 +130,15 @@ export function TranscriptSelectionMenu({
     };
     document.addEventListener("contextmenu", onContextMenu);
     return () => document.removeEventListener("contextmenu", onContextMenu);
-  }, []);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (enabled && onAddToChat) return;
+    setPoint(null);
+    setText("");
+    closeAction();
+    document.getSelection()?.removeAllRanges();
+  }, [closeAction, enabled, onAddToChat]);
 
   useEffect(() => {
     if (!enabled || !onAddToChat) {
@@ -169,6 +178,20 @@ export function TranscriptSelectionMenu({
       dismissedRef.current = null;
       scheduleShow(event.target);
     };
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0) return;
+      const target = event.target instanceof Element ? event.target : null;
+      // Keep the selection alive while the action itself is clicked so the
+      // button can consume the captured text. Every other left-click starts a
+      // new gesture; clear the old range immediately instead of relying on
+      // WebView-specific selectionchange ordering.
+      if (target?.closest(".transcript-selection-action")) return;
+      const selection = document.getSelection();
+      if (!selection || selection.isCollapsed) return;
+      selection.removeAllRanges();
+      dismissedRef.current = null;
+      closeAction();
+    };
     const onKeyUp = (event: KeyboardEvent) => {
       const selection = document.getSelection();
       const target = selection?.focusNode instanceof Element
@@ -190,6 +213,7 @@ export function TranscriptSelectionMenu({
     };
     const close = () => closeAction();
 
+    document.addEventListener("pointerdown", onPointerDown);
     document.addEventListener("pointerup", onPointerUp);
     document.addEventListener("keyup", onKeyUp);
     document.addEventListener("keydown", onKeyDown);
@@ -198,6 +222,7 @@ export function TranscriptSelectionMenu({
     window.addEventListener("scroll", close, true);
     return () => {
       if (frame !== null) cancelAnimationFrame(frame);
+      document.removeEventListener("pointerdown", onPointerDown);
       document.removeEventListener("pointerup", onPointerUp);
       document.removeEventListener("keyup", onKeyUp);
       document.removeEventListener("keydown", onKeyDown);


### PR DESCRIPTION
## What changed

- Release stale transcript selections when a new left-click gesture starts.
- Keep the captured range while the Add to Chat action is activated.
- Clear native selection and copy-menu state when switching tabs or disabling selection handling.
- Add regression coverage for pointer, tab-switch, disabled-state, and copy-menu lifecycles.

## Why

In the desktop WebView, `selectionchange` ordering could leave the native highlight and the Add to Chat action out of sync after selecting transcript text. Disabled states could also leave a stale copy menu or native range behind.

## Verification

- `pnpm exec tsx src/__tests__/transcript-selection-menu.test.tsx` (44 passed)
- `pnpm exec tsx src/__tests__/message-selection-copy.test.ts` (13 passed)
- `pnpm build`

### Real desktop smoke tests

- macOS host, native Wails bundle: mouse-dragged assistant text, confirmed Add to Chat appeared, clicked elsewhere and confirmed the highlight/action disappeared, then confirmed Add to Chat preserved the selection through activation and inserted it into the composer.
- Ubuntu 24.04 ARM64 in Parallels, native Wails/WebKitGTK build (`-tags webkit2_41`): mouse-dragged assistant text, confirmed Add to Chat appeared, then clicked elsewhere and confirmed the selection/action disappeared.
- Windows 11 ARM64 in Parallels, native Wails/WebView2 build: generated a live response through a loopback mock provider, verified a non-collapsed transcript selection and visible Add to Chat toolbar, then clicked elsewhere in the transcript through the native WebView input path and confirmed `selection.isCollapsed === true` and the toolbar was removed.
- The Windows `localhost` browser session was not counted as a desktop result because it has no Wails runtime bridge.

Documentation-impact: none - Existing desktop documentation remains correct; this only repairs transcript selection lifecycle behavior.
Cache-impact: none - Provider-visible prompt construction and cache prefixes are unchanged.
Cache-guard: N/A - No cache-sensitive code changed.
System-prompt-review: N/A
