### PR TITLE
feat(desktop): add expanded reasoning display mode that stays open / 新增思考完成后保持展开的持续展开模式

### DIFF
--- a/desktop/frontend/src/__tests__/message-reasoning-panel.test.tsx
+++ b/desktop/frontend/src/__tests__/message-reasoning-panel.test.tsx
@@ -250,6 +250,22 @@ await render({
 ok(Boolean(document.querySelector(".reasoning__body")), "manual reasoning expansion survives auto completion");
 
 await act(async () => {
+  applyReasoningDisplayMode("expanded");
+});
+await render({
+  kind: "assistant",
+  id: "a-expanded",
+  text: "",
+  reasoning: "kept thought",
+  streaming: false,
+  reasoningComplete: true,
+});
+ok(Boolean(document.querySelector(".reasoning__body")), "expanded mode keeps completed reasoning open");
+ok(!document.querySelector(".reasoning-summary"), "expanded mode never falls back to a summary");
+await click(document.querySelector(".reasoning__head"));
+ok(!document.querySelector(".reasoning__body"), "a manual collapse still wins inside expanded mode");
+
+await act(async () => {
   applyReasoningDisplayMode("hidden");
 });
 await render({

--- a/desktop/frontend/src/__tests__/reasoning-display-preference.test.ts
+++ b/desktop/frontend/src/__tests__/reasoning-display-preference.test.ts
@@ -53,6 +53,9 @@ ok(getReasoningDisplayMode() === "hidden", "explicit new mode wins over every le
 hydrateReasoningDisplayMode("summary", true);
 ok(getReasoningDisplayMode() === "summary", "an explicit summary selection remains persisted");
 
+hydrateReasoningDisplayMode("expanded", true);
+ok(getReasoningDisplayMode() === "expanded", "an explicit expanded selection remains persisted");
+
 storage.set("reasonix-reasoning-summary", "0");
 ok(resolveReasoningDisplayMode("auto", false) === "legacy-collapsed", "resolver applies legacy precedence without hydration");
 hydrateReasoningDisplayMode("auto", false);

--- a/desktop/frontend/src/__tests__/subagent-progress-card.test.tsx
+++ b/desktop/frontend/src/__tests__/subagent-progress-card.test.tsx
@@ -121,6 +121,50 @@ console.log("\nsubagent progress card");
   const rootEl = document.getElementById("root");
   if (!rootEl) throw new Error("missing root");
   const root = createRoot(rootEl);
+  hydrateReasoningDisplayMode("expanded", true);
+  const running = makeItem("reasoning");
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null, React.createElement(ToolCard, { item: running })));
+    for (let i = 0; i < 50; i += 1) {
+      await flushTimers();
+      if (document.querySelector(".tool__subagent-preview .md")) break;
+    }
+  });
+  ok(!!document.querySelector(".tool__subagent-preview .md"), "expanded mode opens live sub-agent reasoning");
+
+  const completed = makeItem("completed", { durationMs: 42_000 });
+  completed.id = running.id;
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null, React.createElement(ToolCard, { item: completed })));
+    await flushTimers();
+  });
+  ok(!!document.querySelector(".tool__subagent-preview .md"), "expanded mode keeps completed sub-agent reasoning visible");
+
+  await act(async () => {
+    document.querySelector<HTMLButtonElement>(".tool__head")?.click();
+    await flushTimers();
+  });
+  ok(!document.querySelector(".tool__subagent-preview"), "manual card collapse still wins in expanded mode");
+
+  await act(async () => {
+    root.render(React.createElement(LocaleProvider, null, React.createElement(ToolCard, { key: "completed-history", item: completed })));
+    for (let i = 0; i < 50; i += 1) {
+      await flushTimers();
+      if (document.querySelector(".tool__subagent-preview .md")) break;
+    }
+  });
+  ok(!!document.querySelector(".tool__subagent-preview .md"), "expanded mode opens completed sub-agent reasoning restored from history");
+
+  await act(async () => root.unmount());
+  dom.window.close();
+  hydrateReasoningDisplayMode("summary", true);
+}
+
+{
+  const dom = installDom();
+  const rootEl = document.getElementById("root");
+  if (!rootEl) throw new Error("missing root");
+  const root = createRoot(rootEl);
 
   // Running card: chip shows phase, live elapsed and recent activity.
   const running = makeItem("reasoning");

--- a/desktop/frontend/src/__tests__/transcript-dom-harness.tsx
+++ b/desktop/frontend/src/__tests__/transcript-dom-harness.tsx
@@ -9,6 +9,7 @@ import { JSDOM } from "jsdom";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { createServer, type ViteDevServer } from "vite";
+import type { ReasoningDisplayMode } from "../lib/reasoningDisplayPreference";
 import type { Item } from "../lib/useController";
 
 export interface TranscriptHarnessOptions {
@@ -18,6 +19,8 @@ export interface TranscriptHarnessOptions {
   rowHeight?: number;
   /** Extra localStorage seed values (display mode, fold preference, …). */
   storage?: Record<string, string>;
+  /** Authoritative reasoning mode to hydrate before Transcript is imported. */
+  reasoningDisplayMode?: ReasoningDisplayMode;
 }
 
 export interface TranscriptHarness {
@@ -185,6 +188,12 @@ export async function createTranscriptHarness(options: TranscriptHarnessOptions 
     logLevel: "silent",
     server: { middlewareMode: true },
   });
+  if (options.reasoningDisplayMode) {
+    const preference = await server.ssrLoadModule("/src/lib/reasoningDisplayPreference.ts") as {
+      hydrateReasoningDisplayMode: (mode: unknown, explicit: boolean) => void;
+    };
+    preference.hydrateReasoningDisplayMode(options.reasoningDisplayMode, true);
+  }
   const { TranscriptTestSurface } = await server.ssrLoadModule("/src/__tests__/transcript-test-surface.tsx");
   const { LocaleProvider } = await server.ssrLoadModule("/src/lib/i18n.tsx");
   const TranscriptComponent = TranscriptTestSurface as React.ComponentType<Record<string, unknown>>;

--- a/desktop/frontend/src/__tests__/transcript-process-fold.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-process-fold.test.ts
@@ -246,7 +246,99 @@ const warningTurn: Item[] = [
   }
 }
 
-// ── Phase 3: summaries disabled ─────────────────────────────────────────────
+// ── Phase 3: expanded reasoning pins its parent process fold ─────────────────
+{
+  const harness = await createTranscriptHarness({ reasoningDisplayMode: "expanded" });
+  const container = harness.container;
+  try {
+    const runningItems: Item[] = [
+      { kind: "user", id: "u-expanded-parent", text: "inspect" },
+      {
+        kind: "assistant",
+        id: "a-expanded-parent",
+        text: "done",
+        reasoning: "completed reasoning should remain visible",
+        streaming: true,
+        reasoningComplete: false,
+        workDurationMs: 1_000,
+      },
+    ];
+    await render(harness, runningItems, { running: true });
+    await harness.waitFor(
+      () => Boolean(
+        container.querySelector(".turn-collapse--open")
+          && container.querySelector(".turn-collapse__reasoning-phase--open .md"),
+      ),
+      "expanded live reasoning",
+    );
+    ok(Boolean(container.querySelector(".turn-collapse--open")), "expanded reasoning starts with its running parent fold open");
+    ok(Boolean(container.querySelector(".turn-collapse__reasoning-phase--open .md")), "expanded running reasoning renders its full body");
+
+    const completedItems: Item[] = runningItems.map((item) => item.kind === "assistant"
+      ? { ...item, streaming: false, reasoningComplete: true }
+      : item);
+    await render(harness, completedItems, { running: false });
+    await harness.waitFor(
+      () => Boolean(
+        container.querySelector(".turn-collapse--open")
+          && container.querySelector(".turn-collapse__reasoning-phase--open .md"),
+      ),
+      "expanded completed reasoning",
+    );
+    ok(Boolean(container.querySelector(".turn-collapse--open")), "expanded reasoning keeps its parent fold open after completion");
+    ok(Boolean(container.querySelector(".turn-collapse__reasoning-phase--open .md")), "expanded completed reasoning remains visible");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(".turn-collapse > .reasoning__head")?.click();
+    });
+    await harness.flush();
+    ok(!container.querySelector(".turn-collapse--open"), "manual parent collapse still wins in expanded reasoning mode");
+    ok(!container.querySelector(".turn-collapse__body"), "manual parent collapse unmounts the expanded reasoning body");
+
+    await render(harness, completedItems, { running: false });
+    ok(!container.querySelector(".turn-collapse--open"), "completed rerenders preserve a manual parent collapse");
+    await harness.settle();
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
+// A completed reasoning fold restored from history has no live transition to
+// open it, so the expanded-mode default must pin it on first reconciliation.
+{
+  const harness = await createTranscriptHarness({ reasoningDisplayMode: "expanded" });
+  const container = harness.container;
+  try {
+    await render(harness, [
+      { kind: "user", id: "u-expanded-history", text: "inspect" },
+      {
+        kind: "assistant",
+        id: "a-expanded-history",
+        text: "done",
+        reasoning: "restored completed reasoning",
+        streaming: false,
+        reasoningComplete: true,
+        workDurationMs: 1_000,
+      },
+    ]);
+    await harness.waitFor(
+      () => Boolean(
+        container.querySelector(".turn-collapse--open")
+          && container.querySelector(".turn-collapse__reasoning-phase--open .md"),
+      ),
+      "expanded reasoning restored from history",
+    );
+    ok(Boolean(container.querySelector(".turn-collapse--open")), "expanded history restores the parent reasoning fold open");
+    ok(Boolean(container.querySelector(".turn-collapse__reasoning-phase--open .md")), "expanded history restores completed reasoning visible");
+    await harness.settle();
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
+// ── Phase 4: summaries disabled ─────────────────────────────────────────────
 {
   const harness = await createTranscriptHarness({
     storage: { "reasonix-process-fold": "expanded", "reasonix-reasoning-summary": "0" },

--- a/desktop/frontend/src/__tests__/transcript-rows.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-rows.test.ts
@@ -206,6 +206,7 @@ const keys = (rows: TranscriptRow[]) => rows.map((row) => row.key).join(",");
   ], undefined, false, true);
   const mixedStates = foldSegmentStates(mixed);
   eq(mixedStates.length, 1, "hidden reasoning keeps a mixed tool process fold");
+  eq(foldSegmentStates(mixed, true)[0]?.keepReasoningExpanded, false, "expanded reasoning mode does not pin tool-only folds");
   eq(mixed[0]?.segments[0]?.displayItems.filter((item) => item.kind === "assistant").length ?? -1, 0, "hidden reasoning is excluded from fold body items");
   eq(mixed[0]?.segments[0]?.displayItems.filter((item) => item.kind === "tool").length ?? -1, 1, "hidden reasoning does not hide tools");
 }
@@ -227,6 +228,27 @@ const keys = (rows: TranscriptRow[]) => rows.map((row) => row.key).join(",");
   const closed = reconcileFoldEntries(seeded ?? EMPTY_FOLDS, settledStates, "auto", false);
   ok(closed?.get("a1")?.open === false, "completion auto-closes an untouched fold");
   eq(reconcileFoldEntries(closed ?? EMPTY_FOLDS, settledStates, "auto", false), null, "steady state reconciles to no change");
+}
+
+{
+  // Expanded reasoning pins only reasoning-bearing folds across completion.
+  const running = buildTurnModels(fixture.slice(0, 7), { id: "a2", hasAnswerText: true, hasReasoning: false, reasoningComplete: true }, true);
+  const runningStates = foldSegmentStates(running, true);
+  eq(runningStates[0]?.keepReasoningExpanded, true, "expanded mode marks a reasoning-bearing fold as pinned");
+  const seeded = reconcileFoldEntries(EMPTY_FOLDS, runningStates, "auto", false) ?? EMPTY_FOLDS;
+
+  const settledModels = buildTurnModels(fixture.slice(0, 7), undefined, false);
+  const settledPinnedStates = foldSegmentStates(settledModels, true);
+  const completed = reconcileFoldEntries(seeded, settledPinnedStates, "auto", false);
+  ok(completed?.get("a1")?.open === true, "expanded reasoning keeps its parent fold open after completion");
+
+  const manuallyCollapsed = foldMapWithToggle(seeded, "a1", true);
+  const completedCollapsed = reconcileFoldEntries(manuallyCollapsed, settledPinnedStates, "auto", false);
+  ok(completedCollapsed?.get("a1")?.open === false, "manual parent collapse still wins when expanded reasoning completes");
+
+  const settledAutoStates = foldSegmentStates(settledModels, false);
+  const backToAuto = reconcileFoldEntries(completed ?? EMPTY_FOLDS, settledAutoStates, "auto", false);
+  ok(backToAuto?.get("a1")?.open === false, "leaving expanded reasoning re-applies the automatic parent fold policy");
 }
 
 {

--- a/desktop/frontend/src/components/AssistantReasoningPanel.tsx
+++ b/desktop/frontend/src/components/AssistantReasoningPanel.tsx
@@ -30,8 +30,9 @@ export function AssistantReasoningPanel({
   const t = useT();
   const displayMode = useReasoningDisplayMode();
   const running = item.streaming && !item.reasoningComplete;
-  const followsWhileStreaming = displayMode === "auto" || expandWhileStreaming;
-  const [open, setOpen] = useState(defaultExpanded || (followsWhileStreaming && running));
+  const followsWhileStreaming = displayMode === "auto" || displayMode === "expanded" || expandWhileStreaming;
+  const keepExpanded = displayMode === "expanded";
+  const [open, setOpen] = useState(defaultExpanded || keepExpanded || (followsWhileStreaming && running));
   const bodyRef = useRef<HTMLDivElement>(null);
   const userOverridden = useRef(false);
   const previousStreaming = useRef(item.streaming);
@@ -48,15 +49,15 @@ export function AssistantReasoningPanel({
     previousMode.current = displayMode;
     if (modeChanged) {
       userOverridden.current = false;
-      setOpen(defaultExpanded || (followsWhileStreaming && !complete));
+      setOpen(defaultExpanded || keepExpanded || (followsWhileStreaming && !complete));
     } else if (item.streaming) {
       if (!wasStreaming) userOverridden.current = false;
-      if (defaultExpanded) setOpen(true);
+      if (defaultExpanded || keepExpanded) setOpen(true);
       else if (!userOverridden.current) setOpen(followsWhileStreaming && !complete);
     } else if ((complete && !wasComplete) || wasStreaming) {
-      if (!defaultExpanded && !userOverridden.current) setOpen(false);
+      if (!defaultExpanded && !keepExpanded && !userOverridden.current) setOpen(false);
     }
-  }, [defaultExpanded, displayMode, followsWhileStreaming, item.reasoningComplete, item.streaming]);
+  }, [defaultExpanded, displayMode, followsWhileStreaming, keepExpanded, item.reasoningComplete, item.streaming]);
 
   const toggle = () => {
     userOverridden.current = true;

--- a/desktop/frontend/src/components/InlineAssistantReasoning.tsx
+++ b/desktop/frontend/src/components/InlineAssistantReasoning.tsx
@@ -15,7 +15,7 @@ export function InlineAssistantReasoning({ item, onManualOpen }: { item: Assista
   const displayMode = useReasoningDisplayMode();
   const shown = live?.id === item.id ? { reasoning: live.reasoning, streaming: true, reasoningComplete: live.reasoningComplete } : item;
   const running = shown.streaming && !shown.reasoningComplete;
-  const [open, setOpen] = useState(displayMode === "auto" && running);
+  const [open, setOpen] = useState(displayMode === "expanded" || (displayMode === "auto" && running));
   const userOverridden = useRef(false);
   const previousRunning = useRef(running);
   const previousMode = useRef(displayMode);
@@ -26,8 +26,8 @@ export function InlineAssistantReasoning({ item, onManualOpen }: { item: Assista
     previousRunning.current = running;
     if (modeChanged) {
       userOverridden.current = false;
-      setOpen(displayMode === "auto" && running);
-    } else if (displayMode === "auto" && running && !wasRunning) {
+      setOpen(displayMode === "expanded" || (displayMode === "auto" && running));
+    } else if (running && !wasRunning && (displayMode === "auto" || displayMode === "expanded")) {
       userOverridden.current = false;
       setOpen(true);
     } else if (displayMode === "auto" && !running && wasRunning && !userOverridden.current) {

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1705,7 +1705,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
         <SettingsField label={t("settings.reasoningDisplay")} hint={t("settings.reasoningDisplayHint")} icon={<BrainCircuit size={18} />}>
           <div>
             <div className="set-seg" role="radiogroup" aria-label={t("settings.reasoningDisplay")}>
-              {(["hidden", "summary", "auto"] as const).map((mode) => (
+              {(["hidden", "summary", "auto", "expanded"] as const).map((mode) => (
                 <button
                   key={mode}
                   type="button"

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -213,7 +213,8 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
   // user sees nested calls; they collapse when done. Reasoning (AssistantMessage)
   // also opens while streaming and closes on finish.
   const subagentReasoningRunning = sp?.phase === "reasoning";
-  const defaultOpen = (hasNested && item.status === "running") || (reasoningDisplayMode === "auto" && subagentReasoningRunning);
+  const liveFollow = reasoningDisplayMode === "auto" || reasoningDisplayMode === "expanded";
+  const defaultOpen = (hasNested && item.status === "running") || (liveFollow && subagentReasoningRunning);
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const open = userOpen ?? defaultOpen;
   const openRef = useRef(open);
@@ -223,7 +224,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
   // The sub-agent reasoning preview opens as a one-line summary; the full
   // Markdown only mounts after the user expands the reasoning section.
   const [subagentReasoningOpen, setSubagentReasoningOpen] = useState(
-    () => reasoningDisplayMode === "auto" && subagentReasoningRunning,
+    () => reasoningDisplayMode === "expanded" || (reasoningDisplayMode === "auto" && subagentReasoningRunning),
   );
   const subagentReasoningUserOverridden = useRef(false);
   const previousSubagentReasoningRunning = useRef(subagentReasoningRunning);
@@ -235,17 +236,16 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
     previousSubagentReasoningRunning.current = subagentReasoningRunning;
     if (modeChanged) {
       subagentReasoningUserOverridden.current = false;
-      setSubagentReasoningOpen(reasoningDisplayMode === "auto" && subagentReasoningRunning);
-      return;
-    }
-    if (reasoningDisplayMode !== "auto") {
-      setSubagentReasoningOpen(false);
+      setSubagentReasoningOpen(reasoningDisplayMode === "expanded" || (reasoningDisplayMode === "auto" && subagentReasoningRunning));
       return;
     }
     if (subagentReasoningRunning && !wasRunning) {
       subagentReasoningUserOverridden.current = false;
-      setSubagentReasoningOpen(true);
-    } else if (!subagentReasoningRunning && wasRunning && !subagentReasoningUserOverridden.current) {
+      if (liveFollow) setSubagentReasoningOpen(true);
+      return;
+    }
+    if (reasoningDisplayMode !== "auto") return;
+    if (!subagentReasoningRunning && wasRunning && !subagentReasoningUserOverridden.current) {
       setSubagentReasoningOpen(false);
     }
   }, [reasoningDisplayMode, subagentReasoningRunning]);

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -214,7 +214,8 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId, displayN
   // also opens while streaming and closes on finish.
   const subagentReasoningRunning = sp?.phase === "reasoning";
   const liveFollow = reasoningDisplayMode === "auto" || reasoningDisplayMode === "expanded";
-  const defaultOpen = (hasNested && item.status === "running") || (liveFollow && subagentReasoningRunning);
+  const keepSubagentReasoningExpanded = reasoningDisplayMode === "expanded" && Boolean(sp?.reasoning);
+  const defaultOpen = (hasNested && item.status === "running") || (liveFollow && subagentReasoningRunning) || keepSubagentReasoningExpanded;
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const open = userOpen ?? defaultOpen;
   const openRef = useRef(open);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -432,7 +432,10 @@ export function Transcript({
     [liveId, liveHasAnswerText, liveHasReasoning, liveReasoningComplete],
   );
   const turnModels = useMemo(() => buildTurnModels(items, liveFlags, running, hideReasoning), [items, liveFlags, running, hideReasoning]);
-  const segmentStates = useMemo(() => foldSegmentStates(turnModels), [turnModels]);
+  const segmentStates = useMemo(
+    () => foldSegmentStates(turnModels, reasoningDisplayMode === "expanded"),
+    [reasoningDisplayMode, turnModels],
+  );
 
   const [foldPreference, setFoldPreference] = useState<ProcessFoldPreference>(getProcessFoldPreference);
   useEffect(() => onProcessFoldPreferenceChange(setFoldPreference), []);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -432,10 +432,7 @@ export function Transcript({
     [liveId, liveHasAnswerText, liveHasReasoning, liveReasoningComplete],
   );
   const turnModels = useMemo(() => buildTurnModels(items, liveFlags, running, hideReasoning), [items, liveFlags, running, hideReasoning]);
-  const segmentStates = useMemo(
-    () => foldSegmentStates(turnModels, reasoningDisplayMode === "expanded"),
-    [reasoningDisplayMode, turnModels],
-  );
+  const segmentStates = useMemo(() => foldSegmentStates(turnModels, reasoningDisplayMode === "expanded"), [reasoningDisplayMode, turnModels]);
 
   const [foldPreference, setFoldPreference] = useState<ProcessFoldPreference>(getProcessFoldPreference);
   useEffect(() => onProcessFoldPreferenceChange(setFoldPreference), []);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -533,7 +533,7 @@ export interface AppBindings extends SessionCatalogBindings, HistoryCatalogBindi
   SetCloseBehavior(mode: string): Promise<void>;
   SetDisplayMode(mode: string): Promise<void>;
   SetStatusBarStyle(style: string): Promise<void>;
-  SetStatusBarItems(items: string[]): Promise<void>; SetReasoningDisplayMode(mode: "hidden" | "summary" | "auto"): Promise<void>;
+  SetStatusBarItems(items: string[]): Promise<void>; SetReasoningDisplayMode(mode: "hidden" | "summary" | "auto" | "expanded"): Promise<void>;
   SetDesktopLanguage(lang: string): Promise<void>;
   SetDesktopCurrency(currency: string): Promise<void>;
   SetDesktopAppearance(theme: string, style: string): Promise<void>;
@@ -4898,7 +4898,7 @@ function makeMockApp(): AppBindings {
           settings.metrics = enabled;
         },
     async SetDesktopConversationWidth(width: string) { settings.conversationWidth = width; },
-    async SetReasoningDisplayMode(mode: "hidden" | "summary" | "auto") { if (!(["hidden", "summary", "auto"] as string[]).includes(mode)) throw new Error("invalid reasoning display mode"); settings.reasoningDisplayMode = mode; settings.reasoningDisplayModeExplicit = true; },
+    async SetReasoningDisplayMode(mode: "hidden" | "summary" | "auto" | "expanded") { if (!(["hidden", "summary", "auto", "expanded"] as string[]).includes(mode)) throw new Error("invalid reasoning display mode"); settings.reasoningDisplayMode = mode; settings.reasoningDisplayModeExplicit = true; },
         async SetExpandThinking(on: boolean) { settings.reasoningDisplayMode = on ? "auto" : "summary"; settings.reasoningDisplayModeExplicit = true; },
         async MigrateDesktopPreferences(language: string, theme: string, style: string) {
           if (!settings.desktopLanguage) settings.desktopLanguage = language === "en" || language === "zh" || language === "zh-TW" ? language : "";

--- a/desktop/frontend/src/lib/reasoningDisplayPreference.ts
+++ b/desktop/frontend/src/lib/reasoningDisplayPreference.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-export type ReasoningDisplayMode = "hidden" | "summary" | "auto";
+export type ReasoningDisplayMode = "hidden" | "summary" | "auto" | "expanded";
 export type ResolvedReasoningDisplayMode = ReasoningDisplayMode | "legacy-collapsed" | "pending";
 
 const LEGACY_SUMMARY_KEY = "reasonix-reasoning-summary";
@@ -16,7 +16,7 @@ function emit(): void {
 }
 
 function normalizeMode(value: unknown): ReasoningDisplayMode | undefined {
-  return value === "hidden" || value === "summary" || value === "auto" ? value : undefined;
+  return value === "hidden" || value === "summary" || value === "auto" || value === "expanded" ? value : undefined;
 }
 
 function legacySummaryValue(): "on" | "off" | undefined {

--- a/desktop/frontend/src/lib/transcriptRows.ts
+++ b/desktop/frontend/src/lib/transcriptRows.ts
@@ -260,6 +260,7 @@ export interface FoldEntry {
   open: boolean;
   userOverridden: boolean;
   running: boolean;
+  keepReasoningExpanded?: boolean;
 }
 
 export type FoldMap = ReadonlyMap<string, FoldEntry>;
@@ -267,24 +268,30 @@ export type FoldMap = ReadonlyMap<string, FoldEntry>;
 export const EMPTY_FOLDS: FoldMap = new Map();
 
 export function defaultFoldOpen(
-  segment: { hasOutsideContent: boolean; hasRunningWork: boolean },
+  segment: { hasOutsideContent: boolean; hasRunningWork: boolean; keepReasoningExpanded?: boolean },
   preference: ProcessFoldPreference,
 ): boolean {
-  return preference === "expanded" || !segment.hasOutsideContent || segment.hasRunningWork;
+  return preference === "expanded" || segment.keepReasoningExpanded === true || !segment.hasOutsideContent || segment.hasRunningWork;
 }
 
 export interface FoldSegmentState {
   key: string;
   hasOutsideContent: boolean;
   hasRunningWork: boolean;
+  keepReasoningExpanded: boolean;
 }
 
-export function foldSegmentStates(models: readonly TurnModel[]): FoldSegmentState[] {
+export function foldSegmentStates(models: readonly TurnModel[], keepReasoningExpanded = false): FoldSegmentState[] {
   const out: FoldSegmentState[] = [];
   for (const model of models) {
     for (const segment of model.segments) {
       if (segment.displayItems.length === 0) continue;
-      out.push({ key: segment.key, hasOutsideContent: segment.hasOutsideContent, hasRunningWork: segment.hasRunningWork });
+      out.push({
+        key: segment.key,
+        hasOutsideContent: segment.hasOutsideContent,
+        hasRunningWork: segment.hasRunningWork,
+        keepReasoningExpanded: keepReasoningExpanded && segment.displayItems.some((item) => item.kind === "assistant"),
+      });
     }
   }
   return out;
@@ -318,17 +325,24 @@ export function reconcileFoldEntries(
         open: defaultFoldOpen(segment, preference),
         userOverridden: false,
         running: segment.hasRunningWork,
+        keepReasoningExpanded: segment.keepReasoningExpanded,
       });
       continue;
     }
-    if (preferenceChanged) {
-      const open = preference === "expanded"
+    const reasoningPinChanged = Boolean(entry.keepReasoningExpanded) !== segment.keepReasoningExpanded;
+    if (preferenceChanged || reasoningPinChanged) {
+      const open = preference === "expanded" || segment.keepReasoningExpanded
         ? true
         : !segment.hasRunningWork && segment.hasOutsideContent
           ? false
           : entry.open;
-      if (open !== entry.open || entry.userOverridden || entry.running !== segment.hasRunningWork) {
-        write(segment.key, { open, userOverridden: false, running: segment.hasRunningWork });
+      if (open !== entry.open || entry.userOverridden || entry.running !== segment.hasRunningWork || reasoningPinChanged) {
+        write(segment.key, {
+          open,
+          userOverridden: false,
+          running: segment.hasRunningWork,
+          keepReasoningExpanded: segment.keepReasoningExpanded,
+        });
       }
       continue;
     }
@@ -338,13 +352,18 @@ export function reconcileFoldEntries(
       const userOverridden = entry.running ? entry.userOverridden : false;
       const open = userOverridden ? entry.open : true;
       if (open !== entry.open || userOverridden !== entry.userOverridden || !entry.running) {
-        write(segment.key, { open, userOverridden, running: true });
+        write(segment.key, { open, userOverridden, running: true, keepReasoningExpanded: segment.keepReasoningExpanded });
       }
       continue;
     }
     if (entry.running) {
-      const open = !entry.userOverridden && segment.hasOutsideContent && preference !== "expanded" ? false : entry.open;
-      write(segment.key, { open, userOverridden: entry.userOverridden, running: false });
+      const open = !entry.userOverridden && segment.hasOutsideContent && preference !== "expanded" && !segment.keepReasoningExpanded ? false : entry.open;
+      write(segment.key, {
+        open,
+        userOverridden: entry.userOverridden,
+        running: false,
+        keepReasoningExpanded: segment.keepReasoningExpanded,
+      });
     }
   }
   for (const key of prev.keys()) {
@@ -360,7 +379,12 @@ export function reconcileFoldEntries(
 export function foldMapWithToggle(prev: FoldMap, key: string, currentlyOpen: boolean): Map<string, FoldEntry> {
   const next = new Map(prev);
   const entry = prev.get(key);
-  next.set(key, { open: !currentlyOpen, userOverridden: true, running: entry?.running ?? false });
+  next.set(key, {
+    open: !currentlyOpen,
+    userOverridden: true,
+    running: entry?.running ?? false,
+    keepReasoningExpanded: entry?.keepReasoningExpanded,
+  });
   return next;
 }
 
@@ -368,7 +392,12 @@ export function foldMapWithToggle(prev: FoldMap, key: string, currentlyOpen: boo
 export function foldMapWithReasoningOpen(prev: FoldMap, key: string, running: boolean): Map<string, FoldEntry> {
   const next = new Map(prev);
   const entry = prev.get(key);
-  next.set(key, { open: true, userOverridden: true, running: entry?.running ?? running });
+  next.set(key, {
+    open: true,
+    userOverridden: true,
+    running: entry?.running ?? running,
+    keepReasoningExpanded: entry?.keepReasoningExpanded,
+  });
   return next;
 }
 

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1727,6 +1727,7 @@ export const en = {
   "settings.reasoningDisplay.hidden": "Hidden",
   "settings.reasoningDisplay.summary": "Summary",
   "settings.reasoningDisplay.auto": "Live follow",
+  "settings.reasoningDisplay.expanded": "Keep expanded",
   "settings.reasoningDisplay.legacy": "Legacy setting: no summary; open thinking from its heading. Choose a new mode to migrate.",
   "settings.statusBarStyle": "Bottom status bar style",
   "settings.statusBarStyleHint": "Choose the compact visual style used for session status.",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2699,6 +2699,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.reasoningDisplay.hidden": "隱藏",
   "settings.reasoningDisplay.summary": "摘要",
   "settings.reasoningDisplay.auto": "即時跟隨",
+  "settings.reasoningDisplay.expanded": "持續展開",
   "settings.reasoningDisplay.legacy": "沿用舊設定：無摘要，可點標題查看。選擇新模式遷移。",
   "settings.statusBarStyle": "底部資訊欄樣式",
   "settings.statusBarStyleHint": "選擇會話狀態資訊使用的緊湊顯示樣式。",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1729,6 +1729,7 @@ export const zh: Record<DictKey, string> = {
   "settings.reasoningDisplay.hidden": "隐藏",
   "settings.reasoningDisplay.summary": "摘要",
   "settings.reasoningDisplay.auto": "实时跟随",
+  "settings.reasoningDisplay.expanded": "持续展开",
   "settings.reasoningDisplay.legacy": "沿用旧设置：无摘要，可点标题查看。选择新模式迁移。",
   "settings.statusBarStyle": "底部信息栏样式",
   "settings.statusBarStyleHint": "选择会话状态信息使用的紧凑展示样式。",

--- a/internal/config/reasoning_display.go
+++ b/internal/config/reasoning_display.go
@@ -9,7 +9,7 @@ import (
 func (c *Config) DesktopReasoningDisplayMode() string {
 	raw := strings.ToLower(strings.TrimSpace(c.Desktop.ReasoningDisplayMode))
 	switch raw {
-	case "hidden", "summary", "auto":
+	case "hidden", "summary", "auto", "expanded":
 		return raw
 	}
 	// Missing and unknown values use the classic live-follow behavior. A user
@@ -20,7 +20,7 @@ func (c *Config) DesktopReasoningDisplayMode() string {
 // DesktopReasoningDisplayModeExplicit reports whether a valid new enum was stored.
 func (c *Config) DesktopReasoningDisplayModeExplicit() bool {
 	switch strings.ToLower(strings.TrimSpace(c.Desktop.ReasoningDisplayMode)) {
-	case "hidden", "summary", "auto":
+	case "hidden", "summary", "auto", "expanded":
 		return true
 	default:
 		return false
@@ -33,11 +33,11 @@ func (c *Config) SetDesktopReasoningDisplayMode(mode string) error {
 	case "hidden", "summary":
 		c.Desktop.ReasoningDisplayMode = strings.ToLower(strings.TrimSpace(mode))
 		c.Desktop.ExpandThinking = false
-	case "auto":
-		c.Desktop.ReasoningDisplayMode = "auto"
+	case "auto", "expanded":
+		c.Desktop.ReasoningDisplayMode = strings.ToLower(strings.TrimSpace(mode))
 		c.Desktop.ExpandThinking = true
 	default:
-		return fmt.Errorf("reasoning display mode %q: must be hidden|summary|auto", mode)
+		return fmt.Errorf("reasoning display mode %q: must be hidden|summary|auto|expanded", mode)
 	}
 	return nil
 }
@@ -53,6 +53,6 @@ func (c *Config) SetExpandThinking(on bool) error {
 func renderDesktopReasoningDisplayMode(b *strings.Builder, c *Config) {
 	fmt.Fprintf(b, "expand_thinking = %v   # desktop: legacy reasoning display alias; use reasoning_display_mode\n", c.Desktop.ExpandThinking)
 	if c.DesktopReasoningDisplayModeExplicit() {
-		fmt.Fprintf(b, "reasoning_display_mode = %q   # desktop: hidden|summary|auto reasoning presentation\n", c.DesktopReasoningDisplayMode())
+		fmt.Fprintf(b, "reasoning_display_mode = %q   # desktop: hidden|summary|auto|expanded reasoning presentation\n", c.DesktopReasoningDisplayMode())
 	}
 }

--- a/internal/config/reasoning_display_test.go
+++ b/internal/config/reasoning_display_test.go
@@ -21,6 +21,7 @@ func TestDesktopReasoningDisplayModeDefaultsAndLegacy(t *testing.T) {
 		{name: "explicit hidden wins over legacy", mode: "hidden", expand: true, want: "hidden", explicit: true},
 		{name: "explicit summary wins over legacy", mode: "summary", expand: true, want: "summary", explicit: true},
 		{name: "explicit auto", mode: "auto", want: "auto", explicit: true},
+		{name: "explicit expanded", mode: "expanded", expand: true, want: "expanded", explicit: true},
 		{name: "unknown follows the live-follow fallback", mode: "future-mode", want: "auto"},
 		{name: "unknown with legacy expand remains auto", mode: "future-mode", expand: true, want: "auto"},
 	}
@@ -48,6 +49,7 @@ func TestSetDesktopReasoningDisplayMode(t *testing.T) {
 		{mode: "hidden", want: "hidden"},
 		{mode: "summary", want: "summary"},
 		{mode: "auto", want: "auto", expand: true},
+		{mode: "expanded", want: "expanded", expand: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.mode, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add an explicit `expanded` reasoning display mode that keeps completed reasoning open.
- Apply the mode consistently to assistant messages, inline transcript reasoning, and sub-agent reasoning previews.
- Preserve manual collapse as a user override.

## Issues

Fixes #8312

## Verification

- `go test ./internal/config`
- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/reasoning-display-preference.test.ts`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/message-reasoning-panel.test.tsx`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/subagent-progress-card.test.tsx`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/transcript-process-fold.test.ts`
- `cd desktop/frontend && pnpm test:settings-responsive`
- `cd desktop/frontend && pnpm build`
- `git diff --check`

## Documentation impact

Documentation-impact: none - existing `docs/*.md` files do not document the desktop-only `reasoning_display_mode` presentation preference, so they remain correct.

## Cache impact

Cache-impact: none - the change is limited to persisted desktop presentation state and frontend rendering.
Cache-guard: existing cache-impact workflow; no provider-visible request or prompt schema changes.
System-prompt-review: N/A

示例效果：

<img width="1564" height="564" alt="Image" src="https://github.com/user-attachments/assets/cfed37d9-7428-4441-bd14-a47f301111f0" />
