### PR TITLE
fix(sessioncatalog): stop the sidebar freezing on a wedged projection

### DIFF
--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -16,6 +16,8 @@ import (
 	"reasonix/internal/taskcatalog"
 )
 
+const sessionCatalogMetadataSyncTimeout = 30 * time.Second
+
 type SessionCatalogStatus struct {
 	State           string `json:"state"`
 	Mode            string `json:"mode"`
@@ -155,7 +157,7 @@ func (a *App) startSessionCatalog(rebuild bool) {
 			return
 		}
 		a.sessionCatalog.Store(catalog)
-		if err := a.syncSessionCatalogMetadata(ctx, catalog); err != nil && !errors.Is(err, context.Canceled) {
+		if err := a.syncSessionCatalogMetadataBounded(ctx, catalog); err != nil && !errors.Is(err, context.Canceled) {
 			slog.Warn("desktop: sync session catalog metadata", "err", err)
 		}
 		select {
@@ -171,7 +173,7 @@ func (a *App) startSessionCatalog(rebuild bool) {
 			// Legacy assignment is deliberately background-only. It can scan and
 			// repair old metadata, but no project-tree or controller request waits.
 			if migrated := migrateLegacySessionsIntoGlobalTopics(target.Path); len(migrated) > 0 {
-				_ = a.syncSessionCatalogMetadata(ctx, catalog)
+				_ = a.syncSessionCatalogMetadataBounded(ctx, catalog)
 			}
 			if err := catalog.ReconcileDirectory(ctx, target); err != nil && !errors.Is(err, context.Canceled) {
 				slog.Debug("desktop: reconcile session catalog directory", "dir", target.Path, "err", err)
@@ -182,12 +184,12 @@ func (a *App) startSessionCatalog(rebuild bool) {
 		for {
 			select {
 			case <-ticker.C:
-				if err := a.syncSessionCatalogMetadata(ctx, catalog); err != nil && !errors.Is(err, context.Canceled) {
+				if err := a.syncSessionCatalogMetadataBounded(ctx, catalog); err != nil && !errors.Is(err, context.Canceled) {
 					slog.Debug("desktop: refresh session catalog metadata", "err", err)
 				}
 				for _, target := range a.sessionCatalogTargets() {
 					if migrated := migrateLegacySessionsIntoGlobalTopics(target.Path); len(migrated) > 0 {
-						_ = a.syncSessionCatalogMetadata(ctx, catalog)
+						_ = a.syncSessionCatalogMetadataBounded(ctx, catalog)
 					}
 					catalog.RequestReconcile(target)
 				}
@@ -320,6 +322,17 @@ func (a *App) indexRestoredSessionPaths(ctx context.Context, catalog *sessioncat
 		}
 		_ = catalog.IndexSessionPath(ctx, item.target, item.path)
 	}
+}
+
+// syncSessionCatalogMetadataBounded is the only form the long-lived catalog
+// goroutine may use. SyncMetadata runs under the catalog's single-writer mutex,
+// so one transaction that never returns silently wedges every later index,
+// reconcile, and revision bump — and the sidebar then stops updating for the
+// rest of the process lifetime instead of failing loudly.
+func (a *App) syncSessionCatalogMetadataBounded(ctx context.Context, catalog *sessioncatalog.Catalog) error {
+	ctx, cancel := context.WithTimeout(ctx, sessionCatalogMetadataSyncTimeout)
+	defer cancel()
+	return a.syncSessionCatalogMetadata(ctx, catalog)
 }
 
 func (a *App) syncSessionCatalogMetadata(ctx context.Context, catalog *sessioncatalog.Catalog) error {

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/sessioncatalog"
 )
 
@@ -114,5 +116,100 @@ func TestProjectTreeShellSurvivesCatalogRevisionRace(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("snapshot projects = %#v, want Shell Race", snapshot.Projects)
+	}
+}
+
+func TestListProjectTopicsSurfacesLiveTabWhileCatalogLags(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := t.TempDir()
+	if err := addProject(root, "Lagging Catalog"); err != nil {
+		t.Fatal(err)
+	}
+	sessionDir := desktopSessionDir(root)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	installSessionCatalogForTest(t, app, sessionDir, "project", root)
+	app.tabs["tab-1"] = &WorkspaceTab{
+		ID: "tab-1", Scope: "project", WorkspaceRoot: root,
+		TopicID: "topic_20260812-082637_live", TopicTitle: "Ownership Hub",
+	}
+
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "project", WorkspaceRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic_20260812-082637_live" {
+		t.Fatalf("page items = %#v, want the live tab's topic", page.Items)
+	}
+	if page.Items[0].CreatedAt <= 0 {
+		t.Fatalf("createdAt = %d, want the topic's creation time", page.Items[0].CreatedAt)
+	}
+}
+
+func TestListProjectTopicsDoesNotDuplicateIndexedLiveTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := t.TempDir()
+	if err := addProject(root, "Indexed"); err != nil {
+		t.Fatal(err)
+	}
+	sessionDir := desktopSessionDir(root)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := filepath.Join(sessionDir, "live.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.UpdateBranchMeta(sessionPath, false, func(meta *agent.BranchMeta) error {
+		meta.TopicID = "topic-indexed"
+		meta.TopicTitle = "Indexed Topic"
+		meta.WorkspaceRoot = root
+		meta.Scope = "project"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	installSessionCatalogForTest(t, app, sessionDir, "project", root)
+	app.tabs["tab-1"] = &WorkspaceTab{
+		ID: "tab-1", Scope: "project", WorkspaceRoot: root,
+		TopicID: "topic-indexed", TopicTitle: "Indexed Topic", SessionPath: sessionPath,
+	}
+
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "project", WorkspaceRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("page items = %#v, want the catalog row only", page.Items)
+	}
+}
+
+// The catalog goroutine outlives every request, so an unbounded metadata sync
+// there can hold the catalog's single-writer mutex forever and freeze the whole
+// sidebar. Guard the call shape, not just today's behaviour.
+func TestSessionCatalogGoroutineOnlySyncsMetadataWithATimeout(t *testing.T) {
+	source, err := os.ReadFile("session_catalog.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(source)
+	start := strings.Index(body, "func (a *App) startSessionCatalog(")
+	if start < 0 {
+		t.Fatal("startSessionCatalog not found")
+	}
+	end := strings.Index(body[start+1:], "\nfunc ")
+	if end < 0 {
+		t.Fatal("end of startSessionCatalog not found")
+	}
+	for line := range strings.SplitSeq(body[start:start+1+end], "\n") {
+		if !strings.Contains(line, "syncSessionCatalogMetadata(") {
+			continue
+		}
+		if !strings.Contains(line, "syncSessionCatalogMetadataBounded(") {
+			t.Fatalf("unbounded metadata sync in startSessionCatalog: %s", strings.TrimSpace(line))
+		}
 	}
 }

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"sort"
@@ -10,6 +11,15 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/sessioncatalog"
 )
+
+// Sidebar reads are bound so a starved connection pool or a slow projection
+// degrades into a stale page the next revision repairs, instead of a Wails call
+// that never returns and a tree that never moves again.
+const sessionCatalogReadTimeout = 10 * time.Second
+
+func (a *App) catalogReadContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(a.bootContext(), sessionCatalogReadTimeout)
+}
 
 type catalogRuntimeSnapshot struct {
 	scope         string
@@ -403,11 +413,65 @@ func topicSummaryFromCatalogTopic(topic sessioncatalog.TopicRecord, visible []se
 }
 
 func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
-	out := ProjectTopicPage{Items: []ProjectNode{}}
 	catalog := a.sessionCatalog.Load()
 	if catalog == nil {
 		return a.metadataTopicPage(req), nil
 	}
+	page, err := a.catalogTopicPage(catalog, req)
+	if err != nil {
+		return page, err
+	}
+	return a.withLiveTopics(req, page), nil
+}
+
+// withLiveTopics restores topics the catalog does not (yet) carry. A tab is
+// authoritative for its own existence, while the catalog is a projection that
+// can lag a fresh session, fall behind a stalled writer, or run degraded — and
+// the sidebar must never hide a conversation this app is running. Only an
+// uncursored page merges, so keyset pagination past it stays the catalog's.
+func (a *App) withLiveTopics(req ProjectTopicPageRequest, page ProjectTopicPage) ProjectTopicPage {
+	if strings.TrimSpace(req.Cursor) != "" {
+		return page
+	}
+	indexed := make(map[string]bool, len(page.Items))
+	for _, item := range page.Items {
+		indexed[item.TopicID] = true
+	}
+	query := strings.ToLower(strings.TrimSpace(req.Query))
+	live := []ProjectNode{}
+	for _, node := range a.runtimeOnlyProjectTopics(req.Scope, req.WorkspaceRoot) {
+		if indexed[node.TopicID] {
+			continue
+		}
+		if query != "" && !strings.Contains(strings.ToLower(node.Label), query) {
+			continue
+		}
+		live = append(live, node)
+	}
+	if len(live) == 0 {
+		return page
+	}
+	f := loadProjectsFile()
+	deleted := map[string]bool{}
+	for _, topicID := range f.DeletedTopics {
+		deleted[topicID] = true
+	}
+	created := loadTopicCreatedAts(topicTitleRoot(req.Scope, req.WorkspaceRoot))
+	kept := page.Items[:0:0]
+	for _, node := range live {
+		if deleted[node.TopicID] {
+			continue
+		}
+		node.CreatedAt = topicCreatedAtForTree(created, node.TopicID)
+		node.LastActivityAt = node.CreatedAt
+		kept = append(kept, node)
+	}
+	page.Items = append(kept, page.Items...)
+	return page
+}
+
+func (a *App) catalogTopicPage(catalog *sessioncatalog.Catalog, req ProjectTopicPageRequest) (ProjectTopicPage, error) {
+	out := ProjectTopicPage{Items: []ProjectNode{}}
 	limit := req.Limit
 	if limit <= 0 {
 		limit = sessioncatalog.DefaultLimit
@@ -417,11 +481,13 @@ func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, 
 	}
 	topicOverlays, sessionOverlays := a.catalogRuntimeOverlays()
 	cursor := req.Cursor
+	ctx, cancel := a.catalogReadContext()
+	defer cancel()
 	// Keep scanning past pages that are entirely idle recovery copies so the
 	// sidebar never shows an empty "no sessions" state when later pages still
 	// have ordinary topics.
 	for {
-		page, err := catalog.ListTopics(a.bootContext(), sessioncatalog.TopicPageRequest{
+		page, err := catalog.ListTopics(ctx, sessioncatalog.TopicPageRequest{
 			Scope: req.Scope, WorkspaceRoot: req.WorkspaceRoot, Cursor: cursor,
 			Limit: limit, Query: req.Query, TimeFilter: req.TimeFilter,
 		})
@@ -462,7 +528,9 @@ func encodeProjectTopicCursor(topic sessioncatalog.TopicRecord) string {
 
 func (a *App) GetTopicSummary(key ProjectTopicKey) (ProjectNode, error) {
 	if catalog := a.sessionCatalog.Load(); catalog != nil {
-		topic, ok, err := catalog.GetTopic(a.bootContext(), sessioncatalog.TopicKey{
+		ctx, cancel := a.catalogReadContext()
+		defer cancel()
+		topic, ok, err := catalog.GetTopic(ctx, sessioncatalog.TopicKey{
 			Scope: key.Scope, WorkspaceRoot: key.WorkspaceRoot, TopicID: key.TopicID,
 		})
 		if err != nil {

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -513,8 +513,10 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 		if err != nil {
 			return out, err
 		}
-		rawCount := 0
-		var lastScanned TopicRecord
+		// Drain the page before hydrating sessions: an open cursor holds a
+		// connection, and listTopicSessions needs a second one, so nesting them
+		// deadlocks whenever the pool is saturated (always in memory mode).
+		scanned := []TopicRecord{}
 		for rows.Next() {
 			var item TopicRecord
 			if err := rows.Scan(&item.Scope, &item.WorkspaceRoot, &item.TopicID, &item.Title,
@@ -523,13 +525,20 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 				_ = rows.Close()
 				return out, err
 			}
-			rawCount++
-			lastScanned = item
+			scanned = append(scanned, item)
+		}
+		rowsErr := rows.Err()
+		_ = rows.Close()
+		if rowsErr != nil {
+			return out, rowsErr
+		}
+		rawCount := len(scanned)
+		overflow := false
+		for _, item := range scanned {
 			sessions, err := c.listTopicSessions(ctx, TopicKey{
 				Scope: item.Scope, WorkspaceRoot: item.WorkspaceRoot, TopicID: item.TopicID,
 			})
 			if err != nil {
-				_ = rows.Close()
 				return TopicPage{Items: []TopicRecord{}, Revision: out.Revision}, err
 			}
 			if len(sessions) == 0 {
@@ -538,17 +547,14 @@ func (c *Catalog) ListTopics(ctx context.Context, req TopicPageRequest) (TopicPa
 			item.Sessions = sessions
 			out.Items = append(out.Items, item)
 			if len(out.Items) > req.Limit {
+				overflow = true
 				break
 			}
 		}
-		rowsErr := rows.Err()
-		_ = rows.Close()
-		if rowsErr != nil {
-			return out, rowsErr
-		}
-		if len(out.Items) > req.Limit || rawCount < scanLimit || rawCount == 0 {
+		if overflow || rawCount < scanLimit || rawCount == 0 {
 			break
 		}
+		lastScanned := scanned[rawCount-1]
 		pinned := 0
 		if lastScanned.Pinned {
 			pinned = 1

--- a/internal/sessioncatalog/connection_pool_test.go
+++ b/internal/sessioncatalog/connection_pool_test.go
@@ -1,0 +1,173 @@
+package sessioncatalog
+
+// Guards for connection-pool starvation: every catalog API must finish on a
+// pool of one, so no path can hold a connection while waiting for another.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+// A memory-mode catalog pools a single connection, so hydrating a topic's
+// sessions from inside the open topic cursor deadlocks until the caller's
+// context expires — with the desktop's boot context, forever.
+func TestListTopicsHydratesSessionsOffTheTopicCursor(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for _, topicID := range []string{"topic-a", "topic-b"} {
+		if err := catalog.UpsertSession(ctx, SessionRecord{
+			Path: filepath.Join("/s", topicID+".jsonl"), Directory: "/s", Scope: "global",
+			TopicID: topicID, TopicTitle: topicID, Turns: 1, TurnsState: TurnsValid,
+			Health: HealthOK, LastActivityAt: 1,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A regression cannot hang the suite: it starves the pool and this deadline
+	// turns the deadlock into a failed call.
+	listCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	page, err := catalog.ListTopics(listCtx, TopicPageRequest{Scope: "global", Limit: MaxLimit})
+	if err != nil {
+		t.Fatalf("ListTopics on a single-connection catalog: %v", err)
+	}
+	if len(page.Items) != 2 {
+		t.Fatalf("topics = %d, want both hydrated topics", len(page.Items))
+	}
+	for _, item := range page.Items {
+		if len(item.Sessions) != 1 {
+			t.Fatalf("topic %q sessions = %d, want 1", item.TopicID, len(item.Sessions))
+		}
+	}
+}
+
+// The disk pool is four connections and every in-flight ListTopics pins one for
+// its topic cursor, so four concurrent sidebar reads used to leave the nested
+// session queries with nothing left to acquire and no deadline to break out of.
+func TestListTopicsSurvivesReadersAtThePoolLimit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	for i := range 50 {
+		topicID := fmt.Sprintf("topic-%02d", i)
+		if err := catalog.UpsertSession(ctx, SessionRecord{
+			Path: filepath.Join("/s", topicID+".jsonl"), Directory: "/s", Scope: "global",
+			TopicID: topicID, TopicTitle: topicID, Turns: 1, TurnsState: TurnsValid,
+			Health: HealthOK, LastActivityAt: int64(i + 1),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	const readers = 8
+	results := make(chan error, readers)
+	for range readers {
+		go func() {
+			page, err := catalog.ListTopics(listCtx, TopicPageRequest{Scope: "global", Limit: MaxLimit})
+			if err == nil && len(page.Items) != 50 {
+				err = fmt.Errorf("topics = %d, want 50", len(page.Items))
+			}
+			results <- err
+		}()
+	}
+	for range readers {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent ListTopics: %v", err)
+		}
+	}
+}
+
+// A memory-mode catalog pools exactly one connection, so any API that holds a
+// connection while asking the pool for another deadlocks here and nowhere else
+// until production saturates a disk pool. This is the general guard: it fails
+// on the API that reintroduces the nesting, not on ListTopics specifically.
+func TestCatalogAPIsSurviveASingleConnectionPool(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		Scope: "project", WorkspaceRoot: "/workspace", TopicID: "topic-1",
+		TopicTitle: "Topic", SchemaVersion: agent.BranchMetaCountsVersion, Turns: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	target := DirectoryTarget{Path: dir, Scope: "project", WorkspaceRoot: "/workspace"}
+	key := TopicKey{Scope: "project", WorkspaceRoot: "/workspace", TopicID: "topic-1"}
+
+	// One deadline across the whole surface: a regression surfaces as this
+	// step's error instead of a hung test binary.
+	call, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	steps := []struct {
+		name string
+		run  func() error
+	}{
+		{"ReconcileDirectory", func() error { return catalog.ReconcileDirectory(call, target) }},
+		{"IndexSessionPath", func() error { return catalog.IndexSessionPath(call, target, path) }},
+		{"SyncMetadata", func() error {
+			return catalog.SyncMetadata(call,
+				[]ProjectRecord{{Scope: "project", WorkspaceRoot: "/workspace", Title: "W"}},
+				[]TopicMetadata{{Scope: "project", WorkspaceRoot: "/workspace", TopicID: "topic-1", Title: "Topic"}})
+		}},
+		{"ListTopics", func() error {
+			page, err := catalog.ListTopics(call, TopicPageRequest{Scope: "project", WorkspaceRoot: "/workspace", Limit: MaxLimit})
+			if err == nil && len(page.Items) != 1 {
+				return fmt.Errorf("topics = %d, want 1", len(page.Items))
+			}
+			return err
+		}},
+		{"GetTopic", func() error {
+			topic, ok, err := catalog.GetTopic(call, key)
+			if err == nil && (!ok || len(topic.Sessions) != 1) {
+				return fmt.Errorf("topic ok=%v sessions=%d, want one session", ok, len(topic.Sessions))
+			}
+			return err
+		}},
+		{"ListSessions", func() error {
+			page, err := catalog.ListSessions(call, SessionPageRequest{Scope: "project", WorkspaceRoot: "/workspace", Limit: MaxLimit})
+			if err == nil && len(page.Items) != 1 {
+				return fmt.Errorf("sessions = %d, want 1", len(page.Items))
+			}
+			return err
+		}},
+		{"GetSession", func() error {
+			if _, ok, err := catalog.GetSession(call, path); err != nil || !ok {
+				return fmt.Errorf("ok=%v err=%v", ok, err)
+			}
+			return nil
+		}},
+		{"RemoveSession", func() error { return catalog.RemoveSession(call, path, "test") }},
+	}
+	for _, step := range steps {
+		if err := step.run(); err != nil {
+			t.Fatalf("%s on a single-connection catalog: %v", step.name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `ListTopics` hydrated each topic's sessions from **inside the open topic cursor**. The cursor pins one pooled connection and `listTopicSessions` asks for a second, so the call deadlocks whenever the pool is saturated — always in memory mode, where `projectiondb` pools a single connection (`maxOpen = 1`), and at four concurrent sidebar reads on disk (`MaxOpenConns: 4`). The frontend loads one topic page per expanded project, concurrently, so four expanded projects are enough.
- Nothing bounded the wait: the sidebar read path and the catalog goroutine's periodic metadata sync both ran on the deadline-less boot context, so one starved call silently froze every later index, reconcile, and revision bump. Observed on a running desktop: the session catalog took no write for 40 minutes (WAL byte-identical, last directory scan frozen mid-afternoon) while the other three projections kept writing normally.
- The user-visible result is a sidebar that stops moving with no error anywhere: without a revision bump the frontend never reloads a topic page, and `ListTopics` skips any topic with no indexed session row — so the session the user was actively running was missing from the tree until the app restarted.

Fix:

- Drain the topic page before hydrating sessions; no query nested inside an open cursor.
- Bound the sidebar reads (10s) and the background metadata sync (30s) so a starved pool degrades into a stale page the next revision repairs, instead of a permanent freeze.
- Merge live tabs into an uncursored topic page: a session this app is running is never hidden because the projection lags.

## Issues

## Verification

- The new guards in `internal/sessioncatalog/connection_pool_test.go` were run against the parent commit (`ea9ee16e4`) in a scratch worktree and **fail there** with `context deadline exceeded` after 15s / 30s, then pass in ~0.1s with this fix:
  - `TestListTopicsHydratesSessionsOffTheTopicCursor` — memory mode, single-connection pool
  - `TestListTopicsSurvivesReadersAtThePoolLimit` — disk pool, 8 concurrent readers
  - `TestCatalogAPIsSurviveASingleConnectionPool` — the whole API surface (reconcile, index, sync, list, get, remove) on a pool of one, so any future path that holds a connection while waiting for another fails by name instead of only under production saturation
- `go test ./internal/sessioncatalog/ ./internal/tool/builtin/ ./internal/boot/`
- `cd desktop && go test . -count=1` → ok in 70s; the same selection previously hit the 10-minute deadlock timeout.
- `make lint` (golangci-lint 0 issues, repolint clean) and `go vet ./...` in both modules.
- Rebuilt and installed the desktop app locally: the session that had been missing from the sidebar is indexed on the first reconcile and ranks first in its project, and the catalog keeps writing afterwards (WAL advancing, three live pooled connections).

## Documentation impact

Documentation-impact: none - internal projection and sidebar read paths only

## Cache impact

Cache-impact: none - no prompt, tool schema, or provider request changes
Cache-guard: not applicable - no cache-sensitive file in the diff; scripts/check-cache-impact.sh reports none
System-prompt-review: N/A
