### PR TITLE
fix(desktop): reduce streaming render jitter (webview coalescing + height-cache hygiene)

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-height-cache.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-height-cache.test.ts
@@ -1,0 +1,85 @@
+// Run: tsx src/__tests__/transcript-height-cache.test.ts
+//
+// Streaming rows must never be written into the height cache: their height is
+// a moving target and cached mid-stream values would poison later estimates
+// for the same row key (re-mounts would replay a transient height).
+
+import { createTranscriptMeasureElement } from "../lib/transcriptHeightCache";
+import type { TranscriptRow } from "../lib/transcriptRows";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function isStreamingRow(row: TranscriptRow | undefined): boolean {
+  if (!row) return false;
+  if (row.kind === "answer") return row.item.streaming;
+  if (row.kind === "reasoning") return row.item.streaming && !row.item.reasoningComplete;
+  return false;
+}
+
+ok(!isStreamingRow({ kind: "answer", key: "a:1", item: { streaming: false } } as TranscriptRow), "settled answer row is cached");
+ok(isStreamingRow({ kind: "answer", key: "a:1", item: { streaming: true } } as TranscriptRow), "streaming answer row is skipped");
+ok(isStreamingRow({ kind: "reasoning", key: "r:1", segmentKey: "s", item: { streaming: true, reasoningComplete: false } } as TranscriptRow), "streaming reasoning row is skipped");
+ok(!isStreamingRow({ kind: "reasoning", key: "r:1", segmentKey: "s", item: { streaming: true, reasoningComplete: true } } as TranscriptRow), "completed reasoning row is cached");
+ok(!isStreamingRow({ kind: "user", key: "u:1", item: {} } as TranscriptRow), "user row is cached");
+ok(!isStreamingRow(undefined), "missing row is cached");
+
+// Integration-level wiring: the measure element evaluates the skip predicate
+// per element and only settles cache writes for non-streaming rows.
+const rows: TranscriptRow[] = [
+  { kind: "answer", key: "a:stream", item: { streaming: true } },
+  { kind: "answer", key: "a:settled", item: { streaming: false } },
+];
+const cachedKeys: string[] = [];
+const measure = createTranscriptMeasureElement({
+  tabId: "tab",
+  getLayoutSnapshot: () => ({ signature: "w:0", width: 0 }),
+  cache: {
+    set(_tabId: string, _sig: string, rowKey: string) {
+      cachedKeys.push(rowKey);
+    },
+  } as never,
+  skipCacheWriteWhen: (el) => {
+    const rowKey = el.dataset.rowKey ?? "";
+    const row = rows.find((candidate) => String(candidate.key) === rowKey);
+    return row?.kind === "answer" && row.item.streaming;
+  },
+});
+
+const fakeRowElement = (rowKey: string): HTMLDivElement =>
+  ({
+    dataset: { rowKey },
+    getBoundingClientRect: () => ({ height: 90, width: 600, top: 0, left: 0, bottom: 90, right: 600, x: 0, y: 0, toJSON: () => ({}) }),
+    offsetHeight: 90,
+    clientHeight: 90,
+    scrollHeight: 90,
+  }) as unknown as HTMLDivElement;
+
+const fakeInstance = {
+  options: {},
+  indexFromElement: () => 0,
+  getItemKey: () => "k",
+  measurementsCache: new Map(),
+  getCurrentOffset: () => 0,
+  getDistanceFromEnd: () => 0,
+  getVirtualItems: () => [],
+  measureElement: () => 90,
+} as never;
+
+measure(fakeRowElement("a:stream"), {} as ResizeObserverEntry, fakeInstance);
+measure(fakeRowElement("a:settled"), {} as ResizeObserverEntry, fakeInstance);
+
+ok(JSON.stringify(cachedKeys) === JSON.stringify(["a:settled"]), `only settled rows cached, got ${JSON.stringify(cachedKeys)}`);
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/transcriptHeightCache.ts
+++ b/desktop/frontend/src/lib/transcriptHeightCache.ts
@@ -72,10 +72,13 @@ export function createTranscriptMeasureElement({
   tabId,
   getLayoutSnapshot,
   cache = transcriptHeightCache,
+  skipCacheWriteWhen,
 }: {
   tabId: string;
   getLayoutSnapshot: () => TranscriptLayoutSnapshot;
   cache?: TranscriptHeightCache;
+  /** Rows matching this predicate are measured but never written to the cache. */
+  skipCacheWriteWhen?: (element: HTMLDivElement) => boolean;
 }) {
   return (
     element: HTMLDivElement,
@@ -83,12 +86,18 @@ export function createTranscriptMeasureElement({
     instance: Virtualizer<HTMLDivElement, HTMLDivElement>,
   ): number => {
     const height = measureVirtualElement(element, entry, instance);
-    cache.set(
-      tabId,
-      getLayoutSnapshot().signature,
-      element.dataset.rowKey ?? String(element.dataset.index ?? ""),
-      height,
-    );
+    // A streaming row's height is a moving target (tail growth, live code
+    // highlighting, worker swaps); caching intermediate values poisons later
+    // estimates for the same row key (re-mounts replay that mid-stream
+    // height). Settled rows keep writing their final measured height.
+    if (!skipCacheWriteWhen?.(element)) {
+      cache.set(
+        tabId,
+        getLayoutSnapshot().signature,
+        element.dataset.rowKey ?? String(element.dataset.index ?? ""),
+        height,
+      );
+    }
     return height;
   };
 }

--- a/desktop/frontend/src/lib/useTranscriptRowMeasurements.ts
+++ b/desktop/frontend/src/lib/useTranscriptRowMeasurements.ts
@@ -18,9 +18,24 @@ export function useTranscriptRowMeasurements(tabId: string | undefined, rows: re
       fallback: estimateTranscriptRowSize(row),
     });
   }, [rows, tabId]);
+  // Streaming rows are measured but never cached: their height is a moving
+  // target during tail growth / live code highlighting, and caching it would
+  // poison later estimates for the same row key (see transcriptHeightCache).
+  // Both answer and reasoning rows stream (answer: item.streaming; reasoning:
+  // item.streaming && !reasoningComplete, same rule as segmentHasRunningWork).
+  const skipCacheWriteWhen = useCallback((element: HTMLDivElement): boolean => {
+    const rowKey = element.dataset.rowKey;
+    if (!rowKey) return false;
+    const row = rows.find((candidate) => String(candidate.key) === rowKey);
+    if (!row) return false;
+    if (row.kind === "answer") return row.item.streaming;
+    if (row.kind === "reasoning") return row.item.streaming && !row.item.reasoningComplete;
+    return false;
+  }, [rows]);
   const measureElement = useMemo(() => createTranscriptMeasureElement({
     tabId: tabId ?? "",
     getLayoutSnapshot: () => layoutSnapshotRef.current,
-  }), [tabId]);
+    skipCacheWriteWhen,
+  }), [tabId, skipCacheWriteWhen]);
   return { estimateSize, layoutSnapshotRef, measureElement };
 }

--- a/desktop/tab_stream_coalescer.go
+++ b/desktop/tab_stream_coalescer.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+// webviewStreamWindow is how long text/reasoning deltas are held before the
+// webview channel is flushed with one merged event. 16ms ≈ one 60Hz frame:
+// the frontend coalesces a second time per animation frame, so the merged
+// event rate never exceeds the repaint rate.
+const webviewStreamWindow = 16 * time.Millisecond
+
+// webviewStreamCoalescer merges consecutive same-kind text/reasoning deltas
+// for the same tab+submission+runtimeEpoch into one wire event per window,
+// immediately before the Wails webview event channel. The agent emits one
+// event per model chunk (hundreds per second on a fast stream); each one
+// crosses the Wails IPC bridge and queues behind the single webview channel,
+// which blocks runtime.EventsEmit when backed up and turns burst latency into
+// visible input lag. Merging preserves event order and the reasoning→text
+// boundary (a kind, submission or epoch switch flushes), and is invisible to
+// every other consumer — bot sinks, project-tree metadata, telemetry and the
+// display buffer all observe before this point.
+//
+// The flush callback runs OUTSIDE the mutex: the emit path may block on the
+// webview channel, and holding the lock there would stall the agent's event
+// loop (runtime.EventsEmit may block; see asyncRuntimeEmitter).
+type webviewStreamCoalescer struct {
+	mu      sync.Mutex
+	window  time.Duration
+	emit    runtimeEventEmitFunc // (ctx, name, payload...)
+	ctx     func() context.Context
+	timer   *time.Timer
+	pending *webviewStreamPending
+	// gen identifies the current window. Timer callbacks capture the gen they
+	// armed and flush only if it still matches: a stale callback that lost the
+	// lock race to a Push must neither stop the newer timer nor drain the
+	// newer window (which would truncate the merge and reorder emissions).
+	gen uint64
+}
+
+// webviewStreamPending accumulates one merged delta within the window. base
+// keeps the first delta's full field set (meta, flags, …) so the merged wire
+// event is the first delta with its text/reasoning payload extended.
+type webviewStreamPending struct {
+	tabID        string
+	runtimeEpoch string
+	submissionID string
+	kind         event.Kind
+	base         event.Event
+	text         strings.Builder
+}
+
+func newWebviewStreamCoalescer(ctx func() context.Context, emit runtimeEventEmitFunc) *webviewStreamCoalescer {
+	if emit == nil {
+		emit = runtimeEventsEmitFallback
+	}
+	return &webviewStreamCoalescer{window: webviewStreamWindow, ctx: ctx, emit: emit}
+}
+
+// Push merges e into the pending window. Non-stream deltas flush the window
+// first and are emitted immediately (causal ordering with the merged event).
+// The pending runtimeEpoch participates in the merge key so a runtime rebuild
+// (epoch change) can never ride a stale window: the frontend filters whole
+// events by epoch equality, so a merged event stamped with an old epoch would
+// silently drop new text after a rebuild.
+func (c *webviewStreamCoalescer) Push(e event.Event, tabID, runtimeEpoch, submissionID string) {
+	streamKind := e.Kind == event.Text || e.Kind == event.Reasoning
+
+	c.mu.Lock()
+	p := c.pending
+	continues := streamKind && p != nil && p.kind == e.Kind &&
+		p.tabID == tabID && p.submissionID == submissionID && p.runtimeEpoch == runtimeEpoch
+	var flushed *webviewStreamPending
+	if !continues {
+		flushed = c.takePendingLocked()
+	}
+	if continues {
+		appendDelta(p, e)
+		c.mu.Unlock()
+		return
+	}
+	if streamKind {
+		p = &webviewStreamPending{
+			tabID:        tabID,
+			runtimeEpoch: runtimeEpoch,
+			submissionID: submissionID,
+			kind:         e.Kind,
+			base:         e,
+		}
+		appendDelta(p, e)
+		c.pending = p
+		c.gen++
+		if c.timer == nil {
+			gen := c.gen
+			c.timer = time.AfterFunc(c.window, func() { c.flushGen(gen) })
+		}
+	}
+	c.mu.Unlock()
+
+	if flushed != nil {
+		c.emitMerged(flushed)
+	}
+	if !streamKind {
+		c.emitOne(e, tabID, runtimeEpoch, submissionID)
+	}
+}
+
+// Flush emits the pending merged event (if any) and stops the window timer.
+// Safe to call from the timer goroutine or externally (sink teardown).
+func (c *webviewStreamCoalescer) Flush() {
+	c.mu.Lock()
+	gen := c.gen
+	c.mu.Unlock()
+	c.flushGen(gen)
+}
+
+// flushGen flushes the window identified by gen, unless a newer window has
+// already replaced it (a stale timer callback that lost the lock race to a
+// Push). A stale callback must not stop the newer timer or drain the newer
+// window: that would truncate the merge window and emit the two windows out
+// of order.
+func (c *webviewStreamCoalescer) flushGen(gen uint64) {
+	c.mu.Lock()
+	if c.gen != gen {
+		c.mu.Unlock()
+		return
+	}
+	p := c.takePendingLocked()
+	c.mu.Unlock()
+	if p != nil {
+		c.emitMerged(p)
+	}
+}
+
+// takePendingLocked stops the window timer and detaches the pending delta.
+// Callers must not emit while holding the lock.
+func (c *webviewStreamCoalescer) takePendingLocked() *webviewStreamPending {
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	p := c.pending
+	c.pending = nil
+	return p
+}
+
+func appendDelta(p *webviewStreamPending, e event.Event) {
+	if e.Kind == event.Text {
+		p.text.WriteString(e.Text)
+	} else {
+		p.text.WriteString(e.Reasoning)
+	}
+}
+
+func (c *webviewStreamCoalescer) emitMerged(p *webviewStreamPending) {
+	merged := p.base
+	switch p.kind {
+	case event.Text:
+		merged.Text = p.text.String()
+	default:
+		merged.Reasoning = p.text.String()
+	}
+	c.emitOne(merged, p.tabID, p.runtimeEpoch, p.submissionID)
+}
+
+func (c *webviewStreamCoalescer) emitOne(e event.Event, tabID, runtimeEpoch, submissionID string) {
+	if c.ctx == nil {
+		return
+	}
+	ctx := c.ctx()
+	if ctx == nil {
+		return
+	}
+	c.emit(ctx, eventChannel, toWireTabWithSubmission(e, tabID, runtimeEpoch, submissionID))
+}

--- a/desktop/tab_stream_coalescer_test.go
+++ b/desktop/tab_stream_coalescer_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+type captureWebviewEmit struct {
+	ctx    context.Context
+	calls  atomic.Int32
+	wire   chan wireEventTab
+	merged chan string
+}
+
+func newCaptureWebviewEmit() *captureWebviewEmit {
+	return &captureWebviewEmit{
+		ctx:    context.Background(),
+		wire:   make(chan wireEventTab, 32),
+		merged: make(chan string, 32),
+	}
+}
+
+func wireFromPayload(payload any) (wireEventTab, string, bool) {
+	switch w := payload.(type) {
+	case wireEventTab:
+		return w, "", true
+	case correlatedWireEventTab:
+		return w.wireEventTab, w.SubmissionID, true
+	}
+	return wireEventTab{}, "", false
+}
+
+func (c *captureWebviewEmit) emitFn(_ context.Context, name string, payload ...any) {
+	if name != eventChannel {
+		return
+	}
+	if len(payload) != 1 {
+		return
+	}
+	w, _, ok := wireFromPayload(payload[0])
+	if !ok {
+		return
+	}
+	c.calls.Add(1)
+	c.wire <- w
+	if w.Text != "" {
+		c.merged <- w.Text
+	}
+}
+
+func TestWebviewStreamCoalescerMergesTextDeltasWithinWindow(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "a"}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "b"}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "c"}, "tab1", "", "sub1")
+	coalescer.Flush()
+
+	if got := c.calls.Load(); got != 1 {
+		t.Fatalf("webview emits = %d, want 1 merged event", got)
+	}
+	select {
+	case got := <-c.merged:
+		if got != "abc" {
+			t.Fatalf("merged text = %q, want abc", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for merged event")
+	}
+}
+
+func TestWebviewStreamCoalescerReasoningTextBoundaryFlushes(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Reasoning, Reasoning: "think"}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "answer"}, "tab1", "", "sub1")
+	coalescer.Flush()
+
+	if got := c.calls.Load(); got != 2 {
+		t.Fatalf("webview emits = %d, want 2 (reasoning and text are not merged)", got)
+	}
+}
+
+func TestWebviewStreamCoalescerDifferentSubmissionsNotMerged(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "first"}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "second"}, "tab1", "", "sub2")
+	coalescer.Flush()
+
+	texts := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-c.merged:
+			texts = append(texts, got)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+	if !strings.Contains(strings.Join(texts, "|"), "first") || !strings.Contains(strings.Join(texts, "|"), "second") {
+		t.Fatalf("both submission texts must survive, got %v", texts)
+	}
+}
+
+func TestWebviewStreamCoalescerNonStreamEventFlushesImmediately(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "pending"}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.TurnDone}, "tab1", "", "")
+	coalescer.Flush()
+
+	if got := c.calls.Load(); got != 2 {
+		t.Fatalf("webview emits = %d, want 2 (turn_done flushes the pending text first)", got)
+	}
+	select {
+	case got := <-c.merged:
+		if got != "pending" {
+			t.Fatalf("pending text = %q, want pending", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for flushed text")
+	}
+}
+
+func TestWebviewStreamCoalescerTimerFlushesWithoutFurtherPushes(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "lonely"}, "tab1", "", "sub1")
+
+	select {
+	case got := <-c.merged:
+		if got != "lonely" {
+			t.Fatalf("timer-flushed text = %q, want lonely", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for the window timer to flush")
+	}
+}
+
+// TestTabEventSinkMergesWebviewButKeepsBotSinkPerEvent: the coalescer sits on
+// the webview exit only. Bot sinks and the project-tree metadata path must
+// keep receiving every event unchanged.
+func TestTabEventSinkMergesWebviewButKeepsBotSinkPerEvent(t *testing.T) {
+	var botEvents atomic.Int32
+	sink := &tabEventSink{
+		tabID: "tab",
+		ctx:   context.Background(),
+	}
+	captured := newCaptureWebviewEmit()
+	sink.webviewCoalescer = newWebviewStreamCoalescer(func() context.Context { return sink.context() }, captured.emitFn)
+	sink.runtimeEvents.emit = captured.emitFn
+
+	sink.SetBotSink(event.FuncSink(func(e event.Event) {
+		botEvents.Add(1)
+	}))
+
+	wrapped := event.Sync(sink)
+	wrapped.Emit(event.Event{Kind: event.Text, Text: "x"})
+	wrapped.Emit(event.Event{Kind: event.Text, Text: "y"})
+	wrapped.Emit(event.Event{Kind: event.Text, Text: "z"})
+	sink.webviewCoalescer.Flush()
+
+	select {
+	case got := <-captured.merged:
+		if got != "xyz" {
+			t.Fatalf("webview merged text = %q, want xyz", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for the merged webview event")
+	}
+	if got := botEvents.Load(); got != 3 {
+		t.Fatalf("bot sink received %d events, want 3 (merge must not reach bot sinks)", got)
+	}
+}
+
+func TestWebviewStreamCoalescerEpochSwitchFlushes(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "before"}, "tab1", "epoch-1", "sub1")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "after"}, "tab1", "epoch-2", "sub1")
+	coalescer.Flush()
+
+	if got := c.calls.Load(); got != 2 {
+		t.Fatalf("webview emits = %d, want 2 (epoch switch must flush)", got)
+	}
+	seen := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case w := <-c.wire:
+			seen = append(seen, w.Text+"@"+w.RuntimeEpoch)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+	if strings.Join(seen, "|") != "before@epoch-1|after@epoch-2" {
+		t.Fatalf("epoch-stamped events = %v, want before@epoch-1, after@epoch-2", seen)
+	}
+}
+
+func TestWebviewStreamCoalescerMergesReasoningWithinWindow(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	coalescer.Push(event.Event{Kind: event.Reasoning, Reasoning: "think "}, "tab1", "", "sub1")
+	coalescer.Push(event.Event{Kind: event.Reasoning, Reasoning: "hard"}, "tab1", "", "sub1")
+	coalescer.Flush()
+
+	if got := c.calls.Load(); got != 1 {
+		t.Fatalf("webview emits = %d, want 1 merged reasoning event", got)
+	}
+	select {
+	case w := <-c.wire:
+		// captureWebviewEmit only mirrors Text into merged; assert directly.
+		if w.Reasoning != "think hard" {
+			t.Fatalf("merged reasoning = %q, want %q", w.Reasoning, "think hard")
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for merged reasoning event")
+	}
+}
+
+// TestWebviewStreamCoalescerStaleGenFlushIsIgnored: a timer callback that
+// lost the lock race to a Push must not drain the newer window. Simulate the
+// race by arming the flush for the first window's generation, then replacing
+// the window (a submission switch flushes the first window and opens a new
+// one): the stale generation flush must be a no-op, and the newer window
+// still merges its own deltas.
+func TestWebviewStreamCoalescerStaleGenFlushIsIgnored(t *testing.T) {
+	c := newCaptureWebviewEmit()
+	coalescer := newWebviewStreamCoalescer(func() context.Context { return c.ctx }, c.emitFn)
+
+	// Lengthen the window so the real timers never fire during this test;
+	// only explicit flushGen/Flush calls move the windows.
+	coalescer.window = time.Hour
+
+	coalescer.Push(event.Event{Kind: event.Text, Text: "one"}, "tab1", "", "sub1")
+	staleGen := coalescer.gen // window 1
+
+	// Submission switch: flushes window 1 (emits "one") and opens window 2.
+	coalescer.Push(event.Event{Kind: event.Text, Text: "two"}, "tab1", "", "sub2")
+	coalescer.Push(event.Event{Kind: event.Text, Text: "!"}, "tab1", "", "sub2")
+	// Consume the first window's own emission from the submission switch.
+	select {
+	case got := <-c.merged:
+		if got != "one" {
+			t.Fatalf("first window text = %q, want one", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first window was not flushed by the submission switch")
+	}
+
+	coalescer.flushGen(staleGen) // stale callback fires: must be a no-op
+	select {
+	case <-c.merged:
+		t.Fatal("stale generation flush emitted a window it did not own")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	coalescer.Flush()
+	select {
+	case got := <-c.merged:
+		if got != "two!" {
+			t.Fatalf("current window text = %q, want two!", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("current window was not flushed")
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1550,6 +1550,10 @@ type tabEventSink struct {
 	botSink       event.Sink // optional: when set, events are also forwarded here
 	botSinkGen    uint64
 	turn          turnSubmissionState // stays reserved through the end of TurnDone fan-out
+	// webviewCoalescer merges per-chunk text/reasoning deltas before the Wails
+	// webview channel (see tab_stream_coalescer.go). nil keeps the legacy
+	// per-event emission (used by tests constructing bare sinks).
+	webviewCoalescer *webviewStreamCoalescer
 }
 
 type closeableEventSink interface {
@@ -1557,6 +1561,15 @@ type closeableEventSink interface {
 }
 
 // binding snapshots the sink's current tab routing under the sink lock.
+// newTabEventSink builds a tab sink whose webview coalescer reads the sink's
+// own context (set later via setContext when the tab activates) so merged
+// events only emit while the tab runtime is live.
+func (a *App) newTabEventSink(tabID string) *tabEventSink {
+	s := &tabEventSink{tabID: tabID, app: a}
+	s.webviewCoalescer = newWebviewStreamCoalescer(s.context, nil)
+	return s
+}
+
 func (s *tabEventSink) binding() (string, *App) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1608,7 +1621,13 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.flushDisplay(e.Cancelled)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot()))
+	epoch := s.runtimeEpochSnapshot()
+	submissionID := s.submissionIDSnapshot()
+	if s.webviewCoalescer != nil {
+		s.webviewCoalescer.Push(e, tabID, epoch, submissionID)
+	} else {
+		s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, epoch, submissionID))
+	}
 	if app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update {
 			changed := app.setTabActivityStatus(tabID, status)
@@ -2470,7 +2489,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 		disabledMCP:      map[string]ServerView{},
 	}
 	applyTabSessionProfile(tab, profile)
-	tab.sink = &tabEventSink{tabID: tabID, app: a}
+	tab.sink = a.newTabEventSink(tabID)
 
 	a.tabs[tabID] = tab
 	a.tabOrder = append(a.tabOrder, tabID)
@@ -2725,7 +2744,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 			disabledMCP:      inheritedDisabledMCP,
 			mcpOrder:         inheritedMCPOrder,
 		}
-		created.sink = &tabEventSink{tabID: tabID, app: a}
+		created.sink = a.newTabEventSink(tabID)
 		a.tabs[tabID] = created
 		a.tabOrder = append(a.tabOrder, tabID)
 		a.activeTabID = tabID
@@ -2781,7 +2800,7 @@ func (a *App) ensureBlankTab(scope, workspaceRoot, forcedTokenMode string) (TabM
 		disabledMCP:      inheritedDisabledMCP,
 		mcpOrder:         inheritedMCPOrder,
 	}
-	created.sink = &tabEventSink{tabID: tabID, app: a}
+	created.sink = a.newTabEventSink(tabID)
 	a.tabs[tabID] = created
 	a.tabOrder = append(a.tabOrder, tabID)
 	a.activeTabID = tabID
@@ -3271,6 +3290,11 @@ func (a *App) closeTab(tabID string, allowDetach bool) error {
 	closeCtrl := tab.Ctrl
 	closeSink := tab.sink
 	a.mu.Unlock()
+	// Drain the webview coalescer so the final ≤16ms of streamed text is not
+	// silently dropped when the tab closes (the sink's timer may never fire).
+	if closeSink != nil && closeSink.webviewCoalescer != nil {
+		closeSink.webviewCoalescer.Flush()
+	}
 	if a.workspaceHub != nil {
 		a.workspaceHub.reconcileRoots()
 	}


### PR DESCRIPTION
## Problem

Streaming rendering jitter on fast model streams. Two compounding sources:

1. **Per-chunk IPC floods the webview channel.** The agent emits one event per model chunk (`internal/agent/agent.go` emits `Text`/`Reasoning` per chunk); `tabEventSink.Emit` forwards every event to Wails `runtime.EventsEmit` one by one. When the single webview event channel backs up, `EventsEmit` blocks, backlog latency spikes, and the frontend's per-frame batch drains a stale backlog in one jump instead of a smooth stream.
2. **Mid-stream heights poison the measurement cache.** Streaming rows are measured every frame (tail growth, live code highlighting); those transient heights were written into `transcriptHeightCache`, so a later re-mount of the same row key (history replay, tab switch) started from a mid-stream height and settled with a second viewport jump.

## Fix

1. **`webviewStreamCoalescer`** (new, `desktop/tab_stream_coalescer.go`): merges consecutive same-kind text/reasoning deltas for the same tab+submission into one wire event per 16ms window (one 60Hz frame — the frontend already coalesces a second time per frame, so the merged rate never exceeds the repaint rate). Event order and the reasoning→text boundary are preserved (a kind or submission switch flushes immediately). The merge sits **only on the webview exit**: bot sinks, project-tree metadata, telemetry and the display buffer keep receiving every event unchanged.
2. **Streaming rows never write the height cache.** `createTranscriptMeasureElement` accepts a `skipCacheWriteWhen` predicate; `useTranscriptRowMeasurements` matches answer rows whose `item.streaming` is still true. Settled rows keep writing their final measured height.

## Tests

Go (`tab_stream_coalescer_test.go`, all pass; full `go test ./desktop/...` green):
- window merge of consecutive text deltas
- reasoning→text boundary flushes separately
- different submissions never merge
- non-stream events (e.g. `turn_done`) flush the pending delta immediately
- window timer flushes a lone delta without further pushes
- sink-level: bot sinks still receive every event unchanged while the webview gets the merged stream

Frontend (`transcript-height-cache.test.ts`, 5 assertions; `tsc --noEmit` and eslint clean):
- predicate matching for streaming/settled/user/missing rows
- integration check that only settled rows reach the cache through the measure element

Cache-impact: none - frontend rendering path + Wails event bridge only; no prompt or tool schema bytes change
Cache-guard: none
System-prompt-review: none - no prompt, config schema, memory, output style, or skill behavior changes
Documentation-impact: none - internal rendering/IPC performance fix; no CLI, docs or config surface changed
