### PR TITLE
fix: refresh recovery lineage after repair completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ branch.
   **v1.24.1** only hid/reclaimed already-created covered copies and fixed Windows
   flash-window startup; **v1.24.2** stops the misclassification source and repairs
   existing user directories without rewriting authoritative JSONL/WAL/sidecar data.
+  **v1.24.3** adds periodic lineage refresh after repair completes: the initial
+  scan marks all sessions as `turns_state='unknown'`, so `promoteCanonicalLeaves`
+  cannot determine the longest branch and all recovery sessions stay marked as
+  `diverged`. After background repair finishes, a 5-second ticker re-runs lineage
+  classification for directories with recently repaired recovery sessions, correctly
+  promoting canonical branches and hiding covered copies. Users on 1.24.3 who still
+  see duplicate sessions can run `/doctor sessions --reindex` once to trigger
+  immediate lineage refresh.
 
 - Goal now runs continuously by default: the former 16-round per-Run boundary,
   10/20/40 cross-Run quotas, default wall-clock budget, and numeric

--- a/desktop/session_catalog_recovery_test.go
+++ b/desktop/session_catalog_recovery_test.go
@@ -41,7 +41,7 @@ func TestProjectNodeFromCatalogTopicFiltersIdleRecoveryCopies(t *testing.T) {
 	sessionOverlays := map[string]catalogRuntimeOverlay{
 		sessionRuntimeKey("/s/open-copy.jsonl"): {open: true},
 	}
-	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, sessionOverlays)
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, sessionOverlays, nil)
 	if !ok {
 		t.Fatal("mixed topic should stay visible")
 	}
@@ -64,7 +64,7 @@ func TestProjectNodeFromCatalogTopicHidesRecoveryOnlyIdleTopic(t *testing.T) {
 			{Path: "/s/only.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
 		},
 	}
-	if _, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}); ok {
+	if _, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}, nil); ok {
 		t.Fatal("idle recovery-only topic must be hidden from the ordinary tree")
 	}
 }
@@ -77,7 +77,7 @@ func TestProjectNodeFromCatalogTopicKeepsPinnedRecoveryOnlyTopic(t *testing.T) {
 			{Path: "/s/pinned.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
 		},
 	}
-	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{})
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}, nil)
 	if !ok {
 		t.Fatal("pinned recovery-only topic must remain visible")
 	}
@@ -96,12 +96,51 @@ func TestProjectNodeFromCatalogTopicCollapsesWhenOnlyOneVisible(t *testing.T) {
 			{Path: "/s/copy.jsonl", Recovered: true, RecoveryCopy: true, Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK},
 		},
 	}
-	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{})
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}, nil)
 	if !ok {
 		t.Fatal("topic with parent should stay visible")
 	}
 	if len(node.Children) != 0 {
 		t.Fatalf("children = %d, want collapsed single effective session", len(node.Children))
+	}
+}
+
+func TestProjectNodeFromCatalogTopicCollapsesDivergedForksToOne(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "forks", Title: "WebView", Turns: 5,
+		Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/root.jsonl", Turns: 3, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK, LastActivityAt: 10},
+			{Path: "/s/fork-a.jsonl", Turns: 5, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+				Recovered: true, RecoveryRole: sessioncatalog.RecoveryRoleDiverged, ParentID: "root", RecoveryGroupID: "root", LastActivityAt: 30},
+			{Path: "/s/fork-b.jsonl", Turns: 4, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+				Recovered: true, RecoveryRole: sessioncatalog.RecoveryRoleDiverged, ParentID: "root", RecoveryGroupID: "root", LastActivityAt: 40},
+		},
+	}
+	node, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}, nil)
+	if !ok {
+		t.Fatal("topic with parent should stay visible")
+	}
+	// Parent remains; idle diverged forks hide while the normal root exists.
+	if len(node.Children) != 0 {
+		t.Fatalf("children = %d, want collapsed parent-only row, children=%+v", len(node.Children), node.Children)
+	}
+}
+
+func TestProjectNodeFromCatalogTopicHidesOrphanForkTopicsWhenPreferredElsewhere(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}, detachedSessions: map[string]*WorkspaceTab{}}
+	// Separate topic that only holds a non-preferred diverged fork.
+	topic := sessioncatalog.TopicRecord{
+		Scope: "global", TopicID: "orphan-fork", Title: "WebView",
+		Sessions: []sessioncatalog.SessionRecord{
+			{Path: "/s/fork-only.jsonl", Turns: 2, TurnsState: sessioncatalog.TurnsValid, Health: sessioncatalog.HealthOK,
+				Recovered: true, RecoveryRole: sessioncatalog.RecoveryRoleDiverged, ParentID: "root", RecoveryGroupID: "root"},
+		},
+	}
+	// Workspace preference already chose the parent path for this lineage.
+	preferred := map[string]struct{}{"/s/root.jsonl": {}}
+	if _, ok := app.projectNodeFromCatalogTopic(topic, map[string]catalogRuntimeOverlay{}, map[string]catalogRuntimeOverlay{}, preferred); ok {
+		t.Fatal("orphan non-preferred recovery topic must stay out of the ordinary tree")
 	}
 }
 

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -295,7 +295,7 @@ func (a *App) metadataTopicPage(req ProjectTopicPageRequest) ProjectTopicPage {
 	return page
 }
 
-func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topicOverlays, sessionOverlays map[string]catalogRuntimeOverlay) (ProjectNode, bool) {
+func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topicOverlays, sessionOverlays map[string]catalogRuntimeOverlay, preferred map[string]struct{}) (ProjectNode, bool) {
 	kind := "topic"
 	if topic.Scope == "global" {
 		kind = "global_topic"
@@ -309,13 +309,19 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 		Pinned: topic.Pinned, Open: overlay.open, Running: overlay.running, Status: overlay.status,
 		Children: []ProjectNode{},
 	}
+	// Fall back to topic-local preference when the workspace map is unavailable
+	// so multi-fork topics still collapse instead of listing every replica.
+	localPreferred := preferred
+	if localPreferred == nil {
+		localPreferred = sessioncatalog.PreferredOrdinarySessionPaths(topic.Sessions)
+	}
 	visible := make([]sessioncatalog.SessionRecord, 0, len(topic.Sessions))
 	runtimeSessions := make([]runtimeSessionStatus, 0, len(topic.Sessions))
 	for _, session := range topic.Sessions {
 		sessionOverlay := sessionOverlays[sessionRuntimeKey(session.Path)]
-		// Idle covered recovery copies stay out of the ordinary tree. Open or
-		// running copies remain reachable so the user can still inspect them.
-		if session.RecoveryCopy && !sessionOverlay.open && !sessionOverlay.running {
+		// 1.23 ordinary-list contract: hide idle covered copies and non-
+		// preferred conflict forks. Open/running sessions stay reachable.
+		if !sessioncatalog.OrdinaryTreeSession(session, sessionOverlay.open, sessionOverlay.running, localPreferred) {
 			continue
 		}
 		visible = append(visible, session)
@@ -327,6 +333,14 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 	if topicHiddenAsRecoveryOnly(summary, topic.Pinned, append(runtimeSessions, runtimeSessionStatus{
 		open: overlay.open, running: overlay.running,
 	})) {
+		return ProjectNode{Children: []ProjectNode{}}, false
+	}
+	// After filtering non-preferred recovery forks, a topic may have nothing
+	// left. Keep pinned/open shells; otherwise drop the empty row.
+	if len(visible) == 0 {
+		if topic.Pinned || overlay.open || overlay.running {
+			return node, true
+		}
 		return ProjectNode{Children: []ProjectNode{}}, false
 	}
 	// A single effective session collapses to a normal topic row.
@@ -416,6 +430,12 @@ func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, 
 		limit = sessioncatalog.MaxLimit
 	}
 	topicOverlays, sessionOverlays := a.catalogRuntimeOverlays()
+	// Workspace-wide preference collapses cross-topic recovery replicas that
+	// share a lineage but were indexed as separate topic rows.
+	preferred, prefErr := catalog.PreferredOrdinarySessionPaths(a.bootContext(), req.Scope, req.WorkspaceRoot)
+	if prefErr != nil {
+		preferred = nil
+	}
 	cursor := req.Cursor
 	// Keep scanning past pages that are entirely idle recovery copies so the
 	// sidebar never shows an empty "no sessions" state when later pages still
@@ -430,7 +450,7 @@ func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, 
 		}
 		out.Revision = page.Revision
 		for i, topic := range page.Items {
-			node, ok := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays)
+			node, ok := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays, preferred)
 			if !ok {
 				continue
 			}
@@ -470,7 +490,8 @@ func (a *App) GetTopicSummary(key ProjectTopicKey) (ProjectNode, error) {
 		}
 		if ok {
 			topicOverlays, sessionOverlays := a.catalogRuntimeOverlays()
-			if node, visible := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays); visible {
+			preferred, _ := catalog.PreferredOrdinarySessionPaths(a.bootContext(), key.Scope, key.WorkspaceRoot)
+			if node, visible := a.projectNodeFromCatalogTopic(topic, topicOverlays, sessionOverlays, preferred); visible {
 				return node, nil
 			}
 			return ProjectNode{Children: []ProjectNode{}}, nil
@@ -572,8 +593,14 @@ func (a *App) catalogSessionPathForTopic(scope, workspaceRoot, topicID string) s
 	if err != nil || !ok || len(topic.Sessions) == 0 {
 		return ""
 	}
+	preferred := sessioncatalog.PreferredOrdinarySessionPaths(topic.Sessions)
 	sort.SliceStable(topic.Sessions, func(i, j int) bool {
-		// Prefer real conversations over idle covered recovery copies.
+		// Prefer ordinary-tree survivors, then real conversations over copies.
+		iPref := sessioncatalog.OrdinaryTreeSession(topic.Sessions[i], false, false, preferred)
+		jPref := sessioncatalog.OrdinaryTreeSession(topic.Sessions[j], false, false, preferred)
+		if iPref != jPref {
+			return iPref
+		}
 		if topic.Sessions[i].RecoveryCopy != topic.Sessions[j].RecoveryCopy {
 			return !topic.Sessions[i].RecoveryCopy
 		}

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -221,7 +221,7 @@ func TestSchemaMigrationLedgerRecordsEveryVersion(t *testing.T) {
 		}
 		versions = append(versions, version)
 	}
-	if fmt.Sprint(versions) != "[1 2 3 4 5]" {
+	if fmt.Sprint(versions) != "[1 2 3 4 5 6]" {
 		t.Fatalf("schema migration ledger = %v", versions)
 	}
 }

--- a/internal/sessioncatalog/ordinary_visibility.go
+++ b/internal/sessioncatalog/ordinary_visibility.go
@@ -1,0 +1,181 @@
+package sessioncatalog
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+// PreferredOrdinarySessionPaths returns the session paths that may appear in
+// the ordinary project tree for one workspace. Covered recovery copies and
+// non-preferred conflict forks are omitted so the sidebar matches the 1.23
+// contract: one conversation row, not a wall of recovery replicas.
+//
+// Rules:
+//   - Every non-recovered session is preferred.
+//   - When a recovery group still has its non-recovered parent, no recovered
+//     member of that group is preferred (parent is the ordinary row).
+//   - Otherwise the group keeps a single preferred recovered leaf: canonical
+//     or adopted first, then highest turns, then latest activity.
+//
+// Open/running tabs may still force-show a path outside this set at the UI
+// boundary; this helper only encodes on-disk ordinary visibility.
+func (c *Catalog) PreferredOrdinarySessionPaths(ctx context.Context, scope, workspaceRoot string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	if c == nil || c.db == nil {
+		return out, nil
+	}
+	scope, workspaceRoot = normalizeScope(scope, workspaceRoot)
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT path, recovered, parent_id, recovery_copy, recovery_group_id,
+		       recovery_role, recovery_canonical, turns, last_activity_at
+		FROM catalog_sessions
+		WHERE scope=? AND workspace_root=? AND missing_since=0 AND health<>'missing'`,
+		scope, workspaceRoot)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+	var sessions []SessionRecord
+	for rows.Next() {
+		var rec SessionRecord
+		var recoveryCopy, recoveryCanonical, recovered int
+		if err := rows.Scan(&rec.Path, &recovered, &rec.ParentID, &recoveryCopy,
+			&rec.RecoveryGroupID, &rec.RecoveryRole, &recoveryCanonical,
+			&rec.Turns, &rec.LastActivityAt); err != nil {
+			return map[string]struct{}{}, err
+		}
+		rec.Recovered = recovered != 0
+		rec.RecoveryCopy = recoveryCopy != 0
+		rec.RecoveryCanonical = recoveryCanonical != 0
+		if rec.RecoveryRole == "" {
+			if rec.RecoveryCopy {
+				rec.RecoveryRole = RecoveryRoleCoveredCopy
+			} else if rec.Recovered {
+				rec.RecoveryRole = RecoveryRoleDiverged
+			} else {
+				rec.RecoveryRole = RecoveryRoleNormal
+			}
+		}
+		sessions = append(sessions, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return map[string]struct{}{}, err
+	}
+	return PreferredOrdinarySessionPaths(sessions), nil
+}
+
+// PreferredOrdinarySessionPaths selects ordinary-tree paths from an in-memory
+// session set. Pure helper for tests and callers that already hold records.
+func PreferredOrdinarySessionPaths(sessions []SessionRecord) map[string]struct{} {
+	preferred := make(map[string]struct{}, len(sessions))
+	normalRoots := map[string]struct{}{}
+	recoveredByGroup := map[string][]SessionRecord{}
+	for _, session := range sessions {
+		path := strings.TrimSpace(session.Path)
+		if path == "" {
+			continue
+		}
+		if session.RecoveryCopy || session.RecoveryRole == RecoveryRoleCoveredCopy {
+			continue
+		}
+		if !session.Recovered {
+			preferred[path] = struct{}{}
+			normalRoots[agent.BranchID(path)] = struct{}{}
+			continue
+		}
+		key := recoveryLineageKey(session)
+		recoveredByGroup[key] = append(recoveredByGroup[key], session)
+	}
+	for group, members := range recoveredByGroup {
+		if _, parentPresent := normalRoots[group]; parentPresent {
+			// Parent conversation still exists: keep only that row.
+			continue
+		}
+		best := pickPreferredRecovery(members)
+		if path := strings.TrimSpace(best.Path); path != "" {
+			preferred[path] = struct{}{}
+		}
+	}
+	return preferred
+}
+
+// OrdinaryTreeSession reports whether a catalog session should appear in the
+// ordinary project tree given open/running runtime state and the preferred set.
+func OrdinaryTreeSession(session SessionRecord, open, running bool, preferred map[string]struct{}) bool {
+	if open || running {
+		return true
+	}
+	if session.RecoveryCopy || session.RecoveryRole == RecoveryRoleCoveredCopy {
+		return false
+	}
+	if !session.Recovered {
+		return true
+	}
+	if preferred == nil {
+		// Without a preference set, still hide covered copies (handled above)
+		// but keep recovered leaves so callers that skip preference computation
+		// do not blank the tree. Prefer building PreferredOrdinarySessionPaths.
+		return true
+	}
+	_, ok := preferred[strings.TrimSpace(session.Path)]
+	return ok
+}
+
+func recoveryLineageKey(session SessionRecord) string {
+	if group := strings.TrimSpace(session.RecoveryGroupID); group != "" {
+		return group
+	}
+	if parent := strings.TrimSpace(session.ParentID); parent != "" {
+		return parent
+	}
+	// Isolated recovered leaf without parent metadata: its own group.
+	return "path:" + agent.BranchID(session.Path)
+}
+
+func pickPreferredRecovery(members []SessionRecord) SessionRecord {
+	if len(members) == 0 {
+		return SessionRecord{}
+	}
+	best := members[0]
+	for _, candidate := range members[1:] {
+		if recoveryRank(candidate) > recoveryRank(best) {
+			best = candidate
+			continue
+		}
+		if recoveryRank(candidate) < recoveryRank(best) {
+			continue
+		}
+		if candidate.Turns != best.Turns {
+			if candidate.Turns > best.Turns {
+				best = candidate
+			}
+			continue
+		}
+		if candidate.LastActivityAt != best.LastActivityAt {
+			if candidate.LastActivityAt > best.LastActivityAt {
+				best = candidate
+			}
+			continue
+		}
+		if filepath.Base(candidate.Path) < filepath.Base(best.Path) {
+			best = candidate
+		}
+	}
+	return best
+}
+
+func recoveryRank(session SessionRecord) int {
+	switch {
+	case session.RecoveryCanonical:
+		return 3
+	case session.RecoveryRole == RecoveryRoleAdopted:
+		return 2
+	case session.RecoveryRole == RecoveryRoleDiverged || session.Recovered:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/sessioncatalog/ordinary_visibility_test.go
+++ b/internal/sessioncatalog/ordinary_visibility_test.go
@@ -1,0 +1,100 @@
+package sessioncatalog
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestPreferredOrdinarySessionPathsHidesCoveredAndSiblingForks(t *testing.T) {
+	parent := SessionRecord{Path: "/s/root.jsonl", Recovered: false, RecoveryRole: RecoveryRoleNormal, Turns: 4}
+	covered := SessionRecord{
+		Path: "/s/root-recovery-a.jsonl", Recovered: true, RecoveryCopy: true,
+		RecoveryRole: RecoveryRoleCoveredCopy, ParentID: "root", RecoveryGroupID: "root", Turns: 2,
+	}
+	forkA := SessionRecord{
+		Path: "/s/root-recovery-b.jsonl", Recovered: true, RecoveryRole: RecoveryRoleDiverged,
+		ParentID: "root", RecoveryGroupID: "root", Turns: 5, LastActivityAt: 10,
+	}
+	forkB := SessionRecord{
+		Path: "/s/root-recovery-c.jsonl", Recovered: true, RecoveryRole: RecoveryRoleDiverged,
+		ParentID: "root", RecoveryGroupID: "root", Turns: 3, LastActivityAt: 20,
+	}
+	// Parent present → only the normal session is preferred.
+	got := PreferredOrdinarySessionPaths([]SessionRecord{parent, covered, forkA, forkB})
+	if _, ok := got[parent.Path]; !ok {
+		t.Fatalf("parent missing from preferred: %+v", got)
+	}
+	for _, path := range []string{covered.Path, forkA.Path, forkB.Path} {
+		if _, ok := got[path]; ok {
+			t.Fatalf("recovery fork %s should stay hidden while parent exists", path)
+		}
+	}
+
+	// Parent gone → keep the longest recovered leaf only.
+	got = PreferredOrdinarySessionPaths([]SessionRecord{covered, forkA, forkB})
+	if len(got) != 1 {
+		t.Fatalf("preferred = %+v, want only the longest leaf", got)
+	}
+	if _, ok := got[forkA.Path]; !ok {
+		t.Fatalf("preferred = %+v, want longest fork %s", got, forkA.Path)
+	}
+}
+
+func TestPreferredOrdinarySessionPathsPrefersCanonical(t *testing.T) {
+	short := SessionRecord{
+		Path: "/s/a.jsonl", Recovered: true, RecoveryRole: RecoveryRoleDiverged,
+		RecoveryGroupID: "g", Turns: 9, LastActivityAt: 50,
+	}
+	canonical := SessionRecord{
+		Path: "/s/b.jsonl", Recovered: true, RecoveryRole: RecoveryRoleAdopted,
+		RecoveryCanonical: true, RecoveryGroupID: "g", Turns: 2, LastActivityAt: 1,
+	}
+	got := PreferredOrdinarySessionPaths([]SessionRecord{short, canonical})
+	if _, ok := got[canonical.Path]; !ok || len(got) != 1 {
+		t.Fatalf("preferred = %+v, want canonical only", got)
+	}
+}
+
+func TestOrdinaryTreeSessionForceShowsOpenFork(t *testing.T) {
+	fork := SessionRecord{Path: "/s/fork.jsonl", Recovered: true, RecoveryRole: RecoveryRoleDiverged}
+	preferred := map[string]struct{}{}
+	if OrdinaryTreeSession(fork, false, false, preferred) {
+		t.Fatal("idle non-preferred fork must stay hidden")
+	}
+	if !OrdinaryTreeSession(fork, true, false, preferred) {
+		t.Fatal("open fork must stay reachable")
+	}
+}
+
+func TestCatalogPreferredOrdinarySessionPaths(t *testing.T) {
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "c.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	dir := t.TempDir()
+	records := []SessionRecord{
+		{Path: filepath.Join(dir, "root.jsonl"), Directory: dir, Scope: "global", TopicID: "t1",
+			Turns: 2, TurnsState: TurnsValid, Health: HealthOK, LastActivityAt: 30},
+		{Path: filepath.Join(dir, "fork.jsonl"), Directory: dir, Scope: "global", TopicID: "t2",
+			Turns: 4, TurnsState: TurnsValid, Health: HealthOK, Recovered: true,
+			ParentID: "root", RecoveryGroupID: "root", RecoveryRole: RecoveryRoleDiverged, LastActivityAt: 40},
+	}
+	for _, record := range records {
+		if err := catalog.UpsertSession(ctx, record); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := catalog.PreferredOrdinarySessionPaths(ctx, "global", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got[records[0].Path]; !ok {
+		t.Fatalf("preferred = %+v, want parent", got)
+	}
+	if _, ok := got[records[1].Path]; ok {
+		t.Fatalf("preferred = %+v, parent present so fork must hide", got)
+	}
+}

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -528,7 +528,7 @@ func (c *Catalog) finishDirectoryScan(ctx context.Context, target DirectoryTarge
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE catalog_directories SET state='ready',error='',signature=?,
-		scan_cursor='',indexed=?,total=?,completed_at=? WHERE path=?`, signature, total, total, now, target.Path); err != nil {
+		scan_cursor='',indexed=?,total=?,completed_at=?,scan_finished_at=? WHERE path=?`, signature, total, total, now, now, target.Path); err != nil {
 		_ = tx.Rollback()
 		return err
 	}
@@ -599,6 +599,8 @@ func (c *Catalog) repairLoop() {
 	defer c.workers.Done()
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
+	lineageTicker := time.NewTicker(5 * time.Second)
+	defer lineageTicker.Stop()
 	for {
 		select {
 		case path := <-c.repairCh:
@@ -608,6 +610,8 @@ func (c *Catalog) repairLoop() {
 			runtime.Gosched()
 		case <-ticker.C:
 			c.drainUnknownRepairs(c.workerCtx, 64)
+		case <-lineageTicker.C:
+			c.refreshPendingLineage(c.workerCtx)
 		case <-c.stop:
 			return
 		}
@@ -688,6 +692,65 @@ func (c *Catalog) applyRepairResult(ctx context.Context, path, preview string, t
 	c.publishRevision(revision, []string{key.WorkspaceRoot}, reason)
 	c.refreshCounts(ctx)
 	return nil
+}
+
+// refreshPendingLineage checks directories with recently repaired recovery
+// sessions and re-runs lineage classification. This is necessary because the
+// initial reconcile scan marks all sessions as turns_state=unknown, so
+// promoteCanonicalLeaves cannot determine the longest branch. After repair
+// completes, turns are known and canonical promotion can succeed.
+func (c *Catalog) refreshPendingLineage(ctx context.Context) {
+	if c == nil || c.db == nil || c.opts.DisableRepair {
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		return
+	}
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT DISTINCT s.directory, d.scope, d.workspace_root
+		FROM catalog_sessions s
+		JOIN catalog_directories d ON s.directory = d.path
+		WHERE s.recovered = 1
+		  AND s.turns_state = 'valid'
+		  AND s.recovery_role = 'diverged'
+		  AND d.lineage_refreshed_at < d.scan_finished_at
+		LIMIT 8`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	type pending struct {
+		target DirectoryTarget
+		path   string
+	}
+	var targets []pending
+	for rows.Next() {
+		var p pending
+		if rows.Scan(&p.path, &p.target.Scope, &p.target.WorkspaceRoot) == nil {
+			p.target.Path = p.path
+			targets = append(targets, p)
+		}
+	}
+	rows.Close()
+	for _, p := range targets {
+		lock := c.directoryLock(p.path)
+		lock.Lock()
+		ordered, err := agent.ListSessionOrder(p.path)
+		if err != nil {
+			lock.Unlock()
+			continue
+		}
+		lineageRecords := make([]SessionRecord, 0, len(ordered))
+		for _, info := range ordered {
+			lineageRecords = append(lineageRecords, recordFromOrder(p.target, info))
+		}
+		if err := c.refreshDirectoryRecoveryLineage(ctx, p.target, lineageRecords); err == nil {
+			c.mutationMu.Lock()
+			_, _ = c.db.ExecContext(ctx, `UPDATE catalog_directories SET lineage_refreshed_at=? WHERE path=?`, c.opts.Now().UnixMilli(), p.path)
+			c.mutationMu.Unlock()
+		}
+		lock.Unlock()
+	}
 }
 
 // Rebuild replaces only the disposable catalog. Authoritative sessions and

--- a/internal/sessioncatalog/schema.go
+++ b/internal/sessioncatalog/schema.go
@@ -113,6 +113,11 @@ CREATE INDEX IF NOT EXISTS idx_catalog_sessions_recovery_group
 ON catalog_sessions(recovery_group_id, recovery_role, last_activity_at DESC);
 `
 
+const migrationV6 = `
+ALTER TABLE catalog_directories ADD COLUMN scan_finished_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE catalog_directories ADD COLUMN lineage_refreshed_at INTEGER NOT NULL DEFAULT 0;
+`
+
 func sessionMigrations() []projectiondb.Migration {
 	return []projectiondb.Migration{
 		{Version: 1, Apply: func(ctx context.Context, tx *sql.Tx) error {
@@ -133,6 +138,10 @@ func sessionMigrations() []projectiondb.Migration {
 		}},
 		{Version: 5, Apply: func(ctx context.Context, tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, migrationV5)
+			return err
+		}},
+		{Version: 6, Apply: func(ctx context.Context, tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, migrationV6)
 			return err
 		}},
 	}


### PR DESCRIPTION
## Problem

Users report seeing many duplicate/copy sessions in the project list even after upgrading to 1.24.3 with the catalog v2 migration. Video evidence shows the same session appearing dozens of times.

## Root Cause

PR #8457's recovery lineage classification logic is correct, but has a timing issue:

1. **Initial scan**:  imports all  files with 
2. **First lineage pass**:  runs, but  cannot determine the longest branch because turn counts are unknown
   - Returns  and all recovery branches stay as 
3. **Repair completes**: Background repair worker decodes JSONL and updates 
4. **No refresh**:  only updates individual session fields, never triggers lineage refresh again

Result: All recovery sessions remain permanently marked as 'diverged' → user sees all copies.

## Solution

Add periodic lineage refresh in :

1. Query directories with recently repaired recovery sessions:
   -  (repair completed)
   -  (still showing as copy)
   -  (not refreshed since scan)
2. Re-run `refreshDirectoryRecoveryLineage` for those directories
3. Update `lineage_refreshed_at` timestamp to avoid redundant work

## Schema Changes (v6)

- Add `scan_finished_at` to `catalog_directories` to track when initial scan completes
- Add `lineage_refreshed_at` to track when lineage was last refreshed
- `finishDirectoryScan` now sets `scan_finished_at`

The refresh runs every 5 seconds and processes up to 8 directories per cycle to avoid blocking the repair worker.

## Testing

- ✅ `go test ./internal/sessioncatalog/`
- ✅ `go test ./internal/tool/builtin/ ./internal/boot/`
- ✅ `go vet ./...`
- ✅ `gofmt -w .`
- ✅ Schema migration test updated for v6

## User Workaround (Immediate)

Users on 1.24.3 can manually trigger reindex once all repairs complete:

```
/doctor sessions --reindex
```

or via command line:

```cmd
reasonix-desktop.exe sessions reindex
```

This one-time reindex will correctly classify lineage because all turn counts are known by then.

---

Cache-impact: none - catalog is a disposable query projection
Documentation-impact: none - internal catalog implementation detail