### PR TITLE
fix(agent): compare the context window against tokens, not characters

### DIFF
--- a/internal/agent/context_report.go
+++ b/internal/agent/context_report.go
@@ -47,10 +47,10 @@ func (a *Agent) ContextReport() ContextReport {
 	}
 	if a.session != nil {
 		canonical, _ := a.session.snapshotMessagesVersion()
-		rep.CanonicalTokens = estimateMessagesTokens(provider.ModelMessages(canonical))
+		rep.CanonicalTokens = a.estimatedPromptTokens(provider.ModelMessages(canonical))
 	}
 	visible := a.modelVisibleMessages()
-	rep.ProjectionTokens = estimateMessagesTokens(provider.ModelMessages(visible))
+	rep.ProjectionTokens = a.estimatedPromptTokens(provider.ModelMessages(visible))
 	rep.Projected = rep.ProjectionTokens != rep.CanonicalTokens
 
 	if a.contextWindow > 0 {

--- a/internal/agent/context_status.go
+++ b/internal/agent/context_status.go
@@ -45,7 +45,7 @@ func (a *Agent) ContextMaintenanceSnapshot() ContextMaintenanceSnapshot {
 	}
 	for _, msg := range visible {
 		if isCompactionSummary(msg) {
-			snapshot.SummaryTokens += estimateMessagesTokens([]provider.Message{msg})
+			snapshot.SummaryTokens += a.estimatedPromptTokens([]provider.Message{msg})
 		}
 	}
 	snapshot.Headroom = max(0, snapshot.HardInputCeiling-snapshot.ProjectedTokens)

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -200,54 +200,27 @@ func (a *Agent) calibratedPromptTokens(shape requestCalibrationShape) (int, bool
 	return 0, false
 }
 
-// estimatedPromptTokens sizes the final provider-visible messages for overflow
-// protection. Real same-session usage calibrates the estimate; before that,
-// CJK text gets a conservative second token per rune to cover the measured
-// tokenizer gap that can otherwise postpone compaction past the hard limit.
+// estimatedPromptTokens sizes the provider-visible messages in real tokens —
+// the only unit comparable against the context window. Same-session usage
+// calibrates it; before that the wire character count carries the ~4 chars per
+// token shape. estimateMessagesTokens counts characters and is for internal
+// planning budgets only; against the window it would compact 4x early.
 func (a *Agent) estimatedPromptTokens(msgs []provider.Message) int {
-	est := estimateMessagesTokens(provider.ModelMessages(msgs))
-	if est <= 0 {
-		return 0
-	}
-	if calibrated, ok := a.calibratedPromptTokens(a.requestCalibrationShape(provider.Request{Messages: msgs})); ok {
-		return calibrated
-	}
-	return est + cjkRunesInMessages(msgs)
+	return a.estimatedShapeTokens(a.requestCalibrationShape(provider.Request{Messages: msgs}))
 }
 
 func (a *Agent) estimatedRequestTokens(req provider.Request) int {
-	if calibrated, ok := a.calibratedPromptTokens(a.requestCalibrationShape(req)); ok {
+	return a.estimatedShapeTokens(a.requestCalibrationShape(req))
+}
+
+func (a *Agent) estimatedShapeTokens(shape requestCalibrationShape) int {
+	if shape.requestChars <= 0 {
+		return 0
+	}
+	if calibrated, ok := a.calibratedPromptTokens(shape); ok {
 		return calibrated
 	}
-	return a.estimatedPromptTokens(req.Messages) + estimateToolSchemaTokens(req.Tools)
-}
-
-func cjkRunesInMessages(msgs []provider.Message) int {
-	total := 0
-	for _, msg := range msgs {
-		if msg.LocalOnly {
-			continue
-		}
-		total += cjkRunesIn(msg.Content) + cjkRunesIn(msg.ReasoningContent)
-		total += cjkRunesIn(msg.Name) + cjkRunesIn(msg.ToolCallID)
-		for _, call := range msg.ToolCalls {
-			total += cjkRunesIn(call.ID) + cjkRunesIn(call.Name) + cjkRunesIn(call.Arguments)
-		}
-		for _, item := range msg.ResponsesItems {
-			total += cjkRunesIn(string(item))
-		}
-	}
-	return total
-}
-
-func cjkRunesIn(s string) int {
-	total := 0
-	for _, r := range s {
-		if isCJKRune(r) {
-			total++
-		}
-	}
-	return total
+	return int(float64(shape.requestChars) * fallbackTokPerChar)
 }
 
 func isCJKRune(r rune) bool {
@@ -255,17 +228,6 @@ func isCJKRune(r rune) bool {
 		(r >= 0x3400 && r <= 0x4DBF) ||
 		(r >= 0x3040 && r <= 0x30FF) ||
 		(r >= 0xAC00 && r <= 0xD7AF)
-}
-
-func estimateToolSchemaTokens(schemas []provider.ToolSchema) int {
-	total := 0
-	for _, schema := range schemas {
-		total += 8
-		total += estimateTextTokens(schema.Name)
-		total += estimateTextTokens(schema.Description)
-		total += estimateTextTokens(string(schema.Parameters))
-	}
-	return total
 }
 
 // effectiveOutputBudget returns an explicit smaller output budget only when a

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -182,19 +182,17 @@ func (a *Agent) calibratedPromptTokens(shape requestCalibrationShape) (int, bool
 		ratio := float64(cal.promptTokens) / float64(cal.requestChars)
 		if ratio > 0.05 && ratio < 2 {
 			trustedChars := shape.requestChars
-			excessCJKRunes := int64(0)
+			excessCJKBytes := int64(0)
 			// A higher CJK share cannot safely reuse the aggregate ratio. Scale its
-			// represented share and apply the cold two-token floor only to excess,
+			// represented share and price only the excess at the cold rate,
 			// preserving exact calibration for stable CJK sessions.
 			if shape.cjkRunes*cal.requestChars > cal.cjkRunes*shape.requestChars {
-				trustedCJKBytes := cal.cjkBytes * shape.requestChars / cal.requestChars
-				trustedCJKRunes := cal.cjkRunes * shape.requestChars / cal.requestChars
-				trustedCJKBytes = min(trustedCJKBytes, shape.cjkBytes)
-				trustedCJKRunes = min(trustedCJKRunes, shape.cjkRunes)
-				trustedChars -= shape.cjkBytes - trustedCJKBytes
-				excessCJKRunes = shape.cjkRunes - trustedCJKRunes
+				trustedCJKBytes := min(cal.cjkBytes*shape.requestChars/cal.requestChars, shape.cjkBytes)
+				excessCJKBytes = shape.cjkBytes - trustedCJKBytes
+				trustedChars -= excessCJKBytes
 			}
-			return int(math.Ceil(float64(trustedChars)*ratio)) + int(2*excessCJKRunes), true
+			cold := math.Ceil(float64(excessCJKBytes) * fallbackTokPerChar)
+			return int(math.Ceil(float64(trustedChars)*ratio) + cold), true
 		}
 	}
 	return 0, false

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -36,6 +36,32 @@ func (p *sharedWindowTestProvider) Stream(_ context.Context, req provider.Reques
 	return ch, nil
 }
 
+// Before any usage calibrates the session, the estimate compared against the
+// context window must still be tokens. It used to be characters, which reads
+// 3-4x high and compacted long before the configured ratio.
+func TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration(t *testing.T) {
+	a := &Agent{contextWindow: 1_000_000}
+	cases := []struct {
+		name           string
+		text           string
+		realish, upper int
+	}{
+		// DeepSeek bills Chinese near 0.6 tokens per han rune, English near 0.25
+		// per character. The cold estimate may be conservative, never 3x.
+		{"chinese", strings.Repeat("上下文压缩策略", 8_000), 33_600, 50_000},
+		{"english", strings.Repeat("compact the context window ", 8_000), 54_000, 70_000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := a.estimatedPromptTokens([]provider.Message{{Role: provider.RoleUser, Content: tc.text}})
+			if got < tc.realish/2 || got > tc.upper {
+				t.Fatalf("cold estimate = %d tokens, want between %d and %d (real ~%d)",
+					got, tc.realish/2, tc.upper, tc.realish)
+			}
+		})
+	}
+}
+
 func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
 	a := &Agent{
@@ -44,7 +70,9 @@ func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
 		sink:              event.Discard,
 	}
-	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 50_000)}}
+	// 200K han runes is ~150K cold-start tokens against a 100K window: the fold
+	// genuinely cannot ride one call, which is what the guard exists to catch.
+	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 200_000)}}
 
 	if _, err := a.foldToSummary(context.Background(), fold, ""); err != nil {
 		t.Fatalf("foldToSummary: %v", err)

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -152,14 +152,18 @@ func TestCalibratedOutputBudgetKeepsCJKConservativeFloor(t *testing.T) {
 		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
+	// Enough unrepresented CJK that the reply no longer fits beside it: at the
+	// corrected unit 430K runes leave most of a 1M window free.
 	current := append(append([]provider.Message(nil), previous...), provider.Message{
 		Role:             provider.RoleAssistant,
-		ReasoningContent: strings.Repeat("字", 430_000),
+		ReasoningContent: strings.Repeat("字", 1_200_000),
 		ToolCalls:        []provider.ToolCall{{ID: "call_1", Name: "bash", Arguments: `{}`}},
 	})
 
+	// The unrepresented CJK runes are priced at the cold rate: 3 bytes each at
+	// ~4 chars per token, i.e. 0.75 tokens per rune against a real ~0.6.
 	calibrated := a.estimatedPromptTokens(current)
-	wantFloor := 75_000 + 2*430_000
+	wantFloor := 75_000 + 1_200_000*3/4
 	if calibrated < wantFloor {
 		t.Fatalf("calibrated estimate %d fell below mixed-script safety floor %d", calibrated, wantFloor)
 	}


### PR DESCRIPTION
## The unit bug

`estimateTextTokens` is `max(runes, bytes/4)`. `runes > bytes/4` holds for every string, so the function always returns the rune count — one "token" per character. That is fine for the internal planning budgets it was written for (tail size, fold economics), but `estimatedPromptTokens` carried it into the comparison against `contextWindow` whenever the session had no usage calibration yet, and added a second token per CJK rune on top of it.

Measured on `main-v2`:

| sample | est | real (DeepSeek) | ratio |
|---|---|---|---|
| Chinese | 10204 | ~3060 | **3.33x** |
| zh + code | 28404 | ~8520 | **3.33x** |
| English | 18804 | ~5640 | **3.33x** |

A context 25% full measures as full, so the turn force-compacts.

## Why it looks random to users

Calibration fixes the estimate for a warm session and leaves it in place for a cold one — after resume, tab switch, fork, rewind, or against a relay that reports no usage. The same session therefore compacts at 25% or at 80% depending on when the question is asked, off one threshold. That is the "it compacts for no reason" in #8132 / #8116 (and matches the 28% figure measured in #7939, whose own root cause was fixed separately).

`/context` and the maintenance snapshot read `estimateMessagesTokens` directly, so the number shown to the user was the character count too — part of what #8191 reports as display and decision disagreeing.

## The fix

- Cold estimate = wire characters × `fallbackTokPerChar` (0.25), the ratio already documented in the same file. CJK lands at 0.75 tokens per rune against a real ~0.6, so it stays conservative without being 3x.
- `/context` (`context_report.go`) and `ContextMaintenanceSnapshot` now use `estimatedPromptTokens`, so the displayed number is the one the decision used.
- Dead after the change: `cjkRunesInMessages`, `cjkRunesIn`, `estimateToolSchemaTokens` (tool schemas are already counted by `requestCalibrationShape`).
- `estimateMessagesTokens` keeps the character unit for internal planning and now says so.

## Test change worth reviewing

`TestSharedWindowFoldUsesGuardedInputBudget` fed 50K han runes against a 100K window and asserted the summarizer input got bounded. At the corrected unit those 50K runes are ~37.5K tokens and genuinely fit, so the assertion would have passed on nothing. The input is now 200K runes (~150K tokens), which does exceed the budget — the guard is still being tested, against a case that actually needs it.

## Verification

- `TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration` pins the cold estimate for Chinese and English inside a token-unit band.
- `go test ./internal/agent/ ./internal/cli/ ./internal/control/ ./internal/boot/ ./internal/serve/ ./internal/tool/builtin/` green.
- `make lint` clean for this diff (`desktop/frontend/src/App.tsx` is a pre-existing violation on `main-v2`).

Independent of #8199 (threshold collapse); they fix two different reasons for the same symptom and do not touch the same functions.

Cache-impact: none - the provider-visible prefix bytes are unchanged. The estimate only decides when maintenance runs, and it now runs later, so cache resets become less frequent.
Cache-guard: TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration pins the cold-start unit; the existing calibration suite (TestCalibratedOutputBudget*) pins the warm path unchanged.
Documentation-impact: none - restores the documented meaning of context_window and compact_ratio rather than changing either.