### PR TITLE
fix(desktop): refresh status bar TPS after each provider request / 底部信息栏吞吐速度改为每次请求后更新

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -5416,6 +5416,7 @@ export default function App() {
             lastTurnOutputTokens={state.lastTurnOutputTokens}
             lastTurnModelMs={state.lastTurnModelMs}
             lastTurnOutputEstimated={state.lastTurnOutputEstimated}
+            lastRequestTps={state.lastRequestTps}
             turnCost={state.turnCost}
             cost={state.sessionCost}
             currency={state.sessionCurrency}

--- a/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
+++ b/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
@@ -217,6 +217,16 @@ console.log("\nstatus bar workspace");
     lastTurnModelMs: 5_000,
   });
   ok(perRequest.includes("35 t/s"), "per-request TPS wins over the completed turn value");
+
+  const slowRequest = renderStatusBar({
+    items: ["turn_tps"], lastRequestTps: 1 / 3, lastTurnOutputTokens: 100, lastTurnModelMs: 5_000,
+  });
+  ok(slowRequest.includes("&lt;1 t/s") && !slowRequest.includes("20 t/s"), "sub-one request TPS replaces the stale turn fallback");
+
+  const unavailable = renderStatusBar({
+    items: ["turn_tps"], lastRequestTps: null, lastTurnOutputTokens: 100, lastTurnModelMs: 5_000,
+  });
+  ok(unavailable.includes('stat__value--empty">-</b>') && !unavailable.includes("20 t/s"), "unmeasured latest requests clear the stale turn fallback");
 }
 
 {

--- a/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
+++ b/desktop/frontend/src/__tests__/statusbar-workspace.test.tsx
@@ -204,6 +204,14 @@ console.log("\nstatus bar workspace");
     lastTurnOutputEstimated: true,
   });
   ok(estimated.includes("≈20 t/s"), "fallback TPS is visibly marked as estimated");
+
+  const perRequest = renderStatusBar({
+    items: ["turn_tps"],
+    lastRequestTps: 35,
+    lastTurnOutputTokens: 100,
+    lastTurnModelMs: 5_000,
+  });
+  ok(perRequest.includes("35 t/s"), "per-request TPS wins over the completed turn value");
 }
 
 {

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -362,5 +362,117 @@ function ev(s: typeof initialState, e: WireEvent) {
   }
 }
 
+// --- 7. lastRequestTps pairs the closed interval with the usage tokens ---
+{
+  const originalNow = Date.now;
+  let now = 50_000;
+  Date.now = () => now;
+  try {
+    let s = ev({ ...initialState }, { kind: "turn_started" } as WireEvent);
+    now = 50_100;
+    s = ev(s, { kind: "text", text: "abcd" } as WireEvent);
+    now = 51_100;
+    // The message event closes the interval BEFORE the usage event arrives.
+    s = ev(s, { kind: "message", text: "abcd" } as WireEvent);
+    now = 51_200;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 100, completionTokens: 20, totalTokens: 120,
+      cacheHitTokens: 0, cacheMissTokens: 100, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 20, "usage pairs the message-closed interval with its tokens");
+
+    now = 52_000;
+    s = ev(s, { kind: "text", text: "more" } as WireEvent);
+    now = 52_050;
+    s = ev(s, { kind: "message", text: "more" } as WireEvent);
+    now = 52_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 5, completionTokens: 50, totalTokens: 55,
+      cacheHitTokens: 0, cacheMissTokens: 5, source: "subagent",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 20, "non-executor usage neither computes nor consumes the pending interval");
+    now = 52_300;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 30, totalTokens: 40,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 20, "intervals under the 500ms gate keep the previous request TPS");
+
+    now = 53_000;
+    s = ev(s, { kind: "text", text: "second" } as WireEvent);
+    now = 54_000;
+    s = ev(s, { kind: "message", text: "second" } as WireEvent);
+    now = 54_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 30, totalTokens: 40,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 30, "a later executor usage refreshes the request TPS");
+
+    now = 55_000;
+    s = ev(s, { kind: "text", text: "direct" } as WireEvent);
+    now = 56_000;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 40, totalTokens: 50,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 40, "usage measures an interval still open at arrival");
+
+    now = 57_000;
+    s = ev(s, { kind: "turn_done" } as WireEvent);
+    eq(s.lastRequestTps, 40, "request TPS persists across turn boundaries");
+
+    now = 58_000;
+    s = ev(s, { kind: "turn_started" } as WireEvent);
+    now = 58_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 8, totalTokens: 18,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 40, "a fresh turn does not inherit the previous pending interval");
+
+    now = 59_000;
+    s = ev(s, { kind: "text", text: "toolcall" } as WireEvent);
+    now = 60_000;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t1", name: "read_file", args: "{}", readOnly: true } } as WireEvent);
+    now = 60_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 25, totalTokens: 35,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 25, "tool_dispatch closes the interval the next executor usage pairs with");
+
+    now = 61_000;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t2", name: "write_file", readOnly: false, partial: true, argChars: 600 } } as WireEvent);
+    now = 62_000;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t2", name: "write_file", args: "{}", readOnly: false } } as WireEvent);
+    now = 62_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 30, totalTokens: 40,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 30, "a partial dispatch starts the interval the full dispatch close pairs");
+
+    now = 63_000;
+    s = ev(s, { kind: "text", text: "closing" } as WireEvent);
+    now = 64_000;
+    s = ev(s, { kind: "message", text: "closing" } as WireEvent);
+    now = 64_100;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t3", name: "write_file", readOnly: false, partial: true, argChars: 300 } } as WireEvent);
+    now = 64_700;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t3", name: "write_file", args: "{}", readOnly: false } } as WireEvent);
+    now = 64_800;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 30, totalTokens: 40,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    // The partial restart begins a new interval; the full dispatch closes it
+    // and overwrites the message-stashed pending with its own (≥500ms) tail.
+    eq(s.lastRequestTps, 50, "a full dispatch overwrites a message-stashed pending with its own tail close");
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -397,7 +397,7 @@ function ev(s: typeof initialState, e: WireEvent) {
       promptTokens: 10, completionTokens: 30, totalTokens: 40,
       cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
     } } as WireEvent);
-    eq(s.lastRequestTps, 20, "intervals under the 500ms gate keep the previous request TPS");
+    eq(s.lastRequestTps, null, "intervals under the 500ms gate clear stale request TPS");
 
     now = 53_000;
     s = ev(s, { kind: "text", text: "second" } as WireEvent);
@@ -430,7 +430,10 @@ function ev(s: typeof initialState, e: WireEvent) {
       promptTokens: 10, completionTokens: 8, totalTokens: 18,
       cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
     } } as WireEvent);
-    eq(s.lastRequestTps, 40, "a fresh turn does not inherit the previous pending interval");
+    eq(s.lastRequestTps, null, "usage without a provider interval clears stale request TPS");
+    now = 58_200;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "final-only", name: "read_file", args: "{}", readOnly: true } } as WireEvent);
+    eq(s.lastRequestTps, null, "a final-only tool dispatch after usage cannot resurrect stale TPS");
 
     now = 59_000;
     s = ev(s, { kind: "text", text: "toolcall" } as WireEvent);
@@ -446,13 +449,14 @@ function ev(s: typeof initialState, e: WireEvent) {
     now = 61_000;
     s = ev(s, { kind: "tool_dispatch", tool: { id: "t2", name: "write_file", readOnly: false, partial: true, argChars: 600 } } as WireEvent);
     now = 62_000;
-    s = ev(s, { kind: "tool_dispatch", tool: { id: "t2", name: "write_file", args: "{}", readOnly: false } } as WireEvent);
-    now = 62_100;
     s = ev(s, { kind: "usage", usage: {
       promptTokens: 10, completionTokens: 30, totalTokens: 40,
       cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
     } } as WireEvent);
-    eq(s.lastRequestTps, 30, "a partial dispatch starts the interval the full dispatch close pairs");
+    eq(s.lastRequestTps, 30, "usage closes the interval started by a partial tool dispatch");
+    now = 62_100;
+    s = ev(s, { kind: "tool_dispatch", tool: { id: "t2", name: "write_file", args: "{}", readOnly: false } } as WireEvent);
+    eq(s.lastRequestTps, 30, "the later full tool dispatch preserves the measured request TPS");
 
     now = 63_000;
     s = ev(s, { kind: "text", text: "closing" } as WireEvent);
@@ -470,6 +474,17 @@ function ev(s: typeof initialState, e: WireEvent) {
     // The partial restart begins a new interval; the full dispatch closes it
     // and overwrites the message-stashed pending with its own (≥500ms) tail.
     eq(s.lastRequestTps, 50, "a full dispatch overwrites a message-stashed pending with its own tail close");
+
+    now = 65_000;
+    s = ev(s, { kind: "text", text: "slow" } as WireEvent);
+    now = 68_000;
+    s = ev(s, { kind: "message", text: "slow" } as WireEvent);
+    now = 68_100;
+    s = ev(s, { kind: "usage", usage: {
+      promptTokens: 10, completionTokens: 1, totalTokens: 11,
+      cacheHitTokens: 0, cacheMissTokens: 10, source: "executor",
+    } } as WireEvent);
+    eq(s.lastRequestTps, 1 / 3, "slow measurable requests retain their raw sub-one TPS");
   } finally {
     Date.now = originalNow;
   }

--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -376,10 +376,11 @@ function ev(s: typeof initialState, e: WireEvent) {
     s = ev(s, { kind: "message", text: "abcd" } as WireEvent);
     now = 51_200;
     s = ev(s, { kind: "usage", usage: {
-      promptTokens: 100, completionTokens: 20, totalTokens: 120,
+      promptTokens: 130, completionTokens: 30, totalTokens: 160,
+      contextPromptTokens: 100, contextCompletionTokens: 20,
       cacheHitTokens: 0, cacheMissTokens: 100, source: "executor",
     } } as WireEvent);
-    eq(s.lastRequestTps, 20, "usage pairs the message-closed interval with its tokens");
+    eq(s.lastRequestTps, 20, "sampling recovery pairs the interval with latest-attempt tokens");
 
     now = 52_000;
     s = ev(s, { kind: "text", text: "more" } as WireEvent);

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -66,9 +66,8 @@ function formatTurnCount(turns: number | undefined, t: Translator): string {
   if (typeof turns !== "number" || turns < 0) return "-";
   return t(turns === 1 ? "history.turnOne" : "history.turnOther", { n: turns });
 }
-function formatTps(outputTokens?: number, modelMs?: number, estimated = false): string | null {
-  if (!outputTokens || outputTokens <= 0 || !modelMs || modelMs < 1) return null;
-  const tps = outputTokens / (modelMs / 1000);
+function formatTps(tps?: number | null, estimated = false): string | null {
+  if (!tps || tps <= 0) return null;
   const prefix = estimated ? "≈" : "";
   if (tps < 1) return `${prefix}<1 t/s`;
   return `${prefix}${Math.round(tps)} t/s`;
@@ -205,7 +204,7 @@ export function StatusBar({
   lastTurnOutputTokens?: number;
   lastTurnModelMs?: number;
   lastTurnOutputEstimated?: boolean;
-  lastRequestTps?: number; // Preferred over completed-turn TPS when available.
+  lastRequestTps?: number | null; // Null means the latest request was not measurable.
   turnCost?: number;
   cost?: number;
   currency?: string;
@@ -252,9 +251,9 @@ export function StatusBar({
   const tokenLabel = markEstimated(formatTokenCount(sessionTokens), sessionEstimated);
   const turnTokenLabel = markEstimated(formatTokenCount(turnTokens), turnEstimated);
   const balanceLabel = balance?.available && balance.display ? balance.display : "-";
-  const tpsLabel = lastRequestTps !== undefined && lastRequestTps > 0
-    ? `${lastRequestTps} t/s`
-    : formatTps(lastTurnOutputTokens, lastTurnModelMs, lastTurnOutputEstimated);
+  const tpsLabel = lastRequestTps === undefined
+    ? formatTps(lastTurnOutputTokens && lastTurnModelMs ? lastTurnOutputTokens / (lastTurnModelMs / 1_000) : null, lastTurnOutputEstimated)
+    : formatTps(lastRequestTps);
   const formatUsageToken = (value: number) => `${usage?.estimated ? "≈" : ""}${value.toLocaleString()}`;
   const outputTokensLabel = usage && typeof usage.completionTokens === "number"
     ? formatUsageToken(usage.completionTokens)

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -66,14 +66,9 @@ function formatTurnCount(turns: number | undefined, t: Translator): string {
   if (typeof turns !== "number" || turns < 0) return "-";
   return t(turns === 1 ? "history.turnOne" : "history.turnOther", { n: turns });
 }
-
-
 function formatTps(outputTokens?: number, modelMs?: number, estimated = false): string | null {
-  if (!outputTokens || outputTokens <= 0) return null;
-  if (!modelMs || modelMs <= 0) return null;
-  const elapsedSec = modelMs / 1000;
-  if (elapsedSec < 0.001) return null;
-  const tps = outputTokens / elapsedSec;
+  if (!outputTokens || outputTokens <= 0 || !modelMs || modelMs < 1) return null;
+  const tps = outputTokens / (modelMs / 1000);
   const prefix = estimated ? "≈" : "";
   if (tps < 1) return `${prefix}<1 t/s`;
   return `${prefix}${Math.round(tps)} t/s`;
@@ -210,9 +205,7 @@ export function StatusBar({
   lastTurnOutputTokens?: number;
   lastTurnModelMs?: number;
   lastTurnOutputEstimated?: boolean;
-  // TPS of the most recent executor request; preferred over the completed
-  // turn's value so the status bar stays live during long turns.
-  lastRequestTps?: number;
+  lastRequestTps?: number; // Preferred over completed-turn TPS when available.
   turnCost?: number;
   cost?: number;
   currency?: string;
@@ -259,11 +252,9 @@ export function StatusBar({
   const tokenLabel = markEstimated(formatTokenCount(sessionTokens), sessionEstimated);
   const turnTokenLabel = markEstimated(formatTokenCount(turnTokens), turnEstimated);
   const balanceLabel = balance?.available && balance.display ? balance.display : "-";
-  // The most recent executor request's TPS (refreshed on every usage event)
-  // takes precedence; the completed turn's value bridges the gap before the
-  // first request of a session.
-  const requestTpsLabel = lastRequestTps !== undefined && lastRequestTps > 0 ? `${lastRequestTps} t/s` : null;
-  const tpsLabel = requestTpsLabel ?? formatTps(lastTurnOutputTokens, lastTurnModelMs, lastTurnOutputEstimated);
+  const tpsLabel = lastRequestTps !== undefined && lastRequestTps > 0
+    ? `${lastRequestTps} t/s`
+    : formatTps(lastTurnOutputTokens, lastTurnModelMs, lastTurnOutputEstimated);
   const formatUsageToken = (value: number) => `${usage?.estimated ? "≈" : ""}${value.toLocaleString()}`;
   const outputTokensLabel = usage && typeof usage.completionTokens === "number"
     ? formatUsageToken(usage.completionTokens)

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -176,6 +176,7 @@ export function StatusBar({
   lastTurnOutputTokens,
   lastTurnModelMs,
   lastTurnOutputEstimated = false,
+  lastRequestTps,
   turnCost,
   cost,
   currency,
@@ -209,6 +210,9 @@ export function StatusBar({
   lastTurnOutputTokens?: number;
   lastTurnModelMs?: number;
   lastTurnOutputEstimated?: boolean;
+  // TPS of the most recent executor request; preferred over the completed
+  // turn's value so the status bar stays live during long turns.
+  lastRequestTps?: number;
   turnCost?: number;
   cost?: number;
   currency?: string;
@@ -255,7 +259,11 @@ export function StatusBar({
   const tokenLabel = markEstimated(formatTokenCount(sessionTokens), sessionEstimated);
   const turnTokenLabel = markEstimated(formatTokenCount(turnTokens), turnEstimated);
   const balanceLabel = balance?.available && balance.display ? balance.display : "-";
-  const tpsLabel = formatTps(lastTurnOutputTokens, lastTurnModelMs, lastTurnOutputEstimated);
+  // The most recent executor request's TPS (refreshed on every usage event)
+  // takes precedence; the completed turn's value bridges the gap before the
+  // first request of a session.
+  const requestTpsLabel = lastRequestTps !== undefined && lastRequestTps > 0 ? `${lastRequestTps} t/s` : null;
+  const tpsLabel = requestTpsLabel ?? formatTps(lastTurnOutputTokens, lastTurnModelMs, lastTurnOutputEstimated);
   const formatUsageToken = (value: number) => `${usage?.estimated ? "≈" : ""}${value.toLocaleString()}`;
   const outputTokensLabel = usage && typeof usage.completionTokens === "number"
     ? formatUsageToken(usage.completionTokens)

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -414,15 +414,8 @@ interface State {
   lastTurnWaitAccumMs: number;
   lastTurnModelMs: number;
   lastTurnOutputEstimated: boolean;
-  // TPS of the most recent executor request: completion tokens over the
-  // provider-output interval that the usage event just closed. Refreshes on
-  // every executor usage event so the status bar stays live during long
-  // turns instead of waiting for turn_done. Persists like state.usage.
+  // Per-request rate and its pending provider interval are tab-local.
   lastRequestTps?: number;
-  // Provider-output time of the interval the message/tool_dispatch event just
-  // closed. The usage event for the same request arrives after that close, so
-  // the time is stashed here until the executor usage pairs it with tokens.
-  // Reset on turn boundaries so a stale close never pairs across turns.
   pendingRequestModelMs?: number;
   promptWaitStartedAt?: number;
   // promptEventClock() reading taken when the CURRENT pending prompt first
@@ -1149,8 +1142,7 @@ function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnDon
     turnOutputCharsAtUsage: 0,
     turnOutputEstimated: false,
     turnModelActiveAt: undefined,
-    turnModelActiveMs: 0,
-    pendingRequestModelMs: undefined,
+    turnModelActiveMs: 0, pendingRequestModelMs: undefined,
     turnCost: 0,
     turnArgChars: 0,
   };
@@ -1167,23 +1159,11 @@ function beginTurnModelActivity(s: State, now = Date.now()): State {
     : { ...s, turnModelActiveAt: now };
 }
 
-function endTurnModelActivity(s: State, now = Date.now()): State {
+function endTurnModelActivity(s: State, now = Date.now(), stashForUsage = false): State {
   if (!s.turnModelActiveAt || s.turnModelActiveAt <= 0) return s;
-  return {
-    ...s,
-    turnModelActiveAt: undefined,
-    turnModelActiveMs: Math.max(0, s.turnModelActiveMs) + Math.max(0, now - s.turnModelActiveAt),
-  };
-}
-
-// Closes the provider-output interval and stashes the closed duration for the
-// usage event that follows this request's message/tool_dispatch. The usage
-// event arrives after the close, so the pairing needs the time preserved.
-function closeModelActivityWithPending(s: State, now = Date.now()): State {
-  const before = s.turnModelActiveMs;
-  const settled = endTurnModelActivity(s, now);
-  const closedMs = Math.max(0, settled.turnModelActiveMs - before);
-  return closedMs > 0 ? { ...settled, pendingRequestModelMs: closedMs } : settled;
+  const closedMs = Math.max(0, now - s.turnModelActiveAt);
+  return { ...s, turnModelActiveAt: undefined, turnModelActiveMs: Math.max(0, s.turnModelActiveMs) + closedMs,
+    pendingRequestModelMs: stashForUsage ? closedMs : s.pendingRequestModelMs };
 }
 
 function snapshotCompletedTurnTelemetry(s: State, now = Date.now()): State {
@@ -1506,10 +1486,10 @@ function applyEvent(s: State, e: WireEvent): State {
           existingAssistant && existingAssistant.text.trim() === "" && existingAssistant.reasoning.trim() === "" && !existingAssistant.memoryCitations?.length
             ? s.items.filter((it) => !(it.kind === "assistant" && it.id === existingAssistant.id))
             : s.items;
-        return { ...closeModelActivityWithPending(s), items, live: undefined, currentAssistant: undefined, turnOutputCharsAtUsage: 0 };
+        return { ...endTurnModelActivity(s, Date.now(), true), items, live: undefined, currentAssistant: undefined, turnOutputCharsAtUsage: 0 };
       }
       const now = Date.now();
-      const settled = closeModelActivityWithPending(s, now);
+      const settled = endTurnModelActivity(s, now, true);
       const { items, id, seq } = ensureAssistant(settled);
       const streamedChars = settled.live?.id === id ? settled.live.text.length + settled.live.reasoning.length : 0;
       const turnOutputChars = Math.max(0, settled.turnOutputChars - streamedChars + text.length + reasoning.length);
@@ -1573,7 +1553,7 @@ function applyEvent(s: State, e: WireEvent): State {
           items: [...activeState.items, { kind: "tool", id, name: t.name, args: "", readOnly: t.readOnly, resolvedName: t.resolvedName, capabilityId: t.capabilityId, status: "running", argChars: t.argChars || undefined, parentId: t.parentId, subagentProgress: SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined }],
         }, id, false, undefined, { attemptId: t.attemptId, parentId: t.parentId, partial: true });
       }
-      const settled = t.parentId ? s : closeModelActivityWithPending(s);
+      const settled = t.parentId ? s : endTurnModelActivity(s, Date.now(), true);
       const id = t.id || `tool${s.seq}`;
       const idx = settled.items.findIndex((it) => it.kind === "tool" && it.id === id);
       if (idx >= 0) {
@@ -1682,32 +1662,17 @@ function applyEvent(s: State, e: WireEvent): State {
       // Only executor usage belongs to the foreground model stream. Planner,
       // subagent, and auxiliary usage still contributes to session totals and
       // usageSeq, but must not close or inflate the executor TPS interval.
-      const settled = updateContextGauge ? closeModelActivityWithPending(s) : s;
-      // Per-request TPS: closeModelActivityWithPending stashed the interval this
-      // usage event just closed — or the one the message/tool_dispatch already
-      // closed — so pendingRequestModelMs carries the request's provider-output
-      // time for the pairing. Intervals under the 500ms composer gate (or
-      // missing — non-executor sources) keep the previous value.
+      const settled = updateContextGauge ? endTurnModelActivity(s, Date.now(), true) : s;
+      const hasRequestContext = (e.usage?.contextPromptTokens ?? 0) > 0 || (e.usage?.contextCompletionTokens ?? 0) > 0;
       const requestModelMs = updateContextGauge ? (settled.pendingRequestModelMs ?? 0) : 0;
-      const requestTokens = updateContextGauge ? (e.usage?.completionTokens ?? 0) : 0;
-      const requestTps = requestTokens > 0 && requestModelMs >= 500
-        ? Math.round(requestTokens / (requestModelMs / 1000))
-        : 0;
-      // A sub-0.5 t/s request rounds to 0 — no more trustworthy than a
-      // sub-500ms interval — so keep the previous request TPS instead of
-      // storing a value the status bar would treat as absent.
+      const requestTokens = updateContextGauge ? (hasRequestContext ? (e.usage?.contextCompletionTokens ?? 0) : (e.usage?.completionTokens ?? 0)) : 0;
+      const requestTps = requestTokens > 0 && requestModelMs >= 500 ? Math.round(requestTokens / (requestModelMs / 1000)) : 0;
       const lastRequestTps = requestTps > 0 ? requestTps : s.lastRequestTps;
-      // Prefer Context* (latest attempt) over billable aggregates when multi-
-      // attempt sampling recovery folds several provider calls into one Usage.
-      // Matches Controller.ContextSnapshot: latest prompt + completion.
+      // Context* is the latest sampling attempt; other token fields are billable aggregates.
       let used = settled.context.used;
-      if (e.usage && settled.context.window && updateContextGauge) {
-        const hasContext =
-          (e.usage.contextPromptTokens ?? 0) > 0 || (e.usage.contextCompletionTokens ?? 0) > 0;
-        used = hasContext
-          ? (e.usage.contextPromptTokens ?? 0) + (e.usage.contextCompletionTokens ?? 0)
-          : (e.usage.promptTokens ?? 0) + (e.usage.completionTokens ?? 0);
-      }
+      if (e.usage && settled.context.window && updateContextGauge) used = hasRequestContext
+        ? (e.usage.contextPromptTokens ?? 0) + (e.usage.contextCompletionTokens ?? 0)
+        : (e.usage.promptTokens ?? 0) + (e.usage.completionTokens ?? 0);
       const turnTokens = settled.turnTokens + (e.usage?.completionTokens ?? 0);
       const turnOutputTokens = updateContextGauge
         ? settled.turnOutputTokens + (e.usage?.completionTokens ?? 0)

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -414,6 +414,16 @@ interface State {
   lastTurnWaitAccumMs: number;
   lastTurnModelMs: number;
   lastTurnOutputEstimated: boolean;
+  // TPS of the most recent executor request: completion tokens over the
+  // provider-output interval that the usage event just closed. Refreshes on
+  // every executor usage event so the status bar stays live during long
+  // turns instead of waiting for turn_done. Persists like state.usage.
+  lastRequestTps?: number;
+  // Provider-output time of the interval the message/tool_dispatch event just
+  // closed. The usage event for the same request arrives after that close, so
+  // the time is stashed here until the executor usage pairs it with tokens.
+  // Reset on turn boundaries so a stale close never pairs across turns.
+  pendingRequestModelMs?: number;
   promptWaitStartedAt?: number;
   // promptEventClock() reading taken when the CURRENT pending prompt first
   // arrived. Orders the prompt against reconciliation snapshots so a snapshot
@@ -1126,7 +1136,7 @@ function endPromptWaitIfIdle(s: State, now = Date.now()): State {
   return endPromptWait(s, now);
 }
 
-function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnDoneAt" | "turnWaitAccumMs" | "promptWaitStartedAt" | "turnTokens" | "turnTotalTokens" | "turnOutputTokens" | "turnOutputChars" | "turnOutputCharsAtUsage" | "turnOutputEstimated" | "turnModelActiveAt" | "turnModelActiveMs" | "turnCost" | "turnArgChars"> {
+function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnDoneAt" | "turnWaitAccumMs" | "promptWaitStartedAt" | "turnTokens" | "turnTotalTokens" | "turnOutputTokens" | "turnOutputChars" | "turnOutputCharsAtUsage" | "turnOutputEstimated" | "turnModelActiveAt" | "turnModelActiveMs" | "turnCost" | "turnArgChars" | "pendingRequestModelMs"> {
   return {
     turnStartAt: now,
     turnDoneAt: 0,
@@ -1140,6 +1150,7 @@ function resetTurnTiming(now = Date.now()): Pick<State, "turnStartAt" | "turnDon
     turnOutputEstimated: false,
     turnModelActiveAt: undefined,
     turnModelActiveMs: 0,
+    pendingRequestModelMs: undefined,
     turnCost: 0,
     turnArgChars: 0,
   };
@@ -1163,6 +1174,16 @@ function endTurnModelActivity(s: State, now = Date.now()): State {
     turnModelActiveAt: undefined,
     turnModelActiveMs: Math.max(0, s.turnModelActiveMs) + Math.max(0, now - s.turnModelActiveAt),
   };
+}
+
+// Closes the provider-output interval and stashes the closed duration for the
+// usage event that follows this request's message/tool_dispatch. The usage
+// event arrives after the close, so the pairing needs the time preserved.
+function closeModelActivityWithPending(s: State, now = Date.now()): State {
+  const before = s.turnModelActiveMs;
+  const settled = endTurnModelActivity(s, now);
+  const closedMs = Math.max(0, settled.turnModelActiveMs - before);
+  return closedMs > 0 ? { ...settled, pendingRequestModelMs: closedMs } : settled;
 }
 
 function snapshotCompletedTurnTelemetry(s: State, now = Date.now()): State {
@@ -1485,10 +1506,10 @@ function applyEvent(s: State, e: WireEvent): State {
           existingAssistant && existingAssistant.text.trim() === "" && existingAssistant.reasoning.trim() === "" && !existingAssistant.memoryCitations?.length
             ? s.items.filter((it) => !(it.kind === "assistant" && it.id === existingAssistant.id))
             : s.items;
-        return { ...endTurnModelActivity(s), items, live: undefined, currentAssistant: undefined, turnOutputCharsAtUsage: 0 };
+        return { ...closeModelActivityWithPending(s), items, live: undefined, currentAssistant: undefined, turnOutputCharsAtUsage: 0 };
       }
       const now = Date.now();
-      const settled = endTurnModelActivity(s, now);
+      const settled = closeModelActivityWithPending(s, now);
       const { items, id, seq } = ensureAssistant(settled);
       const streamedChars = settled.live?.id === id ? settled.live.text.length + settled.live.reasoning.length : 0;
       const turnOutputChars = Math.max(0, settled.turnOutputChars - streamedChars + text.length + reasoning.length);
@@ -1552,7 +1573,7 @@ function applyEvent(s: State, e: WireEvent): State {
           items: [...activeState.items, { kind: "tool", id, name: t.name, args: "", readOnly: t.readOnly, resolvedName: t.resolvedName, capabilityId: t.capabilityId, status: "running", argChars: t.argChars || undefined, parentId: t.parentId, subagentProgress: SUBAGENT_PROGRESS_TOOLS.has(t.name) ? freshSubagentProgress() : undefined }],
         }, id, false, undefined, { attemptId: t.attemptId, parentId: t.parentId, partial: true });
       }
-      const settled = t.parentId ? s : endTurnModelActivity(s);
+      const settled = t.parentId ? s : closeModelActivityWithPending(s);
       const id = t.id || `tool${s.seq}`;
       const idx = settled.items.findIndex((it) => it.kind === "tool" && it.id === id);
       if (idx >= 0) {
@@ -1661,7 +1682,21 @@ function applyEvent(s: State, e: WireEvent): State {
       // Only executor usage belongs to the foreground model stream. Planner,
       // subagent, and auxiliary usage still contributes to session totals and
       // usageSeq, but must not close or inflate the executor TPS interval.
-      const settled = updateContextGauge ? endTurnModelActivity(s) : s;
+      const settled = updateContextGauge ? closeModelActivityWithPending(s) : s;
+      // Per-request TPS: closeModelActivityWithPending stashed the interval this
+      // usage event just closed — or the one the message/tool_dispatch already
+      // closed — so pendingRequestModelMs carries the request's provider-output
+      // time for the pairing. Intervals under the 500ms composer gate (or
+      // missing — non-executor sources) keep the previous value.
+      const requestModelMs = updateContextGauge ? (settled.pendingRequestModelMs ?? 0) : 0;
+      const requestTokens = updateContextGauge ? (e.usage?.completionTokens ?? 0) : 0;
+      const requestTps = requestTokens > 0 && requestModelMs >= 500
+        ? Math.round(requestTokens / (requestModelMs / 1000))
+        : 0;
+      // A sub-0.5 t/s request rounds to 0 — no more trustworthy than a
+      // sub-500ms interval — so keep the previous request TPS instead of
+      // storing a value the status bar would treat as absent.
+      const lastRequestTps = requestTps > 0 ? requestTps : s.lastRequestTps;
       // Prefer Context* (latest attempt) over billable aggregates when multi-
       // attempt sampling recovery folds several provider calls into one Usage.
       // Matches Controller.ContextSnapshot: latest prompt + completion.
@@ -1693,7 +1728,7 @@ function applyEvent(s: State, e: WireEvent): State {
       const usage = updateContextGauge ? e.usage : settled.usage;
       // The completed round's usage now accounts for the streamed tool-call
       // arguments, so drop the live estimate rather than double-count it.
-      return { ...settled, usage, context: { ...settled.context, used, sessionTokens }, turnTokens, turnOutputTokens, turnOutputCharsAtUsage, turnOutputEstimated, turnTotalTokens, turnCost, turnArgChars: updateContextGauge ? 0 : settled.turnArgChars, sessionTokens, sessionCost, sessionCurrency, usageSeq: settled.usageSeq + 1 };
+      return { ...settled, usage, context: { ...settled.context, used, sessionTokens }, turnTokens, turnOutputTokens, turnOutputCharsAtUsage, turnOutputEstimated, turnTotalTokens, turnCost, turnArgChars: updateContextGauge ? 0 : settled.turnArgChars, sessionTokens, sessionCost, sessionCurrency, usageSeq: settled.usageSeq + 1, lastRequestTps, pendingRequestModelMs: updateContextGauge ? undefined : settled.pendingRequestModelMs };
     }
     case "notice":
       return appendNoticeToState(s, e.level ?? "info", e.text ?? "", e.detail, e.code, e.decisionReceipt);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -414,8 +414,8 @@ interface State {
   lastTurnWaitAccumMs: number;
   lastTurnModelMs: number;
   lastTurnOutputEstimated: boolean;
-  // Per-request rate and its pending provider interval are tab-local.
-  lastRequestTps?: number;
+  // Per-request rate (null when unmeasurable) and pending interval are tab-local.
+  lastRequestTps?: number | null;
   pendingRequestModelMs?: number;
   promptWaitStartedAt?: number;
   // promptEventClock() reading taken when the CURRENT pending prompt first
@@ -1666,8 +1666,7 @@ function applyEvent(s: State, e: WireEvent): State {
       const hasRequestContext = (e.usage?.contextPromptTokens ?? 0) > 0 || (e.usage?.contextCompletionTokens ?? 0) > 0;
       const requestModelMs = updateContextGauge ? (settled.pendingRequestModelMs ?? 0) : 0;
       const requestTokens = updateContextGauge ? (hasRequestContext ? (e.usage?.contextCompletionTokens ?? 0) : (e.usage?.completionTokens ?? 0)) : 0;
-      const requestTps = requestTokens > 0 && requestModelMs >= 500 ? Math.round(requestTokens / (requestModelMs / 1000)) : 0;
-      const lastRequestTps = requestTps > 0 ? requestTps : s.lastRequestTps;
+      const lastRequestTps = updateContextGauge ? (requestTokens > 0 && requestModelMs >= 500 ? requestTokens / (requestModelMs / 1000) : null) : s.lastRequestTps;
       // Context* is the latest sampling attempt; other token fields are billable aggregates.
       let used = settled.context.used;
       if (e.usage && settled.context.window && updateContextGauge) used = hasRequestContext


### PR DESCRIPTION
## Summary

This PR corrects the refresh granularity introduced in #6931. The status bar tooltip describes throughput for the most recent request, but the implementation previously displayed completed-turn telemetry and could remain stale throughout a long tool-calling turn.

The status bar now refreshes throughput after every executor `usage` event while preserving completed-turn TPS only as the pre-first-request fallback.

## Implementation

- Tracks the latest request rate and pending provider-output interval per tab.
- Starts provider timing on text/reasoning output or partial tool-call dispatch, then closes it at `message`, full tool dispatch, or executor `usage`.
- Pairs the interval with latest-attempt `contextCompletionTokens` when available; legacy usage payloads retain the `completionTokens` fallback.
- Keeps raw positive rates so a measurable request below 1 TPS renders as `<1 t/s` instead of reusing an older value.
- Distinguishes three states: no request yet (`undefined`, completed-turn fallback allowed), measured latest request (number), and unmeasurable latest request (`null`, rendered as `-`).
- Leaves planner, subagent, title, and other non-executor usage outside the foreground request calculation.

### Event ordering

Both runtime sequences are covered:

- `text/reasoning -> message -> usage`: `message` stashes the closed interval for the following usage event.
- `partial tool_dispatch -> usage -> full tool_dispatch`: usage closes and measures the active interval; the later full dispatch preserves the result.

If an extension emits only a final tool call with no output-start signal, no reliable duration exists, so the latest request is shown as unavailable rather than retaining stale TPS.

## Issues

Refs #6931.

## Verification

- `use-controller-stream-progress.test.ts`: 85 passed.
- `statusbar-workspace.test.tsx`: 43 passed.
- `pnpm --dir desktop/frontend typecheck`: passed.
- `pnpm --dir desktop/frontend build`: passed, including frontend lint, CSS checks, TypeScript, Vite, and bundle budgets.
- `pnpm --dir desktop/frontend test:remote`: passed.
- `go run ./tools/repolint`: clean.
- `git diff --check`: passed.

## Documentation impact

Documentation-impact: none - no documentation files changed; the existing tooltip already describes the intended per-request behavior.

## Cache impact

Cache-impact: none - frontend-only reducer and StatusBar behavior; provider-visible prompts, tool schemas, and request serialization are unchanged.
Cache-guard: existing guard suites cover the untouched provider/tool surface.
System-prompt-review: N/A

---

## 摘要

本 PR 修正 #6931 引入的刷新粒度问题。状态栏工具提示描述的是“最近一次请求”的输出吞吐，但原实现展示完成回合的统计；在长工具调用回合中，它可能一直停留在旧值。

现在每次 executor `usage` 事件到达后都会刷新吞吐；仅在会话尚未完成第一个请求时，才使用已完成回合 TPS 作为兜底。

## 实现

- 按 Tab 保存最近请求速率及待配对的 provider 输出区间。
- 在 text/reasoning 输出或 partial 工具调用分派时开始计时，在 `message`、完整工具分派或 executor `usage` 时结束计时。
- 优先使用最新采样尝试的 `contextCompletionTokens`；旧 usage 载荷继续回退到 `completionTokens`。
- 保存未舍入的正速率，因此低于 1 TPS 的有效慢请求显示 `<1 t/s`，不会继续显示旧值。
- 明确区分三种状态：尚无请求（`undefined`，允许回合级兜底）、最新请求可测（数值）、最新请求不可测（`null`，显示 `-`）。
- planner、subagent、title 等非 executor usage 不参与前台请求吞吐计算。

### 事件顺序

测试覆盖两种真实顺序：

- `text/reasoning -> message -> usage`：`message` 暂存已关闭区间，供随后的 usage 配对。
- `partial tool_dispatch -> usage -> full tool_dispatch`：usage 关闭并计算活跃区间，随后到达的完整分派不会覆盖结果。

如果扩展 provider 只发送最终工具调用、没有任何输出开始信号，就不存在可靠时长；此时显示不可用，而不是保留旧 TPS。

## Issues

Refs #6931。

## 验证

- `use-controller-stream-progress.test.ts`：85 通过。
- `statusbar-workspace.test.tsx`：43 通过。
- `pnpm --dir desktop/frontend typecheck`：通过。
- `pnpm --dir desktop/frontend build`：通过，包括前端 lint、CSS 检查、TypeScript、Vite 和包体预算。
- `pnpm --dir desktop/frontend test:remote`：通过。
- `go run ./tools/repolint`：clean。
- `git diff --check`：通过。

## 文档影响

Documentation-impact: none - 未修改文档；现有工具提示已经描述了预期的逐请求行为。

## 缓存影响

Cache-impact: none - 仅修改前端 reducer 与 StatusBar 行为；provider 可见提示、工具 schema 和请求序列化均未改变。
Cache-guard: existing guard suites cover the untouched provider/tool surface.
System-prompt-review: N/A
