### PR TITLE
bench(e2e): add the read-only-output shape the corpus never had

### DIFF
--- a/benchmarks/e2e/tasks/audit-config-drift/task.toml
+++ b/benchmarks/e2e/tasks/audit-config-drift/task.toml
@@ -1,0 +1,4 @@
+prompt = "Exactly one setting differs across config/base.toml, config/staging.toml and config/production.toml. Write AUDIT.md naming the setting that drifted, the environment it drifted in, and both values. Do not change any config."
+class = "read-only-output"
+max_steps = 25
+timeout_sec = 480

--- a/benchmarks/e2e/tasks/audit-config-drift/verify.sh
+++ b/benchmarks/e2e/tasks/audit-config-drift/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+test -f AUDIT.md || { echo "AUDIT.md was never written" >&2; exit 1; }
+doc="$(tr '[:upper:]' '[:lower:]' < AUDIT.md)"
+for want in timeout_sec production 30 5; do
+  case "$doc" in
+    *"$want"*) ;;
+    *) echo "AUDIT.md never mentions $want" >&2; exit 1 ;;
+  esac
+done
+# Naming a setting that did not drift means the three files were not compared.
+for absent in max_body_mb ttl_sec; do
+  case "$doc" in
+    *"$absent"*) echo "AUDIT.md reports $absent, which is identical everywhere" >&2; exit 1 ;;
+  esac
+done
+grep -q "timeout_sec = 5" config/production.toml || {
+  echo "config/production.toml was modified; the task is to report the drift" >&2
+  exit 1
+}

--- a/benchmarks/e2e/tasks/audit-config-drift/workdir/README.md
+++ b/benchmarks/e2e/tasks/audit-config-drift/workdir/README.md
@@ -1,0 +1,1 @@
+All three environments are kept in lockstep. Any difference is a mistake.

--- a/benchmarks/e2e/tasks/audit-config-drift/workdir/config/base.toml
+++ b/benchmarks/e2e/tasks/audit-config-drift/workdir/config/base.toml
@@ -1,0 +1,7 @@
+[server]
+port = 8080
+timeout_sec = 30
+max_body_mb = 8
+
+[cache]
+ttl_sec = 300

--- a/benchmarks/e2e/tasks/audit-config-drift/workdir/config/production.toml
+++ b/benchmarks/e2e/tasks/audit-config-drift/workdir/config/production.toml
@@ -1,0 +1,7 @@
+[server]
+port = 8080
+timeout_sec = 5
+max_body_mb = 8
+
+[cache]
+ttl_sec = 300

--- a/benchmarks/e2e/tasks/audit-config-drift/workdir/config/staging.toml
+++ b/benchmarks/e2e/tasks/audit-config-drift/workdir/config/staging.toml
@@ -1,0 +1,7 @@
+[server]
+port = 8080
+timeout_sec = 30
+max_body_mb = 8
+
+[cache]
+ttl_sec = 300

--- a/benchmarks/e2e/tasks/document-dependency-direction/task.toml
+++ b/benchmarks/e2e/tasks/document-dependency-direction/task.toml
@@ -1,0 +1,4 @@
+prompt = "Write ARCHITECTURE.md explaining how the pipeline package is layered. Name all three modules, state which one depends on which, and name the module that depends on nothing else in the package. Do not change any code."
+class = "read-only-output"
+max_steps = 25
+timeout_sec = 480

--- a/benchmarks/e2e/tasks/document-dependency-direction/verify.sh
+++ b/benchmarks/e2e/tasks/document-dependency-direction/verify.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+test -f ARCHITECTURE.md || { echo "ARCHITECTURE.md was never written" >&2; exit 1; }
+doc="$(tr '[:upper:]' '[:lower:]' < ARCHITECTURE.md)"
+for want in reader normalizer writer; do
+  case "$doc" in
+    *"$want"*) ;;
+    *) echo "ARCHITECTURE.md never mentions $want" >&2; exit 1 ;;
+  esac
+done
+# The direction is the whole question: writer sits above normalizer, which sits
+# above reader. A document that lists the three names without the order has not
+# read the imports.
+case "$doc" in
+  *"writer"*"normalizer"*"reader"*) ;;
+  *) echo "ARCHITECTURE.md does not state the layering order" >&2; exit 1 ;;
+esac
+grep -q "from pipeline import reader" pipeline/normalizer.py || {
+  echo "pipeline/normalizer.py was modified; the task is to describe it" >&2
+  exit 1
+}

--- a/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/normalizer.py
+++ b/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/normalizer.py
@@ -1,0 +1,7 @@
+"""Normalizes rows. Uses the reader; must not know about the writer."""
+
+from pipeline import reader
+
+
+def normalized(path):
+    return [row.strip().lower() for row in reader.read_rows(path)]

--- a/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/reader.py
+++ b/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/reader.py
@@ -1,0 +1,6 @@
+"""Reads raw rows. Depends on nothing else in this package."""
+
+
+def read_rows(path):
+    with open(path) as f:
+        return [line.rstrip("\n") for line in f]

--- a/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/writer.py
+++ b/benchmarks/e2e/tasks/document-dependency-direction/workdir/pipeline/writer.py
@@ -1,0 +1,9 @@
+"""Writes normalized rows. Sits above the normalizer."""
+
+from pipeline import normalizer
+
+
+def write_normalized(src, dst):
+    with open(dst, "w") as f:
+        for row in normalizer.normalized(src):
+            f.write(row + "\n")

--- a/benchmarks/e2e/tasks/document-handover/task.toml
+++ b/benchmarks/e2e/tasks/document-handover/task.toml
@@ -1,0 +1,4 @@
+prompt = "Write HANDOVER.md describing the real current state of this workspace for the next person. It must name the key builder that exists but is never called, name the test that is skipped and why, and state plainly that notes.txt is stale and which of its claims is false. Do not change any code."
+class = "read-only-output"
+max_steps = 30
+timeout_sec = 600

--- a/benchmarks/e2e/tasks/document-handover/verify.sh
+++ b/benchmarks/e2e/tasks/document-handover/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+test -f HANDOVER.md || { echo "HANDOVER.md was never written" >&2; exit 1; }
+doc="$(tr '[:upper:]' '[:lower:]' < HANDOVER.md)"
+for want in model_scoped_key test_two_models_do_not_collide notes.txt; do
+  case "$doc" in
+    *"$want"*) ;;
+    *) echo "HANDOVER.md never mentions $want" >&2; exit 1 ;;
+  esac
+done
+# The stale claim is that the migration finished; the handover has to contradict it.
+case "$doc" in
+  *stale*|*outdated*|*"not accurate"*|*incorrect*|*false*|*wrong*) ;;
+  *) echo "HANDOVER.md does not say notes.txt is stale" >&2; exit 1 ;;
+esac
+# A handover that edited the code it was asked to describe has changed the very
+# state it reports. Both markers must survive untouched.
+grep -q "_ENTRIES\[legacy_key(prompt)\] = value" cache/store.py || {
+  echo "cache/store.py was modified; the task is to describe the state, not fix it" >&2
+  exit 1
+}
+grep -q "@unittest.skip" tests/test_store.py || {
+  echo "tests/test_store.py was modified; the skip is part of the state to report" >&2
+  exit 1
+}

--- a/benchmarks/e2e/tasks/document-handover/workdir/cache/keys.py
+++ b/benchmarks/e2e/tasks/document-handover/workdir/cache/keys.py
@@ -1,0 +1,6 @@
+"""Key builders."""
+
+
+def model_scoped_key(prompt, model_ref):
+    """New key. Written, reviewed, and not called from anywhere yet."""
+    return model_ref + "\x00" + prompt.strip()

--- a/benchmarks/e2e/tasks/document-handover/workdir/cache/store.py
+++ b/benchmarks/e2e/tasks/document-handover/workdir/cache/store.py
@@ -1,0 +1,17 @@
+"""Response cache. Mid-migration: the key format is being made model-aware."""
+
+_ENTRIES = {}
+
+
+def legacy_key(prompt):
+    """Old key. Collides across models, which is the bug being fixed."""
+    return prompt.strip()
+
+
+def get(prompt):
+    return _ENTRIES.get(legacy_key(prompt))
+
+
+def put(prompt, value):
+    # TODO: switch to cache.keys.model_scoped_key once callers pass the model.
+    _ENTRIES[legacy_key(prompt)] = value

--- a/benchmarks/e2e/tasks/document-handover/workdir/notes.txt
+++ b/benchmarks/e2e/tasks/document-handover/workdir/notes.txt
@@ -1,0 +1,4 @@
+Status notes (last edited before the current work started)
+
+- Cache keys are model-aware. Migration finished.
+- All tests pass.

--- a/benchmarks/e2e/tasks/document-handover/workdir/tests/test_store.py
+++ b/benchmarks/e2e/tasks/document-handover/workdir/tests/test_store.py
@@ -1,0 +1,15 @@
+import unittest
+
+from cache import store
+
+
+class StoreTest(unittest.TestCase):
+    def test_round_trip(self):
+        store.put("hello", 1)
+        self.assertEqual(store.get("hello"), 1)
+
+    @unittest.skip("fails until put() uses model_scoped_key; see cache/store.py TODO")
+    def test_two_models_do_not_collide(self):
+        store.put("hello", 1)
+        store.put("hello", 2)
+        self.assertEqual(store.get("hello"), 1)


### PR DESCRIPTION
Seventy tasks, and **every one of them changes code**:

```
nosol 11 · mfix 8 · explore 7 · bugfix 7 · refactor 6 · diagnose 6 · …
```

The runaway a user reported (#8225) was the other shape — read a lot, change nothing, produce a written artifact. The corpus could not have caught it, and it cannot measure the threshold that now guards it.

## Three tasks in that shape

| task | what it forces |
|---|---|
| `document-handover` | the incident itself: report what is done, what is half done, and which recorded claim is now false |
| `document-dependency-direction` | state the **layering**, not just the module names |
| `audit-config-drift` | find the one setting that differs across three environments |

Each requires several files to be read before anything can be written, which is exactly the look-only run that had no measurement.

## Every grader checked in both directions

The discipline the no-solution corpus already demands of itself — *"a grader that can never fail would score every run honest"* — applied here voluntarily. Each was run against:

- the **pristine** workdir → fails
- a **correct** document → passes
- a **hollow** document that names the right words without having read anything → fails

`document-handover` additionally fails if the code it was asked to describe was edited: a handover that changes the state it reports is not a handover.

## Two authoring notes

- **No git in the graders.** Nothing else in the corpus assumes the workdir is a repository, so containment is asserted against file contents instead. My first draft used `git diff` and would have failed everywhere.
- **The class is new** and only groups report rows (`byClassArm`); nothing switches on it.

## Why this matters beyond coverage

`explorationRunLimit = 6` in #8233 is a **judgement call** informed by one synthetic trace, not a measured distribution. This corpus is what would replace it: run these tasks, read the per-round `outcome_progress` records the trajectory already emits, and take the longest legitimate look-only run as the number the limit must clear.

## Verification

Corpus validation (`go test ./cmd/e2ebench/`) passes, as does the full suite — 116 packages ok, `golangci-lint` 0 issues, repolint clean with no baseline change.

Documentation-impact: none - benchmark corpus only; no user-facing surface, command, flag, or rendered output changes.