### PR TITLE
feat(desktop): show loading placeholder while a tab hydrates

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4915,6 +4915,11 @@ export default function App() {
                 onManageAllowlist={() => openBotAllowlistSettings(sidebarImDetailConnection.connectionId)}
                 onOpenSession={() => void openSidebarImConnectionSession(sidebarImDetailConnection)}
               />
+            ) : transcriptHydrating ? (
+              <div className="loading-screen" role="status" aria-live="polite">
+                <span className="loading-screen__spinner" aria-hidden="true" />
+                <span className="loading-screen__text">{t("common.loading")}</span>
+              </div>
             ) : noticePreviewMockEnabled() ? (
               <NoticePreviewPanel />
             ) : (
@@ -5292,7 +5297,12 @@ export default function App() {
               </div>
             </div>
             <div className="workbench-dock__body">
-              {rightDockMode === "remote" ? (
+              {transcriptHydrating ? (
+                <div className="loading-screen" role="status" aria-live="polite">
+                  <span className="loading-screen__spinner" aria-hidden="true" />
+                  <span className="loading-screen__text">{t("common.loading")}</span>
+                </div>
+              ) : rightDockMode === "remote" ? (
                 <Suspense fallback={null}>
                   <RemotePanel onClose={() => setWorkspacePanel(false)} />
                 </Suspense>

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -507,6 +507,19 @@ ok(
 );
 
 ok(
+  Array.from(appSource.matchAll(/transcriptHydrating \? \(/g)).length === 2 &&
+    /<div className="loading-screen" role="status" aria-live="polite">/.test(appSource) &&
+    /loading-screen__text">\{t\("common\.loading"\)\}/.test(appSource) &&
+    /workbench-dock__body">[\s\S]*?\{transcriptHydrating \? \(/.test(appSource),
+  "tab switching shows a loading placeholder in both the transcript and right dock until history hydrates",
+);
+ok(
+  matchingBlocks(".loading-screen").length === 1 &&
+    /height: 100%/.test(matchingBlocks(".loading-screen")[0]),
+  "loading-screen shell fills the transcript and right dock while hydrating",
+);
+
+ok(
   /const creationEmptyHero =/.test(appSource) &&
     /!sidebarImDetailConnection/.test(appSource) &&
     /!transcriptHydrating/.test(appSource) &&

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3005,9 +3005,12 @@ a[href] {
   flex-direction: column;
 }
 
-/* loading screen shown while boot.Build runs in the background */
+/* loading screen shown while boot.Build runs in the background; also the
+   placeholder while a tab's history hydrates after switching (height: 100%
+   lets it fill the non-flex right dock body). */
 .loading-screen {
   flex: 1;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -2,14 +2,14 @@
   "limits": {
     "banner": 15,
     "commented-code": 0,
-    "complexity": 2096,
-    "essay": 4082,
-    "file-size": 110104,
-    "function-size": 9159,
+    "complexity": 2095,
+    "essay": 4081,
+    "file-size": 110089,
+    "function-size": 9152,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "test-file-size": 69905
+    "test-file-size": 69916
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -27,8 +27,8 @@
     },
     "desktop/app.go": {
       "complexity": 63,
-      "essay": 96,
-      "file-size": 11489,
+      "essay": 95,
+      "file-size": 11484,
       "function-size": 381
     },
     "desktop/app_autosave_test.go": {
@@ -84,10 +84,10 @@
       "essay": 2
     },
     "desktop/frontend/src/App.tsx": {
-      "file-size": 4733
+      "file-size": 4743
     },
     "desktop/frontend/src/__tests__/app-chrome-tabs.test.ts": {
-      "test-file-size": 19
+      "test-file-size": 32
     },
     "desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts": {
       "test-file-size": 307
@@ -308,7 +308,7 @@
     "desktop/tabs.go": {
       "complexity": 74,
       "essay": 133,
-      "file-size": 8716,
+      "file-size": 8715,
       "function-size": 630
     },
     "desktop/tabs_order_test.go": {
@@ -498,8 +498,8 @@
     "internal/agent/execute_one.go": {
       "complexity": 13,
       "essay": 23,
-      "file-size": 157,
-      "function-size": 20
+      "file-size": 142,
+      "function-size": 18
     },
     "internal/agent/extensions.go": {
       "essay": 64
@@ -1073,13 +1073,13 @@
     "internal/control/controller.go": {
       "complexity": 10,
       "essay": 162,
-      "file-size": 5420,
+      "file-size": 5416,
       "function-size": 75,
       "narrative": 4
     },
     "internal/control/controller_test.go": {
       "essay": 10,
-      "test-file-size": 4610
+      "test-file-size": 4608
     },
     "internal/control/errmsg.go": {
       "essay": 2
@@ -1166,9 +1166,9 @@
       "essay": 1
     },
     "internal/control/turn_orchestrator.go": {
-      "complexity": 2,
+      "complexity": 1,
       "essay": 13,
-      "function-size": 60
+      "function-size": 55
     },
     "internal/control/turn_orchestrator_test.go": {
       "essay": 1,


### PR DESCRIPTION
## What

Switching to another conversation now shows a loading placeholder in the
transcript and the right dock instead of the previous tab's stale items,
so the UI reads as "loading" instead of a frozen tab.

Reuses the boot loading-screen kit (one `height:100%` addition) and guards
the behavior with source assertions in `app-chrome-tabs.test.ts`.

Files: `desktop/frontend/src/App.tsx`, `styles.css`, plus tests. The
repolint baseline update records the resulting 10-line App.tsx and 13-line
test-file growth over the ratchet (no new violations beyond that).

## Verification

- `pnpm build` (tsc + vite + bundle budgets) passes
- `go run ./tools/repolint` clean (1957 baselined findings)

Cache-impact: none - provider-visible prefix is untouched (frontend-only change plus repolint baseline bookkeeping)
Cache-guard: no provider/boot/agent path in the diff; existing byte-stable prefix guard tests unchanged
Documentation-impact: none - no docs edited; behavior is a UI affordance, no docs claim the old frozen-tab behavior
