### PR TITLE
feat(config): add OrcaRouter curated provider preset

### DIFF
--- a/internal/config/provider_presets.go
+++ b/internal/config/provider_presets.go
@@ -122,6 +122,16 @@ var (
 	huggingFaceModels = []string{"zai-org/GLM-5.2", "deepseek-ai/DeepSeek-V3.2", "Qwen/Qwen3.5-72B-Instruct"}
 	nvidiaModels      = []string{"nvidia/nemotron-3-nano-30b-a3b", "nvidia/nemotron-3-super-120b-a12b", "nvidia/nemotron-3-ultra-550b-a55b", "deepseek-ai/deepseek-v4-pro", "qwen/qwen3.5-397b-a17b"}
 	ollamaCloudModels = []string{"glm-5.2", "kimi-k2.7-code", "deepseek-v4-pro", "deepseek-v4-flash", "minimax-m3", "nemotron-3-nano:30b", "qwen3-coder-next"}
+
+	orcaRouterModels = []string{
+		"deepseek/deepseek-v4-flash",
+		"deepseek/deepseek-reasoner",
+		"anthropic/claude-sonnet-5",
+		"google/gemini-2.5-flash",
+		"openai/gpt-5.5",
+		"orcarouter/auto",
+		"orcarouter/fusion",
+	}
 )
 
 func qwenModelContextOverrides() map[string]ProviderModelOverride {
@@ -174,6 +184,21 @@ func tokenRhythmModelOverrides() map[string]ProviderModelOverride {
 		"minimax-m2.5":   {ContextWindow: 200_000},
 		"mimo-v2.5-pro":  {ContextWindow: 256_000},
 		"kimi-k2.7-code": {ContextWindow: 256_000},
+	}
+}
+
+func orcaRouterModelOverrides() map[string]ProviderModelOverride {
+	return map[string]ProviderModelOverride{
+		"deepseek/deepseek-v4-flash": {
+			ReasoningProtocol: ReasoningProtocolDeepSeek,
+			SupportedEfforts:  []string{"disabled", "low", "high", "max"},
+			DefaultEffort:     "high",
+		},
+		"deepseek/deepseek-reasoner": {
+			ReasoningProtocol: ReasoningProtocolDeepSeek,
+			SupportedEfforts:  []string{"disabled", "high", "max"},
+			DefaultEffort:     "high",
+		},
 	}
 }
 
@@ -959,6 +984,21 @@ var curatedProviderPresets = []ProviderPreset{
 			Models:    ollamaCloudModels,
 			Default:   "glm-5.2",
 			APIKeyEnv: "OLLAMA_API_KEY",
+		}},
+	},
+	{
+		ID:          "orcarouter",
+		Label:       "OrcaRouter",
+		Description: "OrcaRouter multi-model OpenAI-compatible gateway.",
+		KeyEnv:      "ORCAROUTER_API_KEY",
+		Entries: []ProviderEntry{{
+			Name:           "orcarouter",
+			Kind:           "openai",
+			BaseURL:        "https://api.orcarouter.ai/v1",
+			Models:         orcaRouterModels,
+			Default:        "deepseek/deepseek-v4-flash",
+			APIKeyEnv:      "ORCAROUTER_API_KEY",
+			ModelOverrides: orcaRouterModelOverrides(),
 		}},
 	},
 }

--- a/internal/config/provider_presets_test.go
+++ b/internal/config/provider_presets_test.go
@@ -296,6 +296,39 @@ func TestTokenRhythmPresetMatchesPublicAPIIntegration(t *testing.T) {
 	}
 }
 
+func TestOrcaRouterPresetMatchesPublicAPIIntegration(t *testing.T) {
+	preset, ok := CuratedProviderPreset("orcarouter")
+	if !ok || len(preset.Entries) != 1 {
+		t.Fatalf("OrcaRouter preset = %+v, want one entry", preset)
+	}
+	if preset.Label != "OrcaRouter" || preset.KeyEnv != "ORCAROUTER_API_KEY" {
+		t.Fatalf("OrcaRouter identity = label %q key %q", preset.Label, preset.KeyEnv)
+	}
+	entry := preset.Entries[0]
+	if entry.Kind != "openai" || entry.BaseURL != "https://api.orcarouter.ai/v1" {
+		t.Fatalf("OrcaRouter endpoint mismatch: %+v", entry)
+	}
+	if entry.DefaultModel() != "deepseek/deepseek-v4-flash" || !entry.HasModel("anthropic/claude-sonnet-5") || !entry.HasModel("orcarouter/auto") || entry.HasModel("nonsense/not-a-model") {
+		t.Fatalf("OrcaRouter chat catalog mismatch: models=%v default=%q", entry.Models, entry.DefaultModel())
+	}
+
+	var cfg Config
+	if err := cfg.UpsertProvider(entry); err != nil {
+		t.Fatalf("upsert OrcaRouter preset: %v", err)
+	}
+	deepseek, ok := cfg.ResolveModel("orcarouter/deepseek/deepseek-v4-flash")
+	if !ok || ReasoningProtocolForEntry(deepseek) != ReasoningProtocolDeepSeek {
+		t.Fatalf("OrcaRouter DeepSeek protocol mismatch: %+v", deepseek)
+	}
+	flashCap := EffortCapabilityForEntry(deepseek)
+	if !flashCap.Supported || flashCap.Default != "high" || !stringSlicesEqual(flashCap.Levels, []string{"auto", "disabled", "low", "high", "max"}) {
+		t.Fatalf("OrcaRouter DeepSeek effort mismatch: %+v", flashCap)
+	}
+	if _, ok := cfg.ResolveModel("orcarouter/anthropic/claude-sonnet-5"); !ok {
+		t.Fatalf("OrcaRouter Sonnet should resolve through the gateway")
+	}
+}
+
 func TestCuratedProviderPresetsStepFunUsesOfficialBaseURLs(t *testing.T) {
 	tests := []struct {
 		id      string


### PR DESCRIPTION
## Summary

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats Token Rhythm / NovitaAI-style aggregators in its curated provider preset catalog. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

**Changes**
- `internal/config/provider_presets.go` — new `orcarouter` curated preset (multi-model OpenAI-compatible gateway) with base URL `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY` key env, and model overrides that give DeepSeek models their reasoning protocol and effort vocabulary.
- `internal/config/provider_presets_test.go` — `TestOrcaRouterPresetMatchesPublicAPIIntegration` mirrors the existing Token Rhythm preset test.

## Issues

N/A

## Verification

- `go build ./internal/config/` — clean.
- `go test ./internal/config/ -count=1` — full package suite passes.
- `go vet ./internal/config/` — clean.

## Documentation impact

Documentation-impact: none - the curated preset catalog renders its label/description from the Go preset itself; gateway presets in this catalog have no separate docs page.

## Cache impact

Cache-impact: none
Cache-guard: existing TestCuratedProviderPresets* and TestOrcaRouterPresetMatchesPublicAPIIntegration
System-prompt-review: N/A
