### PR TITLE
fix(grep): detect encoding from a character-safe peek

### DIFF
--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -70,6 +70,49 @@ func Detect(data []byte) (Kind, []byte) {
 	return LossyUTF8, data
 }
 
+// DetectPrefix classifies a stream from a leading window, where truncated says
+// more bytes follow. A truncated window is trimmed to a character boundary
+// first: Detect reads "not valid UTF-8" as a legacy charset and GB18030 accepts
+// nearly any bytes, so a window that merely stops mid-character would decode a
+// UTF-8 file into mojibake — a coin flip for 3-byte-per-character CJK text.
+func DetectPrefix(window []byte, truncated bool) Kind {
+	if truncated {
+		window = trimPartialRune(window)
+	}
+	k, _ := Detect(window)
+	return k
+}
+
+// trimPartialRune drops an incomplete trailing UTF-8 sequence. Bytes that
+// cannot begin a sequence stay, so genuinely non-UTF-8 input keeps failing
+// Detect's utf8.Valid check.
+func trimPartialRune(b []byte) []byte {
+	for i := len(b) - 1; i >= 0 && i >= len(b)-(utf8.UTFMax-1); i-- {
+		c := b[i]
+		if c&0xC0 == 0x80 {
+			continue // continuation byte — keep walking back to the lead byte
+		}
+		var width int
+		switch {
+		case c&0x80 == 0x00:
+			return b // ASCII: the window ends on a character boundary
+		case c&0xE0 == 0xC0:
+			width = 2
+		case c&0xF0 == 0xE0:
+			width = 3
+		case c&0xF8 == 0xF0:
+			width = 4
+		default:
+			return b // not a lead byte, so not a truncated sequence
+		}
+		if len(b)-i < width {
+			return b[:i]
+		}
+		return b
+	}
+	return b
+}
+
 // DetectQuick checks only for BOM prefixes in the first few bytes. This is
 // the fast path for peek-based binary rejection: BOM-prefixed files (UTF-16,
 // UTF-8 BOM) skip the NUL-byte check since 0x00 is normal in UTF-16. Returns

--- a/internal/fileutil/encoding/encoding_test.go
+++ b/internal/fileutil/encoding/encoding_test.go
@@ -317,3 +317,62 @@ func TestSurrogatePairRoundTrip(t *testing.T) {
 		t.Errorf("surrogate pair round-trip failed: got %q, want %q", decoded, original)
 	}
 }
+
+// trimPartialRune
+
+func TestTrimPartialRuneDropsOnlyTruncatedTail(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{"complete cjk", []byte("正文内容"), []byte("正文内容")},
+		{"cjk cut after lead byte", []byte("正文内容")[:len("正文内容")-2], []byte("正文内")},
+		{"cjk cut before last byte", []byte("正文内容")[:len("正文内容")-1], []byte("正文内")},
+		{"ascii tail", []byte("正文ab"), []byte("正文ab")},
+		{"emoji cut", []byte("hi 😀")[:len("hi 😀")-1], []byte("hi ")},
+		{"two-byte cut", []byte("é")[:1], []byte{}},
+		{"empty", []byte{}, []byte{}},
+		// A stray continuation byte is not a truncated sequence — leaving it in
+		// keeps Detect's utf8.Valid check able to reject genuine non-UTF-8 input.
+		{"stray continuation bytes", []byte{0xB2, 0xBB, 0xBA}, []byte{0xB2, 0xBB, 0xBA}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := trimPartialRune(c.in); !bytes.Equal(got, c.want) {
+				t.Errorf("trimPartialRune(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// A detection window cut mid-character must not be mistaken for GB18030: that
+// decoder accepts nearly any byte string, so the misdetection is silent and
+// every CJK line comes back as mojibake.
+func TestDetectPrefixTrimsTruncatedCJKWindow(t *testing.T) {
+	full := bytes.Repeat([]byte("这是一段中文正文内容\n"), 64)
+	cut := full[:len(full)-2] // stops inside the last multi-byte character
+
+	if enc := DetectPrefix(cut, false); enc != GB18030 {
+		t.Fatalf("precondition: an untrimmed mid-character window detects as %v, want GB18030", enc)
+	}
+	if enc := DetectPrefix(cut, true); enc != UTF8 {
+		t.Errorf("truncated window detected as %v, want UTF8", enc)
+	}
+	if enc := DetectPrefix(full, true); enc != UTF8 {
+		t.Errorf("whole-character window detected as %v, want UTF8", enc)
+	}
+}
+
+// Trimming may shorten genuinely non-UTF-8 input by a byte when its tail looks
+// like a lead byte. What remains is still invalid UTF-8, so the cascade must
+// still reach GB18030.
+func TestDetectPrefixKeepsGB18030Detectable(t *testing.T) {
+	gbk, err := simplifiedchinese.GB18030.NewEncoder().Bytes([]byte("这是一段中文正文内容"))
+	if err != nil {
+		t.Fatalf("encode GB18030: %v", err)
+	}
+	if enc := DetectPrefix(gbk, true); enc != GB18030 {
+		t.Errorf("truncated GB18030 window detected as %v, want GB18030", enc)
+	}
+}

--- a/internal/tool/builtin/e2e_encoding_test.go
+++ b/internal/tool/builtin/e2e_encoding_test.go
@@ -164,3 +164,111 @@ func TestE2EDeleteRangePreservesGBK(t *testing.T) {
 		t.Errorf("delete_range removed the wrong lines: %q", s)
 	}
 }
+
+// grep classifies a file from its 8 KiB peek alone. CJK characters are three
+// bytes wide, so that window usually stops mid-character; treating the cut as
+// "not UTF-8" sent the file down the GB18030 branch and produced mojibake.
+func TestE2EGrepUTF8CJKLargerThanPeek(t *testing.T) {
+	dir := t.TempDir()
+	raw := cjkFixtureSplitAt(t, grepBinaryPeek, 12*1024,
+		"统一战线的形成过程\n", "这是一段中文正文内容用于填充文件长度\n", "尾部中文行 tail-marker-1931\n")
+	if err := os.WriteFile(filepath.Join(dir, "chapter.md"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	grepTL, _ := tool.LookupBuiltin("grep")
+	out, err := grepTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"pattern": "统一战线",
+		"path":    dir,
+	}))
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out, "统一战线的形成过程") {
+		t.Errorf("grep missed a Chinese pattern in a UTF-8 file:\n%s", out)
+	}
+
+	// An ASCII pattern matched before the fix too, but printed the line as
+	// mojibake — the Chinese around it must survive the round trip.
+	out, err = grepTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"pattern": "tail-marker-1931",
+		"path":    dir,
+	}))
+	if err != nil {
+		t.Fatalf("grep ascii pattern: %v", err)
+	}
+	if !strings.Contains(out, "尾部中文行") {
+		t.Errorf("grep mangled Chinese text on a matched line:\n%s", out)
+	}
+}
+
+// Trimming the detection window must not cost grep its GB18030 support.
+func TestE2EGrepGBKLargerThanPeek(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("统一战线的形成过程\n")
+	for b.Len() < 12*1024 {
+		b.WriteString("这是一段中文正文内容用于填充文件长度\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "gbk.txt"), gbkBytes(t, b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	grepTL, _ := tool.LookupBuiltin("grep")
+	out, err := grepTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"pattern": "统一战线",
+		"path":    dir,
+	}))
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(out, "统一战线的形成过程") {
+		t.Errorf("grep missed a Chinese pattern in a GBK file:\n%s", out)
+	}
+}
+
+// read_file bounds its detection sample at a newline, which leaves a file with
+// no newline in that window (single-line CJK export) cut mid-character.
+func TestE2EReadFileSingleLineCJKLargerThanSample(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oneline.txt")
+	raw := cjkFixtureSplitAt(t, readFileDetectSample, readFileDetectSample+8*1024,
+		"统一战线", "这是一段中文正文内容没有任何换行符", "")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	readTL, _ := tool.LookupBuiltin("read_file")
+	out, err := readTL.Execute(context.Background(), e2eArgs(map[string]any{"path": path}))
+	if err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	if !strings.Contains(out, "统一战线") {
+		t.Errorf("read_file mangled a single-line UTF-8 CJK file:\n%.200s", out)
+	}
+}
+
+// cjkFixtureSplitAt builds a UTF-8 Chinese fixture of at least minSize bytes
+// whose byte at boundary falls inside a multi-byte character. ASCII padding
+// shifts the boundary a byte at a time, so one of three widths always splits
+// a 3-byte character.
+func cjkFixtureSplitAt(t *testing.T, boundary, minSize int, head, filler, tail string) []byte {
+	t.Helper()
+	for pad := range 3 {
+		var b strings.Builder
+		b.WriteString(strings.Repeat("x", pad))
+		b.WriteString(head)
+		for b.Len() < minSize {
+			b.WriteString(filler)
+		}
+		b.WriteString(tail)
+		raw := []byte(b.String())
+		if !utf8.Valid(raw) {
+			t.Fatal("fixture must be valid UTF-8")
+		}
+		if raw[boundary]&0xC0 == 0x80 {
+			return raw
+		}
+	}
+	t.Fatal("no fixture width split a character at the detection boundary")
+	return nil
+}

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -29,6 +29,7 @@ const (
 	grepMaxMatches     = 200
 	grepDefaultTimeout = 30 * time.Second
 	grepMaxTimeout     = 300 * time.Second
+	grepBinaryPeek     = 8 * 1024 // bytes scanned for NUL and sampled for encoding detection
 )
 
 // grepTimeout clamps a caller-supplied second count to a sane bound; 0 (omitted)
@@ -162,7 +163,7 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 	truncated := false
 
 	// Reused across the serial walk so each file doesn't re-allocate ~72 KiB.
-	peekBuf := make([]byte, 8*1024)
+	peekBuf := make([]byte, grepBinaryPeek)
 	scanBuf := make([]byte, 0, 64*1024)
 
 	// searchFile returns io.EOF as a sentinel once the cap is reached.
@@ -179,8 +180,9 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 		// Peek the first 8 KiB to reject binaries cheaply without reading
 		// the entire file into memory. Check BOM first (UTF-16 files have
 		// 0x00 for ASCII), then NUL.
-		n, _ := io.ReadFull(f, peekBuf)
+		n, perr := io.ReadFull(f, peekBuf)
 		peek := peekBuf[:n]
+		peekEOF := perr != nil // whole file fit in the peek (EOF / ErrUnexpectedEOF)
 
 		bomKind := fileenc.DetectQuick(peek)
 		if bomKind != fileenc.UTF16LE && bomKind != fileenc.UTF16BE && bomKind != fileenc.UTF8BOM {
@@ -193,7 +195,7 @@ func (g grepTool) runNative(ctx context.Context, pattern, path string, info os.F
 		// UTF-8 vs GB18030 distinction (utf8.Valid on 8 KiB is reliable).
 		// Then stream the rest through a decoder so the 200-match cap can
 		// stop reading early instead of buffering the entire file.
-		enc, _ := fileenc.Detect(peek)
+		enc := fileenc.DetectPrefix(peek, !peekEOF)
 
 		var src io.Reader
 		if enc == fileenc.UTF16LE || enc == fileenc.UTF16BE {

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -190,16 +190,9 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		peekEOF = merr != nil
 	}
 
-	// Detect from a char-safe slice: when more file follows, trim to the last
-	// newline so the sample never ends mid multi-byte sequence (UTF-8 and GB18030
-	// are ASCII-transparent, so '\n' is always a clean boundary).
-	sample := head
-	if !peekEOF {
-		if i := bytes.LastIndexByte(head, '\n'); i >= 0 {
-			sample = head[:i+1]
-		}
-	}
-	enc, _ := fileenc.Detect(sample)
+	// Detect from a char-safe slice: a sample that stops mid multi-byte
+	// character is not valid UTF-8 and would be read as GB18030.
+	enc := fileenc.DetectPrefix(head, !peekEOF)
 
 	src := io.MultiReader(bytes.NewReader(head), f)
 	if dec := fileenc.Decoder(enc); dec != nil {


### PR DESCRIPTION
## Summary

- `grep` classifies a file from its first 8 KiB peek, and in CJK text that window usually stops mid-character: most Chinese characters are three bytes wide, so roughly two of three cut points land inside one. `Detect` reads "not valid UTF-8" as evidence of a legacy charset, and the GB18030 decoder accepts nearly any byte string, so a plain UTF-8 file was decoded as GB18030. Chinese patterns then never matched, and ASCII patterns matched but printed their lines as mojibake.
- Adds `encoding.DetectPrefix(window, truncated)`, which trims a truncated window to a character boundary before classifying it, and routes grep's peek and `read_file`'s detection sample through it.
- `read_file` already trimmed its sample to the last newline for this reason. `DetectPrefix` subsumes that and also covers a sample with no newline in it, such as a single-line CJK export or a minified bundle.

This also accounts for the ASCII-ratio correlation in the report: the more ASCII a file contains, the likelier the 8192-byte boundary lands on a character boundary and the file happens to be classified correctly. It is a probability, not a threshold, which is why the reporter's 15.4% file was ambiguous while 18.7% and above looked fine.

## Issues

Fixes #8299

## Verification

- New tests, each confirmed to fail with the trim disabled and to pass with it:
  - `TestE2EGrepUTF8CJKLargerThanPeek`: grep matches a Chinese pattern in a UTF-8 file larger than the peek, and an ASCII match keeps its surrounding Chinese readable.
  - `TestE2EGrepGBKLargerThanPeek`: a real GB18030 file over the peek still decodes, guarding against over-trimming.
  - `TestE2EReadFileSingleLineCJKLargerThanSample`: `read_file` handles a single-line CJK file larger than its 256 KiB detection sample.
  - `TestDetectPrefixTrimsTruncatedCJKWindow`, `TestDetectPrefixKeepsGB18030Detectable`, `TestTrimPartialRuneDropsOnlyTruncatedTail`.
- The fixtures assert that the detection boundary actually splits a character before running the tool, so they cannot pass by luck.
- `gofmt -l .` clean, `go vet ./...` clean, `make lint` clean (golangci-lint v2.12.2 reports 0 issues; repolint clean against the baseline, which is unchanged).
- `go test ./internal/tool/... ./internal/boot/ ./internal/fileutil/... ./internal/checkpoint/ ./internal/config/` passes.

## Documentation impact

Documentation-impact: none - detection is internal. docs/MIGRATING.md:200 already promises that grep "decodes before matching", which is the behavior this restores for UTF-8 CJK files.

## Cache impact

Cache-impact: none - no tool schema, description, registration, or other provider-visible prefix byte changes. The only change is which local byte window is used for encoding detection.
Cache-guard: the provider-visible prefix is untouched, so existing tool-schema and boot guards cover it. Ran `go test ./internal/tool/... ./internal/boot/`.
System-prompt-review: N/A
