### PR TITLE
fix(agent): bound the isolated recovery copy at the depth cap / 修复深度上限后隔离恢复分支无限增长

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -210,6 +210,20 @@ func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 	})
 }
 
+// saveBranchMetaKeepInFlightTurn is SaveBranchMeta for writers that replace a
+// meta they never read. A marker already on the path outlives the write unless
+// the caller brings its own, so an interrupted turn keeps its boundary.
+func saveBranchMetaKeepInFlightTurn(sessionPath string, m BranchMeta) error {
+	return UpdateBranchMeta(sessionPath, true, func(current *BranchMeta) error {
+		if m.InFlightTurn == nil {
+			m.InFlightTurn = current.InFlightTurn
+		}
+		preserveBranchMetaPersistence(&m, *current)
+		*current = m
+		return nil
+	})
+}
+
 func SaveBranchMetaPreserveUpdated(sessionPath string, m BranchMeta) error {
 	return UpdateBranchMeta(sessionPath, false, func(current *BranchMeta) error {
 		preserveBranchMetaPersistence(&m, *current)

--- a/internal/agent/recovery_isolated.go
+++ b/internal/agent/recovery_isolated.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// shutdownRecoverySessionPath names this writer's isolated copy. A content
+// digest would name a new file per save, and the depth cap saturates instead
+// of terminating, so the chain would never end (#8342).
+func shutdownRecoverySessionPath(originalPath string) string {
+	writerDigest := sha256.Sum256([]byte(SessionWriterID()))
+	suffix := fmt.Sprintf("-recovery-%x", writerDigest[:6])
+	id := BranchID(originalPath)
+	if strings.HasSuffix(id, suffix) {
+		// Already this writer's copy: rewriting it in place is what bounds the
+		// chain, since each recovery becomes the parent of the next one.
+		return originalPath
+	}
+	return filepath.Join(filepath.Dir(originalPath),
+		fmt.Sprintf("%s%s.jsonl", recoveryParentStem(id), suffix))
+}
+
+// writeRecoveryEventLog seeds a recovery branch's event log with the recovered
+// transcript. A replace event carries the whole transcript, so the rewritten
+// isolated lane compacts instead: appending would trade one file per save for
+// one transcript per save in a single log.
+func writeRecoveryEventLog(path string, msgs []provider.Message, digest [sha256.Size]byte, isolated bool) error {
+	if isolated {
+		return compactSessionEventLog(path, msgs, digest, 0, "recovery")
+	}
+	return appendSessionReplaceEvent(path, msgs, digest, 0, "recovery")
+}

--- a/internal/agent/recovery_isolated_test.go
+++ b/internal/agent/recovery_isolated_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestSaveConflictRecoveryBranchAtCapStaysBounded(t *testing.T) {
+	dir := t.TempDir()
+	path, stale := divergedSessionPair(t, dir, "session.jsonl")
+	stampRecoveryMeta(t, path, SessionRecoveryMaxDepth)
+
+	// Replay the controller's depth-cap path once per autosave tick, each with
+	// a transcript that grew since the last one (#8342).
+	current := path
+	for i := range 6 {
+		stale.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("tick %d", i)})
+		if _, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: current}); !errors.Is(err, ErrSessionRecoveryDepthExceeded) {
+			t.Fatalf("tick %d: SaveRecoveryBranch err = %v, want ErrSessionRecoveryDepthExceeded", i, err)
+		}
+		info, err := stale.SaveConflictRecoveryBranch(RecoveryBranchOptions{OriginalPath: current})
+		if err != nil {
+			t.Fatalf("tick %d: SaveConflictRecoveryBranch: %v", i, err)
+		}
+		current = info.Path
+		if i == 0 {
+			// The controller only transplants the in-flight turn marker across
+			// distinct paths, so a rewrite in place has to keep it itself.
+			if err := SetSessionInFlightTurn(current, InFlightTurnMeta{StartMessageIndex: 2}); err != nil {
+				t.Fatalf("SetSessionInFlightTurn: %v", err)
+			}
+		}
+	}
+
+	meta, ok, err := LoadBranchMeta(current)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if meta.InFlightTurn == nil || meta.InFlightTurn.StartMessageIndex != 2 {
+		t.Fatalf("in-flight turn marker = %+v, want StartMessageIndex 2", meta.InFlightTurn)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	var isolated []string
+	for _, m := range matches {
+		if !strings.HasSuffix(m, ".events.jsonl") {
+			isolated = append(isolated, m)
+		}
+	}
+	if len(isolated) != 1 {
+		t.Fatalf("isolated copies = %d, want 1: %v", len(isolated), isolated)
+	}
+}
+
+// A recovery fork is itself resumable, so a session and its own fork can be
+// open in one process. Their isolated copies must not share a path.
+func TestShutdownRecoverySessionPathSeparatesSiblingLineages(t *testing.T) {
+	dir := t.TempDir()
+	root := shutdownRecoverySessionPath(filepath.Join(dir, "session.jsonl"))
+	fork := shutdownRecoverySessionPath(filepath.Join(dir, "session-recovery-abcd1234abcd1234.jsonl"))
+	if root == fork {
+		t.Fatalf("session and its fork share an isolated copy: %s", root)
+	}
+	if again := shutdownRecoverySessionPath(root); again != root {
+		t.Fatalf("isolated copy is not a fixed point: %s -> %s", root, again)
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -684,9 +684,10 @@ func (s *Session) SaveShutdownRecoveryBranch(opts RecoveryBranchOptions) (Recove
 }
 
 // SaveConflictRecoveryBranch persists an isolated copy when the ordinary
-// recovery chain has reached its depth cap. It deliberately uses a writer-
-// specific path; the caller must never force an older in-memory snapshot back
-// onto the contested canonical branch just to stop creating nested branches.
+// recovery chain has reached its depth cap. It uses a writer-specific path and
+// rewrites it on every conflicting save, so a capped chain costs one file per
+// writer, not one per save; the caller must never force an older in-memory
+// snapshot back onto the contested canonical branch instead.
 func (s *Session) SaveConflictRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranchInfo, error) {
 	return s.saveRecoveryBranch(opts, true)
 }
@@ -775,7 +776,7 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 
 	recoveryPath := recoverySessionPath(originalPath, digest)
 	if shutdown {
-		recoveryPath = shutdownRecoverySessionPath(originalPath, digest)
+		recoveryPath = shutdownRecoverySessionPath(originalPath)
 	}
 	unlockRecovery := lockSessionSavePath(recoveryPath)
 	defer unlockRecovery()
@@ -812,7 +813,7 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 		return RecoveryBranchInfo{}, err
 	}
 	if recoveryProbe.native {
-		if err := appendSessionReplaceEvent(recoveryPath, msgs, digest, 0, "recovery"); err != nil {
+		if err := writeRecoveryEventLog(recoveryPath, msgs, digest, shutdown); err != nil {
 			return RecoveryBranchInfo{}, err
 		}
 	}
@@ -864,7 +865,7 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 	if strings.TrimSpace(meta.WriterID) == "" {
 		meta.WriterID = SessionWriterID()
 	}
-	if err := SaveBranchMeta(path, meta); err != nil {
+	if err := saveBranchMetaKeepInFlightTurn(path, meta); err != nil {
 		return BranchMeta{}, err
 	}
 	if stored, ok, err := LoadBranchMeta(path); err != nil {
@@ -878,13 +879,6 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 func recoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
 	parent := recoveryParentStem(BranchID(originalPath))
 	return filepath.Join(filepath.Dir(originalPath), fmt.Sprintf("%s-recovery-%x.jsonl", parent, digest[:8]))
-}
-
-func shutdownRecoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
-	parent := recoveryParentStem(BranchID(originalPath))
-	writerDigest := sha256.Sum256([]byte(SessionWriterID()))
-	return filepath.Join(filepath.Dir(originalPath),
-		fmt.Sprintf("%s-recovery-%x-%x.jsonl", parent, digest[:8], writerDigest[:6]))
 }
 
 func recoveryParentStem(parent string) string {


### PR DESCRIPTION
## Summary

- Once the ordinary recovery chain reaches `SessionRecoveryMaxDepth`, the controller falls back to `SaveConflictRecoveryBranch`, and `commitRecoveredSession` makes that isolated copy the active session. The copy's filename was keyed on the transcript digest, so the next autosave — with a transcript one message longer — produced a *different* filename, and `recoveryDepth` saturates at the cap rather than terminating. Every 30s tick therefore wrote a new branch plus its sidecars, forever. Reporters saw 3,330 files, and 926 files / 1.15 GB on a second machine.
- `shutdownRecoverySessionPath` now keys this writer's isolated copy on the writer alone, and is a fixed point: if the path being recovered is already this writer's copy, it is rewritten in place. A capped chain now costs one file per writer instead of one per save. Sibling lineages stay separate — the stem still comes from `recoveryParentStem`, so `session.jsonl` and its own `session-recovery-<digest>.jsonl` fork do not share a copy.
- Because a replace event carries the whole transcript, that lane compacts its event log instead of appending; otherwise the growth would simply move from one file per save into one transcript per save inside a single `.events.jsonl`.
- `saveRecoveryBranchMeta` now preserves an `InFlightTurn` marker already on the path. The controller only transplants markers across *distinct* paths (`transplantInFlightTurnMarker` no-ops when `fromPath == toPath`), so a rewrite in place has to keep the marker itself — otherwise a crash mid-turn would let resume treat an interrupted turn as complete.

Out of scope, deliberately: the false-positive conflict detection that *starts* the chain (a single writer seeing its own just-written file as diverged at δ=0, #8294). This PR bounds the amplifier, turning a disk-filling bug into a warning. The depth-cap bypass on the `shutdown` lane is also left as-is — it is the documented escape hatch, and with the copy bounded it now yields one file rather than an unbounded series.

The new logic lives in `internal/agent/recovery_isolated.go` rather than in `save.go`, because `save.go` and `save_test.go` are already over the `tools/repolint` ratchet baseline and the baseline must not be widened to land a change. `go run ./tools/repolint` is clean and the baseline is untouched.

## Issues

Fixes #8342

Refs #8294

## Verification

- New regression test `TestSaveConflictRecoveryBranchAtCapStaysBounded` replays the controller's depth-cap path once per autosave tick with a growing transcript, and adopts each returned branch as the next parent exactly as `commitRecoveredSession` does. Before this change it reports `isolated copies = 6, want 1`; after, exactly one file. It also asserts an `InFlightTurn` marker written after the first tick survives the later in-place rewrites. This closes the gap noted in #8342 — no test covered "ordinary conflict at the depth cap must not create unbounded forks", which is how the #6948 fix regressed in v1.22.0.
- `TestShutdownRecoverySessionPathSeparatesSiblingLineages` asserts a session and its own recovery fork get distinct isolated copies, and that an isolated copy is a fixed point.
- Live run against a real session directory: 40 consecutive capped ticks produced **1** recovery `.jsonl` (36 KB total, event log 1 line), and `reasonix session list --json` shows it as a resumable `state: recovered` session with the full 42 turns.
- Real binary smoke: `REASONIX_HOME=/tmp/reasonix-ship-qa reasonix -p "..."` completes normally.
- Local CI simulation, all green: `gofmt -l .`, `go vet ./...`, `go build ./...`, `go test ./...`, `go test -race ./internal/agent/ ./internal/control/`, `make lint` (golangci-lint at the `.golangci-version` pin: 0 issues; `tools/repolint`: clean, baseline unchanged), plus the separate `desktop/` module (`gofmt`/`go vet`/`go test .`) since it parses this filename convention. `desktop/isAutomaticRecoverySessionPath` requires exactly 16 hex characters after the last `-recovery-`; the old isolated name yielded 29 and the new one yields 12, so its behaviour is unchanged either way.

## Documentation impact

Documentation-impact: none - internal session-recovery file naming and event-log write only; no CLI, Desktop, configuration, provider, permission or tool behaviour a user sees, and no `docs/*.md` page describes the recovery-branch filename convention.

## Cache impact

Cache-impact: N/A - no cache-sensitive path in `scripts/check-cache-impact.sh` is touched; the `internal/agent` entries in that list are `agent.go`, `ask.go`, `cache*`, `compact*`, `goal_display.go`, `parallel_tasks.go`, `planner_registry.go`, `prune*`, `subagent_registry*`, `subagent_identity.go` and `task.go`, and this diff touches `save.go`, `branch.go` and a new `recovery_isolated.go`. Verified locally: `bash scripts/check-cache-impact.sh <changed files>` reports "No cache-sensitive prompt/tool files changed."

Worth noting for reviewers: a reporter on #8342 observed the prefix-cache hit rate collapsing during the loop, because the session moved to a new branch path every 30 seconds. Holding one stable isolated path removes that churn.
