### PR TITLE
fix(agent): skip warm-cache prune to preserve DeepSeek prefix caching

### DIFF
--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -133,6 +133,16 @@ func (m ContextManager) tryToolMaintenance(visible []provider.Message, prepared 
 	}
 	mode := toolResultSnip
 	if est >= fold || forceFold {
+		// Cache-aware prune guard: rewriting the prefix on a warm provider
+		// cache invalidates prefix caching (DeepSeek: ~50-120x cost
+		// difference between cache hit and miss). Only elide stale tool
+		// results when the cache is known cold or unknown; on a warm cache,
+		// keep the prefix untouched unless the request is a manual/forced
+		// compaction or an overflow — those must proceed regardless.
+		if !(forceFold || policy.Trigger == CompactionTriggerManual || policy.Trigger == CompactionTriggerOverflow) &&
+			a.CacheState() == CacheStateWarm {
+			return PreparedContext{}, false, false, nil
+		}
 		mode = toolResultPrune
 	}
 	maintained, stats := a.applyToolResultMaintenanceView(visible, mode)

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -141,7 +141,11 @@ func (m ContextManager) tryToolMaintenance(visible []provider.Message, prepared 
 		// compaction or an overflow — those must proceed regardless.
 		if !(forceFold || policy.Trigger == CompactionTriggerManual || policy.Trigger == CompactionTriggerOverflow) &&
 			a.CacheState() == CacheStateWarm {
-			return PreparedContext{}, false, false, nil
+			// Return handled=true with the untouched prepared context so the
+			// caller does NOT fall through to foldContext (full summary
+			// compaction is far more expensive than prune and would defeat
+			// the cache-preservation intent).
+			return prepared, true, false, nil
 		}
 		mode = toolResultPrune
 	}


### PR DESCRIPTION
## What

On a **warm** provider cache, the request-time prune (`applyToolResultMaintenanceView` → `tryToolMaintenance`) rewrites the prompt prefix before every request, invalidating DeepSeek's prefix cache. Cost difference between cache hit and miss is roughly **50–120×** (see #3968 and #8118). This makes a warm session silently pay full input price on every request after accumulated tool results cross the fold threshold.

## Fix

In `internal/agent/context_manager.go`, `tryToolMaintenance`: when the fold threshold is crossed, only elide stale tool results if the cache is **cold/unknown**, or the request is **manual/forced compaction / overflow**. On a warm cache the prune is skipped entirely, preserving the cache-first prefix. Canonical transcript is never touched (projection-only, as before).

## Why this is safe

- Manual compaction (`/compact`), forced compaction, and context-overflow still prune as before — the guard only affects the *automatic* request-time prune.
- Snip band (below fold threshold) is untouched.
- Cache state is already tracked (`SetCacheState`/`CacheState`, used by cold-resume prune); we just honor it at request time too.
- Matches the design intent of `cacheColdAfter` gating: only rewrite the prefix when the cache is already cold.

## Related

Fixes #8118