### PR TITLE
fix(session): stop false diverged forks and bound depth-cap recovery / 修复误判 diverged 与 depth-cap 隔离副本无限增长

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -210,6 +210,18 @@ func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 	})
 }
 
+// saveBranchMetaKeepInFlightTurn keeps any existing in-flight turn on rewrite.
+func saveBranchMetaKeepInFlightTurn(sessionPath string, m BranchMeta) error {
+	return UpdateBranchMeta(sessionPath, true, func(current *BranchMeta) error {
+		if m.InFlightTurn == nil {
+			m.InFlightTurn = current.InFlightTurn
+		}
+		preserveBranchMetaPersistence(&m, *current)
+		*current = m
+		return nil
+	})
+}
+
 func SaveBranchMetaPreserveUpdated(sessionPath string, m BranchMeta) error {
 	return UpdateBranchMeta(sessionPath, false, func(current *BranchMeta) error {
 		preserveBranchMetaPersistence(&m, *current)

--- a/internal/agent/recovery_isolated.go
+++ b/internal/agent/recovery_isolated.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// ownsWritableBaseline: digest ownership, or exclusive lease at same revision (#8294).
+func (s *Session) ownsWritableBaseline(path string, existingDigest, rawDigest [sha256.Size]byte, rawDiffers bool, existingRevision int64, existingLedgerDigest string, nextVersion uint64) bool {
+	if s.ownsPersistedState(path, existingDigest, existingRevision, existingLedgerDigest, nextVersion) {
+		return true
+	}
+	if rawDiffers && s.ownsPersistedState(path, rawDigest, existingRevision, existingLedgerDigest, nextVersion) {
+		return true
+	}
+	state := s.persistState(path)
+	if !state.ok || !state.revisionKnown || state.version > nextVersion {
+		return false
+	}
+	if existingRevision != 0 && state.revision != existingRevision {
+		return false
+	}
+	return SessionLeaseHeldByCurrentRuntime(path)
+}
+
+// shutdownRecoverySessionPath is one fixed isolated path per writer (#8342).
+func shutdownRecoverySessionPath(originalPath string) string {
+	writerDigest := sha256.Sum256([]byte(SessionWriterID()))
+	suffix := fmt.Sprintf("-recovery-%x", writerDigest[:6])
+	id := BranchID(originalPath)
+	if strings.HasSuffix(id, suffix) {
+		return originalPath // already this writer's copy: rewrite in place
+	}
+	return filepath.Join(filepath.Dir(originalPath),
+		fmt.Sprintf("%s%s.jsonl", recoveryParentStem(id), suffix))
+}
+
+// writeRecoveryEventLog writes a recovery event log; isolated lanes compact.
+func writeRecoveryEventLog(path string, msgs []provider.Message, digest [sha256.Size]byte, isolated bool) error {
+	if isolated {
+		return compactSessionEventLog(path, msgs, digest, 0, "recovery")
+	}
+	return appendSessionReplaceEvent(path, msgs, digest, 0, "recovery")
+}

--- a/internal/agent/recovery_isolated_test.go
+++ b/internal/agent/recovery_isolated_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestSaveConflictRecoveryBranchAtCapStaysBounded(t *testing.T) {
+	dir := t.TempDir()
+	path, stale := divergedSessionPair(t, dir, "session.jsonl")
+	stampRecoveryMeta(t, path, SessionRecoveryMaxDepth)
+
+	// Depth-cap path once per autosave tick with a growing transcript (#8342).
+	current := path
+	for i := range 6 {
+		stale.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("tick %d", i)})
+		if _, err := stale.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: current}); !errors.Is(err, ErrSessionRecoveryDepthExceeded) {
+			t.Fatalf("tick %d: SaveRecoveryBranch err = %v, want ErrSessionRecoveryDepthExceeded", i, err)
+		}
+		info, err := stale.SaveConflictRecoveryBranch(RecoveryBranchOptions{OriginalPath: current})
+		if err != nil {
+			t.Fatalf("tick %d: SaveConflictRecoveryBranch: %v", i, err)
+		}
+		current = info.Path
+		if i == 0 {
+			// In-place rewrites must preserve markers the controller does not re-transplant.
+			if err := SetSessionInFlightTurn(current, InFlightTurnMeta{StartMessageIndex: 2}); err != nil {
+				t.Fatalf("SetSessionInFlightTurn: %v", err)
+			}
+		}
+	}
+
+	meta, ok, err := LoadBranchMeta(current)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if meta.InFlightTurn == nil || meta.InFlightTurn.StartMessageIndex != 2 {
+		t.Fatalf("in-flight turn marker = %+v, want StartMessageIndex 2", meta.InFlightTurn)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	var isolated []string
+	for _, m := range matches {
+		if !strings.HasSuffix(m, ".events.jsonl") {
+			isolated = append(isolated, m)
+		}
+	}
+	if len(isolated) != 1 {
+		t.Fatalf("isolated copies = %d, want 1: %v", len(isolated), isolated)
+	}
+}
+
+// Sibling lineages get distinct isolated copies; a copy is a fixed point.
+func TestShutdownRecoverySessionPathSeparatesSiblingLineages(t *testing.T) {
+	dir := t.TempDir()
+	root := shutdownRecoverySessionPath(filepath.Join(dir, "session.jsonl"))
+	fork := shutdownRecoverySessionPath(filepath.Join(dir, "session-recovery-abcd1234abcd1234.jsonl"))
+	if root == fork {
+		t.Fatalf("session and its fork share an isolated copy: %s", root)
+	}
+	if again := shutdownRecoverySessionPath(root); again != root {
+		t.Fatalf("isolated copy is not a fixed point: %s -> %s", root, again)
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -558,16 +558,8 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 	}
 	if !appendShaped && baseState.ok && baseState.revisionKnown &&
 		baseState.revision == currentRevision && !contentUnchanged {
-		// Revision equality alone is not ownership proof: another writer can
-		// land transcript/event-log bytes and crash before advancing the
-		// ledger. Require the current bytes to still match this Session's
-		// persisted digest (or its pre-normalization raw form) before treating
-		// an internally reshaped snapshot as a safe full rewrite.
-		owned := s.ownsPersistedState(path, existingDigest, currentRevision, currentLedgerDigest, nextVersion)
-		if !owned && rawDiffers {
-			owned = s.ownsPersistedState(path, rawDigest, currentRevision, currentLedgerDigest, nextVersion)
-		}
-		if owned {
+		// Digest ownership or exclusive lease at the same revision (#8294).
+		if s.ownsWritableBaseline(path, existingDigest, rawDigest, rawDiffers, currentRevision, currentLedgerDigest, nextVersion) {
 			appendShaped = true
 		}
 	}
@@ -618,14 +610,8 @@ func (s *Session) checkSnapshotWrite(path string, next []provider.Message, nextD
 		return decision, nil
 	}
 	if allowOwnedRewrite {
-		owned := s.ownsPersistedState(path, existingDigest, currentRevision, currentLedgerDigest, nextVersion)
-		if !owned && rawDiffers {
-			// The persisted baseline describes the bytes this session wrote, so
-			// a repaired view can never match it; ownership is judged against
-			// the raw transcript.
-			owned = s.ownsPersistedState(path, rawDigest, currentRevision, currentLedgerDigest, nextVersion)
-		}
-		if owned {
+		// Owned rewrite: digest baseline match, or exclusive lease (#8294).
+		if s.ownsWritableBaseline(path, existingDigest, rawDigest, rawDiffers, currentRevision, currentLedgerDigest, nextVersion) {
 			return snapshotWriteDecision{revision: currentRevision, repairLog: current.eventLogDamaged}, nil
 		}
 	}
@@ -683,10 +669,7 @@ func (s *Session) SaveShutdownRecoveryBranch(opts RecoveryBranchOptions) (Recove
 	return s.saveRecoveryBranch(opts, true)
 }
 
-// SaveConflictRecoveryBranch persists an isolated copy when the ordinary
-// recovery chain has reached its depth cap. It deliberately uses a writer-
-// specific path; the caller must never force an older in-memory snapshot back
-// onto the contested canonical branch just to stop creating nested branches.
+// SaveConflictRecoveryBranch writes the depth-cap isolated copy (one path per writer).
 func (s *Session) SaveConflictRecoveryBranch(opts RecoveryBranchOptions) (RecoveryBranchInfo, error) {
 	return s.saveRecoveryBranch(opts, true)
 }
@@ -775,7 +758,7 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 
 	recoveryPath := recoverySessionPath(originalPath, digest)
 	if shutdown {
-		recoveryPath = shutdownRecoverySessionPath(originalPath, digest)
+		recoveryPath = shutdownRecoverySessionPath(originalPath)
 	}
 	unlockRecovery := lockSessionSavePath(recoveryPath)
 	defer unlockRecovery()
@@ -804,15 +787,14 @@ func (s *Session) saveRecoveryBranch(opts RecoveryBranchOptions, shutdown bool) 
 	if err := os.MkdirAll(filepath.Dir(recoveryPath), 0o755); err != nil {
 		return RecoveryBranchInfo{}, fmt.Errorf("create recovery session dir: %w", err)
 	}
-	// Log first, anchor second: a crash in between leaves the (authoritative)
-	// log holding the recovered transcript. A foreign file at the log path is
-	// left alone; the recovery stays checkpoint-only then.
+	// Log first, anchor second. Foreign files at the log path stay untouched.
 	recoveryProbe, err := probeSessionEventLog(recoveryPath)
 	if err != nil {
 		return RecoveryBranchInfo{}, err
 	}
 	if recoveryProbe.native {
-		if err := appendSessionReplaceEvent(recoveryPath, msgs, digest, 0, "recovery"); err != nil {
+		// Isolated copies rewrite one path per writer; compact to bound log growth.
+		if err := writeRecoveryEventLog(recoveryPath, msgs, digest, shutdown); err != nil {
 			return RecoveryBranchInfo{}, err
 		}
 	}
@@ -864,7 +846,8 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 	if strings.TrimSpace(meta.WriterID) == "" {
 		meta.WriterID = SessionWriterID()
 	}
-	if err := SaveBranchMeta(path, meta); err != nil {
+	// Keep any in-flight turn marker across isolated in-place rewrites.
+	if err := saveBranchMetaKeepInFlightTurn(path, meta); err != nil {
 		return BranchMeta{}, err
 	}
 	if stored, ok, err := LoadBranchMeta(path); err != nil {
@@ -878,13 +861,6 @@ func (s *Session) saveRecoveryBranchMeta(path string, opts RecoveryBranchOptions
 func recoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
 	parent := recoveryParentStem(BranchID(originalPath))
 	return filepath.Join(filepath.Dir(originalPath), fmt.Sprintf("%s-recovery-%x.jsonl", parent, digest[:8]))
-}
-
-func shutdownRecoverySessionPath(originalPath string, digest [sha256.Size]byte) string {
-	parent := recoveryParentStem(BranchID(originalPath))
-	writerDigest := sha256.Sum256([]byte(SessionWriterID()))
-	return filepath.Join(filepath.Dir(originalPath),
-		fmt.Sprintf("%s-recovery-%x-%x.jsonl", parent, digest[:8], writerDigest[:6]))
 }
 
 func recoveryParentStem(parent string) string {

--- a/internal/agent/save_false_diverged_test.go
+++ b/internal/agent/save_false_diverged_test.go
@@ -1,0 +1,196 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func recoveryJSONL(dir string) []string {
+	matches, err := filepath.Glob(filepath.Join(dir, "*-recovery-*.jsonl"))
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, m := range matches {
+		if strings.HasSuffix(m, ".events.jsonl") {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// #8294 growth shape: pure append autosaves must never create recovery files.
+func TestSaveSnapshotStreamingAppendDoesNotDiverge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "hi", ReasoningContent: "think"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("u%d", i)})
+		s.Add(provider.Message{
+			Role: provider.RoleAssistant, Content: fmt.Sprintf("a%d", i),
+			ReasoningContent: fmt.Sprintf("r%d", i),
+			ToolCalls:        []provider.ToolCall{{ID: fmt.Sprintf("c%d", i), Name: "bash", Arguments: `{"cmd":"true"}`}},
+		})
+		s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: fmt.Sprintf("c%d", i), Name: "bash", Content: "ok", WorkDurationMs: int64(i)})
+		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("done%d", i), ReasoningContent: "more"})
+		if err := s.SaveSnapshot(path); err != nil {
+			t.Fatalf("SaveSnapshot turn %d: %v", i, err)
+		}
+	}
+	if got := recoveryJSONL(dir); len(got) != 0 {
+		t.Fatalf("recovery branches during pure append: %v", got)
+	}
+}
+
+// Lease + same revision authorizes rewrite when the shared prefix was reshaped (#8294).
+func TestSaveSnapshotLeaseHeldSameRevisionAllowsReshapedPrefix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "editing",
+		ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "edit", Arguments: `{"path":"f"}`}},
+	})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("mid-turn: %v", err)
+	}
+
+	lease, err := TryAcquireSessionLease(path)
+	if err != nil {
+		t.Fatalf("TryAcquireSessionLease: %v", err)
+	}
+	defer lease.Release()
+
+	// Disk reshape at same revision (digest ownership fails; lease authorizes).
+	foreign := NewSession("sys")
+	foreign.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
+	foreign.Add(provider.Message{
+		Role: provider.RoleAssistant, Content: "editing",
+		ToolCalls: []provider.ToolCall{{
+			ID: "call_1", Name: "edit", Arguments: `{"path":"f"}`,
+			Diff: "@@ -1 +1 @@\n-a\n+b\n", Added: 1, Removed: 1,
+		}},
+	})
+	foreignMsgs := foreign.Snapshot()
+	foreignDigest, err := digestSessionMessages(foreignMsgs)
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	revision, _, err := sessionContentRevision(path)
+	if err != nil {
+		t.Fatalf("sessionContentRevision: %v", err)
+	}
+	if err := appendSessionReplaceEvent(path, foreignMsgs, foreignDigest, revision, "snapshot"); err != nil {
+		t.Fatalf("append foreign reshape: %v", err)
+	}
+	if err := writeSessionMessages(path, foreignMsgs); err != nil {
+		t.Fatalf("write foreign reshape: %v", err)
+	}
+	// Intentionally leave the revision ledger at the original value.
+
+	if !s.UpdateToolCallPreview(provider.ToolCall{ID: "call_1", Diff: "@@ -1 +1 @@\n-a\n+b\n", Added: 1, Removed: 1}) {
+		t.Fatal("preview update failed")
+	}
+	s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "call_1", Name: "edit", Content: "ok"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "done", ReasoningContent: "r"})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatalf("SaveSnapshot with lease after reshape: %v", err)
+	}
+	if got := recoveryJSONL(dir); len(got) != 0 {
+		t.Fatalf("unexpected recovery branches: %v", got)
+	}
+
+	// Keep the 30s autosave cadence growing the transcript on the same path.
+	for i := 0; i < 10; i++ {
+		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("n%d", i)})
+		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("r%d", i)})
+		if err := s.SaveSnapshot(path); err != nil {
+			t.Fatalf("continue %d: %v", i, err)
+		}
+	}
+	if got := recoveryJSONL(dir); len(got) != 0 {
+		t.Fatalf("recovery branches after continued autosaves: %v", got)
+	}
+}
+
+// After an intentional recovery retarget, further appends must not cascade.
+func TestSaveSnapshotChainAfterRecoveryForkDoesNotCascade(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "start"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "ok"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("base: %v", err)
+	}
+
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "unsaved"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "local only tail"})
+	info, err := s.SaveRecoveryBranch(RecoveryBranchOptions{OriginalPath: path, Reason: "snapshot conflict"})
+	if err != nil {
+		t.Fatalf("SaveRecoveryBranch: %v", err)
+	}
+	for i := 0; i < 15; i++ {
+		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("u%d", i)})
+		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("a%d", i), ReasoningContent: "x"})
+		if err := s.SaveSnapshot(info.Path); err != nil {
+			var conflict *SessionSnapshotConflictError
+			if errors.As(err, &conflict) {
+				t.Fatalf("SaveSnapshot on recovery path turn %d diverged: %+v", i, conflict)
+			}
+			t.Fatalf("SaveSnapshot turn %d: %v", i, err)
+		}
+	}
+	if got := recoveryJSONL(dir); len(got) != 1 {
+		t.Fatalf("recovery files = %v (want only the intentional fork)", got)
+	}
+}
+
+// Without a lease, foreign bytes at the same revision still conflict.
+func TestSaveSnapshotRejectsInterruptedForeignWriteWithoutLease(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	base := NewSession("sys")
+	base.Add(provider.Message{Role: provider.RoleUser, Content: "base"})
+	if err := base.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	stale, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revision, _, err := sessionContentRevision(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignMessages := append(stale.Snapshot(),
+		provider.Message{Role: provider.RoleAssistant, Content: "foreign writer tail"})
+	foreignDigest, err := digestSessionMessages(foreignMessages)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := appendSessionReplaceEvent(path, foreignMessages, foreignDigest, revision, "snapshot"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessionMessages(path, foreignMessages); err != nil {
+		t.Fatal(err)
+	}
+	// Crash before recordSessionContentRevision: revision still equals baseline.
+
+	stale.Add(provider.Message{Role: provider.RoleAssistant, Content: "stale writer tail"})
+	err = stale.SaveSnapshot(path)
+	if !errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot err = %v, want ErrSessionSnapshotConflict", err)
+	}
+}

--- a/internal/agent/save_false_diverged_test.go
+++ b/internal/agent/save_false_diverged_test.go
@@ -35,7 +35,7 @@ func TestSaveSnapshotStreamingAppendDoesNotDiverge(t *testing.T) {
 	if err := s.SaveSnapshot(path); err != nil {
 		t.Fatalf("initial save: %v", err)
 	}
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("u%d", i)})
 		s.Add(provider.Message{
 			Role: provider.RoleAssistant, Content: fmt.Sprintf("a%d", i),
@@ -113,7 +113,7 @@ func TestSaveSnapshotLeaseHeldSameRevisionAllowsReshapedPrefix(t *testing.T) {
 	}
 
 	// Keep the 30s autosave cadence growing the transcript on the same path.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("n%d", i)})
 		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("r%d", i)})
 		if err := s.SaveSnapshot(path); err != nil {
@@ -142,7 +142,7 @@ func TestSaveSnapshotChainAfterRecoveryForkDoesNotCascade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveRecoveryBranch: %v", err)
 	}
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("u%d", i)})
 		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("a%d", i), ReasoningContent: "x"})
 		if err := s.SaveSnapshot(info.Path); err != nil {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -3827,23 +3827,7 @@ func (c *Controller) snapshotWithDurability(markActivity, forceRewrite, shutdown
 	if strategyErr != nil {
 		return false, strategyErr
 	}
-	forceRewrite = forceRewrite || s.NeedsRewriteSave()
-	var err error
-	if forceRewrite {
-		err = s.SaveRewrite(path)
-	} else {
-		err = s.SaveSnapshot(path)
-		if errors.Is(err, agent.ErrSessionSnapshotConflict) {
-			// The no-rewrite decision may already be stale: auto-compaction
-			// can rewrite history between the decision and the write. Re-check
-			// and retry once as an owned rewrite before treating the failure as
-			// a real cross-runtime conflict.
-			if s.NeedsRewriteSave() {
-				forceRewrite = true
-				err = s.SaveRewrite(path)
-			}
-		}
-	}
+	err, forceRewrite := persistSessionSnapshot(s, path, forceRewrite)
 	if err != nil {
 		if shutdownRecovery && errors.Is(err, agent.ErrSessionFileLockHeld) {
 			recoveredPath, recoverErr := c.recoverShutdownSnapshot(path, err)

--- a/internal/control/snapshot_same_revision.go
+++ b/internal/control/snapshot_same_revision.go
@@ -1,0 +1,45 @@
+package control
+
+import (
+	"errors"
+
+	"reasonix/internal/agent"
+)
+
+// persistSessionSnapshot writes path with snapshot semantics, escalating to an
+// owned rewrite when mid-turn reshape or same-revision divergence is detected
+// (#8294). Returns whether the successful or final attempt used SaveRewrite.
+func persistSessionSnapshot(s *agent.Session, path string, forceRewrite bool) (error, bool) {
+	if s == nil {
+		return nil, forceRewrite
+	}
+	forceRewrite = forceRewrite || s.NeedsRewriteSave()
+	if forceRewrite {
+		return s.SaveRewrite(path), true
+	}
+	err := s.SaveSnapshot(path)
+	if !errors.Is(err, agent.ErrSessionSnapshotConflict) {
+		return err, false
+	}
+	// Auto-compaction may rewrite between the decision and the write.
+	if s.NeedsRewriteSave() {
+		return s.SaveRewrite(path), true
+	}
+	// Same-revision diverged: prefer rewrite over a recovery fork (#8294).
+	if err2, ok := retrySameRevisionDivergedRewrite(s, path, err); ok {
+		return err2, true
+	}
+	return err, false
+}
+
+func retrySameRevisionDivergedRewrite(s *agent.Session, path string, err error) (error, bool) {
+	kind, ok := agent.SnapshotConflictKind(err)
+	if !ok || kind != agent.SessionSnapshotConflictDiverged {
+		return err, false
+	}
+	var conflict *agent.SessionSnapshotConflictError
+	if !errors.As(err, &conflict) || conflict == nil || conflict.BaseRevision != conflict.DiskRevision {
+		return err, false
+	}
+	return s.SaveRewrite(path), true
+}


### PR DESCRIPTION
## Summary

Stop mid-turn autosaves from forking recovery branches on same-revision reshapes, and bound depth-cap isolation to one file per writer so recovery storms cannot fill the sessions directory.

## Problem

- Desktop mid-turn autosaves could classify a same-revision reshape as `diverged`, forking a recovery branch about every 30s.
- The session list (and after v1.24.0 the session catalog UI) then showed near-duplicate conversations.
- Once the ordinary recovery chain hit the depth cap, each autosave still created a new digest-keyed isolated file, so the amplifier never stopped (#8342: thousands of recovery files).

## Root cause

1. **False diverged (#8294):** `checkSnapshotWrite` required a byte-exact digest match for same-revision ownership. Local-only tool preview metadata and load-time reshaping made the shared prefix disagree even when this runtime held the exclusive session lease and the ledger never advanced (`base_revision == disk_revision`, `snapshot_messages = disk + δ`).
2. **Unbounded isolation (#8342):** `SaveConflictRecoveryBranch` named isolated copies by content digest. A growing transcript at the cap produced one new file per save.

## Fix

- Treat same-revision writes as owned when **digest ownership** holds **or** the current process holds the **session lease**. Unleased foreign same-revision bytes still conflict.
- Prefer one owned `SaveRewrite` for same-revision diverged before forking a recovery branch.
- Bound depth-cap/shutdown isolation to **one fixed path per writer**, compact its event log, and preserve in-flight turn markers on in-place rewrite.

## User-visible impact

- Stops continuous `-recovery-*` creation during normal single-window streaming/tool turns.
- Stops disk-filling isolated copies after the depth cap.
- Complements v1.24.1 catalog `RecoveryCopy` hiding (#8425): that fixed display of covered copies; this stops producing the storm that fills the list with non-covered branches.

## Issues

- Fixes #8294
- Fixes #8342
- Refs #8437 #8434 #8423 #8421 (user-visible duplicate session lists / recovery storms)
- Incorporates the depth-cap bounding approach from #8430

## Verification

- `go test ./internal/agent/ -run 'TestSaveSnapshot|TestSaveConflict|TestShutdownRecovery'`
- `go test ./internal/control/ -run 'Snapshot|Recovery|Conflict'`
- `go test -race` on the same subsets
- `go vet ./internal/agent/ ./internal/control/`
- `go run ./tools/repolint` clean

New regressions:

- pure append autosaves create 0 recovery files
- lease + same-revision prefix reshape rewrites in place
- intentional recovery retarget does not cascade
- unleased interrupted foreign write still conflicts
- depth-cap isolated path stays at 1 file across 6 growing ticks

Cache-impact: none - no prompt, tool schema, or provider request changes
Cache-guard: not required - changed paths are outside provider-visible cache construction
Documentation-impact: none - internal session save/recovery contracts only; existing recovery and session catalog docs remain correct
System-prompt-review: n/a

## 中文摘要

修复 mid-turn autosave 在同 revision 下因本地 metadata 前缀不齐误判 `diverged`、每约 30 秒 fork recovery 的问题；depth-cap 后隔离副本改为每 writer 固定一个路径并原地 rewrite，避免 sessions 目录被无限灌满。与 v1.24.1 catalog 隐藏 covered 副本互补：前者管展示，本 PR 管停产。