### PR TITLE
feat(skill): add [skills].suppress_warnings to quiet third-party skill warnings

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -100,6 +100,7 @@ offline = false  # set true when outbound network access is unavailable; prevent
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
 # excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disabled_skills = ["review"]                  # hide skills until /skill enable <name>
+# suppress_warnings = true                 # quiet noisy third-party skill loading warnings (missing description)
 
 [permissions]
 mode  = "ask"                                # writer fallback when no rule matches: ask|allow|deny

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -94,6 +94,7 @@ offline = false  # 无出站网络时设为 true，避免 agent 无效重试网�
 # paths = ["~/my-skills", "../shared/skills"]   # 额外的自定义技能目录
 # excluded_paths = ["~/.agents/skills"]         # 隐藏约定来源，不删除目录
 # disabled_skills = ["review"]                  # 隐藏技能，直到 /skill enable <name>
+# suppress_warnings = true                 # 隐藏第三方 skill 加载时的噪音警告（如缺少 description）
 
 [permissions]
 mode  = "ask"                                # 无规则命中时 writer 的兜底：ask|allow|deny

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1037,6 +1037,7 @@ prefer = "auto"   # auto (default) | bash | powershell | pwsh — force the shel
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
 # excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disabled_skills = ["review"]                  # hidden from prompt, slash invocation, and skill tools
+# suppress_warnings = true                 # quiet noisy third-party skill loading warnings (missing description)
 
 [permissions]
 mode  = "ask"                              # writer fallback when no rule matches: ask|allow|deny

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -641,6 +641,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), PluginPaths: cfg.PluginPackageSkillOwners(),
 			PluginAgentPaths: cfg.PluginPackageAgentOwners(), ExcludedPaths: cfg.SkillExcludedPaths(),
 			DisabledNames: cfg.DisabledSkillNames(), MaxDepth: cfg.SkillMaxDepth(), Stderr: opts.Stderr,
+			SuppressWarnings: cfg.SkillSuppressWarnings(),
 		})
 		skillStore.ConfigureInvocationPolicy(string(runtimeProfile), nil)
 		skills = skillStore.List()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,7 +93,7 @@ type Config struct {
 func (c *Config) KeepProjectSkillKey(key string) error {
 	key = strings.TrimSpace(key)
 	switch key {
-	case "paths", "excluded_paths", "disabled_skills", "disable_implicit_invocation", "max_depth":
+	case "paths", "excluded_paths", "disabled_skills", "disable_implicit_invocation", "max_depth", "suppress_warnings":
 	default:
 		return fmt.Errorf("unknown project skill key %q", key)
 	}
@@ -1033,13 +1033,16 @@ func (c *Config) NetworkProxyMode() string {
 // hides named skills from the agent prompt, slash invocation, and skill tools
 // while keeping them manageable. DisableImplicitInvocation keeps skills
 // discoverable to the host for explicit /skill use and management, but hides
-// their index and model-facing invocation tools.
+// their index and model-facing invocation tools. SuppressWarnings quiets
+// noisy third-party skill loading warnings (missing description) without
+// changing which skills load or their index content.
 type SkillsConfig struct {
 	Paths                     []string `toml:"paths"`
 	ExcludedPaths             []string `toml:"excluded_paths"`
 	DisabledSkills            []string `toml:"disabled_skills"`
 	DisableImplicitInvocation bool     `toml:"disable_implicit_invocation"`
 	MaxDepth                  int      `toml:"max_depth"`
+	SuppressWarnings          bool     `toml:"suppress_warnings"`
 }
 
 // ImplicitSkillInvocationEnabled reports whether the model may discover and
@@ -1090,6 +1093,13 @@ func (c *Config) SkillMaxDepth() int {
 		return maxDepth
 	}
 	return c.Skills.MaxDepth
+}
+
+// SkillSuppressWarnings reports whether noisy third-party skill loading
+// warnings should be quieted at startup. The zero value keeps the historical
+// behavior for old configs.
+func (c *Config) SkillSuppressWarnings() bool {
+	return c != nil && c.Skills.SuppressWarnings
 }
 
 // DisabledSkillNames returns valid disabled skill identifiers, preserving the

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -54,3 +54,19 @@ func TestDefaultDesktopMetricsOn(t *testing.T) {
 		t.Fatal("desktop metrics explicit false = true, want false")
 	}
 }
+
+func TestDefaultSkillsSuppressWarningsOff(t *testing.T) {
+	if got := Default().Skills.SuppressWarnings; got {
+		t.Fatalf("default [skills].suppress_warnings = %v, want false", got)
+	}
+}
+
+func TestDecodeSkillsSuppressWarnings(t *testing.T) {
+	var cfg Config
+	if _, err := decodeTOMLBytes([]byte("[skills]\nsuppress_warnings = true\n"), &cfg); err != nil {
+		t.Fatalf("decode [skills].suppress_warnings: %v", err)
+	}
+	if !cfg.Skills.SuppressWarnings {
+		t.Fatal("decoded [skills].suppress_warnings = false, want true")
+	}
+}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1669,7 +1669,7 @@ func projectSkillsKeysToRemove(body string, c *Config) bool {
 	return false
 }
 
-var projectSkillKeys = [...]string{"paths", "excluded_paths", "disabled_skills", "disable_implicit_invocation", "max_depth"}
+var projectSkillKeys = [...]string{"paths", "excluded_paths", "disabled_skills", "disable_implicit_invocation", "max_depth", "suppress_warnings"}
 
 func projectSkillKeyIsDefault(c *Config, key string) bool {
 	if c != nil && c.keepsProjectSkillKey(key) {
@@ -1686,6 +1686,8 @@ func projectSkillKeyIsDefault(c *Config, key string) bool {
 		return !c.Skills.DisableImplicitInvocation
 	case "max_depth":
 		return c.Skills.MaxDepth == 0
+	case "suppress_warnings":
+		return !c.Skills.SuppressWarnings
 	default:
 		return false
 	}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -2071,6 +2071,7 @@ func TestSaveToExistingProjectRemovesResetSkillOverrides(t *testing.T) {
 		{name: "disabled skills", key: "disabled_skills", set: func(c *Config) { c.Skills.DisabledSkills = []string{"review"} }, reset: func(c *Config) { c.Skills.DisabledSkills = nil }},
 		{name: "implicit invocation", key: "disable_implicit_invocation", set: func(c *Config) { c.Skills.DisableImplicitInvocation = true }, reset: func(c *Config) { c.Skills.DisableImplicitInvocation = false }},
 		{name: "max depth", key: "max_depth", set: func(c *Config) { c.Skills.MaxDepth = 2 }, reset: func(c *Config) { c.Skills.MaxDepth = 0 }},
+		{name: "suppress warnings", key: "suppress_warnings", set: func(c *Config) { c.Skills.SuppressWarnings = true }, reset: func(c *Config) { c.Skills.SuppressWarnings = false }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2099,7 +2100,7 @@ func TestSaveToExistingProjectRemovesResetSkillOverrides(t *testing.T) {
 			if err != nil {
 				t.Fatalf("reload reset project config: %v", err)
 			}
-			if fresh.Skills.Paths != nil || fresh.Skills.ExcludedPaths != nil || fresh.Skills.DisabledSkills != nil || fresh.Skills.DisableImplicitInvocation || fresh.Skills.MaxDepth != 0 {
+			if fresh.Skills.Paths != nil || fresh.Skills.ExcludedPaths != nil || fresh.Skills.DisabledSkills != nil || fresh.Skills.DisableImplicitInvocation || fresh.Skills.MaxDepth != 0 || fresh.Skills.SuppressWarnings {
 				t.Fatalf("reloaded skills retained reset override: %+v", fresh.Skills)
 			}
 		})
@@ -2120,6 +2121,7 @@ func TestSaveToExistingProjectPreservesExplicitSkillDefaults(t *testing.T) {
 	cfg.Skills.DisabledSkills = nil
 	cfg.Skills.DisableImplicitInvocation = false
 	cfg.Skills.MaxDepth = 0
+	cfg.Skills.SuppressWarnings = false
 	for _, key := range projectSkillKeys {
 		if err := cfg.KeepProjectSkillKey(key); err != nil {
 			t.Fatalf("keep %s: %v", key, err)

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -143,6 +143,11 @@ type Options struct {
 	ExcludedPaths    []string
 	DisabledNames    []string
 	MaxDepth         int
+	// SuppressWarnings quiets noisy third-party skill loading warnings (for
+	// example the missing-description warning) without changing which skills
+	// load or their index content. On-demand diagnostics (reasonix doctor)
+	// are unaffected.
+	SuppressWarnings bool
 	DisableBuiltins  bool // suppress shipped built-ins (test-only knob)
 	// DisableDiscovery returns an empty store without probing project, custom,
 	// global, plugin, or built-in skill sources. It is a test-only isolation knob.
@@ -164,6 +169,7 @@ type Store struct {
 	excludedPaths    map[string]bool
 	disabled         map[string]bool
 	maxDepth         int
+	suppressWarnings bool
 	disableBuiltins  bool
 	disableDiscovery bool
 	stderr           io.Writer
@@ -222,6 +228,7 @@ func New(opts Options) *Store {
 		excludedPaths:    excluded,
 		disabled:         disabledNameSet(opts.DisabledNames),
 		maxDepth:         normalizeMaxDepth(opts.MaxDepth),
+		suppressWarnings: opts.SuppressWarnings,
 		disableBuiltins:  opts.DisableBuiltins,
 		disableDiscovery: opts.DisableDiscovery,
 		stderr:           stderr,
@@ -871,7 +878,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		name = v
 	}
 	desc := strings.TrimSpace(fm[skillFrontmatterDescription])
-	if desc == "" {
+	if desc == "" && !s.suppressWarnings {
 		fmt.Fprintf(s.stderr, "warning: skill %q at %s has no description: — it will load but won't appear in the skills index\n", name, path)
 	}
 	sk := Skill{

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -484,6 +484,29 @@ func TestRunAsOnlyFlatClaudeMarkdownIsSkillLike(t *testing.T) {
 	}
 }
 
+func TestSuppressWarningsQuietsMissingDescription(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".claude/skills/noisy.md", "---\nname: noisy\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+	if _, ok := find(st.List(), "noisy"); !ok {
+		t.Fatal("skill without description should still load")
+	}
+	if got := stderr.String(); !strings.Contains(got, "has no description") {
+		t.Fatalf("missing description should warn by default, got %q", got)
+	}
+
+	stderr.Reset()
+	quiet := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr, SuppressWarnings: true})
+	if _, ok := find(quiet.List(), "noisy"); !ok {
+		t.Fatal("suppression must not change which skills load")
+	}
+	if got := stderr.String(); strings.Contains(got, "has no description") {
+		t.Fatalf("suppress_warnings should quiet the missing-description warning, got %q", got)
+	}
+}
+
 func TestExcludedPathsHideConventionRoots(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/keep.md", "---\ndescription: keep\n---\nb")

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -152,6 +152,7 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disable_implicit_invocation = true             # keep /skill explicit; hide skill discovery and tools from the model
 # disabled_skills = ["review"]                  # hide from prompt, slash invocation, and skill tools
+# suppress_warnings = true                  # quiet noisy third-party skill loading warnings (missing description)
 
 # Hooks run shell commands around the loop (PreToolUse / PostToolUse /
 # PermissionRequest / UserPromptSubmit / Stop). They are NOT configured here — put them in


### PR DESCRIPTION
## Summary

Adds `[skills].suppress_warnings` (boolean, default `false`) to quiet noisy third-party skill loading warnings at startup, specifically the missing-description warning emitted by the skill loader in `internal/skill`. The default keeps current behavior unchanged, so this is backward compatible. Suppression is stderr-only: which skills load and the skill index content are untouched. On-demand diagnostics such as `reasonix doctor capabilities` are intentionally not affected, since those are explicit troubleshooting surfaces.

Implements #6483.

## Issues

Fixes #6483

## Verification

- `go test ./...` passes (full suite)
- `gofmt -l .` clean
- `go vet ./...` passes
- New tests: `TestSuppressWarningsQuietsMissingDescription` (internal/skill), `TestDefaultSkillsSuppressWarningsOff` and `TestDecodeSkillsSuppressWarnings` (internal/config), plus the `suppress_warnings` subtest in `TestSaveToExistingProjectRemovesResetSkillOverrides`.

## Documentation impact

Documentation-impact: updated - `[skills].suppress_warnings` documented in `docs/SPEC.md` (config contract), `docs/GUIDE.md`, `docs/GUIDE.zh-CN.md`, and `reasonix.example.toml`.

## Cache impact

Cache-impact: none - suppression affects stderr output only; the skill index and system prompt are unchanged.
Cache-guard: TestSuppressWarningsQuietsMissingDescription (internal/skill) covers the loader warning; existing skill index guard tests cover index behavior.
System-prompt-review: maintainer approval required for the skill-loader change - suppression is stderr-only; the skill index and system prompt are unchanged, but CI classifies internal/skill and internal/boot as system-prompt-sensitive.
