### PR TITLE
fix(evidence): score a read by the question it asked, not just its path

### DIFF
--- a/internal/agent/read_novelty_guard_test.go
+++ b/internal/agent/read_novelty_guard_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// grepNoveltyProbe mirrors the real grep tool's receipt shape: read-only,
+// path-scoped, and carrying its question in an argument rather than the path.
+type grepNoveltyProbe struct{}
+
+func (grepNoveltyProbe) Name() string        { return "grep" }
+func (grepNoveltyProbe) Description() string { return "search" }
+func (grepNoveltyProbe) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"},"path":{"type":"string"}},"required":["pattern"]}`)
+}
+func (grepNoveltyProbe) ReadOnly() bool { return true }
+func (grepNoveltyProbe) Execute(context.Context, json.RawMessage) (string, error) {
+	return "internal/agent/agent.go:120: match\n", nil
+}
+
+// runNoveltyRounds executes one call per round and returns the guard text each
+// round received, indexed from round 1.
+func runNoveltyRounds(t *testing.T, calls []provider.ToolCall) []string {
+	t.Helper()
+	reg := tool.NewRegistry()
+	reg.Add(readProbe{})
+	reg.Add(grepNoveltyProbe{})
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.resetTurnEvidence()
+
+	fired := make([]string, len(calls)+1)
+	for i, call := range calls {
+		batch := a.executeBatch(context.Background(), []provider.ToolCall{call})
+		if out := batch.results[0]; strings.Contains(out, "[progress guard]") {
+			fired[i+1] = out[strings.Index(out, "[progress guard]"):]
+		}
+	}
+	return fired
+}
+
+func assertNoStopTier(t *testing.T, fired []string, what string) {
+	t.Helper()
+	for round, text := range fired {
+		if strings.Contains(text, "produce your final answer now") {
+			t.Errorf("%s: round %d was told it produced no new evidence and ordered to answer", what, round)
+		}
+	}
+}
+
+// Ten searches of one package, a different pattern each time. Every round
+// returns information the turn did not have; keying novelty on the path alone
+// scored nine of them as repeats and stopped the turn at round 7.
+func TestGrepWithNewPatternsNoLongerTripsTheGuard(t *testing.T) {
+	var calls []provider.ToolCall
+	for i, p := range []string{"Compose", "Receipt", "Ledger", "progressGuard", "applyEBM", "Delivery", "ToolCall", "Session", "compact", "readiness"} {
+		calls = append(calls, provider.ToolCall{
+			ID: fmt.Sprintf("g%d", i), Name: "grep",
+			Arguments: fmt.Sprintf(`{"pattern":%q,"path":"internal/agent"}`, p),
+		})
+	}
+	assertNoStopTier(t, runNoveltyRounds(t, calls), "ten distinct searches")
+}
+
+// Paging through one long file: distinct windows, one path.
+func TestPagingOneFileNoLongerTripsTheGuard(t *testing.T) {
+	var calls []provider.ToolCall
+	for i := range 10 {
+		calls = append(calls, provider.ToolCall{
+			ID: fmt.Sprintf("r%d", i), Name: "read_file",
+			Arguments: fmt.Sprintf(`{"path":"internal/agent/agent.go","offset":%d,"limit":300}`, i*300),
+		})
+	}
+	assertNoStopTier(t, runNoveltyRounds(t, calls), "paging one file")
+}
+
+// The discriminator stays intact: re-asking the identical question is still a
+// repeat, and the ladder still escalates on it.
+func TestIdenticalReadsStillEscalate(t *testing.T) {
+	var calls []provider.ToolCall
+	for i := range progressStopStreak + 2 {
+		calls = append(calls, provider.ToolCall{
+			ID: fmt.Sprintf("s%d", i), Name: "read_file", Arguments: `{"path":"same.go"}`,
+		})
+	}
+	fired := runNoveltyRounds(t, calls)
+	stopped := false
+	for _, text := range fired {
+		if strings.Contains(text, "produce your final answer now") {
+			stopped = true
+		}
+	}
+	if !stopped {
+		t.Fatal("re-reading one path must still reach the stop tier")
+	}
+}

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -202,20 +202,38 @@ func (t *OutcomeTracker) scoreReceipt(r Receipt, s *OutcomeSample) {
 	case r.Success && (r.StepProof || r.TodoStep != nil || len(r.Todos) > 0):
 		// Bookkeeping moves no outcome dimension.
 	case r.Success && r.Read && r.OutputBytes > 0 && len(r.Paths) > 0:
+		fresh := 0
 		for _, path := range r.Paths {
 			if path == "" || t.readPaths[path] {
 				continue
 			}
 			t.readPaths[path] = true
-			s.Exploration++
+			fresh++
 		}
+		// A path already read can still answer a question never asked: a new
+		// grep pattern over the same package, the next window of a long file.
+		// Only an identical call is a repeat.
+		if newQuestion := t.noteQuestion(r); fresh == 0 && newQuestion {
+			fresh = 1
+		}
+		s.Exploration += fresh
 	case r.Success:
-		sig := r.ToolName + "\x00" + string(r.Args)
-		if !t.actions[sig] {
-			t.actions[sig] = true
+		if t.noteQuestion(r) {
 			s.Exploration++
 		}
 	}
+}
+
+// noteQuestion records the exact call this receipt came from and reports
+// whether the turn had not asked it before — the novelty key for anything whose
+// value lies in its arguments rather than its target.
+func (t *OutcomeTracker) noteQuestion(r Receipt) bool {
+	sig := r.ToolName + "\x00" + string(r.Args)
+	if t.actions[sig] {
+		return false
+	}
+	t.actions[sig] = true
+	return true
 }
 
 func (t *OutcomeTracker) scoreCommand(command string, r Receipt, s *OutcomeSample) {

--- a/internal/evidence/progress.go
+++ b/internal/evidence/progress.go
@@ -87,29 +87,46 @@ func (t *ProgressTracker) scoreReceipt(r Receipt) int {
 	case r.Success && (r.StepProof || r.TodoStep != nil || len(r.Todos) > 0):
 		return gainTaskProgress
 	case r.Success && r.Read && r.OutputBytes > 0 && len(r.Paths) > 0:
-		return t.scoreReads(r.Paths)
+		return t.scoreReads(r)
 	case r.Success:
 		// Unknown tools (MCP, custom): a first (tool, args) call is evidence;
 		// resending the identical call is not.
-		sig := r.ToolName + "\x00" + string(r.Args)
-		if t.actionSigs[sig] {
-			return 0
+		if t.noteQuestion(r) {
+			return gainNewAction
 		}
-		t.actionSigs[sig] = true
-		return gainNewAction
+		return 0
 	default:
 		return 0
 	}
 }
 
-func (t *ProgressTracker) scoreReads(paths []string) int {
+// noteQuestion records the exact call this receipt came from and reports
+// whether the turn had not asked it before. It is the novelty key for anything
+// whose value lies in its arguments rather than its target: a grep pattern, a
+// read window, an MCP call.
+func (t *ProgressTracker) noteQuestion(r Receipt) bool {
+	sig := r.ToolName + "\x00" + string(r.Args)
+	if t.actionSigs[sig] {
+		return false
+	}
+	t.actionSigs[sig] = true
+	return true
+}
+
+func (t *ProgressTracker) scoreReads(r Receipt) int {
 	gain := 0
-	for _, path := range paths {
+	for _, path := range r.Paths {
 		if path == "" || t.readPaths[path] {
 			continue
 		}
 		t.readPaths[path] = true
 		gain += gainNewRead
+	}
+	// A path already read can still answer a question never asked: a new grep
+	// pattern over the same package, the next window of a long file. Only an
+	// identical call is a repeat.
+	if newQuestion := t.noteQuestion(r); gain == 0 && newQuestion {
+		return gainNewRead
 	}
 	return gain
 }

--- a/internal/evidence/read_novelty_test.go
+++ b/internal/evidence/read_novelty_test.go
@@ -1,0 +1,81 @@
+package evidence
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func grepReceipt(pattern, path string) Receipt {
+	args := json.RawMessage(fmt.Sprintf(`{"pattern":%q,"path":%q}`, pattern, path))
+	r := ReceiptFromToolCall("grep", args, true, true)
+	r.OutputBytes = 64
+	return r
+}
+
+func windowReceipt(path string, offset int) Receipt {
+	args := json.RawMessage(fmt.Sprintf(`{"path":%q,"offset":%d,"limit":300}`, path, offset))
+	r := ReceiptFromToolCall("read_file", args, true, true)
+	r.OutputBytes = 64
+	return r
+}
+
+// Read novelty used to be keyed on the path alone, so the two most common
+// investigation moves — grepping one package for a second symbol, paging
+// through a long file — scored as repeats from the second round on, and a turn
+// doing exactly that was told it had produced no new evidence.
+func TestProgressTrackerScoresTheQuestionNotJustThePath(t *testing.T) {
+	tr := NewProgressTracker()
+
+	if got := tr.ScoreRound([]Receipt{grepReceipt("Compose", "internal/agent")}); got != gainNewRead {
+		t.Fatalf("first grep = %d, want %d", got, gainNewRead)
+	}
+	if got := tr.ScoreRound([]Receipt{grepReceipt("Receipt", "internal/agent")}); got != gainNewRead {
+		t.Fatalf("new pattern over a read path = %d, want %d", got, gainNewRead)
+	}
+	if got := tr.ScoreRound([]Receipt{grepReceipt("Receipt", "internal/agent")}); got != 0 {
+		t.Fatalf("identical grep = %d, want 0", got)
+	}
+
+	if got := tr.ScoreRound([]Receipt{windowReceipt("agent.go", 0)}); got != gainNewRead {
+		t.Fatalf("first window = %d, want %d", got, gainNewRead)
+	}
+	if got := tr.ScoreRound([]Receipt{windowReceipt("agent.go", 300)}); got != gainNewRead {
+		t.Fatalf("next window of the same file = %d, want %d", got, gainNewRead)
+	}
+	if got := tr.ScoreRound([]Receipt{windowReceipt("agent.go", 300)}); got != 0 {
+		t.Fatalf("identical window = %d, want 0", got)
+	}
+
+	// A first read of a new path still counts once, not twice. It needs a fresh
+	// tracker: past explorationRunLimit look-only rounds the run stops counting
+	// whatever it finds, which is the separate cliff this change does not touch.
+	fresh := NewProgressTracker()
+	first := readReceipt("new.go")
+	first.OutputBytes = 64
+	if got := fresh.ScoreRound([]Receipt{first}); got != gainNewRead {
+		t.Fatalf("new path = %d, want %d", got, gainNewRead)
+	}
+}
+
+// The shadow scorer keys novelty the same way, so the two never disagree about
+// what counts as a repeat.
+func TestOutcomeTrackerScoresTheQuestionNotJustThePath(t *testing.T) {
+	tr := NewOutcomeTracker()
+
+	if s := tr.ScoreRound([]Receipt{grepReceipt("Compose", "internal/agent")}); s.Exploration != 1 {
+		t.Fatalf("first grep = %+v, want exploration 1", s)
+	}
+	if s := tr.ScoreRound([]Receipt{grepReceipt("Receipt", "internal/agent")}); s.Exploration != 1 {
+		t.Fatalf("new pattern over a read path = %+v, want exploration 1", s)
+	}
+	if s := tr.ScoreRound([]Receipt{grepReceipt("Receipt", "internal/agent")}); s.Exploration != 0 {
+		t.Fatalf("identical grep = %+v, want exploration 0", s)
+	}
+	if s := tr.ScoreRound([]Receipt{windowReceipt("agent.go", 0)}); s.Exploration != 1 {
+		t.Fatalf("first window = %+v, want exploration 1", s)
+	}
+	if s := tr.ScoreRound([]Receipt{windowReceipt("agent.go", 300)}); s.Exploration != 1 {
+		t.Fatalf("next window of the same file = %+v, want exploration 1", s)
+	}
+}


### PR DESCRIPTION
Split out of #8404 so the smallest fix for the most frequent complaint can land
and be reverted on its own.

The no-progress guard scored read novelty on the path alone. Measured on the
real tool loop:

| turn shape (every round returned information the turn did not have) | before |
| --- | --- |
| grep one package, ten different patterns | ordered to answer at round 7 |
| page through one long file, ten windows | ordered to answer at round 7 |

Nine of those ten rounds scored as repeats because the path had been seen. The
guard then told the model, untruthfully, that it had "produced no new evidence".

A path already read can still answer a question never asked. Both scorers now
key a read on the exact call behind the receipt as well as its paths: a new grep
pattern or the next window counts once, and only an identical call is a repeat.
It also makes grep consistent with itself — a pathless grep was already scored
by its arguments, so searching the whole tree scored better than searching one
directory.

Deliberately not in this PR: the exploration run limit still zeroes novelty
after six look-only rounds, so a read-only turn still reaches the stop tier by
arithmetic around round 12. That cliff, and the fixed 2/4/6 ladder it feeds, are
replaced in #8404.

Tests cover both scorers directly and both turn shapes through the real
`executeBatch` loop, plus the discriminator that must survive: re-reading one
path still escalates to the stop tier.

Cache-impact: none - evidence scoring only; no tool schema, prompt or provider request changes, so the system-prompt prefix stays byte-identical.
Cache-guard: `go test ./internal/boot/` (provider_request golden) and `internal/agent/cachehit_e2e_test.go`, both unchanged and green.
Documentation-impact: none - the docs describe the guard's thresholds and pause behaviour, which this change does not alter; it only stops miscounting a distinct question as a repeat.
