### PR TITLE
fix(config): repoint model refs when a plugin package is removed

### DIFF
--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -614,6 +614,62 @@ func (c *Config) providerRemovalFallback(name string) string {
 	return ""
 }
 
+// RemovePluginModelRefs migrates model references that name models of the
+// plugin id off that plugin, and reports whether anything changed.
+//
+// Plugin-namespaced refs (plugin/<plugin>/<provider>/<model>) resolve through
+// boot's merged resolver rather than the config catalog, so SetDefaultModel
+// accepts them without proof. That trade means removing the plugin strands
+// every ref that named it: the next launch fails with "unknown model" and no
+// session can start until the file is edited by hand. Removal calls this to
+// close that gap the way RemoveProvider does for a deleted provider.
+//
+// References move to the first remaining configured provider. Unlike provider
+// removal this never refuses: the plugin is already gone by the time it runs,
+// so with no fallback the refs are cleared and the keyless-default policy in
+// ResolveNewSessionChatModel picks the boot model instead.
+func (c *Config) RemovePluginModelRefs(pluginID string) bool {
+	pluginID = strings.TrimSpace(pluginID)
+	if pluginID == "" {
+		return false
+	}
+	ownedByPlugin := func(ref string) bool {
+		return protocol.PluginRefOwner(strings.TrimSpace(ref)) == pluginID
+	}
+
+	defaultOwned := ownedByPlugin(c.DefaultModel)
+	plannerOwned := ownedByPlugin(c.Agent.PlannerModel)
+	subagentOwned := ownedByPlugin(c.Agent.SubagentModel)
+	subagentModelsOwned := map[string]bool{}
+	for skill, ref := range c.Agent.SubagentModels {
+		if ownedByPlugin(ref) {
+			subagentModelsOwned[skill] = true
+		}
+	}
+	if !defaultOwned && !plannerOwned && !subagentOwned && len(subagentModelsOwned) == 0 {
+		return false
+	}
+
+	fallback := c.providerRemovalFallback("")
+	if defaultOwned {
+		c.DefaultModel = fallback
+	}
+	if plannerOwned {
+		c.Agent.PlannerModel = fallback
+	}
+	if subagentOwned {
+		c.Agent.SubagentModel = fallback
+	}
+	for skill := range subagentModelsOwned {
+		if fallback != "" {
+			c.Agent.SubagentModels[skill] = fallback
+		} else {
+			delete(c.Agent.SubagentModels, skill)
+		}
+	}
+	return true
+}
+
 // validateProvider checks the fields a provider can't function without.
 func validateProvider(e ProviderEntry) error {
 	switch {

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -320,3 +320,81 @@ func TestRemoveProviderClearsOptionalRefsWithoutFallback(t *testing.T) {
 		t.Fatal("subagent_models.review should be removed")
 	}
 }
+
+func TestRemovePluginModelRefsMigratesRefs(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.DefaultModel = "plugin/commandcode/commandcode/deepseek-v4-flash"
+	c.Agent.PlannerModel = "plugin/commandcode/commandcode/deepseek-v4-pro"
+	c.Agent.SubagentModel = "prov-b/model-b1"
+	c.Agent.SubagentModels = map[string]string{
+		"review":  "plugin/commandcode/commandcode/deepseek-v4-flash",
+		"explore": "plugin/other/other/model",
+	}
+
+	if !c.RemovePluginModelRefs("commandcode") {
+		t.Fatal("RemovePluginModelRefs should report a change")
+	}
+	if c.DefaultModel != "prov-a" {
+		t.Fatalf("default_model = %q, want prov-a", c.DefaultModel)
+	}
+	if c.Agent.PlannerModel != "prov-a" {
+		t.Fatalf("planner_model = %q, want prov-a", c.Agent.PlannerModel)
+	}
+	if c.Agent.SubagentModel != "prov-b/model-b1" {
+		t.Fatalf("unaffected subagent_model changed to %q", c.Agent.SubagentModel)
+	}
+	if c.Agent.SubagentModels["review"] != "prov-a" {
+		t.Fatalf("subagent_models.review = %q, want prov-a", c.Agent.SubagentModels["review"])
+	}
+	if c.Agent.SubagentModels["explore"] != "plugin/other/other/model" {
+		t.Fatalf("ref of another plugin changed to %q", c.Agent.SubagentModels["explore"])
+	}
+}
+
+func TestRemovePluginModelRefsClearsRefsWithoutFallback(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.Providers = nil
+	c.DefaultModel = "plugin/commandcode/commandcode/deepseek-v4-flash"
+	c.Agent.SubagentModels = map[string]string{"review": "plugin/commandcode/commandcode/deepseek-v4-pro"}
+
+	if !c.RemovePluginModelRefs("commandcode") {
+		t.Fatal("RemovePluginModelRefs should report a change")
+	}
+	if c.DefaultModel != "" {
+		t.Fatalf("default_model = %q, want cleared", c.DefaultModel)
+	}
+	if _, ok := c.Agent.SubagentModels["review"]; ok {
+		t.Fatal("subagent_models.review should be removed")
+	}
+}
+
+func TestRemovePluginModelRefsLeavesUnrelatedConfig(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.DefaultModel = "prov-a/model-a1"
+	c.Agent.PlannerModel = "plugin/other/other/model"
+
+	if c.RemovePluginModelRefs("commandcode") {
+		t.Fatal("RemovePluginModelRefs should report no change")
+	}
+	if c.DefaultModel != "prov-a/model-a1" {
+		t.Fatalf("default_model = %q, want unchanged", c.DefaultModel)
+	}
+	if c.Agent.PlannerModel != "plugin/other/other/model" {
+		t.Fatalf("planner_model = %q, want unchanged", c.Agent.PlannerModel)
+	}
+	if c.RemovePluginModelRefs("") {
+		t.Fatal("empty plugin id should report no change")
+	}
+}
+
+func TestRemovePluginModelRefsKeepsProviderNamedLikePlugin(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	c.DefaultModel = "prov-a"
+
+	if c.RemovePluginModelRefs("prov-a") {
+		t.Fatal("a bare provider ref must not be treated as a plugin ref")
+	}
+	if c.DefaultModel != "prov-a" {
+		t.Fatalf("default_model = %q, want unchanged", c.DefaultModel)
+	}
+}

--- a/internal/installsource/plugin_model_refs_test.go
+++ b/internal/installsource/plugin_model_refs_test.go
@@ -1,0 +1,122 @@
+package installsource
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/pluginpkg"
+)
+
+const testPluginConfig = `default_model = "plugin/commandcode/commandcode/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com/v1"
+model = "deepseek-v4-flash"
+api_key_env = "REASONIX_TEST_KEY"
+`
+
+// removePluginPackageFixture installs one plugin package into an isolated
+// REASONIX_HOME and writes cfg as the user config. It returns the tool under
+// test and the config path.
+func removePluginPackageFixture(t *testing.T, cfg string) (*installSourceTool, string) {
+	t.Helper()
+
+	home := t.TempDir()
+	reasonixHome := filepath.Join(home, ".reasonix")
+	if err := os.MkdirAll(filepath.Join(reasonixHome, "plugins", "commandcode"), 0o755); err != nil {
+		t.Fatalf("mkdir plugin root: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("REASONIX_HOME", reasonixHome)
+	// Provider entries resolve keys only from Reasonix's global .env, so the
+	// fallback provider counts as configured only when the key lives there.
+	if err := os.WriteFile(filepath.Join(reasonixHome, ".env"), []byte("REASONIX_TEST_KEY=sk-test\n"), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+	oldUserHomeDir := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { userHomeDir = oldUserHomeDir })
+
+	if err := pluginpkg.Upsert(reasonixHome, pluginpkg.InstalledPlugin{
+		Name:    "commandcode",
+		Root:    filepath.Join("plugins", "commandcode"),
+		Version: "0.1.0",
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("upsert plugin: %v", err)
+	}
+
+	path := filepath.Join(reasonixHome, "config.toml")
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	tl := NewTool(Options{ProjectRoot: t.TempDir()}).(*installSourceTool)
+	return tl, path
+}
+
+func TestRemovePluginPackageRepairsDefaultModel(t *testing.T) {
+	tl, path := removePluginPackageFixture(t, testPluginConfig)
+
+	act := &action{Kind: "plugin", Action: "remove_plugin_package", Name: "commandcode"}
+	if err := tl.applyRemovePluginPackage(request{}, act); err != nil {
+		t.Fatalf("applyRemovePluginPackage: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(got), "plugin/commandcode/") {
+		t.Fatalf("config still references the removed plugin:\n%s", got)
+	}
+	if !strings.Contains(string(got), `default_model = "deepseek-flash"`) {
+		t.Fatalf("default_model was not repaired:\n%s", got)
+	}
+}
+
+func TestRemovePluginPackageLeavesUnrelatedConfigByteIdentical(t *testing.T) {
+	cfg := strings.Replace(testPluginConfig,
+		`default_model = "plugin/commandcode/commandcode/deepseek-v4-flash"`,
+		`default_model = "deepseek-flash"`, 1)
+	tl, path := removePluginPackageFixture(t, cfg)
+
+	act := &action{Kind: "plugin", Action: "remove_plugin_package", Name: "commandcode"}
+	if err := tl.applyRemovePluginPackage(request{}, act); err != nil {
+		t.Fatalf("applyRemovePluginPackage: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != cfg {
+		t.Fatalf("config was rewritten although no ref named the plugin:\ngot:\n%s\nwant:\n%s", got, cfg)
+	}
+}
+
+func TestRemovePluginPackageKeepsMalformedConfig(t *testing.T) {
+	const broken = "default_model = \"plugin/commandcode/commandcode/deepseek-v4-flash\"\n[[providers\n"
+	tl, path := removePluginPackageFixture(t, broken)
+
+	act := &action{Kind: "plugin", Action: "remove_plugin_package", Name: "commandcode"}
+	if err := tl.applyRemovePluginPackage(request{}, act); err != nil {
+		t.Fatalf("applyRemovePluginPackage: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != broken {
+		t.Fatalf("a malformed config must be left for the user to recover:\n%s", got)
+	}
+	if _, ok, _ := pluginpkg.FindInstalled(tl.reasonixHome, "commandcode"); ok {
+		t.Fatal("plugin should still be removed when the config cannot be repaired")
+	}
+}

--- a/internal/installsource/plugin_package.go
+++ b/internal/installsource/plugin_package.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 
+	"reasonix/internal/config"
 	"reasonix/internal/gitcmd"
 	"reasonix/internal/pluginpkg"
 )
@@ -691,6 +692,9 @@ func (t *installSourceTool) applyRemovePluginPackage(_ request, act *action) err
 	if err != nil || !ok {
 		return err
 	}
+	if err := repairPluginModelRefs(act.Name); err != nil {
+		return err
+	}
 	root := pluginpkg.ResolveRoot(t.reasonixHome, installed.Root)
 	if t.onDisconnect != nil {
 		if pkg, _, err := pluginpkg.ParseDir(root); err == nil {
@@ -709,6 +713,43 @@ func (t *installSourceTool) applyRemovePluginPackage(_ request, act *action) err
 		if err := os.RemoveAll(root); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// repairPluginModelRefs moves default_model and the optional agent model refs
+// off a plugin that has just been removed. Its models stop resolving the
+// moment the package is gone, and boot rejects an unknown default_model, so
+// leaving the ref in place locks the user out of every session until they edit
+// the file by hand.
+//
+// Only the user config is repaired: plugin packages install globally, so a
+// project reasonix.toml that names a plugin model is the project's own choice
+// to make and to undo.
+func repairPluginModelRefs(pluginID string) error {
+	path := config.UserConfigPath()
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	// Probe a throwaway copy first. A config with no ref to this plugin is left
+	// byte-for-byte alone, and a malformed one is left for the user to recover:
+	// rewriting it here would trade a stale ref for a lost file.
+	//
+	// Credentials load with it: the fallback provider must be one the user can
+	// actually reach, and Configured() reports false for every provider when
+	// the keys are absent.
+	probe, err := config.LoadForEditReadOnlyStrict(path)
+	if err != nil || probe == nil || !probe.RemovePluginModelRefs(pluginID) {
+		return nil
+	}
+	if err := config.EditConfigFile(path, func(fresh *config.Config) error {
+		fresh.RemovePluginModelRefs(pluginID)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("repair model refs for plugin %q: %w", pluginID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- `reasonix plugin remove <name>` left `default_model` pointing at a model of the removed plugin. The
  next launch failed with `error: unknown model` and no session could start until the user found and
  edited `config.toml` by hand.
- `Config.RemovePluginModelRefs` migrates `default_model`, `planner_model`, `subagent_model`, and
  `subagent_models` off the removed plugin, mirroring what `RemoveProvider` already does for a deleted
  provider. `applyRemovePluginPackage` calls it once the package is gone.
- Unlike provider removal this never refuses: the package is already deleted by the time it runs, so
  with no configured provider to fall back on the refs are cleared and the keyless-default policy in
  `ResolveNewSessionChatModel` picks the boot model.

Why the refs could go stale in the first place: `SetDefaultModel` accepts plugin-namespaced refs
(`plugin/<plugin>/<provider>/<model>`) without proof, because the config catalog cannot vouch for
models that live in an extension sidecar — boot's merged resolver is their only gate. That trade is
correct, but nothing repaired the config when the sidecar went away.

Two deliberate limits:

- **The user config only.** Plugin packages install globally, so a project `reasonix.toml` that names a
  plugin model is the project's own choice to make and to undo.
- **A malformed config is left untouched.** Rewriting it here would trade a stale ref for a lost file,
  so the repair is skipped and removal still succeeds.

A config that names no model of the removed plugin is left byte-for-byte alone — there is a test for
that, since the repair runs on every plugin removal.

## Issues

Fixes #8187

## Verification

```
go test ./internal/config/ -run TestRemovePluginModelRefs
go test ./internal/installsource/ -run TestRemovePluginPackage
go vet ./...
gofmt -l .
```

Seven new tests, all passing:

| Test | Asserts |
|---|---|
| `TestRemovePluginModelRefsMigratesRefs` | every owned ref moves to the first configured provider; refs of another plugin are untouched |
| `TestRemovePluginModelRefsClearsRefsWithoutFallback` | with no configured provider the refs are cleared, not left dangling |
| `TestRemovePluginModelRefsLeavesUnrelatedConfig` | no change, and no false positive, when nothing names the plugin |
| `TestRemovePluginModelRefsKeepsProviderNamedLikePlugin` | a bare provider ref is never mistaken for a plugin ref |
| `TestRemovePluginPackageRepairsDefaultModel` | end to end: after `applyRemovePluginPackage` the file on disk names the surviving provider |
| `TestRemovePluginPackageLeavesUnrelatedConfigByteIdentical` | an untouched config is not rewritten or reformatted |
| `TestRemovePluginPackageKeepsMalformedConfig` | a malformed config survives, and the plugin is still removed |

Manual reproduction of #8187 on macOS 26.5.1 (darwin/arm64): install a provider plugin, set its model as
`default_model`, remove the plugin, start `reasonix`. Before this change the CLI refuses to start; after
it, `default_model` names the remaining configured provider and the session opens.

One finding worth recording: the repair must load credentials. `ProviderEntry.Configured()` reports
false for every provider when keys are absent, so the credential-free loader made the fallback come back
empty and cleared `default_model` even when a usable provider existed. `TestRemovePluginPackageRepairsDefaultModel`
caught it, and the repair now uses `LoadForEditReadOnlyStrict` / `EditConfigFile`.

## Documentation impact

Documentation-impact: none - the repair restores the documented behavior that `default_model` names a
resolvable model. No user-visible flag, command, or configuration key changes.

## Cache impact

Cache-impact: none - the change touches config repair on plugin removal only. It does not reach system
prompt construction, memory prefix, output styles, skill index behavior, tool surfaces or schemas,
provider request serialization, compaction, or MCP/tool registration.
Cache-guard: N/A - no prompt- or tool-prefix surface is involved.
System-prompt-review: N/A
