### PR TITLE
feat(control): on-demand planner escalation for stuck goal continuations / 执行卡住时按需唤醒规划模型（#8774）

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -322,6 +322,10 @@ type Agent struct {
 
 	// recovery is who this agent is to the shared gate above.
 	recovery recoveryIdentity
+	// goalEscalation carries the goal-scoped progress-guard stop signal to
+	// the controller at the turn boundary (#8774).
+	escalationMu    sync.Mutex
+	goalEscalation *goalEscalationSignal
 
 	// writeWorkspaceRoot is the workspace used to normalize parent write
 	// reservations when writeScheduler is set.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -647,11 +647,15 @@ func plannerSink(sink event.Sink) event.Sink {
 }
 
 func plannerTurnInput(input string, decision PlannerDecision) string {
+	escalation := ""
+	if decision.EscalationDetail != "" {
+		escalation = fmt.Sprintf("\nescalation_reason: %s\nescalation_detail: %s", decision.Reason, decision.EscalationDetail)
+	}
 	return fmt.Sprintf(`%s
 
 <planner-turn>
-route: %s
-</planner-turn>`, strings.TrimSpace(input), decision.Route)
+route: %s%s
+</planner-turn>`, strings.TrimSpace(input), decision.Route, escalation)
 }
 
 func formatHandoff(task, plan string, toolContext ...string) string {

--- a/internal/agent/planner_route.go
+++ b/internal/agent/planner_route.go
@@ -27,6 +27,9 @@ type PlannerIntent = PlannerRoute
 type PlannerDecision struct {
 	Route  PlannerRoute
 	Reason string
+	// EscalationDetail carries the stuck-evidence summary for an #8774
+	// escalated planner revision turn; empty otherwise.
+	EscalationDetail string
 }
 
 // PlannerPolicy makes one deterministic routing decision from trusted turn
@@ -39,6 +42,7 @@ func normalizePlannerDecision(d PlannerDecision) PlannerDecision {
 	default:
 		d.Route = PlannerRouteExecutorOnly
 	}
+	d.EscalationDetail = strings.TrimSpace(d.EscalationDetail)
 	d.Reason = strings.TrimSpace(d.Reason)
 	if d.Reason == "" {
 		d.Reason = "default"

--- a/internal/agent/progress_guard.go
+++ b/internal/agent/progress_guard.go
@@ -49,6 +49,36 @@ func (g *progressGuard) observe(receipts []Receipt) int {
 // Receipt aliases the evidence receipt for the guard's signature.
 type Receipt = evidence.Receipt
 
+// goalEscalationSignal is the host-visible request produced when the
+// goal-scoped progress guard reaches its stop tier (#8774). The controller
+// consumes it at the turn boundary and routes the next continuation turn
+// through the planner.
+type goalEscalationSignal struct {
+	Reason string
+	Detail string
+}
+
+// requestGoalEscalation records an escalation request. The in-prompt guidance
+// text stays unchanged; this is an additional host-visible side channel.
+func (a *Agent) requestGoalEscalation(reason, detail string) {
+	a.escalationMu.Lock()
+	defer a.escalationMu.Unlock()
+	a.goalEscalation = &goalEscalationSignal{Reason: reason, Detail: detail}
+}
+
+// ConsumeGoalEscalationSignal returns and clears any pending escalation
+// request produced by the goal-scoped progress guard stop tier.
+func (a *Agent) ConsumeGoalEscalationSignal() (reason, detail string) {
+	a.escalationMu.Lock()
+	defer a.escalationMu.Unlock()
+	if a.goalEscalation == nil || a.goalEscalation.Reason == "" {
+		return "", ""
+	}
+	sig := a.goalEscalation
+	a.goalEscalation = &goalEscalationSignal{}
+	return sig.Reason, sig.Detail
+}
+
 // applyBatchGuards collects this round's signals — storm breaker (failure
 // fixation), progress guard (zero-gain repetition), evidence nudge — and lets
 // the arbiter deliver them as one tail. The shadow trackers observe the same
@@ -132,6 +162,10 @@ func (a *Agent) applyProgressGuard(outcomes []toolOutcome, receiptMark int, goal
 			// Start a fresh intervention epoch. The evidence tracker stays intact,
 			// so repeated work remains visible while a changed strategy can recover.
 			a.turn.progress.streak = 0
+			// #8774: also surface a host-visible escalation request so the
+			// controller can route the next continuation turn through the
+			// planner instead of only injecting in-prompt guidance.
+			a.requestGoalEscalation("progress", detail)
 		} else {
 			guard = fmt.Sprintf(
 				"[progress guard] %d tool rounds in a row produced no new evidence (no new files, results, or changes). Stop exploring: produce your final answer now, stating what was established and what remains unknown.",

--- a/internal/agent/progress_guard_test.go
+++ b/internal/agent/progress_guard_test.go
@@ -126,3 +126,19 @@ func TestProgressGuardResetsOnNewEvidence(t *testing.T) {
 		t.Fatalf("fresh evidence must reset the streak, got %d", a.turn.progress.streak)
 	}
 }
+
+// TestGoalEscalationSignalRoundTrip pins the #8774 host-visible side channel:
+// the goal-scoped progress-guard stop tier records a request that the
+// controller consumes once at the turn boundary.
+func TestGoalEscalationSignalRoundTrip(t *testing.T) {
+	a := &Agent{}
+	a.requestGoalEscalation("progress", "6 zero-gain rounds — forcing a Goal re-plan")
+	reason, detail := a.ConsumeGoalEscalationSignal()
+	if reason != "progress" || !strings.Contains(detail, "zero-gain") {
+		t.Fatalf("signal = (%q, %q), want progress with detail", reason, detail)
+	}
+	// Consumed once: a second read is empty.
+	if again, _ := a.ConsumeGoalEscalationSignal(); again != "" {
+		t.Fatalf("second consume = %q, want empty", again)
+	}
+}

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"strconv"
 	"time"
 
 	"reasonix/internal/agent"
@@ -23,6 +24,9 @@ const (
 	goalContinueTurn   = "Continue pursuing the active goal under its task contract. Do the next useful work, then call update_goal with your disposition: continue (include the next concrete step in next_action), complete (when the request is done and verification was attempted or reported unavailable), or blocked (when only the user can unblock)."
 	goalCompleteNotice = "goal complete"
 	unlimitedGoalTurns = -1
+	// #8774 escalation budget and slow-channel thresholds.
+	maxGoalEscalations   = 3
+	maxReadinessFailures = 3
 
 	// Bound the persisted novelty window. Signatures are compact hashes, and
 	// retaining the most recent window is enough to stop short repeat cycles
@@ -42,6 +46,7 @@ const (
 const (
 	stopCauseBudgetTurns   = "budget_turns" // legacy; the class-derived turn quota is gone
 	stopCauseBudgetSpend   = "budget_spend"
+	stopCauseEscalationExhausted = "escalation_exhausted" // #8774
 	stopCauseBudgetTokens  = "budget_tokens"   // legacy; never written by current runtime
 	stopCauseNoProgress    = "no_progress"     // legacy; never written by current runtime
 	stopCauseGoalRunBudget = "goal_run_budget" // legacy; the per-Run round ceiling is gone
@@ -102,6 +107,14 @@ type goalMachine struct {
 	stopCause              string
 	budgetExtensions       int // deprecated historical sidecar field
 	progressEvidence       []string
+	// #8774 escalation state: set when a stuck continuation turn requests a
+	// planner revision; the next continuation turn routes plan_and_execute
+	// light, then the marker is cleared by the FSM.
+	escalated          bool
+	escalationReason   string
+	escalationDetail   string
+	escalationCount    int
+	readinessFailures  int // consecutive FinalReadiness failures (slow channel)
 	// stateExtra preserves fields written by a newer peer during read/modify/
 	// write cycles. Known current fields always win on serialization.
 	stateExtra map[string]json.RawMessage
@@ -148,6 +161,12 @@ type goalState struct {
 	StopCause              string   `json:"stopCause,omitempty"`
 	BudgetExtensions       int      `json:"budgetExtensions,omitempty"`
 	ProgressEvidence       []string `json:"progressEvidence,omitempty"`
+
+	Escalated          bool   `json:"escalated,omitempty"`
+	EscalationReason   string `json:"escalationReason,omitempty"`
+	EscalationDetail   string `json:"escalationDetail,omitempty"`
+	EscalationCount    int    `json:"escalationCount,omitempty"`
+	ReadinessFailures  int    `json:"readinessFailures,omitempty"`
 }
 
 // goalAdvanceInput carries everything the FSM needs for one continuation step,
@@ -164,6 +183,18 @@ type goalAdvanceInput struct {
 	pauseCause       string   // explicit spend boundary reported by the Agent
 	pauseReason      string
 	expectedEpoch    *uint64
+	// #8774: escalation request produced by the fast channel (model
+	// self-report) or the slow channel (progress guard stop / repeated
+	// readiness failures); wasEscalated marks that the finished turn itself
+	// was an escalated planner revision turn (the marker is then cleared).
+	escalate      *goalEscalation
+	wasEscalated  bool
+}
+
+// goalEscalation is one #8774 re-plan request.
+type goalEscalation struct {
+	reason string
+	detail string
 }
 
 // goalEvaluatorVerdict is the bounded evaluator's structured outcome.
@@ -260,6 +291,21 @@ func newGoalScopeID() string {
 }
 
 // active reports whether a goal is currently running.
+// escalated reports whether a #8774 planner-revision request is pending for
+// the next continuation turn.
+func (g *goalMachine) escalationPending() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.escalated
+}
+
+// escalationInfo returns the pending escalation marker for planner routing.
+func (g *goalMachine) escalationInfo() (reason, detail string, count int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.escalationReason, g.escalationDetail, g.escalationCount
+}
+
 func (g *goalMachine) active() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -494,6 +540,29 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 	// A top-level goal turn (the first turn or a synthetic continuation) counts
 	// as an observational statistic; the in-Run model/tool loop is not re-counted.
 	g.turnsUsed++
+	// #8774: an escalated planner-revision turn clears the marker when it
+	// finishes (the count stays for loop protection).
+	if in.wasEscalated {
+		g.escalated = false
+		g.escalationReason = ""
+		g.escalationDetail = ""
+	}
+	// Slow-channel readiness accounting: consecutive FinalReadiness failures
+	// escalate once the threshold is crossed.
+	if !in.readiness.Ready && len(in.readiness.Missing) > 0 {
+		g.readinessFailures++
+	} else if in.escalate == nil {
+		g.readinessFailures = 0
+	}
+	// Slow-channel escalation: consecutive readiness failures cross the
+	// threshold → request a planner revision (unless a signal already exists).
+	if in.escalate == nil && !in.readiness.Ready && len(in.readiness.Missing) > 0 &&
+		g.readinessFailures >= maxReadinessFailures {
+		in.escalate = &goalEscalation{
+			reason: "readiness",
+			detail: strings.Join(in.readiness.Missing, "; "),
+		}
+	}
 	var notice string
 	var intercept string
 	var interceptNotice string
@@ -505,6 +574,24 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 	complete := g.completeDecision(in, reportComplete, evaluatorComplete)
 	g.observeGoalProgress(in, complete.accept || reportBlocked || evaluatorBlocked)
 	switch {
+	case reportBlocked && in.report.technical:
+		// #8774 fast channel: the executor self-reported a technical blockage
+		// (hard-gated in update_goal: >=2 attempted rounds with >=1 failure).
+		// Route the next continuation turn through the planner instead of
+		// blocking on the user.
+		if g.escalationCount >= maxGoalEscalations {
+			g.status = GoalStatusBlocked
+			g.stopCause = stopCauseEscalationExhausted
+			g.block = clipGoalReason("technical blockage after " + strconv.Itoa(g.escalationCount) + " escalations: " + in.report.reason)
+			g.lastContinuationReason = clipGoalReason(in.report.reason)
+			notice = "goal paused: escalation budget exhausted (" + in.report.reason + ")"
+		} else {
+			g.escalated = true
+			g.escalationReason = "technical"
+			g.escalationDetail = cleanGoalBlockReason(in.report.reason)
+			g.escalationCount++
+			g.lastContinuationReason = clipGoalReason(in.report.reason)
+		}
 	case reportBlocked:
 		// A single blocked report ends the goal immediately; the host no longer
 		// repeats a three-turn confirmation ritual.
@@ -553,6 +640,22 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		g.block = clipGoalReason(reason)
 		g.lastEvaluatorReason = clipGoalReason(reason)
 		notice = "goal paused: " + reason
+	case in.escalate != nil:
+		// #8774 slow channel: the host observed a stuck continuation
+		// (progress-guard stop tier or repeated readiness failures).
+		if g.escalationCount >= maxGoalEscalations {
+			g.status = GoalStatusBlocked
+			g.stopCause = stopCauseEscalationExhausted
+			g.block = clipGoalReason("stuck after " + strconv.Itoa(g.escalationCount) + " escalations: " + in.escalate.reason)
+			g.lastContinuationReason = clipGoalReason(in.escalate.detail)
+			notice = "goal paused: escalation budget exhausted (" + in.escalate.reason + ")"
+		} else {
+			g.escalated = true
+			g.escalationReason = in.escalate.reason
+			g.escalationDetail = in.escalate.detail
+			g.escalationCount++
+			g.lastContinuationReason = clipGoalReason(in.escalate.detail)
+		}
 	case in.pauseCause != "":
 		reason := strings.TrimSpace(in.pauseReason)
 		if reason == "" {
@@ -650,6 +753,11 @@ func (g *goalMachine) buildStateLocked(todos []evidence.TodoItem) (path string, 
 		StopCause:              g.stopCause,
 		BudgetExtensions:       g.budgetExtensions,
 		ProgressEvidence:       append([]string(nil), g.progressEvidence...),
+		Escalated:              g.escalated,
+		EscalationReason:       g.escalationReason,
+		EscalationDetail:       g.escalationDetail,
+		EscalationCount:        g.escalationCount,
+		ReadinessFailures:      g.readinessFailures,
 	}
 	// GoalResearchOff is a downgrade fence for ordinary Goal sidecars. A
 	// fail-closed legacy migration keeps its task identity and compatibility mode
@@ -792,6 +900,11 @@ func (g *goalMachine) restoreFromState(sessionPath string) (path string, data []
 	g.stopCause = state.StopCause
 	g.budgetExtensions = state.BudgetExtensions
 	g.progressEvidence, _ = mergeGoalProgressEvidence(nil, state.ProgressEvidence)
+	g.escalated = state.Escalated
+	g.escalationReason = state.EscalationReason
+	g.escalationDetail = state.EscalationDetail
+	g.escalationCount = state.EscalationCount
+	g.readinessFailures = state.ReadinessFailures
 	g.lastContinuationReason = state.LastContinuationReason
 	g.lastEvaluatorReason = state.LastEvaluatorReason
 	// Old sidecars carry Turns (pre-budget counting); treat it as turn usage.
@@ -948,6 +1061,7 @@ type goalTurnRecorder struct {
 	status           string
 	reason           string
 	nextAction       string
+	technical        bool // blocked_kind=technical (#8774)
 	tokensUsed       int
 	requestsUsed     int
 	workDurationMs   int64
@@ -990,6 +1104,7 @@ func (r *goalTurnRecorder) RecordGoalReport(report tool.GoalReport) (string, err
 	r.status = report.Status
 	r.reason = report.Reason
 	r.nextAction = report.NextAction
+	r.technical = report.Status == GoalStatusBlocked && report.BlockedKind == "technical"
 	if report.Status != GoalStatusRunning {
 		r.terminal = true
 	}
@@ -1045,7 +1160,7 @@ func (r *goalTurnRecorder) validReport(expectedEpoch uint64) *goalTurnReport {
 	if !r.recorded || r.epoch != expectedEpoch || !r.machine.turnActive(r.scopeID, r.epoch) {
 		return nil
 	}
-	return &goalTurnReport{status: r.status, reason: r.reason, nextAction: r.nextAction}
+	return &goalTurnReport{status: r.status, reason: r.reason, nextAction: r.nextAction, technical: r.technical}
 }
 
 // goalTurnReport is the validated update_goal report for one goal turn.
@@ -1053,6 +1168,7 @@ type goalTurnReport struct {
 	status     string
 	reason     string
 	nextAction string
+	technical  bool // blocked_kind=technical (#8774)
 }
 
 // turnActive reports whether the machine's goal lifecycle matches the binding.

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -1018,3 +1018,96 @@ func TestLegacyRunningGoalSidecarAllocatesScope(t *testing.T) {
 		t.Fatalf("legacy checkpoint scope = %q, want %q", got.ScopeID, id)
 	}
 }
+
+
+// --- #8774 escalation FSM ---
+
+func TestGoalEscalationSlowChannelSchedulesPlannerRevision(t *testing.T) {
+	g := &goalMachine{goal: "refactor the parser", status: GoalStatusRunning}
+	g.turnsLimit = unlimitedGoalTurns
+	g.noProgressLimit = 0
+	res := g.advance(goalAdvanceInput{escalate: &goalEscalation{reason: "progress", detail: "6 zero-gain rounds"}})
+	if !res.cont {
+		t.Fatal("escalation must keep the loop running")
+	}
+	if !g.escalated || g.escalationReason != "progress" || g.escalationCount != 1 {
+		t.Fatalf("escalation state wrong, want reason=progress count=1")
+	}
+	if g.status != GoalStatusRunning {
+		t.Fatalf("status = %s, want running (escalation is not a block)", g.status)
+	}
+}
+
+func TestGoalEscalationFastChannelTechnical(t *testing.T) {
+	g := &goalMachine{goal: "refactor the parser", status: GoalStatusRunning}
+	g.turnsLimit = unlimitedGoalTurns
+	g.noProgressLimit = 0
+	res := g.advance(goalAdvanceInput{report: &goalTurnReport{status: GoalStatusBlocked, reason: "the dependency API is deprecated", technical: true}})
+	if !res.cont {
+		t.Fatal("technical self-report must continue, not block")
+	}
+	if !g.escalated || g.escalationReason != "technical" || g.escalationCount != 1 {
+		t.Fatalf("escalation state wrong, want reason=technical count=1")
+	}
+	if g.status != GoalStatusRunning {
+		t.Fatalf("status = %s, want running", g.status)
+	}
+}
+
+func TestGoalEscalationClearedAfterEscalatedTurn(t *testing.T) {
+	g := &goalMachine{goal: "refactor the parser", status: GoalStatusRunning}
+	g.turnsLimit = unlimitedGoalTurns
+	g.noProgressLimit = 0
+	g.advance(goalAdvanceInput{escalate: &goalEscalation{reason: "progress", detail: "6 zero-gain rounds"}})
+	if !g.escalated {
+		t.Fatal("precondition: escalation pending")
+	}
+	res := g.advance(goalAdvanceInput{wasEscalated: true, report: &goalTurnReport{status: GoalStatusRunning, reason: "revised plan applied"}})
+	if !res.cont {
+		t.Fatal("cleared escalation must keep looping")
+	}
+	if g.escalated {
+		t.Fatal("escalation marker must clear after the escalated turn")
+	}
+	if g.escalationCount != 1 {
+		t.Fatalf("count = %d, want 1 (count persists for loop protection)", g.escalationCount)
+	}
+}
+
+func TestGoalEscalationBudgetExhausted(t *testing.T) {
+	g := &goalMachine{goal: "refactor the parser", status: GoalStatusRunning}
+	g.turnsLimit = unlimitedGoalTurns
+	g.noProgressLimit = 0
+	g.escalationCount = maxGoalEscalations
+	res := g.advance(goalAdvanceInput{escalate: &goalEscalation{reason: "progress", detail: "still stuck"}})
+	if res.cont {
+		t.Fatal("escalation budget exhausted must stop the loop")
+	}
+	if g.status != GoalStatusBlocked || g.stopCause != stopCauseEscalationExhausted {
+		t.Fatalf("status=%s cause=%s, want blocked/escalation_exhausted", g.status, g.stopCause)
+	}
+}
+
+func TestGoalReadinessFailuresEscalateAfterThreshold(t *testing.T) {
+	g := &goalMachine{goal: "refactor the parser", status: GoalStatusRunning}
+	g.turnsLimit = unlimitedGoalTurns
+	g.noProgressLimit = 0
+	readiness := agent.ReadinessResult{Ready: false, Missing: []string{"verification"}}
+	for i := 0; i < maxReadinessFailures; i++ {
+		res := g.advance(goalAdvanceInput{readiness: readiness})
+		if !res.cont {
+			t.Fatalf("round %d: loop stopped unexpectedly", i)
+		}
+		if i < maxReadinessFailures-1 && g.escalated {
+			t.Fatalf("round %d: escalated before threshold", i)
+		}
+	}
+	if !g.escalated || g.escalationReason != "readiness" {
+		t.Fatalf("escalation state wrong, want reason=readiness")
+	}
+	// A healthy round resets the failure streak.
+	res := g.advance(goalAdvanceInput{report: &goalTurnReport{status: GoalStatusRunning, reason: "verification passed"}})
+	if !res.cont || g.readinessFailures != 0 {
+		t.Fatalf("after healthy round: failures=%d cont=%v, want 0/true", g.readinessFailures, res.cont)
+	}
+}

--- a/internal/control/planner_gate.go
+++ b/internal/control/planner_gate.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	plannerReasonExplicitPlanMode    = "explicit_plan_mode"
+	plannerReasonEscalated           = "escalated" // #8774
 	plannerReasonSynthetic           = "synthetic"
 	plannerReasonSlash               = "slash_command"
 	plannerReasonShortReply          = "short_reply"
@@ -38,6 +39,8 @@ type plannerTurnMetadata struct {
 	Synthetic              bool
 	ExplicitPlanMode       bool
 	ExplicitGoalStart      bool
+	Escalated              bool   // #8774: pending planner-revision request
+	EscalationDetail       string // stuck-evidence summary for the planner input
 	HasConversationContext bool
 }
 
@@ -63,11 +66,14 @@ func (c *Controller) withPlannerTurnMetadata(ctx context.Context, userText strin
 		constraints.ForbidMutation = true
 	}
 	ctx = runtimepolicy.WithContext(ctx, constraints)
+	escReason, escDetail, _ := c.goals.escalationInfo()
 	return withPlannerTurnMetadata(ctx, plannerTurnMetadata{
 		UserText:               userText,
 		Synthetic:              synthetic,
 		ExplicitPlanMode:       c.PlanMode(),
 		ExplicitGoalStart:      c.consumeExplicitGoalStart(),
+		Escalated:              c.goals.escalationPending(),
+		EscalationDetail:       escReason + ": " + escDetail,
 		HasConversationContext: priorMessages > 1,
 	})
 }
@@ -85,6 +91,14 @@ func DecidePlannerRoute(ctx context.Context, input string) agent.PlannerDecision
 
 	if meta.ExplicitPlanMode || strings.HasPrefix(composedText, PlanModeMarker) {
 		return plannerExecutorDecision(plannerReasonExplicitPlanMode)
+	}
+	// #8774: a pending escalation request routes the next continuation turn
+	// through a light planner revision. This must precede the synthetic check
+	// (goal continuations are synthetic) and all feature heuristics.
+	if meta.Escalated {
+		d := plannerPlanDecision(agent.PlannerRoutePlanAndExecute, plannerReasonEscalated)
+		d.EscalationDetail = meta.EscalationDetail
+		return d
 	}
 	if meta.Synthetic || IsSyntheticUserMessage(text) {
 		return plannerExecutorDecision(plannerReasonSynthetic)

--- a/internal/control/planner_gate_test.go
+++ b/internal/control/planner_gate_test.go
@@ -145,3 +145,32 @@ func TestPlannerPolicyUsesPristineMetadataInsteadOfInjectedContext(t *testing.T)
 		t.Fatalf("decision used injected context instead of pristine user text: %+v", got)
 	}
 }
+
+
+// TestEscalatedRoutesToLightPlanner pins the #8774 routing rule: a pending
+// escalation request beats the synthetic check (goal continuations are
+// synthetic) and routes to a light planner revision carrying the stuck
+// evidence. Without the marker, the synthetic continuation stays executor-only.
+func TestEscalatedRoutesToLightPlanner(t *testing.T) {
+	ctx := withPlannerTurnMetadata(context.Background(), plannerTurnMetadata{
+		Synthetic:        true,
+		Escalated:        true,
+		EscalationDetail: "progress: 6 zero-gain rounds",
+	})
+	got := DecidePlannerRoute(ctx, goalContinueTurn)
+	if got.Route != agent.PlannerRoutePlanAndExecute {
+		t.Fatalf("route = %s, want plan_and_execute", got.Route)
+	}
+	if got.Reason != plannerReasonEscalated {
+		t.Fatalf("reason = %s, want %s", got.Reason, plannerReasonEscalated)
+	}
+	if got.EscalationDetail != "progress: 6 zero-gain rounds" {
+		t.Fatalf("detail = %q, want the stuck-evidence summary", got.EscalationDetail)
+	}
+
+	ctxPlain := withPlannerTurnMetadata(context.Background(), plannerTurnMetadata{Synthetic: true})
+	gotPlain := DecidePlannerRoute(ctxPlain, goalContinueTurn)
+	if gotPlain.Route != agent.PlannerRouteExecutorOnly {
+		t.Fatalf("non-escalated synthetic route = %s, want executor_only", gotPlain.Route)
+	}
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -617,6 +617,16 @@ func (o *turnOrchestrator) advanceGoalAfterTurn(ctx context.Context, expectedCon
 		progressEvidence = c.executor.HostProgressSignatures()
 	}
 
+	// #8774: slow-channel escalation signal from the goal-scoped progress
+	// guard stop tier (consumed once here). The fast channel (technical
+	// self-report) and the readiness-failure threshold are handled inside the
+	// FSM from report/readiness inputs.
+	var escalate *goalEscalation
+	if c.executor != nil {
+		if reason, detail := c.executor.ConsumeGoalEscalationSignal(); reason != "" {
+			escalate = &goalEscalation{reason: reason, detail: detail}
+		}
+	}
 	res := c.goals.advance(goalAdvanceInput{
 		report:           report,
 		readiness:        readiness,
@@ -627,6 +637,8 @@ func (o *turnOrchestrator) advanceGoalAfterTurn(ctx context.Context, expectedCon
 		pauseCause:       pauseCause,
 		pauseReason:      pauseReason,
 		expectedEpoch:    &expectedContinuationEpoch,
+		escalate:         escalate,
+		wasEscalated:     c.goals.escalationPending(),
 	})
 	c.persistGoalState(res.path, res.data, res.ok)
 	if res.notice != "" {

--- a/internal/tool/builtin/updategoal.go
+++ b/internal/tool/builtin/updategoal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"reasonix/internal/evidence"
 	"reasonix/internal/tool"
 )
 
@@ -23,7 +24,7 @@ type updateGoal struct{}
 func (updateGoal) Name() string { return "update_goal" }
 
 func (updateGoal) Description() string {
-	return "Report this turn's disposition for the active goal. Call it at the end of every goal turn instead of using prose markers: `continue` (work is ongoing — give a concrete next_action), `complete` (the request is fully done, output format and constraints satisfied, and verification was attempted or reported unavailable), or `blocked` (only the user can unblock: missing user-only information, an irreversible/externally visible operation, or changed scope). The host validates your claim against Delivery acceptance criteria and decides whether to continue automatically. Fields: `status` (required, one of continue|complete|blocked), `reason` (required for continue and blocked, optional for complete), `next_action` (optional concrete next step; recommended for continue), `completion` (recommended with complete: `verified` is checked against real receipts, while `unverified` and `risks` are yours to declare and never count against you)."
+	return "Report this turn's disposition for the active goal. Call it at the end of every goal turn instead of using prose markers: `continue` (work is ongoing — give a concrete next_action), `complete` (the request is fully done, output format and constraints satisfied, and verification was attempted or reported unavailable), or `blocked` (only the user can unblock: missing user-only information, an irreversible/externally visible operation, or changed scope). For `blocked` you may pass `blocked_kind: \"technical\"` when you are stuck and need the host to re-plan (you tried at least 2 tool rounds and at least one failed) instead of waiting for the user; the host verifies the attempt threshold before acting. The host validates your claim against Delivery acceptance criteria and decides whether to continue automatically. Fields: `status` (required, one of continue|complete|blocked), `blocked_kind` (optional, one of user|technical; default user), `reason` (required for continue and blocked, optional for complete), `next_action` (optional concrete next step; recommended for continue), `completion` (recommended with complete: `verified` is checked against real receipts, while `unverified` and `risks` are yours to declare and never count against you)."
 }
 
 func (updateGoal) Schema() json.RawMessage {
@@ -31,6 +32,7 @@ func (updateGoal) Schema() json.RawMessage {
 "type":"object",
 "properties":{
   "status":{"type":"string","enum":["continue","complete","blocked"],"description":"continue = keep working autonomously; complete = the goal is fully done and verified; blocked = only the user can unblock."},
+  "blocked_kind":{"type":"string","enum":["user","technical"],"description":"Optional with blocked. user (default) = only the user can unblock; technical = the executor is stuck and asks the host to re-plan (requires >=2 attempted tool rounds with >=1 failure — verified by the host)."},
   "reason":{"type":"string","description":"Short explanation. REQUIRED for continue and blocked; optional for complete."},
   "next_action":{"type":"string","description":"Optional concrete next step. Recommended for continue so the host can guide the next turn."},
   "completion":{
@@ -63,10 +65,11 @@ func (updateGoal) PlanModeSafe() bool { return true }
 
 func (updateGoal) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Status     string `json:"status"`
-		Reason     string `json:"reason"`
-		NextAction string `json:"next_action"`
-		Completion struct {
+		Status      string `json:"status"`
+		BlockedKind string `json:"blocked_kind"`
+		Reason      string `json:"reason"`
+		NextAction  string `json:"next_action"`
+		Completion  struct {
 			Verified   []string `json:"verified"`
 			Unverified []string `json:"unverified"`
 			Risks      []string `json:"risks"`
@@ -84,6 +87,22 @@ func (updateGoal) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if (p.Status == "continue" || p.Status == "blocked") && strings.TrimSpace(p.Reason) == "" {
 		return "", fmt.Errorf("update_goal: reason is required for %s — no goal state was changed", p.Status)
 	}
+	blockedKind := strings.ToLower(strings.TrimSpace(p.BlockedKind))
+	switch blockedKind {
+	case "", "user", "technical":
+	default:
+		return "", fmt.Errorf("update_goal: blocked_kind must be one of user|technical, got %q — no goal state was changed", blockedKind)
+	}
+	// #8774 hard gate: a technical self-report is only honored after the
+	// executor actually tried at least minSelfReportRounds tool rounds with
+	// at least one failure or zero-gain round. This is a host-side hard check,
+	// not a prompt soft constraint — a first-round bailout is rejected and the
+	// model must keep working.
+	if p.Status == "blocked" && blockedKind == "technical" {
+		if err := checkTechnicalAttempts(ctx); err != nil {
+			return "", err
+		}
+	}
 	for i, command := range p.Completion.Verified {
 		if strings.TrimSpace(command) == "" {
 			return "", fmt.Errorf("update_goal: completion.verified[%d] is empty — cite the command as it actually ran, or leave the list out", i)
@@ -94,9 +113,10 @@ func (updateGoal) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("update_goal is only available while an active goal turn is running — no goal state was changed")
 	}
 	result, err := recorder.RecordGoalReport(tool.GoalReport{
-		Status:     p.Status,
-		Reason:     strings.TrimSpace(p.Reason),
-		NextAction: strings.TrimSpace(p.NextAction),
+		Status:      p.Status,
+		BlockedKind: blockedKind,
+		Reason:      strings.TrimSpace(p.Reason),
+		NextAction:  strings.TrimSpace(p.NextAction),
 	})
 	if err != nil || p.Status != "complete" {
 		return result, err
@@ -113,4 +133,31 @@ func completionNote(verified, unverified, risks int) string {
 	}
 	return fmt.Sprintf(" Completion account recorded (%d verified, %d unverified, %d risks); the verified commands are reconciled against this session's receipts.",
 		verified, unverified, risks)
+}
+
+// checkTechnicalAttempts enforces the #8774 fast-channel hard gate: the
+// executor must have attempted at least two tool rounds with at least one
+// failure before a technical self-report is honored. The evidence ledger is
+// session-scoped, so attempts from earlier continuation turns of the same
+// Goal count toward the threshold.
+func checkTechnicalAttempts(ctx context.Context) error {
+	ledger, ok := evidence.FromContext(ctx)
+	if !ok || ledger == nil {
+		return fmt.Errorf("update_goal: blocked_kind=technical requires the goal evidence ledger — no goal state was changed")
+	}
+	receipts := ledger.Receipts()
+	attempts := 0
+	failed := 0
+	for _, r := range receipts {
+		if r.Success {
+			attempts++
+		} else {
+			attempts++
+			failed++
+		}
+	}
+	if attempts < 2 || failed < 1 {
+		return fmt.Errorf("update_goal: blocked_kind=technical requires at least 2 attempted tool rounds with at least 1 failure (got %d attempts, %d failures) — keep working and retry later; no goal state was changed", attempts, failed)
+	}
+	return nil
 }

--- a/internal/tool/builtin/updategoal_test.go
+++ b/internal/tool/builtin/updategoal_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/evidence"
 	"reasonix/internal/tool"
 )
 
@@ -147,5 +148,57 @@ func TestUpdateGoalRecorderErrorsPropagate(t *testing.T) {
 	_, err := toolFn.Execute(ctx, json.RawMessage(`{"status":"complete"}`))
 	if err == nil || !strings.Contains(err.Error(), "conflicting reports") {
 		t.Fatalf("Execute() error = %v, want recorder error propagated", err)
+	}
+}
+
+
+// --- #8774 blocked_kind and the technical hard gate ---
+
+func TestUpdateGoalBlockedKindValidation(t *testing.T) {
+	toolFn, _, ctx := goalTool(t)
+	_, err := toolFn.Execute(ctx, json.RawMessage(`{"status":"blocked","blocked_kind":"weird","reason":"nope"}`))
+	if err == nil || !strings.Contains(err.Error(), "blocked_kind") {
+		t.Fatalf("err = %v, want blocked_kind validation error", err)
+	}
+}
+
+func TestUpdateGoalTechnicalBlockedHardGate(t *testing.T) {
+	toolFn, rec, baseCtx := goalTool(t)
+
+	// No evidence ledger at all → rejected.
+	_, err := toolFn.Execute(baseCtx, json.RawMessage(`{"status":"blocked","blocked_kind":"technical","reason":"stuck"}`))
+	if err == nil || !strings.Contains(err.Error(), "ledger") {
+		t.Fatalf("no-ledger err = %v, want ledger error", err)
+	}
+
+	// Ledger with 1 successful round → rejected (attempts < 2).
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true})
+	ctx := evidence.WithLedger(baseCtx, ledger)
+	_, err = toolFn.Execute(ctx, json.RawMessage(`{"status":"blocked","blocked_kind":"technical","reason":"stuck"}`))
+	if err == nil || !strings.Contains(err.Error(), "at least 2") {
+		t.Fatalf("1-round err = %v, want attempt-threshold error", err)
+	}
+
+	// Ledger with 2 successful rounds → rejected (no failure yet).
+	ledger2 := evidence.NewLedger()
+	ledger2.Record(evidence.Receipt{ToolName: "bash", Success: true})
+	ledger2.Record(evidence.Receipt{ToolName: "bash", Success: true})
+	ctx2 := evidence.WithLedger(baseCtx, ledger2)
+	_, err = toolFn.Execute(ctx2, json.RawMessage(`{"status":"blocked","blocked_kind":"technical","reason":"stuck"}`))
+	if err == nil || !strings.Contains(err.Error(), "at least 1 failure") {
+		t.Fatalf("2-success err = %v, want failure-threshold error", err)
+	}
+
+	// Ledger with 1 success + 1 failure → accepted and recorded as technical.
+	ledger3 := evidence.NewLedger()
+	ledger3.Record(evidence.Receipt{ToolName: "bash", Success: true})
+	ledger3.Record(evidence.Receipt{ToolName: "bash", Success: false})
+	ctx3 := evidence.WithLedger(baseCtx, ledger3)
+	if _, err := toolFn.Execute(ctx3, json.RawMessage(`{"status":"blocked","blocked_kind":"technical","reason":"deprecated API"}`)); err != nil {
+		t.Fatalf("qualified technical report rejected: %v", err)
+	}
+	if len(rec.reports) != 1 || rec.reports[0].BlockedKind != "technical" {
+		t.Fatalf("reports = %+v, want one technical record", rec.reports)
 	}
 }

--- a/internal/tool/goal.go
+++ b/internal/tool/goal.go
@@ -13,6 +13,10 @@ type GoalReport struct {
 	Reason string
 	// NextAction is an optional concrete next step (recommended for continue).
 	NextAction string
+	// BlockedKind distinguishes a technical blockage (the executor cannot
+	// make progress and asks the host to re-plan, #8774) from the ordinary
+	// user-blocked disposition. Empty means user-blocked.
+	BlockedKind string
 }
 
 // GoalTurnRecorder records the model's update_goal report for the active goal


### PR DESCRIPTION
## Summary

Goal auto-continuation turns run **executor-only** with no planner involvement: they are synthetic (`synthetic: true`, `turn_orchestrator.go:66`) and the first routing check sends them to `executor_only` (`planner_gate.go:122-124`). When the executor gets stuck, the host only injects a self-guidance text ("Re-plan and continue...", `progress_guard.go:127-134`) and resets the streak counter — no external perspective, no contract update, and the model often spins in the same loop until the token budget is exhausted.

This PR adds an **on-demand planner escalation** for stuck goal continuations (proposal #8774):

1. **Fast channel (model self-report)**: `update_goal` gains a `blocked_kind` field (`user` | `technical`). A `technical` self-report is honored only after a **host-side hard gate** — at least 2 attempted tool rounds with at least 1 failure (checked against the evidence ledger, not a prompt soft constraint; first-round bailouts are rejected with a fixable error).
2. **Slow channel (host evidence monitor)**: the goal-scoped progress-guard stop tier emits a host-visible escalation signal (`Agent.requestGoalEscalation` / `ConsumeGoalEscalationSignal`), and consecutive FinalReadiness failures (≥3) escalate with the missing-requirements list.
3. **Escalation state** persists in the goal sidecar (`goalState.Escalated/EscalationReason/EscalationDetail/EscalationCount`, backward compatible).
4. **Routing**: `DecidePlannerRoute` routes the next continuation turn to `plan_and_execute light` (research ≤2 rounds) when `meta.Escalated` — placed **before** the synthetic check, with the stuck-evidence summary passed to the planner input (`<planner-turn>` escalation block).
5. **Loop protection**: max 3 escalations per goal (`maxGoalEscalations`), then fail-closed `blocked` (`stopCauseEscalationExhausted`). The marker clears after the escalated turn.

Re-planning is real: the planner revision feeds back through the existing `submit_plan` → `deliverPlan` → `seedPlanTodos` path — todos, acceptance criteria and verification expectations update together, so `FinalReadiness` re-checks against the revised contract.

## Issues

Refs #8774

## Verification

- `go test ./internal/control/ -count=1` — pass (48s), incl. new FSM tests
- `go test ./internal/agent/ -count=1` — pass (89s), incl. new signal round-trip test
- `go test ./internal/tool/builtin/ -count=1` — pass (39s), incl. new hard-gate tests
- New tests: `TestEscalatedRoutesToLightPlanner`, `TestGoalEscalationSlowChannelSchedulesPlannerRevision`, `TestGoalEscalationFastChannelTechnical`, `TestGoalEscalationClearedAfterEscalatedTurn`, `TestGoalEscalationBudgetExhausted`, `TestGoalReadinessFailuresEscalateAfterThreshold`, `TestUpdateGoalBlockedKindValidation`, `TestUpdateGoalTechnicalBlockedHardGate`, `TestGoalEscalationSignalRoundTrip`

Documentation-impact: none- internal goal routing and update_goal schema extension only; no CLI, config or user-facing workflow change (the new `blocked_kind` field is optional and defaults to the existing `user` semantics).

Cache-impact: updated- provider-visible change is limited to the `update_goal` tool schema (one optional enum field) and its description.
Cache-guard: updated- `go test ./internal/agent/ -run 'ProjectionValid|LoadProjectionSidecar|CoveredPrefixHash'` plus the full builtin tool suite above.

System-prompt-review: none- no system prompt, memory, or skill prefix changes; the executor tool list is unchanged.

## 中文摘要

Goal 自动续跑轮是合成轮（synthetic → executor_only），planner 从不参与；执行卡住时宿主只注入一句自我指导文本并清零计数，模型常在同一坑里打转直到 token 预算耗尽（见 #8774）。

本 PR 实现"按需唤醒规划模型"：① 快通道——`update_goal` 新增 `blocked_kind: technical`，模型自报"技术性卡住"须通过宿主硬校验（≥2 工具轮且 ≥1 失败，读证据账本，非 prompt 软约束，第一轮就喊救命会被拒绝）；② 慢通道——progressGuard 停止档输出宿主可见信号 + FinalReadiness 连续失败 ≥3 次携带缺失清单；③ 状态入 Goal sidecar（4 字段，向后兼容）；④ 路由在 synthetic 检查之前命中 `plan_and_execute light`（研究 ≤2 轮），卡点证据随 `<planner-turn>` 块给到规划模型；⑤ 每 Goal 最多 3 次 escalate，超出 fail-closed blocked。

修订走既有 `submit_plan → deliverPlan → seedPlanTodos` 链路：todo/验收标准/验证要求同步更新，FinalReadiness 按修订契约复检——这是真实的外部规划，不是文本指导。