### PR TITLE
feat(agent): a proof binds to the criterion it proves

### DIFF
--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"reasonix/internal/completion"
 	"reasonix/internal/event"
@@ -42,6 +44,7 @@ func buildShadowContract(input string, receipts []evidence.Receipt, plan *planco
 	}
 	for _, r := range receipts {
 		c.Observe(r)
+		resolveCitedCriteria(c, r)
 	}
 	for i, todo := range todos {
 		if todo.Status == "completed" {
@@ -49,6 +52,53 @@ func buildShadowContract(input string, receipts []evidence.Receipt, plan *planco
 		}
 	}
 	return c
+}
+
+// resolveCitedCriteria satisfies the criteria a successful complete_step named.
+// The tool verified each proof against the ledger before succeeding, so what the
+// citation adds is the binding: "the command ran" and "the criterion holds" are
+// different claims, and only the model knows which proof was for which.
+func resolveCitedCriteria(c *taskcontract.Contract, r evidence.Receipt) {
+	if r.ToolName != "complete_step" || !r.Success || len(r.Args) == 0 {
+		return
+	}
+	var payload struct {
+		Evidence []struct {
+			Kind        string `json:"kind"`
+			CriterionID string `json:"criterion_id"`
+		} `json:"evidence"`
+	}
+	if json.Unmarshal(r.Args, &payload) != nil {
+		return
+	}
+	for _, e := range payload.Evidence {
+		id := strings.TrimSpace(e.CriterionID)
+		if id == "" {
+			continue
+		}
+		c.Resolve(id, taskcontract.Satisfied, taskcontract.EvidenceRef{
+			Kind:          criterionEvidenceKind(e.Kind),
+			MutationEpoch: c.Epoch(),
+			Source:        "complete_step",
+			Success:       true,
+		})
+	}
+}
+
+// criterionEvidenceKind mirrors the ledger's own classification so staleness
+// behaves identically: a mutation proves it happened and never stales, while a
+// verification, review, or manual check must be re-proven after later changes.
+func criterionEvidenceKind(kind string) taskcontract.EvidenceKind {
+	switch kind {
+	case "verification":
+		return taskcontract.EvidenceVerification
+	case "review":
+		return taskcontract.EvidenceReview
+	case "diff", "files":
+		return taskcontract.EvidenceMutation
+	default:
+		return taskcontract.EvidenceRead
+	}
 }
 
 func contractShadowAudit(c *taskcontract.Contract) event.ContractShadowAudit {

--- a/internal/agent/criterion_proof_test.go
+++ b/internal/agent/criterion_proof_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/plancontract"
+	"reasonix/internal/taskcontract"
+)
+
+func completeStepReceipt(t *testing.T, criterionID, kind, command string) evidence.Receipt {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{
+		"step":   "do it",
+		"result": "done",
+		"evidence": []map[string]any{
+			{"kind": kind, "summary": "proved it", "command": command, "criterion_id": criterionID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return evidence.Receipt{ToolName: "complete_step", Success: true, Step: "do it", Args: args}
+}
+
+func criterionPlan() plancontract.Plan {
+	return plancontract.Plan{
+		Objective: "fix the retry race",
+		Steps: []plancontract.Step{{
+			Title: "fix it",
+			Acceptance: []plancontract.Criterion{
+				{Text: "retries no longer double-charge"},
+				{Text: "existing payment tests keep passing", Regression: true},
+			},
+		}},
+	}.Normalize()
+}
+
+func requirementByID(c *taskcontract.Contract, id string) (taskcontract.Requirement, bool) {
+	for _, req := range c.Requirements {
+		if req.ID == id {
+			return req, true
+		}
+	}
+	return taskcontract.Requirement{}, false
+}
+
+// A command succeeding is not a criterion being met. The citation is what binds
+// the proof to the claim, and without it the criterion stays unproven.
+func TestCitedCriterionBecomesSatisfied(t *testing.T) {
+	plan := criterionPlan()
+	first := plan.Steps[0].Acceptance[0].ID
+
+	uncited := buildShadowContract("fix it", []evidence.Receipt{
+		{ToolName: "bash", Command: "go test ./...", Success: true},
+	}, &plan)
+	if req, ok := requirementByID(uncited, first); !ok || req.Status == taskcontract.Satisfied {
+		t.Fatalf("an uncited passing command must not satisfy a criterion: %+v", req)
+	}
+
+	cited := buildShadowContract("fix it", []evidence.Receipt{
+		{ToolName: "bash", Command: "go test ./...", Success: true},
+		completeStepReceipt(t, first, "verification", "go test ./..."),
+	}, &plan)
+	req, ok := requirementByID(cited, first)
+	if !ok || req.Status != taskcontract.Satisfied {
+		t.Fatalf("the cited criterion was not satisfied: %+v", req)
+	}
+	if len(req.Evidence) == 0 {
+		t.Fatal("a satisfied criterion must carry the proof that satisfied it")
+	}
+}
+
+// Freshness is the point: a criterion proven by a test run stops counting once
+// the code changes underneath it.
+func TestVerifiedCriterionGoesStaleAfterALaterMutation(t *testing.T) {
+	plan := criterionPlan()
+	id := plan.Steps[0].Acceptance[0].ID
+
+	c := buildShadowContract("fix it", []evidence.Receipt{
+		{ToolName: "bash", Command: "go test ./...", Success: true},
+		completeStepReceipt(t, id, "verification", "go test ./..."),
+		{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}},
+	}, &plan)
+
+	req, ok := requirementByID(c, id)
+	if !ok || req.Status != taskcontract.Stale {
+		t.Fatalf("status = %v, want Stale after a mutation landed on top of the proof:\n%s", req.Status, c.Graph())
+	}
+}
+
+// Mutation-kind evidence records that a change happened, which a later change
+// cannot un-happen; whether the fix still holds is verification's job.
+func TestMutationProofDoesNotGoStale(t *testing.T) {
+	plan := criterionPlan()
+	id := plan.Steps[0].Acceptance[0].ID
+
+	c := buildShadowContract("fix it", []evidence.Receipt{
+		completeStepReceipt(t, id, "diff", ""),
+		{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"other.go"}},
+	}, &plan)
+
+	req, _ := requirementByID(c, id)
+	if req.Status != taskcontract.Satisfied {
+		t.Fatalf("status = %v, want Satisfied; mutation evidence must not stale", req.Status)
+	}
+}
+
+func TestUnknownCriterionCitationIsIgnoredByTheReplay(t *testing.T) {
+	plan := criterionPlan()
+	c := buildShadowContract("fix it", []evidence.Receipt{
+		completeStepReceipt(t, "c99", "verification", "go test ./..."),
+	}, &plan)
+	for _, req := range c.Requirements {
+		if req.Status == taskcontract.Satisfied {
+			t.Fatalf("a bogus citation satisfied %q", req.ID)
+		}
+	}
+}
+
+func TestAcceptanceCriterionIDsReachTheToolCall(t *testing.T) {
+	a := New(nil, nil, NewSession(""), Options{}, nil)
+	if ids := a.acceptanceCriterionIDs(); len(ids) != 0 {
+		t.Fatalf("no plan must yield no ids, got %v", ids)
+	}
+	plan := criterionPlan()
+	a.SetPlanContract(&plan)
+	ids := a.acceptanceCriterionIDs()
+	if len(ids) != 2 {
+		t.Fatalf("ids = %v, want both criteria of the approved plan", ids)
+	}
+}

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -681,7 +681,7 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 		}
 	}
 	if !a.planMode.Load() {
-		cctx = evidence.WithTodoState(cctx, a.CanonicalTodoState())
+		cctx = a.withContractState(cctx)
 	}
 	if plan.planReplacementAuthorized {
 		cctx = tool.WithPlanReplacementAuthorization(cctx)

--- a/internal/agent/plan_contract.go
+++ b/internal/agent/plan_contract.go
@@ -1,6 +1,9 @@
 package agent
 
 import (
+	"context"
+
+	"reasonix/internal/evidence"
 	"reasonix/internal/plancontract"
 	"reasonix/internal/taskcontract"
 )
@@ -43,13 +46,14 @@ func planFacts(plan plancontract.Plan) taskcontract.PlanFacts {
 	seen := map[string]bool{}
 	for _, step := range plan.Steps {
 		for _, c := range step.Acceptance {
+			criterion := taskcontract.PlanCriterion{ID: c.ID, Text: c.Text}
 			switch {
 			case c.Optional:
-				facts.Optional = append(facts.Optional, c.Text)
+				facts.Optional = append(facts.Optional, criterion)
 			case c.Regression:
-				facts.Regressions = append(facts.Regressions, c.Text)
+				facts.Regressions = append(facts.Regressions, criterion)
 			default:
-				facts.AcceptanceCriteria = append(facts.AcceptanceCriteria, c.Text)
+				facts.AcceptanceCriteria = append(facts.AcceptanceCriteria, criterion)
 			}
 		}
 		for _, v := range step.Verification {
@@ -79,4 +83,31 @@ func appendUnseen(dst []string, seen map[string]bool, add []string) []string {
 		dst = append(dst, s)
 	}
 	return dst
+}
+
+// acceptanceCriterionIDs lists the approved plan's criterion ids so a tool call
+// can check a citation against the plan the user approved.
+func (a *Agent) acceptanceCriterionIDs() []string {
+	plan := a.planContractSnapshot()
+	if plan == nil {
+		return nil
+	}
+	var ids []string
+	for _, step := range plan.Steps {
+		for _, c := range step.Acceptance {
+			if c.ID != "" {
+				ids = append(ids, c.ID)
+			}
+		}
+	}
+	return ids
+}
+
+// withContractState attaches what a tool call needs to check a claim against the
+// approved work: the canonical task list, and the criterion ids a proof may
+// cite. They travel together because both answer "does this claim name
+// something real".
+func (a *Agent) withContractState(ctx context.Context) context.Context {
+	ctx = evidence.WithTodoState(ctx, a.CanonicalTodoState())
+	return evidence.WithAcceptanceCriteria(ctx, a.acceptanceCriterionIDs())
 }

--- a/internal/agent/plan_contract_test.go
+++ b/internal/agent/plan_contract_test.go
@@ -33,15 +33,30 @@ func contractPlan() plancontract.Plan {
 }
 
 func TestPlanFactsSeparatesCriteriaByKind(t *testing.T) {
-	facts := planFacts(contractPlan())
-	if !slices.Equal(facts.AcceptanceCriteria, []string{"two model refs never share an entry"}) {
+	plan := contractPlan()
+	facts := planFacts(plan)
+	texts := func(cs []taskcontract.PlanCriterion) []string {
+		out := make([]string, 0, len(cs))
+		for _, c := range cs {
+			if c.ID == "" {
+				t.Errorf("criterion %q lost the identity a proof must cite", c.Text)
+			}
+			out = append(out, c.Text)
+		}
+		return out
+	}
+	if !slices.Equal(texts(facts.AcceptanceCriteria), []string{"two model refs never share an entry"}) {
 		t.Errorf("acceptance = %v", facts.AcceptanceCriteria)
 	}
-	if !slices.Equal(facts.Regressions, []string{"existing hits keep hitting"}) {
+	if !slices.Equal(texts(facts.Regressions), []string{"existing hits keep hitting"}) {
 		t.Errorf("regressions = %v", facts.Regressions)
 	}
-	if !slices.Equal(facts.Optional, []string{"the hit rate is logged"}) {
+	if !slices.Equal(texts(facts.Optional), []string{"the hit rate is logged"}) {
 		t.Errorf("optional = %v", facts.Optional)
+	}
+	// The id the plan assigned is the id the contract must carry.
+	if got, want := facts.AcceptanceCriteria[0].ID, plan.Steps[0].Acceptance[0].ID; got != want {
+		t.Errorf("criterion id = %q, want the plan's %q", got, want)
 	}
 	if !slices.Equal(facts.Verifications, []string{"go test ./internal/provider/"}) {
 		t.Errorf("verifications = %v", facts.Verifications)
@@ -83,8 +98,8 @@ func TestShadowContractPrefersPlanCriteriaOverTodoTitles(t *testing.T) {
 // An optional criterion is recorded but must never hold completion open.
 func TestOptionalCriterionDoesNotBlockCompletion(t *testing.T) {
 	c := taskcontract.FromPlan("o", taskcontract.PlanFacts{
-		AcceptanceCriteria: []string{"required one"},
-		Optional:           []string{"nice to have"},
+		AcceptanceCriteria: []taskcontract.PlanCriterion{{Text: "required one"}},
+		Optional:           []taskcontract.PlanCriterion{{Text: "nice to have"}},
 	})
 	for _, req := range c.Requirements {
 		if req.Text == "required one" {

--- a/internal/boot/testdata/golden/prefix_shape.json
+++ b/internal/boot/testdata/golden/prefix_shape.json
@@ -1,7 +1,7 @@
 {
   "SystemHash": "c4a54b2f61c5e15f",
-  "ToolsHash": "f248c046f3a4b949",
-  "PrefixHash": "1fb02ad9410706a3",
+  "ToolsHash": "5b9f0432044a2332",
+  "PrefixHash": "0fc980b33b033718",
   "LogRewriteVersion": 0,
-  "ToolSchemaTokens": 14303
+  "ToolSchemaTokens": 14402
 }

--- a/internal/boot/testdata/golden/provider_request.json
+++ b/internal/boot/testdata/golden/provider_request.json
@@ -174,7 +174,7 @@
     },
     {
       "name": "complete_step",
-      "description": "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`.",
+      "description": "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`, and `criterion_id` naming the acceptance criterion the proof satisfies), and optional `notes`.",
       "parameters": {
         "properties": {
           "evidence": {
@@ -183,6 +183,10 @@
               "properties": {
                 "command": {
                   "description": "REQUIRED for verification evidence: the command as it actually ran (e.g. \"go test ./...\") — it is checked against this session's real command history.",
+                  "type": "string"
+                },
+                "criterion_id": {
+                  "description": "The acceptance criterion this proof satisfies, as the plan renders it (e.g. \"c2\" from \"accept [c2]: ...\"). Cite it whenever the step has criteria: a command succeeding is not the same as a criterion being met, and the host records the proof against the criterion you name.",
                   "type": "string"
                 },
                 "kind": {

--- a/internal/boot/testdata/golden/tool_schemas.json
+++ b/internal/boot/testdata/golden/tool_schemas.json
@@ -148,7 +148,7 @@
   },
   {
     "Name": "complete_step",
-    "Description": "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`.",
+    "Description": "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`, and `criterion_id` naming the acceptance criterion the proof satisfies), and optional `notes`.",
     "ReadOnly": true,
     "Schema": {
       "properties": {
@@ -158,6 +158,10 @@
             "properties": {
               "command": {
                 "description": "REQUIRED for verification evidence: the command as it actually ran (e.g. \"go test ./...\") — it is checked against this session's real command history.",
+                "type": "string"
+              },
+              "criterion_id": {
+                "description": "The acceptance criterion this proof satisfies, as the plan renders it (e.g. \"c2\" from \"accept [c2]: ...\"). Cite it whenever the step has criteria: a command succeeding is not the same as a criterion being met, and the host records the proof against the criterion you name.",
                 "type": "string"
               },
               "kind": {

--- a/internal/evidence/todo_identity.go
+++ b/internal/evidence/todo_identity.go
@@ -4,7 +4,10 @@ package evidence
 // is the authority; the text predicates below are the fallback for lists that
 // never carried one, where wording and position are all there is to go on.
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // todoMatchAt is the one place a positive match is built, so every path reports
 // the matched item's stable id alongside its position.
@@ -73,3 +76,21 @@ func todoContentRelates(todo TodoItem, match TodoStepMatch) bool {
 func textOverlaps(a, b string) bool {
 	return stepTextContains(normalizeStepText(a), normalizeStepText(b))
 }
+
+// WithAcceptanceCriteria carries the ids of the approved plan's criteria into a
+// tool call, so a proof citing one can be checked against the plan the user
+// approved instead of resolving into nothing.
+func WithAcceptanceCriteria(ctx context.Context, ids []string) context.Context {
+	if len(ids) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, acceptanceCriteriaKey{}, append([]string(nil), ids...))
+}
+
+// AcceptanceCriteriaFromContext returns the approved plan's criterion ids.
+func AcceptanceCriteriaFromContext(ctx context.Context) ([]string, bool) {
+	ids, ok := ctx.Value(acceptanceCriteriaKey{}).([]string)
+	return ids, ok && len(ids) > 0
+}
+
+type acceptanceCriteriaKey struct{}

--- a/internal/plancontract/render.go
+++ b/internal/plancontract/render.go
@@ -96,7 +96,9 @@ func renderDetail(b *strings.Builder, step Step, indent string) {
 		if c.Optional {
 			label += " (optional)"
 		}
-		fmt.Fprintf(b, "%s%s: %s\n", indent, label, c.Text)
+		// The id is rendered because a proof has to cite it: a criterion the
+		// executor cannot name is one it cannot satisfy.
+		fmt.Fprintf(b, "%s%s [%s]: %s\n", indent, label, c.ID, c.Text)
 	}
 	for _, v := range step.Verification {
 		command := v.Command

--- a/internal/plancontract/render_test.go
+++ b/internal/plancontract/render_test.go
@@ -89,8 +89,8 @@ func TestRenderKeepsStepDetailOffTheList(t *testing.T) {
 		"   verified: internal/provider/cache.go",
 		"   candidate: internal/boot/boot.go",
 		"   risk: existing warm caches invalidate once",
-		"     accept: two model refs never share an entry",
-		"     regression: existing hits keep hitting",
+		"     accept [c1]: two model refs never share an entry",
+		"     regression [c2]: existing hits keep hitting",
 		"     verify: go test ./internal/provider/ — all green",
 	} {
 		if !strings.Contains(out, want+"\n") {

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -140,12 +140,20 @@ func Atomic(input string) *Contract {
 // PlanFacts is a completed full plan's contract-relevant output, extracted
 // by the coordinator (plain data; this package never sees the plan text).
 type PlanFacts struct {
-	AcceptanceCriteria []string
-	Regressions        []string // must-keep-passing criteria
-	Optional           []string // nice-to-have; recorded but never blocking
-	Verifications      []string // command-level checks; "" entries mean any
+	AcceptanceCriteria []PlanCriterion
+	Regressions        []PlanCriterion // must-keep-passing criteria
+	Optional           []PlanCriterion // nice-to-have; recorded but never blocking
+	Verifications      []string        // command-level checks; "" entries mean any
 	Risky              bool
 	Touchpoints        []string
+}
+
+// PlanCriterion is one criterion with the identity the plan gave it. The id
+// travels rather than being regenerated here: a proof cites the criterion the
+// user approved, and a boundary that re-keys identity breaks that citation.
+type PlanCriterion struct {
+	ID   string
+	Text string
 }
 
 // FromPlan builds the contract straight from a plan the planner already
@@ -153,21 +161,20 @@ type PlanFacts struct {
 // instead of re-deriving a parallel set: Planner → Contract → Executor.
 func FromPlan(input string, facts PlanFacts) *Contract {
 	c := New(input)
-	for i, text := range facts.AcceptanceCriteria {
-		c.Requirements = append(c.Requirements, Requirement{
-			ID: fmt.Sprintf("r%d", i+1), Kind: "behavior", Text: text, Required: true,
-		})
+	add := func(criteria []PlanCriterion, kind, fallback string, required bool) {
+		for i, criterion := range criteria {
+			id := criterion.ID
+			if id == "" {
+				id = fmt.Sprintf("%s%d", fallback, i+1)
+			}
+			c.Requirements = append(c.Requirements, Requirement{
+				ID: id, Kind: kind, Text: criterion.Text, Required: required,
+			})
+		}
 	}
-	for i, text := range facts.Regressions {
-		c.Requirements = append(c.Requirements, Requirement{
-			ID: fmt.Sprintf("g%d", i+1), Kind: "regression", Text: text, Required: true,
-		})
-	}
-	for i, text := range facts.Optional {
-		c.Requirements = append(c.Requirements, Requirement{
-			ID: fmt.Sprintf("o%d", i+1), Kind: "behavior", Text: text,
-		})
-	}
+	add(facts.AcceptanceCriteria, "behavior", "r", true)
+	add(facts.Regressions, "regression", "g", true)
+	add(facts.Optional, "behavior", "o", false)
 	for _, command := range facts.Verifications {
 		c.AddCheck(command)
 	}

--- a/internal/taskcontract/taskcontract_test.go
+++ b/internal/taskcontract/taskcontract_test.go
@@ -142,8 +142,8 @@ func TestTrivialRejectsComplexContracts(t *testing.T) {
 
 func TestFromPlanBuildsContractFromPlannerOutput(t *testing.T) {
 	c := FromPlan("fix stale cache invalidation", PlanFacts{
-		AcceptanceCriteria: []string{"fix stale cache invalidation"},
-		Regressions:        []string{"existing cache tests continue passing"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "fix stale cache invalidation"}},
+		Regressions:        []PlanCriterion{{Text: "existing cache tests continue passing"}},
 		Verifications:      []string{"go test ./internal/cache/", ""},
 		Risky:              true,
 		Touchpoints:        []string{"cache.go", "invalidate.go"},
@@ -164,7 +164,7 @@ func TestFromPlanBuildsContractFromPlannerOutput(t *testing.T) {
 
 func TestExecutionViewIsAViewNotAParallelDescription(t *testing.T) {
 	c := FromPlan("fix it", PlanFacts{
-		AcceptanceCriteria: []string{"behavior fixed"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "behavior fixed"}},
 		Verifications:      []string{"go test ./..."},
 	})
 	todos := c.ExecutionView()
@@ -269,8 +269,8 @@ func TestFinalizeSignalFiresOnlyWhenFullyProven(t *testing.T) {
 	}
 
 	c = FromPlan("fix cache", PlanFacts{
-		AcceptanceCriteria: []string{"fix stale cache invalidation"},
-		Regressions:        []string{"cache tests keep passing"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "fix stale cache invalidation"}},
+		Regressions:        []PlanCriterion{{Text: "cache tests keep passing"}},
 		Verifications:      []string{"go test ./cache/"},
 	})
 	if s := c.FinalizeSignal(); s != "" {
@@ -299,8 +299,8 @@ func TestFinalizeSignalFiresOnlyWhenFullyProven(t *testing.T) {
 
 func TestFinalRejectionNamesExactlyWhatIsUnproven(t *testing.T) {
 	c := FromPlan("fix cache", PlanFacts{
-		AcceptanceCriteria: []string{"fix stale cache invalidation"},
-		Regressions:        []string{"cache tests keep passing"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "fix stale cache invalidation"}},
+		Regressions:        []PlanCriterion{{Text: "cache tests keep passing"}},
 		Verifications:      []string{"go test ./cache/"},
 	})
 	c.Observe(evidence.Receipt{ToolName: "edit_file", Mutation: true, Success: true})
@@ -342,7 +342,7 @@ func TestGoalVerdictDeterministicHotPath(t *testing.T) {
 	}
 
 	c := FromPlan("fix cache", PlanFacts{
-		AcceptanceCriteria: []string{"fix invalidation"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "fix invalidation"}},
 		Verifications:      []string{"go test ./cache/"},
 	})
 	if v := c.GoalVerdict(); v != VerdictContinue {
@@ -381,7 +381,7 @@ func TestGoalVerdictDeterministicHotPath(t *testing.T) {
 
 func TestGateMutationAfterGreen(t *testing.T) {
 	c := FromPlan("fix cache", PlanFacts{
-		AcceptanceCriteria: []string{"fix invalidation"},
+		AcceptanceCriteria: []PlanCriterion{{Text: "fix invalidation"}},
 		Verifications:      []string{"go test ./cache/"},
 	})
 	c.AddRequirement("opt1", "nice-to-have cleanup", false)

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -27,10 +28,11 @@ func init() { tool.RegisterBuiltin(completeStep{}) }
 type completeStep struct{}
 
 type stepEvidence struct {
-	Kind    string   `json:"kind"`
-	Summary string   `json:"summary"`
-	Command string   `json:"command,omitempty"`
-	Paths   []string `json:"paths,omitempty"`
+	Kind        string   `json:"kind"`
+	Summary     string   `json:"summary"`
+	Command     string   `json:"command,omitempty"`
+	Paths       []string `json:"paths,omitempty"`
+	CriterionID string   `json:"criterion_id,omitempty"`
 }
 
 // validEvidenceKinds are the evidence forms a completion may cite. "checkpoint"
@@ -46,7 +48,7 @@ var validEvidenceKinds = map[string]bool{
 func (completeStep) Name() string { return "complete_step" }
 
 func (completeStep) Description() string {
-	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`."
+	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), a completed built-in review that is fresh for any later changes, the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|review|diff|files|manual and a `summary`, plus optional `command`/`paths`, and `criterion_id` naming the acceptance criterion the proof satisfies), and optional `notes`."
 }
 
 func (completeStep) Schema() json.RawMessage {
@@ -64,6 +66,7 @@ func (completeStep) Schema() json.RawMessage {
     "items":{
       "type":"object",
       "properties":{
+        "criterion_id":{"type":"string","description":"The acceptance criterion this proof satisfies, as the plan renders it (e.g. \"c2\" from \"accept [c2]: ...\"). Cite it whenever the step has criteria: a command succeeding is not the same as a criterion being met, and the host records the proof against the criterion you name."},
         "kind":{"type":"string","enum":["verification","review","diff","files","manual"],"description":"verification = a command/test was run (command REQUIRED); review = a built-in review run completed and, after changes, inspected the latest changed result (the verdict/findings still apply separately); diff = a concrete code change (paths REQUIRED); files = files created/edited/inspected (paths REQUIRED); manual = a manual check."},
         "summary":{"type":"string","description":"The evidence itself: the test result, what the diff does, or what was confirmed."},
         "command":{"type":"string","description":"REQUIRED for verification evidence: the command as it actually ran (e.g. \"go test ./...\") — it is checked against this session's real command history."},
@@ -128,6 +131,9 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 			return "", fmt.Errorf("evidence %d: summary is required — the evidence is the summary, not just its kind", i+1)
 		}
 		kinds = append(kinds, e.Kind)
+	}
+	if err := verifyCitedCriteria(ctx, p.Evidence); err != nil {
+		return "", err
 	}
 
 	todoMatch, hasTodo, err := verifyTodoStep(ctx, step)
@@ -512,4 +518,23 @@ func extractCommandFromCall(name string, argsJSON string) string {
 		return name
 	}
 	return name + " " + args.Path
+}
+
+// verifyCitedCriteria rejects a proof citing a criterion the approved plan does
+// not have. Resolving an unknown id into nothing would leave the real criterion
+// unproven and only surface much later, as a completion the host refuses for a
+// reason the model never connected to this call.
+func verifyCitedCriteria(ctx context.Context, items []stepEvidence) error {
+	known, ok := evidence.AcceptanceCriteriaFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	for i, item := range items {
+		id := strings.TrimSpace(item.CriterionID)
+		if id == "" || slices.Contains(known, id) {
+			continue
+		}
+		return fmt.Errorf("evidence %d: criterion_id %q is not in the approved plan; cite one of: %s", i+1, id, strings.Join(known, ", "))
+	}
+	return nil
 }

--- a/internal/tool/builtin/criterion_citation_test.go
+++ b/internal/tool/builtin/criterion_citation_test.go
@@ -1,0 +1,56 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+func criterionCitationArgs(t *testing.T, criterionID string) json.RawMessage {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{
+		"step":   "fix it",
+		"result": "the race is gone",
+		"evidence": []map[string]any{
+			{"kind": "manual", "summary": "walked the retry path", "criterion_id": criterionID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return args
+}
+
+// A citation the plan does not contain would resolve into nothing and only
+// surface much later, as a completion refused for a reason the model never
+// connected to this call. Reject it here, with the ids it may cite.
+func TestCompleteStepRejectsAnUnknownCriterionCitation(t *testing.T) {
+	ctx := evidence.WithAcceptanceCriteria(context.Background(), []string{"c1", "c2"})
+	_, err := (completeStep{}).Execute(ctx, criterionCitationArgs(t, "c9"))
+	if err == nil {
+		t.Fatal("an unknown criterion_id must be rejected")
+	}
+	for _, want := range []string{"c9", "c1, c2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name %q", err, want)
+		}
+	}
+}
+
+func TestCompleteStepAcceptsAKnownCriterionCitation(t *testing.T) {
+	ctx := evidence.WithAcceptanceCriteria(context.Background(), []string{"c1", "c2"})
+	if _, err := (completeStep{}).Execute(ctx, criterionCitationArgs(t, "c2")); err != nil {
+		t.Fatalf("a criterion the plan contains must be accepted: %v", err)
+	}
+}
+
+// An unplanned turn carries no criteria, so citation checking must stand down
+// rather than reject every proof.
+func TestCompleteStepSkipsCitationCheckWithoutAPlan(t *testing.T) {
+	if _, err := (completeStep{}).Execute(context.Background(), criterionCitationArgs(t, "c1")); err != nil {
+		t.Fatalf("without an approved plan the citation must not be checked: %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #8193. The contract took its requirements from the plan in #8183,
but nothing could ever satisfy them.

## The contract could not go green

The only `Contract.Resolve` call in the tree resolves todo-derived ids
(`contract_shadow.go`), and `Observe` auto-satisfies only `Atomic`'s
requirement. Plan-derived ids — `r1`, `g1`, `o1` — had no path to Satisfied at
all, so a planned turn's criteria stayed Pending forever.

That is harmless while the contract only observes, and a hard break the moment
`FinalRejection` is wired: `Complete()` would never be true, so every final
answer would be refused, forever. This PR is the prerequisite that was missing,
not an optional refinement.

## A proof now names what it proves

`complete_step` evidence takes `criterion_id`. The tool already verifies each
proof against the ledger before succeeding, so what the citation adds is the
binding — *the command ran* and *the criterion holds* are different claims, and
only the model knows which proof was for which.

The host records it as an `EvidenceRef` at the current epoch, which is what makes
freshness work:

- a criterion proven by a test run goes **Stale** the moment code changes
  underneath it, and has to be re-proven
- mutation evidence does **not** stale — a change having happened is not
  something a later change undoes; whether the fix still holds is verification's
  job

Both are asserted directly.

## Identity had to stop being regenerated

Same defect as step ids, one layer up: `FromPlan` re-keyed the plan's criteria to
`r1`/`g1`/`o1`, so a proof citing `c2` could never match anything. `PlanFacts`
now carries `PlanCriterion{ID, Text}` and `FromPlan` uses the id the plan
assigned.

`Render` prints the id (`accept [c2]: ...`). Dropping it was my own omission in
the original plancontract PR — I called ids "for machines" and rendered only the
text. A criterion the executor cannot name is one it cannot satisfy.

## Failures are loud

A citation the plan does not contain is rejected in the tool, naming the ids it
may cite, rather than resolving into nothing and surfacing much later as a
refusal the model cannot connect back to this call. An unplanned turn carries no
criteria, so the check stands down instead of rejecting every proof.

## Known-red lint, not from this PR

`make lint` fails on this branch **and on `main-v2` itself**:
`desktop/frontend/src/App.tsx` is 8 lines over its repolint budget. It arrived
with #8103 (`8ea06aff2`), after #8183 merged. This branch does not touch
`App.tsx`, and the baseline was deliberately **not** updated here — laundering
another change's debt through this one is exactly what the ratchet exists to
prevent. `golangci-lint` reports 0 issues and every other repolint finding is
clean.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, `go test ./...` — 116 packages
ok, 0 failures. Eight new tests: an uncited passing command does not satisfy a
criterion, a cited one does and carries its proof, a verification-backed
criterion goes stale after a later mutation, mutation evidence does not, a bogus
citation satisfies nothing, the plan's ids reach the tool call, and the tool
accepts a known citation while rejecting an unknown one with the valid list.

Cache-impact: medium - complete_step's evidence items gain criterion_id, growing the tool schema 99 tokens (ToolSchemaTokens 14303 to 14402). SystemHash is unchanged and the prefix is byte-stable after the one-time change.
Cache-guard: internal/boot TestGoldenBaselineNoExtensions caught the drift; the golden was regenerated with REASONIX_UPDATE_GOLDEN=1 and the recorded delta is exactly the two tool hashes and the token count.
System-prompt-review: esengine - the only internal/boot change is the regenerated golden baseline (two tool hashes and the token count); no system prompt text is edited by this PR.
Documentation-impact: none - no user-facing surface changes. criterion_id is an optional additive field on an existing tool, the rendered plan gains an id label inside the planner's own output, and the docs describe neither.
