### PR TITLE
fix(desktop): keep archive fallback blanks out of the sidebar / 归档后不再在侧栏冒出空白新会话

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -3,6 +3,8 @@
 import {
   projectTreeFolderDisclosure,
   mergeProjectTopicPage,
+  projectTreeWithoutTopic,
+  projectTreeShellChildren,
   projectTreeEventAffectsFolder,
   projectTreeRevisionIsFresh,
   projectTreeShouldApplyShellSnapshot,
@@ -26,6 +28,9 @@ import {
 } from "../components/ProjectTree";
 import { projectTreeTrashingTopics } from "../lib/projectTreeArchive";
 import type { ProjectNode } from "../lib/types";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 let passed = 0;
 let failed = 0;
@@ -696,6 +701,42 @@ eq(
   ).map((node) => `${node.key}:${node.label}`),
   ["topic-a:A", "topic-b:New B", "topic-c:C"],
   "overlapping keyset pages replace duplicates without changing stable order",
+);
+
+eq(
+  projectTreeWithoutTopic(
+    [
+      {
+        key: "p",
+        kind: "project",
+        label: "P",
+        children: [
+          { key: "topic_archive", kind: "topic", label: "Archive me", topicId: "topic_archive" },
+          { key: "topic_keep", kind: "topic", label: "Keep me", topicId: "topic_keep" },
+        ],
+      },
+    ],
+    "topic_archive",
+  ).map((node) => (node.children ?? []).map((child) => child.topicId)),
+  [["topic_keep"]],
+  "archiving a topic removes it from loaded children before the catalog reloads",
+);
+
+eq(
+  projectTreeShellChildren(
+    [{ key: "topic_archive", kind: "topic", label: "Archive me", topicId: "topic_archive" }],
+    { keepLoadedTopics: false },
+  ),
+  [],
+  "a mutation refresh does not restore stale topic children from the previous page",
+);
+
+const projectTreeSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../components/ProjectTree.tsx"), "utf8");
+eq(projectTreeSource.includes("projectTreeWithoutTopic("), true, "TrashTopic removes the archived row before the shell refresh");
+eq(
+  projectTreeSource.includes("keepLoadedTopics: false") || projectTreeSource.includes("reloadTopics"),
+  true,
+  "archive refresh reloads topic pages instead of preserving stale children",
 );
 
 eq(

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -10,7 +10,7 @@ import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
-import { isRuntimeSessionNode, isTopicNode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant } from "../lib/projectTreeTopic";
+import { isRuntimeSessionNode, isTopicNode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
 import type { ProjectNode, SessionCatalogStatus } from "../lib/types";
 import { topicActivityTime } from "../lib/session";
@@ -500,6 +500,7 @@ export function ProjectTree({
   }, []);
 
   const topicLoadSeqRef = useRef<Record<string, number>>({});
+  const loadProjectTopicsRef = useRef<(project: ProjectNode, append?: boolean) => Promise<void>>(async () => {});
 
   const loadProjectTopics = useCallback(async (project: ProjectNode, append = false) => {
     if (project.kind !== "project" && project.kind !== "global_folder") return;
@@ -537,9 +538,10 @@ export function ProjectTree({
       updateTopicPageState(key, { ...topicPageStateRef.current[key], loading: false });
     }
   }, [query, timeFilter, updateTopicPageState]);
+  loadProjectTopicsRef.current = loadProjectTopics;
   // Snapshot is intentionally shells-only. Preserve already loaded pages by
   // project key so a metadata refresh does not collapse or blank the sidebar.
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (options?: { reloadTopics?: boolean }) => {
     try {
       const snapshot = await app.GetProjectTreeSnapshot();
       const rev = snapshot.revision ?? 0, empty = treeRef.current.length === 0;
@@ -548,10 +550,16 @@ export function ProjectTree({
       const projects = asArray(snapshot.projects);
       setCatalogStatus(snapshot.catalog);
       setIndexingDone(Boolean(snapshot.indexingDone));
+      const keepLoadedTopics = !options?.reloadTopics;
       setTree((current) => projects.map((project) => {
         const previous = current.find((node) => node.key === project.key);
-        return { ...project, children: asArray(previous?.children) };
+        return { ...project, children: projectTreeShellChildren(previous?.children, { keepLoadedTopics }) };
       }));
+      if (options?.reloadTopics) {
+        for (const project of projects) {
+          void loadProjectTopicsRef.current(project);
+        }
+      }
     } catch {
       /* bridge unavailable */
     }
@@ -902,14 +910,16 @@ export function ProjectTree({
   const trashTopic = async (topicId: string) => {
     if (!beginTrashingTopic(topicId)) return;
     try {
+      setTree((current) => projectTreeWithoutTopic(current, topicId));
       await app.TrashTopic(topicId);
       setMenuTopic(null);
       setMenuPoint(null);
       setConfirmAction(null);
-      await refresh();
+      await refresh({ reloadTopics: true });
       await onTopicsChanged?.();
     } catch (err) {
       showToast(err instanceof Error ? err.message : String(err), "error");
+      await refresh({ reloadTopics: true });
     } finally {
       endTrashingTopic(topicId);
     }

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -44,6 +44,25 @@ export function mergeProjectTopicPage(current: ProjectNode[], incoming: ProjectN
   return next;
 }
 
+// After archive, drop that topic immediately so a shell-only refresh cannot
+// resurrect it from the previously loaded children.
+export function projectTreeWithoutTopic(tree: ProjectNode[], topicId: string): ProjectNode[] {
+  const id = topicId.trim();
+  if (!id) return tree;
+  return tree.map((node) => {
+    if (node.kind !== "project" && node.kind !== "global_folder") return node;
+    return { ...node, children: asArray(node.children).filter((child) => child.topicId !== id) };
+  });
+}
+
+export function projectTreeShellChildren(
+  previous: ProjectNode[] | undefined,
+  options: { keepLoadedTopics: boolean },
+): ProjectNode[] {
+  if (options.keepLoadedTopics) return asArray(previous);
+  return [];
+}
+
 export function projectTreeEventAffectsFolder(project: ProjectNode, roots: string[]): boolean {
   if (roots.length === 0) return true;
   const root = project.kind === "global_folder" ? "" : project.root ?? "";

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -373,6 +373,9 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 	})) {
 		return ProjectNode{Children: []ProjectNode{}}, false
 	}
+	if a.ordinaryTreeHidesUnindexedBlank(topic) {
+		return ProjectNode{Children: []ProjectNode{}}, false
+	}
 	// After filtering non-preferred recovery forks, a topic may have nothing
 	// left. Keep pinned/open shells; otherwise drop the empty row.
 	if len(visible) == 0 {
@@ -394,6 +397,21 @@ func (a *App) projectNodeFromCatalogTopic(topic sessioncatalog.TopicRecord, topi
 		node.SessionPath = visible[0].Path
 	}
 	return node, true
+}
+
+func (a *App) ordinaryTreeHidesUnindexedBlank(topic sessioncatalog.TopicRecord) bool {
+	if topic.Pinned || topic.Turns > 0 {
+		return false
+	}
+	if !isDefaultTopicTitle(topic.Title) && strings.TrimSpace(topic.Title) != "" {
+		return false
+	}
+	for _, session := range topic.Sessions {
+		if session.Turns > 0 || strings.TrimSpace(session.Preview) != "" {
+			return false
+		}
+	}
+	return !topicIndexedInRegistry(topic.Scope, topic.WorkspaceRoot, topic.TopicID)
 }
 
 func topicSummaryFromCatalogTopic(topic sessioncatalog.TopicRecord, visible []sessioncatalog.SessionRecord) topicSummary {

--- a/desktop/topic_archive.go
+++ b/desktop/topic_archive.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
+	"reasonix/internal/store"
 )
 
 var (
@@ -70,6 +72,19 @@ func (a *App) trashTopic(topicID string) (retErr error) {
 			slog.Warn("desktop: open fallback after topic archive failed")
 		}
 	}
+	keepPath := ""
+	a.mu.RLock()
+	if tab := a.tabs[a.activeTabID]; tab != nil {
+		keepPath = tab.SessionPath
+	}
+	if fallback.workspaceRoot != "" {
+		changedDirs = append(changedDirs, desktopSessionDir(fallback.workspaceRoot))
+	} else if fallback.needs {
+		changedDirs = append(changedDirs, desktopSessionDir(globalWorkspaceRoot()))
+	}
+	a.mu.RUnlock()
+	trace.phase = "discard_unused_blanks"
+	a.discardUnusedTransientBlankSessions(changedDirs, keepPath)
 	trace.phase = "notify"
 	if len(changedDirs) > 0 {
 		a.emitProjectTreeChangedForSessionDirs(changedDirs...)
@@ -267,4 +282,91 @@ func (a *App) topicTrashTargets(topicID string) ([]topicTrashTarget, error) {
 		}
 	}
 	return targets, nil
+}
+
+func topicIndexedInRegistry(scope, workspaceRoot, topicID string) bool {
+	topicID = strings.TrimSpace(topicID)
+	if topicID == "" {
+		return false
+	}
+	if strings.TrimSpace(loadTopicTitles(topicTitleRoot(scope, workspaceRoot))[topicID]) != "" {
+		return true
+	}
+	f := loadProjectsFile()
+	if scope != "project" {
+		return containsDesktopString(f.GlobalTopics, topicID)
+	}
+	if i := projectIndexByRoot(f.Projects, workspaceRoot); i >= 0 {
+		return containsDesktopString(f.Projects[i].Topics, topicID)
+	}
+	return false
+}
+
+func (a *App) discardUnusedTransientBlankSessions(dirs []string, keepPath string) {
+	keepPath = canonicalTabSessionPath(strings.TrimSpace(keepPath))
+	kept := map[string]bool{}
+	if keepPath != "" {
+		kept[keepPath] = true
+	}
+	if a != nil {
+		a.mu.RLock()
+		for _, tabs := range []map[string]*WorkspaceTab{a.tabs, a.detachedSessions} {
+			for _, tab := range tabs {
+				if tab == nil {
+					continue
+				}
+				if path := canonicalTabSessionPath(strings.TrimSpace(tab.SessionPath)); path != "" {
+					kept[path] = true
+				}
+			}
+		}
+		a.mu.RUnlock()
+	}
+	seen := map[string]bool{}
+	for _, dir := range dirs {
+		dir = strings.TrimSpace(dir)
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !store.IsSessionTranscriptName(name) {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			if kept[canonicalTabSessionPath(path)] {
+				continue
+			}
+			if !unusedTransientBlankSession(dir, path) {
+				continue
+			}
+			discardTransientBlankSessionArtifacts(path)
+			if a != nil {
+				a.removeSessionCatalogPath(path, "transient_blank_discarded")
+			}
+		}
+	}
+}
+
+func unusedTransientBlankSession(dir, path string) bool {
+	if !sessionPathHasNoContent(dir, path) {
+		return false
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		return true
+	}
+	topicID := strings.TrimSpace(meta.TopicID)
+	if topicID == "" {
+		return true
+	}
+	if !isDefaultTopicTitle(meta.TopicTitle) && strings.TrimSpace(meta.TopicTitle) != "" {
+		return false
+	}
+	return !topicIndexedInRegistry(meta.DefaultScope(), meta.WorkspaceRoot, topicID)
 }

--- a/desktop/topic_archive.go
+++ b/desktop/topic_archive.go
@@ -354,10 +354,15 @@ func (a *App) discardUnusedTransientBlankSessions(dirs []string, keepPath string
 }
 
 func unusedTransientBlankSession(dir, path string) bool {
-	if !sessionPathHasNoContent(dir, path) {
+	resolved, ok := pinnedTabSessionPath(dir, path)
+	if !ok {
 		return false
 	}
-	meta, ok, err := agent.LoadBranchMeta(path)
+	info, err := os.Stat(resolved)
+	if err != nil || info.IsDir() || info.Size() != 0 {
+		return false
+	}
+	meta, ok, err := agent.LoadBranchMeta(resolved)
 	if err != nil || !ok {
 		return true
 	}

--- a/desktop/topic_archive_test.go
+++ b/desktop/topic_archive_test.go
@@ -510,6 +510,13 @@ func TestTrashTopicFallbackStaysOffCatalogSidebar(t *testing.T) {
 	}
 	ghostID := agent.BranchID(filepath.Join(dir, "ghost-blank.jsonl"))
 	ghostPath := writeEmptyNamedSession(t, dir, "ghost-blank.jsonl", ghostID, defaultTopicTitle, projectRoot)
+	nonzeroPath := filepath.Join(dir, "system-only.jsonl")
+	if err := os.WriteFile(nonzeroPath, []byte(`{"role":"system","content":"identity"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write non-empty sibling: %v", err)
+	}
+	if err := pinNewEmptySessionBranchMeta(nonzeroPath, "project", projectRoot, "", defaultTopicTitle); err != nil {
+		t.Fatalf("pin non-empty sibling: %v", err)
+	}
 	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: archivePath, Label: "test", WorkspaceRoot: projectRoot})
 	defer ctrl.Close()
 	app := &App{
@@ -535,6 +542,9 @@ func TestTrashTopicFallbackStaysOffCatalogSidebar(t *testing.T) {
 	}
 	if _, err := os.Stat(keepPath); err != nil {
 		t.Fatalf("kept session missing: %v", err)
+	}
+	if _, err := os.Stat(nonzeroPath); err != nil {
+		t.Fatalf("non-empty sibling must not be swept, stat err = %v", err)
 	}
 	for _, path := range []string{leftoverA, leftoverB, ghostPath} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -568,6 +578,25 @@ func TestTrashTopicFallbackStaysOffCatalogSidebar(t *testing.T) {
 		if _, err := os.Stat(fallbackPath); err != nil {
 			t.Fatalf("current fallback blank should remain writable: %v", err)
 		}
+	}
+}
+
+func TestUnusedTransientBlankSessionOnlyMatchesZeroByteFiles(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := t.TempDir()
+	zero := filepath.Join(dir, "zero.jsonl")
+	if _, err := os.Create(zero); err != nil {
+		t.Fatalf("create zero-byte session: %v", err)
+	}
+	if !unusedTransientBlankSession(dir, zero) {
+		t.Fatal("zero-byte unindexed session should be an unused transient blank")
+	}
+	nonzero := filepath.Join(dir, "nonzero.jsonl")
+	if err := os.WriteFile(nonzero, []byte(`{"role":"system","content":"identity"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write non-empty session: %v", err)
+	}
+	if unusedTransientBlankSession(dir, nonzero) {
+		t.Fatal("non-empty session must not be classified as an unused transient blank")
 	}
 }
 

--- a/desktop/topic_archive_test.go
+++ b/desktop/topic_archive_test.go
@@ -501,9 +501,7 @@ func TestTrashTopicFallbackStaysOffCatalogSidebar(t *testing.T) {
 	leftoverA := filepath.Join(dir, "leftover-a.jsonl")
 	leftoverB := filepath.Join(dir, "leftover-b.jsonl")
 	for _, path := range []string{leftoverA, leftoverB} {
-		if _, err := os.Create(path); err != nil {
-			t.Fatalf("create leftover %s: %v", path, err)
-		}
+		writeZeroByteSession(t, path)
 		if err := pinNewEmptySessionBranchMeta(path, "project", projectRoot, "", defaultTopicTitle); err != nil {
 			t.Fatalf("pin leftover %s: %v", path, err)
 		}
@@ -585,9 +583,7 @@ func TestUnusedTransientBlankSessionOnlyMatchesZeroByteFiles(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := t.TempDir()
 	zero := filepath.Join(dir, "zero.jsonl")
-	if _, err := os.Create(zero); err != nil {
-		t.Fatalf("create zero-byte session: %v", err)
-	}
+	writeZeroByteSession(t, zero)
 	if !unusedTransientBlankSession(dir, zero) {
 		t.Fatal("zero-byte unindexed session should be an unused transient blank")
 	}
@@ -600,12 +596,17 @@ func TestUnusedTransientBlankSessionOnlyMatchesZeroByteFiles(t *testing.T) {
 	}
 }
 
+func writeZeroByteSession(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write zero-byte session %s: %v", path, err)
+	}
+}
+
 func writeEmptyNamedSession(t *testing.T, dir, name, topicID, topicTitle, workspaceRoot string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	if _, err := os.Create(path); err != nil {
-		t.Fatalf("create empty session: %v", err)
-	}
+	writeZeroByteSession(t, path)
 	if err := pinNewEmptySessionBranchMeta(path, "project", workspaceRoot, topicID, topicTitle); err != nil {
 		t.Fatalf("pin empty session: %v", err)
 	}

--- a/desktop/topic_archive_test.go
+++ b/desktop/topic_archive_test.go
@@ -476,3 +476,109 @@ func TestTopicArchiveOwnershipRollbackRestoresLocalLease(t *testing.T) {
 		t.Fatalf("competing lease after rollback err = %v, want ErrSessionLeaseHeld", err)
 	}
 }
+
+func TestTrashTopicFallbackStaysOffCatalogSidebar(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, "Archive Sidebar"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	keepID := "topic_keep"
+	archiveID := "topic_archive"
+	if err := setTopicTitle(projectRoot, keepID, "Keep me"); err != nil {
+		t.Fatalf("set keep title: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, archiveID, "Archive me"); err != nil {
+		t.Fatalf("set archive title: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	keepPath := writeTopicSession(t, dir, "keep.jsonl", keepID, "Keep me", projectRoot)
+	archivePath := writeTopicSession(t, dir, "archive.jsonl", archiveID, "Archive me", projectRoot)
+	leftoverA := filepath.Join(dir, "leftover-a.jsonl")
+	leftoverB := filepath.Join(dir, "leftover-b.jsonl")
+	for _, path := range []string{leftoverA, leftoverB} {
+		if _, err := os.Create(path); err != nil {
+			t.Fatalf("create leftover %s: %v", path, err)
+		}
+		if err := pinNewEmptySessionBranchMeta(path, "project", projectRoot, "", defaultTopicTitle); err != nil {
+			t.Fatalf("pin leftover %s: %v", path, err)
+		}
+	}
+	ghostID := agent.BranchID(filepath.Join(dir, "ghost-blank.jsonl"))
+	ghostPath := writeEmptyNamedSession(t, dir, "ghost-blank.jsonl", ghostID, defaultTopicTitle, projectRoot)
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: archivePath, Label: "test", WorkspaceRoot: projectRoot})
+	defer ctrl.Close()
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"archive": {
+				ID: "archive", Scope: "project", WorkspaceRoot: projectRoot,
+				TopicID: archiveID, TopicTitle: "Archive me", Ctrl: ctrl, Ready: true,
+				disabledMCP: map[string]ServerView{},
+			},
+		},
+		tabOrder:    []string{"archive"},
+		activeTabID: "archive",
+	}
+	installSessionCatalogForTest(t, app, dir, "project", projectRoot)
+
+	if err := app.TrashTopic(archiveID); err != nil {
+		t.Fatalf("TrashTopic: %v", err)
+	}
+	reconcileSessionCatalogForTest(t, app, dir, "project", projectRoot)
+
+	if _, err := os.Stat(archivePath); !os.IsNotExist(err) {
+		t.Fatalf("archived session should be gone, stat err = %v", err)
+	}
+	if _, err := os.Stat(keepPath); err != nil {
+		t.Fatalf("kept session missing: %v", err)
+	}
+	for _, path := range []string{leftoverA, leftoverB, ghostPath} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("unused transient blank %s should be discarded, stat err = %v", path, err)
+		}
+	}
+	if len(app.tabs) != 1 {
+		t.Fatalf("fallback should create exactly one visible tab, got %d", len(app.tabs))
+	}
+	var fallbackPath string
+	for id, tab := range app.tabs {
+		if strings.TrimSpace(tab.TopicID) != "" {
+			t.Fatalf("fallback tab %q topic ID = %q, want transient unindexed blank", id, tab.TopicID)
+		}
+		fallbackPath = tab.SessionPath
+		if strings.TrimSpace(fallbackPath) == "" {
+			t.Fatalf("fallback tab %q has no precreated session path", id)
+		}
+	}
+	page, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "project", WorkspaceRoot: projectRoot, Limit: 50})
+	if err != nil {
+		t.Fatalf("ListProjectTopics: %v", err)
+	}
+	if len(page.Items) != 1 || page.Items[0].TopicID != keepID {
+		t.Fatalf("sidebar after archive = %#v, want only %q", page.Items, keepID)
+	}
+	if page.Items[0].Label == defaultTopicTitle || page.Items[0].Label == "New session" {
+		t.Fatalf("sidebar listed a default blank title: %#v", page.Items[0])
+	}
+	if fallbackPath != "" {
+		if _, err := os.Stat(fallbackPath); err != nil {
+			t.Fatalf("current fallback blank should remain writable: %v", err)
+		}
+	}
+}
+
+func writeEmptyNamedSession(t *testing.T, dir, name, topicID, topicTitle, workspaceRoot string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if _, err := os.Create(path); err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := pinNewEmptySessionBranchMeta(path, "project", workspaceRoot, topicID, topicTitle); err != nil {
+		t.Fatalf("pin empty session: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- Restore the 1.23.0 sidebar archive contract: clicking Archive removes that conversation and does not add visible "新的会话" rows.
- Keep the 1.23 writable fallback when the archived topic was the last visible tab: the composer stays a hidden unindexed blank, and the first real user turn still indexes it.
- Discard leftover empty or unindexed default-title session files after archive, and hide the same class of ghosts from the ordinary catalog tree. Explicit `+` blanks remain listed because they are registered topics.

## Issues

Fixes #8716
Refs #5317
Refs #5367

## Verification

- `go run ./tools/repolint`
- `cd desktop && go test . -count=1 -run 'TestUnusedTransientBlankSessionOnlyMatchesZeroByteFiles|TestTrashTopicFallbackStaysOffCatalogSidebar|TestTrashTopicFallbackCreatesUnindexedBlank|TestTrashTopicMovesOpenSessionToTrash|TestCreateTopicAppearsFirstInProjectTree'`
- `cd desktop && go vet .`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/project-tree-runtime.test.ts`
- `cd desktop/frontend && pnpm exec tsc --noEmit`
- `git diff --check`

Native Wails click-through of the sidebar Archive control was not run in this change.

## Documentation impact

Documentation-impact: none - archive still moves a conversation to trash; existing product docs remain correct. This restores 1.23 sidebar visibility rather than adding a new control.

## Cache impact

Cache-impact: none - desktop topic archive, leftover empty-session cleanup, and sidebar listing only. No provider-visible prompt, tool schema, memory prefix, or request serialization change.
Cache-guard: N/A; not cache-sensitive. Covered by the desktop TrashTopic and project-tree tests above.
System-prompt-review: N/A

