### PR TITLE
test: two CI flakes, both a fixed budget standing in for "wait until settled"

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-dom-harness.tsx
+++ b/desktop/frontend/src/__tests__/transcript-dom-harness.tsx
@@ -175,7 +175,11 @@ export async function createTranscriptHarness(options: TranscriptHarnessOptions 
     }
   };
 
-  const waitFor = async (condition: () => boolean, description: string, attempts = 8) => {
+  // Each attempt costs one 30ms flush, so the default is a three-second budget,
+  // not eight tries. It returns the moment the condition holds, so a generous
+  // cap is free on the happy path and only makes a genuine failure slower —
+  // which beats failing a correct test on a loaded runner.
+  const waitFor = async (condition: () => boolean, description: string, attempts = 100) => {
     for (let i = 0; i < attempts; i += 1) {
       if (condition()) return;
       await flush();

--- a/internal/control/inbox_test.go
+++ b/internal/control/inbox_test.go
@@ -207,7 +207,10 @@ func TestThirtySteersApplyAndAckExactlyOnce(t *testing.T) {
 		}
 	}
 	close(prov.release)
-	waitForDone(t, done)
+	// Thirty durable round trips are real filesystem work; a loaded Windows
+	// runner spends most of the default five seconds before the turn is even
+	// released. This asserts exactly-once acknowledgement, not latency.
+	waitForDoneWithin(t, done, 60*time.Second)
 
 	if items := c.InboxSnapshot().Items; len(items) != 0 {
 		t.Fatalf("accepted steers were not all acknowledged: %+v", items)


### PR DESCRIPTION
Two intermittent CI failures, same shape one layer apart: a **fixed budget standing in for "wait until settled"**. Both fail on PRs that cannot have caused them, and both pass on rerun.

## Go — `TestThirtySteersApplyAndAckExactlyOnce`

Failed on #8203 (which changed a single JSON data file) and #8222. The Windows job log names it:

```
--- FAIL: TestThirtySteersApplyAndAckExactlyOnce (18.64s)
    inbox_test.go:210: timed out waiting for TurnDone
```

Not a race — twelve local `-race` runs pass, and the repo's `race` job was green on every PR that saw it. Thirty durable enqueue/steer round trips are real filesystem work; on a loaded Windows runner they burn ~13.6s **before** `prov.release` closes, so `waitForDone`'s fixed 5s expires on arrival. 13.6 + 5 ≈ the reported 18.64s.

The test asserts exactly-once acknowledgement, not latency. `waitForDoneWithin` already exists; assertions unchanged.

## Frontend — transcript harness

Failed the `desktop` job on #8228, a Go-only change to `internal/control`:

```
Error: timed out waiting for the pre-prepend anchor row to remount
```

```ts
const waitFor = async (..., attempts = 8) => { ... await flush() }
const flush   = async () => { await act(() => sleep(30)) }
```

Eight attempts *reads* like a retry count. It is a **240ms deadline**. Remounting fifteen rows after a prepend does not reliably finish inside that on a loaded runner — and the `desktop` job was green on the three PRs before it.

`waitFor` returns the moment the condition holds, so a larger cap is free on the happy path and only makes a genuine failure slower.

## Why these are worth a PR

A test that fails on unrelated changes and passes on rerun costs more than the CI minutes: it teaches everyone to re-run red instead of reading it. This repo has already been bitten from the other direction — the cross-boundary gate published a **failing commit status** while every workflow reported success, which is exactly the kind of thing you miss once you have learned to skim red.

## Verification

Go side: `gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean with no baseline change, `go test ./internal/control/` green, the target test run with `-count=3`.

Frontend side is **not verified locally** — this workspace has no `node_modules` and installing needs network. The change cannot turn a passing test red (a wider retry cap converts a timeout into a pass, or into the same failure later), so CI is the appropriate verifier here.

Documentation-impact: none - test-only changes; no user-facing surface, command, flag, or rendered output changes.