### PR TITLE
fix(repolint): restore the Transcript.tsx budget my stale baseline reverted

### DIFF
--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,7 +4,7 @@
     "commented-code": 0,
     "complexity": 2069,
     "essay": 3990,
-    "file-size": 108204,
+    "file-size": 108213,
     "function-size": 8846,
     "layering": 1,
     "marker": 0,
@@ -155,7 +155,7 @@
       "file-size": 158
     },
     "desktop/frontend/src/components/Transcript.tsx": {
-      "file-size": 269
+      "file-size": 278
     },
     "desktop/frontend/src/components/UsageStatsPanel.tsx": {
       "file-size": 276


### PR DESCRIPTION
`main-v2` currently fails `go run ./tools/repolint`:

```
desktop/frontend/src/components/Transcript.tsx:1: [file-size] 1078 lines exceeds the 800-line ceiling
repolint: Transcript.tsx: file-size is 278 over its 269 budget
```

That 269 is mine, not the desktop side's. Tracing the entry:

| commit | budget |
|---|---|
| `9ee45baf7` React Virtuoso refactor | 322 |
| `c49820905` #8564 (session lifetime) | **269** |
| `8c446adaa` #8586 (scrollbar dragging) | 269 |

#8564 branched from `71c7c6f3e`, before the Virtuoso refactor landed.
`repolint -update` regenerates the whole baseline from the local tree, so it
recorded the pre-Virtuoso size of a file that PR never touched, and squash-
merging it overwrote the headroom the Virtuoso PR had correctly raised. #8586
then grew the file to 278 against a budget that was already wrong — its own
`lint` was green because it ran before #8564 merged.

This restores that one entry and the file-size total. Nothing else moves, and
that is checked key-by-key against `origin/main-v2` rather than asserted.

## The verification was wrong, not just the number

Each stage of #8523 reported "no baseline entry increases", and that was true
every time. It is the wrong invariant: a *decrease* in a file the PR does not
touch is the same bug with the opposite sign, and it is the one that silently
discards someone else's headroom. Both directions need checking against the
merge base, and a PR should not move an entry for a file outside its diff at
all.

## What this does not do

`Transcript.tsx` is 1078 lines against an 800-line ceiling. That debt is real,
predates this, and belongs with the desktop transcript work (#8569) — not with
a baseline resync.

Cache-impact: none - a lint baseline file. No Go code, prompt, tool schema, or
provider request field is touched.
Cache-guard: not applicable; `tools/repolint/baseline.json` has no path into any
provider request.
Documentation-impact: none - `docs/*.md` documents behaviour and configuration,
and a repolint baseline is neither.
