### PR TITLE
feat(lease): user-authorized session ownership handoff between runtimes

### DIFF
--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -38,6 +38,13 @@ type SessionLeaseInfo struct {
 	PID         int       `json:"pid"`
 	Hostname    string    `json:"hostname,omitempty"`
 	AcquiredAt  time.Time `json:"acquired_at"`
+	// HandoffTo, when non-empty, marks this lease as handed off by the
+	// previous holder to the named runtime (writer_id). The OS lock is free
+	// while this field is set; only the named target may acquire it, and only
+	// until HandoffExpiresAt. This is the explicit, user-authorized path for
+	// transferring session ownership between runtimes (serve <-> desktop).
+	HandoffTo        string    `json:"handoff_to,omitempty"`
+	HandoffExpiresAt time.Time `json:"handoff_expires_at,omitempty"`
 }
 
 const sessionLeaseOwnerOffset int64 = 1
@@ -48,6 +55,10 @@ func sessionLeaseOwnerBytes(b []byte) []byte {
 	copy(payload[sessionLeaseOwnerOffset:], b)
 	return payload
 }
+
+// HandoffWindow is how long a released-for-handoff lease stays reserved for
+// its intended target before falling back to normal acquire semantics.
+const HandoffWindow = 30 * time.Second
 
 type SessionLeaseError struct {
 	Path string
@@ -123,6 +134,16 @@ func TryAcquireSessionLease(path string) (*SessionLease, error) {
 	if _, loaded := sessionLeaseOwners.LoadOrStore(path, ownerID); loaded {
 		info, _ := LoadSessionLeaseInfo(path)
 		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	// Respect an unexpired handoff reservation: while the previous holder has
+	// released the lease for a named target, only that target may acquire
+	// (via TryAcquireSessionLeaseWithHandoff). A plain acquire during the
+	// window would defeat the user-authorized transfer.
+	if info, err := LoadSessionLeaseInfo(path); err == nil && info != nil && info.HandoffTo != "" {
+		if info.HandoffExpiresAt.IsZero() || time.Now().UTC().Before(info.HandoffExpiresAt) {
+			sessionLeaseOwners.CompareAndDelete(path, ownerID)
+			return nil, &SessionLeaseError{Path: path, Info: info}
+		}
 	}
 	leaseLock, err := tryTakeSessionLeaseLock(path)
 	if err != nil {
@@ -265,6 +286,115 @@ func (l *SessionLease) Path() string {
 		return ""
 	}
 	return l.path
+}
+
+// ReleaseForHandoff releases the lease like Release, but instead of
+// deleting the lease info it rewrites it with a handoff reservation naming
+// targetWriterID. The OS lock is freed (normal acquire proceeds), while the
+// reservation makes TryAcquireSessionLeaseWithHandoff the only acquirer for
+// HandoffWindow. This is the explicit user-authorized transfer path between
+// runtimes; there is no silent stealing path.
+func (l *SessionLease) ReleaseForHandoff(targetWriterID string) error {
+	if l == nil {
+		return nil
+	}
+	if strings.TrimSpace(targetWriterID) == "" {
+		return fmt.Errorf("handoff target writer id is required")
+	}
+	// Same save-drain wait as Release: a concurrent save that already passed
+	// Valid() must finish before ownership is revoked (ABA).
+	for {
+		l.mu.Lock()
+		if l.released {
+			l.mu.Unlock()
+			return nil
+		}
+		if l.activeSaves == 0 {
+			break
+		}
+		if l.releaseWait == nil {
+			l.releaseWait = make(chan struct{})
+		}
+		wait := l.releaseWait
+		l.mu.Unlock()
+		<-wait
+	}
+	l.released = true
+	leaseLock := l.leaseLock
+	l.leaseLock = nil
+	l.mu.Unlock()
+
+	sessionLeaseActiveOwners.CompareAndDelete(l.path, l.ownerID)
+	// Write the handoff reservation while the OS lock is still held so a
+	// concurrent acquirer can never observe a free lock without the marker.
+	info := newSessionLeaseInfo(l.path)
+	info.HandoffTo = targetWriterID
+	info.HandoffExpiresAt = time.Now().UTC().Add(HandoffWindow)
+	if err := SaveSessionLeaseInfo(l.path, info); err != nil {
+		// Reservation write failed: fall back to a plain release so the
+		// session does not stay wedged. The target simply retries takeover.
+		sessionLeaseOwners.CompareAndDelete(l.path, l.ownerID)
+		if leaseLock != nil {
+			_ = leaseLock.RemoveAndUnlock()
+		}
+		return err
+	}
+	sessionLeaseOwners.CompareAndDelete(l.path, l.ownerID)
+	if leaseLock != nil {
+		_ = leaseLock.RemoveAndUnlock()
+	}
+	_ = removeStaleSessionLockSidecar(l.path, store.SessionLockFile(l.path))
+	return nil
+}
+
+// TryAcquireSessionLeaseWithHandoff acquires a lease that was released via
+// ReleaseForHandoff for this runtime. It refuses leases without a valid,
+// unexpired handoff reservation naming this writer, so a live holder is never
+// disturbed and a stale reservation cannot wedge the session. On success the
+// reservation fields are cleared by the normal SaveSessionLeaseInfo path.
+func TryAcquireSessionLeaseWithHandoff(path, sourceWriterID string) (*SessionLease, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("empty session path")
+	}
+	path = canonicalSessionSavePath(path)
+	info, err := LoadSessionLeaseInfo(path)
+	if err != nil || info == nil {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	if info.HandoffTo == "" {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	if sourceWriterID != "" && info.HandoffTo != sourceWriterID {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	if !info.HandoffExpiresAt.IsZero() && time.Now().UTC().After(info.HandoffExpiresAt) {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	// Reservation valid: take the OS lock directly (the previous holder
+	// released it). We cannot reuse TryAcquireSessionLease here because it
+	// refuses unexpired handoff reservations.
+	ownerID := sessionLeaseSeq.Add(1)
+	if _, loaded := sessionLeaseOwners.LoadOrStore(path, ownerID); loaded {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	leaseLock, err := tryTakeSessionLeaseLock(path)
+	if err != nil {
+		sessionLeaseOwners.CompareAndDelete(path, ownerID)
+		if errors.Is(err, ErrSessionLeaseHeld) {
+			return nil, &SessionLeaseError{Path: path, Info: info}
+		}
+		return nil, err
+	}
+	sessionLeaseActiveOwners.Delete(path)
+	lease := &SessionLease{path: path, ownerID: ownerID, leaseLock: leaseLock}
+	// Clear the reservation on the fresh lease info.
+	fresh := newSessionLeaseInfo(path)
+	if err := SaveSessionLeaseInfo(path, fresh); err != nil {
+		lease.Release()
+		return nil, err
+	}
+	sessionLeaseActiveOwners.Store(path, ownerID)
+	return lease, nil
 }
 
 func (l *SessionLease) Release() {

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -387,9 +387,10 @@ func TryAcquireSessionLeaseWithHandoff(path, sourceWriterID string) (*SessionLea
 	}
 	sessionLeaseActiveOwners.Delete(path)
 	lease := &SessionLease{path: path, ownerID: ownerID, leaseLock: leaseLock}
-	// Clear the reservation on the fresh lease info.
-	fresh := newSessionLeaseInfo(path)
-	if err := SaveSessionLeaseInfo(path, fresh); err != nil {
+	// Clear the reservation by publishing a fresh owner identity inside
+	// .lease.lock itself (new-format owner info; the legacy .lease.json
+	// sidecar is never written on the handoff path either).
+	if err := publishSessionLeaseOwner(leaseLock, path); err != nil {
 		lease.Release()
 		return nil, err
 	}

--- a/internal/agent/session_lease.go
+++ b/internal/agent/session_lease.go
@@ -364,7 +364,16 @@ func TryAcquireSessionLeaseWithHandoff(path, sourceWriterID string) (*SessionLea
 	if info.HandoffTo == "" {
 		return nil, &SessionLeaseError{Path: path, Info: info}
 	}
-	if sourceWriterID != "" && info.HandoffTo != sourceWriterID {
+	// Only the named handoff target may acquire: the acquiring runtime's own
+	// writer identity must match the reservation. The caller-supplied
+	// sourceWriterID identifies the RELEASING runtime and must match
+	// info.WriterID (the releasing side) — not handoff_to, so a runtime that
+	// merely reads the lease info cannot spoof the target check by echoing
+	// handoff_to back at us.
+	if SessionWriterID() != info.HandoffTo {
+		return nil, &SessionLeaseError{Path: path, Info: info}
+	}
+	if sourceWriterID != "" && info.WriterID != sourceWriterID {
 		return nil, &SessionLeaseError{Path: path, Info: info}
 	}
 	if !info.HandoffExpiresAt.IsZero() && time.Now().UTC().After(info.HandoffExpiresAt) {

--- a/internal/agent/session_lease_test.go
+++ b/internal/agent/session_lease_test.go
@@ -436,3 +436,86 @@ func TestSessionLeaseReleaseRetiresLockSidecars(t *testing.T) {
 	}
 	first.Release()
 }
+
+func TestSessionLeaseHandoffTransfer(t *testing.T) {
+	userPath, _ := leaseTestPath(t)
+	// First runtime acquires.
+	lease1, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	// ReleaseForHandoff reserves for the target writer.
+	if err := lease1.ReleaseForHandoff("writer-B"); err != nil {
+		t.Fatalf("release for handoff: %v", err)
+	}
+	// A plain acquire still fails while the reservation window is live.
+	if _, err := TryAcquireSessionLease(userPath); err == nil {
+		t.Fatal("plain acquire succeeded during handoff window; want ErrSessionLeaseHeld")
+	}
+	// The wrong target is refused.
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-C"); err == nil {
+		t.Fatal("wrong target acquired; want refusal")
+	}
+	// The intended target succeeds and the reservation is cleared.
+	lease2, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-B")
+	if err != nil {
+		t.Fatalf("handoff acquire: %v", err)
+	}
+	info, err := LoadSessionLeaseInfo(userPath)
+	if err != nil {
+		t.Fatalf("load info: %v", err)
+	}
+	if info.HandoffTo != "" {
+		t.Fatalf("handoff reservation not cleared: %+v", info)
+	}
+	lease2.Release()
+	// After the reservation cleared, plain acquire works again.
+	l3, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("re-acquire after handoff: %v", err)
+	}
+	l3.Release()
+}
+
+func TestSessionLeaseHandoffExpiry(t *testing.T) {
+	userPath, _ := leaseTestPath(t)
+	lease1, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := lease1.ReleaseForHandoff("writer-B"); err != nil {
+		t.Fatalf("release for handoff: %v", err)
+	}
+	// Backdate the reservation past the window.
+	info, err := LoadSessionLeaseInfo(userPath)
+	if err != nil {
+		t.Fatalf("load info: %v", err)
+	}
+	info.HandoffExpiresAt = time.Now().UTC().Add(-time.Second)
+	if err := SaveSessionLeaseInfo(userPath, *info); err != nil {
+		t.Fatalf("save backdated info: %v", err)
+	}
+	// Expired reservation no longer gates handoff acquire.
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-B"); err == nil {
+		t.Fatal("expired handoff still acquired; want refusal")
+	}
+	// Normal acquire is not wedged by the stale reservation.
+	l, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("plain acquire with stale reservation: %v", err)
+	}
+	l.Release()
+}
+
+func TestSessionLeaseHandoffRefusesActiveHolder(t *testing.T) {
+	userPath, _ := leaseTestPath(t)
+	lease1, err := TryAcquireSessionLease(userPath)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer lease1.Release()
+	// No handoff marker: the active holder is never disturbed.
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, ""); err == nil {
+		t.Fatal("handoff acquire without marker succeeded; want refusal")
+	}
+}

--- a/internal/agent/session_lease_test.go
+++ b/internal/agent/session_lease_test.go
@@ -439,7 +439,10 @@ func TestSessionLeaseReleaseRetiresLockSidecars(t *testing.T) {
 
 func TestSessionLeaseHandoffTransfer(t *testing.T) {
 	userPath, _ := leaseTestPath(t)
-	// First runtime acquires.
+	origWriter := sessionWriterID
+	defer func() { sessionWriterID = origWriter }()
+
+	// First runtime (this process, releasing side) acquires.
 	lease1, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
@@ -452,12 +455,19 @@ func TestSessionLeaseHandoffTransfer(t *testing.T) {
 	if _, err := TryAcquireSessionLease(userPath); err == nil {
 		t.Fatal("plain acquire succeeded during handoff window; want ErrSessionLeaseHeld")
 	}
-	// The wrong target is refused.
-	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-C"); err == nil {
-		t.Fatal("wrong target acquired; want refusal")
+	// A runtime whose own identity is NOT the named target is refused, even
+	// if it supplies the releasing writer id (spoof attempt).
+	sessionWriterID = "writer-C"
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, origWriter); err == nil {
+		t.Fatal("non-target runtime acquired via spoofed handoff; want refusal")
 	}
-	// The intended target succeeds and the reservation is cleared.
-	lease2, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-B")
+	// The intended target but a wrong source (releasing runtime) is refused.
+	sessionWriterID = "writer-B"
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-X"); err == nil {
+		t.Fatal("wrong source writer acquired; want refusal")
+	}
+	// The intended target (own id == handoff_to, from == releasing id) succeeds.
+	lease2, err := TryAcquireSessionLeaseWithHandoff(userPath, origWriter)
 	if err != nil {
 		t.Fatalf("handoff acquire: %v", err)
 	}
@@ -479,6 +489,9 @@ func TestSessionLeaseHandoffTransfer(t *testing.T) {
 
 func TestSessionLeaseHandoffExpiry(t *testing.T) {
 	userPath, _ := leaseTestPath(t)
+	origWriter := sessionWriterID
+	defer func() { sessionWriterID = origWriter }()
+
 	lease1, err := TryAcquireSessionLease(userPath)
 	if err != nil {
 		t.Fatalf("acquire: %v", err)
@@ -495,10 +508,13 @@ func TestSessionLeaseHandoffExpiry(t *testing.T) {
 	if err := SaveSessionLeaseInfo(userPath, *info); err != nil {
 		t.Fatalf("save backdated info: %v", err)
 	}
-	// Expired reservation no longer gates handoff acquire.
-	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, "writer-B"); err == nil {
+	// The named target (own id == handoff_to) is still refused once the
+	// reservation expired.
+	sessionWriterID = "writer-B"
+	if _, err := TryAcquireSessionLeaseWithHandoff(userPath, ""); err == nil {
 		t.Fatal("expired handoff still acquired; want refusal")
 	}
+	sessionWriterID = origWriter
 	// Normal acquire is not wedged by the stale reservation.
 	l, err := TryAcquireSessionLease(userPath)
 	if err != nil {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -582,6 +582,8 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /skills", s.skills)
 	mux.HandleFunc("GET /todos", s.todos)
 	mux.HandleFunc("POST /delete-session", s.deleteSession)
+	mux.HandleFunc("POST /release-session", s.releaseSession)
+	mux.HandleFunc("POST /takeover-session", s.takeoverSession)
 	return logMiddleware(gzipMiddleware(s.auth.middleware(s.hostGuard(csrfGuard(mux)))))
 }
 
@@ -1526,6 +1528,109 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// releaseSession releases the lease of a named session with a handoff
+// reservation, so another runtime (e.g. the desktop app) can take it over via
+// /takeover-session. Only the session currently held by this serve runtime can
+// be released; releasing an unheld or foreign-held session is a 409. A
+// running turn rejects the release with 409 so the handoff never tears a
+// mid-write session.
+func (s *Server) releaseSession(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+		To   string `json:"to,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Name) == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		http.Error(w, "invalid session name", http.StatusBadRequest)
+		return
+	}
+	dir := s.ctl().SessionDir()
+	if dir == "" {
+		http.Error(w, "sessions disabled", http.StatusBadRequest)
+		return
+	}
+	abs := filepath.Join(dir, name+".jsonl")
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		http.Error(w, "invalid session dir", http.StatusBadRequest)
+		return
+	}
+	rel, err := filepath.Rel(absDir, abs)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		http.Error(w, "path outside session dir", http.StatusForbidden)
+		return
+	}
+	if filepath.Clean(abs) != filepath.Clean(s.ctl().SessionPath()) {
+		// Only the currently bound session is this runtime's to release.
+		http.Error(w, "session is not held by this runtime", http.StatusConflict)
+		return
+	}
+	keeper := s.leases
+	if keeper == nil {
+		http.Error(w, "lease keeper unavailable", http.StatusInternalServerError)
+		return
+	}
+	lease := keeper.Lease()
+	if lease == nil {
+		http.Error(w, "no lease held for current session", http.StatusConflict)
+		return
+	}
+	target := strings.TrimSpace(body.To)
+	if err := lease.ReleaseForHandoff(target); err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// takeoverSession acquires a session whose lease carries a handoff
+// reservation for this runtime (created by /release-session). The session's
+// path is loaded through the controller so subsequent submits target it.
+func (s *Server) takeoverSession(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name string `json:"name"`
+		From string `json:"from,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Name) == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		http.Error(w, "invalid session name", http.StatusBadRequest)
+		return
+	}
+	dir := s.ctl().SessionDir()
+	if dir == "" {
+		http.Error(w, "sessions disabled", http.StatusBadRequest)
+		return
+	}
+	abs := filepath.Join(dir, name+".jsonl")
+	if _, err := os.Stat(abs); err != nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	lease, err := agent.TryAcquireSessionLeaseWithHandoff(abs, strings.TrimSpace(body.From))
+	if err != nil {
+		http.Error(w, control.SessionInUseMessage(err), http.StatusConflict)
+		return
+	}
+	// Point the controller at the acquired session so /submit and /history
+	// operate on it. Rebind releases any lease this runtime previously held.
+	if err := s.leases.Rebind(abs); err != nil {
+		lease.Release()
+		http.Error(w, control.SessionInUseMessage(err), http.StatusConflict)
+		return
+	}
+	// Rebind re-acquired its own lease; release the probe lease we took.
+	lease.Release()
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -1547,7 +1547,14 @@ func (s *Server) releaseSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	name := strings.TrimSpace(body.Name)
-	if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+	target := strings.TrimSpace(body.To)
+	if target == "" {
+		// Validate the required handoff target up front: a missing target is a
+		// client error (400), not a deferred conflict (409).
+		http.Error(w, "handoff target (to) is required", http.StatusBadRequest)
+		return
+	}
+	if name == "." || name == ".." || strings.ContainsAny(name, `\/`) {
 		http.Error(w, "invalid session name", http.StatusBadRequest)
 		return
 	}
@@ -1556,22 +1563,39 @@ func (s *Server) releaseSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "sessions disabled", http.StatusBadRequest)
 		return
 	}
-	abs := filepath.Join(dir, name+".jsonl")
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		http.Error(w, "invalid session dir", http.StatusBadRequest)
 		return
 	}
+	abs := filepath.Join(absDir, name+".jsonl")
 	rel, err := filepath.Rel(absDir, abs)
 	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 		http.Error(w, "path outside session dir", http.StatusForbidden)
 		return
 	}
-	if filepath.Clean(abs) != filepath.Clean(s.ctl().SessionPath()) {
+	currentPath, err := filepath.Abs(s.ctl().SessionPath())
+	if err != nil {
+		http.Error(w, "invalid current session path", http.StatusInternalServerError)
+		return
+	}
+	if filepath.Clean(abs) != filepath.Clean(currentPath) {
 		// Only the currently bound session is this runtime's to release.
 		http.Error(w, "session is not held by this runtime", http.StatusConflict)
 		return
 	}
+	// A handoff mid-turn would race the session writes: the controller is
+	// single-owner and releaseSession must not hand off while a turn is
+	// executing (between saves).
+	if s.ctl().Running() {
+		http.Error(w, "cannot hand off a session while a turn is running", http.StatusConflict)
+		return
+	}
+	// Serialize with the other session-path-changing endpoints (/resume,
+	// /new, /fork, /takeover-session, model switch) that hold bindMu, so the
+	// lease cannot be handed off while a rebind is mid-flight.
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
 	keeper := s.leases
 	if keeper == nil {
 		http.Error(w, "lease keeper unavailable", http.StatusInternalServerError)
@@ -1582,8 +1606,13 @@ func (s *Server) releaseSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no lease held for current session", http.StatusConflict)
 		return
 	}
-	target := strings.TrimSpace(body.To)
 	if err := lease.ReleaseForHandoff(target); err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	// Drop the released lease from the local keeper so a later rebind to the
+	// same path is a real acquire, not a no-op against a released lease.
+	if err := keeper.Rebind(""); err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
 		return
 	}

--- a/internal/serve/sessions_http.go
+++ b/internal/serve/sessions_http.go
@@ -18,6 +18,10 @@ type sessionListEntry struct {
 	Current    bool   `json:"current,omitempty"`
 	Running    bool   `json:"running,omitempty"`
 	MtimeMilli int64  `json:"mtimeMilli"`
+	// HeldBy reports lease ownership for clients: "me" (this serve
+	// runtime holds it), "other" (another runtime, e.g. the desktop app,
+	// holds it — write attempts will be rejected), or "" (free).
+	HeldBy string `json:"heldBy,omitempty"`
 }
 
 // sessions lists saved sessions with event-log-aware titles and turn counts.
@@ -54,6 +58,11 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 		row := sessionListEntry{Name: strings.TrimSuffix(entry.Name(), ".jsonl"), Path: path, Current: cleanPath == current, Running: running[cleanPath], MtimeMilli: mtime.UnixMilli()}
 		if row.Current {
 			row.Running = controllerHasActiveRuntimeWork(ctrl)
+		}
+		if agent.SessionLeaseHeldByCurrentRuntime(path) {
+			row.HeldBy = "me"
+		} else if agent.SessionLeaseHeldByOtherRuntime(path) {
+			row.HeldBy = "other"
 		}
 		first, turns, cached := agent.SessionPreviewCached(path)
 		if !cached {


### PR DESCRIPTION
> [!IMPORTANT]
> **Direction update 2026-09-08**: this PR's full-transfer semantic competes with the upstream mirrored-session model (`internal/serve/session_ownership.go`). Superseding it with a direction-generalized mirrored takeover — see the design comment on #8745 (https://github.com/esengine/DeepSeek-Reasonix/issues/8745#issuecomment-5578063038). Keeping this PR open until that direction is confirmed; the lease-handoff mechanics here are already absorbed upstream (`ReleaseForHandoff(targetWriterID, handoffID)`).
>
> 中文：本 PR 的「彻底转移」语义与上游 mirrored-session 模型竞争，改为在 #8745 提出方向泛化融合设计；lease 交接机制上游已吸收（双参数 ReleaseForHandoff）。方向确认后本 PR 将关闭并由基于 upstream/main-v2 的新 PR 取代。

**TL;DR**: 会话所有权交接全链路：takeover 后原 tab 停止写入，释放/接管路由完备

## Summary

Adds a **user-authorized session ownership handoff** mechanism to the session lease protocol, enabling seamless transfer of a session between runtimes (serve ↔ desktop app) without the holder closing the session first. This is a prerequisite for remote-control workflows (e.g. a mobile client driving a desktop-hosted Reasonix via `serve`).

Fixes #8745.

## Problem

A session is protected by a single-writer lease (`.jsonl.lease.json` + OS file lock). Today, when one runtime holds a session, any other runtime is rejected:

- `serve --resume` on a session held by the desktop app → `this session is in use by another Reasonix process (pid ...)`
- Desktop app opening a session held by serve → `this session is already open in another Reasonix window or still running in the background`

Ownership only transfers when the holder **exits**. There is no way to actively hand a session to another runtime while both are alive, which forces users to close tabs / start new sessions when switching devices.

## Changes

**Lease layer** (`internal/agent/session_lease.go`):
- `SessionLeaseInfo` gains `HandoffTo` + `HandoffExpiresAt` reservation fields (JSON backward-compatible, `omitempty`).
- `SessionLease.ReleaseForHandoff(targetWriterID)`: releases the OS lock (same save-drain wait as `Release`) but instead of deleting the lease info, rewrites it with a 30s reservation naming the target writer. A failed reservation write falls back to a plain release so the session never wedges.
- `TryAcquireSessionLeaseWithHandoff(path, sourceWriterID)`: acquires only under a valid, unexpired reservation; refuses wrong targets and expired reservations.
- `TryAcquireSessionLease` (plain) now refuses an **unexpired** reservation so a third runtime cannot race the transfer; expired reservations fall back to normal acquire semantics (crash-safe).

**serve layer** (`internal/serve/serve.go`):
- `POST /release-session` `{"name": "...", "to": "writer-id"}` — releases the current binding with a handoff reservation. 204 on success; 409 when the session is not held by this runtime or a turn is running (handoff never tears a mid-write session).
- `POST /takeover-session` `{"name": "...", "from": "writer-id"}` — acquires a reserved session and rebinds the controller so subsequent `/submit`/`/history` target it. 204 on success; 409 when no valid reservation exists.
- `GET /sessions` entries gain `heldBy`: `"me"` / `"other"` / omitted, so clients can render read-only vs writable state and only offer "take over" when appropriate.

**Tests** (`internal/agent/session_lease_test.go`):
- `TestSessionLeaseHandoffTransfer` — full transfer cycle: plain acquire refused during window, wrong target refused, intended target succeeds, reservation cleared, plain acquire works again.
- `TestSessionLeaseHandoffExpiry` — backdated reservation: handoff acquire refused, plain acquire not wedged.
- `TestSessionLeaseHandoffRefusesActiveHolder` — no marker → handoff acquire refuses; live holder never disturbed.

## Safety invariants preserved

- **No silent stealing**: a live holder's lease is never broken without an explicit `ReleaseForHandoff` reservation.
- **Atomic with writes**: handoff waits for in-flight saves to drain (same ABA guard as `Release`); a running turn rejects `/release-session` with 409.
- **Crash-safe**: if the handoff initiator dies before acquiring, the reservation expires after 30s and the session returns to normal acquire semantics.

## Verification

- `go build ./...` ✅
- `go test ./internal/agent/ ./internal/serve/` ✅ (including 3 new handoff tests)
- `go vet ./internal/serve/ ./internal/agent/` ✅

Cache-impact: none- handoff reuses the existing per-session lease info (added two `omitempty` fields, `HandoffTo`/`HandoffExpiresAt`); no cache key, prompt prefix, or model-tool schema changes, so request prefixes stay byte-identical and cached entries remain valid.

Cache-guard: none- no new tool/parameter that touches the cache; the new `/release-session` and `/takeover-session` endpoints are server-only state machines and do not introduce new prompt-side input. Existing cache-impact / cache-guard workflows remain green.

System-prompt-review: none- not applicable to this change - the handoff flow is a server-side lease handoff between runtimes; the model's system prompt and tool schemas are unchanged, so no system-prompt review is required.

Documentation-impact: none- session lease handoff is an internal authorization flow; existing session/lease documentation remains correct (no docs/*.md changed).