### PR TITLE
fix(desktop): keep transcript auto-scroll pinned through stream end

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-scroll-controller.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-controller.test.ts
@@ -1,0 +1,61 @@
+// Run: tsx src/__tests__/transcript-scroll-controller.test.ts
+//
+// Pure-function tests for the transcript scroll arbitration rules
+// (#7420-family: pinned tail-follow must not be derailed by the virtualizer's
+// anchor compensation, and the stream-end fallback repin must never yank a
+// user who scrolled away).
+
+import { canTranscriptScrollOwnerWrite, shouldAdjustScrollOnItemSizeChange, shouldRunStreamEndRepin } from "../lib/transcriptScrollController";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+// ── shouldAdjustScrollOnItemSizeChange ──────────────────────────────────────
+// While pinned (tail-follow), row-size changes must be handled by the stream
+// repin path, never by the virtualizer's anchor compensation.
+
+ok(shouldAdjustScrollOnItemSizeChange(true, "tail-follow") === false, "pinned tail-follow: virtualizer must not compensate");
+ok(shouldAdjustScrollOnItemSizeChange(true, "manual") === false, "pinned manual: virtualizer must not compensate");
+ok(shouldAdjustScrollOnItemSizeChange(true, "programmatic") === false, "pinned programmatic: virtualizer must not compensate");
+
+ok(shouldAdjustScrollOnItemSizeChange(false, "tail-follow") === true, "not pinned: compensation allowed (anchor keeps the read position)");
+ok(shouldAdjustScrollOnItemSizeChange(false, "manual") === true, "not pinned manual: compensation allowed");
+ok(shouldAdjustScrollOnItemSizeChange(false, "programmatic") === true, "not pinned programmatic: compensation allowed");
+
+// Selection modes never compensate — the selection-edge scroll owns the viewport.
+ok(shouldAdjustScrollOnItemSizeChange(false, "native-selecting") === false, "selection: compensation disabled");
+ok(shouldAdjustScrollOnItemSizeChange(false, "logical-selecting") === false, "logical selection: compensation disabled");
+ok(shouldAdjustScrollOnItemSizeChange(true, "native-selecting") === false, "pinned selection: compensation disabled");
+
+// ── shouldRunStreamEndRepin ─────────────────────────────────────────────────
+// Only the live→absent transition while pinned triggers the fallback repin.
+
+ok(shouldRunStreamEndRepin(true, false, true) === true, "stream ended while pinned: repin");
+ok(shouldRunStreamEndRepin(true, false, false) === false, "stream ended while user scrolled away: no yank");
+ok(shouldRunStreamEndRepin(false, true, true) === false, "stream started: no repin");
+ok(shouldRunStreamEndRepin(false, false, true) === false, "no live at all: no repin");
+ok(shouldRunStreamEndRepin(true, true, true) === false, "stream still live: no repin");
+
+// ── canTranscriptScrollOwnerWrite: row-size owner ───────────────────────────
+// row-size repins behave like stream/container-resize repins: only in
+// tail-follow mode.
+
+ok(canTranscriptScrollOwnerWrite("tail-follow", "row-size") === true, "tail-follow allows row-size repin");
+ok(canTranscriptScrollOwnerWrite("manual", "row-size") === false, "manual mode blocks row-size repin");
+ok(canTranscriptScrollOwnerWrite("programmatic", "row-size") === false, "programmatic mode blocks row-size repin");
+ok(canTranscriptScrollOwnerWrite("native-selecting", "row-size") === false, "selection mode blocks row-size repin");
+ok(canTranscriptScrollOwnerWrite("tail-follow", "stream") === true, "tail-follow still allows stream repin");
+ok(canTranscriptScrollOwnerWrite("tail-follow", "virtualizer") === true, "virtualizer owner remains always writable for non-selection modes");
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,5 +1,5 @@
 import { memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
 import type { ControllerLiveStore, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import type { InvocationMetadataMap } from "../lib/invocationDisplay";
@@ -16,6 +16,7 @@ import { getProcessFoldPreference, onProcessFoldPreferenceChange, type ProcessFo
 import { STEER_NOTICE_PREFIX, isSteerNoticeText } from "../lib/useController";
 import { useTranscriptEntranceAnimation } from "../lib/useEntranceAnimation";
 import { useTranscriptScrollController } from "../lib/useTranscriptScrollController";
+import { shouldAdjustScrollOnItemSizeChange, shouldRunStreamEndRepin } from "../lib/transcriptScrollController";
 import { useTranscriptSelectionRetention } from "../lib/useTranscriptSelectionRetention";
 import { useTranscriptMeasurementInvalidation } from "../lib/useTranscriptMeasurementInvalidation";
 import { useTranscriptRowMeasurements } from "../lib/useTranscriptRowMeasurements";
@@ -217,9 +218,9 @@ export function Transcript({
     lastClientHeight,
     lastFooterHeight,
     setMode: setScrollMode,
+    modeRef: scrollModeRef,
     writeOffset,
     resetGeneration,
-    canVirtualizerAdjust,
     captureViewportAnchor,
     reconcileViewportAnchor,
   } = useTranscriptScrollController();
@@ -494,6 +495,22 @@ export function Transcript({
     };
   }, []);
 
+  // Stream-end fallback repin: when the live stream settles (turn_done clears
+  // the live snapshot) and the transcript is still pinned, wait a few frames
+  // for the synchronous markdown layout to settle and force the viewport to
+  // the bottom. Async worker-rendered growth lands after this and is covered
+  // by the row-measurement repin above. A user who scrolled away during the
+  // stream (not pinned) is never yanked back.
+  const prevLiveIdRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const hadLive = prevLiveIdRef.current !== undefined;
+    const hasLive = live?.id !== undefined;
+    prevLiveIdRef.current = live?.id;
+    if (shouldRunStreamEndRepin(hadLive, hasLive, stick.current)) {
+      scrollToBottomAfterLayout(3);
+    }
+  }, [live?.id, scrollToBottomAfterLayout, stick]);
+
   // ResizeObserver for container height changes.
   useEffect(() => {
     const el = scrollRef.current;
@@ -623,12 +640,26 @@ export function Transcript({
   });
   const getRowKey = useCallback((index: number) => `${tabId ?? ""}:${String(rows[index]?.key ?? index)}`, [rows, tabId]);
   const { estimateSize: estimateRowSize, layoutSnapshotRef, measureElement: measureRowSize } = useTranscriptRowMeasurements(tabId, rows);
+  // Row-size changes arrive from ResizeObserver-backed measurements (streaming
+  // tail growth, async markdown worker swaps, images). While pinned to the
+  // bottom, fold each measured change into the frame-batched repin so the
+  // viewport follows instead of relying on the virtualizer's anchor
+  // compensation (which would lift the viewport off the tail and, through the
+  // bottom-state re-evaluation, permanently disable auto-scroll).
+  const trackRowSizeChange = useCallback(
+    (element: HTMLDivElement, entry: ResizeObserverEntry | undefined, instance: Virtualizer<HTMLDivElement, HTMLDivElement>) => {
+      const height = measureRowSize(element, entry, instance);
+      if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
+      return height;
+    },
+    [measureRowSize, scheduleRepinIfWasPinned, stick],
+  );
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,
     getItemKey: getRowKey,
     estimateSize: estimateRowSize,
-    measureElement: measureRowSize,
+    measureElement: trackRowSizeChange,
     overscan: VIRTUAL_OVERSCAN_ROWS,
     rangeExtractor: selectionRetention.rangeExtractor,
     // Key-anchored compensation: prepended history pages, fold toggles and
@@ -645,7 +676,7 @@ export function Transcript({
     useAnimationFrameWithResizeObserver: true,
     onChange: () => selectionRetention.reconcileLogicalFocus(),
   });
-  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => canVirtualizerAdjust();
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => shouldAdjustScrollOnItemSizeChange(stick.current, scrollModeRef.current);
   useTranscriptMeasurementInvalidation({
     scrollRef,
     layoutSnapshotRef,

--- a/desktop/frontend/src/lib/transcriptScrollController.ts
+++ b/desktop/frontend/src/lib/transcriptScrollController.ts
@@ -10,6 +10,7 @@ export type TranscriptScrollOwner =
   | "stream"
   | "container-resize"
   | "footer-resize"
+  | "row-size"
   | "jump"
   | "rewind"
   | "jump-bottom"
@@ -41,10 +42,38 @@ export function isTranscriptSelectionMode(mode: TranscriptScrollMode): boolean {
 export function canTranscriptScrollOwnerWrite(mode: TranscriptScrollMode, owner: TranscriptScrollOwner): boolean {
   if (isTranscriptSelectionMode(mode)) return owner === "selection-edge-scroll";
   if (owner === "selection-edge-scroll") return false;
-  if (owner === "stream" || owner === "container-resize" || owner === "footer-resize") {
+  if (owner === "stream" || owner === "container-resize" || owner === "footer-resize" || owner === "row-size") {
     return mode === "tail-follow";
   }
   if (owner === "virtualizer") return true;
   if (EXPLICIT_OWNERS.has(owner)) return true;
   return mode === "reconciling";
+}
+
+/**
+ * Whether the virtualizer may compensate the scroll position when a row's
+ * measured size changes. Anchored compensation is keyed to the anchor row:
+ * while the transcript is pinned to the bottom (tail-follow), compensation
+ * lifts the viewport off the tail (or, for the streaming tail row, fights the
+ * per-frame repin), and the subsequent bottom-state re-evaluation sees a
+ * distance ≥ threshold — which permanently disables auto-scroll. While
+ * pinned, size changes must be handled by the stream repin path instead
+ * (scheduleRepinIfWasPinned / the row-measurement repin in Transcript), so
+ * the virtualizer must not compensate here at all.
+ */
+export function shouldAdjustScrollOnItemSizeChange(pinned: boolean, mode: TranscriptScrollMode): boolean {
+  if (pinned) return false;
+  return !isTranscriptSelectionMode(mode);
+}
+
+/**
+ * Whether a stream-end repin should run: the live stream just transitioned
+ * from present to absent (turn_done settles the assistant row) and the
+ * transcript is still pinned. The repin then waits a few frames for the
+ * synchronous markdown layout to settle; async worker-rendered growth is
+ * covered by the row-measurement repin. A user who scrolled away (not pinned)
+ * is never yanked back to the bottom.
+ */
+export function shouldRunStreamEndRepin(hadLive: boolean, hasLive: boolean, pinned: boolean): boolean {
+  return hadLive && !hasLive && pinned;
 }


### PR DESCRIPTION
## Problem

Fixes the transcript auto-scroll failure reported for long answers. Answer text ≥8000 chars (STREAMING_TAIL_THRESHOLD) renders its final blocks through an async markdown worker **after** the stream settles (`MarkdownHistory.tsx` → worker parse). Nothing repins after that layout growth:

- The streaming auto-scroll effect (`Transcript.tsx`) only runs on live token changes — after `turn_done` clears the live snapshot it never fires again.
- The virtualizer's anchor compensation (`anchorTo: "end"` + `shouldAdjustScrollPositionOnItemSizeChange`) keeps the *anchor row* in place instead of following the tail.
- The subsequent bottom-state re-evaluation (`useScrollManager.updateBottomState`) sees distance ≥ 80px, flips the transcript to `manual` mode, and **permanently disables auto-scroll** — the viewport is stuck mid-transcript with only the jump-to-bottom button as an escape.

## Fix

Two coordinated changes:

1. **Pinned rows never go through anchor compensation.** New pure rule `shouldAdjustScrollOnItemSizeChange(pinned, mode)`: while pinned (tail-follow) the virtualizer does not compensate on row-size changes. Every measured row-size change while pinned is instead folded into the existing frame-batched repin — the `measureElement` wrapper calls `scheduleRepinIfWasPinned` with a new `"row-size"` scroll owner — so tail growth, async worker swaps and image loads all keep the viewport at the bottom.

2. **Stream-end fallback repin.** When the live snapshot settles (`turn_done`) and the transcript is still pinned, `scrollToBottomAfterLayout(3)` waits a few frames for synchronous markdown layout and snaps to the bottom. A user who scrolled away during the stream (`shouldRunStreamEndRepin` gates on pinned) is never yanked back.

## Tests

- 20 assertions on the new pure arbitration functions: `shouldAdjustScrollOnItemSizeChange` (all mode×pinned quadrants incl. selection modes), `shouldRunStreamEndRepin` (repin only on live→absent while pinned), and `canTranscriptScrollOwnerWrite("row-size", …)` permissions.
- Existing `scroll-manager.test.tsx` suite still passes (17 assertions).
- `tsc --noEmit` and eslint clean.

Cache-impact: none - frontend-only rendering/scroll behavior
Cache-guard: none
System-prompt-review: none - no prompt, config schema, memory, output style, or skill behavior changes
Documentation-impact: none - fixes existing transcript scroll behavior; no CLI, docs or config surface changed
