### PR TITLE
fix(agent): keep the prompt-token calibration across a session swap

### DIFF
--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -37,10 +37,14 @@ type requestCalibrationShape struct {
 	cjkBytes     int64
 }
 
+// resetOutputBudgetState drops what belongs to the transcript being replaced.
+// The prompt-token calibration is a property of the model's tokenizer, and a
+// model switch rebuilds the agent, so it outlives the swap: dropping it sent
+// every rebind — resume, tab switch, recovery adopt — back to the cold
+// estimate for a turn.
 func (a *Agent) resetOutputBudgetState() {
 	a.lastUsage.Store(nil)
 	a.activeReqShape.Store(nil)
-	a.promptCalibration.Store(nil)
 }
 
 func (a *Agent) setPromptTokenCalibration(promptTokens int, shape requestCalibrationShape) {

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -62,6 +62,26 @@ func TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration(t *testing.T) {
 	}
 }
 
+// Desktop rebinds sessions constantly — tab switches, forks, and the snapshot
+// conflict path that adopts the newer disk transcript. Each rebind used to drop
+// the calibration and put the next turn back on the cold estimate.
+func TestSessionSwapKeepsPromptCalibration(t *testing.T) {
+	a := &Agent{contextWindow: 200_000}
+	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 60_000)}}
+	a.setPromptTokenCalibration(36_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
+
+	before := a.estimatedPromptTokens(msgs)
+	a.SetSession(NewSession("system"))
+	after := a.estimatedPromptTokens(msgs)
+
+	if before != after {
+		t.Fatalf("estimate moved across a session swap: %d -> %d", before, after)
+	}
+	if after > 40_000 {
+		t.Fatalf("estimate = %d, want the calibrated ~36000 rather than a cold fallback", after)
+	}
+}
+
 func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
 	a := &Agent{
@@ -360,7 +380,7 @@ func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 	}
 }
 
-func TestSetSessionResetsTokenCalibration(t *testing.T) {
+func TestSetSessionResetsPerTranscriptUsageState(t *testing.T) {
 	a := &Agent{}
 	a.lastUsage.Store(&provider.Usage{PromptTokens: 200_000})
 	active := requestCalibrationShape{requestChars: 900_000, compactChars: 850_000}
@@ -374,8 +394,8 @@ func TestSetSessionResetsTokenCalibration(t *testing.T) {
 	if got := a.activeReqShape.Load(); got != nil {
 		t.Fatalf("activeReqShape survived session switch: %+v", got)
 	}
-	if got := a.promptCalibration.Load(); got != nil {
-		t.Fatalf("promptCalibration survived session switch: %+v", got)
+	if got := a.promptCalibration.Load(); got == nil {
+		t.Fatal("promptCalibration was dropped on session switch; the tokenizer ratio outlives the transcript")
 	}
 }
 


### PR DESCRIPTION
## Why the estimate keeps going cold

`promptCalibration` holds the ratio between wire characters and the tokens the provider actually billed. That is a property of the model's tokenizer, not of the transcript. `SetSession` dropped it anyway (`resetOutputBudgetState`).

Desktop rebinds sessions constantly: tab switches, forks, rewinds, and `adoptDiskSession` on the snapshot-conflict path. A session held by two windows can hit that path hundreds of times a day — #8190 counted 233 recovery branches for one session, 230 of them on a single day. Every rebind put the next turn back on the cold estimate, which is the least accurate reading available and the one most likely to cross a threshold the calibrated view was nowhere near.

## Why it is safe to keep

- A model switch rebuilds the controller and with it the agent (`serve.switchModelLocked` → `boot.Build`), so no ratio survives across tokenizers.
- Per-transcript observations still reset: `lastUsage` and `activeReqShape`.
- A session whose script composition shifts after calibration is still covered by the CJK floor in `calibratedPromptTokens`.

## Test change worth reviewing

`TestSetSessionResetsTokenCalibration` asserted the drop this PR removes. It is now `TestSetSessionResetsPerTranscriptUsageState` and asserts what does have to go (`lastUsage`, `activeReqShape`) plus what must survive. `TestSessionSwapKeepsPromptCalibration` covers the new behavior directly.

## Verification

- `go test ./internal/agent/` green.
- `gofmt`/`go vet` clean.

Stacks conceptually on #8205 (token unit) but does not touch the same lines; both are independent of #8199. Note for review order: with #8205 merged, the cold fallback is a reasonable estimate rather than a 3-4x overshoot, so this PR's benefit narrows to CJK sessions (where the cold path still reads ~25% high) — it is worth keeping, but it is the least urgent of the three.

Cache-impact: none - no change to prompt bytes or to any prefix input; only which estimate the maintenance decision reads after a session rebind.
Cache-guard: TestSessionSwapKeepsPromptCalibration pins the surviving calibration; TestSetSessionResetsPerTranscriptUsageState pins what still resets.
Documentation-impact: none - internal estimator state with no documented surface.