### PR TITLE
test(frontend): cover expanded reasoning display mode / 覆盖持续展开推理显示模式

### DIFF
--- a/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
+++ b/desktop/frontend/src/__tests__/startup-settings-contract.test.ts
@@ -133,7 +133,7 @@ ok(
     settingsSource.includes('settings.displayMode') &&
     settingsSource.includes('["standard", "compact"]') &&
     settingsSource.includes('settings.reasoningDisplay') &&
-    settingsSource.includes('["hidden", "summary", "auto"]') &&
+    settingsSource.includes('["hidden", "summary", "auto", "expanded"]') &&
     settingsSource.includes('settings.processFold') &&
     settingsSource.includes('["auto", "expanded"]') &&
     settingsSource.includes('setProcessFoldPreference(pref)') &&


### PR DESCRIPTION
## Problem

The v1.25.2 qualification run found that the full frontend suite rejected the new expanded reasoning display option because the static startup-settings contract still expected only three modes.

## Root cause

The product implementation and localized labels were updated in #8732, but the source contract was not extended with the fourth `expanded` value.

## Fix

Update the expected reasoning-display mode list to match the implemented four-value contract.

## Verification

- `pnpm tsx src/__tests__/startup-settings-contract.test.ts`
- `pnpm test:all`
- `pnpm build`
- `./scripts/cache-guard.sh`
- `go test ./internal/plugin -run "Tool|List|Name|Notification|Refresh" -count=5`
- `go test ./...`
- `(cd desktop && go test ./...)`
- `go test -race ./...`