### PR TITLE
fix(provider): follow DeepSeek's official 384K output ceiling / 官方 DeepSeek 取消 16/32/64K 自动档，改走 384K

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -70,10 +70,10 @@ reasoning_language = "auto"      # visible reasoning text: auto|zh|en
 # max_subagent_concurrency = 6        # session-wide sub-agent concurrency (task/fleet/skills)
 # max_parallel_writers = 3            # concurrent writers with non-overlapping write_paths
 # compact_ratio = 0.85             # sole auto trigger; presets 0.70 / 0.80 / 0.85
-# max_output_tokens = 0            # recommended: automatic (DeepSeek default high → ~64K; not unlimited)
-# max_output_tokens = 32768        # ordinary coding / cost control
-# max_output_tokens = 65536        # heavy reasoning / long tool loops
-# max_output_tokens = 131072       # only after repeated finish_reason=length
+# max_output_tokens = 0            # recommended: official DeepSeek omits the field (server 384K)
+# max_output_tokens = 32768        # optional cost cap
+# max_output_tokens = 65536        # optional cost cap
+# max_output_tokens = 131072       # optional cost cap
 # max_output_tokens never changes compact_ratio; only the final send-time clip does
 
 [[providers]]

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -64,9 +64,9 @@ reasoning_language = "auto"      # 可见思考过程语言：auto|zh|en
 # max_subagent_concurrency = 6        # 会话级子代理总并发（task/fleet/skills）
 # max_parallel_writers = 3            # 互不重叠 write_paths 时的并行写入上限
 # compact_ratio 是唯一自动维护阈值（默认 0.85；预设 0.70/0.80/0.85）
-# max_output_tokens = 0            # 推荐：自动（DeepSeek 默认 high → 约 64K；不是无限）
-# max_output_tokens = 32768        # 普通编码 / 控制费用
-# max_output_tokens = 65536        # 重推理、长工具链
+# max_output_tokens = 0            # 推荐：官方 DeepSeek 省略字段（服务端 384K）
+# max_output_tokens = 32768        # 可选控费上限
+# max_output_tokens = 65536        # 可选控费上限
 # max_output_tokens = 131072       # 仅在反复 finish_reason=length 时再考虑
 # max_output_tokens 不参与 compact_ratio；只在发送阶段裁剪本轮最长输出
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -274,11 +274,12 @@ when the sole automatic threshold is crossed.
   user-global value used by desktop and new CLI sessions. UI always shows the
   **effective** ratio.
 - `max_output_tokens` is an independent **per-turn** completion ceiling.
-  Recommended: `0` (**automatic**, not unlimited; DeepSeek default high → ~64K).
-  User presets: `32768` ordinary coding / cost control, `65536` heavy reasoning /
-  long tool loops, `131072` only after repeated `finish_reason=length`.
-  Negative omits optional wire limits when the protocol allows. Clipped only at
-  send time against remaining window and **never** changes `triggerTokens` or
+  Recommended: `0` — official DeepSeek omits the field so the server uses the
+  documented **384K** output cap; thinking depth is `effort` only (default high).
+  A positive value is an explicit cost cap. Negative omits optional wire limits
+  when the protocol allows; official DeepSeek Anthropic still sends 384K because
+  `max_tokens` is required (`budget_tokens` is ignored). Clipped only at send
+  time against remaining window and **never** changes `triggerTokens` or
   maintenance timing. Billing follows actual completion tokens, not the ceiling.
 - Giant tool results are bounded **once**, on first entry to the model:
   `Content` is the stable ≤32KB visible form; `RawContent` holds the full original
@@ -1035,10 +1036,10 @@ default        = "deepseek-v4-flash"   # optional; defaults to models[0]
 api_key_env    = "DEEPSEEK_API_KEY"
 web_search     = true
 context_window = 1000000   # tokens; harness compacts older history near this limit (0 disables)
-# max_output_tokens = 0              # recommended: automatic (DeepSeek default high → ~64K)
-# max_output_tokens = 32768          # ordinary coding / cost control
-# max_output_tokens = 65536          # heavy reasoning / long tool loops
-# max_output_tokens = 131072         # only after repeated finish_reason=length
+# max_output_tokens = 0              # recommended: official DeepSeek omits the field (server 384K)
+# max_output_tokens = 32768          # optional cost cap
+# max_output_tokens = 65536          # optional cost cap
+# max_output_tokens = 131072         # optional cost cap
 # max_output_tokens never changes compact_ratio
 # model_overrides = { "deepseek-v4-flash" = { context_window = 1000000, max_output_tokens = 32768 } }
 

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -73,7 +73,7 @@ func New(kind string, cfg Config) (Provider, error)
 - OpenAI-compatible vendor 只是 `kind = "openai"` 的不同配置实例，通过 `base_url`、`model`、`api_key_env` 区分；新增兼容模型通常只需改配置。
 - 一个 provider 表示一个 vendor endpoint，可通过 `models` 暴露多个模型，并以 `default` 指定默认项。设置 `request_url` 时，OpenAI-compatible、Anthropic-compatible 和 Responses provider 都会原样使用该完整请求地址；旧 `chat_url` 只保留 OpenAI 历史兼容语义。`default_model`、`--model` 和桌面端模型选择器都经 `Config.ResolveModel` 解析，可接受 provider 名、裸模型名或 `provider/model`。
 - `context_window` 是 provider 级默认值；`model_overrides.<model>.context_window` 可覆盖单个模型。
-- `max_output_tokens` 是独立的本轮输出上限，不由客户端 reasoning 字节上限换算，也不参与 `compact_ratio`。推荐 `0`（自动：DeepSeek 默认 high 约 64K）；显式 `32768` 控费/普通编码，`65536` 重推理/长工具链，`131072` 仅在反复 `finish_reason=length` 时再考虑。正数为显式上限，负数为在协议允许时省略；混合网关可用 `model_overrides.<model>.max_output_tokens` 覆盖单个模型。Anthropic 因协议要求仍会提供 `max_tokens` 默认值。
+- `max_output_tokens` 是独立的本轮输出上限，不由客户端 reasoning 字节上限换算，也不参与 `compact_ratio`。推荐 `0`：官方 DeepSeek 省略该字段，由服务端使用定价页上的 **384K** 输出上限；思考深度只走 `effort`（默认 high）。正数为用户显式控费上限。负数为在协议允许时省略；官方 DeepSeek 的 Anthropic 兼容层因 `max_tokens` 必填，仍发送 384K。`budget_tokens` 在该兼容层会被忽略。混合网关可用 `model_overrides.<model>.max_output_tokens` 覆盖单个模型。
 - streaming tool-call delta 在 provider 内按 index 聚合，只向上层发出完整 `ToolCall`。
 
 ### 3.2 Tool 与 registry（`internal/tool`）
@@ -173,10 +173,9 @@ transcript，仅在唯一自动阈值被跨越时安装 provider 可见的短 **
 - 用户可用 `reasonix config compact-ratio [--local] [VALUE]` 查看或修改阈值。
   项目配置优先于桌面与新 CLI 会话共用的用户全局配置。UI 始终展示**实际生效**值。
 - `max_output_tokens` 是独立的**本轮**输出上限。
-  推荐 `0`（**自动**，不是无限；DeepSeek 默认 high → 约 64K）。
-  用户侧常用值：`32768` 普通编码/控费，`65536` 重推理/长工具链，`131072` 仅在反复
-  `finish_reason=length` 时再考虑。负数为在协议允许时省略。仅在发送阶段按剩余
-  窗口裁剪，**绝不**改变 `triggerTokens` 或维护时机。计费按实际 completion，不按配置上限。
+  推荐 `0`：官方 DeepSeek 省略该字段，由服务端使用定价页 **384K** 上限；思考深度只走 `effort`。
+  正数为用户显式控费上限。负数为在协议允许时省略（官方 Anthropic 兼容层仍发送 384K）。
+  仅在发送阶段按剩余窗口裁剪，**绝不**改变 `triggerTokens` 或维护时机。计费按实际 completion，不按配置上限。
 - 巨型工具结果只在**第一次**进入模型前限长：`Content` 为稳定 ≤32KB 可见版；
   超限时 `RawContent` 保存完整原文。后续维护不得回头改写。`ModelMessages` 会去掉
   `RawContent`，provider 序列化与缓存 hash 永不包含它。
@@ -410,10 +409,10 @@ default        = "deepseek-v4-flash"
 api_key_env    = "DEEPSEEK_API_KEY"
 web_search     = true
 context_window = 1000000
-# max_output_tokens = 0              # 推荐：自动（DeepSeek 默认 high → 约 64K）
-# max_output_tokens = 32768          # 普通编码 / 控制费用
-# max_output_tokens = 65536          # 重推理、长工具链
-# max_output_tokens = 131072         # 仅在反复 finish_reason=length 时再考虑
+# max_output_tokens = 0              # 推荐：官方 DeepSeek 省略字段（服务端 384K）
+# max_output_tokens = 32768          # 可选控费上限
+# max_output_tokens = 65536          # 可选控费上限
+# max_output_tokens = 131072         # 可选控费上限
 
 [tools]
 enabled = []

--- a/docs/research/cache-aware-compaction-design.md
+++ b/docs/research/cache-aware-compaction-design.md
@@ -88,7 +88,7 @@ stable system / early prefix
 ## 六、Provider 与输出预算
 
 - 应用层 summary 是默认路径；Responses 等 native compaction 标记 unsupported 时回退 summary
-- `max_output_tokens=0` 表示 auto ladder（普通 16K / reasoning 32K / high·max 64K）；128K 仅显式配置
+- `max_output_tokens=0` 在官方 DeepSeek 上省略该字段（服务端 384K 上限）；MiMo 等仍用 16K/32K 梯子。思考深度只走 effort。
 - auto ladder 与 `compact_ratio` 解耦
 
 ## 七、缓存影响

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -50,7 +50,9 @@ const maxStreamRecoveries = 5
 const maxSamplingAttempts = maxStreamRecoveries + 1
 const maxExecutorHandoffNudges = 1
 
-const defaultReasoningByteLimit = 128 * 1024
+// defaultReasoningByteLimit caps stored hidden reasoning for one stream.
+// It does not cancel generation; official DeepSeek may emit up to 384K tokens.
+const defaultReasoningByteLimit = 8 << 20
 
 const finishReasonClientReasoningLimit = "client_reasoning_limit"
 
@@ -1898,12 +1900,12 @@ func (a *Agent) streamWithFrozen(ctx context.Context, turn int, sink event.Sink,
 			if chunk.Text != "" && !transformReasoning {
 				sink.Emit(event.Event{Kind: event.Reasoning, Text: chunk.Text})
 			}
+			// Bound stored hidden reasoning only. Do not cancel the provider
+			// stream: official DeepSeek bills this output and still needs to
+			// emit the visible answer or tool calls.
 			if a.reasoningByteLimit > 0 && reasoning.Len() > a.reasoningByteLimit {
-				stored, _ := finishReasoning()
-				usage = bestEffortStreamUsage(usage, text.Len(), reasoning.Len(), finishReasonClientReasoningLimit)
-				usage = provider.UsageWithRequestAttemptCount(ctx, usage)
-				a.storeLatestRequestUsage(usage)
-				return collect(stored, errReasoningByteLimitExceeded)
+				reasoning.Reset()
+				reasoning.WriteString(snapToRuneBoundary(chunk.Text, 0, min(len(chunk.Text), a.reasoningByteLimit)))
 			}
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)

--- a/internal/agent/cancel_test.go
+++ b/internal/agent/cancel_test.go
@@ -186,62 +186,85 @@ func (p activeReasoningUntilCancelProvider) Stream(ctx context.Context, _ provid
 	return ch, nil
 }
 
-type reasoningGuardCancelProvider struct {
-	canceled chan struct{}
+type finiteReasoningThenTextProvider struct {
+	canceled        chan struct{}
+	reasoning, text string
+	finished        bool
 }
 
-func (reasoningGuardCancelProvider) Name() string { return "reasoning-guard-cancel" }
+func (finiteReasoningThenTextProvider) Name() string { return "finite-reasoning" }
 
-func (p reasoningGuardCancelProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+func (p *finiteReasoningThenTextProvider) Stream(ctx context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
 	ch := make(chan provider.Chunk)
 	go func() {
 		defer close(ch)
 		defer close(p.canceled)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ch <- provider.Chunk{Type: provider.ChunkReasoning, Text: "0123456789abcdef"}:
-			}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- provider.Chunk{Type: provider.ChunkReasoning, Text: p.reasoning}:
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- provider.Chunk{Type: provider.ChunkText, Text: p.text}:
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case ch <- provider.Chunk{Type: provider.ChunkDone}:
+			p.finished = true
 		}
 	}()
 	return ch, nil
 }
 
-func TestRunawayReasoningStopsAtAgentSideByteGuard(t *testing.T) {
+func TestReasoningByteGuardDoesNotAbortTurn(t *testing.T) {
 	sink := &recordSink{}
-	a := New(activeReasoningUntilCancelProvider{}, tool.NewRegistry(), NewSession(""), Options{ReasoningByteLimit: 64}, sink)
+	reasoning := strings.Repeat("abcd", 64)
+	prov := testutil.NewMock("m", testutil.Turn{Reasoning: reasoning, Text: "svg done"})
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{ReasoningByteLimit: 32}, sink)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-
-	err := a.Run(ctx, "parse this binary by offset")
-	if !errors.Is(err, errReasoningByteLimitExceeded) {
-		t.Fatalf("Run error = %v, want reasoning limit guard", err)
+	if err := a.Run(context.Background(), "draw the compound bow"); err != nil {
+		t.Fatalf("Run error = %v, byte guard must not fail the turn", err)
 	}
-	if got := len(sink.kinds(event.Reasoning)); got == 0 {
-		t.Fatal("no reasoning chunks emitted; repro did not exercise the active-output path")
+	if got := sink.kinds(event.Text); len(got) == 0 || !strings.Contains(got[0].Text, "svg done") {
+		t.Fatal("visible answer was dropped after the reasoning buffer cap")
 	}
-	usages := sink.kinds(event.Usage)
-	if len(usages) != 1 {
-		t.Fatalf("usage events = %d, want one best-effort usage event", len(usages))
-	}
-	if u := usages[0].Usage; u == nil || u.FinishReason != "client_reasoning_limit" || !u.Estimated || u.TotalTokens <= 0 || u.ReasoningTokens <= 0 {
-		t.Fatalf("usage = %+v, want client reasoning limit with estimated reasoning tokens", u)
+	for _, notice := range sink.kinds(event.Notice) {
+		if strings.Contains(notice.Text, "client reasoning safety limit") {
+			t.Fatalf("unexpected abort notice %q", notice.Text)
+		}
 	}
 }
 
-func TestReasoningByteGuardCancelsProviderStream(t *testing.T) {
-	canceled := make(chan struct{})
-	a := New(reasoningGuardCancelProvider{canceled: canceled}, tool.NewRegistry(), NewSession(""), Options{ReasoningByteLimit: 32}, event.Discard)
+func TestDefaultReasoningGuardAllowsFormer128KiBStream(t *testing.T) {
+	// 128KiB is ~32K estimated tokens — a legitimate DeepSeek V4 Pro think.
+	reasoning := strings.Repeat("abcd", 128*1024/4+1)
+	prov := testutil.NewMock("m", testutil.Turn{Reasoning: reasoning, Text: "svg done"})
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "draw the compound bow"); errors.Is(err, errReasoningByteLimitExceeded) {
+		t.Fatalf("default guard aborted a %d-byte reasoning stream", len(reasoning))
+	} else if err != nil {
+		t.Fatal(err)
+	}
+}
 
-	if err := a.Run(context.Background(), "trigger the reasoning guard"); !errors.Is(err, errReasoningByteLimitExceeded) {
-		t.Fatalf("Run error = %v, want reasoning limit guard", err)
+func TestReasoningByteGuardDoesNotCancelProviderStream(t *testing.T) {
+	canceled := make(chan struct{})
+	prov := &finiteReasoningThenTextProvider{canceled: canceled, reasoning: strings.Repeat("x", 64), text: "done"}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{ReasoningByteLimit: 16}, event.Discard)
+
+	if err := a.Run(context.Background(), "keep generating"); err != nil {
+		t.Fatalf("Run error = %v, byte guard must not cancel the provider", err)
 	}
 	select {
 	case <-canceled:
 	case <-time.After(time.Second):
-		t.Fatal("provider context remained live after the reasoning guard returned")
+		t.Fatal("provider stream did not finish after the answer")
+	}
+	if !prov.finished {
+		t.Fatal("provider stream was cut off before the final text")
 	}
 }
 

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -300,8 +301,12 @@ func (a *Agent) runToolLoop(ctx context.Context, state *turnRuntime) error {
 		if err != nil {
 			a.emitTurnUsage(usage, &cacheDiagnostics)
 			a.observeRunBudget(state, usage)
-			if msg, ok := finishReasonMessage(usage); ok {
-				a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
+			// The byte-limit sentinel is already the user-facing turn error.
+			// Emitting the finish-reason notice as well doubles the same warning.
+			if !errors.Is(err, errReasoningByteLimitExceeded) {
+				if msg, ok := finishReasonMessage(usage); ok {
+					a.svc.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
+				}
 			}
 			// Exhausted stream retries (or a non-retryable error): persist one
 			// bounded LocalOnly recovery record for the next real user message.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1361,12 +1361,11 @@ type ProviderEntry struct {
 	BalanceURL        string `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
 	ContextWindow     int    `toml:"context_window"`
 	// MaxOutputTokens is a protocol-neutral total output budget for one turn.
-	// Zero means automatic (not unlimited): ordinary 16K, reasoning 32K, high/max
-	// 64K — DeepSeek's default effort is high, so auto is typically ~64K.
-	// User guidance: 0 recommended; 32768 ordinary coding/cost control;
-	// 65536 heavy reasoning/long tools; 131072 only after finish_reason=length.
-	// A negative value omits optional wire limits when the protocol allows;
-	// Anthropic still requires max_tokens. Never feeds compact_ratio.
+	// Zero means official DeepSeek omits the field (server 384K ceiling) and
+	// other vendors keep their own defaults. Effort selects thinking depth only.
+	// A positive value is an explicit cost cap. A negative value omits optional
+	// wire limits when the protocol allows; official DeepSeek Anthropic still
+	// sends 384K because max_tokens is mandatory. Never feeds compact_ratio.
 	MaxOutputTokens int                          `toml:"max_output_tokens"`
 	Price           *provider.Pricing            `toml:"price"`  // legacy/provider-wide fallback
 	Prices          map[string]*provider.Pricing `toml:"prices"` // optional per-model prices; keys are model ids

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -351,12 +351,12 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 				fmt.Fprintf(&b, "context_window = %d   # tokens; compaction triggers near this limit\n", p.ContextWindow)
 			}
 			if p.MaxOutputTokens != 0 {
-				fmt.Fprintf(&b, "max_output_tokens = %d   # per-turn total output; 0 = auto (~64K on DeepSeek high), 32768/65536/131072 explicit; never affects compact_ratio\n", p.MaxOutputTokens)
+				fmt.Fprintf(&b, "max_output_tokens = %d   # per-turn total output; 0 = official DeepSeek 384K / omit field; positive = cost cap; never affects compact_ratio\n", p.MaxOutputTokens)
 			} else {
-				b.WriteString("# max_output_tokens = 0       # recommended: automatic (DeepSeek default high → ~64K; not unlimited)\n")
-				b.WriteString("# max_output_tokens = 32768   # ordinary coding / cost control\n")
-				b.WriteString("# max_output_tokens = 65536   # heavy reasoning / long tool loops\n")
-				b.WriteString("# max_output_tokens = 131072  # only after repeated finish_reason=length\n")
+				b.WriteString("# max_output_tokens = 0       # recommended: official DeepSeek omits the field (server 384K ceiling)\n")
+				b.WriteString("# max_output_tokens = 32768   # optional cost cap\n")
+				b.WriteString("# max_output_tokens = 65536   # optional cost cap\n")
+				b.WriteString("# max_output_tokens = 131072  # optional cost cap\n")
 			}
 			if p.Price != nil {
 				fmt.Fprintf(&b, "price       = %s   # provider-wide fallback, per 1M tokens\n", renderPricingInline(p.Price))

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -51,8 +51,8 @@ const (
 	// gateway). Bedrock/Vertex use a different request shape and are out of scope.
 	defaultBaseURL = "https://api.anthropic.com"
 	// defaultMaxTokens is the mandatory Anthropic fallback when neither config
-	// nor request supplies max_tokens. Ordinary turns use 16K; reasoning-capable
-	// paths raise via AutoOutputBudget. 128K is never automatic.
+	// nor request supplies max_tokens. Native Anthropic stays at 16K; official
+	// DeepSeek sends the documented 384K ceiling because budget_tokens is ignored.
 	defaultMaxTokens = provider.DefaultOrdinaryOutputTokens
 )
 
@@ -112,13 +112,8 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	if maxOutputTokens <= 0 {
 		// Messages requires max_tokens. 0 = automatic; negative also falls back
 		// because the wire field is mandatory.
-		reasoningOn := officialDeepSeek &&
-			!strings.EqualFold(thinking, "disabled") &&
-			!strings.EqualFold(effort, "disabled") &&
-			!strings.EqualFold(effort, "off") &&
-			!strings.EqualFold(effort, "none")
 		if officialDeepSeek {
-			maxOutputTokens = provider.AutoOutputBudget(reasoningOn, effort)
+			maxOutputTokens = provider.DeepSeekMaxOutputTokens
 		} else {
 			// Native Anthropic and unknown gateways: conservative ordinary default.
 			maxOutputTokens = defaultMaxTokens

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -162,8 +162,9 @@ func TestNewSelectsMaxOutputTokenDefaultByEndpoint(t *testing.T) {
 	}{
 		{name: "native anthropic", want: provider.DefaultOrdinaryOutputTokens},
 		{name: "unknown compatible gateway", baseURL: "https://proxy.example.com/anthropic", want: provider.DefaultOrdinaryOutputTokens},
-		{name: "official deepseek", baseURL: "https://api.deepseek.com/anthropic", want: provider.DefaultReasoningOutputTokens},
-		{name: "official deepseek high", baseURL: "https://api.deepseek.com/anthropic", extra: map[string]any{"effort": "high"}, want: provider.DefaultHighReasoningOutputTokens},
+		{name: "official deepseek", baseURL: "https://api.deepseek.com/anthropic", want: provider.DeepSeekMaxOutputTokens},
+		{name: "official deepseek high", baseURL: "https://api.deepseek.com/anthropic", extra: map[string]any{"effort": "high"}, want: provider.DeepSeekMaxOutputTokens},
+		{name: "official deepseek thinking off", baseURL: "https://api.deepseek.com/anthropic", extra: map[string]any{"effort": "none"}, want: provider.DeepSeekMaxOutputTokens},
 		{name: "explicit override", baseURL: "https://api.deepseek.com/anthropic", extra: map[string]any{"max_output_tokens": 8192}, want: 8192},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -223,15 +223,9 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		thinkingType: thinkingType, effort: effort, deepseek: deepseek, flash: deepseekV4Flash,
 		minimax: minimax, zhipu: zhipu, longcat: longcat, ollamaCloud: ollamaCloud,
 		explicit: hasExplicitEfforts, supported: supportedEfforts})
-	// max_output_tokens=0 means automatic (not unlimited). DeepSeek reasoning
-	// uses 32K / high-max 64K; thinking-disabled stays ordinary 16K. 128K is
-	// never automatic — users must set it explicitly after length truncations.
-	// This budget never participates in compact_ratio.
-	autoMaxOutput := maxOutputTokens == 0 && officialDeepSeek
-	if autoMaxOutput {
-		reasoningOn := thinkingType != "disabled" && effort != "disabled" && effort != "off" && effort != "none"
-		maxOutputTokens = provider.AutoOutputBudget(reasoningOn, effort)
-	}
+	// max_output_tokens=0 on official DeepSeek omits the wire field so the
+	// server uses its 384K ceiling. Effort only selects thinking depth.
+	// Non-DeepSeek endpoints leave 0 as "unset / omit". Never compact_ratio.
 	httpClient, err := newHTTPClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("openai: network: %w", err)
@@ -257,7 +251,6 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		vision:          vision,
 		visionDetail:    visionDetail,
 		maxOutputTokens: maxOutputTokens,
-		autoMaxOutput:   autoMaxOutput,
 		effort:          effort,
 		requestEfforts:  requestEfforts,
 		http:            httpClient,
@@ -297,7 +290,6 @@ type client struct {
 	vision          bool          // model accepts image input — embed attached images as image_url parts
 	visionDetail    string        // image_url detail hint (low|high); "" = auto/omit
 	maxOutputTokens int           // resolved total output budget; <=0 omits the optional field
-	autoMaxOutput   bool          // true when max_output_tokens=0 (automatic ladder)
 	effort          string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
 	requestEfforts  []string      // depth levels a per-request EffortOverride may take; empty = overrides ignored
 	idleTimeout     time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
@@ -781,15 +773,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 
 	maxOutputTokens := req.MaxTokens
 	if maxOutputTokens == 0 {
-		if c.autoMaxOutput && c.deepseek {
-			// Re-resolve so per-request EffortOverride (high/max) can raise 32K→64K.
-			effort := c.requestEffort(req)
-			reasoningOn := c.thinkingType != "disabled" &&
-				effort != "disabled" && effort != "off" && effort != "none"
-			maxOutputTokens = provider.AutoOutputBudget(reasoningOn, effort)
-		} else {
-			maxOutputTokens = c.maxOutputTokens
-		}
+		maxOutputTokens = c.maxOutputTokens
 	}
 	if maxOutputTokens < 0 {
 		maxOutputTokens = 0

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -1244,12 +1244,12 @@ func TestBuildRequestUsesProviderSpecificOutputBudget(t *testing.T) {
 		return p.(*client)
 	}
 
-	// Official DeepSeek defaults effort to high when unset, so the automatic
-	// ladder lands on the 64K high-reasoning tier — not 128K.
+	// Official DeepSeek auto omits max_tokens so the server uses its 384K ceiling.
+	// Effort only selects thinking depth; it must not invent a 16/32/64K cap.
 	deepseek := newClient(t, "https://api.deepseek.com", "deepseek-v4-flash", 0).buildRequest(provider.Request{})
-	if deepseek.MaxTokens != provider.DefaultHighReasoningOutputTokens || deepseek.MaxCompletionTokens != 0 {
-		t.Fatalf("DeepSeek auto budget = max_tokens %d, max_completion_tokens %d, want high-reasoning %d",
-			deepseek.MaxTokens, deepseek.MaxCompletionTokens, provider.DefaultHighReasoningOutputTokens)
+	if deepseek.MaxTokens != 0 || deepseek.MaxCompletionTokens != 0 {
+		t.Fatalf("DeepSeek auto budget = max_tokens %d, max_completion_tokens %d, want omitted",
+			deepseek.MaxTokens, deepseek.MaxCompletionTokens)
 	}
 
 	lowEffort, err := New(provider.Config{
@@ -1260,8 +1260,8 @@ func TestBuildRequestUsesProviderSpecificOutputBudget(t *testing.T) {
 		t.Fatalf("New low-effort DeepSeek: %v", err)
 	}
 	lowReq := lowEffort.(*client).buildRequest(provider.Request{})
-	if lowReq.MaxTokens != provider.DefaultReasoningOutputTokens {
-		t.Fatalf("low-effort auto budget = %d, want ordinary reasoning %d", lowReq.MaxTokens, provider.DefaultReasoningOutputTokens)
+	if lowReq.MaxTokens != 0 {
+		t.Fatalf("low-effort auto budget = %d, want omitted", lowReq.MaxTokens)
 	}
 
 	thinkingDisabledProvider, err := New(provider.Config{
@@ -1272,8 +1272,8 @@ func TestBuildRequestUsesProviderSpecificOutputBudget(t *testing.T) {
 		t.Fatalf("New thinking-disabled DeepSeek: %v", err)
 	}
 	thinkingDisabled := thinkingDisabledProvider.(*client).buildRequest(provider.Request{})
-	if thinkingDisabled.MaxTokens != provider.DefaultOrdinaryOutputTokens {
-		t.Fatalf("thinking-disabled DeepSeek auto budget = %d, want ordinary %d", thinkingDisabled.MaxTokens, provider.DefaultOrdinaryOutputTokens)
+	if thinkingDisabled.MaxTokens != 0 {
+		t.Fatalf("thinking-disabled DeepSeek auto budget = %d, want omitted", thinkingDisabled.MaxTokens)
 	}
 	effortDisabledProvider, err := New(provider.Config{
 		Name: "test", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro",
@@ -1283,8 +1283,8 @@ func TestBuildRequestUsesProviderSpecificOutputBudget(t *testing.T) {
 		t.Fatalf("New effort-disabled DeepSeek: %v", err)
 	}
 	effortDisabled := effortDisabledProvider.(*client).buildRequest(provider.Request{})
-	if effortDisabled.MaxTokens != provider.DefaultOrdinaryOutputTokens || effortDisabled.Thinking == nil || effortDisabled.Thinking.Type != "disabled" {
-		t.Fatalf("effort-disabled DeepSeek request = %+v, want thinking disabled with ordinary %d budget", effortDisabled, provider.DefaultOrdinaryOutputTokens)
+	if effortDisabled.MaxTokens != 0 || effortDisabled.Thinking == nil || effortDisabled.Thinking.Type != "disabled" {
+		t.Fatalf("effort-disabled DeepSeek request = %+v, want thinking disabled with omitted budget", effortDisabled)
 	}
 
 	explicitDisabledProvider, err := New(provider.Config{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -231,14 +231,22 @@ type ResponseFormat struct {
 }
 
 // Auto ladder for max_output_tokens=0. Bounds completion only; never compact_ratio.
+// Official DeepSeek does not use this ladder: Chat/Responses omit the field
+// (server 384K ceiling) and Anthropic sends DeepSeekMaxOutputTokens.
 const (
-	DefaultOrdinaryOutputTokens      = 16 * 1024  // non-reasoning
-	DefaultReasoningOutputTokens     = 32 * 1024  // ordinary reasoning
-	DefaultHighReasoningOutputTokens = 64 * 1024  // high/max effort
+	DefaultOrdinaryOutputTokens      = 16 * 1024  // non-reasoning / non-DeepSeek
+	DefaultReasoningOutputTokens     = 32 * 1024  // ordinary reasoning / MiMo
+	DefaultHighReasoningOutputTokens = 64 * 1024  // high/max effort on non-DeepSeek
 	DefaultHighOutputTokens          = 128 * 1024 // explicit only; never auto
+	// DeepSeekMaxOutputTokens is the official V4 Flash/Pro completion ceiling.
+	// Pricing page: 输出长度最大 384K. K is decimal thousands, matching the
+	// documented 1M context = 1,000,000 tokens. Anthropic requires max_tokens.
+	DeepSeekMaxOutputTokens = 384_000
 )
 
-// AutoOutputBudget maps max_output_tokens=0 to 16K/32K/64K by reasoning effort.
+// AutoOutputBudget maps max_output_tokens=0 to 16K/32K/64K for non-DeepSeek
+// vendors. Official DeepSeek omits the field (Chat/Responses) or sends
+// DeepSeekMaxOutputTokens (Anthropic).
 func AutoOutputBudget(reasoningEnabled bool, effort string) int {
 	if !reasoningEnabled {
 		return DefaultOrdinaryOutputTokens

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -73,9 +73,9 @@ type Config struct {
 	KeyEnv     string
 	KeySource  string
 	RequestURL string // optional exact Responses request URL; empty derives from BaseURL
-	// MaxOutputTokens is the total provider output budget. Zero enables Reasonix's
-	// 32K reasoning safety default on official DeepSeek and otherwise omits the
-	// field; thinking-disabled DeepSeek requests and negative values omit it.
+	// MaxOutputTokens is the total provider output budget. Zero omits the field
+	// on official DeepSeek (server 384K ceiling) and unknown endpoints; MiMo
+	// still applies its 16K/32K ladder. Negative values omit it.
 	MaxOutputTokens int
 	// SessionCache controls DashScope's opt-in header. The header is never sent
 	// to non-DashScope endpoints even when this value is true.
@@ -128,15 +128,12 @@ func New(cfg Config) provider.Provider {
 	vendor := DetectVendor(cfg.BaseURL)
 	cap := capabilitiesFor(vendor)
 	maxOutputTokens := cfg.MaxOutputTokens
-	// max_output_tokens=0 is automatic. Known vendors use the 16K/32K/64K ladder;
-	// thinking-disabled DeepSeek still gets the ordinary 16K auto budget.
-	// 128K is never chosen automatically. Compact_ratio is independent.
-	if maxOutputTokens == 0 && cap.defaultMaxOutputTokens > 0 {
-		if vendor == "deepseek" || vendor == "mimo" {
-			maxOutputTokens = responsesAutoOutputBudget(vendor, cfg.Effort)
-		} else {
-			maxOutputTokens = cap.defaultMaxOutputTokens
-		}
+	// Official DeepSeek omits max_output_tokens (server 384K). MiMo still uses
+	// the 16K/32K effort ladder. Compact_ratio is independent.
+	if maxOutputTokens == 0 && vendor == "mimo" {
+		maxOutputTokens = responsesAutoOutputBudget(vendor, cfg.Effort)
+	} else if maxOutputTokens == 0 && vendor != "deepseek" && cap.defaultMaxOutputTokens > 0 {
+		maxOutputTokens = cap.defaultMaxOutputTokens
 	}
 	sessionCache := cap.sessionCacheHeader
 	if cfg.SessionCache != nil {
@@ -177,9 +174,8 @@ func responsesReasoningDisabled(effort string) bool {
 	}
 }
 
-// responsesAutoOutputBudget mirrors Chat Completions: DeepSeek defaults empty
-// effort to high (64K), low stays 32K, thinking disabled is ordinary 16K.
-// Never auto-selects 128K.
+// responsesAutoOutputBudget is the MiMo (and similar) 16K/32K ladder.
+// Official DeepSeek must not call this; it omits max_output_tokens instead.
 func responsesAutoOutputBudget(vendor, effort string) int {
 	if responsesReasoningDisabled(effort) {
 		return provider.AutoOutputBudget(false, effort)
@@ -314,12 +310,10 @@ func (c *client) buildRequestBody(req provider.Request) (map[string]any, bool, [
 	if maxOutputTokens == 0 {
 		maxOutputTokens = c.maxOutputTokens
 	}
-	if maxOutputTokens == 0 && c.caps.defaultMaxOutputTokens > 0 {
-		if c.vendor == "deepseek" || c.vendor == "mimo" {
-			maxOutputTokens = responsesAutoOutputBudget(c.vendor, c.effort)
-		} else {
-			maxOutputTokens = c.caps.defaultMaxOutputTokens
-		}
+	if maxOutputTokens == 0 && c.vendor == "mimo" {
+		maxOutputTokens = responsesAutoOutputBudget(c.vendor, c.effort)
+	} else if maxOutputTokens == 0 && c.vendor != "deepseek" && c.caps.defaultMaxOutputTokens > 0 {
+		maxOutputTokens = c.caps.defaultMaxOutputTokens
 	}
 	if maxOutputTokens > 0 {
 		body["max_output_tokens"] = maxOutputTokens

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -106,21 +106,21 @@ func TestRequestUsesOnlySafeProviderOutputDefaults(t *testing.T) {
 
 	deepseek := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"}).(*client)
 	deepseekBody, _, _ := deepseek.buildRequestBody(provider.Request{Messages: message})
-	if got := deepseekBody["max_output_tokens"]; got != provider.DefaultHighReasoningOutputTokens {
-		t.Fatalf("DeepSeek max_output_tokens = %#v, want high-reasoning auto %d", got, provider.DefaultHighReasoningOutputTokens)
+	if _, exists := deepseekBody["max_output_tokens"]; exists {
+		t.Fatalf("DeepSeek max_output_tokens = %#v, want omitted official 384K ceiling", deepseekBody["max_output_tokens"])
 	}
 
 	high := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", Effort: "high"}).(*client)
 	highBody, _, _ := high.buildRequestBody(provider.Request{Messages: message})
-	if got := highBody["max_output_tokens"]; got != provider.DefaultHighReasoningOutputTokens {
-		t.Fatalf("high-effort DeepSeek budget = %#v, want %d", got, provider.DefaultHighReasoningOutputTokens)
+	if _, exists := highBody["max_output_tokens"]; exists {
+		t.Fatalf("high-effort DeepSeek budget = %#v, want omitted", highBody["max_output_tokens"])
 	}
 
 	for _, effort := range []string{"none", "disabled", "off", " NONE "} {
 		thinkingDisabled := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Effort: effort}).(*client)
 		thinkingDisabledBody, _, _ := thinkingDisabled.buildRequestBody(provider.Request{Messages: message})
-		if got := thinkingDisabledBody["max_output_tokens"]; got != provider.DefaultOrdinaryOutputTokens {
-			t.Fatalf("thinking-disabled DeepSeek effort %q budget = %#v, want ordinary %d", effort, got, provider.DefaultOrdinaryOutputTokens)
+		if _, exists := thinkingDisabledBody["max_output_tokens"]; exists {
+			t.Fatalf("thinking-disabled DeepSeek effort %q budget = %#v, want omitted", effort, thinkingDisabledBody["max_output_tokens"])
 		}
 	}
 
@@ -1154,7 +1154,8 @@ func TestReasoningMetaChunkEndToEnd(t *testing.T) {
 	}
 }
 
-// TestVendorTableMaxOutputTokens: automatic ladder is 16K/32K/64K, never 128K.
+// TestVendorTableMaxOutputTokens: MiMo keeps the 16K/32K ladder; official
+// DeepSeek omits max_output_tokens so the server uses its 384K ceiling.
 func TestVendorTableMaxOutputTokens(t *testing.T) {
 	msg := []provider.Message{{Role: provider.RoleUser, Content: "hi"}}
 
@@ -1170,7 +1171,7 @@ func TestVendorTableMaxOutputTokens(t *testing.T) {
 	}
 	ds := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"}).(*client)
 	db, _, _ := ds.buildRequestBody(provider.Request{Messages: msg})
-	if got := db["max_output_tokens"]; got != provider.DefaultHighReasoningOutputTokens {
-		t.Fatalf("deepseek auto budget = %#v, want high-reasoning %d", got, provider.DefaultHighReasoningOutputTokens)
+	if _, exists := db["max_output_tokens"]; exists {
+		t.Fatalf("deepseek auto budget = %#v, want omitted official ceiling", db["max_output_tokens"])
 	}
 }

--- a/internal/provider/responses/vendor.go
+++ b/internal/provider/responses/vendor.go
@@ -91,9 +91,8 @@ var vendorTable = map[string]vendorCapabilities{
 		toolCallReasoning:      true,
 		singleSegmentReasoning: false,
 		ignoresTemperature:     false,
-		// Auto ceiling for ordinary reasoning; high/max is applied via
-		// AutoOutputBudget at construction/request time (64K). Never 128K.
-		defaultMaxOutputTokens: provider.DefaultReasoningOutputTokens,
+		// 0 = omit max_output_tokens; official server ceiling is 384K.
+		defaultMaxOutputTokens: 0,
 		// Compaction summaries use a dedicated 16K-class budget, independent of
 		// ordinary answer output.
 		compactionOutputTokens: provider.DefaultOrdinaryOutputTokens,

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -4,13 +4,13 @@
     "commented-code": 0,
     "complexity": 2103,
     "essay": 3995,
-    "file-size": 108080,
+    "file-size": 108090,
     "function-size": 8923,
     "layering": 1,
     "marker": 0,
     "narrative": 64,
     "struct-state": 115,
-    "test-file-size": 69269
+    "test-file-size": 69271
   },
   "files": {
     "cmd/e2ebench/main.go": {
@@ -461,7 +461,7 @@
     "internal/agent/agent.go": {
       "complexity": 38,
       "essay": 55,
-      "file-size": 2064,
+      "file-size": 2066,
       "function-size": 105,
       "struct-state": 3
     },
@@ -1576,7 +1576,7 @@
     },
     "internal/provider/anthropic/anthropic_test.go": {
       "essay": 1,
-      "test-file-size": 251
+      "test-file-size": 252
     },
     "internal/provider/openai/host.go": {
       "essay": 8
@@ -1597,7 +1597,7 @@
     },
     "internal/provider/provider.go": {
       "essay": 49,
-      "file-size": 324
+      "file-size": 332
     },
     "internal/provider/responses/responses.go": {
       "complexity": 54,
@@ -1608,7 +1608,7 @@
     },
     "internal/provider/responses/responses_test.go": {
       "essay": 6,
-      "test-file-size": 376
+      "test-file-size": 377
     },
     "internal/provider/responses/vendor.go": {
       "essay": 21


### PR DESCRIPTION
## Summary

Official DeepSeek V4 Pro high thinking could be killed after ~128KB of hidden reasoning (~32K estimated tokens). The user saw two English warnings and no answer, even though context was almost empty.

This removes Reasonix's homemade 16/32/64K auto `max_output_tokens` ladder on official DeepSeek. Thinking depth is `effort` only. Generation follows the documented 384K output ceiling.

- Chat Completions / Responses: `max_output_tokens = 0` omits the field (server 384K).
- Official DeepSeek Anthropic: send `384000` because `max_tokens` is required and `budget_tokens` is ignored.
- A positive config value remains an explicit cost cap.
- MiMo and native Anthropic keep their existing defaults.
- The client no longer cancels the provider stream when stored reasoning grows; it only caps the in-memory buffer (8MiB).
- SPEC / GUIDE describe the official 384K omit behavior.

Sources: [pricing](https://api-docs.deepseek.com/zh-cn/quick_start/pricing), [Responses API](https://api-docs.deepseek.com/zh-cn/guides/responses_api), [Anthropic API](https://api-docs.deepseek.com/zh-cn/guides/anthropic_api).

## Issues

Refs user report: long `deepseek-v4-pro` + `high` think hit `client reasoning safety limit` / `reasoning output exceeded client byte limit` with ~32,769 estimated tokens and no final answer.

## Verification

- `make lint`
- `go test ./internal/provider/openai/ ./internal/provider/responses/ ./internal/provider/anthropic/ ./internal/agent/ ./internal/config/ ./internal/boot/ ./internal/tool/builtin/`
- Focused wire tests: official DeepSeek omits Chat/Responses `max_*`; Anthropic default is 384000 regardless of effort; 128KiB reasoning still produces the visible answer.

## Capacity budget

Accepted a locally attributable repolint ratchet for comments/constants/tests in this change:

- `internal/agent/agent.go` file-size 2064 → 2066 (+2, +0.10%)
- `internal/provider/provider.go` file-size 324 → 332 (+8, +2.5% of that file's over-ceiling debt; +0.7% of the 1132-line file)
- `internal/provider/anthropic/anthropic_test.go` test-file-size 251 → 252 (+1)
- `internal/provider/responses/responses_test.go` test-file-size 376 → 377 (+1)
- repo `file-size` 108080 → 108090 (+10, +0.009%)
- repo `test-file-size` 69269 → 69271 (+2, +0.003%)

No file was split because the added lines are the official-ceiling constant, comments, and one extra Anthropic case. Runtime path did not grow a hot-path bundle.

## Documentation impact

Documentation-impact: updated - SPEC/GUIDE now say official DeepSeek `max_output_tokens=0` omits the field (server 384K) and effort only selects thinking depth

## Cache impact

Cache-impact: low - official DeepSeek no longer changes `max_tokens`/`max_output_tokens` when effort changes; prefix/tool schemas are unchanged. Tool-call turns still replay full reasoning (DeepSeek protocol).
Cache-guard: go test ./internal/provider/openai/ ./internal/provider/responses/ ./internal/provider/anthropic/ -run 'TestBuildRequestUsesProviderSpecificOutputBudget|TestRequestUsesOnlySafeProviderOutputDefaults|TestVendorTableMaxOutputTokens|TestNewSelectsMaxOutputTokenDefaultByEndpoint'
System-prompt-review: Xinwei - config comments and render templates only; no system-prompt prefix, memory, or skill-index bytes changed
