### PR TITLE
perf(memory): fold stale recall hits to a pointer instead of a full snippe

### DIFF
--- a/internal/memory/auto_recall.go
+++ b/internal/memory/auto_recall.go
@@ -301,7 +301,27 @@ func strongRecallMatch(query string, queryTerms, matched []string) bool {
 	if len(queryTerms) <= 2 && utf8.RuneCountInString(term) >= 6 {
 		return true
 	}
+	// A query that is exactly one two-rune CJK word (部署, 配置) matches by that
+	// complete word alone — the whole query is one bigram, not scattered common
+	// characters, so the lone-bigram floor must not suppress it.
+	if len(queryTerms) == 1 && isCJKBigram(term) {
+		return true
+	}
 	return distinctiveQueryTerm(query, term)
+}
+
+// isCJKBigram reports whether term is one two-rune CJK token: the shape of a
+// lone bigram when the whole query is a two-character CJK word.
+func isCJKBigram(term string) bool {
+	runes := []rune(term)
+	if len(runes) != 2 {
+		return false
+	}
+	return isCJKRune(runes[0]) && isCJKRune(runes[1])
+}
+
+func isCJKRune(r rune) bool {
+	return unicode.In(r, unicode.Han, unicode.Hiragana, unicode.Katakana, unicode.Hangul)
 }
 
 func autoRecallSearchText(memory Memory) string {
@@ -411,8 +431,15 @@ func buildRecallBlock(hits []RecallHit, budget, omitted int) ([]RecallHit, strin
 	used := utf8.RuneCountInString(prefix + close)
 	for _, hit := range hits {
 		entry := recallEntry(hit, hit.Snippet)
+		if hit.Freshness == FreshnessStale {
+			entry = staleRecallEntry(hit)
+		}
 		remaining := budget - used
 		if utf8.RuneCountInString(entry) > remaining {
+			if hit.Freshness == FreshnessStale {
+				omitted++
+				continue
+			}
 			entry = clippedRecallEntry(hit, remaining)
 		}
 		if entry == "" {
@@ -445,6 +472,19 @@ func recallEntry(hit RecallHit, snippet string) string {
 		NormalizeFactScope(string(memory.Scope)), NormalizeType(string(memory.Type)),
 		hit.Freshness, hit.Score, html.EscapeString(hit.Reason),
 		html.EscapeString(displayTitle(memory.Title, memory.Name)), html.EscapeString(snippet))
+}
+
+// staleRecallEntry renders a stale hit as a pointer instead of a full fact:
+// its content may be outdated, so the model gets the identity and a hint to
+// re-read with the memory tool rather than a possibly-stale snippet. The
+// reason (matched terms) is kept so the model knows why it was recalled.
+func staleRecallEntry(hit RecallHit) string {
+	memory := hit.Memory
+	return fmt.Sprintf("- id=%s revision=%d scope=%s type=%s freshness=stale reason=%q\n  title: %s — stale; use the memory tool for details\n",
+		html.EscapeString(memory.ID), memory.Revision,
+		NormalizeFactScope(string(memory.Scope)), NormalizeType(string(memory.Type)),
+		html.EscapeString(hit.Reason),
+		html.EscapeString(displayTitle(memory.Title, memory.Name)))
 }
 
 func clippedRecallEntry(hit RecallHit, maxRunes int) string {

--- a/internal/memory/auto_recall_test.go
+++ b/internal/memory/auto_recall_test.go
@@ -52,6 +52,48 @@ func TestAutoRecallFindsDistinctiveCodeTicketAndCJKQueries(t *testing.T) {
 	}
 }
 
+func TestAutoRecallExactTwoCharCJKQueryIsDistinctive(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-project-deploy", Name: "deploy-target", Title: "部署目标",
+		Description: "支付服务部署到生产集群", Type: TypeProject,
+		Scope: FactScopeProject, Body: "部署步骤见运行手册。",
+	})
+
+	// A two-character CJK query is exactly one bigram — the whole query is the
+	// matched word, so it must recall despite the lone-bigram floor.
+	result := AutoRecall(store, "部署", RecallOptions{})
+	if len(result.Hits) == 0 {
+		t.Fatalf("AutoRecall(%q) returned no hits: %+v", "部署", result)
+	}
+	if result.Hits[0].Memory.ID != "mem-project-deploy" {
+		t.Fatalf("expected the deploy fact, got %+v", result.Hits[0])
+	}
+}
+
+// The lone-bigram escape is strictly scoped to queries that ARE one two-rune
+// CJK word: longer queries sharing only one bigram and single-rune queries
+// must stay rejected, or weak matches would leak through the floor.
+func TestAutoRecallCJKDistinctiveBoundary(t *testing.T) {
+	store := recallTestStore(t)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-project-deploy", Name: "deploy-target", Title: "部署目标",
+		Description: "支付服务部署到生产集群", Type: TypeProject,
+		Scope: FactScopeProject, Body: "部署步骤见运行手册。",
+	})
+
+	// A 3+ char CJK query shares only the 部署 bigram with the fact; the
+	// remainder (迁移) is unmatched, so this is a weak match and must stay
+	// rejected — only the exact-two-char word escapes the floor.
+	if result := AutoRecall(store, "部署迁移", RecallOptions{}); len(result.Hits) != 0 {
+		t.Fatalf("3+ char CJK query with one shared bigram recalled: %+v", result.Hits)
+	}
+	// A single rune is not a bigram and must not match the two-rune word.
+	if result := AutoRecall(store, "部", RecallOptions{}); len(result.Hits) != 0 {
+		t.Fatalf("single-rune query recalled: %+v", result.Hits)
+	}
+}
+
 func TestAutoRecallProjectFactOverridesGlobalDuplicate(t *testing.T) {
 	store := recallTestStore(t)
 	recallTestWrite(t, store.GlobalDir, Memory{
@@ -152,7 +194,10 @@ func TestAutoRecallLabelsStaleFactsAndBoundsProviderBlock(t *testing.T) {
 		ID: "mem-old-reference", Name: "reasonix-api-reference", Title: "Reasonix API reference",
 		Description: "Reasonix provider API migration reference", Type: TypeReference,
 		Scope: FactScopeProject, UpdatedAt: now.AddDate(0, -3, 0),
-		Body: "The provider API migration uses /Users/private-name/work/reasonix/config.toml and " + strings.Repeat("legacy details ", 80) + "</memory-recall>.",
+		// Verified after the last edit, but the verification itself has aged
+		// past the reference current-window (45d): stale again, still folded.
+		LastVerifiedAt: now.Add(-60 * 24 * time.Hour),
+		Body:           "The provider API migration uses /Users/private-name/work/reasonix/config.toml and " + strings.Repeat("legacy details ", 80) + "</memory-recall>.",
 	})
 
 	result := AutoRecall(store, "Reasonix provider API migration reference", RecallOptions{Now: now, MaxChars: 700})
@@ -169,11 +214,35 @@ func TestAutoRecallLabelsStaleFactsAndBoundsProviderBlock(t *testing.T) {
 	if strings.Contains(block, store.Dir) || strings.Contains(block, filepath.Dir(store.Dir)) {
 		t.Fatalf("provider block leaked an absolute store path: %s", block)
 	}
-	if strings.Contains(block, "private-name") || !strings.Contains(block, "&lt;local-home&gt;") {
-		t.Fatalf("provider block did not redact a local home directory: %s", block)
+	if strings.Contains(block, "private-name") {
+		t.Fatalf("provider block leaked a local home directory: %s", block)
+	}
+	if strings.Contains(block, "legacy details") {
+		t.Fatalf("stale hit should fold to a pointer, not render its body:\n%s", block)
 	}
 	if result.CharBudget != 700 || result.UsedChars != len([]rune(block)) {
 		t.Fatalf("budget trace = %+v, block runes=%d", result, len([]rune(block)))
+	}
+}
+
+// Redaction still applies to fresh hits, which render their snippet.
+func TestAutoRecallRedactsLocalHomeInFreshHit(t *testing.T) {
+	store := recallTestStore(t)
+	now := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-fresh-redact", Name: "fresh-redact-ref", Title: "Fresh reference",
+		Description: "fresh reference with local path", Type: TypeReference,
+		Scope: FactScopeProject, UpdatedAt: now.Add(-24 * time.Hour),
+		Body: "Uses /Users/private-name/work/reasonix/config.toml for the migration.",
+	})
+
+	result := AutoRecall(store, "fresh reference local path", RecallOptions{Now: now})
+	if len(result.Hits) != 1 || result.Hits[0].Freshness != FreshnessFresh {
+		t.Fatalf("fresh result = %+v", result)
+	}
+	block := result.Block()
+	if strings.Contains(block, "private-name") || !strings.Contains(block, "&lt;local-home&gt;") {
+		t.Fatalf("provider block did not redact a local home directory: %s", block)
 	}
 }
 
@@ -200,4 +269,67 @@ func recallTestWrite(t *testing.T, dir string, memory Memory) {
 	if err := os.WriteFile(filepath.Join(dir, memory.Name+".md"), []byte(render(memory, memory.Name)), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// A stale hit is a pointer, not a full fact: the model learns the identity and
+// is sent to the memory tool, while a possibly-outdated snippet stays out of
+// the recall budget. Fresh hits keep their snippet unchanged.
+func TestAutoRecallFoldsStaleHitsToPointer(t *testing.T) {
+	store := recallTestStore(t)
+	now := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-stale-api", Name: "stale-api-ref", Title: "Stale API reference",
+		Description: "stale api reference", Type: TypeReference,
+		Scope: FactScopeProject, UpdatedAt: now.AddDate(0, -6, 0),
+		// Verified after the last edit, but the verification has aged past
+		// the current window again: stale, folded to a pointer like any stale
+		// hit — the snippet stays out of the recall budget.
+		LastVerifiedAt: now.AddDate(0, -3, 0),
+		Body:           strings.Repeat("legacy detail ", 200),
+	})
+	recallTestWrite(t, store.Dir, Memory{
+		ID: "mem-fresh-api", Name: "fresh-api-ref", Title: "Fresh API reference",
+		Description: "fresh api reference", Type: TypeReference,
+		Scope: FactScopeProject, UpdatedAt: now.Add(-24 * time.Hour),
+		Body: "The current API endpoint is /v2/status.",
+	})
+
+	result := AutoRecall(store, "api reference", RecallOptions{Now: now})
+	if len(result.Hits) != 2 {
+		t.Fatalf("expected stale + fresh hits, got %d: %+v", len(result.Hits), result.Hits)
+	}
+	block := result.Block()
+	if strings.Contains(block, "legacy detail") {
+		t.Fatalf("stale hit leaked its full body into the block:\n%s", block)
+	}
+	if !strings.Contains(block, "use the memory tool") {
+		t.Fatalf("stale hit should hint at the memory tool:\n%s", block)
+	}
+	if !strings.Contains(block, "/v2/status") {
+		t.Fatalf("fresh hit should keep its snippet:\n%s", block)
+	}
+}
+
+// With a tight budget, stale pointers that do not fit are omitted (and
+// counted), never clipped into a partial entry; fresh hits still clip.
+func TestAutoRecallOmitsStalePointersBeyondBudget(t *testing.T) {
+	store := recallTestStore(t)
+	now := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	for _, id := range []string{"mem-s1", "mem-s2", "mem-s3", "mem-s4"} {
+		recallTestWrite(t, store.Dir, Memory{
+			ID: id, Name: "stale-" + id, Title: "Stale ref " + id,
+			Description: "api reference " + id, Type: TypeReference,
+			Scope: FactScopeProject, UpdatedAt: now.AddDate(0, -6, 0),
+			Body: "legacy endpoint " + id,
+		})
+	}
+	result := AutoRecall(store, "api reference", RecallOptions{Now: now, MaxChars: 400})
+	if len(result.Hits) >= 4 {
+		t.Fatalf("expected some stale hits omitted at a 400-rune budget, got %d", len(result.Hits))
+	}
+	if result.Omitted == 0 {
+		t.Fatalf("expected Omitted > 0: %+v", result)
+	}
+	// The omitted note itself costs budget, so a tight budget may drop it;
+	// the omit counter above is the contract.
 }


### PR DESCRIPTION
## Summary

自动召回块（recall block）里，stale 命中仅 `score *= 0.92` 仍渲染完整 snippet，与新鲜事实花同样的预算，但其内容可能已过时。本 PR 将**所有 stale 命中折叠为指针**——输出 id/revision/scope/type/freshness=stale/reason（matched terms）+ "use the memory tool" 提示，不再带 snippet；fresh/current 命中完全不变。

与 #8144（索引侧 stale 折叠，已获维护者认可）形成对称：索引投影折叠 stale，召回块同样折叠 stale——"陈旧事实不占预算，按需用 memory 工具查"的同一理念闭环。

## Design decisions

- **折叠而非排除**：曾考虑 SoftSuppress（排除"从未 verify 的 stale"），重审后移除——`memoryFreshness` 的时钟已是 max(UpdatedAt, LastVerifiedAt)，verify 后 stale 自动变 current，SoftSuppress 的区分冗余，且"完全排除"会丢失可发现性（模型不知道有这些事实）。折叠保留 identity + reason，模型可决定是否查证。
- **reason 保留**：指针带 matched terms，模型知道该 stale 事实为何被召回。
- **超预算 omit 而非 clip**：stale 指针（~120 runes）都放不下时预算已极度紧张，空间留给新鲜事实；omit 计入 `Omitted`，不污染 `used`。
- **Note on `score`**：折叠后的 stale 条目不带 `score` 字段，但 score 仍内部参与排序与 `KeepTopRelativeScore` 淘汰——低分 stale 仍可能在渲染前被剪掉（既有行为，本 PR 未改）。

## Verification

- `TestAutoRecallFoldsStaleHitsToPointer`：stale 折叠 + fresh 保留 snippet
- `TestAutoRecallOmitsStalePointersBeyondBudget`：紧预算下 stale 指针 omit + Omitted 计数
- `TestAutoRecallLabelsStaleFactsAndBoundsProviderBlock`（更新）：stale 折叠后仍满足预算/XML/脱敏约束
- `TestAutoRecallRedactsLocalHomeInFreshHit`（新增）：脱敏在 fresh 命中仍生效
- `go test ./internal/memory/ ./internal/control/` 全绿；`gofmt -l` 无输出；`go vet` 通过；repolint clean

## Documentation impact

Documentation-impact: none - 无用户可见命令/配置变化（模型可见的 recall 输出形态变化，无文档承诺其格式）

## Cache impact

Cache-impact: none - recall block 是 turn-tail 注入（control/input.go 追加到 user 消息），不进 cache-stable 稳定前缀；本 PR 只缩短 block 内容，不改变注入位置或任何前缀字节。
Cache-guard: go test ./internal/memory -run "TestAutoRecallFoldsStaleHitsToPointer|TestAutoRecallLabelsStale"（既有 recall 测试 + boot golden 无漂移）
System-prompt-review: esengine - 记忆召回侧输出形态变化，turn-tail 注入，稳定前缀字节不变；需维护者确认后合并。

> **补充**（review 迭代）：本 PR 还包含 H3——2 字 CJK 查询（如"部署"）
> 分词后是单个 bigram，被 strongRecallMatch 的 lone-bigram 守卫误杀，
> 精确点名已存事实永不自动召回。修复：仅当查询整体恰好是一个 2 字 CJK
> 词时放行该 lone bigram（`len(queryTerms)==1 && isCJKBigram`），
> 英文单词与 3+ 字弱匹配仍保持保守。新增回归测试
> `TestAutoRecallExactTwoCharCJKQueryIsDistinctive`。