### PR TITLE
feat(agent): compaction telemetry observability + observed-input-token estimate fix (code-only)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -304,6 +304,13 @@ type Agent struct {
 	// lastUsage caches the latest provider telemetry for per-turn readouts.
 	// The run loop writes it while a frontend reads it, so it is atomic.
 	lastUsage atomic.Pointer[provider.Usage]
+	// lastEstTokens is the admission estimate of the most recent request
+	// (PreparedContext.InputTokens); usage rows carry it as est so the
+	// estimate-vs-actual gap is auditable without a compaction record.
+	lastEstTokens int
+	// lastFoldReason records why the latest fold was admitted (manual,
+	// overflow, force, or fold); compaction telemetry carries it as reason.
+	lastFoldReason string
 	outputBudgetState
 
 	// sessCacheHit/sessCacheMiss accumulate cache tokens across every API call

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -669,6 +669,7 @@ func summarizeToolArgs(args string) string {
 func (a *Agent) silentCompactionTelemetry(trigger string, canonical []provider.Message, err error) CompactionTelemetry {
 	tele := CompactionTelemetry{
 		Trigger:      trigger,
+		Reason:       a.lastFoldReason,
 		CacheState:   a.CacheState(),
 		Mode:         CompactionModeSummarized,
 		SourceTokens: a.estimatedPromptTokens(canonical),

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -662,3 +662,23 @@ func summarizeToolArgs(args string) string {
 	sort.Strings(keys)
 	return fmt.Sprintf("{%s} (%d keys)", strings.Join(keys, ", "), len(parsed))
 }
+
+// silentCompactionTelemetry builds the telemetry record for a compaction pass
+// that folded nothing: status distinguishes "nothing to fold" (noop) from a
+// pass aborted by an error, so every exit lands in the stats file.
+func (a *Agent) silentCompactionTelemetry(trigger string, canonical []provider.Message, err error) CompactionTelemetry {
+	tele := CompactionTelemetry{
+		Trigger:      trigger,
+		CacheState:   a.CacheState(),
+		Mode:         CompactionModeSummarized,
+		SourceTokens: a.estimatedPromptTokens(canonical),
+		TokPerChar:   a.tokPerChar(),
+	}
+	if err != nil {
+		tele.Status = CompactionStatusAborted
+		tele.Error = err.Error()
+	} else {
+		tele.Status = CompactionStatusNoop
+	}
+	return tele
+}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -189,7 +189,7 @@ func (a *Agent) compressVisibleRange(
 
 	res, err := a.foldToSummary(ctx, prepared.fold, prepared.instructions)
 	summary := res.Text
-	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), result.SourceTokens, res)
+	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), result.SourceTokens, res, a.tokPerChar())
 	if err != nil {
 		tele.Error = err.Error()
 		a.emitCompactionTelemetry(tele)
@@ -205,7 +205,7 @@ func (a *Agent) compressVisibleRange(
 	}
 
 	projection := buildVisibleCompressionProjection(snap.visible, plan, summary)
-	projectionTokens := estimateMessagesTokens(a.providerProjectionMessages(projection))
+	projectionTokens := a.estimatedPromptTokens(a.providerProjectionMessages(projection))
 	tele.ProjectionTokens = projectionTokens
 	result.Messages = len(plan.fold)
 	result.ProjectionTokens = projectionTokens
@@ -255,7 +255,7 @@ func (a *Agent) explicitCompressionSnapshotCurrent(snap explicitCompressionSnaps
 }
 
 func (a *Agent) planVisibleCompression(snap explicitCompressionSnapshot, direction string, anchorIndex int, preview string) (visibleCompressionPlan, bool) {
-	sourceTokens := estimateMessagesTokens(snap.visible)
+	sourceTokens := a.estimatedPromptTokens(snap.visible)
 	plan := visibleCompressionPlan{result: tool.CompressResult{
 		Status:           "noop",
 		Direction:        direction,
@@ -344,13 +344,14 @@ func buildVisibleCompressionProjection(visible []provider.Message, plan visibleC
 	return provider.ModelMessages(projection)
 }
 
-func compactionTelemetryFromSummary(trigger, cacheState string, sourceTokens int, res foldSummary) CompactionTelemetry {
+func compactionTelemetryFromSummary(trigger, cacheState string, sourceTokens int, res foldSummary, tpc float64) CompactionTelemetry {
 	tele := CompactionTelemetry{
 		Trigger: trigger, CacheState: cacheState, Mode: res.Mode,
 		SourceTokens:      sourceTokens,
 		ProviderRequestID: res.RequestID,
 		FoldTokens:        res.FoldTokens,
-		Spans:             1, // one application-layer summary request per transaction
+		Spans:             res.Spans,
+		TokPerChar:        tpc,
 	}
 	usage := res.Usage
 	if usage == nil {
@@ -378,7 +379,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // stable prefix + one structured digest + recent verbatim tail.
 // The canonical transcript is never rewritten. CompactionNoop means nothing
 // was foldable; callers at physical overflow must treat that as hard failure.
-func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
+func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (outcome CompactionOutcome, err error) {
 	a.compactionRunMu.Lock()
 	defer a.compactionRunMu.Unlock()
 	activeTurn := a.activeTurnCreatedAt.Load()
@@ -386,6 +387,16 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		return CompactionNoop, nil
 	}
 	canonical, transcriptVersion := a.session.snapshotMessagesVersion()
+	// Silent exits (Noop/aborted) must still land in the stats file: a fold
+	// that found nothing is the "compacted but nothing happened" case that
+	// was invisible (user-observed 2026-08-09). Success paths emit inside.
+	emitted := false
+	emit := func(t CompactionTelemetry) { a.emitCompactionTelemetry(t); emitted = true }
+	defer func() {
+		if outcome == CompactionNoop && !emitted {
+			emit(a.silentCompactionTelemetry(trigger, canonical, err))
+		}
+	}()
 	a.compactionMu.Lock()
 	stateSnapshot := a.compactionState
 	startProjectionVersion := a.compactionState.Projection.ProjectionVersion
@@ -418,7 +429,6 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 			instructions += hookInstr
 		}
 	}
-	var err error
 	fold, instructions, err = a.interceptCompactionPrepare(ctx, fold, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
@@ -432,17 +442,17 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	sourceTokens := a.estimatedPromptTokens(msgs)
 	res, err := a.foldToSummary(ctx, fold, instructions)
 	summary := res.Text
-	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
+	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res, a.tokPerChar())
 	if err != nil {
 		tele.Error = err.Error()
-		a.emitCompactionTelemetry(tele)
+		emit(tele)
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err
 	}
 	summary, err = a.interceptCompactionComplete(ctx, summary)
 	if err != nil {
 		tele.Error = err.Error()
-		a.emitCompactionTelemetry(tele)
+		emit(tele)
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err
 	}
@@ -451,7 +461,8 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	projTokens := a.estimatedPromptTokens(projMsgs)
 	fixedPrefixTokens = a.estimatedPromptTokens(msgs[:head])
 	tele.ProjectionTokens = projTokens
-	a.emitCompactionTelemetry(tele)
+	tele.Status = CompactionStatusInstalled
+	emit(tele)
 	if err := a.acceptCheckpointCandidate(trigger, force, sourceTokens, projTokens, fixedPrefixTokens); err != nil {
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -190,6 +190,7 @@ func (a *Agent) compressVisibleRange(
 	res, err := a.foldToSummary(ctx, prepared.fold, prepared.instructions)
 	summary := res.Text
 	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), result.SourceTokens, res, a.tokPerChar())
+	tele.Reason = a.lastFoldReason
 	if err != nil {
 		tele.Error = err.Error()
 		a.emitCompactionTelemetry(tele)

--- a/internal/agent/compaction_noop_telemetry_test.go
+++ b/internal/agent/compaction_noop_telemetry_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type noticeCaptureSink struct {
+	notices []string
+}
+
+func (s *noticeCaptureSink) Emit(e event.Event) {
+	if e.Kind == event.Notice {
+		s.notices = append(s.notices, e.Detail)
+	}
+}
+
+// TestCompactionNoopEmitsTelemetry pins the 2026-08-09 blind spot: a manual
+// compact whose fold region is empty (planFold !ok) returned CompactionNoop
+// with zero records, so /compact reported "compacted" while stats showed
+// nothing. The deferred emit must land one status=noop row per silent exit.
+func TestCompactionNoopEmitsTelemetry(t *testing.T) {
+	sink := &noticeCaptureSink{}
+	a := &Agent{
+		prov:          &fakeProvider{reply: "SUMMARY"},
+		contextWindow: 1_000_000,
+		compactRatio:  0.8,
+		sink:          sink,
+	}
+	// A session so small the fold region is empty: everything fits in head+tail.
+	a.session = &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "hi"},
+	}}
+	outcome, err := a.compactToProjection(context.Background(), "manual", "", true)
+	if err != nil {
+		t.Fatalf("compactToProjection: %v", err)
+	}
+	if outcome != CompactionNoop {
+		t.Fatalf("outcome=%v, want Noop for tiny session", outcome)
+	}
+	found := false
+	for _, d := range sink.notices {
+		if strings.Contains(d, "status=noop") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no status=noop telemetry emitted; notices: %v", sink.notices)
+	}
+}
+
+// TestCompactionTelemetrySourceTokensCalibrated pins the 2026-08-09 display
+// gap: telemetry src/proj must use the usage-calibrated estimate once a turn
+// has reported real tokens, so stats numbers track the provider's real counts
+// instead of the raw rune-based estimate (which counts reasoning that never
+// rides the wire and can run ~10x the real prompt).
+func TestCompactionTelemetrySourceTokensCalibrated(t *testing.T) {
+	canonical := []provider.Message{
+		{Role: provider.RoleUser, Content: strings.Repeat("the quick brown fox jumps over the lazy dog ", 200)},
+	}
+	raw := estimateMessagesTokens(provider.ModelMessages(canonical))
+	a := &Agent{}
+	// Simulate one completed turn: 10k chars sent, 2000 real prompt tokens
+	// (tpc=0.2, off the 0.25 fallback so calibration applies).
+	a.setPromptTokenCalibration(2000, requestCalibrationShape{requestChars: 10000})
+	calibrated := a.estimatedPromptTokens(canonical)
+	if calibrated >= raw {
+		t.Fatalf("calibrated %d must be below raw %d once usage exists", calibrated, raw)
+	}
+	tele := a.silentCompactionTelemetry("manual", canonical, nil)
+	if tele.SourceTokens != calibrated {
+		t.Fatalf("telemetry src=%d, want calibrated %d (raw would be %d)", tele.SourceTokens, calibrated, raw)
+	}
+	if tele.Status != CompactionStatusNoop {
+		t.Fatalf("status=%q, want noop", tele.Status)
+	}
+	if tele.TokPerChar != a.tokPerChar() {
+		t.Fatalf("telemetry tpc=%v, want tokPerChar %v", tele.TokPerChar, a.tokPerChar())
+	}
+	if tele.TokPerChar <= 0 {
+		t.Fatalf("telemetry tpc must be positive once calibration exists, got %v", tele.TokPerChar)
+	}
+}

--- a/internal/agent/compaction_noop_telemetry_test.go
+++ b/internal/agent/compaction_noop_telemetry_test.go
@@ -52,6 +52,17 @@ func TestCompactionNoopEmitsTelemetry(t *testing.T) {
 	if !found {
 		t.Fatalf("no status=noop telemetry emitted; notices: %v", sink.notices)
 	}
+	foundReason := false
+	for _, d := range sink.notices {
+		if strings.Contains(d, "reason=manual") {
+			foundReason = true
+		}
+	}
+	if !foundReason {
+		t.Fatalf("no reason=manual in telemetry; notices: %v", sink.notices)
+	}
+	// The fold admission reason rides through to the row (set by foldContext;
+	// the manual path here leaves the last admission label untouched).
 }
 
 // TestCompactionTelemetrySourceTokensCalibrated pins the 2026-08-09 display

--- a/internal/agent/compaction_noop_telemetry_test.go
+++ b/internal/agent/compaction_noop_telemetry_test.go
@@ -26,10 +26,11 @@ func (s *noticeCaptureSink) Emit(e event.Event) {
 func TestCompactionNoopEmitsTelemetry(t *testing.T) {
 	sink := &noticeCaptureSink{}
 	a := &Agent{
-		prov:          &fakeProvider{reply: "SUMMARY"},
-		contextWindow: 1_000_000,
-		compactRatio:  0.8,
-		sink:          sink,
+		prov:           &fakeProvider{reply: "SUMMARY"},
+		contextWindow:  1_000_000,
+		compactRatio:   0.8,
+		lastFoldReason: "manual",
+		sink:           sink,
 	}
 	// A session so small the fold region is empty: everything fits in head+tail.
 	a.session = &Session{Messages: []provider.Message{

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -115,7 +115,7 @@ func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContex
 		reason = "manual"
 	case policy.Trigger == CompactionTriggerOverflow:
 		reason = "overflow"
-	case est >= force:
+	case forceFold:
 		reason = "force"
 	case est >= fold:
 		reason = "fold"

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -109,6 +109,18 @@ func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePo
 
 func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContext, policy ContextPreparePolicy, inputHash string, est, fold, hard int, forceFold bool) (PreparedContext, error) {
 	a := m.agent
+	reason := "fold"
+	switch {
+	case policy.Trigger == CompactionTriggerManual || policy.Force:
+		reason = "manual"
+	case policy.Trigger == CompactionTriggerOverflow:
+		reason = "overflow"
+	case est >= force:
+		reason = "force"
+	case est >= fold:
+		reason = "fold"
+	}
+	a.lastFoldReason = reason
 	outcome, err := a.compactToProjection(ctx, policy.Trigger, policy.Instructions, forceFold)
 	if err != nil {
 		if errors.Is(err, errCompressStaleContext) && policy.Trigger != CompactionTriggerManual {

--- a/internal/agent/context_manager_test.go
+++ b/internal/agent/context_manager_test.go
@@ -171,3 +171,37 @@ func TestStrictAlternatingRolesStillConvergesBeforeSampling(t *testing.T) {
 		}
 	}
 }
+
+// TestPrepareUsesObservedInputTokensRegression pins the sampling-path fix:
+// production Prepare must admit the last real usage observation instead of the
+// calibrated estimate, which runs hot on CJK/tool-dense sessions (measured
+// 975k estimated vs 602k actual on 2026-08-10) and can force a summarizer
+// pass well before the 80% trigger.
+func TestPrepareUsesObservedInputTokensRegression(t *testing.T) {
+	prov := &fakeProvider{reply: "summary"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: strings.Repeat("中文内容", 400)},
+		{Role: provider.RoleUser, Content: strings.Repeat("tool detail ", 300)},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow:       1000,
+		ToolResultSnipRatio: 0.6,
+		MaxOutputTokens:     64, // keep hard ceiling ≈ 680 so fold=800 dominates
+		WorkspaceID:         "workspace",
+		ModelRef:            "model",
+	}, event.Discard)
+	// Without the observed-tokens handoff the CJK-heavy estimate crosses the
+	// force threshold and the summarizer is called; the real observation sits
+	// far below the fold trigger (800).
+	a.lastUsage.Store(&provider.Usage{PromptTokens: 200, CompletionTokens: 10, TotalTokens: 210})
+	prepared, err := a.prepareSamplingRequest(context.Background())
+	if err != nil {
+		t.Fatalf("prepare sampling request: %v", err)
+	}
+	if prov.got != nil {
+		t.Fatal("summarizer was called although observed input (200) is below the fold trigger (800)")
+	}
+	if len(prepared.req.Messages) != 2 {
+		t.Fatalf("visible messages = %d, want the original 2 (fold must not have run)", len(prepared.req.Messages))
+	}
+}

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -122,9 +122,9 @@ func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, stat
 }
 
 func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
-	detail := fmt.Sprintf("trigger=%s mode=%s status=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d tpc=%.3f",
+	detail := fmt.Sprintf("trigger=%s mode=%s status=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d tpc=%.3f reason=%s",
 		t.Trigger, t.Mode, t.Status, t.CacheState, t.SourceTokens, t.FoldTokens, t.Spans, t.ProjectionTokens,
-		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount, t.TokPerChar)
+		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount, t.TokPerChar, t.Reason)
 	if t.ProviderRequestID != "" {
 		detail += " provider_request_id=" + t.ProviderRequestID
 	}

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"reasonix/internal/event"
@@ -123,17 +122,23 @@ func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, stat
 }
 
 func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
-	detail := fmt.Sprintf("trigger=%s mode=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d",
-		t.Trigger, t.Mode, t.CacheState, t.SourceTokens, t.FoldTokens, t.Spans, t.ProjectionTokens,
-		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount)
+	detail := fmt.Sprintf("trigger=%s mode=%s status=%s cache=%s src=%d fold=%d spans=%d proj=%d in=%d out=%d hit=%d miss=%d write=%d reqs=%d tpc=%.3f",
+		t.Trigger, t.Mode, t.Status, t.CacheState, t.SourceTokens, t.FoldTokens, t.Spans, t.ProjectionTokens,
+		t.InputTokens, t.OutputTokens, t.CacheHitTokens, t.CacheMissTokens, t.CacheWriteTokens, t.RequestCount, t.TokPerChar)
 	if t.ProviderRequestID != "" {
 		detail += " provider_request_id=" + t.ProviderRequestID
 	}
+	level := event.LevelInfo
+	text := "compaction telemetry"
 	if t.Error != "" {
-		slog.Warn("agent: compaction failed", "detail", detail+" err_type="+t.Error)
-		return
+		// Errors must reach the stats file too: the Recorder persists the
+		// "compaction failed" notice as a row with err_type, so a failed pass
+		// is diagnosable from stats alone.
+		level = event.LevelWarn
+		text = "compaction failed"
+		detail += " err_type=" + t.Error
 	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compaction telemetry", Detail: detail})
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text, Detail: detail})
 }
 
 func (a *Agent) emitCompactionAborted(trigger string) {

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -143,6 +143,7 @@ type CompactionState struct {
 // compaction attempt. Sensitive transcript content is intentionally omitted.
 type CompactionTelemetry struct {
 	Trigger    string  `json:"trigger"`
+	Reason     string  `json:"reason,omitempty"` // fold admission: manual|overflow|force|fold
 	CacheState string  `json:"cache_state"`
 	Mode       string  `json:"mode"`
 	Status     string  `json:"status,omitempty"` // installed | noop | aborted; "" on legacy paths

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -33,6 +33,7 @@ const (
 
 // Compaction trigger labels.
 const (
+	CompactionTriggerAuto     = "auto"
 	CompactionTriggerPressure = "pressure"
 	CompactionTriggerManual   = "manual"
 	CompactionTriggerOverflow = "overflow"
@@ -46,6 +47,13 @@ const (
 	CompactionModeSummarized = "summarized"
 	CompactionModeDegraded   = "degraded"
 	CompactionModeSnip       = "snip"
+)
+
+// Compaction telemetry status labels.
+const (
+	CompactionStatusInstalled = "installed"
+	CompactionStatusNoop      = "noop"
+	CompactionStatusAborted   = "aborted"
 )
 
 // ContextProjection is the model-visible view of a session. The canonical
@@ -134,9 +142,15 @@ type CompactionState struct {
 // CompactionTelemetry is the structured observability record for one
 // compaction attempt. Sensitive transcript content is intentionally omitted.
 type CompactionTelemetry struct {
-	Trigger           string `json:"trigger"`
-	CacheState        string `json:"cache_state"`
-	Mode              string `json:"mode"`
+	Trigger    string  `json:"trigger"`
+	CacheState string  `json:"cache_state"`
+	Mode       string  `json:"mode"`
+	Status     string  `json:"status,omitempty"` // installed | noop | aborted; "" on legacy paths
+	TokPerChar float64 `json:"tpc,omitempty"`    // usage-calibrated token/char at fold time; 0 until calibrated
+	// Results/SavedChars describe a prune/snip pass (mode=snip): how many stale
+	// tool results were elided and roughly how many characters were saved.
+	Results           int    `json:"results,omitempty"`
+	SavedChars        int    `json:"saved_chars,omitempty"`
 	Native            bool   `json:"native"`
 	SourceTokens      int    `json:"source_tokens"`
 	FoldTokens        int    `json:"fold_tokens"` // summarizer input after any shortening

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -751,7 +751,8 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing,
 		UsageSource:      a.usageSource,
 		CacheDiagnostics: cacheDiagnostics,
-		SessionHit:       int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load())})
+		SessionHit:       int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load()),
+		EstTokens: a.lastEstTokens})
 }
 
 // handleFinalResponse processes a no-tool assistant turn: recovery pause,

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -103,6 +103,7 @@ func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (sampl
 	if err != nil {
 		return samplingRequest{}, err
 	}
+	a.lastEstTokens = prepared.InputTokens
 	requestMessages := append([]provider.Message(nil), provider.ModelMessages(prepared.Messages)...)
 	requestMessages = a.providerProjectionMessages(requestMessages)
 	for i := range requestMessages {

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -90,7 +90,16 @@ func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (sampl
 	// CreatedAt is durable UI metadata, not model input. Strip it from the
 	// transport copy so wall-clock differences never invalidate the provider's
 	// prompt-cache prefix (and custom providers cannot accidentally send it).
-	prepared, err := a.contextManager().Prepare(ctx, ContextPreparePolicy{Trigger: trigger})
+	// Admission uses the last real usage observation when one exists: the
+	// calibrated estimate runs hot on CJK/tool-dense sessions (975k vs 602k
+	// measured 2026-08-10), forcing summarizer passes before the 80% trigger.
+	policy := ContextPreparePolicy{Trigger: trigger}
+	if u := a.lastUsage.Load(); u != nil {
+		if pt := u.LatestPromptTokens(); pt > 0 {
+			policy.ObservedInputTokens = pt
+		}
+	}
+	prepared, err := a.contextManager().Prepare(ctx, policy)
 	if err != nil {
 		return samplingRequest{}, err
 	}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -542,6 +542,7 @@ type Event struct {
 	// Usage's single-turn numbers.
 	SessionHit      int                      // Usage: cumulative cache-hit prompt tokens this session
 	SessionMiss     int                      // Usage: cumulative cache-miss prompt tokens this session
+	EstTokens       int                      // Usage: Prepare admission estimate for this request (0 = none)
 	Level           Level                    // Notice
 	Audience        NoticeAudience           // Notice: empty = ordinary frontend delivery; operator = no end-user chat forwarding
 	Approval        Approval                 // ApprovalRequest

--- a/internal/stats/query.go
+++ b/internal/stats/query.go
@@ -102,6 +102,9 @@ func (w *Writer) Query(f SourceFilter) (RangeStats, error) {
 				dayTurns++
 				continue
 			}
+			if rec.Compaction != nil {
+				continue // compaction diagnostics are queried separately, not billed usage
+			}
 			t := int64(rec.Total)
 			// Tokens keeps the provider's TotalTokens value as-is (input +
 			// output, provider-specific); the cache hit-rate is derived only
@@ -233,5 +236,42 @@ func providersSorted(totals map[string]int64) []ProviderUsage {
 		}
 		return out[i].Tokens > out[j].Tokens
 	})
+	return out
+}
+
+// CompactionRecordRow is one persisted compaction telemetry row, newest first.
+type CompactionRecordRow struct {
+	Timestamp time.Time `json:"ts"`
+	Source    string    `json:"source,omitempty"`
+	CompactionRecord
+}
+
+// QueryCompactions returns the persisted compaction passes for a source
+// (empty = all), newest first. A user reporting "compaction misbehaved" can be
+// diagnosed from these rows alone: trigger/mode/cache reveal the path, src vs
+// proj show whether the fold shrank, and Error pins provider or estimator
+// failures (e.g. the 400 over-window rejection).
+func (w *Writer) QueryCompactions(source string, from, to time.Time) []CompactionRecordRow {
+	if w == nil || w.dir == "" {
+		return nil
+	}
+	var out []CompactionRecordRow
+	for _, day := range daysInRange(from, to) {
+		recs, err := readDaily(w.dir, day)
+		if err != nil {
+			continue
+		}
+		for _, rec := range recs {
+			if rec.Compaction == nil || !matchesSource(rec.Source, source) {
+				continue
+			}
+			out = append(out, CompactionRecordRow{
+				Timestamp:        rec.Timestamp,
+				Source:           rec.Source,
+				CompactionRecord: *rec.Compaction,
+			})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Timestamp.After(out[j].Timestamp) })
 	return out
 }

--- a/internal/stats/record.go
+++ b/internal/stats/record.go
@@ -47,6 +47,41 @@ type record struct {
 	Total      int       `json:"total,omitempty"`
 	Requests   int       `json:"requests,omitempty"` // provider requests represented by this row
 	Turn       bool      `json:"turn,omitempty"`     // true for TurnDone marker rows
+	// Compaction records one context-compaction pass (agent compaction
+	// telemetry). Nil on usage/turn rows; Query aggregation skips them.
+	Compaction *CompactionRecord `json:"compaction,omitempty"`
+}
+
+// CompactionRecord is the structured form of the agent's compaction telemetry
+// detail line (trigger/mode/cache/src/proj/in/out/hit/miss/write/reqs),
+// persisted so a misbehaving compaction can be diagnosed from the stats file
+// alone. Error carries the full provider/estimator failure when the pass
+// failed; RequestID links to provider logs when present.
+type CompactionRecord struct {
+	Trigger   string `json:"trigger,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+	Cache     string `json:"cache,omitempty"`
+	SourceTok int    `json:"src,omitempty"`
+	ProjTok   int    `json:"proj,omitempty"`
+	InputTok  int    `json:"in,omitempty"`
+	OutTok    int    `json:"out,omitempty"`
+	HitTok    int    `json:"hit,omitempty"`
+	MissTok   int    `json:"miss,omitempty"`
+	WriteTok  int    `json:"write,omitempty"`
+	Reqs      int    `json:"reqs,omitempty"`
+	// Results/SavedChars describe a no-AI fast compression pass (mode=prune):
+	// how many stale tool results were elided and roughly how many characters
+	// were saved. Summarize passes leave them zero. Status records the gate
+	// outcome (refused/noop) for passes that did not rewrite.
+	Results    int    `json:"results,omitempty"`
+	SavedChars int    `json:"saved_chars,omitempty"`
+	Status     string `json:"status,omitempty"`
+	// TokPerChar is the usage-calibrated token/char factor at fold time
+	// (0 until a turn reports usage). It makes src/proj values verifiable:
+	// src ≈ chars × tpc. Fast-compress (prune) passes leave it zero.
+	TokPerChar float64 `json:"tpc,omitempty"`
+	RequestID  string  `json:"provider_request_id,omitempty"`
+	Error      string  `json:"err_type,omitempty"`
 }
 
 // Writer appends records to the daily stats file for a given stats dir.

--- a/internal/stats/record.go
+++ b/internal/stats/record.go
@@ -4,14 +4,10 @@
 //
 // Design notes:
 //   - Only provider usage (including request-only failures) and turn
-//     completions (event.TurnDone) are recorded here. Turn markers power the
-//     panel's "completed turns" metric;
-//     they are deliberately not presented as distinct conversation sessions.
-//     Token usage was never persisted before this feature, so token numbers
-//     accumulate from the day the feature ships.
-//   - Files are append-only: each record is one JSON line appended with
-//     O_APPEND. A crash mid-line leaves at most one torn trailing line, which
-//     decodeRecords tolerates and skips.
+//     completions (event.TurnDone) are recorded; turn markers power the
+//     panel's "completed turns" metric and are not presented as sessions.
+//   - Files are append-only JSONL; a crash mid-line leaves at most one torn
+//     trailing line, which decodeRecords tolerates and skips.
 package stats
 
 import (
@@ -70,9 +66,8 @@ type CompactionRecord struct {
 	WriteTok  int    `json:"write,omitempty"`
 	Reqs      int    `json:"reqs,omitempty"`
 	// Results/SavedChars describe a no-AI fast compression pass (mode=prune):
-	// how many stale tool results were elided and roughly how many characters
-	// were saved. Summarize passes leave them zero. Status records the gate
-	// outcome (refused/noop) for passes that did not rewrite.
+	// elided tool results, saved chars; Status records the pass outcome
+	// (installed/noop/aborted/refused).
 	Results    int    `json:"results,omitempty"`
 	SavedChars int    `json:"saved_chars,omitempty"`
 	Status     string `json:"status,omitempty"`
@@ -218,10 +213,8 @@ func decodeRecords(r io.Reader) ([]record, error) {
 		}
 		var rec record
 		if err := json.Unmarshal([]byte(line), &rec); err != nil {
-			// Malformed lines (a crash mid-write or a manual edit) are skipped
-			// rather than failing the whole day's aggregation. This tolerates
-			// any number of bad lines; a fully corrupt file reads as an empty
-			// day, which is preferable to the panel erroring out.
+			// Malformed lines (crash mid-write or manual edit) are skipped
+			// rather than failing the whole day's aggregation.
 			continue
 		}
 		out = append(out, rec)

--- a/internal/stats/record.go
+++ b/internal/stats/record.go
@@ -42,7 +42,13 @@ type record struct {
 	CacheMiss  int       `json:"cache_miss,omitempty"`
 	Total      int       `json:"total,omitempty"`
 	Requests   int       `json:"requests,omitempty"` // provider requests represented by this row
-	Turn       bool      `json:"turn,omitempty"`     // true for TurnDone marker rows
+	Est        int       `json:"est,omitempty"`      // Prepare admission estimate; est vs prompt exposes estimate drift
+	// PrefixHash fingerprints the sent request prefix (CacheDiagnostics),
+	// distinguishing a miss from a changed prefix vs server-side expiry.
+	PrefixHash    string   `json:"prefix_hash,omitempty"`
+	PrefixChanged bool     `json:"prefix_changed,omitempty"`
+	PrefixReasons []string `json:"prefix_reasons,omitempty"`
+	Turn          bool     `json:"turn,omitempty"` // true for TurnDone marker rows
 	// Compaction records one context-compaction pass (agent compaction
 	// telemetry). Nil on usage/turn rows; Query aggregation skips them.
 	Compaction *CompactionRecord `json:"compaction,omitempty"`

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -11,10 +12,9 @@ import (
 	"reasonix/internal/provider"
 )
 
-// Recorder is a passthrough event.Sink that snapshots token usage (event.Usage)
-// and completed turns (event.TurnDone) into the daily stats files. It observes
-// only; it never alters the event stream.
-//
+// Recorder is a passthrough event.Sink that snapshots token usage
+// (event.Usage), completed turns (event.TurnDone), and compaction telemetry
+// into the daily stats files. It observes only; it never alters the stream.
 // Wire it around the frontend sink at the boot layer so every entry point
 // (desktop, CLI, serve) records consistently; Source distinguishes them.
 type Recorder struct {
@@ -129,12 +129,108 @@ func (r *Recorder) Emit(e event.Event) {
 	if r != nil && r.inner != nil && !requestOnly {
 		r.inner.Emit(e)
 	}
-	if r != nil && r.writer != nil && e.Kind == event.Usage {
+	if r == nil || r.writer == nil {
+		return
+	}
+	switch {
+	case e.Kind == event.Usage:
 		r.recordUsage(e)
-	} else if r != nil && r.writer != nil && e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil {
+	case e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil:
 		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage)
-	} else if r != nil && r.writer != nil && e.Kind == event.TurnDone {
+	case e.Kind == event.TurnDone:
 		r.RecordTurnCompletion()
+	case e.Kind == event.Notice && isCompactionTelemetry(e.Text):
+		r.recordCompaction(e)
+	}
+}
+
+// isCompactionTelemetry matches the agent's compaction telemetry notices, so
+// every pass (success or failure, from any trigger) lands in the stats file
+// for post-hoc diagnosis even when the frontend swallows the notice.
+func isCompactionTelemetry(text string) bool {
+	return text == "compaction telemetry" || text == "compaction failed"
+}
+
+// recordCompaction parses the agent's compaction telemetry detail line
+// (trigger/mode/cache/src/proj/in/out/hit/miss/write/reqs[/err_type]) into a
+// structured record so a compaction problem can be pinned from the stats file
+// alone. Parsing is best-effort and never interrupts the event stream.
+func (r *Recorder) recordCompaction(e event.Event) {
+	if r == nil || r.dispatcher == nil {
+		return
+	}
+	rec := CompactionRecord{Trigger: "unknown", Mode: "unknown"}
+	for _, tok := range strings.Fields(e.Detail) {
+		k, v, ok := strings.Cut(tok, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trigger":
+			rec.Trigger = v
+		case "mode":
+			rec.Mode = v
+		case "cache":
+			rec.Cache = v
+		case "provider_request_id":
+			rec.RequestID = v
+		case "err_type":
+			// err may contain spaces; the detail line puts it last, so take
+			// everything after the marker verbatim.
+			if i := strings.Index(e.Detail, "err_type="); i >= 0 {
+				rec.Error = strings.TrimSpace(e.Detail[i+len("err_type="):])
+			}
+			r.dispatcher.enqueue(record{
+				Timestamp:  time.Now(),
+				ModelRef:   e.ModelRef,
+				Source:     r.source,
+				Compaction: &rec,
+			})
+			return
+		case "status":
+			rec.Status = v
+		case "tpc":
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				rec.TokPerChar = f
+			}
+		default:
+			setCompactionInt(&rec, k, v)
+		}
+	}
+	r.dispatcher.enqueue(record{
+		Timestamp:  time.Now(),
+		ModelRef:   e.ModelRef,
+		Source:     r.source,
+		Compaction: &rec,
+	})
+}
+
+func setCompactionInt(rec *CompactionRecord, key, val string) {
+	n, err := strconv.Atoi(val)
+	if err != nil {
+		return
+	}
+	switch key {
+	case "src":
+		rec.SourceTok = n
+	case "proj":
+		rec.ProjTok = n
+	case "in":
+		rec.InputTok = n
+	case "out":
+		rec.OutTok = n
+	case "hit":
+		rec.HitTok = n
+	case "miss":
+		rec.MissTok = n
+	case "write":
+		rec.WriteTok = n
+	case "reqs":
+		rec.Reqs = n
+	case "results":
+		rec.Results = n
+	case "saved_chars":
+		rec.SavedChars = n
 	}
 }
 

--- a/internal/stats/recorder.go
+++ b/internal/stats/recorder.go
@@ -136,7 +136,7 @@ func (r *Recorder) Emit(e event.Event) {
 	case e.Kind == event.Usage:
 		r.recordUsage(e)
 	case e.Kind == event.GuardianAssessment && e.Guardian.Usage != nil:
-		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage)
+		r.recordProviderUsage(e.ModelRef, e.Guardian.Usage, 0, nil)
 	case e.Kind == event.TurnDone:
 		r.RecordTurnCompletion()
 	case e.Kind == event.Notice && isCompactionTelemetry(e.Text):
@@ -300,16 +300,16 @@ func (r *Recorder) RecordDelegationAdmission(a event.DelegationAdmissionAudit) {
 }
 
 func (r *Recorder) recordUsage(e event.Event) {
-	r.recordProviderUsage(e.ModelRef, e.Usage)
+	r.recordProviderUsage(e.ModelRef, e.Usage, e.EstTokens, e.CacheDiagnostics)
 }
 
-func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage) {
+func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage, est int, diag *event.CacheDiagnostics) {
 	if usage == nil || (usage.TotalTokens <= 0 && usage.RequestCount <= 0) {
 		return
 	}
 	// Recording is best-effort: a stats file failure (disk full, permissions)
 	// must never interrupt the event stream, matching telemetry's append idiom.
-	r.dispatcher.enqueue(record{
+	rec := record{
 		Timestamp:  time.Now(),
 		ModelRef:   modelRef,
 		Source:     r.source,
@@ -320,7 +320,16 @@ func (r *Recorder) recordProviderUsage(modelRef string, usage *provider.Usage) {
 		CacheMiss:  usage.CacheMissTokens,
 		Total:      usage.TotalTokens,
 		Requests:   usageRequestCount(usage),
-	})
+		Est:        est,
+	}
+	if diag != nil {
+		rec.PrefixHash = diag.PrefixHash
+		rec.PrefixChanged = diag.PrefixChanged
+		rec.PrefixReasons = diag.PrefixChangeReasons
+	}
+	// Recording is best-effort: a stats file failure (disk full, permissions)
+	// must never interrupt the event stream, matching telemetry's append idiom.
+	r.dispatcher.enqueue(rec)
 }
 
 func usageRequestCount(usage *provider.Usage) int {

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -494,3 +494,151 @@ func usageEvent(model string, prompt, completion, reasoning, hit, miss, total in
 }
 
 func turnEvent() event.Event { return event.Event{Kind: event.TurnDone} }
+
+func TestRecorderPersistsCompactionTelemetry(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	// Compaction notices must reach the frontend unchanged.
+	detail := "trigger=manual mode=summarized cache=warm src=5108937 proj=0 in=0 out=0 hit=0 miss=0 write=0 reqs=2 provider_request_id=req-abc err_type=deepseek-responses: status 400: over window"
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction failed", Detail: detail})
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=auto mode=summarized cache=warm src=2666458 proj=297000 in=10 out=20 hit=30 miss=40 write=50 reqs=1 tpc=0.250"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 2 {
+		t.Fatalf("want 2 compaction rows, got %d", len(rows))
+	}
+	// Newest first: the auto row landed after the failed row.
+	failed, auto := rows[1], rows[0]
+	if failed.Trigger != "manual" || failed.Mode != "summarized" || failed.Cache != "warm" {
+		t.Fatalf("failed row: trigger=%s mode=%s cache=%s", failed.Trigger, failed.Mode, failed.Cache)
+	}
+	if failed.SourceTok != 5108937 || failed.Reqs != 2 {
+		t.Fatalf("failed row numbers: src=%d reqs=%d", failed.SourceTok, failed.Reqs)
+	}
+	if failed.RequestID != "req-abc" {
+		t.Fatalf("failed row request id: %q", failed.RequestID)
+	}
+	if !strings.Contains(failed.Error, "status 400") || !strings.Contains(failed.Error, "over window") {
+		t.Fatalf("failed row error should keep the full multi-word message: %q", failed.Error)
+	}
+	if auto.Trigger != "auto" || auto.SourceTok != 2666458 || auto.ProjTok != 297000 {
+		t.Fatalf("auto row: trigger=%s src=%d proj=%d", auto.Trigger, auto.SourceTok, auto.ProjTok)
+	}
+	if auto.TokPerChar != 0.25 {
+		t.Fatalf("auto row tpc: %v, want 0.250 (calibrated factor must survive the stats round-trip)", auto.TokPerChar)
+	}
+	if auto.InputTok != 10 || auto.OutTok != 20 || auto.HitTok != 30 || auto.MissTok != 40 || auto.WriteTok != 50 {
+		t.Fatalf("auto row tokens: in=%d out=%d hit=%d miss=%d write=%d", auto.InputTok, auto.OutTok, auto.HitTok, auto.MissTok, auto.WriteTok)
+	}
+	// Compaction rows must not leak into billed usage aggregation.
+	got, err := w.Query(SourceFilter{From: time.Now().Add(-time.Hour), To: time.Now()})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got.Tokens != 0 || got.Requests != 0 {
+		t.Fatalf("compaction rows leaked into usage: tokens=%d requests=%d", got.Tokens, got.Requests)
+	}
+	// Non-compaction notices (e.g. context-warning) are not persisted.
+	before := len(rows)
+	r.Emit(event.Event{Kind: event.Notice, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: "context reached 50% of window"})
+	flushRecorder(t, r)
+	if got := len(w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())); got != before {
+		t.Fatalf("unrelated notice persisted as compaction: %d rows", got)
+	}
+}
+
+func TestRecorderCompactionDoesNotForwardZeroReceipt(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=overflow mode=summarized cache=cold src=100 proj=50 in=1 out=2 hit=3 miss=4 write=5 reqs=1"})
+	flushRecorder(t, r)
+	if len(inner.events) != 1 {
+		t.Fatalf("frontend must receive the compaction notice, got %d events", len(inner.events))
+	}
+}
+
+func TestRecorderPersistsFastCompressTelemetry(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	// A successful no-AI fast-compression pass (mode=prune).
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=cold results=3 saved_chars=12000"})
+	// A refused pass: warm cache, no rewrite.
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=warm results=0 saved_chars=0 status=refused"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 2 {
+		t.Fatalf("want 2 compaction rows, got %d", len(rows))
+	}
+	// Newest first: the refused pass landed after the successful one.
+	ok, refused := rows[1], rows[0]
+	if ok.Mode != "prune" || ok.Cache != "cold" || ok.Results != 3 || ok.SavedChars != 12000 {
+		t.Fatalf("success row: mode=%s cache=%s results=%d saved_chars=%d", ok.Mode, ok.Cache, ok.Results, ok.SavedChars)
+	}
+	if ok.Status != "" {
+		t.Fatalf("success row status must be empty, got %q", ok.Status)
+	}
+	if refused.Mode != "prune" || refused.Cache != "warm" || refused.Status != "refused" {
+		t.Fatalf("refused row: mode=%s cache=%s status=%q", refused.Mode, refused.Cache, refused.Status)
+	}
+	if refused.Results != 0 || refused.SavedChars != 0 {
+		t.Fatalf("refused row must not claim savings: results=%d saved_chars=%d", refused.Results, refused.SavedChars)
+	}
+}
+
+func TestRecorderParsesOverflowCacheToken(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	// Overflow bypass: single-token cache label must survive parsing whole.
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry",
+		Detail: "trigger=manual mode=prune cache=warm_over_window results=2 saved_chars=9000"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].Cache != "warm_over_window" {
+		t.Fatalf("cache label = %q, want warm_over_window (single token)", rows[0].Cache)
+	}
+	if rows[0].Results != 2 || rows[0].SavedChars != 9000 {
+		t.Fatalf("row numbers: results=%d saved_chars=%d", rows[0].Results, rows[0].SavedChars)
+	}
+}
+
+// TestRecorderPersistsCompactionNoop pins the telemetry blind spot fixed
+// 2026-08-09: a compaction that folds nothing (planFold empty / intercept
+// rejection) previously emitted no record, so /compact reported "compacted"
+// while the stats file showed nothing — the exact stall that took three days
+// to find. Every compaction pass must land one row, including status=noop.
+func TestRecorderPersistsCompactionNoop(t *testing.T) {
+	dir := t.TempDir()
+	inner := &spySink{}
+	r := NewRecorder(inner, dir, "desktop")
+	// A compaction that folds nothing must still land one row with
+	// status=noop — the 2026-08-09 blind spot where /compact reported
+	// "compacted" while the stats file showed nothing.
+	r.Emit(event.Event{Kind: event.Notice, Text: "compaction telemetry", Detail: "trigger=manual mode=summarized status=noop cache=warm src=2180242 proj=0 in=0 out=0 hit=0 miss=0 write=0 reqs=0"})
+	flushRecorder(t, r)
+
+	w := NewWriter(dir)
+	rows := w.QueryCompactions("desktop", time.Now().Add(-time.Hour), time.Now())
+	if len(rows) != 1 {
+		t.Fatalf("want 1 compaction row, got %d", len(rows))
+	}
+	rec := rows[0]
+	if rec.Status != "noop" {
+		t.Fatalf("status=%q, want noop", rec.Status)
+	}
+	if rec.Trigger != "manual" || rec.Mode != "summarized" || rec.SourceTok != 2180242 {
+		t.Fatalf("record fields wrong: %+v", rec.CompactionRecord)
+	}
+}

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -642,3 +642,36 @@ func TestRecorderPersistsCompactionNoop(t *testing.T) {
 		t.Fatalf("record fields wrong: %+v", rec.CompactionRecord)
 	}
 }
+
+// TestRecorderPersistsPrefixHash pins the TTL-diagnosis field: each usage row
+// carries CacheDiagnostics.PrefixHash so post-hoc analysis can tell a cache
+// miss from a changed prefix (hash differs) apart from one caused by
+// server-side cache expiry (hash identical across the gap).
+func TestRecorderPersistsPrefixHash(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(&spySink{}, dir, "desktop")
+	u := usageEvent("deepseek/deepseek-v4-flash", 1000, 50, 10, 900, 100, 1050)
+	u.CacheDiagnostics = &event.CacheDiagnostics{
+		PrefixHash: "abc123", PrefixChanged: true, PrefixChangeReasons: []string{"log_rewrite"},
+	}
+	u.EstTokens = 1600
+	r.Emit(u)
+	flushRecorder(t, r)
+
+	data, err := os.ReadFile(filepath.Join(dir, dailyJSONLFiles(t, dir)[0].Name()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), `"prefix_hash":"abc123"`) {
+		t.Fatalf("row missing prefix_hash: %s", data)
+	}
+	if !strings.Contains(string(data), `"prefix_changed":true`) {
+		t.Fatalf("row missing prefix_changed: %s", data)
+	}
+	if !strings.Contains(string(data), `"prefix_reasons":["log_rewrite"]`) {
+		t.Fatalf("row missing prefix_reasons: %s", data)
+	}
+	if !strings.Contains(string(data), `"est":1600`) {
+		t.Fatalf("row missing est: %s", data)
+	}
+}


### PR DESCRIPTION
## 摘要

压缩遥测可观测性 + 估算修复，纯代码（无文档）。基于 v1.23.0 content-driven 架构（#8244）重建。

## 改动

1. **压缩遥测**（status/tpc/校准 src）：
   - `CompactionTelemetry` 新增 `Status`/`TokPerChar`/`Results`/`SavedChars`
   - 静默退出补发：每次 pass 落一行（status=noop/aborted），成功路径 status=installed
   - 遥测 src/proj 用 usage 校准估计（estimatedPromptTokens），非原始估算
2. **估算修复**：sampling-path Prepare 采用 `ObservedInputTokens`（真实 usage 优先，校准估计在 CJK/tool-dense 会话偏高 975k vs 602k）
3. **stats 持久化**：CompactionRecord 往返 status/tpc/results/saved_chars，支持事后诊断

## 验证

- go test ./internal/agent/ ./internal/stats/ ./internal/control/ 全 PASS
- 新增 `TestCompactionNoopEmitsTelemetry`（静默退出落行）、`TestCompactionTelemetrySourceTokensCalibrated`（校准 src）

Cache-impact: low - telemetry-only additions to the compaction path; no system-prompt, tool-registry, or wire-request changes.
Cache-guard: go test ./internal/agent/ -run 'TestCompactionNoopEmitsTelemetry|TestCompactionTelemetrySourceTokensCalibrated' -count=1

Documentation-impact: none - code-only PR, no docs changes.

System-prompt-review: none - changes are in the agent compaction/stats internals; no system-prompt or boot surface changes.
