### PR TITLE
fix(desktop): keep session identity stable across invalid-UTF-8 round-trips

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -1228,14 +1228,6 @@ func digestSessionMessages(msgs []provider.Message) ([sha256.Size]byte, error) {
 	return digest, err
 }
 
-func messageForSessionIdentity(m provider.Message) provider.Message {
-	// CreatedAt is local display metadata. Keep it out of transcript identity
-	// so older builds that ignore the optional field can share the same event-
-	// log revision and append without false conflicts.
-	m.CreatedAt = 0
-	return m
-}
-
 // digestAndSizeSessionMessages also reports the encoded transcript size, which
 // the save path uses to bound the event log relative to the live content.
 func digestAndSizeSessionMessages(msgs []provider.Message) ([sha256.Size]byte, int64, error) {

--- a/internal/agent/session_identity.go
+++ b/internal/agent/session_identity.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"reasonix/internal/provider"
+)
+
+// messageForSessionIdentity is the identity chokepoint shared by digests,
+// prefix checks, and storage equality: re-round-tripping the message through
+// the JSON encoder makes identity match the write/load form, so transcripts
+// holding raw invalid UTF-8 bytes (mojibake tool output) no longer fork a
+// recovery branch per save.
+func messageForSessionIdentity(m provider.Message) provider.Message {
+	// CreatedAt is local display metadata. Keep it out of transcript identity
+	// so older builds that ignore the optional field can share the same event-
+	// log revision and append without false conflicts.
+	m.CreatedAt = 0
+	if b, err := json.Marshal(m); err == nil {
+		_ = json.Unmarshal(b, &m)
+	}
+	return m
+}

--- a/internal/agent/session_identity_test.go
+++ b/internal/agent/session_identity_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// Identity must survive a write/load round-trip even when tool output carries
+// invalid UTF-8: encoding/json escapes each raw invalid byte as \ufffd and
+// loading turns it into the U+FFFD rune, so the live transcript (raw bytes)
+// and its reloaded copy must still compare equal.
+func TestSessionIdentityStableAcrossInvalidUTF8RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	mojibake := "tool output \xff\xfe mojibake"
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: mojibake, ReasoningContent: "thinking \xff bad"})
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save with invalid UTF-8: %v", err)
+	}
+
+	// The live session still holds the raw bytes; the reloaded copy holds the
+	// U+FFFD rune. Identity must agree so the next save is a clean append.
+	s.Add(provider.Message{Role: provider.RoleAssistant, Content: "second"})
+	err := s.SaveSnapshot(path)
+	if errors.Is(err, ErrSessionSnapshotConflict) {
+		t.Fatalf("SaveSnapshot after invalid-UTF-8 save conflicted: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("SaveSnapshot after invalid-UTF-8 save: %v", err)
+	}
+
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	memDigest, err := digestSessionMessages(s.Snapshot())
+	if err != nil {
+		t.Fatalf("digest in-memory messages: %v", err)
+	}
+	diskDigest, err := digestSessionMessages(loaded.Snapshot())
+	if err != nil {
+		t.Fatalf("digest loaded messages: %v", err)
+	}
+	if memDigest != diskDigest {
+		t.Fatalf("transcript identity drifted across round-trip: memory=%s disk=%s", digestString(memDigest), digestString(diskDigest))
+	}
+}
+
+// The identity round-trip must match what the JSON encoder itself produces, so
+// invalid bytes in nested fields (tool execution, tool-call arguments) cannot
+// reintroduce drift without a message-level change being caught here.
+func TestMessageForSessionIdentityNormalizesNestedInvalidUTF8(t *testing.T) {
+	execution := &provider.ToolExecution{OutputTail: "tail \xff\xfe"}
+	m := provider.Message{
+		Role:          provider.RoleTool,
+		Content:       "result \xff",
+		ToolExecution: execution,
+	}
+	got := messageForSessionIdentity(m)
+	if got.Content != "result \ufffd" {
+		t.Fatalf("Content = %q, want normalized", got.Content)
+	}
+	if got.ToolExecution.OutputTail != "tail \ufffd\ufffd" {
+		t.Fatalf("OutputTail = %q, want per-byte normalized", got.ToolExecution.OutputTail)
+	}
+	if got.ToolExecution != execution {
+		t.Fatalf("identity must not alias the caller's ToolExecution")
+	}
+}


### PR DESCRIPTION
Fixes #8342
Related: #8294, #8465, #8467, #8443, #8437

## Summary

- 修复：工具输出中的非法 UTF-8 字节（mojibake）导致会话转录“内存 ↔ 磁盘”身份不一致，每次保存都误判为分叉并创建一个恢复副本（`recovery_depth_cap_isolated`），最终侧边栏被大量同名截断的对话条目淹没，磁盘持续膨胀。

## Root cause

`encoding/json` 对非法 UTF-8 字节的往返是不对称的：

- 内存中持有原始非法字节的字符串，序列化时写为 `\ufffd` 转义（每个字节一个）；
- 读回时转义变成合法的 U+FFFD 字符，再序列化则是原始 UTF-8 字节。

因此仍持有原始字节的活动转录，永远无法与它自己的磁盘副本匹配。后果链：

1. `checkSnapshotWrite` 每次保存都判定 `diverged` → 每回合 fork 一个恢复分支（深度上限 3 后经 `SaveConflictRecoveryBranch(shutdown=true)` 绕过上限持续产出，即 #8342 描述的 30s 循环）；
2. `RecoveryBranchCoveredByParent` 的“分支摘要 == 分叉摘要”门槛因同一原因必然失败 → `recovery_copy=0` → 目录库把同一主题下的所有会话全部展开成子行（全部同名、同截断预览，即 #8465/#8467 描述的“重复对话”）；
3. 后台 GC 因同样的门槛永不回收这些副本（实测单个项目 122 个 `-recovery-` 文件，2 天可达数千个）。

## Fix

`messageForSessionIdentity`（`internal/agent/session_identity.go`，摘要/前缀/存储相等性共用的唯一身份咽喉点）现在先把消息重新过一遍 JSON 编码器，使身份计算基于“写入/读回”后的形态。三处同时修复：

- 普通保存恢复 append 判定，分叉风暴停止；
- 既有恢复副本被正确标记 `recovery_copy` → 侧边栏隐藏；
- 后台 GC 开始回收冗余副本。

对合法 UTF-8 转录完全无行为变化（归一化为恒等）。新增回归测试：非法 UTF-8 消息保存后再次 `SaveSnapshot` 不再冲突，且内存/磁盘摘要一致（修复前该测试失败，与线上事故现象一致）。

## Verification

- `go test ./internal/agent/ ./internal/sessioncatalog/`（全量通过）
- desktop 模块 `go build ./...` + 恢复/目录相关测试通过
- `go vet ./...` 通过
- `go run ./tools/repolint` clean（无新增基线）

Documentation-impact: none - behavior-only bug fix; recovery-copy visibility, GC, and topic aggregation now match the documented session-catalog contract (docs/SESSION_CATALOG.md), no doc text changes needed
