### PR TITLE
perf(memory): bound the prefix memory index with a recency budget

### DIFF
--- a/internal/memory/index_bounded.go
+++ b/internal/memory/index_bounded.go
@@ -1,0 +1,99 @@
+package memory
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/textutil"
+)
+
+// defaultPrefixIndexMaxChars bounds the index projection rendered into the
+// cached system-prompt prefix. The on-disk MEMORY.md stays complete; only the
+// prefix-facing projection is capped, keeping every-turn prefix tokens bounded
+// as memories accumulate. Roughly 300 tokens at 4 chars/token.
+const defaultPrefixIndexMaxChars = 1200
+
+// IndexBounded renders the index projection that loads into the cached prefix:
+// stale facts (per memoryFreshness) fold into a summary line and the rest are
+// ordered by recency, capped to a soft budget of maxChars (at least one line
+// always renders). Deterministic in the memory set and now, so the prefix
+// stays byte-stable within a session.
+func (s Store) IndexBounded(now time.Time, maxChars int) string {
+	memories := s.ListAll()
+	if len(memories) == 0 {
+		return ""
+	}
+	return renderBoundedIndex(memories, now, maxChars)
+}
+
+// maxIndexDescriptionGraphemes bounds one line's description in the prefix
+// projection so a single long fresh fact cannot consume the whole budget; the
+// on-disk index keeps descriptions whole.
+const maxIndexDescriptionGraphemes = 120
+
+// renderBoundedIndex is the deterministic core of IndexBounded, separated out
+// for direct testing with a fixed clock and memory set.
+func renderBoundedIndex(memories []Memory, now time.Time, maxChars int) string {
+	// Shadowed globals (project overrides same-name global, #7995) are
+	// represented by their project winner; the shadowed global is dropped so
+	// recency can never surface it as authoritative when the winner was cut.
+	shadowed := map[string]bool{}
+	for _, o := range FindOverrides(memories) {
+		shadowed[o.Global.ID] = true
+	}
+	active := make([]Memory, 0, len(memories))
+	folded := 0     // stale + hard-expired facts
+	suppressed := 0 // shadowed globals represented by their project winner
+	for _, m := range memories {
+		freshness := memoryFreshness(m, now)
+		if freshness == FreshnessStale || freshness == FreshnessExpired {
+			folded++
+			continue
+		}
+		if shadowed[m.ID] {
+			suppressed++
+			continue
+		}
+		active = append(active, m)
+	}
+	// Most recently updated first; equal timestamps keep the stable name order
+	// ListAll() already produced.
+	sort.SliceStable(active, func(i, j int) bool {
+		return memoryUpdatedAt(active[i]).After(memoryUpdatedAt(active[j]))
+	})
+	var b strings.Builder
+	kept := 0
+	for _, m := range active {
+		clipped := m
+		clipped.Description = textutil.ClipGraphemes(m.Description, maxIndexDescriptionGraphemes, "…")
+		line := renderQualifiedIndexLine(clipped) + "\n"
+		if kept > 0 && b.Len()+len(line) > maxChars {
+			break
+		}
+		b.WriteString(line)
+		kept++
+	}
+	omitted := len(active) - kept + suppressed
+	switch {
+	case omitted > 0:
+		fmt.Fprintf(&b, "- +%d more facts", omitted)
+		if folded > 0 {
+			fmt.Fprintf(&b, " (%d stale)", folded)
+		}
+		b.WriteString(" — search with the memory tool\n")
+	case folded > 0:
+		fmt.Fprintf(&b, "- %d stale facts hidden — search with the memory tool\n", folded)
+	}
+	return b.String()
+}
+
+// memoryUpdatedAt returns the timestamp a fact is ordered by: UpdatedAt,
+// falling back to CreatedAt when zero.
+func memoryUpdatedAt(m Memory) time.Time {
+	if !m.UpdatedAt.IsZero() {
+		return m.UpdatedAt
+	}
+	return m.CreatedAt
+}

--- a/internal/memory/index_bounded_test.go
+++ b/internal/memory/index_bounded_test.go
@@ -1,0 +1,216 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIndexBoundedOrdersByRecency verifies the prefix index projection orders
+// active facts by most-recently-updated first.
+func TestIndexBoundedOrdersByRecency(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "oldest", Description: "old", Type: TypeProject, UpdatedAt: now.Add(-90 * 24 * time.Hour)},
+		{Name: "newest", Description: "new", Type: TypeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+		{Name: "middle", Description: "mid", Type: TypeProject, UpdatedAt: now.Add(-30 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	pos := map[string]int{}
+	for _, name := range []string{"newest", "middle", "oldest"} {
+		pos[name] = strings.Index(got, "(project/"+name+".md)")
+		if pos[name] < 0 {
+			t.Fatalf("index missing %q:\n%s", name, got)
+		}
+	}
+	if !(pos["newest"] < pos["middle"] && pos["middle"] < pos["oldest"]) {
+		t.Fatalf("recency order wrong: %v\n%s", pos, got)
+	}
+	if strings.Contains(got, "more facts") || strings.Contains(got, "stale facts") {
+		t.Fatalf("unexpected fold line:\n%s", got)
+	}
+}
+
+// TestIndexBoundedFoldsStale verifies stale facts are hidden from the prefix
+// projection and counted on a summary line instead of occupying budget.
+func TestIndexBoundedFoldsStale(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "stale-one", Description: "old", Type: TypeProject, UpdatedAt: now.Add(-400 * 24 * time.Hour)}, // >180d → stale
+		{Name: "stale-two", Description: "older", Type: TypeProject, UpdatedAt: now.Add(-300 * 24 * time.Hour)},
+		{Name: "active", Description: "new", Type: TypeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Contains(got, "stale-one") || strings.Contains(got, "stale-two") {
+		t.Fatalf("stale facts leaked into index:\n%s", got)
+	}
+	if !strings.Contains(got, "2 stale facts hidden") {
+		t.Fatalf("missing stale fold line:\n%s", got)
+	}
+	if !strings.Contains(got, "active") {
+		t.Fatalf("active fact missing:\n%s", got)
+	}
+}
+
+// TestIndexBoundedAllStale verifies a fully stale set renders only the summary
+// line, never an empty block.
+func TestIndexBoundedAllStale(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "a", Description: "old", Type: TypeProject, UpdatedAt: now.Add(-400 * 24 * time.Hour)},
+		{Name: "b", Description: "older", Type: TypeProject, UpdatedAt: now.Add(-300 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Contains(got, ".md)") {
+		t.Fatalf("stale index lines rendered:\n%s", got)
+	}
+	if !strings.Contains(got, "2 stale facts hidden") {
+		t.Fatalf("missing stale fold line:\n%s", got)
+	}
+}
+
+// TestIndexBoundedTruncatesByBudget verifies the character budget drops the
+// tail while always keeping at least one line, and reports the omitted count.
+func TestIndexBoundedTruncatesByBudget(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "first", Description: "newest fact", Type: TypeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+		{Name: "second", Description: "another fact", Type: TypeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+		{Name: "third", Description: "yet another", Type: TypeProject, UpdatedAt: now.Add(-3 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, 40) // room for roughly one line
+	lines := strings.Count(got, "\n")
+	if lines != 2 { // one index line + fold line
+		t.Fatalf("expected 1 kept line + fold, got %d lines:\n%s", lines, got)
+	}
+	if !strings.Contains(got, "first") || strings.Contains(got, "second") || strings.Contains(got, "third") {
+		t.Fatalf("budget kept wrong lines:\n%s", got)
+	}
+	if !strings.Contains(got, "+2 more facts") {
+		t.Fatalf("missing omitted count:\n%s", got)
+	}
+}
+
+// TestIndexBoundedDeterministic verifies identical inputs produce byte-identical
+// output, which the cache-stable prefix depends on.
+func TestIndexBoundedDeterministic(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "alpha", Description: "a", Type: TypeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+		{Name: "beta", Description: "b", Type: TypeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+	}
+	first := renderBoundedIndex(memories, now, 200)
+	second := renderBoundedIndex(memories, now, 200)
+	if first != second {
+		t.Fatalf("nondeterministic index:\n%q\nvs\n%q", first, second)
+	}
+}
+
+// TestIndexBoundedMixedFold verifies the combined fold line when both stale
+// facts and budget-omitted facts exist.
+func TestIndexBoundedMixedFold(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "stale", Description: "old", Type: TypeProject, UpdatedAt: now.Add(-400 * 24 * time.Hour)},
+		{Name: "keep", Description: "newest fact", Type: TypeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+		{Name: "cut", Description: "second fact", Type: TypeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+		{Name: "cut2", Description: "third fact", Type: TypeProject, UpdatedAt: now.Add(-3 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, 40) // room for ~1 active line
+	if !strings.Contains(got, "+2 more facts (1 stale)") {
+		t.Fatalf("missing combined fold line:\n%s", got)
+	}
+	if strings.Contains(got, "stale facts hidden") {
+		t.Fatalf("wrong fold branch chosen:\n%s", got)
+	}
+}
+
+// TestIndexBoundedZeroTimestampFallback verifies facts with a zero UpdatedAt
+// are ordered by CreatedAt instead of sinking to the bottom.
+func TestIndexBoundedZeroTimestampFallback(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "no-updated", Description: "created recently", Type: TypeProject, CreatedAt: now.Add(-1 * 24 * time.Hour)}, // UpdatedAt zero
+		{Name: "updated", Description: "updated long ago", Type: TypeProject, UpdatedAt: now.Add(-90 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Index(got, "(no-updated.md)") > strings.Index(got, "(updated.md)") {
+		t.Fatalf("CreatedAt fallback ordering wrong:\n%s", got)
+	}
+}
+
+// TestFoldLineNotManagedIndexLine pins that fold lines never match indexLineRe,
+// so reindex/Delete keep treating them as unmanaged (and they never reach disk).
+func TestFoldLineNotManagedIndexLine(t *testing.T) {
+	for _, line := range []string{
+		"- +9 more facts (3 stale) — search with the memory tool",
+		"- 3 stale facts hidden — search with the memory tool",
+	} {
+		if indexLineRe.MatchString(line) {
+			t.Fatalf("fold line %q matches managed index regex", line)
+		}
+	}
+}
+
+// TestIndexBoundedSuppressesShadowedGlobals verifies a global fact shadowed by
+// a same-name project fact never appears alone in the bounded view: the project
+// winner represents it, so a recency order cannot surface the shadowed global
+// as authoritative when the winner was budget-cut or folded.
+func TestIndexBoundedSuppressesShadowedGlobals(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{ID: "g-dup", Name: "dup", Description: "global side", Type: TypeProject, Scope: FactScopeGlobal, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+		{ID: "p-dup", Name: "dup", Description: "project winner", Type: TypeProject, Scope: FactScopeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+		{ID: "p-own", Name: "own", Description: "unrelated", Type: TypeProject, Scope: FactScopeProject, UpdatedAt: now.Add(-3 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Contains(got, "global side") {
+		t.Fatalf("shadowed global leaked into the bounded view:\n%s", got)
+	}
+	if !strings.Contains(got, "project winner") {
+		t.Fatalf("project winner missing from the bounded view:\n%s", got)
+	}
+	if !strings.Contains(got, "+1 more facts") {
+		t.Fatalf("fold line must count the shadowed global:\n%s", got)
+	}
+}
+
+// TestIndexBoundedFoldsExpired verifies hard-expired facts (explicit expires_at
+// in the past) are folded like stale ones instead of rendering as active lines.
+func TestIndexBoundedFoldsExpired(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	memories := []Memory{
+		{Name: "gone", Description: "expired fact", Type: TypeProject, Scope: FactScopeProject, ExpiresAt: now.Add(-1 * time.Hour)},
+		{Name: "alive", Description: "active fact", Type: TypeProject, Scope: FactScopeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Contains(got, "expired fact") {
+		t.Fatalf("expired fact rendered as active:\n%s", got)
+	}
+	if !strings.Contains(got, "1 stale facts hidden") {
+		t.Fatalf("missing expired fold line:\n%s", got)
+	}
+}
+
+// TestIndexBoundedClipsLongDescription verifies the bounded projection clips a
+// single line's description to maxIndexDescriptionGraphemes so one long fresh
+// fact cannot consume the whole budget; short descriptions stay whole and the
+// on-disk index (renderQualifiedIndexLine) is untouched by the clip.
+func TestIndexBoundedClipsLongDescription(t *testing.T) {
+	now := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+	longDesc := strings.Repeat("长描述", 100) // 200 graphemes, over the 120 cap
+	memories := []Memory{
+		{Name: "long", Description: longDesc, Type: TypeProject, UpdatedAt: now.Add(-1 * 24 * time.Hour)},
+		{Name: "short", Description: "brief", Type: TypeProject, UpdatedAt: now.Add(-2 * 24 * time.Hour)},
+	}
+	got := renderBoundedIndex(memories, now, defaultPrefixIndexMaxChars)
+	if strings.Contains(got, longDesc) {
+		t.Fatalf("long description should be clipped in the bounded view:\n%s", got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Fatalf("clipped description should end with ellipsis:\n%s", got)
+	}
+	if !strings.Contains(got, "brief") {
+		t.Fatalf("short description stays whole:\n%s", got)
+	}
+}

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"reasonix/internal/instruction"
 )
@@ -18,7 +19,7 @@ type Set struct {
 	Docs                   []Source // REASONIX.md / AGENTS.md, ascending precedence
 	PinnedGuidance         []Memory // stable snapshot of pinned fact bodies (incl. legacy global user/feedback)
 	Store                  Store    // auto-memory store (may be a zero/disabled Store)
-	Index                  string   // MEMORY.md contents at load time
+	Index                  string   // bounded index projection folded into the prefix at load time
 	CWD                    string   // project working dir used for discovery
 	UserDir                string   // user config root (may be "")
 	InstructionDiagnostics []instruction.Diagnostic
@@ -57,13 +58,22 @@ func Load(opts Options) *Set {
 		Docs:                   resolved.Documents,
 		PinnedGuidance:         store.pinnedGuidanceForProject(),
 		Store:                  store,
-		Index:                  store.Index(),
+		Index:                  store.IndexBounded(prefixIndexNow(), defaultPrefixIndexMaxChars),
 		CWD:                    cwd,
 		UserDir:                opts.UserDir,
 		InstructionDiagnostics: resolved.Diagnostics,
 		recall:                 BuildRecallIndex(store),
 	}
 }
+
+// prefixIndexNow pins the prefix-index reference clock to process start so a
+// same-session rebuild re-Loads the store with the same now: the prefix stays
+// a pure function of the memory set, keeping DeepSeek's prefix cache warm.
+func prefixIndexNow() time.Time {
+	return sessionStartTime
+}
+
+var sessionStartTime = time.Now()
 
 // DocPath returns the doc-memory file a given scope writes to. To avoid splitting
 // a project's memory across conventions, it prefers a file that already exists

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	fileencoding "reasonix/internal/fileutil/encoding"
 )
@@ -54,6 +55,64 @@ func TestBlockSeparatesStandingInstructionsFromBackgroundMemory(t *testing.T) {
 		if strings.Contains(block, privatePath) {
 			t.Fatalf("Block() exposed machine-local path %q:\n%s", privatePath, block)
 		}
+	}
+}
+
+// TestLoadBoundsPrefixIndex verifies the Set.Index projection respects the
+// prefix budget even when the full store holds many facts, and that a fold
+// line tells the model more memories exist.
+func TestLoadBoundsPrefixIndex(t *testing.T) {
+	root := t.TempDir()
+	user := filepath.Join(root, "user")
+	proj := filepath.Join(root, "project")
+	mustMkdir(t, proj)
+	store := StoreFor(user, proj)
+	names := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu"}
+	for _, name := range names {
+		desc := strings.Repeat("description text ", 6) // ~120 chars per line
+		if _, err := store.Save(Memory{Name: name, Description: desc, Type: TypeProject, Body: "body"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	set := Load(Options{CWD: proj, UserDir: user})
+	if set.Index == "" {
+		t.Fatal("expected a bounded index projection")
+	}
+	if len(set.Index) > defaultPrefixIndexMaxChars+200 {
+		t.Fatalf("prefix index %d chars exceeds budget %d:\n%s", len(set.Index), defaultPrefixIndexMaxChars, set.Index)
+	}
+	if !strings.Contains(set.Index, "more facts") {
+		t.Fatalf("expected a fold line:\n%s", set.Index)
+	}
+}
+
+// TestLoadIndexUsesSessionPinnedClock locks the cache contract: the prefix
+// index must be a pure function of the memory set within a session, not of
+// the wall clock — a same-session rebuild must produce byte-identical output.
+func TestLoadIndexUsesSessionPinnedClock(t *testing.T) {
+	old := sessionStartTime
+	defer func() { sessionStartTime = old }()
+
+	// Pin the session clock 200 days ahead of the wall clock: a fact written
+	// now is fresh by the wall clock but stale by the pinned clock, so the
+	// rendered index must fold it — the pinned clock wins.
+	sessionStartTime = time.Now().AddDate(0, 0, 200)
+
+	root := t.TempDir()
+	user := filepath.Join(root, "user")
+	proj := filepath.Join(root, "project")
+	mustMkdir(t, proj)
+	store := StoreFor(user, proj)
+	if _, err := store.Save(Memory{Name: "pinned-fact", Description: "a fact fresh by wall clock", Type: TypeProject, Body: "body"}); err != nil {
+		t.Fatal(err)
+	}
+
+	set := Load(Options{CWD: proj, UserDir: user})
+	if !strings.Contains(set.Index, "stale facts hidden") {
+		t.Fatalf("pinned session clock should fold the stale fact:\n%s", set.Index)
+	}
+	if strings.Contains(set.Index, "pinned-fact") {
+		t.Fatalf("folded fact must not render in the index:\n%s", set.Index)
 	}
 }
 


### PR DESCRIPTION
## Summary

- 现状： MEMORY.md 索引在启动时全量折叠进缓存前缀（system prompt），每轮请求都付这份 token 成本；索引按 Name 排序、陈旧事实永不淘汰（唯一移除路径是手动 forget）——记忆越积越多，前缀成本单调上涨且无上限。
- 本 PR：新增 IndexBounded ，把进前缀的索引投影改为——陈旧事实（沿用 memoryFreshness：user/feedback 90/365 天、reference 14/45 天、其余 30/180 天）折叠成一行汇总，活跃事实按最近更新降序，1200 字符软预算（至少保留 1 行），折叠行提示 "+N more facts (M stale) — search with the memory tool"，告知模型更多记忆存在、可用 memory 工具检索。
- 磁盘 MEMORY.md 保持全量不变（reindex 照旧），只裁剪进前缀的投影；Index() 全量版保留给工具/诊断。渲染是 (记忆集, now) 的纯函数，会话内前缀字节稳定（cache-first 不变式保持），standing instructions 与召回行为零改动。

## Issues

（可留空）

## Verification

- 新增 9 个测试：recency 排序 / stale 折叠（含全 stale）/ 预算裁剪（至少保留 1 行）/ 确定性 / 组合折叠 +N more (M stale) / 零时间戳回落 CreatedAt / 折叠行不匹配 managed 索引正则 / Load 接线预算断言
- go test ./internal/memory/ ./internal/boot/ 全通过（boot golden 无漂移，testdata 无记忆 fixture）
- gofmt -l 无输出；go vet 通过
- 全量 go test -count=1 ./... ：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 fix(sandbox): probe sandbox-exec usability instead of PATH presence #7807）

## Documentation impact

Documentation-impact: none - 不改记忆模型、命令或配置；索引投影是内部渲染规则，MEMORY.md 的语义描述不变。

## Cache impact

Cache-impact: low - 索引投影是 (记忆集, now) 的确定性函数、启动时快照，会话内前缀字节稳定（与现状同一规则）；仅投影规则变化（一次性），standing instructions 与 recall 未动。
Cache-guard: 聚焦 guard—— go test ./internal/boot -run TestGoldenBaseline （前缀基线）+ TestIndexBoundedDeterministic （字节稳定）+ 既有 memory 测试；scripts/cache-guard.sh 为 release 级缓存命中检查（本次未跑，改动不触 provider 请求序列化）。
System-prompt-review: esengine — 模型可见的索引列表可能缩减（折叠行保留可发现性，memory 工具仍是检索路径）；需维护者确认后合并。