### PR TITLE
feat(desktop): aggregate active-session indicator on collapsed project folders

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1698,6 +1698,15 @@ export function ProjectTree({
       );
     };
 
+    // #8209: aggregate "any active child session" onto the folder row so a
+    // collapsed project still shows live activity. projectTreeTopicArchiveBlocked
+    // matches exactly the in-flight states (thinking/streaming/waiting_confirmation/
+    // background_job/running); paused/error/diverged_recovery stay dim. Children
+    // are whatever the catalog already loaded - the indicator degrades to a
+    // best-effort under lazy pagination rather than forcing a full fetch.
+    const folderChildren = asArray(node.children);
+    const folderHasActive = folderChildren.some(projectTreeTopicArchiveBlocked);
+
     if (editingProject?.key === key) {
       return (
         <div key={key} className="project-tree__project-wrapper">
@@ -1760,6 +1769,9 @@ export function ProjectTree({
               {projectLabel}
               {node.isolatedWorktree && <WorktreeBadge size={11} />}
             </span>
+            {folderHasActive && (
+              <span className="project-tree__folder-active-indicator" aria-hidden="true" />
+            )}
           </button>
           {compactTopics && (
             <Tooltip label={t("projectTree.projectActions")} className="project-tree__folder-action-slot">

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30225,6 +30225,20 @@ body > .mermaid-diagram--fullscreen {
   stroke-width: 1.9;
 }
 
+/* #8209: aggregate active-session indicator on collapsed project folders */
+.project-tree__folder-active-indicator {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 10px;
+  margin-left: 6px;
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, currentColor 26%, transparent);
+  border-top-color: currentColor;
+  background: transparent;
+  animation: project-tree-spin 0.9s linear infinite;
+  pointer-events: none;
+}
+
 @keyframes project-tree-spin {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
## Summary

折叠的项目/Global workspace 节点现在会聚合显示内部活跃子会话的转圈指示——无需展开即可快速定位有会话正在运行的项目（thinking / streaming / waiting_confirmation / background_job）。

实现（纯前端，后端数据已齐）：

1. `ProjectTree.tsx` folder 行：遍历 `node.children`，用 `projectTreeTopicArchiveBlocked` 聚合"存在进行中会话"（该函数语义恰好 = 活跃态：thinking/streaming/waiting_confirmation/background_job，paused/error/diverged_recovery 不亮），label 旁渲染 `project-tree__folder-active-indicator`；
2. `styles.css`：新增指示点样式，复用现有 `project-tree-spin` 转圈动画（与 topic 行 thinking/streaming 状态点同款视觉）。

聚合语义（与 issue 要求一致）：任一子会话运行中 → 指示点亮起；全部空闲 → 熄灭。展开/折叠状态均显示。lazy 分页下 children 未加载完全时指示降级为 best-effort（基于已加载数据）。

English: collapsed project / global-folder rows now show a small spinner when any child session is in-flight (thinking/streaming/waiting_confirmation/background_job), so users can spot projects with live activity without expanding. Pure frontend: aggregate `node.children` with `projectTreeTopicArchiveBlocked` in the folder row and reuse the existing `project-tree-spin` animation. Backend already overlays per-topic runtime status (`desktop/session_catalog_runtime.go`), no backend change needed.

## Issues

Fixes #8209

## Verification

- `pnpm typecheck` (tsc --noEmit) — pass
- `pnpm lint:hooks` (eslint src/**/*.{ts,tsx}) — pass
- `pnpm check:css` (CSS syntax + z-index tokens) — pass
- `pnpm test:workspace` — 7 passed, 0 failed

## Documentation impact

Documentation-impact: none - visual indicator only; no config, CLI, provider, permission, or tool surface changed.

## Cache impact

Cache-impact: none - no prompt, tool schema, or provider request changes.
Cache-guard: not required - changed paths are outside provider-visible cache construction.
System-prompt-review: N/A
