### PR TITLE
fix(plugin): fail closed when confined MCP loses its sandbox backend

### DIFF
--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -93,7 +93,11 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	var argv []string
 	if s.ResolvedProcessMode() == MCPProcessConfined {
 		processSandbox.MinimalWrites = true
-		argv, _ = sandbox.CommandArgs(processSandbox, launchArgs)
+		var err error
+		argv, err = wrapConfinedCommand(s.Name, processSandbox, launchArgs, sandbox.CommandArgs)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		argv = launchArgs
 	}
@@ -779,26 +783,4 @@ func (t *stdioTransport) close() {
 	}
 	proc.KillTracked(t.cmd, t.job)
 	waitWithBudget(t.wait, closeWaitBudget)
-}
-
-type tailBuffer struct {
-	mu    sync.Mutex
-	limit int
-	buf   []byte
-}
-
-func (b *tailBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.buf = append(b.buf, p...)
-	if b.limit > 0 && len(b.buf) > b.limit {
-		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
-	}
-	return len(p), nil
-}
-
-func (b *tailBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return strings.TrimSpace(string(b.buf))
 }

--- a/internal/plugin/transport_stdio_buf.go
+++ b/internal/plugin/transport_stdio_buf.go
@@ -1,0 +1,30 @@
+package plugin
+
+import (
+	"strings"
+	"sync"
+)
+
+// tailBuffer keeps the last limit bytes written, for truncating a process's
+// captured output to what teardown diagnostics actually need.
+type tailBuffer struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if b.limit > 0 && len(b.buf) > b.limit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.buf))
+}

--- a/internal/plugin/transport_stdio_confined.go
+++ b/internal/plugin/transport_stdio_confined.go
@@ -1,0 +1,18 @@
+package plugin
+
+import (
+	"fmt"
+
+	"reasonix/internal/sandbox"
+)
+
+// wrapConfinedCommand applies the OS command sandbox for a confined MCP
+// process and fails closed when the backend is unavailable: a confined
+// process must never run unsandboxed. commandArgs is injectable for tests.
+func wrapConfinedCommand(name string, spec sandbox.Spec, launchArgs []string, commandArgs func(sandbox.Spec, []string) ([]string, bool)) ([]string, error) {
+	argv, wrapped := commandArgs(spec, launchArgs)
+	if spec.Enforce() && !wrapped {
+		return nil, fmt.Errorf("stdio plugin %q: confined process requires an available sandbox backend", name)
+	}
+	return argv, nil
+}

--- a/internal/plugin/transport_stdio_confined_test.go
+++ b/internal/plugin/transport_stdio_confined_test.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+)
+
+// TestWrapConfinedCommandFailsClosedWhenBackendUnavailable pins the fail-closed
+// contract for confined MCP processes: when the mode is enforce and the OS
+// sandbox backend cannot wrap the command, launching must error instead of
+// silently degrading to an unsandboxed process.
+func TestWrapConfinedCommandFailsClosedWhenBackendUnavailable(t *testing.T) {
+	spec := sandbox.Spec{Mode: "enforce"}
+	_, err := wrapConfinedCommand("my-server", spec, []string{"node", "server.js"},
+		func(sandbox.Spec, []string) ([]string, bool) {
+			return []string{"node", "server.js"}, false
+		})
+	if err == nil {
+		t.Fatal("confined + enforce + wrapped=false must fail closed, got nil error")
+	}
+	if !strings.Contains(err.Error(), `"my-server"`) {
+		t.Fatalf("error must name the plugin, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "sandbox backend") {
+		t.Fatalf("error must explain the sandbox backend is unavailable, got %q", err)
+	}
+}
+
+// TestWrapConfinedCommandUsesWrappedArgv verifies a confined process with an
+// available backend runs the sandbox-wrapped argv.
+func TestWrapConfinedCommandUsesWrappedArgv(t *testing.T) {
+	spec := sandbox.Spec{Mode: "enforce"}
+	got, err := wrapConfinedCommand("my-server", spec, []string{"node", "server.js"},
+		func(sandbox.Spec, []string) ([]string, bool) {
+			return []string{"bwrap", "--ro-bind", "/", "/", "node", "server.js"}, true
+		})
+	if err != nil {
+		t.Fatalf("wrapped=true must succeed, got %v", err)
+	}
+	if len(got) != 6 || got[0] != "bwrap" {
+		t.Fatalf("argv = %v, want the sandbox-wrapped argv", got)
+	}
+}
+
+// TestWrapConfinedCommandAllowsUnwrappedWhenNotEnforced verifies a sandbox
+// spec that does not enforce (e.g. host mode) keeps the raw launch argv and
+// never fails closed — the product behavior for authorized user installs.
+func TestWrapConfinedCommandAllowsUnwrappedWhenNotEnforced(t *testing.T) {
+	spec := sandbox.Spec{Mode: "host"}
+	launchArgs := []string{"node", "server.js"}
+	got, err := wrapConfinedCommand("my-server", spec, launchArgs,
+		func(sandbox.Spec, []string) ([]string, bool) {
+			return []string{"node", "server.js"}, false
+		})
+	if err != nil {
+		t.Fatalf("non-enforce mode must not fail closed, got %v", err)
+	}
+	if got[0] != "node" {
+		t.Fatalf("argv = %v, want the unchanged launch argv", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Confined stdio MCP processes request an enforced OS sandbox.
- `sandbox.CommandArgs` reports whether wrapping succeeded, but the stdio transport discarded that result and silently launched the raw process when Seatbelt/bubblewrap was unavailable.
- Fail closed instead of degrading a confined process to unsandboxed execution.
- Host-mode MCP behavior remains unchanged.

## Issues

（无关联 issue；候选调研产出，confined 模式隔离契约修复）

## Verification

- 新增 3 个单测（`transport_stdio_confined_test.go`，注入假 `commandArgs`，不依赖本机是否有可用沙箱后端）：
  1. confined + enforce + unavailable backend → 返回错误（含插件名 + sandbox backend 语义）
  2. confined + enforce + available backend → 使用包装后的 argv
  3. 非 enforce sandbox（host）→ 保持原 launchArgs，行为不变
- `go test ./internal/plugin/ ./internal/sandbox/` 全绿；`go test ./internal/boot/` 全绿（`applyMCPIsolation` 调用方无破坏）
- `gofmt -l` 无输出；`go vet ./internal/plugin/ ./internal/sandbox/` 通过

## Documentation impact

Documentation-impact: none - 行为变化仅影响 confined 模式（内部托管部署/测试专用），普通用户默认 host 模式无变化，无用户文档需要更新。

## Cache impact

Cache-impact: none - 不触及 provider 请求、系统提示词或记忆前缀；confined 进程启动路径的行为变更不改变任何 provider 可见字节。
Cache-guard: go test ./internal/boot -run TestGoldenBaseline（前缀基线无漂移）+ go test ./internal/plugin -run TestWrapConfinedCommand（fail-closed 行为锁定）。