### PR TITLE
Fix v1.24.1 recovery catalog and Windows startup / 修复 v1.24.1 恢复会话目录与 Windows 启动闪窗

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3212,19 +3212,20 @@ func channelDisplayName(provider, domain string) string {
 // has an in-process runtime, the runtime is cancelled and removed first so
 // autosave cannot recreate or append to the deleted file later.
 func (a *App) DeleteSession(path string) error {
-	return friendlySessionFileError(a.deleteSession(path, false))
+	return friendlySessionFileError(a.deleteSession(path))
 }
 
 // DeleteRecoveryCopy is the guarded bulk-cleanup path. The frontend's copy
-// marker is only a hint; the backend re-reads the branch and parent immediately
-// before changing runtime state or moving any files.
+// marker is only a hint. Open copies are preserved, and the backend holds both
+// parent and branch removal guards while re-proving coverage and publishing a
+// recoverable trash entry.
 func (a *App) DeleteRecoveryCopy(path string) error {
-	return friendlySessionFileError(a.deleteSession(path, true))
+	return friendlySessionFileError(a.deleteRecoveryCopy(path))
 }
 
 var errRecoveryCopyNotRedundant = errors.New("recovery session contains content not preserved by its parent")
 
-func (a *App) deleteSession(path string, requireRedundantRecovery bool) error {
+func (a *App) deleteSession(path string) error {
 	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
@@ -3242,10 +3243,6 @@ func (a *App) deleteSession(path string, requireRedundantRecovery bool) error {
 		defer a.lockRuntimeMutation("delete-session")()
 		a.sessionRemovalMu.Lock()
 		defer a.sessionRemovalMu.Unlock()
-		if requireRedundantRecovery && !agent.RecoveryBranchCoveredByParent(sessionPath, dir) {
-			return errRecoveryCopyNotRedundant
-		}
-
 		removed, nextFallback := a.removeSessionRuntimeBindings(dir, sessionPath)
 		fallback = nextFallback
 		if err := a.prepareRemovedSessionRuntimes(removed); err != nil {

--- a/desktop/history_catalog.go
+++ b/desktop/history_catalog.go
@@ -141,11 +141,14 @@ func sessionMetaFromCatalog(record sessioncatalog.SessionRecord, current, open b
 		preview = "History is being indexed — " + filepath.Base(record.Path)
 	}
 	recovered := record.Recovered || strings.TrimSpace(record.RecoveryDigest) != "" || isAutomaticRecoverySessionPath(record.Path)
+	// RecoveryCopy comes from the catalog projection, which re-proves coverage
+	// from real content at index time. History uses it for the dedicated
+	// recovery-copy group and safe bulk cleanup entry points.
 	return SessionMeta{Path: record.Path, Preview: preview, Title: title, Turns: record.Turns,
 		TurnsState: string(record.TurnsState), CreatedAt: record.CreatedAt, LastActivityAt: record.LastActivityAt,
 		ModTime: record.LastActivityAt, Current: current, Open: open, Scope: record.Scope,
 		WorkspaceRoot: record.WorkspaceRoot, TopicID: record.TopicID, TopicTitle: record.TopicTitle,
-		Recovered: recovered}
+		Recovered: recovered, RecoveryCopy: record.RecoveryCopy}
 }
 
 func (a *App) ListHistorySessions(req HistorySessionPageRequest) HistorySessionPage {

--- a/desktop/recovery_copy_delete.go
+++ b/desktop/recovery_copy_delete.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/botruntime"
+)
+
+func (a *App) deleteRecoveryCopy(path string) error {
+	dir := a.activeSessionDir()
+	sessionPath, _, err := validateSessionPath(dir, path)
+	if err != nil {
+		var foundErr error
+		if dir, sessionPath, foundErr = a.sessionDirForPath(path); foundErr != nil {
+			return err
+		}
+	}
+	if err := func() error {
+		defer a.lockRuntimeMutation("delete-recovery-copy")()
+		a.sessionRemovalMu.Lock()
+		defer a.sessionRemovalMu.Unlock()
+		// Read-only tabs may not own a lease, so keep this check in addition to
+		// the cross-process guards acquired by the agent helper.
+		if a.sessionOpenInAnyTab(sessionPath) {
+			return errSessionBusyElsewhere
+		}
+		if err := agent.TrashCoveredRecoveryBranch(sessionPath, dir); err != nil {
+			switch {
+			case errors.Is(err, agent.ErrRecoveryBranchNotCovered):
+				return errRecoveryCopyNotRedundant
+			case errors.Is(err, agent.ErrSessionLeaseHeld):
+				return errSessionBusyElsewhere
+			default:
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+	if err := botruntime.ForgetAutoSessionMappingsForPath(sessionPath); err != nil {
+		slog.Warn("desktop: failed to clear auto bot session mapping", "err", err)
+	}
+	a.removeSessionCatalogPath(sessionPath, "recovery_copy_deleted")
+	a.emitProjectTreeChangedForSessionDirs(dir)
+	a.invalidatePromptHistoryCache()
+	return nil
+}

--- a/desktop/recovery_gc.go
+++ b/desktop/recovery_gc.go
@@ -59,13 +59,14 @@ func (a *App) reclaimRecoveryBranchesIn(dirs []string, now time.Time) int {
 		}
 		for _, path := range reclaimable {
 			// Re-check liveness right before disposal: the scan is a snapshot,
-			// and the user may have opened the branch since. DeleteSession then
-			// runs the full removal path (removal guard, runtime unbinding,
-			// trash move), so even a miss here lands in the recoverable trash.
+			// and the user may have opened the branch since.
 			if agent.SessionLeaseHeld(path) || a.sessionOpenInAnyTab(path) {
 				continue
 			}
-			if err := a.DeleteSession(path); err != nil {
+			// DeleteRecoveryCopy re-proves real parent coverage under removal
+			// guards. A concurrent continue-edit, missing parent, or busy lease
+			// skips without moving or permanently deleting anything.
+			if err := a.DeleteRecoveryCopy(path); err != nil {
 				slog.Warn("desktop: trash reclaimed recovery branch", "path", path, "err", err)
 				continue
 			}

--- a/desktop/recovery_gc_test.go
+++ b/desktop/recovery_gc_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -171,4 +172,83 @@ func TestRecoveryGCRunsDespiteSafeModeEnv(t *testing.T) {
 	// Branch may or may not be reclaimed depending on age/coverage; the
 	// important contract is that Safe Mode env does not force a no-op panic-free path.
 	_ = branchPath
+}
+
+func TestRecoveryGCSkipsWhenBranchContinuesAfterScan(t *testing.T) {
+	// Scan marks the branch reclaimable, then a concurrent continue-edit must
+	// make DeleteRecoveryCopy refuse so unique content is never trashed.
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	_, branchPath := forkCoveredRecoveryBranch(t, dir, "race-edit")
+	later := time.Now().Add(48 * time.Hour)
+	reclaimable, err := agent.ReclaimableRecoveryBranches(dir, later, agent.RecoveryGCGracePeriod)
+	if err != nil {
+		t.Fatalf("ReclaimableRecoveryBranches: %v", err)
+	}
+	if len(reclaimable) != 1 || reclaimable[0] != branchPath {
+		t.Fatalf("reclaimable = %v, want only %s", reclaimable, branchPath)
+	}
+	branch, err := agent.LoadSession(branchPath)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	branch.Add(provider.Message{Role: provider.RoleAssistant, Content: "continued after scan"})
+	if err := branch.Save(branchPath); err != nil {
+		t.Fatalf("Save continued branch: %v", err)
+	}
+	app := NewApp()
+	if got := app.reclaimRecoveryBranchesIn([]string{dir}, later); got != 0 {
+		t.Fatalf("reclaimed = %d, want 0 after post-scan continue", got)
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("continued branch must remain: %v", err)
+	}
+}
+
+func TestRecoveryGCSkipsWhenLeaseAcquiredAfterScan(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	_, branchPath := forkCoveredRecoveryBranch(t, dir, "race-lease")
+	later := time.Now().Add(48 * time.Hour)
+	reclaimable, err := agent.ReclaimableRecoveryBranches(dir, later, agent.RecoveryGCGracePeriod)
+	if err != nil {
+		t.Fatalf("ReclaimableRecoveryBranches: %v", err)
+	}
+	if len(reclaimable) != 1 {
+		t.Fatalf("reclaimable = %v, want one path", reclaimable)
+	}
+	lease, err := agent.TryAcquireSessionLease(branchPath)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+	app := NewApp()
+	if got := app.reclaimRecoveryBranchesIn([]string{dir}, later); got != 0 {
+		t.Fatalf("reclaimed = %d, want 0 while lease held", got)
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("leased branch must remain: %v", err)
+	}
+}
+
+func TestRecoveryGCUsesDeleteRecoveryCopyNotDeleteSession(t *testing.T) {
+	source, err := os.ReadFile("recovery_gc.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	if !strings.Contains(text, "DeleteRecoveryCopy(path)") {
+		t.Fatal("background recovery GC must call DeleteRecoveryCopy")
+	}
+	if strings.Contains(text, "DeleteSession(path)") {
+		t.Fatal("background recovery GC must not use unguarded DeleteSession")
+	}
 }

--- a/desktop/session_catalog_recovery_test.go
+++ b/desktop/session_catalog_recovery_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/sessioncatalog"
+)
+
+func TestSessionMetaFromCatalogPropagatesRecoveryCopy(t *testing.T) {
+	meta := sessionMetaFromCatalog(sessioncatalog.SessionRecord{
+		Path: "/s/copy.jsonl", Preview: "hello", Turns: 2, TurnsState: sessioncatalog.TurnsValid,
+		Recovered: true, RecoveryCopy: true, LastActivityAt: 42,
+	}, false, false)
+	if !meta.Recovered || !meta.RecoveryCopy {
+		t.Fatalf("meta = %+v, want recovered recoveryCopy", meta)
+	}
+	meta = sessionMetaFromCatalog(sessioncatalog.SessionRecord{
+		Path: "/s/adopted.jsonl", Recovered: true, RecoveryCopy: false,
+	}, false, false)
+	if !meta.Recovered || meta.RecoveryCopy {
+		t.Fatalf("meta = %+v, want recovered without recoveryCopy", meta)
+	}
+}
+
+func TestProjectNodeFromCatalogTopicFiltersIdleRecoveryCopies(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "t1", Title: "Topic", Turns: 3,
+		TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+		LastActivityAt: 100, Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/parent.jsonl", Turns: 3, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK, LastActivityAt: 90},
+			{Path: "/s/copy.jsonl", Turns: 3, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+				Recovered: true, RecoveryCopy: true, LastActivityAt: 100},
+			{Path: "/s/open-copy.jsonl", Turns: 1, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+				Recovered: true, RecoveryCopy: true, LastActivityAt: 95},
+		},
+	}
+	sessionOverlays := map[string]catalogRuntimeOverlay{
+		sessionRuntimeKey("/s/open-copy.jsonl"): {open: true},
+	}
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, sessionOverlays)
+	if !ok {
+		t.Fatal("mixed topic should stay visible")
+	}
+	// Parent + open copy remain; idle copy is filtered. Two sessions => children.
+	if len(node.Children) != 2 {
+		t.Fatalf("children = %d, want parent + open recovery copy", len(node.Children))
+	}
+	for _, child := range node.Children {
+		if child.SessionPath == "/s/copy.jsonl" {
+			t.Fatal("idle recovery copy must not appear in project tree children")
+		}
+	}
+}
+
+func TestProjectNodeFromCatalogTopicHidesRecoveryOnlyIdleTopic(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "only-copy", Title: "Copy", RecoveryState: "recovery_only",
+		Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/only.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
+		},
+	}
+	if _, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}); ok {
+		t.Fatal("idle recovery-only topic must be hidden from the ordinary tree")
+	}
+}
+
+func TestProjectNodeFromCatalogTopicKeepsPinnedRecoveryOnlyTopic(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "pinned-copy", Title: "Pinned", Pinned: true, RecoveryState: "recovery_only",
+		Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/pinned.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
+		},
+	}
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{})
+	if !ok {
+		t.Fatal("pinned recovery-only topic must remain visible")
+	}
+	// After filtering idle copies nothing is left as children, so single-line topic.
+	if len(node.Children) != 0 {
+		t.Fatalf("children = %d, want collapsed single-line pinned topic", len(node.Children))
+	}
+}
+
+func TestProjectNodeFromCatalogTopicCollapsesWhenOnlyOneVisible(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "collapse", Title: "Collapse", Turns: 2,
+		Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/parent.jsonl", Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
+			{Path: "/s/copy.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
+		},
+	}
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{})
+	if !ok {
+		t.Fatal("topic with parent should stay visible")
+	}
+	if len(node.Children) != 0 {
+		t.Fatalf("children = %d, want collapsed single effective session", len(node.Children))
+	}
+}
+
+func TestListProjectTopicsSkipsRecoveryOnlyPages(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := sessioncatalog.Open(ctx, sessioncatalog.Options{
+		Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	base := time.Date(2026, 8, 11, 10, 0, 0, 0, time.UTC)
+	// Two idle recovery-only topics (newer) then one ordinary topic (older).
+	for i, topicID := range []string{"copy-b", "copy-a", "real"} {
+		record := sessioncatalog.SessionRecord{
+			Path: filepath.Join("/s", topicID+".jsonl"), Directory: "/s", Scope: "global",
+			TopicID: topicID, TopicTitle: topicID, Turns: 1, TurnsState: sessioncatalog.TurnsValid,
+			Health: sessioncatalog.HealthOK, LastActivityAt: base.Add(time.Duration(2-i) * time.Minute).UnixMilli(),
+		}
+		if topicID != "real" {
+			record.Recovered = true
+			record.RecoveryCopy = true
+		}
+		if err := catalog.UpsertSession(ctx, record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	app.sessionCatalog.Store(catalog)
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "global", Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "real" {
+		t.Fatalf("page = %+v, want the ordinary topic after skipping recovery-only pages", page.Items)
+	}
+}

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -295,7 +295,7 @@ func (a *App) metadataTopicPage(req ProjectTopicPageRequest) ProjectTopicPage {
 	return page
 }
 
-func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topicOverlays, sessionOverlays map[string]catalogRuntimeOverlay) ProjectNode {
+func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topicOverlays, sessionOverlays map[string]catalogRuntimeOverlay) (ProjectNode, bool) {
 	kind := "topic"
 	if topic.Scope == "global" {
 		kind = "global_topic"
@@ -309,10 +309,31 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 		Pinned: topic.Pinned, Open: overlay.open, Running: overlay.running, Status: overlay.status,
 		Children: []ProjectNode{},
 	}
-	if len(topic.Sessions) <= 1 {
-		return node
-	}
+	visible := make([]sessioncatalog.SessionRecord, 0, len(topic.Sessions))
+	runtimeSessions := make([]runtimeSessionStatus, 0, len(topic.Sessions))
 	for _, session := range topic.Sessions {
+		sessionOverlay := sessionOverlays[sessionRuntimeKey(session.Path)]
+		// Idle covered recovery copies stay out of the ordinary tree. Open or
+		// running copies remain reachable so the user can still inspect them.
+		if session.RecoveryCopy && !sessionOverlay.open && !sessionOverlay.running {
+			continue
+		}
+		visible = append(visible, session)
+		runtimeSessions = append(runtimeSessions, runtimeSessionStatus{
+			open: sessionOverlay.open, running: sessionOverlay.running,
+		})
+	}
+	summary := topicSummaryFromCatalogTopic(topic, visible)
+	if topicHiddenAsRecoveryOnly(summary, topic.Pinned, append(runtimeSessions, runtimeSessionStatus{
+		open: overlay.open, running: overlay.running,
+	})) {
+		return ProjectNode{Children: []ProjectNode{}}, false
+	}
+	// A single effective session collapses to a normal topic row.
+	if len(visible) <= 1 {
+		return node, true
+	}
+	for _, session := range visible {
 		sessionKind := "session"
 		if topic.Scope == "global" {
 			sessionKind = "global_session"
@@ -337,7 +358,36 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 			Children: []ProjectNode{},
 		})
 	}
-	return node
+	return node, true
+}
+
+func topicSummaryFromCatalogTopic(topic sessioncatalog.TopicRecord, visible []sessioncatalog.SessionRecord) topicSummary {
+	summary := topicSummary{turns: topic.Turns, lastActivityAt: topic.LastActivityAt}
+	if len(visible) == 0 {
+		// Catalog still has only covered recovery copies for this topic.
+		if topic.RecoveryState == "recovery_only" {
+			summary.hasRecoveryOnly = true
+		}
+		return summary
+	}
+	for _, session := range visible {
+		if session.RecoveryCopy {
+			summary.hasRecoveryOnly = true
+			continue
+		}
+		if session.Recovered || strings.TrimSpace(session.RecoveryDigest) != "" {
+			summary.hasAdoptedRecovery = true
+			if session.Turns > summary.adoptedRecoveryTurns {
+				summary.adoptedRecoveryTurns = session.Turns
+			}
+			continue
+		}
+		summary.hasNormalSession = true
+	}
+	if topic.RecoveryState == "recovery_only" && !summary.hasNormalSession && !summary.hasAdoptedRecovery {
+		summary.hasRecoveryOnly = true
+	}
+	return summary
 }
 
 func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
@@ -346,20 +396,56 @@ func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, 
 	if catalog == nil {
 		return a.metadataTopicPage(req), nil
 	}
-	page, err := catalog.ListTopics(a.bootContext(), sessioncatalog.TopicPageRequest{
-		Scope: req.Scope, WorkspaceRoot: req.WorkspaceRoot, Cursor: req.Cursor,
-		Limit: req.Limit, Query: req.Query, TimeFilter: req.TimeFilter,
-	})
-	if err != nil {
-		return out, err
+	limit := req.Limit
+	if limit <= 0 {
+		limit = sessioncatalog.DefaultLimit
+	}
+	if limit > sessioncatalog.MaxLimit {
+		limit = sessioncatalog.MaxLimit
 	}
 	topicOverlays, sessionOverlays := a.catalogRuntimeOverlays()
-	for _, topic := range page.Items {
-		out.Items = append(out.Items, a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays))
+	cursor := req.Cursor
+	// Keep scanning past pages that are entirely idle recovery copies so the
+	// sidebar never shows an empty "no sessions" state when later pages still
+	// have ordinary topics.
+	for {
+		page, err := catalog.ListTopics(a.bootContext(), sessioncatalog.TopicPageRequest{
+			Scope: req.Scope, WorkspaceRoot: req.WorkspaceRoot, Cursor: cursor,
+			Limit: limit, Query: req.Query, TimeFilter: req.TimeFilter,
+		})
+		if err != nil {
+			return out, err
+		}
+		out.Revision = page.Revision
+		for i, topic := range page.Items {
+			node, ok := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays)
+			if !ok {
+				continue
+			}
+			out.Items = append(out.Items, node)
+			if len(out.Items) == limit {
+				if i+1 < len(page.Items) || page.NextCursor != "" {
+					out.NextCursor = encodeProjectTopicCursor(topic)
+				}
+				return out, nil
+			}
+		}
+		if page.NextCursor == "" {
+			out.NextCursor = ""
+			return out, nil
+		}
+		cursor = page.NextCursor
 	}
-	out.NextCursor = page.NextCursor
-	out.Revision = page.Revision
-	return out, nil
+}
+
+func encodeProjectTopicCursor(topic sessioncatalog.TopicRecord) string {
+	// Reuse the catalog's keyset cursor encoding by asking for the next page
+	// after this topic. ListTopics accepts the same opaque cursor it emits.
+	pinned := 0
+	if topic.Pinned {
+		pinned = 1
+	}
+	return sessioncatalog.EncodeTopicCursor(pinned, topic.LastActivityAt, topic.TopicID)
 }
 
 func (a *App) GetTopicSummary(key ProjectTopicKey) (ProjectNode, error) {
@@ -372,7 +458,10 @@ func (a *App) GetTopicSummary(key ProjectTopicKey) (ProjectNode, error) {
 		}
 		if ok {
 			topicOverlays, sessionOverlays := a.catalogRuntimeOverlays()
-			return a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays), nil
+			if node, visible := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays); visible {
+				return node, nil
+			}
+			return ProjectNode{Children: []ProjectNode{}}, nil
 		}
 	}
 	page, err := a.ListProjectTopics(ProjectTopicPageRequest{
@@ -472,6 +561,10 @@ func (a *App) catalogSessionPathForTopic(scope, workspaceRoot, topicID string) s
 		return ""
 	}
 	sort.SliceStable(topic.Sessions, func(i, j int) bool {
+		// Prefer real conversations over idle covered recovery copies.
+		if topic.Sessions[i].RecoveryCopy != topic.Sessions[j].RecoveryCopy {
+			return !topic.Sessions[i].RecoveryCopy
+		}
 		return topic.Sessions[i].LastActivityAt > topic.Sessions[j].LastActivityAt
 	})
 	return topic.Sessions[0].Path

--- a/desktop/session_recovery_cleanup_test.go
+++ b/desktop/session_recovery_cleanup_test.go
@@ -204,6 +204,25 @@ func TestRecoveryCopyCleanupRevalidatesInBackend(t *testing.T) {
 	}
 }
 
+func TestRecoveryCopyCleanupKeepsOpenBranch(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	parentPath, branchPath, branchMsgs := forkDesktopRecoveryBranch(t, dir, "open-delete-guard")
+	coverDesktopRecoveryParent(t, parentPath, branchMsgs)
+	app.tabs["open-copy"] = &WorkspaceTab{ID: "open-copy", Scope: "global", SessionPath: branchPath, Ready: true}
+
+	if err := app.DeleteRecoveryCopy(branchPath); !errors.Is(err, errSessionBusyElsewhere) {
+		t.Fatalf("DeleteRecoveryCopy(open) error = %v, want busy", err)
+	}
+	if _, err := os.Stat(branchPath); err != nil {
+		t.Fatalf("open recovery branch must remain visible: %v", err)
+	}
+}
+
 func TestTopicHiddenAsRecoveryOnly(t *testing.T) {
 	recoveryOnly := topicSummary{hasRecoveryOnly: true}
 	cases := []struct {

--- a/desktop/workspace_watch.go
+++ b/desktop/workspace_watch.go
@@ -7,7 +7,6 @@ package main
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -16,6 +15,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"reasonix/internal/event"
 	"reasonix/internal/fileref"
+	"reasonix/internal/gitcmd"
 )
 
 const (
@@ -254,7 +254,10 @@ func gitMetadataDirsForWorkspace(root string) []string {
 	var dirs []string
 	for _, flag := range []string{"--git-dir", "--git-common-dir"} {
 		ctx, cancel := context.WithTimeout(context.Background(), workspaceGitProbeLimit)
-		cmd := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", flag)
+		// gitcmd.Command applies CREATE_NO_WINDOW / HideWindow on Windows so
+		// these startup probes do not flash console windows, and keeps the
+		// credential-filtered env plus maintenance/fsmonitor hardening.
+		cmd := gitcmd.Command(ctx, root, "rev-parse", flag)
 		out, err := cmd.Output()
 		cancel()
 		if err != nil {

--- a/desktop/workspace_watch_test.go
+++ b/desktop/workspace_watch_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -187,6 +188,23 @@ func TestWorkspaceChangeHubReleasesRootAfterTabWorkspaceSwitch(t *testing.T) {
 	app.workspaceHub.mu.Unlock()
 	if oldExists || !newExists {
 		t.Fatalf("root lifecycle after switch: oldExists=%v newExists=%v", oldExists, newExists)
+	}
+}
+
+func TestGitMetadataDirsForWorkspaceUsesHardenedGitCommand(t *testing.T) {
+	// Source-level contract: both startup rev-parse probes must go through
+	// gitcmd.Command so Windows gets HideWindow + CREATE_NO_WINDOW without
+	// forking a second unhardened path.
+	source, err := os.ReadFile("workspace_watch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	if !strings.Contains(text, `gitcmd.Command(ctx, root, "rev-parse", flag)`) {
+		t.Fatal("gitMetadataDirsForWorkspace must call gitcmd.Command for rev-parse probes")
+	}
+	if strings.Contains(text, `exec.CommandContext(ctx, "git"`) || strings.Contains(text, `exec.Command("git"`) {
+		t.Fatal("workspace_watch must not invoke raw git exec for metadata probes")
 	}
 }
 

--- a/desktop/workspace_watch_windows_test.go
+++ b/desktop/workspace_watch_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/gitcmd"
+)
+
+const workspaceGitCreateNoWindow = 0x08000000
+
+func TestWorkspaceGitProbesHideConsoleWindowOnWindows(t *testing.T) {
+	// Both startup probes use the same gitcmd.Command construction path.
+	// Assert HideWindow + CREATE_NO_WINDOW for each rev-parse flag.
+	for _, flag := range []string{"--git-dir", "--git-common-dir"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		cmd := gitcmd.Command(ctx, t.TempDir(), "rev-parse", flag)
+		cancel()
+		if cmd.SysProcAttr == nil {
+			t.Fatalf("%s: SysProcAttr is nil", flag)
+		}
+		if !cmd.SysProcAttr.HideWindow {
+			t.Fatalf("%s: HideWindow is false", flag)
+		}
+		if cmd.SysProcAttr.CreationFlags&workspaceGitCreateNoWindow == 0 {
+			t.Fatalf("%s: CREATE_NO_WINDOW not set; CreationFlags=%#x", flag, cmd.SysProcAttr.CreationFlags)
+		}
+	}
+}

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -40,7 +40,7 @@ non-destructively when `<Reasonix home>/.env` is missing them.
 | Sessions | `<state root>/sessions/` |
 | Archives | `<state root>/archive/` |
 | Memory | `<state root>/memory/` and `<state root>/projects/` |
-| Disposable session catalog | `<cache root>/session-catalog/v1.sqlite` |
+| Disposable session catalog | `<cache root>/session-catalog/v2.sqlite` |
 | Disposable history search catalog | `<cache root>/history-search/v1.sqlite` |
 | Disposable usage catalog | `<cache root>/usage-catalog/v1.sqlite` |
 | Disposable task catalog | `<cache root>/task-catalog/v1.sqlite` |

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -33,7 +33,7 @@ Legacy 迁移、OS home 约定目录扫描以及其他 fallback 路径都会跳�
 | 会话 | `<state root>/sessions/` |
 | 归档 | `<state root>/archive/` |
 | 记忆 | `<state root>/memory/` 与 `<state root>/projects/` |
-| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v1.sqlite` |
+| 可丢弃的会话 Catalog | `<cache root>/session-catalog/v2.sqlite` |
 | 可丢弃的 Task Catalog | `<cache root>/task-catalog/v1.sqlite` |
 
 `<state root>` 默认等于 `<Reasonix home>`；只有设置 `REASONIX_STATE_HOME`

--- a/docs/SESSION_CATALOG.md
+++ b/docs/SESSION_CATALOG.md
@@ -3,8 +3,9 @@
 Reasonix keeps session transcripts, event logs, metadata sidecars, and
 `desktop-projects.json` as the only authoritative session data. The desktop
 project tree reads a disposable SQLite projection from
-`<cache root>/session-catalog/v1.sqlite`; deleting that database never deletes
-or changes a conversation.
+`<cache root>/session-catalog/v2.sqlite`; deleting that database never deletes
+or changes a conversation. The 1.24.0 `v1.sqlite` cache is left in place so a
+concurrent or downgraded process cannot cross-write the projection.
 
 ## Invariants
 

--- a/docs/SESSION_CATALOG.zh-CN.md
+++ b/docs/SESSION_CATALOG.zh-CN.md
@@ -2,8 +2,9 @@
 
 Reasonix 始终以会话 transcript、event log、metadata sidecar 和
 `desktop-projects.json` 作为唯一权威数据。桌面项目树读取位于
-`<缓存根目录>/session-catalog/v1.sqlite` 的一次性 SQLite 查询投影；删除该数据库
-不会删除或修改任何会话。
+`<缓存根目录>/session-catalog/v2.sqlite` 的一次性 SQLite 查询投影；删除该数据库
+不会删除或修改任何会话。1.24.0 的 `v1.sqlite` 缓存会保留，避免与仍在运行或
+降级后的 1.24.0 进程交叉写同一投影。
 
 ## 不变量
 

--- a/internal/agent/recovery_gc.go
+++ b/internal/agent/recovery_gc.go
@@ -207,14 +207,22 @@ func ReclaimableRecoveryBranches(dir string, now time.Time, grace time.Duration)
 	return out, nil
 }
 
-// TrashReclaimableRecoveryBranch moves one redundant recovery branch into the
-// same recoverable .trash layout used by Desktop. It rechecks parent coverage
-// while holding both the parent and branch removal guards, so a concurrent save
-// cannot turn a redundant copy into unique history between verification and
-// relocation. The operation is durable: an interrupted move stays in an
-// invisible staging directory and is completed by ReconcileCleanupPending on
-// startup.
+// TrashCoveredRecoveryBranch moves a redundant recovery branch into the same
+// recoverable .trash layout used by Desktop. This is the explicit/manual cleanup
+// path, so it does not require the background GC idle grace period. Parent
+// coverage is rechecked while both parent and branch removal guards are held.
+func TrashCoveredRecoveryBranch(path, parentDir string) error {
+	return trashCoveredRecoveryBranch(path, parentDir, false)
+}
+
+// TrashReclaimableRecoveryBranch is the background-GC variant. In addition to
+// the same atomic coverage proof, it requires the branch to remain idle for the
+// full grace period.
 func TrashReclaimableRecoveryBranch(path, parentDir string) error {
+	return trashCoveredRecoveryBranch(path, parentDir, true)
+}
+
+func trashCoveredRecoveryBranch(path, parentDir string, requireIdle bool) error {
 	path = filepath.Clean(strings.TrimSpace(path))
 	parentDir = filepath.Clean(strings.TrimSpace(parentDir))
 	if path == "." || parentDir == "." || filepath.Dir(path) != parentDir {
@@ -236,9 +244,11 @@ func TrashReclaimableRecoveryBranch(path, parentDir string) error {
 		return err
 	}
 	defer branchGuard.Release()
-	meta, ok, err := LoadBranchMeta(path)
-	if err != nil || !ok || !recoveryBranchIdle(path, meta, time.Now(), RecoveryGCGracePeriod) {
-		return ErrRecoveryBranchNotIdle
+	if requireIdle {
+		meta, ok, err := LoadBranchMeta(path)
+		if err != nil || !ok || !recoveryBranchIdle(path, meta, time.Now(), RecoveryGCGracePeriod) {
+			return ErrRecoveryBranchNotIdle
+		}
 	}
 	if !RecoveryBranchCoveredByParent(path, parentDir) {
 		return ErrRecoveryBranchNotCovered

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -395,7 +395,9 @@ func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics WHERE scope=? AND workspace_root=? AND topic_id=?`, key.Scope, key.WorkspaceRoot, key.TopicID)
 		return err
 	}
-	// recovery_copy rows skip turn/health totals; activity still updates recency.
+	// Covered copies skip turn/health totals but still update recency. Adopted
+	// branches are alternate continuations, so preserve the pre-catalog contract:
+	// max(sum(normal turns), max(adopted recovery turns)).
 	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_topics(
         scope,workspace_root,topic_id,title,turns,turns_state,created_at,
         last_activity_at,recovery_state,health
@@ -403,7 +405,10 @@ func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
         COALESCE(NULLIF((SELECT COALESCE(NULLIF(custom_title,''), NULLIF(topic_title,''), preview, '')
             FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?
             ORDER BY recovery_copy ASC, last_activity_at DESC, path ASC LIMIT 1),''), ?),
-        COALESCE(SUM(CASE WHEN recovery_copy=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
+		MAX(
+			COALESCE(SUM(CASE WHEN recovery_copy=0 AND recovered=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
+			COALESCE(MAX(CASE WHEN recovery_copy=0 AND recovered=1 AND turns_state='valid' THEN turns ELSE 0 END),0)
+		),
         CASE WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
              WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
              WHEN SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 THEN 'valid'

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -337,9 +337,9 @@ func (c *Catalog) upsertSessions(ctx context.Context, records []SessionRecord, g
 		if _, err := tx.ExecContext(ctx, `INSERT INTO catalog_sessions(
             path,directory,scope,workspace_root,topic_id,topic_title,custom_title,
             created_at,last_activity_at,preview,turns,turns_state,recovered,
-            recovery_reason,recovery_digest,parent_id,content_fingerprint,
+            recovery_reason,recovery_digest,parent_id,recovery_copy,content_fingerprint,
             meta_fingerprint,health,missing_since,seen_generation
-        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(path) DO UPDATE SET
             directory=excluded.directory, scope=excluded.scope,
             workspace_root=excluded.workspace_root, topic_id=excluded.topic_id,
@@ -349,6 +349,7 @@ func (c *Catalog) upsertSessions(ctx context.Context, records []SessionRecord, g
             turns_state=excluded.turns_state, recovered=excluded.recovered,
             recovery_reason=excluded.recovery_reason,
             recovery_digest=excluded.recovery_digest, parent_id=excluded.parent_id,
+            recovery_copy=excluded.recovery_copy,
             content_fingerprint=excluded.content_fingerprint,
             meta_fingerprint=excluded.meta_fingerprint, health=excluded.health,
             missing_since=0, seen_generation=MAX(catalog_sessions.seen_generation, excluded.seen_generation)`,
@@ -356,7 +357,7 @@ func (c *Catalog) upsertSessions(ctx context.Context, records []SessionRecord, g
 			record.TopicID, record.TopicTitle, record.CustomTitle, record.CreatedAt,
 			record.LastActivityAt, record.Preview, record.Turns, record.TurnsState,
 			record.Recovered, record.RecoveryReason, record.RecoveryDigest,
-			record.ParentID, record.ContentFingerprint, record.MetaFingerprint,
+			record.ParentID, boolToInt(record.RecoveryCopy), record.ContentFingerprint, record.MetaFingerprint,
 			record.Health, 0, generation); err != nil {
 			_ = tx.Rollback()
 			return err
@@ -394,21 +395,23 @@ func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM catalog_topics WHERE scope=? AND workspace_root=? AND topic_id=?`, key.Scope, key.WorkspaceRoot, key.TopicID)
 		return err
 	}
+	// recovery_copy rows skip turn/health totals; activity still updates recency.
 	_, err := tx.ExecContext(ctx, `INSERT INTO catalog_topics(
         scope,workspace_root,topic_id,title,turns,turns_state,created_at,
         last_activity_at,recovery_state,health
     ) SELECT ?,?,?,
         COALESCE(NULLIF((SELECT COALESCE(NULLIF(custom_title,''), NULLIF(topic_title,''), preview, '')
             FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?
-            ORDER BY last_activity_at DESC, path ASC LIMIT 1),''), ?),
-        COALESCE(SUM(CASE WHEN turns_state='valid' THEN turns ELSE 0 END),0),
-        CASE WHEN SUM(CASE WHEN turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
-             WHEN SUM(CASE WHEN turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
+            ORDER BY recovery_copy ASC, last_activity_at DESC, path ASC LIMIT 1),''), ?),
+        COALESCE(SUM(CASE WHEN recovery_copy=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
+        CASE WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
+             WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
+             WHEN SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 THEN 'valid'
              ELSE 'valid' END,
         COALESCE(MIN(NULLIF(created_at,0)),0), COALESCE(MAX(last_activity_at),0),
-        CASE WHEN SUM(CASE WHEN recovered=1 THEN 1 ELSE 0 END)=COUNT(*) THEN 'recovery_only' ELSE '' END,
-        CASE WHEN SUM(CASE WHEN health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
-             WHEN SUM(CASE WHEN health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
+        CASE WHEN SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 THEN 'recovery_only' ELSE '' END,
+        CASE WHEN SUM(CASE WHEN recovery_copy=0 AND health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
+             WHEN SUM(CASE WHEN recovery_copy=0 AND health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
              ELSE 'ok' END
       FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?
     ON CONFLICT(scope,workspace_root,topic_id) DO UPDATE SET
@@ -419,6 +422,13 @@ func recomputeTopic(ctx context.Context, tx *sql.Tx, key TopicKey) error {
 		key.Scope, key.WorkspaceRoot, key.TopicID, key.TopicID,
 		key.Scope, key.WorkspaceRoot, key.TopicID)
 	return err
+}
+
+func boolToInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func bumpRevision(ctx context.Context, tx *sql.Tx) (uint64, error) {
@@ -622,6 +632,13 @@ func (c *Catalog) GetTopic(ctx context.Context, key TopicKey) (TopicRecord, bool
 		return TopicRecord{Sessions: []SessionRecord{}}, false, nil
 	}
 	return item, true, nil
+}
+
+// EncodeTopicCursor builds an exclusive ListTopics keyset cursor after the
+// given topic position. Desktop post-filters recovery-only rows and needs the
+// same cursor shape catalog.ListTopics emits.
+func EncodeTopicCursor(pinned int, lastActivityAt int64, topicID string) string {
+	return encodeCursor(pageCursor{Pinned: pinned, Activity: lastActivityAt, TopicID: topicID})
 }
 
 func encodeCursor(cursor pageCursor) string {

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -221,7 +221,7 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 		}
 		versions = append(versions, version)
 	}
-	if fmt.Sprint(versions) != "[1 2 3]" {
+	if fmt.Sprint(versions) != "[1 2 3 4]" {
 		t.Fatalf("schema migration ledger = %v", versions)
 	}
 }

--- a/internal/sessioncatalog/metadata.go
+++ b/internal/sessioncatalog/metadata.go
@@ -55,11 +55,12 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
             turns,turns_state,created_at,last_activity_at,recovery_state,health,metadata_present
         )
         SELECT ?,?,?,?,?,?,?,
-            COALESCE((SELECT SUM(CASE WHEN turns_state='valid' THEN turns ELSE 0 END) FROM catalog_sessions
+            COALESCE((SELECT SUM(CASE WHEN recovery_copy=0 AND turns_state='valid' THEN turns ELSE 0 END) FROM catalog_sessions
                 WHERE scope=? AND workspace_root=? AND topic_id=?),0),
             COALESCE((SELECT CASE
-                WHEN SUM(CASE WHEN turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
-                WHEN SUM(CASE WHEN turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
+                WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
+                WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'
+                WHEN SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 AND COUNT(*)>0 THEN 'valid'
                 WHEN COUNT(*)=0 THEN 'unknown'
                 ELSE 'valid' END
                 FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),'unknown'),
@@ -67,10 +68,13 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
                 WHERE scope=? AND workspace_root=? AND topic_id=?),0),
             COALESCE((SELECT MAX(last_activity_at) FROM catalog_sessions
                 WHERE scope=? AND workspace_root=? AND topic_id=?),0),
-            '',
             COALESCE((SELECT CASE
-                WHEN SUM(CASE WHEN health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
-                WHEN SUM(CASE WHEN health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
+                WHEN COUNT(*)>0 AND SUM(CASE WHEN recovery_copy=0 THEN 1 ELSE 0 END)=0 THEN 'recovery_only'
+                ELSE '' END
+                FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),''),
+            COALESCE((SELECT CASE
+                WHEN SUM(CASE WHEN recovery_copy=0 AND health='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
+                WHEN SUM(CASE WHEN recovery_copy=0 AND health='missing' THEN 1 ELSE 0 END)>0 THEN 'missing'
                 ELSE 'ok' END
                 FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),'ok'),
             1
@@ -83,12 +87,14 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
                 THEN excluded.last_activity_at ELSE catalog_topics.last_activity_at END,
             turns=CASE WHEN excluded.turns>0 THEN excluded.turns ELSE catalog_topics.turns END,
             turns_state=CASE WHEN excluded.turns_state<>'' AND excluded.turns_state<>'unknown'
-                THEN excluded.turns_state ELSE catalog_topics.turns_state END`,
+                THEN excluded.turns_state ELSE catalog_topics.turns_state END,
+            recovery_state=excluded.recovery_state`,
 			topic.Scope, topic.WorkspaceRoot, topic.TopicID, topic.Title,
 			topic.TitleSource, topic.Pinned, topic.SortOrder,
 			topic.Scope, topic.WorkspaceRoot, topic.TopicID,
 			topic.Scope, topic.WorkspaceRoot, topic.TopicID,
 			topic.CreatedAt, topic.Scope, topic.WorkspaceRoot, topic.TopicID,
+			topic.Scope, topic.WorkspaceRoot, topic.TopicID,
 			topic.Scope, topic.WorkspaceRoot, topic.TopicID,
 			topic.Scope, topic.WorkspaceRoot, topic.TopicID); err != nil {
 			_ = tx.Rollback()

--- a/internal/sessioncatalog/metadata.go
+++ b/internal/sessioncatalog/metadata.go
@@ -55,8 +55,10 @@ func (c *Catalog) SyncMetadata(ctx context.Context, projects []ProjectRecord, to
             turns,turns_state,created_at,last_activity_at,recovery_state,health,metadata_present
         )
         SELECT ?,?,?,?,?,?,?,
-            COALESCE((SELECT SUM(CASE WHEN recovery_copy=0 AND turns_state='valid' THEN turns ELSE 0 END) FROM catalog_sessions
-                WHERE scope=? AND workspace_root=? AND topic_id=?),0),
+			COALESCE((SELECT MAX(
+				COALESCE(SUM(CASE WHEN recovery_copy=0 AND recovered=0 AND turns_state='valid' THEN turns ELSE 0 END),0),
+				COALESCE(MAX(CASE WHEN recovery_copy=0 AND recovered=1 AND turns_state='valid' THEN turns ELSE 0 END),0)
+			) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND topic_id=?),0),
             COALESCE((SELECT CASE
                 WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='corrupt' THEN 1 ELSE 0 END)>0 THEN 'corrupt'
                 WHEN SUM(CASE WHEN recovery_copy=0 AND turns_state='unknown' THEN 1 ELSE 0 END)>0 THEN 'unknown'

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -282,9 +282,7 @@ func (c *Catalog) sessionPathLoop() {
 	}
 }
 
-// IndexSessionPath prioritizes a restored tab's exact session without walking
-// its directory. This keeps cold-start recovery independent from the size of
-// the history store.
+// IndexSessionPath indexes one session without walking its directory.
 func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, path string) error {
 	path = filepath.Clean(strings.TrimSpace(path))
 	if path == "." || path == "" {
@@ -294,9 +292,7 @@ func (c *Catalog) IndexSessionPath(ctx context.Context, target DirectoryTarget, 
 	if target.Path == "." || target.Path == "" {
 		target.Path = filepath.Dir(path)
 	}
-	// Serialize exact indexing with reconciliation so an older scan cannot mark
-	// the new projection missing. Authoritative writes complete before this
-	// projection-only lock is acquired.
+	// Hold the directory lock so a concurrent scan cannot mark this row missing.
 	lock := c.directoryLock(target.Path)
 	lock.Lock()
 	defer lock.Unlock()
@@ -380,6 +376,8 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 			lastActivityAt = fileMS
 		}
 	}
+	// Real content only; failure/missing parent leaves RecoveryCopy false.
+	recoveryCopy := info.Recovered && agent.RecoveryBranchCoveredByParent(info.Path, target.Path)
 	return normalizeSessionRecord(SessionRecord{
 		Path:               info.Path,
 		Directory:          target.Path,
@@ -397,6 +395,7 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 		RecoveryReason:     info.RecoveryReason,
 		RecoveryDigest:     info.RecoveryDigest,
 		ParentID:           info.ParentID,
+		RecoveryCopy:       recoveryCopy,
 		ContentFingerprint: contentFingerprint,
 		MetaFingerprint:    metaFingerprint,
 		Health:             HealthOK,
@@ -623,8 +622,7 @@ func (c *Catalog) repairSession(workerCtx context.Context, path string) {
 	}
 	ctx, cancel := context.WithTimeout(workerCtx, 30*time.Second)
 	defer cancel()
-	// LoadSessionDisplayMessages is not yet context-aware; check cancellation
-	// before and after so shutdown can abandon the result without writing.
+	// LoadSessionDisplayMessages is not yet context-aware; check before/after.
 	msgs, _, _, err := agent.LoadSessionDisplayMessages(path)
 	if ctx.Err() != nil || workerCtx.Err() != nil {
 		return
@@ -664,12 +662,14 @@ func (c *Catalog) applyRepairResult(ctx context.Context, path, preview string, t
 		return err
 	}
 	if valid {
+		recoveryCopy := agent.RecoveryBranchCoveredByParent(path, filepath.Dir(path))
 		if _, err := tx.ExecContext(ctx, `UPDATE catalog_sessions SET preview=?,turns=?,turns_state='valid',
-            health='ok',meta_fingerprint=? WHERE path=?`, preview, turns, fileFingerprint(agent.BranchMetaPath(path)), path); err != nil {
+            health='ok',recovery_copy=?,meta_fingerprint=? WHERE path=?`,
+			preview, turns, boolToInt(recoveryCopy), fileFingerprint(agent.BranchMetaPath(path)), path); err != nil {
 			_ = tx.Rollback()
 			return err
 		}
-	} else if _, err := tx.ExecContext(ctx, `UPDATE catalog_sessions SET turns_state='corrupt',health='corrupt' WHERE path=?`, path); err != nil {
+	} else if _, err := tx.ExecContext(ctx, `UPDATE catalog_sessions SET turns_state='corrupt',health='corrupt',recovery_copy=0 WHERE path=?`, path); err != nil {
 		_ = tx.Rollback()
 		return err
 	}

--- a/internal/sessioncatalog/recovery_copy_test.go
+++ b/internal/sessioncatalog/recovery_copy_test.go
@@ -1,0 +1,234 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+func TestDefaultPathUsesV2CacheFile(t *testing.T) {
+	t.Parallel()
+	path := DefaultPath()
+	if path == "" {
+		// CacheDir unavailable in this environment; empty is still valid.
+		return
+	}
+	if !strings.HasSuffix(filepath.ToSlash(path), "session-catalog/v2.sqlite") {
+		t.Fatalf("DefaultPath = %q, want .../session-catalog/v2.sqlite", path)
+	}
+	if strings.Contains(path, "v1.sqlite") {
+		t.Fatalf("DefaultPath must not reuse the 1.24.0 v1 cache: %q", path)
+	}
+}
+
+func forkCatalogRecoveryBranch(t *testing.T, dir, name string) (parentPath, branchPath string, branchMsgs int) {
+	t.Helper()
+	parentPath = filepath.Join(dir, name+".jsonl")
+	parent := agent.NewSession("sys")
+	parent.Add(agentMessage("user", "first"))
+	parent.Add(agentMessage("assistant", "one"))
+	parent.Add(agentMessage("user", "disk "+name))
+	if err := parent.Save(parentPath); err != nil {
+		t.Fatalf("Save parent: %v", err)
+	}
+	stale := agent.NewSession("sys")
+	stale.Add(agentMessage("user", "first"))
+	stale.Add(agentMessage("assistant", "one"))
+	stale.Add(agentMessage("user", "local "+name))
+	info, err := stale.SaveRecoveryBranch(agent.RecoveryBranchOptions{OriginalPath: parentPath})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	return parentPath, info.Path, len(stale.Snapshot())
+}
+
+func coverCatalogRecoveryParent(t *testing.T, parentPath, branchPath string) {
+	t.Helper()
+	branch, err := agent.LoadSession(branchPath)
+	if err != nil {
+		t.Fatalf("Load branch: %v", err)
+	}
+	parent, err := agent.LoadSession(parentPath)
+	if err != nil {
+		t.Fatalf("Load parent: %v", err)
+	}
+	parent.Replace(append([]provider.Message(nil), branch.Snapshot()...))
+	parent.Add(agentMessage("assistant", "parent kept the recovery content"))
+	if err := parent.SaveRewrite(parentPath); err != nil {
+		t.Fatalf("Save covering parent: %v", err)
+	}
+}
+
+func agentMessage(role, content string) provider.Message {
+	switch role {
+	case "assistant":
+		return provider.Message{Role: provider.RoleAssistant, Content: content}
+	default:
+		return provider.Message{Role: provider.RoleUser, Content: content}
+	}
+}
+
+func assignCatalogTopic(t *testing.T, path, topicID string) {
+	t.Helper()
+	if err := agent.UpdateBranchMeta(path, false, func(meta *agent.BranchMeta) error {
+		meta.Scope = "global"
+		meta.TopicID = topicID
+		meta.TopicTitle = topicID
+		meta.SchemaVersion = agent.BranchMetaCountsVersion
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateBranchMeta %s: %v", path, err)
+	}
+}
+
+func TestReconcileMarksCoveredRecoveryCopyWithoutMutatingSessions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	parentPath, coveredPath, _ := forkCatalogRecoveryBranch(t, dir, "covered")
+	coverCatalogRecoveryParent(t, parentPath, coveredPath)
+	_, divergedPath, _ := forkCatalogRecoveryBranch(t, dir, "diverged")
+	assignCatalogTopic(t, parentPath, "shared")
+	assignCatalogTopic(t, coveredPath, "shared")
+	assignCatalogTopic(t, divergedPath, "adopted")
+
+	// Capture pre-index fingerprints so a catalog open never rewrites authority.
+	hashFile := func(path string) string {
+		t.Helper()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(data)
+	}
+	before := map[string]string{
+		parentPath:   hashFile(parentPath),
+		coveredPath:  hashFile(coveredPath),
+		divergedPath: hashFile(divergedPath),
+	}
+	for _, path := range []string{parentPath, coveredPath, divergedPath} {
+		before[agent.BranchMetaPath(path)] = hashFile(agent.BranchMetaPath(path))
+	}
+
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+
+	covered, ok, err := catalog.GetSession(ctx, coveredPath)
+	if err != nil || !ok {
+		t.Fatalf("GetSession covered: ok=%v err=%v", ok, err)
+	}
+	if !covered.Recovered || !covered.RecoveryCopy {
+		t.Fatalf("covered record = %+v, want recovered recoveryCopy", covered)
+	}
+	diverged, ok, err := catalog.GetSession(ctx, divergedPath)
+	if err != nil || !ok {
+		t.Fatalf("GetSession diverged: ok=%v err=%v", ok, err)
+	}
+	if !diverged.Recovered || diverged.RecoveryCopy {
+		t.Fatalf("diverged record = %+v, want recovered without recoveryCopy", diverged)
+	}
+	parent, ok, err := catalog.GetSession(ctx, parentPath)
+	if err != nil || !ok || parent.RecoveryCopy {
+		t.Fatalf("parent record = %+v ok=%v err=%v", parent, ok, err)
+	}
+
+	shared, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "shared"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic shared: ok=%v err=%v", ok, err)
+	}
+	if shared.Turns != parent.Turns {
+		t.Fatalf("shared turns = %d, want parent turns %d without copy inflation", shared.Turns, parent.Turns)
+	}
+	if shared.RecoveryState == "recovery_only" {
+		t.Fatalf("shared topic should not be recovery_only: %+v", shared)
+	}
+	adopted, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "adopted"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic adopted: ok=%v err=%v", ok, err)
+	}
+	if adopted.RecoveryState == "recovery_only" || adopted.Turns <= 0 {
+		t.Fatalf("adopted topic = %+v, want visible continued recovery with turns", adopted)
+	}
+
+	for path, want := range before {
+		if got := hashFile(path); got != want {
+			t.Fatalf("authoritative file changed during catalog reconcile: %s", path)
+		}
+	}
+}
+
+func TestTopicTurnsIgnoreRecoveryCopyButKeepActivity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	base := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC).UnixMilli()
+	if err := catalog.UpsertSession(ctx, SessionRecord{
+		Path: "/s/parent.jsonl", Directory: "/s", Scope: "global", TopicID: "t",
+		Turns: 3, TurnsState: TurnsValid, Health: HealthOK, LastActivityAt: base,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.UpsertSession(ctx, SessionRecord{
+		Path: "/s/copy.jsonl", Directory: "/s", Scope: "global", TopicID: "t",
+		Turns: 9, TurnsState: TurnsValid, Health: HealthOK, Recovered: true, RecoveryCopy: true,
+		LastActivityAt: base + 60_000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	topic, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "t"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic: ok=%v err=%v", ok, err)
+	}
+	if topic.Turns != 3 {
+		t.Fatalf("turns = %d, want 3", topic.Turns)
+	}
+	if topic.LastActivityAt != base+60_000 {
+		t.Fatalf("lastActivityAt = %d, want recovery activity", topic.LastActivityAt)
+	}
+	if topic.RecoveryState != "" {
+		t.Fatalf("recovery_state = %q, want empty for mixed topic", topic.RecoveryState)
+	}
+}
+
+func TestRecoveryOnlyTopicState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.UpsertSession(ctx, SessionRecord{
+		Path: "/s/only-copy.jsonl", Directory: "/s", Scope: "global", TopicID: "copy-only",
+		Turns: 4, TurnsState: TurnsValid, Health: HealthOK, Recovered: true, RecoveryCopy: true,
+		LastActivityAt: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	topic, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "copy-only"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic: ok=%v err=%v", ok, err)
+	}
+	if topic.RecoveryState != "recovery_only" {
+		t.Fatalf("recovery_state = %q, want recovery_only", topic.RecoveryState)
+	}
+	if topic.Turns != 0 {
+		t.Fatalf("turns = %d, want 0 for recovery-only topic", topic.Turns)
+	}
+}

--- a/internal/sessioncatalog/recovery_copy_test.go
+++ b/internal/sessioncatalog/recovery_copy_test.go
@@ -206,6 +206,46 @@ func TestTopicTurnsIgnoreRecoveryCopyButKeepActivity(t *testing.T) {
 	}
 }
 
+func TestTopicTurnsUseMaxOfNormalLineageAndAdoptedRecovery(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	upsert := func(path string, turns int, recovered, recoveryCopy bool) {
+		t.Helper()
+		if err := catalog.UpsertSession(ctx, SessionRecord{
+			Path: path, Directory: "/s", Scope: "global", TopicID: "t",
+			Turns: turns, TurnsState: TurnsValid, Health: HealthOK,
+			Recovered: recovered, RecoveryCopy: recoveryCopy,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	upsert("/s/parent.jsonl", 3, false, false)
+	upsert("/s/adopted.jsonl", 5, true, false)
+	upsert("/s/copy.jsonl", 99, true, true)
+
+	topic, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "t"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic: ok=%v err=%v", ok, err)
+	}
+	if topic.Turns != 5 {
+		t.Fatalf("turns = %d, want max(normal=3, adopted=5); recovery copy must not inflate", topic.Turns)
+	}
+
+	upsert("/s/second-normal.jsonl", 4, false, false)
+	topic, ok, err = catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "t"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic after second normal: ok=%v err=%v", ok, err)
+	}
+	if topic.Turns != 7 {
+		t.Fatalf("turns = %d, want max(normal=7, adopted=5)", topic.Turns)
+	}
+}
+
 func TestRecoveryOnlyTopicState(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/sessioncatalog/schema.go
+++ b/internal/sessioncatalog/schema.go
@@ -101,6 +101,10 @@ CREATE INDEX IF NOT EXISTS idx_catalog_sessions_history
 ON catalog_sessions(scope, workspace_root, last_activity_at DESC, path ASC);
 `
 
+const migrationV4 = `
+ALTER TABLE catalog_sessions ADD COLUMN recovery_copy INTEGER NOT NULL DEFAULT 0;
+`
+
 func sessionMigrations() []projectiondb.Migration {
 	return []projectiondb.Migration{
 		{Version: 1, Apply: func(ctx context.Context, tx *sql.Tx) error {
@@ -113,6 +117,10 @@ func sessionMigrations() []projectiondb.Migration {
 		}},
 		{Version: 3, Apply: func(ctx context.Context, tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, migrationV3)
+			return err
+		}},
+		{Version: 4, Apply: func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, migrationV4)
 			return err
 		}},
 	}

--- a/internal/sessioncatalog/session_page.go
+++ b/internal/sessioncatalog/session_page.go
@@ -20,17 +20,19 @@ type sessionPageCursor struct {
 
 const sessionSelectColumns = `path,directory,scope,workspace_root,topic_id,topic_title,
     custom_title,created_at,last_activity_at,preview,turns,turns_state,recovered,
-    recovery_reason,recovery_digest,parent_id,content_fingerprint,meta_fingerprint,
-    health,missing_since`
+    recovery_reason,recovery_digest,parent_id,recovery_copy,content_fingerprint,
+    meta_fingerprint,health,missing_since`
 
 func scanSession(scanner interface{ Scan(...any) error }) (SessionRecord, error) {
 	var record SessionRecord
+	var recoveryCopy int
 	err := scanner.Scan(&record.Path, &record.Directory, &record.Scope, &record.WorkspaceRoot,
 		&record.TopicID, &record.TopicTitle, &record.CustomTitle, &record.CreatedAt,
 		&record.LastActivityAt, &record.Preview, &record.Turns, &record.TurnsState,
 		&record.Recovered, &record.RecoveryReason, &record.RecoveryDigest,
-		&record.ParentID, &record.ContentFingerprint, &record.MetaFingerprint,
+		&record.ParentID, &recoveryCopy, &record.ContentFingerprint, &record.MetaFingerprint,
 		&record.Health, &record.MissingSince)
+	record.RecoveryCopy = recoveryCopy != 0
 	return record, err
 }
 

--- a/internal/sessioncatalog/types.go
+++ b/internal/sessioncatalog/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SchemaVersion = 3
+	SchemaVersion = 4
 	DefaultLimit  = 50
 	MaxLimit      = 200
 )
@@ -100,26 +100,28 @@ type TopicMetadata struct {
 }
 
 type SessionRecord struct {
-	Path               string     `json:"path"`
-	Directory          string     `json:"directory"`
-	Scope              string     `json:"scope"`
-	WorkspaceRoot      string     `json:"workspaceRoot,omitempty"`
-	TopicID            string     `json:"topicId,omitempty"`
-	TopicTitle         string     `json:"topicTitle,omitempty"`
-	CustomTitle        string     `json:"customTitle,omitempty"`
-	CreatedAt          int64      `json:"createdAt,omitempty"`
-	LastActivityAt     int64      `json:"lastActivityAt,omitempty"`
-	Preview            string     `json:"preview,omitempty"`
-	Turns              int        `json:"turns"`
-	TurnsState         TurnsState `json:"turnsState"`
-	Recovered          bool       `json:"recovered,omitempty"`
-	RecoveryReason     string     `json:"recoveryReason,omitempty"`
-	RecoveryDigest     string     `json:"recoveryDigest,omitempty"`
-	ParentID           string     `json:"parentId,omitempty"`
-	ContentFingerprint string     `json:"contentFingerprint,omitempty"`
-	MetaFingerprint    string     `json:"metaFingerprint,omitempty"`
-	Health             Health     `json:"health"`
-	MissingSince       int64      `json:"missingSince,omitempty"`
+	Path           string     `json:"path"`
+	Directory      string     `json:"directory"`
+	Scope          string     `json:"scope"`
+	WorkspaceRoot  string     `json:"workspaceRoot,omitempty"`
+	TopicID        string     `json:"topicId,omitempty"`
+	TopicTitle     string     `json:"topicTitle,omitempty"`
+	CustomTitle    string     `json:"customTitle,omitempty"`
+	CreatedAt      int64      `json:"createdAt,omitempty"`
+	LastActivityAt int64      `json:"lastActivityAt,omitempty"`
+	Preview        string     `json:"preview,omitempty"`
+	Turns          int        `json:"turns"`
+	TurnsState     TurnsState `json:"turnsState"`
+	Recovered      bool       `json:"recovered,omitempty"`
+	RecoveryReason string     `json:"recoveryReason,omitempty"`
+	RecoveryDigest string     `json:"recoveryDigest,omitempty"`
+	ParentID       string     `json:"parentId,omitempty"`
+	// RecoveryCopy is true only when real content is still covered by the parent.
+	RecoveryCopy       bool   `json:"recoveryCopy,omitempty"`
+	ContentFingerprint string `json:"contentFingerprint,omitempty"`
+	MetaFingerprint    string `json:"metaFingerprint,omitempty"`
+	Health             Health `json:"health"`
+	MissingSince       int64  `json:"missingSince,omitempty"`
 }
 
 type TopicKey struct {
@@ -176,13 +178,12 @@ type SessionPage struct {
 	StaleCursor bool            `json:"staleCursor,omitempty"`
 }
 
-// DefaultPath returns the disposable session catalog path under CacheDir.
-// When the OS cache directory is unavailable it returns "" so callers fall
-// back to an in-memory projection instead of writing into the project tree.
+// DefaultPath is the disposable cache file under CacheDir ("" when unavailable).
+// v2.sqlite is independent of the 1.24.0 v1 cache so processes cannot cross-write.
 func DefaultPath() string {
 	cache := strings.TrimSpace(config.CacheDir())
 	if cache == "" {
 		return ""
 	}
-	return filepath.Join(cache, "session-catalog", "v1.sqlite")
+	return filepath.Join(cache, "session-catalog", "v2.sqlite")
 }


### PR DESCRIPTION
## Problem

Reasonix Desktop v1.24.0 introduced two user-visible regressions:

- Windows cold start could flash two `git.exe` console windows.
- Recovery branches lost their `RecoveryCopy` classification in the new session catalog, flooding the project tree with duplicate-looking sessions and weakening safe cleanup.

The first implementation also left two release-blocking edge cases: adopted recovery turns could be double-counted, and recovery cleanup revalidated coverage before acquiring the destructive file guards.

## Root cause

- `desktop/workspace_watch.go` bypassed the hardened `gitcmd.Command` wrapper for two startup `git rev-parse` probes.
- Session catalog schema/projections did not persist or propagate `recovery_copy`.
- Topic aggregates treated adopted recovery branches as additive history instead of alternate continuations.
- `DeleteRecoveryCopy` reused the generic delete path, leaving a check-before-lock logical race.

## Fix

- Route both startup probes through `gitcmd.Command`, preserving Windows `HideWindow` / `CREATE_NO_WINDOW`, credential filtering, and disabled Git background maintenance.
- Add schema v4 and `SessionRecord.recoveryCopy`; use the independent disposable `session-catalog/v2.sqlite` cache so v1.24.0 and v1.24.1 never cross-write the same projection.
- Rebuild classification from authoritative branch/parent content via `RecoveryBranchCoveredByParent`.
- Hide only idle covered recovery copies; retain open, running, pinned, or adopted branches and keep pagination scanning past copy-only pages.
- Restore pre-catalog topic turns as `max(sum(normal turns), max(adopted recovery turns))`; covered copies affect recency but not turns or health.
- Move manual and background recovery cleanup through one atomic parent-guard + branch-guard path that re-proves coverage before publishing a recoverable trash entry. Open copies remain untouched.

## Compatibility and safety

- Existing JSONL, event logs, recovery metadata, and project registries remain authoritative.
- The v1.24.0 `v1.sqlite` cache remains in place; v1.24.1 builds and owns `v2.sqlite` independently.
- Older builds ignore the additive Wails/JSON `recoveryCopy` field and continue using their own disposable cache.
- Automatic cleanup moves only proven-covered, idle branches into the normal recoverable trash; it never permanently deletes them or restores user-trashed entries.
- No dependencies, network calls, privilege boundaries, provider payloads, or secret handling changed.

## Verification

Exact rebased head:

- `go test -race ./internal/sessioncatalog -count=1`
- `go test -race ./internal/agent -run 'RecoveryBranchCoveredByParent|ReclaimableRecoveryBranches|TrashReclaimableRecoveryBranch|RecoveryTrash' -count=1`
- Desktop focused recovery/catalog/workspace tests with `-race`
- Windows/amd64 Desktop test cross-compile with `CGO_ENABLED=0`
- `go run ./tools/repolint`

The identical fix tree also passed full root/Desktop tests, full root/Desktop race suites, and root/Desktop vet before rebasing onto the latest disjoint compaction-only `main-v2` commits. PR CI provides the exact-head broad gate.

Cache-impact: none - no prompt prefix, tool schema/order, provider request serialization, memory, MCP, or compaction behavior changed.

Cache-guard: not required - the changed paths are outside provider-visible cache construction.

Documentation-impact: updated - English and Chinese session catalog/config path docs now describe the independent v2 cache and recovery-copy projection.
