### PR TITLE
fix(windows): repair legacy root-level shortcut icon and target / 修复旧版根目录快捷方式

### DIFF
--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -87,6 +87,9 @@ func repairExistingWindowsShortcuts(paths []string, launcher string, repair func
 }
 
 func repairWindowsShortcut(shortcutPath, launcher string) (bool, error) {
+	root := filepath.Dir(filepath.Clean(strings.TrimSpace(launcher)))
+	versionedLayout := installlayout.HasCurrent(root)
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	if err := ole.CoInitializeEx(0, ole.COINIT_APARTMENTTHREADED); err != nil {
@@ -130,7 +133,7 @@ func repairWindowsShortcut(shortcutPath, launcher string) (bool, error) {
 	}
 	iconLocation := iconValue.ToString()
 	_ = iconValue.Clear()
-	repointTarget, fixIcon := repairWindowsShortcutPlan(target, iconLocation, launcher)
+	repointTarget, fixIcon := repairWindowsShortcutPlan(target, iconLocation, launcher, versionedLayout)
 	if !repointTarget && !fixIcon {
 		return false, nil
 	}
@@ -205,30 +208,34 @@ func reasonixWindowsVersionedTarget(target, launcher string) bool {
 
 // repairWindowsShortcutPlan decides which owned-shortcut properties need
 // rewriting. repointTarget is true when TargetPath points into a versioned
-// directory the updater can delete or at a removed legacy root-level desktop
-// binary; fixIcon is true when IconLocation points at a versioned or removed
-// root-level desktop binary instead of the stable launcher.
-func repairWindowsShortcutPlan(target, iconLocation, launcher string) (repointTarget, fixIcon bool) {
-	repointTarget = reasonixWindowsVersionedTarget(target, launcher) || reasonixWindowsFlatDesktopTarget(target, launcher)
-	return repointTarget, reasonixWindowsStaleIcon(iconLocation, launcher)
+// directory the updater can delete or at a legacy root-level desktop binary
+// after the versioned layout is active; fixIcon applies the same policy to
+// IconLocation. Flat installs keep their live root-level binary untouched.
+func repairWindowsShortcutPlan(target, iconLocation, launcher string, versionedLayout bool) (repointTarget, fixIcon bool) {
+	repointTarget = reasonixWindowsVersionedTarget(target, launcher) ||
+		reasonixWindowsFlatDesktopTarget(target, launcher, versionedLayout)
+	return repointTarget, reasonixWindowsStaleIcon(iconLocation, launcher, versionedLayout)
 }
 
 // reasonixWindowsFlatDesktopTarget reports whether target points at the
-// legacy root-level desktop binary (<root>/reasonix-desktop.exe) that no
-// longer exists. Pre-versioned installs created shortcuts against the
-// root-level binary; after the layout migration the file is gone and the
-// shortcut dangles. A still-present root-level binary means a live flat
-// install, which must be left alone.
-func reasonixWindowsFlatDesktopTarget(target, launcher string) bool {
+// legacy root-level desktop binary (<root>/reasonix-desktop.exe) after the
+// versioned layout is active or after that binary has disappeared. A valid
+// current.json is the layout commit point, so a leftover flat binary must not
+// be mistaken for a live flat install when best-effort cleanup could not remove
+// it.
+func reasonixWindowsFlatDesktopTarget(target, launcher string, versionedLayout bool) bool {
 	flat := filepath.Join(filepath.Dir(filepath.Clean(strings.TrimSpace(launcher))), "reasonix-desktop.exe")
 	if !strings.EqualFold(filepath.Clean(strings.TrimSpace(target)), flat) {
 		return false
+	}
+	if versionedLayout {
+		return true
 	}
 	_, err := os.Lstat(flat)
 	return os.IsNotExist(err)
 }
 
-func reasonixWindowsStaleIcon(iconLocation, launcher string) bool {
+func reasonixWindowsStaleIcon(iconLocation, launcher string, versionedLayout bool) bool {
 	iconPath := strings.TrimSpace(iconLocation)
 	if comma := strings.LastIndex(iconPath, ","); comma >= 0 {
 		if _, err := strconv.Atoi(strings.TrimSpace(iconPath[comma+1:])); err == nil {
@@ -249,9 +256,13 @@ func reasonixWindowsStaleIcon(iconLocation, launcher string) bool {
 		strings.EqualFold(parts[2], "reasonix-desktop.exe") {
 		return true
 	}
-	// Legacy root-level icon: stale only when the binary is gone, so a live
-	// flat install keeps its working icon.
+	// Legacy root-level icon: stale once the versioned layout is committed, even
+	// if best-effort cleanup left the old binary behind. Without current.json,
+	// require the file to be gone so a live flat install keeps its working icon.
 	if len(parts) == 1 && strings.EqualFold(parts[0], "reasonix-desktop.exe") {
+		if versionedLayout {
+			return true
+		}
 		_, err := os.Lstat(filepath.Clean(iconPath))
 		return os.IsNotExist(err)
 	}

--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -205,10 +205,27 @@ func reasonixWindowsVersionedTarget(target, launcher string) bool {
 
 // repairWindowsShortcutPlan decides which owned-shortcut properties need
 // rewriting. repointTarget is true when TargetPath points into a versioned
-// directory the updater can delete; fixIcon is true when IconLocation points
-// at the versioned desktop binary instead of the stable launcher.
+// directory the updater can delete or at a removed legacy root-level desktop
+// binary; fixIcon is true when IconLocation points at a versioned or removed
+// root-level desktop binary instead of the stable launcher.
 func repairWindowsShortcutPlan(target, iconLocation, launcher string) (repointTarget, fixIcon bool) {
-	return reasonixWindowsVersionedTarget(target, launcher), reasonixWindowsStaleIcon(iconLocation, launcher)
+	repointTarget = reasonixWindowsVersionedTarget(target, launcher) || reasonixWindowsFlatDesktopTarget(target, launcher)
+	return repointTarget, reasonixWindowsStaleIcon(iconLocation, launcher)
+}
+
+// reasonixWindowsFlatDesktopTarget reports whether target points at the
+// legacy root-level desktop binary (<root>/reasonix-desktop.exe) that no
+// longer exists. Pre-versioned installs created shortcuts against the
+// root-level binary; after the layout migration the file is gone and the
+// shortcut dangles. A still-present root-level binary means a live flat
+// install, which must be left alone.
+func reasonixWindowsFlatDesktopTarget(target, launcher string) bool {
+	flat := filepath.Join(filepath.Dir(filepath.Clean(strings.TrimSpace(launcher))), "reasonix-desktop.exe")
+	if !strings.EqualFold(filepath.Clean(strings.TrimSpace(target)), flat) {
+		return false
+	}
+	_, err := os.Lstat(flat)
+	return os.IsNotExist(err)
 }
 
 func reasonixWindowsStaleIcon(iconLocation, launcher string) bool {
@@ -228,8 +245,17 @@ func reasonixWindowsStaleIcon(iconLocation, launcher string) bool {
 		return false
 	}
 	parts := strings.Split(rel, string(filepath.Separator))
-	return len(parts) == 3 && strings.EqualFold(parts[0], "versions") &&
-		strings.EqualFold(parts[2], "reasonix-desktop.exe")
+	if len(parts) == 3 && strings.EqualFold(parts[0], "versions") &&
+		strings.EqualFold(parts[2], "reasonix-desktop.exe") {
+		return true
+	}
+	// Legacy root-level icon: stale only when the binary is gone, so a live
+	// flat install keeps its working icon.
+	if len(parts) == 1 && strings.EqualFold(parts[0], "reasonix-desktop.exe") {
+		_, err := os.Lstat(filepath.Clean(iconPath))
+		return os.IsNotExist(err)
+	}
+	return false
 }
 
 func notifyWindowsShortcutChanged(path string) {

--- a/desktop/icon_repair_windows.go
+++ b/desktop/icon_repair_windows.go
@@ -217,12 +217,10 @@ func repairWindowsShortcutPlan(target, iconLocation, launcher string, versionedL
 	return repointTarget, reasonixWindowsStaleIcon(iconLocation, launcher, versionedLayout)
 }
 
-// reasonixWindowsFlatDesktopTarget reports whether target points at the
-// legacy root-level desktop binary (<root>/reasonix-desktop.exe) after the
-// versioned layout is active or after that binary has disappeared. A valid
-// current.json is the layout commit point, so a leftover flat binary must not
-// be mistaken for a live flat install when best-effort cleanup could not remove
-// it.
+// reasonixWindowsFlatDesktopTarget reports whether target points at the legacy
+// root-level desktop binary after versioned layout activation or after the file
+// disappeared. A valid current.json is the commit point, so a leftover flat
+// binary is not a live flat install when best-effort cleanup could not remove it.
 func reasonixWindowsFlatDesktopTarget(target, launcher string, versionedLayout bool) bool {
 	flat := filepath.Join(filepath.Dir(filepath.Clean(strings.TrimSpace(launcher))), "reasonix-desktop.exe")
 	if !strings.EqualFold(filepath.Clean(strings.TrimSpace(target)), flat) {

--- a/desktop/icon_repair_windows_test.go
+++ b/desktop/icon_repair_windows_test.go
@@ -73,7 +73,7 @@ func TestReasonixWindowsShortcutTargetRequiresCurrentInstall(t *testing.T) {
 	}
 }
 
-func TestReasonixWindowsStaleIconOnlyMatchesVersionedDesktop(t *testing.T) {
+func TestReasonixWindowsStaleIcon(t *testing.T) {
 	root := filepath.Join(`C:\Program Files, Inc`, "Reasonix")
 	launcher := filepath.Join(root, "reasonix-launcher.exe")
 	tests := []struct {
@@ -83,6 +83,7 @@ func TestReasonixWindowsStaleIconOnlyMatchesVersionedDesktop(t *testing.T) {
 	}{
 		{name: "versioned", icon: filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: true},
 		{name: "quoted versioned", icon: `"` + filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + `", 0`, want: true},
+		{name: "legacy root-level (file gone)", icon: filepath.Join(root, "reasonix-desktop.exe") + ",0", want: true},
 		{name: "stable launcher", icon: launcher + ",0", want: false},
 		{name: "custom icon", icon: filepath.Join(root, "custom.ico") + ",0", want: false},
 		{name: "other install", icon: filepath.Join(`D:\Apps`, "Reasonix", "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: false},
@@ -94,6 +95,37 @@ func TestReasonixWindowsStaleIconOnlyMatchesVersionedDesktop(t *testing.T) {
 				t.Fatalf("reasonixWindowsStaleIcon(%q, %q) = %v, want %v", tt.icon, launcher, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReasonixWindowsFlatDesktopTargetNeedsMissingFile(t *testing.T) {
+	root := t.TempDir()
+	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	flat := filepath.Join(root, "reasonix-desktop.exe")
+
+	// No file on disk: the legacy root-level target dangles after the
+	// versioned-layout migration and must be repointed.
+	if !reasonixWindowsFlatDesktopTarget(flat, launcher) {
+		t.Fatalf("missing flat desktop target = false, want true")
+	}
+
+	// A live flat install still has the binary; its shortcut must be left alone.
+	if err := os.WriteFile(flat, []byte("binary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if reasonixWindowsFlatDesktopTarget(flat, launcher) {
+		t.Fatalf("existing flat desktop target = true, want false")
+	}
+
+	// Non-flat targets never match.
+	for _, target := range []string{
+		launcher,
+		filepath.Join(root, "Reasonix.exe"),
+		filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe"),
+	} {
+		if reasonixWindowsFlatDesktopTarget(target, launcher) {
+			t.Fatalf("reasonixWindowsFlatDesktopTarget(%q) = true, want false", target)
+		}
 	}
 }
 
@@ -125,7 +157,7 @@ func TestReasonixWindowsVersionedTarget(t *testing.T) {
 }
 
 func TestRepairWindowsShortcutPlan(t *testing.T) {
-	root := filepath.Join(`C:\Program Files`, "Reasonix")
+	root := t.TempDir()
 	launcher := filepath.Join(root, "reasonix-launcher.exe")
 	versioned := filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe")
 	tests := []struct {
@@ -139,6 +171,8 @@ func TestRepairWindowsShortcutPlan(t *testing.T) {
 		{name: "versioned target + clean icon", target: versioned, icon: launcher + ",0", wantRepoint: true, wantFixIcon: false},
 		{name: "stable target + versioned icon", target: launcher, icon: versioned + ",0", wantRepoint: false, wantFixIcon: true},
 		{name: "stable target + clean icon", target: launcher, icon: launcher + ",0", wantRepoint: false, wantFixIcon: false},
+		{name: "flat target + flat icon (both gone)", target: filepath.Join(root, "reasonix-desktop.exe"), icon: filepath.Join(root, "reasonix-desktop.exe") + ",0", wantRepoint: true, wantFixIcon: true},
+		{name: "flat target + clean icon", target: filepath.Join(root, "reasonix-desktop.exe"), icon: launcher + ",0", wantRepoint: true, wantFixIcon: false},
 		{name: "custom target + custom icon", target: filepath.Join(root, "custom.ico"), icon: filepath.Join(root, "custom.ico") + ",0", wantRepoint: false, wantFixIcon: false},
 	}
 	for _, tt := range tests {

--- a/desktop/icon_repair_windows_test.go
+++ b/desktop/icon_repair_windows_test.go
@@ -74,8 +74,12 @@ func TestReasonixWindowsShortcutTargetRequiresCurrentInstall(t *testing.T) {
 }
 
 func TestReasonixWindowsStaleIcon(t *testing.T) {
-	root := filepath.Join(`C:\Program Files, Inc`, "Reasonix")
+	root := filepath.Join(t.TempDir(), "Program Files, Inc", "Reasonix")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	launcher := filepath.Join(root, "reasonix-launcher.exe")
+	flat := filepath.Join(root, "reasonix-desktop.exe")
 	tests := []struct {
 		name string
 		icon string
@@ -83,7 +87,7 @@ func TestReasonixWindowsStaleIcon(t *testing.T) {
 	}{
 		{name: "versioned", icon: filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: true},
 		{name: "quoted versioned", icon: `"` + filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe") + `", 0`, want: true},
-		{name: "legacy root-level (file gone)", icon: filepath.Join(root, "reasonix-desktop.exe") + ",0", want: true},
+		{name: "legacy root-level (file gone)", icon: flat + ",0", want: true},
 		{name: "stable launcher", icon: launcher + ",0", want: false},
 		{name: "custom icon", icon: filepath.Join(root, "custom.ico") + ",0", want: false},
 		{name: "other install", icon: filepath.Join(`D:\Apps`, "Reasonix", "versions", "v1.19.3", "reasonix-desktop.exe") + ",0", want: false},
@@ -91,10 +95,20 @@ func TestReasonixWindowsStaleIcon(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := reasonixWindowsStaleIcon(tt.icon, launcher); got != tt.want {
+			if got := reasonixWindowsStaleIcon(tt.icon, launcher, false); got != tt.want {
 				t.Fatalf("reasonixWindowsStaleIcon(%q, %q) = %v, want %v", tt.icon, launcher, got, tt.want)
 			}
 		})
+	}
+
+	if err := os.WriteFile(flat, []byte("binary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if reasonixWindowsStaleIcon(flat+",0", launcher, false) {
+		t.Fatal("live flat icon = stale, want healthy")
+	}
+	if !reasonixWindowsStaleIcon(flat+",0", launcher, true) {
+		t.Fatal("versioned layout with leftover flat icon = healthy, want stale")
 	}
 }
 
@@ -105,7 +119,7 @@ func TestReasonixWindowsFlatDesktopTargetNeedsMissingFile(t *testing.T) {
 
 	// No file on disk: the legacy root-level target dangles after the
 	// versioned-layout migration and must be repointed.
-	if !reasonixWindowsFlatDesktopTarget(flat, launcher) {
+	if !reasonixWindowsFlatDesktopTarget(flat, launcher, false) {
 		t.Fatalf("missing flat desktop target = false, want true")
 	}
 
@@ -113,8 +127,11 @@ func TestReasonixWindowsFlatDesktopTargetNeedsMissingFile(t *testing.T) {
 	if err := os.WriteFile(flat, []byte("binary"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if reasonixWindowsFlatDesktopTarget(flat, launcher) {
+	if reasonixWindowsFlatDesktopTarget(flat, launcher, false) {
 		t.Fatalf("existing flat desktop target = true, want false")
+	}
+	if !reasonixWindowsFlatDesktopTarget(flat, launcher, true) {
+		t.Fatalf("versioned layout with leftover flat desktop target = false, want true")
 	}
 
 	// Non-flat targets never match.
@@ -123,7 +140,7 @@ func TestReasonixWindowsFlatDesktopTargetNeedsMissingFile(t *testing.T) {
 		filepath.Join(root, "Reasonix.exe"),
 		filepath.Join(root, "versions", "v1.19.3", "reasonix-desktop.exe"),
 	} {
-		if reasonixWindowsFlatDesktopTarget(target, launcher) {
+		if reasonixWindowsFlatDesktopTarget(target, launcher, true) {
 			t.Fatalf("reasonixWindowsFlatDesktopTarget(%q) = true, want false", target)
 		}
 	}
@@ -177,10 +194,21 @@ func TestRepairWindowsShortcutPlan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repoint, fixIcon := repairWindowsShortcutPlan(tt.target, tt.icon, launcher)
+			repoint, fixIcon := repairWindowsShortcutPlan(tt.target, tt.icon, launcher, false)
 			if repoint != tt.wantRepoint || fixIcon != tt.wantFixIcon {
 				t.Fatalf("repairWindowsShortcutPlan(%q, %q) = (%v, %v), want (%v, %v)", tt.target, tt.icon, repoint, fixIcon, tt.wantRepoint, tt.wantFixIcon)
 			}
 		})
+	}
+
+	flat := filepath.Join(root, "reasonix-desktop.exe")
+	if err := os.WriteFile(flat, []byte("binary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if repoint, fixIcon := repairWindowsShortcutPlan(flat, flat+",0", launcher, false); repoint || fixIcon {
+		t.Fatalf("live flat plan = (%v, %v), want (false, false)", repoint, fixIcon)
+	}
+	if repoint, fixIcon := repairWindowsShortcutPlan(flat, flat+",0", launcher, true); !repoint || !fixIcon {
+		t.Fatalf("versioned layout leftover plan = (%v, %v), want (true, true)", repoint, fixIcon)
 	}
 }


### PR DESCRIPTION
Fixes #8072

---

### English

**Problem**

Windows shortcuts created before the versioned-v1 layout can retain an `IconLocation` pointing at the root-level `<root>\reasonix-desktop.exe`. In official releases, this affects shortcuts created by v1.19.2 or earlier and then upgraded to the versioned layout introduced in v1.19.3. Still older shortcuts (v1.17.12 or earlier) can also retain that root-level path as their `TargetPath`.

After migration, the root-level desktop binary is normally removed, so the icon becomes generic and an old TargetPath can stop launching. The existing runtime repair only recognized `<root>\versions\<v>\reasonix-desktop.exe`, so these legacy root-level properties never self-healed.

**Root cause**

The shortcut repair recognized the root-level desktop binary as Reasonix-owned, but its stale target/icon checks only matched versioned paths. File existence alone is not enough to distinguish a live flat install: versioned activation commits `current.json` before best-effort cleanup of old flat binaries, so an occupied or ACL-protected root-level executable can remain after the versioned layout is already active.

**Fix**

- Repair a root-level `TargetPath` or `IconLocation` when a valid `current.json` confirms the versioned layout, even if cleanup left the old binary behind.
- Also repair the property when the legacy root-level binary is gone.
- Preserve a true flat install when there is no valid `current.json` and its root-level binary still exists.
- Leave customized shortcuts and paths from other Reasonix installations untouched.
- Read the layout pointer before entering the COM-bound OS-thread section.

**Tests**

- Isolated all file-existence cases under `t.TempDir()` (including paths containing commas).
- Covered missing legacy files, live flat installs, versioned layouts with leftover flat files, customized paths, and other installations for both target and icon decisions.
- Verified the focused tests and real `.lnk` rewrites in a native Windows 11 VM.
- `cd desktop && go vet ./...`
- `cd desktop && go test ./...`
- `cd desktop && GOOS=windows GOARCH=amd64 go test -c`
- `go test ./internal/installlayout`

Documentation-impact: none - this is an internal Windows shortcut-repair correction with no CLI, config, schema, or user-workflow change.

---

### 中文

**问题**

版本化 v1 布局之前创建的 Windows 快捷方式，`IconLocation` 可能一直指向根目录的 `<root>\reasonix-desktop.exe`。对正式版本而言，这主要是由 v1.19.2 及更早版本创建、随后升级到 v1.19.3 引入的版本化布局的快捷方式。更早的快捷方式（v1.17.12 及以前）还可能把同一路径保留为 `TargetPath`。

迁移后，根目录 desktop 二进制通常会被删除，因此图标退化为通用图标，旧 TargetPath 甚至可能无法启动。现有运行时修复只识别 `<root>\versions\<v>\reasonix-desktop.exe`，不会自愈这些根目录形态的旧属性。

**根因**

快捷方式修复虽然承认根目录 desktop 二进制属于 Reasonix，但 stale target/icon 判断只匹配版本化路径。仅靠“文件是否存在”也不能区分活 flat 安装：版本化激活会先提交 `current.json`，再尽力删除旧 flat 二进制；若文件被占用、ACL 拒绝或安全软件拦截，版本化布局已经生效但旧文件仍可能残留。

**修复**

- 有效 `current.json` 确认版本化布局后，即使旧根目录二进制残留，也修复根目录形态的 `TargetPath` 和 `IconLocation`。
- 旧根目录二进制已经消失时同样修复。
- 没有有效 `current.json` 且根目录二进制仍存在时，保留真正的 flat 安装。
- 不修改自定义快捷方式和其他 Reasonix 安装目录中的路径。
- 在进入 COM 绑定的 OS 线程区段之前读取布局指针。

**测试**

- 所有文件存在性场景改用 `t.TempDir()` 隔离（包括带逗号的路径）。
- Target 与 Icon 都覆盖：旧文件缺失、活 flat 安装、版本化布局但旧文件残留、自定义路径、其他安装目录。
- 在原生 Windows 11 VM 中验证聚焦测试和真实 `.lnk` 重写。
- `cd desktop && go vet ./...`
- `cd desktop && go test ./...`
- `cd desktop && GOOS=windows GOARCH=amd64 go test -c`
- `go test ./internal/installlayout`

Documentation-impact: none - 改动仅修正 Windows 内部快捷方式修复逻辑，不涉及 CLI、配置、schema 或用户工作流。

