### PR TITLE
feat(agent): exploration-phase reasoning governor (env-gated)

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -205,7 +205,7 @@ func main() {
 	cacheArm := flag.String("cache", "cold", "suite mode: cold (fresh session per task) | warm (prefix-warming one-step run in the same workdir before the graded run)")
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
-	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge)")
+	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge) | governor (exploration-phase reasoning governor)")
 	forkCapture := flag.String("fork-capture", "", "suite mode: capture a fork bundle per task at first EBM eligibility into <dir>/<task-id>")
 	bundles := flag.String("bundles", "", "fork mode: directory of captured bundles (<task-id>/bundle.json)")
 	forkArms := flag.String("arm", "control,treatment", "fork mode: comma-separated continuation arms (control | treatment)")
@@ -509,10 +509,13 @@ func runTask(cfg suiteConfig, t task) result {
 
 	cmd := exec.CommandContext(ctx, cfg.bin, args...)
 	cmd.Dir = work
-	if cfg.policy == "ebm" || cfg.forkCapture != "" {
+	if cfg.policy != "" || cfg.forkCapture != "" {
 		env := os.Environ()
-		if cfg.policy == "ebm" {
+		switch cfg.policy {
+		case "ebm":
 			env = append(env, "REASONIX_EXPERIMENT_EBM=1")
+		case "governor":
+			env = append(env, "REASONIX_EXPERIMENT_GOVERNOR=1")
 		}
 		if cfg.forkCapture != "" {
 			env = append(env, "REASONIX_EXPERIMENT_FORK_CAPTURE_DIR="+filepath.Join(cfg.forkCapture, t.ID))

--- a/cmd/e2ebench/outcome.go
+++ b/cmd/e2ebench/outcome.go
@@ -42,6 +42,12 @@ type outcomeSummary struct {
 	// coherent patch the copy permits, >=2 = real non-compliance.
 	EBMExtraBlind   int    `json:"ebm_extra_blind_mutations"`
 	EBMPostSequence string `json:"ebm_post_sequence,omitempty"`
+
+	// Governor chain: rounds the exploration trigger held, rounds the depth
+	// override actually rode requests, and where the first engagement sat.
+	GovernorEligibleRounds int `json:"governor_eligible_rounds,omitempty"`
+	GovernorEngagedRounds  int `json:"governor_engaged_rounds,omitempty"`
+	GovernorFirstRound     int `json:"governor_first_round,omitempty"`
 }
 
 // outcomePoint is one recorded shadow sample plus its observation time.
@@ -50,6 +56,7 @@ type outcomePoint struct {
 	exploration, verification, objective, regression, churn int
 	legacyGain, discriminating, debtAge, blindMutations     int
 	ebmEligible, ebmFired                                   bool
+	governorEligible, governorEngaged                       bool
 }
 
 // verifyPoint is one backfilled verification-transition observation.
@@ -166,6 +173,15 @@ func (t *trajScan) attachEBMChain(o *outcomeSummary) {
 		if o.EBMEligibleRound == 0 && p.ebmEligible {
 			o.EBMEligibleRound = i + 1
 		}
+		if p.governorEligible {
+			o.GovernorEligibleRounds++
+		}
+		if p.governorEngaged {
+			o.GovernorEngagedRounds++
+			if o.GovernorFirstRound == 0 {
+				o.GovernorFirstRound = i + 1
+			}
+		}
 		if fire < 0 && p.ebmFired {
 			fire = i
 		}
@@ -206,6 +222,27 @@ func postEBMCategory(p outcomePoint) string {
 	default:
 		return "."
 	}
+}
+
+// governorShadowLine aggregates the reasoning-governor shadow across runs;
+// empty when no round was eligible.
+func governorShadowLine(results []result) string {
+	runs, elig, engaged := 0, 0, 0
+	for _, r := range results {
+		if r.Trajectory == nil || r.Trajectory.Outcome == nil {
+			continue
+		}
+		o := r.Trajectory.Outcome
+		if o.GovernorEligibleRounds > 0 {
+			runs++
+		}
+		elig += o.GovernorEligibleRounds
+		engaged += o.GovernorEngagedRounds
+	}
+	if elig == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" · **governor** eligible %d rounds in %d runs · engaged %d rounds", elig, runs, engaged)
 }
 
 func summarizeVerifyBackfill(points []verifyPoint, lastTS int64) *outcomeSummary {
@@ -316,6 +353,7 @@ func renderOutcomeProgress(results []result) string {
 				pct(comply, fired), median(toCheck))
 		}
 	}
+	line += governorShadowLine(results)
 	if progress > 0 {
 		line += fmt.Sprintf(" · **false progress** %d/%d (%s)", falseProgress, progress, pct(falseProgress, progress))
 	}

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -144,18 +144,20 @@ type trajectoryRecord struct {
 		Complete bool   `json:"complete"`
 	} `json:"contract_shadow"`
 	OutcomeProgress *struct {
-		Exploration    int  `json:"exploration"`
-		Verification   int  `json:"verification"`
-		Objective      int  `json:"objective"`
-		Regression     int  `json:"regression"`
-		Churn          int  `json:"churn"`
-		LegacyGain     int  `json:"legacy_gain"`
-		Discriminating int  `json:"discriminating"`
-		DebtAge        int  `json:"debt_age"`
-		BlindMutations int  `json:"blind_mutations"`
-		EBMEligible    bool `json:"ebm_eligible"`
-		EBMFired       bool `json:"ebm_fired"`
-		LocalExecSeen  bool `json:"local_exec_seen"`
+		Exploration      int  `json:"exploration"`
+		Verification     int  `json:"verification"`
+		Objective        int  `json:"objective"`
+		Regression       int  `json:"regression"`
+		Churn            int  `json:"churn"`
+		LegacyGain       int  `json:"legacy_gain"`
+		Discriminating   int  `json:"discriminating"`
+		DebtAge          int  `json:"debt_age"`
+		BlindMutations   int  `json:"blind_mutations"`
+		EBMEligible      bool `json:"ebm_eligible"`
+		EBMFired         bool `json:"ebm_fired"`
+		LocalExecSeen    bool `json:"local_exec_seen"`
+		GovernorEligible bool `json:"governor_eligible"`
+		GovernorEngaged  bool `json:"governor_engaged"`
 	} `json:"outcome_progress"`
 	DelegationAdmission *struct {
 		Tool    string `json:"tool"`
@@ -360,6 +362,7 @@ func (t *trajScan) record(rec trajectoryRecord) {
 			objective: op.Objective, regression: op.Regression, churn: op.Churn,
 			legacyGain: op.LegacyGain, discriminating: op.Discriminating, debtAge: op.DebtAge,
 			blindMutations: op.BlindMutations, ebmEligible: op.EBMEligible, ebmFired: op.EBMFired,
+			governorEligible: op.GovernorEligible, governorEngaged: op.GovernorEngaged,
 		})
 	}
 	if da := rec.DelegationAdmission; da != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -571,12 +571,15 @@ type Agent struct {
 	// ebm is the Evidence-Before-More-Mutation nudge's once-per-turn state.
 	ebm ebmState
 
+	// governor is the reasoning governor's per-turn engagement state.
+	governor governorState
+
 	// forkRestore, when armed, swaps the frozen fork-bundle conversation in
 	// right after beginRunTurn — the counterfactual-continuation seam.
 	forkRestore func(*runLoopState)
 
-	// lastReasoning is the previous round's reasoning-token spend, observed
-	// by the capture provider; only the governor fork trigger reads it.
+	// lastReasoning is the previous executor round's reasoning-token spend,
+	// read by the governor trigger (live policy and fork capture alike).
 	lastReasoning int
 
 	// repeatFailureCounts tracks semantically identical write-like calls that
@@ -2479,7 +2482,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 				responsesItems = append(responsesItems, append(json.RawMessage(nil), chunk.ResponsesItem...))
 			}
 		case provider.ChunkUsage:
-			usage = chunk.Usage
+			usage, a.lastReasoning = chunk.Usage, chunk.Usage.ReasoningTokens
 			a.lastUsage.Store(chunk.Usage)
 			a.sessCacheHit.Add(int64(chunk.Usage.CacheHitTokens))
 			a.sessCacheMiss.Add(int64(chunk.Usage.CacheMissTokens))

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -47,13 +47,14 @@ func (a *Agent) armForkCapture(sample evidence.OutcomeSample) {
 const govReasoningThreshold = 1500
 
 // armGovernorCapture freezes the exploration-phase state where the reasoning
-// governor would intervene: no verification debt yet, no local check path
-// discovered, and the round that just ended bought expensive thinking.
+// governor would intervene — the same governorTrigger the live policy reads,
+// so experiments fork exactly the states enforcement would treat. Refuses
+// under live enforcement: a treated state must never become a bundle.
 func (a *Agent) armGovernorCapture(sample evidence.OutcomeSample) {
-	if forkCapturePolicy() != "governor" || a.ebm.captured || a.ebm.captureArmed {
+	if forkCapturePolicy() != "governor" || governorEnabled || a.ebm.captured || a.ebm.captureArmed {
 		return
 	}
-	if sample.DebtAge > 0 || sample.LocalExecSeen || a.lastReasoning < govReasoningThreshold {
+	if !governorTrigger(sample, a.lastReasoning) {
 		return
 	}
 	a.ebm.captureArmed = true
@@ -98,23 +99,7 @@ func (p *forkCaptureProvider) Stream(ctx context.Context, req provider.Request) 
 			fmt.Fprintln(os.Stderr, "fork capture:", err)
 		}
 	}
-	inner, err := p.inner.Stream(ctx, req)
-	if err != nil {
-		return inner, err
-	}
-	// Relay chunks while noting each round's reasoning spend — the governor
-	// trigger reads it when the round's shadow sample is scored.
-	out := make(chan provider.Chunk)
-	go func() {
-		defer close(out)
-		for c := range inner {
-			if c.Type == provider.ChunkUsage && c.Usage != nil {
-				a.lastReasoning = c.Usage.ReasoningTokens
-			}
-			out <- c
-		}
-	}()
-	return out, nil
+	return p.inner.Stream(ctx, req)
 }
 
 // forkTurnInput recovers the turn's raw input from the frozen conversation:

--- a/internal/agent/governor.go
+++ b/internal/agent/governor.go
@@ -1,0 +1,72 @@
+// The reasoning governor: while a turn sits in its exploration phase and the
+// previous round bought expensive thinking, ride the next requests at reduced
+// depth; stand down the moment the state stops matching. Fork-validated on
+// frozen exploration states (pass parity exact, reasoning consistently down).
+package agent
+
+import (
+	"os"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+)
+
+// governorEnabled gates enforcement for the A/B experiment; eligibility is
+// always recorded so baseline arms carry the same shadow. Env-scoped on
+// purpose — graduation to config waits on the experiment's verdict.
+var governorEnabled = os.Getenv("REASONIX_EXPERIMENT_GOVERNOR") == "1"
+
+// governorEffort is the reduced depth the engaged governor asks of the
+// provider; endpoints whose vocabulary lacks it silently keep their default.
+const governorEffort = "low"
+
+type governorState struct {
+	engaged bool
+	noticed bool // the engage notice fires once per turn
+}
+
+// governorTrigger reports the exploration cell: no verification debt, no
+// local execution yet, and the round that just ended bought expensive
+// thinking. Shared verbatim with the fork-capture trigger so the live policy
+// and its experiment freeze the same states.
+func governorTrigger(sample evidence.OutcomeSample, lastReasoning int) bool {
+	return sample.DebtAge == 0 && !sample.LocalExecSeen && lastReasoning >= govReasoningThreshold
+}
+
+// governorExit stands the override down: mutation debt opened, a local
+// execution happened, or a discriminating observation landed — the turn has
+// left exploration and full depth is worth buying again.
+func governorExit(sample evidence.OutcomeSample) bool {
+	return sample.DebtAge > 0 || sample.LocalExecSeen || sample.Discriminating > 0
+}
+
+// applyGovernor stamps eligibility on the round's sample and, under the
+// experiment arm, toggles the per-request depth override.
+func (a *Agent) applyGovernor(sample *evidence.OutcomeSample) {
+	sample.GovernorEligible = governorTrigger(*sample, a.lastReasoning)
+	if !governorEnabled {
+		return
+	}
+	switch {
+	case a.governor.engaged && governorExit(*sample):
+		a.governor.engaged = false
+	case !a.governor.engaged && sample.GovernorEligible:
+		a.governor.engaged = true
+		if !a.governor.noticed {
+			a.governor.noticed = true
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeReasoningGovernor,
+				Text:   "Exploration phase with expensive thinking; riding reduced reasoning depth until evidence work starts.",
+				Detail: "reasoning governor engaged: no verification debt, no local execution, previous round over the reasoning threshold"})
+		}
+	}
+	sample.GovernorEngaged = a.governor.engaged
+}
+
+// governorOverride is the request-scoped effort the engaged governor asks
+// for; empty when disengaged so the configured depth stands.
+func (a *Agent) governorOverride() string {
+	if governorEnabled && a.governor.engaged {
+		return governorEffort
+	}
+	return ""
+}

--- a/internal/agent/governor_test.go
+++ b/internal/agent/governor_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestApplyGovernorStampsEligibilityWithoutEngagingByDefault(t *testing.T) {
+	a := &Agent{sink: &ebmSink{}, lastReasoning: govReasoningThreshold}
+	sample := evidence.OutcomeSample{}
+	a.applyGovernor(&sample)
+	if !sample.GovernorEligible || sample.GovernorEngaged {
+		t.Fatalf("sample = %+v, want eligible without engagement (experiment off)", sample)
+	}
+	if a.governorOverride() != "" {
+		t.Fatalf("baseline arm must not override effort, got %q", a.governorOverride())
+	}
+}
+
+func TestApplyGovernorEngagesAndExitsWhenEnabled(t *testing.T) {
+	old := governorEnabled
+	governorEnabled = true
+	defer func() { governorEnabled = old }()
+
+	sink := &ebmSink{}
+	a := &Agent{sink: sink, lastReasoning: govReasoningThreshold}
+
+	cheap := evidence.OutcomeSample{}
+	a.lastReasoning = govReasoningThreshold - 1
+	a.applyGovernor(&cheap)
+	if cheap.GovernorEligible || cheap.GovernorEngaged {
+		t.Fatalf("cheap round = %+v, want untouched", cheap)
+	}
+
+	a.lastReasoning = govReasoningThreshold
+	sample := evidence.OutcomeSample{}
+	a.applyGovernor(&sample)
+	if !sample.GovernorEngaged || a.governorOverride() != governorEffort {
+		t.Fatalf("sample = %+v override = %q, want engaged with %q", sample, a.governorOverride(), governorEffort)
+	}
+	if len(sink.notices) != 1 || sink.notices[0].Code != event.NoticeCodeReasoningGovernor {
+		t.Fatalf("notices = %+v, want one reasoning_governor", sink.notices)
+	}
+
+	// Exploration persists: cheap rounds alone do not disengage.
+	a.lastReasoning = 0
+	quiet := evidence.OutcomeSample{}
+	a.applyGovernor(&quiet)
+	if !quiet.GovernorEngaged {
+		t.Fatalf("quiet round = %+v, want still engaged", quiet)
+	}
+
+	// Debt opening (a mutation) stands the override down immediately.
+	debt := evidence.OutcomeSample{DebtAge: 1}
+	a.applyGovernor(&debt)
+	if debt.GovernorEngaged || a.governorOverride() != "" {
+		t.Fatalf("debt round = %+v override = %q, want disengaged", debt, a.governorOverride())
+	}
+	if len(sink.notices) != 1 {
+		t.Fatalf("notices = %+v, want the engage notice only once per turn", sink.notices)
+	}
+
+	a.resetTurnEvidence()
+	if a.governor.engaged || a.governor.noticed {
+		t.Fatalf("governor = %+v, want reset with the turn", a.governor)
+	}
+}
+
+func TestGovernorExitOnLocalExecAndDiscriminating(t *testing.T) {
+	if !governorExit(evidence.OutcomeSample{LocalExecSeen: true}) {
+		t.Fatal("local execution must exit the governor")
+	}
+	if !governorExit(evidence.OutcomeSample{Discriminating: 1}) {
+		t.Fatal("a discriminating observation must exit the governor")
+	}
+	if governorExit(evidence.OutcomeSample{}) {
+		t.Fatal("pure exploration must not exit the governor")
+	}
+}
+
+// The effect boundary: an expensive exploration round must put the reduced
+// depth on the NEXT provider request, and only under the experiment arm.
+func TestGovernorOverrideReachesProviderRequest(t *testing.T) {
+	old := governorEnabled
+	governorEnabled = true
+	defer func() { governorEnabled = old }()
+
+	reg := tool.NewRegistry()
+	reg.Add(NewAskTool())
+	expensive := provider.Chunk{Type: provider.ChunkUsage,
+		Usage: &provider.Usage{PromptTokens: 10, CompletionTokens: 30, ReasoningTokens: govReasoningThreshold, TotalTokens: 40}}
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":["q":1]}`), expensive, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "explore"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) < 2 {
+		t.Fatalf("requests = %d, want the tool round and the follow-up", len(prov.requests))
+	}
+	if got := prov.requests[0].EffortOverride; got != "" {
+		t.Fatalf("first request override = %q, want empty before any observation", got)
+	}
+	if got := prov.requests[1].EffortOverride; got != governorEffort {
+		t.Fatalf("post-exploration request override = %q, want %q", got, governorEffort)
+	}
+
+	governorEnabled = false
+	prov2 := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":["q":1]}`), expensive, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	b := New(prov2, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	_ = b.Run(context.Background(), "explore")
+	for i, req := range prov2.requests {
+		if req.EffortOverride != "" {
+			t.Fatalf("baseline arm request %d carries override %q", i, req.EffortOverride)
+		}
+	}
+}

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -64,6 +64,7 @@ func (a *Agent) resetTurnEvidence() {
 	a.progress.reset()
 	a.outcome = evidence.NewOutcomeTracker()
 	a.ebm = ebmState{}
+	a.governor = governorState{}
 }
 
 // observeOutcomeShadow scores the round's receipts through the shadow outcome
@@ -78,6 +79,7 @@ func (a *Agent) observeOutcomeShadow(receiptMark int, results []string, outcomes
 	}
 	sample := a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark))
 	a.applyEBM(&sample, results, outcomes)
+	a.applyGovernor(&sample)
 	a.armGovernorCapture(sample)
 	event.RecordOutcomeProgress(a.sink, sample)
 }

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -39,6 +39,7 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 		MaxTokens:      a.maxOutputTokens,
 		Temperature:    provider.OptionalTemperature(a.temperature),
 		ResponseFormat: responseFormatFromRequest(ctx),
+		EffortOverride: a.governorOverride(),
 	}
 	// provider.request: the fully assembled request gets one last ruling
 	// (revalidated by the payload registry) before it goes on the wire.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -484,6 +484,7 @@ const (
 	NoticeCodeLoopGuard                     = "loop_guard"
 	NoticeCodeProgressGuard                 = "progress_guard"
 	NoticeCodeEvidenceNudge                 = "evidence_nudge"
+	NoticeCodeReasoningGovernor             = "reasoning_governor"
 	NoticeCodeWorkspaceLease                = "workspace_lease"
 	NoticeCodeCancelledTurn                 = "cancelled_turn_display"
 	NoticeCodeUnappliedSteer                = "unapplied_steer"

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -41,6 +41,11 @@ type OutcomeSample struct {
 	// interpreter/test command yet — the self-check-propensity observable
 	// (studied set: python/node/go run/pytest; ecosystem bias documented).
 	LocalExecSeen bool
+	// GovernorEligible/GovernorEngaged mark the reasoning governor's
+	// exploration trigger holding and its depth override riding requests;
+	// eligibility is stamped on every arm so baselines carry the shadow.
+	GovernorEligible bool
+	GovernorEngaged  bool
 }
 
 // OutcomeTracker is the shadow counterpart of ProgressTracker: same per-round

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -44,19 +44,21 @@ type DelegationAdmission struct {
 
 // OutcomeProgress mirrors evidence.OutcomeSample with stable snake_case keys.
 type OutcomeProgress struct {
-	Round          int  `json:"round"`
-	Exploration    int  `json:"exploration,omitempty"`
-	Verification   int  `json:"verification,omitempty"`
-	Objective      int  `json:"objective,omitempty"`
-	Regression     int  `json:"regression,omitempty"`
-	Churn          int  `json:"churn,omitempty"`
-	LegacyGain     int  `json:"legacy_gain,omitempty"`
-	Discriminating int  `json:"discriminating,omitempty"`
-	DebtAge        int  `json:"debt_age,omitempty"`
-	BlindMutations int  `json:"blind_mutations,omitempty"`
-	EBMEligible    bool `json:"ebm_eligible,omitempty"`
-	EBMFired       bool `json:"ebm_fired,omitempty"`
-	LocalExecSeen  bool `json:"local_exec_seen,omitempty"`
+	Round            int  `json:"round"`
+	Exploration      int  `json:"exploration,omitempty"`
+	Verification     int  `json:"verification,omitempty"`
+	Objective        int  `json:"objective,omitempty"`
+	Regression       int  `json:"regression,omitempty"`
+	Churn            int  `json:"churn,omitempty"`
+	LegacyGain       int  `json:"legacy_gain,omitempty"`
+	Discriminating   int  `json:"discriminating,omitempty"`
+	DebtAge          int  `json:"debt_age,omitempty"`
+	BlindMutations   int  `json:"blind_mutations,omitempty"`
+	EBMEligible      bool `json:"ebm_eligible,omitempty"`
+	EBMFired         bool `json:"ebm_fired,omitempty"`
+	LocalExecSeen    bool `json:"local_exec_seen,omitempty"`
+	GovernorEligible bool `json:"governor_eligible,omitempty"`
+	GovernorEngaged  bool `json:"governor_engaged,omitempty"`
 }
 
 // ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
@@ -180,19 +182,21 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 
 func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	r.append(Record{OutcomeProgress: &OutcomeProgress{
-		Round:          sample.Round,
-		Exploration:    sample.Exploration,
-		Verification:   sample.Verification,
-		Objective:      sample.Objective,
-		Regression:     sample.Regression,
-		Churn:          sample.Churn,
-		LegacyGain:     sample.LegacyGain,
-		Discriminating: sample.Discriminating,
-		DebtAge:        sample.DebtAge,
-		BlindMutations: sample.BlindMutations,
-		EBMEligible:    sample.EBMEligible,
-		EBMFired:       sample.EBMFired,
-		LocalExecSeen:  sample.LocalExecSeen,
+		Round:            sample.Round,
+		Exploration:      sample.Exploration,
+		Verification:     sample.Verification,
+		Objective:        sample.Objective,
+		Regression:       sample.Regression,
+		Churn:            sample.Churn,
+		LegacyGain:       sample.LegacyGain,
+		Discriminating:   sample.Discriminating,
+		DebtAge:          sample.DebtAge,
+		BlindMutations:   sample.BlindMutations,
+		EBMEligible:      sample.EBMEligible,
+		EBMFired:         sample.EBMFired,
+		LocalExecSeen:    sample.LocalExecSeen,
+		GovernorEligible: sample.GovernorEligible,
+		GovernorEngaged:  sample.GovernorEngaged,
 	}})
 	event.RecordOutcomeProgress(r.inner, sample)
 }


### PR DESCRIPTION
Stacked on #7986. PR2 of the reasoning-governor runtime series - the state-gated policy itself, enforcement env-gated, shadow always on.

## Empirical basis

Fork counterfactuals on frozen exploration states, two independent capture rounds (6 states, 54 continuations): pass parity exact in every state and arm, reasoning tokens consistently down under the low-effort arm (negative class avg 38.3s / 231 reasoning tok vs control 46.5s / 735; quotacalc 44.4s / 3,608 vs 1m02s / 5,538). The act-first arm showed no benefit in either round and is not implemented.

## What

- `governorTrigger` (shared verbatim with fork capture, one source of truth): no verification debt, no local execution this turn, previous round >= 1500 reasoning tokens - the exploration cell holding 62% of slow-round mass.
- While engaged, `prepareSamplingRequest` stamps `EffortOverride: "low"` (the PR1 seam) on each request. Exit conditions: debt opens, local execution lands, or a discriminating observation arrives. Cheap rounds alone do not disengage - the fork evidence treated whole exploration tails.
- Enforcement behind `REASONIX_EXPERIMENT_GOVERNOR=1`, `e2ebench -policy governor` sets it per run. Eligibility is stamped on every arm (EBM precedent) so baselines carry the shadow.
- Shadow chain: `governor_eligible`/`governor_engaged` on OutcomeSample -> trajectory `outcome_progress` -> e2ebench outcome digest + report governor line.
- Round reasoning spend moves from the fork-capture provider wrapper into the executor stream loop: the trigger now observes it on every run, and compaction streams no longer pollute it. Fork capture refuses to arm under live enforcement.
- Effect test at the provider boundary: `TestGovernorOverrideReachesProviderRequest` scripts an expensive exploration round and asserts the override rides the next request under the arm and never on baseline.

## A/B next (not in this PR)

vs-suite + Tier-0 49-task regression under `-policy governor`; release bar per the experiment matrix (Pass@1 CI non-negative, median flat, eligible-subset model-sec and reasoning down). Watch the unstable check-rate effect (round 1: 83% vs 67% control; round 2: 50% vs 67%).

Cache-impact: none - the override is a request-body parameter riding PR1's omitempty field; the provider-visible prompt prefix stays byte-identical (boot golden baseline passes unregenerated)
Cache-guard: internal/boot golden baseline plus TestGovernorOverrideReachesProviderRequest asserting the only request delta is the request-body effort field
Documentation-impact: none - env-gated experiment plumbing off by default; no user-visible behavior, config surface, or CLI change until the A/B verdict graduates it
