### PR TITLE
fix(billing): prefer funded balance over CNY in display fallback

### DIFF
--- a/internal/billing/balance.go
+++ b/internal/billing/balance.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -151,23 +152,23 @@ func symbol(currency string) string {
 	}
 }
 
-// Display renders the primary balance compactly, e.g. "¥110.00". It preserves
-// the legacy CNY-first behavior for callers that have no display-currency
-// preference.
+// Display renders the primary balance compactly, e.g. "$9.82". It uses the
+// funded-first fallback for callers that have no display-currency preference.
 func (b *Balance) Display() string {
 	return b.DisplayForCurrency("")
 }
 
 // DisplayForCurrency renders the balance matching the requested pricing
 // currency. When the provider does not return that currency, it falls back to
-// Display's legacy CNY-first selection and prefixes the provider's real ISO
-// currency (for example "CNY ¥70.16"); it never performs an implicit
-// exchange-rate conversion.
+// the entry with the largest funded balance and prefixes the provider's real
+// ISO currency (for example "CNY ¥70.16"); it never performs an implicit
+// exchange-rate conversion. The funded-first fallback (rather than the legacy
+// CNY-first pick) keeps a zero CNY entry from hiding a funded USD balance on
+// DeepSeek accounts that report both currencies (see #8107).
 func (b *Balance) DisplayForCurrency(currency string) string {
 	if b == nil || len(b.Infos) == 0 {
 		return ""
 	}
-	pick := b.Infos[0]
 	preferred := normalizeCurrency(currency)
 	if preferred != "" {
 		for _, i := range b.Infos {
@@ -176,10 +177,10 @@ func (b *Balance) DisplayForCurrency(currency string) string {
 			}
 		}
 	}
-	for _, i := range b.Infos {
-		if normalizeCurrency(i.Currency) == "CNY" {
+	pick := b.Infos[0]
+	for _, i := range b.Infos[1:] {
+		if fundedValue(i) > fundedValue(pick) {
 			pick = i
-			break
 		}
 	}
 	display := symbol(pick.Currency) + strings.TrimSpace(pick.TotalBalance)
@@ -191,6 +192,16 @@ func (b *Balance) DisplayForCurrency(currency string) string {
 		return actual + " " + display
 	}
 	return display
+}
+
+// fundedValue parses TotalBalance for comparison purposes. Unparseable or
+// empty totals count as zero so malformed entries never win the fallback pick.
+func fundedValue(i Info) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(i.TotalBalance), 64)
+	if err != nil {
+		return 0
+	}
+	return v
 }
 
 func normalizeCurrency(currency string) string {

--- a/internal/billing/balance_test.go
+++ b/internal/billing/balance_test.go
@@ -27,3 +27,40 @@ func TestBalanceSingleWalletCurrencyHint(t *testing.T) {
 		t.Fatalf("currencies = %v", got)
 	}
 }
+
+func TestDisplayFallbackPrefersFundedBalance(t *testing.T) {
+	// DeepSeek returns a zero CNY entry alongside the funded USD entry for
+	// USD-funded accounts, in non-deterministic order (see #8107). The
+	// fallback must show the funded currency, never the zero CNY entry.
+	usdFunded := Info{Currency: "USD", TotalBalance: "9.82"}
+	cnyZero := Info{Currency: "CNY", TotalBalance: "0.00"}
+	for _, infos := range [][]Info{
+		{cnyZero, usdFunded},
+		{usdFunded, cnyZero},
+	} {
+		if got := (&Balance{Infos: infos}).DisplayForCurrency(""); got != "$9.82" {
+			t.Fatalf("fallback display for %v = %q, want $9.82", infos, got)
+		}
+	}
+	// An explicit preference still wins even when its own balance is zero.
+	if got := (&Balance{Infos: []Info{cnyZero, usdFunded}}).DisplayForCurrency("CNY"); got != "¥0.00" {
+		t.Fatalf("explicit CNY display = %q, want ¥0.00", got)
+	}
+	// A USD-only wallet shows USD for every preference; unknown preferences
+	// are normalized to empty and render without a prefix.
+	usdOnly := &Balance{Infos: []Info{usdFunded}}
+	for pref, want := range map[string]string{
+		"":    "$9.82",
+		"USD": "$9.82",
+		"JPY": "$9.82",
+		"CNY": "USD $9.82",
+	} {
+		if got := usdOnly.DisplayForCurrency(pref); got != want {
+			t.Fatalf("USD-only display for %q = %q, want %q", pref, got, want)
+		}
+	}
+	// Malformed totals never win the fallback pick.
+	if got := (&Balance{Infos: []Info{{Currency: "CNY", TotalBalance: "oops"}, usdFunded}}).DisplayForCurrency(""); got != "$9.82" {
+		t.Fatalf("malformed-total fallback = %q, want $9.82", got)
+	}
+}

--- a/internal/cli/serve_frontend.go
+++ b/internal/cli/serve_frontend.go
@@ -142,7 +142,11 @@ func startServeBalanceDiagnostics(ctrl *control.Controller) {
 		} else if balance == nil {
 			fmt.Fprintln(os.Stderr, "  balance: not configured (no balance_url for this provider)")
 		} else {
-			fmt.Printf("  balance: %s\n", balance.Display())
+			displayCurrency := ""
+			if cfg, err := config.LoadForRootReadOnly("."); err == nil && cfg != nil {
+				displayCurrency = cfg.ExplicitDisplayCurrency()
+			}
+			fmt.Printf("  balance: %s\n", balance.DisplayForCurrency(displayCurrency))
 		}
 	}()
 }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1389,13 +1389,17 @@ func (s *Server) status(w http.ResponseWriter, r *http.Request) {
 		sess["lastUsage"] = u
 	}
 	if b, err := s.ctl().Balance(r.Context()); err == nil && b != nil {
-		if cfg, loadErr := config.Load(); loadErr == nil && cfg.DisplayCurrencyPref() == "" {
-			// Runtime-only hint: a single wallet currency may select an existing
-			// valuation, but is never persisted as configuration or history.
-			s.bc.SetDisplayCurrency(b.PrimaryCurrency())
+		displayCurrency := ""
+		if cfg, loadErr := config.Load(); loadErr == nil {
+			displayCurrency = cfg.DisplayCurrencyPref()
+			if displayCurrency == "" {
+				// Runtime-only hint: a single wallet currency may select an existing
+				// valuation, but is never persisted as configuration or history.
+				s.bc.SetDisplayCurrency(b.PrimaryCurrency())
+			}
 		}
 		sess["balance"] = map[string]any{
-			"display":   b.Display(),
+			"display":   b.DisplayForCurrency(displayCurrency),
 			"available": b.Available,
 			"infos":     b.Infos,
 		}


### PR DESCRIPTION
Fixes #8107

## Problem

The CLI/TUI footer and `/status` always show the CNY entry (`¥0.00`) for a
DeepSeek account whose real (funded) balance is USD — even with
`[desktop] currency = "USD"` / `language = "en"` set. `DisplayForCurrency("")`
fell back to a legacy CNY-first pick, and DeepSeek now returns a zero CNY
entry alongside the funded USD entry in **non-deterministic order**, so the
status line deterministically showed `¥0.00`.

The `serve` balance diagnostics and the HTTP `/status` balance display also
ignored the display-currency preference entirely (`balance.Display()`).

## Root cause

- CNY-first fallback in `internal/billing/balance.go` — a zero CNY entry
  always wins over a funded USD entry.
- CLI surfaces calling `Display()` without the resolved currency
  (`internal/cli/serve_frontend.go`, `internal/serve/serve.go`).

## Fix

- **`internal/billing/balance.go`**: fall back to the entry with the largest
  funded balance instead of CNY-first, so a zero CNY entry can never hide a
  funded USD balance. Explicit preferences still win even when their own
  balance is zero (e.g. `DisplayForCurrency("CNY")` on a CNY 0.00 / USD 9.82
  wallet renders `¥0.00`).
- **`internal/cli/serve_frontend.go`** + **`internal/serve/serve.go`**: thread
  the explicit display currency into the balance readout
  (`DisplayForCurrency(currency)`), matching the TUI footer behavior.

## Verification

- `go test ./internal/billing ./internal/cli ./internal/serve` — pass
- `go vet ./internal/billing ./internal/cli ./internal/serve` — clean
- `gofmt` — clean
- New tests cover both entry orders (CNY 0.00 / USD funded), USD-only
  wallets under every preference, unknown preferences, and malformed totals.

## Related

- #7160 — previous desktop-only currency alignment
- #7790 — desktop wallet balance follows recharge currency
- #8058 — unified multi-currency billing (merged; the TUI footer now passes
  the explicit currency — the funded-first fallback completes the picture
  for auto/empty preferences)

Documentation-impact: none - display-only behavior change in the CLI status line and serve balance readout; no docs/*.md documents the CNY-first fallback, and the new fixtures cover the behavior in unit tests.