### PR TITLE
fix(control): the context gauge must measure what the trigger measures

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6682,16 +6682,11 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	if ctrl == nil {
 		return info
 	}
+	// The gauge measures the loaded view, so a rebound session reports its real
+	// fill immediately and no longer needs the persisted last-turn fallback.
 	used, window := ctrl.ContextSnapshot()
 	info.Used = used
 	info.Window = window
-	// Session rebind (project-tree switch) rebuilds the controller: the fresh
-	// executor has no per-turn usage yet, so ContextSnapshot reports used=0.
-	// Fall back to the telemetry-persisted last-used value so the status bar
-	// shows the fill percentage from the last turn instead of 0%.
-	if used == 0 && snap.Usage.LastUsedTokens > 0 {
-		info.Used = snap.Usage.LastUsedTokens
-	}
 	info.CompactRatio = ctrl.CompactRatio()
 	info.Maintenance = contextMaintenanceInfo(ctrl.ContextMaintenanceSnapshot())
 	return info

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -8148,20 +8148,19 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 		if sp := ctrl.SessionPath(); sp != "" {
 			tab.syncTelemetryToSession(sp)
 		}
-		used, window := ctrl.ContextSnapshot()
-		info.UsedTokens = used
+		_, window := ctrl.ContextSnapshot()
 		info.WindowTokens = window
-		// Session rebind rebuilds the controller: the fresh executor has no
-		// per-turn usage yet, so ContextSnapshot reports used=0. Fall back to
-		// the telemetry-persisted last-used value from the most recent turn.
-		if used == 0 {
+		// This panel breaks the last turn down into segments, so its total must
+		// be that turn's usage and not the live-view measurement the status-bar
+		// gauge reports — otherwise the segments stop summing to the total.
+		if u := ctrl.LastUsage(); u != nil {
+			info.UsedTokens = u.PromptTokens + u.CompletionTokens
+		}
+		if info.UsedTokens == 0 {
 			if snap := tab.telemetrySnapshot(); snap.Usage.LastUsedTokens > 0 {
 				info.UsedTokens = snap.Usage.LastUsedTokens
 			}
 		}
-		// Per-turn token breakdown from LastUsage (same snapshot as UsedTokens)
-		// so the donut segments are proportional to the current context fill,
-		// not inflated by cumulative session totals.
 		if u := ctrl.LastUsage(); u != nil {
 			info.PromptTokens = u.PromptTokens
 			info.CompletionTokens = u.CompletionTokens

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -351,7 +351,9 @@ func TestTelemetryLastContextRoundTripAndLegacyDefaults(t *testing.T) {
 	}
 }
 
-func TestContextFallbackUsesPersistedExecutorUsageAfterRebind(t *testing.T) {
+// The gauge measures the rebound session's own view, so it no longer needs the
+// persisted last-used fallback. The panel breakdown still comes from telemetry.
+func TestContextGaugeMeasuresLiveViewAfterRebind(t *testing.T) {
 	ag := agent.New(
 		usageProvider{usage: nil},
 		tool.NewRegistry(),
@@ -383,8 +385,8 @@ func TestContextFallbackUsesPersistedExecutorUsageAfterRebind(t *testing.T) {
 	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
 
 	context := app.ContextUsageForTab("tab")
-	if context.Used != 120 || context.Window != 200 {
-		t.Fatalf("context fallback = used:%d window:%d, want 120/200", context.Used, context.Window)
+	if want := tab.Ctrl.ContextMaintenanceSnapshot().ProjectedTokens; context.Used != want || context.Window != 200 {
+		t.Fatalf("context gauge = used:%d window:%d, want %d/200 — the live view, not the persisted 120", context.Used, context.Window, want)
 	}
 	panel := app.ContextPanel("tab")
 	if panel.UsedTokens != 120 ||
@@ -399,7 +401,8 @@ func TestContextFallbackUsesPersistedExecutorUsageAfterRebind(t *testing.T) {
 
 // TestContextFallbackUsesLatestAttemptAfterMultiAttemptUsage locks the stream-
 // recovery telemetry contract: billable Prompt/Completion may be 2×30K, but
-// Last* fields (and rebind fallback) must use Context* from the latest attempt.
+// Last* fields and the panel breakdown must use Context* from the latest
+// attempt. The gauge itself measures the live view instead.
 func TestContextFallbackUsesLatestAttemptAfterMultiAttemptUsage(t *testing.T) {
 	ag := agent.New(
 		usageProvider{usage: nil},
@@ -443,8 +446,8 @@ func TestContextFallbackUsesLatestAttemptAfterMultiAttemptUsage(t *testing.T) {
 
 	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
 	context := app.ContextUsageForTab("tab")
-	if context.Used != 30_002 {
-		t.Fatalf("rebind context Used = %d, want latest fill 30002 (not billable 60005)", context.Used)
+	if want := tab.Ctrl.ContextMaintenanceSnapshot().ProjectedTokens; context.Used != want {
+		t.Fatalf("context gauge = %d, want the live view %d (never the billable 60005)", context.Used, want)
 	}
 	panel := app.ContextPanel("tab")
 	if panel.UsedTokens != 30_002 ||

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -301,7 +301,7 @@ type Agent struct {
 	// never nil because New defaults it to event.Discard.
 	sink                event.Sink
 	requireVisibleFinal bool // internal callers require final Content
-	// lastUsage caches the latest provider telemetry for the CLI context gauge.
+	// lastUsage caches the latest provider telemetry for per-turn readouts.
 	// The run loop writes it while a frontend reads it, so it is atomic.
 	lastUsage atomic.Pointer[provider.Usage]
 	outputBudgetState

--- a/internal/agent/context_usage.go
+++ b/internal/agent/context_usage.go
@@ -1,0 +1,44 @@
+package agent
+
+// contextUsage memoises the projected prompt size. The estimate walks every
+// visible message, and status gauges redraw far more often than the view moves,
+// so it is keyed on the three things that can change the answer: the
+// transcript, the projection, and the calibration.
+type contextUsage struct {
+	transcriptVersion uint64
+	projectionVersion uint64
+	calibration       *promptTokenCalibration
+	tokens            int
+}
+
+// ContextUsedTokens is the number ContextManager compares against its
+// thresholds: the estimated prompt size of the view the next request sends. A
+// gauge fed from the last turn's usage instead lags a turn, counts completion
+// tokens the trigger ignores, and reads zero on a rebound session — which is
+// how a session displays 8% while it is compacting.
+func (a *Agent) ContextUsedTokens() int {
+	if a == nil {
+		return 0
+	}
+	session := a.Session()
+	if session == nil {
+		return 0
+	}
+	transcriptVersion := session.TranscriptVersion()
+	projectionVersion := a.currentProjectionVersion()
+	calibration := a.promptCalibration.Load()
+	if cached := a.contextUsage.Load(); cached != nil &&
+		cached.transcriptVersion == transcriptVersion &&
+		cached.projectionVersion == projectionVersion &&
+		cached.calibration == calibration {
+		return cached.tokens
+	}
+	tokens := a.estimatedPromptTokens(a.modelVisibleMessages())
+	a.contextUsage.Store(&contextUsage{
+		transcriptVersion: transcriptVersion,
+		projectionVersion: projectionVersion,
+		calibration:       calibration,
+		tokens:            tokens,
+	})
+	return tokens
+}

--- a/internal/agent/context_usage_test.go
+++ b/internal/agent/context_usage_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func usageFixture(t *testing.T, toolResults int) *Agent {
+	t.Helper()
+	big := strings.Repeat("line\n", 400)
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "task"},
+	}
+	for i := range toolResults {
+		id := fmt.Sprintf("call-%d", i)
+		msgs = append(msgs,
+			provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: id, Name: "read_file", Arguments: "{}"}}},
+			provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: "read_file", Content: big},
+		)
+	}
+	return New(nil, tool.NewRegistry(), &Session{Messages: msgs}, Options{
+		ContextWindow: 1_000_000,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+}
+
+// The gauge and the compaction trigger must read the same number. Feeding the
+// gauge from the last turn's provider usage let a session report 8% while it
+// was compacting: that number lags a turn, counts completion tokens the trigger
+// never looks at, and is zero until the first turn of a rebound session.
+func TestContextUsedTokensMatchesTheTriggerInput(t *testing.T) {
+	a := usageFixture(t, 12)
+	// A stale, tiny reading from the previous turn — exactly what a fold leaves
+	// behind, and what the gauge used to display.
+	a.lastUsage.Store(&provider.Usage{PromptTokens: 900, CompletionTokens: 100})
+
+	used := a.ContextUsedTokens()
+	if got := a.ContextMaintenanceSnapshot().ProjectedTokens; used != got {
+		t.Fatalf("gauge = %d, trigger input = %d; they must be the same measurement", used, got)
+	}
+	if used <= 1_000 {
+		t.Fatalf("gauge = %d, want the real view size rather than the last turn's %d", used, 1_000)
+	}
+}
+
+func TestContextUsedTokensIsZeroWithoutASession(t *testing.T) {
+	a := &Agent{}
+	if got := a.ContextUsedTokens(); got != 0 {
+		t.Fatalf("gauge without a session = %d, want 0 so the frontend hides it", got)
+	}
+}
+
+func TestContextUsedTokensFollowsTheTranscript(t *testing.T) {
+	a := usageFixture(t, 4)
+	before := a.ContextUsedTokens()
+	if before != a.ContextUsedTokens() {
+		t.Fatal("repeated reads of an unchanged view disagreed")
+	}
+
+	a.session.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("more context\n", 500)})
+	after := a.ContextUsedTokens()
+	if after <= before {
+		t.Fatalf("gauge %d -> %d, want the appended turn counted", before, after)
+	}
+}

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -16,6 +16,7 @@ type outputBudgetState struct {
 	outputBudget      int
 	activeReqShape    atomic.Pointer[requestCalibrationShape]
 	promptCalibration atomic.Pointer[promptTokenCalibration]
+	contextUsage      atomic.Pointer[contextUsage] // gauge's memoised prompt size
 }
 
 type promptTokenCalibration struct {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4740,19 +4740,15 @@ func (c *Controller) SessionPersistedState() (agent.PersistedState, bool) {
 	return c.executor.Session().PersistedState(c.SessionPath())
 }
 
-// ContextSnapshot returns (usedTokens, contextWindow) from the most recent
-// turn. Both zero means no data yet — a gauge hides itself.
-// usedTokens is promptTokens + completionTokens so the GUI breakdown and
-// gauge reflect the full token usage, not just the prompt fill.
+// ContextSnapshot returns (usedTokens, contextWindow) for the gauge. usedTokens
+// is what the next request will send, measured the way the compaction trigger
+// measures it, so the gauge and the trigger can never disagree. Both zero means
+// no data yet — a gauge hides itself.
 func (c *Controller) ContextSnapshot() (int, int) {
 	if c.executor == nil {
 		return 0, 0
 	}
-	u := c.executor.LastUsage()
-	if u == nil {
-		return 0, c.executor.ContextWindow()
-	}
-	return u.PromptTokens + u.CompletionTokens, c.executor.ContextWindow()
+	return c.executor.ContextUsedTokens(), c.executor.ContextWindow()
 }
 
 // CompactRatio returns the auto-compaction threshold as a fraction of the window

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -141,15 +141,12 @@ func (r cancelingRunner) Run(_ context.Context, _ string) error {
 	return nil
 }
 
-func TestContextSnapshotIncludesCompletionTokens(t *testing.T) {
+// The gauge must measure what the trigger measures. Reporting the previous
+// turn's billed usage is how a session displayed 8% while it was compacting.
+func TestContextSnapshotMeasuresTheTriggerInput(t *testing.T) {
 	prov := &scriptedTurns{turns: [][]provider.Chunk{{
 		{Type: provider.ChunkText, Text: "ok"},
-		{Type: provider.ChunkUsage, Usage: &provider.Usage{
-			PromptTokens:     6840,
-			CompletionTokens: 48,
-			TotalTokens:      6888,
-			ReasoningTokens:  48,
-		}},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 6840, CompletionTokens: 48, TotalTokens: 6888, ReasoningTokens: 48}},
 		{Type: provider.ChunkDone},
 	}}}
 	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{ContextWindow: 1_000_000}, event.Discard)
@@ -159,9 +156,10 @@ func TestContextSnapshotIncludesCompletionTokens(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	want := c.ContextMaintenanceSnapshot().ProjectedTokens
 	used, window := c.ContextSnapshot()
-	if used != 6888 || window != 1_000_000 {
-		t.Fatalf("ContextSnapshot() = (%d, %d), want (6888, 1000000)", used, window)
+	if used != want || used == 6888 || window != 1_000_000 {
+		t.Fatalf("ContextSnapshot() = (%d, %d), want (%d, 1000000): the gauge reads the trigger's live input, never the last turn's 6888", used, window, want)
 	}
 }
 


### PR DESCRIPTION
## Two channels for one number

`ContextSnapshot` fed every frontend's gauge from the last turn's provider usage — `PromptTokens + CompletionTokens`. Compaction decides on something else entirely:

```
modelVisibleMessages() → estimatedPromptTokens() → ContextManager.Prepare() → fold / force
```

The two disagree in three ways at once:

1. **Timing** — the gauge is last turn's snapshot; the trigger is measured before the next request. A turn that just took on a large tool result reads small while the trigger has already fired.
2. **Quantity** — the gauge includes completion tokens; the trigger only ever looks at input.
3. **Rebinding** — `LastUsage()` is nil until a session's first turn, so a rebound session reads zero. Desktop rebinds on every tab switch, fork, and recovery adopt.

Measured on a recorded 13-message session:

```
old gauge (last usage) = 0        new gauge = 27076
trigger input          = 27076    fold trigger = 800000
```

Desktop hid the zero behind a telemetry-persisted `LastUsedTokens` fallback, so the bar showed a plausible but unrelated number rather than an obviously broken one. That is the reported "上下文充足 8%" sitting directly next to "正在压缩对话": the gauge was never reporting the quantity being compared against `compact_ratio`. Reported as #8191 (and it is why #8132 / #8116 read as "8% 就压缩").

## The fix

`Agent.ContextUsedTokens()` returns exactly what `ContextManager` compares against its thresholds, and `ContextSnapshot` returns that. The estimate walks every visible message while gauges redraw constantly, so it is memoised against the three things that can change it — transcript version, projection version, calibration — rather than recomputed per repaint. `ContextMaintenanceSnapshot` was not reused for this: it also hashes the whole view, which is far too heavy for a status bar.

The desktop `LastUsedTokens` fallback is removed: a rebound session now measures its own loaded view immediately, so there is nothing to paper over.

## Test change worth reviewing

`TestContextSnapshotIncludesCompletionTokens` pinned the behaviour this PR removes — its name was the contract. It is now `TestContextSnapshotMeasuresTheTriggerInput` and asserts the gauge equals `ContextMaintenanceSnapshot().ProjectedTokens` and is *not* the last turn's 6888.

## Verification

- `TestContextUsedTokensMatchesTheTriggerInput` — gauge equals the trigger's input even with a stale tiny `lastUsage` (what a fold leaves behind).
- `TestContextUsedTokensFollowsTheTranscript` — memoisation does not go stale when the view grows.
- `TestContextUsedTokensIsZeroWithoutASession` — no session still hides the gauge.
- `go test ./internal/agent/ ./internal/control/ ./internal/cli/ ./internal/serve/ ./internal/boot/` green; `go vet ./internal/...`, desktop `go vet ./...`, and `make lint` clean (no baseline widened — the new lines were pulled back under budget instead).
- The 0 vs 27076 figures above come from a real recorded session, not a fixture.

Cache-impact: none - no provider-visible bytes change; this only alters which number the read-only gauge reports.
Cache-guard: TestContextSnapshotMeasuresTheTriggerInput pins the gauge to the trigger's own input, so the two cannot drift apart again.
Documentation-impact: none - the gauge is documented as context fill, which is what it now actually shows.