### PR TITLE
feat(acp): report token usage to ACP clients (prompt-result usage + usage_update)

### DIFF
--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -74,10 +74,11 @@ func (t fakeTool) Execute(context.Context, json.RawMessage) (string, error) {
 // e2eFactory builds a real Controller around a real Agent driven by the scripted
 // provider, with the fake tool registered and a transcript dir for persistence.
 type e2eFactory struct {
-	prov       provider.Provider
-	tool       tool.Tool
-	policy     permission.Policy
-	sessionDir string
+	prov          provider.Provider
+	tool          tool.Tool
+	policy        permission.Policy
+	sessionDir    string
+	contextWindow int
 }
 
 func (f *e2eFactory) SessionDir() string { return f.sessionDir }
@@ -86,7 +87,7 @@ func (f *e2eFactory) NewSession(_ context.Context, p SessionParams) (*control.Co
 	reg := tool.NewRegistry()
 	reg.Add(f.tool)
 	executor := agent.New(f.prov, reg, agent.NewSession("you are a test agent"),
-		agent.Options{MaxSteps: 5}, p.Sink)
+		agent.Options{MaxSteps: 5, ContextWindow: f.contextWindow}, p.Sink)
 	return control.New(control.Options{
 		Runner:     executor,
 		Executor:   executor,
@@ -630,5 +631,112 @@ func (t blockingTool) Execute(ctx context.Context, _ json.RawMessage) (string, e
 		return "", ctx.Err()
 	case <-t.release:
 		return "released", nil
+	}
+}
+
+// TestE2EPromptResultCarriesUsage runs a turn whose provider completion reports
+// token usage, and checks the session/prompt result carries the experimental
+// usage field (inputTokens/outputTokens/totalTokens, cached/thought breakdown)
+// that ACP clients like Paseo render as a token counter.
+func TestE2EPromptResultCarriesUsage(t *testing.T) {
+	dir := t.TempDir()
+	prov := &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "hi"},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 5,
+				TotalTokens:      105,
+				CacheHitTokens:   80,
+				CacheMissTokens:  20,
+				ReasoningTokens:  2,
+			}},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	factory := &e2eFactory{
+		prov:          prov,
+		tool:          fakeTool{name: "peek", ro: true, out: "x"},
+		policy:        permission.New("ask", nil, nil, nil),
+		sessionDir:    dir,
+		contextWindow: 200_000,
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	sid := openSession(t, client)
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "hi"}},
+	})
+	notifs, resp := drainPrompt(t, client, promptCh)
+
+	// The usage_update notification is emitted immediately before the prompt
+	// response; drain any trailing notifications that raced the response.
+	time.Sleep(100 * time.Millisecond)
+	for {
+		select {
+		case f := <-client.notifs:
+			notifs = append(notifs, f)
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	var pr SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &pr); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if pr.StopReason != StopEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn", pr.StopReason)
+	}
+	if pr.Usage == nil {
+		t.Fatal("prompt result has no usage field")
+	}
+	if pr.Usage.InputTokens != 100 || pr.Usage.OutputTokens != 5 || pr.Usage.TotalTokens != 105 {
+		t.Errorf("usage = in %d out %d total %d, want 100/5/105",
+			pr.Usage.InputTokens, pr.Usage.OutputTokens, pr.Usage.TotalTokens)
+	}
+	if pr.Usage.CachedReadTokens == nil || *pr.Usage.CachedReadTokens != 80 {
+		t.Errorf("cachedReadTokens = %v, want 80", pr.Usage.CachedReadTokens)
+	}
+	if pr.Usage.ThoughtTokens == nil || *pr.Usage.ThoughtTokens != 2 {
+		t.Errorf("thoughtTokens = %v, want 2", pr.Usage.ThoughtTokens)
+	}
+	if pr.Usage.CachedWriteTokens != nil {
+		t.Errorf("cachedWriteTokens = %v, want omitted", *pr.Usage.CachedWriteTokens)
+	}
+
+	// The turn also ends with the stable ACP usage_update notification carrying
+	// the context window size and current context usage.
+	var sawUsageUpdate bool
+	for _, n := range notifs {
+		if updateKind(t, n) != "usage_update" {
+			continue
+		}
+		sawUsageUpdate = true
+		var p struct {
+			Update struct {
+				Used int `json:"used"`
+				Size int `json:"size"`
+			} `json:"update"`
+		}
+		if err := json.Unmarshal(n.Params, &p); err != nil {
+			t.Fatalf("usage_update params: %v", err)
+		}
+		if p.Update.Size != 200_000 {
+			t.Errorf("usage_update size = %d, want 200000", p.Update.Size)
+		}
+		if p.Update.Used < 0 {
+			t.Errorf("usage_update used = %d, want >= 0", p.Update.Used)
+		}
+	}
+	if !sawUsageUpdate {
+		var got []string
+		for _, n := range notifs {
+			got = append(got, updateKind(t, n))
+		}
+		t.Errorf("no usage_update notification in session/update stream (got %v)", got)
 	}
 }

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -567,11 +567,49 @@ const (
 	StopError     StopReason = "error"
 )
 
+// SessionPromptUsage is the optional per-turn token usage attached to the
+// session/prompt result. It mirrors the ACP SDK's experimental Usage shape
+// (agentclientprotocol.com) — required inputTokens/outputTokens/totalTokens
+// plus optional cached/thought breakdowns — so ACP clients such as Paseo can
+// render a token counter. Omitted (nil) when the turn consumed no tokens.
+type SessionPromptUsage struct {
+	InputTokens       int  `json:"inputTokens"`
+	OutputTokens      int  `json:"outputTokens"`
+	TotalTokens       int  `json:"totalTokens"`
+	CachedReadTokens  *int `json:"cachedReadTokens,omitempty"`
+	CachedWriteTokens *int `json:"cachedWriteTokens,omitempty"`
+	ThoughtTokens     *int `json:"thoughtTokens,omitempty"`
+}
+
+// usageFromReasonix maps a finished turn's ReasonixUsage to the ACP
+// session/prompt usage field. Returns nil when the turn reported no tokens.
+func usageFromReasonix(u ReasonixUsage) *SessionPromptUsage {
+	if u.PromptTokens == 0 && u.CompletionTokens == 0 {
+		return nil
+	}
+	usage := &SessionPromptUsage{
+		InputTokens:  u.PromptTokens,
+		OutputTokens: u.CompletionTokens,
+		TotalTokens:  u.PromptTokens + u.CompletionTokens,
+	}
+	if u.CacheHitTokens > 0 {
+		cached := u.CacheHitTokens
+		usage.CachedReadTokens = &cached
+	}
+	if u.ReasoningTokens > 0 {
+		thought := u.ReasoningTokens
+		usage.ThoughtTokens = &thought
+	}
+	return usage
+}
+
 // SessionPromptResult ends a session/prompt. TranscriptPath is reserved for a
-// future on-disk transcript pointer; omitted (null) for now.
+// future on-disk transcript pointer; omitted (null) for now. Usage carries the
+// experimental per-turn token accounting (nil when the turn used no tokens).
 type SessionPromptResult struct {
-	StopReason     StopReason `json:"stopReason"`
-	TranscriptPath *string    `json:"transcriptPath,omitempty"`
+	StopReason     StopReason          `json:"stopReason"`
+	TranscriptPath *string             `json:"transcriptPath,omitempty"`
+	Usage          *SessionPromptUsage `json:"usage,omitempty"`
 }
 
 // session/update (agent → client notifications)
@@ -586,6 +624,23 @@ type SessionPromptResult struct {
 type SessionUpdateParams struct {
 	SessionID string `json:"sessionId"`
 	Update    any    `json:"update"`
+}
+
+// UsageUpdate is the stable ACP v1 "Session Context Size and Cost" update
+// (agentclientprotocol.com/protocol/v1/prompt-turn#session-usage-updates):
+// tokens currently in context, the context window size, and optional
+// cumulative session cost. Clients render it as a context/token gauge.
+type UsageUpdate struct {
+	SessionUpdate string   `json:"sessionUpdate"`
+	Used          int      `json:"used"`
+	Size          int      `json:"size"`
+	Cost          *ACPCost `json:"cost,omitempty"`
+}
+
+// ACPCost is the optional cumulative session cost in a UsageUpdate.
+type ACPCost struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
 }
 
 // messageChunk is agent_message_chunk / agent_thought_chunk.

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -340,3 +340,37 @@ func TestAcpSessionSetCancelNil(t *testing.T) {
 	sess.finish()
 	sess.abort() // should not panic
 }
+
+func TestUsageFromReasonix(t *testing.T) {
+	if got := usageFromReasonix(ReasonixUsage{}); got != nil {
+		t.Fatalf("zero usage should map to nil, got %+v", got)
+	}
+	u := usageFromReasonix(ReasonixUsage{
+		PromptTokens:     100,
+		CompletionTokens: 5,
+		ReasoningTokens:  2,
+		CacheHitTokens:   80,
+		CacheMissTokens:  20,
+	})
+	if u == nil {
+		t.Fatal("non-zero usage mapped to nil")
+	}
+	if u.InputTokens != 100 || u.OutputTokens != 5 || u.TotalTokens != 105 {
+		t.Errorf("got in=%d out=%d total=%d, want 100/5/105", u.InputTokens, u.OutputTokens, u.TotalTokens)
+	}
+	if u.CachedReadTokens == nil || *u.CachedReadTokens != 80 {
+		t.Errorf("cachedReadTokens = %v, want 80", u.CachedReadTokens)
+	}
+	if u.ThoughtTokens == nil || *u.ThoughtTokens != 2 {
+		t.Errorf("thoughtTokens = %v, want 2", u.ThoughtTokens)
+	}
+	if u.CachedWriteTokens != nil {
+		t.Errorf("cachedWriteTokens = %v, want omitted", *u.CachedWriteTokens)
+	}
+
+	// Breakdowns absent when the turn had none (only plain input/output).
+	u2 := usageFromReasonix(ReasonixUsage{PromptTokens: 10, CompletionTokens: 3})
+	if u2 == nil || u2.CachedReadTokens != nil || u2.ThoughtTokens != nil || u2.CachedWriteTokens != nil {
+		t.Errorf("breakdowns should be omitted, got %+v", u2)
+	}
+}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1182,10 +1182,32 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		}
 	}
 	res := SessionPromptResult{StopReason: stop}
+	res.Usage = usageFromReasonix(sess.status.snapshot().turnUsage)
+	s.publishUsageUpdate(sess, p.SessionID)
 	if sess.transcript != "" {
 		res.TranscriptPath = &sess.transcript
 	}
 	return res, nil
+}
+
+// publishUsageUpdate sends the stable ACP usage_update notification for the
+// just-finished turn: current context usage and window size from the
+// controller's context snapshot, plus cumulative estimated cost from session
+// telemetry when known. Skipped when the controller exposes no context window.
+func (s *service) publishUsageUpdate(sess *acpSession, sessionID string) {
+	snap, ok := sess.currentCtrl().(interface{ ContextSnapshot() (int, int) })
+	if !ok {
+		return
+	}
+	used, size := snap.ContextSnapshot()
+	if size <= 0 {
+		return
+	}
+	update := UsageUpdate{SessionUpdate: "usage_update", Used: used, Size: size}
+	if u := sess.status.snapshot().cumulative; u.EstimatedCost != nil && u.Currency != nil {
+		update.Cost = &ACPCost{Amount: *u.EstimatedCost, Currency: *u.Currency}
+	}
+	_ = s.conn.Notify("session/update", SessionUpdateParams{SessionID: sessionID, Update: update})
 }
 
 // sessionSteer durably persists guidance then attempts mid-turn admission.


### PR DESCRIPTION
### Problem
When Reasonix runs as an ACP agent (e.g. through Paseo's ACP provider catalog, getpaseo/paseo#3242), clients cannot render a token/cost counter: the ACP server never sends any usage data — neither the experimental `usage` field on the `session/prompt` result nor the stable `usage_update` session notification, even though per-turn and cumulative accounting exists internally (`statusTelemetry`).

See #8635.

### Changes
- `internal/acp/protocol.go`: `SessionPromptUsage` mirroring the ACP SDK's experimental `Usage` shape (`inputTokens`/`outputTokens`/`totalTokens` + optional `cachedReadTokens`/`cachedWriteTokens`/`thoughtTokens`), attached to `SessionPromptResult`; `UsageUpdate`/`ACPCost` types for the stable `usage_update` variant.
- `internal/acp/service.go`: `session/prompt` result now carries per-turn usage (nil when the turn used no tokens); each finished turn also emits `session/update` → `usage_update` (`used` = current context tokens from `Controller.ContextSnapshot()`, `size` = context window, `cost` = cumulative estimated cost when known).
- Tests: e2e turn asserts both the prompt-result `usage` and the `usage_update` notification; unit test covers the mapping.

### Verification
- `go test ./internal/acp/` green; gofmt/vet clean.
- Live smoke over stdio with a real provider: prompt result includes `usage: {inputTokens: 5325, outputTokens: 12, totalTokens: 5337, cachedReadTokens: 256, thoughtTokens: 10}` and the stream carries `usage_update {used: 5330, size: 1000000}`.
- Confirmed in Paseo's web UI: the context-window token meter now renders (before: no usage at all).

Closes #8635