### PR TITLE
perf(agent): add a compaction cooldown to stop re-trigger token burn

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -525,18 +525,25 @@ type Agent struct {
 	// under archiveDir. compactStuck latches when compaction can't get the prompt
 	// under the window (consecutiveCompacts crosses the limit), so auto-compaction
 	// pauses instead of looping. softCompactNoticed gates the one-shot soft-ratio
-	// notice so it fires once per approach, not every turn.
-	contextWindow       int
-	softCompactRatio    float64
-	toolResultSnipRatio float64
-	compactRatio        float64
-	compactForceRatio   float64
-	softCompactNoticed  bool
-	recentKeep          int
-	archiveDir          string
-	keepPolicy          KeepPolicy
-	compactStuck        bool
-	consecutiveCompacts int
+	// notice so it fires once per approach, not every turn. The cooldown
+	// (compactGapRatio) additionally requires the prompt to regrow past a
+	// fraction of the window after a successful compaction before folding again,
+	// so a tail that still exceeds the trigger (one oversized tool result) does
+	// not re-pay a full-region replay every turn.
+	contextWindow          int
+	softCompactRatio       float64
+	toolResultSnipRatio    float64
+	compactRatio           float64
+	compactGapRatio        float64
+	compactForceRatio      float64
+	softCompactNoticed     bool
+	recentKeep             int
+	archiveDir             string
+	keepPolicy             KeepPolicy
+	compactStuck           bool
+	consecutiveCompacts    int
+	lastAutoCompactPrompt  int  // prompt tokens at the last successful auto-compaction (cooldown anchor)
+	compactCooldownNoticed bool // gates the one-shot cooldown notice so it fires once per stall, not every turn
 	// activeTurnCreatedAt identifies the real/synthetic user message that began
 	// the currently running turn. Compaction may rewrite older history while a
 	// tool loop is active, but it must keep this message and everything after it
@@ -974,7 +981,8 @@ func (a *Agent) CompactRatio() float64 { return a.compactRatio }
 // TUI's `/compact` command so the user can reset the prefix before it
 // naturally fills up.
 func (a *Agent) CompactNow(ctx context.Context, instructions string) error {
-	return a.compact(ctx, "manual", instructions, true)
+	_, err := a.compact(ctx, "manual", instructions, true)
+	return err
 }
 
 // Options configures an Agent.
@@ -1030,6 +1038,7 @@ type Options struct {
 	SoftCompactRatio    float64
 	ToolResultSnipRatio float64
 	CompactRatio        float64
+	CompactGapRatio     float64
 	CompactForceRatio   float64
 	RecentKeep          int
 	ArchiveDir          string
@@ -1145,6 +1154,9 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if opts.CompactRatio <= 0 {
 		opts.CompactRatio = defaultCompactRatio
 	}
+	if opts.CompactGapRatio <= 0 {
+		opts.CompactGapRatio = defaultCompactGapRatio
+	}
 	if opts.ToolResultSnipRatio >= opts.CompactRatio {
 		opts.ToolResultSnipRatio = opts.CompactRatio
 	}
@@ -1235,6 +1247,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		softCompactRatio:          opts.SoftCompactRatio,
 		toolResultSnipRatio:       opts.ToolResultSnipRatio,
 		compactRatio:              opts.CompactRatio,
+		compactGapRatio:           opts.CompactGapRatio,
 		compactForceRatio:         opts.CompactForceRatio,
 		recentKeep:                opts.RecentKeep,
 		archiveDir:                opts.ArchiveDir,

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -27,6 +27,7 @@ const (
 	defaultToolResultSnipRatio = 0.6   // rewrite stale tool results cheaply before summary compaction
 	defaultCompactRatio        = 0.8   // trigger: prompt at this fraction of the window compacts
 	defaultCompactForceRatio   = 0.9   // force compaction at this high-water mark even for low-value folds
+	defaultCompactGapRatio     = 0.1   // cooldown: after a successful auto-compaction, require the prompt to regrow this fraction of the window before folding again
 	defaultCompactTarget       = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
 	defaultTailTokens          = 16384 // verbatim recent-tail budget, in tokens
 	minRecentKeep              = 2     // never keep fewer recent messages than this
@@ -112,6 +113,11 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if u.PromptTokens < high {
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
+		a.compactCooldownNoticed = false
+		// The prompt fell back under the trigger, so the cooldown anchor from any
+		// earlier compaction no longer applies: a fresh approach is a healthy new
+		// cycle, not a re-trigger of a still-full window.
+		a.lastAutoCompactPrompt = 0
 	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
@@ -148,9 +154,38 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 			return
 		}
 	}
-	if err := a.compact(ctx, "auto", "", force); err != nil {
+	// Cooldown: after a successful auto-compaction, wait until the prompt has
+	// regrown meaningfully before folding again. A re-trigger with almost no
+	// growth means the kept tail alone (usually one oversized tool result) still
+	// exceeds the threshold — compacting again would pay another full-region
+	// replay plus a cache crater for the same outcome. The force high-water
+	// mark always bypasses the cooldown so context never runs away.
+	if !force && a.lastAutoCompactPrompt > 0 {
+		gap := int(float64(a.contextWindow) * a.compactGapRatio)
+		if grew := u.PromptTokens - a.lastAutoCompactPrompt; grew < gap {
+			if !a.compactCooldownNoticed {
+				a.compactCooldownNoticed = true
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
+					Text:   "Context cleanup held off briefly by cooldown after the last compaction.",
+					Detail: fmt.Sprintf("prompt grew %d tokens since the last compaction (cooldown needs %d); skipping to avoid another full replay. Will resume as the prompt grows.", grew, gap)})
+			}
+			return
+		}
+	}
+	folded, err := a.compact(ctx, "auto", "", force)
+	if err != nil {
+		// A failed pass must not leave the cooldown armed: nothing was folded, so
+		// the next trigger is a fresh attempt rather than a re-trigger.
+		a.lastAutoCompactPrompt = 0
+		a.compactCooldownNoticed = false
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context cleanup skipped for now.", Detail: fmt.Sprintf("compaction skipped: %v", err)})
 		return
+	}
+	// Anchor the cooldown only on a pass that actually folded something: a
+	// no-op pass (economics, active-turn guard, extension-emptied fold) must
+	// not delay the next genuine attempt to the force high-water mark.
+	if folded {
+		a.lastAutoCompactPrompt = u.PromptTokens
 	}
 	// A healthy compaction drops the prompt under the trigger, so the next turn
 	// won't compact. Compacting on consecutive turns means the kept tail alone
@@ -224,7 +259,7 @@ func estimateTextTokens(s string) int {
 // high-water mark always compact). A Started event is emitted before the (network)
 // summarize so the UI can show a "compacting…" placeholder, and a Done event
 // (carrying the summary) replaces it.
-func (a *Agent) compact(ctx context.Context, trigger, instructions string, force bool) error {
+func (a *Agent) compact(ctx context.Context, trigger, instructions string, force bool) (bool, error) {
 	msgs := a.session.Messages
 	head, start, ok := a.planCompaction(msgs, minCompactMessages)
 	if !ok {
@@ -234,7 +269,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 		head, start, ok = a.planCompaction(msgs, 1)
 	}
 	if !ok {
-		return nil // recent tail already covers everything worth keeping
+		return false, nil // recent tail already covers everything worth keeping
 	}
 	// A controller in-flight marker records the pre-turn message count, but a
 	// compaction rewrites message indexes. Keep the entire active turn outside
@@ -244,7 +279,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	if active := a.activeTurnStart(msgs); active >= head && active < start {
 		start = active
 		if start <= head {
-			return nil
+			return false, nil
 		}
 	}
 	region := msgs[head:start]
@@ -254,13 +289,13 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	// wherever in the session they said it); only the rest folds into the digest.
 	kept, fold := a.partitionFold(region)
 	if len(fold) == 0 {
-		return nil // nothing but kept user turns — a fold would save nothing
+		return false, nil // nothing but kept user turns — a fold would save nothing
 	}
 
 	// Economic check on the foldable part (kept user turns don't count toward the
 	// savings): skip if too small to justify the call, unless force demands it.
 	if !force && !foldEconomics(fold) {
-		return nil
+		return false, nil
 	}
 
 	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
@@ -283,11 +318,11 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	fold, instructions, err = a.interceptCompactionPrepare(ctx, fold, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
-		return err
+		return false, err
 	}
 	if len(fold) == 0 {
 		a.emitCompactionAborted(trigger)
-		return nil // the extension replaced the fold with nothing to fold
+		return false, nil // the extension replaced the fold with nothing to fold
 	}
 
 	archived := ""
@@ -295,7 +330,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 		path, err := archiveMessages(a.archiveDir, fold)
 		if err != nil {
 			a.emitCompactionAborted(trigger)
-			return fmt.Errorf("archive: %w", err)
+			return false, fmt.Errorf("archive: %w", err)
 		}
 		archived = path
 	}
@@ -319,7 +354,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	summary, err = a.interceptCompactionComplete(ctx, summary)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
-		return err
+		return false, err
 	}
 
 	compacted := make([]provider.Message, 0, head+len(kept)+1+len(msgs)-start)
@@ -338,7 +373,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
 	}})
-	return nil
+	return true, nil
 }
 
 // emitCompactionAborted resolves a "compacting…" placeholder when a pass fails

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -161,7 +161,7 @@ func TestCompactKeepsMidSessionUserTurns(t *testing.T) {
 	a := New(&fakeProvider{reply: "digest"}, tool.NewRegistry(), sess,
 		Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -235,7 +235,7 @@ func TestCompactKeepsPriorDigests(t *testing.T) {
 	a := New(&fakeProvider{reply: "new digest"}, tool.NewRegistry(), sess,
 		Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -267,7 +267,7 @@ func TestCompactReplacesHistory(t *testing.T) {
 	dir := t.TempDir()
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := sess.RewriteVersion(); got != 1 {
@@ -324,7 +324,7 @@ func TestCompactKeepsErrorMessages(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir(), KeepPolicy: KeepErrors}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if len(sess.Messages) < 6 {
@@ -391,7 +391,7 @@ func TestCompactKeepsUserMarkedMessages(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir(), KeepPolicy: KeepUserMarked}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	var kept bool
@@ -444,7 +444,7 @@ func TestCompactFallsBackToMechanicalFoldWhenSummaryFails(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, sink)
 
 	before := len(sess.Messages)
-	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact should fall back, not error: %v", err)
 	}
 	if len(sess.Messages) >= before {
@@ -490,7 +490,7 @@ func TestCompactEmitsEvents(t *testing.T) {
 	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, sink)
 
-	if err := a.compact(context.Background(), "auto", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "auto", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -536,7 +536,7 @@ func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, Hooks: &stubHooks{preCompactOut: "KEEP-THE-MIGRATION-PLAN"}}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "focus on the auth refactor", true); err != nil {
+	if _, err := a.compact(context.Background(), "manual", "focus on the auth refactor", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if len(prov.got) == 0 || prov.got[0].Role != provider.RoleSystem {
@@ -565,7 +565,7 @@ func TestCompactRewriteVersionFeedsCacheDiagnostics(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, event.Discard)
 	before := CaptureShape("sys", nil, sess.RewriteVersion())
 
-	if err := a.compact(context.Background(), "auto", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "auto", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -590,7 +590,7 @@ func TestCompactFoldsSingleLargeMessage(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background(), "auto", "", false); err != nil {
+	if _, err := a.compact(context.Background(), "auto", "", false); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := len(sess.Messages); got != 4 {
@@ -614,7 +614,7 @@ func TestCompactSkipsSingleSmallMessage(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background(), "auto", "", false); err != nil {
+	if _, err := a.compact(context.Background(), "auto", "", false); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := len(sess.Messages); got != 4 {
@@ -823,7 +823,7 @@ func TestCompactKeepsActiveTurnVerbatim(t *testing.T) {
 	}, event.Discard)
 	a.activeTurnCreatedAt.Store(currentCreatedAt)
 
-	if err := a.compact(context.Background(), "auto", "", true); err != nil {
+	if _, err := a.compact(context.Background(), "auto", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	start := a.activeTurnStart(sess.Messages)
@@ -983,20 +983,88 @@ func TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger(t *testing.T) {
 	}
 }
 
-// TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger proves the safety
-// valve survives the fix above: a genuinely too-small window (the prompt never
-// drops under the trigger between compactions) must still pause auto-compaction.
-func TestMaybeCompactStillLatchesWhenPromptStaysAboveTrigger(t *testing.T) {
-	sess := NewSession("sys")
-	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
-	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+// foldableSess returns a session with a genuinely foldable early region (an
+// early user message beyond the 1500-token keep cap), so compact() actually
+// folds and arms the cooldown anchor in tests.
+func foldableSess() *Session {
+	return &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("LARGE EARLY CONTENT. ", 300)},
+		{Role: provider.RoleAssistant, Content: "first answer"},
+		{Role: provider.RoleUser, Content: "next"},
+	}}
+}
+
+// TestMaybeCompactCooldownBlocksReTriggerWithoutGrowth proves the cooldown
+// intercepts a re-trigger that regrew almost nothing (the kept tail alone
+// still exceeds the trigger) after a successful compaction — the loop that
+// used to re-pay a full-region replay on consecutive turns. The stuck latch
+// is no longer the first line of defense: the cooldown stops the second
+// compaction before it ever pays.
+func TestMaybeCompactCooldownBlocksReTriggerWithoutGrowth(t *testing.T) {
+	sess := foldableSess()
+	var notices []event.Event
+	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	}))
 
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
-	if a.compactStuck {
-		t.Fatalf("a single over-trigger compaction must not latch: consecutiveCompacts=%d", a.consecutiveCompacts)
+	if a.compactStuck || a.consecutiveCompacts != 1 {
+		t.Fatalf("first over-trigger compaction: consecutiveCompacts=%d compactStuck=%v", a.consecutiveCompacts, a.compactStuck)
 	}
+	// Same prompt again: grew 0 < gap (0.1×20000). Cooldown blocks; no second
+	// compaction, no stuck latch, one cooldown notice.
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
+	if a.compactStuck || a.consecutiveCompacts != 1 {
+		t.Fatalf("cooldown must block the re-trigger: consecutiveCompacts=%d compactStuck=%v", a.consecutiveCompacts, a.compactStuck)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0].Text, "held off") {
+		t.Fatalf("cooldown notice = %+v", notices)
+	}
+	// A single cooldown notice, not one per turn.
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17100})
+	if len(notices) != 1 {
+		t.Fatalf("cooldown notice should emit once, got %d", len(notices))
+	}
+}
+
+// TestMaybeCompactCooldownClearsOnHealthyRecovery verifies a compaction that
+// drops the prompt back under the trigger resets the cooldown anchor, so a
+// later healthy approach compacts again at the normal trigger instead of
+// being pushed to the force high-water mark.
+func TestMaybeCompactCooldownClearsOnHealthyRecovery(t *testing.T) {
+	sess := foldableSess()
+	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000}) // compacts, anchors cooldown
+	if a.consecutiveCompacts != 1 {
+		t.Fatalf("first compaction: consecutiveCompacts=%d", a.consecutiveCompacts)
+	}
+	// Healthy recovery: the prompt drops back under the trigger, clearing the
+	// latch and the cooldown anchor.
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 15000})
+	if a.consecutiveCompacts != 0 || a.lastAutoCompactPrompt != 0 {
+		t.Fatalf("healthy dip must clear latch and cooldown anchor: consecutiveCompacts=%d anchor=%d", a.consecutiveCompacts, a.lastAutoCompactPrompt)
+	}
+	// A fresh approach compacts again at the normal trigger — not delayed to force.
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000})
+	if a.consecutiveCompacts != 1 || a.compactStuck {
+		t.Fatalf("fresh approach must compact: consecutiveCompacts=%d compactStuck=%v", a.consecutiveCompacts, a.compactStuck)
+	}
+}
+
+// TestMaybeCompactForceBypassesCooldownAndLatches keeps the safety valve: the
+// force high-water mark (0.9×window) bypasses the cooldown, so a genuinely
+// too-small window still pauses auto-compaction after two compactions.
+func TestMaybeCompactForceBypassesCooldownAndLatches(t *testing.T) {
+	sess := foldableSess()
+	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 17000}) // non-force, anchors the cooldown
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 18000}) // force (0.9×20000) bypasses cooldown
 	if !a.compactStuck {
-		t.Fatalf("two consecutive over-trigger compactions must still latch: consecutiveCompacts=%d", a.consecutiveCompacts)
+		t.Fatalf("two compactions with force bypassing cooldown must still latch: consecutiveCompacts=%d", a.consecutiveCompacts)
 	}
 }


### PR DESCRIPTION
## Summary

- 现状：压缩无法把 prompt 压回触发阈值以下时（单条超大工具输出被保留在尾部），每轮都会重新触发压缩——每次都是一次 ~0.8×窗口的 summarizer 全量重放 + 缓存前缀失效（命中率 ~99%→0），stuck guard 要到第 2 次烧完之后才暂停。用户报的"动不动自己压缩、token 烧得吓人"正是这个循环（#8132）。
- 本 PR：给自动压缩加冷却（cooldown）——一次成功的自动压缩后，prompt 需再增长 compactGapRatio（默认 0.1×窗口）才允许再次折叠；force 高位（0.9×窗口）永远绕过冷却（上下文不会失控）。连压循环从"烧 2 次"变成"烧 1 次即停"。
- 锚点只在真正折叠（compact 重写会话）时武装：no-op（经济学/active-turn guard/extension 清空）与失败路径不武装，下次真实尝试不会被推迟到 force；prompt 掉回触发阈值以下时锚点与一次性提示重置——健康压缩周期仍在正常阈值（0.8×窗口）触发，不会被推到 0.9×窗口。

## Issues

Fixes #8132

## Verification

- 新增 3 个测试：无增长重触发被冷却拦截（含一次性提示）/ 健康回落清锚点后正常触发 / force 绕过冷却仍 latch
- go test ./internal/agent/ 全通过（含既有 stuck-latch 与 loop e2e 测试）
- gofmt -l 无输出；go vet 通过；boot golden 无漂移
- 全量 go test -count=1 ./... ：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 #7807）

## Documentation impact

Documentation-impact: none - 不新增配置项（默认值 0.1×窗口，Options 可覆盖但 CLI/config 未暴露新键）。

## Cache impact

Cache-impact: low - 不改变前缀渲染或压缩的字节格式；冷却只是减少自动压缩触发次数（每次压缩 = 一次缓存失效），因此缓存命中率只会持平或更好；健康周期触发点不变。
Cache-guard: 聚焦 guard—— go test ./internal/agent/ -run 'TestCompaction|TestMaybeCompact' （触发与循环行为）；compaction 场景的缓存归因由既有 cachehit_e2e_test.go 覆盖。
System-prompt-review: esengine — 压缩触发策略变化（冷却），不改前缀内容本身；需维护者确认冷却参数（0.1×窗口）可接受。