### PR TITLE
fix(config): refresh MiniMax model presets

### DIFF
--- a/internal/billing/money_test.go
+++ b/internal/billing/money_test.go
@@ -54,3 +54,12 @@ func TestOriginalCostMatchesLegacySemantics(t *testing.T) {
 		t.Fatalf("cost = %v, want ~1.2", got)
 	}
 }
+
+func TestOriginalCostUsesExplicitCacheWriteRate(t *testing.T) {
+	amt := OriginalCostAmount(RateCard{Input: 0.30, CacheWrite: 0.375, Currency: "USD"}, UsageTokens{
+		CacheMissTokens: 500_000, CacheWriteTokens: 100_000,
+	})
+	if got := amt.Float64(); got < 0.15749 || got > 0.15751 {
+		t.Fatalf("cost = %v, want ~0.1575", got)
+	}
+}

--- a/internal/billing/quote.go
+++ b/internal/billing/quote.go
@@ -114,10 +114,11 @@ type RateSnapshot struct {
 // RateCard is the per-1M-token price used to compute original cost. It mirrors
 // provider.Pricing without importing that package (billing is a leaf).
 type RateCard struct {
-	CacheHit float64 // per 1M cached prompt tokens
-	Input    float64 // per 1M uncached prompt tokens
-	Output   float64 // per 1M completion tokens
-	Currency string  // ISO or symbol; normalized on quote
+	CacheHit   float64 // per 1M cached prompt tokens
+	CacheWrite float64 // per 1M prompt tokens written to cache; zero falls back to Input
+	Input      float64 // per 1M uncached prompt tokens
+	Output     float64 // per 1M completion tokens
+	Currency   string  // ISO or symbol; normalized on quote
 }
 
 // UsageTokens is the token breakdown needed for cost. Mirrors provider.Usage
@@ -171,10 +172,14 @@ func OriginalCostAmount(rates RateCard, u UsageTokens) Amount {
 			billedWrite = float64(write)
 		}
 	}
-	inputTokenUnits := float64(miss-write) + billedWrite
+	inputTokenUnits := float64(miss - write)
+	writeCost := billedWrite * rates.Input
+	if rates.CacheWrite > 0 {
+		writeCost = float64(write) * rates.CacheWrite
+	}
 	// Combine cached input, uncached input, and output charges per million tokens.
 	total := (float64(hit)*rates.CacheHit +
-		inputTokenUnits*rates.Input +
+		inputTokenUnits*rates.Input + writeCost +
 		float64(u.CompletionTokens)*rates.Output) / 1e6
 	return NewAmountFromFloat(total)
 }
@@ -183,6 +188,9 @@ func OriginalCostAmount(rates RateCard, u UsageTokens) Amount {
 func PricingFingerprint(rates RateCard) string {
 	cur := NormalizeCurrency(rates.Currency)
 	raw := fmt.Sprintf("%s|%.12g|%.12g|%.12g", cur, rates.CacheHit, rates.Input, rates.Output)
+	if rates.CacheWrite > 0 {
+		raw += fmt.Sprintf("|%.12g", rates.CacheWrite)
+	}
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:8])
 }

--- a/internal/config/billing.go
+++ b/internal/config/billing.go
@@ -214,10 +214,11 @@ func QuoteForUsage(price *provider.Pricing, usage *provider.Usage, display strin
 		return billing.CostQuote{Estimated: true, CostComplete: false, DisplayComplete: false, Complete: false, DisplayStatus: billing.DisplayStatusUnavailable, IncompleteReason: "missing_price_or_usage"}
 	}
 	card := billing.RateCard{
-		CacheHit: price.CacheHit,
-		Input:    price.Input,
-		Output:   price.Output,
-		Currency: billing.NormalizeCurrency(price.Currency),
+		CacheHit:   price.CacheHit,
+		CacheWrite: price.CacheWrite,
+		Input:      price.Input,
+		Output:     price.Output,
+		Currency:   billing.NormalizeCurrency(price.Currency),
 	}
 	if card.Currency == "" {
 		card.Currency = "CNY"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1397,6 +1397,10 @@ type ProviderEntry struct {
 	// provider. This lets one provider expose both text-only and multimodal chat
 	// models without enabling image payloads for every model.
 	VisionModels []string `toml:"vision_models"`
+	// VideoModels records models whose upstream API accepts video input. Video
+	// attachment transport is provider-specific; this catalog metadata keeps the
+	// advertised model modality available without enabling video for other models.
+	VideoModels []string `toml:"video_models"`
 	// VisionDetail sets the openai image_url detail hint (low|high); empty = auto
 	// (the field is omitted). "low" caps an image to a fixed ~85 tokens for cheap
 	// coarse reads; ignored by providers without the knob (e.g. anthropic).

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -203,6 +203,17 @@ func mimoV25ProPrice() *provider.Pricing {
 	return &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}
 }
 
+func minimaxMSeriesPricesUSD() map[string]*provider.Pricing {
+	return map[string]*provider.Pricing{
+		"MiniMax-M3": {
+			CacheHit: 0.12, Input: 0.60, Output: 2.40, Currency: "$",
+		},
+		"MiniMax-M2.7": {
+			CacheHit: 0.06, CacheWrite: 0.375, Input: 0.30, Output: 1.20, Currency: "$",
+		},
+	}
+}
+
 func mimoV25Price() *provider.Pricing {
 	return &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}
 }

--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -97,6 +97,7 @@ var (
 
 	minimaxMSeriesModels       = []string{"MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"}
 	minimaxMSeriesVisionModels = []string{"MiniMax-M3"}
+	minimaxMSeriesVideoModels  = []string{"MiniMax-M3"}
 
 	glmAPIModels       = []string{"glm-5.2", "glm-5.1", "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx", "glm-4.6", "glm-4.5", "glm-4.5-air", "glm-4.5-flash"}
 	glmAPIVisionModels = []string{"glm-5v-turbo"}
@@ -476,15 +477,19 @@ var curatedProviderPresets = []ProviderPreset{
 		Description: "MiniMax China OpenAI-compatible M-series API endpoint.",
 		KeyEnv:      "MINIMAX_API_KEY",
 		Entries: []ProviderEntry{{
-			Name:          "minimax-cn-api",
-			Kind:          "openai",
-			BaseURL:       "https://api.minimaxi.com/v1",
-			Models:        minimaxMSeriesModels,
-			VisionModels:  minimaxMSeriesVisionModels,
-			Default:       "MiniMax-M3",
-			APIKeyEnv:     "MINIMAX_API_KEY",
-			ContextWindow: 1048576,
-			ExtraBody:     map[string]any{"reasoning_split": true},
+			Name:            "minimax-cn-api",
+			Kind:            "openai",
+			BaseURL:         "https://api.minimaxi.com/v1",
+			Models:          minimaxMSeriesModels,
+			VisionModels:    minimaxMSeriesVisionModels,
+			VideoModels:     minimaxMSeriesVideoModels,
+			Default:         "MiniMax-M3",
+			APIKeyEnv:       "MINIMAX_API_KEY",
+			ContextWindow:   1_000_000,
+			Prices:          minimaxMSeriesPricesUSD(),
+			BillingCurrency: "USD",
+			ModelOverrides:  minimaxMSeriesModelOverrides(),
+			ExtraBody:       map[string]any{"reasoning_split": true},
 		}},
 	},
 	{
@@ -493,15 +498,19 @@ var curatedProviderPresets = []ProviderPreset{
 		Description: "MiniMax international OpenAI-compatible M-series API endpoint.",
 		KeyEnv:      "MINIMAX_API_KEY",
 		Entries: []ProviderEntry{{
-			Name:          "minimax-global-api",
-			Kind:          "openai",
-			BaseURL:       "https://api.minimax.io/v1",
-			Models:        minimaxMSeriesModels,
-			VisionModels:  minimaxMSeriesVisionModels,
-			Default:       "MiniMax-M3",
-			APIKeyEnv:     "MINIMAX_API_KEY",
-			ContextWindow: 1048576,
-			ExtraBody:     map[string]any{"reasoning_split": true},
+			Name:            "minimax-global-api",
+			Kind:            "openai",
+			BaseURL:         "https://api.minimax.io/v1",
+			Models:          minimaxMSeriesModels,
+			VisionModels:    minimaxMSeriesVisionModels,
+			VideoModels:     minimaxMSeriesVideoModels,
+			Default:         "MiniMax-M3",
+			APIKeyEnv:       "MINIMAX_API_KEY",
+			ContextWindow:   1_000_000,
+			Prices:          minimaxMSeriesPricesUSD(),
+			BillingCurrency: "USD",
+			ModelOverrides:  minimaxMSeriesModelOverrides(),
+			ExtraBody:       map[string]any{"reasoning_split": true},
 		}},
 	},
 	{
@@ -510,15 +519,20 @@ var curatedProviderPresets = []ProviderPreset{
 		Description: "MiniMax China Anthropic-compatible M-series endpoint.",
 		KeyEnv:      "MINIMAX_PLAN_API_KEY",
 		Entries: []ProviderEntry{{
-			Name:          "minimax-cn-anthropic",
-			Kind:          "anthropic",
-			BaseURL:       "https://api.minimaxi.com/anthropic",
-			Models:        minimaxMSeriesModels,
-			VisionModels:  minimaxMSeriesVisionModels,
-			Default:       "MiniMax-M3",
-			APIKeyEnv:     "MINIMAX_PLAN_API_KEY",
-			AuthHeader:    true,
-			ContextWindow: 1048576,
+			Name:            "minimax-cn-anthropic",
+			Kind:            "anthropic",
+			BaseURL:         "https://api.minimaxi.com/anthropic",
+			Models:          minimaxMSeriesModels,
+			VisionModels:    minimaxMSeriesVisionModels,
+			VideoModels:     minimaxMSeriesVideoModels,
+			Default:         "MiniMax-M3",
+			APIKeyEnv:       "MINIMAX_PLAN_API_KEY",
+			AuthHeader:      true,
+			Thinking:        "adaptive",
+			ContextWindow:   1_000_000,
+			Prices:          minimaxMSeriesPricesUSD(),
+			BillingCurrency: "USD",
+			ModelOverrides:  minimaxMSeriesModelOverrides(),
 		}},
 	},
 	{
@@ -527,15 +541,20 @@ var curatedProviderPresets = []ProviderPreset{
 		Description: "MiniMax international Anthropic-compatible endpoint with Bearer auth.",
 		KeyEnv:      "MINIMAX_API_KEY",
 		Entries: []ProviderEntry{{
-			Name:          "minimax-global-anthropic",
-			Kind:          "anthropic",
-			BaseURL:       "https://api.minimax.io/anthropic",
-			Models:        minimaxMSeriesModels,
-			VisionModels:  minimaxMSeriesVisionModels,
-			Default:       "MiniMax-M3",
-			APIKeyEnv:     "MINIMAX_API_KEY",
-			AuthHeader:    true,
-			ContextWindow: 1048576,
+			Name:            "minimax-global-anthropic",
+			Kind:            "anthropic",
+			BaseURL:         "https://api.minimax.io/anthropic",
+			Models:          minimaxMSeriesModels,
+			VisionModels:    minimaxMSeriesVisionModels,
+			VideoModels:     minimaxMSeriesVideoModels,
+			Default:         "MiniMax-M3",
+			APIKeyEnv:       "MINIMAX_API_KEY",
+			AuthHeader:      true,
+			Thinking:        "adaptive",
+			ContextWindow:   1_000_000,
+			Prices:          minimaxMSeriesPricesUSD(),
+			BillingCurrency: "USD",
+			ModelOverrides:  minimaxMSeriesModelOverrides(),
 		}},
 	},
 	{
@@ -967,6 +986,20 @@ func boolPointer(value bool) *bool {
 	return &value
 }
 
+func minimaxMSeriesModelOverrides() map[string]ProviderModelOverride {
+	return map[string]ProviderModelOverride{
+		"MiniMax-M3": {
+			SupportedEfforts: []string{"adaptive", "disabled"},
+			DefaultEffort:    "adaptive",
+			ContextWindow:    1_000_000,
+		},
+		"MiniMax-M2.7": {
+			ReasoningProtocol: ReasoningProtocolNone,
+			ContextWindow:     204_800,
+		},
+	}
+}
+
 func cloneProviderPreset(p ProviderPreset) ProviderPreset {
 	p.Entries = cloneProviderEntries(p.Entries)
 	for i := range p.Entries {
@@ -999,6 +1032,7 @@ func cloneProviderEntry(e ProviderEntry) ProviderEntry {
 	}
 	e.Models = append([]string(nil), e.Models...)
 	e.VisionModels = append([]string(nil), e.VisionModels...)
+	e.VideoModels = append([]string(nil), e.VideoModels...)
 	e.SupportedEfforts = append([]string(nil), e.SupportedEfforts...)
 	e.Headers = cloneStringMap(e.Headers)
 	e.ExtraBody = cloneAnyMap(e.ExtraBody)

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -496,6 +496,30 @@ func TestCuratedProviderPresetCapabilities(t *testing.T) {
 	if cap := EffortCapabilityForEntry(minimax); !cap.Supported || cap.Default != "adaptive" || !containsString(cap.Levels, "disabled") {
 		t.Fatalf("minimax effort capability = %+v, want adaptive/disabled", cap)
 	}
+	if minimax.ContextWindow != 1_000_000 || !minimax.HasVideoModel("MiniMax-M3") {
+		t.Fatalf("minimax M3 context/video capability mismatch: %+v", minimax)
+	}
+	if price := minimax.Price; price == nil || price.CacheHit != 0.12 || price.Input != 0.60 || price.Output != 2.40 || price.Currency != "$" {
+		t.Fatalf("minimax M3 price = %+v, want USD 0.12/0.60/2.40", price)
+	}
+	for _, providerID := range []string{"minimax-cn-api", "minimax-global-api", "minimax-cn-anthropic", "minimax-global-anthropic"} {
+		m27, ok := cfg.ResolveModel(providerID + "/MiniMax-M2.7")
+		if !ok {
+			t.Fatalf("%s MiniMax-M2.7 did not resolve", providerID)
+		}
+		if m27.ContextWindow != 204_800 || ReasoningProtocolForEntry(m27) != ReasoningProtocolNone {
+			t.Fatalf("%s MiniMax-M2.7 context/reasoning mismatch: %+v", providerID, m27)
+		}
+		if cap := EffortCapabilityForEntry(m27); cap.Supported {
+			t.Fatalf("%s MiniMax-M2.7 effort capability = %+v, want provider-controlled thinking", providerID, cap)
+		}
+		if m27.HasVideoModel("MiniMax-M2.7") {
+			t.Fatalf("%s MiniMax-M2.7 unexpectedly advertises video input", providerID)
+		}
+		if price := m27.Price; price == nil || price.CacheHit != 0.06 || price.CacheWrite != 0.375 || price.Input != 0.30 || price.Output != 1.20 || price.Currency != "$" {
+			t.Fatalf("%s MiniMax-M2.7 price = %+v, want USD 0.06/0.375/0.30/1.20", providerID, price)
+		}
+	}
 	minimaxGlobalAPI, ok := cfg.Provider("minimax-global-api")
 	if !ok {
 		t.Fatal("minimax-global-api provider missing")

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -382,6 +382,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			if p.VisionModels != nil {
 				fmt.Fprintf(&b, "vision_models = %s   # models in this provider that accept image input\n", renderStringArray(p.VisionModels))
 			}
+			if p.VideoModels != nil {
+				fmt.Fprintf(&b, "video_models = %s   # models in this provider that accept video input\n", renderStringArray(p.VideoModels))
+			}
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q   # openai image detail hint: low|high; empty = auto\n", p.VisionDetail)
 			}
@@ -1075,6 +1078,9 @@ func RenderTOMLProjectDelta(c *Config) string {
 			if p.VisionModels != nil {
 				fmt.Fprintf(&b, "vision_models = %s\n", renderStringArray(p.VisionModels))
 			}
+			if p.VideoModels != nil {
+				fmt.Fprintf(&b, "video_models = %s\n", renderStringArray(p.VideoModels))
+			}
 			if p.VisionDetail != "" {
 				fmt.Fprintf(&b, "vision_detail = %q\n", p.VisionDetail)
 			}
@@ -1274,8 +1280,11 @@ func renderPricingInline(p *provider.Pricing) string {
 	if p == nil {
 		return "{}"
 	}
-	return fmt.Sprintf("{ cache_hit = %v, input = %v, output = %v, currency = %q }",
-		p.CacheHit, p.Input, p.Output, p.Symbol())
+	if p.CacheWrite > 0 {
+		return fmt.Sprintf("{ cache_hit = %v, cache_write = %v, input = %v, output = %v, currency = %q }",
+			p.CacheHit, p.CacheWrite, p.Input, p.Output, p.Symbol())
+	}
+	return fmt.Sprintf("{ cache_hit = %v, input = %v, output = %v, currency = %q }", p.CacheHit, p.Input, p.Output, p.Symbol())
 }
 
 func renderPricingMap(prices map[string]*provider.Pricing) string {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -994,6 +994,8 @@ func TestProjectRenderPreservesNonDefaultLegacySections(t *testing.T) {
 
 func TestRenderTOMLRoundTripsPerModelPrices(t *testing.T) {
 	orig := Default()
+	prices := DeepSeekV4PricesForCurrency("CNY")
+	prices["deepseek-v4-flash"].CacheWrite = 1.25
 	orig.Providers = []ProviderEntry{{
 		Name:      "deepseek",
 		Kind:      "openai",
@@ -1001,7 +1003,7 @@ func TestRenderTOMLRoundTripsPerModelPrices(t *testing.T) {
 		Models:    []string{"deepseek-v4-flash", "deepseek-v4-pro"},
 		Default:   "deepseek-v4-flash",
 		APIKeyEnv: "DEEPSEEK_API_KEY",
-		Prices:    DeepSeekV4PricesForCurrency("CNY"),
+		Prices:    prices,
 	}}
 
 	var got Config
@@ -1012,7 +1014,7 @@ func TestRenderTOMLRoundTripsPerModelPrices(t *testing.T) {
 	if !ok {
 		t.Fatal("deepseek provider missing after round trip")
 	}
-	if p.Prices["deepseek-v4-flash"].Input != 1 || p.Prices["deepseek-v4-pro"].Output != 6 {
+	if p.Prices["deepseek-v4-flash"].Input != 1 || p.Prices["deepseek-v4-flash"].CacheWrite != 1.25 || p.Prices["deepseek-v4-pro"].Output != 6 {
 		t.Fatalf("prices after round trip = %+v", p.Prices)
 	}
 }
@@ -1028,6 +1030,7 @@ func TestRenderTOMLRoundTripsVisionModels(t *testing.T) {
 			Default:      "text-only",
 			APIKeyEnv:    "CUSTOM_API_KEY",
 			VisionModels: []string{"qwen-vl-plus"},
+			VideoModels:  []string{"qwen-video-plus"},
 			VisionDetail: "low",
 		},
 		{
@@ -1044,6 +1047,9 @@ func TestRenderTOMLRoundTripsVisionModels(t *testing.T) {
 	rendered := RenderTOML(orig)
 	if !strings.Contains(rendered, `vision_models = ["qwen-vl-plus"]`) {
 		t.Fatalf("rendered TOML missing vision_models:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, `video_models = ["qwen-video-plus"]`) {
+		t.Fatalf("rendered TOML missing video_models:\n%s", rendered)
 	}
 	if !strings.Contains(rendered, `vision_models = []`) {
 		t.Fatalf("rendered TOML missing explicit empty vision_models:\n%s", rendered)
@@ -1062,6 +1068,9 @@ func TestRenderTOMLRoundTripsVisionModels(t *testing.T) {
 	}
 	if !reflect.DeepEqual(p.VisionModels, []string{"qwen-vl-plus"}) {
 		t.Fatalf("vision_models after round trip = %v, want [qwen-vl-plus]", p.VisionModels)
+	}
+	if !reflect.DeepEqual(p.VideoModels, []string{"qwen-video-plus"}) {
+		t.Fatalf("video_models after round trip = %v, want [qwen-video-plus]", p.VideoModels)
 	}
 	if p.VisionDetail != "low" {
 		t.Fatalf("vision_detail after round trip = %q, want low", p.VisionDetail)

--- a/internal/config/vision.go
+++ b/internal/config/vision.go
@@ -124,6 +124,21 @@ func (e *ProviderEntry) HasVisionModel(model string) bool {
 	return false
 }
 
+// HasVideoModel reports whether model is explicitly advertised as accepting
+// video input by this provider entry.
+func (e *ProviderEntry) HasVideoModel(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	for _, candidate := range e.VideoModels {
+		if strings.EqualFold(strings.TrimSpace(candidate), model) {
+			return true
+		}
+	}
+	return false
+}
+
 func isOfficialMimoVisionEntry(e *ProviderEntry) bool {
 	if !isOpenAIProviderKind(e) || !mimoVisionModels[strings.ToLower(strings.TrimSpace(e.Model))] {
 		return false

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -95,10 +95,19 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		requestURL = root + "/v1/messages"
 	}
 	officialDeepSeek := openai.IsDeepSeek(root)
+	minimax := openai.IsMiniMax(root)
+	reasoningProtocol, _ := cfg.Extra["reasoning_protocol"].(string)
+	reasoningDisabled := strings.EqualFold(strings.TrimSpace(reasoningProtocol), "none")
+	if reasoningDisabled {
+		minimax = false
+	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
 	keySource, _ := cfg.Extra["api_key_source"].(string)
 	thinking, _ := cfg.Extra["thinking"].(string)
 	thinking = strings.ToLower(strings.TrimSpace(thinking))
+	if reasoningDisabled {
+		thinking = ""
+	}
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	vision, _ := cfg.Extra["vision"].(bool)
@@ -142,6 +151,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		model:            cfg.Model,
 		nativeAnthropic:  strings.EqualFold(root, defaultBaseURL),
 		deepseek:         officialDeepSeek,
+		minimax:          minimax,
 		thinking:         thinking,
 		effort:           effort,
 		vision:           vision,
@@ -170,6 +180,7 @@ type client struct {
 	model            string
 	nativeAnthropic  bool   // first-party endpoint: documented default-5m cache-write pricing applies
 	deepseek         bool   // official DeepSeek Anthropic endpoint: unsigned reasoning replay + automatic cache
+	minimax          bool   // official MiniMax endpoint: adaptive|disabled thinking.type without output_config
 	thinking         string // "adaptive" enables extended thinking; "" = off (config-driven)
 	effort           string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
 	vision           bool   // model accepts image input — embed attached images as base64 image blocks
@@ -475,6 +486,12 @@ func (c *client) buildRequest(_ context.Context, req provider.Request) anthReque
 				r.OutputConfig = &outputConfig{Effort: effort}
 			}
 		}
+	} else if c.minimax {
+		t := c.effort
+		if t == "" {
+			t = "adaptive"
+		}
+		r.Thinking = &thinkingConfig{Type: t}
 	} else {
 		switch c.thinking {
 		case "adaptive":

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -650,6 +650,37 @@ func TestBuildRequestThinkingEnabledGateway(t *testing.T) {
 	}
 }
 
+func TestBuildRequestMiniMaxThinking(t *testing.T) {
+	for _, effort := range []string{"", "adaptive", "disabled"} {
+		c := &client{model: "MiniMax-M3", minimax: true, thinking: "adaptive", effort: effort}
+		r := c.buildRequest(context.Background(), provider.Request{})
+		want := effort
+		if want == "" {
+			want = "adaptive"
+		}
+		if r.Thinking == nil || r.Thinking.Type != want || r.Thinking.Display != "" {
+			t.Fatalf("effort %q thinking = %+v, want %q without display", effort, r.Thinking, want)
+		}
+		if r.OutputConfig != nil {
+			t.Fatalf("effort %q output_config = %+v, want omitted", effort, r.OutputConfig)
+		}
+	}
+}
+
+func TestNewMiniMaxReasoningProtocolNoneUsesModelDefault(t *testing.T) {
+	p, err := New(provider.Config{
+		Name: "minimax", BaseURL: "https://api.minimax.io/anthropic", Model: "MiniMax-M2.7",
+		Extra: map[string]any{"thinking": "adaptive", "reasoning_protocol": "none"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := p.(*client)
+	if c.minimax || c.thinking != "" {
+		t.Fatalf("M2.7 controls = minimax:%t thinking:%q, want provider-default thinking", c.minimax, c.thinking)
+	}
+}
+
 func TestBuildRequestDeepSeekThinking(t *testing.T) {
 	c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "max"}
 	r := c.buildRequest(context.Background(), provider.Request{

--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -109,13 +109,11 @@ func normalizeModelID(baseURL, model string) string {
 	return model
 }
 
-// IsMiniMax reports whether baseURL points at MiniMax's OpenAI-compatible
-// endpoint (api.minimaxi.com or any *.minimaxi.com subdomain).
-//
-// The host string is matched exactly — the spelling is `minimaxi`, not
-// `minimax` — to avoid clashing with any future minimax-branded gateway.
+// IsMiniMax reports whether baseURL points at MiniMax's China or international
+// OpenAI-compatible endpoint.
 func IsMiniMax(baseURL string) bool {
-	return matchesVendorHost(baseURL, "minimaxi.com", "api.minimaxi.com")
+	return matchesVendorHost(baseURL, "minimaxi.com", "api.minimaxi.com") ||
+		matchesVendorHost(baseURL, "minimax.io", "api.minimax.io")
 }
 
 // IsMiMo reports whether baseURL points at Xiaomi MiMo's OpenAI-compatible API.

--- a/internal/provider/openai/host_test.go
+++ b/internal/provider/openai/host_test.go
@@ -111,9 +111,8 @@ func TestUsesGeminiThoughtSignatures(t *testing.T) {
 	}
 }
 
-// TestIsMiniMax pins the host-matching rule for MiniMax. The spelling is
-// `minimaxi`, not `minimax` — the latter is reserved for any future
-// minimax-branded gateway so the two never collide.
+// TestIsMiniMax pins the host-matching rule for MiniMax's China and
+// international API domains.
 func TestIsMiniMax(t *testing.T) {
 	for _, tc := range []struct {
 		baseURL string
@@ -123,16 +122,20 @@ func TestIsMiniMax(t *testing.T) {
 		{"https://api.minimaxi.com", true},
 		{"https://api.minimaxi.com/v1", true},
 		{"https://api.minimaxi.com/anthropic", true},
+		{"https://api.minimax.io/v1", true},
+		{"https://api.minimax.io/anthropic", true},
 		// Regional subdomains under the apex
 		{"https://eu.minimaxi.com/v1", true},
 		{"https://us.minimaxi.com/v1", true},
+		{"https://eu.minimax.io/v1", true},
 		// Apex rejected
 		{"https://minimaxi.com/v1", false},
 		{"https://minimaxi.com", false},
+		{"https://minimax.io/v1", false},
 		// Other vendors must not match
 		{"https://api.deepseek.com", false},
 		{"https://api.openai.com/v1", false},
-		// Wrong spelling — minimax, not minimaxi — must not match
+		// Similar but unrelated domains must not match
 		{"https://api.minimax.com/v1", false},
 		{"https://api.minimax.example.com", false},
 		// Garbage

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -741,10 +741,11 @@ func (u *Usage) LatestPromptTokens() int {
 // Pricing is a provider's per-1M-token rates, used to estimate spend. Currency
 // is a display symbol or ISO-like code (default "¥"). toml tags let config decode it.
 type Pricing struct {
-	CacheHit float64 `toml:"cache_hit"` // per 1M cached prompt tokens
-	Input    float64 `toml:"input"`     // per 1M uncached prompt tokens
-	Output   float64 `toml:"output"`    // per 1M completion tokens
-	Currency string  `toml:"currency"`
+	CacheHit   float64 `toml:"cache_hit"`   // per 1M cached prompt tokens
+	CacheWrite float64 `toml:"cache_write"` // per 1M prompt tokens written to cache; zero falls back to Input
+	Input      float64 `toml:"input"`       // per 1M uncached prompt tokens
+	Output     float64 `toml:"output"`      // per 1M completion tokens
+	Currency   string  `toml:"currency"`
 }
 
 // Cost estimates the spend for a usage record. Compatibility adapter only —
@@ -777,9 +778,13 @@ func (p *Pricing) Cost(u *Usage) float64 {
 			billedWrite = float64(write)
 		}
 	}
-	inputTokenUnits := float64(miss-write) + billedWrite
+	inputTokenUnits := float64(miss - write)
+	writeCost := billedWrite * p.Input
+	if p.CacheWrite > 0 {
+		writeCost = float64(write) * p.CacheWrite
+	}
 	return (float64(hit)*p.CacheHit +
-		inputTokenUnits*p.Input +
+		inputTokenUnits*p.Input + writeCost +
 		float64(u.CompletionTokens)*p.Output) / 1e6
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -480,6 +480,15 @@ func TestPricingCostUsesCacheWriteBillingTier(t *testing.T) {
 	}
 }
 
+func TestPricingCostUsesExplicitCacheWriteRate(t *testing.T) {
+	p := &Pricing{Input: 0.30, CacheWrite: 0.375}
+	u := &Usage{CacheMissTokens: 500_000, CacheWriteTokens: 100_000}
+	// 400K ordinary input at $0.30/M plus 100K cache writes at $0.375/M.
+	if got := p.Cost(u); got != 0.1575 {
+		t.Errorf("Cost = %f, want 0.1575", got)
+	}
+}
+
 func TestPricingCostCacheWriteFieldsAreBackwardCompatible(t *testing.T) {
 	p := &Pricing{Input: 2.0}
 


### PR DESCRIPTION
Reason: MiniMax presets use shared context, pricing, reasoning, and modality metadata that no longer matches the supported models.

- Add per-model context windows, USD token prices, reasoning controls, and M3 video-input metadata to all MiniMax presets.
- Detect the international MiniMax OpenAI endpoint and serialize M3 thinking controls on both compatible APIs while leaving M2.7 provider-controlled.
- Add an optional cache-write rate while preserving existing billing behavior when it is unset.

Cache-impact: low - Provider preset and request serialization changes can alter cache identity for MiniMax requests.
Cache-guard: Focused provider, renderer, and billing tests cover endpoint selection, thinking serialization, and unset cache-write behavior.
System-prompt-review: not applicable - No system prompt text or prompt construction is changed.
Documentation-impact: none - The change refreshes executable provider metadata while the existing configuration documentation remains accurate.

Checks:
- `go test ./internal/config ./internal/provider/openai ./internal/provider/anthropic ./internal/billing ./internal/provider`
- `git diff --check`
