### PR TITLE
fix(provider): accept Anthropic stop_reason without message_stop / 兼容网关省略 message_stop 时不再误判中断

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -675,27 +674,11 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	if ctx.Err() != nil {
 		return
 	}
-	if stalled.Load() {
-		err := fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)
-		send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(err, provider.StreamInterruptIdleTimeout)})
+	if err := streamScanEndError(c.name, idleTimeout, stalled.Load(), scanner.Err(), stopReason); err != nil {
+		send(provider.Chunk{Type: provider.ChunkError, Err: err})
 		return
 	}
-	if err := scanner.Err(); err != nil {
-		wrapped := fmt.Errorf("%s: read stream: %w", c.name, err)
-		if provider.IsConnReset(err) {
-			send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(wrapped, provider.ClassifyStreamInterrupt(err))})
-			return
-		}
-		send(provider.Chunk{Type: provider.ChunkError, Err: wrapped})
-		return
-	}
-	// EOF / clean close before message_stop is an uncommitted attempt. Complete
-	// ChunkToolCall blocks that arrived earlier remain speculative.
-	send(provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(
-		fmt.Errorf("%s: stream ended before message_stop: %w", c.name, io.ErrUnexpectedEOF),
-		provider.StreamInterruptPrematureEOF,
-	)})
-	return
+	goto finalize
 
 finalize:
 	if haveUsage {

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -436,8 +436,8 @@ data: {"type":"message_stop"}
 }
 
 // TestReadStreamRequiresMessageStop: EOF after a complete tool block but before
-// message_stop must surface StreamInterruptedError so the attempt stays
-// uncommitted (tool calls remain speculative).
+// message_stop or message_delta.stop_reason must surface StreamInterruptedError
+// so the attempt stays uncommitted (tool calls remain speculative).
 func TestReadStreamRequiresMessageStop(t *testing.T) {
 	sse := `event: message_start
 data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}

--- a/internal/provider/anthropic/stream_eof.go
+++ b/internal/provider/anthropic/stream_eof.go
@@ -1,0 +1,34 @@
+package anthropic
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// streamScanEndError classifies why the SSE scanner stopped. A clean close
+// after message_delta.stop_reason is a complete terminal: compatible gateways
+// often omit message_stop, the same way OpenAI-compatible gateways omit [DONE]
+// after finish_reason. A clean close with no stop_reason stays uncommitted.
+func streamScanEndError(name string, idleTimeout time.Duration, stalled bool, scanErr error, stopReason string) error {
+	if stalled {
+		err := fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", name, idleTimeout)
+		return provider.StreamInterrupt(err, provider.StreamInterruptIdleTimeout)
+	}
+	if scanErr != nil {
+		wrapped := fmt.Errorf("%s: read stream: %w", name, scanErr)
+		if provider.IsConnReset(scanErr) {
+			return provider.StreamInterrupt(wrapped, provider.ClassifyStreamInterrupt(scanErr))
+		}
+		return wrapped
+	}
+	if stopReason != "" {
+		return nil
+	}
+	return provider.StreamInterrupt(
+		fmt.Errorf("%s: stream ended before message_stop: %w", name, io.ErrUnexpectedEOF),
+		provider.StreamInterruptPrematureEOF,
+	)
+}

--- a/internal/provider/anthropic/stream_eof_test.go
+++ b/internal/provider/anthropic/stream_eof_test.go
@@ -1,0 +1,151 @@
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// Compatible Anthropic gateways often omit message_stop after message_delta
+// the same way OpenAI-compatible gateways omit [DONE] after finish_reason.
+// A stop_reason is the provider's commit signal; EOF after that must finalize.
+
+func TestReadStreamAcceptsStopReasonWithoutMessageStop(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":5}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+`
+	c := &client{name: "cc"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sse))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(context.Background(), resp, ch)
+
+	var text strings.Builder
+	var sawDone, sawErr bool
+	var usage *provider.Usage
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkText:
+			text.WriteString(ck.Text)
+		case provider.ChunkUsage:
+			usage = ck.Usage
+		case provider.ChunkDone:
+			sawDone = true
+		case provider.ChunkError:
+			sawErr = true
+			t.Fatalf("stop_reason without message_stop should complete cleanly: %v", ck.Err)
+		}
+	}
+	if text.String() != "hello" || !sawDone || sawErr {
+		t.Fatalf("text=%q done=%v err=%v", text.String(), sawDone, sawErr)
+	}
+	if usage == nil || usage.FinishReason != "stop" {
+		t.Fatalf("usage = %+v, want finish_reason=stop", usage)
+	}
+}
+
+func TestReadStreamAcceptsToolUseStopReasonWithoutMessageStop(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"bash"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"cmd\":\"ls\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":8}}
+`
+	c := &client{name: "cc"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sse))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(context.Background(), resp, ch)
+
+	var sawDone, sawErr bool
+	var call *provider.ToolCall
+	var usage *provider.Usage
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkToolCall:
+			call = ck.ToolCall
+		case provider.ChunkUsage:
+			usage = ck.Usage
+		case provider.ChunkDone:
+			sawDone = true
+		case provider.ChunkError:
+			sawErr = true
+			t.Fatalf("tool_use stop_reason without message_stop should complete: %v", ck.Err)
+		}
+	}
+	if sawErr || !sawDone {
+		t.Fatalf("done=%v err=%v", sawDone, sawErr)
+	}
+	if call == nil || call.ID != "toolu_1" || call.Name != "bash" || call.Arguments != `{"cmd":"ls"}` {
+		t.Fatalf("tool call = %+v", call)
+	}
+	if usage == nil || usage.FinishReason != "tool_calls" {
+		t.Fatalf("usage = %+v, want finish_reason=tool_calls", usage)
+	}
+}
+
+func TestStreamScanEndErrorClassifiesTerminal(t *testing.T) {
+	if err := streamScanEndError("cc", time.Second, false, nil, "end_turn"); err != nil {
+		t.Fatalf("stop_reason must commit: %v", err)
+	}
+	err := streamScanEndError("cc", time.Second, false, nil, "")
+	if !provider.IsStreamInterrupted(err) {
+		t.Fatalf("empty stop_reason = %v, want interrupt", err)
+	}
+	if !strings.Contains(err.Error(), "stream ended before message_stop") {
+		t.Fatalf("interrupt = %v", err)
+	}
+	if err := streamScanEndError("cc", time.Second, true, nil, ""); !provider.IsStreamInterrupted(err) ||
+		provider.StreamInterruptReason(err) != provider.StreamInterruptIdleTimeout {
+		t.Fatalf("stall = %v", err)
+	}
+}
+
+func TestReadStreamStillInterruptsWithoutStopReasonOrMessageStop(t *testing.T) {
+	sse := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":5}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+`
+	c := &client{name: "cc"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sse))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(context.Background(), resp, ch)
+
+	var gotInterrupted, sawDone bool
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkDone:
+			sawDone = true
+		case provider.ChunkError:
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(ck.Err, &interrupted)
+		}
+	}
+	if sawDone {
+		t.Fatal("must not emit ChunkDone without message_stop or stop_reason")
+	}
+	if !gotInterrupted {
+		t.Fatal("EOF without stop_reason must stay StreamInterruptedError")
+	}
+}


### PR DESCRIPTION
## Summary

Compatible Anthropic gateways can finish a turn with `message_delta.stop_reason` and then close the SSE body without `message_stop`. Reasonix treated that clean EOF as an uncommitted interrupt, discarded a complete response, and exact-replayed the frozen request until recovery exhausted. Users then saw `model stream interrupted after recovery attempts: … stream ended before message_stop`.

This matches the existing OpenAI rule: `finish_reason` is enough even when `[DONE]` is omitted.

- Extract post-scan classification into `streamScanEndError`.
- A non-empty `stop_reason` (`end_turn`, `tool_use`, `max_tokens`, …) finalizes the attempt, including already-closed tool blocks.
- EOF with neither `stop_reason` nor `message_stop` still stays uncommitted, so speculative tool calls do not execute.

## Issues

No linked issue. User report: stream recovery exhausted with `stream ended before message_stop: unexpected EOF`.

## Verification

- `go test ./internal/provider/anthropic/`
- `go test -race ./internal/provider/anthropic/ -run 'TestReadStream|TestStreamScanEndError'`
- `go vet ./internal/provider/anthropic/`
- `go run ./tools/repolint`
- Live OpenCode Go smoke (Chat Completions, Anthropic Messages, Responses) completed without `StreamInterruptedError`. OpenCode Go itself emits `message_stop`; the new fixture covers gateways that omit it after `stop_reason`.

## Documentation impact

Documentation-impact: none - existing docs describe stream recovery after a genuine cut; they do not claim `message_stop` is the only legal Anthropic terminal, and the user-visible exhausted-recovery error still applies when neither `stop_reason` nor `message_stop` arrives.

## Cache impact

Cache-impact: none - stream terminal classification only; provider-visible prefix, tools, and request serialization are unchanged
Cache-guard: go test ./internal/provider/anthropic/ -run 'TestReadStreamAcceptsStopReasonWithoutMessageStop|TestReadStreamRequiresMessageStop|TestStreamScanEndErrorClassifiesTerminal'
System-prompt-review: N/A
