### PR TITLE
feat(agent): one arbiter delivers a round's guard signals

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2532,7 +2532,7 @@ const loopGuardBlockErrMsg = "blocked by loop guard"
 // blocker (see loopGuardAllowsFinal). The hard maxSteps guard remains the
 // ultimate backstop; this just keeps the loop from burning that whole budget
 // bouncing off the same host refusals.
-func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) string {
+func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, receiptMark int) intervention {
 	allBlocked := len(outcomes) > 0
 	for _, outcome := range outcomes {
 		if !outcome.blocked {
@@ -2564,7 +2564,7 @@ func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutc
 	stormHit := ok && a.stormCount >= stormBreakThreshold
 	streakHit := allBlocked && a.blockedTurnStreak >= stormBreakThreshold
 	if !stormHit && !streakHit {
-		return ""
+		return intervention{}
 	}
 
 	const blockedAdvice = "Change approach: do not keep retrying a blocked tool by changing the tool, command, or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
@@ -2603,10 +2603,13 @@ func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutc
 			"loop guard: every tool call blocked %d turns in a row — nudging the model to change approach",
 			a.blockedTurnStreak)
 	}
-	results[0] = outcomes[0].output + "\n\n" + guard
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard, Text: loopGuardNoticeText(), Detail: detail})
 	a.armLoopGuardPass(receiptMark)
-	return detail
+	return intervention{
+		verdict:     verdictRedirect,
+		guidance:    guard,
+		notice:      noticeFor(event.NoticeCodeLoopGuard, event.LevelInfo, loopGuardNoticeText(), detail),
+		stuckReason: detail,
+	}
 }
 
 func loopGuardNoticeText() string {

--- a/internal/agent/arbiter.go
+++ b/internal/agent/arbiter.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"strings"
+
+	"reasonix/internal/event"
+)
+
+// verdict is the escalation ladder every run signal speaks. A round reduces its
+// signals to the strongest one, so a land raised beside an advise still lands.
+type verdict int
+
+const (
+	verdictContinue verdict = iota
+	verdictAdvise
+	verdictRedirect
+	verdictLand
+)
+
+// intervention is one signal's decision for a round. Guidance reaches the model
+// as environment feedback on the round tail rather than as a synthesized user
+// turn: the host is not the user, and a fake user turn competes with real user
+// text when compaction decides what to keep.
+type intervention struct {
+	verdict  verdict
+	guidance string
+	notice   *event.Event
+	// stuckReason is what this signal contributes to a Goal structural-stuck
+	// pause. Ordinary turns carry it and ignore it.
+	stuckReason string
+}
+
+func (i intervention) fired() bool {
+	return i.verdict != verdictContinue || i.guidance != "" || i.notice != nil
+}
+
+// applyInterventions folds a round's signals into one outcome: the strongest
+// verdict, every notice, and all guidance appended to the round tail in signal
+// order. Signals used to write that slot directly from outcomes[0].output, so
+// two firing in the same round silently dropped the earlier one's guidance.
+func (a *Agent) applyInterventions(results []string, outcomes []toolOutcome, ivs ...intervention) verdict {
+	strongest := verdictContinue
+	guidance := make([]string, 0, len(ivs))
+	for _, iv := range ivs {
+		if !iv.fired() {
+			continue
+		}
+		if iv.verdict > strongest {
+			strongest = iv.verdict
+		}
+		if iv.notice != nil {
+			a.sink.Emit(*iv.notice)
+		}
+		if iv.guidance != "" {
+			guidance = append(guidance, iv.guidance)
+		}
+	}
+	if len(guidance) == 0 || len(results) == 0 || len(outcomes) == 0 {
+		return strongest
+	}
+	results[0] = outcomes[0].output + "\n\n" + strings.Join(guidance, "\n\n")
+	return strongest
+}
+
+// noticeFor builds the frontend notice a signal emits alongside its guidance.
+func noticeFor(code string, level event.Level, text, detail string) *event.Event {
+	return &event.Event{Kind: event.Notice, Level: level, Code: code, Text: text, Detail: detail}
+}

--- a/internal/agent/arbiter_test.go
+++ b/internal/agent/arbiter_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func arbiterRound() ([]string, []toolOutcome) {
+	return []string{"tool output"}, []toolOutcome{{output: "tool output"}}
+}
+
+// Every signal used to write results[0] from outcomes[0].output, so a round
+// that fired two of them delivered only the last one's guidance.
+func TestApplyInterventionsKeepsEveryFiredGuidance(t *testing.T) {
+	sink := &ebmSink{}
+	a := &Agent{sink: sink}
+	results, outcomes := arbiterRound()
+
+	got := a.applyInterventions(results, outcomes,
+		intervention{verdict: verdictRedirect, guidance: "[loop guard] change approach",
+			notice: noticeFor(event.NoticeCodeLoopGuard, event.LevelInfo, "loop", "loop detail")},
+		intervention{verdict: verdictAdvise, guidance: "[evidence nudge] verify first",
+			notice: noticeFor(event.NoticeCodeEvidenceNudge, event.LevelInfo, "evidence", "evidence detail")},
+	)
+
+	if got != verdictRedirect {
+		t.Fatalf("verdict = %d, want the strongest (%d)", got, verdictRedirect)
+	}
+	for _, want := range []string{"tool output", "[loop guard] change approach", "[evidence nudge] verify first"} {
+		if !strings.Contains(results[0], want) {
+			t.Fatalf("results[0] = %q, missing %q", results[0], want)
+		}
+	}
+	if len(sink.notices) != 2 {
+		t.Fatalf("notices = %d, want one per fired signal", len(sink.notices))
+	}
+}
+
+func TestApplyInterventionsLeavesQuietRoundsUntouched(t *testing.T) {
+	sink := &ebmSink{}
+	a := &Agent{sink: sink}
+	results, outcomes := arbiterRound()
+
+	if got := a.applyInterventions(results, outcomes, intervention{}, intervention{}); got != verdictContinue {
+		t.Fatalf("verdict = %d, want continue", got)
+	}
+	if results[0] != "tool output" || len(sink.notices) != 0 {
+		t.Fatalf("results = %q notices = %d, want an untouched round", results[0], len(sink.notices))
+	}
+}
+
+// A land must survive being raised beside a lower tier in the same round.
+func TestApplyInterventionsTakesTheStrongestVerdict(t *testing.T) {
+	a := &Agent{sink: &ebmSink{}}
+	results, outcomes := arbiterRound()
+
+	got := a.applyInterventions(results, outcomes,
+		intervention{verdict: verdictLand, guidance: "land now"},
+		intervention{verdict: verdictAdvise, guidance: "just a nudge"},
+	)
+	if got != verdictLand {
+		t.Fatalf("verdict = %d, want land (%d)", got, verdictLand)
+	}
+}

--- a/internal/agent/ebm.go
+++ b/internal/agent/ebm.go
@@ -32,21 +32,24 @@ type ebmState struct {
 }
 
 // applyEBM stamps eligibility on the round's sample and, when the experiment
-// arm is active, injects the nudge once per turn through the guard channel.
-func (a *Agent) applyEBM(sample *evidence.OutcomeSample, results []string, outcomes []toolOutcome) {
+// arm is active, asks once per turn for the cheapest discriminating check.
+func (a *Agent) applyEBM(sample *evidence.OutcomeSample, outcomes []toolOutcome) intervention {
 	if sample.DebtAge == 0 || sample.BlindMutations < ebmBlindThreshold {
-		return
+		return intervention{}
 	}
 	sample.EBMEligible = true
 	a.armForkCapture(*sample)
-	if !ebmEnabled || a.ebm.fired || len(results) == 0 || len(outcomes) == 0 {
-		return
+	if !ebmEnabled || a.ebm.fired || len(outcomes) == 0 {
+		return intervention{}
 	}
 	a.ebm.fired = true
 	a.ebm.captureArmed = false
 	sample.EBMFired = true
-	results[0] = outcomes[0].output + "\n\n" + ebmNudge
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEvidenceNudge,
-		Text:   "Several mutations are unverified; asking for the cheapest discriminating check.",
-		Detail: "evidence nudge: verification debt open with blind mutations at threshold"})
+	return intervention{
+		verdict:  verdictAdvise,
+		guidance: ebmNudge,
+		notice: noticeFor(event.NoticeCodeEvidenceNudge, event.LevelInfo,
+			"Several mutations are unverified; asking for the cheapest discriminating check.",
+			"evidence nudge: verification debt open with blind mutations at threshold"),
+	}
 }

--- a/internal/agent/ebm_test.go
+++ b/internal/agent/ebm_test.go
@@ -18,11 +18,17 @@ func ebmRound() ([]string, []toolOutcome) {
 	return []string{"tool output"}, []toolOutcome{{output: "tool output"}}
 }
 
+// deliverEBM runs the signal and its delivery together, the pairing the batch
+// guards use, so these tests still assert what reaches the model.
+func deliverEBM(a *Agent, sample *evidence.OutcomeSample, results []string, outcomes []toolOutcome) {
+	a.applyInterventions(results, outcomes, a.applyEBM(sample, outcomes))
+}
+
 func TestApplyEBMStampsEligibilityWithoutFiringByDefault(t *testing.T) {
 	a := &Agent{sink: &ebmSink{}}
 	sample := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
 	results, outcomes := ebmRound()
-	a.applyEBM(&sample, results, outcomes)
+	deliverEBM(a, &sample, results, outcomes)
 	if !sample.EBMEligible || sample.EBMFired {
 		t.Fatalf("sample = %+v, want eligible without firing (experiment off)", sample)
 	}
@@ -41,13 +47,13 @@ func TestApplyEBMFiresOncePerTurnWhenEnabled(t *testing.T) {
 
 	below := evidence.OutcomeSample{DebtAge: 1, BlindMutations: 2}
 	results, outcomes := ebmRound()
-	a.applyEBM(&below, results, outcomes)
+	deliverEBM(a, &below, results, outcomes)
 	if below.EBMEligible || below.EBMFired {
 		t.Fatalf("below threshold = %+v, want untouched", below)
 	}
 
 	sample := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
-	a.applyEBM(&sample, results, outcomes)
+	deliverEBM(a, &sample, results, outcomes)
 	if !sample.EBMFired || !strings.Contains(results[0], "[evidence nudge]") {
 		t.Fatalf("sample = %+v results = %q, want fired with nudge appended", sample, results[0])
 	}
@@ -57,7 +63,7 @@ func TestApplyEBMFiresOncePerTurnWhenEnabled(t *testing.T) {
 
 	again := evidence.OutcomeSample{DebtAge: 3, BlindMutations: 4}
 	results2, outcomes2 := ebmRound()
-	a.applyEBM(&again, results2, outcomes2)
+	deliverEBM(a, &again, results2, outcomes2)
 	if again.EBMFired || !again.EBMEligible || results2[0] != "tool output" {
 		t.Fatalf("second trigger = %+v results = %q, want eligible only (once per turn)", again, results2[0])
 	}
@@ -65,7 +71,7 @@ func TestApplyEBMFiresOncePerTurnWhenEnabled(t *testing.T) {
 	a.resetTurnEvidence()
 	fresh := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
 	results3, outcomes3 := ebmRound()
-	a.applyEBM(&fresh, results3, outcomes3)
+	deliverEBM(a, &fresh, results3, outcomes3)
 	if !fresh.EBMFired {
 		t.Fatalf("new turn = %+v, want the pass reset by resetTurnEvidence", fresh)
 	}

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -55,25 +55,27 @@ func (g *progressGuard) observe(receipts []Receipt) int {
 // Receipt aliases the evidence receipt for the guard's signature.
 type Receipt = evidence.Receipt
 
-// applyBatchGuards runs both post-batch guards: the storm breaker (failure
-// fixation) and the progress guard (zero-gain repetition). The outcome shadow
-// observes the same receipts afterwards without influencing either guard.
+// applyBatchGuards collects this round's signals — storm breaker (failure
+// fixation), progress guard (zero-gain repetition), evidence nudge — and lets
+// the arbiter deliver them as one tail. The shadow trackers observe the same
+// receipts without influencing any verdict.
 func (a *Agent) applyBatchGuards(ctx context.Context, cancelled bool, calls []provider.ToolCall, outcomes []toolOutcome, results []string, receiptMark int) goalStuckSignal {
 	if cancelled {
 		return goalStuckSignal{}
 	}
-	stormReason := a.applyStormBreaker(calls, outcomes, results, receiptMark)
-	progressReason := a.applyProgressGuard(results, outcomes, receiptMark)
-	a.observeOutcomeShadow(receiptMark, results, outcomes)
+	storm := a.applyStormBreaker(calls, outcomes, receiptMark)
+	progress := a.applyProgressGuard(outcomes, receiptMark)
+	shadow := a.observeOutcomeShadow(receiptMark, outcomes)
+	a.applyInterventions(results, outcomes, storm, progress, shadow)
 	a.observeDelegationAdmission(calls)
 	if _, scoped := DeliveryExecutionScopeFromContext(ctx); !scoped {
 		return goalStuckSignal{}
 	}
-	if stormReason != "" {
-		return goalStuckSignal{limit: stormBreakThreshold, key: "goal repeated host outcome", reason: stormReason}
+	if storm.stuckReason != "" {
+		return goalStuckSignal{limit: stormBreakThreshold, key: "goal repeated host outcome", reason: storm.stuckReason}
 	}
-	if progressReason != "" {
-		return goalStuckSignal{limit: progressStopStreak, key: "goal zero-evidence rounds", reason: progressReason}
+	if progress.stuckReason != "" {
+		return goalStuckSignal{limit: progressStopStreak, key: "goal zero-evidence rounds", reason: progress.stuckReason}
 	}
 	return goalStuckSignal{}
 }
@@ -91,29 +93,29 @@ func (a *Agent) resetTurnEvidence() {
 // observeOutcomeShadow scores the round's receipts through the shadow outcome
 // tracker, lets the EBM policy stamp (and under its arm, act on) the sample,
 // then records it. Unlike the guards it observes every round.
-func (a *Agent) observeOutcomeShadow(receiptMark int, results []string, outcomes []toolOutcome) {
+func (a *Agent) observeOutcomeShadow(receiptMark int, outcomes []toolOutcome) intervention {
 	if a.evidence == nil {
-		return
+		return intervention{}
 	}
 	if a.outcome == nil {
 		a.outcome = evidence.NewOutcomeTracker()
 	}
 	sample := a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark))
-	a.applyEBM(&sample, results, outcomes)
+	iv := a.applyEBM(&sample, outcomes)
 	a.applyGovernor(&sample)
 	a.armGovernorCapture(sample)
 	event.RecordOutcomeProgress(a.sink, sample)
 	a.observeContractRound()
+	return iv
 }
 
 // applyProgressGuard escalates when consecutive rounds stop producing new
-// evidence. It rides the same channel as the storm breaker: guidance appended
-// to the round's first tool result, a loop-guard notice for the frontend, and
-// at the stop tier the loop-guard pass so final readiness stands down and the
-// model can deliver its answer instead of being sent back for more receipts.
-func (a *Agent) applyProgressGuard(results []string, outcomes []toolOutcome, receiptMark int) string {
-	if a.evidence == nil || len(results) == 0 || len(outcomes) == 0 {
-		return ""
+// evidence. At the stop tier it also arms the loop-guard pass so final
+// readiness stands down and the model can deliver its answer instead of being
+// sent back for more receipts.
+func (a *Agent) applyProgressGuard(outcomes []toolOutcome, receiptMark int) intervention {
+	if a.evidence == nil || len(outcomes) == 0 {
+		return intervention{}
 	}
 	receipts := a.evidence.ReceiptsSince(receiptMark)
 	// Rounds where nothing succeeded are the storm breaker's jurisdiction
@@ -127,10 +129,11 @@ func (a *Agent) applyProgressGuard(results []string, outcomes []toolOutcome, rec
 		}
 	}
 	if !anySuccess {
-		return ""
+		return intervention{}
 	}
 	streak := a.progress.observe(receipts)
 	var guard, detail string
+	tier := verdictAdvise
 	warn := false
 	// Fire only when a threshold is crossed: repeating the injected guidance
 	// every round would inflate prompts (and can even tip compaction).
@@ -140,6 +143,7 @@ func (a *Agent) applyProgressGuard(results []string, outcomes []toolOutcome, rec
 			"[progress guard] %d tool rounds in a row produced no new evidence (no new files, results, or changes). Stop exploring: produce your final answer now, stating what was established and what remains unknown.",
 			streak)
 		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — demanding a final answer", streak)
+		tier = verdictLand
 		warn = true
 		a.armLoopGuardPass(receiptMark)
 	case progressPivotStreak:
@@ -147,24 +151,28 @@ func (a *Agent) applyProgressGuard(results []string, outcomes []toolOutcome, rec
 			"[progress guard] still no new evidence after %d rounds. Change strategy now: take a different angle or tool, delegate a focused sub-task, or reduce the scope of what you are verifying.",
 			streak)
 		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — forcing a strategy change", streak)
+		tier = verdictRedirect
 	case progressNudgeStreak:
 		guard = fmt.Sprintf(
 			"[progress guard] the last %d tool rounds repeated earlier reads or commands without new results. Narrow the investigation or adjust the plan before continuing.",
 			streak)
 		detail = fmt.Sprintf("progress guard: %d zero-gain rounds — nudging to narrow", streak)
 	default:
-		return ""
+		return intervention{}
 	}
-	results[0] = outcomes[0].output + "\n\n" + guard
 	level := event.LevelInfo
 	if warn {
 		level = event.LevelWarn
 	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: level, Code: event.NoticeCodeProgressGuard, Text: progressGuardNoticeText(), Detail: detail})
-	if streak >= progressStopStreak {
-		return fmt.Sprintf("%d consecutive successful tool rounds produced no new host evidence", streak)
+	iv := intervention{
+		verdict:  tier,
+		guidance: guard,
+		notice:   noticeFor(event.NoticeCodeProgressGuard, level, progressGuardNoticeText(), detail),
 	}
-	return ""
+	if streak >= progressStopStreak {
+		iv.stuckReason = fmt.Sprintf("%d consecutive successful tool rounds produced no new host evidence", streak)
+	}
+	return iv
 }
 
 func progressGuardNoticeText() string {


### PR DESCRIPTION
#8286 is merged; this now stands alone on `main-v2`.

## The defect

Three signals write the round tail - storm breaker (`applyStormBreaker`), progress guard (`applyProgressGuard`), evidence nudge (`applyEBM`) - and all three build it identically:

```go
results[0] = outcomes[0].output + "\n\n" + guard
```

They run in sequence inside `applyBatchGuards`. Because each one re-derives the slot from `outcomes[0].output` rather than from `results[0]`, a round that fires two of them delivers only the last one's guidance and silently drops the earlier one. The batch that trips the loop guard *and* the evidence nudge is precisely the batch that needs to hear both.

## The change

Each signal returns an `intervention` - verdict, guidance, notice, stuck reason - instead of writing the slot itself. `applyInterventions` folds a round's signals into one delivery: strongest verdict, every notice, all guidance concatenated in signal order.

The verdict ladder (`advise` / `redirect` / `land`) is the vocabulary the rest of this work needs. Nothing reads it yet beyond the strongest-wins fold - it is introduced here so the signals already speak it when the remaining interventions move onto this channel and when a resource axis joins them as a peer rather than as a fourth bespoke guard.

Guidance deliberately stays on the round tail rather than becoming a synthesized user turn: the host is not the user, and a fake user turn competes with real user text when compaction decides what to keep.

## Verification

- `TestApplyInterventionsKeepsEveryFiredGuidance` pins the two-signal round that used to lose guidance
- `TestApplyInterventionsTakesTheStrongestVerdict` pins land-beside-advise
- `TestApplyInterventionsLeavesQuietRoundsUntouched` pins the no-op round
- EBM tests now exercise signal + delivery together (`deliverEBM`), so they still assert what reaches the model
- `go test ./internal/agent/ ./internal/control/ ./internal/boot/ ./internal/tool/builtin/ ./internal/evidence/` green; `golangci-lint run ./...` 0 issues; repolint clean at baseline

Behaviour is unchanged for any round firing a single signal - which is every round the existing suites cover. The two-signal round gains the guidance it was dropping.

Cache-impact: none - guidance still rides the round tail in the same slot with the same wording; the system-prompt prefix is untouched. A two-signal round now carries both texts instead of one, which changes the turn tail only, never the cached prefix.
Cache-guard: `go test ./internal/agent/` includes the cache-hit e2e suites (`cachehit_e2e_test.go`, `cache_diagnostics_test.go`), green unchanged.
Documentation-impact: none - `docs/*.md` documents guard behaviour from the user's side (notices and pauses), and both are unchanged; this reorganizes how the same guidance is assembled internally.