### PR TITLE
fix(skill): translate Claude Code tool names for .claude skill roots

### DIFF
--- a/docs/SUBAGENT_PROFILES.md
+++ b/docs/SUBAGENT_PROFILES.md
@@ -149,6 +149,12 @@ profile-level allowlist, not a way to bypass permissions. `read-only: true`
 forces the read-only tool registry (writer tools stripped); omitted/`false`
 keeps the legacy writable default.
 
+Skills discovered under a `.claude` convention directory get Claude Code tool
+names in `allowed-tools` (`Read`, `Edit`, `AskUserQuestion`, ...) translated to
+Reasonix tool names, and Claude model aliases (`sonnet`, `opus`, `haiku`,
+`inherit`) fall back to the session model — the same mapping plugin-provided
+Claude agents already receive.
+
 You may hand-author richer `runAs: subagent` Skills, including custom Skill
 paths and extra frontmatter. They can be listed and invoked, but the profile
 editors deliberately refuse to edit or delete:

--- a/docs/SUBAGENT_PROFILES.zh-CN.md
+++ b/docs/SUBAGENT_PROFILES.zh-CN.md
@@ -133,6 +133,11 @@ allowed-tools: [read_file, grep, bash]
 调用。`allowed-tools` 是 Profile 级工具白名单，不能绕过权限系统。`read-only: true`
 强制使用只读工具 registry（剥离写入工具）；省略/`false` 保持旧版默认可写。
 
+在 `.claude` 约定目录下发现的 Skill，其 `allowed-tools` 中的 Claude Code 工具名
+（`Read`、`Edit`、`AskUserQuestion` 等）会被翻译为 Reasonix 工具名；Claude 模型别名
+（`sonnet`、`opus`、`haiku`、`inherit`）回退到会话模型 —— 与插件提供的 Claude Agent
+所获得的映射一致。
+
 也可以手写更丰富的 `runAs: subagent` Skill，例如使用自定义 Skill path 或额外 frontmatter。
 这些 Profile 可以被列出和调用，但 Profile 编辑器会拒绝编辑或删除以下内容：
 

--- a/internal/skill/claude_compat.go
+++ b/internal/skill/claude_compat.go
@@ -1,0 +1,38 @@
+package skill
+
+import "strings"
+
+// mapClaudeAgentTools rewrites Claude Code tool names (Read, Edit,
+// AskUserQuestion, …) to their Reasonix equivalents so skills authored for
+// Claude Code keep their allowed-tools grant; unmapped names pass through.
+func mapClaudeAgentTools(in []string) []string {
+	mapping := map[string]string{
+		"read": "read_file", "write": "write_file", "edit": "edit_file",
+		"bash": "bash", "grep": "grep", "glob": "glob", "ls": "ls",
+		"webfetch": "web_fetch", "websearch": "web_search",
+		"askuserquestion": "ask", "multiedit": "multi_edit",
+		"todowrite": "todo_write", "notebookedit": "notebook_edit",
+	}
+	out := make([]string, 0, len(in))
+	seen := map[string]bool{}
+	for _, name := range in {
+		mapped := strings.TrimSpace(name)
+		if replacement := mapping[strings.ToLower(mapped)]; replacement != "" {
+			mapped = replacement
+		}
+		if mapped != "" && !seen[mapped] {
+			seen[mapped] = true
+			out = append(out, mapped)
+		}
+	}
+	return out
+}
+
+func isClaudeModelAlias(model string) bool {
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "sonnet", "opus", "haiku", "inherit":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/skill/claude_compat_test.go
+++ b/internal/skill/claude_compat_test.go
@@ -1,0 +1,86 @@
+package skill
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMapClaudeAgentToolsCoversClaudeCodeNames(t *testing.T) {
+	in := []string{
+		"Read", "Write", "Edit", "MultiEdit", "TodoWrite", "NotebookEdit",
+		"AskUserQuestion", "WebFetch", "WebSearch", "Bash", "Grep", "Glob", "LS",
+		"read_file", "mcp__github__search", "Read",
+	}
+	want := []string{
+		"read_file", "write_file", "edit_file", "multi_edit", "todo_write",
+		"notebook_edit", "ask", "web_fetch", "web_search", "bash", "grep",
+		"glob", "ls", "mcp__github__search",
+	}
+	if got := mapClaudeAgentTools(in); !slices.Equal(got, want) {
+		t.Fatalf("mapped tools = %v, want %v", got, want)
+	}
+}
+
+func TestClaudeRootTranslatesToolsAndClearsModelAlias(t *testing.T) {
+	proj := t.TempDir()
+	writeSkill(t, proj, ".claude/skills/probe/SKILL.md",
+		"---\ndescription: probe\ncontext: fork\nmodel: sonnet\nallowed-tools:\n  - Read\n  - Grep\n  - AskUserQuestion\n---\nbody")
+
+	st := New(Options{HomeDir: t.TempDir(), ProjectRoot: proj, DisableBuiltins: true})
+	sk, ok := st.Read("probe")
+	if !ok {
+		t.Fatal("probe not found")
+	}
+	want := []string{"read_file", "grep", "ask"}
+	if !slices.Equal(sk.AllowedTools, want) {
+		t.Fatalf("allowed tools = %v, want %v", sk.AllowedTools, want)
+	}
+	if sk.Model != "" {
+		t.Fatalf("model alias should clear, got %q", sk.Model)
+	}
+	if sk.RunAs != RunSubagent {
+		t.Fatalf("runAs = %v, want subagent from its own frontmatter", sk.RunAs)
+	}
+	if sk.Invocation == "manual" {
+		t.Fatal("invocation must not be forced to manual for .claude skills")
+	}
+}
+
+func TestClaudeRootKeepsInlineRunAs(t *testing.T) {
+	proj := t.TempDir()
+	writeSkill(t, proj, ".claude/skills/flat/SKILL.md",
+		"---\ndescription: flat probe\nallowed-tools: [Edit, WebFetch]\nmodel: deepseek-pro\n---\nbody")
+
+	st := New(Options{HomeDir: t.TempDir(), ProjectRoot: proj, DisableBuiltins: true})
+	sk, ok := st.Read("flat")
+	if !ok {
+		t.Fatal("flat not found")
+	}
+	if sk.RunAs != RunInline {
+		t.Fatalf("runAs = %v, want inline", sk.RunAs)
+	}
+	if want := []string{"edit_file", "web_fetch"}; !slices.Equal(sk.AllowedTools, want) {
+		t.Fatalf("allowed tools = %v, want %v", sk.AllowedTools, want)
+	}
+	if sk.Model != "deepseek-pro" {
+		t.Fatalf("non-alias model must survive, got %q", sk.Model)
+	}
+}
+
+func TestCustomRootKeepsClaudeNamesUntranslated(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "probe/SKILL.md",
+		"---\ndescription: probe\ncontext: fork\nmodel: sonnet\nallowed-tools:\n  - Read\n  - AskUserQuestion\n---\nbody")
+
+	st := New(Options{HomeDir: t.TempDir(), CustomPaths: []string{root}, DisableBuiltins: true})
+	sk, ok := st.Read("probe")
+	if !ok {
+		t.Fatal("probe not found")
+	}
+	if want := []string{"Read", "AskUserQuestion"}; !slices.Equal(sk.AllowedTools, want) {
+		t.Fatalf("allowed tools = %v, want %v", sk.AllowedTools, want)
+	}
+	if sk.Model != "sonnet" {
+		t.Fatalf("custom-root model must stay, got %q", sk.Model)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -444,6 +444,7 @@ type discoveryRoot struct {
 	requireFlatMarker bool
 	plugins           []string
 	forceSubagent     bool
+	claudeCompat      bool
 }
 
 // roots returns the discovery directories, highest priority first: the
@@ -458,18 +459,19 @@ func (s *Store) roots() []discoveryRoot {
 		dir               string
 		scope             Scope
 		requireFlatMarker bool
+		claudeCompat      bool
 	}
 	var dirs []de
 	if s.projectRoot != "" {
 		for _, c := range config.ConventionDirs {
-			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject, c == ".claude"})
+			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject, c == ".claude", c == ".claude"})
 		}
 	}
 	for _, d := range s.customPaths {
-		dirs = append(dirs, de{d, ScopeCustom, false})
+		dirs = append(dirs, de{d, ScopeCustom, false, false})
 	}
 	if s.reasonixHomeDir != "" {
-		dirs = append(dirs, de{filepath.Join(s.reasonixHomeDir, SkillsDirname), ScopeGlobal, false})
+		dirs = append(dirs, de{filepath.Join(s.reasonixHomeDir, SkillsDirname), ScopeGlobal, false, false})
 	}
 	if config.IsolatedHomeDir() == "" {
 		for _, c := range config.ConventionDirs {
@@ -477,7 +479,7 @@ func (s *Store) roots() []discoveryRoot {
 			if s.reasonixHomeDir != "" && config.CanonicalSkillPath(filepath.Dir(dir)) == config.CanonicalSkillPath(s.reasonixHomeDir) {
 				continue
 			}
-			dirs = append(dirs, de{dir, ScopeGlobal, c == ".claude"})
+			dirs = append(dirs, de{dir, ScopeGlobal, c == ".claude", c == ".claude"})
 		}
 	}
 	out := make([]discoveryRoot, 0, len(dirs))
@@ -491,6 +493,7 @@ func (s *Store) roots() []discoveryRoot {
 			requireFlatMarker: d.requireFlatMarker,
 			plugins:           append([]string(nil), s.pluginPaths[key]...),
 			forceSubagent:     len(s.pluginAgentPaths[key]) > 0,
+			claudeCompat:      d.claudeCompat,
 		})
 	}
 	return out
@@ -734,6 +737,10 @@ func (s *Store) discoverRoot(r discoveryRoot) []Skill {
 		for i := range out {
 			out[i].RunAs = RunSubagent
 			out[i].Invocation = "manual"
+		}
+	}
+	if r.forceSubagent || r.claudeCompat {
+		for i := range out {
 			out[i].AllowedTools = mapClaudeAgentTools(out[i].AllowedTools)
 			if isClaudeModelAlias(out[i].Model) {
 				out[i].Model = ""
@@ -908,36 +915,6 @@ func firstNonEmptySkillValue(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func isClaudeModelAlias(model string) bool {
-	switch strings.ToLower(strings.TrimSpace(model)) {
-	case "sonnet", "opus", "haiku", "inherit":
-		return true
-	default:
-		return false
-	}
-}
-
-func mapClaudeAgentTools(in []string) []string {
-	mapping := map[string]string{
-		"read": "read_file", "write": "write_file", "edit": "edit_file",
-		"bash": "bash", "grep": "grep", "glob": "glob", "ls": "ls",
-		"webfetch": "web_fetch", "websearch": "web_search",
-	}
-	out := make([]string, 0, len(in))
-	seen := map[string]bool{}
-	for _, name := range in {
-		mapped := strings.TrimSpace(name)
-		if replacement := mapping[strings.ToLower(mapped)]; replacement != "" {
-			mapped = replacement
-		}
-		if mapped != "" && !seen[mapped] {
-			seen[mapped] = true
-			out = append(out, mapped)
-		}
-	}
-	return out
 }
 
 const (


### PR DESCRIPTION
## Summary

- Skills discovered under a `.claude` convention directory (project or home) now get the same Claude Code compatibility mapping that plugin-provided Claude agents already receive: `allowed-tools` names are translated to Reasonix tool names, and Claude model aliases (`sonnet`, `opus`, `haiku`, `inherit`) fall back to the session model.
- Without this, a `runAs: subagent` skill authored for Claude Code silently lost **every** declared tool — the subagent registry filters by exact Reasonix names (`FilterRegistry` → `parent.Get(name)`), so `Read`/`Grep`/`Write` matched nothing and the child was left with only `complete_subtask` plus the capability proxy. A `model: sonnet` line failed the run outright with `unknown model "sonnet"`.
- The mapping table gains the 1:1 equivalents Reasonix actually has: `AskUserQuestion → ask`, `MultiEdit → multi_edit`, `TodoWrite → todo_write`, `NotebookEdit → notebook_edit`. Names with no Reasonix equivalent still pass through unmapped; `Task`/`Agent`/`Skill` are deliberately not mapped (different spawning semantics).
- `RunAs`/`Invocation` forcing stays plugin-agent-only: a `.claude` skill keeps its own `context:`/`runAs:` and, if inline, stays in the pinned skill index exactly as before. `.reasonix`/`.agents`/`.agent`/custom roots are untouched.
- `mapClaudeAgentTools` and `isClaudeModelAlias` move verbatim (plus the four new entries) to a new `internal/skill/claude_compat.go`: `skill.go` sits at its ratcheted file-size baseline, so the extraction keeps the ratchet green without widening it.

## Issues

Extends the `.claude` compatibility surface (plugin-agent tool mapping, `agents/*.md` import) to plain `.claude/skills` discovery roots.

## Verification

- New tests: `go test ./internal/skill/` — mapping-table unit test; `.claude` project root translates tools, clears `model: sonnet`, keeps frontmatter `RunAs`, does not force `invocation: manual`; inline `.claude` skill stays inline with a non-alias model preserved; custom root stays untranslated.
- Live before/after through the real binary (isolated `REASONIX_HOME`, project fixture `.claude/skills/qa-probe/SKILL.md` with `context: fork`, `model: sonnet`, block-list `allowed-tools: Read, Grep, AskUserQuestion`):
  - v1.24.1: `reasonix subagent run qa-probe` fails with `unknown model "sonnet"`; with the model line removed, the child reports its tools as `complete_subtask, web_search` — every declared tool lost.
  - This branch: the same run reports `ask, complete_subtask, grep, read_file, web_search`, and `reasonix doctor` no longer warns `allowed-tools references "Read" ... not in the current registry` (three warnings gone).
- Full local CI simulation: `gofmt` clean, `go vet ./...`, `go build ./...`, `go test ./...` all green, `make lint` (golangci-lint at the pinned version + `tools/repolint`) exits 0 — repolint stays at 1949 baselined findings, no baseline change.

## Documentation impact

Documentation-impact: updated - docs/SUBAGENT_PROFILES.md and docs/SUBAGENT_PROFILES.zh-CN.md document the .claude tool-name translation and model-alias fallback

## Cache impact

Cache-impact: none - the pinned skills index renders only name/description/subagent tag (internal/skill/index.go); AllowedTools and Model never enter the provider-visible prefix, and RunAs/Invocation are not changed by this diff
Cache-guard: go test ./internal/skill/ (claude_compat tests) and go test ./internal/boot/ -run TestBuildComposesByteStableSystemPrompt (prefix byte-stability guard, green on this branch)
System-prompt-review: drummerms - verified internal/skill/index.go renders neither AllowedTools nor Model, so the skills-index block in the prefix is byte-identical before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
