### PR TITLE
fix(config): stop per-provider effort from breaking DeepSeek family canonicalization

### DIFF
--- a/internal/config/effort_persist_repro_test.go
+++ b/internal/config/effort_persist_repro_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression for #8337: a per-provider effort selection written by /effort or
+// the desktop must not make the DeepSeek family non-canonicalizable on the
+// next load. Before the fix, the canonical member carrying effort="max" next
+// to legacy family members with empty effort failed the family-equality check,
+// so canonicalization was bypassed and the stored level was unreachable
+// (the model came back as Auto).
+func TestDeepSeekEffortDoesNotBreakFamilyCanonicalization(t *testing.T) {
+	body := `config_version = 5
+default_model = "deepseek/deepseek-v4-flash"
+
+[[providers]]
+name = "deepseek"
+kind = "anthropic"
+base_url = "https://api.deepseek.com/anthropic"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+effort = "max"
+
+[[providers]]
+name = "deepseek-flash"
+kind = "anthropic"
+base_url = "https://api.deepseek.com/anthropic"
+api_key_env = "DEEPSEEK_API_KEY"
+`
+	path := filepath.Join(t.TempDir(), "reasonix.toml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := LoadForEdit(path)
+	if !canCanonicalizeLegacyDeepSeekProviders(c) {
+		t.Fatal("a per-provider effort selection on the canonical member must not make the DeepSeek family non-canonicalizable")
+	}
+	p, ok := c.Provider("deepseek")
+	if !ok {
+		t.Fatal("canonical deepseek provider missing")
+	}
+	if got := p.Effort; got != "max" {
+		t.Fatalf("stored effort = %q, want max", got)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2192,8 +2192,13 @@ func legacyDeepSeekProviderWideProjection(entry *ProviderEntry) ProviderEntry {
 	out.BalanceURL = normalizedDeepSeekBalanceURL(out.BalanceURL)
 	out.ResponsesMode = strings.TrimSpace(out.ResponsesMode)
 	out.Thinking = strings.TrimSpace(out.Thinking)
-	out.Effort = strings.TrimSpace(out.Effort)
 	out.VisionDetail = strings.TrimSpace(out.VisionDetail)
+
+	// Effort is a per-provider selection, not a family contract: /effort
+	// writes the level to the resolved (possibly retargeted) canonical member,
+	// so comparing it here would flip the family non-canonicalizable after the
+	// first write and strand the stored level on the next restart (#8337).
+	out.Effort = ""
 
 	// These fields can be represented independently for every model in the
 	// canonical provider. They are compared by legacyDeepSeekModelFieldsCompatible.


### PR DESCRIPTION
## Summary

Fixes a config canonicalization bug behind #8337: after `/effort` or the desktop writes a per-provider effort selection (e.g. `effort = "max"`), the next load could flip the DeepSeek family non-canonicalizable. The family-equality comparison included `Effort`, which is a per-selection setting written to the resolved canonical member, not a family contract. When the canonical member carried the effort next to legacy family members with empty effort, the equality check failed, canonicalization was bypassed, and the stored level became unreachable (the model came back as Auto on restart).

The fix excludes `Effort` from the family-wide projection used for the equality check. Stored effort values are unaffected; this only stops the per-selection field from participating in a family-contract comparison.

## Issues

Fixes #8337

## Verification

- `go test ./...` passes
- `gofmt -l .` clean
- `go vet ./...` passes
- New regression test: `TestDeepSeekEffortDoesNotBreakFamilyCanonicalization` (internal/config). Verified to fail without the fix and pass with it.

## Documentation impact

Documentation-impact: none - config behavior contract unchanged; this is a bug fix.

## Cache impact

Cache-impact: none - config canonicalization only; provider-visible system prompt unchanged.
Cache-guard: TestDeepSeekEffortDoesNotBreakFamilyCanonicalization (internal/config).
System-prompt-review: none - no system-prompt-sensitive path touched (internal/config/load.go only).
