### PR TITLE
docs: clarify default_model vs [desktop].provider_access fallback chain

### DIFF
--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -92,6 +92,14 @@ name    = "example"
 command = "example-mcp-server"
 ```
 
+`[desktop].provider_access` and `default_model` interact at desktop startup
+(see [SPEC §3.1.1](SPEC.md#311-desktop-model-access-and-keyless-default-fallback)
+for the full table). If your `default_model` resolves to a provider that is
+not in `provider_access`, the new session silently boots onto the first listed,
+configured, key-bearing chat model. If you see an unexpected model substitution
+at launch, add the default's provider name to the list, or remove the field to
+allow every configured provider.
+
 Do not put API key values in `config.toml`. This file is regular configuration:
 it is safe to inspect, edit, migrate, and include in diagnostics after standard
 redaction. Secrets belong in the global `.env` below.

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -80,6 +80,13 @@ name    = "example"
 command = "example-mcp-server"
 ```
 
+`[desktop].provider_access` 与 `default_model` 在桌面端启动时会联动（完整
+说明见 [SPEC §3.1.1](SPEC.zh-CN.md#311-桌面端模型访问与无密钥默认模型回退)）。
+如果 `default_model` 解析到的 provider 不在 `provider_access` 列表里，新
+会话会静默回退到列表内第一个已配置且有 key 的 chat model。如果启动时看到
+非预期的模型替换，把 default 使用的 provider 加进列表里，或者把整个字段
+删掉让所有已配置的 provider 都可用。
+
 不要把 API key 的真实值写进 `config.toml`。这个文件是普通配置：可以查看、编辑、
 迁移，也可以在常规脱敏后用于诊断。密钥值属于下面的全局 `.env`。
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -105,6 +105,40 @@ type Config struct {
 - Streaming tool-call deltas are accumulated by index inside the provider; only
   complete `ToolCall`s are emitted.
 
+#### 3.1.1 Desktop model access and keyless default fallback
+
+`[desktop].provider_access` is a desktop-only allowlist of provider names shown
+in **Settings → Model → Access** and the in-app model switcher. It has three
+distinct states that the UI must respect:
+
+| State | Effect |
+| --- | --- |
+| **Omitted (nil)** | Desktop shows every configured provider. Legacy "all providers" behavior. |
+| **Explicit non-empty list** | Desktop only shows the named providers. New sessions that would boot onto a `default_model` outside this list silently fall back to the first listed, configured, key-bearing chat model. |
+| **Explicit `[]`** | Desktop shows no providers; new sessions cannot start and `NeedsOnboarding()` returns true so the app prompts the user to add one. |
+
+A keyless `default_model` is therefore acceptable as long as *some* configured
+chat provider has a key, even if it is not your first choice:
+
+- **CLI / shared `boot.Build` path** — `Config.ResolveNewSessionChatModel`
+  (added in #7002) is the shared chat-only fallback policy. TTS, embedding, and
+  other non-chat models are excluded from the candidate list.
+- **Desktop new-session path** — `Config.ResolveDesktopNewSessionModel`
+  (added in #6999) reuses the same policy and additionally filters by
+  `[desktop].provider_access`. If a keyless default is preserved (no candidate
+  has a key), the existing missing-key recovery UI still surfaces so the user
+  knows what to configure.
+
+Explicit user model choices are **never** silently rerouted. A keyless or
+unknown ref on the `--model` flag, the in-app model switcher for the *current*
+session, `c.Agent.PlannerModel`, or `c.Agent.SubagentModel` fails loud (CLI) or
+shows the missing-key recovery prompt (desktop interactive mode). Only the
+*implicit* `default_model` is eligible for the silent fallback above.
+
+`Config.ResolveModelWithFallback` is preserved unchanged for callers that
+already supply a resolvable explicit ref and want both the resolved form and a
+flag indicating whether the resolver had to fall back from an absent env var.
+
 ### 3.2 Tool + registry (`internal/tool`)
 
 ```go

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -76,6 +76,38 @@ func New(kind string, cfg Config) (Provider, error)
 - `max_output_tokens` 是独立的总输出预算，不由客户端 reasoning 字节上限换算。0 表示使用 provider 安全默认值，正数表示显式上限，负数表示在协议允许时省略；混合网关可用 `model_overrides.<model>.max_output_tokens` 覆盖单个模型。Anthropic 因协议要求仍会提供 `max_tokens` 默认值。
 - streaming tool-call delta 在 provider 内按 index 聚合，只向上层发出完整 `ToolCall`。
 
+#### 3.1.1 桌面端模型访问与无密钥默认模型回退
+
+`[desktop].provider_access` 是仅作用于桌面端的 provider 名白名单，控制
+**设置 → 模型 → 访问** 与应用内模型选择器中展示哪些 provider。它有三种
+互不相同的取值，UI 必须区分对待：
+
+| 取值 | 行为 |
+| --- | --- |
+| **省略（nil）** | 桌面端展示所有已配置的 provider，保留旧版"全开放"行为。 |
+| **显式非空列表** | 桌面端只展示列表内 provider；新会话若默认会落到列表外的 `default_model`，会静默回退到列表内第一个已配置且已配 key 的 chat model。 |
+| **显式 `[]`** | 桌面端不展示任何 provider；新会话无法启动，`NeedsOnboarding()` 返回 true 提示用户先添加一个。 |
+
+因此，只要 *任何一个* 已配置的 chat provider 持有 key，`default_model` 指向
+无 key provider 也是可以接受的——系统会按以下规则回退：
+
+- **CLI / 共享 `boot.Build` 路径** —— `Config.ResolveNewSessionChatModel`（#7002
+  新增）是 chat-only 的共享回退策略。TTS、embedding 等非 chat 模型不会作为
+  回退候选。
+- **桌面端新会话路径** —— `Config.ResolveDesktopNewSessionModel`（#6999 新增）
+  复用同一策略，但额外按 `[desktop].provider_access` 做白名单过滤。若全部
+  候选都没 key，仍会保留一个有效的 default 让现有的 missing-key 恢复 UI
+  告诉用户该配什么。
+
+**显式选定的 model 永远不会被静默重路由**。`--model`、当前会话的模型选择
+器、`c.Agent.PlannerModel`、`c.Agent.SubagentModel` 在 keyless 或 unknown
+时都会显式失败（CLI）或弹出 missing-key 恢复提示（桌面端交互模式）。只有
+*隐式* `default_model` 才会走上述静默回退。
+
+`Config.ResolveModelWithFallback` 保持原有语义不变，供已经传入可解析的
+显式 ref、并希望同时拿到 resolved 形式和"是否因 env 缺失而回退"标记的调用
+方继续使用。
+
 ### 3.2 Tool 与 registry（`internal/tool`）
 
 ```go

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -4,7 +4,12 @@
 # Provider entries name secrets via api_key_env; saved key values live in
 # Reasonix's global <Reasonix home>/.env. Never put API key values here.
 
-default_model = "deepseek"   # a provider name (→ its default model) or "provider/model"
+default_model = "deepseek"   # a provider name (→ its default model) or "provider/model".
+                            # If this provider is keyless in the current environment, the CLI/boot
+                            # path falls through to the first configured chat model (#7002); the
+                            # desktop NewSession path applies [desktop].provider_access first
+                            # before falling back (#6999). Explicit --model or the in-app model
+                            # switcher never get silently rerouted.
 # language      = "zh"   # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
 
 [ui]
@@ -21,6 +26,17 @@ layout_style = "classic"   # classic|workbench|creation; desktop layout style
 # theme = "auto"   # desktop only: auto|dark|light
 # terminal_theme = "auto"   # integrated terminal: auto|dark|light; auto follows the desktop app
 # theme_style = "graphite"   # graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
+# provider_access = ["deepseek"]   # desktop-only allowlist of providers shown in Settings >
+                                # Model > Access and the in-app model switcher. Three states:
+                                #   omitted (nil)  — every configured provider is shown
+                                #                    (legacy "all providers" behavior).
+                                #   explicit list  — only the named providers are shown; new
+                                #                    sessions that boot onto a default_model
+                                #                    outside this list will silently fall back
+                                #                    to the first listed, configured chat model.
+                                #   explicit []    — no providers shown; new sessions cannot
+                                #                    start and the app prompts onboarding.
+                                # CLI startup ignores this field; it is desktop-only.
 
 [notifications]
 enabled = false   # system notifications for CLI and desktop turns; default off


### PR DESCRIPTION
## Summary

Documents the desktop `[desktop].provider_access` allowlist and the keyless
`default_model` fallback chain that PRs #6999 and #7002 introduced. GUI users
currently have no way to discover that:

- `provider_access` has three distinct states (omitted, explicit list,
  explicit `[]`); only the omitted state preserves the legacy all-providers
  behavior.
- A keyless `default_model` is silently replaced by the first listed,
  configured, key-bearing chat model at desktop startup.
- Explicit user choices (the `--model` flag, the in-app model switcher for
  the *current* session, `c.Agent.PlannerModel`, `c.Agent.SubagentModel`)
  are **never** silently rerouted. Only the *implicit* `default_model` is
  eligible for the silent fallback.

The existing example template (`reasonix.example.toml`) and the SPEC did not
mention `provider_access` at all, and `CONFIG_PATHS.md` listed the field
without explaining it. This PR closes that documentation gap.

## Motivation

Follow-up to the work that landed in #6999 (desktop) and #7002 (CLI / shared
`boot.Build`). The behavior is correct, but the boundary is invisible to
anyone reading only `config.toml` or the bundled example. While validating
#6996 on a v1.21.3 binary, a GUI user changing the bottom model switcher
expected the change to write back to `config.toml`; it did not, because
that switcher sets the per-session `tab.model` rather than
`cfg.DefaultModel`. The user then asked why the "default model" field in
Settings still showed the old value. The UX confusion comes from the lack
of a single place that documents the two writes.

## Changes

| File | Change |
|:--|:--|
| `reasonix.example.toml` | Extend the `default_model` comment with the fallback summary and PR refs; add a commented `provider_access` example with the three-state table. |
| `docs/SPEC.md` | Add a new `§3.1.1 Desktop model access and keyless default fallback` subsection with the state table, the CLI/boot vs desktop fallback paths, and the explicit-choice carve-out. |
| `docs/SPEC.zh-CN.md` | Chinese translation of the same `§3.1.1` subsection. |
| `docs/CONFIG_PATHS.md` | After the example block, add a short paragraph linking the two fields and pointing readers to SPEC §3.1.1. |
| `docs/CONFIG_PATHS.zh-CN.md` | Chinese translation of the same paragraph. |

Total: 5 files, +97/-1. No code change.

## Verification

- `git diff --check` - passed.
- `git diff --stat` - shows the expected 5-file, 98-line delta.
- Cross-link between `CONFIG_PATHS.md` and `SPEC.md#311-desktop-model-access-and-keyless-default-fallback`
  is rendered correctly by GitHub's anchor generator.
- All factual statements are sourced from the existing Go behavior:
  - `Config.ResolveNewSessionChatModel` (added in #7002) and
    `Config.ResolveDesktopNewSessionModel` (added in #6999).
  - `desktop.modelProviderAccessAllowed` (signature changed in #6999 to
    treat `nil` and `[]` differently).
  - `desktop.NeedsOnboarding` returns true when no desktop-accessible chat
    model exists.
  - `ResolveModelWithFallback` semantics preserved for callers that already
    supply a resolvable explicit ref.

## Compatibility

- No code change. No schema change. No persisted-format change.
- README/i18n mapping in `SPEC.md` ↔ `SPEC.zh-CN.md` is kept parallel.
- The new `§3.1.1` number slot is unused; existing cross-references that
  point at `§3.1` or other sections remain valid.

## Risk review

- Cache impact: none. No prompt, tool schema, memory prefix, or model-call
  path is changed.
- Security impact: none. No credentials, network calls, or permissions
  involved.
- CI gates: `cache-impact` checks a known list of system-prompt-sensitive
  paths; the changed files are all in `docs/` or `reasonix.example.toml`,
  none of which match. The check should skip with "No cache-sensitive
  prompt/tool files changed." The PR body still carries the required
  headers for the case-insensitive grep matcher.

Cache-impact: none - documentation only; no provider-visible prompt, tool
schema, memory prefix, or model-call path is modified.
Cache-guard: the SPEC and CONFIG_PATHS prose additions are factual
statements of behavior already covered by
TestModelsForTabListsNothingWhenProviderAccessExplicitlyEmpty,
TestSettingsDoesNotInferProviderAccessWhenExplicitlyEmpty,
TestNeedsOnboarding, and the fallback regression tables added in #6999 and
#7002. `reasonix.example.toml` is a template with no test coverage.
System-prompt-review: self-reviewed (@PaulDing98) - no system prompt
construction, content, ordering, or dynamic prefix bytes touched; only
markdown prose and TOML comments. Awaiting @esengine maintainer approval.
