### PR TITLE
test(bench): add CompactionBench for the cost and fidelity of repeated folds

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Reasonix Benchmarks
 
-Two primary harnesses live under `benchmarks/`; `cmd/e2ebench` also exposes a
+Three harnesses live under `benchmarks/`; `cmd/e2ebench` also exposes a
 SWE-bench Verified mode:
 
 - `e2e/` — the committed end-to-end task suite, driven by
@@ -10,6 +10,9 @@ SWE-bench Verified mode:
 - `context-maintenance-e2e/` — a standalone seed → resume → comprehension
   harness that A/B-compares cold-restart cache behavior with and without
   context pruning.
+- `compaction/` — CompactionBench: grows a session one generation at a time and
+  folds it after each, measuring what repeated compaction costs and what it
+  loses. See [CompactionBench](#compactionbench) below.
 
 ## Directory layout
 
@@ -278,3 +281,37 @@ recall fired. Scenario classes: exact, paraphrase, cjk, symbol, distractor
 stale (repo truth must beat an expired claim), contradiction, generic (recall
 must stay silent), history (exact repo wording beats a memory paraphrase),
 update (revised value wins), pinned (prefix channel end to end).
+
+## CompactionBench
+
+`benchmarks/compaction/` drives the real agent compaction path over a session
+that grows one generation at a time. Each generation appends a round of work
+and then folds, so generation N folds everything generations 1..N produced —
+which is the growth that matters, because a fold re-derives its digest from the
+whole canonical transcript rather than from the previous digest.
+
+```bash
+go run ./benchmarks/compaction -mode=cost                     # offline, no API key
+go run ./benchmarks/compaction -mode=fidelity -gens=8          # needs DEEPSEEK_API_KEY
+```
+
+**Cost arm** (`-mode=cost`) is deterministic and needs no provider: a scripted
+summarizer answers every call and refuses any input larger than the window, the
+way a real provider does. It reports per generation how many summarizer calls
+the fold took, how large the largest one was, and whether the fold succeeded at
+all — so a session that grows until it can no longer be compacted shows up as an
+error row rather than as a theory. `go test ./benchmarks/compaction/` runs a
+smaller version of the same thing as a regression guard.
+
+**Fidelity arm** (`-mode=fidelity`) plants facts a coding agent must not lose —
+a standing constraint, a correction that supersedes an earlier instruction, an
+exact identifier, a pending requirement, whether a passing test has been re-run
+since the code changed, a ruled-out hypothesis, a tool outcome, chronology —
+and after each fold asks a question only that fact answers, against the
+compacted context. Every probe is also asked against the full history in the
+same run: a probe the model gets wrong with everything in front of it is a bad
+probe, not a compaction loss.
+
+Probe answers are scored on whole words, and a wanted answer does not count if a
+rejected one appears anywhere in the same reply — "yes, but it has not been
+re-run since" is the shape a drifting digest produces, and it is not a pass.

--- a/benchmarks/compaction/main.go
+++ b/benchmarks/compaction/main.go
@@ -1,0 +1,468 @@
+// CompactionBench measures what repeated compaction costs and what it loses.
+// Both arms drive the real agent compaction path over a session that grows one
+// generation at a time:
+//
+//	-mode=cost      offline: what each fold costs and whether any single
+//	                summarizer call can still overflow the window
+//	-mode=fidelity  real provider: which planted facts survive N folds,
+//	                scored against a full-history control
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	_ "reasonix/internal/provider/openai"
+	"reasonix/internal/tool"
+)
+
+const (
+	realModel   = "deepseek-v4-flash"
+	realBaseURL = "https://api.deepseek.com"
+	// probeAnswerTokens must cover a thinking model's reasoning plus the short
+	// answer; too small and every probe scores as lost.
+	probeAnswerTokens = 2048
+)
+
+func main() {
+	mode := flag.String("mode", "cost", "cost | fidelity")
+	gens := flag.Int("gens", 8, "generations of work+compaction to run")
+	report := flag.String("report", "1,2,4,8", "generations to report on")
+	window := flag.Int("window", 128_000, "context window in tokens")
+	control := flag.Bool("control", true, "fidelity: also score probes against full history")
+	out := flag.String("out", "", "write the JSON report here")
+	flag.Parse()
+
+	var (
+		res []genResult
+		err error
+	)
+	switch *mode {
+	case "cost":
+		res, err = runCost(*gens, *window)
+	case "fidelity":
+		res, err = runFidelity(*gens, *window, *control)
+	default:
+		err = fmt.Errorf("unknown mode %q", *mode)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	printReport(*mode, res, reportAt(*report))
+	if *out != "" {
+		b, _ := json.MarshalIndent(map[string]any{"mode": *mode, "window": *window, "generations": res}, "", "  ")
+		if werr := os.WriteFile(*out, append(b, '\n'), 0o644); werr != nil {
+			fmt.Fprintln(os.Stderr, werr)
+			os.Exit(1)
+		}
+	}
+}
+
+// genResult is one generation: the fold that ran and what it cost or lost.
+type genResult struct {
+	Gen              int            `json:"gen"`
+	CanonicalTokens  int            `json:"canonical_tokens"`
+	ProjectionTokens int            `json:"projection_tokens"`
+	SummarizerCalls  int            `json:"summarizer_calls"`
+	SummarizerInput  int            `json:"summarizer_input_tokens"`
+	LargestCall      int            `json:"largest_call_tokens"`
+	Mode             string         `json:"mode,omitempty"`
+	Seconds          float64        `json:"seconds"`
+	Error            string         `json:"error,omitempty"`
+	Survived         map[string]int `json:"survived,omitempty"`   // probe class -> 1 kept, 0 lost
+	ControlOK        map[string]int `json:"control_ok,omitempty"` // same probes against full history
+	// What the model actually said, so a score can be audited rather than trusted.
+	Answers        map[string]string `json:"answers,omitempty"`
+	ControlAnswers map[string]string `json:"control_answers,omitempty"`
+}
+
+type harness struct {
+	sess   *agent.Session
+	agentA *agent.Agent
+	path   string
+	calls  *callRecorder
+}
+
+func newHarness(t *testingDir, p provider.Provider, window int, rec *callRecorder) *harness {
+	sess := newSession()
+	path := filepath.Join(t.dir, "session.jsonl")
+	a := agent.New(p, tool.NewRegistry(), sess, agent.Options{
+		ContextWindow: window,
+		ArchiveDir:    filepath.Join(t.dir, "archive"),
+		SessionPath:   path,
+		RecentKeep:    4,
+	}, rec.sink())
+	return &harness{sess: sess, agentA: a, path: path, calls: rec}
+}
+
+// runGeneration grows the session and folds it, returning what that fold cost.
+func (h *harness) runGeneration(ctx context.Context, gen int, probes []probe) genResult {
+	growSession(h.sess, gen, probes)
+	r := genResult{Gen: gen, CanonicalTokens: estimateTokens(renderAll(h.sess.Snapshot()))}
+
+	h.calls.reset()
+	start := time.Now()
+	err := h.agentA.CompactNow(ctx, "")
+	r.Seconds = time.Since(start).Seconds()
+	if err != nil {
+		r.Error = err.Error()
+	}
+	r.SummarizerCalls = len(h.calls.calls)
+	for _, c := range h.calls.calls {
+		r.SummarizerInput += c.tokens
+		r.LargestCall = max(r.LargestCall, c.tokens)
+	}
+	if st, ok, sterr := agent.LoadCompactionState(h.path); sterr == nil && ok {
+		r.ProjectionTokens = st.Projection.ProjectionTokens
+		r.Mode = st.LastMode
+	}
+	return r
+}
+
+func runCost(gens, window int) ([]genResult, error) {
+	dir, cleanup, err := tempDir()
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	rec := &callRecorder{}
+	p := &scriptedProvider{rec: rec, reply: syntheticDigest, window: window}
+	h := newHarness(dir, p, window, rec)
+
+	var out []genResult
+	for gen := range gens {
+		out = append(out, h.runGeneration(context.Background(), gen, probeSuite()))
+	}
+	return out, nil
+}
+
+func runFidelity(gens, window int, control bool) ([]genResult, error) {
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("fidelity mode needs DEEPSEEK_API_KEY")
+	}
+	p, err := provider.New("openai", provider.Config{Name: "compactionbench", BaseURL: realBaseURL, Model: realModel, APIKey: key})
+	if err != nil {
+		return nil, err
+	}
+	dir, cleanup, cerr := tempDir()
+	if cerr != nil {
+		return nil, cerr
+	}
+	defer cleanup()
+
+	rec := &callRecorder{}
+	h := newHarness(dir, &recordingProvider{inner: p, rec: rec}, window, rec)
+	probes := probeSuite()
+
+	ctx := context.Background()
+	var out []genResult
+	for gen := range gens {
+		r := h.runGeneration(ctx, gen, probes)
+		r.Survived, r.ControlOK = map[string]int{}, map[string]int{}
+		r.Answers, r.ControlAnswers = map[string]string{}, map[string]string{}
+		visible, verr := visibleContext(h.path, h.sess)
+		if verr != nil {
+			return nil, verr
+		}
+		for _, probe := range probes {
+			if probe.plantAt > gen {
+				continue
+			}
+			answer, aerr := ask(ctx, p, visible, probe.question)
+			if aerr != nil {
+				return nil, fmt.Errorf("probe %s: %w", probe, aerr)
+			}
+			r.Survived[probe.class], r.Answers[probe.class] = boolToInt(probe.score(answer)), answer
+			if control {
+				full, ferr := ask(ctx, p, h.sess.Snapshot(), probe.question)
+				if ferr != nil {
+					return nil, fmt.Errorf("control %s: %w", probe, ferr)
+				}
+				r.ControlOK[probe.class], r.ControlAnswers[probe.class] = boolToInt(probe.score(full)), full
+			}
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// ask puts one probe question to the model on top of the given context. The
+// budget has to clear the model's reasoning as well as its answer: a thinking
+// model spends its first tokens reasoning, and a budget sized for the one-word
+// answer alone comes back empty and scores as a fact compaction never lost.
+func ask(ctx context.Context, p provider.Provider, msgs []provider.Message, question string) (string, error) {
+	answer, reasoning, err := askOnce(ctx, p, msgs, question, probeAnswerTokens)
+	if err != nil {
+		return "", err
+	}
+	if answer == "" || strings.Contains(answer, toolCallMarker) {
+		// One retry with room to think: a reply cut off mid-reasoning says
+		// nothing about whether the fold kept the fact.
+		answer, reasoning, err = askOnce(ctx, p, msgs, question, probeAnswerTokens*4)
+		if err != nil {
+			return "", err
+		}
+	}
+	switch {
+	case strings.Contains(answer, toolCallMarker):
+		return toolCallInvalid, nil
+	case answer == "":
+		return fmt.Sprintf("%s: %d reasoning chars>", noAnswerMarker, reasoning), nil
+	}
+	return answer, nil
+}
+
+func askOnce(ctx context.Context, p provider.Provider, msgs []provider.Message, question string, budget int) (string, int, error) {
+	req := provider.Request{
+		Messages: append(append([]provider.Message(nil), provider.ModelMessages(msgs)...),
+			provider.Message{Role: provider.RoleUser, Content: question + "\n\n" + probeAnswerContract}),
+		MaxTokens: budget,
+	}
+	ch, err := p.Stream(ctx, req)
+	if err != nil {
+		return "", 0, err
+	}
+	var answer, reasoning strings.Builder
+	for c := range ch {
+		switch c.Type {
+		case provider.ChunkText:
+			answer.WriteString(c.Text)
+		case provider.ChunkReasoning:
+			reasoning.WriteString(c.Text)
+		case provider.ChunkError:
+			return "", reasoning.Len(), c.Err
+		}
+	}
+	return strings.TrimSpace(answer.String()), reasoning.Len(), nil
+}
+
+func printReport(mode string, res []genResult, at map[int]bool) {
+	fmt.Printf("\n## CompactionBench (%s)\n\n", mode)
+	fmt.Println("| gen | canonical tok | fold calls | fold input tok | largest call | projection tok | s | result |")
+	fmt.Println("| ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
+	for _, r := range res {
+		status := r.Mode
+		if r.Error != "" {
+			status = "ERROR: " + firstLine(r.Error)
+		}
+		fmt.Printf("| %d | %d | %d | %d | %d | %d | %.1f | %s |\n",
+			r.Gen+1, r.CanonicalTokens, r.SummarizerCalls, r.SummarizerInput, r.LargestCall, r.ProjectionTokens, r.Seconds, status)
+	}
+	if mode != "fidelity" {
+		return
+	}
+	classes := probeSuite()
+	fmt.Printf("\n### Probe survival (compacted / full-history control)\n\n| probe | %s |\n", joinGens(res, at))
+	fmt.Printf("| --- | %s |\n", strings.Repeat(" ---: |", countGens(res, at)))
+	for _, p := range classes {
+		row := []string{}
+		for _, r := range res {
+			if !at[r.Gen+1] {
+				continue
+			}
+			if _, asked := r.Survived[p.class]; !asked {
+				row = append(row, "–")
+				continue
+			}
+			row = append(row, fmt.Sprintf("%s/%s", mark(r.Survived[p.class], r.Answers[p.class]), mark(r.ControlOK[p.class], r.ControlAnswers[p.class])))
+		}
+		fmt.Printf("| %s | %s |\n", p.class, strings.Join(row, " | "))
+	}
+	printMeasurementQuality(res)
+}
+
+// printMeasurementQuality reports how many probes never got an answer at all.
+// A survival rate quoted without it would read harness noise as fact loss.
+func printMeasurementQuality(res []genResult) {
+	asked, bad, badControl := 0, 0, 0
+	for _, r := range res {
+		for _, a := range r.Answers {
+			asked++
+			if invalidAnswer(a) {
+				bad++
+			}
+		}
+		for _, a := range r.ControlAnswers {
+			if invalidAnswer(a) {
+				badControl++
+			}
+		}
+	}
+	fmt.Printf("\nUnanswered probes (excluded from the rates above): %d of %d compacted, %d of %d control.\n", bad, asked, badControl, asked)
+	if bad > 0 || badControl > 0 {
+		fmt.Println("A run with unanswered probes measures the harness as much as the compactor; see answers in the JSON report.")
+	}
+}
+
+func mark(v int, answer string) string {
+	switch {
+	case invalidAnswer(answer):
+		return "n/a"
+	case v == 1:
+		return "ok"
+	}
+	return "LOST"
+}
+
+func joinGens(res []genResult, at map[int]bool) string {
+	var s []string
+	for _, r := range res {
+		if at[r.Gen+1] {
+			s = append(s, fmt.Sprintf("gen %d", r.Gen+1))
+		}
+	}
+	return strings.Join(s, " | ")
+}
+
+func countGens(res []genResult, at map[int]bool) int {
+	n := 0
+	for _, r := range res {
+		if at[r.Gen+1] {
+			n++
+		}
+	}
+	return n
+}
+
+func reportAt(spec string) map[int]bool {
+	at := map[int]bool{}
+	for part := range strings.SplitSeq(spec, ",") {
+		var n int
+		if _, err := fmt.Sscanf(strings.TrimSpace(part), "%d", &n); err == nil {
+			at[n] = true
+		}
+	}
+	return at
+}
+
+// estimateTokens mirrors the kernel's own estimator so bench numbers and
+// compaction telemetry are read in the same unit.
+func estimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	if runes := utf8.RuneCountInString(s); runes > (len(s)+3)/4 {
+		return runes
+	}
+	return (len(s) + 3) / 4
+}
+
+func renderAll(msgs []provider.Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		b.WriteString(m.Content)
+		for _, tc := range m.ToolCalls {
+			b.WriteString(tc.Name)
+			b.WriteString(tc.Arguments)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func firstLine(s string) string {
+	first, _, _ := strings.Cut(s, "\n")
+	return first
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+type testingDir struct{ dir string }
+
+func tempDir() (*testingDir, func(), error) {
+	dir, err := os.MkdirTemp("", "compactionbench-")
+	if err != nil {
+		return nil, nil, err
+	}
+	return &testingDir{dir: dir}, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// callRecorder captures every summarizer request the fold issued, which is the
+// measurement the cost arm exists for: how many calls, and how large the
+// largest one got.
+type callRecorder struct{ calls []recordedCall }
+
+type recordedCall struct {
+	tokens int
+	system string
+}
+
+func (r *callRecorder) reset() { r.calls = nil }
+
+func (r *callRecorder) note(req provider.Request) {
+	c := recordedCall{}
+	for _, m := range req.Messages {
+		c.tokens += estimateTokens(m.Content)
+		if m.Role == provider.RoleSystem {
+			c.system = m.Content
+		}
+	}
+	r.calls = append(r.calls, c)
+}
+
+func (r *callRecorder) sink() event.Sink { return event.Discard }
+
+const syntheticDigest = `## Standing facts & constraints
+- never modify config/schema.sql
+## Goal
+Fix the config round-trip formatting bug.
+## Pending & next step
+Re-run TestRoundTrip after the latest edit.`
+
+// scriptedProvider answers every summarizer call with a fixed digest so the
+// cost arm is deterministic and needs no API key. It refuses an input larger
+// than the window the way a real provider does, so the bench observes the
+// wedge — a fold that can no longer be summarized at all — instead of
+// inferring it from the input size.
+type scriptedProvider struct {
+	rec    *callRecorder
+	reply  string
+	window int
+}
+
+func (p *scriptedProvider) Name() string { return "scripted" }
+
+func (p *scriptedProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.rec.note(req)
+	ch := make(chan provider.Chunk, 2)
+	if in := p.rec.calls[len(p.rec.calls)-1].tokens; p.window > 0 && in > p.window {
+		ch <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("this model's maximum context length is %d tokens, however you requested %d tokens", p.window, in)}
+		close(ch)
+		return ch, nil
+	}
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: p.reply}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+// recordingProvider measures the same thing against a real provider.
+type recordingProvider struct {
+	inner provider.Provider
+	rec   *callRecorder
+}
+
+func (p *recordingProvider) Name() string { return p.inner.Name() }
+
+func (p *recordingProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.rec.note(req)
+	return p.inner.Stream(ctx, req)
+}

--- a/benchmarks/compaction/main_test.go
+++ b/benchmarks/compaction/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+// The cost arm is deterministic, so it doubles as the regression guard for the
+// property it was written to measure: a session that keeps growing must keep
+// folding, and no single summarizer call may outgrow the window.
+func TestRepeatedFoldsStayBoundedAndKeepSucceeding(t *testing.T) {
+	const (
+		window   = 64_000
+		gens     = 6
+		reserve  = 8192 // summaryOutputReserve: the digest the call must still return
+		maxCalls = 7    // maxSummarySpans + the merge pass
+	)
+	res, err := runCost(gens, window)
+	if err != nil {
+		t.Fatalf("runCost: %v", err)
+	}
+	if len(res) != gens {
+		t.Fatalf("generations = %d, want %d", len(res), gens)
+	}
+	for _, r := range res {
+		if r.Error != "" {
+			t.Errorf("gen %d failed to fold: %s", r.Gen+1, r.Error)
+		}
+		if r.LargestCall+reserve > window {
+			t.Errorf("gen %d largest summarizer call = %d tokens est.; with %d reserved for the digest that overflows the %d window", r.Gen+1, r.LargestCall, reserve, window)
+		}
+		if r.SummarizerCalls > maxCalls {
+			t.Errorf("gen %d cost %d summarizer calls, over the %d ceiling", r.Gen+1, r.SummarizerCalls, maxCalls)
+		}
+		if r.ProjectionTokens == 0 || r.ProjectionTokens >= r.CanonicalTokens {
+			t.Errorf("gen %d projection = %d tokens vs canonical %d; the fold saved nothing", r.Gen+1, r.ProjectionTokens, r.CanonicalTokens)
+		}
+	}
+	if last := res[len(res)-1]; last.CanonicalTokens <= res[0].CanonicalTokens {
+		t.Fatalf("canonical did not grow across generations: %d -> %d", res[0].CanonicalTokens, last.CanonicalTokens)
+	}
+}
+
+// A probe must score the stale answer as lost even when the model hedges its
+// way to mentioning the right one — "yes, but it has not been re-run since"
+// is the exact shape a drifting digest produces.
+func TestProbeScoringRejectsHedges(t *testing.T) {
+	var freshness probe
+	for _, p := range probeSuite() {
+		if p.class == "verification-freshness" {
+			freshness = p
+		}
+	}
+	if freshness.class == "" {
+		t.Fatal("verification-freshness probe missing from the suite")
+	}
+	for _, tc := range []struct {
+		answer string
+		want   bool
+	}{
+		{"No.", true},
+		{"no — config/format.go changed after the last run", true},
+		{"Yes", false},
+		{"Yes, but it has not been re-run since the edit", false},
+		{"I am not sure", false},
+	} {
+		if got := freshness.score(tc.answer); got != tc.want {
+			t.Errorf("score(%q) = %v, want %v", tc.answer, got, tc.want)
+		}
+	}
+}

--- a/benchmarks/compaction/probes.go
+++ b/benchmarks/compaction/probes.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"unicode"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+// probeAnswerContract rides with every probe question. A context full of tool
+// calls invites the model to answer with another one, which scores as a lost
+// fact when it is really a harness artifact — both arms get the same nudge.
+const probeAnswerContract = "Answer using only the conversation above. Reply with the answer itself in plain text: no tool calls, no tool-call syntax, no explanation."
+
+// noAnswerMarker and toolCallMarker label a reply that never answered, so the
+// report can separate what compaction lost from what the harness failed to ask.
+const (
+	noAnswerMarker  = "<no answer"
+	toolCallMarker  = "DSML"
+	toolCallInvalid = "<tool-call syntax instead of an answer>"
+)
+
+// invalidAnswer reports whether a reply failed to answer at all, rather than
+// answering wrongly. These are excluded from the survival rate and counted.
+func invalidAnswer(s string) bool {
+	return strings.HasPrefix(s, noAnswerMarker) || s == toolCallInvalid
+}
+
+// A probe is a fact planted in history and a question only that fact answers.
+// The question is asked against the compacted context, so a wrong answer means
+// compaction lost the fact — not that the model is weak.
+type probe struct {
+	class    string
+	plantAt  int
+	plant    func(*agent.Session)
+	question string
+	want     []string // answer must contain one of these, lowercased
+	reject   []string // ...and none of these: the pre-correction answer
+}
+
+func userTurn(text string) func(*agent.Session) {
+	return func(s *agent.Session) { s.Add(provider.Message{Role: provider.RoleUser, Content: text}) }
+}
+
+func toolRound(id, name, args, result string) func(*agent.Session) {
+	return func(s *agent.Session) {
+		s.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: id, Name: name, Arguments: args}}})
+		s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: name, Content: result})
+	}
+}
+
+func seq(fns ...func(*agent.Session)) func(*agent.Session) {
+	return func(s *agent.Session) {
+		for _, fn := range fns {
+			fn(s)
+		}
+	}
+}
+
+// probeSuite covers what a coding agent must not lose across a fold. The
+// freshness and correction probes are the ones summaries classically get wrong:
+// both have a plausible stale answer that reads as correct.
+func probeSuite() []probe {
+	return []probe{
+		{
+			class:    "user-constraint",
+			plantAt:  0,
+			plant:    userTurn("Hard rule for this whole task: never modify config/schema.sql."),
+			question: "Are you allowed to modify config/schema.sql? Answer yes or no.",
+			want:     []string{"no"},
+			reject:   []string{"yes"},
+		},
+		{
+			class:   "correction",
+			plantAt: 0,
+			plant: seq(
+				userTurn("Indent the generated config with tabs."),
+				userTurn("Correction: indent the generated config with spaces, not tabs. This supersedes what I said before."),
+			),
+			question: "Should the generated config be indented with tabs or with spaces? Answer with one word.",
+			want:     []string{"spaces", "space"},
+			reject:   []string{"tabs", "tab"},
+		},
+		{
+			class:    "exact-identifier",
+			plantAt:  0,
+			plant:    userTurn("Track this work under ticket RX-4821; put that id in the commit message."),
+			question: "What is the ticket id for this work? Reply with just the id.",
+			want:     []string{"rx-4821"},
+		},
+		{
+			class:    "objective",
+			plantAt:  0,
+			plant:    userTurn("To be clear, the objective is the config round-trip formatting bug, not performance."),
+			question: "In a few words, what is the current objective?",
+			want:     []string{"round-trip", "round trip", "roundtrip", "formatting"},
+		},
+		{
+			class:   "pending-requirement",
+			plantAt: 1,
+			plant: seq(
+				userTurn("Two requirements: R1 preserve unknown keys, R2 keep quoted values quoted."),
+				toolRound("r1", "bash", `{"cmd":"go test ./config -run TestUnknownKeys"}`, "ok\nPASS: TestUnknownKeys (R1 satisfied)"),
+			),
+			question: "Of requirements R1 and R2, which one is still not satisfied? Reply with just R1 or R2.",
+			want:     []string{"r2"},
+			reject:   []string{"r1"},
+		},
+		{
+			class:   "verification-freshness",
+			plantAt: 1,
+			plant: seq(
+				toolRound("v1", "bash", `{"cmd":"go test ./config -run TestRoundTrip"}`, "ok  config\tPASS: TestRoundTrip"),
+				toolRound("w1", "write_file", `{"path":"config/format.go"}`, "wrote config/format.go (42 lines changed)"),
+				userTurn("Note that config/format.go changed after that test run."),
+			),
+			question: "Has TestRoundTrip been run again since config/format.go was last edited? Answer yes or no.",
+			want:     []string{"no"},
+			reject:   []string{"yes"},
+		},
+		{
+			class:   "negative-evidence",
+			plantAt: 1,
+			plant: seq(
+				userTurn("We suspected parser normalization was the root cause."),
+				toolRound("n1", "bash", `{"cmd":"go test ./config -run TestParserNormalization"}`, "PASS — parser normalization is NOT the root cause; ruled out."),
+			),
+			question: "Is parser normalization the root cause of the bug? Answer yes or no.",
+			want:     []string{"no"},
+			reject:   []string{"yes"},
+		},
+		{
+			class:   "tool-outcome",
+			plantAt: 2,
+			plant: seq(
+				toolRound("b1", "bash", `{"cmd":"go vet ./..."}`, "config/format.go:88: printf: non-constant format string\nexit status 1"),
+				userTurn("Leave that vet warning for now; we will fix it at the end."),
+			),
+			question: "Did `go vet ./...` pass the last time it ran? Answer yes or no.",
+			want:     []string{"no"},
+			reject:   []string{"yes"},
+		},
+		{
+			class:    "code-fact",
+			plantAt:  2,
+			plant:    toolRound("c1", "read_file", `{"path":"config/save.go"}`, "// Config.Save intentionally preserves unknown keys so plugins round-trip through this path.\nfunc (c *Config) Save() error { /* ... */ }"),
+			question: "Does Config.Save preserve unknown keys? Answer yes or no.",
+			want:     []string{"yes"},
+			reject:   []string{"no"},
+		},
+		{
+			class:   "chronology",
+			plantAt: 2,
+			plant: seq(
+				toolRound("o1", "write_file", `{"path":"config/parser.go"}`, "wrote config/parser.go"),
+				toolRound("o2", "write_file", `{"path":"config/format.go"}`, "wrote config/format.go"),
+			),
+			question: "Was config/parser.go edited before or after config/format.go? Reply with just: before, or after.",
+			want:     []string{"before"},
+			reject:   []string{"after"},
+		},
+	}
+}
+
+// score reports whether an answer keeps the planted fact. A rejected token
+// anywhere in the answer counts as lost even when the wanted token also
+// appears, so "yes, but it was not re-run" does not pass as "no".
+func (p probe) score(answer string) bool {
+	a := strings.ToLower(answer)
+	for _, bad := range p.reject {
+		if matchesToken(a, bad) {
+			return false
+		}
+	}
+	for _, good := range p.want {
+		if matchesToken(a, good) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesToken compares whole words, never substrings: "I am not sure" must not
+// count as the answer "no". Multi-word wants are phrases and match literally.
+func matchesToken(lowered, want string) bool {
+	if strings.Contains(want, " ") {
+		return strings.Contains(lowered, want)
+	}
+	return slices.Contains(strings.FieldsFunc(lowered, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-'
+	}), want)
+}
+
+func (p probe) String() string { return fmt.Sprintf("%s@gen%d", p.class, p.plantAt) }

--- a/benchmarks/compaction/session.go
+++ b/benchmarks/compaction/session.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+// A generation is one round of work followed by one compaction. Compaction
+// re-derives its digest from the whole canonical transcript, so generation N
+// folds everything generations 1..N produced — which is exactly the growth the
+// cost arm measures and the drift arm probes.
+const (
+	unitsPerGeneration = 12
+	toolResultBytes    = 6_000
+)
+
+// workUnit is one read_file round: the shape that dominates a real coding
+// session's token weight.
+func workUnit(sess *agent.Session, gen, i int) {
+	id := fmt.Sprintf("g%02dc%02d", gen, i)
+	path := fmt.Sprintf("internal/pkg%02d/file%02d.go", gen, i)
+	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+		{ID: id, Name: "read_file", Arguments: fmt.Sprintf(`{"path":%q}`, path)},
+	}})
+	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: "read_file", Content: fakeGoFile(gen, i, toolResultBytes)})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("Read %s; nothing surprising.", path)})
+}
+
+func fakeGoFile(gen, i, size int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "package pkg%02d\n\n// file%02d\n\n", gen, i)
+	for line := 0; b.Len() < size; line++ {
+		fmt.Fprintf(&b, "func helper%02d_%02d_%04d(x int) int { return x*%d + %d }\n", gen, i, line, line+3, line*7)
+	}
+	return b.String()
+}
+
+// growSession appends one generation of work, planting whatever probes belong
+// to that generation so a fact's age is exactly the number of folds it has
+// survived.
+func growSession(sess *agent.Session, gen int, probes []probe) {
+	for _, p := range probes {
+		if p.plantAt == gen {
+			p.plant(sess)
+		}
+	}
+	for i := range unitsPerGeneration {
+		workUnit(sess, gen, i)
+	}
+}
+
+func newSession() *agent.Session {
+	sess := agent.NewSession("You are a terse coding agent. Answer questions from what you know; do not guess.")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "Fix the config round-trip formatting bug in this repo."})
+	return sess
+}
+
+// visibleContext splices the stored projection with the canonical messages
+// appended after it — the same model-visible view the agent would send.
+func visibleContext(sessionPath string, sess *agent.Session) ([]provider.Message, error) {
+	st, ok, err := agent.LoadCompactionState(sessionPath)
+	if err != nil {
+		return nil, err
+	}
+	canonical := sess.Snapshot()
+	if !ok || len(st.Projection.Messages) == 0 {
+		return canonical, nil
+	}
+	out := append([]provider.Message(nil), st.Projection.Messages...)
+	if n := st.Projection.CoveredCount; n >= 0 && n < len(canonical) {
+		out = append(out, canonical[n:]...)
+	}
+	return out, nil
+}


### PR DESCRIPTION
Stacked on #8021 (which is stacked on #8019). The bench's regression guard asserts the bounding #8021 adds, so it cannot be based on `main-v2` until that lands.

**Note on CI:** every workflow here filters `branches: [main-v2]`, so a PR based on a feature branch runs only `label`. This one gets its matrix once #8021 merges and GitHub retargets it — retarget then close/reopen to trigger. Local gate results are below.

## Why

Compaction had no measurement of its own. `context-maintenance-e2e/` covers cold-restart cache behavior after pruning; nothing covered what folding a session over and over *costs*, or what it *loses*.

CompactionBench grows a session one generation at a time and folds after each, so generation N folds everything generations 1..N produced. That is the growth that matters, because a fold re-derives its digest from the whole canonical transcript rather than from the previous digest.

## Cost arm — deterministic, no API key

The scripted summarizer refuses any input larger than the window the way a real provider does, so the wedge is **observed**, not argued. Same bench, same seed, both sides of #8021:

Before #8021 (`fix/compaction-fold-partition`):

```
| gen | canonical tok | fold calls | fold input tok | largest call | result |
| ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 73767 | 1 | 13963 | 13963 | summarized |
| 2 | 147598 | 1 | 88323 | 88323 | summarized |
| 3 | 221320 | 2 | 325288 | 162644 | ERROR: maximum context length is 128000 tokens, however you requested 162644 |
| 4 | 294592 | 2 | 472744 | 236372 | ERROR: ... requested 236372 |
| 5 | 367864 | 2 | 620200 | 310100 | ERROR: ... requested 310100 |
| 6 | 441136 | 2 | 767656 | 383828 | ERROR: ... requested 383828 |
| 7 | 514408 | 2 | 915112 | 457556 | ERROR: ... requested 457556 |
| 8 | 587680 | 2 | 1062568 | 531284 | ERROR: ... requested 531284 |
```

After #8021:

```
| gen | canonical tok | fold calls | fold input tok | largest call | projection tok | result |
| ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 73767 | 1 | 13963 | 13963 | 62155 | summarized |
| 2 | 147598 | 1 | 88323 | 88323 | 62155 | summarized |
| 3 | 221320 | 3 | 139222 | 119482 | 62155 | summarized |
| 4 | 294592 | 3 | 200218 | 119482 | 62155 | summarized |
| 5 | 367864 | 4 | 263133 | 119482 | 62155 | summarized |
| 6 | 441136 | 4 | 324129 | 119482 | 62155 | summarized |
| 7 | 514408 | 5 | 387044 | 119482 | 62155 | summarized |
| 8 | 587680 | 5 | 448040 | 119482 | 62155 | summarized |
```

Read the "after" table as the honest cost of the current design, not as a victory lap: from generation 3 on, one compaction costs 3–5 summarizer calls and grows to ~450k tokens of input per fold, and the largest call sits right against the window minus the digest reserve. That number is the baseline any incremental-fold or capsule work has to beat.

`go test ./benchmarks/compaction/` runs a smaller version as a CI guard: every generation must still fold, no single call may leave the window without room for the digest, the call count stays under the span ceiling, and the projection must actually be smaller than the canonical it replaced.

## It already found a real leak

Writing the guard surfaced two bugs in #8021, both fixed there (amended):

1. The budget bounded the rendered transcript but not the summary system prompt riding in the same request, so the largest call came in over. The prompt and the caller's instructions now come off the top — the provider counts them against the same window.
2. Bounding at half the window was wrong in kind, not just in size: the failure being avoided is `input + output > window`, so half the window threw away half the budget and split folds that fit comfortably. It broke `TestGuardianSessionAlternatesAfterCompaction`, whose 100k-window fold sat just past the old bound. The budget is now the window minus the digest reserve, which is why generation 2 above needs one call rather than three.

## Fidelity arm — run against DeepSeek, 8 generations

Plants what a coding agent must not lose and asks, after each fold, a question only that fact answers. Every probe also runs against full history in the same session, so a probe the model fails with everything in front of it is scored as a bad probe rather than a compaction loss.

```
| probe                  | gen 1 | gen 2 | gen 4 | gen 8 |
| ---------------------- | ----- | ----- | ----- | ----- |
| user-constraint        | ok/ok | ok/ok | ok/ok | ok/ok |
| correction             | ok/ok | ok/ok | ok/ok | ok/ok |
| exact-identifier       | ok/ok | ok/ok | ok/ok | ok/ok |
| objective              | ok/ok | ok/ok | ok/ok | ok/ok |
| pending-requirement    |   –   | ok/ok | ok/ok | ok/ok |
| verification-freshness |   –   | ok/ok | ok/ok | ok/ok |
| negative-evidence      |   –   | ok/ok | ok/ok | ok/ok |
| tool-outcome           |   –   |   –   | ok/ok | ok/ok |
| code-fact              |   –   |   –   | ok/ok | ok/ok |
| chronology             |   –   |   –   | ok/ok | ok/ok |

compacted 71/71 · control 70/71 · unanswered 0 of 71 (both arms)
```

**No fact was lost across eight folds.** `verification-freshness` — the probe most likely to drift, since "it passed once" and "it is verified now" are the same sentence to a careless summary — answered `no` correctly at every generation. The single control failure is gen 7 `chronology`, where full history said "after" and the compacted context said "before"; the compacted answer is the right one, because the digest states the ordering plainly while the raw transcript buries it in 514k tokens of filler.

That result is consistent with the structural finding behind #8019: digests never chain here — every fold re-derives from the canonical transcript — so there is no generational drift to accumulate. The risk in this design is cost and latency, not fidelity.

**What this does not show.** One model, one synthetic workload, one run, no variance estimate. The filler is uniform and trivially compressible, so the summarizer has an easier job than it would on a real session. And these are recall questions: they do not measure whether the agent *acts* correctly afterward — re-discovery cost and task-success delta are not implemented here.

Getting to a number that means anything took three fixes worth calling out, because each one had produced a confidently wrong table first:

1. **Record the answers.** The first run reported control 16/71 vs compacted 25/71 — compaction scoring *better* than full history, which is not physically possible. With only 1/0 recorded there was no way to see why.
2. **Budget for reasoning, not just the answer.** `deepseek-v4-flash` emits reasoning before its visible answer; a 40-token budget was consumed entirely by reasoning, so every probe came back empty and scored as a lost fact.
3. **Separate unanswered from lost.** A context full of tool calls invites the model to reply with another tool call; those replies are now marked, excluded from the rate, and counted in the report — a survival rate quoted without that denominator reads harness noise as fact loss.

Reproduce: `DEEPSEEK_API_KEY=… go run ./benchmarks/compaction -mode=fidelity -gens=8 -out report.json`.

## Local gate

`gofmt` clean · `go vet ./benchmarks/...` clean · `go run ./tools/repolint` clean (1974 baselined, not widened) · `go test ./internal/agent/ ./benchmarks/compaction/` ok

Documentation-impact: updated - benchmarks/README.md documents both arms, how to run them, and how probes are scored.
