### PR TITLE
fix(lsp): default Kotlin LSP to official kotlin-lsp / Kotlin 默认 LSP 切换为官方 kotlin-lsp

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2851,39 +2851,6 @@ func MCPStartupNotice(failures []plugin.Failure) (text, detail string, ok bool) 
 		len(failures), strings.Join(names, ", "), more, strings.Join(details, "\n")), true
 }
 
-// LSPSpecs returns the language → server map: the built-in defaults overlaid with
-// any user overrides. A user entry may set only the fields it wants to change;
-// empty fields keep the default for that language.
-func LSPSpecs(cfg config.LSPConfig) map[string]lsp.ServerSpec {
-	specs := lsp.DefaultSpecs()
-	for lang, s := range cfg.Servers {
-		spec := specs[lang]
-		if s.Command != "" {
-			spec.Command = s.Command
-		}
-		if s.Args != nil {
-			spec.Args = s.Args
-		}
-		if s.Env != nil {
-			spec.Env = s.Env
-		}
-		if s.LanguageID != "" {
-			spec.LanguageID = s.LanguageID
-		}
-		if s.Extensions != nil {
-			spec.Extensions = s.Extensions
-		}
-		if s.InstallHint != "" {
-			spec.InstallHint = s.InstallHint
-		}
-		if spec.LanguageID == "" {
-			spec.LanguageID = lang
-		}
-		specs[lang] = spec
-	}
-	return specs
-}
-
 func providerNames(cfg *config.Config) string {
 	names := make([]string, len(cfg.Providers))
 	for i, p := range cfg.Providers {

--- a/internal/boot/lsp_specs.go
+++ b/internal/boot/lsp_specs.go
@@ -1,0 +1,40 @@
+package boot
+
+import (
+	"reasonix/internal/config"
+	"reasonix/internal/lsp"
+)
+
+// LSPSpecs returns the language → server map: the built-in defaults overlaid
+// with user overrides. Empty fields keep the language default. An explicit
+// command replaces the built-in command family, including fallback names.
+func LSPSpecs(cfg config.LSPConfig) map[string]lsp.ServerSpec {
+	specs := lsp.DefaultSpecs()
+	for lang, s := range cfg.Servers {
+		spec := specs[lang]
+		if s.Command != "" {
+			spec.Command = s.Command
+			spec.Fallbacks = nil
+		}
+		if s.Args != nil {
+			spec.Args = s.Args
+		}
+		if s.Env != nil {
+			spec.Env = s.Env
+		}
+		if s.LanguageID != "" {
+			spec.LanguageID = s.LanguageID
+		}
+		if s.Extensions != nil {
+			spec.Extensions = s.Extensions
+		}
+		if s.InstallHint != "" {
+			spec.InstallHint = s.InstallHint
+		}
+		if spec.LanguageID == "" {
+			spec.LanguageID = lang
+		}
+		specs[lang] = spec
+	}
+	return specs
+}

--- a/internal/boot/lsp_specs_test.go
+++ b/internal/boot/lsp_specs_test.go
@@ -1,0 +1,36 @@
+package boot
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func TestLSPSpecsExplicitCommandDoesNotInheritDefaultFallbacks(t *testing.T) {
+	spec := LSPSpecs(config.LSPConfig{Servers: map[string]config.LSPServer{
+		"kotlin": {
+			Command: "company-kotlin-server",
+			Args:    []string{"--company-mode"},
+		},
+	}})["kotlin"]
+
+	if spec.Command != "company-kotlin-server" {
+		t.Fatalf("Command = %q, want explicit user command", spec.Command)
+	}
+	if len(spec.Args) != 1 || spec.Args[0] != "--company-mode" {
+		t.Fatalf("Args = %v, want explicit user arguments", spec.Args)
+	}
+	if len(spec.Fallbacks) != 0 {
+		t.Fatalf("Fallbacks = %v, want none for an explicit user command", spec.Fallbacks)
+	}
+}
+
+func TestLSPSpecsNonCommandOverrideKeepsDefaultFallbacks(t *testing.T) {
+	spec := LSPSpecs(config.LSPConfig{Servers: map[string]config.LSPServer{
+		"kotlin": {InstallHint: "custom install hint"},
+	}})["kotlin"]
+
+	if len(spec.Fallbacks) != 1 || spec.Fallbacks[0] != "intellij-server" {
+		t.Fatalf("Fallbacks = %v, want the built-in intellij-server fallback", spec.Fallbacks)
+	}
+}

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -79,23 +79,37 @@ func TestKotlinDefaultSpec(t *testing.T) {
 
 func TestResolveCommandFallback(t *testing.T) {
 	binDir := t.TempDir()
-	name := "intellij-server"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
+	fake := func(name string) string {
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return path
 	}
-	want := filepath.Join(binDir, name)
-	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	spec := ServerSpec{Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, InstallHint: "hint"}
 	t.Setenv("PATH", binDir) // hermetic: the real PATH may already have kotlin-lsp
 
-	spec := ServerSpec{Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, InstallHint: "hint"}
+	// Only the fallback on PATH → it is used.
+	fallback := fake("intellij-server")
 	bin, err := resolveCommand(spec)
 	if err != nil {
 		t.Fatalf("resolveCommand: %v", err)
 	}
-	if bin != want {
-		t.Errorf("resolved %q, want fallback %q", bin, want)
+	if bin != fallback {
+		t.Errorf("resolved %q, want fallback %q", bin, fallback)
+	}
+
+	// Both on PATH → the primary command wins.
+	primary := fake("kotlin-lsp")
+	bin, err = resolveCommand(spec)
+	if err != nil {
+		t.Fatalf("resolveCommand with both: %v", err)
+	}
+	if bin != primary {
+		t.Errorf("resolved %q, want primary %q", bin, primary)
 	}
 
 	// Neither name on PATH surfaces the primary command in the install error.

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -72,8 +72,17 @@ func TestKotlinDefaultSpec(t *testing.T) {
 	if !hasFallback {
 		t.Errorf("kotlin Fallbacks = %v, want intellij-server fallback for the Windows zip layout", spec.Fallbacks)
 	}
-	if spec.InstallHint == "" {
-		t.Error("kotlin InstallHint empty")
+	for _, want := range []string{
+		"macOS",
+		"brew install JetBrains/utils/kotlin-lsp",
+		"Linux",
+		"kotlin-lsp.sh",
+		"Windows",
+		"intellij-server.exe",
+	} {
+		if !strings.Contains(spec.InstallHint, want) {
+			t.Errorf("kotlin InstallHint = %q, want platform guidance containing %q", spec.InstallHint, want)
+		}
 	}
 }
 

--- a/internal/lsp/lsp_test.go
+++ b/internal/lsp/lsp_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -23,6 +25,11 @@ func TestDefaultSpecsInvariants(t *testing.T) {
 				t.Errorf("extension %q claimed by both %q and %q", ext, prev, lang)
 			}
 			seen[ext] = lang
+		}
+		for _, fb := range s.Fallbacks {
+			if fb == "" || fb == s.Command {
+				t.Errorf("lang %q: bad fallback %q", lang, fb)
+			}
 		}
 	}
 	if seen[".go"] != "go" || seen[".rs"] != "rust" || seen[".cpp"] != "cpp" || seen[".cs"] != "csharp" {
@@ -42,6 +49,59 @@ func TestExtensionRouting(t *testing.T) {
 	_, err := m.resolve("a.go")
 	if err == nil || !strings.Contains(err.Error(), "no language server") {
 		t.Fatalf("unconfigured extension should report no server, got %v", err)
+	}
+}
+
+func TestKotlinDefaultSpec(t *testing.T) {
+	spec, ok := DefaultSpecs()["kotlin"]
+	if !ok {
+		t.Fatal("kotlin default spec missing")
+	}
+	if spec.Command != "kotlin-lsp" {
+		t.Errorf("kotlin Command = %q, want the official PATH name kotlin-lsp", spec.Command)
+	}
+	if len(spec.Args) != 1 || spec.Args[0] != "--stdio" {
+		t.Errorf("kotlin Args = %v, want [--stdio] (client speaks stdio, server defaults to socket)", spec.Args)
+	}
+	hasFallback := false
+	for _, fb := range spec.Fallbacks {
+		if fb == "intellij-server" {
+			hasFallback = true
+		}
+	}
+	if !hasFallback {
+		t.Errorf("kotlin Fallbacks = %v, want intellij-server fallback for the Windows zip layout", spec.Fallbacks)
+	}
+	if spec.InstallHint == "" {
+		t.Error("kotlin InstallHint empty")
+	}
+}
+
+func TestResolveCommandFallback(t *testing.T) {
+	binDir := t.TempDir()
+	name := "intellij-server"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	want := filepath.Join(binDir, name)
+	if err := os.WriteFile(want, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir) // hermetic: the real PATH may already have kotlin-lsp
+
+	spec := ServerSpec{Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, InstallHint: "hint"}
+	bin, err := resolveCommand(spec)
+	if err != nil {
+		t.Fatalf("resolveCommand: %v", err)
+	}
+	if bin != want {
+		t.Errorf("resolved %q, want fallback %q", bin, want)
+	}
+
+	// Neither name on PATH surfaces the primary command in the install error.
+	t.Setenv("PATH", t.TempDir())
+	if _, err := resolveCommand(spec); !errors.As(err, new(*notInstalledError)) {
+		t.Fatalf("expected notInstalledError, got %v", err)
 	}
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -13,16 +13,18 @@ import (
 )
 
 // ServerSpec declares how to launch one language server. Command resolves on
-// PATH (the binary is never bundled); InstallHint is surfaced when it is missing.
-// Extensions are the file suffixes (".go", ".rs") this server handles — they
-// drive file → language routing, so a config-only entry can add a new language
-// without any code change.
+// PATH (the binary is never bundled); Fallbacks are alternate executable names
+// tried when Command is missing (official installers expose different names per
+// platform); InstallHint is surfaced when none are found. Extensions are the
+// file suffixes (".go", ".rs") this server handles — they drive file → language
+// routing, so a config-only entry can add a new language without any code change.
 type ServerSpec struct {
 	Command     string
 	Args        []string
 	Env         map[string]string
 	LanguageID  string
 	Extensions  []string
+	Fallbacks   []string
 	InstallHint string
 }
 
@@ -91,7 +93,7 @@ func DefaultSpecs() map[string]ServerSpec {
 		"lua":        {Command: "lua-language-server", LanguageID: "lua", Extensions: []string{".lua"}, InstallHint: "install lua-language-server: brew install lua-language-server / scoop install lua-language-server"},
 		"bash":       {Command: "bash-language-server", Args: []string{"start"}, LanguageID: "shellscript", Extensions: []string{".sh", ".bash"}, InstallHint: "npm i -g bash-language-server"},
 		"zig":        {Command: "zls", LanguageID: "zig", Extensions: []string{".zig"}, InstallHint: "install zls (ziglang/zls) matching your zig version"},
-		"kotlin":     {Command: "intellij-server", Args: []string{"--stdio"}, LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install intellij-server (JetBrains Kotlin/kotlin-lsp): brew install JetBrains/utils/kotlin-lsp (brew exposes kotlin-lsp; symlink it to intellij-server) / download the standalone zip from Kotlin/kotlin-lsp releases (Windows)"},
+		"kotlin":     {Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, Args: []string{"--stdio"}, LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install kotlin-lsp (JetBrains Kotlin/kotlin-lsp): brew install JetBrains/utils/kotlin-lsp / download the standalone zip from Kotlin/kotlin-lsp releases (Windows)"},
 		"swift":      {Command: "sourcekit-lsp", LanguageID: "swift", Extensions: []string{".swift"}, InstallHint: "ships with the Swift toolchain (swift.org/download)"},
 		"haskell":    {Command: "haskell-language-server-wrapper", Args: []string{"--lsp"}, LanguageID: "haskell", Extensions: []string{".hs"}, InstallHint: "install via ghcup: ghcup install hls"},
 	}
@@ -154,10 +156,25 @@ func (m *Manager) resolve(path string) (*client, error) {
 	return c, err
 }
 
+// resolveCommand returns the first spec executable found on PATH, trying
+// Command then Fallbacks so installers that expose different names (Homebrew's
+// kotlin-lsp vs the Windows zip's intellij-server.exe) both work out of the box.
+func resolveCommand(spec ServerSpec) (string, error) {
+	for _, name := range append([]string{spec.Command}, spec.Fallbacks...) {
+		if name == "" {
+			continue
+		}
+		if bin, err := exec.LookPath(name); err == nil {
+			return bin, nil
+		}
+	}
+	return "", &notInstalledError{command: spec.Command, hint: spec.InstallHint}
+}
+
 func (m *Manager) spawn(_ string, spec ServerSpec) (*client, error) {
-	bin, err := exec.LookPath(spec.Command)
+	bin, err := resolveCommand(spec)
 	if err != nil {
-		return nil, &notInstalledError{command: spec.Command, hint: spec.InstallHint}
+		return nil, err
 	}
 	return startClient(m.root, bin, spec.Args, spec.Env, spec.LanguageID, m.wsRoot)
 }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -91,7 +91,7 @@ func DefaultSpecs() map[string]ServerSpec {
 		"lua":        {Command: "lua-language-server", LanguageID: "lua", Extensions: []string{".lua"}, InstallHint: "install lua-language-server: brew install lua-language-server / scoop install lua-language-server"},
 		"bash":       {Command: "bash-language-server", Args: []string{"start"}, LanguageID: "shellscript", Extensions: []string{".sh", ".bash"}, InstallHint: "npm i -g bash-language-server"},
 		"zig":        {Command: "zls", LanguageID: "zig", Extensions: []string{".zig"}, InstallHint: "install zls (ziglang/zls) matching your zig version"},
-		"kotlin":     {Command: "kotlin-language-server", LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install kotlin-language-server: brew install kotlin-language-server"},
+		"kotlin":     {Command: "intellij-server", Args: []string{"--stdio"}, LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install intellij-server (JetBrains Kotlin/kotlin-lsp): brew install JetBrains/utils/kotlin-lsp (brew exposes kotlin-lsp; symlink it to intellij-server) / download the standalone zip from Kotlin/kotlin-lsp releases (Windows)"},
 		"swift":      {Command: "sourcekit-lsp", LanguageID: "swift", Extensions: []string{".swift"}, InstallHint: "ships with the Swift toolchain (swift.org/download)"},
 		"haskell":    {Command: "haskell-language-server-wrapper", Args: []string{"--lsp"}, LanguageID: "haskell", Extensions: []string{".hs"}, InstallHint: "install via ghcup: ghcup install hls"},
 	}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -12,12 +12,11 @@ import (
 	"time"
 )
 
-// ServerSpec declares how to launch one language server. Command resolves on
-// PATH (the binary is never bundled); Fallbacks are alternate executable names
-// tried when Command is missing (official installers expose different names per
-// platform); InstallHint is surfaced when none are found. Extensions are the
-// file suffixes (".go", ".rs") this server handles — they drive file → language
-// routing, so a config-only entry can add a new language without any code change.
+// ServerSpec declares how to launch one language server. Command resolves on PATH
+// (the binary is never bundled); Fallbacks are alternate executable names tried
+// when Command is missing. InstallHint is surfaced when none are found. Extensions
+// are the file suffixes (".go", ".rs") this server handles, so a config-only entry
+// can add a new language without any code change.
 type ServerSpec struct {
 	Command     string
 	Args        []string
@@ -93,7 +92,7 @@ func DefaultSpecs() map[string]ServerSpec {
 		"lua":        {Command: "lua-language-server", LanguageID: "lua", Extensions: []string{".lua"}, InstallHint: "install lua-language-server: brew install lua-language-server / scoop install lua-language-server"},
 		"bash":       {Command: "bash-language-server", Args: []string{"start"}, LanguageID: "shellscript", Extensions: []string{".sh", ".bash"}, InstallHint: "npm i -g bash-language-server"},
 		"zig":        {Command: "zls", LanguageID: "zig", Extensions: []string{".zig"}, InstallHint: "install zls (ziglang/zls) matching your zig version"},
-		"kotlin":     {Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, Args: []string{"--stdio"}, LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install kotlin-lsp (JetBrains Kotlin/kotlin-lsp): brew install JetBrains/utils/kotlin-lsp / download the standalone zip from Kotlin/kotlin-lsp releases (Windows)"},
+		"kotlin":     {Command: "kotlin-lsp", Fallbacks: []string{"intellij-server"}, Args: []string{"--stdio"}, LanguageID: "kotlin", Extensions: []string{".kt", ".kts"}, InstallHint: "install JetBrains Kotlin/kotlin-lsp: macOS: brew install JetBrains/utils/kotlin-lsp; Linux: download the standalone zip, chmod +x kotlin-lsp.sh, and symlink it as kotlin-lsp on PATH; Windows: download the standalone zip and add its bin directory containing intellij-server.exe to PATH"},
 		"swift":      {Command: "sourcekit-lsp", LanguageID: "swift", Extensions: []string{".swift"}, InstallHint: "ships with the Swift toolchain (swift.org/download)"},
 		"haskell":    {Command: "haskell-language-server-wrapper", Args: []string{"--lsp"}, LanguageID: "haskell", Extensions: []string{".hs"}, InstallHint: "install via ghcup: ghcup install hls"},
 	}


### PR DESCRIPTION
## Summary

The Kotlin default `kotlin-language-server` points at the deprecated
`fwcd/kotlin-language-server` project (upstream README: "this project can be
considered deprecated"), which misguides new users into installing abandoned
tooling. JetBrains' official `Kotlin/kotlin-lsp` exposes `kotlin-lsp` on PATH
(the binary inside the archives is `bin/intellij-server`).

- Command: `kotlin-language-server` → `kotlin-lsp` (the official PATH name);
  `intellij-server` is kept as a generic `ServerSpec.Fallbacks` entry so the
  Windows zip `bin/` layout works without a reverse symlink.
- Args: `["--stdio"]` — the client talks stdio and the server defaults to
  socket mode; the official VS Code extension launches it with `--stdio`
  (`vscode-extension-core/src/lspClient.ts`), and the issue author confirmed it.
- InstallHint: platform-specific official steps for macOS, Linux, and Windows.

Implements #7971.

## Issues

Fixes #7971

## Verification

- `gofmt -l internal/lsp/` (clean)
- `go vet ./internal/lsp/`
- `go test ./internal/lsp/` — includes new `TestKotlinDefaultSpec` (pins
  `kotlin-lsp` + `--stdio`) and `TestResolveCommandFallback` (fallback used
  when `kotlin-lsp` is missing; primary wins when both are present)
- `go test ./...` (full suite) passes
- `go test -race ./internal/lsp ./internal/boot`
- `go run ./tools/repolint` and focused `golangci-lint` pass
- Local real-server check (not part of this PR): drove the new default
  (`kotlin-lsp --stdio`) against a real `main.kt` — hover, definition, and
  diagnostics all worked, ~6s including cold start.

## Documentation impact

Documentation-impact: none - no `docs/*.md` references the Kotlin server
default; the InstallHint carries the install guidance.

## Cache impact

Cache-impact: none - LSP server defaults are runtime-only; no system prompt,
memory prefix, skill index, or tool surface change.
Cache-guard: TestDefaultSpecsInvariants, TestKotlinDefaultSpec, and the LSPSpecs override tests.
System-prompt-review: Reviewed by @SivanCola - LSP executable selection is runtime-only; system prompt bytes, tool registration, schemas, and ordering are unchanged.