### PR TITLE
fix(provider/responses): diagnose non-streaming responses instead of bare premature EOF / Responses 路径同步非流式响应诊断 (#8781)

### DIFF
--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -547,6 +547,14 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	terminal := false
 	failed := false
 	completedResponseID := ""
+	// sawDataPrefix records whether any `data:` line was seen at all, and
+	// firstNonData the first non-blank line that was not a `data:` line. A
+	// stream that ends without a single SSE event and whose Content-Type is not
+	// event-stream usually means the URL pointed at a non-streaming endpoint
+	// (a gateway landing page, an HTML error page) rather than a real model
+	// stream — surface that instead of a bare premature-EOF (#8781).
+	var sawDataPrefix bool
+	var firstNonData string
 
 	for scanner.Scan() {
 		select {
@@ -555,8 +563,12 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "data:") {
+			if firstNonData == "" && strings.TrimSpace(line) != "" {
+				firstNonData = clipDiagnosticLine(line)
+			}
 			continue
 		}
+		sawDataPrefix = true
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
 			terminal = true
@@ -757,6 +769,16 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	// before a terminal event leaves the attempt uncommitted — including any
 	// complete tool calls already forwarded as speculative output.
 	if !terminal {
+		if !sawDataPrefix && !isEventStreamContentType(resp.Header.Get("Content-Type")) {
+			// No SSE event at all and the response does not even claim to be
+			// event-stream: the endpoint returned a non-streaming body (a
+			// gateway landing page or HTML/JSON error page) for a URL that
+			// should have streamed. This is a config problem, not a dropped
+			// connection, so say so instead of a bare premature-EOF (#8781).
+			_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: stream ended before any SSE event (Content-Type %q, first line %q) — the endpoint returned a non-streaming response, e.g. a gateway landing page. Check that request_url/base_url points to a full API endpoint such as /v1/chat/completions or /v1/responses, not a gateway root: %w",
+				c.name, strings.TrimSpace(resp.Header.Get("Content-Type")), firstNonData, io.ErrUnexpectedEOF)})
+			return
+		}
 		_ = sendChunk(ctx, out, provider.Chunk{Type: provider.ChunkError, Err: provider.StreamInterrupt(io.ErrUnexpectedEOF, provider.StreamInterruptPrematureEOF)})
 		return
 	}
@@ -802,6 +824,25 @@ func sendChunk(ctx context.Context, out chan<- provider.Chunk, chunk provider.Ch
 	case <-ctx.Done():
 		return false
 	}
+}
+
+// isEventStreamContentType reports whether the response's Content-Type claims
+// to be an SSE stream. Some compatible gateways omit or mislabel the header
+// while still streaming correctly, so this is only used to improve diagnostics
+// when the stream ended without a single SSE event — never to reject a response.
+func isEventStreamContentType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	return ct == "" || strings.Contains(ct, "event-stream") || strings.Contains(ct, "ndjson")
+}
+
+// clipDiagnosticLine bounds a non-SSE line before it rides in an error
+// message, so a multi-KB HTML page cannot bloat the surface text.
+func clipDiagnosticLine(line string) string {
+	const max = 120
+	if len(line) <= max {
+		return line
+	}
+	return line[:max] + "…"
 }
 
 func usageFromResponse(response *sseResponse) *provider.Usage {

--- a/internal/provider/responses/responses_test.go
+++ b/internal/provider/responses/responses_test.go
@@ -1175,3 +1175,75 @@ func TestVendorTableMaxOutputTokens(t *testing.T) {
 		t.Fatalf("deepseek auto budget = %#v, want omitted official ceiling", db["max_output_tokens"])
 	}
 }
+
+// TestStreamHTMLResponseDiagnostic reproduces #8781 on the Responses path: a
+// gateway answers a POST to its root path with 200 + an HTML landing page (no
+// SSE events at all). The stream must surface a diagnostic naming the
+// non-streaming response and the Content-Type, instead of a bare premature
+// EOF that reads like a dropped connection.
+func TestStreamHTMLResponseDiagnostic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "<!doctype html><html><head><title>Gateway</title></head><body>Welcome</body></html>")
+	}))
+	defer server.Close()
+
+	chunks := collect(t, New(Config{Name: "deepseek-responses", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateless"}), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	var gotErr error
+	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkError {
+			gotErr = chunk.Err
+		}
+	}
+	if gotErr == nil {
+		t.Fatal("expected a stream error for an HTML response, got none")
+	}
+	msg := gotErr.Error()
+	for _, want := range []string{
+		"non-streaming response",
+		"text/html",
+		"request_url/base_url",
+		"<!doctype html>",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+	if strings.HasPrefix(msg, "unexpected EOF") {
+		t.Errorf("error %q reads like a bare EOF, want diagnostic first", msg)
+	}
+}
+
+// TestStreamMissingContentTypeStillStreams guards the Responses-path
+// diagnostic: a gateway that streams SSE without setting Content-Type must
+// keep working.
+func TestStreamMissingContentTypeStillStreams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // no Content-Type header at all
+		writeEvents(w,
+			`{"type":"response.output_text.delta","item_id":"msg_1","content_index":0,"delta":"ok"}`,
+			`{"type":"response.output_text.done","item_id":"msg_1","content_index":0,"text":"ok"}`,
+			`{"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		)
+	}))
+	defer server.Close()
+
+	chunks := collect(t, New(Config{Name: "test", APIKey: "key", BaseURL: server.URL, Model: "m", Mode: "stateless"}), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	var text strings.Builder
+	for _, chunk := range chunks {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			text.WriteString(chunk.Text)
+		}
+	}
+	if text.String() != "ok" {
+		t.Errorf("streamed text = %q, want %q", text.String(), "ok")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #8870 (same root cause, second wire path). #8781's reporter configured `responses_mode = "stateless"`; the Responses stream reader (`internal/provider/responses/responses.go`) had the same blind spot as the chat path: a gateway answering a POST to its root path with `200 + text/html` (a landing page, not SSE) produced only a bare premature-EOF error, reading like a dropped connection with no hint the URL is misconfigured.

This change mirrors the #8870 diagnostic on the Responses path:

- `readStream` now tracks whether any SSE `data:` line was seen and the first non-SSE line.
- When the stream ends with **no SSE event at all** and the response **does not even claim** to be `text/event-stream`, the error names the non-streaming response, includes the `Content-Type` and first body line, and points at `request_url`/`base_url` needing a full API endpoint (`/v1/chat/completions` or `/v1/responses`).
- `isEventStreamContentType` treats missing/mislabeled headers as unknown (diagnostics only, never rejects); `clipDiagnosticLine` bounds long HTML lines.

Real stream cuts (SSE Content-Type present, or at least one event seen) keep the exact previous `StreamInterruptPrematureEOF` behavior.

## Issues

Refs #8781

## Verification

- `go test ./internal/provider/responses/`
- New tests: `TestStreamHTMLResponseDiagnostic` (200 + HTML landing page), `TestStreamMissingContentTypeStillStreams` (guards the diagnostic against gateways that stream without a Content-Type header).
- `go vet ./...`
- `go test ./internal/provider/...`

## Documentation impact

Documentation-impact: none - the only user-visible change is a clearer runtime error message; no docs/*.md content describes this error path, and the `request_url` vs `base_url` semantics are unchanged.

## Cache impact

Cache-impact: low - error-path diagnostics only in the Responses stream reader; the cache-stable system-prompt prefix and provider-visible tool schemas/order are untouched.

Cache-guard: `go test ./internal/provider/responses/` (adds TestStreamHTMLResponseDiagnostic / TestStreamMissingContentTypeStillStreams); existing boot surface tests still pass with identical tools/system prompt.

System-prompt-review: N/A - no system-prompt, memory prefix, output style, or skill index changes.