### PR TITLE
feat(context): /context shows the window, the thresholds, and the last pass

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -953,7 +953,7 @@ convenient.
 
 ## Slash commands
 
-In an interactive `reasonix` session, built-in commands (`/compact`, `/new`, `/clear`, `/rewind`,
+In an interactive `reasonix` session, built-in commands (`/compact`, `/context`, `/new`, `/clear`, `/rewind`,
 `/tree`, `/branch`, `/switch`, `/todo`, `/model`, `/work-mode`, `/mcp`, `/skills`, `/hooks`,
 `/memory`, `/goal`, `/output-style`, `/sandbox`, `/language`,
 `/reasoning-language`, `/help`) run

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -758,7 +758,7 @@ RPC 调用。两者都可按服务器覆盖。
 
 ## 斜杠命令
 
-交互式 `reasonix` 会话里，内置命令（`/compact`、`/new`、`/clear`、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/work-mode`、`/mcp`、`/skills`、`/hooks`、`/memory`、`/goal`、`/output-style`、`/sandbox`、`/language`、`/reasoning-language`、`/help`）在本地执行——`/help` 可列出全部。
+交互式 `reasonix` 会话里，内置命令（`/compact`、`/context`、`/new`、`/clear`、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/work-mode`、`/mcp`、`/skills`、`/hooks`、`/memory`、`/goal`、`/output-style`、`/sandbox`、`/language`、`/reasoning-language`、`/help`）在本地执行——`/help` 可列出全部。
 内置 **Skill**（如 `/init`、`/explore`、`/test`、`/reasonix-guide`）也会出现在斜杠菜单，
 并可通过 `run_skill` 调用（正文按需加载；只有索引行进入缓存稳定前缀）。配置或能力排障时
 用 `/reasonix-guide`，它会引导运行 `reasonix doctor capabilities`（见

--- a/internal/agent/context_report.go
+++ b/internal/agent/context_report.go
@@ -1,0 +1,74 @@
+package agent
+
+import "reasonix/internal/provider"
+
+// ContextReport is a point-in-time view of context pressure: the declared
+// window, the thresholds derived from it, what the model currently sees, and how
+// the last maintenance pass ended. A misconfigured window and a genuinely full
+// one produce the same notices, so the numbers behind the decision have to be
+// inspectable rather than inferred.
+type ContextReport struct {
+	Window       int
+	HardCeiling  int
+	OutputBudget int
+
+	LatestPrompt     int
+	CanonicalTokens  int
+	ProjectionTokens int
+	Projected        bool
+
+	SoftThreshold  int
+	SnipThreshold  int
+	FoldThreshold  int
+	ForceThreshold int
+
+	LastTrigger   string
+	LastMode      string
+	LastSource    int
+	LastResult    int
+	CacheState    string
+	BlockedReason string
+}
+
+// ContextReport samples the current context state. Compaction is disabled when
+// Window is zero, in which case the thresholds carry no meaning.
+func (a *Agent) ContextReport() ContextReport {
+	if a == nil {
+		return ContextReport{}
+	}
+	rep := ContextReport{
+		Window:       a.contextWindow,
+		HardCeiling:  a.hardInputCeiling(),
+		OutputBudget: a.maxOutputTokens,
+		CacheState:   a.CacheState(),
+	}
+	if u := a.lastUsage.Load(); u != nil {
+		rep.LatestPrompt = u.LatestPromptTokens()
+	}
+	if a.session != nil {
+		canonical, _ := a.session.snapshotMessagesVersion()
+		rep.CanonicalTokens = estimateMessagesTokens(provider.ModelMessages(canonical))
+	}
+	visible := a.modelVisibleMessages()
+	rep.ProjectionTokens = estimateMessagesTokens(provider.ModelMessages(visible))
+	rep.Projected = rep.ProjectionTokens != rep.CanonicalTokens
+
+	if a.contextWindow > 0 {
+		soft, snip, fold := a.compactThresholds()
+		rep.SoftThreshold, rep.SnipThreshold, rep.FoldThreshold = soft, snip, fold
+		rep.ForceThreshold = a.forceCompactThreshold(fold)
+		if _, reason := a.contextMaintenanceBlocked(a.contextMaintenanceInputHash(visible)); reason != "" {
+			rep.BlockedReason = reason
+		}
+	}
+
+	a.compactionMu.Lock()
+	st := a.compactionState
+	a.compactionMu.Unlock()
+	rep.LastTrigger, rep.LastMode = st.LastTrigger, st.LastMode
+	rep.LastSource, rep.LastResult = st.LastSourceTokens, st.LastResultTokens
+	if rep.BlockedReason == "" {
+		rep.BlockedReason = st.BlockedReason
+	}
+	return rep
+}

--- a/internal/agent/context_report_test.go
+++ b/internal/agent/context_report_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// A retry aggregate is billable tokens, not context shape. Reporting it would
+// show pressure that the model never actually saw.
+func TestContextReportUsesLatestPromptNotBillableAggregate(t *testing.T) {
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("x", 400)})
+	a := New(&fakeProvider{reply: "unused"}, tool.NewRegistry(), sess, Options{
+		ContextWindow: 100_000, RecentKeep: 2,
+	}, event.Discard)
+
+	a.lastUsage.Store(&provider.Usage{
+		PromptTokens:        363_000, // three recovery attempts, billed
+		ContextPromptTokens: 122_000, // what the last request actually carried
+		RequestCount:        3,
+	})
+
+	if got := a.ContextReport().LatestPrompt; got != 122_000 {
+		t.Errorf("LatestPrompt = %d, want 122000 (the latest request, not the billed aggregate)", got)
+	}
+}
+
+// Thresholds must come from the same helper the decision uses, so the report
+// cannot drift from what compaction will actually do.
+func TestContextReportThresholdsMatchTheDecision(t *testing.T) {
+	a := New(&fakeProvider{reply: "unused"}, tool.NewRegistry(), NewSession("sys"), Options{
+		ContextWindow: 200_000, CompactRatio: 0.8, CompactForceRatio: 0.9, RecentKeep: 2,
+	}, event.Discard)
+
+	rep := a.ContextReport()
+	soft, snip, fold := a.compactThresholds()
+	if rep.SoftThreshold != soft || rep.SnipThreshold != snip || rep.FoldThreshold != fold {
+		t.Errorf("report thresholds (%d/%d/%d) differ from compactThresholds (%d/%d/%d)",
+			rep.SoftThreshold, rep.SnipThreshold, rep.FoldThreshold, soft, snip, fold)
+	}
+	if want := a.forceCompactThreshold(fold); rep.ForceThreshold != want {
+		t.Errorf("ForceThreshold = %d, want %d", rep.ForceThreshold, want)
+	}
+}
+
+// A zero window disables maintenance; the thresholds then mean nothing and must
+// not be presented as if they did.
+func TestContextReportLeavesThresholdsZeroWhenDisabled(t *testing.T) {
+	a := New(&fakeProvider{reply: "unused"}, tool.NewRegistry(), NewSession("sys"), Options{
+		ContextWindow: 0, RecentKeep: 2,
+	}, event.Discard)
+
+	rep := a.ContextReport()
+	if rep.Window != 0 || rep.FoldThreshold != 0 || rep.ForceThreshold != 0 {
+		t.Errorf("disabled maintenance reported thresholds: %+v", rep)
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4537,6 +4537,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		// guidance steering what the summary keeps.
 		focus := strings.TrimSpace(strings.TrimPrefix(input, typedCmd))
 		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background(), focus)} }
+	case "/context":
+		return m.showContextReport(input)
 	case "/new":
 		m.echoLocalCommand(input)
 		if err := m.ctrl.NewSession(); err != nil {
@@ -4696,14 +4698,7 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/goal":
 		return m.runGoalSubcommand(input)
 	case "/remember":
-		note := strings.TrimSpace(strings.TrimPrefix(input, typedCmd))
-		if note == "" {
-			m.notice("nothing to remember")
-		} else if path, err := m.ctrl.QuickAdd(memory.ScopeProject, note); err != nil {
-			m.notice("memory: " + err.Error())
-		} else {
-			m.notice("remembered → " + path)
-		}
+		m.rememberNote(strings.TrimSpace(strings.TrimPrefix(input, typedCmd)))
 	case "/quit", "/exit":
 		return shutdownNow
 	case "/copy":

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -47,12 +48,10 @@ func TestSlashCompletionFilterAndAccept(t *testing.T) {
 	if !m.completion.active || m.completion.kind != compSlash {
 		t.Fatalf("typing /co should open the slash menu: %+v", m.completion)
 	}
-	// /compact and /copy both start with "/co".
-	if len(m.completion.items) != 2 {
-		t.Fatalf("filter = %v, want /compact and /copy", labels(m.completion.items))
-	}
-	if m.completion.items[0].label != "/compact" || m.completion.items[1].label != "/copy" {
-		t.Fatalf("filter = %v, want [/compact /copy]", labels(m.completion.items))
+	// /compact, /context and /copy all start with "/co", in that order.
+	want := []string{"/compact", "/context", "/copy"}
+	if got := labels(m.completion.items); !slices.Equal(got, want) {
+		t.Fatalf("filter = %v, want %v", got, want)
 	}
 
 	m.acceptCompletion()

--- a/internal/cli/context_command.go
+++ b/internal/cli/context_command.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/memory"
+)
+
+// showContextReport prints the window, the thresholds derived from it, and how
+// the last maintenance pass ended. It commits a block rather than a notice
+// because the numbers are meant to be compared with each other.
+func (m *chatTUI) showContextReport(input string) tea.Cmd {
+	m.echoLocalCommand(input)
+	summary, detail := m.ctrl.ContextReport()
+	if detail != "" {
+		summary += "\n" + detail
+	}
+	m.commitLine(summary)
+	return nil
+}
+
+func (m *chatTUI) rememberNote(note string) {
+	if note == "" {
+		m.notice("nothing to remember")
+		return
+	}
+	path, err := m.ctrl.QuickAdd(memory.ScopeProject, note)
+	if err != nil {
+		m.notice("memory: " + err.Error())
+		return
+	}
+	m.notice("remembered → " + path)
+}

--- a/internal/cli/slash_registry.go
+++ b/internal/cli/slash_registry.go
@@ -22,6 +22,7 @@ type builtinSlashSpec struct {
 func builtinSlashSpecs() []builtinSlashSpec {
 	return []builtinSlashSpec{
 		{name: "/compact", insert: "/compact ", hint: i18n.M.CmdCompact, showInHelp: true},
+		{name: "/context", insert: "/context", hint: i18n.M.CmdContext, showInHelp: true},
 		{name: "/new", insert: "/new ", hint: i18n.M.CmdNew, showInHelp: true},
 		{name: "/clear", insert: "/clear", hint: i18n.M.CmdClear, showInHelp: true},
 		{name: "/cls", insert: "/cls", hint: i18n.M.CmdCls, showInHelp: true},

--- a/internal/control/context_command.go
+++ b/internal/control/context_command.go
@@ -1,0 +1,119 @@
+package control
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+// ContextReport renders the current context state as a one-line summary plus
+// detail lines. The window is the denominator of every compaction decision, so
+// a wrong one looks exactly like a full context until the number is visible.
+func (c *Controller) ContextReport() (summary, detail string) {
+	if c.executor == nil {
+		return "context: unavailable", ""
+	}
+	return renderContextReport(c.executor.ContextReport())
+}
+
+// runSessionVerb runs a session mutation off the dispatch path and reports the
+// outcome, so the slash switch holds routing rather than goroutine plumbing.
+func (c *Controller) runSessionVerb(run func() error, done, failPrefix string) {
+	go func() {
+		if err := run(); err != nil {
+			c.notice(failPrefix + err.Error())
+			return
+		}
+		c.notice(done)
+	}()
+}
+
+func renderContextReport(rep agent.ContextReport) (summary, detail string) {
+	if rep.Window <= 0 {
+		return "context: maintenance disabled (context_window = 0)",
+			fmt.Sprintf("%-18s%s\n%-18s%s", "latest prompt",
+				thousands(rep.LatestPrompt), "canonical", thousands(rep.CanonicalTokens))
+	}
+
+	var b strings.Builder
+	line := func(label string, value string) {
+		fmt.Fprintf(&b, "%-18s%s\n", label, value)
+	}
+	hard := ""
+	if rep.HardCeiling > 0 && rep.HardCeiling < rep.Window {
+		hard = fmt.Sprintf("  (usable %s after output reserve)", thousands(rep.HardCeiling))
+	}
+	line("window", thousands(rep.Window)+hard)
+	line("latest prompt", fmt.Sprintf("%s  (%s of window)", thousands(rep.LatestPrompt), percentOf(rep.LatestPrompt, rep.Window)))
+	line("canonical", thousands(rep.CanonicalTokens))
+	visible := thousands(rep.ProjectionTokens)
+	if rep.Projected {
+		visible += "  (projected)"
+	}
+	line("model-visible", visible)
+	line("thresholds", fmt.Sprintf("snip %s · fold %s · force %s",
+		thousands(rep.SnipThreshold), thousands(rep.FoldThreshold), thousands(rep.ForceThreshold)))
+	if rep.LastMode != "" {
+		last := rep.LastMode
+		if rep.LastTrigger != "" {
+			last += " · " + rep.LastTrigger
+		}
+		if rep.LastSource > 0 && rep.LastResult > 0 {
+			last += fmt.Sprintf(" · %s -> %s", thousands(rep.LastSource), thousands(rep.LastResult))
+		}
+		line("last maintenance", last)
+	} else {
+		line("last maintenance", "none this session")
+	}
+	if rep.CacheState != "" {
+		line("cache", rep.CacheState)
+	}
+	if rep.BlockedReason != "" {
+		line("blocked", rep.BlockedReason)
+	}
+	return contextSummaryLine(rep), strings.TrimRight(b.String(), "\n")
+}
+
+// contextSummaryLine names the next thing that will happen, since "70% full" on
+// its own does not say whether that is close to anything.
+func contextSummaryLine(rep agent.ContextReport) string {
+	next := "fold at " + percentOf(rep.FoldThreshold, rep.Window)
+	switch {
+	case rep.LatestPrompt >= rep.ForceThreshold:
+		next = "at the force threshold"
+	case rep.LatestPrompt >= rep.FoldThreshold:
+		next = "folding"
+	case rep.LatestPrompt >= rep.SnipThreshold:
+		next = "snipping stale tool results"
+	}
+	s := fmt.Sprintf("context %s / %s (%s) · next: %s",
+		thousands(rep.LatestPrompt), thousands(rep.Window),
+		percentOf(rep.LatestPrompt, rep.Window), next)
+	if rep.BlockedReason != "" {
+		s += " · maintenance blocked"
+	}
+	return s
+}
+
+func percentOf(n, total int) string {
+	if total <= 0 {
+		return "n/a"
+	}
+	return strconv.Itoa((n*100+total/2)/total) + "%"
+}
+
+// thousands groups digits so a six-digit token count is readable at a glance.
+func thousands(n int) string {
+	s := strconv.Itoa(n)
+	neg := strings.HasPrefix(s, "-")
+	s = strings.TrimPrefix(s, "-")
+	for i := len(s) - 3; i > 0; i -= 3 {
+		s = s[:i] + "," + s[i:]
+	}
+	if neg {
+		return "-" + s
+	}
+	return s
+}

--- a/internal/control/context_command_test.go
+++ b/internal/control/context_command_test.go
@@ -1,0 +1,54 @@
+package control
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+// "70% full" does not tell the user whether that is close to anything, so the
+// summary names the next action for the pressure it reports.
+func TestContextSummaryNamesTheNextAction(t *testing.T) {
+	base := agent.ContextReport{Window: 1000, SnipThreshold: 600, FoldThreshold: 800, ForceThreshold: 900}
+	for _, tc := range []struct {
+		name   string
+		prompt int
+		want   string
+	}{
+		{"below every threshold", 100, "fold at 80%"},
+		{"in the snip band", 650, "snipping stale tool results"},
+		{"at the fold threshold", 800, "folding"},
+		{"at the force threshold", 950, "at the force threshold"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := base
+			rep.LatestPrompt = tc.prompt
+			if got := contextSummaryLine(rep); !strings.Contains(got, tc.want) {
+				t.Errorf("summary = %q, want it to mention %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A blocked maintenance pass is the thing users cannot currently see, so it has
+// to reach the one-line summary rather than only the detail block.
+func TestContextSummaryFlagsBlockedMaintenance(t *testing.T) {
+	rep := agent.ContextReport{
+		Window: 1000, SnipThreshold: 600, FoldThreshold: 800, ForceThreshold: 900,
+		LatestPrompt: 700, BlockedReason: "context summary failed: deadline exceeded",
+	}
+	if got := contextSummaryLine(rep); !strings.Contains(got, "blocked") {
+		t.Errorf("summary = %q, want it to flag the blocked pass", got)
+	}
+}
+
+func TestThousandsGroupsDigits(t *testing.T) {
+	for in, want := range map[int]string{
+		0: "0", 999: "999", 1000: "1,000", 731281: "731,281", 1048576: "1,048,576", -1234: "-1,234",
+	} {
+		if got := thousands(in); got != want {
+			t.Errorf("thousands(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1358,22 +1358,12 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 				}
 			}
 		}()
+	case trimmed == "/context":
+		c.noticeDetail(c.ContextReport())
 	case trimmed == "/new":
-		go func() {
-			if err := c.NewSession(); err != nil {
-				c.notice("new session failed: " + err.Error())
-			} else {
-				c.notice("new session")
-			}
-		}()
+		c.runSessionVerb(c.NewSession, "new session", "new session failed: ")
 	case trimmed == "/clear":
-		go func() {
-			if err := c.ClearSession(); err != nil {
-				c.notice("clear context failed: " + err.Error())
-			} else {
-				c.notice("context cleared")
-			}
-		}()
+		c.runSessionVerb(c.ClearSession, "context cleared", "clear context failed: ")
 	case strings.HasPrefix(trimmed, "/mcp__"):
 		c.runGuarded(func(ctx context.Context) error {
 			sent, found, err := c.MCPPrompt(ctx, trimmed)

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -135,6 +135,7 @@ type SessionHistory interface {
 	SwitchBranch(ref string) (agent.BranchInfo, error)
 	Compact(ctx context.Context, instructions string) error
 	CompactRatio() float64
+	ContextReport() (summary, detail string)
 	SummarizeFrom(ctx context.Context, turn int) error
 	SummarizeUpTo(ctx context.Context, turn int) error
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -226,6 +226,7 @@ type Messages struct {
 	CmdClear            string // /clear
 	CmdCls              string // /cls
 	CmdCompact          string // /compact
+	CmdContext          string // /context
 	CmdRewind           string // /rewind
 	CmdTree             string // /tree
 	CmdBranch           string // /branch

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -241,6 +241,7 @@ var English = Messages{
 	CmdClear:            "discard current context",
 	CmdCls:              "clear screen only (keep LLM context)",
 	CmdCompact:          "compact context",
+	CmdContext:          "show context window, thresholds, and last maintenance",
 	CmdRewind:           "rewind to an earlier turn",
 	CmdTree:             "show conversation branches",
 	CmdBranch:           "create a conversation branch",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -242,6 +242,7 @@ var Chinese = Messages{
 	CmdClear:            "丢弃当前上下文",
 	CmdCls:              "清屏（保留 LLM 上下文）",
 	CmdCompact:          "压缩上下文",
+	CmdContext:          "查看上下文窗口、阈值与上次维护结果",
 	CmdRewind:           "回滚到更早的一轮",
 	CmdTree:             "查看对话分支树",
 	CmdBranch:           "创建对话分支",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -231,6 +231,7 @@ var ChineseTraditional = Messages{
 	CmdNew:              "清空上下文並儲存歷史",
 	CmdCls:              "清除畫面（保留 LLM 上下文）",
 	CmdCompact:          "壓縮上下文",
+	CmdContext:          "檢視上下文視窗、閾值與上次維護結果",
 	CmdRewind:           "回滾到更早的一輪",
 	CmdTree:             "檢視對話分支樹",
 	CmdBranch:           "建立對話分支",


### PR DESCRIPTION
## Why

Every compaction decision divides by the context window, so a window that is too small looks exactly like a context that is genuinely full — both just compact. Nothing exposed the number, and nothing exposed why a maintenance pass did or did not run. That is the gap behind both "Reasonix compacts too early" reports and #7935's "it keeps snipping but never compacts": the user can see the symptom and never the input.

## What it shows

```
context 121,000 / 131,072 (92%) · next: at the force threshold · maintenance blocked
window            131,072  (usable 98,304 after output reserve)
latest prompt     121,000  (92% of window)
canonical         121,000
model-visible     121,000
thresholds        snip 78,643 · fold 98,304 · force 117,964
last maintenance  degraded · pressure
blocked           context summary failed: span 2 of 2: context deadline exceeded
```

Details worth calling out:

- **latest prompt is the last request's shape**, via `LatestPromptTokens()` — never the billable retry aggregate, which would report pressure the model never saw. A test pins this with a 363K billed / 122K actual usage.
- **thresholds are absolute tokens**, not percentages, so they can be compared directly against the prompt above them.
- **usable ceiling** surfaces `hardInputCeiling()`, i.e. what the output reserve leaves — the number the fold threshold is actually clamped to.
- **blocked** surfaces the persisted maintenance-blocked reason. This is the line that was previously invisible: a failing pass only ever emitted a `LevelInfo` notice.
- The summary **names the next action** instead of only reporting fullness, since "70%" alone does not say whether that is near anything.

Thresholds come from `compactThresholds` and `forceCompactThreshold` — the same helpers the decision uses — and a test asserts the report cannot drift from them.

## Structure

Behavior lives in the controller (`ContextReport`), so `serve` and `desktop` inherit it through the existing slash dispatch rather than reimplementing a panel; the CLI adds a handler that commits the block instead of a one-line notice.

Adding a command to two files already at their size budget would have widened the repolint baseline, which the project forbids, so the routing pays for itself:

- `/new` and `/clear` in the controller were two copies of the same goroutine-and-report block; they now share `runSessionVerb`.
- `/remember` moves out of the CLI switch alongside the new `/context` handler.

Notice texts are unchanged, and repolint stays `clean (1972 baselined findings)` with the baseline untouched — verified by applying the full patch to a clean checkout of the base commit.

## Tests

- report uses latest-request prompt tokens, not the billed aggregate
- report thresholds equal what `compactThresholds` / `forceCompactThreshold` return
- a zero window reports no thresholds rather than meaningless ones
- the summary names the right next action in each pressure band, and flags a blocked pass
- digit grouping
- the existing `/co` completion test now expects `/compact /context /copy`

Documentation-impact: updated - added /context to the built-in command lists in docs/GUIDE.md and docs/GUIDE.zh-CN.md
