### PR TITLE
fix(desktop): refresh history titles after topic changes / 主题变更后同步刷新历史标题

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1136,6 +1136,16 @@ export default function App() {
   const { configLoadWarnings, applySnapshot: applyConfigWarningSnapshot, reload: reloadConfigWarnings, dismiss: dismissConfigWarnings } = useConfigLoadWarnings();
   const [startupUpdateChecksEnabled, setStartupUpdateChecksEnabled] = useState<boolean | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
+  const historyViewOpenRef = useRef(false);
+  historyViewOpenRef.current = histView?.kind === "history";
+  const refreshHistoryView = useCallback(async () => {
+    if (!historyViewOpenRef.current) return;
+    const sessions = await listSessions().catch(() => null);
+    if (!sessions) return;
+    setHistView((cur) => cur === null || cur.kind !== "history" ? cur : cur.source === "scope"
+      ? { ...cur, sessions: sessionsForScope(sessions, cur.filter) }
+      : { ...cur, sessions });
+  }, [listSessions]);
   const paletteOpen = useOverlayStore((s) => s.paletteOpen);
   const setPaletteOpen = useOverlayStore((s) => s.setPaletteOpen);
   const paletteExtensionActions = useOverlayStore((s) => s.paletteExtensionActions);
@@ -2574,13 +2584,14 @@ export default function App() {
     const stopProjectTree = onProjectTreeChanged(() => {
       setProjectRevision((value) => value + 1);
       void refreshTabMetas(undefined, { afterMutation: true });
+      void refreshHistoryView();
     });
     return () => {
       live = false;
       stopProjectTree();
       void ready.then((stop) => stop?.());
     };
-  }, [activeTabId, refreshTabMetas, workspaceScopeKey]);
+  }, [activeTabId, refreshHistoryView, refreshTabMetas, workspaceScopeKey]);
 
   // Bridge remote:* events into the remote store once, app-wide, so the
   // StatusBar chip, host manager, and explorer all see the same live state.
@@ -3651,18 +3662,6 @@ export default function App() {
     closeTransientOverlays();
     setHistView(null);
   }, [closeTransientOverlays]);
-  const refreshHistoryView = useCallback(async () => {
-    const sessions = await listSessions().catch(() => null);
-    if (!sessions) return;
-    setHistView((cur) =>
-      cur === null || cur.kind !== "history"
-        ? cur
-        : cur.source === "scope"
-          ? { ...cur, sessions: sessionsForScope(sessions, cur.filter) }
-          : { ...cur, sessions },
-    );
-  }, [listSessions]);
-
   const navigationSeqRef = useRef(0);
   const navigationRunningRef = useRef(false);
   const navigationPendingRef = useRef<PendingDesktopNavigationRequest | null>(null);

--- a/desktop/frontend/src/__tests__/history-refresh-contract.test.ts
+++ b/desktop/frontend/src/__tests__/history-refresh-contract.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
+const projectTreeSubscription = appSource.slice(
+  appSource.indexOf("const stopProjectTree = onProjectTreeChanged"),
+  appSource.indexOf("const stopProjectTree = onProjectTreeChanged") + 500,
+);
+
+assert.match(
+  projectTreeSubscription,
+  /void refreshHistoryView\(\)/,
+  "project-tree changes refresh an open HistoryPanel session snapshot",
+);
+assert.ok(
+  appSource.indexOf("const refreshHistoryView = useCallback") < appSource.indexOf("const stopProjectTree = onProjectTreeChanged"),
+  "the history refresh callback is initialized before the project-tree subscription uses it",
+);
+
+console.log("history refresh contract passed");


### PR DESCRIPTION
## Summary

- Refresh the open HistoryPanel session snapshot whenever `project-tree:changed` reports a topic title update.
- Keep session-list reloads disabled while HistoryPanel is closed to avoid unnecessary disk scans.
- Recheck the current history view before applying an asynchronous refresh so a closed or replaced panel cannot receive stale results.
- Add focused regression coverage for the project-tree event wiring and callback initialization order while keeping `App.tsx` within its repository size ratchet.

## Issues

Fixes #8280

## Verification

- [x] `cd desktop/frontend && pnpm exec tsx src/__tests__/history-refresh-contract.test.ts`
- [x] `cd desktop/frontend && node_modules/.bin/tsc.cmd --noEmit`
- [x] `cd desktop/frontend && node_modules/.bin/eslint.cmd "src/**/*.{ts,tsx}"`
- [x] `cd desktop/frontend && node scripts/test-todo-visibility.mjs`
- [x] Frontend discovery suites covered in a segmented Windows run; the existing timing-sensitive failure passed 91/91 when rerun in isolation, and all remaining suites passed.
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m ./...`
- [x] `go run ./tools/repolint`
- [x] `git diff --check upstream/main-v2...HEAD`

## Documentation impact

Documentation-impact: none - This change restores the existing desktop history-title synchronization behavior without changing features, configuration, or documented user workflows.

## Cache impact

Cache-impact: none - The change is limited to desktop frontend state refresh wiring and regression coverage; it does not alter prompts, tool definitions, request serialization, or provider-visible prefixes.
Cache-guard: N/A - Focused regression coverage, type checking, frontend linting, golangci-lint, and repolint cover the changed desktop-only path.
System-prompt-review: N/A