### PR TITLE
test(agent): reproduce the unbounded read-only runaway

### DIFF
--- a/internal/agent/runaway_outcome_test.go
+++ b/internal/agent/runaway_outcome_test.go
@@ -1,0 +1,146 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type scriptedTool struct {
+	name     string
+	readOnly bool
+}
+
+func (s scriptedTool) Name() string        { return s.name }
+func (s scriptedTool) Description() string { return s.name }
+func (s scriptedTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"command":{"type":"string"}}}`)
+}
+func (s scriptedTool) ReadOnly() bool { return s.readOnly }
+func (s scriptedTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "ok: 12 tests passed\n", nil
+}
+
+type scriptedCall struct {
+	tool string
+	args string
+}
+
+// seriesProvider replays a fixed sequence of tool rounds, one per model round,
+// then finishes. It is the smallest thing that drives real receipts through the
+// real run loop.
+type seriesProvider struct {
+	calls []scriptedCall
+	round atomic.Int32
+}
+
+func (p *seriesProvider) Name() string { return "scripted" }
+
+func (p *seriesProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	i := int(p.round.Add(1)) - 1
+	ch := make(chan provider.Chunk, 4)
+	if i >= len(p.calls) {
+		ch <- provider.Chunk{Type: provider.ChunkText, Text: "Done."}
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+		close(ch)
+		return ch, nil
+	}
+	call := p.calls[i]
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "收到。先收集当前真实状态。"}
+	ch <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+		ID: fmt.Sprintf("call-%d", i), Name: call.tool, Arguments: call.args,
+	}}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func outcomeSeries(t *testing.T, calls []scriptedCall) []evidence.OutcomeSample {
+	t.Helper()
+	sink := &outcomeSeriesSink{}
+	reg := tool.NewRegistry()
+	reg.Add(scriptedTool{name: "read_file", readOnly: true})
+	reg.Add(scriptedTool{name: "edit_file"})
+	reg.Add(scriptedTool{name: "bash"})
+	prov := &seriesProvider{calls: calls}
+	a := New(prov, reg, NewSession("sys"), Options{MaxSteps: 0}, sink)
+	if err := a.Run(context.Background(), "collect the real state, then rewrite HANDOVER.md"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return sink.samples
+}
+
+type outcomeSeriesSink struct{ samples []evidence.OutcomeSample }
+
+func (s *outcomeSeriesSink) Emit(event.Event) {}
+func (s *outcomeSeriesSink) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	s.samples = append(s.samples, sample)
+}
+
+// The measurement the promotion decision needs: run the incident's shape and a
+// real working turn through the same loop, and print what each scorer saw. The
+// legacy gain is one number; the outcome sample is a decomposition, and the
+// question is whether the decomposition separates them where the number cannot.
+func TestOutcomeVersusLegacyOnTheRunawayShape(t *testing.T) {
+	wandering := make([]scriptedCall, 0, 8)
+	for i := range 8 {
+		wandering = append(wandering, scriptedCall{"read_file", fmt.Sprintf(`{"path":"internal/pkg%d/file.go"}`, i)})
+	}
+	realWork := []scriptedCall{
+		{"read_file", `{"path":"internal/agent/agent.go"}`},
+		{"read_file", `{"path":"internal/agent/run_loop.go"}`},
+		{"edit_file", `{"path":"internal/agent/run_loop.go"}`},
+		{"bash", `{"command":"go test ./internal/agent/"}`},
+		{"edit_file", `{"path":"internal/agent/agent.go"}`},
+		{"bash", `{"command":"go test ./internal/agent/"}`},
+	}
+
+	for _, scenario := range []struct {
+		name  string
+		calls []scriptedCall
+	}{{"wandering (the incident)", wandering}, {"real work", realWork}} {
+		samples := outcomeSeries(t, scenario.calls)
+		t.Logf("\n=== %s ===", scenario.name)
+		t.Logf("%-6s %-6s %-6s %-6s %-6s %-6s %-6s %-6s", "round", "legacy", "explor", "verify", "object", "churn", "discrim", "debt")
+		for _, s := range samples {
+			t.Logf("%-6d %-6d %-6d %-6d %-6d %-6d %-6d %-6d",
+				s.Round, s.LegacyGain, s.Exploration, s.Verification, s.Objective, s.Churn, s.Discriminating, s.DebtAge)
+		}
+	}
+
+	// The legacy scorer cannot separate the two: it reports positive gain on
+	// every wandering round, which is exactly why the streak never climbs.
+	for i, s := range outcomeSeries(t, wandering) {
+		if s.LegacyGain <= 0 {
+			t.Fatalf("wandering round %d scored %d; the runaway depends on every round looking like progress", i+1, s.LegacyGain)
+		}
+		if s.Exploration == 0 || s.Discriminating != 0 || s.Churn != 0 || s.Objective != 0 {
+			t.Fatalf("wandering round %d = %+v; the shape under test is exploration and nothing else", i+1, s)
+		}
+	}
+	// The decomposition can: real work reaches a discriminating observation,
+	// and never spends more than two rounds on exploration alone.
+	discriminating, exploreRun, longestExploreRun := 0, 0, 0
+	for _, s := range outcomeSeries(t, realWork) {
+		discriminating += s.Discriminating
+		if s.Exploration > 0 && s.Discriminating == 0 && s.Churn == 0 {
+			exploreRun++
+			longestExploreRun = max(longestExploreRun, exploreRun)
+			continue
+		}
+		exploreRun = 0
+	}
+	if discriminating == 0 {
+		t.Fatal("real work produced no discriminating observation; the contrast is meaningless")
+	}
+	if longestExploreRun >= len(wandering) {
+		t.Fatalf("real work explored for %d rounds straight; it no longer separates from the runaway", longestExploreRun)
+	}
+}

--- a/internal/agent/runaway_repro_test.go
+++ b/internal/agent/runaway_repro_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// readProbe is a read-only tool taking a path, so its receipt is classified the
+// way a real reader's is — Read=true with Paths set — which is what the progress
+// tracker scores as new evidence.
+type readProbe struct{}
+
+func (readProbe) Name() string        { return "read_file" }
+func (readProbe) Description() string { return "read a file" }
+func (readProbe) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`)
+}
+func (readProbe) ReadOnly() bool { return true }
+func (readProbe) Execute(context.Context, json.RawMessage) (string, error) {
+	return "package main\n\nfunc main() {}\n", nil
+}
+
+// wanderingProvider replays the reported runaway: every round restates the same
+// intent and reads one more file. Nothing fails, so the storm breaker stays
+// quiet; nothing repeats, so every round scores as new evidence. sameArg swaps
+// in one fixed path to isolate novelty as the discriminator.
+type wanderingProvider struct {
+	rounds  atomic.Int32
+	max     int32
+	sameArg bool
+}
+
+func (p *wanderingProvider) Name() string { return "wandering" }
+
+func (p *wanderingProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	round := p.rounds.Add(1)
+	ch := make(chan provider.Chunk, 4)
+	if round > p.max {
+		ch <- provider.Chunk{Type: provider.ChunkText, Text: "Done."}
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+		close(ch)
+		return ch, nil
+	}
+	path := fmt.Sprintf("internal/pkg%d/file.go", round)
+	if p.sameArg {
+		path = "HANDOVER.md"
+	}
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "收到。先收集当前真实状态，然后彻底重写 HANDOVER.md。"}
+	ch <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+		ID:        fmt.Sprintf("call-%d", round),
+		Name:      "read_file",
+		Arguments: fmt.Sprintf(`{"path":%q}`, path),
+	}}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func runRunaway(t *testing.T, sameArg bool, maxRounds int32) (guardFired bool, rounds int32) {
+	t.Helper()
+	var fired, maintained atomic.Bool
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice && e.Code == event.NoticeCodeProgressGuard {
+			fired.Store(true)
+		}
+		if e.Kind == event.ContextMaintenanceEvent {
+			maintained.Store(true)
+		}
+	})
+	t.Cleanup(func() {
+		// The repro must not lean on context maintenance: this shape runs away
+		// on its own, so a fix to trimming alone cannot bound it.
+		if maintained.Load() {
+			t.Error("context maintenance ran; the repro is no longer isolated from trimming")
+		}
+	})
+	reg := tool.NewRegistry()
+	reg.Add(readProbe{})
+	prov := &wanderingProvider{max: maxRounds, sameArg: sameArg}
+	// MaxSteps 0 is the shipped default, not a test convenience: [agent].max_steps
+	// was retired and is normalized to zero on load.
+	a := New(prov, reg, NewSession("sys"), Options{MaxSteps: 0}, sink)
+
+	if err := a.Run(context.Background(), "collect the real state, then rewrite HANDOVER.md"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return fired.Load(), prov.rounds.Load()
+}
+
+// The reported runaway, reproduced: a read-only turn that keeps restating one
+// intent while touching a new path each round runs as long as the model keeps
+// talking. Nothing caps the rounds and no guard ever fires.
+func TestReadOnlyWanderingNeverTripsTheProgressGuard(t *testing.T) {
+	const rounds = 40
+	guardFired, ran := runRunaway(t, false, rounds)
+	if ran < rounds {
+		t.Fatalf("the turn ended after %d rounds; the repro needs the uncapped loop", ran)
+	}
+	if guardFired {
+		t.Fatal("the progress guard fired on novel reads, so this shape would have been caught")
+	}
+}
+
+// The contrast that names the discriminator. The identical loop reading one
+// fixed path is caught within a few rounds: novelty, not usefulness, is what
+// the guard measures — and it is the whole difference between a runaway the
+// host stops early and one that burns four hours.
+func TestRepeatedReadTripsTheProgressGuard(t *testing.T) {
+	guardFired, ran := runRunaway(t, true, 40)
+	if !guardFired {
+		t.Fatalf("repeating one read for %d rounds never fired the guard", ran)
+	}
+}


### PR DESCRIPTION
A user report: four hours, 524 requests, 194M tokens, ¥26.98, and the handover document never written. The model kept restating one intent and reading one more file.

#8185 bounded Goal Runs at 16 rounds — but says so explicitly:

> these hard boundaries apply only to active Goal execution; **ordinary chat keeps the existing advisory behavior**

This happened in ordinary chat. These tests are the measurement for that half.

## What they show

Reproduced in 0.01s, no provider, and — deliberately — **no context maintenance at all**. The tests assert zero `ContextMaintenanceEvent`, isolating the shape from the tool-result trimming under separate investigation. It runs away on its own.

| loop | result |
|---|---|
| read a new path each round | 40 rounds, guard silent, turn never self-limits |
| read one fixed path | the same loop, caught within a few rounds |

Novelty is the only variable. `gainNewRead` scores per first-seen path and any positive round resets the streak, so a turn that keeps touching something new can never reach the nudge threshold. Behind it there is no ceiling: `[agent].max_steps` was retired in #6497 and is normalized to zero on load.

Verified on `main-v2` at the commit that already contains #8185.

## The data the promotion decision needs

`TestOutcomeVersusLegacyOnTheRunawayShape` runs the incident's shape and a real working turn through the same loop and records what each scorer saw:

```
=== wandering (the incident) ===
round  legacy explor verify object churn  discrim debt
1..8   1      1      0      0      0      0      0

=== real work ===
1      1      1      0      0      0      0      0    read
2      1      1      0      0      0      0      0    read
3      3      0      0      0      1      0      1    edit
4      1      0      1      0      0      1      0    verify
5      3      0      0      0      1      0      1    edit
6      0      0      1      0      0      1      0    verify
```

The legacy scorer cannot separate them — positive on all eight wandering rounds, identical to real work's opening reads. The decomposition can: the runaway is exploration with **zero** discriminating observations, while real work reaches one within two rounds.

Round 6 is worth its own look: a successful verification scores **legacy gain 0**, because the command is not new. Re-running the tests after a second edit reads as no progress.

## Scope

Tests only, no behaviour changes. Both assert the current gap, so they fail the day either half is closed — which is the point of landing them first.

Documentation-impact: none - tests only; no user-facing surface, command, flag, or rendered output changes.