### PR TITLE
fix(control): a question queued behind another prompt is no longer invisible

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2270,6 +2270,7 @@ const noticeCodeKeys: Record<string, DictKey> = {
   empty_final: "notice.emptyFinal",
   executor_handoff: "notice.executorHandoff",
   tool_budget: "notice.toolBudget",
+  prompt_queued: "notice.promptQueued",
   loop_guard: "notice.loopGuard",
   workspace_lease: "notice.workspaceLease",
   cancelled_turn_display: "notice.cancelledTurnDisplay",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2897,6 +2897,7 @@ export const en = {
   "notice.emptyFinal": "No visible answer was produced; asking the assistant to respond again.",
   "notice.executorHandoff": "The assistant answered before taking action; asking it to use the required tools.",
   "notice.toolBudget": "Tool round limit reached; asking the assistant to summarize progress.",
+  "notice.promptQueued": "A question is waiting for you to answer the prompt ahead of it.",
   "notice.loopGuard": "The assistant is not making progress; asking it to reassess the current step.",
   "notice.workspaceLease": "Another Delivery session is writing to this workspace; this session will continue automatically when it is safe.",
   "notice.cancelledTurnDisplay": "This turn was interrupted. Partial output is kept for reference; only completed tool pairs and a bounded recovery summary enter the next model turn. Inspect the workspace before continuing or reverting changes.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1997,6 +1997,7 @@ export const zhTW: Record<DictKey, string> = {
   "notice.emptyFinal": "沒有產生可見回覆，已要求助手重新作答。",
   "notice.executorHandoff": "助手尚未執行必要操作，已要求它使用相應工具。",
   "notice.toolBudget": "工具呼叫輪數已達上限，已要求助手總結目前進度。",
+  "notice.promptQueued": "有一個問題正在等你先回答前面的提示。",
   "notice.loopGuard": "助手沒有取得有效進展，已要求它重新評估目前步驟。",
   "notice.workspaceLease": "另一個交付會話正在寫入此工作區；安全後本會話會自動繼續。",
   "notice.cancelledTurnDisplay": "本輪已中斷。上方的部分輸出會永久保留供查看；只有完整工具呼叫及結果和有界恢復摘要會進入模型下一輪。繼續或回復前請先檢查目前工作區。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2900,6 +2900,7 @@ export const zh: Record<DictKey, string> = {
   "notice.emptyFinal": "没有生成可见回复，已要求助手重新作答。",
   "notice.executorHandoff": "助手尚未执行必要操作，已要求它使用相应工具。",
   "notice.toolBudget": "工具调用轮数已达上限，已要求助手总结当前进展。",
+  "notice.promptQueued": "有一个问题在等你先回答前面的提示。",
   "notice.loopGuard": "助手没有取得有效进展，已要求它重新评估当前步骤。",
   "notice.workspaceLease": "另一个交付会话正在写入此工作区；安全后本会话会自动继续。",
   "notice.cancelledTurnDisplay": "本轮已中断。上方的部分输出会永久保留供查看；只有完整工具调用及结果和有界恢复摘要会进入模型下一轮。继续或回滚前请先检查当前工作区。",

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -367,15 +367,41 @@ func (a *approvalManager) resolveTool(id, tool string) (pendingApproval, bool) {
 }
 
 // registerAsk allocates an ask ID, records the pending question batch, and
-// returns the reply channel.
+// returns the reply channel. The ask starts queued: registering before the
+// prompt lock is what makes a question waiting behind another prompt visible
+// at all, instead of existing only inside a blocked goroutine.
 func (a *approvalManager) registerAsk(questions []event.AskQuestion) (string, chan []event.AskAnswer) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.nextID++
 	id := strconv.Itoa(a.nextID)
 	reply := make(chan []event.AskAnswer, 1)
-	a.asks[id] = pendingAsk{questions: questions, reply: reply}
+	a.asks[id] = pendingAsk{questions: questions, reply: reply, queued: true}
 	return id, reply
+}
+
+// markAskEmitted clears the queued flag once the ask has reached a frontend,
+// which is what makes it eligible for replay.
+func (a *approvalManager) markAskEmitted(id string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if p, ok := a.asks[id]; ok {
+		p.queued = false
+		a.asks[id] = p
+	}
+}
+
+// queuedAsks reports asks registered but not yet shown.
+func (a *approvalManager) queuedAsks() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	n := 0
+	for _, p := range a.asks {
+		if p.queued {
+			n++
+		}
+	}
+	return n
 }
 
 // cancelAsk drops a pending ask (timeout/abort path).
@@ -475,6 +501,11 @@ func (a *approvalManager) snapshotPrompts() ([]event.Approval, []event.Ask) {
 	}
 	asks := make([]event.Ask, 0, len(a.asks))
 	for id, p := range a.asks {
+		// A queued ask has never been shown; replaying it would put a question
+		// on screen ahead of the prompt it is waiting behind.
+		if p.queued {
+			continue
+		}
 		asks = append(asks, event.Ask{ID: id, Questions: p.questions})
 	}
 	return approvals, asks

--- a/internal/control/ask_queue_test.go
+++ b/internal/control/ask_queue_test.go
@@ -1,0 +1,237 @@
+package control
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+func askProbeQuestions() []event.AskQuestion {
+	return []event.AskQuestion{{
+		ID: "q1", Header: "Fix", Prompt: "Which fix?",
+		Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+	}}
+}
+
+type askProbeSink struct {
+	mu      sync.Mutex
+	asks    []event.Ask
+	notices []event.Event
+}
+
+func (s *askProbeSink) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch {
+	case e.Kind == event.AskRequest:
+		s.asks = append(s.asks, e.Ask)
+	case e.Kind == event.Notice && e.Code == event.NoticeCodePromptQueued:
+		s.notices = append(s.notices, e)
+	}
+}
+
+func (s *askProbeSink) counts() (asks, notices int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.asks), len(s.notices)
+}
+
+func shortenPromptQueueNotice(t *testing.T) {
+	t.Helper()
+	old := promptQueueNoticeDelay
+	promptQueueNoticeDelay = 40 * time.Millisecond
+	t.Cleanup(func() { promptQueueNoticeDelay = old })
+}
+
+// A question waiting behind an earlier prompt used to be invisible in every
+// direction: Ask took promptMu before registering, so no event was emitted, the
+// prompt snapshot did not list it, and ReplayPendingPrompts could not recover
+// it. The user saw a tool card that never opened a dialog while the turn
+// blocked. It is now registered up front and announced.
+func TestAskQueuedBehindAnotherPromptIsVisibleAndAnnounced(t *testing.T) {
+	shortenPromptQueueNotice(t)
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir()})
+
+	// Stand in for an earlier prompt still awaiting the user.
+	c.approval.promptMu.Lock()
+
+	var returned atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_, _ = c.Ask(ctx, askProbeQuestions())
+		returned.Store(true)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if _, notices := sink.counts(); notices == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("a question queued behind another prompt never told the user why")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	// Registered, so it is visible to diagnostics rather than living only
+	// inside a blocked goroutine.
+	if got := c.approval.queuedAsks(); got != 1 {
+		t.Fatalf("queued asks = %d, want the waiting question registered", got)
+	}
+	// Still not shown, and still not replayable: surfacing it here would put a
+	// question on screen ahead of the prompt it is waiting behind.
+	if asks, _ := sink.counts(); asks != 0 {
+		t.Fatalf("AskRequest events = %d, want the question held until its turn", asks)
+	}
+	c.ReplayPendingPrompts()
+	time.Sleep(30 * time.Millisecond)
+	if asks, _ := sink.counts(); asks != 0 {
+		t.Fatalf("replay surfaced %d queued ask(s) out of order", asks)
+	}
+	if _, pending := c.approval.snapshotPrompts(); len(pending) != 0 {
+		t.Fatalf("snapshot listed %d queued ask(s); replay would show it early", len(pending))
+	}
+
+	// Once the earlier prompt clears, the question appears normally.
+	c.approval.promptMu.Unlock()
+	for {
+		if asks, _ := sink.counts(); asks == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the queued question never appeared after the earlier prompt cleared")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if got := c.approval.queuedAsks(); got != 0 {
+		t.Fatalf("queued asks = %d after emission, want 0", got)
+	}
+	// An emitted ask is replayable, which is how a tab switch rebuilds it.
+	if _, pending := c.approval.snapshotPrompts(); len(pending) != 1 {
+		t.Fatalf("snapshot listed %d shown ask(s), want 1 for replay", len(pending))
+	}
+
+	cancel()
+	for !returned.Load() {
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// A prompt answered promptly must not produce a queue notice.
+func TestPromptQueueNoticeStaysQuietWhenNothingWaits(t *testing.T) {
+	shortenPromptQueueNotice(t)
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir()})
+
+	go func() { _, _ = c.Ask(t.Context(), askProbeQuestions()) }()
+
+	deadline := time.After(2 * time.Second)
+	for asks, _ := sink.counts(); asks != 1; asks, _ = sink.counts() {
+		select {
+		case <-deadline:
+			t.Fatal("the uncontended ask never reached the frontend")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, notices := sink.counts(); notices != 0 {
+		t.Fatalf("queue notices = %d, want none when the prompt was never queued", notices)
+	}
+}
+
+// Cancelling while queued must drop the registration and release the lock to
+// the next prompt rather than leaking either.
+func TestAskCancelledWhileQueuedLeavesNothingBehind(t *testing.T) {
+	shortenPromptQueueNotice(t)
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir()})
+	c.approval.promptMu.Lock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.Ask(ctx, askProbeQuestions())
+		errc <- err
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for c.approval.queuedAsks() != 1 {
+		select {
+		case <-deadline:
+			t.Fatal("the ask never registered while queued")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("cancelled Ask returned a nil error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask did not unblock on cancellation while queued")
+	}
+	if got := c.approval.queuedAsks(); got != 0 {
+		t.Fatalf("queued asks = %d after cancellation, want the registration dropped", got)
+	}
+
+	// The abandoned wait must not keep the lock from the next prompt.
+	c.approval.promptMu.Unlock()
+	acquired := false
+	for range 200 {
+		if c.approval.promptMu.TryLock() {
+			acquired = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !acquired {
+		t.Fatal("the prompt lock was leaked by the cancelled ask")
+	}
+	c.approval.promptMu.Unlock()
+}
+
+// Ask has no timeout of its own: approvalTimeout defaults to zero, so a
+// question nobody answers blocks its turn until the user cancels.
+func TestAskWithoutTimeoutBlocksUntilCancelled(t *testing.T) {
+	c := New(Options{Sink: event.Discard, SessionDir: t.TempDir()})
+	if c.approval.approvalTimeout != 0 {
+		t.Skipf("approvalTimeout is %v; this test pins the unbounded default", c.approval.approvalTimeout)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.Ask(ctx, askProbeQuestions())
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		t.Fatalf("Ask returned %v without an answer; it is expected to block", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("cancelled Ask returned a nil error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask did not unblock after cancellation")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -336,6 +336,7 @@ type pendingApproval struct {
 type pendingAsk struct {
 	questions []event.AskQuestion
 	reply     chan []event.AskAnswer
+	queued    bool // registered but not yet shown; replay must skip it
 }
 
 type plannerSessionResetter interface {
@@ -2421,6 +2422,45 @@ func (c *Controller) SteerConsumed() bool {
 	return true
 }
 
+// promptQueueNoticeDelay is how long a prompt may wait behind another before
+// the user is told why nothing has appeared. Short enough to beat "it's stuck",
+// long enough that an approval answered promptly never emits a notice.
+var promptQueueNoticeDelay = 3 * time.Second
+
+// lockPromptFor acquires the prompt lock, emitting one notice if the wait is
+// long enough to look like a hang. It reports false only when ctx ended first;
+// the lock is held on true.
+func (c *Controller) lockPromptFor(ctx context.Context, kind string) bool {
+	acquired := make(chan struct{})
+	go func() {
+		c.approval.promptMu.Lock()
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		return true
+	case <-ctx.Done():
+	case <-time.After(promptQueueNoticeDelay):
+	}
+	if ctx.Err() == nil {
+		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodePromptQueued,
+			Text:   "A " + kind + " is waiting for you to answer the prompt ahead of it.",
+			Detail: "the assistant asked something while an earlier approval or question was still open; it appears once that one is answered"})
+	}
+	select {
+	case <-acquired:
+		return true
+	case <-ctx.Done():
+		// The lock may still be handed to the goroutine above; release it so the
+		// next prompt is not blocked by this abandoned wait.
+		go func() {
+			<-acquired
+			c.approval.promptMu.Unlock()
+		}()
+		return false
+	}
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.
@@ -2428,11 +2468,18 @@ func (c *Controller) SteerConsumed() bool {
 // tool exists to get a genuine user decision, and YOLO only auto-approves
 // tool calls; it must not answer the user's questions for them.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
-	c.approval.promptMu.Lock()
+	// Registering after the lock left a queued question invisible everywhere:
+	// no event, absent from the snapshot, unreachable by ReplayPendingPrompts.
+	id, reply := c.approval.registerAsk(questions)
+
+	if !c.lockPromptFor(ctx, "question") {
+		c.approval.cancelAsk(id)
+		return nil, ctx.Err()
+	}
 	defer c.approval.promptMu.Unlock()
 
 	c.approval.promptEmitMu.Lock()
-	id, reply := c.approval.registerAsk(questions)
+	c.approval.markAskEmitted(id)
 	c.sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{ID: id, Questions: questions}})
 	c.approval.promptEmitMu.Unlock()
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -507,6 +507,7 @@ const (
 	NoticeCodeEmptyFinal                                        = "empty_final"
 	NoticeCodeExecutorHandoff                                   = "executor_handoff"
 	NoticeCodeToolBudget                                        = "tool_budget"
+	NoticeCodePromptQueued                                      = "prompt_queued"
 	NoticeCodeLoopGuard                                         = "loop_guard"
 	NoticeCodeProgressGuard                                     = "progress_guard"
 	NoticeCodeEvidenceNudge                                     = "evidence_nudge"

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -177,7 +177,7 @@
       "file-size": 1456
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 3935
+      "file-size": 3936
     },
     "desktop/heartbeat.go": {
       "essay": 20,
@@ -1072,7 +1072,7 @@
     "internal/control/controller.go": {
       "complexity": 10,
       "essay": 162,
-      "file-size": 5416,
+      "file-size": 5463,
       "function-size": 75,
       "narrative": 4
     },
@@ -1196,7 +1196,7 @@
     },
     "internal/event/event.go": {
       "essay": 10,
-      "file-size": 46,
+      "file-size": 47,
       "narrative": 1
     },
     "internal/event/subagent_progress.go": {


### PR DESCRIPTION
Reported as an `ask` tool card that sat for 14 minutes without ever opening a dialog, on a Yolo-mode turn. YOLO was not the cause - `Controller.Ask` is deliberately never bypassed by it. The defect is in ordering.

## The defect

`Ask` took `promptMu` **before** it registered or emitted anything:

```go
c.approval.promptMu.Lock()                       // ← first
id, reply := c.approval.registerAsk(questions)   // ← then registered
c.sink.Emit(event.Event{Kind: event.AskRequest})  // ← then emitted
```

So a question raised while an earlier approval was still open existed only inside a blocked goroutine. It was invisible in every direction at once:

| recovery path | result |
|---|---|
| `AskRequest` event | never emitted |
| `snapshotPrompts()` | did not list it |
| `ReplayPendingPrompts` (tab switch, status reconcile) | could not recover it |

Combined with `approvalTimeout` defaulting to zero - `waitContext` returns the parent ctx unchanged, so `Ask` waits with no deadline - the turn blocks until the user cancels. That is exactly the reported symptom: a tool card, no dialog, a timer climbing.

Note the card alone never proved the tool had run: `ChunkToolCallStart` emits a `Partial: true` dispatch while arguments are still streaming.

## The fix

**Register before queuing.** That is what makes a waiting question exist outside the blocked goroutine. It is marked `queued` so replay still skips it - surfacing it early would put a question on screen ahead of the prompt it is waiting behind, and the ordering `promptMu` exists to enforce is unchanged.

**Say so when the wait is long.** Past a few seconds, one `prompt_queued` notice explains why nothing has appeared. A prompt answered promptly emits nothing.

**Cancel cleanly.** Cancelling while queued drops the registration and hands the lock on instead of leaking it to the next prompt.

What this does *not* change: `Ask` still has no timeout of its own, and still blocks until answered or cancelled. Giving it a deadline would answer the user's question for them by expiry, which is the one thing the `ask` tool must not do.

## Verification

`internal/control/ask_queue_test.go`, written against the old code first so it reproduced the defect before fixing it:

- `TestAskQueuedBehindAnotherPromptIsVisibleAndAnnounced` - holds `promptMu`, asserts the queued ask is registered and announced, still not emitted, still not replayable, then appears normally once the earlier prompt clears and becomes replayable at that point
- `TestPromptQueueNoticeStaysQuietWhenNothingWaits` - an uncontended ask emits no notice
- `TestAskCancelledWhileQueuedLeavesNothingBehind` - registration dropped, lock not leaked (`TryLock` proves the next prompt can take it)
- `TestAskWithoutTimeoutBlocksUntilCancelled` - pins the unbounded default that makes this class of defect fatal rather than self-healing

The existing `TestAskSerializesBehindPromptLockEvenWithAutoApproveTools` and `TestAskSerializesBehindPromptLockEvenWithBypass` pass unchanged, which is the guard that the serialization semantics did not move.

`go test -count=1 ./internal/control/ ./internal/event/ ./internal/acp/` green; `golangci-lint run ./...` 0 issues; repolint clean. The race detector needs cgo, unavailable locally - the CI `race` job covers the new goroutine (cross-goroutine `Unlock` is explicitly permitted by the Go memory model).

`internal/cli`'s `TestClearMCPAuthenticationUsesControllerWorkspace` fails identically on `main-v2` without these changes - pre-existing, unrelated, tracked separately.

## Frontend

`prompt_queued` is added to `noticeCodeKeys` and to all three locale dictionaries, so it renders localized rather than falling back to raw English.

Cache-impact: none - this reorders host-side prompt bookkeeping and adds one notice. No prompt content, tool schema, or provider request field changes.
Cache-guard: existing - no model-visible path is touched; `go test ./internal/control/` covers the turn lifecycle around the prompt lock.
Documentation-impact: none - the user-visible contract is unchanged except that a queued question now explains itself; docs describe `ask` as blocking until answered, which still holds.
