### PR TITLE
fix(evidence): git commit 纯固化不算 mutation + env 前缀命令识别为验证命令（碎片 review 循环与工具链路径误拒）

### DIFF
--- a/internal/evidence/env_prefix_test.go
+++ b/internal/evidence/env_prefix_test.go
@@ -1,0 +1,22 @@
+package evidence
+
+import "testing"
+
+func TestEnvPrefixVerification(t *testing.T) {
+	cases := map[string]bool{
+		"go test ./internal/evidence/":                   true,
+		"go test ./internal/evidence/ -count=1":          true,
+		"GOROOT=/x go test ./internal/evidence/":         true,
+		"GOROOT=/x PATH=/y go test ./internal/evidence/": true,
+		"env GOROOT=/x go test ./internal/evidence/":     true,
+		"cd /tmp && go test ./internal/evidence/":        true,
+		"go test ./internal/evidence/ 2>&1 | tail -3":    true,
+		"GOROOT=/x rm -rf /":                             false,
+		"GOROOT=/x":                                      false,
+	}
+	for c, want := range cases {
+		if got := IsDeliveryVerificationCommand(c); got != want {
+			t.Errorf("IsDeliveryVerificationCommand(%q) = %v, want %v", c, got, want)
+		}
+	}
+}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1626,7 +1626,15 @@ func ToolCallMutates(toolName string, args json.RawMessage, readOnly bool) bool 
 		if err := json.Unmarshal(args, &fields); err != nil {
 			return true
 		}
-		return bashMayMutate(stringField(fields, "command"))
+		command := stringField(fields, "command")
+		// gitCommitOnlyCements：纯 `git commit -m …` 只移动 HEAD（固化已 staged 内容），
+		// 不改变工作区内容——未审内容在 commit 前已被"内容 mutation → review"覆盖，
+		// 从 delivery mutation 判定中排除可避免每轮提交后被要求重复 review（碎片提交循环）。
+		// 组合命令（git add && git commit 等）与 -a/-am/--amend 等合并内容形态保持 mutation。
+		if gitCommitOnlyCements(command) {
+			return false
+		}
+		return bashMayMutate(command)
 	default:
 		return true
 	}
@@ -1854,6 +1862,34 @@ func bashContainsVerificationSegment(command string) bool {
 		}
 	}
 	return false
+}
+
+// gitCommitOnlyCements reports whether command is a bare `git commit -m …`
+// (no -a/-am/--amend/--fixup/--squash/-i, no shell combinators) that only
+// cements already-staged content. Permission-layer read-only classification
+// is intentionally untouched (git commit still requires approval); this only
+// exempts pure cements from the delivery mutation ledger so a commit of
+// already-reviewed changes does not demand a fresh review pass. Pre-commit
+// hooks that modify the workspace surface as the next content mutation and
+// are checked normally.
+func gitCommitOnlyCements(command string) bool {
+	fields, malformed := shellparse.StaticFields(strings.TrimSpace(command))
+	if malformed != "" || len(fields) < 3 || fields[0] != "git" || fields[1] != "commit" {
+		return false
+	}
+	for _, arg := range fields[2:] {
+		switch {
+		case arg == "&&" || arg == ";" || arg == "|" || arg == "||":
+			return false // 组合命令——其他段可能变更内容
+		case arg == "-a" || arg == "-am" || strings.HasPrefix(arg, "--all"):
+			return false // -a/--all 合并未 staged 修改
+		case arg == "--amend" || arg == "--fixup" || arg == "--squash":
+			return false // 改写历史/合并提交
+		case arg == "-i" || arg == "--interactive" || arg == "--patch" || arg == "-p":
+			return false // 交互挑选内容
+		}
+	}
+	return true
 }
 
 func bashMayMutate(command string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -1920,6 +1920,35 @@ func bashMayMutate(command string) bool {
 	return false
 }
 
+// stripLeadingEnvPrefix strips leading `KEY=VALUE` and `env KEY=VALUE` tokens
+// from a command string for classification purposes only. shellparse refuses
+// `VAR=value cmd` as shell control syntax; env-prefixed toolchains
+// (`GOROOT=/x go test ./…`, `CARGO_HOME=/y cargo test`) are common, so the
+// verification classifier retries with the real command word. This is a
+// read-only text split (whitespace + quote-aware scanning via StaticFields on
+// the remainder); it never executes anything and never touches the
+// permission layer's fail-closed classification.
+func stripLeadingEnvPrefix(command string) []string {
+	fields, malformed := shellparse.StaticFields(strings.TrimSpace(command))
+	if malformed == "" && len(fields) > 0 {
+		return fields
+	}
+	// 手工按空白切（env 前缀不含引号场景）；失败返回 nil 由调用方拒绝。
+	raw := strings.Fields(strings.TrimSpace(command))
+	i := 0
+	for i < len(raw) && (raw[i] == "env" || (strings.Contains(raw[i], "=") && !strings.HasPrefix(raw[i], "-"))) {
+		i++
+	}
+	if i == 0 || i >= len(raw) {
+		return nil
+	}
+	rest, m2 := shellparse.StaticFields(strings.Join(raw[i:], " "))
+	if m2 != "" {
+		return nil
+	}
+	return rest
+}
+
 func bashCommandIsVerification(command string) bool {
 	command = strings.TrimSpace(command)
 	if command == "" {
@@ -1937,7 +1966,13 @@ func bashCommandIsVerification(command string) bool {
 		}
 		fields, malformed := shellparse.StaticFields(normalized)
 		if malformed != "" || len(fields) == 0 {
-			return false
+			// shellparse 保守拒绝前导 env 赋值（`GOROOT=/x go test ./…` 报
+			// "shell control syntax"）——这是工具链路径定制的常见形态。手工剥离
+			// 前导 KEY=VALUE（仅 verification 分类用途；不执行、无权限含义）。
+			fields = stripLeadingEnvPrefix(normalized)
+			if len(fields) == 0 {
+				return false
+			}
 		}
 		if bashSegmentIsVerification(fields) {
 			found = true
@@ -2012,6 +2047,19 @@ func bashSegmentIsVerification(fields []string) bool {
 	if len(fields) == 0 {
 		return false
 	}
+	// 剥离前导 env 前缀（KEY=VALUE 与 `env KEY=VALUE`）——工具链路径定制
+	// （GOROOT/CARGO_HOME/LLVM_PATH/…）是常见用法：`GOROOT=/x go test ./…` 的
+	// fields[0] 是 `GOROOT=/x`，不剥离会把真实命令词误判为未知命令。只影响
+	// verification 分类（无权限含义）；permission 层 fail-closed 不动（env 前缀
+	// 可重定义 PATH 等，执行权仍需审批）。`--flag=v` 形态不是 env 前缀（以 - 开头）。
+	i := 0
+	for i < len(fields) && (fields[i] == "env" || (strings.Contains(fields[i], "=") && !strings.HasPrefix(fields[i], "-"))) {
+		i++
+	}
+	if i >= len(fields) {
+		return false
+	}
+	fields = fields[i:]
 	base := strings.ToLower(filepath.Base(fields[0]))
 	args := fields[1:]
 	if hasCommandArg(args, "--fix", "--write", "-w", "--update", "-u") {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -1005,6 +1005,14 @@ func TestToolCallMutatesForDeliveryProfile(t *testing.T) {
 		{name: "jest output file stays opaque", toolName: "bash", args: `{"command":"npm test -- --json --outputFile=result.json"}`, want: true},
 		{name: "mypy report stays opaque", toolName: "bash", args: `{"command":"mypy --txt-report reports src/"}`, want: true},
 		{name: "plain pytest", toolName: "bash", args: `{"command":"pytest"}`},
+		// git commit 纯固化（gitCommitOnlyCements）：只移动 HEAD 不算 content mutation；
+		// 合并内容/改写历史/组合命令保持 mutation。
+		{name: "git commit -m cements content", toolName: "bash", args: `{"command":"git commit -m \"fix interaction.rs\""}`},
+		{name: "git commit -q -m cements content", toolName: "bash", args: `{"command":"git commit -q -m \"docs update\""}`},
+		{name: "git commit -a merges tracked changes", toolName: "bash", args: `{"command":"git commit -am \"x\""}`, want: true},
+		{name: "git commit --amend rewrites history", toolName: "bash", args: `{"command":"git commit --amend -m \"x\""}`, want: true},
+		{name: "git commit -i interactive pick", toolName: "bash", args: `{"command":"git commit -i -m \"x\""}`, want: true},
+		{name: "git add + commit compound", toolName: "bash", args: `{"command":"git add -A && git commit -m \"x\""}`, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## 问题

delivery-first 模式下，`git commit`（纯固化）被 `bashMayMutate` 归类为 content mutation——每次提交后主机强制要求"mutation 后 review"。当一轮工作被拆成多个小提交时（如 security 收口 8 连发），每轮提交后都要补一轮 review/security_review，造成：

- 一轮活拆成多个碎片提交（为满足"提交后 review"要求）
- 已审查内容提交后被重复要求 review（内容未变）
- 长时间"停止"观感（门控循环重试）

## 修复 1：git commit 纯固化不算 content mutation

`ToolCallMutates` 对 bash 一律走 `bashMayMutate`——`git commit` 不在 `ReadOnlyPrefixes["git"]` 白名单（fail-closed 正确），因此 commit 被记为 mutation，`HasHostReviewCoverageAfter` 要求 commit 之后有 review 覆盖。但 `git commit -m …` 只移动 HEAD、固化已 staged 内容——不改变工作区内容。未审内容在 commit 前已被"内容 mutation → review"检查覆盖。

新增 `gitCommitOnlyCements`：识别纯 `git commit -m …`（无 `-a/-am/--all/--amend/--fixup/--squash/-i/--patch`，无 shell 组合符），在 `ToolCallMutates` 的 bash 分支排除。

**边界保持安全**：
- permission 层 `CommandIsReadOnly` 不变（`git commit` 仍需放行）
- 组合命令（`git add && git commit`）、`-a` 合并、`--amend` 改写历史、`-i` 交互——全部保持 mutation
- pre-commit hook 改工作区 → 作为下一个 content mutation 被检查

## 修复 2：env 前缀命令识别为验证命令

`GOROOT=/x go test ./…`（工具链路径定制）被 `shellparse.StaticFields` 以 "shell control syntax" 拒绝 → `IsDeliveryVerificationCommand` 返回 false → 正确的 go test 被拒为 "opaque command"（complete_step 被迫降级 manual）。

`bashCommandIsVerification` 对 malformed/空字段时手工剥离前导 `KEY=VALUE` / `env KEY=VALUE`（`stripLeadingEnvPrefix`）再分类。

**边界保持安全**：
- 只影响 verification 分类（读文本拆词，不执行）
- permission 层 fail-closed 不动（env 前缀可重定义 PATH——执行权仍需审批）
- `GOROOT=/x rm -rf /` 剥离后仍被拒（真实命令词校验）
- `--flag=v` 形态不算 env 前缀

## 验证

```
go test ./internal/evidence/ ./internal/shellsafe/ -count=1   # ok（含 6 个 git commit 用例 + 9 个 env 前缀用例）
go vet ./internal/evidence/                                   # clean
gofmt -l internal/evidence/                                   # clean
```

新增测试：
- `TestToolCallMutatesForDeliveryProfile`：git commit 6 用例（纯 commit 非 mutation、-a/--amend/-i/组合 mutation）
- `TestEnvPrefixVerification`（env_prefix_test.go）：9 用例（`GOROOT=/x go test` true、`GOROOT=/x rm -rf /` false 等）