### PR TITLE
feat(agent): the contract's requirements are the plan's acceptance criteria

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,6 +25,7 @@ import (
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/nilutil"
+	"reasonix/internal/plancontract"
 	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
@@ -466,8 +467,9 @@ type Agent struct {
 	// ledger it survives turn boundaries and compaction (it never rides in the
 	// prompt), so the final-answer gate still sees an unfinished plan a later
 	// turn would otherwise hide. Rebuilt from the session in SetSession.
-	todoMu    sync.Mutex
-	todoState []evidence.TodoItem
+	todoMu       sync.Mutex
+	todoState    []evidence.TodoItem
+	planContract *plancontract.Plan // approved plan this turn executes, if any
 
 	// hostAdvanceSeq guarantees unique tool IDs across turns: every
 	// emitTodoState call increments it so the frontend always sees a fresh
@@ -1900,45 +1902,6 @@ func (a *Agent) setTodoState(todos []evidence.TodoItem) {
 	a.todoMu.Unlock()
 }
 
-// SeedTodoState initializes the canonical task list from a host-generated
-// starter list, such as an approved plan. A new host seed replaces stale state
-// from earlier work so complete_step matches the plan the UI just displayed.
-func (a *Agent) SeedTodoState(todos []evidence.TodoItem) {
-	if len(todos) == 0 {
-		return
-	}
-	a.setTodoState(todos)
-}
-
-// ReplaceTodoState mirrors a host-generated todo list into the canonical state.
-// It is used when the host, rather than the model, owns the full state transition.
-func (a *Agent) ReplaceTodoState(todos []evidence.TodoItem) {
-	a.setTodoState(todos)
-	a.recordTodoState(a.CanonicalTodoState())
-}
-
-// CanonicalTodoState returns a copy of the host-reconstructed task list.
-func (a *Agent) CanonicalTodoState() []evidence.TodoItem {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	return append([]evidence.TodoItem(nil), a.todoState...)
-}
-
-func (a *Agent) incompleteCanonicalTodos() ([]evidence.TodoStepMatch, bool) {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	if len(a.todoState) == 0 {
-		return nil, false
-	}
-	return evidence.IncompleteTodos(a.todoState), true
-}
-
-func (a *Agent) hasIncompleteCanonicalCriteria() bool {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	return len(a.todoState) > 0 && len(evidence.IncompleteTodos(a.todoState)) > 0
-}
-
 func (a *Agent) hasActiveCanonicalTodo() bool {
 	a.todoMu.Lock()
 	defer a.todoMu.Unlock()
@@ -2001,30 +1964,6 @@ func (a *Agent) advanceCanonicalTodo(step string) {
 	a.todoMu.Unlock()
 	a.recordTodoState(snapshot)
 	a.emitTodoState(snapshot, m.Index)
-}
-
-// recordTodoState logs the host-advanced list as a synthetic todo_write receipt
-// so the per-turn final gate (which reads the ledger's latest todo_write) sees
-// the advance — the model no longer has to re-send a todo_write to mark the
-// completion. It bypasses the todo_write tool, so the completion-transition
-// guard never runs on it.
-func (a *Agent) recordTodoState(todos []evidence.TodoItem) {
-	if a.evidence == nil {
-		return
-	}
-	args, err := json.Marshal(map[string]any{"todos": todos})
-	if err != nil {
-		return
-	}
-	a.evidence.Record(evidence.ReceiptFromToolCall("todo_write", json.RawMessage(args), true, true))
-}
-
-func canonicalTodoStatus(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "pending"
-	}
-	return s
 }
 
 // emitTodoState emits a synthetic todo_write event so the frontend task panel

--- a/internal/agent/completion_receipt_test.go
+++ b/internal/agent/completion_receipt_test.go
@@ -15,7 +15,7 @@ func TestReceiptCarriesWhatProseDoesNot(t *testing.T) {
 	} {
 		ledger.Record(r)
 	}
-	c := buildShadowContract("fix the add bug in calc.py", ledger.Receipts())
+	c := buildShadowContract("fix the add bug in calc.py", ledger.Receipts(), nil)
 	got := completionReceipt(completion.Build(c, ledger))
 	if got == nil {
 		t.Fatal("a turn that changed a file must produce a receipt")
@@ -39,7 +39,7 @@ func TestReceiptCarriesWhatProseDoesNot(t *testing.T) {
 func TestNoReceiptForATurnWithNothingToJudge(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{ToolName: "read_file", Success: true, Read: true, Paths: []string{"calc.py"}, OutputBytes: 64})
-	c := buildShadowContract("what does this function do?", ledger.Receipts())
+	c := buildShadowContract("what does this function do?", ledger.Receipts(), nil)
 	if got := completionReceipt(completion.Build(c, ledger)); got != nil {
 		t.Fatalf("read-only answer produced a receipt: %+v", got)
 	}

--- a/internal/agent/completion_shadow_test.go
+++ b/internal/agent/completion_shadow_test.go
@@ -14,7 +14,7 @@ func shadowReport(input string, receipts ...evidence.Receipt) (event.ContractSha
 	for _, r := range receipts {
 		ledger.Record(r)
 	}
-	c := buildShadowContract(input, ledger.Receipts())
+	c := buildShadowContract(input, ledger.Receipts(), nil)
 	return contractShadowAudit(c), completionReportAudit(completion.Build(c, ledger))
 }
 

--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -6,19 +6,23 @@ import (
 	"reasonix/internal/completion"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
+	"reasonix/internal/plancontract"
 	"reasonix/internal/taskcontract"
 	"reasonix/internal/taskintent"
 )
 
 // buildShadowContract replays a finished turn's receipts into a task
-// contract that observed everything and decided nothing: mutation-shaped
-// asks get the atomic contract, the latest todo list becomes the
-// requirement set, and the ledger drives evidence and epochs. Pure function
-// so the shadow is testable without an Agent.
-func buildShadowContract(input string, receipts []evidence.Receipt) *taskcontract.Contract {
+// contract that observed everything and decided nothing. An approved plan is
+// the contract's source of truth when there is one — its acceptance criteria
+// are what the work agreed to, and todo titles are only a restatement of the
+// steps. Without a plan the todo list stands in, as it always did.
+func buildShadowContract(input string, receipts []evidence.Receipt, plan *plancontract.Plan) *taskcontract.Contract {
 	var c *taskcontract.Contract
-	switch taskintent.Classify(input) {
-	case taskintent.Mutation, taskintent.PersistentAction:
+	switch {
+	case plan != nil:
+		c = taskcontract.FromPlan(input, planFacts(*plan))
+	case taskintent.Classify(input) == taskintent.Mutation,
+		taskintent.Classify(input) == taskintent.PersistentAction:
 		c = taskcontract.Atomic(input)
 	default:
 		c = taskcontract.New(input)
@@ -29,8 +33,12 @@ func buildShadowContract(input string, receipts []evidence.Receipt) *taskcontrac
 			todos = r.Todos
 		}
 	}
-	for i, todo := range todos {
-		c.AddRequirement(fmt.Sprintf("t%d", i+1), todo.Content, true)
+	// Todo titles restate the plan's steps, so they only become requirements
+	// when no plan supplied the real acceptance criteria.
+	if plan == nil {
+		for i, todo := range todos {
+			c.AddRequirement(fmt.Sprintf("t%d", i+1), todo.Content, true)
+		}
 	}
 	for _, r := range receipts {
 		c.Observe(r)
@@ -91,7 +99,7 @@ func (a *Agent) emitTurnShadows(input string) {
 	if a.evidence == nil {
 		return
 	}
-	c := buildShadowContract(input, a.evidence.Receipts())
+	c := buildShadowContract(input, a.evidence.Receipts(), a.planContractSnapshot())
 	event.RecordContractShadow(a.sink, contractShadowAudit(c))
 	rep := completion.Build(c, a.evidence)
 	a.completion = &rep

--- a/internal/agent/contract_shadow_test.go
+++ b/internal/agent/contract_shadow_test.go
@@ -20,7 +20,7 @@ func TestBuildShadowContractReplaysTheTurn(t *testing.T) {
 			{Content: "run the tests", Status: "completed"},
 		}},
 	}
-	c := buildShadowContract("fix the add bug in calc.py", receipts)
+	c := buildShadowContract("fix the add bug in calc.py", receipts, nil)
 	audit := contractShadowAudit(c)
 
 	if audit.Intent != "mutation" {
@@ -45,7 +45,7 @@ func TestBuildShadowContractIncompleteTurn(t *testing.T) {
 		}},
 		{ToolName: "edit_file", Mutation: true, Success: true},
 	}
-	audit := contractShadowAudit(buildShadowContract("investigate then fix the parser", receipts))
+	audit := contractShadowAudit(buildShadowContract("investigate then fix the parser", receipts, nil))
 	if audit.Complete {
 		t.Fatalf("open todo must keep the shadow incomplete: %+v", audit)
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -332,6 +332,9 @@ func (c *Coordinator) SetPlannerPlanApprover(g PlannerPlanApprover) {
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
+	// A turn starts owing nothing to the last one's plan; deliverPlan installs
+	// this turn's plan only once the executor is actually about to run it.
+	c.executor.SetPlanContract(nil)
 	decision := PlannerDecision{
 		Route:  PlannerRoutePlanAndExecute,
 		Depth:  PlannerDepthFull,
@@ -408,6 +411,9 @@ func (c *Coordinator) deliverPlan(ctx context.Context, input string, outcome pla
 		return nil
 	}
 	runExecutorWithPlan := func(ctx context.Context, planText string) error {
+		if outcome.structured {
+			c.executor.SetPlanContract(&outcome.plan)
+		}
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, formatHandoffWithDecision(input, planText, decision, executorToolHandoffContext(c.executor)))
 	}

--- a/internal/agent/plan_contract.go
+++ b/internal/agent/plan_contract.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"reasonix/internal/plancontract"
+	"reasonix/internal/taskcontract"
+)
+
+// SetPlanContract records the approved plan this turn executes, or clears it
+// when the turn runs without one. The coordinator sets it before every executor
+// run so a turn never inherits the previous turn's plan.
+func (a *Agent) SetPlanContract(plan *plancontract.Plan) {
+	if a == nil {
+		return
+	}
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	if plan == nil {
+		a.planContract = nil
+		return
+	}
+	copied := *plan
+	a.planContract = &copied
+}
+
+func (a *Agent) planContractSnapshot() *plancontract.Plan {
+	if a == nil {
+		return nil
+	}
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	if a.planContract == nil {
+		return nil
+	}
+	copied := *a.planContract
+	return &copied
+}
+
+// planFacts projects a plan onto the contract-relevant facts. The projection
+// lives here rather than in either package so taskcontract keeps never seeing a
+// plan and plancontract keeps depending on nothing above it.
+func planFacts(plan plancontract.Plan) taskcontract.PlanFacts {
+	facts := taskcontract.PlanFacts{}
+	seen := map[string]bool{}
+	for _, step := range plan.Steps {
+		for _, c := range step.Acceptance {
+			switch {
+			case c.Optional:
+				facts.Optional = append(facts.Optional, c.Text)
+			case c.Regression:
+				facts.Regressions = append(facts.Regressions, c.Text)
+			default:
+				facts.AcceptanceCriteria = append(facts.AcceptanceCriteria, c.Text)
+			}
+		}
+		for _, v := range step.Verification {
+			if seen[v.Command] {
+				continue
+			}
+			seen[v.Command] = true
+			facts.Verifications = append(facts.Verifications, v.Command)
+		}
+		if len(step.Risks) > 0 {
+			facts.Risky = true
+		}
+		// Scope is where work is expected, not a claim of fact, so a candidate
+		// path belongs in it even though it was never read.
+		facts.Touchpoints = appendUnseen(facts.Touchpoints, seen, step.VerifiedFiles)
+		facts.Touchpoints = appendUnseen(facts.Touchpoints, seen, step.CandidateFiles)
+	}
+	return facts
+}
+
+func appendUnseen(dst []string, seen map[string]bool, add []string) []string {
+	for _, s := range add {
+		if s == "" || seen["path:"+s] {
+			continue
+		}
+		seen["path:"+s] = true
+		dst = append(dst, s)
+	}
+	return dst
+}

--- a/internal/agent/plan_contract_test.go
+++ b/internal/agent/plan_contract_test.go
@@ -1,0 +1,148 @@
+package agent
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/plancontract"
+	"reasonix/internal/provider"
+	"reasonix/internal/taskcontract"
+)
+
+func contractPlan() plancontract.Plan {
+	return plancontract.Plan{
+		Objective: "make the cache key model-aware",
+		Steps: []plancontract.Step{
+			{
+				ID: "p1", Title: "thread the model ref through",
+				VerifiedFiles:  []string{"internal/provider/cache.go"},
+				CandidateFiles: []string{"internal/boot/boot.go"},
+				Risks:          []string{"warm caches invalidate once"},
+				Acceptance: []plancontract.Criterion{
+					{Text: "two model refs never share an entry"},
+					{Text: "existing hits keep hitting", Regression: true},
+					{Text: "the hit rate is logged", Optional: true},
+				},
+				Verification: []plancontract.Verification{{Command: "go test ./internal/provider/"}},
+			},
+		},
+	}.Normalize()
+}
+
+func TestPlanFactsSeparatesCriteriaByKind(t *testing.T) {
+	facts := planFacts(contractPlan())
+	if !slices.Equal(facts.AcceptanceCriteria, []string{"two model refs never share an entry"}) {
+		t.Errorf("acceptance = %v", facts.AcceptanceCriteria)
+	}
+	if !slices.Equal(facts.Regressions, []string{"existing hits keep hitting"}) {
+		t.Errorf("regressions = %v", facts.Regressions)
+	}
+	if !slices.Equal(facts.Optional, []string{"the hit rate is logged"}) {
+		t.Errorf("optional = %v", facts.Optional)
+	}
+	if !slices.Equal(facts.Verifications, []string{"go test ./internal/provider/"}) {
+		t.Errorf("verifications = %v", facts.Verifications)
+	}
+	if !facts.Risky {
+		t.Error("a step carrying risks must mark the plan risky")
+	}
+	// Scope is where work is expected, so an inferred path belongs in it.
+	if !slices.Equal(facts.Touchpoints, []string{"internal/provider/cache.go", "internal/boot/boot.go"}) {
+		t.Errorf("touchpoints = %v", facts.Touchpoints)
+	}
+}
+
+// The contract's requirements are the plan's acceptance criteria, not a
+// restatement of the step titles the todo list happens to carry.
+func TestShadowContractPrefersPlanCriteriaOverTodoTitles(t *testing.T) {
+	receipts := []evidence.Receipt{
+		{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "thread the model ref through", Status: "completed", StepID: "p1"},
+		}},
+	}
+	c := buildShadowContract("fix the cache key", receipts, ptr(contractPlan()))
+
+	texts := make([]string, 0, len(c.Requirements))
+	for _, req := range c.Requirements {
+		texts = append(texts, req.Text)
+	}
+	if slices.Contains(texts, "thread the model ref through") {
+		t.Fatalf("a todo title became a requirement alongside the plan's criteria: %v", texts)
+	}
+	if !slices.Contains(texts, "two model refs never share an entry") {
+		t.Fatalf("requirements = %v, want the plan's acceptance criteria", texts)
+	}
+	if len(c.Checks) == 0 {
+		t.Fatal("the plan's verification command did not become a check")
+	}
+}
+
+// An optional criterion is recorded but must never hold completion open.
+func TestOptionalCriterionDoesNotBlockCompletion(t *testing.T) {
+	c := taskcontract.FromPlan("o", taskcontract.PlanFacts{
+		AcceptanceCriteria: []string{"required one"},
+		Optional:           []string{"nice to have"},
+	})
+	for _, req := range c.Requirements {
+		if req.Text == "required one" {
+			c.Resolve(req.ID, taskcontract.Satisfied)
+		}
+		if req.Text == "nice to have" && req.Required {
+			t.Fatal("an optional criterion must not be required")
+		}
+	}
+	if !c.Complete() {
+		t.Fatalf("optional work left the contract incomplete: %s", c.Summary())
+	}
+}
+
+func TestShadowContractFallsBackToTodosWithoutAPlan(t *testing.T) {
+	receipts := []evidence.Receipt{
+		{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{
+			{Content: "fix add()", Status: "completed"},
+		}},
+	}
+	c := buildShadowContract("fix the add bug", receipts, nil)
+	found := false
+	for _, req := range c.Requirements {
+		if req.Text == "fix add()" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("without a plan the todo list must still stand in as the requirement set")
+	}
+}
+
+// A turn must never inherit the previous turn's plan: the executor-only route
+// runs with no contract at all.
+func TestCoordinatorClearsThePlanContractEachTurn(t *testing.T) {
+	planner := &mockProvider{name: "planner", streams: submitPlanCall(e2ePlanArgs)}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+	coord, executor := submitPlanCoordinator(t, planner, exec, event.Discard)
+
+	if err := coord.Run(context.Background(), "fix the cache key"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if executor.planContractSnapshot() == nil {
+		t.Fatal("the approved plan never reached the executor's contract")
+	}
+
+	coord.plannerPolicy = func(context.Context, string) PlannerDecision {
+		return PlannerDecision{Route: PlannerRouteExecutorOnly, Reason: "test"}
+	}
+	if err := coord.Run(context.Background(), "just answer me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if executor.planContractSnapshot() != nil {
+		t.Fatal("an executor-only turn inherited the previous turn's plan")
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/agent/todo_state.go
+++ b/internal/agent/todo_state.go
@@ -1,0 +1,74 @@
+package agent
+
+// The host's canonical task list: the state that outlives a turn because it
+// never rides in the prompt, so a later turn still sees an unfinished plan.
+
+import (
+	"encoding/json"
+	"strings"
+
+	"reasonix/internal/evidence"
+)
+
+// SeedTodoState initializes the canonical task list from a host-generated
+// starter list, such as an approved plan. A new host seed replaces stale state
+// from earlier work so complete_step matches the plan the UI just displayed.
+func (a *Agent) SeedTodoState(todos []evidence.TodoItem) {
+	if len(todos) == 0 {
+		return
+	}
+	a.setTodoState(todos)
+}
+
+// ReplaceTodoState mirrors a host-generated todo list into the canonical state.
+// It is used when the host, rather than the model, owns the full state transition.
+func (a *Agent) ReplaceTodoState(todos []evidence.TodoItem) {
+	a.setTodoState(todos)
+	a.recordTodoState(a.CanonicalTodoState())
+}
+
+// CanonicalTodoState returns a copy of the host-reconstructed task list.
+func (a *Agent) CanonicalTodoState() []evidence.TodoItem {
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	return append([]evidence.TodoItem(nil), a.todoState...)
+}
+
+func (a *Agent) incompleteCanonicalTodos() ([]evidence.TodoStepMatch, bool) {
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	if len(a.todoState) == 0 {
+		return nil, false
+	}
+	return evidence.IncompleteTodos(a.todoState), true
+}
+
+func (a *Agent) hasIncompleteCanonicalCriteria() bool {
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	return len(a.todoState) > 0 && len(evidence.IncompleteTodos(a.todoState)) > 0
+}
+
+// recordTodoState logs the host-advanced list as a synthetic todo_write receipt
+// so the per-turn final gate (which reads the ledger's latest todo_write) sees
+// the advance — the model no longer has to re-send a todo_write to mark the
+// completion. It bypasses the todo_write tool, so the completion-transition
+// guard never runs on it.
+func (a *Agent) recordTodoState(todos []evidence.TodoItem) {
+	if a.evidence == nil {
+		return
+	}
+	args, err := json.Marshal(map[string]any{"todos": todos})
+	if err != nil {
+		return
+	}
+	a.evidence.Record(evidence.ReceiptFromToolCall("todo_write", json.RawMessage(args), true, true))
+}
+
+func canonicalTodoStatus(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "pending"
+	}
+	return s
+}

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -142,6 +142,7 @@ func Atomic(input string) *Contract {
 type PlanFacts struct {
 	AcceptanceCriteria []string
 	Regressions        []string // must-keep-passing criteria
+	Optional           []string // nice-to-have; recorded but never blocking
 	Verifications      []string // command-level checks; "" entries mean any
 	Risky              bool
 	Touchpoints        []string
@@ -160,6 +161,11 @@ func FromPlan(input string, facts PlanFacts) *Contract {
 	for i, text := range facts.Regressions {
 		c.Requirements = append(c.Requirements, Requirement{
 			ID: fmt.Sprintf("g%d", i+1), Kind: "regression", Text: text, Required: true,
+		})
+	}
+	for i, text := range facts.Optional {
+		c.Requirements = append(c.Requirements, Requirement{
+			ID: fmt.Sprintf("o%d", i+1), Kind: "behavior", Text: text,
 		})
 	}
 	for _, command := range facts.Verifications {


### PR DESCRIPTION
Follow-up to #8167. `taskcontract.FromPlan` and `PlanFacts` were written to build
a contract from a plan's own acceptance criteria — Planner → Contract → Executor
— and have had no caller since. Now that a plan is a record, they get one.

## The requirements were the wrong thing

The shadow contract inferred requirements from todo titles. A todo title restates
a step; it is not what the work agreed to:

```
"thread the model ref through"          ← a step
"two model refs never share an entry"   ← the thing that must be true when it is done
```

An approved structured plan now becomes the contract. Without a plan the todo
list stands in exactly as before, so nothing regresses for unplanned turns.

## What changed

- `buildShadowContract` takes the plan and prefers it; todo titles only become
  requirements when no plan supplied criteria.
- The coordinator installs the plan on the executor immediately before the run
  and clears it at the top of every turn, so a turn never inherits the last
  one's plan. `perTurnState` was the natural home but is zeroed *inside*
  `Agent.Run`, after the coordinator would have set it.
- `planFacts` projects `plancontract.Plan` → `taskcontract.PlanFacts`. It lives
  in `internal/agent` rather than either package, so `taskcontract` keeps never
  seeing a plan and `plancontract` keeps depending on nothing above it.
- `PlanFacts` gains `Optional`, so a nice-to-have criterion is recorded without
  holding completion open. `Requirement.Required` and `Complete()` already
  supported it; only the projection lacked the field.

Scope deliberately includes `CandidateFiles`: scope is where work is *expected*,
not a claim of fact, so an inferred path belongs in it even though the
verified/candidate split stays intact everywhere a claim is made.

## What this does NOT do

`GateMutation` and `FinalRejection` still have zero callers. This changes what
the contract **observes**, not what it **decides**. Wiring the enforcement —
refusing a completion claim without fresh evidence, and requiring a
post-green mutation to name an unsatisfied requirement — is the first change in
this series that alters runtime refusal behaviour, and it belongs in its own
review with its own evidence.

## Debt

Adding one field to `Agent` pushed `agent.go` past its ratchet. Rather than
widen the baseline, the canonical todo-state accessors moved to `todo_state.go`:
`agent.go` 3567 → 3501 lines, one more responsibility out of the god file.
repolint stays clean at 1967 baselined findings.

## Verification

`gofmt`, `go vet ./...`, `make lint` (golangci-lint 0 issues + repolint clean),
`go test ./...` — 115 packages ok, 0 failures. Six new tests cover the
projection by criterion kind, the contract preferring plan criteria over todo
titles, optional criteria never blocking completion, the todo fallback with no
plan, and — the one that would silently rot otherwise — that an executor-only
turn does not inherit the previous turn's plan.

Cache-impact: none - the only cache-sensitive file is internal/agent/agent.go, and the change there is one unexported struct field plus an import. No prompt text, tool schema, or message assembly is touched, so the provider-visible prefix is byte-identical.
Cache-guard: internal/boot golden baseline (TestGoldenBaselineNoExtensions) passes unchanged, which is the direct evidence that SystemHash, ToolsHash, and ToolSchemaTokens are untouched.
Documentation-impact: none - no user-facing surface changes. The contract shadow is an internal observation recorded to trajectories; no tool schema, command, flag, or rendered output changes.
