### PR TITLE
fix(provider): diagnose non-streaming responses instead of bare unexpected

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -663,6 +663,25 @@ func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Ch
 	}
 }
 
+// isEventStreamContentType reports whether the response's Content-Type claims
+// to be an SSE stream. Some compatible gateways omit or mislabel the header
+// while still streaming correctly, so this is only used to improve diagnostics
+// when the stream ended without a single SSE event — never to reject a response.
+func isEventStreamContentType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	return ct == "" || strings.Contains(ct, "event-stream") || strings.Contains(ct, "ndjson")
+}
+
+// clipDiagnosticLine bounds a non-SSE line before it rides in an error
+// message, so a multi-KB HTML page cannot bloat the surface text.
+func clipDiagnosticLine(line string) string {
+	const max = 120
+	if len(line) <= max {
+		return line
+	}
+	return line[:max] + "…"
+}
+
 func (c *client) buildRequest(req provider.Request) chatRequest {
 	// Repair tool-call pairing before sending: an interrupted/resumed history can
 	// carry an assistant tool_calls turn whose results never landed, which DeepSeek
@@ -923,6 +942,14 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	var lastFinishReason string
 	var sawDone bool
 	var think thinkSplitter
+	// sawDataPrefix records whether any `data:` line was seen at all, and
+	// firstNonData the first non-blank line that was not a `data:` line. A
+	// stream that ends without a single SSE event and whose Content-Type is not
+	// event-stream usually means the URL pointed at a non-streaming endpoint
+	// (a gateway landing page, an HTML error page) rather than a real model
+	// stream — surface that instead of a bare unexpected EOF (#8781).
+	var sawDataPrefix bool
+	var firstNonData string
 
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -933,9 +960,16 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		default:
 		}
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" || !strings.HasPrefix(line, "data:") {
+		if line == "" {
 			continue
 		}
+		if !strings.HasPrefix(line, "data:") {
+			if firstNonData == "" {
+				firstNonData = clipDiagnosticLine(line)
+			}
+			continue
+		}
+		sawDataPrefix = true
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
 			sawDone = true
@@ -1062,6 +1096,16 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	// tool-call arguments, which then 400 on every replay (#3953). OpenAI Chat
 	// accepts either [DONE] or a legal finish_reason as a complete terminal.
 	if !sawDone && lastFinishReason == "" {
+		ct := strings.TrimSpace(resp.Header.Get("Content-Type"))
+		if !sawDataPrefix && !isEventStreamContentType(ct) {
+			// No SSE event at all and the response does not even claim to be
+			// event-stream: the endpoint returned a non-streaming body (a
+			// gateway landing page or HTML/JSON error page) for a URL that
+			// should have streamed. This is a config problem, not a dropped
+			// connection, so say so instead of a bare unexpected EOF (#8781).
+			return emitted, fmt.Errorf("%s: stream ended before any SSE event (Content-Type %q, first line %q) — the endpoint returned a non-streaming response, e.g. a gateway landing page. Check that request_url/base_url points to a full API endpoint such as /v1/chat/completions or /v1/responses, not a gateway root: %w",
+				c.name, ct, firstNonData, io.ErrUnexpectedEOF)
+		}
 		return emitted, fmt.Errorf("%s: stream ended before completion: %w", c.name, io.ErrUnexpectedEOF)
 	}
 

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -2370,3 +2370,134 @@ func TestNormaliseUsageAnthropicStyleFallback(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamHTMLResponseDiagnostic reproduces #8781: a gateway that answers a
+// POST to its root path with 200 + an HTML landing page (no SSE events at all).
+// The stream must surface a diagnostic naming the non-streaming response and
+// the Content-Type, instead of a bare "unexpected EOF" that reads like a
+// dropped connection.
+func TestStreamHTMLResponseDiagnostic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "<!doctype html><html><head><title>Gateway</title></head><body>Welcome</body></html>")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek-responses", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var gotErr error
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			gotErr = chunk.Err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected a stream error for an HTML response, got none")
+	}
+	msg := gotErr.Error()
+	for _, want := range []string{
+		"non-streaming response",
+		"text/html",
+		"request_url/base_url",
+		"<!doctype html>",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+	if strings.HasPrefix(msg, "unexpected EOF") {
+		// The wrapped cause is allowed to keep the category, but the message
+		// must lead with the actionable diagnostic, not the bare EOF.
+		t.Errorf("error %q reads like a bare EOF, want diagnostic first", msg)
+	}
+}
+
+// TestStreamHTMLResponseDiagnosticJSONError covers the sibling case where the
+// root path answers 200 with a JSON error page rather than HTML.
+func TestStreamHTMLResponseDiagnosticJSONError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"error":"not found"}`)
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "gw", BaseURL: srv.URL, Model: "m", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var gotErr error
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			gotErr = chunk.Err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected a stream error for a JSON response, got none")
+	}
+	msg := gotErr.Error()
+	if !strings.Contains(msg, "non-streaming response") || !strings.Contains(msg, "application/json") {
+		t.Errorf("error %q missing non-streaming diagnostic", msg)
+	}
+}
+
+// TestStreamMissingContentTypeStillStreams guards the diagnostic: a gateway
+// that streams SSE without setting Content-Type must keep working.
+func TestStreamMissingContentTypeStillStreams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK) // no Content-Type header at all
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "gw", BaseURL: srv.URL, Model: "m", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var got strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			got.WriteString(chunk.Text)
+		}
+	}
+	if got.String() != "ok" {
+		t.Errorf("streamed text = %q, want %q", got.String(), "ok")
+	}
+}
+
+func TestIsEventStreamContentType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"text/event-stream", true},
+		{"text/event-stream; charset=utf-8", true},
+		{"application/x-ndjson", true},
+		{"text/html", false},
+		{"application/json", false},
+		{"", true}, // unknown: diagnostics only, never reject
+	}
+	for _, tc := range tests {
+		if got := isEventStreamContentType(tc.in); got != tc.want {
+			t.Errorf("isEventStreamContentType(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third-party OpenAI-compatible gateways can answer a POST to their root path (e.g. `request_url = "https://<gateway>/v1"`) with `200 + text/html` — a landing page, not an SSE stream. `SendWithRetry` only checks the status code, so the request is accepted, `readStream` never sees a `data:` line, and the user gets a bare `stream ended before completion: unexpected EOF` that reads like a dropped connection and gives no hint the URL is misconfigured (#8781).

This change improves that diagnostic only (no behavior change to healthy streams):

- `readStream` now tracks whether any SSE `data:` line was seen and the first non-SSE line.
- When the stream ends with **no SSE event at all** and the response **does not even claim** to be `text/event-stream`, the error names the non-streaming response, includes the `Content-Type` and first body line, and points at `request_url`/`base_url` needing a full API endpoint (`/v1/chat/completions` or `/v1/responses`).
- `isEventStreamContentType` treats missing/mislabeled headers as unknown (diagnostics only, never rejects), and `clipDiagnosticLine` bounds long HTML lines in the message.

Real stream cuts (SSE Content-Type present, or at least one event seen) keep the exact previous error text.

## Issues

Fixes #8781

## Verification

- `go test ./internal/provider/openai/`
- New tests: `TestStreamHTMLResponseDiagnostic` (200 + HTML landing page), `TestStreamHTMLResponseDiagnosticJSONError` (200 + JSON error page), `TestStreamMissingContentTypeStillStreams` (guards the diagnostic against gateways that stream without a Content-Type header), `TestIsEventStreamContentType`.
- `go vet ./...`
- `go test ./internal/tool/builtin/ ./internal/boot/ ./internal/provider/...`

## Documentation impact

Documentation-impact: none - the only user-visible change is a clearer runtime error message; no docs/*.md content describes this error path, and the `request_url` vs `base_url` semantics are unchanged.

## Cache impact

Cache-impact: low - error-path diagnostics only in the openai chat-completions stream reader; the cache-stable system-prompt prefix and provider-visible tool schemas/order are untouched.

Cache-guard: `go test ./internal/provider/openai/` (adds TestStreamHTMLResponseDiagnostic / TestStreamHTMLResponseDiagnosticJSONError / TestStreamMissingContentTypeStillStreams / TestIsEventStreamContentType); existing boot surface tests still pass with identical tools/system prompt.

System-prompt-review: N/A - no system-prompt, memory prefix, output style, or skill index changes.