### PR TITLE
Enable external opener for Global workspaces / 为 Global 工作区启用外部打开按钮

### DIFF
--- a/desktop/external_opener.go
+++ b/desktop/external_opener.go
@@ -243,10 +243,9 @@ func (a *App) externalOpenerWorkspacePathForTab(tabID string) (string, error) {
 	if !ok {
 		return "", os.ErrNotExist
 	}
-	// A bound tab with no root has no stable workspace to expose. Preserve the
-	// legacy no-tab call's current-directory fallback (workspaceTargetForTab
-	// returns "." for that case), but do not turn an incomplete tab into an
-	// opener for the Desktop process's launch directory.
+	// A bound tab with no root has no stable workspace to expose. Keep the legacy
+	// no-tab current-directory fallback, but do not turn an incomplete tab into
+	// an opener for the Desktop process's launch directory.
 	if strings.TrimSpace(root) == "" {
 		return "", os.ErrNotExist
 	}

--- a/desktop/external_opener.go
+++ b/desktop/external_opener.go
@@ -35,8 +35,9 @@ type ExternalOpenerView struct {
 
 // ExternalOpenersView is the complete state for the Codex-style Open control.
 type ExternalOpenersView struct {
-	Openers   []ExternalOpenerView `json:"openers"`
-	Preferred string               `json:"preferred"`
+	Openers           []ExternalOpenerView `json:"openers"`
+	Preferred         string               `json:"preferred"`
+	WorkspaceOpenable bool                 `json:"workspaceOpenable,omitempty"`
 }
 
 type externalOpenerSpec struct {
@@ -185,6 +186,18 @@ func (a *App) ExternalOpeners() ExternalOpenersView {
 	return ExternalOpenersView{Openers: views, Preferred: selected.View.ID}
 }
 
+// ExternalOpenersForTab adds the tab-scoped local-workspace capability used by
+// the chat-header Open control. Scope is intentionally not part of the check:
+// both project tabs and Global tabs can own a real local workspace directory.
+func (a *App) ExternalOpenersForTab(tabID string) ExternalOpenersView {
+	if _, err := a.externalOpenerWorkspacePathForTab(tabID); err != nil {
+		return ExternalOpenersView{Openers: []ExternalOpenerView{}}
+	}
+	view := a.ExternalOpeners()
+	view.WorkspaceOpenable = true
+	return view
+}
+
 // SetPreferredExternalOpener persists an installed, platform-owned opener id.
 func (a *App) SetPreferredExternalOpener(id string) error {
 	specs := cachedPlatformExternalOpenerSpecs()
@@ -206,24 +219,14 @@ func (a *App) OpenWorkspaceInExternalOpener(id string) error {
 // OpenWorkspaceInExternalOpenerForTab is tab-scoped so a rapid tab switch cannot
 // send the wrong project to an external application.
 func (a *App) OpenWorkspaceInExternalOpenerForTab(tabID, id string) error {
-	root, _, ok := a.workspaceTargetForTab(tabID)
-	if !ok {
-		return os.ErrNotExist
-	}
-	path, err := workspaceBaseFromRoot(root)
+	path, err := a.externalOpenerWorkspacePathForTab(tabID)
 	if err != nil {
 		return err
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("workspace is not a directory")
 	}
 
 	specs := cachedPlatformExternalOpenerSpecs()
 	var spec externalOpenerSpec
+	var ok bool
 	if strings.TrimSpace(id) == "" {
 		spec, ok = resolveExternalOpener(specs, a.preferredExternalOpenerID())
 	} else {
@@ -233,6 +236,32 @@ func (a *App) OpenWorkspaceInExternalOpenerForTab(tabID, id string) error {
 		return fmt.Errorf("external opener %q is not available", strings.TrimSpace(id))
 	}
 	return launchPlatformExternalOpener(spec, path)
+}
+
+func (a *App) externalOpenerWorkspacePathForTab(tabID string) (string, error) {
+	root, _, ok := a.workspaceTargetForTab(tabID)
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	// A bound tab with no root has no stable workspace to expose. Preserve the
+	// legacy no-tab call's current-directory fallback (workspaceTargetForTab
+	// returns "." for that case), but do not turn an incomplete tab into an
+	// opener for the Desktop process's launch directory.
+	if strings.TrimSpace(root) == "" {
+		return "", os.ErrNotExist
+	}
+	path, err := workspaceBaseFromRoot(root)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("workspace is not a directory")
+	}
+	return path, nil
 }
 
 // OpenLocalPathInExternalOpener opens an absolute local path with one of the

--- a/desktop/external_opener_test.go
+++ b/desktop/external_opener_test.go
@@ -140,6 +140,54 @@ func TestSetPreferredExternalOpenerRejectsRendererCommands(t *testing.T) {
 	}
 }
 
+func TestExternalOpenerWorkspaceCapabilityUsesTheTabDirectoryNotScope(t *testing.T) {
+	projectRoot := t.TempDir()
+	globalRoot := t.TempDir()
+	missingRoot := filepath.Join(t.TempDir(), "missing")
+	fileRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(fileRoot, []byte("file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{
+		"project": {ID: "project", Scope: "project", WorkspaceRoot: projectRoot},
+		"global":  {ID: "global", Scope: "global", WorkspaceRoot: globalRoot},
+		"missing": {ID: "missing", Scope: "project", WorkspaceRoot: missingRoot},
+		"file":    {ID: "file", Scope: "global", WorkspaceRoot: fileRoot},
+		"empty":   {ID: "empty", Scope: "global"},
+	}
+
+	for _, tabID := range []string{"project", "global"} {
+		if _, err := app.externalOpenerWorkspacePathForTab(tabID); err != nil {
+			t.Errorf("externalOpenerWorkspacePathForTab(%q) = %v, want available", tabID, err)
+		}
+	}
+	for _, tabID := range []string{"missing", "file", "empty", "unknown"} {
+		if _, err := app.externalOpenerWorkspacePathForTab(tabID); err == nil {
+			t.Errorf("externalOpenerWorkspacePathForTab(%q) succeeded, want unavailable", tabID)
+		}
+	}
+}
+
+func TestExternalOpenersForGlobalTabReportsWorkspaceCapability(t *testing.T) {
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{
+		"global": {ID: "global", Scope: "global", WorkspaceRoot: t.TempDir()},
+	}
+	view := app.ExternalOpenersForTab("global")
+	if !view.WorkspaceOpenable {
+		t.Fatal("ExternalOpenersForTab(global) workspaceOpenable = false, want true")
+	}
+	if view.Openers == nil {
+		t.Fatal("ExternalOpenersForTab(global) openers = nil, want a Wails-safe array")
+	}
+	unavailable := app.ExternalOpenersForTab("unknown")
+	if unavailable.WorkspaceOpenable || unavailable.Openers == nil {
+		t.Fatalf("ExternalOpenersForTab(unknown) = %+v, want unavailable with an empty Wails-safe array", unavailable)
+	}
+}
+
 func TestLocalSaveDestinationIsSourceDetectsFilesystemAliases(t *testing.T) {
 	dir := t.TempDir()
 	source := filepath.Join(dir, "Readme.md")
@@ -293,5 +341,31 @@ func TestExternalOpenerViewIconIsBackwardCompatible(t *testing.T) {
 	}
 	if !strings.Contains(string(withIcon), `"iconDataUrl":"data:image/png;base64,AA=="`) {
 		t.Fatalf("native icon missing from JSON contract: %s", withIcon)
+	}
+
+	withoutCapability, err := json.Marshal(ExternalOpenersView{Openers: []ExternalOpenerView{}, Preferred: "finder"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(withoutCapability), "workspaceOpenable") {
+		t.Fatalf("false workspace capability should be omitted for old readers: %s", withoutCapability)
+	}
+	withCapability, err := json.Marshal(ExternalOpenersView{
+		Openers:           []ExternalOpenerView{},
+		Preferred:         "finder",
+		WorkspaceOpenable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(withCapability), `"workspaceOpenable":true`) {
+		t.Fatalf("workspace capability missing from JSON contract: %s", withCapability)
+	}
+	var oldReader struct {
+		Openers   []ExternalOpenerView `json:"openers"`
+		Preferred string               `json:"preferred"`
+	}
+	if err := json.Unmarshal(withCapability, &oldReader); err != nil || oldReader.Preferred != "finder" || oldReader.Openers == nil {
+		t.Fatalf("old reader rejected additive workspace capability: reader=%+v err=%v", oldReader, err)
 	}
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -79,7 +79,7 @@ import { WorktreeBadge } from "./components/WorktreeBadge";
 import { HeartbeatPanel } from "./custom/features/heartbeat/HeartbeatPanel";
 import "./custom/features/heartbeat/heartbeat.css";
 import { CopyButton } from "./components/CopyButton";
-import { ExternalOpener } from "./components/ExternalOpener";
+import { ExternalOpener, shouldMountExternalOpener } from "./components/ExternalOpener";
 import { startTerminalEventBridge } from "./lib/terminalEvents";
 import { applyTerminalThemePreference } from "./lib/terminalTheme";
 import { formatTerminalOutputForComposer } from "./lib/terminalOutput";
@@ -4705,8 +4705,8 @@ export default function App() {
             </div>
             <div className="topicbar__spacer" />
             <div className="topicbar__actions">
-              {sidebarCreation && !sidebarImDetailConnection && activeTab?.scope === "project" && (
-                <ExternalOpener tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
+              {sidebarCreation && shouldMountExternalOpener(activeTab, Boolean(sidebarImDetailConnection)) && activeTab && (
+                <ExternalOpener key={activeTab.id} tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
               )}
               {!sidebarImDetailConnection && (
               <>
@@ -4782,8 +4782,8 @@ export default function App() {
                   </button>
                 </Tooltip>
               )}
-              {!sidebarCreation && !sidebarImDetailConnection && activeTab?.scope === "project" && (
-                <ExternalOpener tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
+              {!sidebarCreation && shouldMountExternalOpener(activeTab, Boolean(sidebarImDetailConnection)) && activeTab && (
+                <ExternalOpener key={activeTab.id} tabId={activeTab.id} dismissSignal={transientOverlayDismissSignal} />
               )}
               <Tooltip label={t("shortcuts.cheatsheetTitle")}>
                 <button

--- a/desktop/frontend/src/__tests__/external-opener-preference-sync.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener-preference-sync.test.tsx
@@ -1,0 +1,130 @@
+// Run: tsx src/__tests__/external-opener-preference-sync.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { ExternalOpener, type ExternalOpenerBridge } from "../components/ExternalOpener";
+import { LocaleProvider } from "../lib/i18n";
+import { ToastProvider } from "../lib/toast";
+import type { ExternalOpenersView } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+function ok(value: boolean, label: string) {
+  process.stdout.write(`  ${value ? "PASS" : "FAIL"}  ${label}\n`);
+  if (value) passed += 1;
+  else failed += 1;
+}
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+
+const openers = [
+  { id: "finder", name: "Finder", kind: "file-manager" as const },
+  { id: "xcode", name: "Xcode", kind: "editor" as const },
+];
+
+function createHarness(bridge: ExternalOpenerBridge) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const renderTab = async (tabId: string) => {
+    await act(async () => {
+      root.render(
+        <LocaleProvider>
+          <ToastProvider>
+            <ExternalOpener key={tabId} tabId={tabId} dismissSignal={0} bridge={bridge} />
+          </ToastProvider>
+        </LocaleProvider>,
+      );
+      await flush();
+    });
+  };
+  const choose = async (name: string) => {
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flush();
+    });
+    await act(async () => {
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]'))
+        .find((button) => button.textContent?.includes(name))
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flush();
+    });
+  };
+  const primaryLabel = () => container.querySelector<HTMLButtonElement>(".external-opener__primary")?.ariaLabel;
+  const unmount = async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  };
+  return { container, renderTab, choose, primaryLabel, unmount };
+}
+
+console.log("\nexternal opener preference synchronization");
+
+let preferred = "finder";
+let resolveOlderLaunch: (() => void) | undefined;
+const launches: string[] = [];
+const completionBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab() { return { openers, preferred, workspaceOpenable: true }; },
+  async SetPreferredExternalOpener(id) { preferred = id; },
+  async OpenWorkspaceInExternalOpenerForTab(tabId, id) {
+    launches.push(`${tabId}:${id}`);
+    if (tabId === "older") await new Promise<void>((resolve) => { resolveOlderLaunch = resolve; });
+  },
+};
+const completion = createHarness(completionBridge);
+await completion.renderTab("older");
+await completion.choose("Xcode");
+await completion.renderTab("visible");
+ok(completion.primaryLabel()?.includes("Finder") === true, "the visible tab initially discovers the old preference");
+await act(async () => { resolveOlderLaunch?.(); await flush(); });
+ok(preferred === "xcode" && completion.primaryLabel()?.includes("Xcode") === true, "an older tab completion synchronizes the visible control");
+await act(async () => {
+  completion.container.querySelector<HTMLButtonElement>(".external-opener__primary")
+    ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  await flush();
+});
+ok(launches.at(-1) === "visible:xcode", "the visible primary action uses the synchronized preference");
+await completion.unmount();
+
+preferred = "finder";
+let resolveSecondOlderLaunch: (() => void) | undefined;
+let resolveStaleDiscovery: ((view: ExternalOpenersView) => void) | undefined;
+const staleDiscoveryBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab(tabId) {
+    if (tabId !== "visible") return { openers, preferred, workspaceOpenable: true };
+    return new Promise<ExternalOpenersView>((resolve) => { resolveStaleDiscovery = resolve; });
+  },
+  async SetPreferredExternalOpener(id) { preferred = id; },
+  async OpenWorkspaceInExternalOpenerForTab(tabId) {
+    if (tabId === "older") await new Promise<void>((resolve) => { resolveSecondOlderLaunch = resolve; });
+  },
+};
+const staleDiscovery = createHarness(staleDiscoveryBridge);
+await staleDiscovery.renderTab("older");
+await staleDiscovery.choose("Xcode");
+await staleDiscovery.renderTab("visible");
+await act(async () => { resolveSecondOlderLaunch?.(); await flush(); });
+await act(async () => {
+  resolveStaleDiscovery?.({ openers, preferred: "finder", workspaceOpenable: true });
+  await flush();
+});
+ok(staleDiscovery.primaryLabel()?.includes("Xcode") === true, "a discovery started before the write cannot restore the stale preference");
+await staleDiscovery.unmount();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/external-opener.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener.test.tsx
@@ -214,6 +214,76 @@ ok(raceContainer.textContent?.includes("Xcode") === true && !raceContainer.textC
 await act(async () => raceRoot.unmount());
 raceContainer.remove();
 
+const preferenceWrites: string[] = [];
+const preferenceLaunches: string[] = [];
+let resolveOlderLaunch: (() => void) | undefined;
+const preferenceRaceBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab() {
+    return {
+      openers: [
+        { id: "finder", name: "Finder", kind: "file-manager" },
+        { id: "xcode", name: "Xcode", kind: "editor" },
+      ],
+      preferred: "finder",
+      workspaceOpenable: true,
+    };
+  },
+  async SetPreferredExternalOpener(id) {
+    preferenceWrites.push(id);
+  },
+  async OpenWorkspaceInExternalOpenerForTab(tabId, id) {
+    preferenceLaunches.push(`${tabId}:${id}`);
+    if (tabId === "older-tab") {
+      await new Promise<void>((resolve) => {
+        resolveOlderLaunch = resolve;
+      });
+    }
+  },
+};
+const preferenceContainer = document.createElement("div");
+document.body.append(preferenceContainer);
+const preferenceRoot = createRoot(preferenceContainer);
+const renderPreferenceTab = async (tabId: string) => {
+  await act(async () => {
+    preferenceRoot.render(
+      <LocaleProvider>
+        <ToastProvider>
+          <ExternalOpener key={tabId} tabId={tabId} dismissSignal={0} bridge={preferenceRaceBridge} />
+        </ToastProvider>
+      </LocaleProvider>,
+    );
+    await flush();
+  });
+};
+const choosePreference = async (name: string) => {
+  await act(async () => {
+    preferenceContainer.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+  });
+  await act(async () => {
+    Array.from(preferenceContainer.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]'))
+      .find((button) => button.textContent?.includes(name))
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flush();
+  });
+};
+await renderPreferenceTab("older-tab");
+await choosePreference("Xcode");
+await renderPreferenceTab("newer-tab");
+await choosePreference("Finder");
+ok(
+  preferenceLaunches.join(",") === "older-tab:xcode,newer-tab:finder" && preferenceWrites.join(",") === "finder",
+  "a newer tab selection persists even when it matches the discovered preference",
+);
+await act(async () => {
+  resolveOlderLaunch?.();
+  await flush();
+});
+ok(preferenceWrites.join(",") === "finder", "an older tab completion cannot overwrite the latest opener preference");
+await act(async () => preferenceRoot.unmount());
+preferenceContainer.remove();
+
 const failureLog: string[] = [];
 let failOpen = true;
 let failPersist = false;

--- a/desktop/frontend/src/__tests__/external-opener.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener.test.tsx
@@ -243,35 +243,39 @@ const preferenceRaceBridge: ExternalOpenerBridge = {
 const preferenceContainer = document.createElement("div");
 document.body.append(preferenceContainer);
 const preferenceRoot = createRoot(preferenceContainer);
-const renderPreferenceTab = async (tabId: string) => {
+const renderPreferenceTab = async (
+  root: ReturnType<typeof createRoot>,
+  targetBridge: ExternalOpenerBridge,
+  tabId: string,
+) => {
   await act(async () => {
-    preferenceRoot.render(
+    root.render(
       <LocaleProvider>
         <ToastProvider>
-          <ExternalOpener key={tabId} tabId={tabId} dismissSignal={0} bridge={preferenceRaceBridge} />
+          <ExternalOpener key={tabId} tabId={tabId} dismissSignal={0} bridge={targetBridge} />
         </ToastProvider>
       </LocaleProvider>,
     );
     await flush();
   });
 };
-const choosePreference = async (name: string) => {
+const choosePreference = async (targetContainer: HTMLElement, name: string) => {
   await act(async () => {
-    preferenceContainer.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')
+    targetContainer.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await flush();
   });
   await act(async () => {
-    Array.from(preferenceContainer.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]'))
+    Array.from(targetContainer.querySelectorAll<HTMLButtonElement>('button[role="menuitemradio"]'))
       .find((button) => button.textContent?.includes(name))
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await flush();
   });
 };
-await renderPreferenceTab("older-tab");
-await choosePreference("Xcode");
-await renderPreferenceTab("newer-tab");
-await choosePreference("Finder");
+await renderPreferenceTab(preferenceRoot, preferenceRaceBridge, "older-tab");
+await choosePreference(preferenceContainer, "Xcode");
+await renderPreferenceTab(preferenceRoot, preferenceRaceBridge, "newer-tab");
+await choosePreference(preferenceContainer, "Finder");
 ok(
   preferenceLaunches.join(",") === "older-tab:xcode,newer-tab:finder" && preferenceWrites.join(",") === "finder",
   "a newer tab selection persists even when it matches the discovered preference",
@@ -283,6 +287,97 @@ await act(async () => {
 ok(preferenceWrites.join(",") === "finder", "an older tab completion cannot overwrite the latest opener preference");
 await act(async () => preferenceRoot.unmount());
 preferenceContainer.remove();
+
+const failedNewerWrites: string[] = [];
+let resolveOlderSuccessfulLaunch: (() => void) | undefined;
+const failedNewerBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab() {
+    return {
+      openers: [
+        { id: "finder", name: "Finder", kind: "file-manager" },
+        { id: "xcode", name: "Xcode", kind: "editor" },
+      ],
+      preferred: "finder",
+      workspaceOpenable: true,
+    };
+  },
+  async SetPreferredExternalOpener(id) {
+    failedNewerWrites.push(id);
+  },
+  async OpenWorkspaceInExternalOpenerForTab(tabId) {
+    if (tabId === "older-success") {
+      await new Promise<void>((resolve) => {
+        resolveOlderSuccessfulLaunch = resolve;
+      });
+      return;
+    }
+    throw new Error("newer launch failed");
+  },
+};
+const failedNewerContainer = document.createElement("div");
+document.body.append(failedNewerContainer);
+const failedNewerRoot = createRoot(failedNewerContainer);
+await renderPreferenceTab(failedNewerRoot, failedNewerBridge, "older-success");
+await choosePreference(failedNewerContainer, "Xcode");
+await renderPreferenceTab(failedNewerRoot, failedNewerBridge, "newer-failure");
+await choosePreference(failedNewerContainer, "Finder");
+await act(async () => {
+  resolveOlderSuccessfulLaunch?.();
+  await flush();
+});
+ok(
+  failedNewerWrites.join(",") === "xcode",
+  "a newer failed launch does not cancel an older successful selection",
+);
+await act(async () => failedNewerRoot.unmount());
+failedNewerContainer.remove();
+
+const inFlightWrites: string[] = [];
+let markOlderWriteStarted: (() => void) | undefined;
+const olderWriteStarted = new Promise<void>((resolve) => {
+  markOlderWriteStarted = resolve;
+});
+let resolveOlderWrite: (() => void) | undefined;
+const inFlightWriteBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab() {
+    return {
+      openers: [
+        { id: "finder", name: "Finder", kind: "file-manager" },
+        { id: "xcode", name: "Xcode", kind: "editor" },
+      ],
+      preferred: "finder",
+      workspaceOpenable: true,
+    };
+  },
+  async SetPreferredExternalOpener(id) {
+    inFlightWrites.push(id);
+    markOlderWriteStarted?.();
+    await new Promise<void>((resolve) => {
+      resolveOlderWrite = resolve;
+    });
+  },
+  async OpenWorkspaceInExternalOpenerForTab(tabId) {
+    if (tabId === "newer-failure") throw new Error("newer launch failed");
+  },
+};
+const inFlightContainer = document.createElement("div");
+document.body.append(inFlightContainer);
+const inFlightRoot = createRoot(inFlightContainer);
+await renderPreferenceTab(inFlightRoot, inFlightWriteBridge, "older-write");
+await choosePreference(inFlightContainer, "Xcode");
+await olderWriteStarted;
+await renderPreferenceTab(inFlightRoot, inFlightWriteBridge, "newer-failure");
+await choosePreference(inFlightContainer, "Finder");
+await act(async () => {
+  resolveOlderWrite?.();
+  await flush();
+});
+ok(
+  inFlightWrites.join(",") === "xcode",
+  "an in-flight older preference write has the same result when a newer launch fails",
+);
+await act(async () => inFlightRoot.unmount());
+inFlightContainer.remove();
 
 const failureLog: string[] = [];
 let failOpen = true;

--- a/desktop/frontend/src/__tests__/external-opener.test.tsx
+++ b/desktop/frontend/src/__tests__/external-opener.test.tsx
@@ -1,10 +1,11 @@
 // Run: tsx src/__tests__/external-opener.test.tsx
 
+import { readFileSync } from "node:fs";
 import { JSDOM } from "jsdom";
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 
-import { ExternalOpener, type ExternalOpenerBridge } from "../components/ExternalOpener";
+import { ExternalOpener, shouldMountExternalOpener, type ExternalOpenerBridge } from "../components/ExternalOpener";
 import { LocaleProvider, t } from "../lib/i18n";
 import { ToastProvider } from "../lib/toast";
 import type { ExternalOpenersView } from "../lib/types";
@@ -45,7 +46,7 @@ const opened: Array<[string, string]> = [];
 const nativeIcon = "data:image/png;base64,iVBORw0KGgo=";
 let discoveryCalls = 0;
 const bridge: ExternalOpenerBridge = {
-  async ExternalOpeners() {
+  async ExternalOpenersForTab() {
     discoveryCalls += 1;
     return {
       openers: [
@@ -54,6 +55,7 @@ const bridge: ExternalOpenerBridge = {
         ...(discoveryCalls > 1 ? [{ id: "xcode", name: "Xcode", kind: "editor" as const, iconDataUrl: nativeIcon }] : []),
       ],
       preferred: "finder",
+      workspaceOpenable: true,
     };
   },
   async SetPreferredExternalOpener(id) {
@@ -66,13 +68,49 @@ const bridge: ExternalOpenerBridge = {
 
 console.log("\nexternal opener");
 
+const stylesSource = readFileSync(new URL("../styles.css", import.meta.url), "utf8");
+const sharedControlRule = stylesSource.match(/(?:^|\n)\.external-opener\s*\{([^}]*)\}/)?.[1] ?? "";
+const sharedSegmentRule = stylesSource.match(
+  /\.external-opener__primary,\s*\.external-opener__menu-trigger\s*\{([^}]*)\}/,
+)?.[1] ?? "";
+const creationControlRule = stylesSource.match(
+  /\.app--creation \.topicbar__actions \.external-opener,\s*:root\[data-theme-style\] \.app--creation \.topicbar__actions \.external-opener\s*\{([^}]*)\}/,
+)?.[1] ?? "";
+const sharedIconRule = stylesSource.match(/(?:^|\n)\.external-opener__app-icon\s*\{([^}]*)\}/)?.[1] ?? "";
+const creationIconRule = stylesSource.match(
+  /\.app--creation \.topicbar__actions \.external-opener__app-icon,\s*:root\[data-theme-style\] \.app--creation \.topicbar__actions \.external-opener__app-icon\s*\{([^}]*)\}/,
+)?.[1] ?? "";
+ok(
+  /height:\s*28px;/.test(sharedControlRule)
+    && /border-radius:\s*7px;/.test(sharedControlRule)
+    && /box-shadow:\s*none;/.test(sharedControlRule),
+  "uses the shared 28px / 7px topic-bar control geometry without an extra shadow",
+);
+ok(/height:\s*100%;/.test(sharedSegmentRule), "keeps both split-button segments within the shared control height");
+ok(
+  /height:\s*28px;/.test(creationControlRule) && /border-radius:\s*7px;/.test(creationControlRule),
+  "keeps Creation topic bars on the same 28px / 7px geometry",
+);
+ok(
+  /width:\s*18px;/.test(sharedIconRule) && /height:\s*18px;/.test(sharedIconRule),
+  "fits Workbench application artwork to the compact topic-bar control",
+);
+ok(
+  /width:\s*15px;/.test(creationIconRule) && /height:\s*15px;/.test(creationIconRule),
+  "preserves the slimmer Creation application artwork size",
+);
+
+ok(shouldMountExternalOpener({ id: "tab-project", scope: "project" }, false), "mounts for a Project tab");
+ok(shouldMountExternalOpener({ id: "tab-global", scope: "global" }, false), "mounts for a Global tab without guessing from scope");
+ok(!shouldMountExternalOpener({ id: "tab-global", scope: "global" }, true), "stays hidden while an IM detail surface owns the header");
+
 const container = document.getElementById("root")!;
 const root = createRoot(container);
 await act(async () => {
   root.render(
     <LocaleProvider>
       <ToastProvider>
-        <ExternalOpener tabId="tab-project" dismissSignal={0} bridge={bridge} />
+        <ExternalOpener tabId="tab-global" dismissSignal={0} bridge={bridge} />
       </ToastProvider>
     </LocaleProvider>,
   );
@@ -99,7 +137,7 @@ await act(async () => {
   await flush();
 });
 ok(selected.join(",") === "ghostty", "persists the selected application id");
-ok(JSON.stringify(opened) === JSON.stringify([["tab-project", "ghostty"]]), "opens the exact tab workspace with the selection");
+ok(JSON.stringify(opened) === JSON.stringify([["tab-global", "ghostty"]]), "opens the exact Global workspace with the selection");
 
 const primary = container.querySelector<HTMLButtonElement>('button.external-opener__primary');
 await act(async () => {
@@ -122,17 +160,17 @@ await act(async () => root.unmount());
 let staleResolve: ((value: ExternalOpenersView) => void) | undefined;
 let raceCalls = 0;
 const raceBridge: ExternalOpenerBridge = {
-  async ExternalOpeners() {
+  async ExternalOpenersForTab() {
     raceCalls += 1;
     if (raceCalls === 1) {
-      return { openers: [{ id: "finder", name: "Finder", kind: "file-manager" }], preferred: "finder" };
+      return { openers: [{ id: "finder", name: "Finder", kind: "file-manager" }], preferred: "finder", workspaceOpenable: true };
     }
     if (raceCalls === 2) {
       return new Promise<ExternalOpenersView>((resolve) => {
         staleResolve = resolve;
       });
     }
-    return { openers: [{ id: "xcode", name: "Xcode", kind: "editor" }], preferred: "xcode" };
+    return { openers: [{ id: "xcode", name: "Xcode", kind: "editor" }], preferred: "xcode", workspaceOpenable: true };
   },
   async SetPreferredExternalOpener() {},
   async OpenWorkspaceInExternalOpenerForTab() {},
@@ -169,7 +207,7 @@ await act(async () => {
 });
 ok(raceContainer.textContent?.includes("Xcode") === true, "the latest overlapping discovery result wins");
 await act(async () => {
-  staleResolve?.({ openers: [{ id: "stale", name: "Stale Editor", kind: "editor" }], preferred: "stale" });
+  staleResolve?.({ openers: [{ id: "stale", name: "Stale Editor", kind: "editor" }], preferred: "stale", workspaceOpenable: true });
   await flush();
 });
 ok(raceContainer.textContent?.includes("Xcode") === true && !raceContainer.textContent?.includes("Stale Editor"), "a stale discovery cannot replace the current menu");
@@ -180,13 +218,14 @@ const failureLog: string[] = [];
 let failOpen = true;
 let failPersist = false;
 const failureBridge: ExternalOpenerBridge = {
-  async ExternalOpeners() {
+  async ExternalOpenersForTab() {
     return {
       openers: [
         { id: "finder", name: "Finder", kind: "file-manager" },
         { id: "xcode", name: "Xcode", kind: "editor" },
       ],
       preferred: "finder",
+      workspaceOpenable: true,
     };
   },
   async SetPreferredExternalOpener(id) {
@@ -246,6 +285,34 @@ ok(
 );
 await act(async () => failureRoot.unmount());
 failureContainer.remove();
+
+const unavailableContainer = document.createElement("div");
+document.body.append(unavailableContainer);
+const unavailableRoot = createRoot(unavailableContainer);
+const unavailableBridge: ExternalOpenerBridge = {
+  async ExternalOpenersForTab() {
+    return {
+      openers: [{ id: "finder", name: "Finder", kind: "file-manager" }],
+      preferred: "finder",
+      workspaceOpenable: false,
+    };
+  },
+  async SetPreferredExternalOpener() {},
+  async OpenWorkspaceInExternalOpenerForTab() {},
+};
+await act(async () => {
+  unavailableRoot.render(
+    <LocaleProvider>
+      <ToastProvider>
+        <ExternalOpener tabId="tab-missing-workspace" dismissSignal={0} bridge={unavailableBridge} />
+      </ToastProvider>
+    </LocaleProvider>,
+  );
+  await flush();
+});
+ok(unavailableContainer.querySelector(".external-opener") == null, "hides when the backend reports no local workspace capability");
+await act(async () => unavailableRoot.unmount());
+unavailableContainer.remove();
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ExternalOpener.tsx
+++ b/desktop/frontend/src/components/ExternalOpener.tsx
@@ -17,6 +17,9 @@ type ExternalOpenerPreferenceCoordinator = {
   nextIntent: number;
   latestSuccessfulIntent: number;
   writeTail: Promise<void>;
+  preferred: string;
+  revision: number;
+  listeners: Set<(preferred: string) => void>;
 };
 
 const externalOpenerPreferenceCoordinators = new WeakMap<ExternalOpenerBridge, ExternalOpenerPreferenceCoordinator>();
@@ -24,7 +27,14 @@ const externalOpenerPreferenceCoordinators = new WeakMap<ExternalOpenerBridge, E
 function preferenceCoordinatorFor(bridge: ExternalOpenerBridge): ExternalOpenerPreferenceCoordinator {
   const current = externalOpenerPreferenceCoordinators.get(bridge);
   if (current) return current;
-  const created = { nextIntent: 0, latestSuccessfulIntent: 0, writeTail: Promise.resolve() };
+  const created: ExternalOpenerPreferenceCoordinator = {
+    nextIntent: 0,
+    latestSuccessfulIntent: 0,
+    writeTail: Promise.resolve(),
+    preferred: "",
+    revision: 0,
+    listeners: new Set(),
+  };
   externalOpenerPreferenceCoordinators.set(bridge, created);
   return created;
 }
@@ -38,6 +48,9 @@ function persistPreferredExternalOpener(
   const write = coordinator.writeTail.then(async () => {
     if (intent !== coordinator.latestSuccessfulIntent) return false;
     await bridge.SetPreferredExternalOpener(id);
+    coordinator.preferred = id;
+    coordinator.revision += 1;
+    for (const listener of coordinator.listeners) listener(id);
     return true;
   });
   coordinator.writeTail = write.then(() => undefined, () => undefined);
@@ -114,8 +127,13 @@ export function ExternalOpener({
 
   const refreshOpeners = useCallback(async () => {
     const request = ++discoveryRequestRef.current;
+    const preferenceCoordinator = preferenceCoordinatorFor(bridge);
+    const preferenceRevision = preferenceCoordinator.revision;
     try {
       const next = normalizeOpeners(await bridge.ExternalOpenersForTab(tabId));
+      if (preferenceCoordinator.revision !== preferenceRevision && preferenceCoordinator.preferred) {
+        next.preferred = preferenceCoordinator.preferred;
+      }
       if (mountedRef.current && request === discoveryRequestRef.current) setState({ ...next, tabId });
     } catch (error) {
       if (mountedRef.current && request === discoveryRequestRef.current) {
@@ -126,12 +144,18 @@ export function ExternalOpener({
 
   useEffect(() => {
     mountedRef.current = true;
+    const preferenceCoordinator = preferenceCoordinatorFor(bridge);
+    const syncPreferred = (preferred: string) => {
+      if (mountedRef.current) setState((current) => ({ ...current, preferred }));
+    };
+    preferenceCoordinator.listeners.add(syncPreferred);
     void refreshOpeners();
     return () => {
       mountedRef.current = false;
       discoveryRequestRef.current += 1;
+      preferenceCoordinator.listeners.delete(syncPreferred);
     };
-  }, [refreshOpeners]);
+  }, [bridge, refreshOpeners]);
 
   useEffect(() => setMenuOpen(false), [dismissSignal, tabId]);
 

--- a/desktop/frontend/src/components/ExternalOpener.tsx
+++ b/desktop/frontend/src/components/ExternalOpener.tsx
@@ -14,7 +14,8 @@ export interface ExternalOpenerBridge {
 }
 
 type ExternalOpenerPreferenceCoordinator = {
-  latestIntent: number;
+  nextIntent: number;
+  latestSuccessfulIntent: number;
   writeTail: Promise<void>;
 };
 
@@ -23,7 +24,7 @@ const externalOpenerPreferenceCoordinators = new WeakMap<ExternalOpenerBridge, E
 function preferenceCoordinatorFor(bridge: ExternalOpenerBridge): ExternalOpenerPreferenceCoordinator {
   const current = externalOpenerPreferenceCoordinators.get(bridge);
   if (current) return current;
-  const created = { latestIntent: 0, writeTail: Promise.resolve() };
+  const created = { nextIntent: 0, latestSuccessfulIntent: 0, writeTail: Promise.resolve() };
   externalOpenerPreferenceCoordinators.set(bridge, created);
   return created;
 }
@@ -35,7 +36,7 @@ function persistPreferredExternalOpener(
   intent: number,
 ): Promise<boolean> {
   const write = coordinator.writeTail.then(async () => {
-    if (intent !== coordinator.latestIntent) return false;
+    if (intent !== coordinator.latestSuccessfulIntent) return false;
     await bridge.SetPreferredExternalOpener(id);
     return true;
   });
@@ -161,7 +162,7 @@ export function ExternalOpener({
     async (opener: ExternalOpenerView, persist: boolean) => {
       if (busyRef.current) return;
       const preferenceCoordinator = persist ? preferenceCoordinatorFor(bridge) : undefined;
-      const preferenceIntent = preferenceCoordinator ? ++preferenceCoordinator.latestIntent : 0;
+      const preferenceIntent = preferenceCoordinator ? ++preferenceCoordinator.nextIntent : 0;
       busyRef.current = true;
       discoveryRequestRef.current += 1;
       setBusy(true);
@@ -176,6 +177,10 @@ export function ExternalOpener({
           return;
         }
         if (preferenceCoordinator) {
+          preferenceCoordinator.latestSuccessfulIntent = Math.max(
+            preferenceCoordinator.latestSuccessfulIntent,
+            preferenceIntent,
+          );
           try {
             const persisted = await persistPreferredExternalOpener(
               bridge,

--- a/desktop/frontend/src/components/ExternalOpener.tsx
+++ b/desktop/frontend/src/components/ExternalOpener.tsx
@@ -13,6 +13,36 @@ export interface ExternalOpenerBridge {
   OpenWorkspaceInExternalOpenerForTab(tabID: string, id: string): Promise<void>;
 }
 
+type ExternalOpenerPreferenceCoordinator = {
+  latestIntent: number;
+  writeTail: Promise<void>;
+};
+
+const externalOpenerPreferenceCoordinators = new WeakMap<ExternalOpenerBridge, ExternalOpenerPreferenceCoordinator>();
+
+function preferenceCoordinatorFor(bridge: ExternalOpenerBridge): ExternalOpenerPreferenceCoordinator {
+  const current = externalOpenerPreferenceCoordinators.get(bridge);
+  if (current) return current;
+  const created = { latestIntent: 0, writeTail: Promise.resolve() };
+  externalOpenerPreferenceCoordinators.set(bridge, created);
+  return created;
+}
+
+function persistPreferredExternalOpener(
+  bridge: ExternalOpenerBridge,
+  id: string,
+  coordinator: ExternalOpenerPreferenceCoordinator,
+  intent: number,
+): Promise<boolean> {
+  const write = coordinator.writeTail.then(async () => {
+    if (intent !== coordinator.latestIntent) return false;
+    await bridge.SetPreferredExternalOpener(id);
+    return true;
+  });
+  coordinator.writeTail = write.then(() => undefined, () => undefined);
+  return write;
+}
+
 function fallbackOpenerIcon(opener: ExternalOpenerView) {
   if (opener.kind === "file-manager") return <Folder size={15} strokeWidth={1.9} />;
   if (opener.kind === "terminal") return <SquareTerminal size={15} strokeWidth={1.9} />;
@@ -130,6 +160,8 @@ export function ExternalOpener({
   const openIn = useCallback(
     async (opener: ExternalOpenerView, persist: boolean) => {
       if (busyRef.current) return;
+      const preferenceCoordinator = persist ? preferenceCoordinatorFor(bridge) : undefined;
+      const preferenceIntent = preferenceCoordinator ? ++preferenceCoordinator.latestIntent : 0;
       busyRef.current = true;
       discoveryRequestRef.current += 1;
       setBusy(true);
@@ -143,10 +175,15 @@ export function ExternalOpener({
           showToast(t("externalOpener.failed", { name: opener.name, error: errorText(error) }), "error");
           return;
         }
-        if (persist && opener.id !== state.preferred) {
+        if (preferenceCoordinator) {
           try {
-            await bridge.SetPreferredExternalOpener(opener.id);
-            setState((current) => ({ ...current, preferred: opener.id }));
+            const persisted = await persistPreferredExternalOpener(
+              bridge,
+              opener.id,
+              preferenceCoordinator,
+              preferenceIntent,
+            );
+            if (persisted && mountedRef.current) setState((current) => ({ ...current, preferred: opener.id }));
           } catch (error) {
             showToast(t("externalOpener.persistFailed", { name: opener.name, error: errorText(error) }), "error");
           }
@@ -156,7 +193,7 @@ export function ExternalOpener({
         setBusy(false);
       }
     },
-    [bridge, showToast, state.preferred, tabId],
+    [bridge, showToast, tabId],
   );
 
   if (state.tabId !== tabId || state.workspaceOpenable !== true || !selected) return null;

--- a/desktop/frontend/src/components/ExternalOpener.tsx
+++ b/desktop/frontend/src/components/ExternalOpener.tsx
@@ -4,11 +4,11 @@ import { Check, ChevronDown, Code2, Folder, SquareTerminal } from "lucide-react"
 import { app as desktopApp } from "../lib/bridge";
 import { t } from "../lib/i18n";
 import { useToast } from "../lib/toast";
-import type { ExternalOpenerView, ExternalOpenersView } from "../lib/types";
+import type { ExternalOpenerView, ExternalOpenersView, TabMeta } from "../lib/types";
 import { Tooltip } from "./Tooltip";
 
 export interface ExternalOpenerBridge {
-  ExternalOpeners(): Promise<ExternalOpenersView>;
+  ExternalOpenersForTab(tabID: string): Promise<ExternalOpenersView>;
   SetPreferredExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpenerForTab(tabID: string, id: string): Promise<void>;
 }
@@ -42,7 +42,20 @@ function errorText(error: unknown): string {
 }
 
 function normalizeOpeners(next: ExternalOpenersView): ExternalOpenersView {
-  return { openers: Array.isArray(next.openers) ? next.openers : [], preferred: next.preferred ?? "" };
+  return {
+    openers: Array.isArray(next.openers) ? next.openers : [],
+    preferred: next.preferred ?? "",
+    workspaceOpenable: next.workspaceOpenable === true,
+  };
+}
+
+type ResolvedExternalOpeners = ExternalOpenersView & { tabId: string };
+
+export function shouldMountExternalOpener(
+  tab: Pick<TabMeta, "id" | "scope"> | null | undefined,
+  imDetailVisible: boolean,
+): boolean {
+  return !imDetailVisible && Boolean(tab?.id);
 }
 
 export function ExternalOpener({
@@ -59,21 +72,26 @@ export function ExternalOpener({
   const discoveryRequestRef = useRef(0);
   const mountedRef = useRef(true);
   const busyRef = useRef(false);
-  const [state, setState] = useState<ExternalOpenersView>({ openers: [], preferred: "" });
+  const [state, setState] = useState<ResolvedExternalOpeners>({
+    openers: [],
+    preferred: "",
+    workspaceOpenable: false,
+    tabId: "",
+  });
   const [menuOpen, setMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
 
   const refreshOpeners = useCallback(async () => {
     const request = ++discoveryRequestRef.current;
     try {
-      const next = normalizeOpeners(await bridge.ExternalOpeners());
-      if (mountedRef.current && request === discoveryRequestRef.current) setState(next);
+      const next = normalizeOpeners(await bridge.ExternalOpenersForTab(tabId));
+      if (mountedRef.current && request === discoveryRequestRef.current) setState({ ...next, tabId });
     } catch (error) {
       if (mountedRef.current && request === discoveryRequestRef.current) {
         console.error("Failed to discover external openers", error);
       }
     }
-  }, [bridge]);
+  }, [bridge, tabId]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -103,8 +121,10 @@ export function ExternalOpener({
   }, [menuOpen]);
 
   const selected = useMemo(
-    () => state.openers.find((opener) => opener.id === state.preferred) ?? state.openers[0],
-    [state],
+    () => state.tabId === tabId
+      ? state.openers.find((opener) => opener.id === state.preferred) ?? state.openers[0]
+      : undefined,
+    [state, tabId],
   );
 
   const openIn = useCallback(
@@ -139,7 +159,7 @@ export function ExternalOpener({
     [bridge, showToast, state.preferred, tabId],
   );
 
-  if (!selected) return null;
+  if (state.tabId !== tabId || state.workspaceOpenable !== true || !selected) return null;
   const openLabel = t("externalOpener.openIn", { name: selected.name });
 
   return (

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -389,6 +389,7 @@ export interface AppBindings {
   OpenWorkspacePath(rel: string): Promise<void>;
   OpenWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
   ExternalOpeners(): Promise<ExternalOpenersView>;
+  ExternalOpenersForTab(tabID: string): Promise<ExternalOpenersView>;
   SetPreferredExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpenerForTab(tabID: string, id: string): Promise<void>; OpenLocalPathInExternalOpener(path: string, id: string): Promise<void>; SaveLocalPathAs(path: string): Promise<string>;
@@ -3992,6 +3993,9 @@ function makeMockApp(): AppBindings {
         ],
         preferred: "vscode",
       } as ExternalOpenersView;
+    },
+    async ExternalOpenersForTab(_tabID: string) {
+      return { ...(await this.ExternalOpeners()), workspaceOpenable: true };
     },
     async SetPreferredExternalOpener(_id: string) {},
     async OpenWorkspaceInExternalOpener(_id: string) {},

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -388,8 +388,7 @@ export interface AppBindings {
   WorkspaceGitCommitDetail(tabID: string, hash: string, path: string): Promise<GitCommitDetailView>;
   OpenWorkspacePath(rel: string): Promise<void>;
   OpenWorkspacePathForTab(tabID: string, rel: string): Promise<void>;
-  ExternalOpeners(): Promise<ExternalOpenersView>;
-  ExternalOpenersForTab(tabID: string): Promise<ExternalOpenersView>;
+  ExternalOpeners(): Promise<ExternalOpenersView>; ExternalOpenersForTab(tabID: string): Promise<ExternalOpenersView>;
   SetPreferredExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpener(id: string): Promise<void>;
   OpenWorkspaceInExternalOpenerForTab(tabID: string, id: string): Promise<void>; OpenLocalPathInExternalOpener(path: string, id: string): Promise<void>; SaveLocalPathAs(path: string): Promise<string>;
@@ -3993,10 +3992,7 @@ function makeMockApp(): AppBindings {
         ],
         preferred: "vscode",
       } as ExternalOpenersView;
-    },
-    async ExternalOpenersForTab(_tabID: string) {
-      return { ...(await this.ExternalOpeners()), workspaceOpenable: true };
-    },
+    }, async ExternalOpenersForTab(_tabID: string) { return { ...(await this.ExternalOpeners()), workspaceOpenable: true }; },
     async SetPreferredExternalOpener(_id: string) {},
     async OpenWorkspaceInExternalOpener(_id: string) {},
     async OpenWorkspaceInExternalOpenerForTab(_tabID: string, id: string) {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -2128,8 +2128,7 @@ export interface ExternalOpenerView {
 
 export interface ExternalOpenersView {
   openers: ExternalOpenerView[];
-  preferred: string;
-  workspaceOpenable?: boolean;
+  preferred: string; workspaceOpenable?: boolean;
 }
 
 // Auto-updater payloads (desktop/updater.go). UpdateInfo drives the update banner;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -2129,6 +2129,7 @@ export interface ExternalOpenerView {
 export interface ExternalOpenersView {
   openers: ExternalOpenerView[];
   preferred: string;
+  workspaceOpenable?: boolean;
 }
 
 // Auto-updater payloads (desktop/updater.go). UpdateInfo drives the update banner;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -22948,11 +22948,11 @@ body > .mermaid-diagram--fullscreen {
   position: relative;
   display: inline-flex;
   align-items: stretch;
-  height: 32px;
+  height: 28px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 7px;
   background: var(--bg-elev);
-  box-shadow: 0 1px 1px color-mix(in srgb, #000 9%, transparent);
+  box-shadow: none;
   overflow: visible;
   --wails-draggable: no-drag;
 }
@@ -22964,6 +22964,7 @@ body > .mermaid-diagram--fullscreen {
 
 .external-opener__primary-wrap {
   display: inline-flex;
+  height: 100%;
 }
 
 .external-opener__primary,
@@ -22971,7 +22972,7 @@ body > .mermaid-diagram--fullscreen {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 30px;
+  height: 100%;
   padding: 0;
   border: none;
   background: transparent;
@@ -22980,13 +22981,13 @@ body > .mermaid-diagram--fullscreen {
 
 .external-opener__primary {
   width: 38px;
-  border-radius: 9px 0 0 9px;
+  border-radius: 6px 0 0 6px;
 }
 
 .external-opener__menu-trigger {
   width: 27px;
   border-left: 1px solid var(--border-soft);
-  border-radius: 0 9px 9px 0;
+  border-radius: 0 6px 6px 0;
 }
 
 .external-opener__primary:hover:not(:disabled),
@@ -23010,8 +23011,8 @@ body > .mermaid-diagram--fullscreen {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 23px;
-  height: 23px;
+  width: 18px;
+  height: 18px;
 }
 
 .external-opener__app-icon img {
@@ -30776,7 +30777,7 @@ body > .mermaid-diagram--fullscreen {
 :root[data-theme-style] .app--creation .topicbar__actions .external-opener {
   height: 28px;
   border: none;
-  border-radius: 8px;
+  border-radius: 7px;
   background: transparent;
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary

- Show the header external-opener split control for Global tabs when the backend confirms that the tab owns a valid local workspace directory.
- Replace renderer-side `scope === "project"` guessing with an additive tab-scoped capability returned by the Desktop backend.
- Align the split control with the surrounding 28px / 7px topic-bar recipe, use 18px Workbench artwork, and preserve the slimmer Creation and larger menu icon sizes.

## Root cause

The renderer treated project scope as a proxy for whether a workspace could be opened locally. Global tabs can also own a real local workspace, so the control was hidden even though the tab-scoped launch path already had enough information to open it.

The control also retained its older 32px standalone styling after adjacent topic-bar actions moved to a compact 28px recipe.

## Fix

- Add `ExternalOpenersForTab`, which returns opener discovery plus `workspaceOpenable` only after resolving and validating the exact tab workspace directory.
- Reuse the same tab-path validation for launch execution so visibility and execution cannot drift.
- Fence asynchronous opener discovery by request and tab identity, and keep missing, stale, file-backed, or otherwise unavailable workspaces hidden.
- Keep the existing split-button behavior while matching the shared topic-bar geometry and artwork scale.

## Safety and compatibility

- Launches still resolve only installed, platform-owned opener IDs; this does not add renderer-supplied commands.
- The capability is an optional additive JSON field. Existing readers can ignore it, and the legacy `ExternalOpeners` binding remains available.
- No persisted format migration is required.
- No provider prompt, tool schema, serialization, compaction, or cache-prefix behavior changes.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go test -race . -run 'Test(ExternalOpener|ResolveExternalOpener|SetPreferredExternalOpener)' -count=1`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/external-opener.test.tsx` (26/26)
- `cd desktop/frontend && pnpm test:typecheck`
- `cd desktop/frontend && pnpm build`
- Live browser DOM and interaction checks for Global visibility, 28px control alignment, 18px Workbench artwork, and the four-item opener menu

Documentation-impact: none - Existing documentation does not describe scope-based header opener visibility or this split-control geometry; the change is fully covered by runtime behavior and focused regression tests.
