### PR TITLE
fix(agent): inherit context projection across recovery forks / 恢复分支继承上下文投影（与 #8390 共同解决新旧版本会话兼容）

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -804,6 +804,7 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 			return RecoveryBranchInfo{}, digestErr
 		}
 		if bytes.Equal(existingDigest[:], digest[:]) {
+			s.inheritParentProjection(originalPath, recoveryPath, msgs, version)
 			meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, recoveryDepth)
 			if err != nil {
 				return RecoveryBranchInfo{}, err
@@ -833,6 +834,7 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 	if err := writeSessionMessages(recoveryPath, msgs); err != nil {
 		return RecoveryBranchInfo{}, err
 	}
+	s.inheritParentProjection(originalPath, recoveryPath, msgs, version)
 	meta, err := s.saveRecoveryBranchMeta(recoveryPath, opts, preview, turns, digestText, recoveryDepth)
 	if err != nil {
 		return RecoveryBranchInfo{}, err
@@ -847,6 +849,41 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 	}
 	s.markPersisted(recoveryPath, digest, version, meta.Revision, rewriteVersion)
 	return RecoveryBranchInfo{Path: recoveryPath, Digest: digestText, Meta: meta, Preview: preview, Turns: turns}, nil
+}
+
+// inheritParentProjection copies a valid context projection from the parent
+// session to the recovery fork. Compaction only ever writes the sidecar and
+// never rewrites the canonical transcript, so a fork produced from this
+// in-memory snapshot covers the same prefix the projection was built on.
+// Carrying the projection over keeps the model view compressed across the
+// fork instead of snapping back to the full canonical transcript, which would
+// re-trigger a full-price compaction on the fork and cascade into the
+// compact-recover-compact loop. Best-effort: a missing/invalid parent
+// projection or a sidecar write failure leaves the fork uncompressed but does
+// not fail the recovery itself. A fork that already has a sidecar (a prior
+// inheritance that was already rebound) is left untouched.
+func (s *Session) inheritParentProjection(originalPath, recoveryPath string, msgs []provider.Message, version uint64) {
+	if _, ok, err := LoadCompactionState(recoveryPath); err == nil && ok {
+		return
+	}
+	st, ok, err := LoadCompactionState(originalPath)
+	if err != nil || !ok {
+		return
+	}
+	// Content check, independent of the projection's lineage key: the covered
+	// prefix hash must still match the fork's transcript and the projection
+	// must cover a valid prefix (append-only growth past the covered count is
+	// fine; edited prefixes or overruns fail closed and rebuild on load).
+	n := st.Projection.CoveredCount
+	if len(st.Projection.Messages) == 0 || n <= 0 || n > len(msgs) ||
+		st.Projection.CoveredPrefixHash == "" ||
+		coveredPrefixHash(msgs, n) != st.Projection.CoveredPrefixHash {
+		return
+	}
+	if err := SaveCompactionState(recoveryPath, st); err != nil {
+		slog.Warn("session: recovery branch did not inherit context projection",
+			"path", recoveryPath, "err", err)
+	}
 }
 
 func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions, preview string, turns int, digest string, depth int) (BranchMeta, error) {

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -2744,3 +2744,119 @@ func TestReconcileOverlongMigratesDiagnosticSidecars(t *testing.T) {
 		}
 	}
 }
+func TestSaveRecoveryBranchInheritsValidProjection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// Parent session on disk: a compressed session whose projection sidecar
+	// covers the first messages of the canonical transcript.
+	parent := NewSession("sys")
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	parent.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := parent.Save(path); err != nil {
+		t.Fatalf("Save parent: %v", err)
+	}
+	parentMsgs, parentVersion := parent.snapshotMessagesVersion()
+	st := CompactionState{
+		SchemaVersion:     compactionStateSchemaCurrent,
+		TranscriptVersion: parentVersion,
+		PromptCacheKey:    promptCacheKey("ws", BranchID(path), "test/model"),
+		Projection: ContextProjection{
+			ProjectionVersion: 1,
+			CoveredCount:      2,
+			CoveredPrefixHash: coveredPrefixHash(parentMsgs, 2),
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "summary"},
+				{Role: provider.RoleAssistant, Content: "one"},
+			},
+		},
+	}
+	if err := SaveCompactionState(path, st); err != nil {
+		t.Fatalf("SaveCompactionState: %v", err)
+	}
+
+	// Stale in-memory session (diverged tail) triggers a recovery fork.
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local only"})
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+
+	// The fork must carry the parent's valid projection sidecar over, so the
+	// model view stays compressed after the fork instead of snapping back to
+	// the full canonical transcript.
+	got, ok, err := LoadCompactionState(info.Path)
+	if err != nil || !ok {
+		t.Fatalf("LoadCompactionState recovery ok=%v err=%v, want inherited sidecar", ok, err)
+	}
+	if got.Projection.CoveredCount != 2 || got.Projection.CoveredPrefixHash != st.Projection.CoveredPrefixHash {
+		t.Fatalf("recovery projection = %+v, want parent projection inherited", got.Projection)
+	}
+	recovered, err := LoadSession(info.Path)
+	if err != nil {
+		t.Fatalf("LoadSession recovery: %v", err)
+	}
+	// The inherited sidecar's covered prefix must still match the recovery
+	// transcript (the same content the fork was created from).
+	recoveredMsgs, _ := recovered.snapshotMessagesVersion()
+	if n := got.Projection.CoveredCount; n <= 0 || n > len(recoveredMsgs) ||
+		coveredPrefixHash(recoveredMsgs, n) != got.Projection.CoveredPrefixHash {
+		t.Fatalf("inherited projection does not match the recovery transcript")
+	}
+}
+
+func TestSaveRecoveryBranchSkipsInvalidProjection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	parent := NewSession("sys")
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	parent.Add(provider.Message{Role: provider.RoleAssistant, Content: "one"})
+	parent.Add(provider.Message{Role: provider.RoleUser, Content: "second"})
+	if err := parent.Save(path); err != nil {
+		t.Fatalf("Save parent: %v", err)
+	}
+	parentMsgs, parentVersion := parent.snapshotMessagesVersion()
+	// A stale projection whose covered prefix no longer matches (content was
+	// edited) must NOT be inherited.
+	st := CompactionState{
+		SchemaVersion:     compactionStateSchemaCurrent,
+		TranscriptVersion: parentVersion,
+		PromptCacheKey:    promptCacheKey("ws", BranchID(path), "test/model"),
+		Projection: ContextProjection{
+			ProjectionVersion: 1,
+			CoveredCount:      2,
+			CoveredPrefixHash: coveredPrefixHash(parentMsgs, 2),
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "summary"},
+				{Role: provider.RoleAssistant, Content: "one"},
+			},
+		},
+	}
+	if err := SaveCompactionState(path, st); err != nil {
+		t.Fatalf("SaveCompactionState: %v", err)
+	}
+	// Rewrite the canonical transcript so the covered prefix changes.
+	rewritten := parent.Snapshot()
+	rewritten[0] = provider.Message{Role: provider.RoleUser, Content: "edited"}
+	parent.Rewrite(rewritten, "test rewrite")
+	if err := parent.Save(path); err != nil {
+		t.Fatalf("Save rewritten parent: %v", err)
+	}
+
+	stale := NewSession("sys")
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "edited"})
+	stale.Add(provider.Message{Role: provider.RoleUser, Content: "local only"})
+	info, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	if _, ok, err := LoadCompactionState(info.Path); err != nil || ok {
+		t.Fatalf("LoadCompactionState recovery ok=%v err=%v, want no inherited sidecar", ok, err)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -4070,9 +4070,12 @@ func (c *Controller) commitRecoveredSession(originalPath, reason string, info ag
 	c.sessionPath = info.Path
 	c.guardianPath = guardian.PathFor(info.Path)
 	c.mu.Unlock()
-	// Recovery branch is a new lineage path; do not keep writing the original
-	// session's projection sidecar.
-	c.bindExecutorProjection(info.Path, false)
+	// Recovery branch is a new lineage path. Load its projection sidecar if the
+	// fork inherited one (saveRecoveryBranch carries a valid parent projection
+	// over), so the model view stays compressed across the fork instead of
+	// snapping back to the full canonical transcript and re-triggering a
+	// full-price compaction. A mismatched key is rebound to this path on load.
+	c.bindExecutorProjection(info.Path, true)
 	c.setActiveJobSession(info.Path)
 	c.rebindCheckpoints(info.Path)
 	c.transplantInFlightTurnMarker(originalPath, info.Path)


### PR DESCRIPTION
## What breaks today

A recovery fork (`SaveRecoveryBranch`) dumps the in-memory transcript to a new `*-recovery-*.jsonl` path and commits the session to it (`commitRecoveredSession`). The fork had **no projection sidecar of its own**, so after a context compaction the model view snapped back to the full canonical transcript. That re-triggered a full-price compaction, which conflicted again on save, which forked again — a compact-recover-compact loop (#8393) that burned tens of millions of cache-miss tokens per hour and accumulated recovery files without bound (125–822 files reported).

## Why this PR exists (cross-version session compatibility)

This PR is the second half of the **cross-version session compatibility** fix, together with #8390 (rebind projection lineage key across upgrade/model switch). Both keep old sessions usable after an upgrade without the "start a new session per version" workaround:

- **#8390** keeps a projection valid when its lineage key changed (upgrade / model switch / workspace migration) — same session path, same sidecar.
- **This PR** keeps the projection across a recovery fork (new path, inherited sidecar) — the loop that #8393 reports.

This PR is independent and applies cleanly on `main-v2` (it does not depend on #8390's code, only on the same fix direction).

## Fix

- `saveRecoveryBranch` inherits a valid parent projection onto the fork's sidecar. Compaction only ever writes the sidecar and never rewrites the canonical transcript, so the fork's covered prefix still matches. The content check is self-contained: covered prefix hash + valid covered count; append-only growth past the covered count is fine, edited prefixes or overruns fail closed and rebuild on load.
- `commitRecoveredSession` loads the inherited sidecar (`bindExecutorProjection(path, true)` instead of clearing it), so the model view stays compressed across the fork instead of snapping back to the full canonical transcript.
- The inherited sidecar's lineage key still names the parent path; it is rebound to the fork's path on load (see #8390 for that mechanism).
- Forks that already have a sidecar are left untouched; missing or invalid parent projections fail closed and the fork proceeds uncompressed.

## Verification

- New: `TestSaveRecoveryBranchInheritsValidProjection`, `TestSaveRecoveryBranchSkipsInvalidProjection`
- `go test ./internal/agent/` (incl. all existing recovery-branch tests) — green
- `go test ./internal/control/` — green
- `gofmt` / `go vet` clean, `git diff --check` clean

Documentation-impact: none - this fixes the recovery-fork projection inheritance so compacted sessions keep their compressed model view across forks; no configuration, command, or documented behavior changes.
Cache-impact: none - the inherited projection body and prompt prefix bytes are unchanged; the fork reuses the parent's projection instead of re-feeding the full canonical transcript, which was a cache break by construction.
Cache-guard: go test ./internal/agent/ -run 'SaveRecoveryBranch' covers inherit and fail-closed skip cases.

Fixes #8393

---

## 修复内容

恢复分支（`SaveRecoveryBranch`）把内存转录 dump 到新的 `*-recovery-*.jsonl` 路径，并通过 `commitRecoveredSession` 将会话切换到该路径。分支**没有自己的投影 sidecar**，因此上下文压缩后模型视图弹回完整 canonical 转录——再次触发全价压缩 → 保存再冲突 → 再 fork，形成压缩-恢复死循环（#8393）：每小时烧掉数千万 cache-miss token，恢复文件无限累积（报告 125–822 个）。

## 为什么有这个 PR（新旧版本会话兼容）

本 PR 是**跨版本会话兼容性**修复的后半部分，与 #8390（升级/切换模型后重绑投影 lineage key）共同解决：旧会话升级后无需再"每个版本新开会话"。

- **#8390**：投影 lineage key 变化（升级/换模型/workspace 迁移）时保持投影有效——同路径、同 sidecar。
- **本 PR**：跨恢复分支（新路径、继承 sidecar）保持投影——即 #8393 报告的死循环。

本 PR 独立，可直接应用在 `main-v2` 上（不依赖 #8390 的代码，仅方向一致）。

## 修改方式

- `saveRecoveryBranch` 将父会话有效投影继承到分支的 sidecar。压缩只写 sidecar、从不改写 canonical 转录，因此分支的 covered 前缀必然匹配。内容校验自包含：covered prefix hash + 有效 covered count；covered 之后的 append-only 增长允许，前缀被编辑或越界则 fail-closed，加载时重建。
- `commitRecoveredSession` 加载继承的 sidecar（`bindExecutorProjection(path, true)` 而非清空），模型视图跨分支保持压缩，不再弹回完整 canonical。
- 继承的 sidecar 的 lineage key 仍指向父路径；加载时重绑为分支路径的 key（机制见 #8390）。
- 已有分支保留已有 sidecar 不动；父投影缺失或无效时 fail-closed，分支以未压缩状态继续。

## 验证

- 新增：`TestSaveRecoveryBranchInheritsValidProjection`、`TestSaveRecoveryBranchSkipsInvalidProjection`
- `go test ./internal/agent/`（含全部既有 recovery-branch 测试）— 通过
- `go test ./internal/control/` — 通过
- `gofmt` / `go vet` 干净、`git diff --check` 干净

Fixes #8393