### PR TITLE
feat(tool): add set_session_title tool for agent-named sessions / 新增 set_session_title 工具，Agent 可按内容为会话命名 (#8838)

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1161,12 +1161,14 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		if opts.Ablation.Off(ablation.Retrieval) {
 			reg.Add(sessiontool.NewListSessionsTool(sessionDir))
 			reg.Add(sessiontool.NewReadSessionTool(sessionDir))
-			return "enabled list_sessions, read_session."
+			reg.Add(sessiontool.NewSetSessionTitleTool(sessionDir))
+			return "enabled list_sessions, read_session, set_session_title."
 		}
 		reg.Add(history.NewIndexedTool(history.Options{SessionDir: sessionDir, GlobalSessionDir: config.SessionDir(), ArchiveDir: config.ArchiveDir()}))
 		reg.Add(sessiontool.NewListSessionsTool(sessionDir))
 		reg.Add(sessiontool.NewReadSessionTool(sessionDir))
-		return "enabled history, list_sessions, read_session."
+		reg.Add(sessiontool.NewSetSessionTitleTool(sessionDir))
+		return "enabled history, list_sessions, read_session, set_session_title."
 	}
 	memoryToolsAdded := false
 	addMemoryTools := func() string {

--- a/internal/tool/sessiontool/sessiontool.go
+++ b/internal/tool/sessiontool/sessiontool.go
@@ -115,21 +115,9 @@ func (t *readSessionTool) Execute(_ context.Context, args json.RawMessage) (stri
 		return "", fmt.Errorf("read_session: 'session' argument is required")
 	}
 
-	sessionPath := params.Session
-	// If it's just a filename (no path separator), resolve relative to sessionDir
-	if !strings.Contains(sessionPath, string(filepath.Separator)) && !strings.Contains(sessionPath, "/") {
-		sessionPath = filepath.Join(t.sessionDir, sessionPath)
-	}
-	// Guard against path traversal
-	sessionPath = filepath.Clean(sessionPath)
-	dir := filepath.Clean(t.sessionDir)
-	if !strings.HasPrefix(sessionPath, dir+string(filepath.Separator)) && sessionPath != dir {
-		return "", fmt.Errorf("read_session: path %q is outside the session directory", params.Session)
-	}
-
-	// Reject cleanup-pending sessions (reuses agent.IsCleanupPending directly).
-	if agent.IsCleanupPending(sessionPath) {
-		return "", fmt.Errorf("read_session: session %q is pending cleanup", filepath.Base(sessionPath))
+	sessionPath, err := resolveSessionPath(t.sessionDir, params.Session)
+	if err != nil {
+		return "", fmt.Errorf("read_session: %w", err)
 	}
 
 	// Reuse agent.LoadSession for JSONL decoding.
@@ -222,4 +210,83 @@ func modelFromPath(path string) string {
 		return rest
 	}
 	return after0
+}
+
+// set_session_title tool
+
+type setSessionTitleTool struct {
+	sessionDir string
+}
+
+// NewSetSessionTitleTool creates a tool that sets the display title of a saved
+// session, letting the agent name sessions from their content (#8838).
+func NewSetSessionTitleTool(sessionDir string) *setSessionTitleTool {
+	return &setSessionTitleTool{sessionDir: sessionDir}
+}
+
+func (t *setSessionTitleTool) Name() string   { return "set_session_title" }
+func (t *setSessionTitleTool) ReadOnly() bool { return false }
+
+func (t *setSessionTitleTool) Description() string {
+	return "Set (or clear) the display title of a saved session. The title overrides the first-user-message preview in the session list and in --resume matching. To clear the title, pass an empty string. Use list_sessions to discover session file names."
+}
+
+func (t *setSessionTitleTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "session": {
+      "type": "string",
+      "description": "Session file name (e.g. \"20260618-231556.000000000-gpt-4.jsonl\") or full path. Use list_sessions to see available sessions."
+    },
+    "title": {
+      "type": "string",
+      "description": "New display title for the session. An empty string clears the title and falls back to the first user message preview."
+    }
+  },
+  "required": ["session", "title"]
+}`)
+}
+
+func (t *setSessionTitleTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		Session string `json:"session"`
+		Title   string `json:"title"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("set_session_title: invalid args: %w", err)
+	}
+	if params.Session == "" {
+		return "", fmt.Errorf("set_session_title: 'session' argument is required")
+	}
+	sessionPath, err := resolveSessionPath(t.sessionDir, params.Session)
+	if err != nil {
+		return "", fmt.Errorf("set_session_title: %w", err)
+	}
+	if err := agent.RenameSession(sessionPath, params.Title); err != nil {
+		return "", fmt.Errorf("set_session_title: %w", err)
+	}
+	return fmt.Sprintf("Session %s title set to %q.", filepath.Base(sessionPath), params.Title), nil
+}
+
+// resolveSessionPath resolves a session file name (or full path) against the
+// session directory, guarding against path traversal, and rejects sessions
+// that are pending cleanup. Used by read_session and set_session_title.
+func resolveSessionPath(sessionDir, session string) (string, error) {
+	sessionPath := session
+	// If it's just a filename (no path separator), resolve relative to sessionDir
+	if !strings.Contains(sessionPath, string(filepath.Separator)) && !strings.Contains(sessionPath, "/") {
+		sessionPath = filepath.Join(sessionDir, sessionPath)
+	}
+	// Guard against path traversal
+	sessionPath = filepath.Clean(sessionPath)
+	dir := filepath.Clean(sessionDir)
+	if !strings.HasPrefix(sessionPath, dir+string(filepath.Separator)) && sessionPath != dir {
+		return "", fmt.Errorf("path %q is outside the session directory", session)
+	}
+	// Reject cleanup-pending sessions (reuses agent.IsCleanupPending directly).
+	if agent.IsCleanupPending(sessionPath) {
+		return "", fmt.Errorf("session %q is pending cleanup", filepath.Base(sessionPath))
+	}
+	return sessionPath, nil
 }

--- a/internal/tool/sessiontool/sessiontool_test.go
+++ b/internal/tool/sessiontool/sessiontool_test.go
@@ -373,3 +373,70 @@ func TestCleanupPendingContract(t *testing.T) {
 		t.Fatal("read_session should reject cleanup-pending session created by agent.MarkCleanupPending")
 	}
 }
+
+// set_session_title tests
+
+func TestSetSessionTitle_SetsMetaTitle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260618-231556.000000000-gpt-4.jsonl")
+	writeSessionJSONL(t, path, []provider.Message{{Role: provider.RoleUser, Content: "help me parse the ledger"}})
+
+	tool := NewSetSessionTitleTool(dir)
+	out := runTool(t, tool, map[string]any{
+		"session": "20260618-231556.000000000-gpt-4.jsonl",
+		"title":   "Parse the ledger",
+	})
+	if !strings.Contains(out, `title set to "Parse the ledger"`) {
+		t.Fatalf("output %q missing confirmation", out)
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("load meta: ok=%v err=%v", ok, err)
+	}
+	if meta.CustomTitle != "Parse the ledger" {
+		t.Fatalf("meta.CustomTitle = %q, want %q", meta.CustomTitle, "Parse the ledger")
+	}
+}
+
+func TestSetSessionTitle_ClearsTitle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260618-231556.000000000-gpt-4.jsonl")
+	writeSessionJSONL(t, path, []provider.Message{{Role: provider.RoleUser, Content: "hi"}})
+	if err := agent.RenameSession(path, "Initial title"); err != nil {
+		t.Fatalf("seed title: %v", err)
+	}
+
+	tool := NewSetSessionTitleTool(dir)
+	runTool(t, tool, map[string]any{
+		"session": "20260618-231556.000000000-gpt-4.jsonl",
+		"title":   "",
+	})
+
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("load meta: ok=%v err=%v", ok, err)
+	}
+	if meta.CustomTitle != "" {
+		t.Fatalf("meta.CustomTitle = %q, want empty after clearing", meta.CustomTitle)
+	}
+}
+
+func TestSetSessionTitle_RejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewSetSessionTitleTool(dir)
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{
+		"session":"../../elsewhere.jsonl",
+		"title":"nope"
+	}`))
+	if err == nil || !strings.Contains(err.Error(), "outside the session directory") {
+		t.Fatalf("path traversal should be rejected, got %v", err)
+	}
+}
+
+func TestSetSessionTitle_RequiresSession(t *testing.T) {
+	tool := NewSetSessionTitleTool(t.TempDir())
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"title":"x"}`)); err == nil {
+		t.Fatal("missing session argument should be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

Implements option A of #8838: a new `set_session_title` agent tool so the agent can name sessions from their content, instead of every session showing the first-user-message preview.

`internal/tool/sessiontool/sessiontool.go`:

- New `set_session_title(session, title)` tool: writes `BranchMeta.CustomTitle` via the existing `agent.RenameSession` (preserves `UpdatedAt`, so renaming does not reorder the recent-session list). An empty `title` clears the title and falls back to the preview.
- Reuses the `read_session` path resolution, extracted into a shared `resolveSessionPath` helper (relative-to-sessionDir resolution + path-traversal guard + cleanup-pending rejection).
- Registered as a mutating tool (`ReadOnly: false`), so it rides the normal tool-approval flow.

`internal/boot/boot.go`: registers `set_session_title` in both session-tool branches (with and without the retrieval ablation arm).

The agent discovers session file names via the existing `list_sessions` tool and names its current session after a meaningful turn.

## Issues

Fixes #8838

## Verification

- `go test ./internal/tool/sessiontool/`
- New tests: `TestSetSessionTitle_SetsMetaTitle` (title lands in the sidecar meta), `TestSetSessionTitle_ClearsTitle` (empty title clears), `TestSetSessionTitle_RejectsPathTraversal`, `TestSetSessionTitle_RequiresSession`.
- `go vet ./internal/tool/sessiontool/ ./internal/boot/`
- `go test ./internal/boot/`

## Documentation impact

Documentation-impact: none - `docs/TOOL_CONTRACT.md` enumerates read-only tools only; `set_session_title` is a mutating tool like `todo_write`/`remember` and needs no contract entry. Session title semantics are unchanged (the sidecar `custom_title` field already existed and was already used by `--resume` matching and the session list).

## Cache impact

Cache-impact: medium - registering a new tool changes the provider-visible tool schema/list, so the cache-stable system-prompt prefix invalidates once on this feature (one-time cost of adding any tool); no other prefix bytes change.

Cache-guard: `go test ./internal/boot/ ./internal/tool/sessiontool/` (boot surface tool-list tests + the four new set_session_title tests).

System-prompt-review: 工具注册变更仅在 addSessionTools 追加 set_session_title（沿用既有 sessiontool 注册模式），系统提示词 base prompt 与 memory 前缀未改动；缓存前缀唯一变化是工具列表新增一项，由 boot surface 工具列表测试（go test ./internal/boot/）覆盖，请维护者评审确认注册方式与既有工具一致。