### PR TITLE
fix(desktop): keep user bubbles inside chat when workspace is open / 修复打开工作区后用户气泡被裁切

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -81,6 +81,60 @@ try {
   assert(box != null, "bench exposes the Virtuoso transcript viewport");
   assert(await page.locator('[data-virtuoso-scroller="true"]').count() === 1, "Transcript is backed by React Virtuoso");
 
+  // Stay on the tail. Opening the workspace dock must not crop right-aligned
+  // user bubbles — that is a width/padding bug, not the scroll-up overlap.
+  const measureDockCrop = () => page.evaluate(() => {
+    const layout = document.querySelector(".layout");
+    const chat = document.querySelector(".chat-pane");
+    const dock = document.querySelector(".workbench-dock");
+    const scroller = document.querySelector(".transcript");
+    const bubbles = [...document.querySelectorAll(".msg--user .msg__body")];
+    const bubble = bubbles.at(-1);
+    if (!(chat instanceof HTMLElement) || !(bubble instanceof HTMLElement) || !(scroller instanceof HTMLElement)) {
+      return { ok: false };
+    }
+    const chatBox = chat.getBoundingClientRect();
+    const bubbleBox = bubble.getBoundingClientRect();
+    const dockBox = dock instanceof HTMLElement ? dock.getBoundingClientRect() : null;
+    return {
+      ok: true,
+      workspaceOpen: Boolean(layout?.classList.contains("layout--workspace-open")),
+      overflowChatRight: +(bubbleBox.right - chatBox.right).toFixed(2),
+      overflowDock: dockBox ? +(bubbleBox.right - dockBox.left).toFixed(2) : null,
+      fromBottom: +(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight).toFixed(2),
+    };
+  });
+  const dockOpen = await measureDockCrop();
+  assert(dockOpen.ok, "tail-follow dock check can see the chat and a user bubble");
+  assert(dockOpen.workspaceOpen === true, "bench starts with the workspace dock open");
+  assert(dockOpen.fromBottom <= 1, `dock-open check stays on the tail without scrolling up (${dockOpen.fromBottom})`);
+  assert(dockOpen.overflowChatRight <= 1, `user bubble stays inside the chat column with the dock open (${dockOpen.overflowChatRight})`);
+  assert(
+    dockOpen.overflowDock == null || dockOpen.overflowDock <= 1,
+    `user bubble does not extend into the workspace dock (${dockOpen.overflowDock})`,
+  );
+
+  const collapse = page.getByRole("button", { name: /Collapse workspace|收起工作区/ });
+  if (await collapse.count()) {
+    await collapse.click();
+    await page.waitForFunction(() => !document.querySelector(".layout")?.classList.contains("layout--workspace-open"));
+    const dockClosed = await measureDockCrop();
+    assert(dockClosed.ok && dockClosed.workspaceOpen === false, "workspace toggle collapses the dock");
+    assert(dockClosed.fromBottom <= 1, `collapsing the dock does not require scrolling up (${dockClosed.fromBottom})`);
+    assert(dockClosed.overflowChatRight <= 1, `user bubble stays inside the chat column with the dock closed (${dockClosed.overflowChatRight})`);
+    const expand = page.getByRole("button", { name: /Expand workspace|展开工作区/ });
+    await expand.click();
+    await page.waitForFunction(() => Boolean(document.querySelector(".layout")?.classList.contains("layout--workspace-open")));
+    const dockReopen = await measureDockCrop();
+    assert(dockReopen.ok && dockReopen.workspaceOpen === true, "workspace toggle reopens the dock");
+    assert(dockReopen.fromBottom <= 1, `reopening the dock stays on the tail (${dockReopen.fromBottom})`);
+    assert(dockReopen.overflowChatRight <= 1, `user bubble stays inside the chat column after reopening the dock (${dockReopen.overflowChatRight})`);
+    assert(
+      dockReopen.overflowDock == null || dockReopen.overflowDock <= 1,
+      `user bubble still does not enter the dock after reopen (${dockReopen.overflowDock})`,
+    );
+  }
+
   // Start away from either edge and record a visible stable row. Growing an
   // already-mounted row above it reproduces async Markdown/tool hydration.
   const beforeGrowth = await transcript.evaluate((element) => {

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -114,20 +114,31 @@ try {
     `user bubble does not extend into the workspace dock (${dockOpen.overflowDock})`,
   );
 
+  // Width changes remasure Virtuoso and can leave a few pixels off the
+  // physical bottom. Keep the crop assertions tight; only the post-resize
+  // stick-to-tail check gets this slack (CI saw 7px after collapse).
+  const tailAfterResizePx = 16;
+  const waitNearTailAfterResize = () => page.waitForFunction((limit) => {
+    const scroller = document.querySelector(".transcript");
+    return Boolean(scroller && scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= limit);
+  }, tailAfterResizePx);
+
   const collapse = page.getByRole("button", { name: /Collapse workspace|收起工作区/ });
   if (await collapse.count()) {
     await collapse.click();
     await page.waitForFunction(() => !document.querySelector(".layout")?.classList.contains("layout--workspace-open"));
+    await waitNearTailAfterResize();
     const dockClosed = await measureDockCrop();
     assert(dockClosed.ok && dockClosed.workspaceOpen === false, "workspace toggle collapses the dock");
-    assert(dockClosed.fromBottom <= 1, `collapsing the dock does not require scrolling up (${dockClosed.fromBottom})`);
+    assert(dockClosed.fromBottom <= tailAfterResizePx, `collapsing the dock does not require scrolling up (${dockClosed.fromBottom})`);
     assert(dockClosed.overflowChatRight <= 1, `user bubble stays inside the chat column with the dock closed (${dockClosed.overflowChatRight})`);
     const expand = page.getByRole("button", { name: /Expand workspace|展开工作区/ });
     await expand.click();
     await page.waitForFunction(() => Boolean(document.querySelector(".layout")?.classList.contains("layout--workspace-open")));
+    await waitNearTailAfterResize();
     const dockReopen = await measureDockCrop();
     assert(dockReopen.ok && dockReopen.workspaceOpen === true, "workspace toggle reopens the dock");
-    assert(dockReopen.fromBottom <= 1, `reopening the dock stays on the tail (${dockReopen.fromBottom})`);
+    assert(dockReopen.fromBottom <= tailAfterResizePx, `reopening the dock stays on the tail (${dockReopen.fromBottom})`);
     assert(dockReopen.overflowChatRight <= 1, `user bubble stays inside the chat column after reopening the dock (${dockReopen.overflowChatRight})`);
     assert(
       dockReopen.overflowDock == null || dockReopen.overflowDock <= 1,

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -113,6 +113,36 @@ ok(
   "virtual transcript cards stay measurable after the markdown override",
 );
 
+function paddingSides(value: string) {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length === 1) return { right: parts[0], left: parts[0] };
+  if (parts.length === 2 || parts.length === 3) return { right: parts[1], left: parts[1] };
+  return { right: parts[1], left: parts[3] };
+}
+function isZeroPad(value: string | undefined) {
+  return value === undefined || value === "0" || value === "0px";
+}
+for (const block of matchingBlocks(".transcript")) {
+  const shorthand = /(?:^|;)\s*padding\s*:\s*([^;]+)/.exec(block);
+  if (shorthand) {
+    const sides = paddingSides(shorthand[1]);
+    ok(
+      isZeroPad(sides.left) && isZeroPad(sides.right),
+      `Virtuoso scroller padding stays vertical-only (${shorthand[1].trim()})`,
+    );
+  }
+  const padLeft = /(?:^|;)\s*padding-left\s*:\s*([^;]+)/.exec(block);
+  const padRight = /(?:^|;)\s*padding-right\s*:\s*([^;]+)/.exec(block);
+  ok(isZeroPad(padLeft?.[1].trim()), "Virtuoso scroller does not set padding-left");
+  ok(isZeroPad(padRight?.[1].trim()), "Virtuoso scroller does not set padding-right");
+}
+ok(hasDeclaration(".transcript", "--transcript-inline-pad", "32px"), "default transcript inline inset is 32px");
+ok(hasDeclaration(".transcript", "--transcript-inline-pad", "16px"), "narrow viewports tighten the transcript inline inset");
+eq(finalDeclaration(".transcript__row", "padding-left"), "var(--transcript-inline-pad, 32px)", "virtual rows own the left inset");
+eq(finalDeclaration(".transcript__row", "padding-right"), "var(--transcript-inline-pad, 32px)", "virtual rows own the right inset");
+eq(finalDeclaration(".transcript__header", "padding-left"), "var(--transcript-inline-pad, 32px)", "load-older header uses the same inline inset");
+eq(finalDeclaration(".transcript--empty", "padding"), "16px 32px", "empty transcript keeps its own horizontal inset");
+
 {
   const stylesheet = readFileSync(resolve(testDir, "../styles.css"), "utf8");
   const dom = new JSDOM(

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -99,6 +99,19 @@ eq(
 eq(finalDeclaration(".transcript--empty", "overflow-y"), "auto", "empty transcript can scroll instead of clipping");
 eq(finalDeclaration(".welcome", "overflow"), "visible", "welcome empty state is not clipped by its own box");
 ok(
+  /\.md\s*>\s*:where\([^)]*p[^)]*ul[^)]*ol[^)]*\)\s*\{[^}]*content-visibility:\s*auto;[^}]*contain-intrinsic-size:\s*auto 72px;/.test(styles),
+  "non-transcript markdown still culls offscreen blocks with a 72px placeholder",
+);
+ok(
+  /\.transcript__row\s+\.md\s*>\s*\*\s*(?:,[^{]*)?\{[^}]*content-visibility:\s*visible;[^}]*contain-intrinsic-size:\s*none;/.test(styles),
+  "virtual transcript rows do not measure markdown through 72px placeholders",
+);
+ok(
+  hasDeclaration(".transcript__row .msg", "content-visibility", "visible") &&
+    hasDeclaration(".transcript__row .turn-collapse", "content-visibility", "visible"),
+  "virtual transcript cards stay measurable after the markdown override",
+);
+ok(
   hasDeclaration(".transcript--empty > .welcome", "margin-block", "auto"),
   "empty-state auto margins apply only to the welcome content",
 );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3458,7 +3458,8 @@ a[href] {
 .transcript__row .tool,
 .transcript__row .process-card,
 .transcript__row .readonly-batch,
-.transcript__row .tool-group {
+.transcript__row .tool-group,
+.transcript__row .md > * {
   content-visibility: visible;
   contain-intrinsic-size: none;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3372,13 +3372,18 @@ a[href] {
   }
 }
 .transcript {
+  /* Virtuoso sizes rows from the scroller clientWidth (padding included) but
+     lays them out in the content box. Horizontal padding here therefore makes
+     right-aligned bubbles extend under the workspace dock. Keep only vertical
+     inset on the scroller; rows own --transcript-inline-pad. */
+  --transcript-inline-pad: 32px;
   position: relative;
   height: 100%;
   overflow-y: auto;
   overflow-y: overlay;
   overflow-x: hidden;
   scrollbar-gutter: stable both-edges;
-  padding: 24px 32px 32px;
+  padding: 24px 0 32px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
@@ -3415,11 +3420,17 @@ a[href] {
 .transcript__row {
   position: relative;
   display: flow-root;
+  box-sizing: border-box;
   width: 100%;
+  padding-left: var(--transcript-inline-pad, 32px);
+  padding-right: var(--transcript-inline-pad, 32px);
 }
 .transcript__header {
   display: flow-root;
+  box-sizing: border-box;
   width: 100%;
+  padding-left: var(--transcript-inline-pad, 32px);
+  padding-right: var(--transcript-inline-pad, 32px);
 }
 .transcript__header > * {
   max-width: var(--maxw);
@@ -15130,7 +15141,8 @@ body > .mermaid-diagram--fullscreen {
   font-size: var(--font-control);
 }
 .history-preview__body .transcript {
-  padding: 14px 14px 18px;
+  --transcript-inline-pad: 14px;
+  padding: 14px 0 18px;
 }
 .history-preview__body .transcript > * {
   max-width: none;
@@ -21363,7 +21375,8 @@ body > .mermaid-diagram--fullscreen {
     display: flex;
   }
   .transcript {
-    padding: 18px 16px 28px;
+    --transcript-inline-pad: 16px;
+    padding: 18px 0 28px;
   }
   .jump-bar {
     display: none;
@@ -26720,7 +26733,7 @@ body > .mermaid-diagram--fullscreen {
 }
 
 .transcript {
-  padding: 24px 32px 28px;
+  padding: 24px 0 28px;
 }
 
 .transcript > * {
@@ -27999,7 +28012,7 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .transcript {
-  padding: 24px 32px 28px;
+  padding: 24px 0 28px;
 }
 
 :root[data-theme-style] .transcript--empty {
@@ -28606,7 +28619,8 @@ body > .mermaid-diagram--fullscreen {
 }
 
 :root[data-theme-style] .history-preview__body .transcript {
-  padding: 14px;
+  --transcript-inline-pad: 14px;
+  padding: 14px 0;
 }
 
 :root[data-theme-style] .settings-center__nav {


### PR DESCRIPTION
## Summary

Opening the right workspace dock cropped right-aligned user bubbles, especially short image turns. The same turn looked normal after collapsing the dock. This is separate from the scroll-up stacked-text bug already fixed in #8659.

## Root cause

The Virtuoso scroller (`.transcript`) used 32px horizontal padding. Virtuoso sizes rows from the scroller `clientWidth`, which includes that padding, but lays the list out in the content box after `padding-left`. Rows therefore extended 32px past the chat column. `overflow-x: hidden` clipped them under the dock.

## Fix

Keep only vertical padding on the scroller. Move the inline inset onto `.transcript__row` and `.transcript__header` via `--transcript-inline-pad` so row width matches the visible chat column after padding.

The earlier `content-visibility` override from this branch is already on `main-v2` via #8659. This update merges that base and adds the real dock-open crop fix.

## Verification

- `tsx src/__tests__/typography-overflow-contract.test.ts`
- `node scripts/check-css-syntax.mjs src/styles.css`
- Playwright mock bench: stay at the tail, open only the right dock, assert the last user bubble stays inside `.chat-pane` and does not enter `.workbench-dock`

Documentation-impact: none - layout measurement only; existing docs do not describe this dock/transcript inset
