### PR TITLE
refactor(agent): extract the task lifetime into taskRuntime

### DIFF
--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -11,17 +11,17 @@ func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 
-	gated := &Agent{evidence: readinessLedger(writer, todo)}
+	gated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
 	if gated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("control arm must still gate an incomplete todo after a write")
 	}
 
-	off := &Agent{evidence: readinessLedger(writer, todo), ablation: ablation.New(ablation.Evidence)}
+	off := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Evidence)}
 	if got := off.finalReadinessCheckFor().reason; got != "" {
 		t.Fatalf("evidence ablation still gated the final answer: %q", got)
 	}
 
-	unrelated := &Agent{evidence: readinessLedger(writer, todo), ablation: ablation.New(ablation.Planner)}
+	unrelated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Planner)}
 	if unrelated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("an unrelated ablation must not disable the readiness gate")
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -432,9 +432,11 @@ type Agent struct {
 	// instead of leaving them in a queue no loop will ever consume.
 	steerRunActive bool
 
-	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
-	// complete_step validate that cited evidence happened before the claim.
-	evidence *evidence.Ledger
+	// task is the state shared by every Run continuing one delivery scope: the
+	// receipt ledger complete_step validates citations against, the spend that
+	// outlives a single Run, and the guards keyed to the task rather than the
+	// turn. See taskstate.go.
+	task taskRuntime
 
 	// todoState is the host's canonical task list: the latest successful
 	// todo_write with completions applied by complete_step. Unlike the per-turn
@@ -455,15 +457,12 @@ type Agent struct {
 	projectChecks []instruction.VerifyCheck
 
 	// deliveryProfile enables the runtime-enforced delivery contract. The stable
-	// profile prompt explains intent; these fields are host state and never enter
-	// the provider-cached prefix. deliveryScopeID and deliveryCheckpoint survive
-	// turns while a stable delivery scope continues; the per-turn expectations
-	// live in perTurnState.
+	// profile prompt explains intent; this is host state and never enters the
+	// provider-cached prefix. The scope ID and checkpoint it works against live
+	// in task; the per-turn expectations live in perTurnState.
 	// When agentPreset is set, deliveryProfile is derived for baseline Delivery
 	// and may be elevated per-turn by TaskPolicy (e.g. Light high-risk).
-	deliveryProfile    bool
-	deliveryScopeID    string
-	deliveryCheckpoint evidence.DeliveryCheckpoint
+	deliveryProfile bool
 
 	// agentPreset is the session role setting. Atomic so SetAgentPreset can
 	// update subsequent turns without rebuilding the agent.
@@ -557,22 +556,6 @@ type Agent struct {
 	// (see progress_guard.go); reset with the evidence ledger each turn.
 	progress progressGuard
 
-	// outcome shadows progress with an outcome-decomposed scorer whose samples
-	// only feed trajectory recording; it never influences guard behavior.
-	outcome *evidence.OutcomeTracker
-
-	// taskBudget accumulates spend across every Run continuing one task and
-	// resets with the evidence ledger: one ledger, one task, one bill. A
-	// per-Run total cannot see the failures worth stopping — those are
-	// measured in hours, and every "continue" starts a fresh Run.
-	taskBudget runBudget
-
-	// ebm is the Evidence-Before-More-Mutation nudge's once-per-turn state.
-	ebm ebmState
-
-	// governor is the reasoning governor's per-turn engagement state.
-	governor governorState
-
 	// forkRestore, when armed, swaps the frozen fork-bundle conversation in
 	// right after beginRunTurn — the counterfactual-continuation seam.
 	forkRestore func(*runLoopState)
@@ -580,16 +563,6 @@ type Agent struct {
 	// lastReasoning is the previous executor round's reasoning-token spend,
 	// read by the governor trigger (live policy and fork capture alike).
 	lastReasoning int
-
-	// repeatFailureCounts tracks semantically identical write-like calls that
-	// keep failing with the same failure class. Unlike stormSig, successful
-	// reads do not blindly clear this state: re-reading a file and then
-	// resending the same stale anchor is still zero progress. Stale-anchor
-	// records also survive target mutations until Preview proves the anchor is
-	// applicable again. Ordinary turns reset the map at Run start; Goal
-	// continuations retain it while their stable delivery scope is unchanged.
-	repeatFailureCounts map[string]repeatFailureRecord
-	repeatFailureScope  string
 }
 
 type repeatFailureRecord struct {
@@ -808,8 +781,8 @@ func (a *Agent) SetSession(s *Session) {
 	a.missingReasoning.active = false
 	a.missingReasoning.stateRecorded = false
 	a.missingReasoning.healthyStreak = 0
-	a.repeatFailureCounts = nil
-	a.repeatFailureScope = ""
+	a.task.repeatFailures = nil
+	a.task.repeatScope = ""
 	a.compactionMu.Lock()
 	a.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
 	a.cacheState = CacheStateUnknown
@@ -1294,10 +1267,13 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 			recentKeep:         opts.RecentKeep,
 			archiveDir:         opts.ArchiveDir,
 		},
-		prov:                prov,
-		tools:               tools,
-		session:             session,
-		taskBudget:          runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
+		prov:    prov,
+		tools:   tools,
+		session: session,
+		task: taskRuntime{
+			ledger: evidence.NewLedger(),
+			budget: runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
+		},
 		pricing:             opts.Pricing,
 		sink:                sink,
 		requireVisibleFinal: opts.RequireVisibleFinal,
@@ -1319,7 +1295,6 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		writeScheduler:            opts.WriteScheduler,
 		workspaceLease:            opts.WorkspaceLease,
 		missingReasoningWarnState: missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
-		evidence:                  evidence.NewLedger(),
 		projectChecks:             append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		deliveryProfile:           opts.DeliveryProfile || agentpreset.Normalize(opts.AgentPreset) == agentpreset.Delivery,
 		ablation:                  opts.Ablation,
@@ -1472,10 +1447,10 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	// job's evidence can be permanently drained. A failed or cancelled turn
 	// leaves the lease uncommitted so the next turn re-collects it.
 	defer func() {
-		if runErr != nil || a.evidence == nil || a.jobs == nil {
+		if runErr != nil || a.task.ledger == nil || a.jobs == nil {
 			return
 		}
-		for _, lease := range a.evidence.BackgroundLeases() {
+		for _, lease := range a.task.ledger.BackgroundLeases() {
 			a.jobs.CommitEvidenceForSession(lease.Session, lease.JobID)
 		}
 	}()
@@ -1543,7 +1518,7 @@ func boolInt(v bool) int {
 // DeliveryCheckpoint returns the compact Goal-scoped delivery state. It is safe
 // to persist next to the Goal sidecar because it contains no raw arguments.
 func (a *Agent) DeliveryCheckpoint() evidence.DeliveryCheckpoint {
-	return a.deliveryCheckpoint
+	return a.task.checkpoint
 }
 
 // RestoreDeliveryCheckpoint seeds a rebuilt controller before its next Goal
@@ -1553,8 +1528,8 @@ func (a *Agent) RestoreDeliveryCheckpoint(checkpoint evidence.DeliveryCheckpoint
 	if checkpoint.ScopeID == "" {
 		return
 	}
-	a.deliveryCheckpoint = checkpoint
-	a.deliveryScopeID = checkpoint.ScopeID
+	a.task.checkpoint = checkpoint
+	a.task.scopeID = checkpoint.ScopeID
 }
 
 // PrepareDeliveryRecovery preserves the exhausted turn's evidence for exactly
@@ -1570,18 +1545,18 @@ func (a *Agent) PrepareDeliveryRecovery() bool {
 }
 
 func (a *Agent) updateDeliveryCheckpoint(runErr error) {
-	if !a.deliveryScopeActive || a.deliveryScopeID == "" || a.evidence == nil {
+	if !a.deliveryScopeActive || a.task.scopeID == "" || a.task.ledger == nil {
 		return
 	}
-	cp := a.deliveryCheckpoint
-	if cp.ScopeID != a.deliveryScopeID {
-		cp = evidence.DeliveryCheckpoint{ScopeID: a.deliveryScopeID}
+	cp := a.task.checkpoint
+	if cp.ScopeID != a.task.scopeID {
+		cp = evidence.DeliveryCheckpoint{ScopeID: a.task.scopeID}
 	}
-	cp.CriteriaEstablished = cp.CriteriaEstablished || a.deliveryCriteriaEstablished || a.evidence.HasSuccessfulTodoWrite()
-	cp.WorkObserved = cp.WorkObserved || a.evidence.HasSuccessfulWorkReceipt()
+	cp.CriteriaEstablished = cp.CriteriaEstablished || a.deliveryCriteriaEstablished || a.task.ledger.HasSuccessfulTodoWrite()
+	cp.WorkObserved = cp.WorkObserved || a.task.ledger.HasSuccessfulWorkReceipt()
 	persistentOnlyReady := a.deliveryPersistentExpected && !a.deliveryMutationExpected &&
-		a.evidence.HasSuccessfulToolReceipt("remember") && !a.evidence.HasSuccessfulMutationOtherThan("remember")
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok && !persistentOnlyReady {
+		a.task.ledger.HasSuccessfulToolReceipt("remember") && !a.task.ledger.HasSuccessfulMutationOtherThan("remember")
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok && !persistentOnlyReady {
 		cp.MutationObserved = true
 		cp.PendingMutation = true
 	}
@@ -1591,20 +1566,20 @@ func (a *Agent) updateDeliveryCheckpoint(runErr error) {
 	if runErr == nil && cp.PendingMutation && a.deliveryMutationCheckpointReady() {
 		cp.PendingMutation = false
 	}
-	a.deliveryCheckpoint = cp
+	a.task.checkpoint = cp
 }
 
 func (a *Agent) deliveryMutationCheckpointReady() bool {
-	if a.evidence == nil || !a.deliveryCriteriaEstablished {
+	if a.task.ledger == nil || !a.deliveryCriteriaEstablished {
 		return false
 	}
-	mutation, ok := a.evidence.LatestSuccessfulMutationIndex()
+	mutation, ok := a.task.ledger.LatestSuccessfulMutationIndex()
 	if !ok {
 		mutation = -1
 	}
-	return a.evidence.HasSuccessfulCompleteStepAfter(mutation) &&
-		a.evidence.HasSuccessfulDeliverySignoffAfter(mutation) &&
-		a.evidence.HasSuccessfulReviewAfter(mutation) &&
+	return a.task.ledger.HasSuccessfulCompleteStepAfter(mutation) &&
+		a.task.ledger.HasSuccessfulDeliverySignoffAfter(mutation) &&
+		a.task.ledger.HasSuccessfulReviewAfter(mutation) &&
 		a.deliveryReviewGateFailure() == ""
 }
 
@@ -2723,15 +2698,15 @@ func (a *Agent) repeatedSuccessBlock(call provider.ToolCall, t tool.Tool) (strin
 }
 
 func (a *Agent) staleAnchorEditBlock(call provider.ToolCall) (string, bool) {
-	if a.evidence == nil || !anchorBasedEditTool(call.Name) {
+	if a.task.ledger == nil || !anchorBasedEditTool(call.Name) {
 		return "", false
 	}
 	rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, false)
 	if len(rec.Paths) == 0 {
 		return "", false
 	}
-	writeIndex, ok := a.evidence.LatestSuccessfulWriteIndex(rec.Paths)
-	if !ok || a.evidence.HasSuccessfulAnchorRefreshReadAfter(rec.Paths, writeIndex) {
+	writeIndex, ok := a.task.ledger.LatestSuccessfulWriteIndex(rec.Paths)
+	if !ok || a.task.ledger.HasSuccessfulAnchorRefreshReadAfter(rec.Paths, writeIndex) {
 		return "", false
 	}
 	return fmt.Sprintf(

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -15,19 +15,19 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 
 	// Turn did work (a successful bash) but issued no todo_write this turn, so the
 	// per-turn ledger has no list — the canonical state must still gate.
-	a := &Agent{evidence: readinessLedger(ran), todoState: open}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, todoState: open}
 	if got := a.ReadinessResult(); !strings.Contains(got.Reason, "incomplete") {
 		t.Fatalf("cross-turn gate = %q, want it to report incomplete canonical todos", got.Reason)
 	}
 
 	// A turn that touched nothing (pure Q&A) must never gate on stale canonical state.
-	idle := &Agent{evidence: evidence.NewLedger(), todoState: open}
+	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, todoState: open}
 	if got := idle.ReadinessResult(); !got.Ready {
 		t.Fatalf("no-work turn gated on canonical todos: %+v", got)
 	}
 
 	// All canonical items completed → no gate even after work.
-	done := &Agent{evidence: readinessLedger(ran), todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}
+	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}
 	if got := done.ReadinessResult(); !got.Ready {
 		t.Fatalf("completed canonical todos still gated: %+v", got)
 	}

--- a/internal/agent/capability_gate.go
+++ b/internal/agent/capability_gate.go
@@ -175,7 +175,7 @@ func (a *Agent) capabilityGateFailure() string {
 			a.capabilityAudit.RecordGate(true, false, false)
 		}
 		// Do not hard-block forever: once reported, allow final if no mutation pending.
-		if _, ok := a.evidence.LatestSuccessfulMutationIndex(); !ok {
+		if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
 			return ""
 		}
 		return gate.Reason
@@ -201,7 +201,7 @@ func (a *Agent) capabilityGateFailure() string {
 // latest mutation. When TaskPolicy is set, its Review level is authoritative;
 // otherwise Delivery-profile medium/high risk keeps the legacy matrix.
 func (a *Agent) deliveryReviewGateFailure() string {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return ""
 	}
 	// Without Delivery elevation or a forced TaskPolicy review, skip.
@@ -218,12 +218,12 @@ func (a *Agent) deliveryReviewGateFailure() string {
 		// file or run git diff/status) still applies via finalReadinessCheck.
 		return ""
 	}
-	mutation, ok := a.evidence.LatestSuccessfulMutationIndex()
+	mutation, ok := a.task.ledger.LatestSuccessfulMutationIndex()
 	if !ok {
 		return ""
 	}
 	a.emitTurnPhase(event.TurnPhaseReviewing)
-	risk := a.evidence.MutationRiskAfter(mutation)
+	risk := a.task.ledger.MutationRiskAfter(mutation)
 	// TaskPolicy may force higher review than mutation-risk alone.
 	if a.turnPolicySet {
 		switch a.turnPolicy.Review {
@@ -237,7 +237,7 @@ func (a *Agent) deliveryReviewGateFailure() string {
 			return ""
 		}
 	}
-	paths := productionPaths(a.evidence.PathsSince(mutation))
+	paths := productionPaths(a.task.ledger.PathsSince(mutation))
 	hasReviewTool := a.tools != nil && (toolPresent(a.tools, "review") || toolPresent(a.tools, "run_skill") || toolPresent(a.tools, "use_capability"))
 	hasSecurityTool := a.tools != nil && (toolPresent(a.tools, "security_review") || toolPresent(a.tools, "run_skill") || toolPresent(a.tools, "use_capability"))
 	switch risk {
@@ -249,7 +249,7 @@ func (a *Agent) deliveryReviewGateFailure() string {
 			// Test/minimal registries without review keep the light review gate.
 			return ""
 		}
-		ok, blocking, report := a.evidence.HasStructuredReviewAfter(evidence.ReviewKindReview, mutation, paths)
+		ok, blocking, report := a.task.ledger.HasStructuredReviewAfter(evidence.ReviewKindReview, mutation, paths)
 		if blocking {
 			if a.capabilityAudit != nil {
 				a.capabilityAudit.RecordReviewBlock(false)
@@ -257,8 +257,8 @@ func (a *Agent) deliveryReviewGateFailure() string {
 			return "structured review reported blocking findings; fix them and re-run review"
 		}
 		if !ok {
-			hostProof := a.evidence.HasSuccessfulDeliverySignoffAfter(mutation) &&
-				a.evidence.HasHostReviewCoverageAfter(mutation, paths)
+			hostProof := a.task.ledger.HasSuccessfulDeliverySignoffAfter(mutation) &&
+				a.task.ledger.HasHostReviewCoverageAfter(mutation, paths)
 			if !hostProof {
 				return "medium-risk changes require either a successful structured review or host-proven verification plus diff/file inspection after the latest mutation" + reviewCoverageHint(paths)
 			}
@@ -270,7 +270,7 @@ func (a *Agent) deliveryReviewGateFailure() string {
 		if !hasReviewTool && !hasSecurityTool {
 			return "high-risk changes require review and security_review tools after the latest mutation"
 		}
-		okR, blockR, repR := a.evidence.HasStructuredReviewAfter(evidence.ReviewKindReview, mutation, paths)
+		okR, blockR, repR := a.task.ledger.HasStructuredReviewAfter(evidence.ReviewKindReview, mutation, paths)
 		if blockR {
 			if a.capabilityAudit != nil {
 				a.capabilityAudit.RecordReviewBlock(false)
@@ -280,7 +280,7 @@ func (a *Agent) deliveryReviewGateFailure() string {
 		if !okR {
 			return "high-risk changes require review with review_report after the latest mutation" + reviewCoverageHint(paths)
 		}
-		okS, blockS, repS := a.evidence.HasStructuredReviewAfter(evidence.ReviewKindSecurity, mutation, paths)
+		okS, blockS, repS := a.task.ledger.HasStructuredReviewAfter(evidence.ReviewKindSecurity, mutation, paths)
 		if blockS {
 			if a.capabilityAudit != nil {
 				a.capabilityAudit.RecordReviewBlock(true)

--- a/internal/agent/capability_gate_test.go
+++ b/internal/agent/capability_gate_test.go
@@ -21,7 +21,7 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
 
 	got := a.deliveryReviewGateFailure()
 	for _, want := range []string{"high-risk", "git status --short", "git diff", "mutation did not report file paths"} {
@@ -62,7 +62,7 @@ func TestNonDeliveryProfileNeverRequiresStructuredReview(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: false, evidence: ledger, tools: reg}
+	a := &Agent{deliveryProfile: false, task: taskRuntime{ledger: ledger}, tools: reg}
 
 	if got := a.deliveryReviewGateFailure(); got != "" {
 		t.Fatalf("non-Delivery review gate = %q, want disabled", got)
@@ -76,7 +76,7 @@ func TestDeliveryReviewGateHighRiskStillRequiresSecurityReview(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
 
 	if got := a.deliveryReviewGateFailure(); !strings.Contains(got, "high-risk") {
 		t.Fatalf("review gate = %q, want high-risk review demand", got)
@@ -115,7 +115,7 @@ func TestDeliveryReviewGateMediumAcceptsHostProvenVerificationAndCoverage(t *tes
 
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
-	a := &Agent{deliveryProfile: true, evidence: ledger, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
 	if got := a.deliveryReviewGateFailure(); got != "" {
 		t.Fatalf("medium-risk host proof was rejected: %q", got)
 	}
@@ -123,7 +123,7 @@ func TestDeliveryReviewGateMediumAcceptsHostProvenVerificationAndCoverage(t *tes
 	missingVerification := evidence.NewLedger()
 	missingVerification.Record(evidence.ReceiptFromToolCall("edit_file", json.RawMessage(`{"path":"internal/agent/parser.go"}`), true, false))
 	missingVerification.Record(evidence.ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"internal/agent/parser.go"}`), true, true))
-	a.evidence = missingVerification
+	a.task.ledger = missingVerification
 	if got := a.deliveryReviewGateFailure(); !strings.Contains(got, "host-proven verification") {
 		t.Fatalf("medium-risk review without verification = %q, want host-proof guidance", got)
 	}
@@ -136,7 +136,7 @@ func TestDeliveryReviewGateDefersToParentInSubagents(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{agentConfig: agentConfig{subagentDepth: 1}, deliveryProfile: true, evidence: ledger, tools: reg}
+	a := &Agent{agentConfig: agentConfig{subagentDepth: 1}, deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
 
 	// Inside a sub-agent the structured-review contract belongs to the parent,
 	// which receives the child's mutation receipts via mergeChildEvidence. The

--- a/internal/agent/complete_subtask.go
+++ b/internal/agent/complete_subtask.go
@@ -98,14 +98,14 @@ func AttachCompleteSubtaskTool(reg *tool.Registry) {
 // submitted one. Adjudication re-runs here so the returned status reflects the
 // full run, including receipts recorded after the tool call itself.
 func (a *Agent) CompletionReport() (evidence.CompletionReport, []string, bool) {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return evidence.CompletionReport{}, nil, false
 	}
-	report, ok := a.evidence.LatestCompletionReport()
+	report, ok := a.task.ledger.LatestCompletionReport()
 	if !ok {
 		return evidence.CompletionReport{}, nil, false
 	}
-	adjudicated, reasons := a.evidence.AdjudicateCompletion(report)
+	adjudicated, reasons := a.task.ledger.AdjudicateCompletion(report)
 	return adjudicated, reasons, true
 }
 

--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -147,10 +147,10 @@ func intentName(i taskintent.Intent) string {
 // keeping incremental state because one code path serves the per-round view and
 // the end-of-turn record, so the two can never disagree.
 func (a *Agent) LiveContract() *taskcontract.Contract {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return nil
 	}
-	return buildShadowContract(a.turnInput, a.evidence.Receipts(), a.planContractSnapshot())
+	return buildShadowContract(a.turnInput, a.task.ledger.Receipts(), a.planContractSnapshot())
 }
 
 // observeContractRound records the contract after one tool round, so a
@@ -168,10 +168,10 @@ func (a *Agent) observeContractRound() {
 // state, and the completion report derived from it. Both observe; neither
 // decides.
 func (a *Agent) emitTurnShadows(input string) {
-	if a.evidence == nil {
+	if a.task.ledger == nil {
 		return
 	}
-	c := buildShadowContract(input, a.evidence.Receipts(), a.planContractSnapshot())
+	c := buildShadowContract(input, a.task.ledger.Receipts(), a.planContractSnapshot())
 	// Prefer the live contract when present so Suppressed/Partial state is not
 	// lost in the pure replay path.
 	if live := a.LiveContract(); live != nil && (live.HasSuppressed() || len(live.Requirements) > 0 || len(live.Checks) > 0) {
@@ -186,7 +186,7 @@ func (a *Agent) emitTurnShadows(input string) {
 		}
 	}
 	event.RecordContractShadow(a.sink, contractShadowAudit(c))
-	rep := completion.Build(c, a.evidence)
+	rep := completion.Build(c, a.task.ledger)
 	a.completion = &rep
 	event.RecordCompletionReport(a.sink, completionReportAudit(rep))
 	a.emitCompletionSummary(c)

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -132,7 +132,7 @@ func TestDeliveryResolvedReadOnlyBashDoesNotArmMutationReadiness(t *testing.T) {
 	if err := a.Run(context.Background(), "inspect and report the current workspace basename"); err != nil {
 		t.Fatalf("resolved read-only delivery command: %v", err)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("resolved read-only bash was recorded as a mutation")
 	}
 	msgs := a.session.Snapshot()
@@ -481,7 +481,7 @@ func TestExplicitDeliveryRecoveryPreservesEvidenceOnce(t *testing.T) {
 	if err := a.Run(context.Background(), "continue the remaining delivery checks"); err != nil {
 		t.Fatalf("recovery Run: %v", err)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); !ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
 		t.Fatal("recovery turn lost the prior mutation receipt")
 	}
 }
@@ -502,7 +502,7 @@ func TestOrdinaryFollowUpDoesNotPreserveFailedDeliveryEvidence(t *testing.T) {
 	if err := a.Run(context.Background(), "implement main"); !errors.As(err, &firstErr) {
 		t.Fatalf("first Run error = %v, want FinalReadinessError", err)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); !ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
 		t.Fatal("first failed delivery should retain its mutation until the next turn is classified")
 	}
 
@@ -510,7 +510,7 @@ func TestOrdinaryFollowUpDoesNotPreserveFailedDeliveryEvidence(t *testing.T) {
 	if err := a.Run(context.Background(), "fix the unrelated crash in other.go"); !errors.As(err, &followUpErr) {
 		t.Fatalf("ordinary follow-up error = %v, want FinalReadinessError", err)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("ordinary follow-up inherited stale mutation evidence without explicit recovery")
 	}
 }

--- a/internal/agent/ebm.go
+++ b/internal/agent/ebm.go
@@ -39,11 +39,11 @@ func (a *Agent) applyEBM(sample *evidence.OutcomeSample, outcomes []toolOutcome)
 	}
 	sample.EBMEligible = true
 	a.armForkCapture(*sample)
-	if !ebmEnabled || a.ebm.fired || len(outcomes) == 0 {
+	if !ebmEnabled || a.task.ebm.fired || len(outcomes) == 0 {
 		return intervention{}
 	}
-	a.ebm.fired = true
-	a.ebm.captureArmed = false
+	a.task.ebm.fired = true
+	a.task.ebm.captureArmed = false
 	sample.EBMFired = true
 	return intervention{
 		verdict:  verdictAdvise,

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -294,7 +294,7 @@ func TestDeliveryProfileBlocksMixedVerificationBeforeItBecomesMutation(t *testin
 	if got := toolResult(a.session, "bash"); !strings.Contains(got, "mixes a verification check") {
 		t.Fatalf("mixed command result = %q, want pre-execution split guidance", got)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("blocked scratch-file verification must not become a successful mutation")
 	}
 }
@@ -315,7 +315,7 @@ func TestDeliveryProfileExplainsMaskedVerifierExitBeforeExecution(t *testing.T) 
 	if got := toolResultByID(a.session, "masked"); !strings.Contains(got, "masks the verifier's exit status") {
 		t.Fatalf("masked command result = %q, want precise exit-status guidance", got)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("blocked masked verifier must not become a successful mutation")
 	}
 }
@@ -336,7 +336,7 @@ func TestDeliveryProfileBlocksOpaqueInlineInterpreterBeforeItBecomesMutation(t *
 	if got := toolResultByID(a.session, "opaque"); !strings.Contains(got, "cannot audit inline interpreter source") {
 		t.Fatalf("opaque command result = %q, want pre-execution audit guidance", got)
 	}
-	if _, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("blocked inline interpreter must not become a successful mutation")
 	}
 }

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -74,8 +74,8 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) bat
 	// for this batch, successes recorded during it (a mixed batch where only one
 	// call was guard-blocked) must already count as progress against the pass.
 	receiptMark := 0
-	if a.evidence != nil {
-		receiptMark = a.evidence.Len()
+	if a.task.ledger != nil {
+		receiptMark = a.task.ledger.Len()
 	}
 	// Full dispatches used the batch's initial file state. After a writer runs
 	// (even a failed one — disk may have mutated), refresh dependent writer
@@ -99,8 +99,8 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) bat
 		if calls[i].Name == "complete_step" && completedStepInBatch {
 			output := "blocked: only one successful complete_step is allowed per tool-call round. Continue from the newly promoted in_progress todo in the next round instead of batching sign-offs."
 			outcomes[i] = toolOutcome{output: output, blocked: true, errMsg: "blocked: complete_step sign-offs must be serial"}
-			if a.evidence != nil {
-				a.evidence.Record(evidence.ReceiptFromToolCall(calls[i].Name, json.RawMessage(calls[i].Arguments), false, true))
+			if a.task.ledger != nil {
+				a.task.ledger.Record(evidence.ReceiptFromToolCall(calls[i].Name, json.RawMessage(calls[i].Arguments), false, true))
 			}
 			durations[i] = time.Since(start).Milliseconds()
 			results[i] = output

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -334,11 +334,11 @@ func (a *Agent) applyPlanModeAndProxy(ctx context.Context, plan *toolCallPlan) (
 				a.noteCapabilityInvocation(call.Name, json.RawMessage(call.Arguments), nil)
 			}
 			result := rc.Result
-			if a.evidence != nil {
+			if a.task.ledger != nil {
 				// inspect/decline are not mutations; unavailable call targets are not success.
 				success := !rc.Unavailable
 				rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), success, true)
-				a.evidence.Record(rec)
+				a.task.ledger.Record(rec)
 			}
 			if rc.Unavailable {
 				return toolOutcome{output: result, errMsg: firstLine(rc.UnavailableReason)}, true
@@ -670,8 +670,8 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	}
 	cctx := tool.WithContextCompressor(withCallContext(ctx, plan.call.ID, a.sink, a.asker, a.planMode.Load()), a)
 	cctx = WithSubagentDepth(cctx, a.subagentDepth)
-	if a.evidence != nil {
-		cctx = evidence.WithLedger(cctx, a.evidence)
+	if a.task.ledger != nil {
+		cctx = evidence.WithLedger(cctx, a.task.ledger)
 		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot)
 		if a.deliveryProfile {
 			cctx = evidence.WithDeliveryProfile(cctx)

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -82,7 +82,7 @@ func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recover
 }
 
 func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
-	if a.evidence == nil || a.ablation.Off(ablation.Evidence) {
+	if a.task.ledger == nil || a.ablation.Off(ablation.Evidence) {
 		return finalReadinessCheck{}
 	}
 	var missing []string
@@ -94,23 +94,23 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		return out
 	}
 	{
-		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
-		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
+		incomplete, hasTodos := a.task.ledger.IncompleteLatestTodos()
+		if !hasTodos && a.task.ledger.HasAnySuccessfulReceipt() {
 			incomplete, hasTodos = a.incompleteCanonicalTodos()
 		}
-		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
+		if hasTodos && len(incomplete) > 0 && a.task.ledger.HasSuccessfulTodoProgressReceipt() {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
 		}
 	}
-	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
+	writer, hasWriter := a.task.ledger.LatestSuccessfulWriterIndex()
 	deliveryMutation := false
 	deliveryVerificationOnly := false
-	checkpoint := a.deliveryCheckpoint
-	checkpointApplies := a.deliveryScopeActive && checkpoint.ScopeID == a.deliveryScopeID
+	checkpoint := a.task.checkpoint
+	checkpointApplies := a.deliveryScopeActive && checkpoint.ScopeID == a.task.scopeID
 	if a.deliveryProfile {
-		if mutation, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
+		if mutation, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 			writer, hasWriter = mutation, true
 			deliveryMutation = true
 		} else if checkpointApplies && checkpoint.PendingMutation {
@@ -122,12 +122,12 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		} else if checkpointApplies && checkpoint.MutationObserved {
 			deliveryMutation = true
 		}
-		workObserved := a.evidence.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
+		workObserved := a.task.ledger.HasSuccessfulWorkReceipt() || (checkpointApplies && checkpoint.WorkObserved)
 		if a.deliveryTaskExpected && !a.deliveryPersistentExpected && !workObserved {
 			out.missingActionEvidence++
 			missing = append(missing, "perform host-observable work for this technical task before answering")
 		}
-		if a.deliveryPersistentExpected && !a.evidence.HasSuccessfulToolReceipt("remember") {
+		if a.deliveryPersistentExpected && !a.task.ledger.HasSuccessfulToolReceipt("remember") {
 			out.missingMutation++
 			missing = append(missing, "save the requested durable memory with the remember tool before answering")
 		}
@@ -135,7 +135,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 			out.missingMutation++
 			missing = append(missing, "the request requires a state change, but no successful mutation was observed")
 		}
-		if !hasWriter && a.evidence.HasSuccessfulVerificationCommand() {
+		if !hasWriter && a.task.ledger.HasSuccessfulVerificationCommand() {
 			writer, hasWriter = -1, true
 			deliveryVerificationOnly = true
 		}
@@ -147,7 +147,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 			out.missingCapabilities++
 			missing = append(missing, msg)
 		}
-		if a.deliveryPersistentExpected && !a.deliveryMutationExpected && !a.evidence.HasSuccessfulMutationOtherThan("remember") {
+		if a.deliveryPersistentExpected && !a.deliveryMutationExpected && !a.task.ledger.HasSuccessfulMutationOtherThan("remember") {
 			// A durable-memory-only request has its own concrete receipt contract.
 			// It must not inherit code-delivery todo/test/diff/review ceremonies;
 			// any unrelated mutation falls through to the full contract below.
@@ -169,13 +169,13 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 	}
 	if !a.deliveryProfile && a.turnPolicySet && a.turnPolicy.Verification >= taskpolicy.VerifyTargeted &&
 		a.turnPolicy.AllowsTests() && toolPresent(a.tools, "bash") &&
-		!a.evidence.HasSuccessfulVerificationCommandAfter(writer) {
+		!a.task.ledger.HasSuccessfulVerificationCommandAfter(writer) {
 		out.applies = true
 		out.missingVerification++
 		missing = append(missing, "run a relevant verification command after the latest write for the current role setting")
 	}
 	hasProjectChecks := len(a.projectChecks) > 0
-	hasTodoReceipt := a.evidence.HasSuccessfulTodoWrite()
+	hasTodoReceipt := a.task.ledger.HasSuccessfulTodoWrite()
 	if !a.deliveryProfile && !hasProjectChecks && !hasTodoReceipt && len(missing) == 0 {
 		return finalReadinessCheck{}
 	}
@@ -187,16 +187,16 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 			out.missingAcceptanceCriteria++
 			missing = append(missing, "establish concrete acceptance criteria with todo_write before changing state")
 		}
-		hasCompleteStep := a.evidence.HasSuccessfulCompleteStepAfter(writer)
+		hasCompleteStep := a.task.ledger.HasSuccessfulCompleteStepAfter(writer)
 		if !hasCompleteStep {
 			out.missingSignoff++
 			missing = append(missing, "call complete_step after the latest mutation")
 		}
-		if !a.evidence.HasSuccessfulDeliverySignoffAfter(writer) {
+		if !a.task.ledger.HasSuccessfulDeliverySignoffAfter(writer) {
 			out.missingVerification++
 			missing = append(missing, "run relevant verification after the latest mutation and cite that successful command in complete_step")
 		}
-		if deliveryMutation && !a.evidence.HasSuccessfulReviewAfter(writer) {
+		if deliveryMutation && !a.task.ledger.HasSuccessfulReviewAfter(writer) {
 			out.missingReview++
 			missing = append(missing, "inspect the changed result after the latest mutation (read the touched file or run git diff/status)")
 		}
@@ -214,7 +214,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		if command == "" {
 			continue
 		}
-		if !a.evidence.HasSuccessfulCommandAfter(command, writer) {
+		if !a.task.ledger.HasSuccessfulCommandAfter(command, writer) {
 			out.missingProjectChecks++
 			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
 		}

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -47,7 +47,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			a := &Agent{evidence: tc.evidence, projectChecks: tc.checks}
+			a := &Agent{task: taskRuntime{ledger: tc.evidence}, projectChecks: tc.checks}
 			got := a.ReadinessResult()
 			if tc.wantEmpty {
 				if !got.Ready {
@@ -70,7 +70,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 
 func TestFinalReadinessAllowsIncompleteTodosInPlanMode(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "draft implementation plan", Status: "pending"}}}
-	a := &Agent{evidence: readinessLedger(todo)}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(todo)}}
 	a.SetPlanMode(true)
 
 	if got := a.ReadinessResult(); !got.Ready {
@@ -84,7 +84,7 @@ func TestFinalReadinessAllowsIncompleteTodosInPlanMode(t *testing.T) {
 func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
-	a := &Agent{evidence: readinessLedger(writer, todo)}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
 
 	got := a.finalReadinessCheckFor()
 	if !got.applies {
@@ -106,7 +106,7 @@ func TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{evidence: ledger}
+	a := &Agent{task: taskRuntime{ledger: ledger}}
 	a.armLoopGuardPass(ledger.Len())
 
 	got := a.finalReadinessCheckFor()
@@ -125,7 +125,7 @@ func TestFinalReadinessLoopGuardPassSurvivesBookkeeping(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{evidence: ledger}
+	a := &Agent{task: taskRuntime{ledger: ledger}}
 	a.armLoopGuardPass(ledger.Len())
 
 	ledger.Record(evidence.Receipt{ToolName: "ask", Success: true})
@@ -144,7 +144,7 @@ func TestFinalReadinessLoopGuardPassRevokedByRealProgress(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{evidence: ledger}
+	a := &Agent{task: taskRuntime{ledger: ledger}}
 	a.armLoopGuardPass(ledger.Len())
 
 	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
@@ -164,7 +164,7 @@ func TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput(t *testing.T) {
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
 	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "agent.go:2082: \"[loop guard] %s has now %s %d times\""})
-	a := &Agent{evidence: readinessLedger(writer, todo), session: sess}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, session: sess}
 
 	if got := a.finalReadinessCheckFor(); got.reason == "" {
 		t.Fatal("finalReadinessCheckFor() reason empty, want quoted loop-guard text to be ignored")

--- a/internal/agent/final_rejection_test.go
+++ b/internal/agent/final_rejection_test.go
@@ -23,7 +23,7 @@ func rejectionAgent(t *testing.T, plan *plancontract.Plan) *Agent {
 func TestUnprovenPlanCriterionBlocksTheFinalAnswer(t *testing.T) {
 	plan := criterionPlan()
 	a := rejectionAgent(t, &plan)
-	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
 
 	outstanding := a.outstandingPlanCriteria()
 	if len(outstanding) == 0 {
@@ -41,7 +41,7 @@ func TestProvenPlanCriteriaLeaveNothingOutstanding(t *testing.T) {
 	plan := criterionPlan()
 	a := rejectionAgent(t, &plan)
 	for _, c := range plan.Steps[0].Acceptance {
-		a.evidence.Record(completeStepReceipt(t, c.ID, "manual", ""))
+		a.task.ledger.Record(completeStepReceipt(t, c.ID, "manual", ""))
 	}
 	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
 		t.Fatalf("outstanding = %v, want none once every criterion is proven", outstanding)
@@ -54,13 +54,13 @@ func TestStaleProofBecomesOutstandingAgain(t *testing.T) {
 	plan := criterionPlan()
 	a := rejectionAgent(t, &plan)
 	for _, c := range plan.Steps[0].Acceptance {
-		a.evidence.Record(completeStepReceipt(t, c.ID, "verification", "go test ./..."))
+		a.task.ledger.Record(completeStepReceipt(t, c.ID, "verification", "go test ./..."))
 	}
 	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
 		t.Fatalf("outstanding = %v, want none while the proofs are fresh", outstanding)
 	}
 
-	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
 	outstanding := a.outstandingPlanCriteria()
 	if len(outstanding) == 0 {
 		t.Fatal("a mutation after the proofs must reopen them")
@@ -73,7 +73,7 @@ func TestStaleProofBecomesOutstandingAgain(t *testing.T) {
 // An unplanned turn must not inherit a contract it never agreed to.
 func TestUnplannedTurnHasNoOutstandingCriteria(t *testing.T) {
 	a := rejectionAgent(t, nil)
-	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"pay.go"}})
 	if outstanding := a.outstandingPlanCriteria(); len(outstanding) != 0 {
 		t.Fatalf("outstanding = %v, want none without an approved plan", outstanding)
 	}

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -35,11 +35,11 @@ const forkBundleVersion = 1
 // does the session hold the eligible round's tool results. Arming refuses
 // under live enforcement: a treated state must never become a bundle.
 func (a *Agent) armForkCapture(sample evidence.OutcomeSample) {
-	if forkCapturePolicy() != "ebm" || ebmEnabled || a.ebm.captured || a.ebm.captureArmed {
+	if forkCapturePolicy() != "ebm" || ebmEnabled || a.task.ebm.captured || a.task.ebm.captureArmed {
 		return
 	}
-	a.ebm.captureArmed = true
-	a.ebm.captureRound = sample.Round
+	a.task.ebm.captureArmed = true
+	a.task.ebm.captureRound = sample.Round
 }
 
 // govReasoningThreshold marks a round's thinking as expensive enough that a
@@ -51,14 +51,14 @@ const govReasoningThreshold = 1500
 // so experiments fork exactly the states enforcement would treat. Refuses
 // under live enforcement: a treated state must never become a bundle.
 func (a *Agent) armGovernorCapture(sample evidence.OutcomeSample) {
-	if forkCapturePolicy() != "governor" || governorEnabled || a.ebm.captured || a.ebm.captureArmed {
+	if forkCapturePolicy() != "governor" || governorEnabled || a.task.ebm.captured || a.task.ebm.captureArmed {
 		return
 	}
 	if !governorTrigger(sample, a.lastReasoning) {
 		return
 	}
-	a.ebm.captureArmed = true
-	a.ebm.captureRound = sample.Round
+	a.task.ebm.captureArmed = true
+	a.task.ebm.captureRound = sample.Round
 }
 
 // forkCapturePolicy selects which policy's trigger owns bundle capture;
@@ -92,14 +92,14 @@ func (p *forkCaptureProvider) SharedWindowInputPolicy() provider.SharedWindowInp
 
 func (p *forkCaptureProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	a := p.a
-	if a.ebm.captureArmed && !a.ebm.captured {
-		a.ebm.captured = true
+	if a.task.ebm.captureArmed && !a.task.ebm.captured {
+		a.task.ebm.captured = true
 		messages := a.session.Snapshot()
-		seed := a.outcome.ForkSeed()
+		seed := a.task.outcome.ForkSeed()
 		b := ForkBundle{
 			Version: forkBundleVersion, Policy: forkCapturePolicy(),
 			Input:         forkTurnInput(messages),
-			EligibleRound: a.ebm.captureRound, BlindAtFork: seed.BlindMutations,
+			EligibleRound: a.task.ebm.captureRound, BlindAtFork: seed.BlindMutations,
 			DebtAtFork: seed.DebtAge, MutatedBases: seed.MutatedBases,
 			LocalExecSeen: seed.LocalExecSeen, Messages: messages,
 		}
@@ -215,11 +215,11 @@ func (a *Agent) armForkContinuation(b *ForkBundle, nudge string) {
 			applyForkTreatment(messages, nudge)
 		}
 		a.session.Replace(messages)
-		a.outcome = evidence.RestoreOutcomeTracker(evidence.OutcomeSeed{
+		a.task.outcome = evidence.RestoreOutcomeTracker(evidence.OutcomeSeed{
 			MutatedBases: b.MutatedBases, DebtAge: b.DebtAtFork,
 			BlindMutations: b.BlindAtFork, LocalExecSeen: b.LocalExecSeen,
 		})
-		a.ebm = ebmState{fired: true, captured: true, captureRound: b.EligibleRound}
+		a.task.ebm = ebmState{fired: true, captured: true, captureRound: b.EligibleRound}
 	}
 }
 

--- a/internal/agent/goal_run_boundary.go
+++ b/internal/agent/goal_run_boundary.go
@@ -28,32 +28,15 @@ func isToolLoopPause(err error) bool {
 
 // HostProgressSignatures exposes successful evidence identities to the Goal FSM.
 func (a *Agent) HostProgressSignatures() []string {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return nil
 	}
-	return a.evidence.SuccessfulProgressSignaturesSince(0)
+	return a.task.ledger.SuccessfulProgressSignaturesSince(0)
 }
 
 func (a *Agent) resetStructuralRunGuards() {
 	a.stormSig, a.stormCount, a.blockedTurnStreak = "", 0, 0
 	a.progress.reset()
-}
-
-func (a *Agent) prepareRepeatFailureScope(scoped bool, scopeID string) {
-	if !scoped || a.repeatFailureScope != scopeID {
-		a.repeatFailureCounts = nil
-	} else {
-		for sig, failure := range a.repeatFailureCounts {
-			if !failure.stateRecheck {
-				delete(a.repeatFailureCounts, sig)
-			}
-		}
-	}
-	if scoped {
-		a.repeatFailureScope = scopeID
-	} else {
-		a.repeatFailureScope = ""
-	}
 }
 
 func (a *Agent) stopUnexecutedBoundaryCalls(state *runLoopState, calls []provider.ToolCall, usage *provider.Usage) (error, bool) {
@@ -84,8 +67,8 @@ func (a *Agent) trackTodoProgress(ctx context.Context, state *runLoopState, rece
 	}
 	nextProgress, nextTracking := a.canonicalTodoProgress()
 	hostProgress := false
-	if a.evidence != nil {
-		for _, sig := range a.evidence.SuccessfulProgressSignaturesSince(receiptMark) {
+	if a.task.ledger != nil {
+		for _, sig := range a.task.ledger.SuccessfulProgressSignaturesSince(receiptMark) {
 			if _, seen := state.seenTodoProgress[sig]; !seen {
 				hostProgress = true
 				state.seenTodoProgress[sig] = struct{}{}

--- a/internal/agent/governor.go
+++ b/internal/agent/governor.go
@@ -48,24 +48,24 @@ func (a *Agent) applyGovernor(sample *evidence.OutcomeSample) {
 		return
 	}
 	switch {
-	case a.governor.engaged && governorExit(*sample):
-		a.governor.engaged = false
-	case !a.governor.engaged && sample.GovernorEligible:
-		a.governor.engaged = true
-		if !a.governor.noticed {
-			a.governor.noticed = true
+	case a.task.governor.engaged && governorExit(*sample):
+		a.task.governor.engaged = false
+	case !a.task.governor.engaged && sample.GovernorEligible:
+		a.task.governor.engaged = true
+		if !a.task.governor.noticed {
+			a.task.governor.noticed = true
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeReasoningGovernor,
 				Text:   "Exploration phase with expensive thinking; riding reduced reasoning depth until evidence work starts.",
 				Detail: "reasoning governor engaged: no verification debt, no local execution, previous round over the reasoning threshold"})
 		}
 	}
-	sample.GovernorEngaged = a.governor.engaged
+	sample.GovernorEngaged = a.task.governor.engaged
 }
 
 // governorOverride is the request-scoped effort the engaged governor asks
 // for; empty when disengaged so the configured depth stands.
 func (a *Agent) governorOverride() string {
-	if governorEnabled && a.governor.engaged {
+	if governorEnabled && a.task.governor.engaged {
 		return governorEffort
 	}
 	return ""

--- a/internal/agent/governor_test.go
+++ b/internal/agent/governor_test.go
@@ -66,8 +66,8 @@ func TestApplyGovernorEngagesAndExitsWhenEnabled(t *testing.T) {
 	}
 
 	a.resetTurnEvidence()
-	if a.governor.engaged || a.governor.noticed {
-		t.Fatalf("governor = %+v, want reset with the turn", a.governor)
+	if a.task.governor.engaged || a.task.governor.noticed {
+		t.Fatalf("governor = %+v, want reset with the turn", a.task.governor)
 	}
 }
 

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -559,7 +559,7 @@ func TestExecuteOneFailedReceiptDoesNotVerify(t *testing.T) {
 	if out.errMsg == "" {
 		t.Fatal("failing fake tool should return an error outcome")
 	}
-	if a.evidence.HasSuccessfulCommand("go test ./...") {
+	if a.task.ledger.HasSuccessfulCommand("go test ./...") {
 		t.Fatal("failed bash receipt must not verify")
 	}
 }
@@ -571,14 +571,14 @@ func TestRunResetsEvidenceLedger(t *testing.T) {
 	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
 
 	a.executeOne(context.Background(), provider.ToolCall{Name: "bash", Arguments: `{"command":"go test ./..."}`})
-	if !a.evidence.HasSuccessfulCommand("go test ./...") {
+	if !a.task.ledger.HasSuccessfulCommand("go test ./...") {
 		t.Fatal("setup failed to record evidence")
 	}
 
 	if err := a.Run(context.Background(), "next turn"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if a.evidence.HasSuccessfulCommand("go test ./...") {
+	if a.task.ledger.HasSuccessfulCommand("go test ./...") {
 		t.Fatal("new user turn should not inherit previous receipts")
 	}
 }

--- a/internal/agent/live_contract_test.go
+++ b/internal/agent/live_contract_test.go
@@ -43,7 +43,7 @@ func TestLiveContractReflectsEvidenceAsItLands(t *testing.T) {
 		}
 	}
 
-	a.evidence.Record(evidence.Receipt{
+	a.task.ledger.Record(evidence.Receipt{
 		ToolName: "bash", Command: "go test ./internal/provider/", Success: true,
 	})
 	after := a.LiveContract()
@@ -62,11 +62,11 @@ func TestLiveContractReflectsEvidenceAsItLands(t *testing.T) {
 // never disagree about the same receipts.
 func TestLiveContractMatchesTheEndOfTurnReplay(t *testing.T) {
 	a := liveContractAgent(t, event.Discard)
-	a.evidence.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"internal/provider/cache.go"}})
-	a.evidence.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "edit_file", Mutation: true, Write: true, Success: true, Paths: []string{"internal/provider/cache.go"}})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
 
 	live := contractShadowAudit(a.LiveContract())
-	replay := contractShadowAudit(buildShadowContract(a.turnInput, a.evidence.Receipts(), a.planContractSnapshot()))
+	replay := contractShadowAudit(buildShadowContract(a.turnInput, a.task.ledger.Receipts(), a.planContractSnapshot()))
 	if live != replay {
 		t.Fatalf("live view %+v disagrees with the end-of-turn replay %+v", live, replay)
 	}
@@ -77,7 +77,7 @@ func TestContractRoundObservationRecordsATimeSeries(t *testing.T) {
 	a := liveContractAgent(t, sink)
 
 	a.observeContractRound()
-	a.evidence.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
+	a.task.ledger.Record(evidence.Receipt{ToolName: "bash", Command: "go test ./internal/provider/", Success: true})
 	a.observeContractRound()
 
 	if len(sink.audits) != 2 {
@@ -103,7 +103,7 @@ func TestContractRoundObservationSkipsAnEmptyContract(t *testing.T) {
 
 func TestLiveContractIsNilWithoutALedger(t *testing.T) {
 	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
-	a.evidence = nil
+	a.task.ledger = nil
 	if a.LiveContract() != nil {
 		t.Fatal("no ledger means no contract to answer with")
 	}

--- a/internal/agent/plan_transition_diff.go
+++ b/internal/agent/plan_transition_diff.go
@@ -51,7 +51,7 @@ func (a *Agent) recoveryProposal(plan *toolCallPlan, episodeID, subject, preview
 	return RecoveryProposal{
 		AgentID:        a.recovery.agentID,
 		TaskID:         a.recovery.taskID,
-		TaskScopeID:    recoveryTaskScopeID(a.deliveryScopeID, a.recovery.runSeq.Load()),
+		TaskScopeID:    recoveryTaskScopeID(a.task.scopeID, a.recovery.runSeq.Load()),
 		EpisodeID:      episodeID,
 		TaskSummary:    a.recoveryTaskSummary,
 		Tool:           plan.evidenceName,

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -69,26 +69,22 @@ func (a *Agent) applyBatchGuards(ctx context.Context, cancelled bool, calls []pr
 // task budget resets with them: a fresh ledger is what "a new task" means here,
 // and a continuation keeps both.
 func (a *Agent) resetTurnEvidence() {
-	a.evidence.Reset()
+	a.task.restartLedger()
 	a.progress.reset()
 	a.stormSig, a.stormCount, a.blockedTurnStreak = "", 0, 0
-	a.outcome = evidence.NewOutcomeTracker()
-	a.ebm = ebmState{}
-	a.governor = governorState{}
-	a.taskBudget = runBudget{limit: a.taskBudget.limit}
 }
 
 // observeOutcomeShadow scores the round's receipts through the shadow outcome
 // tracker, lets the EBM policy stamp (and under its arm, act on) the sample,
 // then records it. Unlike the guards it observes every round.
 func (a *Agent) observeOutcomeShadow(receiptMark int, outcomes []toolOutcome) intervention {
-	if a.evidence == nil {
+	if a.task.ledger == nil {
 		return intervention{}
 	}
-	if a.outcome == nil {
-		a.outcome = evidence.NewOutcomeTracker()
+	if a.task.outcome == nil {
+		a.task.outcome = evidence.NewOutcomeTracker()
 	}
-	sample := a.outcome.ScoreRound(a.evidence.ReceiptsSince(receiptMark))
+	sample := a.task.outcome.ScoreRound(a.task.ledger.ReceiptsSince(receiptMark))
 	iv := a.applyEBM(&sample, outcomes)
 	a.applyGovernor(&sample)
 	a.armGovernorCapture(sample)
@@ -102,10 +98,10 @@ func (a *Agent) observeOutcomeShadow(receiptMark int, outcomes []toolOutcome) in
 // readiness stands down and the model can deliver its answer instead of being
 // sent back for more receipts.
 func (a *Agent) applyProgressGuard(outcomes []toolOutcome, receiptMark int, goalScoped bool) intervention {
-	if a.evidence == nil || len(outcomes) == 0 {
+	if a.task.ledger == nil || len(outcomes) == 0 {
 		return intervention{}
 	}
-	receipts := a.evidence.ReceiptsSince(receiptMark)
+	receipts := a.task.ledger.ReceiptsSince(receiptMark)
 	// Rounds where nothing succeeded are the storm breaker's jurisdiction
 	// (same-failure fixation); this guard owns the storm-blind case — rounds
 	// that keep SUCCEEDING without producing anything new.
@@ -192,8 +188,8 @@ func (a *Agent) loopGuardAllowsFinal() bool {
 	if a == nil || !a.loopGuardArmed {
 		return false
 	}
-	if a.evidence == nil {
+	if a.task.ledger == nil {
 		return true
 	}
-	return !a.evidence.HasWriteOrCommandSince(a.loopGuardReceiptMark)
+	return !a.task.ledger.HasWriteOrCommandSince(a.loopGuardReceiptMark)
 }

--- a/internal/agent/progress_guard_test.go
+++ b/internal/agent/progress_guard_test.go
@@ -119,9 +119,9 @@ func TestProgressGuardResetsOnNewEvidence(t *testing.T) {
 		t.Fatalf("streak = %d, want >= %d before fresh evidence", a.progress.streak, progressNudgeStreak)
 	}
 	// A successful bash command receipt is fresh evidence: streak resets.
-	a.evidence.Record(bashProgressReceipt(t, "go test ./pkg", true))
-	mark := a.evidence.Len() - 1
-	a.progress.observe(a.evidence.ReceiptsSince(mark))
+	a.task.ledger.Record(bashProgressReceipt(t, "go test ./pkg", true))
+	mark := a.task.ledger.Len() - 1
+	a.progress.observe(a.task.ledger.ReceiptsSince(mark))
 	if a.progress.streak != 0 {
 		t.Fatalf("fresh evidence must reset the streak, got %d", a.progress.streak)
 	}

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -221,7 +221,7 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 	guidance := a.recoveryGate.ObserveResult(ctx, RecoveryObservation{
 		AgentID:      a.recovery.agentID,
 		TaskID:       a.recovery.taskID,
-		TaskScopeID:  recoveryTaskScopeID(a.deliveryScopeID, a.recovery.runSeq.Load()),
+		TaskScopeID:  recoveryTaskScopeID(a.task.scopeID, a.recovery.runSeq.Load()),
 		EpisodeID:    episodeID,
 		Generation:   generation,
 		Tool:         toolName,

--- a/internal/agent/repeat_failure_guard.go
+++ b/internal/agent/repeat_failure_guard.go
@@ -19,10 +19,10 @@ const repeatFailureBreakThreshold = 2
 
 func (a *Agent) repeatedFailureBlock(ctx context.Context, call provider.ToolCall, t tool.Tool) (string, bool) {
 	sig, _, ok := a.repeatFailureSignature(call, t)
-	if !ok || a.repeatFailureCounts == nil {
+	if !ok || a.task.repeatFailures == nil {
 		return "", false
 	}
-	record, ok := a.repeatFailureCounts[sig]
+	record, ok := a.task.repeatFailures[sig]
 	if !ok || record.count < repeatFailureBreakThreshold {
 		return "", false
 	}
@@ -30,7 +30,7 @@ func (a *Agent) repeatedFailureBlock(ctx context.Context, call provider.ToolCall
 		if previewer, ok := t.(tool.Previewer); ok {
 			_, err := previewer.Preview(ctx, json.RawMessage(call.Arguments))
 			if err == nil || repeatFailureErrorClass(call.Name, err) != record.errClass {
-				delete(a.repeatFailureCounts, sig)
+				delete(a.task.repeatFailures, sig)
 				return "", false
 			}
 		}
@@ -50,11 +50,11 @@ func (a *Agent) recordRepeatFailure(call provider.ToolCall, t tool.Tool, execErr
 	if !ok {
 		return
 	}
-	if a.repeatFailureCounts == nil {
-		a.repeatFailureCounts = make(map[string]repeatFailureRecord)
+	if a.task.repeatFailures == nil {
+		a.task.repeatFailures = make(map[string]repeatFailureRecord)
 	}
 	errClass := repeatFailureErrorClass(call.Name, execErr)
-	record := a.repeatFailureCounts[sig]
+	record := a.task.repeatFailures[sig]
 	if record.errClass != errClass {
 		record = repeatFailureRecord{
 			errClass:     errClass,
@@ -63,7 +63,7 @@ func (a *Agent) recordRepeatFailure(call provider.ToolCall, t tool.Tool, execErr
 		}
 	}
 	record.count++
-	a.repeatFailureCounts[sig] = record
+	a.task.repeatFailures[sig] = record
 }
 
 func (a *Agent) repeatFailureSignature(call provider.ToolCall, t tool.Tool) (string, []string, bool) {
@@ -147,26 +147,26 @@ func repeatFailurePreviewRechecksState(name, errClass string) bool {
 }
 
 func (a *Agent) clearRepeatFailuresAfterMutation(toolName string, args json.RawMessage, readOnly bool) {
-	if len(a.repeatFailureCounts) == 0 {
+	if len(a.task.repeatFailures) == 0 {
 		return
 	}
 	rec := evidence.ReceiptFromToolCall(toolName, args, true, readOnly)
 	mutatedPaths := a.normalizeRepeatFailurePaths(rec.Paths)
 	if len(mutatedPaths) == 0 {
-		for sig, failure := range a.repeatFailureCounts {
+		for sig, failure := range a.task.repeatFailures {
 			// Anchor errors have an exact, side-effect-free state check. Keep
 			// their history until Preview shows that the old anchor works again.
 			if !failure.stateRecheck {
-				delete(a.repeatFailureCounts, sig)
+				delete(a.task.repeatFailures, sig)
 			}
 		}
 		return
 	}
-	for sig, failure := range a.repeatFailureCounts {
+	for sig, failure := range a.task.repeatFailures {
 		// A different edit to the same file does not make this old anchor valid.
 		// repeatedFailureBlock rechecks the actual call through Preview.
 		if !failure.stateRecheck && repeatFailurePathsOverlap(failure.paths, mutatedPaths) {
-			delete(a.repeatFailureCounts, sig)
+			delete(a.task.repeatFailures, sig)
 		}
 	}
 }

--- a/internal/agent/review_report.go
+++ b/internal/agent/review_report.go
@@ -107,8 +107,8 @@ func AttachReviewReportTool(reg *tool.Registry) {
 // HasSuccessfulReviewReport reports whether this agent's evidence ledger holds
 // a successful review_report of the given kind.
 func (a *Agent) HasSuccessfulReviewReport(kind evidence.ReviewKind) bool {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return false
 	}
-	return a.evidence.HasSuccessfulReviewReportOfKind(kind)
+	return a.task.ledger.HasSuccessfulReviewReportOfKind(kind)
 }

--- a/internal/agent/run_budget.go
+++ b/internal/agent/run_budget.go
@@ -120,14 +120,14 @@ func (a *Agent) taskBudgetLimit(ctx context.Context) TaskBudget {
 	if b, ok := taskBudgetFromContext(ctx); ok {
 		return b
 	}
-	return a.taskBudget.limit
+	return a.task.budget.limit
 }
 
 // ResetTaskBudget starts a fresh user-approved spend slice without touching
 // Delivery evidence or the persisted Goal usage totals. Callers use this only
 // after a resumable explicit-budget pause, while no Agent Run is active.
 func (a *Agent) ResetTaskBudget() {
-	a.taskBudget = runBudget{limit: a.taskBudget.limit}
+	a.task.budget = runBudget{limit: a.task.budget.limit}
 }
 
 // observeRunBudget folds a round into both scopes and reports them.
@@ -136,17 +136,17 @@ func (a *Agent) observeRunBudget(state *runLoopState, usage *provider.Usage) {
 		return
 	}
 	state.budget.observe(usage, a.pricing)
-	if a.taskBudget.started.IsZero() {
-		a.taskBudget.started = state.budget.started
+	if a.task.budget.started.IsZero() {
+		a.task.budget.started = state.budget.started
 	}
-	a.taskBudget.observe(usage, a.pricing)
+	a.task.budget.observe(usage, a.pricing)
 	currency := ""
 	if a.pricing != nil {
 		currency = a.pricing.Symbol()
 	}
 	event.RecordRunBudget(a.sink, event.RunBudgetSample{
 		Turn:     state.budget.totals(),
-		Task:     a.taskBudget.totals(),
+		Task:     a.task.budget.totals(),
 		Currency: currency,
 	})
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -123,12 +123,12 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// evidence-preserving continuation) and then passes readiness counts as a
 	// recovery in the final audit.
 	a.readinessRecovered = preserveEvidence || a.deliveryRecoveryPending
-	if a.evidence != nil {
+	if a.task.ledger != nil {
 		switch {
 		case preserveEvidence:
-			a.evidence.ResetBackgroundLeases()
-		case scoped && a.deliveryScopeID == scope.ID:
-			a.evidence.ResetBackgroundLeases()
+			a.task.ledger.ResetBackgroundLeases()
+		case scoped && a.task.scopeID == scope.ID:
+			a.task.ledger.ResetBackgroundLeases()
 		default:
 			a.resetTurnEvidence()
 		}
@@ -138,13 +138,13 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 		a.deliveryRecoveryPending = false
 	}
 	if scoped {
-		a.deliveryScopeID = scope.ID
+		a.task.scopeID = scope.ID
 	} else if !preserveEvidence {
-		a.deliveryScopeID = ""
+		a.task.scopeID = ""
 	}
 	a.deliveryScopeActive = scoped
-	if scoped && a.deliveryCheckpoint.ScopeID != scope.ID {
-		a.deliveryCheckpoint = evidence.DeliveryCheckpoint{ScopeID: scope.ID}
+	if scoped && a.task.checkpoint.ScopeID != scope.ID {
+		a.task.checkpoint = evidence.DeliveryCheckpoint{ScopeID: scope.ID}
 	}
 	// Re-lease this session's background-job mutations that no turn has
 	// committed yet. The Reset above just wiped any lease a failed or
@@ -156,22 +156,22 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// change without the final-readiness gate ever seeing it. Plan turns defer
 	// this lease like collectBackgroundEvidence does so execution evidence is
 	// consumed and audited only after plan approval.
-	if a.evidence != nil && a.jobs != nil && !a.planMode.Load() {
+	if a.task.ledger != nil && a.jobs != nil && !a.planMode.Load() {
 		session := jobs.SessionFromContext(ctx)
 		for _, jobID := range a.jobs.PendingEvidenceJobIDsForSession(session) {
 			summary, ready := a.jobs.TryLeaseEvidenceForSession(session, jobID)
 			if !ready {
 				continue
 			}
-			if !a.evidence.NoteBackgroundLease(session, jobID) {
+			if !a.task.ledger.NoteBackgroundLease(session, jobID) {
 				continue
 			}
-			a.evidence.MergeChild(summary)
+			a.task.ledger.MergeChild(summary)
 		}
 	}
 	a.deliveryCriteriaEstablished = a.hasIncompleteCanonicalCriteria() ||
-		(a.evidence != nil && a.evidence.HasSuccessfulTodoWrite()) ||
-		(scoped && a.deliveryCheckpoint.CriteriaEstablished)
+		(a.task.ledger != nil && a.task.ledger.HasSuccessfulTodoWrite()) ||
+		(scoped && a.task.checkpoint.CriteriaEstablished)
 	// Classify delivery expectations from the task text. Sub-agent spawners
 	// pass the pristine task through Options.ClassifierTaskText (a trusted
 	// host channel) because their Run input carries host framing whose
@@ -220,7 +220,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// transcript tail. Fold its bounded facts into this new user turn exactly
 	// once; the user's raw text remains the classifier source above.
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
-	a.prepareRepeatFailureScope(scoped, scope.ID)
+	a.task.prepareScope(scoped, scope.ID)
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
 	a.emitTurnPhase(event.TurnPhaseWorking)
 	input = a.withTurnPreferences(providerInput)
@@ -254,8 +254,8 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 		budget:             runBudget{started: time.Now()},
 	}
 	state.todoProgress, state.trackingTodoProgress = a.canonicalTodoProgress()
-	if a.evidence != nil {
-		for _, sig := range a.evidence.SuccessfulProgressSignaturesSince(0) {
+	if a.task.ledger != nil {
+		for _, sig := range a.task.ledger.SuccessfulProgressSignaturesSince(0) {
 			state.seenTodoProgress[sig] = struct{}{}
 		}
 	}
@@ -631,8 +631,8 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 	}
 
 	receiptMark := 0
-	if a.evidence != nil {
-		receiptMark = a.evidence.Len()
+	if a.task.ledger != nil {
+		receiptMark = a.task.ledger.Len()
 	}
 	batch := a.executeBatch(ctx, calls)
 	results, images := batch.results, batch.images
@@ -691,7 +691,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 
 	// Spend is checked before rounds: it is the axis a runaway is actually
 	// reported in, so on the turns both would catch it should be the one named.
-	if axis, detail := a.taskBudget.exceeded(a.taskBudgetLimit(ctx)); axis != "" {
+	if axis, detail := a.task.budget.exceeded(a.taskBudgetLimit(ctx)); axis != "" {
 		a.armFinalizationRound(state, landCause{kind: "task_budget", axis: axis, detail: detail})
 		return true, nil
 	}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -2011,10 +2011,10 @@ func mergeChildEvidence(ctx context.Context, sub *Agent) {
 
 // EvidenceSummary exports this agent's turn-scoped receipts for parent merge.
 func (a *Agent) EvidenceSummary() evidence.ChildEvidenceSummary {
-	if a == nil || a.evidence == nil {
+	if a == nil || a.task.ledger == nil {
 		return evidence.ChildEvidenceSummary{}
 	}
-	return a.evidence.Summary()
+	return a.task.ledger.Summary()
 }
 
 func isFreshSubagentSession(sess *Session) bool {

--- a/internal/agent/taskpolicy_execution_test.go
+++ b/internal/agent/taskpolicy_execution_test.go
@@ -95,7 +95,7 @@ func TestTaskPolicyRequiresPostMutationVerification(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Mutation: true}
 	check := evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."}
 	a := &Agent{
-		evidence:      readinessLedger(check, writer),
+		task:          taskRuntime{ledger: readinessLedger(check, writer)},
 		tools:         reg,
 		turnPolicy:    taskpolicy.TaskPolicy{Verification: taskpolicy.VerifyTargeted},
 		turnPolicySet: true,
@@ -103,7 +103,7 @@ func TestTaskPolicyRequiresPostMutationVerification(t *testing.T) {
 	if got := a.finalReadinessCheckFor(); !strings.Contains(got.reason, "verification command") {
 		t.Fatalf("readiness = %+v, want post-mutation verification", got)
 	}
-	a.evidence.Record(check)
+	a.task.ledger.Record(check)
 	if got := a.finalReadinessCheckFor(); got.reason != "" {
 		t.Fatalf("readiness after verification = %+v, want ready", got)
 	}

--- a/internal/agent/taskstate.go
+++ b/internal/agent/taskstate.go
@@ -1,0 +1,59 @@
+package agent
+
+import "reasonix/internal/evidence"
+
+// taskRuntime is the host state shared by every Agent.Run continuing one
+// delivery scope: one ledger, one bill, one set of failure budgets. Its
+// lifetime sits between the session and the turn — SetSession replaces it
+// wholesale, beginRunTurn restarts it when the scope changes, and state valid
+// for exactly one Run lives in perTurnState instead.
+type taskRuntime struct {
+	scopeID    string
+	checkpoint evidence.DeliveryCheckpoint
+	ledger     *evidence.Ledger
+	outcome    *evidence.OutcomeTracker
+	budget     runBudget
+	ebm        ebmState
+	governor   governorState
+	// repeatFailures outlives a Run: re-reading a file and resending the same
+	// stale anchor is still zero progress, so prepareScope — not the ledger
+	// restart — decides what survives a scope-stable continuation.
+	repeatFailures map[string]repeatFailureRecord
+	repeatScope    string
+}
+
+// restartLedger begins a new task's accounting. It is written as one assignment
+// so a field added to taskRuntime resets by default; the four fields carried
+// forward are named because each answers to its own condition in beginRunTurn.
+func (t *taskRuntime) restartLedger() {
+	*t = taskRuntime{
+		scopeID:        t.scopeID,
+		checkpoint:     t.checkpoint,
+		repeatFailures: t.repeatFailures,
+		repeatScope:    t.repeatScope,
+		ledger:         t.ledger,
+		outcome:        evidence.NewOutcomeTracker(),
+		budget:         runBudget{limit: t.budget.limit},
+	}
+	t.ledger.Reset()
+}
+
+// prepareScope reconciles the repeat-failure records against the scope this Run
+// belongs to. A scope-stable continuation keeps only the records whose anchor
+// still needs re-checking; anything else starts from empty.
+func (t *taskRuntime) prepareScope(scoped bool, scopeID string) {
+	if !scoped || t.repeatScope != scopeID {
+		t.repeatFailures = nil
+	} else {
+		for sig, failure := range t.repeatFailures {
+			if !failure.stateRecheck {
+				delete(t.repeatFailures, sig)
+			}
+		}
+	}
+	if scoped {
+		t.repeatScope = scopeID
+	} else {
+		t.repeatScope = ""
+	}
+}

--- a/internal/agent/taskstate_test.go
+++ b/internal/agent/taskstate_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+// taskCarryOver names the fields restartLedger hands to the next task in the
+// same session. Everything else must come back zeroed, which is what makes
+// "one ledger, one task, one bill" a property of the type rather than of the
+// call sites that used to clear these fields one by one.
+var taskCarryOver = map[string]bool{
+	"scopeID":        true,
+	"checkpoint":     true,
+	"repeatFailures": true,
+	"repeatScope":    true,
+	"ledger":         true, // identity, not contents: executeOne hands the pointer to every tool context
+}
+
+func TestTaskRuntimeRestartCarriesScopeAndResetsAccounting(t *testing.T) {
+	ledger := evidence.NewLedger()
+	before := &taskRuntime{
+		scopeID:        "scope-1",
+		checkpoint:     evidence.DeliveryCheckpoint{ScopeID: "scope-1"},
+		ledger:         ledger,
+		outcome:        evidence.NewOutcomeTracker(),
+		budget:         runBudget{rounds: 4, requests: 9, cost: 1.5, limit: TaskBudget{}},
+		ebm:            ebmState{fired: true, captured: true},
+		governor:       governorState{engaged: true, noticed: true},
+		repeatFailures: map[string]repeatFailureRecord{"sig": {count: 2}},
+		repeatScope:    "scope-1",
+	}
+	after := *before
+	after.restartLedger()
+
+	if after.scopeID != "scope-1" || after.checkpoint.ScopeID != "scope-1" {
+		t.Errorf("scope = %q/%q, want it carried: beginRunTurn owns the scope transition", after.scopeID, after.checkpoint.ScopeID)
+	}
+	if after.repeatScope != "scope-1" || len(after.repeatFailures) != 1 {
+		t.Errorf("repeat failures = %q/%d, want them carried: prepareScope decides what survives", after.repeatScope, len(after.repeatFailures))
+	}
+	if after.ledger != ledger {
+		t.Error("ledger pointer replaced; tool contexts hold it for the length of a call")
+	}
+	if after.budget.rounds != 0 || after.budget.requests != 0 || after.budget.cost != 0 {
+		t.Errorf("budget = %+v, want a fresh bill for the new task", after.budget)
+	}
+	if after.ebm != (ebmState{}) || after.governor != (governorState{}) {
+		t.Errorf("ebm/governor = %+v/%+v, want both reset with the ledger", after.ebm, after.governor)
+	}
+	if after.outcome == nil || after.outcome == before.outcome {
+		t.Error("outcome tracker not replaced; the shadow scorer must not span tasks")
+	}
+}
+
+// taskRestarted names the fields the test above asserts a new task starts
+// from. Together with taskCarryOver it must cover taskRuntime exactly, so a
+// field added to the type fails here until someone states which side it is on.
+var taskRestarted = map[string]bool{
+	"outcome":  true,
+	"budget":   true,
+	"ebm":      true,
+	"governor": true,
+}
+
+// restartLedger is one assignment, so an unlisted field resets by default —
+// the safe direction. The risk is the other one: a field that quietly ends up
+// carried, or reset with nothing asserting it. Both lists are therefore
+// checked against the struct rather than trusted.
+func TestTaskRuntimeLifetimeListsCoverTheStruct(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "taskstate.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse taskstate.go: %v", err)
+	}
+	fields := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || spec.Name.Name != "taskRuntime" {
+			return true
+		}
+		st, ok := spec.Type.(*ast.StructType)
+		if !ok {
+			return false
+		}
+		for _, field := range st.Fields.List {
+			for _, name := range field.Names {
+				fields[name.Name] = true
+			}
+		}
+		return false
+	})
+	if len(fields) == 0 {
+		t.Fatal("taskRuntime has no fields; the guard would pass vacuously")
+	}
+	for _, list := range []map[string]bool{taskCarryOver, taskRestarted} {
+		for name := range list {
+			if !fields[name] {
+				t.Errorf("the lifetime lists name %q, which taskRuntime no longer has", name)
+			}
+		}
+	}
+	for name := range fields {
+		switch {
+		case taskCarryOver[name] && taskRestarted[name]:
+			t.Errorf("taskRuntime.%s is listed as both carried and restarted", name)
+		case !taskCarryOver[name] && !taskRestarted[name]:
+			t.Errorf("taskRuntime.%s is on neither list; decide whether a new task keeps it and assert that above", name)
+		}
+	}
+}
+
+func TestTaskRuntimePrepareScopeKeepsOnlyRecheckableFailures(t *testing.T) {
+	records := func() map[string]repeatFailureRecord {
+		return map[string]repeatFailureRecord{
+			"stale":  {count: 2, stateRecheck: true},
+			"solved": {count: 1},
+		}
+	}
+	cases := []struct {
+		name    string
+		scoped  bool
+		scopeID string
+		want    []string
+	}{
+		{"same scope keeps the anchors still worth re-checking", true, "scope-1", []string{"stale"}},
+		{"a new scope is a new task", true, "scope-2", nil},
+		{"an unscoped run keeps nothing", false, "", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := taskRuntime{repeatFailures: records(), repeatScope: "scope-1"}
+			task.prepareScope(tc.scoped, tc.scopeID)
+			if len(task.repeatFailures) != len(tc.want) {
+				t.Fatalf("repeatFailures = %v, want %v", task.repeatFailures, tc.want)
+			}
+			for _, sig := range tc.want {
+				if _, ok := task.repeatFailures[sig]; !ok {
+					t.Errorf("repeatFailures lost %q", sig)
+				}
+			}
+			if tc.scoped && task.repeatScope != tc.scopeID {
+				t.Errorf("repeatScope = %q, want %q", task.repeatScope, tc.scopeID)
+			}
+			if !tc.scoped && task.repeatScope != "" {
+				t.Errorf("repeatScope = %q, want it cleared", task.repeatScope)
+			}
+		})
+	}
+}

--- a/internal/agent/todo_state.go
+++ b/internal/agent/todo_state.go
@@ -55,14 +55,14 @@ func (a *Agent) hasIncompleteCanonicalCriteria() bool {
 // completion. It bypasses the todo_write tool, so the completion-transition
 // guard never runs on it.
 func (a *Agent) recordTodoState(todos []evidence.TodoItem) {
-	if a.evidence == nil {
+	if a.task.ledger == nil {
 		return
 	}
 	args, err := json.Marshal(map[string]any{"todos": todos})
 	if err != nil {
 		return
 	}
-	a.evidence.Record(evidence.ReceiptFromToolCall("todo_write", json.RawMessage(args), true, true))
+	a.task.ledger.Record(evidence.ReceiptFromToolCall("todo_write", json.RawMessage(args), true, true))
 }
 
 func canonicalTodoStatus(s string) string {

--- a/internal/agent/tool_receipts.go
+++ b/internal/agent/tool_receipts.go
@@ -11,7 +11,7 @@ import (
 // always the model-visible call for audit, plus the real target's attributes
 // for mutation/read classification when a proxy resolved elsewhere.
 func (a *Agent) recordToolReceipts(plan *toolCallPlan, result string, execution *tool.ShellExecution, err error) {
-	if a.evidence == nil {
+	if a.task.ledger == nil {
 		return
 	}
 	call := plan.call
@@ -19,19 +19,19 @@ func (a *Agent) recordToolReceipts(plan *toolCallPlan, result string, execution 
 	switch {
 	case call.Name == "complete_step":
 		rec := evidence.ReceiptFromToolCall(call.Name, args, err == nil, plan.readOnly)
-		a.evidence.Record(rec)
+		a.task.ledger.Record(rec)
 		if err == nil {
 			a.advanceCanonicalTodo(rec.Step)
 		}
 	case plan.evidenceName != call.Name:
-		a.evidence.Record(evidence.ReceiptFromToolCall(call.Name, args, err == nil, true))
+		a.task.ledger.Record(evidence.ReceiptFromToolCall(call.Name, args, err == nil, true))
 		rec := evidence.ReceiptFromToolCall(plan.evidenceName, plan.evidenceArgs, err == nil, plan.readOnly)
 		decorateExecutionReceipt(&rec, result, execution)
-		a.evidence.Record(rec)
+		a.task.ledger.Record(rec)
 	default:
 		rec := evidence.ReceiptFromToolCall(call.Name, args, err == nil, plan.tool.ReadOnly())
 		decorateExecutionReceipt(&rec, result, execution)
-		a.evidence.Record(rec)
+		a.task.ledger.Record(rec)
 		if err == nil && call.Name == "todo_write" {
 			a.setTodoState(rec.Todos)
 			if len(rec.Todos) > 0 {

--- a/internal/agent/turn_phase.go
+++ b/internal/agent/turn_phase.go
@@ -22,8 +22,8 @@ func (a *Agent) emitCompletionSummary(c *taskcontract.Contract) {
 		return
 	}
 	mutations := 0
-	if a.evidence != nil {
-		for _, r := range a.evidence.Receipts() {
+	if a.task.ledger != nil {
+		for _, r := range a.task.ledger.Receipts() {
 			if r.Success && (r.Mutation || r.Write) {
 				mutations++
 			}
@@ -53,9 +53,9 @@ func (a *Agent) emitCompletionSummary(c *taskcontract.Contract) {
 		case taskpolicy.ReviewNone:
 			review = "none"
 		default:
-			if a.evidence != nil {
-				if mut, ok := a.evidence.LatestSuccessfulMutationIndex(); ok {
-					if a.evidence.HasSuccessfulReviewAfter(mut) {
+			if a.task.ledger != nil {
+				if mut, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
+					if a.task.ledger.HasSuccessfulReviewAfter(mut) {
 						review = "passed"
 					} else if a.turnPolicy.RequiresIndependentReview() {
 						review = "unavailable"

--- a/internal/agent/usecapability_test.go
+++ b/internal/agent/usecapability_test.go
@@ -933,7 +933,7 @@ func TestCapabilityGateRecoveryIsAudited(t *testing.T) {
 	a.SeedCapabilityRoute(capability.RouteDecision{Candidates: []capability.RouteCandidate{
 		{Entry: capability.Entry{ID: "skill:review"}, Policy: capability.AutoUseRequire},
 	}})
-	a.evidence.Record(evidence.ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"a.go"}`), true, true))
+	a.task.ledger.Record(evidence.ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"a.go"}`), true, true))
 	if check := a.finalReadinessCheckFor(); check.reason == "" {
 		t.Fatal("expected a require miss first")
 	}
@@ -1094,7 +1094,7 @@ func TestCapabilityGateAppliesToReadOnlyTasks(t *testing.T) {
 		{Entry: capability.Entry{ID: "skill:review"}, Policy: capability.AutoUseRequire},
 	}})
 	// Only ordinary reads happened — no writer. The require gate must still hold.
-	a.evidence.Record(evidence.ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"a.go"}`), true, true))
+	a.task.ledger.Record(evidence.ReceiptFromToolCall("read_file", json.RawMessage(`{"path":"a.go"}`), true, true))
 	check := a.finalReadinessCheckFor()
 	if !strings.Contains(check.reason, "required capabilities") {
 		t.Fatalf("read-only answer must not skip the require gate; reason = %q", check.reason)

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -3,13 +3,13 @@
     "banner": 15,
     "commented-code": 0,
     "complexity": 2086,
-    "essay": 4033,
-    "file-size": 108600,
+    "essay": 4028,
+    "file-size": 108575,
     "function-size": 8886,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 132,
+    "struct-state": 130,
     "test-file-size": 69238
   },
   "files": {
@@ -451,10 +451,10 @@
     },
     "internal/agent/agent.go": {
       "complexity": 37,
-      "essay": 81,
-      "file-size": 2276,
+      "essay": 76,
+      "file-size": 2251,
       "function-size": 102,
-      "struct-state": 20
+      "struct-state": 18
     },
     "internal/agent/ask.go": {
       "essay": 4


### PR DESCRIPTION
First stage of #8523. `Agent` holds four state lifetimes in one flat struct and
records the boundaries in prose — "reset every turn", "reset by SetSession",
"*not* reset on goal continuation". `agentConfig` and `perTurnState` already
typed two of them. This one types the third.

## The lifetime this extracts

Eight fields survive multiple `Agent.Run` calls but are narrower than a
session: they belong to one delivery scope. `resetTurnEvidence` is only reached
from `beginRunTurn` when the scope changes and no evidence preservation is
pending, which is what makes this a lifetime of its own rather than
session-scoped state. `taskBudget`'s own doc already said so — "accumulates
spend across every Run continuing one task".

They now live in `taskRuntime` (`internal/agent/taskstate.go`), reached as
`a.task.ledger`, `a.task.budget`, and so on.

## Behaviour is unchanged, deliberately

The three fields share a name but not a reset condition:

- ledger / outcome / budget / ebm / governor restart when the scope changes and
  nothing is preserving evidence
- the checkpoint restarts only when a *scoped* run finds a different scope ID
- repeat-failure records are pruned rather than dropped on a scope-stable
  continuation

Unifying those conditions would be a behaviour change and belongs in its own
PR, so `restartLedger` carries scope, checkpoint, and the failure records
forward exactly as the old code left them untouched. What it buys is that the
carry-over is now a named list in one assignment instead of an emergent
property of which fields each call site happened not to mention.

`prepareRepeatFailureScope` moves to `taskRuntime.prepareScope` verbatim.

## How the mechanical part was done

`gopls rename` for the nine fields, so `internal/control`'s own
`deliveryCheckpoint` and `taskBudget` — different types, same names — were left
alone by construction rather than by a careful regex. Then the now-unique names
were rewritten to the nested selector. 35 files, no call site changed meaning.

## Guard

`taskstate_test.go` asserts the carry/restart split directly and, in the style
of `agent_config_test.go`, checks both lifetime lists against the struct via
AST: a field added to `taskRuntime` fails the test until someone states which
side it is on. Reset-by-omission stays the safe default; the guard catches the
other direction.

## Ratchet

The repolint baseline goes down, not up: `struct-state` 20 → 18 for `agent.go`
(130 repo-wide), `essay` 81 → 76, `file-size` 2276 → 2251. No entry increases.
The larger `struct-state` repayment is stage 4, where the turn-scoped flags
move.

Part of #8523.

Cache-impact: none - host state only. No system prompt, tool schema, memory, or
provider request field is touched; the cacheable prefix is byte-identical
because nothing in this diff reaches `Compose` or the request builder.
Cache-guard: go test ./internal/agent/ -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction|TestSessionAggregateCacheRate'
System-prompt-review: yhh - the gate fires on `internal/agent/task.go`, whose
entire diff is one selector rename inside `EvidenceSummary` (`a.evidence` ->
`a.task.ledger`). No prompt string, tool schema, or system-prompt assembly is
reached; `internal/config/`, `internal/memory/`, `internal/outputstyle/`,
`internal/skill/`, and `internal/boot/` are untouched.
Documentation-impact: none - `docs/*.md` describes behaviour and configuration,
and this PR changes neither. The lifetimes it names are internal to
`internal/agent`, documented at their declarations and in #8523.
