### PR TITLE
fix(agent): stop an oversized output budget from collapsing every compaction threshold

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -41,6 +41,7 @@ const (
 	maxCarriedDigestTokens     = 12000 // ceiling on digests carried verbatim across folds before one consolidating fold merges them
 	maxEarlyUserTurns          = 3     // small user turns hoisted verbatim ahead of the digest; position-fixed (the first N of the fold region, never "the latest N") so the projection prefix stays byte-stable
 	protocolReserveTokens      = 256   // provider framing and control fields not represented by message estimates
+	maxOutputReserveRatio      = 0.25  // ceiling on the window share an output budget may reserve before the thresholds collapse
 )
 
 var errSummaryOutputTruncated = errors.New("summarizer output truncated")
@@ -119,14 +120,26 @@ func (a *Agent) hardInputCeiling() int {
 		return 0
 	}
 	hard := a.contextWindow
-	outputBudget := a.maxOutputTokens
-	if outputBudget <= 0 && sharesContextWindow(a.prov) {
-		outputBudget = a.outputBudget
-	}
-	if outputBudget > 0 {
+	if outputBudget := a.reservedOutputTokens(); outputBudget > 0 {
 		hard -= outputBudget + protocolReserveTokens
 	}
 	return max(1, hard)
+}
+
+// reservedOutputTokens is the window share the thresholds hold back for the
+// reply. An output budget can exceed the configured window entirely (DeepSeek
+// defaults to 128K), which would drive every threshold to the one-token floor.
+// effectiveOutputBudget clips the actual reply at send time, so reserving more
+// than a quarter of the window buys nothing here.
+func (a *Agent) reservedOutputTokens() int {
+	budget := a.maxOutputTokens
+	if budget <= 0 && sharesContextWindow(a.prov) {
+		budget = a.outputBudget
+	}
+	if budget <= 0 {
+		return 0
+	}
+	return minInt(budget, int(float64(a.contextWindow)*maxOutputReserveRatio))
 }
 
 func (a *Agent) forceCompactThreshold(high int) int {

--- a/internal/agent/compact_threshold_test.go
+++ b/internal/agent/compact_threshold_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import "testing"
+
+// An output budget larger than the window it shares (DeepSeek defaults to 128K,
+// and 128000 was the value the custom-provider wizard wrote unconditionally)
+// used to drive the hard ceiling to its one-token floor, so every turn crossed
+// every trigger and compacted.
+func TestCompactThresholdsSurviveOversizedOutputBudget(t *testing.T) {
+	a := &Agent{
+		prov:                &sharedWindowTestProvider{budget: 131_072, shared: true},
+		contextWindow:       128_000,
+		outputBudgetState:   outputBudgetState{outputBudget: 131_072},
+		softCompactRatio:    defaultSoftCompactRatio,
+		toolResultSnipRatio: defaultToolResultSnipRatio,
+		compactRatio:        defaultCompactRatio,
+		compactForceRatio:   defaultCompactForceRatio,
+	}
+	soft, snip, fold := a.compactThresholds()
+	force := a.forceCompactThreshold(fold)
+	// reserve = min(131072, 0.25*128000) = 32000; hard = 128000 - 32000 - 256.
+	if soft != 64_000 || snip != 76_800 || fold != 95_744 || force != 95_744 {
+		t.Fatalf("thresholds = %d/%d/%d/%d, want 64000/76800/95744/95744", soft, snip, fold, force)
+	}
+	if !(soft < snip && snip < fold) {
+		t.Fatalf("thresholds collapsed onto each other: soft=%d snip=%d fold=%d", soft, snip, fold)
+	}
+}
+
+// A declared window that genuinely fits its output budget keeps reserving the
+// whole budget: the clamp must not loosen the ceiling for correct setups.
+func TestCompactThresholdsReserveWholeBudgetWhenWindowFits(t *testing.T) {
+	a := &Agent{
+		prov:                &sharedWindowTestProvider{budget: 131_072, shared: true},
+		contextWindow:       1_000_000,
+		outputBudgetState:   outputBudgetState{outputBudget: 131_072},
+		softCompactRatio:    defaultSoftCompactRatio,
+		toolResultSnipRatio: defaultToolResultSnipRatio,
+		compactRatio:        defaultCompactRatio,
+		compactForceRatio:   defaultCompactForceRatio,
+	}
+	soft, snip, fold := a.compactThresholds()
+	force := a.forceCompactThreshold(fold)
+	if soft != 500_000 || snip != 600_000 || fold != 800_000 || force != 868_672 {
+		t.Fatalf("thresholds = %d/%d/%d/%d, want 500000/600000/800000/868672", soft, snip, fold, force)
+	}
+}


### PR DESCRIPTION
## What breaks today

`hardInputCeiling` subtracts the whole output budget from the context window, and `compactThresholds` clamps every trigger to it. An output budget can be larger than the window itself — DeepSeek's Anthropic-compatible endpoint defaults to 128K output (`provider.DefaultHighOutputTokens`), and the custom-provider wizard wrote `context_window = 128000` unconditionally on all four paths until #8124. That pair is ordinary in existing configs.

Measured on `main-v2` (official DeepSeek shape: shared window, 128K output budget):

| context_window | soft | snip | fold | force |
|---|---|---|---|---|
| 1,000,000 | 50% | 60% | 80% | 87% |
| 400,000 | 50% | 60% | 67% | 67% |
| 256,000 | 49% | 49% | 49% | 49% |
| 200,000 | 34% | 34% | 34% | 34% |
| 160,000 | 18% | 18% | 18% | 18% |
| **128,000** | **1 token** | 1 | 1 | 1 |

At 128K every turn crosses every trigger, so every turn force-compacts. Two things make it unexplainable from the user's side: `forceFold` is always true, so the low-value-fold guard never applies; and `est >= soft && est < snip` is unreachable once the two are equal, so the "context is getting large" notice never fires. The configured `compact_ratio` has no effect at all.

Reported as #8132, #8116, #8191, #8176; #7869 and #7978 are the same root cause seen from the window side.

## The fix

Reserve at most a quarter of the window for the reply. `effectiveOutputBudget` already clips the real reply against the measured prompt before the request goes out (#8057), so a larger reservation in the threshold math protects nothing it does not already cover. A window that genuinely fits its budget (1M / 128K) still reserves it whole and is byte-for-byte unchanged.

After the fix, 128K/128K gives soft 64000 (50%) < snip 76800 (60%) < fold 95744 (75%) = force — grading restored, and compaction happens once per long session instead of once per turn.

## Not fixed here

Two further causes of "it compacts for no reason" are separate PRs: the cold-start token estimate overshoots by 3-4x (`estimateTextTokens` returns `max(runes, bytes/4)`, which always picks runes), and `SetSession` drops the prompt-token calibration on every session rebind so the overshoot recurs after each recovery/tab switch.

## Verification

- `TestCompactThresholdsSurviveOversizedOutputBudget` pins the whole 128K/128K threshold table and asserts the levels stay strictly separated.
- `TestCompactThresholdsReserveWholeBudgetWhenWindowFits` pins 1M/128K unchanged.
- `go test ./internal/agent/ ./internal/cli/ ./internal/control/ ./internal/boot/ ./internal/tool/builtin/` green; `make lint` clean for this diff (`desktop/frontend/src/App.tsx` is a pre-existing violation on `main-v2`).

Cache-impact: low - threshold arithmetic only; the provider-visible prefix bytes are unchanged, and affected setups compact far less often, so cache resets go down rather than up.
Cache-guard: TestCompactThresholdsSurviveOversizedOutputBudget / TestCompactThresholdsReserveWholeBudgetWhenWindowFits pin the derived triggers for both the clamped and unclamped shapes.
Documentation-impact: none - the documented knobs (context_window, compact_ratio) keep their meaning; this restores the behavior the docs already describe.