### PR TITLE
fix(desktop): keep an explicit [bot] enabled = false through a QR scan / 扫码不再覆盖用户显式设置的 [bot] enabled = false

### DIFF
--- a/desktop/bot_connection_app.go
+++ b/desktop/bot_connection_app.go
@@ -176,7 +176,7 @@ func (a *App) PollBotConnectionInstall(installID string) (BotInstallPollResult, 
 			Access:     botInstallAccess(result.UserID),
 			Credential: config.BotConnectionCredential{AccountID: result.AccountID, TokenEnv: "WEIXIN_BOT_TOKEN"},
 		}, func(c *config.Config) {
-			c.Bot.Enabled = true
+			c.Bot.Enabled = c.Bot.Enabled || config.BotInstallMayEnableGateway(c)
 			c.Bot.Weixin.Enabled = true
 			c.Bot.Weixin.AccountID = result.AccountID
 			c.Bot.Weixin.APIBase = result.BaseURL
@@ -531,7 +531,7 @@ func (a *App) pollFeishuConnectionInstall(installID string, session *botInstallS
 		Access:     botInstallAccess(userID),
 		Credential: config.BotConnectionCredential{AppID: appID, AppSecretEnv: secretEnv},
 	}, func(c *config.Config) {
-		c.Bot.Enabled = true
+		c.Bot.Enabled = c.Bot.Enabled || config.BotInstallMayEnableGateway(c)
 		c.Bot.Feishu.Enabled = true
 		c.Bot.Feishu.Domain = domain
 		c.Bot.Feishu.AppID = appID

--- a/desktop/bot_connection_app_test.go
+++ b/desktop/bot_connection_app_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -318,33 +319,7 @@ func TestFeishuInstallStoresFeishuSecretAndSurvivesReload(t *testing.T) {
 
 func TestWeixinInstallStoresSavedAccountAndConnection(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	withRewrittenHTTP(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/ilink/bot/get_bot_qrcode":
-			if r.URL.Query().Get("bot_type") != "3" {
-				http.Error(w, "missing bot type", http.StatusBadRequest)
-				return
-			}
-			writeJSON(t, w, map[string]any{
-				"qrcode":             "qr-weixin",
-				"qrcode_img_content": "data:image/png;base64,abc",
-			})
-		case "/ilink/bot/get_qrcode_status":
-			if r.URL.Query().Get("qrcode") != "qr-weixin" {
-				http.Error(w, "wrong qr", http.StatusBadRequest)
-				return
-			}
-			writeJSON(t, w, map[string]any{
-				"status":        "confirmed",
-				"ilink_bot_id":  "weixin-account",
-				"bot_token":     "token-1",
-				"ilink_user_id": "user-1",
-				"baseurl":       "https://ilinkai.weixin.qq.com",
-			})
-		default:
-			http.NotFound(w, r)
-		}
-	}))
+	serveWeixinInstall(t)
 
 	app := NewApp()
 	start, err := app.StartBotConnectionInstall("weixin", "")
@@ -388,6 +363,105 @@ func TestWeixinInstallStoresSavedAccountAndConnection(t *testing.T) {
 	reloadedConnection := botConnectionView(reloaded.Bot.Connections[0])
 	if reloadedConnection.Credential.AccountID != "weixin-account" || !reloadedConnection.Credential.SecretSet {
 		t.Fatalf("reloaded credential = %+v, want saved weixin account to survive restart", reloadedConnection.Credential)
+	}
+}
+
+func serveWeixinInstall(t *testing.T) {
+	t.Helper()
+	withRewrittenHTTP(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ilink/bot/get_bot_qrcode":
+			if r.URL.Query().Get("bot_type") != "3" {
+				http.Error(w, "missing bot type", http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, map[string]any{
+				"qrcode":             "qr-weixin",
+				"qrcode_img_content": "data:image/png;base64,abc",
+			})
+		case "/ilink/bot/get_qrcode_status":
+			if r.URL.Query().Get("qrcode") != "qr-weixin" {
+				http.Error(w, "wrong qr", http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, map[string]any{
+				"status":        "confirmed",
+				"ilink_bot_id":  "weixin-account",
+				"bot_token":     "token-1",
+				"ilink_user_id": "user-1",
+				"baseurl":       "https://ilinkai.weixin.qq.com",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func writeUserConfig(t *testing.T, body string) {
+	t.Helper()
+	path := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func completeWeixinInstall(t *testing.T, app *App) {
+	t.Helper()
+	start, err := app.StartBotConnectionInstall("weixin", "")
+	if err != nil {
+		t.Fatalf("StartBotConnectionInstall: %v", err)
+	}
+	poll, err := app.PollBotConnectionInstall(start.InstallID)
+	if err != nil {
+		t.Fatalf("PollBotConnectionInstall: %v", err)
+	}
+	if !poll.Done {
+		t.Fatalf("poll result = %+v, want done", poll)
+	}
+}
+
+func TestWeixinInstallKeepsExplicitBotDisabled(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	serveWeixinInstall(t)
+	writeUserConfig(t, `[bot]
+enabled = false
+
+[[bot.connections]]
+id = "weixin-weixin"
+provider = "weixin"
+domain = "weixin"
+label = "微信"
+enabled = true
+status = "connected"
+`)
+
+	completeWeixinInstall(t, NewApp())
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if cfg.Bot.Enabled {
+		t.Fatal("re-scanning an existing connection re-enabled the embedded bot over an explicit enabled = false")
+	}
+	if !cfg.Bot.Weixin.Enabled || cfg.Bot.Weixin.AccountID != "weixin-account" {
+		t.Fatalf("saved weixin config = %+v, want refreshed credentials", cfg.Bot.Weixin)
+	}
+	if len(cfg.Bot.Allowlist.WeixinUsers) != 1 || cfg.Bot.Allowlist.WeixinUsers[0] != "user-1" {
+		t.Fatalf("weixin allowlist = %+v, want installer user id", cfg.Bot.Allowlist.WeixinUsers)
+	}
+}
+
+func TestWeixinFirstInstallEnablesBotDespiteExplicitFalse(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	serveWeixinInstall(t)
+	writeUserConfig(t, "[bot]\nenabled = false\n")
+
+	completeWeixinInstall(t, NewApp())
+
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if !cfg.Bot.Enabled {
+		t.Fatal("first install left the embedded bot off, so connecting from the desktop does nothing")
 	}
 }
 

--- a/internal/config/bot_provenance.go
+++ b/internal/config/bot_provenance.go
@@ -1,0 +1,12 @@
+package config
+
+// BotInstallMayEnableGateway reports whether a finished bot install may switch
+// the embedded gateway on. The first connection is onboarding and always may;
+// after that an explicit [bot] enabled is the user's, so re-scanning a QR code
+// to refresh credentials must not turn a deliberate false back on (#8041).
+func BotInstallMayEnableGateway(c *Config) bool {
+	if c == nil {
+		return false
+	}
+	return len(c.Bot.Connections) == 0 || !tomlFileDefinesKey(UserConfigPath(), "bot", "enabled")
+}


### PR DESCRIPTION
## Summary

`PollBotConnectionInstall` set `c.Bot.Enabled = true` on every successful scan, in both the WeChat and the Feishu/Lark branch, so a rescan switched the embedded gateway back on for anyone running the CLI bot separately and each message was answered twice.

Deleting the write (方案 A) breaks onboarding instead: `config.Default()` leaves `Bot.Enabled` at Go's zero value `false`, and three install tests pin it.

So it is conditional now. `BotInstallMayEnableGateway` enables on the first connection, and after that only when the user config does not define `[bot] enabled`, reusing the `tomlFileDefinesKey` check behind `ConfigFileDefinesCompactRatio`. The first-connection clause is needed because the user-scope render always writes `enabled`, so a present key alone cannot spot a deliberate `false`. Narrower alternative if you prefer: provenance only.

再次扫码只刷新凭证，不会把用户手动设为 `false` 的 `[bot] enabled` 改回 `true`。

Adjacent gap, not fixed here: two gateways on one channel each receive every message anyway, since the WeChat adapter's `get_updates_buf` cursor is per-process in `a.syncBuf` with no server-side ack.

## Issues

Fixes #8041

## Verification

- `cd desktop && go test ./ -run Bot`, `go test ./internal/config/`
- New `TestWeixinInstallKeepsExplicitBotDisabled` fails on unpatched code and passes here; `TestWeixinFirstInstallEnablesBotDespiteExplicitFalse` pins the onboarding clause; the three existing install tests stay green
- `gofmt`, `go vet`, `go run ./tools/repolint` (clean, baseline unchanged), `golangci-lint run` on both changed packages at the pinned v2.12.2
- `desktop/bot_connection_app.go` keeps its line count, so its `file-size` baseline entry still holds

## Documentation impact

Documentation-impact: none - `docs/BOT_GUIDE.md` already presents `[bot] enabled` as the user's own switch, and this makes the desktop honor what is documented.

## Cache impact

Cache-impact: none - no prompt prefix, tool schema, or provider serialization changed.
Cache-guard: not required - `internal/config/bot_provenance.go` sits outside the path list in `scripts/check-cache-impact.sh`.
System-prompt-review: N/A
