### PR TITLE
refactor(agent): separate construct-once configuration from live state

### DIFF
--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -28,13 +28,12 @@ func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
 }
 
 func TestCompactionAblationCollapsesTheCachePreservingDeferral(t *testing.T) {
-	full := &Agent{contextWindow: 100_000, compactRatio: 0.8}
+	full := &Agent{agentConfig: agentConfig{contextWindow: 100_000, compactRatio: 0.8}}
 	if got := full.compactTrigger(); got != 80_000 {
 		t.Fatalf("control trigger = %d, want 80000", got)
 	}
 
-	off := &Agent{contextWindow: 100_000, compactRatio: 0.8,
-		ablation: ablation.New(ablation.Compaction)}
+	off := &Agent{agentConfig: agentConfig{contextWindow: 100_000, compactRatio: 0.8}, ablation: ablation.New(ablation.Compaction)}
 	// Compaction ablation forces the sole trigger down to 50% so folds fire earlier.
 	if got := off.compactTrigger(); got != 50_000 {
 		t.Fatalf("ablated trigger = %d, want 50000", got)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -281,20 +281,14 @@ type ToolHooks interface {
 // Agent drives a single task: a Provider, a tool Registry, and a Session wired
 // into the main loop.
 type Agent struct {
-	prov               provider.Provider
-	tools              *tool.Registry
-	session            *Session
-	sessMu             sync.Mutex // guards the session pointer for external Session()/SetSession
-	maxSteps           int
-	maxStepsKey        string
-	reasoningByteLimit int
-	maxOutputTokens    int
+	agentConfig
+	prov    provider.Provider
+	tools   *tool.Registry
+	session *Session
+	sessMu  sync.Mutex // guards the session pointer for external Session()/SetSession
 	// executorHandoffGuard is enabled by Coordinator only for the executor agent.
 	executorHandoffGuard bool
-	temperature          float64
 	pricing              *provider.Pricing
-	usageSource          string
-	modelRef             string
 	responseLanguage     atomic.Value // string: auto|zh|en
 	reasoningLanguage    atomic.Value // string: auto|zh|en
 
@@ -419,7 +413,6 @@ type Agent struct {
 	writeScheduler *SubagentScheduler
 	// writeWorkspaceRoot is the workspace used to normalize parent write
 	// reservations when writeScheduler is set.
-	writeWorkspaceRoot string
 
 	// workspaceLease is shared by every writer-capable agent in one Delivery
 	// session. It is acquired lazily on the first mutation and held through the
@@ -524,15 +517,9 @@ type Agent struct {
 
 	// subagentDepth tracks the current agent's nesting depth. maxSubagentDepth
 	// caps delegation; when reached, recursive agent/skill tools are excluded.
-	subagentDepth    int
-	maxSubagentDepth int
 
 	// Context management keeps the canonical transcript immutable and installs
 	// at most one provider-visible checkpoint each time compactRatio is crossed.
-	contextWindow   int
-	compactRatio    float64
-	recentKeep      int
-	archiveDir      string
 	keepPolicy      KeepPolicy
 	compaction      compactionProgress
 	sessionPath     string // bound transcript path for projection sidecars
@@ -1291,18 +1278,27 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		reasoningByteLimit = defaultReasoningByteLimit
 	}
 	a := &Agent{
+		agentConfig: agentConfig{
+			maxSteps:           opts.MaxSteps,
+			maxStepsKey:        maxStepsKey,
+			reasoningByteLimit: reasoningByteLimit,
+			maxOutputTokens:    opts.MaxOutputTokens,
+			temperature:        opts.Temperature,
+			usageSource:        usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
+			modelRef:           strings.TrimSpace(opts.ModelRef),
+			writeWorkspaceRoot: strings.TrimSpace(opts.WriteWorkspaceRoot),
+			subagentDepth:      subagentDepth,
+			maxSubagentDepth:   maxSubagentDepth,
+			contextWindow:      opts.ContextWindow,
+			compactRatio:       opts.CompactRatio,
+			recentKeep:         opts.RecentKeep,
+			archiveDir:         opts.ArchiveDir,
+		},
 		prov:                prov,
 		tools:               tools,
 		session:             session,
 		taskBudget:          runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
-		maxSteps:            opts.MaxSteps,
-		maxStepsKey:         maxStepsKey,
-		reasoningByteLimit:  reasoningByteLimit,
-		maxOutputTokens:     opts.MaxOutputTokens,
-		temperature:         opts.Temperature,
 		pricing:             opts.Pricing,
-		usageSource:         usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
-		modelRef:            strings.TrimSpace(opts.ModelRef),
 		sink:                sink,
 		requireVisibleFinal: opts.RequireVisibleFinal,
 		gate:                gate,
@@ -1321,7 +1317,6 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		jobs:                      opts.Jobs,
 		memQueue:                  opts.MemoryQueue,
 		writeScheduler:            opts.WriteScheduler,
-		writeWorkspaceRoot:        strings.TrimSpace(opts.WriteWorkspaceRoot),
 		workspaceLease:            opts.WorkspaceLease,
 		missingReasoningWarnState: missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
 		evidence:                  evidence.NewLedger(),
@@ -1331,17 +1326,11 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		classifierTaskText:        opts.ClassifierTaskText,
 		capabilityLedger:          opts.CapabilityLedger,
 		capabilityAudit:           opts.CapabilityAudit,
-		contextWindow:             opts.ContextWindow,
-		compactRatio:              opts.CompactRatio,
-		recentKeep:                opts.RecentKeep,
-		archiveDir:                opts.ArchiveDir,
 		keepPolicy:                opts.KeepPolicy,
 		sessionPath:               strings.TrimSpace(opts.SessionPath),
 		workspaceID:               strings.TrimSpace(opts.WorkspaceID),
 		cacheState:                CacheStateUnknown,
 		strictAlternatingRoles:    opts.StrictAlternatingRoles,
-		subagentDepth:             subagentDepth,
-		maxSubagentDepth:          maxSubagentDepth,
 		mutationObserver:          opts.MutationObserver,
 	}
 	a.outputBudget = outputBudgetOf(prov)

--- a/internal/agent/agent_config.go
+++ b/internal/agent/agent_config.go
@@ -1,0 +1,28 @@
+package agent
+
+// agentConfig is everything New fixes for an Agent's lifetime; nothing writes
+// it afterwards, which agent_config_test.go enforces. Embedded rather than
+// nested so access stays flat, as perTurnState already does. Separating it lets
+// the struct-state ratchet count reachable states instead of size: an immutable
+// field combines with nothing. Anything that changes after New goes on Agent.
+type agentConfig struct {
+	maxSteps           int
+	maxStepsKey        string
+	reasoningByteLimit int
+	maxOutputTokens    int
+	temperature        float64
+	usageSource        string
+	modelRef           string
+	// writeWorkspaceRoot scopes write reservations when writeScheduler is set.
+	writeWorkspaceRoot string
+	// subagentDepth caps delegation; at maxSubagentDepth the recursive
+	// agent/skill tools are excluded.
+	subagentDepth    int
+	maxSubagentDepth int
+	// contextWindow and compactRatio decide when at most one provider-visible
+	// checkpoint is installed; recentKeep and archiveDir shape what it keeps.
+	contextWindow int
+	compactRatio  float64
+	recentKeep    int
+	archiveDir    string
+}

--- a/internal/agent/agent_config_test.go
+++ b/internal/agent/agent_config_test.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// configFieldNames is agentConfig's surface, read from the type itself so the
+// guard below cannot drift from what the struct actually holds.
+func configFieldNames(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "agent_config.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse agent_config.go: %v", err)
+	}
+	names := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || spec.Name.Name != "agentConfig" {
+			return true
+		}
+		st, ok := spec.Type.(*ast.StructType)
+		if !ok {
+			return false
+		}
+		for _, field := range st.Fields.List {
+			for _, name := range field.Names {
+				names[name.Name] = true
+			}
+		}
+		return false
+	})
+	if len(names) == 0 {
+		t.Fatal("agentConfig has no fields; the guard would pass vacuously")
+	}
+	return names
+}
+
+// Field promotion makes `a.contextWindow = x` compile from anywhere in the
+// package, so "configuration" is a claim rather than a guarantee. That claim is
+// what lets the struct-state ratchet exclude these fields; unenforced, the
+// exclusion would just be a way to hide state. So it is checked, not asserted.
+func TestAgentConfigIsNeverAssignedAfterConstruction(t *testing.T) {
+	fields := configFieldNames(t)
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for _, lhs := range assign.Lhs {
+				sel, ok := lhs.(*ast.SelectorExpr)
+				if !ok || !fields[sel.Sel.Name] {
+					continue
+				}
+				// Only Agent's own receiver: other types (TaskTool) legitimately
+				// carry same-named fields of their own.
+				recv, ok := sel.X.(*ast.Ident)
+				if !ok || recv.Name != "a" {
+					continue
+				}
+				t.Errorf("%s:%d: %s.%s is assigned after construction; agentConfig must stay immutable, or the field belongs on Agent",
+					name, fset.Position(sel.Pos()).Line, recv.Name, sel.Sel.Name)
+			}
+			return true
+		})
+	}
+}

--- a/internal/agent/capability_gate_test.go
+++ b/internal/agent/capability_gate_test.go
@@ -136,7 +136,7 @@ func TestDeliveryReviewGateDefersToParentInSubagents(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg, subagentDepth: 1}
+	a := &Agent{agentConfig: agentConfig{subagentDepth: 1}, deliveryProfile: true, evidence: ledger, tools: reg}
 
 	// Inside a sub-agent the structured-review contract belongs to the parent,
 	// which receives the child's mutation receipts via mergeChildEvidence. The

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -655,11 +655,7 @@ func TestMaybeCompactDefersWhenOnlyActiveTurnRemains(t *testing.T) {
 }
 
 func TestCompactTriggerIgnoresConfiguredOutputBudget(t *testing.T) {
-	a := &Agent{
-		contextWindow:   100_000,
-		maxOutputTokens: 20_000,
-		compactRatio:    0.85,
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000, maxOutputTokens: 20_000, compactRatio: 0.85}}
 	if got := a.compactTrigger(); got != 85_000 {
 		t.Fatalf("trigger = %d, want 85000 (output budget must not change it)", got)
 	}

--- a/internal/agent/compact_threshold_test.go
+++ b/internal/agent/compact_threshold_test.go
@@ -7,9 +7,8 @@ import "testing"
 func TestCompactTriggerIndependentOfOutputBudget(t *testing.T) {
 	a := &Agent{
 		prov:              &sharedWindowTestProvider{budget: 131_072, shared: true},
-		contextWindow:     128_000,
+		agentConfig:       agentConfig{contextWindow: 128_000, compactRatio: defaultCompactRatio},
 		outputBudgetState: outputBudgetState{outputBudget: 131_072},
-		compactRatio:      defaultCompactRatio,
 	}
 	trigger := a.compactTrigger()
 	want := int(float64(128_000) * defaultCompactRatio)
@@ -38,7 +37,7 @@ func TestRecentTailBudgetClamp(t *testing.T) {
 		{2_000_000, maxRecentTailTokens}, // still 96K
 	}
 	for _, tc := range cases {
-		a := &Agent{contextWindow: tc.window, compactRatio: defaultCompactRatio}
+		a := &Agent{agentConfig: agentConfig{contextWindow: tc.window, compactRatio: defaultCompactRatio}}
 		if got := a.recentTailBudget(); got != tc.want {
 			t.Fatalf("window %d: recentTailBudget = %d, want %d", tc.window, got, tc.want)
 		}
@@ -46,7 +45,7 @@ func TestRecentTailBudgetClamp(t *testing.T) {
 }
 
 func TestCheckpointCeilingAndExceptionalSavings(t *testing.T) {
-	a := &Agent{contextWindow: 1_000_000, compactRatio: 0.85}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_000_000, compactRatio: 0.85}}
 	if got := a.checkpointCeiling(); got != 500_000 {
 		t.Fatalf("checkpointCeiling = %d, want 500000", got)
 	}
@@ -59,7 +58,7 @@ func TestCheckpointCeilingAndExceptionalSavings(t *testing.T) {
 }
 
 func TestAcceptCheckpointCandidateRules(t *testing.T) {
-	a := &Agent{contextWindow: 1_000_000, compactRatio: 0.85}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_000_000, compactRatio: 0.85}}
 	// 20% candidate under normal path: accept.
 	if err := a.acceptCheckpointCandidate(CompactionTriggerPressure, false, 850_000, 180_000, 50_000); err != nil {
 		t.Fatalf("20%% candidate: %v", err)

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -40,7 +40,7 @@ func (p *sharedWindowTestProvider) Stream(_ context.Context, req provider.Reques
 // context window must still be tokens. It used to be characters, which reads
 // 3-4x high and compacted long before the configured ratio.
 func TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration(t *testing.T) {
-	a := &Agent{contextWindow: 1_000_000}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_000_000}}
 	cases := []struct {
 		name           string
 		text           string
@@ -66,7 +66,7 @@ func TestEstimatedPromptTokensStayInTokenUnitBeforeCalibration(t *testing.T) {
 // conflict path that adopts the newer disk transcript. Each rebind used to drop
 // the calibration and put the next turn back on the cold estimate.
 func TestSessionSwapKeepsPromptCalibration(t *testing.T) {
-	a := &Agent{contextWindow: 200_000}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 60_000)}}
 	a.setPromptTokenCalibration(36_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
 
@@ -84,12 +84,7 @@ func TestSessionSwapKeepsPromptCalibration(t *testing.T) {
 
 func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{
-		prov:              prov,
-		contextWindow:     100_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
-		sink:              event.Discard,
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
 	// Oversized tool bodies are deterministically shortened for the single
 	// summarizer request (no multi-span). The guard must still fit one call.
 	toolBody := strings.Repeat("file line content here. ", 20_000) // ~480K chars
@@ -124,12 +119,7 @@ func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 // all deterministic shorteners must fail once (no multi-span split).
 func TestSharedWindowFoldRejectsUnshortenableOverBudgetInput(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{
-		prov:              prov,
-		contextWindow:     100_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
-		sink:              event.Discard,
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
 	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 200_000)}}
 	_, err := a.foldToSummary(context.Background(), fold, "")
 	if err == nil || !strings.Contains(err.Error(), "exceeds single-request budget") {
@@ -149,8 +139,7 @@ func (p *sharedWindowTestProvider) SharedWindowInputPolicy() provider.SharedWind
 
 func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{prov: prov, contextWindow: 1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}}
 	// Calibrate this session at one token per rune. The 950K prompt fits, but
 	// not beside the provider's full 128K output default.
@@ -174,8 +163,7 @@ func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 
 func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{prov: prov, contextWindow: 200_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	current := append(previous, provider.Message{
@@ -200,8 +188,7 @@ func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 
 func TestCalibratedOutputBudgetKeepsCJKConservativeFloor(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{prov: prov, contextWindow: 1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	// Enough unrepresented CJK that the reply no longer fits beside it: at the
@@ -250,8 +237,7 @@ func TestCalibrationIgnoresNonReplayableOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysOrdinaryReasoning: true}}
-	a := &Agent{prov: prov, contextWindow: 200_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -272,8 +258,7 @@ func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewReplayItems(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysResponsesItems: true}}
-	a := &Agent{prov: prov, contextWindow: 200_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -312,14 +297,8 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}}
 	sess := NewSession("")
 	sess.Replace(msgs)
-	a := &Agent{
-		prov:              prov,
-		tools:             tool.NewRegistry(),
-		session:           sess,
-		contextWindow:     1_048_576,
-		compactRatio:      2, // disable auto maintenance for this output-clip test
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576, compactRatio: 2}, prov: prov, tools: tool.NewRegistry(), session: sess, // disable auto maintenance for this output-clip test
+		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	a.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
 	a.setPromptTokenCalibration(950_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
 
@@ -334,8 +313,7 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 
 func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{prov: prov, contextWindow: 1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 1_045_000)}}
 	a.lastUsage.Store(&provider.Usage{PromptTokens: 1_045_000})
 	a.setPromptTokenCalibration(1_045_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
@@ -348,8 +326,7 @@ func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 
 func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: false}
-	a := &Agent{prov: prov, contextWindow: 1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 	})
@@ -360,8 +337,7 @@ func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 
 func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{prov: prov, contextWindow: 1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages:  []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 		MaxTokens: -1,
@@ -373,12 +349,7 @@ func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 
 func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{
-		prov:              prov,
-		contextWindow:     100_000,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
-		sink:              event.Discard,
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
 	region := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 50_000)}}
 	a.lastUsage.Store(&provider.Usage{PromptTokens: 50_000})
 	a.setPromptTokenCalibration(50_000, requestCalibrationShapeOf(provider.Request{Messages: region}))
@@ -393,12 +364,7 @@ func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 
 func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true, finish: "length"}
-	a := &Agent{
-		prov:              prov,
-		contextWindow:     1_048_576,
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget},
-		sink:              event.Discard,
-	}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
 
 	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{{
 		Role: provider.RoleUser, Content: "retain every durable fact",

--- a/internal/agent/path_bound_tools_test.go
+++ b/internal/agent/path_bound_tools_test.go
@@ -287,11 +287,7 @@ func TestParentWriteReservationBashClaimsWholeWorkspace(t *testing.T) {
 func TestAgentReserveParentWriteSkipsSubagentDepth(t *testing.T) {
 	root := t.TempDir()
 	sched := NewSubagentScheduler(4, 2)
-	a := &Agent{
-		writeScheduler:     sched,
-		writeWorkspaceRoot: root,
-		subagentDepth:      1,
-	}
+	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 1}, writeScheduler: sched}
 	inner := &recordingWriter{name: "write_file"}
 	release, err := a.reserveParentWrite(inner, mustJSON(t, map[string]string{
 		"path": filepath.Join(root, "a.md"), "content": "x",
@@ -309,11 +305,7 @@ func TestAgentReserveParentWriteSkipsSubagentDepth(t *testing.T) {
 func TestAgentReserveParentWriteHoldsClaim(t *testing.T) {
 	root := t.TempDir()
 	sched := NewSubagentScheduler(4, 2)
-	a := &Agent{
-		writeScheduler:     sched,
-		writeWorkspaceRoot: root,
-		subagentDepth:      0,
-	}
+	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 0}, writeScheduler: sched}
 	inner := &recordingWriter{name: "write_file"}
 	release, err := a.reserveParentWrite(inner, mustJSON(t, map[string]string{
 		"path": filepath.Join(root, "a.md"), "content": "x",

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -9,7 +9,7 @@
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 146,
+    "struct-state": 132,
     "test-file-size": 69298
   },
   "files": {
@@ -452,9 +452,9 @@
     "internal/agent/agent.go": {
       "complexity": 37,
       "essay": 85,
-      "file-size": 2297,
+      "file-size": 2286,
       "function-size": 102,
-      "struct-state": 34
+      "struct-state": 20
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
Fifth and final bucket under the `struct-state` ratchet (#8436).

## The question this answers

After four buckets, ~14 of `Agent`'s remaining scalars were construct-once
configuration: `maxSteps`, `contextWindow`, `compactRatio`, `recentKeep`,
`archiveDir`, `temperature`, `maxSubagentDepth`, `modelRef`, `usageSource` and
friends. Written once in `New`, read forever after.

They take no part in the implicit state machine the ratchet targets — an
immutable field combines with nothing — so counting them measured **size**
rather than **reachable states**. Two options were on the table: exempt
immutable configuration in the rule, or accept the floor and stop.

Both were wrong. Exempting in the rule means the linter has to *guess* which
fields are immutable, from a single file's AST, with no way to see writes
elsewhere in the package. Stopping leaves the count meaning something other than
what it claims.

The third option puts the distinction in the type system, where the compiler and
a test can both see it.

## Zero read sites changed

`agentConfig` is **embedded**, not nested — the same shape `perTurnState`
already uses. Field promotion keeps `a.contextWindow` resolving exactly as
before, so none of the hundreds of read sites move. Only two things changed:

- `New`'s fourteen assignments, scattered through a ~60-line literal, become one
  `agentConfig{...}` block.
- 24 test literals that construct an `&Agent{...}` directly now nest their
  config fields (field promotion does not extend to literal initialisation).

## The claim is enforced, not documented

This is the part that decides whether the change is real or cosmetic. Field
promotion means `a.contextWindow = x` **still compiles** from anywhere in the
package. An unchecked "this is configuration" claim would turn the ratchet's
exclusion into a convenient place to hide state — exactly the failure mode the
ratchet exists to prevent.

`agent_config_test.go` walks the package AST and fails on any assignment to a
promoted config field, reading the field list from `agentConfig` itself so the
guard cannot drift from the type:

```
agent_config_test.go:83: compact.go:92: a.contextWindow is assigned after
construction; agentConfig must stay immutable, or the field belongs on Agent
```

That output is from a mutation check — one assignment added to `compact.go`
turns it red. Restored and re-verified green.

## Ratchet

`Agent`: **46 → 32** scalars. Baseline tightened — `agent.go` 34 → 20, total
146 → 132, `file-size` 2297 → 2286.

## The series

| | Agent scalars |
|---|---|
| before the ratchet | 59 |
| #8439 capability | 56 |
| #8447 missing-reasoning | 52 |
| #8453 recovery identity | 49 |
| #8460 compaction progress | 46 |
| this (config separation) | **32** |

27 scalars retired. Every bucket was a group that already shared a reset point,
a reader, or a name — none invented to move the number.

## Where this stops

The remaining 32 are genuinely mutable and coordinated. Two candidates could
still be grouped — steering (`steerConsumed` / `steerRunActive`) and the session
cache counters (`sessCacheHit` / `sessCacheMiss`) — each worth exactly one
field. That is below the threshold where the churn is worth it.

Three groups were checked and deliberately left alone:

- `stormSig` / `stormCount` — cross-turn by design; `perTurnState`'s own doc says
  storm counters stay on `Agent`.
- `preserveEvidenceOnce` / `deliveryRecoveryPending` — read in `beginRunTurn`
  *after* `perTurnState` is zeroed, because crossing that boundary is their job.
- `planMode` / `readOnlyExecution` / `plannerMCPExecution` /
  `mutationDependencyBarrier` — they read as one "execution mode", but their
  lifetimes are three different things (runtime-toggled, per-batch, and
  setup-once). Grouping by what they *mean* rather than when they *change* would
  have produced a struct with three reset semantics inside it.

Cache-impact: none - fourteen unexported fields move into an embedded unexported struct on Agent. Field promotion keeps every read identical, no logic changes, and nothing crosses the provider boundary: no system-prompt text, tool schema, message content, or request shape is touched.
Cache-guard: internal/agent/cachehit_e2e_test.go (unchanged, passing) plus the full internal/agent suite; contextWindow/compactRatio drive the compaction thresholds those tests already assert on.
Documentation-impact: none - docs/*.md describe the configuration's effect (context window, compact ratio, subagent depth), not the private field layout holding it, and every value and behaviour is unchanged.
