### PR TITLE
perf(desktop): the project tree is data, not a function of which session is open

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -694,23 +694,14 @@ export function ProjectTree({
     });
   }, []);
 
+  // Keyed by the data, not the selection: a switch cannot change the tree.
   const refresh = useCallback(async () => {
     try {
-      const nodes = await app.ListProjectTree();
-      const list = asArray(nodes);
-      setTree(list);
-      setExpanded((prev) => {
-        const next = new Set(prev);
-        const collapsed = manuallyCollapsedRef.current;
-        for (const key of defaultExpandedProjectTreeKeys(list, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) {
-          if (!collapsed.has(key)) next.add(key);
-        }
-        return next;
-      });
+      setTree(asArray(await app.ListProjectTree()));
     } catch {
       /* bridge unavailable */
     }
-  }, [activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath]);
+  }, []);
 
   useEffect(() => {
     manuallyCollapsedRef.current = manuallyCollapsed;
@@ -726,6 +717,15 @@ export function ProjectTree({
   useEffect(() => {
     void refresh();
   }, [refresh, refreshSignal]);
+
+  // Following the active topic is a view concern over the tree already held.
+  useEffect(() => {
+    const collapsed = manuallyCollapsedRef.current;
+    const keys = defaultExpandedProjectTreeKeys(tree, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath).filter((key) => !collapsed.has(key));
+    // Returning prev unchanged keeps a switch that expands nothing new from
+    // re-rendering the tree at all.
+    setExpanded((prev) => (keys.every((key) => prev.has(key)) ? prev : new Set([...prev, ...keys])));
+  }, [tree, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath]);
 
   const markNodeRead = useCallback((node: ProjectNode) => {
     const key = projectTreeReadActivityKey(node);


### PR DESCRIPTION
Stacked concern, independent branch: this is the call-site half of the switch-cost work
in #8063, and it lands on its own because it is a different kind of fix.

## The cause was a dependency list, not a decision

```ts
const refresh = useCallback(async () => {
  const nodes = await app.ListProjectTree();   // the data
  setTree(list);
  setExpanded(...activeScope, activeTopicId, activeSessionPath...);  // the selection
}, [activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath]);

useEffect(() => { void refresh(); }, [refresh, refreshSignal]);
```

Fetching and selection-following lived in one callback, so the callback's identity
depended on which session was open. **Every switch minted a new `refresh` and the effect
watching it refetched the entire tree** — a tree that cannot change because a different
session became active, and whose cost grows with the number of topics (70–336ms on a
201-topic sidebar).

## The fix

Fetching is keyed by the data — `refreshSignal` (`projectRevision`) is what already
marks the tree stale. Following the active topic became a separate effect over the tree
already in hand.

That effect also returns the previous set unchanged when a switch expands nothing new,
so a switch that changes nothing re-renders nothing.

## Measured

Same machine, same 201-topic sidebar, six switches, instrumented bridge:

| | before | after |
| --- | --- | --- |
| `ListProjectTree` per switch | **2** | **1** |

(Measured against `main-v2`, without #8063.)

**These two overlap on this call and do not add up.** #8063's 200ms window already
collapses the two tree listings into one backend call; this PR stops the second one from
being made at all. Measured together the result is the same — one listing per switch —
so the value here is not an extra call saved but the cause removed: coalescing masks a
request that should never have been issued, and masking it leaves the next component
free to reintroduce it. Coalescing keeps earning its place on the calls this cannot
reach (`ContextPanel`×3, `MetaForTab`×2, `EffortForTab`×3), which come from genuinely
independent hooks.

`53 passed, 0 failed` in `project-tree-runtime.test.ts` — the expansion behaviour it
pins is unchanged.

## The remaining one, and why it is not here

`App.tsx` lists the **entire tree to read a single number**: the active topic's turn
count, used only as a fallback while the transcript still shows zero turns. Listing 201
topics to fill in a value the loaded session supersedes moments later is the real waste,
but the fix belongs on the tab's own meta (`SessionMeta` already carries `Turns`), which
is a Go + type + App change and deserves its own review rather than riding along here.

Documentation-impact: none - no user-visible behaviour change; the tree renders and expands exactly as before, it is simply not refetched by a switch.
