### PR TITLE
fix(tool): annotate locked-file writes with actionable Office hint

### DIFF
--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -27,7 +27,10 @@ func readFileEncoded(path string) (content string, enc fileenc.Kind, err error) 
 // driver holding a transient lock, a full disk) would leave the user's source
 // file empty or half-written.
 func writeFileEncoded(path string, content string, enc fileenc.Kind) error {
-	return fileutil.AtomicOverwriteFile(path, fileenc.Encode(content, enc), 0o644)
+	if err := fileutil.AtomicOverwriteFile(path, fileenc.Encode(content, enc), 0o644); err != nil {
+		return annotateWriteLockError(path, err)
+	}
+	return nil
 }
 
 // matchLineEndings adapts an edit's old/new text to a CRLF file when the literal

--- a/internal/tool/builtin/writelock.go
+++ b/internal/tool/builtin/writelock.go
@@ -44,8 +44,8 @@ func annotateWriteLockError(path string, err error) error {
 	if lock, ok := officeLockFile(path); ok {
 		return fmt.Errorf("%w; the file appears to be locked by an Office app (lock file %s found) — close the document in Word/Excel/PowerPoint and retry", err, lock)
 	}
-	if isWindowsSharingViolation(err) {
-		return fmt.Errorf("%w; the file is locked by another process — close the program using it and retry", err)
+	if isWindowsFileLocked(err) {
+		return fmt.Errorf("%w; the file is in use by another process or not writable — close the program holding it and retry", err)
 	}
 	return err
 }

--- a/internal/tool/builtin/writelock.go
+++ b/internal/tool/builtin/writelock.go
@@ -1,0 +1,51 @@
+package builtin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// officeLockFile reports the sibling lock file that Microsoft Office creates
+// next to an open document: "~$" followed by the document's base name. Word,
+// Excel and PowerPoint hold the document with deny-write sharing while the
+// lock file exists, so a failed write alongside a matching lock file almost
+// always means the document is open in the office app. The match is
+// case-insensitive, mirroring Windows filename semantics.
+func officeLockFile(path string) (string, bool) {
+	base := filepath.Base(path)
+	if base == "." || base == string(filepath.Separator) || strings.HasPrefix(base, "~$") {
+		return "", false
+	}
+	lock := "~$" + base
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		return "", false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.EqualFold(entry.Name(), lock) {
+			return entry.Name(), true
+		}
+	}
+	return "", false
+}
+
+// annotateWriteLockError appends an actionable hint when a file write fails
+// because another process holds the target open. Without it the agent sees a
+// bare "Access is denied" from the atomic rename and cannot tell the user what
+// to do (issue #5599). The check runs only after a failed write: a stale lock
+// file left by a crashed Office session must not block a write that would
+// otherwise succeed.
+func annotateWriteLockError(path string, err error) error {
+	if lock, ok := officeLockFile(path); ok {
+		return fmt.Errorf("%w; the file appears to be locked by an Office app (lock file %s found) — close the document in Word/Excel/PowerPoint and retry", err, lock)
+	}
+	if isWindowsSharingViolation(err) {
+		return fmt.Errorf("%w; the file is locked by another process — close the program using it and retry", err)
+	}
+	return err
+}

--- a/internal/tool/builtin/writelock_other.go
+++ b/internal/tool/builtin/writelock_other.go
@@ -2,7 +2,7 @@
 
 package builtin
 
-// isWindowsSharingViolation is a no-op outside Windows: sharing violations are
-// a Windows-specific error class. The Office lock-file hint still applies via
-// officeLockFile inside annotateWriteLockError.
-func isWindowsSharingViolation(err error) bool { return false }
+// isWindowsFileLocked is a no-op outside Windows: sharing and access-denied
+// errnos are a Windows-specific error class. The Office lock-file hint still
+// applies via officeLockFile inside annotateWriteLockError.
+func isWindowsFileLocked(err error) bool { return false }

--- a/internal/tool/builtin/writelock_other.go
+++ b/internal/tool/builtin/writelock_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package builtin
+
+// isWindowsSharingViolation is a no-op outside Windows: sharing violations are
+// a Windows-specific error class. The Office lock-file hint still applies via
+// officeLockFile inside annotateWriteLockError.
+func isWindowsSharingViolation(err error) bool { return false }

--- a/internal/tool/builtin/writelock_test.go
+++ b/internal/tool/builtin/writelock_test.go
@@ -1,0 +1,111 @@
+package builtin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOfficeLockFileFindsSiblingLock(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "~$report.docx"), []byte("lock"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := officeLockFile(doc)
+	if !ok || got != "~$report.docx" {
+		t.Fatalf("officeLockFile(%q) = %q, %v; want ~$report.docx, true", doc, got, ok)
+	}
+}
+
+func TestOfficeLockFileCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "~$REPORT.DOCX"), []byte("lock"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := officeLockFile(doc); !ok {
+		t.Fatalf("officeLockFile(%q) should match ~$REPORT.DOCX case-insensitively", doc)
+	}
+}
+
+func TestOfficeLockFileNone(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := officeLockFile(doc); ok {
+		t.Fatalf("officeLockFile(%q) matched without any lock file", doc)
+	}
+}
+
+func TestOfficeLockFileSkipsLockTargets(t *testing.T) {
+	// Writing a lock file itself must never match: the write target already
+	// carries the ~$ prefix, so officeLockFile must not self-match.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "~$report.docx")
+	if err := os.WriteFile(lock, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := officeLockFile(lock); ok {
+		t.Fatalf("officeLockFile(%q) self-matched a ~$ target", lock)
+	}
+}
+
+func TestOfficeLockFileIgnoresDirectories(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A directory named like the lock file must not be treated as a lock.
+	if err := os.Mkdir(filepath.Join(dir, "~$report.docx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := officeLockFile(doc); ok {
+		t.Fatalf("officeLockFile(%q) matched a directory", doc)
+	}
+}
+
+func TestAnnotateWriteLockErrorWithOfficeLock(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "~$report.docx"), []byte("lock"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := errors.New("rename report.docx: access denied")
+	err := annotateWriteLockError(doc, base)
+	if !errors.Is(err, base) {
+		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
+	}
+	for _, want := range []string{"locked by an Office app", "~$report.docx", "retry"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("annotated error should mention %q: %v", want, err)
+		}
+	}
+}
+
+func TestAnnotateWriteLockErrorUnrelatedError(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := errors.New("no space left on device")
+	err := annotateWriteLockError(doc, base)
+	if err != base {
+		t.Fatalf("unrelated errors must pass through unchanged, got: %v", err)
+	}
+}

--- a/internal/tool/builtin/writelock_windows.go
+++ b/internal/tool/builtin/writelock_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package builtin
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isWindowsSharingViolation reports whether err is a Windows sharing or lock
+// violation (another process holds the file open). The atomic rename in
+// fileutil surfaces these as *os.LinkError, so errors.Is must unwrap.
+func isWindowsSharingViolation(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/internal/tool/builtin/writelock_windows.go
+++ b/internal/tool/builtin/writelock_windows.go
@@ -4,13 +4,19 @@ package builtin
 
 import (
 	"errors"
+	"os"
 
 	"golang.org/x/sys/windows"
 )
 
-// isWindowsSharingViolation reports whether err is a Windows sharing or lock
-// violation (another process holds the file open). The atomic rename in
-// fileutil surfaces these as *os.LinkError, so errors.Is must unwrap.
-func isWindowsSharingViolation(err error) bool {
-	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+// isWindowsFileLocked reports whether err is a Windows error class that a
+// locked or unwritable target surfaces through the atomic rename. The rename
+// step reports *os.LinkError, so a plain ERROR_ACCESS_DENIED (WinError 5) can
+// be narrowed to the rename instead of any os.MkdirAll/CreateTemp path error.
+func isWindowsFileLocked(err error) bool {
+	if errors.Is(err, windows.ERROR_SHARING_VIOLATION) || errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return true
+	}
+	var linkErr *os.LinkError
+	return errors.As(err, &linkErr) && errors.Is(err, windows.ERROR_ACCESS_DENIED)
 }

--- a/internal/tool/builtin/writelock_windows_test.go
+++ b/internal/tool/builtin/writelock_windows_test.go
@@ -3,6 +3,7 @@
 package builtin
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ func TestAnnotateWriteLockErrorSharingViolation(t *testing.T) {
 	if !errors.Is(err, base) {
 		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
 	}
-	for _, want := range []string{"locked by another process", "retry"} {
+	for _, want := range []string{"in use by another process", "retry"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("annotated error should mention %q: %v", want, err)
 		}
@@ -43,7 +44,114 @@ func TestAnnotateWriteLockErrorLockViolation(t *testing.T) {
 	if !errors.Is(err, base) {
 		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "locked by another process") {
+	if !strings.Contains(err.Error(), "in use by another process") {
 		t.Errorf("lock violation should be annotated, got: %v", err)
+	}
+}
+
+// TestAnnotateWriteLockErrorAccessDeniedRename covers the errno the atomic
+// rename actually produces against a holder with FILE_SHARE_READ only: a plain
+// ERROR_ACCESS_DENIED inside *os.LinkError, not ERROR_SHARING_VIOLATION.
+func TestAnnotateWriteLockErrorAccessDeniedRename(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := &os.LinkError{Op: "rename", Old: "tmp", New: doc, Err: windows.ERROR_ACCESS_DENIED}
+	err := annotateWriteLockError(doc, base)
+	if !errors.Is(err, base) {
+		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "in use by another process") {
+		t.Errorf("rename access denied should be annotated, got: %v", err)
+	}
+}
+
+// TestAnnotateWriteLockErrorAccessDeniedPathError covers the negative case:
+// an ERROR_ACCESS_DENIED from a non-rename step (*os.PathError, e.g. a
+// directory the caller cannot enter) is not a lock symptom and must pass
+// through unchanged.
+func TestAnnotateWriteLockErrorAccessDeniedPathError(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := &os.PathError{Op: "mkdir", Path: doc, Err: windows.ERROR_ACCESS_DENIED}
+	err := annotateWriteLockError(doc, base)
+	if err != base {
+		t.Fatalf("non-rename access denied must pass through unchanged, got: %v", err)
+	}
+}
+
+// holdDenyWrite opens path with FILE_SHARE_READ only — the exact sharing mode
+// Microsoft Word uses while a document is open: readers may share, but no other
+// process may write or delete the file, so the atomic rename must fail.
+func holdDenyWrite(t *testing.T, path string) func() {
+	t.Helper()
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handle, err := windows.CreateFile(pathPtr, windows.GENERIC_READ, windows.FILE_SHARE_READ, nil, windows.OPEN_EXISTING, 0, 0)
+	if err != nil {
+		t.Skipf("cannot hold a deny-write handle: %v", err)
+	}
+	return func() { windows.CloseHandle(handle) }
+}
+
+// TestWriteFileLockedByOfficeAppLock is the end-to-end regression test for
+// issue #5599: a document held open like Word holds it (deny-write handle plus
+// a ~$ sibling lock file) must fail with an actionable hint naming the lock
+// file, and must leave the document untouched.
+func TestWriteFileLockedByOfficeAppLock(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "~$report.docx"), []byte("lock"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	release := holdDenyWrite(t, doc)
+	defer release()
+
+	_, err := writeFile{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": doc, "content": "new"}))
+	if err == nil {
+		t.Fatal("expected the locked write to fail")
+	}
+	for _, want := range []string{"locked by an Office app", "~$report.docx", "retry"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q: %v", want, err)
+		}
+	}
+	got, _ := os.ReadFile(doc)
+	if string(got) != "hello" {
+		t.Fatalf("locked write must leave the document unchanged, got %q", got)
+	}
+}
+
+// TestWriteFileLockedByOtherProcess covers a lock without an Office lock file:
+// the generic sharing-violation hint must still explain the failure.
+func TestWriteFileLockedByOtherProcess(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "data.bin")
+	if err := os.WriteFile(doc, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	release := holdDenyWrite(t, doc)
+	defer release()
+
+	_, err := writeFile{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": doc, "content": "new"}))
+	if err == nil {
+		t.Fatal("expected the locked write to fail")
+	}
+	if !strings.Contains(err.Error(), "in use by another process") {
+		t.Errorf("error should carry the generic lock hint: %v", err)
+	}
+	got, _ := os.ReadFile(doc)
+	if string(got) != "old" {
+		t.Fatalf("locked write must leave the file unchanged, got %q", got)
 	}
 }

--- a/internal/tool/builtin/writelock_windows_test.go
+++ b/internal/tool/builtin/writelock_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package builtin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestAnnotateWriteLockErrorSharingViolation(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The atomic rename wraps the raw errno in *os.LinkError; errors.Is must
+	// unwrap it to recognize the sharing violation (WinError 32).
+	base := &os.LinkError{Op: "rename", Old: "tmp", New: doc, Err: windows.ERROR_SHARING_VIOLATION}
+	err := annotateWriteLockError(doc, base)
+	if !errors.Is(err, base) {
+		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
+	}
+	for _, want := range []string{"locked by another process", "retry"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("annotated error should mention %q: %v", want, err)
+		}
+	}
+}
+
+func TestAnnotateWriteLockErrorLockViolation(t *testing.T) {
+	dir := t.TempDir()
+	doc := filepath.Join(dir, "report.docx")
+	if err := os.WriteFile(doc, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := &os.LinkError{Op: "rename", Old: "tmp", New: doc, Err: windows.ERROR_LOCK_VIOLATION}
+	err := annotateWriteLockError(doc, base)
+	if !errors.Is(err, base) {
+		t.Fatalf("annotateWriteLockError must preserve the wrapped error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "locked by another process") {
+		t.Errorf("lock violation should be annotated, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

When a file write fails because another process holds the target open, the agent only sees a bare rename error (`Access is denied.`) with no actionable guidance. Microsoft Word/Excel/PowerPoint hold an open document with deny-write sharing and drop a `~$` sibling lock file, so write_file (and edit_file/multi_edit/delete_*/notebookedit, which share the same write path) now annotate the failure:

- An Office lock file (`~$<name>`) is detected and named in the error: *"the file appears to be locked by an Office app (lock file ~$report.docx found) — close the document in Word/Excel/PowerPoint and retry"*.
- A Windows rename-step sharing/access-denied errno (32/33, or 5 on the rename step only) gets a generic *"in use by another process or not writable"* hint.
- Detection runs only after a failed write, so a stale lock file left by a crashed Office session never blocks a write that would otherwise succeed. Retry-with-backoff already exists in `fileutil.ReplaceFile`.

Fixes #5599

## Verification

Ablation on a real Windows host with a real deny-write handle (`CreateFile` with `FILE_SHARE_READ`, the sharing mode Word uses):

| State | Result |
|---|---|
| main-v2 (no fix) | `rename ...: Access is denied.` — bare error, no hint (issue reproduced) |
| this branch | annotated with lock file `~$report.docx` and retry guidance (fixed) |

The ablation also showed the rename surfaces `ERROR_ACCESS_DENIED` (WinError 5), not `ERROR_SHARING_VIOLATION`; the generic hint matches only the rename step (`*os.LinkError`) so mkdir/temp-creation denials pass through untouched.

Tests added in `internal/tool/builtin/writelock_windows_test.go` (incl. end-to-end locked-write tests). `go test ./internal/tool/builtin/` passes; linux/darwin cross-build OK; `gofmt -l` clean.

## Documentation impact

Documentation-impact: none - the change only annotates the error text of an already-failing write; no documented interface, config, or behavior described in docs changes.

## Cache impact

Cache-impact: none - no provider-visible prompt, tool schema, or default tool surface change; only post-failure error annotation.
Cache-guard: N/A - the change cannot affect prompt cache hits.
System-prompt-review: N/A