### PR TITLE
fix(installsource): reject oversized remote manifests

### DIFF
--- a/internal/installsource/http.go
+++ b/internal/installsource/http.go
@@ -21,7 +21,7 @@ const defaultFetchLimit = 2 << 20
 
 // fetchText performs a bounded GET on sourceURL using the tool's HTTP client.
 // It applies defaultFetchTimeout unless the caller's context already has a
-// tighter deadline, and never reads more than defaultFetchLimit bytes.
+// tighter deadline, and rejects bodies larger than defaultFetchLimit bytes.
 func (t *installSourceTool) fetchText(ctx context.Context, sourceURL string) (string, error) {
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
@@ -46,10 +46,13 @@ func (t *installSourceTool) fetchText(ctx context.Context, sourceURL string) (st
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", newErr(ErrSourceUnreadable, "%s: HTTP %d", sourceURL, resp.StatusCode)
 	}
-	limited := io.LimitReader(resp.Body, defaultFetchLimit)
+	limited := io.LimitReader(resp.Body, defaultFetchLimit+1)
 	body, err := io.ReadAll(limited)
 	if err != nil {
 		return "", newErr(ErrSourceUnreadable, "%s: read body: %v", sourceURL, err)
+	}
+	if len(body) > defaultFetchLimit {
+		return "", newErr(ErrSourceUnreadable, "%s: body exceeds %d-byte limit", sourceURL, defaultFetchLimit)
 	}
 	return string(body), nil
 }

--- a/internal/installsource/http_test.go
+++ b/internal/installsource/http_test.go
@@ -1,0 +1,54 @@
+package installsource
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchTextAllowsBodyAtLimit(t *testing.T) {
+	body := strings.Repeat("x", defaultFetchLimit)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	tool := NewTool(Options{
+		ProjectRoot: t.TempDir(),
+		HomeDir:     t.TempDir(),
+		HTTPClient:  srv.Client(),
+	}).(*installSourceTool)
+
+	got, err := tool.fetchText(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchText() error = %v", err)
+	}
+	if got != body {
+		t.Fatalf("fetchText() returned %d bytes, want %d", len(got), len(body))
+	}
+}
+
+func TestFetchTextRejectsOversizedBody(t *testing.T) {
+	body := strings.Repeat("x", defaultFetchLimit+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	tool := NewTool(Options{
+		ProjectRoot: t.TempDir(),
+		HomeDir:     t.TempDir(),
+		HTTPClient:  srv.Client(),
+	}).(*installSourceTool)
+
+	got, err := tool.fetchText(context.Background(), srv.URL)
+	if !errors.Is(err, ErrSourceUnreadable) {
+		t.Fatalf("fetchText() error = %v, want ErrSourceUnreadable", err)
+	}
+	if got != "" {
+		t.Fatalf("fetchText() returned %d bytes after rejecting oversized body", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- Reject remote install manifests that exceed the documented 2 MiB fetch limit instead of silently truncating them.
- Preserve exact-limit responses and add boundary regression coverage for both cases.

## Issues

No linked issue.

## Verification

- `go test ./internal/installsource -run TestFetchText -count=1`
- `go test ./internal/installsource -count=1`
- `go vet ./internal/installsource`
- `go vet ./...`
- `go run ./tools/repolint`
- `go test ./internal/tool/builtin/ ./internal/boot/` (non-root container, matching permission-sensitive test assumptions)
- `go test ./...` was also exercised in the root container. The affected package passed; four unrelated permission/process tests failed under root container semantics and passed when rerun with an unprivileged user.

## Documentation impact

Documentation-impact: none - behavior now enforces the existing documented 2 MiB cap instead of returning truncated content.

## Cache impact

Cache-impact: none - install-source response handling does not affect provider-visible prompts or tool schemas.
Cache-guard: go test ./internal/installsource -run TestFetchText -count=1
System-prompt-review: N/A