### PR TITLE
refactor(agent): one compaction trigger, and stop rewriting history below it

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -68,7 +68,7 @@ reasoning_language = "auto"      # visible reasoning text: auto|zh|en
 # max_subagent_depth = 2              # nested delegation depth; set 1 for the old single-layer boundary
 # max_subagent_concurrency = 6        # session-wide sub-agent concurrency (task/fleet/skills)
 # max_parallel_writers = 3            # concurrent writers with non-overlapping write_paths
-tool_result_snip_ratio = 0.6       # shorten stale tool output before summary compaction
+tool_result_snip_ratio = 0.6       # at compact_ratio, pruning stale tool output replaces the summary if it gets under this
 # context_editing = "native"       # opt in only for the official Anthropic endpoint; default local
 
 [[providers]]

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -62,7 +62,7 @@ reasoning_language = "auto"      # 可见思考过程语言：auto|zh|en
 # max_subagent_depth = 2              # 子代理嵌套委派深度；设为 1 可恢复旧的单层边界
 # max_subagent_concurrency = 6        # 会话级子代理总并发（task/fleet/skills）
 # max_parallel_writers = 3            # 互不重叠 write_paths 时的并行写入上限
-tool_result_snip_ratio = 0.6       # 在摘要 compaction 前先缩短旧工具输出
+tool_result_snip_ratio = 0.6       # 到达 compact_ratio 时，修剪旧工具输出若能降到此值以下则免去摘要
 # context_editing = "native"       # 仅官方 Anthropic 端点显式启用；默认 local
 
 [[providers]]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -253,15 +253,16 @@ prefix cache-stable:
 Long tasks eventually fill the model's context window. Reasonix manages this with
 **low-frequency compaction** that respects the cache-first design:
 
-- Each provider declares its `context_window` (tokens). Context maintenance is
-  tiered: below `agent.tool_result_snip_ratio` (default `0.6`) the session is
-  left untouched apart from the soft notice; at the snip ratio, stale tool
-  results before the recent tail are archived and shortened with deterministic
-  head/tail markers; at `agent.compact_ratio` (default `0.8`) stale tool results
-  are archived and pruned to short placeholders before any summary call; only if
-  pruning still leaves the prompt above the threshold does summary compaction
-  run. At `agent.compact_force_ratio` (default `0.9`), the existing forced fold
-  may proceed even when the fold economics would normally skip it.
+- Each provider declares its `context_window` (tokens). There is one trigger:
+  `agent.compact_ratio` (default `0.8`). Below it the history is never
+  rewritten, because a rewrite invalidates the provider's prompt cache from that
+  point on; `agent.soft_compact_ratio` (default `0.5`) only emits a notice. At
+  the trigger, stale tool results before the recent tail are archived and pruned
+  to short placeholders first; if that alone brings the prompt below
+  `agent.tool_result_snip_ratio` (default `0.6`) it stands in for the summary and
+  no summarizer call is made, otherwise summary compaction runs. At
+  `agent.compact_force_ratio` (default `0.9`), the forced fold may proceed even
+  when the fold economics would normally skip it.
 - Users can inspect or change the 65–85% automatic threshold with
   `reasonix config compact-ratio [--local] [VALUE]`. The default is 80%; the
   project-local value overrides the shared user config used by desktop and new

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -144,9 +144,11 @@ type Tool interface {
 
 Reasonix 通过低频 compaction 保持 cache-first：
 
-- 低于 `agent.tool_result_snip_ratio` 时不改写历史；
-- 达到 snip ratio 后，归档并缩短较旧 tool result；
-- 达到 `agent.compact_ratio` 后，先把旧 tool result 修剪为占位符，仍超阈值才调用摘要；
+- 低于 `agent.compact_ratio` 时绝不改写历史：任何改写都会让该处之后的 prompt
+  缓存整体失效；`agent.soft_compact_ratio` 只发提示，不参与决策；
+- 达到 `agent.compact_ratio` 后，先归档并把旧 tool result 修剪为占位符；若仅此
+  就降到 `agent.tool_result_snip_ratio` 以下，则以它替代摘要，不调用摘要模型，
+  否则再执行摘要 compaction；
 - 达到 `agent.compact_force_ratio` 后，可执行强制折叠；
 - `context_window = 0` 会关闭该实例的 compaction。
 

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -90,9 +90,10 @@ What is still in progress or unstarted, and the single most concrete next action
 Rules: be terse — bullet points and fragments, not prose. Preserve identifiers, paths, and numbers exactly. Do NOT invent anything not present in the messages; if something is unknown, leave it out rather than guessing.`
 
 // compactThresholds returns the prompt-token boundaries ContextManager switches
-// on. The compaction ablation arm collapses the snip and fold triggers onto
-// soft, so the cache-preserving deferral branch is unreachable and the session
-// folds as soon as it grows — what a harness with no prompt-cache strategy does.
+// on. Only high triggers maintenance: soft is a notice, and snip is how far a
+// tool-result pass must bring the prompt down to stand in for the summary. The
+// compaction ablation arm folds at soft instead, which is what a harness with
+// no prompt-cache strategy does.
 func (a *Agent) compactThresholds() (soft, snip, high int) {
 	hard := a.hardInputCeiling()
 	high = int(float64(a.contextWindow) * a.compactRatio)

--- a/internal/agent/context_maintenance_issue7935_test.go
+++ b/internal/agent/context_maintenance_issue7935_test.go
@@ -37,19 +37,26 @@ func TestIssue7935Maintains206ToolResultsOnceAndOnlyProcessesNewTail(t *testing.
 		ArchiveDir:    t.TempDir(),
 	}, sink)
 
-	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
+	// Below the fold trigger nothing may be rewritten: a prefix change voids the
+	// prompt cache from that point on, so it waits for the reset it comes with.
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 700})
+	if got := a.currentProjectionVersion(); got != 0 {
+		t.Fatalf("history was rewritten below the fold trigger: projection version %d", got)
+	}
+
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 850})
 	firstVersion := a.currentProjectionVersion()
 	if firstVersion == 0 {
 		t.Fatal("first maintenance did not install a projection")
 	}
-	if got := countToolResultsWithPrefix(a.modelVisibleMessages(), snippedMarker); got != staleResults {
-		t.Fatalf("first maintenance snipped %d results, want %d", got, staleResults)
+	if got := countToolResultsWithPrefix(a.modelVisibleMessages(), prunedMarker); got != staleResults {
+		t.Fatalf("first maintenance elided %d results, want %d", got, staleResults)
 	}
 	status := a.ContextMaintenanceSnapshot()
 	if status.ProjectedTokens <= 0 || status.CanonicalTokens <= status.ProjectedTokens {
 		t.Fatalf("maintenance snapshot canonical/projected = %d/%d", status.CanonicalTokens, status.ProjectedTokens)
 	}
-	if status.LastReceipt == nil || status.LastReceipt.Action != "snip" || status.LastReceipt.AffectedToolResults != staleResults {
+	if status.LastReceipt == nil || status.LastReceipt.Action != "prune" || status.LastReceipt.AffectedToolResults != staleResults {
 		t.Fatalf("maintenance snapshot receipt = %+v", status.LastReceipt)
 	}
 	for i, msg := range sess.Snapshot() {
@@ -58,26 +65,24 @@ func TestIssue7935Maintains206ToolResultsOnceAndOnlyProcessesNewTail(t *testing.
 		}
 	}
 
-	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
-	if got := a.currentProjectionVersion(); got != firstVersion {
-		t.Fatalf("unchanged visible view was maintained again: version %d -> %d", firstVersion, got)
-	}
-
+	// Already-elided results give the next pass nothing to do; only the new tail
+	// is maintained, and the applied-notification count below proves the earlier
+	// 206 are not rewritten a second time.
 	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "new", Name: "read_file", Arguments: "{}"}}})
 	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "new", Name: "read_file", Content: big})
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "move new result out of the protected tail"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "ok"})
-	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 850})
 	if got := a.currentProjectionVersion(); got != firstVersion+1 {
 		t.Fatalf("new tail maintenance version = %d, want %d", got, firstVersion+1)
 	}
-	if got := countToolResultsWithPrefix(a.modelVisibleMessages(), snippedMarker); got != staleResults+1 {
+	if got := countToolResultsWithPrefix(a.modelVisibleMessages(), prunedMarker); got != staleResults+1 {
 		t.Fatalf("maintained visible results = %d, want %d", got, staleResults+1)
 	}
 
 	var applied int
 	for _, got := range sink.kinds(event.ContextMaintenanceEvent) {
-		if got.Maintenance != nil && got.Maintenance.Status == "applied" && got.Maintenance.Action == "snip" {
+		if got.Maintenance != nil && got.Maintenance.Status == "applied" && got.Maintenance.Action == "prune" {
 			applied++
 		}
 	}

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -104,38 +104,44 @@ func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePo
 	if a.compactStuck && policy.Trigger == CompactionTriggerPressure {
 		return prepared, false, nil
 	}
-	if est >= soft && est < snip && !a.softCompactNoticed {
+	if soft > 0 && est >= soft && est < fold && !a.softCompactNoticed {
 		a.softCompactNoticed = true
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 			Text:   "Context is getting large; preserving cache until cleanup is needed.",
 			Detail: fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)})
 	}
-	if est < snip && !policy.Force && policy.Trigger != CompactionTriggerManual && policy.Trigger != CompactionTriggerOverflow {
+
+	// One trigger. Rewriting stale tool results invalidates the prompt prefix
+	// from the rewrite point on, and a cache miss costs 50x a hit, so it only
+	// pays at the fold point — where the prefix is being reset anyway.
+	forceFold := policy.Force || policy.Trigger == CompactionTriggerManual || policy.Trigger == CompactionTriggerOverflow || est >= force
+	if est < fold && !forceFold {
 		return prepared, false, nil
 	}
 
 	// Native Anthropic tool clearing replaces only local snip/prune. Full-fold
 	// summary remains the hard/manual convergence path.
-	forceFold := policy.Force || policy.Trigger == CompactionTriggerManual || policy.Trigger == CompactionTriggerOverflow || est >= force
-	if maintained, handled, retry, err := m.tryToolMaintenance(visible, prepared, policy, est, fold, forceFold, inputHash); handled {
+	if maintained, handled, retry, err := m.tryToolMaintenance(visible, prepared, policy, est, snip, forceFold, inputHash); handled {
 		return maintained, retry, err
-	}
-	if est < fold && !forceFold {
-		return prepared, false, nil
 	}
 	return m.foldContext(ctx, prepared, policy, inputHash, est, fold, force, forceFold)
 }
 
-func (m ContextManager) tryToolMaintenance(visible []provider.Message, prepared PreparedContext, policy ContextPreparePolicy, est, fold int, forceFold bool, inputHash string) (PreparedContext, bool, bool, error) {
+// tryToolMaintenance is the first step of a fold, not a trigger of its own:
+// dropping stale tool results is cheap and sometimes enough, which saves the
+// summarizer round trip. sufficient is how far down the result must land to
+// stand in for the summary; anything above it falls through to the fold.
+func (m ContextManager) tryToolMaintenance(visible []provider.Message, prepared PreparedContext, policy ContextPreparePolicy, est, sufficient int, forceFold bool, inputHash string) (PreparedContext, bool, bool, error) {
 	a := m.agent
 	if a.effectiveContextEditing() == "native" {
 		return PreparedContext{}, false, false, nil
 	}
-	mode := toolResultSnip
-	if est >= fold || forceFold {
-		mode = toolResultPrune
+	if forceFold || policy.Trigger == CompactionTriggerManual {
+		return PreparedContext{}, false, false, nil
 	}
-	maintained, stats := a.applyToolResultMaintenanceView(visible, mode)
+	// Elide in one pass rather than shortening now and eliding next turn: each
+	// rewrite costs a prefix, so a two-step escalation pays it twice.
+	maintained, stats := a.applyToolResultMaintenanceView(visible, toolResultPrune)
 	if stats.Results == 0 {
 		return PreparedContext{}, false, false, nil
 	}
@@ -143,9 +149,7 @@ func (m ContextManager) tryToolMaintenance(visible []provider.Message, prepared 
 	if policy.ObservedInputTokens > 0 {
 		maintainedTokens = max(0, est-int(float64(stats.SavedChars)*a.tokPerChar()))
 	}
-	// An over-trigger result is only an intermediate plan; summary installs the
-	// sole prefix switch for this transaction.
-	if maintainedTokens >= fold || forceFold || policy.Trigger == CompactionTriggerManual {
+	if maintainedTokens >= sufficient {
 		return PreparedContext{}, false, false, nil
 	}
 	before := a.currentProjectionVersion()

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -228,7 +228,10 @@ func TestMaybeCompactPruneAvoidsFold(t *testing.T) {
 	}
 }
 
-func TestMaybeCompactSnipsAtSnipRatioWithoutFold(t *testing.T) {
+// Rewriting a stale tool result invalidates the prompt prefix from that point
+// on, so below the fold trigger history is left exactly as the provider cached
+// it, however large it has grown.
+func TestMaintenanceLeavesHistoryAloneBelowFoldTrigger(t *testing.T) {
 	prov := &fakeProvider{reply: "summary"}
 	sess := pruneFixture(strings.Repeat("line\n", 1000))
 	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
@@ -236,30 +239,52 @@ func TestMaybeCompactSnipsAtSnipRatioWithoutFold(t *testing.T) {
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
 
 	if prov.got != nil {
-		t.Fatal("summarizer was called at snip ratio")
+		t.Fatal("summarizer was called below the fold trigger")
+	}
+	if got := a.currentProjectionVersion(); got != 0 {
+		t.Fatalf("projection installed below the fold trigger: version %d", got)
+	}
+	for _, m := range visibleContext(a) {
+		if m.Role == provider.RoleTool && (strings.HasPrefix(m.Content, snippedMarker) || strings.HasPrefix(m.Content, prunedMarker)) {
+			t.Fatalf("tool result rewritten below the fold trigger: %.80q", m.Content)
+		}
+	}
+}
+
+// At the fold trigger, dropping stale tool results comes first: when that gets
+// the prompt low enough it stands in for the summary, saving the round trip for
+// the same single prefix switch.
+func TestMaintenancePrefersPruneOverSummaryAtFoldTrigger(t *testing.T) {
+	prov := &fakeProvider{reply: "summary"}
+	sess := pruneFixture(strings.Repeat("line\n", 1000))
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 850})
+
+	if prov.got != nil {
+		t.Fatal("summarizer was called although pruning was enough")
 	}
 	if got := sess.Snapshot()[3].Content; !strings.HasPrefix(got, "line") {
-		t.Errorf("canonical tool result rewritten at snip ratio: %.80q", got)
+		t.Errorf("canonical tool result rewritten: %.80q", got)
 	}
-	proj := visibleContext(a)
 	found := false
-	for _, m := range proj {
-		if m.Role == provider.RoleTool && strings.HasPrefix(m.Content, snippedMarker) {
+	for _, m := range visibleContext(a) {
+		if m.Role == provider.RoleTool && strings.HasPrefix(m.Content, prunedMarker) {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("tool result not snipped in projection: %+v", proj)
+		t.Errorf("tool result not elided in projection: %+v", visibleContext(a))
 	}
 }
 
 func TestProjectionMaintenanceContinuesFromVisibleView(t *testing.T) {
 	sess := pruneFixture(strings.Repeat("line\n", 1000))
 	a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
+	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 850})
 	first := a.compactionState.Projection.ProjectionVersion
-	if first == 0 || !strings.HasPrefix(visibleContext(a)[3].Content, snippedMarker) {
-		t.Fatalf("first maintenance did not install a snipped projection: %+v", visibleContext(a))
+	if first == 0 || !strings.HasPrefix(visibleContext(a)[3].Content, prunedMarker) {
+		t.Fatalf("first maintenance did not install an elided projection: %+v", visibleContext(a))
 	}
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 650})
 	if got := a.compactionState.Projection.ProjectionVersion; got != first {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -228,7 +228,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("# reasoning_language = \"zh\"   # visible reasoning language: auto|zh|en\n")
 	}
 	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
-	fmt.Fprintf(&b, "tool_result_snip_ratio = %s   # snip stale tool results at this fraction before summary compaction\n", formatFloat(c.Agent.ToolResultSnipRatio))
+	fmt.Fprintf(&b, "tool_result_snip_ratio = %s   # at compact_ratio, dropping stale tool results replaces the summary if it gets under this\n", formatFloat(c.Agent.ToolResultSnipRatio))
 	fmt.Fprintf(&b, "compact_ratio       = %s   # try compacting when prompt reaches this fraction\n", formatFloat(c.Agent.CompactRatio))
 	fmt.Fprintf(&b, "compact_force_ratio = %s   # force compacting at this high-water mark\n", formatFloat(c.Agent.CompactForceRatio))
 	if strings.TrimSpace(c.Agent.ContextEditing) == "native" {


### PR DESCRIPTION
## The cost of the second trigger

Tool-result maintenance had a trigger of its own at `tool_result_snip_ratio` (0.6), below the fold. Every pass rewrites messages in the middle of the prompt, which invalidates the provider's cache from the rewrite point on. DeepSeek bills a miss at **50x** a hit (`CacheHit 0.0028` vs `Input 0.14` per M, `internal/config/pricing.go`), so a pass that drops 20% of a 100K prompt turns 95K cached tokens into 75K uncached ones — fewer tokens, roughly ten times the money.

#8109 made a pass idempotent per view, which stops the same results being rewritten twice. It does not stop a *new* result going stale every turn, and in a coding session one usually does. The steady state was a cache reset per turn — what #8118 and #8132 report, and the opposite of what the cache-first design exists for.

## What changes

Maintenance runs only at `compact_ratio`, where the prefix is being reset anyway. It still runs *first*, because eliding stale tool results is cheap and often enough on its own — `tool_result_snip_ratio` keeps its name and default but now says how far down that pass must land to stand in for the summary. One prefix switch per fold either way. `soft_compact_ratio` no longer gates anything; it emits its notice and nothing else.

Below the trigger the transcript is now byte-identical to what the provider cached, however large it grows.

## Measured on the real API

Same task (read 8 files one by one and report), same model (deepseek-v4-flash, official endpoint), `context_window = 30000` so the session sits between the old snip ratio and the fold. Both builds also carry #8199/#8205/#8207, without which the thresholds collapse and neither arm is meaningful.

| build | prompt | cache hit | cache miss | hit rate | steps | folds | cost |
|---|---:|---:|---:|---:|---:|---:|---:|
| three tiers (0.6 snip) | 77057 | 48000 | 29057 | 62.3% | 5 | 1 | ¥0.0375 |
| single trigger | 94865 | 80256 | 14609 | 84.6% | 6 | 1 | ¥0.0274 |

23% more prompt carried, **half the cache misses**, and 27% cheaper. Both runs completed the task.

## Tests

- `TestMaintenanceLeavesHistoryAloneBelowFoldTrigger` — nothing is rewritten below the trigger, no summarizer call, no projection.
- `TestMaintenancePrefersPruneOverSummaryAtFoldTrigger` — at the trigger, pruning alone is preferred and the summarizer is not called when it suffices.
- `TestIssue7935…` keeps its subject (206 results maintained once, only the new tail afterwards) and gains an explicit below-trigger assertion. Its "same view twice" step is gone: under one trigger that case falls through to the summary, which belongs to the fold tests, and the applied-notification count already proves the 206 are not rewritten again.
- `go test ./internal/agent/ ./internal/cli/ ./internal/control/ ./internal/boot/ ./internal/config/ ./internal/tool/builtin/` green; `make lint` clean.

Cache-impact: high - this is a cache change by intent. The prefix bytes for a given view are unchanged; what changes is how often the prefix is invalidated at all, and it strictly decreases. Measured above: 62.3% -> 84.6% hit rate on the same task.
Cache-guard: TestMaintenanceLeavesHistoryAloneBelowFoldTrigger pins the no-rewrite-below-trigger rule that the hit rate depends on; TestMaintenancePrefersPruneOverSummaryAtFoldTrigger pins that the one allowed switch still prefers the cheap pass.
Documentation-impact: updated - docs/SPEC.md, docs/SPEC.zh-CN.md, docs/GUIDE.md and docs/GUIDE.zh-CN.md now describe one trigger and tool_result_snip_ratio's new role.