### PR TITLE
fix(desktop): preserve Unicode filenames in commit details / 修复提交详情中文文件名显示

### DIFF
--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -638,17 +638,16 @@ func (a *App) WorkspaceGitCommitDetail(tabID string, hash string, path string) (
 	}
 
 	// Project level: list of files changed
-	cmd := workspaceGit("-C", base, "diff-tree", "--relative", "--no-commit-id", "--name-only", "-r", hash)
+	cmd := workspaceGit("-C", base, "diff-tree", "--relative", "--no-commit-id", "--name-only", "-z", "-r", hash)
 	raw, err := cmd.Output()
 	if err != nil {
 		return GitCommitDetailView{}, err
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
 	var files []string
-	for _, line := range lines {
-		if line != "" {
-			files = append(files, line)
+	for path := range bytes.SplitSeq(raw, []byte{0}) {
+		if len(path) > 0 {
+			files = append(files, string(path))
 		}
 	}
 	return GitCommitDetailView{Files: files}, nil

--- a/desktop/workspace_commit_detail_test.go
+++ b/desktop/workspace_commit_detail_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"testing"
+)
+
+func TestWorkspaceGitCommitDetailPreservesUnicodeFilenames(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+	runGit(t, "config", "core.quotepath", "true")
+
+	if err := os.WriteFile("seed.txt", []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "seed.txt")
+	runGit(t, "commit", "-m", "seed")
+
+	const unicodeFilename = "中文文件名测试.txt"
+	if err := os.WriteFile("plain.txt", []byte("plain\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unicodeFilename, []byte("unicode\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "plain.txt", unicodeFilename)
+	runGit(t, "commit", "-m", "add files")
+
+	detail, err := (&App{}).WorkspaceGitCommitDetail("", gitOutput(t, "rev-parse", "HEAD"), "")
+	if err != nil {
+		t.Fatalf("WorkspaceGitCommitDetail err = %v", err)
+	}
+	want := []string{"plain.txt", unicodeFilename}
+	if !slices.Equal(detail.Files, want) {
+		t.Fatalf("files = %q, want %q", detail.Files, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Read commit filenames from NUL-delimited `git diff-tree` output.
- Preserve raw UTF-8 paths instead of displaying Git's quoted octal representation.
- Add regression coverage using a real Git repository with `core.quotepath=true` and a Chinese filename.

## Issues

Fixes #8242

## Verification

- [x] `cd desktop && go test . -run '^TestWorkspaceGitCommitDetail(PreservesUnicodeFilenames)?$' -count=1`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m ./...`
- [x] `cd desktop && go vet ./...`
- [x] `cd desktop && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m ./...`
- [x] `go run ./tools/repolint`
- [x] `git diff --check`

Full desktop package testing was also attempted. The changed tests pass, but three existing Windows packaging tests require `bash`, which is unavailable in this environment.

## Documentation impact

Documentation-impact: none - This restores the intended display of existing commit-detail filenames without changing configuration or documented workflows.

## Cache impact

Cache-impact: none - The change only affects parsing of local Git filename output in the desktop commit-detail view.

Cache-guard: N/A - A focused integration test creates a real Git repository with `core.quotepath=true` and verifies that a Chinese filename is preserved.

System-prompt-review: N/A