### PR TITLE
fix(memory): archive every duplicate of an ID, not just the first

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -200,7 +200,7 @@ func (s Store) archiveLocked(name string) (string, error) {
 	ref := strings.TrimSpace(name)
 	parsed := parseMemoryReference(ref)
 	if active, path, ok := s.findActive(ref); ok && ref == active.ID {
-		return archiveMemoryInDir(filepath.Dir(path), active.Name)
+		return s.archiveByID(active.Name, ref)
 	} else if ok && parsed.qualified {
 		return archiveMemoryInDir(filepath.Dir(path), active.Name)
 	} else if ok {

--- a/internal/memory/store_archive_id.go
+++ b/internal/memory/store_archive_id.go
@@ -1,0 +1,32 @@
+package memory
+
+import "path/filepath"
+
+// archiveByID archives every active copy of a fact that shares the given ID
+// across directories (migration duplicates share the deterministic ID), while
+// same-named facts with a different ID stay put. Returns the last path
+// archived. The unqualified-name path already archives from every directory.
+func (s Store) archiveByID(name, id string) (string, error) {
+	var lastPath string
+	for _, dir := range s.dirs() {
+		if dir == "" || !memoryIDInDir(dir, name, id) {
+			continue
+		}
+		p, err := archiveMemoryInDir(dir, name)
+		if err != nil {
+			return "", err
+		}
+		if p != "" {
+			lastPath = p
+		}
+	}
+	return lastPath, nil
+}
+
+// memoryIDInDir reports whether dir holds an active fact with the given ID.
+// Used to archive every migration duplicate of an ID while leaving same-named
+// facts with a different identity untouched.
+func memoryIDInDir(dir, name, id string) bool {
+	m, ok := loadMemory(filepath.Join(dir, name+".md"))
+	return ok && m.ID == id
+}

--- a/internal/memory/store_archive_id_test.go
+++ b/internal/memory/store_archive_id_test.go
@@ -1,0 +1,52 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStoreDeleteByIDRemovesFromAllDirs covers the ID-reference path of
+// Archive: an ID may name the same fact in several directories (migration
+// duplicates share the deterministic legacy ID), so deletion by ID must
+// archive from every directory — the unqualified-name path already does.
+func TestStoreDeleteByIDRemovesFromAllDirs(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	name := "prefers-tabs"
+	for _, d := range []string{s.Dir, s.GlobalDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "user pref", Type: TypeUser, Body: "use tabs"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Both copies share one identity (same name + scope → same legacy ID).
+	list := s.List()
+	if len(list) != 1 {
+		t.Fatalf("want 1 deduplicated memory, got %d", len(list))
+	}
+
+	// Delete by the identity ID, not the name.
+	if err := s.Delete(list[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{s.Dir, s.GlobalDir} {
+		if _, err := os.Stat(filepath.Join(d, name+".md")); !os.IsNotExist(err) {
+			t.Fatalf("copy in %s should be gone after ID delete", d)
+		}
+	}
+	if idx := s.Index(); idx != "" {
+		t.Fatalf("Index() should be empty after deleting all entries, got:\n%s", idx)
+	}
+}


### PR DESCRIPTION
## Summary

**现状**：`Store.Archive`（`forget` 路径）注释承诺"archives from every directory the memory appears in（处理迁移重复）"，但按 **ID** 引用时（`ref == active.ID` 分支）直接 `return archiveMemoryInDir(filepath.Dir(path), ...)`——只归档 `findActive` 找到的**第一个目录**。迁移遗留的跨目录同 ID 重复项用 ID 执行 `forget` 后，另一个副本仍会加载进下一会话，与"不再加载"的语义相悖。

**本 PR**：ID 命中时遍历所有目录，每目录先经 `memoryIDInDir`（`loadMemory` 校验 ID 匹配）过滤再归档——**同 ID 的迁移重复项全部清除**，而**同名但不同 ID 的 fact（合法的 scope 变体）保持不动**（由既有测试 `TestStoreV2ArchiveByIDOnlyArchivesMatchingIdentity` 锁定该语义）。

## Issues

（无关联 issue；整体代码审查产出，forget 语义修复）

## Verification

- 新增 `TestStoreDeleteByIDRemovesFromAllDirs`：双目录同 ID 副本（确定性 legacy ID）→ `Delete(ID)` → 修复前失败（global 副本残留），修复后两处都清除、`Index()` 为空
- 既有 6 个 Delete/Archive 测试全过（含 `TestStoreV2ArchiveByIDOnlyArchivesMatchingIdentity` 同名不同 ID 不动）
- `go test ./internal/memory/ ./internal/control/ ./internal/tool/builtin/` 全绿
- `go test ./internal/boot/ -run TestGoldenBaseline` 无漂移
- `gofmt -l` 无输出；`go vet ./internal/memory/` 通过

## Documentation impact

Documentation-impact: none - forget 按 ID 删除的边界行为修复，无命令/配置/文档变化。

## Cache impact

Cache-impact: none - 归档路径（forget 写侧）改动，不改变任何 provider 可见字节：系统提示词、记忆前缀、工具 schema、召回注入全部原样。
Cache-guard: go test ./internal/boot -run TestGoldenBaseline（前缀基线无漂移）+ 既有 memory 测试（TestStoreDelete* / TestStoreV2Archive*）。
System-prompt-review: esengine - 记忆 forget（Archive）按 ID 删除的边界语义修复，系统提示词/记忆前缀字节不变；需维护者确认后合并。