### PR TITLE
docs: add keyless Parallel Search MCP example

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -934,6 +934,11 @@ name    = "stripe"
 type    = "http"
 url     = "https://mcp.stripe.com"
 headers = { Authorization = "Bearer ${STRIPE_KEY}" }
+
+[[plugins]]                       # free web search and URL fetching; no account or API key
+name = "parallel-search"
+type = "http"
+url  = "https://search.parallel.ai/mcp"
 ```
 
 Enabled MCP servers start connecting automatically in the background after a

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -737,6 +737,11 @@ name    = "stripe"
 type    = "http"
 url     = "https://mcp.stripe.com"
 headers = { Authorization = "Bearer ${STRIPE_KEY}" }
+
+[[plugins]]                       # 免费网页搜索和 URL 内容获取；无需账户或 API 密钥
+name = "parallel-search"
+type = "http"
+url  = "https://search.parallel.ai/mcp"
 ```
 
 启用的 MCP 服务器会在会话开始后于后台自动连接，因此工具上线期间聊天仍可正常使用。


### PR DESCRIPTION
## Summary

- Add an optional Parallel Search MCP configuration example to the English and Simplified Chinese guides.
- Keep the existing Stripe example unchanged while documenting a credential-free HTTP endpoint for web search and URL fetching.

## Issues

- None.

## Verification

- `git diff --check`
- `go test ./docs`
- Repository documentation-impact guard
- Credential-free MCP `initialize` and `tools/list`, confirming `web_search` and `web_fetch`

## Documentation impact

Documentation-impact: updated - added a keyless Parallel Search MCP configuration example

## Cache impact

Cache-impact: none - documentation-only change; the provider-visible prefix is unchanged
Cache-guard: not applicable - no cache-sensitive paths or runtime behavior changed
System-prompt-review: N/A

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.