### PR TITLE
fix(memory): surface read errors in quick-add instead of overwriting

### DIFF
--- a/internal/memory/quickadd.go
+++ b/internal/memory/quickadd.go
@@ -37,7 +37,12 @@ func AppendDoc(path, note string) error {
 		return err
 	}
 
-	existing, _ := fileencoding.ReadFileUTF8(path) // missing → new file
+	existing, err := fileencoding.ReadFileUTF8(path)
+	if err != nil && !os.IsNotExist(err) {
+		// An existing but unreadable file must not be treated as empty: that
+		// would rebuild the document from scratch and destroy its content.
+		return fmt.Errorf("read %q before appending: %w", path, err)
+	}
 	body := string(existing)
 	bullet := "- " + note
 

--- a/internal/memory/quickadd_test.go
+++ b/internal/memory/quickadd_test.go
@@ -98,3 +98,19 @@ func TestAppendDocRejectsSymlinkDestination(t *testing.T) {
 		t.Fatalf("outside target changed to %q", body)
 	}
 }
+
+// TestAppendDocPropagatesReadErrors pins the fail-safe contract: a doc-memory
+// file that exists but cannot be read (permission, encoding, IO) must surface
+// the read error instead of treating the file as empty and overwriting it with
+// a fresh Notes-only document, which would silently destroy existing content.
+func TestAppendDocPropagatesReadErrors(t *testing.T) {
+	// A directory is a real path that os.ReadFile refuses with a non-NotExist
+	// error (EISDIR), exercising the "exists but unreadable" branch without
+	// relying on permission bits that vary across platforms and CI users.
+	dir := t.TempDir()
+	if err := AppendDoc(dir, "note"); err == nil {
+		t.Fatal("AppendDoc on an unreadable path must fail")
+	} else if !strings.Contains(err.Error(), "read") {
+		t.Fatalf("error must surface the read failure, got %q", err)
+	}
+}


### PR DESCRIPTION
## Summary

**现状**：`AppendDoc`（`#` 快速添加的写侧）读取已有记忆文档时丢弃 `ReadFileUTF8` 的错误——`existing, _ := ...`。当文档存在但瞬时不可读（权限受限、编码损坏、IO 错误），会被当作**空文档**处理并整文件覆盖重建，用户/会话已有内容被静默清空。

**本 PR**：区分 `os.IsNotExist`（缺文件 = 新建文档）与"其他读错误"——后者直接返回错误，**绝不把不可读文件当空文档覆盖**。

## Issues

（无关联 issue；整体代码审查产出，fail-safe 数据保护修复）

## Verification

- 新增 `TestAppendDocPropagatesReadErrors`：不可读路径（目录，EISDIR，跨平台稳定）→ 修复前实测返回 `rename ... file exists`（证实真的尝试了覆盖写入），修复后返回含 "read" 的读错误
- 现有 4 个 AppendDoc 测试（新建/保留内容/规范化/symlink 拒绝）全部保持通过
- `go test ./internal/memory/ ./internal/control/` 全绿（control 是 AppendDoc 调用方）
- `go test ./internal/boot/ -run TestGoldenBaseline` 无漂移（写路径错误处理不影响前缀字节）
- `gofmt -l` 无输出；`go vet ./internal/memory/ ./internal/control/` 通过

## Documentation impact

Documentation-impact: none - 行为变化仅在读失败时（从"静默清空"变为"报错"），正常路径无变化，无用户文档需要更新。

## Cache impact

Cache-impact: none - 写路径错误处理，不改变任何 provider 可见字节：系统提示词、记忆前缀、工具 schema、召回注入全部原样。
Cache-guard: go test ./internal/boot -run TestGoldenBaseline（前缀基线无漂移）+ 既有 memory 测试（TestAppendDoc*）。
System-prompt-review: esengine - 记忆写路径（AppendDoc）错误处理变更，系统提示词/记忆前缀字节不变；需维护者确认后合并。