### PR TITLE
fix(desktop): preserve IME mid-caret insertion / 修复中文输入法光标定位后首次插入丢失

### DIFF
--- a/desktop/frontend/src/__tests__/composer-ime-mid-caret.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-ime-mid-caret.test.tsx
@@ -1,0 +1,333 @@
+// Run: tsx src/__tests__/composer-ime-mid-caret.test.tsx
+//
+// Regression coverage for issue #8593: an unrelated React render while a
+// plain Composer textarea is composing must not restore the pre-IME value.
+
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { Composer } from "../components/Composer";
+import { LocaleProvider } from "../lib/i18n";
+import { ToastProvider } from "../lib/toast";
+import type { CollaborationMode, TokenMode, ToolApprovalMode } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  ok(actual === expected, actual === expected
+    ? label
+    : `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function flushTimers(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function drainFrames(count = 2): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await flushTimers();
+  }
+}
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function installDom() {
+  const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+  globalThis.Node = dom.window.Node;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+  globalThis.Event = dom.window.Event;
+  globalThis.CustomEvent = dom.window.CustomEvent;
+  globalThis.CompositionEvent = dom.window.CompositionEvent;
+  globalThis.InputEvent = dom.window.InputEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.File = dom.window.File;
+  globalThis.FileReader = dom.window.FileReader;
+  globalThis.PointerEvent = dom.window.MouseEvent as unknown as typeof PointerEvent;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.localStorage = dom.window.localStorage;
+  globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+  globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+  globalThis.ResizeObserver = TestResizeObserver;
+  Object.defineProperty(dom.window.HTMLElement.prototype, "attachEvent", { configurable: true, value: () => {} });
+  Object.defineProperty(dom.window.HTMLElement.prototype, "detachEvent", { configurable: true, value: () => {} });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent: () => false,
+    }),
+  });
+  return dom;
+}
+
+function installBridgeApp() {
+  (window as unknown as { go: { main: { App: Record<string, unknown> } } }).go = {
+    main: {
+      App: {
+        Commands: async () => [],
+        Models: async () => [],
+        ModelsForTab: async () => [],
+        ListDirForTab: async () => [],
+        SearchFileRefsForTab: async () => [],
+      },
+    },
+  };
+}
+
+async function renderComposer() {
+  const rootElement = document.getElementById("root");
+  if (!rootElement) throw new Error("missing root");
+  const root = createRoot(rootElement);
+  let props: Parameters<typeof Composer>[0] = {
+    running: false,
+    collaborationMode: "normal" as CollaborationMode,
+    toolApprovalMode: "ask" as ToolApprovalMode,
+    tokenMode: "full" as TokenMode,
+    goal: "",
+    cwd: "/repo",
+    modelLabel: "DeepSeek-R1",
+    imageInputEnabled: true,
+    tabId: "ime-tab",
+    sessionKey: "session:project:/repo:ime:session",
+    onSend: () => {},
+    onCancel: () => undefined,
+    onCycleMode: () => {},
+    onSetMode: () => {},
+    onSetCollaborationMode: () => {},
+    onSetToolApprovalMode: () => {},
+    onToggleYoloApprovalMode: () => {},
+    onClearGoal: () => {},
+    onSwitchModel: () => {},
+    onSetEffort: () => {},
+    onSetTokenMode: () => {},
+    ready: true,
+  };
+  const rerender = async (next: Partial<Parameters<typeof Composer>[0]> = {}) => {
+    props = { ...props, ...next };
+    await act(async () => {
+      root.render(
+        <LocaleProvider>
+          <ToastProvider>
+            <Composer {...props} />
+          </ToastProvider>
+        </LocaleProvider>,
+      );
+      await flushTimers();
+    });
+  };
+  await rerender();
+  return { root, rerender };
+}
+
+function textarea(): HTMLTextAreaElement {
+  const node = document.querySelector("#composer-input");
+  if (!(node instanceof HTMLTextAreaElement)) throw new Error("composer textarea did not render");
+  return node;
+}
+
+async function runProgrammaticReplacementScenario() {
+  const dom = installDom();
+  installBridgeApp();
+  const { root, rerender } = await renderComposer();
+  await rerender({ insertRequest: { id: 85931, text: "hello world", mode: "replace" } });
+  await act(async () => {
+    await drainFrames();
+  });
+
+  const input = textarea();
+  input.focus();
+  input.setSelectionRange(5, 5);
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+  if (!setter) throw new Error("textarea value setter is unavailable");
+  await act(async () => {
+    input.dispatchEvent(new window.CompositionEvent("compositionstart", { bubbles: true, data: "" }));
+    setter.call(input, "helloni world");
+    input.setSelectionRange(7, 7);
+    input.dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: "ni",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    }));
+    await flushTimers();
+  });
+
+  await rerender({ insertRequest: { id: 85932, text: "external replacement", mode: "replace" } });
+  eq(textarea().value, "external replacement", "a programmatic replacement cancels stale IME state");
+
+  await act(async () => {
+    await drainFrames();
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+async function runDraftSwitchScenario() {
+  const dom = installDom();
+  installBridgeApp();
+  const { root, rerender } = await renderComposer();
+  const firstSession = "session:project:/repo:ime:session";
+  await rerender({ insertRequest: { id: 85933, text: "hello world", mode: "replace" } });
+  await act(async () => {
+    await drainFrames();
+  });
+
+  const input = textarea();
+  input.focus();
+  input.setSelectionRange(5, 5);
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+  if (!setter) throw new Error("textarea value setter is unavailable");
+  await act(async () => {
+    input.dispatchEvent(new window.CompositionEvent("compositionstart", { bubbles: true, data: "" }));
+    await flushTimers();
+  });
+  await act(async () => {
+    setter.call(input, "helloni world");
+    input.setSelectionRange(7, 7);
+    input.dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: "ni",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    }));
+    await flushTimers();
+  });
+
+  await rerender({ sessionKey: "session:project:/repo:ime:other", insertRequest: null });
+  eq(textarea().value, "", "switching drafts clears the old active IME value");
+  await rerender({ sessionKey: firstSession, insertRequest: null });
+  eq(textarea().value, "helloni world", "switching back restores the composing draft snapshot");
+
+  await act(async () => {
+    await drainFrames();
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+async function main() {
+  const dom = installDom();
+  installBridgeApp();
+  const { root, rerender } = await renderComposer();
+  await rerender({ insertRequest: { id: 8593, text: "hello world", mode: "replace" } });
+  await act(async () => {
+    await drainFrames();
+  });
+
+  const input = textarea();
+  input.focus();
+  input.setSelectionRange(5, 5);
+  await act(async () => {
+    input.dispatchEvent(new window.CompositionEvent("compositionstart", { bubbles: true, data: "" }));
+    await flushTimers();
+  });
+
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+  if (!setter) throw new Error("textarea value setter is unavailable");
+  setter.call(input, "helloni world");
+  input.setSelectionRange(7, 7);
+  await act(async () => {
+    input.dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: "ni",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    }));
+    await flushTimers();
+  });
+
+  // This prop update stands in for the unrelated renders that occur in the
+  // desktop while an IME candidate window is open.
+  await rerender({ goal: "updated while composing" });
+  eq(textarea().value, "helloni world", "an unrelated render preserves the composing DOM value");
+  eq(textarea().selectionStart, 7, "an unrelated render preserves the IME caret");
+
+  // Chromium/WebView2 can briefly expose the pre-composition value at
+  // compositionend. The last native composition value must win that race.
+  setter.call(input, "hello world");
+  input.setSelectionRange(5, 5);
+  await act(async () => {
+    textarea().dispatchEvent(new window.CompositionEvent("compositionend", { bubbles: true, data: "你" }));
+    await flushTimers();
+  });
+  await act(async () => {
+    await flushTimers();
+    setter.call(textarea(), "hello world");
+    textarea().setSelectionRange(5, 5);
+    textarea().dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: "你",
+      inputType: "insertText",
+      isComposing: false,
+    }));
+    await flushTimers();
+  });
+  eq(textarea().value, "helloni world", "a stale post-composition DOM echo does not overwrite the candidate");
+  await act(async () => {
+    setter.call(textarea(), "helloni world");
+    textarea().setSelectionRange(7, 7);
+    textarea().dispatchEvent(new window.InputEvent("input", {
+      bubbles: true,
+      data: "你",
+      inputType: "insertText",
+      isComposing: false,
+    }));
+    await flushTimers();
+  });
+  eq(textarea().value, "helloni world", "a delayed final input keeps the committed IME candidate");
+  await act(async () => {
+    await drainFrames();
+  });
+  await rerender({ goal: "after composition" });
+  eq(textarea().value, "helloni world", "compositionend commits the native value to the controlled model");
+  eq(textarea().selectionStart, 7, "compositionend restores the caret after the committed text");
+
+  await act(async () => {
+    await drainFrames();
+    root.unmount();
+  });
+  dom.window.close();
+  await runProgrammaticReplacementScenario();
+  await runDraftSwitchScenario();
+
+  if (failed > 0) {
+    process.stderr.write(`\n${failed} assertion(s) failed\n`);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(`\n${passed} assertions passed\n`);
+  }
+}
+
+void main();

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -661,6 +661,11 @@ export function Composer({
   const draftKey = sessionKey || tabId || DEFAULT_COMPOSER_DRAFT_KEY;
   const now = useTick(running);
   const [text, setText] = useState("");
+  // During IME composition the browser owns the textarea value. Keeping the
+  // last native value here prevents an unrelated React render from writing the
+  // previous controlled value back into the textarea and cancelling the
+  // composition (Chromium then drops the first committed character).
+  const [plainCompositionActive, setPlainCompositionActive] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [imageViewer, setImageViewer] = useState<{ open: boolean; url: string; name: string }>({ open: false, url: "", name: "" });
   const openComposerImageViewer = useCallback((url: string, name: string) => {
@@ -746,6 +751,12 @@ export function Composer({
   const creationChrome = showContextWindowRing;
   const wasRunningByDraftRef = useRef<Record<string, boolean>>({ [draftKey]: running });
   const composingRef = useRef(false);
+  const plainCompositionValueRef = useRef<string | null>(null);
+  const plainCompositionStartValueRef = useRef<string | null>(null);
+  const plainCompositionSelectionRef = useRef<RichComposerSelection | null>(null);
+  const plainCompositionFinalizeFrameRef = useRef<number | null>(null);
+  const plainCompositionCancelRef = useRef<(commitNative?: boolean) => void>(() => {});
+  const plainCompositionHandlersRef = useRef({ start: () => {}, end: () => {} });
   const lastCompositionEndAt = useRef(0);
   const pastChatSearchComposingRef = useRef(false);
   const pastChatSearchLastCompositionEndAt = useRef(0);
@@ -790,8 +801,157 @@ export function Composer({
   pendingPasteRef.current = pendingPaste;
   submittingRef.current = submitting;
 
+  plainCompositionCancelRef.current = (commitNative = true) => {
+    const latest = plainCompositionValueRef.current ?? taRef.current?.value ?? textRef.current;
+    if (plainCompositionFinalizeFrameRef.current !== null) {
+      window.clearTimeout(plainCompositionFinalizeFrameRef.current);
+      plainCompositionFinalizeFrameRef.current = null;
+    }
+    composingRef.current = false;
+    if (commitNative) {
+      textRef.current = latest;
+      setText(latest);
+      const textarea = taRef.current;
+      if (textarea) {
+        const selection = plainCompositionSelectionRef.current ?? {
+          start: textarea.selectionStart ?? latest.length,
+          end: textarea.selectionEnd ?? latest.length,
+        };
+        lastSelectionRef.current = selection;
+        setPlainSelection(selection);
+      }
+    }
+    plainCompositionValueRef.current = null;
+    plainCompositionStartValueRef.current = null;
+    plainCompositionSelectionRef.current = null;
+    setPlainCompositionActive(false);
+  };
+
+  plainCompositionHandlersRef.current = {
+    start: () => {
+      if (plainCompositionFinalizeFrameRef.current !== null) {
+        window.clearTimeout(plainCompositionFinalizeFrameRef.current);
+        plainCompositionFinalizeFrameRef.current = null;
+      }
+      composingRef.current = true;
+      plainCompositionValueRef.current = taRef.current?.value ?? textRef.current;
+      plainCompositionStartValueRef.current = plainCompositionValueRef.current;
+      const textarea = taRef.current;
+      plainCompositionSelectionRef.current = textarea
+        ? { start: textarea.selectionStart ?? 0, end: textarea.selectionEnd ?? 0 }
+        : lastSelectionRef.current;
+      setPlainCompositionActive(true);
+    },
+    end: () => {
+      const next = plainCompositionValueRef.current ?? taRef.current?.value ?? textRef.current;
+      const textarea = taRef.current;
+      const nextSelection = plainCompositionSelectionRef.current ?? (textarea
+        ? { start: textarea.selectionStart ?? next.length, end: textarea.selectionEnd ?? next.length }
+        : lastSelectionRef.current);
+      composingRef.current = false;
+      lastCompositionEndAt.current = Date.now();
+      // Keep the native value as the rendered value until the browser has
+      // delivered any follow-up non-composing input event. Chromium/WebView2
+      // differ on whether that event precedes or follows compositionend.
+      plainCompositionValueRef.current = next;
+      textRef.current = next;
+      lastSelectionRef.current = nextSelection;
+      setPlainSelection(nextSelection);
+      setText(next);
+      setPlainCompositionActive(true);
+      plainCompositionFinalizeFrameRef.current = window.setTimeout(() => {
+        plainCompositionFinalizeFrameRef.current = null;
+        const latest = plainCompositionValueRef.current ?? taRef.current?.value ?? next;
+        const latestSelection = plainCompositionSelectionRef.current;
+        textRef.current = latest;
+        setText(latest);
+        if (latestSelection) {
+          lastSelectionRef.current = latestSelection;
+          setPlainSelection(latestSelection);
+          const active = document.activeElement;
+          const currentTextarea = taRef.current;
+          if (currentTextarea && active === currentTextarea && latestSelection.start <= latest.length && latestSelection.end <= latest.length) {
+            currentTextarea.setSelectionRange(latestSelection.start, latestSelection.end);
+          }
+        }
+        plainCompositionValueRef.current = null;
+        plainCompositionStartValueRef.current = null;
+        plainCompositionSelectionRef.current = null;
+        setPlainCompositionActive(false);
+      }, 250);
+    },
+  };
+
+  useLayoutEffect(() => {
+    if (!plainCompositionActive || plainCompositionValueRef.current === null) return;
+    if (text !== plainCompositionValueRef.current || invocations.length > 0) plainCompositionCancelRef.current(false);
+  }, [invocations.length, plainCompositionActive, text]);
+
+  useLayoutEffect(() => {
+    const textarea = taRef.current;
+    if (!textarea) return;
+    const onCompositionStart = () => plainCompositionHandlersRef.current.start();
+    const onCompositionEnd = () => plainCompositionHandlersRef.current.end();
+    const rememberCompositionSelection = () => {
+      plainCompositionSelectionRef.current = {
+        start: textarea.selectionStart ?? textarea.value.length,
+        end: textarea.selectionEnd ?? textarea.value.length,
+      };
+    };
+    const onCompositionUpdate = () => {
+      if (plainCompositionValueRef.current !== null) {
+        plainCompositionValueRef.current = textarea.value;
+        rememberCompositionSelection();
+      }
+    };
+    const onInput = () => {
+      const currentValue = textarea.value;
+      const stalePostCompositionEcho = !composingRef.current
+        && plainCompositionStartValueRef.current !== null
+        && currentValue === plainCompositionStartValueRef.current
+        && plainCompositionValueRef.current !== null
+        && currentValue !== plainCompositionValueRef.current;
+      if (stalePostCompositionEcho) {
+        // WebView2 can briefly expose the pre-composition value in this slot.
+        // Restore the candidate before React's delegated onChange listener sees
+        // the event; otherwise its controlled echo would overwrite the commit.
+        const committed = plainCompositionValueRef.current;
+        if (committed !== null) {
+          textarea.value = committed;
+          const selection = plainCompositionSelectionRef.current;
+          if (selection && selection.start <= committed.length && selection.end <= committed.length) {
+            textarea.setSelectionRange(selection.start, selection.end);
+          }
+        }
+      } else if (plainCompositionValueRef.current !== null) {
+        plainCompositionValueRef.current = currentValue;
+        rememberCompositionSelection();
+      }
+      if (!stalePostCompositionEcho && !composingRef.current && plainCompositionValueRef.current !== null) {
+        plainCompositionCancelRef.current();
+      }
+    };
+    textarea.addEventListener("compositionstart", onCompositionStart);
+    textarea.addEventListener("compositionupdate", onCompositionUpdate);
+    textarea.addEventListener("compositionend", onCompositionEnd);
+    textarea.addEventListener("input", onInput);
+    return () => {
+      textarea.removeEventListener("compositionstart", onCompositionStart);
+      textarea.removeEventListener("compositionupdate", onCompositionUpdate);
+      textarea.removeEventListener("compositionend", onCompositionEnd);
+      textarea.removeEventListener("input", onInput);
+    };
+  }, [invocations.length]);
+
+  useLayoutEffect(() => () => {
+    if (plainCompositionFinalizeFrameRef.current !== null) {
+      window.clearTimeout(plainCompositionFinalizeFrameRef.current);
+      plainCompositionFinalizeFrameRef.current = null;
+    }
+  }, []);
+
   const snapshotComposerDraft = (): ComposerDraft => ({
-    text: textRef.current,
+    text: plainCompositionValueRef.current ?? textRef.current,
     invocations: invocationsRef.current.map((invocation) => ({ ...invocation, command: { ...invocation.command } })),
     attachments: [...attachmentsRef.current],
     workspaceRefs: [...workspaceRefsRef.current],
@@ -811,6 +971,7 @@ export function Composer({
   });
 
   const restoreComposerDraft = (draft: ComposerDraft) => {
+    plainCompositionCancelRef.current(false);
     const next = cloneComposerDraft(draft);
     textRef.current = next.text;
     invocationsRef.current = next.invocations;
@@ -1131,6 +1292,7 @@ export function Composer({
     const previousKey = activeDraftKeyRef.current;
     if (previousKey === draftKey) return;
     draftsBySessionRef.current[previousKey] = snapshotComposerDraft();
+    plainCompositionCancelRef.current(false);
     draftActivationEpochRef.current += 1;
     activeDraftKeyRef.current = draftKey;
     setGuidanceDraftKey(draftKey);
@@ -1626,6 +1788,7 @@ export function Composer({
   };
 
   const setTextCaretEnd = (next: string, trackEdit = true) => {
+    plainCompositionCancelRef.current(false);
     const targetDraftKey = activeDraftKeyRef.current;
     const beforeEdit = trackEdit ? composerEditSnapshot(targetDraftKey) : null;
     textRef.current = next;
@@ -1654,6 +1817,7 @@ export function Composer({
   };
 
   const insertNewlineAtCaret = () => {
+    plainCompositionCancelRef.current(false);
     const selection = getComposerSelection();
     const targetDraftKey = activeDraftKeyRef.current;
     const beforeEdit = composerEditSnapshot(targetDraftKey, selection);
@@ -1672,6 +1836,7 @@ export function Composer({
   };
 
   const insertTextAtCaret = (snippet: string) => {
+    plainCompositionCancelRef.current(false);
     const selection = getComposerSelection();
     const targetDraftKey = activeDraftKeyRef.current;
     const beforeEdit = composerEditSnapshot(targetDraftKey, selection);
@@ -2379,6 +2544,7 @@ export function Composer({
     // reconciliation cannot race with the native DOM update and lose the
     // pasted content (WebView2 / Windows). We insert the text manually below.
     e.preventDefault();
+    plainCompositionCancelRef.current(false);
     const selection = getComposerSelection();
     const start = selection.start;
     const end = selection.end;
@@ -4565,17 +4731,25 @@ export function Composer({
                   ref={taRef}
                   className="composer__input"
                   aria-label={t("composer.placeholder")} spellCheck={false} autoCorrect="off" autoCapitalize="off"
-                  value={text}
+                  value={plainCompositionActive ? (plainCompositionValueRef.current ?? text) : text}
                   onInputCapture={(e) => {
-                    pendingNativeInputTypeRef.current = (e.nativeEvent as InputEvent).inputType;
+                    const nativeEvent = e.nativeEvent as InputEvent;
+                    pendingNativeInputTypeRef.current = nativeEvent.inputType;
+                    if (composingRef.current || nativeEvent.isComposing) {
+                      plainCompositionValueRef.current = e.currentTarget.value;
+                    }
                   }}
                   onChange={(e) => {
                     const targetDraftKey = activeDraftKeyRef.current;
+                    const compositionActive = composingRef.current || plainCompositionValueRef.current !== null;
                     const inputType = (e.nativeEvent as InputEvent).inputType
                       || pendingNativeInputTypeRef.current;
                     pendingNativeInputTypeRef.current = undefined;
                     resetPromptHistoryNavigation();
                     textRef.current = e.target.value;
+                    if (compositionActive) {
+                      plainCompositionValueRef.current = e.target.value;
+                    }
                     setText(e.target.value);
                     const nextSelection = {
                       start: e.target.selectionStart ?? e.target.value.length,
@@ -4583,7 +4757,7 @@ export function Composer({
                     };
                     lastSelectionRef.current = nextSelection;
                     setPlainSelection(nextSelection);
-                    syncComposerNativeHistory(targetDraftKey, inputType);
+                    if (!compositionActive) syncComposerNativeHistory(targetDraftKey, inputType);
                     if (composerPrompt) setComposerPrompt(null);
                   }}
                   onSelect={rememberCaret}
@@ -4593,13 +4767,6 @@ export function Composer({
                   onContextMenu={openInputMenu}
                   onPaste={onPaste}
                   onKeyDown={onKeyDown}
-                  onCompositionStart={() => {
-                    composingRef.current = true;
-                  }}
-                  onCompositionEnd={() => {
-                    composingRef.current = false;
-                    lastCompositionEndAt.current = Date.now();
-                  }}
                   style={textareaStyle}
                   placeholder={composerPlaceholder}
                   rows={1}


### PR DESCRIPTION
## Summary

- Preserve the latest native plain-textarea value while an IME composition is active so unrelated React renders cannot write the previous controlled value back into the DOM.
- Recover the committed candidate and caret when Chromium/WebView2 exposes a stale pre-composition value around `compositionend`, while cancelling composition state before external text, draft, or editor replacements.
- Add focused regression coverage for mid-caret composition, stale post-composition echoes, delayed final input, programmatic replacement, and draft switching.

## Issues

Fixes #8593

## Verification

- [x] `pnpm exec tsx src/__tests__/composer-ime-mid-caret.test.tsx` (9 assertions)
- [x] `pnpm exec tsx src/__tests__/composer-goal-toggle.test.tsx` (230 passed)
- [x] `pnpm exec tsx src/__tests__/composer-session-draft.test.tsx` (129 passed)
- [x] `pnpm exec tsx src/__tests__/composer-context-menu-clipboard.test.tsx` (15 passed)
- [x] `pnpm exec tsx src/__tests__/composer-run-strip.test.tsx` (63 passed)
- [x] `pnpm exec tsx src/__tests__/rich-composer-selection.test.tsx` (102 passed)
- [x] `pnpm exec tsx src/__tests__/composer-keyboard.test.ts` (50 passed)
- [x] `pnpm test:typecheck`
- [x] `pnpm lint:hooks`
- [x] `pnpm test:todo-visibility`
- [x] `pnpm build`
- [x] Real Chromium Playwright event-sequence probe: composing value, stale post-`compositionend` echo, delayed final input, and caret all remained correct.
- [x] `git diff --check`

The broader `pnpm test` command was also attempted. Its pretest `TaskMonitorPanel.test.tsx` suite currently reports 17 unrelated failures for missing task buttons; that suite and its source are outside this change. The focused Composer suites, test typecheck, lint, and production build pass.

## Documentation impact

Documentation-impact: none - this restores existing textarea input behavior without changing user-facing controls, configuration, or documented workflows.

## Cache impact

Cache-impact: none - the change is limited to local Composer composition state, caret recovery, and draft lifecycle handling; prompts, tools, provider-visible serialization, and caches are unchanged.

Cache-guard: N/A - focused regression coverage protects the affected desktop IME path and its draft/replacement boundaries.

System-prompt-review: N/A