### PR TITLE
fix(desktop): stabilize transcript scrolling during async row growth / 修复异步行高变化导致的对话跳动

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -55,8 +55,18 @@ try {
     if (!transcript) return;
     transcript.scrollTop = Math.max(0, transcript.scrollHeight - transcript.clientHeight * 2);
     window.__scrollWrites = [];
+    window.__scrollEvents = [];
     window.__scrollGestureTrace = [];
     window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = (owner, top) => window.__scrollWrites.push({ owner, top });
+    transcript.addEventListener("scroll", () => {
+      window.__scrollEvents.push({
+        top: transcript.scrollTop,
+        height: transcript.scrollHeight,
+        mode: transcript.dataset.scrollMode,
+        gesture: transcript.dataset.scrollGesture ?? "idle",
+      });
+      window.__scrollEvents = window.__scrollEvents.slice(-20);
+    });
     new MutationObserver(() => {
       window.__scrollGestureTrace.push(transcript.dataset.scrollGesture ?? "idle");
     }).observe(transcript, { attributes: true, attributeFilter: ["data-scroll-gesture"] });
@@ -68,6 +78,9 @@ try {
   await page.mouse.wheel(0, -420);
   await page.waitForFunction(() => window.__scrollGestureTrace?.includes("wheel"), undefined, { timeout: 3_000 });
   assert(true, "real Chromium wheel input enters the user scroll session");
+  await page.waitForTimeout(64);
+  await page.evaluate(() => document.querySelector(".transcript")?.dispatchEvent(new Event("scrollend")));
+  await page.waitForFunction(() => !document.querySelector(".transcript")?.dataset.scrollGesture);
 
   const midGesture = await page.evaluate(() => {
     const transcript = document.querySelector(".transcript");
@@ -76,21 +89,51 @@ try {
     transcript.dispatchEvent(new WheelEvent("wheel", { deltaY: -240, bubbles: true, cancelable: true }));
     transcript.scrollTop = Math.max(0, transcript.scrollTop - 240);
     transcript.dispatchEvent(new Event("scroll"));
-    const row = [...transcript.querySelectorAll(".transcript__row")].find((candidate) => {
-      const rect = candidate.getBoundingClientRect();
-      return rect.bottom > transcript.getBoundingClientRect().top;
-    });
-    if (row instanceof HTMLElement) row.style.paddingTop = "180px";
-    return { gesture: transcript.dataset.scrollGesture, top: transcript.scrollTop, rowKey: row?.dataset.rowKey ?? null };
+    const viewport = transcript.getBoundingClientRect();
+    const rows = [...transcript.querySelectorAll(".transcript__row")];
+    const anchor = rows
+      .filter((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.bottom > viewport.top && rect.top < viewport.bottom;
+      })
+      .sort((left, right) => (
+        Math.abs(left.getBoundingClientRect().top - viewport.top)
+        - Math.abs(right.getBoundingClientRect().top - viewport.top)
+      ))[0];
+    const above = rows
+      .filter((candidate) => candidate.getBoundingClientRect().bottom <= viewport.top)
+      .sort((left, right) => right.getBoundingClientRect().bottom - left.getBoundingClientRect().bottom)[0];
+    if (above instanceof HTMLElement) {
+      above.style.paddingBottom = `${Number.parseFloat(above.style.paddingBottom || "0") + 1200}px`;
+    }
+    return {
+      gesture: transcript.dataset.scrollGesture,
+      top: transcript.scrollTop,
+      anchorKey: anchor?.dataset.rowKey ?? null,
+      anchorOffset: anchor ? anchor.getBoundingClientRect().top - viewport.top : null,
+      grownRowKey: above?.dataset.rowKey ?? null,
+    };
   });
   assert(midGesture?.gesture === "wheel", "variable-height mutation occurs while wheel ownership is active");
+  assert(midGesture?.anchorKey && midGesture?.grownRowKey, "bench exposes a visible anchor with a mounted row above it");
   await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
-  const during = await page.evaluate(() => ({
-    writes: window.__scrollWrites ?? [],
-    gesture: document.querySelector(".transcript")?.dataset.scrollGesture,
-  }));
+  const during = await page.evaluate((anchorKey) => {
+    const transcript = document.querySelector(".transcript");
+    const anchor = transcript
+      ? [...transcript.querySelectorAll(".transcript__row")].find((candidate) => candidate.dataset.rowKey === anchorKey)
+      : null;
+    return {
+      writes: window.__scrollWrites ?? [],
+      gesture: transcript?.dataset.scrollGesture,
+      anchorOffset: transcript && anchor
+        ? anchor.getBoundingClientRect().top - transcript.getBoundingClientRect().top
+        : null,
+    };
+  }, midGesture?.anchorKey);
   assert(during.writes.every((write) => !["virtualizer", "stream", "container-resize", "footer-resize", "row-size"].includes(write.owner)),
     `compensating owners stay silent during variable-height scroll (${JSON.stringify(during.writes)})`);
+  assert(during.anchorOffset != null && midGesture?.anchorOffset != null && Math.abs(during.anchorOffset - midGesture.anchorOffset) <= 1,
+    `variable-height growth preserves the visible anchor during wheel ownership (${midGesture?.anchorOffset} → ${during.anchorOffset})`);
 
   await page.evaluate(() => document.querySelector(".transcript")?.dispatchEvent(new Event("scrollend")));
   await page.waitForFunction(() => !document.querySelector(".transcript")?.dataset.scrollGesture);
@@ -170,6 +213,7 @@ try {
     if (!(transcript instanceof HTMLElement) || !(tailRow instanceof HTMLElement)) return null;
     transcript.scrollTop = transcript.scrollHeight;
     window.__scrollWrites = [];
+    window.__scrollEvents = [];
     transcript.dispatchEvent(new WheelEvent("wheel", { deltaY: 48, bubbles: true, cancelable: true }));
     tailRow.style.paddingBottom = `${Number.parseFloat(tailRow.style.paddingBottom || "0") + 160}px`;
     return { gesture: transcript.dataset.scrollGesture, mode: transcript.dataset.scrollMode };
@@ -182,19 +226,21 @@ try {
     `tail growth stays write-free during the downward gesture (${JSON.stringify(harmlessDuring)})`);
   await page.waitForTimeout(64);
   await page.evaluate(() => document.querySelector(".transcript")?.dispatchEvent(new Event("scrollend")));
-  await page.waitForFunction(() => {
-    const transcript = document.querySelector(".transcript");
-    return transcript
-      && !transcript.dataset.scrollGesture
-      && transcript.dataset.scrollMode === "tail-follow"
-      && transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight <= 0.5;
-  });
+  await page.waitForTimeout(500);
   const harmlessSettled = await page.locator(".transcript").evaluate((element) => ({
     distance: element.scrollHeight - element.scrollTop - element.clientHeight,
     mode: element.dataset.scrollMode,
+    gesture: element.dataset.scrollGesture ?? "idle",
+    writes: window.__scrollWrites ?? [],
+    events: window.__scrollEvents ?? [],
   }));
-  assert(harmlessSettled.distance <= 0.5 && harmlessSettled.mode === "tail-follow",
-    `deferred tail growth replays once after gesture idle (${JSON.stringify(harmlessSettled)})`);
+  const tailSettled = harmlessSettled.distance <= 0.5
+    && harmlessSettled.mode === "tail-follow"
+    && harmlessSettled.gesture === "idle";
+  assert(tailSettled,
+    tailSettled
+      ? `deferred tail growth settles at the bottom after gesture idle (${harmlessSettled.distance}px)`
+      : `deferred tail growth failed to settle after gesture idle (${JSON.stringify(harmlessSettled)})`);
 
   process.stdout.write("\ntranscript scroll stability browser gate passed\n");
 } finally {

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -88,6 +88,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // startup config warnings, hover-revealed turn-action labels, and compact
 // execution-setting receipts add small always-available contracts. Keep the
 // raw allowance ratcheted while gzip startup budgets stay flat.
-// The same contracts add 5.8 KiB raw (0.26%) over the 2,264.0 KiB base.
-assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_270 * 1024);
+// The same contracts add 6.1 KiB raw (0.27%) over the 2,264.0 KiB base.
+assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_270.5 * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/scripts/check-bundle-budget.mjs
+++ b/desktop/frontend/scripts/check-bundle-budget.mjs
@@ -57,9 +57,10 @@ const localeChunks = readdirSync(resolve(distDir, "assets"))
   .map((name) => resolve(distDir, "assets", name));
 
 console.log("\nbundle budgets");
-// The merged execution-setting controller adds 1.1 KiB gzip (0.27%) over the
-// 400.8 KiB base while keeping the interaction on the existing startup path.
-assertBudget("initial JavaScript gzip", initialJSGzip, 402 * 1024);
+// The merged execution-setting controller and gesture-stable transcript row
+// measurement add 1.6 KiB gzip (0.40%) over the 400.8 KiB base while keeping
+// both interactions on the existing startup path.
+assertBudget("initial JavaScript gzip", initialJSGzip, 402.5 * 1024);
 assertBudget("largest initial JavaScript chunk gzip", largestInitialJS, 280 * 1024);
 assertBudget("render-blocking CSS gzip", initialCSSGzip, 4 * 1024);
 // Extension surfaces, Task Monitor, and compact decision receipts share the
@@ -87,6 +88,6 @@ const rawInitialBytes = [...initialJS, ...initialCSS, ...appShellCSS]
 // startup config warnings, hover-revealed turn-action labels, and compact
 // execution-setting receipts add small always-available contracts. Keep the
 // raw allowance ratcheted while gzip startup budgets stay flat.
-// The same contract adds 4.2 KiB raw (0.19%) over the 2,264.0 KiB base.
-assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_268.5 * 1024);
+// The same contracts add 5.8 KiB raw (0.26%) over the 2,264.0 KiB base.
+assertBudget("initial raw JavaScript and CSS", rawInitialBytes, 2_270 * 1024);
 assertBudget("largest initial JavaScript chunk raw", largestInitialJSRaw, 1_000 * 1024);

--- a/desktop/frontend/src/__tests__/scroll-manager.test.tsx
+++ b/desktop/frontend/src/__tests__/scroll-manager.test.tsx
@@ -123,6 +123,25 @@ await act(async () => {
 });
 eq(scrollTop, 860, "streaming cannot re-pin after a settled short upward gesture");
 
+// A row-height correction can shrink the virtual extent until the browser
+// clamps the unchanged scrollTop to the new physical bottom. That layout
+// correction is not user intent and must not clear the manual-reading latch.
+Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 960 });
+await act(async () => {
+  api!.onScroll();
+});
+eq(api!.stick.current, false, "layout clamping to the physical bottom preserves the manual latch");
+eq(api!.modeRef.current, "manual", "layout clamping cannot masquerade as a downward user scroll");
+await act(async () => {
+  api!.onWheelIntent({ deltaX: 0, deltaY: 48 } as React.WheelEvent<HTMLElement>);
+});
+eq(api!.stick.current, true, "downward intent at a clamped physical bottom explicitly restores tail-follow");
+eq(api!.modeRef.current, "tail-follow", "bottom-edge intent restores tail-follow even without a scroll event");
+await act(async () => {
+  api!.onWheelIntent({ deltaX: 0, deltaY: -48 } as React.WheelEvent<HTMLElement>);
+});
+Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 1000 });
+
 // User-owned downward scrolling may deliberately opt back into tail-follow,
 // but only after reaching the physical bottom rather than merely its 80px
 // proximity band.
@@ -326,9 +345,28 @@ await act(async () => {
   const wrote = api!.writeOffset("virtualizer", 500);
   eq(wrote, true, "virtualizer writes when no user gesture is active");
   api!.onScroll();
+  // Chromium can emit another scroll event for the same write after the
+  // virtualizer's following layout pass. It is still controller-owned.
+  api!.onScroll();
 });
-eq(api!.gestureSourceRef.current, null, "owned scroll event does not create a user session");
+eq(api!.gestureSourceRef.current, null, "owned scroll event window does not create a user session");
 eq(api!.canVirtualizerAdjust(), true, "owned scroll event keeps virtualizer writes enabled");
+
+Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 1000 });
+scrollTop = 900;
+await act(async () => {
+  api!.setMode("tail-follow", "passive-layout-settle-test");
+  api!.stick.current = true;
+  api!.writeOffset("row-size", transcript.scrollHeight);
+  api!.onScroll();
+});
+Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 1020 });
+scrollTop = 902;
+await act(async () => {
+  api!.onScroll();
+});
+eq(api!.gestureSourceRef.current, null, "passive tail layout settling stays controller-owned");
+eq(api!.modeRef.current, "tail-follow", "passive tail layout settling preserves tail-follow mode");
 
 scrollTop = 900;
 await act(async () => {

--- a/desktop/frontend/src/__tests__/transcript-measurement-invalidation.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-measurement-invalidation.test.tsx
@@ -5,7 +5,7 @@ import React, { useRef } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { useTranscriptMeasurementInvalidation } from "../lib/useTranscriptMeasurementInvalidation";
-import { EMPTY_TRANSCRIPT_LAYOUT_SNAPSHOT } from "../lib/transcriptHeightCache";
+import { EMPTY_TRANSCRIPT_LAYOUT_SNAPSHOT, transcriptHeightCache } from "../lib/transcriptHeightCache";
 
 let passed = 0;
 let failed = 0;
@@ -33,12 +33,16 @@ globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.windo
 let allowMeasure = false;
 let measureCalls = 0;
 let reconcileCalls = 0;
+let flushedCalls = 0;
+let cachedDeferredHeight: number | undefined;
 let idleListener: (() => void) | null = null;
+const deferredMeasurements = new Map<string, number>();
 const virtualizer = { measure: () => { measureCalls += 1; } };
 
 function Harness() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const layoutSnapshotRef = useRef(EMPTY_TRANSCRIPT_LAYOUT_SNAPSHOT);
+  const deferredRowMeasurements = useRef(deferredMeasurements);
   useTranscriptMeasurementInvalidation({
     scrollRef,
     layoutSnapshotRef,
@@ -53,6 +57,16 @@ function Harness() {
     reconcileViewportAnchor: () => {
       reconcileCalls += 1;
       return true;
+    },
+    deferredRowMeasurements,
+    tabId: "measurement-invalidation-test",
+    onMeasurementsFlushed: () => {
+      flushedCalls += 1;
+      cachedDeferredHeight = transcriptHeightCache.get(
+        "measurement-invalidation-test",
+        layoutSnapshotRef.current.signature,
+        "deferred-row",
+      );
     },
   });
   return <div ref={scrollRef} style={{ width: 600, fontSize: 14 }} />;
@@ -75,6 +89,16 @@ await act(async () => {
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 });
 eq(measureCalls, 1, "ordinary gesture idle does not trigger an unconditional full measure");
+
+deferredMeasurements.set("deferred-row", 222);
+await act(async () => {
+  idleListener?.();
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+});
+eq(measureCalls, 2, "deferred row heights trigger one idle measurement flush");
+eq(deferredMeasurements.size, 0, "idle measurement flush consumes the deferred row queue");
+eq(cachedDeferredHeight, 222, "idle measurement flush persists the observed row height");
+eq(flushedCalls, 2, "post-measure callback runs after each real invalidation flush");
 
 await act(async () => { root.unmount(); });
 dom.window.close();

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,5 +1,5 @@
 import { memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { ControllerLiveStore, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import type { InvocationMetadataMap } from "../lib/invocationDisplay";
@@ -490,46 +490,18 @@ export function Transcript({
     onScrollEnd,
     onSelectionPointerDown: selectionRetention.onPointerDownCapture,
   });
-  const getRowKey = useCallback((index: number) => `${tabId ?? ""}:${String(rows[index]?.key ?? index)}`, [rows, tabId]);
-  const {
-    estimateSize: estimateRowSize,
-    layoutSnapshotRef,
-    measureElement: measureRowSize,
-  } = useTranscriptRowMeasurements(tabId, rows);
-  const deferredRowMeasurementsRef = useRef(new Map<string, number>());
-  const repinAfterMeasurementFlush = useCallback(() => {
-    // TanStack can publish its corrected total size one frame after measure().
-    // Re-pin across that short layout window so a growing tail cannot finish a
-    // few pixels above the new physical bottom.
-    if (stick.current) scrollToBottomAfterLayout(2, "row-size");
-  }, [scrollToBottomAfterLayout, stick]);
-  const trackRowSizeChange = useCallback(
-    (element: HTMLDivElement, entry: ResizeObserverEntry | undefined, instance: Virtualizer<HTMLDivElement, HTMLDivElement>) => {
-      if (gestureUntilRef.current > Date.now()) {
-        const index = instance.indexFromElement(element);
-        const key = index >= 0 && index < rows.length ? instance.options.getItemKey(index) : null;
-        const box = entry?.borderBoxSize?.[0];
-        const measured = box ? Math.round(box.blockSize) : element.offsetHeight;
-        const frozen = key == null
-          ? undefined
-          : instance.itemSizeCache.get(key) ?? instance.measurementsCache[index]?.size;
-        const rowKey = element.dataset.rowKey;
-        if (rowKey && measured > 0 && frozen !== measured) deferredRowMeasurementsRef.current.set(rowKey, measured);
-        if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
-        return frozen ?? measured;
-      }
-      const height = measureRowSize(element, entry, instance);
-      if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
-      return height;
-    },
-    [gestureUntilRef, measureRowSize, rows.length, scheduleRepinIfWasPinned, stick],
-  );
+  const rowMeasurements = useTranscriptRowMeasurements(tabId, rows, {
+    gestureUntilRef,
+    stick,
+    scheduleRepinIfWasPinned,
+    scrollToBottomAfterLayout,
+  });
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,
-    getItemKey: getRowKey,
-    estimateSize: estimateRowSize,
-    measureElement: trackRowSizeChange,
+    getItemKey: rowMeasurements.getItemKey,
+    estimateSize: rowMeasurements.estimateSize,
+    measureElement: rowMeasurements.measureElement,
     overscan: VIRTUAL_OVERSCAN_ROWS,
     rangeExtractor: selectionRetention.rangeExtractor,
     // Key-anchored compensation: prepended history pages, fold toggles and
@@ -552,20 +524,17 @@ export function Transcript({
   );
   useTranscriptMeasurementInvalidation({
     scrollRef,
-    layoutSnapshotRef,
+    layoutSnapshotRef: rowMeasurements.layoutSnapshotRef,
     virtualizer,
     selectionActive: selectionRetention.active,
     canMeasure: canVirtualizerAdjust,
     onMeasureIdle: onGestureIdle,
     captureViewportAnchor,
     reconcileViewportAnchor,
-    deferredRowMeasurements: deferredRowMeasurementsRef,
+    deferredRowMeasurements: rowMeasurements.deferredRowMeasurementsRef,
     tabId,
-    onMeasurementsFlushed: repinAfterMeasurementFlush,
+    onMeasurementsFlushed: rowMeasurements.onMeasurementsFlushed,
   });
-  useEffect(() => () => {
-    deferredRowMeasurementsRef.current.clear();
-  }, [tabId]);
 
   const sizerRef = useCallback(
     (el: HTMLDivElement | null) => {

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -231,6 +231,7 @@ export function Transcript({
     captureViewportAnchor,
     reconcileViewportAnchor,
     onGestureIdle,
+    gestureUntilRef,
     finishProgrammaticScroll,
   } = useTranscriptScrollController();
   const autoScrollFrame = useRef<number | null>(null);
@@ -490,14 +491,38 @@ export function Transcript({
     onSelectionPointerDown: selectionRetention.onPointerDownCapture,
   });
   const getRowKey = useCallback((index: number) => `${tabId ?? ""}:${String(rows[index]?.key ?? index)}`, [rows, tabId]);
-  const { estimateSize: estimateRowSize, layoutSnapshotRef, measureElement: measureRowSize } = useTranscriptRowMeasurements(tabId, rows);
+  const {
+    estimateSize: estimateRowSize,
+    layoutSnapshotRef,
+    measureElement: measureRowSize,
+  } = useTranscriptRowMeasurements(tabId, rows);
+  const deferredRowMeasurementsRef = useRef(new Map<string, number>());
+  const repinAfterMeasurementFlush = useCallback(() => {
+    // TanStack can publish its corrected total size one frame after measure().
+    // Re-pin across that short layout window so a growing tail cannot finish a
+    // few pixels above the new physical bottom.
+    if (stick.current) scrollToBottomAfterLayout(2, "row-size");
+  }, [scrollToBottomAfterLayout, stick]);
   const trackRowSizeChange = useCallback(
     (element: HTMLDivElement, entry: ResizeObserverEntry | undefined, instance: Virtualizer<HTMLDivElement, HTMLDivElement>) => {
+      if (gestureUntilRef.current > Date.now()) {
+        const index = instance.indexFromElement(element);
+        const key = index >= 0 && index < rows.length ? instance.options.getItemKey(index) : null;
+        const box = entry?.borderBoxSize?.[0];
+        const measured = box ? Math.round(box.blockSize) : element.offsetHeight;
+        const frozen = key == null
+          ? undefined
+          : instance.itemSizeCache.get(key) ?? instance.measurementsCache[index]?.size;
+        const rowKey = element.dataset.rowKey;
+        if (rowKey && measured > 0 && frozen !== measured) deferredRowMeasurementsRef.current.set(rowKey, measured);
+        if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
+        return frozen ?? measured;
+      }
       const height = measureRowSize(element, entry, instance);
       if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
       return height;
     },
-    [measureRowSize, scheduleRepinIfWasPinned, stick],
+    [gestureUntilRef, measureRowSize, rows.length, scheduleRepinIfWasPinned, stick],
   );
   const virtualizer = useVirtualizer({
     count: rows.length,
@@ -534,7 +559,13 @@ export function Transcript({
     onMeasureIdle: onGestureIdle,
     captureViewportAnchor,
     reconcileViewportAnchor,
+    deferredRowMeasurements: deferredRowMeasurementsRef,
+    tabId,
+    onMeasurementsFlushed: repinAfterMeasurementFlush,
   });
+  useEffect(() => () => {
+    deferredRowMeasurementsRef.current.clear();
+  }, [tabId]);
 
   const sizerRef = useCallback(
     (el: HTMLDivElement | null) => {

--- a/desktop/frontend/src/lib/useScrollManager.ts
+++ b/desktop/frontend/src/lib/useScrollManager.ts
@@ -90,12 +90,14 @@ export function useScrollManager() {
   const touchStartY = useRef<number | null>(null);
   const lastClientHeight = useRef<number | null>(null);
   const lastFooterHeight = useRef<number | null>(null);
+  const lastObservedScrollTopRef = useRef<number | null>(null);
   /** Epoch ms until which compensating writers must stay silent. */
   const gestureUntilRef = useRef(0);
   const gestureSourceRef = useRef<TranscriptUserScrollSource | null>(null);
   const gestureLastActivityRef = useRef(0);
   const gestureIdleTimerRef = useRef<number | null>(null);
   const gestureIdleListenersRef = useRef(new Set<() => void>());
+  const preserveTailDuringGestureRef = useRef(false);
   const deferredTailRepinRef = useRef<{
     generation: number;
     owner: TranscriptScrollOwner;
@@ -130,6 +132,7 @@ export function useScrollManager() {
     gestureUntilRef.current = 0;
     gestureSourceRef.current = null;
     gestureLastActivityRef.current = 0;
+    preserveTailDuringGestureRef.current = false;
     if (gestureIdleTimerRef.current !== null) {
       clearTimeout(gestureIdleTimerRef.current);
       gestureIdleTimerRef.current = null;
@@ -204,6 +207,13 @@ export function useScrollManager() {
     }
     return shouldFollow;
   }, []);
+
+  const restoreTailFollowAtBottom = useCallback((el: HTMLElement) => {
+    if (!tailFollowSuppressedRef.current || !isAtPhysicalBottom(el)) return false;
+    tailFollowSuppressedRef.current = false;
+    updateBottomState(el);
+    return true;
+  }, [updateBottomState]);
 
   const cancelPendingBottomScroll = useCallback(() => {
     if (resizeFrame.current !== null) {
@@ -283,10 +293,27 @@ export function useScrollManager() {
       return false;
     }
     if (marker.behavior === "smooth") return true;
-    if (Math.abs(marker.target - top) <= 1) {
-      programmaticScrollRef.current = null;
+    // A single controller write can produce more than one scroll event while
+    // the browser and virtualizer settle the following layout frames. Keep the
+    // ownership marker for its short hold window as long as those events still
+    // report the owned target. A different offset is genuine user/native input.
+    if (Math.abs(marker.target - top) <= 1) return true;
+    const el = scrollRef.current;
+    if (
+      PASSIVE_TAIL_OWNERS.has(marker.owner)
+      && modeRef.current === "tail-follow"
+      && stick.current
+      && !tailFollowSuppressedRef.current
+      && el
+      && (top >= marker.target - 1 || isAtPhysicalBottom(el))
+    ) {
+      // Scroll anchoring may advance the old bottom a few pixels at a time as
+      // the virtualizer publishes a larger tail. That monotonic movement is a
+      // continuation of the passive tail write, not a fresh user gesture.
+      marker.target = top;
       return true;
     }
+    programmaticScrollRef.current = null;
     return false;
   }, []);
 
@@ -301,6 +328,7 @@ export function useScrollManager() {
     // release is never blocked by the gesture lock itself.
     if (el) cancelInFlightSmoothScroll(el);
     cancelPendingBottomScroll();
+    preserveTailDuringGestureRef.current = false;
     tailFollowSuppressedRef.current = true;
     stick.current = false;
     setIsAtBottom(false);
@@ -322,8 +350,10 @@ export function useScrollManager() {
       releaseAutoScroll();
       return true;
     }
+    restoreTailFollowAtBottom(el);
+    preserveTailDuringGestureRef.current = stick.current;
     return false;
-  }, [markUserGesture, releaseAutoScroll]);
+  }, [markUserGesture, releaseAutoScroll, restoreTailFollowAtBottom]);
 
   const onTouchStartIntent = useCallback((event: ReactTouchEvent<HTMLElement>) => {
     touchStartY.current = event.touches[0]?.clientY ?? null;
@@ -341,8 +371,10 @@ export function useScrollManager() {
       releaseAutoScroll();
       return true;
     }
+    restoreTailFollowAtBottom(el);
+    preserveTailDuringGestureRef.current = stick.current;
     return false;
-  }, [markUserGesture, releaseAutoScroll]);
+  }, [markUserGesture, releaseAutoScroll, restoreTailFollowAtBottom]);
 
   const onKeyScrollIntent = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
     const el = scrollRef.current;
@@ -357,8 +389,9 @@ export function useScrollManager() {
       releaseAutoScroll();
       return true;
     }
+    if (CONDITIONAL_SCROLL_KEYS.has(event.key)) restoreTailFollowAtBottom(el);
     return false;
-  }, [markUserGesture, releaseAutoScroll]);
+  }, [markUserGesture, releaseAutoScroll, restoreTailFollowAtBottom]);
 
   const onPointerDownIntent = useCallback((event: ReactPointerEvent<HTMLElement>) => {
     const el = scrollRef.current;
@@ -376,15 +409,23 @@ export function useScrollManager() {
       releaseAutoScroll();
       return true;
     }
+    restoreTailFollowAtBottom(el);
+    preserveTailDuringGestureRef.current = stick.current;
     return false;
-  }, [markUserGesture, releaseAutoScroll]);
+  }, [markUserGesture, releaseAutoScroll, restoreTailFollowAtBottom]);
 
   const onScroll = useCallback((event?: ReactUIEvent<HTMLElement>) => {
     const el = scrollRef.current;
     if (!el) return;
+    const previousTop = lastObservedScrollTopRef.current;
+    lastObservedScrollTopRef.current = el.scrollTop;
     const programmatic = consumeProgrammaticScroll(el.scrollTop) || isTranscriptSelectionMode(modeRef.current);
     if (programmatic) {
       updateBottomState(el, true);
+      return;
+    }
+    if (preserveTailDuringGestureRef.current && modeRef.current === "tail-follow") {
+      markUserGesture(gestureSourceRef.current ?? "native-scroll");
       return;
     }
     if (event?.nativeEvent.isTrusted === false && !isUserGestureActive(gestureUntilRef.current)) {
@@ -397,7 +438,8 @@ export function useScrollManager() {
     // scroll events without wheel samples. Treat every unowned scroll as user
     // activity; controller-owned writes are consumed above.
     markUserGesture(gestureSourceRef.current ?? "native-scroll");
-    tailFollowSuppressedRef.current = !isAtPhysicalBottom(el);
+    if (!isAtPhysicalBottom(el)) tailFollowSuppressedRef.current = true;
+    else if (previousTop !== null && el.scrollTop > previousTop + BOTTOM_REENGAGE_PX) tailFollowSuppressedRef.current = false;
     updateBottomState(el);
     if (tailFollowSuppressedRef.current) cancelPendingBottomScroll();
   }, [cancelPendingBottomScroll, consumeProgrammaticScroll, markUserGesture, updateBottomState]);

--- a/desktop/frontend/src/lib/useTranscriptMeasurementInvalidation.ts
+++ b/desktop/frontend/src/lib/useTranscriptMeasurementInvalidation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, type MutableRefObject, type RefObject } from "react";
 import type { Virtualizer } from "@tanstack/react-virtual";
-import { readTranscriptLayoutSnapshot, type TranscriptLayoutSnapshot } from "./transcriptHeightCache";
+import { readTranscriptLayoutSnapshot, transcriptHeightCache, type TranscriptLayoutSnapshot } from "./transcriptHeightCache";
 import type { TranscriptViewportAnchor } from "./transcriptScrollController";
 
 /**
@@ -17,6 +17,9 @@ export function useTranscriptMeasurementInvalidation({
   onMeasureIdle,
   captureViewportAnchor,
   reconcileViewportAnchor,
+  deferredRowMeasurements,
+  tabId,
+  onMeasurementsFlushed,
 }: {
   scrollRef: RefObject<HTMLDivElement | null>;
   layoutSnapshotRef: MutableRefObject<TranscriptLayoutSnapshot>;
@@ -26,6 +29,9 @@ export function useTranscriptMeasurementInvalidation({
   onMeasureIdle: (listener: () => void) => () => void;
   captureViewportAnchor: () => TranscriptViewportAnchor | null;
   reconcileViewportAnchor: (snapshot: TranscriptViewportAnchor | null) => boolean;
+  deferredRowMeasurements?: MutableRefObject<Map<string, number>>;
+  tabId?: string;
+  onMeasurementsFlushed?: () => void;
 }) {
   const activeRef = useRef(selectionActive);
   const pendingRef = useRef(false);
@@ -33,7 +39,15 @@ export function useTranscriptMeasurementInvalidation({
   activeRef.current = selectionActive;
 
   const flushPending = useCallback(() => {
-    if (!pendingRef.current || activeRef.current || !canMeasure()) return;
+    if (activeRef.current || !canMeasure()) return;
+    if (deferredRowMeasurements?.current.size) {
+      for (const [rowKey, height] of deferredRowMeasurements.current) {
+        transcriptHeightCache.set(tabId ?? "", layoutSnapshotRef.current.signature, rowKey, height);
+      }
+      deferredRowMeasurements.current.clear();
+      pendingRef.current = true;
+    }
+    if (!pendingRef.current) return;
     pendingRef.current = false;
     const anchor = captureViewportAnchor();
     virtualizer.measure();
@@ -45,8 +59,9 @@ export function useTranscriptMeasurementInvalidation({
         return;
       }
       reconcileViewportAnchor(anchor);
+      onMeasurementsFlushed?.();
     });
-  }, [canMeasure, captureViewportAnchor, reconcileViewportAnchor, virtualizer]);
+  }, [canMeasure, captureViewportAnchor, deferredRowMeasurements, layoutSnapshotRef, onMeasurementsFlushed, reconcileViewportAnchor, tabId, virtualizer]);
 
   useEffect(() => {
     if (!selectionActive) flushPending();

--- a/desktop/frontend/src/lib/useTranscriptRowMeasurements.ts
+++ b/desktop/frontend/src/lib/useTranscriptRowMeasurements.ts
@@ -1,13 +1,30 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, type RefObject } from "react";
+import type { Virtualizer } from "@tanstack/react-virtual";
 import { estimateTranscriptRowSize, type TranscriptRow } from "./transcriptRows";
+import type { TranscriptScrollOwner } from "./transcriptScrollController";
 import {
   createTranscriptMeasureElement,
   EMPTY_TRANSCRIPT_LAYOUT_SNAPSHOT,
   estimateTranscriptRowHeightForLayout,
 } from "./transcriptHeightCache";
 
-export function useTranscriptRowMeasurements(tabId: string | undefined, rows: readonly TranscriptRow[]) {
+export function useTranscriptRowMeasurements(
+  tabId: string | undefined,
+  rows: readonly TranscriptRow[],
+  {
+    gestureUntilRef,
+    stick,
+    scheduleRepinIfWasPinned,
+    scrollToBottomAfterLayout,
+  }: {
+    gestureUntilRef: RefObject<number>;
+    stick: RefObject<boolean>;
+    scheduleRepinIfWasPinned: (containerHeightDelta: number, owner?: TranscriptScrollOwner) => void;
+    scrollToBottomAfterLayout: (frames?: number, owner?: TranscriptScrollOwner) => void;
+  },
+) {
   const layoutSnapshotRef = useRef(EMPTY_TRANSCRIPT_LAYOUT_SNAPSHOT);
+  const getItemKey = useCallback((index: number) => `${tabId ?? ""}:${String(rows[index]?.key ?? index)}`, [rows, tabId]);
   const estimateSize = useCallback((index: number) => {
     const row = rows[index];
     return estimateTranscriptRowHeightForLayout({
@@ -18,9 +35,34 @@ export function useTranscriptRowMeasurements(tabId: string | undefined, rows: re
       fallback: estimateTranscriptRowSize(row),
     });
   }, [rows, tabId]);
-  const measureElement = useMemo(() => createTranscriptMeasureElement({
+  const measureRowSize = useMemo(() => createTranscriptMeasureElement({
     tabId: tabId ?? "",
     getLayoutSnapshot: () => layoutSnapshotRef.current,
   }), [tabId]);
-  return { estimateSize, layoutSnapshotRef, measureElement };
+  const deferredRowMeasurementsRef = useRef(new Map<string, number>());
+  const onMeasurementsFlushed = useCallback(() => {
+    // TanStack can publish its corrected total size one frame after measure().
+    if (stick.current) scrollToBottomAfterLayout(2, "row-size");
+  }, [scrollToBottomAfterLayout, stick]);
+  const measureElement = useCallback(
+    (element: HTMLDivElement, entry: ResizeObserverEntry | undefined, instance: Virtualizer<HTMLDivElement, HTMLDivElement>) => {
+      if (gestureUntilRef.current > Date.now()) {
+        const index = instance.indexFromElement(element);
+        const key = index >= 0 && index < rows.length ? instance.options.getItemKey(index) : null;
+        const box = entry?.borderBoxSize?.[0];
+        const measured = box ? Math.round(box.blockSize) : element.offsetHeight;
+        const frozen = key == null ? undefined : instance.itemSizeCache.get(key) ?? instance.measurementsCache[index]?.size;
+        const rowKey = element.dataset.rowKey;
+        if (rowKey && measured > 0 && frozen !== measured) deferredRowMeasurementsRef.current.set(rowKey, measured);
+        if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
+        return frozen ?? measured;
+      }
+      const height = measureRowSize(element, entry, instance);
+      if (stick.current) scheduleRepinIfWasPinned(0, "row-size");
+      return height;
+    },
+    [gestureUntilRef, measureRowSize, rows.length, scheduleRepinIfWasPinned, stick],
+  );
+  useEffect(() => () => deferredRowMeasurementsRef.current.clear(), [tabId]);
+  return { getItemKey, estimateSize, layoutSnapshotRef, measureElement, deferredRowMeasurementsRef, onMeasurementsFlushed };
 }


### PR DESCRIPTION
## Summary

- Freeze mounted transcript row measurements while a wheel, touch, or nested-scroll gesture owns the viewport.
- Batch observed row heights until gesture idle, then remeasure once, restore the visible row anchor, and settle pinned tails across the virtualizer's layout frames.
- Distinguish explicit user intent from browser layout clamping and controller-owned follow-up scroll events, preserving both manual reading and tail-follow behavior.
- Keep row-key generation, gesture-stable measurement, deferred cleanup, and tail settling in the dedicated transcript measurement hook so the rendering component stays within its repository lint baseline.
- Extend unit and real-Chromium coverage for async growth above the viewport, physical-bottom re-engagement, repeated owned scroll events, and deferred tail growth.

## Root cause

The existing gesture lock prevented compensating `scrollTop` writes, but TanStack Virtual could still publish new row sizes and transforms while asynchronous Markdown content changed height. The viewport therefore moved even though the write gate remained silent. During tail growth, follow-up layout scroll events could also outlive the first programmatic marker and be misclassified as native user scrolling.

## User impact

Long transcripts no longer jump upward by a large distance when the user scrolls up from the bottom while Markdown, code blocks, or other variable-height content finishes mounting. Manual upward intent remains latched, while deliberate downward movement to the physical bottom restores tail-follow.

## Verification

- `pnpm test:transcript`
- `pnpm test:transcript-browser`
  - visible anchor remains `6px -> 6px` during a 1200px above-viewport row growth
  - no passive compensating writes occur during active wheel ownership
  - deferred tail growth settles at `0px` from the physical bottom
- `pnpm build`
  - initial JavaScript gzip: 402.5 KiB / 402.5 KiB
  - initial raw JavaScript and CSS: 2270.1 KiB / 2270.5 KiB
- `go run ./tools/repolint`

## Risk and compatibility

- Frontend-only change; no persisted data, Wails API, provider, prompt, cache, auth, dependency, network, or filesystem contract changes.
- Deferred measurements are scoped to the mounted transcript/tab and cleared on tab changes and unmount.
- Existing selection, jump, custom-scrollbar, middle-button, keyboard, touch, nested-scroll, streaming, and virtualization paths remain covered by the transcript suites.

Documentation-impact: none - This fixes internal transcript scrolling behavior without changing user-facing setup or documented workflows.
