### PR TITLE
fix(acp): expose authoritative session token totals / 修复 ACP 会话令牌重复统计

### DIFF
--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -103,30 +103,6 @@ type ReasonixFinalReadiness struct {
 	Risks          []string `json:"risks"`
 }
 
-type ReasonixUsage struct {
-	PromptTokens     int                `json:"promptTokens"`
-	CompletionTokens int                `json:"completionTokens"`
-	ReasoningTokens  int                `json:"reasoningTokens"`
-	CacheHitTokens   int                `json:"cacheHitTokens"`
-	CacheMissTokens  int                `json:"cacheMissTokens"`
-	Estimated        bool               `json:"estimated,omitempty"`
-	CacheHitRatio    *float64           `json:"cacheHitRatio"`
-	EstimatedCost    *float64           `json:"estimatedCost"`
-	Currency         *string            `json:"currency"`
-	CostComplete     *bool              `json:"costComplete,omitempty"`
-	DisplayComplete  *bool              `json:"displayComplete,omitempty"`
-	DisplayStatus    string             `json:"displayStatus,omitempty"`
-	AggregateMode    string             `json:"aggregateMode,omitempty"`
-	OriginalTotals   []billing.Money    `json:"originalTotals,omitempty"`
-	CostQuote        *billing.CostQuote `json:"costQuote,omitempty"`
-	UsageSource      string             `json:"usageSource"`
-}
-
-type ReasonixStatusUsage struct {
-	Turn       ReasonixUsage `json:"turn"`
-	Cumulative ReasonixUsage `json:"cumulative"`
-}
-
 // ReasonixSessionStatus is the stable schemaVersion=1 recovery snapshot.
 // Reasoning text and unbounded terminal output are intentionally absent.
 type ReasonixSessionStatus struct {
@@ -253,6 +229,7 @@ func (a *usageAccumulator) addQuoted(u *provider.Usage, pricing *provider.Pricin
 
 func (a usageAccumulator) wire() ReasonixUsage {
 	usage := ReasonixUsage{
+		TotalTokens:      a.promptTokens + a.completionTokens,
 		PromptTokens:     a.promptTokens,
 		CompletionTokens: a.completionTokens,
 		ReasoningTokens:  a.reasoningTokens,

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -42,6 +42,33 @@ func TestUsageAccumulatorTotalsMoreThanAuditLimit(t *testing.T) {
 	}
 }
 
+func TestUsageAccumulatorExposesAuthoritativeTotalWithoutCacheDoubleCount(t *testing.T) {
+	var accumulator usageAccumulator
+	accumulator.addQuoted(&provider.Usage{
+		PromptTokens: 1_000, CompletionTokens: 500, ReasoningTokens: 300,
+		CacheHitTokens: 800, CacheMissTokens: 200,
+	}, nil, nil, event.UsageSourceExecutor)
+
+	wire := accumulator.wire()
+	if wire.TotalTokens != 1_500 {
+		t.Fatalf("total tokens = %d, want 1500: %+v", wire.TotalTokens, wire)
+	}
+	if wire.PromptTokens != wire.CacheHitTokens+wire.CacheMissTokens {
+		t.Fatalf("cache split no longer partitions prompt tokens: %+v", wire)
+	}
+}
+
+func TestRestoreUsageReconstructsTotalTokensFromLegacySnapshot(t *testing.T) {
+	wire := restoreUsage(persistedUsageAccumulator{
+		PromptTokens: 1_000, CompletionTokens: 500,
+		CacheHitTokens: 800, CacheMissTokens: 200,
+	}).wire()
+
+	if wire.TotalTokens != 1_500 {
+		t.Fatalf("restored total tokens = %d, want 1500: %+v", wire.TotalTokens, wire)
+	}
+}
+
 func TestRestoredUsageKeepsFullScalarTotalAfterNewQuote(t *testing.T) {
 	complete := true
 	accumulator := restoreUsage(persistedUsageAccumulator{
@@ -151,7 +178,7 @@ func TestStatusExtensionTracksMultipleSessionsAndUsage(t *testing.T) {
 		t.Fatalf("effective runtime status = %+v", firstStatus)
 	}
 	usage := firstStatus.Usage.Cumulative
-	if usage.PromptTokens != 15 || usage.CompletionTokens != 5 || usage.ReasoningTokens != 2 || usage.CacheHitTokens != 7 || usage.CacheMissTokens != 8 {
+	if usage.TotalTokens != 20 || usage.PromptTokens != 15 || usage.CompletionTokens != 5 || usage.ReasoningTokens != 2 || usage.CacheHitTokens != 7 || usage.CacheMissTokens != 8 {
 		t.Fatalf("cumulative usage = %+v", usage)
 	}
 	if usage.UsageSource != "mixed" || usage.CacheHitRatio == nil || usage.EstimatedCost == nil || usage.Currency == nil || *usage.Currency != "USD" {

--- a/internal/acp/status_usage.go
+++ b/internal/acp/status_usage.go
@@ -1,0 +1,29 @@
+package acp
+
+import "reasonix/internal/billing"
+
+// ReasonixUsage reports inclusive totals alongside cache and reasoning subsets.
+type ReasonixUsage struct {
+	TotalTokens      int                `json:"totalTokens"`
+	PromptTokens     int                `json:"promptTokens"`
+	CompletionTokens int                `json:"completionTokens"`
+	ReasoningTokens  int                `json:"reasoningTokens"`
+	CacheHitTokens   int                `json:"cacheHitTokens"`
+	CacheMissTokens  int                `json:"cacheMissTokens"`
+	Estimated        bool               `json:"estimated,omitempty"`
+	CacheHitRatio    *float64           `json:"cacheHitRatio"`
+	EstimatedCost    *float64           `json:"estimatedCost"`
+	Currency         *string            `json:"currency"`
+	CostComplete     *bool              `json:"costComplete,omitempty"`
+	DisplayComplete  *bool              `json:"displayComplete,omitempty"`
+	DisplayStatus    string             `json:"displayStatus,omitempty"`
+	AggregateMode    string             `json:"aggregateMode,omitempty"`
+	OriginalTotals   []billing.Money    `json:"originalTotals,omitempty"`
+	CostQuote        *billing.CostQuote `json:"costQuote,omitempty"`
+	UsageSource      string             `json:"usageSource"`
+}
+
+type ReasonixStatusUsage struct {
+	Turn       ReasonixUsage `json:"turn"`
+	Cumulative ReasonixUsage `json:"cumulative"`
+}


### PR DESCRIPTION
## Summary

ACP session status now exposes `totalTokens` as the authoritative inclusive total while preserving prompt, completion, reasoning, and cache fields as breakdowns.

Problem

`usage.turn` and `usage.cumulative` exposed `promptTokens`, `completionTokens`, `reasoningTokens`, `cacheHitTokens`, and `cacheMissTokens`, but no authoritative total. Hosts summing every field counted cached input twice because `cacheHitTokens + cacheMissTokens` partitions `promptTokens`; reasoning is likewise a subset of completion.

Root cause

The status accumulator retained the provider's inclusive prompt count and its cache breakdown correctly, but the wire schema gave consumers no unambiguous total field.

Fix

Add `totalTokens = promptTokens + completionTokens` to the schema-v1 usage payload. Existing breakdown fields remain unchanged for compatibility. The total is derived when serializing status, so legacy persisted snapshots also receive the correct value after restore.

中文摘要

为 ACP 会话状态新增权威 `totalTokens` 字段，避免宿主把 prompt 与缓存命中/未命中拆分重复相加；保留现有明细字段，并兼容旧会话快照。

## Issues

Fixes #8668

## Verification

- [x] `go test -count=1 ./internal/acp`
- [x] `go vet ./internal/acp`
- [x] `go run ./tools/repolint`
- [x] `git diff --check`
- [ ] `go test ./...` on this Windows host: unrelated environment-sensitive failures require symlink privileges, Git Bash, and an executable bundled `rg.exe`; `internal/acp` passed in the same run.

## Documentation impact

Documentation-impact: none - the vendor status extension remains schema v1 and existing fields retain their meanings; the new self-describing total is covered by wire-level tests.

## Cache impact

Cache-impact: none - status telemetry serialization only; provider prompts, tool schemas, and cache keys are unchanged.
Cache-guard: `go test -count=1 ./internal/acp`
System-prompt-review: N/A