### PR TITLE
feat(desktop): apply monospace font setting to the integrated terminal

### DIFF
--- a/desktop/frontend/src/__tests__/font-family-terminal.test.ts
+++ b/desktop/frontend/src/__tests__/font-family-terminal.test.ts
@@ -1,0 +1,105 @@
+// Run: tsx src/__tests__/font-family-terminal.test.ts
+
+import {
+  MONO_FONT_CHANGED_EVENT,
+  applyMonoFontFamily,
+  monoFontStackForTerminal,
+} from "../lib/fontFamily";
+
+const MONO_KEY = "reasonix-mono-font-family";
+const CUSTOM_MONO_KEY = "reasonix-mono-font-family-custom";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  },
+});
+Object.defineProperty(globalThis, "document", {
+  configurable: true,
+  value: {
+    documentElement: {
+      setAttribute: () => {},
+      removeAttribute: () => {},
+      style: {
+        removeProperty: () => {},
+        setProperty: () => {},
+      },
+    },
+  },
+});
+const dispatched: string[] = [];
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    dispatchEvent: (event: Event) => {
+      dispatched.push(event.type);
+    },
+  },
+});
+
+function setMono(font: string, custom = "") {
+  store.clear();
+  store.set(MONO_KEY, font);
+  if (custom) store.set(CUSTOM_MONO_KEY, custom);
+}
+
+console.log("\nterminal monospace font stack");
+
+setMono("system");
+eq(monoFontStackForTerminal().includes("ui-monospace"), true, "system maps to the platform monospace stack");
+
+setMono("jetbrains");
+eq(monoFontStackForTerminal().startsWith('"JetBrains Mono"'), true, "jetbrains preset resolves first");
+
+setMono("cascadia");
+eq(monoFontStackForTerminal().startsWith('"Cascadia Code"'), true, "cascadia preset resolves first");
+
+setMono("sfmono");
+eq(monoFontStackForTerminal().startsWith('"SF Mono"'), true, "sfmono preset resolves first");
+
+setMono("custom", "Hack NF");
+eq(
+  monoFontStackForTerminal().startsWith('"Hack NF", "Cascadia Code"'),
+  true,
+  "custom nerd-font name is quoted and keeps the mono fallback",
+);
+
+setMono("custom", '"FiraCode Nerd Font Mono"');
+eq(
+  monoFontStackForTerminal().startsWith('"FiraCode Nerd Font Mono"'),
+  true,
+  "already-quoted custom names are kept as-is",
+);
+
+setMono("custom", "Menlo");
+eq(monoFontStackForTerminal().startsWith("Menlo,"), true, "single-word custom names stay unquoted");
+
+setMono("custom", "");
+eq(monoFontStackForTerminal().includes("ui-monospace"), true, "empty custom name falls back to the system stack");
+
+dispatched.length = 0;
+store.clear();
+applyMonoFontFamily("jetbrains");
+eq(dispatched.includes(MONO_FONT_CHANGED_EVENT), true, "font change dispatches the terminal sync event");
+eq(store.get(MONO_KEY), "jetbrains", "preference is still persisted");
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/TerminalView.tsx
+++ b/desktop/frontend/src/components/TerminalView.tsx
@@ -5,6 +5,7 @@ import "@xterm/xterm/css/xterm.css";
 
 import { useTerminalStore } from "../store/terminal";
 import { registerTerminalSink, startTerminalEventBridge } from "../lib/terminalEvents";
+import { MONO_FONT_CHANGED_EVENT, monoFontStackForTerminal } from "../lib/fontFamily";
 import { observeTerminalTheme, terminalThemeForElement } from "../lib/terminalTheme";
 import type { TerminalSessionView } from "../lib/types";
 
@@ -20,7 +21,7 @@ export function TerminalView({ tabId, session }: { tabId: string; session: Termi
     const terminal = new Terminal({
       convertEol: true,
       cursorBlink: true,
-      fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+      fontFamily: monoFontStackForTerminal(),
       fontSize: 13,
       theme: terminalThemeForElement(host),
     });
@@ -31,6 +32,13 @@ export function TerminalView({ tabId, session }: { tabId: string; session: Termi
       terminal.options.theme = terminalThemeForElement(host);
     };
     const stopObservingTheme = observeTerminalTheme(host, updateTheme);
+    const applyFont = () => {
+      terminal.options.fontFamily = monoFontStackForTerminal();
+      fit.fit();
+      terminal.refresh(0, terminal.rows - 1);
+    };
+    const onMonoFontChanged = () => applyFont();
+    window.addEventListener(MONO_FONT_CHANGED_EVENT, onMonoFontChanged);
     const unregister = registerTerminalSink(session.id, (bytes) => terminal.write(bytes));
     const input = terminal.onData((data) => { void write(tabId, session.id, data).catch(() => {}); });
     const outputResize = terminal.onResize(({ cols, rows }) => { void resize(tabId, session.id, cols, rows).catch(() => {}); });
@@ -45,6 +53,7 @@ export function TerminalView({ tabId, session }: { tabId: string; session: Termi
     return () => {
       observer?.disconnect();
       stopObservingTheme();
+      window.removeEventListener(MONO_FONT_CHANGED_EVENT, onMonoFontChanged);
       input.dispose();
       outputResize.dispose();
       unregister();

--- a/desktop/frontend/src/lib/fontFamily.ts
+++ b/desktop/frontend/src/lib/fontFamily.ts
@@ -12,6 +12,10 @@ const CUSTOM_FONT_KEY = "reasonix-font-family-custom";
 const MONO_FONT_FAMILY_KEY = "reasonix-mono-font-family";
 const CUSTOM_MONO_FONT_KEY = "reasonix-mono-font-family-custom";
 
+/** Fired after the monospace font preference changes, so non-DOM renderers
+ *  (e.g. the xterm.js integrated terminal) can pick up the new font. */
+export const MONO_FONT_CHANGED_EVENT = "reasonix:mono-font-changed";
+
 export function isFontFamily(value: unknown): value is FontFamily {
   return typeof value === "string" && (FONT_FAMILIES as readonly string[]).includes(value);
 }
@@ -100,9 +104,45 @@ export function applyMonoFontFamily(font: MonoFontFamily): void {
   } catch {
     /* private mode / no storage */
   }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(MONO_FONT_CHANGED_EVENT));
+  }
 }
 
 export function initFontFamily(): void {
   applyFontFamily(getFontFamily());
   applyMonoFontFamily(getMonoFontFamily());
+}
+
+/**
+ * Monospace font stacks for the xterm.js integrated terminal, mirroring the
+ * `--font-mono` presets in styles.css. The terminal renders into a canvas, so
+ * CSS variables never reach it — resolve the stack here instead.
+ */
+const TERMINAL_MONO_STACKS: Record<Exclude<MonoFontFamily, "custom">, string> = {
+  system: 'ui-monospace, "Cascadia Code", "JetBrains Mono", "Noto Sans Mono", "Liberation Mono", Consolas, monospace',
+  cascadia: '"Cascadia Code", "Cascadia Mono", Consolas, "Liberation Mono", ui-monospace, monospace',
+  jetbrains: '"JetBrains Mono", "Cascadia Code", "SF Mono", Consolas, ui-monospace, monospace',
+  sfmono: '"SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, "Cascadia Code", Consolas, monospace',
+};
+
+const TERMINAL_MONO_CUSTOM_FALLBACK = '"Cascadia Code", "SF Mono", Consolas, ui-monospace, monospace';
+
+function quoteFontNameForStack(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith('"') || trimmed.startsWith("'")) return trimmed;
+  if (/\s/.test(trimmed)) return `"${trimmed}"`;
+  return trimmed;
+}
+
+/** The CSS font stack the integrated terminal should use, honoring the
+ *  user's monospace font preference (including a custom Nerd Font name). */
+export function monoFontStackForTerminal(): string {
+  const font = getMonoFontFamily();
+  if (font === "custom") {
+    const name = quoteFontNameForStack(getCustomMonoFontName());
+    return name ? `${name}, ${TERMINAL_MONO_CUSTOM_FALLBACK}` : TERMINAL_MONO_STACKS.system;
+  }
+  return TERMINAL_MONO_STACKS[font];
 }


### PR DESCRIPTION
## Summary

Fixes the desktop half of #8046: the integrated terminal (xterm.js) hard-coded its `fontFamily`, so the **monospace font** setting in Settings → Appearance never reached the terminal area — xterm renders into a canvas, so the CSS variables used for the rest of the UI don't apply to it.

Now the terminal font is resolved from the existing monospace preference:

- `System` / `JetBrains Mono` / `Cascadia Code` / `SF Mono` presets map to the same stacks as `--font-mono` in `styles.css`
- `Custom` accepts any installed font name, so **Nerd Font variants work out of the box** (e.g. `Hack NF`, `FiraCode Nerd Font Mono`)
- `applyMonoFontFamily` dispatches a change event; the terminal subscribes and updates `terminal.options.fontFamily` live, so no app restart is needed

Font size stays at 13 (unchanged behavior).

No new settings UI was added — the terminal simply follows the existing monospace font setting.

## Changes

- `desktop/frontend/src/lib/fontFamily.ts`: add `monoFontStackForTerminal()` + `MONO_FONT_CHANGED_EVENT`, dispatched from `applyMonoFontFamily`
- `desktop/frontend/src/components/TerminalView.tsx`: use the resolved stack at creation; re-apply on font change events
- `desktop/frontend/src/__tests__/font-family-terminal.test.ts`: new tests for stack mapping / custom-name quoting / event dispatch

## Verification

- `tsx src/__tests__/font-family-terminal.test.ts` — 10/10 pass (new)
- `pnpm test:terminal` — 40/40 pass (existing)
- `pnpm typecheck` — clean
- `pnpm exec eslint` on changed files — clean

Documentation-impact: none - no docs/*.md changed; the integrated terminal now simply follows the existing monospace font setting, so the embedded documentation of font preferences remains correct.

Cache-impact: none (desktop frontend only; no system prompt / tool surface changes)
Cache-guard: not applicable — no provider-visible output changes; existing desktop tests cover the change surface
System-prompt-review: not applicable

