### PR TITLE
Fix horizontal Reasonix wordmark sizing / 修复横向 Reasonix 标识尺寸

### DIFF
--- a/site/public/logo.svg
+++ b/site/public/logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="_图层_1" data-name=" 图层 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1151.55 217.07">
+<svg id="_图层_1" data-name=" 图层 1" xmlns="http://www.w3.org/2000/svg" width="1151.55" height="217.07" viewBox="0 0 1151.55 217.07">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
## Summary

- Fixes the homepage header logo rendering as a large square.
- Declares the horizontal SVG intrinsic dimensions so existing responsive CSS preserves the wordmark ratio.
- Keeps the compact favicon treatment below 400px.

## Root cause

The horizontal `logo.svg` only declared a `viewBox`. With `width: 90px; height: auto`, browsers treated it as a square replaced element and rendered a 90x90 logo.

## Verification

- `npm test` (58 passing)
- `npm run build` (47 pages)
- Browser: desktop logo computed at 90x16.96px; 390px mobile compact mark remains visible; no console warnings/errors.

This is a follow-up to merged PR #7984.