### PR TITLE
fix(desktop): harden paged session loading / 修复分页会话加载与跨项目竞态

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,15 @@ jobs:
       # internal/agent 82s, 92s, 144s and 180s — a 2.2x spread from runner
       # variance alone, with four heavy packages sharing four vCPUs. At 3m the
       # step failed on slow runners without a code change; a hang still trips
-      # the 15 minute job budget above.
+      # the 15 minute job budget above. internal/control runs in its own
+      # Windows job below so its durable-session I/O does not compete here.
       - name: test (Windows smoke)
         if: env.RUN_STEPS == 'true' && runner.os == 'Windows' && github.event_name == 'pull_request'
         timeout-minutes: 15
         env:
           REASONIX_RELEASE_CACHE_GUARD: "1"
           WINDOWS_SANDBOX_WAIT_MS: "20000"
-        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/control/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
+        run: go test -p 4 -timeout=8m ./internal/agent/... ./internal/appidentity/... ./internal/boot/... ./internal/checkpoint/... ./internal/cli/... ./internal/desktoplauncher/... ./internal/filelock/... ./internal/fileutil/... ./internal/hook/... ./internal/instruction/... ./internal/mcplaunch/... ./internal/notify/... ./internal/proc/... ./internal/remote/... ./internal/repair/... ./internal/sandbox/... ./internal/sysproxy/... ./internal/workspacelease/... ./cmd/...
 
       # The general Windows PR smoke list intentionally omits internal/tool.
       # Keep the session-temp portability contract covered without widening the
@@ -194,6 +195,30 @@ jobs:
         timeout-minutes: 10
         shell: powershell
         run: .\scripts\test-scoop-desktop-launch.ps1
+
+  windows-control:
+    needs: changes
+    if: always()
+    runs-on: windows-latest
+    env:
+      RUN_STEPS: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code != 'false' }}
+    steps:
+      - if: env.RUN_STEPS == 'true'
+        uses: actions/checkout@v7
+
+      - if: env.RUN_STEPS == 'true'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: test
+        if: env.RUN_STEPS == 'true'
+        timeout-minutes: 10
+        env:
+          REASONIX_RELEASE_CACHE_GUARD: "1"
+          WINDOWS_SANDBOX_WAIT_MS: "20000"
+        run: go test -p 1 -timeout=8m ./internal/control/...
 
   race:
     needs: changes

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   projectTreeShellChildren,
   projectTreeEventAffectsFolder,
   projectTreeRevisionIsFresh,
+  projectTreeTopicPageIsFresh,
   projectTreeShouldApplyShellSnapshot,
   defaultExpandedProjectTreeKeys,
   activeSessionAncestorKeys,
@@ -685,6 +686,15 @@ eq(
   [projectTreeRevisionIsFresh(12, 11), projectTreeRevisionIsFresh(12, 12), projectTreeRevisionIsFresh(12, 13)],
   [false, true, true],
   "project tree ignores stale snapshots and pages while accepting the current revision",
+);
+
+eq(
+  [
+    projectTreeTopicPageIsFresh({ "project-a": 11, "project-b": 9 }, "project-a", 10),
+    projectTreeTopicPageIsFresh({ "project-a": 11, "project-b": 9 }, "project-b", 10),
+  ],
+  [false, true],
+  "a newer revision in one project does not discard another project's slower page",
 );
 
 eq(

--- a/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
@@ -18,6 +18,16 @@ assert.match(panel, /treeRef\.current\.length === 0/, "v2 event re-fetches shell
 assert.match(panel, /void refresh\(\)/, "empty-tree event path calls refresh");
 assert.match(
   panel,
+  /projectTreeTopicPageIsFresh\(topicRevisionRef\.current, key, page\.revision\)/,
+  "topic pages compare revisions within their own project",
+);
+assert.doesNotMatch(
+  panel,
+  /projectTreeRevisionIsFresh\(latestRevisionRef\.current, page\.revision\)/,
+  "an unrelated project's revision cannot discard a valid slower topic page",
+);
+assert.match(
+  panel,
   /onProjectTreeChangedV2[\s\S]*projectTreeRevisionIsFresh\(latestRevisionRef\.current, event\.revision\)/,
   "equal-revision catalog events use the shared freshness contract",
 );

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -491,7 +491,9 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   eq(rendered.live, undefined, "final message closes the live stream before turn_done");
   eq(shouldReconcileStaleTurn(rendered, 1_000, 31_000), true, "stale completed stream still reconciles missed turn_done");
   eq(shouldReconcileStaleTurn(rendered, 1_000, 20_000), false, "fresh completed stream waits before reconciling");
-  eq(shouldReconcileStaleTurn({ ...rendered, turnActive: false }, 0, rendered.turnStartAt + 30_000), true, "optimistic send reconciles even when turn_started is missed");
+  const optimistic = reducer(initialState, { type: "user", text: "hello", seq: 0, submissionId: "watchdog-submit" });
+  eq(optimistic.turnActive, false, "optimistic send starts before turn_started arrives");
+  eq(shouldReconcileStaleTurn(optimistic, 0, optimistic.turnStartAt + 30_000), true, "optimistic send reconciles even when turn_started is missed");
 }
 
 {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -10,7 +10,7 @@ import { asArray } from "../lib/array";
 import { useToast } from "../lib/toast";
 import { app } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
-import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
+import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeTopicPageIsFresh, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
 import type { ProjectNode, SessionCatalogStatus } from "../lib/types";
 import { topicActivityTime } from "../lib/session";
@@ -384,6 +384,7 @@ export function ProjectTree({
   const [tree, setTree] = useState<ProjectNode[]>([]);
   const treeRef = useRef<ProjectNode[]>([]);
   const latestRevisionRef = useRef(0);
+  const topicRevisionRef = useRef<Record<string, number>>({});
   const [catalogStatus, setCatalogStatus] = useState<SessionCatalogStatus>({
     state: "opening", revision: 0, indexed: 0, total: 0, repairPending: 0,
   });
@@ -505,11 +506,11 @@ export function ProjectTree({
         sortMode,
       });
       if (topicLoadSeqRef.current[key] !== seq) return;
-      if (!projectTreeRevisionIsFresh(latestRevisionRef.current, page.revision)) {
+      if (!projectTreeTopicPageIsFresh(topicRevisionRef.current, key, page.revision)) {
         updateTopicPageState(key, { ...topicPageStateRef.current[key], loading: false });
         return;
       }
-      latestRevisionRef.current = Math.max(latestRevisionRef.current, page.revision);
+      topicRevisionRef.current[key] = Math.max(topicRevisionRef.current[key] ?? 0, page.revision);
       const items = projectTreeWithoutTopics(asArray(page.items), currentArchiveTombstones());
       setTree((current) => applyRuntimeProjection(current.map((node) => {
         if (node.key !== key) return node;

--- a/desktop/frontend/src/lib/projectTreeTopic.ts
+++ b/desktop/frontend/src/lib/projectTreeTopic.ts
@@ -42,6 +42,14 @@ export function projectTreeRevisionIsFresh(currentRevision: number, incomingRevi
   return incomingRevision >= currentRevision;
 }
 
+export function projectTreeTopicPageIsFresh(
+  revisions: Readonly<Record<string, number>>,
+  projectKey: string,
+  incomingRevision: number,
+): boolean {
+  return projectTreeRevisionIsFresh(revisions[projectKey] ?? 0, incomingRevision);
+}
+
 // Project shells come from desktop-projects.json and are valid even when the
 // disposable catalog still reports revision 0. Catalog revision only gates
 // topic pages and non-empty tree refreshes after the first shell is painted.

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -553,6 +553,69 @@ func TestListProjectTopicsUsesAvailableProjectionBeforeEveryGlobalDirectoryIsSca
 	}
 }
 
+func TestListProjectTopicsPaginatesMetadataWhileCatalogIsPartiallyAvailable(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	legacy := config.SessionDir()
+	global := desktopSessionDir(globalWorkspaceRoot())
+	for _, dir := range []string{legacy, global} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := updateProjectsFile(func(f *desktopProjectFile) (bool, error) {
+		f.GlobalTopics = []string{"topic-a", "topic-b", "topic-c"}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicTitles("", map[string]string{
+		"topic-a": "A", "topic-b": "B", "topic-c": "C",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveTopicCreatedAts("", map[string]int64{
+		"topic-a": 100, "topic-b": 200, "topic-c": 300,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+	catalog, err := sessioncatalog.Open(context.Background(), sessioncatalog.Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		app.sessionCatalog.CompareAndSwap(catalog, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = catalog.Close(ctx)
+	})
+	app.sessionCatalog.Store(catalog)
+	if err := catalog.ReconcileDirectory(context.Background(), sessioncatalog.DirectoryTarget{Path: legacy, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "global", Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Items) != 2 || first.Items[0].TopicID != "topic-c" || first.Items[1].TopicID != "topic-b" {
+		t.Fatalf("first page topics = %#v", first.Items)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first page omitted metadata continuation cursor")
+	}
+	second, err := app.ListProjectTopics(ProjectTopicPageRequest{Scope: "global", Limit: 2, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second.Items) != 1 || second.Items[0].TopicID != "topic-a" {
+		t.Fatalf("second page topics = %#v", second.Items)
+	}
+	if second.NextCursor != "" {
+		t.Fatalf("second page next cursor = %q, want empty", second.NextCursor)
+	}
+}
+
 func TestAuthoritativeBotStylePersistIndexesSessionImmediately(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	root := t.TempDir()

--- a/desktop/session_catalog_availability.go
+++ b/desktop/session_catalog_availability.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"sort"
-	"strings"
 
 	"reasonix/internal/sessioncatalog"
 )
@@ -59,9 +58,6 @@ func (a *App) catalogWorkspaceAvailability(catalog *sessioncatalog.Catalog, scop
 }
 
 func (a *App) mergeMetadataTopics(req ProjectTopicPageRequest, page ProjectTopicPage) ProjectTopicPage {
-	if strings.TrimSpace(req.Cursor) != "" {
-		return page
-	}
 	metadata := a.metadataTopicPage(req)
 	seen := make(map[string]struct{}, len(page.Items)+len(metadata.Items))
 	for _, item := range page.Items {
@@ -85,5 +81,20 @@ func (a *App) mergeMetadataTopics(req ProjectTopicPageRequest, page ProjectTopic
 		}
 		return page.Items[i].TopicID < page.Items[j].TopicID
 	})
+	limit := req.Limit
+	if limit <= 0 {
+		limit = sessioncatalog.DefaultLimit
+	}
+	if limit > sessioncatalog.MaxLimit {
+		limit = sessioncatalog.MaxLimit
+	}
+	hasMore := page.NextCursor != "" || metadata.NextCursor != "" || len(page.Items) > limit
+	if len(page.Items) > limit {
+		page.Items = page.Items[:limit]
+	}
+	page.NextCursor = ""
+	if hasMore && len(page.Items) > 0 {
+		page.NextCursor = encodeProjectNodeCursor(page.Items[len(page.Items)-1], req.SortMode)
+	}
 	return page
 }

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -284,6 +284,22 @@ func (a *App) metadataTopicPage(req ProjectTopicPageRequest) ProjectTopicPage {
 				break
 			}
 		}
+	} else if strings.TrimSpace(req.Cursor) != "" {
+		start = len(items)
+		for index, item := range items {
+			after, err := sessioncatalog.TopicSortKeyAfterCursor(
+				req.Cursor, item.Pinned,
+				projectTopicSortValue(item.CreatedAt, item.LastActivityAt, req.SortMode), item.TopicID,
+			)
+			if err != nil {
+				start = 0
+				break
+			}
+			if after {
+				start = index
+				break
+			}
+		}
 	}
 	limit := req.Limit
 	if limit <= 0 {
@@ -606,6 +622,14 @@ func projectTopicSortValue(createdAt, lastActivityAt int64, sortMode string) int
 func encodeProjectTopicCursor(topic sessioncatalog.TopicRecord, sortMode string) string {
 	// Reuse the catalog's keyset cursor encoding by asking for the next page
 	// after this topic. ListTopics accepts the same opaque cursor it emits.
+	pinned := 0
+	if topic.Pinned {
+		pinned = 1
+	}
+	return sessioncatalog.EncodeTopicCursor(pinned, projectTopicSortValue(topic.CreatedAt, topic.LastActivityAt, sortMode), topic.TopicID)
+}
+
+func encodeProjectNodeCursor(topic ProjectNode, sortMode string) string {
 	pinned := 0
 	if topic.Pinned {
 		pinned = 1

--- a/internal/control/inbox_dispatch_test.go
+++ b/internal/control/inbox_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/sessioninbox"
 )
+
+const inboxDispatchTestTimeout = 15 * time.Second
 
 type inboxDispatchRunner struct {
 	inputs chan string
@@ -43,23 +46,43 @@ func newInboxDispatchController(t *testing.T) (*Controller, *inboxDispatchRunner
 	return c, runner, done
 }
 
-func waitForInboxDispatch(t *testing.T, runner *inboxDispatchRunner) string {
+func failInboxDispatchWait(t *testing.T, c *Controller, waitingFor string) {
+	t.Helper()
+	c.inbox.mu.Lock()
+	active := c.inbox.activeIDs()
+	dispatching := c.inbox.dispatching
+	dispatchPending := c.inbox.dispatchPending
+	c.inbox.mu.Unlock()
+	sort.Strings(active)
+	t.Fatalf(
+		"timed out after %s waiting for %s: runtime=%+v inbox=%+v active_items=%v dispatching=%t dispatch_pending=%t",
+		inboxDispatchTestTimeout,
+		waitingFor,
+		c.RuntimeStatus(),
+		c.InboxSnapshot(),
+		active,
+		dispatching,
+		dispatchPending,
+	)
+}
+
+func waitForInboxDispatch(t *testing.T, c *Controller, runner *inboxDispatchRunner) string {
 	t.Helper()
 	select {
 	case input := <-runner.inputs:
 		return input
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for inbox dispatch")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "inbox dispatch")
 		return ""
 	}
 }
 
-func waitForInboxTurnDone(t *testing.T, done <-chan struct{}) {
+func waitForInboxTurnDone(t *testing.T, c *Controller, done <-chan struct{}) {
 	t.Helper()
 	select {
 	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for inbox turn completion")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "inbox turn completion")
 	}
 }
 
@@ -76,10 +99,10 @@ func TestEndRotationDispatchesQueuedInboxItem(t *testing.T) {
 	}
 	c.endRotation()
 
-	if got := waitForInboxDispatch(t, runner); got != "queued during rotation" {
+	if got := waitForInboxDispatch(t, c, runner); got != "queued during rotation" {
 		t.Fatalf("dispatched input = %q", got)
 	}
-	waitForInboxTurnDone(t, done)
+	waitForInboxTurnDone(t, c, done)
 }
 
 func TestRejectedIdleSteerDispatchesAsFollowup(t *testing.T) {
@@ -99,10 +122,10 @@ func TestRejectedIdleSteerDispatchesAsFollowup(t *testing.T) {
 		t.Fatalf("disposition = %q", receipt.Disposition)
 	}
 
-	if got := waitForInboxDispatch(t, runner); got != "late steer becomes follow-up" {
+	if got := waitForInboxDispatch(t, c, runner); got != "late steer becomes follow-up" {
 		t.Fatalf("dispatched input = %q", got)
 	}
-	waitForInboxTurnDone(t, done)
+	waitForInboxTurnDone(t, c, done)
 }
 
 func TestInboxDispatchKickDuringEmptyScanIsNotLost(t *testing.T) {
@@ -129,8 +152,8 @@ func TestInboxDispatchKickDuringEmptyScanIsNotLost(t *testing.T) {
 	}()
 	select {
 	case <-scanReached:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not reach empty scan")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "dispatcher empty scan")
 	}
 	if _, err := c.EnqueueInbox(InboxRequest{Submit: "arrived during empty scan"}); err != nil {
 		t.Fatal(err)
@@ -142,13 +165,13 @@ func TestInboxDispatchKickDuringEmptyScanIsNotLost(t *testing.T) {
 
 	select {
 	case <-dispatchReturned:
-	case <-time.After(time.Second):
-		t.Fatal("dispatcher did not return")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "dispatcher return")
 	}
-	if got := waitForInboxDispatch(t, runner); got != "arrived during empty scan" {
+	if got := waitForInboxDispatch(t, c, runner); got != "arrived during empty scan" {
 		t.Fatalf("dispatched input = %q", got)
 	}
-	waitForInboxTurnDone(t, done)
+	waitForInboxTurnDone(t, c, done)
 }
 
 func TestInboxDispatchRetriesTransientOwnerFailure(t *testing.T) {
@@ -175,8 +198,8 @@ func TestInboxDispatchRetriesTransientOwnerFailure(t *testing.T) {
 	var retry func()
 	select {
 	case retry = <-retryReady:
-	case <-time.After(time.Second):
-		t.Fatal("transient failure did not schedule a retry")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "transient failure retry")
 	}
 	select {
 	case got := <-runner.inputs:
@@ -184,10 +207,10 @@ func TestInboxDispatchRetriesTransientOwnerFailure(t *testing.T) {
 	default:
 	}
 	retry()
-	if got := waitForInboxDispatch(t, runner); got != "retry me" {
+	if got := waitForInboxDispatch(t, c, runner); got != "retry me" {
 		t.Fatalf("retried input = %q", got)
 	}
-	waitForInboxTurnDone(t, done)
+	waitForInboxTurnDone(t, c, done)
 }
 
 type gatedInboxDispatchRunner struct {
@@ -241,8 +264,8 @@ func TestNaturalCompletionAutoDispatchesDurableFIFO(t *testing.T) {
 	c.Submit("active turn")
 	select {
 	case <-runner.firstStarted:
-	case <-time.After(time.Second):
-		t.Fatal("active turn did not start")
+	case <-time.After(inboxDispatchTestTimeout):
+		failInboxDispatchWait(t, c, "active turn start")
 	}
 	if got := <-runner.inputs; got != "active turn" {
 		t.Fatalf("initial input = %q", got)
@@ -253,12 +276,12 @@ func TestNaturalCompletionAutoDispatchesDurableFIFO(t *testing.T) {
 		}
 	}
 	close(runner.releaseFirst)
-	waitForInboxTurnDone(t, done)
+	waitForInboxTurnDone(t, c, done)
 	for _, want := range []string{"queued one", "queued two"} {
-		if got := waitForInboxDispatch(t, &inboxDispatchRunner{inputs: runner.inputs}); got != want {
+		if got := waitForInboxDispatch(t, c, &inboxDispatchRunner{inputs: runner.inputs}); got != want {
 			t.Fatalf("FIFO input = %q, want %q", got, want)
 		}
-		waitForInboxTurnDone(t, done)
+		waitForInboxTurnDone(t, c, done)
 	}
 	if snap := c.InboxSnapshot(); len(snap.Items) != 0 || snap.Paused {
 		t.Fatalf("completed FIFO left inbox state: %+v", snap)

--- a/internal/sessioncatalog/topic_cursor.go
+++ b/internal/sessioncatalog/topic_cursor.go
@@ -1,0 +1,20 @@
+package sessioncatalog
+
+// TopicSortKeyAfterCursor reports whether a topic key belongs after an
+// exclusive ListTopics cursor under the catalog's canonical ordering.
+func TopicSortKeyAfterCursor(encoded string, pinned bool, activity int64, topicID string) (bool, error) {
+	cursor, err := decodeCursor(encoded)
+	if err != nil {
+		return false, err
+	}
+	if cursor == nil {
+		return true, nil
+	}
+	pinnedValue := 0
+	if pinned {
+		pinnedValue = 1
+	}
+	return pinnedValue < cursor.Pinned ||
+		pinnedValue == cursor.Pinned && activity < cursor.Activity ||
+		pinnedValue == cursor.Pinned && activity == cursor.Activity && topicID > cursor.TopicID, nil
+}


### PR DESCRIPTION
## Summary

- Preserve metadata-only conversations across every page while session catalog directory scans are incomplete or degraded.
- Merge catalog and metadata pages with the catalog's canonical keyset ordering so continuation cursors remain complete and stable.
- Track topic-page revision watermarks per project so an update in one project cannot discard a valid slower response from another project.
- Exercise the real optimistic-send state in the stale-turn watchdog regression test and restore test TypeScript validation.
- Stabilize Windows inbox completion checks with a diagnostic 15-second wait budget and an isolated serial `internal/control` job.

## Issues

None.

## Verification

- `pnpm --dir desktop/frontend test:all`
- `pnpm --dir desktop/frontend build`
- `cd desktop && go test ./...`
- `cd desktop && go test -race . -run 'TestListProjectTopics|TestProjectTreeSnapshot|TestForkForTabDoesNotOverrideLaterActiveTab' -count=1`
- `go test -race ./internal/sessioncatalog -count=1`
- `go test ./internal/control -run '^(TestRejectedIdleSteerDispatchesAsFollowup|TestEndRotationDispatchesQueuedInboxItem|TestInboxDispatchKickDuringEmptyScanIsNotLost|TestInboxDispatchRetriesTransientOwnerFailure|TestNaturalCompletionAutoDispatchesDurableFIFO)$' -count=100`
- `go test -race ./internal/control -run '^(TestRejectedIdleSteerDispatchesAsFollowup|TestEndRotationDispatchesQueuedInboxItem|TestInboxDispatchKickDuringEmptyScanIsNotLost|TestInboxDispatchRetriesTransientOwnerFailure|TestNaturalCompletionAutoDispatchesDurableFIFO)$' -count=20`
- `go test -p 1 -timeout=8m ./internal/control/...`
- `go test ./...` in a clean worktree
- `go vet ./...`, actionlint, and `make lint` in a clean worktree

Compatibility: no persisted format or Wails JSON shape changes. Metadata-only pages continue to accept the legacy `meta:` cursor, while mixed pages use the existing catalog keyset cursor.

Security: no dependency, credential, permission, network, or file-access behavior changes.

Concurrency: deterministic coverage proves that a newer revision in project A does not discard a valid slower page for project B. The Windows control shard keeps durable-session I/O away from the four-way smoke package contention without skipping or automatically retrying tests.

## Documentation impact

Documentation-impact: none - This restores existing session-list behavior and stabilizes CI tests without changing user-facing workflows, configuration, or documented behavior.

## Cache impact

Cache-impact: none - No prompt, tool-schema, provider-serialization, compaction, memory-prefix, or skill-index code changes.
Cache-guard: The repository cache-impact detector reports no cache-sensitive files in this diff.
System-prompt-review: N/A