### PR TITLE
fix(compaction): keep folded user turns out of summarizer judgement

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -338,13 +338,27 @@ when the sole automatic threshold is crossed.
   detailed implementation contract.
 
 **What survives a fold.** Verbatim, at every compaction: the system prompt, the
-first user turn when it is small enough to be a brief, the first few small user
-turns of the fold region, and the recent tail. The messages the keep policy
-protects also survive, though a failure with a recorded execution keeps only its
-failure-carrying lines. Everything else is **best-effort** — it reaches the summarizer and survives
-only as well as the digest captured it. That includes small user turns beyond the
-hoisted window, so a durable constraint is safest restated in a recent turn
-rather than assumed to hold from turn 4 of a long session.
+first user turn when it is small enough to be a brief, **every user turn in the
+fold region that fits the retention budget**, and the recent tail. The messages
+the keep policy protects also survive, though a failure with a recorded execution
+keeps only its failure-carrying lines. Everything else is **best-effort** — it
+reaches the summarizer and survives only as well as the digest captured it.
+
+User turns are held to a different standard than the work they govern. A
+constraint stated at turn 4 ("do not change the public API") exists nowhere but
+the transcript, while the code it constrains stays re-derivable from the
+workspace — so the asymmetry of loss, not the token count, decides. Retention is
+bounded rather than unconditional, because hoisting user turns without a budget
+is what padded an earlier revision's candidates past the acceptance ceiling,
+failing compaction outright instead of degrading it. One turn may spend up to
+1500 tokens and all of them together `min(8192, window×5%)`, oldest first — the
+recent tail already covers the newest turns, and an old turn has survived more
+folds than a new one. Unlike the keep policy this is not scoped to the latest
+digest, so a constraint keeps its protection across repeated compaction.
+
+A turn past those bounds folds like any other content. Prefix it with `[[keep]]`
+(keep policy `user_marked`, on by default) to hold it verbatim regardless of
+size.
 
 Two properties bound that loss. Each fold re-derives its digest from the
 canonical transcript rather than from the previous digest, so digests do not

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -156,6 +156,12 @@ transcript，仅在唯一自动阈值被跨越时安装 provider 可见的短 **
   典型落地约占窗口 10%–30%。
   内部构造预算（非用户设置）：
   `recentTailBudget = clamp(window×10%, 32K, 96K)`，摘要输出上限 **16K**。
+- **用户轮次不交给摘要器裁决**：折叠区内的每条 user turn 在预算内原样保留（单条
+  ≤1500 tokens，合计 `min(8192, window×5%)`，从最旧开始）。理由是丢失的不对称
+  性——第 4 轮说的"不许改 public API"只存在于 transcript 里，它约束的代码却能从
+  工作区重新推导。预算是必须的：无上限地保留会把候选撑过验收天花板，使压缩直接
+  失败而非降级。该保护不以最近一次 digest 为界，因此能跨多次压缩存活；超出预算的
+  轮次可用 `[[keep]]` 前缀（keep 策略 `user_marked`，默认开启）强制原样保留。
 - 用户可用 `reasonix config compact-ratio [--local] [VALUE]` 查看或修改阈值。
   项目配置优先于桌面与新 CLI 会话共用的用户全局配置。UI 始终展示**实际生效**值。
 - `max_output_tokens` 是独立的**本轮**输出上限。

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -33,6 +33,9 @@ const (
 	fallbackTokPerChar         = 0.25      // ~4 chars/token, used before any usage is available to calibrate
 	maxPinnedFirstUserTokens   = 1500      // ceiling on pinning the first user turn verbatim
 	pinnedFirstUserWindowFrac  = 0.15      // and never pin a first turn worth more than this fraction of the window
+	maxKeptUserTurnTokens      = 1500      // ceiling on carrying one folded user turn verbatim
+	keptUserTurnsBudgetTokens  = 8192      // and on all of them together within one fold
+	keptUserTurnsWindowFrac    = 0.05      // never spend more than this fraction of the window on them
 	protocolReserveTokens      = 256       // provider framing and control fields not represented by message estimates
 )
 
@@ -292,8 +295,6 @@ func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	return i
 }
 
-// fixedPinnableUserTurn uses a fixed estimate only: provider usage after
-// projection would make the same turn drift across checkpoints.
 func (a *Agent) fixedPinnableUserTurn(m provider.Message) bool {
 	budget := maxPinnedFirstUserTokens
 	if a.contextWindow > 0 {
@@ -301,10 +302,10 @@ func (a *Agent) fixedPinnableUserTurn(m provider.Message) bool {
 			budget = f
 		}
 	}
-	return int(float64(msgChars(m))*fallbackTokPerChar) <= budget
+	return fixedTokenEstimate(m) <= budget
 }
 
-func keepIndexes(region []provider.Message, policy KeepPolicy) []bool {
+func (a *Agent) keepIndexes(region []provider.Message) []bool {
 	keep := make([]bool, len(region))
 	policyStart := 0
 	for i, m := range region {
@@ -315,10 +316,11 @@ func keepIndexes(region []provider.Message, policy KeepPolicy) []bool {
 	// Retention applies only to messages since the latest digest; older kept
 	// messages are allowed to fold on the next pass so they cannot grow forever.
 	for i, m := range region {
-		if i >= policyStart && shouldKeepMessage(m, policy) {
+		if i >= policyStart && shouldKeepMessage(m, a.keepPolicy) {
 			keep[i] = true
 		}
 	}
+	a.keepUserTurns(region, keep)
 	for i, m := range region {
 		if !keep[i] {
 			continue
@@ -333,6 +335,45 @@ func keepIndexes(region []provider.Message, policy KeepPolicy) []bool {
 		}
 	}
 	return keep
+}
+
+// keepUserTurns protects the user's own words from summarizer judgement: a
+// constraint stated mid-session is unrecoverable once a digest drops it, while
+// the work it governs stays re-derivable from the workspace. Unlike the keep
+// policy it ignores policyStart — a bounded budget, not a fold horizon, is what
+// stops it growing.
+func (a *Agent) keepUserTurns(region []provider.Message, keep []bool) {
+	budget := a.keptUserTurnsBudget()
+	// Oldest-first: the recent tail already covers the newest turns verbatim,
+	// and an old turn has survived more folds than a new one.
+	for i, m := range region {
+		if keep[i] || m.Role != provider.RoleUser || m.LocalOnly || isCompactionSummary(m) {
+			continue
+		}
+		cost := fixedTokenEstimate(m)
+		if cost > maxKeptUserTurnTokens || cost > budget {
+			continue
+		}
+		keep[i] = true
+		budget -= cost
+	}
+}
+
+// keptUserTurnsBudget caps what user turns may spend of the checkpoint. Hoisting
+// them unbounded is what made an earlier revision pad candidates past the
+// acceptance ceiling, which fails compaction outright rather than degrading it.
+func (a *Agent) keptUserTurnsBudget() int {
+	if a.contextWindow <= 0 {
+		return keptUserTurnsBudgetTokens
+	}
+	return min(keptUserTurnsBudgetTokens, int(float64(a.contextWindow)*keptUserTurnsWindowFrac))
+}
+
+// fixedTokenEstimate is what every verbatim-retention decision measures with.
+// Calibrated usage must not be used here: a threshold that moves with the last
+// turn's ratio would keep a turn at one checkpoint and fold it at the next.
+func fixedTokenEstimate(m provider.Message) int {
+	return int(float64(msgChars(m)) * fallbackTokPerChar)
 }
 
 func keepToolCallGroup(region []provider.Message, keep []bool, assistantIndex int) {

--- a/internal/agent/compact_partition_test.go
+++ b/internal/agent/compact_partition_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -39,9 +40,9 @@ func partitionCoversRegion(t *testing.T, a *Agent, region []provider.Message) (k
 	return kept, fold
 }
 
-func TestPartitionFoldsAllUserTurnsByDefault(t *testing.T) {
-	// Content-driven summary no longer hoists early user turns to pad the
-	// checkpoint; only keep-policy content and the recent tail stay verbatim.
+func TestPartitionKeepsSmallUserTurnsVerbatim(t *testing.T) {
+	// A constraint stated mid-session cannot be re-derived once a digest drops
+	// it, so small user turns never reach the summarizer's judgement.
 	a := &Agent{}
 	region := []provider.Message{
 		{Role: provider.RoleUser, Content: "small turn 0"},
@@ -50,8 +51,75 @@ func TestPartitionFoldsAllUserTurnsByDefault(t *testing.T) {
 		{Role: provider.RoleAssistant, Content: "work"},
 	}
 	kept, fold := partitionCoversRegion(t, a, region)
-	if len(kept) != 0 || len(fold) != 4 {
-		t.Fatalf("kept=%d fold=%d, want 0/4", len(kept), len(fold))
+	if len(kept) != 3 || len(fold) != 1 {
+		t.Fatalf("kept=%d fold=%d, want 3/1", len(kept), len(fold))
+	}
+	if got := renderTranscript(fold); strings.Contains(got, "small turn") {
+		t.Fatalf("no user turn should reach the summarizer: %s", got)
+	}
+}
+
+func TestPartitionFoldsUserTurnsPastBudget(t *testing.T) {
+	// Unbounded hoisting is what padded an earlier revision's candidates past
+	// the acceptance ceiling, so oversize and over-budget turns still fold.
+	a := &Agent{}
+	oversize := provider.Message{
+		Role:    provider.RoleUser,
+		Content: strings.Repeat("y", maxKeptUserTurnTokens*8),
+	}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: "small and kept"},
+		oversize,
+	}
+	kept, fold := partitionCoversRegion(t, a, region)
+	if len(kept) != 1 || len(fold) != 1 {
+		t.Fatalf("kept=%d fold=%d, want the oversize turn folded", len(kept), len(fold))
+	}
+	if !strings.Contains(renderTranscript(kept), "small and kept") {
+		t.Fatal("the small turn should survive alongside a folded oversize one")
+	}
+}
+
+func TestPartitionUserTurnBudgetIsBoundedInTotal(t *testing.T) {
+	a := &Agent{}
+	// Each turn is a quarter of the per-turn ceiling, so the total budget —
+	// not the per-turn one — is what must stop retention.
+	each := strings.Repeat("z", maxKeptUserTurnTokens)
+	region := make([]provider.Message, 0, 32)
+	for i := range 32 {
+		// Distinct content: partitionCoversRegion keys its coverage check on it.
+		region = append(region, provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("%02d%s", i, each)})
+	}
+	kept, fold := partitionCoversRegion(t, a, region)
+	if len(fold) == 0 {
+		t.Fatal("total budget never engaged: every turn was kept")
+	}
+	budget := keptUserTurnsBudgetTokens
+	spent := 0
+	for _, m := range kept {
+		spent += fixedTokenEstimate(m)
+	}
+	if spent > budget {
+		t.Fatalf("kept %d tokens of user turns, over the %d budget", spent, budget)
+	}
+}
+
+func TestPartitionKeepsUserTurnsAcrossPriorDigest(t *testing.T) {
+	// The keep policy is scoped to messages after the latest digest so it cannot
+	// grow forever; user turns are bounded by budget instead, so a turn from
+	// before the digest must still survive the next fold.
+	a := &Agent{}
+	region := []provider.Message{
+		{Role: provider.RoleUser, Content: "constraint from before the digest"},
+		{Role: provider.RoleUser, Content: summaryTagOpen + "\nprior digest\n" + summaryTagClose},
+		{Role: provider.RoleAssistant, Content: "work"},
+	}
+	kept, fold := partitionCoversRegion(t, a, region)
+	if len(kept) != 1 || !strings.Contains(renderTranscript(kept), "constraint from before") {
+		t.Fatalf("pre-digest user turn must survive; kept=%v", renderTranscript(kept))
+	}
+	if !strings.Contains(renderTranscript(fold), "prior digest") {
+		t.Fatal("the digest itself must still fold into the next one")
 	}
 }
 
@@ -73,15 +141,15 @@ func TestPartitionFoldsPriorDigests(t *testing.T) {
 func TestPartitionKeepPolicyOutranksFold(t *testing.T) {
 	a := &Agent{keepPolicy: KeepErrors}
 	region := []provider.Message{
-		{Role: provider.RoleUser, Content: "small"},
+		{Role: provider.RoleAssistant, Content: "unrelated prose"},
 		{Role: provider.RoleAssistant, Content: "call", ToolCalls: []provider.ToolCall{{ID: "t1", Name: "bash"}}},
 		{Role: provider.RoleTool, ToolCallID: "t1", Name: "bash", Content: "error: boom"},
 	}
 	kept, fold := partitionCoversRegion(t, a, region)
 	if len(kept) != 2 || len(fold) != 1 {
-		t.Fatalf("kept=%d fold=%d, want error tool-call group kept and user folded", len(kept), len(fold))
+		t.Fatalf("kept=%d fold=%d, want the error tool-call group kept and the prose folded", len(kept), len(fold))
 	}
-	if got := renderTranscript(fold); !strings.Contains(got, "small") {
-		t.Fatalf("user turn should fold: %s", got)
+	if got := renderTranscript(kept); !strings.Contains(got, "error: boom") || !strings.Contains(got, "call") {
+		t.Fatalf("the failing call and its result must be kept together: %s", got)
 	}
 }

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -552,7 +552,7 @@ func (a *Agent) planFoldRegion(msgs []provider.Message, force bool) (head, start
 }
 
 func (a *Agent) partitionFoldForProjection(region []provider.Message) (early, carried, kept, fold []provider.Message) {
-	policyKeep := keepIndexes(region, a.keepPolicy)
+	policyKeep := a.keepIndexes(region)
 	for i, m := range region {
 		switch {
 		case m.LocalOnly: // display-only output never reaches a provider

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -168,7 +168,7 @@ func TestKeepIndexesKeepsSiblingToolResultsForKeptError(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "ok", Name: "read_file", Content: "package main"},
 	}
 
-	keep := keepIndexes(region, KeepErrors)
+	keep := (&Agent{keepPolicy: KeepErrors}).keepIndexes(region)
 	for i, kept := range keep {
 		if !kept {
 			t.Fatalf("keep[%d] = false, want all sibling tool-call messages kept: %v", i, keep)
@@ -186,7 +186,7 @@ func TestKeepIndexesScopesPolicyAfterLatestSummary(t *testing.T) {
 		{Role: provider.RoleTool, ToolCallID: "new", Name: "bash", Content: "error: new failure"},
 	}
 
-	keep := keepIndexes(region, KeepErrors)
+	keep := (&Agent{keepPolicy: KeepErrors}).keepIndexes(region)
 	want := []bool{false, false, false, true, true}
 	for i := range want {
 		if keep[i] != want[i] {
@@ -195,19 +195,25 @@ func TestKeepIndexesScopesPolicyAfterLatestSummary(t *testing.T) {
 	}
 }
 
+// The marker is what lets a user turn exceed the size budget keepUserTurns
+// applies, so it is asserted directly: at keepIndexes level every small user
+// turn is kept regardless, which would hide a broken marker match.
 func TestKeepUserMarkedRequiresUserPrefixMarker(t *testing.T) {
-	region := []provider.Message{
-		{Role: provider.RoleAssistant, Content: "[keep] assistant output"},
-		{Role: provider.RoleUser, Content: "ordinary prose mentioning [keep] later"},
-		{Role: provider.RoleUser, Content: "  <keep> exact requirement"},
+	cases := []struct {
+		name string
+		msg  provider.Message
+		want bool
+	}{
+		{"assistant marker ignored", provider.Message{Role: provider.RoleAssistant, Content: "[keep] assistant output"}, false},
+		{"marker must lead", provider.Message{Role: provider.RoleUser, Content: "ordinary prose mentioning [keep] later"}, false},
+		{"leading marker after space", provider.Message{Role: provider.RoleUser, Content: "  <keep> exact requirement"}, true},
 	}
-
-	keep := keepIndexes(region, KeepUserMarked)
-	want := []bool{false, false, true}
-	for i := range want {
-		if keep[i] != want[i] {
-			t.Fatalf("keep = %v, want %v", keep, want)
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUserMarked(tc.msg); got != tc.want {
+				t.Fatalf("isUserMarked = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/projection_test.go
+++ b/internal/agent/projection_test.go
@@ -541,10 +541,9 @@ func TestCompactKeepsMidSessionUserTurns(t *testing.T) {
 		{Role: provider.RoleUser, Content: "next"},
 		{Role: provider.RoleAssistant, Content: "ok"},
 	}}
-	// Summarizer carries the mid-session fact into the single rolling digest.
-	// No early-user-turn hoist: only the stable prefix (system + first user) is
-	// kept verbatim; mid-session user turns in the fold region merge into the summary.
-	a := New(&fakeProvider{reply: "Standing facts: always use pnpm not npm"}, tool.NewRegistry(), sess,
+	// The summarizer is given a reply that drops the fact entirely: a mid-session
+	// user turn must survive on its own, never on the digest having captured it.
+	a := New(&fakeProvider{reply: "Standing facts: none"}, tool.NewRegistry(), sess,
 		Options{ContextWindow: window, CompactRatio: 0.85, RecentKeep: 2}, event.Discard)
 
 	if err := a.compact(context.Background(), "manual", "", true); err != nil {
@@ -580,11 +579,11 @@ func TestCompactKeepsMidSessionUserTurns(t *testing.T) {
 	if !projFirst {
 		t.Fatalf("fixed early user turn missing from projection: %+v", proj)
 	}
-	if projMidVerbatim {
-		t.Fatalf("mid-session user turn must fold into summary, not stay verbatim: %+v", proj)
+	if !projMidVerbatim {
+		t.Fatalf("mid-session user turn must stay verbatim, not depend on the digest: %+v", proj)
 	}
 	if !strings.Contains(joinContents(proj), "pnpm") {
-		t.Fatalf("mid-session fact missing from rolling summary: %+v", proj)
+		t.Fatalf("mid-session fact lost from projection: %+v", proj)
 	}
 	if strings.Contains(joinContents(proj), big) {
 		t.Errorf("assistant/tool work was not folded out of projection")

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -75,7 +75,7 @@ var ErrUnknownModel = errors.New("unknown model")
 
 func agentKeepPolicy(keep []string) agent.KeepPolicy {
 	if keep == nil {
-		return agent.KeepErrors
+		return agent.KeepErrors | agent.KeepUserMarked
 	}
 	var p agent.KeepPolicy
 	for _, k := range keep {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -46,8 +46,8 @@ import (
 )
 
 func TestAgentKeepPolicyFromConfig(t *testing.T) {
-	if got := agentKeepPolicy(nil); got != agent.KeepErrors {
-		t.Fatalf("nil keep policy = %v, want KeepErrors", got)
+	if got := agentKeepPolicy(nil); got != agent.KeepErrors|agent.KeepUserMarked {
+		t.Fatalf("nil keep policy = %v, want KeepErrors|KeepUserMarked", got)
 	}
 	if got := agentKeepPolicy([]string{}); got != 0 {
 		t.Fatalf("empty keep policy = %v, want 0", got)


### PR DESCRIPTION
## Problem

Only the **first** user turn was pinned verbatim through a fold
(`pinnedPrefixLen`). Every later one entered the fold region, where its survival
came down to a single summarizer judgement call — with two fallbacks that rarely
apply: landing inside the recent tail, or the user having manually typed
`[[keep]]` under a policy bit that was **off by default**.

So a constraint stated at turn 8 of a 40-turn session ("do not change the public
API", "Go 1.24 compatible", "no new dependencies") could disappear from the
projection while the digest still read as perfectly reasonable. That is the
failure mode where a summary looks right and has quietly dropped a requirement.

The asymmetry is the point: the code a constraint governs stays re-derivable
from the workspace, while the constraint itself exists nowhere but the
transcript. Token count is the wrong thing to rank on; cost of loss is the right
one.

## Change

Every user turn in the fold region now stays verbatim within a budget, carried
on the **existing** `kept` channel (`keepIndexes` → `partitionFoldForProjection`)
rather than a new mechanism. `pinnedPrefixLen` is deliberately untouched — it is
the cache prefix boundary (`msgs[:head]` opens the projection) and must stay a
contiguous prefix.

Three properties make the protection hold:

- **Structural, not a keep-policy bit.** A stated constraint is a fact about the
  task, not content a policy flag should be able to switch off. It sits at the
  same level as `isCompactionSummary` in the partition.
- **Ignores `policyStart`.** The keep policy is scoped to messages after the
  latest digest so it cannot grow without bound; user turns are bounded by
  budget instead, which is what lets protection survive *repeated* compaction
  rather than lapsing at the next checkpoint.
- **Fixed token estimate.** A threshold tracking the last turn's calibrated
  ratio would keep a turn at one checkpoint and fold it at the next. Merged with
  `fixedPinnableUserTurn`'s duplicate expression into `fixedTokenEstimate`.

**Retention is bounded, not unconditional.** `compact_partition_test.go` recorded
that an earlier revision hoisted early user turns and it padded candidates past
the acceptance ceiling — which fails compaction outright instead of degrading it.
One turn may spend 1500 tokens, all of them `min(8192, window x 5%)`, oldest
first (the recent tail already covers the newest turns, and an old turn has
survived more folds than a new one). Past those bounds a turn folds like any
other content, so `KeepUserMarked` joins the default policy and `[[keep]]` is now
the documented escape hatch for an oversize turn.

## Tests that had fixed the defect as correct behavior

`TestCompactKeepsMidSessionUserTurns` read like a guard for this behavior but
asserted the opposite: the mid-session turn **must** fold, and the fact then had
to come back via a fake summarizer echoing it. Its reply is now
`"Standing facts: none"` — dropping the fact entirely — so the turn has to
survive on its own. It runs the real `a.compact()` and asserts on
`visibleContext(a)`, i.e. the provider-visible projection.

`TestPartitionFoldsAllUserTurnsByDefault` becomes
`TestPartitionKeepsSmallUserTurnsVerbatim`, joined by guards for the per-turn
ceiling, the total budget, and retention across a prior digest.
`TestKeepUserMarkedRequiresUserPrefixMarker` moves down to `isUserMarked`: at
`keepIndexes` level every small user turn is kept regardless, which would have
hidden a broken marker match.

## Verification

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          113571 — byte-identical to the main-v2 baseline (verified via stash)
go test ./...     all green, zero failures
```

repolint's two remaining findings (`desktop/frontend/wailsjs/go/models.ts`,
repo file-size total) are pre-existing on main-v2. The baseline was **not**
widened: a 6-line comment and a +2-line growth in `boot.go` that this change
introduced were fixed in the code instead.

## Scope

This closes the "summarizer dropped it" failure mode only. It does not track
constraint **lifecycle** — if turn 8 says "do not change the public API" and turn
30 says "actually, go ahead", both now survive verbatim and the model reads the
resolution itself. Status tracking (active / satisfied / superseded) is a
separate concern and not attempted here.

Cache-impact: low - the stable system-prompt prefix (base prompt + tools + memory) is byte-identical; the only change is which messages compose the post-checkpoint projection, and compaction is already a declared cache reset point. Kept user turns are capped at 5% of the window, well inside the 50% acceptance ceiling.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing) plus TestCompactKeepsMidSessionUserTurns, which drives the real compact() and asserts on the provider-visible projection.
System-prompt-review: esengine - internal/boot/boot.go changes one default policy value (KeepUserMarked added to the nil-config default); no system-prompt text, tool schema, or memory content is touched.
Documentation-impact: updated - docs/SPEC.md "What survives a fold" rewritten (it still described the removed early-user-turn hoist), with the matching section added to docs/SPEC.zh-CN.md.
