### PR TITLE
sessioncatalog: don't raise last_activity_at from file mtime

### DIFF
--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -374,14 +374,19 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 	metaFingerprint := fileFingerprint(agent.BranchMetaPath(info.Path))
 	createdAt := unixMilli(info.CreatedAt)
 	lastActivityAt := unixMilli(info.LastActivityAt)
-	// File mtime is a hard floor. Migration/meta can temporarily write zero
-	// UpdatedAt; without this, topics sort as inactive and look "missing".
+	// File mtime is only a fallback for missing authoritative timestamps.
+	// It must not act as a floor that raises a valid UpdatedAt: any external
+	// touch (backup, sync, cloud mirror, antivirus, or a projection rebuild
+	// that rewrites sidecars) advances mtime without representing real user
+	// activity, and would otherwise stamp every historical session as "just
+	// now". The meta UpdatedAt (already preferred by ListSessionOrder /
+	// IndexSessionPath) is the source of truth for recency.
 	if st, err := os.Stat(info.Path); err == nil {
 		fileMS := st.ModTime().UnixMilli()
 		if createdAt <= 0 {
 			createdAt = fileMS
 		}
-		if lastActivityAt <= 0 || fileMS > lastActivityAt {
+		if lastActivityAt <= 0 {
 			lastActivityAt = fileMS
 		}
 	}

--- a/internal/sessioncatalog/reconcile_test.go
+++ b/internal/sessioncatalog/reconcile_test.go
@@ -1,0 +1,70 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+// TestReconcileDoesNotRaiseLastActivityFromFileMtime guards against a recency
+// regression: an external touch (backup, sync, cloud mirror, antivirus scan, or
+// a projection rebuild that rewrites sidecars) advances the .jsonl mtime
+// without representing real user activity. The catalog must keep the
+// authoritative meta UpdatedAt instead of stamping every historical session as
+// "just now".
+func TestReconcileDoesNotRaiseLastActivityFromFileMtime(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	past := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+		Scope:         "global",
+		TopicID:       "topic",
+		TopicTitle:    "Topic",
+		SchemaVersion: agent.BranchMetaCountsVersion,
+		Turns:         1,
+		CreatedAt:     past,
+		UpdatedAt:     past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a later external touch that advances only the file mtime.
+	later := time.Now()
+	if err := os.Chtimes(path, later, later); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{
+		Path:          filepath.Join(t.TempDir(), "catalog.sqlite"),
+		DisableRepair: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := catalog.ListTopics(ctx, TopicPageRequest{Scope: "global", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("items = %d, want 1", len(page.Items))
+	}
+	if got, want := page.Items[0].LastActivityAt, past.UnixMilli(); got != want {
+		t.Fatalf("lastActivityAt = %d, want %d (meta UpdatedAt must not be raised by file mtime)", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

After a Reasonix upgrade/restart — or any external touch of session `.jsonl` files (backup, sync, cloud mirror, antivirus scan, or the projection rebuild that rewrites sidecars) — every historical session in the sidebar suddenly shows as "just now". The catalog's `last_activity_at` for all topics gets overwritten with the current file mtime, so real recency ordering is lost.

## Root cause

`internal/sessioncatalog/reconcile.go` → `recordFromOrder` used the `.jsonl` file mtime as a *hard floor* for `last_activity_at`:

```go
if lastActivityAt <= 0 || fileMS > lastActivityAt {
    lastActivityAt = fileMS
}
```

`ListSessionOrder` (and `IndexSessionPath`) already prefer the authoritative `meta.UpdatedAt` from the branch-meta sidecar. The extra `fileMS > lastActivityAt` branch then raises that valid `UpdatedAt` to the current mtime whenever the file is touched without real user activity — stamping every historical session as "just now".

## Fix

File mtime is now only a fallback when the authoritative meta timestamps are missing (`lastActivityAt <= 0`); it no longer raises a valid `UpdatedAt`.

## Test

Added `TestReconcileDoesNotRaiseLastActivityFromFileMtime`: writes a session whose `UpdatedAt` is in the past, advances only the file mtime, reconciles, and asserts `last_activity_at` stays at the meta value.

Note: I don't have a Go toolchain on this machine, so I couldn't run `go test ./internal/sessioncatalog/` locally — flagging so CI can confirm.

Cache-impact: none
Cache-guard: no prompt/skill/cache surface touched; change is isolated to session-catalog recency sorting.
