### PR TITLE
fix(desktop): keep upgraded conversations visible and open the latest leaf / 修复更新后会话消失且只剩前半段

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3761,28 +3761,7 @@ func (a *App) ResumeSessionPage(path string, limit int) (HistoryPage, error) {
 }
 
 func (a *App) ResumeSessionPageForTab(tabID, path string, limit int) (HistoryPage, error) {
-	tab, ctrl := a.tabAndCtrlByID(tabID)
-	if tab == nil || ctrl == nil {
-		return HistoryPage{}, fmt.Errorf("tab is not ready")
-	}
-	if continued := a.continuePathForOpen(path); continued != "" {
-		path = continued
-	}
-	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
-	if err != nil {
-		return HistoryPage{}, err
-	}
-	loaded, err := loadResumableSession(sessionPath)
-	if err != nil {
-		return HistoryPage{}, err
-	}
-	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(sessionPath) {
-		if err := a.rebindTabToLoadedSessionPath(tab, sessionPath, loaded); err != nil {
-			return HistoryPage{}, err
-		}
-	}
-	a.setTabReadOnly(tab.ID, false)
-	return a.HistoryPageForTab(tab.ID, 0, limit), nil
+	return a.resumeSessionPageForTab(tabID, path, limit)
 }
 
 // ResumeSessionForTab is the tab-scoped form of ResumeSession. A saved session

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3765,6 +3765,9 @@ func (a *App) ResumeSessionPageForTab(tabID, path string, limit int) (HistoryPag
 	if tab == nil || ctrl == nil {
 		return HistoryPage{}, fmt.Errorf("tab is not ready")
 	}
+	if continued := a.continuePathForOpen(path); continued != "" {
+		path = continued
+	}
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {
 		return HistoryPage{}, err

--- a/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
@@ -23,5 +23,7 @@ assert.doesNotMatch(
   /event\.revision\s*<=\s*latestRevisionRef\.current/,
   "equal-revision tombstone overlays are not discarded",
 );
+assert.match(panel, /setIndexingDone\(Boolean\(snapshot\.indexingDone\)\)/, "shell snapshot records first-scan completion");
+assert.match(panel, /if \(!indexingDone\) return;/, "first completed scan reloads expanded topic pages");
 
 console.log("  PASS  project tree shell race contract");

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -410,6 +410,7 @@ export function ProjectTree({
   const [catalogStatus, setCatalogStatus] = useState<SessionCatalogStatus>({
     state: "opening", revision: 0, indexed: 0, total: 0, repairPending: 0,
   });
+  const [indexingDone, setIndexingDone] = useState(false);
   const [topicPageState, setTopicPageState] = useState<Record<string, { nextCursor?: string; loading: boolean }>>({});
   const topicPageStateRef = useRef(topicPageState);
   const updateTopicPageState = useCallback((key: string, next: { nextCursor?: string; loading: boolean }) => {
@@ -546,6 +547,7 @@ export function ProjectTree({
       if (projectTreeRevisionIsFresh(latestRevisionRef.current, rev)) latestRevisionRef.current = Math.max(latestRevisionRef.current, rev);
       const projects = asArray(snapshot.projects);
       setCatalogStatus(snapshot.catalog);
+      setIndexingDone(Boolean(snapshot.indexingDone));
       setTree((current) => projects.map((project) => {
         const previous = current.find((node) => node.key === project.key);
         return { ...project, children: asArray(previous?.children) };
@@ -599,6 +601,17 @@ export function ProjectTree({
     }, 200);
     return () => clearTimeout(timer);
   }, [expanded, loadProjectTopics, query, timeFilter, tree]);
+
+  // First catalog scan can finish before the frontend subscribed to v2 events.
+  // Reload expanded folders once indexingDone flips so the metadata fallback
+  // is replaced by the scanned projection without requiring New Chat.
+  useEffect(() => {
+    if (!indexingDone) return;
+    for (const project of treeRef.current) {
+      const key = projectNodeKey(project, 0);
+      if (expanded.has(key)) void loadProjectTopics(project);
+    }
+  }, [indexingDone, expanded, loadProjectTopics]);
 
   // Following the active topic is a view concern over the tree already held.
   useEffect(() => {

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/sessioncatalog"
 )
 
@@ -36,4 +37,99 @@ func (a *App) resolveCanonicalSessionPath(path string) string {
 		return ""
 	}
 	return sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, path)
+}
+
+func (a *App) continuePathForOpen(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return ""
+	}
+	ctx := context.Background()
+	rec, ok, err := catalog.GetSession(ctx, path)
+	if err != nil || !ok {
+		return a.continuePathForMissingParent(ctx, catalog, path)
+	}
+	if rec.TopicID == "" {
+		return ""
+	}
+	topic, ok, err := catalog.GetTopic(ctx, sessioncatalog.TopicKey{Scope: rec.Scope, WorkspaceRoot: rec.WorkspaceRoot, TopicID: rec.TopicID})
+	if err != nil || !ok {
+		return ""
+	}
+	return sessioncatalog.OrdinaryContinuePath(topic.Sessions, path)
+}
+
+func (a *App) continuePathForMissingParent(ctx context.Context, catalog *sessioncatalog.Catalog, path string) string {
+	parentID := agent.BranchID(path)
+	if parentID == "" {
+		return ""
+	}
+	// desktop-tabs.json may still name a parent that lineage folded off the
+	// ordinary row. Look up the topic by the filename id.
+	for _, target := range a.sessionCatalogTargets() {
+		page, err := catalog.ListTopics(ctx, sessioncatalog.TopicPageRequest{
+			Scope: target.Scope, WorkspaceRoot: target.WorkspaceRoot, Limit: sessioncatalog.MaxLimit,
+		})
+		if err != nil {
+			continue
+		}
+		for _, topic := range page.Items {
+			for _, session := range topic.Sessions {
+				if session.ParentID == parentID || strings.TrimSpace(session.RecoveryGroupID) == parentID {
+					if next := sessioncatalog.OrdinaryContinuePath(topic.Sessions, path); next != "" {
+						return next
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (a *App) retargetOpenTabsToCoveringLeaves() {
+	if a == nil {
+		return
+	}
+	type pending struct {
+		tab  *WorkspaceTab
+		next string
+	}
+	a.mu.RLock()
+	items := make([]pending, 0, len(a.tabs)+len(a.detachedSessions))
+	collect := func(tab *WorkspaceTab) {
+		if tab == nil {
+			return
+		}
+		current := tab.currentSessionPath()
+		next := a.continuePathForOpen(current)
+		if next == "" || sessionRuntimeKey(next) == sessionRuntimeKey(current) {
+			return
+		}
+		items = append(items, pending{tab: tab, next: next})
+	}
+	for _, tab := range a.tabs {
+		collect(tab)
+	}
+	for _, tab := range a.detachedSessions {
+		collect(tab)
+	}
+	a.mu.RUnlock()
+	for _, item := range items {
+		if item.tab.Ctrl == nil {
+			a.mu.Lock()
+			if a.tabs[item.tab.ID] == item.tab || a.detachedSessions[sessionRuntimeKey(item.tab.currentSessionPath())] == item.tab {
+				item.tab.SessionPath = item.next
+				a.saveTabsLocked()
+			}
+			a.mu.Unlock()
+			continue
+		}
+		if err := a.rebindTabToSessionPath(item.tab, item.next); err != nil {
+			continue
+		}
+	}
 }

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"reasonix/internal/agent"
@@ -37,6 +38,17 @@ func (a *App) resolveCanonicalSessionPath(path string) string {
 		return ""
 	}
 	return sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, path)
+}
+
+func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath string) (string, string) {
+	actualRoot := workspaceRoot
+	if scope == "global" {
+		actualRoot = globalWorkspaceRoot()
+	}
+	if continued := a.continuePathForOpen(sessionPath); continued != "" {
+		sessionPath = continued
+	}
+	return actualRoot, sessionPath
 }
 
 func (a *App) continuePathForOpen(path string) string {
@@ -90,26 +102,46 @@ func (a *App) continuePathForMissingParent(ctx context.Context, catalog *session
 	return ""
 }
 
+func (a *App) resumeSessionPageForTab(tabID, path string, limit int) (HistoryPage, error) {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
+		return HistoryPage{}, fmt.Errorf("tab is not ready")
+	}
+	if continued := a.continuePathForOpen(path); continued != "" {
+		path = continued
+	}
+	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
+	if err != nil {
+		return HistoryPage{}, err
+	}
+	loaded, err := loadResumableSession(sessionPath)
+	if err != nil {
+		return HistoryPage{}, err
+	}
+	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(sessionPath) {
+		if err := a.rebindTabToLoadedSessionPath(tab, sessionPath, loaded); err != nil {
+			return HistoryPage{}, err
+		}
+	}
+	a.setTabReadOnly(tab.ID, false)
+	return a.HistoryPageForTab(tab.ID, 0, limit), nil
+}
+
 func (a *App) retargetOpenTabsToCoveringLeaves() {
 	if a == nil {
 		return
 	}
-	type pending struct {
-		tab  *WorkspaceTab
-		next string
+	type candidate struct {
+		tab     *WorkspaceTab
+		current string
 	}
 	a.mu.RLock()
-	items := make([]pending, 0, len(a.tabs)+len(a.detachedSessions))
+	items := make([]candidate, 0, len(a.tabs)+len(a.detachedSessions))
 	collect := func(tab *WorkspaceTab) {
-		if tab == nil {
+		if tab == nil || tab.hasActiveRuntimeWork() {
 			return
 		}
-		current := tab.currentSessionPath()
-		next := a.continuePathForOpen(current)
-		if next == "" || sessionRuntimeKey(next) == sessionRuntimeKey(current) {
-			return
-		}
-		items = append(items, pending{tab: tab, next: next})
+		items = append(items, candidate{tab: tab, current: tab.currentSessionPath()})
 	}
 	for _, tab := range a.tabs {
 		collect(tab)
@@ -118,10 +150,25 @@ func (a *App) retargetOpenTabsToCoveringLeaves() {
 		collect(tab)
 	}
 	a.mu.RUnlock()
+	type pending struct {
+		tab  *WorkspaceTab
+		next string
+	}
+	ready := make([]pending, 0, len(items))
 	for _, item := range items {
+		next := a.continuePathForOpen(item.current)
+		if next == "" || sessionRuntimeKey(next) == sessionRuntimeKey(item.current) {
+			continue
+		}
+		ready = append(ready, pending{tab: item.tab, next: next})
+	}
+	for _, item := range ready {
+		if item.tab.hasActiveRuntimeWork() {
+			continue
+		}
 		if item.tab.Ctrl == nil {
 			a.mu.Lock()
-			if a.tabs[item.tab.ID] == item.tab || a.detachedSessions[sessionRuntimeKey(item.tab.currentSessionPath())] == item.tab {
+			if !item.tab.hasActiveRuntimeWork() && (a.tabs[item.tab.ID] == item.tab || a.detachedSessions[sessionRuntimeKey(item.tab.currentSessionPath())] == item.tab) {
 				item.tab.SessionPath = item.next
 				a.saveTabsLocked()
 			}

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -40,20 +40,46 @@ func (a *App) resolveCanonicalSessionPath(path string) string {
 	return sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, path)
 }
 
-func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, topicID, sessionPath string) (string, string) {
+func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath string) (string, string) {
 	actualRoot := workspaceRoot
 	if scope == "global" {
 		actualRoot = globalWorkspaceRoot()
 	}
-	// A live topic tab owns the surface. Continuing onto the covering leaf
-	// here would make the first session-key match prefer an idle leaf copy.
-	if a.topicHasActiveRuntimeWork(topicID) {
-		return actualRoot, sessionPath
-	}
+	// Only suppress covering-leaf continue when the live runtime is already
+	// on this path. Opening a different ordinary session of the same topic
+	// must still detach and switch (OpenGlobalTab latest-session contract).
 	if continued := a.continuePathForOpen(sessionPath); continued != "" {
+		if a.sessionHasActiveRuntimeWork(sessionPath) {
+			return actualRoot, sessionPath
+		}
 		sessionPath = continued
 	}
 	return actualRoot, sessionPath
+}
+
+func (a *App) sessionHasActiveRuntimeWork(path string) bool {
+	key := sessionRuntimeKey(path)
+	if a == nil || key == "" {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, tabs := range []map[string]*WorkspaceTab{a.tabs, a.detachedSessions} {
+		for _, tab := range tabs {
+			if tab != nil && sessionRuntimeKey(tab.currentSessionPath()) == key && tab.hasActiveRuntimeWork() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *App) skipCoveringLeafRebind(tab *WorkspaceTab, target string) bool {
+	if tab == nil || !tab.hasActiveRuntimeWork() {
+		return false
+	}
+	next := a.continuePathForOpen(tab.currentSessionPath())
+	return next != "" && sessionRuntimeKey(next) == sessionRuntimeKey(target)
 }
 
 func (a *App) continuePathForOpen(path string) string {
@@ -112,12 +138,11 @@ func (a *App) resumeSessionPageForTab(tabID, path string, limit int) (HistoryPag
 	if tab == nil || ctrl == nil {
 		return HistoryPage{}, fmt.Errorf("tab is not ready")
 	}
-	if tab.hasActiveRuntimeWork() {
-		a.setTabReadOnly(tab.ID, false)
-		return a.HistoryPageForTab(tab.ID, 0, limit), nil
-	}
 	if continued := a.continuePathForOpen(path); continued != "" {
-		path = continued
+		current := tab.currentSessionPath()
+		if !tab.hasActiveRuntimeWork() || sessionRuntimeKey(current) != sessionRuntimeKey(path) {
+			path = continued
+		}
 	}
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -40,10 +40,15 @@ func (a *App) resolveCanonicalSessionPath(path string) string {
 	return sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, path)
 }
 
-func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath string) (string, string) {
+func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, topicID, sessionPath string) (string, string) {
 	actualRoot := workspaceRoot
 	if scope == "global" {
 		actualRoot = globalWorkspaceRoot()
+	}
+	// A live topic tab owns the surface. Continuing onto the covering leaf
+	// here would make the first session-key match prefer an idle leaf copy.
+	if a.topicHasActiveRuntimeWork(topicID) {
+		return actualRoot, sessionPath
 	}
 	if continued := a.continuePathForOpen(sessionPath); continued != "" {
 		sessionPath = continued
@@ -106,6 +111,10 @@ func (a *App) resumeSessionPageForTab(tabID, path string, limit int) (HistoryPag
 	tab, ctrl := a.tabAndCtrlByID(tabID)
 	if tab == nil || ctrl == nil {
 		return HistoryPage{}, fmt.Errorf("tab is not ready")
+	}
+	if tab.hasActiveRuntimeWork() {
+		a.setTabReadOnly(tab.ID, false)
+		return a.HistoryPageForTab(tab.ID, 0, limit), nil
 	}
 	if continued := a.continuePathForOpen(path); continued != "" {
 		path = continued

--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -179,6 +180,7 @@ func (a *App) startSessionCatalog(rebuild bool) {
 				slog.Debug("desktop: reconcile session catalog directory", "dir", target.Path, "err", err)
 			}
 		}
+		a.retargetOpenTabsToCoveringLeaves()
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for {
@@ -508,6 +510,33 @@ func (a *App) GetProjectTreeSnapshot() ProjectTreeSnapshot {
 	return ProjectTreeSnapshot{
 		Revision: status.Revision, Projects: projects, Catalog: status,
 		Indexed: status.Indexed, Total: status.Total,
-		IndexingDone: status.State == string(sessioncatalog.StateReady) && status.RepairPending == 0,
+		IndexingDone: a.catalogIndexingDone(status),
 	}
+}
+
+func (a *App) catalogIndexingDone(status SessionCatalogStatus) bool {
+	if status.State != string(sessioncatalog.StateReady) || status.RepairPending > 0 {
+		return false
+	}
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return false
+	}
+	ctx, cancel := a.catalogReadContext()
+	defer cancel()
+	targets := a.sessionCatalogTargets()
+	if len(targets) == 0 {
+		return false
+	}
+	sawExisting := false
+	for _, target := range targets {
+		if _, err := os.Stat(target.Path); os.IsNotExist(err) {
+			continue
+		}
+		sawExisting = true
+		if !catalog.DirectoryScanReady(ctx, target.Path) {
+			return false
+		}
+	}
+	return sawExisting
 }

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/provider"
 	"reasonix/internal/sessioncatalog"
 )
@@ -430,5 +432,115 @@ func TestContinuePathForOpenFollowsCoveringLeafFromParent(t *testing.T) {
 	}
 	if got := app.continuePathForOpen(leaf); got != "" {
 		t.Fatalf("continue leaf = %q, want keep", got)
+	}
+}
+
+func TestListProjectTopicsWaitsUntilEveryGlobalDirectoryIsScanned(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	legacy := config.SessionDir()
+	global := desktopSessionDir(globalWorkspaceRoot())
+	for _, dir := range []string{legacy, global} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.GlobalTopics = []string{"topic-keep"}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicTitles("", map[string]string{"topic-keep": "Previous chat"}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	catalog, err := sessioncatalog.Open(context.Background(), sessioncatalog.Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		app.sessionCatalog.CompareAndSwap(catalog, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = catalog.Close(ctx)
+	})
+	app.sessionCatalog.Store(catalog)
+	if err := catalog.ReconcileDirectory(context.Background(), sessioncatalog.DirectoryTarget{Path: legacy, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "global", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic-keep" || page.Items[0].Label != "Previous chat" {
+		t.Fatalf("topics after only the empty global dir scanned = %#v, want metadata fallback", page.Items)
+	}
+}
+
+type retargetRuntimeController struct {
+	control.SessionAPI
+	status control.RuntimeStatus
+	path   string
+}
+
+func (c *retargetRuntimeController) RuntimeStatus() control.RuntimeStatus { return c.status }
+func (c *retargetRuntimeController) SessionPath() string                  { return c.path }
+func (c *retargetRuntimeController) PlanMode() bool                       { return false }
+func (c *retargetRuntimeController) AutoApproveTools() bool               { return false }
+func (c *retargetRuntimeController) Goal() string                         { return "" }
+func (c *retargetRuntimeController) GoalStatus() string                   { return "" }
+func (c *retargetRuntimeController) ToolApprovalMode() string             { return control.ToolApprovalAsk }
+
+func TestRetargetOpenTabsSkipsRunningSessions(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := provider.Message{Role: provider.RoleUser, Content: "question"}
+	a := provider.Message{Role: provider.RoleAssistant, Content: "answer"}
+	save := func(path, topic string, messages ...provider.Message) {
+		t.Helper()
+		session := agent.NewSession("sys")
+		for _, message := range messages {
+			session.Add(message)
+		}
+		if err := session.Save(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+			ID: agent.BranchID(path), Scope: "global", TopicID: topic, TopicTitle: "Upgraded",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := filepath.Join(dir, "root.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	save(root, "conversation", q, a)
+	save(leaf, "legacy-leaf-topic", q, a,
+		provider.Message{Role: provider.RoleUser, Content: "next"},
+		provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := agent.SaveBranchMetaPreserveUpdated(leaf, agent.BranchMeta{
+		ID: "leaf", Scope: "global", TopicID: "legacy-leaf-topic",
+		Recovered: true, ParentID: "root", RecoveryDepth: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	installSessionCatalogForTest(t, app, dir, "global", "")
+	idle := &WorkspaceTab{ID: "idle", Scope: "global", SessionPath: root}
+	running := &WorkspaceTab{
+		ID: "running", Scope: "global", SessionPath: root,
+		Ctrl: &retargetRuntimeController{status: control.RuntimeStatus{Running: true}, path: root},
+	}
+	app.tabs = map[string]*WorkspaceTab{"idle": idle, "running": running}
+
+	app.retargetOpenTabsToCoveringLeaves()
+	if idle.SessionPath != leaf {
+		t.Fatalf("idle tab path = %q, want covering leaf %q", idle.SessionPath, leaf)
+	}
+	if running.SessionPath != root {
+		t.Fatalf("running tab path = %q, want original parent %q", running.SessionPath, root)
 	}
 }

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -544,3 +544,70 @@ func TestRetargetOpenTabsSkipsRunningSessions(t *testing.T) {
 		t.Fatalf("running tab path = %q, want original parent %q", running.SessionPath, root)
 	}
 }
+
+func TestOpenTopicTabKeepsRunningParentInsteadOfCoveringLeaf(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := provider.Message{Role: provider.RoleUser, Content: "question"}
+	a := provider.Message{Role: provider.RoleAssistant, Content: "answer"}
+	save := func(path, topic string, messages ...provider.Message) {
+		t.Helper()
+		session := agent.NewSession("sys")
+		for _, message := range messages {
+			session.Add(message)
+		}
+		if err := session.Save(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+			ID: agent.BranchID(path), Scope: "global", TopicID: topic, TopicTitle: "Upgraded",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := filepath.Join(dir, "root.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	save(root, "conversation", q, a)
+	save(leaf, "legacy-leaf-topic", q, a,
+		provider.Message{Role: provider.RoleUser, Content: "next"},
+		provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := agent.SaveBranchMetaPreserveUpdated(leaf, agent.BranchMeta{
+		ID: "leaf", Scope: "global", TopicID: "legacy-leaf-topic",
+		Recovered: true, ParentID: "root", RecoveryDepth: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	installSessionCatalogForTest(t, app, dir, "global", "")
+	running := &WorkspaceTab{
+		ID: "running", Scope: "global", TopicID: "conversation", SessionPath: root,
+		Ctrl: &retargetRuntimeController{status: control.RuntimeStatus{Running: true}, path: root},
+	}
+	app.tabs = map[string]*WorkspaceTab{"running": running}
+
+	_, resolved := app.resolveOpenTopicSessionPath("global", "", "conversation", root)
+	if resolved != root {
+		t.Fatalf("resolve running open = %q, want parent %q", resolved, root)
+	}
+
+	meta, err := app.openTopicTab("global", "", "conversation", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running.SessionPath != root {
+		t.Fatalf("running tab path = %q, want parent %q", running.SessionPath, root)
+	}
+	if meta.ID != "running" || meta.SessionPath != root {
+		t.Fatalf("open meta = %+v, want focused running parent", meta)
+	}
+
+	idle := &WorkspaceTab{ID: "idle", Scope: "global", TopicID: "conversation", SessionPath: root}
+	app.tabs = map[string]*WorkspaceTab{"idle": idle}
+	_, idleResolved := app.resolveOpenTopicSessionPath("global", "", "conversation", root)
+	if idleResolved != leaf {
+		t.Fatalf("resolve idle open = %q, want covering leaf %q", idleResolved, leaf)
+	}
+}

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -588,7 +588,7 @@ func TestOpenTopicTabKeepsRunningParentInsteadOfCoveringLeaf(t *testing.T) {
 	}
 	app.tabs = map[string]*WorkspaceTab{"running": running}
 
-	_, resolved := app.resolveOpenTopicSessionPath("global", "", "conversation", root)
+	_, resolved := app.resolveOpenTopicSessionPath("global", "", root)
 	if resolved != root {
 		t.Fatalf("resolve running open = %q, want parent %q", resolved, root)
 	}
@@ -606,7 +606,7 @@ func TestOpenTopicTabKeepsRunningParentInsteadOfCoveringLeaf(t *testing.T) {
 
 	idle := &WorkspaceTab{ID: "idle", Scope: "global", TopicID: "conversation", SessionPath: root}
 	app.tabs = map[string]*WorkspaceTab{"idle": idle}
-	_, idleResolved := app.resolveOpenTopicSessionPath("global", "", "conversation", root)
+	_, idleResolved := app.resolveOpenTopicSessionPath("global", "", root)
 	if idleResolved != leaf {
 		t.Fatalf("resolve idle open = %q, want covering leaf %q", idleResolved, leaf)
 	}

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -325,3 +325,110 @@ func TestSessionCatalogGoroutineOnlySyncsMetadataWithATimeout(t *testing.T) {
 		}
 	}
 }
+
+func TestListProjectTopicsKeepsMetadataWhileFirstCatalogScanIsPending(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := t.TempDir()
+	if err := addProject(root, "Upgraded App"); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		for i := range f.Projects {
+			if sameProjectRoot(f.Projects[i].Root, root) {
+				f.Projects[i].Topics = []string{"topic-keep"}
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicTitles(root, map[string]string{"topic-keep": "Previous chat"}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	catalog, err := sessioncatalog.Open(context.Background(), sessioncatalog.Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		app.sessionCatalog.CompareAndSwap(catalog, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = catalog.Close(ctx)
+	})
+	app.sessionCatalog.Store(catalog)
+
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "project", WorkspaceRoot: root, Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != "topic-keep" || page.Items[0].Label != "Previous chat" {
+		t.Fatalf("topics while v4 catalog is still empty = %#v, want the desktop-projects conversation", page.Items)
+	}
+}
+
+func TestProjectTreeSnapshotIndexingWaitsForFirstDirectoryScan(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	catalog, err := sessioncatalog.Open(context.Background(), sessioncatalog.Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		app.sessionCatalog.CompareAndSwap(catalog, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = catalog.Close(ctx)
+	})
+	app.sessionCatalog.Store(catalog)
+	snapshot := app.GetProjectTreeSnapshot()
+	if snapshot.IndexingDone {
+		t.Fatal("indexingDone must stay false until the first directory scan finishes")
+	}
+}
+
+func TestContinuePathForOpenFollowsCoveringLeafFromParent(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := provider.Message{Role: provider.RoleUser, Content: "question"}
+	a := provider.Message{Role: provider.RoleAssistant, Content: "answer"}
+	next := provider.Message{Role: provider.RoleUser, Content: "next"}
+	done := provider.Message{Role: provider.RoleAssistant, Content: "done"}
+	save := func(path, topic string, messages ...provider.Message) {
+		t.Helper()
+		session := agent.NewSession("sys")
+		for _, message := range messages {
+			session.Add(message)
+		}
+		if err := session.Save(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+			ID: agent.BranchID(path), Scope: "global", TopicID: topic, TopicTitle: "Upgraded",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := filepath.Join(dir, "root.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	save(root, "conversation", q, a)
+	save(leaf, "legacy-leaf-topic", q, a, next, done)
+	if err := agent.SaveBranchMetaPreserveUpdated(leaf, agent.BranchMeta{
+		ID: "leaf", Scope: "global", TopicID: "legacy-leaf-topic",
+		Recovered: true, ParentID: "root", RecoveryDepth: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	installSessionCatalogForTest(t, app, dir, "global", "")
+	if got := app.continuePathForOpen(root); got != leaf {
+		t.Fatalf("continue parent = %q, want covering leaf %q", got, leaf)
+	}
+	if got := app.continuePathForOpen(leaf); got != "" {
+		t.Fatalf("continue leaf = %q, want keep", got)
+	}
+}

--- a/desktop/session_catalog_recovery_test.go
+++ b/desktop/session_catalog_recovery_test.go
@@ -143,6 +143,7 @@ func TestProjectNodeFromCatalogTopicHidesOrphanForkTopicsWhenPreferredElsewhere(
 }
 
 func TestListProjectTopicsSkipsRecoveryOnlyPages(t *testing.T) {
+	isolateDesktopUserDirs(t)
 	ctx := context.Background()
 	catalog, err := sessioncatalog.Open(ctx, sessioncatalog.Options{
 		Path: filepath.Join(t.TempDir(), "catalog.sqlite"), DisableRepair: true,

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -424,18 +424,55 @@ func topicSummaryFromCatalogTopic(topic sessioncatalog.TopicRecord, visible []se
 
 func (a *App) ListProjectTopics(req ProjectTopicPageRequest) (ProjectTopicPage, error) {
 	catalog := a.sessionCatalog.Load()
-	if catalog == nil {
-		// Catalog unavailable: use project metadata shells only. Never scan
-		// every recovery JSONL into the ordinary tree (1.23 contract).
-		// While opening/rebuilding with a live catalog, ListTopics already
-		// skips non-ordinary recovery shells so empty pages beat a replica wall.
-		return a.metadataTopicPage(req), nil
+	if catalog == nil || !a.catalogWorkspaceScanReady(catalog, req.Scope, req.WorkspaceRoot) {
+		// A freshly opened v4 cache is live but empty until the first directory
+		// scan. Treat that the same as "catalog unavailable" so upgrade does
+		// not blank the sidebar that desktop-projects.json still knows about.
+		page := a.metadataTopicPage(req)
+		if catalog == nil {
+			return page, nil
+		}
+		return a.withLiveTopics(catalog, req, page), nil
 	}
 	page, err := a.catalogTopicPage(catalog, req)
 	if err != nil {
 		return page, err
 	}
 	return a.withLiveTopics(catalog, req, page), nil
+}
+
+func (a *App) catalogWorkspaceScanReady(catalog *sessioncatalog.Catalog, scope, workspaceRoot string) bool {
+	if a == nil || catalog == nil {
+		return false
+	}
+	ctx, cancel := a.catalogReadContext()
+	defer cancel()
+	scope, workspaceRoot = normalizeDesktopTopicScope(scope, workspaceRoot)
+	if catalog.HasWorkspaceRecords(ctx, scope, workspaceRoot) {
+		return true
+	}
+	ready := false
+	matched := false
+	for _, target := range a.sessionCatalogTargets() {
+		if target.Scope != scope {
+			continue
+		}
+		if scope == "project" && !sameProjectRoot(target.WorkspaceRoot, workspaceRoot) {
+			continue
+		}
+		matched = true
+		if catalog.DirectoryScanReady(ctx, target.Path) {
+			ready = true
+		}
+	}
+	return matched && ready
+}
+
+func normalizeDesktopTopicScope(scope, workspaceRoot string) (string, string) {
+	if strings.TrimSpace(scope) != "project" {
+		return "global", ""
+	}
+	return "project", strings.TrimSpace(workspaceRoot)
 }
 
 // withLiveTopics restores topics the catalog does not (yet) carry. A tab is

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -448,11 +449,7 @@ func (a *App) catalogWorkspaceScanReady(catalog *sessioncatalog.Catalog, scope, 
 	ctx, cancel := a.catalogReadContext()
 	defer cancel()
 	scope, workspaceRoot = normalizeDesktopTopicScope(scope, workspaceRoot)
-	if catalog.HasWorkspaceRecords(ctx, scope, workspaceRoot) {
-		return true
-	}
-	ready := false
-	matched := false
+	matchedExisting := 0
 	for _, target := range a.sessionCatalogTargets() {
 		if target.Scope != scope {
 			continue
@@ -460,12 +457,18 @@ func (a *App) catalogWorkspaceScanReady(catalog *sessioncatalog.Catalog, scope, 
 		if scope == "project" && !sameProjectRoot(target.WorkspaceRoot, workspaceRoot) {
 			continue
 		}
-		matched = true
-		if catalog.DirectoryScanReady(ctx, target.Path) {
-			ready = true
+		if _, err := os.Stat(target.Path); os.IsNotExist(err) {
+			continue
+		}
+		matchedExisting++
+		if !catalog.DirectoryScanReady(ctx, target.Path) {
+			return false
 		}
 	}
-	return matched && ready
+	if matchedExisting > 0 {
+		return true
+	}
+	return catalog.HasWorkspaceRecords(ctx, scope, workspaceRoot)
 }
 
 func normalizeDesktopTopicScope(scope, workspaceRoot string) (string, string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2359,7 +2359,7 @@ func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
 }
 
 func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
-	actualRoot, sessionPath := a.resolveOpenTopicSessionPath(scope, workspaceRoot, topicID, sessionPath)
+	actualRoot, sessionPath := a.resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath)
 	targetKey := sessionRuntimeKey(sessionPath)
 
 	a.mu.Lock()
@@ -2389,7 +2389,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 			a.saveTabsLocked()
 			a.mu.Unlock()
-			if sameSession || tab.hasActiveRuntimeWork() {
+			if sameSession || a.skipCoveringLeafRebind(tab, sessionPath) {
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2363,6 +2363,9 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 	if scope == "global" {
 		actualRoot = globalWorkspaceRoot()
 	}
+	if continued := a.continuePathForOpen(sessionPath); continued != "" {
+		sessionPath = continued
+	}
 	targetKey := sessionRuntimeKey(sessionPath)
 
 	a.mu.Lock()
@@ -3772,6 +3775,11 @@ func (a *App) buildTabControllerWithContextCore(tab *WorkspaceTab, loadedSession
 		// not mistaken for a deliberate empty placeholder afterward.
 		hasPinnedPath = false
 		pinnedPath = ""
+	}
+	if hasPinnedPath {
+		if continued := a.continuePathForOpen(pinnedPath); continued != "" {
+			pinnedPath = continued
+		}
 	}
 	catalogTopicPath := ""
 	if hasPinnedPath {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2359,13 +2359,7 @@ func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
 }
 
 func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
-	actualRoot := workspaceRoot
-	if scope == "global" {
-		actualRoot = globalWorkspaceRoot()
-	}
-	if continued := a.continuePathForOpen(sessionPath); continued != "" {
-		sessionPath = continued
-	}
+	actualRoot, sessionPath := a.resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath)
 	targetKey := sessionRuntimeKey(sessionPath)
 
 	a.mu.Lock()
@@ -3775,11 +3769,6 @@ func (a *App) buildTabControllerWithContextCore(tab *WorkspaceTab, loadedSession
 		// not mistaken for a deliberate empty placeholder afterward.
 		hasPinnedPath = false
 		pinnedPath = ""
-	}
-	if hasPinnedPath {
-		if continued := a.continuePathForOpen(pinnedPath); continued != "" {
-			pinnedPath = continued
-		}
 	}
 	catalogTopicPath := ""
 	if hasPinnedPath {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2359,7 +2359,7 @@ func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
 }
 
 func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
-	actualRoot, sessionPath := a.resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath)
+	actualRoot, sessionPath := a.resolveOpenTopicSessionPath(scope, workspaceRoot, topicID, sessionPath)
 	targetKey := sessionRuntimeKey(sessionPath)
 
 	a.mu.Lock()
@@ -2389,7 +2389,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 			a.saveTabsLocked()
 			a.mu.Unlock()
-			if sameSession {
+			if sameSession || tab.hasActiveRuntimeWork() {
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {

--- a/internal/sessioncatalog/catalog_test.go
+++ b/internal/sessioncatalog/catalog_test.go
@@ -64,6 +64,35 @@ func TestReconcileMakesUnknownCountsVisibleWithoutReadingTranscript(t *testing.T
 	}
 }
 
+func TestDirectoryScanReadyOnlyAfterFirstReconcile(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "chat.jsonl"), []byte(`{"role":"user","content":"hi"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = catalog.Close(context.Background()) })
+	if catalog.DirectoryScanReady(ctx, dir) {
+		t.Fatal("opened catalog must not report the directory ready before the first scan")
+	}
+	if catalog.HasWorkspaceRecords(ctx, "global", "") {
+		t.Fatal("opened catalog must not report workspace records before the first scan")
+	}
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	if !catalog.DirectoryScanReady(ctx, dir) {
+		t.Fatal("directory must be ready after ReconcileDirectory finishes")
+	}
+	if !catalog.HasWorkspaceRecords(ctx, "global", "") {
+		t.Fatal("reconciled directory should report workspace records")
+	}
+}
+
 func TestListTopicsUsesStableKeysetCursor(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/sessioncatalog/directory_scan.go
+++ b/internal/sessioncatalog/directory_scan.go
@@ -1,0 +1,37 @@
+package sessioncatalog
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+)
+
+// DirectoryScanReady reports whether this directory has finished at least one
+// catalog scan. An opened-but-unscanned v4 cache is not ready: ListTopics would
+// otherwise treat "no rows yet" as "the user has no conversations".
+func (c *Catalog) DirectoryScanReady(ctx context.Context, path string) bool {
+	if c == nil || c.db == nil {
+		return false
+	}
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" || path == "." {
+		return false
+	}
+	var state string
+	err := c.db.QueryRowContext(ctx, `SELECT state FROM catalog_directories WHERE path=?`, path).Scan(&state)
+	return err == nil && state == "ready"
+}
+
+// HasWorkspaceRecords reports whether any non-missing session is already
+// projected for this workspace. Used so an in-progress scan that has written
+// rows stays authoritative, while a brand-new empty v4 cache does not.
+func (c *Catalog) HasWorkspaceRecords(ctx context.Context, scope, workspaceRoot string) bool {
+	if c == nil || c.db == nil {
+		return false
+	}
+	scope, workspaceRoot = normalizeScope(scope, workspaceRoot)
+	var n int
+	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND missing_since=0`,
+		scope, workspaceRoot).Scan(&n)
+	return err == nil && n > 0
+}

--- a/internal/sessioncatalog/lineage.go
+++ b/internal/sessioncatalog/lineage.go
@@ -569,3 +569,27 @@ func CanonicalSessionPathForTopic(sessions []SessionRecord, current string) stri
 	}
 	return canonical
 }
+
+// OrdinaryContinuePath returns the unique covering leaf when current is the
+// ordinary parent (or a stale parent path after re-anchoring). An explicit
+// recovery fork stays put so History can inspect it.
+func OrdinaryContinuePath(sessions []SessionRecord, current string) string {
+	canonical := CanonicalSessionPathForTopic(sessions, current)
+	if canonical == "" {
+		return ""
+	}
+	current = strings.TrimSpace(current)
+	if current == "" || current == canonical {
+		return canonical
+	}
+	for _, session := range sessions {
+		if session.Path != current {
+			continue
+		}
+		if session.Recovered {
+			return ""
+		}
+		return canonical
+	}
+	return canonical
+}

--- a/internal/sessioncatalog/lineage_test.go
+++ b/internal/sessioncatalog/lineage_test.go
@@ -121,6 +121,29 @@ func TestCanonicalSessionPathForTopic(t *testing.T) {
 	}
 }
 
+func TestOrdinaryContinuePathFollowsParentOnly(t *testing.T) {
+	parent := "/s/old.jsonl"
+	leaf := "/s/leaf.jsonl"
+	fork := "/s/fork.jsonl"
+	sessions := []SessionRecord{
+		{Path: parent, RecoveryRole: RecoveryRoleNormal},
+		{Path: leaf, Recovered: true, RecoveryRole: RecoveryRoleAdopted, RecoveryCanonical: true},
+		{Path: fork, Recovered: true, RecoveryRole: RecoveryRoleDiverged},
+	}
+	if got := OrdinaryContinuePath(sessions, parent); got != leaf {
+		t.Fatalf("parent continue = %q, want leaf", got)
+	}
+	if got := OrdinaryContinuePath(sessions, leaf); got != "" {
+		t.Fatalf("leaf continue = %q, want keep", got)
+	}
+	if got := OrdinaryContinuePath(sessions, fork); got != "" {
+		t.Fatalf("fork continue = %q, want keep inspection path", got)
+	}
+	if got := OrdinaryContinuePath(sessions, "/s/stale-parent.jsonl"); got != leaf {
+		t.Fatalf("stale parent continue = %q, want leaf", got)
+	}
+}
+
 func TestExplicitPreferredRecoveryWinsWithoutMakingPeersCovered(t *testing.T) {
 	dir := t.TempDir()
 	root := filepath.Join(dir, "root.jsonl")

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -419,36 +419,6 @@ func unixMilli(value time.Time) int64 {
 	return value.UnixMilli()
 }
 
-// DirectoryScanReady reports whether this directory has finished at least one
-// catalog scan. An opened-but-unscanned v4 cache is not ready: ListTopics would
-// otherwise treat "no rows yet" as "the user has no conversations".
-func (c *Catalog) DirectoryScanReady(ctx context.Context, path string) bool {
-	if c == nil || c.db == nil {
-		return false
-	}
-	path = filepath.Clean(strings.TrimSpace(path))
-	if path == "" || path == "." {
-		return false
-	}
-	var state string
-	err := c.db.QueryRowContext(ctx, `SELECT state FROM catalog_directories WHERE path=?`, path).Scan(&state)
-	return err == nil && state == "ready"
-}
-
-// HasWorkspaceRecords reports whether any non-missing session is already
-// projected for this workspace. Used so an in-progress scan that has written
-// rows stays authoritative, while a brand-new empty v4 cache does not.
-func (c *Catalog) HasWorkspaceRecords(ctx context.Context, scope, workspaceRoot string) bool {
-	if c == nil || c.db == nil {
-		return false
-	}
-	scope, workspaceRoot = normalizeScope(scope, workspaceRoot)
-	var n int
-	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND missing_since=0`,
-		scope, workspaceRoot).Scan(&n)
-	return err == nil && n > 0
-}
-
 func fileFingerprint(path string) string {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/sessioncatalog/reconcile.go
+++ b/internal/sessioncatalog/reconcile.go
@@ -419,6 +419,36 @@ func unixMilli(value time.Time) int64 {
 	return value.UnixMilli()
 }
 
+// DirectoryScanReady reports whether this directory has finished at least one
+// catalog scan. An opened-but-unscanned v4 cache is not ready: ListTopics would
+// otherwise treat "no rows yet" as "the user has no conversations".
+func (c *Catalog) DirectoryScanReady(ctx context.Context, path string) bool {
+	if c == nil || c.db == nil {
+		return false
+	}
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" || path == "." {
+		return false
+	}
+	var state string
+	err := c.db.QueryRowContext(ctx, `SELECT state FROM catalog_directories WHERE path=?`, path).Scan(&state)
+	return err == nil && state == "ready"
+}
+
+// HasWorkspaceRecords reports whether any non-missing session is already
+// projected for this workspace. Used so an in-progress scan that has written
+// rows stays authoritative, while a brand-new empty v4 cache does not.
+func (c *Catalog) HasWorkspaceRecords(ctx context.Context, scope, workspaceRoot string) bool {
+	if c == nil || c.db == nil {
+		return false
+	}
+	scope, workspaceRoot = normalizeScope(scope, workspaceRoot)
+	var n int
+	err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM catalog_sessions WHERE scope=? AND workspace_root=? AND missing_since=0`,
+		scope, workspaceRoot).Scan(&n)
+	return err == nil && n > 0
+}
+
 func fileFingerprint(path string) string {
 	info, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
## Summary

After a desktop upgrade, the sidebar could go empty until New Chat, and opening a recovered conversation often showed only the older half.

This restores the ordinary upgrade path:

- Treat a freshly opened empty v4 catalog as not ready, and keep showing `desktop-projects.json` topics until that workspace has catalog rows or a finished first scan.
- Keep `indexingDone` false until existing session directories have been scanned, then reload expanded folders so a missed first-scan event is not stuck on the metadata fallback.
- When opening or restoring the ordinary parent of a unique covering recovery leaf, bind the leaf. Explicit History forks stay put. After the first reconcile, retarget already-open parent tabs onto that leaf.

Conversation JSONL and metadata are not rewritten. The catalog remains a disposable projection.

## Issues

Refs #8705
Refs #8712
Refs #8352

Related open work that this does not replace: #8650 (defer catalog startup), #8656 (canonical resume chooser), #8727 (mid-stream hydrate).

## Verification

- `go test ./internal/sessioncatalog/`
- `cd desktop && go test -run 'TestListProjectTopics|TestProjectTreeSnapshotIndexingWaitsForFirstDirectoryScan|TestContinuePathForOpenFollowsCoveringLeafFromParent|TestUpgradeLegacy|TestSessionCatalogGoroutineOnlySyncsMetadataWithATimeout'`
- `pnpm exec tsx src/__tests__/project-tree-shell-race.test.ts`
- `go vet ./internal/sessioncatalog/` and `cd desktop && go vet .`

## Documentation impact

Documentation-impact: none - SESSION_CATALOG.md already says the sqlite cache is disposable and startup must not wait on a scan; this restores that contract instead of changing documented behavior.

## Cache impact

Cache-impact: none - desktop catalog, tab bind, and sidebar refresh only; provider-visible prefix, tools, and serialization are unchanged
Cache-guard: scripts/check-cache-impact.sh reported no cache-sensitive files; focused catalog/desktop tests above
System-prompt-review: N/A