### PR TITLE
fix(desktop): render completed list items while answers stream / 修复流式列表中间闪源码

### DIFF
--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -205,6 +205,71 @@ console.log("\nmermaid rendering");
   eq(streamingCommitTarget("t\n\n$$\nx\n$$\nafter"), "t\n\n$$\nx\n$$\n", "closed display math promotes immediately");
   eq(streamingCommitTarget("para\n## Next sec"), "para\n", "a partial heading line completes the paragraph before it");
   eq(streamingCommitTarget("para\n## Done\ntail"), "para\n## Done\n", "a terminated heading promotes itself as a complete block");
+
+  const searchItem = (title: string, url: string) => `- **${title}**\n  <${url}>`;
+  const searchDump = [
+    searchItem("新闻本文", "https://example.com/a"),
+    searchItem("Bitcoin (BTC) Price", "https://example.com/b?utm_source=x"),
+    searchItem("KuCoin", "https://example.com/c"),
+  ].join("\n");
+  eq(
+    streamingCommitTarget(searchDump),
+    `${searchItem("新闻本文", "https://example.com/a")}\n${searchItem("Bitcoin (BTC) Price", "https://example.com/b?utm_source=x")}\n`,
+    "a later list marker commits prior tight list items, including indented URL continuations",
+  );
+  eq(
+    streamingCommitTarget(`${searchItem("新闻本文", "https://example.com/a")}\n- **Bit`),
+    `${searchItem("新闻本文", "https://example.com/a")}\n`,
+    "an in-progress list marker still commits the previous completed item",
+  );
+  eq(
+    streamingCommitTarget(searchItem("新闻本文", "https://example.com/a")),
+    "",
+    "a single list item stays in the tail until the next item or a blank line",
+  );
+  eq(
+    streamingCommitTarget("1. alpha\n2. beta\n3. gamma"),
+    "1. alpha\n2. beta\n",
+    "ordered list markers complete prior items the same way",
+  );
+  eq(
+    streamingCommitTarget("- [ ] one\n- [x] two\n- [ ] three"),
+    "- [ ] one\n- [x] two\n",
+    "task-list markers complete prior items the same way",
+  );
+  eq(
+    streamingCommitTarget("intro paragraph\n- first item\n  continued"),
+    "intro paragraph\n",
+    "a list marker completes the paragraph before it without taking the new item",
+  );
+  eq(
+    streamingCommitTarget("- parent\n  - child still typing"),
+    "- parent\n",
+    "a nested list marker completes the parent item and leaves the child in the tail",
+  );
+  eq(
+    streamingCommitTarget("not a heading\n---\nstill setext"),
+    "",
+    "a setext underline is not treated as a list marker",
+  );
+  eq(
+    streamingCommitTarget("*not-a-list*\nstill paragraph"),
+    "",
+    "emphasis without a marker space is not a list item",
+  );
+  eq(
+    streamingCommitTarget("t\n\n```\n- not a list\n- also not\n"),
+    "t\n\n```\n- not a list\n- also not\n",
+    "list markers inside an open fence do not create commit boundaries",
+  );
+  eq(
+    streamingCommitTarget("- one\n- two\n\n"),
+    "- one\n- two\n\n",
+    "a blank line after a list still commits the whole list",
+  );
+  const searchHtml = renderToStaticMarkup(<ReactMarkdown remarkPlugins={[]}>{searchDump}</ReactMarkdown>);
+  ok(searchHtml.includes("<ul>") && searchHtml.includes("<li>") && searchHtml.includes("https://example.com/a"),
+    "the search-list source still renders as a list in the final Markdown tree");
 }
 
 {
@@ -268,6 +333,25 @@ console.log("\nmermaid rendering");
     root.render(<MarkdownTextProbe text="complete" streaming={false} />);
   });
   eq(rootEl.textContent, "complete", "short stream finalization still commits immediately");
+
+  pendingFrame = undefined;
+  const firstSearch = "- **新闻本文**\n  <https://example.com/a>\n";
+  const secondSearch = `${firstSearch}- **Bitcoin**\n  <https://example.com/b>`;
+  await act(async () => {
+    root.render(<MarkdownTextProbe text={firstSearch} streaming />);
+    await flushTimers();
+  });
+  eq(rootEl.textContent, "", "a single tight list item stays off the parsed prefix");
+  await act(async () => {
+    root.render(<MarkdownTextProbe text={secondSearch} streaming />);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
+  const listFrame = pendingFrame;
+  await act(async () => {
+    listFrame?.(performance.now());
+    await flushTimers();
+  });
+  eq(rootEl.textContent, firstSearch, "a later list item commits the previous tight item into the parsed prefix");
 
   await act(async () => root.unmount());
   dom.window.close();

--- a/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
+++ b/desktop/frontend/src/__tests__/mermaid-rendering.test.tsx
@@ -268,7 +268,7 @@ console.log("\nmermaid rendering");
     "a blank line after a list still commits the whole list",
   );
   const searchHtml = renderToStaticMarkup(<ReactMarkdown remarkPlugins={[]}>{searchDump}</ReactMarkdown>);
-  ok(searchHtml.includes("<ul>") && searchHtml.includes("<li>") && searchHtml.includes("https://example.com/a"),
+  ok(searchHtml.includes("<ul>") && searchHtml.includes("<li>") && searchHtml.includes("新闻本文"),
     "the search-list source still renders as a list in the final Markdown tree");
 }
 

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -131,12 +131,15 @@ export function streamingMarkdownCommitInterval(textLength: number): number {
   return 50;
 }
 
-// streamingCommitTarget returns the prefix worth parsing while a stream is
-// live: everything up to the last completed block — a blank line, a closed
-// fence, closed display math, or the start of a heading, all on terminated
-// lines. The in-progress block rides the plain-text tail instead, so Markdown
-// re-parses once per completed block rather than once per commit interval. An
-// unclosed fence or $$ keeps the whole text parsed for live code highlighting.
+const STREAMING_LIST_ITEM_RE = /^ {0,3}(?:[*+-]|\d{1,9}[.)])(?:[ \t]+|$)/;
+const STREAMING_THEMATIC_BREAK_RE = /^ {0,3}(?:(?:-[ \t]*){3,}|(?:\*[ \t]*){3,}|(?:_[ \t]*){3,})[ \t]*$/;
+
+function isStreamingListItemLine(line: string): boolean {
+  return STREAMING_LIST_ITEM_RE.test(line) && !STREAMING_THEMATIC_BREAK_RE.test(line);
+}
+
+// Live parse prefix: last completed block. A later list marker commits prior
+// items only — the new item stays in the tail so indented continuations can join.
 export function streamingCommitTarget(text: string): string {
   let lineStart = 0;
   let fence: { marker: string; length: number } | null = null;
@@ -165,6 +168,7 @@ export function streamingCommitTarget(text: string): string {
       // A heading interrupts a paragraph, so a partial heading line already
       // completes everything before it; a terminated one is itself complete.
       else if (/^ {0,3}#{1,6}[ \t]+/.test(line)) boundary = terminated ? lineEnd : lineStart;
+      else if (isStreamingListItemLine(line)) boundary = lineStart;
     }
     lineStart = lineEnd;
   }


### PR DESCRIPTION
## Summary

While an answer is still streaming, tight markdown lists flashed as raw source (`- **title**` and `<url>`) and only became the finished title-and-link list after the turn ended. The final list look stays the same; this change only lets completed items render as they arrive.

## Root cause

`streamingCommitTarget` only promoted a live prefix at blank lines, closed fences, closed display math, or headings. Provider `web_search` dumps and other tight lists have no blank lines, so the whole list stayed in the plain-text streaming tail.

## Fix

A later CommonMark list marker now commits prior items, including indented URL continuations. The new item itself stays in the tail so the next continuation line can still join it. Setext underlines, thematic breaks, emphasis without a marker space, and markers inside open fences are unchanged.

## Verification

- `tsx src/__tests__/mermaid-rendering.test.tsx`
- `tsx src/__tests__/ui-perf-scenarios.test.ts`
- `tsx src/__tests__/markdown-pipeline.test.tsx`
- `tsx src/__tests__/markdown-streaming-worker.test.tsx`
- `tsx src/__tests__/markdown-history.test.tsx`

Documentation-impact: none - streaming renderer timing only; existing docs do not describe list commit boundaries
