### PR TITLE
feat(agent): the contract is answerable while the turn runs

### DIFF
--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -92,9 +92,31 @@ func intentName(i taskintent.Intent) string {
 	}
 }
 
-// emitTurnShadows records the end-of-turn shadow observations from one replay
-// of the turn's receipts: the contract's state, and the completion report
-// derived from it. Both observe; neither decides.
+// LiveContract is the contract as it stands right now: the same pure replay the
+// turn ends with, run against the receipts recorded so far. Rebuilding beats
+// keeping incremental state because one code path serves the per-round view and
+// the end-of-turn record, so the two can never disagree.
+func (a *Agent) LiveContract() *taskcontract.Contract {
+	if a == nil || a.evidence == nil {
+		return nil
+	}
+	return buildShadowContract(a.turnInput, a.evidence.Receipts(), a.planContractSnapshot())
+}
+
+// observeContractRound records the contract after one tool round, so a
+// trajectory carries how the evidence graph filled in rather than only where it
+// landed. It observes; it decides nothing.
+func (a *Agent) observeContractRound() {
+	c := a.LiveContract()
+	if c == nil || (len(c.Requirements) == 0 && len(c.Checks) == 0) {
+		return
+	}
+	event.RecordContractShadow(a.sink, contractShadowAudit(c))
+}
+
+// emitTurnShadows records the end-of-turn shadow observations: the contract's
+// state, and the completion report derived from it. Both observe; neither
+// decides.
 func (a *Agent) emitTurnShadows(input string) {
 	if a.evidence == nil {
 		return

--- a/internal/agent/live_contract_test.go
+++ b/internal/agent/live_contract_test.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/taskcontract"
+	"reasonix/internal/tool"
+)
+
+type contractShadowSink struct {
+	audits []event.ContractShadowAudit
+}
+
+func (s *contractShadowSink) Emit(event.Event) {}
+func (s *contractShadowSink) RecordContractShadow(a event.ContractShadowAudit) {
+	s.audits = append(s.audits, a)
+}
+
+func liveContractAgent(t *testing.T, sink event.Sink) *Agent {
+	t.Helper()
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, sink)
+	a.resetTurnEvidence()
+	a.turnInput = "make the cache key model-aware"
+	a.SetPlanContract(ptr(contractPlan()))
+	return a
+}
+
+// The contract has to be answerable while the turn is running, not only after
+// it: a gate that asks "is anything still unproven" has nothing to ask today.
+func TestLiveContractReflectsEvidenceAsItLands(t *testing.T) {
+	a := liveContractAgent(t, event.Discard)
+
+	before := a.LiveContract()
+	if before == nil || before.Complete() {
+		t.Fatalf("a plan with unproven criteria must not start complete: %+v", before)
+	}
+	startingChecks := 0
+	for _, check := range before.Checks {
+		if check.Status == taskcontract.Satisfied {
+			startingChecks++
+		}
+	}
+
+	a.evidence.Record(evidence.Receipt{
+		ToolName: "bash", Command: "go test ./internal/provider/", Success: true,
+	})
+	after := a.LiveContract()
+	satisfied := 0
+	for _, check := range after.Checks {
+		if check.Status == taskcontract.Satisfied {
+			satisfied++
+		}
+	}
+	if satisfied <= startingChecks {
+		t.Fatalf("a passing verification did not satisfy the plan's check: %s", after.Graph())
+	}
+}
+
+// One replay serves both views, so the live contract and the turn's record can
+// never disagree about the same receipts.
+func TestLiveContractMatchesTheEndOfTurnReplay(t *testing.T) {
+	a := liveContractAgent(t, event.Discard)
+	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"internal/provider/cache.go"}})
+	a.evidence.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
+
+	live := contractShadowAudit(a.LiveContract())
+	replay := contractShadowAudit(buildShadowContract(a.turnInput, a.evidence.Receipts(), a.planContractSnapshot()))
+	if live != replay {
+		t.Fatalf("live view %+v disagrees with the end-of-turn replay %+v", live, replay)
+	}
+}
+
+func TestContractRoundObservationRecordsATimeSeries(t *testing.T) {
+	sink := &contractShadowSink{}
+	a := liveContractAgent(t, sink)
+
+	a.observeContractRound()
+	a.evidence.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
+	a.observeContractRound()
+
+	if len(sink.audits) != 2 {
+		t.Fatalf("recorded %d contract samples, want one per round", len(sink.audits))
+	}
+	if sink.audits[0].ChecksSatisfied >= sink.audits[1].ChecksSatisfied {
+		t.Fatalf("the series does not show the check being satisfied: %+v", sink.audits)
+	}
+}
+
+// A turn with nothing to prove must not spray empty samples into the trajectory.
+func TestContractRoundObservationSkipsAnEmptyContract(t *testing.T) {
+	sink := &contractShadowSink{}
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, sink)
+	a.resetTurnEvidence()
+	a.turnInput = "what does this function do?"
+
+	a.observeContractRound()
+	if len(sink.audits) != 0 {
+		t.Fatalf("recorded %d samples for a contract with nothing to prove", len(sink.audits))
+	}
+}
+
+func TestLiveContractIsNilWithoutALedger(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	a.evidence = nil
+	if a.LiveContract() != nil {
+		t.Fatal("no ledger means no contract to answer with")
+	}
+}

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -82,6 +82,7 @@ func (a *Agent) observeOutcomeShadow(receiptMark int, results []string, outcomes
 	a.applyGovernor(&sample)
 	a.armGovernorCapture(sample)
 	event.RecordOutcomeProgress(a.sink, sample)
+	a.observeContractRound()
 }
 
 // applyProgressGuard escalates when consecutive rounds stop producing new

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -141,7 +141,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// A fresh user turn starts from zeroed per-turn host state; the new turn's
 	// values are computed below. Cross-turn state (checkpoint, scope, failure
 	// budgets) lives directly on Agent and is reconciled field by field.
-	a.perTurnState = perTurnState{}
+	a.perTurnState = perTurnState{turnInput: input}
 	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
 	preserveEvidence := a.preserveEvidenceOnce
 	// A run that starts with a pending readiness recovery (or an explicit

--- a/internal/agent/turnstate.go
+++ b/internal/agent/turnstate.go
@@ -9,6 +9,10 @@ import "reasonix/internal/completion"
 // survive turns (delivery checkpoint/scope, failure budgets, storm counters)
 // stays directly on Agent.
 type perTurnState struct {
+	// turnInput is this run's task text. The contract is rebuilt from it and
+	// the ledger whenever a live view is needed, so one replay serves both the
+	// per-round observation and the end-of-turn record.
+	turnInput string
 	// completion is the report built as the turn ends; the host reads it while
 	// emitting TurnDone, before the next turn resets this state.
 	completion *completion.Report


### PR DESCRIPTION
Follow-up to #8183. `Contract.GateMutation` and `Contract.FinalRejection` have
never had callers, and the reason turned out not to be a missing call site.

## The contract did not exist when it was needed

```go
// run_loop.go — the only time in the whole turn, and then it is discarded
a.emitTurnShadows(state.input)
```

The contract was built at the *end* of a turn from a full replay of its
receipts. But both gates have to answer mid-turn: `GateMutation` before a
mutation runs, `FinalRejection` at the moment a completion is claimed. There was
nothing in scope for them to ask.

## LiveContract answers now

It reruns the same pure replay against the receipts recorded so far, rather than
keeping incremental state. One code path serves the per-round view and the
end-of-turn record, so the two cannot disagree — asserted directly in
`TestLiveContractMatchesTheEndOfTurnReplay`. Rebuilding is cheap: a turn's
receipts number in the tens, and `buildShadowContract` was already pure.

Incremental state was the obvious alternative and is the wrong one here.
`Contract.Observe` advances a mutation epoch and stales verification-backed
satisfactions, so feeding it the same receipt twice would corrupt freshness. A
replay from zero has no such failure mode.

## Every round is recorded

Each tool round now records the contract alongside the outcome sample, so a
trajectory carries how the evidence graph filled in rather than only where it
landed — requirements satisfied, checks satisfied, epoch, verdict, per round. A
turn with nothing to prove records nothing, so this does not spray empty samples
into conversational turns.

## Still decides nothing

`GateMutation` and `FinalRejection` remain uncalled. Enforcement is the next
change and carries an open design question that belongs in its own review:
`GateMutation(requirementID)` expects a post-green mutation to name the
unsatisfied requirement it serves, and no tool carries such an argument today.
The options — an explicit argument on writer tools, a binary gate with no
binding, or host-side inference from touched paths — differ in cost and in how
much they lean on the host guessing, which is what this whole series has been
removing.

## Verification

`gofmt`, `go vet ./...`, `make lint` (golangci-lint 0 issues + repolint clean at
1967), `go test ./...` — 115 packages ok, 0 failures. Five new tests: the live
view reflects evidence as it lands, it matches the end-of-turn replay for the
same receipts, the per-round record forms a time series that shows a check being
satisfied, an empty contract records nothing, and a missing ledger yields no
contract.

`turnInput` rides the existing single `perTurnState` zeroing assignment, so a
turn can never forget to reset it — the reason that struct exists — and
`run_loop.go` stays inside its ratchet with no baseline change.

Cache-impact: none - the only touched files are internal/agent/run_loop.go, progress_guard.go, contract_shadow.go and turnstate.go, none of which contribute prompt text, tool schemas, or message assembly. No provider-visible bytes change.
Cache-guard: internal/boot golden baseline (TestGoldenBaselineNoExtensions) passes unchanged, which is the direct evidence that SystemHash, ToolsHash and ToolSchemaTokens are untouched.
Documentation-impact: none - no user-facing surface changes. The contract shadow is an internal observation recorded to trajectories; no tool schema, command, flag, or rendered output changes.
