### PR TITLE
fix(desktop): replay pending ask/approval prompts on tab activation / 切换到后台会话时重放未回答的 Ask/审批弹窗 (#8810)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1563,6 +1563,22 @@ func (a *App) ReplayPendingPrompts() {
 	}
 }
 
+// replayPendingPromptsFor re-emits any ask/approval prompt a tab's controller
+// is currently blocking on. A prompt emitted while the tab was in the
+// background never surfaced; switching to the tab must replay it or the turn
+// stays stuck with only a sidebar badge and no modal (#8810).
+func (a *App) replayPendingPromptsFor(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	a.mu.RLock()
+	ctrl := tab.Ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.ReplayPendingPrompts()
+	}
+}
+
 // SetPlanMode toggles the plan-first workflow while preserving the current
 // tool-approval posture and sandbox settings.
 func (a *App) SetPlanMode(on bool) {

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -678,6 +678,11 @@ func (c *retargetRuntimeController) Goal() string                         { retu
 func (c *retargetRuntimeController) GoalStatus() string                   { return "" }
 func (c *retargetRuntimeController) ToolApprovalMode() string             { return control.ToolApprovalAsk }
 
+// ReplayPendingPrompts is a no-op for the retarget stub: tab activation now
+// replays pending prompts on the activated controller, so the stub needs the
+// method on the interface without a real approval store behind it.
+func (c *retargetRuntimeController) ReplayPendingPrompts() {}
+
 func TestRetargetOpenTabsSkipsRunningSessions(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := desktopSessionDir(globalWorkspaceRoot())

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2368,6 +2368,11 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 				meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 				a.saveTabsLocked()
 				a.mu.Unlock()
+				if activate {
+					// Surface an ask/approval prompt the background tab raised
+					// before it became the active tab (#8810).
+					a.replayPendingPromptsFor(tab)
+				}
 				return enrichTabMeta(meta), nil
 			}
 		}
@@ -2383,6 +2388,11 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.saveTabsLocked()
 			a.mu.Unlock()
 			if sameSession || a.skipCoveringLeafRebind(tab, sessionPath) {
+				if activate {
+					// Surface an ask/approval prompt the background tab raised
+					// before it became the active tab (#8810).
+					a.replayPendingPromptsFor(tab)
+				}
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
@@ -3107,6 +3117,10 @@ func (a *App) SetActiveTab(tabID string) error {
 	}
 	if next != nil {
 		next.clearRuntimeDisplayCurrency()
+		// A background tab can have an ask/approval prompt that was emitted
+		// while it was not the active tab; replay it so the modal surfaces
+		// instead of leaving the turn stuck (#8810).
+		a.replayPendingPromptsFor(next)
 	}
 	if supersededReq != "" {
 		a.emitTopicActivation(TopicActivationEvent{RequestID: supersededReq, TabID: supersededTab, Phase: topicActivationPhaseCancelled})

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -1193,3 +1193,63 @@ func TestRestoredTabIDLockedReplacesEmptyAndDuplicateIDs(t *testing.T) {
 		}
 	}
 }
+
+// TestSetActiveTabReplaysBackgroundPendingPrompt covers #8810: an ask/approval
+// prompt raised while a tab was in the background (not the active tab) must be
+// replayed when the user switches to that tab, instead of leaving the turn
+// stuck with only a sidebar badge and no modal.
+func TestSetActiveTabReplaysBackgroundPendingPrompt(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	asks := make(chan event.Ask, 2)
+	done := make(chan event.Event, 1)
+	runner := &desktopAskRuntimeRunner{}
+	ctrl := control.New(control.Options{
+		Runner: runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.AskRequest:
+				asks <- e.Ask
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+	runner.ask = func(ctx context.Context) error {
+		_, err := ctrl.Ask(ctx, []event.AskQuestion{{
+			ID:      "choice",
+			Prompt:  "Pick one",
+			Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+		}})
+		return err
+	}
+	defer ctrl.Close()
+
+	app := testAppWithOrderedTabs(t, "a", "a", "b")
+	app.tabs["b"].Ctrl = ctrl
+
+	// The ask is raised while tab A is active — B is a background tab, so the
+	// prompt's modal never surfaces to the user.
+	go ctrl.Send("ask user")
+	select {
+	case <-asks:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for background ask request")
+	}
+
+	// Switching to tab B must replay the pending prompt.
+	if err := app.SetActiveTab("b"); err != nil {
+		t.Fatalf("SetActiveTab: %v", err)
+	}
+	select {
+	case <-asks:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replayed ask request after tab switch")
+	}
+
+	app.CancelTab("b")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for turn_done")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #8810. When a session tab raised an `ask`/approval prompt while it was **not** the active tab, switching to that tab never surfaced the modal: the turn stayed stuck with only a sidebar badge, and the only recovery was restarting Reasonix.

Root cause: `ReplayPendingPrompts` was wired to the same-session switch-back path (#5481 / `95390ad18`), detached-runtime re-attach, and frontend reconnect — but **plain tab activation did not replay**. A prompt emitted while the session was a background tab was simply never re-emitted to its sink.

Fix:

- New `App.replayPendingPromptsFor(tab)` helper: reads `tab.Ctrl` under a read lock, then calls `ctrl.ReplayPendingPrompts()` (outside `App.mu`, since replay emits events that can call back into the app).
- `SetActiveTab`: after switching to the target tab, replay its pending prompts.
- `openTopicTabWithActivation`: both "already-open tab activated" branches (same-session key match and topic-target match) replay after activation. New-tab creation paths are untouched (a fresh tab has no background prompt).

## Issues

Fixes #8810

## Verification

- `go test . -run TestSetActiveTabReplaysBackgroundPendingPrompt -v` — new test: a background tab's `ask` is replayed after `SetActiveTab`, and the turn then cancels cleanly.
- `go test . -run 'TestOpenTopicTabKeepsRunningParentInsteadOfCoveringLeaf|TestRetargetOpenTabsSkipsRunningSessions'` — the full desktop suite exposed a missing `ReplayPendingPrompts` stub on the `retargetRuntimeController` test double (nil embedded SessionAPI → panic once tab activation started replaying); added a no-op stub implementation.
- `go test . -count=1` — full desktop suite passes (~100s).

## Documentation impact

Documentation-impact: none - user-visible behavior fix only (a pending modal now appears when expected); no docs/*.md describes tab-activation prompt replay.

## Cache impact

Cache-impact: low - desktop-only tab-activation event flow; no system-prompt prefix, tool schema, or provider-visible bytes change (desktop/session_prompt.go untouched).

Cache-guard: `cd desktop && go test . -run TestSetActiveTabReplaysBackgroundPendingPrompt -count=1` (replay-on-activation regression test); existing boot surface tests unaffected.

System-prompt-review: N/A - no system-prompt, memory prefix, output style, skill index, or boot surface changes.