### PR TITLE
fix(desktop): reconcile immediately cancelled turns / 修复立即中断回合的历史与操作

### DIFF
--- a/desktop/frontend/src/__tests__/turn-actions-rendering.test.ts
+++ b/desktop/frontend/src/__tests__/turn-actions-rendering.test.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
 const styles = readFileSync(resolve(testDir, "../styles.css"), "utf8");
+const transcriptSource = readFileSync(resolve(testDir, "../components/Transcript.tsx"), "utf8");
+const messageSource = readFileSync(resolve(testDir, "../components/Message.tsx"), "utf8");
 
 let passed = 0;
 let failed = 0;
@@ -21,6 +23,17 @@ function ok(value: unknown, label: string) {
 }
 
 console.log("\nturn actions rendering");
+
+ok(
+  transcriptSource.includes("!actionText.trim() && !checkpointsByTurn.has(turn)") &&
+    transcriptSource.includes("actionText.trim() || checkpoints.has(turn)"),
+  "checkpointed turns keep rewind actions visible even when cancellation produced no assistant text",
+);
+
+ok(
+  messageSource.includes("text.trim() && <CopyButton text={text} label={t(\"msg.copy\")} />"),
+  "empty interrupted turns do not render a misleading empty copy action",
+);
 
 const creationTranscriptRule = styles.match(
   /\.app--creation \.transcript\.transcript--creation-scrollbar,\s*:root\[data-theme-style\] \.app--creation \.transcript\.transcript--creation-scrollbar\s*\{([^}]+)\}/,

--- a/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
@@ -103,6 +103,8 @@ const eventHandlers: Array<(e: WireEvent) => void> = [];
 let backendRunning = false;
 let cancelCalls = 0;
 let effortCalls = 0;
+let historyLoads = 0;
+let checkpointLoads = 0;
 const context: ContextInfo = { used: 0, window: 100, sessionTokens: 0 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 
@@ -126,11 +128,24 @@ window.go = {
       },
       BalanceForTab: async () => ({ available: false, display: "" }),
       JobsForTab: async () => [],
-      CheckpointsForTab: async () => [],
+      CheckpointsForTab: async () => {
+        checkpointLoads += 1;
+        return [{ turn: 0, prompt: "hello", files: [], time: Date.now(), canConversation: true }];
+      },
       HistoryForTab: async () => [],
-      HistoryPageForTab: async () => ({ messages: [], startTurn: 0, endTurn: 0, totalTurns: 0, hasOlder: false }),
+      HistoryPageForTab: async () => {
+        historyLoads += 1;
+        return {
+          messages: [{ role: "user", content: "hello", createdAt: Date.now(), checkpointTurn: 0 }],
+          startTurn: 0,
+          endTurn: 0,
+          totalTurns: 1,
+          hasOlder: false,
+        };
+      },
       HistoryCheckpointTurnsForTab: async () => [],
       ReplayPendingPrompts: async () => {},
+      SubmitToTab: async () => {},
       CancelTab: async () => {
         cancelCalls += 1;
         backendRunning = false;
@@ -159,6 +174,8 @@ await waitFor("active tab", () => controller?.activeTabId === "tab-a");
 await act(async () => {
   await flushPromises(50);
 });
+historyLoads = 0;
+checkpointLoads = 0;
 
 backendRunning = true;
 await act(async () => {
@@ -182,6 +199,27 @@ for (let attempt = 0; attempt < 20 && controller?.state.running; attempt += 1) {
 eq(controller?.state.running, false, "cancel reconciliation clears the running state");
 eq(cancelCalls, 1, "CancelTab is called once");
 eq(controller?.state.cancelRequested, false, "cancel reconciliation clears cancelRequested");
+await waitFor("cancelled transcript reload", () => historyLoads > 0 && checkpointLoads > 0);
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "hello"), "cancelled prompt is restored from the authoritative transcript");
+ok(controller?.state.checkpoints.some((checkpoint) => checkpoint.turn === 0 && checkpoint.canConversation), "cancelled prompt keeps its conversation checkpoint");
+
+// The screenshot repro stops before turn_started, while the backend has
+// already accepted the prompt and will persist it during cancellation cleanup.
+historyLoads = 0;
+checkpointLoads = 0;
+backendRunning = true;
+await act(async () => {
+  await controller?.send("hello");
+  await flushPromises();
+});
+eq(controller?.state.pendingUser, "hello", "an immediate stop still has the optimistic prompt marker");
+await act(async () => {
+  controller?.cancel();
+  await flushPromises();
+});
+await waitFor("immediate cancelled transcript reload", () => !controller?.state.running && historyLoads > 0 && checkpointLoads > 0);
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "hello"), "immediate cancellation restores the persisted prompt bubble");
+ok(controller?.state.checkpoints.some((checkpoint) => checkpoint.turn === 0 && checkpoint.canConversation), "immediate cancellation restores the rewind checkpoint");
 
 await act(async () => {
   await controller?.setEffort("max");

--- a/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-cancel-reconcile.test.tsx
@@ -5,7 +5,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { useController } from "../lib/useController";
 import type { AppBindings } from "../lib/bridge";
-import type { ContextInfo, EffortInfo, Meta, TabMeta, WireEvent } from "../lib/types";
+import type { ContextInfo, EffortInfo, HistoryPage, Meta, TabMeta, WireEvent } from "../lib/types";
 
 let passed = 0;
 let failed = 0;
@@ -105,6 +105,9 @@ let cancelCalls = 0;
 let effortCalls = 0;
 let historyLoads = 0;
 let checkpointLoads = 0;
+let historyShouldFail = false;
+let deferredHistory = false;
+let resolveDeferredHistory: ((page: HistoryPage) => void) | undefined;
 const context: ContextInfo = { used: 0, window: 100, sessionTokens: 0 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 
@@ -135,6 +138,12 @@ window.go = {
       HistoryForTab: async () => [],
       HistoryPageForTab: async () => {
         historyLoads += 1;
+        if (historyShouldFail) throw new Error("history unavailable");
+        if (deferredHistory) {
+          return await new Promise<HistoryPage>((resolve) => {
+            resolveDeferredHistory = resolve;
+          });
+        }
         return {
           messages: [{ role: "user", content: "hello", createdAt: Date.now(), checkpointTurn: 0 }],
           startTurn: 0,
@@ -220,6 +229,47 @@ await act(async () => {
 await waitFor("immediate cancelled transcript reload", () => !controller?.state.running && historyLoads > 0 && checkpointLoads > 0);
 ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "hello"), "immediate cancellation restores the persisted prompt bubble");
 ok(controller?.state.checkpoints.some((checkpoint) => checkpoint.turn === 0 && checkpoint.canConversation), "immediate cancellation restores the rewind checkpoint");
+
+// A new submission must invalidate a cancellation hydrate that is still
+// waiting on authoritative history; otherwise its replace dispatch can erase
+// the new optimistic turn.
+historyLoads = 0;
+deferredHistory = true;
+backendRunning = true;
+await act(async () => {
+  await controller?.send("accidental");
+  controller?.cancel();
+  await flushPromises();
+});
+await waitFor("deferred cancellation history", () => historyLoads > 0 && resolveDeferredHistory !== undefined);
+await act(async () => {
+  await controller?.send("corrected");
+  resolveDeferredHistory?.({
+    messages: [{ role: "user", content: "stale cancellation history", createdAt: Date.now(), checkpointTurn: 0 }],
+    startTurn: 0,
+    endTurn: 0,
+    totalTurns: 1,
+    hasOlder: false,
+  });
+  resolveDeferredHistory = undefined;
+  deferredHistory = false;
+  await flushPromises();
+});
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "corrected"), "resubmission survives a stale cancellation hydrate");
+ok(!controller?.state.items.some((item) => item.kind === "user" && item.text === "stale cancellation history"), "stale cancellation history cannot replace a resubmitted turn");
+
+// A failed cancellation history read must preserve the transcript that was
+// already visible instead of resetting it to an empty state.
+historyLoads = 0;
+historyShouldFail = true;
+backendRunning = true;
+await act(async () => {
+  controller?.cancel();
+  await flushPromises();
+});
+await waitFor("failed cancellation history", () => !controller?.state.running && historyLoads > 0);
+ok(controller?.state.items.some((item) => item.kind === "user" && item.text === "corrected"), "history failure preserves the visible transcript");
+historyShouldFail = false;
 
 await act(async () => {
   await controller?.setEffort("max");

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -780,7 +780,7 @@ export function TurnActions({
   };
   return (
     <div className={`turn-actions${openMenu ? " turn-actions--open" : ""}${hoverMenus ? " turn-actions--hover-menu" : ""}`}>
-      <CopyButton text={text} label={t("msg.copy")} />
+      {text.trim() && <CopyButton text={text} label={t("msg.copy")} />}
       {canAct && (
         <>
           <button

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -782,7 +782,7 @@ export function Transcript({
         if (item.kind !== "assistant" || item.streaming || !item.text.trim()) continue;
         actionText = appendTurnActionCopyText(actionText, item.text);
       }
-      if (!actionText.trim()) return;
+      if (!actionText.trim() && !checkpointsByTurn.has(turn)) return;
       const openMenu = openAction && openAction.turn === turn ? openAction.menu : null;
       out.push(
         <TurnActions
@@ -1266,7 +1266,7 @@ function WarmTurnItems({
     if (item.kind !== "assistant" || item.streaming || !item.text.trim()) continue;
     actionText = appendTurnActionCopyText(actionText, item.text);
   }
-  if (turn != null && actionText.trim()) {
+  if (turn != null && (actionText.trim() || checkpoints.has(turn))) {
     const openMenu = openAction && openAction.turn === turn ? openAction.menu : null;
     nodes.push(
       <TurnActions

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -3019,11 +3019,20 @@ export function useController() {
         const stillReconciling = foregroundRunningFromRuntimeMeta(tab) || Boolean(tab.cancelRequested);
         if (stillReconciling && attempt + 1 < CANCEL_RECONCILE_DELAYS_MS.length) {
           scheduleCancelReconcile(tabId, attempt + 1);
+          return;
+        }
+        // Cancel can race the optimistic user bubble before turn_started. The
+        // backend still persists that visible prompt (and its checkpoint), so
+        // hydrate the authoritative transcript once teardown is idle instead
+        // of leaving the UI with a discarded bubble and no edit/rewind target.
+        if (!stillReconciling) {
+          void loadSessionDataForTab(tabId, true, "rewind").catch(() => {});
+          void refreshCheckpoints(tabId);
         }
       }).catch(() => {});
     }, delay);
     cancelReconcileTimers.current.set(tabId, timer);
-  }, [clearCancelReconcileTimer, reconcileTabRuntime]);
+  }, [clearCancelReconcileTimer, loadSessionDataForTab, reconcileTabRuntime, refreshCheckpoints]);
 
   useEffect(() => {
     const textBatch = createRafBatch<StreamDeltaEntry>((batch) => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2654,6 +2654,7 @@ export function useController() {
   const checkpointRefreshSeq = useRef(new Map<string, number>());
   const metaRefreshSeq = useRef(new Map<string, number>());
   const sessionLoadSeq = useRef(new Map<string, number>());
+  const cancelHydrateSeq = useRef(new Map<string, number>());
   const sessionLoadInFlight = useRef(new Map<string, { sessionPath: string; promise: Promise<void> }>());
   const bumpMetaRefreshSeq = useCallback((tabId: string): number => {
     const seq = (metaRefreshSeq.current.get(tabId) ?? 0) + 1;
@@ -2674,6 +2675,14 @@ export function useController() {
   }, [bumpMetaRefreshSeq]);
   const sessionLoadCurrent = useCallback((tabId: string, seq: number): boolean => {
     return sessionLoadSeq.current.get(tabId) === seq;
+  }, []);
+  const bumpCancelHydrateSeq = useCallback((tabId: string): number => {
+    const seq = (cancelHydrateSeq.current.get(tabId) ?? 0) + 1;
+    cancelHydrateSeq.current.set(tabId, seq);
+    return seq;
+  }, []);
+  const cancelHydrateCurrent = useCallback((tabId: string, seq: number): boolean => {
+    return cancelHydrateSeq.current.get(tabId) === seq;
   }, []);
   const loadMetaForTab = useCallback(async (tabId: string): Promise<Meta | undefined> => {
     const seq = bumpMetaRefreshSeq(tabId);
@@ -2715,7 +2724,14 @@ export function useController() {
     tabId: string,
     reset = false,
     reason: HydrateReason = "startup",
-    options: { skipHistory?: boolean; placeholderItems?: Item[]; preserveCachedHistory?: boolean; sessionPath?: string } = {},
+    options: {
+      skipHistory?: boolean;
+      placeholderItems?: Item[];
+      preserveCachedHistory?: boolean;
+      sessionPath?: string;
+      cancelHydrateGeneration?: number;
+      deferResetUntilHistory?: boolean;
+    } = {},
   ) => {
     const sessionPath = (options.sessionPath ?? statesRef.current.get(tabId)?.meta?.sessionPath ?? "").trim();
     const canJoinInFlight = !reset && !options.skipHistory;
@@ -2728,17 +2744,22 @@ export function useController() {
     }
 
     const promise = (async () => {
+      const cancelHydrateGeneration = options.cancelHydrateGeneration;
+      if (cancelHydrateGeneration !== undefined && !cancelHydrateCurrent(tabId, cancelHydrateGeneration)) return;
       const seq = bumpSessionLoadSeq(tabId);
       const hydrateStartedAt = Date.now();
       const skipHistory = Boolean(
         options.skipHistory ||
         (options.preserveCachedHistory && !reset && hasReusableCachedTranscript(statesRef.current.get(tabId), options.sessionPath)),
       );
+      const deferResetUntilHistory = Boolean(options.deferResetUntilHistory && reset && !skipHistory);
+      const stillCurrent = () =>
+        sessionLoadCurrent(tabId, seq) &&
+        (cancelHydrateGeneration === undefined || cancelHydrateCurrent(tabId, cancelHydrateGeneration));
+      if (!stillCurrent()) return;
       addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
       dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: options.placeholderItems });
-      if (reset && sessionLoadCurrent(tabId, seq)) dispatchTo(tabId, { type: "reset" });
-
-      const stillCurrent = () => sessionLoadCurrent(tabId, seq);
+      if (reset && !deferResetUntilHistory && stillCurrent()) dispatchTo(tabId, { type: "reset" });
       const requiresVisibleTab = reason === "startup" || reason === "switch-tab" || reason === "open-topic";
       const stillVisible = () => !requiresVisibleTab || activeTabIdRef.current === tabId;
       const noteFailure = (label: string, err: unknown) => {
@@ -2766,6 +2787,7 @@ export function useController() {
       if (!stillCurrent()) return;
       if (!skipHistory && historyPage !== undefined) {
         const messages = asArray(historyPage.messages);
+        if (deferResetUntilHistory && stillCurrent()) dispatchTo(tabId, { type: "reset" });
         dispatchTo(tabId, { type: "history_page", page: historyPage, mode: "replace" });
         addBreadcrumb(
           "tab.hydrate",
@@ -2785,6 +2807,7 @@ export function useController() {
         }
       }
 
+      if (!stillCurrent()) return;
       dispatchTo(tabId, { type: "hydrate_done" });
       addBreadcrumb("tab.hydrate", `done ${reason} ${tabId} ms=${Date.now() - hydrateStartedAt}`);
 
@@ -2851,7 +2874,7 @@ export function useController() {
         sessionLoadInFlight.current.delete(tabId);
       }
     }
-  }, [bumpSessionLoadSeq, dispatchTo, loadMetaForTab, refreshBalanceForTab, sessionLoadCurrent]);
+  }, [bumpSessionLoadSeq, cancelHydrateCurrent, dispatchTo, loadMetaForTab, refreshBalanceForTab, sessionLoadCurrent]);
 
   const loadOlderHistory = useCallback(async (tabId?: string): Promise<void> => {
     const targetTabId = tabId || activeTabIdRef.current;
@@ -3008,7 +3031,7 @@ export function useController() {
     cancelReconcileTimers.current.delete(tabId);
   }, []);
 
-  const scheduleCancelReconcile = useCallback((tabId: string, attempt = 0) => {
+  const scheduleCancelReconcile = useCallback((tabId: string, attempt = 0, cancelHydrateGeneration?: number) => {
     clearCancelReconcileTimer(tabId);
     const delay = CANCEL_RECONCILE_DELAYS_MS[Math.min(attempt, CANCEL_RECONCILE_DELAYS_MS.length - 1)];
     const timer = window.setTimeout(() => {
@@ -3018,7 +3041,7 @@ export function useController() {
         if (!tab) return;
         const stillReconciling = foregroundRunningFromRuntimeMeta(tab) || Boolean(tab.cancelRequested);
         if (stillReconciling && attempt + 1 < CANCEL_RECONCILE_DELAYS_MS.length) {
-          scheduleCancelReconcile(tabId, attempt + 1);
+          scheduleCancelReconcile(tabId, attempt + 1, cancelHydrateGeneration);
           return;
         }
         // Cancel can race the optimistic user bubble before turn_started. The
@@ -3026,7 +3049,10 @@ export function useController() {
         // hydrate the authoritative transcript once teardown is idle instead
         // of leaving the UI with a discarded bubble and no edit/rewind target.
         if (!stillReconciling) {
-          void loadSessionDataForTab(tabId, true, "rewind").catch(() => {});
+          void loadSessionDataForTab(tabId, true, "rewind", {
+            cancelHydrateGeneration,
+            deferResetUntilHistory: true,
+          }).catch(() => {});
           void refreshCheckpoints(tabId);
         }
       }).catch(() => {});
@@ -3252,6 +3278,8 @@ export function useController() {
     const promptEpoch = currentState.promptEpoch;
     const { display, submit } = normalizeTurnSubmit(displayText, submitText);
     const original = originalText?.trim() ?? "";
+    bumpCancelHydrateSeq(tabId);
+    if (currentState.hydrateReason === "rewind") dispatchTo(tabId, { type: "hydrate_done" });
     dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq });
     invalidateCache();
     try {
@@ -3283,7 +3311,7 @@ export function useController() {
       dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
       throw error;
     }
-  }, [dispatchTo]);
+  }, [bumpCancelHydrateSeq, dispatchTo]);
 
   const recoverDeliveryToTab = useCallback(async (tabId: string, displayText: string, submitText = displayText) => {
     if (!tabId) throw new Error(t("composer.workspaceStarting"));
@@ -3374,12 +3402,13 @@ export function useController() {
   }, [activeTabId, dispatchTo]);
 
   const cancelTab = useCallback((tabId: string) => {
+    const cancelHydrateGeneration = bumpCancelHydrateSeq(tabId);
     app.CancelTab(tabId)
-      .then(() => scheduleCancelReconcile(tabId))
+      .then(() => scheduleCancelReconcile(tabId, 0, cancelHydrateGeneration))
       .catch((error) => {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: `Cancel failed: ${errorMessage(error)}` });
       });
-  }, [dispatchTo, scheduleCancelReconcile]);
+  }, [bumpCancelHydrateSeq, dispatchTo, scheduleCancelReconcile]);
 
   const cancel = useCallback((): string | undefined => {
     const cur = stateRef.current;

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -165,7 +165,7 @@
       "file-size": 1369
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 3503
+      "file-size": 3541
     },
     "desktop/heartbeat.go": {
       "essay": 18,


### PR DESCRIPTION
## Summary

- Reconcile authoritative history and checkpoints after an immediate cancellation race.
- Keep Edit/rewind actions available for checkpointed turns without assistant text.
- Hide the empty assistant copy action.

## Problem

When a desktop turn is stopped before `turn_started`, the optimistic user bubble can disappear after cancellation. The turn then has no visible Edit or rewind action even though the backend persisted the prompt and checkpoint.

## Root cause

Cancel reconciliation stopped after runtime teardown and did not reload authoritative history/checkpoints. Turn action rendering also required assistant text, so checkpoint-only interrupted turns had no action toolbar.

## Fix

Reload the authoritative transcript and checkpoints once cancellation settles, render turn actions for checkpointed turns without assistant content, and omit copy for empty assistant content. Added deterministic regressions for immediate cancellation and action rendering.

## Verification

- `pnpm exec tsx src/__tests__/use-controller-cancel-reconcile.test.tsx` (11 passed)
- `pnpm exec tsx src/__tests__/turn-actions-rendering.test.ts` (12 passed)
- `pnpm exec tsc --noEmit`
- `pnpm lint:hooks`

Related: #7951

Documentation-impact: none - This restores existing desktop cancellation, edit, and rewind behavior; no user documentation changes are required.