### PR TITLE
fix(desktop): refresh history panel after in-session rename / auto-title

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2566,21 +2566,6 @@ export default function App() {
     return { scope, workspaceRoot: activeWorkspaceRoot };
   }, [activeTab?.scope, activeTab?.workspaceRoot]);
 
-  useEffect(() => {
-    let live = true;
-    const ready = import("./lib/workspaceRefreshStore")
-      .then(({ default: startWorkspaceFocusReconciliation }) => live ? startWorkspaceFocusReconciliation(activeTabId, workspaceScopeKey, refreshTabMetas) : undefined)
-      .catch(() => undefined);
-    const stopProjectTree = onProjectTreeChanged(() => {
-      setProjectRevision((value) => value + 1);
-      void refreshTabMetas(undefined, { afterMutation: true });
-    });
-    return () => {
-      live = false;
-      stopProjectTree();
-      void ready.then((stop) => stop?.());
-    };
-  }, [activeTabId, refreshTabMetas, workspaceScopeKey]);
 
   // Bridge remote:* events into the remote store once, app-wide, so the
   // StatusBar chip, host manager, and explorer all see the same live state.
@@ -3663,6 +3648,27 @@ export default function App() {
     );
   }, [listSessions]);
 
+  useEffect(() => {
+    let live = true;
+    const ready = import("./lib/workspaceRefreshStore")
+      .then(({ default: startWorkspaceFocusReconciliation }) => live ? startWorkspaceFocusReconciliation(activeTabId, workspaceScopeKey, refreshTabMetas) : undefined)
+      .catch(() => undefined);
+    const stopProjectTree = onProjectTreeChanged(() => {
+      setProjectRevision((value) => value + 1);
+      void refreshTabMetas(undefined, { afterMutation: true });
+      // #8280: in-session renames / auto-titles emit project-tree:changed but
+      // the history panel snapshot (histView.sessions) was never refreshed, so
+      // the sidebar kept stale titles until a pull-triggering action. refreshHistoryView
+      // is a no-op while the panel is closed (kind !== "history").
+      void refreshHistoryView();
+    });
+    return () => {
+      live = false;
+      stopProjectTree();
+      void ready.then((stop) => stop?.());
+    };
+  }, [activeTabId, refreshTabMetas, workspaceScopeKey, refreshHistoryView]);
+
   const navigationSeqRef = useRef(0);
   const navigationRunningRef = useRef(false);
   const navigationPendingRef = useRef<PendingDesktopNavigationRequest | null>(null);
@@ -4165,10 +4171,12 @@ export default function App() {
     try {
       await app.RenameTopic(topicId, nextTitle);
       await refreshProjectsAndTabs();
+      // #8280: keep the history panel snapshot in sync after in-session renames.
+      await refreshHistoryView();
     } catch (err) {
       showToast(err instanceof Error ? err.message : String(err), "error");
     }
-  }, [refreshProjectsAndTabs, showToast]);
+  }, [refreshHistoryView, refreshProjectsAndTabs, showToast]);
 
   const startActiveTopicRename = useCallback(() => {
     if (!activeTab?.topicId) return;


### PR DESCRIPTION
## Summary

会话内改名（topicbar 的 `renameTopic`）或自动命名后，左侧 HistoryPanel 的会话名称不会立即更新——`project-tree:changed` 事件回调只刷新了项目树 revision 和 tab 元数据，从不重拉 HistoryPanel 的数据源 `histView.sessions`（快照），导致侧边栏持续显示旧标题，直到删除/恢复/打开回收站等触发重拉的操作发生。

本 PR 让改名/自动命名事件同步刷新历史面板快照：

1. `onProjectTreeChanged` 回调追加 `refreshHistoryView()`——该函数对未打开面板无副作用（`kind !== "history"` 时原样返回），覆盖会话内改名与自动命名两条事件路径；
2. `renameTopic` 成功后同样追加 `refreshHistoryView()`，覆盖用户主动改名路径；
3. 因 `refreshHistoryView` 定义于回调 useEffect 之后（TDZ），将该 useEffect 移动到其定义之后并加入依赖数组。

Root cause（详见 #8280）：`desktop/frontend/src/App.tsx` 的 `onProjectTreeChanged` 回调只做 `setProjectRevision` + `refreshTabMetas`；`histView.sessions` 仅在删除/恢复/清空/回收站/导航失败/列表内改名时重拉，会话内改名路径不在此列。

English: after renaming a session/topic from inside the chat (or after auto-title), the sidebar kept showing the stale title because the `project-tree:changed` handler never refreshed the HistoryPanel snapshot (`histView.sessions`). This PR adds `refreshHistoryView()` to the event callback and to `renameTopic` (with the effect moved after the `refreshHistoryView` definition to satisfy TDZ/deps).

## Issues

Fixes #8280

## Verification

- `pnpm typecheck` (tsc --noEmit) — pass
- `pnpm lint:hooks` (eslint src/**/*.{ts,tsx}) — pass
- `pnpm test:workspace` — 7 passed, 0 failed
- `pnpm test:typecheck` — blocked by a **pre-existing** TS6133 in `src/__tests__/transcript-scroll-release.test.ts:6` (`'equal' declared but never read`); reproduced on clean main-v2 HEAD (stash-verified), unrelated to this change

## Documentation impact

Documentation-impact: none- UI behavior fix only; no config, CLI, provider, permission, or tool surface changed.

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- no relevant changes.