### PR TITLE
fix(desktop): stop short-chat ghost bubble and empty band / 修复短对话幽灵气泡与中间空带

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
@@ -248,5 +248,31 @@ function firstTextNode(root: Node): Text | null {
   }
 }
 
+// ── Short transcripts must not clone the first user bubble at the top ────────
+// Virtuoso alignToBottom uses margin-top:auto to pin short lists to the
+// composer. Combined with firstItemIndex it also paints a second copy of the
+// first user row at the scroller top, leaving a large empty band in between.
+{
+  const harness = await createTranscriptHarness({ viewportHeight: 600, rowHeight: 80 });
+  try {
+    await harness.render(
+      [
+        { kind: "user", id: "u-short", text: "你好" },
+        { kind: "assistant", id: "a-short", text: "hello", reasoning: "", streaming: false },
+      ],
+      { running: false },
+    );
+    await harness.settle();
+    const users = harness.container.querySelectorAll(".msg--user");
+    ok(users.length === 1, `a one-turn transcript mounts the user bubble once (got ${users.length})`);
+    const list = harness.container.querySelector<HTMLElement>('[data-testid="virtuoso-item-list"]');
+    ok(list != null, "short transcript mounts the Virtuoso item list");
+    ok(list?.style.marginTop !== "auto", `short content is not bottom-shifted (marginTop=${JSON.stringify(list?.style.marginTop ?? null)})`);
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -721,7 +721,9 @@ export function Transcript({
             components={hasOlderHistory ? TRANSCRIPT_VIRTUOSO_COMPONENTS_WITH_HEADER : TRANSCRIPT_VIRTUOSO_COMPONENTS}
             computeItemKey={(_index, row) => `${tabId ?? ""}:${String(row.key)}`}
             firstItemIndex={firstItemIndex}
-            alignToBottom
+            // Do not set alignToBottom: Virtuoso's margin-top:auto plus
+            // firstItemIndex paints a ghost first-user bubble and empty band
+            // in short chats. Tail pin stays followOutput + scrollToBottom.
             followOutput={(atBottom) => atBottom ? "auto" : false}
             atBottomThreshold={TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX}
             atBottomStateChange={atBottomStateChange}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,7 +4,7 @@
     "commented-code": 0,
     "complexity": 2109,
     "essay": 4001,
-    "file-size": 108396,
+    "file-size": 108398,
     "function-size": 8934,
     "layering": 1,
     "marker": 0,
@@ -158,7 +158,7 @@
       "file-size": 158
     },
     "desktop/frontend/src/components/Transcript.tsx": {
-      "file-size": 278
+      "file-size": 280
     },
     "desktop/frontend/src/components/UsageStatsPanel.tsx": {
       "file-size": 276


### PR DESCRIPTION
## Summary

- Follow-up to #8659. That PR stopped remounted Markdown from being measured at the 72px `content-visibility` placeholder, then restored Virtuoso `alignToBottom` so short chats sat next to the composer.
- `alignToBottom` is the remaining bug in the screenshot: a one-turn chat shows two copies of the first user bubble (one at the scroller top without a timestamp, one above the composer) with a large empty band between them.
- Remove `alignToBottom`. Virtuoso implements it as `margin-top: auto` on the item list; combined with `firstItemIndex` that bottom-shifts the real turn and paints a ghost first-user row at the scroller top.
- Short transcripts now start from the top of the pane. Long transcripts still pin to the tail via `followOutput` and `scrollToBottom`. The #8659 measurement override is unchanged.
- Add a short-transcript regression: one user bubble, and the Virtuoso list must not use `margin-top: auto`.

## Issues

No linked issue. Reported after #8659 against current `main-v2`: a short chat shows a cloned first user bubble and a large empty band above the real turn.

Related: #8492 introduced `alignToBottom`. #8660 is a separate workspace-open CSS overlap and does not touch this path.

## Verification

- `pnpm exec tsx src/__tests__/transcript-virtualization.test.tsx`
- `pnpm test:transcript`
- `pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts` (keeps the #8659 row-measurement contract)
- `go run ./tools/repolint`

## Repolint

`desktop/frontend/src/components/Transcript.tsx` was already 1078 lines (278 over the 800-line ceiling). This PR is a net +2: drop the `alignToBottom` prop and add a three-line comment so it is not restored. File-size overage 278 -> 280; repo `file-size` total 108396 -> 108398. No other baseline entries.

## Documentation impact

Documentation-impact: none - this restores a single copy of each short-chat turn. No user-facing control, setting, or documented contract changed, so `docs/*.md` stay correct.

## Cache impact

Cache-impact: none - desktop frontend Virtuoso layout only; no prompt, provider serialization, tools, memory, or compaction changes.
Cache-guard: N/A - no cache-sensitive path changed.
