### PR TITLE
fix(inbox): avoid pausing empty sessions

### DIFF
--- a/internal/control/inbox.go
+++ b/internal/control/inbox.go
@@ -224,8 +224,8 @@ func (c *Controller) rebindInbox() {
 		if path != "" && c.inbox.store.SessionPath() == path {
 			return
 		}
-		// Pause the old session's queue so it is not auto-run if reopened.
-		_ = c.inbox.store.SetPaused(true)
+		// Pending work must remain inspectable if this session is reopened.
+		_ = c.inbox.store.PauseIfPending()
 		c.inbox.store.Close()
 		c.inbox.store = nil
 		c.inbox.clearActive()
@@ -259,7 +259,7 @@ func (c *Controller) pauseInboxOnRotate() {
 	st := c.inbox.store
 	c.inbox.mu.Unlock()
 	if st != nil {
-		_ = st.SetPaused(true)
+		_ = st.PauseIfPending()
 	}
 }
 

--- a/internal/control/inbox_test.go
+++ b/internal/control/inbox_test.go
@@ -49,6 +49,37 @@ func TestEnqueueInboxDurableAndSnapshot(t *testing.T) {
 	}
 }
 
+func TestSessionRebindOnlyPausesInboxWithPendingWork(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		pending bool
+	}{
+		{name: "empty"},
+		{name: "pending", pending: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			oldPath := filepath.Join(dir, "old.jsonl")
+			c := New(Options{SessionPath: oldPath, SessionDir: dir, Sink: event.Discard})
+			if tc.pending {
+				if _, err := c.EnqueueInbox(InboxRequest{Submit: "work"}); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			c.SetSessionPath(filepath.Join(dir, "new.jsonl"))
+			oldInbox, err := sessioninbox.Open(oldPath, sessioninbox.Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldInbox.Close()
+			if got := oldInbox.Snapshot().Paused; got != tc.pending {
+				t.Fatalf("paused = %v, want %v", got, tc.pending)
+			}
+		})
+	}
+}
+
 func TestTrySteerRejectedBecomesFollowup(t *testing.T) {
 	dir := t.TempDir()
 	session := filepath.Join(dir, "s.jsonl")

--- a/internal/sessioninbox/ops.go
+++ b/internal/sessioninbox/ops.go
@@ -200,6 +200,33 @@ func (s *Store) SetPaused(paused bool) error {
 	return nil
 }
 
+// PauseIfPending pauses dispatch only when the inbox still contains work.
+func (s *Store) PauseIfPending() error {
+	if s == nil {
+		return ErrClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	release, err := s.beginDiskTransactionLocked()
+	if err != nil {
+		return err
+	}
+	defer release()
+	if err := s.mutableLocked(); err != nil {
+		return err
+	}
+	if len(s.man.Items) == 0 || s.man.Paused {
+		return nil
+	}
+	next := s.man.clone()
+	next.Paused = true
+	if err := s.commitManifestLocked(next); err != nil {
+		return err
+	}
+	s.notifyLocked(s.snapshotLocked())
+	return nil
+}
+
 // SetState transitions one item's durable state.
 func (s *Store) SetState(id string, state InboxState, blockReason string) error {
 	if s == nil {

--- a/internal/sessioninbox/ops_pause_test.go
+++ b/internal/sessioninbox/ops_pause_test.go
@@ -1,0 +1,37 @@
+package sessioninbox
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPauseIfPendingLeavesEmptyInboxUnpaused(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "s.jsonl"), Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.PauseIfPending(); err != nil {
+		t.Fatal(err)
+	}
+	if snap := s.Snapshot(); snap.Paused {
+		t.Fatalf("empty inbox paused during internal rebind: %+v", snap)
+	}
+}
+
+func TestPauseIfPendingPausesQueuedWork(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "s.jsonl"), Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if _, err := s.Enqueue(EnqueueRequest{Envelope: PromptEnvelope{SubmitText: "work"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PauseIfPending(); err != nil {
+		t.Fatal(err)
+	}
+	if snap := s.Snapshot(); !snap.Paused || len(snap.Items) != 1 {
+		t.Fatalf("queued work was not preserved paused: %+v", snap)
+	}
+}


### PR DESCRIPTION
## What

- only auto-pause a session inbox during rebind or rotation when it still contains pending work
- keep explicitly paused inboxes and pending queues paused
- add store-level and controller-level regression coverage for empty and non-empty inboxes

## Why

Session switching and new-session rotation previously called `SetPaused(true)` unconditionally. That persisted `paused: true` even for an empty, non-recovered inbox, so reopening the session could show `Inbox is paused` despite there being no interrupted work to review.

## Checks

- `go test ./internal/sessioninbox ./internal/control -count=1`
- `go vet ./internal/sessioninbox ./internal/control`
- `go run ./tools/repolint`
- `git diff --check`

The repository's broader `go test ./internal/tool/builtin ./internal/boot` pre-push check is not portable to this Windows PowerShell-only environment: existing shell fallback tests invoke `printf` and fail because Bash is unavailable. `make lint` could not be run because `make`, Bash, and `golangci-lint` are not installed; the available `repolint` target passed.

Documentation-impact: none - this corrects internal inbox pause semantics without changing commands or configuration.
Cache-impact: none - no prompt assembly or provider-cache behavior changes.
Cache-guard: N/A - inbox persistence only.