### PR TITLE
refactor(agent): group the missing-reasoning incident into one watch

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -322,23 +322,9 @@ type Agent struct {
 	lastPrefixShape     PrefixShape
 	haveLastPrefixShape bool
 
-	// warnedMissingToolCallReasoning marks one active missing-reasoning incident
-	// within this agent. The legacy name is retained because the persisted state
-	// predates silent recovery; it now gates one automatic retry rather than a
-	// user-visible warning. A healthy tool-call turn clears it. Loop-owned;
-	// reset by SetSession.
-	warnedMissingToolCallReasoning bool
-	// missingReasoningWarnStateChecked avoids a file transaction on every
-	// healthy tool-call turn. It resets with the session so a new Agent can
-	// continue or confirm an incident persisted by an earlier process.
-	missingReasoningWarnStateChecked bool
-	// missingReasoningHealthyStreak provides the same three-turn anti-flapping
-	// policy when no cross-process state directory is configured.
-	missingReasoningHealthyStreak int
-	// missingReasoningWarnPendingResolveAt keeps a healthy observation retryable
-	// when its state write fails. The next missing turn retries that watermark
-	// before consulting the persisted incident and otherwise fails visible.
-	missingReasoningWarnPendingResolveAt time.Time
+	// missingReasoning is the live view of one missing-reasoning incident.
+	// Loop-owned; SetSession clears all of it but the resolve watermark.
+	missingReasoning missingReasoningWatch
 
 	// missingReasoningWarnState rate-limits recovery retries across sessions and
 	// processes by an opaque provider-configuration fingerprint (#7059). The
@@ -839,9 +825,12 @@ func (a *Agent) SetSession(s *Session) {
 	a.sessCacheHit.Store(0)
 	a.sessCacheMiss.Store(0)
 	a.resetOutputBudgetState()
-	a.warnedMissingToolCallReasoning = false
-	a.missingReasoningWarnStateChecked = false
-	a.missingReasoningHealthyStreak = 0
+	// pendingResolveAt is deliberately not cleared: an unwritten resolve
+	// watermark belongs to the provider configuration, not to the conversation
+	// being replaced, and the next missing turn still owes it a retry.
+	a.missingReasoning.active = false
+	a.missingReasoning.stateRecorded = false
+	a.missingReasoning.healthyStreak = 0
 	a.repeatFailureCounts = nil
 	a.repeatFailureScope = ""
 	a.compactionMu.Lock()
@@ -1529,94 +1518,6 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	state.runLimitHostOwned = runLimitHostOwned
 	state.workDurationMs = workDurationMs
 	return a.runToolLoop(ctx, state)
-}
-
-// observeMissingToolCallReasoning classifies a thinking-mode tool-call turn and
-// claims the single silent retry allowed for its active compatibility incident.
-// DeepSeek requires provider-issued thinking content to be replayed, so a
-// missing value is retried once before tools execute. Persistent broken rounds
-// use the existing exact-configuration cooldown; a healthy round resolves the
-// incident after three consecutive healthy turns and re-arms a future isolated
-// regression (#6259, #7059).
-func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) (missing, shouldRetry bool) {
-	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.prov) {
-		return false, false
-	}
-	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(a.prov)
-	observedAt := time.Now()
-	if strings.TrimSpace(reasoning) != "" {
-		if a.missingReasoningWarnState == nil {
-			if a.warnedMissingToolCallReasoning {
-				a.missingReasoningHealthyStreak++
-				if a.missingReasoningHealthyStreak >= missingReasoningHealthyResolveStreak {
-					a.warnedMissingToolCallReasoning = false
-					a.missingReasoningHealthyStreak = 0
-				}
-			}
-			return false, false
-		}
-		shouldResolve := !a.missingReasoningWarnStateChecked || a.warnedMissingToolCallReasoning
-		if shouldResolve {
-			result := missingReasoningResolveResult{Recorded: true, Resolved: true}
-			if pending := a.missingReasoningWarnPendingResolveAt; !pending.IsZero() {
-				result = a.missingReasoningWarnState.resolveAt(fingerprint, pending)
-				if result.Recorded {
-					a.missingReasoningWarnPendingResolveAt = time.Time{}
-				}
-			}
-			if result.Recorded {
-				result = a.missingReasoningWarnState.resolveAt(fingerprint, observedAt)
-			}
-			if !result.Recorded {
-				if observedAt.After(a.missingReasoningWarnPendingResolveAt) {
-					a.missingReasoningWarnPendingResolveAt = observedAt
-				}
-				a.warnedMissingToolCallReasoning = true
-				a.missingReasoningWarnStateChecked = false
-			} else if result.Resolved {
-				a.warnedMissingToolCallReasoning = false
-				a.missingReasoningWarnStateChecked = true
-			} else {
-				a.warnedMissingToolCallReasoning = true
-				a.missingReasoningWarnStateChecked = false
-			}
-		}
-		return false, false
-	}
-	a.missingReasoningHealthyStreak = 0
-	if s := a.missingReasoningWarnState; s != nil {
-		stateReady := true
-		alreadyActive := a.warnedMissingToolCallReasoning
-		if pending := a.missingReasoningWarnPendingResolveAt; !pending.IsZero() {
-			result := s.resolveAt(fingerprint, pending)
-			stateReady = result.Recorded
-			if result.Recorded {
-				a.missingReasoningWarnPendingResolveAt = time.Time{}
-				if result.Resolved {
-					alreadyActive = false
-					a.warnedMissingToolCallReasoning = false
-				}
-			}
-		}
-		claimed := stateReady && s.claimAt(fingerprint, observedAt)
-		if !claimed || alreadyActive {
-			// This exact configuration already attempted recovery for the active
-			// incident, so keep the empty-key fallback without doubling requests.
-			a.warnedMissingToolCallReasoning = true
-			a.missingReasoningWarnStateChecked = true
-			return true, false
-		}
-		if !stateReady {
-			a.missingReasoningWarnStateChecked = false
-		}
-	} else if a.warnedMissingToolCallReasoning {
-		return true, false
-	}
-	a.warnedMissingToolCallReasoning = true
-	if a.missingReasoningWarnPendingResolveAt.IsZero() {
-		a.missingReasoningWarnStateChecked = true
-	}
-	return true, true
 }
 
 // ReadinessResult is the host-consumable outcome of the Delivery final-answer

--- a/internal/agent/missing_reasoning_watch.go
+++ b/internal/agent/missing_reasoning_watch.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"strings"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// missingReasoningWatch is this agent's live view of one incident: whether it
+// is active, whether the persisted state already records it, how many healthy
+// rounds have run since, and a resolve timestamp whose write failed. The four
+// only ever move together, and only observeMissingToolCallReasoning moves them.
+type missingReasoningWatch struct {
+	active           bool      // gates the one automatic retry, not a user-visible warning
+	stateRecorded    bool      // avoids a file transaction on every healthy tool-call turn
+	healthyStreak    int       // anti-flapping when no cross-process state dir is configured
+	pendingResolveAt time.Time // a resolve whose write failed; outlives SetSession
+}
+
+// observeMissingToolCallReasoning classifies a thinking-mode tool-call turn and
+// claims the one silent retry its active incident allows. DeepSeek requires
+// provider-issued thinking content to be replayed, so a missing value is retried
+// once before tools execute; three consecutive healthy rounds then resolve the
+// incident and re-arm a future isolated regression (#6259, #7059).
+func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) (missing, shouldRetry bool) {
+	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.prov) {
+		return false, false
+	}
+	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(a.prov)
+	observedAt := time.Now()
+	if strings.TrimSpace(reasoning) != "" {
+		if a.missingReasoningWarnState == nil {
+			if a.missingReasoning.active {
+				a.missingReasoning.healthyStreak++
+				if a.missingReasoning.healthyStreak >= missingReasoningHealthyResolveStreak {
+					a.missingReasoning.active = false
+					a.missingReasoning.healthyStreak = 0
+				}
+			}
+			return false, false
+		}
+		shouldResolve := !a.missingReasoning.stateRecorded || a.missingReasoning.active
+		if shouldResolve {
+			result := missingReasoningResolveResult{Recorded: true, Resolved: true}
+			if pending := a.missingReasoning.pendingResolveAt; !pending.IsZero() {
+				result = a.missingReasoningWarnState.resolveAt(fingerprint, pending)
+				if result.Recorded {
+					a.missingReasoning.pendingResolveAt = time.Time{}
+				}
+			}
+			if result.Recorded {
+				result = a.missingReasoningWarnState.resolveAt(fingerprint, observedAt)
+			}
+			if !result.Recorded {
+				if observedAt.After(a.missingReasoning.pendingResolveAt) {
+					a.missingReasoning.pendingResolveAt = observedAt
+				}
+				a.missingReasoning.active = true
+				a.missingReasoning.stateRecorded = false
+			} else if result.Resolved {
+				a.missingReasoning.active = false
+				a.missingReasoning.stateRecorded = true
+			} else {
+				a.missingReasoning.active = true
+				a.missingReasoning.stateRecorded = false
+			}
+		}
+		return false, false
+	}
+	a.missingReasoning.healthyStreak = 0
+	if s := a.missingReasoningWarnState; s != nil {
+		stateReady := true
+		alreadyActive := a.missingReasoning.active
+		if pending := a.missingReasoning.pendingResolveAt; !pending.IsZero() {
+			result := s.resolveAt(fingerprint, pending)
+			stateReady = result.Recorded
+			if result.Recorded {
+				a.missingReasoning.pendingResolveAt = time.Time{}
+				if result.Resolved {
+					alreadyActive = false
+					a.missingReasoning.active = false
+				}
+			}
+		}
+		claimed := stateReady && s.claimAt(fingerprint, observedAt)
+		if !claimed || alreadyActive {
+			// This exact configuration already attempted recovery for the active
+			// incident, so keep the empty-key fallback without doubling requests.
+			a.missingReasoning.active = true
+			a.missingReasoning.stateRecorded = true
+			return true, false
+		}
+		if !stateReady {
+			a.missingReasoning.stateRecorded = false
+		}
+	} else if a.missingReasoning.active {
+		return true, false
+	}
+	a.missingReasoning.active = true
+	if a.missingReasoning.pendingResolveAt.IsZero() {
+		a.missingReasoning.stateRecorded = true
+	}
+	return true, true
+}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 156,
+    "struct-state": 152,
     "test-file-size": 69298
   },
   "files": {
@@ -452,9 +452,9 @@
     "internal/agent/agent.go": {
       "complexity": 37,
       "essay": 85,
-      "file-size": 2404,
+      "file-size": 2317,
       "function-size": 102,
-      "struct-state": 44
+      "struct-state": 40
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
Second bucket under the `struct-state` ratchet (#8436), after #8439.

## What was combining

Four fields on `Agent` tracked one provider incident:

```go
warnedMissingToolCallReasoning       bool
missingReasoningWarnStateChecked     bool
missingReasoningHealthyStreak        int
missingReasoningWarnPendingResolveAt time.Time
```

`observeMissingToolCallReasoning` is their only writer, and it moves them
together in **twelve places across eighty lines**. Read as four independent
fields they suggest sixteen-plus states; in practice only a handful are
reachable, and nothing said so.

`missingReasoningWatch` names them for their role instead of their history —
`warnedMissingToolCallReasoning` → `active`, `missingReasoningWarnStateChecked`
→ `stateRecorded`. The legacy names exist to protect an **on-disk** contract,
which `missingReasoningWarnState` (untouched here) still owns. The in-memory
view carries no such obligation, and `a.missingReasoning.active` says what
`a.warnedMissingToolCallReasoning` only hinted at.

The type and its single user move into their own file, which also takes **87
lines out of `agent.go`** (3194 → 3107).

## The one thing deliberately not tidied

`SetSession` clears three of the four and leaves `pendingResolveAt` alone.
Zeroing the struct is the obvious write, and it would have been wrong:

```go
// pendingResolveAt is deliberately not cleared: an unwritten resolve
// watermark belongs to the provider configuration, not to the conversation
// being replaced, and the next missing turn still owes it a retry.
a.missingReasoning.active = false
a.missingReasoning.stateRecorded = false
a.missingReasoning.healthyStreak = 0
```

Collapsing it to `a.missingReasoning = missingReasoningWatch{}` would silently
drop a pending resolve on every session switch. No test would have caught it —
the failure is a state write that never happens, on a path that only runs after
an earlier write already failed.

This is the same lesson as #8439's `preserveEvidenceOnce`: grouping fields is
safe, assuming they share a reset is not. Each bucket gets its reset points read
before it moves.

## Ratchet

`Agent`: **56 → 52** scalars. Baseline tightened to match — `agent.go` 44 → 40,
total 156 → 152.

`file-size` for `agent.go` also drops 2404 → 2317, paying back exactly the 87
lines moved out. The ~10-unit drift already recorded on that entry is left
untouched: correcting it belongs to whatever PR takes on the baseline drift as a
whole, not to a refactor that happens to touch the same number.

## Verification

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          clean apart from the two pre-existing entries
go test ./...     all green
```

The moved code is unchanged apart from field renames; the incident state machine
itself was not touched.

## Progress

| | Agent scalars |
|---|---|
| before the ratchet | 59 |
| after #8439 (capability) | 56 |
| after this (missing-reasoning) | **52** |

Cache-impact: none - four unexported fields become one unexported struct on Agent, with renames confined to internal/agent. No system-prompt text, tool schema, message content, or request shape changes; the moved function's logic is identical, so the provider-visible prefix is byte-identical.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing), plus the full internal/agent suite, which covers the missing-reasoning retry and resolve paths.
Documentation-impact: none - docs/*.md describe the missing-reasoning retry behaviour, not the private fields implementing it, and that behaviour is unchanged: same retry claim, same three-round resolve, same cross-session watermark handling.
