### PR TITLE
fix(cli): a failed run must say why, including under -p

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -783,15 +783,7 @@ func runAgent(args []string, version string) int {
 		}
 	}
 	if runErr != nil {
-		if !completion.isError {
-			if format == runOutputText {
-				fmt.Fprintln(os.Stderr, "\n"+runErr.Error())
-			}
-			return completion.exitCode
-		}
-		if resultOutput == nil {
-			fmt.Fprintln(os.Stderr, "\n"+i18n.M.ErrorPrefix, runErr)
-		}
+		reportRunFailure(os.Stderr, format, resultOutput != nil, completion, runErr)
 		return completion.exitCode
 	}
 	return completion.exitCode

--- a/internal/cli/run_completion.go
+++ b/internal/cli/run_completion.go
@@ -3,10 +3,36 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/i18n"
 )
+
+// reportRunFailure states why a run ended without a result. Text output — which
+// -p/--print also selects — has nowhere else to carry that: its sink prints the
+// final response and nothing else, so a failed run exited 1 with an empty
+// stderr and a half-finished answer. Structured formats encode the failure in
+// their own payload and need this only when no such sink was built.
+func reportRunFailure(w io.Writer, format runOutputFormat, structured bool, completion runCompletion, runErr error) {
+	if runErr == nil {
+		return
+	}
+	switch {
+	case format != runOutputText:
+		if !structured {
+			fmt.Fprintln(w, "\n"+i18n.M.ErrorPrefix, runErr)
+		}
+	case completion.isError:
+		fmt.Fprintln(w, "\n"+i18n.M.ErrorPrefix, runErr)
+	default:
+		// A paused run is a reportable outcome, not a failure, and reads better
+		// without the error prefix.
+		fmt.Fprintln(w, "\n"+runErr.Error())
+	}
+}
 
 type runCompletion struct {
 	outcome string

--- a/internal/cli/run_failure_report_test.go
+++ b/internal/cli/run_failure_report_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A failed run must say why. -p/--print builds a result sink, and text output
+// carries only the final response, so the failure had no path to the user at
+// all: exit 1, empty stderr.
+func TestReportRunFailureAlwaysExplainsTextRuns(t *testing.T) {
+	runErr := errors.New("context maintenance is blocked for the current view")
+	cases := []struct {
+		name       string
+		format     runOutputFormat
+		structured bool
+		want       string
+	}{
+		{"print mode builds a sink", runOutputText, true, "context maintenance is blocked"},
+		{"plain text without a sink", runOutputText, false, "context maintenance is blocked"},
+		{"json carries it in the payload", runOutputJSON, true, ""},
+		{"json without a sink still reports", runOutputJSON, false, "context maintenance is blocked"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out strings.Builder
+			reportRunFailure(&out, tc.format, tc.structured, classifyRunCompletion(runErr), runErr)
+			if tc.want == "" {
+				if out.Len() != 0 {
+					t.Fatalf("wrote %q, want the structured payload to carry it alone", out.String())
+				}
+				return
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("wrote %q, want it to contain %q", out.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestReportRunFailureStaysSilentOnSuccess(t *testing.T) {
+	var out strings.Builder
+	reportRunFailure(&out, runOutputText, true, classifyRunCompletion(nil), nil)
+	if out.Len() != 0 {
+		t.Fatalf("successful run wrote %q", out.String())
+	}
+}


### PR DESCRIPTION
## Exit 1, empty stderr

`run` reported nothing at all when a turn failed under text output. `-p/--print` selects text *and* builds a result sink, `runOutputSink.Finalize`'s text branch prints the final response and nothing else, and the stderr fallback in `cli.go` was gated on `resultOutput == nil` — so with a sink present the error had no path out. Structured formats were unaffected; they encode the failure in their own payload.

Compaction failures are where this bites: the run stops mid-task, the user sees a truncated answer and no reason, and the report reads as "it just stops" (#8148, #8176).

## Before / after, real API

Same task and config both times (three 46KB files, `context_window = 128000`, official DeepSeek endpoint):

```
# before
exit=1
--- stdout ---
三个文件都在项目根目录，现在依次读取全部内容。
--- stderr ---
(empty)

# after
exit=1
--- stdout ---
三个文件都在项目根目录,现在依次读取:
--- stderr ---
错误： context exceeds provider limit and compaction failed: summary result remains above fold trigger (39954 >= 1)
```

That message is also worth reading on its own: `39954 >= 1` is the collapsed threshold #8199 fixes, visible from the outside for the first time.

## Shape

`reportRunFailure` takes over the whole decision so the two branches cannot drift apart again: text always reports (error prefix when the run failed, plain text for a reportable pause), structured formats report only when no sink was built to carry it.

## Verification

- `TestReportRunFailureAlwaysExplainsTextRuns` covers print-with-sink, plain text, and both json cases.
- `TestReportRunFailureStaysSilentOnSuccess` keeps a successful run quiet.
- `go test ./internal/cli/` green, `go vet` and `make lint` clean.
- The before/after above is a real run, not a fixture.

Documentation-impact: none - the docs never promised silence here; this restores the reporting they already imply.