### PR TITLE
perf(frontend): coalesce tool progress and skip background-tab re-renders

### DIFF
--- a/desktop/frontend/src/__tests__/wire-event-batching.test.ts
+++ b/desktop/frontend/src/__tests__/wire-event-batching.test.ts
@@ -1,0 +1,66 @@
+// Run: tsx src/__tests__/wire-event-batching.test.ts
+//
+// Multi-session rendering cost: pure progress deltas (tool output, subagent
+// preview) must classify as frame-coalescable, state/result events must stay
+// immediate, and a background tab's streaming delta must not bump the full
+// controller tree — switching tabs while other sessions run must not starve on
+// re-renders driven by the other sessions' progress.
+
+import { classifyWireEvent, flushOnTypeSwitch, isBackgroundStreamingAction } from "../lib/wireEventBatching";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+// --- classifyWireEvent routes the three dispatch budgets ---
+{
+  eq(classifyWireEvent({ kind: "text" }), "text", "text deltas keep their existing frame batch");
+  eq(classifyWireEvent({ kind: "reasoning" }), "text", "reasoning deltas share the text batch");
+  eq(classifyWireEvent({ kind: "tool_progress" }), "progress", "tool progress coalesces per frame");
+  eq(classifyWireEvent({ kind: "subagent_progress" }), "progress", "subagent progress coalesces per frame");
+  eq(classifyWireEvent({ kind: "tool_result" }), "immediate", "tool result stays immediate");
+  eq(classifyWireEvent({ kind: "usage" }), "immediate", "usage stays immediate");
+  eq(classifyWireEvent({ kind: "notice" }), "immediate", "notice stays immediate");
+  eq(classifyWireEvent({ kind: "turn_done" }), "immediate", "turn_done stays immediate");
+}
+
+// --- isBackgroundStreamingAction: only pure deltas may skip the re-render ---
+{
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "tool_progress" } }), true, "background tool progress skips the bump");
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "subagent_progress" } }), true, "background subagent progress skips the bump");
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "text" } }), true, "background text delta skips the bump");
+  eq(isBackgroundStreamingAction({ type: "stream_batch", segments: [] } as never), true, "stream_batch action skips the bump");
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "tool_result" } }), false, "tool result still re-renders");
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "turn_done" } }), false, "turn_done still re-renders");
+  eq(isBackgroundStreamingAction({ type: "event", e: { kind: "notice" } }), false, "notice still re-renders");
+  eq(isBackgroundStreamingAction({ type: "context", context: {} } as never), false, "non-event actions still re-render");
+}
+
+// --- flushOnTypeSwitch: batching must not invert wire arrival order ---
+// tool_progress → text → tool_result must apply progress before text; the
+// kind switch drains the other queue so causal order survives coalescing.
+{
+  const seq: string[] = [];
+  const text = { drain: () => seq.push("text") };
+  const progress = { drain: () => seq.push("progress") };
+  flushOnTypeSwitch("text", text, progress);
+  eq(seq.join(","), "progress", "text event flushes queued progress first");
+  seq.length = 0;
+  flushOnTypeSwitch("progress", text, progress);
+  eq(seq.join(","), "text", "progress event flushes queued text first");
+  seq.length = 0;
+  flushOnTypeSwitch("immediate", text, progress);
+  eq(seq.join(","), "text,progress", "immediate event flushes both queues");
+}
+
+process.stdout.write(`\n${failed === 0 ? "ALL PASS" : `${failed} FAILED`} (${passed} passed)\n`);
+process.exit(failed === 0 ? 0 : 1);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1,6 +1,5 @@
-// useController is the frontend's state machine over the agent event stream. Per-tab
-// state preserves background streaming output, tools, and approvals across tab switches;
-// components render only the active tab's state.
+// useController is the frontend's state machine over the agent event stream,
+// keeping per-tab streaming, tool, and approval state across tab switches.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { asArray } from "./array";
@@ -11,9 +10,9 @@ import { formatInboxCancelError, inboxSteerQueuedMessage } from "./inboxError";
 import { formatContextMaintenanceNotice, isNewMaintenanceOperation, rememberMaintenanceOperation } from "./contextMaintenanceTypes";
 import { formatGuardianAssessmentNotice } from "./guardianEvents";
 import { invalidateSharedQuery } from "./queryCoalesce";
-import { createRafBatch } from "./rafBatch";
+import { classifyWireEvent, createProgressBatch, createTextBatch, flushOnTypeSwitch, shouldSkipBackgroundBump } from "./wireEventBatching";
 import { aliasActivationRequest, noteActivationRequested, noteActivationSettled, noteActivationStarted } from "./sessionDiagnostics";
-import { applyLiveSegments, coalesceStreamDeltas, completeLiveReasoning, type StreamDeltaEntry, type StreamSegment } from "./streamDeltaBatch";
+import { applyLiveSegments, completeLiveReasoning, type StreamSegment } from "./streamDeltaBatch";
 import { getTranscriptStore } from "./transcriptStore";
 import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
@@ -2673,10 +2672,11 @@ export function useController() {
         prev.pendingUser === next.pendingUser &&
         prev.retry === next.retry;
       // Text/reasoning-only deltas only update the live stream — which the
-      // frontend reads through its own subscription — so they must not bump the
-      // full controller tree (the run-strip TPS estimate subscribes to the live
-      // stream directly and updates itself).
-      if (!streamDeltaOnly) bump();
+      // frontend reads through its own subscription — so they must not bump
+      // the full controller tree (the TPS estimate subscribes to the stream).
+      if (!streamDeltaOnly && !shouldSkipBackgroundBump(tabId, activeTabIdRef.current, action)) {
+        bump();
+      }
     }
   }, [bump, notifyLiveListeners]);
   const clearBalanceForTab = useCallback((tabId: string): void => {
@@ -3357,10 +3357,8 @@ export function useController() {
   }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime]);
 
   useEffect(() => {
-    const textBatch = createRafBatch<StreamDeltaEntry>((batch) => {
-      uiPerfTracker.onStreamDispatch();
-      for (const b of coalesceStreamDeltas(batch)) dispatchTo(b.tabId, { type: "stream_batch", segments: b.segments });
-    });
+    const textBatch = createTextBatch(dispatchTo);
+    const progressBatch = createProgressBatch(dispatchTo);
     const off = onEvent((e) => {
       // Untagged compatibility events belong to the tab that the backend has
       // actually activated, not the frontend's optimistic selection. During a
@@ -3375,11 +3373,13 @@ export function useController() {
       }
       uiPerfTracker.onWireEvent(targetTabId, e.kind);
       if (TURN_ACTIVITY_KINDS.has(e.kind)) lastTurnActivityAtByTab.current.set(targetTabId, Date.now());
-      if (e.kind === "text" || e.kind === "reasoning") {
+      const batchKind = flushOnTypeSwitch(classifyWireEvent(e), textBatch, progressBatch);
+      if (batchKind === "text") {
         if (e.submissionId) dispatchTo(targetTabId, { type: "send_confirmed", submissionId: e.submissionId });
         textBatch.push({ tabId: targetTabId, e });
+      } else if (batchKind === "progress") {
+        progressBatch.push({ tabId: targetTabId, e });
       } else {
-        textBatch.drain();
         dispatchTo(targetTabId, { type: "event", e });
       }
       if (e.kind === "turn_done" || e.kind === "context_maintenance") {

--- a/desktop/frontend/src/lib/wireEventBatching.ts
+++ b/desktop/frontend/src/lib/wireEventBatching.ts
@@ -1,0 +1,73 @@
+// Wire-event batching for the controller's per-event render cost. With several
+// sessions running in parallel, every tool chunk / progress tick used to force
+// a full App re-render, so switching tabs starved on the main thread. Text and
+// pure-progress deltas coalesce into the animation-frame budget instead, and a
+// background tab's streaming deltas update only its own state.
+
+import { createRafBatch } from "./rafBatch";
+import { coalesceStreamDeltas, type StreamDeltaEntry, type StreamSegment } from "./streamDeltaBatch";
+import type { WireEvent } from "./types";
+import { uiPerfTracker } from "./uiPerf";
+
+// createTextBatch coalesces text/reasoning deltas into one dispatch pass per
+// animation frame.
+export function createTextBatch(dispatchTo: (tabId: string, action: { type: "stream_batch"; segments: StreamSegment[] }) => void) {
+  return createRafBatch<StreamDeltaEntry>((batch) => {
+    uiPerfTracker.onStreamDispatch();
+    for (const b of coalesceStreamDeltas(batch)) dispatchTo(b.tabId, { type: "stream_batch", segments: b.segments });
+  });
+}
+
+// createProgressBatch coalesces pure tool/subagent progress into the same
+// animation-frame budget as text: a frame's worth of chunks dispatches once
+// instead of forcing one full-tree re-render per chunk.
+export function createProgressBatch(dispatchTo: (tabId: string, action: { type: "event"; e: WireEvent }) => void) {
+  return createRafBatch<{ tabId: string; e: WireEvent }>((batch) => {
+    for (const { tabId, e } of batch) dispatchTo(tabId, { type: "event", e });
+  });
+}
+
+// flushOnTypeSwitch flushes the other coalescer when the wire kind changes so
+// batched progress/text keep their wire arrival order; immediate events flush
+// both before the caller applies them. Returns the kind for branch routing.
+export function flushOnTypeSwitch(kind: WireEventBatchKind, textBatch: { drain(): void }, progressBatch: { drain(): void }): WireEventBatchKind {
+  if (kind === "text") progressBatch.drain();
+  else if (kind === "progress") textBatch.drain();
+  else {
+    textBatch.drain();
+    progressBatch.drain();
+  }
+  return kind;
+}
+
+// shouldSkipBackgroundBump reports whether a pure streaming action on a
+// background tab may skip the full controller re-render: the tab's own state
+// updates and renders when it becomes active again.
+export function shouldSkipBackgroundBump(tabId: string, activeTabId: string | null | undefined, action: { type: string; e?: { kind: string } }): boolean {
+  return tabId !== activeTabId && isBackgroundStreamingAction(action);
+}
+
+// WireEventBatchKind classifies a wire event for dispatch routing:
+// - "text"      — token deltas (already coalesced by textBatch)
+// - "progress"  — pure tool/subagent progress, safe to coalesce into the frame
+// - "immediate" — state/notice/result events, must apply right away to keep
+//                 causal ordering (e.g. tool_result after tool_progress)
+export type WireEventBatchKind = "text" | "progress" | "immediate";
+
+export function classifyWireEvent(e: { kind: string }): WireEventBatchKind {
+  if (e.kind === "text" || e.kind === "reasoning") return "text";
+  if (e.kind === "tool_progress" || e.kind === "subagent_progress") return "progress";
+  return "immediate";
+}
+
+// isBackgroundStreamingAction reports whether an action is a pure streaming
+// delta (text/reasoning/progress), which a background tab may apply to its own
+// state without forcing the full controller re-render — the tab re-renders
+// when it becomes active again.
+export function isBackgroundStreamingAction(action: {
+  type: string;
+  e?: { kind: string };
+}): boolean {
+  if (action.type === "stream_batch") return true;
+  return action.type === "event" && classifyWireEvent(action.e ?? { kind: "" }) !== "immediate";
+}


### PR DESCRIPTION
## Summary

**现状**：多个会话并行运行时切换会话特别卡（macOS 实测）。根因：每个 wire 事件都触发 App 全树重渲染——`tool_progress`/`subagent_progress`/`usage` 等事件**每个到达都 `bump()`**（`useController.ts` dispatchTo），而工具进度**每个输出 chunk 发一个事件**（bash 每 chunk ToolProgress）。N 个任务并行 = 每帧事件 ×N 个全树重建，切 tab 的 hydrate 首帧/点击响应全部被挤到主线程后面。

**本 PR**：
1. **后台 tab 门控**：纯流式事件（text/reasoning/tool_progress/subagent_progress）落在非活动 tab 时只更新该 tab 自己的 state，不触发全树重渲染（该 tab 变活动时自然渲染）——消灭 N-1 个后台任务的事件渲染成本
2. **进度帧合并**：`tool_progress`/`subagent_progress` 并入 rAF 帧批（仿既有 `textBatch`），一帧的 chunk 一次 dispatch，React 18 自动批处理 → 每帧 1 次渲染而非每 chunk
3. 因果顺序保持：`tool_result`/`notice`/`turn_done` 等状态类事件仍即时 dispatch（先 drain 两批再应用）

## Issues

（无关联 issue；macOS 本机真实使用发现 + 代码级机制验证）

## Verification

- 新增 `wire-event-batching.test.ts`（16 断言）：事件分类（text/progress/immediate 三档）、后台流式判定（progress/text/stream_batch → 不 bump；tool_result/turn_done/notice/context → 仍 bump）
- 既有 `stream-delta-batch`（20）/`subagent-progress`（46）/`use-controller-stream-progress`（85）全过
- `tsc --noEmit` 通过
- 全量 `run-tests.mjs`：仅 `markdown-worker-client` 失败（Node 24 `ErrorEvent` 环境缺失，与本改动无关——该文件不引用改动路径）

## Documentation impact

Documentation-impact: none - 纯前端渲染调度优化，无用户可见界面/行为变化（事件仍逐帧可见，仅合并到帧内）。

## Cache impact

Cache-impact: none - 前端渲染层改动，不触及 provider 请求、系统提示词、记忆前缀或工具 schema。