### PR TITLE
feat(goal): replace the guessed turn quota with an opt-in token budget

### DIFF
--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -10,7 +10,7 @@ Reasonix 的 Goal 模式（`/goal`）将目标推进（Goal）、验收（Delive
 | 完成校验 | 默认 | `complete` 声明必须通过 Delivery readiness（todos、验证、review、签收、能力门禁）才会真正完成；不满足时用缺失项开启下一轮 |
 | 完成自述与对账 | `update_goal` 的 `completion` | `complete` 可附带自述：`verified` 命令逐条与本会话真实 receipt 对账，没跑过 / 跑失败 / 早于最后一次改动都记为 unbacked claim；`unverified` 与 `risks` 是宿主推断不出的声明，只增不减，永远不阻塞完成 |
 | 独立评审 | 无报告时 | 模型未调用 `update_goal` 时，宿主调用一次独立 bounded evaluator 判定；评审不可用/出错/不确定时安全暂停，绝不默认继续 |
-| 执行预算 | 默认 | **真实执行轮次 + 结构化卡死检测**：简单/写入/研究型跨 Run 总预算为 10/20/40 轮；用户未显式配置 `max_steps` 时，每次 Goal Run 默认 16 个模型轮次并提供一次仅总结响应。相同宿主失败 3 次或成功轮连续 6 次没有新证据时结构化暂停。累计 token、provider 请求数和跨 turn 无进展只做观测，**没有 token/请求数硬上限** |
+| 执行预算 | 默认 | **默认不设任何上限**：没有轮数预算，也没有单次 Run 的轮次上限。需要为无人值守循环设护栏时，配置 `[agent].goal_token_budget`（整个 Goal 累计 token），越线产出一次总结并进入可恢复的 `budget_spend` 暂停。结构化卡死检测保留：相同宿主失败 3 次或成功轮连续 6 次没有新证据时暂停。跨 turn 无进展仍只做观测 |
 | 暂停/恢复 | `/goal pause` / `/goal resume` | 暂停保留 Goal、todo、Delivery checkpoint 与运行历史；轮次型暂停恢复时追加一档同类别**轮数**（`budget_extensions` 统计轮次追加次数） |
 | 立即阻塞 | `blocked` 报告 | 单个 blocked 报告立即结束目标，不再重复三轮确认 |
 | 并行调度 | `parallel_tasks` 工具 | 并发派发多个子 agent，各自独立显示结果 |
@@ -59,7 +59,7 @@ Reasonix 的 Goal 模式（`/goal`）将目标推进（Goal）、验收（Delive
 - 没有 provider 请求前的 token 预留/准入；
 - 累计 token 再大也不会单独暂停 Goal。
 
-可停止 Goal 的条件：10/20/40 外层轮次耗尽、单次 Run 的 16 轮默认边界、结构化卡死、evaluator 故障、显式 `blocked`、账号额度或人工暂停。跨 Goal turn 的 `noProgressTurns` 继续记录新颖证据变化，但不再直接停止 Goal。
+可停止 Goal 的条件：目标达成、显式 `blocked`、evaluator 故障或不确定（fail-closed）、结构化卡死、配置了 `goal_token_budget` 时的 token 预算耗尽、账号额度或人工暂停。**轮数不再是其中任何一条**。跨 Goal turn 的 `noProgressTurns` 继续记录新颖证据变化，但不直接停止 Goal。
 
 达到轮次预算后目标安全暂停（持久化层表现为 `blocked` + `stop_cause`，旧客户端安全显示为 blocked，不会误恢复自动运行）。`/goal status` 显示完整运行摘要：
 
@@ -67,7 +67,7 @@ Reasonix 的 Goal 模式（`/goal`）将目标推进（Goal）、验收（Delive
 runtime: turns 12/20, tokens 214000, requests 37, no-progress 6 (observational), extensions 0
 ```
 
-`/goal resume` 恢复目标：只有 10/20/40 外层轮次型暂停才追加一档同类别轮数；`goal_run_budget` 与 `goal_stuck` 只开启一个新的 Run，不增加外层额度。累计 token、请求数与 `budget_extensions` 保留。旧版本因 `budget_tokens` 或 `no_progress` 暂停的 sidecar 在新版本加载时会自动改为 `running` 并立即持久化；旧 `noProgressLimit` 字段继续兼容读写但不再参与决策。
+`/goal resume` 恢复目标：`budget_spend` 暂停会重新授予一次完整 token 预算（而不是恢复后立刻再次耗尽）；`goal_stuck` 只开启一个新的 Run。请求数与 `budget_extensions` 保留。旧版本因 `budget_tokens` 或 `no_progress` 暂停的 sidecar 在新版本加载时会自动改为 `running` 并立即持久化；旧 `noProgressLimit` 字段继续兼容读写但不再参与决策。
 
 上下文压缩继续使用全局既有策略：仅由 `compact_ratio`（默认 85%）触发一次内容驱动摘要 checkpoint，不另设 soft/snip/force 多阈值。Goal 开启本身不额外触发 summarizer，也不改变工具 Schema 或稳定 prompt 前缀。
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -664,7 +664,7 @@ Mode and display shortcuts:
 | `/theme [auto|light|dark|style]` | Shows or switches the CLI theme | Bare `/theme` lists background modes and named accent palettes. The choice is saved to the user config; `REASONIX_THEME` and `REASONIX_THEME_STYLE` can override it for one run. |
 | `Ctrl+O` | Toggles verbose reasoning display | Also available through `/verbose`. |
 | `Ctrl+B` | Expands or collapses long shell output | Long shell-output hint lines can also be clicked in the transcript; text selection is handled in-app while the full-screen TUI has mouse reporting enabled. |
-| `/goal <objective>`, `/goal status`, `/goal pause`, `/goal resume`, `/goal clear` | Starts, checks, pauses, resumes, or clears Goal | Goal automatically selects a simple, write, or research turn budget. |
+| `/goal <objective>`, `/goal status`, `/goal pause`, `/goal resume`, `/goal clear` | Starts, checks, pauses, resumes, or clears Goal | A Goal is unbounded unless `[agent].goal_token_budget` is set. |
 | `/migrate`, `/migrate --from <legacy-dir>` | Retries legacy migration or imports sessions from a chosen v0.x source | Use `--from` for custom Windows v0.52 install/data directories; it imports sessions only. See [Configuration paths](./CONFIG_PATHS.md). |
 
 Picker and approval shortcuts:
@@ -1139,11 +1139,20 @@ until the goal is complete, blocked, paused, or cleared. Ordinary chat never
 changes collaboration mode implicitly; choose Goal in the composer or use
 `/goal` to start a long-running objective.
 
-Goal runs under a per-class **turn** budget: simple goals get 10 turns, write
-goals 20 turns, and research goals 40 turns. This is a cross-Run continuation
-backstop. Each Goal Run also defaults to 16 model rounds when no explicit
-`max_steps` is configured, then gets one summary-only response before a
-resumable `goal_run_budget` pause. Progress is goal-scoped and novelty based:
+A Goal runs until it finishes, hits a blocker, stops making progress, or you
+stop it. **Nothing bounds it by default** — not turns, not rounds. If you want
+a ceiling on an unattended loop, set one:
+
+```toml
+[agent]
+goal_token_budget = 20000000   # cumulative tokens across the whole goal
+```
+
+Reaching it produces one summary and a resumable `budget_spend` pause, and
+`/goal resume` grants the budget again rather than resuming into an
+immediately exhausted one. Tokens are the unit because they catch both a slow
+expensive loop and a fast empty one, where wall clock catches only the first
+and money is not portable across models. Progress is goal-scoped and novelty based:
 new read/search results, mutations, verification, todo/signoff changes, and
 reviews advance the goal; an exact tool/argument/result repeat does not.
 Cumulative token and real provider request usage is tracked and shown for
@@ -1151,11 +1160,11 @@ diagnostics, but there is
 **no token hard limit** and no pre-provider request admission. In Goal mode, a
 bare bug/crash/exception statement defaults to the write turn class unless the
 user asks only for analysis/explanation or forbids changes. A paused goal keeps its todos, Delivery
-checkpoint, and runtime history — use `/goal resume` to continue (turn-budget
-pauses add one more slice of turns of the same class; Run-budget and structural
-stuck pauses start a fresh Run without extending the outer budget), or `/goal pause` to pause
-a running goal manually. `/goal status` shows the full runtime summary (turns
-used/limit, tokens, requests, observational no-progress streak, extensions).
+checkpoint, and runtime history — use `/goal resume` to continue (a spend pause
+resumes with its budget granted again; structural stuck pauses start a fresh
+Run), or `/goal pause` to pause a running goal manually. `/goal status` shows
+the full runtime summary (turns used, tokens used/limit, requests,
+observational no-progress streak, extensions).
 Within one Run, three repeated identical host failures or six successful
 zero-evidence rounds produce a resumable `goal_stuck` pause. At the end of every goal turn
 the model reports its disposition through the structured `update_goal` tool

--- a/internal/agent/run_budget.go
+++ b/internal/agent/run_budget.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -8,14 +9,15 @@ import (
 	"reasonix/internal/provider"
 )
 
-// TaskBudget bounds one task on the axes its failures are reported in.
-// Crossing either yields one tool-free summary and a resumable pause. Both
-// axes ship off: stopping a task is the user's call, since only they know
-// which model they are paying for and whether a long task is a runaway or the
-// job they asked for.
+// TaskBudget bounds one task on the axes its failures are reported in, and
+// every axis ships off: stopping a task is the user's call. Tokens is the one
+// that generalizes — a slow expensive loop accumulates them and so does a fast
+// empty one, where wall clock catches only the first and money is not portable
+// across models.
 type TaskBudget struct {
-	Cost float64
-	Wall time.Duration
+	Cost   float64
+	Wall   time.Duration
+	Tokens int
 }
 
 // normalizeTaskBudget reads a negative value as unset, so a disabled axis and
@@ -26,6 +28,9 @@ func normalizeTaskBudget(b TaskBudget) TaskBudget {
 	}
 	if b.Wall < 0 {
 		b.Wall = 0
+	}
+	if b.Tokens < 0 {
+		b.Tokens = 0
 	}
 	return b
 }
@@ -91,6 +96,11 @@ func (b *runBudget) totals() event.RunBudgetTotals {
 // the budget. Cost only counts when the turn was actually priced: an unpriced
 // model reads as free, and a free reading must never look like a crossing.
 func (b *runBudget) exceeded(limit TaskBudget) (axis, detail string) {
+	if limit.Tokens > 0 {
+		if used := b.promptTokens + b.outputTokens; used >= limit.Tokens {
+			return "token", fmt.Sprintf("task used %d tokens, reaching the %d budget", used, limit.Tokens)
+		}
+	}
 	if limit.Cost > 0 && b.pricedRounds > 0 && !b.unpricedTurns && b.cost >= limit.Cost {
 		return "cost", fmt.Sprintf("task spend %.4f reached the %.4f budget", b.cost, limit.Cost)
 	}
@@ -101,6 +111,16 @@ func (b *runBudget) exceeded(limit TaskBudget) (axis, detail string) {
 		}
 	}
 	return "", ""
+}
+
+// taskBudgetLimit resolves this turn's bound: a host-injected budget wins over
+// the configured one, which is how an unattended loop gets a ceiling while
+// ordinary chat keeps none.
+func (a *Agent) taskBudgetLimit(ctx context.Context) TaskBudget {
+	if b, ok := taskBudgetFromContext(ctx); ok {
+		return b
+	}
+	return a.taskBudget.limit
 }
 
 // observeRunBudget folds a round into both scopes and reports them.
@@ -122,4 +142,21 @@ func (a *Agent) observeRunBudget(state *runLoopState, usage *provider.Usage) {
 		Task:     a.taskBudget.totals(),
 		Currency: currency,
 	})
+}
+
+type taskBudgetContextKey struct{}
+
+// WithTaskBudget overrides a run's task budget for one turn. The agent serving
+// an unattended loop and the one serving chat are the same instance, so the
+// bound is a property of the turn, not of construction.
+func WithTaskBudget(ctx context.Context, b TaskBudget) context.Context {
+	return context.WithValue(ctx, taskBudgetContextKey{}, normalizeTaskBudget(b))
+}
+
+func taskBudgetFromContext(ctx context.Context) (TaskBudget, bool) {
+	if ctx == nil {
+		return TaskBudget{}, false
+	}
+	b, ok := ctx.Value(taskBudgetContextKey{}).(TaskBudget)
+	return b, ok
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -664,7 +664,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 
 	// Spend is checked before rounds: it is the axis a runaway is actually
 	// reported in, so on the turns both would catch it should be the one named.
-	if axis, detail := a.taskBudget.exceeded(a.taskBudget.limit); axis != "" {
+	if axis, detail := a.taskBudget.exceeded(a.taskBudgetLimit(ctx)); axis != "" {
 		a.armFinalizationRound(state, landCause{kind: "task_budget", axis: axis, detail: detail})
 		return true, nil
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1907,6 +1907,8 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 	}
 
 	ctrlOpts := control.Options{
+		TaskBudget:                     taskBudgetFromConfig(cfg),
+		GoalTokenBudget:                cfg.Agent.GoalTokenBudget,
 		Runner:                         runner,
 		Executor:                       executor,
 		Sink:                           sink,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1282,6 +1282,9 @@ type AgentConfig struct {
 	TaskCostBudget float64 `toml:"task_cost_budget"`
 	// TaskTimeBudgetMinutes is the same gate on wall clock. Both ship off.
 	TaskTimeBudgetMinutes float64 `toml:"task_time_budget_minutes"`
+	// GoalTokenBudget bounds an unattended Goal loop by cumulative tokens.
+	// Off unless set: a Goal runs until it finishes or you stop it.
+	GoalTokenBudget int `toml:"goal_token_budget"`
 	// MaxSubagentConcurrency bounds how many sub-agents (task, fleet items,
 	// profile skills, nested children) may run at once in one session.
 	// 0 means the default (6). Values outside 1–32 are clamped on load.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -94,6 +94,11 @@ type Controller struct {
 	// recoveryGate is the shared Auto Guard state for this controller.
 	// nil when the feature is not wired for this controller.
 	recoveryGate *recovery.Gate
+
+	// taskBudget is the configured spend gate, as passed at construction.
+	taskBudget agent.TaskBudget
+	// goalTokenBudget bounds an unattended Goal loop; 0 leaves it unbounded.
+	goalTokenBudget int
 	// evaluator is the bounded Goal completion evaluator consulted when the
 	// working model submits no update_goal report. nil fails closed: the goal
 	// pauses instead of defaulting to continue.
@@ -417,6 +422,10 @@ type Options struct {
 	// RecoveryHeadless blocks mutations that need confirmation instead of
 	// waiting forever when no human decision channel exists.
 	RecoveryHeadless bool
+	// TaskBudget is the configured spend gate; unset leaves a turn unbounded.
+	TaskBudget agent.TaskBudget
+	// GoalTokenBudget bounds an unattended Goal loop by cumulative tokens.
+	GoalTokenBudget int
 	// GoalEvaluator is the optional bounded Goal completion evaluator consulted
 	// when the working model submits no update_goal report. nil fails closed:
 	// the goal pauses instead of defaulting to continue.
@@ -571,6 +580,9 @@ func New(opts Options) *Controller {
 		opts.Hooks.SetSessionID(agent.BranchID(opts.SessionPath))
 	}
 	c := &Controller{
+		taskBudget:                        opts.TaskBudget,
+		goalTokenBudget:                   opts.GoalTokenBudget,
+		goals:                             goalMachine{tokenBudget: opts.GoalTokenBudget},
 		runner:                            opts.Runner,
 		executor:                          opts.Executor,
 		guardianSess:                      opts.Guardian,

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -802,8 +802,10 @@ func TestResumeRestoresRunningAutoResearchGoalFromSidecar(t *testing.T) {
 	if strings.Contains(strings.ToLower(composed), "autoresearch") {
 		t.Fatalf("Compose after resume exposed removed AutoResearch protocol:\n%s", composed)
 	}
-	if got := c.GoalRuntime().TurnsLimit; got != 40 {
-		t.Fatalf("resumed legacy Goal budget = %d, want 40", got)
+	// The class-derived turn quota is retired: a migrated legacy Goal is
+	// bounded by what the user configures, not by a number derived from its text.
+	if got := c.GoalRuntime().TurnsLimit; got != 0 {
+		t.Fatalf("resumed legacy Goal turn budget = %d, want it retired", got)
 	}
 }
 

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -43,7 +43,8 @@ const (
 // blocked either way. stopCauseBudgetTokens is only for recognizing and
 // auto-resuming old token-limit pauses.
 const (
-	stopCauseBudgetTurns   = "budget_turns"
+	stopCauseBudgetTurns   = "budget_turns" // legacy; the class-derived turn quota is gone
+	stopCauseBudgetSpend   = "budget_spend"
 	stopCauseBudgetTokens  = "budget_tokens"   // legacy; never written by current runtime
 	stopCauseNoProgress    = "no_progress"     // legacy; never written by current runtime
 	stopCauseGoalRunBudget = "goal_run_budget" // legacy; the per-Run round ceiling is gone
@@ -52,12 +53,6 @@ const (
 	stopCauseLegacyArchive = "legacy_archive"
 	stopCauseManual        = "manual"
 )
-
-// budgetQuota returns the default turn quota for a budget class. Token hard
-// limits were removed; callers no longer receive a token ceiling.
-func budgetQuota(class string) (turns int) {
-	return taskintent.BudgetTurns(class)
-}
 
 // budgetClassForLegacyMode translates old sidecars and deprecated CLI flags at
 // the compatibility boundary. The active Goal runtime stores only budgetClass.
@@ -89,6 +84,8 @@ type goalMachine struct {
 	block              string
 	strict             bool
 	continuationEpoch  uint64
+
+	tokenBudget int // configured ceiling for an unattended loop; 0 = unbounded
 
 	// Runtime budget state, persisted across turns and restarts.
 	// tokensUsed is observational only (no hard limit). tokensLimit is kept at
@@ -281,6 +278,9 @@ func (g *goalMachine) statusForDisplay() string {
 
 // budgetExhausted reports whether the goal's turn budget is spent. Token usage
 // never exhausts the goal by itself.
+// budgetExhausted reports a spent turn quota. The quota is retired, so this is
+// false for every Goal started by the current runtime; a restored sidecar that
+// still carries a limit keeps answering truthfully until it resumes.
 func (g *goalMachine) budgetExhausted() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -348,8 +348,8 @@ func (g *goalMachine) installGoalLocked(goal, preferredBudgetClass string) {
 		g.scopeID = newGoalScopeID()
 		g.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: g.scopeID}
 		g.budgetClass = preferredBudgetClass
-		g.turnsLimit = budgetQuota(g.budgetClass)
-		g.tokensLimit = 0 // no token hard limit
+		g.turnsLimit = 0 // retired; the spend budget bounds a Goal now
+		g.tokensLimit = g.tokenBudget
 		g.noProgressLimit = noProgressQuota(g.budgetClass)
 	}
 	// Installing a normal Goal always abandons any pending legacy migration.
@@ -412,21 +412,27 @@ func (g *goalMachine) resume(todos []evidence.TodoItem) (path string, data []byt
 	// can resume without understanding the removed hard limit.
 	extend := g.stopCause == stopCauseBudgetTurns ||
 		g.stopCause == stopCauseBudgetTokens ||
+		g.stopCause == stopCauseBudgetSpend ||
 		(g.turnsLimit > 0 && g.turnsUsed >= g.turnsLimit)
+	// Resuming a spend pause grants the budget again rather than leaving the
+	// goal instantly re-exhausted (openai/codex#34215 has the opposite).
+	spentBudget := g.stopCause == stopCauseBudgetSpend
 	g.continuationEpoch++
 	g.status = GoalStatusRunning
 	g.block = ""
 	g.stopCause = ""
 	g.noProgressTurns = 0
-	g.tokensLimit = 0
+	g.tokensLimit = g.tokenBudget
+	if spentBudget {
+		g.tokensUsed = 0
+	}
 	if g.scopeID == "" {
 		g.scopeID = newGoalScopeID()
 	}
 	if extend {
-		if g.budgetClass == "" {
-			g.budgetClass = taskintent.ClassifyGoalBudget(g.goal)
-		}
-		g.turnsLimit += budgetQuota(g.budgetClass)
+		// An old sidecar paused on the retired turn quota resumes by clearing
+		// it, not by being granted more turns.
+		g.turnsLimit = 0
 		g.budgetExtensions++
 	}
 	path, data, persist = g.buildStateLocked(todos)
@@ -569,10 +575,10 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		g.block = clipGoalReason(reason)
 		g.lastEvaluatorReason = clipGoalReason(reason)
 		notice = "goal paused: " + reason
-	case g.turnsLimit > 0 && g.turnsUsed >= g.turnsLimit:
-		reason := fmt.Sprintf("turn budget exhausted (%d/%d turns used)", g.turnsUsed, g.turnsLimit)
+	case g.tokensLimit > 0 && g.tokensUsed >= g.tokensLimit:
+		reason := fmt.Sprintf("token budget reached (%d/%d tokens used)", g.tokensUsed, g.tokensLimit)
 		g.status = GoalStatusBlocked
-		g.stopCause = stopCauseBudgetTurns
+		g.stopCause = stopCauseBudgetSpend
 		g.block = clipGoalReason(reason)
 		notice = "goal paused: " + reason
 	case in.pauseCause != "":
@@ -840,9 +846,6 @@ func (g *goalMachine) restoreFromState(sessionPath string) (path string, data []
 		}
 		if legacy.taskID != "" {
 			g.budgetClass = budgetClassResearch
-		}
-		if g.turnsLimit == 0 {
-			g.turnsLimit = budgetQuota(g.budgetClass)
 		}
 		g.noProgressLimit = resolvedNoProgressLimit(g.noProgressLimit, g.budgetClass)
 		if g.migrateRemovedGoalPause() {

--- a/internal/control/goal_boundary_runtime_test.go
+++ b/internal/control/goal_boundary_runtime_test.go
@@ -42,11 +42,25 @@ func TestMergeGoalProgressEvidenceIsNovelAndBounded(t *testing.T) {
 	}
 }
 
-func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
+// legacyTurnQuota reproduces the retired class-derived turn quota. Fixtures
+// below only ever needed "some plausible number of turns"; the runtime no
+// longer derives one.
+func legacyTurnQuota(class string) int {
+	switch class {
+	case budgetClassResearch:
+		return 40
+	case budgetClassWrite:
+		return 20
+	default:
+		return 10
+	}
+}
+
+func TestTurnCountNeverPausesAndResumeClearsLegacyBudget(t *testing.T) {
 	newMachine := func() *goalMachine {
 		g := &goalMachine{goal: "fix the parser", status: GoalStatusRunning}
 		g.budgetClass = budgetClassWrite
-		g.turnsLimit = budgetQuota(budgetClassWrite)
+		g.turnsLimit = legacyTurnQuota(budgetClassWrite)
 		g.noProgressLimit = noProgressQuota(g.budgetClass)
 		return g
 	}
@@ -54,16 +68,19 @@ func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
 		return goalAdvanceInput{report: report, progressEvidence: progress}
 	}
 
-	t.Run("turn budget pauses", func(t *testing.T) {
+	// Turn count is not a resource. A goal that keeps reporting progress runs
+	// as long as it keeps making it; a ceiling now lives on spend, and only
+	// when the user sets one.
+	t.Run("turn count never pauses", func(t *testing.T) {
 		g := newMachine()
-		for i := range g.turnsLimit {
+		for i := range g.turnsLimit * 3 {
 			res := g.advance(in(&goalTurnReport{status: GoalStatusRunning, reason: "keep going"}, "sig-"+fmt.Sprint(i)))
-			if res.cont && i == g.turnsLimit-1 {
-				t.Fatal("last turn must pause")
+			if !res.cont {
+				t.Fatalf("goal paused at turn %d on turn count alone", i+1)
 			}
 		}
-		if g.status != GoalStatusBlocked || g.stopCause != stopCauseBudgetTurns {
-			t.Fatalf("machine = (%q, %q), want blocked+budget_turns", g.status, g.stopCause)
+		if g.status != GoalStatusRunning || g.stopCause != "" {
+			t.Fatalf("machine = (%q, %q), want it still running", g.status, g.stopCause)
 		}
 	})
 
@@ -110,7 +127,7 @@ func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
 
 	t.Run("research accepts new read evidence but keeps a larger synthesis budget", func(t *testing.T) {
 		g := &goalMachine{goal: "research", status: GoalStatusRunning, budgetClass: budgetClassResearch,
-			turnsLimit: budgetQuota(budgetClassResearch), noProgressLimit: noProgressQuota(budgetClassResearch)}
+			turnsLimit: legacyTurnQuota(budgetClassResearch), noProgressLimit: noProgressQuota(budgetClassResearch)}
 		for i := range 8 {
 			if res := g.advance(in(&goalTurnReport{status: GoalStatusRunning}, "read-"+fmt.Sprint(i))); !res.cont {
 				t.Fatalf("new research evidence paused at turn %d", i+1)
@@ -121,28 +138,27 @@ func TestTurnTokenNoProgressPausesAndResumeExtendsBudget(t *testing.T) {
 		}
 	})
 
-	t.Run("resume extension contract", func(t *testing.T) {
+	// An old sidecar paused on the retired quota resumes by clearing it, not
+	// by being granted more turns.
+	t.Run("resume clears a legacy turn budget", func(t *testing.T) {
 		g := newMachine()
-		for range g.turnsLimit {
-			g.advance(in(&goalTurnReport{status: GoalStatusRunning}))
-		}
-		before := g.turnsLimit
+		g.turnsUsed = g.turnsLimit
+		g.pauseFor(stopCauseBudgetTurns, "turn budget exhausted", nil)
 		_, _, _, resumed, extended := g.resume(nil)
-		if !resumed || !extended || g.turnsLimit != before+budgetQuota(budgetClassWrite) || g.budgetExtensions != 1 {
-			t.Fatalf("budget resume failed: %+v", g)
+		if !resumed || !extended || g.turnsLimit != 0 || g.budgetExtensions != 1 {
+			t.Fatalf("legacy budget resume failed: %+v", g)
 		}
 		g.pauseFor(stopCauseManual, "user paused", nil)
-		before = g.turnsLimit
 		_, _, _, resumed, extended = g.resume(nil)
-		if !resumed || extended || g.turnsLimit != before {
-			t.Fatalf("manual resume extended budget: %+v", g)
+		if !resumed || extended {
+			t.Fatalf("manual resume treated as a budget extension: %+v", g)
 		}
 	})
 }
 
 func TestWireContinueDoesNotKeepExactRepeatedEvidenceAlive(t *testing.T) {
 	g := &goalMachine{goal: "repeat", status: GoalStatusRunning, budgetClass: budgetClassSimple,
-		turnsLimit: budgetQuota(budgetClassSimple), noProgressLimit: noProgressQuota(budgetClassSimple), scopeID: newGoalScopeID()}
+		turnsLimit: legacyTurnQuota(budgetClassSimple), noProgressLimit: noProgressQuota(budgetClassSimple), scopeID: newGoalScopeID()}
 	advance := func() goalAdvanceResult {
 		epoch := g.continuationEpoch
 		rec := g.newTurnRecorder(g.scopeID, epoch)
@@ -241,7 +257,7 @@ func TestGoalRunBoundariesPauseAfterTerminalDecisions(t *testing.T) {
 func TestGoalProgressEvidenceRestoresAsBoundedNoveltyState(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
 	state := goalState{Goal: "research", Status: GoalStatusRunning, BudgetClass: budgetClassResearch,
-		TurnsLimit: budgetQuota(budgetClassResearch), NoProgressTurns: 2, NoProgressLimit: defaultNoProgressLimit,
+		TurnsLimit: legacyTurnQuota(budgetClassResearch), NoProgressTurns: 2, NoProgressLimit: defaultNoProgressLimit,
 		ProgressEvidence: []string{"read-a", "read-a", "read-b", strings.Repeat("x", 129)}}
 	raw, err := json.Marshal(state)
 	if err != nil {

--- a/internal/control/goal_legacy.go
+++ b/internal/control/goal_legacy.go
@@ -138,9 +138,7 @@ func (g *goalMachine) fillGoalTextIfEmpty(expectedEpoch uint64, goal string) (ui
 		g.stopCause, g.block = "", ""
 	}
 	g.budgetClass = budgetClassResearch
-	if g.turnsLimit < budgetQuota(g.budgetClass) {
-		g.turnsLimit = budgetQuota(g.budgetClass)
-	}
+	g.turnsLimit = 0 // retired quota; a migrated goal is not re-bounded by turns
 	if g.noProgressLimit == 0 {
 		g.noProgressLimit = noProgressQuota(g.budgetClass)
 	}
@@ -169,9 +167,7 @@ func (g *goalMachine) resumeLegacyArchive(expectedEpoch uint64, goal string) (ui
 	g.status = GoalStatusRunning
 	g.stopCause, g.block = "", ""
 	g.budgetClass = budgetClassResearch
-	if g.turnsLimit < budgetQuota(g.budgetClass) {
-		g.turnsLimit = budgetQuota(g.budgetClass)
-	}
+	g.turnsLimit = 0 // retired quota; a migrated goal is not re-bounded by turns
 	if g.noProgressLimit == 0 {
 		g.noProgressLimit = noProgressQuota(g.budgetClass)
 	}

--- a/internal/control/goal_legacy_restore_test.go
+++ b/internal/control/goal_legacy_restore_test.go
@@ -80,8 +80,8 @@ func TestGoalSidecarWriterFencesLegacyAutoResearchForEveryBudget(t *testing.T) {
 			if state.ResearchMode != GoalResearchOff || state.AutoResearchTaskID != "" {
 				t.Fatalf("legacy reader fence missing: %+v", state)
 			}
-			if state.BudgetClass != tt.class || state.TurnsLimit != budgetQuota(tt.class) {
-				t.Fatalf("budget state = %+v, want %s/%d", state, tt.class, budgetQuota(tt.class))
+			if state.BudgetClass != tt.class || state.TurnsLimit != 0 {
+				t.Fatalf("budget state = %+v, want %s with no turn quota", state, tt.class)
 			}
 			// Frozen previous readers treated any non-Off mode or retained task id
 			// as an AutoResearch activation signal.
@@ -100,8 +100,8 @@ func TestGoalSidecarWriterFencesLegacyAutoResearchForEveryBudget(t *testing.T) {
 			}
 			reloaded := &goalMachine{}
 			reloaded.restoreFromState(sessionPath)
-			if reloaded.budgetClass != tt.class || reloaded.turnsLimit != budgetQuota(tt.class) {
-				t.Fatalf("reloaded budget = %q/%d, want %q/%d", reloaded.budgetClass, reloaded.turnsLimit, tt.class, budgetQuota(tt.class))
+			if reloaded.budgetClass != tt.class || reloaded.turnsLimit != 0 {
+				t.Fatalf("reloaded budget = %q/%d, want %q with no turn quota", reloaded.budgetClass, reloaded.turnsLimit, tt.class)
 			}
 		})
 	}
@@ -133,8 +133,8 @@ func TestGoalSetIdempotencyUsesEffectiveBudgetClass(t *testing.T) {
 	if _, _, ok := g.set("same goal", budgetClassResearch, nil); !ok {
 		t.Fatal("budget class change was incorrectly treated as idempotent")
 	}
-	if g.budgetClass != budgetClassResearch || g.turnsLimit != budgetQuota(budgetClassResearch) {
-		t.Fatalf("budget upgrade = class:%q turns:%d", g.budgetClass, g.turnsLimit)
+	if g.budgetClass != budgetClassResearch || g.turnsLimit != 0 {
+		t.Fatalf("budget upgrade = class:%q turns:%d, want the class kept and no turn quota", g.budgetClass, g.turnsLimit)
 	}
 }
 
@@ -215,8 +215,9 @@ func TestLegacySidecarArchiveFailureBlocksWithRetryableTaskID(t *testing.T) {
 		t.Fatalf("retried status = %q, want running", got)
 	}
 	runtime := c.GoalRuntime()
-	if runtime.TurnsUsed != 3 || runtime.TurnsLimit != 40 || runtime.TokensUsed != 1234 || runtime.NoProgressTurns != 2 || runtime.BudgetExtensions != 1 {
-		t.Fatalf("retried runtime = %+v, want preserved legacy consumption", runtime)
+	// Consumption counters survive the migration; the retired turn quota does not.
+	if runtime.TurnsUsed != 3 || runtime.TurnsLimit != 0 || runtime.TokensUsed != 1234 || runtime.NoProgressTurns != 2 || runtime.BudgetExtensions != 1 {
+		t.Fatalf("retried runtime = %+v, want preserved legacy consumption without a turn quota", runtime)
 	}
 	if got := exec.CanonicalTodoState(); len(got) != 1 || got[0] != wantTodo {
 		t.Fatalf("retried todos = %+v, want %+v", got, wantTodo)
@@ -398,8 +399,8 @@ func TestLegacySidecarArchiveCanRetryInSameController(t *testing.T) {
 	if got := c.Goal(); got != "recover objective in the same controller" {
 		t.Fatalf("Goal() = %q, want recovered archive objective", got)
 	}
-	if runtime := c.GoalRuntime(); runtime.TurnsUsed != 5 || runtime.TurnsLimit != 40 {
-		t.Fatalf("runtime = %+v, want preserved use with research quota", runtime)
+	if runtime := c.GoalRuntime(); runtime.TurnsUsed != 5 || runtime.TurnsLimit != 0 {
+		t.Fatalf("runtime = %+v, want preserved use without a turn quota", runtime)
 	}
 	persisted, err := os.ReadFile(goalStatePath(sessionPath))
 	if err != nil {
@@ -607,7 +608,7 @@ func TestExplicitLegacyGoalRetryNeverRunsArchivePathAsGoal(t *testing.T) {
 	if got := c.Goal(); got != "recover the original objective" {
 		t.Fatalf("Goal() = %q, want archive objective", got)
 	}
-	if c.GoalStatus() != GoalStatusRunning || c.GoalRuntime().TurnsLimit != 40 {
+	if c.GoalStatus() != GoalStatusRunning || c.GoalRuntime().TurnsLimit != 0 {
 		t.Fatalf("recovered runtime = status:%q %+v", c.GoalStatus(), c.GoalRuntime())
 	}
 }

--- a/internal/control/goal_runtime_test.go
+++ b/internal/control/goal_runtime_test.go
@@ -22,12 +22,18 @@ import (
 // returns the TurnDone/Notice channel for waiting.
 func goalRuntimeController(t *testing.T, prov provider.Provider, eval goaleval.Evaluator) (*Controller, *agent.Agent, <-chan event.Event) {
 	t.Helper()
+	return goalRuntimeControllerWithTokenBudget(t, prov, eval, 0)
+}
+
+func goalRuntimeControllerWithTokenBudget(t *testing.T, prov provider.Provider, eval goaleval.Evaluator, tokens int) (*Controller, *agent.Agent, <-chan event.Event) {
+	t.Helper()
 	ag := agent.New(prov, goalRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
 	events := make(chan event.Event, 8)
 	c := New(Options{
-		Runner:        ag,
-		Executor:      ag,
-		GoalEvaluator: eval,
+		Runner:          ag,
+		Executor:        ag,
+		GoalEvaluator:   eval,
+		GoalTokenBudget: tokens,
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.TurnDone || e.Kind == event.Notice {
 				events <- e
@@ -104,18 +110,27 @@ func TestEvaluatorOutcomesDriveFSM(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done.")}}
-			c, _, events := goalRuntimeController(t, prov, &fakeGoalEvaluator{outcome: tc.outcome, reason: "verdict"})
+			turn := textTurn("done.")
+			// A continue verdict loops forever unless a budget is configured.
+			budget := 0
+			if tc.wantStatus == GoalStatusRunning {
+				budget = 1
+				turn = []provider.Chunk{
+					{Type: provider.ChunkText, Text: "done."},
+					{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}},
+					{Type: provider.ChunkDone},
+				}
+			}
+			prov := &scriptedTurns{turns: [][]provider.Chunk{turn}}
+			c, _, events := goalRuntimeControllerWithTokenBudget(t, prov, &fakeGoalEvaluator{outcome: tc.outcome, reason: "verdict"}, budget)
 			c.Submit("/goal assess the impact")
 			waitGoalTurnDone(t, events)
 			if tc.wantStatus == GoalStatusRunning {
-				// Continue keeps the loop going until the recoverable outer turn
-				// backstop; cross-turn no-progress is observational only.
 				if got := c.GoalStatus(); got != GoalStatusBlocked {
-					t.Fatalf("GoalStatus() = %q, want the loop to keep going until a pause", got)
+					t.Fatalf("GoalStatus() = %q, want the loop to keep going until its spend budget", got)
 				}
-				if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetTurns || rt.TurnsUsed != rt.TurnsLimit {
-					t.Fatalf("runtime = %+v, want outer turn-budget pause", rt)
+				if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetSpend {
+					t.Fatalf("runtime = %+v, want a spend-budget pause", rt)
 				}
 				return
 			}
@@ -161,17 +176,22 @@ func TestEvaluatorUnavailablePausesFirstTurn(t *testing.T) {
 // TestEvaluatorCompleteStillGatedByReadiness: the evaluator's complete claim
 // must pass host readiness — seeded incomplete todos keep the goal going.
 func TestEvaluatorCompleteStillGatedByReadiness(t *testing.T) {
-	prov := &scriptedTurns{turns: [][]provider.Chunk{
-		textTurn("done."),
-		textTurn("done again."),
-	}}
+	billedTurn := []provider.Chunk{
+		{Type: provider.ChunkText, Text: "done."},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}},
+		{Type: provider.ChunkDone},
+	}
+	prov := &scriptedTurns{turns: [][]provider.Chunk{billedTurn, billedTurn}}
 	ag := agent.New(prov, goalRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
 	ag.SeedTodoState([]evidence.TodoItem{{Content: "Fix the parser", Status: "in_progress"}})
 	done := make(chan event.Event, 1)
 	c := New(Options{
-		Runner:        ag,
-		Executor:      ag,
-		GoalEvaluator: &fakeGoalEvaluator{outcome: goaleval.OutcomeComplete, reason: "all done"},
+		Runner:   ag,
+		Executor: ag,
+		// A rejected complete keeps the loop going; without a configured
+		// budget nothing would ever end it.
+		GoalTokenBudget: 1,
+		GoalEvaluator:   &fakeGoalEvaluator{outcome: goaleval.OutcomeComplete, reason: "all done"},
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.TurnDone {
 				done <- e
@@ -181,12 +201,12 @@ func TestEvaluatorCompleteStillGatedByReadiness(t *testing.T) {
 	c.Submit("/goal fix everything")
 	<-done
 	// The evaluator's complete claim is rejected (incomplete todos) and the
-	// goal continues until the outer continuation backstop.
+	// goal continues until its configured spend budget.
 	if got := c.GoalStatus(); got != GoalStatusBlocked {
-		t.Fatalf("GoalStatus() = %q, want blocked (turn budget after rejected complete)", got)
+		t.Fatalf("GoalStatus() = %q, want blocked (spend budget after rejected complete)", got)
 	}
-	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetTurns {
-		t.Fatalf("StopCause = %q, want %q", rt.StopCause, stopCauseBudgetTurns)
+	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetSpend {
+		t.Fatalf("StopCause = %q, want %q", rt.StopCause, stopCauseBudgetSpend)
 	}
 }
 
@@ -311,7 +331,7 @@ func TestGoalUsageTeeAttributesScopedBillableCallsAndExcludesTitle(t *testing.T)
 	tee := NewGoalUsageTee(event.Discard).(*goalUsageTee)
 	g := &goalMachine{goal: "ship it", status: GoalStatusRunning}
 	g.budgetClass = budgetClassWrite
-	g.turnsLimit = budgetQuota(budgetClassWrite)
+	g.turnsLimit = legacyTurnQuota(budgetClassWrite)
 	g.tokensLimit = 0
 	g.noProgressLimit = noProgressQuota(g.budgetClass)
 	g.scopeID = newGoalScopeID()
@@ -355,7 +375,7 @@ func TestBudgetClassForBareFaultIsWrite(t *testing.T) {
 	if class != budgetClassWrite {
 		t.Fatalf("budget class = %q, want write", class)
 	}
-	if turns := budgetQuota(class); turns != 20 {
+	if turns := legacyTurnQuota(class); turns != 20 {
 		t.Fatalf("write turn quota = %d, want 20", turns)
 	}
 	// Consultative / diagnostic fault statements stay simple.
@@ -496,11 +516,13 @@ func TestGoalSidecarCompatRestoresOldAndNewFields(t *testing.T) {
 		if rt.TokensUsed != 0 {
 			t.Fatalf("TokensUsed = %d, want 0 (no legacy token record)", rt.TokensUsed)
 		}
-		if rt.TurnsLimit == 0 {
-			t.Fatalf("turn limit not re-derived: %+v", rt)
+		// The class-derived turn quota is retired and is not re-derived on
+		// restore; an unconfigured goal carries no ceiling of either kind.
+		if rt.TurnsLimit != 0 {
+			t.Fatalf("turn quota re-derived on restore: %+v", rt)
 		}
 		if rt.TokensLimit != 0 {
-			t.Fatalf("TokensLimit = %d, want 0 (no hard token limit)", rt.TokensLimit)
+			t.Fatalf("TokensLimit = %d, want 0 when no budget is configured", rt.TokensLimit)
 		}
 	})
 
@@ -589,8 +611,8 @@ func TestGoalRuntimeViewPopulatesFromController(t *testing.T) {
 	c := New(Options{Sink: event.Discard})
 	c.SetGoal("finish the migration")
 	rt := c.GoalRuntime()
-	if rt.TurnsUsed != 0 || rt.TurnsLimit == 0 || rt.NoProgressLimit == 0 {
-		t.Fatalf("runtime view = %+v, want derived turn budget defaults", rt)
+	if rt.TurnsUsed != 0 || rt.TurnsLimit != 0 || rt.NoProgressLimit == 0 {
+		t.Fatalf("runtime view = %+v, want no derived turn quota", rt)
 	}
 	if rt.TokensLimit != 0 {
 		t.Fatalf("TokensLimit = %d, want 0 (no hard token limit)", rt.TokensLimit)
@@ -601,17 +623,22 @@ func TestGoalRuntimeViewPopulatesFromController(t *testing.T) {
 // historical [goal:complete] footer in the latest answer never influences the
 // FSM — only the structured tool report does.
 func TestFooterTextDoesNotDriveGoalState(t *testing.T) {
-	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("All done.\n\n[goal:complete]")}}
-	c, _, events := goalRuntimeController(t, prov, &fakeGoalEvaluator{outcome: goaleval.OutcomeContinue, reason: "work is ongoing"})
+	prov := &scriptedTurns{turns: [][]provider.Chunk{{
+		{Type: provider.ChunkText, Text: "All done.\n\n[goal:complete]"},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}},
+		{Type: provider.ChunkDone},
+	}}}
+	// The evaluator says continue, so only a configured budget ends this run.
+	c, _, events := goalRuntimeControllerWithTokenBudget(t, prov, &fakeGoalEvaluator{outcome: goaleval.OutcomeContinue, reason: "work is ongoing"}, 1)
 	c.Submit("/goal migrate the storage")
 	waitGoalTurnDone(t, events)
 	// The footer alone must never complete the goal: the evaluator's continue
-	// keeps it going until the outer continuation backstop pauses it.
+	// keeps it going until the spend budget pauses it.
 	if got := c.GoalStatus(); got == GoalStatusComplete {
 		t.Fatal("a [goal:complete] footer must not complete the goal")
 	}
-	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetTurns {
-		t.Fatalf("runtime = %+v, want turn-budget pause (footer ignored)", rt)
+	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetSpend {
+		t.Fatalf("runtime = %+v, want spend-budget pause (footer ignored)", rt)
 	}
 	c.ClearGoal()
 	for _, m := range c.History() {

--- a/internal/control/goal_runtime_view.go
+++ b/internal/control/goal_runtime_view.go
@@ -26,7 +26,7 @@ func (g *goalMachine) runtimeView() GoalRuntimeView {
 	return GoalRuntimeView{
 		TurnsUsed: g.turnsUsed, TurnsLimit: g.turnsLimit,
 		TokensUsed: g.tokensUsed, RequestsUsed: g.requestsUsed,
-		TokensLimit: 0, NoProgressTurns: g.noProgressTurns,
+		TokensLimit: g.tokensLimit, NoProgressTurns: g.noProgressTurns,
 		NoProgressLimit: g.noProgressLimit, LastReason: last,
 		StopCause: g.stopCause, BudgetExtensions: g.budgetExtensions,
 	}

--- a/internal/control/goal_spend_budget_test.go
+++ b/internal/control/goal_spend_budget_test.go
@@ -1,0 +1,57 @@
+package control
+
+import (
+	"testing"
+
+	"reasonix/internal/goaleval"
+	"reasonix/internal/provider"
+)
+
+func billedGoalTurn() []provider.Chunk {
+	return []provider.Chunk{
+		{Type: provider.ChunkText, Text: "still working."},
+		{Type: provider.ChunkUsage, Usage: &provider.Usage{
+			PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}},
+		{Type: provider.ChunkDone},
+	}
+}
+
+// The class-derived turn quota is gone: a Goal is no longer bounded by a number
+// guessed from its own text. What bounds it is what the user configures.
+func TestGoalStartsWithNoTurnQuota(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{billedGoalTurn()}}
+	c, _, _ := goalRuntimeController(t, prov, &fakeGoalEvaluator{outcome: goaleval.OutcomeComplete, reason: "done"})
+	c.SetGoal("research the whole subsystem end to end")
+
+	if rt := c.GoalRuntime(); rt.TurnsLimit != 0 || rt.TokensLimit != 0 {
+		t.Fatalf("runtime = %+v, want an unbounded goal out of the box", rt)
+	}
+}
+
+// A configured token budget pauses the loop on its own axis, with the goal
+// resumable rather than finished.
+func TestGoalTokenBudgetPausesAndResumes(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{billedGoalTurn()}}
+	c, _, events := goalRuntimeControllerWithTokenBudget(t, prov,
+		&fakeGoalEvaluator{outcome: goaleval.OutcomeContinue, reason: "ongoing"}, 150)
+
+	c.Submit("/goal keep going forever")
+	waitGoalTurnDone(t, events)
+
+	rt := c.GoalRuntime()
+	if c.GoalStatus() != GoalStatusBlocked || rt.StopCause != stopCauseBudgetSpend {
+		t.Fatalf("status = %q runtime = %+v, want a spend-budget pause", c.GoalStatus(), rt)
+	}
+	if rt.TokensUsed < rt.TokensLimit {
+		t.Fatalf("paused at %d/%d tokens, want the budget actually reached", rt.TokensUsed, rt.TokensLimit)
+	}
+
+	// Unlike openai/codex#34215, a spend pause resumes with its budget granted
+	// again instead of being instantly re-exhausted.
+	if !c.ResumeGoal() || c.GoalStatus() != GoalStatusRunning {
+		t.Fatalf("spend pause did not resume: status = %q", c.GoalStatus())
+	}
+	if rt := c.GoalRuntime(); rt.TokensUsed != 0 || rt.TokensLimit != 150 {
+		t.Fatalf("resumed runtime = %+v, want a fresh budget", rt)
+	}
+}

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -235,8 +235,9 @@ func TestResearchGoalUsesUnifiedGoalBudgetWithoutArchive(t *testing.T) {
 	c.Resume(sess, sessionPath)
 	c.SetGoalWithResearchMode("fix the typo and add a test", GoalResearchOn)
 	defer c.Close()
-	if got := c.GoalRuntime().TurnsLimit; got != 40 {
-		t.Fatalf("research Goal turns limit = %d, want 40", got)
+	// The class still drives behaviour; it just no longer mints a turn quota.
+	if got := c.goals.budgetClass; got != budgetClassResearch {
+		t.Fatalf("research Goal budget class = %q, want %q", got, budgetClassResearch)
 	}
 	if _, err := os.Stat(filepath.Join(root, ".reasonix", "autoresearch")); !os.IsNotExist(err) {
 		t.Fatalf("research Goal created legacy archive: %v", err)
@@ -261,8 +262,8 @@ func TestLegacyGoalSidecarMigratesToResearchBudgetWithoutTaskID(t *testing.T) {
 	c := New(Options{WorkspaceRoot: root, SessionDir: root, Executor: exec})
 	c.Resume(sess, sessionPath)
 	defer c.Close()
-	if got := c.GoalRuntime().TurnsLimit; got != 40 {
-		t.Fatalf("migrated Goal turns limit = %d, want 40", got)
+	if got := c.goals.budgetClass; got != budgetClassResearch {
+		t.Fatalf("migrated Goal budget class = %q, want %q", got, budgetClassResearch)
 	}
 	if got := c.Goal(); got != "investigate runtime" {
 		t.Fatalf("migrated Goal = %q, want sidecar goal", got)
@@ -361,8 +362,8 @@ func TestExplicitLegacyTaskPathRestoresOriginalGoal(t *testing.T) {
 	if got := c.Goal(); got != "find the original root cause" {
 		t.Fatalf("Goal() = %q, want original archive goal", got)
 	}
-	if got := c.GoalRuntime().TurnsLimit; got != 40 {
-		t.Fatalf("turns limit = %d, want research budget", got)
+	if got := c.goals.budgetClass; got != budgetClassResearch {
+		t.Fatalf("budget class = %q, want %q", got, budgetClassResearch)
 	}
 	if got := c.GoalStatus(); got != GoalStatusRunning {
 		t.Fatalf("status = %q", got)
@@ -882,14 +883,18 @@ func TestCompleteRemainingGoalTodosEdgeCases(t *testing.T) {
 
 // TestRepeatedCompleteWithIncompleteTodosPausesOnBudget verifies that a goal
 // whose model keeps reporting complete while todos stay unfinished is
-// intercepted every turn (no override path) and finally pauses on the turn
+// intercepted every turn (no override path) and finally pauses on its spend
 // budget instead of completing.
 func TestRepeatedCompleteWithIncompleteTodosPausesOnBudget(t *testing.T) {
-	// The write-class budget is 20 turns; give the scripted provider a full
-	// pair per turn so the model keeps reporting complete each time.
+	// Nothing bounds an unattended loop unless the user configures it, so this
+	// sets a token budget and bills a turn against it.
 	turns := flattenTurns()
 	for range 21 {
 		turns = append(turns, goalToolTurn(GoalStatusComplete, "", "")...)
+	}
+	for i := range turns {
+		turns[i] = append([]provider.Chunk{{Type: provider.ChunkUsage,
+			Usage: &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}}}, turns[i]...)
 	}
 	prov := &scriptedTurns{turns: turns}
 	ag := agent.New(prov, goalRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
@@ -899,8 +904,9 @@ func TestRepeatedCompleteWithIncompleteTodosPausesOnBudget(t *testing.T) {
 
 	done := make(chan event.Event, 1)
 	c := New(Options{
-		Runner:   ag,
-		Executor: ag,
+		Runner:          ag,
+		Executor:        ag,
+		GoalTokenBudget: 1,
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.TurnDone {
 				done <- e
@@ -909,7 +915,7 @@ func TestRepeatedCompleteWithIncompleteTodosPausesOnBudget(t *testing.T) {
 	})
 
 	c.Submit("/goal fix everything")
-	<-done // wait for the whole loop (intercept until the turn budget pauses)
+	<-done // wait for the whole loop (intercept until the spend budget pauses)
 
 	if c.GoalStatus() == GoalStatusComplete {
 		t.Fatal("goal must not complete with incomplete todos")
@@ -918,11 +924,11 @@ func TestRepeatedCompleteWithIncompleteTodosPausesOnBudget(t *testing.T) {
 		t.Fatalf("GoalStatus() = %q, want blocked (budget pause)", got)
 	}
 	rt := c.GoalRuntime()
-	if rt.StopCause == "" {
-		t.Fatal("expected a stop cause for the budget pause")
+	if rt.StopCause != stopCauseBudgetSpend {
+		t.Fatalf("stop cause = %q, want the spend budget", rt.StopCause)
 	}
-	if rt.TurnsUsed != rt.TurnsLimit {
-		t.Fatalf("turn budget was not enforced: %d/%d", rt.TurnsUsed, rt.TurnsLimit)
+	if rt.TokensUsed < rt.TokensLimit {
+		t.Fatalf("spend budget was not enforced: %d/%d tokens", rt.TokensUsed, rt.TokensLimit)
 	}
 }
 

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -847,21 +847,21 @@ func TestGoalAutoResearchTriggersForLongHorizonGoals(t *testing.T) {
 	if !strings.Contains(got, "<active-goal>") || strings.Contains(strings.ToLower(got), "autoresearch") {
 		t.Fatalf("unified research Goal prompt = %q", got)
 	}
-	if c.GoalRuntime().TurnsLimit != 40 {
-		t.Fatalf("research budget = %+v", c.GoalRuntime())
+	if got := c.goals.budgetClass; got != budgetClassResearch {
+		t.Fatalf("research budget class = %q, want %q", got, budgetClassResearch)
 	}
 }
 
 func TestGoalAutoResearchCanBeForcedOrDisabled(t *testing.T) {
 	c := New(Options{})
 	c.SetGoalWithResearchMode("fix the typo and add a test", GoalResearchOn)
-	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.GoalRuntime().TurnsLimit != 40 {
-		t.Fatalf("forced research Goal should use hidden 40-turn budget: %q %+v", got, c.GoalRuntime())
+	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.goals.budgetClass != budgetClassResearch {
+		t.Fatalf("forced research Goal should select the research class: %q %q", got, c.goals.budgetClass)
 	}
 
 	c.SetGoalWithResearchMode("持续排查这个线上卡顿直到根因明确", GoalResearchOff)
-	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.GoalRuntime().TurnsLimit == 40 {
-		t.Fatalf("simple override should use non-research budget: %q %+v", got, c.GoalRuntime())
+	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.goals.budgetClass == budgetClassResearch {
+		t.Fatalf("simple override should not select the research class: %q %q", got, c.goals.budgetClass)
 	}
 }
 
@@ -870,8 +870,8 @@ func TestGoalCommandPreservesResearchModeFlags(t *testing.T) {
 	if !c.applyGoalCommand("/goal --research fix the typo", "") {
 		t.Fatal("goal command was not parsed")
 	}
-	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.GoalRuntime().TurnsLimit != 40 {
-		t.Fatalf("/goal --research should select research budget: %q %+v", got, c.GoalRuntime())
+	if got := c.Compose("start"); strings.Contains(strings.ToLower(got), "autoresearch") || c.goals.budgetClass != budgetClassResearch {
+		t.Fatalf("/goal --research should select the research class: %q %q", got, c.goals.budgetClass)
 	}
 
 	c = New(Options{})

--- a/internal/control/run_ceiling.go
+++ b/internal/control/run_ceiling.go
@@ -3,20 +3,31 @@ package control
 import (
 	"context"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/tool"
 )
 
-// bindTurnScope binds a Goal turn's usage recorder, whose span stays active
-// until the FSM commits. Neither chat nor Goal gets a round ceiling: rounds
-// carry no information the spend axes lack, and a turn that reaches a high
-// count without crossing them is one whose rounds are cheap and fast. An
-// explicit max_steps still owns either turn.
+// bindTurnScope binds a Goal turn's spend budget and its usage recorder, the
+// latter active until the FSM commits. Neither chat nor Goal gets a round
+// ceiling: rounds carry no information the spend axes lack. An explicit
+// max_steps still owns either turn.
 func (c *Controller) bindTurnScope(ctx context.Context, continuation *goalContinuationSnapshot) context.Context {
 	goalScopeID, goalScoped := c.goals.goalScopeIDForTurn(continuation)
 	if !goalScoped {
 		return ctx
 	}
+	ctx = agent.WithTaskBudget(ctx, c.goalTaskBudget())
 	recorder := c.goals.newTurnRecorder(goalScopeID, c.goals.continuationToken())
 	c.goalUsageTee.setActiveRecorder(recorder)
 	return tool.WithGoalTurnRecorder(ctx, recorder)
+}
+
+// goalTaskBudget is the spend gate a Goal turn runs under: the shared budget
+// plus the Goal-only token axis. Nothing here has a default — a Goal runs
+// until it finishes, hits a blocker, stops making progress, or the user stops
+// it. Anyone who wants a ceiling on an unattended loop sets one.
+func (c *Controller) goalTaskBudget() agent.TaskBudget {
+	b := c.taskBudget
+	b.Tokens = c.goalTokenBudget
+	return b
 }

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -505,6 +505,12 @@ func goalPauseFromRunError(err error) (cause, reason string, ok bool) {
 		return "", "", false
 	}
 	switch {
+	case info.Kind == "task_budget" && info.HostOwned:
+		reason := strings.TrimSpace(info.Reason)
+		if reason == "" {
+			reason = "the Goal reached its spend budget"
+		}
+		return stopCauseBudgetSpend, reason, true
 	case info.Kind == "goal_stuck" && info.HostOwned:
 		reason := strings.TrimSpace(info.Reason)
 		if reason == "" {

--- a/internal/control/turn_orchestrator_test.go
+++ b/internal/control/turn_orchestrator_test.go
@@ -334,33 +334,43 @@ type recordingSessionRunner struct {
 
 type deliveryScopeErrorRunner struct {
 	scopes []agent.DeliveryExecutionScope
+	// usage stands in for the billable work a real executor would report; the
+	// goal's spend budget is measured in it.
+	usage event.Sink
 }
 
 func (r *deliveryScopeErrorRunner) Run(ctx context.Context, _ string) error {
 	if scope, ok := agent.DeliveryExecutionScopeFromContext(ctx); ok {
 		r.scopes = append(r.scopes, scope)
 	}
+	if r.usage != nil {
+		r.usage.Emit(event.Event{Kind: event.Usage, UsageSource: event.UsageSourceExecutor,
+			Usage: &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110, RequestCount: 1}})
+	}
 	return &agent.FinalReadinessError{Attempts: 1, Reason: "missing verification", Missing: []string{"verification"}}
 }
 
-func TestGoalReadinessFailureContinuesThenPausesOnTurnBudget(t *testing.T) {
+func TestGoalReadinessFailureContinuesThenPausesOnSpendBudget(t *testing.T) {
 	runner := &deliveryScopeErrorRunner{}
 	executor := agent.New(nil, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
-	c := New(Options{Runner: runner, Executor: executor})
+	// Readiness failures are absorbed and retried forever; only a configured
+	// budget ends an unattended loop.
+	c := New(Options{Runner: runner, Executor: executor, GoalTokenBudget: 200})
+	runner.usage = c.goalUsageTee
 	c.SetGoal("ship the integration")
 
 	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "start", "start", "")
 	if err != nil {
-		t.Fatalf("run err = %v, want the loop to absorb FinalReadinessError and pause on the turn budget", err)
+		t.Fatalf("run err = %v, want the loop to absorb FinalReadinessError and pause on its budget", err)
 	}
 	// The FSM absorbs the readiness failure and continues with the missing
-	// requirements; cross-turn no-progress remains observational and the outer
-	// continuation backstop eventually pauses the goal.
+	// requirements; cross-turn no-progress remains observational and the spend
+	// budget eventually pauses the goal.
 	if got := c.GoalStatus(); got != GoalStatusBlocked {
-		t.Fatalf("GoalStatus = %q, want blocked (turn-budget pause)", got)
+		t.Fatalf("GoalStatus = %q, want blocked (spend-budget pause)", got)
 	}
-	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetTurns {
-		t.Fatalf("stop cause = %q, want %q", rt.StopCause, stopCauseBudgetTurns)
+	if rt := c.GoalRuntime(); rt.StopCause != stopCauseBudgetSpend {
+		t.Fatalf("stop cause = %q, want %q", rt.StopCause, stopCauseBudgetSpend)
 	}
 	if len(runner.scopes) < 2 || runner.scopes[0].ID == "" || runner.scopes[0].TaskText != "ship the integration" {
 		t.Fatalf("delivery scopes = %+v, want scoped continuation turns", runner.scopes)

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "test-file-size": 69921
+    "test-file-size": 69938
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -675,8 +675,8 @@
     "internal/boot/boot.go": {
       "complexity": 298,
       "essay": 102,
-      "file-size": 2239,
-      "function-size": 1867,
+      "file-size": 2241,
+      "function-size": 1869,
       "narrative": 3
     },
     "internal/boot/boot_test.go": {
@@ -977,7 +977,7 @@
     },
     "internal/config/config.go": {
       "essay": 54,
-      "file-size": 1508,
+      "file-size": 1510,
       "narrative": 2
     },
     "internal/config/credentials.go": {
@@ -1072,13 +1072,13 @@
     "internal/control/controller.go": {
       "complexity": 10,
       "essay": 162,
-      "file-size": 5463,
-      "function-size": 75,
+      "file-size": 5469,
+      "function-size": 78,
       "narrative": 4
     },
     "internal/control/controller_test.go": {
       "essay": 10,
-      "test-file-size": 4608
+      "test-file-size": 4610
     },
     "internal/control/errmsg.go": {
       "essay": 2
@@ -1097,11 +1097,11 @@
     "internal/control/goal.go": {
       "complexity": 3,
       "essay": 11,
-      "file-size": 274,
+      "file-size": 277,
       "function-size": 1
     },
     "internal/control/goal_test.go": {
-      "test-file-size": 243
+      "test-file-size": 249
     },
     "internal/control/goalusage.go": {
       "essay": 2
@@ -1171,7 +1171,7 @@
     },
     "internal/control/turn_orchestrator_test.go": {
       "essay": 1,
-      "test-file-size": 429
+      "test-file-size": 439
     },
     "internal/control/yolo_test.go": {
       "test-file-size": 473


### PR DESCRIPTION
#8357 is merged; this stands alone on `main-v2`. Step 2 of unifying Goal's boundaries: the cross-Run turn quota goes, an optional token budget takes its place.

## What was wrong with 10/20/40

A Goal was bounded by 10, 20 or 40 turns, chosen by classifying its own text as simple / write / research. That is **two guesses stacked**: guess how big the task is, then stop it on the guess.

It was also the only axis, which makes it wrong in both directions:

- a **slow, expensive** loop (ten-minute turns, large context) never came close to 10 turns
- a **fast, empty** one (model answering instantly without working) hit it for no reason

## What Codex does

This feature follows Codex's `/goal` (internally the "Ralph Loop"). Its stop conditions are success / pause / clear / interruption / **budget limit** / a blocker needing the user. The budget is **tokens**, it is **optional**, and reaching it produces a summary and a `budget_limited` state rather than ending the goal. There is no iteration cap — the `-n 10` in `ralphloop.sh` is a third-party wrapper, not Codex.

This change matches that shape.

## The design

```toml
[agent]
goal_token_budget = 20000000   # cumulative tokens across the whole goal
```

Off unless set. Reaching it yields one summary and a resumable `budget_spend` pause.

**Why tokens.** They are the axis that generalizes: a slow expensive loop accumulates them, and so does a fast empty one, because every iteration pays for at least one prompt plus one evaluator call. Wall clock catches only the first. Money is not portable across models (see #8340).

**Why this is not #7725 again.** That PR removed token limits because they were enforced as *class-derived ceilings at every provider boundary*, conflating cumulative autonomous-work safety with per-request context size — a Goal could pause before its first request. This is the cumulative check at the FSM's continuation decision, which is the point where the loop actually decides to keep going. The `tokensUsed` counter it needs has been accumulating and persisting across Runs the whole time.

**Resume.** A spend pause resumes with its budget granted again rather than returning into an exhausted one. openai/codex#34215 is the same situation without that.

## What still stops a Goal

Everything that reads content rather than counting it: completion, a blocked report, a failed or uncertain evaluator (fail-closed), and the structural no-progress loop.

`TurnsLimit` stays in the sidecar and the runtime view for compatibility and is never set by the current runtime. `GoalRuntimeView` reports the real `TokensLimit` again — #7725 had pinned that field to a literal `0`.

## Verification

- `TestGoalStartsWithNoTurnQuota` — a fresh Goal carries no ceiling of either kind
- `TestGoalTokenBudgetPausesAndResumes` — pauses on `budget_spend` with the budget actually reached, then resumes with a fresh budget
- `TestTurnCountNeverPausesAndResumeClearsLegacyBudget` — 3x the old quota in turns never pauses; an old sidecar's quota is cleared on resume rather than extended
- Legacy sidecar tests now assert the quota is *not* re-derived on restore or migration
- Tests that used the quota as their termination condition now configure a budget and bill usage against it. **Several looped forever without that** — which is the design, stated plainly: an unattended loop with nothing configured has no host-owned stop.

`go test -count=1 ./internal/control/ ./internal/agent/ ./internal/boot/ ./internal/config/` green; `golangci-lint run ./...` 0 issues; repolint clean.

## Baseline diff

Six entries grow by 2-10 lines each (`boot.go`, `config.go`, `controller.go`, `goal.go`, and two test files) for the new config key, the controller field, the FSM gate, and the tests. All are files already far past the 800-line ceiling. Two `essay` findings an earlier draft introduced were fixed by rewriting the comments to the one-line field standard rather than recorded.

Cache-impact: none - adds a config key read at construction and a counter comparison in the Goal FSM. No prompt, tool schema, or provider request field changes.
Cache-guard: existing - `go test ./internal/agent/` covers the cache-hit e2e suites, green unchanged.
System-prompt-review: needed - adds one `[agent]` key and touches `internal/config/` and `internal/boot/`. The key feeds the Goal FSM only and never reaches the system-prompt prefix; requesting review from @esengine as config owner.
Documentation-impact: updated - `docs/GUIDE.md` and `docs/GOAL_ENFORCEMENT.zh-CN.md` replace the 10/20/40 turn budget and the 16-round Run boundary with the opt-in token budget, and restate the full list of what stops a Goal.