### PR TITLE
test: harden two Windows-flaky tests

### DIFF
--- a/internal/cli/serve_provider_setup_test.go
+++ b/internal/cli/serve_provider_setup_test.go
@@ -90,6 +90,7 @@ api_key_env = "REASONIX_TEST_REMOTE_MISSING_KEY"
 	})
 
 	var addr string
+	var lastReadErr error
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		data, err := os.ReadFile(portFile)
@@ -97,13 +98,14 @@ api_key_env = "REASONIX_TEST_REMOTE_MISSING_KEY"
 			addr = strings.TrimSpace(string(data))
 			break
 		}
-		if err != nil && !os.IsNotExist(err) {
-			t.Fatalf("read Serve port file: %v", err)
-		}
+		// Every read error is retryable inside the deadline: on Windows the
+		// writing child briefly holds the file (sharing violation), which is a
+		// timing condition, not a failure.
+		lastReadErr = err
 		time.Sleep(20 * time.Millisecond)
 	}
 	if addr == "" {
-		t.Fatalf("Serve did not publish its port with a missing Provider key:\n%s", output.String())
+		t.Fatalf("Serve did not publish its port with a missing Provider key (last read err: %v):\n%s", lastReadErr, output.String())
 	}
 	select {
 	case <-balanceStarted:

--- a/internal/control/recovery_test.go
+++ b/internal/control/recovery_test.go
@@ -445,7 +445,10 @@ func TestNewSessionWaitsForPendingRecoveryPersistence(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewSession: %v", err)
 		}
-	case <-time.After(time.Second):
+	// The assertion is ordering (the select above proved NewSession blocked
+	// until release), not speed: NewSession does real file IO and one second
+	// flakes on loaded Windows runners.
+	case <-time.After(10 * time.Second):
 		t.Fatal("NewSession did not resume after recovery persistence drained")
 	}
 }


### PR DESCRIPTION
Hardens the two tests that failed on Windows in back-to-back CI rounds tonight (runs 31289029731, 31290288161), both timing races on loaded runners, not product bugs.

- `TestServeStartsWithMissingProviderKey` (internal/cli): the poll loop treated any `serve.addr` read error other than not-exist as fatal. On Windows the writing child briefly holds the file — a sharing violation is timing, not failure. Every read error is now retryable inside the existing 15s deadline; the deadline failure message carries the last read error for diagnosis.
- `TestNewSessionWaitsForPendingRecoveryPersistence` (internal/control): gave `NewSession` one second to finish after the release gate. The test's real assertion is ordering — the preceding select already proves NewSession blocked until release — and one second of session/goal-state file IO flakes on loaded Windows runners. Ten seconds keeps the ordering assertion and drops the accidental speed assertion.

Both tests pass locally; behavior under test is unchanged.

Documentation-impact: none - test-only changes, user-visible behavior untouched
