### PR TITLE
fix(desktop): stop old sessions flipping back to unread / 修复旧会话反复变成未读

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   projectTreeShouldSuppressOpenForRename,
   projectTreeReadActivityKey,
   projectTreeTopicHasUnreadActivity,
+  topicIsActive,
   projectTreeTopicArchiveBlocked,
   projectTreeShouldRenderTopicActions,
   projectTreeTopicMetaLine,
@@ -209,6 +210,34 @@ eq(
   projectTreeTopicHasUnreadActivity({ ...completedTopic, status: "streaming", running: true }, { [completedTopicKey]: 1000 }, "project", "/repo", "other-topic"),
   false,
   "running topic keeps runtime status instead of completed-unread attention",
+);
+
+const relocatedTopic = { ...completedTopic, sessionPath: "/s/b.jsonl" };
+const relocatedKey = projectTreeReadActivityKey({ ...completedTopic, sessionPath: "/s/a.jsonl" }) ?? "";
+eq(
+  projectTreeReadActivityKey(relocatedTopic),
+  relocatedKey,
+  "unread key stays on the logical topic when the representative path changes",
+);
+eq(
+  projectTreeTopicHasUnreadActivity(relocatedTopic, { [relocatedKey]: 2000 }, "project", "/repo", "other-topic"),
+  false,
+  "marking a topic read survives a later representative-path refresh",
+);
+eq(
+  projectTreeTopicHasUnreadActivity(completedTopic, {}, "project", "/repo", "other-topic", undefined, 2000),
+  false,
+  "activity at or before the first-seen baseline is not unread",
+);
+eq(
+  projectTreeTopicHasUnreadActivity(completedTopic, {}, "project", "/repo", "other-topic", undefined, 1999),
+  true,
+  "activity newer than the first-seen baseline is unread",
+);
+eq(
+  topicIsActive({ ...completedTopic, sessionPath: "/s/a.jsonl" }, "project", "/repo", "topic-complete", "/s/other.jsonl"),
+  true,
+  "logical topic stays active when the representative path is not the open file",
 );
 
 for (const status of ["thinking", "streaming", "waiting_confirmation", "background_job"] as const) {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -77,7 +77,7 @@ const WORKBENCH_ORGANIZE_KEY = "projectTree:workbenchOrganize";
 // Shared by classic and workbench; key string kept for existing saved choices.
 const WORKBENCH_SORT_KEY = "projectTree:workbenchSort";
 const READ_ACTIVITY_KEY = "projectTree:readActivity";
-const READ_ACTIVITY_INIT_KEY = "projectTree:readActivityInitialized";
+const READ_ACTIVITY_BASELINE_KEY = "projectTree:readActivityBaselineAt";
 
 function loadReadActivity(): ProjectTreeReadActivity {
   try {
@@ -99,6 +99,18 @@ function saveReadActivity(readActivity: ProjectTreeReadActivity) {
     localStorage.setItem(READ_ACTIVITY_KEY, JSON.stringify(readActivity));
   } catch {
     /* localStorage unavailable */
+  }
+}
+
+function loadReadActivityBaselineAt(): number {
+  try {
+    const parsed = Number(localStorage.getItem(READ_ACTIVITY_BASELINE_KEY));
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    const now = Date.now();
+    localStorage.setItem(READ_ACTIVITY_BASELINE_KEY, String(now));
+    return now;
+  } catch {
+    return Date.now();
   }
 }
 
@@ -431,6 +443,7 @@ export function ProjectTree({
   const [workbenchOrganizeMode, setWorkbenchOrganizeMode] = useState<WorkbenchOrganizeMode>(loadWorkbenchOrganizeMode);
   const [workbenchSortMode, setWorkbenchSortMode] = useState<WorkbenchSortMode>(loadWorkbenchSortMode);
   const [readActivity, setReadActivity] = useState<ProjectTreeReadActivity>(loadReadActivity);
+  const [readBaselineAt] = useState(loadReadActivityBaselineAt);
   const filterRef = useRef<HTMLDivElement>(null);
   const filterTriggerRef = useRef<HTMLButtonElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -601,51 +614,13 @@ export function ProjectTree({
     const activityAt = topicActivityAt(node);
     if (!key || activityAt <= 0) return;
     setReadActivity((prev) => {
-      if ((prev[key] ?? 0) >= activityAt) return prev;
-      const next = { ...prev, [key]: activityAt };
+      const readAt = Math.max(activityAt, Date.now());
+      if ((prev[key] ?? 0) >= readAt) return prev;
+      const next = { ...prev, [key]: readAt };
       saveReadActivity(next);
       return next;
     });
   }, []);
-
-  useEffect(() => {
-    if (tree.length === 0) return;
-    try {
-      if (localStorage.getItem(READ_ACTIVITY_INIT_KEY)) return;
-    } catch {
-      return;
-    }
-    const baseline: ProjectTreeReadActivity = {};
-    const collectBaseline = (nodes: ProjectNode[]) => {
-      for (const node of nodes) {
-        if ((isTopicNode(node) || isRuntimeSessionNode(node)) && topicStatus(node) === "") {
-          const key = projectTreeReadActivityKey(node);
-          const activityAt = topicActivityAt(node);
-          if (key && activityAt > 0) baseline[key] = Math.max(baseline[key] ?? 0, activityAt);
-        }
-        collectBaseline(asArray(node.children));
-      }
-    };
-    collectBaseline(tree);
-    try {
-      localStorage.setItem(READ_ACTIVITY_INIT_KEY, "1");
-    } catch {
-      /* localStorage unavailable */
-    }
-    if (Object.keys(baseline).length === 0) return;
-    setReadActivity((prev) => {
-      const next = { ...prev };
-      let changed = false;
-      for (const [key, value] of Object.entries(baseline)) {
-        if ((next[key] ?? 0) >= value) continue;
-        next[key] = value;
-        changed = true;
-      }
-      if (!changed) return prev;
-      saveReadActivity(next);
-      return next;
-    });
-  }, [tree]);
 
   useEffect(() => {
     const markActive = (nodes: ProjectNode[]) => {
@@ -1191,7 +1166,7 @@ export function ProjectTree({
       const showStatusInSide = status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job";
       const showWaitingPill = waitingConfirmation;
       const showSideTime = sideTimeVisible && !showWaitingPill;
-      const unread = projectTreeTopicHasUnreadActivity(node, readActivity, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
+      const unread = projectTreeTopicHasUnreadActivity(node, readActivity, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath, readBaselineAt);
       const topicId = node.topicId ?? "";
       const topicTrashing = trashingTopics.has(topicId);
       const imSource = scope === "global" && topicId ? imTopicSources[topicId] : undefined;

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -105,16 +105,21 @@ export function projectTreeFolderDisclosure(hasChildren: boolean, isExpanded: bo
   };
 }
 
+function topicMatchesActiveIdentity(node: ProjectNode, activeScope?: string, activeWorkspaceRoot?: string, activeTopicId?: string): boolean {
+  if (!node.topicId || !activeTopicId) return false;
+  const scope = node.kind === "global_topic" || node.kind === "global_session" ? "global" : "project";
+  if (scope === "global") return activeScope === "global" && activeTopicId === node.topicId;
+  return activeScope === "project" && activeTopicId === node.topicId && activeWorkspaceRoot === node.root;
+}
+
 export function topicIsActive(node: ProjectNode, activeScope?: string, activeWorkspaceRoot?: string, activeTopicId?: string, activeSessionPath?: string): boolean {
-  if (!isTopicNode(node) && !isRuntimeSessionNode(node)) return false;
-  if (node.sessionPath) return Boolean(activeSessionPath && activeSessionPath === node.sessionPath);
+  if (isRuntimeSessionNode(node)) {
+    return Boolean(node.sessionPath && activeSessionPath && activeSessionPath === node.sessionPath);
+  }
+  if (!isTopicNode(node)) return false;
   if (activeSessionPath && asArray(node.children).some(isRuntimeSessionNode)) return false;
-  const scope = node.kind === "global_topic" ? "global" : "project";
-  return (
-    activeTopicId === node.topicId &&
-    activeScope === scope &&
-    (scope === "global" || activeWorkspaceRoot === node.root)
-  );
+  if (topicMatchesActiveIdentity(node, activeScope, activeWorkspaceRoot, activeTopicId)) return true;
+  return Boolean(node.sessionPath && activeSessionPath && activeSessionPath === node.sessionPath);
 }
 
 export function projectTreeTopicMetaLine(node: ProjectNode, t: Translator, compact = false): string {
@@ -208,12 +213,7 @@ export function topicActivityAt(node: ProjectNode): number {
 export function projectTreeReadActivityKey(node: ProjectNode): string | null {
   const request = projectTreeTopicOpenRequest(node);
   if (!request?.topicId) return null;
-  return [
-    request.scope,
-    request.workspaceRoot,
-    request.topicId,
-    request.sessionPath ?? "",
-  ].join("\u001f");
+  return [request.scope, request.workspaceRoot, request.topicId].join("\u001f");
 }
 
 export type ProjectTreeReadActivity = Record<string, number>;
@@ -225,13 +225,16 @@ export function projectTreeTopicHasUnreadActivity(
   activeWorkspaceRoot?: string,
   activeTopicId?: string,
   activeSessionPath?: string,
+  baselineAt = 0,
 ): boolean {
   if (!isTopicNode(node) && !isRuntimeSessionNode(node)) return false;
   if (topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) return false;
+  if (topicMatchesActiveIdentity(node, activeScope, activeWorkspaceRoot, activeTopicId)) return false;
   if (topicStatus(node) !== "") return false;
   const key = projectTreeReadActivityKey(node);
   const activityAt = topicActivityAt(node);
-  return Boolean(key && activityAt > 0 && (readActivity[key] ?? 0) < activityAt);
+  const readAt = Math.max(readActivity[key] ?? 0, baselineAt);
+  return Boolean(key && activityAt > 0 && readAt < activityAt);
 }
 
 export function projectTreeShouldRenderTopicActions(isSessionNode: boolean, variant: ProjectTreeVariant, unread: boolean): boolean {

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -233,8 +233,8 @@ export function projectTreeTopicHasUnreadActivity(
   if (topicStatus(node) !== "") return false;
   const key = projectTreeReadActivityKey(node);
   const activityAt = topicActivityAt(node);
-  const readAt = Math.max(readActivity[key] ?? 0, baselineAt);
-  return Boolean(key && activityAt > 0 && readAt < activityAt);
+  if (!key || activityAt <= 0) return false;
+  return Math.max(readActivity[key] ?? 0, baselineAt) < activityAt;
 }
 
 export function projectTreeShouldRenderTopicActions(isSessionNode: boolean, variant: ProjectTreeVariant, unread: boolean): boolean {

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -253,8 +253,14 @@ func saveBranchMeta(sessionPath string, m BranchMeta, touchUpdated bool) error {
 	if m.CreatedAt.IsZero() {
 		m.CreatedAt = now
 	}
-	if touchUpdated || m.UpdatedAt.IsZero() {
+	if touchUpdated {
 		m.UpdatedAt = now
+	} else if m.UpdatedAt.IsZero() {
+		if info, err := os.Stat(sessionPath); err == nil {
+			m.UpdatedAt = info.ModTime().UTC()
+		} else {
+			m.UpdatedAt = now
+		}
 	}
 	if existing, ok, err := LoadBranchMeta(sessionPath); err == nil && ok {
 		preserveBranchMetaPersistence(&m, existing)

--- a/internal/agent/branch_test.go
+++ b/internal/agent/branch_test.go
@@ -290,6 +290,37 @@ func TestSessionInFlightTurnMetaRoundTrip(t *testing.T) {
 	}
 }
 
+func TestUpdateBranchMetaWithoutTouchUsesFileMtimeForZeroUpdatedAt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	when := time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(BranchMetaPath(path), []byte(`{"id":"session","created_at":"2026-02-03T04:05:06Z","updated_at":"0001-01-01T00:00:00Z"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpdateBranchMeta(path, false, func(meta *BranchMeta) error {
+		meta.TopicID = "topic"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if !got.UpdatedAt.Equal(when.UTC()) {
+		t.Fatalf("UpdatedAt = %v, want file mtime %v (listing writes must not mint wall-clock activity)", got.UpdatedAt, when.UTC())
+	}
+	if got.TopicID != "topic" {
+		t.Fatalf("TopicID = %q, want topic", got.TopicID)
+	}
+}
+
 func TestSessionModelRoundTripPreservesActivity(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/sessioncatalog/activity_time_test.go
+++ b/internal/sessioncatalog/activity_time_test.go
@@ -1,0 +1,84 @@
+package sessioncatalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+)
+
+func TestReconcileKeepsSidecarActivityWhenFileMtimeIsNewer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	activity := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+		CreatedAt:     activity,
+		UpdatedAt:     activity,
+		Scope:         "global",
+		TopicID:       "topic-old",
+		TopicTitle:    "old",
+		SchemaVersion: agent.BranchMetaCountsVersion,
+		Turns:         1,
+		Preview:       "hi",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	later := activity.Add(48 * time.Hour)
+	if err := os.Chtimes(path, later, later); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	record, ok, err := catalog.GetSession(ctx, path)
+	if err != nil || !ok {
+		t.Fatalf("GetSession: ok=%v err=%v", ok, err)
+	}
+	if record.LastActivityAt != activity.UnixMilli() {
+		t.Fatalf("lastActivityAt = %d, want sidecar %d; file mtime must not raise known activity", record.LastActivityAt, activity.UnixMilli())
+	}
+}
+
+func TestReconcileFillsZeroActivityFromFileMtime(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bare.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog, err := Open(ctx, Options{Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	record, ok, err := catalog.GetSession(ctx, path)
+	if err != nil || !ok {
+		t.Fatalf("GetSession: ok=%v err=%v", ok, err)
+	}
+	if record.LastActivityAt != when.UnixMilli() {
+		t.Fatalf("lastActivityAt = %d, want file mtime %d", record.LastActivityAt, when.UnixMilli())
+	}
+}

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -374,14 +374,14 @@ func recordFromOrder(target DirectoryTarget, info agent.SessionOrderInfo) Sessio
 	metaFingerprint := fileFingerprint(agent.BranchMetaPath(info.Path))
 	createdAt := unixMilli(info.CreatedAt)
 	lastActivityAt := unixMilli(info.LastActivityAt)
-	// File mtime is a hard floor. Migration/meta can temporarily write zero
-	// UpdatedAt; without this, topics sort as inactive and look "missing".
+	// File mtime fills a missing clock. Do not raise a known sidecar UpdatedAt:
+	// repair and other metadata writes bump mtime without new user turns.
 	if st, err := os.Stat(info.Path); err == nil {
 		fileMS := st.ModTime().UnixMilli()
 		if createdAt <= 0 {
 			createdAt = fileMS
 		}
-		if lastActivityAt <= 0 || fileMS > lastActivityAt {
+		if lastActivityAt <= 0 {
 			lastActivityAt = fileMS
 		}
 	}


### PR DESCRIPTION
## Summary

Old sidebar sessions all showed unread dots. Clicking a row cleared unread, then the next catalog refresh put the dots back. This change keeps unread on the logical topic, seeds a one-time read baseline for already-seen history, and stops catalog/sidecar maintenance from minting fake "now" activity.

## Root cause

Unread compared `lastActivityAt` to a localStorage key that included the representative session path, and the first-run baseline ran on project shells before topics loaded. Catalog repair wrote sidecars with `UpdatedAt=now` when the field was zero, then treated file mtime as a hard floor, so later reconciles raised `lastActivityAt` without a new user turn.

## Fix

- Key unread on scope + workspace + topic id, not the representative path.
- Seed a one-time baseline watermark so already-present activity is not unread.
- Keep a topic row active when only the representative path changed.
- Fill a missing sidecar `UpdatedAt` from file mtime, not wall clock, on non-activity writes.
- Use file mtime only when activity is missing; do not raise a known sidecar time.

## Related

#8677 independently removes the same catalog mtime floor. This PR keeps that catalog condition and also fixes the desktop unread identity, first-seen baseline, and sidecar `UpdatedAt` minting that made the dots return after a click.

## Verification

- `pnpm exec tsx src/__tests__/project-tree-runtime.test.ts` (67 passed, including the new unread regressions)
- `go test ./internal/sessioncatalog ./internal/agent`
- `go test -race ./internal/sessioncatalog` and focused agent sidecar tests
- `cd desktop && go test .`
- `go test ./...` with an isolated `REASONIX_HOME`
- `cd desktop/frontend && pnpm test` (160 discovered suites)
- `make lint`

Documentation-impact: none - unread attention is not documented in docs/*.md; the ordinary path stays automatic
Cache-impact: none - unread/catalog recency only; provider-visible prefix and tool schemas are unchanged
Cache-guard: existing sessioncatalog/agent listing tests plus new activity-time regressions
