### PR TITLE
refactor(tool): give a tool call an explicit environment

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -83,9 +83,8 @@ type Renderer interface {
 // the agent stays independent of the frontend; a nil asker means no interactive
 // user (headless runs), where `ask` returns a "decide for yourself" result. The
 // interactive frontends wire the controller in as the Asker.
-type Asker interface {
-	Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error)
-}
+// Asker is tool.Asker: the capability lives at the layer tools can import.
+type Asker = tool.Asker
 
 // callContextKey carries the executing tool call's identity into Execute.
 type callContextKey struct{}
@@ -103,14 +102,10 @@ type callContext struct {
 	planMode bool
 }
 
-// withCallContext stamps ctx with the executing call's ID, the agent's sink, and
-// the asker. executeOne sets this before every Execute; `task` reads it (via
-// CallContext) to nest sub-agent events, and `ask` reads the asker to prompt.
-// The plan-mode flag is mirrored onto the leaf planmode key so tools that must
-// not import this package (for example internal/tool/builtin) can still read it.
+// withCallContext is the positional form of installCallEnv, kept for callers
+// that have the four values loose rather than as an env.
 func withCallContext(ctx context.Context, parentID string, sink event.Sink, asker Asker, planMode bool) context.Context {
-	ctx = planmode.WithActive(ctx, planMode)
-	return context.WithValue(ctx, callContextKey{}, callContext{parentID: parentID, sink: sink, asker: asker, planMode: planMode})
+	return installCallEnv(ctx, tool.ExecutionEnv{Call: tool.CallIdentity{ID: parentID}, Sink: sink, Asker: asker, PlanMode: planMode})
 }
 
 // WithToolCallContext stamps ctx as a host-initiated top-level tool call.
@@ -644,19 +639,11 @@ func midTurnSteerMessage(text string) string {
 	return MidTurnSteerPrefix + "\n" + text
 }
 
-// SteerText checks whether content is a mid-turn steer message and, if so,
-// returns the original user text without the wrapper prefix. The returned
-// text preserves the user's exact input — it only strips the prefix and the
-// "\n" separator that midTurnSteerMessage inserts between the prefix and the
-// user text; it does not trim spaces so the history replay matches the live
-// Steer event rendering character-for-character.
-//
-// Steers are persisted through withTurnPreferences, which can prepend
-// transient language blocks (for Chinese text even in auto mode) and append
-// the delivery-runtime marker. Both are transport framing, not steer text:
-// leading blocks are skipped before matching the prefix and a trailing
-// marker is cut from the returned text, so replay recognizes steers
-// regardless of the session's language and profile settings.
+// SteerText returns the user's text from a mid-turn steer message. Only the
+// prefix and its separator are stripped -- spaces are not trimmed, so history
+// replay matches the live Steer event character-for-character.
+// withTurnPreferences may wrap a steer in transient language blocks and the
+// delivery-runtime marker; both are framing, and both are skipped here.
 func SteerText(content string) (string, bool) {
 	s := content
 	for {

--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
 
 // AskTool lets the model put a structured multiple-choice question (or a few) to
@@ -68,7 +69,17 @@ func (*AskTool) Schema() json.RawMessage {
 // and stays available in plan mode (clarifying scope while planning is fine).
 func (*AskTool) ReadOnly() bool { return true }
 
-func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+// Execute is the legacy entry point: it recovers the asker from the context
+// the agent installed. ExecuteEnv is the one that states the dependency.
+func (t *AskTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	_, _, asker, _ := CallContext(ctx)
+	return t.ExecuteEnv(ctx, tool.ExecutionEnv{Asker: asker}, args)
+}
+
+// ExecuteEnv answers with the user's selections, or says plainly that nobody
+// answered. The asker arrives as a field, so a caller that has no user to ask
+// says so by leaving it nil rather than by omitting a context value.
+func (*AskTool) ExecuteEnv(ctx context.Context, env tool.ExecutionEnv, args json.RawMessage) (string, error) {
 	var p struct {
 		Questions []struct {
 			Header      string `json:"header"`
@@ -115,14 +126,13 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 		})
 	}
 
-	_, _, asker, ok := CallContext(ctx)
-	if !ok || asker == nil {
+	if env.Asker == nil {
 		// Headless / no interactive user: don't block an autonomous run, but make
 		// the provenance explicit so the model doesn't treat this as a user choice.
 		return "No interactive user answered. This is a model-assumption fallback, not a user answer. Proceed with your best judgment, state the assumption you made, and prefer the safest reversible option when choices differ in risk.", nil
 	}
 
-	answers, err := asker.Ask(ctx, qs)
+	answers, err := env.Asker.Ask(ctx, qs)
 	if err != nil {
 		return "", fmt.Errorf("ask: %w", err)
 	}

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -26,6 +26,9 @@ type toolCallPlan struct {
 	call          provider.ToolCall
 	tool          tool.Tool
 	canonicalName string
+	// env is the capability set this call executes against, resolved once in
+	// prepareToolExecution so the run stage cannot reach for a different one.
+	env tool.ExecutionEnv
 
 	permName     string
 	permArgs     json.RawMessage
@@ -668,7 +671,8 @@ func (a *Agent) prepareToolExecution(ctx context.Context, plan *toolCallPlan) (t
 			}, true
 		}
 	}
-	cctx := tool.WithContextCompressor(withCallContext(ctx, plan.call.ID, a.svc.sink, a.svc.asker, a.planMode.Load()), a)
+	plan.env = tool.ExecutionEnv{Call: tool.CallIdentity{ID: plan.call.ID}, Sink: a.svc.sink, Asker: a.svc.asker, PlanMode: a.planMode.Load()}
+	cctx := tool.WithContextCompressor(installCallEnv(ctx, plan.env), a)
 	cctx = WithSubagentDepth(cctx, a.subagentDepth)
 	if a.task.ledger != nil {
 		cctx = evidence.WithLedger(cctx, a.task.ledger)
@@ -751,7 +755,6 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 
 	var result string
 	var images []string
-	var err error
 	// A call that was authorized under reader classification carries that
 	// basis into dispatch: the MCP execution layer re-verifies it linearizably
 	// against server authorization and live safety metadata, and refuses to
@@ -764,33 +767,7 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	if a.plannerMCPExecution && isMCPExecutionTarget(runTool, permName) && mcpServerAuthorized(runTool) && !mcpDestructiveHint(runTool) {
 		cctx = tool.WithNonDestructiveMCPExecutionIntent(cctx)
 	}
-	var execution *tool.ShellExecution
-	if de, ok := runTool.(tool.DetailedExecutor); ok {
-		var detailed tool.DetailedResult
-		detailed, err = de.ExecuteDetailed(cctx, runArgs)
-		result, images, execution = detailed.Output, detailed.Images, detailed.Execution
-		// Annotate verification outcome when the host classified this call as a verifier.
-		if execution != nil && plan.verification {
-			switch {
-			case err != nil:
-				execution.Verification = tool.ShellVerificationFailed
-			default:
-				execution.Verification = tool.ShellVerificationPassed
-			}
-		} else if execution != nil && execution.Verification == "" {
-			execution.Verification = tool.ShellVerificationNotVerification
-		}
-		// Sole opaque inline interpreters are allowed outside Delivery but cannot
-		// prove mutation completeness.
-		if execution != nil && evidence.BashCommandMayBeOpaqueMutation(runArgs) &&
-			execution.MutationRisk == tool.ShellMutationMayHaveCompleted {
-			execution.MutationRisk = tool.ShellMutationUnknown
-		}
-	} else if it, ok := runTool.(tool.ImageTool); ok {
-		result, images, err = it.ExecuteWithImages(cctx, runArgs)
-	} else {
-		result, err = runTool.Execute(cctx, runArgs)
-	}
+	execution, err := a.dispatchTool(cctx, plan, runTool, runArgs, &result, &images)
 	// tool.after: extensions rule on the executed result (success or error)
 	// before evidence, hooks, and recovery observation, so every downstream
 	// consumer sees the final (possibly replaced) outcome.

--- a/internal/agent/executionenv.go
+++ b/internal/agent/executionenv.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/planmode"
+	"reasonix/internal/tool"
+)
+
+// installCallEnv adapts env onto a context for tools that still read it from
+// there. It is the one place the legacy keys are written, so migrating a tool
+// to EnvTool is a local change rather than a hunt through call sites.
+func installCallEnv(ctx context.Context, env tool.ExecutionEnv) context.Context {
+	ctx = planmode.WithActive(ctx, env.PlanMode)
+	return context.WithValue(ctx, callContextKey{}, callContext{
+		parentID: env.Call.ID, sink: env.Sink, asker: env.Asker, planMode: env.PlanMode,
+	})
+}
+
+// dispatchTool picks the richest entry point the tool implements. EnvTool is
+// the migration target: it states its host dependencies as a parameter, while
+// the other paths still recover them from cctx.
+func (a *Agent) dispatchTool(cctx context.Context, plan *toolCallPlan, runTool tool.Tool, runArgs json.RawMessage, result *string, images *[]string) (*tool.ShellExecution, error) {
+	var execution *tool.ShellExecution
+	var err error
+	if de, ok := runTool.(tool.DetailedExecutor); ok {
+		var detailed tool.DetailedResult
+		detailed, err = de.ExecuteDetailed(cctx, runArgs)
+		*result, *images, execution = detailed.Output, detailed.Images, detailed.Execution
+		// Annotate verification outcome when the host classified this call as a verifier.
+		if execution != nil && plan.verification {
+			switch {
+			case err != nil:
+				execution.Verification = tool.ShellVerificationFailed
+			default:
+				execution.Verification = tool.ShellVerificationPassed
+			}
+		} else if execution != nil && execution.Verification == "" {
+			execution.Verification = tool.ShellVerificationNotVerification
+		}
+		// Sole opaque inline interpreters are allowed outside Delivery but cannot
+		// prove mutation completeness.
+		if execution != nil && evidence.BashCommandMayBeOpaqueMutation(runArgs) &&
+			execution.MutationRisk == tool.ShellMutationMayHaveCompleted {
+			execution.MutationRisk = tool.ShellMutationUnknown
+		}
+	} else if it, ok := runTool.(tool.ImageTool); ok {
+		*result, *images, err = it.ExecuteWithImages(cctx, runArgs)
+	} else if et, ok := runTool.(tool.EnvTool); ok {
+		*result, err = et.ExecuteEnv(cctx, plan.env, runArgs)
+	} else {
+		*result, err = runTool.Execute(cctx, runArgs)
+	}
+	return execution, err
+}

--- a/internal/agent/executionenv_test.go
+++ b/internal/agent/executionenv_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+type countingAsker struct {
+	asked int
+}
+
+func (a *countingAsker) Ask(context.Context, []event.AskQuestion) ([]event.AskAnswer, error) {
+	a.asked++
+	return []event.AskAnswer{{QuestionID: "q1", Selected: []string{"yes"}}}, nil
+}
+
+const askArgs = `{"questions":[{"question":"ship it?","header":"ship","options":[{"label":"yes"},{"label":"no"}]}]}`
+
+// The point of the parameter is that omitting the capability is visible. A tool
+// reached through ExecuteEnv must use what it was handed and must not fall back
+// to whatever an ambient context happens to carry.
+func TestAskToolUsesTheEnvAskerNotTheContext(t *testing.T) {
+	fromEnv, fromContext := &countingAsker{}, &countingAsker{}
+	ctx := installCallEnv(context.Background(), tool.ExecutionEnv{Asker: fromContext})
+
+	out, err := (&AskTool{}).ExecuteEnv(ctx, tool.ExecutionEnv{Asker: fromEnv}, json.RawMessage(askArgs))
+	if err != nil {
+		t.Fatalf("ExecuteEnv: %v", err)
+	}
+	if fromEnv.asked != 1 {
+		t.Errorf("env asker consulted %d times, want 1", fromEnv.asked)
+	}
+	if fromContext.asked != 0 {
+		t.Error("the context asker was consulted; the parameter must win, or it records nothing")
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Error("no answer rendered")
+	}
+}
+
+// A nil Asker is the headless case and must stay a stated fallback rather than
+// an error, because an autonomous run has no user to answer.
+func TestAskToolWithoutAnAskerSaysSoInsteadOfFailing(t *testing.T) {
+	out, err := (&AskTool{}).ExecuteEnv(context.Background(), tool.ExecutionEnv{}, json.RawMessage(askArgs))
+	if err != nil {
+		t.Fatalf("ExecuteEnv: %v", err)
+	}
+	if !strings.Contains(out, "model-assumption fallback") {
+		t.Errorf("output = %q, want the provenance stated so the model does not read it as a user choice", out)
+	}
+}
+
+// The legacy path has to keep working while tools migrate one at a time, so the
+// context the agent installs still reaches a tool through plain Execute.
+func TestAskToolLegacyExecuteStillReadsTheInstalledContext(t *testing.T) {
+	asker := &countingAsker{}
+	ctx := installCallEnv(context.Background(), tool.ExecutionEnv{Asker: asker})
+
+	if _, err := (&AskTool{}).Execute(ctx, json.RawMessage(askArgs)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if asker.asked != 1 {
+		t.Errorf("installed asker consulted %d times, want 1", asker.asked)
+	}
+}
+
+// installCallEnv is the only place the legacy keys are written. If a second
+// writer appears, a tool can be handed one env and read another.
+func TestInstalledEnvMatchesWhatTheToolLayerWasGiven(t *testing.T) {
+	sink := event.Discard
+	env := tool.ExecutionEnv{
+		Call:     tool.CallIdentity{ID: "call-7"},
+		Sink:     sink,
+		Asker:    &countingAsker{},
+		PlanMode: true,
+	}
+	ctx := installCallEnv(context.Background(), env)
+
+	id, gotSink, gotAsker, ok := CallContext(ctx)
+	if !ok {
+		t.Fatal("CallContext found nothing after installCallEnv")
+	}
+	// event.Sink is not comparable, so identity is checked on what is: a nil
+	// sink here would mean a tool loses the card it should nest under.
+	if id != env.Call.ID || gotAsker != env.Asker || gotSink == nil {
+		t.Errorf("installed call context = (%q, sink!=nil:%t, %v), want it to match the env", id, gotSink != nil, gotAsker)
+	}
+	if !PlanModeFromContext(ctx) {
+		t.Error("plan mode did not survive the install; it travels under a second key for tools that cannot import this package")
+	}
+}

--- a/internal/tool/executionenv.go
+++ b/internal/tool/executionenv.go
@@ -1,0 +1,54 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+
+	"reasonix/internal/event"
+)
+
+// Asker lets a tool put a question to the user. nil in headless runs, where no
+// user is there to answer.
+type Asker interface {
+	Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error)
+}
+
+// CallIdentity names the tool call being executed, so a tool that spawns
+// further work can nest it under the right card.
+type CallIdentity struct {
+	ID string
+}
+
+// ExecutionEnv is the host capability set one tool call runs against. A call
+// site that omits a field here does not compile; a missing context value
+// instead reaches the tool as a zero that reads like a legitimate default —
+// no asker, not in plan mode, no parent to nest under. It lives at this layer
+// because the tools that need it must not import the agent.
+type ExecutionEnv struct {
+	Call     CallIdentity
+	Sink     event.Sink
+	Asker    Asker
+	PlanMode bool
+}
+
+// EnvTool is a Tool that takes its environment explicitly. The registry prefers
+// this method when a tool implements it; every other tool keeps receiving the
+// same values through the context, so tools migrate one at a time instead of
+// on a flag day.
+type EnvTool interface {
+	Tool
+	ExecuteEnv(ctx context.Context, env ExecutionEnv, args json.RawMessage) (string, error)
+}
+
+// Execute runs t with env, preferring the explicit path. install adapts env
+// onto a context for tools that have not migrated; it is supplied by the agent
+// because the legacy context keys are private to it.
+func Execute(ctx context.Context, t Tool, env ExecutionEnv, args json.RawMessage, install func(context.Context, ExecutionEnv) context.Context) (string, error) {
+	if et, ok := t.(EnvTool); ok {
+		return et.ExecuteEnv(ctx, env, args)
+	}
+	if install != nil {
+		ctx = install(ctx, env)
+	}
+	return t.Execute(ctx, args)
+}


### PR DESCRIPTION
`context.Context` carries the agent's capabilities to tools. Counted across
`internal/`: **42 key types, 45 `WithValue` sites, 27 `FromContext` readers**,
against **47 `Tool` implementations in 9 packages**.

Every reader degrades quietly. `PlanModeFromContext` is the shape:

```go
func PlanModeFromContext(ctx context.Context) bool {
	cc, ok := ctx.Value(callContextKey{}).(callContext)
	return ok && cc.planMode
}
```

A path that forgets the injection gets `false` — not an error, a plausible
default. Same for a nil asker, a nil sink, an absent parent call. The compiler
knows nothing about any of it.

## The code already said this was the wrong shape

Two pieces of existing evidence, not an argument from taste:

**`callContext` is already the bundle.** It is a struct of
`{parentID, sink, asker, planMode}` — and it gets stuffed *into* a context
instead of passed. The design pressure was recognised; it just took the
comfortable route.

**Implicit inheritance already leaked.** `withAgentContext` exists to shadow
inherited values "so child agents cannot reach parent Goal, Jobs, or memory
state **accidentally**". Capabilities had crossed an agent boundary by
accident, and the fix was more context plumbing — the same mechanism that
caused it.

## What this adds

`tool.ExecutionEnv`, in `internal/tool` — **not** `internal/agent`, because the
tools that need it must not import the agent. That constraint is load-bearing:
it is why plan mode is currently written under *two* separate context keys, one
of them purely so `internal/tool/builtin` can read it.

```go
type ExecutionEnv struct {
    Call     CallIdentity
    Sink     event.Sink
    Asker    Asker
    PlanMode bool
}

type EnvTool interface {
    Tool
    ExecuteEnv(ctx context.Context, env ExecutionEnv, args json.RawMessage) (string, error)
}
```

`ctx` stays the first parameter and keeps only cancellation, deadline and
tracing. It is deliberately **not** a field: `go vet`'s `lostcancel` and the
`contextcheck` family key on the first-parameter shape, so burying it in a
struct would trade one implicit mechanism for another.

`EnvTool` is opt-in and dispatched exactly the way `ImageTool` and
`DetailedExecutor` already are, so the other ~40 tools are untouched and
migrate one at a time rather than on a flag day.

## Scope

`ask` migrates first — it is the sole consumer of the asker. Its guard test
installs a *different* asker in the context and asserts the parameter wins and
the context one is never consulted, so "migrated but still secretly reading
context" fails.

The env is resolved once into `toolCallPlan` rather than rebuilt at the call
site, because the prepare and run stages already communicate through the plan.

`agent.Asker` becomes an alias for `tool.Asker`, so the capability is defined at
the layer that can express it.

Deliberately **not** in this PR: `Jobs`, `Memory`, `Evidence`, `Workspace`.
Each has a wider consumer set, and the useful order is prove-the-consumers then
move-the-field, not one big struct up front.

## Verification

- `go test` green: `./internal/agent/`, `./internal/tool/...`,
  `./internal/control/`, `./internal/boot/`
- `go vet ./...` clean; golangci-lint 2.12.2, 0 issues repo-wide
- repolint clean with **no baseline widened**. This change added one essay line
  to `agent.go`; it is paid back by bringing `SteerText`'s 13-line declaration
  doc down to the documented 5-line limit. Extracting `dispatchTool` also
  returns `execute_one.go`'s complexity to budget.

Cache-impact: none - no prompt text, tool schema, or provider request field is
touched. Tool schemas are unchanged: `EnvTool` adds a Go method, not a
parameter the model can see.
Cache-guard: go test ./internal/agent/ -run 'TestCacheHitPrefixStable|TestCacheHitClimbsWithoutCompaction|TestAskToolProviderContractStable'
System-prompt-review: yhh - the gate fires on `internal/agent/agent.go` and
`internal/tool/`. The agent diff is the Asker alias and delegating
`withCallContext` to `installCallEnv`; the tool diff is a new file plus a new
optional interface. No prompt string or tool schema is reached.
Documentation-impact: none - `docs/*.md` describes behaviour and configuration.
`EnvTool` is an internal Go interface with no user-visible surface; tool
behaviour and schemas are unchanged.
