### PR TITLE
refactor(agent): group the capability gate's turn memory into one state

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -532,13 +532,8 @@ type Agent struct {
 	capabilityLedger *capability.Ledger
 	// capabilityAudit accumulates non-persisted routing/proxy counters.
 	capabilityAudit *capability.Audit
-	// lastCapabilityGate tracks prefer-reminder state across final-answer retries.
-	capabilityPreferReminded bool
-	// capabilityRequireMissSeen / capabilityPreferMissSeen remember that the
-	// final gate reported a miss earlier this turn, so a later clean gate is
-	// audited as a recovery. Reset per turn in SeedCapabilityRoute.
-	capabilityRequireMissSeen bool
-	capabilityPreferMissSeen  bool
+	// capabilityGate is the turn's gate memory across final-answer retries.
+	capabilityGate capabilityGateState
 	// pendingReviewWarnings are warn-level findings to surface in the final summary.
 	pendingReviewWarnings []string
 

--- a/internal/agent/capability_gate.go
+++ b/internal/agent/capability_gate.go
@@ -14,6 +14,16 @@ import (
 	"reasonix/internal/tool"
 )
 
+// capabilityGateState is one user turn's gate memory, scoped to the same turn
+// as the ledger it reads: whether the prefer reminder has already been spent,
+// and which kind of miss was reported, so a later clean gate is audited as a
+// recovery instead of a first pass. Zeroing the struct is the turn reset.
+type capabilityGateState struct {
+	preferReminded  bool
+	requireMissSeen bool
+	preferMissSeen  bool
+}
+
 // SeedCapabilityRoute installs the turn's route decision into the capability ledger.
 func (a *Agent) SeedCapabilityRoute(decision capability.RouteDecision) {
 	if a == nil {
@@ -24,9 +34,7 @@ func (a *Agent) SeedCapabilityRoute(decision capability.RouteDecision) {
 	}
 	a.capabilityLedger.Reset()
 	a.capabilityLedger.SeedCandidates(decision)
-	a.capabilityPreferReminded = false
-	a.capabilityRequireMissSeen = false
-	a.capabilityPreferMissSeen = false
+	a.capabilityGate = capabilityGateState{}
 }
 
 // CapabilityLedger returns the turn-scoped capability ledger (may be nil).
@@ -137,21 +145,21 @@ func (a *Agent) capabilityGateFailure() string {
 	if gate.Reason == "" {
 		// A clean gate after an earlier miss this turn is a recovery — the
 		// model was nudged and then actually invoked the capability.
-		if a.capabilityRequireMissSeen || a.capabilityPreferMissSeen {
+		if a.capabilityGate.requireMissSeen || a.capabilityGate.preferMissSeen {
 			if a.capabilityAudit != nil {
-				a.capabilityAudit.RecordGateRecovery(a.capabilityRequireMissSeen, a.capabilityPreferMissSeen)
+				a.capabilityAudit.RecordGateRecovery(a.capabilityGate.requireMissSeen, a.capabilityGate.preferMissSeen)
 			}
-			a.capabilityRequireMissSeen = false
-			a.capabilityPreferMissSeen = false
+			a.capabilityGate.requireMissSeen = false
+			a.capabilityGate.preferMissSeen = false
 		}
 		return ""
 	}
-	if gate.PreferRemind && !a.capabilityPreferReminded {
+	if gate.PreferRemind && !a.capabilityGate.preferReminded {
 		for _, id := range gate.PreferIDs {
 			a.capabilityLedger.MarkReminded(id)
 		}
-		a.capabilityPreferReminded = true
-		a.capabilityPreferMissSeen = true
+		a.capabilityGate.preferReminded = true
+		a.capabilityGate.preferMissSeen = true
 		if a.capabilityAudit != nil {
 			a.capabilityAudit.RecordGate(false, true, false)
 		}
@@ -173,14 +181,14 @@ func (a *Agent) capabilityGateFailure() string {
 		return gate.Reason
 	}
 	if len(gate.RequireIDs) > 0 {
-		a.capabilityRequireMissSeen = true
+		a.capabilityGate.requireMissSeen = true
 		if a.capabilityAudit != nil {
 			a.capabilityAudit.RecordGate(true, false, false)
 		}
 		return gate.Reason
 	}
 	if len(gate.PreferIDs) > 0 {
-		a.capabilityPreferMissSeen = true
+		a.capabilityGate.preferMissSeen = true
 		if a.capabilityAudit != nil {
 			a.capabilityAudit.RecordGate(false, true, false)
 		}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 159,
+    "struct-state": 156,
     "test-file-size": 69298
   },
   "files": {
@@ -454,7 +454,7 @@
       "essay": 85,
       "file-size": 2404,
       "function-size": 102,
-      "struct-state": 47
+      "struct-state": 44
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
First bucket under the `struct-state` ratchet from #8436.

## What was combining

Three bools on `Agent` were one turn's capability-gate memory:

```go
capabilityPreferReminded  bool
capabilityRequireMissSeen bool
capabilityPreferMissSeen  bool
```

They are reset together in `SeedCapabilityRoute` and read only by
`capabilityGateFailure`. Held separately they were three independent
multipliers in `Agent`'s state product, and nothing recorded that only some of
their eight combinations are reachable — `preferReminded` without
`preferMissSeen`, for instance, is not a state the code can produce.

`capabilityGateState` gives them the lifetime they already had, stated once:

```go
// capabilityGateState is one user turn's gate memory, scoped to the same turn
// as the ledger it reads: whether the prefer reminder has already been spent,
// and which kind of miss was reported, so a later clean gate is audited as a
// recovery instead of a first pass. Zeroing the struct is the turn reset.
```

This bucket went first because its coupling is the cleanest in the struct:
every read and write lived in `capability_gate.go`, with zero cross-file
references. So the type sits beside its only user, and the three-line reset
becomes zeroing a struct.

## The ratchet moves with it

`Agent`: **59 → 56** scalar fields. The baseline tightens to match —
`internal/agent/agent.go` 47 → 44, repo total 159 → 156.

This half matters as much as the refactor. Leaving the budget at 47 would
convert three repaid slots into headroom for three new flags, which is the
exact outcome the ratchet exists to prevent. The two numbers were edited
directly rather than via `-update`, so none of the pre-existing baseline drift
(noted in #8436) rides along — the diff is literally two integers.

## What was deliberately not moved

`preserveEvidenceOnce` and `deliveryRecoveryPending` look like per-turn flags
by name, and I had them slated for a turn bucket until reading the reset point.
`beginRunTurn` zeroes `perTurnState` and *then* reads both:

```go
a.perTurnState = perTurnState{}
a.resetStructuralRunGuards()
scope, scoped := DeliveryExecutionScopeFromContext(ctx)
preserveEvidence := a.preserveEvidenceOnce
a.readinessRecovered = preserveEvidence || a.deliveryRecoveryPending
```

Carrying a prior turn's readiness-recovery intent across the boundary is their
purpose, which the struct comment already states:

> Cross-turn state (checkpoint, scope, failure budgets) lives directly on Agent
> and is reconciled field by field.

Grouping by name instead of by reset point would have silently broken evidence
preservation on recovery continuations. Remaining buckets get the same check
before they move.

## Verification

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          clean apart from the pre-existing models.ts entry
go test ./...     all green
```

## Next

`stormSig` / `stormCount` / `repeatFailureScope` / `compactStuck` /
`consecutiveCompacts` — storm and repeat-failure detection. `progress_guard.go`
already clears several of them on one line, which is evidence they form a
group, but `compactStuck` is read across four files, so its boundary needs
checking before it moves.

Cache-impact: none - three unexported bools become fields of one unexported struct. No system-prompt text, tool schema, message content, or request shape is touched, so the provider-visible prefix is byte-identical; the change is invisible outside internal/agent.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing), plus the full internal/agent suite which covers the capability gate's reset and recovery paths.
Documentation-impact: none - docs/*.md describe the capability gate's behaviour, not the private field layout that implements it, and the behaviour is unchanged: the same reset point, the same recovery audit, the same gate reasons.
