### PR TITLE
fix(desktop): label delivery-check pause separately from recovery pause / 交付检查未完成时侧栏显示待交付检查

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   projectTreeReadActivityKey,
   projectTreeTopicHasUnreadActivity,
   topicIsActive,
+  topicStatusLabel,
   projectTreeTopicArchiveBlocked,
   projectTreeShouldRenderTopicActions,
   projectTreeTopicMetaLine,
@@ -248,13 +249,24 @@ for (const status of ["thinking", "streaming", "waiting_confirmation", "backgrou
   );
 }
 
-for (const status of ["paused", "error"] as const) {
+for (const status of ["paused", "error", "awaiting_delivery"] as const) {
   eq(
     projectTreeTopicArchiveBlocked({ ...completedTopic, status, running: true }),
     false,
     `${status} topic remains archivable despite the legacy running flag`,
   );
 }
+
+eq(
+  topicStatusLabel({ ...completedTopic, status: "awaiting_delivery" }, testT),
+  "projectTree.status.awaitingDelivery",
+  "delivery-check pause uses its own sidebar label, not paused",
+);
+eq(
+  topicStatusLabel({ ...completedTopic, status: "paused" }, testT),
+  "projectTree.status.paused",
+  "recovery pause keeps the paused sidebar label",
+);
 
 eq(
   projectTreeTopicArchiveBlocked({ ...completedTopic, running: true }),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1308,7 +1308,7 @@ export function ProjectTree({
                     <span>{imSourceLabel}</span>
                   </span>
                 )}
-                {!compactTopics && statusLabel && (!classicTopics || status === "paused" || status === "error") && (
+                {!compactTopics && statusLabel && (!classicTopics || status === "paused" || status === "awaiting_delivery" || status === "error") && (
                   <span className={`project-tree__topic-status project-tree__topic-status--${status}`}>{statusLabel}</span>
                 )}
               </span>

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -172,13 +172,14 @@ const topicStatusLabels: Record<ProjectTopicStatus, DictKey> = {
   waiting_confirmation: "projectTree.status.waitingConfirmation",
   background_job: "projectTree.status.backgroundJob",
   paused: "projectTree.status.paused",
+  awaiting_delivery: "projectTree.status.awaitingDelivery",
   error: "projectTree.status.error",
   diverged_recovery: "projectTree.status.divergedRecovery",
 };
 
 export function normalizeTopicStatus(status?: string): ProjectTopicStatus | "" {
   if (!status) return "";
-  if (status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job" || status === "paused" || status === "error" || status === "diverged_recovery") {
+  if (status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job" || status === "paused" || status === "awaiting_delivery" || status === "error" || status === "diverged_recovery") {
     return status;
   }
   return "";
@@ -197,7 +198,7 @@ export function projectTreeTopicArchiveBlocked(node: ProjectNode): boolean {
   if (asArray(node.children).some(projectTreeTopicArchiveBlocked)) return true;
   const status = normalizeTopicStatus(node.status);
   if (status === "thinking" || status === "streaming" || status === "waiting_confirmation" || status === "background_job") return true;
-  if (status === "paused" || status === "error" || status === "diverged_recovery") return false;
+  if (status === "paused" || status === "awaiting_delivery" || status === "error" || status === "diverged_recovery") return false;
   return Boolean(node.running);
 }
 

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -585,7 +585,7 @@ export interface DeliveryWorktreeOpenResult {
   tab: TabMeta;
 }
 
-export type ProjectTopicStatus = "thinking" | "streaming" | "waiting_confirmation" | "background_job" | "paused" | "error" | "diverged_recovery";
+export type ProjectTopicStatus = "thinking" | "streaming" | "waiting_confirmation" | "background_job" | "paused" | "awaiting_delivery" | "error" | "diverged_recovery";
 
 export interface TopicMeta {
   id: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1300,6 +1300,7 @@ export const en = {
   "projectTree.status.waitingConfirmation": "awaiting",
   "projectTree.status.backgroundJob": "background job",
   "projectTree.status.paused": "paused",
+  "projectTree.status.awaitingDelivery": "need checks",
   "projectTree.status.error": "error",
   "projectTree.status.divergedRecovery": "multiple recovery branches",
   "projectTree.removeProject": "Remove from sidebar",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2567,6 +2567,7 @@ export const zhTW: Record<DictKey, string> = {
   "projectTree.status.waitingConfirmation": "待確認",
   "projectTree.status.backgroundJob": "背景任務",
   "projectTree.status.paused": "已暫停",
+  "projectTree.status.awaitingDelivery": "待交付檢查",
   "projectTree.status.error": "異常",
   "projectTree.status.divergedRecovery": "多個復原分支",
   "projectTree.collapseAllTooltip": "收起所有專案",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1301,6 +1301,7 @@ export const zh: Record<DictKey, string> = {
   "projectTree.status.waitingConfirmation": "待确认",
   "projectTree.status.backgroundJob": "后台任务",
   "projectTree.status.paused": "已暂停",
+  "projectTree.status.awaitingDelivery": "待交付检查",
   "projectTree.status.error": "异常",
   "projectTree.status.divergedRecovery": "多个恢复分支",
   "projectTree.removeProject": "移出侧边栏",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24405,6 +24405,12 @@ body > .mermaid-diagram--fullscreen {
   color: var(--fg-faint);
 }
 
+.project-tree__topic-status--awaiting_delivery {
+  max-width: 80px;
+  background: color-mix(in srgb, var(--warn) 13%, transparent);
+  color: color-mix(in srgb, var(--warn) 82%, var(--fg));
+}
+
 .project-tree__topic-status--error {
   background: color-mix(in srgb, var(--err) 12%, transparent);
   color: color-mix(in srgb, var(--err) 84%, var(--fg));
@@ -27836,6 +27842,13 @@ body > .mermaid-diagram--fullscreen {
   background: color-mix(in srgb, var(--fg-faint) 10%, var(--bg-elev));
   color: var(--fg-faint);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg-faint) 18%, transparent);
+}
+
+:root[data-theme-style] .project-tree__topic-status--awaiting_delivery {
+  max-width: 80px;
+  background: color-mix(in srgb, var(--warn) 12%, var(--bg-elev));
+  color: color-mix(in srgb, var(--warn) 82%, var(--fg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--warn) 20%, transparent);
 }
 
 :root[data-theme-style] .project-tree__topic-status--error {

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -44,7 +44,7 @@ func catalogRuntimeStatus(activity string, runtimeStatus control.RuntimeStatus) 
 		return topicStatusWaitingConfirmation
 	}
 	if runtimeStatus.Running {
-		if status == "" || status == topicStatusError || status == topicStatusPaused {
+		if status == "" || status == topicStatusError || status == topicStatusPaused || status == topicStatusAwaitingDelivery {
 			return topicStatusThinking
 		}
 		return status
@@ -52,7 +52,7 @@ func catalogRuntimeStatus(activity string, runtimeStatus control.RuntimeStatus) 
 	if runtimeStatus.BackgroundJobs > 0 {
 		return topicStatusBackgroundJob
 	}
-	if status == topicStatusError || status == topicStatusPaused {
+	if status == topicStatusError || status == topicStatusPaused || status == topicStatusAwaitingDelivery {
 		return status
 	}
 	return status

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1789,11 +1789,8 @@ func topicActivityStatusFromEvent(e event.Event) (string, bool) {
 	case event.ApprovalRequest, event.AskRequest:
 		return topicStatusWaitingConfirmation, true
 	case event.TurnDone:
-		if e.Outcome == event.TurnOutcomeFinalReadiness || e.Outcome == event.TurnOutcomeRecoveryPaused {
-			// The transcript presents this turn end as a recoverable delivery
-			// pause with a continue action, so the sidebar must not flag it
-			// as an error.
-			return topicStatusPaused, true
+		if status, ok := topicStatusFromTurnDone(e.Outcome); ok {
+			return status, true
 		}
 		if e.Err != nil {
 			return topicStatusError, true
@@ -6473,7 +6470,7 @@ type ProjectNode struct {
 
 func normalizeTopicStatus(status string) string {
 	switch status {
-	case topicStatusThinking, topicStatusStreaming, topicStatusWaitingConfirmation, topicStatusBackgroundJob, topicStatusPaused, topicStatusError, topicStatusDivergedRecovery:
+	case topicStatusThinking, topicStatusStreaming, topicStatusWaitingConfirmation, topicStatusBackgroundJob, topicStatusPaused, topicStatusAwaitingDelivery, topicStatusError, topicStatusDivergedRecovery:
 		return status
 	default:
 		return ""

--- a/desktop/tabs_runtime_status_test.go
+++ b/desktop/tabs_runtime_status_test.go
@@ -255,14 +255,14 @@ func waitNoJobs(t *testing.T, ctrl control.SessionAPI) {
 	}
 }
 
-func TestTopicActivityStatusPresentsReadinessAsPaused(t *testing.T) {
+func TestTopicActivityStatusPresentsReadinessSeparatelyFromPause(t *testing.T) {
 	readiness := event.Event{
 		Kind:    event.TurnDone,
 		Err:     &agent.FinalReadinessError{Attempts: 3, Reason: "missing verification"},
 		Outcome: event.TurnOutcomeFinalReadiness,
 	}
-	if status, ok := topicActivityStatusFromEvent(readiness); !ok || status != topicStatusPaused {
-		t.Fatalf("readiness turn end = (%q, %v), want (%q, true)", status, ok, topicStatusPaused)
+	if status, ok := topicActivityStatusFromEvent(readiness); !ok || status != topicStatusAwaitingDelivery {
+		t.Fatalf("readiness turn end = (%q, %v), want (%q, true)", status, ok, topicStatusAwaitingDelivery)
 	}
 	recoveryPause := event.Event{
 		Kind:    event.TurnDone,
@@ -277,5 +277,20 @@ func TestTopicActivityStatusPresentsReadinessAsPaused(t *testing.T) {
 	}
 	if status, ok := topicActivityStatusFromEvent(event.Event{Kind: event.TurnDone}); !ok || status != "" {
 		t.Fatalf("clean turn end = (%q, %v), want cleared status", status, ok)
+	}
+}
+
+func TestCatalogRuntimeStatusPreservesDeliveryCheckWhenIdle(t *testing.T) {
+	got := catalogRuntimeStatus(topicStatusAwaitingDelivery, control.RuntimeStatus{})
+	if got != topicStatusAwaitingDelivery {
+		t.Fatalf("idle delivery check = %q, want %q", got, topicStatusAwaitingDelivery)
+	}
+	got = catalogRuntimeStatus(topicStatusAwaitingDelivery, control.RuntimeStatus{Running: true})
+	if got != topicStatusThinking {
+		t.Fatalf("running delivery check = %q, want %q", got, topicStatusThinking)
+	}
+	got = catalogRuntimeStatus(topicStatusPaused, control.RuntimeStatus{})
+	if got != topicStatusPaused {
+		t.Fatalf("idle recovery pause = %q, want %q", got, topicStatusPaused)
 	}
 }

--- a/desktop/topic_status.go
+++ b/desktop/topic_status.go
@@ -1,0 +1,17 @@
+package main
+
+import "reasonix/internal/event"
+
+// topicStatusAwaitingDelivery is a delivery-check pause, not a recovery pause.
+const topicStatusAwaitingDelivery = "awaiting_delivery"
+
+func topicStatusFromTurnDone(outcome string) (string, bool) {
+	switch outcome {
+	case event.TurnOutcomeFinalReadiness:
+		return topicStatusAwaitingDelivery, true
+	case event.TurnOutcomeRecoveryPaused:
+		return topicStatusPaused, true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
## Summary

Sidebar sessions that stop on a Goal/delivery-check gate no longer reuse the recovery-pause badge.

- `TurnOutcomeFinalReadiness` now maps to `awaiting_delivery` and shows **待交付检查** / `need checks`.
- `TurnOutcomeRecoveryPaused` still maps to `paused` and shows **已暂停** / `paused`.
- A later running turn still replaces either badge with thinking, same as today.

This keeps the earlier non-error presentation (`c0980b86f`) but stops completed todos from looking like a stalled run.

## Issues

No linked issue. User report: delivery-check sessions with signed-off todos still showed 已暂停.

## Verification

- `cd desktop && go test -count=1 -run 'TestTopicActivityStatusPresentsReadiness|TestCatalogRuntimeStatusPreservesDeliveryCheck|TestProjectTreeShowsDetached'`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/project-tree-runtime.test.ts`
- `make lint`

## Documentation impact

Documentation-impact: none - existing docs do not specify the sidebar paused badge wording; the in-app delivery card already says checks are incomplete.

## Cache impact

Cache-impact: none - desktop sidebar activity labels only; provider-visible prefix, tools, and serialization are unchanged
Cache-guard: not applicable; no cache-sensitive paths in this diff
System-prompt-review: N/A
