### PR TITLE
fix(goal): stop mispausing research goals that only read and analyze

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1594,7 +1594,7 @@ func (a *Agent) HostProgressSignature() string {
 		return ""
 	}
 	s := a.evidence.ReceiptProgressSummary()
-	return fmt.Sprintf("w=%d;c=%d;t=%d;s=%d;r=%d", s.Writes, s.Commands, s.Todos, s.Signoffs, s.Reviews)
+	return fmt.Sprintf("w=%d;c=%d;t=%d;s=%d;r=%d;reads=%d", s.Writes, s.Commands, s.Todos, s.Signoffs, s.Reviews, s.Reads)
 }
 
 type finalReadinessCheck struct {

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -69,6 +69,22 @@ func budgetClassForLegacyMode(goal string, researchMode GoalResearchMode) string
 	}
 }
 
+// noProgressQuota returns the no-progress stall limit for a budget class.
+// Research-class goals are allowed more read/analyze-only turns before the
+// host pauses them: reads and searches carry a task forward but are not
+// host-verifiable mutations, and a flat four-turn limit misfires on real
+// research (issue #8137). The turn budget remains the final backstop.
+func noProgressQuota(class string) int {
+	switch class {
+	case budgetClassResearch:
+		return 10
+	case budgetClassWrite:
+		return 6
+	default:
+		return defaultNoProgressLimit
+	}
+}
+
 // goalMachine owns the active goal FSM and its persistence. It is a strict
 // leaf: methods take only machine locks and never call back into Controller.
 // advance() takes already-gathered inputs so no disk/executor work holds mu.
@@ -335,7 +351,7 @@ func (g *goalMachine) installGoalLocked(goal, preferredBudgetClass string) {
 		g.budgetClass = preferredBudgetClass
 		g.turnsLimit = budgetQuota(g.budgetClass)
 		g.tokensLimit = 0 // no token hard limit
-		g.noProgressLimit = defaultNoProgressLimit
+		g.noProgressLimit = noProgressQuota(g.budgetClass)
 	}
 	// Installing a normal Goal always abandons any pending legacy migration.
 	g.legacyTaskID = ""
@@ -826,8 +842,11 @@ func (g *goalMachine) restoreFromState(sessionPath string) (path string, data []
 		if g.turnsLimit == 0 {
 			g.turnsLimit = budgetQuota(g.budgetClass)
 		}
-		if g.noProgressLimit == 0 {
-			g.noProgressLimit = defaultNoProgressLimit
+		if g.noProgressLimit == 0 || g.noProgressLimit == defaultNoProgressLimit {
+			// A missing or legacy flat limit (4) is re-derived from the budget
+			// class so already-running research goals benefit after an upgrade
+			// (issue #8137); only a deliberately different value is honored.
+			g.noProgressLimit = noProgressQuota(g.budgetClass)
 		}
 		// Auto-clear legacy token-budget pauses so the next user turn can
 		// continue without a manual resume. Loading itself never calls a

--- a/internal/control/goal_runtime_test.go
+++ b/internal/control/goal_runtime_test.go
@@ -196,6 +196,20 @@ func TestEvaluatorCompleteStillGatedByReadiness(t *testing.T) {
 // TestTurnTokenNoProgressPausesAndResumeExtendsBudget covers turn and
 // no-progress budgets at the FSM level and the resume extension contract.
 // Token hard limits no longer pause goals.
+// TestNoProgressQuotaByBudgetClass pins the per-class stall limits.
+func TestNoProgressQuotaByBudgetClass(t *testing.T) {
+	cases := map[string]int{
+		budgetClassResearch: 10,
+		budgetClassWrite:    6,
+		budgetClassSimple:   defaultNoProgressLimit,
+	}
+	for class, want := range cases {
+		if got := noProgressQuota(class); got != want {
+			t.Fatalf("noProgressQuota(%q) = %d, want %d", class, got, want)
+		}
+	}
+}
+
 func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
 	newMachine := func() *goalMachine {
 		g := &goalMachine{goal: "fix the parser", status: GoalStatusRunning}
@@ -243,6 +257,25 @@ func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
 		}
 		if g.status != GoalStatusBlocked || g.stopCause != stopCauseNoProgress {
 			t.Fatalf("machine = (%q, %q), want blocked+no_progress", g.status, g.stopCause)
+		}
+	})
+
+	t.Run("research class raises the no-progress limit", func(t *testing.T) {
+		g := &goalMachine{goal: "research the topic", status: GoalStatusRunning, budgetClass: budgetClassResearch}
+		g.turnsLimit = budgetQuota(budgetClassResearch)
+		g.noProgressLimit = noProgressQuota(g.budgetClass)
+		if g.noProgressLimit != 10 {
+			t.Fatalf("research no-progress limit = %d, want 10", g.noProgressLimit)
+		}
+		for i := 0; i < g.noProgressLimit-1; i++ {
+			g.advance(in(&goalTurnReport{status: GoalStatusRunning, reason: "still researching"}, "sig", "sig"))
+		}
+		if g.status != GoalStatusRunning {
+			t.Fatalf("research class paused before its quota: %+v", g)
+		}
+		g.advance(in(&goalTurnReport{status: GoalStatusRunning, reason: "still researching"}, "sig", "sig"))
+		if g.status != GoalStatusBlocked || g.stopCause != stopCauseNoProgress {
+			t.Fatalf("machine = (%q, %q), want blocked+no_progress at quota", g.status, g.stopCause)
 		}
 	})
 

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -456,16 +456,18 @@ func (l *Ledger) Len() int {
 }
 
 // ReceiptProgressSummary counts successful host-observable receipts by category
-// for cross-turn progress signatures. Failed receipts and reads never count:
-// repeated reads, failed bookkeeping, and reworded answers must not masquerade
-// as progress. Categories are not mutually exclusive (a successful bash command
-// that also writes counts in both), which is fine for a change detector.
+// for cross-turn progress signatures. Failed receipts never count; reads count
+// only when they produced output, so read/analyze-heavy turns register as
+// progress while empty or failed reads cannot masquerade as one. Categories
+// are not mutually exclusive (a successful bash command that also writes counts
+// in both), which is fine for a change detector.
 type ReceiptProgressSummary struct {
 	Writes   int // successful mutations/writes
 	Commands int // successful commands (bash receipts)
 	Todos    int // successful todo_write receipts
 	Signoffs int // successful complete_step signoffs
 	Reviews  int // successful review receipts
+	Reads    int // successful read/search receipts with content (read_file, grep, glob, …)
 }
 
 // ReceiptProgressSummary returns the current ledger's progress counts.
@@ -494,6 +496,13 @@ func (l *Ledger) ReceiptProgressSummary() ReceiptProgressSummary {
 		}
 		if successfulForegroundReviewReceipt(r) || completedStructuredReviewReceipt(r, nil) {
 			out.Reviews++
+		}
+		// A read with real output carries research forward even though it is not
+		// a mutation: counting it keeps read/analyze-heavy goal turns from being
+		// misclassified as stalled (issue #8137). Empty or failed reads stay out
+		// so bare retries cannot masquerade as progress.
+		if r.Read && r.OutputBytes > 0 {
+			out.Reads++
 		}
 	}
 	return out

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -1294,6 +1294,27 @@ func TestLedgerReviewAfterRestoredCheckpointBaseline(t *testing.T) {
 	}
 }
 
+// TestReceiptProgressSummaryCountsReads pins the A2 read-progress rule: only
+// successful reads with real output count toward the cross-turn signature, so
+// read/analyze-heavy goal turns stop being misclassified as stalled while
+// empty or failed reads cannot masquerade as progress.
+func TestReceiptProgressSummaryCountsReads(t *testing.T) {
+	l := NewLedger()
+	l.Record(Receipt{ToolName: "read_file", Success: true, Read: true, OutputBytes: 512})
+	l.Record(Receipt{ToolName: "grep", Success: true, Read: true, OutputBytes: 120})
+	l.Record(Receipt{ToolName: "read_file", Success: true, Read: true, OutputBytes: 0})    // empty read: not progress
+	l.Record(Receipt{ToolName: "read_file", Success: false, Read: true, OutputBytes: 512}) // failed read: not progress
+	l.Record(Receipt{ToolName: "bash", Success: true, Command: "go test ./internal/..."})
+	l.Record(Receipt{ToolName: "edit_file", Success: true, Write: true, Mutation: true})
+	s := l.ReceiptProgressSummary()
+	if s.Reads != 2 {
+		t.Fatalf("Reads = %d, want 2 (only successful reads with output)", s.Reads)
+	}
+	if s.Commands != 1 || s.Writes != 1 {
+		t.Fatalf("existing categories regressed: %+v", s)
+	}
+}
+
 func TestLedgerDeliverySignoffRequiresPostMutationVerificationAndReview(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(ReceiptFromToolCall("todo_write", json.RawMessage(`{"todos":[{"content":"Ship parser","status":"in_progress"}]}`), true, true))


### PR DESCRIPTION
## Summary

- 现状：goal 模式连续 4 轮"无宿主可验证进展"就自动暂停。但进展签名只统计写文件 / 执行命令 / todo / 签核 / review——**纯读文件、grep、搜索、分析轮一律不算**，导致研究型任务（读代码 → 分析 → 读更多 → 结论）连续 4 轮就被误停。该机制在 1.20.0 的 "Goal Completion Fail-Closed" 重写中引入，与报障人观察一致（1.19.7 无此门不暂停 / 1.20.0 暂停 / 1.21.2 部分缓解）。
- 本 PR：① 有输出的读/搜索类工具调用计入进展签名（`ReceiptProgressSummary.Reads`，空读/失败读仍不算，防空转刷进展）；② no-progress 停顿限制按预算类分级（research 10 / write 6 / simple 4，原为统一 4）——研究任务获得更多"只读不见写"的轮次；轮次预算（40/20/10）仍是最终兜底，evaluator fail-closed 路径不变；③ 恢复中的 goal：持久化的旧版统一值（4）按预算类重新推导，升级后已运行的研究 goal 立即受益；刻意设置的不同值仍被保留。

## Issues

Fixes #8137

## Verification

- 新增 5 个测试：Reads 计数规则（有输出计入/空读失败读不计入/原有类别不回归）/ 预算类映射（10/6/4）/ 恢复推导（旧 4→重推、缺失→默认、刻意值保留）/ research 类到配额才暂停 / 现有 no-progress 与 e2e 测试全过
- go test ./internal/control/ ./internal/evidence/ ./internal/agent/ 全通过
- gofmt -l 无输出；go vet 通过；boot golden 无漂移
- 全量 go test -count=1 ./... ：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 #7807）

## Documentation impact

Documentation-impact: none - 不新增配置项；no-progress 限制按预算类内部推导（无 CLI/config 暴露）。

## Cache impact

Cache-impact: none - 不触碰系统提示词、前缀或任何缓存相关路径；只改 goal 循环的进展判定（agent/control 运行时逻辑）。
Cache-guard: 不适用（无前缀/缓存变更）；guard 为既有 goal 状态机测试（internal/control/goal*_test.go）。
System-prompt-review: 不需要 - 不改 system prompt / 记忆前缀 / 工具 schema。