### PR TITLE
fix(desktop): reconcile project sessions on registration

### DIFF
--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -45,6 +45,57 @@ func reconcileSessionCatalogForTest(t *testing.T, app *App, path, scope, workspa
 	}
 }
 
+func waitForCatalogSessionPath(t *testing.T, app *App, workspaceRoot, sessionDir, sessionPath string) sessioncatalog.SessionRecord {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last []sessioncatalog.SessionRecord
+	for time.Now().Before(deadline) {
+		catalog := app.sessionCatalog.Load()
+		if catalog == nil {
+			t.Fatal("session catalog is not installed")
+		}
+		page, err := catalog.ListSessions(context.Background(), sessioncatalog.SessionPageRequest{
+			Scope: "project", WorkspaceRoot: workspaceRoot, Directory: sessionDir, Limit: 20,
+		})
+		if err != nil {
+			t.Fatalf("list project sessions: %v", err)
+		}
+		last = page.Items
+		for _, item := range page.Items {
+			if item.Path == sessionPath {
+				return item
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("project session %q did not become visible: %#v", sessionPath, last)
+	return sessioncatalog.SessionRecord{}
+}
+
+func TestRegisterProjectRootReconcilesNewProjectSessionDirectory(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	globalDir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatalf("mkdir global session dir: %v", err)
+	}
+	installSessionCatalogForTest(t, app, globalDir, "global", "")
+
+	root := t.TempDir()
+	sessionDir := desktopSessionDir(root)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir project session dir: %v", err)
+	}
+	sessionPath := writeTopicSession(t, sessionDir, "existing.jsonl", "topic-existing", "Existing topic", root)
+
+	app.registerProjectRoot(root)
+
+	session := waitForCatalogSessionPath(t, app, root, sessionDir, sessionPath)
+	if session.TopicTitle != "Existing topic" {
+		t.Fatalf("session topic title = %q, want Existing topic", session.TopicTitle)
+	}
+}
+
 func TestProjectTreeSnapshotReturnsProjectShellWithoutMigratingSessions(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	root := t.TempDir()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2308,6 +2308,9 @@ func (a *App) syncTabWorkspaceRootSpellings() {
 func (a *App) registerProjectRoot(workspaceRoot string) {
 	_ = addProject(workspaceRoot, "")
 	a.syncTabWorkspaceRootSpellings()
+	if strings.TrimSpace(workspaceRoot) != "" {
+		a.requestSessionCatalogReconcile(desktopSessionDir(workspaceRoot))
+	}
 }
 
 // OpenProjectTab builds a controller scoped to workspaceRoot and opens the


### PR DESCRIPTION
## Summary
- Reconcile a project session directory as soon as a project root is registered.
- Add a regression test covering an existing project session that was not in the catalog before registration.

Fixes #8531

## Root Cause
Opening or registering a new project root only updated the project registry and tab root spellings. The session catalog did not get an immediate reconcile request for `desktopSessionDir(workspaceRoot)`, so existing sessions under that newly registered project stayed invisible until the next periodic catalog pass or another write-triggered reconcile.

## Verification
- `go test -C desktop . -run TestRegisterProjectRootReconcilesNewProjectSessionDirectory -count=1 -v -timeout=20s`
- `go test -C desktop . -run 'TestRegisterProjectRootReconcilesNewProjectSessionDirectory|TestProjectTreeSnapshotReturnsProjectShellWithoutMigratingSessions|TestCompatibilityProjectTreeDoesNotMigrateLegacySession|TestProjectTreeShellSurvivesCatalogRevisionRace|TestTopicMigrationMarkerRescansWhenSessionFileChanges|TestProjectTreeRepairsIndexedGlobalTopicsAfterMigrationMarker' -count=1 -timeout=90s`
- `go test ./internal/sessioncatalog -count=1`
- `go test -C desktop . -run 'Test.*(SessionCatalog|ProjectTree|ProjectTab|Workspace)' -count=1 -timeout=3m`
- `go test -C desktop . -count=1 -timeout=8m`
- `git diff --check`

Documentation-impact: none - this fixes internal desktop session catalog refresh timing without changing user-facing documentation or configuration.

Cache-impact: none - desktop catalog indexing only; no prompt text, provider serialization, model-visible tool schema, memory, or compaction behavior changes.
Cache-guard: N/A - no provider cache-sensitive path changed.
System-prompt-review: N/A

## Notes
Local `.git/hooks/pre-commit` and `pre-push` still run npm scripts from the repository root, but this Go v2 checkout has no root `package.json`. I used `SKIP_SIMPLE_GIT_HOOKS=1` for the local commit/push after running the Go verification above.