### PR TITLE
fix(agent): rebind projection lineage key across upgrade/model switch / 升级或切换模型后重绑投影 lineage key

### DIFF
--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -112,6 +112,21 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 		st.BlockedInputHash != "" ||
 		(st.LastReceipt != nil && (st.LastReceipt.Status == "blocked" || st.LastReceipt.Status == "failed" ||
 			st.LastReceipt.Status == "applied"))
+	if key != "" && !keyOK {
+		// Lineage key changed (upgrade, model/workspace switch). The projection
+		// body is provider-neutral; when it still matches the canonical covered
+		// prefix, rebind it to the current key instead of dropping back to the
+		// full canonical transcript. Content mismatches (edited prefix, missing
+		// prefix hash) still fail closed and are rebuilt.
+		var msgs []provider.Message
+		var version uint64
+		if a.session != nil {
+			msgs, version = a.session.snapshotMessagesVersion()
+		}
+		if projectionContentValid(st, msgs, version) {
+			normalized, keyOK = key, true
+		}
+	}
 	if (key != "" && !keyOK) || !hasMaintenanceSignal {
 		a.compactionState = CompactionState{}
 		a.checkpointState = "none"

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -315,15 +315,28 @@ func projectionValid(st CompactionState, msgs []provider.Message, transcriptVers
 	if len(st.Projection.Messages) == 0 {
 		return false
 	}
-	n := st.Projection.CoveredCount
-	if n <= 0 || n > len(msgs) {
-		return false
-	}
 	// Current lineage known: stored key must match (legacy native suffix ok).
 	if cacheKey != "" {
 		if _, ok := lineageKeyCompatible(st.PromptCacheKey, cacheKey); !ok {
 			return false
 		}
+	}
+	return projectionContentValid(st, msgs, transcriptVersion)
+}
+
+// projectionContentValid reports whether st's projection body still matches the
+// canonical transcript, independent of provider/model lineage. It is the
+// key-agnostic half of projectionValid: LoadProjectionSidecar uses it to decide
+// whether a sidecar whose lineage key changed (upgrade, model/workspace switch)
+// can be rebound to the current key instead of dropping back to the full
+// canonical transcript.
+func projectionContentValid(st CompactionState, msgs []provider.Message, transcriptVersion uint64) bool {
+	if len(st.Projection.Messages) == 0 {
+		return false
+	}
+	n := st.Projection.CoveredCount
+	if n <= 0 || n > len(msgs) {
+		return false
 	}
 	// Prefix hash is required; legacy sidecars without it are rebuilt.
 	if st.Projection.CoveredPrefixHash == "" {

--- a/internal/agent/projection_valid_test.go
+++ b/internal/agent/projection_valid_test.go
@@ -130,17 +130,72 @@ func TestCoveredPrefixHashIncludesProviderVisibleFields(t *testing.T) {
 	}
 }
 
+func TestLoadProjectionSidecarRebindsMatchingContentAcrossLineage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+	}
+	hash := coveredPrefixHash(msgs, 2)
+	if err := SaveCompactionState(path, CompactionState{
+		SchemaVersion:     compactionStateSchemaV1,
+		PromptCacheKey:    "ws|s|other-model",
+		TranscriptVersion: 1,
+		Projection: ContextProjection{
+			Messages:          []provider.Message{{Role: provider.RoleSystem, Content: "sys summary"}},
+			CoveredCount:      2,
+			CoveredPrefixHash: hash,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "task"})
+	a := New(nil, nil, sess, Options{
+		SessionPath: path,
+		WorkspaceID: "ws",
+		ModelRef:    "this-model",
+	}, event.Discard)
+	// New() already called LoadProjectionSidecar; the projection body matches
+	// the canonical covered prefix, so it must be rebound to the current key
+	// instead of being dropped (upgrade / model-switch path).
+	if len(a.compactionState.Projection.Messages) == 0 {
+		t.Fatal("matching projection body was dropped on lineage change")
+	}
+	wantKey := promptCacheKey("ws", BranchID(path), "this-model")
+	if a.compactionState.PromptCacheKey != wantKey {
+		t.Fatalf("PromptCacheKey = %q, want %q", a.compactionState.PromptCacheKey, wantKey)
+	}
+	if a.checkpointState != "restored" {
+		t.Fatalf("checkpointState = %q, want restored", a.checkpointState)
+	}
+	// The rebind must be persisted so the next launch does not re-downgrade.
+	disk, ok, err := LoadCompactionState(path)
+	if err != nil || !ok {
+		t.Fatalf("sidecar should remain on disk: ok=%v err=%v", ok, err)
+	}
+	if disk.PromptCacheKey != wantKey {
+		t.Fatalf("persisted PromptCacheKey = %q, want %q", disk.PromptCacheKey, wantKey)
+	}
+}
+
 func TestLoadProjectionSidecarDropsForeignCacheKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "s.jsonl")
 	msgs := []provider.Message{{Role: provider.RoleSystem, Content: "sys"}}
+	// The covered prefix hash is computed from different content than the
+	// session actually holds, so content validation fails even though the
+	// stored key differs only by model: a lineage change must not resurrect
+	// a projection whose canonical prefix no longer matches.
+	foreign := []provider.Message{{Role: provider.RoleSystem, Content: "sys-old"}}
 	if err := SaveCompactionState(path, CompactionState{
 		SchemaVersion:  compactionStateSchemaV1,
 		PromptCacheKey: "ws|s|other-model",
 		Projection: ContextProjection{
 			Messages:          msgs,
 			CoveredCount:      1,
-			CoveredPrefixHash: coveredPrefixHash(msgs, 1),
+			CoveredPrefixHash: coveredPrefixHash(foreign, 1),
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -150,11 +205,11 @@ func TestLoadProjectionSidecarDropsForeignCacheKey(t *testing.T) {
 		WorkspaceID: "ws",
 		ModelRef:    "this-model",
 	}, event.Discard)
-	// New() already called LoadProjectionSidecar; foreign key must be dropped.
+	// New() already called LoadProjectionSidecar; mismatched content must drop
+	// the projection body and keep the sidecar file for the other model.
 	if len(a.compactionState.Projection.Messages) != 0 {
 		t.Fatalf("foreign projection loaded: %+v", a.compactionState.Projection)
 	}
-	// Sidecar file remains for the other model.
 	if _, ok, err := LoadCompactionState(path); err != nil || !ok {
 		t.Fatalf("sidecar should remain on disk: ok=%v err=%v", ok, err)
 	}


### PR DESCRIPTION
## What breaks today

`LoadProjectionSidecar` (internal/agent/preflight.go) dropped the projection body whenever the stored `PromptCacheKey` did not match the current `workspaceID|session|modelRef` lineage, falling back to the full canonical transcript. Any of the following then made the context gauge show the complete history while the provider request only sent the projected view:

- opening a session created by an older release (lineage key differs across versions),
- switching the working model (the key embeds `modelRef`),
- a workspace migration that changed `workspaceID`.

The concrete symptom is the gauge reading ~971K for a session whose last compaction produced an 83K projection and whose real request prompt is ~170K, plus a full-price compaction on resume. This is the cross-version variant of the projection invalidation reported in #8111 (Bug 1, model switch), which upstream left unfixed.

## Fix

Split `projectionValid` into:

- `projectionContentValid` — key-agnostic content check: covered prefix hash, transcript version, append-only growth;
- `projectionValid` — keeps the fail-closed lineage gate for callers that must not reuse a foreign projection.

On load, when the lineage key changed but the projection body still matches the canonical covered prefix (`coveredPrefixHash` + `transcriptVersion`), rebind the sidecar to the current key and persist it, instead of dropping back to the full canonical transcript. Content mismatches (edited prefix, missing prefix hash) still fail closed and are rebuilt; blocked/failed receipts and the sidecar file remain untouched on disk.

The rebind is conservative compared to "never gate the key": a projection whose canonical prefix no longer matches is still discarded.

## Verification

- `go build ./internal/agent/ ./internal/control/`
- `go test ./internal/agent/` (incl. new `TestLoadProjectionSidecarRebindsMatchingContentAcrossLineage`, reworked `TestLoadProjectionSidecarDropsForeignCacheKey`)
- `go test ./internal/control/ -p 1`
- `gofmt -l` clean on changed files, `go vet ./internal/agent/` clean, `git diff --check` clean

Documentation-impact: none - this fixes the internal projection sidecar loading path so upgraded/remodeled sessions keep using their valid projection; no configuration, command, or documented behavior changes.
Cache-impact: none - the projection body and prompt prefix bytes are unchanged; a rebind only rewrites the lineage key, and the removed fallback-to-canonical path was a cache break by construction.
Cache-guard: go test ./internal/agent/ -run 'ProjectionValid|LoadProjectionSidecar|CoveredPrefixHash' covers rebind, drop, and fail-closed cases.

Fixes #8111

---

## 修复内容

`LoadProjectionSidecar`（internal/agent/preflight.go）在存储的 `PromptCacheKey` 与当前 `workspaceID|session|modelRef` lineage 不匹配时会丢弃投影 body、回退完整 canonical 转录。以下情况都会触发：

- 打开旧版本创建的会话（跨版本 lineage key 不同），
- 切换工作模型（key 内嵌 `modelRef`），
- workspace 迁移导致 `workspaceID` 变化。

具体症状：会话压缩后投影仅 83K、真实请求 prompt 约 170K，但上下文 gauge 显示 ~971K（完整历史），且 resume 时触发一次全价压缩。这是 #8111（Bug 1：切换模型使投影失效，上游未修复）的跨版本变体。

## 修改方式

将 `projectionValid` 拆分为：

- `projectionContentValid` — 与 key 无关的内容校验：covered prefix hash、transcript version、append-only 增长；
- `projectionValid` — 保留 fail-closed 的 lineage gate（调用方不能复用它方投影时）。

加载时若 lineage key 变化但投影 body 仍与 canonical covered 前缀匹配（`coveredPrefixHash` + `transcriptVersion`），则把 sidecar 重绑到当前 key 并持久化，不再回退完整 canonical。内容不匹配（前缀被编辑、缺少 prefix hash）仍然 fail-closed 丢弃重建；blocked/failed receipts 与磁盘 sidecar 文件保持不变。

与"完全不 gate key"的方案相比，本修复更保守：canonical 前缀不再匹配的投影仍会被丢弃。

## 验证

- `go build ./internal/agent/ ./internal/control/`
- `go test ./internal/agent/`（含新增 `TestLoadProjectionSidecarRebindsMatchingContentAcrossLineage`、改造 `TestLoadProjectionSidecarDropsForeignCacheKey`）
- `go test ./internal/control/ -p 1`
- 改动文件 `gofmt -l` 干净、`go vet ./internal/agent/` 干净、`git diff --check` 干净

Fixes #8111