### PR TITLE
fix(desktop): recover answers after missed turn events / 修复漏事件后回答一直转圈

### DIFF
--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
-import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, shouldReconcileStaleTurn, tokenModeSwitchNoticeText, type Item } from "../lib/useController";
+import { currentTurnWaitMs, effortSwitchNoticeText, foregroundRunningFromRuntimeMeta, historyMessagesToItems, initialState, localizedBackendNoticeText, localizedNoticeText, metaFromTab, modelSwitchNoticeText, reducer, sameMeta, tokenModeSwitchNoticeText, type Item } from "../lib/useController";
+import { shouldReconcileStaleTurn } from "../lib/useStaleTurnWatchdog";
 import { parseTodos } from "../lib/tools";
 import { resolveTodoPanelTodos } from "../lib/todoVisibility";
 import type { HistoryMessage, Meta, TabMeta, WireUsage } from "../lib/types";
@@ -490,7 +491,7 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   eq(rendered.live, undefined, "final message closes the live stream before turn_done");
   eq(shouldReconcileStaleTurn(rendered, 1_000, 31_000), true, "stale completed stream still reconciles missed turn_done");
   eq(shouldReconcileStaleTurn(rendered, 1_000, 20_000), false, "fresh completed stream waits before reconciling");
-  eq(shouldReconcileStaleTurn({ ...rendered, turnActive: false }, 1_000, 31_000), false, "local pending send before turn_started does not reconcile");
+  eq(shouldReconcileStaleTurn({ ...rendered, turnActive: false }, 0, rendered.turnStartAt + 30_000), true, "optimistic send reconciles even when turn_started is missed");
 }
 
 {

--- a/desktop/frontend/src/__tests__/use-controller-stale-turn-watchdog.test.tsx
+++ b/desktop/frontend/src/__tests__/use-controller-stale-turn-watchdog.test.tsx
@@ -1,0 +1,228 @@
+// Run: tsx src/__tests__/use-controller-stale-turn-watchdog.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { AppBindings } from "../lib/bridge";
+import type { HistoryMessage, Meta, TabMeta, WireEvent } from "../lib/types";
+import { useController } from "../lib/useController";
+import { historySliceFromMessages } from "./mockHistorySlice";
+
+let passed = 0;
+let failed = 0;
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+}
+
+async function waitFor(label: string, predicate: () => boolean) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await act(async () => { await flushPromises(); });
+    if (predicate()) return;
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+console.log("\nstale turn watchdog");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+const originalNow = Date.now;
+let fakeNow = 1_000;
+Date.now = () => fakeNow;
+let nextTimerID = 1;
+const watchdogTimers = new Map<number, () => void>();
+window.setTimeout = ((handler: TimerHandler, delay?: number) => {
+  const id = nextTimerID++;
+  if ((delay ?? 0) >= 29_000 && typeof handler === "function") watchdogTimers.set(id, handler);
+  else globalThis.setTimeout(handler, delay);
+  return id;
+}) as typeof window.setTimeout;
+window.clearTimeout = ((id?: number) => {
+  if (id !== undefined) watchdogTimers.delete(id);
+}) as typeof window.clearTimeout;
+
+const tabID = "tab-watchdog";
+const sessionPath = "/repo/sessions/watchdog.jsonl";
+let backendRunning = false;
+let revision = 1;
+let history: HistoryMessage[] = [];
+let listTabsCalls = 0;
+let historyCalls = 0;
+const agentEventHandlers: Array<(event: WireEvent) => void> = [];
+
+function tabMeta(): TabMeta {
+  return {
+    id: tabID,
+    scope: "project",
+    workspaceRoot: "/repo",
+    workspaceName: "repo",
+    workspacePath: "/repo",
+    topicId: "topic-watchdog",
+    topicTitle: "Watchdog",
+    sessionPath,
+    sessionRevision: revision,
+    sessionDigest: `digest-${revision}`,
+    label: "model",
+    ready: true,
+    running: backendRunning,
+    cancellable: backendRunning,
+    mode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    active: true,
+    cwd: "/repo",
+  };
+}
+
+function meta(): Meta {
+  return {
+    label: "model",
+    ready: true,
+    eventChannel: "agent:event",
+    sessionPath,
+    sessionRevision: revision,
+    sessionDigest: `digest-${revision}`,
+    cwd: "/repo",
+    workspaceRoot: "/repo",
+    workspaceName: "repo",
+    workspacePath: "/repo",
+    autoApproveTools: false,
+    bypass: false,
+    collaborationMode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    goal: "",
+    goalStatus: "stopped",
+  };
+}
+
+window.runtime = {
+  EventsOn: (name, handler) => {
+    if (name === "agent:event") agentEventHandlers.push(handler as (event: WireEvent) => void);
+    return () => {};
+  },
+  BrowserOpenURL: () => {},
+};
+window.go = {
+  main: {
+    App: {
+      ListTabs: async () => {
+        listTabsCalls += 1;
+        return [tabMeta()];
+      },
+      MetaForTab: async () => meta(),
+      ContextUsageForTab: async () => ({ used: 0, window: 1000, sessionTokens: 0 }),
+      EffortForTab: async () => ({ supported: true, current: "auto", default: "auto", levels: ["auto"] }),
+      BalanceForTab: async () => ({ available: false, display: "" }),
+      JobsForTab: async () => [],
+      CheckpointsForTab: async () => [],
+      HistorySliceForTab: async (_id, request) => {
+        historyCalls += 1;
+        return historySliceFromMessages(tabID, history, request, { revision, digest: `digest-${revision}` });
+      },
+      HistoryCheckpointTurnsForTab: async () => [],
+      ReplayPendingPrompts: async () => {},
+      SubmitToTabWithID: async () => {
+        backendRunning = true;
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+type Controller = ReturnType<typeof useController>;
+let controller: Controller | undefined;
+function Probe() {
+  controller = useController();
+  return null;
+}
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+await act(async () => {
+  root.render(<Probe />);
+  await flushPromises();
+});
+await waitFor("initial session", () => controller?.activeTabId === tabID && historyCalls > 0);
+
+await act(async () => {
+  for (const handler of agentEventHandlers) {
+    handler({ kind: "turn_started", tabId: tabID });
+    handler({ kind: "turn_done", tabId: tabID });
+  }
+  await flushPromises();
+});
+fakeNow += 60_000;
+await act(async () => {
+  await controller?.send("hello");
+  await flushPromises();
+});
+ok(controller?.state.running ?? false, "optimistic submit enters running state without any agent events");
+ok(controller?.state.turnActive === false, "missing turn_started leaves no live turn evidence");
+ok(watchdogTimers.size === 1, "optimistic submit arms the stale-turn watchdog");
+
+const firstTimer = watchdogTimers.entries().next().value as [number, () => void] | undefined;
+if (firstTimer) {
+  watchdogTimers.delete(firstTimer[0]);
+  fakeNow += 30_000;
+  await act(async () => {
+    firstTimer[1]();
+    await flushPromises();
+  });
+}
+ok(listTabsCalls >= 2, "first quiet-period probe reconciles backend runtime state");
+ok(controller?.state.running ?? false, "a genuinely running backend remains running");
+ok(watchdogTimers.size === 1, "still-running probe re-arms instead of stopping after one check");
+
+backendRunning = false;
+revision = 2;
+history = [
+  { role: "user", content: "hello" },
+  { role: "assistant", content: "recovered answer" },
+];
+const secondTimer = watchdogTimers.entries().next().value as [number, () => void] | undefined;
+if (secondTimer) {
+  watchdogTimers.delete(secondTimer[0]);
+  fakeNow += 30_000;
+  await act(async () => {
+    secondTimer[1]();
+    await flushPromises();
+  });
+}
+await waitFor("missed answer hydration", () => controller?.state.items.some(
+  (item) => item.kind === "assistant" && item.text === "recovered answer",
+) ?? false);
+ok(controller?.state.running === false, "idle backend settles the spinner without switching tabs");
+ok(controller?.state.items.some((item) => item.kind === "assistant" && item.text === "recovered answer") ?? false, "watchdog hydrates the persisted missed answer");
+ok(watchdogTimers.size === 0, "settled turn leaves no watchdog timer behind");
+
+await act(async () => { root.unmount(); });
+Date.now = originalNow;
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -22,6 +22,7 @@ import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
+import { useStaleTurnWatchdog } from "./useStaleTurnWatchdog";
 import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
 import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
@@ -681,7 +682,6 @@ function metaWithoutCanonicalTodos(meta?: Meta): Meta | undefined {
   return { ...meta, canonicalTodos: undefined, dismissedTodoBatches: undefined };
 }
 
-const STALE_TURN_RECONCILE_MS = 30_000;
 const CANCEL_RECONCILE_DELAYS_MS = [0, 100, 300, 1_000] as const;
 // After a stale runtime snapshot is rejected (its fetch predates the live
 // prompt), refetch authoritative backend state once. Short enough to be barely
@@ -690,16 +690,6 @@ const CANCEL_RECONCILE_DELAYS_MS = [0, 100, 300, 1_000] as const;
 const STALE_PROMPT_RECONCILE_MS = 150;
 const STARTUP_READY_META_RECONCILE_MS = 250;
 const STARTUP_READY_META_RECONCILE_ATTEMPTS = 60;
-
-export function shouldReconcileStaleTurn(
-  state: Pick<State, "running" | "turnActive"> | undefined,
-  lastTurnActivityAt: number,
-  now = Date.now(),
-  timeoutMs = STALE_TURN_RECONCILE_MS,
-): boolean {
-  if (!state?.running || !state.turnActive || lastTurnActivityAt <= 0) return false;
-  return Math.max(0, now - lastTurnActivityAt) >= timeoutMs;
-}
 
 function hasReusableCachedTranscript(state: State | undefined, sessionPath?: string, revision?: number, digest?: string): boolean {
   if (!state || state.items.length === 0) return false;
@@ -2662,6 +2652,10 @@ export function useController() {
   const dispatchTo = useCallback((tabId: string, action: Action) => {
     const states = statesRef.current;
     const prev = getOrCreateState(states, tabId);
+    // Activity timestamps belong to one submitted turn. A new optimistic turn
+    // must age from its own turnStartAt if turn_started is lost, not inherit an
+    // old turn's already-stale wire timestamp and probe immediately.
+    if (action.type === "user") lastTurnActivityAtByTab.current.delete(tabId);
     const next = reducer(prev, action);
     if (prev !== next) {
       states.set(tabId, next);
@@ -3252,9 +3246,10 @@ export function useController() {
 
   const reconcileTabRuntime = useCallback(async (
     tabId: string,
-    options: { hydrateSessionData?: boolean } = {},
+    options: { hydrateSessionData?: boolean; refreshAncillary?: boolean } = {},
   ): Promise<TabMeta[] | undefined> => {
     const hydrateSessionData = options.hydrateSessionData ?? true;
+    const refreshAncillary = options.refreshAncillary ?? true;
     const snapshotAt = promptEventClock();
     const tabs = asArray(await app.ListTabs().catch(() => [] as TabMeta[]));
     const tab = tabs.find((candidate) => candidate.id === tabId);
@@ -3272,6 +3267,7 @@ export function useController() {
       });
       return tabs;
     }
+    if (!refreshAncillary) return tabs;
     const [jobs, effort] = await Promise.all([
       app.JobsForTab(tabId).catch(() => undefined),
       app.EffortForTab(tabId).catch(() => undefined),
@@ -3572,30 +3568,19 @@ export function useController() {
     };
   }, [activeTabId, activeState.meta?.ready, activeState.meta?.startupErr, activeState.backendActivationPending, refreshMetaOnlyForTab]);
 
-  // Stale-turn watchdog: if the frontend thinks the agent is running but the
-  // turn stream has gone quiet, reconcile with the backend. This catches cases
-  // where the Wails event channel silently drops turn_done after the final
-  // message or synthetic todo update has already closed the live stream.
-  useEffect(() => {
-    if (!activeTabId) return;
-    const s = statesRef.current.get(activeTabId);
-    const now = Date.now();
-    const lastTurnActivityAt = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
-    if (!s?.running || !s.turnActive || lastTurnActivityAt <= 0) return;
-    const since = Math.max(0, now - lastTurnActivityAt);
-    if (shouldReconcileStaleTurn(s, lastTurnActivityAt, now)) {
-      void reconcileTabRuntime(activeTabId);
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      const cur = statesRef.current.get(activeTabId);
-      const lastActivity = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
-      if (shouldReconcileStaleTurn(cur, lastActivity)) {
-        void reconcileTabRuntime(activeTabId);
-      }
-    }, STALE_TURN_RECONCILE_MS - since);
-    return () => window.clearTimeout(timer);
-  }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.turnActive]);
+  // Stale-turn watchdog: keep reconciling while the frontend thinks the agent
+  // is running but the event stream is quiet. The optimistic submit timestamp
+  // is evidence too: if Wails drops the entire turn stream (including
+  // turn_started), waiting for a live event would leave the blank assistant
+  // placeholder spinning forever. Re-arm after a still-running snapshot so a
+  // later missed message + turn_done converges without a tab switch.
+  const reconcileStaleTurn = useCallback(async (tabId: string) => {
+    await reconcileTabRuntime(tabId, { refreshAncillary: false });
+  }, [reconcileTabRuntime]);
+  useStaleTurnWatchdog({
+    tabId: activeTabId, visibleState: activeState, activeTabIdRef, statesRef,
+    lastTurnActivityAtByTab, reconcile: reconcileStaleTurn,
+  });
 
   // Replay any pending approval/ask prompts when switching tabs, so a
   // plan-mode session left awaiting confirmation rebuilds its modal (#4275).

--- a/desktop/frontend/src/lib/useStaleTurnWatchdog.ts
+++ b/desktop/frontend/src/lib/useStaleTurnWatchdog.ts
@@ -1,0 +1,71 @@
+import { useEffect, type RefObject } from "react";
+
+const STALE_TURN_RECONCILE_MS = 30_000;
+
+export type StaleTurnWatchdogState = {
+  running: boolean;
+  turnStartAt: number;
+};
+
+export function shouldReconcileStaleTurn(
+  state: StaleTurnWatchdogState | undefined,
+  lastTurnActivityAt: number,
+  now = Date.now(),
+  timeoutMs = STALE_TURN_RECONCILE_MS,
+): boolean {
+  const lastEvidenceAt = lastTurnActivityAt > 0 ? lastTurnActivityAt : state?.turnStartAt ?? 0;
+  if (!state?.running || lastEvidenceAt <= 0) return false;
+  return Math.max(0, now - lastEvidenceAt) >= timeoutMs;
+}
+
+export function useStaleTurnWatchdog<T extends StaleTurnWatchdogState>({
+  tabId,
+  visibleState,
+  activeTabIdRef,
+  statesRef,
+  lastTurnActivityAtByTab,
+  reconcile,
+}: {
+  tabId?: string;
+  visibleState: StaleTurnWatchdogState;
+  activeTabIdRef: RefObject<string | undefined>;
+  statesRef: RefObject<Map<string, T>>;
+  lastTurnActivityAtByTab: RefObject<Map<string, number>>;
+  reconcile: (tabId: string) => Promise<void>;
+}) {
+  useEffect(() => {
+    if (!tabId) return;
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const schedule = (delay?: number) => {
+      if (cancelled || activeTabIdRef.current !== tabId) return;
+      const current = statesRef.current.get(tabId);
+      const lastActivityAt = lastTurnActivityAtByTab.current.get(tabId) ?? 0;
+      const lastEvidenceAt = lastActivityAt > 0 ? lastActivityAt : current?.turnStartAt ?? 0;
+      if (!current?.running || lastEvidenceAt <= 0) return;
+      const nextDelay = delay ?? Math.max(0, STALE_TURN_RECONCILE_MS - Math.max(0, Date.now() - lastEvidenceAt));
+      timer = window.setTimeout(() => { void tick(); }, nextDelay);
+    };
+
+    const tick = async () => {
+      if (cancelled || activeTabIdRef.current !== tabId) return;
+      const current = statesRef.current.get(tabId);
+      const lastActivityAt = lastTurnActivityAtByTab.current.get(tabId) ?? 0;
+      if (!shouldReconcileStaleTurn(current, lastActivityAt)) {
+        schedule();
+        return;
+      }
+      await reconcile(tabId);
+      if (!cancelled && activeTabIdRef.current === tabId && statesRef.current.get(tabId)?.running) {
+        schedule(STALE_TURN_RECONCILE_MS);
+      }
+    };
+
+    schedule();
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [activeTabIdRef, lastTurnActivityAtByTab, reconcile, statesRef, tabId, visibleState.running, visibleState.turnStartAt]);
+}


### PR DESCRIPTION
## Summary

- arm stale-turn recovery from the optimistic submission timestamp even when the entire `agent:event` stream, including `turn_started`, is missed;
- keep a lightweight active-tab watchdog running while the backend still reports work in progress;
- hydrate the persisted answer once the backend becomes idle, so the result appears without switching conversations;
- add deterministic dropped-stream coverage plus adjacent controller regression coverage.

## Root cause

The existing watchdog required a received turn event before it considered a turn stale. If Wails dropped the whole stream, the optimistic frontend state stayed `running` with no activity timestamp, so recovery never started. In addition, a watchdog probe that found the backend still running did not schedule another probe, leaving a later missed answer and `turn_done` unreconciled.

## User impact

Long desktop conversations no longer remain on an empty spinning assistant placeholder when the latest event stream is lost. Once the backend has persisted the completed turn, the visible conversation converges automatically without a tab switch.

## Concurrency and performance

- only the active tab owns a watchdog timer;
- tab identity is checked before probing, after asynchronous reconciliation, and before re-arming;
- effect cleanup cancels the timer and prevents stale completions from scheduling work after a tab change;
- a still-running backend is probed again after 30 seconds;
- watchdog probes use `ListTabs` only and skip jobs, effort, and balance refreshes;
- history hydration runs only when reconciliation observes the backend transition to idle.

## Compatibility, security, and cache

- no Wails method or JSON contract, persistence format, provider, prompt, tool schema, dependency, credential, or network boundary changes;
- prompt-cache behavior is unaffected;
- the fix reuses existing tab status and history APIs.

## Related work

#4522 addresses replaying a pending approval after stale reconciliation. Current `main-v2` already preserves that behavior in runtime status dispatch. This PR covers a different failure mode: zero received turn events and repeated reconciliation while the backend remains active.

## Verification

- stale-turn watchdog regression: 9 passed;
- controller meta/reducer coverage: 146 passed;
- live-history race: 5 passed;
- running-tab history hydration: 9 passed;
- send fallback: 5 passed;
- cancel reconciliation: 18 passed;
- `pnpm typecheck`;
- `pnpm lint:hooks`;
- `pnpm build` (all bundle budgets pass; initial JavaScript gzip 411.7 KiB / 425.0 KiB);
- `go run ./tools/repolint` (`clean`, 1932 baselined findings);
- `git diff --check`.

`pnpm test` is not fully green in this checkout: it reaches `composer-goal-toggle.test.tsx` and reports three durable-guidance assertion failures. An isolated rerun reproduces those three failures (227 passed, 3 failed); that suite renders `Composer` directly and does not exercise the controller/watchdog path changed here.

Documentation-impact: none - This is automatic desktop recovery behavior with no new setting or user workflow.
