### PR TITLE
feat(desktop): manual topic drag-to-reorder in project tree

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -208,6 +208,21 @@ function reorderedProjectRoots(nodes: ProjectNode[], draggedRoot: string, target
   return next;
 }
 
+// reorderedTopicIDs computes the full topic order for the parent folder after
+// moving draggedID next to targetID. Returns null when the drag is invalid.
+function reorderedTopicIDs(nodes: ProjectNode[], draggedID: string, targetID: string, position: ProjectDropPosition): string[] | null {
+  const parent = nodes.find((n) => asArray(n.children).some((c) => c.topicId === draggedID || c.topicId === targetID));
+  if (!parent) return null;
+  const ids = asArray(parent.children)
+    .filter((c) => isTopicNode(c) && c.topicId)
+    .map((c) => c.topicId as string);
+  if (!ids.includes(draggedID) || !ids.includes(targetID)) return null;
+  const rest = ids.filter((id) => id !== draggedID);
+  const at = rest.indexOf(targetID);
+  const insertAt = position === "before" ? at : at + 1;
+  return [...rest.slice(0, insertAt), draggedID, ...rest.slice(insertAt)];
+}
+
 function applyProjectOrder(nodes: ProjectNode[], roots: string[]): ProjectNode[] {
   const projectEntries = nodes
     .map((node): [string, ProjectNode] => [projectOrderKey(node), node])
@@ -235,6 +250,12 @@ function sortWorkbenchChildren(children: ProjectNode[], sortMode: WorkbenchSortM
   return [...children].sort((a, b) => {
     if (!isTopicNode(a) || !isTopicNode(b)) return 0;
     if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1;
+    // #8194: manual topic order (persisted via ReorderTopics → catalog
+    // sort_order) wins over the activity-based fallback, so users can keep
+    // important sessions above the fold even when folders are collapsed.
+    const ao = typeof a.sortOrder === "number" ? a.sortOrder : Number.MAX_SAFE_INTEGER;
+    const bo = typeof b.sortOrder === "number" ? b.sortOrder : Number.MAX_SAFE_INTEGER;
+    if (ao !== bo) return ao - bo;
     return topicSortValue(b, sortMode) - topicSortValue(a, sortMode);
   });
 }
@@ -424,6 +445,10 @@ export function ProjectTree({
   const [confirmAction, setConfirmAction] = useState<{ topicId: string; action: "trash" } | null>(null);
   const [confirmRemoveProject, setConfirmRemoveProject] = useState<string | null>(null);
   const [dragProjectRoot, setDragProjectRoot] = useState<string | null>(null);
+  const [dragTopicID, setDragTopicID] = useState<string | null>(null);
+  const [dragTopicScope, setDragTopicScope] = useState<"global" | "project">("project");
+  const [dragTopicRoot, setDragTopicRoot] = useState("");
+  const [dropTopic, setDropTopic] = useState<{ topicID: string; position: "before" | "after" } | null>(null);
   const [dropProject, setDropProject] = useState<{ root: string; position: ProjectDropPosition } | null>(null);
   const [collapseSnapshot, setCollapseSnapshot] = useState<CollapseSnapshot | null>(null);
   const [platform, setPlatform] = useState("");
@@ -1118,6 +1143,19 @@ export function ProjectTree({
     }
   }, [onTopicsChanged, refresh, tree]);
 
+  const commitTopicReorder = useCallback(async (draggedID: string, targetID: string, position: "before" | "after") => {
+    if (!draggedID || draggedID === targetID) return;
+    const nextIDs = reorderedTopicIDs(tree, draggedID, targetID, position);
+    if (!nextIDs) return;
+    try {
+      await app.ReorderTopics(dragTopicScope, dragTopicRoot, nextIDs);
+      await refresh();
+      await onTopicsChanged?.();
+    } catch {
+      await refresh();
+    }
+  }, [dragTopicRoot, dragTopicScope, onTopicsChanged, refresh, tree]);
+
   const clearProjectDrag = useCallback(() => {
     setDragProjectRoot(null);
     setDropProject(null);
@@ -1274,10 +1312,57 @@ export function ProjectTree({
           sessionPath: openRequest.sessionPath,
         });
       }
+      // #8194: manual drag-to-reorder for topic rows (disabled while
+      // searching, renaming, or another drag is in flight).
+      const topicDraggable = !isSessionNode && !query && !menuTopic && !editingTopic && !dragProjectRoot && !creatingProject && Boolean(node.topicId);
+      const handleTopicDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+        event.dataTransfer.setData("text/plain", key);
+        event.dataTransfer.effectAllowed = "move";
+        setDragTopicID(node.topicId ?? null);
+        setDragTopicScope(node.kind === "global_topic" ? "global" : "project");
+        setDragTopicRoot(node.root ?? "");
+      };
+      const handleTopicDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+        if (!dragTopicID || dragTopicID === node.topicId) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        const rect = event.currentTarget.getBoundingClientRect();
+        const position = event.clientY < rect.top + rect.height / 2 ? ("before" as const) : ("after" as const);
+        setDropTopic((prev) => (prev !== null && prev.topicID === node.topicId && prev.position === position ? prev : { topicID: node.topicId as string, position }));
+      };
+      const handleTopicDragLeave = () => {
+        setDropTopic((prev) => (prev?.topicID === node.topicId ? null : prev));
+      };
+      const handleTopicDrop = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        let dragged = dragTopicID;
+        if (!dragged) {
+          const transferKey = event.dataTransfer.getData("text/plain");
+          if (transferKey.startsWith("topic_")) dragged = transferKey.slice("topic_".length);
+          else if (transferKey.startsWith("global_topic_")) dragged = transferKey.slice("global_topic_".length);
+        }
+        if (dragged && dragged !== node.topicId) {
+          const rect = event.currentTarget.getBoundingClientRect();
+          const position = event.clientY < rect.top + rect.height / 2 ? ("before" as const) : ("after" as const);
+          void commitTopicReorder(dragged, node.topicId as string, position);
+        }
+        setDragTopicID(null);
+        setDropTopic(null);
+      };
+      const handleTopicDragEnd = () => {
+        setDragTopicID(null);
+        setDropTopic(null);
+      };
       const row = (
         <div
-          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${unread ? " project-tree__topic--unread" : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${sideTimeVisible && (timeLabel || showStatusInSide || showWaitingPill) ? " project-tree__topic--with-side" : metaFull ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
+          className={`project-tree__topic${scopeClass}${isSessionNode ? " project-tree__topic--session" : ""}${active ? " project-tree__topic--active" : ""}${node.running ? " project-tree__topic--running" : ""}${status ? ` project-tree__topic--status-${status}` : ""}${unread ? " project-tree__topic--unread" : ""}${!isSessionNode && pinned ? " project-tree__topic--pinned" : ""}${topicMenuOpen ? " project-tree__topic--menu-open" : ""}${dropTopic !== null && dropTopic.topicID === node.topicId && dragTopicID !== null && dragTopicID !== node.topicId ? ` project-tree__topic--drop-${dropTopic.position}` : ""}${sideTimeVisible && (timeLabel || showStatusInSide || showWaitingPill) ? " project-tree__topic--with-side" : metaFull ? " project-tree__topic--has-meta" : ""}${imSource ? " project-tree__topic--im-source" : ""}${shortcutIndex > 0 ? " project-tree__topic--show-shortcut" : ""}`}
           style={accentStyle}
+          draggable={topicDraggable}
+          onDragStart={topicDraggable ? handleTopicDragStart : undefined}
+          onDragOver={topicDraggable ? handleTopicDragOver : undefined}
+          onDragLeave={topicDraggable ? handleTopicDragLeave : undefined}
+          onDrop={topicDraggable ? handleTopicDrop : undefined}
+          onDragEnd={topicDraggable ? handleTopicDragEnd : undefined}
           onContextMenu={isSessionNode ? undefined : openTopicMenu}
           onMouseEnter={classicTopics ? (event) => scheduleHoverCard(event.currentTarget, key, node) : undefined}
           onMouseLeave={classicTopics ? cancelHoverCard : undefined}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -620,6 +620,7 @@ export interface AppBindings extends SessionCatalogBindings, HistoryCatalogBindi
   DeleteTopic(topicID: string): Promise<void>;
   TrashTopic(topicID: string): Promise<void>;
   SetTopicPinned(topicID: string, pinned: boolean): Promise<void>;
+  ReorderTopics(scope: string, workspaceRoot: string, orderedTopicIDs: string[]): Promise<void>;
   ContextPanel(tabID: string): Promise<ContextPanelInfo>;
   // New native-feel bindings (added with the desktop native-feel plan).
   ConfirmAction(req: NativeConfirmRequest): Promise<boolean>;
@@ -5339,6 +5340,21 @@ function makeMockApp(): AppBindings {
     },
     async SetTopicPinned(topicID: string, pinned: boolean) {
       setMockTopicPinned(topicID, pinned);
+    },
+    async ReorderTopics(scope: string, workspaceRoot: string, orderedTopicIDs: string[]) {
+      const parents = mockProjectTree.filter((node) =>
+        scope === "global" ? node.kind === "global_folder" : node.kind === "project" && node.root === workspaceRoot,
+      );
+      for (const parent of parents) {
+        const children = projectChildren(parent);
+        const topicIDs = children.map((child) => child.topicId).filter((id): id is string => Boolean(id));
+        if (!topicIDs.every((id) => orderedTopicIDs.includes(id))) continue;
+        const byID = new Map(children.filter((c) => c.topicId).map((c) => [c.topicId, c]));
+        parent.children = orderedTopicIDs
+          .map((id) => byID.get(id))
+          .filter((c): c is NonNullable<typeof c> => Boolean(c));
+        return;
+      }
     },
     async SaveWindowState(_state) {
       // no-op in browser dev — no real window geometry to persist

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -508,6 +508,7 @@ export interface ProjectNode {
   running?: boolean;
   status?: ProjectTopicStatus;
   pinned?: boolean;
+  sortOrder?: number;
   recovered?: boolean;
   recoveryReason?: string;
   recoveryDigest?: string;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30225,6 +30225,13 @@ body > .mermaid-diagram--fullscreen {
   stroke-width: 1.9;
 }
 
+.project-tree__topic--drop-before {
+  box-shadow: inset 0 2px 0 currentColor;
+}
+.project-tree__topic--drop-after {
+  box-shadow: inset 0 -2px 0 currentColor;
+}
+
 @keyframes project-tree-spin {
   to {
     transform: rotate(360deg);

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -141,7 +141,7 @@ func (a *App) metadataProjectTopics(scope, workspaceRoot string) []ProjectNode {
 	}
 	out := []ProjectNode{}
 	seen := map[string]bool{}
-	for _, topicID := range pinnedTopicIDs(orderedTopicIDs(ids, titles), pinnedIDs) {
+	for sortOrder, topicID := range pinnedTopicIDs(orderedTopicIDs(ids, titles), pinnedIDs) {
 		if deleted[topicID] {
 			continue
 		}
@@ -159,7 +159,7 @@ func (a *App) metadataProjectTopics(scope, workspaceRoot string) []ProjectNode {
 			Key: kind + "_" + topicID, Kind: kind,
 			Label: a.localizedTopicTitle(title, sources[topicID]), Root: workspaceRoot,
 			TopicID: topicID, ProjectColor: projectColor,
-			CreatedAt: topicCreatedAtForTree(created, topicID), Pinned: containsDesktopString(pinnedIDs, topicID),
+			CreatedAt: topicCreatedAtForTree(created, topicID), Pinned: containsDesktopString(pinnedIDs, topicID), SortOrder: sortOrder,
 			Open: overlay.open, Running: overlay.running, Status: overlay.status,
 			TurnsState: string(sessioncatalog.TurnsUnknown), Health: string(sessioncatalog.HealthOK),
 			Children: []ProjectNode{},
@@ -329,7 +329,8 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 		Root: topic.WorkspaceRoot, TopicID: topic.TopicID, Turns: topic.Turns,
 		TurnsState: string(topic.TurnsState), Health: string(topic.Health),
 		CreatedAt: topic.CreatedAt, LastActivityAt: topic.LastActivityAt,
-		Pinned: topic.Pinned, Open: overlay.open, Running: overlay.running, Status: overlay.status,
+		Pinned: topic.Pinned, SortOrder: topic.SortOrder,
+		Open: overlay.open, Running: overlay.running, Status: overlay.status,
 		// Ordinary tree is zero-config: never surface recovery counts, badges,
 		// or forced-handling status. History "other saved versions" owns that.
 		Children: []ProjectNode{},

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6459,6 +6459,7 @@ type ProjectNode struct {
 	Running                      bool          `json:"running,omitempty"`
 	Status                       string        `json:"status,omitempty"`
 	Pinned                       bool          `json:"pinned,omitempty"`
+	SortOrder                    int           `json:"sortOrder"` // manual topic order index (0-based); -1 when unknown
 	Recovered                    bool          `json:"recovered,omitempty"`
 	RecoveryReason               string        `json:"recoveryReason,omitempty"`
 	RecoveryDigest               string        `json:"recoveryDigest,omitempty"`
@@ -6756,6 +6757,77 @@ func (a *App) SetProjectPinned(workspaceRoot string, pinned bool) error {
 
 // ReorderProjects persists the user-defined order of project folders and,
 // when present, the virtual Global sidebar section.
+// ReorderTopics persists the user's manual topic order for a project or the
+// global workspace (#8194). orderedTopicIDs must be the complete desired order
+// for every topic in the scope; missing topics are appended in their previous
+// relative order so a stale client can never drop topics from the list.
+func (a *App) ReorderTopics(scope, workspaceRoot string, orderedTopicIDs []string) error {
+	scope = strings.TrimSpace(scope)
+	workspaceRoot = normalizeProjectRoot(workspaceRoot)
+	if scope != "global" && workspaceRoot == "" {
+		return fmt.Errorf("workspaceRoot is required for project scope")
+	}
+	if len(orderedTopicIDs) == 0 {
+		return fmt.Errorf("orderedTopicIDs is required")
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		if scope == "global" {
+			next, err := completeTopicOrder(orderedTopicIDs, f.GlobalTopics)
+			if err != nil {
+				return false, err
+			}
+			if sameStringList(next, f.GlobalTopics) {
+				return false, nil
+			}
+			f.GlobalTopics = next
+			return true, nil
+		}
+		i := projectIndexByRoot(f.Projects, workspaceRoot)
+		if i < 0 {
+			return false, fmt.Errorf("project %q not found", workspaceRoot)
+		}
+		next, err := completeTopicOrder(orderedTopicIDs, f.Projects[i].Topics)
+		if err != nil {
+			return false, err
+		}
+		if sameStringList(next, f.Projects[i].Topics) {
+			return false, nil
+		}
+		f.Projects[i].Topics = next
+		return true, nil
+	}); err != nil {
+		return err
+	}
+	a.emitProjectTreeMetadataChanged()
+	return nil
+}
+
+// completeTopicOrder returns orderedTopicIDs deduplicated in order, followed by
+// any topics from previous that were not included (preserving their previous
+// relative order).
+func completeTopicOrder(orderedTopicIDs, previous []string) ([]string, error) {
+	seen := make(map[string]bool, len(orderedTopicIDs))
+	next := make([]string, 0, len(orderedTopicIDs))
+	for _, id := range orderedTopicIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("duplicate topic %q", id)
+		}
+		seen[id] = true
+		next = append(next, id)
+	}
+	for _, id := range previous {
+		if !seen[id] {
+			seen[id] = true
+			next = append(next, id)
+		}
+	}
+	return next, nil
+}
+
 func (a *App) ReorderProjects(workspaceRoots []string) error {
 	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
 		var seenProjects []string


### PR DESCRIPTION
## Summary

项目内 / Global workspace 的会话（topic）行现在支持**手动拖拽排序**（#8194 的第一阶段：排序）。顺序持久化到 `projects.json`（`desktopProject.Topics` / `GlobalTopics` 有序数组），重启后保留。

**机制链路**（全部复用现有设施，不动 SQL/分页）：

1. **新 IPC `ReorderTopics(scope, workspaceRoot, orderedTopicIDs)`**（desktop/tabs.go，仿 `ReorderProjects` + `SetTopicPinned` 的 scope 分支）：完整顺序写入 `Projects[i].Topics` / `GlobalTopics`；缺失 topic 按原相对顺序补尾（防旧客户端丢 topic）；写盘后 `emitProjectTreeMetadataChanged` 触发同步。
2. **`ProjectNode.SortOrder` 透传**（projectNodeFromCatalogTopic + metadataProjectTopics fallback）：catalog 的 `sort_order` 列已由 `syncSessionCatalogMetadata` 按文件顺序写入（session_catalog.go:342-354），本次仅透传到前端——**不改 `ListTopics` 的 ORDER BY / cursor**，分页零风险。
3. **前端 `sortWorkbenchChildren` 手动优先**（ProjectTree.tsx）：pinned 置顶 → 手动 `sortOrder` 升序 → 未排序项按活跃度 fallback。
4. **topic 行拖拽**：原生 HTML5 drag&drop（仿项目行 1467-1499），drop 位置按行上下半判定（before/after），高亮线反馈；搜索/重命名/其他拖拽进行中时禁用；提交失败自动 refresh 回滚。

拖拽只作用于 topic 行（不作用于展开的 session 子行）；Global 与 project 完全同构（`global_topic` 分支）。

English: topic rows in the project tree (project + global workspace) are now manually reorderable by drag & drop. Order persists via the new `ReorderTopics` IPC into the existing ordered `Topics`/`GlobalTopics` arrays in projects.json; the catalog's existing `sort_order` column is surfaced through `ProjectNode.SortOrder` and the frontend sort prefers manual order (pinned → sortOrder → activity fallback). SQL/pagination untouched.

## Issues

Fixes #8194 (phase 1: ordering; grouping planned as a follow-up)

## Verification

- `pnpm typecheck` (tsc --noEmit) — pass
- `pnpm lint:hooks` (eslint src/**/*.{ts,tsx}) — pass
- `pnpm check:css` — pass
- `pnpm test:workspace` — 7 passed, 0 failed
- `go build ./...` (desktop) — pass

## Documentation impact

Documentation-impact: none - no config, CLI, provider, permission, or tool surface changed (new IPC only).

## Cache impact

Cache-impact: none - no prompt, tool schema, or provider request changes.
Cache-guard: not required - changed paths are outside provider-visible cache construction.
System-prompt-review: N/A
