### PR TITLE
feat(memory): subject keys — the knowledge-conflict model

### DIFF
--- a/docs/SESSION_MEMORY_RETRIEVAL.md
+++ b/docs/SESSION_MEMORY_RETRIEVAL.md
@@ -82,6 +82,8 @@ Each fact is a Markdown file with:
 - an independent `type` and `scope`;
 - optional search `keywords` — aliases and translations of key terms that let
   a paraphrased or cross-language query reach the fact;
+- an optional `subject_key` — a dotted key naming the question the fact
+  answers (`project.package_manager`, `user.response_style`);
 - the Markdown body.
 
 `type` classifies the content:
@@ -98,6 +100,13 @@ Each fact is a Markdown file with:
 
 Type does not imply scope. Project feedback remains project-local, and a global
 reference remains a reference.
+
+A subject key is the knowledge-conflict model: one scope holds at most one
+active value per subject. Saving a second fact for a held subject is rejected
+with the holder's id, so "npm → pnpm" becomes a revision of one fact instead
+of two contradicting facts both staying active. `/memory subjects` lists the
+keys in use; facts answering the same subject count as equivalent for
+overrides and recall suppression regardless of their names and titles.
 
 When equivalent project and global facts exist, automatic recall uses the
 project fact. Both remain visible in Context Center and `/memory`, with the

--- a/docs/SESSION_MEMORY_RETRIEVAL.zh-CN.md
+++ b/docs/SESSION_MEMORY_RETRIEVAL.zh-CN.md
@@ -72,6 +72,8 @@ Reasonix 识别 `REASONIX.md`、`AGENTS.md`、`CLAUDE.md`，以及对应的 `.lo
 - 相互独立的 `type` 与 `scope`；
 - 可选的检索 `keywords` —— 关键词的同义词与双语别名，让换一种说法或换一种
   语言的提问也能命中这条事实；
+- 可选的 `subject_key` —— 点号分隔的键，标明这条事实回答的是哪个问题
+  （`project.package_manager`、`user.response_style`）；
 - Markdown 正文。
 
 `type` 表示内容类别：
@@ -87,6 +89,11 @@ Reasonix 识别 `REASONIX.md`、`AGENTS.md`、`CLAUDE.md`，以及对应的 `.lo
 - `global` 必须显式选择。
 
 type 不推导 scope。项目反馈仍只属于项目，全局 reference 仍然是 reference。
+
+subject key 是知识冲突模型：同一 scope 内每个 subject 至多一个 active 值。对已被
+占用的 subject 再存新事实会被拒绝并给出持有者的 id——于是 "npm → pnpm" 成为同一
+事实的新 revision，而不是两条互相矛盾、同时活跃的事实。`/memory subjects` 列出在用
+的 key；回答同一 subject 的事实在覆盖与召回抑制中视为等价，与它们的 name/title 无关。
 
 当等价的项目事实和全局事实同时存在时，自动召回使用项目事实。Context Center 和
 `/memory` 仍展示两者，并解释覆盖关系，而不是删除或隐藏任何来源。

--- a/internal/boot/testdata/golden/prefix_shape.json
+++ b/internal/boot/testdata/golden/prefix_shape.json
@@ -1,7 +1,7 @@
 {
   "SystemHash": "c4a54b2f61c5e15f",
-  "ToolsHash": "c489708bdb558cb6",
-  "PrefixHash": "ebd70f3b5e99d49a",
+  "ToolsHash": "9674df33a22e9ee4",
+  "PrefixHash": "75fb4282ce36487d",
   "LogRewriteVersion": 0,
-  "ToolSchemaTokens": 13486
+  "ToolSchemaTokens": 13603
 }

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -1369,6 +1369,10 @@
             ],
             "type": "string"
           },
+          "subject_key": {
+            "description": "Dotted key naming the question this fact answers, e.g. project.package_manager, project.release_branch, user.response_style. One active value per scope+subject: saving a new fact for a held subject is rejected with the holder's id — update that id so the change becomes a revision, not a contradiction. Search existing memories first and reuse their keys; omit for narrative facts that are not a single-valued answer.",
+            "type": "string"
+          },
           "title": {
             "description": "Short human-readable label shown in the memory index, e.g. \"Prefers tabs\". Omit to derive one from the name.",
             "type": "string"

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -1376,6 +1376,10 @@
           ],
           "type": "string"
         },
+        "subject_key": {
+          "description": "Dotted key naming the question this fact answers, e.g. project.package_manager, project.release_branch, user.response_style. One active value per scope+subject: saving a new fact for a held subject is rejected with the holder's id — update that id so the change becomes a revision, not a contradiction. Search existing memories first and reuse their keys; omit for narrative facts that are not a single-valued answer.",
+          "type": "string"
+        },
         "title": {
           "description": "Short human-readable label shown in the memory index, e.g. \"Prefers tabs\". Omit to derive one from the name.",
           "type": "string"

--- a/internal/control/memory_command.go
+++ b/internal/control/memory_command.go
@@ -11,7 +11,7 @@ import (
 	"reasonix/internal/memory"
 )
 
-const memoryCommandUsage = "usage: /memory [recall|pin <id-or-name>|unpin <id-or-name>|verify <id-or-name>|revisions <id-or-name>|restore <id-or-name> <revision>|archived|recover <archive-path>|instructions]"
+const memoryCommandUsage = "usage: /memory [recall|subjects|pin <id-or-name>|unpin <id-or-name>|verify <id-or-name>|revisions <id-or-name>|restore <id-or-name> <revision>|archived|recover <archive-path>|instructions]"
 
 // MemoryCompletionData returns stable references for structured /memory
 // completion. IDs come first because they remain unambiguous if a fact is
@@ -73,6 +73,11 @@ func MemoryCommandText(api MemoryControl, input string) string {
 			return "usage: /memory verify <id-or-name>"
 		}
 		return verifyMemory(api, ref)
+	case "subjects":
+		if rest != "" {
+			return "usage: /memory subjects"
+		}
+		return renderMemorySubjects(api.Memory())
 	case "revisions":
 		ref, err := singleMemoryArgument(rest)
 		if err != nil {
@@ -158,6 +163,34 @@ func verifyMemory(api MemoryControl, ref string) string {
 		return "memory verify: " + err.Error()
 	}
 	return fmt.Sprintf("%s verified; freshness clock renewed (revision %d -> %d)", fact.Name, fact.Revision, fact.Revision+1)
+}
+
+// renderMemorySubjects lists the subject keys in use so writers reuse them
+// instead of minting near-duplicates.
+func renderMemorySubjects(set *memory.Set) string {
+	if set == nil {
+		return i18n.M.ListMemoryNone
+	}
+	type holder struct{ key, line string }
+	var rows []holder
+	for _, fact := range set.Store.ListAll() {
+		key := memory.NormalizeSubjectKey(fact.SubjectKey)
+		if key == "" {
+			continue
+		}
+		rows = append(rows, holder{key, fmt.Sprintf("  %s -> id=%s scope=%s name=%s %s",
+			key, fact.ID, memory.NormalizeFactScope(string(fact.Scope)), fact.Name, memoryOneLine(fact.Description))})
+	}
+	if len(rows) == 0 {
+		return "no subject keys in use\nassign one with remember's subject_key to track single-valued facts (e.g. project.package_manager)"
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].key < rows[j].key })
+	var b strings.Builder
+	b.WriteString("subject keys (one active value per scope+subject)\n")
+	for _, row := range rows {
+		b.WriteString(row.line + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 func parseMemoryCommand(input string) (subcommand, rest string) {

--- a/internal/memory/auto_recall.go
+++ b/internal/memory/auto_recall.go
@@ -353,6 +353,12 @@ func recallIdentityKeys(memory Memory) []string {
 	if title := normalizedRecallTitle(memory.Title); title != "" {
 		keys = append(keys, "title:"+title)
 	}
+	// Subject keys make equivalence semantic: two facts answering the same
+	// question are the same identity for overrides and suppression, however
+	// their names and titles differ.
+	if subject := NormalizeSubjectKey(memory.SubjectKey); subject != "" {
+		keys = append(keys, "subject:"+subject)
+	}
 	return keys
 }
 

--- a/internal/memory/remember.go
+++ b/internal/memory/remember.go
@@ -26,6 +26,7 @@ type rememberRequest struct {
 	Scope            string `json:"scope"`
 	Activation       string `json:"activation"`
 	Volatility       string `json:"volatility"`
+	SubjectKey       string `json:"subject_key"`
 	ExpiresAt        string `json:"expires_at"`
 	Verified         bool   `json:"verified"`
 	Keywords         string `json:"keywords"`
@@ -67,6 +68,7 @@ func (rememberTool) Schema() json.RawMessage {
 			"scope": {"type": "string", "enum": ["project", "global"], "description": "Where the fact applies. For a new fact, omit for the safe default, project. When updating an existing name, omit to preserve its current scope. Use global only when it should affect every workspace."},
 			"activation": {"type": "string", "enum": ["relevant", "pinned"], "description": "How the fact reaches the model: relevant (the default) is retrieval-only; pinned loads the body into every session's stable prefix. Use pinned ONLY when the user explicitly asks for an always-available fact — pinned space is budget-limited, and rules that must always hold belong in REASONIX.md/AGENTS.md instructions instead. Omit on update to preserve the current choice."},
 			"volatility": {"type": "string", "enum": ["evergreen", "stable", "volatile"], "description": "How fast the fact ages, independent of type: volatile for facts that die in days (a current release branch, this week's task), stable for slow-changing ones, evergreen for facts that never age (a README location, a fixed preference). Omit to use the type default, or on update to preserve the current choice."},
+			"subject_key": {"type": "string", "description": "Dotted key naming the question this fact answers, e.g. project.package_manager, project.release_branch, user.response_style. One active value per scope+subject: saving a new fact for a held subject is rejected with the holder's id — update that id so the change becomes a revision, not a contradiction. Search existing memories first and reuse their keys; omit for narrative facts that are not a single-valued answer."},
 			"expires_at": {"type": "string", "description": "Hard expiry as RFC3339 or YYYY-MM-DD. Past this moment the fact stops being auto-recalled entirely. Set it when the fact has a known end of life. Omit on update to preserve; \"never\" clears an existing expiry."},
 			"verified": {"type": "boolean", "description": "Set true only when you have JUST re-confirmed the fact still holds (checked the file, ran the command). Renews the freshness clock without changing the meaning of updated_at."},
 			"keywords": {"type": "string", "description": "Space-separated search aliases a future query might use where the body's own words would miss: synonyms, translations of key terms (recall matching is lexical, so give Chinese facts English aliases and vice versa), related command or tool names. Omit when the body already carries the likely query words. When updating, omit to preserve existing keywords."},
@@ -116,6 +118,7 @@ func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string
 		Scope:          factScope,
 		Activation:     activation,
 		Volatility:     volatility,
+		SubjectKey:     NormalizeSubjectKey(in.SubjectKey),
 		ExpiresAt:      expiresAt,
 		LastVerifiedAt: verifiedAt,
 		Keywords:       in.Keywords,

--- a/internal/memory/render.go
+++ b/internal/memory/render.go
@@ -25,6 +25,7 @@ type memoryFrontmatter struct {
 	Keywords       string `yaml:"keywords,omitempty"`
 	Activation     string `yaml:"activation,omitempty"`
 	Volatility     string `yaml:"volatility,omitempty"`
+	SubjectKey     string `yaml:"subject_key,omitempty"`
 	ExpiresAt      string `yaml:"expires_at,omitempty"`
 	LastVerifiedAt string `yaml:"last_verified_at,omitempty"`
 	Metadata       struct {
@@ -40,6 +41,7 @@ func render(m Memory, name string) string {
 		ID: m.ID, Revision: m.Revision, Name: name, Title: oneLine(m.Title), Desc: oneLine(m.Description),
 		Keywords: oneLine(m.Keywords), Activation: string(NormalizeActivation(string(m.Activation))),
 		Volatility: string(NormalizeVolatility(string(m.Volatility))),
+		SubjectKey: NormalizeSubjectKey(m.SubjectKey),
 	}
 	if !m.CreatedAt.IsZero() {
 		fm.CreatedAt = m.CreatedAt.UTC().Format(time.RFC3339Nano)

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -86,6 +86,7 @@ type Memory struct {
 	Scope          FactScope  // project by default; global only when explicitly requested
 	Activation     Activation // persisted choice; "" = unset, resolved by ResolveActivation
 	Volatility     Volatility // how fast the fact ages; "" = unset, type default applies
+	SubjectKey     string     // which question the fact answers (project.package_manager); one active value per scope+subject
 	ExpiresAt      time.Time  // hard freshness boundary; zero = never expires
 	LastVerifiedAt time.Time  // last explicit confirmation; renews the freshness clock
 	Keywords       string     // search aliases (bilingual synonyms, related commands); recall-only, never rendered into the index
@@ -737,6 +738,7 @@ func loadMemory(path string) (Memory, bool) {
 		Keywords:       fm["keywords"],
 		Activation:     NormalizeActivation(fm["activation"]),
 		Volatility:     NormalizeVolatility(fm["volatility"]),
+		SubjectKey:     NormalizeSubjectKey(fm["subject_key"]),
 		ExpiresAt:      parseMemoryTime(fm["expires_at"]),
 		LastVerifiedAt: parseMemoryTime(fm["last_verified_at"]),
 		Type:           persistedFactType(fm),

--- a/internal/memory/store_v2.go
+++ b/internal/memory/store_v2.go
@@ -104,6 +104,9 @@ func inheritOnUpdate(m Memory, existing Memory, clearExpiry bool) Memory {
 	if NormalizeVolatility(string(m.Volatility)) == "" {
 		m.Volatility = existing.Volatility
 	}
+	if NormalizeSubjectKey(m.SubjectKey) == "" {
+		m.SubjectKey = existing.SubjectKey
+	}
 	if clearExpiry {
 		m.ExpiresAt = time.Time{}
 	} else if m.ExpiresAt.IsZero() {
@@ -116,6 +119,15 @@ func inheritOnUpdate(m Memory, existing Memory, clearExpiry bool) Memory {
 		m.Keywords = existing.Keywords
 	}
 	return m
+}
+
+// validateSave runs the cross-fact invariants once identity, scope, and
+// inheritance are resolved: the pinned budget and subject uniqueness.
+func (s Store) validateSave(m Memory) error {
+	if err := s.validatePinnedBudget(m); err != nil {
+		return err
+	}
+	return s.validateSubjectKey(m)
 }
 
 // validatePinnedBudget rejects a save that would push the total pinned-body
@@ -213,7 +225,7 @@ func (s Store) SaveWithOptions(m Memory, opts SaveOptions) (SaveResult, error) {
 	} else {
 		m.Scope = NormalizeFactScope(string(m.Scope))
 	}
-	if err := s.validatePinnedBudget(m); err != nil {
+	if err := s.validateSave(m); err != nil {
 		return SaveResult{}, err
 	}
 

--- a/internal/memory/subject.go
+++ b/internal/memory/subject.go
@@ -1,0 +1,90 @@
+// Subject keys: the knowledge-conflict model. A fact may declare which
+// question it answers (project.package_manager, user.response_style); one
+// scope holds at most one active value per subject, so a new answer becomes
+// an update of the existing fact instead of a silent contradiction.
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NormalizeSubjectKey canonicalizes a subject key: lowercase, dot-separated
+// segments of [a-z0-9_-], empty segments collapsed. Returns "" (no subject)
+// for keys with no usable content so punctuation typos never mint a distinct
+// identity.
+func NormalizeSubjectKey(s string) string {
+	var segments []string
+	for seg := range strings.SplitSeq(strings.ToLower(strings.TrimSpace(s)), ".") {
+		var b strings.Builder
+		for _, r := range seg {
+			switch {
+			case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+				b.WriteRune(r)
+			case r == ' ', r == '_':
+				b.WriteRune('_')
+			}
+		}
+		if cleaned := strings.Trim(b.String(), "_-"); cleaned != "" {
+			segments = append(segments, cleaned)
+		}
+	}
+	return strings.Join(segments, ".")
+}
+
+// findActiveSubject returns the active fact holding a subject key within one
+// scope's directory, if any.
+func (s Store) findActiveSubject(scope FactScope, key string) (Memory, bool) {
+	dir := s.DirFor(scope)
+	if dir == "" || key == "" {
+		return Memory{}, false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return Memory{}, false
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == indexFile || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		m, ok := loadMemory(filepath.Join(dir, e.Name()))
+		if !ok || NormalizeSubjectKey(m.SubjectKey) != key {
+			continue
+		}
+		if m.Scope == "" {
+			m.Scope = s.scopeForDir(dir)
+		}
+		return m, true
+	}
+	return Memory{}, false
+}
+
+// validateSubjectKey enforces one active value per (scope, subject): a save
+// claiming an already-held subject is rejected with directions to update the
+// holder, so "npm -> pnpm" becomes a revision of one fact, not a second
+// contradicting fact. The error is written for the model to act on.
+func (s Store) validateSubjectKey(m Memory) error {
+	key := NormalizeSubjectKey(m.SubjectKey)
+	if key == "" {
+		return nil
+	}
+	holder, ok := s.findActiveSubject(NormalizeFactScope(string(m.Scope)), key)
+	if !ok || holder.ID == m.ID {
+		return nil
+	}
+	return fmt.Errorf(
+		"subject %q is already tracked by memory id=%s revision=%d name=%s (current: %s); "+
+			"if this is the new value of the same fact, update that id instead of creating a second one",
+		key, holder.ID, holder.Revision, holder.Name, oneLine(firstNonEmpty(holder.Description, holder.Body)))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/memory/subject_test.go
+++ b/internal/memory/subject_test.go
@@ -1,0 +1,106 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSubjectKey(t *testing.T) {
+	for in, want := range map[string]string{
+		"project.package_manager":  "project.package_manager",
+		" Project.Package Manager": "project.package_manager",
+		"project..release-branch":  "project.release-branch",
+		"项目.包管理":                   "",
+		"...":                      "",
+	} {
+		if got := NormalizeSubjectKey(in); got != want {
+			t.Fatalf("NormalizeSubjectKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The npm -> pnpm scenario: a second fact answering a held subject is
+// rejected with directions to the holder, and updating the holder lands the
+// new value as a revision.
+func TestSubjectKeyRejectsSecondActiveValueWithDirections(t *testing.T) {
+	store := recallTestStore(t)
+	saved, err := store.SaveWithOptions(Memory{
+		Name: "package-manager", Title: "Package manager",
+		Description: "This project uses npm", SubjectKey: "project.package_manager",
+		Body: "This project uses npm.",
+	}, SaveOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.SaveWithOptions(Memory{
+		Name: "dependency-tooling", Title: "Dependency tooling",
+		Description: "We migrated to pnpm", SubjectKey: "project.package_manager",
+		Body: "We migrated to pnpm.",
+	}, SaveOptions{})
+	if err == nil {
+		t.Fatal("a second active value for a held subject must be rejected")
+	}
+	for _, want := range []string{saved.Memory.ID, "update that id", "uses npm"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("conflict error must carry %q for the model to act on, got: %v", want, err)
+		}
+	}
+
+	updated, err := store.SaveWithOptions(Memory{
+		ID: saved.Memory.ID, Description: "We migrated to pnpm", Body: "We migrated to pnpm.",
+	}, SaveOptions{})
+	if err != nil || updated.Memory.Revision != 2 {
+		t.Fatalf("updating the holder must land the new value as a revision: %+v %v", updated.Memory, err)
+	}
+	if NormalizeSubjectKey(updated.Memory.SubjectKey) != "project.package_manager" {
+		t.Fatalf("subject key must inherit on update, got %+v", updated.Memory)
+	}
+}
+
+func TestSubjectKeyScopesAreIndependentAndProjectShadowsGlobal(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.GlobalDir, Memory{
+		ID: "mem-global-style", Name: "response-style-global", Title: "Response style",
+		Description: "Prefers detailed answers", Type: TypeUser, Scope: FactScopeGlobal,
+		Activation: ActivationRelevant, SubjectKey: "user.response_style",
+		Body: "Prefers long, detailed answers.",
+	})
+	if _, err := store.SaveWithOptions(Memory{
+		Name: "response-style-here", Title: "Response style for this repo",
+		Description: "结论先行，宁短勿长", Scope: FactScopeProject,
+		SubjectKey: "user.response_style", Keywords: "response style answers",
+		Body: "结论先行，宁短勿长。",
+	}, SaveOptions{}); err != nil {
+		t.Fatalf("the same subject in another scope is an override, not a conflict: %v", err)
+	}
+
+	result := AutoRecall(store, "response style preference for answers", RecallOptions{})
+	for _, hit := range result.Hits {
+		if hit.Memory.ID == "mem-global-style" {
+			t.Fatalf("project subject holder must shadow the global one in recall: %+v", result.Hits)
+		}
+	}
+}
+
+func TestSubjectConflictSkipsSelfAndUnkeyedFacts(t *testing.T) {
+	store := recallTestStore(t)
+	saved, err := store.SaveWithOptions(Memory{
+		Name: "release-branch", Description: "release/1.21",
+		SubjectKey: "project.release_branch", Body: "release/1.21",
+	}, SaveOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SaveWithOptions(Memory{
+		ID: saved.Memory.ID, Description: "release/1.22", Body: "release/1.22",
+		SubjectKey: "project.release_branch",
+	}, SaveOptions{}); err != nil {
+		t.Fatalf("re-saving the holder itself must not self-conflict: %v", err)
+	}
+	if _, err := store.SaveWithOptions(Memory{
+		Name: "unrelated-note", Description: "no subject here", Body: "narrative fact",
+	}, SaveOptions{}); err != nil {
+		t.Fatalf("facts without a subject key are exempt: %v", err)
+	}
+}


### PR DESCRIPTION
Fourth of the memory-dimension series (#7994 keywords/bigrams -> #7996 activation -> #7998 volatility -> subject keys): the knowledge-conflict model.

## Problem

Duplicate prevention matched names, titles, and descriptions. A fact titled "Package manager" (body: uses npm) and one titled "Dependency tooling" (body: migrated to pnpm) were unrelated to the store — both stayed active, contradicting each other. Text similarity is not identity.

## What

- **`subject_key`**: an optional dotted key naming the question a fact answers (`project.package_manager`, `project.release_branch`, `user.response_style`). Deliberately not a knowledge graph — a single-valued slot model, the smallest thing that stops silent contradictions.
- **One active value per (scope, subject)**, enforced at save with reject-with-directions: the error carries the holder's id, revision, and current value, worded for the model to act on. The model re-issues as an update of that id and "npm → pnpm" lands as a revision of one fact, old value recoverable via `/memory revisions`. Same subject in another scope is an override, not a conflict.
- **Subject keys join `recallIdentityKeys`** — the single equivalence source — so `FindOverrides`, pinned project-over-global suppression, and recall dedup all treat facts answering the same question as equivalent regardless of names/titles. This also strengthens the #7995 semantics: overrides become "same subject", not "coincidentally same title".
- **Vocabulary discipline without a controlled vocabulary**: keys normalize (lowercase, dotted segments of `[a-z0-9_-]`, empty segments collapsed) so punctuation variants cannot mint identities; the remember schema instructs search-first/reuse; `/memory subjects` lists keys in use with their holders. Unkeyed (narrative) facts are exempt from the conflict model entirely — the bootstrap gap with legacy unkeyed facts is documented, and the flywheel is the schema guidance to add keys when updating.
- Cross-fact save invariants (pinned budget, subject uniqueness) consolidate into `validateSave`.

Tests: normalization table (incl. CJK-only keys rejected), the npm→pnpm reject-then-update flow asserting the error carries id/directions/current value, scope independence + project-shadows-global through recall, self-update and unkeyed exemptions.

Cache-impact: low - the remember tool schema gains one optional property (one-time prefix change at upgrade, goldens regenerated); conflict enforcement is store-side and never touches the prefix
Cache-guard: internal/boot golden baseline suite re-passes on regenerated goldens
System-prompt-review: esengine - no prefix change beyond the remember schema property; index lines, pinned guidance, and recall block format unchanged
Documentation-impact: updated - docs/SESSION_MEMORY_RETRIEVAL.md and .zh-CN.md document subject keys and the conflict model
