### PR TITLE
fix(agent,desktop): align context gauge with compaction trigger / 对齐上下文容量条与压缩触发器

### DIFF
--- a/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-stream-progress.test.ts
@@ -490,5 +490,33 @@ function ev(s: typeof initialState, e: WireEvent) {
   }
 }
 
+// --- 8. context occupancy uses prompt tokens and keeps legacy fallback semantics ---
+{
+  let s = ev({
+    ...initialState,
+    running: true,
+    turnActive: true,
+    context: { ...initialState.context, window: 1_000 },
+  }, { kind: "usage", usage: {
+    promptTokens: 500,
+    completionTokens: 20,
+    totalTokens: 520,
+    contextPromptTokens: 0,
+    contextCompletionTokens: 20,
+    source: "executor",
+  } } as WireEvent);
+  eq(s.context.used, 500, "completion-only latest usage falls back to aggregate prompt occupancy");
+
+  s = ev({ ...s, running: true, turnActive: true }, { kind: "usage", usage: {
+    promptTokens: 700,
+    completionTokens: 30,
+    totalTokens: 730,
+    contextPromptTokens: 450,
+    contextCompletionTokens: 0,
+    source: "executor",
+  } } as WireEvent);
+  eq(s.context.used, 450, "latest-attempt prompt occupancy excludes completion tokens");
+}
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1669,20 +1669,13 @@ function applyEvent(s: State, e: WireEvent): State {
       // subagent, and auxiliary usage still contributes to session totals and
       // usageSeq, but must not close or inflate the executor TPS interval.
       const settled = updateContextGauge ? endTurnModelActivity(s, Date.now(), true) : s;
-      const hasRequestContext = (e.usage?.contextPromptTokens ?? 0) > 0 || (e.usage?.contextCompletionTokens ?? 0) > 0;
+      const hasRequestCompletion = (e.usage?.contextCompletionTokens ?? 0) > 0;
       const requestModelMs = updateContextGauge ? (settled.pendingRequestModelMs ?? 0) : 0;
-      const requestTokens = updateContextGauge ? (hasRequestContext ? (e.usage?.contextCompletionTokens ?? 0) : (e.usage?.completionTokens ?? 0)) : 0;
+      const requestTokens = updateContextGauge ? (hasRequestCompletion ? (e.usage?.contextCompletionTokens ?? 0) : (e.usage?.completionTokens ?? 0)) : 0;
       const lastRequestTps = updateContextGauge ? (requestTokens > 0 && requestModelMs >= 500 ? requestTokens / (requestModelMs / 1000) : null) : s.lastRequestTps;
       // Context* is the latest sampling attempt; other token fields are billable aggregates.
-      // The context gauge must measure what the compaction trigger measures: the
-      // prompt that the next request sends. Counting the last turn's completion
-      // tokens here inflated the displayed fill (a 25K output round read as 25K
-      // of "used context"), so the gauge showed e.g. 90% while the trigger still
-      // sat below compact_ratio — the compaction never fired and the session ran
-      // into a real overflow. Completion belongs in the output metrics, not the
-      // occupancy gauge.
       let used = settled.context.used;
-      if (e.usage && settled.context.window && updateContextGauge) used = hasRequestContext
+      if (e.usage && settled.context.window && updateContextGauge) used = (e.usage.contextPromptTokens ?? 0) > 0
         ? (e.usage.contextPromptTokens ?? 0)
         : (e.usage.promptTokens ?? 0);
       const turnTokens = settled.turnTokens + (e.usage?.completionTokens ?? 0);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1674,10 +1674,17 @@ function applyEvent(s: State, e: WireEvent): State {
       const requestTokens = updateContextGauge ? (hasRequestContext ? (e.usage?.contextCompletionTokens ?? 0) : (e.usage?.completionTokens ?? 0)) : 0;
       const lastRequestTps = updateContextGauge ? (requestTokens > 0 && requestModelMs >= 500 ? requestTokens / (requestModelMs / 1000) : null) : s.lastRequestTps;
       // Context* is the latest sampling attempt; other token fields are billable aggregates.
+      // The context gauge must measure what the compaction trigger measures: the
+      // prompt that the next request sends. Counting the last turn's completion
+      // tokens here inflated the displayed fill (a 25K output round read as 25K
+      // of "used context"), so the gauge showed e.g. 90% while the trigger still
+      // sat below compact_ratio — the compaction never fired and the session ran
+      // into a real overflow. Completion belongs in the output metrics, not the
+      // occupancy gauge.
       let used = settled.context.used;
       if (e.usage && settled.context.window && updateContextGauge) used = hasRequestContext
-        ? (e.usage.contextPromptTokens ?? 0) + (e.usage.contextCompletionTokens ?? 0)
-        : (e.usage.promptTokens ?? 0) + (e.usage.completionTokens ?? 0);
+        ? (e.usage.contextPromptTokens ?? 0)
+        : (e.usage.promptTokens ?? 0);
       const turnTokens = settled.turnTokens + (e.usage?.completionTokens ?? 0);
       const turnOutputTokens = updateContextGauge
         ? settled.turnOutputTokens + (e.usage?.completionTokens ?? 0)

--- a/internal/agent/context_usage.go
+++ b/internal/agent/context_usage.go
@@ -1,14 +1,18 @@
 package agent
 
+import "reasonix/internal/tool"
+
 // contextUsage memoises the projected prompt size. The estimate walks every
 // visible message, and status gauges redraw far more often than the view moves,
-// so it is keyed on the three things that can change the answer: the
-// transcript, the projection, and the calibration.
+// so it is keyed on everything that can change the answer: the transcript,
+// projection, calibration, and provider-visible tool schemas.
 type contextUsage struct {
-	transcriptVersion uint64
-	projectionVersion uint64
-	calibration       *promptTokenCalibration
-	tokens            int
+	transcriptVersion  uint64
+	projectionVersion  uint64
+	calibration        *promptTokenCalibration
+	tools              *tool.Registry
+	toolSchemaRevision uint64
+	tokens             int
 }
 
 // ContextUsedTokens is the number ContextManager compares against its
@@ -16,14 +20,6 @@ type contextUsage struct {
 // gauge fed from the last turn's usage instead lags a turn, counts completion
 // tokens the trigger ignores, and reads zero on a rebound session — which is
 // how a session displays 8% while it is compacting.
-//
-// The gauge must use the exact same estimator as the trigger
-// (estimatedVisibleRequestTokens: messages + role projection + tool schemas).
-// The message-only estimator (estimatedPromptTokens) under-reported the fill
-// by the tool schemas' token cost, so the gauge could sit below compact_ratio
-// while the trigger had already crossed it — and the desktop gauge (which
-// additionally counted the last turn's completion tokens) showed the opposite
-// skew. One estimator, one number, everywhere the UI reads context pressure.
 func (a *Agent) ContextUsedTokens() int {
 	if a == nil {
 		return 0
@@ -35,18 +31,24 @@ func (a *Agent) ContextUsedTokens() int {
 	transcriptVersion := session.TranscriptVersion()
 	projectionVersion := a.currentProjectionVersion()
 	calibration := a.promptCalibration.Load()
+	tools := a.tools
+	toolSchemaRevision := tools.SchemaRevision()
 	if cached := a.contextUsage.Load(); cached != nil &&
 		cached.transcriptVersion == transcriptVersion &&
 		cached.projectionVersion == projectionVersion &&
-		cached.calibration == calibration {
+		cached.calibration == calibration &&
+		cached.tools == tools &&
+		cached.toolSchemaRevision == toolSchemaRevision {
 		return cached.tokens
 	}
 	tokens := a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
 	a.contextUsage.Store(&contextUsage{
-		transcriptVersion: transcriptVersion,
-		projectionVersion: projectionVersion,
-		calibration:       calibration,
-		tokens:            tokens,
+		transcriptVersion:  transcriptVersion,
+		projectionVersion:  projectionVersion,
+		calibration:        calibration,
+		tools:              tools,
+		toolSchemaRevision: toolSchemaRevision,
+		tokens:             tokens,
 	})
 	return tokens
 }

--- a/internal/agent/context_usage.go
+++ b/internal/agent/context_usage.go
@@ -16,6 +16,14 @@ type contextUsage struct {
 // gauge fed from the last turn's usage instead lags a turn, counts completion
 // tokens the trigger ignores, and reads zero on a rebound session — which is
 // how a session displays 8% while it is compacting.
+//
+// The gauge must use the exact same estimator as the trigger
+// (estimatedVisibleRequestTokens: messages + role projection + tool schemas).
+// The message-only estimator (estimatedPromptTokens) under-reported the fill
+// by the tool schemas' token cost, so the gauge could sit below compact_ratio
+// while the trigger had already crossed it — and the desktop gauge (which
+// additionally counted the last turn's completion tokens) showed the opposite
+// skew. One estimator, one number, everywhere the UI reads context pressure.
 func (a *Agent) ContextUsedTokens() int {
 	if a == nil {
 		return 0
@@ -33,7 +41,7 @@ func (a *Agent) ContextUsedTokens() int {
 		cached.calibration == calibration {
 		return cached.tokens
 	}
-	tokens := a.estimatedPromptTokens(a.modelVisibleMessages())
+	tokens := a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
 	a.contextUsage.Store(&contextUsage{
 		transcriptVersion: transcriptVersion,
 		projectionVersion: projectionVersion,

--- a/internal/agent/context_usage_test.go
+++ b/internal/agent/context_usage_test.go
@@ -25,7 +25,7 @@ func (bigSchemaTool) Schema() json.RawMessage {
 		`"},"query":{"type":"string","description":"another long field to inflate the schema"}}}`)
 }
 func (bigSchemaTool) Execute(context.Context, json.RawMessage) (string, error) { return "", nil }
-func (bigSchemaTool) ReadOnly() bool                                            { return true }
+func (bigSchemaTool) ReadOnly() bool                                           { return true }
 
 func usageFixture(t *testing.T, toolResults int) *Agent {
 	t.Helper()
@@ -94,6 +94,42 @@ func TestContextUsedTokensIncludesToolSchemasLikeTheTrigger(t *testing.T) {
 	// message-only estimator ignored them and reported exactly the message cost.
 	if msgOnly := a.estimatedPromptTokens(a.modelVisibleMessages()); used <= msgOnly {
 		t.Fatalf("gauge = %d, message-only estimate = %d; the gauge must price tool schemas like the trigger", used, msgOnly)
+	}
+}
+
+func TestContextUsedTokensFollowsLiveToolRegistry(t *testing.T) {
+	reg := tool.NewRegistry()
+	a := New(nil, reg, &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "task"},
+	}}, Options{ContextWindow: 1_000_000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	withoutTools := a.ContextUsedTokens()
+	reg.Add(bigSchemaTool{})
+	withTools := a.ContextUsedTokens()
+	if got := a.ContextMaintenanceSnapshot().ProjectedTokens; withTools != got {
+		t.Fatalf("gauge after tool registration = %d, trigger input = %d", withTools, got)
+	}
+	if withTools <= withoutTools {
+		t.Fatalf("gauge did not grow after tool registration: %d -> %d", withoutTools, withTools)
+	}
+
+	if removed := reg.RemovePrefix("big_"); removed != 1 {
+		t.Fatalf("removed %d tools, want 1", removed)
+	}
+	if got := a.ContextUsedTokens(); got != withoutTools {
+		t.Fatalf("gauge after tool removal = %d, want %d", got, withoutTools)
+	}
+
+	reg.Add(bigSchemaTool{})
+	if got := a.ContextUsedTokens(); got != withTools {
+		t.Fatalf("gauge after re-registration = %d, want %d", got, withTools)
+	}
+	if removed := reg.SuspendPrefix("big_"); removed != 1 {
+		t.Fatalf("suspended %d tools, want 1", removed)
+	}
+	if got := a.ContextUsedTokens(); got != withoutTools {
+		t.Fatalf("gauge after tool suspension = %d, want %d", got, withoutTools)
 	}
 }
 

--- a/internal/agent/context_usage_test.go
+++ b/internal/agent/context_usage_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,6 +11,21 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
+
+// bigSchemaTool mimics a real built-in tool whose JSON schema is large enough
+// to matter: the compaction trigger counts tool schemas in the prompt it sizes,
+// so the gauge must too.
+type bigSchemaTool struct{}
+
+func (bigSchemaTool) Name() string        { return "big_schema" }
+func (bigSchemaTool) Description() string { return "a tool with a large schema" }
+func (bigSchemaTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"` +
+		strings.Repeat("a fairly long property description that consumes tokens. ", 200) +
+		`"},"query":{"type":"string","description":"another long field to inflate the schema"}}}`)
+}
+func (bigSchemaTool) Execute(context.Context, json.RawMessage) (string, error) { return "", nil }
+func (bigSchemaTool) ReadOnly() bool                                            { return true }
 
 func usageFixture(t *testing.T, toolResults int) *Agent {
 	t.Helper()
@@ -47,6 +64,36 @@ func TestContextUsedTokensMatchesTheTriggerInput(t *testing.T) {
 	}
 	if used <= 1_000 {
 		t.Fatalf("gauge = %d, want the real view size rather than the last turn's %d", used, 1_000)
+	}
+}
+
+// Regression: the gauge used the message-only estimator while the trigger also
+// sizes tool schemas, so with a non-empty tool registry the gauge under-reported
+// the fill — a session could display 80% while the trigger had already crossed
+// compact_ratio (and after a compaction the two disagreed again). The gauge must
+// call the exact same estimator as the trigger, tool schemas included.
+func TestContextUsedTokensIncludesToolSchemasLikeTheTrigger(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(bigSchemaTool{})
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: "task"},
+	}
+	a := New(nil, reg, &Session{Messages: msgs}, Options{
+		ContextWindow: 1_000_000,
+		RecentKeep:    2,
+		ArchiveDir:    t.TempDir(),
+	}, event.Discard)
+
+	used := a.ContextUsedTokens()
+	// The trigger's own measurement, verbatim.
+	if got := a.ContextMaintenanceSnapshot().ProjectedTokens; used != got {
+		t.Fatalf("gauge = %d, trigger input = %d; they must be the same measurement", used, got)
+	}
+	// The gauge must include the tool schemas the trigger counts. The old
+	// message-only estimator ignored them and reported exactly the message cost.
+	if msgOnly := a.estimatedPromptTokens(a.modelVisibleMessages()); used <= msgOnly {
+		t.Fatalf("gauge = %d, message-only estimate = %d; the gauge must price tool schemas like the trigger", used, msgOnly)
 	}
 }
 

--- a/internal/agent/usage_accounting_test.go
+++ b/internal/agent/usage_accounting_test.go
@@ -88,8 +88,12 @@ func TestFinalizeSamplingUsageKeepsLatestPromptContext(t *testing.T) {
 	if got.ContextPromptTokens != 30000 || got.ContextCompletionTokens != 10 {
 		t.Fatalf("context shape = prompt %d completion %d, want latest 30000/10", got.ContextPromptTokens, got.ContextCompletionTokens)
 	}
-	if got.ContextFillTokens() != 30010 {
-		t.Fatalf("ContextFillTokens = %d, want 30010", got.ContextFillTokens())
+	if got.ContextFillTokens() != 30000 {
+		t.Fatalf("ContextFillTokens = %d, want 30000", got.ContextFillTokens())
+	}
+	completionOnly := &provider.Usage{PromptTokens: 500, ContextCompletionTokens: 20}
+	if fill := completionOnly.ContextFillTokens(); fill != 500 {
+		t.Fatalf("completion-only ContextFillTokens = %d, want prompt fallback 500", fill)
 	}
 	if got.CompletionTokens != 30 || got.RequestCount != 3 {
 		t.Fatalf("billable fields = %+v, want summed completion/requests", got)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -754,17 +754,9 @@ type Usage struct {
 	ContextCacheMissTokens  int
 }
 
-// ContextFillTokens returns the latest-attempt context fill (prompt+completion)
-// used by status bars and context panels. Falls back to billable totals when
-// no Context* fields were set (single-attempt / legacy usage events).
+// ContextFillTokens returns the latest prompt occupancy used by context gauges.
 func (u *Usage) ContextFillTokens() int {
-	if u == nil {
-		return 0
-	}
-	if u.ContextPromptTokens > 0 || u.ContextCompletionTokens > 0 {
-		return u.ContextPromptTokens + u.ContextCompletionTokens
-	}
-	return u.PromptTokens + u.CompletionTokens
+	return u.LatestPromptTokens()
 }
 
 // LatestPromptTokens returns the latest-attempt prompt size for context-aware

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -149,6 +149,27 @@ func TestRegistrySuspendPrefixBlocksLateAddsUntilResume(t *testing.T) {
 	}
 }
 
+func TestRegistrySchemaRevisionTracksVisibleChanges(t *testing.T) {
+	r := NewRegistry()
+	initial := r.SchemaRevision()
+	r.Add(stubTool{name: "mcp__fs__read"})
+	afterAdd := r.SchemaRevision()
+	if afterAdd <= initial {
+		t.Fatalf("revision after add = %d, want greater than %d", afterAdd, initial)
+	}
+	r.Add(stubTool{name: "mcp__fs__read", schema: json.RawMessage(`{"type":"string"}`)})
+	afterReplace := r.SchemaRevision()
+	if afterReplace <= afterAdd {
+		t.Fatalf("revision after replace = %d, want greater than %d", afterReplace, afterAdd)
+	}
+	if removed := r.RemovePrefix("missing"); removed != 0 || r.SchemaRevision() != afterReplace {
+		t.Fatalf("no-op removal changed revision: removed=%d revision=%d", removed, r.SchemaRevision())
+	}
+	if removed := r.SuspendPrefix("mcp__fs__"); removed != 1 || r.SchemaRevision() <= afterReplace {
+		t.Fatalf("suspension did not advance revision: removed=%d revision=%d", removed, r.SchemaRevision())
+	}
+}
+
 // TestRegistrySchemasSorted proves Schemas() emits tool definitions in
 // deterministic alphabetical order regardless of insertion order, so a logically
 // identical tool set produces a stable provider-facing request prefix (prompt

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"reasonix/internal/diff"
 	"reasonix/internal/provider"
@@ -284,6 +285,7 @@ type Registry struct {
 	order     []string
 	canon     map[string]json.RawMessage
 	suspended map[string]bool
+	schemaRev atomic.Uint64
 }
 
 // NewRegistry returns an empty registry.
@@ -309,6 +311,7 @@ func (r *Registry) Add(t Tool) {
 	}
 	r.tools[name] = t
 	r.canon[name] = provider.CanonicalizeSchema(t.Schema())
+	r.schemaRev.Add(1)
 }
 
 // MCPNamePrefix is the namespace every MCP tool name carries: the
@@ -349,6 +352,9 @@ func (r *Registry) RemovePrefix(prefix string) int {
 		kept = append(kept, name)
 	}
 	r.order = kept
+	if removed > 0 {
+		r.schemaRev.Add(1)
+	}
 	return removed
 }
 
@@ -373,6 +379,9 @@ func (r *Registry) SuspendPrefix(prefix string) int {
 		kept = append(kept, name)
 	}
 	r.order = kept
+	if removed > 0 {
+		r.schemaRev.Add(1)
+	}
 	return removed
 }
 
@@ -513,6 +522,14 @@ func (r *Registry) Len() int {
 	defer r.mu.RUnlock()
 
 	return len(r.order)
+}
+
+// SchemaRevision changes whenever the provider-visible tool set changes.
+func (r *Registry) SchemaRevision() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.schemaRev.Load()
 }
 
 // Names returns the registered tool names in insertion order.


### PR DESCRIPTION
## What breaks today

The desktop context gauge measured something different from the compaction trigger in both directions:

1. **The backend gauge under-reported.** `ContextUsedTokens()` used the message-only estimator, while the trigger sizes messages, role projection, and tool schemas.
2. **The frontend inflated the fill.** It added completion tokens to prompt occupancy, so a large output could make the gauge cross the threshold even though the next request prompt had not.
3. **Live MCP changes could leave the gauge stale.** The context-usage cache did not observe tool registration, replacement, removal, or suspension.

## Fix

- Use `estimatedVisibleRequestTokens()` for both the gauge and compaction trigger.
- Track a lock-free provider-visible tool schema revision and include the registry identity plus revision in the context-usage cache key.
- Count prompt tokens only for context occupancy, with latest-attempt and legacy aggregate fallbacks selected independently.
- Align the shared `ContextFillTokens()` helper with prompt occupancy.
- Add deterministic regression coverage for live tool changes and completion-only usage payloads.

## Verification

- `go test ./...`
- `go test -race ./internal/tool ./internal/agent`
- `go vet ./...`
- `go run ./tools/repolint`
- `pnpm build` in `desktop/frontend`
- Relevant frontend controller suites: 280 assertions passed
- Latest `main-v2` virtual merge: relevant Go tests, frontend reducer test, frontend build, and repolint passed

Refs: #8191, #8221

Documentation-impact: none - this aligns internal context-capacity measurement with the existing compaction semantics and does not change configuration or user workflows.
Cache-impact: none - the revision is internal bookkeeping only; tool schema bytes, ordering, and provider request construction are unchanged.
Cache-guard: `go test ./internal/tool ./internal/agent ./internal/provider` covers registry revision changes, live add/remove/suspend invalidation, and prompt-only occupancy fallbacks.
