### PR TITLE
fix(desktop): keep the frontend suites runnable on Node >= 25 / 修复 Node 25 下前端测试崩溃

### DIFF
--- a/desktop/frontend/scripts/run-tests.mjs
+++ b/desktop/frontend/scripts/run-tests.mjs
@@ -67,6 +67,14 @@ for (const [name, owner] of OWNED_ELSEWHERE) {
 const suites = files.filter((name) => !OWNED_ELSEWHERE.has(name));
 console.log(`run-tests: ${suites.length} discovered suites (${OWNED_ELSEWHERE.size} owned by dedicated scripts)`);
 
+// Node >= 25 enables Web Storage by default, so `localStorage` is a global
+// whose methods are absent unless --localstorage-file names a real file — every
+// `typeof localStorage !== "undefined"` guard in the app then throws. CI pins
+// Node 24; opt out so a suite cannot pass there and crash on a newer local Node.
+const nodeArgs = process.allowedNodeEnvironmentFlags.has("--no-experimental-webstorage")
+  ? ["--no-experimental-webstorage"]
+  : [];
+
 const failures = [];
 for (const name of suites) {
   const path = join(TESTS_DIR, name);
@@ -75,7 +83,7 @@ for (const name of suites) {
   // Node's built-in navigator.language follows the machine's ICU locale, and
   // suites assert English UI strings.
   const env = { ...process.env, LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8" };
-  const result = spawnSync(process.execPath, [tsxCli, path], { stdio: "inherit", env });
+  const result = spawnSync(process.execPath, [...nodeArgs, tsxCli, path], { stdio: "inherit", env });
   if (result.error) console.error(`run-tests: spawn failed for ${path}: ${result.error.message}`);
   if (result.status !== 0) {
     if (!keepGoing) {

--- a/desktop/frontend/src/__tests__/subagent-progress-card.test.tsx
+++ b/desktop/frontend/src/__tests__/subagent-progress-card.test.tsx
@@ -58,6 +58,10 @@ function installDom() {
   globalThis.Event = dom.window.Event;
   globalThis.CustomEvent = dom.window.CustomEvent;
   globalThis.MouseEvent = dom.window.MouseEvent;
+  // Node >= 25 exposes a built-in localStorage whose methods are absent
+  // without --localstorage-file, so `typeof localStorage` alone stops being a
+  // usable guard: the jsdom one has to win.
+  globalThis.localStorage = dom.window.localStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
   dom.window.matchMedia = () => ({

--- a/desktop/frontend/src/__tests__/tool-card-error-details.test.tsx
+++ b/desktop/frontend/src/__tests__/tool-card-error-details.test.tsx
@@ -46,6 +46,10 @@ function installDom() {
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.Event = dom.window.Event;
   globalThis.MouseEvent = dom.window.MouseEvent;
+  // Node >= 25 exposes a built-in localStorage whose methods are absent
+  // without --localstorage-file, so `typeof localStorage` alone stops being a
+  // usable guard: the jsdom one has to win.
+  globalThis.localStorage = dom.window.localStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
   dom.window.matchMedia = () => ({

--- a/desktop/frontend/src/__tests__/tool-card-shell-execution.test.tsx
+++ b/desktop/frontend/src/__tests__/tool-card-shell-execution.test.tsx
@@ -52,6 +52,10 @@ function installDom() {
   globalThis.HTMLElement = dom.window.HTMLElement;
   globalThis.Event = dom.window.Event;
   globalThis.MouseEvent = dom.window.MouseEvent;
+  // Node >= 25 exposes a built-in localStorage whose methods are absent
+  // without --localstorage-file, so `typeof localStorage` alone stops being a
+  // usable guard: the jsdom one has to win.
+  globalThis.localStorage = dom.window.localStorage;
   globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
   globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
   dom.window.matchMedia = () => ({


### PR DESCRIPTION
## Problem

Three frontend suites crash on Node 25 with `TypeError: localStorage.getItem is not a function`:

- `subagent-progress-card.test.tsx`
- `tool-card-error-details.test.tsx`
- `tool-card-shell-execution.test.tsx`

CI pins Node 24, so the break is invisible there and only bites locally.

## Root cause

Node >= 25 enables Web Storage by default:

```
$ node -e "console.log(typeof localStorage, typeof localStorage.getItem)"
object undefined
Warning: `--localstorage-file` was provided without a valid path
```

`localStorage` exists as a global whose methods are absent unless `--localstorage-file` names a real file, so every `typeof localStorage !== "undefined"` guard passes and then throws. 19 modules under `src/lib` use that idiom; `reasoningDisplayPreference.ts` is the one these three suites reach.

These three build a jsdom window but never install its `localStorage`, unlike the suites that pass.

## Fix

Two independent layers:

1. Install the jsdom `localStorage` in the three jsdom setups, so a suite run directly — `tsx src/__tests__/<name>.test.tsx`, as each file header documents — behaves like a browser.
2. `run-tests.mjs` spawns each suite with `--no-experimental-webstorage` when the running Node accepts it (feature-detected via `process.allowedNodeEnvironmentFlags`, so Node 24 is unaffected). This matches CI's Node 24 for **every** suite — 44 others build a jsdom without `localStorage` today and pass only because nothing they render reaches it.

## Verification

- `node scripts/run-tests.mjs --keep-going` on Node 25.9 — 160/160
- each of the three suites run directly with plain `tsx`, without the flag
- `go run ./tools/repolint` — clean

Documentation-impact: none - test-harness only; no runtime behaviour or documented surface changes.
