### PR TITLE
fix(desktop): hide base providers from plugin model group / 隐藏插件模型分组中的普通供应商

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9709,10 +9709,12 @@ func (a *App) ModelsForTab(tabID string) []ModelInfo {
 }
 
 // mergeExtensionModelInfos folds the tab controller's extension provider
-// catalog into the config-backed switcher list. Extension refs arrive fully
-// namespaced (plugin/<plugin>/<provider>/<model>) and need no provider-access
-// gate: installing/enabling the plugin package is the host-level grant. A nil
-// catalog (no provider-declaring sidecar) leaves the list untouched.
+// catalog into the config-backed switcher list. ProviderCatalog is merged, so
+// only fully namespaced extension refs (plugin/<plugin>/<provider>/<model>)
+// belong here; unnamespaced base descriptors are already represented by out.
+// Extension refs need no provider-access gate: installing/enabling the plugin
+// package is the host-level grant. A nil catalog (no provider-declaring
+// sidecar) leaves the list untouched.
 func mergeExtensionModelInfos(out []ModelInfo, catalog []provider.Descriptor, curModel string) []ModelInfo {
 	if len(catalog) == 0 {
 		return out
@@ -9723,15 +9725,13 @@ func mergeExtensionModelInfos(out []ModelInfo, catalog []provider.Descriptor, cu
 	}
 	for _, d := range catalog {
 		ref := strings.TrimSpace(d.Ref)
-		if ref == "" || seen[ref] {
+		owner := providerext.PluginRefOwner(ref)
+		if ref == "" || owner == "" || seen[ref] {
 			continue
 		}
 		seen[ref] = true
-		providerName, model := "plugin", ref
-		if owner := providerext.PluginRefOwner(ref); owner != "" {
-			providerName = "plugin/" + owner
-			model = strings.TrimPrefix(ref, "plugin/"+owner+"/")
-		}
+		providerName := "plugin/" + owner
+		model := strings.TrimPrefix(ref, providerName+"/")
 		out = append(out, ModelInfo{Ref: ref, Provider: providerName, Model: model, Current: ref == curModel})
 	}
 	return out

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -9708,13 +9708,10 @@ func (a *App) ModelsForTab(tabID string) []ModelInfo {
 	return mergeExtensionModelInfos(out, extensionCatalog, curModel)
 }
 
-// mergeExtensionModelInfos folds the tab controller's extension provider
-// catalog into the config-backed switcher list. ProviderCatalog is merged, so
-// only fully namespaced extension refs (plugin/<plugin>/<provider>/<model>)
-// belong here; unnamespaced base descriptors are already represented by out.
-// Extension refs need no provider-access gate: installing/enabling the plugin
-// package is the host-level grant. A nil catalog (no provider-declaring
-// sidecar) leaves the list untouched.
+// mergeExtensionModelInfos adds namespaced plugin models from the controller's
+// merged provider catalog. Base descriptors are already represented by out;
+// plugin refs need no provider-access gate because enabling the package grants
+// access. A nil catalog leaves the config-backed list untouched.
 func mergeExtensionModelInfos(out []ModelInfo, catalog []provider.Descriptor, curModel string) []ModelInfo {
 	if len(catalog) == 0 {
 		return out

--- a/desktop/extension_models_test.go
+++ b/desktop/extension_models_test.go
@@ -40,6 +40,11 @@ func TestModelsForTabIncludesExtensionProviders(t *testing.T) {
 			{Ref: "plugin/demo/fake/x", Model: "x"},
 			{Ref: "plugin/demo/fake/y", Model: "y"},
 			{Ref: "old/old-model"}, // claim-replaced duplicate must not repeat
+			// ProviderCatalog is merged, so it can also contain unnamespaced
+			// config-backed descriptors. They are not extension models and must
+			// never leak into a synthetic PLUGIN group in the desktop picker.
+			{Ref: "deepseek-responses", DisplayName: "deepseek-responses"},
+			{Ref: "siliconflow-cn", DisplayName: "siliconflow-cn"},
 		}},
 		disabledMCP: map[string]ServerView{},
 	}
@@ -72,6 +77,11 @@ func TestModelsForTabIncludesExtensionProviders(t *testing.T) {
 	}
 	if oldSeen != 1 || oldCount == nil {
 		t.Fatalf("config ref repeated %d times, want exactly one", oldSeen)
+	}
+	for _, info := range models {
+		if info.Ref == "deepseek-responses" || info.Ref == "siliconflow-cn" || info.Provider == "plugin" {
+			t.Fatalf("unnamespaced provider descriptor leaked into plugin models: %+v", info)
+		}
 	}
 
 	// A tab whose controller has no extension catalog (nil → no sidecar

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/config"
+	"reasonix/internal/extension/providerext"
 	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
 )
@@ -197,7 +198,7 @@ func mergeExtensionModelRefs(base []string, catalog []provider.Descriptor) []str
 	}
 	for _, d := range catalog {
 		ref := strings.TrimSpace(d.Ref)
-		if ref == "" || seen[ref] {
+		if ref == "" || providerext.PluginRefOwner(ref) == "" || seen[ref] {
 			continue
 		}
 		seen[ref] = true

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -152,8 +152,9 @@ func TestMergeExtensionModelRefs(t *testing.T) {
 	catalog := []provider.Descriptor{
 		{Ref: "plugin/demo/fake/x"},
 		{Ref: "plugin/demo/fake/y"},
-		{Ref: "deepseek/deepseek-v4"}, // claim-replaced duplicate must not repeat
-		{Ref: "  "},                   // blank entries are dropped
+		{Ref: "deepseek/deepseek-v4"},  // claim-replaced duplicate must not repeat
+		{Ref: "hidden/ordinary-model"}, // merged base refs are not extension models
+		{Ref: "  "},                    // blank entries are dropped
 	}
 	got := mergeExtensionModelRefs(base, catalog)
 	want := []string{"deepseek/deepseek-v4", "mimo/mimo-v2", "plugin/demo/fake/x", "plugin/demo/fake/y"}


### PR DESCRIPTION
## Summary

- Prevent unnamespaced config-backed provider descriptors from appearing in a synthetic `PLUGIN` group in the Desktop model picker.
- Apply the same namespace filter to the CLI `/model` picker so every consumer of the merged provider catalog preserves the plugin boundary.
- Keep real `plugin/<owner>/...` models discoverable and add regression coverage for unnamespaced base descriptors.

## Issues

Fixes #8070

## Verification

- `go test ./internal/cli -run 'TestMergeExtensionModelRefs|TestPersistModelAcceptsPluginRef' -count=1`
- `cd desktop && go test . -run 'TestModelsForTabIncludesExtensionProviders|TestSetModelForTabPluginRefReachesBoot|TestModelsForTab' -count=1`
- `cd desktop && go vet .`
- `go run ./tools/repolint`
- `git diff --check`
- Repeated the focused checks on a clean merge of PR head `fc8516e35` with `origin/main-v2` `85c7c0e80`; all passed.

## Documentation impact

Documentation-impact: none - this restores the intended Desktop and CLI model picker behavior without changing documented configuration or workflows.

## Cache impact

Cache-impact: none - model catalog filtering only; no provider requests, system prompts, tool schemas, or cache prefixes change.
Cache-guard: Focused Desktop and CLI model-catalog tests cover base-provider filtering, plugin model retention, and config-model deduplication.
System-prompt-review: N/A
