### PR TITLE
fix(desktop): 顶部「新建会话」默认创建全局会话，不再继承当前激活 tab 的项目

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2561,10 +2561,11 @@ export default function App() {
   }, [refreshTabMetas, setControllerCollaborationMode]);
 
   const blankSessionTarget = useCallback(() => {
-    const activeWorkspaceRoot = activeTab?.scope === "project" ? activeTab.workspaceRoot || "" : "";
-    const scope = activeWorkspaceRoot ? "project" : "global";
-    return { scope, workspaceRoot: activeWorkspaceRoot };
-  }, [activeTab?.scope, activeTab?.workspaceRoot]);
+    // Top-level "New Session" always creates a global (non-project) session.
+    // It must never inherit the project of the currently active tab; project
+    // sessions are only created through explicit project-tree actions.
+    return { scope: "global", workspaceRoot: "" };
+  }, []);
 
   useEffect(() => {
     let live = true;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2430,7 +2430,7 @@ export const en = {
   "shortcuts.action.textSizeReset": "Reset text size",
   "shortcuts.action.yoloToggle": "Toggle YOLO approvals",
   "shortcuts.action.showShortcuts": "Show shortcuts",
-  "shortcuts.desc.newSession": "Create a new session for the current workspace scope.",
+  "shortcuts.desc.newSession": "Create a new non-project session.",
   "shortcuts.desc.commandPalette": "Search commands and recent sessions.",
   "shortcuts.desc.settings": "Open the desktop settings center.",
   "shortcuts.desc.closeTab": "Close the active tab.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -3090,7 +3090,7 @@ export const zhTW: Record<DictKey, string> = {
   "shortcuts.action.textSizeReset": "重置字號",
   "shortcuts.action.yoloToggle": "切換 YOLO 審批",
   "shortcuts.action.showShortcuts": "顯示快捷鍵",
-  "shortcuts.desc.newSession": "為當前工作區範圍建立新會話。",
+  "shortcuts.desc.newSession": "建立新的非專案會話。",
   "shortcuts.desc.commandPalette": "搜尋命令和最近會話。",
   "shortcuts.desc.settings": "開啟桌面設定中心。",
   "shortcuts.desc.closeTab": "關閉目前標籤頁。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2433,7 +2433,7 @@ export const zh: Record<DictKey, string> = {
   "shortcuts.action.textSizeReset": "重置字号",
   "shortcuts.action.yoloToggle": "切换 YOLO 审批",
   "shortcuts.action.showShortcuts": "显示快捷键",
-  "shortcuts.desc.newSession": "为当前工作区范围创建新会话。",
+  "shortcuts.desc.newSession": "创建新的非项目会话。",
   "shortcuts.desc.commandPalette": "搜索命令和最近会话。",
   "shortcuts.desc.settings": "打开桌面设置中心。",
   "shortcuts.desc.closeTab": "关闭当前标签页。",


### PR DESCRIPTION
## 问题

顶部「新建会话」入口（`handleNewTab` → `blankSessionTarget`）原先会读取当前激活 tab：若激活 tab 是项目会话（`scope === "project"`），新会话会隐式继承该项目的 `workspaceRoot`，进入项目上下文。

这导致：用户在项目会话中点击顶部「新建会话」，期望的是全新全局会话，实际却仍停留在原项目上下文，行为与直觉不符。

## 改动

`desktop/frontend/src/App.tsx` 中 `blankSessionTarget` 固定返回 `{ scope: "global", workspaceRoot: "" }`：

- 顶部「新建会话」始终创建全局（非项目）会话
- 项目会话只通过**项目树的显式操作**创建（`handleOpenTopic` 等路径带显式 scope/workspaceRoot 参数，不受影响）

调用点核查：`blankSessionTarget` 仅被 `handleNewTab` 一处使用；项目树创建项目会话不经过该函数，行为无回归。

## 测试

- 改动仅 9 行，逻辑为纯函数返回值变更
- 调用点唯一性已通过 grep 核查

Documentation-impact: none - 纯前端行为调整，不涉及内嵌文档变更