### PR TITLE
feat(cli): print a resume hint when the interactive session exits

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1341,7 +1341,7 @@ func chatREPL(args []string, version string) int {
 		leases.Release()
 		return runWebCommand(webHandoffArgs(launchWebPath, launchWebSessionID, launchWebModelRef, launchWebProfile))
 	}
-	return 0
+	return exitWithResumeHint(final, ctrl)
 }
 
 // adoptCarriedHistoryPreservingProfileAndGrants resumes c on the carried

--- a/internal/cli/resume_exit_hint.go
+++ b/internal/cli/resume_exit_hint.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/i18n"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// exitWithResumeHint prints a tip for resuming the just-closed conversation
+// and returns the normal exit code. Error and Web-handoff paths return before
+// reaching it.
+func exitWithResumeHint(final tea.Model, ctrl control.SessionAPI) int {
+	if hint := resumeExitHint(activeSessionPath(final, ctrl)); hint != "" {
+		fmt.Println(hint)
+	}
+	return 0
+}
+
+// activeSessionPath returns the final session path after the TUI exits; a
+// /model switch retires the launch controller, so its path wins.
+func activeSessionPath(final tea.Model, ctrl control.SessionAPI) string {
+	if fm, ok := final.(chatTUI); ok && fm.ctrl != nil {
+		return fm.ctrl.SessionPath()
+	}
+	return ctrl.SessionPath()
+}
+
+// resumeExitHint returns a one-line tip for resuming the just-closed
+// conversation, or "" when there is no session to resume.
+func resumeExitHint(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return fmt.Sprintf(i18n.M.ResumeExitHintFmt, agent.BranchID(sessionPath))
+}

--- a/internal/cli/resume_exit_hint_test.go
+++ b/internal/cli/resume_exit_hint_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/i18n"
+)
+
+func TestResumeExitHintEmpty(t *testing.T) {
+	if got := resumeExitHint(""); got != "" {
+		t.Fatalf("resumeExitHint(\"\") = %q, want empty", got)
+	}
+}
+
+func TestResumeExitHintFormatsSessionID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "20260718-101530.123456789-deepseek-v3.jsonl")
+	id := agent.BranchID(path)
+	got := resumeExitHint(path)
+	if want := fmt.Sprintf(i18n.M.ResumeExitHintFmt, id); got != want {
+		t.Fatalf("resumeExitHint(%q) = %q, want %q", path, got, want)
+	}
+	if !strings.Contains(got, "reasonix --resume "+id) {
+		t.Fatalf("resumeExitHint(%q) = %q, missing resume command with session id", path, got)
+	}
+}
+
+func TestActiveSessionPathPrefersFinalController(t *testing.T) {
+	launch := control.New(control.Options{SessionDir: t.TempDir()})
+	t.Cleanup(launch.Close)
+	active := control.New(control.Options{SessionDir: t.TempDir()})
+	t.Cleanup(active.Close)
+	launch.EnsureSessionPath()
+	active.EnsureSessionPath()
+
+	if got := activeSessionPath(chatTUI{ctrl: active}, launch); got != active.SessionPath() {
+		t.Fatalf("activeSessionPath with active final ctrl = %q, want %q", got, active.SessionPath())
+	}
+	if got := activeSessionPath(chatTUI{ctrl: nil}, launch); got != launch.SessionPath() {
+		t.Fatalf("activeSessionPath with nil final ctrl = %q, want %q", got, launch.SessionPath())
+	}
+	if got := activeSessionPath(nil, launch); got != launch.SessionPath() {
+		t.Fatalf("activeSessionPath with non-chatTUI final = %q, want %q", got, launch.SessionPath())
+	}
+}
+
+func TestExitWithResumeHintPrintsActiveSession(t *testing.T) {
+	launch := control.New(control.Options{SessionDir: t.TempDir()})
+	t.Cleanup(launch.Close)
+	active := control.New(control.Options{SessionDir: t.TempDir()})
+	t.Cleanup(active.Close)
+	launch.EnsureSessionPath()
+	active.EnsureSessionPath()
+	want := fmt.Sprintf(i18n.M.ResumeExitHintFmt, agent.BranchID(active.SessionPath()))
+
+	out := captureStdout(t, func() {
+		if code := exitWithResumeHint(chatTUI{ctrl: active}, launch); code != 0 {
+			t.Fatalf("exitWithResumeHint = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(out, want) {
+		t.Fatalf("exitWithResumeHint printed %q, want it to contain %q", out, want)
+	}
+}
+
+func TestExitWithResumeHintSilentWithoutSession(t *testing.T) {
+	ctrl := control.New(control.Options{SessionDir: t.TempDir()})
+	t.Cleanup(ctrl.Close)
+
+	out := captureStdout(t, func() {
+		if code := exitWithResumeHint(nil, ctrl); code != 0 {
+			t.Fatalf("exitWithResumeHint = %d, want 0", code)
+		}
+	})
+	if out != "" {
+		t.Fatalf("exitWithResumeHint printed %q for an empty session path, want nothing", out)
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -45,6 +45,7 @@ type Messages struct {
 	NoSessionToResume string // shown when --continue / --resume finds nothing
 	ResumeRequiresTTY string // shown when --resume runs piped instead of on a terminal
 	PickSessionLabel  string // header on the --resume picker
+	ResumeExitHintFmt string // shown when the chat exits — %s = session id to resume
 
 	// in-chat /resume command
 	ResumeBusy          string // shown when /resume is used mid-turn

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -29,6 +29,7 @@ var English = Messages{
 	NoSessionToResume: "no saved session to resume — start a new one with `reasonix`",
 	ResumeRequiresTTY: "--resume needs an interactive terminal; pass --continue for the most recent session",
 	PickSessionLabel:  "Resume which session?",
+	ResumeExitHintFmt: "Tip: resume this conversation later with `reasonix --resume %s`, or `reasonix --continue` for the latest.",
 
 	ResumeBusy:          "finish or cancel the current turn before resuming",
 	ResumeBadIndexFmt:   "pick a session 1–%d (run /resume to list)",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -30,6 +30,7 @@ var Chinese = Messages{
 	NoSessionToResume: "没有可恢复的会话 — 用 `reasonix` 开一个新的",
 	ResumeRequiresTTY: "--resume 需要交互式终端；用 --continue 直接恢复最近一次",
 	PickSessionLabel:  "恢复哪个会话？",
+	ResumeExitHintFmt: "提示：以后可用 `reasonix --resume %s` 恢复本次对话，或用 `reasonix --continue` 恢复最近一次。",
 
 	ResumeBusy:          "请先完成或取消当前这一轮再恢复会话",
 	ResumeBadIndexFmt:   "请选择 1–%d 的会话（用 /resume 查看列表）",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -30,6 +30,7 @@ var ChineseTraditional = Messages{
 	NoSessionToResume: "沒有可恢復的會話 — 用 `reasonix` 開一個新的",
 	ResumeRequiresTTY: "--resume 需要互動式終端；用 --continue 直接恢復最近一次",
 	PickSessionLabel:  "恢復哪個會話？",
+	ResumeExitHintFmt: "提示：之後可用 `reasonix --resume %s` 恢復本次對話，或用 `reasonix --continue` 恢復最近一次。",
 
 	ResumeBusy:             "請先完成或取消當前這一輪再恢復會話",
 	ResumeBadIndexFmt:      "請選擇 1–%d 的會話（用 /resume 檢視列表）",


### PR DESCRIPTION
## Summary

CLI 会话正常退出时打印一行恢复提示(resume hint),便于用 `reasonix --resume <id>` 或 `reasonix --continue` 重新拾起对话。(en/zh/zh_tw)本地化;错误退出与 Web handoff 路径保持静默;/model 切换后提示指向最终活跃 session

##  Issue
N/A

## Verification

- gofmt / go vet ./... / make lint(golangci-lint 0 issues + repolint clean + wails pin) pass。
- i18n catalog (`TestCatalogsComplete` / `TestCatalogsAgreeOnPlaceholders` / `TestCatalogsAgreeOnCodeTokens`) pass
- 手动测试:退出打印提示、`--resume <id>` 恢复成功

## Documentation impact

Documentation-impact: none - 新增退出提示不改变既有命令语义,docs/ 未描述退出行为,无需更新。

## Cache impact

Cache-impact:  改动限于 internal/cli/ 与 internal/i18n/,provider-visible 系统提示前缀字节不变,无 cache 影响。
Cache-guard:  无 cache 敏感路径(internal/tool/、internal/provider/、internal/boot/ 等)变更;现有前缀稳定性守护测试未受影响。
System-prompt-review: N/A 未触及 internal/config、internal/memory、internal/outputstyle、internal/skill、internal/boot 等系统提示相关代码。


