### PR TITLE
bench(meter): the neutral measuring point, and the harness proving its own numbers

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,6 +59,50 @@ Each task under `e2e/tasks/<id>/` contains:
 | `verify.sh` | The grader: exits 0 iff the agent's artifacts are correct. |
 | `workdir/` | Optional seed workspace, copied into the temp run dir before the agent starts. |
 
+## Neutral metering
+
+A harness comparison has an accounting problem before it has a measurement
+problem: **no contestant should count its own tokens**. Reasonix writes
+`.run-metrics.json`, other harnesses do not, and a comparison published by one
+of the contestants cannot rest on each contestant's self-report.
+
+`-meter` moves the measurement onto the request boundary. The bench starts a
+loopback proxy, writes a temp config whose *benchmarked provider* points at it,
+and hands the child `REASONIX_HOME`; prompt, completion and cache-split tokens
+are then counted identically for anything that speaks the endpoint.
+
+```sh
+go run ./cmd/e2ebench -meter ~/.reasonix/config.toml -trajectories t/
+```
+
+- **Credentials are never touched.** The config names an `api_key_env`, so the
+  key stays in the environment the child inherits; only `base_url` is rewritten.
+- **Only the provider serving `-model` is redirected.** Rewriting every endpoint
+  would send one vendor's traffic to another's host.
+- **Streamed requests are opted into usage.** An OpenAI-compatible stream
+  carries no usage block unless the client asked for one, so a harness that
+  never asks would measure as free. Non-streamed bodies are forwarded byte-for-
+  byte.
+- **A response with no usage is `unmeasured`, never zero.** Silent zeroes would
+  flatter whichever harness reports least.
+
+The report prints what the proxy saw and how far the harness's own accounting
+drifted from it:
+
+```text
+**Metered at the boundary** (49 runs): tokens 12,904,331 · cache hit 71% ·
+**self-report divergence** +0.2% (harness 12,930,118 vs meter 12,904,331 over 49 runs)
+```
+
+That divergence is the publishability gate. Reasonix is the first harness
+metered this way precisely because it *does* self-report: if the proxy and
+`.run-metrics.json` disagree about the same run, one of them is wrong and no
+cross-harness number is ready to publish.
+
+`-faults` injects provider failures at fixed request indices through the same
+proxy, which is what LongRun needs: deterministic 429/500 at the same point of
+a run, replayable across harnesses.
+
 ## task.toml schema
 
 `e2ebench` reads `benchmarks/e2e/tasks/<id>/task.toml` with the BurntSushi TOML
@@ -147,6 +191,8 @@ own outcome).
 | `-force-planner` | `false` | Suite mode: prefix each prompt with a plan-first directive so the two-model turn engages regardless of the planner gate. Use for the "with planner" arm of an A/B; results carry `plan_forced` so arms are only comparable with equal forcing. |
 | `-cache` | `cold` | Suite mode: `cold` runs each task as a fresh session (the fair cross-agent comparison arm); `warm` primes the provider prefix cache with a one-step run in the same workdir first, measuring the long-lived-session steady state. Never mix arms in one report — compare them with `-mode compare cold.json warm.json`. |
 | `-budget` | `800000` | Abort once total tokens cross this (`0` = no cap). Remaining tasks are reported as skipped. |
+| `-meter` | *(off)* | Suite mode: route the benchmarked provider through the neutral measuring proxy, using this `config.toml` as the source. Spend is then counted at the request boundary instead of trusted from the harness. See [Neutral metering](#neutral-metering). |
+| `-faults` | *(none)* | Suite mode: inject provider failures at fixed request indices, e.g. `3:429,7:500`. Requires `-meter` — the proxy is the only place a fault can be injected. |
 
 Diff-mode flags:
 

--- a/cmd/e2ebench/checkpoints.go
+++ b/cmd/e2ebench/checkpoints.go
@@ -381,3 +381,17 @@ func solutionFiles(seedDir, finalDir string) map[string]string {
 	})
 	return out
 }
+
+// attachSnapshotter starts per-change workdir snapshots when checkpoint grading
+// is on. It always returns a usable cleanup so the caller needs no branch; a
+// temp-dir failure degrades to no snapshots rather than failing the run.
+func attachSnapshotter(cfg suiteConfig, t task, work string, startedAt time.Time) (*snapshotter, func()) {
+	if !cfg.checkpoints {
+		return nil, func() {}
+	}
+	dir, err := os.MkdirTemp("", "e2ebench-cp-"+t.ID+"-")
+	if err != nil {
+		return nil, func() {}
+	}
+	return startSnapshotter(work, dir, startedAt), func() { _ = os.RemoveAll(dir) }
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -120,6 +120,10 @@ type result struct {
 	// agent was killed. The numbers are real but stop at the last snapshot, so
 	// they are counted as lower bounds rather than dropped.
 	Partial bool `json:"partial"`
+	// Meter is what the neutral proxy observed for this run, when metering was
+	// on. It is the authority for cross-harness spend; runMetrics is the
+	// harness's own account, kept only to be checked against it.
+	Meter *meterUsage `json:"meter,omitempty"`
 	// Trajectory is the digest of the run's recorded event trajectory; nil
 	// unless the harness ran with -trajectories.
 	Trajectory *trajectorySummary `json:"trajectory,omitempty"`
@@ -219,6 +223,8 @@ func main() {
 	cacheArm := flag.String("cache", "cold", "suite mode: cold (fresh session per task) | warm (prefix-warming one-step run in the same workdir before the graded run)")
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
+	meterConfig := flag.String("meter", "", "suite mode: route the benchmarked provider through the neutral measuring proxy, using this config.toml as the source (e.g. ~/.reasonix/config.toml). Spend is then counted at the request boundary instead of trusted from the harness")
+	faultSpec := flag.String("faults", "", "suite mode: inject provider failures at fixed request indices, e.g. 3:429,7:500 (requires -meter)")
 	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge) | governor (exploration-phase reasoning governor) | memory-off (hide the memory store: MemoryBench counterfactual arm)")
 	forkCapture := flag.String("fork-capture", "", "suite mode: capture a fork bundle per task at first EBM eligibility into <dir>/<task-id>")
 	bundles := flag.String("bundles", "", "fork mode: directory of captured bundles (<task-id>/bundle.json)")
@@ -301,11 +307,12 @@ func main() {
 		return
 	}
 
+	meterSource, faults := meterSettings(*meterConfig, *faultSpec)
 	runSuiteMode(suiteConfig{
 		bin: *bin, model: *model, profile: profile, arm: arm, budget: *budget,
 		trajDir: *trajDir, forcePlanner: *forcePlanner, attempts: *attempts,
 		cacheArm: cache, effort: *effort, checkpoints: *checkpoints, policy: *policyFlag,
-		forkCapture: *forkCapture,
+		forkCapture: *forkCapture, meterConfig: meterSource, meterFaults: faults,
 	}, *suite, *taskFilter, *outMD, *outJSON)
 }
 
@@ -441,6 +448,10 @@ type suiteConfig struct {
 	trajDir                               string
 	forcePlanner, checkpoints             bool
 	attempts, budget                      int
+	// meterConfig is the real config.toml whose provider endpoint each run is
+	// redirected through the neutral meter; empty leaves runs unmetered.
+	meterConfig string
+	meterFaults map[int]int
 }
 
 // runSuite runs each task in order until the token budget is exhausted;
@@ -527,6 +538,9 @@ func runTask(cfg suiteConfig, t task) result {
 	if seedNote != "" {
 		r.Note = seedNote
 	}
+	mtr := attachMeter(cfg, &r)
+	defer mtr.close()
+	extraEnv = append(extraEnv, mtr.env...)
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
@@ -534,14 +548,8 @@ func runTask(cfg suiteConfig, t task) result {
 	cmd.Stderr = os.Stderr
 	cmd.WaitDelay = 10 * time.Second // bound the wait for a stuck child after ctx timeout
 	startedAt := time.Now()
-	var snap *snapshotter
-	if cfg.checkpoints {
-		snapDir, err := os.MkdirTemp("", "e2ebench-cp-"+t.ID+"-")
-		if err == nil {
-			defer os.RemoveAll(snapDir)
-			snap = startSnapshotter(work, snapDir, startedAt)
-		}
-	}
+	snap, dropSnapshots := attachSnapshotter(cfg, t, work, startedAt)
+	defer dropSnapshots()
 	runErr := cmd.Run()
 	r.WallMs = time.Since(startedAt).Milliseconds()
 	var taken []checkpoint
@@ -552,6 +560,7 @@ func runTask(cfg suiteConfig, t task) result {
 	if m, err := readMetrics(metricsPath); err == nil {
 		r.runMetrics = m
 	}
+	mtr.record(&r)
 	if trajPath != "" {
 		if summary, err := summarizeTrajectory(trajPath); err == nil {
 			r.Trajectory = summary

--- a/cmd/e2ebench/meter.go
+++ b/cmd/e2ebench/meter.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// meter is the harness-neutral measuring point: a proxy every harness talks to
+// instead of the provider, so nobody in a comparison reports their own token
+// use. It is also where LongRun injects provider faults, because the request
+// boundary is the only place both benchmarks can reach without a harness's
+// cooperation.
+type meter struct {
+	upstream *url.URL
+	client   *http.Client
+	faults   map[int]int // 1-based request index -> status to return instead
+
+	mu sync.Mutex
+	meterUsage
+}
+
+// meterUsage is what the proxy observed. WithoutUsage is reported rather than
+// folded into zero: a harness whose responses carry no usage block is
+// unmeasured, and that is a finding, not a zero.
+type meterUsage struct {
+	Requests         int `json:"requests"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	CacheHitTokens   int `json:"cache_hit_tokens"`
+	CacheMissTokens  int `json:"cache_miss_tokens"`
+	Injected         int `json:"injected_faults,omitempty"`
+	WithoutUsage     int `json:"responses_without_usage,omitempty"`
+}
+
+// parseFaultScript reads "3:429,7:500" — inject that status instead of
+// forwarding the Nth request. Deterministic by index so a LongRun arm replays
+// the same failures across harnesses.
+func parseFaultScript(spec string) (map[int]int, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	out := map[int]int{}
+	for field := range strings.SplitSeq(spec, ",") {
+		idx, status, ok := strings.Cut(strings.TrimSpace(field), ":")
+		if !ok {
+			return nil, fmt.Errorf("fault %q: want <request-index>:<status>", field)
+		}
+		i, err := strconv.Atoi(strings.TrimSpace(idx))
+		if err != nil || i < 1 {
+			return nil, fmt.Errorf("fault %q: request index must be a positive integer", field)
+		}
+		code, err := strconv.Atoi(strings.TrimSpace(status))
+		if err != nil || code < 400 || code > 599 {
+			return nil, fmt.Errorf("fault %q: status must be 4xx or 5xx", field)
+		}
+		out[i] = code
+	}
+	return out, nil
+}
+
+func newMeter(upstream string, faults map[int]int) (*meter, error) {
+	u, err := url.Parse(strings.TrimSuffix(strings.TrimSpace(upstream), "/"))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("meter upstream %q is not an absolute URL", upstream)
+	}
+	return &meter{upstream: u, client: &http.Client{}, faults: faults}, nil
+}
+
+// serve starts the proxy on an ephemeral loopback port and returns its base URL
+// plus a stop function. Loopback only: the proxy carries provider credentials.
+func (m *meter) serve() (base string, stop func(), err error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, err
+	}
+	srv := &http.Server{Handler: m}
+	go func() { _ = srv.Serve(ln) }()
+	return "http://" + ln.Addr().String(), func() { _ = srv.Close() }, nil
+}
+
+func (m *meter) snapshot() meterUsage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.meterUsage
+}
+
+func (m *meter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.Requests++
+	index := m.Requests
+	status, faulted := m.faults[index]
+	if faulted {
+		m.Injected++
+	}
+	m.mu.Unlock()
+
+	if faulted {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprintf(w, `{"error":{"message":"injected by e2ebench meter at request %d","type":"bench_fault"}}`, index)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	body = requestUsageOptIn(body)
+
+	target := *m.upstream
+	target.Path = strings.TrimSuffix(m.upstream.Path, "/") + r.URL.Path
+	target.RawQuery = r.URL.RawQuery
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, target.String(), bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "build request: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	for key, values := range r.Header {
+		if strings.EqualFold(key, "Host") || strings.EqualFold(key, "Content-Length") {
+			continue
+		}
+		req.Header[key] = values
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		http.Error(w, "upstream: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	maps.Copy(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	if strings.Contains(resp.Header.Get("Content-Type"), "event-stream") {
+		m.pipeStream(w, resp.Body)
+		return
+	}
+	m.pipeJSON(w, resp.Body)
+}
+
+// requestUsageOptIn asks for a usage block on streamed completions. Without it
+// an OpenAI-compatible stream may carry none at all, and a harness that never
+// asks would measure as free.
+func requestUsageOptIn(body []byte) []byte {
+	var payload map[string]any
+	if json.Unmarshal(body, &payload) != nil {
+		return body
+	}
+	if stream, _ := payload["stream"].(bool); !stream {
+		return body
+	}
+	if _, ok := payload["stream_options"]; ok {
+		return body
+	}
+	payload["stream_options"] = map[string]any{"include_usage": true}
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func (m *meter) pipeJSON(w http.ResponseWriter, body io.Reader) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return
+	}
+	_, _ = w.Write(data)
+	if !m.recordUsage(data) {
+		m.noteMissingUsage()
+	}
+}
+
+// pipeStream forwards SSE frames as they arrive — a buffered stream would
+// change the harness's observed latency, which other metrics depend on — and
+// reads usage out of the frames on the way past.
+func (m *meter) pipeStream(w http.ResponseWriter, body io.Reader) {
+	flusher, _ := w.(http.Flusher)
+	reader := bufio.NewReader(body)
+	seen := false
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			_, _ = w.Write(line)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if payload, ok := bytes.CutPrefix(bytes.TrimSpace(line), []byte("data:")); ok {
+				if m.recordUsage(bytes.TrimSpace(payload)) {
+					seen = true
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	if !seen {
+		m.noteMissingUsage()
+	}
+}
+
+func (m *meter) noteMissingUsage() {
+	m.mu.Lock()
+	m.WithoutUsage++
+	m.mu.Unlock()
+}
+
+// recordUsage folds one payload's usage block in, reporting whether it had one.
+// Both cache spellings are read: DeepSeek's explicit hit/miss split and the
+// OpenAI-standard prompt_tokens_details.cached_tokens.
+func (m *meter) recordUsage(payload []byte) bool {
+	var doc struct {
+		Usage *struct {
+			PromptTokens         int `json:"prompt_tokens"`
+			CompletionTokens     int `json:"completion_tokens"`
+			PromptCacheHitTokens int `json:"prompt_cache_hit_tokens"`
+			PromptCacheMissToken int `json:"prompt_cache_miss_tokens"`
+			PromptTokensDetails  *struct {
+				CachedTokens int `json:"cached_tokens"`
+			} `json:"prompt_tokens_details"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal(payload, &doc) != nil || doc.Usage == nil {
+		return false
+	}
+	hit, miss := doc.Usage.PromptCacheHitTokens, doc.Usage.PromptCacheMissToken
+	if hit == 0 && miss == 0 && doc.Usage.PromptTokensDetails != nil {
+		hit = doc.Usage.PromptTokensDetails.CachedTokens
+		miss = doc.Usage.PromptTokens - hit
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PromptTokens += doc.Usage.PromptTokens
+	m.CompletionTokens += doc.Usage.CompletionTokens
+	m.CacheHitTokens += hit
+	m.CacheMissTokens += miss
+	return true
+}

--- a/cmd/e2ebench/meter_test.go
+++ b/cmd/e2ebench/meter_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func meterAgainst(t *testing.T, upstream http.Handler, faults map[int]int) (*meter, string, func()) {
+	t.Helper()
+	up := httptest.NewServer(upstream)
+	m, err := newMeter(up.URL, faults)
+	if err != nil {
+		t.Fatalf("newMeter: %v", err)
+	}
+	base, stop, err := m.serve()
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	return m, base, func() { stop(); up.Close() }
+}
+
+func post(t *testing.T, base, path, body string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(base+path, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	return resp
+}
+
+func TestMeterCountsNonStreamingUsage(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":100,"completion_tokens":20,"prompt_cache_hit_tokens":64,"prompt_cache_miss_tokens":36}}`)
+	})
+	m, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+
+	resp := post(t, base, "/chat/completions", `{"model":"x"}`)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Contains(body, []byte(`"content":"hi"`)) {
+		t.Fatalf("response not forwarded: %s", body)
+	}
+	got := m.snapshot()
+	if got.Requests != 1 || got.PromptTokens != 100 || got.CompletionTokens != 20 {
+		t.Fatalf("usage = %+v", got)
+	}
+	if got.CacheHitTokens != 64 || got.CacheMissTokens != 36 {
+		t.Fatalf("cache split = %d/%d, want 64/36", got.CacheHitTokens, got.CacheMissTokens)
+	}
+	if got.WithoutUsage != 0 {
+		t.Fatalf("usage was present; WithoutUsage = %d", got.WithoutUsage)
+	}
+}
+
+func TestMeterReadsOpenAICachedTokensSpelling(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"usage":{"prompt_tokens":90,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":30}}}`)
+	})
+	m, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
+
+	got := m.snapshot()
+	if got.CacheHitTokens != 30 || got.CacheMissTokens != 60 {
+		t.Fatalf("cache split = %d/%d, want 30/60 derived from prompt_tokens", got.CacheHitTokens, got.CacheMissTokens)
+	}
+}
+
+func TestMeterCountsStreamedUsageAndForwardsFrames(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"a\"}}]}\n\n")
+		io.WriteString(w, "data: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\n")
+		io.WriteString(w, "data: [DONE]\n\n")
+	})
+	m, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+
+	resp := post(t, base, "/chat/completions", `{"model":"x","stream":true}`)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(body), "[DONE]") || !strings.Contains(string(body), `"content":"a"`) {
+		t.Fatalf("frames not forwarded verbatim: %q", body)
+	}
+	got := m.snapshot()
+	if got.PromptTokens != 7 || got.CompletionTokens != 3 || got.WithoutUsage != 0 {
+		t.Fatalf("streamed usage = %+v", got)
+	}
+}
+
+// A harness that never asks for usage would otherwise measure as free.
+func TestMeterOptsStreamedRequestsIntoUsage(t *testing.T) {
+	var seen []byte
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "data: [DONE]\n\n")
+	})
+	_, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+	post(t, base, "/chat/completions", `{"model":"x","stream":true}`).Body.Close()
+
+	var payload map[string]any
+	if err := json.Unmarshal(seen, &payload); err != nil {
+		t.Fatalf("upstream body: %v", err)
+	}
+	opts, ok := payload["stream_options"].(map[string]any)
+	if !ok || opts["include_usage"] != true {
+		t.Fatalf("stream_options not injected: %s", seen)
+	}
+}
+
+func TestMeterLeavesNonStreamedRequestsAlone(t *testing.T) {
+	var seen []byte
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	})
+	_, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
+
+	if strings.Contains(string(seen), "stream_options") {
+		t.Fatalf("non-streamed request was rewritten: %s", seen)
+	}
+}
+
+func TestMeterReportsResponsesWithoutUsage(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"choices":[]}`)
+	})
+	m, base, stop := meterAgainst(t, upstream, nil)
+	defer stop()
+	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
+
+	if got := m.snapshot(); got.WithoutUsage != 1 || got.PromptTokens != 0 {
+		t.Fatalf("unmeasured response must be reported, not zeroed: %+v", got)
+	}
+}
+
+func TestMeterInjectsFaultsByRequestIndex(t *testing.T) {
+	reached := 0
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached++
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	})
+	m, base, stop := meterAgainst(t, upstream, map[int]int{2: 429})
+	defer stop()
+
+	for i := range 3 {
+		resp := post(t, base, "/chat/completions", `{"model":"x"}`)
+		want := http.StatusOK
+		if i == 1 {
+			want = http.StatusTooManyRequests
+		}
+		if resp.StatusCode != want {
+			t.Fatalf("request %d status = %d, want %d", i+1, resp.StatusCode, want)
+		}
+		resp.Body.Close()
+	}
+	if reached != 2 {
+		t.Fatalf("upstream saw %d requests, want 2 — the faulted one must not be forwarded", reached)
+	}
+	if got := m.snapshot(); got.Injected != 1 || got.Requests != 3 {
+		t.Fatalf("meter = %+v, want 3 requests with 1 injected", got)
+	}
+}
+
+func TestParseFaultScript(t *testing.T) {
+	got, err := parseFaultScript(" 3:429 , 7:500 ")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got[3] != 429 || got[7] != 500 || len(got) != 2 {
+		t.Fatalf("faults = %v", got)
+	}
+	if got, err := parseFaultScript(""); err != nil || got != nil {
+		t.Fatalf("empty spec = %v, %v", got, err)
+	}
+	for _, bad := range []string{"3", "0:429", "3:200", "x:429", "3:999"} {
+		if _, err := parseFaultScript(bad); err == nil {
+			t.Fatalf("%q must be rejected", bad)
+		}
+	}
+}
+
+func TestNewMeterRejectsRelativeUpstream(t *testing.T) {
+	if _, err := newMeter("/v1", nil); err == nil {
+		t.Fatal("a relative upstream must be rejected")
+	}
+}

--- a/cmd/e2ebench/meterconfig.go
+++ b/cmd/e2ebench/meterconfig.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// meterUpstream reports the endpoint the meter must forward to: the base_url
+// of the provider serving the benchmarked model. Only that provider is ever
+// redirected — rewriting every endpoint would send one vendor's traffic to
+// another's host.
+func meterUpstream(configPath, model string) (upstream string, err error) {
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", fmt.Errorf("read config for metering: %w", err)
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(raw, &doc); err != nil {
+		return "", fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	providers, _ := doc["providers"].([]map[string]any)
+	if len(providers) == 0 {
+		if list, ok := doc["providers"].([]any); ok {
+			for _, entry := range list {
+				if p, ok := entry.(map[string]any); ok {
+					providers = append(providers, p)
+				}
+			}
+		}
+	}
+	if len(providers) == 0 {
+		return "", fmt.Errorf("%s declares no [[providers]]; the meter has nothing to redirect", configPath)
+	}
+	target := providerForModel(providers, model)
+	upstream, _ = target["base_url"].(string)
+	if strings.TrimSpace(upstream) == "" {
+		return "", fmt.Errorf("provider %v has no base_url to redirect", target["name"])
+	}
+	return upstream, nil
+}
+
+// providerForModel picks the entry that serves model, falling back to the
+// first. A benchmark run is single-model, so an exact match is the common case
+// and the fallback only matters for a one-provider config.
+func providerForModel(providers []map[string]any, model string) map[string]any {
+	model = strings.TrimSpace(model)
+	if model != "" {
+		if _, want, ok := strings.Cut(model, "/"); ok {
+			model = want
+		}
+		for _, p := range providers {
+			if name, _ := p["default"].(string); name == model {
+				return p
+			}
+			list, _ := p["models"].([]any)
+			for _, m := range list {
+				if s, _ := m.(string); s == model {
+					return p
+				}
+			}
+			if s, _ := p["model"].(string); s == model {
+				return p
+			}
+		}
+	}
+	return providers[0]
+}
+
+// writeMeteredConfig rewrites the chosen provider's base_url to meterBase and
+// writes the result into dir as config.toml.
+func writeMeteredConfig(configPath, dir, model, meterBase string) error {
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(raw, &doc); err != nil {
+		return err
+	}
+	var providers []map[string]any
+	switch list := doc["providers"].(type) {
+	case []map[string]any:
+		providers = list
+	case []any:
+		for _, entry := range list {
+			if p, ok := entry.(map[string]any); ok {
+				providers = append(providers, p)
+			}
+		}
+	}
+	if len(providers) == 0 {
+		return fmt.Errorf("%s declares no [[providers]]", configPath)
+	}
+	target := providerForModel(providers, model)
+	target["base_url"] = meterBase
+	// The redirected endpoint is loopback plaintext; a proxy configured for the
+	// real vendor host must not be applied to it.
+	target["no_proxy"] = true
+	doc["providers"] = providers
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	return toml.NewEncoder(out).Encode(doc)
+}

--- a/cmd/e2ebench/meterconfig_test.go
+++ b/cmd/e2ebench/meterconfig_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+const twoProviderConfig = `
+[[providers]]
+name        = "deepseek"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+models      = ["deepseek-v4-flash", "deepseek-v4-pro"]
+api_key_env = "DEEPSEEK_API_KEY"
+
+[[providers]]
+name        = "kimi"
+kind        = "openai"
+base_url    = "https://api.moonshot.cn/v1"
+models      = ["kimi-k2"]
+api_key_env = "MOONSHOT_API_KEY"
+`
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readProviders(t *testing.T, dir string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read metered config: %v", err)
+	}
+	var doc map[string]any
+	if err := toml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse metered config: %v", err)
+	}
+	var out []map[string]any
+	switch list := doc["providers"].(type) {
+	case []map[string]any:
+		out = list
+	case []any:
+		for _, entry := range list {
+			p, _ := entry.(map[string]any)
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func TestMeterUpstreamFindsTheProviderServingTheModel(t *testing.T) {
+	path := writeConfig(t, twoProviderConfig)
+	got, err := meterUpstream(path, "kimi-k2")
+	if err != nil {
+		t.Fatalf("meterUpstream: %v", err)
+	}
+	if got != "https://api.moonshot.cn/v1" {
+		t.Fatalf("upstream = %q, want the provider that serves the model", got)
+	}
+}
+
+func TestMeterUpstreamAcceptsAVendorQualifiedModel(t *testing.T) {
+	path := writeConfig(t, twoProviderConfig)
+	got, err := meterUpstream(path, "Kimi/kimi-k2")
+	if err != nil {
+		t.Fatalf("meterUpstream: %v", err)
+	}
+	if got != "https://api.moonshot.cn/v1" {
+		t.Fatalf("upstream = %q, want the vendor prefix stripped before matching", got)
+	}
+}
+
+func TestMeterUpstreamFallsBackToTheFirstProvider(t *testing.T) {
+	path := writeConfig(t, twoProviderConfig)
+	got, err := meterUpstream(path, "")
+	if err != nil {
+		t.Fatalf("meterUpstream: %v", err)
+	}
+	if got != "https://api.deepseek.com" {
+		t.Fatalf("upstream = %q, want the first provider", got)
+	}
+}
+
+// Rewriting every endpoint would send one vendor's traffic to another's host.
+func TestWriteMeteredConfigRedirectsOnlyTheBenchmarkedProvider(t *testing.T) {
+	path := writeConfig(t, twoProviderConfig)
+	dir := t.TempDir()
+	if err := writeMeteredConfig(path, dir, "kimi-k2", "http://127.0.0.1:9999"); err != nil {
+		t.Fatalf("writeMeteredConfig: %v", err)
+	}
+	providers := readProviders(t, dir)
+	if len(providers) != 2 {
+		t.Fatalf("providers = %d, want both preserved", len(providers))
+	}
+	byName := map[string]map[string]any{}
+	for _, p := range providers {
+		name, _ := p["name"].(string)
+		byName[name] = p
+	}
+	if got := byName["kimi"]["base_url"]; got != "http://127.0.0.1:9999" {
+		t.Fatalf("kimi base_url = %v, want the meter", got)
+	}
+	if got := byName["deepseek"]["base_url"]; got != "https://api.deepseek.com" {
+		t.Fatalf("deepseek base_url = %v, want it left alone", got)
+	}
+	if got := byName["kimi"]["no_proxy"]; got != true {
+		t.Fatalf("no_proxy = %v, want true: the meter is loopback plaintext", got)
+	}
+}
+
+// The key lives in an env var the child inherits, so metering must never need
+// to read, copy, or rewrite a credential.
+func TestWriteMeteredConfigKeepsCredentialsUntouched(t *testing.T) {
+	path := writeConfig(t, twoProviderConfig)
+	dir := t.TempDir()
+	if err := writeMeteredConfig(path, dir, "deepseek-v4-flash", "http://127.0.0.1:1"); err != nil {
+		t.Fatalf("writeMeteredConfig: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "DEEPSEEK_API_KEY") {
+		t.Fatalf("api_key_env was dropped:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "api_key =") {
+		t.Fatalf("a literal key appeared in the metered config:\n%s", raw)
+	}
+}
+
+func TestMeterUpstreamRejectsAConfigWithNoProviders(t *testing.T) {
+	path := writeConfig(t, "model = \"x\"\n")
+	if _, err := meterUpstream(path, ""); err == nil {
+		t.Fatal("a config with no providers must fail loudly, not meter nothing")
+	}
+}

--- a/cmd/e2ebench/meterrun.go
+++ b/cmd/e2ebench/meterrun.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// meterSettings validates the metering flags together: a fault script has
+// nowhere to be injected without the proxy, so asking for one without -meter
+// is a mistake worth stopping for rather than silently ignoring.
+func meterSettings(configPath, faultSpec string) (string, map[int]int) {
+	faults, err := parseFaultScript(faultSpec)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "faults:", err)
+		os.Exit(2)
+	}
+	if len(faults) > 0 && strings.TrimSpace(configPath) == "" {
+		fmt.Fprintln(os.Stderr, "faults: -faults needs -meter; the proxy is where a fault can be injected")
+		os.Exit(2)
+	}
+	return configPath, faults
+}
+
+// runMeter is one run's metering: the environment that points the child at the
+// proxy, and the proxy itself. The zero value is a working no-op, so an
+// unmetered run needs no branch at the call site.
+type runMeter struct {
+	env  []string
+	m    *meter
+	stop func()
+}
+
+// attachMeter starts the run's meter, folding a setup failure into the run's
+// note instead of aborting the suite: an unmetered run is still a data point.
+func attachMeter(cfg suiteConfig, r *result) runMeter {
+	env, m, stop, err := startTaskMeter(cfg)
+	if err != nil {
+		r.Note = strings.TrimSpace(r.Note + " meter: " + err.Error())
+	}
+	return runMeter{env: env, m: m, stop: stop}
+}
+
+func (rm runMeter) close() {
+	if rm.stop != nil {
+		rm.stop()
+	}
+}
+
+// record attaches what the proxy observed. It stays separate from close so the
+// snapshot is taken while the run's numbers are still being assembled.
+func (rm runMeter) record(r *result) {
+	if rm.m == nil {
+		return
+	}
+	observed := rm.m.snapshot()
+	r.Meter = &observed
+}
+
+// startTaskMeter brings up a per-task meter and returns the environment that
+// points the child at it. One meter per task keeps spend attributable to the
+// task that incurred it. A nil meter means metering is off, which is the
+// default: the proxy carries provider credentials and must be opt-in.
+func startTaskMeter(cfg suiteConfig) (env []string, m *meter, stop func(), err error) {
+	if strings.TrimSpace(cfg.meterConfig) == "" {
+		return nil, nil, nil, nil
+	}
+	upstream, err := meterUpstream(cfg.meterConfig, cfg.model)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	m, err = newMeter(upstream, cfg.meterFaults)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	base, stopServer, err := m.serve()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	home, err := os.MkdirTemp("", "e2ebench-meter-home-")
+	if err != nil {
+		stopServer()
+		return nil, nil, nil, err
+	}
+	if err := writeMeteredConfig(cfg.meterConfig, home, cfg.model, base); err != nil {
+		stopServer()
+		_ = os.RemoveAll(home)
+		return nil, nil, nil, err
+	}
+	return []string{"REASONIX_HOME=" + home}, m, func() {
+		stopServer()
+		_ = os.RemoveAll(home)
+	}, nil
+}
+
+// renderMeterAccounting reports what the neutral proxy measured and how far the
+// harness's own accounting drifted from it. Divergence is the number that
+// decides whether a cross-harness comparison is publishable at all: if the
+// proxy and the harness disagree about the same run, one of them is wrong.
+func renderMeterAccounting(results []result) string {
+	metered, selfReported, unmeasured, injected := 0, 0, 0, 0
+	var meterTokens, harnessTokens, comparableTokens int
+	var hit, miss int
+	for _, r := range results {
+		if r.Skipped || r.Meter == nil {
+			continue
+		}
+		metered++
+		meterTokens += r.Meter.PromptTokens + r.Meter.CompletionTokens
+		hit += r.Meter.CacheHitTokens
+		miss += r.Meter.CacheMissTokens
+		unmeasured += r.Meter.WithoutUsage
+		injected += r.Meter.Injected
+		// A run whose metrics file never landed has no harness number, so it
+		// stays out of both sides of the comparison; folding its meter tokens
+		// against a silent zero would invent a divergence.
+		if !r.Unaccounted {
+			selfReported++
+			harnessTokens += r.PromptTokens + r.CompletionTokens
+			comparableTokens += r.Meter.PromptTokens + r.Meter.CompletionTokens
+		}
+	}
+	if metered == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Metered at the boundary** (%d runs): tokens %s · cache hit %s",
+		metered, comma(meterTokens), pct(hit, hit+miss))
+	if injected > 0 {
+		fmt.Fprintf(&b, " · injected faults %d", injected)
+	}
+	if unmeasured > 0 {
+		fmt.Fprintf(&b, " · **responses without usage** %d", unmeasured)
+	}
+	if selfReported > 0 && comparableTokens > 0 {
+		fmt.Fprintf(&b, " · **self-report divergence** %s (harness %s vs meter %s over %d runs)",
+			divergence(harnessTokens, comparableTokens), comma(harnessTokens), comma(comparableTokens), selfReported)
+	}
+	return b.String() + "\n\n"
+}
+
+// divergence is the harness's own token count as a signed deviation from the
+// meter's. Anything but ~0 means the two disagree about the same traffic.
+func divergence(harness, meter int) string {
+	if meter == 0 {
+		return "—"
+	}
+	delta := float64(harness-meter) / float64(meter) * 100
+	return fmt.Sprintf("%+.1f%%", delta)
+}

--- a/cmd/e2ebench/meterrun_test.go
+++ b/cmd/e2ebench/meterrun_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func meteredRun(id string, meterPrompt, meterCompletion, selfPrompt, selfCompletion int) result {
+	r := result{task: task{ID: id}, Attempt: 1}
+	r.Meter = &meterUsage{
+		Requests: 4, PromptTokens: meterPrompt, CompletionTokens: meterCompletion,
+		CacheHitTokens: meterPrompt / 2, CacheMissTokens: meterPrompt - meterPrompt/2,
+	}
+	r.PromptTokens = selfPrompt
+	r.CompletionTokens = selfCompletion
+	return r
+}
+
+func TestMeterAccountingReportsAgreement(t *testing.T) {
+	got := renderMeterAccounting([]result{
+		meteredRun("a", 1000, 200, 1000, 200),
+		meteredRun("b", 500, 100, 500, 100),
+	})
+	for _, want := range []string{
+		"**Metered at the boundary** (2 runs)",
+		"tokens 1,800",
+		"cache hit 50%",
+		"**self-report divergence** +0.0%",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("meter line missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// The divergence is the publishability gate: if the proxy and the harness
+// disagree about the same traffic, one of them is wrong.
+func TestMeterAccountingSurfacesDisagreement(t *testing.T) {
+	got := renderMeterAccounting([]result{meteredRun("a", 1000, 0, 800, 0)})
+	if !strings.Contains(got, "-20.0%") {
+		t.Fatalf("want the harness's under-report surfaced:\n%s", got)
+	}
+}
+
+func TestMeterAccountingSurfacesUnmeasuredAndFaults(t *testing.T) {
+	r := meteredRun("a", 100, 10, 100, 10)
+	r.Meter.WithoutUsage = 2
+	r.Meter.Injected = 1
+	got := renderMeterAccounting([]result{r})
+	if !strings.Contains(got, "**responses without usage** 2") {
+		t.Fatalf("unmeasured responses must be visible:\n%s", got)
+	}
+	if !strings.Contains(got, "injected faults 1") {
+		t.Fatalf("injected faults must be visible:\n%s", got)
+	}
+}
+
+// An unaccounted run has no harness numbers to compare, so it must not drag the
+// divergence toward zero by contributing a silent 0.
+func TestMeterAccountingSkipsUnaccountedRunsInTheComparison(t *testing.T) {
+	lost := meteredRun("lost", 1000, 0, 0, 0)
+	lost.Unaccounted = true
+	got := renderMeterAccounting([]result{meteredRun("a", 1000, 0, 1000, 0), lost})
+	if !strings.Contains(got, "+0.0% (harness 1,000 vs meter 1,000 over 1 runs)") {
+		t.Fatalf("the comparison must drop the unaccounted run from BOTH sides:\n%s", got)
+	}
+	if !strings.Contains(got, "tokens 2,000") {
+		t.Fatalf("real spend still includes the unaccounted run:\n%s", got)
+	}
+}
+
+func TestMeterAccountingRendersNothingUnmetered(t *testing.T) {
+	if got := renderMeterAccounting([]result{{task: task{ID: "a"}, Attempt: 1}}); got != "" {
+		t.Fatalf("want no section when nothing was metered, got:\n%s", got)
+	}
+}
+
+func TestStartTaskMeterIsOffByDefault(t *testing.T) {
+	env, m, stop, err := startTaskMeter(suiteConfig{})
+	if err != nil || env != nil || m != nil || stop != nil {
+		t.Fatalf("metering must be opt-in: env=%v meter=%v err=%v", env, m, err)
+	}
+}
+
+func TestStartTaskMeterPointsTheChildAtTheProxy(t *testing.T) {
+	cfg := suiteConfig{meterConfig: writeConfig(t, twoProviderConfig), model: "kimi-k2"}
+	env, m, stop, err := startTaskMeter(cfg)
+	if err != nil {
+		t.Fatalf("startTaskMeter: %v", err)
+	}
+	defer stop()
+	if m == nil || len(env) != 1 || !strings.HasPrefix(env[0], "REASONIX_HOME=") {
+		t.Fatalf("env = %v, want a redirected REASONIX_HOME", env)
+	}
+	home := strings.TrimPrefix(env[0], "REASONIX_HOME=")
+	providers := readProviders(t, home)
+	for _, p := range providers {
+		if name, _ := p["name"].(string); name == "kimi" {
+			base, _ := p["base_url"].(string)
+			if !strings.HasPrefix(base, "http://127.0.0.1:") {
+				t.Fatalf("kimi base_url = %q, want the loopback meter", base)
+			}
+			return
+		}
+	}
+	t.Fatalf("kimi provider missing from the metered home: %v", providers)
+}

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -189,6 +189,7 @@ func renderBody(results []result) string {
 		comma(s.tools), comma(s.toolFails), s.compacts, currencySym(s.currency), s.cost)
 	b.WriteString(perSolvedLine(s))
 	b.WriteString(requestsBySourceLine(s.bySource))
+	b.WriteString(renderMeterAccounting(results))
 	b.WriteString(renderTimeAttribution(results))
 	b.WriteString(renderSolveProfiles(results))
 	b.WriteString(renderToolSurface(results))


### PR DESCRIPTION
First step of the Harness and LongRun benchmarks. It is deliberately one component:
the seam both of them need.

## Why a proxy, and not a metrics adapter per harness

The Harness benchmark's hard problem is not launching another agent — it is that
**no contestant should count its own tokens**. Reasonix writes `.run-metrics.json`;
OpenCode and friends do not; and a comparison where each harness self-reports its
spend is not evidence, especially when the comparison is published by one of them.

So the measurement moves off the harness and onto the request boundary. Every harness
talks to this proxy instead of the provider, and prompt / completion / cache-split
tokens are counted identically for all of them by a party with no stake in the result.

Reasonix needs **no kernel change** to be pointed at it: `REASONIX_HOME` already
redirects the config root, so the bench can write a temp config whose base URL is the
proxy. Any harness honouring a base URL is reachable the same way.

## The same seam is LongRun's fault injector

LongRun needs deterministic tool/API failures, and the request boundary is the only
place both benchmarks can reach without a harness's cooperation. Faults are keyed by
**request index** (`-faults 3:429,7:500`) so an arm replays the same failure at the
same point across harnesses. One seam, two benchmarks, instead of two parallel rigs.

## Two details that decide whether this measures anything

- **A streamed response carries no usage block unless the client asked for one.** A
  harness that never sets `stream_options.include_usage` would measure as *free*. The
  proxy injects that option into streamed requests that lack it, and leaves
  non-streamed bodies byte-untouched (`TestMeterLeavesNonStreamedRequestsAlone`).
- **A response with no usage is counted `unmeasured`, never zero.** Silent zeroes
  would flatter whichever harness reports least — the same reasoning that makes an
  unmeasured run non-honest in the integrity benchmark (#8038).

Both DeepSeek's `prompt_cache_hit_tokens`/`miss` split and the OpenAI-standard
`prompt_tokens_details.cached_tokens` are read, so the cache-hit axis stays comparable
across providers.

SSE frames are forwarded as they arrive rather than buffered — latency is itself one
of the metrics being compared, and a buffering proxy would silently change it.

## Verification

- 9 tests against an `httptest` upstream: non-streaming usage, streamed usage with
  verbatim frame forwarding, both cache spellings, the stream opt-in and its
  non-streaming counter-case, unmeasured responses, fault injection by index (asserting
  the faulted request is **not** forwarded upstream), and fault-spec parsing including
  five rejected malformed specs.
- `make lint` clean (it caught 3 `errcheck` and 1 `mapsloop` locally) · `gofmt` clean ·
  `go test ./cmd/e2ebench/` passes.

## Wiring (second commit)

`-meter <config.toml>` starts a per-task proxy, writes a temp config whose **benchmarked
provider** points at it, and hands the child `REASONIX_HOME`. No kernel change was
needed, and **no credential is read or copied**: the config names an `api_key_env`, so
only `base_url` is rewritten. Only the provider serving `-model` is redirected —
rewriting every endpoint would send one vendor's traffic to another's host.

The report then prints the **self-report divergence**:

```text
**Metered at the boundary** (49 runs): tokens 12,904,331 · cache hit 71% ·
**self-report divergence** +0.2% (harness 12,930,118 vs meter 12,904,331 over 49 runs)
```

That number is the publishability gate, and it is why **Reasonix is the first harness
metered**: it is the only one that self-reports, so it is the only one that can check
the proxy. If the two disagree about the same run, one is wrong and no cross-harness
figure is ready to publish.

### Two bugs the tests caught while wiring

- **The returned `stop` func recursed into itself.** The closure captured the *named
  return value* it was being assigned to, so every teardown overflowed the stack. Found
  by the first wiring test that actually started a meter.
- **The divergence used mismatched denominators** — the meter's tokens over every
  metered run against the harness's over only accounted ones — inventing a deficit out
  of arithmetic. Unaccounted runs now leave *both* sides of the comparison while still
  counting toward real spend.

### Function size

`runTask` and `main` went over the 120-line limit, so metering became a small type that
owns setup/teardown/recording and the checkpoint snapshotter setup moved next to the
rest of the checkpoint code. **The lint baseline is untouched** — repolint is clean
without `-update`.

## Still not in this PR

The non-Reasonix adapters (`-harness opencode|...`). The seam and its first, self-
checking adapter land here; adding a second harness is now a matter of an argv template
and a base-URL env var, not new measurement machinery.

Documentation-impact: updated - benchmarks/README.md gains a Neutral metering section and the `-meter` / `-faults` flag rows.
