### PR TITLE
fix(cli): indent fenced code blocks for clean copy instead of a rail

### DIFF
--- a/internal/cli/md.go
+++ b/internal/cli/md.go
@@ -307,7 +307,11 @@ func (r *mdRenderer) renderList(buf *strings.Builder, n *ast.List, src []byte, i
 }
 
 func (r *mdRenderer) renderFenced(buf *strings.Builder, n ast.Node, src []byte, indent int) {
-	prefix := strings.Repeat(" ", indent) + dim("│ ")
+	// Fixed two-space indent, mirroring Claude Code. A "│ " rail or an
+	// indent-tracking prefix would be copied verbatim with the source, so keep
+	// the copy clean and mark the block with a constant, small indent instead of
+	// growing with the surrounding nesting.
+	prefix := strings.Repeat(" ", 2)
 	for i := range n.Lines().Len() {
 		l := n.Lines().At(i)
 		line := strings.TrimRight(string(l.Value(src)), "\n")


### PR DESCRIPTION
## Summary / 概述

Reasonix rendered markdown fenced code blocks with a `"│ "` rail prefix on every line (plus dim ANSI styling). When a user selected and copied the code, the rail character — and, inside nested lists, a large indent — was copied verbatim together with the source, making the pasted code unusable (it could not be compiled / run directly).

Reasonix 渲染 Markdown 围栏代码块时，会在每一行前面加上 `"│ "` 竖线前缀（并附带弱化的 ANSI 样式）。当用户选中并复制代码时，这个竖线字符——以及嵌套列表里的大段缩进——会连同源码一起被复制进剪贴板，导致粘贴后的代码无法直接使用（无法直接编译 / 运行）。

## Change / 改动

Switch fenced code blocks to a **fixed two-space indent**, mirroring Claude Code's behavior. This keeps the copy clean (no rail character, no indent that grows with nesting) while still visually marking the block.

将围栏代码块改为**固定的两空格缩进**，与 Claude Code 的行为保持一致。这样既能保证复制内容干净（没有竖线字符，缩进也不会随嵌套层级增长），又能在视觉上标识出代码块。

```go
func (r *mdRenderer) renderFenced(buf *strings.Builder, n ast.Node, src []byte, indent int) {
	// Fixed two-space indent, mirroring Claude Code. A "│ " rail or an
	// indent-tracking prefix would be copied verbatim with the source, so keep
	// the copy clean and mark the block with a constant, small indent instead of
	// growing with the surrounding nesting.
	prefix := strings.Repeat(" ", 2)
	for i := range n.Lines().Len() {
		l := n.Lines().At(i)
		line := strings.TrimRight(string(l.Value(src)), "\n")
		buf.WriteString(prefix)
		buf.WriteString(accent(line))
		buf.WriteString("\n")
	}
	buf.WriteString("\n")
}
```

### Before / 修改前

```
│ func main() {
│     os.Exit(runWithCrashCapture(os.Args[1:], version))
│ }
```

### After / 修改后

```
  func main() {
      os.Exit(runWithCrashCapture(os.Args[1:], version))
  }
```

## Verification / 验证

- `go build ./internal/cli/` passes
- `go test ./internal/cli/` passes
- A temporary render test confirmed top-level, in-list, and nested-list fenced blocks all emit exactly two leading spaces with no `│` character.

- `go build ./internal/cli/` 通过
- `go test ./internal/cli/` 通过
- 临时渲染测试确认：顶层、列表内、嵌套列表内的围栏代码块均只输出两个前导空格，且不含 `│` 字符。