### PR TITLE
Disable composer spellcheck / 禁用输入框拼写检查

### DIFF
--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -268,13 +268,9 @@ console.log("\ncomposer goal toggle");
 {
   const dom = installDom();
   const { root, calls, rerender } = await renderComposer();
-
   let textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
   if (!textarea) throw new Error("composer textarea did not render");
-  eq(textarea.getAttribute("spellcheck"), "false", "plain composer disables browser spellcheck");
-  eq(textarea.getAttribute("autocorrect"), "off", "plain composer disables browser autocorrect");
-  eq(textarea.getAttribute("autocapitalize"), "off", "plain composer disables browser autocapitalization");
-
+  eq(["spellcheck", "autocorrect", "autocapitalize"].map((name) => textarea.getAttribute(name)).join("/"), "false/off/off", "plain composer disables browser text assistance");
   await rerender({ insertRequest: { id: 1, text: "ship the release notes", mode: "replace" } });
   eq(textarea.value, "ship the release notes", "insert request populates the composer draft");
   // The insert queues a rAF that refocuses the textarea; drain that frame
@@ -607,9 +603,7 @@ console.log("\ncomposer goal toggle");
   let token = richInput?.querySelector<HTMLElement>(".composer-invocation-token");
   const invocationId = token?.dataset.invocationId;
   if (!richInput || !token || !invocationId) throw new Error("rich invocation did not render for paste undo selection");
-  eq(richInput.getAttribute("spellcheck"), "false", "rich composer disables browser spellcheck");
-  eq(richInput.getAttribute("autocorrect"), "off", "rich composer disables browser autocorrect");
-  eq(richInput.getAttribute("autocapitalize"), "off", "rich composer disables browser autocapitalization");
+  eq(["spellcheck", "autocorrect", "autocapitalize"].map((name) => richInput.getAttribute(name)).join("/"), "false/off/off", "rich composer disables browser text assistance");
   const afterToken = document.createRange();
   afterToken.setStartAfter(token);
   afterToken.collapse(true);

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -271,6 +271,9 @@ console.log("\ncomposer goal toggle");
 
   let textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
   if (!textarea) throw new Error("composer textarea did not render");
+  eq(textarea.getAttribute("spellcheck"), "false", "plain composer disables browser spellcheck");
+  eq(textarea.getAttribute("autocorrect"), "off", "plain composer disables browser autocorrect");
+  eq(textarea.getAttribute("autocapitalize"), "off", "plain composer disables browser autocapitalization");
 
   await rerender({ insertRequest: { id: 1, text: "ship the release notes", mode: "replace" } });
   eq(textarea.value, "ship the release notes", "insert request populates the composer draft");
@@ -604,6 +607,9 @@ console.log("\ncomposer goal toggle");
   let token = richInput?.querySelector<HTMLElement>(".composer-invocation-token");
   const invocationId = token?.dataset.invocationId;
   if (!richInput || !token || !invocationId) throw new Error("rich invocation did not render for paste undo selection");
+  eq(richInput.getAttribute("spellcheck"), "false", "rich composer disables browser spellcheck");
+  eq(richInput.getAttribute("autocorrect"), "off", "rich composer disables browser autocorrect");
+  eq(richInput.getAttribute("autocapitalize"), "off", "rich composer disables browser autocapitalization");
   const afterToken = document.createRange();
   afterToken.setStartAfter(token);
   afterToken.collapse(true);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -4503,10 +4503,7 @@ export function Composer({
                   id="composer-input"
                   ref={taRef}
                   className="composer__input"
-                  aria-label={t("composer.placeholder")}
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="off"
+                  aria-label={t("composer.placeholder")} spellCheck={false} autoCorrect="off" autoCapitalize="off"
                   value={text}
                   onInputCapture={(e) => {
                     pendingNativeInputTypeRef.current = (e.nativeEvent as InputEvent).inputType;

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -4504,6 +4504,9 @@ export function Composer({
                   ref={taRef}
                   className="composer__input"
                   aria-label={t("composer.placeholder")}
+                  spellCheck={false}
+                  autoCorrect="off"
+                  autoCapitalize="off"
                   value={text}
                   onInputCapture={(e) => {
                     pendingNativeInputTypeRef.current = (e.nativeEvent as InputEvent).inputType;

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -917,10 +917,7 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
       id="composer-input"
       ref={rootRef}
       className="composer__rich-input"
-      contentEditable={!disabled}
-      spellCheck={false}
-      autoCorrect="off"
-      autoCapitalize="off"
+      contentEditable={!disabled} spellCheck={false} autoCorrect="off" autoCapitalize="off"
       suppressContentEditableWarning
       role="textbox"
       aria-multiline="true"

--- a/desktop/frontend/src/components/RichComposerInput.tsx
+++ b/desktop/frontend/src/components/RichComposerInput.tsx
@@ -918,6 +918,9 @@ export const RichComposerInput = forwardRef<RichComposerInputHandle, {
       ref={rootRef}
       className="composer__rich-input"
       contentEditable={!disabled}
+      spellCheck={false}
+      autoCorrect="off"
+      autoCapitalize="off"
       suppressContentEditableWarning
       role="textbox"
       aria-multiline="true"


### PR DESCRIPTION
## Summary

- Disable browser spellcheck, autocorrect, and autocapitalization in both plain and rich composer modes.
- Preserve Reasonix's custom context menu, clipboard behavior, and edit history.
- Add regression assertions for the rendered input attributes.

## Problem

Closes #8062.

Reasonix inherited each platform webview's spellcheck behavior while replacing the native context menu with its own. That could show spelling underlines without offering correction suggestions, which was especially misleading for code-heavy and multilingual prompts.

## Root cause

Neither the plain `textarea` nor the rich `contenteditable` composer declared an explicit spellcheck policy, so Windows, macOS, and Linux webviews were free to apply platform defaults even though the related native correction UI was unavailable.

## Solution

Set `spellCheck={false}`, `autoCorrect="off"`, and `autoCapitalize="off"` on both composer implementations. This makes the behavior consistent across platforms without changing the existing Reasonix menu or adding a partial spellcheck setting.

## User impact

Composer text no longer shows browser-managed spelling underlines or receives browser-managed corrections/capitalization on Windows, macOS, or Linux.

## Verification

- `pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx` — 230 passed
- `pnpm exec tsx src/__tests__/composer-context-menu-clipboard.test.tsx` — 15 passed
- `pnpm typecheck`
- `pnpm exec eslint src/components/Composer.tsx src/components/RichComposerInput.tsx src/__tests__/composer-goal-toggle.test.tsx`
- `go run ./tools/repolint`
- `git diff --check`
- Playwright Chromium: rendered `TEXTAREA` reported `spellcheck="false"`, `autocorrect="off"`, and `autocapitalize="off"`, with no console errors

## Impact

- No provider, prompt-cache, persistence, or session behavior changes.
- No external contributor code was adopted.

Documentation-impact: none - this removes an incomplete browser-native editing affordance and does not change any documented configuration or workflow.
