### PR TITLE
refactor(agent): type the session lifetime, and the one that outlives it

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -282,10 +282,11 @@ type ToolHooks interface {
 // into the main loop.
 type Agent struct {
 	agentConfig
-	prov    provider.Provider
-	tools   *tool.Registry
-	session *Session
-	sessMu  sync.Mutex // guards the session pointer for external Session()/SetSession
+	prov  provider.Provider
+	tools *tool.Registry
+	// sess is the state one conversation owns; SetSession restarts it. See
+	// sessionstate.go.
+	sess sessionRuntime
 	// executorHandoffGuard is enabled by Coordinator only for the executor agent.
 	executorHandoffGuard bool
 	pricing              *provider.Pricing
@@ -297,28 +298,10 @@ type Agent struct {
 	// never nil because New defaults it to event.Discard.
 	sink                event.Sink
 	requireVisibleFinal bool // internal callers require final Content
-	// lastUsage caches the latest provider telemetry for per-turn readouts.
-	// The run loop writes it while a frontend reads it, so it is atomic.
-	lastUsage atomic.Pointer[provider.Usage]
-	outputBudgetState
 
-	// sessCacheHit/sessCacheMiss accumulate cache tokens across every API call
-	// this session, so frontends can show the aggregate hit-rate (Σhit/Σ(hit+miss))
-	// — a steadier, cost-oriented number than the single-turn rate. They are NOT
-	// reset on compaction, so the aggregate never craters when the model-visible
-	// prefix is summarized away. Atomic: the run
-	// loop accumulates them while the status line reads them.
-	sessCacheHit  atomic.Int64
-	sessCacheMiss atomic.Int64
-
-	// lastPrefixShape records the previous provider request's cacheable prefix
-	// so usage events can explain prefix churn on the next request.
-	lastPrefixShape     PrefixShape
-	haveLastPrefixShape bool
-
-	// missingReasoning is the live view of one missing-reasoning incident.
-	// Loop-owned; SetSession clears all of it but the resolve watermark.
-	missingReasoning missingReasoningWatch
+	// unwrittenResolve is the resolve watermark a failed state write still owes.
+	// It outlives the conversation, which is why it is not in sessionRuntime.
+	unwrittenResolve unwrittenResolve
 
 	// missingReasoningWarnState rate-limits recovery retries across sessions and
 	// processes by an opaque provider-configuration fingerprint (#7059). The
@@ -438,13 +421,6 @@ type Agent struct {
 	// turn. See taskstate.go.
 	task taskRuntime
 
-	// todoState is the host's canonical task list: the latest successful
-	// todo_write with completions applied by complete_step. Unlike the per-turn
-	// ledger it survives turn boundaries and compaction (it never rides in the
-	// prompt), so the final-answer gate still sees an unfinished plan a later
-	// turn would otherwise hide. Rebuilt from the session in SetSession.
-	todoMu       sync.Mutex
-	todoState    []evidence.TodoItem
 	planContract *plancontract.Plan // approved plan this turn executes, if any
 
 	// hostAdvanceSeq guarantees unique tool IDs across turns: every
@@ -519,19 +495,7 @@ type Agent struct {
 
 	// Context management keeps the canonical transcript immutable and installs
 	// at most one provider-visible checkpoint each time compactRatio is crossed.
-	keepPolicy      KeepPolicy
-	compaction      compactionProgress
-	sessionPath     string // bound transcript path for projection sidecars
-	workspaceID     string // stable prompt-cache lineage component
-	cacheState      string // legacy resume telemetry; never provider-visible
-	checkpointState string // none|restored|applied; runtime-only
-	compactionState CompactionState
-	// compactionMu guards projection snapshots/install and the in-memory sidecar
-	// generation. Network summarization never runs while this lock is held.
-	compactionMu sync.Mutex
-	// compactionRunMu singleflights the expensive summary transaction without
-	// holding the session lock during network I/O.
-	compactionRunMu        sync.Mutex
+	keepPolicy             KeepPolicy
 	strictAlternatingRoles bool // coalesce adjacent user turns on provider request copies
 	// activeTurnCreatedAt identifies the real/synthetic user message that began
 	// the currently running turn. Compaction may rewrite older history while a
@@ -759,9 +723,9 @@ func (a *Agent) MutationObserver() *checkpoint.MutationObserver {
 // /new handlers) can't race the swap. The run loop touches a.session directly and
 // only swaps it via SetSession while idle, so its reads need no lock.
 func (a *Agent) Session() *Session {
-	a.sessMu.Lock()
-	defer a.sessMu.Unlock()
-	return a.session
+	a.sess.mu.Lock()
+	defer a.sess.mu.Unlock()
+	return a.sess.conversation
 }
 
 // SetSession replaces the agent's conversation wholesale. Used by
@@ -769,27 +733,11 @@ func (a *Agent) Session() *Session {
 // so the model picks up exactly where it left off. Callers serialise it against a
 // running turn (it only fires while idle); sessMu guards the pointer swap itself.
 func (a *Agent) SetSession(s *Session) {
-	a.sessMu.Lock()
-	a.session = s
-	a.sessMu.Unlock()
-	a.sessCacheHit.Store(0)
-	a.sessCacheMiss.Store(0)
-	a.resetOutputBudgetState()
-	// pendingResolveAt is deliberately not cleared: an unwritten resolve
-	// watermark belongs to the provider configuration, not to the conversation
-	// being replaced, and the next missing turn still owes it a retry.
-	a.missingReasoning.active = false
-	a.missingReasoning.stateRecorded = false
-	a.missingReasoning.healthyStreak = 0
+	a.sess.reset(s)
+	// The replaced conversation's task is over, but the ledger and the bill
+	// answer to beginRunTurn's scope check rather than to this seam.
 	a.task.repeatFailures = nil
 	a.task.repeatScope = ""
-	a.compactionMu.Lock()
-	a.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
-	a.cacheState = CacheStateUnknown
-	a.compactionMu.Unlock()
-	a.compaction.stuck = false
-	a.compaction.consecutive = 0
-	a.compaction.lastTurn.Store(0)
 	if s != nil {
 		a.rebuildTodoState(s.Snapshot())
 	}
@@ -799,12 +747,12 @@ func (a *Agent) SetSession(s *Session) {
 // reported (nil if no turn has run yet). The TUI uses it to show a context
 // gauge alongside the prompt; ContextManager.Prepare owns cache-breaking
 // maintenance decisions.
-func (a *Agent) LastUsage() *provider.Usage { return a.lastUsage.Load() }
+func (a *Agent) LastUsage() *provider.Usage { return a.sess.output.lastUsage.Load() }
 
 // SessionCache returns the cumulative cache hit/miss prompt tokens across every
 // API call this session — the basis for the status line's aggregate hit-rate.
 func (a *Agent) SessionCache() (hit, miss int) {
-	return int(a.sessCacheHit.Load()), int(a.sessCacheMiss.Load())
+	return int(a.sess.cacheHit.Load()), int(a.sess.cacheMiss.Load())
 }
 
 // ContextWindow returns the configured context-window size in tokens. 0
@@ -990,14 +938,14 @@ func UnappliedSteerNotice(text string) string {
 // before every provider request. itemID correlates the notice with the durable
 // session inbox entry when one exists.
 func (a *Agent) RecordUnappliedSteer(text string, itemID ...string) {
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return
 	}
 	id := ""
 	if len(itemID) > 0 {
 		id = itemID[0]
 	}
-	a.session.Add(provider.Message{
+	a.sess.conversation.Add(provider.Message{
 		Role:       provider.RoleTool,
 		Content:    a.withTurnPreferences(midTurnSteerMessage(text)),
 		ToolCallID: provider.LocalOnlyToolID,
@@ -1259,6 +1207,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 			temperature:        opts.Temperature,
 			usageSource:        usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
 			modelRef:           strings.TrimSpace(opts.ModelRef),
+			workspaceID:        strings.TrimSpace(opts.WorkspaceID),
 			writeWorkspaceRoot: strings.TrimSpace(opts.WriteWorkspaceRoot),
 			subagentDepth:      subagentDepth,
 			maxSubagentDepth:   maxSubagentDepth,
@@ -1267,9 +1216,13 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 			recentKeep:         opts.RecentKeep,
 			archiveDir:         opts.ArchiveDir,
 		},
-		prov:    prov,
-		tools:   tools,
-		session: session,
+		prov:  prov,
+		tools: tools,
+		sess: sessionRuntime{
+			conversation: session,
+			path:         strings.TrimSpace(opts.SessionPath),
+			cacheState:   CacheStateUnknown,
+		},
 		task: taskRuntime{
 			ledger: evidence.NewLedger(),
 			budget: runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
@@ -1302,15 +1255,12 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		capabilityLedger:          opts.CapabilityLedger,
 		capabilityAudit:           opts.CapabilityAudit,
 		keepPolicy:                opts.KeepPolicy,
-		sessionPath:               strings.TrimSpace(opts.SessionPath),
-		workspaceID:               strings.TrimSpace(opts.WorkspaceID),
-		cacheState:                CacheStateUnknown,
 		strictAlternatingRoles:    opts.StrictAlternatingRoles,
 		mutationObserver:          opts.MutationObserver,
 	}
-	a.outputBudget = outputBudgetOf(prov)
-	if a.sessionPath != "" {
-		a.LoadProjectionSidecar(a.sessionPath)
+	a.sess.output.outputBudget = outputBudgetOf(prov)
+	if a.sess.path != "" {
+		a.LoadProjectionSidecar(a.sess.path)
 	}
 	preset := strings.TrimSpace(opts.AgentPreset)
 	if preset == "" && opts.DeliveryProfile {
@@ -1584,15 +1534,15 @@ func (a *Agent) deliveryMutationCheckpointReady() bool {
 }
 
 func (a *Agent) setTodoState(todos []evidence.TodoItem) {
-	a.todoMu.Lock()
-	a.todoState = evidence.NormalizeSerialTodos(todos)
-	a.todoMu.Unlock()
+	a.sess.todoMu.Lock()
+	a.sess.todoState = evidence.NormalizeSerialTodos(todos)
+	a.sess.todoMu.Unlock()
 }
 
 func (a *Agent) hasActiveCanonicalTodo() bool {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	for _, todo := range a.todoState {
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
+	for _, todo := range a.sess.todoState {
 		if canonicalTodoStatus(todo.Status) == "in_progress" {
 			return true
 		}
@@ -1601,11 +1551,11 @@ func (a *Agent) hasActiveCanonicalTodo() bool {
 }
 
 func (a *Agent) canonicalTodoProgress() (int, bool) {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
 	completed := 0
 	incomplete := false
-	for _, todo := range a.todoState {
+	for _, todo := range a.sess.todoState {
 		status := canonicalTodoStatus(todo.Status)
 		if status == "completed" {
 			completed++
@@ -1637,18 +1587,18 @@ func registryHasWriterTools(reg *tool.Registry) bool {
 // synthetic todo_write so the task panel reflects it without the model
 // re-sending the whole list. No-op when nothing matches or it is already done.
 func (a *Agent) advanceCanonicalTodo(step string) {
-	a.todoMu.Lock()
-	if len(a.todoState) == 0 {
-		a.todoMu.Unlock()
+	a.sess.todoMu.Lock()
+	if len(a.sess.todoState) == 0 {
+		a.sess.todoMu.Unlock()
 		return
 	}
-	m, ok := evidence.MatchStep(step, a.todoState)
-	if !ok || !evidence.AdvanceSerialTodo(a.todoState, m.Index-1) {
-		a.todoMu.Unlock()
+	m, ok := evidence.MatchStep(step, a.sess.todoState)
+	if !ok || !evidence.AdvanceSerialTodo(a.sess.todoState, m.Index-1) {
+		a.sess.todoMu.Unlock()
 		return
 	}
-	snapshot := append([]evidence.TodoItem(nil), a.todoState...)
-	a.todoMu.Unlock()
+	snapshot := append([]evidence.TodoItem(nil), a.sess.todoState...)
+	a.sess.todoMu.Unlock()
 	a.recordTodoState(snapshot)
 	a.emitTodoState(snapshot, m.Index)
 }
@@ -2141,8 +2091,8 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 		case provider.ChunkUsage:
 			usage, a.lastReasoning = chunk.Usage, chunk.Usage.ReasoningTokens
 			a.storeLatestRequestUsage(chunk.Usage)
-			a.sessCacheHit.Add(int64(chunk.Usage.CacheHitTokens))
-			a.sessCacheMiss.Add(int64(chunk.Usage.CacheMissTokens))
+			a.sess.cacheHit.Add(int64(chunk.Usage.CacheHitTokens))
+			a.sess.cacheMiss.Add(int64(chunk.Usage.CacheMissTokens))
 		case provider.ChunkError:
 			if provider.IsStreamInterrupted(chunk.Err) {
 				stored, _ := finishReasoning()
@@ -2231,7 +2181,7 @@ func (a *Agent) recordInterruptedDisplay(text, reasoning string, calls []provide
 			interrupted = append(interrupted, name)
 		}
 	}
-	a.session.Add(provider.Message{
+	a.sess.conversation.Add(provider.Message{
 		Role:             provider.RoleTool,
 		Content:          text,
 		ReasoningContent: reasoning,
@@ -2250,12 +2200,12 @@ func (a *Agent) recordInterruptedDisplay(text, reasoning string, calls []provide
 }
 
 func (a *Agent) capturePrefixShape(schemas []provider.ToolSchema) PrefixShape {
-	return CaptureShape(a.systemPrompt(), schemas, a.session.RewriteVersion())
+	return CaptureShape(a.systemPrompt(), schemas, a.sess.conversation.RewriteVersion())
 }
 
 func (a *Agent) systemPrompt() string {
 	var b strings.Builder
-	for _, m := range a.session.Messages {
+	for _, m := range a.sess.conversation.Messages {
 		if m.Role != provider.RoleSystem {
 			continue
 		}

--- a/internal/agent/agent_config.go
+++ b/internal/agent/agent_config.go
@@ -13,6 +13,9 @@ type agentConfig struct {
 	temperature        float64
 	usageSource        string
 	modelRef           string
+	// workspaceID is a prompt-cache lineage component, so it must not move
+	// while an agent lives — a change would silently rekey the cache.
+	workspaceID string
 	// writeWorkspaceRoot scopes write reservations when writeScheduler is set.
 	writeWorkspaceRoot string
 	// subagentDepth caps delegation; at maxSubagentDepth the recursive

--- a/internal/agent/argserror_test.go
+++ b/internal/agent/argserror_test.go
@@ -25,7 +25,7 @@ func TestMalformedToolArgsEchoSchema(t *testing.T) {
 	if err := a.Run(context.Background(), "ask me"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	got := toolResult(a.session, "ask")
+	got := toolResult(a.sess.conversation, "ask")
 	if !strings.Contains(got, "not valid JSON") || !strings.Contains(got, `"options"`) {
 		t.Fatalf("malformed-args result should echo the schema, got %q", got)
 	}
@@ -44,7 +44,7 @@ func TestValidArgsErrorOmitsSchema(t *testing.T) {
 	if err := a.Run(context.Background(), "ask me"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	got := toolResult(a.session, "ask")
+	got := toolResult(a.sess.conversation, "ask")
 	if strings.Contains(got, "not valid JSON") {
 		t.Fatalf("a valid-JSON arg error must not get the schema hint, got %q", got)
 	}

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -15,19 +15,19 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 
 	// Turn did work (a successful bash) but issued no todo_write this turn, so the
 	// per-turn ledger has no list — the canonical state must still gate.
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, todoState: open}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: open}}
 	if got := a.ReadinessResult(); !strings.Contains(got.Reason, "incomplete") {
 		t.Fatalf("cross-turn gate = %q, want it to report incomplete canonical todos", got.Reason)
 	}
 
 	// A turn that touched nothing (pure Q&A) must never gate on stale canonical state.
-	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, todoState: open}
+	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, sess: sessionRuntime{todoState: open}}
 	if got := idle.ReadinessResult(); !got.Ready {
 		t.Fatalf("no-work turn gated on canonical todos: %+v", got)
 	}
 
 	// All canonical items completed → no gate even after work.
-	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}
+	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}}
 	if got := done.ReadinessResult(); !got.Ready {
 		t.Fatalf("completed canonical todos still gated: %+v", got)
 	}
@@ -36,33 +36,33 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 func TestAdvanceCanonicalTodoCompletesAndPromotes(t *testing.T) {
 	a := &Agent{
 		sink: event.Discard,
-		todoState: []evidence.TodoItem{
+		sess: sessionRuntime{todoState: []evidence.TodoItem{
 			{Content: "sync branch", Status: "in_progress"},
 			{Content: "push to origin", Status: "pending"},
 			{Content: "rebase", Status: "pending"},
-		},
+		}},
 	}
 	a.advanceCanonicalTodo("sync branch")
 
-	if a.todoState[0].Status != "completed" {
-		t.Fatalf("signed-off item not completed: %+v", a.todoState[0])
+	if a.sess.todoState[0].Status != "completed" {
+		t.Fatalf("signed-off item not completed: %+v", a.sess.todoState[0])
 	}
-	if a.todoState[1].Status != "in_progress" {
-		t.Fatalf("next pending item not promoted: %+v", a.todoState[1])
+	if a.sess.todoState[1].Status != "in_progress" {
+		t.Fatalf("next pending item not promoted: %+v", a.sess.todoState[1])
 	}
-	if a.todoState[2].Status != "pending" {
-		t.Fatalf("a later item was promoted out of order: %+v", a.todoState[2])
+	if a.sess.todoState[2].Status != "pending" {
+		t.Fatalf("a later item was promoted out of order: %+v", a.sess.todoState[2])
 	}
 }
 
 func TestAdvanceCanonicalTodoRejectsPendingMatchByNumber(t *testing.T) {
-	a := &Agent{sink: event.Discard, todoState: []evidence.TodoItem{
+	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "first", Status: "in_progress"},
 		{Content: "second", Status: "pending"},
-	}}
+	}}}
 	a.advanceCanonicalTodo("2")
-	if a.todoState[1].Status != "pending" || a.todoState[0].Status != "in_progress" {
-		t.Fatalf("pending numeric step advanced out of order: %+v", a.todoState)
+	if a.sess.todoState[1].Status != "pending" || a.sess.todoState[0].Status != "in_progress" {
+		t.Fatalf("pending numeric step advanced out of order: %+v", a.sess.todoState)
 	}
 }
 
@@ -80,8 +80,8 @@ func TestRebuildTodoStateIgnoresHistoricalPendingSignoff(t *testing.T) {
 	}
 	a := &Agent{}
 	a.rebuildTodoState(msgs)
-	if a.todoState[0].Status != "in_progress" || a.todoState[1].Status != "pending" {
-		t.Fatalf("historical pending signoff restored invalid state: %+v", a.todoState)
+	if a.sess.todoState[0].Status != "in_progress" || a.sess.todoState[1].Status != "pending" {
+		t.Fatalf("historical pending signoff restored invalid state: %+v", a.sess.todoState)
 	}
 }
 
@@ -91,8 +91,8 @@ func TestSetTodoStateNormalizesLegacyOutOfOrderSnapshot(t *testing.T) {
 		{Content: "first", Status: "in_progress"},
 		{Content: "second", Status: "completed"},
 	})
-	if a.todoState[0].Status != "in_progress" || a.todoState[1].Status != "pending" {
-		t.Fatalf("legacy snapshot was not normalized: %+v", a.todoState)
+	if a.sess.todoState[0].Status != "in_progress" || a.sess.todoState[1].Status != "pending" {
+		t.Fatalf("legacy snapshot was not normalized: %+v", a.sess.todoState)
 	}
 }
 
@@ -111,14 +111,14 @@ func TestRebuildTodoStateReplaysCompleteSteps(t *testing.T) {
 	a := &Agent{}
 	a.rebuildTodoState(msgs)
 
-	if len(a.todoState) != 2 {
-		t.Fatalf("rebuilt %d todos, want 2", len(a.todoState))
+	if len(a.sess.todoState) != 2 {
+		t.Fatalf("rebuilt %d todos, want 2", len(a.sess.todoState))
 	}
-	if a.todoState[0].Status != "completed" {
-		t.Fatalf("complete_step not replayed onto canonical state: %+v", a.todoState[0])
+	if a.sess.todoState[0].Status != "completed" {
+		t.Fatalf("complete_step not replayed onto canonical state: %+v", a.sess.todoState[0])
 	}
-	if a.todoState[1].Status != "in_progress" {
-		t.Fatalf("next item not promoted on replay: %+v", a.todoState[1])
+	if a.sess.todoState[1].Status != "in_progress" {
+		t.Fatalf("next item not promoted on replay: %+v", a.sess.todoState[1])
 	}
 }
 
@@ -137,8 +137,8 @@ func TestRebuildTodoStateSkipsFailedCompleteStep(t *testing.T) {
 	a := &Agent{}
 	a.rebuildTodoState(msgs)
 
-	if a.todoState[0].Status == "completed" {
-		t.Fatalf("a failed complete_step must not advance canonical state: %+v", a.todoState[0])
+	if a.sess.todoState[0].Status == "completed" {
+		t.Fatalf("a failed complete_step must not advance canonical state: %+v", a.sess.todoState[0])
 	}
 }
 
@@ -154,8 +154,8 @@ func TestRebuildTodoStateRequiresToolResults(t *testing.T) {
 	}
 	a := &Agent{}
 	a.rebuildTodoState(msgs)
-	if len(a.todoState) != 0 {
-		t.Fatalf("todo_write without tool result rebuilt canonical state: %+v", a.todoState)
+	if len(a.sess.todoState) != 0 {
+		t.Fatalf("todo_write without tool result rebuilt canonical state: %+v", a.sess.todoState)
 	}
 
 	msgs = append(msgs[:1],
@@ -163,10 +163,10 @@ func TestRebuildTodoStateRequiresToolResults(t *testing.T) {
 		msgs[1],
 	)
 	a.rebuildTodoState(msgs)
-	if len(a.todoState) != 1 {
-		t.Fatalf("successful todo_write did not rebuild canonical state: %+v", a.todoState)
+	if len(a.sess.todoState) != 1 {
+		t.Fatalf("successful todo_write did not rebuild canonical state: %+v", a.sess.todoState)
 	}
-	if got := a.todoState[0].Status; got != "in_progress" {
+	if got := a.sess.todoState[0].Status; got != "in_progress" {
 		t.Fatalf("complete_step without tool result changed status to %q", got)
 	}
 }
@@ -188,8 +188,8 @@ func TestRebuildTodoStateHonorsEmptyTodoWriteClear(t *testing.T) {
 	}
 	a := &Agent{}
 	a.rebuildTodoState(msgs)
-	if len(a.todoState) != 0 {
-		t.Fatalf("empty todo_write should clear rebuilt canonical state: %+v", a.todoState)
+	if len(a.sess.todoState) != 0 {
+		t.Fatalf("empty todo_write should clear rebuilt canonical state: %+v", a.sess.todoState)
 	}
 }
 
@@ -200,23 +200,23 @@ func TestSeedTodoState(t *testing.T) {
 		{Content: "step 2", Status: "pending"},
 	}
 	a.SeedTodoState(todos)
-	if len(a.todoState) != 2 {
-		t.Fatalf("SeedTodoState: got %d items, want 2", len(a.todoState))
+	if len(a.sess.todoState) != 2 {
+		t.Fatalf("SeedTodoState: got %d items, want 2", len(a.sess.todoState))
 	}
-	if a.todoState[0].Status != "in_progress" {
-		t.Fatalf("SeedTodoState: first item status = %q, want in_progress", a.todoState[0].Status)
+	if a.sess.todoState[0].Status != "in_progress" {
+		t.Fatalf("SeedTodoState: first item status = %q, want in_progress", a.sess.todoState[0].Status)
 	}
 }
 
 func TestSeedTodoStateReplacesExisting(t *testing.T) {
-	a := &Agent{sink: event.Discard, todoState: []evidence.TodoItem{
+	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "existing", Status: "in_progress"},
-	}}
+	}}}
 	a.SeedTodoState([]evidence.TodoItem{
 		{Content: "new", Status: "in_progress"},
 	})
-	if len(a.todoState) != 1 || a.todoState[0].Content != "new" {
-		t.Fatalf("SeedTodoState did not replace existing state: %+v", a.todoState)
+	if len(a.sess.todoState) != 1 || a.sess.todoState[0].Content != "new" {
+		t.Fatalf("SeedTodoState did not replace existing state: %+v", a.sess.todoState)
 	}
 }
 
@@ -227,40 +227,40 @@ func TestSeedTodoStateAllowsAdvanceAfterSeed(t *testing.T) {
 		{Content: "step 2", Status: "pending"},
 	})
 	a.advanceCanonicalTodo("step 1")
-	if a.todoState[0].Status != "completed" {
-		t.Fatalf("advance after seed: item 0 status = %q, want completed", a.todoState[0].Status)
+	if a.sess.todoState[0].Status != "completed" {
+		t.Fatalf("advance after seed: item 0 status = %q, want completed", a.sess.todoState[0].Status)
 	}
-	if a.todoState[1].Status != "in_progress" {
-		t.Fatalf("advance after seed: item 1 status = %q, want in_progress", a.todoState[1].Status)
+	if a.sess.todoState[1].Status != "in_progress" {
+		t.Fatalf("advance after seed: item 1 status = %q, want in_progress", a.sess.todoState[1].Status)
 	}
 }
 
 func TestAdvanceCanonicalTodoWalksPhaseChain(t *testing.T) {
-	a := &Agent{sink: event.Discard, todoState: []evidence.TodoItem{
+	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "Port the parser", Status: "pending"},
 		{Content: "move files", Status: "in_progress", Level: 1},
 		{Content: "fix imports", Status: "pending", Level: 1},
 		{Content: "Ship it", Status: "pending"},
 		{Content: "run tests", Status: "pending", Level: 1},
-	}}
+	}}}
 
 	a.advanceCanonicalTodo("Port the parser")
-	if a.todoState[0].Status != "pending" {
-		t.Fatalf("pending phase advanced ahead of its sub-steps: %+v", a.todoState)
+	if a.sess.todoState[0].Status != "pending" {
+		t.Fatalf("pending phase advanced ahead of its sub-steps: %+v", a.sess.todoState)
 	}
 
 	a.advanceCanonicalTodo("move files")
-	if a.todoState[1].Status != "completed" || a.todoState[2].Status != "in_progress" {
-		t.Fatalf("completing a sub-step should promote its sibling: %+v", a.todoState)
+	if a.sess.todoState[1].Status != "completed" || a.sess.todoState[2].Status != "in_progress" {
+		t.Fatalf("completing a sub-step should promote its sibling: %+v", a.sess.todoState)
 	}
 
 	a.advanceCanonicalTodo("fix imports")
-	if a.todoState[2].Status != "completed" || a.todoState[0].Status != "in_progress" {
-		t.Fatalf("after the last sub-step the phase should become the signable item: %+v", a.todoState)
+	if a.sess.todoState[2].Status != "completed" || a.sess.todoState[0].Status != "in_progress" {
+		t.Fatalf("after the last sub-step the phase should become the signable item: %+v", a.sess.todoState)
 	}
 
 	a.advanceCanonicalTodo("Port the parser")
-	if a.todoState[0].Status != "completed" || a.todoState[3].Status != "pending" || a.todoState[4].Status != "in_progress" {
-		t.Fatalf("phase sign-off should promote the next phase's first sub-step: %+v", a.todoState)
+	if a.sess.todoState[0].Status != "completed" || a.sess.todoState[3].Status != "pending" || a.sess.todoState[4].Status != "in_progress" {
+		t.Fatalf("phase sign-off should promote the next phase's first sub-step: %+v", a.sess.todoState)
 	}
 }

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -505,7 +505,7 @@ func tailStart(msgs []provider.Message, head, budgetTokens int, tokPerChar float
 // actually sent (the provider strips it). Falls back to ~4 chars/token before
 // any usage is known, and ignores absurd ratios.
 func (a *Agent) tokPerChar() float64 {
-	if cal := a.promptCalibration.Load(); cal != nil && cal.compactChars > 0 {
+	if cal := a.sess.output.promptCalibration.Load(); cal != nil && cal.compactChars > 0 {
 		if r := float64(cal.promptTokens) / float64(cal.compactChars); r > 0.05 && r < 2 {
 			return r
 		}

--- a/internal/agent/compact_commit.go
+++ b/internal/agent/compact_commit.go
@@ -23,32 +23,32 @@ type summaryProjectionCommit struct {
 // that re-enters ContextMaintenanceSnapshot cannot deadlock.
 func (a *Agent) commitSummaryProjection(commit summaryProjectionCommit) (CompactionState, error) {
 	state := a.summaryProjectionState(commit)
-	a.compactionMu.Lock()
-	current, currentVersion := a.session.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	current, currentVersion := a.sess.conversation.snapshotMessagesVersion()
 	if currentVersion != commit.transcriptVersion ||
 		len(current) != len(commit.canonical) ||
 		coveredPrefixHash(current, len(current)) != coveredPrefixHash(commit.canonical, len(commit.canonical)) ||
-		a.compactionState.Projection.ProjectionVersion != commit.projectionVersion ||
-		a.compactionState.Generation != commit.generation {
-		a.compactionMu.Unlock()
+		a.sess.compactionState.Projection.ProjectionVersion != commit.projectionVersion ||
+		a.sess.compactionState.Generation != commit.generation {
+		a.sess.compactionMu.Unlock()
 		return CompactionState{}, errCompressStaleContext
 	}
-	prev := a.compactionState
-	a.compactionState = state
+	prev := a.sess.compactionState
+	a.sess.compactionState = state
 	if err := a.persistCompactionStateLocked(); err != nil {
-		a.compactionState = prev
-		a.compactionMu.Unlock()
+		a.sess.compactionState = prev
+		a.sess.compactionMu.Unlock()
 		if errors.Is(err, errCompressStaleContext) {
 			return CompactionState{}, err
 		}
 		return CompactionState{}, fmt.Errorf("persist projection: %w", err)
 	}
-	a.checkpointState = "applied"
+	a.sess.checkpointState = "applied"
 	if commit.activeTurn != 0 && commit.trigger != CompactionTriggerManual {
-		a.compaction.lastTurn.Store(commit.activeTurn)
+		a.sess.compaction.lastTurn.Store(commit.activeTurn)
 	}
 	receipt := state.LastReceipt
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Unlock()
 	a.emitContextMaintenance(receipt)
 	return state, nil
 }

--- a/internal/agent/compact_commit_emit_test.go
+++ b/internal/agent/compact_commit_emit_test.go
@@ -106,8 +106,8 @@ func TestCommitSurvivesPostPublishDirSyncFailure(t *testing.T) {
 	if disk.Projection.ProjectionVersion != memVer {
 		t.Fatalf("disk/memory fork: disk=%d mem=%d", disk.Projection.ProjectionVersion, memVer)
 	}
-	if disk.Generation != a.compactionState.Generation {
-		t.Fatalf("generation fork: disk=%d mem=%d", disk.Generation, a.compactionState.Generation)
+	if disk.Generation != a.sess.compactionState.Generation {
+		t.Fatalf("generation fork: disk=%d mem=%d", disk.Generation, a.sess.compactionState.Generation)
 	}
 }
 
@@ -143,18 +143,18 @@ func TestBlockedReceiptSurvivesPostPublishDirSyncFailure(t *testing.T) {
 	if prov.calls != 1 {
 		t.Fatalf("summary calls = %d, want 1", prov.calls)
 	}
-	if a.compactionState.LastReceipt == nil {
+	if a.sess.compactionState.LastReceipt == nil {
 		t.Fatal("memory lost blocked/failed receipt after post-publish dir-sync fault")
 	}
-	if status := a.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
+	if status := a.sess.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
 		t.Fatalf("receipt status = %q", status)
 	}
 	disk, ok, err := LoadCompactionState(path)
 	if err != nil || !ok || disk.LastReceipt == nil {
 		t.Fatalf("disk receipt missing: ok=%v err=%v", ok, err)
 	}
-	if disk.Generation != a.compactionState.Generation {
-		t.Fatalf("blocked generation fork: disk=%d mem=%d", disk.Generation, a.compactionState.Generation)
+	if disk.Generation != a.sess.compactionState.Generation {
+		t.Fatalf("blocked generation fork: disk=%d mem=%d", disk.Generation, a.sess.compactionState.Generation)
 	}
 	if _, err := a.contextManager().Prepare(context.Background(), policy); err != nil {
 		t.Fatal(err)

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -69,11 +69,11 @@ type explicitCompressionSnapshot struct {
 }
 
 func (a *Agent) snapshotExplicitCompression() explicitCompressionSnapshot {
-	canonical, version := a.session.snapshotMessagesVersion()
+	canonical, version := a.sess.conversation.snapshotMessagesVersion()
 	cacheKey := a.currentPromptCacheKey()
-	a.compactionMu.Lock()
-	state := a.compactionState
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	state := a.sess.compactionState
+	a.sess.compactionMu.Unlock()
 	visible := canonical
 	if projectionValid(state, canonical, version, cacheKey) {
 		if projected := modelVisibleFromProjection(state.Projection, canonical); len(projected) > 0 {
@@ -164,8 +164,8 @@ func (a *Agent) compressVisibleRange(
 	preview string,
 	instructions string,
 ) (tool.CompressResult, error) {
-	a.compactionRunMu.Lock()
-	defer a.compactionRunMu.Unlock()
+	a.sess.compactionRunMu.Lock()
+	defer a.sess.compactionRunMu.Unlock()
 	if !a.explicitCompressionSnapshotCurrent(snap) {
 		return tool.CompressResult{}, errCompressStaleContext
 	}
@@ -243,11 +243,11 @@ func (a *Agent) compressVisibleRange(
 }
 
 func (a *Agent) explicitCompressionSnapshotCurrent(snap explicitCompressionSnapshot) bool {
-	current, version := a.session.snapshotMessagesVersion()
-	a.compactionMu.Lock()
-	projectionVersion := a.compactionState.Projection.ProjectionVersion
-	generation := a.compactionState.Generation
-	a.compactionMu.Unlock()
+	current, version := a.sess.conversation.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	projectionVersion := a.sess.compactionState.Projection.ProjectionVersion
+	generation := a.sess.compactionState.Generation
+	a.sess.compactionMu.Unlock()
 	return version == snap.transcriptVersion && len(current) == len(snap.canonical) &&
 		coveredPrefixHash(current, len(current)) == snap.coveredHash &&
 		projectionVersion == snap.projectionVersion && generation == snap.generation &&
@@ -380,18 +380,18 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 // was foldable; callers at physical overflow must treat that as hard failure.
 // mustFree marks the fold the caller cannot proceed without.
 func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions string, force, mustFree bool) (CompactionOutcome, error) {
-	a.compactionRunMu.Lock()
-	defer a.compactionRunMu.Unlock()
+	a.sess.compactionRunMu.Lock()
+	defer a.sess.compactionRunMu.Unlock()
 	activeTurn := a.activeTurnCreatedAt.Load()
-	if activeTurn != 0 && a.compaction.lastTurn.Load() == activeTurn && trigger != CompactionTriggerManual {
+	if activeTurn != 0 && a.sess.compaction.lastTurn.Load() == activeTurn && trigger != CompactionTriggerManual {
 		return CompactionNoop, nil
 	}
-	canonical, transcriptVersion := a.session.snapshotMessagesVersion()
-	a.compactionMu.Lock()
-	stateSnapshot := a.compactionState
-	startProjectionVersion := a.compactionState.Projection.ProjectionVersion
-	startGeneration := a.compactionState.Generation
-	a.compactionMu.Unlock()
+	canonical, transcriptVersion := a.sess.conversation.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	stateSnapshot := a.sess.compactionState
+	startProjectionVersion := a.sess.compactionState.Projection.ProjectionVersion
+	startGeneration := a.sess.compactionState.Generation
+	a.sess.compactionMu.Unlock()
 	msgs := a.visibleInputForFold(stateSnapshot, canonical, transcriptVersion)
 	viewInputHash := providerVisibleFingerprint(provider.ModelMessages(msgs))
 	if trigger != CompactionTriggerManual && stateSnapshot.LastReceipt != nil && stateSnapshot.LastReceipt.Status == "applied" && stateSnapshot.LastReceipt.Action == "summary" && stateSnapshot.LastReceipt.InputHash == viewInputHash {

--- a/internal/agent/compact_summary_failure_test.go
+++ b/internal/agent/compact_summary_failure_test.go
@@ -53,9 +53,9 @@ func agentOverForceWindow(t *testing.T, prov provider.Provider, sess *Session, w
 // standing in for the summary. The receipt is the host record that the
 // projection was installed; the digest text is what the model is actually told.
 func degradedFold(a *Agent) bool {
-	r := a.compactionState.LastReceipt
+	r := a.sess.compactionState.LastReceipt
 	return r != nil && r.Status == "applied" &&
-		strings.Contains(latestDigest(a.compactionState.Projection.Messages), "summary was unavailable")
+		strings.Contains(latestDigest(a.sess.compactionState.Projection.Messages), "summary was unavailable")
 }
 
 func prepareContext(ctx context.Context, a *Agent, trigger string) error {
@@ -65,8 +65,8 @@ func prepareContext(ctx context.Context, a *Agent, trigger string) error {
 
 // foldRegionOf is the region the next compaction would hand the summarizer.
 func foldRegionOf(a *Agent) []provider.Message {
-	canonical, version := a.session.snapshotMessagesVersion()
-	msgs := a.visibleInputForFold(a.compactionState, canonical, version)
+	canonical, version := a.sess.conversation.snapshotMessagesVersion()
+	msgs := a.visibleInputForFold(a.sess.compactionState, canonical, version)
 	head, start, ok := a.planFoldRegion(msgs, false)
 	if !ok {
 		return nil
@@ -87,8 +87,8 @@ func latestDigest(msgs []provider.Message) string {
 
 // projectionTokens reports what the model would actually see.
 func projectionTokens(a *Agent) int {
-	msgs, _ := a.session.snapshotMessagesVersion()
-	return estimateMessagesTokens(provider.ModelMessages(modelVisibleFromProjection(a.compactionState.Projection, msgs)))
+	msgs, _ := a.sess.conversation.snapshotMessagesVersion()
+	return estimateMessagesTokens(provider.ModelMessages(modelVisibleFromProjection(a.sess.compactionState.Projection, msgs)))
 }
 
 // The 90s summary bound is deliberately not retried, so a summarizer that never
@@ -112,7 +112,7 @@ func TestSummarizerTimeoutWhereFoldIsTheOnlyWayOutDegrades(t *testing.T) {
 	}
 	if !degradedFold(a) {
 		t.Errorf("no degraded fold committed: receipt=%+v digest=%q",
-			a.compactionState.LastReceipt, latestDigest(a.compactionState.Projection.Messages))
+			a.sess.compactionState.LastReceipt, latestDigest(a.sess.compactionState.Projection.Messages))
 	}
 }
 
@@ -131,7 +131,7 @@ func TestOverflowSummarizerFailureDegradesInsteadOfBlockingTheTurn(t *testing.T)
 		t.Fatalf("degraded fold freed no context: %d -> %d", before, after)
 	}
 	if !degradedFold(a) {
-		t.Errorf("no degraded fold committed: receipt=%+v", a.compactionState.LastReceipt)
+		t.Errorf("no degraded fold committed: receipt=%+v", a.sess.compactionState.LastReceipt)
 	}
 }
 
@@ -149,7 +149,7 @@ func TestSummarizerFailureOnOversizedFoldDegrades(t *testing.T) {
 		t.Fatalf("prepare = %v, want a degraded fold", err)
 	}
 	if !degradedFold(a) {
-		t.Errorf("no degraded fold committed: receipt=%+v", a.compactionState.LastReceipt)
+		t.Errorf("no degraded fold committed: receipt=%+v", a.sess.compactionState.LastReceipt)
 	}
 }
 
@@ -169,7 +169,7 @@ func TestPressureBelowHardCeilingKeepsTheFailure(t *testing.T) {
 	if degradedFold(a) {
 		t.Error("a recoverable view was folded without a summary")
 	}
-	if r := a.compactionState.LastReceipt; r == nil || (r.Status != "blocked" && r.Status != "failed") {
+	if r := a.sess.compactionState.LastReceipt; r == nil || (r.Status != "blocked" && r.Status != "failed") {
 		t.Errorf("receipt = %+v, want the failure recorded so the summary is not paid for twice", r)
 	}
 }

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -623,14 +623,14 @@ func TestMaybeCompactClearsStuckLatchAnywhereBelowTrigger(t *testing.T) {
 			sess := NewSession("sys")
 			sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
 			a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
-			a.compaction.consecutive = 1
-			a.compaction.stuck = true
+			a.sess.compaction.consecutive = 1
+			a.sess.compaction.stuck = true
 
 			prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: tc.prompt})
 
-			if a.compaction.consecutive != 0 || a.compaction.stuck {
+			if a.sess.compaction.consecutive != 0 || a.sess.compaction.stuck {
 				t.Fatalf("prompt %d sits under the trigger; want the latch cleared, got consecutiveCompacts=%d compactStuck=%v",
-					tc.prompt, a.compaction.consecutive, a.compaction.stuck)
+					tc.prompt, a.sess.compaction.consecutive, a.sess.compaction.stuck)
 			}
 		})
 	}
@@ -644,8 +644,8 @@ func TestMaybeCompactDefersWhenOnlyActiveTurnRemains(t *testing.T) {
 	a := New(&fakeProvider{reply: "- summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 20000}, event.Discard)
 
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 17000})
-	if a.compaction.stuck {
-		t.Fatalf("active turn should be deferred, not durably blocked: consecutiveCompacts=%d", a.compaction.consecutive)
+	if a.sess.compaction.stuck {
+		t.Fatalf("active turn should be deferred, not durably blocked: consecutiveCompacts=%d", a.sess.compaction.consecutive)
 	}
 	version := a.currentProjectionVersion()
 	prepareForObservedUsage(a, context.Background(), &provider.Usage{PromptTokens: 17000})

--- a/internal/agent/compact_threshold_test.go
+++ b/internal/agent/compact_threshold_test.go
@@ -6,9 +6,9 @@ import "testing"
 // sole compact_ratio trigger. Output is clipped only at send time.
 func TestCompactTriggerIndependentOfOutputBudget(t *testing.T) {
 	a := &Agent{
-		prov:              &sharedWindowTestProvider{budget: 131_072, shared: true},
-		agentConfig:       agentConfig{contextWindow: 128_000, compactRatio: defaultCompactRatio},
-		outputBudgetState: outputBudgetState{outputBudget: 131_072},
+		prov:        &sharedWindowTestProvider{budget: 131_072, shared: true},
+		agentConfig: agentConfig{contextWindow: 128_000, compactRatio: defaultCompactRatio},
+		sess:        sessionRuntime{output: outputBudgetState{outputBudget: 131_072}},
 	}
 	trigger := a.compactTrigger()
 	want := int(float64(128_000) * defaultCompactRatio)
@@ -16,7 +16,7 @@ func TestCompactTriggerIndependentOfOutputBudget(t *testing.T) {
 		t.Fatalf("trigger = %d, want %d (compact_ratio only)", trigger, want)
 	}
 	// Oversized output budget must not lower the trigger.
-	a.outputBudget = 200_000
+	a.sess.output.outputBudget = 200_000
 	if got := a.compactTrigger(); got != want {
 		t.Fatalf("trigger after larger output budget = %d, want %d", got, want)
 	}

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -103,7 +103,7 @@ func TestE2ESerialPlanHostAdvancesAndAllowsFinalAnswer(t *testing.T) {
 	if runErr != nil {
 		t.Fatalf("final answer blocked despite host-advanced completions: %v", runErr)
 	}
-	for i, td := range a.todoState {
+	for i, td := range a.sess.todoState {
 		if canonicalTodoStatus(td.Status) != "completed" {
 			t.Fatalf("canonical todo %d (%q) = %s, want completed", i+1, td.Content, td.Status)
 		}
@@ -168,7 +168,7 @@ func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
 	if err := a.Run(context.Background(), "finish up"); err != nil {
 		t.Fatalf("follow-up Run: %v", err)
 	}
-	for i, td := range a.todoState {
+	for i, td := range a.sess.todoState {
 		if canonicalTodoStatus(td.Status) != "completed" {
 			t.Fatalf("canonical todo %d (%q) = %s after sign-off, want completed", i+1, td.Content, td.Status)
 		}
@@ -200,7 +200,7 @@ func TestE2ECrossTurnPendingSignoffIsRejectedUntilCurrentAdvances(t *testing.T) 
 	if !sessionContains(a, "only signs the current in_progress item") {
 		t.Fatal("cross-turn pending signoff was not rejected")
 	}
-	for i, td := range a.todoState {
+	for i, td := range a.sess.todoState {
 		if canonicalTodoStatus(td.Status) != "completed" {
 			t.Fatalf("canonical todo %d (%q) = %s, want completed", i+1, td.Content, td.Status)
 		}

--- a/internal/agent/compress_tool_test.go
+++ b/internal/agent/compress_tool_test.go
@@ -59,7 +59,7 @@ func TestCompressContextBeforePreservesCanonicalAndTail(t *testing.T) {
 	if len(prov.got) < 2 || strings.Contains(prov.got[1].Content, local.Content) {
 		t.Fatalf("LocalOnly content reached summarizer: %+v", prov.got)
 	}
-	state := a.compactionState
+	state := a.sess.compactionState
 	if state.Generation != 1 || state.Projection.ViewInputHash == "" || state.Projection.ViewOutputHash == "" {
 		t.Fatalf("range compression did not install complete v3 lineage: %+v", state)
 	}
@@ -134,7 +134,7 @@ func TestCompressContextAnchorErrorsDoNotChangeState(t *testing.T) {
 			t.Fatalf("anchor %q error = %v, want %q", tc.anchor, err, tc.want)
 		}
 	}
-	if !reflect.DeepEqual(sess.Snapshot(), before) || len(a.compactionState.Projection.Messages) != 0 {
+	if !reflect.DeepEqual(sess.Snapshot(), before) || len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("failed anchor lookup changed state")
 	}
 }
@@ -217,7 +217,7 @@ func TestCompressContextNoSavingsIsNoop(t *testing.T) {
 	if got.Status != "noop" || !strings.Contains(got.Reason, "not be smaller") {
 		t.Fatalf("result = %+v", got)
 	}
-	if len(a.compactionState.Projection.Messages) != 0 {
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("noop installed a projection")
 	}
 	if reasons := sess.DrainContentRewriteReasons(); len(reasons) != 0 {
@@ -245,8 +245,8 @@ func TestCompressContextFailureDoesNotArchiveUncommittedRange(t *testing.T) {
 	if len(entries) != 0 {
 		t.Fatalf("failed range compression left %d archive files", len(entries))
 	}
-	if a.compactionState.Generation != 0 || a.compactionState.LastReceipt != nil {
-		t.Fatalf("failed range compression changed sidecar state: %+v", a.compactionState)
+	if a.sess.compactionState.Generation != 0 || a.sess.compactionState.LastReceipt != nil {
+		t.Fatalf("failed range compression changed sidecar state: %+v", a.sess.compactionState)
 	}
 }
 
@@ -316,7 +316,7 @@ func TestCompressContextRejectsStaleTranscript(t *testing.T) {
 	if err := <-errCh; !errors.Is(err, errCompressStaleContext) {
 		t.Fatalf("error = %v, want stale context", err)
 	}
-	if len(a.compactionState.Projection.Messages) != 0 {
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("stale compression installed a projection")
 	}
 	if reasons := sess.DrainContentRewriteReasons(); len(reasons) != 0 {

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -74,7 +74,7 @@ func (m ContextManager) Prepare(ctx context.Context, policy ContextPreparePolicy
 
 func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePolicy) (PreparedContext, error) {
 	a := m.agent
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return PreparedContext{}, nil
 	}
 	visible := a.modelVisibleMessages()
@@ -105,10 +105,10 @@ func (m ContextManager) prepareOnce(ctx context.Context, policy ContextPreparePo
 		return prepared, nil
 	}
 	if est < fold {
-		a.compaction.consecutive = 0
-		a.compaction.stuck = false
+		a.sess.compaction.consecutive = 0
+		a.sess.compaction.stuck = false
 	}
-	if a.compaction.stuck && policy.Trigger == CompactionTriggerPressure {
+	if a.sess.compaction.stuck && policy.Trigger == CompactionTriggerPressure {
 		return prepared, nil
 	}
 	// One user trigger. Overflow is a one-shot physical recovery path only.
@@ -152,7 +152,7 @@ func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContex
 		return prepared, nil
 	}
 	if outcome == CompactionNoop {
-		canonical, _ := a.session.snapshotMessagesVersion()
+		canonical, _ := a.sess.conversation.snapshotMessagesVersion()
 		if policy.Trigger == CompactionTriggerPressure && a.activeTurnStart(canonical) >= 0 {
 			return prepared, nil
 		}
@@ -171,8 +171,8 @@ func (m ContextManager) foldContext(ctx context.Context, prepared PreparedContex
 	if result.InputTokens >= fold {
 		reason := fmt.Sprintf("summary result remains above fold trigger (%d >= %d)", result.InputTokens, fold)
 		a.recordContextMaintenanceBlocked(a.contextMaintenanceInputHash(result.Messages), policy.Trigger, "summary", reason)
-		a.compaction.stuck = true
-		a.compaction.consecutive++
+		a.sess.compaction.stuck = true
+		a.sess.compaction.consecutive++
 		if policy.Trigger == CompactionTriggerOverflow || result.InputTokens >= hard {
 			return PreparedContext{}, fmt.Errorf("%w: %s", ErrCompactionRequired, reason)
 		}

--- a/internal/agent/context_manager_test.go
+++ b/internal/agent/context_manager_test.go
@@ -60,17 +60,17 @@ func TestContextManagerPersistsAndRestoresBlockedFailureFingerprint(t *testing.T
 	if firstProvider.calls != 1 { // single summary attempt; no summarizeOnce second pass
 		t.Fatalf("summary calls = %d, want 1", firstProvider.calls)
 	}
-	if first.compactionState.LastReceipt == nil {
+	if first.sess.compactionState.LastReceipt == nil {
 		t.Fatal("failed summary did not persist a maintenance receipt")
 	}
-	if status := first.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
+	if status := first.sess.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
 		t.Fatalf("receipt status = %q, want blocked or failed", status)
 	}
-	if first.compactionState.LastReceipt.BlockedInputHash == "" {
+	if first.sess.compactionState.LastReceipt.BlockedInputHash == "" {
 		t.Fatal("failure receipt missing input hash")
 	}
-	if first.compactionState.BlockedInputHash != "" {
-		t.Fatalf("top-level blocked mirror should not be written: %q", first.compactionState.BlockedInputHash)
+	if first.sess.compactionState.BlockedInputHash != "" {
+		t.Fatalf("top-level blocked mirror should not be written: %q", first.sess.compactionState.BlockedInputHash)
 	}
 	if _, err := first.contextManager().Prepare(context.Background(), policy); err != nil {
 		t.Fatal(err)
@@ -81,10 +81,10 @@ func TestContextManagerPersistsAndRestoresBlockedFailureFingerprint(t *testing.T
 
 	resumedProvider := &failingSummaryProvider{}
 	resumed := newAgent(resumedProvider)
-	if resumed.compactionState.LastReceipt == nil {
+	if resumed.sess.compactionState.LastReceipt == nil {
 		t.Fatal("failure receipt was not restored")
 	}
-	if status := resumed.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
+	if status := resumed.sess.compactionState.LastReceipt.Status; status != "blocked" && status != "failed" {
 		t.Fatalf("restored receipt status = %q, want blocked or failed", status)
 	}
 	if _, err := resumed.contextManager().Prepare(context.Background(), policy); err != nil {

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -24,14 +24,14 @@ func (a *Agent) contextMaintenanceBlocked(inputHash string) (bool, string) {
 	if a == nil {
 		return false, ""
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
-	r := a.compactionState.LastReceipt
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
+	r := a.sess.compactionState.LastReceipt
 	if r == nil {
 		// Legacy sidecars may only have BlockedInputHash without a receipt.
-		if a.compactionState.BlockedInputHash != "" &&
-			(inputHash == "" || a.compactionState.BlockedInputHash == inputHash) {
-			return true, a.compactionState.BlockedReason
+		if a.sess.compactionState.BlockedInputHash != "" &&
+			(inputHash == "" || a.sess.compactionState.BlockedInputHash == inputHash) {
+			return true, a.sess.compactionState.BlockedReason
 		}
 		return false, ""
 	}
@@ -41,7 +41,7 @@ func (a *Agent) contextMaintenanceBlocked(inputHash string) (bool, string) {
 	// Generation-scoped: once this generation fails, automatic maintenance
 	// does not pay for another summary until a successful install, manual
 	// compress, or lineage change advances the generation.
-	return true, firstNonEmpty(a.compactionState.BlockedReason, r.Reason)
+	return true, firstNonEmpty(a.sess.compactionState.BlockedReason, r.Reason)
 }
 
 func (a *Agent) emitContextMaintenance(r *ContextMaintenanceReceipt) {
@@ -65,7 +65,7 @@ func (a *Agent) recordContextMaintenanceBlocked(inputHash, trigger, action, reas
 // generation. Automatic Prepare will not re-enter summary until the generation
 // advances (successful install, manual compress, or lineage change).
 func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, status, reason string) {
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return
 	}
 	if inputHash == "" {
@@ -80,15 +80,15 @@ func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, stat
 	if status != "failed" {
 		status = "blocked"
 	}
-	_, transcriptVersion := a.session.snapshotMessagesVersion()
+	_, transcriptVersion := a.sess.conversation.snapshotMessagesVersion()
 	promptCacheKey := a.currentPromptCacheKey()
-	a.compactionMu.Lock()
-	state := a.compactionState
+	a.sess.compactionMu.Lock()
+	state := a.sess.compactionState
 	previous := state
 	if state.LastReceipt != nil &&
 		(state.LastReceipt.Status == "blocked" || state.LastReceipt.Status == "failed") &&
 		state.LastReceipt.Action == action {
-		a.compactionMu.Unlock()
+		a.sess.compactionMu.Unlock()
 		return
 	}
 	now := time.Now().UTC()
@@ -112,13 +112,13 @@ func (a *Agent) recordContextMaintenanceOutcome(inputHash, trigger, action, stat
 		BlockedInputHash: inputHash, Reason: reason, CreatedAt: now,
 	}
 	state.UpdatedAt = now
-	a.compactionState = state
+	a.sess.compactionState = state
 	if err := a.persistCompactionStateLocked(); err != nil {
-		a.compactionState = previous
-		a.compactionMu.Unlock()
+		a.sess.compactionState = previous
+		a.sess.compactionMu.Unlock()
 		return
 	}
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Unlock()
 	a.emitContextMaintenance(state.LastReceipt)
 }
 

--- a/internal/agent/context_report.go
+++ b/internal/agent/context_report.go
@@ -42,11 +42,11 @@ func (a *Agent) ContextReport() ContextReport {
 		OutputBudget: a.maxOutputTokens,
 		CacheState:   a.CacheState(),
 	}
-	if u := a.lastUsage.Load(); u != nil {
+	if u := a.sess.output.lastUsage.Load(); u != nil {
 		rep.LatestPrompt = u.LatestPromptTokens()
 	}
-	if a.session != nil {
-		canonical, _ := a.session.snapshotMessagesVersion()
+	if a.sess.conversation != nil {
+		canonical, _ := a.sess.conversation.snapshotMessagesVersion()
 		rep.CanonicalTokens = a.estimatedPromptTokens(provider.ModelMessages(canonical))
 	}
 	visible := a.modelVisibleMessages()
@@ -60,9 +60,9 @@ func (a *Agent) ContextReport() ContextReport {
 		}
 	}
 
-	a.compactionMu.Lock()
-	st := a.compactionState
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	st := a.sess.compactionState
+	a.sess.compactionMu.Unlock()
 	// Prefer LastReceipt; fall back to legacy top-level mirrors from older sidecars.
 	if r := st.LastReceipt; r != nil && r.Status == "applied" {
 		rep.LastTrigger = r.Trigger

--- a/internal/agent/context_report_test.go
+++ b/internal/agent/context_report_test.go
@@ -18,7 +18,7 @@ func TestContextReportUsesLatestPromptNotBillableAggregate(t *testing.T) {
 		ContextWindow: 100_000, RecentKeep: 2,
 	}, event.Discard)
 
-	a.lastUsage.Store(&provider.Usage{
+	a.sess.output.lastUsage.Store(&provider.Usage{
 		PromptTokens:        363_000, // three recovery attempts, billed
 		ContextPromptTokens: 122_000, // what the last request actually carried
 		RequestCount:        3,

--- a/internal/agent/context_status.go
+++ b/internal/agent/context_status.go
@@ -22,14 +22,14 @@ type ContextMaintenanceSnapshot struct {
 }
 
 func (a *Agent) ContextMaintenanceSnapshot() ContextMaintenanceSnapshot {
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return ContextMaintenanceSnapshot{}
 	}
-	canonical, version := a.session.snapshotMessagesVersion()
-	a.compactionMu.Lock()
-	state := a.compactionState
-	checkpointState := a.checkpointState
-	a.compactionMu.Unlock()
+	canonical, version := a.sess.conversation.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	state := a.sess.compactionState
+	checkpointState := a.sess.checkpointState
+	a.sess.compactionMu.Unlock()
 	visible := canonical
 	valid := projectionValid(state, canonical, version, a.currentPromptCacheKey())
 	if valid {

--- a/internal/agent/context_usage.go
+++ b/internal/agent/context_usage.go
@@ -30,10 +30,10 @@ func (a *Agent) ContextUsedTokens() int {
 	}
 	transcriptVersion := session.TranscriptVersion()
 	projectionVersion := a.currentProjectionVersion()
-	calibration := a.promptCalibration.Load()
+	calibration := a.sess.output.promptCalibration.Load()
 	tools := a.tools
 	toolSchemaRevision := tools.SchemaRevision()
-	if cached := a.contextUsage.Load(); cached != nil &&
+	if cached := a.sess.output.contextUsage.Load(); cached != nil &&
 		cached.transcriptVersion == transcriptVersion &&
 		cached.projectionVersion == projectionVersion &&
 		cached.calibration == calibration &&
@@ -42,7 +42,7 @@ func (a *Agent) ContextUsedTokens() int {
 		return cached.tokens
 	}
 	tokens := a.estimatedVisibleRequestTokens(a.modelVisibleMessages())
-	a.contextUsage.Store(&contextUsage{
+	a.sess.output.contextUsage.Store(&contextUsage{
 		transcriptVersion:  transcriptVersion,
 		projectionVersion:  projectionVersion,
 		calibration:        calibration,

--- a/internal/agent/context_usage_test.go
+++ b/internal/agent/context_usage_test.go
@@ -56,7 +56,7 @@ func TestContextUsedTokensMatchesTheTriggerInput(t *testing.T) {
 	a := usageFixture(t, 12)
 	// A stale, tiny reading from the previous turn — exactly what a fold leaves
 	// behind, and what the gauge used to display.
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 900, CompletionTokens: 100})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 900, CompletionTokens: 100})
 
 	used := a.ContextUsedTokens()
 	if got := a.ContextMaintenanceSnapshot().ProjectedTokens; used != got {
@@ -147,7 +147,7 @@ func TestContextUsedTokensFollowsTheTranscript(t *testing.T) {
 		t.Fatal("repeated reads of an unchanged view disagreed")
 	}
 
-	a.session.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("more context\n", 500)})
+	a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: strings.Repeat("more context\n", 500)})
 	after := a.ContextUsedTokens()
 	if after <= before {
 		t.Fatalf("gauge %d -> %d, want the appended turn counted", before, after)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -487,7 +487,7 @@ func lastNonEmptyLine(s string) string {
 }
 
 func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan string) {
-	if c == nil || c.executor == nil || c.executor.session == nil {
+	if c == nil || c.executor == nil || c.executor.sess.conversation == nil {
 		return
 	}
 	rawInput := RawUserInput(ctx, input)
@@ -496,11 +496,11 @@ func (c *Coordinator) persistExecutorNoOp(ctx context.Context, input, plan strin
 	if providerContent != rawInput {
 		rawContent = rawInput
 	}
-	c.executor.session.Add(provider.Message{
+	c.executor.sess.conversation.Add(provider.Message{
 		Role: provider.RoleUser, Content: providerContent, RawContent: rawContent,
 		Images: userImages(ctx), CreatedAt: time.Now().UnixMilli(),
 	})
-	c.executor.session.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
+	c.executor.sess.conversation.Add(provider.Message{Role: provider.RoleAssistant, Content: plan})
 }
 
 // plannerOutcome is one planning turn's result. A submitted plan is the

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -967,7 +967,7 @@ func TestCoordinatorSkipsExecutorWhenPlannerConcludesNoChanges(t *testing.T) {
 	if got := len(exec.requests); got != 0 {
 		t.Fatalf("executor requests = %d, want skip after no-op planner conclusion", got)
 	}
-	messages := executor.session.Messages
+	messages := executor.sess.conversation.Messages
 	if got := len(messages); got != 3 {
 		t.Fatalf("executor session messages = %d, want system + user + no-op assistant", got)
 	}
@@ -1314,7 +1314,7 @@ func TestCoordinatorSkipsExecutorOnExplicitNoChangesMarker(t *testing.T) {
 	if got := len(exec.requests); got != 0 {
 		t.Fatalf("executor requests = %d, want skip on explicit [no_changes] marker", got)
 	}
-	messages := executor.session.Messages
+	messages := executor.sess.conversation.Messages
 	if got := len(messages); got != 3 {
 		t.Fatalf("executor session messages = %d, want system + user + no-op assistant", got)
 	}
@@ -1775,7 +1775,7 @@ func TestCoordinatorPersistsDeniedPlanTurnToExecutorSession(t *testing.T) {
 	if len(exec.requests) != 0 {
 		t.Fatal("executor must not run when the plan is denied")
 	}
-	msgs := executor.session.Messages
+	msgs := executor.sess.conversation.Messages
 	if len(msgs) < 2 {
 		t.Fatalf("executor session messages = %d, want the denied turn persisted", len(msgs))
 	}

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -135,7 +135,7 @@ func TestDeliveryResolvedReadOnlyBashDoesNotArmMutationReadiness(t *testing.T) {
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		t.Fatal("resolved read-only bash was recorded as a mutation")
 	}
-	msgs := a.session.Snapshot()
+	msgs := a.sess.conversation.Snapshot()
 	var resolved bool
 	for _, msg := range msgs {
 		for _, call := range msg.ToolCalls {

--- a/internal/agent/dependent_writer_preview_test.go
+++ b/internal/agent/dependent_writer_preview_test.go
@@ -90,11 +90,11 @@ func TestDependentSameBatchEditRefreshesPreviewBeforeExecution(t *testing.T) {
 	if secondResult < 0 || lastUpdatedDispatch >= secondResult {
 		t.Fatalf("updated dispatch index %d must precede result index %d", lastUpdatedDispatch, secondResult)
 	}
-	if got := lastToolResult(a.session, "edit_file"); !strings.Contains(got, "-ready") || !strings.Contains(got, "+done") {
+	if got := lastToolResult(a.sess.conversation, "edit_file"); !strings.Contains(got, "-ready") || !strings.Contains(got, "+done") {
 		t.Fatalf("second edit result did not ground the actual replacement:\n%s", got)
 	}
 	var archived provider.ToolCall
-	for _, msg := range a.session.Snapshot() {
+	for _, msg := range a.sess.conversation.Snapshot() {
 		for _, call := range msg.ToolCalls {
 			if call.ID == "c2" {
 				archived = call
@@ -104,7 +104,7 @@ func TestDependentSameBatchEditRefreshesPreviewBeforeExecution(t *testing.T) {
 	if !strings.Contains(archived.Diff, `-status="ready"`) || !strings.Contains(archived.Diff, `+status="done"`) {
 		t.Fatalf("session archived stale dependent preview:\n%s", archived.Diff)
 	}
-	if !a.session.NeedsRewriteSave() {
+	if !a.sess.conversation.NeedsRewriteSave() {
 		t.Fatal("refreshing an already-appended assistant call must require a rewrite-safe snapshot")
 	}
 }
@@ -144,7 +144,7 @@ func TestDependentMutationSkippedAfterFailedWriterInBatch(t *testing.T) {
 	if string(data) != "status=\"ready\"\n" {
 		t.Fatalf("final file = %q, want partial first write preserved", data)
 	}
-	if got := toolResultByID(a.session, "c2"); !strings.Contains(got, "earlier modification") {
+	if got := toolResultByID(a.sess.conversation, "c2"); !strings.Contains(got, "earlier modification") {
 		t.Fatalf("second edit result = %q, want dependency skip", got)
 	}
 }

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -29,10 +29,10 @@ func TestRunRetriesReasoningOnlyFinalAnswer(t *testing.T) {
 	if prov.call != 2 {
 		t.Fatalf("provider calls = %d, want retry after reasoning-only answer", prov.call)
 	}
-	if got := lastAssistantContent(a.session); got != "visible reply" {
+	if got := lastAssistantContent(a.sess.conversation); got != "visible reply" {
 		t.Fatalf("last assistant content = %q, want visible reply", got)
 	}
-	if !sessionHasUserMessageContaining(a.session, "visible answer") {
+	if !sessionHasUserMessageContaining(a.sess.conversation, "visible answer") {
 		t.Fatal("missing synthetic visible-answer retry message")
 	}
 }
@@ -125,10 +125,10 @@ func TestRunAcceptsReasoningOnlyFinalWhenModelStopped(t *testing.T) {
 	if prov.call != 1 {
 		t.Fatalf("provider calls = %d, want 1 (model signalled stop; no retry)", prov.call)
 	}
-	if sessionHasUserMessageContaining(a.session, "visible answer") {
+	if sessionHasUserMessageContaining(a.sess.conversation, "visible answer") {
 		t.Fatal("must not inject a synthetic visible-answer retry when the model signalled stop")
 	}
-	if got := lastAssistantContent(a.session); got != "" {
+	if got := lastAssistantContent(a.sess.conversation); got != "" {
 		t.Fatalf("last assistant content = %q, want empty (answer lived in reasoning)", got)
 	}
 }
@@ -159,10 +159,10 @@ func TestRunRetriesReasoningOnlyStopWithoutDeepSeekPolicy(t *testing.T) {
 	if prov.call != 2 {
 		t.Fatalf("provider calls = %d, want 2 (non-DeepSeek providers must keep the retry)", prov.call)
 	}
-	if !sessionHasUserMessageContaining(a.session, "visible answer") {
+	if !sessionHasUserMessageContaining(a.sess.conversation, "visible answer") {
 		t.Fatal("missing synthetic visible-answer retry message for non-DeepSeek provider")
 	}
-	if got := lastAssistantContent(a.session); got != "visible reply" {
+	if got := lastAssistantContent(a.sess.conversation); got != "visible reply" {
 		t.Fatalf("last assistant content = %q, want visible reply", got)
 	}
 }

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -139,7 +139,7 @@ func TestEvidenceFlowEndToEnd(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if got := toolResult(a.session, "complete_step"); !strings.Contains(got, "host-verified 1") {
+	if got := toolResult(a.sess.conversation, "complete_step"); !strings.Contains(got, "host-verified 1") {
 		t.Fatalf("complete_step result = %q, want it host-verified from the bash receipt", got)
 	}
 }
@@ -172,13 +172,13 @@ func TestDeliveryProfileEnforcesAcceptanceReviewVerificationAndSignoff(t *testin
 	if err := a.Run(context.Background(), "implement main"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResult(a.session, "write_file"); !strings.Contains(got, "delivery-first mode requires acceptance criteria") {
+	if got := toolResult(a.sess.conversation, "write_file"); !strings.Contains(got, "delivery-first mode requires acceptance criteria") {
 		t.Fatalf("first write result = %q, want delivery acceptance gate", got)
 	}
-	if !sessionHasUserMessageContaining(a.session, "<execution-policy") {
+	if !sessionHasUserMessageContaining(a.sess.conversation, "<execution-policy") {
 		t.Fatal("execution-policy marker was not injected into the turn tail")
 	}
-	if got := lastToolResult(a.session, "complete_step"); !strings.Contains(got, "signed off") {
+	if got := lastToolResult(a.sess.conversation, "complete_step"); !strings.Contains(got, "signed off") {
 		t.Fatalf("complete_step result = %q, want successful sign-off", got)
 	}
 	firstSystem := systemMessageContent(prov.requests[0])
@@ -270,10 +270,10 @@ func TestDeliveryProfileCommandOnlyActionRequiresCriteriaAndSignoff(t *testing.T
 	if err := a.Run(context.Background(), "run tests"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResult(a.session, "bash"); !strings.Contains(got, "delivery-first mode requires acceptance criteria") {
+	if got := toolResult(a.sess.conversation, "bash"); !strings.Contains(got, "delivery-first mode requires acceptance criteria") {
 		t.Fatalf("first bash result = %q, want acceptance gate", got)
 	}
-	if got := lastToolResult(a.session, "complete_step"); !strings.Contains(got, "signed off") {
+	if got := lastToolResult(a.sess.conversation, "complete_step"); !strings.Contains(got, "signed off") {
 		t.Fatalf("complete_step result = %q, want successful command-only sign-off", got)
 	}
 }
@@ -291,7 +291,7 @@ func TestDeliveryProfileBlocksMixedVerificationBeforeItBecomesMutation(t *testin
 	if err := a.Run(context.Background(), "check the snake game"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResult(a.session, "bash"); !strings.Contains(got, "mixes a verification check") {
+	if got := toolResult(a.sess.conversation, "bash"); !strings.Contains(got, "mixes a verification check") {
 		t.Fatalf("mixed command result = %q, want pre-execution split guidance", got)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
@@ -312,7 +312,7 @@ func TestDeliveryProfileExplainsMaskedVerifierExitBeforeExecution(t *testing.T) 
 	if err := a.Run(context.Background(), "check the snake game"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResultByID(a.session, "masked"); !strings.Contains(got, "masks the verifier's exit status") {
+	if got := toolResultByID(a.sess.conversation, "masked"); !strings.Contains(got, "masks the verifier's exit status") {
 		t.Fatalf("masked command result = %q, want precise exit-status guidance", got)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
@@ -333,7 +333,7 @@ func TestDeliveryProfileBlocksOpaqueInlineInterpreterBeforeItBecomesMutation(t *
 	if err := a.Run(context.Background(), "check the snake game"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResultByID(a.session, "opaque"); !strings.Contains(got, "cannot audit inline interpreter source") {
+	if got := toolResultByID(a.sess.conversation, "opaque"); !strings.Contains(got, "cannot audit inline interpreter source") {
 		t.Fatalf("opaque command result = %q, want pre-execution audit guidance", got)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
@@ -362,10 +362,10 @@ func TestDeliveryProfileRequiresActiveTodoForLateMutation(t *testing.T) {
 	if err := a.Run(context.Background(), "implement main and incorporate review fixes"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := toolResultByID(a.session, "late-write"); !strings.Contains(got, "current in_progress todo") {
+	if got := toolResultByID(a.sess.conversation, "late-write"); !strings.Contains(got, "current in_progress todo") {
 		t.Fatalf("late mutation result = %q, want active-todo gate", got)
 	}
-	if got := toolResultByID(a.session, "retry-write"); strings.HasPrefix(got, "blocked:") || strings.HasPrefix(got, "error:") {
+	if got := toolResultByID(a.sess.conversation, "retry-write"); strings.HasPrefix(got, "blocked:") || strings.HasPrefix(got, "error:") {
 		t.Fatalf("mutation after appended active todo should run, got %q", got)
 	}
 }
@@ -414,7 +414,7 @@ func TestEvidenceFlowEnforcesProjectChecksAfterWrite(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := toolResult(a.session, "complete_step")
+	got := toolResult(a.sess.conversation, "complete_step")
 	if !strings.Contains(got, "project checks 1") {
 		t.Fatalf("complete_step result = %q, want project check verified from same batch", got)
 	}
@@ -528,7 +528,7 @@ func TestFinalReadinessBlocksUntilProjectCheckRunsAfterWriter(t *testing.T) {
 	if err := a.Run(ctx, "finish"); err != nil {
 		t.Fatalf("verified Run: %v", err)
 	}
-	if got := lastToolResult(a.session, "bash"); !strings.Contains(got, "bash done") {
+	if got := lastToolResult(a.sess.conversation, "bash"); !strings.Contains(got, "bash done") {
 		t.Fatalf("bash tool result = %q, want command run after the block", got)
 	}
 }
@@ -651,7 +651,7 @@ func TestFinalReadinessRequiresCompleteStepAfterWriterWhenTodoSeen(t *testing.T)
 	if err := a.Run(ctx, "finish"); err != nil {
 		t.Fatalf("signed-off Run: %v", err)
 	}
-	if got := lastToolResult(a.session, "complete_step"); !strings.Contains(got, "signed off") {
+	if got := lastToolResult(a.sess.conversation, "complete_step"); !strings.Contains(got, "signed off") {
 		t.Fatalf("complete_step result = %q, want successful sign-off", got)
 	}
 }
@@ -719,10 +719,10 @@ func TestFinalReadinessPermissionLoopGuardAllowsBlockedFinal(t *testing.T) {
 	if prov.call != 5 {
 		t.Fatalf("provider calls = %d, want writer turn, three blocked bash calls, then final", prov.call)
 	}
-	if got := lastToolResult(a.session, "bash"); !strings.Contains(got, "[loop guard]") {
+	if got := lastToolResult(a.sess.conversation, "bash"); !strings.Contains(got, "[loop guard]") {
 		t.Fatalf("last bash result = %q, want permission loop guard", got)
 	}
-	if got := toolResults(a.session, "bash"); len(got) != stormBreakThreshold {
+	if got := toolResults(a.sess.conversation, "bash"); len(got) != stormBreakThreshold {
 		t.Fatalf("bash results = %d, want exactly %d blocked attempts", len(got), stormBreakThreshold)
 	}
 	if len(*notices) == 0 {
@@ -777,7 +777,7 @@ func TestFinalReadinessPermissionLoopGuardAllowsBlockedFinalForBatch(t *testing.
 	if prov.call != 5 {
 		t.Fatalf("provider calls = %d, want writer turn, three blocked batches, then final", prov.call)
 	}
-	results := toolResults(a.session, "bash")
+	results := toolResults(a.sess.conversation, "bash")
 	if len(results) != 2*stormBreakThreshold {
 		t.Fatalf("bash results = %d, want %d blocked attempts across three batches", len(results), 2*stormBreakThreshold)
 	}
@@ -811,7 +811,7 @@ func TestTodoWriteOnlyTurnMayEndWithIncompleteTodos(t *testing.T) {
 	if prov.call != 2 {
 		t.Fatalf("provider calls = %d, want 2 without readiness retry", prov.call)
 	}
-	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "Todos updated") {
+	if got := lastToolResult(a.sess.conversation, "todo_write"); !strings.Contains(got, "Todos updated") {
 		t.Fatalf("todo_write result = %q, want successful todo update", got)
 	}
 }
@@ -840,7 +840,7 @@ func TestReadOnlyContextAndTodoTurnMayEndWithIncompleteTodos(t *testing.T) {
 	if prov.call != 2 {
 		t.Fatalf("provider calls = %d, want 2 without readiness retry", prov.call)
 	}
-	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "Todos updated") {
+	if got := lastToolResult(a.sess.conversation, "todo_write"); !strings.Contains(got, "Todos updated") {
 		t.Fatalf("todo_write result = %q, want successful todo update", got)
 	}
 }
@@ -908,7 +908,7 @@ func TestEvidenceFlowRejectsUncitedCommand(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := toolResult(a.session, "complete_step")
+	got := toolResult(a.sess.conversation, "complete_step")
 	if !strings.Contains(got, "has no matching successful receipt") {
 		t.Fatalf("complete_step result = %q, want the uncited command rejected", got)
 	}
@@ -954,7 +954,7 @@ func TestEvidenceFlowRejectsStepMissingFromTodoWrite(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := toolResult(a.session, "complete_step")
+	got := toolResult(a.sess.conversation, "complete_step")
 	if !strings.Contains(got, "matching todo_write item") {
 		t.Fatalf("complete_step result = %q, want todo-backed rejection", got)
 	}
@@ -992,7 +992,7 @@ func TestEvidenceFlowAcceptsTodoCompletionAfterCompleteStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "Todos updated") {
+	if got := lastToolResult(a.sess.conversation, "todo_write"); !strings.Contains(got, "Todos updated") {
 		t.Fatalf("final todo_write result = %q, want update accepted", got)
 	}
 }
@@ -1030,7 +1030,7 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	results := toolResults(a.session, "todo_write")
+	results := toolResults(a.sess.conversation, "todo_write")
 	if len(results) < 2 {
 		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
 	}
@@ -1074,7 +1074,7 @@ func TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress(t
 		t.Fatalf("Run: %v", err)
 	}
 
-	stepResult := lastToolResult(a.session, "complete_step")
+	stepResult := lastToolResult(a.sess.conversation, "complete_step")
 	if !strings.Contains(stepResult, "no matching successful receipt") {
 		t.Fatalf("complete_step result = %q, want the sign-off attempt to fail first", stepResult)
 	}
@@ -1084,7 +1084,7 @@ func TestEvidenceFlowRecoversTodoCompletionAfterFailedCompleteStepWithProgress(t
 	if strings.Contains(stepResult, "todo_write") {
 		t.Fatalf("complete_step result = %q, want command hints without todo tool noise", stepResult)
 	}
-	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "1 completed") {
+	if got := lastToolResult(a.sess.conversation, "todo_write"); !strings.Contains(got, "1 completed") {
 		t.Fatalf("todo_write result = %q, want completion recovery accepted", got)
 	}
 }
@@ -1143,7 +1143,7 @@ func TestEvidenceFlowRecoversAfterBatchTodoCompletionRejection(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	stepResults := toolResults(a.session, "complete_step")
+	stepResults := toolResults(a.sess.conversation, "complete_step")
 	if len(stepResults) < 3 {
 		t.Fatalf("complete_step results = %v, want blocked batch sign-off and a retry", stepResults)
 	}
@@ -1198,7 +1198,7 @@ func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing
 		t.Fatalf("Run: %v", err)
 	}
 
-	results := toolResults(a.session, "todo_write")
+	results := toolResults(a.sess.conversation, "todo_write")
 	if len(results) < 2 {
 		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
 	}
@@ -1241,7 +1241,7 @@ func TestEvidenceFlowRejectsReplacedTodoAfterNumericCompleteStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	results := toolResults(a.session, "todo_write")
+	results := toolResults(a.sess.conversation, "todo_write")
 	if len(results) < 2 {
 		t.Fatalf("todo_write results = %v, want the rejected replacement result", results)
 	}
@@ -1297,7 +1297,7 @@ func TestEvidenceFlowRejectsReorderedTodoAndRecoversSerially(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	results := toolResults(a.session, "todo_write")
+	results := toolResults(a.sess.conversation, "todo_write")
 	if len(results) != 2 || !strings.Contains(results[1], "completed after unfinished") {
 		t.Fatalf("reordered todo_write results = %v, want serial-order rejection", results)
 	}

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -90,7 +90,7 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) bat
 		if earlierWriterRan && writer {
 			if refreshed, changed := refreshCurrentFileDiff(ctx, t, calls[i]); changed {
 				calls[i] = refreshed
-				a.session.UpdateToolCallPreview(refreshed)
+				a.sess.conversation.UpdateToolCallPreview(refreshed)
 				a.emitFullToolDispatch(ctx, refreshed, true)
 			}
 		}
@@ -126,7 +126,7 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) bat
 	}
 	finalize := func(i int) {
 		if calls[i].ResolvedReadOnly != nil {
-			a.session.UpdateToolCallResolution(calls[i])
+			a.sess.conversation.UpdateToolCallResolution(calls[i])
 			a.emitResolvedToolDispatch(calls[i])
 		}
 		if surfaceWriters[i] || (outcomes[i].resolved && !outcomes[i].resolvedReadOnly) {

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -672,7 +672,7 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	cctx = WithSubagentDepth(cctx, a.subagentDepth)
 	if a.task.ledger != nil {
 		cctx = evidence.WithLedger(cctx, a.task.ledger)
-		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot)
+		cctx = evidence.WithSessionMessages(cctx, a.sess.conversation.Snapshot)
 		if a.deliveryProfile {
 			cctx = evidence.WithDeliveryProfile(cctx)
 		}

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -164,7 +164,7 @@ func TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput(t *testing.T) {
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
 	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "agent.go:2082: \"[loop guard] %s has now %s %d times\""})
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, session: sess}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, sess: sessionRuntime{conversation: sess}}
 
 	if got := a.finalReadinessCheckFor(); got.reason == "" {
 		t.Fatal("finalReadinessCheckFor() reason empty, want quoted loop-guard text to be ignored")

--- a/internal/agent/finalization.go
+++ b/internal/agent/finalization.go
@@ -43,7 +43,7 @@ func (a *Agent) armFinalizationRound(state *runLoopState, cause landCause) {
 	}
 	state.graceRound = true
 	state.landCause = cause
-	a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(cause.nudge(state))})
+	a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(cause.nudge(state))})
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeToolBudget,
 		Text: cause.noticeText(), Detail: cause.detail})
 }

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -94,7 +94,7 @@ func (p *forkCaptureProvider) Stream(ctx context.Context, req provider.Request) 
 	a := p.a
 	if a.task.ebm.captureArmed && !a.task.ebm.captured {
 		a.task.ebm.captured = true
-		messages := a.session.Snapshot()
+		messages := a.sess.conversation.Snapshot()
 		seed := a.task.outcome.ForkSeed()
 		b := ForkBundle{
 			Version: forkBundleVersion, Policy: forkCapturePolicy(),
@@ -214,7 +214,7 @@ func (a *Agent) armForkContinuation(b *ForkBundle, nudge string) {
 		if nudge != "" {
 			applyForkTreatment(messages, nudge)
 		}
-		a.session.Replace(messages)
+		a.sess.conversation.Replace(messages)
 		a.task.outcome = evidence.RestoreOutcomeTracker(evidence.OutcomeSeed{
 			MutatedBases: b.MutatedBases, DebtAge: b.DebtAtFork,
 			BlindMutations: b.BlindAtFork, LocalExecSeen: b.LocalExecSeen,

--- a/internal/agent/goal_run_boundary.go
+++ b/internal/agent/goal_run_boundary.go
@@ -83,7 +83,7 @@ func (a *Agent) trackTodoProgress(ctx context.Context, state *runLoopState, rece
 	}
 	state.todoProgress, state.trackingTodoProgress = nextProgress, nextTracking
 	if state.todoStallRounds == todoProgressNudgeRounds {
-		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(todoProgressNudgeMessage(state.todoStallRounds))})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(todoProgressNudgeMessage(state.todoStallRounds))})
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
 			Text: loopGuardNoticeText(), Detail: fmt.Sprintf("the current todo has no new completion, unique read, command, or mutation for %d consecutive tool-call rounds; asking the assistant to reassess", state.todoStallRounds)})
 	}
@@ -94,7 +94,7 @@ func (a *Agent) trackTodoProgress(ctx context.Context, state *runLoopState, rece
 		rounds := state.todoStallRounds
 		state.todoStallRounds = 0
 		nudge := fmt.Sprintf("Host progress redirect: the current todo still has no new completion or unique host-observed work after %d tool-call rounds. Re-plan and continue: shrink the active step, switch tools or approach, delegate a focused sub-task, or use update_goal(blocked) only if a user or external condition is the sole blocker. Do not repeat the same calls.", rounds)
-		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
 			Text: loopGuardNoticeText(), Detail: fmt.Sprintf("the current Goal todo made no host-observed progress for %d rounds; resetting the intervention epoch and requiring a new plan", rounds)})
 		return

--- a/internal/agent/interrupted_recovery.go
+++ b/internal/agent/interrupted_recovery.go
@@ -21,10 +21,10 @@ const (
 // A later real user turn consumes older handoffs implicitly, so the persisted
 // LocalOnly record never needs an in-place mutation that could churn history.
 func (a *Agent) pendingInterruptedRecovery() *provider.InterruptedTurnRecovery {
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return nil
 	}
-	msgs := a.session.Snapshot()
+	msgs := a.sess.conversation.Snapshot()
 	for _, v := range slices.Backward(msgs) {
 		m := v
 		if m.LocalOnly && m.InterruptedTurn != nil && m.InterruptedTurn.Pending {

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -409,7 +409,7 @@ func TestRunStreamRetryRequestCountIsLinearNotTriangular(t *testing.T) {
 		t.Fatalf("CompletionTokens = %d, want billable sum 4", u.CompletionTokens)
 	}
 	// ContextSnapshot and compaction use the latest full attempt shape.
-	if last := a.lastUsage.Load(); last == nil || last.PromptTokens != 30 {
+	if last := a.sess.output.lastUsage.Load(); last == nil || last.PromptTokens != 30 {
 		t.Fatalf("lastUsage prompt = %+v, want latest attempt prompt 30", last)
 	}
 }
@@ -1083,7 +1083,7 @@ func TestRunStoresTransformedNonToolReasoningForToolCallOnlyProvider(t *testing.
 	if err := a.Run(context.Background(), "go"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := assistantReasoning(a.session.Messages); got != "translated display" {
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "translated display" {
 		t.Fatalf("stored non-tool reasoning = %q, want transformed display text", got)
 	}
 }

--- a/internal/agent/missing_reasoning_watch.go
+++ b/internal/agent/missing_reasoning_watch.go
@@ -7,15 +7,21 @@ import (
 	"reasonix/internal/provider"
 )
 
-// missingReasoningWatch is this agent's live view of one incident: whether it
-// is active, whether the persisted state already records it, how many healthy
-// rounds have run since, and a resolve timestamp whose write failed. The four
-// only ever move together, and only observeMissingToolCallReasoning moves them.
+// missingReasoningWatch is this conversation's live view of one incident. Only
+// observeMissingToolCallReasoning moves these, and they belong to the session:
+// replacing the conversation ends the incident being watched.
 type missingReasoningWatch struct {
-	active           bool      // gates the one automatic retry, not a user-visible warning
-	stateRecorded    bool      // avoids a file transaction on every healthy tool-call turn
-	healthyStreak    int       // anti-flapping when no cross-process state dir is configured
-	pendingResolveAt time.Time // a resolve whose write failed; outlives SetSession
+	active        bool // gates the one automatic retry, not a user-visible warning
+	stateRecorded bool // avoids a file transaction on every healthy tool-call turn
+	healthyStreak int  // anti-flapping when no cross-process state dir is configured
+}
+
+// unwrittenResolve is a resolve whose state write failed. It answers to the
+// provider configuration rather than to any conversation, so it sits beside
+// missingReasoningWarnState instead of in sessionRuntime — a new session
+// inherits the debt because the retry it owes is still owed.
+type unwrittenResolve struct {
+	at time.Time
 }
 
 // observeMissingToolCallReasoning classifies a thinking-mode tool-call turn and
@@ -31,55 +37,55 @@ func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reaso
 	observedAt := time.Now()
 	if strings.TrimSpace(reasoning) != "" {
 		if a.missingReasoningWarnState == nil {
-			if a.missingReasoning.active {
-				a.missingReasoning.healthyStreak++
-				if a.missingReasoning.healthyStreak >= missingReasoningHealthyResolveStreak {
-					a.missingReasoning.active = false
-					a.missingReasoning.healthyStreak = 0
+			if a.sess.missingReasoning.active {
+				a.sess.missingReasoning.healthyStreak++
+				if a.sess.missingReasoning.healthyStreak >= missingReasoningHealthyResolveStreak {
+					a.sess.missingReasoning.active = false
+					a.sess.missingReasoning.healthyStreak = 0
 				}
 			}
 			return false, false
 		}
-		shouldResolve := !a.missingReasoning.stateRecorded || a.missingReasoning.active
+		shouldResolve := !a.sess.missingReasoning.stateRecorded || a.sess.missingReasoning.active
 		if shouldResolve {
 			result := missingReasoningResolveResult{Recorded: true, Resolved: true}
-			if pending := a.missingReasoning.pendingResolveAt; !pending.IsZero() {
+			if pending := a.unwrittenResolve.at; !pending.IsZero() {
 				result = a.missingReasoningWarnState.resolveAt(fingerprint, pending)
 				if result.Recorded {
-					a.missingReasoning.pendingResolveAt = time.Time{}
+					a.unwrittenResolve.at = time.Time{}
 				}
 			}
 			if result.Recorded {
 				result = a.missingReasoningWarnState.resolveAt(fingerprint, observedAt)
 			}
 			if !result.Recorded {
-				if observedAt.After(a.missingReasoning.pendingResolveAt) {
-					a.missingReasoning.pendingResolveAt = observedAt
+				if observedAt.After(a.unwrittenResolve.at) {
+					a.unwrittenResolve.at = observedAt
 				}
-				a.missingReasoning.active = true
-				a.missingReasoning.stateRecorded = false
+				a.sess.missingReasoning.active = true
+				a.sess.missingReasoning.stateRecorded = false
 			} else if result.Resolved {
-				a.missingReasoning.active = false
-				a.missingReasoning.stateRecorded = true
+				a.sess.missingReasoning.active = false
+				a.sess.missingReasoning.stateRecorded = true
 			} else {
-				a.missingReasoning.active = true
-				a.missingReasoning.stateRecorded = false
+				a.sess.missingReasoning.active = true
+				a.sess.missingReasoning.stateRecorded = false
 			}
 		}
 		return false, false
 	}
-	a.missingReasoning.healthyStreak = 0
+	a.sess.missingReasoning.healthyStreak = 0
 	if s := a.missingReasoningWarnState; s != nil {
 		stateReady := true
-		alreadyActive := a.missingReasoning.active
-		if pending := a.missingReasoning.pendingResolveAt; !pending.IsZero() {
+		alreadyActive := a.sess.missingReasoning.active
+		if pending := a.unwrittenResolve.at; !pending.IsZero() {
 			result := s.resolveAt(fingerprint, pending)
 			stateReady = result.Recorded
 			if result.Recorded {
-				a.missingReasoning.pendingResolveAt = time.Time{}
+				a.unwrittenResolve.at = time.Time{}
 				if result.Resolved {
 					alreadyActive = false
-					a.missingReasoning.active = false
+					a.sess.missingReasoning.active = false
 				}
 			}
 		}
@@ -87,19 +93,19 @@ func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reaso
 		if !claimed || alreadyActive {
 			// This exact configuration already attempted recovery for the active
 			// incident, so keep the empty-key fallback without doubling requests.
-			a.missingReasoning.active = true
-			a.missingReasoning.stateRecorded = true
+			a.sess.missingReasoning.active = true
+			a.sess.missingReasoning.stateRecorded = true
 			return true, false
 		}
 		if !stateReady {
-			a.missingReasoning.stateRecorded = false
+			a.sess.missingReasoning.stateRecorded = false
 		}
-	} else if a.missingReasoning.active {
+	} else if a.sess.missingReasoning.active {
 		return true, false
 	}
-	a.missingReasoning.active = true
-	if a.missingReasoning.pendingResolveAt.IsZero() {
-		a.missingReasoning.stateRecorded = true
+	a.sess.missingReasoning.active = true
+	if a.unwrittenResolve.at.IsZero() {
+		a.sess.missingReasoning.stateRecorded = true
 	}
 	return true, true
 }

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -13,7 +13,10 @@ import (
 const outputBudgetReserve = 8 * 1024
 
 type outputBudgetState struct {
-	outputBudget      int
+	outputBudget int
+	// lastUsage caches the latest provider telemetry for per-turn readouts.
+	// The run loop writes it while a frontend reads it, so it is atomic.
+	lastUsage         atomic.Pointer[provider.Usage]
 	activeReqShape    atomic.Pointer[requestCalibrationShape]
 	promptCalibration atomic.Pointer[promptTokenCalibration]
 	contextUsage      atomic.Pointer[contextUsage] // gauge's memoised prompt size
@@ -43,16 +46,16 @@ type requestCalibrationShape struct {
 // model switch rebuilds the agent, so it outlives the swap: dropping it sent
 // every rebind — resume, tab switch, recovery adopt — back to the cold
 // estimate for a turn.
-func (a *Agent) resetOutputBudgetState() {
-	a.lastUsage.Store(nil)
-	a.activeReqShape.Store(nil)
+func (o *outputBudgetState) reset() {
+	o.lastUsage.Store(nil)
+	o.activeReqShape.Store(nil)
 }
 
 func (a *Agent) setPromptTokenCalibration(promptTokens int, shape requestCalibrationShape) {
 	if a == nil || promptTokens <= 0 || shape.requestChars <= 0 {
 		return
 	}
-	a.promptCalibration.Store(&promptTokenCalibration{
+	a.sess.output.promptCalibration.Store(&promptTokenCalibration{
 		promptTokens: promptTokens,
 		requestChars: shape.requestChars,
 		compactChars: shape.compactChars,
@@ -65,7 +68,7 @@ func (a *Agent) setPromptTokenCalibrationFromActive(promptTokens int) {
 	if a == nil {
 		return
 	}
-	if shape := a.activeReqShape.Load(); shape != nil {
+	if shape := a.sess.output.activeReqShape.Load(); shape != nil {
 		a.setPromptTokenCalibration(promptTokens, *shape)
 	}
 }
@@ -112,7 +115,7 @@ func (a *Agent) configuredOutputBudget(explicit int) int {
 	if explicit != 0 {
 		return explicit
 	}
-	return a.outputBudget
+	return a.sess.output.outputBudget
 }
 
 func requestCalibrationShapeOf(req provider.Request) requestCalibrationShape {
@@ -183,7 +186,7 @@ func (a *Agent) calibratedPromptTokens(shape requestCalibrationShape) (int, bool
 	if shape.requestChars <= 0 {
 		return 0, false
 	}
-	if cal := a.promptCalibration.Load(); cal != nil && cal.requestChars > 0 {
+	if cal := a.sess.output.promptCalibration.Load(); cal != nil && cal.requestChars > 0 {
 		ratio := float64(cal.promptTokens) / float64(cal.requestChars)
 		if ratio > 0.05 && ratio < 2 {
 			trustedChars := shape.requestChars

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -84,7 +84,7 @@ func TestSessionSwapKeepsPromptCalibration(t *testing.T) {
 
 func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
 	// Oversized tool bodies are deterministically shortened for the single
 	// summarizer request (no multi-span). The guard must still fit one call.
 	toolBody := strings.Repeat("file line content here. ", 20_000) // ~480K chars
@@ -119,7 +119,7 @@ func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 // all deterministic shorteners must fail once (no multi-span split).
 func TestSharedWindowFoldRejectsUnshortenableOverBudgetInput(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
 	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 200_000)}}
 	_, err := a.foldToSummary(context.Background(), fold, "")
 	if err == nil || !strings.Contains(err.Error(), "exceeds single-request budget") {
@@ -139,11 +139,11 @@ func (p *sharedWindowTestProvider) SharedWindowInputPolicy() provider.SharedWind
 
 func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}}
 	// Calibrate this session at one token per rune. The 950K prompt fits, but
 	// not beside the provider's full 128K output default.
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
 	a.setPromptTokenCalibration(950_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
 
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{Messages: msgs})
@@ -163,7 +163,7 @@ func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 
 func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	current := append(previous, provider.Message{
@@ -188,7 +188,7 @@ func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 
 func TestCalibratedOutputBudgetKeepsCJKConservativeFloor(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	// Enough unrepresented CJK that the reply no longer fits beside it: at the
@@ -237,7 +237,7 @@ func TestCalibrationIgnoresNonReplayableOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysOrdinaryReasoning: true}}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -258,7 +258,7 @@ func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewReplayItems(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysResponsesItems: true}}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -297,9 +297,10 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}}
 	sess := NewSession("")
 	sess.Replace(msgs)
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576, compactRatio: 2}, prov: prov, tools: tool.NewRegistry(), session: sess, // disable auto maintenance for this output-clip test
-		outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
+	// compactRatio 2 disables auto maintenance for this output-clip test
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576, compactRatio: 2}, prov: prov, tools: tool.NewRegistry(),
+		sess: sessionRuntime{conversation: sess, output: outputBudgetState{outputBudget: prov.budget}}}
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
 	a.setPromptTokenCalibration(950_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
 
 	prepared, err := a.prepareSamplingRequest(context.Background())
@@ -313,9 +314,9 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 
 func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 1_045_000)}}
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 1_045_000})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 1_045_000})
 	a.setPromptTokenCalibration(1_045_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
 
 	_, _, err := a.effectiveOutputBudget(provider.Request{Messages: msgs})
@@ -326,7 +327,7 @@ func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 
 func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: false}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 	})
@@ -337,7 +338,7 @@ func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 
 func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages:  []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 		MaxTokens: -1,
@@ -349,9 +350,9 @@ func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 
 func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
 	region := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 50_000)}}
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 50_000})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 50_000})
 	a.setPromptTokenCalibration(50_000, requestCalibrationShapeOf(provider.Request{Messages: region}))
 
 	if _, _, err := a.summarize(context.Background(), region, ""); err != nil {
@@ -364,7 +365,7 @@ func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 
 func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true, finish: "length"}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, outputBudgetState: outputBudgetState{outputBudget: prov.budget}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
 
 	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{{
 		Role: provider.RoleUser, Content: "retain every durable fact",
@@ -379,19 +380,19 @@ func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 
 func TestSetSessionResetsPerTranscriptUsageState(t *testing.T) {
 	a := &Agent{}
-	a.lastUsage.Store(&provider.Usage{PromptTokens: 200_000})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 200_000})
 	active := requestCalibrationShape{requestChars: 900_000, compactChars: 850_000}
-	a.activeReqShape.Store(&active)
+	a.sess.output.activeReqShape.Store(&active)
 	a.setPromptTokenCalibration(200_000, requestCalibrationShape{requestChars: 1_000_000, compactChars: 950_000})
 	a.SetSession(NewSession("new"))
 
-	if got := a.lastUsage.Load(); got != nil {
+	if got := a.sess.output.lastUsage.Load(); got != nil {
 		t.Fatalf("lastUsage survived session switch: %+v", got)
 	}
-	if got := a.activeReqShape.Load(); got != nil {
+	if got := a.sess.output.activeReqShape.Load(); got != nil {
 		t.Fatalf("activeReqShape survived session switch: %+v", got)
 	}
-	if got := a.promptCalibration.Load(); got == nil {
+	if got := a.sess.output.promptCalibration.Load(); got == nil {
 		t.Fatal("promptCalibration was dropped on session switch; the tokenizer ratio outlives the transcript")
 	}
 }
@@ -399,10 +400,10 @@ func TestSetSessionResetsPerTranscriptUsageState(t *testing.T) {
 func TestLatestUsagePairsWithActiveRequestSize(t *testing.T) {
 	a := &Agent{}
 	active := requestCalibrationShape{requestChars: 222, compactChars: 111, cjkRunes: 22, cjkBytes: 66}
-	a.activeReqShape.Store(&active)
+	a.sess.output.activeReqShape.Store(&active)
 	a.storeLatestRequestUsage(&provider.Usage{PromptTokens: 100})
 
-	if got := a.promptCalibration.Load(); got == nil || got.promptTokens != 100 || got.requestChars != 222 || got.compactChars != 111 || got.cjkRunes != 22 || got.cjkBytes != 66 {
+	if got := a.sess.output.promptCalibration.Load(); got == nil || got.promptTokens != 100 || got.requestChars != 222 || got.compactChars != 111 || got.cjkRunes != 22 || got.cjkBytes != 66 {
 		t.Fatalf("promptCalibration = %+v, want promptTokens=100 requestChars=222 compactChars=111 cjkRunes=22 cjkBytes=66", got)
 	}
 }
@@ -410,7 +411,7 @@ func TestLatestUsagePairsWithActiveRequestSize(t *testing.T) {
 func TestEstimatedUsageDoesNotReplacePromptCalibration(t *testing.T) {
 	a := &Agent{}
 	active := requestCalibrationShape{requestChars: 200_000, compactChars: 100_000}
-	a.activeReqShape.Store(&active)
+	a.sess.output.activeReqShape.Store(&active)
 	a.setPromptTokenCalibration(50_000, requestCalibrationShape{requestChars: 100_000, compactChars: 80_000})
 
 	a.storeLatestRequestUsage(&provider.Usage{
@@ -419,11 +420,11 @@ func TestEstimatedUsageDoesNotReplacePromptCalibration(t *testing.T) {
 		Estimated:    true,
 	})
 
-	got := a.promptCalibration.Load()
+	got := a.sess.output.promptCalibration.Load()
 	if got == nil || got.promptTokens != 50_000 || got.requestChars != 100_000 || got.compactChars != 80_000 {
 		t.Fatalf("estimated usage replaced provider calibration: %+v", got)
 	}
-	if latest := a.lastUsage.Load(); latest == nil || !latest.Estimated {
+	if latest := a.sess.output.lastUsage.Load(); latest == nil || !latest.Estimated {
 		t.Fatalf("estimated usage was not retained for accounting: %+v", latest)
 	}
 }

--- a/internal/agent/plan_contract.go
+++ b/internal/agent/plan_contract.go
@@ -17,8 +17,8 @@ func (a *Agent) SetPlanContract(plan *plancontract.Plan) {
 	if a == nil {
 		return
 	}
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
 	if plan == nil {
 		a.planContract = nil
 		return
@@ -31,8 +31,8 @@ func (a *Agent) planContractSnapshot() *plancontract.Plan {
 	if a == nil {
 		return nil
 	}
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
 	if a.planContract == nil {
 		return nil
 	}

--- a/internal/agent/positional_compression_test.go
+++ b/internal/agent/positional_compression_test.go
@@ -38,7 +38,7 @@ func TestSummarizeFromPreservesLocalOnlyOutsideModelAndArchive(t *testing.T) {
 	if !reflect.DeepEqual(sess.Snapshot(), before) {
 		t.Fatalf("canonical transcript changed: before=%+v after=%+v", before, sess.Snapshot())
 	}
-	if len(a.compactionState.Projection.Messages) == 0 {
+	if len(a.sess.compactionState.Projection.Messages) == 0 {
 		t.Fatal("expected summarize-from projection")
 	}
 	assertLocalOnlyAbsentFromSummary(t, prov, a, local)
@@ -70,7 +70,7 @@ func TestSummarizeUpToPreservesLocalOnlyOutsideModelAndArchive(t *testing.T) {
 	if !reflect.DeepEqual(sess.Snapshot(), before) {
 		t.Fatalf("canonical transcript changed: before=%+v after=%+v", before, sess.Snapshot())
 	}
-	if len(a.compactionState.Projection.Messages) == 0 {
+	if len(a.sess.compactionState.Projection.Messages) == 0 {
 		t.Fatal("expected summarize-up-to projection")
 	}
 	assertLocalOnlyAbsentFromSummary(t, prov, a, local)
@@ -90,12 +90,12 @@ func TestSummarizeAtProjectionBoundaryReportsFoldedAnchor(t *testing.T) {
 	if err := a.SummarizeUpTo(context.Background(), 3); err != nil {
 		t.Fatalf("initial SummarizeUpTo: %v", err)
 	}
-	version := a.compactionState.Projection.ProjectionVersion
+	version := a.sess.compactionState.Projection.ProjectionVersion
 	err := a.SummarizeFrom(context.Background(), 1)
 	if err == nil || !strings.Contains(err.Error(), "no longer present in the model context") {
 		t.Fatalf("folded-boundary error = %v", err)
 	}
-	if a.compactionState.Projection.ProjectionVersion != version {
+	if a.sess.compactionState.Projection.ProjectionVersion != version {
 		t.Fatal("folded-boundary retry replaced the projection")
 	}
 	if !reflect.DeepEqual(sess.Snapshot(), before) {
@@ -115,7 +115,7 @@ func TestSummarizeAtProjectionBoundaryReportsNoSavings(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "compressed context would not be smaller") {
 		t.Fatalf("no-savings error = %v", err)
 	}
-	if len(a.compactionState.Projection.Messages) != 0 {
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("no-savings positional compression installed a projection")
 	}
 }
@@ -127,12 +127,12 @@ func assertLocalOnlyAbsentFromSummary(t *testing.T, prov *fakeProvider, a *Agent
 	if len(prov.got) < 2 || strings.Contains(prov.got[1].Content, local.Content) || strings.Contains(prov.got[1].Content, local.ReasoningContent) {
 		t.Fatalf("local-only output leaked into summarizer prompt: %+v", prov.got)
 	}
-	for _, m := range a.compactionState.Projection.Messages {
+	for _, m := range a.sess.compactionState.Projection.Messages {
 		if m.LocalOnly || strings.Contains(m.Content, local.Content) || strings.Contains(m.Content, local.ReasoningContent) {
 			t.Fatalf("local-only output entered projection: %+v", m)
 		}
 	}
-	if a.compactionState.LastReceipt != nil && a.compactionState.LastReceipt.Archive != "" {
-		t.Fatalf("checkpoint must not create archives, got %q", a.compactionState.LastReceipt.Archive)
+	if a.sess.compactionState.LastReceipt != nil && a.sess.compactionState.LastReceipt.Archive != "" {
+		t.Fatalf("checkpoint must not create archives, got %q", a.sess.compactionState.LastReceipt.Archive)
 	}
 }

--- a/internal/agent/postllmcall_flow_test.go
+++ b/internal/agent/postllmcall_flow_test.go
@@ -60,7 +60,7 @@ func TestPostLLMCallAbsentStreamsReasoningLive(t *testing.T) {
 	if joined := strings.Join(reasoningEvents, ""); joined != "think A think B" {
 		t.Fatalf("streamed reasoning = %q, want the full chain", joined)
 	}
-	if got := assistantReasoning(a.session.Messages); got != "think A think B" {
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "think A think B" {
 		t.Fatalf("stored reasoning = %q, want the untransformed chain", got)
 	}
 }
@@ -87,7 +87,7 @@ func TestPostLLMCallTransformsReasoningOnce(t *testing.T) {
 	if len(h.postLLMTurns) != 1 || h.postLLMTurns[0] != 1 {
 		t.Fatalf("hook turns = %v, want [1]", h.postLLMTurns)
 	}
-	if got := assistantReasoning(a.session.Messages); got != "TRANSLATED" {
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "TRANSLATED" {
 		t.Fatalf("stored reasoning = %q, want the hook's replacement", got)
 	}
 }
@@ -100,7 +100,7 @@ func TestPostLLMCallKeepsOriginalForReasoningRoundTripProvider(t *testing.T) {
 	if err := a.Run(context.Background(), "go"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := assistantReasoning(a.session.Messages); got != "think A think B" {
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "think A think B" {
 		t.Fatalf("stored reasoning = %q, want raw provider reasoning for replay", got)
 	}
 }
@@ -127,7 +127,7 @@ func TestPostLLMCallKeepsOriginalForProviderReasoningMetadata(t *testing.T) {
 	if len(reasoningEvents) != 1 || reasoningEvents[0] != "TRANSLATED" {
 		t.Fatalf("want transformed reasoning shown live, got %v", reasoningEvents)
 	}
-	for _, m := range a.session.Messages {
+	for _, m := range a.sess.conversation.Messages {
 		if m.Role != provider.RoleAssistant {
 			continue
 		}
@@ -187,10 +187,10 @@ func TestPostLLMCallKeepsSignedReasoningOriginal(t *testing.T) {
 	if len(reasoningEvents) != 1 || reasoningEvents[0] != "TRANSLATED" {
 		t.Fatalf("want the transformed reasoning shown live, got %v", reasoningEvents)
 	}
-	if got := assistantReasoning(a.session.Messages); got != "think A think B" {
+	if got := assistantReasoning(a.sess.conversation.Messages); got != "think A think B" {
 		t.Fatalf("stored reasoning = %q, want the original (signature pins it)", got)
 	}
-	for _, m := range a.session.Messages {
+	for _, m := range a.sess.conversation.Messages {
 		if m.Role == provider.RoleAssistant && m.ReasoningSignature != "sig-xyz" {
 			t.Fatalf("stored signature = %q, want sig-xyz alongside its original text", m.ReasoningSignature)
 		}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -17,13 +17,13 @@ var ErrCompactionRequired = errors.New("context exceeds provider limit and compa
 // projection plus any post-projection appends, otherwise the full canonical
 // transcript. LocalOnly stripping still happens in prepareSamplingRequest.
 func (a *Agent) modelVisibleMessages() []provider.Message {
-	if a == nil || a.session == nil {
+	if a == nil || a.sess.conversation == nil {
 		return nil
 	}
-	msgs, version := a.session.snapshotMessagesVersion()
-	a.compactionMu.Lock()
-	st := a.compactionState
-	a.compactionMu.Unlock()
+	msgs, version := a.sess.conversation.snapshotMessagesVersion()
+	a.sess.compactionMu.Lock()
+	st := a.sess.compactionState
+	a.sess.compactionMu.Unlock()
 	if projectionValid(st, msgs, version, a.currentPromptCacheKey()) {
 		if visible := modelVisibleFromProjection(st.Projection, msgs); len(visible) > 0 {
 			return visible
@@ -36,9 +36,9 @@ func (a *Agent) currentProjectionVersion() uint64 {
 	if a == nil {
 		return 0
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
-	return a.compactionState.Projection.ProjectionVersion
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
+	return a.sess.compactionState.Projection.ProjectionVersion
 }
 
 // currentPromptCacheKey is the lineage key for the bound session + model.
@@ -46,13 +46,13 @@ func (a *Agent) currentPromptCacheKey() string {
 	if a == nil {
 		return ""
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
 	return a.currentPromptCacheKeyLocked()
 }
 
 func (a *Agent) currentPromptCacheKeyLocked() string {
-	return promptCacheKey(a.workspaceID, BranchID(a.sessionPath), a.modelRef)
+	return promptCacheKey(a.workspaceID, BranchID(a.sess.path), a.modelRef)
 }
 
 // InvalidateProjection drops the in-memory and on-disk projection after
@@ -61,13 +61,13 @@ func (a *Agent) InvalidateProjection() {
 	if a == nil {
 		return
 	}
-	a.compactionMu.Lock()
-	path := a.sessionPath
-	a.compactionState = CompactionState{}
-	a.compactionMu.Unlock()
-	a.compaction.stuck = false
-	a.compaction.consecutive = 0
-	a.compaction.lastTurn.Store(0)
+	a.sess.compactionMu.Lock()
+	path := a.sess.path
+	a.sess.compactionState = CompactionState{}
+	a.sess.compactionMu.Unlock()
+	a.sess.compaction.stuck = false
+	a.sess.compaction.consecutive = 0
+	a.sess.compaction.lastTurn.Store(0)
 	if path != "" {
 		if err := RemoveCompactionState(path); err != nil {
 			slog.Warn("agent: remove context projection", "err", err)
@@ -83,11 +83,11 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	if a == nil {
 		return
 	}
-	a.compactionMu.Lock()
-	a.sessionPath = sessionPath
-	a.compactionState = CompactionState{}
-	a.checkpointState = "none"
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	a.sess.path = sessionPath
+	a.sess.compactionState = CompactionState{}
+	a.sess.checkpointState = "none"
+	a.sess.compactionMu.Unlock()
 	if sessionPath == "" {
 		a.resetCompactionState()
 		return
@@ -103,7 +103,7 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 		a.resetCompactionState()
 		return
 	}
-	a.compactionMu.Lock()
+	a.sess.compactionMu.Lock()
 	key := a.currentPromptCacheKeyLocked()
 	normalized, keyOK := lineageKeyCompatible(st.PromptCacheKey, key)
 	// Keep receipt-only blocked/failed sidecars (no projection body) and legacy
@@ -117,17 +117,17 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 		// the projection body still matches the canonical covered prefix.
 		var msgs []provider.Message
 		var version uint64
-		if a.session != nil {
-			msgs, version = a.session.snapshotMessagesVersion()
+		if a.sess.conversation != nil {
+			msgs, version = a.sess.conversation.snapshotMessagesVersion()
 		}
 		if projectionContentValid(st, msgs, version) {
 			normalized, keyOK = key, true
 		}
 	}
 	if (key != "" && !keyOK) || !hasMaintenanceSignal {
-		a.compactionState = CompactionState{}
-		a.checkpointState = "none"
-		a.compactionMu.Unlock()
+		a.sess.compactionState = CompactionState{}
+		a.sess.checkpointState = "none"
+		a.sess.compactionMu.Unlock()
 		return
 	}
 	// Only rewrite legacy native-editing lineage keys; exact matches stay pure-read.
@@ -139,26 +139,26 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	// Only mark restored when the projection still matches the transcript.
 	var msgs []provider.Message
 	var version uint64
-	if a.session != nil {
-		msgs, version = a.session.snapshotMessagesVersion()
+	if a.sess.conversation != nil {
+		msgs, version = a.sess.conversation.snapshotMessagesVersion()
 	}
 	valid := len(st.Projection.Messages) > 0 && projectionValid(st, msgs, version, key)
 	if !valid && len(st.Projection.Messages) > 0 {
 		// Keep blocked receipts / telemetry; drop unusable projection body.
 		st.Projection = ContextProjection{}
 	}
-	a.compactionState = st
+	a.sess.compactionState = st
 	if valid {
-		a.checkpointState = "restored"
+		a.sess.checkpointState = "restored"
 		if needsNormalization {
 			if err := a.persistCompactionStateLocked(); err != nil {
 				slog.Warn("agent: persist normalized projection lineage", "err", err)
 			}
 		}
 	} else {
-		a.checkpointState = "none"
+		a.sess.checkpointState = "none"
 	}
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Unlock()
 }
 
 // lineageKeyCompatible reports whether a stored PromptCacheKey still belongs to
@@ -187,10 +187,10 @@ func lineageKeyCompatible(stored, current string) (normalized string, ok bool) {
 }
 
 func (a *Agent) resetCompactionState() {
-	a.compactionMu.Lock()
-	a.compactionState = CompactionState{}
-	a.checkpointState = "none"
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	a.sess.compactionState = CompactionState{}
+	a.sess.checkpointState = "none"
+	a.sess.compactionMu.Unlock()
 }
 
 // BindSessionPath rebinds projection persistence to path. When loadSidecar is
@@ -204,15 +204,15 @@ func (a *Agent) BindSessionPath(path string, loadSidecar bool) {
 		a.LoadProjectionSidecar(path)
 		return
 	}
-	a.compactionMu.Lock()
-	a.sessionPath = path
-	a.compactionState = CompactionState{}
-	a.checkpointState = "none"
-	a.cacheState = CacheStateUnknown
-	a.compactionMu.Unlock()
-	a.compaction.stuck = false
-	a.compaction.consecutive = 0
-	a.compaction.lastTurn.Store(0)
+	a.sess.compactionMu.Lock()
+	a.sess.path = path
+	a.sess.compactionState = CompactionState{}
+	a.sess.checkpointState = "none"
+	a.sess.cacheState = CacheStateUnknown
+	a.sess.compactionMu.Unlock()
+	a.sess.compaction.stuck = false
+	a.sess.compaction.consecutive = 0
+	a.sess.compaction.lastTurn.Store(0)
 }
 
 // SetSessionPath binds the transcript path used for projection persistence.
@@ -220,9 +220,9 @@ func (a *Agent) SetSessionPath(path string) {
 	if a == nil {
 		return
 	}
-	a.compactionMu.Lock()
-	a.sessionPath = path
-	a.compactionMu.Unlock()
+	a.sess.compactionMu.Lock()
+	a.sess.path = path
+	a.sess.compactionMu.Unlock()
 }
 
 // SessionPath returns the bound transcript path.
@@ -230,9 +230,9 @@ func (a *Agent) SessionPath() string {
 	if a == nil {
 		return ""
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
-	return a.sessionPath
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
+	return a.sess.path
 }
 
 // SetCacheState records the resume-time cache estimate without rewriting history.
@@ -245,14 +245,14 @@ func (a *Agent) SetCacheState(state string) {
 	default:
 		state = CacheStateUnknown
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
-	a.cacheState = state
-	if a.compactionState.SchemaVersion == 0 && len(a.compactionState.Projection.Messages) == 0 {
-		a.compactionState.SchemaVersion = compactionStateSchemaCurrent
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
+	a.sess.cacheState = state
+	if a.sess.compactionState.SchemaVersion == 0 && len(a.sess.compactionState.Projection.Messages) == 0 {
+		a.sess.compactionState.SchemaVersion = compactionStateSchemaCurrent
 	}
-	a.compactionState.LastCacheState = state
-	a.compactionState.UpdatedAt = time.Now().UTC()
+	a.sess.compactionState.LastCacheState = state
+	a.sess.compactionState.UpdatedAt = time.Now().UTC()
 }
 
 // CacheState returns the last estimated cache warm/cold/unknown label.
@@ -260,19 +260,19 @@ func (a *Agent) CacheState() string {
 	if a == nil {
 		return CacheStateUnknown
 	}
-	a.compactionMu.Lock()
-	defer a.compactionMu.Unlock()
-	if a.cacheState == "" {
+	a.sess.compactionMu.Lock()
+	defer a.sess.compactionMu.Unlock()
+	if a.sess.cacheState == "" {
 		return CacheStateUnknown
 	}
-	return a.cacheState
+	return a.sess.cacheState
 }
 
 func (a *Agent) persistCompactionStateLocked() error {
-	if a.sessionPath == "" {
+	if a.sess.path == "" {
 		return nil
 	}
-	return SaveCompactionState(a.sessionPath, a.compactionState)
+	return SaveCompactionState(a.sess.path, a.sess.compactionState)
 }
 
 // promptCacheKey builds a stable lineage key for session + model identity.

--- a/internal/agent/projection_test.go
+++ b/internal/agent/projection_test.go
@@ -163,13 +163,13 @@ func TestCompactToProjectionLeavesCanonicalIntact(t *testing.T) {
 			t.Fatalf("canonical message %d changed", i)
 		}
 	}
-	if len(a.compactionState.Projection.Messages) == 0 {
+	if len(a.sess.compactionState.Projection.Messages) == 0 {
 		t.Fatal("expected projection messages")
 	}
 	// Projection must be shorter than canonical.
-	if estimateMessagesTokens(a.compactionState.Projection.Messages) >= estimateMessagesTokens(before) {
+	if estimateMessagesTokens(a.sess.compactionState.Projection.Messages) >= estimateMessagesTokens(before) {
 		t.Fatalf("projection did not shrink: proj=%d src=%d",
-			estimateMessagesTokens(a.compactionState.Projection.Messages),
+			estimateMessagesTokens(a.sess.compactionState.Projection.Messages),
 			estimateMessagesTokens(before))
 	}
 	// Sidecar must exist and reload with an applied summary receipt (v3 does not
@@ -217,7 +217,7 @@ func TestCompactFailureDoesNotWriteMechanicalMarker(t *testing.T) {
 			t.Fatalf("mechanical marker written into history: %q", m.Content)
 		}
 	}
-	if len(a.compactionState.Projection.Messages) != 0 {
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("failed compaction installed a projection")
 	}
 }
@@ -241,7 +241,7 @@ func TestFixedEarlyUserTurnsStableAcrossCompactions(t *testing.T) {
 	if err := a.CompactNow(context.Background(), ""); err != nil {
 		t.Fatalf("compact1: %v", err)
 	}
-	firstPrefix := earlyUserPrefix(a.compactionState.Projection.Messages)
+	firstPrefix := earlyUserPrefix(a.sess.compactionState.Projection.Messages)
 	// Grow the session and compact again.
 	for i := range 8 {
 		sess.Add(provider.Message{Role: provider.RoleUser, Content: "later-fact-" + strings.Repeat("z", 30) + string(rune('0'+i))})
@@ -250,7 +250,7 @@ func TestFixedEarlyUserTurnsStableAcrossCompactions(t *testing.T) {
 	// Simulate a projected request reporting a very different calibration from
 	// the pre-projection canonical estimate. This remains useful for tail sizing,
 	// but must not change which early turns define the stable prefix.
-	a.lastUsage.Store(&provider.Usage{PromptTokens: charsOfMessages(sess.Messages)})
+	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: charsOfMessages(sess.Messages)})
 	a.setPromptTokenCalibration(charsOfMessages(sess.Messages), requestCalibrationShapeOf(provider.Request{Messages: sess.Messages}))
 	if got := a.tokPerChar(); got < 0.9 || got > 1.1 {
 		t.Fatalf("test did not install the intended dynamic calibration: %f", got)
@@ -259,13 +259,13 @@ func TestFixedEarlyUserTurnsStableAcrossCompactions(t *testing.T) {
 	if err := a.CompactNow(context.Background(), ""); err != nil {
 		t.Fatalf("compact2: %v", err)
 	}
-	secondPrefix := earlyUserPrefix(a.compactionState.Projection.Messages)
+	secondPrefix := earlyUserPrefix(a.sess.compactionState.Projection.Messages)
 	if firstPrefix != secondPrefix {
 		t.Fatalf("early user prefix drifted across compactions:\n1: %q\n2: %q", firstPrefix, secondPrefix)
 	}
 	// Exactly one summary in the projection (A1 rolling merge).
 	summaries := 0
-	for _, m := range a.compactionState.Projection.Messages {
+	for _, m := range a.sess.compactionState.Projection.Messages {
 		if isCompactionSummary(m) {
 			summaries++
 		}
@@ -312,7 +312,7 @@ func TestLocalOnlyExcludedFromCompactionRequest(t *testing.T) {
 			t.Fatal("LocalOnly content reached summarizer")
 		}
 	}
-	for _, m := range a.compactionState.Projection.Messages {
+	for _, m := range a.sess.compactionState.Projection.Messages {
 		if m.LocalOnly || strings.Contains(m.Content, "secret local only") {
 			t.Fatal("LocalOnly content entered projection")
 		}
@@ -343,11 +343,11 @@ func TestArchiveDirIgnoredOnCheckpointInstall(t *testing.T) {
 	if err := a.CompactNow(context.Background(), ""); err != nil {
 		t.Fatalf("CompactNow with unusable ArchiveDir: %v", err)
 	}
-	if len(a.compactionState.Projection.Messages) == 0 {
+	if len(a.sess.compactionState.Projection.Messages) == 0 {
 		t.Fatal("expected projection despite unusable ArchiveDir")
 	}
-	if a.compactionState.LastReceipt != nil && a.compactionState.LastReceipt.Archive != "" {
-		t.Fatalf("checkpoint must not create archives, got %q", a.compactionState.LastReceipt.Archive)
+	if a.sess.compactionState.LastReceipt != nil && a.sess.compactionState.LastReceipt.Archive != "" {
+		t.Fatalf("checkpoint must not create archives, got %q", a.sess.compactionState.LastReceipt.Archive)
 	}
 }
 
@@ -359,11 +359,11 @@ func visibleContext(a *Agent) []provider.Message {
 	if a == nil {
 		return nil
 	}
-	if msgs := a.compactionState.Projection.Messages; len(msgs) > 0 {
+	if msgs := a.sess.compactionState.Projection.Messages; len(msgs) > 0 {
 		return msgs
 	}
-	if a.session != nil {
-		return a.session.Snapshot()
+	if a.sess.conversation != nil {
+		return a.sess.conversation.Snapshot()
 	}
 	return nil
 }
@@ -471,7 +471,7 @@ func TestManualCompactReportsSummarizerFailure(t *testing.T) {
 			t.Fatalf("mechanical marker written: %q", m.Content)
 		}
 	}
-	if len(a.compactionState.Projection.Messages) != 0 {
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
 		t.Fatal("failed compact installed a projection")
 	}
 	// CompactionDone with empty summary resolves the UI placeholder.

--- a/internal/agent/projection_valid_test.go
+++ b/internal/agent/projection_valid_test.go
@@ -160,15 +160,15 @@ func TestLoadProjectionSidecarRebindsMatchingContentAcrossLineage(t *testing.T) 
 	// New() already called LoadProjectionSidecar; the projection body matches
 	// the canonical covered prefix, so it must be rebound to the current key
 	// instead of being dropped (upgrade / model-switch path).
-	if len(a.compactionState.Projection.Messages) == 0 {
+	if len(a.sess.compactionState.Projection.Messages) == 0 {
 		t.Fatal("matching projection body was dropped on lineage change")
 	}
 	wantKey := promptCacheKey("ws", BranchID(path), "this-model")
-	if a.compactionState.PromptCacheKey != wantKey {
-		t.Fatalf("PromptCacheKey = %q, want %q", a.compactionState.PromptCacheKey, wantKey)
+	if a.sess.compactionState.PromptCacheKey != wantKey {
+		t.Fatalf("PromptCacheKey = %q, want %q", a.sess.compactionState.PromptCacheKey, wantKey)
 	}
-	if a.checkpointState != "restored" {
-		t.Fatalf("checkpointState = %q, want restored", a.checkpointState)
+	if a.sess.checkpointState != "restored" {
+		t.Fatalf("checkpointState = %q, want restored", a.sess.checkpointState)
 	}
 	// The rebind must be persisted so the next launch does not re-downgrade.
 	disk, ok, err := LoadCompactionState(path)
@@ -205,8 +205,8 @@ func TestLoadProjectionSidecarDropsForeignCacheKey(t *testing.T) {
 	}, event.Discard)
 	// New() already called LoadProjectionSidecar; mismatched content must drop
 	// the projection body and keep the sidecar file for the other model.
-	if len(a.compactionState.Projection.Messages) != 0 {
-		t.Fatalf("foreign projection loaded: %+v", a.compactionState.Projection)
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
+		t.Fatalf("foreign projection loaded: %+v", a.sess.compactionState.Projection)
 	}
 	if _, ok, err := LoadCompactionState(path); err != nil || !ok {
 		t.Fatalf("sidecar should remain on disk: ok=%v err=%v", ok, err)
@@ -308,7 +308,7 @@ func TestCompactInstallsCoveredPrefixHash(t *testing.T) {
 	if err := a.CompactNow(context.Background(), ""); err != nil {
 		t.Fatal(err)
 	}
-	st := a.compactionState
+	st := a.sess.compactionState
 	if st.Projection.CoveredPrefixHash == "" {
 		t.Fatal("CoveredPrefixHash not set")
 	}

--- a/internal/agent/repeat_guard_test.go
+++ b/internal/agent/repeat_guard_test.go
@@ -101,7 +101,7 @@ func TestRepeatGuardBlocksRepeatedSuccessfulBashFileWrite(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Fatalf("bash executed %d times, want 2 before the repeat guard blocks", got)
 	}
-	results := toolResults(a.session, "bash")
+	results := toolResults(a.sess.conversation, "bash")
 	if len(results) != 3 {
 		t.Fatalf("tool results = %d, want 3", len(results))
 	}
@@ -130,7 +130,7 @@ func TestRepeatGuardAllowsRepeatedNonWritingBashCommand(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != 3 {
 		t.Fatalf("bash executed %d times, want 3 for non-writing commands", got)
 	}
-	if last := lastToolResult(a.session, "bash"); strings.Contains(last, "[loop guard]") {
+	if last := lastToolResult(a.sess.conversation, "bash"); strings.Contains(last, "[loop guard]") {
 		t.Fatalf("non-writing bash should not trip the repeat guard, got %q", last)
 	}
 }
@@ -238,7 +238,7 @@ func TestRepeatGuardAllowsTwoRepeatedWriterSuccesses(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != 2 {
 		t.Fatalf("writer executed %d times, want 2 before the guard threshold", got)
 	}
-	if last := lastToolResult(a.session, "write_file"); strings.Contains(last, "[loop guard]") {
+	if last := lastToolResult(a.sess.conversation, "write_file"); strings.Contains(last, "[loop guard]") {
 		t.Fatalf("second repeated writer call should still be allowed, got %q", last)
 	}
 }
@@ -272,7 +272,7 @@ func TestRepeatGuardBlocksStaleEditLoopAcrossSuccessfulReads(t *testing.T) {
 	if got := atomic.LoadInt32(&readCalls); got != 2 {
 		t.Fatalf("read_file executed %d times, want 2", got)
 	}
-	last := lastToolResult(a.session, "edit_file")
+	last := lastToolResult(a.sess.conversation, "edit_file")
 	for _, want := range []string{"[loop guard]", "already failed 2 times", "Re-reading alone"} {
 		if !strings.Contains(last, want) {
 			t.Fatalf("blocked stale edit result should mention %q, got %q", want, last)
@@ -311,7 +311,7 @@ func TestRepeatGuardRetainsStaleEditFailuresAcrossGoalScope(t *testing.T) {
 	if got := atomic.LoadInt32(&editCalls); got != 2 {
 		t.Fatalf("edit_file executed %d times across one goal scope, want 2", got)
 	}
-	if last := lastToolResult(a.session, "edit_file"); !strings.Contains(last, "[loop guard]") {
+	if last := lastToolResult(a.sess.conversation, "edit_file"); !strings.Contains(last, "[loop guard]") {
 		t.Fatalf("third goal-scope edit should be blocked, got %q", last)
 	}
 }

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -236,7 +236,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	if rawContent == "" {
 		rawContent = a.turnInput
 	}
-	a.session.Add(provider.Message{
+	a.sess.conversation.Add(provider.Message{
 		Role: provider.RoleUser, Content: input, RawContent: rawContent,
 		Images: userImages(ctx), CreatedAt: userCreatedAt,
 	})
@@ -272,7 +272,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		// guidance (with a prefix), not a new task. One cache miss per
 		// steer is unavoidable — the model must see the new instruction.
 		if text, itemID, ok := a.consumeSteer(); ok {
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
+			a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
 			a.sink.Emit(event.Event{Kind: event.Steer, Text: text, ItemID: itemID})
 		} else if itemID != "" {
 			// Loader failed after dequeue: durable entry stays for inspection
@@ -281,8 +281,8 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
-		prevPrefixShape := a.lastPrefixShape
-		if !a.haveLastPrefixShape {
+		prevPrefixShape := a.sess.lastPrefixShape
+		if !a.sess.haveLastPrefixShape {
 			prevPrefixShape = prefixShape
 		}
 
@@ -291,7 +291,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		// any prefix change to the operation that actually caused it, instead
 		// of a generic rewrite signal that also fires on local-only metadata
 		// edits.
-		contentReasons := a.session.DrainContentRewriteReasons()
+		contentReasons := a.sess.conversation.DrainContentRewriteReasons()
 
 		// Prefix shape is captured once before sampling and frozen for the
 		// whole attempt lifecycle — stream retries must not rewrite session
@@ -312,8 +312,8 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 			a.recordInterruptedDisplay(text, reasoning, partialCalls, true, state.workDurationMs())
 			return err
 		}
-		a.lastPrefixShape = prefixShape
-		a.haveLastPrefixShape = true
+		a.sess.lastPrefixShape = prefixShape
+		a.sess.haveLastPrefixShape = true
 		a.emitTurnUsage(usage, &cacheDiagnostics)
 		a.observeRunBudget(state, usage)
 		if msg, ok := finishReasonMessage(usage); ok {
@@ -325,7 +325,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *runLoopState) error {
 		// archive. Most OpenAI-compatible backends do not replay it; providers
 		// with an explicit round-trip contract retain the raw provider text.
 		calls = a.withPreviewFileDiffs(ctx, calls)
-		a.session.Add(provider.Message{
+		a.sess.conversation.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,
 			ReasoningContent:   reasoning,
@@ -578,7 +578,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 				return false, fmt.Errorf("model finished without a visible final answer %d times", state.emptyFinalBlocks)
 			}
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEmptyFinal, Text: emptyFinalNotice(), Detail: emptyFinalNoticeDetail(a.prov.Name(), usage, len(reasoning))})
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
+			a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
 			a.contextManager().ObserveUsage(usage)
 			return true, nil
 		}
@@ -586,7 +586,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *runLoopState, te
 	if state.executorHandoff && !state.usedAnyTool && state.handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(state.input, text) {
 		state.handoffNudges++
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeExecutorHandoff, Text: executorHandoffNoticeText(), Detail: "executor answered without taking any action; nudging it to use its tools"})
-		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(executorHandoffRetryMessage())})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(executorHandoffRetryMessage())})
 		a.contextManager().ObserveUsage(usage)
 		return true, nil
 	}
@@ -615,7 +615,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 	if len(unavailableContextTools) > 0 && state.contextToolRepairs > 0 {
 		msg := fmt.Sprintf("blocked: context-unavailable tools were called again after the repair instruction: %s", strings.Join(unavailableContextTools, ", "))
 		for _, call := range calls {
-			a.session.Add(provider.Message{Role: provider.RoleTool, Content: msg, ToolCallID: call.ID, Name: call.Name})
+			a.sess.conversation.Add(provider.Message{Role: provider.RoleTool, Content: msg, ToolCallID: call.ID, Name: call.Name})
 		}
 		if hasVisibleFinalAnswer(text) {
 			return a.handleFinalResponse(ctx, state, text, reasoning, usage)
@@ -652,7 +652,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 		if i < len(batch.executions) {
 			msg.ToolExecution = toProviderToolExecution(batch.executions[i])
 		}
-		a.session.Add(msg)
+		a.sess.conversation.Add(msg)
 	}
 	// If the context was cancelled during tool execution, return after storing
 	// the batch results so the session keeps paired tool-call history.
@@ -668,7 +668,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 		}
 		state.contextToolRepairs++
 		nudge := fmt.Sprintf("The following tools are unavailable in the current workflow phase: %s. Do not call them again. Respond to the user's request with visible answer text now; call a different tool only if it is still needed to complete the request.", strings.Join(unavailableContextTools, ", "))
-		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 	}
 	a.trackTodoProgress(ctx, state, receiptMark)
 
@@ -685,7 +685,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 			ctrl.MarkFinalizationOffered(a.recovery.taskID)
 		}
 		nudge := "Auto recovery has reached its limit for this turn. Do not call any more tools. Summarize what was completed, what failed, and what the user should do next. The user can continue in the next message."
-		a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
 		return true, nil
 	}
 
@@ -704,7 +704,7 @@ func (a *Agent) handleToolRound(ctx context.Context, state *runLoopState, step i
 
 func (a *Agent) pairUnexecutedGraceCalls(calls []provider.ToolCall, msg string) {
 	for _, call := range calls {
-		a.session.Add(provider.Message{Role: provider.RoleTool, Content: msg, ToolCallID: call.ID, Name: call.Name})
+		a.sess.conversation.Add(provider.Message{Role: provider.RoleTool, Content: msg, ToolCallID: call.ID, Name: call.Name})
 	}
 }
 

--- a/internal/agent/run_usage.go
+++ b/internal/agent/run_usage.go
@@ -201,7 +201,7 @@ func (a *Agent) storeLatestRequestUsage(attempt *provider.Usage) {
 	}
 	clone := *attempt
 	// Keep the per-attempt RequestCount; context calculations do not use it.
-	a.lastUsage.Store(&clone)
+	a.sess.output.lastUsage.Store(&clone)
 	a.setPromptTokenCalibrationFromUsage(&clone)
 }
 
@@ -267,11 +267,11 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	// lastUsage must stay as the latest single-request shape (set during
 	// sampling recovery). Never overwrite it with a multi-attempt billable
 	// aggregate — that would inflate ContextSnapshot and compaction decisions.
-	if a.lastUsage.Load() == nil && usage.PromptTokens > 0 {
+	if a.sess.output.lastUsage.Load() == nil && usage.PromptTokens > 0 {
 		a.storeLatestRequestUsage(usage)
 	}
 	a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing,
 		UsageSource:      a.usageSource,
 		CacheDiagnostics: cacheDiagnostics,
-		SessionHit:       int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load())})
+		SessionHit:       int(a.sess.cacheHit.Load()), SessionMiss: int(a.sess.cacheMiss.Load())})
 }

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -76,13 +76,13 @@ func (a *Agent) prepareSamplingRequest(ctx context.Context) (samplingRequest, er
 			rebuilt.req.MaxTokens = budget2
 		}
 		shape := a.requestCalibrationShape(rebuilt.req)
-		a.activeReqShape.Store(&shape)
+		a.sess.output.activeReqShape.Store(&shape)
 		return samplingRequest{req: freezeProviderRequest(rebuilt.req)}, nil
 	} else if clipped {
 		frozen.req.MaxTokens = budget
 	}
 	shape := a.requestCalibrationShape(frozen.req)
-	a.activeReqShape.Store(&shape)
+	a.sess.output.activeReqShape.Store(&shape)
 	return samplingRequest{req: freezeProviderRequest(frozen.req)}, nil
 }
 

--- a/internal/agent/secret_redaction_test.go
+++ b/internal/agent/secret_redaction_test.go
@@ -22,7 +22,7 @@ func (secretOutputTool) Execute(context.Context, json.RawMessage) (string, error
 func TestExecuteOnePreservesToolResultBeforeHistory(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(secretOutputTool{})
-	a := &Agent{tools: reg, session: NewSession("")}
+	a := &Agent{tools: reg, sess: sessionRuntime{conversation: NewSession("")}}
 
 	outcome := a.executeOne(context.Background(), provider.ToolCall{ID: "call_1", Name: "secret_output", Arguments: `{}`})
 	const want = "DEEPSEEK_API_KEY=sk-real-secret-value-123456\n"

--- a/internal/agent/sessionstate.go
+++ b/internal/agent/sessionstate.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"reasonix/internal/evidence"
+)
+
+// sessionRuntime is the host state one conversation owns. Its lifetime sits
+// between the process and the task: SetSession replaces the conversation and
+// reset restarts everything here that belongs to it. Atomics and mutexes make
+// the whole-value assignment taskRuntime uses illegal, so the "no field is
+// forgotten" property is enforced by sessionstate_test.go instead.
+type sessionRuntime struct {
+	mu           sync.Mutex // guards conversation for external Session()/SetSession
+	conversation *Session
+	output       outputBudgetState
+
+	// cacheHit/cacheMiss are the session aggregate, which compaction must not
+	// reset — the hit-rate would crater every time the visible prefix is folded.
+	// Atomic: the run loop accumulates while the status line reads.
+	cacheHit  atomic.Int64
+	cacheMiss atomic.Int64
+
+	missingReasoning missingReasoningWatch
+
+	// compactionMu guards projection snapshots/install and the in-memory sidecar
+	// generation. Network summarization never runs while this lock is held.
+	compactionMu sync.Mutex
+	// compactionRunMu singleflights the expensive summary transaction without
+	// holding the session lock during network I/O.
+	compactionRunMu sync.Mutex
+	compaction      compactionProgress
+	compactionState CompactionState
+	cacheState      string // legacy resume telemetry; never provider-visible
+
+	// path and checkpointState are rebound by preflight when a transcript is
+	// bound, so reset leaves them to their owner rather than blanking them.
+	path            string // bound transcript path for projection sidecars
+	checkpointState string // none|restored|applied; runtime-only
+
+	// todoState is the host's canonical task list. It never rides in the prompt,
+	// so it survives compaction, and SetSession rebuilds it from the incoming
+	// snapshot rather than letting reset blank it.
+	todoMu    sync.Mutex
+	todoState []evidence.TodoItem
+
+	// lastPrefixShape records the previous provider request's cacheable prefix
+	// so usage events can explain prefix churn on the next request. Carried
+	// across a conversation swap; see sessionCarryOver.
+	lastPrefixShape     PrefixShape
+	haveLastPrefixShape bool
+}
+
+// reset rebinds the runtime to a new conversation. Every field is named here or
+// in sessionCarryOver, and sessionstate_test.go checks both lists against the
+// struct: an atomic-bearing type cannot be replaced by one assignment, so the
+// guarantee has to be tested rather than compiled.
+func (r *sessionRuntime) reset(s *Session) {
+	r.mu.Lock()
+	r.conversation = s
+	r.mu.Unlock()
+	r.cacheHit.Store(0)
+	r.cacheMiss.Store(0)
+	r.output.reset()
+	r.missingReasoning = missingReasoningWatch{}
+	r.compactionMu.Lock()
+	r.compactionState = CompactionState{} // lineage change; disk reloaded on Resume
+	r.cacheState = CacheStateUnknown
+	r.compactionMu.Unlock()
+	r.compaction.stuck = false
+	r.compaction.consecutive = 0
+	r.compaction.lastTurn.Store(0)
+}
+
+// session returns the bound conversation under the lock that guards the
+// pointer against a concurrent SetSession.
+func (r *sessionRuntime) session() *Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.conversation
+}

--- a/internal/agent/sessionstate_test.go
+++ b/internal/agent/sessionstate_test.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+	"time"
+)
+
+// sessionReset names the fields a new conversation starts from. taskRuntime
+// gets this for free — one assignment zeroes anything unlisted — but a struct
+// holding atomics and mutexes cannot be assigned, so reset must name each field
+// and this list is what keeps it honest.
+var sessionReset = map[string]bool{
+	"mu":               true,
+	"conversation":     true,
+	"output":           true,
+	"cacheHit":         true,
+	"cacheMiss":        true,
+	"missingReasoning": true,
+	"compactionMu":     true,
+	"compactionState":  true,
+	"cacheState":       true,
+	"compaction":       true,
+}
+
+// sessionCarryOver names the fields reset deliberately leaves alone, each with
+// an owner that rebinds it. Being on this list is a claim that someone else
+// sets the field for the new conversation — not that it does not matter.
+var sessionCarryOver = map[string]bool{
+	"compactionRunMu": true, // a singleflight latch, not conversation state
+	"path":            true, // preflight rebinds on the next transcript bind
+	"checkpointState": true, // preflight rebinds with the transcript
+	"todoMu":          true,
+	"todoState":       true, // SetSession rebuilds it from the new snapshot
+	// lastPrefixShape survives the swap today; the next request compares its
+	// prefix against the replaced conversation's shape. Left as found here.
+	"lastPrefixShape":     true,
+	"haveLastPrefixShape": true,
+}
+
+func sessionRuntimeFields(t *testing.T) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sessionstate.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse sessionstate.go: %v", err)
+	}
+	fields := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || spec.Name.Name != "sessionRuntime" {
+			return true
+		}
+		st, ok := spec.Type.(*ast.StructType)
+		if !ok {
+			return false
+		}
+		for _, field := range st.Fields.List {
+			if len(field.Names) == 0 {
+				// An embedded type contributes its own name.
+				if ident, ok := field.Type.(*ast.Ident); ok {
+					fields[ident.Name] = true
+				}
+				continue
+			}
+			for _, name := range field.Names {
+				fields[name.Name] = true
+			}
+		}
+		return false
+	})
+	if len(fields) == 0 {
+		t.Fatal("sessionRuntime has no fields; the guard would pass vacuously")
+	}
+	return fields
+}
+
+func TestSessionRuntimeLifetimeListsCoverTheStruct(t *testing.T) {
+	fields := sessionRuntimeFields(t)
+	for _, list := range []map[string]bool{sessionReset, sessionCarryOver} {
+		for name := range list {
+			if !fields[name] {
+				t.Errorf("the lifetime lists name %q, which sessionRuntime no longer has", name)
+			}
+		}
+	}
+	for name := range fields {
+		switch {
+		case sessionReset[name] && sessionCarryOver[name]:
+			t.Errorf("sessionRuntime.%s is listed as both reset and carried", name)
+		case !sessionReset[name] && !sessionCarryOver[name]:
+			t.Errorf("sessionRuntime.%s is on neither list; decide whether a new conversation starts from it", name)
+		}
+	}
+}
+
+// The list above is a claim about reset's body, so it is read back from the
+// source: a field dropped from reset stops being covered, and the mismatch
+// fails here instead of surfacing as state leaking between conversations.
+func TestSessionRuntimeResetAssignsEveryResetField(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sessionstate.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse sessionstate.go: %v", err)
+	}
+	touched := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "reset" {
+			return true
+		}
+		ast.Inspect(fn, func(inner ast.Node) bool {
+			sel, ok := inner.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if recv, ok := sel.X.(*ast.Ident); ok && recv.Name == "r" {
+				touched[sel.Sel.Name] = true
+			}
+			return true
+		})
+		return false
+	})
+	for name := range sessionReset {
+		if !touched[name] {
+			t.Errorf("reset never touches sessionRuntime.%s, but the list says a new conversation starts from it", name)
+		}
+	}
+}
+
+func TestSetSessionRestartsTheConversationState(t *testing.T) {
+	a := &Agent{}
+	a.sess.cacheHit.Store(11)
+	a.sess.cacheMiss.Store(7)
+	a.sess.missingReasoning = missingReasoningWatch{active: true, stateRecorded: true, healthyStreak: 2}
+	a.sess.compaction.stuck = true
+	a.sess.compaction.consecutive = 3
+	a.sess.compaction.lastTurn.Store(9)
+	a.sess.compactionState = CompactionState{}
+	a.unwrittenResolve.at = time.Unix(1, 0)
+
+	next := NewSession("")
+	a.SetSession(next)
+
+	if a.sess.session() != next {
+		t.Error("SetSession did not bind the new conversation")
+	}
+	if a.sess.cacheHit.Load() != 0 || a.sess.cacheMiss.Load() != 0 {
+		t.Errorf("cache tallies = %d/%d, want a fresh aggregate", a.sess.cacheHit.Load(), a.sess.cacheMiss.Load())
+	}
+	if a.sess.missingReasoning != (missingReasoningWatch{}) {
+		t.Errorf("missingReasoning = %+v, want the incident to end with its conversation", a.sess.missingReasoning)
+	}
+	if a.sess.compaction.stuck || a.sess.compaction.consecutive != 0 || a.sess.compaction.lastTurn.Load() != 0 {
+		t.Errorf("compaction progress = stuck:%t consecutive:%d lastTurn:%d, want it restarted",
+			a.sess.compaction.stuck, a.sess.compaction.consecutive, a.sess.compaction.lastTurn.Load())
+	}
+	if a.sess.cacheState != CacheStateUnknown {
+		t.Errorf("cacheState = %q, want %q", a.sess.cacheState, CacheStateUnknown)
+	}
+	if a.unwrittenResolve.at.IsZero() {
+		t.Error("unwrittenResolve was cleared; the retry it owes belongs to the provider configuration, not the conversation")
+	}
+}

--- a/internal/agent/shell_contract_test.go
+++ b/internal/agent/shell_contract_test.go
@@ -29,14 +29,14 @@ func TestOrdinaryModeBlocksMixedMutationAndVerification(t *testing.T) {
 	if err := a.Run(context.Background(), "test"); err != nil {
 		t.Fatal(err)
 	}
-	got := toolResultByID(a.session, "m1")
+	got := toolResultByID(a.sess.conversation, "m1")
 	if strings.Contains(got, "bash done") {
 		t.Fatal("mixed command was executed")
 	}
 	if !strings.Contains(got, "state-changing segment") {
 		t.Fatalf("result = %q, want ordinary-mode mixed block", got)
 	}
-	for _, msg := range a.session.Snapshot() {
+	for _, msg := range a.sess.conversation.Snapshot() {
 		if msg.ToolCallID != "m1" {
 			continue
 		}
@@ -78,7 +78,7 @@ func TestOrdinaryModeRunsShortCircuitBuildAndVerify(t *testing.T) {
 			if err := a.Run(context.Background(), "test"); err != nil {
 				t.Fatal(err)
 			}
-			got := toolResultByID(a.session, "m1")
+			got := toolResultByID(a.sess.conversation, "m1")
 			if strings.Contains(got, "blocked:") {
 				t.Fatalf("ordinary mode blocked %q: %s", command, got)
 			}
@@ -100,7 +100,7 @@ func TestOrdinaryModeBlocksMaskedVerifierExit(t *testing.T) {
 	if err := a.Run(context.Background(), "test"); err != nil {
 		t.Fatal(err)
 	}
-	got := toolResultByID(a.session, "m1")
+	got := toolResultByID(a.sess.conversation, "m1")
 	if strings.Contains(got, "bash done") {
 		t.Fatal("masked exit command was executed")
 	}
@@ -121,7 +121,7 @@ func TestOrdinaryModeBlocksNonTerminalInlineInterpreter(t *testing.T) {
 	if err := a.Run(context.Background(), "test"); err != nil {
 		t.Fatal(err)
 	}
-	got := toolResultByID(a.session, "m1")
+	got := toolResultByID(a.sess.conversation, "m1")
 	if strings.Contains(got, "bash done") {
 		t.Fatal("non-terminal inline interpreter was executed")
 	}
@@ -154,13 +154,13 @@ func TestBatchDependencyBarrierSkipsVerificationAfterFailedMutation(t *testing.T
 	if err := a.Run(context.Background(), "edit then verify"); err != nil {
 		t.Fatal(err)
 	}
-	if got := toolResultByID(a.session, "v1"); !strings.Contains(got, "earlier modification") {
+	if got := toolResultByID(a.sess.conversation, "v1"); !strings.Contains(got, "earlier modification") {
 		t.Fatalf("verify result = %q, want dependency skip", got)
 	}
-	if strings.Contains(toolResultByID(a.session, "v1"), "bash done") {
+	if strings.Contains(toolResultByID(a.sess.conversation, "v1"), "bash done") {
 		t.Fatal("verification process should not have started")
 	}
-	for _, msg := range a.session.Snapshot() {
+	for _, msg := range a.sess.conversation.Snapshot() {
 		if msg.ToolCallID != "v1" {
 			continue
 		}
@@ -206,7 +206,7 @@ func TestBatchDependencyBarrierIgnoresFailedNonMutationMetaTool(t *testing.T) {
 	if err := a.Run(context.Background(), "track then edit"); err != nil {
 		t.Fatal(err)
 	}
-	if got := toolResultByID(a.session, "e1"); strings.Contains(got, "earlier modification") {
+	if got := toolResultByID(a.sess.conversation, "e1"); strings.Contains(got, "earlier modification") {
 		t.Fatalf("edit was blocked by a failed todo_write: %s", got)
 	}
 	got, err := os.ReadFile(path)
@@ -241,7 +241,7 @@ func TestBatchDependencyBarrierStopsAfterFailedWorkspaceWrite(t *testing.T) {
 	if err := a.Run(context.Background(), "two edits"); err != nil {
 		t.Fatal(err)
 	}
-	if got := toolResultByID(a.session, "e2"); !strings.Contains(got, "earlier modification") {
+	if got := toolResultByID(a.sess.conversation, "e2"); !strings.Contains(got, "earlier modification") {
 		t.Fatalf("second edit result = %q, want dependency skip", got)
 	}
 	got, err := os.ReadFile(filepath.Join(dir, "x.txt"))
@@ -343,7 +343,7 @@ func TestBatchDependencyBarrierBlocksResolvedMCPWriterAfterFailedMutation(t *tes
 	if _, err := os.Stat(proxyWrote); err == nil {
 		t.Fatal("proxy writer mutated disk after failed edit")
 	}
-	got := toolResultByID(a.session, "m1")
+	got := toolResultByID(a.sess.conversation, "m1")
 	if !strings.Contains(got, "earlier modification") {
 		t.Fatalf("proxy result = %q, want dependency skip", got)
 	}
@@ -377,7 +377,7 @@ func TestBatchDependencyBarrierAllowsReadOnlyDiagnosisAfterFailedMutation(t *tes
 	if err := a.Run(context.Background(), "fail then diagnose"); err != nil {
 		t.Fatal(err)
 	}
-	readOut := toolResultByID(a.session, "r1")
+	readOut := toolResultByID(a.sess.conversation, "r1")
 	if strings.Contains(readOut, "earlier modification") {
 		t.Fatalf("read_file was incorrectly dependency-skipped: %q", readOut)
 	}
@@ -388,10 +388,10 @@ func TestBatchDependencyBarrierAllowsReadOnlyDiagnosisAfterFailedMutation(t *tes
 	if !strings.Contains(readOut, "a") {
 		t.Fatalf("read_file body missing original file content: %q", readOut)
 	}
-	if got := toolResultByID(a.session, "v1"); !strings.Contains(got, "earlier modification") {
+	if got := toolResultByID(a.sess.conversation, "v1"); !strings.Contains(got, "earlier modification") {
 		t.Fatalf("verification should be dependency-skipped, got %q", got)
 	}
-	if strings.Contains(toolResultByID(a.session, "v1"), "bash done") {
+	if strings.Contains(toolResultByID(a.sess.conversation, "v1"), "bash done") {
 		t.Fatal("verification process must not start after failed mutation")
 	}
 }

--- a/internal/agent/stale_anchor_guard_test.go
+++ b/internal/agent/stale_anchor_guard_test.go
@@ -33,7 +33,7 @@ func TestDeleteRangeRequiresReadAfterSameTurnWrite(t *testing.T) {
 	if got := atomic.LoadInt32(&deleteCalls); got != 1 {
 		t.Fatalf("delete_range executed %d times, want only the first call", got)
 	}
-	results := toolResults(a.session, "delete_range")
+	results := toolResults(a.sess.conversation, "delete_range")
 	if len(results) != 2 {
 		t.Fatalf("tool results = %d, want 2", len(results))
 	}
@@ -66,7 +66,7 @@ func TestEditFileAllowedAfterSameTurnWriteWithoutFreshRead(t *testing.T) {
 	if got := atomic.LoadInt32(&editCalls); got != 2 {
 		t.Fatalf("edit_file executed %d times, want both optimistic exact-match edits", got)
 	}
-	if last := lastToolResult(a.session, "edit_file"); strings.Contains(last, "[fresh read required]") {
+	if last := lastToolResult(a.sess.conversation, "edit_file"); strings.Contains(last, "[fresh read required]") {
 		t.Fatalf("edit_file should rely on its current-file uniqueness check, got %q", last)
 	}
 }
@@ -98,7 +98,7 @@ func TestDeleteRangeAllowedAfterFreshRead(t *testing.T) {
 	if got := atomic.LoadInt32(&deleteCalls); got != 2 {
 		t.Fatalf("delete_range executed %d times, want 2 after fresh read", got)
 	}
-	if last := lastToolResult(a.session, "delete_range"); strings.Contains(last, "[fresh read required]") {
+	if last := lastToolResult(a.sess.conversation, "delete_range"); strings.Contains(last, "[fresh read required]") {
 		t.Fatalf("fresh read should allow the second edit, got %q", last)
 	}
 }
@@ -130,7 +130,7 @@ func TestDeleteRangeStillRequiresReadAfterWindowedRead(t *testing.T) {
 	if got := atomic.LoadInt32(&deleteCalls); got != 1 {
 		t.Fatalf("delete_range executed %d times, want only the first call", got)
 	}
-	if last := lastToolResult(a.session, "delete_range"); !strings.Contains(last, "[fresh read required]") {
+	if last := lastToolResult(a.sess.conversation, "delete_range"); !strings.Contains(last, "[fresh read required]") {
 		t.Fatalf("windowed read should not allow the second edit, got %q", last)
 	}
 }

--- a/internal/agent/task_budget_gate_test.go
+++ b/internal/agent/task_budget_gate_test.go
@@ -60,7 +60,7 @@ func TestTaskBudgetGateKeepsTheWorkAndAsksForASummary(t *testing.T) {
 	_ = a.Run(context.Background(), "read everything")
 
 	var sawNudge, sawToolResult bool
-	for _, m := range a.session.Messages {
+	for _, m := range a.sess.conversation.Messages {
 		if m.Role == provider.RoleUser && strings.Contains(m.Content, "reached its cost budget") {
 			sawNudge = true
 		}

--- a/internal/agent/todo_progress_guard_test.go
+++ b/internal/agent/todo_progress_guard_test.go
@@ -147,10 +147,10 @@ func TestTodoProgressGuardRenewsOnUniqueHostWork(t *testing.T) {
 }
 
 func TestCanonicalTodoProgressIgnoresTitleAndPendingListChurn(t *testing.T) {
-	a := &Agent{todoState: []evidence.TodoItem{
+	a := &Agent{sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "finish the task", Status: "in_progress"},
 		{Content: "write tests", Status: "pending"},
-	}}
+	}}}
 	before, tracking := a.canonicalTodoProgress()
 	if !tracking {
 		t.Fatal("incomplete todo list should be tracked")

--- a/internal/agent/todo_state.go
+++ b/internal/agent/todo_state.go
@@ -29,24 +29,24 @@ func (a *Agent) ReplaceTodoState(todos []evidence.TodoItem) {
 
 // CanonicalTodoState returns a copy of the host-reconstructed task list.
 func (a *Agent) CanonicalTodoState() []evidence.TodoItem {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	return append([]evidence.TodoItem(nil), a.todoState...)
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
+	return append([]evidence.TodoItem(nil), a.sess.todoState...)
 }
 
 func (a *Agent) incompleteCanonicalTodos() ([]evidence.TodoStepMatch, bool) {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	if len(a.todoState) == 0 {
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
+	if len(a.sess.todoState) == 0 {
 		return nil, false
 	}
-	return evidence.IncompleteTodos(a.todoState), true
+	return evidence.IncompleteTodos(a.sess.todoState), true
 }
 
 func (a *Agent) hasIncompleteCanonicalCriteria() bool {
-	a.todoMu.Lock()
-	defer a.todoMu.Unlock()
-	return len(a.todoState) > 0 && len(evidence.IncompleteTodos(a.todoState)) > 0
+	a.sess.todoMu.Lock()
+	defer a.sess.todoMu.Unlock()
+	return len(a.sess.todoState) > 0 && len(evidence.IncompleteTodos(a.sess.todoState)) > 0
 }
 
 // recordTodoState logs the host-advanced list as a synthetic todo_write receipt

--- a/internal/agent/toolimages_test.go
+++ b/internal/agent/toolimages_test.go
@@ -47,9 +47,9 @@ func TestToolResultImagesBypassTruncation(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	var msg *provider.Message
-	for i := range a.session.Messages {
-		if a.session.Messages[i].Role == provider.RoleTool && a.session.Messages[i].Name == "shot" {
-			msg = &a.session.Messages[i]
+	for i := range a.sess.conversation.Messages {
+		if a.sess.conversation.Messages[i].Role == provider.RoleTool && a.sess.conversation.Messages[i].Name == "shot" {
+			msg = &a.sess.conversation.Messages[i]
 			break
 		}
 	}

--- a/internal/agent/turn_phase_test.go
+++ b/internal/agent/turn_phase_test.go
@@ -72,7 +72,7 @@ func TestExecutionPolicyPresentOnMutationTurn(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), NewSession("sys"), Options{AgentPreset: "delivery"}, event.Discard)
 	_ = a.Run(context.Background(), "explain mutexes")
 	found := false
-	for _, m := range a.session.Messages {
+	for _, m := range a.sess.conversation.Messages {
 		if m.Role == provider.RoleUser && strings.Contains(m.Content, `preset="delivery"`) {
 			found = true
 		}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -2,15 +2,15 @@
   "limits": {
     "banner": 15,
     "commented-code": 0,
-    "complexity": 2086,
-    "essay": 4028,
-    "file-size": 108575,
-    "function-size": 8886,
+    "complexity": 2069,
+    "essay": 4012,
+    "file-size": 108250,
+    "function-size": 8850,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
-    "struct-state": 130,
-    "test-file-size": 69238
+    "struct-state": 122,
+    "test-file-size": 69236
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -27,10 +27,10 @@
       "essay": 19
     },
     "desktop/app.go": {
-      "complexity": 63,
+      "complexity": 59,
       "essay": 96,
-      "file-size": 11338,
-      "function-size": 371,
+      "file-size": 11308,
+      "function-size": 367,
       "struct-state": 15
     },
     "desktop/app_autosave_test.go": {
@@ -155,7 +155,7 @@
       "file-size": 158
     },
     "desktop/frontend/src/components/Transcript.tsx": {
-      "file-size": 322
+      "file-size": 269
     },
     "desktop/frontend/src/components/UsageStatsPanel.tsx": {
       "file-size": 276
@@ -176,7 +176,7 @@
       "file-size": 269
     },
     "desktop/frontend/src/lib/types.ts": {
-      "file-size": 1554
+      "file-size": 1527
     },
     "desktop/frontend/src/lib/useController.ts": {
       "file-size": 3969
@@ -234,9 +234,6 @@
     },
     "desktop/race_regression_test.go": {
       "essay": 4
-    },
-    "desktop/recovery_gc.go": {
-      "essay": 1
     },
     "desktop/recovery_gc_test.go": {
       "essay": 1
@@ -312,9 +309,9 @@
     },
     "desktop/tabs.go": {
       "complexity": 41,
-      "essay": 112,
-      "file-size": 7716,
-      "function-size": 372,
+      "essay": 111,
+      "file-size": 7704,
+      "function-size": 369,
       "struct-state": 23
     },
     "desktop/tabs_order_test.go": {
@@ -434,8 +431,8 @@
       "test-file-size": 1374
     },
     "internal/acp/service.go": {
-      "essay": 66,
-      "file-size": 2285,
+      "essay": 61,
+      "file-size": 2257,
       "function-size": 97,
       "struct-state": 2
     },
@@ -451,10 +448,10 @@
     },
     "internal/agent/agent.go": {
       "complexity": 37,
-      "essay": 76,
-      "file-size": 2251,
+      "essay": 71,
+      "file-size": 2201,
       "function-size": 102,
-      "struct-state": 18
+      "struct-state": 10
     },
     "internal/agent/ask.go": {
       "essay": 4
@@ -593,10 +590,10 @@
       "essay": 5
     },
     "internal/agent/save.go": {
-      "complexity": 49,
-      "essay": 112,
-      "file-size": 1522,
-      "function-size": 124
+      "complexity": 36,
+      "essay": 109,
+      "file-size": 1466,
+      "function-size": 102
     },
     "internal/agent/save_test.go": {
       "essay": 9,
@@ -769,7 +766,7 @@
       "essay": 8
     },
     "internal/bot/gateway_test.go": {
-      "test-file-size": 1705
+      "test-file-size": 1703
     },
     "internal/bot/project_index.go": {
       "file-size": 31
@@ -1093,9 +1090,9 @@
     },
     "internal/control/controller.go": {
       "complexity": 10,
-      "essay": 162,
-      "file-size": 5553,
-      "function-size": 82,
+      "essay": 161,
+      "file-size": 5489,
+      "function-size": 75,
       "narrative": 4,
       "struct-state": 17
     },
@@ -1747,7 +1744,7 @@
     },
     "internal/serve/serve.go": {
       "essay": 27,
-      "file-size": 887
+      "file-size": 882
     },
     "internal/serve/serve_lease_test.go": {
       "essay": 3


### PR DESCRIPTION
Second stage of #8523, on top of `taskRuntime`. `SetSession` reset fifteen
fields one at a time and carried a comment naming the one it deliberately
spared. That set is now `sessionRuntime`, and the seam is `a.sess.reset(s)`.

## Three fields were in the wrong layer

Each candidate was checked against its write sites rather than its name, which
moved three of them:

**`workspaceID`** is written only by `New`. It belongs in `agentConfig`, where
`agent_config_test.go` now enforces that nothing writes it again — worth having,
because it is a prompt-cache lineage component and a mid-life change would
silently rekey the cache.

**`activeTurnCreatedAt`** is cleared by a `defer` in `Run`. It is turn state, so
it stays where it is until the turn stage.

**`pendingResolveAt`** was the field `SetSession` spared, and the comment
explaining why turned out to be describing a lifetime rather than an exception:
it answers to the provider configuration, not to any conversation. It is now
`unwrittenResolve`, sitting beside the warn state it belongs with.
`missingReasoningWatch` goes back to being ordinary session state with nothing
to explain.

`outputBudgetState` also stops being embedded in `Agent`. It becomes a named
field that owns `lastUsage`, so restarting it is one visible `r.output.reset()`
instead of an `Agent` method reaching across two layers to clear fields in a
third.

## Why this layer is guarded by a test, not by an assignment

`taskRuntime` gets its "a new field cannot be forgotten" property for free:
`*t = taskRuntime{...}` zeroes anything unlisted. `sessionRuntime` cannot do
that — it holds three mutexes and five atomics, and `vet`'s copylocks rejects
assigning such a value.

So the property is enforced instead:

- both lifetime lists (`sessionReset`, `sessionCarryOver`) are checked against
  the struct via AST, so a field added to `sessionRuntime` fails until someone
  states which side it is on, and a field on both lists fails too
- `reset`'s body is read back from source to confirm it actually touches
  everything the reset list claims

That second check is not decoration: it caught `lastUsage` being listed as reset
while `reset` only reached it indirectly, which is what prompted giving
`outputBudgetState` a name and its own `reset`.

This constraint is specific to the session layer. The turn stage does not
inherit it — that state is bools, ints and strings, so it can still be a real
local value replaced by one assignment.

## Behaviour

Unchanged. `lastPrefixShape` / `haveLastPrefixShape` survive a conversation swap
exactly as they did before; that is now recorded on the carry-over list instead
of being invisible. Worth a follow-up look — after a swap the next request
explains its prefix churn against the replaced conversation's shape — but
changing it is a behaviour change and does not belong in this PR.

## Verification

- `go test ./internal/agent/` green; `./internal/tool/builtin/`,
  `./internal/boot/`, `./internal/control/` green
- `go vet ./...` clean, including copylocks over the new mutex- and
  atomic-bearing struct
- golangci-lint 2.12.2 (the pinned version), 0 issues repo-wide
- repolint: `struct-state` for `agent.go` 18 -> 10, repo total 130 -> 122;
  `essay`, `file-size`, `complexity` and `function-size` all fall. Verified
  key-by-key that no baseline entry increases. `sessionstate.go` adds no
  findings of its own.

Part of #8523.

Cache-impact: none - host state only. No prompt text, tool schema, memory, or
provider request field is touched. `workspaceID` moves between structs but keeps
its value and its single reader, `promptCacheKey`, so the cache key it feeds is
byte-identical.
Cache-guard: go test ./internal/agent/ -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction|TestSessionAggregateCacheRate|TestSessionSwapKeepsPromptCalibration'
System-prompt-review: yhh - the gate fires on `internal/agent/agent.go` and
`internal/agent/task.go`. Both diffs are field relocation and selector renames;
no prompt string, tool schema, or system-prompt assembly is reached, and
`internal/config/`, `internal/memory/`, `internal/outputstyle/`,
`internal/skill/` and `internal/boot/` are untouched.
Documentation-impact: none - `docs/*.md` describes behaviour and configuration,
and this PR changes neither. The lifetimes it names are internal to
`internal/agent`, documented at their declarations and in #8523.
