### PR TITLE
feat(cli): add themed composer background

### DIFF
--- a/internal/cli/theme.go
+++ b/internal/cli/theme.go
@@ -388,6 +388,9 @@ func refreshCLIStyles() {
 	inputBoxStyle = withThemeBorderFG(lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), true, false, true, false), activeCLITheme.accent).
 		PaddingLeft(1)
+	if colorOn() {
+		inputBoxStyle = inputBoxStyle.Background(themeLipColor(activeCLITheme.userBubbleBG))
+	}
 	todoPanelStyle = withThemeBorderFG(lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder(), true, false, false, false), activeCLITheme.border).
 		PaddingLeft(1)

--- a/internal/cli/theme_test.go
+++ b/internal/cli/theme_test.go
@@ -250,7 +250,7 @@ func TestApplyTextareaThemeHonorsCursorShape(t *testing.T) {
 	}
 }
 
-func TestComposerBorderAndCursorTrackThemeAccent(t *testing.T) {
+func TestComposerStyleTracksTheme(t *testing.T) {
 	t.Setenv("REASONIX_THEME", "")
 	t.Setenv("REASONIX_THEME_STYLE", "")
 	defer restoreThemeForTest(activeColorProfile, activeCLITheme)
@@ -259,18 +259,22 @@ func TestComposerBorderAndCursorTrackThemeAccent(t *testing.T) {
 	for _, theme := range cliThemeStyles {
 		t.Run(theme.name, func(t *testing.T) {
 			configureCLITheme(theme.name)
-			want := themeLipColor(activeCLITheme.accent)
-			if got := inputBoxStyle.GetBorderTopForeground(); !reflect.DeepEqual(got, want) {
-				t.Fatalf("composer top border color = %v, want theme accent %v", got, want)
+			wantAccent := themeLipColor(activeCLITheme.accent)
+			if got := inputBoxStyle.GetBorderTopForeground(); !reflect.DeepEqual(got, wantAccent) {
+				t.Fatalf("composer top border color = %v, want theme accent %v", got, wantAccent)
 			}
-			if got := inputBoxStyle.GetBorderBottomForeground(); !reflect.DeepEqual(got, want) {
-				t.Fatalf("composer bottom border color = %v, want theme accent %v", got, want)
+			if got := inputBoxStyle.GetBorderBottomForeground(); !reflect.DeepEqual(got, wantAccent) {
+				t.Fatalf("composer bottom border color = %v, want theme accent %v", got, wantAccent)
+			}
+			wantBackground := themeLipColor(activeCLITheme.userBubbleBG)
+			if got := inputBoxStyle.GetBackground(); !reflect.DeepEqual(got, wantBackground) {
+				t.Fatalf("composer background color = %v, want theme background %v", got, wantBackground)
 			}
 
 			ti := textarea.New()
 			applyTextareaTheme(&ti)
-			if got := ti.Styles().Cursor.Color; !reflect.DeepEqual(got, want) {
-				t.Fatalf("composer cursor color = %v, want theme accent %v", got, want)
+			if got := ti.Styles().Cursor.Color; !reflect.DeepEqual(got, wantAccent) {
+				t.Fatalf("composer cursor color = %v, want theme accent %v", got, wantAccent)
 			}
 		})
 	}
@@ -283,6 +287,9 @@ func TestComposerBorderAndCursorTrackThemeAccent(t *testing.T) {
 	}
 	if got := inputBoxStyle.GetBorderBottomForeground(); !reflect.DeepEqual(got, empty) {
 		t.Fatalf("NO_COLOR composer bottom border color = %v, want no color", got)
+	}
+	if got := inputBoxStyle.GetBackground(); !reflect.DeepEqual(got, empty) {
+		t.Fatalf("NO_COLOR composer background color = %v, want no color", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a theme-aware background to the TUI composer
- reuse the existing `userBubbleBG` palette token across every CLI theme
- preserve `NO_COLOR` behavior and cover the new style with regression tests

## Issues

Fixes #8005

## Verification

- `go test ./internal/cli -run 'TestComposerStyleTracksTheme|TestApplyTextareaTheme' -count=1`
- `go test ./internal/cli -run '^TestComposerStyleTracksTheme$' -count=10`
- `go vet ./...`
- `go run ./tools/repolint`
- `golangci-lint run --timeout=5m ./...`
- `git diff --check`

On Windows, the full `go test ./internal/cli -count=1` run still hits the unrelated existing `TestModelSwitchRefreshesCustomStatusline` failure; the focused tests and static checks above pass.

## Documentation impact

Documentation-impact: none - this is a self-evident visual theme refinement and adds no configuration, command, or public API.

## Cache impact

Cache-impact: none - the change is limited to CLI rendering and theme tests.
Cache-guard: N/A - no cache-sensitive prompt, provider, memory, or skills paths changed.
System-prompt-review: N/A