### PR TITLE
fix(desktop): restore mid-stream history and hide Auto Guard steers / 修复中途打开会话丢历史并隐藏 Auto Guard 引导

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5682,6 +5682,9 @@ func (state *historyMessageConvertState) convertHistoryMessage(
 	}
 	if m.LocalOnly {
 		if steerText, isSteer := agent.SteerText(agent.UserMessageText(m)); isSteer {
+			if agent.IsHostRecoveryGuidance(steerText) {
+				return out
+			}
 			return append(out, HistoryMessage{
 				Role:    "notice",
 				Content: agent.UnappliedSteerNotice(steerText),
@@ -5706,6 +5709,9 @@ func (state *historyMessageConvertState) convertHistoryMessage(
 		// Check against the raw m.Content: resolveUserContent applies
 		// StripComposePrefixes which trims trailing whitespace.
 		if steerText, isSteer := agent.SteerText(agent.UserMessageText(m)); isSteer {
+			if agent.IsHostRecoveryGuidance(steerText) {
+				return out
+			}
 			return append(out, HistoryMessage{Role: "notice", Content: "↪ " + steerText})
 		}
 		content = historyUserDisplayContent(m, resolveUserContent)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5681,16 +5681,8 @@ func (state *historyMessageConvertState) convertHistoryMessage(
 		})
 	}
 	if m.LocalOnly {
-		if steerText, isSteer := agent.SteerText(agent.UserMessageText(m)); isSteer {
-			if agent.IsHostRecoveryGuidance(steerText) {
-				return out
-			}
-			return append(out, HistoryMessage{
-				Role:    "notice",
-				Content: agent.UnappliedSteerNotice(steerText),
-				Code:    event.NoticeCodeUnappliedSteer,
-				Level:   "warn",
-			})
+		if rows, handled := historySteerRows(agent.UserMessageText(m), true); handled {
+			return append(out, rows...)
 		}
 	}
 	if state.suppressCanonicalTurn {
@@ -5708,11 +5700,8 @@ func (state *historyMessageConvertState) convertHistoryMessage(
 		// regular user bubble or being filtered as synthetic (#4044).
 		// Check against the raw m.Content: resolveUserContent applies
 		// StripComposePrefixes which trims trailing whitespace.
-		if steerText, isSteer := agent.SteerText(agent.UserMessageText(m)); isSteer {
-			if agent.IsHostRecoveryGuidance(steerText) {
-				return out
-			}
-			return append(out, HistoryMessage{Role: "notice", Content: "↪ " + steerText})
+		if rows, handled := historySteerRows(agent.UserMessageText(m), false); handled {
+			return append(out, rows...)
 		}
 		content = historyUserDisplayContent(m, resolveUserContent)
 		if control.IsSyntheticUserMessage(content) {

--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -1,9 +1,10 @@
 // Run: tsx src/__tests__/hydrate-history-apply.test.ts
 
 import {
+  duplicateLiveItemIds,
   hasCachedLiveTurn,
+  hydratedHistoryApplyMode,
   sameSessionPlaceholderItems,
-  shouldApplyHydratedHistory,
 } from "../lib/hydrateHistoryApply";
 
 let passed = 0;
@@ -21,34 +22,49 @@ function ok(value: boolean, label: string) {
 
 console.log("\nhydrate history apply");
 
-ok(!shouldApplyHydratedHistory(true, true, false, { items: [] }), "skipHistory blocks apply");
-ok(!shouldApplyHydratedHistory(false, false, false, { items: [] }), "missing projection blocks apply");
-ok(shouldApplyHydratedHistory(false, true, false, { items: [] }), "idle empty surface applies history");
+const mode = hydratedHistoryApplyMode;
+
+ok(mode(true, true, false, { items: [] }) === "skip", "skipHistory blocks apply");
+ok(mode(false, false, false, { items: [] }) === "skip", "missing projection blocks apply");
+ok(mode(false, true, false, { items: [] }) === "replace", "idle empty surface applies history");
+ok(mode(false, true, true, { running: true, items: [] }) === "replace", "running empty surface applies history");
 ok(
-  shouldApplyHydratedHistory(false, true, true, { running: true, items: [] }),
-  "running empty surface applies history",
+  mode(false, true, true, { running: true, live: { text: "partial" }, items: [] }) === "replace",
+  "a mid-stream surface with no rows yet applies history",
 );
 ok(
-  !shouldApplyHydratedHistory(false, true, true, {
-    running: true,
-    items: [{ kind: "user" }],
-  }),
-  "running visible transcript is not replaced",
+  mode(false, true, true, { running: true, items: [{ kind: "user" }] }) === "prepend",
+  "a running turn with no history page behind it gets one prepended",
 );
 ok(
-  !shouldApplyHydratedHistory(false, true, true, {
-    running: true,
-    live: { text: "partial" },
-    items: [],
-  }),
-  "running live stream without items is not replaced",
+  mode(false, true, true, { running: true, historyTotalTurns: 3, items: [{ kind: "user" }] }) === "skip",
+  "an already-hydrated running transcript is left alone",
 );
 ok(
   hasCachedLiveTurn({
     running: true,
+    historyTotalTurns: 2,
     items: [{ kind: "assistant", streaming: true }],
   }),
   "streaming assistant counts as a cached live turn",
+);
+ok(
+  !hasCachedLiveTurn({ running: true, items: [{ kind: "assistant", streaming: true }] }),
+  "a live turn with no history page behind it is not cached",
+);
+ok(
+  duplicateLiveItemIds(
+    [{ kind: "user", id: "h1", text: "ask" }],
+    [{ kind: "user", id: "l1", text: "ask" }, { kind: "assistant", id: "l2", text: "" }],
+  ).join(",") === "l1",
+  "a live row the page already carries is dropped",
+);
+ok(
+  duplicateLiveItemIds(
+    [{ kind: "user", id: "h1", text: "ask" }],
+    [{ kind: "assistant", id: "l2", text: "" }],
+  ).length === 0,
+  "a live tail the page does not carry is kept",
 );
 ok(
   sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "b.jsonl" }, items: [{ kind: "user" }] }) === undefined,

--- a/desktop/frontend/src/__tests__/running-tab-history-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/running-tab-history-hydration.test.tsx
@@ -1,0 +1,265 @@
+// Run: tsx src/__tests__/running-tab-history-hydration.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { AppBindings } from "../lib/bridge";
+import { useController } from "../lib/useController";
+import { historySliceFromMessages } from "./mockHistorySlice";
+import type { BalanceInfo, CheckpointMeta, ContextInfo, EffortInfo, HistoryMessage, HistorySliceRequest, JobView, Meta, TabMeta, WireEvent } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) ok(true, label);
+  else ok(false, `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function waitFor(label: string, predicate: () => boolean) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await act(async () => {
+      await flushPromises();
+    });
+    if (predicate()) return;
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function settle() {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    await act(async () => {
+      await flushPromises();
+    });
+  }
+}
+
+function tabMeta(id: string, overrides: Partial<TabMeta> = {}): TabMeta {
+  const workspaceRoot = `/repo/${id}`;
+  return {
+    id,
+    scope: "project",
+    workspaceRoot,
+    workspaceName: id,
+    workspacePath: workspaceRoot,
+    gitBranch: "main",
+    topicId: `topic-${id}`,
+    topicTitle: id,
+    sessionPath: `${workspaceRoot}/sessions/${id}.jsonl`,
+    label: `model-${id}`,
+    ready: true,
+    running: false,
+    mode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    active: false,
+    cwd: workspaceRoot,
+    ...overrides,
+  };
+}
+
+function metaFor(tab: TabMeta): Meta {
+  return {
+    label: tab.label,
+    ready: tab.ready,
+    startupErr: tab.startupErr,
+    eventChannel: "agent:event",
+    cwd: tab.cwd || tab.workspaceRoot,
+    workspaceRoot: tab.workspaceRoot,
+    workspaceName: tab.workspaceName,
+    workspacePath: tab.workspacePath,
+    sessionPath: tab.sessionPath,
+    sessionRevision: tab.sessionRevision,
+    sessionDigest: tab.sessionDigest,
+    gitBranch: tab.gitBranch,
+    autoApproveTools: false,
+    bypass: false,
+    collaborationMode: tab.collaborationMode ?? "normal",
+    toolApprovalMode: tab.toolApprovalMode ?? "ask",
+    tokenMode: tab.tokenMode ?? "full",
+    goal: "",
+    goalStatus: "stopped",
+  };
+}
+
+function userMessage(content: string): HistoryMessage {
+  return { role: "user", content };
+}
+
+console.log("\nrunning tab history hydration");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+const context: ContextInfo = { used: 12, window: 100, sessionTokens: 12 };
+const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
+const balance: BalanceInfo = { available: false, display: "" };
+const jobs: JobView[] = [];
+const checkpoints: CheckpointMeta[] = [];
+
+const tabA = tabMeta("tab-a", { active: true });
+// The session the user clicks into: it has been running for a while, so the
+// backend reports it running before hydration finishes.
+const tabR = tabMeta("tab-r");
+const tabsById = new Map([tabA, tabR].map((tab) => [tab.id, tab]));
+const runningTabs = new Set<string>(["tab-r"]);
+let backendActiveId = "tab-a";
+const eventHandlers: Array<(e: WireEvent) => void> = [];
+const readyHandlers: Array<(tabId?: string) => void> = [];
+
+function currentTabs(): TabMeta[] {
+  return Array.from(tabsById.values()).map((tab) => {
+    const running = runningTabs.has(tab.id);
+    return { ...tab, active: tab.id === backendActiveId, running, cancellable: running };
+  });
+}
+
+function historyFor(tabID: string): HistoryMessage[] {
+  if (tabID === "tab-r") return [userMessage("history R 1"), userMessage("history R 2")];
+  if (tabID === "tab-s") return [userMessage("history S")];
+  return [userMessage("cached A")];
+}
+
+window.runtime = {
+  EventsOn: (name: string, cb: (...data: unknown[]) => void) => {
+    if (name === "agent:event") eventHandlers.push(cb as (e: WireEvent) => void);
+    if (name === "agent:ready") readyHandlers.push(cb as (tabId?: string) => void);
+    return () => {};
+  },
+  BrowserOpenURL: () => {},
+};
+window.go = {
+  main: {
+    App: {
+      ListTabs: async () => currentTabs(),
+      MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
+      ContextUsageForTab: async () => context,
+      EffortForTab: async () => effort,
+      BalanceForTab: async () => balance,
+      JobsForTab: async () => jobs,
+      CheckpointsForTab: async () => checkpoints,
+      HistoryForTab: async (tabID: string) => historyFor(tabID),
+      HistoryPageForTab: async (tabID: string) => {
+        const messages = historyFor(tabID);
+        const turns = messages.filter((message) => message.role === "user").length;
+        return { messages, startTurn: 0, endTurn: turns, totalTurns: turns, hasOlder: false };
+      },
+      HistorySliceForTab: async (tabID: string, req: HistorySliceRequest) =>
+        historySliceFromMessages(tabID, historyFor(tabID), req),
+      HistoryCheckpointTurnsForTab: async () => [],
+      ReplayPendingPrompts: async () => {},
+      SetActiveTab: async (tabID: string) => {
+        backendActiveId = tabID;
+      },
+      CancelTab: async (tabID: string) => {
+        runningTabs.delete(tabID);
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+type Controller = ReturnType<typeof useController>;
+let controller: Controller | undefined;
+
+function Probe() {
+  controller = useController();
+  return null;
+}
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing root");
+const root = createRoot(rootEl);
+
+await act(async () => {
+  root.render(<Probe />);
+  await flushPromises();
+});
+
+await waitFor(
+  "initial active tab hydrated",
+  () => controller?.activeTabId === "tab-a" && controller.state.items.some((item) => item.kind === "user" && item.text === "cached A"),
+);
+
+// Clicking a session that the backend already reports as running: the tab has
+// no cached transcript, so hydration is the only thing that can put the
+// conversation on screen.
+await act(async () => {
+  void controller?.switchTab("tab-r", { ...tabR, running: true, cancellable: true });
+  await flushPromises();
+});
+await settle();
+
+eq(controller?.activeTabId, "tab-r", "switching to the running session activates its tab");
+eq(controller?.state.running, true, "the running session keeps its live status");
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history R 1") ?? false,
+  "an uncached running session still hydrates its persisted history",
+);
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history R 2") ?? false,
+  "the whole history page lands, not just the newest turn",
+);
+
+// Second door: a session that is mid-stream when it is opened. Its live text
+// makes the transcript look cached, which used to skip the history fetch
+// outright and leave the streaming turn floating over an empty transcript.
+tabsById.set("tab-s", tabMeta("tab-s"));
+runningTabs.add("tab-s");
+await act(async () => {
+  for (const handler of eventHandlers) {
+    handler({ kind: "turn_started", tabId: "tab-s" } as WireEvent);
+    handler({ kind: "text", tabId: "tab-s", text: "streaming S" } as WireEvent);
+  }
+  await flushPromises();
+});
+await act(async () => {
+  void controller?.switchTab("tab-s", { ...tabsById.get("tab-s")!, running: true, cancellable: true });
+  await flushPromises();
+});
+await settle();
+
+eq(controller?.activeTabId, "tab-s", "switching to the streaming session activates its tab");
+ok(
+  controller?.state.items.some((item) => item.kind === "user" && item.text === "history S") ?? false,
+  "a mid-stream session still fetches and installs its history",
+);
+ok(controller?.state.live !== undefined, "installing history leaves the live stream alone");
+eq(controller?.state.items[0]?.kind, "user", "the persisted page lands in front of the streaming turn");
+eq(controller?.state.items[controller.state.items.length - 1]?.kind, "assistant", "the streaming turn stays at the tail");
+
+await act(async () => {
+  root.unmount();
+});
+dom.window.close();
+
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -628,7 +628,7 @@ ok(controller?.state.items.some((item) => item.kind === "user" && item.text === 
 const tabCUser = controller?.state.items.find((item) => item.kind === "user" && item.text === "streaming C");
 eq(tabCUser?.kind === "user" && tabCUser.submissionId, tabCSubmissionId, "Wails receives the same opaque correlation stored on the optimistic user");
 ok(Boolean(tabCSubmissionId) && tabCSubmissionId !== tabCUser?.id, "opaque submission correlation is distinct from the render item id");
-ok(!historyCalls.includes("tab-c"), "cached running tab skips history hydration");
+ok(historyCalls.includes("tab-c"), "a running tab with no history page of its own still hydrates one");
 await act(async () => {
   submitTabCGate.resolve();
   await submitTabCGate.promise;

--- a/desktop/frontend/src/__tests__/transcript-rows.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-rows.test.ts
@@ -176,6 +176,20 @@ const keys = (rows: TranscriptRow[]) => rows.map((row) => row.key).join(",");
 
 {
   const models = buildTurnModels([
+    { kind: "user", id: "u1", text: "请继续完成 PPT 任务" },
+    { kind: "assistant", id: "a-step", text: "下一步：安装 pptxgenjs 并确认 Pillow。", reasoning: "", streaming: false },
+    { kind: "notice", id: "auto-guard", level: "info", text: "↪ A tool failed. Use read-only diagnosis as needed, continue unrelated work automatically." },
+    { kind: "notice", id: "user-steer", level: "info", text: "↪ 改用 Pillow 10 验证" },
+    { kind: "assistant", id: "a-done", text: "pptxgenjs 已安装成功", reasoning: "", streaming: false },
+  ]);
+  const rows = buildTranscriptRows(models, rowOptions(EMPTY_FOLDS));
+  eq(kinds(rows), "user,answer,notice,answer,turn-actions", "host Auto Guard guidance is not a user-side steer row");
+  const notice = rows.find((row) => row.kind === "notice");
+  eq(notice && "item" in notice ? notice.item.text : "", "↪ 改用 Pillow 10 验证", "real user steers stay visible");
+}
+
+{
+  const models = buildTurnModels([
     { kind: "user", id: "u1", text: "cancelled before output" },
   ]);
   const withoutCheckpoint = buildTranscriptRows(models, rowOptions(EMPTY_FOLDS));

--- a/desktop/frontend/src/__tests__/use-controller-history-live-race.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-history-live-race.test.tsx
@@ -161,7 +161,11 @@ await waitFor("hydration completion", () => controller?.state.hydrating === fals
 
 ok(controller?.state.running ?? false, "late history keeps the live turn running");
 ok(controller?.state.items.some((item) => item.kind === "assistant" && item.streaming) ?? false, "late history keeps the live assistant stream");
-ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "stale durable history") ?? false), "late history cannot replace the live transcript");
+// The page read before the turn started is this session's history, not a
+// competing version of it: it goes in front of the live turn instead of
+// replacing it, so the turn never streams over a blank transcript.
+ok(controller?.state.items[0]?.kind === "user", "late history lands in front of the live turn");
+ok(controller?.state.items.at(-1)?.kind === "assistant", "late history leaves the live turn at the tail");
 
 await act(async () => { root.unmount(); });
 dom.window.close();

--- a/desktop/frontend/src/lib/hostRecoverySteer.ts
+++ b/desktop/frontend/src/lib/hostRecoverySteer.ts
@@ -1,0 +1,11 @@
+/** Model-facing Auto Guard policy. Must not render as a user-side steer. */
+const HOST_RECOVERY_PREFIXES = [
+  "A tool failed. Use read-only diagnosis as needed",
+  "The tool timed out or hit a transient execution limit.",
+];
+
+export function isHostRecoveryGuidance(text: string): boolean {
+  const trimmed = text.trim();
+  const body = trimmed.startsWith("↪ ") ? trimmed.slice("↪ ".length).trimStart() : trimmed;
+  return HOST_RECOVERY_PREFIXES.some((prefix) => body.startsWith(prefix));
+}

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -5,11 +5,18 @@ export type HydrateLiveState = {
   live?: unknown;
   currentAssistant?: unknown;
   pendingUser?: unknown;
+  historyTotalTurns?: number;
   items: ReadonlyArray<{ kind: string; streaming?: boolean; status?: string }>;
 };
 
+export type HydratedHistoryApplyMode = "replace" | "prepend" | "skip";
+
+// A live turn is only "cached" once a history page has landed behind it.
+// Without that, a session opened mid-stream reports a cached turn, skips the
+// fetch, and streams over a blank transcript.
 export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean {
   if (!state?.running && !state?.turnActive) return false;
+  if ((state.historyTotalTurns ?? 0) === 0) return false;
   if (state.live || state.currentAssistant || state.pendingUser !== undefined) return true;
   return state.items.some((item) =>
     (item.kind === "assistant" && item.streaming) ||
@@ -17,17 +24,59 @@ export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean 
   );
 }
 
-// Skip replace when a live transcript is already on screen; an empty
-// surface still has to apply history or switch-back shows Welcome.
-export function shouldApplyHydratedHistory(
+// An empty surface has to apply history or switch-back shows Welcome. A turn
+// that has already streamed rows keeps them — but a tab with no history page
+// behind it still gets one, prepended, instead of a blank transcript above the
+// live turn. Only an already-hydrated live turn is left alone.
+export function hydratedHistoryApplyMode(
   skipHistory: boolean,
   hasProjection: boolean,
   foregroundTurnActive: boolean,
   state: HydrateLiveState | undefined,
-): boolean {
-  if (skipHistory || !hasProjection) return false;
-  if (!foregroundTurnActive) return true;
-  return (state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state);
+): HydratedHistoryApplyMode {
+  if (skipHistory || !hasProjection) return "skip";
+  if (!foregroundTurnActive) return "replace";
+  if ((state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state)) return "replace";
+  return (state?.historyTotalTurns ?? 0) === 0 ? "prepend" : "skip";
+}
+
+type SignatureItem = {
+  kind: string;
+  id: string;
+  text?: string;
+  reasoning?: string;
+  name?: string;
+  level?: string;
+  trigger?: string;
+  messages?: number;
+  surfaceKey?: string;
+  generation?: number;
+};
+
+function itemSignature(item: SignatureItem): string {
+  switch (item.kind) {
+    case "tool": return `tool|${item.id}|${item.name ?? ""}`;
+    case "extension": return `extension|${item.surfaceKey ?? ""}|${item.generation ?? 0}`;
+    case "compaction": return `compaction|${item.trigger ?? ""}|${item.messages ?? 0}`;
+    default: return `${item.kind}|${item.level ?? ""}|${item.text ?? ""}|${item.reasoning ?? ""}`;
+  }
+}
+
+// A page read while its turn is live can already carry rows the live stream
+// rendered. Only a suffix of the page can overlap a prefix of the live rows, so
+// the longest such match is the duplicate set.
+export function duplicateLiveItemIds(
+  pageItems: readonly SignatureItem[],
+  liveItems: readonly SignatureItem[],
+): string[] {
+  for (let k = Math.min(pageItems.length, liveItems.length); k > 0; k -= 1) {
+    let same = true;
+    for (let i = 0; i < k && same; i += 1) {
+      same = itemSignature(pageItems[pageItems.length - k + i]) === itemSignature(liveItems[i]);
+    }
+    if (same) return liveItems.slice(0, k).map((item) => item.id);
+  }
+  return [];
 }
 
 export function sameSessionPlaceholderItems<T>(

--- a/desktop/frontend/src/lib/transcriptRows.ts
+++ b/desktop/frontend/src/lib/transcriptRows.ts
@@ -10,6 +10,7 @@
 // auto-close on completion (unless the user toggled or the preference is
 // "expanded"), and preference switches applying to folds already on screen.
 
+import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { isBatchedReadOnlyTool, isSteerNoticeText, type ExtensionItem, type Item } from "./useController";
 import { appendTurnActionCopyText } from "./turnActionCopy";
 import { isCreationGroupableTool, toolGroupKind, type ToolGroupKind } from "../components/ToolGroup";
@@ -79,6 +80,9 @@ export function partitionTurnItems(items: readonly Item[], live: TranscriptLiveF
   for (const item of items) {
     if (item.kind === "user") continue;
     if (item.kind === "notice") {
+      if (isHostRecoveryGuidance(item.text)) {
+        continue;
+      }
       if (isSteerNoticeText(item.text)) {
         current.outsideItems.push(item);
         currentHasConversation = true;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -18,7 +18,8 @@ import { getTranscriptStore } from "./transcriptStore";
 import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
-import { hasCachedLiveTurn, sameSessionPlaceholderItems, shouldApplyHydratedHistory } from "./hydrateHistoryApply";
+import { isHostRecoveryGuidance } from "./hostRecoverySteer";
+import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameTodoList } from "./todoVisibility";
 import type { SearchSource } from "./searchSources";
@@ -1728,6 +1729,7 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, running: s.turnActive ? s.running : false, seq: s.seq + 1, items };
     }
     case "steer":
+      if (isHostRecoveryGuidance(e.text ?? "")) return s;
       return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `s${s.seq}`, level: "info", text: `${STEER_NOTICE_PREFIX}${e.text ?? ""}` }] };
     case "approval_request": {
       if (s.cancelRequested) return s;
@@ -2952,17 +2954,20 @@ export function useController() {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
-      if (projection !== undefined && shouldApplyHydratedHistory(skipHistory, true, foregroundTurnActive(), statesRef.current.get(tabId))) {
+      const applyMode = hydratedHistoryApplyMode(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId));
+      if (projection !== undefined && applyMode !== "skip") {
         if (deferResetUntilHistory && stillCurrent() && !foregroundTurnActive()) dispatchTo(tabId, { type: "reset" });
-        dispatchTo(tabId, {
-          type: "history_replace",
+        const page = {
           items: projection.items,
           startTurn: projection.startTurn,
           totalTurns: projection.totalTurns,
           hasOlder: projection.hasOlder,
           revision: projection.revisionKnown ? projection.revision : undefined,
           digest: projection.digest || undefined,
-        });
+        };
+        dispatchTo(tabId, applyMode === "prepend"
+          ? { type: "history_prepend", ...page, removeIds: duplicateLiveItemIds(projection.items, statesRef.current.get(tabId)?.items ?? []) }
+          : { type: "history_replace", ...page });
         addBreadcrumb(
           "tab.hydrate",
           `history page ${tabId} items=${projection.items.length} turns=${projection.startTurn}-${projection.endTurn}/${projection.totalTurns} ms=${Date.now() - historyStartedAt}`,

--- a/desktop/history_host_recovery_test.go
+++ b/desktop/history_host_recovery_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+)
+
+func TestHistoryMessagesHideHostRecoverySteer(t *testing.T) {
+	userPrompt := "请继续完成 PPT 任务，按昨天的素材清单生成。"
+	userSteer := "改用 Pillow 10 验证"
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: userPrompt},
+		{Role: provider.RoleAssistant, Content: "下一步：安装 pptxgenjs 并确认 Pillow。"},
+		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."},
+		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + userSteer},
+		{Role: provider.RoleAssistant, Content: "pptxgenjs 已安装成功"},
+	}
+	got := historyMessages(msgs, func(content string) string { return content })
+	var roles []string
+	var contents []string
+	for _, row := range got {
+		roles = append(roles, row.Role)
+		contents = append(contents, row.Content)
+		if strings.Contains(row.Content, "A tool failed") || strings.Contains(row.Content, "Use read-only diagnosis") {
+			t.Fatalf("host recovery guidance leaked into history: %+v", row)
+		}
+	}
+	if strings.Join(roles, ",") != "user,assistant,notice,assistant" {
+		t.Fatalf("history roles = %s, want user,assistant,notice,assistant", strings.Join(roles, ","))
+	}
+	if contents[0] != userPrompt {
+		t.Fatalf("user prompt = %q, want original task prompt", contents[0])
+	}
+	if contents[2] != "↪ "+userSteer {
+		t.Fatalf("user steer = %q, want visible mid-turn steer", contents[2])
+	}
+}

--- a/desktop/history_steer.go
+++ b/desktop/history_steer.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+func historySteerRows(content string, unapplied bool) ([]HistoryMessage, bool) {
+	text, handled := agent.ReplaySteerText(content)
+	if !handled {
+		return nil, false
+	}
+	if text == "" {
+		return nil, true
+	}
+	if unapplied {
+		return []HistoryMessage{{
+			Role:    "notice",
+			Content: agent.UnappliedSteerNotice(text),
+			Code:    event.NoticeCodeUnappliedSteer,
+			Level:   "warn",
+		}}, true
+	}
+	return []HistoryMessage{{Role: "notice", Content: "↪ " + text}}, true
+}

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -20,37 +20,6 @@ import (
 	"reasonix/internal/tool"
 )
 
-func TestHistoryMessagesHideHostRecoverySteer(t *testing.T) {
-	userPrompt := "请继续完成 PPT 任务，按昨天的素材清单生成。"
-	userSteer := "改用 Pillow 10 验证"
-	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: userPrompt},
-		{Role: provider.RoleAssistant, Content: "下一步：安装 pptxgenjs 并确认 Pillow。"},
-		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."},
-		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + userSteer},
-		{Role: provider.RoleAssistant, Content: "pptxgenjs 已安装成功"},
-	}
-	got := historyMessages(msgs, func(content string) string { return content })
-	var roles []string
-	var contents []string
-	for _, row := range got {
-		roles = append(roles, row.Role)
-		contents = append(contents, row.Content)
-		if strings.Contains(row.Content, "A tool failed") || strings.Contains(row.Content, "Use read-only diagnosis") {
-			t.Fatalf("host recovery guidance leaked into history: %+v", row)
-		}
-	}
-	if strings.Join(roles, ",") != "user,assistant,notice,assistant" {
-		t.Fatalf("history roles = %s, want user,assistant,notice,assistant", strings.Join(roles, ","))
-	}
-	if contents[0] != userPrompt {
-		t.Fatalf("user prompt = %q, want original task prompt", contents[0])
-	}
-	if contents[2] != "↪ "+userSteer {
-		t.Fatalf("user steer = %q, want visible mid-turn steer", contents[2])
-	}
-}
-
 func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "expanded prompt", CreatedAt: 1_718_000_000_000},

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -20,6 +20,37 @@ import (
 	"reasonix/internal/tool"
 )
 
+func TestHistoryMessagesHideHostRecoverySteer(t *testing.T) {
+	userPrompt := "请继续完成 PPT 任务，按昨天的素材清单生成。"
+	userSteer := "改用 Pillow 10 验证"
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: userPrompt},
+		{Role: provider.RoleAssistant, Content: "下一步：安装 pptxgenjs 并确认 Pillow。"},
+		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."},
+		{Role: provider.RoleUser, Content: agent.MidTurnSteerPrefix + "\n" + userSteer},
+		{Role: provider.RoleAssistant, Content: "pptxgenjs 已安装成功"},
+	}
+	got := historyMessages(msgs, func(content string) string { return content })
+	var roles []string
+	var contents []string
+	for _, row := range got {
+		roles = append(roles, row.Role)
+		contents = append(contents, row.Content)
+		if strings.Contains(row.Content, "A tool failed") || strings.Contains(row.Content, "Use read-only diagnosis") {
+			t.Fatalf("host recovery guidance leaked into history: %+v", row)
+		}
+	}
+	if strings.Join(roles, ",") != "user,assistant,notice,assistant" {
+		t.Fatalf("history roles = %s, want user,assistant,notice,assistant", strings.Join(roles, ","))
+	}
+	if contents[0] != userPrompt {
+		t.Fatalf("user prompt = %q, want original task prompt", contents[0])
+	}
+	if contents[2] != "↪ "+userSteer {
+		t.Fatalf("user steer = %q, want visible mid-turn steer", contents[2])
+	}
+}
+
 func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "expanded prompt", CreatedAt: 1_718_000_000_000},

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -779,7 +779,12 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	// change the previewed path even when the concrete tool returned an error.
 	a.finalizeObservedToolReceipts(plan, result, execution, err)
 	if a.svc.recoveryGate != nil {
-		a.observeRecoveryResult(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, false, false, recoveryGen)
+		// Ride the failed tool result so the model sees the policy on this
+		// same turn. Do not Steer: that persists a fake user message and
+		// the desktop renders it on the user side of the transcript.
+		if guidance := a.observeRecoveryResult(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, false, false, recoveryGen); guidance != "" {
+			result = appendHostRecoveryGuidance(result, guidance)
+		}
 	}
 	if err != nil {
 		detail := result

--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -778,14 +778,7 @@ func (a *Agent) finishToolExecution(ctx context.Context, plan *toolCallPlan) too
 	// Always re-read after post hooks — partial writes and hook side effects can
 	// change the previewed path even when the concrete tool returned an error.
 	a.finalizeObservedToolReceipts(plan, result, execution, err)
-	if a.svc.recoveryGate != nil {
-		// Ride the failed tool result so the model sees the policy on this
-		// same turn. Do not Steer: that persists a fake user message and
-		// the desktop renders it on the user side of the transcript.
-		if guidance := a.observeRecoveryResult(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, false, false, recoveryGen); guidance != "" {
-			result = appendHostRecoveryGuidance(result, guidance)
-		}
-	}
+	result = a.withRecoveryObservation(ctx, evidenceName, evidenceArgs, readOnly, mutates, result, err, recoveryGen)
 	if err != nil {
 		detail := result
 		// Malformed-args failures are a transient model JSON glitch (e.g. options

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -301,9 +301,22 @@ func IsHostRecoveryGuidance(text string) bool {
 // VisibleSteerText is the user-authored mid-turn steer the transcript may
 // show. Host Auto Guard policy is not user-authored and must stay hidden.
 func VisibleSteerText(content string) (string, bool) {
-	text, ok := SteerText(content)
-	if !ok || IsHostRecoveryGuidance(text) {
+	text, handled := ReplaySteerText(content)
+	if !handled || text == "" {
 		return "", false
+	}
+	return text, true
+}
+
+// ReplaySteerText reports a persisted steer for display replay. handled is
+// true for any steer; text is empty when host Auto Guard policy must be omitted.
+func ReplaySteerText(content string) (text string, handled bool) {
+	text, isSteer := SteerText(content)
+	if !isSteer {
+		return "", false
+	}
+	if IsHostRecoveryGuidance(text) {
+		return "", true
 	}
 	return text, true
 }

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -250,6 +250,14 @@ func hasLegacyProviderWrapper(content string) bool {
 	return HandoffTask(stripped) != stripped
 }
 
+// Auto Guard writes these onto the failed tool result for the model. Older
+// sessions may still have them persisted as mid-turn user steers; display
+// paths must hide those so they never appear as the user's own words.
+const (
+	HostRecoveryGuidanceToolFailedPrefix = "A tool failed. Use read-only diagnosis as needed"
+	HostRecoveryGuidanceTransientPrefix  = "The tool timed out or hit a transient execution limit."
+)
+
 // SyntheticUserPrefixes lists the openings of host-injected user-role messages
 // (readiness retries, stream recovery, goal-loop nudges, compaction folds).
 // They are persisted with role "user" for provider-contract reasons but are not
@@ -273,12 +281,43 @@ var SyntheticUserPrefixes = []string{
 	"The agent signaled goal completion and all tasks are marked done.",
 	"Goal signaled complete but issues remain:",
 	"No tool calls in recent turns.",
+	HostRecoveryGuidanceToolFailedPrefix,
+	HostRecoveryGuidanceTransientPrefix,
+}
+
+// IsHostRecoveryGuidance reports model-facing Auto Guard policy text.
+func IsHostRecoveryGuidance(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	if after, ok := strings.CutPrefix(trimmed, "↪ "); ok {
+		trimmed = strings.TrimSpace(after)
+	}
+	return strings.HasPrefix(trimmed, HostRecoveryGuidanceToolFailedPrefix) ||
+		strings.HasPrefix(trimmed, HostRecoveryGuidanceTransientPrefix)
+}
+
+// VisibleSteerText is the user-authored mid-turn steer the transcript may
+// show. Host Auto Guard policy is not user-authored and must stay hidden.
+func VisibleSteerText(content string) (string, bool) {
+	text, ok := SteerText(content)
+	if !ok || IsHostRecoveryGuidance(text) {
+		return "", false
+	}
+	return text, true
 }
 
 // IsSyntheticUserText reports whether a persisted user-role message is a
 // host-injected synthetic turn rather than user-authored input.
 func IsSyntheticUserText(content string) bool {
 	trimmed := strings.TrimSpace(StripTransientUserBlocks(content))
+	if IsHostRecoveryGuidance(trimmed) {
+		return true
+	}
+	if text, ok := SteerText(content); ok && IsHostRecoveryGuidance(text) {
+		return true
+	}
 	for _, prefix := range SyntheticUserPrefixes {
 		if strings.HasPrefix(trimmed, prefix) {
 			return true

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -183,3 +183,28 @@ func mcContract(t *testing.T, sourceEvent string) string {
 	}
 	return "<memory-compiler-execution>\n" + string(body) + "\n</memory-compiler-execution>"
 }
+
+func TestIsHostRecoveryGuidance(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "tool failed", in: HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically.", want: true},
+		{name: "transient", in: HostRecoveryGuidanceTransientPrefix + " Inspect its current state.", want: true},
+		{name: "steer notice prefix", in: "↪ " + HostRecoveryGuidanceToolFailedPrefix + ", continue.", want: true},
+		{name: "user quoting failure", in: "A tool failed yesterday, please retry the install.", want: false},
+		{name: "user steer", in: "改用 Pillow 10 验证", want: false},
+	}
+	for _, tc := range cases {
+		if got := IsHostRecoveryGuidance(tc.in); got != tc.want {
+			t.Errorf("%s: IsHostRecoveryGuidance(%q) = %v, want %v", tc.name, tc.in, got, tc.want)
+		}
+	}
+	if text, ok := VisibleSteerText(MidTurnSteerPrefix + "\n改用 Pillow 10 验证"); !ok || text != "改用 Pillow 10 验证" {
+		t.Fatalf("VisibleSteerText user steer = %q %v", text, ok)
+	}
+	if text, ok := VisibleSteerText(MidTurnSteerPrefix + "\n" + HostRecoveryGuidanceToolFailedPrefix + ", continue."); ok {
+		t.Fatalf("VisibleSteerText host recovery = %q, want hidden", text)
+	}
+}

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -251,6 +251,13 @@ func appendHostRecoveryGuidance(result, guidance string) string {
 	return strings.TrimRight(result, "\n") + "\n\n" + guidance
 }
 
+func (a *Agent) withRecoveryObservation(ctx context.Context, toolName string, args json.RawMessage, readOnly, mutates bool, result string, err error, generation uint64) string {
+	if a == nil || a.svc.recoveryGate == nil {
+		return result
+	}
+	return appendHostRecoveryGuidance(result, a.observeRecoveryResult(ctx, toolName, args, readOnly, mutates, result, err, false, false, generation))
+}
+
 func (a *Agent) recoveryEpisodeControl() RecoveryEpisodeControl {
 	if a == nil || a.svc.recoveryGate == nil {
 		return nil

--- a/internal/agent/recovery_gate.go
+++ b/internal/agent/recovery_gate.go
@@ -30,9 +30,9 @@ type recoveryIdentity struct {
 // mutation classification, and before permission approval and workspace
 // write-lock acquisition, so a waiting decision never holds a write lease.
 type RecoveryGate interface {
-	// ObserveResult records a completed call and returns optional guidance for
-	// the same agent's active turn. The caller, not the gate, owns delivery so a
-	// root or sub-agent failure can never start a concurrent controller turn.
+	// ObserveResult records a completed call and returns optional model-facing
+	// guidance for the same agent's active turn. The caller appends that text
+	// to the tool result. Do not deliver it as a user steer.
 	ObserveResult(ctx context.Context, result RecoveryObservation) string
 	BeforeMutation(ctx context.Context, proposal RecoveryProposal) (RecoveryDecision, error)
 }
@@ -186,9 +186,9 @@ const (
 	RecoveryActionRevise       RecoveryAction = "revise"
 )
 
-func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args json.RawMessage, readOnly, mutates bool, result string, err error, blocked, userRejected bool, generation uint64) {
+func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args json.RawMessage, readOnly, mutates bool, result string, err error, blocked, userRejected bool, generation uint64) string {
 	if a == nil || a.svc.recoveryGate == nil {
-		return
+		return ""
 	}
 	verification := toolName == "bash" && evidence.IsDeliveryVerificationCommand(bashCommandFromArgs(args))
 	success := err == nil && !blocked
@@ -218,7 +218,7 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 			generation = ctrl.Generation()
 		}
 	}
-	guidance := a.svc.recoveryGate.ObserveResult(ctx, RecoveryObservation{
+	return strings.TrimSpace(a.svc.recoveryGate.ObserveResult(ctx, RecoveryObservation{
 		AgentID:      a.recovery.agentID,
 		TaskID:       a.recovery.taskID,
 		TaskScopeID:  recoveryTaskScopeID(a.task.scopeID, a.recovery.runSeq.Load()),
@@ -237,14 +237,18 @@ func (a *Agent) observeRecoveryResult(ctx context.Context, toolName string, args
 		EmptySearch:  emptySearch,
 		ErrSummary:   errSummary,
 		Output:       result,
-	})
-	if strings.TrimSpace(guidance) != "" {
-		// Tool execution happens inside Agent.Run, so this targets the exact root
-		// or sub-agent turn that failed. Never fall back to Controller.Steer here:
-		// synchronous headless Run does not participate in controller admission,
-		// and a fallback would start a second Agent.Run concurrently.
-		_ = a.Steer(guidance)
+	}))
+}
+
+func appendHostRecoveryGuidance(result, guidance string) string {
+	guidance = strings.TrimSpace(guidance)
+	if guidance == "" {
+		return result
 	}
+	if strings.TrimSpace(result) == "" {
+		return guidance
+	}
+	return strings.TrimRight(result, "\n") + "\n\n" + guidance
 }
 
 func (a *Agent) recoveryEpisodeControl() RecoveryEpisodeControl {

--- a/internal/agent/recovery_gate_test.go
+++ b/internal/agent/recovery_gate_test.go
@@ -18,6 +18,7 @@ type recordingRecoveryGate struct {
 	observation RecoveryObservation
 	proposals   []RecoveryProposal
 	decision    RecoveryDecision
+	guidance    string
 }
 
 func TestRecoveryPlanTransitionDetectsOnlyStructuralRewriteOfActivePlan(t *testing.T) {
@@ -57,7 +58,7 @@ func TestRecoveryPlanTransitionIgnoresCompletedPriorPlan(t *testing.T) {
 
 func (g *recordingRecoveryGate) ObserveResult(_ context.Context, observation RecoveryObservation) string {
 	g.observation = observation
-	return ""
+	return g.guidance
 }
 
 func (g *recordingRecoveryGate) BeforeMutation(_ context.Context, proposal RecoveryProposal) (RecoveryDecision, error) {
@@ -117,6 +118,29 @@ func TestPlanTransitionNeedsDedicatedReplacementAuthorization(t *testing.T) {
 	})
 	if out.errMsg == "" || !strings.Contains(out.output, "cannot be removed or replaced") {
 		t.Fatalf("plain allow unexpectedly replaced current todo: %+v", out)
+	}
+}
+
+func TestHostRecoveryGuidanceRidesToolResultNotSteer(t *testing.T) {
+	guidance := HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."
+	gate := &recordingRecoveryGate{guidance: guidance}
+	sink := &recordSink{}
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "fail_tool"})
+	a := New(nil, reg, NewSession(""), Options{RecoveryGate: gate}, sink)
+	a.steerRunActive = true
+
+	out := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID: "fail-1", Name: "fail_tool", Arguments: `{}`,
+	})
+	if !strings.Contains(out.output, guidance) {
+		t.Fatalf("tool output missing host recovery guidance: %q", out.output)
+	}
+	if text, _, ok := a.consumeSteer(); ok {
+		t.Fatalf("host recovery queued a user steer: %q", text)
+	}
+	for _, e := range sink.kinds(event.Steer) {
+		t.Fatalf("host recovery emitted a steer event: %+v", e)
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -5485,11 +5485,10 @@ func replaySectionsForWithAssistantRenderer(
 		switch m.Role {
 		case provider.RoleUser:
 			// Steer messages are surfaced as a notice line, not a user bubble.
-			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
-				if agent.IsHostRecoveryGuidance(steerText) {
-					continue
+			if text, handled := agent.ReplaySteerText(m.Content); handled {
+				if text != "" {
+					out = append(out, fmt.Sprintf("  ↪ %s\n\n", text))
 				}
-				out = append(out, fmt.Sprintf("  ↪ %s\n\n", steerText))
 				continue
 			}
 			content := control.StripComposePrefixes(m.Content)

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -5486,6 +5486,9 @@ func replaySectionsForWithAssistantRenderer(
 		case provider.RoleUser:
 			// Steer messages are surfaced as a notice line, not a user bubble.
 			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
+				if agent.IsHostRecoveryGuidance(steerText) {
+					continue
+				}
 				out = append(out, fmt.Sprintf("  ↪ %s\n\n", steerText))
 				continue
 			}

--- a/internal/control/input_host_recovery_test.go
+++ b/internal/control/input_host_recovery_test.go
@@ -1,0 +1,22 @@
+package control
+
+import (
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestIsSyntheticUserMessageHostRecovery(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "plain guidance", input: agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."},
+		{name: "persisted steer", input: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically."},
+	}
+	for _, tc := range cases {
+		if !IsSyntheticUserMessage(tc.input) {
+			t.Errorf("%s: IsSyntheticUserMessage() = false, want true", tc.name)
+		}
+	}
+}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -1533,16 +1533,6 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			input: agent.MidTurnSteerPrefix + "\nplease use smaller diffs",
 			want:  false,
 		},
-		{
-			name:  "host auto guard guidance is synthetic",
-			input: agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically.",
-			want:  true,
-		},
-		{
-			name:  "persisted host auto guard steer is synthetic",
-			input: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically.",
-			want:  true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -1533,6 +1533,16 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			input: agent.MidTurnSteerPrefix + "\nplease use smaller diffs",
 			want:  false,
 		},
+		{
+			name:  "host auto guard guidance is synthetic",
+			input: agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically.",
+			want:  true,
+		},
+		{
+			name:  "persisted host auto guard steer is synthetic",
+			input: agent.MidTurnSteerPrefix + "\n" + agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically.",
+			want:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/recovery/gate.go
+++ b/internal/recovery/gate.go
@@ -1153,10 +1153,10 @@ func (g *Gate) recoveryGuidanceLocked(st *taskRuntime) string {
 	}
 	st.guidanceSent = true
 	if st.lastFailure != nil && st.lastFailure.evidence.Class == FailureClassTransient {
-		return "The tool timed out or hit a transient execution limit. Inspect its current state and output before retrying so partial effects are not duplicated. " +
+		return agent.HostRecoveryGuidanceTransientPrefix + " Inspect its current state and output before retrying so partial effects are not duplicated. " +
 			"Read-only diagnosis and unrelated work remain available without asking the user; retry the exact operation only after ruling out partial effects."
 	}
-	return "A tool failed. Use read-only diagnosis as needed, continue unrelated work automatically, and do not ask the user unless a genuine product or plan choice is required. " +
+	return agent.HostRecoveryGuidanceToolFailedPrefix + ", continue unrelated work automatically, and do not ask the user unless a genuine product or plan choice is required. " +
 		"Repeated retries of the exact failed operation remain bounded."
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -849,11 +849,10 @@ func historyMessages(msgs []provider.Message) []historyMessage {
 	for _, m := range msgs {
 		// Steer messages are surfaced as a notice, not a user message.
 		if m.Role == provider.RoleUser {
-			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
-				if agent.IsHostRecoveryGuidance(steerText) {
-					continue
+			if text, handled := agent.ReplaySteerText(m.Content); handled {
+				if text != "" {
+					out = append(out, historyMessage{Role: "notice", Content: "↪ " + text})
 				}
-				out = append(out, historyMessage{Role: "notice", Content: "↪ " + steerText})
 				continue
 			}
 		}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -850,6 +850,9 @@ func historyMessages(msgs []provider.Message) []historyMessage {
 		// Steer messages are surfaced as a notice, not a user message.
 		if m.Role == provider.RoleUser {
 			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
+				if agent.IsHostRecoveryGuidance(steerText) {
+					continue
+				}
 				out = append(out, historyMessage{Role: "notice", Content: "↪ " + steerText})
 				continue
 			}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -182,7 +182,7 @@
       "file-size": 1580
     },
     "desktop/frontend/src/lib/useController.ts": {
-      "file-size": 3976
+      "file-size": 3980
     },
     "desktop/heartbeat.go": {
       "essay": 20,
@@ -840,7 +840,7 @@
     "internal/cli/chat_tui.go": {
       "complexity": 333,
       "essay": 109,
-      "file-size": 4767,
+      "file-size": 4769,
       "function-size": 1304
     },
     "internal/cli/chat_tui_paste.go": {
@@ -1758,7 +1758,7 @@
     },
     "internal/serve/serve.go": {
       "essay": 27,
-      "file-size": 882
+      "file-size": 884
     },
     "internal/serve/serve_lease_test.go": {
       "essay": 3


### PR DESCRIPTION
## Summary

Two desktop transcript bugs that showed up after 1.25.0:

1. Auto Guard recovery policy (`A tool failed. Use read-only diagnosis...`) was injected with `Agent.Steer`, persisted as a user-role message, and rendered on the right as if the user typed it. The real prompt looked swallowed.
2. Opening a session whose turn was already running or streaming skipped history hydration, so earlier turns and tool cards disappeared until the turn ended.

This PR hides host Auto Guard guidance from the user-side transcript, keeps it on the failed tool result for the model, and prepends a history page in front of a live turn that has never loaded one.

## Issues

Refs #8696

## Consolidation

Kept / adapted from #8696 by @yingziisme:

- `hydratedHistoryApplyMode` (`replace` / `prepend` / `skip`)
- `hasCachedLiveTurn` requires a landed history page
- suffix/prefix signature dedupe before `history_prepend`
- the running-tab hydration suite and the sharper live-race / tab-switch assertions

Reviewed but not adopted:

- Cherry-picking the #8696 branch onto current `main-v2`. The durable mechanism was re-implemented on the current `history_prepend` reducer instead of carrying the older base.

## Capacity

Follow-up commit `e10fed7ff` extracted the host-recovery test and replay helpers so `app.go`, `execute_one.go`, `history_test.go`, and `input_test.go` no longer grow. The remaining ratchet updates are only the filters that must stay in already-over-budget wiring files:

| File | Budget | Head | Delta |
| --- | --- | --- | --- |
| `desktop/frontend/src/lib/useController.ts` file-size | 3976 | 3980 | +4 (0.10%) |
| `internal/cli/chat_tui.go` file-size | 4767 | 4769 | +2 (0.04%) |
| `internal/serve/serve.go` file-size | 882 | 884 | +2 (0.23%) |

These stay well under a 1% exceptional overrun. Splitting `loadSessionDataForTab` or the CLI/serve replay loops just to hide two lines would reduce cohesion.

## Verification

- `go test ./internal/agent/ ./internal/recovery/ ./internal/control/`
- `cd desktop && go test . -run TestHistoryMessagesHideHostRecoverySteer`
- `tsx src/__tests__/hydrate-history-apply.test.ts`
- `tsx src/__tests__/running-tab-history-hydration.test.tsx`
- `tsx src/__tests__/tab-switch-hydration.test.tsx`
- `tsx src/__tests__/use-controller-history-live-race.test.tsx`
- `tsx src/__tests__/transcript-rows.test.ts`
- `go run ./tools/repolint`

## Documentation impact

Documentation-impact: none - transcript hydration and Auto Guard delivery stay internal; existing docs do not describe host recovery steers or the mid-stream history skip.

## Cache impact

Cache-impact: none - system prompt, memory prefix, and tool schemas are unchanged. Auto Guard text moves from a synthetic user message onto the failed tool-result tail, which is append-only conversation growth.
Cache-guard: `go test ./internal/agent/ -run TestHostRecoveryGuidanceRidesToolResultNotSteer` plus existing prefix/shape tests in `./internal/agent/`
System-prompt-review: N/A
