### PR TITLE
fix(remote): run one-shot exec commands via explicit POSIX sh

### DIFF
--- a/internal/remote/bootstrap/launch.go
+++ b/internal/remote/bootstrap/launch.go
@@ -2,7 +2,8 @@ package bootstrap
 
 import (
 	"fmt"
-	"strings"
+
+	"reasonix/internal/remote"
 )
 
 // StatePaths are the absolute remote-side paths for one workspace's serve
@@ -22,7 +23,7 @@ type StatePaths struct {
 // single quotes as '\”. This is the only quoting used for remote command
 // operands; every interpolated path/workspace passes through it.
 func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+	return remote.ShellQuote(s)
 }
 
 // LaunchCommand builds the `sh -c` script that starts a detached serve in

--- a/internal/remote/client.go
+++ b/internal/remote/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -199,7 +200,19 @@ type ExecResult struct {
 	ExitCode int
 }
 
-// Exec runs cmd via `sh -c` on a fresh session and collects its output.
+// ShellQuote single-quote-escapes s for a POSIX shell so hostile contents
+// (spaces, quotes, `; rm -rf ~`) cannot break out of the quoted argument.
+// Shared with the bootstrap package so the escaping rule cannot drift into a
+// divergence that opens an injection hole.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// Exec runs a one-shot remote command via explicit POSIX-sh execution: the
+// script is fed through the session's stdin and the remote side runs plain
+// `sh`. sshd runs session commands via the user's login shell (tcsh, csh,
+// zsh, …), which may not parse POSIX-sh quoting (issue #8130); keeping the
+// outer command to `sh` leaves nothing for the login shell to misinterpret.
 func (c *Client) Exec(ctx context.Context, cmd string) (ExecResult, error) {
 	cl, err := c.SSH()
 	if err != nil {
@@ -218,9 +231,10 @@ func (c *Client) Exec(ctx context.Context, cmd string) (ExecResult, error) {
 		}
 		defer sess.Close()
 		var stdout, stderr bytes.Buffer
+		sess.Stdin = strings.NewReader(cmd)
 		sess.Stdout = &stdout
 		sess.Stderr = &stderr
-		runErr := sess.Run(cmd)
+		runErr := sess.Run("sh")
 		out := ExecResult{Stdout: stdout.Bytes(), Stderr: stderr.Bytes()}
 		if runErr != nil {
 			var ee *ssh.ExitError

--- a/internal/remote/client_test.go
+++ b/internal/remote/client_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,6 +45,106 @@ func newTestClient(t *testing.T, srv *sshtest.Server, opts Options) *Client {
 	return c
 }
 
+// TestExecSendsBareShCommand pins the issue #8130 wire contract: the remote
+// side receives exactly `sh` — never a quoted payload — so the user's login
+// shell (tcsh/csh/zsh) has nothing to misinterpret — and the full script
+// arrives intact via the session stdin.
+func TestExecSendsBareShCommand(t *testing.T) {
+	// gotCmd is written by the sshtest handler goroutine and read by the test
+	// goroutine after Exec returns; the network round trip alone establishes no
+	// happens-before, so the pair must be synchronized for -race.
+	var (
+		mu     sync.Mutex
+		gotCmd string
+	)
+	srv := sshtest.Start(t, sshtest.Options{
+		Password: "hunter2",
+		Exec: func(cmd string) (string, string, int) {
+			mu.Lock()
+			gotCmd = cmd
+			mu.Unlock()
+			return "ok", "", 0
+		},
+	})
+	c := newTestClient(t, srv, Options{Auth: AuthOptions{Password: func() (string, error) { return "hunter2", nil }}})
+	if err := c.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer c.Close()
+	payload := `echo 'x; echo PWNED; echo y'`
+	res, err := c.Exec(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	mu.Lock()
+	cmd := gotCmd
+	mu.Unlock()
+	if cmd != "sh" {
+		t.Fatalf("remote command = %q, want exactly %q", cmd, "sh")
+	}
+	if strings.TrimSpace(string(res.Stdout)) != "ok" {
+		t.Fatalf("stdout = %q, want ok", res.Stdout)
+	}
+	// The script travels via stdin and must arrive byte-identical.
+	deadline := time.Now().Add(2 * time.Second)
+	for srv.LastStdin() != payload && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := srv.LastStdin(); got != payload {
+		t.Fatalf("session stdin = %q, want the full payload %q", got, payload)
+	}
+}
+
+// TestShViaStdinRoundTripsPayload verifies the stdin-fed script executes under
+// /bin/sh with quoting intact — the same stdin path the remote `sh` uses.
+func TestShViaStdinRoundTripsPayload(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	payload := `echo 'x; echo PWNED; echo y'`
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(payload)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sh via stdin failed: %v", err)
+	}
+	if string(out) != "x; echo PWNED; echo y\n" {
+		t.Fatalf("stdin payload output = %q, want literal %q", out, "x; echo PWNED; echo y\n")
+	}
+}
+
+// TestExecSurvivesTcshLoginShell reproduces the sshd execution model on a host
+// whose login shell is tcsh: the outer command is `sh` (trivially parsed) and
+// the script arrives via stdin. Skipped when tcsh is unavailable (Linux CI).
+func TestExecSurvivesTcshLoginShell(t *testing.T) {
+	tcsh, err := exec.LookPath("tcsh")
+	if err != nil {
+		t.Skip("tcsh not installed")
+	}
+	payload := `SX=; command -v setsid >/dev/null 2>&1 && SX=setsid; echo "probe-ok $SX"`
+	cmd := exec.Command(tcsh, "-fc", "sh")
+	cmd.Stdin = strings.NewReader(payload)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("tcsh -fc sh via stdin failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); !strings.HasPrefix(got, "probe-ok") {
+		t.Fatalf("output = %q, want prefix probe-ok", out)
+	}
+	// A payload with POSIX '\'' escaping (bootstrap quoted paths) must survive
+	// too — the escaping is resolved inside sh, never by tcsh.
+	quoted := `echo 'a'\''b'`
+	cmd2 := exec.Command(tcsh, "-fc", "sh")
+	cmd2.Stdin = strings.NewReader(quoted)
+	out2, err := cmd2.Output()
+	if err != nil {
+		t.Fatalf("quoted payload via tcsh sh failed: %v", err)
+	}
+	if string(out2) != "a'b\n" {
+		t.Fatalf("quoted output = %q, want a'b", out2)
+	}
+}
+
 func TestClientConnectPasswordAuth(t *testing.T) {
 	srv := sshtest.Start(t, sshtest.Options{Password: "hunter2"})
 	c := newTestClient(t, srv, Options{
@@ -64,8 +166,11 @@ func TestClientConnectPasswordAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
-	if strings.TrimSpace(string(res.Stdout)) != "echo hello" {
-		t.Fatalf("exec stdout = %q", res.Stdout)
+	// The sshtest server echoes the received exec command; since issue #8130
+	// the remote side receives exactly `sh` — the stdin script path is covered
+	// by TestShViaStdinRoundTripsPayload and the tcsh test.
+	if strings.TrimSpace(string(res.Stdout)) != "sh" {
+		t.Fatalf("exec stdout = %q, want the bare `sh` command", res.Stdout)
 	}
 }
 
@@ -300,10 +405,9 @@ func TestClientFallsBackFromStoredPassphraseToPerIdentityPrompt(t *testing.T) {
 		},
 	}
 
-	// This handshake performs three passphrase KDFs (stored + prompted for the
-	// first identity, then stored for the second). Under full -race package
-	// parallelism on a constrained CI runner, ten seconds is too close to the CPU
-	// bound work even though the in-process SSH server remains responsive.
+	// This handshake performs three passphrase KDFs; under full -race package
+	// parallelism on a constrained CI runner ten seconds is too close to the
+	// CPU-bound work even though the in-process server stays responsive.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := c.Start(ctx); err != nil {

--- a/internal/remote/sshtest/sshtest.go
+++ b/internal/remote/sshtest/sshtest.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
@@ -31,6 +32,12 @@ type Server struct {
 	conns     []net.Conn
 	listeners []net.Listener
 	wg        sync.WaitGroup
+
+	// stdinMu guards lastStdin, the session script the client streams after
+	// the exec request (models sshd's forwarding to the remote process's
+	// stdin). Test code reads it to assert the payload arrived intact.
+	stdinMu   sync.Mutex
+	lastStdin []byte
 }
 
 // Options configures a test server.
@@ -202,8 +209,26 @@ func (s *Server) handleSession(newCh ssh.NewChannel) {
 		switch req.Type {
 		case "exec":
 			cmd := parseStringPayload(req.Payload)
+			// The client streams the script after the exec request; model the
+			// same ordering: wait for the first data frame, then run the
+			// handler. Reading until EOF would deadlock.
+			first := make(chan struct{})
+			go func() {
+				buf := make([]byte, 64*1024)
+				n, _ := ch.Read(buf)
+				if n > 0 {
+					s.stdinMu.Lock()
+					s.lastStdin = append([]byte(nil), buf[:n]...)
+					s.stdinMu.Unlock()
+				}
+				close(first)
+			}()
 			if req.WantReply {
 				_ = req.Reply(true, nil)
+			}
+			select {
+			case <-first:
+			case <-time.After(500 * time.Millisecond):
 			}
 			s.runExec(ch, cmd)
 			return
@@ -229,6 +254,15 @@ func (s *Server) handleSession(newCh ssh.NewChannel) {
 			}
 		}
 	}
+}
+
+// LastStdin returns the script streamed by the most recent exec request,
+// once the session channel has closed (the same completion point a remote
+// process observes). Test code polls it to assert the payload arrived intact.
+func (s *Server) LastStdin() string {
+	s.stdinMu.Lock()
+	defer s.stdinMu.Unlock()
+	return string(s.lastStdin)
 }
 
 func (s *Server) runExec(ch ssh.Channel, cmd string) {


### PR DESCRIPTION
## Summary

**现状**：`Client.Exec` 把命令字符串直接交给 `sess.Run`，sshd 会用远端用户的登录 shell（tcsh/csh/zsh 等）解析该字符串。对含单引号路径或 POSIX 转义（`'\''`）的 bootstrap 片段，tcsh 等非 POSIX shell 会解析失败——实测 `tcsh -fc "sh -c 'echo a'\''b'"` → `unexpected EOF`。#8130 的初版修复用 `sh -c <payload>` 包裹，但外层字符串**仍先被登录 shell 解析**，问题未真正消除。

**本 PR**：把脚本通过 session 的 **stdin** 喂给远端，`sess.Run` 只执行字面 `sh` —— 登录 shell 没有任何引号或特殊字符可误解读，POSIX 脚本由 `sh` 自己从 stdin 解析。`ShellQuote` 保留为 remote 与 bootstrap 包共享的唯一转义规则（bootstrap 生成脚本内部的路径转义仍由 sh 解析，安全语义不变）。

## Issues

Fixes #8130（远程命令经登录 shell 解析可能失败/被误解读）。

## Verification

- 本机真实 tcsh 回归：`tcsh -fc "sh" < 脚本`（含 `'\''` 转义 payload）执行成功 → 新增 `TestExecSurvivesTcshLoginShell`（macOS 自带 tcsh；Linux CI 无 tcsh 自动 skip）
- wire 测试 `TestExecSendsBareShCommand`：远端 exec 收到恰好 `sh`，且 stdin 完整到达 payload（sshtest 扩展 stdin 帧捕获）
- `TestShViaStdinRoundTripsPayload`：stdin 脚本在 /bin/sh 下执行、引号原样
- `go test ./internal/remote/...`、`go vet ./internal/remote/...` 全绿

## Documentation impact

Documentation-impact: none - 远程执行是内部行为，无用户可见文档变化。

## Cache impact

Cache-impact: none - 不触及 provider 请求、系统提示词或记忆前缀（internal/remote 不在缓存敏感路径列表）。