### PR TITLE
fix(temp): honor TMPDIR for lock and metrics temp paths

### DIFF
--- a/cmd/e2ebench/swebench_run.go
+++ b/cmd/e2ebench/swebench_run.go
@@ -91,7 +91,7 @@ func runSwebenchInstance(o swebenchOpts, inst swebenchInstance) (result, string)
 		return r, ""
 	}
 
-	metricsPath := "/tmp/reasonix-metrics.json"
+	metricsPath := filepath.Join(os.TempDir(), "reasonix-metrics.json")
 	args := swebenchAgentArgs(metricsPath, o.model, o.profile, o.permission, o.arm, o.maxSteps, swebenchPrompt(inst))
 	agentCmd := append([]string{"exec", "-e", "REASONIX_HOME=/opt/rxhome", container},
 		testbedShell("/usr/local/bin/reasonix "+shellQuoteAll(args))...)

--- a/internal/config/mutate.go
+++ b/internal/config/mutate.go
@@ -293,7 +293,7 @@ func configEditLockRegistryDir() (string, error) {
 		// The OS-wide temporary root is invariant across process-specific TMPDIR
 		// overrides. The per-user directory is verified and forced to mode 0700
 		// before the advisory lock file is opened.
-		return filepath.Join(string(filepath.Separator), "tmp", fmt.Sprintf("reasonix-config-locks-%x", digest[:8])), nil
+		return filepath.Join(os.TempDir(), fmt.Sprintf("reasonix-config-locks-%x", digest[:8])), nil
 	}
 	home := strings.TrimSpace(current.HomeDir)
 	if home == "" {


### PR DESCRIPTION
  ## Summary

  On Android/Termux, `/tmp` is not writable, so `reasonix setup` failed with:


  warning: config migration failed: lock config edits: create lock directory:
  mkdir /tmp/reasonix-config-locks-...: permission denied


  Replace the hardcoded `/tmp` paths with `os.TempDir()` so `$TMPDIR` is honored
  (Termux points it at a writable location). On standard Unix where `TMPDIR` is
  unset, `os.TempDir()` still resolves to `/tmp`, so behavior on Linux/macOS is
  unchanged.

  - `internal/config/mutate.go`: config lock directory
  - `cmd/e2ebench/swebench_run.go`: e2e benchmark metrics path


  ## Verification

  - `gofmt -l internal/config/mutate.go cmd/e2ebench/swebench_run.go` → clean
  - `go build ./internal/config/... ./cmd/e2ebench/...` → OK
  - `reasonix setup` on Termux no longer hits the permission-denied warnings
    (verified with a freshly built binary)

  ## Documentation impact

  Documentation-impact: none - internal temp path implementation only

  ## Cache impact

  Cache-impact: none - no prompt/tool surface changes
  Cache-guard: N/A
  System-prompt-review: N/A