### PR TITLE
feat(control): detach a running turn to a background job

### DIFF
--- a/internal/agent/detach_store_test.go
+++ b/internal/agent/detach_store_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestPrepareDetachedCopiesSnapshot(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	dir := t.TempDir()
+	snapshot := filepath.Join(dir, "main-session.jsonl")
+
+	// Build a valid transcript file to use as the detach snapshot source.
+	seed := NewSubagentStore(filepath.Join(t.TempDir(), "sub"))
+	spec := testSubagentSpec(t, "review")
+	seedRun, err := seed.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("seed PrepareFresh: %v", err)
+	}
+	seedRun.Session.Add(provider.Message{Role: provider.RoleUser, Content: "detach me"})
+	seedRun.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "tool result committed"})
+	if err := seed.SaveCompleted(seedRun); err != nil {
+		t.Fatalf("seed SaveCompleted: %v", err)
+	}
+	seedPath := seed.sessionPath(seedRun.Ref)
+	seedRun.Release()
+	data, err := os.ReadFile(seedPath)
+	if err != nil {
+		t.Fatalf("read seed transcript: %v", err)
+	}
+	if err := os.WriteFile(snapshot, data, 0o644); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	run, err := store.PrepareDetached(snapshot, spec)
+	if err != nil {
+		t.Fatalf("PrepareDetached: %v", err)
+	}
+	defer run.Release()
+	if run.Meta.Kind != "detach" {
+		t.Fatalf("meta.Kind = %q, want detach", run.Meta.Kind)
+	}
+	msgs := run.Session.Snapshot()
+	if len(msgs) < 2 || msgs[1].Content != "detach me" {
+		t.Fatalf("detached session messages = %+v, want snapshot contents", msgs)
+	}
+	// Transcript file must exist and differ from the source path.
+	if _, err := os.Stat(store.sessionPath(run.Ref)); err != nil {
+		t.Fatalf("transcript not copied: %v", err)
+	}
+}
+
+func TestPrepareDetachedRejectsMissingSnapshot(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	if _, err := store.PrepareDetached(filepath.Join(t.TempDir(), "nope.jsonl"), spec); err == nil {
+		t.Fatal("PrepareDetached with missing snapshot should fail")
+	}
+}
+
+func TestDeleteTranscriptRemovesFiles(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	dir := t.TempDir()
+	snapshot := filepath.Join(dir, "main-session.jsonl")
+	os.WriteFile(snapshot, []byte("{\"role\":\"system\",\"content\":\"sys\"}\n"), 0o644)
+
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareDetached(snapshot, spec)
+	if err != nil {
+		t.Fatalf("PrepareDetached: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+	if err := store.DeleteTranscript(ref); err != nil {
+		t.Fatalf("DeleteTranscript: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(ref)); !os.IsNotExist(err) {
+		t.Fatalf("transcript still exists after DeleteTranscript (err=%v)", err)
+	}
+	if _, err := os.Stat(store.metaPath(ref)); !os.IsNotExist(err) {
+		t.Fatalf("meta still exists after DeleteTranscript (err=%v)", err)
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -323,6 +323,15 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 		if !cont {
 			return terr
 		}
+		// #8170: the host asked to move the remainder of this turn to a
+		// background job. The current tool round already committed to the
+		// session, so the controller can snapshot it and continue as a job.
+		// The final-response branch above returns before this check, so a
+		// detach request that arrives while the model streams a final answer
+		// naturally falls through (best-effort: the turn just finishes).
+		if detach := turnDetachSignal(ctx); detach != nil && detach() {
+			return ErrTurnDetached
+		}
 	}
 	// Only reached when a positive maxSteps guard is configured. The work so far
 	// is already in the session, so the user can just send another message to pick

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -373,6 +374,94 @@ func (s *SubagentStore) parentSessionPath(parentSession string) (string, bool) {
 		return "", false
 	}
 	return filepath.Join(filepath.Dir(s.dir), parentSession+".jsonl"), true
+}
+
+// PrepareDetached starts a subagent-style run from an existing session-file
+// snapshot — the detach point of a foreground turn (#8170). The snapshot is
+// copied into the transcript store so the detached run owns a fully isolated
+// file; the job deletes it again on completion (DeleteTranscript).
+func (s *SubagentStore) PrepareDetached(snapshotPath string, spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("subagent transcript store is required")
+	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("detach snapshot %q: %w", snapshotPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("detach snapshot %q is not a regular file", snapshotPath)
+	}
+	ref, err := s.newRef()
+	if err != nil {
+		return nil, err
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	meta := metaFromSpec(ref, SubagentRunning, now, now, spec)
+	meta.Kind = "detach"
+	if err := copyFile(snapshotPath, s.sessionPath(ref)); err != nil {
+		release()
+		return nil, fmt.Errorf("copy detach snapshot: %w", err)
+	}
+	if err := s.saveMeta(meta); err != nil {
+		release()
+		return nil, err
+	}
+	sess, err := LoadSession(s.sessionPath(ref))
+	if err != nil {
+		release()
+		return nil, fmt.Errorf("load detach snapshot: %w", err)
+	}
+	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
+}
+
+// DeleteTranscript removes the transcript file and its metadata for a ref.
+// Used after a detached job completes: the result summary lives in the jobs
+// manager, the isolated snapshot file is no longer needed (#8170).
+func (s *SubagentStore) DeleteTranscript(ref string) error {
+	if s == nil || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return err
+	}
+	defer release()
+	if err := os.Remove(s.sessionPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Remove(s.metaPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// copyFile copies a regular file to dst, creating parent directories as
+// needed. Used for detach snapshots (#8170).
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {

--- a/internal/agent/turn_detach.go
+++ b/internal/agent/turn_detach.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrTurnDetached is returned by the run loop when the host requested the
+// remaining work of the current turn to continue as a background job (#8170).
+// Controllers distinguish it from cancellation: the turn is NOT treated as
+// interrupted; it finished normally up to the detach boundary (the current
+// tool round already committed), and the host snapshots the session and
+// hands the remainder to a job.
+var ErrTurnDetached = errors.New("turn detached to background job")
+
+type turnDetachSignalKey struct{}
+
+// WithTurnDetachSignal attaches a host-provided predicate that reports whether
+// a detach was requested. The run loop consults it at turn boundaries.
+func WithTurnDetachSignal(ctx context.Context, fn func() bool) context.Context {
+	return context.WithValue(ctx, turnDetachSignalKey{}, fn)
+}
+
+func turnDetachSignal(ctx context.Context) func() bool {
+	fn, _ := ctx.Value(turnDetachSignalKey{}).(func() bool)
+	return fn
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1383,6 +1383,49 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}
+
+	// detachRunner continues a foreground turn that the user moved to a
+	// background job (#8170). The controller hands it the session snapshot
+	// file; we copy it into the subagent transcript store and run the
+	// remainder as an isolated job with the main agent's registry and model.
+	// The job returns its reference immediately; completion surfaces through
+	// the jobs manager (notice + <background-jobs> on the next turn).
+	detachContinueInstruction := "Continue the task that was detached from the foreground turn. The session history before this message is your starting point; work autonomously until the task is done."
+	detachRunner := func(sctx context.Context, snapshotPath string, spec control.DetachSpec) (string, error) {
+		subSpec := agent.SubagentSpec{
+			Kind:          "detach",
+			Name:          spec.Label,
+			WorkspaceRoot: spec.WorkspaceRoot,
+			ParentSession: spec.ParentSession,
+			SystemPrompt:  spec.SystemPrompt,
+			Registry:      reg,
+			Model:         entry.Model,
+			Effort:        entry.Effort,
+		}
+		job := jm.StartForSession(spec.ParentSession, "detach", spec.Label, func(jobCtx context.Context, out io.Writer) (string, error) {
+			run, err := subagentStore.PrepareDetached(snapshotPath, subSpec)
+			if err != nil {
+				return "", err
+			}
+			defer run.Release()
+			runOptions := subagentSkillOptions(jobCtx, 0, entry.Price, entry.ContextWindow, 0)
+			answer, err := agent.RunSubAgentWithSession(jobCtx, execProv, reg, run.Session, detachContinueInstruction, runOptions, agent.NestedSink(jobCtx, event.Discard))
+			if err != nil {
+				_ = subagentStore.SaveFailed(run)
+				_ = subagentStore.DeleteTranscript(run.Ref)
+				return "", err
+			}
+			if err := subagentStore.SaveCompleted(run); err != nil {
+				_ = subagentStore.DeleteTranscript(run.Ref)
+				return "", err
+			}
+			// #8170: the isolated snapshot file is no longer needed once the
+			// job completes; the summary lives in the jobs manager.
+			_ = subagentStore.DeleteTranscript(run.Ref)
+			return agent.FormatSubagentRunResult(answer, run, false), nil
+		})
+		return job.ID, nil
+	}
 	skillProfile := func(sk skill.Skill) *event.Profile {
 		model, effort := subagentModelRef(cfg, sk), subagentEffortRef(cfg, sk)
 		if model == "" && effort == "" {
@@ -1734,6 +1777,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		DisableImplicitSkillInvocation: !implicitSkillInvocation,
 		SkillRunner:                    skillRunner,
 		ReadOnlySkillRunner:            readOnlySkillRunner,
+		DetachRunner:                   detachRunner,
 		SkillProfile:                   skillProfile,
 		Hooks:                          hookRunner,
 		Memory:                         mem,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -272,6 +272,12 @@ type Controller struct {
 	finishing         bool // TurnDone is still being delivered; park a replacement turn
 	finishingBoundary turnFinishingBoundary
 	canceling         bool
+	// detachRequested is set by RequestDetach while a turn runs; the run loop
+	// consumes it at the next tool-round boundary (#8170). It self-clears so a
+	// turn that finishes first simply ends normally.
+	detachRequested bool
+	// detachRunner continues a detached turn as a background job (boot layer).
+	detachRunner DetachRunner
 	// closed marks the controller as terminally torn down (close() ran). It
 	// seals turn admission: without it, a submit arriving AFTER close cleared
 	// the parked queue — but while a still-running turn's TurnDone delivery
@@ -466,6 +472,9 @@ type Options struct {
 	// metadata for the synthetic top-level run_skill event.
 	SkillRunner         skill.SubagentRunner
 	ReadOnlySkillRunner skill.SubagentRunner
+	// DetachRunner continues a turn the user moved to a background job from a
+	// session snapshot (#8170). Nil disables RequestDetach.
+	DetachRunner DetachRunner
 	SkillProfile        skill.ProfileResolver
 	Hooks               *hook.Runner
 	Memory              *memory.Set
@@ -625,6 +634,7 @@ func New(opts Options) *Controller {
 		disableImplicitSkillInvocation:    opts.DisableImplicitSkillInvocation,
 		skillRunner:                       opts.SkillRunner,
 		readOnlySkillRunner:               opts.ReadOnlySkillRunner,
+		detachRunner:                      opts.DetachRunner,
 		skillProfile:                      opts.SkillProfile,
 		hooks:                             opts.Hooks,
 		memory:                            newMemoryManager(opts.Memory),

--- a/internal/control/detach.go
+++ b/internal/control/detach.go
@@ -1,0 +1,99 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// DetachSpec describes the continuation of a turn that the user moved to a
+// background job (#8170). The snapshot file (the session transcript at the
+// detach boundary) is owned by the caller; the runner copies it into the
+// transcript store and deletes it again on completion.
+type DetachSpec struct {
+	ParentSession string
+	WorkspaceRoot string
+	SystemPrompt  string
+	Label         string
+}
+
+// DetachRunner launches a background job that continues a detached turn from
+// the given session-file snapshot and returns the job reference immediately
+// (the job runs asynchronously). Implemented by the boot layer, which owns
+// the provider/tool registry/subagent store.
+type DetachRunner func(ctx context.Context, snapshotPath string, spec DetachSpec) (string, error)
+
+// RequestDetach asks the running turn to hand its remaining work to a
+// background job at the next tool-round boundary. It is a no-op unless a
+// turn is currently running. The request self-clears: if the turn finishes
+// before reaching a boundary, nothing is detached (best-effort).
+func (c *Controller) RequestDetach() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.running {
+		return fmt.Errorf("no running turn to detach")
+	}
+	c.detachRequested = true
+	return nil
+}
+
+// detachRequestedSignal is the predicate handed to the run loop; it reads
+// under the controller mutex because the loop runs in its own goroutine.
+func (c *Controller) detachRequestedSignal() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.detachRequested
+}
+
+func (c *Controller) clearDetachRequested() {
+	c.mu.Lock()
+	c.detachRequested = false
+	c.mu.Unlock()
+}
+
+// performDetach executes the detach ritual: persist the transcript up to the
+// boundary, then hand it to the background runner. The runner must return
+// immediately (the job itself runs asynchronously).
+func (c *Controller) performDetach(ctx context.Context, startMessages int) error {
+	if c.detachRunner == nil {
+		return fmt.Errorf("turn detach is not available in this session")
+	}
+	// Persist the transcript so the snapshot is complete (the current tool
+	// round already committed in-memory).
+	if durable, err := c.snapshotActivityIfChanged(startMessages); err != nil && !durable {
+		return fmt.Errorf("detach: persist transcript: %w", err)
+	}
+	spec := DetachSpec{
+		ParentSession: c.parentSessionID(),
+		WorkspaceRoot: c.workspaceRoot,
+		SystemPrompt:  systemPromptFromHistory(c.History()),
+		Label:         "detached turn",
+	}
+	jobRef, err := c.detachRunner(ctx, c.SessionPath(), spec)
+	if err != nil {
+		return fmt.Errorf("detach: start background job: %w", err)
+	}
+	if jobRef != "" && c.sink != nil {
+		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Turn moved to background job " + jobRef})
+	}
+	return nil
+}
+
+// systemPromptFromHistory returns the first system-role message content.
+func systemPromptFromHistory(msgs []provider.Message) string {
+	for _, m := range msgs {
+		if m.Role == provider.RoleSystem {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// isTurnDetached reports whether err is the run-loop's detach sentinel.
+func isTurnDetached(err error) bool {
+	return errors.Is(err, agent.ErrTurnDetached)
+}

--- a/internal/control/detach_test.go
+++ b/internal/control/detach_test.go
@@ -1,0 +1,80 @@
+package control
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestRequestDetachRequiresRunningTurn(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	if err := c.RequestDetach(); err == nil {
+		t.Fatal("RequestDetach on idle controller should fail")
+	}
+}
+
+func TestRequestDetachSetsFlagWhileRunning(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+	if err := c.RequestDetach(); err != nil {
+		t.Fatalf("RequestDetach: %v", err)
+	}
+	if !c.detachRequestedSignal() {
+		t.Fatal("detach flag not set after RequestDetach")
+	}
+	c.clearDetachRequested()
+	if c.detachRequestedSignal() {
+		t.Fatal("detach flag not cleared by clearDetachRequested")
+	}
+}
+
+func TestPerformDetachInvokesRunnerAndEmitsNotice(t *testing.T) {
+	var gotPath string
+	var gotSpec DetachSpec
+	var noticeText string
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice && noticeText == "" {
+				noticeText = e.Text
+			}
+		}),
+		DetachRunner: func(ctx context.Context, path string, spec DetachSpec) (string, error) {
+			gotPath = path
+			gotSpec = spec
+			return "detach-1", nil
+		},
+	})
+	c.mu.Lock()
+	c.running = true
+	c.workspaceRoot = t.TempDir()
+	c.mu.Unlock()
+	c.setSessionPath(t.TempDir()+"/session.jsonl", false)
+	if err := c.performDetach(context.Background(), 0); err != nil {
+		t.Fatalf("performDetach: %v", err)
+	}
+	if gotPath == "" {
+		t.Fatal("detach runner was not invoked with a snapshot path")
+	}
+	if gotSpec.WorkspaceRoot != c.workspaceRoot {
+		t.Fatalf("spec.WorkspaceRoot = %q, want %q", gotSpec.WorkspaceRoot, c.workspaceRoot)
+	}
+	if gotSpec.ParentSession == "" {
+		t.Fatal("spec.ParentSession is empty")
+	}
+	if noticeText == "" {
+		t.Fatal("expected a notice event naming the background job")
+	}
+}
+
+func TestPerformDetachFailsWithoutRunner(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+	if err := c.performDetach(context.Background(), 0); err == nil {
+		t.Fatal("performDetach without DetachRunner should fail")
+	}
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -282,6 +282,11 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	if !turn.synthetic {
 		modelInput = c.withCapabilityRoute(ctx, input, turn.raw)
 	}
+	// #8170: surface the host's detach request to the run loop; it stops at
+	// the next tool-round boundary so the controller can snapshot and hand
+	// the remainder to a background job.
+	ctx = agent.WithTurnDetachSignal(ctx, c.detachRequestedSignal)
+	defer c.clearDetachRequested()
 	// Real user turns open a fresh Recovery Episode. Goal auto-continues and
 	// other synthetic turns inherit the current Episode so budgets accumulate
 	// only within one host-owned execution round.
@@ -291,6 +296,16 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	err = c.runner.Run(ctx, modelInput)
 	c.captureGoalRunWorkDuration(startMessages)
 	c.persistGoalDeliveryCheckpoint()
+	if isTurnDetached(err) {
+		// #8170: the turn stopped cleanly at a detach boundary. The current
+		// tool round already committed; snapshot the session and continue the
+		// remainder as a background job. The turn itself finishes normally
+		// (no strip, no failure), and queued input dispatches right after.
+		if detachErr := c.performDetach(ctx, startMessages); detachErr != nil {
+			return detachErr
+		}
+		return nil
+	}
 	if err != nil {
 		// When the user explicitly cancels, keep the real prompt and any fully
 		// paired tool work. Partial reasoning/output remains durable for display


### PR DESCRIPTION
## Summary

#8170 核心部分：**运行中的前台 turn 可在工具轮边界转为后台 job**（用户点击转后台 → 当前工具调用完成后，会话快照 + 剩余任务以 subagent 式 job 后台继续；主 turn 正常结束，排队输入立即接续执行）。

设计经 14 项评审共识（grill）定稿，要点：黑盒隔离（job 看不到主会话后续）、文件快照（job 完成后删除）、subagent 式 runner（复用主注册表/模型）、尽力而为（turn 尾声自然结束则 detach 失效）、取消即杀死。

**改动（纯 Go 核心，前端/CLI 入口为后续 PR）**：

1. **`internal/agent`**：
   - `turn_detach.go`（新）：`ErrTurnDetached` sentinel + `WithTurnDetachSignal` 上下文谓词
   - `run_loop.go`：每轮工具调用提交后检查 detach 信号 → 返回 `ErrTurnDetached`（最终响应分支不检查 → 自然结束 = 尽力而为）
   - `subagent_store.go`：`PrepareDetached(snapshotPath, spec)`（复制快照进 transcript store + 标记 `kind=detach`）+ `DeleteTranscript(ref)`（完成后清理）+ `copyFile`
2. **`internal/control`**：
   - `detach.go`（新）：`RequestDetach()`（仅 running 时置位，自清除）+ `DetachSpec`/`DetachRunner` 类型 + `performDetach`（持久化 → 调用 runner → notice）
   - `controller.go`：`detachRequested` 字段 + `Options.DetachRunner` 注入
   - `turn_orchestrator.go`：注入 detach 信号（defer 自清）+ `ErrTurnDetached` 分支 → `performDetach` → 正常结束（不 strip、不视为失败）
3. **`internal/boot`**：`detachRunner` 闭包——`PrepareDetached` + `jobs.StartForSession`（异步）+ `RunSubAgentWithSession`（主注册表/模型）+ 完成时 `DeleteTranscript`；注册进 `Options.DetachRunner`

**前缀链**：主会话链与 job 独立链物理隔离（独立文件），各自严格顺序；结果经 jobs manager（`<background-jobs>` + notice）回主会话。

English: core of #8170 — a running foreground turn can be moved to a background job at the next tool-round boundary. The controller snapshots the session file and hands the remainder to a subagent-style job (main registry/model) via the new `DetachRunner`; the turn finishes normally and queued input dispatches right after. Snapshot file is deleted on completion. Pure Go core; desktop/CLI entry points follow in a separate PR.

## Issues

Refs #8170 (part 1: core; entry points in a follow-up PR)

## Verification

- `go build ./...` (repo root) — pass
- `go test ./internal/agent/...` — pass (113s, incl. new `TestPrepareDetached*` / `TestDeleteTranscript*`)
- `go test ./internal/control/...` — pass (64s, incl. new `TestRequestDetach*` / `TestPerformDetach*`)
- `go test ./internal/boot/...` — pass

## Documentation impact

Documentation-impact: none- no config, CLI, provider, permission, or tool surface changed yet (entry points are the follow-up PR).

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (boot wiring only); explicit maintainer review requested