### PR TITLE
feat(agent): the spend axis spans a task, not one Run

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -589,6 +589,12 @@ type Agent struct {
 	// only feed trajectory recording; it never influences guard behavior.
 	outcome *evidence.OutcomeTracker
 
+	// taskBudget accumulates spend across every Run continuing one task and
+	// resets with the evidence ledger: one ledger, one task, one bill. A
+	// per-Run total cannot see the failures worth stopping — those are
+	// measured in hours, and every "continue" starts a fresh Run.
+	taskBudget runBudget
+
 	// ebm is the Evidence-Before-More-Mutation nudge's once-per-turn state.
 	ebm ebmState
 
@@ -2482,161 +2488,6 @@ func (a *Agent) withPreviewFileDiffs(ctx context.Context, calls []provider.ToolC
 		}
 	}
 	return out
-}
-
-// stormBreakThreshold is how many times in a row the same tool may fail the same
-// way before the loop stops echoing the raw error back and instead returns a
-// directive to change approach. Two natural self-corrections are healthy; the
-// third identical failure is a death-spiral — the dominant case being a tool call
-// whose arguments are truncated at the output-token ceiling, which the model then
-// re-emits (re-worded but still over-long), truncating the same way again.
-const stormBreakThreshold = 3
-
-// repeatSuccessBreakThreshold is how many identical write-like successes the
-// agent allows before refusing another copy in the same user turn. Two gives the
-// model room for a natural self-correction; the third repeat is usually a
-// no-op/write loop and should be redirected to a different tool or final answer.
-const repeatSuccessBreakThreshold = 2
-
-const (
-	// todoProgressNudgeRounds is the first adaptive checkpoint. The host asks
-	// the model to reassess, but keeps the turn alive so it can recover.
-	todoProgressNudgeRounds = 8
-	// maxTodoStallRounds pauses only after the reassessment also failed to
-	// produce a new completion or unique host-observed work receipt.
-	maxTodoStallRounds = 16
-)
-
-func todoProgressNudgeMessage(rounds int) string {
-	return fmt.Sprintf("Host progress check: the current todo has produced no new completion, unique read, command, or mutation for %d tool-call rounds. Reassess before using more tools: sign off the current item if it is done, narrow the remaining work without replacing the active item, or explain/ask about a real blocker. Do not repeat reads, commands, or writes just to reset this guard.", rounds)
-}
-
-// loopGuardBlockErrMsg is the errMsg carried by a repeat-success loop-guard
-// block. applyStormBreaker matches it to arm the final-readiness loop-guard
-// pass, since that guard also invites the model to report the blocker.
-const loopGuardBlockErrMsg = "blocked by loop guard"
-
-// applyStormBreaker detects a run of zero-progress turns and, past the
-// threshold, rewrites the model-facing result (results[0]) into a directive to
-// change approach. Two detectors, because a stuck model varies its retries two
-// ways. The signature detector keys on each call's (tool, error/blocker) — not
-// its args — since a stuck model reworks the arguments cosmetically while
-// hitting the same host refusal or failure (see the stormSig field doc). The
-// streak detector counts consecutive turns in which every call was blocked,
-// regardless of shape: rotating tools, reordering a batch, or a blocker whose
-// text varies per attempt escapes the signature but is still zero progress —
-// only a host refusal (not a plain error) proves that, so the streak requires
-// blocked outcomes. Any success resets both. When a guard fires — or when a
-// call in the batch was already blocked by the per-call repeat-success guard —
-// the final-readiness loop-guard pass is armed so the model may report the
-// blocker (see loopGuardAllowsFinal). The hard maxSteps guard remains the
-// ultimate backstop; this just keeps the loop from burning that whole budget
-// bouncing off the same host refusals.
-func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, receiptMark int) intervention {
-	allBlocked := len(outcomes) > 0
-	for _, outcome := range outcomes {
-		if !outcome.blocked {
-			allBlocked = false
-			break
-		}
-	}
-	if allBlocked {
-		a.blockedTurnStreak++
-	} else {
-		a.blockedTurnStreak = 0
-	}
-	for _, outcome := range outcomes {
-		if outcome.blocked && outcome.errMsg == loopGuardBlockErrMsg {
-			a.armLoopGuardPass(receiptMark)
-			break
-		}
-	}
-
-	sig, ok := batchStormSignature(calls, outcomes)
-	switch {
-	case !ok:
-		a.stormSig, a.stormCount = "", 0
-	case sig != a.stormSig:
-		a.stormSig, a.stormCount = sig, 1
-	default:
-		a.stormCount++
-	}
-	stormHit := ok && a.stormCount >= stormBreakThreshold
-	streakHit := allBlocked && a.blockedTurnStreak >= stormBreakThreshold
-	if !stormHit && !streakHit {
-		return intervention{}
-	}
-
-	const blockedAdvice = "Change approach: do not keep retrying a blocked tool by changing the tool, command, or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
-	var guard, detail string
-	if stormHit {
-		subject := fmt.Sprintf("%q", calls[0].Name)
-		short := calls[0].Name
-		if len(calls) > 1 {
-			subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
-			short = fmt.Sprintf("a batch of %d calls", len(calls))
-		}
-		anyBlocked := false
-		for _, outcome := range outcomes {
-			if outcome.blocked {
-				anyBlocked = true
-				break
-			}
-		}
-		action := "failed"
-		advice := "Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer."
-		if anyBlocked {
-			action = "been blocked or failed"
-			advice = blockedAdvice
-		}
-		guard = fmt.Sprintf(
-			"[loop guard] %s has now %s %d times in a row with the same host response. Re-sending it — even with the wording changed — will not help: the calls keep hitting the same outcome. %s",
-			subject, action, a.stormCount, advice)
-		detail = fmt.Sprintf(
-			"loop guard: %s hit the same host response %d× — nudging the model to change approach",
-			short, a.stormCount)
-	} else {
-		guard = fmt.Sprintf(
-			"[loop guard] every tool call in the last %d turns has been blocked by the host (permission, plan mode, hook, or loop guard). Switching tools, reordering calls, or rewording arguments will not help while the blockers stand. %s",
-			a.blockedTurnStreak, blockedAdvice)
-		detail = fmt.Sprintf(
-			"loop guard: every tool call blocked %d turns in a row — nudging the model to change approach",
-			a.blockedTurnStreak)
-	}
-	a.armLoopGuardPass(receiptMark)
-	return intervention{
-		verdict:     verdictRedirect,
-		guidance:    guard,
-		notice:      noticeFor(event.NoticeCodeLoopGuard, event.LevelInfo, loopGuardNoticeText(), detail),
-		stuckReason: detail,
-	}
-}
-
-func loopGuardNoticeText() string {
-	return "The assistant is not making progress; asking it to change approach."
-}
-
-// batchStormSignature returns a per-turn fixation signature — each call's
-// (name, error/blocker) in order — and ok=true only when every call errored or
-// was blocked. ok=false (any success) means the turn made progress, so the
-// caller resets the counter. Keying on the host response rather than the args is
-// deliberate: a stuck model reworks the arguments while hitting the same
-// response, so identical-args matching would miss the loop.
-func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (string, bool) {
-	if len(calls) == 0 {
-		return "", false
-	}
-	var sb strings.Builder
-	for i := range calls {
-		if outcomes[i].errMsg == "" {
-			return "", false
-		}
-		sb.WriteString(calls[i].Name)
-		sb.WriteByte(0)
-		sb.WriteString(outcomes[i].errMsg)
-		sb.WriteByte(0)
-	}
-	return sb.String(), true
 }
 
 // toolOutcome is one tool call's result. output is the first-visible bounded

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -80,7 +80,9 @@ func (a *Agent) applyBatchGuards(ctx context.Context, cancelled bool, calls []pr
 	return goalStuckSignal{}
 }
 
-// resetTurnEvidence clears the ledger and both progress scorers together.
+// resetTurnEvidence clears the ledger and both progress scorers together. The
+// task budget resets with them: a fresh ledger is what "a new task" means here,
+// and a continuation keeps both.
 func (a *Agent) resetTurnEvidence() {
 	a.evidence.Reset()
 	a.progress.reset()
@@ -88,6 +90,7 @@ func (a *Agent) resetTurnEvidence() {
 	a.outcome = evidence.NewOutcomeTracker()
 	a.ebm = ebmState{}
 	a.governor = governorState{}
+	a.taskBudget = runBudget{}
 }
 
 // observeOutcomeShadow scores the round's receipts through the shadow outcome

--- a/internal/agent/run_budget.go
+++ b/internal/agent/run_budget.go
@@ -48,32 +48,38 @@ func (b *runBudget) elapsed() time.Duration {
 	return time.Since(b.started)
 }
 
-// sample is the per-round shadow reading: counts and money, never content.
-func (b *runBudget) sample(currency string) event.RunBudgetSample {
-	return event.RunBudgetSample{
+// totals is the shadow reading for one scope: counts and money, never content.
+func (b *runBudget) totals() event.RunBudgetTotals {
+	return event.RunBudgetTotals{
 		Rounds:       b.rounds,
 		Requests:     b.requests,
 		PromptTokens: b.promptTokens,
 		OutputTokens: b.outputTokens,
 		Cost:         b.cost,
-		Currency:     currency,
 		Priced:       !b.unpricedTurns && b.pricedRounds > 0,
 		ElapsedMs:    b.elapsed().Milliseconds(),
 	}
 }
 
-// observeRunBudget records the turn's spend after a round and reports it to
-// sinks that opt in. Shadow only: nothing reads the verdict yet, and no
-// threshold exists to read it against until the recorded distribution says
-// where one belongs.
+// observeRunBudget folds a round into both scopes and reports them. Shadow
+// only: nothing reads a verdict yet, and no threshold exists to read it against
+// until the recorded distribution says where one belongs.
 func (a *Agent) observeRunBudget(state *runLoopState, usage *provider.Usage) {
 	if state == nil {
 		return
 	}
 	state.budget.observe(usage, a.pricing)
+	if a.taskBudget.started.IsZero() {
+		a.taskBudget.started = state.budget.started
+	}
+	a.taskBudget.observe(usage, a.pricing)
 	currency := ""
 	if a.pricing != nil {
 		currency = a.pricing.Symbol()
 	}
-	event.RecordRunBudget(a.sink, state.budget.sample(currency))
+	event.RecordRunBudget(a.sink, event.RunBudgetSample{
+		Turn:     state.budget.totals(),
+		Task:     a.taskBudget.totals(),
+		Currency: currency,
+	})
 }

--- a/internal/agent/run_budget_test.go
+++ b/internal/agent/run_budget_test.go
@@ -78,23 +78,94 @@ func TestRunBudgetTracksRealTurnSpend(t *testing.T) {
 	}
 
 	last := sink.samples[len(sink.samples)-1]
-	if last.Rounds != 4 || last.Requests != 4 {
-		t.Fatalf("last sample = %+v, want 4 rounds and 4 requests", last)
+	if last.Turn.Rounds != 4 || last.Turn.Requests != 4 {
+		t.Fatalf("last sample = %+v, want 4 rounds and 4 requests", last.Turn)
 	}
-	if last.PromptTokens != 4000 || last.OutputTokens != 400 {
-		t.Fatalf("tokens = prompt %d output %d, want 4000/400", last.PromptTokens, last.OutputTokens)
+	if last.Turn.PromptTokens != 4000 || last.Turn.OutputTokens != 400 {
+		t.Fatalf("tokens = prompt %d output %d, want 4000/400", last.Turn.PromptTokens, last.Turn.OutputTokens)
 	}
-	if !last.Priced || last.Currency != "¥" {
+	if !last.Turn.Priced || last.Currency != "¥" {
 		t.Fatalf("sample = %+v, want a priced reading in ¥", last)
 	}
 	// Cache hits are 50x cheaper than misses; a turn that bills 900 hits per
 	// round must not read as if all 1000 prompt tokens were misses.
 	wantCost := 4 * (900*0.02 + 100*1 + 100*2) / 1e6
-	if diff := last.Cost - wantCost; diff > 1e-12 || diff < -1e-12 {
-		t.Fatalf("cost = %v, want %v (cache-hit priced)", last.Cost, wantCost)
+	if diff := last.Turn.Cost - wantCost; diff > 1e-12 || diff < -1e-12 {
+		t.Fatalf("cost = %v, want %v (cache-hit priced)", last.Turn.Cost, wantCost)
 	}
-	if last.ElapsedMs < 0 {
-		t.Fatalf("elapsed = %d, want a wall-clock reading", last.ElapsedMs)
+	if last.Turn.ElapsedMs < 0 {
+		t.Fatalf("elapsed = %d, want a wall-clock reading", last.Turn.ElapsedMs)
+	}
+}
+
+// The whole point of the task scope: "continue" starts a new Run, and a
+// per-Run total resets there. The four-hour failure this axis exists for was
+// never one Run.
+func TestTaskBudgetSurvivesAContinuation(t *testing.T) {
+	sink := newBudgetSink()
+	reg := tool.NewRegistry()
+	reg.Add(readProbe{})
+	pricing := &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "CNY"}
+	a := New(&spendingProvider{max: 2}, reg, NewSession("sys"), Options{Pricing: pricing}, sink)
+
+	if err := a.Run(context.Background(), "start the work"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	afterFirst := sink.samples[len(sink.samples)-1]
+
+	// What the host does for a continuation: keep the evidence ledger.
+	a.preserveEvidenceOnce = true
+	if err := a.Run(context.Background(), "continue"); err != nil {
+		t.Fatalf("continuation Run: %v", err)
+	}
+	afterSecond := sink.samples[len(sink.samples)-1]
+
+	if afterSecond.Turn.Rounds >= afterFirst.Turn.Rounds {
+		t.Fatalf("turn rounds = %d, want the per-Run scope to restart below the first Run's %d",
+			afterSecond.Turn.Rounds, afterFirst.Turn.Rounds)
+	}
+	wantTaskRounds := afterFirst.Task.Rounds + afterSecond.Turn.Rounds
+	if afterSecond.Task.Rounds != wantTaskRounds {
+		t.Fatalf("task rounds = %d, want %d carried across the continuation",
+			afterSecond.Task.Rounds, wantTaskRounds)
+	}
+	if afterSecond.Task.Cost <= afterFirst.Task.Cost {
+		t.Fatalf("task cost = %v, want it to accumulate past the first Run's %v",
+			afterSecond.Task.Cost, afterFirst.Task.Cost)
+	}
+	if afterSecond.Task.ElapsedMs < afterSecond.Turn.ElapsedMs {
+		t.Fatal("task elapsed must span both Runs, not just the current one")
+	}
+}
+
+// A genuinely new task starts from zero, because a fresh evidence ledger is
+// what "new task" means here.
+func TestTaskBudgetResetsWithTheEvidenceLedger(t *testing.T) {
+	sink := newBudgetSink()
+	reg := tool.NewRegistry()
+	reg.Add(readProbe{})
+	a := New(&spendingProvider{max: 1}, reg, NewSession("sys"),
+		Options{Pricing: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2}}, sink)
+
+	if err := a.Run(context.Background(), "first task"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	first := sink.samples[len(sink.samples)-1].Task
+	if first.Rounds == 0 {
+		t.Fatal("first Run recorded nothing; the reset assertion would be vacuous")
+	}
+
+	if err := a.Run(context.Background(), "an unrelated second task"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	second := sink.samples[len(sink.samples)-1]
+
+	if second.Task.Rounds != second.Turn.Rounds {
+		t.Fatalf("task rounds = %d, want a reset to this Run's own %d",
+			second.Task.Rounds, second.Turn.Rounds)
+	}
+	if second.Task.Cost >= first.Cost+second.Turn.Cost {
+		t.Fatalf("task cost = %v, want the first task's %v dropped", second.Task.Cost, first.Cost)
 	}
 }
 
@@ -104,7 +175,7 @@ func TestRunBudgetCountsRoundsWithoutUsage(t *testing.T) {
 	var b runBudget
 	b.observe(nil, nil)
 	b.observe(&provider.Usage{PromptTokens: 10, CompletionTokens: 1, RequestCount: 1}, nil)
-	got := b.sample("")
+	got := b.totals()
 	if got.Rounds != 2 || got.Requests != 1 || got.PromptTokens != 10 {
 		t.Fatalf("sample = %+v, want 2 rounds / 1 request / 10 prompt tokens", got)
 	}

--- a/internal/agent/storm_breaker.go
+++ b/internal/agent/storm_breaker.go
@@ -1,0 +1,164 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// stormBreakThreshold is how many times in a row the same tool may fail the same
+// way before the loop stops echoing the raw error back and instead returns a
+// directive to change approach. Two natural self-corrections are healthy; the
+// third identical failure is a death-spiral — the dominant case being a tool call
+// whose arguments are truncated at the output-token ceiling, which the model then
+// re-emits (re-worded but still over-long), truncating the same way again.
+const stormBreakThreshold = 3
+
+// repeatSuccessBreakThreshold is how many identical write-like successes the
+// agent allows before refusing another copy in the same user turn. Two gives the
+// model room for a natural self-correction; the third repeat is usually a
+// no-op/write loop and should be redirected to a different tool or final answer.
+const repeatSuccessBreakThreshold = 2
+
+const (
+	// todoProgressNudgeRounds is the first adaptive checkpoint. The host asks
+	// the model to reassess, but keeps the turn alive so it can recover.
+	todoProgressNudgeRounds = 8
+	// maxTodoStallRounds pauses only after the reassessment also failed to
+	// produce a new completion or unique host-observed work receipt.
+	maxTodoStallRounds = 16
+)
+
+func todoProgressNudgeMessage(rounds int) string {
+	return fmt.Sprintf("Host progress check: the current todo has produced no new completion, unique read, command, or mutation for %d tool-call rounds. Reassess before using more tools: sign off the current item if it is done, narrow the remaining work without replacing the active item, or explain/ask about a real blocker. Do not repeat reads, commands, or writes just to reset this guard.", rounds)
+}
+
+// loopGuardBlockErrMsg is the errMsg carried by a repeat-success loop-guard
+// block. applyStormBreaker matches it to arm the final-readiness loop-guard
+// pass, since that guard also invites the model to report the blocker.
+const loopGuardBlockErrMsg = "blocked by loop guard"
+
+// applyStormBreaker detects a run of zero-progress turns and, past the
+// threshold, rewrites the model-facing result (results[0]) into a directive to
+// change approach. Two detectors, because a stuck model varies its retries two
+// ways. The signature detector keys on each call's (tool, error/blocker) — not
+// its args — since a stuck model reworks the arguments cosmetically while
+// hitting the same host refusal or failure (see the stormSig field doc). The
+// streak detector counts consecutive turns in which every call was blocked,
+// regardless of shape: rotating tools, reordering a batch, or a blocker whose
+// text varies per attempt escapes the signature but is still zero progress —
+// only a host refusal (not a plain error) proves that, so the streak requires
+// blocked outcomes. Any success resets both. When a guard fires — or when a
+// call in the batch was already blocked by the per-call repeat-success guard —
+// the final-readiness loop-guard pass is armed so the model may report the
+// blocker (see loopGuardAllowsFinal). The hard maxSteps guard remains the
+// ultimate backstop; this just keeps the loop from burning that whole budget
+// bouncing off the same host refusals.
+func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, receiptMark int) intervention {
+	allBlocked := len(outcomes) > 0
+	for _, outcome := range outcomes {
+		if !outcome.blocked {
+			allBlocked = false
+			break
+		}
+	}
+	if allBlocked {
+		a.blockedTurnStreak++
+	} else {
+		a.blockedTurnStreak = 0
+	}
+	for _, outcome := range outcomes {
+		if outcome.blocked && outcome.errMsg == loopGuardBlockErrMsg {
+			a.armLoopGuardPass(receiptMark)
+			break
+		}
+	}
+
+	sig, ok := batchStormSignature(calls, outcomes)
+	switch {
+	case !ok:
+		a.stormSig, a.stormCount = "", 0
+	case sig != a.stormSig:
+		a.stormSig, a.stormCount = sig, 1
+	default:
+		a.stormCount++
+	}
+	stormHit := ok && a.stormCount >= stormBreakThreshold
+	streakHit := allBlocked && a.blockedTurnStreak >= stormBreakThreshold
+	if !stormHit && !streakHit {
+		return intervention{}
+	}
+
+	const blockedAdvice = "Change approach: do not keep retrying a blocked tool by changing the tool, command, or arguments. Respect the permission, plan-mode, hook, or loop-guard blocker; use an already-allowed tool, ask the user for the specific approval or choice if appropriate, or explain the blocker in your final answer."
+	var guard, detail string
+	if stormHit {
+		subject := fmt.Sprintf("%q", calls[0].Name)
+		short := calls[0].Name
+		if len(calls) > 1 {
+			subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
+			short = fmt.Sprintf("a batch of %d calls", len(calls))
+		}
+		anyBlocked := false
+		for _, outcome := range outcomes {
+			if outcome.blocked {
+				anyBlocked = true
+				break
+			}
+		}
+		action := "failed"
+		advice := "Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer."
+		if anyBlocked {
+			action = "been blocked or failed"
+			advice = blockedAdvice
+		}
+		guard = fmt.Sprintf(
+			"[loop guard] %s has now %s %d times in a row with the same host response. Re-sending it — even with the wording changed — will not help: the calls keep hitting the same outcome. %s",
+			subject, action, a.stormCount, advice)
+		detail = fmt.Sprintf(
+			"loop guard: %s hit the same host response %d× — nudging the model to change approach",
+			short, a.stormCount)
+	} else {
+		guard = fmt.Sprintf(
+			"[loop guard] every tool call in the last %d turns has been blocked by the host (permission, plan mode, hook, or loop guard). Switching tools, reordering calls, or rewording arguments will not help while the blockers stand. %s",
+			a.blockedTurnStreak, blockedAdvice)
+		detail = fmt.Sprintf(
+			"loop guard: every tool call blocked %d turns in a row — nudging the model to change approach",
+			a.blockedTurnStreak)
+	}
+	a.armLoopGuardPass(receiptMark)
+	return intervention{
+		verdict:     verdictRedirect,
+		guidance:    guard,
+		notice:      noticeFor(event.NoticeCodeLoopGuard, event.LevelInfo, loopGuardNoticeText(), detail),
+		stuckReason: detail,
+	}
+}
+
+func loopGuardNoticeText() string {
+	return "The assistant is not making progress; asking it to change approach."
+}
+
+// batchStormSignature returns a per-turn fixation signature — each call's
+// (name, error/blocker) in order — and ok=true only when every call errored or
+// was blocked. ok=false (any success) means the turn made progress, so the
+// caller resets the counter. Keying on the host response rather than the args is
+// deliberate: a stuck model reworks the arguments while hitting the same
+// response, so identical-args matching would miss the loop.
+func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (string, bool) {
+	if len(calls) == 0 {
+		return "", false
+	}
+	var sb strings.Builder
+	for i := range calls {
+		if outcomes[i].errMsg == "" {
+			return "", false
+		}
+		sb.WriteString(calls[i].Name)
+		sb.WriteByte(0)
+		sb.WriteString(outcomes[i].errMsg)
+		sb.WriteByte(0)
+	}
+	return sb.String(), true
+}

--- a/internal/event/run_budget.go
+++ b/internal/event/run_budget.go
@@ -2,18 +2,26 @@ package event
 
 import "reasonix/internal/nilutil"
 
-// RunBudgetSample is one turn's accumulated spend after a round: counts and
-// money, never content. Priced is false when no price table covered the turn,
-// so a reader can tell a genuinely free turn from an unpriced one.
-type RunBudgetSample struct {
+// RunBudgetTotals is one scope's accumulated spend: counts and money, never
+// content. Priced is false when no price table covered it, so a reader can
+// tell a genuinely free stretch from an unpriced one.
+type RunBudgetTotals struct {
 	Rounds       int     `json:"rounds"`
 	Requests     int     `json:"requests"`
 	PromptTokens int     `json:"promptTokens"`
 	OutputTokens int     `json:"outputTokens"`
 	Cost         float64 `json:"cost"`
-	Currency     string  `json:"currency,omitempty"`
 	Priced       bool    `json:"priced"`
 	ElapsedMs    int64   `json:"elapsedMs"`
+}
+
+// RunBudgetSample reports both scopes after a round. Turn is the current Run;
+// Task spans every Run continuing the same work, because "continue" starts a
+// new Run and the spend worth stopping accrues across them.
+type RunBudgetSample struct {
+	Turn     RunBudgetTotals `json:"turn"`
+	Task     RunBudgetTotals `json:"task"`
+	Currency string          `json:"currency,omitempty"`
 }
 
 // RunBudgetSink is an optional sink capability for the per-round spend axis.

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -440,8 +440,8 @@
     },
     "internal/agent/agent.go": {
       "complexity": 37,
-      "essay": 97,
-      "file-size": 2508,
+      "essay": 84,
+      "file-size": 2357,
       "function-size": 102
     },
     "internal/agent/ask.go": {
@@ -618,6 +618,9 @@
     },
     "internal/agent/session_removal.go": {
       "essay": 6
+    },
+    "internal/agent/storm_breaker.go": {
+      "essay": 13
     },
     "internal/agent/steer_flush_test.go": {
       "essay": 1


### PR DESCRIPTION
Stacked on #8309. Third structural step: give the axis the scope the failures actually have.

## Why

`runLoopState` is rebuilt every `Run`, so a per-Run total restarts at zero on every "continue". The reported runaway was four hours - many Runs. Anything scoped to one Run, the existing round ceiling included, offers no protection against it at all.

## The scope boundary

The task scope resets with the evidence ledger. That boundary already answers "is this new work": a continuation preserves the ledger, an unrelated turn resets it, and the delivery scope decides which. Reusing it means there is one answer to that question instead of two that can disagree.

Samples now carry both scopes - `Turn` is what this Run spent, `Task` is what the work has cost since it started - so a reader wanting either has it without differencing.

Still shadow: no threshold reads it. That is the next PR, and per the decision on this thread it will gate on cost and wall clock rather than on rounds.

## File extraction

`agent.go` was 4 lines over its file-size budget with the new field. The storm breaker moved to `storm_breaker.go`: the threshold, the block message, the batch signature and the guard itself were already one concern sitting in the middle of another file. `agent.go` drops 151 lines and 13 essay findings; the baseline diff moves those findings rather than forgiving them, and total findings are unchanged at 1949.

## Verification

- `TestTaskBudgetSurvivesAContinuation` runs two `Run`s with the continuation flag the host sets, and asserts the turn scope restarts while task rounds, cost and elapsed carry across
- `TestTaskBudgetResetsWithTheEvidenceLedger` asserts an unrelated second task starts from its own Run's spend, with a guard against the assertion going vacuous
- `TestRunBudgetTracksRealTurnSpend` still pins cache-hit-aware pricing end to end
- `go test -count=1 ./internal/agent/ ./internal/boot/ ./internal/event/ ./internal/control/` green; `golangci-lint run ./...` 0 issues; repolint clean

`internal/cli`'s `TestClearMCPAuthenticationUsesControllerWorkspace` still fails identically with these changes stashed - pre-existing, tracked separately.

Cache-impact: none - reads `provider.Usage` after a round and writes an opt-in sink. No prompt, tool schema, or request field changes.
Cache-guard: `go test ./internal/agent/` includes `cachehit_e2e_test.go` and `cache_diagnostics_test.go`, green unchanged.
Documentation-impact: none - shadow-only with no user-visible surface, config key, or flag. Docs land with the gate that reads it.
