### PR TITLE
fix(desktop): stop project tree load-more loop / 修复历史会话多时加载更多与整理历史反复循环

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -23,6 +23,7 @@ import {
   projectTreeTopicHoverCardModel,
   projectTreeTopicMenuOffersPin,
   projectTreeDedupedExactTime,
+  projectTreeShellSignature,
 } from "../components/ProjectTree";
 import { projectTreeTrashingTopics } from "../lib/projectTreeArchive";
 import type { ProjectNode } from "../lib/types";
@@ -706,6 +707,23 @@ eq(
   ],
   [true, false, true],
   "revision events refresh only affected expanded roots, with an empty roots list as broadcast",
+);
+
+const shellWithTopics = (label: string): ProjectNode => ({
+  key: "p1",
+  kind: "project",
+  label,
+  root: "/repo",
+  children: [{ key: "t1", kind: "topic", label: "T1", topicId: "t1" }],
+});
+eq(
+  [
+    projectTreeShellSignature([{ key: "p1", kind: "project", label: "P" }]),
+    projectTreeShellSignature([shellWithTopics("P")]),
+    projectTreeShellSignature([{ key: "p1", kind: "project", label: "P" }, { key: "p2", kind: "project", label: "P2" }]),
+  ],
+  ["p1", "p1", "p1\u001fp2"],
+  "shell signature tracks project arrivals only, so topic page loads cannot re-arm the reload effect",
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
@@ -25,5 +25,15 @@ assert.doesNotMatch(
 );
 assert.match(panel, /setIndexingDone\(Boolean\(snapshot\.indexingDone\)\)/, "shell snapshot records first-scan completion");
 assert.match(panel, /if \(!indexingDone\) return;/, "first completed scan reloads expanded topic pages");
+assert.match(
+  panel,
+  /projectTreeShellSignature/,
+  "debounced reload observes project arrivals through a shell signature",
+);
+assert.doesNotMatch(
+  panel,
+  /\[\s*expanded,\s*loadProjectTopics,\s*query,\s*timeFilter,\s*tree\s*\]/,
+  "debounced reload depends on the shell signature, not tree (topic loads would re-arm it forever)",
+);
 
 console.log("  PASS  project tree shell race contract");

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -10,7 +10,7 @@ import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
-import { isRuntimeSessionNode, isTopicNode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant } from "../lib/projectTreeTopic";
+import { isRuntimeSessionNode, isTopicNode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
 import type { ProjectNode, SessionCatalogStatus } from "../lib/types";
 import { topicActivityTime } from "../lib/session";
@@ -590,7 +590,9 @@ export function ProjectTree({
   }), [expanded, loadProjectTopics, refresh]);
 
   // Debounce query/timeFilter reloads so typing does not stampede the catalog.
-  // Expansion and tree shell arrival still load on the same path after the delay.
+  // Dependency is the project-shell signature, not tree: topic page loads
+  // rewrite children and would otherwise re-arm this effect in a loop.
+  const projectShellSignature = useMemo(() => projectTreeShellSignature(tree), [tree]);
   useEffect(() => {
     const filtering = query.trim() !== "" || timeFilter !== "all";
     const timer = setTimeout(() => {
@@ -600,7 +602,7 @@ export function ProjectTree({
       }
     }, 200);
     return () => clearTimeout(timer);
-  }, [expanded, loadProjectTopics, query, timeFilter, tree]);
+  }, [expanded, loadProjectTopics, projectShellSignature, query, timeFilter]);
 
   // First catalog scan can finish before the frontend subscribed to v2 events.
   // Reload expanded folders once indexingDone flips so the metadata fallback

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -44,6 +44,13 @@ export function mergeProjectTopicPage(current: ProjectNode[], incoming: ProjectN
   return next;
 }
 
+// Topic page loads rewrite children, so a signature keyed only on the project
+// shells lets the debounced reload effect observe arrivals without re-arming
+// itself on its own writes.
+export function projectTreeShellSignature(tree: ProjectNode[]): string {
+  return tree.map((node) => node.key).join("\u001f");
+}
+
 export function projectTreeEventAffectsFolder(project: ProjectNode, roots: string[]): boolean {
   if (roots.length === 0) return true;
   const root = project.kind === "global_folder" ? "" : project.root ?? "";


### PR DESCRIPTION
**Fixes #8721**

**问题**：历史 session 较多的项目中，项目树底部按钮持续在「加载更多」与「正在整理历史」之间循环跳动，同时后端不断收到 `ListProjectTopics` 请求。

**根因**：`desktop/frontend/src/components/ProjectTree.tsx` 的防抖重载 effect 依赖数组包含整个 `tree`。`loadProjectTopics` 每次加载完成都通过 `setTree(current => current.map(...))` 写入新数组引用（`map` 恒产生新引用），于是 effect 无限自触发：加载完成 → setTree → effect 重新调度 → 200ms 后再次加载 → 循环。项目 session 越多，「加载更多」按钮（存在 `nextCursor` 时可见）越明显表现为两态循环。

**修复**：
- 新增纯函数 `projectTreeShellSignature(tree)`（`src/lib/projectTreeTopic.ts`）：仅对顶层项目 `key` 生成稳定签名，话题 children 的写入不影响签名。
- 防抖 effect 依赖由 `tree` 改为该签名：话题分页加载不再自触发重载，同时保留「项目外壳新增/移除（tree shell arrival）仍触发加载」的原有设计。

**验证**：
- `project-tree-runtime.test.ts`：71 passed（含新增签名单测）
- `project-tree-shell-race.test.ts`：PASS（新增契约断言，锁定 effect 不再依赖裸 `tree`）
- `tsc --noEmit`、`eslint` 通过
- 已 rebase 到当前上游 `main-v2`（`49f24d19`），上游尚未修复此问题

Cache-impact: none - 仅 desktop/frontend UI 改动，不在缓存敏感路径，provider 可见的系统提示前缀字节不变
Documentation-impact: none - 纯 UI 行为修复，无文档变更，现有文档描述不受影响

Closes #8721