### PR TITLE
fix(desktop): stop losing lifecycle records to Windows sharing violations

### DIFF
--- a/desktop/lifecycle_diagnostics.go
+++ b/desktop/lifecycle_diagnostics.go
@@ -22,6 +22,8 @@ const (
 	desktopLifecycleSchemaVersion = 2
 	desktopLifecycleRetention     = 30 * 24 * time.Hour
 	maxDesktopLifecycleRecords    = 20
+	desktopLifecycleReadRetries   = 12
+	desktopLifecycleReadBackoff   = 20 * time.Millisecond
 )
 
 type desktopLifecycleState struct {
@@ -326,10 +328,13 @@ func (t *desktopLifecycleTracker) consumePrevious(emit bool) []desktopLifecycleO
 			continue
 		}
 		claimed := path + ".claimed-" + t.state.RunID
-		if err := os.Rename(path, claimed); err != nil {
+		// Windows fails a bare rename with a sharing violation while any other
+		// instance still holds the record open, so without the retry every
+		// claimant can lose the same race and the evidence is dropped by all.
+		if err := fileutil.ClaimRename(path, claimed); err != nil {
 			continue
 		}
-		state, readErr = readDesktopLifecycleState(claimed)
+		state, readErr = readClaimedLifecycleState(claimed)
 		if readErr != nil || state.SchemaVersion != desktopLifecycleSchemaVersion {
 			// The file changed between inspection and claim. Put it back when
 			// possible instead of deleting data that may belong to another schema.
@@ -347,6 +352,28 @@ func (t *desktopLifecycleTracker) consumePrevious(emit bool) []desktopLifecycleO
 	}
 	t.pruneRecords()
 	return observations
+}
+
+// readClaimedLifecycleState re-reads a just-claimed record. Winning the rename
+// does not make the file readable yet: an instance that was inspecting it still
+// holds a handle, and Windows answers with a sharing violation until it drops.
+// Only the open is retried — content this build cannot parse is a definite
+// answer about the record, not a lock waiting to clear.
+func readClaimedLifecycleState(path string) (desktopLifecycleState, error) {
+	var body []byte
+	var err error
+	for attempt := range desktopLifecycleReadRetries {
+		if body, err = os.ReadFile(path); err == nil || os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(time.Duration(attempt+1) * desktopLifecycleReadBackoff)
+	}
+	if err != nil {
+		return desktopLifecycleState{}, err
+	}
+	var state desktopLifecycleState
+	err = json.Unmarshal(body, &state)
+	return state, err
 }
 
 func readDesktopLifecycleState(path string) (desktopLifecycleState, error) {

--- a/desktop/lifecycle_diagnostics_test.go
+++ b/desktop/lifecycle_diagnostics_test.go
@@ -232,6 +232,14 @@ func TestDesktopLifecycleAsyncWriterKeepsLatestPhase(t *testing.T) {
 	tracker.markAsync("ready")
 	tracker.markAsync("healthy")
 	tracker.stopWriter()
+	// stopWriter leaves after 250ms so quitting never blocks on diagnostic I/O.
+	// That budget is not a flush guarantee — one atomic replace on a loaded
+	// Windows runner has taken 500ms — so wait for the drain before reading.
+	select {
+	case <-tracker.writerDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("lifecycle writer never drained")
+	}
 
 	state, err := readDesktopLifecycleState(tracker.path)
 	if err != nil || state.Phase != "healthy" {

--- a/internal/fileutil/atomicwrite.go
+++ b/internal/fileutil/atomicwrite.go
@@ -218,6 +218,15 @@ func ReplaceFile(tmp, dest string) error {
 	return replaceFile(tmp, dest, true)
 }
 
+// ClaimRename renames src to dst for callers that use the rename itself as a
+// claim: it retries the same transient locks ReplaceFile does, but never falls
+// back to a copy, because a copy would let two claimants both succeed. A src
+// that has disappeared ends the retries at once — that is the loser of a race,
+// not a fault.
+func ClaimRename(src, dst string) error {
+	return replaceFile(src, dst, false)
+}
+
 func replaceFile(tmp, dest string, allowCrossDeviceCopy bool) error {
 	var err error
 	for attempt := 0; ; attempt++ {

--- a/internal/fileutil/atomicwrite_test.go
+++ b/internal/fileutil/atomicwrite_test.go
@@ -412,3 +412,49 @@ func TestAtomicOverwriteFileUsesDefaultPermForNewFile(t *testing.T) {
 		t.Fatalf("perm = %o, want 600", perm)
 	}
 }
+
+// The claim's whole value is that exactly one caller can win it, so the copy
+// fallback ReplaceFile takes for undoable renames must never apply here: a copy
+// would leave both claimants holding the record.
+func TestClaimRenameNeverFallsBackToCopy(t *testing.T) {
+	oldBase, oldMax := replaceRetryBase, maxReplaceRetries
+	replaceRetryBase, maxReplaceRetries = 0, 2
+	t.Cleanup(func() { replaceRetryBase, maxReplaceRetries = oldBase, oldMax })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "record.json")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "blocked")
+	if err := os.Mkdir(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClaimRename(src, dst); err == nil {
+		t.Fatal("want an error when the claim cannot rename")
+	}
+	if entries, err := os.ReadDir(dst); err != nil || len(entries) != 0 {
+		t.Fatalf("destination directory = %v, %v — the claim copied into it", entries, err)
+	}
+	if got, err := os.ReadFile(src); err != nil || string(got) != "payload" {
+		t.Fatalf("source = %q, %v — a failed claim must leave the record in place", got, err)
+	}
+}
+
+// A source that has already been claimed by someone else is the loser of a
+// race, not a lock worth waiting out.
+func TestClaimRenameDoesNotRetryWhenSourceIsGone(t *testing.T) {
+	oldBase := replaceRetryBase
+	replaceRetryBase = 10 * time.Second
+	t.Cleanup(func() { replaceRetryBase = oldBase })
+
+	dir := t.TempDir()
+	start := time.Now()
+	err := ClaimRename(filepath.Join(dir, "taken.json"), filepath.Join(dir, "taken.json.claimed"))
+	if err == nil {
+		t.Fatal("want an error when the record is already claimed")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("lost claim took %v — it retried a race it had already lost", elapsed)
+	}
+}


### PR DESCRIPTION
`desktop-windows` fails often enough to be noise. Two tests in
`desktop/lifecycle_diagnostics_test.go` are responsible, for two unrelated
reasons — and one of them is not a test problem at all.

## 1. Lifecycle records are lost on Windows, not just in the test

`TestDesktopLifecycleConcurrentConsumersClaimOnce` starts 16 consumers against
one dead-instance record and expects exactly one to claim it. Locally it
reported **0 claims in 33 of 60 runs**. Never more than one — so the
exactly-once property held; what failed was at-least-once.

`consumePrevious` claims a record by renaming it, then re-reads it to confirm
the schema did not change under the claim. Both steps were bare syscalls with
no retry. On Windows each fails with a sharing violation while any other
instance still holds the file open, and the two failures are handled the same
unhelpful way: the rename failure is skipped, and the re-read failure is
treated as "the file changed", which renames the record back and drops it.

An isolated reproduction of just that pattern (16 goroutines, read then rename
then re-read) shows both:

```
claims per round:
  0 claimed: 12 rounds
  1 claimed: 188 rounds
loser outcomes:
  rename: ...The process cannot access the file because it is being used by another process.
  reread: ...The process cannot access the file because it is being used by another process.
```

That is a real defect: when two Desktop instances start together, the crash
evidence from a previous run can be dropped by all of them, and retention
eventually deletes it. The diagnostics exist precisely for that case.

`fileutil.ClaimRename` is the fix for the rename half — the same retry
`ReplaceFile` already performs, minus the copy fallback, because a copy would
let two claimants both succeed. A source that has vanished ends the retries at
once: that is the loser of a race, not a lock. The re-read half gets a bounded
retry that distinguishes a transient lock from a record that genuinely changed.

Measured on the real test, not the reproduction:

| | claim test |
|---|---|
| before | 33 failures / 60 runs |
| rename retry only | 6 / 60 |
| both | **0 / 100** |

## 2. The async-writer test assumed a flush it was never promised

`TestDesktopLifecycleAsyncWriterKeepsLatestPhase` wrote `ready` where it
expected `healthy`. `stopWriter` gives the writer 250ms and then leaves, on
purpose — quitting must not block on diagnostic I/O. That budget is not a flush
guarantee: in the failing CI run a single atomic replace took over 500ms
(`StartedAt 07:02:07.027` → `UpdatedAt 07:02:07.547`), so `stopWriter` returned
and the test read the record mid-write.

The product behaviour is right and is left alone — terminal phases go through
the synchronous `mark`, which is why `TestDesktopShutdownPanicPreservesLifecycleRecord`
was never affected. The test now waits for the writer to actually drain, which
is the contract it means to check: coalescing is last-state-wins. 200/200 runs
pass.

## Verification

- claim test: 100 consecutive runs, no failures (was 33/60 failing)
- async writer test: 200 consecutive runs, no failures
- `go test -run TestDesktopLifecycle -count=30 ./desktop/`, full desktop suite,
  and `./internal/fileutil/...` all pass
- `ClaimRename` gets its own tests for the two properties that carry the
  behaviour: no copy fallback, and no retry once the source is gone
- The race detector could not be run locally (no cgo toolchain); CI covers it

Cache-impact: none - `internal/fileutil` and `desktop/` diagnostics are host
file I/O. No prompt, tool schema, or provider request field is touched.
Cache-guard: not applicable to this diff; the cacheable prefix has no path into
lifecycle diagnostics or `atomicwrite.go`.
Documentation-impact: none - `docs/*.md` documents Desktop behaviour and
configuration. Crash-record claiming is internal, unconfigurable, and its
observable contract (a previous run's record is reported once) is what this
restores rather than changes.
