### PR TITLE
fix(desktop): restore thinking transcript after session switch / 修复思考中切走再切回变成欢迎页

### DIFF
--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -1,0 +1,63 @@
+// Run: tsx src/__tests__/hydrate-history-apply.test.ts
+
+import {
+  hasCachedLiveTurn,
+  sameSessionPlaceholderItems,
+  shouldApplyHydratedHistory,
+} from "../lib/hydrateHistoryApply";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nhydrate history apply");
+
+ok(!shouldApplyHydratedHistory(true, true, false, { items: [] }), "skipHistory blocks apply");
+ok(!shouldApplyHydratedHistory(false, false, false, { items: [] }), "missing projection blocks apply");
+ok(shouldApplyHydratedHistory(false, true, false, { items: [] }), "idle empty surface applies history");
+ok(
+  shouldApplyHydratedHistory(false, true, true, { running: true, items: [] }),
+  "running empty surface applies history",
+);
+ok(
+  !shouldApplyHydratedHistory(false, true, true, {
+    running: true,
+    items: [{ kind: "user" }],
+  }),
+  "running visible transcript is not replaced",
+);
+ok(
+  !shouldApplyHydratedHistory(false, true, true, {
+    running: true,
+    live: { text: "partial" },
+    items: [],
+  }),
+  "running live stream without items is not replaced",
+);
+ok(
+  hasCachedLiveTurn({
+    running: true,
+    items: [{ kind: "assistant", streaming: true }],
+  }),
+  "streaming assistant counts as a cached live turn",
+);
+ok(
+  sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "b.jsonl" }, items: [{ kind: "user" }] }) === undefined,
+  "foreign session items are not placeholders",
+);
+ok(
+  (sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "a.jsonl" }, items: [{ kind: "user" }] }) ?? []).length === 1,
+  "same-session items stay placeholders",
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/topic-activation.test.tsx
+++ b/desktop/frontend/src/__tests__/topic-activation.test.tsx
@@ -134,8 +134,9 @@ const checkpoints: CheckpointMeta[] = [];
 const tabA = tabMeta("tab-a", { active: true });
 const tabB = tabMeta("tab-b");
 const tabC = tabMeta("tab-c");
+const tabR = tabMeta("tab-r", { running: true, cancellable: true });
 let backendActiveId = "tab-a";
-const tabsById = new Map([tabA, tabB, tabC].map((tab) => [tab.id, tab]));
+const tabsById = new Map([tabA, tabB, tabC, tabR].map((tab) => [tab.id, tab]));
 const eventHandlers: Array<(e: WireEvent) => void> = [];
 const readyHandlers: Array<(tabId?: string) => void> = [];
 const topicActivationHandlers: Array<(e: TopicActivationEvent) => void> = [];
@@ -151,6 +152,7 @@ function emitActivation(event: TopicActivationEvent): void {
 }
 
 function historyFor(tabID: string): HistoryMessage[] {
+  if (tabID === "tab-r") return [{ role: "user", content: "帮我查询，现在我链接的 deep" }];
   return [{ role: "user", content: `history ${tabID}` }];
 }
 
@@ -296,6 +298,55 @@ await act(async () => {
   await flushPromises();
 });
 eq(controller?.state.meta?.gitBranch, "feature/x", "tab:meta for a different session binding is discarded");
+
+// ── switch away from a thinking session and back: keep its transcript ──────
+await act(async () => {
+  await controller?.activateTopic("project", tabR.workspaceRoot, tabR.topicId ?? "");
+  await flushPromises();
+});
+await act(async () => {
+  emitActivation({ requestId: requestIdByTab.get("tab-r") ?? "", tabId: "tab-r", phase: "ready" });
+  await flushPromises();
+});
+await waitFor("running session hydrates on first open", () =>
+  controller?.activeTabId === "tab-r" &&
+  (controller.state.items.some((item) => item.kind === "user" && item.text === "帮我查询，现在我链接的 deep") ?? false),
+);
+eq(controller?.state.running, true, "reattached thinking session stays marked running");
+eq(controller?.state.hydrating, false, "running-session hydrate settles instead of leaving Welcome");
+
+await act(async () => {
+  await controller?.activateTopic("project", tabB.workspaceRoot, tabB.topicId ?? "");
+  await flushPromises();
+});
+await act(async () => {
+  emitActivation({ requestId: requestIdByTab.get("tab-b") ?? "", tabId: "tab-b", phase: "ready" });
+  await flushPromises();
+});
+await waitFor("idle session replaces the thinking surface", () => hasHistory("tab-b") && controller?.state.hydrating === false);
+
+await act(async () => {
+  await controller?.activateTopic("project", tabR.workspaceRoot, tabR.topicId ?? "");
+  await flushPromises();
+});
+eq(controller?.activeTabId, "tab-r", "switch-back selects the thinking session");
+eq(
+  controller?.state.hydratePlaceholderItems?.some((item) => item.kind === "user" && item.text === "history tab-b") ?? false,
+  false,
+  "switch-back does not present the other session as a hydration placeholder",
+);
+await act(async () => {
+  emitActivation({ requestId: requestIdByTab.get("tab-r") ?? "", tabId: "tab-r", phase: "ready" });
+  await flushPromises();
+});
+await waitFor("switch-back restores the thinking transcript", () =>
+  controller?.activeTabId === "tab-r" &&
+  controller.state.hydrating === false &&
+  (controller.state.items.some((item) => item.kind === "user" && item.text === "帮我查询，现在我链接的 deep") ?? false),
+);
+eq(controller?.state.running, true, "switch-back keeps the composer in the live turn");
+eq(controller?.state.items.some((item) => item.kind === "user" && item.text === "history tab-b") ?? false, false, "switch-back does not keep the other session as the visible transcript");
+eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "switch-back clears the foreign placeholder after live history lands");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -1,0 +1,41 @@
+/** Live-turn markers that a lagging history snapshot must not replace. */
+export type HydrateLiveState = {
+  running?: boolean;
+  turnActive?: boolean;
+  live?: unknown;
+  currentAssistant?: unknown;
+  pendingUser?: unknown;
+  items: ReadonlyArray<{ kind: string; streaming?: boolean; status?: string }>;
+};
+
+export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean {
+  if (!state?.running && !state?.turnActive) return false;
+  if (state.live || state.currentAssistant || state.pendingUser !== undefined) return true;
+  return state.items.some((item) =>
+    (item.kind === "assistant" && item.streaming) ||
+    (item.kind === "tool" && item.status === "running"),
+  );
+}
+
+// Skip replace when a live transcript is already on screen; an empty
+// surface still has to apply history or switch-back shows Welcome.
+export function shouldApplyHydratedHistory(
+  skipHistory: boolean,
+  hasProjection: boolean,
+  foregroundTurnActive: boolean,
+  state: HydrateLiveState | undefined,
+): boolean {
+  if (skipHistory || !hasProjection) return false;
+  if (!foregroundTurnActive) return true;
+  return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
+}
+
+export function sameSessionPlaceholderItems<T>(
+  targetSessionPath: string | undefined,
+  prev: { meta?: { sessionPath?: string }; items?: T[] } | undefined,
+): T[] | undefined {
+  const target = (targetSessionPath ?? "").trim();
+  const current = (prev?.meta?.sessionPath ?? "").trim();
+  if (!target || !current || target !== current) return undefined;
+  return prev?.items;
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -705,6 +705,19 @@ function hasCachedLiveTurn(state: State | undefined): boolean {
   );
 }
 
+// Skip replace when a live transcript is already on screen; an empty
+// surface still has to apply history or switch-back shows Welcome.
+function shouldApplyHydratedHistory(
+  skipHistory: boolean,
+  hasProjection: boolean,
+  foregroundTurnActive: boolean,
+  state: State | undefined,
+): boolean {
+  if (skipHistory || !hasProjection) return false;
+  if (!foregroundTurnActive) return true;
+  return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
+}
+
 function hasReusableCachedTranscript(state: State | undefined, sessionPath?: string, revision?: number, digest?: string): boolean {
   if (!state || state.items.length === 0) return false;
   const expectedSessionPath = (sessionPath ?? "").trim();
@@ -2944,8 +2957,10 @@ export function useController() {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
-      if (!skipHistory && projection !== undefined && !foregroundTurnActive()) {
-        if (deferResetUntilHistory && stillCurrent()) dispatchTo(tabId, { type: "reset" });
+      if (shouldApplyHydratedHistory(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId))) {
+        // Reset wipes running/live flags. Keep them when this apply is only
+        // filling an empty surface that already knows a turn is in flight.
+        if (deferResetUntilHistory && stillCurrent() && !foregroundTurnActive()) dispatchTo(tabId, { type: "reset" });
         dispatchTo(tabId, {
           type: "history_replace",
           items: projection.items,
@@ -4614,9 +4629,15 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("topic.activate", meta.id);
       return meta;
     }
-    // Save previous tab's items so the new tab can use them as a placeholder
-    // during loading, avoiding a blank/Welcome flash before history arrives.
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
+    // Same-session items can fill the gap before history lands. Another
+    // session's transcript would look like the old chat on a new surface.
+    const prevState = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined;
+    const sameSession = Boolean(
+      meta.sessionPath &&
+      prevState?.meta?.sessionPath &&
+      prevState.meta.sessionPath === meta.sessionPath,
+    );
+    const prevItems = sameSession ? prevState?.items : undefined;
     pending.placeholderItems = prevItems;
     for (const id of Array.from(statesRef.current.keys())) {
       if (id !== meta.id) {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -18,6 +18,7 @@ import { getTranscriptStore } from "./transcriptStore";
 import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
+import { hasCachedLiveTurn, sameSessionPlaceholderItems, shouldApplyHydratedHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameTodoList } from "./todoVisibility";
 import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
@@ -694,28 +695,6 @@ export function shouldReconcileStaleTurn(
 ): boolean {
   if (!state?.running || !state.turnActive || lastTurnActivityAt <= 0) return false;
   return Math.max(0, now - lastTurnActivityAt) >= timeoutMs;
-}
-
-function hasCachedLiveTurn(state: State | undefined): boolean {
-  if (!state?.running && !state?.turnActive) return false;
-  if (state.live || state.currentAssistant || state.pendingUser !== undefined) return true;
-  return state.items.some((item) =>
-    (item.kind === "assistant" && item.streaming) ||
-    (item.kind === "tool" && item.status === "running")
-  );
-}
-
-// Skip replace when a live transcript is already on screen; an empty
-// surface still has to apply history or switch-back shows Welcome.
-function shouldApplyHydratedHistory(
-  skipHistory: boolean,
-  hasProjection: boolean,
-  foregroundTurnActive: boolean,
-  state: State | undefined,
-): boolean {
-  if (skipHistory || !hasProjection) return false;
-  if (!foregroundTurnActive) return true;
-  return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
 }
 
 function hasReusableCachedTranscript(state: State | undefined, sessionPath?: string, revision?: number, digest?: string): boolean {
@@ -2957,9 +2936,7 @@ export function useController() {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
-      if (shouldApplyHydratedHistory(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId))) {
-        // Reset wipes running/live flags. Keep them when this apply is only
-        // filling an empty surface that already knows a turn is in flight.
+      if (projection !== undefined && shouldApplyHydratedHistory(skipHistory, true, foregroundTurnActive(), statesRef.current.get(tabId))) {
         if (deferResetUntilHistory && stillCurrent() && !foregroundTurnActive()) dispatchTo(tabId, { type: "reset" });
         dispatchTo(tabId, {
           type: "history_replace",
@@ -4629,15 +4606,10 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("topic.activate", meta.id);
       return meta;
     }
-    // Same-session items can fill the gap before history lands. Another
-    // session's transcript would look like the old chat on a new surface.
-    const prevState = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined;
-    const sameSession = Boolean(
-      meta.sessionPath &&
-      prevState?.meta?.sessionPath &&
-      prevState.meta.sessionPath === meta.sessionPath,
+    const prevItems = sameSessionPlaceholderItems(
+      meta.sessionPath,
+      activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined,
     );
-    const prevItems = sameSession ? prevState?.items : undefined;
     pending.placeholderItems = prevItems;
     for (const id of Array.from(statesRef.current.keys())) {
       if (id !== meta.id) {
@@ -4653,9 +4625,7 @@ export function useController() {
     noteActivationStarted(pending.requestId, meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    // The hydrate is driven by the activation's terminal "ready" event; until
-    // then keep the loading surface up with the previous tab's items as the
-    // placeholder (same no-flash behavior the immediate hydrate had).
+    // Ready hydrates; only same-session items are a safe placeholder.
     dispatchTo(meta.id, { type: "hydrate_start", reason: "open-topic", placeholderItems: prevItems });
     if (pending.terminal && pendingTopicActivationRef.current === pending) {
       // The terminal event beat the ticket resolution; process it now.


### PR DESCRIPTION
## Summary

- Switching away from a conversation that is still thinking, then switching back, left the sidebar spinner and live composer in place but painted the empty Welcome surface. The transcript only returned after the turn finished and the user switched back again.
- Single-surface topic activation drops the previous tab's frontend cache. Reopening the running session marks `running` from tab meta, then hydration skipped applying the live history slice whenever a foreground turn was active. `hydrate_done` cleared placeholders, so Welcome won.
- Apply hydrated history when the visible transcript is empty, even if a turn is in flight. Do not `reset` on that path, so running/live flags stay. Keep the skip when a live transcript is already on screen.
- Activation placeholders now reuse items only when the session path matches. Another conversation's bubbles no longer appear on the new surface.

## Issues

No linked issue. Reported against current `main-v2` from a desktop usage screenshot: a thinking session stays selected and spinning, the composer shows the live turn, and the transcript is the new-conversation Welcome.

Related: #8656 resumes canonical recovery sessions. #8660 and #8663 are separate transcript paint/layout bugs and do not touch this hydration path.

## Verification

- `pnpm exec tsx src/__tests__/topic-activation.test.tsx`
- `pnpm exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- `pnpm exec tsx src/__tests__/activate-topic-stale.test.tsx`
- `pnpm exec tsx src/__tests__/new-session-load-race.test.tsx`

## Documentation impact

Documentation-impact: none - this restores an already-open thinking transcript after session switch. No user-facing control, setting, or documented contract changed, so `docs/*.md` stay correct.

## Cache impact

Cache-impact: none - desktop frontend hydration only; no prompt, provider serialization, tools, memory, or compaction changes.
Cache-guard: N/A - no cache-sensitive path changed.
