### PR TITLE
fix(boot): distinguish planner providers with shared model names / 区分使用相同模型名称的规划器提供商

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1716,7 +1716,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			Text: fmt.Sprintf("planner_model %q is not a configured provider — continuing with the executor alone", pm)})
 	}
 	if pm != "" && plannerResolved {
-		if pe.Model != entry.Model {
+		if modelRefFromEntry(pe) != modelRefFromEntry(entry) {
 			plannerProv, err := resolveProvider(effectiveResolver, cfg, proxySpec, provider.Selection{Ref: modelRefFromEntry(pe)})
 			if err != nil {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)

--- a/internal/boot/planner_provider_identity_test.go
+++ b/internal/boot/planner_provider_identity_test.go
@@ -1,0 +1,42 @@
+package boot
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+)
+
+func TestBuildEnablesPlannerWhenProvidersShareModelName(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	registerBootTokenProfileTestProvider()
+	setBootTokenProfileTestProvider(t, testutil.NewMock("shared-model-planner"))
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "executor"
+
+[agent]
+planner_model = "planner"
+
+[[providers]]
+name = "executor"
+kind = "boot-token-profile-test"
+model = "shared-model"
+
+[[providers]]
+name = "planner"
+kind = "boot-token-profile-test"
+model = "shared-model"
+`)
+
+	ctrl, err := Build(context.Background(), Options{WorkspaceRoot: dir, Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if got := ctrl.Label(); got != "shared-model + planner shared-model" {
+		t.Fatalf("controller label = %q, want planner enabled for distinct provider/model refs", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Compare planner and executor by their canonical `provider/model` identity instead of model name alone.
- Keep two-model collaboration enabled when different providers expose the same model name.
- Add a boot regression test covering identical model names across distinct providers.

## Issues

Fixes #8230

## Verification

- [x] `go test ./internal/boot -run TestBuildEnablesPlannerWhenProvidersShareModelName -count=1`
- [x] `go test ./internal/boot -run TestBuildBalancedDualModelAddsStableProxyToExecutor -count=1`
- [x] `go test ./internal/config ./internal/control -count=1`
- [x] `go vet ./...`
- [x] `go run ./tools/repolint`
- [x] `git diff --check`
- [ ] `go test ./internal/boot -count=1` - attempted; existing tests currently fail because the repository baseline loads the host Reasonix configuration, requires an unavailable DeepSeek key, and reports unrelated golden/skill-discovery drift.

## Documentation impact

Documentation-impact: none - planner/executor selection remains an internal wiring detail and no user-facing configuration syntax changes.

## Cache impact

Cache-impact: none - this only corrects whether the configured planner is wired; provider request schemas and prompts are unchanged for single-model sessions.
Cache-guard: `go test ./internal/boot -run TestBuildEnablesPlannerWhenProvidersShareModelName -count=1`; `go vet ./...`; `go run ./tools/repolint`; `git diff --check`
System-prompt-review: Reviewed boot wiring; no system prompt or prompt composition changes.
