### PR TITLE
refactor(agent): group the recovery gate's identity into one value

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -370,14 +370,8 @@ type Agent struct {
 	// Shared by root and sub-agents for the same controller task. nil disables
 	// recovery checks (Ask/YOLO, headless without wiring, or feature off).
 	recoveryGate RecoveryGate
-	// recoveryAgentID labels this agent on recovery cards (empty = root).
-	recoveryAgentID string
-	// recoveryTaskID isolates recovery state across concurrent top-level tasks.
-	// Empty shares the root task bucket.
-	recoveryTaskID string
-	// recoveryRunSeq gives ordinary (non-goal) runs a collision-free host scope.
-	// Goal runs use their stable delivery scope instead.
-	recoveryRunSeq atomic.Uint64
+	// recovery is who this agent is to the shared gate above.
+	recovery recoveryIdentity
 
 	// planModeReadOnlyTrust is retained for legacy controller wiring. The main
 	// Plan execution path no longer consults it.
@@ -703,8 +697,8 @@ func (a *Agent) SetRecoveryIdentity(agentID, taskID string) {
 	if a == nil {
 		return
 	}
-	a.recoveryAgentID = strings.TrimSpace(agentID)
-	a.recoveryTaskID = strings.TrimSpace(taskID)
+	a.recovery.agentID = strings.TrimSpace(agentID)
+	a.recovery.taskID = strings.TrimSpace(taskID)
 }
 
 // RecoveryGate returns the attached Auto Guard (may be nil).
@@ -1301,25 +1295,27 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		reasoningByteLimit = defaultReasoningByteLimit
 	}
 	a := &Agent{
-		prov:                      prov,
-		tools:                     tools,
-		session:                   session,
-		taskBudget:                runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
-		maxSteps:                  opts.MaxSteps,
-		maxStepsKey:               maxStepsKey,
-		reasoningByteLimit:        reasoningByteLimit,
-		maxOutputTokens:           opts.MaxOutputTokens,
-		temperature:               opts.Temperature,
-		pricing:                   opts.Pricing,
-		usageSource:               usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
-		modelRef:                  strings.TrimSpace(opts.ModelRef),
-		sink:                      sink,
-		requireVisibleFinal:       opts.RequireVisibleFinal,
-		gate:                      gate,
-		extensions:                opts.Extensions,
-		recoveryGate:              opts.RecoveryGate,
-		recoveryAgentID:           strings.TrimSpace(opts.RecoveryAgentID),
-		recoveryTaskID:            strings.TrimSpace(opts.RecoveryTaskID),
+		prov:                prov,
+		tools:               tools,
+		session:             session,
+		taskBudget:          runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
+		maxSteps:            opts.MaxSteps,
+		maxStepsKey:         maxStepsKey,
+		reasoningByteLimit:  reasoningByteLimit,
+		maxOutputTokens:     opts.MaxOutputTokens,
+		temperature:         opts.Temperature,
+		pricing:             opts.Pricing,
+		usageSource:         usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
+		modelRef:            strings.TrimSpace(opts.ModelRef),
+		sink:                sink,
+		requireVisibleFinal: opts.RequireVisibleFinal,
+		gate:                gate,
+		extensions:          opts.Extensions,
+		recoveryGate:        opts.RecoveryGate,
+		recovery: recoveryIdentity{
+			agentID: strings.TrimSpace(opts.RecoveryAgentID),
+			taskID:  strings.TrimSpace(opts.RecoveryTaskID),
+		},
 		readOnlyExecution:         opts.ReadOnlyExecution,
 		plannerMCPExecution:       opts.PlannerMCPExecution,
 		planModeReadOnlyTrust:     planModeReadOnlyTrust,
@@ -1464,7 +1460,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 			runMaxStepsKey = limit.key
 		}
 	}
-	a.recoveryRunSeq.Add(1)
+	a.recovery.runSeq.Add(1)
 	// All role settings participate in the workspace lease for the run; the
 	// exclusive write lock is still acquired lazily on the first real writer.
 	if a.workspaceLease != nil {

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -486,7 +486,7 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 	episodeStopped := false
 	if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
 		plan.recoveryGen = ctrl.Generation()
-		episodeStopped = ctrl.EpisodeStopped(a.recoveryTaskID)
+		episodeStopped = ctrl.EpisodeStopped(a.recovery.taskID)
 	}
 	if a.recoveryGate != nil && (plan.mutates || plan.verification || plan.planTransition || episodeStopped) {
 		subject := recoverySubject(plan.evidenceName, plan.evidenceArgs)

--- a/internal/agent/goal_run_boundary.go
+++ b/internal/agent/goal_run_boundary.go
@@ -63,7 +63,7 @@ func (a *Agent) stopUnexecutedBoundaryCalls(state *runLoopState, calls []provide
 		return a.gracePause(state), true
 	case state.recoveryGraceRound:
 		if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
-			_, _ = ctrl.ConsumeFinalization(a.recoveryTaskID)
+			_, _ = ctrl.ConsumeFinalization(a.recovery.taskID)
 		}
 		a.pairUnexecutedGraceCalls(calls, "blocked: Auto recovery already paused this turn. Do not call tools; the user will continue in the next message.")
 		a.contextManager().ObserveUsage(usage)

--- a/internal/agent/plan_transition_diff.go
+++ b/internal/agent/plan_transition_diff.go
@@ -49,9 +49,9 @@ func planFromTodos(todos []evidence.TodoItem, revision int) (plancontract.Plan, 
 // It lives beside the plan diff because that is the field most likely to grow.
 func (a *Agent) recoveryProposal(plan *toolCallPlan, episodeID, subject, preview string) RecoveryProposal {
 	return RecoveryProposal{
-		AgentID:        a.recoveryAgentID,
-		TaskID:         a.recoveryTaskID,
-		TaskScopeID:    recoveryTaskScopeID(a.deliveryScopeID, a.recoveryRunSeq.Load()),
+		AgentID:        a.recovery.agentID,
+		TaskID:         a.recovery.taskID,
+		TaskScopeID:    recoveryTaskScopeID(a.deliveryScopeID, a.recovery.runSeq.Load()),
 		EpisodeID:      episodeID,
 		TaskSummary:    a.recoveryTaskSummary,
 		Tool:           plan.evidenceName,

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -5,9 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync/atomic"
 
 	"reasonix/internal/evidence"
 )
+
+// recoveryIdentity is who this agent is to the shared gate: the labels a
+// recovery card shows, and a run counter that keeps ordinary (non-goal) runs of
+// one task in collision-free scopes. Goal runs use their stable delivery scope
+// instead, so the counter is only ever read through recoveryTaskScopeID.
+type recoveryIdentity struct {
+	agentID string        // empty = root
+	taskID  string        // empty shares the root task bucket
+	runSeq  atomic.Uint64 // bumped per Run; never reset
+}
 
 // RecoveryGate is the host-side Auto Guard consulted by the agent around tool
 // execution. It is independent of the permission Gate and of
@@ -208,9 +219,9 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 		}
 	}
 	guidance := a.recoveryGate.ObserveResult(ctx, RecoveryObservation{
-		AgentID:      a.recoveryAgentID,
-		TaskID:       a.recoveryTaskID,
-		TaskScopeID:  recoveryTaskScopeID(a.deliveryScopeID, a.recoveryRunSeq.Load()),
+		AgentID:      a.recovery.agentID,
+		TaskID:       a.recovery.taskID,
+		TaskScopeID:  recoveryTaskScopeID(a.deliveryScopeID, a.recovery.runSeq.Load()),
 		EpisodeID:    episodeID,
 		Generation:   generation,
 		Tool:         toolName,

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -534,7 +534,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 		a.contextManager().ObserveUsage(usage)
 		reason := ""
 		if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
-			_, _ = ctrl.ConsumeFinalization(a.recoveryTaskID)
+			_, _ = ctrl.ConsumeFinalization(a.recovery.taskID)
 		}
 		return false, &RecoveryPauseError{
 			Message:    "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send \"continue\" to start a fresh attempt, or add instructions to change direction.",
@@ -682,7 +682,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 	if batch.recoveryStopTurn && !state.recoveryGraceRound {
 		state.recoveryGraceRound = true
 		if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
-			ctrl.MarkFinalizationOffered(a.recoveryTaskID)
+			ctrl.MarkFinalizationOffered(a.recovery.taskID)
 		}
 		nudge := "Auto recovery has reached its limit for this turn. Do not call any more tools. Summarize what was completed, what failed, and what the user should do next. The user can continue in the next message."
 		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 152,
+    "struct-state": 149,
     "test-file-size": 69298
   },
   "files": {
@@ -452,9 +452,9 @@
     "internal/agent/agent.go": {
       "complexity": 37,
       "essay": 85,
-      "file-size": 2317,
+      "file-size": 2301,
       "function-size": 102,
-      "struct-state": 40
+      "struct-state": 37
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
Third bucket under the `struct-state` ratchet (#8436), after #8439 and #8447.

## The concept already had a name

```go
recoveryAgentID string
recoveryTaskID  string
recoveryRunSeq  atomic.Uint64
```

Both readers build a `RecoveryObservation` whose first three fields are exactly
these, in order:

```go
AgentID:     a.recovery.agentID,
TaskID:      a.recovery.taskID,
TaskScopeID: recoveryTaskScopeID(a.deliveryScopeID, a.recovery.runSeq.Load()),
```

And `Agent` already exposed them through `SetRecoveryIdentity`. The grouping was
named in the setter, named in the observation type, and unnamed only in the
struct that owned it.

`recoveryIdentity` puts it beside the gate it describes, in `recovery_gate.go`.

## One mechanical note

The counter stays an `atomic.Uint64` inside the value, so the identity is
assigned field by field rather than wholesale. An atomic cannot be copied, and
nothing here wants to reset the counter anyway — `runSeq` is bumped per `Run`
and never cleared, which the field comment now states.

## Ratchet

`Agent`: **52 → 49** scalars. Baseline tightened — `agent.go` 40 → 37, total
152 → 149, and `file-size` 2317 → 2301 for the 16 lines removed.

## Verification

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          clean apart from the two pre-existing entries
go test ./...     all green
```

## Progress

| | Agent scalars |
|---|---|
| before the ratchet | 59 |
| #8439 capability | 56 |
| #8447 missing-reasoning | 52 |
| this (recovery identity) | **49** |

Ten scalars retired across three buckets, each one a group that already had a
shared reset, a shared reader, or a shared name — none invented for the sake of
the count.

## What is deliberately staying

Two candidates were checked and rejected rather than moved:

- `stormSig` / `stormCount` — cross-turn by design. `perTurnState`'s own doc
  says storm counters stay directly on `Agent`, and `blockedTurnStreak` (which
  *is* per-turn) already lives in `perTurnState`. The line that clears all three
  together is a deliberate cross-category reset, not evidence of one lifetime.
- `preserveEvidenceOnce` / `deliveryRecoveryPending` — read in `beginRunTurn`
  *after* `perTurnState` is zeroed, because carrying a prior turn's
  readiness-recovery intent across the boundary is their purpose.

Roughly a dozen of the remaining 49 are construct-once config (`maxSteps`,
`contextWindow`, `archiveDir`, `temperature`). They take no part in the implicit
state machine the rule is aimed at, and boxing them would lower the number
without making anything safer. Exempting immutable configuration by convention
is a better answer than grouping it, and worth deciding before the count gets
pushed much lower.

Cache-impact: none - three unexported fields become one unexported value on Agent, with renames confined to internal/agent. No system-prompt text, tool schema, message content, or request shape changes; the recovery observation is built from the same values in the same order.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing), plus the full internal/agent suite covering the recovery-gate observation and scope-id paths.
Documentation-impact: none - docs/*.md describe recovery-gate behaviour and card labels, not the private fields carrying them, and the observed values are unchanged.
