### PR TITLE
fix(agent): abort degenerate repetition loops at the stream boundary

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -278,14 +278,15 @@ type ToolHooks interface {
 // Agent drives a single task: a Provider, a tool Registry, and a Session wired
 // into the main loop.
 type Agent struct {
-	prov               provider.Provider
-	tools              *tool.Registry
-	session            *Session
-	sessMu             sync.Mutex // guards the session pointer for external Session()/SetSession
-	maxSteps           int
-	maxStepsKey        string
-	reasoningByteLimit int
-	maxOutputTokens    int
+	prov                provider.Provider
+	tools               *tool.Registry
+	session             *Session
+	sessMu              sync.Mutex // guards the session pointer for external Session()/SetSession
+	maxSteps            int
+	maxStepsKey         string
+	reasoningByteLimit  int
+	repetitionTripLimit int
+	maxOutputTokens     int
 	// executorHandoffGuard is enabled by Coordinator for the executor agent. The
 	// per-turn marker check in Run keeps ordinary single-model turns unaffected.
 	executorHandoffGuard bool
@@ -1034,6 +1035,10 @@ type Options struct {
 	// uses the default guard; a negative value disables only this client guard.
 	// Provider output budgets are a separate protocol/model capability.
 	ReasoningByteLimit int
+	// RepetitionTripLimit is how many identical output segments the recent
+	// stream window tolerates before the client repetition guard aborts the
+	// attempt. Zero uses the default guard; a negative value disables it.
+	RepetitionTripLimit int
 	// MaxOutputTokens overrides the provider's configured/default total output
 	// budget. Zero delegates to the provider; a negative value asks optional
 	// protocols to omit the budget (Anthropic still requires max_tokens).
@@ -1251,6 +1256,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		maxSteps:                  opts.MaxSteps,
 		maxStepsKey:               maxStepsKey,
 		reasoningByteLimit:        reasoningByteLimit,
+		repetitionTripLimit:       resolveRepetitionTripLimit(opts.RepetitionTripLimit),
 		maxOutputTokens:           opts.MaxOutputTokens,
 		temperature:               opts.Temperature,
 		pricing:                   opts.Pricing,
@@ -2337,6 +2343,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	if err != nil {
 		return streamedTurn{usage: provider.UsageWithRequestAttemptCount(ctx, nil), err: err}
 	}
+	repetition := newRepetitionDetector(a.repetitionTripLimit)
 
 	// A PostLLMCall hook rewrites the whole reasoning block, so when one is wired
 	// up we buffer reasoning silently and emit the transformed text once after the
@@ -2436,7 +2443,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 					partialCalls: partialCalls, maxArgChars: maxArgChars,
 				}
 			}
-			chunk = c
+			chunk = repetition.filter(c)
 		}
 		switch chunk.Type {
 		case provider.ChunkReasoning:

--- a/internal/agent/compact_loop_e2e_test.go
+++ b/internal/agent/compact_loop_e2e_test.go
@@ -119,6 +119,18 @@ func compactionsPerTurn(t *testing.T, windowTok int, blob, finalText string, tur
 	return perTurn, paused, prunes
 }
 
+// variedAnalysisText grows assistant text like a real answer: same volume as
+// the old repeated-filler blob (~20 chars per sentence), but with distinct
+// sentences so the client repetition guard (correctly) does not read it as a
+// degenerate loop.
+func variedAnalysisText(sentences int) string {
+	var b strings.Builder
+	for i := range sentences {
+		fmt.Fprintf(&b, "analysis part %04d. ", i)
+	}
+	return b.String()
+}
+
 func consecutiveCompactingTurns(perTurn []int) int {
 	worst, run := 0, 0
 	for _, n := range perTurn {
@@ -161,7 +173,7 @@ func TestCompactionPausesWhenWindowTooSmall(t *testing.T) {
 // session grows but reclaims enough headroom that it never fires on consecutive
 // turns and never trips the stuck guard.
 func TestCompactionHealthyWindowNeverLoops(t *testing.T) {
-	perTurn, paused, _ := compactionsPerTurn(t, 40000, "small tool output", strings.Repeat("analysis paragraph. ", 600), 20)
+	perTurn, paused, _ := compactionsPerTurn(t, 40000, "small tool output", variedAnalysisText(600), 20)
 
 	total := 0
 	for _, n := range perTurn {

--- a/internal/agent/repetition_guard.go
+++ b/internal/agent/repetition_guard.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"reasonix/internal/provider"
+)
+
+// The client repetition guard aborts a stream whose output degenerates into
+// re-emitting the same sentence instead of acting — a DeepSeek-class failure
+// the provider's own repetition_truncation often misses. Aborted attempts ride
+// the sampling-recovery discard path, so degenerate text never reaches the
+// session and cannot self-reinforce on the retry.
+const (
+	defaultRepetitionTripLimit = 12
+	repetitionWindowSegments   = 192
+	repetitionSegmentMinRunes  = 12
+	// Two tiers: exact segments trip at the limit; lowercased 24-rune stem
+	// buckets trip at twice the limit, because degenerate loops paraphrase
+	// ("Let me push to the fork." / "Let me push to the fork remote first.")
+	// while legitimate enumerations also share stems, just never that many.
+	repetitionStemRunes       = 24
+	repetitionStemTripFactor  = 2
+	repetitionSegmentMaxBytes = 512
+	repetitionCarryMaxBytes   = 4096
+
+	repetitionDiscardReason = "repetition_loop"
+	// maxRepetitionRetries is deliberately smaller than the stream-recovery
+	// budget: every degenerate attempt burns real completion tokens before the
+	// guard trips, and a frozen-request replay may reproduce the loop.
+	maxRepetitionRetries = 2
+)
+
+var errRepetitionLoop = errors.New("output repetition loop detected; stream stopped by client guard")
+
+// Escape hatch while the guard gathers field experience; graduation to config
+// waits on that verdict (governor precedent).
+var repetitionGuardDisabledByEnv = os.Getenv("REASONIX_REPETITION_GUARD") == "0"
+
+// resolveRepetitionTripLimit applies the Options contract: zero means the
+// default guard, negative (or the env escape hatch) disables it.
+func resolveRepetitionTripLimit(v int) int {
+	if v == 0 {
+		v = defaultRepetitionTripLimit
+	}
+	if v < 0 || repetitionGuardDisabledByEnv {
+		return 0
+	}
+	return v
+}
+
+// filter passes one received chunk through, replacing it with a terminal
+// ChunkError once text or reasoning output degenerates. The consumer's error
+// path rides the sampling-recovery discard, so the loop never commits. A nil
+// detector forwards everything untouched.
+func (d *repetitionDetector) filter(c provider.Chunk) provider.Chunk {
+	if d == nil {
+		return c
+	}
+	if (c.Type == provider.ChunkText || c.Type == provider.ChunkReasoning) && d.observe(c.Text) {
+		return provider.Chunk{Type: provider.ChunkError, Err: errRepetitionLoop}
+	}
+	return c
+}
+
+// samplingRetryPlan decides whether a failed sampling attempt is retried and
+// under which discard reason and budget. Repetition trips get a deliberately
+// smaller budget than transport interruptions (see maxRepetitionRetries).
+func samplingRetryPlan(err error, attempt int) (reason string, retryMax int, ok bool) {
+	if provider.IsStreamInterrupted(err) && attempt < maxSamplingAttempts {
+		return provider.StreamInterruptReason(err), maxStreamRecoveries, true
+	}
+	if errors.Is(err, errRepetitionLoop) && attempt <= maxRepetitionRetries && attempt < maxSamplingAttempts {
+		return repetitionDiscardReason, maxRepetitionRetries + 1, true
+	}
+	return "", 0, false
+}
+
+// repetitionDetector counts normalized line/sentence segments across a sliding
+// window of one stream. A nil detector observes nothing and never trips.
+type repetitionDetector struct {
+	tripLimit  int
+	carry      []byte
+	ring       []repetitionKeys
+	counts     map[string]int
+	stemCounts map[string]int
+	repeated   string
+}
+
+type repetitionKeys struct {
+	exact string
+	stem  string
+}
+
+func newRepetitionDetector(tripLimit int) *repetitionDetector {
+	if tripLimit <= 0 {
+		return nil
+	}
+	return &repetitionDetector{
+		tripLimit:  tripLimit,
+		counts:     make(map[string]int),
+		stemCounts: make(map[string]int),
+	}
+}
+
+// observe folds one streamed chunk and reports whether the guard has tripped.
+// Once tripped it stays tripped.
+func (d *repetitionDetector) observe(chunk string) bool {
+	if d == nil {
+		return false
+	}
+	if d.repeated != "" {
+		return true
+	}
+	d.carry = append(d.carry, chunk...)
+	for {
+		seg, rest, ok := cutRepetitionSegment(d.carry)
+		if !ok {
+			break
+		}
+		d.carry = rest
+		d.push(seg)
+		if d.repeated != "" {
+			return true
+		}
+	}
+	// Separator-less streams flush in blocks so carry stays bounded; identical
+	// blocks still count when the stream repeats in phase.
+	if len(d.carry) > repetitionCarryMaxBytes {
+		block := string(d.carry)
+		d.carry = d.carry[:0]
+		d.push(block)
+	}
+	return d.repeated != ""
+}
+
+// cutRepetitionSegment splits off the earliest complete segment: a newline
+// always ends one; ASCII sentence enders need trailing whitespace so decimals
+// and abbreviations survive; fullwidth CJK enders split unconditionally.
+func cutRepetitionSegment(b []byte) (seg string, rest []byte, ok bool) {
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		switch r {
+		case '\n':
+			return string(b[:i]), b[i+size:], true
+		case '.', '!', '?':
+			next := i + size
+			if next < len(b) && (b[next] == ' ' || b[next] == '\t' || b[next] == '\r' || b[next] == '\n') {
+				return string(b[:next]), b[next:], true
+			}
+		case '。', '！', '？':
+			return string(b[:i+size]), b[i+size:], true
+		}
+		i += size
+	}
+	return "", b, false
+}
+
+func (d *repetitionDetector) push(raw string) {
+	seg := strings.ToLower(strings.TrimSpace(raw))
+	if utf8.RuneCountInString(seg) < repetitionSegmentMinRunes {
+		return
+	}
+	if len(seg) > repetitionSegmentMaxBytes {
+		cut := repetitionSegmentMaxBytes
+		for cut > 0 && !utf8.RuneStart(seg[cut]) {
+			cut--
+		}
+		seg = seg[:cut]
+	}
+	keys := repetitionKeys{exact: seg, stem: repetitionStem(seg)}
+	if len(d.ring) == repetitionWindowSegments {
+		oldest := d.ring[0]
+		d.ring = d.ring[1:]
+		decrement(d.counts, oldest.exact)
+		decrement(d.stemCounts, oldest.stem)
+	}
+	d.ring = append(d.ring, keys)
+	d.counts[keys.exact]++
+	d.stemCounts[keys.stem]++
+	if d.counts[keys.exact] >= d.tripLimit || d.stemCounts[keys.stem] >= repetitionStemTripFactor*d.tripLimit {
+		d.repeated = keys.stem
+	}
+}
+
+func decrement(m map[string]int, key string) {
+	if n := m[key] - 1; n > 0 {
+		m[key] = n
+	} else {
+		delete(m, key)
+	}
+}
+
+func repetitionStem(seg string) string {
+	runes := 0
+	for i := range seg {
+		if runes == repetitionStemRunes {
+			return seg[:i]
+		}
+		runes++
+	}
+	return seg
+}

--- a/internal/agent/repetition_guard_test.go
+++ b/internal/agent/repetition_guard_test.go
@@ -1,0 +1,246 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestRepetitionDetectorTripsOnSentenceLoop(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	line := "Let me create the PR body file and run both gate scripts.\n\n"
+	tripped := false
+	for i := 0; i < 40 && !tripped; i++ {
+		// Odd-sized chunks exercise the carry across segment boundaries.
+		tripped = slices.ContainsFunc([]string{line[:7], line[7:23], line[23:]}, d.observe)
+		if tripped && i+1 < defaultRepetitionTripLimit {
+			t.Fatalf("tripped after %d repeats, want at least %d", i+1, defaultRepetitionTripLimit)
+		}
+	}
+	if !tripped {
+		t.Fatal("detector never tripped on 40 identical sentences")
+	}
+}
+
+func TestRepetitionDetectorTripsOnCycledSentences(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	cycle := []string{
+		"Let me write the PR body and run the checks. ",
+		"Let me do it now. This is taking too long already. ",
+		"I will now execute the command for real. ",
+	}
+	for i := range 60 {
+		if d.observe(cycle[i%len(cycle)]) {
+			return
+		}
+	}
+	t.Fatal("detector never tripped on an A/B/C sentence cycle")
+}
+
+// Stems taken from a real DeepSeek-V4-Flash looping session: the model
+// paraphrases ("Let me check the git config." / "Let me check the git
+// configuration now."), so exact-segment counting never trips. Prefix
+// bucketing must pool the variants.
+func TestRepetitionDetectorTripsOnParaphrasedLoop(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	variants := []string{
+		"Let me check the git config. ",
+		"Let me check the git configuration now. ",
+		"Let me check the git config for the fork remote. ",
+		"Let me check the git config once more, for real this time. ",
+	}
+	for i := range 80 {
+		if d.observe(variants[i%len(variants)]) {
+			if i+1 < repetitionStemTripFactor*defaultRepetitionTripLimit {
+				t.Fatalf("tripped after %d segments, want at least %d", i+1, repetitionStemTripFactor*defaultRepetitionTripLimit)
+			}
+			return
+		}
+	}
+	t.Fatal("detector never tripped on paraphrased same-stem loop")
+}
+
+// Parallel-construction enumerations legitimately share a sentence stem; the
+// stem tier must tolerate them up to twice the exact limit.
+func TestRepetitionDetectorToleratesParallelEnumeration(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	for i := range defaultRepetitionTripLimit + 3 {
+		line := fmt.Sprintf("Returns an error when the input payload is variant %d of the schema. \n", i)
+		if d.observe(line) {
+			t.Fatalf("tripped on a legitimate %d-item parallel enumeration", i+1)
+		}
+	}
+}
+
+func TestRepetitionDetectorIgnoresVariedProseAndShortRepeats(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	heads := []string{
+		"The parser", "Compaction", "Every provider", "Session state", "A retry",
+		"Tool receipts", "The controller", "Prefix caching", "Steering", "Evidence",
+		"The gate", "Recovery", "Billing", "Telemetry", "The sink", "Streams", "Budgets",
+	}
+	for i := range 300 {
+		line := fmt.Sprintf("Case %03d: %s behaves differently here, as covered above. \n", i, heads[i%len(heads)])
+		if d.observe(line) {
+			t.Fatalf("tripped on varied prose at line %d", i)
+		}
+		if d.observe("```\n") || d.observe("}\n") {
+			t.Fatalf("tripped on short structural line at %d", i)
+		}
+	}
+}
+
+func TestRepetitionDetectorCJKSentences(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	for range 40 {
+		if d.observe("让我现在就创建这个文件并运行两个脚本。") {
+			return
+		}
+	}
+	t.Fatal("detector never tripped on repeated CJK sentences without newlines")
+}
+
+func TestRepetitionDetectorSeparatorlessStreamStaysBounded(t *testing.T) {
+	d := newRepetitionDetector(defaultRepetitionTripLimit)
+	filler := strings.Repeat("a", 1024)
+	for range 200 {
+		d.observe(filler)
+		if len(d.carry) > repetitionCarryMaxBytes+len(filler) {
+			t.Fatalf("carry grew unbounded: %d bytes", len(d.carry))
+		}
+	}
+}
+
+func TestRepetitionDetectorDisabled(t *testing.T) {
+	if d := newRepetitionDetector(0); d != nil {
+		t.Fatal("tripLimit 0 should return a nil detector")
+	}
+	var d *repetitionDetector
+	for range 100 {
+		if d.observe("identical degenerate sentence, over and over.\n") {
+			t.Fatal("nil detector must never trip")
+		}
+	}
+}
+
+// repetitionLoopProvider streams the same sentence until the context is
+// cancelled, recording how many stream bodies were requested.
+type repetitionLoopProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *repetitionLoopProvider) Name() string { return "repetition-loop" }
+
+func (p *repetitionLoopProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk)
+	go func() {
+		defer close(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- provider.Chunk{Type: provider.ChunkText, Text: "Let me run the gate scripts now. "}:
+			}
+		}
+	}()
+	return ch, nil
+}
+
+func (p *repetitionLoopProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func TestRunawayTextLoopStopsAtRepetitionGuard(t *testing.T) {
+	prov := &repetitionLoopProvider{}
+	sink := &recordSink{}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := a.Run(ctx, "do the thing")
+	if !errors.Is(err, errRepetitionLoop) {
+		t.Fatalf("Run error = %v, want repetition loop guard", err)
+	}
+	if got, want := prov.callCount(), maxRepetitionRetries+1; got != want {
+		t.Fatalf("provider stream calls = %d, want %d (initial + capped retries)", got, want)
+	}
+	var discards int
+	for _, e := range sink.kinds(event.StreamAttempt) {
+		if e.StreamAttempt.Action == event.StreamAttemptDiscard && e.StreamAttempt.Reason == repetitionDiscardReason {
+			discards++
+		}
+	}
+	if discards != maxRepetitionRetries {
+		t.Fatalf("repetition discard events = %d, want %d", discards, maxRepetitionRetries)
+	}
+}
+
+// repetitionRecoveryProvider degenerates on the first attempt and answers
+// cleanly on the second.
+type repetitionRecoveryProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *repetitionRecoveryProvider) Name() string { return "repetition-recovery" }
+
+func (p *repetitionRecoveryProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk)
+	go func() {
+		defer close(ch)
+		if call == 1 {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case ch <- provider.Chunk{Type: provider.ChunkText, Text: "Let me write the body and run the scripts. "}:
+				}
+			}
+		}
+		ch <- provider.Chunk{Type: provider.ChunkText, Text: "All gate checks pass; the PR body is valid."}
+		ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{FinishReason: "stop", PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2}}
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+	}()
+	return ch, nil
+}
+
+func TestRepetitionGuardRecoversWithCleanRetry(t *testing.T) {
+	prov := &repetitionRecoveryProvider{}
+	sess := NewSession("")
+	a := New(prov, tool.NewRegistry(), sess, Options{}, event.Discard)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := a.Run(ctx, "validate the PR body"); err != nil {
+		t.Fatalf("Run after clean retry = %v, want nil", err)
+	}
+	msgs := sess.Snapshot()
+	last := msgs[len(msgs)-1]
+	if last.Role != provider.RoleAssistant || last.Content != "All gate checks pass; the PR body is valid." {
+		t.Fatalf("last message = %+v, want the clean second attempt", last)
+	}
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Let me write the body") {
+			t.Fatalf("degenerate attempt leaked into the session: %q", m.Content)
+		}
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -420,12 +420,11 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		last.usage = finalizeSamplingUsage(billable, result.usage)
 
 		if result.err != nil {
-			if provider.IsStreamInterrupted(result.err) && attempt < maxSamplingAttempts {
+			if reason, retryMax, retryable := samplingRetryPlan(result.err, attempt); retryable {
 				streamSink.Discard()
-				reason := provider.StreamInterruptReason(result.err)
 				a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, reason, result.err)
 				a.sink.Emit(event.Event{
-					Kind: event.Retrying, RetryAttempt: attempt, RetryMax: maxStreamRecoveries,
+					Kind: event.Retrying, RetryAttempt: attempt, RetryMax: retryMax,
 					RetryScope: event.RetryScopeStream,
 				})
 				if !streamRetrySleep(ctx, attempt) {

--- a/internal/boot/repetition_effect_test.go
+++ b/internal/boot/repetition_effect_test.go
@@ -1,0 +1,113 @@
+package boot
+
+// Final-boundary proof for the client repetition guard: a degenerate stream is
+// discarded and re-sampled through the real Build stack, and the degenerate
+// text never reaches the provider on the following turn.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type repetitionEffectProvider struct {
+	mu   sync.Mutex
+	reqs []provider.Request
+}
+
+func (p *repetitionEffectProvider) Name() string { return "boot-repetition-effect" }
+
+func (p *repetitionEffectProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	p.reqs = append(p.reqs, req)
+	call := len(p.reqs)
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk)
+	go func() {
+		defer close(ch)
+		if call == 1 {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case ch <- provider.Chunk{Type: provider.ChunkText, Text: "Let me run the gate scripts now, for real this time. "}:
+				}
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- provider.Chunk{Type: provider.ChunkText, Text: "gates pass"}:
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- provider.Chunk{Type: provider.ChunkDone}:
+		}
+	}()
+	return ch, nil
+}
+
+func (p *repetitionEffectProvider) requests() []provider.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]provider.Request(nil), p.reqs...)
+}
+
+func TestEffectRepetitionGuardDiscardsDegenerateAttempt(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	rec := &repetitionEffectProvider{}
+	provider.Register("boot-repetition-effect", func(provider.Config) (provider.Provider, error) {
+		return rec, nil
+	})
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-repetition-effect"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if err := ctrl.Run(context.Background(), "check the gates"); err != nil {
+		t.Fatalf("Run: %v (the guard should discard the degenerate attempt and commit the retry)", err)
+	}
+	if err := ctrl.Run(context.Background(), "and then?"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	reqs := rec.requests()
+	if len(reqs) != 3 {
+		t.Fatalf("provider requests = %d, want 3 (degenerate + clean retry + next turn)", len(reqs))
+	}
+	for _, m := range reqs[2].Messages {
+		if strings.Contains(m.Content, "Let me run the gate scripts") {
+			t.Fatalf("degenerate attempt reached the provider on the next turn: %q", m.Content)
+		}
+	}
+	var sawClean bool
+	for _, m := range reqs[2].Messages {
+		if m.Role == provider.RoleAssistant && strings.Contains(m.Content, "gates pass") {
+			sawClean = true
+		}
+	}
+	if !sawClean {
+		t.Fatal("clean retry text missing from the next turn's provider request")
+	}
+}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,8 +4,8 @@
     "commented-code": 0,
     "complexity": 2081,
     "essay": 4113,
-    "file-size": 111289,
-    "function-size": 9171,
+    "file-size": 111295,
+    "function-size": 9170,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
@@ -14,7 +14,7 @@
   "files": {
     "cmd/e2ebench/main.go": {
       "essay": 1,
-      "function-size": 2
+      "function-size": 1
     },
     "cmd/e2ebench/mutation.go": {
       "essay": 1
@@ -438,8 +438,8 @@
     "internal/agent/agent.go": {
       "complexity": 61,
       "essay": 109,
-      "file-size": 2743,
-      "function-size": 124
+      "file-size": 2750,
+      "function-size": 125
     },
     "internal/agent/ask.go": {
       "essay": 4
@@ -575,8 +575,8 @@
     "internal/agent/run_loop.go": {
       "complexity": 8,
       "essay": 32,
-      "file-size": 281,
-      "function-size": 57
+      "file-size": 280,
+      "function-size": 56
     },
     "internal/agent/save.go": {
       "complexity": 49,


### PR DESCRIPTION
## Problem

DeepSeek-class models can degenerate into re-emitting the same sentence ("Let me run the gate scripts now.") hundreds of times instead of acting. Observed in a live session: ~300 near-identical "Let me do it" lines, no tool call, tokens burning until manual interrupt. Three compounding failures:

1. The provider's own `repetition_truncation` often misses sentence-level loops (it targets token-level repetition), so the stream runs to the output cap.
2. Nothing client-side watches the visible/reasoning text stream; the existing guards cover repeated failing tool calls (`repeat_failure_guard`), zero-evidence rounds (`progress_guard`), and premature finals (`final_readiness`), but not intra-stream text degeneration.
3. Worst: the degenerate text commits to the session, so the next attempt sees 300 "Let me do it" lines and the loop self-reinforces.

This is the same defense mature harnesses converge on (Claude Code: cycle detection + step budgets + discard-and-correct; see also DeepSeek-R1's model-card guidance on endless repetition).

## Fix

A per-stream `repetitionDetector` (new `internal/agent/repetition_guard.go`) segments text and reasoning chunks at line/sentence boundaries (ASCII enders need trailing whitespace so decimals survive; fullwidth CJK enders split unconditionally), normalizes segments, and counts repeats across a 192-segment sliding window. At 16 identical segments of >= 12 runes the attempt is cut off with `errRepetitionLoop` via a synchronous `filter` at the single chunk-receipt point in `streamWithFrozen`.

The abort rides the existing sampling-recovery rails: the attempt is discarded (never written to the session, killing self-reinforcement), and the frozen request is re-sampled under a deliberately smaller retry budget (`maxRepetitionRetries = 2`) than transport interruptions, since every degenerate attempt burns real completion tokens before tripping. Retry policy for both cases now lives in one `samplingRetryPlan` helper. On exhaustion the turn fails with a legible error and the junk stays display-only (LocalOnly recovery record).

Guard is on by default for every frontend via `agent.New`; `Options.RepetitionTripLimit` tunes it (zero = default, negative = off) and `REASONIX_REPETITION_GUARD=0` is the env escape hatch (governor precedent: config graduation waits on field experience).

## Tests

- Detector unit tests: sentence loops fed in odd-sized chunks, A/B/C cycles, CJK sentences, varied-prose and short-structural non-trips, carry bound on separator-less streams, nil/disabled behavior.
- Integration: a runaway-loop provider stops after initial + 2 retries with `repetition_loop` discard events; a degenerate-then-clean provider commits only the clean retry, and the degenerate text never appears in the session.
- Effect test at the final boundary (`internal/boot/repetition_effect_test.go`, real `boot.Build`): the next turn's provider request contains the clean retry text and none of the degenerate attempt.
- `TestCompactionHealthyWindowNeverLoops` fixture updated: it grew assistant text with 600 copies of the same sentence, which the new guard (correctly) reads as a degenerate loop. The fixture now emits distinct sentences at the same byte volume, preserving its intent (size growth, not literal repetition).

## repolint baseline

`tools/repolint/baseline.json` re-measured: repo file-size +6 (the documented `Options` field), repo function-size net -1 (the merged retry branches shrink `streamWithFrozen`'s callers more than the one added filter line grows it). No hot-path budget widened beyond `internal/agent/agent.go` +7 lines / +1 function unit; new logic lives in its own file.

Cache-impact: none - the guard filters received stream chunks only; prompt bytes, tool schemas, and the system-prefix composition are untouched, so the provider-visible prefix stays byte-identical
Cache-guard: existing prefix-shape guards (internal/agent cache_shape and cachehit e2e tests) plus TestEffectRepetitionGuardDiscardsDegenerateAttempt, which asserts the next-turn provider request through real boot.Build
System-prompt-review: boot diff is a new effect test only and agent.go changes are stream-side; no prompt-path change - reviewer: oguzvuruskaner
Documentation-impact: none - internal resilience guard; the only user-visible surface is an automatic discard-and-retry rendered by the existing stream-retry UI, and the env escape hatch is intentionally undocumented while the guard gathers field experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)
