### PR TITLE
chore(repolint): ratchet scalar state on mutex- and atomic-guarded structs

### DIFF
--- a/REASONIX.md
+++ b/REASONIX.md
@@ -27,6 +27,12 @@ agent. It is the Reasonix analog of Claude Code's CLAUDE.md.
   (`internal/boot/effect_test.go` pattern): assert what actually reaches the
   provider request, frontend sink, or trajectory through the real `boot.Build`
   assembly. Component correctness is not system effectiveness.
+- A mutex- or atomic-guarded struct is ratcheted on its **scalar** field count
+  (`struct-state`), not its total: independent flags multiply into states no
+  type records as legal. Fixing a boundary case by adding one more `bool` is
+  the move this blocks — group by lifetime into a named sub-state instead
+  (`agent.perTurnState` is the pattern), which costs one field and removes the
+  whole product.
 
 ## Comments
 

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,6 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
+    "struct-state": 159,
     "test-file-size": 69298
   },
   "files": {
@@ -29,7 +30,8 @@
       "complexity": 63,
       "essay": 96,
       "file-size": 11341,
-      "function-size": 371
+      "function-size": 371,
+      "struct-state": 15
     },
     "desktop/app_autosave_test.go": {
       "essay": 1
@@ -312,7 +314,8 @@
       "complexity": 41,
       "essay": 112,
       "file-size": 7716,
-      "function-size": 372
+      "function-size": 372,
+      "struct-state": 23
     },
     "desktop/tabs_order_test.go": {
       "test-file-size": 395
@@ -433,7 +436,8 @@
     "internal/acp/service.go": {
       "essay": 66,
       "file-size": 2285,
-      "function-size": 97
+      "function-size": 97,
+      "struct-state": 2
     },
     "internal/acp/service_lock_test.go": {
       "essay": 7,
@@ -449,7 +453,8 @@
       "complexity": 37,
       "essay": 85,
       "file-size": 2404,
-      "function-size": 102
+      "function-size": 102,
+      "struct-state": 47
     },
     "internal/agent/ask.go": {
       "essay": 4
@@ -779,6 +784,9 @@
     "internal/bot/turn_dispatch_test.go": {
       "essay": 3
     },
+    "internal/capability/audit.go": {
+      "struct-state": 12
+    },
     "internal/capability/catalog.go": {
       "essay": 1
     },
@@ -1088,7 +1096,8 @@
       "essay": 162,
       "file-size": 5553,
       "function-size": 82,
-      "narrative": 4
+      "narrative": 4,
+      "struct-state": 17
     },
     "internal/control/controller_test.go": {
       "essay": 10,
@@ -1112,7 +1121,8 @@
       "complexity": 3,
       "essay": 11,
       "file-size": 277,
-      "function-size": 1
+      "function-size": 1,
+      "struct-state": 10
     },
     "internal/control/goal_test.go": {
       "test-file-size": 249
@@ -1262,6 +1272,9 @@
     },
     "internal/extension/intercept.go": {
       "essay": 1
+    },
+    "internal/extension/metrics.go": {
+      "struct-state": 5
     },
     "internal/extension/plugin_resources_test.go": {
       "essay": 2
@@ -1426,7 +1439,8 @@
     "internal/jobs/jobs.go": {
       "essay": 42,
       "file-size": 1271,
-      "function-size": 12
+      "function-size": 12,
+      "struct-state": 6
     },
     "internal/jobs/jobs_extra_test.go": {
       "essay": 1
@@ -1547,7 +1561,8 @@
       "complexity": 45,
       "essay": 36,
       "file-size": 125,
-      "function-size": 154
+      "function-size": 154,
+      "struct-state": 6
     },
     "internal/provider/anthropic/anthropic_test.go": {
       "essay": 1,
@@ -1560,7 +1575,8 @@
       "complexity": 68,
       "essay": 41,
       "file-size": 547,
-      "function-size": 267
+      "function-size": 267,
+      "struct-state": 10
     },
     "internal/provider/openai/openai_test.go": {
       "essay": 5,
@@ -1577,7 +1593,8 @@
       "complexity": 54,
       "essay": 25,
       "file-size": 105,
-      "function-size": 181
+      "function-size": 181,
+      "struct-state": 6
     },
     "internal/provider/responses/responses_test.go": {
       "essay": 6,

--- a/tools/repolint/main.go
+++ b/tools/repolint/main.go
@@ -22,22 +22,23 @@ type Finding struct {
 }
 
 const (
-	ruleEssay      = "essay"
-	ruleBanner     = "banner"
-	ruleMarker     = "marker"
-	ruleDeadCode   = "commented-code"
-	ruleNarrative  = "narrative"
-	ruleFileSize   = "file-size"
-	ruleTestSize   = "test-file-size"
-	ruleLayering   = "layering"
-	ruleFuncSize   = "function-size"
-	ruleComplexity = "complexity"
+	ruleEssay       = "essay"
+	ruleBanner      = "banner"
+	ruleMarker      = "marker"
+	ruleDeadCode    = "commented-code"
+	ruleNarrative   = "narrative"
+	ruleFileSize    = "file-size"
+	ruleTestSize    = "test-file-size"
+	ruleLayering    = "layering"
+	ruleFuncSize    = "function-size"
+	ruleComplexity  = "complexity"
+	ruleStructState = "struct-state"
 )
 
 var allRules = []string{
 	ruleEssay, ruleBanner, ruleMarker, ruleDeadCode,
 	ruleNarrative, ruleFileSize, ruleTestSize, ruleLayering,
-	ruleFuncSize, ruleComplexity,
+	ruleFuncSize, ruleComplexity, ruleStructState,
 }
 
 func main() {
@@ -123,6 +124,7 @@ func run(root string) ([]Finding, error) {
 		}
 		findings = append(findings, checkComments(src)...)
 		findings = append(findings, checkComplexity(src)...)
+		findings = append(findings, checkStructState(src)...)
 		imports[rel] = src.importRefs()
 	}
 	return append(findings, checkLayering(imports)...), nil

--- a/tools/repolint/structstate.go
+++ b/tools/repolint/structstate.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+)
+
+// Each independent scalar multiplies the states a guarded type can be in, and
+// nothing records which combinations are legal; grouping them by lifetime costs
+// one field and removes the whole product. Only types owning a mutex or atomic
+// are counted — a struct without one is not concurrently mutated state, and
+// counting config or DTOs would bury this finding under a translation table.
+const maxScalarFields = 12
+
+var scalarBasicTypes = map[string]bool{
+	"bool": true, "string": true, "byte": true, "rune": true,
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
+	"uintptr": true, "float32": true, "float64": true,
+}
+
+// atomic.Bool and friends are scalars whose concurrency contract is per-field,
+// which is exactly the combination problem this counts.
+var scalarQualifiedTypes = map[string]bool{
+	"atomic.Bool": true, "atomic.Int32": true, "atomic.Int64": true,
+	"atomic.Uint32": true, "atomic.Uint64": true, "atomic.Pointer": true,
+	"atomic.Value": true, "time.Duration": true, "time.Time": true,
+}
+
+// guardsConcurrentState reports whether the type owns a synchronisation
+// primitive, which is what separates state several goroutines reach from a
+// record that merely has fields.
+func guardsConcurrentState(st *ast.StructType) bool {
+	if st.Fields == nil {
+		return false
+	}
+	for _, field := range st.Fields.List {
+		sel, ok := unwrapPointer(field.Type).(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch pkg.Name + "." + sel.Sel.Name {
+		case "sync.Mutex", "sync.RWMutex":
+			return true
+		}
+		if pkg.Name == "atomic" {
+			return true
+		}
+	}
+	return false
+}
+
+func unwrapPointer(expr ast.Expr) ast.Expr {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		return star.X
+	}
+	return expr
+}
+
+func scalarFieldCount(st *ast.StructType) int {
+	if st.Fields == nil {
+		return 0
+	}
+	total := 0
+	for _, field := range st.Fields.List {
+		if !isScalarType(field.Type) {
+			continue
+		}
+		// An embedded scalar still occupies one slot in the product.
+		total += max(len(field.Names), 1)
+	}
+	return total
+}
+
+func isScalarType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return scalarBasicTypes[t.Name]
+	case *ast.SelectorExpr:
+		pkg, ok := t.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		return scalarQualifiedTypes[pkg.Name+"."+t.Sel.Name]
+	case *ast.IndexExpr: // atomic.Pointer[T]
+		return isScalarType(t.X)
+	}
+	return false
+}
+
+func checkStructState(s *sourceFile) []Finding {
+	if s.isTest() {
+		return nil
+	}
+	var out []Finding
+	ast.Inspect(s.file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		st, ok := spec.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		if !guardsConcurrentState(st) {
+			return false
+		}
+		if n := scalarFieldCount(st); n > maxScalarFields {
+			out = append(out, Finding{s.rel, s.line(spec.Pos()), ruleStructState,
+				fmt.Sprintf("%s carries %d scalar state fields, over the %d ceiling; group them by lifetime",
+					spec.Name.Name, n, maxScalarFields),
+				n - maxScalarFields})
+		}
+		return false
+	})
+	return out
+}

--- a/tools/repolint/structstate_test.go
+++ b/tools/repolint/structstate_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+func structSource(guard string, scalars int) string {
+	var b strings.Builder
+	b.WriteString("package p\n\nimport (\n\t\"sync\"\n\t\"sync/atomic\"\n)\n\nvar _ = sync.Mutex{}\nvar _ = atomic.Bool{}\n\ntype T struct {\n")
+	if guard != "" {
+		fmt.Fprintf(&b, "\t%s\n", guard)
+	}
+	for i := range scalars {
+		fmt.Fprintf(&b, "\tf%d bool\n", i)
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+// The rule exists for state several goroutines reach. A record with many fields
+// is describing many things, which is not the same defect and would bury it.
+func TestStructStateIgnoresTypesWithoutASynchronisationPrimitive(t *testing.T) {
+	s := parseBytes("t.go", []byte(structSource("", maxScalarFields*4)))
+	if got := checkStructState(s); len(got) != 0 {
+		t.Fatalf("a plain record was flagged: %v", got)
+	}
+}
+
+func TestStructStateFlagsGuardedTypesPastTheCeiling(t *testing.T) {
+	cases := []struct {
+		guard string
+		// An atomic guard is itself one of the scalars it makes concurrent, so
+		// it counts twice over; a mutex guards other fields and counts as none.
+		selfCounts int
+	}{
+		{"mu sync.Mutex", 0},
+		{"mu sync.RWMutex", 0},
+		{"mu *sync.Mutex", 0},
+		{"ready atomic.Bool", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.guard, func(t *testing.T) {
+			s := parseBytes("t.go", []byte(structSource(tc.guard, maxScalarFields+3)))
+			found := checkStructState(s)
+			if len(found) != 1 {
+				t.Fatalf("guarded type past the ceiling produced %d findings, want 1", len(found))
+			}
+			if want := 3 + tc.selfCounts; found[0].Weight != want {
+				t.Fatalf("weight = %d, want %d: the excess over the ceiling, so a worse struct outranks a better one",
+					found[0].Weight, want)
+			}
+		})
+	}
+}
+
+func TestStructStateCountsAtomicsAsScalars(t *testing.T) {
+	src := "package p\n\nimport \"sync/atomic\"\n\ntype T struct {\n\ta atomic.Bool\n\tb atomic.Int64\n\tc atomic.Uint64\n}\n"
+	s := parseBytes("t.go", []byte(src))
+	if got := scalarFieldCount(firstStruct(t, s)); got != 3 {
+		t.Fatalf("scalarFieldCount = %d, want 3: an atomic's concurrency contract is per-field", got)
+	}
+}
+
+func TestStructStateCountsEachNameInAGroupedDeclaration(t *testing.T) {
+	src := "package p\n\nimport \"sync\"\n\ntype T struct {\n\tmu sync.Mutex\n\ta, b, c bool\n}\n"
+	s := parseBytes("t.go", []byte(src))
+	if got := scalarFieldCount(firstStruct(t, s)); got != 3 {
+		t.Fatalf("scalarFieldCount = %d, want 3: `a, b, c bool` is three independent flags", got)
+	}
+}
+
+// Grouping by lifetime is the fix the message asks for, so it has to register:
+// one sub-state field must replace the whole product it absorbed.
+func TestStructStateFallsWhenScalarsMoveIntoASubState(t *testing.T) {
+	before := parseBytes("t.go", []byte(structSource("mu sync.Mutex", maxScalarFields+5)))
+	if len(checkStructState(before)) != 1 {
+		t.Fatal("fixture did not exceed the ceiling")
+	}
+	after := parseBytes("t.go", []byte("package p\n\nimport \"sync\"\n\ntype sub struct{ a, b, c, d, e bool }\n\ntype T struct {\n\tmu sync.Mutex\n\tturn sub\n}\n"))
+	if got := checkStructState(after); len(got) != 0 {
+		t.Fatalf("grouping five flags into one sub-state still flagged: %v", got)
+	}
+}
+
+func TestStructStateSkipsTestFiles(t *testing.T) {
+	s := parseBytes("t_test.go", []byte(structSource("mu sync.Mutex", maxScalarFields*3)))
+	if got := checkStructState(s); got != nil {
+		t.Fatalf("test file measured: %v", got)
+	}
+}
+
+func firstStruct(t *testing.T, s *sourceFile) *ast.StructType {
+	t.Helper()
+	var out *ast.StructType
+	ast.Inspect(s.file, func(n ast.Node) bool {
+		if st, ok := n.(*ast.StructType); ok && out == nil {
+			out = st
+		}
+		return out == nil
+	})
+	if out == nil {
+		t.Fatal("no struct in source")
+	}
+	return out
+}


### PR DESCRIPTION
## The measurement

`Agent`'s struct, sampled from git history:

| Date | Total fields | Bare scalars |
|------|-------------|--------------|
| 2026-05-29 | 16 | 8 |
| 2026-07-02 | 59 | 27 |
| 2026-08-02 | 89 | **52** |
| 2026-08-12 | 105 | **48** |

Each independent `bool`, counter, or atomic multiplies the states the type can
be in, and nothing in the language records which combinations are legal. Fixing
one boundary case by adding one more flag is cheap where it is written and paid
for by everyone who later has to reason about the product.

## Why a ratchet and not a refactor

The counter-pressure already exists and works. `agent.perTurnState` absorbed
five delivery flags together with an explicit lifetime —

```go
// completion is the report built as the turn ends; the host reads it while
// emitting TurnDone, before the next turn resets this state.
```

— and that is why the scalar count fell for the first time this month (52 → 48).
Grouping by *lifetime* rather than by feature is the right shape and it is
already happening.

What is missing is anything that stops the next flag from arriving faster than
the last one is grouped: −4 against +16 over the same ten days. A refactor moves
the current pile once and leaves that ratio untouched. A ratchet changes who
pays: the person adding flag 49 either groups something first or says in the PR
why it belongs to no existing lifetime.

## The rule

`struct-state` counts **scalars, not fields**. The field total cannot tell a new
flag from the container that just absorbed five, so grouping would score as no
progress — precisely the wrong incentive.

**Only mutex- or atomic-guarded types are measured.** A struct without a
synchronisation primitive is not concurrently mutated state, and this
distinction is what makes the rule usable rather than noise:

| Scope | Findings | Led by |
|-------|---------|--------|
| every struct | 131 | `i18n.Messages` (505 fields — a translation table), `RunMetrics` (79 — a metrics DTO) |
| guarded structs | **12** | `Agent` (59), `WorkspaceTab` (35), `Controller` (29), desktop `App` (27) |

Every one of the 12 is a type that genuinely coordinates concurrent state. No
DTO or config struct is flagged.

`Weight` is the excess over the ceiling, so the existing ratchet machinery
already prevents trading a small violation for a larger one.

## Baseline

The 12 existing violations are recorded via `-update`, which introducing a rule
requires. Per `REASONIX.md` that diff needs justification, so it was also
**scoped**: running `-update` on a clean `main-v2` produces 22 insertions of
unrelated drift (the baseline has fallen behind the tree on `essay`,
`file-size`, `function-size` and others). That drift is pre-existing and is
**not** included here — the committed baseline is `HEAD`'s, plus `struct-state`
entries only. Verified programmatically: every non-`struct-state` limit and
per-file count is byte-identical to `HEAD`.

That drift is worth a separate look, but it is not this PR's to fix.

## Verified both directions

- Clean tree today: no `struct-state` finding.
- Add one scalar to `Agent` → `struct-state is 48 over its 47 budget` **and**
  `repo total for struct-state is 160, above the 159 ceiling`. Both the per-file
  budget and the repo total trip, so the flag cannot be smuggled in by shrinking
  another struct.

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          clean apart from the pre-existing models.ts entry
go test ./...     all green
```

## Note on the prompt cache

`REASONIX.md` gains a six-line convention entry. That file is loaded into the
session system prompt, so the cache-stable prefix changes and existing sessions
pay one rebuild on their next start. No gate requires a `Cache-impact` field for
this path (neither guard script matches `tools/` or `REASONIX.md`), but the
effect is real and worth stating: a rule nobody can discover is a rule that does
not exist, and this one only works if the person about to add flag 49 has read
it.

## Next

The 48 scalars fall into roughly five lifetime groups (per-turn, capability
reminders, missing-reasoning recovery, storm/repeat detection, and ~12
construct-once config values that are harmless and should probably be exempted
by convention rather than counted). One group per PR is the follow-up; this
change only stops the bleeding.
