### PR TITLE
fix(control): give an ordinary chat turn a Run ceiling

### DIFF
--- a/internal/control/chat_run_budget_test.go
+++ b/internal/control/chat_run_budget_test.go
@@ -1,0 +1,91 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// wanderingChatProvider never stops on its own: every round reads one more
+// path, so nothing repeats and the adaptive guards stay silent. It is the
+// reported runaway's shape, driven through the controller rather than the agent.
+type wanderingChatProvider struct{ calls atomic.Int32 }
+
+func (p *wanderingChatProvider) Name() string { return "wandering" }
+
+func (p *wanderingChatProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	round := p.calls.Add(1)
+	ch := make(chan provider.Chunk, 4)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "收到。先收集当前真实状态。"}
+	ch <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+		ID:        fmt.Sprintf("call-%d", round),
+		Name:      "read_file",
+		Arguments: fmt.Sprintf(`{"path":"internal/pkg%d/file.go"}`, round),
+	}}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+// An ordinary chat turn had no Run ceiling: [agent].max_steps was retired and
+// normalized to zero, and the adaptive guards escalate on repetition, so a loop
+// that keeps reading something new ran until the user noticed. The backstop
+// bounds it without truncating the work — the turn ends with one tool-free
+// summary and stays resumable.
+func TestOrdinaryChatTurnStopsAtTheRunBackstop(t *testing.T) {
+	dir := t.TempDir()
+	prov := &wanderingChatProvider{}
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "read_file"})
+	exec := agent.New(prov, reg, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	sink, done, _ := collectSink()
+	c := New(Options{
+		Runner:      exec,
+		Executor:    exec,
+		Sink:        sink,
+		SessionDir:  dir,
+		SessionPath: filepath.Join(dir, "s.jsonl"),
+	})
+	defer c.autosaveWG.Wait()
+
+	c.Submit("collect the real state, then rewrite HANDOVER.md")
+	waitForDone(t, done)
+
+	// One committed sample per bounded round, then the single tool-free
+	// finalization the limit allows.
+	if got, want := prov.calls.Load(), int32(chatRunRoundLimit+1); got != want {
+		t.Fatalf("provider rounds = %d, want %d (%d bounded rounds plus one summary)", got, want, chatRunRoundLimit)
+	}
+}
+
+// The backstop must not touch a turn the user bounded explicitly.
+func TestExplicitMaxStepsOwnsTheOrdinaryTurn(t *testing.T) {
+	dir := t.TempDir()
+	prov := &wanderingChatProvider{}
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "read_file"})
+	exec := agent.New(prov, reg, agent.NewSession("sys"), agent.Options{MaxSteps: 3}, event.Discard)
+	sink, done, _ := collectSink()
+	c := New(Options{
+		Runner:      exec,
+		Executor:    exec,
+		Sink:        sink,
+		SessionDir:  dir,
+		SessionPath: filepath.Join(dir, "s.jsonl"),
+	})
+	defer c.autosaveWG.Wait()
+
+	c.Submit("collect the real state")
+	waitForDone(t, done)
+
+	if got := prov.calls.Load(); got != 4 {
+		t.Fatalf("provider rounds = %d, want the explicit 3 plus one summary", got)
+	}
+}

--- a/internal/control/run_ceiling.go
+++ b/internal/control/run_ceiling.go
@@ -1,0 +1,32 @@
+package control
+
+import (
+	"context"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/tool"
+)
+
+// chatRunRoundLimit bounds one ordinary chat Run. Crossing it yields one
+// tool-free summary and a resumable pause, so setting it too low costs a
+// "continue" while leaving it unset costs hours.
+const (
+	chatRunRoundLimit = 100
+	chatRunRoundKey   = "chat model rounds"
+)
+
+// bindTurnScope installs the turn's Run ceiling and, for a Goal turn, the usage
+// recorder whose span stays active until the FSM commits. Ordinary chat had no
+// ceiling: max_steps was retired, and the adaptive guards cannot stand in —
+// they escalate on repetition and stay silent while a loop keeps finding
+// something new. An explicit max_steps still owns either turn.
+func (c *Controller) bindTurnScope(ctx context.Context, continuation *goalContinuationSnapshot) context.Context {
+	goalScopeID, goalScoped := c.goals.goalScopeIDForTurn(continuation)
+	if !goalScoped {
+		return agent.WithDefaultRunStepLimit(ctx, chatRunRoundLimit, chatRunRoundKey)
+	}
+	ctx = agent.WithDefaultRunStepLimit(ctx, goalRunRoundLimit, goalRunRoundKey)
+	recorder := c.goals.newTurnRecorder(goalScopeID, c.goals.continuationToken())
+	c.goalUsageTee.setActiveRecorder(recorder)
+	return tool.WithGoalTurnRecorder(ctx, recorder)
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -280,12 +280,7 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	// events during the turn fold into the goal's observational token total. The span stays
 	// active until the FSM commits (advanceGoalAfterTurn) so evaluator usage
 	// also counts; error paths that skip the FSM clear it explicitly.
-	if goalScopeID, ok := c.goals.goalScopeIDForTurn(continuation); ok {
-		ctx = agent.WithDefaultRunStepLimit(ctx, goalRunRoundLimit, goalRunRoundKey)
-		recorder := c.goals.newTurnRecorder(goalScopeID, c.goals.continuationToken())
-		ctx = tool.WithGoalTurnRecorder(ctx, recorder)
-		c.goalUsageTee.setActiveRecorder(recorder)
-	}
+	ctx = c.bindTurnScope(ctx, continuation)
 	modelInput := input
 	if !turn.synthetic {
 		modelInput = c.withCapabilityRoute(ctx, input, turn.raw)


### PR DESCRIPTION
A user report: four hours, 524 requests, 194M tokens, ¥26.98, and the handover document never written. Every round the turn read one more file and restated the same intent.

## The gap

#8185 bounded Goal Runs at 16 rounds and said so precisely:

> these hard boundaries apply only to active Goal execution; **ordinary chat keeps the existing advisory behavior**

Ordinary chat had nothing. `[agent].max_steps` was retired in #6497 — normalized to zero on load and removed from user TOML by a one-time migration — and the run loop reads `runMaxSteps <= 0` as no ceiling at all:

```go
for step := 0; state.runMaxSteps <= 0 || step < state.runMaxSteps || ...; step++ {
```

The adaptive guards were the stated replacement and cannot cover this. They escalate on **consecutive zero-gain** rounds, while `gainNewRead` scores every first-seen path, so a loop that keeps touching something new resets the streak before it can climb. #8225 reproduces exactly that in 0.01s, with **zero context maintenance**, so it is not a symptom of the tool-result trimming under separate investigation.

## What changed

One line of policy, reusing #8185's mechanism rather than adding a parallel one:

- same `WithDefaultRunStepLimit`, so an explicit `max_steps` still wins, child agents still inherit, and crossing the line still yields **one tool-free summary and a resumable pause** rather than a truncated turn
- a Goal turn keeps its tighter 16
- 100 is a runaway backstop, not a budget: real work stays far under it, being wrong costs one "continue", leaving it unset costs hours

The Goal recorder setup moved with it into `bindTurnScope`, so "what bounds this turn" lives in one place and `runOrchestratedTurn` **shrinks** rather than grows — it was already 180 lines against a 120 ceiling.

## What this does not fix

The guard's blind spot. #8225's reproduction still passes on this branch, by design: it isolates the *guard*, and this PR closes the *ceiling*. Making a wandering loop actually register as stalled is the separate change — the outcome decomposition already separates the two shapes where the legacy scorer cannot, and #8225 records that measurement.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean with no baseline change, `go test ./...` — 116 packages ok. Two new control tests: an ordinary turn stops at the ceiling plus one summary round, and an explicitly configured `max_steps` still owns the turn.

Documentation-impact: none - no user-facing surface changes. The ceiling is host-owned with no configuration key, and crossing it reuses the existing resumable-pause path users already see from Goal runs.

Cache-impact: none - the diff adds a context value and moves the Goal recorder setup into a helper. No prompt text, tool schema, or message assembly is touched, so the provider-visible prefix is byte-identical.
Cache-guard: internal/boot TestGoldenBaselineNoExtensions passes unchanged, which is the direct evidence that SystemHash, ToolsHash and ToolSchemaTokens are untouched.
