### PR TITLE
fix(acp): return prompt failures as JSON-RPC errors

### DIFF
--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -162,9 +162,14 @@ audio are not advertised. During a turn, Reasonix may send:
 - `session/request_permission` requests for permission-gated tools and user
   questions.
 
-Hosts should keep the `session/prompt` request open until Reasonix returns its
-stop reason, while continuing to process requests and notifications in both
-directions.
+Hosts should keep the `session/prompt` request open until Reasonix returns a
+stop reason or JSON-RPC error, while continuing to process requests and
+notifications in both directions.
+
+Normal completion and a controlled automatic-recovery pause return `end_turn`;
+client cancellation returns `cancelled`. Other failures return `-32603
+InternalError` with a redacted, bounded error summary instead of inventing a
+non-standard stop reason.
 
 ## Mid-turn steering extension
 

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -150,8 +150,12 @@ Reasonix 把互不相关的选择拆成独立控制轴，而不是混在一个 m
 - 当前 mode 和配置项更新；
 - 针对受权限控制工具及用户问题的 `session/request_permission` 请求。
 
-Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止原因；期间仍需同时处理
-双向 request 和 notification。
+Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止原因或 JSON-RPC error；
+期间仍需同时处理双向 request 和 notification。
+
+正常完成和受控的自动恢复暂停返回 `end_turn`；客户端取消返回 `cancelled`。如果回合因
+其他原因失败，Reasonix 会返回 `-32603 InternalError`，并携带经脱敏、限制长度的错误
+摘要，而不是构造规范外的停止原因。
 
 ## 回合中引导扩展
 

--- a/internal/acp/prompt_result.go
+++ b/internal/acp/prompt_result.go
@@ -1,0 +1,18 @@
+package acp
+
+import "log/slog"
+
+func promptStopReason(runErr error, cancelled, recoveryPaused bool, sessionID string) (StopReason, error) {
+	if cancelled {
+		return StopCancelled, nil
+	}
+	if runErr == nil {
+		return StopEndTurn, nil
+	}
+	if recoveryPaused {
+		return StopEndTurn, nil
+	}
+	reason := clipStatusError(runErr, 2_048)
+	slog.Error("acp: session/prompt failed", "session_id", sessionID, "err", reason)
+	return "", &RPCError{Code: ErrInternal, Message: "session/prompt: " + reason}
+}

--- a/internal/acp/prompt_result_test.go
+++ b/internal/acp/prompt_result_test.go
@@ -1,0 +1,174 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+func TestServePromptErrorReturnsJSONRPCError(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+	const opaqueSecret = "relayKeyAbcdefghijkl"
+	const maskedSuffix = "ae54"
+	var mu sync.Mutex
+	attempts := 0
+	factory := &fakeFactory{behavior: func(_ context.Context, sink event.Sink, _ string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		attempts++
+		if attempts == 1 {
+			return errors.New("provider failed: Authorization: Bearer " + secret + " credential " + opaqueSecret + " rejected token ****" + maskedSuffix + "\ndetails=" + strings.Repeat("x", 3_000))
+		}
+		sink.Emit(event.Event{Kind: event.Text, Text: "recovered"})
+		return nil
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "fail"}},
+	})
+	notifications, resp := drainPrompt(t, client, promptCh)
+	if resp.Error == nil {
+		t.Fatalf("prompt response = %+v, want JSON-RPC error", resp)
+	}
+	if resp.Error.Code != ErrInternal {
+		t.Errorf("error code = %d, want %d", resp.Error.Code, ErrInternal)
+	}
+	if !strings.HasPrefix(resp.Error.Message, "session/prompt: provider failed:") {
+		t.Errorf("error message = %q, want underlying cause", resp.Error.Message)
+	}
+	if strings.Contains(resp.Error.Message, secret) || strings.Contains(resp.Error.Message, opaqueSecret) || strings.Contains(resp.Error.Message, maskedSuffix) {
+		t.Errorf("error message leaked credential: %q", resp.Error.Message)
+	}
+	if len(resp.Error.Message) > len("session/prompt: ")+2_048 {
+		t.Errorf("error message length = %d, want at most %d", len(resp.Error.Message), len("session/prompt: ")+2_048)
+	}
+	if len(resp.Result) != 0 {
+		t.Errorf("result = %s, want no stopReason result on failure", resp.Result)
+	}
+
+	wantReason := strings.TrimPrefix(resp.Error.Message, "session/prompt: ")
+	foundStatus := false
+	for _, notification := range notifications {
+		if notification.Method != sessionStatusUpdateMethod {
+			continue
+		}
+		var update ReasonixStatusUpdate
+		if err := json.Unmarshal(notification.Params, &update); err != nil {
+			t.Fatalf("status update: %v", err)
+		}
+		if update.Event == "error" {
+			foundStatus = true
+			if update.Status.TurnOutcome.Kind != "error" || update.Status.TurnOutcome.Reason != wantReason {
+				t.Errorf("error status = %+v, want reason %q", update.Status.TurnOutcome, wantReason)
+			}
+		}
+	}
+	if !foundStatus {
+		t.Fatal("missing error status update before prompt response")
+	}
+
+	retryCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "retry"}},
+	})
+	_, retryResp := drainPrompt(t, client, retryCh)
+	if retryResp.Error != nil {
+		t.Fatalf("retry prompt errored: %+v", retryResp.Error)
+	}
+	var retryResult SessionPromptResult
+	if err := json.Unmarshal(retryResp.Result, &retryResult); err != nil {
+		t.Fatalf("retry prompt result: %v", err)
+	}
+	if retryResult.StopReason != StopEndTurn {
+		t.Errorf("retry stopReason = %q, want %q", retryResult.StopReason, StopEndTurn)
+	}
+}
+
+func TestServePromptRecoveryPauseReturnsEndTurn(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
+		return &agent.RecoveryPauseError{Message: "automatic recovery paused"}
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "pause"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt error = %+v, want controlled completion", resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if result.StopReason != StopEndTurn {
+		t.Errorf("stopReason = %q, want %q", result.StopReason, StopEndTurn)
+	}
+}
+
+func TestServeCancelWhenRunnerReturnsNil(t *testing.T) {
+	started := make(chan struct{})
+	factory := &fakeFactory{behavior: func(ctx context.Context, _ event.Sink, _ string) error {
+		close(started)
+		<-ctx.Done()
+		return nil
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "loop"}},
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prompt never started")
+	}
+	client.notify("session/cancel", SessionCancelParams{SessionID: nr.SessionID})
+
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("cancelled prompt errored: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if result.StopReason != StopCancelled {
+		t.Errorf("stopReason = %q, want %q", result.StopReason, StopCancelled)
+	}
+}

--- a/internal/acp/prompt_result_unit_test.go
+++ b/internal/acp/prompt_result_unit_test.go
@@ -1,0 +1,59 @@
+package acp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPromptStopReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		runErr         error
+		cancelled      bool
+		recoveryPaused bool
+		wantStop       StopReason
+		wantError      bool
+	}{
+		{name: "completed", wantStop: StopEndTurn},
+		{name: "cancelled after graceful stop", cancelled: true, wantStop: StopCancelled},
+		{name: "cancelled", runErr: errors.New("stopped"), cancelled: true, wantStop: StopCancelled},
+		{name: "recovery paused", runErr: errors.New("paused"), recoveryPaused: true, wantStop: StopEndTurn},
+		{name: "failed", runErr: errors.New("provider failed"), wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStop, gotErr := promptStopReason(tt.runErr, tt.cancelled, tt.recoveryPaused, "session-1")
+			if gotStop != tt.wantStop {
+				t.Errorf("stopReason = %q, want %q", gotStop, tt.wantStop)
+			}
+			if (gotErr != nil) != tt.wantError {
+				t.Errorf("error = %v, wantError %v", gotErr, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestPromptStopReasonRedactsAndClipsFailure(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+	const opaqueSecret = "relayKeyAbcdefghijkl"
+	const maskedSuffix = "ae54"
+	runErr := errors.New("provider failed: Authorization: Bearer " + secret + " credential " + opaqueSecret + " rejected token ****" + maskedSuffix + "\ndetails=" + strings.Repeat("x", 3_000))
+	stop, err := promptStopReason(runErr, false, false, "session-1")
+	if stop != "" {
+		t.Errorf("stopReason = %q, want empty error result", stop)
+	}
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) || rpcErr.Code != ErrInternal {
+		t.Fatalf("error = %#v, want ErrInternal RPCError", err)
+	}
+	if !strings.HasPrefix(rpcErr.Message, "session/prompt: provider failed:") {
+		t.Errorf("error message = %q, want underlying cause", rpcErr.Message)
+	}
+	if strings.Contains(rpcErr.Message, secret) || strings.Contains(rpcErr.Message, opaqueSecret) || strings.Contains(rpcErr.Message, maskedSuffix) {
+		t.Errorf("error message leaked credential: %q", rpcErr.Message)
+	}
+	if len(rpcErr.Message) > len("session/prompt: ")+2_048 {
+		t.Errorf("error message length = %d, want at most %d", len(rpcErr.Message), len("session/prompt: ")+2_048)
+	}
+}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -558,13 +558,13 @@ type SessionReloadExtensionsResult struct {
 // could collide with a future official ACP method and must not be used.
 const sessionReloadExtensionsMethod = "_reasonix.io/session/reloadExtensions"
 
-// StopReason tells the client why a turn ended. Values match main's wire.
+// StopReason tells the client why a turn ended. Reasonix only emits values from
+// the ACP v1 enum; failed turns are returned as JSON-RPC errors instead.
 type StopReason string
 
 const (
 	StopEndTurn   StopReason = "end_turn"
 	StopCancelled StopReason = "cancelled"
-	StopError     StopReason = "error"
 )
 
 // SessionPromptResult ends a session/prompt. TranscriptPath is reserved for a

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -1856,32 +1855,6 @@ func TestServeSteerInjectsIntoActivePrompt(t *testing.T) {
 	})
 	if idleResp.Error == nil || idleResp.Error.Code != ErrInvalidRequest {
 		t.Fatalf("idle %s = %+v, want invalid request", sessionSteerMethod, idleResp.Error)
-	}
-}
-
-func TestServePromptErrorIsNotReportedAsCancelled(t *testing.T) {
-	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
-		return errors.New("provider failed")
-	}}
-	client, stop := startServer(t, factory)
-	defer stop()
-
-	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
-	newResp := client.call(t, "session/new", SessionNewParams{})
-	var nr SessionNewResult
-	json.Unmarshal(newResp.Result, &nr)
-
-	promptCh := client.callAsync("session/prompt", SessionPromptParams{
-		SessionID: nr.SessionID,
-		Prompt:    []ContentBlock{{Type: "text", Text: "fail"}},
-	})
-	_, resp := drainPrompt(t, client, promptCh)
-	var pr SessionPromptResult
-	if err := json.Unmarshal(resp.Result, &pr); err != nil {
-		t.Fatalf("prompt result: %v", err)
-	}
-	if pr.StopReason != StopError {
-		t.Errorf("stopReason = %q, want error", pr.StopReason)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1185,10 +1185,11 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		cancel()
 	}()
 	runErr := drainACPInbox(runCtx, sess.ctrl, sess.ctrl.RunTurn(runCtx, text))
+	cancelled := runCtx.Err() != nil
 
 	statusEvent := sess.status.finishTurn(
 		runErr,
-		runCtx.Err() != nil,
+		cancelled,
 		sess.currentCtrl().GoalStatus(),
 		finalAssistantSummary(sess.currentCtrl()),
 	)
@@ -1197,13 +1198,10 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	// the transcript and the same sequence/usage/outcome snapshot.
 	sess.persistAfterTurn(text)
 
-	stop := StopEndTurn
-	if runErr != nil {
-		if runCtx.Err() != nil {
-			stop = StopCancelled
-		} else {
-			stop = StopError
-		}
+	var recoveryPause *agent.RecoveryPauseError
+	stop, promptErr := promptStopReason(runErr, cancelled, errors.As(runErr, &recoveryPause), p.SessionID)
+	if promptErr != nil {
+		return nil, promptErr
 	}
 	res := SessionPromptResult{StopReason: stop}
 	if sess.transcript != "" {

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -16,7 +16,6 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
-	"reasonix/internal/secrets"
 )
 
 const (
@@ -409,7 +408,7 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 				eventName = "pause"
 			case runErr != nil:
 				t.phase = "error"
-				t.turnOutcome = ReasonixTurnOutcome{Kind: "error", Reason: clipStatusText(runErr.Error(), 2_048)}
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "error", Reason: clipStatusError(runErr, 2_048)}
 				t.goalOverride = "failed"
 				eventName = "error"
 			default:
@@ -592,14 +591,6 @@ func normalizeGoalStatus(value string) string {
 	default:
 		return "none"
 	}
-}
-
-func clipStatusText(value string, limit int) string {
-	value = strings.TrimSpace(secrets.Redact(value))
-	if len(value) <= limit {
-		return value
-	}
-	return value[:limit]
 }
 
 func redactStatusTexts(values []string, limit int) []string {

--- a/internal/acp/status_text.go
+++ b/internal/acp/status_text.go
@@ -1,0 +1,23 @@
+package acp
+
+import (
+	"strings"
+
+	"reasonix/internal/secrets"
+)
+
+func clipStatusText(value string, limit int) string {
+	value = strings.TrimSpace(secrets.Redact(value))
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}
+
+func clipStatusError(err error, limit int) string {
+	value := strings.TrimSpace(secrets.RedactError(err))
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}


### PR DESCRIPTION
## Summary

- Return non-cancellation ACP prompt failures as JSON-RPC `-32603` errors with a redacted, bounded error summary instead of the non-standard `stopReason: "error"`.
- Keep successful turns, client cancellation, and controlled recovery pauses on ACP v1-compatible stop reasons, while using one cancellation snapshot for status and response consistency.
- Cover error propagation, credential redaction, retrying the same session, graceful cancellation, and recovery-pause behavior.

## Issues

Fixes #8241

## Verification

- Focused file-level prompt-result tests passed with the checked-in dependency graph and `GOPROXY=off`.
- The full `internal/acp` test package and `go vet` passed in an offline compatibility run using locally cached patch-adjacent releases for four modules whose locked versions were unavailable; project dependency files were not changed.
- `go run ./tools/repolint`, focused `gofmt`, and `git diff --check` passed.
- The exact locked-dependency package run could not start offline because those four declared module versions were not present in the local cache; CI remains the authoritative locked-version validation.

## Documentation impact

Documentation-impact: updated - documented ACP v1 prompt failure semantics in both ACP guides

## Cache impact

Cache-impact: none - ACP response handling does not alter the provider-visible prompt or tool prefix
Cache-guard: go test ./internal/acp/
System-prompt-review: N/A

## Notes for reviewers

- Failed prompts now return a JSON-RPC error without a success result, so `transcriptPath` is not included on that path; transcript persistence and the existing status extension remain unchanged.
