### PR TITLE
feat(agent): the plan reviewer is told what moved

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2719,24 +2719,24 @@ func completedMCPConnect(reg *tool.Registry, name string) (string, bool) {
 // task list. Initial plans and progress-only status updates stay on the fast
 // path; changing step identity, order, or hierarchy while work remains is a
 // semantic transition for the independent Auto reviewer.
-func (a *Agent) recoveryPlanTransition(toolName string, args json.RawMessage) (bool, string, string) {
+func (a *Agent) recoveryPlanTransition(toolName string, args json.RawMessage) (bool, string, string, string) {
 	if a == nil || toolName != "todo_write" || a.planMode.Load() {
-		return false, "", ""
+		return false, "", "", ""
 	}
 	before := a.CanonicalTodoState()
 	if len(before) == 0 || len(evidence.IncompleteTodos(before)) == 0 {
-		return false, "", ""
+		return false, "", "", ""
 	}
 	after := evidence.ReceiptFromToolCall("todo_write", args, true, true).Todos
 	if len(after) == 0 || evidence.ValidateSerialTodos(after) != nil || !evidence.PreservesCompletedTodoPositions(before, after) {
 		// Let todo_write report malformed or invalid state directly; an invalid
 		// task list is not a meaningful plan proposal for the reviewer.
-		return false, "", ""
+		return false, "", "", ""
 	}
 	if samePlanStructure(before, after) {
-		return false, "", ""
+		return false, "", "", ""
 	}
-	return true, planReviewText(before), planReviewText(after)
+	return true, planReviewText(before), planReviewText(after), planTransitionDiff(before, after)
 }
 
 func samePlanStructure(a, b []evidence.TodoItem) bool {

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -43,6 +43,7 @@ type toolCallPlan struct {
 	planTransition            bool
 	planBefore                string
 	planAfter                 string
+	planDiff                  string
 	planReplacementAuthorized bool
 	recoveryGen               uint64
 
@@ -477,7 +478,7 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 	// is exhausted so host-proven read-only diagnosis can remain available while
 	// further execution is quarantined. Ask/Yolo still bypass inside the gate.
 	plan.verification = plan.evidenceName == "bash" && evidence.IsDeliveryVerificationCommand(bashCommandFromArgs(plan.evidenceArgs))
-	plan.planTransition, plan.planBefore, plan.planAfter = a.recoveryPlanTransition(plan.evidenceName, plan.evidenceArgs)
+	plan.planTransition, plan.planBefore, plan.planAfter, plan.planDiff = a.recoveryPlanTransition(plan.evidenceName, plan.evidenceArgs)
 	episodeStopped := false
 	if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
 		plan.recoveryGen = ctrl.Generation()
@@ -499,23 +500,7 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 		if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
 			episodeID = ctrl.EpisodeID()
 		}
-		dec, rerr := a.recoveryGate.BeforeMutation(ctx, RecoveryProposal{
-			AgentID:        a.recoveryAgentID,
-			TaskID:         a.recoveryTaskID,
-			TaskScopeID:    recoveryTaskScopeID(a.deliveryScopeID, a.recoveryRunSeq.Load()),
-			EpisodeID:      episodeID,
-			TaskSummary:    a.recoveryTaskSummary,
-			Tool:           plan.evidenceName,
-			Args:           plan.evidenceArgs,
-			Subject:        subject,
-			Preview:        preview,
-			ReadOnly:       plan.readOnly,
-			Mutates:        plan.mutates,
-			Verification:   plan.verification,
-			PlanTransition: plan.planTransition,
-			PlanBefore:     plan.planBefore,
-			PlanAfter:      plan.planAfter,
-		})
+		dec, rerr := a.recoveryGate.BeforeMutation(ctx, a.recoveryProposal(plan, episodeID, subject, preview))
 		if dec.Generation != 0 {
 			plan.recoveryGen = dec.Generation
 		}

--- a/internal/agent/plan_transition_diff.go
+++ b/internal/agent/plan_transition_diff.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"reasonix/internal/evidence"
+	"reasonix/internal/plancontract"
+)
+
+// planTransitionDiff summarises a task-list rewrite by pairing steps on their
+// stable ids; the task list is the plan's projection, so one comparison serves
+// both layers. It returns "" when either side predates step ids, since pairing
+// a list without them reads every step as replaced.
+func planTransitionDiff(before, after []evidence.TodoItem) string {
+	from, ok := planFromTodos(before, 1)
+	if !ok {
+		return ""
+	}
+	to, ok := planFromTodos(after, 2)
+	if !ok {
+		return ""
+	}
+	diff := plancontract.Compare(from, to)
+	if !diff.Moved() {
+		return ""
+	}
+	return plancontract.RenderDiff(diff)
+}
+
+// planFromTodos rebuilds the projection's shape. Only identity and hierarchy
+// matter here — the comparison never looks at the fields a todo cannot carry.
+func planFromTodos(todos []evidence.TodoItem, revision int) (plancontract.Plan, bool) {
+	plan := plancontract.Plan{Objective: "task list", Revision: revision}
+	phase := ""
+	for _, todo := range todos {
+		if todo.StepID == "" {
+			return plancontract.Plan{}, false
+		}
+		step := plancontract.Step{ID: todo.StepID, Title: todo.Content}
+		if todo.Level == 1 {
+			step.ParentID = phase
+		} else {
+			phase = todo.StepID
+		}
+		plan.Steps = append(plan.Steps, step)
+	}
+	return plan, len(plan.Steps) > 0
+}
+
+// recoveryProposal assembles what the isolated reviewer is shown for one call.
+// It lives beside the plan diff because that is the field most likely to grow.
+func (a *Agent) recoveryProposal(plan *toolCallPlan, episodeID, subject, preview string) RecoveryProposal {
+	return RecoveryProposal{
+		AgentID:        a.recoveryAgentID,
+		TaskID:         a.recoveryTaskID,
+		TaskScopeID:    recoveryTaskScopeID(a.deliveryScopeID, a.recoveryRunSeq.Load()),
+		EpisodeID:      episodeID,
+		TaskSummary:    a.recoveryTaskSummary,
+		Tool:           plan.evidenceName,
+		Args:           plan.evidenceArgs,
+		Subject:        subject,
+		Preview:        preview,
+		ReadOnly:       plan.readOnly,
+		Mutates:        plan.mutates,
+		Verification:   plan.verification,
+		PlanTransition: plan.planTransition,
+		PlanBefore:     plan.planBefore,
+		PlanAfter:      plan.planAfter,
+		PlanDiff:       plan.planDiff,
+	}
+}

--- a/internal/agent/plan_transition_diff_test.go
+++ b/internal/agent/plan_transition_diff_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+func todoList(items ...[2]string) []evidence.TodoItem {
+	out := make([]evidence.TodoItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, evidence.TodoItem{StepID: it[0], Content: it[1], Status: "pending"})
+	}
+	return out
+}
+
+// The reviewer used to receive two renderings and have to diff them itself,
+// which a clip can cut in half. Pairing on step ids says what moved.
+func TestPlanTransitionDiffNamesTheInsertion(t *testing.T) {
+	before := todoList([2]string{"plan_step_01", "change the DB"}, [2]string{"plan_step_02", "change the API"})
+	after := todoList(
+		[2]string{"plan_step_01", "change the DB"},
+		[2]string{"plan_step_03", "add the migration"},
+		[2]string{"plan_step_02", "change the API"},
+	)
+	got := planTransitionDiff(before, after)
+	for _, want := range []string{"**Added**", "plan_step_03", "**Preserved**"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diff missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "**Changed**") {
+		t.Errorf("an insertion must not report its neighbours as changed:\n%s", got)
+	}
+}
+
+func TestPlanTransitionDiffReportsARetitleAsChanged(t *testing.T) {
+	before := todoList([2]string{"plan_step_01", "fix authentication"})
+	after := todoList([2]string{"plan_step_01", "fix authentication refresh flow"})
+	got := planTransitionDiff(before, after)
+	if !strings.Contains(got, "**Changed**") || !strings.Contains(got, "title") {
+		t.Fatalf("a retitle under a kept id is a change, not a replacement:\n%s", got)
+	}
+}
+
+// A list that never carried ids cannot be paired: every step would read as
+// replaced, which is worse than the plain renderings the reviewer already has.
+func TestPlanTransitionDiffStandsDownWithoutIdentity(t *testing.T) {
+	before := []evidence.TodoItem{{Content: "change the DB", Status: "pending"}}
+	after := []evidence.TodoItem{{Content: "change the DB", Status: "pending"}, {Content: "and more", Status: "pending"}}
+	if got := planTransitionDiff(before, after); got != "" {
+		t.Fatalf("diff = %q, want none without step ids", got)
+	}
+}
+
+func TestPlanTransitionDiffSaysNothingWhenNothingMoved(t *testing.T) {
+	same := todoList([2]string{"plan_step_01", "change the DB"})
+	if got := planTransitionDiff(same, same); got != "" {
+		t.Fatalf("diff = %q, want none", got)
+	}
+}

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -124,6 +124,9 @@ type RecoveryProposal struct {
 	// the isolated reviewer. They are internal evidence, not persisted wire state.
 	PlanBefore string
 	PlanAfter  string
+	// PlanDiff pairs the two revisions by step id, so the reviewer is told what
+	// moved instead of diffing two clipped renderings itself.
+	PlanDiff string
 	// SafeRetry is true when the host can prove this is a same-strategy
 	// verification/idempotent retry (e.g. re-running the same test command).
 	SafeRetry bool

--- a/internal/agent/recovery_gate_test.go
+++ b/internal/agent/recovery_gate_test.go
@@ -23,7 +23,7 @@ type recordingRecoveryGate struct {
 func TestRecoveryPlanTransitionDetectsOnlyStructuralRewriteOfActivePlan(t *testing.T) {
 	a := &Agent{}
 	initial := json.RawMessage(`{"todos":[{"content":"Implement parser","status":"in_progress"}]}`)
-	if changed, _, _ := a.recoveryPlanTransition("todo_write", initial); changed {
+	if changed, _, _, _ := a.recoveryPlanTransition("todo_write", initial); changed {
 		t.Fatal("initial plan must stay on the fast path")
 	}
 
@@ -32,12 +32,12 @@ func TestRecoveryPlanTransitionDetectsOnlyStructuralRewriteOfActivePlan(t *testi
 		{Content: "Run tests", Status: "pending"},
 	})
 	progressOnly := json.RawMessage(`{"todos":[{"content":"Implement parser","status":"completed"},{"content":"Run tests","status":"in_progress"}]}`)
-	if changed, _, _ := a.recoveryPlanTransition("todo_write", progressOnly); changed {
+	if changed, _, _, _ := a.recoveryPlanTransition("todo_write", progressOnly); changed {
 		t.Fatal("progress-only update must not invoke the plan reviewer")
 	}
 
 	replacement := json.RawMessage(`{"todos":[{"content":"Replace parser architecture","status":"in_progress"},{"content":"Run tests","status":"pending"}]}`)
-	changed, before, after := a.recoveryPlanTransition("todo_write", replacement)
+	changed, before, after, _ := a.recoveryPlanTransition("todo_write", replacement)
 	if !changed {
 		t.Fatal("structural rewrite of active plan was not detected")
 	}
@@ -50,7 +50,7 @@ func TestRecoveryPlanTransitionIgnoresCompletedPriorPlan(t *testing.T) {
 	a := &Agent{}
 	a.setTodoState([]evidence.TodoItem{{Content: "Old task", Status: "completed"}})
 	next := json.RawMessage(`{"todos":[{"content":"New user task","status":"in_progress"}]}`)
-	if changed, _, _ := a.recoveryPlanTransition("todo_write", next); changed {
+	if changed, _, _, _ := a.recoveryPlanTransition("todo_write", next); changed {
 		t.Fatal("a new task after a completed plan is not a mid-plan transition")
 	}
 }

--- a/internal/recovery/reviewer.go
+++ b/internal/recovery/reviewer.go
@@ -209,6 +209,9 @@ func buildReviewEvidence(failure *FailureEvent, diagnosis []string, proposal Pro
 	if proposal.PlanAfter != "" {
 		p["plan_after"] = samplePreview(proposal.PlanAfter)
 	}
+	if proposal.PlanDiff != "" {
+		p["plan_diff"] = samplePreview(proposal.PlanDiff)
+	}
 	if proposal.Subject != "" {
 		p["subject"] = clipBytes(proposal.Subject, 300)
 	}


### PR DESCRIPTION
`recoveryPlanTransition` hands the isolated reviewer two rendered task lists and leaves it to work out the difference:

```go
return true, planReviewText(before), planReviewText(after)
```

`samplePreview` clips both before the reviewer sees them, so **on a long plan the change can fall past the cut** — the reviewer is asked to judge a rewrite it cannot fully see. That is exactly when a diff is worth most.

## One comparison, both layers

The task list is the plan's projection, so rebuilding its shape as a `Plan` lets #8235's `Compare` serve here too rather than growing a second implementation:

| rewrite | before | now |
|---|---|---|
| insert a step | every step below it looks different | **Added** `plan_step_03`, neighbours **Preserved** |
| retitle a step | reads like a replacement | **Changed** … *(title)* |

It stands down when either side predates step ids: pairing a list without them would read every step as replaced, which is worse than the plain renderings the reviewer already has.

## Scope narrowed by reading the types

The first cut also threaded `PlanDiff` through `PendingProposal`. Reading further, `recovery.Proposal` is a **type alias** for `agent.RecoveryProposal` — the reviewer already receives the field, and the gate's pending state never needed a copy. That copy is gone, and with it the ratchet pressure it created.

`event.RecoveryApproval` is deliberately untouched: this is reviewer evidence, not a UI surface.

## Debt

`execute_one.go` shrinks — the recovery proposal assembly moved out beside the diff, which is the field most likely to grow next. repolint 1958 → **1957**.

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean, `go test ./...` — 116 packages ok. Four new tests: the insertion case, the retitle case, standing down without ids, and saying nothing when nothing moved.

Cache-impact: none - the only cache-sensitive file is internal/agent/agent.go, where the change is one function's return signature. No prompt text, tool schema, or message assembly moves, so the provider-visible prefix is byte-identical.
Cache-guard: internal/boot TestGoldenBaselineNoExtensions passes unchanged, which is the direct evidence that SystemHash, ToolsHash and ToolSchemaTokens are untouched.
Documentation-impact: none - no user-facing surface changes. The diff reaches the isolated reviewer's evidence payload only; the approval card and its event are untouched.