### PR TITLE
fix(agent): remove the todo-stall pause

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -645,13 +645,6 @@ func plannerResearchPauseDetail(err error) string {
 			maxPause.key,
 		)
 	}
-	var stallPause *todoStallPause
-	if errors.As(err, &stallPause) {
-		return fmt.Sprintf(
-			"planner did not finalize after %d tool-call rounds without progress",
-			stallPause.rounds,
-		)
-	}
 	return "planner did not finalize after its bounded research and finalization rounds"
 }
 

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -18,10 +18,6 @@ func PauseClass(err error) string {
 	if errors.As(err, &maxSteps) {
 		return "max_steps"
 	}
-	var stall *todoStallPause
-	if errors.As(err, &stall) {
-		return "todo_stall"
-	}
 	var stuck *goalStuckPause
 	if errors.As(err, &stuck) {
 		return "goal_stuck"
@@ -57,10 +53,6 @@ func InspectRunPause(err error) (RunPauseInfo, bool) {
 	var stuck *goalStuckPause
 	if errors.As(err, &stuck) {
 		return RunPauseInfo{Kind: "goal_stuck", Limit: stuck.limit, Key: stuck.key, HostOwned: true, Reason: stuck.reason}, true
-	}
-	var stall *todoStallPause
-	if errors.As(err, &stall) {
-		return RunPauseInfo{Kind: "todo_stall", Limit: stall.rounds, Key: "todo progress", HostOwned: true, Reason: "the current todo made no host-observed progress"}, true
 	}
 	var budget *taskBudgetPause
 	if errors.As(err, &budget) {

--- a/internal/agent/errors_test.go
+++ b/internal/agent/errors_test.go
@@ -20,7 +20,6 @@ func TestPauseClassNamesEachGuard(t *testing.T) {
 		want string
 	}{
 		{&maxStepsPause{steps: 40, key: "max_steps"}, "max_steps"},
-		{&todoStallPause{rounds: 12}, "todo_stall"},
 		{&FinalReadinessError{Attempts: 3}, "final_readiness"},
 		{&RecoveryPauseError{Message: "paused"}, "recovery_paused"},
 		{fmt.Errorf("wrapped: %w", &maxStepsPause{steps: 5}), "max_steps"},

--- a/internal/agent/goal_run_boundary.go
+++ b/internal/agent/goal_run_boundary.go
@@ -33,21 +33,11 @@ func (e *goalStuckPause) Error() string {
 	return "goal paused after a structural no-progress loop: " + e.reason
 }
 
-type todoStallPause struct {
-	rounds int
-}
-
-func (e *todoStallPause) Error() string {
-	return fmt.Sprintf("paused after %d tool-call rounds without advancing the current todo — the work so far is saved; inspect the blocker or send another message to continue", e.rounds)
-}
-
 func isToolLoopPause(err error) bool {
 	var maxPause *maxStepsPause
-	var stallPause *todoStallPause
 	var stuckPause *goalStuckPause
 	var budgetPause *taskBudgetPause
-	return errors.As(err, &maxPause) || errors.As(err, &stallPause) ||
-		errors.As(err, &stuckPause) || errors.As(err, &budgetPause)
+	return errors.As(err, &maxPause) || errors.As(err, &stuckPause) || errors.As(err, &budgetPause)
 }
 
 // HostProgressSignatures exposes successful evidence identities to the Goal FSM.
@@ -100,9 +90,14 @@ func (a *Agent) stopUnexecutedBoundaryCalls(state *runLoopState, calls []provide
 	}
 }
 
-func (a *Agent) trackTodoProgress(state *runLoopState, receiptMark int) error {
+// trackTodoProgress advances the stall streak and asks the model to reassess
+// once, at the checkpoint. It never ends a run: the zero-evidence ladder and
+// the storm breaker already own that decision on the same receipts, and they
+// reach it far earlier, so a second stop keyed to a todo only added a way for
+// the host to end a turn the user never asked it to end.
+func (a *Agent) trackTodoProgress(state *runLoopState, receiptMark int) {
 	if a.planMode.Load() {
-		return nil
+		return
 	}
 	nextProgress, nextTracking := a.canonicalTodoProgress()
 	hostProgress := false
@@ -126,12 +121,6 @@ func (a *Agent) trackTodoProgress(state *runLoopState, receiptMark int) error {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
 			Text: loopGuardNoticeText(), Detail: fmt.Sprintf("the current todo has no new completion, unique read, command, or mutation for %d consecutive tool-call rounds; asking the assistant to reassess", state.todoStallRounds)})
 	}
-	if state.todoStallRounds < maxTodoStallRounds {
-		return nil
-	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
-		Text: "Task progress stalled; pausing before more tools are called.", Detail: fmt.Sprintf("the current todo has no new completion, unique read, command, or mutation for %d consecutive tool-call rounds after a host reassessment; work is saved and can be resumed", state.todoStallRounds)})
-	return &todoStallPause{rounds: state.todoStallRounds}
 }
 
 func (a *Agent) armGoalStuckFinalization(state *runLoopState, stuck goalStuckSignal) bool {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -640,9 +640,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 		nudge := fmt.Sprintf("The following tools are unavailable in the current workflow phase: %s. Do not call them again. Respond to the user's request with visible answer text now; call a different tool only if it is still needed to complete the request.", strings.Join(unavailableContextTools, ", "))
 		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 	}
-	if err := a.trackTodoProgress(state, receiptMark); err != nil {
-		return false, err
-	}
+	a.trackTodoProgress(state, receiptMark)
 	if a.armGoalStuckFinalization(state, batch.goalStuck) {
 		return true, nil
 	}

--- a/internal/agent/storm_breaker.go
+++ b/internal/agent/storm_breaker.go
@@ -26,9 +26,6 @@ const (
 	// todoProgressNudgeRounds is the first adaptive checkpoint. The host asks
 	// the model to reassess, but keeps the turn alive so it can recover.
 	todoProgressNudgeRounds = 8
-	// maxTodoStallRounds pauses only after the reassessment also failed to
-	// produce a new completion or unique host-observed work receipt.
-	maxTodoStallRounds = 16
 )
 
 func todoProgressNudgeMessage(rounds int) string {

--- a/internal/agent/todo_progress_guard_test.go
+++ b/internal/agent/todo_progress_guard_test.go
@@ -15,34 +15,66 @@ import (
 	_ "reasonix/internal/tool/builtin"
 )
 
-func TestTodoProgressGuardPausesSemanticToolDrift(t *testing.T) {
+// stalledTodoTurns drives a todo that never advances: the first unique read
+// renews the lease, exact repeats after it do not.
+func stalledTodoTurns(extra int) []testutil.Turn {
 	turns := []testutil.Turn{{ToolCalls: []provider.ToolCall{{
 		ID: "todo", Name: "todo_write",
 		Arguments: `{"todos":[{"content":"finish the task","status":"in_progress"}]}`,
 	}}}}
-	// The first unique read renews the lease; exact repeats after it do not.
-	for i := range maxTodoStallRounds + 1 {
+	for i := range todoProgressNudgeRounds*2 + extra {
 		turns = append(turns, testutil.Turn{ToolCalls: []provider.ToolCall{{
 			ID: fmt.Sprintf("read-%d", i), Name: "inspect", Arguments: `{"path":"same"}`,
 		}}})
 	}
+	return turns
+}
 
+func stalledTodoAgent(t *testing.T, turns []testutil.Turn) (*Agent, *testutil.MockProvider) {
+	t.Helper()
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "inspect", readOnly: true})
 	reg.Add(mustBuiltinTool(t, "todo_write"))
 	mp := testutil.NewMock("m", turns...)
-	a := New(mp, reg, NewSession(""), Options{}, event.Discard)
+	return New(mp, reg, NewSession(""), Options{}, event.Discard), mp
+}
 
-	err := a.Run(context.Background(), "work until the todo is complete")
-	var pause *todoStallPause
-	if !errors.As(err, &pause) {
-		t.Fatalf("Run error = %v, want todoStallPause", err)
-	}
-	if mp.CallCount() != maxTodoStallRounds+2 {
-		t.Fatalf("provider calls = %d, want %d", mp.CallCount(), maxTodoStallRounds+2)
-	}
-	if !sessionContains(a, "Host progress check") {
-		t.Fatal("semantic drift did not receive the adaptive progress nudge")
+// A stalled todo never ends a run, under Goal or ordinary chat. The model is
+// asked to reassess once; what it does after that is its own call, and the
+// zero-evidence ladder already owns the structural stop on the same receipts.
+func TestTodoProgressGuardNeverPausesARun(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func() context.Context
+	}{
+		{"chat", context.Background},
+		{"goal", func() context.Context {
+			return WithDeliveryExecutionScope(context.Background(), DeliveryExecutionScope{ID: "goal-1"})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			turns := append(stalledTodoTurns(4), testutil.Turn{Text: "Done."})
+			a, mp := stalledTodoAgent(t, turns)
+
+			err := a.Run(tc.ctx(), "work until the todo is complete")
+			if err != nil && !isToolLoopPause(err) {
+				t.Fatalf("Run error = %v", err)
+			}
+			if err != nil {
+				// Goal's structural guard may stop first on its own terms; what
+				// must not exist is a stop keyed to the todo streak.
+				if got := PauseClass(err); got == "todo_stall" {
+					t.Fatalf("pause class = %q, want the todo stall pause gone", got)
+				}
+				return
+			}
+			if got, want := mp.CallCount(), len(turns); got != want {
+				t.Fatalf("provider calls = %d, want all %d turns to run past the old threshold", got, want)
+			}
+			if !sessionContains(a, "Host progress check") {
+				t.Fatal("the reassessment nudge went missing; only the pause was meant to go")
+			}
+		})
 	}
 }
 

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -520,9 +520,6 @@ func goalPauseFromRunError(err error) (cause, reason string, ok bool) {
 			reason = "host-detected structural no-progress loop"
 		}
 		return stopCauseGoalStuck, reason, true
-	case info.Kind == "todo_stall" && info.HostOwned:
-		return stopCauseGoalStuck,
-			fmt.Sprintf("current todo stalled for %d model rounds without host-observed progress", info.Limit), true
 	default:
 		return "", "", false
 	}


### PR DESCRIPTION
The last remaining way for the host to end a turn the user never asked it to end.

## What it was

A stalled todo could end a run: 8 rounds without a new completion, read, command or mutation got a reassessment nudge, 16 got a resumable pause. **The pause goes; the nudge stays.**

## It was not the mechanism that caught what it claimed

The zero-evidence ladder escalates on the same receipts and reaches its stop at **6**; the storm breaker reaches its own at **3**. The todo streak reached 16.

Writing the Goal test for this proved it outright: under Goal the run never got to 16 at all, because the ladder's structural pause fired first every time. So this was **dead code under Goal**, and in ordinary chat it was the only host-owned stop left after #8320 and #8340.

What it measured was also narrower than it reads. Any *first-time* successful read, command or mutation renews the streak - `progressReceiptSignature` counts reads, and folds the output digest into the signature, so even re-reading a file whose contents changed renews it. Sixteen rounds without renewal means sixteen rounds producing literally nothing new: exactly the state the two guards above already handle, twice over and far sooner.

## What is removed

- `todoStallPause` and `maxTodoStallRounds`
- the `todo_stall` pause class and its `RunPauseInfo` mapping
- the planner's non-finalization message for it
- the Goal FSM's stop cause branch

`trackTodoProgress` no longer returns an error at all - it advances the streak and nudges once.

## Verification

- `TestTodoProgressGuardNeverPausesARun` runs the identical stall under **both** ordinary chat and a Goal delivery scope, and asserts no run ends with a `todo_stall` pause in either. The chat case additionally asserts every scripted turn runs past the old threshold and that the reassessment nudge survived.
- `TestTodoProgressGuardRenewsOnUniqueHostWork` unchanged - the renewal rule is untouched.
- `TestPauseClassNamesEachGuard` updated: `todo_stall` is no longer a class.

`go test -count=1 ./internal/agent/ ./internal/control/ ./internal/boot/` green; `golangci-lint run ./...` 0 issues; repolint clean with no baseline change (net removal).

## Where this leaves the host

After #8320, #8340 and this, an ordinary chat turn has no host-owned stop of any kind. What remains is advisory (the zero-evidence ladder, the storm breaker, the exploration decay), user-invoked (`--max-steps`, the opt-in spend gate), or Goal's own bounded-autonomy contract.

Cache-impact: none - removes a host-side stop and its bookkeeping. No prompt, tool schema, or provider request field changes; the reassessment nudge is unchanged in wording and trigger.
Cache-guard: existing - `go test ./internal/agent/` covers the cache-hit e2e suites, green unchanged.
Documentation-impact: none - the pause was never documented as a user-facing limit; `docs/GUIDE.md` describes the guards that remain, which are unchanged.
