### PR TITLE
feat(agent): a write outside the approved plan reads as expanded scope

### DIFF
--- a/internal/agent/plan_contract.go
+++ b/internal/agent/plan_contract.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"path/filepath"
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/plancontract"
@@ -125,4 +127,34 @@ func (a *Agent) outstandingPlanCriteria() []string {
 		return nil
 	}
 	return c.Outstanding()
+}
+
+// mutationEscapesPlan reports whether a pending write touches a path the
+// approved plan never named. A plan that named no touchpoints says nothing
+// about scope, so nothing escapes it: silence is not a claim that everything is
+// out of bounds. Directory containment counts — a plan naming a file implies
+// its directory is in play, which is how a test file beside it stays in scope.
+func (a *Agent) mutationEscapesPlan(toolName string, args json.RawMessage) bool {
+	plan := a.planContractSnapshot()
+	if plan == nil {
+		return false
+	}
+	allowed := map[string]bool{}
+	for _, step := range plan.Steps {
+		for _, p := range append(append([]string{}, step.VerifiedFiles...), step.CandidateFiles...) {
+			clean := filepath.Clean(p)
+			allowed[clean] = true
+			allowed[filepath.Dir(clean)] = true
+		}
+	}
+	if len(allowed) == 0 {
+		return false
+	}
+	for _, p := range evidence.ReceiptFromToolCall(toolName, args, false, true).Paths {
+		clean := filepath.Clean(p)
+		if !allowed[clean] && !allowed[filepath.Dir(clean)] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/agent/plan_transition_diff.go
+++ b/internal/agent/plan_transition_diff.go
@@ -62,8 +62,12 @@ func (a *Agent) recoveryProposal(plan *toolCallPlan, episodeID, subject, preview
 		Mutates:        plan.mutates,
 		Verification:   plan.verification,
 		PlanTransition: plan.planTransition,
-		PlanBefore:     plan.planBefore,
-		PlanAfter:      plan.planAfter,
-		PlanDiff:       plan.planDiff,
+		// The existing rule asks whether a retry drifts from the call that
+		// failed. This asks the question the user actually approved an answer
+		// to: is this write outside the plan they agreed on.
+		ExpandedScope: plan.mutates && a.mutationEscapesPlan(plan.evidenceName, plan.evidenceArgs),
+		PlanBefore:    plan.planBefore,
+		PlanAfter:     plan.planAfter,
+		PlanDiff:      plan.planDiff,
 	}
 }

--- a/internal/agent/scope_escape_test.go
+++ b/internal/agent/scope_escape_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/plancontract"
+	"reasonix/internal/tool"
+)
+
+func scopedAgent(t *testing.T, plan *plancontract.Plan) *Agent {
+	t.Helper()
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, nil)
+	a.SetPlanContract(plan)
+	return a
+}
+
+func writeArgs(path string) json.RawMessage {
+	return json.RawMessage(`{"path":"` + path + `","content":"x"}`)
+}
+
+// The question the user actually approved an answer to: is this write outside
+// the plan they agreed on. The existing rule only asks whether a retry drifts
+// from the call that failed, which says nothing about the plan.
+func TestMutationOutsideThePlanEscapes(t *testing.T) {
+	plan := plancontract.Plan{Objective: "o", Steps: []plancontract.Step{{
+		Title:         "fix the retry race",
+		VerifiedFiles: []string{"internal/pay/retry.go"},
+	}}}.Normalize()
+	a := scopedAgent(t, &plan)
+
+	if a.mutationEscapesPlan("write_file", writeArgs("internal/billing/invoice.go")) != true {
+		t.Fatal("a write the plan never named must read as leaving the approved scope")
+	}
+}
+
+// A plan naming a file implies its directory is in play, which is how the test
+// file beside it stays in scope.
+func TestMutationBesideAPlannedFileStaysInScope(t *testing.T) {
+	plan := plancontract.Plan{Objective: "o", Steps: []plancontract.Step{{
+		Title:         "fix the retry race",
+		VerifiedFiles: []string{"internal/pay/retry.go"},
+	}}}.Normalize()
+	a := scopedAgent(t, &plan)
+
+	for _, path := range []string{"internal/pay/retry.go", "internal/pay/retry_test.go"} {
+		if a.mutationEscapesPlan("write_file", writeArgs(path)) {
+			t.Errorf("%s is inside the planned surface", path)
+		}
+	}
+}
+
+// A candidate path was inferred rather than read, but the plan still named it as
+// where the work is expected — scope is an expectation, not a claim of fact.
+func TestCandidatePathsCountAsScope(t *testing.T) {
+	plan := plancontract.Plan{Objective: "o", Steps: []plancontract.Step{{
+		Title:          "fix it",
+		CandidateFiles: []string{"internal/boot/boot.go"},
+	}}}.Normalize()
+	a := scopedAgent(t, &plan)
+
+	if a.mutationEscapesPlan("write_file", writeArgs("internal/boot/boot.go")) {
+		t.Fatal("a candidate path is inside the planned surface")
+	}
+}
+
+// Silence is not a claim that everything is out of bounds.
+func TestNoPlanAndNoTouchpointsNeverEscape(t *testing.T) {
+	if scopedAgent(t, nil).mutationEscapesPlan("write_file", writeArgs("anything.go")) {
+		t.Error("an unplanned turn has no approved surface to leave")
+	}
+	silent := plancontract.Plan{Objective: "o", Steps: []plancontract.Step{{Title: "do it"}}}.Normalize()
+	if scopedAgent(t, &silent).mutationEscapesPlan("write_file", writeArgs("anything.go")) {
+		t.Error("a plan that named no touchpoints says nothing about scope")
+	}
+}


### PR DESCRIPTION
The fourth of the automatic replan conditions — *actual touched surface exceeds planned scope* — and the only one whose evidence is already flowing.

## The field existed; it asked a different question

The reviewer already weighs `ExpandedScope`, but the rule behind it compares the **failed call's** paths against the **retry's**:

```go
failedPaths := WriteScopePaths(failure.Tool, failure.Args)
nextPaths   := WriteScopePaths(proposal.Tool, proposal.Args)
```

That asks whether a retry drifted. It says nothing about the plan. A model that abandons the approved surface entirely and edits somewhere else answers **"no drift"**.

The plan names its touchpoints and the agent already carries it, so the question can be asked directly: does this pending write touch a path the approved plan never named.

The old rule is unchanged and still runs. This **widens what the field means**, it does not replace how it was computed.

## Two limits, both about not over-claiming

- **A plan that named no touchpoints says nothing about scope**, so nothing escapes it. Silence is not a claim that everything is out of bounds.
- **Directory containment counts.** A plan naming `internal/pay/retry.go` puts `internal/pay` in play, so the test file beside it stays in scope without the planner enumerating it.

Candidate paths count as scope even though they were inferred rather than read: scope is *where work is expected*, not a claim of fact — the same line the plan already draws everywhere it makes a claim.

## Where the other five stand

| condition | buildable today |
|---|---|
| touched surface exceeds plan | **this PR** |
| acceptance criterion changed | done in #8235 / #8249 |
| same failure repeated N times | detector exists (storm breaker); needs routing, not detection |
| planned assumption disproved | only when the assumption carries a `confirm` command that then fails |
| active step blocked | needs a `blocked` status, which has no supporting data yet |
| high-risk unexpected mutation | needs a risk classifier; the existing `HighRisk` means something else |

## Verification

`gofmt`, `go vet ./...`, `golangci-lint` 0 issues, repolint clean with no baseline change, `go test ./...` — 116 packages ok. Four new tests: a write the plan never named escapes, the file beside a planned one does not, candidate paths count, and neither an unplanned turn nor a plan without touchpoints ever escapes.

Documentation-impact: none - no user-facing surface changes. The signal reaches the isolated reviewer's existing evidence field; no approval card, event, or rendered output changes.