### PR TITLE
fix(goal): drop the per-Run round ceiling

### DIFF
--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -44,9 +44,9 @@ const (
 // auto-resuming old token-limit pauses.
 const (
 	stopCauseBudgetTurns   = "budget_turns"
-	stopCauseBudgetTokens  = "budget_tokens" // legacy; never written by current runtime
-	stopCauseNoProgress    = "no_progress"   // legacy; never written by current runtime
-	stopCauseGoalRunBudget = "goal_run_budget"
+	stopCauseBudgetTokens  = "budget_tokens"   // legacy; never written by current runtime
+	stopCauseNoProgress    = "no_progress"     // legacy; never written by current runtime
+	stopCauseGoalRunBudget = "goal_run_budget" // legacy; the per-Run round ceiling is gone
 	stopCauseGoalStuck     = "goal_stuck"
 	stopCauseEvaluator     = "evaluator_unavailable"
 	stopCauseLegacyArchive = "legacy_archive"

--- a/internal/control/goal_run_ceiling_test.go
+++ b/internal/control/goal_run_ceiling_test.go
@@ -1,0 +1,77 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// workingGoalTool is a writer, so every round counts as acting on the
+// investigation rather than only looking at it.
+type workingGoalTool struct{ name string }
+
+func (t workingGoalTool) Name() string      { return t.name }
+func (workingGoalTool) Description() string { return "apply an edit" }
+func (workingGoalTool) ReadOnly() bool      { return false }
+func (workingGoalTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)
+}
+func (workingGoalTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "applied", nil
+}
+
+// steadyWorkProvider makes real progress every round: a distinct mutation, so
+// neither the zero-evidence ladder nor the exploration decay ever escalates.
+type steadyWorkProvider struct {
+	calls atomic.Int32
+	max   int32
+}
+
+func (p *steadyWorkProvider) Name() string { return "steady-work" }
+
+func (p *steadyWorkProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	round := p.calls.Add(1)
+	ch := make(chan provider.Chunk, 4)
+	if round > p.max {
+		ch <- provider.Chunk{Type: provider.ChunkText, Text: "All done."}
+		ch <- provider.Chunk{Type: provider.ChunkDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{
+		ID:        fmt.Sprintf("edit-%d", round),
+		Name:      "apply_edit",
+		Arguments: fmt.Sprintf(`{"path":"pkg%d/file.go"}`, round),
+	}}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+// A Goal turn used to be cut at 16 model rounds. Rounds were the wrong unit
+// there for the same reason they were wrong for chat: a turn that reaches a
+// high count while still producing new work is the case least worth
+// interrupting. Goal now ends on its own terms — completion, a block, or a
+// structural no-progress loop — none of which is a round count.
+func TestGoalTurnRunsPastTheOldRoundCeiling(t *testing.T) {
+	prov := &steadyWorkProvider{max: 24}
+	reg := tool.NewRegistry()
+	reg.Add(workingGoalTool{name: "apply_edit"})
+	exec := agent.New(prov, reg, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	c, done := newChatBudgetController(t, exec)
+
+	c.SetGoal("apply every pending edit")
+	c.Submit("start")
+	waitForDone(t, done)
+
+	if got := prov.calls.Load(); got <= 16 {
+		t.Fatalf("provider rounds = %d, want productive work to run past the retired 16-round ceiling", got)
+	}
+}

--- a/internal/control/run_ceiling.go
+++ b/internal/control/run_ceiling.go
@@ -3,21 +3,19 @@ package control
 import (
 	"context"
 
-	"reasonix/internal/agent"
 	"reasonix/internal/tool"
 )
 
-// bindTurnScope binds a turn's boundaries: the Goal run ceiling and the usage
-// recorder whose span stays active until the FSM commits. Ordinary chat gets no
-// round ceiling — rounds carry no information agent.TaskBudget's axes lack, and
-// a turn that reaches a high count without crossing them is one whose rounds
-// are cheap and fast. An explicit max_steps still owns either turn.
+// bindTurnScope binds a Goal turn's usage recorder, whose span stays active
+// until the FSM commits. Neither chat nor Goal gets a round ceiling: rounds
+// carry no information the spend axes lack, and a turn that reaches a high
+// count without crossing them is one whose rounds are cheap and fast. An
+// explicit max_steps still owns either turn.
 func (c *Controller) bindTurnScope(ctx context.Context, continuation *goalContinuationSnapshot) context.Context {
 	goalScopeID, goalScoped := c.goals.goalScopeIDForTurn(continuation)
 	if !goalScoped {
 		return ctx
 	}
-	ctx = agent.WithDefaultRunStepLimit(ctx, goalRunRoundLimit, goalRunRoundKey)
 	recorder := c.goals.newTurnRecorder(goalScopeID, c.goals.continuationToken())
 	c.goalUsageTee.setActiveRecorder(recorder)
 	return tool.WithGoalTurnRecorder(ctx, recorder)

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -23,11 +23,6 @@ type turnOrchestrator struct {
 	c *Controller
 }
 
-const (
-	goalRunRoundLimit = 16
-	goalRunRoundKey   = "goal model rounds"
-)
-
 type orchestratedTurn struct {
 	input            string
 	raw              string
@@ -99,7 +94,6 @@ func (o *turnOrchestrator) runSubagentSkillTurnsGoalLoop(ctx context.Context, sk
 	// call update_goal itself.
 	if scopeID, goal, ok := o.c.goals.deliveryScope(); ok {
 		ctx = agent.WithDeliveryExecutionScope(ctx, agent.DeliveryExecutionScope{ID: scopeID, TaskText: goal})
-		ctx = agent.WithDefaultRunStepLimit(ctx, goalRunRoundLimit, goalRunRoundKey)
 		recorder := o.c.goals.newTurnRecorder(scopeID, o.c.goals.continuationToken())
 		o.c.goalUsageTee.setActiveRecorder(recorder)
 	}
@@ -511,9 +505,6 @@ func goalPauseFromRunError(err error) (cause, reason string, ok bool) {
 		return "", "", false
 	}
 	switch {
-	case info.Kind == "max_steps" && info.HostOwned && info.Key == goalRunRoundKey:
-		return stopCauseGoalRunBudget,
-			fmt.Sprintf("Goal run budget exhausted (%d model rounds); completed work is saved", info.Limit), true
 	case info.Kind == "goal_stuck" && info.HostOwned:
 		reason := strings.TrimSpace(info.Reason)
 		if reason == "" {


### PR DESCRIPTION
Step 1 of unifying Goal's boundaries with the rest of the runtime. Same argument as #8320, applied where it was still true.

## What changes

A Goal turn was cut at 16 model rounds. That ceiling is gone.

Rounds were the wrong unit there for exactly the reason they were wrong for chat: a turn that reaches a high count *while still producing new work* is the case least worth interrupting, and a turn that produces nothing is caught by something that actually measures that.

## Writing the test proved the second half

My first version of the test drove a wandering Goal turn and asserted it ran past 16. It stopped at **round 13** — with no ceiling present at all:

1. `explorationRunLimit` stops crediting look-only rounds after 6 (#8233)
2. the zero-evidence ladder escalates to its stop 6 rounds later
3. the Goal structural guard ends the run

So the 16-round ceiling was never what caught a stalled Goal. The stall detector got there first, every time. The ceiling only ever cut *productive* turns short — which is what the shipped test now pins, using a provider that makes a distinct mutation every round.

## What Goal keeps

Every boundary that reads what a turn is doing rather than counting it:

- completion (report or evaluator)
- a blocked report
- a failed or uncertain evaluator (fail-closed)
- the structural no-progress loop
- the cross-Run turn budget — 10/20/40 by guessed task class, which the next change takes up

`stopCauseGoalRunBudget` stays as a legacy constant so an old sidecar still resumes; nothing writes it any more.

## Verification

- `TestGoalTurnRunsPastTheOldRoundCeiling` — a Goal turn making real progress runs 24 rounds untruncated, which the ceiling would have cut at 16
- `go test -count=1 ./internal/control/ ./internal/agent/` green
- `golangci-lint run ./...` 0 issues; repolint clean, no baseline change (net removal)

Cache-impact: none - removes a context value from Goal turn setup. No prompt, tool schema, or provider request field changes.
Cache-guard: existing - `go test ./internal/agent/` covers the cache-hit e2e suites, green unchanged.
Documentation-impact: none - the 16-round Run ceiling was internal; `docs/GUIDE.md` documents Goal's turn budget and stop causes, which this does not change.
