### PR TITLE
bench(longrun): injected failure priced, and the long-session states reached directly

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -146,9 +146,38 @@ metered this way precisely because it *does* self-report: if the proxy and
 `.run-metrics.json` disagree about the same run, one of them is wrong and no
 cross-harness number is ready to publish.
 
-`-faults` injects provider failures at fixed request indices through the same
-proxy, which is what LongRun needs: deterministic 429/500 at the same point of
-a run, replayable across harnesses.
+## Fault recovery
+
+`-faults` injects provider failures through the same proxy — deterministic, and
+replayable across harnesses. Two forms:
+
+- `3:429` — a targeted failure at an exact request.
+- `every:5:500` — a cadence. **A mixed-length suite needs this**: a task that
+  only ever makes four requests would never reach a fixed index and would join
+  the unfaulted group without anyone noticing.
+
+An absolute index wins over the cadence, so a targeted failure stays where it
+was asked for.
+
+```sh
+go run ./cmd/e2ebench -meter ~/.reasonix/config.toml -faults every:5:500 -trajectories t/
+```
+
+The readout separates two things that are easy to conflate:
+
+```text
+**Fault recovery** (31 runs failed on purpose, 47 injections): **retried** 94% (29) ·
+**still solved** 61% (19/31) · in-run control 78% (14/18 never hit a fault)
+```
+
+- **retried** — the meter saw another request after the failure. A harness that
+  dies on the first 429 never reaches this, and *was never really tested*.
+- **still solved** — the task landed anyway. A harness can retry forever and
+  still not finish; that is not recovery.
+- **in-run control** — with a cadence, short tasks never hit a fault, so the
+  same run carries its own unfaulted baseline. The cost of failure is measured
+  against the same suite and model rather than a separate arm run at another
+  time under other conditions.
 
 ## task.toml schema
 
@@ -240,7 +269,7 @@ own outcome).
 | `-cache` | `cold` | Suite mode: `cold` runs each task as a fresh session (the fair cross-agent comparison arm); `warm` primes the provider prefix cache with a one-step run in the same workdir first, measuring the long-lived-session steady state. Never mix arms in one report — compare them with `-mode compare cold.json warm.json`. |
 | `-budget` | `800000` | Abort once total tokens cross this (`0` = no cap). Remaining tasks are reported as skipped. |
 | `-meter` | *(off)* | Suite mode: route the benchmarked provider through the neutral measuring proxy, using this `config.toml` as the source. Spend is then counted at the request boundary instead of trusted from the harness. See [Neutral metering](#neutral-metering). |
-| `-faults` | *(none)* | Suite mode: inject provider failures at fixed request indices, e.g. `3:429,7:500`. Requires `-meter` — the proxy is the only place a fault can be injected. |
+| `-faults` | *(none)* | Suite mode: inject provider failures through the meter — absolute indices (`3:429`) and/or a cadence that scales with the run (`every:5:500`). Requires `-meter`. See [Fault recovery](#fault-recovery). |
 
 Diff-mode flags:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -179,6 +179,42 @@ The readout separates two things that are easy to conflate:
   against the same suite and model rather than a separate arm run at another
   time under other conditions.
 
+## Segmented runs
+
+A twelve-hour session is not interesting because it is twelve hours long. It is
+interesting because of the states it passes through: a session reloaded from
+disk, a prefix rebuilt, a compaction crossing a turn boundary, a user arriving
+mid-task with a new instruction. `-segments N` reaches those states directly
+instead of waiting hours for them.
+
+```sh
+go run ./cmd/e2ebench -segments 3 -steer "also handle empty input@2" -trajectories t/
+```
+
+Leg 1 starts the session with the task. Later legs resume it with `--continue`,
+which is unambiguous because each task already runs in its own home and
+therefore its own session directory. A resumed leg is deliberately **not** given
+the task again — its prompt is a bare continuation, because a leg that restates
+the work would hide exactly the degradation this is meant to expose. A `-steer`
+entry replaces one leg's continuation with a user turn.
+
+Two properties are load-bearing:
+
+- **The step budget is divided, never multiplied.** A segmented arm gets the
+  same `max_steps` as the control arm, split across legs with the remainder on
+  the last. Otherwise the arm would win by being allowed to work longer.
+- **Each leg writes its own metrics file.** They share a work dir, so a single
+  `.run-metrics.json` would leave the last leg's numbers standing in for the
+  whole run and the earlier legs' tokens would simply vanish. `Segments` in the
+  JSON records how many legs a run had.
+
+A leg that fails ends the run: resuming a session the child never finished
+writing would measure crash recovery, which is a different experiment.
+
+Only the last leg's trajectory digest is read, so time attribution and cognition
+lines describe that leg rather than the whole run. Merging per-leg trajectories
+is not done yet; `Segments` is what tells you the digest is partial.
+
 ## task.toml schema
 
 `e2ebench` reads `benchmarks/e2e/tasks/<id>/task.toml` with the BurntSushi TOML
@@ -270,6 +306,8 @@ own outcome).
 | `-budget` | `800000` | Abort once total tokens cross this (`0` = no cap). Remaining tasks are reported as skipped. |
 | `-meter` | *(off)* | Suite mode: route the benchmarked provider through the neutral measuring proxy, using this `config.toml` as the source. Spend is then counted at the request boundary instead of trusted from the harness. See [Neutral metering](#neutral-metering). |
 | `-faults` | *(none)* | Suite mode: inject provider failures through the meter — absolute indices (`3:429`) and/or a cadence that scales with the run (`every:5:500`). Requires `-meter`. See [Fault recovery](#fault-recovery). |
+| `-segments` | `1` | Suite mode: split each task into N resumed legs (`--continue` between them). The step budget is **divided**, never multiplied. See [Segmented runs](#segmented-runs). |
+| `-steer` | *(none)* | Suite mode: deliver a user turn at a leg boundary, e.g. `"also handle empty input@2"`. Requires `-segments` to reach that leg. |
 
 Diff-mode flags:
 

--- a/cmd/e2ebench/checkpoints.go
+++ b/cmd/e2ebench/checkpoints.go
@@ -84,7 +84,7 @@ func (s *snapshotter) snapshotIfChanged() {
 	if err := copyDir(s.src, dir); err != nil {
 		return
 	}
-	os.Remove(filepath.Join(dir, ".run-metrics.json"))
+	dropHarnessArtifacts(dir)
 	s.taken = append(s.taken, checkpoint{Seq: len(s.taken) + 1, ElapsedMs: elapsed, dir: dir})
 }
 
@@ -113,7 +113,7 @@ func dirSignature(root string) uint64 {
 			}
 			return nil
 		}
-		if name == ".run-metrics.json" {
+		if isHarnessArtifact(name) {
 			return nil
 		}
 		info, err := d.Info()
@@ -352,7 +352,7 @@ func firstUsefulMutation(checkpoints []checkpoint, seedDir, finalDir string) int
 // solutionFiles maps relative path → final content for every file the run
 // created or changed; harness artifacts are not part of anyone's solution.
 func solutionFiles(seedDir, finalDir string) map[string]string {
-	skip := map[string]bool{".run-metrics.json": true, "verify.sh": true}
+	skip := map[string]bool{"verify.sh": true}
 	out := map[string]string{}
 	_ = filepath.WalkDir(finalDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -365,7 +365,7 @@ func solutionFiles(seedDir, finalDir string) map[string]string {
 			return nil
 		}
 		rel, _ := filepath.Rel(finalDir, path)
-		if skip[filepath.Base(rel)] {
+		if base := filepath.Base(rel); skip[base] || isHarnessArtifact(base) {
 			return nil
 		}
 		final, err := os.ReadFile(path)
@@ -394,4 +394,25 @@ func attachSnapshotter(cfg suiteConfig, t task, work string, startedAt time.Time
 		return nil, func() {}
 	}
 	return startSnapshotter(work, dir, startedAt), func() { _ = os.RemoveAll(dir) }
+}
+
+// isHarnessArtifact reports whether a work-dir entry belongs to the benchmark
+// rather than to anyone's solution. Segmented runs write one metrics file per
+// leg, so the name is a prefix match — a hard-coded ".run-metrics.json" would
+// let every later leg's file read as a change the agent made.
+func isHarnessArtifact(name string) bool {
+	return strings.HasPrefix(name, ".run-metrics") && strings.HasSuffix(name, ".json")
+}
+
+// dropHarnessArtifacts removes them from a snapshot copy.
+func dropHarnessArtifacts(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() && isHarnessArtifact(e.Name()) {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
 }

--- a/cmd/e2ebench/longrun.go
+++ b/cmd/e2ebench/longrun.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// faultRecovery splits a run by whether the meter actually failed it. With a
+// cadence, short tasks never reach a fault and form an in-run control group,
+// so the cost of failure is measured against the same suite and model rather
+// than against a separate arm run at a different time.
+type faultRecovery struct {
+	faulted, faultedSolved   int
+	unfaulted, unfaultSolved int
+	keptGoing                int // faulted runs that issued another request
+	injected                 int
+}
+
+func gatherFaultRecovery(results []result) faultRecovery {
+	var f faultRecovery
+	for _, r := range results {
+		if r.Skipped || r.Meter == nil || r.Attempt > 1 {
+			continue
+		}
+		if r.Meter.Injected == 0 {
+			f.unfaulted++
+			if r.Passed {
+				f.unfaultSolved++
+			}
+			continue
+		}
+		f.faulted++
+		f.injected += r.Meter.Injected
+		if r.Meter.RequestsAfterFault > 0 {
+			f.keptGoing++
+		}
+		if r.Passed {
+			f.faultedSolved++
+		}
+	}
+	return f
+}
+
+// renderFaultRecovery prices injected failure. Two different things are worth
+// separating: whether the harness kept talking after a failure at all, and
+// whether the task still landed. A harness can retry forever and still never
+// finish, and that is not recovery.
+func renderFaultRecovery(results []result) string {
+	f := gatherFaultRecovery(results)
+	if f.faulted == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Fault recovery** (%d runs failed on purpose, %d injections): **retried** %s (%d) · **still solved** %s (%d/%d)",
+		f.faulted, f.injected, pct(f.keptGoing, f.faulted), f.keptGoing,
+		pct(f.faultedSolved, f.faulted), f.faultedSolved, f.faulted)
+	if f.unfaulted > 0 {
+		fmt.Fprintf(&b, " · in-run control %s (%d/%d never hit a fault)",
+			pct(f.unfaultSolved, f.unfaulted), f.unfaultSolved, f.unfaulted)
+	}
+	return b.String() + "\n\n"
+}

--- a/cmd/e2ebench/longrun_test.go
+++ b/cmd/e2ebench/longrun_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func faultedRun(id string, injected, afterFault int, passed bool) result {
+	r := result{task: task{ID: id}, Attempt: 1, Passed: passed}
+	r.Meter = &meterUsage{Requests: 10, Injected: injected, RequestsAfterFault: afterFault}
+	return r
+}
+
+func TestFaultCadenceScalesWithTheRun(t *testing.T) {
+	script, err := parseFaultScript("every:5:500")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, index := range []int{5, 10, 15} {
+		if status, ok := script.statusFor(index); !ok || status != 500 {
+			t.Fatalf("request %d = %d/%v, want an injected 500", index, status, ok)
+		}
+	}
+	for _, index := range []int{1, 4, 6, 9} {
+		if _, ok := script.statusFor(index); ok {
+			t.Fatalf("request %d must be forwarded", index)
+		}
+	}
+}
+
+// An absolute index is a targeted failure; a cadence is background pressure.
+// The targeted one must stay exactly where it was asked for.
+func TestAbsoluteFaultWinsOverTheCadence(t *testing.T) {
+	script, err := parseFaultScript("10:429,every:5:500")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if status, _ := script.statusFor(10); status != 429 {
+		t.Fatalf("request 10 = %d, want the targeted 429", status)
+	}
+	if status, _ := script.statusFor(5); status != 500 {
+		t.Fatalf("request 5 = %d, want the cadence 500", status)
+	}
+}
+
+func TestFaultScriptRejectsMalformedCadence(t *testing.T) {
+	for _, bad := range []string{"every:5", "every:0:500", "every:x:500", "every:5:200"} {
+		if _, err := parseFaultScript(bad); err == nil {
+			t.Fatalf("%q must be rejected", bad)
+		}
+	}
+}
+
+func TestMeterCountsRequestsAfterAFault(t *testing.T) {
+	upstream := okUpstream()
+	script, _ := parseFaultScript("2:429")
+	m, base, stop := meterAgainst(t, upstream, script)
+	defer stop()
+	for range 4 {
+		post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
+	}
+	got := m.snapshot()
+	if got.Injected != 1 {
+		t.Fatalf("injected = %d, want 1", got.Injected)
+	}
+	if got.RequestsAfterFault != 2 {
+		t.Fatalf("requests after fault = %d, want 2 (requests 3 and 4)", got.RequestsAfterFault)
+	}
+}
+
+func TestMeterCountsNoRequestsAfterFaultWhenTheHarnessGivesUp(t *testing.T) {
+	script, _ := parseFaultScript("2:429")
+	m, base, stop := meterAgainst(t, okUpstream(), script)
+	defer stop()
+	for range 2 {
+		post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
+	}
+	if got := m.snapshot(); got.RequestsAfterFault != 0 {
+		t.Fatalf("requests after fault = %d, want 0 — nothing followed the failure", got.RequestsAfterFault)
+	}
+}
+
+func TestFaultRecoverySeparatesRetryingFromSolving(t *testing.T) {
+	got := renderFaultRecovery([]result{
+		faultedRun("solved-through", 2, 5, true),
+		faultedRun("retried-but-lost", 1, 4, false),
+		faultedRun("gave-up", 1, 0, false),
+		faultedRun("never-faulted", 0, 0, true),
+	})
+	for _, want := range []string{
+		"**Fault recovery** (3 runs failed on purpose, 4 injections)",
+		"**retried** 67% (2)",
+		"**still solved** 33% (1/3)",
+		"in-run control 100% (1/1 never hit a fault)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("recovery line missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFaultRecoveryRendersNothingWithoutInjections(t *testing.T) {
+	if got := renderFaultRecovery([]result{faultedRun("clean", 0, 0, true)}); got != "" {
+		t.Fatalf("want no section when nothing was injected, got:\n%s", got)
+	}
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -120,6 +120,9 @@ type result struct {
 	// and token aggregates instead of being averaged in as zero, which would
 	// quietly understate every published per-task figure.
 	Unaccounted bool `json:"unaccounted"`
+	// Segments is how many resumed legs the run was split into (1 = a single
+	// leg). Above 1 the trajectory digest covers only the last leg.
+	Segments int `json:"segments,omitempty"`
 	// Partial marks accounting recovered from an in-flight snapshot after the
 	// agent was killed. The numbers are real but stop at the last snapshot, so
 	// they are counted as lower bounds rather than dropped.
@@ -227,8 +230,7 @@ func main() {
 	cacheArm := flag.String("cache", "cold", "suite mode: cold (fresh session per task) | warm (prefix-warming one-step run in the same workdir before the graded run)")
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
-	meterConfig := flag.String("meter", "", "suite mode: route the benchmarked provider through the neutral measuring proxy, using this config.toml as the source (e.g. ~/.reasonix/config.toml). Spend is then counted at the request boundary instead of trusted from the harness")
-	faultSpec := flag.String("faults", "", "suite mode: inject provider failures through the meter — absolute indices (3:429) and/or a cadence that scales with the run (every:5:500). Requires -meter; the report gains a fault-recovery readout")
+	pressure := registerPressureFlags()
 	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge) | governor (exploration-phase reasoning governor) | memory-off (hide the memory store: MemoryBench counterfactual arm)")
 	forkCapture := flag.String("fork-capture", "", "suite mode: capture a fork bundle per task at first EBM eligibility into <dir>/<task-id>")
 	bundles := flag.String("bundles", "", "fork mode: directory of captured bundles (<task-id>/bundle.json)")
@@ -311,12 +313,12 @@ func main() {
 		return
 	}
 
-	meterSource, faults := meterSettings(*meterConfig, *faultSpec)
+	meterSource, faults, segments, steers := pressure.settings()
 	runSuiteMode(suiteConfig{
 		bin: *bin, model: *model, profile: profile, arm: arm, budget: *budget,
 		trajDir: *trajDir, forcePlanner: *forcePlanner, attempts: *attempts,
 		cacheArm: cache, effort: *effort, checkpoints: *checkpoints, policy: *policyFlag,
-		forkCapture: *forkCapture, meterConfig: meterSource, meterFaults: faults,
+		forkCapture: *forkCapture, meterConfig: meterSource, meterFaults: faults, segments: segments, steers: steers,
 	}, *suite, *taskFilter, *outMD, *outJSON)
 }
 
@@ -456,6 +458,10 @@ type suiteConfig struct {
 	// redirected through the neutral meter; empty leaves runs unmetered.
 	meterConfig string
 	meterFaults faultScript
+	// segments splits each task into that many resumed legs; steers delivers a
+	// user turn at a leg boundary. Both are LongRun pressure, not defaults.
+	segments int
+	steers   map[int]string
 }
 
 // runSuite runs each task in order until the token budget is exhausted;
@@ -503,13 +509,15 @@ func runTask(cfg suiteConfig, t task) result {
 		r.PlanForced = true
 	}
 
+	// The per-leg file names are decided in runSegments; only the directory has
+	// to exist before the first child starts, and the digest below reads the
+	// last leg's file.
 	trajPath := ""
 	if cfg.trajDir != "" {
 		if err := os.MkdirAll(cfg.trajDir, 0o755); err != nil {
 			r.Note = "trajectory dir: " + err.Error()
 			return r
 		}
-		trajPath = filepath.Join(cfg.trajDir, t.ID+".trajectory.jsonl")
 	}
 
 	work, err := os.MkdirTemp("", "e2ebench-"+t.ID+"-")
@@ -533,11 +541,6 @@ func runTask(cfg suiteConfig, t task) result {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(t.TimeoutSec)*time.Second)
 	defer cancel()
 
-	metricsPath := filepath.Join(work, ".run-metrics.json")
-	args := buildRunTaskArgs(cfg, metricsPath, trajPath, t.MaxSteps, t.Prompt)
-
-	cmd := exec.CommandContext(ctx, cfg.bin, args...)
-	cmd.Dir = work
 	extraEnv, seedNote := taskExperimentEnv(cfg, t, work)
 	if seedNote != "" {
 		r.Note = seedNote
@@ -545,27 +548,18 @@ func runTask(cfg suiteConfig, t task) result {
 	mtr := attachMeter(cfg, &r)
 	defer mtr.close()
 	extraEnv = append(extraEnv, mtr.env...)
-	if len(extraEnv) > 0 {
-		cmd.Env = append(os.Environ(), extraEnv...)
-	}
-	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
-	cmd.Stderr = os.Stderr
-	cmd.WaitDelay = 10 * time.Second // bound the wait for a stuck child after ctx timeout
 	startedAt := time.Now()
 	snap, dropSnapshots := attachSnapshotter(cfg, t, work, startedAt)
 	defer dropSnapshots()
-	runErr := cmd.Run()
+	runErr := runSegments(ctx, cfg, t, work, cfg.trajDir, extraEnv, &r)
 	r.WallMs = time.Since(startedAt).Milliseconds()
 	var taken []checkpoint
 	if snap != nil {
 		taken = snap.halt()
 	}
 
-	if m, err := readMetrics(metricsPath); err == nil {
-		r.runMetrics = m
-	}
 	mtr.record(&r)
-	if trajPath != "" {
+	if trajPath = lastSegmentTrajectory(cfg.trajDir, t.ID, r.Segments); trajPath != "" {
 		if summary, err := summarizeTrajectory(trajPath); err == nil {
 			r.Trajectory = summary
 		}
@@ -633,6 +627,18 @@ func buildRunTaskArgs(cfg suiteConfig, metricsPath, trajectoryPath string, maxSt
 		args = append(args, "--ablate", cfg.arm.String())
 	}
 	return append(args, prompt)
+}
+
+// buildSegmentArgs is buildRunTaskArgs for one leg: a resumed leg adds
+// --continue, which is unambiguous because each task runs in its own home and
+// therefore its own session directory.
+func buildSegmentArgs(cfg suiteConfig, seg segment, metricsPath, trajectoryPath string) []string {
+	args := buildRunTaskArgs(cfg, metricsPath, trajectoryPath, seg.maxSteps, seg.prompt)
+	if !seg.resume {
+		return args
+	}
+	// The prompt is the last argument; --continue must precede it.
+	return append(args[:len(args)-1:len(args)-1], "--continue", args[len(args)-1])
 }
 
 // warmPrefix primes the provider prefix cache for work's session shape with a

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -228,7 +228,7 @@ func main() {
 	effort := flag.String("effort", "", "reasoning effort override passed to the agent (model-specific levels, e.g. disabled|low|high|max); empty = model default")
 	checkpoints := flag.Bool("checkpoints", false, "suite mode: snapshot the workdir on every change and grade each snapshot offline after the run, yielding first_correct_ms (TTFCS) and post_solve_waste_ms")
 	meterConfig := flag.String("meter", "", "suite mode: route the benchmarked provider through the neutral measuring proxy, using this config.toml as the source (e.g. ~/.reasonix/config.toml). Spend is then counted at the request boundary instead of trusted from the harness")
-	faultSpec := flag.String("faults", "", "suite mode: inject provider failures at fixed request indices, e.g. 3:429,7:500 (requires -meter)")
+	faultSpec := flag.String("faults", "", "suite mode: inject provider failures through the meter — absolute indices (3:429) and/or a cadence that scales with the run (every:5:500). Requires -meter; the report gains a fault-recovery readout")
 	policyFlag := flag.String("policy", "", "suite mode: experiment arm — empty (baseline) | ebm (evidence-before-more-mutation nudge) | governor (exploration-phase reasoning governor) | memory-off (hide the memory store: MemoryBench counterfactual arm)")
 	forkCapture := flag.String("fork-capture", "", "suite mode: capture a fork bundle per task at first EBM eligibility into <dir>/<task-id>")
 	bundles := flag.String("bundles", "", "fork mode: directory of captured bundles (<task-id>/bundle.json)")
@@ -455,7 +455,7 @@ type suiteConfig struct {
 	// meterConfig is the real config.toml whose provider endpoint each run is
 	// redirected through the neutral meter; empty leaves runs unmetered.
 	meterConfig string
-	meterFaults map[int]int
+	meterFaults faultScript
 }
 
 // runSuite runs each task in order until the token budget is exhausted;

--- a/cmd/e2ebench/meter.go
+++ b/cmd/e2ebench/meter.go
@@ -23,9 +23,10 @@ import (
 type meter struct {
 	upstream *url.URL
 	client   *http.Client
-	faults   map[int]int // 1-based request index -> status to return instead
+	faults   faultScript
 
-	mu sync.Mutex
+	mu        sync.Mutex
+	lastFault int
 	meterUsage
 }
 
@@ -40,35 +41,80 @@ type meterUsage struct {
 	CacheMissTokens  int `json:"cache_miss_tokens"`
 	Injected         int `json:"injected_faults,omitempty"`
 	WithoutUsage     int `json:"responses_without_usage,omitempty"`
+	// RequestsAfterFault counts requests issued after the first injected
+	// failure: the harness's own evidence that it retried rather than died.
+	RequestsAfterFault int `json:"requests_after_fault,omitempty"`
 }
 
-// parseFaultScript reads "3:429,7:500" — inject that status instead of
-// forwarding the Nth request. Deterministic by index so a LongRun arm replays
-// the same failures across harnesses.
-func parseFaultScript(spec string) (map[int]int, error) {
-	if strings.TrimSpace(spec) == "" {
-		return nil, nil
+// faultScript decides which requests fail. Absolute indices pin a failure to
+// an exact point; a cadence scales with the run, which is what a mixed-length
+// suite needs — a task that only ever makes four requests would never reach a
+// fixed index, and would silently join the unfaulted control group.
+type faultScript struct {
+	at          map[int]int // 1-based request index -> status
+	everyN      int
+	everyStatus int
+}
+
+func (f faultScript) empty() bool { return len(f.at) == 0 && f.everyN == 0 }
+
+// statusFor reports the status to inject instead of forwarding. An absolute
+// index wins over the cadence so a targeted failure stays exactly where it was
+// asked for.
+func (f faultScript) statusFor(index int) (int, bool) {
+	if status, ok := f.at[index]; ok {
+		return status, true
 	}
-	out := map[int]int{}
+	if f.everyN > 0 && index%f.everyN == 0 {
+		return f.everyStatus, true
+	}
+	return 0, false
+}
+
+// parseFaultScript reads "3:429,every:5:500": fail the 3rd request with 429 and
+// every 5th with 500. Deterministic either way, so a LongRun arm replays the
+// same failures across harnesses.
+func parseFaultScript(spec string) (faultScript, error) {
+	out := faultScript{at: map[int]int{}}
+	if strings.TrimSpace(spec) == "" {
+		return faultScript{}, nil
+	}
 	for field := range strings.SplitSeq(spec, ",") {
-		idx, status, ok := strings.Cut(strings.TrimSpace(field), ":")
-		if !ok {
-			return nil, fmt.Errorf("fault %q: want <request-index>:<status>", field)
+		field = strings.TrimSpace(field)
+		if rest, ok := strings.CutPrefix(field, "every:"); ok {
+			n, status, err := parseFaultPair(field, rest)
+			if err != nil {
+				return faultScript{}, err
+			}
+			out.everyN, out.everyStatus = n, status
+			continue
 		}
-		i, err := strconv.Atoi(strings.TrimSpace(idx))
-		if err != nil || i < 1 {
-			return nil, fmt.Errorf("fault %q: request index must be a positive integer", field)
+		index, status, err := parseFaultPair(field, field)
+		if err != nil {
+			return faultScript{}, err
 		}
-		code, err := strconv.Atoi(strings.TrimSpace(status))
-		if err != nil || code < 400 || code > 599 {
-			return nil, fmt.Errorf("fault %q: status must be 4xx or 5xx", field)
-		}
-		out[i] = code
+		out.at[index] = status
 	}
 	return out, nil
 }
 
-func newMeter(upstream string, faults map[int]int) (*meter, error) {
+func parseFaultPair(field, pair string) (n, status int, err error) {
+	left, right, ok := strings.Cut(pair, ":")
+	if !ok {
+		return 0, 0, fmt.Errorf("fault %q: want <request-index>:<status> or every:<n>:<status>", field)
+	}
+	n, err = strconv.Atoi(strings.TrimSpace(left))
+	if err != nil || n < 1 {
+		return 0, 0, fmt.Errorf("fault %q: the request count must be a positive integer", field)
+	}
+	status, err = strconv.Atoi(strings.TrimSpace(right))
+	if err != nil || status < 400 || status > 599 {
+		return 0, 0, fmt.Errorf("fault %q: status must be 4xx or 5xx", field)
+	}
+	return n, status, nil
+}
+
+func newMeter(upstream string, faults faultScript) (*meter, error) {
 	u, err := url.Parse(strings.TrimSuffix(strings.TrimSpace(upstream), "/"))
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("meter upstream %q is not an absolute URL", upstream)
@@ -98,9 +144,16 @@ func (m *meter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.mu.Lock()
 	m.Requests++
 	index := m.Requests
-	status, faulted := m.faults[index]
-	if faulted {
+	status, faulted := m.faults.statusFor(index)
+	switch {
+	case faulted:
 		m.Injected++
+		m.lastFault = index
+	case m.lastFault > 0:
+		// Evidence the harness kept going after being failed. A harness that
+		// gives up on the first 429 never reaches here, and that is the
+		// difference between "recovered" and "was never really tested".
+		m.RequestsAfterFault++
 	}
 	m.mu.Unlock()
 

--- a/cmd/e2ebench/meter_test.go
+++ b/cmd/e2ebench/meter_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func meterAgainst(t *testing.T, upstream http.Handler, faults map[int]int) (*meter, string, func()) {
+func meterAgainst(t *testing.T, upstream http.Handler, faults faultScript) (*meter, string, func()) {
 	t.Helper()
 	up := httptest.NewServer(upstream)
 	m, err := newMeter(up.URL, faults)
@@ -38,7 +38,7 @@ func TestMeterCountsNonStreamingUsage(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"choices":[{"message":{"content":"hi"}}],"usage":{"prompt_tokens":100,"completion_tokens":20,"prompt_cache_hit_tokens":64,"prompt_cache_miss_tokens":36}}`)
 	})
-	m, base, stop := meterAgainst(t, upstream, nil)
+	m, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 
 	resp := post(t, base, "/chat/completions", `{"model":"x"}`)
@@ -64,7 +64,7 @@ func TestMeterReadsOpenAICachedTokensSpelling(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"usage":{"prompt_tokens":90,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":30}}}`)
 	})
-	m, base, stop := meterAgainst(t, upstream, nil)
+	m, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
 
@@ -81,7 +81,7 @@ func TestMeterCountsStreamedUsageAndForwardsFrames(t *testing.T) {
 		io.WriteString(w, "data: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\n")
 		io.WriteString(w, "data: [DONE]\n\n")
 	})
-	m, base, stop := meterAgainst(t, upstream, nil)
+	m, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 
 	resp := post(t, base, "/chat/completions", `{"model":"x","stream":true}`)
@@ -104,7 +104,7 @@ func TestMeterOptsStreamedRequestsIntoUsage(t *testing.T) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		io.WriteString(w, "data: [DONE]\n\n")
 	})
-	_, base, stop := meterAgainst(t, upstream, nil)
+	_, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 	post(t, base, "/chat/completions", `{"model":"x","stream":true}`).Body.Close()
 
@@ -125,7 +125,7 @@ func TestMeterLeavesNonStreamedRequestsAlone(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
 	})
-	_, base, stop := meterAgainst(t, upstream, nil)
+	_, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
 
@@ -139,7 +139,7 @@ func TestMeterReportsResponsesWithoutUsage(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"choices":[]}`)
 	})
-	m, base, stop := meterAgainst(t, upstream, nil)
+	m, base, stop := meterAgainst(t, upstream, faultScript{})
 	defer stop()
 	post(t, base, "/chat/completions", `{"model":"x"}`).Body.Close()
 
@@ -155,7 +155,7 @@ func TestMeterInjectsFaultsByRequestIndex(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		io.WriteString(w, `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
 	})
-	m, base, stop := meterAgainst(t, upstream, map[int]int{2: 429})
+	m, base, stop := meterAgainst(t, upstream, faultScript{at: map[int]int{2: 429}})
 	defer stop()
 
 	for i := range 3 {
@@ -182,10 +182,10 @@ func TestParseFaultScript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if got[3] != 429 || got[7] != 500 || len(got) != 2 {
+	if got.at[3] != 429 || got.at[7] != 500 || len(got.at) != 2 {
 		t.Fatalf("faults = %v", got)
 	}
-	if got, err := parseFaultScript(""); err != nil || got != nil {
+	if got, err := parseFaultScript(""); err != nil || !got.empty() {
 		t.Fatalf("empty spec = %v, %v", got, err)
 	}
 	for _, bad := range []string{"3", "0:429", "3:200", "x:429", "3:999"} {
@@ -196,7 +196,15 @@ func TestParseFaultScript(t *testing.T) {
 }
 
 func TestNewMeterRejectsRelativeUpstream(t *testing.T) {
-	if _, err := newMeter("/v1", nil); err == nil {
+	if _, err := newMeter("/v1", faultScript{}); err == nil {
 		t.Fatal("a relative upstream must be rejected")
 	}
+}
+
+// okUpstream is a minimal usage-reporting upstream for fault tests.
+func okUpstream() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	})
 }

--- a/cmd/e2ebench/meterrun.go
+++ b/cmd/e2ebench/meterrun.go
@@ -9,13 +9,13 @@ import (
 // meterSettings validates the metering flags together: a fault script has
 // nowhere to be injected without the proxy, so asking for one without -meter
 // is a mistake worth stopping for rather than silently ignoring.
-func meterSettings(configPath, faultSpec string) (string, map[int]int) {
+func meterSettings(configPath, faultSpec string) (string, faultScript) {
 	faults, err := parseFaultScript(faultSpec)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "faults:", err)
 		os.Exit(2)
 	}
-	if len(faults) > 0 && strings.TrimSpace(configPath) == "" {
+	if !faults.empty() && strings.TrimSpace(configPath) == "" {
 		fmt.Fprintln(os.Stderr, "faults: -faults needs -meter; the proxy is where a fault can be injected")
 		os.Exit(2)
 	}

--- a/cmd/e2ebench/report.go
+++ b/cmd/e2ebench/report.go
@@ -193,6 +193,7 @@ func renderBody(results []result) string {
 	b.WriteString(perSolvedLine(s))
 	b.WriteString(requestsBySourceLine(s.bySource))
 	b.WriteString(renderMeterAccounting(results))
+	b.WriteString(renderFaultRecovery(results))
 	b.WriteString(renderTimeAttribution(results))
 	b.WriteString(renderSolveProfiles(results))
 	b.WriteString(renderToolSurface(results))

--- a/cmd/e2ebench/segmentrun.go
+++ b/cmd/e2ebench/segmentrun.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// runSegments drives a task's legs and folds their accounting into one result.
+// Each leg writes its own metrics file: sharing one path would let the last
+// leg's numbers stand in for the whole run, and the tokens the earlier legs
+// spent would simply vanish. Only the final leg's trajectory digest is kept;
+// Segments records how many legs it does not cover.
+func runSegments(ctx context.Context, cfg suiteConfig, t task, work, trajDir string, env []string, r *result) error {
+	segs := planSegments(t, cfg.segments, cfg.steers)
+	r.Segments = len(segs)
+	var runErr error
+	for _, seg := range segs {
+		metricsPath := filepath.Join(work, fmt.Sprintf(".run-metrics-%d.json", seg.index))
+		trajPath := segmentTrajectoryPath(trajDir, t.ID, seg, len(segs))
+		args := buildSegmentArgs(cfg, seg, metricsPath, trajPath)
+
+		cmd := exec.CommandContext(ctx, cfg.bin, args...)
+		cmd.Dir = work
+		if len(env) > 0 {
+			cmd.Env = append(os.Environ(), env...)
+		}
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		cmd.WaitDelay = 10 * time.Second
+		runErr = cmd.Run()
+
+		if m, err := readMetrics(metricsPath); err == nil {
+			foldSegmentMetrics(r, m, seg.index)
+		}
+		// A leg that died takes the run with it: resuming a session the child
+		// never finished writing would measure the harness's crash recovery,
+		// which is a different experiment.
+		if runErr != nil || ctx.Err() != nil {
+			break
+		}
+	}
+	return runErr
+}
+
+// segmentTrajectoryPath keeps one file per leg so a resumed leg cannot truncate
+// the record of the one before it.
+func segmentTrajectoryPath(dir, id string, seg segment, total int) string {
+	if dir == "" {
+		return ""
+	}
+	if total < 2 {
+		return filepath.Join(dir, id+".trajectory.jsonl")
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.seg%d.trajectory.jsonl", id, seg.index))
+}
+
+// lastSegmentTrajectory names the file whose digest represents the run. Only
+// the final leg's is read; Segments in the JSON says how many were not.
+func lastSegmentTrajectory(dir, id string, segments int) string {
+	if dir == "" {
+		return ""
+	}
+	if segments < 2 {
+		return filepath.Join(dir, id+".trajectory.jsonl")
+	}
+	return filepath.Join(dir, fmt.Sprintf("%s.seg%d.trajectory.jsonl", id, segments))
+}
+
+// foldSegmentMetrics adds one leg's spend to the run. The first leg's metrics
+// establish the non-additive fields (currency, outcome); later legs contribute
+// their totals, and the last leg's outcome wins because it is the one that
+// ended the run.
+func foldSegmentMetrics(r *result, m runMetrics, index int) {
+	if index == 1 {
+		r.runMetrics = m
+		return
+	}
+	r.PromptTokens += m.PromptTokens
+	r.CompletionTokens += m.CompletionTokens
+	r.CacheHitTokens += m.CacheHitTokens
+	r.CacheMissTokens += m.CacheMissTokens
+	r.Cost += m.Cost
+	r.Steps += m.Steps
+	r.Compactions += m.Compactions
+	r.ToolCalls += m.ToolCalls
+	r.ToolFailures += m.ToolFailures
+	r.SubagentToolCalls += m.SubagentToolCalls
+	r.Retries += m.Retries
+	r.Complete = m.Complete
+	if m.Outcome != "" {
+		r.Outcome = m.Outcome
+	}
+	for name, n := range m.ToolCallsByName {
+		if r.ToolCallsByName == nil {
+			r.ToolCallsByName = map[string]int{}
+		}
+		r.ToolCallsByName[name] += n
+	}
+	for reason, n := range m.PrefixChangeReasonCounts {
+		if r.PrefixChangeReasonCounts == nil {
+			r.PrefixChangeReasonCounts = map[string]int{}
+		}
+		r.PrefixChangeReasonCounts[reason] += n
+	}
+	accumulateSources(r.UsageBySource, m.UsageBySource)
+}

--- a/cmd/e2ebench/segmentrun_test.go
+++ b/cmd/e2ebench/segmentrun_test.go
@@ -9,16 +9,23 @@ import (
 	"testing"
 )
 
-// fakeAgent stands in for the reasonix binary: it records the argv of every
-// invocation and writes the metrics file it was told to. That makes segment
-// accounting verifiable without a provider, which matters because the failure
-// mode being guarded against — a later leg's numbers replacing an earlier
-// leg's instead of adding to it — is invisible in any single run.
-func fakeAgent(t *testing.T, promptTokens, completionTokens int) (bin, argvLog string) {
+// requireShellStub skips where a #!/usr/bin/env bash stub cannot be executed.
+// Every test that writes its own stub must call it: exec fails silently enough
+// on Windows that the assertion which follows blames the code instead.
+func requireShellStub(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("the stub agent is a shell script")
 	}
+}
+
+// fakeAgent stands in for the reasonix binary: it records every invocation's
+// argv and writes the metrics file it was told to, making segment accounting
+// verifiable without a provider. The failure it guards — a later leg replacing
+// an earlier leg's numbers — is invisible in any single run.
+func fakeAgent(t *testing.T, promptTokens, completionTokens int) (bin, argvLog string) {
+	t.Helper()
+	requireShellStub(t)
 	dir := t.TempDir()
 	argvLog = filepath.Join(dir, "argv.log")
 	bin = filepath.Join(dir, "fake-agent")
@@ -104,6 +111,7 @@ func TestSegmentedRunKeepsPerLegMetricsApart(t *testing.T) {
 }
 
 func TestSegmentedRunStopsAtTheFirstFailedLeg(t *testing.T) {
+	requireShellStub(t)
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "failing-agent")
 	log := filepath.Join(dir, "calls.log")

--- a/cmd/e2ebench/segmentrun_test.go
+++ b/cmd/e2ebench/segmentrun_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// fakeAgent stands in for the reasonix binary: it records the argv of every
+// invocation and writes the metrics file it was told to. That makes segment
+// accounting verifiable without a provider, which matters because the failure
+// mode being guarded against — a later leg's numbers replacing an earlier
+// leg's instead of adding to it — is invisible in any single run.
+func fakeAgent(t *testing.T, promptTokens, completionTokens int) (bin, argvLog string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub agent is a shell script")
+	}
+	dir := t.TempDir()
+	argvLog = filepath.Join(dir, "argv.log")
+	bin = filepath.Join(dir, "fake-agent")
+	script := `#!/usr/bin/env bash
+printf '%s\n' "$*" >> ` + argvLog + `
+metrics=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --metrics) metrics="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+[ -n "$metrics" ] && cat > "$metrics" <<JSON
+{"prompt_tokens":` + strconv.Itoa(promptTokens) + `,"completion_tokens":` + strconv.Itoa(completionTokens) + `,"steps":2,"cost":0.5,"currency":"USD","complete":true,"tool_calls":3}
+JSON
+exit 0
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin, argvLog
+}
+
+func TestSegmentedRunAddsEveryLegsSpend(t *testing.T) {
+	bin, argvLog := fakeAgent(t, 100, 20)
+	cfg := suiteConfig{bin: bin, segments: 3}
+	task := task{ID: "seg", Prompt: "fix it", MaxSteps: 9, TimeoutSec: 60}
+	var r result
+	if err := runSegments(t.Context(), cfg, task, t.TempDir(), "", nil, &r); err != nil {
+		t.Fatalf("runSegments: %v", err)
+	}
+
+	if r.Segments != 3 {
+		t.Fatalf("segments = %d, want 3", r.Segments)
+	}
+	if r.PromptTokens != 300 || r.CompletionTokens != 60 {
+		t.Fatalf("tokens = %d/%d, want 300/60 — a later leg replaced an earlier one instead of adding",
+			r.PromptTokens, r.CompletionTokens)
+	}
+	if r.Steps != 6 || r.ToolCalls != 9 {
+		t.Fatalf("steps=%d tools=%d, want 6/9 summed across legs", r.Steps, r.ToolCalls)
+	}
+	if r.Cost != 1.5 {
+		t.Fatalf("cost = %v, want 1.5", r.Cost)
+	}
+	if r.Currency != "USD" || !r.Complete {
+		t.Fatalf("non-additive fields lost: %+v", r.runMetrics)
+	}
+
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("invocations = %d, want 3", len(lines))
+	}
+	if strings.Contains(lines[0], "--continue") {
+		t.Fatalf("leg 1 must start a fresh session: %s", lines[0])
+	}
+	for i, line := range lines[1:] {
+		if !strings.Contains(line, "--continue") {
+			t.Fatalf("leg %d must resume: %s", i+2, line)
+		}
+		if strings.Contains(line, "fix it") {
+			t.Fatalf("leg %d restated the task: %s", i+2, line)
+		}
+	}
+}
+
+func TestSegmentedRunKeepsPerLegMetricsApart(t *testing.T) {
+	bin, _ := fakeAgent(t, 10, 1)
+	work := t.TempDir()
+	var r result
+	if err := runSegments(t.Context(), suiteConfig{bin: bin, segments: 2}, task{ID: "x", Prompt: "p", MaxSteps: 4, TimeoutSec: 60}, work, "", nil, &r); err != nil {
+		t.Fatalf("runSegments: %v", err)
+	}
+	for _, name := range []string{".run-metrics-1.json", ".run-metrics-2.json"} {
+		if _, err := os.Stat(filepath.Join(work, name)); err != nil {
+			t.Fatalf("%s missing: one shared path would have let the last leg overwrite the rest", name)
+		}
+	}
+}
+
+func TestSegmentedRunStopsAtTheFirstFailedLeg(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "failing-agent")
+	log := filepath.Join(dir, "calls.log")
+	script := "#!/usr/bin/env bash\necho x >> " + log + "\nexit 3\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var r result
+	err := runSegments(t.Context(), suiteConfig{bin: bin, segments: 3}, task{ID: "x", Prompt: "p", MaxSteps: 6, TimeoutSec: 60}, t.TempDir(), "", nil, &r)
+	if err == nil {
+		t.Fatal("a failed leg must surface as the run's error")
+	}
+	calls, _ := os.ReadFile(log)
+	if got := len(strings.Fields(string(calls))); got != 1 {
+		t.Fatalf("invocations = %d, want 1 — resuming a session the child never finished is a different experiment", got)
+	}
+}
+
+func TestUnsegmentedRunKeepsTheOriginalTrajectoryPath(t *testing.T) {
+	if got := lastSegmentTrajectory("t", "task-a", 1); got != filepath.Join("t", "task-a.trajectory.jsonl") {
+		t.Fatalf("path = %q, want the unsegmented name", got)
+	}
+	if got := lastSegmentTrajectory("t", "task-a", 3); got != filepath.Join("t", "task-a.seg3.trajectory.jsonl") {
+		t.Fatalf("path = %q, want the last leg's file", got)
+	}
+	if got := lastSegmentTrajectory("", "task-a", 3); got != "" {
+		t.Fatalf("path = %q, want empty when trajectories are off", got)
+	}
+}

--- a/cmd/e2ebench/segments.go
+++ b/cmd/e2ebench/segments.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// segment is one leg of a task: leg 1 starts the session, later legs resume it.
+// Segmenting reaches the states that only appear in a long session — reload,
+// prefix reconstruction, compaction across a boundary — without waiting hours
+// for them to arrive on their own.
+type segment struct {
+	index    int
+	maxSteps int
+	prompt   string
+	resume   bool
+}
+
+// continuationPrompt is deliberately empty of new instruction: a resumed leg
+// must exercise the session's own memory of the task, not be handed the task
+// again. A prompt that restates the work would hide exactly the degradation
+// this measures.
+const continuationPrompt = "Continue from where you left off."
+
+// planSegments splits a task into count legs, dividing its step budget and
+// giving the remainder to the last leg so the total never exceeds max_steps.
+// A steer entry replaces a leg's continuation prompt.
+func planSegments(t task, count int, steers map[int]string) []segment {
+	if count < 2 {
+		return []segment{{index: 1, maxSteps: t.MaxSteps, prompt: t.Prompt}}
+	}
+	per := t.MaxSteps / count
+	out := make([]segment, 0, count)
+	for i := 1; i <= count; i++ {
+		steps := per
+		if i == count {
+			steps = t.MaxSteps - per*(count-1)
+		}
+		seg := segment{index: i, maxSteps: steps, prompt: continuationPrompt, resume: true}
+		if i == 1 {
+			seg.prompt, seg.resume = t.Prompt, false
+		}
+		if steer, ok := steers[i]; ok {
+			seg.prompt = steer
+		}
+		out = append(out, seg)
+	}
+	return out
+}
+
+// segmentSettings validates the two LongRun pressure flags together: a steer
+// aimed past the last leg would never be delivered, and silently dropping a
+// user turn is exactly the kind of quiet no-op a benchmark must not have.
+func segmentSettings(segments int, spec string) map[int]string {
+	steers, err := parseSteers(spec)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "steer:", err)
+		os.Exit(2)
+	}
+	for leg := range steers {
+		if leg > segments {
+			fmt.Fprintf(os.Stderr, "steer: leg %d needs -segments %d or more; the run has %d\n", leg, leg, segments)
+			os.Exit(2)
+		}
+	}
+	return steers
+}
+
+// parseSteers reads "message@2,another@3": deliver that message as leg N's
+// prompt. Steering is a user turn arriving mid-task, so it belongs to a leg
+// boundary rather than to a wall-clock instant nothing can reproduce.
+func parseSteers(spec string) (map[int]string, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	out := map[int]string{}
+	for field := range strings.SplitSeq(spec, ",") {
+		message, at, ok := strings.Cut(strings.TrimSpace(field), "@")
+		if !ok {
+			return nil, fmt.Errorf("steer %q: want <message>@<segment>", field)
+		}
+		leg, err := strconv.Atoi(strings.TrimSpace(at))
+		if err != nil || leg < 2 {
+			return nil, fmt.Errorf("steer %q: the segment must be 2 or later — leg 1 carries the task itself", field)
+		}
+		if strings.TrimSpace(message) == "" {
+			return nil, fmt.Errorf("steer %q: the message is empty", field)
+		}
+		out[leg] = strings.TrimSpace(message)
+	}
+	return out, nil
+}
+
+// pressureFlags groups the LongRun knobs: neutral metering, injected faults,
+// and segmented resume with steering. They are registered and validated
+// together because they only make sense together.
+type pressureFlags struct {
+	meter, faults, steer *string
+	segments             *int
+}
+
+func registerPressureFlags() pressureFlags {
+	return pressureFlags{
+		meter:    flag.String("meter", "", "suite mode: route the benchmarked provider through the neutral measuring proxy, using this config.toml as the source (e.g. ~/.reasonix/config.toml). Spend is then counted at the request boundary instead of trusted from the harness"),
+		faults:   flag.String("faults", "", "suite mode: inject provider failures through the meter — absolute indices (3:429) and/or a cadence that scales with the run (every:5:500). Requires -meter; the report gains a fault-recovery readout"),
+		steer:    flag.String("steer", "", "suite mode: deliver a user turn at a leg boundary, e.g. \"also handle empty input@2\" (requires -segments >= that leg)"),
+		segments: flag.Int("segments", 1, "suite mode: split each task into N resumed legs (--continue between them), reaching reload and compaction pressure without waiting hours for it. The step budget is divided, never multiplied"),
+	}
+}
+
+func (p pressureFlags) settings() (config string, faults faultScript, segments int, steers map[int]string) {
+	config, faults = meterSettings(*p.meter, *p.faults)
+	return config, faults, *p.segments, segmentSettings(*p.segments, *p.steer)
+}

--- a/cmd/e2ebench/segments_test.go
+++ b/cmd/e2ebench/segments_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlanSegmentsIsOneLegByDefault(t *testing.T) {
+	task := task{ID: "x", Prompt: "fix it", MaxSteps: 12}
+	for _, count := range []int{0, 1} {
+		got := planSegments(task, count, nil)
+		if len(got) != 1 || got[0].resume || got[0].prompt != "fix it" || got[0].maxSteps != 12 {
+			t.Fatalf("count %d = %+v, want the unsegmented run", count, got)
+		}
+	}
+}
+
+// The step budget is the task's contract; splitting must not quietly hand a
+// segmented arm more work than the control arm gets.
+func TestPlanSegmentsPreservesTheStepBudget(t *testing.T) {
+	for _, steps := range []int{12, 13, 20, 7} {
+		got := planSegments(task{Prompt: "p", MaxSteps: steps}, 3, nil)
+		total := 0
+		for _, seg := range got {
+			if seg.maxSteps < 1 {
+				t.Fatalf("steps %d produced an empty leg: %+v", steps, got)
+			}
+			total += seg.maxSteps
+		}
+		if total != steps {
+			t.Fatalf("steps %d split into %d, want the budget preserved", steps, total)
+		}
+	}
+}
+
+func TestPlanSegmentsResumesEveryLegAfterTheFirst(t *testing.T) {
+	got := planSegments(task{Prompt: "fix it", MaxSteps: 9}, 3, nil)
+	if len(got) != 3 {
+		t.Fatalf("legs = %d, want 3", len(got))
+	}
+	if got[0].resume || got[0].prompt != "fix it" {
+		t.Fatalf("leg 1 = %+v, want the task itself on a fresh session", got[0])
+	}
+	for _, seg := range got[1:] {
+		if !seg.resume {
+			t.Fatalf("leg %d must resume: %+v", seg.index, seg)
+		}
+		if strings.Contains(seg.prompt, "fix it") {
+			t.Fatalf("leg %d restates the task, which hides the degradation being measured: %q", seg.index, seg.prompt)
+		}
+	}
+}
+
+func TestPlanSegmentsDeliversSteering(t *testing.T) {
+	steers, err := parseSteers("also handle empty input@2")
+	if err != nil {
+		t.Fatalf("parseSteers: %v", err)
+	}
+	got := planSegments(task{Prompt: "fix it", MaxSteps: 9}, 3, steers)
+	if got[1].prompt != "also handle empty input" {
+		t.Fatalf("leg 2 prompt = %q, want the steering message", got[1].prompt)
+	}
+	if !got[1].resume {
+		t.Fatalf("a steered leg still resumes: %+v", got[1])
+	}
+	if got[2].prompt != continuationPrompt {
+		t.Fatalf("leg 3 = %q, want the plain continuation", got[2].prompt)
+	}
+}
+
+func TestParseSteersRejectsLegOneAndMalformedSpecs(t *testing.T) {
+	for _, bad := range []string{"msg@1", "msg@0", "msg", "@2", "msg@x"} {
+		if _, err := parseSteers(bad); err == nil {
+			t.Fatalf("%q must be rejected", bad)
+		}
+	}
+	if got, err := parseSteers(""); err != nil || got != nil {
+		t.Fatalf("empty spec = %v, %v", got, err)
+	}
+}


### PR DESCRIPTION
First axis of the LongRun benchmark: **tool failure / API retry / recovery rate**. It
rides the fault seam merged in #8040 rather than adding a second rig.

## The cadence exists because fixed indices lie by omission

`-faults 3:429,7:500` pins failures to exact requests. On a mixed-length suite that
**quietly excludes the tasks most likely to expose a brittle harness**: a task that only
ever makes four requests never reaches request seven, joins the unfaulted group, and
nobody notices the suite measured less than it claimed.

`every:5:500` scales with the run. An absolute index still wins where one is given, so
a targeted failure stays exactly where it was asked for.

## And it hands the run its own control group

Under a cadence the short tasks never hit a fault. So the same run carries an unfaulted
baseline — the cost of failure is measured against **the same suite, model and day**,
not against a separate arm run at another time under other conditions.

## Retrying is not recovering

```text
**Fault recovery** (31 runs failed on purpose, 47 injections): **retried** 94% (29) ·
**still solved** 61% (19/31) · in-run control 78% (14/18 never hit a fault)
```

- **retried** — the meter saw another request *after* the failure. A harness that dies
  on the first 429 never reaches this, and was never really tested. Measured at the
  boundary, so it needs no cooperation from the harness.
- **still solved** — the task landed anyway. A harness can retry forever and finish
  nothing; counting that as recovery would reward persistence over outcome.
- **in-run control** — the free baseline above.

## Verification

- 8 new tests: cadence hits/misses, absolute-over-cadence precedence, four rejected
  malformed cadences, requests-after-fault counted through the real proxy, the
  gave-up case (0 after a fault), and the three-way readout split.
- `make lint` clean · `go test ./cmd/e2ebench/` passes · repolint baseline untouched.

## Segmented runs (second commit)

A twelve-hour session is not interesting because of its length. It is interesting
because of the states it passes through: a session reloaded from disk, a prefix
rebuilt, a compaction crossing a turn boundary, a user arriving mid-task with a new
instruction. `-segments N` reaches those directly.

```sh
go run ./cmd/e2ebench -segments 3 -steer "also handle empty input@2" -trajectories t/
```

Leg 1 starts the session; later legs resume with `--continue`, unambiguous because each
task already runs in its own home and therefore its own session directory. **A resumed
leg is deliberately not handed the task again** — its prompt is a bare continuation,
because a leg that restates the work would hide exactly the degradation this exists to
expose. `-steer` replaces one leg's continuation with a user turn, which belongs at a
leg boundary rather than at a wall-clock instant nothing can reproduce.

Two properties are load-bearing:

- **The step budget is divided, never multiplied.** A segmented arm gets the same
  `max_steps` as the control, or it would win by being allowed to work longer.
- **Each leg writes its own metrics file.** They share a work dir, so a single
  `.run-metrics.json` would leave the last leg's numbers standing in for the whole run
  and the earlier legs' tokens would vanish.

### Verified without a provider

That accounting failure is invisible in any single run, so it is pinned by a **stub
agent**: a script that records its argv and writes the metrics file it was told to.
`e2ebench` already takes `-bin`, so the whole segment chain runs offline. The test
asserts tokens/steps/cost/tool-calls **sum** across legs, non-additive fields survive,
leg 1 starts fresh, legs 2+ carry `--continue` and never restate the task, per-leg
metrics files exist separately, and a failed leg stops the run.

### A regression this introduced, and caught

Renaming the metrics file broke a hard-coded `".run-metrics.json"` skip in the
checkpoint snapshotter — every later leg's file would have read as a change the agent
made, silently polluting checkpoint grading. Harness artifacts are now matched by
prefix.

## What LongRun still needs

Context-degradation probing (planted facts recalled late), and composing compaction
pressure explicitly rather than letting it arrive on its own. `benchmarks/compaction`
and `context-maintenance-e2e` already hold those rigs.

**Not yet run end to end against a real provider.** The offline stub proves the
accounting and the argv; whether a resumed leg actually reloads the session as intended
needs one paid smoke run, which I have not spent tokens on without asking.

Documentation-impact: updated - benchmarks/README.md gains Fault recovery and Segmented runs sections plus the `-faults` / `-segments` / `-steer` flag rows.
