### PR TITLE
fix(skill): stop registering plugin documentation markdown as skills

### DIFF
--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -7,9 +7,9 @@
 // demand. Discovery scans several conventions (.reasonix / .agents / .agent /
 // .claude under the project root and the home dir — see config.ConventionDirs) so
 // skills authored for other agent tools migrate in unchanged. Directory skills
-// use <name>/SKILL.md; flat <name>.md files from Claude roots are loaded only
-// when they carry skill frontmatter. Discovery follows symlinks, so linked
-// skills are picked up like real ones.
+// use <name>/SKILL.md; flat <name>.md files from Claude and plugin-package
+// roots are loaded only when they carry skill frontmatter. Discovery follows
+// symlinks, so linked skills are picked up like real ones.
 package skill
 
 import (
@@ -487,7 +487,7 @@ func (s *Store) roots() []discoveryRoot {
 		key := config.CanonicalSkillPath(d.dir)
 		out = append(out, discoveryRoot{
 			Root:              Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)},
-			requireFlatMarker: d.requireFlatMarker,
+			requireFlatMarker: d.requireFlatMarker || len(s.pluginPaths[key]) > 0 || len(s.pluginAgentPaths[key]) > 0,
 			plugins:           append([]string(nil), s.pluginPaths[key]...),
 			forceSubagent:     len(s.pluginAgentPaths[key]) > 0,
 		})

--- a/internal/skill/skill_extra_test.go
+++ b/internal/skill/skill_extra_test.go
@@ -1,13 +1,49 @@
 package skill
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"reasonix/internal/config"
 )
 
 // IsValidName
+
+func TestPluginSkillRootIgnoresDocumentationMarkdown(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := filepath.Join(t.TempDir(), "skills")
+	writeSkill(t, pluginRoot, "plan/SKILL.md", "---\ndescription: plan work\n---\nbody")
+	writeSkill(t, pluginRoot, "guide.md", "# Plugin documentation, not a skill.")
+	writeSkill(t, pluginRoot, "notes.md", "---\ntitle: Notes\n---\n# Notes")
+
+	var stderr bytes.Buffer
+	st := New(Options{
+		HomeDir:         home,
+		CustomPaths:     []string{pluginRoot},
+		PluginPaths:     map[string][]string{config.CanonicalSkillPath(pluginRoot): {"superpowers"}},
+		DisableBuiltins: true,
+		Stderr:          &stderr,
+	})
+	list := st.List()
+	if _, ok := find(list, "plan"); !ok {
+		t.Fatal("real plugin directory skill should be discovered")
+	}
+	for _, name := range []string{"guide", "notes"} {
+		if _, ok := find(list, name); ok {
+			t.Errorf("plugin documentation markdown %q should not be registered as a skill", name)
+		}
+	}
+	slash := st.SlashList()
+	if len(slash) != 1 || slash[0].SlashName() != "superpowers:plan" {
+		t.Fatalf("slash skills = %+v, want only superpowers:plan", slash)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("documentation markdown should not warn during List, got %q", got)
+	}
+}
 
 func TestIsValidName(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

Plugin skill roots were scanned with the permissive custom-root mode where any flat .md file becomes a skill. Plugin packages ship documentation markdown next to their `<name>/SKILL.md` skills, so those docs registered as empty skill shells and inflated the model-visible index (20-some real skills became 70+ entries).

The fix treats plugin-package-owned roots like Claude convention roots: flat .md files must carry skill frontmatter before they are registered. Directory skills, built-ins, and single-.md skills in plain custom roots are unaffected.

## Issues

Fixes #8316

## Verification

- `go test ./...` passes
- `gofmt -l .` clean
- `go vet ./...` passes
- New regression test: `TestPluginSkillRootIgnoresDocumentationMarkdown` (internal/skill) asserts a plugin root registers only the real skill, holds one slash entry, and emits no warnings. It fails without the fix.

## Documentation impact

Documentation-impact: none - no docs/*.md edited; behavior is a bug fix, not a contract change.

## Cache impact

Cache-impact: low - provider-visible skills index is byte-identical for users without plugin doc files; for affected plugin users the spurious empty entries disappear once (one-time shrink, then stable).
Cache-guard: TestPluginSkillRootIgnoresDocumentationMarkdown (asserts doc .md is not registered and the slash index holds only the real skill); TestPluginSkillsUseQualifiedSlashNamesWithoutChangingModelIndex still guards index stability for real plugin skills.
System-prompt-review: SivanCola - authored the plugin skill/Claude plugin compatibility work (cfe2b80c, 43993f5a); skill index behavior change verified by the reproduction test.
