### PR TITLE
fix(agent): make the compaction fold region a real partition

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -278,12 +278,16 @@ Long tasks eventually fill the model's context window. Reasonix manages this wit
   tool results stay paired. `KeepErrors` preserves error/blocked tool outputs,
   and the recent tail is not rewritten. Snipped results can later be upgraded to
   pruned placeholders; already-pruned results are left alone.
-- When summary compaction runs, it folds only the assistant/tool work. Every
-  **user turn** small enough to be a brief and every **prior digest** is kept
-  verbatim; the foldable remainder is summarized — using the executor's own
-  provider, no tools — in place. The boundary is aligned backward off any tool
-  result so the recent tail never begins with an orphan tool message whose
-  `tool_calls` were summarized away.
+- When summary compaction runs, the fold region (everything between the pinned
+  prefix and the recent tail) is split three ways: the first few **small user
+  turns** are hoisted verbatim ahead of the digest, messages the keep policy
+  protects stay verbatim, and **everything else** — assistant/tool work, later
+  user turns, and any prior digest — is summarized into a single digest, using
+  the executor's own provider, no tools. The split is a partition: a message in
+  the region is either kept verbatim or reaches the summarizer, never neither.
+  The tail boundary is aligned backward off any tool result so the recent tail
+  never begins with an orphan tool message whose `tool_calls` were summarized
+  away.
 - The dropped originals are archived under the user config dir
   (`reasonix/archive/<timestamp>.jsonl`; see §5 for its per-OS location), one
   message per line, so the full history stays traceable.
@@ -322,16 +326,20 @@ Long tasks eventually fill the model's context window. Reasonix manages this wit
   See [`SESSION_MEMORY_RETRIEVAL.md`](SESSION_MEMORY_RETRIEVAL.md) for the
   detailed implementation contract.
 
-**What survives a fold.** A fact the user states in a normal-sized turn is kept
-verbatim and is never summarized away — at any point in the session, across any
-number of compactions. A digest, once written, is likewise kept verbatim rather
-than re-summarized, so facts it captured are not lost to drift. The one
-**best-effort** boundary: a fact buried inside a single oversized message (a
-large paste, over the per-turn pin budget) folds with the rest, so its survival
-depends on the summarizer catching it while compressing bulk. There is no
-reliable way to auto-detect an arbitrary fact in bulk, so durable facts belong in
-their own turn rather than buried in a large paste; the raw oversized content is
-still archived and recoverable either way.
+**What survives a fold.** Verbatim, at every compaction: the system prompt, the
+first user turn when it is small enough to be a brief, the first few small user
+turns of the fold region, the messages the keep policy protects, and the recent
+tail. Everything else is **best-effort** — it reaches the summarizer and survives
+only as well as the digest captured it. That includes small user turns beyond the
+hoisted window, so a durable constraint is safest restated in a recent turn
+rather than assumed to hold from turn 4 of a long session.
+
+Two properties bound that loss. Each fold re-derives its digest from the
+canonical transcript rather than from the previous digest, so digests do not
+chain and repeated compaction does not compound summarizer drift. And compaction
+only ever writes a projection: the canonical transcript keeps every original, so
+a folded detail stays recoverable through the `history` tool and the archive
+(`reasonix/archive/<timestamp>.jsonl`) even when the digest missed it.
 
 This is the **only** point where the prompt prefix changes — a deliberate, rare
 "cache-reset point". Between compactions the session grows prepend-only and

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -153,7 +153,21 @@ Reasonix 通过低频 compaction 保持 cache-first：
 用户可用 `reasonix config compact-ratio [--local] [VALUE]` 查看或修改 65–85% 的自动
 压缩阈值，内置默认值为 80%。项目级设置优先于桌面端与新 CLI 会话共用的用户全局配置。
 
-tool result 的 snip/prune 不删除消息，确保 assistant `tool_calls` 与 tool result 配对。摘要只折叠 assistant/tool 工作；正常大小的用户回合和既有 digest 原样保留。被移除的原文归档到 `reasonix/archive/<timestamp>.jsonl`。
+tool result 的 snip/prune 不删除消息，确保 assistant `tool_calls` 与 tool result 配对。
+
+摘要折叠时，固定前缀与近期 tail 之间的区间被划分为三部分：开头若干条小体量用户回合原样提升到
+digest 之前，keep policy 保护的消息原样保留，其余全部——assistant/tool 工作、后续用户回合、以及
+已有 digest——折叠进同一条 digest。三者构成一个划分：区间内的消息要么原样保留，要么进入摘要输入，
+不存在两者皆非的情况。
+
+因此逐字保留的是：system prompt、体量足够小的首个用户回合、折叠区间开头若干条小体量用户回合、
+keep policy 保护的消息，以及近期 tail。其余均为尽力而为——只在 digest 抓住它的前提下留存，
+其中包括超出提升窗口的小体量用户回合，所以长期有效的约束更适合在近期回合中重述。
+
+两个性质限制了这种损失：每次折叠都从 canonical transcript 重新生成 digest，而不是在上一条 digest
+之上再摘要，因此 digest 不会形成链条，反复压缩也不会累积摘要漂移；同时 compaction 只写 projection，
+canonical transcript 保留全部原文，被折叠的细节仍可通过 `history` tool 与归档
+（`reasonix/archive/<timestamp>.jsonl`）取回。
 
 `history` tool 支持对 session 与归档进行 BM25 搜索；`memory` tool 用于检索自动记忆，
 `remember` 与 `forget` 负责写入和归档。每个真实用户回合前，Reasonix 会用原始用户消息执行

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -34,7 +34,7 @@ const (
 	fallbackTokPerChar         = 0.25  // ~4 chars/token, used before any usage is available to calibrate
 	maxPinnedFirstUserTokens   = 1500  // ceiling on pinning the first user turn verbatim; larger first turns (pasted content) stay foldable
 	pinnedFirstUserWindowFrac  = 0.15  // and never pin a first turn worth more than this fraction of the window
-	maxKeepSmallUserTurns      = 20    // position-fixed keep window for small user turns in the fold region; the first N survive verbatim, older ones fold (prefix byte-stable, never "latest N")
+	maxEarlyUserTurns          = 3     // small user turns hoisted verbatim ahead of the digest; position-fixed (the first N of the fold region, never "the latest N") so the projection prefix stays byte-stable
 )
 
 // summaryTag wraps the compaction summary so the model can distinguish it from
@@ -303,14 +303,11 @@ func isCompactionSummary(m provider.Message) bool {
 		strings.HasPrefix(strings.TrimLeft(m.Content, "\n "), summaryTagOpen)
 }
 
-// pinnedPrefixLen counts the leading messages a fold keeps verbatim: the system
-// prompt, the first user turn (its task + stated facts/constraints) when it is
-// small enough to be a brief, and the NEWEST prior summary — so a fold never
-// summarizes the user's facts away. Older summaries are NOT pinned: they enter
-// the fold region and are merged into the next digest (A1 rolling merge), so a
-// long session cannot accumulate an unbounded chain of digests. Merging re-feeds
-// the old summary text into the summarizer, so the facts it captured survive in
-// the new digest instead of being silently dropped.
+// pinnedPrefixLen counts the leading messages a fold keeps verbatim ahead of
+// everything else: the system prompt and the first user turn (its task + stated
+// facts/constraints) when it is small enough to be a brief. Digests are never
+// pinned — any digest in the transcript enters the fold region and is merged
+// into the next one, so a session cannot accumulate a chain of them.
 func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	i := 0
 	if i < len(msgs) && msgs[i].Role == provider.RoleSystem {
@@ -319,10 +316,6 @@ func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && a.fixedPinnableUserTurn(msgs[i]) {
 		i++
 	}
-	// The entire summary run stays inside the fold region; partitionFold keeps
-	// the NEWEST summary verbatim and folds the older ones into the next digest
-	// (A1 rolling merge) — re-feeding their text through the summarizer so a
-	// long session cannot accumulate an unbounded chain of digests.
 	return i
 }
 
@@ -340,57 +333,6 @@ func (a *Agent) fixedPinnableUserTurn(m provider.Message) bool {
 		}
 	}
 	return int(float64(msgChars(m))*fallbackTokPerChar) <= budget
-}
-
-// partitionFold splits a compaction region into what is kept verbatim — small user
-// turns (a fact the user stated is never summarized away) — and the rest, which
-// folds. Order within each group is preserved.
-//
-// Prior digests inside the region are folded (not kept verbatim): the newest
-// digest is already pinned by pinnedPrefixLen outside the region, so any summary
-// seen here is an older one being merged into the next digest (A1 rolling merge).
-// Merging re-feeds the old summary text into the summarizer, preserving its facts.
-//
-// The small-turn keep window is position-fixed (only the first keepSmallUserTurns
-// small user turns in the region survive), never "the most recent N" — a dynamic
-// tail window would move with every compaction and rewrite the kept prefix,
-// cratering the server-side prefix cache (mental-seal: prefix stability is the
-// first principle). A fixed prefix window keeps the surviving bytes identical
-// across compactions; only the folded middle is replaced by a digest.
-func (a *Agent) partitionFold(region []provider.Message) (kept, fold []provider.Message) {
-	policyKeep := keepIndexes(region, a.keepPolicy)
-	keptSmallUserTurns := 0
-	// The NEWEST summary in the region (the last one in the contiguous summary
-	// run) is kept verbatim; older digests fold into the next digest (A1 rolling
-	// merge) and are re-fed through the summarizer, so the digest chain cannot
-	// accumulate unboundedly.
-	lastSummary := -1
-	for i, m := range region {
-		if isCompactionSummary(m) {
-			lastSummary = i
-		}
-	}
-	for i, m := range region {
-		keep := m.LocalOnly || policyKeep[i] || (isCompactionSummary(m) && i == lastSummary)
-		if !keep && m.Role == provider.RoleUser && !isCompactionSummary(m) && a.fixedPinnableUserTurn(m) {
-			// Position-fixed small-turn keep window: the first N small user turns
-			// in the region survive verbatim; older ones fold into the digest so
-			// a long session cannot accumulate unbounded verbatim user turns.
-			// N is fixed (not "latest N"), so the kept prefix stays byte-stable.
-			// Digests are excluded: they are governed by the A1 rolling merge
-			// (only the newest survives verbatim; older ones re-enter the fold).
-			if keptSmallUserTurns < maxKeepSmallUserTurns {
-				keep = true
-			}
-			keptSmallUserTurns++
-		}
-		if keep {
-			kept = append(kept, m)
-		} else {
-			fold = append(fold, m)
-		}
-	}
-	return kept, fold
 }
 
 func keepIndexes(region []provider.Message, policy KeepPolicy) []bool {

--- a/internal/agent/compact_partition_test.go
+++ b/internal/agent/compact_partition_test.go
@@ -1,0 +1,155 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// bigTurn is comfortably over maxPinnedFirstUserTokens, so it is never pinnable.
+func bigTurn() string { return strings.Repeat("paste ", 4000) }
+
+// partitionCoversRegion is the invariant that makes a lost user turn impossible:
+// every provider-visible message in the region lands in exactly one group.
+func partitionCoversRegion(t *testing.T, a *Agent, region []provider.Message) (early, kept, fold []provider.Message) {
+	t.Helper()
+	early, kept, fold = a.partitionFoldForProjection(region)
+	seen := map[string]int{}
+	for _, group := range [][]provider.Message{early, kept, fold} {
+		for _, m := range group {
+			seen[m.Content]++
+		}
+	}
+	for _, m := range region {
+		if m.LocalOnly {
+			if seen[m.Content] != 0 {
+				t.Errorf("display-only message %q reached the projection", m.Content)
+			}
+			continue
+		}
+		switch seen[m.Content] {
+		case 1:
+		case 0:
+			t.Errorf("message %q is in no group — it would vanish from the projection", m.Content)
+		default:
+			t.Errorf("message %q is in %d groups — it would be duplicated", m.Content, seen[m.Content])
+		}
+	}
+	return early, kept, fold
+}
+
+func TestPartitionHoistsFirstSmallUserTurnsInOrder(t *testing.T) {
+	// The hoist window is position-fixed (the first N), never "the most recent
+	// N": a window that moved with each fold would rewrite the projection prefix
+	// and crater the server-side cache.
+	a := &Agent{}
+	var region []provider.Message
+	for i := range 25 {
+		region = append(region, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("small turn %d", i)})
+	}
+	early, kept, fold := partitionCoversRegion(t, a, region)
+	if len(early) != maxEarlyUserTurns || len(kept) != 0 || len(fold) != 25-maxEarlyUserTurns {
+		t.Fatalf("early=%d kept=%d fold=%d, want %d/0/%d", len(early), len(kept), len(fold), maxEarlyUserTurns, 25-maxEarlyUserTurns)
+	}
+	for i, m := range early {
+		if want := fmt.Sprintf("small turn %d", i); UserMessageText(m) != want {
+			t.Fatalf("early[%d]=%q, want %q — the hoist window must be the leading turns", i, UserMessageText(m), want)
+		}
+	}
+	for i, m := range fold {
+		if want := fmt.Sprintf("small turn %d", maxEarlyUserTurns+i); UserMessageText(m) != want {
+			t.Fatalf("fold[%d]=%q, want %q", i, UserMessageText(m), want)
+		}
+	}
+}
+
+func TestPartitionFoldsLargeUserTurns(t *testing.T) {
+	a := &Agent{}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: bigTurn()},
+		{Role: provider.RoleUser, Content: "small"},
+	}
+	early, _, fold := partitionCoversRegion(t, a, region)
+	if len(early) != 1 || UserMessageText(early[0]) != "small" {
+		t.Fatalf("early=%+v, want only the small turn hoisted", early)
+	}
+	if len(fold) != 1 {
+		t.Fatalf("fold=%d, want the large turn folded", len(fold))
+	}
+}
+
+// A user turn that is not hoisted must still reach the summarizer. Two rules
+// that disagreed on which turns count as "early" used to drop the turns after an
+// oversized one from both groups, deleting stated constraints outright.
+func TestPartitionKeepsSmallTurnsAfterALargeOne(t *testing.T) {
+	a := &Agent{}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: "constraint A"},
+		{Role: provider.RoleUser, Content: bigTurn()},
+		{Role: provider.RoleUser, Content: "never touch the db schema"},
+		{Role: provider.RoleUser, Content: "constraint C"},
+		{Role: provider.RoleAssistant, Content: "work"},
+	}
+	early, _, fold := partitionCoversRegion(t, a, region)
+	if len(early) != 3 {
+		t.Fatalf("early=%d (%+v), want the three small turns hoisted across the oversized one", len(early), early)
+	}
+	if got := renderTranscript(fold); !strings.Contains(got, "paste") {
+		t.Fatalf("the oversized turn must still reach the summarizer:\n%s", got)
+	}
+}
+
+// The hoist set is drawn from the fold region only. Reading past it would hoist
+// a turn that also rides in the verbatim tail, sending it to the model twice.
+func TestPartitionHoistIsDisjointFromTail(t *testing.T) {
+	a := &Agent{}
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleUser, Content: "constraint A"},
+		{Role: provider.RoleAssistant, Content: "work"},
+		{Role: provider.RoleUser, Content: "tail turn one"},
+		{Role: provider.RoleAssistant, Content: "more"},
+		{Role: provider.RoleUser, Content: "tail turn two"},
+	}
+	head := a.pinnedPrefixLen(msgs)
+	const start = 4
+	early, _, _ := partitionCoversRegion(t, a, msgs[head:start])
+	for _, m := range early {
+		for _, tail := range msgs[start:] {
+			if m.Content == tail.Content {
+				t.Fatalf("hoisted turn %q also rides in the verbatim tail", m.Content)
+			}
+		}
+	}
+}
+
+func TestPartitionFoldsPriorDigests(t *testing.T) {
+	// Any digest in the transcript is merged into the next one, so the model
+	// never sees a chain of them.
+	a := &Agent{}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: summaryTagOpen + "\nolder digest\n" + summaryTagClose},
+		{Role: provider.RoleUser, Content: summaryTagOpen + "\nnewer digest\n" + summaryTagClose},
+		{Role: provider.RoleAssistant, Content: "work"},
+	}
+	early, kept, fold := partitionCoversRegion(t, a, region)
+	if len(early) != 0 || len(kept) != 0 || len(fold) != 3 {
+		t.Fatalf("early=%d kept=%d fold=%d, want every digest folded", len(early), len(kept), len(fold))
+	}
+}
+
+func TestPartitionKeepPolicyOutranksFold(t *testing.T) {
+	a := &Agent{keepPolicy: KeepErrors}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: "small"},
+		{Role: provider.RoleAssistant, Content: "call", ToolCalls: []provider.ToolCall{{ID: "t1", Name: "bash"}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "bash", Content: "error: boom"},
+	}
+	early, kept, fold := partitionCoversRegion(t, a, region)
+	if len(early) != 1 || len(kept) != 2 || len(fold) != 0 {
+		t.Fatalf("early=%d kept=%d fold=%d, want the error result and its caller kept", len(early), len(kept), len(fold))
+	}
+}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -412,7 +412,7 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		}
 	}
 	region := msgs[head:start]
-	kept, fold := a.partitionFoldForProjection(region)
+	early, kept, fold := a.partitionFoldForProjection(region)
 	if len(fold) == 0 {
 		return CompactionNoop, nil
 	}
@@ -470,7 +470,6 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		return CompactionNoop, err
 	}
 
-	early := a.fixedEarlyUserTurns(msgs, head)
 	projMsgs := make([]provider.Message, 0, head+len(early)+1+len(kept)+len(msgs)-start)
 	projMsgs = append(projMsgs, msgs[:head]...)
 	projMsgs = append(projMsgs, early...)
@@ -521,41 +520,50 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	return CompactionInstalled, nil
 }
 
-// partitionFoldForProjection is like partitionFold but prior digests join the
-// fold so A1 rolling merge produces a single latest summary. Fixed early user
-// turns are excluded from both kept and fold — the caller re-inserts them from
-// the full transcript so their bytes stay position-stable.
-func (a *Agent) partitionFoldForProjection(region []provider.Message) (kept, fold []provider.Message) {
+// partitionFoldForProjection splits the fold region three ways: user turns
+// hoisted verbatim ahead of the digest, messages the keep policy protects, and
+// the remainder that folds (prior digests included, so a merge yields one
+// summary). The groups partition the region — one pass decides each message
+// once, so no turn can fall between a hoist rule and a fold rule that disagree.
+func (a *Agent) partitionFoldForProjection(region []provider.Message) (early, kept, fold []provider.Message) {
 	policyKeep := keepIndexes(region, a.keepPolicy)
-	earlySeen := 0
-	const maxEarly = 3
+	hoist := a.earlyUserTurns(region)
 	for i, m := range region {
-		if m.LocalOnly {
-			continue
-		}
-		// Skip the fixed early small user turns — they are re-added from the
-		// full transcript after the summary so the prefix stays byte-stable.
-		if m.Role == provider.RoleUser && !isCompactionSummary(m) && a.fixedPinnableUserTurn(m) && earlySeen < maxEarly {
-			earlySeen++
-			continue
-		}
-		if isCompactionSummary(m) {
-			fold = append(fold, m)
-			continue
-		}
-		if policyKeep[i] {
+		switch {
+		case m.LocalOnly: // display-only output never reaches a provider
+		case hoist[i]:
+			early = append(early, m)
+		case policyKeep[i] && !isCompactionSummary(m):
 			kept = append(kept, m)
-			continue
-		}
-		if m.Role == provider.RoleUser && a.fixedPinnableUserTurn(m) {
-			// Additional small user turns beyond the fixed early window fold so
-			// the projection does not grow unbounded with every user fact.
+		default:
 			fold = append(fold, m)
+		}
+	}
+	return early, kept, fold
+}
+
+// earlyUserTurns marks the region positions of the small user turns hoisted
+// verbatim ahead of the digest. Selecting from the fold region alone keeps the
+// set disjoint from the verbatim tail, and taking the first N (never the latest
+// N) keeps the hoisted bytes identical across folds: the region only ever grows
+// at its end, so the set can gain a member but never reorder or lose one.
+func (a *Agent) earlyUserTurns(region []provider.Message) []bool {
+	hoist := make([]bool, len(region))
+	n := 0
+	for i, m := range region {
+		if n == maxEarlyUserTurns {
+			break
+		}
+		if m.LocalOnly || m.Role != provider.RoleUser || isCompactionSummary(m) {
 			continue
 		}
-		fold = append(fold, m)
+		if !a.fixedPinnableUserTurn(m) {
+			continue
+		}
+		hoist[i] = true
+		n++
 	}
-	return kept, fold
+	return hoist
 }
 
 // runCompactionSummary tries native compaction first, then summarizeWithRetry.

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"reasonix/internal/event"
 	"strings"
 	"testing"
@@ -477,16 +476,19 @@ func TestRenderTranscriptRedactsToolCallArgs(t *testing.T) {
 	}
 }
 
-func TestInterruptedDisplayStaysVerbatimAndOutOfCompactionPrompt(t *testing.T) {
+// Display-only output stays verbatim in the canonical transcript by construction
+// (compaction only writes a projection); this pins the other half: it must never
+// reach the summarizer or the model-visible projection.
+func TestInterruptedDisplayStaysOutOfCompactionPromptAndProjection(t *testing.T) {
 	local := provider.Message{
 		Role: provider.RoleTool, ToolCallID: provider.LocalOnlyToolID, Name: provider.LocalOnlyToolName,
 		LocalOnly: true, Content: "partial visible answer", ReasoningContent: "private partial reasoning",
 		InterruptedTurn: &provider.InterruptedTurnRecovery{Pending: true},
 	}
 	a := &Agent{}
-	kept, fold := a.partitionFold([]provider.Message{local})
-	if len(kept) != 1 || !kept[0].LocalOnly || len(fold) != 0 {
-		t.Fatalf("compaction partition kept=%+v fold=%+v, want local display kept verbatim", kept, fold)
+	early, kept, fold := a.partitionFoldForProjection([]provider.Message{local})
+	if len(early) != 0 || len(kept) != 0 || len(fold) != 0 {
+		t.Fatalf("compaction partition early=%+v kept=%+v fold=%+v, want display-only output in none of them", early, kept, fold)
 	}
 	if transcript := renderTranscript([]provider.Message{local}); transcript != "" {
 		t.Fatalf("local interrupted output leaked into compaction prompt: %q", transcript)
@@ -617,55 +619,6 @@ func TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger(t *testing.T) {
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
 	if !a.compactStuck {
 		t.Fatalf("two consecutive over-trigger compactions must still latch: consecutiveCompacts=%d", a.consecutiveCompacts)
-	}
-}
-
-func TestPartitionFoldSmallTurnWindowIsPositionFixed(t *testing.T) {
-	// 25 small user turns in the region: the first 20 must be kept verbatim,
-	// the last 5 must fold. The window is position-fixed (first N), never
-	// "the most recent N" — a dynamic tail would rewrite the kept prefix on
-	// every compaction and crater the server-side prefix cache.
-	a := &Agent{}
-	var region []provider.Message
-	for i := range 25 {
-		region = append(region, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("small turn %d", i)})
-	}
-	kept, fold := a.partitionFold(region)
-	if len(kept) != maxKeepSmallUserTurns {
-		t.Fatalf("kept %d small user turns, want %d (position-fixed window)", len(kept), maxKeepSmallUserTurns)
-	}
-	if len(fold) != 5 {
-		t.Fatalf("folded %d turns, want 5 (turns beyond the fixed window)", len(fold))
-	}
-	// The kept turns must be the FIRST ones in order (positions 0..19).
-	for i := range maxKeepSmallUserTurns {
-		want := fmt.Sprintf("small turn %d", i)
-		if got := UserMessageText(kept[i]); got != want {
-			t.Fatalf("kept[%d]=%q, want %q — keep window must be the leading turns", i, got, want)
-		}
-	}
-	// Folded turns are the oldest beyond the window (positions 20..24).
-	for i, m := range fold {
-		want := fmt.Sprintf("small turn %d", 20+i)
-		if got := UserMessageText(m); got != want {
-			t.Fatalf("fold[%d]=%q, want %q", i, got, want)
-		}
-	}
-}
-
-func TestPartitionFoldLargeTurnsStillFold(t *testing.T) {
-	// Large user turns are not pinnable regardless of window position.
-	a := &Agent{}
-	region := []provider.Message{
-		{Role: provider.RoleUser, Content: strings.Repeat("big", 4000)}, // 12000 chars ×0.25 = 3000 > 1500 → not pinnable
-		{Role: provider.RoleUser, Content: "small"},
-	}
-	kept, fold := a.partitionFold(region)
-	if len(kept) != 1 || UserMessageText(kept[0]) != "small" {
-		t.Fatalf("kept=%+v, want only the small turn", kept)
-	}
-	if len(fold) != 1 {
-		t.Fatalf("fold=%d, want the large turn folded", len(fold))
 	}
 }
 

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -382,24 +382,3 @@ func extractLatestSummary(msgs []provider.Message) string {
 	}
 	return ""
 }
-
-// fixedEarlyUserTurns returns position-stable early small user turns after the
-// system prompt. Unlike "latest N user turns", the set is fixed from the start
-// of the transcript so later compressions do not reshuffle the cache prefix.
-func (a *Agent) fixedEarlyUserTurns(msgs []provider.Message, head int) []provider.Message {
-	const maxEarly = 3
-	var early []provider.Message
-	for i := head; i < len(msgs) && len(early) < maxEarly; i++ {
-		m := msgs[i]
-		if m.LocalOnly || m.Role != provider.RoleUser || isCompactionSummary(m) {
-			continue
-		}
-		if !a.fixedPinnableUserTurn(m) {
-			// Large early turns stay foldable; stop extending the fixed prefix
-			// once a non-pinnable user turn appears so positions stay stable.
-			break
-		}
-		early = append(early, m)
-	}
-	return early
-}


### PR DESCRIPTION
## Problem

The projection fold carried two disagreeing definitions of "early user turn":

- `partitionFoldForProjection` skipped the first three *pinnable* turns it saw, continuing past oversized ones.
- `fixedEarlyUserTurns` stopped at the first oversized turn.

When an oversized user turn (a large paste) appeared among the first few turns of the fold region, the small turns after it were hoisted by neither rule and folded by neither. They left the projection **without ever reaching the summarizer** — a user-stated constraint disappeared outright rather than being compressed.

`fixedEarlyUserTurns` also scanned the whole transcript rather than the fold region, so it could hoist a turn that already rode in the verbatim tail, sending it to the model twice.

Reproduced against `main-v2` (fb993e12a) before the fix:

```
"constraint A"                   -> early(verbatim)
"NEVER touch the db schema"      -> DROPPED
"constraint C"                   -> DROPPED

early turn "tail turn one" is also in the verbatim tail → duplicated in the projection
```

## Fix

One pass decides each message exactly once and returns the hoisted, kept and folded groups together; the hoist set is drawn from the fold region alone. `partitionCoversRegion` asserts the partition property in every partition test, so a future rule cannot reopen the gap.

Also removes the dead `partitionFold` path (test-only since compaction became projection-only) and its `maxKeepSmallUserTurns = 20` window, which advertised a 20-turn verbatim guarantee the live path never applied — the live window is 3.

## Docs

SPEC.md and SPEC.zh-CN.md promised that every normal-sized user turn and every prior digest stays verbatim forever. Neither has been true since compaction became projection-only. They now describe the real contract: the fold region is partitioned (verbatim or summarized, never neither), the hoist window is the first few small turns, and each fold re-derives its digest from the canonical transcript rather than from the previous digest, so digests do not chain.

Cache-impact: low - the stable system-prompt prefix (base prompt, tools, memory) is untouched. Only the projection's hoisted-turn block changes, and only at a fold, which is already the designated cache-reset point. The hoist set stays position-fixed and append-only across folds, so the projection prefix remains byte-stable between compactions.
Cache-guard: go test ./internal/agent/ -run 'TestPartition|TestProjection|TestCompact|TestCaptureShape'
Documentation-impact: updated - docs/SPEC.md and docs/SPEC.zh-CN.md 3.6 now match the implemented fold contract.
