### PR TITLE
refactor(agent): group compaction's session progress into one value

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -529,27 +529,23 @@ type Agent struct {
 
 	// Context management keeps the canonical transcript immutable and installs
 	// at most one provider-visible checkpoint each time compactRatio is crossed.
-	contextWindow       int
-	compactRatio        float64
-	recentKeep          int
-	archiveDir          string
-	keepPolicy          KeepPolicy
-	compactStuck        bool
-	consecutiveCompacts int
-	sessionPath         string // bound transcript path for projection sidecars
-	workspaceID         string // stable prompt-cache lineage component
-	cacheState          string // legacy resume telemetry; never provider-visible
-	checkpointState     string // none|restored|applied; runtime-only
-	compactionState     CompactionState
+	contextWindow   int
+	compactRatio    float64
+	recentKeep      int
+	archiveDir      string
+	keepPolicy      KeepPolicy
+	compaction      compactionProgress
+	sessionPath     string // bound transcript path for projection sidecars
+	workspaceID     string // stable prompt-cache lineage component
+	cacheState      string // legacy resume telemetry; never provider-visible
+	checkpointState string // none|restored|applied; runtime-only
+	compactionState CompactionState
 	// compactionMu guards projection snapshots/install and the in-memory sidecar
 	// generation. Network summarization never runs while this lock is held.
 	compactionMu sync.Mutex
 	// compactionRunMu singleflights the expensive summary transaction without
 	// holding the session lock during network I/O.
-	compactionRunMu sync.Mutex
-	// lastCompactionTurn prevents the post-turn observer and pre-send preflight
-	// from paying for two summaries during one active tool loop.
-	lastCompactionTurn     atomic.Int64
+	compactionRunMu        sync.Mutex
 	strictAlternatingRoles bool // coalesce adjacent user turns on provider request copies
 	// activeTurnCreatedAt identifies the real/synthetic user message that began
 	// the currently running turn. Compaction may rewrite older history while a
@@ -831,9 +827,9 @@ func (a *Agent) SetSession(s *Session) {
 	a.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	a.cacheState = CacheStateUnknown
 	a.compactionMu.Unlock()
-	a.compactStuck = false
-	a.consecutiveCompacts = 0
-	a.lastCompactionTurn.Store(0)
+	a.compaction.stuck = false
+	a.compaction.consecutive = 0
+	a.compaction.lastTurn.Store(0)
 	if s != nil {
 		a.rebuildTodoState(s.Snapshot())
 	}

--- a/internal/agent/compact_commit.go
+++ b/internal/agent/compact_commit.go
@@ -45,7 +45,7 @@ func (a *Agent) commitSummaryProjection(commit summaryProjectionCommit) (Compact
 	}
 	a.checkpointState = "applied"
 	if commit.activeTurn != 0 && commit.trigger != CompactionTriggerManual {
-		a.lastCompactionTurn.Store(commit.activeTurn)
+		a.compaction.lastTurn.Store(commit.activeTurn)
 	}
 	receipt := state.LastReceipt
 	a.compactionMu.Unlock()

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -383,7 +383,7 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 	a.compactionRunMu.Lock()
 	defer a.compactionRunMu.Unlock()
 	activeTurn := a.activeTurnCreatedAt.Load()
-	if activeTurn != 0 && a.lastCompactionTurn.Load() == activeTurn && trigger != CompactionTriggerManual {
+	if activeTurn != 0 && a.compaction.lastTurn.Load() == activeTurn && trigger != CompactionTriggerManual {
 		return CompactionNoop, nil
 	}
 	canonical, transcriptVersion := a.session.snapshotMessagesVersion()

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -623,14 +623,14 @@ func TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger(t *testing.T) {
 			sess := NewSession("sys")
 			sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
 			a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
-			a.consecutiveCompacts = 1
-			a.compactStuck = true
+			a.compaction.consecutive = 1
+			a.compaction.stuck = true
 
 			prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: tc.prompt})
 
-			if a.consecutiveCompacts != 0 || a.compactStuck {
+			if a.compaction.consecutive != 0 || a.compaction.stuck {
 				t.Fatalf("prompt %d sits under the trigger; want the latch cleared, got consecutiveCompacts=%d compactStuck=%v",
-					tc.prompt, a.consecutiveCompacts, a.compactStuck)
+					tc.prompt, a.compaction.consecutive, a.compaction.stuck)
 			}
 		})
 	}
@@ -644,8 +644,8 @@ func TestMaybeCompactDefersWhenOnlyActiveTurnRemains(t *testing.T) {
 	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
 
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 17000})
-	if a.compactStuck {
-		t.Fatalf("active turn should be deferred, not durably blocked: consecutiveCompacts=%d", a.consecutiveCompacts)
+	if a.compaction.stuck {
+		t.Fatalf("active turn should be deferred, not durably blocked: consecutiveCompacts=%d", a.compaction.consecutive)
 	}
 	version := a.currentProjectionVersion()
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 17000})

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -5,9 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	"reasonix/internal/provider"
 )
+
+// compactionProgress is how compaction is faring in this session: whether a
+// fold stopped reducing, how many ran back to back, and the turn the last one
+// committed under. All three are cleared together whenever the lineage resets,
+// which is why they travel as one value rather than three fields.
+type compactionProgress struct {
+	stuck       bool // a fold landed above the trigger, so pressure retries are pointless
+	consecutive int  // back-to-back folds since one last helped
+	// lastTurn stops the post-turn observer and the pre-send preflight from
+	// paying for two summaries during one active tool loop.
+	lastTurn atomic.Int64
+}
 
 // ContextManager is the sole owner of provider-visible context maintenance.
 // Canonical session messages are immutable inputs; Prepare evolves only the
@@ -92,10 +105,10 @@ func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePo
 		return prepared, nil
 	}
 	if est < fold {
-		a.consecutiveCompacts = 0
-		a.compactStuck = false
+		a.compaction.consecutive = 0
+		a.compaction.stuck = false
 	}
-	if a.compactStuck && policy.Trigger == CompactionTriggerPressure {
+	if a.compaction.stuck && policy.Trigger == CompactionTriggerPressure {
 		return prepared, nil
 	}
 	// One user trigger. Overflow is a one-shot physical recovery path only.
@@ -158,8 +171,8 @@ func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContex
 	if result.InputTokens >= fold {
 		reason := fmt.Sprintf("summary result remains above fold trigger (%d >= %d)", result.InputTokens, fold)
 		a.recordContextMaintenanceBlocked(a.contextMaintenanceInputHash(result.Messages), policy.Trigger, "summary", reason)
-		a.compactStuck = true
-		a.consecutiveCompacts++
+		a.compaction.stuck = true
+		a.compaction.consecutive++
 		if policy.Trigger == CompactionTriggerOverflow || result.InputTokens >= hard {
 			return PreparedContext{}, fmt.Errorf("%w: %s", ErrCompactionRequired, reason)
 		}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -65,9 +65,9 @@ func (a *Agent) InvalidateProjection() {
 	path := a.sessionPath
 	a.compactionState = CompactionState{}
 	a.compactionMu.Unlock()
-	a.compactStuck = false
-	a.consecutiveCompacts = 0
-	a.lastCompactionTurn.Store(0)
+	a.compaction.stuck = false
+	a.compaction.consecutive = 0
+	a.compaction.lastTurn.Store(0)
 	if path != "" {
 		if err := RemoveCompactionState(path); err != nil {
 			slog.Warn("agent: remove context projection", "err", err)
@@ -198,9 +198,9 @@ func (a *Agent) BindSessionPath(path string, loadSidecar bool) {
 	a.checkpointState = "none"
 	a.cacheState = CacheStateUnknown
 	a.compactionMu.Unlock()
-	a.compactStuck = false
-	a.consecutiveCompacts = 0
-	a.lastCompactionTurn.Store(0)
+	a.compaction.stuck = false
+	a.compaction.consecutive = 0
+	a.compaction.lastTurn.Store(0)
 }
 
 // SetSessionPath binds the transcript path used for projection persistence.

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 149,
+    "struct-state": 146,
     "test-file-size": 69298
   },
   "files": {
@@ -452,9 +452,9 @@
     "internal/agent/agent.go": {
       "complexity": 37,
       "essay": 85,
-      "file-size": 2301,
+      "file-size": 2297,
       "function-size": 102,
-      "struct-state": 37
+      "struct-state": 34
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
Fourth bucket under the `struct-state` ratchet (#8436), after #8439, #8447 and #8453.

## Three lines, three places, always together

```go
a.compactionState = CompactionState{}
a.compactionMu.Unlock()
a.compactStuck = false
a.consecutiveCompacts = 0
a.lastCompactionTurn.Store(0)
```

That trio appears verbatim in `SetSession` and in both `preflight` lineage
resets — always immediately after `compactionState` is zeroed. They were already
part of compaction's state; they just were not part of its struct.

## Why not just put them in CompactionState

`CompactionState` is serialized into the projection sidecar. These three are
runtime-only: a stuck flag, a back-to-back counter, and a turn stamp. Folding
them into the persisted type would put runtime bookkeeping into an on-disk
format for no reason.

`compactionProgress` is the runtime half, and it lives next to `ContextManager`
— the only thing that advances `stuck` and `consecutive`.

## One asymmetry kept on purpose

`lastTurn` stays an `atomic.Int64` inside the value; the other two are plain.
That is not an oversight left over from the old fields: the turn stamp is read
by the post-turn observer while a tool loop may still be running, while `stuck`
and `consecutive` are only touched on the `Prepare` path. Grouping them does not
make their concurrency identical, and pretending otherwise — by making all three
atomic, or none — would either add cost or add a race.

## Ratchet

`Agent`: **49 → 46** scalars. Baseline tightened — `agent.go` 37 → 34, total
149 → 146, `file-size` 2301 → 2297.

## Verification

```
gofmt -l .        clean
golangci-lint     0 issues
repolint          clean apart from the two pre-existing entries
go test ./...     all green
```

## Progress

| | Agent scalars |
|---|---|
| before the ratchet | 59 |
| #8439 capability | 56 |
| #8447 missing-reasoning | 52 |
| #8453 recovery identity | 49 |
| this (compaction progress) | **46** |

Thirteen retired across four buckets, every one a group that already shared a
reset point, a reader, or a name.

## What is left, and the question it raises

Of the remaining 46, roughly a dozen are construct-once configuration —
`maxSteps`, `contextWindow`, `compactRatio`, `recentKeep`, `archiveDir`,
`temperature`, `maxSubagentDepth`, `modelRef`, `usageSource`. They are written
once in `New` and read thereafter. They take no part in the implicit state
machine the rule targets: no concurrent write, no lifetime, no reachable-state
question.

Boxing them would take the count to roughly 34 without making anything safer,
which is the failure mode of measuring a proxy instead of the thing. The honest
options are to exempt immutable configuration in the rule (the counter then
means "mutable coordinated state", which is what it was always about), or to
accept ~34 as the floor and stop.

I'd rather decide that before pushing the number lower, so the next bucket is
whichever mutable group survives that call — the candidates are steering
(`steerConsumed` / `steerRunActive`) and the session cache counters
(`sessCacheHit` / `sessCacheMiss`), each worth one.

Cache-impact: none - three unexported fields become one unexported value on Agent, with renames confined to internal/agent. No system-prompt text, tool schema, message content, or request shape changes, and the compaction decisions read the same values in the same order.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing) plus the full internal/agent suite, which covers the stuck/consecutive fold paths and the same-turn compaction guard.
Documentation-impact: none - docs/*.md describe compaction thresholds and behaviour, not the private runtime fields tracking them, and that behaviour is unchanged.
