### PR TITLE
fix(desktop): open folders in Explorer via explore verb plus trailing separator

### DIFF
--- a/desktop/external_opener.go
+++ b/desktop/external_opener.go
@@ -235,7 +235,7 @@ func (a *App) OpenWorkspaceInExternalOpenerForTab(tabID, id string) error {
 	if !ok {
 		return fmt.Errorf("external opener %q is not available", strings.TrimSpace(id))
 	}
-	return launchPlatformExternalOpener(spec, path)
+	return launchPlatformExternalOpener(spec, path, true)
 }
 
 func (a *App) externalOpenerWorkspacePathForTab(tabID string) (string, error) {
@@ -291,7 +291,7 @@ func (a *App) OpenLocalPathInExternalOpener(path, id string) error {
 	if !ok {
 		return fmt.Errorf("external opener %q is not available", strings.TrimSpace(id))
 	}
-	return launchPlatformExternalOpener(spec, path)
+	return launchPlatformExternalOpener(spec, path, info.IsDir())
 }
 
 // SaveLocalPathAs copies a local file to a user-selected destination without

--- a/desktop/external_opener_darwin.go
+++ b/desktop/external_opener_darwin.go
@@ -176,6 +176,6 @@ func darwinExternalOpenerCommand(spec externalOpenerSpec, path string) *exec.Cmd
 	return exec.Command("/usr/bin/open", "-a", spec.Target, launchPath)
 }
 
-func launchPlatformExternalOpener(spec externalOpenerSpec, path string) error {
+func launchPlatformExternalOpener(spec externalOpenerSpec, path string, _ bool) error {
 	return startDetachedExternalOpener(darwinExternalOpenerCommand(spec, path))
 }

--- a/desktop/external_opener_linux.go
+++ b/desktop/external_opener_linux.go
@@ -285,7 +285,7 @@ func linuxExternalOpenerCommand(spec externalOpenerSpec, path string) (*exec.Cmd
 	return cmd, nil
 }
 
-func launchPlatformExternalOpener(spec externalOpenerSpec, path string) error {
+func launchPlatformExternalOpener(spec externalOpenerSpec, path string, _ bool) error {
 	cmd, err := linuxExternalOpenerCommand(spec, path)
 	if err != nil {
 		return err

--- a/desktop/external_opener_windows.go
+++ b/desktop/external_opener_windows.go
@@ -367,12 +367,12 @@ func renderWindowsExternalOpenerIcon(icon windows.Handle, background byte) ([]by
 	return append([]byte(nil), pixels...), true
 }
 
-func launchPlatformExternalOpener(spec externalOpenerSpec, path string) error {
+func launchPlatformExternalOpener(spec externalOpenerSpec, path string, isDir bool) error {
 	var cmd *exec.Cmd
 	launchPath := externalOpenerLaunchPath(spec, path)
 	switch spec.LaunchMode {
 	case "shell-open":
-		return openWorkspacePath(path)
+		return openWorkspacePathWithType(path, isDir)
 	case "path":
 		cmd = exec.Command(spec.Target, path)
 	case "windows-terminal":

--- a/desktop/open_local_path.go
+++ b/desktop/open_local_path.go
@@ -150,5 +150,5 @@ func (a *App) OpenLocalPath(path string) error {
 	if !openTargetPathAllowed(path, info) {
 		return fmt.Errorf("refusing to open executable target %q", path)
 	}
-	return openWorkspacePath(path)
+	return openWorkspacePathWithType(path, info.IsDir())
 }

--- a/desktop/open_local_path.go
+++ b/desktop/open_local_path.go
@@ -94,8 +94,8 @@ func hasDisallowedWindowsPathSyntax(path string) bool {
 // "open" verb. Directories and documents open normally; executable targets
 // are refused because OpenLocalPath is fed by AI-generated chat content —
 // a prompt-injected or hallucinated ".bat" path must not run on click.
-// openWorkspacePath itself stays untouched: it is also used by
-// RevealWorkspacePathForTab with trusted workspace inputs.
+// openWorkspacePath remains outside this executable-target guard because its
+// callers use it for paths already authorized by the workspace boundary.
 var executableOpenSuffixes = map[string]bool{
 	".app": true,
 	".bat": true, ".cmd": true, ".com": true, ".exe": true,

--- a/desktop/open_workspace_darwin.go
+++ b/desktop/open_workspace_darwin.go
@@ -7,3 +7,7 @@ import "os/exec"
 func openWorkspacePath(path string) error {
 	return exec.Command("open", path).Start()
 }
+
+func openWorkspacePathWithType(path string, _ bool) error {
+	return openWorkspacePath(path)
+}

--- a/desktop/open_workspace_unix.go
+++ b/desktop/open_workspace_unix.go
@@ -7,3 +7,7 @@ import "os/exec"
 func openWorkspacePath(path string) error {
 	return exec.Command("xdg-open", path).Start()
 }
+
+func openWorkspacePathWithType(path string, _ bool) error {
+	return openWorkspacePath(path)
+}

--- a/desktop/open_workspace_windows.go
+++ b/desktop/open_workspace_windows.go
@@ -9,7 +9,15 @@ import (
 )
 
 func openWorkspacePath(path string) error {
-	verb, target := shellOpenCommand(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return openWorkspacePathWithType(path, info.IsDir())
+}
+
+func openWorkspacePathWithType(path string, isDir bool) error {
+	verb, target := shellOpenCommand(path, isDir)
 	verbPtr, err := windows.UTF16PtrFromString(verb)
 	if err != nil {
 		return err
@@ -22,14 +30,16 @@ func openWorkspacePath(path string) error {
 }
 
 // shellOpenCommand returns the ShellExecute verb and target used to open path.
-// Folders use the "explore" verb with a trailing separator: both force the
-// shell to treat the target as a directory, so a sibling "<folder>.lnk" with
-// the same base name can never hijack the open and launch the shortcut's
-// target instead of Explorer (#7851). Files keep the "open" verb and the path
-// unchanged.
-func shellOpenCommand(path string) (verb, target string) {
-	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		return "explore", path + string(os.PathSeparator)
+// Folders use "explore" and a trailing separator so the shell cannot confuse
+// them with a sibling "<folder>.lnk" and launch its target (#7851). Files keep
+// the "open" verb and their original path.
+func shellOpenCommand(path string, isDir bool) (verb, target string) {
+	if isDir {
+		target = path
+		if target == "" || !os.IsPathSeparator(target[len(target)-1]) {
+			target += string(os.PathSeparator)
+		}
+		return "explore", target
 	}
 	return "open", path
 }

--- a/desktop/open_workspace_windows.go
+++ b/desktop/open_workspace_windows.go
@@ -9,25 +9,27 @@ import (
 )
 
 func openWorkspacePath(path string) error {
-	verb, err := windows.UTF16PtrFromString(shellOpenVerb(path))
+	verb, target := shellOpenCommand(path)
+	verbPtr, err := windows.UTF16PtrFromString(verb)
 	if err != nil {
 		return err
 	}
-	file, err := windows.UTF16PtrFromString(path)
+	filePtr, err := windows.UTF16PtrFromString(target)
 	if err != nil {
 		return err
 	}
-	return windows.ShellExecute(0, verb, file, nil, nil, windows.SW_SHOWNORMAL)
+	return windows.ShellExecute(0, verbPtr, filePtr, nil, nil, windows.SW_SHOWNORMAL)
 }
 
-// shellOpenVerb returns the ShellExecute verb used to open path. The "open"
-// verb resolves folders through the shell namespace, where a sibling
-// "<folder>.lnk" with the same base name wins and launches the shortcut's
-// target instead of Explorer (#7851). The "explore" verb opens a folder in
-// Explorer directly and never consults .lnk files; files keep "open".
-func shellOpenVerb(path string) string {
+// shellOpenCommand returns the ShellExecute verb and target used to open path.
+// Folders use the "explore" verb with a trailing separator: both force the
+// shell to treat the target as a directory, so a sibling "<folder>.lnk" with
+// the same base name can never hijack the open and launch the shortcut's
+// target instead of Explorer (#7851). Files keep the "open" verb and the path
+// unchanged.
+func shellOpenCommand(path string) (verb, target string) {
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		return "explore"
+		return "explore", path + string(os.PathSeparator)
 	}
-	return "open"
+	return "open", path
 }

--- a/desktop/open_workspace_windows.go
+++ b/desktop/open_workspace_windows.go
@@ -2,10 +2,14 @@
 
 package main
 
-import "golang.org/x/sys/windows"
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
 
 func openWorkspacePath(path string) error {
-	verb, err := windows.UTF16PtrFromString("open")
+	verb, err := windows.UTF16PtrFromString(shellOpenVerb(path))
 	if err != nil {
 		return err
 	}
@@ -14,4 +18,16 @@ func openWorkspacePath(path string) error {
 		return err
 	}
 	return windows.ShellExecute(0, verb, file, nil, nil, windows.SW_SHOWNORMAL)
+}
+
+// shellOpenVerb returns the ShellExecute verb used to open path. The "open"
+// verb resolves folders through the shell namespace, where a sibling
+// "<folder>.lnk" with the same base name wins and launches the shortcut's
+// target instead of Explorer (#7851). The "explore" verb opens a folder in
+// Explorer directly and never consults .lnk files; files keep "open".
+func shellOpenVerb(path string) string {
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return "explore"
+	}
+	return "open"
 }

--- a/desktop/open_workspace_windows_test.go
+++ b/desktop/open_workspace_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShellOpenVerbFolder(t *testing.T) {
+	dir := t.TempDir()
+	if got := shellOpenVerb(dir); got != "explore" {
+		t.Fatalf("shellOpenVerb(folder %q) = %q, want explore", dir, got)
+	}
+}
+
+func TestShellOpenVerbFile(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "notes.md")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := shellOpenVerb(file); got != "open" {
+		t.Fatalf("shellOpenVerb(file %q) = %q, want open", file, got)
+	}
+}
+
+func TestShellOpenVerbMissingPath(t *testing.T) {
+	if got := shellOpenVerb(filepath.Join(t.TempDir(), "missing")); got != "open" {
+		t.Fatalf("shellOpenVerb(missing) = %q, want open fallback", got)
+	}
+}
+
+func TestShellOpenVerbFolderWithSiblingLnk(t *testing.T) {
+	// The reported regression: a folder whose base name also exists as a .lnk
+	// shortcut must still open in Explorer, not launch the shortcut's target.
+	dir := t.TempDir()
+	folder := filepath.Join(dir, "app")
+	if err := os.Mkdir(folder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.lnk"), []byte("shortcut"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := shellOpenVerb(folder); got != "explore" {
+		t.Fatalf("shellOpenVerb(folder with sibling .lnk %q) = %q, want explore", folder, got)
+	}
+}

--- a/desktop/open_workspace_windows_test.go
+++ b/desktop/open_workspace_windows_test.go
@@ -8,32 +8,39 @@ import (
 	"testing"
 )
 
-func TestShellOpenVerbFolder(t *testing.T) {
+func TestShellOpenCommandFolder(t *testing.T) {
 	dir := t.TempDir()
-	if got := shellOpenVerb(dir); got != "explore" {
-		t.Fatalf("shellOpenVerb(folder %q) = %q, want explore", dir, got)
+	verb, target := shellOpenCommand(dir)
+	if verb != "explore" {
+		t.Fatalf("shellOpenCommand(folder %q) verb = %q, want explore", dir, verb)
+	}
+	if target != dir+string(os.PathSeparator) {
+		t.Fatalf("shellOpenCommand(folder %q) target = %q, want trailing separator", dir, target)
 	}
 }
 
-func TestShellOpenVerbFile(t *testing.T) {
+func TestShellOpenCommandFile(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "notes.md")
 	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := shellOpenVerb(file); got != "open" {
-		t.Fatalf("shellOpenVerb(file %q) = %q, want open", file, got)
+	verb, target := shellOpenCommand(file)
+	if verb != "open" || target != file {
+		t.Fatalf("shellOpenCommand(file) = (%q, %q), want (open, %q)", verb, target, file)
 	}
 }
 
-func TestShellOpenVerbMissingPath(t *testing.T) {
-	if got := shellOpenVerb(filepath.Join(t.TempDir(), "missing")); got != "open" {
-		t.Fatalf("shellOpenVerb(missing) = %q, want open fallback", got)
+func TestShellOpenCommandMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	verb, target := shellOpenCommand(missing)
+	if verb != "open" || target != missing {
+		t.Fatalf("shellOpenCommand(missing) = (%q, %q), want (open, %q)", verb, target, missing)
 	}
 }
 
-func TestShellOpenVerbFolderWithSiblingLnk(t *testing.T) {
+func TestShellOpenCommandFolderWithSiblingLnk(t *testing.T) {
 	// The reported regression: a folder whose base name also exists as a .lnk
-	// shortcut must still open in Explorer, not launch the shortcut's target.
+	// shortcut must open in Explorer, not launch the shortcut's target.
 	dir := t.TempDir()
 	folder := filepath.Join(dir, "app")
 	if err := os.Mkdir(folder, 0o755); err != nil {
@@ -42,7 +49,11 @@ func TestShellOpenVerbFolderWithSiblingLnk(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "app.lnk"), []byte("shortcut"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := shellOpenVerb(folder); got != "explore" {
-		t.Fatalf("shellOpenVerb(folder with sibling .lnk %q) = %q, want explore", folder, got)
+	verb, target := shellOpenCommand(folder)
+	if verb != "explore" {
+		t.Fatalf("shellOpenCommand(folder with sibling .lnk %q) verb = %q, want explore", folder, verb)
+	}
+	if target != folder+string(os.PathSeparator) {
+		t.Fatalf("shellOpenCommand(folder with sibling .lnk %q) target = %q, want trailing separator", folder, target)
 	}
 }

--- a/desktop/open_workspace_windows_test.go
+++ b/desktop/open_workspace_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +11,7 @@ import (
 
 func TestShellOpenCommandFolder(t *testing.T) {
 	dir := t.TempDir()
-	verb, target := shellOpenCommand(dir)
+	verb, target := shellOpenCommand(dir, true)
 	if verb != "explore" {
 		t.Fatalf("shellOpenCommand(folder %q) verb = %q, want explore", dir, verb)
 	}
@@ -24,17 +25,24 @@ func TestShellOpenCommandFile(t *testing.T) {
 	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	verb, target := shellOpenCommand(file)
+	verb, target := shellOpenCommand(file, false)
 	if verb != "open" || target != file {
 		t.Fatalf("shellOpenCommand(file) = (%q, %q), want (open, %q)", verb, target, file)
 	}
 }
 
-func TestShellOpenCommandMissingPath(t *testing.T) {
+func TestOpenWorkspacePathMissingPath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
-	verb, target := shellOpenCommand(missing)
-	if verb != "open" || target != missing {
-		t.Fatalf("shellOpenCommand(missing) = (%q, %q), want (open, %q)", verb, target, missing)
+	if err := openWorkspacePath(missing); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("openWorkspacePath(missing) error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestShellOpenCommandFolderWithTrailingSeparator(t *testing.T) {
+	dir := t.TempDir() + string(os.PathSeparator)
+	verb, target := shellOpenCommand(dir, true)
+	if verb != "explore" || target != dir {
+		t.Fatalf("shellOpenCommand(folder with separator) = (%q, %q), want (explore, %q)", verb, target, dir)
 	}
 }
 
@@ -49,7 +57,7 @@ func TestShellOpenCommandFolderWithSiblingLnk(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "app.lnk"), []byte("shortcut"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	verb, target := shellOpenCommand(folder)
+	verb, target := shellOpenCommand(folder, true)
 	if verb != "explore" {
 		t.Fatalf("shellOpenCommand(folder with sibling .lnk %q) verb = %q, want explore", folder, verb)
 	}


### PR DESCRIPTION
## Summary

"Open in File Explorer" (and folder clicks from chat) launch the target of a sibling `"<folder>.lnk"` shortcut instead of opening the folder in Explorer. ShellExecute's `open` verb resolves a folder through the shell namespace, where a `.lnk` with the same base name wins.

Fix: folders now open with the `explore` verb and a trailing separator. Both force the shell to treat the target as a directory, so the `.lnk` is never consulted. Files keep `open` unchanged.

Fixes #7851

## Verification

Ablation on a real Windows host (folder `app` + `app.lnk` → `cmd.exe /c echo > marker`, driving the real `openWorkspacePath` path):

| State | Result |
|---|---|
| main-v2 (no fix) | `open` verb launched the .lnk target — marker written, bug reproduced |
| this branch | `explore` + trailing separator opens the folder; .lnk target NOT launched |

The ablation also invalidated the initial approach: with a sibling `.lnk` present, the `explore` verb **alone** returns `E_FAIL` (hinst 5) and opens nothing; a trailing separator is required for both verbs to behave as directory opens (hinst 42).

Tests: `desktop/open_workspace_windows_test.go` covers verb/target selection incl. the .lnk sibling case. `go test ./desktop/` (opener/local-path suites) passes; `gofmt -l` clean.

## Documentation impact

Documentation-impact: none - the File Explorer opener's visible behavior (opens the folder) is unchanged when no `.lnk` collision exists; no documented interface changes.

## Cache impact

Cache-impact: none - desktop-only change; no provider-visible surface.
Cache-guard: N/A - the change cannot affect prompt cache hits.
System-prompt-review: N/A