### PR TITLE
refactor(agent): separate the collaborators from the state

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -150,13 +150,13 @@ func (a *Agent) withAgentContext(ctx context.Context) context.Context {
 	if a == nil {
 		return ctx
 	}
-	if a.jobs != nil {
-		ctx = jobs.WithManager(ctx, a.jobs)
+	if a.svc.jobs != nil {
+		ctx = jobs.WithManager(ctx, a.svc.jobs)
 	} else {
 		ctx = jobs.WithoutManager(ctx)
 	}
-	if a.memQueue != nil {
-		ctx = memory.WithQueue(ctx, a.memQueue)
+	if a.svc.memQueue != nil {
+		ctx = memory.WithQueue(ctx, a.svc.memQueue)
 	} else {
 		ctx = memory.WithoutQueue(ctx)
 	}
@@ -282,32 +282,21 @@ type ToolHooks interface {
 // into the main loop.
 type Agent struct {
 	agentConfig
-	prov  provider.Provider
-	tools *tool.Registry
+	// svc are the collaborators this agent talks to; see services.go.
+	svc agentServices
 	// sess is the state one conversation owns; SetSession restarts it. See
 	// sessionstate.go.
 	sess sessionRuntime
 	// executorHandoffGuard is enabled by Coordinator only for the executor agent.
 	executorHandoffGuard bool
-	pricing              *provider.Pricing
 	responseLanguage     atomic.Value // string: auto|zh|en
 	reasoningLanguage    atomic.Value // string: auto|zh|en
 
-	// sink receives the turn's typed event stream (reasoning/text deltas, tool
-	// dispatch/results, usage, notices). Frontends decide how to render it;
-	// never nil because New defaults it to event.Discard.
-	sink                event.Sink
 	requireVisibleFinal bool // internal callers require final Content
 
 	// unwrittenResolve is the resolve watermark a failed state write still owes.
 	// It outlives the conversation, which is why it is not in sessionRuntime.
 	unwrittenResolve unwrittenResolve
-
-	// missingReasoningWarnState rate-limits recovery retries across sessions and
-	// processes by an opaque provider-configuration fingerprint (#7059). The
-	// legacy type/file names preserve the on-disk v2 contract. nil (no dir in
-	// Options) keeps in-memory active-incident gating only.
-	missingReasoningWarnState *missingReasoningWarnState
 
 	// planMode enables planning workflow instructions and explicit phase opt-outs.
 	// It does not replace the permission or sandbox boundary. The system prompt and
@@ -333,74 +322,11 @@ type Agent struct {
 	// false and still require readOnlyHint.
 	plannerMCPExecution bool
 
-	// gate, when non-nil, is the per-call permission gate for both standard and
-	// Plan workflows. nil disables gating entirely.
-	gate Gate
-
-	// extensions, when non-nil, is the frozen Extension Protocol v2 dispatcher
-	// for this controller generation. The run loop consults it at the
-	// agent-side intercept points (see extensions.go); nil means no runtime
-	// packages are installed and every point passes through byte-identically.
-	extensions *dispatch.Dispatcher
-
-	// recoveryGate, when non-nil, is the Auto Guard boundary for Auto mode.
-	// Shared by root and sub-agents for the same controller task. nil disables
-	// recovery checks (Ask/YOLO, headless without wiring, or feature off).
-	recoveryGate RecoveryGate
 	// recovery is who this agent is to the shared gate above.
 	recovery recoveryIdentity
 
-	// planModeReadOnlyTrust is retained for legacy controller wiring. The main
-	// Plan execution path no longer consults it.
-	planModeReadOnlyTrust PlanModeReadOnlyTrustGate
-
-	// sandboxEscapeApprover, when non-nil, can ask the user whether one shell
-	// command may rerun unconfined after the OS sandbox failed to start.
-	sandboxEscapeApprover sandbox.EscapeApprover
-
-	// configWriteApprover, when non-nil, can ask the user whether a file tool
-	// may write a Reasonix-managed config file outside the workspace roots.
-	configWriteApprover tool.ConfigWriteApprover
-
-	// hooks, when non-nil, fires PreToolUse / PostToolUse shell hooks around each
-	// tool call. nil disables hook firing.
-	hooks ToolHooks
-
-	// asker, when non-nil, lets the `ask` tool put questions to the user. nil in
-	// headless runs (no interactive user). Set via SetAsker.
-	asker Asker
-
-	// onPreEdit, when non-nil, is called with a writer tool's previewed change
-	// just before it runs — the seam the checkpoint store uses to snapshot a
-	// file's pre-edit content. Only fires for non-ReadOnly tools that implement
-	// tool.Previewer (so bash, whose targets are unknowable, is never tracked).
-	// Set via SetPreEditHook. Prefer mutationObserver when both are set.
-	onPreEdit func(diff.Change)
-
-	// mutationObserver is the host-side unified file mutation observer. It
-	// captures preimages before tools run and after-fingerprints regardless of
-	// success/failure. Passed through Options to sub-agents; never changes
-	// provider-visible tool schemas or prompts.
-	mutationObserver *checkpoint.MutationObserver
-
-	// jobs, when non-nil, is the session's background-job manager. executeOne
-	// stamps it onto each tool call's context so the background tools (bash
-	// run_in_background, task run_in_background, bash_output/kill_shell/wait) can
-	// reach it. nil leaves those tools to degrade gracefully.
-	jobs *jobs.Manager
-
-	// writeScheduler coordinates parent-agent writes against background
-	// subagent write claims. Set on the parent executor only (subagentDepth 0);
-	// reservation is taken around Execute so late-loaded MCP/Economy tools are
-	// covered without registry wrapping. Provider-visible schemas are unchanged.
-	writeScheduler *SubagentScheduler
 	// writeWorkspaceRoot is the workspace used to normalize parent write
 	// reservations when writeScheduler is set.
-
-	// workspaceLease is shared by every writer-capable agent in one Delivery
-	// session. It is acquired lazily on the first mutation and held through the
-	// final participating run/background job so verification remains isolated.
-	workspaceLease *workspacelease.Owner
 
 	// steerQueue holds mid-turn guidance admitted while the agent is running.
 	// Entries keep a durable inbox item ID plus a loader so full bodies are not
@@ -464,11 +390,6 @@ type Agent struct {
 	// capabilityGate is the turn's gate memory across final-answer retries.
 	capabilityGate capabilityGateState
 
-	// memQueue, when non-nil, lets the remember/forget tools fold a turn-tail note
-	// about a just-made memory change into the next turn, so it applies this
-	// session without touching the cache-stable prefix. Set via SetMemoryQueue.
-	memQueue memory.Queue
-
 	// subagentDepth tracks the current agent's nesting depth. maxSubagentDepth
 	// caps delegation; when reached, recursive agent/skill tools are excluded.
 
@@ -512,7 +433,7 @@ func (a *Agent) SetTools(tools *tool.Registry) {
 	if a == nil {
 		return
 	}
-	a.tools = tools
+	a.svc.tools = tools
 }
 
 // SetReasoningLanguage updates the visible reasoning language preference for
@@ -540,7 +461,7 @@ func (a *Agent) SetGate(g Gate) {
 	if nilutil.IsNil(g) {
 		g = nil
 	}
-	a.gate = g
+	a.svc.gate = g
 }
 
 // SetExtensions installs the extension dispatcher after construction. Boot
@@ -551,7 +472,7 @@ func (a *Agent) SetExtensions(d *dispatch.Dispatcher) {
 	if a == nil {
 		return
 	}
-	a.extensions = d
+	a.svc.extensions = d
 }
 
 // SetRecoveryGate installs Auto Guard. Safe to call before the run loop starts;
@@ -563,7 +484,7 @@ func (a *Agent) SetRecoveryGate(g RecoveryGate) {
 	if nilutil.IsNil(g) {
 		g = nil
 	}
-	a.recoveryGate = g
+	a.svc.recoveryGate = g
 }
 
 // SetRecoveryIdentity sets the agent/task labels used on recovery cards.
@@ -580,7 +501,7 @@ func (a *Agent) RecoveryGate() RecoveryGate {
 	if a == nil {
 		return nil
 	}
-	return a.recoveryGate
+	return a.svc.recoveryGate
 }
 
 // SetPlanModeReadOnlyTrustGate retains the legacy confirmation bridge for old
@@ -589,7 +510,7 @@ func (a *Agent) SetPlanModeReadOnlyTrustGate(g PlanModeReadOnlyTrustGate) {
 	if nilutil.IsNil(g) {
 		g = nil
 	}
-	a.planModeReadOnlyTrust = g
+	a.svc.planTrust = g
 }
 
 // SetSandboxEscapeApprover installs the optional one-shot approval path used by
@@ -598,7 +519,7 @@ func (a *Agent) SetSandboxEscapeApprover(g sandbox.EscapeApprover) {
 	if nilutil.IsNil(g) {
 		g = nil
 	}
-	a.sandboxEscapeApprover = g
+	a.svc.sandboxEscape = g
 }
 
 // SetConfigWriteApprover installs the optional per-write approval path used by
@@ -608,7 +529,7 @@ func (a *Agent) SetConfigWriteApprover(g tool.ConfigWriteApprover) {
 	if nilutil.IsNil(g) {
 		g = nil
 	}
-	a.configWriteApprover = g
+	a.svc.configWrite = g
 }
 
 func (a *Agent) withTurnPreferences(input string) string {
@@ -637,26 +558,26 @@ func (a *Agent) withTurnPreferences(input string) string {
 
 // SetAsker installs the asker the `ask` tool uses to question the user.
 // Interactive frontends wire one in; headless runs leave it nil.
-func (a *Agent) SetAsker(as Asker) { a.asker = as }
+func (a *Agent) SetAsker(as Asker) { a.svc.asker = as }
 
 // SetMemoryQueue installs the sink the remember/forget tools use to apply a
 // memory change in the current session. The controller wires itself in.
-func (a *Agent) SetMemoryQueue(q memory.Queue) { a.memQueue = q }
+func (a *Agent) SetMemoryQueue(q memory.Queue) { a.svc.memQueue = q }
 
 // SetPreEditHook installs the pre-edit snapshot hook (see onPreEdit). The
 // controller wires it to its per-session checkpoint store; nil disables capture.
 // Prefer SetMutationObserver for v2 capture (before+after fingerprints).
-func (a *Agent) SetPreEditHook(fn func(diff.Change)) { a.onPreEdit = fn }
+func (a *Agent) SetPreEditHook(fn func(diff.Change)) { a.svc.preEdit = fn }
 
 // SetMutationObserver installs the unified mutation observer. When set, it
 // supersedes onPreEdit for capture and also records after-mutation fingerprints.
 // When a task tool is already registered it inherits the observer for sub-agents.
 func (a *Agent) SetMutationObserver(obs *checkpoint.MutationObserver) {
-	a.mutationObserver = obs
-	if a.tools == nil || obs == nil {
+	a.svc.mutationObserver = obs
+	if a.svc.tools == nil || obs == nil {
 		return
 	}
-	if t, ok := a.tools.Get("task"); ok {
+	if t, ok := a.svc.tools.Get("task"); ok {
 		if task, ok := t.(*TaskTool); ok {
 			task.WithMutationObserver(obs)
 		}
@@ -668,7 +589,7 @@ func (a *Agent) MutationObserver() *checkpoint.MutationObserver {
 	if a == nil {
 		return nil
 	}
-	return a.mutationObserver
+	return a.svc.mutationObserver
 }
 
 // Session returns the agent's current conversation, useful for persistence
@@ -819,7 +740,7 @@ func (a *Agent) SetSink(sink event.Sink) {
 	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
-	a.sink = sink
+	a.svc.sink = sink
 }
 
 func (a *Agent) consumeSteer() (text, itemID string, ok bool) {
@@ -906,7 +827,7 @@ func (a *Agent) RecordUnappliedSteer(text string, itemID ...string) {
 		Name:       provider.LocalOnlyToolName,
 		LocalOnly:  true,
 	})
-	a.sink.Emit(event.Event{
+	a.svc.sink.Emit(event.Event{
 		Kind:   event.Notice,
 		Level:  event.LevelWarn,
 		Code:   event.NoticeCodeUnappliedSteer,
@@ -1153,6 +1074,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		reasoningByteLimit = defaultReasoningByteLimit
 	}
 	a := &Agent{
+		svc: newAgentServices(prov, tools, sink, gate, planModeReadOnlyTrust,
+			sandboxEscapeApprover, configWriteApprover, hooks, opts),
 		agentConfig: agentConfig{
 			maxSteps:           opts.MaxSteps,
 			maxStepsKey:        maxStepsKey,
@@ -1171,8 +1094,6 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 			recentKeep:         opts.RecentKeep,
 			archiveDir:         opts.ArchiveDir,
 		},
-		prov:  prov,
-		tools: tools,
 		sess: sessionRuntime{
 			conversation: session,
 			path:         strings.TrimSpace(opts.SessionPath),
@@ -1182,35 +1103,20 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 			ledger: evidence.NewLedger(),
 			budget: runBudget{limit: normalizeTaskBudget(opts.TaskBudget)},
 		},
-		pricing:             opts.Pricing,
-		sink:                sink,
 		requireVisibleFinal: opts.RequireVisibleFinal,
-		gate:                gate,
-		extensions:          opts.Extensions,
-		recoveryGate:        opts.RecoveryGate,
 		recovery: recoveryIdentity{
 			agentID: strings.TrimSpace(opts.RecoveryAgentID),
 			taskID:  strings.TrimSpace(opts.RecoveryTaskID),
 		},
-		readOnlyExecution:         opts.ReadOnlyExecution,
-		plannerMCPExecution:       opts.PlannerMCPExecution,
-		planModeReadOnlyTrust:     planModeReadOnlyTrust,
-		sandboxEscapeApprover:     sandboxEscapeApprover,
-		configWriteApprover:       configWriteApprover,
-		hooks:                     hooks,
-		jobs:                      opts.Jobs,
-		memQueue:                  opts.MemoryQueue,
-		writeScheduler:            opts.WriteScheduler,
-		workspaceLease:            opts.WorkspaceLease,
-		missingReasoningWarnState: missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
-		projectChecks:             append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
-		deliveryProfile:           opts.DeliveryProfile || agentpreset.Normalize(opts.AgentPreset) == agentpreset.Delivery,
-		ablation:                  opts.Ablation,
-		capabilityLedger:          opts.CapabilityLedger,
-		capabilityAudit:           opts.CapabilityAudit,
-		keepPolicy:                opts.KeepPolicy,
-		strictAlternatingRoles:    opts.StrictAlternatingRoles,
-		mutationObserver:          opts.MutationObserver,
+		readOnlyExecution:      opts.ReadOnlyExecution,
+		plannerMCPExecution:    opts.PlannerMCPExecution,
+		projectChecks:          append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
+		deliveryProfile:        opts.DeliveryProfile || agentpreset.Normalize(opts.AgentPreset) == agentpreset.Delivery,
+		ablation:               opts.Ablation,
+		capabilityLedger:       opts.CapabilityLedger,
+		capabilityAudit:        opts.CapabilityAudit,
+		keepPolicy:             opts.KeepPolicy,
+		strictAlternatingRoles: opts.StrictAlternatingRoles,
 	}
 	a.sess.output.outputBudget = outputBudgetOf(prov)
 	if a.sess.path != "" {
@@ -1294,7 +1200,7 @@ func missingReasoningWarnStateFor(dir string) *missingReasoningWarnState {
 // (subagent, read-only, no scheduler, or non-write tool).
 func (a *Agent) reserveParentWrite(runTool tool.Tool, args json.RawMessage, readOnly bool) (release func(), err error) {
 	noop := func() {}
-	if a == nil || a.writeScheduler == nil || a.subagentDepth > 0 || readOnly || runTool == nil {
+	if a == nil || a.svc.writeScheduler == nil || a.subagentDepth > 0 || readOnly || runTool == nil {
 		return noop, nil
 	}
 	name := runTool.Name()
@@ -1305,7 +1211,7 @@ func (a *Agent) reserveParentWrite(runTool tool.Tool, args json.RawMessage, read
 	if err != nil {
 		return noop, err
 	}
-	return a.writeScheduler.ReserveParentWrite(claim)
+	return a.svc.writeScheduler.ReserveParentWrite(claim)
 }
 
 // Run appends the user input and drives the tool loop until the model returns a
@@ -1327,9 +1233,9 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	a.recovery.runSeq.Add(1)
 	// All role settings participate in the workspace lease for the run; the
 	// exclusive write lock is still acquired lazily on the first real writer.
-	if a.workspaceLease != nil {
-		a.workspaceLease.BeginRun()
-		defer a.workspaceLease.EndRun()
+	if a.svc.workspaceLease != nil {
+		a.svc.workspaceLease.BeginRun()
+		defer a.svc.workspaceLease.EndRun()
 	}
 	turnStartedAt := time.Now()
 	workDurationMs := func() int64 {
@@ -1351,11 +1257,11 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	// job's evidence can be permanently drained. A failed or cancelled turn
 	// leaves the lease uncommitted so the next turn re-collects it.
 	defer func() {
-		if runErr != nil || a.task.ledger == nil || a.jobs == nil {
+		if runErr != nil || a.task.ledger == nil || a.svc.jobs == nil {
 			return
 		}
 		for _, lease := range a.task.ledger.BackgroundLeases() {
-			a.jobs.CommitEvidenceForSession(lease.Session, lease.JobID)
+			a.svc.jobs.CommitEvidenceForSession(lease.Session, lease.JobID)
 		}
 	}()
 	if _, scoped := DeliveryExecutionScopeFromContext(ctx); scoped {
@@ -1567,9 +1473,9 @@ func (a *Agent) emitTodoState(todos []evidence.TodoItem, itemIndex int) {
 	}
 	id := fmt.Sprintf("host-advance-%d-%d", a.hostAdvanceSeq.Add(1), itemIndex)
 	t := event.Tool{ID: id, Name: "todo_write", Args: string(args), ReadOnly: true}
-	a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
+	a.svc.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
 	t.Output = "task list advanced by complete_step"
-	a.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
+	a.svc.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
 }
 
 // RebuildTodoState re-derives canonical task state from the current session
@@ -1878,7 +1784,7 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 	// up we buffer reasoning silently and emit the transformed text once after the
 	// stream. With no such hook the reasoning streams live, chunk by chunk, as
 	// before — the common case must not lose its live "thinking…" display.
-	transformReasoning := a.hooks != nil && a.hooks.HasPostLLMCall()
+	transformReasoning := a.svc.hooks != nil && a.svc.hooks.HasPostLLMCall()
 
 	var text, reasoning strings.Builder
 	var signature string                    // provider-issued proof for the reasoning (Anthropic thinking)
@@ -1905,14 +1811,14 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 		original := reasoning.String()
 		display = original
 		if transformReasoning && original != "" {
-			display = a.hooks.PostLLMCall(ctx, original, turn)
+			display = a.svc.hooks.PostLLMCall(ctx, original, turn)
 			if display != "" {
 				sink.Emit(event.Event{Kind: event.Reasoning, Text: display})
 			}
 		}
 		stored = display
 		providerBound := signature != "" || reasoningID != "" || reasoningStatus != ""
-		if providerBound || provider.RequiresReasoningRoundTrip(a.prov) || (len(calls) > 0 && provider.RequiresToolCallReasoning(a.prov)) {
+		if providerBound || provider.RequiresReasoningRoundTrip(a.svc.prov) || (len(calls) > 0 && provider.RequiresToolCallReasoning(a.svc.prov)) {
 			stored = original
 		}
 		return stored, display
@@ -2223,7 +2129,7 @@ func toProviderToolExecution(in *tool.ShellExecution) *provider.ToolExecution {
 }
 
 func (a *Agent) emitFullToolDispatch(ctx context.Context, c provider.ToolCall, refreshed bool) {
-	t, _, ambiguous := a.tools.ResolveCall(c.Name)
+	t, _, ambiguous := a.svc.tools.ResolveCall(c.Name)
 	ok := t != nil && len(ambiguous) == 0
 	ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly(), Refreshed: refreshed}
 	ev.FileDiff = event.FileDiff{Diff: c.Diff, Added: c.Added, Removed: c.Removed}
@@ -2239,7 +2145,7 @@ func (a *Agent) emitFullToolDispatch(ctx context.Context, c provider.ToolCall, r
 			ev.Profile = pr.ResolveProfile(json.RawMessage(c.Arguments))
 		}
 	}
-	a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: ev})
+	a.svc.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: ev})
 }
 
 // emitResolvedToolDispatch upserts the real target classification of a stable
@@ -2250,13 +2156,13 @@ func (a *Agent) emitResolvedToolDispatch(c provider.ToolCall) {
 		return
 	}
 	if c.ResolvedName != "" && c.ResolvedName != c.Name {
-		EmitProxyAudit(a.sink, tool.ResolvedCall{
+		EmitProxyAudit(a.svc.sink, tool.ResolvedCall{
 			DisplayName:  c.Name,
 			TargetName:   c.ResolvedName,
 			CapabilityID: c.CapabilityID,
 		})
 	}
-	a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+	a.svc.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
 		ID:           c.ID,
 		Name:         c.Name,
 		Args:         c.Arguments,
@@ -2302,7 +2208,7 @@ func (a *Agent) withPreviewFileDiffs(ctx context.Context, calls []provider.ToolC
 		if out[i].Diff != "" || out[i].Added != 0 || out[i].Removed != 0 {
 			continue
 		}
-		t, _, ambiguous := a.tools.ResolveCall(out[i].Name)
+		t, _, ambiguous := a.svc.tools.ResolveCall(out[i].Name)
 		ok := t != nil && len(ambiguous) == 0
 		if !ok {
 			continue
@@ -2834,7 +2740,7 @@ func isBackgroundTaskCall(args string) bool {
 // toolReadOnly reports a tool's ReadOnly classification by name (false for an
 // unknown tool), for stamping early ToolDispatch events.
 func (a *Agent) toolReadOnly(name string) bool {
-	t, _, ambiguous := a.tools.ResolveCall(name)
+	t, _, ambiguous := a.svc.tools.ResolveCall(name)
 	return t != nil && len(ambiguous) == 0 && t.ReadOnly()
 }
 

--- a/internal/agent/arbiter.go
+++ b/internal/agent/arbiter.go
@@ -46,7 +46,7 @@ func (a *Agent) applyInterventions(results []string, outcomes []toolOutcome, ivs
 			strongest = iv.verdict
 		}
 		if iv.notice != nil {
-			a.sink.Emit(*iv.notice)
+			a.svc.sink.Emit(*iv.notice)
 		}
 		if iv.guidance != "" {
 			guidance = append(guidance, iv.guidance)

--- a/internal/agent/arbiter_test.go
+++ b/internal/agent/arbiter_test.go
@@ -15,7 +15,7 @@ func arbiterRound() ([]string, []toolOutcome) {
 // that fired two of them delivered only the last one's guidance.
 func TestApplyInterventionsKeepsEveryFiredGuidance(t *testing.T) {
 	sink := &ebmSink{}
-	a := &Agent{sink: sink}
+	a := &Agent{svc: agentServices{sink: sink}}
 	results, outcomes := arbiterRound()
 
 	got := a.applyInterventions(results, outcomes,
@@ -40,7 +40,7 @@ func TestApplyInterventionsKeepsEveryFiredGuidance(t *testing.T) {
 
 func TestApplyInterventionsLeavesQuietRoundsUntouched(t *testing.T) {
 	sink := &ebmSink{}
-	a := &Agent{sink: sink}
+	a := &Agent{svc: agentServices{sink: sink}}
 	results, outcomes := arbiterRound()
 
 	if got := a.applyInterventions(results, outcomes, intervention{}, intervention{}); got != verdictContinue {
@@ -53,7 +53,7 @@ func TestApplyInterventionsLeavesQuietRoundsUntouched(t *testing.T) {
 
 // A land must survive being raised beside a lower tier in the same round.
 func TestApplyInterventionsTakesTheStrongestVerdict(t *testing.T) {
-	a := &Agent{sink: &ebmSink{}}
+	a := &Agent{svc: agentServices{sink: &ebmSink{}}}
 	results, outcomes := arbiterRound()
 
 	got := a.applyInterventions(results, outcomes,

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -35,7 +35,7 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 
 func TestAdvanceCanonicalTodoCompletesAndPromotes(t *testing.T) {
 	a := &Agent{
-		sink: event.Discard,
+		svc: agentServices{sink: event.Discard},
 		sess: sessionRuntime{todoState: []evidence.TodoItem{
 			{Content: "sync branch", Status: "in_progress"},
 			{Content: "push to origin", Status: "pending"},
@@ -56,7 +56,7 @@ func TestAdvanceCanonicalTodoCompletesAndPromotes(t *testing.T) {
 }
 
 func TestAdvanceCanonicalTodoRejectsPendingMatchByNumber(t *testing.T) {
-	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
+	a := &Agent{svc: agentServices{sink: event.Discard}, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "first", Status: "in_progress"},
 		{Content: "second", Status: "pending"},
 	}}}
@@ -194,7 +194,7 @@ func TestRebuildTodoStateHonorsEmptyTodoWriteClear(t *testing.T) {
 }
 
 func TestSeedTodoState(t *testing.T) {
-	a := &Agent{sink: event.Discard}
+	a := &Agent{svc: agentServices{sink: event.Discard}}
 	todos := []evidence.TodoItem{
 		{Content: "step 1", Status: "in_progress"},
 		{Content: "step 2", Status: "pending"},
@@ -209,7 +209,7 @@ func TestSeedTodoState(t *testing.T) {
 }
 
 func TestSeedTodoStateReplacesExisting(t *testing.T) {
-	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
+	a := &Agent{svc: agentServices{sink: event.Discard}, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "existing", Status: "in_progress"},
 	}}}
 	a.SeedTodoState([]evidence.TodoItem{
@@ -221,7 +221,7 @@ func TestSeedTodoStateReplacesExisting(t *testing.T) {
 }
 
 func TestSeedTodoStateAllowsAdvanceAfterSeed(t *testing.T) {
-	a := &Agent{sink: event.Discard}
+	a := &Agent{svc: agentServices{sink: event.Discard}}
 	a.SeedTodoState([]evidence.TodoItem{
 		{Content: "step 1", Status: "in_progress"},
 		{Content: "step 2", Status: "pending"},
@@ -236,7 +236,7 @@ func TestSeedTodoStateAllowsAdvanceAfterSeed(t *testing.T) {
 }
 
 func TestAdvanceCanonicalTodoWalksPhaseChain(t *testing.T) {
-	a := &Agent{sink: event.Discard, sess: sessionRuntime{todoState: []evidence.TodoItem{
+	a := &Agent{svc: agentServices{sink: event.Discard}, sess: sessionRuntime{todoState: []evidence.TodoItem{
 		{Content: "Port the parser", Status: "pending"},
 		{Content: "move files", Status: "in_progress", Level: 1},
 		{Content: "fix imports", Status: "pending", Level: 1},

--- a/internal/agent/capability_gate.go
+++ b/internal/agent/capability_gate.go
@@ -238,8 +238,8 @@ func (a *Agent) deliveryReviewGateFailure() string {
 		}
 	}
 	paths := productionPaths(a.task.ledger.PathsSince(mutation))
-	hasReviewTool := a.tools != nil && (toolPresent(a.tools, "review") || toolPresent(a.tools, "run_skill") || toolPresent(a.tools, "use_capability"))
-	hasSecurityTool := a.tools != nil && (toolPresent(a.tools, "security_review") || toolPresent(a.tools, "run_skill") || toolPresent(a.tools, "use_capability"))
+	hasReviewTool := a.svc.tools != nil && (toolPresent(a.svc.tools, "review") || toolPresent(a.svc.tools, "run_skill") || toolPresent(a.svc.tools, "use_capability"))
+	hasSecurityTool := a.svc.tools != nil && (toolPresent(a.svc.tools, "security_review") || toolPresent(a.svc.tools, "run_skill") || toolPresent(a.svc.tools, "use_capability"))
 	switch risk {
 	case evidence.RiskLow:
 		// Existing light review (read/diff) already checked elsewhere.

--- a/internal/agent/capability_gate_test.go
+++ b/internal/agent/capability_gate_test.go
@@ -21,7 +21,7 @@ func TestDeliveryReviewGateExplainsOpaqueMutationRecovery(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, svc: agentServices{tools: reg}}
 
 	got := a.deliveryReviewGateFailure()
 	for _, want := range []string{"high-risk", "git status --short", "git diff", "mutation did not report file paths"} {
@@ -62,7 +62,7 @@ func TestNonDeliveryProfileNeverRequiresStructuredReview(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: false, task: taskRuntime{ledger: ledger}, tools: reg}
+	a := &Agent{deliveryProfile: false, task: taskRuntime{ledger: ledger}, svc: agentServices{tools: reg}}
 
 	if got := a.deliveryReviewGateFailure(); got != "" {
 		t.Fatalf("non-Delivery review gate = %q, want disabled", got)
@@ -76,7 +76,7 @@ func TestDeliveryReviewGateHighRiskStillRequiresSecurityReview(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, svc: agentServices{tools: reg}}
 
 	if got := a.deliveryReviewGateFailure(); !strings.Contains(got, "high-risk") {
 		t.Fatalf("review gate = %q, want high-risk review demand", got)
@@ -115,7 +115,7 @@ func TestDeliveryReviewGateMediumAcceptsHostProvenVerificationAndCoverage(t *tes
 
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
-	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
+	a := &Agent{deliveryProfile: true, task: taskRuntime{ledger: ledger}, svc: agentServices{tools: reg}}
 	if got := a.deliveryReviewGateFailure(); got != "" {
 		t.Fatalf("medium-risk host proof was rejected: %q", got)
 	}
@@ -136,7 +136,7 @@ func TestDeliveryReviewGateDefersToParentInSubagents(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "review", readOnly: true})
 	reg.Add(fakeTool{name: "security_review", readOnly: true})
-	a := &Agent{agentConfig: agentConfig{subagentDepth: 1}, deliveryProfile: true, task: taskRuntime{ledger: ledger}, tools: reg}
+	a := &Agent{agentConfig: agentConfig{subagentDepth: 1}, deliveryProfile: true, task: taskRuntime{ledger: ledger}, svc: agentServices{tools: reg}}
 
 	// Inside a sub-agent the structured-review contract belongs to the parent,
 	// which receives the child's mutation receipts via mergeChildEvidence. The

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -549,7 +549,7 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 	defer func() {
 		usage = provider.UsageWithRequestAttemptCount(ctx, usage)
 		if usage != nil && (usage.TotalTokens > 0 || usage.RequestCount > 0) {
-			a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing, UsageSource: event.UsageSourceCompaction})
+			a.svc.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.svc.pricing, UsageSource: event.UsageSourceCompaction})
 		}
 	}()
 	defer trackPublishedHostStream(ctx, cancel)()
@@ -576,10 +576,10 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 	if req.MaxTokens < 256 {
 		return "", usage, fmt.Errorf("summary output budget too small (%d tokens)", req.MaxTokens)
 	}
-	if a.prov == nil {
+	if a.svc.prov == nil {
 		return "", usage, fmt.Errorf("summary unavailable")
 	}
-	ch, err := a.prov.Stream(ctx, req)
+	ch, err := a.svc.prov.Stream(ctx, req)
 	if err != nil {
 		return "", usage, err
 	}

--- a/internal/agent/compact_fold_input.go
+++ b/internal/agent/compact_fold_input.go
@@ -46,7 +46,7 @@ func summaryInputTokens(msgs []provider.Message) int {
 // estimate.
 func (a *Agent) guardedSummaryInputTokens(msgs []provider.Message) int {
 	raw := summaryInputTokens(msgs)
-	if !sharesContextWindow(a.prov) || a.configuredOutputBudget(a.maxOutputTokens) <= 0 || len(msgs) == 0 {
+	if !sharesContextWindow(a.svc.prov) || a.configuredOutputBudget(a.maxOutputTokens) <= 0 || len(msgs) == 0 {
 		return raw
 	}
 	return a.estimatedPromptTokens([]provider.Message{{
@@ -61,7 +61,7 @@ func (a *Agent) summaryInputBudget(instructions string) int {
 		return 0
 	}
 	reserve := summaryOutputReserve
-	if sharesContextWindow(a.prov) && a.configuredOutputBudget(a.maxOutputTokens) > 0 {
+	if sharesContextWindow(a.svc.prov) && a.configuredOutputBudget(a.maxOutputTokens) > 0 {
 		reserve += outputBudgetReserve
 	}
 	budget := a.contextWindow - reserve - estimateTextTokens(summarySystemPrompt) - estimateTextTokens(instructions) - 256
@@ -145,7 +145,7 @@ func (a *Agent) degradeFoldSummary(res foldSummary, mustFree bool, fold []provid
 	if !mustFree || errors.Is(cause, context.Canceled) {
 		return res, cause
 	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text:   "Context was compacted without a generated summary.",
 		Detail: fmt.Sprintf("compaction summary unavailable (%v); folded mechanically", cause)})
 	res.Text = mechanicalFoldDigest(len(fold))

--- a/internal/agent/compact_loop_e2e_test.go
+++ b/internal/agent/compact_loop_e2e_test.go
@@ -94,7 +94,7 @@ func compactionsPerTurn(t *testing.T, windowTok int, blob, finalText string, tur
 
 	a, _ := newAgent(t, srv.URL, reg, windowTok, 4)
 	started := 0
-	a.sink = event.FuncSink(func(e event.Event) {
+	a.svc.sink = event.FuncSink(func(e event.Event) {
 		switch e.Kind {
 		case event.CompactionStarted:
 			started++
@@ -154,7 +154,7 @@ func TestCompactionPausesWhenWindowTooSmall(t *testing.T) {
 	a, _ := newAgent(t, srv.URL, reg, 1600, 4)
 	started := 0
 	blocked := 0
-	a.sink = event.FuncSink(func(e event.Event) {
+	a.svc.sink = event.FuncSink(func(e event.Event) {
 		if e.Kind == event.CompactionStarted {
 			started++
 		}

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -175,7 +175,7 @@ func (a *Agent) compressVisibleRange(
 	}
 	result := plan.result
 
-	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
+	a.svc.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
 	prepared, reason, err := a.prepareVisibleCompression(ctx, trigger, plan.fold, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
@@ -234,7 +234,7 @@ func (a *Agent) compressVisibleRange(
 		return tool.CompressResult{}, err
 	}
 	a.emitCompactionTelemetry(tele)
-	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
+	a.svc.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(plan.fold), Summary: summary, Archive: state.LastReceipt.Archive,
 	}})
 	result.Status = "ok"
@@ -312,8 +312,8 @@ func (a *Agent) planVisibleCompression(snap explicitCompressionSnapshot, directi
 }
 
 func (a *Agent) prepareVisibleCompression(ctx context.Context, trigger string, fold []provider.Message, instructions string) (preparedVisibleCompression, string, error) {
-	if a.hooks != nil {
-		if hookInstructions := a.hooks.PreCompact(ctx, trigger); hookInstructions != "" {
+	if a.svc.hooks != nil {
+		if hookInstructions := a.svc.hooks.PreCompact(ctx, trigger); hookInstructions != "" {
 			if instructions != "" {
 				instructions += "\n"
 			}
@@ -410,9 +410,9 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		return CompactionNoop, fmt.Errorf("%w: fixed prefix (%d tokens) already exceeds trigger (%d)", errCheckpointRejected, fixedPrefixTokens, a.compactTrigger())
 	}
 
-	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
-	if a.hooks != nil {
-		if hookInstr := a.hooks.PreCompact(ctx, trigger); hookInstr != "" {
+	a.svc.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
+	if a.svc.hooks != nil {
+		if hookInstr := a.svc.hooks.PreCompact(ctx, trigger); hookInstr != "" {
 			if instructions != "" {
 				instructions += "\n"
 			}
@@ -467,7 +467,7 @@ func (a *Agent) compactToProjection(ctx context.Context, trigger, instructions s
 		a.emitCompactionAborted(trigger)
 		return CompactionNoop, err
 	}
-	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
+	a.svc.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(fold), Summary: summary,
 	}})
 	// Only once the checkpoint is committed: a rejected candidate folded nothing.

--- a/internal/agent/compact_threshold_test.go
+++ b/internal/agent/compact_threshold_test.go
@@ -6,7 +6,7 @@ import "testing"
 // sole compact_ratio trigger. Output is clipped only at send time.
 func TestCompactTriggerIndependentOfOutputBudget(t *testing.T) {
 	a := &Agent{
-		prov:        &sharedWindowTestProvider{budget: 131_072, shared: true},
+		svc:         agentServices{prov: &sharedWindowTestProvider{budget: 131_072, shared: true}},
 		agentConfig: agentConfig{contextWindow: 128_000, compactRatio: defaultCompactRatio},
 		sess:        sessionRuntime{output: outputBudgetState{outputBudget: 131_072}},
 	}

--- a/internal/agent/compact_user_turns.go
+++ b/internal/agent/compact_user_turns.go
@@ -67,7 +67,7 @@ func (a *Agent) noticeDroppedUserTurns(ret userTurnRetention) {
 	if ret.Dropped == 0 {
 		return
 	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 		Text: fmt.Sprintf("%s of yours %s too large to keep whole and now survive only through the summary. Prefix a turn with [[keep]] to hold it verbatim.",
 			pluralTurns(ret.Dropped), wereOrWas(ret.Dropped)),
 		Detail: fmt.Sprintf("compaction dropped %d user turn(s) (~%d tokens) past the retention budget of %d",

--- a/internal/agent/context_manager.go
+++ b/internal/agent/context_manager.go
@@ -205,8 +205,8 @@ func (a *Agent) estimatedVisibleRequestTokens(visible []provider.Message) int {
 		msgs[i].CreatedAt = 0
 	}
 	var tools []provider.ToolSchema
-	if a.tools != nil {
-		tools = a.tools.Schemas()
+	if a.svc.tools != nil {
+		tools = a.svc.tools.Schemas()
 	}
 	return a.estimatedRequestTokens(provider.Request{
 		Messages:    msgs,

--- a/internal/agent/context_receipt.go
+++ b/internal/agent/context_receipt.go
@@ -45,10 +45,10 @@ func (a *Agent) contextMaintenanceBlocked(inputHash string) (bool, string) {
 }
 
 func (a *Agent) emitContextMaintenance(r *ContextMaintenanceReceipt) {
-	if a == nil || r == nil || a.sink == nil {
+	if a == nil || r == nil || a.svc.sink == nil {
 		return
 	}
-	a.sink.Emit(event.Event{Kind: event.ContextMaintenanceEvent, Maintenance: &event.ContextMaintenance{
+	a.svc.sink.Emit(event.Event{Kind: event.ContextMaintenanceEvent, Maintenance: &event.ContextMaintenance{
 		Status: r.Status, Action: r.Action, Trigger: r.Trigger, OperationID: r.OperationID,
 		InputTokens: r.InputTokens, ResultTokens: r.ResultTokens, SavedTokens: r.SavedTokens,
 		AffectedToolResults: r.AffectedToolResults, ProjectionVersion: r.ProjectionVersion,
@@ -139,9 +139,9 @@ func (a *Agent) emitCompactionTelemetry(t CompactionTelemetry) {
 		}
 		detail += " err_type=" + t.Error
 	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compaction telemetry", Detail: detail})
+	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compaction telemetry", Detail: detail})
 }
 
 func (a *Agent) emitCompactionAborted(trigger string) {
-	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{Trigger: trigger}})
+	a.svc.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{Trigger: trigger}})
 }

--- a/internal/agent/context_usage.go
+++ b/internal/agent/context_usage.go
@@ -31,7 +31,7 @@ func (a *Agent) ContextUsedTokens() int {
 	transcriptVersion := session.TranscriptVersion()
 	projectionVersion := a.currentProjectionVersion()
 	calibration := a.sess.output.promptCalibration.Load()
-	tools := a.tools
+	tools := a.svc.tools
 	toolSchemaRevision := tools.SchemaRevision()
 	if cached := a.sess.output.contextUsage.Load(); cached != nil &&
 		cached.transcriptVersion == transcriptVersion &&

--- a/internal/agent/contract_shadow.go
+++ b/internal/agent/contract_shadow.go
@@ -161,7 +161,7 @@ func (a *Agent) observeContractRound() {
 	if c == nil || (len(c.Requirements) == 0 && len(c.Checks) == 0) {
 		return
 	}
-	event.RecordContractShadow(a.sink, contractShadowAudit(c))
+	event.RecordContractShadow(a.svc.sink, contractShadowAudit(c))
 }
 
 // emitTurnShadows records the end-of-turn shadow observations: the contract's
@@ -185,10 +185,10 @@ func (a *Agent) emitTurnShadows(input string) {
 			}
 		}
 	}
-	event.RecordContractShadow(a.sink, contractShadowAudit(c))
+	event.RecordContractShadow(a.svc.sink, contractShadowAudit(c))
 	rep := completion.Build(c, a.task.ledger)
 	a.turn.completion = &rep
-	event.RecordCompletionReport(a.sink, completionReportAudit(rep))
+	event.RecordCompletionReport(a.svc.sink, completionReportAudit(rep))
 	a.emitCompletionSummary(c)
 }
 

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -345,7 +345,7 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	}
 	routeDetail := fmt.Sprintf("planner route=%s depth=%s reason=%s", decision.Route, decision.Depth, decision.Reason)
 	if decision.Route == PlannerRouteExecutorOnly {
-		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Detail: routeDetail, Source: event.UsageSourceExecutor})
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.svc.prov.Name() + " · executing", Detail: routeDetail, Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, input)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning", Detail: routeDetail, Source: event.UsageSourcePlanner})
@@ -375,7 +375,7 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 				Detail: plannerResearchPauseDetail(err),
 				Source: event.UsageSourcePlanner,
 			})
-			c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
+			c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.svc.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 			return c.executor.Run(ctx, input)
 		}
 		// Plan-only explicitly excludes execution, while plan-for-approval
@@ -389,7 +389,7 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		// healthy and owns the full tool set, so degrade to single-model for
 		// this turn.
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: plannerFallbackNotice, Detail: "planner failed; running the executor without a plan: " + err.Error(), Source: event.UsageSourcePlanner})
-		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.svc.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, input)
 	}
 	return c.deliverPlan(ctx, input, outcome, decision)
@@ -414,7 +414,7 @@ func (c *Coordinator) deliverPlan(ctx context.Context, input string, outcome pla
 		if outcome.structured {
 			c.executor.SetPlanContract(&outcome.plan)
 		}
-		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.svc.prov.Name() + " · executing", Source: event.UsageSourceExecutor})
 		return c.executor.Run(ctx, formatHandoffWithDecision(input, planText, decision, executorToolHandoffContext(c.executor)))
 	}
 	runWithPlanApproval := func() error {
@@ -724,10 +724,10 @@ Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, 
 // executor carries MCP tools; the built-in tool list would just restate the
 // schema already attached to the request and pay its tokens every planned turn.
 func executorToolHandoffContext(a *Agent) string {
-	if a == nil || a.tools == nil {
+	if a == nil || a.svc.tools == nil {
 		return ""
 	}
-	schemas := a.tools.Schemas()
+	schemas := a.svc.tools.Schemas()
 	if len(schemas) == 0 {
 		return ""
 	}

--- a/internal/agent/delegation_admission.go
+++ b/internal/agent/delegation_admission.go
@@ -55,7 +55,7 @@ func (a *Agent) observeDelegationAdmission(calls []provider.ToolCall) {
 			continue
 		}
 		verdict, reason, intent := delegationAdmission(a.turn.recoveryTaskSummary, call.Arguments)
-		event.RecordDelegationAdmission(a.sink, event.DelegationAdmissionAudit{
+		event.RecordDelegationAdmission(a.svc.sink, event.DelegationAdmissionAudit{
 			Tool: call.Name, Verdict: verdict, Reason: reason, Intent: intentName(intent),
 		})
 	}

--- a/internal/agent/delegation_admission_test.go
+++ b/internal/agent/delegation_admission_test.go
@@ -39,7 +39,7 @@ func (s *admissionSink) RecordDelegationAdmission(a event.DelegationAdmissionAud
 
 func TestObserveDelegationAdmissionRecordsOnlyGatedTools(t *testing.T) {
 	sink := &admissionSink{}
-	a := &Agent{sink: sink}
+	a := &Agent{svc: agentServices{sink: sink}}
 	a.turn.recoveryTaskSummary = "fix the failing date parser"
 	a.observeDelegationAdmission([]provider.ToolCall{
 		{Name: "read_file", Arguments: `{"path":"a.go"}`},

--- a/internal/agent/ebm_test.go
+++ b/internal/agent/ebm_test.go
@@ -25,7 +25,7 @@ func deliverEBM(a *Agent, sample *evidence.OutcomeSample, results []string, outc
 }
 
 func TestApplyEBMStampsEligibilityWithoutFiringByDefault(t *testing.T) {
-	a := &Agent{sink: &ebmSink{}}
+	a := &Agent{svc: agentServices{sink: &ebmSink{}}}
 	sample := evidence.OutcomeSample{DebtAge: 2, BlindMutations: 3}
 	results, outcomes := ebmRound()
 	deliverEBM(a, &sample, results, outcomes)
@@ -43,7 +43,7 @@ func TestApplyEBMFiresOncePerTurnWhenEnabled(t *testing.T) {
 	defer func() { ebmEnabled = old }()
 
 	sink := &ebmSink{}
-	a := &Agent{sink: sink}
+	a := &Agent{svc: agentServices{sink: sink}}
 
 	below := evidence.OutcomeSample{DebtAge: 1, BlindMutations: 2}
 	results, outcomes := ebmRound()

--- a/internal/agent/execute_batch.go
+++ b/internal/agent/execute_batch.go
@@ -83,7 +83,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 	earlierWriterRan := false
 	surfaceWriters := make([]bool, len(calls))
 	run := func(i int) {
-		t, _, ambiguous := a.tools.ResolveCall(calls[i].Name)
+		t, _, ambiguous := a.svc.tools.ResolveCall(calls[i].Name)
 		known := t != nil && len(ambiguous) == 0
 		writer := known && !t.ReadOnly()
 		surfaceWriters[i] = writer
@@ -107,7 +107,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 			return
 		}
 		outcomes[i] = a.executeOne(ctx, turn, calls[i])
-		recordWorkspaceMutation(a.sink, outcomes[i].workspaceMutation)
+		recordWorkspaceMutation(a.svc.sink, outcomes[i].workspaceMutation)
 		if outcomes[i].executed {
 			surfaceWriters[i] = outcomes[i].workspaceMutation != nil
 		}
@@ -204,7 +204,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 				if isVerification {
 					ex.Verification = tool.ShellVerificationNotRun
 				}
-				if t, _, amb := a.tools.ResolveCall(calls[j].Name); t != nil && len(amb) == 0 {
+				if t, _, amb := a.svc.tools.ResolveCall(calls[j].Name); t != nil && len(amb) == 0 {
 					if bt, ok := t.(tool.DetailedExecutor); ok {
 						if desc := bt.ExecutionDescriptor(json.RawMessage(calls[j].Arguments)); desc != nil {
 							ex.Shell = desc.Shell
@@ -227,7 +227,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 		mutationBatchStop = true
 	}
 
-	for _, batch := range partitionToolCalls(a.tools, calls) {
+	for _, batch := range partitionToolCalls(a.svc.tools, calls) {
 		if ctx.Err() != nil {
 			markCancelled(batch.start)
 			break
@@ -280,7 +280,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 				if results[i] != "" {
 					continue
 				}
-				t, _, ambiguous := a.tools.ResolveCall(calls[i].Name)
+				t, _, ambiguous := a.svc.tools.ResolveCall(calls[i].Name)
 				known := t != nil && len(ambiguous) == 0
 				readOnly := known && t.ReadOnly()
 				if calls[i].Name == "bash" && permission.BashCommandIsReadOnly(json.RawMessage(calls[i].Arguments)) {
@@ -329,7 +329,7 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 
 	for i, c := range calls {
 		o := outcomes[i]
-		t, _, ambiguous := a.tools.ResolveCall(c.Name)
+		t, _, ambiguous := a.svc.tools.ResolveCall(c.Name)
 		ok := t != nil && len(ambiguous) == 0
 		readOnly := ok && t.ReadOnly()
 		if c.ResolvedReadOnly != nil {
@@ -357,9 +357,9 @@ func (a *Agent) executeBatch(ctx context.Context, turn *turnRuntime, calls []pro
 				tr.WorkspaceAllPaths = mutation.AllPaths
 			}
 		}
-		a.sink.Emit(event.Event{Kind: event.ToolResult, Tool: tr})
+		a.svc.sink.Emit(event.Event{Kind: event.ToolResult, Tool: tr})
 		if o.truncated && o.truncMsg != "" {
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: o.truncMsg})
+			a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: o.truncMsg})
 		}
 	}
 	a.applyBatchGuards(ctx, cancelled, calls, outcomes, results, receiptMark)
@@ -395,7 +395,7 @@ func batchCallIsMutatingFailure(a *Agent, call provider.ToolCall, o toolOutcome)
 	readOnly := false
 	toolName := call.Name
 	toolArgs := json.RawMessage(call.Arguments)
-	t, _, ambiguous := a.tools.ResolveCall(call.Name)
+	t, _, ambiguous := a.svc.tools.ResolveCall(call.Name)
 	known := t != nil && len(ambiguous) == 0
 	if known {
 		readOnly = t.ReadOnly()
@@ -437,7 +437,7 @@ func batchCallIsMutatingFailure(a *Agent, call provider.ToolCall, o toolOutcome)
 // not_run/dependency without resolving a proxy. Proxies and unknown tools
 // return false so executeOne can resolve the real target first.
 func batchCallStaticallySkippable(a *Agent, call provider.ToolCall) bool {
-	t, _, ambiguous := a.tools.ResolveCall(call.Name)
+	t, _, ambiguous := a.svc.tools.ResolveCall(call.Name)
 	if t == nil || len(ambiguous) > 0 {
 		// Unknown / ambiguous: fail closed via executeOne path.
 		return false

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -108,7 +108,7 @@ func (a *Agent) executeOne(ctx context.Context, turn *turnRuntime, call provider
 // parseToolCall resolves the canonical tool, rejects ambiguity/unknown tools,
 // and applies repeat-success and stale-anchor guards.
 func (a *Agent) parseToolCall(ctx context.Context, plan *toolCallPlan) (toolOutcome, bool) {
-	t, canonicalName, ambiguous := a.tools.ResolveCall(plan.call.Name)
+	t, canonicalName, ambiguous := a.svc.tools.ResolveCall(plan.call.Name)
 	if len(ambiguous) > 0 {
 		msg := fmt.Sprintf("ambiguous MCP tool reference %q; use one of: %s", plan.call.Name, strings.Join(ambiguous, ", "))
 		return toolOutcome{
@@ -117,7 +117,7 @@ func (a *Agent) parseToolCall(ctx context.Context, plan *toolCallPlan) (toolOutc
 		}, true
 	}
 	if t == nil {
-		if server, ok := completedMCPConnect(a.tools, plan.call.Name); ok {
+		if server, ok := completedMCPConnect(a.svc.tools, plan.call.Name); ok {
 			return toolOutcome{
 				output: fmt.Sprintf("MCP server %q is connected; its real tools are now available", server),
 			}, true
@@ -488,7 +488,7 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 		plan.recoveryGen = ctrl.Generation()
 		episodeStopped = ctrl.EpisodeStopped(a.recovery.taskID)
 	}
-	if a.recoveryGate != nil && (plan.mutates || plan.verification || plan.planTransition || episodeStopped) {
+	if a.svc.recoveryGate != nil && (plan.mutates || plan.verification || plan.planTransition || episodeStopped) {
 		subject := recoverySubject(plan.evidenceName, plan.evidenceArgs)
 		if plan.planTransition {
 			subject = "Update the active execution plan"
@@ -504,7 +504,7 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 		if ctrl := a.recoveryEpisodeControl(); ctrl != nil {
 			episodeID = ctrl.EpisodeID()
 		}
-		dec, rerr := a.recoveryGate.BeforeMutation(ctx, a.recoveryProposal(plan, episodeID, subject, preview))
+		dec, rerr := a.svc.recoveryGate.BeforeMutation(ctx, a.recoveryProposal(plan, episodeID, subject, preview))
 		if dec.Generation != 0 {
 			plan.recoveryGen = dec.Generation
 		}
@@ -549,15 +549,15 @@ func (a *Agent) applyRecoveryAndPermission(ctx context.Context, plan *toolCallPl
 				errMsg:  "blocked: MCP server identity is not authorized",
 			}, true
 		}
-		if denyGate, ok := a.gate.(ExplicitDenyGate); ok && denyGate.ExplicitlyDenies(plan.permName, plan.permArgs) {
+		if denyGate, ok := a.svc.gate.(ExplicitDenyGate); ok && denyGate.ExplicitlyDenies(plan.permName, plan.permArgs) {
 			return toolOutcome{
 				output:  "blocked: denied by permission policy — this tool/command is on the deny list. Do not retry it; choose another approach or stop and explain.",
 				blocked: true,
 				errMsg:  "blocked by permission policy",
 			}, true
 		}
-	} else if a.gate != nil {
-		allow, reason, err := a.gate.Check(ctx, plan.permName, plan.permArgs, plan.readOnly)
+	} else if a.svc.gate != nil {
+		allow, reason, err := a.svc.gate.Check(ctx, plan.permName, plan.permArgs, plan.readOnly)
 		if err != nil {
 			return toolOutcome{
 				output:  fmt.Sprintf("blocked: %s (%v)", reason, err),
@@ -598,8 +598,8 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	// concurrent and avoids holding the workspace during an approval prompt while
 	// still covering every write-side action that follows authorization.
 	// Lazy workspace lease on the first real writer for every role setting.
-	if plan.mutates && a.workspaceLease != nil {
-		if err := a.workspaceLease.AcquireWrite(ctx); err != nil {
+	if plan.mutates && a.svc.workspaceLease != nil {
+		if err := a.svc.workspaceLease.AcquireWrite(ctx); err != nil {
 			return toolOutcome{
 				output:  fmt.Sprintf("blocked: the workspace did not become available for writing: %v", err),
 				blocked: true,
@@ -636,8 +636,8 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	// Acquire the checkpoint barrier before preimage capture and any hook. It is
 	// held through post hooks and AfterMutation so rewind cannot interleave with
 	// writer-side user code.
-	if !plan.readOnly && a.mutationObserver != nil && a.mutationObserver.Store() != nil {
-		barrier := a.mutationObserver.Store().Barrier()
+	if !plan.readOnly && a.svc.mutationObserver != nil && a.svc.mutationObserver.Store() != nil {
+		barrier := a.svc.mutationObserver.Store().Barrier()
 		if err := barrier.EnterWrite(); err != nil {
 			return toolOutcome{output: "blocked: " + err.Error(), blocked: true, errMsg: "blocked: mutation barrier unavailable"}, true
 		}
@@ -651,13 +651,13 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	if !plan.readOnly {
 		a.observeBeforeMutation(ctx, plan)
 		plan.mutationObserved = plan.mutationPath != ""
-		if toolHooksMayMutateWorkspace(a.hooks) && a.mutationObserver != nil {
-			a.mutationObserver.RecordGap(checkpoint.CoverageGap{Reason: checkpoint.GapHookWrite, Tool: plan.evidenceName, Detail: "tool hook may write paths that are not declared by the tool"})
+		if toolHooksMayMutateWorkspace(a.svc.hooks) && a.svc.mutationObserver != nil {
+			a.svc.mutationObserver.RecordGap(checkpoint.CoverageGap{Reason: checkpoint.GapHookWrite, Tool: plan.evidenceName, Detail: "tool hook may write paths that are not declared by the tool"})
 		}
 	}
 	// Proxy tools fire hooks against the real MCP target name and arguments.
-	if a.hooks != nil {
-		if block, msg := a.hooks.PreToolUse(ctx, plan.permName, plan.permArgs); block {
+	if a.svc.hooks != nil {
+		if block, msg := a.svc.hooks.PreToolUse(ctx, plan.permName, plan.permArgs); block {
 			if msg == "" {
 				msg = "blocked by a PreToolUse hook"
 			}
@@ -668,7 +668,7 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 			}, true
 		}
 	}
-	cctx := tool.WithContextCompressor(withCallContext(ctx, plan.call.ID, a.sink, a.asker, a.planMode.Load()), a)
+	cctx := tool.WithContextCompressor(withCallContext(ctx, plan.call.ID, a.svc.sink, a.svc.asker, a.planMode.Load()), a)
 	cctx = WithSubagentDepth(cctx, a.subagentDepth)
 	if a.task.ledger != nil {
 		cctx = evidence.WithLedger(cctx, a.task.ledger)
@@ -686,14 +686,14 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 	if len(a.projectChecks) > 0 {
 		cctx = instruction.WithChecks(cctx, a.projectChecks)
 	}
-	if a.jobs != nil {
-		cctx = jobs.WithManager(cctx, a.jobs)
+	if a.svc.jobs != nil {
+		cctx = jobs.WithManager(cctx, a.svc.jobs)
 	}
-	if a.sandboxEscapeApprover != nil {
-		cctx = sandbox.WithEscapeApprover(cctx, a.sandboxEscapeApprover)
+	if a.svc.sandboxEscape != nil {
+		cctx = sandbox.WithEscapeApprover(cctx, a.svc.sandboxEscape)
 	}
-	if a.configWriteApprover != nil {
-		cctx = tool.WithConfigWriteApprover(cctx, a.configWriteApprover)
+	if a.svc.configWrite != nil {
+		cctx = tool.WithConfigWriteApprover(cctx, a.svc.configWrite)
 	}
 	if v := a.responseLanguage.Load(); v != nil {
 		if lang, ok := v.(string); ok {
@@ -705,12 +705,12 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 			cctx = WithReasoningLanguagePreference(cctx, lang)
 		}
 	}
-	if a.memQueue != nil {
-		cctx = memory.WithQueue(cctx, a.memQueue)
+	if a.svc.memQueue != nil {
+		cctx = memory.WithQueue(cctx, a.svc.memQueue)
 	}
 	callID := plan.call.ID
 	cctx = tool.WithProgress(cctx, func(chunk string) {
-		a.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: chunk}})
+		a.svc.sink.Emit(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: callID, Output: chunk}})
 	})
 	plan.cctx = cctx
 	return toolOutcome{}, false
@@ -805,18 +805,18 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	a.noteCapabilityInvocation(call.Name, json.RawMessage(call.Arguments), err)
 	// Success and failure hooks observe the result after the tool ran. Use the
 	// real target name for proxied tools.
-	if a.hooks != nil {
+	if a.svc.hooks != nil {
 		if err != nil {
-			a.hooks.PostToolUseFailure(ctx, permName, permArgs, result, err)
+			a.svc.hooks.PostToolUseFailure(ctx, permName, permArgs, result, err)
 		} else {
-			a.hooks.PostToolUse(ctx, permName, permArgs, result)
+			a.svc.hooks.PostToolUse(ctx, permName, permArgs, result)
 		}
 	}
 	// Always re-read after post hooks — partial writes and hook side effects can
 	// change the previewed path even when the concrete tool returned an error.
 	a.observeAfterMutation(plan)
 	plan.mutationAfterDone = true
-	if a.recoveryGate != nil {
+	if a.svc.recoveryGate != nil {
 		a.observeRecoveryResult(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, false, false, recoveryGen)
 	}
 	if err != nil {
@@ -847,8 +847,8 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	// A foreground `task` sub-agent just finished — its result is the final answer.
 	// (A backgrounded one returns a "Started…" string and stops later in a job, so
 	// it doesn't fire here.) SubagentStop lets a hook react to delegated work.
-	if a.hooks != nil && call.Name == "task" && !isBackgroundTaskCall(call.Arguments) {
-		a.hooks.SubagentStop(ctx, result)
+	if a.svc.hooks != nil && call.Name == "task" && !isBackgroundTaskCall(call.Arguments) {
+		a.svc.hooks.SubagentStop(ctx, result)
 	}
 	body, truncMsg := truncateToolOutputFor(result, call.Name, call.ID)
 	out := toolOutcome{
@@ -871,7 +871,7 @@ func (a *Agent) observeBeforeMutation(ctx context.Context, plan *toolCallPlan) {
 	if toolName == "" {
 		toolName = plan.call.Name
 	}
-	obs := a.mutationObserver
+	obs := a.svc.mutationObserver
 	if obs != nil {
 		if pv, ok := plan.execTool.(tool.Previewer); ok {
 			if change, perr := pv.Preview(ctx, plan.execArgs); perr == nil && change.Path != "" {
@@ -893,10 +893,10 @@ func (a *Agent) observeBeforeMutation(ctx context.Context, plan *toolCallPlan) {
 		return
 	}
 	// Legacy onPreEdit path.
-	if a.onPreEdit != nil {
+	if a.svc.preEdit != nil {
 		if pv, ok := plan.execTool.(tool.Previewer); ok {
 			if change, perr := pv.Preview(ctx, plan.execArgs); perr == nil {
-				a.onPreEdit(change)
+				a.svc.preEdit(change)
 				plan.mutationPath = change.Path
 			}
 		}
@@ -906,12 +906,12 @@ func (a *Agent) observeBeforeMutation(ctx context.Context, plan *toolCallPlan) {
 // observeAfterMutation records the after fingerprint when a concrete path was
 // known before execution, regardless of tool success or failure.
 func (a *Agent) observeAfterMutation(plan *toolCallPlan) {
-	if a == nil || plan == nil || plan.mutationPath == "" || a.mutationObserver == nil {
+	if a == nil || plan == nil || plan.mutationPath == "" || a.svc.mutationObserver == nil {
 		return
 	}
 	toolName := plan.evidenceName
 	if toolName == "" {
 		toolName = plan.call.Name
 	}
-	a.mutationObserver.AfterMutation(plan.mutationPath, toolName)
+	a.svc.mutationObserver.AfterMutation(plan.mutationPath, toolName)
 }

--- a/internal/agent/extensions.go
+++ b/internal/agent/extensions.go
@@ -107,14 +107,14 @@ func strategyReplaced(ctx context.Context, d *dispatch.Dispatcher, slot extensio
 // a required extension's failure) aborts the run before the user turn is
 // appended; the error surfaces like a normal run error.
 func (a *Agent) interceptAgentStart(ctx context.Context) error {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return nil
 	}
 	providerCtx := a.withAgentContext(ctx)
 	payload := dispatch.AgentStartPayload{
-		Model:     a.prov.Name(),
-		ToolCount: len(a.tools.SchemasForContext(providerCtx)),
+		Model:     a.svc.prov.Name(),
+		ToolCount: len(a.svc.tools.SchemasForContext(providerCtx)),
 		SessionID: ParentSession(ctx),
 	}
 	result, err := d.Intercept(ctx, extension.PointAgentBeforeStart, &payload)
@@ -133,7 +133,7 @@ func (a *Agent) interceptAgentStart(ctx context.Context) error {
 // never touched, so a replacement is invisible to the next turn (and to the
 // prompt-cache prefix) — ephemerality is the cache contract.
 func (a *Agent) interceptContextPrepare(ctx context.Context, messages []provider.Message) ([]provider.Message, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return messages, nil
 	}
@@ -163,7 +163,7 @@ func (a *Agent) interceptContextPrepare(ctx context.Context, messages []provider
 // registry (tool parameter schemas must be JSON objects, messages/tools must
 // be arrays) before it may substitute the request being sent.
 func (a *Agent) interceptProviderRequest(ctx context.Context, req provider.Request) (provider.Request, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return req, nil
 	}
@@ -199,7 +199,7 @@ func (a *Agent) interceptProviderRequest(ctx context.Context, req provider.Reque
 // streaming); a replaced Usage drives only this turn's Usage event and
 // compaction decision. A block fails the turn with the redacted reason.
 func (a *Agent) interceptProviderResponse(ctx context.Context, text, reasoning, signature string, calls []provider.ToolCall, usage *provider.Usage) (string, string, string, []provider.ToolCall, *provider.Usage, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return text, reasoning, signature, calls, usage, nil
 	}
@@ -241,7 +241,7 @@ func (a *Agent) interceptProviderResponse(ctx context.Context, text, reasoning, 
 // see the call that will actually execute. An invalid replacement fails the
 // call with a contract-violation error result.
 func (a *Agent) interceptToolBefore(ctx context.Context, plan *toolCallPlan) (toolOutcome, bool) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return toolOutcome{}, false
 	}
@@ -268,7 +268,7 @@ func (a *Agent) interceptToolBefore(ctx context.Context, plan *toolCallPlan) (to
 	if trimmed == "" || trimmed[0] != '{' {
 		return violation("arguments must decode as a JSON object")
 	}
-	t, _, ambiguous := a.tools.ResolveCall(payload.Name)
+	t, _, ambiguous := a.svc.tools.ResolveCall(payload.Name)
 	if t == nil || len(ambiguous) > 0 {
 		return violation(fmt.Sprintf("substituted tool name %q does not resolve in the registry", payload.Name))
 	}
@@ -288,7 +288,7 @@ func (a *Agent) interceptToolBefore(ctx context.Context, plan *toolCallPlan) (to
 // host decision standing. allow is updated in place; early=true carries the
 // blocked outcome.
 func (a *Agent) interceptExtensionPermission(ctx context.Context, plan *toolCallPlan, allow *bool) (toolOutcome, bool) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return toolOutcome{}, false
 	}
@@ -330,7 +330,7 @@ func (a *Agent) interceptExtensionPermission(ctx context.Context, plan *toolCall
 	}
 	d.Event(extension.PointPermissionDecision, payload)
 	for _, note := range result.Audit {
-		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: note})
+		a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: note})
 	}
 	switch {
 	case result.Blocked:
@@ -359,7 +359,7 @@ func (a *Agent) interceptExtensionPermission(ctx context.Context, plan *toolCall
 // (or a required extension's failure) converts the call to an error tool
 // result with the reason; the tool itself already ran.
 func (a *Agent) interceptToolAfter(ctx context.Context, call provider.ToolCall, result string, err error) (string, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return result, err
 	}
@@ -395,7 +395,7 @@ func (a *Agent) interceptToolAfter(ctx context.Context, call provider.ToolCall, 
 // replacement's messages and guidance drive only this compaction pass; a
 // block skips the pass with the reason surfaced through the caller's notice.
 func (a *Agent) interceptCompactionPrepare(ctx context.Context, fold []provider.Message, guidance string) ([]provider.Message, string, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return fold, guidance, nil
 	}
@@ -429,7 +429,7 @@ func (a *Agent) interceptCompactionPrepare(ctx context.Context, fold []provider.
 // into the session. A replacement is persisted as the summary; a block skips
 // the pass.
 func (a *Agent) interceptCompactionComplete(ctx context.Context, summary string) (string, error) {
-	d := a.extensions
+	d := a.svc.extensions
 	if d == nil {
 		return summary, nil
 	}

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -168,7 +168,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		return out
 	}
 	if !a.deliveryProfile && a.turn.policySet && a.turn.policy.Verification >= taskpolicy.VerifyTargeted &&
-		a.turn.policy.AllowsTests() && toolPresent(a.tools, "bash") &&
+		a.turn.policy.AllowsTests() && toolPresent(a.svc.tools, "bash") &&
 		!a.task.ledger.HasSuccessfulVerificationCommandAfter(writer) {
 		out.applies = true
 		out.missingVerification++

--- a/internal/agent/finalization.go
+++ b/internal/agent/finalization.go
@@ -44,7 +44,7 @@ func (a *Agent) armFinalizationRound(state *turnRuntime, cause landCause) {
 	state.graceRound = true
 	state.landCause = cause
 	a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(cause.nudge(state))})
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeToolBudget,
+	a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeToolBudget,
 		Text: cause.noticeText(), Detail: cause.detail})
 }
 

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -243,8 +243,8 @@ func applyForkTreatment(messages []provider.Message, nudge string) {
 // maybeWrapForkCaptureProvider interposes the capture wrapper when the
 // experiment env asks for bundles; inert otherwise.
 func (a *Agent) maybeWrapForkCaptureProvider() {
-	if os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR") != "" && a.prov != nil {
-		a.prov = &forkCaptureProvider{inner: a.prov, a: a}
+	if os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR") != "" && a.svc.prov != nil {
+		a.svc.prov = &forkCaptureProvider{inner: a.svc.prov, a: a}
 	}
 }
 

--- a/internal/agent/goal_run_boundary.go
+++ b/internal/agent/goal_run_boundary.go
@@ -84,7 +84,7 @@ func (a *Agent) trackTodoProgress(ctx context.Context, state *turnRuntime, recei
 	state.todoProgress, state.trackingTodoProgress = nextProgress, nextTracking
 	if state.todoStallRounds == todoProgressNudgeRounds {
 		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(todoProgressNudgeMessage(state.todoStallRounds))})
-		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
+		a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
 			Text: loopGuardNoticeText(), Detail: fmt.Sprintf("the current todo has no new completion, unique read, command, or mutation for %d consecutive tool-call rounds; asking the assistant to reassess", state.todoStallRounds)})
 	}
 	if state.todoStallRounds < maxTodoStallRounds {
@@ -95,7 +95,7 @@ func (a *Agent) trackTodoProgress(ctx context.Context, state *turnRuntime, recei
 		state.todoStallRounds = 0
 		nudge := fmt.Sprintf("Host progress redirect: the current todo still has no new completion or unique host-observed work after %d tool-call rounds. Re-plan and continue: shrink the active step, switch tools or approach, delegate a focused sub-task, or use update_goal(blocked) only if a user or external condition is the sole blocker. Do not repeat the same calls.", rounds)
 		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(nudge)})
-		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
+		a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeLoopGuard,
 			Text: loopGuardNoticeText(), Detail: fmt.Sprintf("the current Goal todo made no host-observed progress for %d rounds; resetting the intervention epoch and requiring a new plan", rounds)})
 		return
 	}

--- a/internal/agent/governor.go
+++ b/internal/agent/governor.go
@@ -54,7 +54,7 @@ func (a *Agent) applyGovernor(sample *evidence.OutcomeSample) {
 		a.task.governor.engaged = true
 		if !a.task.governor.noticed {
 			a.task.governor.noticed = true
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeReasoningGovernor,
+			a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeReasoningGovernor,
 				Text:   "Exploration phase with expensive thinking; riding reduced reasoning depth until evidence work starts.",
 				Detail: "reasoning governor engaged: no verification debt, no local execution, previous round over the reasoning threshold"})
 		}

--- a/internal/agent/governor_test.go
+++ b/internal/agent/governor_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestApplyGovernorStampsEligibilityWithoutEngagingByDefault(t *testing.T) {
-	a := &Agent{sink: &ebmSink{}, turn: turnRuntime{lastReasoning: govReasoningThreshold}}
+	a := &Agent{svc: agentServices{sink: &ebmSink{}}, turn: turnRuntime{lastReasoning: govReasoningThreshold}}
 	sample := evidence.OutcomeSample{}
 	a.applyGovernor(&sample)
 	if !sample.GovernorEligible || sample.GovernorEngaged {
@@ -28,7 +28,7 @@ func TestApplyGovernorEngagesAndExitsWhenEnabled(t *testing.T) {
 	defer func() { governorEnabled = old }()
 
 	sink := &ebmSink{}
-	a := &Agent{sink: sink, turn: turnRuntime{lastReasoning: govReasoningThreshold}}
+	a := &Agent{svc: agentServices{sink: sink}, turn: turnRuntime{lastReasoning: govReasoningThreshold}}
 
 	cheap := evidence.OutcomeSample{}
 	a.turn.lastReasoning = govReasoningThreshold - 1

--- a/internal/agent/missing_reasoning_watch.go
+++ b/internal/agent/missing_reasoning_watch.go
@@ -30,13 +30,13 @@ type unwrittenResolve struct {
 // once before tools execute; three consecutive healthy rounds then resolve the
 // incident and re-arm a future isolated regression (#6259, #7059).
 func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reasoning string) (missing, shouldRetry bool) {
-	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.prov) {
+	if len(calls) == 0 || !provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
 		return false, false
 	}
-	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(a.prov)
+	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(a.svc.prov)
 	observedAt := time.Now()
 	if strings.TrimSpace(reasoning) != "" {
-		if a.missingReasoningWarnState == nil {
+		if a.svc.warnState == nil {
 			if a.sess.missingReasoning.active {
 				a.sess.missingReasoning.healthyStreak++
 				if a.sess.missingReasoning.healthyStreak >= missingReasoningHealthyResolveStreak {
@@ -50,13 +50,13 @@ func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reaso
 		if shouldResolve {
 			result := missingReasoningResolveResult{Recorded: true, Resolved: true}
 			if pending := a.unwrittenResolve.at; !pending.IsZero() {
-				result = a.missingReasoningWarnState.resolveAt(fingerprint, pending)
+				result = a.svc.warnState.resolveAt(fingerprint, pending)
 				if result.Recorded {
 					a.unwrittenResolve.at = time.Time{}
 				}
 			}
 			if result.Recorded {
-				result = a.missingReasoningWarnState.resolveAt(fingerprint, observedAt)
+				result = a.svc.warnState.resolveAt(fingerprint, observedAt)
 			}
 			if !result.Recorded {
 				if observedAt.After(a.unwrittenResolve.at) {
@@ -75,7 +75,7 @@ func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reaso
 		return false, false
 	}
 	a.sess.missingReasoning.healthyStreak = 0
-	if s := a.missingReasoningWarnState; s != nil {
+	if s := a.svc.warnState; s != nil {
 		stateReady := true
 		alreadyActive := a.sess.missingReasoning.active
 		if pending := a.unwrittenResolve.at; !pending.IsZero() {

--- a/internal/agent/nil_boundary_test.go
+++ b/internal/agent/nil_boundary_test.go
@@ -37,11 +37,11 @@ func TestNewNormalizesTypedNilInterfaces(t *testing.T) {
 	var hooks *typedNilHooks
 
 	a := New(nil, tool.NewRegistry(), NewSession(""), Options{Gate: gate, Hooks: hooks}, sink)
-	a.sink.Emit(event.Event{Kind: event.Text, Text: "typed nil sink should not panic"})
-	if a.gate != nil {
+	a.svc.sink.Emit(event.Event{Kind: event.Text, Text: "typed nil sink should not panic"})
+	if a.svc.gate != nil {
 		t.Fatal("typed nil gate should be normalized to nil")
 	}
-	if a.hooks != nil {
+	if a.svc.hooks != nil {
 		t.Fatal("typed nil hooks should be normalized to nil")
 	}
 }
@@ -51,7 +51,7 @@ func TestSetGateNormalizesTypedNil(t *testing.T) {
 	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
 
 	a.SetGate(gate)
-	if a.gate != nil {
+	if a.svc.gate != nil {
 		t.Fatal("typed nil gate should be normalized to nil")
 	}
 }

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -123,7 +123,7 @@ func requestCalibrationShapeOf(req provider.Request) requestCalibrationShape {
 }
 
 func (a *Agent) requestCalibrationShape(req provider.Request) requestCalibrationShape {
-	return requestCalibrationShapeWithPolicy(req, sharedWindowInputPolicyOf(a.prov))
+	return requestCalibrationShapeWithPolicy(req, sharedWindowInputPolicyOf(a.svc.prov))
 }
 
 func requestCalibrationShapeWithPolicy(req provider.Request, policy provider.SharedWindowInputPolicy) requestCalibrationShape {
@@ -239,7 +239,7 @@ func isCJKRune(r rune) bool {
 // effectiveOutputBudget clips completion tokens at send time only; it never
 // moves compact_ratio. Exhausted windows fail locally before HTTP 400.
 func (a *Agent) effectiveOutputBudget(req provider.Request) (int, bool, error) {
-	if a == nil || a.contextWindow <= 0 || !sharesContextWindow(a.prov) {
+	if a == nil || a.contextWindow <= 0 || !sharesContextWindow(a.svc.prov) {
 		return 0, false, nil
 	}
 	budget := a.configuredOutputBudget(req.MaxTokens)

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -84,7 +84,7 @@ func TestSessionSwapKeepsPromptCalibration(t *testing.T) {
 
 func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	// Oversized tool bodies are deterministically shortened for the single
 	// summarizer request (no multi-span). The guard must still fit one call.
 	toolBody := strings.Repeat("file line content here. ", 20_000) // ~480K chars
@@ -119,7 +119,7 @@ func TestSharedWindowFoldUsesGuardedInputBudget(t *testing.T) {
 // all deterministic shorteners must fail once (no multi-span split).
 func TestSharedWindowFoldRejectsUnshortenableOverBudgetInput(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	fold := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 200_000)}}
 	_, err := a.foldToSummary(context.Background(), fold, "")
 	if err == nil || !strings.Contains(err.Error(), "exceeds single-request budget") {
@@ -139,7 +139,7 @@ func (p *sharedWindowTestProvider) SharedWindowInputPolicy() provider.SharedWind
 
 func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}}
 	// Calibrate this session at one token per rune. The 950K prompt fits, but
 	// not beside the provider's full 128K output default.
@@ -163,7 +163,7 @@ func TestEffectiveOutputBudgetClipsSharedWindowRequest(t *testing.T) {
 
 func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	current := append(previous, provider.Message{
@@ -188,7 +188,7 @@ func TestCalibratedOutputBudgetIncludesReplayedReasoning(t *testing.T) {
 
 func TestCalibratedOutputBudgetKeepsCJKConservativeFloor(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("x", 300_000)}}
 	a.setPromptTokenCalibration(75_000, requestCalibrationShapeOf(provider.Request{Messages: previous}))
 	// Enough unrepresented CJK that the reply no longer fits beside it: at the
@@ -237,7 +237,7 @@ func TestCalibrationIgnoresNonReplayableOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysOrdinaryReasoning: true}}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -258,7 +258,7 @@ func TestCalibratedResponsesBudgetIncludesNewOrdinaryReasoning(t *testing.T) {
 func TestCalibratedResponsesBudgetIncludesNewReplayItems(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,
 		policy: provider.SharedWindowInputPolicy{ReplaysResponsesItems: true}}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	previous := provider.Request{Messages: []provider.Message{{
 		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
 	}}}
@@ -298,7 +298,7 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 	sess := NewSession("")
 	sess.Replace(msgs)
 	// compactRatio 2 disables auto maintenance for this output-clip test
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576, compactRatio: 2}, prov: prov, tools: tool.NewRegistry(),
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576, compactRatio: 2}, svc: agentServices{prov: prov, tools: tool.NewRegistry()},
 		sess: sessionRuntime{conversation: sess, output: outputBudgetState{outputBudget: prov.budget}}}
 	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 950_000})
 	a.setPromptTokenCalibration(950_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
@@ -314,7 +314,7 @@ func TestPrepareSamplingRequestClipsSharedWindowOutput(t *testing.T) {
 
 func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	msgs := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 1_045_000)}}
 	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 1_045_000})
 	a.setPromptTokenCalibration(1_045_000, requestCalibrationShapeOf(provider.Request{Messages: msgs}))
@@ -327,7 +327,7 @@ func TestEffectiveOutputBudgetRejectsExhaustedSharedWindow(t *testing.T) {
 
 func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: false}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages: []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 	})
@@ -338,7 +338,7 @@ func TestEffectiveOutputBudgetLeavesIndependentProviderUnchanged(t *testing.T) {
 
 func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	got, clipped, err := a.effectiveOutputBudget(provider.Request{
 		Messages:  []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 950_000)}},
 		MaxTokens: -1,
@@ -350,7 +350,7 @@ func TestEffectiveOutputBudgetHonorsExplicitOmit(t *testing.T) {
 
 func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 100_000}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 	region := []provider.Message{{Role: provider.RoleUser, Content: strings.Repeat("字", 50_000)}}
 	a.sess.output.lastUsage.Store(&provider.Usage{PromptTokens: 50_000})
 	a.setPromptTokenCalibration(50_000, requestCalibrationShapeOf(provider.Request{Messages: region}))
@@ -365,7 +365,7 @@ func TestSummarizeClipsSharedWindowOutputBudget(t *testing.T) {
 
 func TestSummarizeRejectsLengthTruncation(t *testing.T) {
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true, finish: "length"}
-	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, prov: prov, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}, sink: event.Discard}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 1_048_576}, svc: agentServices{prov: prov, sink: event.Discard}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
 
 	_, _, err := a.summarizeOnce(context.Background(), []provider.Message{{
 		Role: provider.RoleUser, Content: "retain every durable fact",
@@ -435,13 +435,13 @@ func TestForkCaptureProviderPreservesOutputBudgetCapabilities(t *testing.T) {
 		policy: provider.SharedWindowInputPolicy{ReplaysOrdinaryReasoning: true, ReplaysResponsesItems: true}}
 	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
 
-	if !sharesContextWindow(a.prov) {
+	if !sharesContextWindow(a.svc.prov) {
 		t.Fatal("fork capture wrapper erased shared-window output capability")
 	}
-	if got := outputBudgetOf(a.prov); got != prov.budget {
+	if got := outputBudgetOf(a.svc.prov); got != prov.budget {
 		t.Fatalf("wrapped output budget = %d, want %d", got, prov.budget)
 	}
-	if got := sharedWindowInputPolicyOf(a.prov); got != prov.policy {
+	if got := sharedWindowInputPolicyOf(a.svc.prov); got != prov.policy {
 		t.Fatalf("wrapped input policy = %+v, want %+v", got, prov.policy)
 	}
 }

--- a/internal/agent/path_bound_tools_test.go
+++ b/internal/agent/path_bound_tools_test.go
@@ -287,7 +287,7 @@ func TestParentWriteReservationBashClaimsWholeWorkspace(t *testing.T) {
 func TestAgentReserveParentWriteSkipsSubagentDepth(t *testing.T) {
 	root := t.TempDir()
 	sched := NewSubagentScheduler(4, 2)
-	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 1}, writeScheduler: sched}
+	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 1}, svc: agentServices{writeScheduler: sched}}
 	inner := &recordingWriter{name: "write_file"}
 	release, err := a.reserveParentWrite(inner, mustJSON(t, map[string]string{
 		"path": filepath.Join(root, "a.md"), "content": "x",
@@ -305,7 +305,7 @@ func TestAgentReserveParentWriteSkipsSubagentDepth(t *testing.T) {
 func TestAgentReserveParentWriteHoldsClaim(t *testing.T) {
 	root := t.TempDir()
 	sched := NewSubagentScheduler(4, 2)
-	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 0}, writeScheduler: sched}
+	a := &Agent{agentConfig: agentConfig{writeWorkspaceRoot: root, subagentDepth: 0}, svc: agentServices{writeScheduler: sched}}
 	inner := &recordingWriter{name: "write_file"}
 	release, err := a.reserveParentWrite(inner, mustJSON(t, map[string]string{
 		"path": filepath.Join(root, "a.md"), "content": "x",

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -88,7 +88,7 @@ func (a *Agent) observeOutcomeShadow(receiptMark int, outcomes []toolOutcome) in
 	iv := a.applyEBM(&sample, outcomes)
 	a.applyGovernor(&sample)
 	a.armGovernorCapture(sample)
-	event.RecordOutcomeProgress(a.sink, sample)
+	event.RecordOutcomeProgress(a.svc.sink, sample)
 	a.observeContractRound()
 	return iv
 }

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -77,8 +77,8 @@ var (
 )
 
 func (a *Agent) snipStrategyFor(name string) snipStrategy {
-	if a.tools != nil {
-		if t, ok := a.tools.Get(name); ok {
+	if a.svc.tools != nil {
+		if t, ok := a.svc.tools.Get(name); ok {
 			if h, ok := t.(tool.SnipHinter); ok {
 				return snipStrategyFromHint(h.SnipHint())
 			}

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -83,7 +83,7 @@ func TestMaintenanceUsesSummaryNotPruneAtFoldTrigger(t *testing.T) {
 }
 
 func TestSnipStrategyStillAvailableForFirstVisibleAndSummaryInput(t *testing.T) {
-	a := &Agent{tools: tool.NewRegistry()}
+	a := &Agent{svc: agentServices{tools: tool.NewRegistry()}}
 	s := a.snipStrategyFor("read_file")
 	if s.head <= 0 || s.tail <= 0 {
 		t.Fatalf("snip strategy for read_file = %+v", s)

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -187,7 +187,7 @@ const (
 )
 
 func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args json.RawMessage, readOnly, mutates bool, result string, err error, blocked, userRejected bool, generation uint64) {
-	if a == nil || a.recoveryGate == nil {
+	if a == nil || a.svc.recoveryGate == nil {
 		return
 	}
 	verification := toolName == "bash" && evidence.IsDeliveryVerificationCommand(bashCommandFromArgs(args))
@@ -212,13 +212,13 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 		cancelled = true
 	}
 	episodeID := ""
-	if ctrl, ok := a.recoveryGate.(RecoveryEpisodeControl); ok {
+	if ctrl, ok := a.svc.recoveryGate.(RecoveryEpisodeControl); ok {
 		episodeID = ctrl.EpisodeID()
 		if generation == 0 {
 			generation = ctrl.Generation()
 		}
 	}
-	guidance := a.recoveryGate.ObserveResult(ctx, RecoveryObservation{
+	guidance := a.svc.recoveryGate.ObserveResult(ctx, RecoveryObservation{
 		AgentID:      a.recovery.agentID,
 		TaskID:       a.recovery.taskID,
 		TaskScopeID:  recoveryTaskScopeID(a.task.scopeID, a.recovery.runSeq.Load()),
@@ -248,10 +248,10 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 }
 
 func (a *Agent) recoveryEpisodeControl() RecoveryEpisodeControl {
-	if a == nil || a.recoveryGate == nil {
+	if a == nil || a.svc.recoveryGate == nil {
 		return nil
 	}
-	ctrl, _ := a.recoveryGate.(RecoveryEpisodeControl)
+	ctrl, _ := a.svc.recoveryGate.(RecoveryEpisodeControl)
 	return ctrl
 }
 

--- a/internal/agent/recovery_gate_test.go
+++ b/internal/agent/recovery_gate_test.go
@@ -122,7 +122,7 @@ func TestPlanTransitionNeedsDedicatedReplacementAuthorization(t *testing.T) {
 
 func TestObserveRecoveryResultMarksCancellation(t *testing.T) {
 	gate := &recordingRecoveryGate{}
-	a := &Agent{recoveryGate: gate}
+	a := &Agent{svc: agentServices{recoveryGate: gate}}
 	a.observeRecoveryResult(
 		context.Background(),
 		"write_file",
@@ -145,7 +145,7 @@ func TestObserveRecoveryResultMarksCancellation(t *testing.T) {
 
 func TestObserveRecoveryResultKeepsToolOwnedDeadlineAsFailure(t *testing.T) {
 	gate := &recordingRecoveryGate{}
-	a := &Agent{recoveryGate: gate}
+	a := &Agent{svc: agentServices{recoveryGate: gate}}
 	a.observeRecoveryResult(
 		context.Background(),
 		"mcp__server__write",
@@ -168,7 +168,7 @@ func TestObserveRecoveryResultKeepsToolOwnedDeadlineAsFailure(t *testing.T) {
 
 func TestObserveRecoveryResultMarksParentDeadlineCancellation(t *testing.T) {
 	gate := &recordingRecoveryGate{}
-	a := &Agent{recoveryGate: gate}
+	a := &Agent{svc: agentServices{recoveryGate: gate}}
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
 	a.observeRecoveryResult(

--- a/internal/agent/run_budget.go
+++ b/internal/agent/run_budget.go
@@ -135,16 +135,16 @@ func (a *Agent) observeRunBudget(state *turnRuntime, usage *provider.Usage) {
 	if state == nil {
 		return
 	}
-	state.budget.observe(usage, a.pricing)
+	state.budget.observe(usage, a.svc.pricing)
 	if a.task.budget.started.IsZero() {
 		a.task.budget.started = state.budget.started
 	}
-	a.task.budget.observe(usage, a.pricing)
+	a.task.budget.observe(usage, a.svc.pricing)
 	currency := ""
-	if a.pricing != nil {
-		currency = a.pricing.Symbol()
+	if a.svc.pricing != nil {
+		currency = a.svc.pricing.Symbol()
 	}
-	event.RecordRunBudget(a.sink, event.RunBudgetSample{
+	event.RecordRunBudget(a.svc.sink, event.RunBudgetSample{
 		Turn:     state.budget.totals(),
 		Task:     a.task.budget.totals(),
 		Currency: currency,

--- a/internal/agent/run_budget_test.go
+++ b/internal/agent/run_budget_test.go
@@ -186,7 +186,7 @@ func TestRunBudgetCountsRoundsWithoutUsage(t *testing.T) {
 
 func TestRunBudgetIgnoresSinksThatDoNotOptIn(t *testing.T) {
 	plain := event.FuncSink(func(event.Event) {})
-	a := &Agent{sink: plain}
+	a := &Agent{svc: agentServices{sink: plain}}
 	state := &turnRuntime{}
 	a.observeRunBudget(state, &provider.Usage{PromptTokens: 5, RequestCount: 1})
 	if state.budget.rounds != 1 || state.budget.promptTokens != 5 {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -156,10 +156,10 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// change without the final-readiness gate ever seeing it. Plan turns defer
 	// this lease like collectBackgroundEvidence does so execution evidence is
 	// consumed and audited only after plan approval.
-	if a.task.ledger != nil && a.jobs != nil && !a.planMode.Load() {
+	if a.task.ledger != nil && a.svc.jobs != nil && !a.planMode.Load() {
 		session := jobs.SessionFromContext(ctx)
-		for _, jobID := range a.jobs.PendingEvidenceJobIDsForSession(session) {
-			summary, ready := a.jobs.TryLeaseEvidenceForSession(session, jobID)
+		for _, jobID := range a.svc.jobs.PendingEvidenceJobIDsForSession(session) {
+			summary, ready := a.svc.jobs.TryLeaseEvidenceForSession(session, jobID)
 			if !ready {
 				continue
 			}
@@ -188,7 +188,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	}
 	intent := taskintent.Classify(a.turn.turnInput)
 	a.turn.deliveryTaskExpected = intent.NeedsEvidence()
-	a.turn.deliveryMutationExpected = intent == taskintent.Mutation && registryHasWriterTools(a.tools)
+	a.turn.deliveryMutationExpected = intent == taskintent.Mutation && registryHasWriterTools(a.svc.tools)
 	a.turn.deliveryPersistentExpected = taskintent.NeedsPersistentAction(a.turn.turnInput)
 	a.turn.recoveryTaskSummary = boundedRecoveryTaskSummary(a.turn.turnInput)
 	// Freeze TaskPolicy for this turn from the session role setting. Subsequent
@@ -221,7 +221,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// once; the user's raw text remains the classifier source above.
 	providerInput = withInterruptedRecovery(providerInput, a.pendingInterruptedRecovery())
 	a.task.prepareScope(scoped, scope.ID)
-	a.sink.Emit(event.Event{Kind: event.TurnStarted})
+	a.svc.sink.Emit(event.Event{Kind: event.TurnStarted})
 	a.emitTurnPhase(event.TurnPhaseWorking)
 	input = a.withTurnPreferences(providerInput)
 	// Persist the short execution-policy block in provider Content; keep the
@@ -269,13 +269,13 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 		// steer is unavoidable — the model must see the new instruction.
 		if text, itemID, ok := a.consumeSteer(); ok {
 			a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(midTurnSteerMessage(text))})
-			a.sink.Emit(event.Event{Kind: event.Steer, Text: text, ItemID: itemID})
+			a.svc.sink.Emit(event.Event{Kind: event.Steer, Text: text, ItemID: itemID})
 		} else if itemID != "" {
 			// Loader failed after dequeue: durable entry stays for inspection
 			// (unapplied path marks uncertain + pause via the notice sink).
 			a.RecordUnappliedSteer("(body load failed)", itemID)
 		}
-		schemas := a.tools.Schemas()
+		schemas := a.svc.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.sess.lastPrefixShape
 		if !a.sess.haveLastPrefixShape {
@@ -300,7 +300,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 			a.emitTurnUsage(usage, &cacheDiagnostics)
 			a.observeRunBudget(state, usage)
 			if msg, ok := finishReasonMessage(usage); ok {
-				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
+				a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
 			}
 			// Exhausted stream retries (or a non-retryable error): persist one
 			// bounded LocalOnly recovery record for the next real user message.
@@ -313,7 +313,7 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 		a.emitTurnUsage(usage, &cacheDiagnostics)
 		a.observeRunBudget(state, usage)
 		if msg, ok := finishReasonMessage(usage); ok {
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
+			a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
 		}
 
 		// Commit boundary: only a clean terminal attempt reaches here.
@@ -398,9 +398,9 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		a.emitStreamAttempt(attemptID, event.StreamAttemptBegin, attempt, "", nil)
 
 		var streamSink *deferredStreamSink
-		attemptSink := a.sink
-		if provider.WarnOnMissingToolCallReasoning(a.prov) {
-			streamSink = newReasoningAwareStreamSink(a.sink)
+		attemptSink := a.svc.sink
+		if provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
+			streamSink = newReasoningAwareStreamSink(a.svc.sink)
 			attemptSink = streamSink
 		}
 
@@ -425,10 +425,10 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 		// exact replay of the same frozen request (no synthetic prompt).
 		missing, shouldRetry := a.observeMissingToolCallReasoning(result.calls, result.reasoning)
 		if missing {
-			event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+			event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
 			if shouldRetry && strings.TrimSpace(result.text) == "" {
-				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryAttempted})
-				retrySink := newDeferredStreamSink(a.sink)
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryAttempted})
+				retrySink := newDeferredStreamSink(a.svc.sink)
 				retry := runAttempt(attemptID, retrySink)
 				billable = mergeSamplingUsage(billable, retry.usage)
 				if retry.err != nil {
@@ -444,7 +444,7 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 					streamSink.Flush()
 					a.storeLatestRequestUsage(result.usage)
 					result.usage = finalizeSamplingUsage(billable, result.usage)
-					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+					event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
 					a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 					return result
 				}
@@ -454,21 +454,21 @@ func (a *Agent) streamWithSamplingRecovery(ctx context.Context, turn int) stream
 				retry.usage = finalizeSamplingUsage(billable, retry.usage)
 				retryMissing, _ := a.observeMissingToolCallReasoning(retry.calls, retry.reasoning)
 				if retryMissing {
-					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
-					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+					event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
+					event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
 				} else if len(retry.calls) == 0 {
-					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryReplaced})
+					event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryReplaced})
 				} else {
-					event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryRecovered})
+					event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetryRecovered})
 				}
 				a.emitStreamAttempt(attemptID, event.StreamAttemptCommit, attempt, "", nil)
 				return retry
 			}
 			if !shouldRetry || strings.TrimSpace(result.text) != "" {
-				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
-				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningRetrySuppressed})
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
 			} else {
-				event.RecordProtocolRecovery(a.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
+				event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningFallback})
 			}
 		}
 
@@ -484,7 +484,7 @@ func (a *Agent) emitStreamAttempt(id string, action event.StreamAttemptAction, a
 	if reason == "" && err != nil {
 		reason = provider.StreamInterruptReason(err)
 	}
-	a.sink.Emit(event.Event{
+	a.svc.sink.Emit(event.Event{
 		Kind: event.StreamAttempt,
 		StreamAttempt: event.StreamAttemptInfo{
 			ID: id, Action: action, Attempt: attempt, Max: maxSamplingAttempts, Reason: reason,
@@ -555,7 +555,7 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		// what happens next. In Goal mode the FSM auto-continues under budget
 		// with the missing list as the next turn; plain Delivery turns surface
 		// the recovery card for an explicit user continuation.
-		event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessErrored, false))
+		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
 		a.pending.deliveryRecovery = true
 		return false, &FinalReadinessError{Attempts: 1, Reason: readiness.reason, Missing: readiness.missingIDs()}
 	}
@@ -568,12 +568,12 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		// "still thinking after the task is done" symptom), so honour the
 		// stop when reasoning carried the substance of the answer and treat
 		// the turn as a final answer instead of retrying.
-		if a.requireVisibleFinal || !reasoningOnlyFinishHonoured(a.prov, usage, reasoning) {
+		if a.requireVisibleFinal || !reasoningOnlyFinishHonoured(a.svc.prov, usage, reasoning) {
 			state.emptyFinalBlocks++
 			if state.emptyFinalBlocks >= maxEmptyFinalBlocks {
 				return false, fmt.Errorf("model finished without a visible final answer %d times", state.emptyFinalBlocks)
 			}
-			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEmptyFinal, Text: emptyFinalNotice(), Detail: emptyFinalNoticeDetail(a.prov.Name(), usage, len(reasoning))})
+			a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeEmptyFinal, Text: emptyFinalNotice(), Detail: emptyFinalNoticeDetail(a.svc.prov.Name(), usage, len(reasoning))})
 			a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(emptyFinalRetryMessage())})
 			a.contextManager().ObserveUsage(usage)
 			return true, nil
@@ -581,13 +581,13 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 	}
 	if state.executorHandoff && !state.usedAnyTool && state.handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(state.input, text) {
 		state.handoffNudges++
-		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeExecutorHandoff, Text: executorHandoffNoticeText(), Detail: "executor answered without taking any action; nudging it to use its tools"})
+		a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Code: event.NoticeCodeExecutorHandoff, Text: executorHandoffNoticeText(), Detail: "executor answered without taking any action; nudging it to use its tools"})
 		a.sess.conversation.Add(provider.Message{Role: provider.RoleUser, Content: a.withTurnPreferences(executorHandoffRetryMessage())})
 		a.contextManager().ObserveUsage(usage)
 		return true, nil
 	}
 	if readiness.applies {
-		event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
+		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
 	}
 	a.emitTurnShadows(a.turn.turnInput)
 	if !a.closeSteerIntakeIfIdle() {
@@ -708,13 +708,13 @@ func (a *Agent) unavailableContextualToolCalls(ctx context.Context, calls []prov
 	if len(calls) == 0 {
 		return nil
 	}
-	if a == nil || a.tools == nil {
+	if a == nil || a.svc.tools == nil {
 		return nil
 	}
 	names := make([]string, 0, len(calls))
 	seen := make(map[string]struct{}, len(calls))
 	for _, call := range calls {
-		t, canonical, ambiguous := a.tools.ResolveCall(call.Name)
+		t, canonical, ambiguous := a.svc.tools.ResolveCall(call.Name)
 		if t == nil || len(ambiguous) > 0 {
 			continue
 		}

--- a/internal/agent/run_usage.go
+++ b/internal/agent/run_usage.go
@@ -270,7 +270,7 @@ func (a *Agent) emitTurnUsage(usage *provider.Usage, cacheDiagnostics *CacheDiag
 	if a.sess.output.lastUsage.Load() == nil && usage.PromptTokens > 0 {
 		a.storeLatestRequestUsage(usage)
 	}
-	a.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.pricing,
+	a.svc.sink.Emit(event.Event{Kind: event.Usage, ModelRef: a.modelRef, Usage: usage, Pricing: a.svc.pricing,
 		UsageSource:      a.usageSource,
 		CacheDiagnostics: cacheDiagnostics,
 		SessionHit:       int(a.sess.cacheHit.Load()), SessionMiss: int(a.sess.cacheMiss.Load())})

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -16,7 +16,7 @@ type samplingRequest struct {
 }
 
 func (a *Agent) streamProviderRequest(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
-	return a.prov.Stream(ctx, req)
+	return a.svc.prov.Stream(ctx, req)
 }
 
 func (a *Agent) handleSamplingError(
@@ -32,7 +32,7 @@ func (a *Agent) handleSamplingError(
 		streamSink.Discard()
 		reason := provider.StreamInterruptReason(result.err)
 		a.emitStreamAttempt(attemptID, event.StreamAttemptDiscard, attempt, reason, result.err)
-		a.sink.Emit(event.Event{
+		a.svc.sink.Emit(event.Event{
 			Kind: event.Retrying, RetryAttempt: attempt, RetryMax: maxStreamRecoveries,
 			RetryScope: event.RetryScopeStream,
 		})
@@ -108,7 +108,7 @@ func (a *Agent) buildSamplingRequest(ctx context.Context, trigger string) (sampl
 	}
 	req := provider.Request{
 		Messages:       requestMessages,
-		Tools:          a.tools.Schemas(),
+		Tools:          a.svc.tools.Schemas(),
 		MaxTokens:      a.maxOutputTokens,
 		Temperature:    provider.OptionalTemperature(a.temperature),
 		ResponseFormat: responseFormatFromRequest(ctx),

--- a/internal/agent/secret_redaction_test.go
+++ b/internal/agent/secret_redaction_test.go
@@ -22,7 +22,7 @@ func (secretOutputTool) Execute(context.Context, json.RawMessage) (string, error
 func TestExecuteOnePreservesToolResultBeforeHistory(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(secretOutputTool{})
-	a := &Agent{tools: reg, sess: sessionRuntime{conversation: NewSession("")}}
+	a := &Agent{svc: agentServices{tools: reg}, sess: sessionRuntime{conversation: NewSession("")}}
 
 	outcome := a.executeOne(context.Background(), &a.turn, provider.ToolCall{ID: "call_1", Name: "secret_output", Arguments: `{}`})
 	const want = "DEEPSEEK_API_KEY=sk-real-secret-value-123456\n"

--- a/internal/agent/services.go
+++ b/internal/agent/services.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"reasonix/internal/checkpoint"
+	"reasonix/internal/diff"
+	"reasonix/internal/event"
+	"reasonix/internal/extension/dispatch"
+	"reasonix/internal/jobs"
+	"reasonix/internal/memory"
+	"reasonix/internal/provider"
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/workspacelease"
+)
+
+// agentServices are the collaborators an Agent talks to, separated from the
+// state it remembers. This is not a lifetime: the controller rebinds most of
+// these between turns through the Set* seams, and fork wraps prov mid-run. A
+// nil field is a capability the host did not wire, which each reader handles.
+type agentServices struct {
+	prov  provider.Provider
+	tools *tool.Registry
+	// pricing turns provider usage into money for the task budget.
+	pricing *provider.Pricing
+	// sink receives the turn's typed event stream. Frontends decide how to
+	// render it; never nil because New defaults it to event.Discard.
+	sink event.Sink
+	// warnState rate-limits recovery retries across sessions and processes by an
+	// opaque provider-configuration fingerprint (#7059). The legacy type and file
+	// names preserve the on-disk v2 contract. nil keeps in-memory gating only.
+	warnState *missingReasoningWarnState
+	// gate is the per-call permission gate for both standard and Plan
+	// workflows. nil disables gating entirely.
+	gate Gate
+	// extensions is the frozen Extension Protocol v2 dispatcher for this
+	// controller generation; nil means every intercept point passes through
+	// byte-identically. See extensions.go.
+	extensions *dispatch.Dispatcher
+	// recoveryGate is the Auto Guard boundary, shared by root and sub-agents for
+	// one controller task. nil disables recovery checks.
+	recoveryGate RecoveryGate
+	// planTrust is retained for legacy controller wiring. The main Plan
+	// execution path no longer consults it.
+	planTrust PlanModeReadOnlyTrustGate
+	// sandboxEscape can ask the user whether one shell command may rerun
+	// unconfined after the OS sandbox failed to start.
+	sandboxEscape sandbox.EscapeApprover
+	// configWrite can ask the user whether a file tool may write a
+	// Reasonix-managed config file outside the workspace roots.
+	configWrite tool.ConfigWriteApprover
+	// hooks fires PreToolUse / PostToolUse shell hooks around each tool call.
+	hooks ToolHooks
+	// asker lets the `ask` tool put questions to the user; nil in headless runs.
+	asker Asker
+	// preEdit is the seam the checkpoint store uses to snapshot pre-edit
+	// content. Only non-ReadOnly tool.Previewer tools fire it, so bash — whose
+	// targets are unknowable — is never tracked. Prefer mutationObserver.
+	preEdit func(diff.Change)
+	// mutationObserver is the host-side unified file mutation observer: it
+	// captures preimages before tools run and fingerprints after, regardless of
+	// outcome. Never changes provider-visible schemas or prompts.
+	mutationObserver *checkpoint.MutationObserver
+	// jobs is the session's background-job manager, stamped onto each tool
+	// call's context so the background tools can reach it. nil degrades
+	// gracefully.
+	jobs *jobs.Manager
+	// writeScheduler coordinates parent-agent writes against background
+	// subagent write claims. Set on the parent executor only.
+	writeScheduler *SubagentScheduler
+	// workspaceLease is shared by every writer-capable agent in one Delivery
+	// session, acquired lazily on the first mutation and held through the final
+	// participating run so verification stays isolated.
+	workspaceLease *workspacelease.Owner
+	// memQueue lets the remember/forget tools fold a turn-tail note about a
+	// just-made memory change into the next turn, so it applies this session
+	// without touching the cache-stable prefix.
+	memQueue memory.Queue
+}
+
+// newAgentServices binds the collaborators New resolved. It exists so New stays
+// under the function-size limit and so adding a collaborator touches one place.
+func newAgentServices(
+	prov provider.Provider, tools *tool.Registry, sink event.Sink, gate Gate,
+	planTrust PlanModeReadOnlyTrustGate, sandboxEscape sandbox.EscapeApprover,
+	configWrite tool.ConfigWriteApprover, hooks ToolHooks, opts Options,
+) agentServices {
+	return agentServices{
+		prov:             prov,
+		tools:            tools,
+		pricing:          opts.Pricing,
+		sink:             sink,
+		gate:             gate,
+		extensions:       opts.Extensions,
+		recoveryGate:     opts.RecoveryGate,
+		planTrust:        planTrust,
+		sandboxEscape:    sandboxEscape,
+		configWrite:      configWrite,
+		hooks:            hooks,
+		jobs:             opts.Jobs,
+		memQueue:         opts.MemoryQueue,
+		writeScheduler:   opts.WriteScheduler,
+		workspaceLease:   opts.WorkspaceLease,
+		warnState:        missingReasoningWarnStateFor(opts.MissingReasoningWarnStateDir),
+		mutationObserver: opts.MutationObserver,
+	}
+}

--- a/internal/agent/taskpolicy_execution_test.go
+++ b/internal/agent/taskpolicy_execution_test.go
@@ -95,8 +95,8 @@ func TestTaskPolicyRequiresPostMutationVerification(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Mutation: true}
 	check := evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."}
 	a := &Agent{
-		task:  taskRuntime{ledger: readinessLedger(check, writer)},
-		tools: reg,
+		task: taskRuntime{ledger: readinessLedger(check, writer)},
+		svc:  agentServices{tools: reg},
 		turn: turnRuntime{
 			policy:    taskpolicy.TaskPolicy{Verification: taskpolicy.VerifyTargeted},
 			policySet: true,

--- a/internal/agent/turn_phase.go
+++ b/internal/agent/turn_phase.go
@@ -8,17 +8,17 @@ import (
 
 // emitTurnPhase publishes a content-free host phase for the active turn.
 func (a *Agent) emitTurnPhase(phase event.TurnPhaseName) {
-	if a == nil || a.sink == nil || phase == "" {
+	if a == nil || a.svc.sink == nil || phase == "" {
 		return
 	}
-	a.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: phase, Text: string(phase)})
+	a.svc.sink.Emit(event.Event{Kind: event.TurnPhase, PhaseName: phase, Text: string(phase)})
 }
 
 // emitCompletionSummary publishes the content-free end-of-turn quality summary
 // when the turn mutated state or finished Partial/Blocked. Pure conversation
 // and ordinary read-only success do not emit a quality card.
 func (a *Agent) emitCompletionSummary(c *taskcontract.Contract) {
-	if a == nil || a.sink == nil || c == nil {
+	if a == nil || a.svc.sink == nil || c == nil {
 		return
 	}
 	mutations := 0
@@ -92,7 +92,7 @@ func (a *Agent) emitCompletionSummary(c *taskcontract.Contract) {
 	case taskcontract.VerdictContinue:
 		summaryVerdict = "continue"
 	}
-	a.sink.Emit(event.Event{
+	a.svc.sink.Emit(event.Event{
 		Kind: event.CompletionSummary,
 		Completion: &event.CompletionSummaryInfo{
 			Preset:             a.AgentPreset(),

--- a/internal/agent/workspace_lease_test.go
+++ b/internal/agent/workspace_lease_test.go
@@ -94,7 +94,7 @@ func TestDeliveryWriterWaitsBeforeToolExecutionButReaderDoesNot(t *testing.T) {
 	}
 
 	hooks := &workspaceLeaseTestHooks{}
-	a.hooks = hooks
+	a.svc.hooks = hooks
 	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
 	defer cancel()
 	outcome := a.executeOne(ctx, &a.turn, providerToolCall("write", writer.Name()))
@@ -115,7 +115,7 @@ func TestDeniedDeliveryWriterDoesNotAcquireWorkspaceLease(t *testing.T) {
 	probeOwner, _ := workspacelease.New(root, locks, nil)
 	writer := &workspaceLeaseTestTool{name: "denied_writer"}
 	a := deliveryLeaseTestAgent(t, deniedOwner, writer)
-	a.gate = workspaceLeaseDenyGate{}
+	a.svc.gate = workspaceLeaseDenyGate{}
 	deniedOwner.BeginRun()
 	outcome := a.executeOne(context.Background(), &a.turn, providerToolCall("write", writer.Name()))
 	deniedOwner.EndRun()

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -3,8 +3,8 @@
     "banner": 15,
     "commented-code": 0,
     "complexity": 2069,
-    "essay": 3990,
-    "file-size": 108213,
+    "essay": 3983,
+    "file-size": 108119,
     "function-size": 8846,
     "layering": 1,
     "marker": 0,
@@ -448,8 +448,8 @@
     },
     "internal/agent/agent.go": {
       "complexity": 37,
-      "essay": 62,
-      "file-size": 2155,
+      "essay": 55,
+      "file-size": 2061,
       "function-size": 102,
       "struct-state": 3
     },


### PR DESCRIPTION
Last stage of #8523, stacked on #8588. Nineteen fields on `Agent` were who it
talks to, interleaved with what it remembers. They are now `agentServices`,
reached as `a.svc`.

## This one is not a lifetime, and does not claim to be

The original plan had this as the process-scoped layer. Checking the candidates
against their write sites instead of their names says otherwise:

- 13 of the 19 are rebound at runtime through the `Set*` seams the controller
  uses between turns — `SetSink`, `SetGate`, `SetTools`, `SetExtensions`,
  `SetAsker`, `SetMemoryQueue`, `SetPreEditHook`, `SetMutationObserver`, and
  the rest
- `fork.go` wraps `a.svc.prov` in a capture provider mid-run

So the axis is collaborators-versus-state, and the type's doc comment says that
rather than implying a scope the code does not have. `agentConfig` remains the
only immutable layer, and it is the one with the guard test.

It also pays down no ratchet: every one of these is an interface or a pointer,
and `struct-state` counts scalars. That was the reason for doing it last.

## What it buys

`Agent` is now readable as a list of lifetimes plus a short tail:

```go
type Agent struct {
    agentConfig                  // immutable, guarded
    svc  agentServices           // collaborators
    sess sessionRuntime          // one conversation
    task taskRuntime             // one delivery scope, many Runs
    turn turnRuntime             // one Run
    pending pendingTurn          // armed outside a Run, consumed by the next
    ...                          // ~12 flags and atomics
}
```

`New` would have crossed the 120-line function limit carrying the literal, so
the binding moves to `newAgentServices`. Adding a collaborator now touches one
place instead of two.

## Verification

- `go test ./internal/agent/` green; `./internal/tool/builtin/`,
  `./internal/boot/` green; `./internal/control/` green over 2 runs
- `go vet ./...` clean; golangci-lint 2.12.2, 0 issues repo-wide
- repolint: verified key-by-key that no baseline entry increases. `agent.go`
  `essay` 62 → 55 and `file-size` 2155 → 2061 as the field docs move to
  `services.go`, which adds no findings of its own.

## Where #8523 ends up

`struct-state` for `agent.go` across the four stages: **20 → 18 → 10 → 3**.

Two things are deliberately left, both recorded rather than quietly changed:

- `capabilityLedger` / `capabilityGate` stay on `Agent` because their reset
  lives in `internal/control` — `SeedCapabilityRoute` has no caller inside
  `internal/agent`. A turn-local ledger would be a behaviour change.
- `lastPrefixShape` survives a conversation swap, so the next request explains
  its prefix churn against the replaced conversation. Listed in
  `sessionCarryOver` (#8564).

Part of #8523.

Cache-impact: none - host state only. No prompt text, tool schema, or provider
request field is touched; the collaborators keep their values and their readers.
Cache-guard: go test ./internal/agent/ -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction|TestSessionAggregateCacheRate'
System-prompt-review: yhh - the gate fires on `internal/agent/agent.go` and
`internal/agent/task.go`. Both diffs are field relocation and selector renames;
no prompt string, tool schema, or system-prompt assembly is reached, and
`internal/config/`, `internal/memory/`, `internal/outputstyle/`,
`internal/skill/` and `internal/boot/` are untouched.
Documentation-impact: none - `docs/*.md` describes behaviour and configuration,
and this PR changes neither. The grouping is internal to `internal/agent`,
documented at its declaration and in #8523.
