### PR TITLE
feat(completion): the host-authored completion report — silence stops hiding gaps

### DIFF
--- a/cmd/e2ebench/mechanisms.go
+++ b/cmd/e2ebench/mechanisms.go
@@ -174,3 +174,64 @@ func renderContractShadow(results []result) string {
 	return fmt.Sprintf("**Contract shadow**: verdicts %s · **agreement with grader** %s (%d/%d)\n\n",
 		strings.Join(parts, " · "), pct(agree, agree+disagree), agree, agree+disagree)
 }
+
+// renderCompletionReport prices the host-authored receipt against the hidden
+// grader. Overclaim — "done" on a task the grader failed — is the number this
+// whole mechanism exists to drive down; caught is its counterpart, the share
+// of failed runs whose receipt already named a gap.
+func renderCompletionReport(results []result) string {
+	verdicts := map[string]int{}
+	kinds := map[string]int{}
+	recorded, done, overclaim, failed, caught := 0, 0, 0, 0, 0
+	for _, r := range results {
+		t := r.Trajectory
+		if t == nil || t.CompletionVerdict == "" {
+			continue
+		}
+		recorded++
+		verdicts[t.CompletionVerdict]++
+		for _, kind := range t.CompletionGapKinds {
+			kinds[kind]++
+		}
+		if t.CompletionVerdict == "done" {
+			done++
+			if !r.Passed {
+				overclaim++
+			}
+		}
+		if !r.Passed {
+			failed++
+			if t.CompletionGaps > 0 {
+				caught++
+			}
+		}
+	}
+	if recorded == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(verdicts))
+	for _, v := range []string{"done", "partial", "incomplete", "unknown"} {
+		if verdicts[v] > 0 {
+			parts = append(parts, fmt.Sprintf("%s ×%d", v, verdicts[v]))
+		}
+	}
+	line := fmt.Sprintf("**Completion report**: verdicts %s · **overclaim** %s (%d/%d done runs the grader failed)",
+		strings.Join(parts, " · "), pct(overclaim, done), overclaim, done)
+	if failed > 0 {
+		line += fmt.Sprintf(" · **caught** %s (%d/%d failed runs declared a gap)", pct(caught, failed), caught, failed)
+	}
+	if census := gapCensus(kinds); census != "" {
+		line += " · gaps " + census
+	}
+	return line + "\n\n"
+}
+
+func gapCensus(kinds map[string]int) string {
+	var parts []string
+	for _, kind := range []string{"unproven_criterion", "missing_check", "failed_verification", "stale_verification", "unverified_change", "unreviewed_change"} {
+		if kinds[kind] > 0 {
+			parts = append(parts, fmt.Sprintf("%s ×%d", kind, kinds[kind]))
+		}
+	}
+	return strings.Join(parts, " · ")
+}

--- a/cmd/e2ebench/mechanisms_test.go
+++ b/cmd/e2ebench/mechanisms_test.go
@@ -165,6 +165,51 @@ func TestRenderContractShadowAgreement(t *testing.T) {
 	}
 }
 
+func TestRenderCompletionReportPricesOverclaim(t *testing.T) {
+	honest := result{task: task{ID: "a"}, Passed: true}
+	honest.Trajectory = &trajectorySummary{CompletionVerdict: "done"}
+	overclaimed := result{task: task{ID: "b"}, Passed: false}
+	overclaimed.Trajectory = &trajectorySummary{CompletionVerdict: "done"}
+	warned := result{task: task{ID: "c"}, Passed: false}
+	warned.Trajectory = &trajectorySummary{
+		CompletionVerdict: "partial", CompletionGaps: 2,
+		CompletionGapKinds: []string{"unreviewed_change", "stale_verification"},
+	}
+	got := renderCompletionReport([]result{honest, overclaimed, warned})
+	for _, want := range []string{
+		"verdicts done ×2 · partial ×1",
+		"**overclaim** 50% (1/2 done runs the grader failed)",
+		"**caught** 50% (1/2 failed runs declared a gap)",
+		"gaps stale_verification ×1 · unreviewed_change ×1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("completion line missing %q:\n%s", want, got)
+		}
+	}
+	if renderCompletionReport([]result{{task: task{ID: "d"}}}) != "" {
+		t.Fatal("runs without completion audits must render nothing")
+	}
+}
+
+func TestSummarizeTrajectoryReadsCompletionReport(t *testing.T) {
+	path := t.TempDir() + "/completion.trajectory.jsonl"
+	lines := []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"completion_report":{"verdict":"partial","gaps":1,"gap_kinds":["unreviewed_change"]}}`,
+		`{"seq":3,"ts":3000,"event":{"kind":"turn_done"}}`,
+	}
+	if err := writeLines(path, lines); err != nil {
+		t.Fatal(err)
+	}
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.CompletionVerdict != "partial" || s.CompletionGaps != 1 || len(s.CompletionGapKinds) != 1 {
+		t.Fatalf("completion = %q/%d/%v", s.CompletionVerdict, s.CompletionGaps, s.CompletionGapKinds)
+	}
+}
+
 func TestSummarizeTrajectoryReadsContractShadow(t *testing.T) {
 	path := t.TempDir() + "/shadow.trajectory.jsonl"
 	lines := []string{

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -193,6 +193,7 @@ func renderBody(results []result) string {
 	b.WriteString(renderSolveProfiles(results))
 	b.WriteString(renderToolSurface(results))
 	b.WriteString(renderContractShadow(results))
+	b.WriteString(renderCompletionReport(results))
 	b.WriteString(renderOutcomeProgress(results))
 	b.WriteString(renderMemoryShadow(results))
 	b.WriteString(renderCognition(results))

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -105,6 +105,12 @@ type trajectorySummary struct {
 	ShadowVerdict  string `json:"shadow_verdict,omitempty"`
 	ShadowComplete bool   `json:"shadow_complete,omitempty"`
 
+	// Completion report (last of the turn): the host-authored receipt's
+	// verdict and the gaps it refused to hide, priced against the grader.
+	CompletionVerdict  string   `json:"completion_verdict,omitempty"`
+	CompletionGaps     int      `json:"completion_gaps,omitempty"`
+	CompletionGapKinds []string `json:"completion_gap_kinds,omitempty"`
+
 	// Outcome shadow: the runtime outcome scorer's per-round series condensed,
 	// or a verification-receipt backfill for recordings that predate it.
 	Outcome *outcomeSummary `json:"outcome,omitempty"`
@@ -143,6 +149,11 @@ type trajectoryRecord struct {
 		Verdict  string `json:"verdict"`
 		Complete bool   `json:"complete"`
 	} `json:"contract_shadow"`
+	CompletionReport *struct {
+		Verdict  string   `json:"verdict"`
+		Gaps     int      `json:"gaps"`
+		GapKinds []string `json:"gap_kinds"`
+	} `json:"completion_report"`
 	OutcomeProgress *struct {
 		Exploration      int  `json:"exploration"`
 		Verification     int  `json:"verification"`
@@ -355,6 +366,11 @@ func (t *trajScan) record(rec trajectoryRecord) {
 		t.s.ShadowIntent = cs.Intent
 		t.s.ShadowVerdict = cs.Verdict
 		t.s.ShadowComplete = cs.Complete
+	}
+	if cr := rec.CompletionReport; cr != nil {
+		t.s.CompletionVerdict = cr.Verdict
+		t.s.CompletionGaps = cr.Gaps
+		t.s.CompletionGapKinds = cr.GapKinds
 	}
 	if op := rec.OutcomeProgress; op != nil {
 		t.outcomePoints = append(t.outcomePoints, outcomePoint{

--- a/internal/agent/completion_shadow.go
+++ b/internal/agent/completion_shadow.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"reasonix/internal/completion"
+	"reasonix/internal/event"
+	"reasonix/internal/taskcontract"
+)
+
+// completionReportAudit reduces a completion report to its content-free
+// summary: counts, enums, and gap kinds, never a path or a command.
+func completionReportAudit(rep completion.Report) event.CompletionReportAudit {
+	audit := event.CompletionReportAudit{
+		Verdict:  rep.Verdict.String(),
+		Risk:     riskName(rep.Risk),
+		Gaps:     len(rep.Gaps),
+		GapKinds: rep.GapKinds(),
+	}
+	for _, criterion := range rep.Criteria {
+		if !criterion.Required {
+			continue
+		}
+		audit.Criteria++
+		if criterion.Status == taskcontract.Satisfied {
+			audit.CriteriaSatisfied++
+		}
+	}
+	audit.Changes = len(rep.Changes)
+	for _, change := range rep.Changes {
+		if !change.Reviewed {
+			audit.ChangesUnreviewed++
+		}
+	}
+	audit.Verifications = len(rep.Verifications)
+	for _, verification := range rep.Verifications {
+		switch {
+		case !verification.Passed:
+			audit.VerificationsFailed++
+		case verification.Stale:
+			audit.VerificationsStale++
+		}
+	}
+	return audit
+}
+
+func riskName(r taskcontract.Risk) string {
+	switch r {
+	case taskcontract.RiskHigh:
+		return "high"
+	case taskcontract.RiskMedium:
+		return "medium"
+	default:
+		return "low"
+	}
+}

--- a/internal/agent/completion_shadow_test.go
+++ b/internal/agent/completion_shadow_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"slices"
+	"testing"
+
+	"reasonix/internal/completion"
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+)
+
+func shadowReport(input string, receipts ...evidence.Receipt) (event.ContractShadowAudit, event.CompletionReportAudit) {
+	ledger := evidence.NewLedger()
+	for _, r := range receipts {
+		ledger.Record(r)
+	}
+	c := buildShadowContract(input, ledger.Receipts())
+	return contractShadowAudit(c), completionReportAudit(completion.Build(c, ledger))
+}
+
+// A green contract is not automatically a clean report: this turn changed
+// calc.py, verified it, and never looked at the result.
+func TestCompletionShadowFlagsWhatTheContractCallsComplete(t *testing.T) {
+	contract, report := shadowReport("fix the add bug in calc.py",
+		evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "fix add()", Status: "completed"},
+		}},
+		evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"calc.py"}},
+		evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true, OutputBytes: 64},
+	)
+	if !contract.Complete {
+		t.Fatalf("contract = %+v, want complete — the report's disagreement is the point", contract)
+	}
+	if report.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial: the changed file was never inspected", report.Verdict)
+	}
+	if report.Changes != 1 || report.ChangesUnreviewed != 1 {
+		t.Fatalf("changes = %d, unreviewed = %d, want 1/1", report.Changes, report.ChangesUnreviewed)
+	}
+	if report.Verifications != 1 || report.VerificationsFailed != 0 || report.VerificationsStale != 0 {
+		t.Fatalf("verifications = %+v, want one fresh pass", report)
+	}
+	if !slices.Equal(report.GapKinds, []string{"unreviewed_change"}) {
+		t.Fatalf("gap kinds = %v, want [unreviewed_change]", report.GapKinds)
+	}
+}
+
+func TestCompletionShadowReportsDoneWhenTheChangeWasInspected(t *testing.T) {
+	_, report := shadowReport("fix the add bug in calc.py",
+		evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"calc.py"}},
+		evidence.Receipt{ToolName: "read_file", Read: true, Success: true, Paths: []string{"calc.py"}, OutputBytes: 64},
+		evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: true, OutputBytes: 64},
+	)
+	if report.Verdict != "done" {
+		t.Fatalf("verdict = %q, want done; gaps %v", report.Verdict, report.GapKinds)
+	}
+	if report.Gaps != 0 {
+		t.Fatalf("gaps = %d, want none", report.Gaps)
+	}
+}
+
+func TestCompletionShadowCountsFailedVerification(t *testing.T) {
+	_, report := shadowReport("fix the add bug in calc.py",
+		evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"calc.py"}},
+		evidence.Receipt{ToolName: "read_file", Read: true, Success: true, Paths: []string{"calc.py"}, OutputBytes: 64},
+		evidence.Receipt{ToolName: "bash", Command: "go test ./...", Success: false, OutputBytes: 64},
+	)
+	if report.VerificationsFailed != 1 {
+		t.Fatalf("failed verifications = %d, want 1", report.VerificationsFailed)
+	}
+	if !slices.Contains(report.GapKinds, "failed_verification") {
+		t.Fatalf("gap kinds = %v, want the failure recorded", report.GapKinds)
+	}
+}
+
+func TestCompletionShadowStaysQuietOnAConversationTurn(t *testing.T) {
+	_, report := shadowReport("what does this function do?",
+		evidence.Receipt{ToolName: "read_file", Read: true, Success: true, Paths: []string{"calc.py"}, OutputBytes: 64},
+	)
+	if report.Verdict != "unknown" {
+		t.Fatalf("verdict = %q, want unknown for a read-only answer", report.Verdict)
+	}
+	if report.Gaps != 0 {
+		t.Fatalf("gaps = %d, want none — nothing was claimed", report.Gaps)
+	}
+}

--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 
+	"reasonix/internal/completion"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/taskcontract"
@@ -83,12 +84,14 @@ func intentName(i taskintent.Intent) string {
 	}
 }
 
-// emitContractShadow records the shadow contract's end-of-turn summary; the
-// contract observed the turn and decided nothing.
-func (a *Agent) emitContractShadow(input string) {
+// emitTurnShadows records the end-of-turn shadow observations from one replay
+// of the turn's receipts: the contract's state, and the completion report
+// derived from it. Both observe; neither decides.
+func (a *Agent) emitTurnShadows(input string) {
 	if a.evidence == nil {
 		return
 	}
 	c := buildShadowContract(input, a.evidence.Receipts())
 	event.RecordContractShadow(a.sink, contractShadowAudit(c))
+	event.RecordCompletionReport(a.sink, completionReportAudit(completion.Build(c, a.evidence)))
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -938,7 +938,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 	if readiness.applies {
 		event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, a.readinessRecovered))
 	}
-	a.emitContractShadow(state.input)
+	a.emitTurnShadows(state.input)
 	if !a.closeSteerIntakeIfIdle() {
 		return true, nil
 	}

--- a/internal/completion/doc.go
+++ b/internal/completion/doc.go
@@ -1,0 +1,20 @@
+// Package completion assembles the host-authored completion report: the
+// evidence-backed answer to "is this done, and what is not proven?".
+//
+// The model never authors this record. It may claim a task is complete, but
+// every factual field here is derived from the task contract and the evidence
+// ledger: which acceptance criteria carry fresh proof, which paths the turn
+// changed, which verification commands ran and how they exited. What the
+// report adds beyond the contract is subtraction — a change nobody looked at
+// again, a mutation no verification followed, a command that passed only
+// before the latest edit. Silence cannot hide those, because the host computes
+// them instead of reading them off a claim.
+//
+// A report is therefore not a gate. Its verdict separates work that lacks
+// proof (Incomplete) from work that is proven but carries declared gaps
+// (Partial); the latter is a legitimate terminal state. The contract decides
+// whether the agent may stop, the report decides what the user is told when it
+// does.
+//
+// Building a report makes no model call and mutates nothing.
+package completion

--- a/internal/completion/report.go
+++ b/internal/completion/report.go
@@ -1,0 +1,317 @@
+package completion
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskcontract"
+)
+
+// Verdict is the report's headline. Partial is terminal: the work is proven
+// against its criteria, and the gaps it still carries are declared rather
+// than hidden.
+type Verdict uint8
+
+const (
+	VerdictUnknown Verdict = iota
+	VerdictIncomplete
+	VerdictPartial
+	VerdictDone
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case VerdictIncomplete:
+		return "incomplete"
+	case VerdictPartial:
+		return "partial"
+	case VerdictDone:
+		return "done"
+	default:
+		return "unknown"
+	}
+}
+
+// Criterion is one acceptance criterion and the proof the ledger attached.
+type Criterion struct {
+	ID       string
+	Text     string
+	Required bool
+	Status   taskcontract.Status
+	Proofs   int // successful evidence refs attached to it
+}
+
+// Change is one path the turn mutated. Reviewed reports whether the changed
+// result was inspected after the last write to it.
+type Change struct {
+	Path     string
+	Reviewed bool
+}
+
+// Verification is a delivery-verification command's latest outcome. Stale
+// means it last ran before the newest mutation, so it proves nothing about
+// the current tree.
+type Verification struct {
+	Command string
+	Passed  bool
+	Stale   bool
+}
+
+// GapKind classifies one thing the report refuses to present as verified.
+type GapKind uint8
+
+const (
+	GapUnprovenCriterion GapKind = iota
+	GapMissingCheck
+	GapFailedVerification
+	GapStaleVerification
+	GapUnverifiedChange
+	GapUnreviewedChange
+)
+
+func (k GapKind) String() string {
+	switch k {
+	case GapUnprovenCriterion:
+		return "unproven_criterion"
+	case GapMissingCheck:
+		return "missing_check"
+	case GapFailedVerification:
+		return "failed_verification"
+	case GapStaleVerification:
+		return "stale_verification"
+	case GapUnverifiedChange:
+		return "unverified_change"
+	case GapUnreviewedChange:
+		return "unreviewed_change"
+	default:
+		return "unknown"
+	}
+}
+
+// Gap is one unproven thing, in the report's own words.
+type Gap struct {
+	Kind   GapKind
+	Detail string
+}
+
+// Report is the host's completion record for one turn.
+type Report struct {
+	Verdict Verdict
+	Risk    taskcontract.Risk
+	// Mutations counts every successful mutating receipt, including ones that
+	// named no path; Changes lists only the paths.
+	Mutations     int
+	Criteria      []Criterion
+	Changes       []Change
+	Verifications []Verification
+	Gaps          []Gap
+}
+
+// Build derives the report from a contract and the turn's receipts. Both may
+// be nil: a nil contract means nothing declared acceptance criteria, which
+// leaves the ledger alone to speak.
+func Build(c *taskcontract.Contract, ledger *evidence.Ledger) Report {
+	receipts := ledger.Receipts()
+	rep := Report{
+		Mutations:     mutationsOf(receipts),
+		Criteria:      criteriaOf(c),
+		Changes:       changesOf(ledger, receipts),
+		Verifications: verificationsOf(receipts),
+	}
+	if c != nil {
+		rep.Risk = c.Risk
+	}
+	rep.Gaps = gapsOf(rep, c)
+	rep.Verdict = verdictOf(rep, c)
+	return rep
+}
+
+func criteriaOf(c *taskcontract.Contract) []Criterion {
+	if c == nil {
+		return nil
+	}
+	out := make([]Criterion, 0, len(c.Requirements))
+	for _, req := range c.Requirements {
+		proofs := 0
+		for _, ref := range req.Evidence {
+			if ref.Success {
+				proofs++
+			}
+		}
+		out = append(out, Criterion{
+			ID:       req.ID,
+			Text:     req.Text,
+			Required: req.Required,
+			Status:   req.Status,
+			Proofs:   proofs,
+		})
+	}
+	return out
+}
+
+// changesOf lists mutated paths in first-write order and asks the ledger
+// whether each one was inspected after its own latest write, so a review that
+// covered one file never vouches for another.
+func changesOf(ledger *evidence.Ledger, receipts []evidence.Receipt) []Change {
+	var out []Change
+	at := map[string]int{}
+	lastWrite := map[string]int{}
+	for i, r := range receipts {
+		if !r.Success || !(r.Mutation || r.Write) {
+			continue
+		}
+		for _, p := range r.Paths {
+			if p == "" {
+				continue
+			}
+			if _, seen := at[p]; !seen {
+				at[p] = len(out)
+				out = append(out, Change{Path: p})
+			}
+			lastWrite[p] = i
+		}
+	}
+	for i := range out {
+		out[i].Reviewed = ledger.HasHostReviewCoverageAfter(lastWrite[out[i].Path], []string{out[i].Path})
+	}
+	return out
+}
+
+// mutationsOf counts successful mutating receipts, path-named or not: a
+// `sed -i` or `rm` that named nothing still changed the workspace, and must
+// not escape the unverified-change gap by leaving no path behind.
+func mutationsOf(receipts []evidence.Receipt) int {
+	count := 0
+	for _, r := range receipts {
+		if r.Success && (r.Mutation || r.Write) {
+			count++
+		}
+	}
+	return count
+}
+
+// verificationsOf keeps each delivery-verification command's latest run, in
+// first-run order, and marks the ones that predate the newest mutation.
+func verificationsOf(receipts []evidence.Receipt) []Verification {
+	lastMutation := -1
+	for i, r := range receipts {
+		if r.Success && (r.Mutation || r.Write) {
+			lastMutation = i
+		}
+	}
+	var out []Verification
+	at := map[string]int{}
+	for i, r := range receipts {
+		command := strings.TrimSpace(r.Command)
+		if command == "" || !evidence.IsDeliveryVerificationCommand(command) {
+			continue
+		}
+		if _, seen := at[command]; !seen {
+			at[command] = len(out)
+			out = append(out, Verification{Command: command})
+		}
+		out[at[command]].Passed = r.Success
+		out[at[command]].Stale = i < lastMutation
+	}
+	return out
+}
+
+func gapsOf(rep Report, c *taskcontract.Contract) []Gap {
+	var gaps []Gap
+	for _, cr := range rep.Criteria {
+		if cr.Required && cr.Status != taskcontract.Satisfied {
+			gaps = append(gaps, Gap{GapUnprovenCriterion, fmt.Sprintf("%s: %s", cr.ID, cr.Text)})
+		}
+	}
+	missingCheck := false
+	if c != nil {
+		for _, check := range c.Checks {
+			if check.Status == taskcontract.Satisfied {
+				continue
+			}
+			missingCheck = true
+			gaps = append(gaps, Gap{GapMissingCheck, checkLabel(check)})
+		}
+	}
+	proven := false
+	for _, v := range rep.Verifications {
+		switch {
+		case !v.Passed:
+			gaps = append(gaps, Gap{GapFailedVerification, v.Command})
+		case v.Stale:
+			gaps = append(gaps, Gap{GapStaleVerification, v.Command})
+		default:
+			proven = true
+		}
+	}
+	// Only report the blanket gap when no declared check already said it: a
+	// contract with checks states the same absence in more specific words.
+	if rep.Mutations > 0 && !proven && !missingCheck {
+		gaps = append(gaps, Gap{GapUnverifiedChange, "no verification passed after the latest change"})
+	}
+	for _, ch := range rep.Changes {
+		if !ch.Reviewed {
+			gaps = append(gaps, Gap{GapUnreviewedChange, ch.Path})
+		}
+	}
+	return gaps
+}
+
+func checkLabel(check taskcontract.Check) string {
+	switch {
+	case check.Command != "":
+		return check.Command
+	case check.Kind == taskcontract.CheckMutation:
+		return "the required change"
+	default:
+		return "any verification"
+	}
+}
+
+func verdictOf(rep Report, c *taskcontract.Contract) Verdict {
+	declared := c != nil && (len(c.Requirements) > 0 || len(c.Checks) > 0)
+	switch {
+	case !declared && rep.Mutations == 0 && len(rep.Verifications) == 0:
+		return VerdictUnknown
+	case c != nil && !c.Complete():
+		return VerdictIncomplete
+	case len(rep.Gaps) > 0:
+		return VerdictPartial
+	default:
+		return VerdictDone
+	}
+}
+
+// Summary is the one-line report headline for logs and host notes.
+func (r Report) Summary() string {
+	satisfied := 0
+	required := 0
+	for _, cr := range r.Criteria {
+		if !cr.Required {
+			continue
+		}
+		required++
+		if cr.Status == taskcontract.Satisfied {
+			satisfied++
+		}
+	}
+	return fmt.Sprintf("%s · criteria %d/%d · changes %d · verifications %d · gaps %d",
+		r.Verdict, satisfied, required, len(r.Changes), len(r.Verifications), len(r.Gaps))
+}
+
+// GapKinds lists the distinct gap kinds present, in declaration order, so a
+// content-free audit can carry what kind of proof is missing.
+func (r Report) GapKinds() []string {
+	seen := map[GapKind]bool{}
+	var out []string
+	for _, kind := range []GapKind{GapUnprovenCriterion, GapMissingCheck, GapFailedVerification, GapStaleVerification, GapUnverifiedChange, GapUnreviewedChange} {
+		for _, gap := range r.Gaps {
+			if gap.Kind == kind && !seen[kind] {
+				seen[kind] = true
+				out = append(out, kind.String())
+			}
+		}
+	}
+	return out
+}

--- a/internal/completion/report_test.go
+++ b/internal/completion/report_test.go
@@ -1,0 +1,222 @@
+package completion
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskcontract"
+)
+
+func ledgerOf(receipts ...evidence.Receipt) *evidence.Ledger {
+	l := evidence.NewLedger()
+	for _, r := range receipts {
+		l.Record(r)
+	}
+	return l
+}
+
+func wrote(path string) evidence.Receipt {
+	return evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Mutation: true, Paths: []string{path}}
+}
+
+func read(path string) evidence.Receipt {
+	return evidence.Receipt{ToolName: "read_file", Success: true, Read: true, Paths: []string{path}, OutputBytes: 64}
+}
+
+func ran(command string, ok bool) evidence.Receipt {
+	return evidence.Receipt{ToolName: "bash", Success: ok, Command: command, OutputBytes: 64}
+}
+
+func gapKinds(rep Report) []string { return rep.GapKinds() }
+
+func TestBuildWithNothingToJudgeStaysUnknown(t *testing.T) {
+	rep := Build(nil, evidence.NewLedger())
+	if rep.Verdict != VerdictUnknown {
+		t.Fatalf("verdict = %v, want unknown for a turn with no contract and no receipts", rep.Verdict)
+	}
+	if len(rep.Gaps) != 0 {
+		t.Fatalf("gaps = %+v, want none", rep.Gaps)
+	}
+}
+
+func TestBuildIsDoneWhenChangeIsVerifiedAndReviewed(t *testing.T) {
+	c := taskcontract.New("fix the parser")
+	c.AddRequirement("r1", "parser accepts empty input", true)
+	c.AddCheck("go test ./...")
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"), ran("go test ./...", true))
+	for _, r := range ledger.Receipts() {
+		c.Observe(r)
+	}
+	c.Resolve("r1", taskcontract.Satisfied, taskcontract.EvidenceRef{Kind: taskcontract.EvidenceVerification, MutationEpoch: c.Epoch(), Success: true})
+
+	rep := Build(c, ledger)
+	if rep.Verdict != VerdictDone {
+		t.Fatalf("verdict = %v (%s), want done; gaps %+v", rep.Verdict, rep.Summary(), rep.Gaps)
+	}
+	if len(rep.Changes) != 1 || !rep.Changes[0].Reviewed {
+		t.Fatalf("changes = %+v, want parser.go reviewed", rep.Changes)
+	}
+	if len(rep.Verifications) != 1 || !rep.Verifications[0].Passed || rep.Verifications[0].Stale {
+		t.Fatalf("verifications = %+v, want one fresh pass", rep.Verifications)
+	}
+	if rep.Criteria[0].Proofs != 1 {
+		t.Fatalf("criterion proofs = %d, want 1", rep.Criteria[0].Proofs)
+	}
+}
+
+func TestBuildReportsUnreviewedChangeAsPartial(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), ran("go test ./...", true))
+
+	rep := Build(nil, ledger)
+	if rep.Verdict != VerdictPartial {
+		t.Fatalf("verdict = %v, want partial: a verified but never-inspected change is not a clean done", rep.Verdict)
+	}
+	if got := gapKinds(rep); !slices.Equal(got, []string{"unreviewed_change"}) {
+		t.Fatalf("gap kinds = %v, want [unreviewed_change]", got)
+	}
+	if rep.Gaps[0].Detail != "parser.go" {
+		t.Fatalf("gap detail = %q, want the unreviewed path", rep.Gaps[0].Detail)
+	}
+}
+
+func TestBuildReportsMutationWithNoVerificationAtAll(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"))
+
+	rep := Build(nil, ledger)
+	if got := gapKinds(rep); !slices.Equal(got, []string{"unverified_change"}) {
+		t.Fatalf("gap kinds = %v, want [unverified_change]", got)
+	}
+	if rep.Verdict != VerdictPartial {
+		t.Fatalf("verdict = %v, want partial", rep.Verdict)
+	}
+}
+
+func TestBuildKeepsFailedVerificationVisible(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"), ran("go test ./...", false))
+
+	rep := Build(nil, ledger)
+	if len(rep.Verifications) != 1 || rep.Verifications[0].Passed {
+		t.Fatalf("verifications = %+v, want the failing run recorded", rep.Verifications)
+	}
+	if got := gapKinds(rep); !slices.Equal(got, []string{"failed_verification", "unverified_change"}) {
+		t.Fatalf("gap kinds = %v, want the failure and the resulting unverified change", got)
+	}
+}
+
+func TestBuildStalesVerificationThatPredatesTheLatestChange(t *testing.T) {
+	ledger := ledgerOf(ran("go test ./...", true), wrote("parser.go"), read("parser.go"))
+
+	rep := Build(nil, ledger)
+	if !rep.Verifications[0].Stale {
+		t.Fatalf("verification = %+v, want stale: it ran before the change", rep.Verifications[0])
+	}
+	if got := gapKinds(rep); !slices.Equal(got, []string{"stale_verification", "unverified_change"}) {
+		t.Fatalf("gap kinds = %v", got)
+	}
+}
+
+func TestBuildLatestRunOfACommandWins(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"), ran("go test ./...", false), ran("go test ./...", true))
+
+	rep := Build(nil, ledger)
+	if len(rep.Verifications) != 1 || !rep.Verifications[0].Passed {
+		t.Fatalf("verifications = %+v, want one entry showing the latest (passing) run", rep.Verifications)
+	}
+	if len(rep.Gaps) != 0 {
+		t.Fatalf("gaps = %+v, want none once the retry passed", rep.Gaps)
+	}
+	if rep.Verdict != VerdictDone {
+		t.Fatalf("verdict = %v, want done", rep.Verdict)
+	}
+}
+
+func TestBuildIncompleteWhenARequiredCriterionHasNoProof(t *testing.T) {
+	c := taskcontract.New("fix the parser")
+	c.AddRequirement("r1", "parser accepts empty input", true)
+	c.AddRequirement("r2", "nice to have", false)
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"), ran("go test ./...", true))
+	for _, r := range ledger.Receipts() {
+		c.Observe(r)
+	}
+
+	rep := Build(c, ledger)
+	if rep.Verdict != VerdictIncomplete {
+		t.Fatalf("verdict = %v, want incomplete", rep.Verdict)
+	}
+	if got := gapKinds(rep); !slices.Contains(got, "unproven_criterion") {
+		t.Fatalf("gap kinds = %v, want an unproven criterion", got)
+	}
+	for _, gap := range rep.Gaps {
+		if strings.Contains(gap.Detail, "nice to have") {
+			t.Fatalf("optional criterion must not become a gap: %+v", gap)
+		}
+	}
+}
+
+func TestBuildDeclaredCheckReplacesTheBlanketGap(t *testing.T) {
+	c := taskcontract.New("fix the parser")
+	c.AddCheck("go vet ./...")
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"))
+	for _, r := range ledger.Receipts() {
+		c.Observe(r)
+	}
+
+	rep := Build(c, ledger)
+	if got := gapKinds(rep); !slices.Equal(got, []string{"missing_check"}) {
+		t.Fatalf("gap kinds = %v, want only the specific missing check", got)
+	}
+	if rep.Gaps[0].Detail != "go vet ./..." {
+		t.Fatalf("gap detail = %q, want the declared command", rep.Gaps[0].Detail)
+	}
+}
+
+func TestBuildReviewIsScopedPerPath(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), wrote("lexer.go"), read("parser.go"), ran("go test ./...", true))
+
+	rep := Build(nil, ledger)
+	if len(rep.Changes) != 2 {
+		t.Fatalf("changes = %+v, want both paths", rep.Changes)
+	}
+	if !rep.Changes[0].Reviewed || rep.Changes[1].Reviewed {
+		t.Fatalf("changes = %+v: reading parser.go must not vouch for lexer.go", rep.Changes)
+	}
+	if rep.Gaps[0].Detail != "lexer.go" {
+		t.Fatalf("gap = %+v, want the unreviewed path only", rep.Gaps[0])
+	}
+}
+
+func TestBuildRewritingAPathAfterReviewReopensIt(t *testing.T) {
+	ledger := ledgerOf(wrote("parser.go"), read("parser.go"), ran("go test ./...", true), wrote("parser.go"))
+
+	rep := Build(nil, ledger)
+	if rep.Changes[0].Reviewed {
+		t.Fatalf("change = %+v, want unreviewed: the last write came after the read", rep.Changes[0])
+	}
+	if got := gapKinds(rep); !slices.Equal(got, []string{"stale_verification", "unverified_change", "unreviewed_change"}) {
+		t.Fatalf("gap kinds = %v, want the late edit to stale every proof", got)
+	}
+}
+
+func TestBuildCountsAPathlessMutation(t *testing.T) {
+	shell := evidence.Receipt{ToolName: "bash", Success: true, Command: "sed -i '' s/a/b/ parser.go", Mutation: true, OutputBytes: 8}
+	rep := Build(nil, ledgerOf(shell))
+	if rep.Mutations != 1 || len(rep.Changes) != 0 {
+		t.Fatalf("mutations = %d, changes = %+v: a path-less mutation still changed the workspace", rep.Mutations, rep.Changes)
+	}
+	if got := gapKinds(rep); !slices.Equal(got, []string{"unverified_change"}) {
+		t.Fatalf("gap kinds = %v, want the mutation flagged even with no path to name", got)
+	}
+}
+
+func TestSummaryCountsRequiredCriteriaOnly(t *testing.T) {
+	c := taskcontract.New("fix the parser")
+	c.AddRequirement("r1", "done", true)
+	c.AddRequirement("r2", "optional", false)
+	c.Resolve("r1", taskcontract.Satisfied)
+	rep := Build(c, ledgerOf())
+	if got := rep.Summary(); !strings.Contains(got, "criteria 1/1") {
+		t.Fatalf("summary = %q, want required-only criteria counts", got)
+	}
+}

--- a/internal/control/extensions.go
+++ b/internal/control/extensions.go
@@ -207,6 +207,10 @@ func (s *frontendEventSink) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(s.inner, a)
 }
 
+func (s *frontendEventSink) RecordCompletionReport(a event.CompletionReportAudit) {
+	event.RecordCompletionReport(s.inner, a)
+}
+
 func (s *frontendEventSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(s.inner, sample)
 }

--- a/internal/control/frontend_sink_capability_test.go
+++ b/internal/control/frontend_sink_capability_test.go
@@ -16,14 +16,15 @@ func TestFrontendEventSinkForwardsAuditCapabilities(t *testing.T) {
 	event.RecordMemoryRecall(s, event.MemoryRecallAudit{Suppressed: "probe"})
 	event.RecordDelegationAdmission(s, event.DelegationAdmissionAudit{Tool: "probe"})
 	event.RecordContractShadow(s, event.ContractShadowAudit{Verdict: "probe"})
-	if inner.outcome != 1 || inner.recall != 1 || inner.delegation != 1 || inner.contract != 1 {
+	event.RecordCompletionReport(s, event.CompletionReportAudit{Verdict: "probe"})
+	if inner.outcome != 1 || inner.recall != 1 || inner.delegation != 1 || inner.contract != 1 || inner.completion != 1 {
 		t.Fatalf("audits dropped by frontendEventSink: %+v", inner)
 	}
 }
 
 type capabilityProbeSink struct {
 	event.Sink
-	outcome, recall, delegation, contract int
+	outcome, recall, delegation, contract, completion int
 }
 
 func (p *capabilityProbeSink) RecordOutcomeProgress(evidence.OutcomeSample) { p.outcome++ }
@@ -32,3 +33,6 @@ func (p *capabilityProbeSink) RecordDelegationAdmission(event.DelegationAdmissio
 	p.delegation++
 }
 func (p *capabilityProbeSink) RecordContractShadow(event.ContractShadowAudit) { p.contract++ }
+func (p *capabilityProbeSink) RecordCompletionReport(event.CompletionReportAudit) {
+	p.completion++
+}

--- a/internal/control/goalusage.go
+++ b/internal/control/goalusage.go
@@ -97,6 +97,14 @@ func (t *goalUsageTee) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(t.inner, a)
 }
 
+// RecordCompletionReport forwards the completion report audit unchanged.
+func (t *goalUsageTee) RecordCompletionReport(a event.CompletionReportAudit) {
+	if t == nil || t.inner == nil {
+		return
+	}
+	event.RecordCompletionReport(t.inner, a)
+}
+
 // setActiveRecorder binds the current goal turn's recorder (nil clears it).
 func (t *goalUsageTee) setActiveRecorder(rec *goalTurnRecorder) {
 	if t == nil {

--- a/internal/event/coalesce.go
+++ b/internal/event/coalesce.go
@@ -167,6 +167,13 @@ func (c *coalescer) RecordContractShadow(a ContractShadowAudit) {
 	RecordContractShadow(c.inner, a)
 }
 
+func (c *coalescer) RecordCompletionReport(a CompletionReportAudit) {
+	c.mu.Lock()
+	c.enqueueFlushLocked()
+	c.drainAndUnlock()
+	RecordCompletionReport(c.inner, a)
+}
+
 func (c *coalescer) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	c.mu.Lock()
 	c.enqueueFlushLocked()

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -621,6 +621,40 @@ func RecordContractShadow(s Sink, a ContractShadowAudit) {
 	}
 }
 
+// CompletionReportAudit is the host-authored completion report's end-of-turn
+// summary: counts, enums, and gap kinds only, never paths or command text.
+// The gap counters carry the point — what the turn left unproven.
+type CompletionReportAudit struct {
+	Verdict             string
+	Risk                string
+	Criteria            int
+	CriteriaSatisfied   int
+	Changes             int
+	ChangesUnreviewed   int
+	Verifications       int
+	VerificationsFailed int
+	VerificationsStale  int
+	Gaps                int
+	GapKinds            []string
+}
+
+// CompletionReportAuditSink is an optional sink capability; implementations
+// must keep it content-free, like every other audit channel.
+type CompletionReportAuditSink interface {
+	RecordCompletionReport(CompletionReportAudit)
+}
+
+// RecordCompletionReport forwards the completion summary only to sinks that
+// explicitly opt in. Ordinary UI sinks receive nothing.
+func RecordCompletionReport(s Sink, a CompletionReportAudit) {
+	if nilutil.IsNil(s) {
+		return
+	}
+	if cs, ok := s.(CompletionReportAuditSink); ok {
+		cs.RecordCompletionReport(a)
+	}
+}
+
 // MemoryRecallAudit summarizes one automatic-recall decision: identifiers,
 // scores, and budget numbers only — never the query or fact text.
 type MemoryRecallAudit struct {

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -64,6 +64,14 @@ func (s *syncSink) RecordContractShadow(a ContractShadowAudit) {
 	}
 }
 
+func (s *syncSink) RecordCompletionReport(a CompletionReportAudit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rs, ok := s.inner.(CompletionReportAuditSink); ok {
+		rs.RecordCompletionReport(a)
+	}
+}
+
 func (s *syncSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/notify/sink.go
+++ b/internal/notify/sink.go
@@ -53,6 +53,10 @@ func (s *Sink) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(s.inner, a)
 }
 
+func (s *Sink) RecordCompletionReport(a event.CompletionReportAudit) {
+	event.RecordCompletionReport(s.inner, a)
+}
+
 func (s *Sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(s.inner, sample)
 }

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -179,6 +179,11 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(r.inner, a)
 }
 
+// RecordCompletionReport preserves the wrapped sink's audit capability.
+func (r *Recorder) RecordCompletionReport(a event.CompletionReportAudit) {
+	event.RecordCompletionReport(r.inner, a)
+}
+
 // RecordOutcomeProgress preserves the wrapped sink's audit capability.
 func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(r.inner, sample)

--- a/internal/telemetry/sink.go
+++ b/internal/telemetry/sink.go
@@ -135,6 +135,10 @@ func (s *sink) RecordContractShadow(a event.ContractShadowAudit) {
 	event.RecordContractShadow(s.inner, a)
 }
 
+func (s *sink) RecordCompletionReport(a event.CompletionReportAudit) {
+	event.RecordCompletionReport(s.inner, a)
+}
+
 func (s *sink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	event.RecordOutcomeProgress(s.inner, sample)
 }

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -30,6 +30,7 @@ type Record struct {
 	ProtocolRecovery    string               `json:"protocol_recovery,omitempty"`
 	TurnCompletion      bool                 `json:"turn_completion,omitempty"`
 	ContractShadow      *ContractShadowAudit `json:"contract_shadow,omitempty"`
+	CompletionReport    *CompletionReport    `json:"completion_report,omitempty"`
 	OutcomeProgress     *OutcomeProgress     `json:"outcome_progress,omitempty"`
 	DelegationAdmission *DelegationAdmission `json:"delegation_admission,omitempty"`
 	MemoryRecall        *MemoryRecall        `json:"memory_recall,omitempty"`
@@ -92,6 +93,21 @@ type ContractShadowAudit struct {
 	Verdict               string `json:"verdict"`
 	Complete              bool   `json:"complete,omitempty"`
 	ReadyToFinalize       bool   `json:"ready_to_finalize,omitempty"`
+}
+
+// CompletionReport mirrors event.CompletionReportAudit with stable keys.
+type CompletionReport struct {
+	Verdict             string   `json:"verdict"`
+	Risk                string   `json:"risk,omitempty"`
+	Criteria            int      `json:"criteria,omitempty"`
+	CriteriaSatisfied   int      `json:"criteria_satisfied,omitempty"`
+	Changes             int      `json:"changes,omitempty"`
+	ChangesUnreviewed   int      `json:"changes_unreviewed,omitempty"`
+	Verifications       int      `json:"verifications,omitempty"`
+	VerificationsFailed int      `json:"verifications_failed,omitempty"`
+	VerificationsStale  int      `json:"verifications_stale,omitempty"`
+	Gaps                int      `json:"gaps,omitempty"`
+	GapKinds            []string `json:"gap_kinds,omitempty"`
 }
 
 // ReadinessAudit mirrors evidence.ReadinessAudit with stable snake_case keys.
@@ -198,6 +214,23 @@ func (r *Recorder) RecordContractShadow(a event.ContractShadowAudit) {
 		ReadyToFinalize:       a.ReadyToFinalize,
 	}})
 	event.RecordContractShadow(r.inner, a)
+}
+
+func (r *Recorder) RecordCompletionReport(a event.CompletionReportAudit) {
+	r.append(Record{CompletionReport: &CompletionReport{
+		Verdict:             a.Verdict,
+		Risk:                a.Risk,
+		Criteria:            a.Criteria,
+		CriteriaSatisfied:   a.CriteriaSatisfied,
+		Changes:             a.Changes,
+		ChangesUnreviewed:   a.ChangesUnreviewed,
+		Verifications:       a.Verifications,
+		VerificationsFailed: a.VerificationsFailed,
+		VerificationsStale:  a.VerificationsStale,
+		Gaps:                a.Gaps,
+		GapKinds:            a.GapKinds,
+	}})
+	event.RecordCompletionReport(r.inner, a)
 }
 
 func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {

--- a/internal/trajectory/recorder_test.go
+++ b/internal/trajectory/recorder_test.go
@@ -17,6 +17,7 @@ type capabilitySink struct {
 	readiness  []evidence.ReadinessAudit
 	recoveries []event.ProtocolRecoveryAudit
 	outcomes   []evidence.OutcomeSample
+	reports    []event.CompletionReportAudit
 	turns      int
 }
 
@@ -30,6 +31,9 @@ func (s *capabilitySink) RecordProtocolRecovery(a event.ProtocolRecoveryAudit) {
 func (s *capabilitySink) RecordTurnCompletion() { s.turns++ }
 func (s *capabilitySink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 	s.outcomes = append(s.outcomes, sample)
+}
+func (s *capabilitySink) RecordCompletionReport(a event.CompletionReportAudit) {
+	s.reports = append(s.reports, a)
 }
 
 func readRecords(t *testing.T, path string) []Record {
@@ -111,13 +115,16 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	r.RecordTurnCompletion()
 	r.RecordOutcomeProgress(evidence.OutcomeSample{Round: 3, Exploration: 2, Objective: 1, LegacyGain: 4})
 	r.RecordDelegationAdmission(event.DelegationAdmissionAudit{Tool: "research", Verdict: "deny", Reason: "local_fix_no_external_need", Intent: "mutation"})
+	r.RecordCompletionReport(event.CompletionReportAudit{
+		Verdict: "partial", Changes: 2, ChangesUnreviewed: 1, Gaps: 1, GapKinds: []string{"unreviewed_change"},
+	})
 	if err := r.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
 	recs := readRecords(t, path)
-	if len(recs) != 5 {
-		t.Fatalf("got %d records, want 5", len(recs))
+	if len(recs) != 6 {
+		t.Fatalf("got %d records, want 6", len(recs))
 	}
 	if recs[0].ReadinessAudit == nil || recs[0].ReadinessAudit.Result != "blocked" || recs[0].ReadinessAudit.MissingVerification != 2 {
 		t.Errorf("readiness record = %+v", recs[0].ReadinessAudit)
@@ -134,8 +141,11 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	if recs[4].DelegationAdmission == nil || recs[4].DelegationAdmission.Verdict != "deny" || recs[4].DelegationAdmission.Tool != "research" {
 		t.Errorf("delegation admission record = %+v", recs[4].DelegationAdmission)
 	}
-	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 || len(inner.outcomes) != 1 {
-		t.Errorf("inner capabilities = %d/%d/%d/%d, want 1/1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns, len(inner.outcomes))
+	if rec := recs[5].CompletionReport; rec == nil || rec.Verdict != "partial" || rec.ChangesUnreviewed != 1 || len(rec.GapKinds) != 1 {
+		t.Errorf("completion report record = %+v", recs[5].CompletionReport)
+	}
+	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 || len(inner.outcomes) != 1 || len(inner.reports) != 1 {
+		t.Errorf("inner capabilities = %d/%d/%d/%d/%d, want 1/1/1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns, len(inner.outcomes), len(inner.reports))
 	}
 }
 


### PR DESCRIPTION
## Why

The contract subsystem already answers "does every criterion carry fresh proof?".
Nothing computed the **subtraction**: a file this turn changed and never looked at
again, a mutation no verification followed, a command that passed only *before* the
latest edit. Those are precisely the facts a premature "done" leaves out — and the
model is the wrong author for them.

This is step 1 of the completion contract: the receipt exists, it is host-authored,
and it decides nothing yet.

## What

`internal/completion` projects a `Report` over `taskcontract.Contract` + `evidence.Ledger`:

- **criteria** — each requirement's status and how many successful proofs are attached
- **changes** — mutated paths, each asked *individually* whether it was inspected after
  its own latest write, so a review of one file never vouches for another
- **verifications** — each delivery-verification command's latest run, marked `stale`
  when it predates the newest mutation, and kept when it **failed**
- **gaps** — the six ways proof can be missing, computed by subtraction rather than read
  off a claim

The verdict separates `incomplete` (proof missing) from `partial` (proven, gaps
declared). **`partial` is terminal on purpose**: the mechanism's job is not to force
verification, it is to make the absence of verification impossible to omit. A gate that
loops until everything is green would cost turns and produce false negatives; a receipt
that always names what it could not prove costs nothing.

A path-less mutation (`sed -i`, `rm`) still counts — `Mutations` is tracked separately
from `Changes` so a change that named no file cannot slip past the gap check.

Building a report makes no model call and mutates nothing.

## Shadow only

`emitTurnShadows` replays the finished turn's receipts once and emits both the existing
contract shadow and the new report. The report rides a new content-free audit capability
(counts, enums, gap kinds — never a path or a command) forwarded by every sink wrapper,
and lands in the trajectory JSONL.

`e2ebench` prices it against the hidden grader:

```
**Completion report**: verdicts done ×12 · partial ×8 · **overclaim** 8% (1/12 done runs
the grader failed) · **caught** 78% (7/9 failed runs declared a gap) · gaps
unreviewed_change ×14 · stale_verification ×3
```

**overclaim** is the number this whole direction exists to drive down. **caught** is its
counterpart — of the runs that actually failed, how many already said so.

## Verification

- `go test ./internal/completion/ ./internal/agent/ ./internal/control/ ./internal/event/
  ./internal/trajectory/ ./internal/stats/ ./internal/telemetry/ ./internal/notify/
  ./internal/tool/builtin/ ./internal/boot/ ./cmd/e2ebench/` — all pass
- `gofmt -l .` clean · `go vet ./...` clean · `go run ./tools/repolint` clean (baseline unchanged)
- New behavioral test worth reading: `TestCompletionShadowFlagsWhatTheContractCallsComplete`
  — the contract says complete, the report says partial, because the changed file was
  never inspected. That disagreement is the feature.

Cache-impact: none - no prompt, tool schema, or provider-visible prefix changes; the report is derived host-side from receipts after the turn ends and never enters a request.
Cache-guard: existing internal/boot golden prefix tests (testdata/golden/provider_request.json, tool_schemas.json) stay byte-identical; go test ./internal/boot/ passes.
Documentation-impact: none - shadow-only observation with no user-visible surface yet; docs land with the rendered receipt in a later step.
