### PR TITLE
fix(agent): snip the projection, not the canonical transcript

### DIFF
--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -670,17 +670,35 @@ func (a *Agent) runCompactionSummary(ctx context.Context, fold []provider.Messag
 }
 
 // snipToProjection builds a projection that only snips stale tool results.
+// maintenanceBase is the view tool-result maintenance must rewrite: the active
+// projection when one is valid, never the canonical transcript. Rebuilding from
+// canonical would silently discard an existing summary and undo the compaction
+// that produced it.
+func (a *Agent) maintenanceBase(msgs []provider.Message, version uint64) []provider.Message {
+	st := a.compactionState
+	if !projectionValid(st, msgs, version, a.currentPromptCacheKey()) {
+		return msgs
+	}
+	if visible := modelVisibleFromProjection(st.Projection, msgs); len(visible) > 0 {
+		return visible
+	}
+	return msgs
+}
+
 func (a *Agent) snipToProjection(ctx context.Context) error {
 	_ = ctx
-	msgs, _ := a.session.snapshotMessagesVersion()
-	snipped, st := a.applyToolResultMaintenanceView(msgs, toolResultSnip)
+	msgs, version := a.session.snapshotMessagesVersion()
+	// Snipping the projection rather than canonical also makes the count honest:
+	// already-snipped results carry the marker and no longer qualify, so this
+	// reports what this pass actually reclaimed instead of the running total.
+	snipped, st := a.applyToolResultMaintenanceView(a.maintenanceBase(msgs, version), toolResultSnip)
 	if st.Results == 0 {
 		return nil
 	}
 	ratio := a.tokPerChar()
 	saved := int(float64(st.SavedChars) * ratio)
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
-		"snipped %d stale tool results (~%d tokens est.) before compaction", st.Results, saved)})
+		"snipped %d stale tool results (~%d tokens est.)", st.Results, saved)})
 	return a.installPruneProjection(snipped, st)
 }
 

--- a/internal/agent/compact_snip_projection_test.go
+++ b/internal/agent/compact_snip_projection_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func toolHeavySession(turns int) *Session {
+	sess := NewSession("sys")
+	for i := range turns {
+		sess.Add(provider.Message{Role: provider.RoleUser, Content: "turn " + strings.Repeat("x", 80) + string(rune('A'+i%26))})
+		sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c", Name: "read", Arguments: "{}"}}})
+		sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "c", Name: "read", Content: strings.Repeat("tool-output ", 200)})
+	}
+	return sess
+}
+
+func projectionHasSummary(a *Agent) bool {
+	return slices.ContainsFunc(a.compactionState.Projection.Messages, isCompactionSummary)
+}
+
+// Tool-result maintenance rewrites the model-visible view, so it must start from
+// the active projection. Rebuilding from canonical throws the summary away and
+// inflates the context it was supposed to shrink.
+func TestSnipPreservesSummaryProjection(t *testing.T) {
+	sess := toolHeavySession(12)
+	a := New(&fakeProvider{reply: "DIGEST body"}, tool.NewRegistry(), sess, Options{
+		ContextWindow: 4000, RecentKeep: 2, ArchiveDir: t.TempDir(),
+	}, event.Discard)
+
+	if err := a.CompactNow(context.Background(), ""); err != nil {
+		t.Fatalf("CompactNow: %v", err)
+	}
+	if !projectionHasSummary(a) {
+		t.Fatal("setup: compaction produced no summary projection")
+	}
+	compacted := estimateMessagesTokens(a.compactionState.Projection.Messages)
+
+	if err := a.snipToProjection(context.Background()); err != nil {
+		t.Fatalf("snipToProjection: %v", err)
+	}
+
+	if !projectionHasSummary(a) {
+		t.Error("snip discarded the summary projection")
+	}
+	if got := estimateMessagesTokens(a.compactionState.Projection.Messages); got > compacted {
+		t.Errorf("snip grew the projection: %d -> %d tokens", compacted, got)
+	}
+}
+
+// The same stale results must not be re-reported every turn: once snipped they
+// carry the marker, so a second pass has nothing fresh to announce.
+func TestSnipDoesNotRepeatItsNotice(t *testing.T) {
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice && strings.Contains(e.Text, "stale tool results") {
+			notices = append(notices, e.Text)
+		}
+	})
+	a := New(&fakeProvider{reply: "unused"}, tool.NewRegistry(), toolHeavySession(10), Options{
+		ContextWindow: 4000, RecentKeep: 2, ArchiveDir: t.TempDir(),
+	}, sink)
+
+	for range 3 {
+		if err := a.snipToProjection(context.Background()); err != nil {
+			t.Fatalf("snipToProjection: %v", err)
+		}
+	}
+	if len(notices) != 1 {
+		t.Errorf("snip announced itself %d times, want 1: %q", len(notices), notices)
+	}
+}
+
+// preflight's free prune runs the same view and must not undo a summary either.
+func TestPreflightPruneKeepsSummaryProjection(t *testing.T) {
+	sess := toolHeavySession(14)
+	a := New(&fakeProvider{reply: "DIGEST body"}, tool.NewRegistry(), sess, Options{
+		ContextWindow: 4000, CompactRatio: 0.5, CompactForceRatio: 0.6, RecentKeep: 2, ArchiveDir: t.TempDir(),
+	}, event.Discard)
+
+	if err := a.CompactNow(context.Background(), ""); err != nil {
+		t.Fatalf("CompactNow: %v", err)
+	}
+	if !projectionHasSummary(a) {
+		t.Fatal("setup: compaction produced no summary projection")
+	}
+
+	if err := a.contextPreflight(context.Background(), CompactionTriggerPressure); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if !projectionHasSummary(a) {
+		t.Error("preflight prune discarded the summary projection")
+	}
+}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -41,7 +41,7 @@ func (a *Agent) contextPreflight(ctx context.Context, trigger string) error {
 	}
 
 	// Prefer a free prune/snip projection before a paid summarize call.
-	pruned, pst := a.applyToolResultMaintenanceView(msgs, toolResultPrune)
+	pruned, pst := a.applyToolResultMaintenanceView(a.maintenanceBase(msgs, version), toolResultPrune)
 	if pst.Results > 0 {
 		if err := a.installPruneProjection(pruned, pst); err == nil {
 			projEst := estimateMessagesTokens(provider.ModelMessages(pruned))


### PR DESCRIPTION
Fixes #7935.

## What the report showed

A long session printed the same line after nearly every tool call:

```
(i) snipped 206 stale tool results (~34672 tokens est.) before compaction
(i) snipped 206 stale tool results (~34769 tokens est.) before compaction
(i) snipped 207 stale tool results (~34905 tokens est.) before compaction
```

while the window kept filling toward 766.6K / 1M. The reporter read this as "it keeps claiming to snip but nothing is ever compacted", and that reading turns out to be right for a reason the log never showed.

## Root cause

`snipToProjection` and preflight's free prune both rebuilt their view from the canonical transcript. Canonical is never rewritten, so:

**An existing summary is discarded.** `installPruneProjection` stores the canonical-derived view as the whole projection, so a snip pass silently undoes the compaction that produced the summary. Measured on a 12-turn tool-heavy session:

| | messages | tokens |
| --- | --- | --- |
| after compaction | 15 | 8073 |
| after one snip | 37 | 25966 |

The context grows 3.2x immediately after it was supposed to shrink, and the session climbs straight back to the compaction threshold.

**The count never settles.** `shouldMaintainToolResult` excludes results that already carry the snipped marker, but canonical never carries it, so every pass re-counts the same 206 results and re-announces the same running total. The number creeping 206 -> 207 is new stale results arriving, not progress being made.

Both symptoms are the same bug: the maintenance base.

## Fix

`maintenanceBase` returns the active projection when one is valid, canonical only when there is none. Both the snip path and preflight's prune path go through it.

The summary now survives a snip, and because already-snipped results stop qualifying, the count becomes what the pass actually reclaimed — so a settled view reports nothing at all instead of repeating itself. The notice also drops "before compaction", which implied a compaction was imminent when the session could still be far from the threshold.

## Tests

New `compact_snip_projection_test.go`:

- a snip after a compaction keeps the summary and must not grow the projection
- three consecutive snips announce themselves once, not three times
- preflight's prune path keeps the summary too

Cache-impact: low - the provider-visible projection is unchanged when no maintenance runs; where it differs it now preserves a summary that was previously dropped, which shrinks the prefix rather than perturbing a stable one
Cache-guard: go test ./internal/agent/ -run 'Snip|Prune|Compact'
Documentation-impact: none - no documented behavior, option, or output contract changes; the notice text is an informational log line
