### PR TITLE
fix(desktop): hydrate history for a session opened mid-stream / 修复流式输出中点进会话看不到历史

### DIFF
--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -1,9 +1,10 @@
 // Run: tsx src/__tests__/hydrate-history-apply.test.ts
 
 import {
+  duplicateLiveItemIds,
   hasCachedLiveTurn,
+  hydratedHistoryApplyMode,
   sameSessionPlaceholderItems,
-  shouldApplyHydratedHistory,
 } from "../lib/hydrateHistoryApply";
 
 let passed = 0;
@@ -21,34 +22,49 @@ function ok(value: boolean, label: string) {
 
 console.log("\nhydrate history apply");
 
-ok(!shouldApplyHydratedHistory(true, true, false, { items: [] }), "skipHistory blocks apply");
-ok(!shouldApplyHydratedHistory(false, false, false, { items: [] }), "missing projection blocks apply");
-ok(shouldApplyHydratedHistory(false, true, false, { items: [] }), "idle empty surface applies history");
+const mode = hydratedHistoryApplyMode;
+
+ok(mode(true, true, false, { items: [] }) === "skip", "skipHistory blocks apply");
+ok(mode(false, false, false, { items: [] }) === "skip", "missing projection blocks apply");
+ok(mode(false, true, false, { items: [] }) === "replace", "idle empty surface applies history");
+ok(mode(false, true, true, { running: true, items: [] }) === "replace", "running empty surface applies history");
 ok(
-  shouldApplyHydratedHistory(false, true, true, { running: true, items: [] }),
-  "running empty surface applies history",
+  mode(false, true, true, { running: true, live: { text: "partial" }, items: [] }) === "replace",
+  "a mid-stream surface with no rows yet applies history",
 );
 ok(
-  !shouldApplyHydratedHistory(false, true, true, {
-    running: true,
-    items: [{ kind: "user" }],
-  }),
-  "running visible transcript is not replaced",
+  mode(false, true, true, { running: true, items: [{ kind: "user" }] }) === "prepend",
+  "a running turn with no history page behind it gets one prepended",
 );
 ok(
-  !shouldApplyHydratedHistory(false, true, true, {
-    running: true,
-    live: { text: "partial" },
-    items: [],
-  }),
-  "running live stream without items is not replaced",
+  mode(false, true, true, { running: true, historyTotalTurns: 3, items: [{ kind: "user" }] }) === "skip",
+  "an already-hydrated running transcript is left alone",
 );
 ok(
   hasCachedLiveTurn({
     running: true,
+    historyTotalTurns: 2,
     items: [{ kind: "assistant", streaming: true }],
   }),
   "streaming assistant counts as a cached live turn",
+);
+ok(
+  !hasCachedLiveTurn({ running: true, items: [{ kind: "assistant", streaming: true }] }),
+  "a live turn with no history page behind it is not cached",
+);
+ok(
+  duplicateLiveItemIds(
+    [{ kind: "user", id: "h1", text: "ask" }],
+    [{ kind: "user", id: "l1", text: "ask" }, { kind: "assistant", id: "l2", text: "" }],
+  ).join(",") === "l1",
+  "a live row the page already carries is dropped",
+);
+ok(
+  duplicateLiveItemIds(
+    [{ kind: "user", id: "h1", text: "ask" }],
+    [{ kind: "assistant", id: "l2", text: "" }],
+  ).length === 0,
+  "a live tail the page does not carry is kept",
 );
 ok(
   sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "b.jsonl" }, items: [{ kind: "user" }] }) === undefined,

--- a/desktop/frontend/src/__tests__/running-tab-history-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/running-tab-history-hydration.test.tsx
@@ -1,0 +1,265 @@
+// Run: tsx src/__tests__/running-tab-history-hydration.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { AppBindings } from "../lib/bridge";
+import { useController } from "../lib/useController";
+import { historySliceFromMessages } from "./mockHistorySlice";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, HistorySliceRequest, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) ok(true, label);
+  else ok(false, `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(label: string, predicate: () => boolean) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await act(async () => {
+      await flushPromises();
+    });
+    if (predicate()) return;
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function settle() {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await flushPromises();
+    });
+  }
+}
+
+function tabMeta(id: string, overrides: Partial<TabMeta> = {}): TabMeta {
+  const workspaceRoot = `/repo/${id}`;
+  return {
+    id,
+    scope: "project",
+    workspaceRoot,
+    workspaceName: id,
+    workspacePath: workspaceRoot,
+    gitBranch: "main",
+    topicId: `topic-${id}`,
+    topicTitle: id,
+    sessionPath: `${workspaceRoot}/sessions/${id}.jsonl`,
+    label: `model-${id}`,
+    ready: true,
+    running: false,
+    mode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    active: false,
+    cwd: workspaceRoot,
+    ...overrides,
+  };
+}
+
+function metaFor(tab: TabMeta): Meta {
+  return {
+    label: tab.label,
+    ready: tab.ready,
+    startupErr: tab.startupErr,
+    eventChannel: "agent:event",
+    cwd: tab.cwd || tab.workspaceRoot,
+    workspaceRoot: tab.workspaceRoot,
+    workspaceName: tab.workspaceName,
+    workspacePath: tab.workspacePath,
+    sessionPath: tab.sessionPath,
+    sessionRevision: tab.sessionRevision,
+    sessionDigest: tab.sessionDigest,
+    gitBranch: tab.gitBranch,
+    autoApproveTools: false,
+    bypass: false,
+    collaborationMode: tab.collaborationMode ?? "normal",
+    toolApprovalMode: tab.toolApprovalMode ?? "ask",
+    tokenMode: tab.tokenMode ?? "full",
+    goal: "",
+    goalStatus: "stopped",
+  };
+}
+
+function userMessage(content: string): HistoryMessage {
+  return { role: "user", content };
+}
+
+console.log("\nrunning tab history hydration");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+const context: ContextInfo = { used: 12, window: 100, sessionTokens: 12 };
+const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
+const balance: BalanceInfo = { available: false, display: "" };
+const jobs: JobView[] = [];
+const checkpoints: CheckpointMeta[] = [];
+
+const tabA = tabMeta("tab-a", { active: true });
+// The session the user clicks into: it has been running for a while, so the
+// backend reports it running before hydration finishes.
+const tabR = tabMeta("tab-r");
+const tabsById = new Map([tabA, tabR].map((tab) => [tab.id, tab]));
+const runningTabs = new Set<string>(["tab-r"]);
+let backendActiveId = "tab-a";
+const eventHandlers: Array<(e: WireEvent) => void> = [];
+const readyHandlers: Array<(tabId?: string) => void> = [];
+
+function currentTabs(): TabMeta[] {
+  return Array.from(tabsById.values()).map((tab) => {
+    const running = runningTabs.has(tab.id);
+    return { ...tab, active: tab.id === backendActiveId, running, cancellable: running };
+  });
+}
+
+function historyFor(tabID: string): HistoryMessage[] {
+  if (tabID === "tab-r") return [userMessage("history R 1"), userMessage("history R 2")];
+  if (tabID === "tab-s") return [userMessage("history S")];
+  return [userMessage("cached A")];
+}
+
+window.runtime = {
+  EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(cb as (e: WireEvent) => void);
+    if (name === "agent:ready") readyHandlers.push(cb as (tabId?: string) => void);
+    return () => {};
+  },
+  BrowserOpenURL: () => {},
+};
+window.go = {
+  main: {
+    App: {
+      ListTabs: async () => currentTabs(),
+      MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
+      ContextUsageForTab: async () => context,
+      EffortForTab: async () => effort,
+      BalanceForTab: async () => balance,
+      JobsForTab: async () => jobs,
+      CheckpointsForTab: async () => checkpoints,
+      HistoryForTab: async (tabID: string) => historyFor(tabID),
+      HistoryPageForTab: async (tabID: string) => {
+        const messages = historyFor(tabID);
+        const turns = messages.filter((message) => message.role === "user").length;
+        return { messages, startTurn: 0, endTurn: turns, totalTurns: turns, hasOlder: false };
+      },
+      HistorySliceForTab: async (tabID: string, req: HistorySliceRequest) =>
+        historySliceFromMessages(tabID, historyFor(tabID), req),
+      HistoryCheckpointTurnsForTab: async () => [],
+      ReplayPendingPrompts: async () => {},
+      SetActiveTab: async (tabID: string) => {
+        backendActiveId = tabID;
+      },
+      CancelTab: async (tabID: string) => {
+        runningTabs.delete(tabID);
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+type Controller = ReturnType<typeof useController>;
+let controller: Controller | undefined;
+
+function Probe() {
+  controller = useController();
+  return null;
+}
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing root");
+const root = createRoot(rootEl);
+
+await act(async () => {
+  root.render(<Probe />);
+  await flushPromises();
+});
+
+await waitFor(
+  "initial active tab hydrated",
+  () => controller?.activeTabId === "tab-a" && controller.state.items.some((item) => item.kind === "user" && item.text === "cached A"),
+);
+
+// Clicking a session that the backend already reports as running: the tab has
+// no cached transcript, so hydration is the only thing that can put the
+// conversation on screen.
+await act(async () => {
+  void controller?.switchTab("tab-r", { ...tabR, running: true, cancellable: true });
+  await flushPromises();
+});
+await settle();
+
+eq(controller?.activeTabId, "tab-r", "switching to the running session activates its tab");
+eq(controller?.state.running, true, "the running session keeps its live status");
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history R 1") ?? false,
+  "an uncached running session still hydrates its persisted history",
+);
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history R 2") ?? false,
+  "the whole history page lands, not just the newest turn",
+);
+
+// Second door: a session that is mid-stream when it is opened. Its live text
+// makes the transcript look cached, which used to skip the history fetch
+// outright and leave the streaming turn floating over an empty transcript.
+tabsById.set("tab-s", tabMeta("tab-s"));
+runningTabs.add("tab-s");
+await act(async () => {
+  for (const handler of eventHandlers) {
+    handler({ kind: "turn_started", tabId: "tab-s" } as WireEvent);
+    handler({ kind: "text", tabId: "tab-s", text: "streaming S" } as WireEvent);
+  }
+  await flushPromises();
+});
+await act(async () => {
+  void controller?.switchTab("tab-s", { ...tabsById.get("tab-s")!, running: true, cancellable: true });
+  await flushPromises();
+});
+await settle();
+
+eq(controller?.activeTabId, "tab-s", "switching to the streaming session activates its tab");
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history S") ?? false,
+  "a mid-stream session still fetches and installs its history",
+);
+ok(controller?.state.live !== undefined, "installing history leaves the live stream alone");
+eq(controller?.state.items[0]?.kind, "user", "the persisted page lands in front of the streaming turn");
+eq(controller?.state.items[controller.state.items.length - 1]?.kind, "assistant", "the streaming turn stays at the tail");
+
+await act(async () => {
+  root.unmount();
+});
+dom.window.close();
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -628,7 +628,7 @@ ok(controller?.state.items.some((item) => item.kind === "user" && item.text === 
 const tabCUser = controller?.state.items.find((item) => item.kind === "user" && item.text === "streaming C");
 eq(tabCUser?.kind === "user" && tabCUser.submissionId, tabCSubmissionId, "Wails receives the same opaque correlation stored on the optimistic user");
 ok(Boolean(tabCSubmissionId) && tabCSubmissionId !== tabCUser?.id, "opaque submission correlation is distinct from the render item id");
-ok(!historyCalls.includes("tab-c"), "cached running tab skips history hydration");
+ok(historyCalls.includes("tab-c"), "a running tab with no history page of its own still hydrates one");
 await act(async () => {
   submitTabCGate.resolve();
   await submitTabCGate.promise;

--- a/desktop/frontend/src/__tests__/use-controller-history-live-race.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-history-live-race.test.tsx
@@ -161,7 +161,11 @@ await waitFor("hydration completion", () => controller?.state.hydrating === fals
 
 ok(controller?.state.running ?? false, "late history keeps the live turn running");
 ok(controller?.state.items.some((item) => item.kind === "assistant" && item.streaming) ?? false, "late history keeps the live assistant stream");
-ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "stale durable history") ?? false), "late history cannot replace the live transcript");
+// The page read before the turn started is this session's history, not a
+// competing version of it: it goes in front of the live turn instead of
+// replacing it, so the turn never streams over a blank transcript.
+ok(controller?.state.items[0]?.kind === "user", "late history lands in front of the live turn");
+ok(controller?.state.items.at(-1)?.kind === "assistant", "late history leaves the live turn at the tail");
 
 await act(async () => { root.unmount(); });
 dom.window.close();

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -5,11 +5,18 @@ export type HydrateLiveState = {
   live?: unknown;
   currentAssistant?: unknown;
   pendingUser?: unknown;
+  historyTotalTurns?: number;
   items: ReadonlyArray<{ kind: string; streaming?: boolean; status?: string }>;
 };
 
+export type HydratedHistoryApplyMode = "replace" | "prepend" | "skip";
+
+// A live turn is only "cached" once a history page has landed behind it.
+// Without that, a session opened mid-stream reports a cached turn, skips the
+// fetch, and streams over a blank transcript.
 export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean {
   if (!state?.running && !state?.turnActive) return false;
+  if ((state.historyTotalTurns ?? 0) === 0) return false;
   if (state.live || state.currentAssistant || state.pendingUser !== undefined) return true;
   return state.items.some((item) =>
     (item.kind === "assistant" && item.streaming) ||
@@ -17,17 +24,59 @@ export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean 
   );
 }
 
-// Skip replace when a live transcript is already on screen; an empty
-// surface still has to apply history or switch-back shows Welcome.
-export function shouldApplyHydratedHistory(
+// An empty surface has to apply history or switch-back shows Welcome. A turn
+// that has already streamed rows keeps them — but a tab with no history page
+// behind it still gets one, prepended, instead of a blank transcript above the
+// live turn. Only an already-hydrated live turn is left alone.
+export function hydratedHistoryApplyMode(
   skipHistory: boolean,
   hasProjection: boolean,
   foregroundTurnActive: boolean,
   state: HydrateLiveState | undefined,
-): boolean {
-  if (skipHistory || !hasProjection) return false;
-  if (!foregroundTurnActive) return true;
-  return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
+): HydratedHistoryApplyMode {
+  if (skipHistory || !hasProjection) return "skip";
+  if (!foregroundTurnActive) return "replace";
+  if ((state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state)) return "replace";
+  return (state?.historyTotalTurns ?? 0) === 0 ? "prepend" : "skip";
+}
+
+type SignatureItem = {
+  kind: string;
+  id: string;
+  text?: string;
+  reasoning?: string;
+  name?: string;
+  level?: string;
+  trigger?: string;
+  messages?: number;
+  surfaceKey?: string;
+  generation?: number;
+};
+
+function itemSignature(item: SignatureItem): string {
+  switch (item.kind) {
+    case "tool": return `tool|${item.id}|${item.name ?? ""}`;
+    case "extension": return `extension|${item.surfaceKey ?? ""}|${item.generation ?? 0}`;
+    case "compaction": return `compaction|${item.trigger ?? ""}|${item.messages ?? 0}`;
+    default: return `${item.kind}|${item.level ?? ""}|${item.text ?? ""}|${item.reasoning ?? ""}`;
+  }
+}
+
+// A page read while its turn is live can already carry rows the live stream
+// rendered. Only a suffix of the page can overlap a prefix of the live rows, so
+// the longest such match is the duplicate set.
+export function duplicateLiveItemIds(
+  pageItems: readonly SignatureItem[],
+  liveItems: readonly SignatureItem[],
+): string[] {
+  for (let k = Math.min(pageItems.length, liveItems.length); k > 0; k -= 1) {
+    let same = true;
+    for (let i = 0; i < k && same; i += 1) {
+      same = itemSignature(pageItems[pageItems.length - k + i]) === itemSignature(liveItems[i]);
+    }
+    if (same) return liveItems.slice(0, k).map((item) => item.id);
+  }
+  return [];
 }
 
 export function sameSessionPlaceholderItems<T>(

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -18,7 +18,7 @@ import { getTranscriptStore } from "./transcriptStore";
 import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
-import { hasCachedLiveTurn, sameSessionPlaceholderItems, shouldApplyHydratedHistory } from "./hydrateHistoryApply";
+import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameTodoList } from "./todoVisibility";
 import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
@@ -2936,17 +2936,15 @@ export function useController() {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
-      if (projection !== undefined && shouldApplyHydratedHistory(skipHistory, true, foregroundTurnActive(), statesRef.current.get(tabId))) {
+      const applyMode = hydratedHistoryApplyMode(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId));
+      if (projection !== undefined && applyMode !== "skip") {
         if (deferResetUntilHistory && stillCurrent() && !foregroundTurnActive()) dispatchTo(tabId, { type: "reset" });
-        dispatchTo(tabId, {
-          type: "history_replace",
-          items: projection.items,
-          startTurn: projection.startTurn,
-          totalTurns: projection.totalTurns,
-          hasOlder: projection.hasOlder,
-          revision: projection.revisionKnown ? projection.revision : undefined,
-          digest: projection.digest || undefined,
-        });
+        const page = { items: projection.items, startTurn: projection.startTurn, totalTurns: projection.totalTurns,
+          hasOlder: projection.hasOlder, revision: projection.revisionKnown ? projection.revision : undefined,
+          digest: projection.digest || undefined };
+        dispatchTo(tabId, applyMode === "prepend"
+          ? { type: "history_prepend", ...page, removeIds: duplicateLiveItemIds(projection.items, statesRef.current.get(tabId)?.items ?? []) }
+          : { type: "history_replace", ...page });
         addBreadcrumb(
           "tab.hydrate",
           `history page ${tabId} items=${projection.items.length} turns=${projection.startTurn}-${projection.endTurn}/${projection.totalTurns} ms=${Date.now() - historyStartedAt}`,


### PR DESCRIPTION
## Problem

Clicking into a session whose turn is already streaming renders the live turn over a blank transcript — `alignToBottom` pins those few rows to the bottom and everything above stays empty until the turn ends.

#8665 fixed the empty-surface half of this. What is left: a surface that already carries a live stream, or any row the turn has emitted, still loses its history page.

## Root cause

`shouldApplyHydratedHistory` treats "a live turn is on screen" as reason to drop the loaded page, without asking whether a history page ever landed behind it:

```ts
if (!foregroundTurnActive) return true;
return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
```

`hasCachedLiveTurn` has the same gap, so `switchTab` passes `skipHistory: true` for such a tab and the page is never even read.

## Fix

The decision becomes `replace` / `prepend` / `skip`:

- empty surface → `replace` (unchanged from #8665)
- live turn with **no** history page behind it → `prepend`, so the page lands in front of the rows the turn already streamed, deduped against them by a page-suffix / live-prefix signature match
- already-hydrated live turn → `skip`, the protection #8665 added stays intact

`hasCachedLiveTurn` gains the same precondition, so `switchTab` stops skipping the fetch for a tab that has never loaded a page.

Two existing assertions encoded the old contract and now assert the sharper one — history lands **in front of** the live turn rather than not at all:

- `tab-switch-hydration`: "cached running tab skips history hydration"
- `use-controller-history-live-race`: "late history cannot replace the live transcript"

## Verification

- `pnpm exec tsx src/__tests__/running-tab-history-hydration.test.tsx` — new suite; fails on `main-v2` (2 FAIL), passes here
- `pnpm exec tsx src/__tests__/hydrate-history-apply.test.ts` — 13 passed
- `node scripts/run-tests.mjs --keep-going` — 161/161
- `pnpm exec tsc --noEmit -p tsconfig.json` and `-p tsconfig.test.json` — clean
- `go run ./tools/repolint` — clean; `useController.ts` goes 4760 → 4758 lines, inside its budget

Documentation-impact: none - behaviour fix inside desktop hydration; no documented surface or flag changes.
