### PR TITLE
feat(agent): an unproven acceptance criterion blocks the final answer

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1608,221 +1608,11 @@ func (a *Agent) ReadinessResult() ReadinessResult {
 	}
 }
 
-type finalReadinessCheck struct {
-	applies                   bool
-	reason                    string
-	missingProjectChecks      int
-	incompleteTodos           int
-	missingAcceptanceCriteria int
-	missingVerification       int
-	missingReview             int
-	missingSignoff            int
-	missingActionEvidence     int
-	missingMutation           int
-	missingCapabilities       int
-}
-
-func (c finalReadinessCheck) progressSignature() string {
-	return fmt.Sprintf("%d/%d/%d/%d/%d/%d/%d/%d/%d/%d\x00%s",
-		c.missingProjectChecks,
-		c.incompleteTodos,
-		c.missingAcceptanceCriteria,
-		c.missingVerification,
-		c.missingReview,
-		c.missingSignoff,
-		c.missingActionEvidence,
-		c.missingMutation,
-		c.missingCapabilities,
-		boolInt(c.applies),
-		c.reason,
-	)
-}
-
-func (c finalReadinessCheck) missingIDs() []string {
-	missing := make([]string, 0, 9)
-	add := func(id string, count int) {
-		if count > 0 {
-			missing = append(missing, id)
-		}
-	}
-	add("project_check", c.missingProjectChecks)
-	add("todo", c.incompleteTodos)
-	add("criteria", c.missingAcceptanceCriteria)
-	add("verification", c.missingVerification)
-	add("review", c.missingReview)
-	add("signoff", c.missingSignoff)
-	add("action", c.missingActionEvidence)
-	add("mutation", c.missingMutation)
-	add("capability", c.missingCapabilities)
-	return missing
-}
-
 func boolInt(v bool) int {
 	if v {
 		return 1
 	}
 	return 0
-}
-
-func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recovered bool) evidence.ReadinessAudit {
-	return evidence.ReadinessAudit{
-		Result:                    result,
-		Recovered:                 recovered,
-		MissingProjectChecks:      c.missingProjectChecks,
-		IncompleteTodos:           c.incompleteTodos,
-		CommandMismatchMissing:    c.missingProjectChecks,
-		MissingAcceptanceCriteria: c.missingAcceptanceCriteria,
-		MissingVerification:       c.missingVerification,
-		MissingReview:             c.missingReview,
-		MissingSignoff:            c.missingSignoff,
-		MissingActionEvidence:     c.missingActionEvidence,
-		MissingMutation:           c.missingMutation,
-		MissingCapabilities:       c.missingCapabilities,
-	}
-}
-
-func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
-	if a.evidence == nil || a.ablation.Off(ablation.Evidence) {
-		return finalReadinessCheck{}
-	}
-	var missing []string
-	out := finalReadinessCheck{}
-	// Planning returns a proposal to the controller, which owns the approval gate
-	// and starts a fresh execution turn after Plan is disabled. Delivery completion
-	// requirements, including required capabilities, wait for that execution turn:
-	// forcing them here could make a writer requirement contradict the plan-first
-	// workflow. This is a workflow boundary only; model-initiated tool calls above
-	// still use the normal Permissions/Sandbox path.
-	if a.planMode.Load() {
-		return out
-	}
-	{
-		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
-		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
-			incomplete, hasTodos = a.incompleteCanonicalTodos()
-		}
-		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
-			out.applies = true
-			out.incompleteTodos = len(incomplete)
-			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
-		}
-	}
-	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
-	deliveryMutation := false
-	deliveryVerificationOnly := false
-	checkpoint := a.deliveryCheckpoint
-	checkpointApplies := a.deliveryScopeActive && checkpoint.ScopeID == a.deliveryScopeID
-	if a.deliveryProfile {
-		if mutation, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
-			writer, hasWriter = mutation, true
-			deliveryMutation = true
-		} else if checkpointApplies && checkpoint.PendingMutation {
-			// The mutation happened before a controller rebuild/restart. Treat it as
-			// the baseline so this run can satisfy verification/review/sign-off
-			// without manufacturing another write.
-			writer, hasWriter = -1, true
-			deliveryMutation = true
-		} else if checkpointApplies && checkpoint.MutationObserved {
-			deliveryMutation = true
-		}
-		workObserved := a.evidence.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
-		if a.deliveryTaskExpected && !a.deliveryPersistentExpected && !workObserved {
-			out.missingActionEvidence++
-			missing = append(missing, "perform host-observable work for this technical task before answering")
-		}
-		if a.deliveryPersistentExpected && !a.evidence.HasSuccessfulToolReceipt("remember") {
-			out.missingMutation++
-			missing = append(missing, "save the requested durable memory with the remember tool before answering")
-		}
-		if a.deliveryMutationExpected && !deliveryMutation {
-			out.missingMutation++
-			missing = append(missing, "the request requires a state change, but no successful mutation was observed")
-		}
-		if !hasWriter && a.evidence.HasSuccessfulVerificationCommand() {
-			writer, hasWriter = -1, true
-			deliveryVerificationOnly = true
-		}
-		// Required/preferred capability gates apply before the no-writer fast
-		// path below: a user-required Skill/MCP must not be skippable by
-		// answering from ordinary reads alone.
-		if msg := a.capabilityGateFailure(); msg != "" {
-			out.applies = true
-			out.missingCapabilities++
-			missing = append(missing, msg)
-		}
-		if a.deliveryPersistentExpected && !a.deliveryMutationExpected && !a.evidence.HasSuccessfulMutationOtherThan("remember") {
-			// A durable-memory-only request has its own concrete receipt contract.
-			// It must not inherit code-delivery todo/test/diff/review ceremonies;
-			// any unrelated mutation falls through to the full contract below.
-			out.applies = true
-			if len(missing) > 0 {
-				out.reason = strings.Join(missing, "; ")
-			}
-			return out
-		}
-	}
-	if !hasWriter {
-		if len(missing) > 0 {
-			if a.loopGuardAllowsFinal() {
-				return out
-			}
-			out.reason = strings.Join(missing, "; ")
-		}
-		return out
-	}
-	hasProjectChecks := len(a.projectChecks) > 0
-	hasTodoReceipt := a.evidence.HasSuccessfulTodoWrite()
-	if !a.deliveryProfile && !hasProjectChecks && !hasTodoReceipt && len(missing) == 0 {
-		return finalReadinessCheck{}
-	}
-	out.applies = true
-	if a.deliveryProfile {
-		criteriaEstablished := a.deliveryCriteriaEstablished || (checkpointApplies && checkpoint.CriteriaEstablished)
-		if !criteriaEstablished {
-			out.missingAcceptanceCriteria++
-			missing = append(missing, "establish concrete acceptance criteria with todo_write before changing state")
-		}
-		hasCompleteStep := a.evidence.HasSuccessfulCompleteStepAfter(writer)
-		if !hasCompleteStep {
-			out.missingSignoff++
-			missing = append(missing, "call complete_step after the latest mutation")
-		}
-		if !a.evidence.HasSuccessfulDeliverySignoffAfter(writer) {
-			out.missingVerification++
-			missing = append(missing, "run relevant verification after the latest mutation and cite that successful command in complete_step")
-		}
-		if deliveryMutation && !a.evidence.HasSuccessfulReviewAfter(writer) {
-			out.missingReview++
-			missing = append(missing, "inspect the changed result after the latest mutation (read the touched file or run git diff/status)")
-		}
-		if msg := a.deliveryReviewGateFailure(); msg != "" {
-			out.missingReview++
-			missing = append(missing, msg)
-		}
-		// The capability gate already ran before the no-writer fast path above.
-	}
-	for _, check := range a.projectChecks {
-		if deliveryVerificationOnly {
-			break
-		}
-		command := strings.TrimSpace(check.Command)
-		if command == "" {
-			continue
-		}
-		if !a.evidence.HasSuccessfulCommandAfter(command, writer) {
-			out.missingProjectChecks++
-			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
-		}
-	}
-
-	if len(missing) == 0 {
-		return out
-	}
-	if a.loopGuardAllowsFinal() {
-		return out
-	}
-	out.reason = strings.Join(missing, "; ")
-	return out
 }
 
 // DeliveryCheckpoint returns the compact Goal-scoped delivery state. It is safe
@@ -1891,18 +1681,6 @@ func (a *Agent) deliveryMutationCheckpointReady() bool {
 		a.evidence.HasSuccessfulDeliverySignoffAfter(mutation) &&
 		a.evidence.HasSuccessfulReviewAfter(mutation) &&
 		a.deliveryReviewGateFailure() == ""
-}
-
-func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
-	parts := make([]string, 0, len(items))
-	for _, item := range items {
-		label := strings.TrimSpace(item.Content)
-		if label == "" {
-			label = fmt.Sprintf("todo %d", item.Index)
-		}
-		parts = append(parts, fmt.Sprintf("%s: %s", label, item.Status))
-	}
-	return "latest successful todo_write still has incomplete items: " + strings.Join(parts, ", ")
 }
 
 func (a *Agent) setTodoState(todos []evidence.TodoItem) {
@@ -2055,17 +1833,6 @@ func toolResultFailed(content string) bool {
 		strings.HasPrefix(content, "blocked:") ||
 		strings.HasPrefix(content, "Error:") ||
 		strings.HasPrefix(content, "[error")
-}
-
-func finalReadinessCheckSource(check instruction.VerifyCheck) string {
-	source := strings.TrimSpace(check.SourcePath)
-	if source == "" {
-		source = "project memory"
-	}
-	if check.Line > 0 {
-		return fmt.Sprintf("%s:%d", source, check.Line)
-	}
-	return source
 }
 
 func shouldNudgeExecutorHandoff(input, answer string) bool {

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -1,0 +1,249 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/ablation"
+	"reasonix/internal/evidence"
+	"reasonix/internal/instruction"
+)
+
+// Final readiness: whether a turn has earned the right to stop. It reads the
+// evidence ledger, the delivery profile, and the approved plan's contract, and
+// says what is missing rather than merely that something is.
+
+type finalReadinessCheck struct {
+	applies                   bool
+	reason                    string
+	missingProjectChecks      int
+	incompleteTodos           int
+	missingAcceptanceCriteria int
+	missingVerification       int
+	missingReview             int
+	missingSignoff            int
+	missingActionEvidence     int
+	missingMutation           int
+	missingCapabilities       int
+}
+
+func (c finalReadinessCheck) progressSignature() string {
+	return fmt.Sprintf("%d/%d/%d/%d/%d/%d/%d/%d/%d/%d\x00%s",
+		c.missingProjectChecks,
+		c.incompleteTodos,
+		c.missingAcceptanceCriteria,
+		c.missingVerification,
+		c.missingReview,
+		c.missingSignoff,
+		c.missingActionEvidence,
+		c.missingMutation,
+		c.missingCapabilities,
+		boolInt(c.applies),
+		c.reason,
+	)
+}
+
+func (c finalReadinessCheck) missingIDs() []string {
+	missing := make([]string, 0, 9)
+	add := func(id string, count int) {
+		if count > 0 {
+			missing = append(missing, id)
+		}
+	}
+	add("project_check", c.missingProjectChecks)
+	add("todo", c.incompleteTodos)
+	add("criteria", c.missingAcceptanceCriteria)
+	add("verification", c.missingVerification)
+	add("review", c.missingReview)
+	add("signoff", c.missingSignoff)
+	add("action", c.missingActionEvidence)
+	add("mutation", c.missingMutation)
+	add("capability", c.missingCapabilities)
+	return missing
+}
+
+func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recovered bool) evidence.ReadinessAudit {
+	return evidence.ReadinessAudit{
+		Result:                    result,
+		Recovered:                 recovered,
+		MissingProjectChecks:      c.missingProjectChecks,
+		IncompleteTodos:           c.incompleteTodos,
+		CommandMismatchMissing:    c.missingProjectChecks,
+		MissingAcceptanceCriteria: c.missingAcceptanceCriteria,
+		MissingVerification:       c.missingVerification,
+		MissingReview:             c.missingReview,
+		MissingSignoff:            c.missingSignoff,
+		MissingActionEvidence:     c.missingActionEvidence,
+		MissingMutation:           c.missingMutation,
+		MissingCapabilities:       c.missingCapabilities,
+	}
+}
+
+func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
+	if a.evidence == nil || a.ablation.Off(ablation.Evidence) {
+		return finalReadinessCheck{}
+	}
+	var missing []string
+	out := finalReadinessCheck{}
+	// Planning returns a proposal; the controller owns approval and starts a
+	// fresh execution turn, which is where delivery requirements belong. A
+	// workflow boundary only — tool calls still take the usual permission path.
+	if a.planMode.Load() {
+		return out
+	}
+	{
+		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
+		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
+			incomplete, hasTodos = a.incompleteCanonicalTodos()
+		}
+		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
+			out.applies = true
+			out.incompleteTodos = len(incomplete)
+			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+		}
+	}
+	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
+	deliveryMutation := false
+	deliveryVerificationOnly := false
+	checkpoint := a.deliveryCheckpoint
+	checkpointApplies := a.deliveryScopeActive && checkpoint.ScopeID == a.deliveryScopeID
+	if a.deliveryProfile {
+		if mutation, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+			writer, hasWriter = mutation, true
+			deliveryMutation = true
+		} else if checkpointApplies && checkpoint.PendingMutation {
+			// The mutation happened before a controller rebuild/restart. Treat it as
+			// the baseline so this run can satisfy verification/review/sign-off
+			// without manufacturing another write.
+			writer, hasWriter = -1, true
+			deliveryMutation = true
+		} else if checkpointApplies && checkpoint.MutationObserved {
+			deliveryMutation = true
+		}
+		workObserved := a.evidence.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
+		if a.deliveryTaskExpected && !a.deliveryPersistentExpected && !workObserved {
+			out.missingActionEvidence++
+			missing = append(missing, "perform host-observable work for this technical task before answering")
+		}
+		if a.deliveryPersistentExpected && !a.evidence.HasSuccessfulToolReceipt("remember") {
+			out.missingMutation++
+			missing = append(missing, "save the requested durable memory with the remember tool before answering")
+		}
+		if a.deliveryMutationExpected && !deliveryMutation {
+			out.missingMutation++
+			missing = append(missing, "the request requires a state change, but no successful mutation was observed")
+		}
+		if !hasWriter && a.evidence.HasSuccessfulVerificationCommand() {
+			writer, hasWriter = -1, true
+			deliveryVerificationOnly = true
+		}
+		// Required/preferred capability gates apply before the no-writer fast
+		// path below: a user-required Skill/MCP must not be skippable by
+		// answering from ordinary reads alone.
+		if msg := a.capabilityGateFailure(); msg != "" {
+			out.applies = true
+			out.missingCapabilities++
+			missing = append(missing, msg)
+		}
+		if a.deliveryPersistentExpected && !a.deliveryMutationExpected && !a.evidence.HasSuccessfulMutationOtherThan("remember") {
+			// A durable-memory-only request has its own concrete receipt contract.
+			// It must not inherit code-delivery todo/test/diff/review ceremonies;
+			// any unrelated mutation falls through to the full contract below.
+			out.applies = true
+			if len(missing) > 0 {
+				out.reason = strings.Join(missing, "; ")
+			}
+			return out
+		}
+	}
+	if !hasWriter {
+		if len(missing) > 0 {
+			if a.loopGuardAllowsFinal() {
+				return out
+			}
+			out.reason = strings.Join(missing, "; ")
+		}
+		return out
+	}
+	hasProjectChecks := len(a.projectChecks) > 0
+	hasTodoReceipt := a.evidence.HasSuccessfulTodoWrite()
+	if !a.deliveryProfile && !hasProjectChecks && !hasTodoReceipt && len(missing) == 0 {
+		return finalReadinessCheck{}
+	}
+	out.applies = true
+	if a.deliveryProfile {
+		criteriaEstablished := a.deliveryCriteriaEstablished || (checkpointApplies && checkpoint.CriteriaEstablished)
+		if !criteriaEstablished {
+			out.missingAcceptanceCriteria++
+			missing = append(missing, "establish concrete acceptance criteria with todo_write before changing state")
+		}
+		hasCompleteStep := a.evidence.HasSuccessfulCompleteStepAfter(writer)
+		if !hasCompleteStep {
+			out.missingSignoff++
+			missing = append(missing, "call complete_step after the latest mutation")
+		}
+		if !a.evidence.HasSuccessfulDeliverySignoffAfter(writer) {
+			out.missingVerification++
+			missing = append(missing, "run relevant verification after the latest mutation and cite that successful command in complete_step")
+		}
+		if deliveryMutation && !a.evidence.HasSuccessfulReviewAfter(writer) {
+			out.missingReview++
+			missing = append(missing, "inspect the changed result after the latest mutation (read the touched file or run git diff/status)")
+		}
+		if msg := a.deliveryReviewGateFailure(); msg != "" {
+			out.missingReview++
+			missing = append(missing, msg)
+		}
+		// The capability gate already ran before the no-writer fast path above.
+	}
+	for _, check := range a.projectChecks {
+		if deliveryVerificationOnly {
+			break
+		}
+		command := strings.TrimSpace(check.Command)
+		if command == "" {
+			continue
+		}
+		if !a.evidence.HasSuccessfulCommandAfter(command, writer) {
+			out.missingProjectChecks++
+			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
+		}
+	}
+
+	// Before the loop-guard escape on purpose: a criterion the model cannot
+	// prove must still be able to stop asking.
+	outstanding := a.outstandingPlanCriteria()
+	out.missingAcceptanceCriteria += len(outstanding)
+	missing = append(missing, outstanding...)
+	if len(missing) == 0 {
+		return out
+	}
+	if a.loopGuardAllowsFinal() {
+		return out
+	}
+	out.reason = strings.Join(missing, "; ")
+	return out
+}
+
+func finalReadinessCheckSource(check instruction.VerifyCheck) string {
+	source := strings.TrimSpace(check.SourcePath)
+	if source == "" {
+		source = "project memory"
+	}
+	if check.Line > 0 {
+		return fmt.Sprintf("%s:%d", source, check.Line)
+	}
+	return source
+}
+
+func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := strings.TrimSpace(item.Content)
+		if label == "" {
+			label = fmt.Sprintf("todo %d", item.Index)
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", label, item.Status))
+	}
+	return "latest successful todo_write still has incomplete items: " + strings.Join(parts, ", ")
+}

--- a/internal/agent/final_rejection_test.go
+++ b/internal/agent/final_rejection_test.go
@@ -1,0 +1,80 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/plancontract"
+	"reasonix/internal/tool"
+)
+
+func rejectionAgent(t *testing.T, plan *plancontract.Plan) *Agent {
+	t.Helper()
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, nil)
+	a.resetTurnEvidence()
+	a.turnInput = "fix the retry race"
+	a.SetPlanContract(plan)
+	return a
+}
+
+// The gate has to name what is missing. A criterion nobody proved is exactly
+// what "pretending to be done" looks like from the host's side.
+func TestUnprovenPlanCriterionBlocksTheFinalAnswer(t *testing.T) {
+	plan := criterionPlan()
+	a := rejectionAgent(t, &plan)
+	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+
+	outstanding := a.outstandingPlanCriteria()
+	if len(outstanding) == 0 {
+		t.Fatal("a plan whose criteria have no evidence must have something outstanding")
+	}
+	joined := strings.Join(outstanding, "; ")
+	if !strings.Contains(joined, "retries no longer double-charge") {
+		t.Fatalf("outstanding = %v, want the criterion named", outstanding)
+	}
+}
+
+// Once every criterion carries fresh proof the gate must let go, or the model
+// can never finish.
+func TestProvenPlanCriteriaLeaveNothingOutstanding(t *testing.T) {
+	plan := criterionPlan()
+	a := rejectionAgent(t, &plan)
+	for _, c := range plan.Steps[0].Acceptance {
+		a.evidence.Record(completeStepReceipt(t, c.ID, "manual", ""))
+	}
+	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
+		t.Fatalf("outstanding = %v, want none once every criterion is proven", outstanding)
+	}
+}
+
+// Freshness has to survive the trip into the gate: a proof from before the last
+// mutation is not a proof of the current code.
+func TestStaleProofBecomesOutstandingAgain(t *testing.T) {
+	plan := criterionPlan()
+	a := rejectionAgent(t, &plan)
+	for _, c := range plan.Steps[0].Acceptance {
+		a.evidence.Record(completeStepReceipt(t, c.ID, "verification", "go test ./..."))
+	}
+	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
+		t.Fatalf("outstanding = %v, want none while the proofs are fresh", outstanding)
+	}
+
+	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+	outstanding := a.outstandingPlanCriteria()
+	if len(outstanding) == 0 {
+		t.Fatal("a mutation after the proofs must reopen them")
+	}
+	if !strings.Contains(strings.Join(outstanding, "; "), "stale") {
+		t.Fatalf("outstanding = %v, want the staleness said out loud", outstanding)
+	}
+}
+
+// An unplanned turn must not inherit a contract it never agreed to.
+func TestUnplannedTurnHasNoOutstandingCriteria(t *testing.T) {
+	a := rejectionAgent(t, nil)
+	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
+		t.Fatalf("outstanding = %v, want none without an approved plan", outstanding)
+	}
+}

--- a/internal/agent/plan_contract.go
+++ b/internal/agent/plan_contract.go
@@ -111,3 +111,18 @@ func (a *Agent) withContractState(ctx context.Context) context.Context {
 	ctx = evidence.WithTodoState(ctx, a.CanonicalTodoState())
 	return evidence.WithAcceptanceCriteria(ctx, a.acceptanceCriterionIDs())
 }
+
+// outstandingPlanCriteria lists what the approved plan still lacks fresh
+// evidence for, empty when the turn is unplanned. It is the contract's answer to
+// "is this actually done", named criterion by criterion, including proofs that
+// went stale under a later mutation.
+func (a *Agent) outstandingPlanCriteria() []string {
+	if a == nil || a.planContractSnapshot() == nil {
+		return nil
+	}
+	c := a.LiveContract()
+	if c == nil {
+		return nil
+	}
+	return c.Outstanding()
+}

--- a/internal/taskcontract/taskcontract.go
+++ b/internal/taskcontract/taskcontract.go
@@ -548,7 +548,14 @@ func (c *Contract) Outstanding() []string {
 	var out []string
 	for _, req := range c.Requirements {
 		if req.Required && req.Status != Satisfied {
-			out = append(out, fmt.Sprintf("requirement %s: %s", req.ID, req.Text))
+			// Stale is said out loud here as it already is for checks: "verify
+			// it" and "re-verify it because the code moved" are different
+			// instructions, and only one of them is actionable after a change.
+			entry := fmt.Sprintf("requirement %s: %s", req.ID, req.Text)
+			if req.Status == Stale {
+				entry += " (stale: re-verify after the latest mutation)"
+			}
+			out = append(out, entry)
 		}
 	}
 	for _, check := range c.Checks {

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -2,10 +2,10 @@
   "limits": {
     "banner": 15,
     "commented-code": 0,
-    "complexity": 2099,
-    "essay": 4085,
-    "file-size": 110345,
-    "function-size": 9165,
+    "complexity": 2096,
+    "essay": 4082,
+    "file-size": 110104,
+    "function-size": 9159,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
@@ -436,10 +436,10 @@
       "essay": 7
     },
     "internal/agent/agent.go": {
-      "complexity": 61,
-      "essay": 107,
-      "file-size": 2711,
-      "function-size": 125
+      "complexity": 37,
+      "essay": 104,
+      "file-size": 2478,
+      "function-size": 103
     },
     "internal/agent/ask.go": {
       "essay": 4
@@ -508,6 +508,10 @@
       "essay": 4,
       "narrative": 1,
       "test-file-size": 1020
+    },
+    "internal/agent/final_readiness.go": {
+      "complexity": 24,
+      "function-size": 24
     },
     "internal/agent/fleet.go": {
       "essay": 3,
@@ -819,10 +823,10 @@
       "test-file-size": 3596
     },
     "internal/cli/cli.go": {
-      "complexity": 75,
+      "complexity": 72,
       "essay": 60,
-      "file-size": 1951,
-      "function-size": 506
+      "file-size": 1943,
+      "function-size": 498
     },
     "internal/cli/cli_test.go": {
       "essay": 9,


### PR DESCRIPTION
Completes the chain: the contract has known what the work agreed to since #8183, could answer mid-turn since #8193, and became provable in #8201. Nothing consulted it.

## What a turn could get away with

Every delivery ceremony could pass — todos closed, `complete_step` called, verification run after the latest mutation — while a criterion the user approved sat unproven. Those ceremonies check that **steps happened**; they do not check that the **agreed outcome holds**.

`finalReadinessCheckFor` now folds the contract's outstanding criteria into the same `missing` list it already builds. One gate, one `FinalReadinessError`, one host recovery path — the Goal FSM's auto-continue and the recovery card keep working unchanged, which they would not if this were a second parallel refusal.

The existing `missingAcceptanceCriteria` field asked whether criteria were *established*. This asks whether they are *proven*, and names which one.

## Freshness carries through

A proof that went stale under a later mutation reads as outstanding again, so "verified before I changed it" stops counting as verified. `Outstanding()` now annotates a stale requirement the way it already annotated a stale check — *verify it* and *re-verify it, the code moved* are different instructions and only one is actionable.

## Two deliberate limits

- **Only a planned turn contributes.** Without a plan the contract's requirements are the todo list, which the existing checks already cover; an unplanned turn inherits nothing.
- **Placed before the loop-guard escape.** A criterion the model cannot prove — an acceptance line like "P95 under 100ms" — must still be able to stop asking, or it loops forever. The guard that already exists for that keeps working.

## Debt moved, not added

Readiness left `agent.go` for `final_readiness.go`. The baseline update records exactly that move and nothing else:

```
final_readiness.go  complexity   0 -> 24     function-size   0 -> 24
agent.go            complexity  61 -> 37     function-size 125 -> 103
agent.go            file-size 2711 -> 2478   (-233 lines out of the god file)
```

Every category total falls or holds: complexity 2099→2096, file-size 110345→110104, function-size 9165→9159, essay 4085→4082, test-file-size flat.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean, `go test ./...` — 116 packages ok, 0 failures. Golden baseline passes unchanged. Four new tests: an unproven criterion is outstanding and named, proven criteria leave nothing outstanding, a stale proof reopens and says so, and an unplanned turn has nothing outstanding.

Cache-impact: none - internal/agent/agent.go shrinks by an extraction and gains a three-statement call; no prompt text, tool schema, or message assembly changes. The provider-visible prefix is byte-identical.
Cache-guard: internal/boot TestGoldenBaselineNoExtensions passes unchanged, which is the direct evidence that SystemHash, ToolsHash and ToolSchemaTokens are untouched.
Documentation-impact: none - no user-facing surface changes. The gate reuses the existing FinalReadinessError path, so the recovery card and Goal auto-continue render exactly as before, with a more specific reason string.