### PR TITLE
fix(cli): rebuild selection copy from raw markdown without wrap newlines

### DIFF
--- a/internal/cli/copy_selection_test.go
+++ b/internal/cli/copy_selection_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// selectionCopyTestUI builds a chatTUI whose transcript is a set of assistant
+// markdown blocks rendered at the given terminal width, with the wrap cache
+// populated exactly as the viewport would see it.
+func selectionCopyTestUI(t *testing.T, width int, raws ...string) chatTUI {
+	t.Helper()
+	defer restoreThemeForTest(activeColorProfile, activeCLITheme)
+	activeColorProfile = colorprofile.NoTTY
+	configureCLITheme("dark")
+
+	m := newTestChatTUI()
+	m.width = width + 4
+	contentWidth := transcriptContentWidth(m.width, m.nativeScrollback)
+	m.viewport.SetWidth(contentWidth)
+	for _, raw := range raws {
+		source := transcriptSource{kind: transcriptSourceMarkdown, raw: raw}
+		m.transcript = append(m.transcript, m.renderTranscriptSource(source, m.width))
+		m.transcriptSources = append(m.transcriptSources, source)
+	}
+	for i := range m.transcript {
+		m.wrapBlockLines = append(m.wrapBlockLines, wrapBlockLines(m.transcript[i], contentWidth))
+	}
+	m.wrappedLines = flattenBlockWraps(m.wrapBlockLines)
+	return m
+}
+
+func findDisplayLine(m chatTUI, substr string) int {
+	for i, line := range m.wrappedLines {
+		if strings.Contains(ansi.Strip(line), substr) {
+			return i
+		}
+	}
+	return -1
+}
+
+func selectAll(m *chatTUI) {
+	last := len(m.wrappedLines) - 1
+	m.sel = selection{
+		active: true,
+		anchor: selPos{line: 0, col: 0},
+		head:   selPos{line: last, col: ansi.StringWidth(m.wrappedLines[last])},
+	}
+}
+
+// A long command wrapped across several display rows must copy as a single
+// logical line — no display wrap newline may reach the clipboard.
+func TestCopySelectionLongCommandStaysSingleLine(t *testing.T) {
+	cmd := "npx skills add @stablyai/skills --agent cursor --agent codex --agent claude-code --agent grok --agent reasonix -y"
+	for _, width := range []int{40, 50, 160} {
+		m := selectionCopyTestUI(t, width, cmd)
+		startLine, endLine := findDisplayLine(m, "npx skills"), findDisplayLine(m, "reasonix -y")
+		if startLine < 0 || endLine < 0 {
+			t.Fatalf("width %d: command rows not found", width)
+		}
+		if endLine > startLine {
+			// Wrapped: selecting the whole command must yield one logical line.
+			m.sel = selection{
+				active: true,
+				anchor: selPos{line: startLine, col: 0},
+				head:   selPos{line: endLine, col: ansi.StringWidth(m.wrappedLines[endLine])},
+			}
+		} else {
+			m.sel = selection{active: true, anchor: selPos{line: startLine, col: 0}, head: selPos{line: endLine, col: ansi.StringWidth(m.wrappedLines[endLine])}}
+		}
+		got := m.selectedText()
+		if strings.Count(got, "\n") != 0 {
+			t.Errorf("width %d: command copied with %d newlines: %q", width, strings.Count(got, "\n"), got)
+		}
+		if !strings.Contains(got, cmd) {
+			t.Errorf("width %d: copied command = %q, want to contain %q", width, got, cmd)
+		}
+	}
+}
+
+// Real newlines inside a fenced code block are source semantics and must be
+// preserved; only display wrap newlines are removed.
+func TestCopySelectionPreservesFenceNewlines(t *testing.T) {
+	m := selectionCopyTestUI(t, 40, "Here is the command:\n\n```\ncat <<'EOF' > /tmp/x\necho hello\nEOF\n```\n\nDone.")
+	startLine := findDisplayLine(m, "cat <<")
+	endLine := -1
+	for i, line := range m.wrappedLines {
+		if strings.TrimRight(ansi.Strip(line), " ") == "  │ EOF" {
+			endLine = i
+		}
+	}
+	if startLine < 0 || endLine < 0 {
+		t.Fatalf("fence rows not found:\n%s", m.wrappedContentString())
+	}
+	m.sel = selection{
+		active: true,
+		anchor: selPos{line: startLine, col: 0},
+		head:   selPos{line: endLine, col: ansi.StringWidth(m.wrappedLines[endLine])},
+	}
+	got := m.selectedText()
+	for _, want := range []string{"cat <<'EOF' > /tmp/x", "echo hello", "EOF"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("fence copy missing %q:\n%q", want, got)
+		}
+	}
+	if got := strings.Count(got, "\n"); got != 2 {
+		t.Errorf("fence copy has %d newlines, want 2 (one per real code line break):\n%q", got, got)
+	}
+}
+
+// Partial-row selection maps display columns back to unwrapped source text.
+func TestCopySelectionPartialRow(t *testing.T) {
+	cmd := "npx skills add @stablyai/skills --agent cursor --agent codex --agent claude-code --agent grok --agent reasonix -y"
+	m := selectionCopyTestUI(t, 40, cmd)
+	line := findDisplayLine(m, "codex")
+	if line < 0 {
+		t.Fatalf("codex display row not found:\n%s", m.wrappedContentString())
+	}
+	plain := ansi.Strip(m.wrappedLines[line])
+	lo := strings.Index(plain, "codex")
+	if lo < 0 {
+		t.Fatalf("codex not in row %q", plain)
+	}
+	m.sel = selection{active: true, anchor: selPos{line: line, col: lo}, head: selPos{line: line, col: lo + len("codex")}}
+	if got, want := m.selectedText(), "codex"; got != want {
+		t.Errorf("partial selection = %q, want %q", got, want)
+	}
+}
+
+// A selection spanning two transcript blocks keeps both blocks' content.
+func TestCopySelectionAcrossBlocks(t *testing.T) {
+	m := selectionCopyTestUI(t, 40, "Block one content.", "Block two content.")
+	selectAll(&m)
+	got := m.selectedText()
+	for _, want := range []string{"◆ Reasonix", "Block one content.", "Block two content."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("cross-block copy missing %q:\n%q", want, got)
+		}
+	}
+}
+
+// Paragraph spacing and list structure survive the copy rebuild.
+func TestCopySelectionKeepsStructure(t *testing.T) {
+	m := selectionCopyTestUI(t, 40, "First para.\n\n- item one\n- item two\n\nSecond para.")
+	selectAll(&m)
+	got := m.selectedText()
+	for _, want := range []string{"First para.", "• item one", "• item two", "Second para."} {
+		if !strings.Contains(got, want) {
+			t.Errorf("structure copy missing %q:\n%q", want, got)
+		}
+	}
+	if !strings.Contains(got, "First para.\n\n") || !strings.Contains(got, "item two\n\n  Second para.") {
+		t.Errorf("paragraph blank lines lost:\n%q", got)
+	}
+}
+
+// Without transcript sources the semantic rebuild is unavailable and the
+// fallback still yields the exact displayed rows.
+func TestCopySelectionFallbackDisplayRows(t *testing.T) {
+	m := newTestChatTUI()
+	m.wrappedLines = []string{"hello world", "second line", "third row"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 6}, head: selPos{line: 2, col: 5}}
+	if got, want := m.selectedText(), "world\nsecond line\nthird"; got != want {
+		t.Errorf("fallback selection = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/md.go
+++ b/internal/cli/md.go
@@ -27,6 +27,39 @@ type mdRenderer struct {
 	copyMath       bool
 	copyMathPrefix string
 	nextCopyMathID int
+	copyNoWrap     bool
+	copyRows       []mdCopyRow
+}
+
+// mdCopyRow is one semantic output row of a copy-mode render plus the rows it
+// expands to on the display layer. bases[j] is the semantic-text column of the
+// first visible character of display row j, so a screen selection can be
+// translated back to unwrapped source text without carrying wrap newlines.
+type mdCopyRow struct {
+	text  string
+	rows  []string
+	bases []int
+}
+
+// recordCopyRow appends one semantic row with its display mapping.
+func (r *mdRenderer) recordCopyRow(row mdCopyRow) {
+	r.copyRows = append(r.copyRows, row)
+}
+
+// blankCopyRow is the mapping for an empty semantic row (a blank display row).
+func blankCopyRow() mdCopyRow {
+	return mdCopyRow{rows: []string{""}, bases: []int{0}}
+}
+
+// copyRowBases derives per-row semantic column offsets from display widths.
+func copyRowBases(rows []string) []int {
+	bases := make([]int, len(rows))
+	acc := 0
+	for i, row := range rows {
+		bases[i] = acc
+		acc += ansi.StringWidth(row)
+	}
+	return bases
 }
 
 func newMarkdownRenderer(width int) *mdRenderer {
@@ -76,24 +109,34 @@ func (r *mdRenderer) Render(input string) string {
 // zero-width internal markers. The markers are consumed only when the user
 // copies a transcript selection, so display wrapping and selection coordinates
 // stay identical without maintaining a second raw transcript.
-func (r *mdRenderer) RenderCopy(input, prefix string) string {
+func (r *mdRenderer) RenderCopy(input, prefix string) (string, []mdCopyRow) {
 	if strings.TrimSpace(input) == "" {
-		return ""
+		return "", nil
 	}
 	input = fixCJKEmphasis(normalizeMath(input))
 	src := []byte(input)
 	doc := r.md.Parser().Parse(text.NewReader(src))
 	var buf strings.Builder
 	r.copyMath = true
+	r.copyNoWrap = true
 	r.copyMathPrefix = prefix
 	r.nextCopyMathID = 0
+	r.copyRows = nil
 	r.renderBlocks(&buf, doc, src, 0)
 	r.copyMath = false
+	r.copyNoWrap = false
 	out := strings.TrimRight(buf.String(), "\n")
-	if out == "" {
-		return ""
+	// copyRows holds one entry per written line; TrimRight drops trailing blank
+	// lines, so trim the tail entries by the line-count difference.
+	if removed := strings.Count(buf.String(), "\n") - (strings.Count(out, "\n") + 1); removed > 0 {
+		r.copyRows = r.copyRows[:len(r.copyRows)-removed]
 	}
-	return out + "\n"
+	if out == "" {
+		return "", nil
+	}
+	rows := r.copyRows
+	r.copyRows = nil
+	return out + "\n", rows
 }
 
 // fixCJKEmphasis works around goldmark's CommonMark parser not recognising
@@ -216,9 +259,12 @@ func (r *mdRenderer) renderBlock(buf *strings.Builder, node ast.Node, src []byte
 		r.renderTable(buf, n, src, indent)
 	case *ast.ThematicBreak:
 		w := max(r.width-indent, 8)
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString(dim(strings.Repeat("─", w)))
-		buf.WriteString("\n\n")
+		row := strings.Repeat(" ", indent) + dim(strings.Repeat("─", w))
+		r.recordCopyRow(mdCopyRow{text: row, rows: []string{row}, bases: []int{0}})
+		buf.WriteString(row)
+		buf.WriteString("\n")
+		r.recordCopyRow(blankCopyRow())
+		buf.WriteString("\n")
 	default:
 		// Unknown block: drop into children rather than dropping content.
 		r.renderBlocks(buf, node, src, indent)
@@ -227,17 +273,21 @@ func (r *mdRenderer) renderBlock(buf *strings.Builder, node ast.Node, src []byte
 
 func (r *mdRenderer) renderHeading(buf *strings.Builder, n *ast.Heading, src []byte, indent int) {
 	inline := r.collectInline(n, src)
-	buf.WriteString(strings.Repeat(" ", indent))
-	buf.WriteString(bold(accent(inline)))
+	ind := strings.Repeat(" ", indent)
+	head := ind + bold(accent(inline))
+	r.recordCopyRow(mdCopyRow{text: head, rows: []string{head}, bases: []int{0}})
+	buf.WriteString(head)
 	buf.WriteString("\n")
 	// Level-1 headings get an accent underline; deeper levels rely on
 	// bold+colour alone so the hierarchy reads at a glance without piling
 	// on visual weight on every "###" in a long response.
 	if n.Level == 1 {
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString(accent(strings.Repeat("─", visibleWidth(inline))))
+		rule := ind + accent(strings.Repeat("─", visibleWidth(inline)))
+		r.recordCopyRow(mdCopyRow{text: rule, rows: []string{rule}, bases: []int{0}})
+		buf.WriteString(rule)
 		buf.WriteString("\n")
 	}
+	r.recordCopyRow(blankCopyRow())
 	buf.WriteString("\n")
 }
 
@@ -252,6 +302,21 @@ func (r *mdRenderer) renderTextBlock(buf *strings.Builder, n *ast.TextBlock, src
 func (r *mdRenderer) renderInlineBlock(buf *strings.Builder, n ast.Node, src []byte, indent int, trailingBlank bool) {
 	inline := r.collectInline(n, src)
 	prefix := strings.Repeat(" ", indent)
+	if r.copyNoWrap {
+		rows := strings.Split(wrapAnsi(inline, r.width-indent), "\n")
+		for i := range rows {
+			rows[i] = prefix + rows[i]
+		}
+		r.recordCopyRow(mdCopyRow{text: prefix + inline, rows: rows, bases: copyRowBases(rows)})
+		buf.WriteString(prefix)
+		buf.WriteString(inline)
+		buf.WriteString("\n")
+		if trailingBlank {
+			r.recordCopyRow(blankCopyRow())
+			buf.WriteString("\n")
+		}
+		return
+	}
 	wrapped := wrapAnsi(inline, r.width-indent)
 	for line := range strings.SplitSeq(wrapped, "\n") {
 		buf.WriteString(prefix)
@@ -277,8 +342,6 @@ func (r *mdRenderer) renderList(buf *strings.Builder, n *ast.List, src []byte, i
 		} else {
 			marker = "•"
 		}
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString(accent(marker) + " ")
 		markerW := visibleWidth(marker) + 1
 
 		first := item.FirstChild()
@@ -288,21 +351,45 @@ func (r *mdRenderer) renderList(buf *strings.Builder, n *ast.List, src []byte, i
 		inlineHost := inlineCarrier(first)
 		if inlineHost != nil {
 			inline := r.collectInline(inlineHost, src)
-			wrapped := wrapAnsi(inline, r.width-indent-markerW)
-			lines := strings.Split(wrapped, "\n")
-			buf.WriteString(lines[0] + "\n")
-			for _, l := range lines[1:] {
-				buf.WriteString(strings.Repeat(" ", indent+markerW))
-				buf.WriteString(l + "\n")
+			if r.copyNoWrap {
+				head := strings.Repeat(" ", indent) + accent(marker) + " " + inline
+				lines := strings.Split(wrapAnsi(inline, r.width-indent-markerW), "\n")
+				rows := make([]string, 0, len(lines))
+				bases := make([]int, 0, len(lines))
+				contBase := visibleWidth(strings.Repeat(" ", indent)) + markerW
+				for i, l := range lines {
+					if i == 0 {
+						rows = append(rows, strings.Repeat(" ", indent)+accent(marker)+" "+l)
+						bases = append(bases, 0)
+					} else {
+						rows = append(rows, strings.Repeat(" ", indent+markerW)+l)
+						bases = append(bases, contBase)
+					}
+				}
+				r.recordCopyRow(mdCopyRow{text: head, rows: rows, bases: bases})
+				buf.WriteString(head)
+				buf.WriteString("\n")
+			} else {
+				buf.WriteString(strings.Repeat(" ", indent))
+				buf.WriteString(accent(marker) + " ")
+				wrapped := wrapAnsi(inline, r.width-indent-markerW)
+				lines := strings.Split(wrapped, "\n")
+				buf.WriteString(lines[0] + "\n")
+				for _, l := range lines[1:] {
+					buf.WriteString(strings.Repeat(" ", indent+markerW))
+					buf.WriteString(l + "\n")
+				}
 			}
 			for s := first.NextSibling(); s != nil; s = s.NextSibling() {
 				r.renderBlock(buf, s, src, indent+markerW)
 			}
 		} else {
+			r.recordCopyRow(blankCopyRow())
 			buf.WriteString("\n")
 			r.renderBlocks(buf, item, src, indent+2)
 		}
 	}
+	r.recordCopyRow(blankCopyRow())
 	buf.WriteString("\n")
 }
 
@@ -311,22 +398,38 @@ func (r *mdRenderer) renderFenced(buf *strings.Builder, n ast.Node, src []byte, 
 	for i := range n.Lines().Len() {
 		l := n.Lines().At(i)
 		line := strings.TrimRight(string(l.Value(src)), "\n")
-		buf.WriteString(prefix)
-		buf.WriteString(accent(line))
+		row := prefix + accent(line)
+		r.recordCopyRow(mdCopyRow{text: row, rows: []string{row}, bases: []int{0}})
+		buf.WriteString(row)
 		buf.WriteString("\n")
 	}
+	r.recordCopyRow(blankCopyRow())
 	buf.WriteString("\n")
 }
 
 func (r *mdRenderer) renderBlockquote(buf *strings.Builder, n *ast.Blockquote, src []byte, indent int) {
 	var inner strings.Builder
+	rowsStart := len(r.copyRows)
 	r.renderBlocks(&inner, n, src, 0)
 	prefix := strings.Repeat(" ", indent) + dim("▎ ")
-	for line := range strings.SplitSeq(strings.TrimRight(inner.String(), "\n"), "\n") {
+	innerStr := inner.String()
+	trimmed := strings.TrimRight(innerStr, "\n")
+	removed := strings.Count(innerStr, "\n") - strings.Count(trimmed, "\n")
+	// Inner rows already carry the semantic text; re-prefix them so the
+	// recorded mapping stays aligned with the ▎-prefixed output lines.
+	r.copyRows = r.copyRows[:len(r.copyRows)-removed]
+	for i := rowsStart; i < len(r.copyRows); i++ {
+		r.copyRows[i].text = prefix + r.copyRows[i].text
+		for j := range r.copyRows[i].rows {
+			r.copyRows[i].rows[j] = prefix + r.copyRows[i].rows[j]
+		}
+	}
+	for line := range strings.SplitSeq(trimmed, "\n") {
 		buf.WriteString(prefix)
 		buf.WriteString(dim(line))
 		buf.WriteString("\n")
 	}
+	r.recordCopyRow(blankCopyRow())
 	buf.WriteString("\n")
 }
 
@@ -461,18 +564,22 @@ func (r *mdRenderer) renderTable(buf *strings.Builder, n *extast.Table, src []by
 
 	if len(header) > 0 {
 		r.renderTableRow(buf, prefix, sep, header, widths, true)
-		buf.WriteString(prefix)
+		var rule strings.Builder
+		rule.WriteString(prefix)
 		for i := range widths {
 			if i > 0 {
-				buf.WriteString(dim("─┼─"))
+				rule.WriteString(dim("─┼─"))
 			}
-			buf.WriteString(dim(strings.Repeat("─", widths[i])))
+			rule.WriteString(dim(strings.Repeat("─", widths[i])))
 		}
+		r.recordCopyRow(mdCopyRow{text: rule.String(), rows: []string{rule.String()}, bases: []int{0}})
+		buf.WriteString(rule.String())
 		buf.WriteByte('\n')
 	}
 	for _, row := range rows {
 		r.renderTableRow(buf, prefix, sep, row, widths, false)
 	}
+	r.recordCopyRow(blankCopyRow())
 	buf.WriteByte('\n')
 }
 
@@ -493,6 +600,72 @@ func (r *mdRenderer) renderTableRow(buf *strings.Builder, prefix, sep string, ce
 		if len(wrapped[i]) > maxLines {
 			maxLines = len(wrapped[i])
 		}
+	}
+	if r.copyNoWrap {
+		// Semantic row: unwrapped cell text joined by rails, no column padding.
+		// Display rows still mirror the visible padded layout so selection
+		// coordinates translate back (pad columns map approximately).
+		var sem strings.Builder
+		sem.WriteString(prefix)
+		cellBase := make([]int, cols)
+		acc := 0
+		for i := range cols {
+			cellBase[i] = acc
+			acc += 3 // rail " │ "
+			if i < len(cells) {
+				acc += visibleWidth(cells[i])
+			}
+		}
+		for i := range cols {
+			if i > 0 {
+				sem.WriteString(" │ ")
+			}
+			if i < len(cells) {
+				sem.WriteString(cells[i])
+			}
+		}
+		rowsOut := make([]string, maxLines)
+		bases := make([]int, maxLines)
+		for line := range maxLines {
+			var b strings.Builder
+			b.WriteString(prefix)
+			for i := range cols {
+				if i > 0 {
+					b.WriteString(sep)
+				}
+				var cell string
+				if line < len(wrapped[i]) {
+					cell = wrapped[i][line]
+				}
+				padded := padRight(cell, widths[i])
+				if isHeader {
+					padded = bold(padded)
+				}
+				b.WriteString(padded)
+			}
+			rowsOut[line] = b.String()
+			for i := range cols {
+				var seg string
+				if line < len(wrapped[i]) {
+					seg = wrapped[i][line]
+				}
+				if seg == "" {
+					continue
+				}
+				segCol := 0
+				for t := 0; t < line && t < len(wrapped[i]); t++ {
+					segCol += visibleWidth(wrapped[i][t])
+				}
+				bases[line] = cellBase[i] + segCol
+				break
+			}
+		}
+		r.recordCopyRow(mdCopyRow{text: sem.String(), rows: rowsOut, bases: bases})
+		for line := range maxLines {
+			buf.WriteString(rowsOut[line])
+			buf.WriteByte('\n')
+		}
+		return
 	}
 	for line := range maxLines {
 		buf.WriteString(prefix)

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -13,6 +13,9 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/i18n"
 	"reasonix/internal/provider"
 )
 
@@ -133,17 +136,103 @@ func (m chatTUI) renderReplayBundle(
 	return strings.TrimRight(b.String(), "\n")
 }
 
+// copyBlock is one transcript block's copy rendition: the semantic text (for
+// markdown blocks, free of display wrap newlines) plus the display-row mapping
+// used to translate a screen selection back to that text.
+type copyBlock struct {
+	text string
+	rows []mdCopyRow
+}
+
+// textRows splits display text into its logical rows: every newline-terminated
+// segment counts as a row (including blank rows), while a trailing newline is
+// only a terminator and adds no row of its own.
+func textRows(block string) []string {
+	if block == "" {
+		return []string{""}
+	}
+	return strings.Split(strings.TrimSuffix(block, "\n"), "\n")
+}
+
+// splitCopyRows maps display-rendered text onto 1:1 copy rows. Used for blocks
+// whose only rendition is the wrapped display text (user bubbles, tool cards,
+// reasoning, banners): their copy semantics are the display rows themselves.
+func splitCopyRows(block string) []mdCopyRow {
+	lines := textRows(block)
+	rows := make([]mdCopyRow, len(lines))
+	for i, l := range lines {
+		rows[i] = mdCopyRow{text: l, rows: []string{l}, bases: []int{0}}
+	}
+	return rows
+}
+
 func (m chatTUI) renderReplayBundleCopy(
 	source transcriptSource,
 	contentWidth int,
 	prefix string,
-) string {
+) copyBlock {
+	var b strings.Builder
+	var rows []mdCopyRow
+	banner := renderTUIBanner(m.label, source.raw, contentWidth)
+	b.WriteString(banner)
+	rows = append(rows, splitCopyRows(banner)...)
+
+	// Mirror replaySectionsForWithAssistantRenderer so the copy rendition and
+	// its display mapping stay in lockstep; assistant markdown sections use the
+	// unwrapped copy renderer, everything else its wrapped display text.
 	assistantIndex := 0
-	return m.renderReplayBundle(source, contentWidth, func(raw string, width int) string {
-		messagePrefix := prefix + "-" + strconv.Itoa(assistantIndex)
+	appendSection := func(text string) {
+		b.WriteString(text)
+		rows = append(rows, splitCopyRows(text)...)
+	}
+	appendAssistant := func(body string) {
+		blk := renderAssistantMarkdownCopy(body, contentWidth, prefix+"-"+strconv.Itoa(assistantIndex))
 		assistantIndex++
-		return renderAssistantMarkdownCopy(raw, width, messagePrefix)
-	})
+		b.WriteString(blk.text + "\n\n")
+		rows = append(rows, blk.rows...)
+		rows = append(rows, blankCopyRow())
+	}
+	for _, msg := range source.history {
+		if msg.LocalOnly {
+			if reasoning := strings.TrimSpace(msg.ReasoningContent); reasoning != "" {
+				appendSection(dim("  ▎ "+i18n.M.ChatThinking) + "\n" + reasoningBlock(reasoning, contentWidth, 0) + "\n\n")
+			}
+			if body := strings.TrimSpace(msg.Content); body != "" {
+				appendAssistant(body)
+			}
+			for _, call := range msg.ToolCalls {
+				appendSection(toolCard(call.Name, "", contentWidth) + "\n\n")
+			}
+			if msg.InterruptedTurn != nil {
+				appendSection("  · " + interruptedTurnDisplayNotice() + "\n\n")
+			}
+			continue
+		}
+		switch msg.Role {
+		case provider.RoleUser:
+			if steerText, isSteer := agent.SteerText(msg.Content); isSteer {
+				appendSection("  ↪ " + steerText + "\n\n")
+				continue
+			}
+			content := control.StripComposePrefixes(msg.Content)
+			appendSection(renderUserBubble(content, contentWidth, false) + "\n\n")
+		case provider.RoleAssistant:
+			if reasoning := strings.TrimSpace(msg.ReasoningContent); reasoning != "" {
+				appendSection(dim("  ▎ "+i18n.M.ChatThinking) + "\n" + reasoningBlock(reasoning, contentWidth, 0) + "\n\n")
+			}
+			if body := strings.TrimSpace(msg.Content); body != "" {
+				appendAssistant(body)
+			}
+			for _, call := range msg.ToolCalls {
+				appendSection(toolCard(call.Name, call.Arguments, contentWidth) + "\n\n")
+			}
+		}
+	}
+	text := strings.TrimRight(b.String(), "\n")
+	if segs := strings.Count(text, "\n") + 1; len(rows) > segs {
+		rows = rows[:segs]
+	}
+	return copyBlock{text: text, rows: rows}
 }
 
 const assistantTranscriptIndent = "  "
@@ -172,9 +261,11 @@ func renderAssistantMarkdown(raw string, contentWidth int) string {
 	return header + "\n\n" + indentTranscriptBlock(body, indent)
 }
 
-// renderAssistantMarkdownCopy mirrors renderAssistantMarkdown's visible output
-// and adds zero-width math markers for on-demand clipboard reconstruction.
-func renderAssistantMarkdownCopy(raw string, contentWidth int, prefix string) string {
+// renderAssistantMarkdownCopy mirrors renderAssistantMarkdown's visible output,
+// renders it without display wrap newlines, and adds zero-width math markers for
+// on-demand clipboard reconstruction. The returned rows carry the display-layer
+// expansion of each semantic row so selection coordinates still translate.
+func renderAssistantMarkdownCopy(raw string, contentWidth int, prefix string) copyBlock {
 	contentWidth = max(contentWidth, 1)
 	indent := assistantTranscriptIndent
 	if contentWidth <= visibleWidth(indent) {
@@ -182,16 +273,40 @@ func renderAssistantMarkdownCopy(raw string, contentWidth int, prefix string) st
 	}
 	bodyWidth := max(contentWidth-visibleWidth(indent), 1)
 	renderer := newMarkdownRenderer(bodyWidth)
-	rendered := renderer.RenderCopy(raw, prefix)
+	rendered, rows := renderer.RenderCopy(raw, prefix)
 	if rendered == "" {
 		rendered = raw
+		rows = splitCopyRows(raw)
 	}
 	body := strings.TrimRight(rendered, "\n")
+	if segs := strings.Count(body, "\n") + 1; len(rows) > segs {
+		rows = rows[:segs]
+	}
 	header := indent + accent("◆") + " " + bold("Reasonix")
 	if body == "" {
-		return header
+		return copyBlock{text: header, rows: []mdCopyRow{{text: header, rows: []string{header}, bases: []int{0}}}}
 	}
-	return header + "\n\n" + indentTranscriptBlock(body, indent)
+	// Re-apply the two-cell gutter the display layer adds to non-blank rows;
+	// the semantic-column offsets are unaffected (both sides shift equally).
+	for i := range rows {
+		if rows[i].text == "" {
+			continue
+		}
+		rows[i].text = indent + rows[i].text
+		for j := range rows[i].rows {
+			if rows[i].rows[j] != "" {
+				rows[i].rows[j] = indent + rows[i].rows[j]
+			}
+		}
+	}
+	all := make([]mdCopyRow, 0, len(rows)+2)
+	all = append(all, mdCopyRow{text: header, rows: []string{header}, bases: []int{0}})
+	all = append(all, blankCopyRow())
+	all = append(all, rows...)
+	return copyBlock{
+		text: header + "\n\n" + indentTranscriptBlock(body, indent),
+		rows: all,
+	}
 }
 
 func indentTranscriptBlock(block, indent string) string {
@@ -255,32 +370,34 @@ func copyMathEndMarker(id string) string {
 }
 
 // buildCopyTranscript renders semantic Markdown only when a copy is requested.
-// The visible text stays byte-for-byte equivalent after ANSI stripping, while
-// math markers retain the source needed to map display cells back to LaTeX.
-func (m chatTUI) buildCopyTranscript(contentWidth int) (string, int, bool) {
+// The text is the copy source (no display wrap newlines for markdown blocks);
+// rows track each semantic row's display expansion so a screen selection can be
+// mapped back. math markers retain the source needed to reconstruct LaTeX.
+func (m chatTUI) buildCopyTranscript(contentWidth int) (string, []mdCopyRow, int, bool) {
 	if len(m.transcriptSources) != len(m.transcript) {
-		return "", 0, false
+		return "", nil, 0, false
 	}
 	var b strings.Builder
+	var rows []mdCopyRow
 	markers := 0
 	for i, source := range m.transcriptSources {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
+		var blk copyBlock
 		switch source.kind {
 		case transcriptSourceMarkdown:
-			rendered := renderAssistantMarkdownCopy(source.raw, contentWidth, strconv.Itoa(i))
-			markers += strings.Count(rendered, copyMathStartPrefix)
-			b.WriteString(rendered)
+			blk = renderAssistantMarkdownCopy(source.raw, contentWidth, strconv.Itoa(i))
 		case transcriptSourceReplayBundle:
-			rendered := m.renderReplayBundleCopy(source, contentWidth, strconv.Itoa(i))
-			markers += strings.Count(rendered, copyMathStartPrefix)
-			b.WriteString(rendered)
+			blk = m.renderReplayBundleCopy(source, contentWidth, strconv.Itoa(i))
 		default:
-			b.WriteString(m.transcript[i])
+			blk = copyBlock{text: m.transcript[i], rows: splitCopyRows(m.transcript[i])}
 		}
+		markers += strings.Count(blk.text, copyMathStartPrefix)
+		b.WriteString(blk.text)
+		rows = append(rows, blk.rows...)
 	}
-	return b.String(), markers, true
+	return b.String(), rows, markers, true
 }
 
 // transcriptResizeAnchor identifies the transcript block at the top of the
@@ -520,9 +637,14 @@ type copyMathSpan struct {
 	source string
 }
 
+// copyTranscriptLine is one semantic copy row: unwrapped source text (still
+// carrying copy-math markers and ANSI), its in-row math spans, and the display
+// rows it expands to (display[j] with semantic column offset bases[j]).
 type copyTranscriptLine struct {
-	text string
-	math []copyMathSpan
+	text    string
+	math    []copyMathSpan
+	display []string
+	bases   []int
 }
 
 type activeCopyMath struct {
@@ -622,22 +744,106 @@ func parseCopyTranscript(wrapped string) ([]copyTranscriptLine, int, bool) {
 	return lines, parsedMarkers, true
 }
 
+// copyTranscriptLines builds the semantic copy rendition of the transcript and
+// validates it against the wrapped display lines: row count and, per display
+// row, the ANSI-stripped text must match exactly, so selection coordinates are
+// trustworthy before selectedCopyText consumes them.
 func (m chatTUI) copyTranscriptLines() ([]copyTranscriptLine, bool) {
 	contentWidth := m.viewport.Width()
-	marked, expectedMarkers, ok := m.buildCopyTranscript(contentWidth)
-	if !ok {
+	marked, rows, expectedMarkers, ok := m.buildCopyTranscript(contentWidth)
+	if !ok || len(rows) != strings.Count(marked, "\n")+1 {
 		return nil, false
 	}
-	lines, parsedMarkers, ok := parseCopyTranscript(wrapTranscript(marked, contentWidth))
-	if !ok || parsedMarkers != expectedMarkers || len(lines) != len(m.wrappedLines) {
+	lines := make([]copyTranscriptLine, 0, len(rows))
+	var display []string
+	markers := 0
+	for _, row := range rows {
+		parsed, parsedMarkers, ok := parseCopyTranscript(row.text)
+		if !ok || len(parsed) != 1 {
+			return nil, false
+		}
+		markers += parsedMarkers
+		dl, mdBases := expandCopyRow(row, contentWidth)
+		bases := semanticBases(row.text, dl, mdBases)
+		lines = append(lines, copyTranscriptLine{text: row.text, math: parsed[0].math, display: dl, bases: bases})
+		display = append(display, dl...)
+	}
+	if markers != expectedMarkers || len(display) != len(m.wrappedLines) {
 		return nil, false
 	}
-	for i := range lines {
-		if ansi.Strip(lines[i].text) != ansi.Strip(m.wrappedLines[i]) {
+	for i := range display {
+		if ansi.Strip(display[i]) != ansi.Strip(m.wrappedLines[i]) {
 			return nil, false
 		}
 	}
 	return lines, true
+}
+
+// expandCopyRow soft-wraps each recorded display row (the lipgloss pass the
+// display layer applies after the md renderer), returning the viewport rows and
+// their md-layer semantic column offsets (used when matching is ambiguous).
+func expandCopyRow(row mdCopyRow, width int) ([]string, []int) {
+	var out []string
+	var bases []int
+	for j, r := range row.rows {
+		sub := strings.Split(wrapTranscript(r, width), "\n")
+		acc := 0
+		for _, s := range sub {
+			out = append(out, s)
+			bases = append(bases, row.bases[j]+acc)
+			acc += ansi.StringWidth(s)
+		}
+	}
+	return out, bases
+}
+
+// semanticBases returns, for every display row, the visual column at which the
+// row's first character maps back into the semantic text. Word-wrapping drops
+// the break-point space, so a plain width prefix sum is off by one per break;
+// matching each row fragment against the unwrapped text absorbs that. The
+// per-row indent the display layer repeats on every line is tolerated by
+// trimming it off before matching and subtracting it from the offset. Rows
+// whose fragment cannot be matched (e.g. padded table rails) fall back to the
+// md-layer offset.
+func semanticBases(text string, display []string, mdBases []int) []int {
+	t := []rune(ansi.Strip(text))
+	bases := make([]int, len(display))
+	pos := 0
+	for i, d := range display {
+		frag := strings.TrimRight(ansi.Strip(d), " ")
+		if frag == "" {
+			bases[i] = pos
+			continue
+		}
+		cand := []rune(frag)
+		skip := 0
+		if cand[0] == ' ' {
+			trimmed := []rune(strings.TrimLeft(frag, " "))
+			skip = len(cand) - len(trimmed)
+			cand = trimmed
+		}
+		if idx := indexRunes(t, cand, pos); idx >= 0 {
+			bases[i] = max(idx-skip, 0)
+			pos = idx + len(cand)
+			continue
+		}
+		bases[i] = mdBases[i]
+	}
+	return bases
+}
+
+// indexRunes finds sub in s at or after from, in rune space.
+func indexRunes(s, sub []rune, from int) int {
+	if from < 0 || from > len(s) {
+		return -1
+	}
+	s = s[from:]
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if string(s[i:i+len(sub)]) == string(sub) {
+			return from + i
+		}
+	}
+	return -1
 }
 
 func selectedDisplayText(lines []string, start, end selPos) string {
@@ -655,51 +861,82 @@ func selectedDisplayText(lines []string, start, end selPos) string {
 	return strings.Join(out, "\n")
 }
 
+// selectedCopyText maps the display-cell selection back to semantic rows: each
+// selected viewport row resolves to a semantic row plus a column range, and the
+// output is rebuilt from the unwrapped source text so no display wrap newline
+// leaks into the clipboard.
 func selectedCopyText(lines []copyTranscriptLine, start, end selPos) string {
 	seen := make(map[string]bool)
 	var out []string
-	for idx := start.line; idx <= end.line && idx < len(lines); idx++ {
-		line := lines[idx]
-		lo, hi := 0, ansi.StringWidth(line.text)
-		if idx == start.line {
-			lo = start.col
-		}
-		if idx == end.line {
-			hi = end.col
-		}
-
-		var selected strings.Builder
-		cursor := lo
-		touchedMath := false
-		for _, span := range line.math {
-			if span.end <= lo || span.start >= hi {
-				continue
+	visLine := 0 // global display-line index of the first display row of lines[i]
+	for _, line := range lines {
+		firstVis := visLine
+		lastVis := visLine + len(line.display) - 1
+		if lastVis >= start.line && firstVis <= end.line && len(line.display) > 0 {
+			width := ansi.StringWidth(line.text)
+			var a, b int
+			if start.line >= firstVis {
+				a = line.bases[start.line-firstVis] + start.col
 			}
-			touchedMath = true
-			if span.start > cursor {
-				selected.WriteString(ansi.Strip(ansi.Cut(line.text, cursor, min(span.start, hi))))
+			if end.line <= lastVis {
+				b = line.bases[end.line-firstVis] + end.col
+			} else {
+				b = width
 			}
-			if !seen[span.id] {
-				selected.WriteString(span.source)
-				seen[span.id] = true
+			a = max(a, 0)
+			b = min(b, width)
+			if line.text == "" {
+				out = append(out, "")
+			} else if a < b || mathSpanOverlaps(line.math, a, b) {
+				out = append(out, selectCopyRange(line, a, b, seen))
 			}
-			cursor = max(cursor, min(span.end, hi))
 		}
-		if cursor < hi {
-			selected.WriteString(ansi.Strip(ansi.Cut(line.text, cursor, hi)))
-		}
-		if selected.Len() == 0 && touchedMath {
-			continue
-		}
-		out = append(out, strings.TrimRight(selected.String(), " "))
+		visLine = lastVis + 1
 	}
 	return strings.Join(out, "\n")
 }
 
+func mathSpanOverlaps(spans []copyMathSpan, a, b int) bool {
+	for _, span := range spans {
+		if span.end > a && span.start < b {
+			return true
+		}
+	}
+	return false
+}
+
+func selectCopyRange(line copyTranscriptLine, a, b int, seen map[string]bool) string {
+	var selected strings.Builder
+	cursor := a
+	touchedMath := false
+	for _, span := range line.math {
+		if span.end <= a || span.start >= b {
+			continue
+		}
+		touchedMath = true
+		if span.start > cursor {
+			selected.WriteString(ansi.Strip(ansi.Cut(line.text, cursor, min(span.start, b))))
+		}
+		if !seen[span.id] {
+			selected.WriteString(span.source)
+			seen[span.id] = true
+		}
+		cursor = max(cursor, min(span.end, b))
+	}
+	if cursor < b {
+		selected.WriteString(ansi.Strip(ansi.Cut(line.text, cursor, b)))
+	}
+	if selected.Len() == 0 && touchedMath {
+		return ""
+	}
+	return strings.TrimRight(selected.String(), " ")
+}
+
 // selectedText is the plain text of the active display-cell selection. Math is
 // reconstructed on demand from semantic transcript sources; if the marked copy
-// rendition ever diverges from the visible transcript, the safe fallback keeps
-// the exact displayed text rather than applying mismatched coordinates.
+// rendition ever diverges from the visible transcript, the fallback rebuilds
+// whole markdown blocks from their unwrapped source and only resorts to the
+// exact displayed rows for partial blocks and non-markdown content.
 func (m chatTUI) selectedText() string {
 	if !m.sel.active || m.sel.empty() {
 		return ""
@@ -708,7 +945,42 @@ func (m chatTUI) selectedText() string {
 	if lines, ok := m.copyTranscriptLines(); ok {
 		return selectedCopyText(lines, start, end)
 	}
-	return selectedDisplayText(m.wrappedLines, start, end)
+	return m.selectedFallbackText(start, end)
+}
+
+func (m chatTUI) selectedFallbackText(start, end selPos) string {
+	if len(m.wrapBlockLines) == 0 || len(m.transcriptSources) != len(m.wrapBlockLines) {
+		return selectedDisplayText(m.wrappedLines, start, end)
+	}
+	contentWidth := m.viewport.Width()
+	var out []string
+	vis := 0
+	for i := range m.wrapBlockLines {
+		blockVis := len(m.wrapBlockLines[i])
+		blockStart, blockEnd := vis, vis+blockVis-1
+		if blockEnd >= start.line && blockStart <= end.line {
+			inLo := max(start.line-blockStart, 0)
+			inHi := min(end.line-blockStart, blockVis-1)
+			full := inLo == 0 && inHi == blockVis-1
+			if full && m.transcriptSources[i].kind == transcriptSourceMarkdown {
+				blk := renderAssistantMarkdownCopy(m.transcriptSources[i].raw, contentWidth, strconv.Itoa(i))
+				out = append(out, blk.text)
+			} else {
+				for idx := blockStart + inLo; idx <= blockStart+inHi && idx < len(m.wrappedLines); idx++ {
+					lo, hi := 0, ansi.StringWidth(m.wrappedLines[idx])
+					if idx == start.line {
+						lo = start.col
+					}
+					if idx == end.line {
+						hi = end.col
+					}
+					out = append(out, strings.TrimRight(ansi.Strip(ansi.Cut(m.wrappedLines[idx], lo, hi)), " "))
+				}
+			}
+		}
+		vis = blockEnd + 1
+	}
+	return strings.Join(out, "\n")
 }
 
 // scrollbarThumb returns the thumb's [start, start+size) row span for a viewport

--- a/internal/cli/transcript_test.go
+++ b/internal/cli/transcript_test.go
@@ -323,27 +323,32 @@ func TestSelectedTextRestoresMathWrappedAcrossDisplayLinesOnce(t *testing.T) {
 	if !ok {
 		t.Fatal("copy rendition diverged from the displayed transcript")
 	}
-	firstLine, lastLine := -1, -1
-	firstCol, lastCol := 0, 0
+	// The formula now sits on a single semantic row that spans several display
+	// rows; locate that row and its display-row span.
+	firstVis, idx := -1, -1
+	visLine := 0
 	for i, line := range copyLines {
-		if len(line.math) == 0 {
-			continue
+		if len(line.math) > 0 {
+			firstVis, idx = visLine, i
+			break
 		}
-		if firstLine < 0 {
-			firstLine = i
-			firstCol = line.math[0].start
-		}
-		lastLine = i
-		lastCol = line.math[len(line.math)-1].end
+		visLine += len(line.display)
 	}
-	if firstLine < 0 || lastLine <= firstLine {
-		t.Fatalf("expected formula to wrap across lines:\n%s", ansi.Strip(rendered))
+	if idx < 0 {
+		t.Fatalf("rendered transcript did not contain the formula:\n%s", ansi.Strip(rendered))
 	}
+	line := copyLines[idx]
+	if len(line.display) <= 1 {
+		t.Fatalf("expected formula to wrap across display lines:\n%s", ansi.Strip(rendered))
+	}
+	lastVis := firstVis + len(line.display) - 1
+	firstCol := max(line.math[0].start-line.bases[0], 0)
+	lastCol := min(line.math[len(line.math)-1].end-line.bases[len(line.bases)-1], ansi.StringWidth(line.display[len(line.display)-1]))
 
 	m.sel = selection{
 		active: true,
-		anchor: selPos{line: firstLine, col: firstCol},
-		head:   selPos{line: lastLine, col: lastCol},
+		anchor: selPos{line: firstVis, col: firstCol},
+		head:   selPos{line: lastVis, col: lastCol},
 	}
 	if got, want := m.selectedText(), `$`+latex+`$`; got != want {
 		t.Fatalf("wrapped formula selection = %q, want %q", got, want)


### PR DESCRIPTION
## 现象

在 Reasonix TUI 里鼠标拖选 AI 回复中的一条长命令复制，粘贴进 `zsh` 后被断成多条命令执行失败（`zsh: command not found: code` 之类）。断点出现在 hyphen（`--agent` 断成 `--` + `agent`）和超宽单词中间。

复现样例：

```
npx skills add @stablyai/skills --agent cursor --agent codex --agent claude-code --agent grok --agent reasonix -y
```

## 根因（一句话）

显示层为了折行往渲染输出里插入真实 `\n`（`mdRenderer` 的 `wrapAnsi` 在 hyphen/超宽处硬断 + `wrapTranscript`/lipgloss 二次软断），而复制路径 `RenderCopy → copyTranscriptLines` 复用同一份已断行的渲染文本，复制出来的内容因此带渲染折行 `\n`。

## 复现步骤

1. 把终端宽度收到 ~50 列。
2. 渲染一条含上述长命令的普通段落消息（**不要**放在代码块里——代码块本来不硬断）。
3. 鼠标拖选整段复制，`pbpaste | cat -A` 可见命令中间出现行尾 `$`（即被插入 `\n`）。

## 改动范围

- `internal/cli/md.go`：`mdRenderer` 增加 copy 模式（`copyNoWrap`）——复制渲染时段落/列表/表格不再 `wrapAnsi` 硬断，产出无渲染折行的语义文本；同时记录每个语义行在显示层的展开行与语义列偏移（`mdCopyRow`）。显示渲染分支零改动。
- `internal/cli/transcript.go`：复制路径重构为按块重建——`renderAssistantMarkdownCopy`/`renderReplayBundleCopy`/`buildCopyTranscript` 返回语义文本 + 显示映射；`copyTranscriptLines` 不再对语义副本调用 `wrapTranscript`（lipgloss 软断），改用 `expandCopyRow` + `semanticBases` 把屏幕选中行/列映射回语义文本后裁剪。校验（行数 + strip 逐行一致）保留，失败时 fallback 优先整块语义文本而非硬断显示文本。
- `internal/cli/transcript_test.go` / `internal/cli/copy_selection_test.go`：更新/新增测试。

显示层零改动：`wrap_cache.go`、viewport 滚动/滚动条/点击定位、`wrappedLines` 行数语义均未触碰。

## 为什么不用现有 copyTranscriptLines

现有路径被 `wrapTranscript`（lipgloss 软断）和渲染层 `wrapAnsi` 双重插入 `\n`；且它要求语义副本 wrap 后的行数与显示层逐行一致，校验失败时 fallback 到更糟的硬断显示文本——两条路都带断行。改后复制文本从原始 markdown 重建（无 wrap 断点），显示映射只用于把选中坐标翻译回语义文本。

## 验收清单

1. ✅ 长命令复制后为**单行**（cat -A 等效：命令中间无行尾 `$`）——40/50/160 列均验证（`TestCopySelectionLongCommandStaysSingleLine`）。
2. ✅ 粘贴进 zsh = 一条命令（由单行性保证；手工验证方法见下）。
3. ✅ 代码块内多行复制后换行原样保留（`TestCopySelectionPreservesFenceNewlines`）。
4. ✅ 多条消息、段落间空行、有序/无序列表复制后结构换行保留（`TestCopySelectionAcrossBlocks` / `TestCopySelectionKeepsStructure`）。
5. ✅ 数学公式复制语义不回归（`copyMath` 标记路径，`TestSelectedTextRestoresMath*` 全绿）。
6. ✅ 显示层零回归：`wrap_cache.go` / `chat_tui.go` 未改动，`go test ./...` 全绿。
7. ✅ 窄 40 列 / 宽 160 列双验证（同 1）。

## pbpaste | cat -A 前后对比

改前（复现，`--agent` 处出现行尾 `$`）：

```
npx skills add @stablyai/skills --agent cursor --$
agent codex --agent claude-code --agent grok --$
agent reasonix -y$
```

改后（单行，无中间 `$`）：

```
  npx skills add @stablyai/skills --agent cursor --agent codex --agent claude-code --agent grok --agent reasonix -y
```

整条消息复制（cat -A 等效，命令单行 + 代码块/列表/段落换行保留）：

```
  ◆ Reasonix$
$
  Run this:$
$
  npx skills add @stablyai/skills --agent cursor --agent codex --agent claude-code --agent grok --agent reasonix -y$
$
  │ cat <<'EOF' > /tmp/x$
  │ echo hello$
  │ EOF$
$
  • item one$
  • item two
```

## 手工 TUI 验证方法

`go run ./cmd/reasonix` 打开 TUI，宽度收到 ~50 列，渲染含长命令的回复后拖选复制，`pbpaste | cat -A` 应无中间行尾 `$`。

---

Documentation-impact: none - 复制行为修复不改变文档描述的 CLI 用法，无需更新 docs。
