### PR TITLE
fix(evidence): exploration stops counting once it stops leading anywhere

### DIFF
--- a/internal/agent/runaway_outcome_test.go
+++ b/internal/agent/runaway_outcome_test.go
@@ -115,15 +115,25 @@ func TestOutcomeVersusLegacyOnTheRunawayShape(t *testing.T) {
 		}
 	}
 
-	// The legacy scorer cannot separate the two: it reports positive gain on
-	// every wandering round, which is exactly why the streak never climbs.
+	// Exploration counts while it might still lead somewhere and then stops, so
+	// the ladder can finally climb. Both halves matter: never decaying is the
+	// runaway, decaying at once would nudge ordinary investigation.
+	scored, decayed := 0, 0
 	for i, s := range outcomeSeries(t, wandering) {
-		if s.LegacyGain <= 0 {
-			t.Fatalf("wandering round %d scored %d; the runaway depends on every round looking like progress", i+1, s.LegacyGain)
-		}
 		if s.Exploration == 0 || s.Discriminating != 0 || s.Churn != 0 || s.Objective != 0 {
 			t.Fatalf("wandering round %d = %+v; the shape under test is exploration and nothing else", i+1, s)
 		}
+		if s.LegacyGain > 0 {
+			scored++
+			continue
+		}
+		decayed++
+	}
+	if scored == 0 {
+		t.Fatal("exploration stopped counting immediately; ordinary investigation would be nudged on arrival")
+	}
+	if decayed == 0 {
+		t.Fatal("a look-only run never stopped counting as progress; the ladder can never climb")
 	}
 	// The decomposition can: real work reaches a discriminating observation,
 	// and never spends more than two rounds on exploration alone.

--- a/internal/agent/runaway_repro_test.go
+++ b/internal/agent/runaway_repro_test.go
@@ -94,17 +94,13 @@ func runRunaway(t *testing.T, sameArg bool, maxRounds int32) (guardFired bool, r
 	return fired.Load(), prov.rounds.Load()
 }
 
-// The reported runaway, reproduced: a read-only turn that keeps restating one
-// intent while touching a new path each round runs as long as the model keeps
-// talking. Nothing caps the rounds and no guard ever fires.
-func TestReadOnlyWanderingNeverTripsTheProgressGuard(t *testing.T) {
-	const rounds = 40
-	guardFired, ran := runRunaway(t, false, rounds)
-	if ran < rounds {
-		t.Fatalf("the turn ended after %d rounds; the repro needs the uncapped loop", ran)
-	}
-	if guardFired {
-		t.Fatal("the progress guard fired on novel reads, so this shape would have been caught")
+// The reported runaway: a read-only turn restating one intent while touching a
+// new path each round. It used to score positive gain forever, so the ladder
+// could never climb; reading is progress only while it leads somewhere.
+func TestReadOnlyWanderingTripsTheProgressGuard(t *testing.T) {
+	guardFired, ran := runRunaway(t, false, 40)
+	if !guardFired {
+		t.Fatalf("wandering for %d rounds never reached the no-progress ladder", ran)
 	}
 }
 

--- a/internal/evidence/progress.go
+++ b/internal/evidence/progress.go
@@ -17,6 +17,11 @@ const (
 	gainRepeatFailure = -2
 )
 
+// explorationRunLimit is how many consecutive look-only rounds still count as
+// progress. Deep investigation rarely runs longer before touching something;
+// a wandering loop runs until someone notices.
+const explorationRunLimit = 6
+
 // ProgressTracker scores each tool round's receipts for new evidence so the
 // agent can react to stalled investigation adaptively instead of at a fixed
 // round count. State is per user turn, like the ledger it observes.
@@ -25,6 +30,7 @@ type ProgressTracker struct {
 	commandRuns map[string]bool
 	commandFail map[string]bool
 	actionSigs  map[string]bool
+	exploreRun  int
 }
 
 func NewProgressTracker() *ProgressTracker {
@@ -37,16 +43,36 @@ func NewProgressTracker() *ProgressTracker {
 }
 
 // ScoreRound folds one round's receipts into the tracker and returns the
-// round's evidence gain.
+// round's evidence gain. Reading something new is progress only while it leads
+// somewhere: past explorationRunLimit look-only rounds the novelty stops
+// counting, because a loop that keeps opening files it has never opened scored
+// positive every round and so could never reach the no-progress ladder.
 func (t *ProgressTracker) ScoreRound(receipts []Receipt) int {
 	if t == nil {
 		return 0
 	}
 	gain := 0
+	acted := false
 	for _, r := range receipts {
 		gain += t.scoreReceipt(r)
+		acted = acted || roundActedOn(r)
+	}
+	if acted {
+		t.exploreRun = 0
+		return gain
+	}
+	t.exploreRun++
+	if t.exploreRun > explorationRunLimit {
+		return 0
 	}
 	return gain
+}
+
+// roundActedOn reports whether a receipt did something other than look: a
+// mutation, or any command run. Either one means the exploration led somewhere
+// and the run starts over.
+func roundActedOn(r Receipt) bool {
+	return r.Mutation || r.Write || strings.TrimSpace(r.Command) != ""
 }
 
 func (t *ProgressTracker) scoreReceipt(r Receipt) int {


### PR DESCRIPTION
The judgement half of the runaway reported in #8225. #8228 is the ceiling half; neither replaces the other.

## Why the guard never fired

The no-progress ladder escalates on **consecutive zero-gain** rounds, and `gainNewRead` scores every first-seen path:

```go
if g.tracker.ScoreRound(receipts) > 0 { g.streak = 0 } else { g.streak++ }
```

A turn that keeps opening files it has never opened scored positive on every round, reset the streak on every round, and could never reach the first rung. That is how the reported turn read for four hours across 524 requests without writing the document it was asked for.

## The change

Reading something new is progress *while it might still lead somewhere*. Past six consecutive rounds that read and did nothing else, the novelty stops counting. Any mutation or command in a round starts the run over, so an ordinary read → read → edit → verify rhythm is untouched.

## The measurement, not the argument

`TestOutcomeVersusLegacyOnTheRunawayShape` records both shapes through the real run loop.

Before — the incident and real work's opening reads are **indistinguishable**:

```
wandering   1..8   legacy=1
real work   1..2   legacy=1
```

After — the run decays, real work is unchanged because its longest look-only run is two:

```
wandering   1..6   legacy=1
            7..8   legacy=0     <- the ladder can finally climb
real work   unchanged
```

`TestReadOnlyWanderingNeverTripsTheProgressGuard`, landed in #8225 to record the gap, inverts to `TestReadOnlyWanderingTripsTheProgressGuard`. The comparison test now pins **both** sides of the threshold: never decaying is the runaway, decaying at once would nudge ordinary investigation on arrival.

## Scope

Deliberately not promoting `OutcomeTracker` to drive the guard. The decomposition separates these shapes and the shadow is already instrumented, but promoting it changes every escalation decision at once; this changes one scoring rule and the whole repository's 116 packages pass unchanged.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean with no baseline change, `go test ./...` — 116 packages ok, 0 failures.

Documentation-impact: none - no user-facing surface changes. The guard's escalation text and thresholds are unchanged; only what counts as a zero-gain round moves.