### PR TITLE
fix(desktop): make session sidecars durable / 持久化并串行化会话 sidecar

### DIFF
--- a/desktop/session_sidecar_durability_test.go
+++ b/desktop/session_sidecar_durability_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/filelock"
+	"reasonix/internal/fileutil"
+)
+
+func TestSessionSidecarSavesUseDurableAtomicWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(string) string
+		save func(string) error
+	}{
+		{
+			name: "titles",
+			path: sessionTitlesPath,
+			save: func(dir string) error {
+				return saveSessionTitles(dir, map[string]string{"session.jsonl": "Durable title"})
+			},
+		},
+		{
+			name: "displays",
+			path: sessionDisplayPath,
+			save: func(dir string) error {
+				return saveSessionDisplays(dir, sessionDisplayMap{
+					"session.jsonl": {messageDisplayKey("expanded prompt"): "visible prompt"},
+				})
+			},
+		},
+		{
+			name: "planner displays",
+			path: sessionPlannerDisplayPath,
+			save: func(dir string) error {
+				return saveSessionPlannerDisplays(dir, sessionPlannerDisplayMap{
+					"session.jsonl": {{UserHash: "prompt-digest", Messages: []HistoryMessage{}}},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := tt.path(dir)
+			previousCrashPoint := fileutil.CrashPoint
+			t.Cleanup(func() { fileutil.CrashPoint = previousCrashPoint })
+			usedDurableWrite := false
+			fileutil.CrashPoint = func(op, gotPath string) {
+				if op == "atomic-write" && gotPath == path {
+					usedDurableWrite = true
+				}
+			}
+
+			if err := tt.save(dir); err != nil {
+				t.Fatalf("save %s sidecar: %v", tt.name, err)
+			}
+			if !usedDurableWrite {
+				t.Fatalf("%s sidecar bypassed fileutil.AtomicWriteFile", tt.name)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s sidecar: %v", tt.name, err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("%s sidecar mode = %o, want 600", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestSetSessionTitleHonorsSidecarLock(t *testing.T) {
+	dir := t.TempDir()
+	release, err := filelock.Acquire(context.Background(), sessionTitlesPath(dir)+".lock")
+	if err != nil {
+		t.Fatalf("acquire title sidecar lock: %v", err)
+	}
+	previousTimeout := sessionTitlesLockTimeout
+	sessionTitlesLockTimeout = 40 * time.Millisecond
+	t.Cleanup(func() { sessionTitlesLockTimeout = previousTimeout })
+
+	err = setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Locked")
+	if err == nil {
+		release()
+		t.Fatal("setSessionTitle succeeded while the title sidecar lock was held")
+	}
+	release()
+	if err := setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Saved"); err != nil {
+		t.Fatalf("setSessionTitle after release: %v", err)
+	}
+}
+
+func TestSetSessionTitleSerializesConcurrentUpdates(t *testing.T) {
+	dir := t.TempDir()
+	const sessions = 32
+	errs := make(chan error, sessions)
+	var wg sync.WaitGroup
+	for i := range sessions {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := filepath.Join(dir, fmt.Sprintf("session-%02d.jsonl", i))
+			errs <- setSessionTitle(dir, path, fmt.Sprintf("Title %02d", i))
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("setSessionTitle: %v", err)
+		}
+	}
+
+	titles := loadSessionTitles(dir)
+	if len(titles) != sessions {
+		t.Fatalf("title count = %d, want %d: %#v", len(titles), sessions, titles)
+	}
+	for i := range sessions {
+		key := fmt.Sprintf("session-%02d.jsonl", i)
+		if got := titles[key]; got != fmt.Sprintf("Title %02d", i) {
+			t.Fatalf("%s title = %q, want retained concurrent value", key, got)
+		}
+	}
+}

--- a/desktop/session_sidecar_durability_test.go
+++ b/desktop/session_sidecar_durability_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -65,12 +66,14 @@ func TestSessionSidecarSavesUseDurableAtomicWrite(t *testing.T) {
 			if !usedDurableWrite {
 				t.Fatalf("%s sidecar bypassed fileutil.AtomicWriteFile", tt.name)
 			}
-			info, err := os.Stat(path)
-			if err != nil {
-				t.Fatalf("stat %s sidecar: %v", tt.name, err)
-			}
-			if got := info.Mode().Perm(); got != 0o600 {
-				t.Fatalf("%s sidecar mode = %o, want 600", tt.name, got)
+			if runtime.GOOS != "windows" {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("stat %s sidecar: %v", tt.name, err)
+				}
+				if got := info.Mode().Perm(); got != 0o600 {
+					t.Fatalf("%s sidecar mode = %o, want 600", tt.name, got)
+				}
 			}
 		})
 	}

--- a/desktop/session_sidecar_durability_test.go
+++ b/desktop/session_sidecar_durability_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -85,9 +88,9 @@ func TestSetSessionTitleHonorsSidecarLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("acquire title sidecar lock: %v", err)
 	}
-	previousTimeout := sessionTitlesLockTimeout
-	sessionTitlesLockTimeout = 40 * time.Millisecond
-	t.Cleanup(func() { sessionTitlesLockTimeout = previousTimeout })
+	previousTimeout := sessionTitlesQueueTimeout
+	sessionTitlesQueueTimeout = 40 * time.Millisecond
+	t.Cleanup(func() { sessionTitlesQueueTimeout = previousTimeout })
 
 	err = setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Locked")
 	if err == nil {
@@ -97,6 +100,63 @@ func TestSetSessionTitleHonorsSidecarLock(t *testing.T) {
 	release()
 	if err := setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Saved"); err != nil {
 		t.Fatalf("setSessionTitle after release: %v", err)
+	}
+}
+
+func TestRecordSessionDisplayExternalLockUsesShortBudget(t *testing.T) {
+	if os.Getenv("REASONIX_DISPLAY_LOCK_HELPER") != "" {
+		dir := os.Getenv("REASONIX_DISPLAY_LOCK_DIR")
+		release, err := filelock.Acquire(context.Background(), sessionDisplayPath(dir)+".lock")
+		if err != nil {
+			t.Fatalf("acquire external display lock: %v", err)
+		}
+		defer release()
+		if err := os.WriteFile(filepath.Join(dir, "display-lock.ready"), []byte("ready"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !waitForPlannerDisplayTestFile(filepath.Join(dir, "display-lock.release"), 10*time.Second) {
+			t.Fatal("timed out waiting to release external display lock")
+		}
+		return
+	}
+
+	dir := t.TempDir()
+	var output strings.Builder
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRecordSessionDisplayExternalLockUsesShortBudget$")
+	cmd.Env = append(os.Environ(),
+		"REASONIX_DISPLAY_LOCK_HELPER=1",
+		"REASONIX_DISPLAY_LOCK_DIR="+dir,
+	)
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start external display-lock helper: %v", err)
+	}
+	releasePath := filepath.Join(dir, "display-lock.release")
+	releaseHelper := func() {
+		_ = os.WriteFile(releasePath, []byte("release"), 0o600)
+	}
+	if !waitForPlannerDisplayTestFile(filepath.Join(dir, "display-lock.ready"), 5*time.Second) {
+		releaseHelper()
+		_ = cmd.Wait()
+		t.Fatalf("external display-lock helper did not start: %s", output.String())
+	}
+
+	previousTimeout := sessionDisplayExternalLockTimeout
+	sessionDisplayExternalLockTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { sessionDisplayExternalLockTimeout = previousTimeout })
+	started := time.Now()
+	err := recordSessionDisplay(dir, filepath.Join(dir, "session.jsonl"), "expanded prompt", "visible prompt")
+	elapsed := time.Since(started)
+	releaseHelper()
+	if waitErr := cmd.Wait(); waitErr != nil {
+		t.Fatalf("external display-lock helper failed: %v\n%s", waitErr, output.String())
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("record display error = %v, want external lock deadline exceeded", err)
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("record display waited %v, want the short external lock budget", elapsed)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -33,11 +33,20 @@ const sessionPlannerDisplayFile = ".planner-display.json"
 const sessionTrashDir = ".trash"
 const sessionTrashMetaFile = ".trash-meta.json"
 
-// Durable sidecar publication includes an fsync while holding the update lock.
-// Keep enough budget for a burst of in-process writers on slower Windows disks.
-const sessionSidecarLockTimeout = 5 * time.Second
+const (
+	// Durable sidecar publication includes an fsync while holding the update
+	// lock. Keep enough queue budget for a burst of in-process writers on
+	// slower Windows disks, but fail external contention quickly so turn
+	// completion and retry-queue handoff do not stall behind another process.
+	sessionSidecarQueueTimeout        = 5 * time.Second
+	sessionSidecarExternalLockTimeout = 750 * time.Millisecond
+)
 
-var sessionTitlesLockTimeout = sessionSidecarLockTimeout
+var (
+	sessionTitlesQueueTimeout                = sessionSidecarQueueTimeout
+	sessionPlannerDisplayExternalLockTimeout = sessionSidecarExternalLockTimeout
+	sessionDisplayExternalLockTimeout        = sessionSidecarExternalLockTimeout
+)
 
 func sessionTitlesPath(dir string) string  { return filepath.Join(dir, sessionTitlesFile) }
 func sessionDisplayPath(dir string) string { return filepath.Join(dir, sessionDisplayFile) }
@@ -86,9 +95,9 @@ func updateSessionTitles(dir string, mutate func(map[string]string) bool) error 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), sessionTitlesLockTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sessionTitlesQueueTimeout)
 	defer cancel()
-	release, err := filelock.Acquire(ctx, sessionTitlesPath(dir)+".lock")
+	release, err := filelock.AcquireWithExternalTimeout(ctx, sessionTitlesPath(dir)+".lock", sessionSidecarExternalLockTimeout)
 	if err != nil {
 		return fmt.Errorf("lock title sidecar: %w", err)
 	}
@@ -972,10 +981,7 @@ type plannerDisplayTurn struct {
 	Messages []HistoryMessage `json:"messages"`
 }
 
-var (
-	sessionPlannerDisplayLockTimeout = sessionSidecarLockTimeout
-	errCorruptSessionPlannerDisplay  = errors.New("corrupt planner display sidecar")
-)
+var errCorruptSessionPlannerDisplay = errors.New("corrupt planner display sidecar")
 
 // sessionPlannerDisplayUpdateAfterLoad is a subprocess-test seam. Production
 // leaves it nil; tests use it to force two independent processes into the old
@@ -1061,9 +1067,9 @@ func updateSessionPlannerDisplays(dir string, recoverCorrupt bool, mutate func(s
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), sessionPlannerDisplayLockTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sessionSidecarQueueTimeout)
 	defer cancel()
-	release, err := filelock.Acquire(ctx, sessionPlannerDisplayPath(dir)+".lock")
+	release, err := filelock.AcquireWithExternalTimeout(ctx, sessionPlannerDisplayPath(dir)+".lock", sessionPlannerDisplayExternalLockTimeout)
 	if err != nil {
 		return fmt.Errorf("lock planner display sidecar: %w", err)
 	}
@@ -1188,9 +1194,9 @@ func updateSessionDisplays(dir string, mutate func(sessionDisplayMap) bool) erro
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), sessionSidecarLockTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), sessionSidecarQueueTimeout)
 	defer cancel()
-	release, err := filelock.Acquire(ctx, sessionDisplayPath(dir)+".lock")
+	release, err := filelock.AcquireWithExternalTimeout(ctx, sessionDisplayPath(dir)+".lock", sessionDisplayExternalLockTimeout)
 	if err != nil {
 		return fmt.Errorf("lock display sidecar: %w", err)
 	}

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -33,7 +33,11 @@ const sessionPlannerDisplayFile = ".planner-display.json"
 const sessionTrashDir = ".trash"
 const sessionTrashMetaFile = ".trash-meta.json"
 
-var sessionTitlesLockTimeout = 750 * time.Millisecond
+// Durable sidecar publication includes an fsync while holding the update lock.
+// Keep enough budget for a burst of in-process writers on slower Windows disks.
+const sessionSidecarLockTimeout = 5 * time.Second
+
+var sessionTitlesLockTimeout = sessionSidecarLockTimeout
 
 func sessionTitlesPath(dir string) string  { return filepath.Join(dir, sessionTitlesFile) }
 func sessionDisplayPath(dir string) string { return filepath.Join(dir, sessionDisplayFile) }
@@ -969,7 +973,7 @@ type plannerDisplayTurn struct {
 }
 
 var (
-	sessionPlannerDisplayLockTimeout = 750 * time.Millisecond
+	sessionPlannerDisplayLockTimeout = sessionSidecarLockTimeout
 	errCorruptSessionPlannerDisplay  = errors.New("corrupt planner display sidecar")
 )
 
@@ -1184,7 +1188,7 @@ func updateSessionDisplays(dir string, mutate func(sessionDisplayMap) bool) erro
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), sessionSidecarLockTimeout)
 	defer cancel()
 	release, err := filelock.Acquire(ctx, sessionDisplayPath(dir)+".lock")
 	if err != nil {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -33,6 +33,8 @@ const sessionPlannerDisplayFile = ".planner-display.json"
 const sessionTrashDir = ".trash"
 const sessionTrashMetaFile = ".trash-meta.json"
 
+var sessionTitlesLockTimeout = 750 * time.Millisecond
+
 func sessionTitlesPath(dir string) string  { return filepath.Join(dir, sessionTitlesFile) }
 func sessionDisplayPath(dir string) string { return filepath.Join(dir, sessionDisplayFile) }
 func sessionTrashPath(dir string) string   { return filepath.Join(dir, sessionTrashDir) }
@@ -73,7 +75,33 @@ func loadSessionTitlesForUpdate(dir string) (map[string]string, error) {
 	return loadStringMapForUpdate(sessionTitlesPath(dir))
 }
 
-// saveSessionTitles writes the map atomically (temp file + rename).
+func updateSessionTitles(dir string, mutate func(map[string]string) bool) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("title directory is empty")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), sessionTitlesLockTimeout)
+	defer cancel()
+	release, err := filelock.Acquire(ctx, sessionTitlesPath(dir)+".lock")
+	if err != nil {
+		return fmt.Errorf("lock title sidecar: %w", err)
+	}
+	defer release()
+
+	m, err := loadSessionTitlesForUpdate(dir)
+	if err != nil {
+		return err
+	}
+	if !mutate(m) {
+		return nil
+	}
+	return saveSessionTitles(dir, m)
+}
+
+// saveSessionTitles writes the map durably and atomically. Keep this on the
+// shared helper so the temporary file is fsynced before it is published.
 func saveSessionTitles(dir string, m map[string]string) error {
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -82,21 +110,7 @@ func saveSessionTitles(dir string, m map[string]string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, ".titles.*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	return fileutil.ReplaceFile(tmpPath, sessionTitlesPath(dir))
+	return fileutil.AtomicWriteFile(sessionTitlesPath(dir), b, 0o600)
 }
 
 // setSessionTitle sets (or, with an empty title, clears) a session's custom name.
@@ -105,17 +119,22 @@ func setSessionTitle(dir, sessionPath, title string) error {
 	if err != nil {
 		return err
 	}
-	m, err := loadSessionTitlesForUpdate(dir)
-	if err != nil {
-		return err
-	}
 	key := filepath.Base(sessionPath)
-	if strings.TrimSpace(title) == "" {
-		delete(m, key)
-	} else {
-		m[key] = strings.TrimSpace(title)
-	}
-	return saveSessionTitles(dir, m)
+	return updateSessionTitles(dir, func(m map[string]string) bool {
+		title = strings.TrimSpace(title)
+		if title == "" {
+			if _, ok := m[key]; !ok {
+				return false
+			}
+			delete(m, key)
+			return true
+		}
+		if m[key] == title {
+			return false
+		}
+		m[key] = title
+		return true
+	})
 }
 
 // deleteSessionFile moves a session's .jsonl and file sidecars into the local
@@ -598,15 +617,14 @@ func purgeTrashedSessionFile(dir, path string) error {
 	if err := os.RemoveAll(itemDir); err != nil {
 		return err
 	}
-	m, err := loadSessionTitlesForUpdate(dir)
-	if err != nil {
-		return err
-	}
-	if _, ok := m[key]; ok {
-		delete(m, key)
-		if err := saveSessionTitles(dir, m); err != nil {
-			return err
+	if err := updateSessionTitles(dir, func(m map[string]string) bool {
+		if _, ok := m[key]; !ok {
+			return false
 		}
+		delete(m, key)
+		return true
+	}); err != nil {
+		return err
 	}
 	if err := removeSessionDisplayKey(dir, key); err != nil {
 		return err
@@ -1018,21 +1036,7 @@ func saveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, ".planner-display.*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	return fileutil.ReplaceFile(tmpPath, sessionPlannerDisplayPath(dir))
+	return fileutil.AtomicWriteFile(sessionPlannerDisplayPath(dir), b, 0o600)
 }
 
 func saveOrRemoveSessionPlannerDisplays(dir string, m sessionPlannerDisplayMap) error {
@@ -1155,21 +1159,7 @@ func saveSessionDisplays(dir string, m sessionDisplayMap) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, ".display.*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	return fileutil.ReplaceFile(tmpPath, sessionDisplayPath(dir))
+	return fileutil.AtomicWriteFile(sessionDisplayPath(dir), b, 0o600)
 }
 
 func saveOrRemoveSessionDisplays(dir string, m sessionDisplayMap) error {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -1243,7 +1243,7 @@ func TestRecordSessionPlannerDisplayConcurrentPreservesEverySession(t *testing.T
 func TestRecordSessionPlannerDisplayCrossProcessPreservesEverySession(t *testing.T) {
 	if role := os.Getenv("REASONIX_PLANNER_DISPLAY_HELPER"); role != "" {
 		dir := os.Getenv("REASONIX_PLANNER_DISPLAY_DIR")
-		sessionPlannerDisplayLockTimeout = 5 * time.Second
+		sessionPlannerDisplayExternalLockTimeout = 5 * time.Second
 		attempted := filepath.Join(dir, role+".attempted")
 		loaded := filepath.Join(dir, role+".loaded")
 		release := filepath.Join(dir, role+".release")

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,8 +13,6 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
-	"reasonix/internal/filelock"
-	"reasonix/internal/fileutil"
 	"reasonix/internal/jobs"
 	"reasonix/internal/store"
 )
@@ -105,69 +102,6 @@ func TestSaveSessionTitlesRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSessionSidecarSavesUseDurableAtomicWrite(t *testing.T) {
-	tests := []struct {
-		name string
-		path func(string) string
-		save func(string) error
-	}{
-		{
-			name: "titles",
-			path: sessionTitlesPath,
-			save: func(dir string) error {
-				return saveSessionTitles(dir, map[string]string{"session.jsonl": "Durable title"})
-			},
-		},
-		{
-			name: "displays",
-			path: sessionDisplayPath,
-			save: func(dir string) error {
-				return saveSessionDisplays(dir, sessionDisplayMap{
-					"session.jsonl": {messageDisplayKey("expanded prompt"): "visible prompt"},
-				})
-			},
-		},
-		{
-			name: "planner displays",
-			path: sessionPlannerDisplayPath,
-			save: func(dir string) error {
-				return saveSessionPlannerDisplays(dir, sessionPlannerDisplayMap{
-					"session.jsonl": {{UserHash: "prompt-digest", Messages: []HistoryMessage{}}},
-				})
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			path := tt.path(dir)
-			previousCrashPoint := fileutil.CrashPoint
-			t.Cleanup(func() { fileutil.CrashPoint = previousCrashPoint })
-			usedDurableWrite := false
-			fileutil.CrashPoint = func(op, gotPath string) {
-				if op == "atomic-write" && gotPath == path {
-					usedDurableWrite = true
-				}
-			}
-
-			if err := tt.save(dir); err != nil {
-				t.Fatalf("save %s sidecar: %v", tt.name, err)
-			}
-			if !usedDurableWrite {
-				t.Fatalf("%s sidecar bypassed fileutil.AtomicWriteFile", tt.name)
-			}
-			info, err := os.Stat(path)
-			if err != nil {
-				t.Fatalf("stat %s sidecar: %v", tt.name, err)
-			}
-			if got := info.Mode().Perm(); got != 0o600 {
-				t.Fatalf("%s sidecar mode = %o, want 600", tt.name, got)
-			}
-		})
-	}
-}
-
 // setSessionTitle
 
 func TestSetSessionTitle(t *testing.T) {
@@ -223,60 +157,6 @@ func TestSetSessionTitlePreservesExistingTitlesWhenTimedReadSlotsFull(t *testing
 	}
 	if got := m["new.jsonl"]; got != "New" {
 		t.Fatalf("new title = %q, want New (all titles: %v)", got, m)
-	}
-}
-
-func TestSetSessionTitleHonorsSidecarLock(t *testing.T) {
-	dir := t.TempDir()
-	release, err := filelock.Acquire(context.Background(), sessionTitlesPath(dir)+".lock")
-	if err != nil {
-		t.Fatalf("acquire title sidecar lock: %v", err)
-	}
-	previousTimeout := sessionTitlesLockTimeout
-	sessionTitlesLockTimeout = 40 * time.Millisecond
-	t.Cleanup(func() { sessionTitlesLockTimeout = previousTimeout })
-
-	err = setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Locked")
-	if err == nil {
-		release()
-		t.Fatal("setSessionTitle succeeded while the title sidecar lock was held")
-	}
-	release()
-	if err := setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Saved"); err != nil {
-		t.Fatalf("setSessionTitle after release: %v", err)
-	}
-}
-
-func TestSetSessionTitleSerializesConcurrentUpdates(t *testing.T) {
-	dir := t.TempDir()
-	const sessions = 32
-	errs := make(chan error, sessions)
-	var wg sync.WaitGroup
-	for i := range sessions {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			path := filepath.Join(dir, fmt.Sprintf("session-%02d.jsonl", i))
-			errs <- setSessionTitle(dir, path, fmt.Sprintf("Title %02d", i))
-		}(i)
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("setSessionTitle: %v", err)
-		}
-	}
-
-	titles := loadSessionTitles(dir)
-	if len(titles) != sessions {
-		t.Fatalf("title count = %d, want %d: %#v", len(titles), sessions, titles)
-	}
-	for i := range sessions {
-		key := fmt.Sprintf("session-%02d.jsonl", i)
-		if got := titles[key]; got != fmt.Sprintf("Title %02d", i) {
-			t.Fatalf("%s title = %q, want retained concurrent value", key, got)
-		}
 	}
 }
 

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,8 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/filelock"
+	"reasonix/internal/fileutil"
 	"reasonix/internal/jobs"
 	"reasonix/internal/store"
 )
@@ -102,6 +105,69 @@ func TestSaveSessionTitlesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSessionSidecarSavesUseDurableAtomicWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(string) string
+		save func(string) error
+	}{
+		{
+			name: "titles",
+			path: sessionTitlesPath,
+			save: func(dir string) error {
+				return saveSessionTitles(dir, map[string]string{"session.jsonl": "Durable title"})
+			},
+		},
+		{
+			name: "displays",
+			path: sessionDisplayPath,
+			save: func(dir string) error {
+				return saveSessionDisplays(dir, sessionDisplayMap{
+					"session.jsonl": {messageDisplayKey("expanded prompt"): "visible prompt"},
+				})
+			},
+		},
+		{
+			name: "planner displays",
+			path: sessionPlannerDisplayPath,
+			save: func(dir string) error {
+				return saveSessionPlannerDisplays(dir, sessionPlannerDisplayMap{
+					"session.jsonl": {{UserHash: "prompt-digest", Messages: []HistoryMessage{}}},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := tt.path(dir)
+			previousCrashPoint := fileutil.CrashPoint
+			t.Cleanup(func() { fileutil.CrashPoint = previousCrashPoint })
+			usedDurableWrite := false
+			fileutil.CrashPoint = func(op, gotPath string) {
+				if op == "atomic-write" && gotPath == path {
+					usedDurableWrite = true
+				}
+			}
+
+			if err := tt.save(dir); err != nil {
+				t.Fatalf("save %s sidecar: %v", tt.name, err)
+			}
+			if !usedDurableWrite {
+				t.Fatalf("%s sidecar bypassed fileutil.AtomicWriteFile", tt.name)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s sidecar: %v", tt.name, err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("%s sidecar mode = %o, want 600", tt.name, got)
+			}
+		})
+	}
+}
+
 // setSessionTitle
 
 func TestSetSessionTitle(t *testing.T) {
@@ -157,6 +223,60 @@ func TestSetSessionTitlePreservesExistingTitlesWhenTimedReadSlotsFull(t *testing
 	}
 	if got := m["new.jsonl"]; got != "New" {
 		t.Fatalf("new title = %q, want New (all titles: %v)", got, m)
+	}
+}
+
+func TestSetSessionTitleHonorsSidecarLock(t *testing.T) {
+	dir := t.TempDir()
+	release, err := filelock.Acquire(context.Background(), sessionTitlesPath(dir)+".lock")
+	if err != nil {
+		t.Fatalf("acquire title sidecar lock: %v", err)
+	}
+	previousTimeout := sessionTitlesLockTimeout
+	sessionTitlesLockTimeout = 40 * time.Millisecond
+	t.Cleanup(func() { sessionTitlesLockTimeout = previousTimeout })
+
+	err = setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Locked")
+	if err == nil {
+		release()
+		t.Fatal("setSessionTitle succeeded while the title sidecar lock was held")
+	}
+	release()
+	if err := setSessionTitle(dir, filepath.Join(dir, "locked.jsonl"), "Saved"); err != nil {
+		t.Fatalf("setSessionTitle after release: %v", err)
+	}
+}
+
+func TestSetSessionTitleSerializesConcurrentUpdates(t *testing.T) {
+	dir := t.TempDir()
+	const sessions = 32
+	errs := make(chan error, sessions)
+	var wg sync.WaitGroup
+	for i := range sessions {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := filepath.Join(dir, fmt.Sprintf("session-%02d.jsonl", i))
+			errs <- setSessionTitle(dir, path, fmt.Sprintf("Title %02d", i))
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("setSessionTitle: %v", err)
+		}
+	}
+
+	titles := loadSessionTitles(dir)
+	if len(titles) != sessions {
+		t.Fatalf("title count = %d, want %d: %#v", len(titles), sessions, titles)
+	}
+	for i := range sessions {
+		key := fmt.Sprintf("session-%02d.jsonl", i)
+		if got := titles[key]; got != fmt.Sprintf("Title %02d", i) {
+			t.Fatalf("%s title = %q, want retained concurrent value", key, got)
+		}
 	}
 }
 

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -36,6 +36,21 @@ var localRegistry = struct {
 // function is called. It serializes both goroutines in this process and other
 // Reasonix processes, and never waits past ctx's deadline.
 func Acquire(ctx context.Context, path string) (func(), error) {
+	return acquire(ctx, path, 0)
+}
+
+// AcquireWithExternalTimeout obtains an exclusive lock while keeping the
+// in-process queue and cross-process file-lock budgets separate. ctx bounds
+// only the wait for another goroutine in this process; externalTimeout starts
+// after that queue is acquired and bounds retries against other processes.
+func AcquireWithExternalTimeout(ctx context.Context, path string, externalTimeout time.Duration) (func(), error) {
+	if externalTimeout <= 0 {
+		return nil, errors.New("external file lock timeout must be positive")
+	}
+	return acquire(ctx, path, externalTimeout)
+}
+
+func acquire(ctx context.Context, path string, externalTimeout time.Duration) (func(), error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -48,6 +63,12 @@ func Acquire(ctx context.Context, path string) (func(), error) {
 		return nil, err
 	}
 	_ = local
+	fileCtx := ctx
+	cancel := func() {}
+	if externalTimeout > 0 {
+		fileCtx, cancel = context.WithTimeout(context.Background(), externalTimeout)
+	}
+	defer cancel()
 
 	for {
 		releaseFile, err := tryLockFile(key)
@@ -67,7 +88,7 @@ func Acquire(ctx context.Context, path string) (func(), error) {
 		timer := time.NewTimer(retryInterval)
 		select {
 		case <-timer.C:
-		case <-ctx.Done():
+		case <-fileCtx.Done():
 			if !timer.Stop() {
 				select {
 				case <-timer.C:
@@ -75,7 +96,7 @@ func Acquire(ctx context.Context, path string) (func(), error) {
 				}
 			}
 			releaseLocal()
-			return nil, fmt.Errorf("acquire file lock: %w", ctx.Err())
+			return nil, fmt.Errorf("acquire file lock: %w", fileCtx.Err())
 		}
 	}
 }

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -29,6 +29,34 @@ func TestAcquireHonorsDeadlineAndRecoversAfterRelease(t *testing.T) {
 	secondRelease()
 }
 
+func TestAcquireWithExternalTimeoutBoundsOnlyFileLockRetries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.lock")
+	releaseExternal, err := tryLockFile(path)
+	if err != nil {
+		t.Fatalf("hold external file lock: %v", err)
+	}
+	defer releaseExternal()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	started := time.Now()
+	_, err = AcquireWithExternalTimeout(ctx, path, 60*time.Millisecond)
+	elapsed := time.Since(started)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("external acquire error = %v, want deadline exceeded", err)
+	}
+	if elapsed >= time.Second {
+		t.Fatalf("external acquire waited %v, want the short external budget", elapsed)
+	}
+}
+
+func TestAcquireWithExternalTimeoutRejectsInvalidBudget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.lock")
+	if _, err := AcquireWithExternalTimeout(context.Background(), path, 0); err == nil {
+		t.Fatal("zero external timeout should be rejected")
+	}
+}
+
 func TestLocalRegistryReclaimsReleasedEntries(t *testing.T) {
 	before := RegistrySizeForTest()
 	path := filepath.Join(t.TempDir(), "ephemeral.lock")


### PR DESCRIPTION
## Summary

- publish `.titles.json`, `.display.json`, and `.planner-display.json` through the shared fsync-before-replace writer
- serialize the legacy title sidecar's full read-modify-write cycle with a bounded cross-process file lock
- keep a 5s in-process fsync queue while bounding cross-process OS-lock retries to 750ms
- cover the durable-writer contract, held-lock behavior, and concurrent title updates

Refs #5841, #6905, #7074, #7078, #5794, #6770, and #6873.

## Problem

Current session transcripts already have WAL, CAS, cross-process save locks, and recovery branches, but three Desktop-owned display sidecars still duplicated an older `write -> close -> replace` sequence. A crash could therefore publish a temporary file whose data had not been flushed. The title sidecar also performed `load -> mutate -> save` without the serialization already used by display sidecars, so concurrent renames or cleanup could lose another writer's update.

## Root cause

The title and display sidecars predated `fileutil.AtomicWriteFile` or were added by copying the old manual pattern. The durability and last-writer-wins lessons from the earlier session-data-loss work were applied to the transcript and display map, but not swept across every later Desktop session sidecar.

## Fix

- Reuse `fileutil.AtomicWriteFile(..., 0o600)` for all three Desktop session sidecars. This preserves the existing JSON and replacement behavior while adding the helper's temporary-file fsync.
- Add a `.titles.json.lock` critical section around title load, mutation, and write.
- Split sidecar locking into a 5s in-process queue budget and a fresh 750ms cross-process OS-lock budget. Durable writer bursts retain enough time on slower Windows disks, while another Reasonix process cannot stall turn completion for 5s.
- Route both rename and permanent-trash cleanup through the locked title updater.
- Preserve no-op updates without rewriting the sidecar.
- Add focused coverage for the shared durable writer, file mode, 32 concurrent title updates, split lock budgets, and the real display-sidecar subprocess contention path.

## Source PR consolidation

### Kept or adapted

- #5841 by @myipanta: kept the core insight that Desktop title/display sidecars must fsync before publication. The old hand-written `tmp.Sync()` patch is adapted to the current shared `fileutil.AtomicWriteFile` owner. The same defect-shape sweep also covers the newer planner-display sidecar.
- #6905 by @myipanta: its WAL fsync and `.display.json` serialization are already in `main-v2`. This PR adapts the same full read-modify-write locking principle to the remaining `.titles.json` map.
- #7074 by @SivanCola: retained as the merged architectural baseline for migrated-session repair, durable append events, safe lock-failure behavior, and multi-session reload coverage. This PR does not duplicate those mechanisms.
- #7078 by @SivanCola: retained as the merged integration that serialized display updates in the guarded runtime work. This PR extends that established boundary to the remaining title sidecar.

### Reviewed but not adopted

- #5841's `copyOnto` replacement is not reused. The current fallback exists only for environments whose filter driver rejects the original same-directory rename; attempting another equivalent rename does not solve that compatibility class. Critical pointers can already opt into `AtomicWriteFileStrict`, while session recovery is WAL-backed.
- #5841's corrupted-session listing is not reused. Assigning `Turns: 1` to undecodable data makes a broken entry look loadable. Damaged-history visibility should expose an honest corruption/recovery state and an actionable recovery path rather than fabricate a turn count.
- #6905's automatic recovery branch on every `SaveSnapshot` lock timeout is not reused. Current navigation aborts safely on persistence failure, while shutdown recovery branches are created only when the in-memory runtime is actually being discarded; returning success for every lock timeout would hide failures and proliferate branches.
- The permission, steer, and parallel-task changes in #7074/#7078 are outside this PR's storage-only scope and remain unchanged in `main-v2`.

## Per-PR contributions

| Source PR | Author | Repository contribution | Treatment here |
| --- | --- | --- | --- |
| #5841 | @myipanta | Identified non-durable session/sidecar publication and silent damaged-history visibility | Durable sidecar insight adapted; two alternatives reviewed but not adopted |
| #6905 | @myipanta | Added durable WAL appends, serialized display-map updates, and proposed lock-timeout recovery | Existing merged mechanisms preserved; locking principle extended to titles |
| #7074 | @SivanCola | Integrated session durability with migrated-session repair, safe recovery semantics, and end-to-end concurrency coverage | Used as the current architectural and test baseline |
| #7078 | @SivanCola | Landed guarded-runtime integration including serialized display updates | Used as the current merged implementation baseline |

## Repository contributors

Every source PR author is listed explicitly, including PRs whose alternatives were reviewed but not adopted:

| PR | Contributor |
| --- | --- |
| #5841 | @myipanta |
| #6905 | @myipanta |
| #7074 | @SivanCola |
| #7078 | @SivanCola |

The implementation commit is authored by @SivanCola and carries a commit-level `Co-authored-by` trailer for @myipanta because the adopted durable-sidecar and serialized-sidecar mechanisms derive from #5841/#6905.

## Compatibility and security

| Surface | Compatibility result |
| --- | --- |
| Sidecar JSON | Filenames, keys, values, and JSON shape are unchanged |
| File permissions | Unix mode bits remain private `0600`; Windows ACL behavior is unchanged |
| Replacement behavior | Continues through the same `ReplaceFile` compatibility fallback used before |
| New title lock | Current builds serialize updates; older builds ignore the additive `.titles.json.lock` file |
| Lock contention | Same-process fsync bursts may queue for up to 5s; cross-process OS-lock retries remain bounded to 750ms before display/planner writes enter their existing retry path |
| Cross-version coexistence | Old/new concurrent title writers can still race because old builds do not honor the new lock; branch metadata remains the authoritative current title |
| Security surface | No dependency, network, command, credential, sandbox, or privilege changes |

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/filelock -count=20`
- `cd desktop && go test ./... -count=1`
- `cd desktop && go test . -run (sidecar focused suite) -count=10`
- `cd desktop && go test -race . -run (sidecar focused suite) -count=5`
- `go vet ./...` and `cd desktop && go vet ./...`
- `go run ./tools/repolint`
- Windows cross-compilation for `internal/filelock` and the Desktop test binary
- latest-`main-v2` merge-tree and `git diff --check`

## Cache impact

- Cache-impact: none — storage-only Desktop sidecar changes; no prompt, memory, tool schema/order, provider serialization, or request bytes change.
- Cache-guard: not required for this storage-only diff; existing provider-visible artifacts are untouched.
- System-prompt-review: N/A.

## Documentation impact

Documentation-impact: none - this is an internal crash-durability and concurrency repair with no user-facing command, configuration, workflow, or documented behavior change.
