### PR TITLE
fix(acp): return ACP v1-compliant prompt outcomes / 修复 ACP v1 Prompt 结果

### DIFF
--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -170,6 +170,15 @@ Hosts should keep the `session/prompt` request open until Reasonix returns its
 stop reason, while continuing to process requests and notifications in both
 directions.
 
+Reasonix emits only ACP v1 stop reasons. A completed turn that still needs a
+final-readiness check sends a `[warning]` message chunk and returns `end_turn`;
+its vendor status remains `readiness_paused` so the host can offer recovery.
+Client cancellation returns `cancelled`, even when the interrupted runner exits
+without an error. Other provider, tool, or runtime failures return a JSON-RPC
+`-32603 InternalError` whose message contains a bounded, credential-redacted
+cause; they do not return a successful prompt result with a non-standard
+`stopReason`.
+
 When the status phase is `readiness_paused`, resume that exact check with a
 `session/prompt` request whose optional `action` is
 `"final_readiness_recovery"`. Sending `/continue-checks` as the sole text block

--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -173,6 +173,10 @@ directions.
 Reasonix emits only ACP v1 stop reasons. A completed turn that still needs a
 final-readiness check sends a `[warning]` message chunk and returns `end_turn`;
 its vendor status remains `readiness_paused` so the host can offer recovery.
+An explicit model-round limit (`max_steps`) sends a `[warning]`, returns
+`max_turn_requests`, and records a paused vendor outcome. A host task-time,
+token, or cost budget also sends a `[warning]` and records a paused outcome,
+but returns `end_turn` because ACP v1 has no task-budget-specific stop reason.
 Client cancellation returns `cancelled`, even when the interrupted runner exits
 without an error. Other provider, tool, or runtime failures return a JSON-RPC
 `-32603 InternalError` whose message contains a bounded, credential-redacted
@@ -184,7 +188,8 @@ When the status phase is `readiness_paused`, resume that exact check with a
 `"final_readiness_recovery"`. Sending `/continue-checks` as the sole text block
 is the compatibility form. Both forms consume a one-shot, persisted host
 checkpoint; ordinary prompt text never inherits it, and a stale action after a
-newer user turn is rejected.
+newer user turn is rejected as JSON-RPC `-32600 InvalidRequest` without
+publishing or persisting a synthetic status turn.
 
 ## Mid-turn steering extension
 

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -154,6 +154,13 @@ Reasonix 把互不相关的选择拆成独立控制轴，而不是混在一个 m
 Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止原因；期间仍需同时处理
 双向 request 和 notification。
 
+Reasonix 只会返回 ACP v1 规定的停止原因。工作已完成但仍需 final-readiness 检查时，
+agent 会发送带 `[warning]` 的消息 chunk 并返回 `end_turn`；厂商状态仍保持
+`readiness_paused`，便于 host 提供恢复入口。客户端取消始终返回 `cancelled`，即使被中断
+的 runner 没有返回 error。其他 provider、工具或运行时失败会返回 JSON-RPC
+`-32603 InternalError`，消息携带长度受限且已脱敏的原因；不会再用协议外的
+`stopReason` 构造成功结果。
+
 状态 phase 为 `readiness_paused` 时，可发送新的 `session/prompt`，并把可选 `action`
 设为 `"final_readiness_recovery"`，以继续这一次检查。只发送 `/continue-checks` 文本 block
 是兼容写法。两种方式都会消费一次持久化的 host checkpoint；普通 prompt 不会继承该

--- a/docs/ACP.zh-CN.md
+++ b/docs/ACP.zh-CN.md
@@ -157,14 +157,18 @@ Host 应让 `session/prompt` 请求保持打开，直到 Reasonix 返回停止�
 Reasonix 只会返回 ACP v1 规定的停止原因。工作已完成但仍需 final-readiness 检查时，
 agent 会发送带 `[warning]` 的消息 chunk 并返回 `end_turn`；厂商状态仍保持
 `readiness_paused`，便于 host 提供恢复入口。客户端取消始终返回 `cancelled`，即使被中断
-的 runner 没有返回 error。其他 provider、工具或运行时失败会返回 JSON-RPC
+的 runner 没有返回 error。显式模型轮数上限（`max_steps`）会发送 `[warning]`、返回
+`max_turn_requests`，并记录 paused 厂商状态；host 的任务时间、token 或成本预算也会发送
+`[warning]` 并记录 paused 状态，但因 ACP v1 没有任务预算专用停止原因而返回 `end_turn`。
+其他 provider、工具或运行时失败会返回 JSON-RPC
 `-32603 InternalError`，消息携带长度受限且已脱敏的原因；不会再用协议外的
 `stopReason` 构造成功结果。
 
 状态 phase 为 `readiness_paused` 时，可发送新的 `session/prompt`，并把可选 `action`
 设为 `"final_readiness_recovery"`，以继续这一次检查。只发送 `/continue-checks` 文本 block
 是兼容写法。两种方式都会消费一次持久化的 host checkpoint；普通 prompt 不会继承该
-证据，出现更新的用户消息后再提交旧 action 会被拒绝。
+证据，出现更新的用户消息后再提交旧 action 会以 JSON-RPC `-32600 InvalidRequest` 被拒绝，
+且不会发布或持久化虚假的状态回合。
 
 ## 回合中引导扩展
 

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -558,9 +558,9 @@ func TestE2EApprovalRoundTrip(t *testing.T) {
 	var result SessionPromptResult
 	json.Unmarshal(resp.Result, &result)
 	// Adaptive standard execution may pause the turn for missing readiness
-	// after a write; the approval round-trip is the contract under test.
-	if result.StopReason != StopEndTurn && result.StopReason != StopError {
-		t.Errorf("stopReason = %q, want end_turn or error", result.StopReason)
+	// after a write; controlled readiness pauses use ACP v1 end_turn.
+	if result.StopReason != StopEndTurn {
+		t.Errorf("stopReason = %q, want end_turn", result.StopReason)
 	}
 }
 

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -78,6 +78,7 @@ type e2eFactory struct {
 	tool       tool.Tool
 	policy     permission.Policy
 	sessionDir string
+	options    *agent.Options
 }
 
 func (f *e2eFactory) SessionDir() string { return f.sessionDir }
@@ -85,8 +86,12 @@ func (f *e2eFactory) SessionDir() string { return f.sessionDir }
 func (f *e2eFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
 	reg := tool.NewRegistry()
 	reg.Add(f.tool)
+	opts := agent.Options{MaxSteps: 5}
+	if f.options != nil {
+		opts = *f.options
+	}
 	executor := agent.New(f.prov, reg, agent.NewSession("you are a test agent"),
-		agent.Options{MaxSteps: 5}, p.Sink)
+		opts, p.Sink)
 	return control.New(control.Options{
 		Runner:     executor,
 		Executor:   executor,
@@ -95,6 +100,96 @@ func (f *e2eFactory) NewSession(_ context.Context, p SessionParams) (*control.Co
 		Label:      "fake-model",
 		SessionDir: f.sessionDir,
 	}), nil
+}
+
+func TestE2EExplicitMaxStepsReturnsSuccessfulPause(t *testing.T) {
+	responses := [][]provider.Chunk{
+		{toolCallChunk("c1", "peek", `{}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("c2", "peek", `{}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("c3", "peek", `{}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("c4", "peek", `{}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("c5", "peek", `{}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "Saved progress summary."}, {Type: provider.ChunkDone}},
+	}
+	assertE2ERunPause(t, responses, nil, StopMaxTurnRequests, "paused after 5 tool-call rounds")
+}
+
+func TestE2ETaskBudgetReturnsSuccessfulPause(t *testing.T) {
+	responses := [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "peek", `{}`),
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: 100, CacheMissTokens: 100}},
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "Saved budget summary."}, {Type: provider.ChunkDone}},
+	}
+	options := &agent.Options{
+		Pricing:    &provider.Pricing{Input: 1, Currency: "USD"},
+		TaskBudget: agent.TaskBudget{Cost: 0.000001},
+	}
+	assertE2ERunPause(t, responses, options, StopEndTurn, "paused after reaching this task's cost budget")
+}
+
+func assertE2ERunPause(t *testing.T, responses [][]provider.Chunk, options *agent.Options, wantStop StopReason, wantWarning string) {
+	t.Helper()
+	factory := &e2eFactory{
+		prov:       &scriptedProvider{name: "fake", responses: responses},
+		tool:       fakeTool{name: "peek", ro: true, out: "ok"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: t.TempDir(),
+		options:    options,
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	sid := openSession(t, client)
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "keep working"}},
+	})
+	notifications, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("controlled pause returned JSON-RPC error: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if result.StopReason != wantStop {
+		t.Errorf("stopReason = %q, want %q", result.StopReason, wantStop)
+	}
+
+	var warned, paused bool
+	for _, notification := range notifications {
+		if notification.Method == sessionStatusUpdateMethod {
+			var update ReasonixStatusUpdate
+			if err := json.Unmarshal(notification.Params, &update); err != nil {
+				t.Fatalf("status update: %v", err)
+			}
+			if update.Event == "pause" && update.Status.TurnOutcome.Kind == "paused" {
+				paused = true
+			}
+		}
+		var params SessionUpdateParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			continue
+		}
+		update, ok := params.Update.(map[string]any)
+		if !ok || update["sessionUpdate"] != "agent_message_chunk" {
+			continue
+		}
+		content, _ := update["content"].(map[string]any)
+		text, _ := content["text"].(string)
+		if strings.Contains(text, "[warning]") && strings.Contains(text, wantWarning) {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("missing controlled-pause warning containing %q", wantWarning)
+	}
+	if !paused {
+		t.Fatal("missing paused status outcome")
+	}
 }
 
 func toolCallChunk(id, name, args string) provider.Chunk {

--- a/internal/acp/prompt_result.go
+++ b/internal/acp/prompt_result.go
@@ -1,0 +1,33 @@
+package acp
+
+import (
+	"errors"
+	"log/slog"
+
+	"reasonix/internal/agent"
+)
+
+// promptStopReason maps a finished controller run onto ACP v1. Controlled
+// pauses remain successful prompt responses; genuine failures use JSON-RPC's
+// error channel because ACP v1 has no error stop reason.
+func promptStopReason(runErr error, cancelled bool, sessionID string) (StopReason, *agent.FinalReadinessError, error) {
+	if cancelled {
+		return StopCancelled, nil, nil
+	}
+	if runErr == nil {
+		return StopEndTurn, nil, nil
+	}
+
+	var readinessErr *agent.FinalReadinessError
+	if errors.As(runErr, &readinessErr) {
+		return StopEndTurn, readinessErr, nil
+	}
+	var recoveryPause *agent.RecoveryPauseError
+	if errors.As(runErr, &recoveryPause) {
+		return StopEndTurn, nil, nil
+	}
+
+	reason := clipStatusError(runErr, 2_048)
+	slog.Error("acp: session/prompt failed", "session_id", sessionID, "err", reason)
+	return "", nil, &RPCError{Code: ErrInternal, Message: "session/prompt: " + reason}
+}

--- a/internal/acp/prompt_result.go
+++ b/internal/acp/prompt_result.go
@@ -10,24 +10,31 @@ import (
 // promptStopReason maps a finished controller run onto ACP v1. Controlled
 // pauses remain successful prompt responses; genuine failures use JSON-RPC's
 // error channel because ACP v1 has no error stop reason.
-func promptStopReason(runErr error, cancelled bool, sessionID string) (StopReason, *agent.FinalReadinessError, error) {
+func promptStopReason(runErr error, cancelled bool, sessionID string) (StopReason, string, error) {
 	if cancelled {
-		return StopCancelled, nil, nil
+		return StopCancelled, "", nil
 	}
 	if runErr == nil {
-		return StopEndTurn, nil, nil
+		return StopEndTurn, "", nil
 	}
 
 	var readinessErr *agent.FinalReadinessError
 	if errors.As(runErr, &readinessErr) {
-		return StopEndTurn, readinessErr, nil
+		return StopEndTurn, finalReadinessNotice(readinessErr), nil
 	}
 	var recoveryPause *agent.RecoveryPauseError
 	if errors.As(runErr, &recoveryPause) {
-		return StopEndTurn, nil, nil
+		return StopEndTurn, "", nil
+	}
+	if pause, ok := agent.InspectRunPause(runErr); ok {
+		stop := StopEndTurn
+		if pause.Kind == "max_steps" {
+			stop = StopMaxTurnRequests
+		}
+		return stop, clipStatusError(runErr, 2_048), nil
 	}
 
 	reason := clipStatusError(runErr, 2_048)
 	slog.Error("acp: session/prompt failed", "session_id", sessionID, "err", reason)
-	return "", nil, &RPCError{Code: ErrInternal, Message: "session/prompt: " + reason}
+	return "", "", &RPCError{Code: ErrInternal, Message: "session/prompt: " + reason}
 }

--- a/internal/acp/prompt_result_test.go
+++ b/internal/acp/prompt_result_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/control"
 	"reasonix/internal/event"
 )
 
@@ -157,5 +158,47 @@ func TestServePromptRecoveryPauseReturnsEndTurn(t *testing.T) {
 	}
 	if result.StopReason != StopEndTurn {
 		t.Errorf("stopReason = %q, want end_turn", result.StopReason)
+	}
+}
+
+func TestServeStaleFinalReadinessRecoveryIsInvalidWithoutStatusTurn(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error { return nil }}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	before := getStatus(t, client, nr.SessionID)
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Action:    control.FinalReadinessRecoveryAction,
+		Prompt:    []ContentBlock{{Type: "text", Text: "continue checks"}},
+	})
+	notifications, resp := drainPrompt(t, client, promptCh)
+	if resp.Error == nil || resp.Error.Code != ErrInvalidRequest {
+		t.Fatalf("stale recovery response = %+v, want %d", resp, ErrInvalidRequest)
+	}
+	for _, notification := range notifications {
+		if notification.Method == sessionStatusUpdateMethod {
+			t.Fatalf("stale recovery published a status turn: %+v", notification)
+		}
+	}
+	after := getStatus(t, client, nr.SessionID)
+	if after.Sequence != before.Sequence || after.Phase != before.Phase || after.TurnOutcome != before.TurnOutcome {
+		t.Fatalf("stale recovery changed status: before=%+v after=%+v", before, after)
+	}
+
+	retryCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "ordinary turn"}},
+	})
+	_, retryResp := drainPrompt(t, client, retryCh)
+	if retryResp.Error != nil {
+		t.Fatalf("ordinary prompt after stale recovery errored: %+v", retryResp.Error)
 	}
 }

--- a/internal/acp/prompt_result_test.go
+++ b/internal/acp/prompt_result_test.go
@@ -1,0 +1,161 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+func TestServePromptFailureReturnsRedactedJSONRPCError(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+	const opaqueSecret = "relayKeyAbcdefghijkl"
+	const maskedSuffix = "ae54"
+	var attempts atomic.Int32
+	factory := &fakeFactory{behavior: func(_ context.Context, sink event.Sink, _ string) error {
+		if attempts.Add(1) == 1 {
+			return errors.New("provider failed: Authorization: Bearer " + secret + " credential " + opaqueSecret +
+				" rejected token ****" + maskedSuffix + "\ndetails=" + strings.Repeat("x", 3_000))
+		}
+		sink.Emit(event.Event{Kind: event.Text, Text: "recovered"})
+		return nil
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "fail"}},
+	})
+	notifications, resp := drainPrompt(t, client, promptCh)
+	if resp.Error == nil || resp.Error.Code != ErrInternal {
+		t.Fatalf("prompt response = %+v, want %d JSON-RPC error", resp, ErrInternal)
+	}
+	if !strings.HasPrefix(resp.Error.Message, "session/prompt: provider failed:") {
+		t.Errorf("error message = %q, want underlying cause", resp.Error.Message)
+	}
+	if strings.Contains(resp.Error.Message, secret) || strings.Contains(resp.Error.Message, opaqueSecret) || strings.Contains(resp.Error.Message, maskedSuffix) {
+		t.Errorf("error message leaked credential: %q", resp.Error.Message)
+	}
+	if len(resp.Error.Message) > len("session/prompt: ")+2_048 {
+		t.Errorf("error message length = %d, want at most %d", len(resp.Error.Message), len("session/prompt: ")+2_048)
+	}
+	if len(resp.Result) != 0 {
+		t.Errorf("result = %s, want no successful prompt result", resp.Result)
+	}
+
+	wantReason := strings.TrimPrefix(resp.Error.Message, "session/prompt: ")
+	foundStatus := false
+	for _, notification := range notifications {
+		if notification.Method != sessionStatusUpdateMethod {
+			continue
+		}
+		var update ReasonixStatusUpdate
+		if err := json.Unmarshal(notification.Params, &update); err != nil {
+			t.Fatalf("status update: %v", err)
+		}
+		if update.Event == "error" {
+			foundStatus = true
+			if update.Status.TurnOutcome.Kind != "error" || update.Status.TurnOutcome.Reason != wantReason {
+				t.Errorf("error status = %+v, want reason %q", update.Status.TurnOutcome, wantReason)
+			}
+		}
+	}
+	if !foundStatus {
+		t.Fatal("missing error status update before prompt response")
+	}
+
+	retryCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "retry"}},
+	})
+	_, retryResp := drainPrompt(t, client, retryCh)
+	if retryResp.Error != nil {
+		t.Fatalf("retry prompt errored: %+v", retryResp.Error)
+	}
+	var retryResult SessionPromptResult
+	if err := json.Unmarshal(retryResp.Result, &retryResult); err != nil {
+		t.Fatalf("retry prompt result: %v", err)
+	}
+	if retryResult.StopReason != StopEndTurn {
+		t.Errorf("retry stopReason = %q, want end_turn", retryResult.StopReason)
+	}
+}
+
+func TestServeCancelWhenRunnerReturnsNil(t *testing.T) {
+	started := make(chan struct{})
+	factory := &fakeFactory{behavior: func(ctx context.Context, _ event.Sink, _ string) error {
+		close(started)
+		<-ctx.Done()
+		return nil
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "loop"}},
+	})
+	<-started
+	client.notify("session/cancel", SessionCancelParams{SessionID: nr.SessionID})
+
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("cancelled prompt errored: %+v", resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if result.StopReason != StopCancelled {
+		t.Errorf("stopReason = %q, want cancelled", result.StopReason)
+	}
+}
+
+func TestServePromptRecoveryPauseReturnsEndTurn(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
+		return &agent.RecoveryPauseError{Message: "automatic recovery paused"}
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "pause"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt error = %+v, want controlled completion", resp.Error)
+	}
+	var result SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if result.StopReason != StopEndTurn {
+		t.Errorf("stopReason = %q, want end_turn", result.StopReason)
+	}
+}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -562,13 +562,13 @@ type SessionReloadExtensionsResult struct {
 // could collide with a future official ACP method and must not be used.
 const sessionReloadExtensionsMethod = "_reasonix.io/session/reloadExtensions"
 
-// StopReason tells the client why a turn ended. Values match main's wire.
+// StopReason tells the client why a turn ended. Reasonix only emits values from
+// the ACP v1 enum; failed turns are returned as JSON-RPC errors instead.
 type StopReason string
 
 const (
 	StopEndTurn   StopReason = "end_turn"
 	StopCancelled StopReason = "cancelled"
-	StopError     StopReason = "error"
 )
 
 // SessionPromptResult ends a session/prompt. TranscriptPath is reserved for a

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -566,11 +566,6 @@ const sessionReloadExtensionsMethod = "_reasonix.io/session/reloadExtensions"
 // the ACP v1 enum; failed turns are returned as JSON-RPC errors instead.
 type StopReason string
 
-const (
-	StopEndTurn   StopReason = "end_turn"
-	StopCancelled StopReason = "cancelled"
-)
-
 // SessionPromptResult ends a session/prompt. TranscriptPath is reserved for a
 // future on-disk transcript pointer; omitted (null) for now.
 type SessionPromptResult struct {

--- a/internal/acp/readiness_gate_test.go
+++ b/internal/acp/readiness_gate_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -12,7 +13,7 @@ import (
 
 func TestServePromptReadinessGateFailureEndsTurnWithWarning(t *testing.T) {
 	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
-		return &agent.FinalReadinessError{Attempts: 1, Reason: "missing verification", Missing: []string{"verify"}}
+		return fmt.Errorf("turn stopped: %w", &agent.FinalReadinessError{Attempts: 1, Reason: "missing verification", Missing: []string{"verify"}})
 	}}
 	client, stop := startServer(t, factory)
 	defer stop()

--- a/internal/acp/readiness_gate_test.go
+++ b/internal/acp/readiness_gate_test.go
@@ -1,0 +1,59 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+func TestServePromptReadinessGateFailureEndsTurnWithWarning(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
+		return &agent.FinalReadinessError{Attempts: 1, Reason: "missing verification", Missing: []string{"verify"}}
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "do the thing"}},
+	})
+	notifs, resp := drainPrompt(t, client, promptCh)
+	var pr SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &pr); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if pr.StopReason != StopEndTurn {
+		t.Fatalf("stopReason = %q, want end_turn", pr.StopReason)
+	}
+
+	warned := false
+	for _, n := range notifs {
+		var params SessionUpdateParams
+		if err := json.Unmarshal(n.Params, &params); err != nil {
+			continue
+		}
+		upd, ok := params.Update.(map[string]any)
+		if !ok || upd["sessionUpdate"] != "agent_message_chunk" {
+			continue
+		}
+		content, _ := upd["content"].(map[string]any)
+		text, _ := content["text"].(string)
+		if strings.Contains(text, "[warning]") && strings.Contains(text, "missing verification") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("no readiness warning chunk in notifications: %+v", notifs)
+	}
+}

--- a/internal/acp/readiness_gate_test.go
+++ b/internal/acp/readiness_gate_test.go
@@ -12,8 +12,12 @@ import (
 )
 
 func TestServePromptReadinessGateFailureEndsTurnWithWarning(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+	const opaqueSecret = "readinessSecretAbc123"
+	longReason := "missing verification; Authorization: Bearer " + secret +
+		" credential " + opaqueSecret + "; details=" + strings.Repeat("x", 3_000)
 	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
-		return fmt.Errorf("turn stopped: %w", &agent.FinalReadinessError{Attempts: 1, Reason: "missing verification", Missing: []string{"verify"}})
+		return fmt.Errorf("turn stopped: %w", &agent.FinalReadinessError{Attempts: 1, Reason: longReason, Missing: []string{"verify"}})
 	}}
 	client, stop := startServer(t, factory)
 	defer stop()
@@ -51,6 +55,12 @@ func TestServePromptReadinessGateFailureEndsTurnWithWarning(t *testing.T) {
 		content, _ := upd["content"].(map[string]any)
 		text, _ := content["text"].(string)
 		if strings.Contains(text, "[warning]") && strings.Contains(text, "missing verification") {
+			if strings.Contains(text, secret) || strings.Contains(text, opaqueSecret) {
+				t.Fatalf("readiness warning leaked credential: %q", text)
+			}
+			if len(text) > len("\n\n[warning] ")+2_048 {
+				t.Fatalf("readiness warning length = %d, want at most %d", len(text), len("\n\n[warning] ")+2_048)
+			}
 			warned = true
 		}
 	}

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -1856,32 +1855,6 @@ func TestServeSteerInjectsIntoActivePrompt(t *testing.T) {
 	})
 	if idleResp.Error == nil || idleResp.Error.Code != ErrInvalidRequest {
 		t.Fatalf("idle %s = %+v, want invalid request", sessionSteerMethod, idleResp.Error)
-	}
-}
-
-func TestServePromptErrorIsNotReportedAsCancelled(t *testing.T) {
-	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
-		return errors.New("provider failed")
-	}}
-	client, stop := startServer(t, factory)
-	defer stop()
-
-	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
-	newResp := client.call(t, "session/new", SessionNewParams{})
-	var nr SessionNewResult
-	json.Unmarshal(newResp.Result, &nr)
-
-	promptCh := client.callAsync("session/prompt", SessionPromptParams{
-		SessionID: nr.SessionID,
-		Prompt:    []ContentBlock{{Type: "text", Text: "fail"}},
-	})
-	_, resp := drainPrompt(t, client, promptCh)
-	var pr SessionPromptResult
-	if err := json.Unmarshal(resp.Result, &pr); err != nil {
-		t.Fatalf("prompt result: %v", err)
-	}
-	if pr.StopReason != StopError {
-		t.Errorf("stopReason = %q, want error", pr.StopReason)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1177,10 +1177,11 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		runErr = sess.ctrl.RunTurn(runCtx, text)
 	}
 	runErr = drainACPInbox(runCtx, sess.ctrl, runErr)
+	cancelled := runCtx.Err() != nil
 
 	statusEvent := sess.status.finishTurn(
 		runErr,
-		runCtx.Err() != nil,
+		cancelled,
 		sess.currentCtrl().GoalStatus(),
 		finalAssistantSummary(sess.currentCtrl()),
 	)
@@ -1189,23 +1190,19 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	// the transcript and the same sequence/usage/outcome snapshot.
 	sess.persistAfterTurn(text)
 
-	stop := StopEndTurn
-	if runErr != nil && runCtx.Err() == nil {
-		var readinessErr *agent.FinalReadinessError
-		if errors.As(runErr, &readinessErr) {
-			// The TUI keeps completed work and shows a recovery card for an
-			// unsatisfied readiness gate; mirror that for ACP instead of
-			// collapsing every delivery gap into stopReason=error.
-			sess.sink.Emit(event.Event{
-				Kind:  event.Notice,
-				Level: event.LevelWarn,
-				Text:  finalReadinessNotice(readinessErr),
-			})
-		} else {
-			stop = StopError
-		}
-	} else if runErr != nil {
-		stop = StopCancelled
+	stop, readinessErr, promptErr := promptStopReason(runErr, cancelled, p.SessionID)
+	if promptErr != nil {
+		return nil, promptErr
+	}
+	if readinessErr != nil {
+		// The TUI keeps completed work and shows a recovery card for an
+		// unsatisfied readiness gate; mirror that for ACP instead of
+		// collapsing every delivery gap into a hard failure.
+		sess.sink.Emit(event.Event{
+			Kind:  event.Notice,
+			Level: event.LevelWarn,
+			Text:  finalReadinessNotice(readinessErr),
+		})
 	}
 	res := SessionPromptResult{StopReason: stop}
 	if sess.transcript != "" {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1215,13 +1215,15 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 // turn's final-readiness gate stays unsatisfied; the TUI shows the same gaps in
 // its recovery card.
 func finalReadinessNotice(e *agent.FinalReadinessError) string {
+	const maxNoticeBytes = 2_048
+	const fallback = "final-answer readiness gate not satisfied"
 	if e == nil {
-		return "final-answer readiness gate not satisfied"
+		return fallback
 	}
 	if reason := strings.TrimSpace(e.Reason); reason != "" {
-		return "final-answer readiness gate not satisfied: " + reason
+		return clipStatusCredentialText(fallback+": "+reason, maxNoticeBytes)
 	}
-	return e.Error()
+	return clipStatusError(e, maxNoticeBytes)
 }
 
 // sessionSteer durably persists guidance then attempts mid-turn admission.

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -252,6 +252,7 @@ func (s *service) bindClientIO(p *SessionParams, sessionID string) {
 type acpController interface {
 	control.Lifecycle
 	control.TurnControl
+	RunFinalReadinessRecoveryWithAdmission(ctx context.Context, input string, onAdmitted func()) error
 	TrySteer(text string) bool
 	control.Approvals
 	control.Capabilities
@@ -1155,26 +1156,37 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	if !ok {
 		return nil, &RPCError{Code: ErrInvalidRequest, Message: "session/prompt: session already has an active prompt"}
 	}
-	if sess.status == nil {
-		sess.status = newStatusTelemetry()
-	}
-	sess.status.beginTurn()
-	s.publishStatus(sess, "phase")
-	sess.sink.setTurnContext(runCtx)
-	if sess.takeGoalDraftMode() {
-		sess.currentCtrl().SetGoal(text)
-		sess.saveMetaIfPresent()
-	}
 	defer func() {
 		sess.sink.clearTurnContext()
 		s.finishTurn(ctx, sess)
 		cancel()
 	}()
+	statusStarted := false
+	beginTurn := func() {
+		if sess.status == nil {
+			sess.status = newStatusTelemetry()
+		}
+		sess.status.beginTurn()
+		s.publishStatus(sess, "phase")
+		sess.sink.setTurnContext(runCtx)
+		if sess.takeGoalDraftMode() {
+			sess.currentCtrl().SetGoal(text)
+			sess.saveMetaIfPresent()
+		}
+		statusStarted = true
+	}
 	var runErr error
 	if recovery {
-		runErr = sess.ctrl.RunFinalReadinessRecovery(runCtx, text)
+		runErr = sess.ctrl.RunFinalReadinessRecoveryWithAdmission(runCtx, text, beginTurn)
 	} else {
+		beginTurn()
 		runErr = sess.ctrl.RunTurn(runCtx, text)
+	}
+	if errors.Is(runErr, control.ErrNoFinalReadinessRecovery) && !statusStarted {
+		return nil, &RPCError{
+			Code:    ErrInvalidRequest,
+			Message: "session/prompt: no pending final-readiness check to continue",
+		}
 	}
 	runErr = drainACPInbox(runCtx, sess.ctrl, runErr)
 	cancelled := runCtx.Err() != nil
@@ -1190,18 +1202,17 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	// the transcript and the same sequence/usage/outcome snapshot.
 	sess.persistAfterTurn(text)
 
-	stop, readinessErr, promptErr := promptStopReason(runErr, cancelled, p.SessionID)
+	stop, warning, promptErr := promptStopReason(runErr, cancelled, p.SessionID)
 	if promptErr != nil {
 		return nil, promptErr
 	}
-	if readinessErr != nil {
-		// The TUI keeps completed work and shows a recovery card for an
-		// unsatisfied readiness gate; mirror that for ACP instead of
-		// collapsing every delivery gap into a hard failure.
+	if warning != "" {
+		// The TUI keeps completed work for deliberate run boundaries; mirror
+		// that for ACP and tell clients how the successful turn ended.
 		sess.sink.Emit(event.Event{
 			Kind:  event.Notice,
 			Level: event.LevelWarn,
-			Text:  finalReadinessNotice(readinessErr),
+			Text:  warning,
 		})
 	}
 	res := SessionPromptResult{StopReason: stop}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1190,18 +1190,41 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	sess.persistAfterTurn(text)
 
 	stop := StopEndTurn
-	if runErr != nil {
-		if runCtx.Err() != nil {
-			stop = StopCancelled
+	if runErr != nil && runCtx.Err() == nil {
+		var readinessErr *agent.FinalReadinessError
+		if errors.As(runErr, &readinessErr) {
+			// The TUI keeps completed work and shows a recovery card for an
+			// unsatisfied readiness gate; mirror that for ACP instead of
+			// collapsing every delivery gap into stopReason=error.
+			sess.sink.Emit(event.Event{
+				Kind:  event.Notice,
+				Level: event.LevelWarn,
+				Text:  finalReadinessNotice(readinessErr),
+			})
 		} else {
 			stop = StopError
 		}
+	} else if runErr != nil {
+		stop = StopCancelled
 	}
 	res := SessionPromptResult{StopReason: stop}
 	if sess.transcript != "" {
 		res.TranscriptPath = &sess.transcript
 	}
 	return res, nil
+}
+
+// finalReadinessNotice is the warning text ACP clients receive when a completed
+// turn's final-readiness gate stays unsatisfied; the TUI shows the same gaps in
+// its recovery card.
+func finalReadinessNotice(e *agent.FinalReadinessError) string {
+	if e == nil {
+		return "final-answer readiness gate not satisfied"
+	}
+	if reason := strings.TrimSpace(e.Reason); reason != "" {
+		return "final-answer readiness gate not satisfied: " + reason
+	}
+	return e.Error()
 }
 
 // sessionSteer durably persists guidance then attempts mid-turn admission.

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -16,7 +16,6 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
-	"reasonix/internal/secrets"
 )
 
 const (
@@ -386,7 +385,7 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 				eventName = "pause"
 			case runErr != nil:
 				t.phase = "error"
-				t.turnOutcome = ReasonixTurnOutcome{Kind: "error", Reason: clipStatusText(runErr.Error(), 2_048)}
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "error", Reason: clipStatusError(runErr, 2_048)}
 				t.goalOverride = "failed"
 				eventName = "error"
 			default:
@@ -569,14 +568,6 @@ func normalizeGoalStatus(value string) string {
 	default:
 		return "none"
 	}
-}
-
-func clipStatusText(value string, limit int) string {
-	value = strings.TrimSpace(secrets.Redact(value))
-	if len(value) <= limit {
-		return value
-	}
-	return value[:limit]
 }
 
 func redactStatusTexts(values []string, limit int) []string {

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -376,7 +376,7 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 			switch {
 			case errors.As(runErr, &readinessErr):
 				t.phase = "readiness_paused"
-				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusText(readinessErr.Error(), 2_048)}
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusError(readinessErr, 2_048)}
 				t.finalReadiness.Risks = redactStatusTexts(readinessErr.Missing, 2_048)
 				eventName = "pause"
 			case errors.As(runErr, &recoveryPause):

--- a/internal/acp/status.go
+++ b/internal/acp/status.go
@@ -373,6 +373,7 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 		default:
 			var readinessErr *agent.FinalReadinessError
 			var recoveryPause *agent.RecoveryPauseError
+			_, runPause := agent.InspectRunPause(runErr)
 			switch {
 			case errors.As(runErr, &readinessErr):
 				t.phase = "readiness_paused"
@@ -382,6 +383,10 @@ func (t *statusTelemetry) finishTurn(runErr error, cancelled bool, goalStatus, s
 			case errors.As(runErr, &recoveryPause):
 				t.phase = "recovery_paused"
 				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusText(recoveryPause.Error(), 2_048)}
+				eventName = "pause"
+			case runPause:
+				t.phase = "paused"
+				t.turnOutcome = ReasonixTurnOutcome{Kind: "paused", Reason: clipStatusError(runErr, 2_048)}
 				eventName = "pause"
 			case runErr != nil:
 				t.phase = "error"
@@ -472,7 +477,7 @@ func (t *statusTelemetry) persisted() *persistedStatusTelemetry {
 	defer t.mu.Unlock()
 	return &persistedStatusTelemetry{
 		Sequence: t.sequence, State: t.state, Phase: t.phase,
-		TurnOutcome: t.turnOutcome,
+		TurnOutcome: redactTurnOutcome(t.turnOutcome),
 		FinalReadiness: ReasonixFinalReadiness{
 			ReadyForReview: t.finalReadiness.ReadyForReview,
 			Summary:        clipStatusText(t.finalReadiness.Summary, 16_384),
@@ -495,7 +500,7 @@ func restoreStatusTelemetry(saved *persistedStatusTelemetry) *statusTelemetry {
 	// waiting on work that no longer exists in this runtime.
 	t.state = "idle"
 	t.phase = normalizePersistedStatusPhase(saved.Phase)
-	t.turnOutcome = saved.TurnOutcome
+	t.turnOutcome = redactTurnOutcome(saved.TurnOutcome)
 	if t.turnOutcome.Kind == "" {
 		t.turnOutcome.Kind = "none"
 	}
@@ -524,7 +529,7 @@ func (t *statusTelemetry) snapshot() statusTelemetrySnapshot {
 		state:    t.state,
 		phase:    t.phase,
 		turnOutcome: ReasonixTurnOutcome{
-			Kind: t.turnOutcome.Kind, Reason: clipStatusText(t.turnOutcome.Reason, 2_048),
+			Kind: t.turnOutcome.Kind, Reason: clipStatusCredentialText(t.turnOutcome.Reason, 2_048),
 		},
 		finalReadiness: ReasonixFinalReadiness{
 			ReadyForReview: t.finalReadiness.ReadyForReview,
@@ -535,6 +540,11 @@ func (t *statusTelemetry) snapshot() statusTelemetrySnapshot {
 		cumulative:   t.cumulative.wire(),
 		goalOverride: t.goalOverride,
 	}
+}
+
+func redactTurnOutcome(outcome ReasonixTurnOutcome) ReasonixTurnOutcome {
+	outcome.Reason = clipStatusCredentialText(outcome.Reason, 2_048)
+	return outcome
 }
 
 func defaultSessionRuntimeState(cwd string) SessionRuntimeState {

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -267,6 +267,28 @@ func TestRestoreStatusNormalizesLegacyPresentationPhase(t *testing.T) {
 	}
 }
 
+func TestRestoreStatusStronglyRedactsLegacyTurnOutcome(t *testing.T) {
+	const opaqueSecret = "readinessSecretAbc123"
+	const bearerSecret = "bearerSecretAbc123"
+	restored := restoreStatusTelemetry(&persistedStatusTelemetry{
+		TurnOutcome: ReasonixTurnOutcome{
+			Kind:   "error",
+			Reason: "credential " + opaqueSecret + " Authorization: Bearer " + bearerSecret,
+		},
+	})
+
+	snapshot := restored.snapshot()
+	persisted := restored.persisted()
+	for name, reason := range map[string]string{
+		"public snapshot":  snapshot.turnOutcome.Reason,
+		"repersisted data": persisted.TurnOutcome.Reason,
+	} {
+		if strings.Contains(reason, opaqueSecret) || strings.Contains(reason, bearerSecret) {
+			t.Errorf("%s leaked a legacy credential: %q", name, reason)
+		}
+	}
+}
+
 func TestRestoreStatusMarksInterruptedTurnPaused(t *testing.T) {
 	restored := restoreStatusTelemetry(&persistedStatusTelemetry{
 		Sequence:    7,

--- a/internal/acp/status_test.go
+++ b/internal/acp/status_test.go
@@ -220,6 +220,7 @@ func TestStatusExtensionTracksMultipleSessionsAndUsage(t *testing.T) {
 }
 
 func TestStatusNormalizesPhaseAndRedactsPublicText(t *testing.T) {
+	const opaqueSecret = "readinessSecretAbc123"
 	telemetry := newStatusTelemetry()
 	telemetry.beginTurn()
 	telemetry.onEvent(event.Event{Kind: event.Phase, Source: event.UsageSourcePlanner, Text: "planner · private stage label"})
@@ -232,7 +233,7 @@ func TestStatusNormalizesPhaseAndRedactsPublicText(t *testing.T) {
 	}
 	telemetry.finishTurn(&agent.FinalReadinessError{
 		Attempts: 1,
-		Reason:   "token=secret-reason",
+		Reason:   "token=secret-reason credential " + opaqueSecret,
 		Missing:  []string{"api_key=secret-risk"},
 	}, false, "running", "authorization: bearer secret-summary")
 	snapshot := telemetry.snapshot()
@@ -243,7 +244,7 @@ func TestStatusNormalizesPhaseAndRedactsPublicText(t *testing.T) {
 	if strings.Contains(string(encoded), "secret-") || !strings.Contains(string(encoded), "[redacted]") {
 		t.Fatalf("status text was not redacted: %s", encoded)
 	}
-	if strings.Contains(snapshot.turnOutcome.Reason, "secret-") {
+	if strings.Contains(snapshot.turnOutcome.Reason, "secret-") || strings.Contains(snapshot.turnOutcome.Reason, opaqueSecret) {
 		t.Fatalf("turn outcome was not redacted: %q", snapshot.turnOutcome.Reason)
 	}
 

--- a/internal/acp/status_text.go
+++ b/internal/acp/status_text.go
@@ -8,6 +8,18 @@ import (
 
 func clipStatusText(value string, limit int) string {
 	value = strings.TrimSpace(secrets.Redact(value))
+	return clipStatusValue(value, limit)
+}
+
+func clipStatusCredentialText(value string, limit int) string {
+	value = strings.TrimSpace(secrets.RedactCredentials(value))
+	return clipStatusValue(value, limit)
+}
+
+func clipStatusValue(value string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
 	if len(value) <= limit {
 		return value
 	}
@@ -15,9 +27,8 @@ func clipStatusText(value string, limit int) string {
 }
 
 func clipStatusError(err error, limit int) string {
-	value := strings.TrimSpace(secrets.RedactError(err))
-	if len(value) <= limit {
-		return value
+	if err == nil {
+		return ""
 	}
-	return value[:limit]
+	return clipStatusCredentialText(err.Error(), limit)
 }

--- a/internal/acp/status_text.go
+++ b/internal/acp/status_text.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"reasonix/internal/secrets"
 )
@@ -20,10 +21,15 @@ func clipStatusValue(value string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
+	value = strings.ToValidUTF8(value, "\uFFFD")
 	if len(value) <= limit {
 		return value
 	}
-	return value[:limit]
+	end := limit
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end]
 }
 
 func clipStatusError(err error, limit int) string {

--- a/internal/acp/status_text.go
+++ b/internal/acp/status_text.go
@@ -1,0 +1,23 @@
+package acp
+
+import (
+	"strings"
+
+	"reasonix/internal/secrets"
+)
+
+func clipStatusText(value string, limit int) string {
+	value = strings.TrimSpace(secrets.Redact(value))
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}
+
+func clipStatusError(err error, limit int) string {
+	value := strings.TrimSpace(secrets.RedactError(err))
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit]
+}

--- a/internal/acp/status_text_test.go
+++ b/internal/acp/status_text_test.go
@@ -1,0 +1,46 @@
+package acp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestClipStatusValuePreservesUTF8AcrossJSON(t *testing.T) {
+	const limit = 2_048
+	want := strings.Repeat("x", limit-1)
+	clipped := clipStatusValue(want+"中", limit)
+
+	if clipped != want {
+		t.Fatalf("clipStatusValue() = %q, want the complete UTF-8 prefix", clipped)
+	}
+	if len(clipped) > limit {
+		t.Fatalf("clipStatusValue() returned %d bytes, limit %d", len(clipped), limit)
+	}
+	if !utf8.ValidString(clipped) {
+		t.Fatalf("clipStatusValue() returned invalid UTF-8: %q", clipped)
+	}
+
+	wire, err := json.Marshal(clipped)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var decoded string
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded != clipped {
+		t.Fatalf("JSON round trip changed clipped diagnostic: got %q, want %q", decoded, clipped)
+	}
+}
+
+func TestClipStatusValueRepairsInvalidUTF8(t *testing.T) {
+	clipped := clipStatusValue("status: \xff", 32)
+	if !utf8.ValidString(clipped) {
+		t.Fatalf("clipStatusValue() returned invalid UTF-8: %q", clipped)
+	}
+	if clipped != "status: \uFFFD" {
+		t.Fatalf("clipStatusValue() = %q, want invalid bytes replaced", clipped)
+	}
+}

--- a/internal/acp/stop_reason.go
+++ b/internal/acp/stop_reason.go
@@ -1,0 +1,8 @@
+package acp
+
+// ACP v1 stop reasons emitted by Reasonix.
+const (
+	StopEndTurn         StopReason = "end_turn"
+	StopCancelled       StopReason = "cancelled"
+	StopMaxTurnRequests StopReason = "max_turn_requests"
+)

--- a/internal/control/final_readiness_recovery.go
+++ b/internal/control/final_readiness_recovery.go
@@ -30,9 +30,20 @@ func ParseFinalReadinessRecoveryCommand(input string) (prompt string, ok bool) {
 
 // RunFinalReadinessRecovery is the synchronous transport-neutral recovery path.
 func (c *Controller) RunFinalReadinessRecovery(ctx context.Context, input string) error {
+	return c.RunFinalReadinessRecoveryWithAdmission(ctx, input, nil)
+}
+
+// RunFinalReadinessRecoveryWithAdmission runs the recovery after the controller
+// has admitted the request and consumed a valid one-shot checkpoint. Hosts that
+// publish turn lifecycle state use the callback to avoid announcing a turn for
+// a stale recovery request.
+func (c *Controller) RunFinalReadinessRecoveryWithAdmission(ctx context.Context, input string, onAdmitted func()) error {
 	return c.runSynchronousTurn(ctx, nil, func(runCtx context.Context) error {
 		if c.executor == nil || !c.executor.PrepareFinalReadinessRecovery() {
 			return ErrNoFinalReadinessRecovery
+		}
+		if onAdmitted != nil {
+			onAdmitted()
 		}
 		return c.runTurn(runCtx, input)
 	})


### PR DESCRIPTION
> **AI authorship disclosure:** The original PR implementation, test, and description were written autonomously by an AI coding agent (DeepSeek-V4-Pro on DeepSeek Harness). The maintainer follow-up below was reviewed and verified against the live PR head.
>
> **AI 作者声明：** 本 PR 的初始实现、测试与说明由 AI 编码代理（DeepSeek Harness 上的 DeepSeek-V4-Pro）自主完成；后续维护者修复已基于实时 PR head 完成评审与验证。

## Summary

- Treat `FinalReadinessError` and controlled recovery pauses as ACP v1 `end_turn` outcomes while preserving readiness diagnostics through a bounded, credential-redacted `[warning]` message chunk and status telemetry.
- Return genuine provider, tool, or runtime failures as JSON-RPC `-32603 InternalError` responses with a bounded, credential-redacted cause instead of the non-standard `stopReason: "error"`.
- Use one cancellation snapshot for telemetry and the prompt response, including runners that stop gracefully and return `nil` after cancellation.
- Document the ACP prompt-outcome contract in English and Chinese and add focused wire-level regression coverage.

## Issues

Closes #8811

Closes #8241

Refs multica-ai/multica#6873

## Repository contribution credits and integration

All related PR authors below are credited as repository contributors, whether their implementation was kept, adapted, or evaluated without adoption.

### Kept or adapted

- Kept the original readiness-gate mapping and warning delivery from #8916 by @RayySummers, then hardened the warning's external diagnostic boundary with credential redaction and a 2,048-byte limit.
- Adapted the ACP v1 JSON-RPC failure, credential redaction, and cancellation-consistency work from #8510 by @Oxygen56 onto the current `main-v2` architecture. The adopting commit also carries GitHub co-author attribution.

### Evaluated contributions (not adopted)

- Credited #8655 by @altiummm as a repository contribution after reviewing its ACP usage-reporting work. Its implementation is orthogonal to this prompt-outcome fix and is not adopted here; because both PRs assemble the prompt result in `internal/acp/service.go`, #8655 should rebase after this PR lands.

## Behavior

| Controller outcome | ACP result |
| --- | --- |
| Completed | `stopReason: "end_turn"` |
| Final-readiness gap | bounded, credential-redacted `[warning]` chunk plus `stopReason: "end_turn"` |
| Controlled recovery pause | `stopReason: "end_turn"` |
| Client cancellation | `stopReason: "cancelled"` |
| Genuine runtime failure | JSON-RPC `-32603 InternalError` with a clipped, credential-redacted cause |

On the genuine-failure path there is no successful `SessionPromptResult`, so `transcriptPath` is not returned in that response. Transcript and vendor-status persistence still complete before the JSON-RPC error is sent.

## Verification

- `go test ./internal/acp -count=1`
- `go test -race ./internal/acp -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go run ./tools/repolint`
- `go test ./internal/productdocs -count=1`
- `git diff --check`

## Documentation impact

Documentation-impact: updated - documented ACP v1 readiness, cancellation, and genuine-failure outcomes in both ACP integration guides.

## Cache impact

Cache-impact: none - the change runs after controller completion and does not alter provider-visible prompts, memory prefixes, tool schemas/order, provider serialization, compaction, or reasoning upload.

Cache-guard: `go test ./internal/acp -count=1`

System-prompt-review: N/A

## Compatibility and security

- Wire compatibility improves for strict ACP v1 clients: Reasonix no longer emits the unsupported `error` stop reason.
- No persisted format or cross-version storage contract changes.
- External error and final-readiness diagnostic text remains valid UTF-8, is bounded to 2,048 bytes, and uses the stronger credential-redaction path before reaching ACP clients, status telemetry, or logs.
