### PR TITLE
Fix phantom transcript bottom after interrupted turns / 修复中断回合的虚假底部按钮

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
@@ -277,5 +277,70 @@ function firstTextNode(root: Node): Text | null {
   }
 }
 
+// ── A short interrupted turn has no phantom "bottom" to jump to ─────────────
+// Once alignToBottom was removed, short content correctly stayed at the top.
+// An upward wheel intent still unpinned it even though the scroller had no
+// overflow, exposing a jump-bottom button whose click could not move anywhere.
+{
+  const harness = await createTranscriptHarness({ viewportHeight: 700, rowHeight: 60 });
+  try {
+    const interrupted: Item[] = [
+      { kind: "user", id: "u-interrupted", text: "inspect the four metrics" },
+      { kind: "assistant", id: "r1", text: "", reasoning: "checking the first source", streaming: false },
+      { kind: "tool", id: "t1", name: "read_file", args: "{}", output: "ok", status: "done", readOnly: true },
+      { kind: "assistant", id: "r2", text: "", reasoning: "checking the second source", streaming: false },
+      { kind: "tool", id: "t2", name: "read_file", args: "{}", output: "ok", status: "done", readOnly: true },
+      { kind: "notice", id: "cancelled", level: "info", code: "cancelled_turn_display", text: "This turn was interrupted." },
+    ];
+    await harness.render(interrupted, { running: false });
+    await harness.settle();
+    const el = harness.scrollElement();
+    ok(el.scrollHeight <= el.clientHeight, `interrupted fixture has no scroll range (${el.scrollHeight}/${el.clientHeight})`);
+
+    el.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+    dispatchScroll(el);
+    await harness.flush();
+
+    ok(
+      el.dataset.scrollMode === "tail-follow",
+      "wheel-up on a non-overflowing interrupted turn preserves tail-follow state",
+    );
+    ok(
+      harness.container.querySelector(".transcript__jump-bottom") === null,
+      "wheel-up on a non-overflowing interrupted turn does not expose a dead jump-bottom button",
+    );
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
+// ── Real overflow still exposes a working jump-bottom control ──────────────
+{
+  const harness = await createTranscriptHarness({ viewportHeight: 200, rowHeight: 100 });
+  try {
+    await harness.render(turns(10), { running: false });
+    await harness.settle();
+    const el = harness.scrollElement();
+    el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 400);
+    el.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+    dispatchScroll(el);
+    await harness.flush();
+
+    const jump = harness.container.querySelector<HTMLButtonElement>(".transcript__jump-bottom");
+    ok(jump != null, "a transcript with real overflow still exposes jump-bottom after wheel-up");
+    jump?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await harness.settle();
+
+    ok(
+      el.scrollHeight - el.scrollTop - el.clientHeight <= 1,
+      "jump-bottom still reaches the native bottom when overflow exists",
+    );
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -47,7 +47,7 @@ import { useTranscriptSelectableRows } from "../lib/useTranscriptSelectableRows"
 import { TranscriptSelectionOverlay } from "./TranscriptSelectionOverlay";
 import { useCreationTranscriptScrollbar } from "../lib/useCreationTranscriptScrollbar";
 import { useTranscriptScrollInteractions } from "../lib/useTranscriptScrollInteractions";
-import { TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX, useTranscriptVirtuosoScroll } from "../lib/useTranscriptVirtuosoScroll";
+import { hasTranscriptScrollableRange, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX, useTranscriptVirtuosoScroll } from "../lib/useTranscriptVirtuosoScroll";
 import { useTranscriptVirtuosoFirstItemIndex } from "../lib/transcriptVirtuosoIndex";
 type OpenTurnAction = { turn: number; menu: "summary" | "rewind" };
 const QUESTION_NAV_MIN_COUNT = 2;
@@ -763,7 +763,7 @@ export function Transcript({
         <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
       )}
 
-      {!empty && !isAtBottom && (
+      {!empty && !isAtBottom && scrollElement && hasTranscriptScrollableRange(scrollElement) && (
         <button
           type="button"
           className="transcript__jump-bottom"

--- a/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
+++ b/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
@@ -107,6 +107,13 @@ export function nativeTranscriptBottomTop(element: {
   return Math.max(0, element.scrollHeight - element.clientHeight);
 }
 
+export function hasTranscriptScrollableRange(
+  element: { scrollHeight: number; clientHeight: number },
+  threshold = TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
+) {
+  return nativeTranscriptBottomTop(element) > threshold;
+}
+
 export function isPhysicallyAtTranscriptBottom(
   element: { scrollHeight: number; scrollTop: number; clientHeight: number },
   threshold = TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
@@ -359,8 +366,21 @@ export function useTranscriptVirtuosoScroll() {
     });
   }, [finishTailAtNativeBottom]);
 
+  const restoreTailIfNotScrollable = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element || hasTranscriptScrollableRange(element)) return false;
+    clearBottomRequest();
+    if (!isTranscriptSelectionMode(modeRef.current)) {
+      pinnedRef.current = true;
+      setIsAtBottom(true);
+      publishMode("tail-follow");
+    }
+    return true;
+  }, [clearBottomRequest, publishMode]);
+
   const atBottomStateChange = useCallback((atBottom: boolean) => {
     const element = scrollRef.current;
+    if (!atBottom && restoreTailIfNotScrollable()) return;
     if (!atBottom && element && shouldKeepPinnedOnAtBottomFalse({
       pinned: pinnedRef.current,
       previousScrollHeight: pinnedMetricsRef.current.scrollHeight,
@@ -418,7 +438,7 @@ export function useTranscriptVirtuosoScroll() {
     if (!isTranscriptSelectionMode(modeRef.current)) {
       publishMode(atBottom ? "tail-follow" : "manual");
     }
-  }, [clearBottomRequest, finishTailAtNativeBottom, followGrowingTail, publishMode]);
+  }, [clearBottomRequest, finishTailAtNativeBottom, followGrowingTail, publishMode, restoreTailIfNotScrollable]);
 
   const reset = useCallback(() => {
     clearBottomRequest();
@@ -478,6 +498,7 @@ export function useTranscriptVirtuosoScroll() {
 
   const onWheelIntent = useCallback((event: ReactWheelEvent<HTMLElement>) => {
     if (event.ctrlKey || event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) return false;
+    if (restoreTailIfNotScrollable()) return false;
     if (event.deltaY < 0 || !pinnedRef.current) {
       releaseTailFollow();
       return true;
@@ -492,7 +513,7 @@ export function useTranscriptVirtuosoScroll() {
       return true;
     }
     return false;
-  }, [finishTailAtNativeBottom, releaseTailFollow]);
+  }, [finishTailAtNativeBottom, releaseTailFollow, restoreTailIfNotScrollable]);
 
   const onTouchStartIntent = useCallback((event: ReactTouchEvent<HTMLElement>) => {
     touchStartYRef.current = event.touches[0]?.clientY ?? null;
@@ -502,15 +523,18 @@ export function useTranscriptVirtuosoScroll() {
     const start = touchStartYRef.current;
     const current = event.touches[0]?.clientY;
     if (start == null || current == null || Math.abs(current - start) < 2) return false;
+    if (restoreTailIfNotScrollable()) return false;
     if (current > start || !pinnedRef.current) {
       releaseTailFollow();
       return true;
     }
     return false;
-  }, [releaseTailFollow]);
+  }, [releaseTailFollow, restoreTailIfNotScrollable]);
 
   const onKeyScrollIntent = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
     if (isEditableTarget(event.target)) return false;
+    if (!SCROLL_UP_KEYS.has(event.key) && !SCROLL_DOWN_KEYS.has(event.key)) return false;
+    if (restoreTailIfNotScrollable()) return false;
     if (SCROLL_UP_KEYS.has(event.key) || (SCROLL_DOWN_KEYS.has(event.key) && !pinnedRef.current)) {
       releaseTailFollow();
       return true;
@@ -525,7 +549,7 @@ export function useTranscriptVirtuosoScroll() {
       return true;
     }
     return false;
-  }, [finishTailAtNativeBottom, releaseTailFollow]);
+  }, [finishTailAtNativeBottom, releaseTailFollow, restoreTailIfNotScrollable]);
 
   const onPointerDownIntent = useCallback((event: ReactPointerEvent<HTMLElement>) => {
     const element = scrollRef.current;
@@ -539,11 +563,13 @@ export function useTranscriptVirtuosoScroll() {
       return true;
     }
     if (event.button !== 1) return false;
+    if (restoreTailIfNotScrollable()) return false;
     releaseTailFollow();
     return true;
-  }, [releaseTailFollow]);
+  }, [releaseTailFollow, restoreTailIfNotScrollable]);
 
   const onNestedScrollIntent = useCallback((deltaY: number) => {
+    if (deltaY === 0 || restoreTailIfNotScrollable()) return false;
     if (deltaY < 0 || !pinnedRef.current) {
       releaseTailFollow();
       return true;
@@ -558,7 +584,7 @@ export function useTranscriptVirtuosoScroll() {
       return true;
     }
     return false;
-  }, [finishTailAtNativeBottom, releaseTailFollow]);
+  }, [finishTailAtNativeBottom, releaseTailFollow, restoreTailIfNotScrollable]);
 
   return {
     virtuosoRef,


### PR DESCRIPTION
## Summary

- Prevent manual scroll intents from releasing tail-follow when the transcript has no physical native scroll range.
- Self-heal false at-bottom callbacks and render the jump-to-bottom control only when a native range exists.
- Add regression coverage for a short interrupted transcript and preserve the working long-transcript jump path.

## Root cause

The scroll controller treated wheel, touch, keyboard, middle-button, and nested-scroll input as manual intent even when scroll height did not exceed viewport height. That allowed logical scroll state to become manual while the native viewport had nowhere to move, and the jump control rendered from logical state alone.

## Verification

- pnpm test:transcript
- pnpm test:typecheck
- pnpm typecheck
- pnpm build
- Microsoft Edge real-browser check: a 1185/1185 no-range transcript remains in tail-follow with no jump control after wheel input
- Microsoft Edge real-browser check: a 5235/585 overflowing transcript still exposes the control and reaches bottom distance 0 after click
- go run ./tools/repolint
- git diff --check

## Compatibility and risk

- Frontend-only scroll-state handling; no persisted-data, Wails API, dependency, provider, or prompt-cache changes.
- Uses the existing 4 px at-bottom tolerance, so genuine overflow and explicit jump-to-bottom behavior remain unchanged.

Documentation-impact: none - This restores existing transcript scroll behavior and does not change documented user workflows or interfaces.