### PR TITLE
feat(cli): ask for the context window instead of assuming 128K

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1937,7 +1937,7 @@ func promptCustomProviderManualWith(in *bufio.Scanner, baseURL, keyEnv, apiKey s
 	}
 	entry := config.ProviderEntry{
 		Name: providerName, Kind: "openai", BaseURL: baseURL,
-		Model: modelName, APIKeyEnv: keyEnv, ContextWindow: 128000,
+		Model: modelName, APIKeyEnv: keyEnv, ContextWindow: askContextWindow(in, os.Stdout),
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.CustomAddedFmt, entry.Name+"/"+modelName)))
 	return newProviderPromptResult([]config.ProviderEntry{entry}, keyEnv, apiKey), nil
@@ -1987,7 +1987,7 @@ func promptCustomProviderFromURL() (providerPromptResult, error) {
 	}
 	entry := config.ProviderEntry{
 		Name: providerName, Kind: "openai", BaseURL: baseURL,
-		Models: selected, Model: selected[0], APIKeyEnv: keyEnv, ContextWindow: 128000,
+		Models: selected, Model: selected[0], APIKeyEnv: keyEnv, ContextWindow: askContextWindow(in, os.Stdout),
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.CustomAddedFmt, entry.Name+"/"+selected[0])))
 	return newProviderPromptResult([]config.ProviderEntry{entry}, keyEnv, apiKey), nil
@@ -2039,7 +2039,7 @@ func promptAnthropicProviderManualWith(in *bufio.Scanner, baseURL, keyEnv, apiKe
 	}
 	entry := config.ProviderEntry{
 		Name: providerSlug("anthropic", baseURL), Kind: "anthropic", BaseURL: baseURL,
-		Model: modelName, APIKeyEnv: keyEnv, ContextWindow: 128000,
+		Model: modelName, APIKeyEnv: keyEnv, ContextWindow: askContextWindow(in, os.Stdout),
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.AnthropicAddedFmt, entry.Name+"/"+modelName)))
 	return newProviderPromptResult([]config.ProviderEntry{entry}, keyEnv, apiKey), nil
@@ -2089,7 +2089,7 @@ func promptAnthropicProviderFromURL() (providerPromptResult, error) {
 	}
 	entry := config.ProviderEntry{
 		Name: providerSlug("anthropic", baseURL), Kind: "anthropic", BaseURL: baseURL,
-		Models: selected, Model: selected[0], APIKeyEnv: keyEnv, ContextWindow: 128000,
+		Models: selected, Model: selected[0], APIKeyEnv: keyEnv, ContextWindow: askContextWindow(in, os.Stdout),
 	}
 	fmt.Printf("  %s\n", green(fmt.Sprintf(i18n.M.AnthropicAddedFmt, entry.Name+"/"+selected[0])))
 	return newProviderPromptResult([]config.ProviderEntry{entry}, keyEnv, apiKey), nil

--- a/internal/cli/context_window_prompt_test.go
+++ b/internal/cli/context_window_prompt_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+// The wizard used to write 128000 unconditionally, so a 1M-window relay was
+// recorded as 128K and compacted at roughly a tenth of its real capacity.
+func TestAskContextWindowAcceptsTheRealWindow(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"explicit large window", "1048576\n", 1048576},
+		{"surrounding spaces", "  200000  \n", 200000},
+		{"empty keeps the conservative default", "\n", defaultCustomContextWindow},
+		{"non-numeric keeps the default", "not-a-number\n", defaultCustomContextWindow},
+		{"zero keeps the default", "0\n", defaultCustomContextWindow},
+		{"negative keeps the default", "-5\n", defaultCustomContextWindow},
+		{"closed input keeps the default", "", defaultCustomContextWindow},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := askContextWindow(bufio.NewScanner(strings.NewReader(tc.input)), io.Discard)
+			if got != tc.want {
+				t.Errorf("askContextWindow(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/provider_context_window.go
+++ b/internal/cli/provider_context_window.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/i18n"
+)
+
+// defaultCustomContextWindow is the fallback for a relay whose window we cannot
+// know. It is deliberately conservative: too small only wastes context, while
+// too large makes the provider reject the request outright.
+const defaultCustomContextWindow = 128000
+
+// askContextWindow prompts for the model's context window. An OpenAI-compatible
+// endpoint does not report it, and a value below the real window is what makes
+// compaction fire long before it needs to, so the wizard asks instead of
+// recording an assumption the user never sees.
+func askContextWindow(in *bufio.Scanner, w io.Writer) int {
+	raw := ask(in, w, i18n.M.CustomPromptWindow, strconv.Itoa(defaultCustomContextWindow))
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return defaultCustomContextWindow
+	}
+	return n
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -472,6 +472,7 @@ type Messages struct {
 	CustomPromptBaseURL  string // "Enter Base URL"
 	CustomPromptKeyEnv   string // "Enter API Key env var name"
 	CustomPromptAPIKey   string // "Enter API Key"
+	CustomPromptWindow   string // "Enter context window in tokens"
 	CustomAddedFmt       string // "Added custom model: %s"
 
 	// Anthropic compatible provider

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -439,6 +439,7 @@ var English = Messages{
 	CustomPromptBaseURL:  "Enter Base URL",
 	CustomPromptKeyEnv:   "API Key variable name (press Enter to use the default; not the model name)",
 	CustomPromptAPIKey:   "Enter API Key",
+	CustomPromptWindow:   "Context window in tokens (a value below the model's real window makes compaction fire early)",
 	CustomAddedFmt:       "Added custom model: %s",
 
 	// Anthropic compatible provider

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -440,6 +440,7 @@ var Chinese = Messages{
 	CustomPromptBaseURL:  "请输入 Base URL",
 	CustomPromptKeyEnv:   "API Key 变量名（直接回车使用默认值，不是模型名）",
 	CustomPromptAPIKey:   "请输入 API Key",
+	CustomPromptWindow:   "上下文窗口(tokens,填得比模型真实窗口小会导致过早压缩)",
 	CustomAddedFmt:       "已添加自定义模型: %s",
 
 	// Anthropic 兼容 provider

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -412,6 +412,7 @@ var ChineseTraditional = Messages{
 	CustomPromptBaseURL:  "請輸入 Base URL",
 	CustomPromptKeyEnv:   "API Key 變數名稱（直接按 Enter 使用預設值，不是模型名稱）",
 	CustomPromptAPIKey:   "請輸入 API Key",
+	CustomPromptWindow:   "上下文視窗(tokens,填得比模型真實視窗小會導致過早壓縮)",
 	CustomAddedFmt:       "已新增自訂模型: %s",
 
 	// Anthropic 相容 provider


### PR DESCRIPTION
## Problem

The custom-provider wizard wrote `ContextWindow: 128000` unconditionally on all four paths — OpenAI-compatible and Anthropic-compatible, single model and model list:

```
internal/cli/cli.go:1940, 1990, 2042, 2092
```

A relay serving a 1M-window model is therefore recorded as 128K. Compaction then fires at 80% of the wrong number, which is roughly 10% of the model's real capacity. From the user's side that is indistinguishable from "Reasonix compacts far too early", and nothing in the UI reveals that the window is the reason.

An OpenAI-compatible endpoint does not report its context window, and guessing it from a model name is unreliable for a relay, so the wizard cannot discover the right value. What it can do is stop pretending it knows.

## Change

The wizard asks. The default stays `128000` for the case where the user does not know either — conservative on purpose, since too small only wastes context while too large makes the provider reject the request outright — but it is now a visible answer instead of a silent assumption. The prompt states what a wrong value costs, which is the part that was previously invisible.

`askContextWindow` lives in a new `provider_context_window.go` rather than in `cli.go`: that file is already at its size budget, and the call sites are inlined so it stays there.

## Not changed here, but worth a decision

`internal/config/provider_presets.go:678` gives `opencode-go` a provider-wide `ContextWindow: 128000`, and its `ModelOverrides` for `deepseek-v4-flash` set only the reasoning fields — no `context_window`. Meanwhile `docs/SPEC.md:737` documents exactly that model with `context_window = 1000000`:

```
# model_overrides = { "deepseek-v4-flash" = { context_window = 1000000, max_output_tokens = 32768 } }
```

So the preset and the documented example disagree, and users on that preset get 128K unless they hand-write the override. #7935 shows a session on `opencode-go / deepseek-v4-flash` running at 766.6K / 1M, i.e. someone who did hand-write it.

I did not change the preset: if the relay's real ceiling is lower than the model's, raising it trades premature compaction for outright request rejection, and that call needs someone who knows the relay's limits. Flagging it so it can be decided rather than inherited.

## Tests

`context_window_prompt_test.go` covers the parse contract: an explicit large window, surrounding whitespace, and the four ways of declining to answer (empty, non-numeric, zero, negative, closed input) all resolving to the conservative default.

Documentation-impact: none - no configuration field, format, or default changes; `context_window` and its per-model override are already specified in docs/SPEC.md and remain accurate. The wizard gains one prompt for a field it was previously filling in silently.
