### PR TITLE
fix(config): bound legacy keyring lookup so serve cannot hang at startup (#8129)

### DIFF
--- a/internal/config/credentials_keyring_default.go
+++ b/internal/config/credentials_keyring_default.go
@@ -12,8 +12,10 @@ import (
 
 // legacyKeyringProbe reads one legacy credential from the platform keyring.
 // keyring.ErrNotFound (and empty values) are absent; other errors stay error.
-// ctx is checked before the call so a shared batch budget can stop the scan;
-// platform Get is not context-aware on these OSes.
+// The platform Get is not context-aware on these OSes, so the lookup is run
+// under the shared migration budget via legacyKeyringGetBounded: a wedged OS
+// keyring (locked macOS login keychain, hung Windows Credential Manager) must
+// not hang `serve` forever, and headless boxes must not stall startup.
 func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -22,7 +24,12 @@ func legacyKeyringProbe(ctx context.Context, key string) legacyKeyringOutcome {
 	if err := ctx.Err(); err != nil {
 		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
 	}
-	value, err := keyring.Get(credentialsKeyringService, key)
+	value, err, timedOut := legacyKeyringGetBounded(ctx, func() (string, error) {
+		return keyring.Get(credentialsKeyringService, key)
+	})
+	if timedOut {
+		return legacyKeyringOutcome{Status: legacyKeyringTimeout}
+	}
 	if err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return legacyKeyringOutcome{Status: legacyKeyringAbsent}

--- a/internal/config/credentials_keyring_helper.go
+++ b/internal/config/credentials_keyring_helper.go
@@ -25,6 +25,35 @@ type legacyKeyringOutcome struct {
 	Value  string
 }
 
+// legacyKeyringGetBounded runs one uncancellable keyring lookup under ctx's
+// budget. A buffered channel lets a late result be dropped without blocking
+// the probe goroutine; the caller-side wait is bounded even though the OS
+// call itself cannot be interrupted. On timeout the probe goroutine may stay
+// blocked inside the OS call until the keyring answers (macOS may pop a GUI
+// prompt) — that is inherent to an uncancellable API and only leaks a parked
+// goroutine that exits on its own once the OS returns. timedOut reports that
+// the budget expired before the lookup returned. A result that won the select
+// race is returned as-is: err-vs-timeout classification stays in the
+// per-platform probe, keeping the pre-existing semantics (a found value is
+// not demoted to timeout).
+func legacyKeyringGetBounded(ctx context.Context, get func() (string, error)) (value string, err error, timedOut bool) {
+	type result struct {
+		value string
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		v, e := get()
+		ch <- result{value: v, err: e}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", nil, true
+	case r := <-ch:
+		return r.value, r.err, false
+	}
+}
+
 // lookupLegacyKeyringBatch probes keys under a single shared deadline in-process.
 // There is no external helper entrypoint: secrets never leave the process via
 // stdout or a caller-controlled REASONIX_HOME dump path.

--- a/internal/config/credentials_keyring_timeout_test.go
+++ b/internal/config/credentials_keyring_timeout_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -225,5 +226,73 @@ func TestLegacyKeyringMarkerUsesRawURLBase64(t *testing.T) {
 	other := legacyKeyringMigrationMarkerPath("A_B_C_")
 	if path == other {
 		t.Fatalf("marker collision between %q and A_B_C_", key)
+	}
+}
+
+func TestLegacyKeyringGetBoundedReturnsValue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	value, err, timedOut := legacyKeyringGetBounded(ctx, func() (string, error) {
+		return "sk-secret", nil
+	})
+	if timedOut || err != nil || value != "sk-secret" {
+		t.Fatalf("value=%q err=%v timedOut=%v, want found value", value, err, timedOut)
+	}
+}
+
+func TestLegacyKeyringGetBoundedReturnsError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	probeErr := errors.New("platform keychain unavailable")
+	value, err, timedOut := legacyKeyringGetBounded(ctx, func() (string, error) {
+		return "", probeErr
+	})
+	if timedOut || !errors.Is(err, probeErr) || value != "" {
+		t.Fatalf("value=%q err=%v timedOut=%v, want wrapped error", value, err, timedOut)
+	}
+}
+
+// TestLegacyKeyringGetBoundedTimesOutHangingGet: the whole point of #8129 —
+// an uncancellable platform Get (locked macOS keychain, hung Windows
+// Credential Manager) must not hang migration forever, even though the OS
+// call itself cannot be interrupted.
+func TestLegacyKeyringGetBoundedTimesOutHangingGet(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		value, err, timedOut := legacyKeyringGetBounded(ctx, func() (string, error) {
+			<-ctx.Done() // platform Get never returns; it only notices when the OS does
+			return "", errors.New("eventually wedged")
+		})
+		done <- timedOut && err == nil && value == ""
+	}()
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("hanging get did not report timeout")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("hanging get exceeded the shared budget")
+	}
+}
+
+// TestLegacyKeyringGetBoundedNeverDemotesFoundValue pins the helper's
+// responsibility boundary: when the result channel wins the select, the value
+// is returned as-is. Demotion of a found value to timeout must never happen
+// here (only the per-platform probe may classify err as timeout), even if ctx
+// expires in the same instant the result arrives.
+func TestLegacyKeyringGetBoundedNeverDemotesFoundValue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	value, err, timedOut := legacyKeyringGetBounded(ctx, func() (string, error) {
+		return "late-but-real", nil
+	})
+	if timedOut || err != nil || value != "late-but-real" {
+		t.Fatalf("value=%q err=%v timedOut=%v, want found value preserved", value, err, timedOut)
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #8129. On Windows/macOS, `reasonix serve` (any invocation, even `serve --help`) blocks forever **before printing anything** on headless hosts. The legacy-credential migration probe runs ahead of command dispatch and calls the platform keyring synchronously — `keyring.Get` has no context support there, so a wedged OS keyring (locked macOS login keychain, hung Windows Credential Manager) never returns, and the 1s shared budget (`legacyKeyringLookupTimeout`) cannot interrupt a call that has already started.

## Fix

- New platform-independent helper `legacyKeyringGetBounded(ctx, get)` in `internal/config/credentials_keyring_helper.go`: runs the uncancellable lookup in a goroutine, bounded by `select` on `ctx.Done()`. A buffered channel lets a late result be dropped without blocking the probe goroutine.
- `legacyKeyringProbe` (Windows/macOS build tag) now routes its `keyring.Get` through the helper, so the existing shared migration budget actually bounds the caller-side wait on every OS.
- Classification stays in the per-platform probe: `keyring.ErrNotFound` → absent, empty value → absent, other error + expired ctx → timeout, other error → error. A found value that wins the select race is never demoted to timeout, preserving pre-fix semantics.
- On timeout the probe goroutine may remain parked inside the OS call until the keyring answers — inherent to an uncancellable API; it exits on its own once the OS returns (documented in the helper comment).

## Tests

- `TestLegacyKeyringGetBoundedReturnsValue` — value path.
- `TestLegacyKeyringGetBoundedReturnsError` — error passthrough.
- `TestLegacyKeyringGetBoundedTimesOutHangingGet` — a Get that never returns is bounded by the budget (the #8129 scenario).
- `TestLegacyKeyringGetBoundedNeverDemotesFoundValue` — found value preserved.
- Helper lives outside the build-tag file, so these run on Linux CI too; existing four-state batch tests unchanged.

## Verification

- gofmt / go vet ./internal/config/ clean
- go test -count=1 ./internal/config/ ok
- Cross-compile build ok: linux/amd64, darwin/arm64, windows/amd64 (CGO_ENABLED=0)

Cache-impact: none - keyring migration runs once per install, not per request
Cache-guard: none
System-prompt-review: none - no prompt, config schema, memory, output style, or skill behavior changes
Documentation-impact: none - startup hang is a behavioral fix; no user-facing docs, CLI surface, or config schema changed
