### PR TITLE
fix(agent): keep encrypted web_search replay out of compact estimates / 密文搜索回放不再计入 compact 估算

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -182,9 +182,9 @@ func estimateMessagesTokens(msgs []provider.Message) int {
 			total += estimateTextTokens(string(item))
 		}
 		for _, search := range m.ServerSearch {
-			total += estimateTextTokens(search.ID)
-			total += estimateTextTokens(search.Query)
-			total += estimateTextTokens(string(search.Raw))
+			provider.WalkServerSearchEstimate(search, func(s string) {
+				total += estimateTextTokens(s)
+			})
 		}
 	}
 	return total

--- a/internal/agent/compact_search_estimate_test.go
+++ b/internal/agent/compact_search_estimate_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestEstimateMessagesTokensOmitsEncryptedSearchRaw(t *testing.T) {
+	visible := provider.ServerSearchCall{
+		ID: "s1", Query: "q",
+		Results: []provider.ServerSearchHit{{Title: "T", URL: "https://a.example"}},
+	}
+	withRaw := []provider.Message{{
+		Role: provider.RoleAssistant, Content: "answer",
+		ServerSearch: []provider.ServerSearchCall{{
+			ID: visible.ID, Query: visible.Query, Results: visible.Results,
+			Raw: json.RawMessage(strings.Repeat("E", 50_000)),
+		}},
+	}}
+	withoutRaw := []provider.Message{{
+		Role:         provider.RoleAssistant,
+		Content:      "answer",
+		ServerSearch: []provider.ServerSearchCall{visible},
+	}}
+	if got, want := estimateMessagesTokens(withRaw), estimateMessagesTokens(withoutRaw); got != want {
+		t.Fatalf("estimateMessagesTokens with raw = %d, without = %d", got, want)
+	}
+	if estimateSamplingRequestInputTokens(provider.Request{Messages: withRaw}) != estimateSamplingRequestInputTokens(provider.Request{Messages: withoutRaw}) {
+		t.Fatal("interrupted-usage estimate counted encrypted search raw")
+	}
+}

--- a/internal/agent/output_budget.go
+++ b/internal/agent/output_budget.go
@@ -173,9 +173,7 @@ func requestCalibrationTextShape(req provider.Request, policy provider.SharedWin
 			}
 		}
 		for _, search := range msg.ServerSearch {
-			add(search.ID)
-			add(search.Query)
-			add(string(search.Raw))
+			provider.WalkServerSearchEstimate(search, add)
 		}
 	}
 	for _, schema := range req.Tools {

--- a/internal/agent/output_budget_test.go
+++ b/internal/agent/output_budget_test.go
@@ -429,6 +429,42 @@ func TestEstimatedUsageDoesNotReplacePromptCalibration(t *testing.T) {
 	}
 }
 
+func TestCalibratedBudgetIgnoresEncryptedSearchRaw(t *testing.T) {
+	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true}
+	a := &Agent{agentConfig: agentConfig{contextWindow: 200_000}, svc: agentServices{prov: prov}, sess: sessionRuntime{output: outputBudgetState{outputBudget: prov.budget}}}
+	previous := provider.Request{Messages: []provider.Message{{
+		Role: provider.RoleUser, Content: strings.Repeat("x", 300_000),
+	}}}
+	a.setPromptTokenCalibration(75_000, a.requestCalibrationShape(previous))
+	visible := provider.ServerSearchCall{
+		ID: "s1", Query: "latest",
+		Results: []provider.ServerSearchHit{{Title: "Change Log", URL: "https://api-docs.deepseek.com/updates/"}},
+	}
+	withRaw := previous
+	withRaw.Messages = append(append([]provider.Message(nil), previous.Messages...), provider.Message{
+		Role: provider.RoleAssistant, Content: "answer",
+		ServerSearch: []provider.ServerSearchCall{{
+			ID: visible.ID, Query: visible.Query, Results: visible.Results,
+			Raw: json.RawMessage(`[{"encrypted_content":"` + strings.Repeat("E", 400_000) + `"}]`),
+		}},
+	})
+	withoutRaw := previous
+	withoutRaw.Messages = append(append([]provider.Message(nil), previous.Messages...), provider.Message{
+		Role:         provider.RoleAssistant,
+		Content:      "answer",
+		ServerSearch: []provider.ServerSearchCall{visible},
+	})
+	if got, want := a.estimatedRequestTokens(withRaw), a.estimatedRequestTokens(withoutRaw); got != want {
+		t.Fatalf("estimate with encrypted raw = %d, without = %d", got, want)
+	}
+	wantBudget, wantClipped, wantErr := a.effectiveOutputBudget(withoutRaw)
+	gotBudget, gotClipped, gotErr := a.effectiveOutputBudget(withRaw)
+	if gotBudget != wantBudget || gotClipped != wantClipped || (gotErr != nil) != (wantErr != nil) {
+		t.Fatalf("encrypted raw changed output budget: got %d clipped=%v err=%v, want %d clipped=%v err=%v",
+			gotBudget, gotClipped, gotErr, wantBudget, wantClipped, wantErr)
+	}
+}
+
 func TestForkCaptureProviderPreservesOutputBudgetCapabilities(t *testing.T) {
 	t.Setenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR", t.TempDir())
 	prov := &sharedWindowTestProvider{budget: 128 * 1024, shared: true,

--- a/internal/agent/run_usage.go
+++ b/internal/agent/run_usage.go
@@ -119,9 +119,9 @@ func estimateSamplingRequestInputTokens(req provider.Request) int {
 			total += estimateTextTokens(string(item))
 		}
 		for _, search := range msg.ServerSearch {
-			total += estimateTextTokens(search.ID)
-			total += estimateTextTokens(search.Query)
-			total += estimateTextTokens(string(search.Raw))
+			provider.WalkServerSearchEstimate(search, func(s string) {
+				total += estimateTextTokens(s)
+			})
 		}
 	}
 	for _, schema := range req.Tools {

--- a/internal/provider/server_search.go
+++ b/internal/provider/server_search.go
@@ -174,6 +174,22 @@ func ServerSearchFromResponsesItem(raw json.RawMessage) *ServerSearchCall {
 	return call
 }
 
+// WalkServerSearchEstimate visits the compact and overflow-estimate surface
+// for one provider search: id, query, and visible hit titles/URLs. Encrypted
+// Raw is omitted because Anthropic does not count it toward input tokens
+// when the block is replayed. Replay still sends Raw verbatim.
+func WalkServerSearchEstimate(search ServerSearchCall, visit func(string)) {
+	if visit == nil {
+		return
+	}
+	visit(search.ID)
+	visit(search.Query)
+	for _, hit := range search.Results {
+		visit(hit.Title)
+		visit(hit.URL)
+	}
+}
+
 // MergeServerSearch upserts call into dst by ID, filling query/results/raw.
 func MergeServerSearch(dst []ServerSearchCall, call ServerSearchCall) []ServerSearchCall {
 	if strings.TrimSpace(call.ID) == "" {

--- a/internal/provider/server_search_test.go
+++ b/internal/provider/server_search_test.go
@@ -62,6 +62,22 @@ func TestFormatServerSearchArgs(t *testing.T) {
 	}
 }
 
+func TestWalkServerSearchEstimateOmitsEncryptedRaw(t *testing.T) {
+	var got []string
+	WalkServerSearchEstimate(ServerSearchCall{
+		ID: "s1", Query: "latest",
+		Results: []ServerSearchHit{{Title: "Change Log", URL: "https://api-docs.deepseek.com/updates/"}},
+		Raw:     json.RawMessage(`[{"encrypted_content":"xxx"}]`),
+	}, func(s string) {
+		if s != "" {
+			got = append(got, s)
+		}
+	})
+	if len(got) != 4 || got[0] != "s1" || got[1] != "latest" || got[2] != "Change Log" || got[3] != "https://api-docs.deepseek.com/updates/" {
+		t.Fatalf("estimate fields = %#v", got)
+	}
+}
+
 func TestServerSearchFromResponsesItem(t *testing.T) {
 	raw := json.RawMessage(`{"id":"ws_1","type":"web_search_call","status":"completed","action":{"type":"search","query":"latest","sources":[{"title":"Change Log","url":"https://api-docs.deepseek.com/updates/"}]}}`)
 	got := ServerSearchFromResponsesItem(raw)


### PR DESCRIPTION
## Summary

Follow-up to #8674. Anthropic still replays `encrypted_content` verbatim. Compact, overflow, and interrupted-usage estimates no longer treat that ciphertext as ordinary prompt text.

## Root cause

After the first provider search, the next Anthropic request must send `web_search_tool_result` including `encrypted_content` or the API returns 400. The compact trigger uses `requestChars`, which counted `ServerSearch.Raw`. Official Anthropic does not bill replayed encrypted search results as input tokens, so a search-heavy session could cross `compact_ratio` earlier than the real window.

## Fix

- `WalkServerSearchEstimate` counts id, query, and visible title/URL only.
- `requestCalibrationTextShape`, `estimateMessagesTokens`, and `estimateSamplingRequestInputTokens` use that walk.
- Replay, session persistence, and Wails stripping of `Raw` are unchanged.

## Verification

- `go test ./internal/provider/ ./internal/provider/anthropic/ ./internal/agent/ -run 'TestWalkServerSearchEstimate|TestCalibratedBudgetIgnoresEncryptedSearchRaw|TestEstimateMessagesTokensOmitsEncryptedSearchRaw|TestBuildRequestReplaysServerSearchBlocks|TestMessageServerSearchRemainBackwardCompatible|TestCalibratedResponsesBudgetIncludesNewReplayItems|TestRunPersistsServerSearch'`
- `go run ./tools/repolint`

Cache-impact: none - provider-visible request bytes are unchanged; only compact and overflow estimates stop counting encrypted web_search replay payloads, which can only delay an unnecessary early compact
Cache-guard: go test ./internal/provider/ ./internal/agent/ -run 'TestWalkServerSearchEstimateOmitsEncryptedRaw|TestCalibratedBudgetIgnoresEncryptedSearchRaw|TestEstimateMessagesTokensOmitsEncryptedSearchRaw|TestBuildRequestReplaysServerSearchBlocks'

Documentation-impact: none - no docs describe compact estimates for encrypted web_search replay

Compatibility: no persisted or Wails contract change. Sessions still store Raw for Anthropic replay. Previous readers keep counting Raw in estimates.
