### PR TITLE
feat(agent): price incremental folding as a benchmark arm

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -315,3 +315,16 @@ probe, not a compaction loss.
 Probe answers are scored on whole words, and a wanted answer does not count if a
 rejected one appears anywhere in the same reply — "yes, but it has not been
 re-run since" is the shape a drifting digest produces, and it is not a pass.
+
+### Fold arms
+
+`-arm=full` (default) re-derives every digest from the canonical transcript, so
+digests never chain. `-arm=incremental` folds the model-visible view instead,
+feeding the previous digest back through the summarizer. The arms exist to price
+that trade: run the cost arm for what chaining saves, and the fidelity arm for
+what it costs.
+
+```bash
+go run ./benchmarks/compaction -mode=cost -arm=incremental
+DEEPSEEK_API_KEY=… go run ./benchmarks/compaction -mode=fidelity -arm=incremental
+```

--- a/benchmarks/compaction/main.go
+++ b/benchmarks/compaction/main.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -40,6 +41,7 @@ func main() {
 	report := flag.String("report", "1,2,4,8", "generations to report on")
 	window := flag.Int("window", 128_000, "context window in tokens")
 	control := flag.Bool("control", true, "fidelity: also score probes against full history")
+	arm := flag.String("arm", "full", "full | incremental: re-derive each digest from canonical, or fold the previous projection")
 	out := flag.String("out", "", "write the JSON report here")
 	flag.Parse()
 
@@ -47,11 +49,14 @@ func main() {
 		res []genResult
 		err error
 	)
-	switch *mode {
-	case "cost":
-		res, err = runCost(*gens, *window)
-	case "fidelity":
-		res, err = runFidelity(*gens, *window, *control)
+	incremental := *arm == "incremental"
+	switch {
+	case *arm != "full" && *arm != "incremental":
+		err = fmt.Errorf("unknown arm %q", *arm)
+	case *mode == "cost":
+		res, err = runCost(*gens, *window, incremental)
+	case *mode == "fidelity":
+		res, err = runFidelity(*gens, *window, *control, incremental)
 	default:
 		err = fmt.Errorf("unknown mode %q", *mode)
 	}
@@ -59,9 +64,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	printReport(*mode, res, reportAt(*report))
+	printReport(*mode+" / "+*arm, res, reportAt(*report))
 	if *out != "" {
-		b, _ := json.MarshalIndent(map[string]any{"mode": *mode, "window": *window, "generations": res}, "", "  ")
+		b, _ := json.MarshalIndent(map[string]any{"mode": *mode, "arm": *arm, "window": *window, "generations": res}, "", "  ")
 		if werr := os.WriteFile(*out, append(b, '\n'), 0o644); werr != nil {
 			fmt.Fprintln(os.Stderr, werr)
 			os.Exit(1)
@@ -94,7 +99,7 @@ type harness struct {
 	calls  *callRecorder
 }
 
-func newHarness(t *testingDir, p provider.Provider, window int, rec *callRecorder) *harness {
+func newHarness(t *testingDir, p provider.Provider, window int, rec *callRecorder, incremental bool) *harness {
 	sess := newSession()
 	path := filepath.Join(t.dir, "session.jsonl")
 	a := agent.New(p, tool.NewRegistry(), sess, agent.Options{
@@ -102,8 +107,18 @@ func newHarness(t *testingDir, p provider.Provider, window int, rec *callRecorde
 		ArchiveDir:    filepath.Join(t.dir, "archive"),
 		SessionPath:   path,
 		RecentKeep:    4,
+		Ablation:      foldArm(incremental),
 	}, rec.sink())
 	return &harness{sess: sess, agentA: a, path: path, calls: rec}
+}
+
+// foldArm switches full re-derivation off, which is what makes a fold read the
+// previous projection instead of the canonical transcript.
+func foldArm(incremental bool) ablation.Set {
+	if incremental {
+		return ablation.New(ablation.FullFold)
+	}
+	return ablation.Set{}
 }
 
 // runGeneration grows the session and folds it, returning what that fold cost.
@@ -130,7 +145,7 @@ func (h *harness) runGeneration(ctx context.Context, gen int, probes []probe) ge
 	return r
 }
 
-func runCost(gens, window int) ([]genResult, error) {
+func runCost(gens, window int, incremental bool) ([]genResult, error) {
 	dir, cleanup, err := tempDir()
 	if err != nil {
 		return nil, err
@@ -139,7 +154,7 @@ func runCost(gens, window int) ([]genResult, error) {
 
 	rec := &callRecorder{}
 	p := &scriptedProvider{rec: rec, reply: syntheticDigest, window: window}
-	h := newHarness(dir, p, window, rec)
+	h := newHarness(dir, p, window, rec, incremental)
 
 	var out []genResult
 	for gen := range gens {
@@ -148,7 +163,7 @@ func runCost(gens, window int) ([]genResult, error) {
 	return out, nil
 }
 
-func runFidelity(gens, window int, control bool) ([]genResult, error) {
+func runFidelity(gens, window int, control, incremental bool) ([]genResult, error) {
 	key := os.Getenv("DEEPSEEK_API_KEY")
 	if key == "" {
 		return nil, fmt.Errorf("fidelity mode needs DEEPSEEK_API_KEY")
@@ -164,7 +179,7 @@ func runFidelity(gens, window int, control bool) ([]genResult, error) {
 	defer cleanup()
 
 	rec := &callRecorder{}
-	h := newHarness(dir, &recordingProvider{inner: p, rec: rec}, window, rec)
+	h := newHarness(dir, &recordingProvider{inner: p, rec: rec}, window, rec, incremental)
 	probes := probeSuite()
 
 	ctx := context.Background()
@@ -261,7 +276,7 @@ func printReport(mode string, res []genResult, at map[int]bool) {
 		fmt.Printf("| %d | %d | %d | %d | %d | %d | %.1f | %s |\n",
 			r.Gen+1, r.CanonicalTokens, r.SummarizerCalls, r.SummarizerInput, r.LargestCall, r.ProjectionTokens, r.Seconds, status)
 	}
-	if mode != "fidelity" {
+	if !strings.HasPrefix(mode, "fidelity") {
 		return
 	}
 	classes := probeSuite()

--- a/benchmarks/compaction/main_test.go
+++ b/benchmarks/compaction/main_test.go
@@ -12,7 +12,7 @@ func TestRepeatedFoldsStayBoundedAndKeepSucceeding(t *testing.T) {
 		reserve  = 8192 // summaryOutputReserve: the digest the call must still return
 		maxCalls = 7    // maxSummarySpans + the merge pass
 	)
-	res, err := runCost(gens, window)
+	res, err := runCost(gens, window, false)
 	if err != nil {
 		t.Fatalf("runCost: %v", err)
 	}

--- a/internal/ablation/ablation.go
+++ b/internal/ablation/ablation.go
@@ -16,11 +16,14 @@ const (
 	Subagent   Module = "subagent"
 	Retrieval  Module = "retrieval"
 	Compaction Module = "compaction"
+	// FullFold off means a fold reads the previous projection instead of
+	// re-deriving its digest from the canonical transcript.
+	FullFold Module = "full-fold"
 )
 
 // Modules returns every switchable module in the order arm names use.
 func Modules() []Module {
-	return []Module{Evidence, Planner, Subagent, Retrieval, Compaction}
+	return []Module{Evidence, Planner, Subagent, Retrieval, Compaction, FullFold}
 }
 
 // Set is the group of modules disabled for a run. The zero value is the

--- a/internal/ablation/ablation_test.go
+++ b/internal/ablation/ablation_test.go
@@ -14,7 +14,7 @@ func TestParseAcceptsSpecFormsAndRejectsUnknownModules(t *testing.T) {
 		{"planner,evidence", "no-evidence+no-planner"},
 		{"planner evidence", "no-evidence+no-planner"},
 		{" Evidence , Retrieval ", "no-evidence+no-retrieval"},
-		{"all", "no-evidence+no-planner+no-subagent+no-retrieval+no-compaction"},
+		{"all", "no-evidence+no-planner+no-subagent+no-retrieval+no-compaction+no-full-fold"},
 	} {
 		set, err := Parse(tc.spec)
 		if err != nil {

--- a/internal/agent/compact_incremental_test.go
+++ b/internal/agent/compact_incremental_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/ablation"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// foldAgent builds an agent whose session grows past the verbatim tail every
+// generation, so each CompactNow has something to fold.
+func foldAgent(t *testing.T, prov provider.Provider, incremental bool) (*Agent, *Session) {
+	t.Helper()
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "task"})
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 128_000,
+		RecentKeep:    2,
+		SessionPath:   t.TempDir() + "/session.jsonl",
+		ArchiveDir:    t.TempDir(),
+		Ablation:      foldArmSet(incremental),
+	}, event.Discard)
+	return a, sess
+}
+
+func foldArmSet(incremental bool) ablation.Set {
+	if incremental {
+		return ablation.New(ablation.FullFold)
+	}
+	return ablation.Set{}
+}
+
+func addWork(sess *Session, gen int) {
+	for i := range 8 {
+		id := fmt.Sprintf("g%dc%d", gen, i)
+		sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: id, Name: "read_file", Arguments: "{}"}}})
+		sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: "read_file",
+			Content: strings.Repeat(fmt.Sprintf("gen %d line %d\n", gen, i), 1200)})
+	}
+}
+
+// foldInput runs one generation and returns everything that fold sent the
+// summarizer, joined — a fold may take several calls, and the question is what
+// it read in total.
+func foldInput(t *testing.T, a *Agent, sess *Session, prov *countingProvider, gen int) string {
+	t.Helper()
+	addWork(sess, gen)
+	prov.got = nil
+	if err := a.CompactNow(context.Background(), ""); err != nil {
+		t.Fatalf("gen %d: %v", gen, err)
+	}
+	if len(prov.got) == 0 {
+		t.Fatalf("gen %d folded nothing", gen)
+	}
+	var b strings.Builder
+	for _, req := range prov.got {
+		for _, m := range req.Messages {
+			b.WriteString(m.Content)
+		}
+	}
+	return b.String()
+}
+
+func TestFullFoldRereadsTheOldestHistoryEveryTime(t *testing.T) {
+	// The default arm is what keeps digests from chaining: a later fold still
+	// re-reads the oldest raw work rather than a summary of it.
+	prov := &countingProvider{reply: "digest"}
+	a, sess := foldAgent(t, prov, false)
+	var last string
+	for gen := range 3 {
+		last = foldInput(t, a, sess, prov, gen)
+	}
+	if !strings.Contains(last, "gen 0 line 0") {
+		t.Fatal("a full fold must re-read the oldest raw history")
+	}
+	if strings.Contains(last, summaryTagOpen) {
+		t.Fatal("a full fold must not feed its own prior digest back in")
+	}
+}
+
+func TestIncrementalFoldFeedsThePriorDigestInsteadOfRereading(t *testing.T) {
+	prov := &countingProvider{reply: "digest"}
+	a, sess := foldAgent(t, prov, true)
+	var last string
+	for gen := range 3 {
+		last = foldInput(t, a, sess, prov, gen)
+	}
+	if !strings.Contains(last, summaryTagOpen) {
+		t.Fatalf("an incremental fold must feed the prior digest back in:\n%.200q", last)
+	}
+	if strings.Contains(last, "gen 0 line 0") {
+		t.Fatal("an incremental fold must not re-read history the prior digest already covers")
+	}
+}
+
+func TestIncrementalFoldKeepsTheProjectionValidAgainstCanonical(t *testing.T) {
+	// The fold reads the projection, but its coverage bookkeeping still indexes
+	// the canonical transcript — otherwise the next turn rebuilds from scratch.
+	prov := &countingProvider{reply: "digest"}
+	a, sess := foldAgent(t, prov, true)
+	for gen := range 2 {
+		foldInput(t, a, sess, prov, gen)
+	}
+	canonical, version := a.session.snapshotMessagesVersion()
+	st := a.compactionState
+	if st.Projection.CoveredCount != len(canonical) {
+		t.Fatalf("CoveredCount = %d, want %d (the canonical length)", st.Projection.CoveredCount, len(canonical))
+	}
+	if !projectionValid(st, canonical, version, a.currentPromptCacheKey()) {
+		t.Fatal("incremental fold left the projection invalid against the canonical transcript")
+	}
+	if visible := a.modelVisibleMessages(); len(visible) >= len(canonical) {
+		t.Fatalf("model-visible = %d messages vs canonical %d; the fold saved nothing", len(visible), len(canonical))
+	}
+}
+
+func TestIncrementalFoldFallsBackToCanonicalWithoutAProjection(t *testing.T) {
+	prov := &countingProvider{reply: "digest"}
+	a, sess := foldAgent(t, prov, true)
+	if first := foldInput(t, a, sess, prov, 0); !strings.Contains(first, "gen 0 line 0") {
+		t.Fatal("the first fold has no projection to read and must fold the canonical transcript")
+	}
+}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/ablation"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
@@ -401,19 +402,11 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // installed (nothing to fold); callers at the force threshold must treat that
 // as a hard failure rather than sending the oversized canonical prompt.
 func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
-	msgs, transcriptVersion := a.session.snapshotMessagesVersion()
-	head, start, ok := a.planCompaction(msgs, minCompactMessages)
-	if !ok {
-		head, start, ok = a.planCompaction(msgs, 1)
-	}
+	canonical, transcriptVersion := a.session.snapshotMessagesVersion()
+	msgs := a.foldSource(canonical)
+	head, start, ok := a.planFoldRegion(msgs)
 	if !ok {
 		return CompactionNoop, nil
-	}
-	if active := a.activeTurnStart(msgs); active >= head && active < start {
-		start = active
-		if start <= head {
-			return CompactionNoop, nil
-		}
 	}
 	region := msgs[head:start]
 	early, kept, fold := a.partitionFoldForProjection(region)
@@ -456,7 +449,7 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		archived = path
 	}
 
-	sourceTokens := estimateMessagesTokens(provider.ModelMessages(msgs))
+	sourceTokens := estimateMessagesTokens(provider.ModelMessages(canonical))
 	res, err := a.foldToSummary(ctx, fold, instructions)
 	summary := res.Text
 	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
@@ -495,8 +488,8 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 			Messages:          projMsgs,
 			TranscriptVersion: transcriptVersion,
 			ProjectionVersion: projVersion,
-			CoveredCount:      len(msgs),
-			CoveredPrefixHash: coveredPrefixHash(msgs, len(msgs)),
+			CoveredCount:      len(canonical),
+			CoveredPrefixHash: coveredPrefixHash(canonical, len(canonical)),
 			SummaryHash:       summaryContentHash(summary),
 			SourceTokens:      sourceTokens,
 			ProjectionTokens:  projTokens,
@@ -523,6 +516,38 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
 	}})
 	return CompactionInstalled, nil
+}
+
+// planFoldRegion locates msgs[head:start] for a fold, stopping short of an
+// active turn so a tool loop is never folded mid-flight. ok is false when there
+// is nothing left to fold.
+func (a *Agent) planFoldRegion(msgs []provider.Message) (head, start int, ok bool) {
+	head, start, ok = a.planCompaction(msgs, minCompactMessages)
+	if !ok {
+		head, start, ok = a.planCompaction(msgs, 1)
+	}
+	if !ok {
+		return head, start, false
+	}
+	if active := a.activeTurnStart(msgs); active >= head && active < start {
+		start = active
+	}
+	return head, start, start > head
+}
+
+// foldSource picks what a fold reads. By default every fold re-derives its
+// digest from the canonical transcript, so digests never chain — at the cost of
+// re-reading the whole session each time. The incremental experiment folds the
+// model-visible view instead, which feeds the previous digest back through the
+// summarizer: cheaper per fold, and lossy in a way CompactionBench measures.
+func (a *Agent) foldSource(canonical []provider.Message) []provider.Message {
+	if !a.ablation.Off(ablation.FullFold) {
+		return canonical
+	}
+	if visible := a.modelVisibleMessages(); len(visible) > 0 {
+		return visible
+	}
+	return canonical
 }
 
 // partitionFoldForProjection splits the fold region three ways: user turns


### PR DESCRIPTION
Stacked on #8024 → #8021 → #8019. Same CI caveat as #8024: workflows filter `branches: [main-v2]`, so this runs only `label` until the stack lands.

## The question

Every fold re-derives its digest from the canonical transcript. That is what keeps digests from chaining, and #8024 priced what it costs: by generation 8, one fold reads 448k tokens across 5 summarizer calls, growing without bound.

The obvious optimization is to fold the previous projection instead — reuse the digest, summarize only what is new. That is the "summary of a summary" this work started out worried about. Rather than argue about it, this PR implements it as an arm and measures both sides.

## Cost: O(n) → O(1)

`go run ./benchmarks/compaction -mode=cost -gens=8 -arm=…`

| gen | full: calls | full: input tok | incremental: calls | incremental: input tok |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1 | 13 963 | 1 | 13 963 |
| 2 | 1 | 88 323 | 1 | 76 239 |
| 4 | 3 | 200 218 | 1 | 75 607 |
| 6 | 4 | 324 129 | 1 | 75 607 |
| 8 | 5 | 448 040 | 1 | 75 607 |

Flat from generation 2 on: one call, ~76k tokens, forever. Against a real provider the wall-clock difference is the same shape — 109s at generation 8 for the full arm, 11.6s for the incremental one.

## Fidelity: it loses facts, and silently

`-mode=fidelity -gens=8` against DeepSeek, both arms, same probes, each scored against a full-history control:

```
full arm         71/71 survived
incremental arm  53/71 survived
```

| probe | full | incremental |
| --- | --- | --- |
| user-constraint, correction, objective, pending-requirement, verification-freshness, negative-evidence, tool-outcome | ok at every gen | ok at every gen |
| **exact-identifier** | ok at every gen | **LOST from gen 2 on, permanently** |
| **code-fact** | ok at every gen | **LOST from gen 4 on** |
| chronology | ok at every gen | lost at gen 4, back at gen 8 (noisy) |

What the incremental arm actually answers when asked for the ticket id it was told once, in a user turn, at generation 0:

```
gen 2: No ticket ID is present in the conversation.
gen 4: unknown
gen 8: I don't have a ticket id from the conversation.
```

The mechanism is visible in the shape of the loss. `RX-4821` is stated in a small user turn that falls outside the three-turn hoist window, so it survives only inside the digest. The first re-summarization drops it, and because the incremental arm never reads the canonical transcript again, **it can never come back**. The full arm re-derives from raw every time, so the same fact is recovered at every generation.

Note what did *not* drift: `verification-freshness` — "has this test been re-run since the code changed" — survived all eight generations in both arms. The failure mode is dropped identifiers and dropped code facts, not the stale-verification semantics that motivated this line of work.

## Why it lands as an arm

Off by default, no config key, no `Options` field, nothing in SPEC. `full-fold` joins the ablation package, which exists to attribute a benchmark result to one mechanism — and full re-derivation is exactly such a mechanism. `-arm=incremental` in the bench, `--ablate full-fold` for the e2e suite.

That also keeps the door open for the real answer, which the numbers now argue for rather than assume: fold incrementally for the cost, and carry the classes that drift (identifiers, stated constraints, code facts) forward as host-owned state instead of trusting a digest to re-copy them. That is a separate PR with a measured target — 53/71 back to 71/71 at 1 call per fold.

## Also here

`planFoldRegion` is extracted from `compactToProjection`: the fold source and the region plan are separate decisions, and the function was over the size limit with both inline.

## Local gate

`gofmt` clean · `go vet ./internal/... ./benchmarks/...` clean · `go run ./tools/repolint` clean (1973 baselined, not widened) · `go test ./internal/... ./benchmarks/...` all ok

Four tests pin the semantics: the full arm still re-reads the oldest raw history and never eats its own digest; the incremental arm does the opposite; coverage bookkeeping still indexes the canonical transcript so the projection stays valid; and the first fold, having no projection to read, falls back to canonical.

Cache-impact: none - default behavior is byte-identical. The arm is off unless a benchmark switches it on, and it changes only what the summarizer reads inside a fold, never the stable prompt prefix.
Cache-guard: go test ./internal/agent/ -run 'TestFullFold|TestIncrementalFold|TestProjection|TestCompact'
Documentation-impact: none - the arm is a benchmark switch with no user-visible surface; benchmarks/README.md documents how to run it.
