### PR TITLE
fix(desktop): keep transcript pinned after todo dismiss / 修复关闭待办后会话画面回跳

### DIFF
--- a/desktop/frontend/src/__tests__/history-load-failure-contract.test.ts
+++ b/desktop/frontend/src/__tests__/history-load-failure-contract.test.ts
@@ -8,6 +8,7 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const controller = readFileSync(join(root, "lib/useController.ts"), "utf8");
 const store = readFileSync(join(root, "lib/transcriptStore.ts"), "utf8");
 const app = readFileSync(join(root, "App.tsx"), "utf8");
+const transcript = readFileSync(join(root, "components/Transcript.tsx"), "utf8");
 
 assert.match(controller, /deferResetUntilHistory \?\? true/, "history reset waits for successful load");
 assert.match(controller, /type: "hydrate_error"/, "history failure dispatches hydrate_error");
@@ -15,6 +16,11 @@ assert.match(controller, /applyHydrateErrorState|hydratePlaceholderItems/, "hydr
 assert.match(readFileSync(join(root, "lib/hydrateErrorState.ts"), "utf8"), /keptItems/, "hydrateErrorState preserves items");
 assert.match(controller, /throw new Error\(t\("history\.failedLoadHistory"\)\)/, "listSessions does not swallow failures as empty");
 assert.match(controller, /retrySessionHistory/, "retry path is exported");
+assert.match(
+  transcript,
+  /scrollToBottom\(\);\n  \}, \[footerHeight, scrollToBottom, stick\]\)/,
+  "footer re-pin is not tied to transcript item appends",
+);
 assert.match(controller, /shouldPreferResidentHistory\(reset, options\.preserveCachedHistory\)/, "retry hydrates fetch instead of serving the resident snapshot");
 assert.match(
   controller,

--- a/desktop/frontend/src/__tests__/history-load-failure-contract.test.ts
+++ b/desktop/frontend/src/__tests__/history-load-failure-contract.test.ts
@@ -15,6 +15,12 @@ assert.match(controller, /applyHydrateErrorState|hydratePlaceholderItems/, "hydr
 assert.match(readFileSync(join(root, "lib/hydrateErrorState.ts"), "utf8"), /keptItems/, "hydrateErrorState preserves items");
 assert.match(controller, /throw new Error\(t\("history\.failedLoadHistory"\)\)/, "listSessions does not swallow failures as empty");
 assert.match(controller, /retrySessionHistory/, "retry path is exported");
+assert.match(controller, /shouldPreferResidentHistory\(reset, options\.preserveCachedHistory\)/, "retry hydrates fetch instead of serving the resident snapshot");
+assert.match(
+  controller,
+  /loadSessionDataForTab\(tabId, false, "startup", \{ preserveCachedHistory: true \}\)/,
+  "failed clear keeps the visible transcript instead of a resident snapshot",
+);
 assert.match(store, /slice\.error/, "transcript store rejects slice.error as failure");
 assert.match(app, /retrySessionHistory/, "App wires history retry control");
 assert.match(app, /history-load-error/, "App surfaces hydrate error banner");

--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -5,6 +5,7 @@ import {
   hasCachedLiveTurn,
   hydratedHistoryApplyMode,
   sameSessionPlaceholderItems,
+  shouldPreferResidentHistory,
 } from "../lib/hydrateHistoryApply";
 
 let passed = 0;
@@ -73,6 +74,44 @@ ok(
 ok(
   (sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "a.jsonl" }, items: [{ kind: "user" }] }) ?? []).length === 1,
   "same-session items stay placeholders",
+);
+
+ok(
+  !shouldPreferResidentHistory(false, false),
+  "retry / explicit no-cache hydrates must not serve the resident snapshot",
+);
+ok(shouldPreferResidentHistory(false, true), "preserveCachedHistory still allows a resident hit");
+ok(shouldPreferResidentHistory(false, undefined), "unspecified preserveCachedHistory still allows a resident hit");
+ok(!shouldPreferResidentHistory(true, true), "reset hydrates never prefer the resident snapshot");
+
+const liveIdle = {
+  items: [{ kind: "user" }, { kind: "assistant" }, { kind: "user" }],
+  historyRevision: 10,
+  historyDigest: "rev-10",
+};
+ok(
+  mode(false, true, false, liveIdle, {
+    items: [{ kind: "user" }],
+    revision: 10,
+    digest: "rev-10",
+  }) === "skip",
+  "idle transcript is not replaced by a shorter same-fingerprint resident snapshot",
+);
+ok(
+  mode(false, true, false, liveIdle, {
+    items: [{ kind: "user" }, { kind: "assistant" }, { kind: "user" }, { kind: "assistant" }],
+    revision: 11,
+    digest: "rev-11",
+  }) === "replace",
+  "a newer backend page still replaces the idle transcript",
+);
+ok(
+  mode(false, true, false, { items: [] }, {
+    items: [{ kind: "user" }],
+    revision: 10,
+    digest: "rev-10",
+  }) === "replace",
+  "empty idle surface still applies history",
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -5,6 +5,8 @@
 
 import {
   isPinnedTranscriptLayoutGrowth,
+  isPinnedTranscriptViewportChange,
+  shouldKeepPinnedOnAtBottomFalse,
   TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
 } from "../lib/useTranscriptVirtuosoScroll";
 
@@ -70,6 +72,18 @@ const layoutGrowth = isPinnedTranscriptLayoutGrowth({
   scrollTop: 9714,
 });
 check(layoutGrowth, "pinned row growth preserves tail-follow through callback reordering");
+check(
+  shouldKeepPinnedOnAtBottomFalse({
+    pinned: true,
+    previousScrollHeight: 10000,
+    previousScrollTop: 9400,
+    previousClientHeight: 600,
+    scrollHeight: 10320,
+    scrollTop: 9714,
+    clientHeight: 600,
+  }),
+  "pinned row growth still keeps the tail through the combined policy",
+);
 
 const userScrollDuringGrowth = isPinnedTranscriptLayoutGrowth({
   pinned: true,
@@ -79,6 +93,54 @@ const userScrollDuringGrowth = isPinnedTranscriptLayoutGrowth({
   scrollTop: 9000,
 });
 check(!userScrollDuringGrowth, "upward user movement is not mistaken for pinned row growth");
+
+const dismissTodoViewport = {
+  pinned: true,
+  previousScrollHeight: 10000,
+  previousScrollTop: 9400,
+  previousClientHeight: 600,
+  scrollHeight: 10000,
+  // Virtuoso can reset scrollTop to the start of the loaded window when the
+  // composer/todo footer shrinks and the transcript viewport grows.
+  scrollTop: 0,
+  clientHeight: 760,
+};
+check(
+  isPinnedTranscriptViewportChange(dismissTodoViewport),
+  "dismissing the todo footer is a pinned viewport change",
+);
+check(
+  shouldKeepPinnedOnAtBottomFalse(dismissTodoViewport),
+  "todo dismiss must not treat a viewport-grow remasure as leaving the tail",
+);
+
+const openTodoViewport = {
+  ...dismissTodoViewport,
+  previousClientHeight: 760,
+  clientHeight: 600,
+  scrollTop: 9400,
+};
+check(
+  isPinnedTranscriptViewportChange(openTodoViewport),
+  "opening the todo footer is a pinned viewport change",
+);
+check(
+  shouldKeepPinnedOnAtBottomFalse(openTodoViewport),
+  "todo open must keep tail-follow while the composer chrome grows",
+);
+
+const readingHistory = {
+  ...dismissTodoViewport,
+  pinned: false,
+};
+check(
+  !isPinnedTranscriptViewportChange(readingHistory),
+  "an unpinned reader is not forced back to the tail when the footer resizes",
+);
+check(
+  !shouldKeepPinnedOnAtBottomFalse(readingHistory),
+  "unpinned history reading survives todo dismiss",
+);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -396,12 +396,11 @@ export function Transcript({
     };
   }, []);
 
-  // Virtuoso observes both its viewport and rows. When the composer/todo
-  // chrome changes height, re-assert the tail only if the reader is still pinned.
+  // Footer chrome resize only. Item growth stays on followGrowingTail.
   useEffect(() => {
-    if (items.length === 0 || !virtuosoReadyRef.current || !stick.current) return;
+    if (!virtuosoReadyRef.current || !stick.current) return;
     scrollToBottom();
-  }, [footerHeight, items.length, scrollToBottom, stick]);
+  }, [footerHeight, scrollToBottom, stick]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -396,11 +396,12 @@ export function Transcript({
     };
   }, []);
 
-  // Virtuoso observes both its viewport and rows. When the composer changes
-  // height, ask its tail policy to settle only if the reader is still pinned.
+  // Virtuoso observes both its viewport and rows. When the composer/todo
+  // chrome changes height, re-assert the tail only if the reader is still pinned.
   useEffect(() => {
-    if (items.length > 0 && virtuosoReadyRef.current) followGrowingTail();
-  }, [followGrowingTail, footerHeight, items.length]);
+    if (items.length === 0 || !virtuosoReadyRef.current || !stick.current) return;
+    scrollToBottom();
+  }, [footerHeight, items.length, scrollToBottom, stick]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -7,9 +7,39 @@ export type HydrateLiveState = {
   pendingUser?: unknown;
   historyTotalTurns?: number;
   items: ReadonlyArray<{ kind: string; streaming?: boolean; status?: string }>;
+  historyRevision?: number;
+  historyDigest?: string;
 };
 
 export type HydratedHistoryApplyMode = "replace" | "prepend" | "skip";
+
+export type HydrateProjection = {
+  items: ReadonlyArray<unknown>;
+  revision?: number;
+  digest?: string;
+};
+
+export function shouldPreferResidentHistory(reset: boolean, preserveCachedHistory?: boolean): boolean {
+  return !reset && preserveCachedHistory !== false;
+}
+
+function sameHydrateFingerprint(state: HydrateLiveState | undefined, projection: HydrateProjection | undefined): boolean {
+  if (!state || !projection) return false;
+  const revision = projection.revision ?? 0;
+  const digest = (projection.digest ?? "").trim();
+  if (revision > 0 && state.historyRevision === revision) return true;
+  if (digest !== "" && (state.historyDigest ?? "") === digest) return true;
+  return false;
+}
+
+export function isStaleResidentProjection(
+  state: HydrateLiveState | undefined,
+  projection: HydrateProjection | undefined,
+): boolean {
+  if (!state || !projection || state.items.length === 0) return false;
+  if (projection.items.length >= state.items.length) return false;
+  return sameHydrateFingerprint(state, projection);
+}
 
 // A live turn is only "cached" once a history page has landed behind it.
 // Without that, a session opened mid-stream reports a cached turn, skips the
@@ -27,15 +57,18 @@ export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean 
 // An empty surface has to apply history or switch-back shows Welcome. A turn
 // that has already streamed rows keeps them — but a tab with no history page
 // behind it still gets one, prepended, instead of a blank transcript above the
-// live turn. Only an already-hydrated live turn is left alone.
+// live turn. Only an already-hydrated live turn is left alone. An idle
+// same-fingerprint resident page that is shorter than the visible transcript
+// is skipped so Retry/clear cannot roll the chat back.
 export function hydratedHistoryApplyMode(
   skipHistory: boolean,
   hasProjection: boolean,
   foregroundTurnActive: boolean,
   state: HydrateLiveState | undefined,
+  projection?: HydrateProjection,
 ): HydratedHistoryApplyMode {
   if (skipHistory || !hasProjection) return "skip";
-  if (!foregroundTurnActive) return "replace";
+  if (!foregroundTurnActive) return isStaleResidentProjection(state, projection) ? "skip" : "replace";
   if ((state?.items.length ?? 0) === 0 && !hasCachedLiveTurn(state)) return "replace";
   return (state?.historyTotalTurns ?? 0) === 0 ? "prepend" : "skip";
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -2935,9 +2935,7 @@ export function useController() {
       let projection = skipHistory
         ? undefined
         : await loadTimed("history", () =>
-            // Windowed slice load through the transcript store. Resident LRU
-            // hits are allowed only when the caller keeps cache; reset and
-            // explicit no-cache hydrates re-fetch.
+            // Resident LRU only when the caller keeps cache; reset/no-cache re-fetch.
             getTranscriptStore().loadLatest(tabId, sessionPath, {
               turns: HISTORY_PAGE_TURNS,
               preferResident: shouldPreferResidentHistory(reset, options.preserveCachedHistory),

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -19,7 +19,7 @@ import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
-import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems } from "./hydrateHistoryApply";
+import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameTodoList } from "./todoVisibility";
 import type { SearchSource } from "./searchSources";
@@ -2935,13 +2935,12 @@ export function useController() {
       let projection = skipHistory
         ? undefined
         : await loadTimed("history", () =>
-            // Windowed slice load through the transcript store. A resident
-            // session (LRU hit) projects synchronously with no backend round
-            // trip; reset loads always re-fetch so a rebound session can never
-            // serve the previous session's rows.
+            // Windowed slice load through the transcript store. Resident LRU
+            // hits are allowed only when the caller keeps cache; reset and
+            // explicit no-cache hydrates re-fetch.
             getTranscriptStore().loadLatest(tabId, sessionPath, {
               turns: HISTORY_PAGE_TURNS,
-              preferResident: !reset,
+              preferResident: shouldPreferResidentHistory(reset, options.preserveCachedHistory),
               expectedRevision: sessionRevision,
               expectedDigest: sessionDigest,
             }),
@@ -2954,7 +2953,10 @@ export function useController() {
         dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
-      const applyMode = hydratedHistoryApplyMode(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId));
+      const applyProj = projection && {
+        items: projection.items, revision: projection.revisionKnown ? projection.revision : undefined, digest: projection.digest || undefined,
+      };
+      const applyMode = hydratedHistoryApplyMode(skipHistory, projection !== undefined, foregroundTurnActive(), statesRef.current.get(tabId), applyProj);
       if (projection !== undefined && applyMode !== "skip") {
         if (deferResetUntilHistory && stillCurrent() && !foregroundTurnActive()) dispatchTo(tabId, { type: "reset" });
         const page = {
@@ -4051,7 +4053,7 @@ export function useController() {
     try {
       cleared = tabId ? await app.ClearSessionForTab(tabId) : await app.ClearSession();
     } catch {
-      if (tabId) void loadSessionDataForTab(tabId);
+      if (tabId) void loadSessionDataForTab(tabId, false, "startup", { preserveCachedHistory: true });
       return;
     }
     if (tabId) bumpSessionLoadSeq(tabId);

--- a/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
+++ b/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
@@ -43,6 +43,53 @@ export function isPinnedTranscriptLayoutGrowth({
     && scrollTop >= previousScrollTop - 1;
 }
 
+export function isPinnedTranscriptViewportChange({
+  pinned,
+  previousClientHeight,
+  clientHeight,
+}: {
+  pinned: boolean;
+  previousClientHeight: number;
+  clientHeight: number;
+}) {
+  // Composer chrome such as the todo shelf changes the transcript viewport
+  // without a user scroll. Virtuoso can then publish atBottom=false and even
+  // reset scrollTop to the start of the loaded window.
+  return pinned
+    && previousClientHeight > 0
+    && Math.abs(clientHeight - previousClientHeight) > 1;
+}
+
+export function shouldKeepPinnedOnAtBottomFalse({
+  pinned,
+  previousScrollHeight,
+  previousScrollTop,
+  previousClientHeight,
+  scrollHeight,
+  scrollTop,
+  clientHeight,
+}: {
+  pinned: boolean;
+  previousScrollHeight: number;
+  previousScrollTop: number;
+  previousClientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}) {
+  return isPinnedTranscriptLayoutGrowth({
+    pinned,
+    previousScrollHeight,
+    previousScrollTop,
+    scrollHeight,
+    scrollTop,
+  }) || isPinnedTranscriptViewportChange({
+    pinned,
+    previousClientHeight,
+    clientHeight,
+  });
+}
+
 /**
  * Product-level scroll intent around React Virtuoso.
  *
@@ -56,7 +103,7 @@ export function useTranscriptVirtuosoScroll() {
   const pinnedRef = useRef(true);
   const bottomRequestRef = useRef(false);
   const bottomRequestTimerRef = useRef<number | null>(null);
-  const pinnedMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0 });
+  const pinnedMetricsRef = useRef({ scrollHeight: 0, scrollTop: 0, clientHeight: 0 });
   const modeRef = useRef<TranscriptScrollMode>("tail-follow");
   const touchStartYRef = useRef<number | null>(null);
   const nativeScrollbarDragRef = useRef(false);
@@ -136,7 +183,11 @@ export function useTranscriptVirtuosoScroll() {
     if (element) {
       element.dataset.scrollMode = modeRef.current;
       if (pinnedRef.current) {
-        pinnedMetricsRef.current = { scrollHeight: element.scrollHeight, scrollTop: element.scrollTop };
+        pinnedMetricsRef.current = {
+          scrollHeight: element.scrollHeight,
+          scrollTop: element.scrollTop,
+          clientHeight: element.clientHeight,
+        };
       }
     }
     setScrollElement((current) => current === element ? current : element);
@@ -162,17 +213,23 @@ export function useTranscriptVirtuosoScroll() {
 
   const atBottomStateChange = useCallback((atBottom: boolean) => {
     const element = scrollRef.current;
-    if (!atBottom && element && isPinnedTranscriptLayoutGrowth({
+    if (!atBottom && element && shouldKeepPinnedOnAtBottomFalse({
       pinned: pinnedRef.current,
       previousScrollHeight: pinnedMetricsRef.current.scrollHeight,
       previousScrollTop: pinnedMetricsRef.current.scrollTop,
+      previousClientHeight: pinnedMetricsRef.current.clientHeight,
       scrollHeight: element.scrollHeight,
       scrollTop: element.scrollTop,
+      clientHeight: element.clientHeight,
     })) {
-      // A mounted row grew while the reader still owned the tail. Virtuoso can
-      // publish `false` before totalListHeightChanged asks us to follow the new
-      // extent; preserve intent through that callback ordering race.
-      pinnedMetricsRef.current = { scrollHeight: element.scrollHeight, scrollTop: element.scrollTop };
+      // A mounted row grew, or composer chrome resized the viewport, while the
+      // reader still owned the tail. Virtuoso can publish `false` and even jump
+      // scrollTop to the loaded-window start before we follow the new extent.
+      pinnedMetricsRef.current = {
+        scrollHeight: element.scrollHeight,
+        scrollTop: element.scrollTop,
+        clientHeight: element.clientHeight,
+      };
       followGrowingTail();
       return;
     }
@@ -196,7 +253,11 @@ export function useTranscriptVirtuosoScroll() {
     if (atBottom) {
       clearBottomRequest();
       if (element) {
-        pinnedMetricsRef.current = { scrollHeight: element.scrollHeight, scrollTop: element.scrollTop };
+        pinnedMetricsRef.current = {
+          scrollHeight: element.scrollHeight,
+          scrollTop: element.scrollTop,
+          clientHeight: element.clientHeight,
+        };
       }
     }
     pinnedRef.current = atBottom;


### PR DESCRIPTION
## Summary

Dismissing a completed desktop todo shelf no longer jumps the visible chat back to an earlier todo list. Retry / failed-clear hydrates also stop replacing a longer live transcript with a shorter same-fingerprint resident snapshot.

Closing the todo footer grows the transcript viewport. Virtuoso then reported `atBottom=false` and could reset `scrollTop` to the start of the loaded window (up to ~60 turns), so yesterday's unsigned todos and progress table reappeared. The latest session was still on disk; re-clicking the session remounted the transcript and pinned it to the tail.

The same user-visible shape could happen on Retry or a failed clear: those hydrates preferred the resident LRU page, which live events never update.

## Issues

## Verification

- Composer/todo viewport resizes while pinned stay on the tail; an unpinned reader who is already scrolling history is not yanked back.
- Explicit no-cache hydrates fetch instead of serving the resident snapshot.
- A shorter same-fingerprint page cannot replace a longer idle transcript.
- A failed clear keeps the visible transcript.
- `pnpm exec tsx src/__tests__/transcript-scroll-release.test.ts`
- `pnpm exec tsx src/__tests__/hydrate-history-apply.test.ts`
- `pnpm exec tsx src/__tests__/history-load-failure-contract.test.ts`
- `pnpm exec tsx src/__tests__/use-controller-history-live-race.test.tsx`
- `pnpm test:transcript`

Protected chat paths: send/stop/model/effort are untouched. Tab switch and resume still skip or refetch history by fingerprint. This change only refuses a stale shorter resident page and keeps the tail pin across footer resize.

## Documentation impact

Documentation-impact: none - embedded docs do not describe transcript tail-follow after the todo shelf closes, or resident hydrate cache policy. The documented todo panel, session restore, and history retry behavior stay correct.

## Cache impact

Cache-impact: none - desktop frontend scroll and hydrate apply policy only; provider-visible prefix, tool schemas, and serialization are unchanged
Cache-guard: existing frontend hydrate/history tests; no new provider or boot cache guard required
System-prompt-review: N/A
