### PR TITLE
fix(ci): unblock Windows main-v2 full suite before v1.23.0 / 修复 Windows 全量 CI 以便发布 v1.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,14 @@ jobs:
         timeout-minutes: 5
         run: go test -timeout=3m -run '^TestBashPowerShellExecuteDetailedContract$|^TestBashPowerShell51PreflightRejectsAndAndDetailed$|^TestBashPowerShellOutputIsUTF8$|^TestBashPowerShellSurfacesNonZeroExit$|^TestBashPowerShellRejectsChaining$' ./internal/tool/builtin
 
+      # Full push suite still uses the same 8m package budget as Windows smoke:
+      # agent/boot/control already hit 180s package timeouts under runner load,
+      # so 3m fails on slow machines without a code regression. Keep the step
+      # above normal full-suite wall time (~8-12m) so a hang still dies on the
+      # job budget rather than a false package timeout.
       - name: test (full)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request'
-        timeout-minutes: 10
+        timeout-minutes: 20
         env:
           # Run the prompt-cache prefix-stability guard (TestCacheHit*) in CI: a
           # regression there silently tanks the cache hit rate the project is
@@ -182,7 +187,7 @@ jobs:
           # Bound sandbox helper children in Windows tests so a failed OS-level
           # launch cannot pin the Actions step after Go's package timeout fires.
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=3m ./...
+        run: go test -p 4 -timeout=8m ./...
 
       - name: test (Scoop desktop launch)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows'

--- a/internal/hook/windows_batch_test.go
+++ b/internal/hook/windows_batch_test.go
@@ -214,10 +214,7 @@ func TestDefaultSpawnerRunsPowerShellHookWithNestedQuotes(t *testing.T) {
 	// Cold PowerShell start under the Windows full suite (-p 4) can exceed the
 	// default 60s real-spawn budget when the runner is already hot from
 	// agent/boot/control packages. Keep the assertion, give the host longer.
-	timeout := realSpawnTimeout
-	if timeout < 2*time.Minute {
-		timeout = 2 * time.Minute
-	}
+	timeout := max(realSpawnTimeout, 2*time.Minute)
 	result := DefaultSpawner(context.Background(), SpawnInput{
 		Command: `$items = @("a b", "c'd", 'e"f', "中文", "🧪"); Write-Output ($items -join "|")`,
 		Mode:    ExecutionShell,

--- a/internal/hook/windows_batch_test.go
+++ b/internal/hook/windows_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/pluginpkg"
 	"reasonix/internal/sandbox"
@@ -210,11 +211,18 @@ func TestDefaultSpawnerRunsCompoundCmdShellHook(t *testing.T) {
 }
 
 func TestDefaultSpawnerRunsPowerShellHookWithNestedQuotes(t *testing.T) {
+	// Cold PowerShell start under the Windows full suite (-p 4) can exceed the
+	// default 60s real-spawn budget when the runner is already hot from
+	// agent/boot/control packages. Keep the assertion, give the host longer.
+	timeout := realSpawnTimeout
+	if timeout < 2*time.Minute {
+		timeout = 2 * time.Minute
+	}
 	result := DefaultSpawner(context.Background(), SpawnInput{
 		Command: `$items = @("a b", "c'd", 'e"f', "中文", "🧪"); Write-Output ($items -join "|")`,
 		Mode:    ExecutionShell,
 		Shell:   "powershell",
-		Timeout: realSpawnTimeout,
+		Timeout: timeout,
 	})
 	if result.ExitCode != 0 || result.SpawnErr != nil {
 		t.Fatalf("PowerShell hook failed: %+v", result)

--- a/internal/sessioninbox/store_test.go
+++ b/internal/sessioninbox/store_test.go
@@ -56,8 +56,7 @@ func TestEnqueueSnapshotAndRead(t *testing.T) {
 	if meta.ID != rec.ItemID || env.SubmitText != "hello world" {
 		t.Fatalf("read = meta=%+v env=%+v", meta, env)
 	}
-	// Permissions: dir 0700 on Unix. Windows reports 0777 for directories and
-	// does not enforce the same owner-only mode bits.
+	// Unix: dir 0700. Windows reports 0777 and does not enforce owner-only bits.
 	if runtime.GOOS != "windows" {
 		info, err := os.Stat(store.SessionInboxDir(session))
 		if err != nil {

--- a/internal/sessioninbox/store_test.go
+++ b/internal/sessioninbox/store_test.go
@@ -56,13 +56,16 @@ func TestEnqueueSnapshotAndRead(t *testing.T) {
 	if meta.ID != rec.ItemID || env.SubmitText != "hello world" {
 		t.Fatalf("read = meta=%+v env=%+v", meta, env)
 	}
-	// Permissions: dir 0700, blob 0600.
-	info, err := os.Stat(store.SessionInboxDir(session))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o700 {
-		t.Fatalf("inbox dir perm = %o", info.Mode().Perm())
+	// Permissions: dir 0700 on Unix. Windows reports 0777 for directories and
+	// does not enforce the same owner-only mode bits.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(store.SessionInboxDir(session))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o700 {
+			t.Fatalf("inbox dir perm = %o", info.Mode().Perm())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Unblock `main-v2` Windows push CI so v1.23.0 can be tagged.

Recent completed non-cancelled `ci.yml` runs on `main-v2` failed on
`test (windows-latest)` with:

- `panic: test timed out after 3m0s` in `internal/agent`, `internal/boot`,
  `internal/control` (exactly the runner-variance case already documented
  for the PR smoke suite)
- `TestEnqueueSnapshotAndRead`: `inbox dir perm = 777` on Windows
- `TestDefaultSpawnerRunsPowerShellHookWithNestedQuotes`: 60s spawn timeout
  under the full suite's `-p 4` load

## Changes

1. **Windows full push suite**: `-timeout=3m` → `-timeout=8m`, step budget
   `10m` → `20m` (aligned with the existing smoke-suite rationale).
2. **sessioninbox**: gate the 0700 directory mode assertion to non-Windows.
3. **hook**: allow 2m for the nested PowerShell spawn under Windows load.

## Why this is a release gate

`release-stable.sh` requires successful exact-SHA push CI, and
`release-testing.md` treats a red completed-run streak as a release blocker
even when an individual candidate later looks green.

## Verification

- [x] `go test ./internal/sessioninbox/ -count=1`
- [x] `GOOS=windows go test -c ./internal/hook/`
- [ ] CI `test (windows-latest)` green on this PR / post-merge main-v2

## Test plan

- [ ] Confirm Windows full suite no longer dies at 180s package timeouts
- [ ] Confirm sessioninbox and hook packages pass on Windows
- [ ] After merge, wait for green `main-v2` push CI before Prepare release for v1.23.0

Cache-impact: none
Cache-guard: n/a