### PR TITLE
fix(agent): use single-request prompt for compaction threshold and bound auto-compaction

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -531,6 +531,7 @@ type Agent struct {
 	toolResultSnipRatio float64
 	compactRatio        float64
 	compactForceRatio   float64
+	autoCompactBudget   time.Duration // whole-pass timeout for auto-compaction; manual /compact ignores it
 	softCompactNoticed  bool
 	recentKeep          int
 	archiveDir          string
@@ -1031,6 +1032,7 @@ type Options struct {
 	ToolResultSnipRatio float64
 	CompactRatio        float64
 	CompactForceRatio   float64
+	AutoCompactBudget   time.Duration // total budget for one auto-compaction pass; 0 uses the default
 	RecentKeep          int
 	ArchiveDir          string
 	KeepPolicy          KeepPolicy
@@ -1151,6 +1153,9 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if opts.CompactForceRatio <= 0 {
 		opts.CompactForceRatio = defaultCompactForceRatio
 	}
+	if opts.AutoCompactBudget <= 0 {
+		opts.AutoCompactBudget = defaultAutoCompactBudget
+	}
 	if opts.RecentKeep <= 0 {
 		opts.RecentKeep = minRecentKeep
 	}
@@ -1236,6 +1241,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		toolResultSnipRatio:       opts.ToolResultSnipRatio,
 		compactRatio:              opts.CompactRatio,
 		compactForceRatio:         opts.CompactForceRatio,
+		autoCompactBudget:         opts.AutoCompactBudget,
 		recentKeep:                opts.RecentKeep,
 		archiveDir:                opts.ArchiveDir,
 		keepPolicy:                opts.KeepPolicy,

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -47,6 +47,14 @@ const (
 // failure (then a mechanical fold) instead of hanging compaction indefinitely.
 const summaryTimeout = 90 * time.Second
 
+// defaultAutoCompactBudget bounds the whole auto-compaction pass (summarizer
+// retries + PreCompact hook + compaction extension intercepts all run serially
+// inside the run loop), so a stuck extension or slow summarizer surfaces as a
+// bounded wait followed by a mechanical fold instead of minutes of
+// "compacting…" placeholder (issue #8148). Manual /compact keeps the longer
+// per-call timeouts.
+const defaultAutoCompactBudget = 45 * time.Second
+
 // summarySystemPrompt steers the executor to distill older history into a
 // structured briefing it can keep relying on after the originals are dropped.
 // The section layout mirrors what a coding agent actually needs to resume work
@@ -98,7 +106,19 @@ func (a *Agent) compactThresholds() (soft, snip, high int) {
 // configured fraction of the context window. It is a no-op when compaction is
 // disabled (no window) or usage is unavailable.
 func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
-	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
+	if a.contextWindow <= 0 || u == nil {
+		return
+	}
+	// Threshold decisions use the latest single-request prompt size: billable
+	// PromptTokens sums every streaming-replay attempt, so a retried request
+	// would look 2–5× larger than the actual context occupancy and trigger
+	// compaction early (issue #8148). ContextPromptTokens carries the latest
+	// attempt's shape; fall back to PromptTokens when absent.
+	prompt := u.PromptTokens
+	if u.ContextPromptTokens > 0 {
+		prompt = u.ContextPromptTokens
+	}
+	if prompt == 0 {
 		return
 	}
 	soft, snip, high := a.compactThresholds()
@@ -109,19 +129,19 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	// leaving a stale run count behind there would latch the *next* compaction as
 	// "the window is too small" and silently disable auto-compaction for the rest
 	// of the session.
-	if u.PromptTokens < high {
+	if prompt < high {
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
 	}
 	// Between the soft ratio and the trigger, report growing context once without
 	// rewriting the prefix — a compaction here would needlessly crater the cache.
-	if u.PromptTokens >= soft && u.PromptTokens < snip && !a.softCompactNoticed {
+	if prompt >= soft && prompt < snip && !a.softCompactNoticed {
 		a.softCompactNoticed = true
 		detail := fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context is getting large; preserving cache until cleanup is needed.", Detail: detail})
 		return
 	}
-	if u.PromptTokens >= snip && u.PromptTokens < high {
+	if prompt >= snip && prompt < high {
 		ratio := a.tokPerChar()
 		if st, err := a.SnipStaleToolResults(); err == nil && st.Results > 0 {
 			saved := int(float64(st.SavedChars) * ratio)
@@ -130,13 +150,13 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		}
 		return
 	}
-	if u.PromptTokens < high {
+	if prompt < high {
 		return // the latch was already cleared above
 	}
 	if a.compactStuck {
 		return
 	}
-	force := u.PromptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
+	force := prompt >= int(float64(a.contextWindow)*a.compactForceRatio)
 	// Prune before folding: when eliding stale tool results alone clears the
 	// trigger, this turn's (paid) summarize call is skipped entirely.
 	ratio := a.tokPerChar()
@@ -144,11 +164,20 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		saved := int(float64(st.SavedChars) * ratio)
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
 			"pruned %d stale tool results (~%d tokens est.) before compaction", st.Results, saved)})
-		if !force && u.PromptTokens-saved < high {
+		if !force && prompt-saved < high {
 			return
 		}
 	}
-	if err := a.compact(ctx, "auto", "", force); err != nil {
+	// Auto-compaction gets one bounded budget for the whole pass; force (the
+	// 0.9-window high-water mark) keeps the longer per-call timeouts so a
+	// genuinely overfull window is always reclaimed.
+	compactCtx := ctx
+	if !force && a.autoCompactBudget > 0 {
+		var cancel context.CancelFunc
+		compactCtx, cancel = context.WithTimeout(ctx, a.autoCompactBudget)
+		defer cancel()
+	}
+	if err := a.compact(compactCtx, "auto", "", force); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Context cleanup skipped for now.", Detail: fmt.Sprintf("compaction skipped: %v", err)})
 		return
 	}

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -8,6 +8,7 @@ import (
 	"reasonix/internal/event"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
@@ -622,6 +623,88 @@ func TestCompactSkipsSingleSmallMessage(t *testing.T) {
 	}
 	if len(prov.got) != 0 {
 		t.Fatalf("summarizer was called for tiny region: %+v", prov.got)
+	}
+}
+
+// TestMaybeCompactUsesSingleRequestPrompt pins the issue #8148 fix: threshold
+// decisions use the latest single-request prompt (ContextPromptTokens), not the
+// billable aggregate PromptTokens that sums streaming-replay attempts and would
+// trigger compaction early.
+func TestMaybeCompactUsesSingleRequestPrompt(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
+		{Role: provider.RoleAssistant, Content: "b"},
+		{Role: provider.RoleUser, Content: "c"},
+	}}
+	prov := &fakeProvider{reply: "- summary"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
+
+	// PromptTokens is a 2.5× replay-aggregated 40000; the real single-request
+	// context is 15000 (< 0.8×20000 = 16000). No compaction should trigger.
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 40000, ContextPromptTokens: 15000})
+	if a.consecutiveCompacts != 0 {
+		t.Fatalf("aggregated prompt must not trigger compaction: consecutiveCompacts=%d", a.consecutiveCompacts)
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("summarizer called despite single-request prompt under the trigger")
+	}
+
+	// Same aggregate, but the real single-request context crossed the trigger:
+	// compacts.
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 40000, ContextPromptTokens: 17000})
+	if a.consecutiveCompacts != 1 {
+		t.Fatalf("single-request prompt over the trigger must compact: consecutiveCompacts=%d", a.consecutiveCompacts)
+	}
+}
+
+// TestAutoCompactBoundedByBudget pins the issue #8148 fix: auto-compaction gets
+// one bounded whole-pass budget, so a stalled summarizer surfaces as a bounded
+// wait plus a mechanical fold instead of pinning the run loop.
+func TestAutoCompactBoundedByBudget(t *testing.T) {
+	prov := &fakeProvider{hang: true} // stream never sends or closes
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a ", 1000)}, // ≈500 tok, beyond the 15-tok keep cap at window 100 → real fold
+		{Role: provider.RoleAssistant, Content: "step one"},
+		{Role: provider.RoleUser, Content: "more"},
+		{Role: provider.RoleAssistant, Content: "step two"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	var notices []event.Event
+	a := New(prov, tool.NewRegistry(), sess, Options{
+		ContextWindow: 100, AutoCompactBudget: 50 * time.Millisecond, RecentKeep: 2, ArchiveDir: t.TempDir(),
+	}, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	}))
+
+	start := time.Now()
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80}) // trigger (0.8×100)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("auto-compaction took %v with a 50ms budget; must not hang", elapsed)
+	}
+	folded := false
+	for _, n := range notices {
+		if strings.Contains(n.Text, "folded mechanically") || strings.Contains(n.Detail, "folded mechanically") {
+			folded = true
+		}
+	}
+	if !folded {
+		t.Fatalf("expected a mechanical-fold notice after the budget expired: %+v", notices)
+	}
+}
+
+// TestMaybeCompactNilUsageNoPanic guards the nil-usage path: finalizeSamplingUsage
+// returns nil when a provider emits no usage chunk, and maybeCompact must no-op
+// (issue #8148 regression guard for the ContextPromptTokens reorder).
+func TestMaybeCompactNilUsageNoPanic(t *testing.T) {
+	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), &Session{Messages: []provider.Message{{Role: provider.RoleSystem, Content: "sys"}}}, Options{ContextWindow: 100}, event.Discard)
+	a.maybeCompact(context.Background(), nil)
+	if a.consecutiveCompacts != 0 {
+		t.Fatalf("nil usage must not trigger compaction")
 	}
 }
 


### PR DESCRIPTION
## Summary

- 现状：自动压缩有两个问题（#8148 用户报，1.22.0）：① 上下文远没到窗口阈值就开始自动压缩；② 压缩过程显示失败、进程卡住。
- 根因 1（提前压缩）：触发判定用的是**计费聚合的 PromptTokens**——1.21 引入流中断重放（最多 5 次）后，`mergeSamplingUsage` 把每次重放的 PromptTokens **相加**，一次请求重放 2-5 次后看起来比真实上下文大 2-5 倍，单轮就越过 0.8×窗口阈值。而 `finalizeSamplingUsage` 已经携带了**最新单次请求**的真实 prompt（`ContextPromptTokens`），阈值判定改用它（缺失时回退 PromptTokens）。计费（Cost）聚合不受影响。
- 根因 2（卡死）：自动压缩没有**整趟预算**——summarizer（90s×最多重试 2 次）+ PreCompact hook + 两个压缩扩展拦截点全在 run loop 内同步串行，慢的拦截点/超时的 summarizer 会让"compacting…"占位卡数分钟。自动压缩现在有整趟预算（默认 45s，`Options.AutoCompactBudget` 可调，force 与手动 /compact 绕过），超时快速降级为机械折叠。
- 顺带修复：maybeCompact 的 nil usage 空指针风险（provider 不返回 usage chunk 时 `finalizeSamplingUsage` 返回 nil）。

## Issues

Fixes #8148（bug2：自动压缩异常部分）

## Verification

- 新增 3 个测试：单次 prompt（ContextPromptTokens）优先于聚合值、超时预算内挂死的 summarizer 降级为机械折叠、nil usage 不 panic
- go test ./internal/agent/ 全通过（含既有压缩阈值/重放/超时测试）
- gofmt -l 无输出；go vet 通过；boot golden 无漂移
- 全量 go test -count=1 ./... ：仅 2 个已知 macOS sandbox 环境失败（与本 PR 无关，见 #7807）

## Documentation impact

Documentation-impact: none - Options.AutoCompactBudget 新增（默认 45s，不暴露 CLI/config 新键）。

## Cache impact

Cache-impact: low - 不改变前缀渲染或压缩字节格式；只改**触发判定**（用真实单次 prompt，压缩次数只会减少）与**压缩过程超时**（每次压缩仍是一次缓存失效点，但次数减少）；计费路径（Cost）零改动。
Cache-guard: 聚焦 guard—— go test ./internal/agent/ -run 'TestMaybeCompact|TestAutoCompact|TestCompact' （触发/预算/降级行为）+ 既有 cachehit_e2e_test.go（压缩缓存归因）。
System-prompt-review: esengine — 压缩触发策略与超时预算变化，不改前缀内容；需维护者确认 45s 默认预算可接受。