### PR TITLE
feat(memory): session recall index and unified crash-safe writers

### DIFF
--- a/internal/control/memory.go
+++ b/internal/control/memory.go
@@ -84,12 +84,7 @@ func (m *memoryManager) claimAutoRemember(args json.RawMessage) bool {
 }
 
 func (m *memoryManager) recall(query string) memory.RecallResult {
-	mem := m.current()
-	store := memory.Store{}
-	if mem != nil {
-		store = mem.Store
-	}
-	result := memory.AutoRecall(store, query, memory.RecallOptions{})
+	result := m.current().AutoRecall(query, memory.RecallOptions{})
 	m.recordRecall(result)
 	return result
 }

--- a/internal/memory/auto_recall.go
+++ b/internal/memory/auto_recall.go
@@ -130,34 +130,31 @@ type autoRecallDoc struct {
 // and one-common-word matches return no block rather than spending context.
 func AutoRecall(store Store, query string, opts RecallOptions) RecallResult {
 	result := RecallResult{Query: strings.TrimSpace(query), CharBudget: recallCharBudget(opts.MaxChars)}
-	queryTerms, err := retrieval.QueryTerms(result.Query)
-	if err != nil {
-		result.Suppressed = "no searchable terms"
-		return result
-	}
 	if genericRecallQuery(result.Query) {
 		result.Suppressed = "generic user turn"
 		return result
 	}
 
-	memories := recallMemories(store.ListAll())
+	return autoRecallIndexed(BuildRecallIndex(store), result, opts)
+}
+
+// autoRecallIndexed is AutoRecall's scoring core over a prebuilt index. The
+// per-turn path uses the session snapshot's index (zero disk IO); the direct
+// AutoRecall entry builds one on the spot for tools, tests, and the bench.
+func autoRecallIndexed(index *RecallIndex, result RecallResult, opts RecallOptions) RecallResult {
+	if index == nil {
+		result.Suppressed = "memory store is empty"
+		return result
+	}
 	// The shadow ranks the full pool before any production gate: what V1
 	// misses entirely is exactly what the comparison must be able to see.
-	result.ShadowHits = shadowRankV2(result.Query, memories)
-	docs := make([]autoRecallDoc, 0, len(memories))
-	for _, memory := range memories {
-		text := autoRecallSearchText(memory)
-		terms := retrieval.Tokens(text)
-		if len(terms) == 0 {
-			continue
-		}
-		docs = append(docs, autoRecallDoc{
-			memory: memory,
-			text:   text,
-			counts: retrieval.Counts(terms),
-			length: len(terms),
-		})
+	result.ShadowHits = shadowRankV2(result.Query, index.fielded)
+	queryTerms, err := retrieval.QueryTerms(result.Query)
+	if err != nil {
+		result.Suppressed = "no searchable terms"
+		return result
 	}
+	docs := index.docs
 	if len(docs) == 0 {
 		result.Suppressed = "memory store is empty"
 		return result
@@ -237,14 +234,7 @@ func AutoRecall(store Store, query string, opts RecallOptions) RecallResult {
 // shadowRankV2 runs the Retrieval V2 candidate (BM25F, code-symbol split,
 // mixed CJK grams) over the recall pool. Shadow only: recorded for offline
 // comparison, gated by MemoryBench before it can ever serve.
-func shadowRankV2(query string, memories []Memory) []ShadowHit {
-	docs := make([]retrieval.FieldedDoc, 0, len(memories))
-	for _, m := range memories {
-		docs = append(docs, retrieval.FieldedDoc{ID: m.ID, Fields: map[string]string{
-			"name": m.Name, "title": m.Title, "keywords": m.Keywords,
-			"subject": m.SubjectKey, "description": m.Description, "body": m.Body,
-		}})
-	}
+func shadowRankV2(query string, docs []retrieval.FieldedDoc) []ShadowHit {
 	ranked := retrieval.RankV2(query, docs)
 	if len(ranked) > maxAutoRecallLimit {
 		ranked = ranked[:maxAutoRecallLimit]

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -22,6 +22,10 @@ type Set struct {
 	CWD                    string   // project working dir used for discovery
 	UserDir                string   // user config root (may be "")
 	InstructionDiagnostics []instruction.Diagnostic
+
+	// recall is the snapshot's prebuilt retrieval index (nil when memory is
+	// hidden or empty); Set.AutoRecall serves each turn from it without disk.
+	recall *RecallIndex
 }
 
 // Options configures discovery. CWD defaults to "." and UserDir is the user
@@ -57,6 +61,7 @@ func Load(opts Options) *Set {
 		CWD:                    cwd,
 		UserDir:                opts.UserDir,
 		InstructionDiagnostics: resolved.Diagnostics,
+		recall:                 BuildRecallIndex(store),
 	}
 }
 

--- a/internal/memory/recall_index.go
+++ b/internal/memory/recall_index.go
@@ -1,0 +1,66 @@
+// The session recall index: the recall pool read and tokenized once per
+// memory snapshot, so each user turn's automatic recall costs zero disk IO.
+// Markdown files stay the source of truth — every write path reloads the
+// snapshot through memory.Load, which rebuilds this index with it.
+package memory
+
+import (
+	"strings"
+
+	"reasonix/internal/retrieval"
+)
+
+// RecallIndex is the prebuilt retrieval state for one immutable Set snapshot.
+type RecallIndex struct {
+	docs    []autoRecallDoc
+	fielded []retrieval.FieldedDoc // V2 shadow pool, prebuilt field split
+}
+
+// BuildRecallIndex reads and tokenizes the recall pool once. A zero store
+// yields nil, which recall reports as an empty memory store.
+func BuildRecallIndex(store Store) *RecallIndex {
+	memories := recallMemories(store.ListAll())
+	if len(memories) == 0 {
+		return nil
+	}
+	index := &RecallIndex{}
+	for _, memory := range memories {
+		index.fielded = append(index.fielded, retrieval.FieldedDoc{ID: memory.ID, Fields: map[string]string{
+			"name": memory.Name, "title": memory.Title, "keywords": memory.Keywords,
+			"subject": memory.SubjectKey, "description": memory.Description, "body": memory.Body,
+		}})
+		text := autoRecallSearchText(memory)
+		terms := retrieval.Tokens(text)
+		if len(terms) == 0 {
+			continue
+		}
+		index.docs = append(index.docs, autoRecallDoc{
+			memory: memory,
+			text:   text,
+			counts: retrieval.Counts(terms),
+			length: len(terms),
+		})
+	}
+	return index
+}
+
+// AutoRecall runs automatic recall against this snapshot's prebuilt index —
+// the per-turn path. Semantics are identical to the package-level AutoRecall.
+func (s *Set) AutoRecall(query string, opts RecallOptions) RecallResult {
+	result := RecallResult{Query: strings.TrimSpace(query), CharBudget: recallCharBudget(opts.MaxChars)}
+	if genericRecallQuery(result.Query) {
+		result.Suppressed = "generic user turn"
+		return result
+	}
+	if s == nil {
+		result.Suppressed = "memory store is empty"
+		return result
+	}
+	index := s.recall
+	if index == nil {
+		// Hand-built sets (tests, embedders) carry no prebuilt index; the
+		// Load path always does, so per-turn recall stays disk-free there.
+		index = BuildRecallIndex(s.Store)
+	}
+	return autoRecallIndexed(index, result, opts)
+}

--- a/internal/memory/recall_index_test.go
+++ b/internal/memory/recall_index_test.go
@@ -1,0 +1,51 @@
+package memory
+
+import "testing"
+
+// The index and the direct store scan must be indistinguishable: same hits,
+// same shadow, same suppression reasons.
+func TestSetAutoRecallMatchesStoreScan(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-a", Name: "fast-check", Title: "Fast check command",
+		Description: "The canonical fast check", Type: TypeProject, Scope: FactScopeProject,
+		Body: "Run make check-fast before pushing.",
+	})
+	set := &Set{Store: store, recall: BuildRecallIndex(store)}
+	for _, query := range []string{"what is the fast check command", "continue", "总结一下"} {
+		direct := AutoRecall(store, query, RecallOptions{})
+		indexed := set.AutoRecall(query, RecallOptions{})
+		if len(direct.Hits) != len(indexed.Hits) || direct.Suppressed != indexed.Suppressed ||
+			len(direct.ShadowHits) != len(indexed.ShadowHits) {
+			t.Fatalf("index diverged from scan for %q: direct=%+v indexed=%+v", query, direct, indexed)
+		}
+	}
+	if hits := set.AutoRecall("fast check command", RecallOptions{}).Hits; len(hits) != 1 {
+		t.Fatalf("indexed recall should hit: %+v", hits)
+	}
+
+	var nilSet *Set
+	if r := nilSet.AutoRecall("anything relevant", RecallOptions{}); r.Suppressed == "" {
+		t.Fatalf("nil set must suppress, got %+v", r)
+	}
+}
+
+// Writes rebuild the snapshot (and with it the index) through memory.Load —
+// the invalidation contract that keeps Markdown the source of truth.
+func TestLoadRebuildsIndexAfterWrite(t *testing.T) {
+	root := t.TempDir()
+	user, proj := root+"/user", root+"/project"
+	mustMkdir(t, proj+"/.git")
+	set := Load(Options{CWD: proj, UserDir: user})
+	if r := set.AutoRecall("release branch for hotfixes", RecallOptions{}); len(r.Hits) != 0 {
+		t.Fatalf("empty store recalled: %+v", r)
+	}
+	if _, err := set.Store.Save(Memory{Name: "release-branch", Description: "current release branch",
+		Body: "Hotfixes target the release branch release/1.21."}); err != nil {
+		t.Fatal(err)
+	}
+	reloaded := Load(Options{CWD: proj, UserDir: user})
+	if r := reloaded.AutoRecall("release branch for hotfixes", RecallOptions{}); len(r.Hits) != 1 {
+		t.Fatalf("reloaded index missed the new fact: %+v", r)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/config"
+	"reasonix/internal/fileutil"
 	fileencoding "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/frontmatter"
 )
@@ -445,10 +446,12 @@ func flushIndexIn(dir string, lines map[string]string) error {
 		b.WriteString("\n")
 	}
 	result := strings.TrimRight(b.String(), "\n")
-	if result == "" {
-		return os.WriteFile(path, []byte(""), 0o644)
+	if result != "" {
+		result += "\n"
 	}
-	return os.WriteFile(path, []byte(result+"\n"), 0o644)
+	// The index is derived state, but a torn write would still hide facts
+	// from the next session's prefix until the next reindex.
+	return fileutil.AtomicWriteFile(path, []byte(result), 0o644)
 }
 
 // reindexIn rewrites the MEMORY.md line for name in the given directory,

--- a/internal/memory/store_v2.go
+++ b/internal/memory/store_v2.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"reasonix/internal/fileutil"
 )
 
 type SaveOptions struct {
@@ -568,61 +570,23 @@ func snapshotMemoryRevisionInDir(base, path string, memory Memory) error {
 	return writeMemoryAtomic(filepath.Join(dir, name), b, 0o644)
 }
 
+// writeMemoryAtomic publishes a fact file through the shared crash-safe
+// writer (temp + fsync + replace), creating the parent directory on demand.
 func writeMemoryAtomic(path string, data []byte, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".memory-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(mode); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
+	return fileutil.AtomicWriteFile(path, data, mode)
 }
 
-func writeMemoryCreate(path string, data []byte, mode os.FileMode) (err error) {
+// writeMemoryCreate publishes a fact file only when path is still absent; a
+// concurrent creator wins. The shared writer stages a complete temp file, so
+// a crash can never leave a partial fact where active truth lives.
+func writeMemoryCreate(path string, data []byte, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
-	if err != nil {
-		return err
-	}
-	complete := false
-	defer func() {
-		if !complete {
-			_ = os.Remove(path)
-		}
-	}()
-	if _, err = file.Write(data); err != nil {
-		_ = file.Close()
-		return err
-	}
-	if err = file.Sync(); err != nil {
-		_ = file.Close()
-		return err
-	}
-	if err = file.Close(); err != nil {
-		return err
-	}
-	complete = true
-	return nil
+	return fileutil.AtomicCreateFile(path, data, mode)
 }
 
 func newMemoryID(name string, now time.Time) string {


### PR DESCRIPTION
Step 6 of the memory roadmap, the last one: retrieval state and durability.

## RecallIndex

Automatic recall re-read and re-tokenized every fact file from disk on every user turn. The recall pool is now read and tokenized once per memory snapshot (`memory.Load`), and `Set.AutoRecall` serves each turn from that prebuilt index — zero disk IO per turn. Deliberately NOT new invalidation machinery: Markdown files stay the source of truth, and every write path already reloads the snapshot through `memory.Load`, which rebuilds the index with it — the existing immutable-snapshot contract does the invalidation. The V2 shadow pool's field split is prebuilt too. Hand-built Sets (tests, embedders) fall back to an on-the-spot build; indexed-vs-direct equivalence is pinned by test, as is the write→reload→rebuild cycle.

## Unified crash-safe writers

- `writeMemoryAtomic` was a weaker duplicate of `fileutil.AtomicWriteFile` (no Windows filter-driver fallback, no crash-injection instrumentation) — now a thin wrapper over it.
- `writeMemoryCreate` wrote IN PLACE with `O_EXCL`: a crash mid-write could leave a partial fact file as active truth. Now routes through `fileutil.AtomicCreateFile` (complete-or-absent).
- The MEMORY.md index flush was a bare `os.WriteFile` — now atomic as well: derived state, but a torn write would hide facts from the next session's prefix until the next reindex.

Cache-impact: none - performance and durability only; the provider-visible prefix and recall block are byte-identical (boot goldens untouched), and TestSetAutoRecallMatchesStoreScan pins recall-result equivalence
Cache-guard: internal/boot golden suite passes unregenerated
System-prompt-review: esengine - no prompt-visible change; recall semantics pinned equivalent by test
Documentation-impact: none - internal performance/durability work; documented behavior unchanged
