### PR TITLE
fix(desktop): harden display performance boundaries / 强化桌面显示性能边界

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -12,6 +12,10 @@ process.env.PLAYWRIGHT_BROWSERS_PATH = !process.env.PLAYWRIGHT_BROWSERS_PATH || 
 const { chromium } = await import("playwright");
 const port = Number(process.env.REASONIX_TRANSCRIPT_SCROLL_PORT ?? 4619);
 const url = `http://127.0.0.1:${port}/?mock=bench&bench=1`;
+const maxFrameGapMs = Number(process.env.REASONIX_TRANSCRIPT_MAX_FRAME_GAP_MS ?? 250);
+const p95FrameGapMs = Number(process.env.REASONIX_TRANSCRIPT_P95_FRAME_GAP_MS ?? 80);
+const maxLongTaskMs = Number(process.env.REASONIX_TRANSCRIPT_MAX_LONG_TASK_MS ?? 250);
+const totalLongTaskMs = Number(process.env.REASONIX_TRANSCRIPT_TOTAL_LONG_TASK_MS ?? 750);
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -223,11 +227,59 @@ try {
   assert(afterGrowth.samples.every((sample) => sample.occupied), "dynamic measurement never exposes a blank transcript viewport");
 
   // Rapid direction changes are the exact user report. Sample every frame and
-  // require that Virtuoso always maintains mounted coverage.
-  for (const delta of [-700, -700, 480, -600, 520, -460]) {
+  // require that Virtuoso always maintains mounted coverage. Keep a real
+  // Chromium long-task budget around 60 events so accidental synchronous
+  // storage/layout work cannot return unnoticed.
+  await page.evaluate(() => {
+    const probe = {
+      active: true,
+      frameGaps: [],
+      lastFrame: null,
+      longTasks: [],
+      observer: null,
+    };
+    if (PerformanceObserver.supportedEntryTypes?.includes("longtask")) {
+      probe.observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) probe.longTasks.push(entry.duration);
+      });
+      probe.observer.observe({ type: "longtask", buffered: false });
+    }
+    const sampleFrame = (now) => {
+      if (!probe.active) return;
+      if (probe.lastFrame != null) probe.frameGaps.push(now - probe.lastFrame);
+      probe.lastFrame = now;
+      requestAnimationFrame(sampleFrame);
+    };
+    window.__reasonixScrollPerfProbe = probe;
+    requestAnimationFrame(sampleFrame);
+  });
+  const rapidDeltas = Array.from({ length: 10 }, () => [-700, -700, 480, -600, 520, -460]).flat();
+  for (const delta of rapidDeltas) {
     await page.mouse.wheel(0, delta);
-    await page.waitForTimeout(24);
+    await page.waitForTimeout(16);
   }
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const perf = await page.evaluate(() => {
+    const probe = window.__reasonixScrollPerfProbe;
+    if (!probe) return null;
+    probe.active = false;
+    probe.observer?.disconnect();
+    const gaps = [...probe.frameGaps].sort((left, right) => left - right);
+    const percentileIndex = Math.max(0, Math.ceil(gaps.length * 0.95) - 1);
+    return {
+      frames: gaps.length,
+      maxFrameGap: gaps.at(-1) ?? 0,
+      p95FrameGap: gaps[percentileIndex] ?? 0,
+      maxLongTask: Math.max(0, ...probe.longTasks),
+      totalLongTask: probe.longTasks.reduce((sum, duration) => sum + duration, 0),
+      longTasks: probe.longTasks.length,
+    };
+  });
+  assert(perf && perf.frames >= 30, `rapid-scroll performance probe samples enough frames (${perf?.frames ?? 0})`);
+  assert(perf.maxFrameGap <= maxFrameGapMs, `rapid-scroll maximum frame gap stays within budget (${perf.maxFrameGap.toFixed(1)}ms <= ${maxFrameGapMs}ms)`);
+  assert(perf.p95FrameGap <= p95FrameGapMs, `rapid-scroll p95 frame gap stays within budget (${perf.p95FrameGap.toFixed(1)}ms <= ${p95FrameGapMs}ms)`);
+  assert(perf.maxLongTask <= maxLongTaskMs, `rapid-scroll longest main-thread task stays within budget (${perf.maxLongTask.toFixed(1)}ms <= ${maxLongTaskMs}ms)`);
+  assert(perf.totalLongTask <= totalLongTaskMs, `rapid-scroll total long-task time stays within budget (${perf.totalLongTask.toFixed(1)}ms <= ${totalLongTaskMs}ms; ${perf.longTasks} tasks)`);
   const rapid = await transcript.evaluate((element) => {
     const rect = element.getBoundingClientRect();
     const visible = [...element.querySelectorAll(".transcript__row")].filter((row) => {

--- a/desktop/frontend/scripts/check-motion-ci-contract.mjs
+++ b/desktop/frontend/scripts/check-motion-ci-contract.mjs
@@ -10,6 +10,7 @@ const packageJSON = JSON.parse(readFileSync(resolve(repoRoot, "desktop/frontend/
 const appSource = readFileSync(resolve(repoRoot, "desktop/frontend/src/App.tsx"), "utf8");
 const bridgeSource = readFileSync(resolve(repoRoot, "desktop/frontend/src/lib/bridge.ts"), "utf8");
 const desktopMainSource = readFileSync(resolve(repoRoot, "desktop/main.go"), "utf8");
+const transcriptScrollBenchSource = readFileSync(resolve(repoRoot, "desktop/frontend/bench/transcript-scroll-stability.mjs"), "utf8");
 
 function jobBody(name, nextName) {
   const match = workflow.match(new RegExp(`\\n  ${name}:\\n([\\s\\S]*?)\\n  ${nextName}:`));
@@ -136,6 +137,17 @@ if (!jobBody("desktop", "desktop-macos").includes("PLAYWRIGHT_BROWSERS_PATH=.pw-
 for (const required of ["transcript-selection.mjs", "transcript-scroll-stability.mjs"]) {
   if (!packageJSON.scripts?.["test:transcript-browser"]?.includes(required)) {
     throw new Error(`motion-ci-contract: test:transcript-browser must include ${required}`);
+  }
+}
+for (const required of [
+  "PerformanceObserver",
+  "__reasonixScrollPerfProbe",
+  "REASONIX_TRANSCRIPT_MAX_FRAME_GAP_MS",
+  "REASONIX_TRANSCRIPT_MAX_LONG_TASK_MS",
+  "Array.from({ length: 10 }",
+]) {
+  if (!transcriptScrollBenchSource.includes(required)) {
+    throw new Error(`motion-ci-contract: transcript scroll browser gate must retain performance probe ${required}`);
   }
 }
 

--- a/desktop/frontend/src/__tests__/workspace-panel-swr-contract.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-panel-swr-contract.test.ts
@@ -47,5 +47,12 @@ assert.match(
   /\.workspace-resource-status\s*\{[\s\S]*?position:\s*absolute;/,
   "refresh and error badges overlay stale content without changing its layout",
 );
+assert.match(
+  panel,
+  /onScroll=\{\(event\) => \{\s*rememberWorkspaceTreeScroll\(workspaceMemoryKey, event\.currentTarget\.scrollTop\);/,
+  "tree scrolling updates memory without synchronously serializing localStorage",
+);
+assert.match(panel, /addEventListener\("scrollend", flush\)/, "tree scroll persistence flushes at the native scroll boundary");
+assert.match(panel, /addEventListener\("pagehide", flush\)/, "pending tree scroll state flushes before page suspension");
 
 console.log("  PASS  workspace panel SWR and per-project restoration contract");

--- a/desktop/frontend/src/__tests__/workspace-panel-swr-contract.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-panel-swr-contract.test.ts
@@ -7,6 +7,7 @@ const testDir = dirname(fileURLToPath(import.meta.url));
 const panel = readFileSync(resolve(testDir, "../components/WorkspacePanel.tsx"), "utf8");
 const stabilityCSS = readFileSync(resolve(testDir, "../components/WorkspacePanelStability.css"), "utf8");
 const workspaceChangesResource = readFileSync(resolve(testDir, "../lib/useWorkspaceChangesResource.ts"), "utf8");
+const workspaceTreeScrollPersistence = readFileSync(resolve(testDir, "../lib/useWorkspaceTreeScrollPersistence.ts"), "utf8");
 
 assert.match(
   workspaceChangesResource,
@@ -49,10 +50,18 @@ assert.match(
 );
 assert.match(
   panel,
-  /onScroll=\{\(event\) => \{\s*rememberWorkspaceTreeScroll\(workspaceMemoryKey, event\.currentTarget\.scrollTop\);/,
+  /onScroll=\{onWorkspaceTreeScroll\}/,
   "tree scrolling updates memory without synchronously serializing localStorage",
 );
-assert.match(panel, /addEventListener\("scrollend", flush\)/, "tree scroll persistence flushes at the native scroll boundary");
-assert.match(panel, /addEventListener\("pagehide", flush\)/, "pending tree scroll state flushes before page suspension");
+assert.match(
+  workspaceTreeScrollPersistence,
+  /addEventListener\("scrollend", flush\)/,
+  "tree scroll persistence flushes at the native scroll boundary",
+);
+assert.match(
+  workspaceTreeScrollPersistence,
+  /addEventListener\("pagehide", flush\)/,
+  "pending tree scroll state flushes before page suspension",
+);
 
 console.log("  PASS  workspace panel SWR and per-project restoration contract");

--- a/desktop/frontend/src/__tests__/workspace-tree-memory.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-tree-memory.test.ts
@@ -2,10 +2,16 @@
 
 import { JSDOM } from "jsdom";
 import {
+  flushWorkspaceTreeMemory,
   readWorkspaceTreeMemory,
+  rememberWorkspaceTreeScroll,
   rememberWorkspaceTreeState,
   resetWorkspaceTreeMemoryForTests,
 } from "../lib/workspaceTreeMemory";
+import {
+  createWorkspaceTreePersistenceScheduler,
+  type WorkspaceTreePersistenceClock,
+} from "../lib/workspaceTreePersistence";
 
 let passed = 0;
 function ok(value: boolean, label: string): void {
@@ -42,6 +48,66 @@ ok(projectB?.selectedFilePath === "README.md" && projectB.treeWidth === 220, "ke
 
 const persisted = JSON.parse(localStorage.getItem("reasonix.workspaceState.v2") ?? "null") as { version?: number } | null;
 ok(persisted?.version === 2, "writes an explicit schema version");
+
+let synchronousWrites = 0;
+const originalStorage = globalThis.localStorage;
+const countingStorage: Storage = {
+  get length() { return originalStorage.length; },
+  clear: () => originalStorage.clear(),
+  getItem: (key) => originalStorage.getItem(key),
+  key: (index) => originalStorage.key(index),
+  removeItem: (key) => originalStorage.removeItem(key),
+  setItem: (key, value) => {
+    synchronousWrites += 1;
+    originalStorage.setItem(key, value);
+  },
+};
+globalThis.localStorage = countingStorage;
+for (let index = 0; index < 120; index += 1) rememberWorkspaceTreeScroll("project-a", 200 + index);
+ok(synchronousWrites === 0, "keeps high-frequency scroll updates off the synchronous storage path");
+ok(readWorkspaceTreeMemory("project-a")?.scrollTop === 319, "updates the in-memory scroll position immediately");
+flushWorkspaceTreeMemory();
+ok(synchronousWrites === 1, "coalesces 120 scroll updates into one durable write");
+globalThis.localStorage = originalStorage;
+
+let nextHandle = 1;
+const frames = new Map<number, () => void>();
+const timers = new Map<number, () => void>();
+const fakeClock: WorkspaceTreePersistenceClock = {
+  requestFrame(callback) {
+    const handle = nextHandle++;
+    frames.set(handle, callback);
+    return handle;
+  },
+  cancelFrame(handle) {
+    frames.delete(handle);
+  },
+  setTimer(callback) {
+    const handle = nextHandle++;
+    timers.set(handle, callback);
+    return handle as unknown as ReturnType<typeof setTimeout>;
+  },
+  clearTimer(handle) {
+    timers.delete(handle as unknown as number);
+  },
+};
+const persistedKeys: string[] = [];
+const scheduler = createWorkspaceTreePersistenceScheduler((key) => persistedKeys.push(key), 200, fakeClock);
+for (let index = 0; index < 120; index += 1) scheduler.schedule("project-a");
+ok(frames.size === 1 && timers.size === 0, "allows at most one persistence scheduling frame");
+for (const callback of Array.from(frames.values())) callback();
+frames.clear();
+ok(timers.size === 1 && persistedKeys.length === 0, "waits for the quiet-period timer after the frame");
+for (const callback of Array.from(timers.values())) callback();
+timers.clear();
+ok(persistedKeys.join(",") === "project-a", "persists the final project once after the quiet period");
+
+scheduler.schedule("project-b");
+scheduler.flush();
+ok(
+  frames.size === 0 && persistedKeys[persistedKeys.length - 1] === "project-b",
+  "flushes pending state before a scope or page exit",
+);
 
 resetWorkspaceTreeMemoryForTests();
 localStorage.setItem("reasonix.workspaceState.v2", JSON.stringify({ version: 99, projects: [{ key: "future", state: {} }] }));

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -42,14 +42,13 @@ import { createWorkspaceRefreshScheduler } from "../lib/workspaceRefreshSchedule
 import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
 import { mergeWorkspaceSearchResults } from "../lib/workspaceTreeSearch";
 import {
-  flushWorkspaceTreeMemory,
   readWorkspaceTreeMemory,
   rememberWorkspaceTreeOpenDirs,
-  rememberWorkspaceTreeScroll,
   rememberWorkspaceTreeState,
   touchWorkspaceTreeVisit,
   workspaceTreeVisitId,
 } from "../lib/workspaceTreeMemory";
+import { useWorkspaceTreeScrollPersistence } from "../lib/useWorkspaceTreeScrollPersistence";
 import { loadLayoutSize, loadOptionalLayoutSize } from "../lib/layoutPreferences";
 import {
   RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH,
@@ -206,6 +205,7 @@ export function WorkspacePanel({
   const legacyTreeWidth = loadOptionalLayoutSize("workspaceTreeWidth");
   const panelRef = useRef<HTMLElement>(null);
   const treeRef = useRef<HTMLDivElement>(null);
+  const onWorkspaceTreeScroll = useWorkspaceTreeScrollPersistence({ memoryKey: workspaceMemoryKey, open, scrollRef: treeRef });
   const filterRef = useRef<HTMLInputElement>(null);
   const previewBodyRef = useRef<HTMLDivElement>(null);
   const [entriesByDir, setEntriesByDir] = useState<Record<string, DirEntry[]>>({});
@@ -352,24 +352,6 @@ export function WorkspacePanel({
       });
     }
   }, [creationMode, legacyTreeWidth, onRestoreDockWidths, workspaceMemoryKey, workspaceMemoryVisitId]);
-
-  useEffect(() => {
-    if (!open) return;
-    const tree = treeRef.current;
-    const flush = () => flushWorkspaceTreeMemory();
-    const flushWhenHidden = () => {
-      if (document.visibilityState === "hidden") flush();
-    };
-    tree?.addEventListener("scrollend", flush);
-    window.addEventListener("pagehide", flush);
-    document.addEventListener("visibilitychange", flushWhenHidden);
-    return () => {
-      tree?.removeEventListener("scrollend", flush);
-      window.removeEventListener("pagehide", flush);
-      document.removeEventListener("visibilitychange", flushWhenHidden);
-      flush();
-    };
-  }, [open, workspaceMemoryKey]);
 
   useEffect(() => {
     if (memoryRestorePendingRef.current) return;
@@ -2159,9 +2141,7 @@ export function WorkspacePanel({
           className="workspace-tree"
           ref={treeRef}
           onContextMenu={openTreeBlankMenu}
-          onScroll={(event) => {
-            rememberWorkspaceTreeScroll(workspaceMemoryKey, event.currentTarget.scrollTop);
-          }}
+          onScroll={onWorkspaceTreeScroll}
           style={{
             height: "100%",
             overflow: "auto",

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -42,8 +42,10 @@ import { createWorkspaceRefreshScheduler } from "../lib/workspaceRefreshSchedule
 import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
 import { mergeWorkspaceSearchResults } from "../lib/workspaceTreeSearch";
 import {
+  flushWorkspaceTreeMemory,
   readWorkspaceTreeMemory,
   rememberWorkspaceTreeOpenDirs,
+  rememberWorkspaceTreeScroll,
   rememberWorkspaceTreeState,
   touchWorkspaceTreeVisit,
   workspaceTreeVisitId,
@@ -350,6 +352,24 @@ export function WorkspacePanel({
       });
     }
   }, [creationMode, legacyTreeWidth, onRestoreDockWidths, workspaceMemoryKey, workspaceMemoryVisitId]);
+
+  useEffect(() => {
+    if (!open) return;
+    const tree = treeRef.current;
+    const flush = () => flushWorkspaceTreeMemory();
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    tree?.addEventListener("scrollend", flush);
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", flushWhenHidden);
+    return () => {
+      tree?.removeEventListener("scrollend", flush);
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", flushWhenHidden);
+      flush();
+    };
+  }, [open, workspaceMemoryKey]);
 
   useEffect(() => {
     if (memoryRestorePendingRef.current) return;
@@ -2140,7 +2160,7 @@ export function WorkspacePanel({
           ref={treeRef}
           onContextMenu={openTreeBlankMenu}
           onScroll={(event) => {
-            rememberWorkspaceTreeState(workspaceMemoryKey, { scrollTop: event.currentTarget.scrollTop });
+            rememberWorkspaceTreeScroll(workspaceMemoryKey, event.currentTarget.scrollTop);
           }}
           style={{
             height: "100%",

--- a/desktop/frontend/src/lib/useWorkspaceTreeScrollPersistence.ts
+++ b/desktop/frontend/src/lib/useWorkspaceTreeScrollPersistence.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, type RefObject, type UIEvent } from "react";
+import { flushWorkspaceTreeMemory, rememberWorkspaceTreeScroll } from "./workspaceTreeMemory";
+
+export function useWorkspaceTreeScrollPersistence<T extends HTMLElement>({
+  memoryKey,
+  open,
+  scrollRef,
+}: {
+  memoryKey: string;
+  open: boolean;
+  scrollRef: RefObject<T | null>;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const element = scrollRef.current;
+    const flush = () => flushWorkspaceTreeMemory();
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    element?.addEventListener("scrollend", flush);
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", flushWhenHidden);
+    return () => {
+      element?.removeEventListener("scrollend", flush);
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", flushWhenHidden);
+      flush();
+    };
+  }, [memoryKey, open, scrollRef]);
+
+  return useCallback((event: UIEvent<T>) => {
+    rememberWorkspaceTreeScroll(memoryKey, event.currentTarget.scrollTop);
+  }, [memoryKey]);
+}

--- a/desktop/frontend/src/lib/workspaceTreeMemory.ts
+++ b/desktop/frontend/src/lib/workspaceTreeMemory.ts
@@ -1,3 +1,5 @@
+import { createWorkspaceTreePersistenceScheduler } from "./workspaceTreePersistence";
+
 export type WorkspaceTreeWidthMode = "manual" | "even";
 
 export interface WorkspaceTreeMemorySnapshot {
@@ -113,6 +115,8 @@ function persistWorkspaceTreeMemory(recentKey: string): void {
   }
 }
 
+const deferredScrollPersistence = createWorkspaceTreePersistenceScheduler(persistWorkspaceTreeMemory);
+
 function cloneSnapshot(snapshot: WorkspaceTreeMemorySnapshot): WorkspaceTreeMemorySnapshot {
   return { ...snapshot, openDirs: new Set(snapshot.openDirs) };
 }
@@ -142,7 +146,25 @@ export function rememberWorkspaceTreeState(
     ...patch,
     openDirs: patch.openDirs ? new Set(patch.openDirs) : new Set(current.openDirs),
   });
+  // An immediate state write already includes the latest in-memory scroll
+  // position, so retire any trailing scroll write instead of duplicating it.
+  deferredScrollPersistence.cancel();
   persistWorkspaceTreeMemory(memoryKey);
+}
+
+export function rememberWorkspaceTreeScroll(memoryKey: string, scrollTop: number): void {
+  hydrateWorkspaceTreeMemory();
+  const current = workspaceTreeMemory.get(memoryKey) ?? defaultSnapshot();
+  workspaceTreeMemory.set(memoryKey, {
+    ...current,
+    openDirs: new Set(current.openDirs),
+    scrollTop: Number.isFinite(scrollTop) && scrollTop >= 0 ? scrollTop : current.scrollTop,
+  });
+  deferredScrollPersistence.schedule(memoryKey);
+}
+
+export function flushWorkspaceTreeMemory(): void {
+  deferredScrollPersistence.flush();
 }
 
 export function rememberWorkspaceTreeOpenDirs(memoryKey: string, openDirs: ReadonlySet<string>, visitId: number): void {
@@ -154,6 +176,7 @@ export function touchWorkspaceTreeVisit(memoryKey: string, visitId: number): voi
 }
 
 export function resetWorkspaceTreeMemoryForTests(): void {
+  deferredScrollPersistence.cancel();
   workspaceTreeMemory.clear();
   storageHydrated = false;
   activeWorkspaceTreeKey = "";

--- a/desktop/frontend/src/lib/workspaceTreePersistence.ts
+++ b/desktop/frontend/src/lib/workspaceTreePersistence.ts
@@ -1,0 +1,80 @@
+export interface WorkspaceTreePersistenceClock {
+  requestFrame(callback: () => void): number;
+  cancelFrame(handle: number): void;
+  setTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimer(handle: ReturnType<typeof setTimeout>): void;
+}
+
+export interface WorkspaceTreePersistenceScheduler {
+  schedule(memoryKey: string): void;
+  flush(): void;
+  cancel(): void;
+}
+
+const browserClock: WorkspaceTreePersistenceClock = {
+  requestFrame(callback) {
+    if (typeof requestAnimationFrame === "function") return requestAnimationFrame(callback);
+    return setTimeout(callback, 0) as unknown as number;
+  },
+  cancelFrame(handle) {
+    if (typeof cancelAnimationFrame === "function") cancelAnimationFrame(handle);
+    else clearTimeout(handle);
+  },
+  setTimer(callback, delayMs) {
+    return setTimeout(callback, delayMs);
+  },
+  clearTimer(handle) {
+    clearTimeout(handle);
+  },
+};
+
+export function createWorkspaceTreePersistenceScheduler(
+  persist: (memoryKey: string) => void,
+  delayMs = 200,
+  clock: WorkspaceTreePersistenceClock = browserClock,
+): WorkspaceTreePersistenceScheduler {
+  let frameHandle: number | null = null;
+  let timerHandle: ReturnType<typeof setTimeout> | null = null;
+  let pendingKey = "";
+  let dirty = false;
+
+  const clearPendingHandles = () => {
+    if (frameHandle != null) {
+      clock.cancelFrame(frameHandle);
+      frameHandle = null;
+    }
+    if (timerHandle != null) {
+      clock.clearTimer(timerHandle);
+      timerHandle = null;
+    }
+  };
+
+  const write = () => {
+    timerHandle = null;
+    if (!dirty || !pendingKey) return;
+    dirty = false;
+    persist(pendingKey);
+  };
+
+  return {
+    schedule(memoryKey) {
+      pendingKey = memoryKey;
+      dirty = true;
+      if (frameHandle != null) return;
+      frameHandle = clock.requestFrame(() => {
+        frameHandle = null;
+        if (timerHandle != null) clock.clearTimer(timerHandle);
+        timerHandle = clock.setTimer(write, delayMs);
+      });
+    },
+    flush() {
+      clearPendingHandles();
+      write();
+    },
+    cancel() {
+      clearPendingHandles();
+      dirty = false;
+      pendingKey = "";
+    },
+  };
+}

--- a/desktop/markdown_image_budget.go
+++ b/desktop/markdown_image_budget.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"os"
+
+	_ "golang.org/x/image/bmp"
+	"golang.org/x/image/webp"
+)
+
+const markdownImageMaxPixels int64 = 40_000_000
+
+var errMarkdownImageTooLarge = errors.New("markdown image exceeds the decode budget")
+
+func validateMarkdownImageFile(path, mimeType string, size int64) error {
+	if size <= 0 {
+		return fmt.Errorf("empty image")
+	}
+	if size > remoteMarkdownImageMaxBytes {
+		return errMarkdownImageTooLarge
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return validateMarkdownImageConfig(f, mimeType)
+}
+
+func validateMarkdownImageBytes(body []byte, mimeType string) error {
+	if len(body) == 0 {
+		return fmt.Errorf("empty image")
+	}
+	if len(body) > remoteMarkdownImageMaxBytes {
+		return errMarkdownImageTooLarge
+	}
+	return validateMarkdownImageConfig(bytes.NewReader(body), mimeType)
+}
+
+func validateMarkdownImageConfig(r io.Reader, mimeType string) error {
+	// SVG is sanitized by the remote proxy and does not allocate a source-sized
+	// raster during Go-side validation. ICO remains byte-bounded; Go has no
+	// decoder for it in the supported dependency set.
+	if mimeType == "image/svg+xml" || mimeType == "image/x-icon" {
+		return nil
+	}
+
+	var (
+		cfg    image.Config
+		format string
+		err    error
+	)
+	if mimeType == "image/webp" {
+		cfg, err = webp.DecodeConfig(r)
+		format = "webp"
+	} else {
+		cfg, format, err = image.DecodeConfig(r)
+	}
+	if err != nil {
+		return fmt.Errorf("decode image config: %w", err)
+	}
+	wantFormat := map[string]string{
+		"image/png":  "png",
+		"image/jpeg": "jpeg",
+		"image/gif":  "gif",
+		"image/bmp":  "bmp",
+		"image/webp": "webp",
+	}[mimeType]
+	if wantFormat == "" || format != wantFormat {
+		return fmt.Errorf("image MIME/format mismatch: %s/%s", mimeType, format)
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 {
+		return fmt.Errorf("invalid image dimensions")
+	}
+	if int64(cfg.Width) > markdownImageMaxPixels/int64(cfg.Height) {
+		return errMarkdownImageTooLarge
+	}
+	return nil
+}

--- a/desktop/markdown_image_budget.go
+++ b/desktop/markdown_image_budget.go
@@ -19,18 +19,13 @@ const markdownImageMaxPixels int64 = 40_000_000
 
 var errMarkdownImageTooLarge = errors.New("markdown image exceeds the decode budget")
 
-func validateMarkdownImageFile(path, mimeType string, size int64) error {
+func validateOpenMarkdownImageFile(f *os.File, mimeType string, size int64) error {
 	if size <= 0 {
 		return fmt.Errorf("empty image")
 	}
 	if size > remoteMarkdownImageMaxBytes {
 		return errMarkdownImageTooLarge
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
 	return validateMarkdownImageConfig(f, mimeType)
 }
 

--- a/desktop/markdown_image_resolver.go
+++ b/desktop/markdown_image_resolver.go
@@ -75,6 +75,13 @@ func (a *App) ResolveMarkdownImageForTab(tabID, source string) MarkdownImageView
 	if kind != "image" {
 		return MarkdownImageView{Filename: info.Name(), Size: info.Size(), OpenHref: openHref, ErrorCode: "unsupported-type"}
 	}
+	if err := validateMarkdownImageFile(path, mimeType, info.Size()); err != nil {
+		code := "invalid-image"
+		if errors.Is(err, errMarkdownImageTooLarge) {
+			code = "too-large"
+		}
+		return MarkdownImageView{Filename: info.Name(), Size: info.Size(), OpenHref: openHref, ErrorCode: code}
+	}
 	token := a.ensureMediaTokenStore().create(path, info.Name(), mimeType, kind, info.Size(), info.ModTime())
 	return MarkdownImageView{
 		URL:      "/__reasonix_workspace_media/" + token + "/" + url.PathEscape(info.Name()),
@@ -137,8 +144,14 @@ func resolveMarkdownDataImage(source string) MarkdownImageView {
 	if len(data) > remoteMarkdownImageMaxBytes {
 		return MarkdownImageView{ErrorCode: "too-large"}
 	}
-	_, detected := safeRemoteMarkdownImage(data)
+	validated, detected := safeRemoteMarkdownImage(data)
 	if detected != declared || detected == "image/svg+xml" {
+		return MarkdownImageView{ErrorCode: "invalid-data"}
+	}
+	if err := validateMarkdownImageBytes(validated, detected); err != nil {
+		if errors.Is(err, errMarkdownImageTooLarge) {
+			return MarkdownImageView{ErrorCode: "too-large"}
+		}
 		return MarkdownImageView{ErrorCode: "invalid-data"}
 	}
 	return MarkdownImageView{URL: source, Mime: detected, Size: int64(len(data))}

--- a/desktop/markdown_image_resolver.go
+++ b/desktop/markdown_image_resolver.go
@@ -63,11 +63,14 @@ func (a *App) ResolveMarkdownImageForTab(tabID, source string) MarkdownImageView
 		}
 		return MarkdownImageView{ErrorCode: code}
 	}
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return MarkdownImageView{ErrorCode: "not-found"}
 	}
 	openHref := localFileHref(path)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return MarkdownImageView{OpenHref: openHref, ErrorCode: "forbidden"}
+	}
 	if info.IsDir() || !info.Mode().IsRegular() {
 		return MarkdownImageView{OpenHref: openHref, ErrorCode: "not-a-file"}
 	}
@@ -75,19 +78,28 @@ func (a *App) ResolveMarkdownImageForTab(tabID, source string) MarkdownImageView
 	if kind != "image" {
 		return MarkdownImageView{Filename: info.Name(), Size: info.Size(), OpenHref: openHref, ErrorCode: "unsupported-type"}
 	}
-	if err := validateMarkdownImageFile(path, mimeType, info.Size()); err != nil {
+	f, err := os.Open(path)
+	if err != nil {
+		return MarkdownImageView{Filename: info.Name(), OpenHref: openHref, ErrorCode: "not-found"}
+	}
+	defer f.Close()
+	opened, err := f.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return MarkdownImageView{Filename: info.Name(), OpenHref: openHref, ErrorCode: "invalid-path"}
+	}
+	if err := validateOpenMarkdownImageFile(f, mimeType, opened.Size()); err != nil {
 		code := "invalid-image"
 		if errors.Is(err, errMarkdownImageTooLarge) {
 			code = "too-large"
 		}
-		return MarkdownImageView{Filename: info.Name(), Size: info.Size(), OpenHref: openHref, ErrorCode: code}
+		return MarkdownImageView{Filename: info.Name(), Size: opened.Size(), OpenHref: openHref, ErrorCode: code}
 	}
-	token := a.ensureMediaTokenStore().create(path, info.Name(), mimeType, kind, info.Size(), info.ModTime())
+	token := a.ensureMediaTokenStore().createMarkdownImage(path, info.Name(), mimeType, opened)
 	return MarkdownImageView{
 		URL:      "/__reasonix_workspace_media/" + token + "/" + url.PathEscape(info.Name()),
 		Filename: info.Name(),
 		Mime:     mimeType,
-		Size:     info.Size(),
+		Size:     opened.Size(),
 		OpenHref: openHref,
 	}
 }

--- a/desktop/markdown_image_resolver_test.go
+++ b/desktop/markdown_image_resolver_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,7 +12,22 @@ import (
 	"testing"
 )
 
-var markdownImageTestPNG = []byte("\x89PNG\r\n\x1a\nreasonix-image")
+var markdownImageTestPNG, _ = base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+
+func markdownImageTestPNGConfig(width, height uint32) []byte {
+	var out bytes.Buffer
+	out.Write([]byte("\x89PNG\r\n\x1a\n"))
+	_ = binary.Write(&out, binary.BigEndian, uint32(13))
+	chunk := make([]byte, 17)
+	copy(chunk, "IHDR")
+	binary.BigEndian.PutUint32(chunk[4:8], width)
+	binary.BigEndian.PutUint32(chunk[8:12], height)
+	chunk[12] = 8 // bit depth
+	chunk[13] = 6 // RGBA
+	out.Write(chunk)
+	_ = binary.Write(&out, binary.BigEndian, crc32.ChecksumIEEE(chunk))
+	return out.Bytes()
+}
 
 func TestResolveMarkdownImageForTabWorkspaceAndRemotePolicy(t *testing.T) {
 	original, _ := os.Getwd()
@@ -95,5 +113,42 @@ func TestResolveMarkdownDataImageMatrix(t *testing.T) {
 	tooLarge := "data:image/png;base64," + strings.Repeat("A", markdownDataImageMaxEncodedBytes)
 	if view := app.ResolveMarkdownImageForTab("", tooLarge); view.ErrorCode != "too-large" {
 		t.Fatalf("oversized data image = %+v", view)
+	}
+	tooManyPixels := "data:image/png;base64," + base64.StdEncoding.EncodeToString(markdownImageTestPNGConfig(10_000, 4_001))
+	if view := app.ResolveMarkdownImageForTab("", tooManyPixels); view.ErrorCode != "too-large" {
+		t.Fatalf("oversized decoded image = %+v", view)
+	}
+}
+
+func TestResolveMarkdownImageForTabRejectsLargeLocalImages(t *testing.T) {
+	original, _ := os.Getwd()
+	defer os.Chdir(original)
+	workspace := t.TempDir()
+	if err := os.Chdir(workspace); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+
+	largeFile := filepath.Join(workspace, "large.png")
+	f, err := os.Create(largeFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(remoteMarkdownImageMaxBytes + 1); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if view := app.ResolveMarkdownImageForTab("", "large.png"); view.ErrorCode != "too-large" || view.OpenHref == "" {
+		t.Fatalf("large local image = %+v", view)
+	}
+
+	if err := os.WriteFile("wide.png", markdownImageTestPNGConfig(20_000, 2_001), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if view := app.ResolveMarkdownImageForTab("", "wide.png"); view.ErrorCode != "too-large" || view.OpenHref == "" {
+		t.Fatalf("large decoded local image = %+v", view)
 	}
 }

--- a/desktop/remote_markdown_image.go
+++ b/desktop/remote_markdown_image.go
@@ -267,6 +267,14 @@ func serveRemoteMarkdownImage(
 		http.Error(w, "remote response is not a supported image", http.StatusUnsupportedMediaType)
 		return
 	}
+	if err := validateMarkdownImageBytes(body, mimeType); err != nil {
+		if errors.Is(err, errMarkdownImageTooLarge) {
+			http.Error(w, "remote image exceeds the decode budget", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "remote response is not a valid image", http.StatusUnsupportedMediaType)
+		return
+	}
 
 	w.Header().Set("Content-Type", mimeType)
 	w.Header().Set("Cache-Control", "private, max-age=600")

--- a/desktop/remote_markdown_image_test.go
+++ b/desktop/remote_markdown_image_test.go
@@ -27,7 +27,7 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestRemoteMarkdownImageUsesReasonixProxySpec(t *testing.T) {
-	png := []byte("\x89PNG\r\n\x1a\nproxy-image")
+	png := append([]byte(nil), markdownImageTestPNG...)
 	wantSpec := netclient.ProxySpec{Mode: netclient.ModeCustom, URL: "socks5://127.0.0.1:10808"}
 	var gotSpec netclient.ProxySpec
 	var gotRequest *http.Request
@@ -72,7 +72,7 @@ func TestRemoteMarkdownImageUsesReasonixProxySpec(t *testing.T) {
 }
 
 func TestRemoteMarkdownImageTraversesConfiguredHTTPProxy(t *testing.T) {
-	png := []byte("\x89PNG\r\n\x1a\nproxied")
+	png := append([]byte(nil), markdownImageTestPNG...)
 	var proxyCalled atomic.Bool
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxyCalled.Store(true)
@@ -151,7 +151,7 @@ func TestRemoteMarkdownImageHTTPSConnectPinsVettedIP(t *testing.T) {
 }
 
 func TestRemoteMarkdownImageTraversesConfiguredSOCKSProxyWithVettedIP(t *testing.T) {
-	png := []byte("\x89PNG\r\n\x1a\nsocks-proxied")
+	png := append([]byte(nil), markdownImageTestPNG...)
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -386,6 +386,7 @@ func TestRemoteMarkdownImageRejectsNonImagesAndOversizedBodies(t *testing.T) {
 	}{
 		{name: "html", body: []byte("<!doctype html><script>alert(1)</script>"), want: http.StatusUnsupportedMediaType},
 		{name: "oversized", body: bytes.Repeat([]byte{'x'}, remoteMarkdownImageMaxBytes+1), want: http.StatusBadGateway},
+		{name: "pixel budget", body: markdownImageTestPNGConfig(10_000, 4_001), want: http.StatusRequestEntityTooLarge},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			factory := func(netclient.ProxySpec) (*http.Client, error) {

--- a/desktop/workspace_media.go
+++ b/desktop/workspace_media.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
+	"io"
 	"mime"
 	"net/http"
 	"os"
@@ -12,15 +15,16 @@ import (
 )
 
 type mediaTokenEntry struct {
-	absPath   string
-	identity  os.FileInfo
-	filename  string
-	mime      string
-	kind      string
-	size      int64
-	modTime   time.Time
-	createdAt time.Time
-	expiresAt time.Time
+	absPath       string
+	identity      os.FileInfo
+	filename      string
+	mime          string
+	kind          string
+	size          int64
+	modTime       time.Time
+	markdownImage bool
+	createdAt     time.Time
+	expiresAt     time.Time
 }
 
 type mediaTokenStore struct {
@@ -65,6 +69,14 @@ func (s *mediaTokenStore) cleanupLocked() {
 }
 
 func (s *mediaTokenStore) create(absPath, filename, mime, kind string, size int64, modTime time.Time) string {
+	return s.createWithPolicy(absPath, filename, mime, kind, size, modTime, false, nil)
+}
+
+func (s *mediaTokenStore) createMarkdownImage(absPath, filename, mime string, identity os.FileInfo) string {
+	return s.createWithPolicy(absPath, filename, mime, "image", identity.Size(), identity.ModTime(), true, identity)
+}
+
+func (s *mediaTokenStore) createWithPolicy(absPath, filename, mime, kind string, size int64, modTime time.Time, markdownImage bool, identity os.FileInfo) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cleanupLocked()
@@ -75,10 +87,12 @@ func (s *mediaTokenStore) create(absPath, filename, mime, kind string, size int6
 	}
 	token := hex.EncodeToString(tok)
 	now := time.Now()
-	identity, _ := os.Stat(absPath)
+	if identity == nil {
+		identity, _ = os.Stat(absPath)
+	}
 	s.byTok[token] = &mediaTokenEntry{
 		absPath: absPath, identity: identity, filename: filename, mime: mime, kind: kind,
-		size: size, modTime: modTime, createdAt: now, expiresAt: now.Add(s.ttl),
+		size: size, modTime: modTime, markdownImage: markdownImage, createdAt: now, expiresAt: now.Add(s.ttl),
 	}
 	s.order = append(s.order, token)
 
@@ -88,6 +102,30 @@ func (s *mediaTokenStore) create(absPath, filename, mime, kind string, size int6
 		s.order = s.order[1:]
 	}
 	return token
+}
+
+func readValidatedMarkdownImageSnapshot(f *os.File, mimeType string, size int64) ([]byte, error) {
+	if size <= 0 {
+		return nil, errors.New("empty markdown image")
+	}
+	if size > remoteMarkdownImageMaxBytes {
+		return nil, errMarkdownImageTooLarge
+	}
+	body, err := io.ReadAll(io.LimitReader(f, remoteMarkdownImageMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > remoteMarkdownImageMaxBytes {
+		return nil, errMarkdownImageTooLarge
+	}
+	snapshot, detected := safeRemoteMarkdownImage(body)
+	if detected == "" || detected != mimeType {
+		return nil, errors.New("markdown image MIME does not match the authorized file")
+	}
+	if err := validateMarkdownImageBytes(snapshot, detected); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
 }
 
 func (s *mediaTokenStore) get(token string) *mediaTokenEntry {
@@ -150,6 +188,19 @@ func (a *App) workspaceMediaMiddleware() func(http.Handler) http.Handler {
 				http.NotFound(w, r)
 				return
 			}
+			content := io.ReadSeeker(f)
+			if entry.markdownImage {
+				snapshot, snapshotErr := readValidatedMarkdownImageSnapshot(f, entry.mime, opened.Size())
+				if snapshotErr != nil {
+					if errors.Is(snapshotErr, errMarkdownImageTooLarge) {
+						http.Error(w, "markdown image exceeds the decode budget", http.StatusRequestEntityTooLarge)
+					} else {
+						http.Error(w, "markdown image is invalid", http.StatusUnsupportedMediaType)
+					}
+					return
+				}
+				content = bytes.NewReader(snapshot)
+			}
 
 			w.Header().Set("Content-Type", entry.mime)
 			w.Header().Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{"filename": entry.filename}))
@@ -160,7 +211,7 @@ func (a *App) workspaceMediaMiddleware() func(http.Handler) http.Handler {
 				w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
 				w.Header().Set("Referrer-Policy", "no-referrer")
 			}
-			http.ServeContent(w, r, entry.filename, entry.modTime, f)
+			http.ServeContent(w, r, entry.filename, entry.modTime, content)
 		})
 	}
 }

--- a/desktop/workspace_media_security_test.go
+++ b/desktop/workspace_media_security_test.go
@@ -57,3 +57,95 @@ func TestMediaTokenHandlerRejectsFileReplacedAfterAuthorization(t *testing.T) {
 		t.Fatal("replacement target escaped the authorized media identity")
 	}
 }
+
+func TestMarkdownMediaTokenRevalidatesInPlaceContent(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		replacement []byte
+	}{
+		{name: "pixel budget", replacement: markdownImageTestPNGConfig(10_000, 4_001)},
+		{name: "byte budget", replacement: make([]byte, remoteMarkdownImageMaxBytes+1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original, _ := os.Getwd()
+			defer os.Chdir(original)
+			workspace := t.TempDir()
+			if err := os.Chdir(workspace); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile("shot.png", markdownImageTestPNG, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.Stat("shot.png")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			app := NewApp()
+			preview := app.ResolveMarkdownImageForTab("", "shot.png")
+			if preview.URL == "" || preview.ErrorCode != "" {
+				t.Fatalf("markdown image token = %+v", preview)
+			}
+			handler := app.workspaceMediaMiddleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Error("fallback handler should not be called")
+			}))
+			valid := httptest.NewRecorder()
+			handler.ServeHTTP(valid, httptest.NewRequest(http.MethodGet, preview.URL, nil))
+			if valid.Code != http.StatusOK || valid.Body.String() != string(markdownImageTestPNG) {
+				t.Fatalf("validated markdown image response = %d, body=%q", valid.Code, valid.Body.String())
+			}
+			if err := os.WriteFile("shot.png", tc.replacement, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			after, err := os.Stat("shot.png")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !os.SameFile(before, after) {
+				t.Fatal("test replacement must preserve the authorized file identity")
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, preview.URL, nil))
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("in-place replacement response = %d, want 413; body=%q", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestMarkdownMediaTokenBindsAuthorizedIdentity(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "shot.png")
+	if err := os.WriteFile(path, markdownImageTestPNG, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	authorized, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, markdownImageTestPNGConfig(10_000, 4_001), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(authorized, replacement) {
+		t.Fatal("test replacement must have a different file identity")
+	}
+
+	app := NewApp()
+	token := app.ensureMediaTokenStore().createMarkdownImage(path, "shot.png", "image/png", authorized)
+	handler := app.workspaceMediaMiddleware()(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("fallback handler should not be called")
+	}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/__reasonix_workspace_media/"+token+"/shot.png", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("replacement identity response = %d, want 404", rec.Code)
+	}
+}

--- a/desktop/workspace_media_security_test.go
+++ b/desktop/workspace_media_security_test.go
@@ -124,18 +124,22 @@ func TestMarkdownMediaTokenBindsAuthorizedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Remove(path); err != nil {
+	replacementPath := filepath.Join(workspace, "replacement.png")
+	if err := os.WriteFile(replacementPath, markdownImageTestPNGConfig(10_000, 4_001), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, markdownImageTestPNGConfig(10_000, 4_001), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	replacement, err := os.Stat(path)
+	replacement, err := os.Stat(replacementPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if os.SameFile(authorized, replacement) {
 		t.Fatal("test replacement must have a different file identity")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacementPath, path); err != nil {
+		t.Fatal(err)
 	}
 
 	app := NewApp()


### PR DESCRIPTION
## Summary

This is a focused follow-up to #8827 that hardens three remaining display-performance boundaries:

- Coalesce workspace-tree scroll persistence behind one animation frame and a 200 ms quiet period, while flushing on `scrollend`, scope changes, page hiding, and unmount.
- Apply the existing 10 MiB encoded-size limit plus a 40-megapixel decode budget to supported local, data-URI, and remote Markdown raster images.
- Extend the existing real-Chromium transcript gate to stress 60 bidirectional wheel events and enforce frame-gap and long-task budgets.

## User impact

- Continuous file-tree scrolling no longer serializes and rewrites the complete project-state envelope for every scroll event.
- Malicious or accidental compressed images with extreme decoded dimensions are rejected before WebView rendering can create a large raster allocation.
- Future transcript changes that reintroduce main-thread stalls now fail the existing required browser job.

## Compatibility and security

- The localStorage envelope remains schema version 2; existing project state stays readable by current and previous versions.
- `MarkdownImageView` keeps the same Wails JSON shape. Existing frontends already handle unknown non-empty `errorCode` values through the generic fallback.
- Rejected local images retain their safe external-open entry.
- No dependencies, provider-visible prompts, tool schemas, network destinations, credentials, or command-execution paths change.

## Performance evidence

- Deterministic unit coverage verifies that 120 scroll events produce zero synchronous storage writes and one durable trailing write.
- Real Chromium sampled 177 frames during the 60-event stress pass: 9.4 ms maximum frame gap, 8.8 ms p95, and zero long tasks.
- Image validation decodes headers/configuration only; it does not decode full pixel buffers.

## Verification

- [x] `pnpm build`
- [x] `pnpm test:workspace`
- [x] `pnpm test:motion`
- [x] `pnpm test:transcript`
- [x] `pnpm test:transcript-browser`
- [x] `pnpm test:remote`
- [x] `pnpm test:performance`
- [x] `pnpm test` (172 suites)
- [x] `go test ./...` from `desktop/`
- [x] `git diff --check`

## Baseline note

`pnpm test:typecheck` still reports the pre-existing `StaleTurnWatchdogState.turnActive` test-fixture mismatch on current `main-v2`; this PR does not touch that type or test.

Documentation-impact: none - This hardens internal persistence, image safety, and CI performance gates without changing documented user workflows or configuration.