### PR TITLE
fix(desktop): guard IME confirm Enter in ask inputs and small inputs

### DIFF
--- a/desktop/frontend/src/__tests__/ask-card-layout.test.ts
+++ b/desktop/frontend/src/__tests__/ask-card-layout.test.ts
@@ -54,6 +54,10 @@ function installDom() {
   globalThis.localStorage = dom.window.localStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+  // React 19 falls back to the IE input-event polyfill unless attachEvent is
+  // present; without this, synthetic keydown/input handlers never run in jsdom.
+  Object.defineProperty(dom.window.HTMLElement.prototype, "attachEvent", { configurable: true, value: () => {} });
+  Object.defineProperty(dom.window.HTMLElement.prototype, "detachEvent", { configurable: true, value: () => {} });
   Object.defineProperty(dom.window.HTMLElement.prototype, "clientHeight", {
     configurable: true,
     get() {
@@ -588,6 +592,80 @@ console.log("\nask card layout");
   });
   eq(optionButtons[1]?.getAttribute("aria-selected"), "true", "click checks the multi-select option");
   eq(confirm.disabled, false, "multi-select confirm enables after a real check");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  // IME confirm Enter must not confirm the custom answer; a deliberate Enter
+  // after the confirm grace still reaches the handler.
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
+  const answers: QuestionAnswer[][] = [];
+  const ask: WireAsk = {
+    id: "ask-ime-custom",
+    questions: [
+      {
+        id: "decision",
+        header: "Review",
+        prompt: "What should the archive logic do?",
+        options: [{ label: "Full alignment", description: "Keep behavior consistent." }],
+      },
+    ],
+  };
+  await act(async () => {
+    root.render(
+      React.createElement(LocaleProvider, null,
+        React.createElement(AskCard, {
+          ask,
+          onAnswer: (_id: string, next: QuestionAnswer[]) => answers.push(next),
+          onDismiss: () => undefined,
+          onStop: () => undefined,
+        }),
+      ),
+    );
+    await flushTimers();
+  });
+  const customOption = [...document.querySelectorAll(".prompt-shelf__actions .prompt-action")].at(-1) as HTMLElement | undefined;
+  if (!customOption) throw new Error("custom option did not render");
+  await act(async () => {
+    customOption.click();
+    await flushTimers();
+  });
+  const customInput = document.querySelector(".ask-shelf__custom") as HTMLInputElement | null;
+  if (!customInput) throw new Error("custom input did not render");
+  // A focusin activates React's jsdom input polyfill so keydown dispatches run.
+  const dispatchEnter = (): KeyboardEvent => {
+    const event = new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    customInput.dispatchEvent(event);
+    return event;
+  };
+  let imeEnter: KeyboardEvent | null = null;
+  await act(async () => {
+    customInput.dispatchEvent(new window.FocusEvent("focusin", { bubbles: true }));
+    // Typing a pinyin letter primes the shared compositionend listener before
+    // the confirming Enter arrives (a real IME session always types first).
+    customInput.dispatchEvent(new window.KeyboardEvent("keydown", { key: "n", bubbles: true, cancelable: true }));
+    customInput.dispatchEvent(new window.Event("compositionstart", { bubbles: true }));
+    customInput.dispatchEvent(new window.Event("compositionend", { bubbles: true }));
+    imeEnter = dispatchEnter();
+    await flushTimers();
+  });
+  eq(imeEnter?.defaultPrevented, true, "IME confirm Enter is swallowed in the ask custom input");
+  eq(answers.length, 0, "IME confirm Enter does not confirm the custom answer");
+
+  let plainEnter: KeyboardEvent | null = null;
+  await act(async () => {
+    await flushTimers(150);
+    plainEnter = dispatchEnter();
+    await flushTimers();
+  });
+  eq(plainEnter?.defaultPrevented, false, "a deliberate Enter after the confirm grace is not swallowed");
 
   await act(async () => {
     root.unmount();

--- a/desktop/frontend/src/__tests__/command-palette-interactions.test.tsx
+++ b/desktop/frontend/src/__tests__/command-palette-interactions.test.tsx
@@ -134,5 +134,39 @@ console.log("\ncommand palette interactions");
   dom.window.close();
 }
 
+{
+  const dom = installDom();
+  const { root, calls } = await renderPalette();
+  const input = document.querySelector<HTMLInputElement>(".palette__input");
+  if (!input) throw new Error("missing palette input");
+  const dispatchKey = (key: string): KeyboardEvent => {
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    input.dispatchEvent(event);
+    return event;
+  };
+
+  await act(async () => {
+    input.dispatchEvent(new dom.window.FocusEvent("focusin", { bubbles: true }));
+    dispatchKey("n");
+    input.dispatchEvent(new Event("compositionstart", { bubbles: true }));
+    input.dispatchEvent(new Event("compositionend", { bubbles: true }));
+    dispatchKey("Enter");
+    await flush();
+  });
+  ok(calls.run === 0, "IME confirm Enter does not run the highlighted command");
+
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    dispatchKey("Enter");
+    await flush();
+  });
+  ok(calls.run === 1, "a deliberate Enter after the confirm grace runs the highlighted command");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useT, type Translator } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import type { ComposerInsertRequest, DirEntry, ToolApprovalMode, WireApproval } from "../lib/types";
 import {
   DecisionConfirmBar,
@@ -632,6 +633,7 @@ export function ApprovalModal({
   };
 
   const onRevisionKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (isImeEvent(event)) return;
     if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
       submitRevision();
       event.stopPropagation();

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useT } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import type { QuestionAnswer, WireAsk, WireAskQuestion } from "../lib/types";
 import {
   DecisionConfirmBar,
@@ -341,6 +342,10 @@ export function AskCard({
                 disabled={submitting}
                 onChange={(e) => setTyped(q, e.target.value)}
                 onKeyDown={(e) => {
+                  if (isImeEvent(e)) {
+                    e.preventDefault();
+                    return;
+                  }
                   if (e.key === "Enter" && canConfirm()) {
                     e.preventDefault();
                     confirmSelected();

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { ReactNode } from "react";
 import { Command, Search } from "lucide-react";
 import { useT } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import { useMountTransition } from "../lib/useMountTransition";
 
 // CommandPalette is a ⌘K / Ctrl+K modal that surfaces the desktop app's
@@ -163,6 +164,7 @@ export function CommandPalette({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
+      if (isImeEvent({ nativeEvent: e })) return;
       const closeButtonHasFocus = e.target instanceof HTMLElement && Boolean(e.target.closest("[data-palette-close]"));
       if (closeButtonHasFocus && (e.key === "Enter" || e.key === " ")) return;
       if (e.key === "Escape") {

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent as ReactMouseEvent } from "react";
 import { Archive, Pencil, Search, Trash2, RotateCcw } from "lucide-react";
 import { t, useT } from "../lib/i18n";
 import { historySessionDisplayTitle, sessionActivityTime } from "../lib/session";
+import { isImeEvent } from "../lib/imeComposition";
 import type { HistoryMessage, SessionMeta } from "../lib/types";
 import { historyMessagesToItems, type Item } from "../lib/useController";
 import { Transcript } from "./Transcript";
@@ -515,6 +516,7 @@ export function HistoryPanel({
                             value={draft}
                             onChange={(e) => setDraft(e.target.value)}
                             onKeyDown={(e) => {
+                              if (isImeEvent(e)) return;
                               if (e.key === "Enter") commitRename(s.path);
                               if (e.key === "Escape") setEditing(null);
                             }}

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -2,6 +2,7 @@ import { Activity, AlertTriangle, ArchiveRestore, Check, ChevronDown, ChevronRig
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion, TabMeta } from "../lib/types";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { ResizableDrawer } from "./ResizableDrawer";
@@ -658,6 +659,7 @@ export function MemoryPanel({
                   value={note}
                   onChange={(e) => setNote(e.target.value)}
                   onKeyDown={(e) => {
+                    if (isImeEvent(e)) return;
                     if (e.key === "Enter") void submitNote();
                   }}
                 />
@@ -1785,6 +1787,7 @@ export function MemorySettingsPage() {
 								value={note}
 								onChange={(e) => setNote(e.target.value)}
 								onKeyDown={(e) => {
+									if (isImeEvent(e)) return;
 									if (e.key === "Enter") void submitNote();
 								}}
 							/>

--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -3,6 +3,7 @@ import { Brain, Check, ChevronsUpDown, Search } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import type { ModelInfo } from "../lib/types";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { Tooltip } from "./Tooltip";
@@ -194,6 +195,7 @@ export function ModelSwitcher({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => {
+                if (isImeEvent(e)) return;
                 if (e.key === "Escape") setOpen(false);
                 if (e.key === "Enter" && filtered.length === 1) pick(filtered[0]);
               }}

--- a/desktop/frontend/src/components/OnboardingOverlay.tsx
+++ b/desktop/frontend/src/components/OnboardingOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import logo from "../assets/logo.svg";
 import { useT } from "../lib/i18n";
+import { isImeEvent } from "../lib/imeComposition";
 import { app, openExternal } from "../lib/bridge";
 
 // Full-window first-run guide: DeepSeek stays the fastest path, while users can
@@ -73,6 +74,7 @@ export function OnboardingOverlay({
             if (state === "error") setState("idle");
           }}
           onKeyDown={(e) => {
+            if (isImeEvent(e)) return;
             if (e.key === "Enter" && state !== "validating") {
               e.preventDefault();
               void submit();

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -8,6 +8,7 @@ import { apiKeyEnvFromProviderName, createLatestRequestGate, inferredVisionModel
 import { cachedFetchProviderModels, invalidateProviderCacheByAPIKeyEnv, shouldSkipAutoRefresh } from "../lib/providerModelCache";
 import { opencodeGoPresetDescriptionKeys } from "../lib/providerPresetDescriptions";
 import { useUpdater } from "../lib/useUpdater";
+import { isImeEvent } from "../lib/imeComposition";
 import {
   applyTheme,
   getTheme,
@@ -6863,6 +6864,7 @@ function RuleList({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
+            if (isImeEvent(e)) return;
             if (e.key === "Enter") add();
           }}
         />

--- a/desktop/frontend/src/lib/imeComposition.ts
+++ b/desktop/frontend/src/lib/imeComposition.ts
@@ -1,0 +1,27 @@
+// IME guard for the many small Enter-submitting inputs (ask card, command
+// palette, rule/note/rename/add). WebKit fires compositionend before the
+// confirming Enter keydown, so a shared compositionend timestamp plus the
+// 229-keyCode check covers every input without per-input listeners.
+import { isImeKeyEvent } from "./composerKeyboard";
+
+let lastGlobalCompositionEndAt = 0;
+let globalListenerTarget: Document | null = null;
+
+function onGlobalCompositionEnd(): void {
+  lastGlobalCompositionEndAt = Date.now();
+}
+
+function ensureGlobalCompositionListener(): void {
+  if (typeof document === "undefined") return;
+  if (globalListenerTarget === document) return;
+  // Tests swap the jsdom document between cases; never leave the listener on
+  // a closed document.
+  globalListenerTarget?.removeEventListener("compositionend", onGlobalCompositionEnd);
+  globalListenerTarget = document;
+  document.addEventListener("compositionend", onGlobalCompositionEnd);
+}
+
+export function isImeEvent(e: { nativeEvent: { isComposing?: boolean; keyCode?: number } }): boolean {
+  ensureGlobalCompositionListener();
+  return isImeKeyEvent(e.nativeEvent, false, lastGlobalCompositionEndAt);
+}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -117,7 +117,7 @@
       "test-file-size": 106
     },
     "desktop/frontend/src/components/ApprovalModal.tsx": {
-      "file-size": 238
+      "file-size": 240
     },
     "desktop/frontend/src/components/CapabilitiesPanel.tsx": {
       "file-size": 2658
@@ -126,7 +126,7 @@
       "file-size": 4003
     },
     "desktop/frontend/src/components/MemoryPanel.tsx": {
-      "file-size": 1088
+      "file-size": 1091
     },
     "desktop/frontend/src/components/Message.tsx": {
       "file-size": 91
@@ -138,7 +138,7 @@
       "file-size": 141
     },
     "desktop/frontend/src/components/SettingsPanel.tsx": {
-      "file-size": 6768
+      "file-size": 6770
     },
     "desktop/frontend/src/components/StatusBar.tsx": {
       "file-size": 20


### PR DESCRIPTION
## 背景

WebKit（桌面端内嵌 WebView）的 IME 事件时序特殊：输入法确认 Enter 时，`compositionend` 先于确认的 `keydown` 触发（此时 `isComposing=false`、`keyCode=13`），导致**所有"回车即提交"的小输入框在中文等输入法确认候选词时误发送**。

Composer 此前已有防护（上游已通过 `lib/composerKeyboard.ts` 的 `isImeKeyEvent` 合入），但 **ask 卡片、命令面板、规则/笔记/重命名/添加等小输入框没有防护**，IME 用户在这些输入框敲回车确认候选词时会把半截内容提交出去。

## 目的

把 IME 防护统一扩展到所有 Enter 提交的小输入框：

- 新增 `lib/imeComposition.ts`：共享的全局 `compositionend` 监听（`isImeEvent`），复用上游 `isImeKeyEvent` 的 `keyCode 229` 检查与 100ms 确认宽限期
- 每个输入框的 `keydown` 处理前加一次 `isImeEvent(e)` 检查，命中则 `preventDefault` 并返回

## 价值

- **中文等 IME 用户不再误提交**：确认候选词的回车被正确吞掉，只有真正的回车才提交
- 轻量实现：单个全局监听器 + 每处一行检查，无需为每个输入框维护 composition 状态；100ms 宽限期同时保证快速连按第二个回车仍可正常提交
- 测试覆盖：`ask-card-layout.test.ts`（+78）、`command-palette-interactions.test.tsx`（+34）

## 变更内容

11 个文件，+159：

- 新增：`lib/imeComposition.ts`（`isImeEvent`，复用 `composerKeyboard.isImeKeyEvent`）
- 组件（各 +1~4 行 guard）：`AskCard`、`ApprovalModal`、`CommandPalette`、`HistoryPanel`、`MemoryPanel`、`ModelSwitcher`、`OnboardingOverlay`、`SettingsPanel`
- 测试：`__tests__/ask-card-layout.test.ts`、`__tests__/command-palette-interactions.test.tsx`

另含 3 行 ratchet 边界调整（`tools/repolint/baseline.json`）：guard 给 3 个历史遗留大文件（ApprovalModal 1040 行 / MemoryPanel 1891 行 / SettingsPanel 7570 行）各净增 2-3 行，预算相应 238→240、1088→1091、6768→6770。已拒绝全量 `-update` 以保持 PR diff 聚焦，理由见提交信息。

## 验证

- `go run ./tools/repolint` clean（1957 baselined）；`gofmt` / `go vet` 无 Go 侧改动
- 前端测试需 node 环境，本机未安装，建议 CI 中跑 `pnpm test`

---

Cache-impact: none - 仅 desktop/frontend TS 与 repolint baseline 调整，不触及 provider 可见的系统提示前缀
Cache-guard: 未改动 internal/tool、internal/provider、internal/boot 等缓存敏感路径
Documentation-impact: none - 无 docs/*.md 改动，文档保持正确
