### PR TITLE
docs(control): the chat Run ceiling is a backstop, not the judgement

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1386,15 +1386,10 @@ func (a *Agent) reserveParentWrite(runTool tool.Tool, args json.RawMessage, read
 }
 
 // Run appends the user input and drives the tool loop until the model returns a
-// final answer (no tool calls), the context is cancelled, or the provider errors.
-// With maxSteps <= 0 the loop is unbounded — the natural termination is the model
-// finishing, and the real safety bounds are user cancellation and compaction, not
-// a round count. A positive maxSteps imposes an optional hard guard, surfaced as
-// a resumable notice when hit.
-// Run is the agent lifecycle entry point: lifecycle setup, turn initialization,
-// tool-round loop, and deferred cleanup. Turn policy lives in beginRunTurn /
-// runToolLoop / handleFinalResponse / handleToolRound so the state machine stays
-// readable without changing provider-visible behavior or lock ownership.
+// final answer, the context is cancelled, or the provider errors. maxSteps <= 0
+// leaves the loop unbounded here: bounding it is the host's call, and the
+// adaptive stop is the no-progress ladder rather than a round count. Turn policy
+// lives in beginRunTurn / runToolLoop / handleFinalResponse / handleToolRound.
 func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	runMaxSteps := a.maxSteps
 	runMaxStepsKey := a.maxStepsKey

--- a/internal/control/run_ceiling.go
+++ b/internal/control/run_ceiling.go
@@ -7,19 +7,19 @@ import (
 	"reasonix/internal/tool"
 )
 
-// chatRunRoundLimit bounds one ordinary chat Run. Crossing it yields one
-// tool-free summary and a resumable pause, so setting it too low costs a
-// "continue" while leaving it unset costs hours.
+// chatRunRoundLimit is a backstop, not a budget. Judging when a turn stopped
+// earning its rounds belongs to the no-progress ladder, which covers the
+// wandering shape since evidence.explorationRunLimit; this only bounds a turn
+// whose judgement is wrong in a shape nobody has seen yet. Rounds count per
+// Run, so a "continue" starts them over — it does not bound a whole task.
 const (
 	chatRunRoundLimit = 100
 	chatRunRoundKey   = "chat model rounds"
 )
 
 // bindTurnScope installs the turn's Run ceiling and, for a Goal turn, the usage
-// recorder whose span stays active until the FSM commits. Ordinary chat had no
-// ceiling: max_steps was retired, and the adaptive guards cannot stand in —
-// they escalate on repetition and stay silent while a loop keeps finding
-// something new. An explicit max_steps still owns either turn.
+// recorder whose span stays active until the FSM commits. An explicit max_steps
+// still owns either turn.
 func (c *Controller) bindTurnScope(ctx context.Context, continuation *goalContinuationSnapshot) context.Context {
 	goalScopeID, goalScoped := c.goals.goalScopeIDForTurn(continuation)
 	if !goalScoped {


### PR DESCRIPTION
`bindTurnScope` told readers that the adaptive guards "escalate on repetition and stay silent while a loop keeps finding something new". That was accurate when #8228 landed and stopped being accurate an hour later, when #8233 added `evidence.explorationRunLimit`: a look-only run now stops scoring as progress past six rounds, so the no-progress ladder does reach its first rung on the wandering shape the ceiling was added for.

The stale claim matters because it reads the ceiling as the primary defence. It is not. It is the backstop for a shape the ladder has not learned yet, and two properties belong next to the constant instead of being inferred:

- the ladder owns the judgement, the ceiling owns only the case where the judgement is wrong
- rounds count per `Run`, so a "continue" starts them over - the ceiling bounds one turn, never a whole task

`Agent.Run`'s doc had the same gap from the other side: it named cancellation and compaction as the real safety bounds and omitted the ladder entirely. It also carried two overlapping paragraphs, collapsed here into one.

No behaviour change - comments only.

Cache-impact: none - comments only; the provider-visible prefix is byte-identical.
Cache-guard: existing - no code path changed, and the agent cache suites (`go test ./internal/agent/`) pass unchanged.
Documentation-impact: none - `docs/*.md` describes the pause behaviour, which is unchanged; this only corrects in-code claims about which mechanism owns it.
