### PR TITLE
feat(desktop): 文件右键菜单支持用默认应用打开并分组

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -16,7 +16,7 @@
     "test:terminal": "tsx src/__tests__/terminal-events.test.ts && tsx src/__tests__/terminal-store.test.ts && tsx src/__tests__/terminal-output.test.ts && tsx src/__tests__/terminal-theme.test.ts && tsx src/__tests__/workspace-layout.test.ts",
     "test:usage-stats": "tsx src/__tests__/usage-stats-format.test.ts && tsx src/__tests__/usage-stats-panel.test.tsx",
     "test:task-monitor": "tsx src/components/TaskMonitorPanel.test.tsx && tsx src/__tests__/task-monitor-navigation.test.ts",
-    "test:workspace": "tsx src/__tests__/workspace-refresh-store.test.ts && tsx src/__tests__/workspace-changes-errors.test.tsx",
+    "test:workspace": "tsx src/__tests__/workspace-refresh-store.test.ts && tsx src/__tests__/workspace-changes-errors.test.tsx && tsx src/__tests__/workspace-context-menu.test.tsx",
     "test:settings-responsive": "tsx src/__tests__/settings-responsive-layout.test.ts",
     "test:motion": "node scripts/check-motion-ci-contract.mjs && node scripts/check-waapi-contract.mjs --self-test && tsx src/__tests__/native-motion.test.tsx && tsx src/__tests__/approval-animation.test.tsx",
     "test:transcript": "tsx src/__tests__/transcript-virtualization.test.tsx",

--- a/desktop/frontend/scripts/run-tests.mjs
+++ b/desktop/frontend/scripts/run-tests.mjs
@@ -24,6 +24,7 @@ const OWNED_ELSEWHERE = new Map(Object.entries({
   "task-monitor-navigation.test.ts": "test:task-monitor",
   "workspace-refresh-store.test.ts": "test:workspace",
   "workspace-changes-errors.test.tsx": "test:workspace",
+  "workspace-context-menu.test.tsx": "test:workspace",
   "rich-composer-selection.test.tsx": "pretest",
   "context-center-contract.test.ts": "pretest",
   "provider-model-cache.test.ts": "pretest",

--- a/desktop/frontend/src/__tests__/workspace-context-menu.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-context-menu.test.tsx
@@ -1,0 +1,200 @@
+// Run: tsx src/__tests__/workspace-context-menu.test.tsx
+
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { WorkspacePanel } from "../components/WorkspacePanel";
+import type { AppBindings } from "../lib/bridge";
+import { LocaleProvider } from "../lib/i18n";
+import { resetWorkspaceTreeMemoryForTests } from "../lib/workspaceTreeMemory";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function flushTimers(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(label: string, predicate: () => boolean) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await act(async () => {
+      await flushTimers();
+    });
+    if (predicate()) return;
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function installDom() {
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  Object.defineProperty(dom.window.navigator, "language", { configurable: true, value: "en-US" });
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  globalThis.Node = dom.window.Node;
+  globalThis.Element = dom.window.Element;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.PointerEvent = dom.window.MouseEvent as unknown as typeof PointerEvent;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.ResizeObserver = TestResizeObserver;
+  dom.window.ResizeObserver = TestResizeObserver;
+  globalThis.localStorage = dom.window.localStorage;
+  globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+  globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+  Object.defineProperty(dom.window.HTMLElement.prototype, "scrollIntoView", { configurable: true, value: () => {} });
+  Object.defineProperty(dom.window.HTMLElement.prototype, "offsetWidth", { configurable: true, get: () => 320 });
+  Object.defineProperty(dom.window.HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get: function offsetHeight(this: HTMLElement) {
+      return this.classList.contains("workspace-tree") ? 300 : this.dataset.index ? 24 : 0;
+    },
+  });
+  Object.defineProperty(dom.window.HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: function getBoundingClientRect(this: HTMLElement) {
+      const width = 320;
+      const height = this.classList.contains("workspace-tree") ? 300 : this.dataset.index ? 24 : 0;
+      return { x: 0, y: 0, top: 0, left: 0, right: width, bottom: height, width, height, toJSON: () => ({}) } as DOMRect;
+    },
+  });
+  return dom;
+}
+
+function menuLabels(): string[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>(".workspace-tree-menu button")).map(
+    (button) => button.textContent?.trim() ?? "",
+  );
+}
+
+async function openRowMenu(path: string) {
+  const row = document.querySelector<HTMLButtonElement>(`[data-workspace-path="${path}"]`);
+  if (!row) throw new Error(`missing workspace row ${path}`);
+  await act(async () => {
+    row.dispatchEvent(new window.MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 30, clientY: 30 }));
+    await flushTimers();
+  });
+}
+
+console.log("\nworkspace file context menu");
+
+resetWorkspaceTreeMemoryForTests();
+const dom = installDom();
+const openCalls: Array<{ tabId: string; path: string }> = [];
+window.go = {
+  main: {
+    App: {
+      ListDirForTab: async (_tabId, dir) => dir === ""
+        ? [
+            { name: "docs", isDir: true },
+            { name: "README.md", isDir: false },
+          ]
+        : [],
+      SearchFileRefsForTab: async () => [],
+      WorkspaceGitHistory: async () => [],
+      WorkspaceChanges: async () => ({ files: [], gitAvailable: true }),
+      WorkspaceChangeDetail: async () => ({}),
+      ReadFileForTab: async (_tabId, path) => ({ path, body: "", size: 0, truncated: false, binary: false }),
+      ResolveWorkspacePathForTab: async (_tabId, path) => `/repo/${path}`,
+      RevealWorkspacePathForTab: async () => {},
+      OpenWorkspacePathForTab: async (tabId, path) => {
+        openCalls.push({ tabId, path });
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+await act(async () => {
+  root.render(
+    <LocaleProvider>
+      <WorkspacePanel
+        open
+        tabId="workspace-tab"
+        cwd="/repo"
+        maximized={false}
+        initialViewMode="files"
+        onClose={() => {}}
+        onToggleMaximized={() => {}}
+        onOpenInTerminal={() => {}}
+      />
+    </LocaleProvider>,
+  );
+  await flushTimers();
+});
+
+await waitFor("workspace rows", () => document.querySelector('[data-workspace-path="README.md"]') != null);
+await openRowMenu("README.md");
+
+const fileLabels = [
+  "Open with default app",
+  "Show in file manager",
+  "Open in integrated terminal",
+  "Copy relative path",
+  "Copy absolute path",
+  "Add file reference",
+  "Add file contents",
+];
+ok(JSON.stringify(menuLabels()) === JSON.stringify(fileLabels), "file menu keeps the default-open action first and preserves command order");
+ok(document.querySelectorAll(".workspace-tree-menu [role=separator]").length === 1, "file menu separates path commands from chat commands");
+
+const defaultOpen = Array.from(document.querySelectorAll<HTMLButtonElement>(".workspace-tree-menu button")).find(
+  (button) => button.textContent?.trim() === "Open with default app",
+);
+await act(async () => {
+  defaultOpen?.click();
+  await flushTimers();
+});
+ok(
+  JSON.stringify(openCalls) === JSON.stringify([{ tabId: "workspace-tab", path: "README.md" }]),
+  "default-open routes the selected relative file path through the active workspace tab",
+);
+ok(document.querySelector(".workspace-tree-menu") == null, "default-open closes the file menu");
+
+await openRowMenu("docs/");
+ok(!menuLabels().includes("Open with default app"), "folder menu does not offer default-open");
+ok(
+  JSON.stringify(menuLabels()) === JSON.stringify([
+    "Show in file manager",
+    "Open in integrated terminal",
+    "Copy relative path",
+    "Copy absolute path",
+    "Add folder reference",
+  ]),
+  "folder menu preserves its existing command order",
+);
+ok(document.querySelectorAll(".workspace-tree-menu [role=separator]").length === 1, "folder menu keeps one chat-command separator");
+
+await act(async () => {
+  root.unmount();
+});
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/FloatingMenu.tsx
+++ b/desktop/frontend/src/components/FloatingMenu.tsx
@@ -4,12 +4,18 @@ import { createPortal } from "react-dom";
 
 const FLOATING_MENU_MARGIN = 8;
 
-export interface FloatingMenuItem {
-  icon?: ReactNode;
-  label: ReactNode;
-  onSelect: () => void;
-  disabled?: boolean;
-}
+export type FloatingMenuItem =
+  | {
+      separator: true;
+      key?: string;
+    }
+  | {
+      icon?: ReactNode;
+      label: ReactNode;
+      onSelect: () => void;
+      disabled?: boolean;
+      separator?: false;
+    };
 
 function clampFloatingMenuPosition(x: number, y: number, width: number, height: number): { left: number; top: number } {
   if (typeof window === "undefined") return { left: x, top: y };
@@ -61,20 +67,24 @@ export function FloatingMenu({
 export function FloatingMenuItems({ items }: { items: FloatingMenuItem[] }) {
   return (
     <>
-      {items.map((item, index) => (
-        <button
-          key={index}
-          type="button"
-          disabled={item.disabled}
-          onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
-            event.stopPropagation();
-            if (!item.disabled) item.onSelect();
-          }}
-        >
-          {item.icon}
-          <span>{item.label}</span>
-        </button>
-      ))}
+      {items.map((item, index) =>
+        item.separator ? (
+          <div key={item.key ?? `sep-${index}`} className="floating-menu__separator" role="separator" />
+        ) : (
+          <button
+            key={index}
+            type="button"
+            disabled={item.disabled}
+            onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
+              event.stopPropagation();
+              if (!item.disabled) item.onSelect();
+            }}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </button>
+        ),
+      )}
     </>
   );
 }

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -11,10 +11,8 @@ import type {
 import {
   ChevronDown,
   ChevronRight,
-  ExternalLink,
   FileText,
   Folder,
-  FolderOpen,
   FolderTree,
   FolderX,
   GitBranch,
@@ -23,7 +21,6 @@ import {
   Minimize2,
   RefreshCw,
   Search,
-  TerminalSquare,
   X,
 } from "lucide-react";
 import { asArray } from "../lib/array";
@@ -64,7 +61,6 @@ import { workspaceGitStatusLabel } from "../lib/workspaceChanges";
 import { formatWorkspaceReference, WORKSPACE_REF_DRAG_TYPE } from "../lib/workspaceDrag";
 import { formatSelectionReference, languageFor } from "../lib/selectedTextContext";
 import { cleanGitDiff } from "../lib/diff";
-import { WORKSPACE_CONTEXT_MENU_FILE_HEIGHT, WORKSPACE_CONTEXT_MENU_REF_HEIGHT, workspacePathCopyMenuItems } from "../lib/workspacePathCopyMenuItems";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
 import { ContextMenu, contextMenuPointFromEvent, type ContextMenuItem, type ContextMenuPoint } from "./ContextMenu";
@@ -73,6 +69,7 @@ import { Markdown } from "./Markdown";
 import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { WorkspaceFileIcon } from "./WorkspaceFileIcon";
+import { WorkspaceTreeMenu } from "./WorkspaceTreeMenu";
 
 const WORKSPACE_TREE_MIN_WIDTH = 140;
 const WORKSPACE_TREE_DEFAULT_WIDTH = 300;
@@ -1398,18 +1395,6 @@ export function WorkspacePanel({
     }
   };
 
-  const revealInFileManager = () => {
-    if (!treeMenu) return;
-    setTreeMenu(null);
-    void app.RevealWorkspacePathForTab(workspaceTabId, treeMenu.path).catch(() => {});
-  };
-
-  const openWithDefaultApp = () => {
-    if (!treeMenu) return;
-    setTreeMenu(null);
-    void app.OpenWorkspacePathForTab(workspaceTabId, treeMenu.path).catch(() => {});
-  };
-
   const renderNormalRow = (row: TreeRow) => {
     const { path, depth, entry, isOpen, active, compactPaths = [path], displayName = entry.name } = row;
     return (
@@ -2159,58 +2144,15 @@ export function WorkspacePanel({
         </div>
       </section>
       {treeMenu && (
-        <FloatingMenu
-          x={treeMenu.x}
-          y={treeMenu.y}
-          estimatedHeight={treeMenu.isDir ? WORKSPACE_CONTEXT_MENU_REF_HEIGHT : WORKSPACE_CONTEXT_MENU_FILE_HEIGHT}
-          className="workspace-tree-menu"
-        >
-          <FloatingMenuItems
-            items={[
-              ...(treeMenu.isDir
-                ? []
-                : [
-                    {
-                      icon: <ExternalLink size={14} />,
-                      label: t("workspace.openWithDefaultApp"),
-                      onSelect: openWithDefaultApp,
-                    },
-                  ]),
-              {
-                icon: <FolderOpen size={14} />,
-                label: t("workspace.revealInFileManager"),
-                onSelect: revealInFileManager,
-              },
-              ...(onOpenInTerminal
-                ? [{
-                    icon: <TerminalSquare size={14} />,
-                    label: t("workspace.openInTerminal"),
-                    onSelect: () => {
-                      const target = treeMenu;
-                      setTreeMenu(null);
-                      onOpenInTerminal(target.path);
-                    },
-                  }]
-                : []),
-              ...workspacePathCopyMenuItems({ path: treeMenu.path, resolveAbsolutePath: () => app.ResolveWorkspacePathForTab(workspaceTabId, treeMenu.path), isScopeCurrent: () => currentWorkspaceScopeKeyRef.current === workspaceScopeKey, close: () => setTreeMenu(null), relativeLabel: t("workspace.copyRelativePath"), absoluteLabel: t("workspace.copyAbsolutePath") }),
-              { separator: true },
-              {
-                icon: <MessageSquarePlus size={14} />,
-                label: treeMenu.isDir ? t("workspace.addFolderReferenceToChat") : t("workspace.addFileReferenceToChat"),
-                onSelect: addTreeReferenceToChat,
-              },
-              ...(treeMenu.isDir
-                ? []
-                : [
-                    {
-                      icon: <FileText size={14} />,
-                      label: t("workspace.addFileContentToChat"),
-                      onSelect: () => void addTreeFileToChat(),
-                    },
-                  ]),
-            ]}
-          />
-        </FloatingMenu>
+        <WorkspaceTreeMenu
+          target={treeMenu}
+          workspaceTabId={workspaceTabId}
+          isScopeCurrent={() => currentWorkspaceScopeKeyRef.current === workspaceScopeKey}
+          onClose={() => setTreeMenu(null)}
+          onOpenInTerminal={onOpenInTerminal}
+          onAddReference={addTreeReferenceToChat}
+          onAddFile={() => void addTreeFileToChat()}
+        />
       )}
       <ContextMenu
         open={Boolean(treeBlankMenuPoint)}

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -11,6 +11,7 @@ import type {
 import {
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   FileText,
   Folder,
   FolderOpen,
@@ -1403,6 +1404,12 @@ export function WorkspacePanel({
     void app.RevealWorkspacePathForTab(workspaceTabId, treeMenu.path).catch(() => {});
   };
 
+  const openWithDefaultApp = () => {
+    if (!treeMenu) return;
+    setTreeMenu(null);
+    void app.OpenWorkspacePathForTab(workspaceTabId, treeMenu.path).catch(() => {});
+  };
+
   const renderNormalRow = (row: TreeRow) => {
     const { path, depth, entry, isOpen, active, compactPaths = [path], displayName = entry.name } = row;
     return (
@@ -2160,21 +2167,15 @@ export function WorkspacePanel({
         >
           <FloatingMenuItems
             items={[
-              {
-                icon: <MessageSquarePlus size={14} />,
-                label: treeMenu.isDir ? t("workspace.addFolderReferenceToChat") : t("workspace.addFileReferenceToChat"),
-                onSelect: addTreeReferenceToChat,
-              },
               ...(treeMenu.isDir
                 ? []
                 : [
                     {
-                      icon: <FileText size={14} />,
-                      label: t("workspace.addFileContentToChat"),
-                      onSelect: () => void addTreeFileToChat(),
+                      icon: <ExternalLink size={14} />,
+                      label: t("workspace.openWithDefaultApp"),
+                      onSelect: openWithDefaultApp,
                     },
                   ]),
-              ...workspacePathCopyMenuItems({ path: treeMenu.path, resolveAbsolutePath: () => app.ResolveWorkspacePathForTab(workspaceTabId, treeMenu.path), isScopeCurrent: () => currentWorkspaceScopeKeyRef.current === workspaceScopeKey, close: () => setTreeMenu(null), relativeLabel: t("workspace.copyRelativePath"), absoluteLabel: t("workspace.copyAbsolutePath") }),
               {
                 icon: <FolderOpen size={14} />,
                 label: t("workspace.revealInFileManager"),
@@ -2191,6 +2192,22 @@ export function WorkspacePanel({
                     },
                   }]
                 : []),
+              ...workspacePathCopyMenuItems({ path: treeMenu.path, resolveAbsolutePath: () => app.ResolveWorkspacePathForTab(workspaceTabId, treeMenu.path), isScopeCurrent: () => currentWorkspaceScopeKeyRef.current === workspaceScopeKey, close: () => setTreeMenu(null), relativeLabel: t("workspace.copyRelativePath"), absoluteLabel: t("workspace.copyAbsolutePath") }),
+              { separator: true },
+              {
+                icon: <MessageSquarePlus size={14} />,
+                label: treeMenu.isDir ? t("workspace.addFolderReferenceToChat") : t("workspace.addFileReferenceToChat"),
+                onSelect: addTreeReferenceToChat,
+              },
+              ...(treeMenu.isDir
+                ? []
+                : [
+                    {
+                      icon: <FileText size={14} />,
+                      label: t("workspace.addFileContentToChat"),
+                      onSelect: () => void addTreeFileToChat(),
+                    },
+                  ]),
             ]}
           />
         </FloatingMenu>

--- a/desktop/frontend/src/components/WorkspaceTreeMenu.tsx
+++ b/desktop/frontend/src/components/WorkspaceTreeMenu.tsx
@@ -1,0 +1,94 @@
+import { ExternalLink, FileText, FolderOpen, MessageSquarePlus, TerminalSquare } from "lucide-react";
+import { app } from "../lib/bridge";
+import { useT } from "../lib/i18n";
+import {
+  WORKSPACE_CONTEXT_MENU_FILE_HEIGHT,
+  WORKSPACE_CONTEXT_MENU_REF_HEIGHT,
+  workspacePathCopyMenuItems,
+} from "../lib/workspacePathCopyMenuItems";
+import { FloatingMenu, FloatingMenuItems } from "./FloatingMenu";
+
+export interface WorkspaceTreeMenuTarget {
+  x: number;
+  y: number;
+  path: string;
+  isDir: boolean;
+}
+
+export function WorkspaceTreeMenu({
+  target,
+  workspaceTabId,
+  isScopeCurrent,
+  onClose,
+  onOpenInTerminal,
+  onAddReference,
+  onAddFile,
+}: {
+  target: WorkspaceTreeMenuTarget;
+  workspaceTabId: string;
+  isScopeCurrent: () => boolean;
+  onClose: () => void;
+  onOpenInTerminal?: (path: string) => void;
+  onAddReference: () => void;
+  onAddFile: () => void;
+}) {
+  const t = useT();
+  const closeThen = (action: () => void) => {
+    onClose();
+    action();
+  };
+
+  return (
+    <FloatingMenu
+      x={target.x}
+      y={target.y}
+      estimatedHeight={target.isDir ? WORKSPACE_CONTEXT_MENU_REF_HEIGHT : WORKSPACE_CONTEXT_MENU_FILE_HEIGHT}
+      className="workspace-tree-menu"
+    >
+      <FloatingMenuItems
+        items={[
+          ...(target.isDir
+            ? []
+            : [{
+                icon: <ExternalLink size={14} />,
+                label: t("workspace.openWithDefaultApp"),
+                onSelect: () => closeThen(() => void app.OpenWorkspacePathForTab(workspaceTabId, target.path).catch(() => {})),
+              }]),
+          {
+            icon: <FolderOpen size={14} />,
+            label: t("workspace.revealInFileManager"),
+            onSelect: () => closeThen(() => void app.RevealWorkspacePathForTab(workspaceTabId, target.path).catch(() => {})),
+          },
+          ...(onOpenInTerminal
+            ? [{
+                icon: <TerminalSquare size={14} />,
+                label: t("workspace.openInTerminal"),
+                onSelect: () => closeThen(() => onOpenInTerminal(target.path)),
+              }]
+            : []),
+          ...workspacePathCopyMenuItems({
+            path: target.path,
+            resolveAbsolutePath: () => app.ResolveWorkspacePathForTab(workspaceTabId, target.path),
+            isScopeCurrent,
+            close: onClose,
+            relativeLabel: t("workspace.copyRelativePath"),
+            absoluteLabel: t("workspace.copyAbsolutePath"),
+          }),
+          { separator: true },
+          {
+            icon: <MessageSquarePlus size={14} />,
+            label: target.isDir ? t("workspace.addFolderReferenceToChat") : t("workspace.addFileReferenceToChat"),
+            onSelect: onAddReference,
+          },
+          ...(target.isDir
+            ? []
+            : [{
+                icon: <FileText size={14} />,
+                label: t("workspace.addFileContentToChat"),
+                onSelect: onAddFile,
+              }]),
+        ]}
+      />
+    </FloatingMenu>
+  );
+}

--- a/desktop/frontend/src/lib/workspacePathCopyMenuItems.tsx
+++ b/desktop/frontend/src/lib/workspacePathCopyMenuItems.tsx
@@ -2,8 +2,8 @@ import { Copy } from "lucide-react";
 import type { FloatingMenuItem } from "../components/FloatingMenu";
 import { writeClipboardText } from "./clipboard";
 
-export const WORKSPACE_CONTEXT_MENU_FILE_HEIGHT = 204;
-export const WORKSPACE_CONTEXT_MENU_REF_HEIGHT = 160;
+export const WORKSPACE_CONTEXT_MENU_FILE_HEIGHT = 280;
+export const WORKSPACE_CONTEXT_MENU_REF_HEIGHT = 236;
 
 export function workspacePathCopyMenuItems({
   path,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -296,6 +296,7 @@ export const en = {
   "workspace.deleted": "Deleted",
   "workspace.fileDeleted": "This file was deleted from the workspace.",
   "workspace.revealInFileManager": "Show in file manager",
+  "workspace.openWithDefaultApp": "Open with default app",
   "workspace.openInTerminal": "Open in integrated terminal",
   "terminal.title": "Terminal",
   "terminal.sessions": "Terminal sessions",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2335,6 +2335,7 @@ export const zhTW: Record<DictKey, string> = {
   "workspace.clearFileScope": "顯示完整檔案樹",
   "workspace.clearChangeScope": "顯示全部改動",
   "workspace.revealInFileManager": "在檔案管理器中顯示",
+  "workspace.openWithDefaultApp": "用預設應用程式開啟",
   "workspace.openInTerminal": "在內建終端機開啟",
   "terminal.title": "終端機",
   "terminal.sessions": "終端機工作階段",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -297,6 +297,7 @@ export const zh: Record<DictKey, string> = {
   "workspace.deleted": "已删除",
   "workspace.fileDeleted": "该文件已从工作区删除。",
   "workspace.revealInFileManager": "在文件管理器中显示",
+  "workspace.openWithDefaultApp": "用默认应用打开",
   "workspace.openInTerminal": "在内置终端打开",
   "terminal.title": "终端",
   "terminal.sessions": "终端会话",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10174,6 +10174,11 @@ body > .mermaid-diagram--fullscreen {
 .floating-menu button:hover {
   background: var(--bg-soft);
 }
+.floating-menu__separator {
+  height: 1px;
+  margin: 5px 4px;
+  background: var(--border-soft);
+}
 .tooltip-trigger {
   display: inline-flex;
   min-width: 0;


### PR DESCRIPTION
## 变更内容

1. **新增「用默认应用打开」菜单项**：工作区文件树右键菜单支持用系统默认应用打开文件（macOS `open` / Linux `xdg-open` / Windows `ShellExecute`），复用现有 `app.OpenWorkspacePathForTab` 后端绑定，零后端改动。仅对文件显示，文件夹不显示。
2. **右键菜单分组**：`FloatingMenuItem` 支持 `separator` 分隔线，菜单按「文件操作 / 与聊天交互」两组分组。
3. **菜单顺序重排**：按使用频率排列（用默认应用打开 → 在文件管理器中显示 → 在内置终端打开 → 复制相对/绝对路径 → 添加引用/内容到聊天）。
4. 菜单高度估算随项数上调（FILE 280 / REF 236）；新增 `workspace.openWithDefaultApp` 三语言键（en/zh/zh-TW）。

## 验证

- `pnpm run typecheck` 通过
- `pnpm run test:workspace` 通过（右键菜单相关测试无回归）
- `wails build` 完整打包通过（darwin/arm64）
- 已在实际构建产物中人工验证：文件右键出现「用默认应用打开」，文件夹不出现

## 环境

- Agent 生成：Reasonix（DeepSeek 模型），无其他插件

Documentation-impact: none - 本次为纯 UI 功能改动（右键菜单项与分组），不涉及任何内嵌文档（docs/*.md），现有文档描述仍准确无需更新