### PR TITLE
feat(plancontract): compare two revisions instead of two strings

### DIFF
--- a/internal/agent/plan_submission.go
+++ b/internal/agent/plan_submission.go
@@ -14,6 +14,7 @@ import (
 type PlanSubmission struct {
 	mu       sync.Mutex
 	plan     plancontract.Plan
+	previous plancontract.Plan
 	attempts int
 }
 
@@ -48,8 +49,24 @@ func (s *PlanSubmission) Plan() (plancontract.Plan, bool) {
 func (s *PlanSubmission) record(p plancontract.Plan) plancontract.Plan {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.previous = s.plan
 	s.attempts++
 	p.Revision = s.attempts
 	s.plan = p
 	return p
+}
+
+// Revised compares a resubmission against the revision it replaces, so the
+// planner is told what its own edit changed rather than assuming. ok is false
+// for a first submission, which replaces nothing.
+func (s *PlanSubmission) Revised() (plancontract.Diff, bool) {
+	if s == nil {
+		return plancontract.Diff{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.attempts < 2 {
+		return plancontract.Diff{}, false
+	}
+	return plancontract.Compare(s.previous, s.plan), true
 }

--- a/internal/agent/submit_plan.go
+++ b/internal/agent/submit_plan.go
@@ -125,7 +125,17 @@ func (*SubmitPlanTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	if plan.RequiresApproval {
 		approval = " Approval was requested; the host decides whether execution gates."
 	}
+	// A revision is told what it changed. Left to describe its own edit a model
+	// reports intent, not effect, and a step it dropped by accident reads the
+	// same as one it kept.
+	revised := ""
+	if diff, ok := submission.Revised(); ok && diff.Moved() {
+		revised = "\n\n" + plancontract.RenderDiff(diff)
+		if diff.NeedsApproval() {
+			revised += "\n\nThis revision expands the approved scope; the host may gate it again."
+		}
+	}
 	return fmt.Sprintf(
-		"Plan revision %d accepted: %d phase(s), %d sub-step(s). The host renders it for the user and hands it to the executor — do not restate it.%s",
-		plan.Revision, phases, subSteps, approval), nil
+		"Plan revision %d accepted: %d phase(s), %d sub-step(s). The host renders it for the user and hands it to the executor — do not restate it.%s%s",
+		plan.Revision, phases, subSteps, approval, revised), nil
 }

--- a/internal/agent/submit_plan_test.go
+++ b/internal/agent/submit_plan_test.go
@@ -157,3 +157,38 @@ func TestSubmitPlanSchemaCarriesTheEvidenceContract(t *testing.T) {
 		t.Error("submit_plan schema exposes revision; identity is host-assigned")
 	}
 }
+
+// A planner that resubmits is told what its own edit changed. Left to describe
+// it, a model reports intent rather than effect — and a step it dropped by
+// accident reads exactly like one it meant to keep.
+func TestSubmitPlanTellsARevisionWhatItChanged(t *testing.T) {
+	ctx, _ := WithPlanSubmission(context.Background())
+	first := `{"objective":"o","steps":[{"id":"s1","title":"change the DB"},{"id":"s2","title":"change the API"}]}`
+	if _, err := submitPlan(t, ctx, first); err != nil {
+		t.Fatalf("first submission: %v", err)
+	}
+	second := `{"objective":"o","steps":[{"id":"s1","title":"change the DB"},{"id":"s3","title":"add the migration"},{"id":"s2","title":"change the API"}]}`
+	out, err := submitPlan(t, ctx, second)
+	if err != nil {
+		t.Fatalf("revision: %v", err)
+	}
+	for _, want := range []string{"Revision 1 → 2", "**Added**", "s3", "expands the approved scope"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("revision result missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "**Changed**") {
+		t.Errorf("an insertion must not report its neighbours as changed:\n%s", out)
+	}
+}
+
+func TestSubmitPlanSaysNothingAboutAFirstSubmission(t *testing.T) {
+	ctx, _ := WithPlanSubmission(context.Background())
+	out, err := submitPlan(t, ctx, `{"objective":"o","steps":[{"title":"do it"}]}`)
+	if err != nil {
+		t.Fatalf("submit_plan: %v", err)
+	}
+	if strings.Contains(out, "Revision") && strings.Contains(out, "→") {
+		t.Errorf("a first submission replaces nothing and must not render a diff:\n%s", out)
+	}
+}

--- a/internal/plancontract/diff.go
+++ b/internal/plancontract/diff.go
@@ -1,0 +1,141 @@
+package plancontract
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Diff is what one revision changed. Steps pair by id, which is why identity is
+// host-assigned and never regenerated: a diff that pairs by position or title
+// cannot tell a step that moved from a step that was replaced.
+type Diff struct {
+	FromRevision int
+	ToRevision   int
+	Objective    *TextChange
+	Added        []Step
+	Removed      []Step
+	Changed      []StepChange
+	Preserved    []Step
+}
+
+// TextChange is a plan-level field that moved.
+type TextChange struct{ Before, After string }
+
+// StepChange names which parts of a step moved, because "the title was reworded"
+// and "the acceptance criteria were rewritten" carry very different risk.
+type StepChange struct {
+	Before Step
+	After  Step
+	Fields []string
+}
+
+// Compare pairs the two revisions by step id. It is a pure function so the host
+// can render it, gate on it, and record it from the same result.
+func Compare(before, after Plan) Diff {
+	before, after = before.Normalize(), after.Normalize()
+	d := Diff{FromRevision: before.Revision, ToRevision: after.Revision}
+	if before.Objective != after.Objective {
+		d.Objective = &TextChange{Before: before.Objective, After: after.Objective}
+	}
+	prev := make(map[string]Step, len(before.Steps))
+	for _, step := range before.Steps {
+		prev[step.ID] = step
+	}
+	for _, step := range after.Ordered() {
+		old, existed := prev[step.ID]
+		delete(prev, step.ID)
+		if !existed {
+			d.Added = append(d.Added, step)
+			continue
+		}
+		if fields := changedFields(old, step); len(fields) > 0 {
+			d.Changed = append(d.Changed, StepChange{Before: old, After: step, Fields: fields})
+			continue
+		}
+		d.Preserved = append(d.Preserved, step)
+	}
+	for _, step := range before.Ordered() {
+		if _, gone := prev[step.ID]; gone {
+			d.Removed = append(d.Removed, step)
+		}
+	}
+	return d
+}
+
+func changedFields(before, after Step) []string {
+	var fields []string
+	add := func(name string, same bool) {
+		if !same {
+			fields = append(fields, name)
+		}
+	}
+	add("title", before.Title == after.Title)
+	add("phase", before.ParentID == after.ParentID)
+	add("depends_on", slices.Equal(before.DependsOn, after.DependsOn))
+	add("verified_files", slices.Equal(before.VerifiedFiles, after.VerifiedFiles))
+	add("candidate_files", slices.Equal(before.CandidateFiles, after.CandidateFiles))
+	add("acceptance", slices.Equal(before.Acceptance, after.Acceptance))
+	add("verification", slices.Equal(before.Verification, after.Verification))
+	add("risks", slices.Equal(before.Risks, after.Risks))
+	return fields
+}
+
+// NeedsApproval reports whether the revision expands what the user agreed to.
+// Narrowing, reordering, retitling, and adding evidence never do: re-asking for
+// those trains the user to approve without reading, which costs more than the
+// gate saves.
+func (d Diff) NeedsApproval() bool {
+	if d.Objective != nil || len(d.Added) > 0 {
+		return true
+	}
+	for _, change := range d.Changed {
+		if grew(change.Before.Risks, change.After.Risks) ||
+			grew(change.Before.Acceptance, change.After.Acceptance) ||
+			grew(change.Before.VerifiedFiles, change.After.VerifiedFiles) ||
+			grew(change.Before.CandidateFiles, change.After.CandidateFiles) {
+			return true
+		}
+	}
+	return false
+}
+
+func grew[T any](before, after []T) bool { return len(after) > len(before) }
+
+// Moved reports whether anything actually changed. Preserved alone is not a
+// change — it is the reassurance that sits beside one.
+func (d Diff) Moved() bool {
+	return d.Objective != nil || len(d.Added) > 0 || len(d.Removed) > 0 || len(d.Changed) > 0
+}
+
+// RenderDiff turns the comparison into the summary a reviewer reads. Empty
+// sections are omitted, and a revision that changed nothing renders as nothing.
+func RenderDiff(d Diff) string {
+	if !d.Moved() {
+		return ""
+	}
+	var b strings.Builder
+	if d.FromRevision > 0 && d.ToRevision > 0 {
+		fmt.Fprintf(&b, "**Revision %d → %d**\n", d.FromRevision, d.ToRevision)
+	}
+	if d.Objective != nil {
+		fmt.Fprintf(&b, "\n**Objective**\n  was: %s\n  now: %s\n", d.Objective.Before, d.Objective.After)
+	}
+	diffSection(&b, "Added", d.Added, func(s Step) string { return s.ID + "  " + s.Title })
+	diffSection(&b, "Removed", d.Removed, func(s Step) string { return s.ID + "  " + s.Title })
+	diffSection(&b, "Changed", d.Changed, func(c StepChange) string {
+		return c.After.ID + "  " + c.After.Title + " (" + strings.Join(c.Fields, ", ") + ")"
+	})
+	diffSection(&b, "Preserved", d.Preserved, func(s Step) string { return s.ID + "  " + s.Title })
+	return strings.TrimSpace(b.String())
+}
+
+func diffSection[T any](b *strings.Builder, title string, items []T, line func(T) string) {
+	if len(items) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n**%s**\n", title)
+	for _, item := range items {
+		fmt.Fprintf(b, "  %s\n", line(item))
+	}
+}

--- a/internal/plancontract/diff_test.go
+++ b/internal/plancontract/diff_test.go
@@ -1,0 +1,136 @@
+package plancontract
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func diffIDs(steps []Step) []string {
+	out := make([]string, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, s.ID)
+	}
+	return out
+}
+
+func basePlan() Plan {
+	return Plan{
+		Objective: "make the cache key model-aware",
+		Revision:  1,
+		Steps: []Step{
+			{ID: "s1", Title: "change the DB"},
+			{ID: "s2", Title: "change the API", CandidateFiles: []string{"api.go"}},
+			{ID: "s3", Title: "write tests"},
+		},
+	}.Normalize()
+}
+
+// The whole reason identity is host-assigned and never regenerated: a diff that
+// paired by position would call every step below an insertion "changed".
+func TestCompareParesByIdentityNotPosition(t *testing.T) {
+	after := basePlan()
+	after.Revision = 2
+	after.Steps = []Step{
+		after.Steps[0],
+		{ID: "s4", Title: "add the migration"},
+		after.Steps[1],
+		after.Steps[2],
+	}
+
+	d := Compare(basePlan(), after.Normalize())
+	if !slices.Equal(diffIDs(d.Added), []string{"s4"}) {
+		t.Errorf("added = %v, want only the inserted step", diffIDs(d.Added))
+	}
+	if len(d.Changed) != 0 {
+		t.Errorf("changed = %+v; an insertion must not mark its neighbours changed", d.Changed)
+	}
+	if !slices.Equal(diffIDs(d.Preserved), []string{"s1", "s2", "s3"}) {
+		t.Errorf("preserved = %v, want every untouched step", diffIDs(d.Preserved))
+	}
+}
+
+// "The title was reworded" and "the acceptance criteria were rewritten" carry
+// different risk, so the diff names which part moved.
+func TestCompareNamesWhichFieldsMoved(t *testing.T) {
+	after := basePlan()
+	after.Revision = 2
+	after.Steps[1].Title = "change the API and its schema"
+	after.Steps[1].CandidateFiles = []string{"api.go", "schema.go"}
+
+	d := Compare(basePlan(), after.Normalize())
+	if len(d.Changed) != 1 {
+		t.Fatalf("changed = %+v, want one step", d.Changed)
+	}
+	if got := d.Changed[0].Fields; !slices.Equal(got, []string{"title", "candidate_files"}) {
+		t.Fatalf("fields = %v, want the two that moved", got)
+	}
+}
+
+func TestCompareReportsRemoval(t *testing.T) {
+	after := basePlan()
+	after.Revision = 2
+	after.Steps = after.Steps[:2]
+
+	d := Compare(basePlan(), after.Normalize())
+	if !slices.Equal(diffIDs(d.Removed), []string{"s3"}) {
+		t.Fatalf("removed = %v", diffIDs(d.Removed))
+	}
+}
+
+// Re-asking for a narrowing trains the user to approve without reading, which
+// costs more than the gate saves.
+func TestNeedsApprovalOnlyOnExpansion(t *testing.T) {
+	base := basePlan()
+	widen := func(mutate func(*Plan)) Diff {
+		after := basePlan()
+		after.Revision = 2
+		mutate(&after)
+		return Compare(base, after.Normalize())
+	}
+
+	expansions := map[string]func(*Plan){
+		"a new step":      func(p *Plan) { p.Steps = append(p.Steps, Step{ID: "s4", Title: "extra"}) },
+		"a new objective": func(p *Plan) { p.Objective = "something else entirely" },
+		"a new risk":      func(p *Plan) { p.Steps[0].Risks = []string{"data loss"} },
+		"a new criterion": func(p *Plan) { p.Steps[0].Acceptance = []Criterion{{Text: "must hold"}} },
+		"a wider surface": func(p *Plan) { p.Steps[1].CandidateFiles = []string{"api.go", "schema.go"} },
+	}
+	for name, mutate := range expansions {
+		if !widen(mutate).NeedsApproval() {
+			t.Errorf("%s must ask again", name)
+		}
+	}
+
+	narrowings := map[string]func(*Plan){
+		"a dropped step":   func(p *Plan) { p.Steps = p.Steps[:2] },
+		"a reworded title": func(p *Plan) { p.Steps[0].Title = "change the database" },
+		"a reorder":        func(p *Plan) { p.Steps[0], p.Steps[2] = p.Steps[2], p.Steps[0] },
+	}
+	for name, mutate := range narrowings {
+		if widen(mutate).NeedsApproval() {
+			t.Errorf("%s must not ask again", name)
+		}
+	}
+}
+
+func TestRenderDiffOmitsEmptySectionsAndSaysNothingWhenNothingMoved(t *testing.T) {
+	if got := RenderDiff(Compare(basePlan(), basePlan())); got != "" {
+		t.Fatalf("an unchanged plan rendered %q", got)
+	}
+
+	after := basePlan()
+	after.Revision = 2
+	after.Steps = append(after.Steps, Step{ID: "s4", Title: "add the migration"})
+	out := RenderDiff(Compare(basePlan(), after.Normalize()))
+	for _, want := range []string{"Revision 1 → 2", "**Added**", "s4  add the migration", "**Preserved**"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diff missing %q:\n%s", want, out)
+		}
+	}
+	for _, absent := range []string{"**Removed**", "**Changed**", "**Objective**"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("diff should omit %q:\n%s", absent, out)
+		}
+	}
+}


### PR DESCRIPTION
The last place in the pipeline where a structured thing is compared as text.

`recoveryPlanTransition` detects a structural rewrite of an active plan and hands an independent reviewer **two rendered strings**:

```go
return true, planReviewText(before), planReviewText(after)
```

A text diff cannot distinguish *"s2's touchpoints widened"* from *"s2 was replaced by different work"*, and it calls every step below an insertion changed.

## Compare pairs by identity

`Compare` pairs by step id — which is exactly why identity is host-assigned and never regenerated — so an inserted step is **Added** and its neighbours stay **Preserved**. `StepChange.Fields` names which parts moved, because *"the title was reworded"* and *"the acceptance criteria were rewritten"* carry very different risk.

## NeedsApproval is the decision the diff exists for

| | |
|---|---|
| asks again | a new step, a new objective, a new risk, a new criterion, a wider touchpoint surface |
| does not | dropping a step, rewording a title, reordering |

Re-asking for a narrowing trains the user to approve without reading, which costs more than the gate saves. This implements the four escalation conditions directly: scope expansion, risk increase, criteria change, objective change.

## It ships with a consumer

Not another `PlanFacts` waiting a year for a caller. A planner that resubmits gets the diff back as its tool result:

```
Plan revision 2 accepted: 3 phase(s), 0 sub-step(s). …

**Revision 1 → 2**

**Added**
  s3  add the migration

**Preserved**
  s1  change the DB
  s2  change the API

This revision expands the approved scope; the host may gate it again.
```

Left to describe its own edit, a model reports intent rather than effect — and a step it dropped by accident reads exactly like one it meant to keep.

## A flaw the tests caught

A revision that changed nothing rendered the revision header plus the entire Preserved list. `Preserved` is the reassurance beside a change, not a standalone report, so `Moved()` gates the whole render. That test is in the file.

## Scope

`recoveryPlanTransition` itself is **not** rewired here — it compares `[]evidence.TodoItem`, and giving it two `Plan` values needs the previous plan threaded to the agent. That is the next step; this lands the function with a real consumer first so it cannot rot unused.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean with no baseline change, `go test ./...` — 116 packages ok. Nine new tests: identity pairing across an insertion, field naming, removal, both sides of the approval policy, empty-render, and the two end-to-end submission cases.

Cache-impact: none - only the tool's runtime result text changes; no schema, description, or prompt text moves. The boot golden baseline passes unchanged.
Cache-guard: internal/boot TestGoldenBaselineNoExtensions passes unchanged, which is the direct evidence that SystemHash, ToolsHash and ToolSchemaTokens are untouched.
Documentation-impact: none - no user-facing surface changes. The diff is returned to the planner model inside an existing tool result.