### PR TITLE
Keep transient routing out of completion receipts / 避免内部能力路由污染完成回执

### DIFF
--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -113,7 +113,11 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// A fresh user turn starts from zeroed per-turn host state; the new turn's
 	// values are computed below. Cross-turn state (checkpoint, scope, failure
 	// budgets) lives directly on Agent and is reconciled field by field.
-	a.perTurnState = perTurnState{turnInput: input}
+	// Host-composed input can contain transient capability, memory, and hook
+	// blocks. Keep the authenticated user text as the contract source so those
+	// implementation details never become acceptance criteria or completion
+	// receipt text. The provider still receives the composed input below.
+	a.perTurnState = perTurnState{turnInput: rawInput}
 	a.resetStructuralRunGuards()
 	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
 	preserveEvidence := a.preserveEvidenceOnce
@@ -829,7 +833,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 	if readiness.applies {
 		event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, a.readinessRecovered))
 	}
-	a.emitTurnShadows(state.input)
+	a.emitTurnShadows(a.turnInput)
 	if !a.closeSteerIntakeIfIdle() {
 		return true, nil
 	}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -113,11 +113,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// A fresh user turn starts from zeroed per-turn host state; the new turn's
 	// values are computed below. Cross-turn state (checkpoint, scope, failure
 	// budgets) lives directly on Agent and is reconciled field by field.
-	// Host-composed input can contain transient capability, memory, and hook
-	// blocks. Keep the authenticated user text as the contract source so those
-	// implementation details never become acceptance criteria or completion
-	// receipt text. The provider still receives the composed input below.
-	a.perTurnState = perTurnState{turnInput: rawInput}
+	a.perTurnState = perTurnState{}
 	a.resetStructuralRunGuards()
 	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
 	preserveEvidence := a.preserveEvidenceOnce
@@ -182,17 +178,17 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// deadlocked read-only subagents. Without the override the raw input is
 	// classified verbatim: stripping user-controllable markup here would let
 	// input dressed up as host framing disarm the delivery gates.
-	classifierInput := a.classifierTaskText
+	a.turnInput = a.classifierTaskText
 	if scoped && strings.TrimSpace(scope.TaskText) != "" {
-		classifierInput = scope.TaskText
-	} else if strings.TrimSpace(classifierInput) == "" {
-		classifierInput = rawInput
+		a.turnInput = scope.TaskText
+	} else if strings.TrimSpace(a.turnInput) == "" {
+		a.turnInput = rawInput
 	}
-	intent := taskintent.Classify(classifierInput)
+	intent := taskintent.Classify(a.turnInput)
 	a.deliveryTaskExpected = intent.NeedsEvidence()
 	a.deliveryMutationExpected = intent == taskintent.Mutation && registryHasWriterTools(a.tools)
-	a.deliveryPersistentExpected = taskintent.NeedsPersistentAction(classifierInput)
-	a.recoveryTaskSummary = boundedRecoveryTaskSummary(classifierInput)
+	a.deliveryPersistentExpected = taskintent.NeedsPersistentAction(a.turnInput)
+	a.recoveryTaskSummary = boundedRecoveryTaskSummary(a.turnInput)
 	// A cancelled/error turn leaves a provider-excluded recovery record at the
 	// transcript tail. Fold its bounded facts into this new user turn exactly
 	// once; the user's raw text remains the classifier source above.

--- a/internal/agent/user_input_test.go
+++ b/internal/agent/user_input_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"reasonix/internal/event"
@@ -68,6 +69,53 @@ func TestRunPersistsRawUserInputSeparatelyFromProviderContext(t *testing.T) {
 	}
 	if legacy.Content != composed {
 		t.Fatalf("previous-release reader sees %q, want provider-visible %q", legacy.Content, composed)
+	}
+
+	receipt := a.CompletionReceipt()
+	if receipt == nil {
+		t.Fatal("completion receipt is nil")
+	}
+	if len(receipt.Gaps) != 2 {
+		t.Fatalf("completion gaps = %+v, want the atomic requirement and mutation check", receipt.Gaps)
+	}
+	if got := receipt.Gaps[0].Detail; got != "r1: "+raw {
+		t.Fatalf("atomic criterion = %q, want raw user input %q", got, raw)
+	}
+	if strings.Contains(receipt.Gaps[0].Detail, "capability-route") {
+		t.Fatalf("completion receipt leaked transient provider context: %+v", receipt.Gaps)
+	}
+}
+
+func TestTransientCapabilityRouteCannotTurnConversationIntoDeliveryReceipt(t *testing.T) {
+	prov := &userInputCaptureProvider{}
+	a := New(prov, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
+
+	const raw = "请解释这个项目目前的进度"
+	const composed = `<capability-route version="1">
+Relevant capabilities for this turn:
+- skill:minimax-docx prefer: the skill trigger matches the user request
+Policy: prefer means use the skill for the required change
+</capability-route>
+
+` + raw
+	if err := a.Run(WithRawUserInput(context.Background(), raw), composed); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if a.CompletionReceipt() != nil {
+		t.Fatalf("an advisory turn received a delivery receipt from transient routing: %+v", a.CompletionReceipt())
+	}
+	if len(prov.request.Messages) < 2 ||
+		!strings.Contains(prov.request.Messages[1].Content, `<capability-route version="1">`) ||
+		!strings.Contains(prov.request.Messages[1].Content, raw) {
+		t.Fatalf("provider lost the capability route: %+v", prov.request.Messages)
+	}
+	if got := a.turnInput; got != raw {
+		t.Fatalf("contract input = %q, want authenticated raw input %q", got, raw)
+	}
+	c := a.LiveContract()
+	if c == nil || len(c.Requirements) != 0 || len(c.Checks) != 0 {
+		t.Fatalf("transient route created delivery requirements: %+v", c)
 	}
 }
 

--- a/internal/agent/user_input_test.go
+++ b/internal/agent/user_input_test.go
@@ -119,6 +119,42 @@ Policy: prefer means use the skill for the required change
 	}
 }
 
+func TestCompletionContractUsesGoalScopeTaskText(t *testing.T) {
+	prov := &userInputCaptureProvider{}
+	a := New(prov, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
+	ctx := WithRawUserInput(context.Background(), "Continue working.")
+	ctx = WithDeliveryExecutionScope(ctx, DeliveryExecutionScope{ID: "goal-1", TaskText: "fix the parser"})
+
+	if err := a.Run(ctx, "<goal-context>continue</goal-context>"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertAtomicCriterion(t, a, "fix the parser")
+}
+
+func TestCompletionContractUsesPristineSubagentTaskText(t *testing.T) {
+	prov := &userInputCaptureProvider{}
+	a := New(prov, tool.NewRegistry(), NewSession("system"), Options{
+		ClassifierTaskText: "fix the parser",
+	}, event.Discard)
+	const wrapped = "<workspace-context>private host framing</workspace-context>\n\nfix the parser"
+
+	if err := a.Run(context.Background(), wrapped); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertAtomicCriterion(t, a, "fix the parser")
+}
+
+func assertAtomicCriterion(t *testing.T, a *Agent, want string) {
+	t.Helper()
+	receipt := a.CompletionReceipt()
+	if receipt == nil || len(receipt.Gaps) == 0 {
+		t.Fatalf("completion receipt = %+v, want atomic criterion %q", receipt, want)
+	}
+	if got := receipt.Gaps[0].Detail; got != "r1: "+want {
+		t.Fatalf("atomic criterion = %q, want %q", got, want)
+	}
+}
+
 func TestSubagentImageCandidatesAreCopiedAndIsolated(t *testing.T) {
 	images := []string{"data:image/png;base64,AAAA"}
 	ctx := WithSubagentImageCandidates(context.Background(), images)


### PR DESCRIPTION
## Summary

- build live and final task contracts from the same host-trusted task text used by delivery classification
- use raw user input for ordinary turns, Goal scope text for continuations, and pristine classifier text for wrapped sub-agents
- keep capability, memory, hook, and other transient context in the provider prompt without exposing it as acceptance criteria
- prevent advisory conversations from being misclassified as delivery work by routing text such as `required change`
- add regression coverage for ordinary turns, Goal continuations, and the reported `minimax-docx` capability-route scenario

## Root cause

The controller already separated raw user text from provider-composed input, but the agent stored and replayed the composed input when building completion contracts. Internal capability routing could therefore become requirement `r1` and trigger a synthetic mutation check. Goal continuations and wrapped sub-agents also require their existing host-trusted task sources to remain authoritative.

## Verification

- `go run ./tools/repolint`
- `go test -race ./internal/agent -run TestCompletionContract -count=1`
- `go test ./internal/agent ./internal/completion ./internal/taskcontract`
- `go vet ./...`
- `go test ./...`
- `cd desktop && go test ./...`
- `git diff --check`

## Compatibility and cache impact

No persisted format or provider-visible prompt changes. Capability routing and prompt bytes remain unchanged, so this does not reduce prompt-cache stability.

Documentation-impact: none - this corrects internal completion-receipt classification without changing user configuration or documented workflows.