### PR TITLE
fix(memory): make the stable index agree with recall on scope precedence

### DIFF
--- a/internal/memory/index.go
+++ b/internal/memory/index.go
@@ -1,0 +1,61 @@
+// The provider-visible memory index: scope-qualified references for every
+// active fact, override annotations for shadowed global guidance.
+package memory
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Index returns the provider-visible index that loads into the cached
+// prefix: every active fact from both scopes with a scope-qualified
+// reference, shadowed global facts annotated rather than hidden — the index
+// agrees with the project-over-global rule recall enforces (#7995). The
+// per-directory MEMORY.md files keep their unqualified format.
+func (s Store) Index() string {
+	memories := s.ListAll()
+	if len(memories) == 0 {
+		return ""
+	}
+	shadowed := map[string]string{} // global fact ID -> winning project reference
+	for _, o := range FindOverrides(memories) {
+		shadowed[o.Global.ID] = providerMemoryReference(o.Project)
+	}
+	sort.SliceStable(memories, func(i, j int) bool {
+		if memories[i].Name != memories[j].Name {
+			return memories[i].Name < memories[j].Name
+		}
+		return NormalizeFactScope(string(memories[i].Scope)) == FactScopeProject
+	})
+	var b strings.Builder
+	seen := map[string]bool{} // collapse legacy migration duplicates (same qualified ref)
+	for _, memory := range memories {
+		if ref := providerMemoryReference(memory); seen[ref] {
+			continue
+		} else {
+			seen[ref] = true
+		}
+		b.WriteString(renderQualifiedIndexLine(memory))
+		if winner, ok := shadowed[memory.ID]; ok &&
+			NormalizeFactScope(string(memory.Scope)) == FactScopeGlobal {
+			b.WriteString(" (overridden by " + winner + ")")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// renderQualifiedIndexLine is the provider-index variant of renderIndexLine:
+// the link is the scope-qualified reference every memory tool accepts, so a
+// name collision across scopes can never be misread.
+func renderQualifiedIndexLine(m Memory) string {
+	marker := ""
+	if ResolveActivation(m) == ActivationPinned {
+		marker = " pinned"
+	}
+	ref := providerMemoryReference(m)
+	return fmt.Sprintf("- [%s](%s) — [%s/%s%s] %s",
+		displayTitle(m.Title, m.Name), ref,
+		NormalizeFactScope(string(m.Scope)), NormalizeType(string(m.Type)), marker, oneLine(m.Description))
+}

--- a/internal/memory/index_scope_test.go
+++ b/internal/memory/index_scope_test.go
@@ -1,0 +1,43 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+// #7995: the stable index and automatic recall must share one world view. On a
+// name collision both scopes stay visible with qualified references, and the
+// shadowed global entry says which project fact overrides it.
+func TestIndexShowsBothScopesWithOverrideAnnotation(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-proj", Name: "deploy-region", Title: "Deploy region",
+		Description: "This project deploys to eu-central-1", Type: TypeProject,
+		Scope: FactScopeProject, Body: "eu-central-1",
+	})
+	recallTestWrite(t, store.GlobalDir, Memory{
+		ID: "mem-glob", Name: "deploy-region", Title: "Deploy region",
+		Description: "Default deploy region", Type: TypeProject,
+		Scope: FactScopeGlobal, Body: "us-east-1",
+	})
+
+	index := store.Index()
+	for _, want := range []string{
+		"(project/deploy-region.md)",
+		"(global/deploy-region.md)",
+		"(overridden by project/deploy-region.md)",
+	} {
+		if !strings.Contains(index, want) {
+			t.Fatalf("index missing %q:\n%s", want, index)
+		}
+	}
+	if strings.Contains(index, "](deploy-region.md)") {
+		t.Fatalf("provider index must never use unqualified references:\n%s", index)
+	}
+	// The project entry (the recall winner) must not carry the annotation.
+	for line := range strings.SplitSeq(index, "\n") {
+		if strings.Contains(line, "(project/deploy-region.md)") && strings.Contains(line, "overridden") {
+			t.Fatalf("winning project entry wrongly annotated: %s", line)
+		}
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -136,23 +136,6 @@ func (s Store) dirs() []string {
 	return []string{s.Dir}
 }
 
-// Index returns the MEMORY.md contents (the per-line index of saved memories),
-// or "" if there are none yet. This is what loads into the cached prefix.
-// When both GlobalDir and Dir have indexes, they are merged with deduplication
-// (global first).
-func (s Store) Index() string {
-	memories := s.List()
-	if len(memories) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for _, memory := range memories {
-		b.WriteString(renderIndexLine(memory.Name, memory))
-		b.WriteString("\n")
-	}
-	return b.String()
-}
-
 // Path returns the absolute file path a memory with the given name lives at.
 // It checks GlobalDir first, then Dir, returning the first match. If no file
 // exists yet, it returns the path in Dir (the default project scope).

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -235,7 +235,7 @@ func TestStoreSaveTitleInIndexAndFrontmatter(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if idx := s.Index(); !strings.Contains(idx, "[Prefers tabs](tabs-rule.md)") {
+	if idx := s.Index(); !strings.Contains(idx, "[Prefers tabs](project/tabs-rule.md)") {
 		t.Fatalf("index link should use the title label:\n%s", idx)
 	}
 	if got := s.List()[0].Title; got != "Prefers tabs" {
@@ -250,7 +250,7 @@ func TestStoreIndexLabelFallsBackToDeKebabbedName(t *testing.T) {
 	if _, err := s.Save(Memory{Name: "likes-go", Description: "d", Type: TypeUser, Body: "b"}); err != nil {
 		t.Fatal(err)
 	}
-	if idx := s.Index(); !strings.Contains(idx, "[likes go](likes-go.md)") {
+	if idx := s.Index(); !strings.Contains(idx, "[likes go](project/likes-go.md)") {
 		t.Fatalf("missing-title label should de-kebab the name:\n%s", idx)
 	}
 }

--- a/internal/memory/store_v2_test.go
+++ b/internal/memory/store_v2_test.go
@@ -45,7 +45,7 @@ func TestStoreV2IndexIsDerivedFromFacts(t *testing.T) {
 	}
 
 	index := store.Index()
-	if !strings.Contains(index, "[Source of truth](source-of-truth.md)") || strings.Contains(index, "Ghost") {
+	if !strings.Contains(index, "[Source of truth](project/source-of-truth.md)") || strings.Contains(index, "Ghost") {
 		t.Fatalf("derived index used stale MEMORY.md:\n%s", index)
 	}
 }


### PR DESCRIPTION
Fixes #7995 with the option B agreed there: show both entries, annotate the override, qualify every reference.

## What

- `Store.Index()` (the provider-visible index in the cached prefix) is now assembled from `ListAll` + the same `FindOverrides` resolution automatic recall uses — one world view for both layers. Previously the legacy name-deduped `List` let a global fact silently win a name collision (global-first directory order) while recall resolved the same collision project-over-global.
- Every index reference is scope-qualified (`project/foo.md` / `global/foo.md` — the form every memory tool already accepts); the bare `foo.md` form that made collisions invisible is gone from the provider index.
- A shadowed global fact stays visible, annotated `(overridden by project/foo.md)` — provenance preserved, ambiguity gone (the "activation made membership a stored property" foundation from #7996 is what makes this cheap).
- Exact migration duplicates (same qualified reference) still collapse; per-directory MEMORY.md files keep their unqualified format — they live inside their scope directory, and reindex/Delete line targeting stays byte-compatible.
- Provider-index assembly extracted to `internal/memory/index.go`.

Tests: collision shows both scopes qualified, shadowed global annotated, winning project entry not annotated, no unqualified references; existing index tests updated to the qualified format; migration-duplicate collapse retained.

Cache-impact: low - the index line format in the stable prefix changes once at binary upgrade (qualified refs + annotations); within a session it stays byte-stable, goldens regenerated to pin the new shape
Cache-guard: internal/boot golden baseline suite re-passes on regenerated goldens; TestLoadIncludesStableGlobalPreferencesAndFeedback asserts repeated Block() byte-stability
System-prompt-review: esengine - index lines gain scope qualification and override annotations; pinned markers and line structure otherwise unchanged
Documentation-impact: none - docs describe the override-explained behavior abstractly and remain correct; the reference format change is provider-internal
