### PR TITLE
fix(desktop): persist completed todo dismissals on the session / 关闭待办写入会话文件

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6700,6 +6700,8 @@ type Meta struct {
 	GoalRuntime *GoalRuntimeView `json:"goalRuntime,omitempty"`
 	// Nil means no authoritative snapshot; non-nil empty means clear the panel.
 	CanonicalTodos *[]evidence.TodoItem `json:"canonicalTodos,omitempty"`
+	// Closed completed todo fingerprints from this session and its lineage.
+	DismissedTodoBatches []string `json:"dismissedTodoBatches,omitempty"`
 }
 
 type GoalRuntimeView struct {
@@ -6799,30 +6801,31 @@ func (a *App) MetaForTab(tabID string) Meta {
 		sessionDigest = branchMeta.ContentDigest
 	}
 	return Meta{
-		Label:             snap.label,
-		Ready:             runtimeView.Phase == sessionRuntimeReady && snap.ctrl != nil,
-		Runtime:           runtimeView,
-		StartupErr:        snap.startupErr,
-		EventChannel:      eventChannel,
-		SessionPath:       sessionPath,
-		SessionRevision:   sessionRevision,
-		SessionDigest:     sessionDigest,
-		Cwd:               cwd,
-		WorkspaceRoot:     cwd,
-		WorkspaceName:     tabWorkspaceNameForScope(snap.scope, cwd),
-		WorkspacePath:     cwd,
-		GitBranch:         extras.gitBranch,
-		ImageInputEnabled: extras.imageInputEnabled,
-		AutoApproveTools:  autoApproveTools,
-		Bypass:            autoApproveTools,
-		CollaborationMode: collaborationMode,
-		ToolApprovalMode:  toolApprovalMode,
-		AgentPreset:       boot.NormalizeAgentPreset(tokenMode),
-		TokenMode:         tokenMode,
-		Goal:              goal,
-		GoalStatus:        goalStatus,
-		GoalRuntime:       goalRuntimeViewFromController(snap.ctrl),
-		CanonicalTodos:    ctrlTodos(snap.ctrl),
+		Label:                snap.label,
+		Ready:                runtimeView.Phase == sessionRuntimeReady && snap.ctrl != nil,
+		Runtime:              runtimeView,
+		StartupErr:           snap.startupErr,
+		EventChannel:         eventChannel,
+		SessionPath:          sessionPath,
+		SessionRevision:      sessionRevision,
+		SessionDigest:        sessionDigest,
+		Cwd:                  cwd,
+		WorkspaceRoot:        cwd,
+		WorkspaceName:        tabWorkspaceNameForScope(snap.scope, cwd),
+		WorkspacePath:        cwd,
+		GitBranch:            extras.gitBranch,
+		ImageInputEnabled:    extras.imageInputEnabled,
+		AutoApproveTools:     autoApproveTools,
+		Bypass:               autoApproveTools,
+		CollaborationMode:    collaborationMode,
+		ToolApprovalMode:     toolApprovalMode,
+		AgentPreset:          boot.NormalizeAgentPreset(tokenMode),
+		TokenMode:            tokenMode,
+		Goal:                 goal,
+		GoalStatus:           goalStatus,
+		GoalRuntime:          goalRuntimeViewFromController(snap.ctrl),
+		CanonicalTodos:       ctrlTodos(snap.ctrl),
+		DismissedTodoBatches: a.dismissedTodoBatchesForSession(sessionPath),
 	}
 }
 

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -17,8 +17,10 @@ const transpiled = ts.transpileModule(source, {
 
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
 const {
+  dismissedCompletedTodoKey,
   dismissedTodoKeyForScope,
   resolveTodoPanelTodos,
+  sameStringList,
   sameTodoList,
   scopedTodoBatchKey,
   scopedTodoDismissalKey,
@@ -161,6 +163,30 @@ assert.equal(
   true,
   "an incomplete restored todo list must reappear even after a stale local dismissal",
 );
+assert.equal(
+  shouldShowTodoPanel(activeKey, null, activeTodos, { batchKey: todoBatchKey(activeTodos), batches: [todoBatchKey(activeTodos)] }),
+  true,
+  "a persisted completed-batch dismissal cannot hide unfinished work",
+);
+const remounted = dismissedCompletedTodoKey("session:leaf.jsonl", dismissedBySession, completedKey);
+assert.equal(
+  remounted,
+  completedKey,
+  "a completed dismissal survives a session-path remount in local storage",
+);
+assert.equal(
+  shouldShowTodoPanel(completedKey, remounted, completedTodos),
+  false,
+  "the remounted completed fingerprint stays hidden",
+);
+const completedBatch = todoBatchKey(completedTodos);
+assert.equal(
+  shouldShowTodoPanel(completedKey, null, completedTodos, { batchKey: completedBatch, batches: [completedBatch] }),
+  false,
+  "a session-sidecar batch dismissal hides the completed shelf after upgrade remount",
+);
+assert.equal(sameStringList(["a"], ["a"]), true, "identical dismissed batch lists compare equal");
+assert.equal(sameStringList(["a"], ["b"]), false, "changed dismissed batch lists compare unequal");
 assert.notEqual(
   activeKey,
   todoDismissalKey([{ ...activeTodos[0], status: "completed" }, { ...activeTodos[1], status: "in_progress" }]),

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -17,7 +17,6 @@ const transpiled = ts.transpileModule(source, {
 
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
 const {
-  dismissedCompletedTodoKey,
   dismissedTodoKeyForScope,
   resolveTodoPanelTodos,
   sameStringList,
@@ -167,17 +166,6 @@ assert.equal(
   shouldShowTodoPanel(activeKey, null, activeTodos, { batchKey: todoBatchKey(activeTodos), batches: [todoBatchKey(activeTodos)] }),
   true,
   "a persisted completed-batch dismissal cannot hide unfinished work",
-);
-const remounted = dismissedCompletedTodoKey("session:leaf.jsonl", dismissedBySession, completedKey);
-assert.equal(
-  remounted,
-  completedKey,
-  "a completed dismissal survives a session-path remount in local storage",
-);
-assert.equal(
-  shouldShowTodoPanel(completedKey, remounted, completedTodos),
-  false,
-  "the remounted completed fingerprint stays hidden",
 );
 const completedBatch = todoBatchKey(completedTodos);
 assert.equal(

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -81,7 +81,7 @@ import { useTerminalStore } from "./store/terminal";
 import { hydrateReasoningDisplayMode, setReasoningDisplayPending } from "./lib/reasoningDisplayPreference";
 import { parseTodos } from "./lib/tools";
 import {
-  dismissedTodoKeyForScope,
+  dismissedCompletedTodoKey,
   resolveTodoPanelTodos,
   scopedTodoBatchKey,
   scopedTodoDismissalKey,
@@ -2136,12 +2136,13 @@ export default function App() {
     [activeTab, activeTabId, state.meta?.eventChannel],
   );
   const dismissedTodo = useMemo(
-    () => dismissedTodoKeyForScope(todoScope, dismissedTodoKeys, todoKey),
+    () => dismissedCompletedTodoKey(todoScope, dismissedTodoKeys, todoKey),
     [dismissedTodoKeys, todoKey, todoScope],
   );
   const scopedTodoKey = useMemo(() => scopedTodoDismissalKey(todoScope, todoKey), [todoKey, todoScope]);
   const scopedTodoBatch = useMemo(() => scopedTodoBatchKey(todoScope, todoBatch), [todoBatch, todoScope]);
-  const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos);
+  const persistedTodoBatches = state.meta?.sessionPath === activeTab?.sessionPath ? state.meta?.dismissedTodoBatches : undefined;
+  const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos, { batchKey: todoBatch, batches: persistedTodoBatches });
   const dismissTodos = useCallback(() => {
     if (!scopedTodoKey) return;
     setDismissedTodoKeys((current) => {
@@ -2151,7 +2152,10 @@ export default function App() {
       saveDismissedTodoKeys(next);
       return next;
     });
-  }, [scopedTodoKey]);
+    if (activeTabId && todoBatch) {
+      void app.DismissTodoBatchForTab(activeTabId, todoBatch).catch(() => undefined);
+    }
+  }, [activeTabId, scopedTodoKey, todoBatch]);
 
   const sessionTitle = topicTitle(activeTab);
   const sessionHasContent = state.items.length > 0 || Boolean(state.live?.text || state.live?.reasoning);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -81,7 +81,7 @@ import { useTerminalStore } from "./store/terminal";
 import { hydrateReasoningDisplayMode, setReasoningDisplayPending } from "./lib/reasoningDisplayPreference";
 import { parseTodos } from "./lib/tools";
 import {
-  dismissedCompletedTodoKey,
+  dismissedTodoKeyForScope,
   resolveTodoPanelTodos,
   scopedTodoBatchKey,
   scopedTodoDismissalKey,
@@ -2107,12 +2107,10 @@ export default function App() {
   // a stale local dismissal cannot hide work that still blocks final readiness;
   // every new list starts collapsed while its header keeps showing live progress
   // and the current task; completed lists can then be dismissed. The dismissal
-  // key is still based on stable todo content/state so history reloads
-  // do not resurrect the same finished list under a different event id. The
-  // batch key ignores status changes so progress within the same task list does
-  // not look like a brand-new task batch. Dismissal and open state are scoped to
-  // the active session/topic/tab so different projects and sessions do not hide
-  // or reopen each other's todo panels.
+  // key is still based on stable todo content/state so history reloads do not
+  // resurrect the same finished list under a different event id. The batch key
+  // ignores status so progress in the same list is not a new batch. Dismissal
+  // is scoped per session/topic/tab and also persisted on the session sidecar.
   const todoEntry = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const it = state.items[i];
@@ -2136,13 +2134,12 @@ export default function App() {
     [activeTab, activeTabId, state.meta?.eventChannel],
   );
   const dismissedTodo = useMemo(
-    () => dismissedCompletedTodoKey(todoScope, dismissedTodoKeys, todoKey),
+    () => dismissedTodoKeyForScope(todoScope, dismissedTodoKeys, todoKey),
     [dismissedTodoKeys, todoKey, todoScope],
   );
   const scopedTodoKey = useMemo(() => scopedTodoDismissalKey(todoScope, todoKey), [todoKey, todoScope]);
   const scopedTodoBatch = useMemo(() => scopedTodoBatchKey(todoScope, todoBatch), [todoBatch, todoScope]);
-  const persistedTodoBatches = state.meta?.sessionPath === activeTab?.sessionPath ? state.meta?.dismissedTodoBatches : undefined;
-  const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos, { batchKey: todoBatch, batches: persistedTodoBatches });
+  const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos, { batchKey: todoBatch, batches: state.meta?.sessionPath === activeTab?.sessionPath ? state.meta?.dismissedTodoBatches : undefined });
   const dismissTodos = useCallback(() => {
     if (!scopedTodoKey) return;
     setDismissedTodoKeys((current) => {
@@ -2152,9 +2149,7 @@ export default function App() {
       saveDismissedTodoKeys(next);
       return next;
     });
-    if (activeTabId && todoBatch) {
-      void app.DismissTodoBatchForTab(activeTabId, todoBatch).catch(() => undefined);
-    }
+    if (activeTabId && todoBatch) void app.DismissTodoBatchForTab(activeTabId, todoBatch).catch(() => undefined);
   }, [activeTabId, scopedTodoKey, todoBatch]);
 
   const sessionTitle = topicTitle(activeTab);

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -394,6 +394,16 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
     true,
     "equivalent empty canonical todo lists keep meta stable",
   );
+  eq(
+    sameMeta(meta({ dismissedTodoBatches: ["a"] }), meta({ dismissedTodoBatches: ["a"] })),
+    true,
+    "identical dismissed todo batches keep meta stable",
+  );
+  eq(
+    sameMeta(meta({ dismissedTodoBatches: ["a"] }), meta({ dismissedTodoBatches: ["b"] })),
+    false,
+    "persisted todo dismissal changes invalidate meta equality",
+  );
 }
 
 {
@@ -403,6 +413,10 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   const todos = [{ content: "Keep task state", status: "in_progress" }];
   const withTodos = metaFromTab(tab(), meta({ canonicalTodos: todos }));
   eq(withTodos.canonicalTodos, todos, "optimistic tab metadata preserves canonical todos for the same session");
+  const dismissed = metaFromTab(tab({ sessionPath: "/s/a.jsonl" }), meta({ sessionPath: "/s/a.jsonl", dismissedTodoBatches: ["done"] }));
+  eq(dismissed.dismissedTodoBatches?.[0], "done", "optimistic metadata keeps session-sidecar todo dismissals");
+  const remounted = metaFromTab(tab({ sessionPath: "/s/leaf.jsonl" }), meta({ sessionPath: "/s/a.jsonl", dismissedTodoBatches: ["done"] }));
+  eq(remounted.dismissedTodoBatches, undefined, "a session remount waits for the new sidecar dismissals");
 }
 
 {
@@ -411,8 +425,10 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   const updated = reducer({ ...initialState, meta: before }, { type: "meta", meta: completed });
   eq(updated.meta?.canonicalTodos?.[0]?.status, "completed", "meta refresh applies canonical todo progress");
 
-  const reset = reducer(updated, { type: "reset" });
+  const withDismissed = reducer(updated, { type: "meta", meta: meta({ canonicalTodos: completed.canonicalTodos, dismissedTodoBatches: ["done"] }) });
+  const reset = reducer(withDismissed, { type: "reset" });
   eq(reset.meta?.canonicalTodos, undefined, "session reset clears canonical todos from the previous session");
+  eq(reset.meta?.dismissedTodoBatches, undefined, "session reset clears persisted todo dismissals from the previous session");
 
   const cleared = reducer(reset, { type: "meta", meta: meta({ canonicalTodos: [] }) });
   eq(cleared.meta?.canonicalTodos?.length, 0, "authoritative empty canonical todos survive meta refresh");

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -363,8 +363,7 @@ export interface AppBindings extends SessionCatalogBindings, HistoryCatalogBindi
   CloseTabWithPolicy(tabID: string, policy: "keep_running" | "stop_and_close"): Promise<void>;
   ToolResultForTab(tabID: string, toolID: string): Promise<{ args: string; output: string; execution?: import("./types").WireShellExecution } | null>;
   Meta(): Promise<Meta>;
-  MetaForTab(tabID: string): Promise<Meta>;
-  DismissTodoBatchForTab(tabID: string, batchKey: string): Promise<void>;
+  MetaForTab(tabID: string): Promise<Meta>; DismissTodoBatchForTab(tabID: string, batchKey: string): Promise<void>;
   Commands(): Promise<CommandInfo[]>;
   Capabilities(): Promise<CapabilitiesView>;
   MCPServers(): Promise<ServerView[]>;
@@ -3486,8 +3485,7 @@ function makeMockApp(): AppBindings {
             goal: active?.goal ?? "",
             goalStatus: active?.goalStatus ?? (active?.goal ? "running" : "stopped"),
           };
-        },
-        async DismissTodoBatchForTab() {},
+        }, async DismissTodoBatchForTab() {},
         async MetaForTab(tabID) {
           const tab = mockTabs.find((item) => item.id === tabID) ?? mockTabs.find((item) => item.active) ?? mockTabs[0];
           const toolApprovalMode = normalizeToolApprovalMode(tab?.toolApprovalMode, tab ? normalizeMode(tab.mode) : "normal", settings.autoApproveTools);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -364,6 +364,7 @@ export interface AppBindings extends SessionCatalogBindings, HistoryCatalogBindi
   ToolResultForTab(tabID: string, toolID: string): Promise<{ args: string; output: string; execution?: import("./types").WireShellExecution } | null>;
   Meta(): Promise<Meta>;
   MetaForTab(tabID: string): Promise<Meta>;
+  DismissTodoBatchForTab(tabID: string, batchKey: string): Promise<void>;
   Commands(): Promise<CommandInfo[]>;
   Capabilities(): Promise<CapabilitiesView>;
   MCPServers(): Promise<ServerView[]>;
@@ -3486,6 +3487,7 @@ function makeMockApp(): AppBindings {
             goalStatus: active?.goalStatus ?? (active?.goal ? "running" : "stopped"),
           };
         },
+        async DismissTodoBatchForTab() {},
         async MetaForTab(tabID) {
           const tab = mockTabs.find((item) => item.id === tabID) ?? mockTabs.find((item) => item.active) ?? mockTabs[0];
           const toolApprovalMode = normalizeToolApprovalMode(tab?.toolApprovalMode, tab ? normalizeMode(tab.mode) : "normal", settings.autoApproveTools);

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -76,6 +76,23 @@ export function dismissedTodoKeyForScope(
   return todoKey ?? null;
 }
 
+export function dismissedCompletedTodoKey(
+  scope: string | null | undefined,
+  dismissedKeys: ReadonlySet<string> | null | undefined,
+  todoKey: string | null | undefined,
+): string | null {
+  const exact = dismissedTodoKeyForScope(scope, dismissedKeys, todoKey);
+  if (exact) return exact;
+  const key = String(todoKey ?? "").trim();
+  if (!key || !dismissedKeys?.size) return null;
+  if (dismissedKeys.has(key)) return key;
+  const suffix = `\0${key}`;
+  for (const stored of dismissedKeys) {
+    if (stored.endsWith(suffix)) return key;
+  }
+  return null;
+}
+
 export function todoBatchKey(todos: Todo[]): string {
   if (todos.length === 0) return "";
   return JSON.stringify(todos.map((todo) => ({
@@ -95,10 +112,21 @@ export function shouldShowTodoPanel(
   todoKey: string | null | undefined,
   dismissedTodoKey: string | null,
   todos: Todo[],
+  persisted?: { batchKey?: string | null; batches?: readonly string[] | null },
 ): boolean {
   if (!todoKey || todos.length === 0) return false;
   if (hasIncompleteTodos(todos)) return true;
-  return todoKey !== dismissedTodoKey;
+  if (todoKey === dismissedTodoKey) return false;
+  const batchKey = String(persisted?.batchKey ?? "").trim();
+  if (batchKey && persisted?.batches?.includes(batchKey)) return false;
+  return true;
+}
+
+export function sameStringList(a?: readonly string[] | null, b?: readonly string[] | null): boolean {
+  if (a === b) return true;
+  const left = Array.isArray(a) ? a : [];
+  const right = Array.isArray(b) ? b : [];
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 export function shouldOpenTodoPanelByDefault(): boolean {

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -76,23 +76,6 @@ export function dismissedTodoKeyForScope(
   return todoKey ?? null;
 }
 
-export function dismissedCompletedTodoKey(
-  scope: string | null | undefined,
-  dismissedKeys: ReadonlySet<string> | null | undefined,
-  todoKey: string | null | undefined,
-): string | null {
-  const exact = dismissedTodoKeyForScope(scope, dismissedKeys, todoKey);
-  if (exact) return exact;
-  const key = String(todoKey ?? "").trim();
-  if (!key || !dismissedKeys?.size) return null;
-  if (dismissedKeys.has(key)) return key;
-  const suffix = `\0${key}`;
-  for (const stored of dismissedKeys) {
-    if (stored.endsWith(suffix)) return key;
-  }
-  return null;
-}
-
 export function todoBatchKey(todos: Todo[]): string {
   if (todos.length === 0) return "";
   return JSON.stringify(todos.map((todo) => ({

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -938,6 +938,7 @@ export interface Meta {
   goalStatus?: GoalStatus;
   goalRuntime?: GoalRuntime;
   canonicalTodos?: Todo[];
+  dismissedTodoBatches?: string[];
 }
 
 export type CollaborationMode = "normal" | "plan" | "goal";

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -937,8 +937,7 @@ export interface Meta {
   goal?: string;
   goalStatus?: GoalStatus;
   goalRuntime?: GoalRuntime;
-  canonicalTodos?: Todo[];
-  dismissedTodoBatches?: string[];
+  canonicalTodos?: Todo[]; dismissedTodoBatches?: string[];
 }
 
 export type CollaborationMode = "normal" | "plan" | "goal";

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -21,7 +21,7 @@ import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceh
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
-import { sameTodoList } from "./todoVisibility";
+import { sameStringList, sameTodoList } from "./todoVisibility";
 import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
 import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
@@ -571,6 +571,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     (tab.toolApprovalMode ?? "").trim() === "" ? existing?.toolApprovalMode : undefined,
   );
   const autoApproveTools = toolApprovalMode === "yolo";
+  const sessionPath = tab.sessionPath !== undefined ? tab.sessionPath : existing?.sessionPath;
   return {
     label: tab.label || existing?.label || "",
     ready: tab.ready,
@@ -581,7 +582,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     workspaceRoot: tab.workspaceRoot || existing?.workspaceRoot || cwd,
     workspaceName: tab.workspaceName || existing?.workspaceName,
     workspacePath: tab.workspacePath || tab.workspaceRoot || existing?.workspacePath,
-    sessionPath: tab.sessionPath !== undefined ? tab.sessionPath : existing?.sessionPath,
+    sessionPath,
     sessionRevision: tab.sessionRevision !== undefined ? tab.sessionRevision : existing?.sessionRevision,
     sessionDigest: tab.sessionDigest !== undefined ? tab.sessionDigest : existing?.sessionDigest,
     sessionGeneration: tab.sessionGeneration !== undefined ? tab.sessionGeneration : existing?.sessionGeneration,
@@ -594,6 +595,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     goal: tab.goal ?? existing?.goal,
     goalStatus: tab.goalStatus ?? existing?.goalStatus,
     canonicalTodos: existing?.canonicalTodos,
+    dismissedTodoBatches: sessionPath === existing?.sessionPath ? existing?.dismissedTodoBatches : undefined,
   };
 }
 function countsTowardCurrentTurn(state: State): boolean {
@@ -633,7 +635,8 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
     a.tokenMode === b.tokenMode &&
     a.goal === b.goal &&
     a.goalStatus === b.goalStatus &&
-    sameTodoList(a.canonicalTodos, b.canonicalTodos)
+    sameTodoList(a.canonicalTodos, b.canonicalTodos) &&
+    sameStringList(a.dismissedTodoBatches, b.dismissedTodoBatches)
   );
 }
 
@@ -677,8 +680,8 @@ export function composerProfileApplicationKey(
 }
 
 function metaWithoutCanonicalTodos(meta?: Meta): Meta | undefined {
-  if (!meta || meta.canonicalTodos === undefined) return meta;
-  return { ...meta, canonicalTodos: undefined };
+  if (!meta || (meta.canonicalTodos === undefined && meta.dismissedTodoBatches === undefined)) return meta;
+  return { ...meta, canonicalTodos: undefined, dismissedTodoBatches: undefined };
 }
 
 const STALE_TURN_RECONCILE_MS = 30_000;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -571,7 +571,6 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     (tab.toolApprovalMode ?? "").trim() === "" ? existing?.toolApprovalMode : undefined,
   );
   const autoApproveTools = toolApprovalMode === "yolo";
-  const sessionPath = tab.sessionPath !== undefined ? tab.sessionPath : existing?.sessionPath;
   return {
     label: tab.label || existing?.label || "",
     ready: tab.ready,
@@ -582,7 +581,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     workspaceRoot: tab.workspaceRoot || existing?.workspaceRoot || cwd,
     workspaceName: tab.workspaceName || existing?.workspaceName,
     workspacePath: tab.workspacePath || tab.workspaceRoot || existing?.workspacePath,
-    sessionPath,
+    sessionPath: tab.sessionPath !== undefined ? tab.sessionPath : existing?.sessionPath,
     sessionRevision: tab.sessionRevision !== undefined ? tab.sessionRevision : existing?.sessionRevision,
     sessionDigest: tab.sessionDigest !== undefined ? tab.sessionDigest : existing?.sessionDigest,
     sessionGeneration: tab.sessionGeneration !== undefined ? tab.sessionGeneration : existing?.sessionGeneration,
@@ -594,8 +593,7 @@ export function metaFromTab(tab: TabMeta, existing?: Meta): Meta {
     tokenMode: tab.tokenMode ?? existing?.tokenMode ?? "full",
     goal: tab.goal ?? existing?.goal,
     goalStatus: tab.goalStatus ?? existing?.goalStatus,
-    canonicalTodos: existing?.canonicalTodos,
-    dismissedTodoBatches: sessionPath === existing?.sessionPath ? existing?.dismissedTodoBatches : undefined,
+    canonicalTodos: existing?.canonicalTodos, dismissedTodoBatches: (tab.sessionPath !== undefined ? tab.sessionPath : existing?.sessionPath) === existing?.sessionPath ? existing?.dismissedTodoBatches : undefined,
   };
 }
 function countsTowardCurrentTurn(state: State): boolean {
@@ -635,8 +633,7 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
     a.tokenMode === b.tokenMode &&
     a.goal === b.goal &&
     a.goalStatus === b.goalStatus &&
-    sameTodoList(a.canonicalTodos, b.canonicalTodos) &&
-    sameStringList(a.dismissedTodoBatches, b.dismissedTodoBatches)
+    sameTodoList(a.canonicalTodos, b.canonicalTodos) && sameStringList(a.dismissedTodoBatches, b.dismissedTodoBatches)
   );
 }
 

--- a/desktop/todo_dismissal.go
+++ b/desktop/todo_dismissal.go
@@ -30,7 +30,7 @@ func (a *App) DismissTodoBatchForTab(tabID, batchKey string) error {
 	return firstErr
 }
 
-func (a *App) todoDismissalPersistPaths(sessionPath string) []string {
+func (a *App) todoDismissalReadPaths(sessionPath string) []string {
 	sessionPath = strings.TrimSpace(sessionPath)
 	if sessionPath == "" {
 		return nil
@@ -39,6 +39,11 @@ func (a *App) todoDismissalPersistPaths(sessionPath string) []string {
 	if parent := parentSessionPathForTodoDismissal(sessionPath); parent != "" {
 		paths = append(paths, parent)
 	}
+	return uniqueExistingSessionPaths(paths)
+}
+
+func (a *App) todoDismissalPersistPaths(sessionPath string) []string {
+	paths := a.todoDismissalReadPaths(sessionPath)
 	if a != nil {
 		if leaf := strings.TrimSpace(a.continuePathForOpen(sessionPath)); leaf != "" {
 			paths = append(paths, leaf)
@@ -49,7 +54,7 @@ func (a *App) todoDismissalPersistPaths(sessionPath string) []string {
 
 func (a *App) dismissedTodoBatchesForSession(sessionPath string) []string {
 	var sets [][]string
-	for _, path := range a.todoDismissalPersistPaths(sessionPath) {
+	for _, path := range a.todoDismissalReadPaths(sessionPath) {
 		sets = append(sets, agent.DismissedTodoBatches(path))
 	}
 	out := agent.MergeDismissedTodoBatches(sets...)
@@ -65,10 +70,22 @@ func parentSessionPathForTodoDismissal(sessionPath string) string {
 		return ""
 	}
 	parentID := strings.TrimSpace(meta.ParentID)
-	if parentID == "" || parentID == agent.BranchID(sessionPath) {
+	if !safeTodoDismissalParentID(parentID) || parentID == agent.BranchID(sessionPath) {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(sessionPath), parentID+".jsonl")
+	dir := filepath.Clean(filepath.Dir(sessionPath))
+	candidate := filepath.Join(dir, parentID+".jsonl")
+	if filepath.Dir(filepath.Clean(candidate)) != dir {
+		return ""
+	}
+	return candidate
+}
+
+func safeTodoDismissalParentID(parentID string) bool {
+	if parentID == "" || parentID == "." || parentID == ".." {
+		return false
+	}
+	return filepath.Base(parentID) == parentID && !strings.ContainsAny(parentID, `/\`)
 }
 
 func uniqueExistingSessionPaths(paths []string) []string {

--- a/desktop/todo_dismissal.go
+++ b/desktop/todo_dismissal.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/agent"
+)
+
+// DismissTodoBatchForTab records a closed completed todo list on the session
+// sidecar (and its parent/covering leaf) so the shelf stays hidden after an
+// upgrade remounts the same conversation on a different path.
+func (a *App) DismissTodoBatchForTab(tabID, batchKey string) error {
+	tab := a.tabByID(tabID)
+	if tab == nil {
+		return a.workspaceNotReadyErr(nil)
+	}
+	sessionPath := strings.TrimSpace(tab.currentSessionPath())
+	batchKey = strings.TrimSpace(batchKey)
+	if sessionPath == "" || batchKey == "" {
+		return nil
+	}
+	var firstErr error
+	for _, path := range a.todoDismissalPersistPaths(sessionPath) {
+		if err := agent.RecordDismissedTodoBatch(path, batchKey); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (a *App) todoDismissalPersistPaths(sessionPath string) []string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return nil
+	}
+	paths := []string{sessionPath}
+	if parent := parentSessionPathForTodoDismissal(sessionPath); parent != "" {
+		paths = append(paths, parent)
+	}
+	if a != nil {
+		if leaf := strings.TrimSpace(a.continuePathForOpen(sessionPath)); leaf != "" {
+			paths = append(paths, leaf)
+		}
+	}
+	return uniqueExistingSessionPaths(paths)
+}
+
+func (a *App) dismissedTodoBatchesForSession(sessionPath string) []string {
+	var sets [][]string
+	for _, path := range a.todoDismissalPersistPaths(sessionPath) {
+		sets = append(sets, agent.DismissedTodoBatches(path))
+	}
+	out := agent.MergeDismissedTodoBatches(sets...)
+	if out == nil {
+		return []string{}
+	}
+	return out
+}
+
+func parentSessionPathForTodoDismissal(sessionPath string) string {
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return ""
+	}
+	parentID := strings.TrimSpace(meta.ParentID)
+	if parentID == "" || parentID == agent.BranchID(sessionPath) {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(sessionPath), parentID+".jsonl")
+}
+
+func uniqueExistingSessionPaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		key := agent.CanonicalSessionPath(path)
+		if key == "" {
+			key = path
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		if _, err := os.Stat(path); err != nil {
+			if _, metaErr := os.Stat(agent.BranchMetaPath(path)); metaErr != nil {
+				continue
+			}
+		}
+		seen[key] = struct{}{}
+		out = append(out, path)
+	}
+	return out
+}

--- a/desktop/todo_dismissal_test.go
+++ b/desktop/todo_dismissal_test.go
@@ -104,3 +104,59 @@ func TestDismissTodoBatchSkipsMissingTab(t *testing.T) {
 		t.Fatal("missing tab should fail")
 	}
 }
+
+func TestMetaForTabDoesNotReadSiblingCoveringLeaf(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	if err := os.WriteFile(parent, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(leaf, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(parent, agent.BranchMeta{ID: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(leaf, agent.BranchMeta{
+		ID: "leaf", ParentID: "parent", DismissedTodoBatches: []string{`[{"content":"Ship"}]`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{"tab-1": {ID: "tab-1", SessionPath: parent, Ready: true}}
+	app.activeTabID = "tab-1"
+	if got := app.dismissedTodoBatchesForSession(parent); len(got) != 0 {
+		t.Fatalf("read path saw covering-leaf batches = %#v", got)
+	}
+}
+
+func TestParentSessionPathRejectsTraversal(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	outside := filepath.Join(filepath.Dir(dir), "escaped.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	if err := os.WriteFile(leaf, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(leaf, agent.BranchMeta{ID: "leaf", ParentID: filepath.Join("..", "escaped")}); err != nil {
+		t.Fatal(err)
+	}
+	if got := parentSessionPathForTodoDismissal(leaf); got != "" {
+		t.Fatalf("traversal parent = %q", got)
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{"tab-1": {ID: "tab-1", SessionPath: leaf}}
+	if err := app.DismissTodoBatchForTab("tab-1", `[{"content":"Ship"}]`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(agent.BranchMetaPath(outside)); !os.IsNotExist(err) {
+		t.Fatalf("traversal wrote outside the session dir: %v", err)
+	}
+	if !safeTodoDismissalParentID("parent") || safeTodoDismissalParentID("../escaped") || safeTodoDismissalParentID(`foo/bar`) {
+		t.Fatal("parent id sanitizer accepted a path-shaped id")
+	}
+}

--- a/desktop/todo_dismissal_test.go
+++ b/desktop/todo_dismissal_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+)
+
+func TestDismissTodoBatchPersistsOnSessionAndParent(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	if err := os.WriteFile(parent, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(leaf, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(leaf, agent.BranchMeta{ID: "leaf", ParentID: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{"tab-1": {ID: "tab-1", SessionPath: leaf}}
+	app.activeTabID = "tab-1"
+
+	if err := app.DismissTodoBatchForTab("tab-1", `[{"content":"Ship"}]`); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{leaf, parent} {
+		got, ok, err := agent.LoadBranchMeta(path)
+		if err != nil || !ok {
+			t.Fatalf("LoadBranchMeta(%s) = %+v ok=%v err=%v", path, got, ok, err)
+		}
+		if len(got.DismissedTodoBatches) != 1 || got.DismissedTodoBatches[0] != `[{"content":"Ship"}]` {
+			t.Fatalf("%s dismissed batches = %#v", path, got.DismissedTodoBatches)
+		}
+	}
+}
+
+func TestMetaForTabSurfacesParentDismissedTodoBatches(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "parent.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	if err := os.WriteFile(parent, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(leaf, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(parent, agent.BranchMeta{
+		ID: "parent", DismissedTodoBatches: []string{`[{"content":"Ship"}]`},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(leaf, agent.BranchMeta{ID: "leaf", ParentID: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{"tab-1": {ID: "tab-1", SessionPath: leaf, Ready: true}}
+	app.activeTabID = "tab-1"
+
+	got := app.dismissedTodoBatchesForSession(leaf)
+	if len(got) != 1 || got[0] != `[{"content":"Ship"}]` {
+		t.Fatalf("lineage batches = %#v", got)
+	}
+
+	meta := app.MetaForTab("tab-1")
+	if len(meta.DismissedTodoBatches) != 1 || meta.DismissedTodoBatches[0] != `[{"content":"Ship"}]` {
+		t.Fatalf("meta dismissed batches = %#v", meta.DismissedTodoBatches)
+	}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"dismissedTodoBatches"`) {
+		t.Fatalf("meta JSON missing dismissedTodoBatches: %s", raw)
+	}
+}
+
+func TestDismissedTodoBatchesEmptySliceNotNull(t *testing.T) {
+	meta := Meta{DismissedTodoBatches: []string{}}
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"dismissedTodoBatches":null`) {
+		t.Fatalf("empty dismissed batches encoded as null: %s", raw)
+	}
+}
+
+func TestDismissTodoBatchSkipsMissingTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	if err := app.DismissTodoBatchForTab("missing", "batch"); err == nil {
+		t.Fatal("missing tab should fail")
+	}
+}

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -74,6 +74,8 @@ type BranchMeta struct {
 	Turns        int               `json:"turns,omitempty"`
 	Preview      string            `json:"preview,omitempty"`
 	InFlightTurn *InFlightTurnMeta `json:"in_flight_turn,omitempty"`
+	// Closed completed todo shelves; desktop remounts hide the same fingerprint.
+	DismissedTodoBatches []string `json:"dismissed_todo_batches,omitempty"`
 }
 
 const (
@@ -298,6 +300,7 @@ func preserveBranchMetaPersistence(next *BranchMeta, existing BranchMeta) {
 	if next == nil {
 		return
 	}
+	next.DismissedTodoBatches = MergeDismissedTodoBatches(existing.DismissedTodoBatches, next.DismissedTodoBatches)
 	if existing.Revision > next.Revision {
 		next.Revision = existing.Revision
 		next.ContentDigest = existing.ContentDigest

--- a/internal/agent/todo_dismissal.go
+++ b/internal/agent/todo_dismissal.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"os"
+	"strings"
+)
+
+const maxDismissedTodoBatches = 160
+
+// RecordDismissedTodoBatch appends a completed todo-list fingerprint to the
+// session sidecar so desktop can hide that shelf after an upgrade remount.
+func RecordDismissedTodoBatch(sessionPath, batch string) error {
+	sessionPath = strings.TrimSpace(sessionPath)
+	batch = strings.TrimSpace(batch)
+	if sessionPath == "" || batch == "" {
+		return nil
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		if _, metaErr := os.Stat(BranchMetaPath(sessionPath)); metaErr != nil {
+			return nil
+		}
+	}
+	return UpdateBranchMeta(sessionPath, false, func(m *BranchMeta) error {
+		m.DismissedTodoBatches = AppendDismissedTodoBatch(m.DismissedTodoBatches, batch)
+		return nil
+	})
+}
+
+func AppendDismissedTodoBatch(existing []string, key string) []string {
+	return MergeDismissedTodoBatches(existing, []string{key})
+}
+
+func MergeDismissedTodoBatches(sets ...[]string) []string {
+	n := 0
+	for _, set := range sets {
+		n += len(set)
+	}
+	all := make([]string, 0, n)
+	for _, set := range sets {
+		all = append(all, set...)
+	}
+	return NormalizeDismissedTodoBatches(all)
+}
+
+func NormalizeDismissedTodoBatches(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	if len(out) > maxDismissedTodoBatches {
+		out = out[len(out)-maxDismissedTodoBatches:]
+	}
+	return out
+}
+
+func DismissedTodoBatches(sessionPath string) []string {
+	meta, ok, err := LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return nil
+	}
+	return NormalizeDismissedTodoBatches(meta.DismissedTodoBatches)
+}

--- a/internal/agent/todo_dismissal_test.go
+++ b/internal/agent/todo_dismissal_test.go
@@ -96,7 +96,7 @@ func TestRecordDismissedTodoBatchSkipsMissingSession(t *testing.T) {
 
 func TestNormalizeDismissedTodoBatchesCapsAndDedups(t *testing.T) {
 	keys := []string{" keep ", "keep", ""}
-	for i := 0; i < maxDismissedTodoBatches+2; i++ {
+	for i := range maxDismissedTodoBatches + 2 {
 		keys = append(keys, "batch-"+strconv.Itoa(i))
 	}
 	got := NormalizeDismissedTodoBatches(keys)

--- a/internal/agent/todo_dismissal_test.go
+++ b/internal/agent/todo_dismissal_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRecordDismissedTodoBatchRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordDismissedTodoBatch(path, `[{"content":"Ship"}]`); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordDismissedTodoBatch(path, `[{"content":"Ship"}]`); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordDismissedTodoBatch(path, `[{"content":"Next"}]`); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta = %+v ok=%v err=%v", got, ok, err)
+	}
+	if len(got.DismissedTodoBatches) != 2 || got.DismissedTodoBatches[0] != `[{"content":"Ship"}]` || got.DismissedTodoBatches[1] != `[{"content":"Next"}]` {
+		t.Fatalf("dismissed batches = %#v", got.DismissedTodoBatches)
+	}
+}
+
+func TestSaveBranchMetaPreservesDismissedTodoBatches(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecordDismissedTodoBatch(path, "batch-a"); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMetaPreserveUpdated(path, BranchMeta{ID: "session", Name: "renamed"}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta = %+v ok=%v err=%v", got, ok, err)
+	}
+	if got.Name != "renamed" {
+		t.Fatalf("name = %q", got.Name)
+	}
+	if len(got.DismissedTodoBatches) != 1 || got.DismissedTodoBatches[0] != "batch-a" {
+		t.Fatalf("dismissed batches dropped: %#v", got.DismissedTodoBatches)
+	}
+}
+
+func TestOldBranchMetaWithoutDismissedBatchesStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	legacy := []byte("{\n  \"id\": \"session\",\n  \"name\": \"legacy\"\n}\n")
+	if err := os.WriteFile(BranchMetaPath(path), legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta = %+v ok=%v err=%v", got, ok, err)
+	}
+	if got.Name != "legacy" || len(got.DismissedTodoBatches) != 0 {
+		t.Fatalf("legacy meta = %+v", got)
+	}
+}
+
+func TestDismissedTodoBatchesOmitemptyOnEmpty(t *testing.T) {
+	raw, err := json.Marshal(BranchMeta{ID: "session"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "dismissed_todo_batches") {
+		t.Fatalf("empty dismissed batches should omit: %s", raw)
+	}
+}
+
+func TestRecordDismissedTodoBatchSkipsMissingSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.jsonl")
+	if err := RecordDismissedTodoBatch(path, "batch-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(BranchMetaPath(path)); !os.IsNotExist(err) {
+		t.Fatalf("missing session grew a sidecar: %v", err)
+	}
+}
+
+func TestNormalizeDismissedTodoBatchesCapsAndDedups(t *testing.T) {
+	keys := []string{" keep ", "keep", ""}
+	for i := 0; i < maxDismissedTodoBatches+2; i++ {
+		keys = append(keys, "batch-"+strconv.Itoa(i))
+	}
+	got := NormalizeDismissedTodoBatches(keys)
+	if len(got) != maxDismissedTodoBatches {
+		t.Fatalf("len = %d, want %d", len(got), maxDismissedTodoBatches)
+	}
+	if got[0] == "keep" || got[len(got)-1] != "batch-"+strconv.Itoa(maxDismissedTodoBatches+1) {
+		t.Fatalf("cap should keep the newest fingerprints: first=%q last=%q", got[0], got[len(got)-1])
+	}
+}


### PR DESCRIPTION
## Summary

Closing a completed desktop todo shelf now follows the session file, not only WebView2 `localStorage`. After an upgrade remounts the same conversation on a different path, or the WebView2 profile is reset, that finished shelf stays hidden. Incomplete lists still always show.

- Persist completed-list fingerprints on the session sidecar (`dismissed_todo_batches`)
- Copy them to the parent on close, and to a covering leaf only on that write
- `MetaForTab` reads only the current sidecar and a same-directory, filename-only parent
- Hide a completed shelf when the sidecar batch matches; localStorage stays session-scoped
- Keep `localStorage` as an optimistic cache

This is the durable half of #8755. #8728 already binds the latest covering leaf after upgrade; without sidecar persistence, a path remount or wiped WebView2 profile still resurrected the closed list.

Follow-up `b87536cf7` adopts the #8758 review: drop the catalog walk from the meta poll, restore session-scoped localStorage matching, reject path-shaped parent IDs, and stay inside the existing frontend file-size budgets.

## Issues

Fixes #8755

## Verification

- `go test ./internal/agent -count=1 -run 'TestRecordDismissedTodoBatch|TestSaveBranchMetaPreservesDismissed|TestOldBranchMetaWithoutDismissed|TestDismissedTodoBatchesOmitempty|TestNormalizeDismissedTodoBatches'`
- `cd desktop && go test -count=1 -run 'TestDismissTodoBatch|TestMetaForTabSurfacesParentDismissed|TestDismissedTodoBatchesEmptySlice|TestMetaForTabDoesNotReadSibling|TestParentSessionPathRejects'`
- `pnpm exec node scripts/test-todo-visibility.mjs`
- `pnpm exec tsx src/__tests__/use-controller-meta.test.ts`
- `go run ./tools/repolint`
- `scripts/check-cache-impact.sh` reported no cache-sensitive files

No Windows upgrade install was run in this change.

## Compatibility

| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| `dismissed_todo_batches` | Field absent | Treat as no persisted dismissals | Ignore unknown field | Compatible |
| Other `BranchMeta` fields | Unchanged | Unchanged | Unchanged | Compatible |
| Wails `dismissedTodoBatches` | Field absent | Treat as no persisted dismissals | Ignore unknown field | Compatible |

## Documentation impact

Documentation-impact: none - closing the completed todo shelf is existing desktop UI; this only changes where that close is stored. Embedded docs do not describe WebView2 localStorage as the source of truth.

## Cache impact

Cache-impact: none - desktop session sidecar and todo-shelf visibility only; provider-visible prefix, tools, and serialization are unchanged
Cache-guard: scripts/check-cache-impact.sh reported no cache-sensitive files; focused agent/desktop/frontend tests above
System-prompt-review: N/A
