### PR TITLE
fix(desktop): keep pinned chats visible after restart / 修复重启后置顶会话不显示

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-pinned-shell-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-pinned-shell-runtime.test.ts
@@ -1,0 +1,48 @@
+import { mergeProjectTopicPage, projectTreeShellChildren } from "../components/ProjectTree";
+
+type Equal = (actual: unknown, expected: unknown, label: string) => void;
+
+export function runProjectTreePinnedShellRuntimeTests(eq: Equal, projectTreeSource: string) {
+  eq(
+    mergeProjectTopicPage(
+      [
+        { key: "topic-off-page-pin", kind: "topic", label: "Pinned", topicId: "pin", pinned: true },
+        { key: "topic-stale", kind: "topic", label: "Stale", topicId: "stale" },
+      ],
+      [{ key: "topic-page", kind: "topic", label: "First page", topicId: "page" }],
+      false,
+    ).map((node) => node.key),
+    ["topic-page", "topic-off-page-pin"],
+    "a bounded first page keeps pinned shells that fall beyond the page limit",
+  );
+
+  eq(
+    projectTreeShellChildren(undefined, [
+      { key: "topic_pin", kind: "topic", label: "Pinned", topicId: "pin", pinned: true },
+    ]).map((node) => node.topicId),
+    ["pin"],
+    "a cold collapsed tree paints pinned topic shells before any folder page loads",
+  );
+
+  eq(
+    projectTreeShellChildren(
+      [
+        { key: "topic_old", kind: "topic", label: "Old pin", topicId: "old", pinned: true },
+        { key: "topic_regular", kind: "topic", label: "Regular", topicId: "regular" },
+      ],
+      [{ key: "topic_new", kind: "topic", label: "New pin", topicId: "new", pinned: true }],
+    ).map((node) => ({ topicId: node.topicId, pinned: Boolean(node.pinned) })),
+    [
+      { topicId: "old", pinned: false },
+      { topicId: "regular", pinned: false },
+      { topicId: "new", pinned: true },
+    ],
+    "shell refresh removes stale pins and adds newly pinned collapsed topics",
+  );
+
+  eq(
+    projectTreeSource.includes("children: projectTreeShellChildren(previous?.children, project.children)"),
+    true,
+    "shell refresh preserves loaded folders while reconciling pinned topic shells",
+  );
+}

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -30,6 +30,7 @@ import {
 import { projectTreeTrashingTopics } from "../lib/projectTreeArchive";
 import { normalizeProjectTreeRuntimeSnapshot } from "../lib/projectTreeRuntime";
 import { runProjectTreeSortRuntimeTests } from "./project-tree-sort-runtime.test";
+import { runProjectTreePinnedShellRuntimeTests } from "./project-tree-pinned-shell-runtime.test";
 import type { ProjectNode } from "../lib/types";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -747,11 +748,7 @@ eq(
   true,
   "archive refresh reloads only the affected topic folder after preserving the painted siblings",
 );
-eq(
-  projectTreeSource.includes("children: projectTreeShellChildren(previous?.children)"),
-  true,
-  "shell refresh never clears loaded folders while asynchronous topic reloads are pending",
-);
+runProjectTreePinnedShellRuntimeTests(eq, projectTreeSource);
 await runProjectTreeSortRuntimeTests(eq, projectTreeSource);
 
 eq(

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -547,8 +547,9 @@ export function ProjectTree({
       if (filtering || expanded.has(key)) void loadProjectTopics(project);
     }
   }, [closeMenu, expanded, loadProjectTopics, query, timeFilter]);
-  // Snapshot is intentionally shells-only. Preserve already loaded pages by
-  // project key so a metadata refresh does not collapse or blank the sidebar.
+  // Snapshot carries project shells plus lightweight pinned topic shells.
+  // Preserve already loaded pages by project key while reconciling pins, so a
+  // metadata refresh does not collapse or blank the sidebar.
   const refresh = useCallback(async (options?: ProjectTreeRefreshOptions) => {
     const reloadRequestedProjects = (projects: ProjectNode[]) => reloadProjectTreeTopics(projects, options, loadProjectTopicsRef.current);
     try {
@@ -567,7 +568,7 @@ export function ProjectTree({
         // Topic pages reload asynchronously. Keep the last painted children
         // until their replacement arrives so a mutation cannot blank every
         // expanded folder for the duration of a catalog scan.
-        return { ...project, children: projectTreeShellChildren(previous?.children) };
+        return { ...project, children: projectTreeShellChildren(previous?.children, project.children) };
       })));
       await reloadRequestedProjects(projects);
     } catch {

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -55,7 +55,14 @@ export function projectTreeShouldApplyShellSnapshot(options: {
 }
 
 export function mergeProjectTopicPage(current: ProjectNode[], incoming: ProjectNode[], append: boolean): ProjectNode[] {
-  if (!append) return [...incoming];
+  if (!append) {
+    const incomingKeys = new Set(incoming.map((node) => node.key));
+    // Project snapshots carry every pinned topic shell, while a lazy first
+    // page is bounded. Keep off-page pins so expanding a busy project cannot
+    // make its pinned section incomplete again.
+    const offPagePins = current.filter((node) => Boolean(node.pinned) && !incomingKeys.has(node.key));
+    return [...incoming, ...offPagePins];
+  }
   const next = [...current];
   const positions = new Map(next.map((node, index) => [node.key, index]));
   for (const node of incoming) {
@@ -125,8 +132,20 @@ export function invalidateProjectTreeTopicLoads(sequences: Record<string, number
 
 export function projectTreeShellChildren(
   previous: ProjectNode[] | undefined,
+  pinnedShells: ProjectNode[] | undefined = [],
 ): ProjectNode[] {
-  return asArray(previous);
+  const shells = asArray(pinnedShells).filter((node) => isTopicNode(node) && Boolean(node.pinned));
+  if (!previous || previous.length === 0) return shells;
+
+  const shellByKey = new Map(shells.map((node) => [node.key, node]));
+  const next = asArray(previous).map((node) => {
+    if (!isTopicNode(node)) return node;
+    const shell = shellByKey.get(node.key);
+    if (!shell) return node.pinned ? { ...node, pinned: false } : node;
+    shellByKey.delete(node.key);
+    return { ...node, ...shell, children: node.children ?? shell.children };
+  });
+  return [...next, ...shellByKey.values()];
 }
 
 export function projectTreeEventAffectsFolder(project: ProjectNode, roots: string[]): boolean {

--- a/desktop/frontend/src/lib/sessionCatalogBridge.ts
+++ b/desktop/frontend/src/lib/sessionCatalogBridge.ts
@@ -45,7 +45,10 @@ export function makeMockSessionCatalogBindings(cloneProjectTree: () => ProjectNo
     async GetProjectTreeSnapshot() {
       return {
         revision: 1,
-        projects: cloneProjectTree().map((project) => ({ ...project, children: [] })),
+        projects: cloneProjectTree().map((project) => ({
+          ...project,
+          children: asArray(project.children).filter((topic) => Boolean(topic.pinned)),
+        })),
         catalog: { state: "ready", mode: "memory", revision: 1, indexed: 4, total: 4, repairPending: 0 },
         indexed: 4,
         total: 4,

--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -499,6 +499,10 @@ func (a *App) requestSessionCatalogMetadataSync() {
 
 func (a *App) GetProjectTreeSnapshot() ProjectTreeSnapshot {
 	f := loadProjectsFile()
+	deleted := make(map[string]bool, len(f.DeletedTopics))
+	for _, topicID := range f.DeletedTopics {
+		deleted[topicID] = true
+	}
 	projects := []ProjectNode{}
 	if strings.TrimSpace(f.GlobalTitle) != "" || len(f.GlobalTopics) > 0 || len(f.Projects) == 0 {
 		label := strings.TrimSpace(f.GlobalTitle)
@@ -508,7 +512,7 @@ func (a *App) GetProjectTreeSnapshot() ProjectTreeSnapshot {
 		projects = append(projects, ProjectNode{
 			Key: "global_folder", Kind: "global_folder", Label: label,
 			Root: globalWorkspaceRoot(), ProjectColor: normalizeProjectColor(f.GlobalColor),
-			Children: []ProjectNode{},
+			Children: a.pinnedTopicShells("global", "", f.GlobalTopics, f.GlobalPinnedTopics, f.GlobalColor, deleted),
 		})
 	}
 	for _, project := range f.Projects {
@@ -520,7 +524,7 @@ func (a *App) GetProjectTreeSnapshot() ProjectTreeSnapshot {
 			Key: "project_" + project.Root, Kind: "project", Label: label,
 			Root: project.Root, ProjectColor: project.Color,
 			Pinned:   containsDesktopString(f.PinnedProjects, project.Root),
-			Children: []ProjectNode{},
+			Children: a.pinnedTopicShells("project", project.Root, project.Topics, project.PinnedTopics, project.Color, deleted),
 		})
 	}
 	projects = applyPinnedProjectOrder(applyProjectTreeOrder(projects, f.SidebarOrder), f.PinnedProjects)
@@ -530,6 +534,45 @@ func (a *App) GetProjectTreeSnapshot() ProjectTreeSnapshot {
 		Indexed: status.Indexed, Total: status.Total,
 		IndexingDone: a.catalogIndexingDone(status),
 	}
+}
+
+// pinnedTopicShells keeps pinned conversations available in the metadata-only
+// project snapshot. Ordinary topic pages remain lazy, but a collapsed folder
+// must not hide its pinned conversations until the user expands it.
+func (a *App) pinnedTopicShells(scope, workspaceRoot string, topicIDs, pinnedIDs []string, projectColor string, deleted map[string]bool) []ProjectNode {
+	if len(pinnedIDs) == 0 {
+		return []ProjectNode{}
+	}
+	titles := loadTopicTitles(workspaceRoot)
+	sources := loadTopicTitleSources(workspaceRoot)
+	created := loadTopicCreatedAts(workspaceRoot)
+	available := make(map[string]bool, len(topicIDs)+len(titles))
+	for _, topicID := range orderedTopicIDs(topicIDs, titles) {
+		available[topicID] = true
+	}
+	kind := "topic"
+	if scope != "project" {
+		kind = "global_topic"
+	}
+	out := make([]ProjectNode, 0, len(pinnedIDs))
+	for _, topicID := range uniqueStrings(pinnedIDs) {
+		if !available[topicID] || deleted[topicID] {
+			continue
+		}
+		title := strings.TrimSpace(titles[topicID])
+		if title == "" {
+			title = defaultTopicTitle
+		}
+		out = append(out, ProjectNode{
+			Key: kind + "_" + topicID, Kind: kind,
+			Label: a.localizedTopicTitle(title, sources[topicID]), Root: workspaceRoot,
+			TopicID: topicID, ProjectColor: normalizeProjectColor(projectColor),
+			CreatedAt: topicCreatedAtForTree(created, topicID), Pinned: true,
+			TurnsState: string(sessioncatalog.TurnsUnknown), Health: string(sessioncatalog.HealthOK),
+			Children: []ProjectNode{},
+		})
+	}
+	return out
 }
 
 func (a *App) catalogIndexingDone(status SessionCatalogStatus) bool {

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -74,6 +74,36 @@ func TestProjectTreeSnapshotReturnsProjectShellWithoutMigratingSessions(t *testi
 	}
 }
 
+func TestProjectTreeSnapshotIncludesPinnedTopicsForCollapsedFolders(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := t.TempDir()
+	if err := addProject(root, "Pinned Project"); err != nil {
+		t.Fatal(err)
+	}
+	if err := setTopicTitle(root, "ordinary", "Ordinary chat"); err != nil {
+		t.Fatal(err)
+	}
+	if err := setTopicTitle(root, "pinned", "Pinned chat"); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	if err := app.SetTopicPinned("pinned", true); err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := app.GetProjectTreeSnapshot()
+	if len(snapshot.Projects) != 1 {
+		t.Fatalf("project shells = %#v, want one project", snapshot.Projects)
+	}
+	children := snapshot.Projects[0].Children
+	if len(children) != 1 || children[0].TopicID != "pinned" || !children[0].Pinned {
+		t.Fatalf("collapsed project children = %#v, want only pinned topic shell", children)
+	}
+	if children[0].Label != "Pinned chat" {
+		t.Fatalf("pinned topic label = %q, want %q", children[0].Label, "Pinned chat")
+	}
+}
+
 func TestCompatibilityProjectTreeDoesNotMigrateLegacySession(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	root := t.TempDir()

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -711,6 +711,10 @@ func (a *App) ListProjectTree() []ProjectNode {
 	}
 	for index := range snapshot.Projects {
 		project := &snapshot.Projects[index]
+		// The lightweight snapshot carries pinned topic shells for collapsed
+		// folders. This compatibility wrapper rebuilds the complete child list,
+		// so start clean to avoid duplicating those shells with catalog rows.
+		project.Children = []ProjectNode{}
 		scope := "project"
 		root := project.Root
 		if project.Kind == "global_folder" {


### PR DESCRIPTION
## Summary

- keep pinned conversations visible immediately after Desktop starts, even when their project folders have not been expanded;
- preserve ordinary lazy topic loading by adding only lightweight pinned-topic shells to the project snapshot;
- reconcile pin/unpin changes with already-loaded topic pages and retain pinned rows beyond the first bounded page;
- keep the one-release `ListProjectTree` compatibility wrapper duplicate-free.

## Root cause

`GetProjectTreeSnapshot` intentionally returned project folder shells without topics. The frontend built its pinned section from loaded folder children, but `ListProjectTopics` only ran for expanded or filtered folders. After restart, a collapsed folder therefore contributed no topic nodes, so its pinned conversations remained invisible until the folder was expanded.

## Concurrency, performance, and compatibility

- No locks, goroutines, controller ownership, session persistence, or async request ordering changed.
- Existing catalog revision and topic-load generation guards remain authoritative for stale responses.
- Startup still does not scan or decode session files. Only folders that contain pins read their small title/source/created-at metadata files.
- No persisted format or new Wails field was added. Older frontends already accept `ProjectNode.children`; current frontend boundaries continue normalizing arrays with `asArray`.
- No provider-visible prompt, tool schema, serialization, memory prefix, or prompt-cache input changed.
- No dependency, network, command execution, credential, permission, or sandbox surface changed.

## Related PRs

- #8827 changes partial session-catalog availability in the same owner files but does not cover pinned conversations in collapsed startup snapshots. A merge-tree check against its current head is clean; either PR can merge first, although the later PR should still re-run its focused catalog/tree tests.
- #8598, #8608, and #8699 share the project-tree component for active indicators, manual ordering, and grouping respectively; they do not implement this cold-start pinned projection.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `cd desktop && go test -race . -run 'TestProjectTreeSnapshot(IncludesPinnedTopicsForCollapsedFolders|ReturnsProjectShellWithoutMigratingSessions)$' -count=1`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/project-tree-runtime.test.ts` — 85 passed
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend build` — production build and bundle budgets passed
- Browser DOM interaction: pin a conversation, collapse its project, and verify the pinned section and row remain visible with no console errors
- `go run ./tools/repolint`
- `git diff --check`

Documentation-impact: none - this restores the existing pinned-conversation behavior without adding configuration or a new workflow.
