### PR TITLE
fix(agent): a failed summary must not strand the turn

### DIFF
--- a/internal/agent/compact_fold_input.go
+++ b/internal/agent/compact_fold_input.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
 
@@ -107,6 +109,48 @@ func (a *Agent) singleCallSummary(ctx context.Context, res foldSummary, fold []p
 	summary, mode, usage, reqID, err := a.runCompactionSummary(ctx, fold, instructions)
 	res.Text, res.Mode, res.Usage, res.RequestID = summary, mode, usage, reqID
 	return res, err
+}
+
+// foldOrDegrade summarizes a fold and, when that fold is the only way out,
+// converts a summarizer failure into a mechanical one. The telemetry it returns
+// always reports the original failure, even when the fold recovered from it.
+func (a *Agent) foldOrDegrade(ctx context.Context, trigger string, mustFree bool, fold []provider.Message, instructions string, sourceTokens int) (foldSummary, CompactionTelemetry, error) {
+	res, err := a.foldToSummary(ctx, fold, instructions)
+	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
+	if err == nil {
+		return res, tele, nil
+	}
+	cause := err.Error()
+	if res, err = a.degradeFoldSummary(res, mustFree, fold, err); err != nil {
+		tele.Error = cause
+		return res, tele, err
+	}
+	tele = compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
+	tele.Error = cause
+	return res, tele, nil
+}
+
+// mechanicalFoldDigest stands in for a digest the summarizer could not produce.
+// Saying the summary is missing is what stops the model reading the gap as
+// "nothing was there" and inventing what the folded turns contained.
+func mechanicalFoldDigest(n int) string {
+	return fmt.Sprintf("%d earlier message(s) were folded here to free context, but the automatic summary was unavailable. Ask the user if you need details from before this point.", n)
+}
+
+// degradeFoldSummary turns a summarizer failure into a mechanical fold only
+// where that fold is the only way out; below the ceiling the turn still goes
+// out, so the error is kept and a recoverable view is not folded blind.
+// Cancellation is the caller's decision, never a summarizer failure.
+func (a *Agent) degradeFoldSummary(res foldSummary, mustFree bool, fold []provider.Message, cause error) (foldSummary, error) {
+	if !mustFree || errors.Is(cause, context.Canceled) {
+		return res, cause
+	}
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text:   "Context was compacted without a generated summary.",
+		Detail: fmt.Sprintf("compaction summary unavailable (%v); folded mechanically", cause)})
+	res.Text = mechanicalFoldDigest(len(fold))
+	res.Mode = CompactionModeDegraded
+	return res, nil
 }
 
 // shortenFoldForSummary rewrites only summarizer input: long tool bodies become

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -370,7 +370,7 @@ func compactionTelemetryFromSummary(trigger, cacheState string, sourceTokens int
 
 // compact writes a context projection; trigger stays "auto"/"manual" for UI cards.
 func (a *Agent) compact(ctx context.Context, trigger, instructions string, force bool) error {
-	_, err := a.compactToProjection(ctx, trigger, instructions, force)
+	_, err := a.compactToProjection(ctx, trigger, instructions, force, false)
 	return err
 }
 
@@ -378,7 +378,8 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // stable prefix + one structured digest + recent verbatim tail.
 // The canonical transcript is never rewritten. CompactionNoop means nothing
 // was foldable; callers at physical overflow must treat that as hard failure.
-func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force bool) (CompactionOutcome, error) {
+// mustFree marks the fold the caller cannot proceed without.
+func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force, mustFree bool) (CompactionOutcome, error) {
 	a.compactionRunMu.Lock()
 	defer a.compactionRunMu.Unlock()
 	activeTurn := a.activeTurnCreatedAt.Load()
@@ -430,16 +431,13 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	}
 
 	sourceTokens := a.estimatedPromptTokens(msgs)
-	res, err := a.foldToSummary(ctx, fold, instructions)
-	summary := res.Text
-	tele := compactionTelemetryFromSummary(trigger, a.CacheState(), sourceTokens, res)
+	res, tele, err := a.foldOrDegrade(ctx, trigger, mustFree, fold, instructions, sourceTokens)
 	if err != nil {
-		tele.Error = err.Error()
 		a.emitCompactionTelemetry(tele)
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err
 	}
-	summary, err = a.interceptCompactionComplete(ctx, summary)
+	summary, err := a.interceptCompactionComplete(ctx, res.Text)
 	if err != nil {
 		tele.Error = err.Error()
 		a.emitCompactionTelemetry(tele)

--- a/internal/agent/compact_summary_failure_test.go
+++ b/internal/agent/compact_summary_failure_test.go
@@ -1,0 +1,192 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// foldableSessionOverForce builds a transcript whose bulk is assistant text, so
+// the free prune pass cannot reclaim it and Prepare must reach the summarizer.
+func foldableSessionOverForce(turns int) *Session {
+	big := strings.Repeat("word ", 400)
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "standing constraint: never change the public API"},
+	}
+	for range turns {
+		msgs = append(msgs,
+			provider.Message{Role: provider.RoleAssistant, Content: big},
+			provider.Message{Role: provider.RoleUser, Content: "continue"},
+		)
+	}
+	return &Session{Messages: msgs}
+}
+
+func agentOverForce(t *testing.T, prov provider.Provider, sess *Session) *Agent {
+	t.Helper()
+	return agentOverForceWindow(t, prov, sess, 5000)
+}
+
+// agentOverForceWindow sits the session above the force ratio. A folded
+// transcript lands back under the trigger, so a blocked turn can only mean the
+// fold itself failed.
+func agentOverForceWindow(t *testing.T, prov provider.Provider, sess *Session, window int) *Agent {
+	t.Helper()
+	return New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow:     window,
+		CompactRatio:      0.5,
+		CompactForceRatio: 0.5,
+		RecentKeep:        2,
+		ArchiveDir:        t.TempDir(),
+	}, event.Discard)
+}
+
+// degradedFold reports whether a fold was committed with the mechanical digest
+// standing in for the summary. The receipt is the host record that the
+// projection was installed; the digest text is what the model is actually told.
+func degradedFold(a *Agent) bool {
+	r := a.compactionState.LastReceipt
+	return r != nil && r.Status == "applied" &&
+		strings.Contains(latestDigest(a.compactionState.Projection.Messages), "summary was unavailable")
+}
+
+func prepareContext(ctx context.Context, a *Agent, trigger string) error {
+	_, err := a.contextManager().Prepare(ctx, ContextPreparePolicy{Trigger: trigger})
+	return err
+}
+
+// foldRegionOf is the region the next compaction would hand the summarizer.
+func foldRegionOf(a *Agent) []provider.Message {
+	canonical, version := a.session.snapshotMessagesVersion()
+	msgs := a.visibleInputForFold(a.compactionState, canonical, version)
+	head, start, ok := a.planFoldRegion(msgs, false)
+	if !ok {
+		return nil
+	}
+	_, _, _, fold := a.partitionFoldForProjection(msgs[head:start])
+	return fold
+}
+
+// latestDigest returns the text of the last compaction digest in a projection.
+func latestDigest(msgs []provider.Message) string {
+	for _, m := range slices.Backward(msgs) {
+		if isCompactionSummary(m) {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// projectionTokens reports what the model would actually see.
+func projectionTokens(a *Agent) int {
+	msgs, _ := a.session.snapshotMessagesVersion()
+	return estimateMessagesTokens(provider.ModelMessages(modelVisibleFromProjection(a.compactionState.Projection, msgs)))
+}
+
+// The 90s summary bound is deliberately not retried, so a summarizer that never
+// answers is the original reason a mechanical fold exists. Where the fold is the
+// only way out, its timeout must free the context rather than strand the turn.
+func TestSummarizerTimeoutWhereFoldIsTheOnlyWayOutDegrades(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	a := agentOverForce(t, &fakeProvider{hang: true}, sess)
+	before := estimateMessagesTokens(provider.ModelMessages(sess.Messages))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	if err := prepareContext(ctx, a, CompactionTriggerOverflow); err != nil {
+		t.Fatalf("prepare = %v, want a degraded fold instead of a hard failure", err)
+	}
+	after := projectionTokens(a)
+	t.Logf("degraded fold: est %d -> %d tokens", before, after)
+	if after >= before {
+		t.Fatalf("degraded fold freed no context: %d -> %d", before, after)
+	}
+	if !degradedFold(a) {
+		t.Errorf("no degraded fold committed: receipt=%+v digest=%q",
+			a.compactionState.LastReceipt, latestDigest(a.compactionState.Projection.Messages))
+	}
+}
+
+// Overflow is the trigger that reports ErrCompactionRequired, so it is where a
+// failed summary turns into "context exceeds provider limit and compaction
+// failed" and blocks every further message. A mechanical fold answers it.
+func TestOverflowSummarizerFailureDegradesInsteadOfBlockingTheTurn(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	a := agentOverForce(t, &fakeProvider{streamErr: errors.New("provider down")}, sess)
+	before := estimateMessagesTokens(provider.ModelMessages(sess.Messages))
+
+	if err := prepareContext(context.Background(), a, CompactionTriggerOverflow); err != nil {
+		t.Fatalf("prepare = %v, want a degraded fold instead of ErrCompactionRequired", err)
+	}
+	if after := projectionTokens(a); after >= before {
+		t.Fatalf("degraded fold freed no context: %d -> %d", before, after)
+	}
+	if !degradedFold(a) {
+		t.Errorf("no degraded fold committed: receipt=%+v", a.compactionState.LastReceipt)
+	}
+}
+
+// A fold too large for one request is shortened before it is sent, which is a
+// second way into the same failure. That path must degrade like a plain
+// summarizer failure rather than strand the turn.
+func TestSummarizerFailureOnOversizedFoldDegrades(t *testing.T) {
+	sess := foldableSessionOverForce(120)
+	a := agentOverForceWindow(t, &fakeProvider{streamErr: errors.New("provider exploded")}, sess, 60000)
+	if tokens, budget := a.guardedSummaryInputTokens(foldRegionOf(a)), a.summaryInputBudget(""); budget <= 0 || tokens <= budget {
+		t.Fatalf("fixture fold is %d tokens against a %d budget; the shortening path is not exercised", tokens, budget)
+	}
+
+	if err := prepareContext(context.Background(), a, CompactionTriggerOverflow); err != nil {
+		t.Fatalf("prepare = %v, want a degraded fold", err)
+	}
+	if !degradedFold(a) {
+		t.Errorf("no degraded fold committed: receipt=%+v", a.compactionState.LastReceipt)
+	}
+}
+
+// Below the hard ceiling the turn still goes out, so a failed summary must stay
+// a failure: degrading here would fold a recoverable view without a summary and
+// spend the mechanical fold on a turn that never needed it.
+func TestPressureBelowHardCeilingKeepsTheFailure(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	a := agentOverForce(t, &fakeProvider{streamErr: errors.New("provider down")}, sess)
+	if est, hard := a.estimatedPromptTokens(sess.Messages), a.hardInputCeiling(); est >= hard {
+		t.Fatalf("fixture estimates %d tokens against a %d ceiling; it is not below it", est, hard)
+	}
+
+	if err := prepareContext(context.Background(), a, CompactionTriggerPressure); err != nil {
+		t.Fatalf("prepare = %v, want the turn to proceed unfolded", err)
+	}
+	if degradedFold(a) {
+		t.Error("a recoverable view was folded without a summary")
+	}
+	if r := a.compactionState.LastReceipt; r == nil || (r.Status != "blocked" && r.Status != "failed") {
+		t.Errorf("receipt = %+v, want the failure recorded so the summary is not paid for twice", r)
+	}
+}
+
+// Cancellation is the user's decision, not a summarizer failure: it must keep
+// its error and leave the projection alone.
+func TestCallerCancellationDoesNotDegrade(t *testing.T) {
+	sess := foldableSessionOverForce(6)
+	a := agentOverForce(t, &fakeProvider{hang: true}, sess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := prepareContext(ctx, a, CompactionTriggerOverflow); err == nil {
+		t.Fatal("cancelled prepare reported success")
+	}
+	if degradedFold(a) {
+		t.Error("cancellation installed a degraded fold; it should change nothing")
+	}
+}

--- a/internal/agent/compress_tool_test.go
+++ b/internal/agent/compress_tool_test.go
@@ -336,7 +336,7 @@ func TestRangeCompressionSharesSummarySingleflight(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 	autoErr := make(chan error, 1)
 	go func() {
-		_, err := a.compactToProjection(context.Background(), CompactionTriggerPressure, "", true)
+		_, err := a.compactToProjection(context.Background(), CompactionTriggerPressure, "", true, false)
 		autoErr <- err
 	}()
 	<-prov.started

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -109,7 +109,10 @@ func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePo
 
 func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContext, policy ContextPreparePolicy, inputHash string, est, fold, hard int, forceFold bool) (PreparedContext, error) {
 	a := m.agent
-	outcome, err := a.compactToProjection(ctx, policy.Trigger, policy.Instructions, forceFold)
+	// Where this function would answer ErrCompactionRequired, the fold is the
+	// only way out and a failed summary must degrade rather than strand the turn.
+	mustFree := policy.Trigger != CompactionTriggerManual && (policy.Trigger == CompactionTriggerOverflow || est >= hard)
+	outcome, err := a.compactToProjection(ctx, policy.Trigger, policy.Instructions, forceFold, mustFree)
 	if err != nil {
 		if errors.Is(err, errCompressStaleContext) && policy.Trigger != CompactionTriggerManual {
 			// Transcript changed during the summary call: discard the candidate

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -130,8 +130,13 @@ func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
 		detail += " provider_request_id=" + t.ProviderRequestID
 	}
 	if t.Error != "" {
-		slog.Warn("agent: compaction failed", "detail", detail+" err_type="+t.Error)
-		return
+		// A degraded fold carries the summarizer's error but still freed the
+		// context, so it is a notice with a cause rather than a failure.
+		if t.Mode != CompactionModeDegraded {
+			slog.Warn("agent: compaction failed", "detail", detail+" err_type="+t.Error)
+			return
+		}
+		detail += " err_type=" + t.Error
 	}
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compaction telemetry", Detail: detail})
 }

--- a/internal/agent/projection_test.go
+++ b/internal/agent/projection_test.go
@@ -441,10 +441,10 @@ func TestCompactReplacesHistory(t *testing.T) {
 	}
 }
 
-func TestCompactFallsBackToMechanicalFoldWhenSummaryFails(t *testing.T) {
-	// Projection compaction must not rewrite history or install a mechanical
-	// marker when the summarizer fails. The error is returned so the caller
-	// can retry or report it.
+func TestManualCompactReportsSummarizerFailure(t *testing.T) {
+	// Manual compaction must not rewrite history or degrade to a mechanical
+	// fold when the summarizer fails. The error is returned so the caller,
+	// who is present, can retry or report it.
 	prov := &fakeProvider{streamErr: errors.New("provider down")}
 	sess := &Session{Messages: []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},


### PR DESCRIPTION
## The strand

At physical overflow — and at pressure above the hard input ceiling — the summarizer is the only way out of context pressure. When it fails, `Prepare` answers `ErrCompactionRequired` and every further message is blocked:

```
context exceeds provider limit and compaction failed: context deadline exceeded
```

#4138 made the 90s summary bound safe by pairing it with a deterministic mechanical fold: the summarizer may time out, a timeout is deliberately **not** retried, but the fold still frees context. #7839 removed `mechanicalFoldDigest` and added `CompactionModeDegraded` without ever wiring it — so the no-retry policy stayed while the fallback did not. `CompactionModeDegraded` is still declared on `main-v2` and still has no writer.

## Where it degrades, and where it deliberately does not

The fold degrades **only where the caller would otherwise answer `ErrCompactionRequired`** — the condition is computed in `foldContext`, next to the returns that raise it, and passed down as `mustFree`.

| Path | Behaviour | Why |
| --- | --- | --- |
| overflow, or `est >= hard` | degrade to a mechanical fold | nothing else can free the context; the turn is otherwise dead |
| pressure below the ceiling | keep the error | the turn still goes out, and the blocked fingerprint stops a second summary being paid for |
| manual `/compact`, `compress_context` | keep the error | the caller is present and can retry |
| cancellation | keep the error | the caller's decision, never a summarizer failure |

The narrower scope is the substantive change from the first version of this PR, which degraded on every automatic path. That would have folded views that were still recoverable and thrown away the retry economics `TestContextManagerPersistsAndRestoresBlockedFailureFingerprint` and `TestBlockedReceiptSurvivesPostPublishDirSyncFailure` exist to protect. Both pass unchanged; `TestPressureBelowHardCeilingKeepsTheFailure` now states that boundary from this side.

The canonical transcript stays untouched on every path — only the projection changes.

## Telemetry

A degraded fold freed the context, so it is no longer logged as `agent: compaction failed`. It emits the ordinary telemetry notice carrying `mode=degraded` and the summarizer's error as the cause. A degrade that *fails* (manual, cancellation) still warns.

## Tests

`compact_summary_failure_test.go`, all driven through the real `contextManager().Prepare`:

- `TestSummarizerTimeoutWhereFoldIsTheOnlyWayOutDegrades` — the hanging summarizer that motivated the mechanical fold: prepare succeeds, projection shrinks, the digest tells the model the summary is missing.
- `TestOverflowSummarizerFailureDegradesInsteadOfBlockingTheTurn` — the trigger that raises `ErrCompactionRequired`.
- `TestSummarizerFailureOnOversizedFoldDegrades` — a fold that exceeds the single-request budget, the other way into the same failure.
- `TestPressureBelowHardCeilingKeepsTheFailure` — the boundary: no degraded fold, and the failure is still recorded.
- `TestCallerCancellationDoesNotDegrade` — cancellation changes nothing.
- `TestManualCompactReportsSummarizerFailure` (renamed from `TestCompactFallsBackToMechanicalFoldWhenSummaryFails`) — manual keeps the error, which is now the stated contract rather than an accident.

## Rebase note

This was rebased across #8210 and #8244. The original commit split `archiveMessages` so the digest could name the archive it was about to write; `main-v2` has since removed compaction archiving entirely, so that half is gone and the digest points the model at the user instead.

## Verification

`gofmt` · `go vet ./...` · `make lint` (golangci-lint 0 issues, `repolint: clean (1950 baselined findings)`) · `go test ./internal/agent/ ./internal/cli/ ./internal/control/ ./internal/boot/ ./internal/tool/builtin/` all green on the rebased branch.

Cache-impact: none - the prefix bytes for a given view are unchanged. This alters only what is installed when a summary has already failed, which is a cache break either way (the fold rewrites the prefix); it does not add, remove or reorder any tool schema, system-prompt or turn content.
Cache-guard: go test ./internal/agent/ -run 'CacheShape|CacheHit|CacheDiagnostic|Prefix' (green on this branch)
Documentation-impact: none - no docs/*.md needs to change. The behaviour change is confined to a failure path: a summarizer failure that would previously block the turn now folds mechanically. No flag, command, config key or documented output changes.
