### PR TITLE
docs(README): 同步中文版从源码构建的工具链要求

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,12 +106,38 @@ Windows 安装器通过 [SignPath.io](https://signpath.io/) 完成代码签名�
 
 ### 路径 D：从源码构建
 
+先克隆仓库：
+
 ```sh
 git clone https://github.com/esengine/DeepSeek-Reasonix.git
 cd DeepSeek-Reasonix
+```
+
+#### CLI
+
+CLI 构建需要 **Go 1.25+**。模块固定了 `toolchain` 指令；
+保持 `GOTOOLCHAIN=auto` 让 Go 自动下载固定的工具链，或自行安装。
+
+```sh
 make build      # -> bin/reasonix(.exe)
 make cross      # -> dist/（darwin|linux|windows × amd64|arm64）
 ```
+
+#### 桌面端
+
+桌面端构建额外需要：
+
+- **Node 24+ 和 pnpm 10**（`npm install -g pnpm@10`）用于前端
+- **Wails CLI**，与共享的 `.wails-version` 固定版本一致
+
+```sh
+make wails-install
+cd desktop
+wails build
+```
+
+平台相关的 WebView 依赖和 Linux 构建标签见
+[桌面端构建指南](desktop/README.md#prerequisites)。
 
 ## 快速开始
 


### PR DESCRIPTION
## 背景

英文版 README 在 #8098（chore(desktop): harden build toolchain contracts）中新增了「从源码构建」部分的工具链要求：
- CLI 需要 **Go 1.25+**，模块固定 `toolchain` 指令，需保持 `GOTOOLCHAIN=auto`
- 桌面端需要 **Node 24+ 与 pnpm 10**，以及匹配 `.wails-version` 的 **Wails CLI**

中文版 README.zh-CN.md 未同步这部分，只保留了 `make build` / `make cross` 两行命令。

## 影响

中文用户按中文文档从源码构建时，会漏掉上述环境要求（例如直接 `wails build` 因 CLI 版本不匹配而失败），排查成本高。

## 改动

同步 README.zh-CN.md「路径 D：从源码构建」小节，补齐：
- 先克隆仓库的说明
- CLI 构建的 Go 1.25+ / toolchain 要求
- 桌面端构建的 Node 24+ / pnpm 10 / Wails CLI 要求
- 桌面端构建指南链接

内容与英文版一一对应，无新增/删减信息。

Cache-impact: none（文档改动，不涉及系统提示或缓存路径）