### PR TITLE
feat: entry points for turn detach - desktop button, CLI /detach

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1251,6 +1251,20 @@ func (a *App) SteerForTab(tabID, text string) error {
 	return nil
 }
 
+// DetachRunningTurn moves the running turn of the given tab to a background
+// job at the next tool-round boundary (#8170). The tab stays open; queued
+// user input dispatches right after the turn finishes.
+func (a *App) DetachRunningTurn(tabID string) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab == nil || ctrl == nil {
+		return a.workspaceNotReadyErr(tab)
+	}
+	if a.tabIsReadOnly(tab) {
+		return readOnlyChannelErr()
+	}
+	return ctrl.RequestDetach()
+}
+
 func (a *App) tabAndCtrlByID(tabID string) (*WorkspaceTab, control.SessionAPI) {
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowRight, ArrowUp, AtSign, Check, ChevronsUpDown, CornerDownRight, Equal, Eye, FilePlus2, FileText, Folder, Gauge, Hash, List, MessageSquare, PackageCheck, Plus, Search, Shield, ShieldAlert, ShieldCheck, Square, Target, Trash2, X } from "lucide-react";
+import { ArrowRight, ArrowUp, AtSign, Check, ChevronsUpDown, CornerDownRight, Equal, Eye, FilePlus2, FileText, Folder, Gauge, Hash, List, MessageSquare, PackageCheck, Plus, Search, SendToBack, Shield, ShieldAlert, ShieldCheck, Square, Target, Trash2, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
@@ -2742,6 +2742,16 @@ export function Composer({
 
   // handleCancel stops the in-flight turn; if it was cancelled before the server
   // replied, the just-sent text is handed back so we drop it back into the input.
+  const handleDetach = useCallback(async () => {
+    if (!tabId) return;
+    try {
+      await app.DetachRunningTurn(tabId);
+    } catch (err) {
+      console.warn("DetachRunningTurn failed", err);
+      showToast?.(err instanceof Error ? err.message : String(err), "error");
+    }
+  }, [tabId, showToast]);
+
   const handleCancel = async () => {
     const targetDraftKey = activeDraftKeyRef.current;
     if (cancelSettlingDraftsRef.current.has(targetDraftKey)) return;
@@ -4568,6 +4578,18 @@ export function Composer({
                   aria-label={t("composer.stop")}
                 >
                   <Square size={12} fill="currentColor" />
+                </button>
+              </Tooltip>
+            )}
+            {running && !readOnly && (
+              <Tooltip label={t("composer.detach")}>
+                <button
+                  className="composer__btn composer__btn--detach"
+                  type="button"
+                  onClick={() => void handleDetach()}
+                  aria-label={t("composer.detach")}
+                >
+                  <SendToBack size={14} />
                 </button>
               </Tooltip>
             )}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -637,6 +637,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   TrashTopic(topicID: string): Promise<void>;
   SetTopicPinned(topicID: string, pinned: boolean): Promise<void>;
   ContextPanel(tabID: string): Promise<ContextPanelInfo>;
+  DetachRunningTurn(tabID: string): Promise<void>;
   // New native-feel bindings (added with the desktop native-feel plan).
   ConfirmAction(req: NativeConfirmRequest): Promise<boolean>;
   SaveWindowState(state: DesktopWindowState): Promise<void>;
@@ -5361,6 +5362,9 @@ function makeMockApp(): AppBindings {
     },
     async TrashTopic(topicID: string) {
       deleteMockTopic(topicID);
+    },
+    async DetachRunningTurn(_tabID: string) {
+      // no-op in the browser mock
     },
     async SetTopicPinned(topicID: string, pinned: boolean) {
       setMockTopicPinned(topicID, pinned);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -794,6 +794,7 @@ export const en = {
   "composer.shellMode": "Shell mode: prefix input with !",
   "composer.shellModeOn": "Shell mode on: click to remove !",
   "composer.stop": "Stop (Esc)",
+  "composer.detach": "Move to background",
   "composer.stopShort": "Stop",
   "composer.pastedLabel": "[Pasted text #{id} · {lines} lines]",
   "composer.pastedShowPreview": "Preview pasted text",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -599,6 +599,7 @@ export const zhTW: Record<DictKey, string> = {
   "composer.guidanceEmptyPreview": "沒有預覽正文",
   "composer.guidanceMore": "更多引導選項",
   "composer.stop": "停止（Esc）",
+  "composer.detach": "轉為背景",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已貼上文字 #{id} · {lines} 行]",
   "composer.pastedShowPreview": "預覽貼上文字",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -795,6 +795,7 @@ export const zh: Record<DictKey, string> = {
   "composer.shellMode": "Shell 模式：给输入前加 !",
   "composer.shellModeOn": "Shell 模式已开：点击移除 !",
   "composer.stop": "停止（Esc）",
+  "composer.detach": "转后台",
   "composer.stopShort": "停止",
   "composer.pastedLabel": "[已粘贴文本 #{id} · {lines} 行]",
   "composer.pastedShowPreview": "预览粘贴文本",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7127,6 +7127,12 @@ body > .mermaid-diagram--fullscreen {
   background: color-mix(in srgb, var(--err) 14%, var(--bg-elev-2));
   color: var(--err);
 }
+.composer__btn--detach {
+  color: var(--color-text-muted, inherit);
+}
+.composer__btn--detach:hover {
+  color: var(--color-accent, inherit);
+}
 .composer__btn--stop:hover,
 .composer__btn--stop:focus-visible {
   color: var(--fg);

--- a/internal/agent/detach_store_test.go
+++ b/internal/agent/detach_store_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestPrepareDetachedCopiesSnapshot(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	dir := t.TempDir()
+	snapshot := filepath.Join(dir, "main-session.jsonl")
+
+	// Build a valid transcript file to use as the detach snapshot source.
+	seed := NewSubagentStore(filepath.Join(t.TempDir(), "sub"))
+	spec := testSubagentSpec(t, "review")
+	seedRun, err := seed.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("seed PrepareFresh: %v", err)
+	}
+	seedRun.Session.Add(provider.Message{Role: provider.RoleUser, Content: "detach me"})
+	seedRun.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "tool result committed"})
+	if err := seed.SaveCompleted(seedRun); err != nil {
+		t.Fatalf("seed SaveCompleted: %v", err)
+	}
+	seedPath := seed.sessionPath(seedRun.Ref)
+	seedRun.Release()
+	data, err := os.ReadFile(seedPath)
+	if err != nil {
+		t.Fatalf("read seed transcript: %v", err)
+	}
+	if err := os.WriteFile(snapshot, data, 0o644); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	run, err := store.PrepareDetached(snapshot, spec)
+	if err != nil {
+		t.Fatalf("PrepareDetached: %v", err)
+	}
+	defer run.Release()
+	if run.Meta.Kind != "detach" {
+		t.Fatalf("meta.Kind = %q, want detach", run.Meta.Kind)
+	}
+	msgs := run.Session.Snapshot()
+	if len(msgs) < 2 || msgs[1].Content != "detach me" {
+		t.Fatalf("detached session messages = %+v, want snapshot contents", msgs)
+	}
+	// Transcript file must exist and differ from the source path.
+	if _, err := os.Stat(store.sessionPath(run.Ref)); err != nil {
+		t.Fatalf("transcript not copied: %v", err)
+	}
+}
+
+func TestPrepareDetachedRejectsMissingSnapshot(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	if _, err := store.PrepareDetached(filepath.Join(t.TempDir(), "nope.jsonl"), spec); err == nil {
+		t.Fatal("PrepareDetached with missing snapshot should fail")
+	}
+}
+
+func TestDeleteTranscriptRemovesFiles(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	dir := t.TempDir()
+	snapshot := filepath.Join(dir, "main-session.jsonl")
+	os.WriteFile(snapshot, []byte("{\"role\":\"system\",\"content\":\"sys\"}\n"), 0o644)
+
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareDetached(snapshot, spec)
+	if err != nil {
+		t.Fatalf("PrepareDetached: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+	if err := store.DeleteTranscript(ref); err != nil {
+		t.Fatalf("DeleteTranscript: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(ref)); !os.IsNotExist(err) {
+		t.Fatalf("transcript still exists after DeleteTranscript (err=%v)", err)
+	}
+	if _, err := os.Stat(store.metaPath(ref)); !os.IsNotExist(err) {
+		t.Fatalf("meta still exists after DeleteTranscript (err=%v)", err)
+	}
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -329,6 +329,15 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 		if !cont {
 			return terr
 		}
+		// #8170: the host asked to move the remainder of this turn to a
+		// background job. The current tool round already committed to the
+		// session, so the controller can snapshot it and continue as a job.
+		// The final-response branch above returns before this check, so a
+		// detach request that arrives while the model streams a final answer
+		// naturally falls through (best-effort: the turn just finishes).
+		if detach := turnDetachSignal(ctx); detach != nil && detach() {
+			return ErrTurnDetached
+		}
 	}
 	// Only reached when a positive maxSteps guard is configured. The work so far
 	// is already in the session, so the user can just send another message to pick

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -373,6 +374,94 @@ func (s *SubagentStore) parentSessionPath(parentSession string) (string, bool) {
 		return "", false
 	}
 	return filepath.Join(filepath.Dir(s.dir), parentSession+".jsonl"), true
+}
+
+// PrepareDetached starts a subagent-style run from an existing session-file
+// snapshot — the detach point of a foreground turn (#8170). The snapshot is
+// copied into the transcript store so the detached run owns a fully isolated
+// file; the job deletes it again on completion (DeleteTranscript).
+func (s *SubagentStore) PrepareDetached(snapshotPath string, spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("subagent transcript store is required")
+	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("detach snapshot %q: %w", snapshotPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("detach snapshot %q is not a regular file", snapshotPath)
+	}
+	ref, err := s.newRef()
+	if err != nil {
+		return nil, err
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	meta := metaFromSpec(ref, SubagentRunning, now, now, spec)
+	meta.Kind = "detach"
+	if err := copyFile(snapshotPath, s.sessionPath(ref)); err != nil {
+		release()
+		return nil, fmt.Errorf("copy detach snapshot: %w", err)
+	}
+	if err := s.saveMeta(meta); err != nil {
+		release()
+		return nil, err
+	}
+	sess, err := LoadSession(s.sessionPath(ref))
+	if err != nil {
+		release()
+		return nil, fmt.Errorf("load detach snapshot: %w", err)
+	}
+	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
+}
+
+// DeleteTranscript removes the transcript file and its metadata for a ref.
+// Used after a detached job completes: the result summary lives in the jobs
+// manager, the isolated snapshot file is no longer needed (#8170).
+func (s *SubagentStore) DeleteTranscript(ref string) error {
+	if s == nil || strings.TrimSpace(ref) == "" {
+		return nil
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return err
+	}
+	defer release()
+	if err := os.Remove(s.sessionPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.Remove(s.metaPath(ref)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// copyFile copies a regular file to dst, creating parent directories as
+// needed. Used for detach snapshots (#8170).
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {

--- a/internal/agent/turn_detach.go
+++ b/internal/agent/turn_detach.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrTurnDetached is returned by the run loop when the host requested the
+// remaining work of the current turn to continue as a background job (#8170).
+// Controllers distinguish it from cancellation: the turn is NOT treated as
+// interrupted; it finished normally up to the detach boundary (the current
+// tool round already committed), and the host snapshots the session and
+// hands the remainder to a job.
+var ErrTurnDetached = errors.New("turn detached to background job")
+
+type turnDetachSignalKey struct{}
+
+// WithTurnDetachSignal attaches a host-provided predicate that reports whether
+// a detach was requested. The run loop consults it at turn boundaries.
+func WithTurnDetachSignal(ctx context.Context, fn func() bool) context.Context {
+	return context.WithValue(ctx, turnDetachSignalKey{}, fn)
+}
+
+func turnDetachSignal(ctx context.Context) func() bool {
+	fn, _ := ctx.Value(turnDetachSignalKey{}).(func() bool)
+	return fn
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1393,6 +1393,49 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		}
 		return agent.FormatSubagentRunResult(answer, run, false), nil
 	}
+
+	// detachRunner continues a foreground turn that the user moved to a
+	// background job (#8170). The controller hands it the session snapshot
+	// file; we copy it into the subagent transcript store and run the
+	// remainder as an isolated job with the main agent's registry and model.
+	// The job returns its reference immediately; completion surfaces through
+	// the jobs manager (notice + <background-jobs> on the next turn).
+	detachContinueInstruction := "Continue the task that was detached from the foreground turn. The session history before this message is your starting point; work autonomously until the task is done."
+	detachRunner := func(sctx context.Context, snapshotPath string, spec control.DetachSpec) (string, error) {
+		subSpec := agent.SubagentSpec{
+			Kind:          "detach",
+			Name:          spec.Label,
+			WorkspaceRoot: spec.WorkspaceRoot,
+			ParentSession: spec.ParentSession,
+			SystemPrompt:  spec.SystemPrompt,
+			Registry:      reg,
+			Model:         entry.Model,
+			Effort:        entry.Effort,
+		}
+		job := jm.StartForSession(spec.ParentSession, "detach", spec.Label, func(jobCtx context.Context, out io.Writer) (string, error) {
+			run, err := subagentStore.PrepareDetached(snapshotPath, subSpec)
+			if err != nil {
+				return "", err
+			}
+			defer run.Release()
+			runOptions := subagentSkillOptions(jobCtx, 0, entry.Price, entry.ContextWindow, 0)
+			answer, err := agent.RunSubAgentWithSession(jobCtx, execProv, reg, run.Session, detachContinueInstruction, runOptions, agent.NestedSink(jobCtx, event.Discard))
+			if err != nil {
+				_ = subagentStore.SaveFailed(run)
+				_ = subagentStore.DeleteTranscript(run.Ref)
+				return "", err
+			}
+			if err := subagentStore.SaveCompleted(run); err != nil {
+				_ = subagentStore.DeleteTranscript(run.Ref)
+				return "", err
+			}
+			// #8170: the isolated snapshot file is no longer needed once the
+			// job completes; the summary lives in the jobs manager.
+			_ = subagentStore.DeleteTranscript(run.Ref)
+			return agent.FormatSubagentRunResult(answer, run, false), nil
+		})
+		return job.ID, nil
+	}
 	skillProfile := func(sk skill.Skill) *event.Profile {
 		model, effort := subagentModelRef(cfg, sk), subagentEffortRef(cfg, sk)
 		if model == "" && effort == "" {
@@ -1748,6 +1791,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		DisableImplicitSkillInvocation: !implicitSkillInvocation,
 		SkillRunner:                    skillRunner,
 		ReadOnlySkillRunner:            readOnlySkillRunner,
+		DetachRunner:                   detachRunner,
 		SkillProfile:                   skillProfile,
 		Hooks:                          hookRunner,
 		Memory:                         mem,

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4668,6 +4668,13 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		return m.startControllerTurn(input, input, func() {
 			m.ctrl.SubmitFinalReadinessRecovery(input, prompt)
 		})
+	case "/detach":
+		m.echoLocalCommand(input)
+		if err := m.ctrl.RequestDetach(); err != nil {
+			m.notice(fmt.Sprintf("/detach: %v", err))
+		} else {
+			m.notice(i18n.M.SlashDetachQueued)
+		}
 	case "/compact":
 		m.echoLocalCommand(input)
 		// Compaction makes a (network) summarizer call; run it off the Update loop

--- a/internal/cli/slash_registry.go
+++ b/internal/cli/slash_registry.go
@@ -24,6 +24,7 @@ type builtinSlashSpec struct {
 func builtinSlashSpecs() []builtinSlashSpec {
 	return []builtinSlashSpec{
 		{name: "/compact", insert: "/compact ", hint: i18n.M.CmdCompact, showInHelp: true},
+		{name: "/detach", insert: "/detach", hint: i18n.M.CmdDetach, showInHelp: true},
 		{name: "/context", insert: "/context", hint: i18n.M.CmdContext, showInHelp: true},
 		{name: "/new", insert: "/new ", hint: i18n.M.CmdNew, showInHelp: true},
 		{name: "/clear", insert: "/clear", hint: i18n.M.CmdClear, showInHelp: true},

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -272,6 +272,12 @@ type Controller struct {
 	finishing         bool // TurnDone is still being delivered; park a replacement turn
 	finishingBoundary turnFinishingBoundary
 	canceling         bool
+	// detachRequested is set by RequestDetach while a turn runs; the run loop
+	// consumes it at the next tool-round boundary (#8170). It self-clears so a
+	// turn that finishes first simply ends normally.
+	detachRequested bool
+	// detachRunner continues a detached turn as a background job (boot layer).
+	detachRunner DetachRunner
 	// closed marks the controller as terminally torn down (close() ran). It
 	// seals turn admission: without it, a submit arriving AFTER close cleared
 	// the parked queue — but while a still-running turn's TurnDone delivery
@@ -468,6 +474,9 @@ type Options struct {
 	// metadata for the synthetic top-level run_skill event.
 	SkillRunner         skill.SubagentRunner
 	ReadOnlySkillRunner skill.SubagentRunner
+	// DetachRunner continues a turn the user moved to a background job from a
+	// session snapshot (#8170). Nil disables RequestDetach.
+	DetachRunner DetachRunner
 	SkillProfile        skill.ProfileResolver
 	Hooks               *hook.Runner
 	Memory              *memory.Set
@@ -627,6 +636,7 @@ func New(opts Options) *Controller {
 		disableImplicitSkillInvocation:    opts.DisableImplicitSkillInvocation,
 		skillRunner:                       opts.SkillRunner,
 		readOnlySkillRunner:               opts.ReadOnlySkillRunner,
+		detachRunner:                      opts.DetachRunner,
 		skillProfile:                      opts.SkillProfile,
 		hooks:                             opts.Hooks,
 		memory:                            newMemoryManager(opts.Memory),

--- a/internal/control/detach.go
+++ b/internal/control/detach.go
@@ -1,0 +1,99 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// DetachSpec describes the continuation of a turn that the user moved to a
+// background job (#8170). The snapshot file (the session transcript at the
+// detach boundary) is owned by the caller; the runner copies it into the
+// transcript store and deletes it again on completion.
+type DetachSpec struct {
+	ParentSession string
+	WorkspaceRoot string
+	SystemPrompt  string
+	Label         string
+}
+
+// DetachRunner launches a background job that continues a detached turn from
+// the given session-file snapshot and returns the job reference immediately
+// (the job runs asynchronously). Implemented by the boot layer, which owns
+// the provider/tool registry/subagent store.
+type DetachRunner func(ctx context.Context, snapshotPath string, spec DetachSpec) (string, error)
+
+// RequestDetach asks the running turn to hand its remaining work to a
+// background job at the next tool-round boundary. It is a no-op unless a
+// turn is currently running. The request self-clears: if the turn finishes
+// before reaching a boundary, nothing is detached (best-effort).
+func (c *Controller) RequestDetach() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.running {
+		return fmt.Errorf("no running turn to detach")
+	}
+	c.detachRequested = true
+	return nil
+}
+
+// detachRequestedSignal is the predicate handed to the run loop; it reads
+// under the controller mutex because the loop runs in its own goroutine.
+func (c *Controller) detachRequestedSignal() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.detachRequested
+}
+
+func (c *Controller) clearDetachRequested() {
+	c.mu.Lock()
+	c.detachRequested = false
+	c.mu.Unlock()
+}
+
+// performDetach executes the detach ritual: persist the transcript up to the
+// boundary, then hand it to the background runner. The runner must return
+// immediately (the job itself runs asynchronously).
+func (c *Controller) performDetach(ctx context.Context, startMessages int) error {
+	if c.detachRunner == nil {
+		return fmt.Errorf("turn detach is not available in this session")
+	}
+	// Persist the transcript so the snapshot is complete (the current tool
+	// round already committed in-memory).
+	if durable, err := c.snapshotActivityIfChanged(startMessages); err != nil && !durable {
+		return fmt.Errorf("detach: persist transcript: %w", err)
+	}
+	spec := DetachSpec{
+		ParentSession: c.parentSessionID(),
+		WorkspaceRoot: c.workspaceRoot,
+		SystemPrompt:  systemPromptFromHistory(c.History()),
+		Label:         "detached turn",
+	}
+	jobRef, err := c.detachRunner(ctx, c.SessionPath(), spec)
+	if err != nil {
+		return fmt.Errorf("detach: start background job: %w", err)
+	}
+	if jobRef != "" && c.sink != nil {
+		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "Turn moved to background job " + jobRef})
+	}
+	return nil
+}
+
+// systemPromptFromHistory returns the first system-role message content.
+func systemPromptFromHistory(msgs []provider.Message) string {
+	for _, m := range msgs {
+		if m.Role == provider.RoleSystem {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// isTurnDetached reports whether err is the run-loop's detach sentinel.
+func isTurnDetached(err error) bool {
+	return errors.Is(err, agent.ErrTurnDetached)
+}

--- a/internal/control/detach_test.go
+++ b/internal/control/detach_test.go
@@ -1,0 +1,80 @@
+package control
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestRequestDetachRequiresRunningTurn(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	if err := c.RequestDetach(); err == nil {
+		t.Fatal("RequestDetach on idle controller should fail")
+	}
+}
+
+func TestRequestDetachSetsFlagWhileRunning(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+	if err := c.RequestDetach(); err != nil {
+		t.Fatalf("RequestDetach: %v", err)
+	}
+	if !c.detachRequestedSignal() {
+		t.Fatal("detach flag not set after RequestDetach")
+	}
+	c.clearDetachRequested()
+	if c.detachRequestedSignal() {
+		t.Fatal("detach flag not cleared by clearDetachRequested")
+	}
+}
+
+func TestPerformDetachInvokesRunnerAndEmitsNotice(t *testing.T) {
+	var gotPath string
+	var gotSpec DetachSpec
+	var noticeText string
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice && noticeText == "" {
+				noticeText = e.Text
+			}
+		}),
+		DetachRunner: func(ctx context.Context, path string, spec DetachSpec) (string, error) {
+			gotPath = path
+			gotSpec = spec
+			return "detach-1", nil
+		},
+	})
+	c.mu.Lock()
+	c.running = true
+	c.workspaceRoot = t.TempDir()
+	c.mu.Unlock()
+	c.setSessionPath(t.TempDir()+"/session.jsonl", false)
+	if err := c.performDetach(context.Background(), 0); err != nil {
+		t.Fatalf("performDetach: %v", err)
+	}
+	if gotPath == "" {
+		t.Fatal("detach runner was not invoked with a snapshot path")
+	}
+	if gotSpec.WorkspaceRoot != c.workspaceRoot {
+		t.Fatalf("spec.WorkspaceRoot = %q, want %q", gotSpec.WorkspaceRoot, c.workspaceRoot)
+	}
+	if gotSpec.ParentSession == "" {
+		t.Fatal("spec.ParentSession is empty")
+	}
+	if noticeText == "" {
+		t.Fatal("expected a notice event naming the background job")
+	}
+}
+
+func TestPerformDetachFailsWithoutRunner(t *testing.T) {
+	c := New(Options{Sink: event.FuncSink(func(event.Event) {})})
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+	if err := c.performDetach(context.Background(), 0); err == nil {
+		t.Fatal("performDetach without DetachRunner should fail")
+	}
+}

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -66,6 +66,7 @@ type TurnControl interface {
 	Cancel()
 	Steer(text string)
 	SteerConsumed() bool
+	RequestDetach() error
 	Running() bool
 	CancelRequested() bool
 	RuntimeStatus() RuntimeStatus

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -282,6 +282,11 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	if !turn.synthetic {
 		modelInput = c.withCapabilityRoute(ctx, input, turn.raw)
 	}
+	// #8170: surface the host's detach request to the run loop; it stops at
+	// the next tool-round boundary so the controller can snapshot and hand
+	// the remainder to a background job.
+	ctx = agent.WithTurnDetachSignal(ctx, c.detachRequestedSignal)
+	defer c.clearDetachRequested()
 	// Real user turns open a fresh Recovery Episode. Goal auto-continues and
 	// other synthetic turns inherit the current Episode so budgets accumulate
 	// only within one host-owned execution round.
@@ -291,6 +296,16 @@ func (o *turnOrchestrator) runOrchestratedTurn(ctx context.Context, turn orchest
 	err = c.runner.Run(ctx, modelInput)
 	c.captureGoalRunWorkDuration(startMessages)
 	c.persistGoalDeliveryCheckpoint()
+	if isTurnDetached(err) {
+		// #8170: the turn stopped cleanly at a detach boundary. The current
+		// tool round already committed; snapshot the session and continue the
+		// remainder as a background job. The turn itself finishes normally
+		// (no strip, no failure), and queued input dispatches right after.
+		if detachErr := c.performDetach(ctx, startMessages); detachErr != nil {
+			return detachErr
+		}
+		return nil
+	}
 	if err != nil {
 		// When the user explicitly cancels, keep the real prompt and any fully
 		// paired tool work. Partial reasoning/output remains durable for display

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -242,6 +242,8 @@ type Messages struct {
 	CmdCls              string // /cls
 	CmdCompact          string // /compact
 	CmdContinueChecks   string // /continue-checks
+	CmdDetach           string // /detach
+	SlashDetachQueued   string // /detach accepted notice
 	CmdContext          string // /context
 	CmdRewind           string // /rewind
 	CmdTree             string // /tree

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -257,6 +257,8 @@ var English = Messages{
 	CmdCls:              "clear screen only (keep LLM context)",
 	CmdCompact:          "compact context",
 	CmdContinueChecks:   "continue a paused final-readiness check",
+	CmdDetach:           "move running turn to a background job",
+	SlashDetachQueued:   "turn will move to a background job at the next tool boundary; keep typing",
 	CmdContext:          "show context window, thresholds, and last maintenance",
 	CmdRewind:           "rewind to an earlier turn",
 	CmdTree:             "show conversation branches",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -258,6 +258,8 @@ var Chinese = Messages{
 	CmdCls:              "清屏（保留 LLM 上下文）",
 	CmdCompact:          "压缩上下文",
 	CmdContinueChecks:   "继续已暂停的任务收尾检查",
+	CmdDetach:           "将运行中的任务转为后台",
+	SlashDetachQueued:   "任务将在下一个工具边界转入后台，可以继续输入",
 	CmdContext:          "查看上下文窗口、阈值与上次维护结果",
 	CmdRewind:           "回滚到更早的一轮",
 	CmdTree:             "查看对话分支树",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -247,6 +247,8 @@ var ChineseTraditional = Messages{
 	CmdCls:              "清除畫面（保留 LLM 上下文）",
 	CmdCompact:          "壓縮上下文",
 	CmdContinueChecks:   "繼續已暫停的任務收尾檢查",
+	CmdDetach:           "將執行中的任務轉為背景",
+	SlashDetachQueued:   "任務將在下一個工具邊界轉入背景，可以繼續輸入",
 	CmdContext:          "檢視上下文視窗、閾值與上次維護結果",
 	CmdRewind:           "回滾到更早的一輪",
 	CmdTree:             "檢視對話分支樹",


### PR DESCRIPTION
## Summary

#8170 入口部分（核心在 PR #8735）：**用户可触发的转后台入口**。

1. **Desktop**：
   - 新 IPC `DetachRunningTurn(tabID)`（desktop/app.go → `controller.RequestDetach()`，只读 tab 拒绝）
   - Composer 停止按钮旁新增**"转后台"按钮**（`SendToBack` 图标，turn 运行中显示；`t("composer.detach")` en/zh/zh-TW）
   - **输入排队已天然存在**：Composer 在 turn 运行中提交消息时走 durable inbox（steer follow-up），turn 结束后自动 dispatch——detach 生效（主 turn 结束）后排队输入立即执行，与设计共识一致，**零新增**
2. **CLI**：`/detach` 命令（`runSlashCommand` case → `ctrl.RequestDetach()`；`builtinSlashSpecs` 注册进斜杠菜单；i18n `CmdDetach`/`SlashDetachQueued` en/zh/zh-TW）——CLI 输入排队（inbox）已有，detach 后排队输入自动接续
3. `TurnControl` 接口（internal/control/port.go）新增 `RequestDetach() error`

行为（grill 共识）：点击/命令后 turn 在当前工具轮结束后转后台 job（快照 + subagent runner，核心 PR）；输入框立即可用；停止按钮语义不变（取消即杀死）。

English: entry points for #8170 (core in #8735) — desktop "move to background" button next to the stop button in the Composer (new `DetachRunningTurn` IPC), and a `/detach` slash command in the CLI. Desktop input queueing already exists (durable inbox steer follow-ups auto-dispatch after TurnDone), so queued input runs right after detach takes effect. No behavior change to the stop button.

## Issues

Refs #8170 (part 2: entry points; core in #8735)

## Verification

- `go build ./...` (control/i18n/cli/desktop) — pass
- `go test ./internal/i18n/...` — pass (catalog parity)
- `go test ./internal/cli/...` — pass
- `pnpm typecheck` / `pnpm lint:hooks` / `pnpm check:css` — pass
- `pnpm test:workspace` — 7 passed, 0 failed

## Documentation impact

Documentation-impact: none- new IPC + slash command only; no config, provider, permission, or tool surface changed.

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (inherited boot wiring from #8735); explicit maintainer review requested