### PR TITLE
fix(desktop): attach the live topic runtime instead of an old catalog leaf / 点活会话时附着当前 runtime，不再打开旧副本

### DIFF
--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -45,11 +45,10 @@ func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath stri
 	if scope == "global" {
 		actualRoot = globalWorkspaceRoot()
 	}
-	// Only suppress covering-leaf continue when the live runtime is already
-	// on this path. Opening a different ordinary session of the same topic
-	// must still detach and switch (OpenGlobalTab latest-session contract).
+	// Keep a live controller on this path (including paused). Opening a
+	// different ordinary session of the same topic must still switch.
 	if continued := a.continuePathForOpen(sessionPath); continued != "" {
-		if a.sessionHasActiveRuntimeWork(sessionPath) {
+		if a.sessionHasLiveController(sessionPath) {
 			return actualRoot, sessionPath
 		}
 		sessionPath = continued
@@ -57,7 +56,7 @@ func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath stri
 	return actualRoot, sessionPath
 }
 
-func (a *App) sessionHasActiveRuntimeWork(path string) bool {
+func (a *App) sessionHasLiveController(path string) bool {
 	key := sessionRuntimeKey(path)
 	if a == nil || key == "" {
 		return false
@@ -66,7 +65,7 @@ func (a *App) sessionHasActiveRuntimeWork(path string) bool {
 	defer a.mu.RUnlock()
 	for _, tabs := range []map[string]*WorkspaceTab{a.tabs, a.detachedSessions} {
 		for _, tab := range tabs {
-			if tab != nil && sessionRuntimeKey(tab.currentSessionPath()) == key && tab.hasActiveRuntimeWork() {
+			if tab != nil && tab.Ctrl != nil && sessionRuntimeKey(tab.currentSessionPath()) == key {
 				return true
 			}
 		}
@@ -75,7 +74,7 @@ func (a *App) sessionHasActiveRuntimeWork(path string) bool {
 }
 
 func (a *App) skipCoveringLeafRebind(tab *WorkspaceTab, target string) bool {
-	if tab == nil || !tab.hasActiveRuntimeWork() {
+	if tab == nil || tab.Ctrl == nil {
 		return false
 	}
 	next := a.continuePathForOpen(tab.currentSessionPath())

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -384,7 +384,9 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 	// Ordinary list is always one logical row. Multiple normal non-recovery
 	// sessions under one topic also collapse: open/running already aggregated.
 	// History "other saved versions" is the only place physical forks appear.
-	if rep := strings.TrimSpace(topic.RepresentativePath); rep != "" {
+	if live := a.liveSessionPathForTopic(topic.Scope, topic.WorkspaceRoot, topic.TopicID); live != "" {
+		node.SessionPath = live
+	} else if rep := strings.TrimSpace(topic.RepresentativePath); rep != "" {
 		node.SessionPath = rep
 	} else if path := sessioncatalog.CanonicalSessionPathForTopic(visible, ""); path != "" {
 		node.SessionPath = path

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2325,7 +2325,7 @@ func (a *App) openProjectTab(workspaceRoot, topicID string) (TabMeta, error) {
 	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
-	return a.openTopicTab("project", workspaceRoot, topicID, sessionPath)
+	return a.openTopicTabPreferLive("project", workspaceRoot, topicID, sessionPath)
 }
 
 func (a *App) openTopicTab(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
@@ -2342,7 +2342,7 @@ func (a *App) openProjectTabInactive(workspaceRoot, topicID string) (TabMeta, er
 	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
-	return a.openTopicTabWithActivation("project", workspaceRoot, topicID, sessionPath, false)
+	return a.openTopicTabPreferLiveInactive("project", workspaceRoot, topicID, sessionPath)
 }
 
 func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
@@ -2352,7 +2352,7 @@ func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
 	}
 
 	sessionPath, _ := a.findTopicSessionForTarget("global", "", topicID)
-	return a.openTopicTabWithActivation("global", "", topicID, sessionPath, false)
+	return a.openTopicTabPreferLiveInactive("global", "", topicID, sessionPath)
 }
 
 func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
@@ -2461,7 +2461,7 @@ func (a *App) openGlobalTab(topicID string) (TabMeta, error) {
 	}
 
 	sessionPath, _ := a.findTopicSessionForTarget("global", "", topicID)
-	return a.openTopicTab("global", "", topicID, sessionPath)
+	return a.openTopicTabPreferLive("global", "", topicID, sessionPath)
 }
 
 // OpenTopicSession opens a concrete saved session from the sidebar. Unlike
@@ -2489,7 +2489,7 @@ func (a *App) openTopicSession(scope, workspaceRoot, topicID, sessionPath string
 	if err != nil {
 		return TabMeta{}, err
 	}
-	return a.openTopicTab(scope, workspaceRoot, topicID, validPath)
+	return a.openTopicTabPreferLive(scope, workspaceRoot, topicID, validPath)
 }
 
 // ActivateTopic opens a topic into the single visible conversation surface used

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2325,11 +2325,11 @@ func (a *App) openProjectTab(workspaceRoot, topicID string) (TabMeta, error) {
 	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
-	return a.openTopicTabPreferLive("project", workspaceRoot, topicID, sessionPath)
+	return a.openTopicTabWithActivation("project", workspaceRoot, topicID, sessionPath, true)
 }
 
 func (a *App) openTopicTab(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
-	return a.openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath, true)
+	return a.openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath, true)
 }
 
 func (a *App) openProjectTabInactive(workspaceRoot, topicID string) (TabMeta, error) {
@@ -2342,7 +2342,7 @@ func (a *App) openProjectTabInactive(workspaceRoot, topicID string) (TabMeta, er
 	a.registerProjectRoot(workspaceRoot)
 
 	sessionPath, _ := a.findTopicSessionForTarget("project", workspaceRoot, topicID)
-	return a.openTopicTabPreferLiveInactive("project", workspaceRoot, topicID, sessionPath)
+	return a.openTopicTabWithActivation("project", workspaceRoot, topicID, sessionPath, false)
 }
 
 func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
@@ -2352,7 +2352,7 @@ func (a *App) openGlobalTabInactive(topicID string) (TabMeta, error) {
 	}
 
 	sessionPath, _ := a.findTopicSessionForTarget("global", "", topicID)
-	return a.openTopicTabPreferLiveInactive("global", "", topicID, sessionPath)
+	return a.openTopicTabWithActivation("global", "", topicID, sessionPath, false)
 }
 
 func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
@@ -2461,7 +2461,7 @@ func (a *App) openGlobalTab(topicID string) (TabMeta, error) {
 	}
 
 	sessionPath, _ := a.findTopicSessionForTarget("global", "", topicID)
-	return a.openTopicTabPreferLive("global", "", topicID, sessionPath)
+	return a.openTopicTabWithActivation("global", "", topicID, sessionPath, true)
 }
 
 // OpenTopicSession opens a concrete saved session from the sidebar. Unlike
@@ -2489,7 +2489,7 @@ func (a *App) openTopicSession(scope, workspaceRoot, topicID, sessionPath string
 	if err != nil {
 		return TabMeta{}, err
 	}
-	return a.openTopicTabPreferLive(scope, workspaceRoot, topicID, validPath)
+	return a.openTopicTab(scope, workspaceRoot, topicID, validPath)
 }
 
 // ActivateTopic opens a topic into the single visible conversation surface used

--- a/desktop/topic_activation.go
+++ b/desktop/topic_activation.go
@@ -230,6 +230,11 @@ func (a *App) runTopicActivationCompletion(gen uint64, requestID, tabID string) 
 		<-buildDone
 	}
 
+	// A reused/reattached runtime is already usable. Publish ready before
+	// prune: keepOnlyVisibleTab takes runtimeRebuildMu, which an in-flight
+	// MCP rebuild on the previous tab can hold for a long time.
+	emittedReady := a.emitTopicActivationReadyIfCurrent(gen, requestID, tabID)
+
 	// The generation check and the prune serialize against new activations
 	// through singleSurfaceMu: either this completion runs entirely before the
 	// next activation's synchronous phase (its tabs are not there to prune),
@@ -249,14 +254,22 @@ func (a *App) runTopicActivationCompletion(gen uint64, requestID, tabID string) 
 
 	if _, err := a.keepOnlyVisibleTab(tabID); err != nil {
 		a.finishTopicActivation(gen, requestID)
-		a.emitTopicActivation(TopicActivationEvent{
-			RequestID: requestID,
-			TabID:     tabID,
-			Phase:     topicActivationPhaseFailed,
-			// keepOnlyVisibleTab errors can wrap snapshot/path details; the
-			// event stays generic, the slog entry keeps the specifics.
-			Error: "failed to switch the visible session",
-		})
+		if !emittedReady {
+			a.emitTopicActivation(TopicActivationEvent{
+				RequestID: requestID,
+				TabID:     tabID,
+				Phase:     topicActivationPhaseFailed,
+				// keepOnlyVisibleTab errors can wrap snapshot/path details; the
+				// event stays generic, the slog entry keeps the specifics.
+				Error: "failed to switch the visible session",
+			})
+		}
+		return
+	}
+
+	if emittedReady {
+		a.finishTopicActivation(gen, requestID)
+		a.scheduleTabMetaExtrasRefresh(tabID)
 		return
 	}
 
@@ -289,6 +302,21 @@ func (a *App) runTopicActivationCompletion(gen uint64, requestID, tabID string) 
 			Error:     sanitizedTopicActivationError(startupErr, leaseHeld),
 		})
 	}
+}
+
+func (a *App) emitTopicActivationReadyIfCurrent(gen uint64, requestID, tabID string) bool {
+	a.mu.RLock()
+	tab := a.tabs[tabID]
+	ok := a.activationGen == gen &&
+		a.latestActivationRequestID == requestID &&
+		a.pendingActivationTabID == tabID &&
+		tab != nil && tab.Ready && tab.Ctrl != nil
+	a.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	a.emitTopicActivation(TopicActivationEvent{RequestID: requestID, TabID: tabID, Phase: topicActivationPhaseReady})
+	return true
 }
 
 // sanitizedTopicActivationError keeps local paths and lease-holder writer IDs

--- a/desktop/topic_activation_test.go
+++ b/desktop/topic_activation_test.go
@@ -311,9 +311,13 @@ type activationStubController struct {
 	control.SessionAPI
 	sessionPath string
 	closed      atomic.Bool
+	status      *control.RuntimeStatus
 }
 
 func (c *activationStubController) RuntimeStatus() control.RuntimeStatus {
+	if c.status != nil {
+		return *c.status
+	}
 	return control.RuntimeStatus{Running: true}
 }
 func (c *activationStubController) SessionPath() string      { return c.sessionPath }

--- a/desktop/topic_live_runtime.go
+++ b/desktop/topic_live_runtime.go
@@ -1,9 +1,16 @@
 package main
 
+import (
+	"strings"
+
+	"reasonix/internal/sessioncatalog"
+)
+
 // preferLiveSessionPath chooses which session a topic row should open.
-// A live runtime wins over the catalog representative. An explicit
-// non-representative path (History inspect) is left alone.
-func preferLiveSessionPath(requested, live, representative string) string {
+// A live runtime wins over ordinary catalog rows (RepresentativePath,
+// canonical leaf, and the covering parent that continue would follow).
+// An explicit non-ordinary path (History inspect) is left alone.
+func preferLiveSessionPath(requested, live string, ordinary ...string) string {
 	liveKey := sessionRuntimeKey(live)
 	if liveKey == "" {
 		return requested
@@ -15,9 +22,13 @@ func preferLiveSessionPath(requested, live, representative string) string {
 		}
 		return requested
 	}
-	repKey := sessionRuntimeKey(representative)
-	if repKey == "" || reqKey == repKey {
+	if len(ordinary) == 0 {
 		return live
+	}
+	for _, path := range ordinary {
+		if sessionRuntimeKey(path) == reqKey {
+			return live
+		}
 	}
 	return requested
 }
@@ -66,16 +77,45 @@ func (a *App) liveRuntimeForTopicLocked(scope, workspaceRoot, topicID string) *W
 
 func (a *App) resolveOpenSessionPath(scope, workspaceRoot, topicID, requested string) string {
 	live := a.liveSessionPathForTopic(scope, workspaceRoot, topicID)
-	representative := a.catalogSessionPathForTopic(scope, workspaceRoot, topicID)
-	return preferLiveSessionPath(requested, live, representative)
+	return preferLiveSessionPath(requested, live, a.ordinaryOpenSessionPaths(scope, workspaceRoot, topicID, requested)...)
 }
 
-func (a *App) openTopicTabPreferLive(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
-	return a.openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath, true)
+func (a *App) catalogTopicRecord(scope, workspaceRoot, topicID string) (sessioncatalog.TopicRecord, bool) {
+	if a == nil || strings.TrimSpace(topicID) == "" {
+		return sessioncatalog.TopicRecord{}, false
+	}
+	catalog := a.sessionCatalog.Load()
+	if catalog == nil {
+		return sessioncatalog.TopicRecord{}, false
+	}
+	topic, ok, err := catalog.GetTopic(a.bootContext(), sessioncatalog.TopicKey{
+		Scope: scope, WorkspaceRoot: workspaceRoot, TopicID: topicID,
+	})
+	if err != nil || !ok {
+		return sessioncatalog.TopicRecord{}, false
+	}
+	return topic, true
 }
 
-func (a *App) openTopicTabPreferLiveInactive(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
-	return a.openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath, false)
+// ordinaryOpenSessionPaths are the catalog identities of the sidebar row:
+// RepresentativePath, the canonical covering leaf, and the parent that
+// continue would follow. History inspect paths are not in this set.
+func (a *App) ordinaryOpenSessionPaths(scope, workspaceRoot, topicID, requested string) []string {
+	var ordinary []string
+	if topic, ok := a.catalogTopicRecord(scope, workspaceRoot, topicID); ok {
+		if rep := strings.TrimSpace(topic.RepresentativePath); rep != "" {
+			ordinary = append(ordinary, rep)
+		}
+		if canonical := sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, ""); canonical != "" {
+			ordinary = append(ordinary, canonical)
+		}
+	} else if path := a.catalogSessionPathForTopic(scope, workspaceRoot, topicID); path != "" {
+		ordinary = append(ordinary, path)
+	}
+	if continued := a.continuePathForOpen(requested); continued != "" {
+		ordinary = append(ordinary, requested, continued)
+	}
+	return ordinary
 }
 
 func (a *App) openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {

--- a/desktop/topic_live_runtime.go
+++ b/desktop/topic_live_runtime.go
@@ -1,0 +1,112 @@
+package main
+
+// preferLiveSessionPath chooses which session a topic row should open.
+// A live runtime wins over the catalog representative. An explicit
+// non-representative path (History inspect) is left alone.
+func preferLiveSessionPath(requested, live, representative string) string {
+	liveKey := sessionRuntimeKey(live)
+	if liveKey == "" {
+		return requested
+	}
+	reqKey := sessionRuntimeKey(requested)
+	if reqKey == "" || reqKey == liveKey {
+		if reqKey == "" {
+			return live
+		}
+		return requested
+	}
+	repKey := sessionRuntimeKey(representative)
+	if repKey == "" || reqKey == repKey {
+		return live
+	}
+	return requested
+}
+
+func (a *App) liveSessionPathForTopic(scope, workspaceRoot, topicID string) string {
+	if a == nil {
+		return ""
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if tab := a.liveRuntimeForTopicLocked(scope, workspaceRoot, topicID); tab != nil {
+		return tab.currentSessionPath()
+	}
+	return ""
+}
+
+func (a *App) liveRuntimeForTopicLocked(scope, workspaceRoot, topicID string) *WorkspaceTab {
+	var best *WorkspaceTab
+	visit := func(tab *WorkspaceTab) {
+		if tab == nil || !tabMatchesTopicTarget(tab, scope, workspaceRoot, topicID) {
+			return
+		}
+		if tab.currentSessionPath() == "" {
+			return
+		}
+		if best == nil {
+			best = tab
+			return
+		}
+		if best.Ctrl == nil && tab.Ctrl != nil {
+			best = tab
+			return
+		}
+		if normalizeTopicStatus(best.ActivityStatus) == "" && normalizeTopicStatus(tab.ActivityStatus) != "" {
+			best = tab
+		}
+	}
+	for _, tab := range a.tabs {
+		visit(tab)
+	}
+	for _, tab := range a.detachedSessions {
+		visit(tab)
+	}
+	return best
+}
+
+func (a *App) resolveOpenSessionPath(scope, workspaceRoot, topicID, requested string) string {
+	live := a.liveSessionPathForTopic(scope, workspaceRoot, topicID)
+	representative := a.catalogSessionPathForTopic(scope, workspaceRoot, topicID)
+	return preferLiveSessionPath(requested, live, representative)
+}
+
+func (a *App) openTopicTabPreferLive(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
+	return a.openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath, true)
+}
+
+func (a *App) openTopicTabPreferLiveInactive(scope, workspaceRoot, topicID, sessionPath string) (TabMeta, error) {
+	return a.openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath, false)
+}
+
+func (a *App) openTopicTabPreferLiveActivation(scope, workspaceRoot, topicID, sessionPath string, activate bool) (TabMeta, error) {
+	sessionPath = a.resolveOpenSessionPath(scope, workspaceRoot, topicID, sessionPath)
+	a.mu.Lock()
+	if promoted := a.promoteDetachedRuntimeLocked(sessionPath, activate); promoted != nil {
+		meta := a.tabMeta(promoted, promoted.ID == a.activeTabID)
+		a.saveTabsLocked()
+		a.mu.Unlock()
+		return enrichTabMeta(meta), nil
+	}
+	a.mu.Unlock()
+	return a.openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionPath, activate)
+}
+
+func (a *App) promoteDetachedRuntimeLocked(sessionPath string, activate bool) *WorkspaceTab {
+	key := sessionRuntimeKey(sessionPath)
+	if key == "" {
+		return nil
+	}
+	tab := a.detachedSessions[key]
+	if tab == nil || tab.Ctrl == nil {
+		return nil
+	}
+	delete(a.detachedSessions, key)
+	if a.tabs[tab.ID] == nil {
+		a.tabs[tab.ID] = tab
+		a.tabOrder = append(a.tabOrder, tab.ID)
+	}
+	if activate {
+		a.activeTabID = tab.ID
+	}
+	return tab
+}

--- a/desktop/topic_live_runtime_test.go
+++ b/desktop/topic_live_runtime_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestStartTopicActivationPrefersLiveRuntimeOverRepresentative(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	sessionDir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	oldPath := writeTopicSessionWithPrompt(t, sessionDir, "old.jsonl", "topic-b", "Topic B", projectRoot, "yesterday unsigned todos", time.Now().Add(-24*time.Hour))
+	livePath := writeTopicSessionWithPrompt(t, sessionDir, "live.jsonl", "topic-b", "Topic B", projectRoot, "today live turn", time.Now())
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	events := newActivationEventRecorder(app)
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	stub := &activationStubController{sessionPath: livePath}
+	live := &WorkspaceTab{
+		ID:             "tab-live",
+		Scope:          "project",
+		WorkspaceRoot:  projectRoot,
+		TopicID:        "topic-b",
+		TopicTitle:     "Topic B",
+		SessionPath:    livePath,
+		Ctrl:           stub,
+		Label:          "stub-model",
+		Ready:          true,
+		ActivityStatus: topicStatusPaused,
+		disabledMCP:    map[string]ServerView{},
+	}
+	live.sink = &tabEventSink{tabID: live.ID, app: app}
+	installNoopRuntimeEvents(app, live.sink)
+	if err := live.ensureSessionLease(livePath); err != nil {
+		t.Fatalf("ensureSessionLease live: %v", err)
+	}
+	app.detachedSessions[sessionRuntimeKey(livePath)] = live
+
+	ticket, err := app.StartTopicActivation(TopicActivationRequest{
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       "topic-b",
+		SessionPath:   oldPath,
+		RequestID:     "req-live",
+	})
+	if err != nil {
+		t.Fatalf("StartTopicActivation: %v", err)
+	}
+	events.waitFor(t, activationEventFor("req-live", "ready"))
+
+	app.mu.RLock()
+	tab := app.tabs[ticket.TabID]
+	app.mu.RUnlock()
+	if tab == nil {
+		t.Fatal("activated tab missing")
+	}
+	if tab.Ctrl != stub {
+		t.Fatal("clicking the live topic row opened the catalog representative instead of attaching the live controller")
+	}
+	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(livePath) {
+		t.Fatalf("session path = %q, want live %q", tab.currentSessionPath(), livePath)
+	}
+	if stub.closed.Load() {
+		t.Fatal("live controller was closed while attaching")
+	}
+	if ticket.Meta.SessionPath != "" && sessionRuntimeKey(ticket.Meta.SessionPath) != sessionRuntimeKey(livePath) {
+		t.Fatalf("ticket session path = %q, want live %q", ticket.Meta.SessionPath, livePath)
+	}
+}
+
+func TestStartTopicActivationReadyDoesNotWaitForRebuildMutex(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	sessionDir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	pathA := writeTopicSession(t, sessionDir, "a.jsonl", "topic-a", "Topic A", projectRoot)
+	oldB := writeTopicSessionWithPrompt(t, sessionDir, "b-old.jsonl", "topic-b", "Topic B", projectRoot, "old b", time.Now().Add(-time.Hour))
+	liveB := writeTopicSessionWithPrompt(t, sessionDir, "b-live.jsonl", "topic-b", "Topic B", projectRoot, "live b", time.Now())
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	events := newActivationEventRecorder(app)
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	stubA := &activationStubController{sessionPath: pathA}
+	tabA := &WorkspaceTab{
+		ID:            "tab-a",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       "topic-a",
+		TopicTitle:    "Topic A",
+		SessionPath:   pathA,
+		Ctrl:          stubA,
+		Label:         "stub-a",
+		Ready:         true,
+		disabledMCP:   map[string]ServerView{},
+	}
+	tabA.sink = &tabEventSink{tabID: tabA.ID, app: app}
+	installNoopRuntimeEvents(app, tabA.sink)
+	if err := tabA.ensureSessionLease(pathA); err != nil {
+		t.Fatalf("ensureSessionLease A: %v", err)
+	}
+	app.tabs[tabA.ID] = tabA
+	app.tabOrder = []string{tabA.ID}
+	app.activeTabID = tabA.ID
+
+	stubB := &activationStubController{sessionPath: liveB}
+	live := &WorkspaceTab{
+		ID:            "tab-b",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       "topic-b",
+		TopicTitle:    "Topic B",
+		SessionPath:   liveB,
+		Ctrl:          stubB,
+		Label:         "stub-b",
+		Ready:         true,
+		disabledMCP:   map[string]ServerView{},
+	}
+	live.sink = &tabEventSink{tabID: live.ID, app: app}
+	installNoopRuntimeEvents(app, live.sink)
+	if err := live.ensureSessionLease(liveB); err != nil {
+		t.Fatalf("ensureSessionLease B: %v", err)
+	}
+	app.detachedSessions[sessionRuntimeKey(liveB)] = live
+
+	app.runtimeRebuildMu.Lock()
+	defer app.runtimeRebuildMu.Unlock()
+
+	started := time.Now()
+	ticket, err := app.StartTopicActivation(TopicActivationRequest{
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       "topic-b",
+		SessionPath:   oldB,
+		RequestID:     "req-rebuild",
+	})
+	if err != nil {
+		t.Fatalf("StartTopicActivation: %v", err)
+	}
+	if time.Since(started) > 300*time.Millisecond {
+		t.Fatalf("StartTopicActivation blocked %s while MCP rebuild held the mutex", time.Since(started))
+	}
+	deadline := time.After(400 * time.Millisecond)
+	for {
+		select {
+		case ev := <-events.ch:
+			if ev.RequestID == "req-rebuild" && ev.Phase == "ready" {
+				if sessionRuntimeKey(ticket.Meta.SessionPath) != sessionRuntimeKey(liveB) {
+					t.Fatalf("ticket path = %q, want live %q", ticket.Meta.SessionPath, liveB)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("ready waited for keepOnlyVisibleTab to acquire the rebuild mutex")
+		}
+	}
+}
+
+func TestPreferLiveSessionPathKeepsExplicitNonRepresentativeInspect(t *testing.T) {
+	live := "/sessions/live.jsonl"
+	rep := "/sessions/rep.jsonl"
+	inspect := "/sessions/inspect.jsonl"
+	if got := preferLiveSessionPath(inspect, live, rep); sessionRuntimeKey(got) != sessionRuntimeKey(inspect) {
+		t.Fatalf("inspect path = %q, want %q", got, inspect)
+	}
+	if got := preferLiveSessionPath(rep, live, rep); sessionRuntimeKey(got) != sessionRuntimeKey(live) {
+		t.Fatalf("representative path = %q, want live %q", got, live)
+	}
+	if got := preferLiveSessionPath("", live, rep); sessionRuntimeKey(got) != sessionRuntimeKey(live) {
+		t.Fatalf("empty path = %q, want live %q", got, live)
+	}
+	if got := preferLiveSessionPath(rep, "", rep); sessionRuntimeKey(got) != sessionRuntimeKey(rep) {
+		t.Fatalf("no live runtime = %q, want representative", got)
+	}
+}

--- a/desktop/topic_live_runtime_test.go
+++ b/desktop/topic_live_runtime_test.go
@@ -3,8 +3,14 @@ package main
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+	"reasonix/internal/sessioncatalog"
 )
 
 func TestStartTopicActivationPrefersLiveRuntimeOverRepresentative(t *testing.T) {
@@ -183,5 +189,153 @@ func TestPreferLiveSessionPathKeepsExplicitNonRepresentativeInspect(t *testing.T
 	}
 	if got := preferLiveSessionPath(rep, "", rep); sessionRuntimeKey(got) != sessionRuntimeKey(rep) {
 		t.Fatalf("no live runtime = %q, want representative", got)
+	}
+}
+
+func TestPreferLiveSessionPathTreatsRepresentativeAndCanonicalAsOrdinary(t *testing.T) {
+	live := "/sessions/live.jsonl"
+	parent := "/sessions/parent.jsonl"
+	leaf := "/sessions/leaf.jsonl"
+	inspect := "/sessions/inspect.jsonl"
+	if got := preferLiveSessionPath(parent, live, parent, leaf); sessionRuntimeKey(got) != sessionRuntimeKey(live) {
+		t.Fatalf("covering parent = %q, want live %q", got, live)
+	}
+	if got := preferLiveSessionPath(leaf, live, parent, leaf); sessionRuntimeKey(got) != sessionRuntimeKey(live) {
+		t.Fatalf("canonical leaf = %q, want live %q", got, live)
+	}
+	if got := preferLiveSessionPath(inspect, live, parent, leaf); sessionRuntimeKey(got) != sessionRuntimeKey(inspect) {
+		t.Fatalf("history inspect = %q, want %q", got, inspect)
+	}
+}
+
+func installCoveringLeafTopicCatalog(t *testing.T, app *App) (parent, leaf, live string) {
+	t.Helper()
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := provider.Message{Role: provider.RoleUser, Content: "question"}
+	a := provider.Message{Role: provider.RoleAssistant, Content: "answer"}
+	save := func(path, topic string, messages ...provider.Message) {
+		t.Helper()
+		session := agent.NewSession("sys")
+		for _, message := range messages {
+			session.Add(message)
+		}
+		if err := session.Save(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := agent.SaveBranchMetaPreserveUpdated(path, agent.BranchMeta{
+			ID: agent.BranchID(path), Scope: "global", TopicID: topic, TopicTitle: "Upgraded",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	parent = filepath.Join(dir, "root.jsonl")
+	leaf = filepath.Join(dir, "leaf.jsonl")
+	live = filepath.Join(dir, "live.jsonl")
+	save(parent, "conversation", q, a)
+	save(leaf, "legacy-leaf-topic", q, a,
+		provider.Message{Role: provider.RoleUser, Content: "next"},
+		provider.Message{Role: provider.RoleAssistant, Content: "done"})
+	if err := agent.SaveBranchMetaPreserveUpdated(leaf, agent.BranchMeta{
+		ID: "leaf", Scope: "global", TopicID: "legacy-leaf-topic",
+		Recovered: true, ParentID: "root", RecoveryDepth: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	save(live, "conversation",
+		provider.Message{Role: provider.RoleUser, Content: "today live turn"},
+		provider.Message{Role: provider.RoleAssistant, Content: "paused here"})
+	installSessionCatalogForTest(t, app, dir, "global", "")
+	return parent, leaf, live
+}
+
+func TestResolveOpenTopicSessionPathKeepsPausedLiveOnCoveringParent(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	parent, leaf, _ := installCoveringLeafTopicCatalog(t, app)
+	paused := &WorkspaceTab{
+		ID:             "paused",
+		Scope:          "global",
+		TopicID:        "conversation",
+		SessionPath:    parent,
+		Ctrl:           &retargetRuntimeController{status: control.RuntimeStatus{}, path: parent},
+		ActivityStatus: topicStatusPaused,
+	}
+	app.detachedSessions[sessionRuntimeKey(parent)] = paused
+
+	_, resolved := app.resolveOpenTopicSessionPath("global", "", parent)
+	if resolved != parent {
+		t.Fatalf("resolve paused parent = %q, want keep live parent %q (not covering leaf %q)", resolved, parent, leaf)
+	}
+}
+
+func TestStartTopicActivationAttachesPausedLiveWhenOpeningCoveringParent(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	events := newActivationEventRecorder(app)
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+
+	parent, leaf, livePath := installCoveringLeafTopicCatalog(t, app)
+	topic, ok := app.catalogTopicRecord("global", "", "conversation")
+	if !ok {
+		t.Fatal("catalog topic missing")
+	}
+	canonical := sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, "")
+	if sessionRuntimeKey(canonical) != sessionRuntimeKey(leaf) {
+		t.Fatalf("canonical = %q, want covering leaf %q", canonical, leaf)
+	}
+	if topic.RepresentativePath != "" && sessionRuntimeKey(topic.RepresentativePath) != sessionRuntimeKey(parent) && sessionRuntimeKey(topic.RepresentativePath) != sessionRuntimeKey(leaf) {
+		t.Fatalf("representative = %q, want parent %q or covering leaf %q", topic.RepresentativePath, parent, leaf)
+	}
+
+	stub := &activationStubController{sessionPath: livePath, status: &control.RuntimeStatus{}}
+	live := &WorkspaceTab{
+		ID:             "tab-live",
+		Scope:          "global",
+		TopicID:        "conversation",
+		TopicTitle:     "Upgraded",
+		SessionPath:    livePath,
+		Ctrl:           stub,
+		Label:          "stub-model",
+		Ready:          true,
+		ActivityStatus: topicStatusPaused,
+		disabledMCP:    map[string]ServerView{},
+	}
+	live.sink = &tabEventSink{tabID: live.ID, app: app}
+	installNoopRuntimeEvents(app, live.sink)
+	if err := live.ensureSessionLease(livePath); err != nil {
+		t.Fatalf("ensureSessionLease live: %v", err)
+	}
+	app.detachedSessions[sessionRuntimeKey(livePath)] = live
+
+	ticket, err := app.StartTopicActivation(TopicActivationRequest{
+		Scope:       "global",
+		TopicID:     "conversation",
+		SessionPath: parent,
+		RequestID:   "req-covering-parent",
+	})
+	if err != nil {
+		t.Fatalf("StartTopicActivation: %v", err)
+	}
+	events.waitFor(t, activationEventFor("req-covering-parent", "ready"))
+
+	app.mu.RLock()
+	tab := app.tabs[ticket.TabID]
+	app.mu.RUnlock()
+	if tab == nil {
+		t.Fatal("activated tab missing")
+	}
+	if tab.Ctrl != stub {
+		t.Fatal("clicking the covering parent opened the catalog leaf instead of attaching the paused live controller")
+	}
+	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(livePath) {
+		t.Fatalf("session path = %q, want live %q (parent %q leaf %q)", tab.currentSessionPath(), livePath, parent, leaf)
+	}
+	if ticket.Meta.SessionPath != "" && sessionRuntimeKey(ticket.Meta.SessionPath) != sessionRuntimeKey(livePath) {
+		t.Fatalf("ticket session path = %q, want live %q", ticket.Meta.SessionPath, livePath)
 	}
 }


### PR DESCRIPTION
## Summary

Clicking a sidebar topic that is already running or paused now attaches that live runtime instead of opening the catalog representative.

- Ordinary-tree `sessionPath` prefers the live tab or detached controller.
- Opening the representative (or an empty path) retargets to the live session; History inspect of a non-representative file is unchanged.
- A detached live runtime is promoted into the visible tab. No new controller is built.
- Topic-activation `ready` is emitted before `keepOnlyVisibleTab` when the runtime is already usable, so MCP rebuild on the previous tab cannot hide the correct transcript.

Related but independent of #8728 (catalog latest leaf) and #8730 (delivery-check badge copy).

## Issues

No linked issue. User report: switching from a session that was editing MCP to another project's paused session first showed yesterday's unsigned todos, then recovered after a long wait.

## Verification

- `cd desktop && go test -count=1 -run 'TestStartTopicActivationPrefersLiveRuntimeOverRepresentative|TestStartTopicActivationReadyDoesNotWaitForRebuildMutex|TestPreferLiveSessionPath|TestStartTopicActivationFailureDetachesPreviousAndReattaches|TestStartTopicActivation|TestActivateTopic|TestBuildTabControllerReattach'`
- `make lint`

## Documentation impact

Documentation-impact: none - existing docs do not specify which physical session file a live sidebar row opens.

## Cache impact

Cache-impact: none - desktop tab/session routing only; provider-visible prefix, tools, and serialization are unchanged
Cache-guard: not applicable; no cache-sensitive paths in this diff
System-prompt-review: N/A
