### PR TITLE
Fix compacted recovery chains opening the short root / 修复压缩恢复链误开短根会话

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3539,8 +3539,8 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 	if tab == nil || ctrl == nil {
 		return []HistoryMessage{}, fmt.Errorf("tab is not ready")
 	}
-	if canonical := a.resolveCanonicalSessionPath(path); canonical != "" {
-		path = canonical
+	if continued := a.continuePathForOpen(path); continued != "" {
+		path = continued
 	}
 	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
 	if err != nil {

--- a/desktop/session_canonical_retarget.go
+++ b/desktop/session_canonical_retarget.go
@@ -9,37 +9,6 @@ import (
 	"reasonix/internal/sessioncatalog"
 )
 
-// resolveCanonicalSessionPath returns a unique adopted/canonical leaf for the
-// topic that owns path, when the catalog has one. Empty means keep path.
-// Retarget happens before Controller create/rebind so the new controller leases
-// and binds authority on the canonical path only.
-func (a *App) resolveCanonicalSessionPath(path string) string {
-	if a == nil || strings.TrimSpace(path) == "" {
-		return ""
-	}
-	catalog := a.sessionCatalog.Load()
-	if catalog == nil {
-		return ""
-	}
-	ctx := context.Background()
-	rec, ok, err := catalog.GetSession(ctx, path)
-	if err != nil || !ok {
-		return ""
-	}
-	if rec.TopicID == "" {
-		// Group by recovery group when topic is unset.
-		if rec.RecoveryCanonical && (rec.RecoveryRole == sessioncatalog.RecoveryRoleAdopted || rec.RecoveryRole == sessioncatalog.RecoveryRolePreferred) {
-			return ""
-		}
-		return ""
-	}
-	topic, ok, err := catalog.GetTopic(ctx, sessioncatalog.TopicKey{Scope: rec.Scope, WorkspaceRoot: rec.WorkspaceRoot, TopicID: rec.TopicID})
-	if err != nil || !ok {
-		return ""
-	}
-	return sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, path)
-}
-
 func (a *App) resolveOpenTopicSessionPath(scope, workspaceRoot, sessionPath string) (string, string) {
 	actualRoot := workspaceRoot
 	if scope == "global" {
@@ -73,7 +42,7 @@ func (a *App) sessionHasLiveController(path string) bool {
 	return false
 }
 
-func (a *App) skipCoveringLeafRebind(tab *WorkspaceTab, target string) bool {
+func (a *App) skipContinuationRebind(tab *WorkspaceTab, target string) bool {
 	if tab == nil || tab.Ctrl == nil {
 		return false
 	}
@@ -160,7 +129,7 @@ func (a *App) resumeSessionPageForTab(tabID, path string, limit int) (HistoryPag
 	return a.HistoryPageForTab(tab.ID, 0, limit), nil
 }
 
-func (a *App) retargetOpenTabsToCoveringLeaves() {
+func (a *App) retargetOpenTabsToContinuations() {
 	if a == nil {
 		return
 	}

--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -233,7 +233,7 @@ func (a *App) startSessionCatalog(rebuild bool) {
 				slog.Debug("desktop: reconcile session catalog directory", "dir", target.Path, "err", err)
 			}
 		}
-		a.retargetOpenTabsToCoveringLeaves()
+		a.retargetOpenTabsToContinuations()
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for {

--- a/desktop/session_catalog_app_test.go
+++ b/desktop/session_catalog_app_test.go
@@ -722,7 +722,7 @@ func TestRetargetOpenTabsSkipsRunningSessions(t *testing.T) {
 	}
 	app.tabs = map[string]*WorkspaceTab{"idle": idle, "running": running}
 
-	app.retargetOpenTabsToCoveringLeaves()
+	app.retargetOpenTabsToContinuations()
 	if idle.SessionPath != leaf {
 		t.Fatalf("idle tab path = %q, want covering leaf %q", idle.SessionPath, leaf)
 	}

--- a/desktop/session_catalog_runtime.go
+++ b/desktop/session_catalog_runtime.go
@@ -756,6 +756,9 @@ func (a *App) catalogSessionPathForTopic(scope, workspaceRoot, topicID string) s
 	if err != nil || !ok || len(topic.Sessions) == 0 {
 		return ""
 	}
+	if representative := strings.TrimSpace(topic.RepresentativePath); representative != "" {
+		return representative
+	}
 	if canonical := sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, ""); canonical != "" {
 		return canonical
 	}

--- a/desktop/session_linear_recovery_test.go
+++ b/desktop/session_linear_recovery_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/provider"
+	"reasonix/internal/sessioncatalog"
+)
+
+func TestRetargetOpenTabsUsesUniqueLinearCompactedLeaf(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := desktopSessionDir(globalWorkspaceRoot())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	save := func(path, id string, turns int, prefix string) {
+		t.Helper()
+		session := agent.NewSession("sys")
+		for i := range turns {
+			session.Add(provider.Message{Role: provider.RoleUser, Content: prefix + " question " + strings.Repeat("q", i+1)})
+			session.Add(provider.Message{Role: provider.RoleAssistant, Content: prefix + " answer " + strings.Repeat("a", i+1)})
+		}
+		if err := session.Save(path); err != nil {
+			t.Fatal(err)
+		}
+		meta := agent.BranchMeta{ID: id, Scope: "global", TopicID: "conversation", TopicTitle: "Compacted"}
+		if id != "root" {
+			meta.Recovered = true
+			meta.ParentID = "root"
+			meta.RecoveryDepth = 1
+		}
+		if err := agent.SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+			t.Fatal(err)
+		}
+	}
+	root := filepath.Join(dir, "root.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	save(root, "root", 9, "root")
+	save(leaf, "leaf", 72, "compacted")
+	app := NewApp()
+	installSessionCatalogForTest(t, app, dir, "global", "")
+
+	topic, ok := app.catalogTopicRecord("global", "", "conversation")
+	if !ok || topic.RepresentativePath != leaf {
+		t.Fatalf("representative = %q ok=%v, want compacted leaf %q", topic.RepresentativePath, ok, leaf)
+	}
+	if got := app.catalogSessionPathForTopic("global", "", "conversation"); got != leaf {
+		t.Fatalf("catalog session path = %q, want compacted leaf %q", got, leaf)
+	}
+	if got := sessioncatalog.CanonicalSessionPathForTopic(topic.Sessions, root); got != "" {
+		t.Fatalf("content canonical = %q, want unresolved", got)
+	}
+	idleRoot := &WorkspaceTab{ID: "root", Scope: "global", TopicID: "conversation", SessionPath: root}
+	idleLeaf := &WorkspaceTab{ID: "leaf", Scope: "global", TopicID: "conversation", SessionPath: leaf}
+	app.tabs = map[string]*WorkspaceTab{"root": idleRoot, "leaf": idleLeaf}
+
+	app.retargetOpenTabsToContinuations()
+	if idleRoot.SessionPath != leaf {
+		t.Fatalf("root tab path = %q, want compacted leaf %q", idleRoot.SessionPath, leaf)
+	}
+	if idleLeaf.SessionPath != leaf {
+		t.Fatalf("leaf tab regressed to %q, want %q", idleLeaf.SessionPath, leaf)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2382,7 +2382,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 			a.saveTabsLocked()
 			a.mu.Unlock()
-			if sameSession || a.skipCoveringLeafRebind(tab, sessionPath) {
+			if sameSession || a.skipContinuationRebind(tab, sessionPath) {
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {

--- a/internal/sessioncatalog/catalog.go
+++ b/internal/sessioncatalog/catalog.go
@@ -702,7 +702,7 @@ func (c *Catalog) GetTopic(ctx context.Context, key TopicKey) (TopicRecord, bool
 }
 
 func topicRepresentativePath(sessions []SessionRecord) string {
-	if path := CanonicalSessionPathForTopic(sessions, ""); path != "" {
+	if path := OrdinaryContinuePath(sessions, ""); path != "" {
 		return path
 	}
 	preferred := PreferredOrdinarySessionPaths(sessions)

--- a/internal/sessioncatalog/lineage.go
+++ b/internal/sessioncatalog/lineage.go
@@ -570,16 +570,18 @@ func CanonicalSessionPathForTopic(sessions []SessionRecord, current string) stri
 	return canonical
 }
 
-// OrdinaryContinuePath returns the unique covering leaf when current is the
-// ordinary parent (or a stale parent path after re-anchoring). An explicit
-// recovery fork stays put so History can inspect it.
+// OrdinaryContinuePath returns a safe continuation when current is the ordinary
+// parent. Explicit recovery paths stay put so History can inspect them.
 func OrdinaryContinuePath(sessions []SessionRecord, current string) string {
 	canonical := CanonicalSessionPathForTopic(sessions, current)
 	if canonical == "" {
-		return ""
+		canonical = uniqueLinearRecoveryLeaf(sessions)
 	}
 	current = strings.TrimSpace(current)
-	if current == "" || current == canonical {
+	if canonical == "" || current == canonical {
+		return ""
+	}
+	if current == "" {
 		return canonical
 	}
 	for _, session := range sessions {
@@ -592,4 +594,75 @@ func OrdinaryContinuePath(sessions []SessionRecord, current string) string {
 		return canonical
 	}
 	return canonical
+}
+
+// uniqueLinearRecoveryLeaf selects the only monotonic descendant in a complete
+// parent chain. It is an open target only; content coverage still exclusively
+// controls adoption and cleanup.
+func uniqueLinearRecoveryLeaf(sessions []SessionRecord) string {
+	if len(sessions) < 2 {
+		return ""
+	}
+	byID := make(map[string]int, len(sessions))
+	root := -1
+	recovered := 0
+	for i, session := range sessions {
+		id := agent.BranchID(session.Path)
+		if id == "" {
+			return ""
+		}
+		if _, duplicate := byID[id]; duplicate {
+			return ""
+		}
+		byID[id] = i
+		if session.Recovered {
+			recovered++
+			continue
+		}
+		if root >= 0 {
+			return ""
+		}
+		root = i
+	}
+	if root < 0 || recovered == 0 {
+		return ""
+	}
+	children := make(map[string]int, recovered)
+	for i, session := range sessions {
+		if !session.Recovered {
+			continue
+		}
+		parentID := strings.TrimSpace(session.ParentID)
+		parent, ok := byID[parentID]
+		if parentID == "" || !ok {
+			return ""
+		}
+		if _, forked := children[parentID]; forked {
+			return ""
+		}
+		if session.TurnsState == TurnsValid && sessions[parent].TurnsState == TurnsValid && session.Turns < sessions[parent].Turns {
+			return ""
+		}
+		if session.LastActivityAt > 0 && sessions[parent].LastActivityAt > 0 && session.LastActivityAt < sessions[parent].LastActivityAt {
+			return ""
+		}
+		children[parentID] = i
+	}
+	seen := make(map[int]struct{}, recovered+1)
+	leaf := root
+	for {
+		if _, duplicate := seen[leaf]; duplicate {
+			return ""
+		}
+		seen[leaf] = struct{}{}
+		next, ok := children[agent.BranchID(sessions[leaf].Path)]
+		if !ok {
+			break
+		}
+		leaf = next
+	}
+	if len(seen) != len(sessions) || !sessions[leaf].Recovered {
+		return ""
+	}
+	return strings.TrimSpace(sessions[leaf].Path)
 }

--- a/internal/sessioncatalog/lineage_test.go
+++ b/internal/sessioncatalog/lineage_test.go
@@ -2,6 +2,7 @@ package sessioncatalog
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -144,6 +145,54 @@ func TestOrdinaryContinuePathFollowsParentOnly(t *testing.T) {
 	}
 }
 
+func TestOrdinaryContinuePathFollowsUniqueLinearCompactedLeaf(t *testing.T) {
+	root := filepath.Join("/s", "root.jsonl")
+	parentID := "root"
+	sessions := []SessionRecord{{
+		Path: root, RecoveryRole: RecoveryRoleNormal,
+		Turns: 9, TurnsState: TurnsValid, LastActivityAt: 1,
+	}}
+	for i := 1; i <= 130; i++ {
+		id := fmt.Sprintf("recovery-%03d", i)
+		sessions = append(sessions, SessionRecord{
+			Path: filepath.Join("/s", id+".jsonl"), Recovered: true,
+			ParentID: parentID, RecoveryGroupID: "root", RecoveryRole: RecoveryRoleDiverged,
+			Turns: 9 + (i*63)/130, TurnsState: TurnsValid, LastActivityAt: int64(i + 1),
+		})
+		parentID = id
+	}
+	leaf := sessions[len(sessions)-1].Path
+	if got := OrdinaryContinuePath(sessions, root); got != leaf {
+		t.Fatalf("parent continue = %q, want unique 72-turn leaf %q", got, leaf)
+	}
+	if got := topicRepresentativePath(sessions); got != leaf {
+		t.Fatalf("representative = %q, want unique 72-turn leaf %q", got, leaf)
+	}
+	if got := OrdinaryContinuePath(sessions, leaf); got != "" {
+		t.Fatalf("leaf continue = %q, want keep current leaf", got)
+	}
+}
+
+func TestOrdinaryContinuePathRejectsForkedOrRegressingLineage(t *testing.T) {
+	root := SessionRecord{Path: "/s/root.jsonl", RecoveryRole: RecoveryRoleNormal, Turns: 9, TurnsState: TurnsValid, LastActivityAt: 1}
+	linear := SessionRecord{
+		Path: "/s/linear.jsonl", Recovered: true, ParentID: "root", RecoveryGroupID: "root",
+		RecoveryRole: RecoveryRoleDiverged, Turns: 10, TurnsState: TurnsValid, LastActivityAt: 2,
+	}
+	fork := SessionRecord{
+		Path: "/s/fork.jsonl", Recovered: true, ParentID: "root", RecoveryGroupID: "root",
+		RecoveryRole: RecoveryRoleDiverged, Turns: 11, TurnsState: TurnsValid, LastActivityAt: 3,
+	}
+	if got := OrdinaryContinuePath([]SessionRecord{root, linear, fork}, root.Path); got != "" {
+		t.Fatalf("forked continue = %q, want unresolved", got)
+	}
+	regressed := linear
+	regressed.Turns = 8
+	if got := OrdinaryContinuePath([]SessionRecord{root, regressed}, root.Path); got != "" {
+		t.Fatalf("regressing continue = %q, want unresolved", got)
+	}
+}
+
 func TestExplicitPreferredRecoveryWinsWithoutMakingPeersCovered(t *testing.T) {
 	dir := t.TempDir()
 	root := filepath.Join(dir, "root.jsonl")
@@ -197,6 +246,55 @@ func TestReconcilePersistsContentProvenCanonicalLeaf(t *testing.T) {
 	}
 	if record.RecoveryRole != RecoveryRoleAdopted || !record.RecoveryCanonical {
 		t.Fatalf("reconciled recovery = %+v, want adopted canonical", record)
+	}
+}
+
+func TestReconcileOpensUniqueLinearCompactedLeafWithoutAuthorizingCleanup(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	root := filepath.Join(dir, "root.jsonl")
+	leaf := filepath.Join(dir, "leaf.jsonl")
+	rootMessages := make([]string, 0, 18)
+	for i := range 9 {
+		rootMessages = append(rootMessages, fmt.Sprintf("root question %d", i), fmt.Sprintf("root answer %d", i))
+	}
+	leafMessages := make([]string, 0, 144)
+	for i := range 72 {
+		leafMessages = append(leafMessages, fmt.Sprintf("compacted question %d", i), fmt.Sprintf("compacted answer %d", i))
+	}
+	saveLineageSession(t, root, rootMessages...)
+	saveLineageSession(t, leaf, leafMessages...)
+	for path, meta := range map[string]agent.BranchMeta{
+		root: {ID: "root", Scope: "global", TopicID: "conversation", TopicTitle: "Compacted"},
+		leaf: {ID: "leaf", Scope: "global", TopicID: "conversation", TopicTitle: "Compacted", Recovered: true, ParentID: "root", RecoveryDepth: 1},
+	} {
+		if err := agent.SaveBranchMetaPreserveUpdated(path, meta); err != nil {
+			t.Fatal(err)
+		}
+	}
+	catalog, err := Open(ctx, Options{InMemory: true, DisableRepair: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer catalog.Close(ctx)
+	if err := catalog.ReconcileDirectory(ctx, DirectoryTarget{Path: dir, Scope: "global"}); err != nil {
+		t.Fatal(err)
+	}
+	topic, ok, err := catalog.GetTopic(ctx, TopicKey{Scope: "global", TopicID: "conversation"})
+	if err != nil || !ok {
+		t.Fatalf("GetTopic ok=%v err=%v", ok, err)
+	}
+	if topic.RepresentativePath != leaf {
+		t.Fatalf("representative = %q, want compacted leaf %q", topic.RepresentativePath, leaf)
+	}
+	if topic.RecoveryCleanupEligibleCount != 0 {
+		t.Fatalf("cleanup eligible = %d, want 0 without content coverage", topic.RecoveryCleanupEligibleCount)
+	}
+	if got := CanonicalSessionPathForTopic(topic.Sessions, root); got != "" {
+		t.Fatalf("cleanup canonical = %q, want unresolved", got)
+	}
+	if got := OrdinaryContinuePath(topic.Sessions, root); got != leaf {
+		t.Fatalf("ordinary continue = %q, want compacted leaf %q", got, leaf)
 	}
 }
 


### PR DESCRIPTION
## Summary

- follow a recovered session to its leaf when metadata forms one complete, unique, monotonic linear continuation
- keep strict canonical/adopted lineage rules unchanged for cleanup and destructive decisions
- retarget restored desktop tabs and catalog fallback opens to the same continuation path without regressing a tab already bound to the leaf

## Issues

- No public issue.

## Contribution

- [@wuyong-exe](https://github.com/wuyong-exe) provided the local reproduction data that made the failure mode, root cause, and regression shape verifiable.

## User-visible behavior

Older sessions that accumulated a long sequence of recovery files can no longer collapse back to a short root transcript after the desktop session catalog finishes loading, provided the recovery metadata proves there is exactly one safe continuation.

Ambiguous forks, missing parents, duplicate IDs, cycles, disconnected nodes, decreasing turn counts, and decreasing activity timestamps are rejected and retain the existing conservative behavior.

## Safety and compatibility

| Contract | Previous-version behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| Session JSONL and metadata | Existing files remain unchanged | Reads the same files and selects a proven linear leaf for display/open | Reads the same unchanged files with its prior selection behavior | Compatible |
| Cleanup eligibility | Requires strict canonical/adopted proof | Still requires strict canonical/adopted proof | Unchanged | No broader deletion authority |
| Desktop/Wails payloads | Existing shapes | Existing shapes | Existing shapes | No bridge contract change |

This change adds no schema, migration, rewrite, or new persisted field. It changes only automatic display/open target selection after validating lineage invariants.

## Verification

- `go test ./internal/sessioncatalog -count=1`
- focused desktop session continuation and retarget tests
- focused `go test -race` coverage for session catalog and desktop retarget paths
- desktop `go test ./...`
- clean-source root `go test ./...`
- root and desktop `go vet ./...`
- `make lint` in a clean source view (`0 issues`; `repolint: clean`)
- `git diff --check origin/main-v2...HEAD`

Documentation-impact: none - this is an internal compatibility correction that does not change the documented workflow or public API.

## Cache impact

Cache-impact: none - no system prompt, tool schema, provider request serialization, or model-visible prefix changes.
Cache-guard: the changed-file cache gate reports no cache-sensitive prompt or tool surfaces, and the existing provider assembly path is untouched.
System-prompt-review: not required - no system-prompt-sensitive files changed.
