### PR TITLE
fix(config): avoid headless keyring probe hangs

### DIFF
--- a/internal/config/credentials_keyring_unix.go
+++ b/internal/config/credentials_keyring_unix.go
@@ -3,14 +3,26 @@
 package config
 
 import (
+	"context"
+	"os"
 	"strings"
+	"time"
 
+	dbus "github.com/godbus/dbus/v5"
 	ss "github.com/zalando/go-keyring/secret_service"
 )
+
+const legacyKeyringProbeTimeout = 2 * time.Second
 
 func legacyKeyringCredentialValue(key string) (string, bool) {
 	key = strings.TrimSpace(key)
 	if key == "" {
+		return "", false
+	}
+	// A session bus is not available on most headless hosts. Avoid creating a
+	// Secret Service connection there because the provider can wait forever for
+	// a reply from a bus that has no secrets service.
+	if strings.TrimSpace(os.Getenv("DBUS_SESSION_BUS_ADDRESS")) == "" {
 		return "", false
 	}
 
@@ -20,7 +32,10 @@ func legacyKeyringCredentialValue(key string) (string, bool) {
 	}
 	defer svc.Conn.Close()
 
-	collection := svc.GetLoginCollection()
+	collection, err := legacyKeyringLoginCollection(svc)
+	if err != nil {
+		return "", false
+	}
 	search := map[string]string{
 		"username": key,
 		"service":  credentialsKeyringService,
@@ -47,4 +62,29 @@ func legacyKeyringCredentialValue(key string) (string, bool) {
 		return "", false
 	}
 	return string(secret.Value), true
+}
+
+func legacyKeyringLoginCollection(svc *ss.SecretService) (dbus.BusObject, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), legacyKeyringProbeTimeout)
+	defer cancel()
+
+	var value dbus.Variant
+	err := svc.Conn.Object("org.freedesktop.secrets", "/org/freedesktop/secrets").
+		CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0,
+			"org.freedesktop.Secret.Service.Collections").Store(&value)
+	if err != nil {
+		return nil, err
+	}
+	paths, ok := value.Value().([]dbus.ObjectPath)
+	if !ok {
+		return nil, dbus.ErrMsgInvalidArg
+	}
+
+	login := dbus.ObjectPath("/org/freedesktop/secrets/collection/login")
+	for _, path := range paths {
+		if path == login {
+			return svc.Object("org.freedesktop.secrets", path), nil
+		}
+	}
+	return svc.Object("org.freedesktop.secrets", "/org/freedesktop/secrets/aliases/default"), nil
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // legacyHome points HOME / config-dir / .env resolution at a fresh temp tree and
@@ -805,6 +806,24 @@ func TestMigrateLegacyCredentialsSkipsKeyringWhenIsolated(t *testing.T) {
 	}
 	if _, err := os.Stat(UserCredentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("isolated runtime imported legacy credentials to %s; stat err=%v", UserCredentialsPath(), err)
+	}
+}
+
+func TestLegacyKeyringLookupSkipsWithoutSessionBus(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Secret Service lookup is Linux-specific")
+	}
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = legacyKeyringCredentialValue("DEEPSEEK_API_KEY")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("legacy keyring lookup did not return without a session bus")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Skip legacy Secret Service credential probing when no session bus is configured.
- Bound the initial Secret Service collection probe with a 2-second context timeout.
- Add a Linux regression test for headless startup behavior.

## Issues

Fixes #8129

## Verification

- `go test ./...`
- `git diff --check`
- Built the CLI and ran `serve --help` with `DBUS_SESSION_BUS_ADDRESS` unset, `REASONIX_HOME` unset, and a fresh `HOME`; it exited normally and printed usage.

## Documentation impact

Documentation-impact: none - this changes an internal startup guard; existing isolated/headless configuration guidance remains correct.

## Cache impact

Cache-impact: none - this only changes legacy credential migration and does not alter prompts, tools, providers, or request serialization.
Cache-guard: Not applicable; `go test ./...` covers the changed configuration package.
System-prompt-review: N/A
