### PR TITLE
fix(provider): block vision on official DeepSeek text-only models

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -359,10 +359,11 @@ For common providers, choose **Add model service -> Recommended preset** instead
 The official DeepSeek service continues to use its specially adapted OpenAI Chat
 Completions path by default; add the optional **DeepSeek Anthropic** preset only
 when Anthropic Messages compatibility is needed. The two entries do not replace
-each other. Official DeepSeek APIs currently accept text-only message content,
-so Reasonix rejects `vision = true`, `vision_models`, and per-model `vision`
-overrides on `*.deepseek.com` endpoints with a clear error; custom
-DeepSeek-compatible gateways remain configurable. Reasonix can prefill editable
+each other. Official DeepSeek's current text-only models (`deepseek-v4-flash`
+and `deepseek-v4-pro`) accept text message content only, so Reasonix rejects
+`vision = true`, `vision_models`, and per-model `vision` overrides for them with
+a clear error. Future official multimodal models and custom DeepSeek-compatible
+gateways can still opt in explicitly. Reasonix can prefill editable
 custom-provider entries for Kimi CN,
 Kimi Global,
 Kimi Coding Plan, MiMo API, MiMo Anthropic, MiMo Token Plan CN/SGP/AMS and their

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -359,7 +359,11 @@ For common providers, choose **Add model service -> Recommended preset** instead
 The official DeepSeek service continues to use its specially adapted OpenAI Chat
 Completions path by default; add the optional **DeepSeek Anthropic** preset only
 when Anthropic Messages compatibility is needed. The two entries do not replace
-each other. Reasonix can prefill editable custom-provider entries for Kimi CN,
+each other. Official DeepSeek APIs currently accept text-only message content,
+so Reasonix rejects `vision = true`, `vision_models`, and per-model `vision`
+overrides on `*.deepseek.com` endpoints with a clear error; custom
+DeepSeek-compatible gateways remain configurable. Reasonix can prefill editable
+custom-provider entries for Kimi CN,
 Kimi Global,
 Kimi Coding Plan, MiMo API, MiMo Anthropic, MiMo Token Plan CN/SGP/AMS and their
 Anthropic-compatible variants, MiniMax CN/Global API, MiniMax CN/Global

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -307,7 +307,10 @@ Serve。认证失败或主机密钥错误属于终止性故障，此时会关闭
 
 常用服务优先使用 **添加模型服务 -> 推荐预设**。DeepSeek 官方服务默认继续使用经过专项适配的
 OpenAI Chat Completions；需要 Anthropic Messages 兼容时，可单独添加 **DeepSeek Anthropic**
-可选预设，两者不会互相替换。Reasonix 还可以预填以下可编辑的自定义 provider：
+可选预设，两者不会互相替换。官方 DeepSeek API 目前仅接受纯文本消息，Reasonix
+会拒绝在 `*.deepseek.com` 端点配置 `vision = true`、`vision_models` 或逐模型
+`vision` 覆盖并给出明确报错；自定义 DeepSeek 兼容网关不受影响。Reasonix 还可以
+预填以下可编辑的自定义 provider：
 Kimi CN、Kimi Global、Kimi Coding Plan、MiMo API、MiMo Anthropic、MiMo Token Plan
 CN/SGP/AMS 及其 Anthropic-compatible 变体、MiniMax CN/Global API、MiniMax
 CN/Global Anthropic、GLM CN、Z.AI Global、GLM/Z.AI Coding Plan 的

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -307,10 +307,11 @@ Serve。认证失败或主机密钥错误属于终止性故障，此时会关闭
 
 常用服务优先使用 **添加模型服务 -> 推荐预设**。DeepSeek 官方服务默认继续使用经过专项适配的
 OpenAI Chat Completions；需要 Anthropic Messages 兼容时，可单独添加 **DeepSeek Anthropic**
-可选预设，两者不会互相替换。官方 DeepSeek API 目前仅接受纯文本消息，Reasonix
-会拒绝在 `*.deepseek.com` 端点配置 `vision = true`、`vision_models` 或逐模型
-`vision` 覆盖并给出明确报错；自定义 DeepSeek 兼容网关不受影响。Reasonix 还可以
-预填以下可编辑的自定义 provider：
+可选预设，两者不会互相替换。官方 DeepSeek 当前纯文本模型
+（`deepseek-v4-flash`、`deepseek-v4-pro`）仅接受文本消息，Reasonix 会拒绝为
+它们配置 `vision = true`、`vision_models` 或逐模型 `vision` 覆盖并给出明确
+报错；未来的官方多模态模型和自定义 DeepSeek 兼容网关仍可显式开启。
+Reasonix 还可以预填以下可编辑的自定义 provider：
 Kimi CN、Kimi Global、Kimi Coding Plan、MiMo API、MiMo Anthropic、MiMo Token Plan
 CN/SGP/AMS 及其 Anthropic-compatible 变体、MiniMax CN/Global API、MiniMax
 CN/Global Anthropic、GLM CN、Z.AI Global、GLM/Z.AI Coding Plan 的

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1517,7 +1517,7 @@ func TestNewProviderBuildsDeepSeekAnthropicPreset(t *testing.T) {
 	}
 }
 
-func TestNewProviderAllowsExplicitOfficialDeepSeekVisionModel(t *testing.T) {
+func TestNewProviderOfficialDeepSeekDropsExplicitVisionImages(t *testing.T) {
 	var gotReq map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
@@ -1562,13 +1562,16 @@ func TestNewProviderAllowsExplicitOfficialDeepSeekVisionModel(t *testing.T) {
 	if !ok {
 		t.Fatalf("message = %#v, want object", messages[0])
 	}
-	parts, ok := message["content"].([]any)
-	if !ok || len(parts) != 2 {
-		t.Fatalf("content = %#v, want [text, image_url]", message["content"])
+	content, ok := message["content"].(string)
+	if !ok || content != "describe" {
+		t.Fatalf("content = %#v, want plain text", message["content"])
 	}
-	imagePart, ok := parts[1].(map[string]any)
-	if !ok || imagePart["type"] != "image_url" {
-		t.Fatalf("image part = %#v, want image_url", parts[1])
+	raw, err := json.Marshal(gotReq)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if strings.Contains(string(raw), "image_url") || strings.Contains(string(raw), "base64,AAAA") {
+		t.Fatalf("official DeepSeek request leaked explicit image payload: %s", raw)
 	}
 }
 

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1533,8 +1533,8 @@ func TestNewProviderOfficialDeepSeekDropsExplicitVisionImages(t *testing.T) {
 		Kind:         "openai",
 		BaseURL:      "https://api.deepseek.com",
 		ChatURL:      srv.URL,
-		Model:        "deepseek-v5-vision",
-		VisionModels: []string{"deepseek-v5-vision"},
+		Model:        "deepseek-v4-flash",
+		VisionModels: []string{"deepseek-v4-flash"},
 	})
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/mcpdiag"
 	"reasonix/internal/netclient"
 	"reasonix/internal/permission"
+	"reasonix/internal/provider/openai"
 )
 
 var validDesktopExternalOpenerID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
@@ -633,6 +634,8 @@ func validateProvider(e ProviderEntry) error {
 		return fmt.Errorf("provider %q: base_url is required", e.Name)
 	case !providerHasAnyModel(e):
 		return fmt.Errorf("provider %q: model is required", e.Name)
+	case openai.IsDeepSeek(e.BaseURL) && providerDeclaresVision(e):
+		return fmt.Errorf("provider %q: official DeepSeek endpoints are text-only and do not accept image input; remove vision=true, vision_models, or model_overrides vision", e.Name)
 	case strings.TrimSpace(e.APIKeyEnv) != "" && !IsValidCredentialKey(e.APIKeyEnv):
 		return fmt.Errorf("provider %q: api_key_env %q is not a valid environment variable name", e.Name, e.APIKeyEnv)
 	}
@@ -645,6 +648,18 @@ func providerHasAnyModel(e ProviderEntry) bool {
 	}
 	for _, m := range e.Models {
 		if strings.TrimSpace(m) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func providerDeclaresVision(e ProviderEntry) bool {
+	if e.Vision || len(e.VisionModels) > 0 {
+		return true
+	}
+	for _, override := range e.ModelOverrides {
+		if override.Vision != nil && *override.Vision {
 			return true
 		}
 	}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -625,6 +625,7 @@ func (c *Config) providerRemovalFallback(name string) string {
 
 // validateProvider checks the fields a provider can't function without.
 func validateProvider(e ProviderEntry) error {
+	conflicts := officialDeepSeekTextOnlyVisionModels(e)
 	switch {
 	case strings.TrimSpace(e.Name) == "":
 		return fmt.Errorf("provider: name is required")
@@ -634,8 +635,8 @@ func validateProvider(e ProviderEntry) error {
 		return fmt.Errorf("provider %q: base_url is required", e.Name)
 	case !providerHasAnyModel(e):
 		return fmt.Errorf("provider %q: model is required", e.Name)
-	case openai.IsDeepSeek(e.BaseURL) && providerDeclaresVision(e):
-		return fmt.Errorf("provider %q: official DeepSeek endpoints are text-only and do not accept image input; remove vision=true, vision_models, or model_overrides vision", e.Name)
+	case len(conflicts) > 0:
+		return fmt.Errorf("provider %q: official DeepSeek model(s) %s are text-only and do not accept image input; remove vision=true, vision_models, or model_overrides vision for them", e.Name, strings.Join(conflicts, ", "))
 	case strings.TrimSpace(e.APIKeyEnv) != "" && !IsValidCredentialKey(e.APIKeyEnv):
 		return fmt.Errorf("provider %q: api_key_env %q is not a valid environment variable name", e.Name, e.APIKeyEnv)
 	}
@@ -654,11 +655,36 @@ func providerHasAnyModel(e ProviderEntry) bool {
 	return false
 }
 
-func providerDeclaresVision(e ProviderEntry) bool {
-	if e.Vision || len(e.VisionModels) > 0 {
+func officialDeepSeekTextOnlyVisionModels(e ProviderEntry) []string {
+	if !openai.IsDeepSeek(e.BaseURL) {
+		return nil
+	}
+	models := make([]string, 0, len(e.Models)+1)
+	models = append(models, e.Models...)
+	if strings.TrimSpace(e.Model) != "" {
+		models = append(models, e.Model)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" || seen[model] || !openai.IsOfficialDeepSeekTextOnlyModel(model) {
+			continue
+		}
+		if !modelDeclaresVision(e, model) {
+			continue
+		}
+		seen[model] = true
+		out = append(out, model)
+	}
+	return out
+}
+
+func modelDeclaresVision(e ProviderEntry, model string) bool {
+	if e.Vision || e.HasVisionModel(model) {
 		return true
 	}
-	for _, override := range e.ModelOverrides {
+	if override, ok := e.ModelOverrides[model]; ok {
 		if override.Vision != nil && *override.Vision {
 			return true
 		}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -552,6 +552,60 @@ func TestUpsertProvider(t *testing.T) {
 	}
 }
 
+func TestUpsertProviderRejectsVisionOnOfficialDeepSeek(t *testing.T) {
+	visionOn := true
+	for _, tc := range []struct {
+		name string
+		edit func(*ProviderEntry)
+	}{
+		{name: "provider-wide vision", edit: func(e *ProviderEntry) { e.Vision = true }},
+		{name: "vision_models", edit: func(e *ProviderEntry) { e.VisionModels = []string{"deepseek-v4-flash"} }},
+		{name: "model override vision", edit: func(e *ProviderEntry) {
+			e.ModelOverrides = map[string]ProviderModelOverride{"deepseek-v4-flash": {Vision: &visionOn}}
+		}},
+	} {
+		c := Default()
+		entry := ProviderEntry{
+			Name:    "deepseek",
+			Kind:    "openai",
+			BaseURL: "https://api.deepseek.com",
+			Models:  []string{"deepseek-v4-flash"},
+			Default: "deepseek-v4-flash",
+		}
+		tc.edit(&entry)
+		err := c.UpsertProvider(entry)
+		if err == nil {
+			t.Fatalf("%s: expected official DeepSeek vision configuration to be rejected", tc.name)
+		}
+		if !strings.Contains(err.Error(), "text-only") {
+			t.Fatalf("%s: error = %v, want clear text-only message", tc.name, err)
+		}
+	}
+
+	// Plain official DeepSeek entries remain valid.
+	c := Default()
+	if err := c.UpsertProvider(ProviderEntry{
+		Name:    "deepseek",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Models:  []string{"deepseek-v4-flash"},
+		Default: "deepseek-v4-flash",
+	}); err != nil {
+		t.Fatalf("plain official DeepSeek provider: %v", err)
+	}
+
+	// Custom DeepSeek-compatible gateways may still opt in.
+	if err := c.UpsertProvider(ProviderEntry{
+		Name:    "deepseek-gateway",
+		Kind:    "openai",
+		BaseURL: "https://gateway.example/v1",
+		Model:   "deepseek-v4-pro",
+		Vision:  true,
+	}); err != nil {
+		t.Fatalf("custom gateway with vision: %v", err)
+	}
+}
+
 func TestSetProviderEffort(t *testing.T) {
 	c := Default()
 	if err := c.SetProviderEffort("deepseek-flash", "MAX"); err != nil {
@@ -761,7 +815,7 @@ func TestEffectiveVisionDoesNotInferCustomMimoProxy(t *testing.T) {
 	}
 }
 
-func TestEffectiveVisionDefaultsOfficialDeepSeekToTextOnlyButAllowsExplicitModels(t *testing.T) {
+func TestEffectiveVisionOfficialDeepSeekNeverAllowsExplicitModels(t *testing.T) {
 	for _, endpoint := range []struct {
 		kind    string
 		baseURL string
@@ -785,6 +839,9 @@ func TestEffectiveVisionDefaultsOfficialDeepSeekToTextOnlyButAllowsExplicitModel
 		if ExplicitModelVision(official) {
 			t.Fatalf("provider-wide vision must not count as an explicit model capability for %q", endpoint.baseURL)
 		}
+		if CanConfigureVision(official) {
+			t.Fatalf("official DeepSeek endpoint %q must not be vision-configurable", endpoint.baseURL)
+		}
 	}
 
 	future := &ProviderEntry{
@@ -794,8 +851,8 @@ func TestEffectiveVisionDefaultsOfficialDeepSeekToTextOnlyButAllowsExplicitModel
 		Model:        "deepseek-v5-vision",
 		VisionModels: []string{"deepseek-v5-vision"},
 	}
-	if !EffectiveVision(future) || !ExplicitModelVision(future) {
-		t.Fatal("model listed in vision_models must opt in on the official DeepSeek endpoint")
+	if EffectiveVision(future) || ExplicitModelVision(future) || CanConfigureVision(future) {
+		t.Fatal("official DeepSeek endpoint must ignore explicit vision_models")
 	}
 
 	visionOn := true
@@ -812,8 +869,8 @@ func TestEffectiveVisionDefaultsOfficialDeepSeekToTextOnlyButAllowsExplicitModel
 	if !ok {
 		t.Fatal("ResolveModel did not find explicit future DeepSeek model")
 	}
-	if !EffectiveVision(overridden) || !ExplicitModelVision(overridden) {
-		t.Fatal("model_overrides vision=true must opt in on the official DeepSeek endpoint")
+	if EffectiveVision(overridden) || ExplicitModelVision(overridden) {
+		t.Fatal("official DeepSeek endpoint must ignore model_overrides vision=true")
 	}
 
 	custom := &ProviderEntry{
@@ -824,7 +881,7 @@ func TestEffectiveVisionDefaultsOfficialDeepSeekToTextOnlyButAllowsExplicitModel
 		Vision:            true,
 		ReasoningProtocol: ReasoningProtocolDeepSeek,
 	}
-	if !EffectiveVision(custom) {
+	if !CanConfigureVision(custom) || !EffectiveVision(custom) {
 		t.Fatal("explicit vision=true must remain available for custom DeepSeek gateways")
 	}
 }

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -552,7 +552,7 @@ func TestUpsertProvider(t *testing.T) {
 	}
 }
 
-func TestUpsertProviderRejectsVisionOnOfficialDeepSeek(t *testing.T) {
+func TestUpsertProviderRejectsVisionOnOfficialDeepSeekTextOnlyModels(t *testing.T) {
 	visionOn := true
 	for _, tc := range []struct {
 		name string
@@ -592,6 +592,18 @@ func TestUpsertProviderRejectsVisionOnOfficialDeepSeek(t *testing.T) {
 		Default: "deepseek-v4-flash",
 	}); err != nil {
 		t.Fatalf("plain official DeepSeek provider: %v", err)
+	}
+
+	// Official DeepSeek future multimodal models may still opt in explicitly.
+	if err := c.UpsertProvider(ProviderEntry{
+		Name:         "deepseek-future",
+		Kind:         "openai",
+		BaseURL:      "https://api.deepseek.com",
+		Models:       []string{"deepseek-v5-vision"},
+		Default:      "deepseek-v5-vision",
+		VisionModels: []string{"deepseek-v5-vision"},
+	}); err != nil {
+		t.Fatalf("future official DeepSeek vision model: %v", err)
 	}
 
 	// Custom DeepSeek-compatible gateways may still opt in.
@@ -815,7 +827,7 @@ func TestEffectiveVisionDoesNotInferCustomMimoProxy(t *testing.T) {
 	}
 }
 
-func TestEffectiveVisionOfficialDeepSeekNeverAllowsExplicitModels(t *testing.T) {
+func TestEffectiveVisionOfficialDeepSeekBlocksCurrentTextOnlyModels(t *testing.T) {
 	for _, endpoint := range []struct {
 		kind    string
 		baseURL string
@@ -834,14 +846,25 @@ func TestEffectiveVisionOfficialDeepSeekNeverAllowsExplicitModels(t *testing.T) 
 			ReasoningProtocol: ReasoningProtocolDeepSeek,
 		}
 		if EffectiveVision(official) {
-			t.Fatalf("official DeepSeek endpoint %q must remain text-only", endpoint.baseURL)
+			t.Fatalf("official DeepSeek endpoint %q must remain text-only for deepseek-v4-pro", endpoint.baseURL)
 		}
 		if ExplicitModelVision(official) {
 			t.Fatalf("provider-wide vision must not count as an explicit model capability for %q", endpoint.baseURL)
 		}
 		if CanConfigureVision(official) {
-			t.Fatalf("official DeepSeek endpoint %q must not be vision-configurable", endpoint.baseURL)
+			t.Fatalf("official DeepSeek endpoint %q must not be vision-configurable for deepseek-v4-pro", endpoint.baseURL)
 		}
+	}
+
+	flash := &ProviderEntry{
+		Name:         "deepseek",
+		Kind:         "openai",
+		BaseURL:      "https://api.deepseek.com",
+		Model:        "deepseek-v4-flash",
+		VisionModels: []string{"deepseek-v4-flash"},
+	}
+	if EffectiveVision(flash) || ExplicitModelVision(flash) || CanConfigureVision(flash) {
+		t.Fatal("official DeepSeek deepseek-v4-flash must ignore explicit vision_models")
 	}
 
 	future := &ProviderEntry{
@@ -851,8 +874,8 @@ func TestEffectiveVisionOfficialDeepSeekNeverAllowsExplicitModels(t *testing.T) 
 		Model:        "deepseek-v5-vision",
 		VisionModels: []string{"deepseek-v5-vision"},
 	}
-	if EffectiveVision(future) || ExplicitModelVision(future) || CanConfigureVision(future) {
-		t.Fatal("official DeepSeek endpoint must ignore explicit vision_models")
+	if !EffectiveVision(future) || !ExplicitModelVision(future) || !CanConfigureVision(future) {
+		t.Fatal("official DeepSeek future multimodal model must opt in through vision_models")
 	}
 
 	visionOn := true
@@ -869,8 +892,8 @@ func TestEffectiveVisionOfficialDeepSeekNeverAllowsExplicitModels(t *testing.T) 
 	if !ok {
 		t.Fatal("ResolveModel did not find explicit future DeepSeek model")
 	}
-	if EffectiveVision(overridden) || ExplicitModelVision(overridden) {
-		t.Fatal("official DeepSeek endpoint must ignore model_overrides vision=true")
+	if !EffectiveVision(overridden) || !ExplicitModelVision(overridden) {
+		t.Fatal("official DeepSeek future multimodal model must opt in through model_overrides vision=true")
 	}
 
 	custom := &ProviderEntry{

--- a/internal/config/vision.go
+++ b/internal/config/vision.go
@@ -60,13 +60,14 @@ func modelTokenSeparator(r rune) bool {
 }
 
 // CanConfigureVision reports whether user-supplied vision metadata may enable
-// image input for this endpoint. Official DeepSeek APIs currently accept text
-// message content only, so their protocol constraint is authoritative over
-// persisted provider-wide flags, vision_models, and model overrides. Custom
-// DeepSeek-compatible gateways remain configurable because they may implement
-// their own multimodal translation layer.
+// image input for this model. Official DeepSeek's current text-only models
+// accept text message content only, so their protocol constraint is
+// authoritative over persisted provider-wide flags, vision_models, and model
+// overrides. Other official models and custom DeepSeek-compatible gateways
+// remain configurable so a future multimodal model can opt in explicitly.
 func CanConfigureVision(e *ProviderEntry) bool {
-	return e != nil && !openai.IsDeepSeek(e.BaseURL)
+	return e != nil &&
+		!(openai.IsDeepSeek(e.BaseURL) && openai.IsOfficialDeepSeekTextOnlyModel(e.Model))
 }
 
 // EffectiveVision resolves whether the selected model accepts image input.

--- a/internal/config/vision.go
+++ b/internal/config/vision.go
@@ -59,24 +59,26 @@ func modelTokenSeparator(r rune) bool {
 	return r == '-' || r == '_' || r == '.' || r == '/' || r == ':'
 }
 
+// CanConfigureVision reports whether user-supplied vision metadata may enable
+// image input for this endpoint. Official DeepSeek APIs currently accept text
+// message content only, so their protocol constraint is authoritative over
+// persisted provider-wide flags, vision_models, and model overrides. Custom
+// DeepSeek-compatible gateways remain configurable because they may implement
+// their own multimodal translation layer.
+func CanConfigureVision(e *ProviderEntry) bool {
+	return e != nil && !openai.IsDeepSeek(e.BaseURL)
+}
+
 // EffectiveVision resolves whether the selected model accepts image input.
 // Explicit provider vision still wins for custom vision-capable gateways; the
 // MiMo endpoint heuristic is deliberately limited to known MiMo endpoints so
 // arbitrary OpenAI-compatible proxies do not get image payloads unexpectedly.
 func EffectiveVision(e *ProviderEntry) bool {
-	if e == nil {
+	if !CanConfigureVision(e) {
 		return false
 	}
 	if enabled, explicit := explicitModelVision(e); explicit {
 		return enabled
-	}
-	// DeepSeek's official APIs currently accept text message content only. Treat
-	// current official models as text-only when only the legacy provider-wide
-	// vision flag is set, so stale configs cannot make requests 400. A concrete
-	// model can still opt in through vision_models or a model override when
-	// DeepSeek documents a future multimodal request shape.
-	if openai.IsDeepSeek(e.BaseURL) {
-		return false
 	}
 	if e.Vision {
 		return true
@@ -89,6 +91,9 @@ func EffectiveVision(e *ProviderEntry) bool {
 // provenance to distinguish a deliberate future-model opt-in from a stale
 // provider-wide vision=true setting.
 func ExplicitModelVision(e *ProviderEntry) bool {
+	if !CanConfigureVision(e) {
+		return false
+	}
 	enabled, explicit := explicitModelVision(e)
 	return explicit && enabled
 }

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -101,10 +101,10 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
-	// Official DeepSeek APIs accept text message content only; keep the
-	// provider-boundary guard even though config capability resolution
-	// normally prevents image attachments from reaching this layer.
-	vision = vision && !officialDeepSeek
+	// Official DeepSeek's current text-only models accept text message content
+	// only; keep the provider-boundary guard even though config capability
+	// resolution normally prevents image attachments from reaching this layer.
+	vision = vision && !(officialDeepSeek && openai.IsOfficialDeepSeekTextOnlyModel(cfg.Model))
 	webSearch, _ := cfg.Extra["web_search"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -101,6 +101,10 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
+	// Official DeepSeek APIs accept text message content only; keep the
+	// provider-boundary guard even though config capability resolution
+	// normally prevents image attachments from reaching this layer.
+	vision = vision && !officialDeepSeek
 	webSearch, _ := cfg.Extra["web_search"].(bool)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	authHeader, _ := cfg.Extra["auth_header"].(bool)

--- a/internal/provider/anthropic/image_test.go
+++ b/internal/provider/anthropic/image_test.go
@@ -63,6 +63,31 @@ func TestOfficialDeepSeekAnthropicStaysTextOnlyWithVision(t *testing.T) {
 	}
 }
 
+func TestOfficialDeepSeekAnthropicFutureVisionEmbedsImageBlock(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "deepseek",
+		BaseURL: "https://api.deepseek.com/anthropic",
+		Model:   "deepseek-v5-vision",
+		Extra:   map[string]any{"vision": true},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := p.(*client)
+	if !c.vision {
+		t.Fatal("future official DeepSeek multimodal model must keep vision enabled")
+	}
+	req := c.buildRequest(context.Background(), provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
+		},
+	})
+	blocks := req.Messages[0].Content
+	if len(blocks) != 2 || blocks[0].Type != "text" || blocks[1].Type != "image" {
+		t.Fatalf("future DeepSeek blocks = %+v, want [text, image]", blocks)
+	}
+}
+
 // toolMessages is a paired history whose tool result carries an image: the
 // shape parseToolResult produces for an MCP screenshot tool.
 func toolMessages(images []string) []provider.Message {

--- a/internal/provider/anthropic/image_test.go
+++ b/internal/provider/anthropic/image_test.go
@@ -38,6 +38,31 @@ func TestBuildRequestSkipsImageBlockWithoutVision(t *testing.T) {
 	}
 }
 
+func TestOfficialDeepSeekAnthropicStaysTextOnlyWithVision(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "deepseek",
+		BaseURL: "https://api.deepseek.com/anthropic",
+		Model:   "deepseek-v4-flash",
+		Extra:   map[string]any{"vision": true},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := p.(*client)
+	if c.vision {
+		t.Fatal("official DeepSeek Anthropic endpoint must ignore vision=true")
+	}
+	req := c.buildRequest(context.Background(), provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
+		},
+	})
+	blocks := req.Messages[0].Content
+	if len(blocks) != 1 || blocks[0].Type != "text" {
+		t.Fatalf("official DeepSeek blocks = %+v, want [text] only", blocks)
+	}
+}
+
 // toolMessages is a paired history whose tool result carries an image: the
 // shape parseToolResult produces for an MCP screenshot tool.
 func toolMessages(images []string) []provider.Message {

--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -37,6 +37,20 @@ func IsDeepSeek(baseURL string) bool {
 	return matchesVendorHost(baseURL, "deepseek.com", "api.deepseek.com")
 }
 
+// IsOfficialDeepSeekTextOnlyModel reports whether the model ID is one of the
+// official DeepSeek models whose API currently accepts text message content
+// only. The endpoint-level guard is intentionally model-scoped so a future
+// official multimodal model can opt in explicitly instead of waiting for a
+// code change.
+func IsOfficialDeepSeekTextOnlyModel(model string) bool {
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "deepseek-v4-flash", "deepseek-v4-pro":
+		return true
+	default:
+		return false
+	}
+}
+
 // IsOpenAI reports whether baseURL points at OpenAI's official API host. Keep
 // this exact-host so a compatible gateway under another openai.com subdomain
 // cannot accidentally receive the official max_completion_tokens wire shape.

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -113,6 +113,34 @@ func TestOfficialDeepSeekExplicitVisionInputStaysTextOnly(t *testing.T) {
 	}
 }
 
+func TestOfficialDeepSeekFutureVisionInputUsesImageParts(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "deepseek",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v5-vision",
+		Extra: map[string]any{
+			"vision":                true,
+			"vision_model_explicit": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := p.(*client)
+	if !c.vision {
+		t.Fatal("explicit model-scoped vision must remain enabled for future official DeepSeek multimodal models")
+	}
+
+	req := c.buildRequest(provider.Request{Messages: []provider.Message{{
+		Role: provider.RoleUser, Content: "describe",
+		Images: []string{"data:image/png;base64,AAAA"},
+	}}})
+	parts, ok := req.Messages[0].Content.([]chatContentPart)
+	if !ok || len(parts) != 2 || parts[1].ImageURL == nil {
+		t.Fatalf("future DeepSeek content = %#v, want [text, image_url]", req.Messages[0].Content)
+	}
+}
+
 func TestOfficialDeepSeekDoesNotInjectToolResultImages(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek",

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -79,11 +79,11 @@ func TestOfficialDeepSeekProviderWideVisionInputMatchesTextOnlyRequest(t *testin
 	}
 }
 
-func TestOfficialDeepSeekExplicitFutureVisionInputUsesImageParts(t *testing.T) {
+func TestOfficialDeepSeekExplicitVisionInputStaysTextOnly(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek",
 		BaseURL: "https://api.deepseek.com",
-		Model:   "deepseek-v5-vision",
+		Model:   "deepseek-v4-flash",
 		Extra: map[string]any{
 			"vision":                true,
 			"vision_model_explicit": true,
@@ -93,17 +93,23 @@ func TestOfficialDeepSeekExplicitFutureVisionInputUsesImageParts(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	c := p.(*client)
-	if !c.vision {
-		t.Fatal("explicit model-scoped vision must remain enabled on the official DeepSeek endpoint")
+	if c.vision {
+		t.Fatal("official DeepSeek endpoint must ignore explicit model-scoped vision")
 	}
 
 	req := c.buildRequest(provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: "describe",
 		Images: []string{"data:image/png;base64,AAAA"},
 	}}})
-	parts, ok := req.Messages[0].Content.([]chatContentPart)
-	if !ok || len(parts) != 2 || parts[1].ImageURL == nil {
-		t.Fatalf("explicit future DeepSeek content = %#v, want [text, image_url]", req.Messages[0].Content)
+	if content, ok := req.Messages[0].Content.(string); !ok || content != "describe" {
+		t.Fatalf("official DeepSeek content = %#v, want plain string", req.Messages[0].Content)
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if strings.Contains(string(body), "image_url") || strings.Contains(string(body), "base64,AAAA") {
+		t.Fatalf("official DeepSeek request leaked explicit image payload: %s", body)
 	}
 }
 

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -91,10 +91,11 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	extraBody, _ := cfg.Extra["extra_body"].(map[string]any)
 	vision, _ := cfg.Extra["vision"].(bool)
 	officialDeepSeek := IsDeepSeek(cfg.BaseURL)
-	// DeepSeek's official chat API accepts string message content only. Keep
-	// this provider-boundary guard even though config capability resolution
-	// normally prevents image attachments from reaching this layer.
-	vision = vision && !officialDeepSeek
+	// DeepSeek's official chat API accepts string message content only for its
+	// current text-only models. Keep this provider-boundary guard even though
+	// config capability resolution normally prevents image attachments from
+	// reaching this layer.
+	vision = vision && !(officialDeepSeek && IsOfficialDeepSeekTextOnlyModel(cfg.Model))
 	visionDetail, _ := cfg.Extra["vision_detail"].(string)
 	visionDetail = strings.ToLower(strings.TrimSpace(visionDetail))
 	if visionDetail != "low" && visionDetail != "high" {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -90,14 +90,11 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	extraBody, _ := cfg.Extra["extra_body"].(map[string]any)
 	vision, _ := cfg.Extra["vision"].(bool)
-	explicitModelVision, _ := cfg.Extra["vision_model_explicit"].(bool)
 	officialDeepSeek := IsDeepSeek(cfg.BaseURL)
 	// DeepSeek's official chat API accepts string message content only. Keep
 	// this provider-boundary guard even though config capability resolution
-	// normally prevents image attachments from reaching this layer. A positive
-	// model-scoped capability can opt in without letting stale provider-wide
-	// vision=true settings affect current text-only models.
-	vision = vision && (!officialDeepSeek || explicitModelVision)
+	// normally prevents image attachments from reaching this layer.
+	vision = vision && !officialDeepSeek
 	visionDetail, _ := cfg.Extra["vision_detail"].(string)
 	visionDetail = strings.ToLower(strings.TrimSpace(visionDetail))
 	if visionDetail != "low" && visionDetail != "high" {

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -140,6 +140,12 @@ func New(cfg Config) provider.Provider {
 		sessionCache = *cfg.SessionCache
 	}
 	vision, _ := cfg.Extra["vision"].(bool)
+	// Official DeepSeek APIs accept text message content only; keep the
+	// provider-boundary guard even though config capability resolution
+	// normally prevents image attachments from reaching this layer.
+	if vendor == "deepseek" {
+		vision = false
+	}
 	httpClient := &http.Client{Timeout: 300 * time.Second}
 	if built, err := netclient.NewHTTPClient(cfg.Proxy, netclient.TransportOptions{
 		DialTimeout: 30 * time.Second, KeepAlive: 30 * time.Second,

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -21,6 +21,7 @@ import (
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
+	"reasonix/internal/provider/openai"
 )
 
 const (
@@ -140,10 +141,10 @@ func New(cfg Config) provider.Provider {
 		sessionCache = *cfg.SessionCache
 	}
 	vision, _ := cfg.Extra["vision"].(bool)
-	// Official DeepSeek APIs accept text message content only; keep the
-	// provider-boundary guard even though config capability resolution
-	// normally prevents image attachments from reaching this layer.
-	if vendor == "deepseek" {
+	// Official DeepSeek's current text-only models accept text message content
+	// only; keep the provider-boundary guard even though config capability
+	// resolution normally prevents image attachments from reaching this layer.
+	if vendor == "deepseek" && openai.IsOfficialDeepSeekTextOnlyModel(cfg.Model) {
 		vision = false
 	}
 	httpClient := &http.Client{Timeout: 300 * time.Second}

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -920,7 +920,7 @@ func TestMessagesToInputTextOnlyStaysStringShape(t *testing.T) {
 }
 
 func TestMessagesToInputEmbedsImagesAsInputImageParts(t *testing.T) {
-	c := New(Config{Name: "test", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Extra: map[string]any{"vision": true}}).(*client)
+	c := New(Config{Name: "test", BaseURL: "https://gateway.example/v1", Model: "deepseek-v4-flash", Extra: map[string]any{"vision": true}}).(*client)
 	body, _, _ := c.buildRequestBody(provider.Request{Messages: []provider.Message{
 		{Role: provider.RoleUser, Content: "what is this", Images: []string{"data:image/png;base64,AAAA", "data:image/jpeg;base64,BBBB"}},
 	}})
@@ -951,6 +951,20 @@ func TestMessagesToInputEmbedsImagesAsInputImageParts(t *testing.T) {
 	items2 := body2["input"].([]map[string]any)
 	if got, ok := items2[0]["content"].(string); !ok || got != "what is this" {
 		t.Fatalf("vision-off user content = %#v, want string", items2[0]["content"])
+	}
+}
+
+func TestOfficialDeepSeekResponsesStaysTextOnlyWithVision(t *testing.T) {
+	c := New(Config{Name: "test", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Extra: map[string]any{"vision": true}}).(*client)
+	if c.vision {
+		t.Fatal("official DeepSeek Responses endpoint must ignore vision=true")
+	}
+	body, _, _ := c.buildRequestBody(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "what is this", Images: []string{"data:image/png;base64,AAAA"}},
+	}})
+	items := body["input"].([]map[string]any)
+	if got, ok := items[0]["content"].(string); !ok || got != "what is this" {
+		t.Fatalf("official DeepSeek user content = %#v, want string", items[0]["content"])
 	}
 }
 

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -968,6 +968,21 @@ func TestOfficialDeepSeekResponsesStaysTextOnlyWithVision(t *testing.T) {
 	}
 }
 
+func TestOfficialDeepSeekResponsesFutureVisionUsesInputImageParts(t *testing.T) {
+	c := New(Config{Name: "test", BaseURL: "https://api.deepseek.com", Model: "deepseek-v5-vision", Extra: map[string]any{"vision": true}}).(*client)
+	if !c.vision {
+		t.Fatal("future official DeepSeek multimodal model must keep vision enabled")
+	}
+	body, _, _ := c.buildRequestBody(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "what is this", Images: []string{"data:image/png;base64,AAAA"}},
+	}})
+	items := body["input"].([]map[string]any)
+	parts, ok := items[0]["content"].([]map[string]string)
+	if !ok || len(parts) != 2 || parts[1]["type"] != "input_image" {
+		t.Fatalf("future DeepSeek user content = %#v, want [input_text, input_image]", items[0]["content"])
+	}
+}
+
 func TestResponseFormatJSONObjectOnWire(t *testing.T) {
 	// text.format.type=json_object must be serialized when requested, and
 	// the request body must stay byte-identical without it (cache stability).


### PR DESCRIPTION
﻿## Summary

Official DeepSeek's current text-only models (`deepseek-v4-flash`, `deepseek-v4-pro`) accept text message content only. An earlier fix (#6908) gated provider-wide `vision = true`, but the explicit `vision_models` / per-model `vision` override escape hatch remained open. As a result, these models could still receive `image_url` / `input_image` payloads, fail with HTTP 400.

The trigger is a user-side configuration (marking an official DeepSeek model as vision-capable), but Reasonix currently allows and persists that configuration without validation, and one failed image message permanently breaks the rest of the conversation. This PR fixes both surfaces: invalid vision configuration is rejected with a clear error at save time, and the model layer never serializes image payloads to official DeepSeek endpoints, which also resumes sessions previously corrupted by an `image_url` 400 error. 

Close https://github.com/esengine/DeepSeek-Reasonix/issues/7396 
Close https://github.com/esengine/DeepSeek-Reasonix/issues/7859

#7396 was reported on v1.19.5, and #7859 on August 7. I checked the latest main-v2 source (which v1.21.3 is built from) and confirmed the escape hatch is still present, so the newest release has not fully fixed this.

## Fix

This PR makes the text-only constraint authoritative for those two model IDs at both the config and provider layers:

- Saving `vision = true`, `vision_models`, or a per-model `vision` override for `deepseek-v4-flash` / `deepseek-v4-pro` on official `*.deepseek.com` endpoints is rejected with a clear error.
- The OpenAI Chat Completions, Anthropic Messages, and Responses providers never serialize image payloads for those models, even if stale vision flags are passed in.
- Future official multimodal models and custom DeepSeek-compatible gateways can still opt in explicitly, so no code change is needed when DeepSeek opens up multimodal support.

## Changes

- `internal/provider/openai/host.go`: add `IsOfficialDeepSeekTextOnlyModel` (currently `deepseek-v4-flash`, `deepseek-v4-pro`).
- `internal/config/vision.go`: `CanConfigureVision` / `EffectiveVision` / `ExplicitModelVision` only block those text-only IDs on official DeepSeek endpoints.
- `internal/config/edit.go`: provider save validation rejects vision configuration for those model IDs with an actionable message.
- `internal/provider/openai|anthropic|responses`: provider-boundary guards drop image parts for the text-only IDs even when stale vision flags are passed in.
- Tests updated/added across config, boot, openai, anthropic, and responses; English/Chinese guide updated.

## Verification

- `go test ./internal/config ./internal/provider/openai ./internal/provider/responses ./internal/provider/anthropic` - passed
- `go vet` on the same packages - clean
- `gofmt` - clean

Cache-impact: low - text-only official DeepSeek requests keep the exact same provider-visible shape; stale vision flags for the two text-only IDs can no longer add image parts.
Cache-guard: `go test ./internal/config ./internal/provider/openai ./internal/provider/responses ./internal/provider/anthropic` covers serialization and capability resolution.
System-prompt-review: reviewed by kanchengw - no system prompt, tool schema, memory prefix, or message ordering change; internal/boot/boot_test.go is a test-only capability assertion update.
Documentation-impact: updated - GUIDE.md and GUIDE.zh-CN.md now state that the current official DeepSeek text-only models reject vision configuration, while future multimodal models and custom gateways can opt in.
