### PR TITLE
fix(desktop): add vertical scrolling to bounded code blocks / 为有界代码块添加垂直滚动

### DIFF
--- a/desktop/frontend/src/__tests__/code-block-copy-position.test.tsx
+++ b/desktop/frontend/src/__tests__/code-block-copy-position.test.tsx
@@ -59,6 +59,7 @@ ok(pre?.parentElement === wrap, "scrollable pre is inside the wrapper");
 ok(copy?.parentElement === wrap, "copy button is a wrapper child");
 notOk(pre?.contains(copy ?? null), "copy button is outside the scrollable pre");
 ok(copy?.previousElementSibling === pre, "copy button follows pre as a sibling");
+ok(pre?.classList.contains("code--scroll-y"), "bounded code blocks opt into vertical scrolling");
 
 const stylesPath = fileURLToPath(new URL("../styles.css", import.meta.url));
 const css = readFileSync(stylesPath, "utf8");

--- a/desktop/frontend/src/components/editors/HljsCode.tsx
+++ b/desktop/frontend/src/components/editors/HljsCode.tsx
@@ -51,7 +51,7 @@ const HljsCode = memo(function HljsCode({ value, language, maxHeight, sourceSize
   return (
     <div className="code-block__wrap">
       <pre
-        className="code hljs"
+        className={`code hljs${maxHeight != null ? " code--scroll-y" : ""}`}
         data-highlight-mode={highlighted ? "syntax" : "plain"}
         data-lang={language}
         style={maxHeight ? { maxHeight } : undefined}


### PR DESCRIPTION
## Summary

- Apply the existing bounded vertical-scroll contract to highlighted code viewers when `maxHeight` is provided.
- Keep unbounded code blocks on transcript-owned vertical scrolling while allowing long chat, tool, and Markdown code blocks to scroll inside their capped viewport.
- Add regression coverage for the bounded `HljsCode` rendering contract.

## Issues

Fixes #8534

## Verification

- [x] `pnpm exec tsx src/__tests__/code-block-copy-position.test.tsx` (from `desktop/frontend`)
- [x] `pnpm exec tsx src/__tests__/typography-overflow-contract.test.ts` (from `desktop/frontend`)
- [x] `pnpm exec tsx src/__tests__/markdown-pipeline.test.tsx` (from `desktop/frontend`)
- [x] `pnpm exec tsx src/__tests__/line-number-code.test.tsx` (from `desktop/frontend`)
- [x] `pnpm exec tsx src/__tests__/markdown-table-virtual.test.tsx` (from `desktop/frontend`)
- [x] `pnpm typecheck` (from `desktop/frontend`)
- [x] `pnpm lint:hooks` (from `desktop/frontend`)
- [x] `pnpm build` (from `desktop/frontend`)
- [x] `go run ./tools/repolint`
- [x] `git diff --check`

## Documentation impact

Documentation-impact: none - this restores scrolling for existing bounded code viewers without changing user-facing commands, configuration, or documented workflows.

## Cache impact

Cache-impact: none - this is a frontend presentation-only change; it does not alter prompts, tool definitions, request serialization, or provider-visible prefixes.

Cache-guard: N/A - no prompt or provider request path changed.

System-prompt-review: Reviewed the changed desktop viewer and regression test; no system prompt or prompt composition changes.
