### PR TITLE
fix(desktop): avoid locking nested Windows workspaces / 修复 Windows 嵌套工作区目录锁定

### DIFF
--- a/desktop/workspace_watch.go
+++ b/desktop/workspace_watch.go
@@ -34,7 +34,7 @@ type workspaceWatchRoot struct {
 	key        string
 	root       string
 	gitDirs    []string
-	watcher    *fsnotify.Watcher
+	watcher    workspaceWatcher
 	watched    map[string]struct{}
 	dirs       int
 	state      event.WorkspaceWatchState
@@ -97,7 +97,7 @@ func (h *workspaceChangeHub) ensureRoot(root string) string {
 }
 
 func (h *workspaceChangeHub) startRootLocked(r *workspaceWatchRoot) {
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := newWorkspaceWatcher()
 	if err != nil {
 		r.state = event.WorkspaceWatchUnavailable
 		return
@@ -122,6 +122,10 @@ func (h *workspaceChangeHub) startRootLocked(r *workspaceWatchRoot) {
 }
 
 func (h *workspaceChangeHub) addTreeLocked(r *workspaceWatchRoot, root string) {
+	if r.watcher != nil && r.watcher.SupportsRecursive() {
+		h.addWatchDirModeLocked(r, root, true)
+		return
+	}
 	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			r.state = event.WorkspaceWatchDegraded
@@ -154,6 +158,10 @@ func (h *workspaceChangeHub) addTreeLocked(r *workspaceWatchRoot, root string) {
 }
 
 func (h *workspaceChangeHub) addWatchDirLocked(r *workspaceWatchRoot, path string) bool {
+	return h.addWatchDirModeLocked(r, path, false)
+}
+
+func (h *workspaceChangeHub) addWatchDirModeLocked(r *workspaceWatchRoot, path string, recursive bool) bool {
 	path = filepath.Clean(path)
 	if _, ok := r.watched[path]; ok {
 		return true
@@ -162,7 +170,7 @@ func (h *workspaceChangeHub) addWatchDirLocked(r *workspaceWatchRoot, path strin
 		r.state = event.WorkspaceWatchDegraded
 		return false
 	}
-	if err := r.watcher.Add(path); err != nil {
+	if err := r.watcher.Add(path, recursive); err != nil {
 		r.state = event.WorkspaceWatchDegraded
 		return false
 	}
@@ -192,6 +200,21 @@ func (h *workspaceChangeHub) addGitMetadataLocked(r *workspaceWatchRoot) {
 		r.gitDirs = gitMetadataDirsForWorkspace(r.root)
 	}
 	if len(r.gitDirs) == 0 || r.watcher == nil || r.dirs >= workspaceWatchMaxDirs {
+		return
+	}
+	if r.watcher.SupportsRecursive() {
+		for _, gitDir := range r.gitDirs {
+			if pathWithinRoot(r.root, gitDir) {
+				continue
+			}
+			h.addWatchDirModeLocked(r, gitDir, false)
+			for _, rel := range []string{"refs", "logs", "worktrees"} {
+				path := filepath.Join(gitDir, rel)
+				if info, err := os.Stat(path); err == nil && info.IsDir() {
+					h.addWatchDirModeLocked(r, path, true)
+				}
+			}
+		}
 		return
 	}
 	// Watch selected metadata trees recursively. fsnotify is non-recursive, so
@@ -249,6 +272,76 @@ func gitMetadataPathAllowed(gitDirs []string, path string) bool {
 	return false
 }
 
+func gitMetadataEventAllowed(gitDir, path string) bool {
+	rel, err := filepath.Rel(gitDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	if rel == "." || !strings.Contains(filepath.ToSlash(rel), "/") {
+		return true
+	}
+	first := strings.SplitN(filepath.ToSlash(rel), "/", 2)[0]
+	return first == "refs" || first == "logs" || first == "worktrees"
+}
+
+func pathWithinRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func workspaceWatchPathSkipped(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	for i, name := range parts {
+		prefix := strings.Join(parts[:i+1], "/")
+		if fileref.SkipEntry(prefix, name, i < len(parts)-1) {
+			return true
+		}
+	}
+	return false
+}
+
+func workspaceWatchPathClass(r *workspaceWatchRoot, path string) (isGit, ignored bool) {
+	underGit := false
+	for _, gitDir := range r.gitDirs {
+		if path != gitDir && !strings.HasPrefix(path, gitDir+string(filepath.Separator)) {
+			continue
+		}
+		underGit = true
+		if gitMetadataEventAllowed(gitDir, path) {
+			return true, false
+		}
+	}
+	if underGit {
+		return false, true
+	}
+	return false, workspaceWatchPathSkipped(r.root, path)
+}
+
+func (h *workspaceChangeHub) addCreatedGitMetadataLocked(r *workspaceWatchRoot, path string) {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() || !gitMetadataPathAllowed(r.gitDirs, path) {
+		return
+	}
+	if !r.watcher.SupportsRecursive() {
+		h.addGitMetadataTreeLocked(r, path)
+		return
+	}
+	if pathWithinRoot(r.root, path) {
+		return
+	}
+	for _, gitDir := range r.gitDirs {
+		rel, relErr := filepath.Rel(gitDir, path)
+		if relErr == nil && (rel == "refs" || rel == "logs" || rel == "worktrees") {
+			h.addWatchDirModeLocked(r, path, true)
+			return
+		}
+	}
+}
+
 func gitMetadataDirsForWorkspace(root string) []string {
 	seen := make(map[string]struct{}, 2)
 	var dirs []string
@@ -286,12 +379,12 @@ func gitMetadataDirsForWorkspace(root string) []string {
 func (h *workspaceChangeHub) watchLoop(r *workspaceWatchRoot) {
 	for {
 		select {
-		case ev, ok := <-r.watcher.Events:
+		case ev, ok := <-r.watcher.Events():
 			if !ok {
 				return
 			}
 			h.observeFilesystem(r.key, ev)
-		case _, ok := <-r.watcher.Errors:
+		case _, ok := <-r.watcher.Errors():
 			if !ok {
 				return
 			}
@@ -315,18 +408,14 @@ func (h *workspaceChangeHub) observeFilesystem(key string, ev fsnotify.Event) {
 		h.mu.Unlock()
 		return
 	}
-	isGit := false
-	for _, gitDir := range r.gitDirs {
-		if path == gitDir || strings.HasPrefix(path, gitDir+string(filepath.Separator)) {
-			isGit = true
-			break
-		}
+	isGit, ignored := workspaceWatchPathClass(r, path)
+	if ignored {
+		h.mu.Unlock()
+		return
 	}
 	if isGit {
 		if ev.Op&fsnotify.Create != 0 {
-			if info, statErr := os.Stat(path); statErr == nil && info.IsDir() && gitMetadataPathAllowed(r.gitDirs, path) {
-				h.addGitMetadataTreeLocked(r, path)
-			}
+			h.addCreatedGitMetadataLocked(r, path)
 		}
 		if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
 			h.removeWatchTreeLocked(r, path)
@@ -352,7 +441,7 @@ func (h *workspaceChangeHub) observeFilesystem(key string, ev fsnotify.Event) {
 			r.allPaths = true
 		}
 		r.source = mergeWorkspaceSource(r.source, "filesystem")
-		if ev.Op&fsnotify.Create != 0 {
+		if ev.Op&fsnotify.Create != 0 && !r.watcher.SupportsRecursive() {
 			if info, statErr := os.Stat(path); statErr == nil && info.IsDir() {
 				h.addTreeLocked(r, path)
 			}
@@ -592,7 +681,7 @@ func (h *workspaceChangeHub) reconcileRoots() {
 		}
 	}
 	h.mu.Lock()
-	watchers := make([]*fsnotify.Watcher, 0)
+	watchers := make([]workspaceWatcher, 0)
 	for key, r := range h.roots {
 		if _, ok := used[key]; ok {
 			continue
@@ -623,7 +712,7 @@ func (h *workspaceChangeHub) close() {
 		return
 	}
 	h.closed = true
-	watchers := make([]*fsnotify.Watcher, 0, len(h.roots))
+	watchers := make([]workspaceWatcher, 0, len(h.roots))
 	for key, r := range h.roots {
 		r.closed = true
 		if r.timer != nil {

--- a/desktop/workspace_watch_test.go
+++ b/desktop/workspace_watch_test.go
@@ -231,11 +231,19 @@ func TestWorkspaceChangeHubRecursivelyWatchesGitMetadataOnly(t *testing.T) {
 	gitDir = canonicalWorkspaceRoot(gitDir)
 	app.workspaceHub.mu.Lock()
 	r := app.workspaceHub.roots[key]
+	recursive := r != nil && r.watcher != nil && r.watcher.SupportsRecursive()
+	_, rootWatched := r.watched[key]
 	_, refsWatched := r.watched[filepath.Join(gitDir, "refs", "heads")]
 	_, logsWatched := r.watched[filepath.Join(gitDir, "logs", "refs", "heads")]
 	_, worktreeWatched := r.watched[filepath.Join(gitDir, "worktrees", "linked")]
 	_, objectsWatched := r.watched[filepath.Join(gitDir, "objects")]
 	app.workspaceHub.mu.Unlock()
+	if recursive {
+		if !rootWatched || refsWatched || logsWatched || worktreeWatched || objectsWatched {
+			t.Fatalf("recursive workspace watch root=%v refs=%v logs=%v worktrees=%v objects=%v", rootWatched, refsWatched, logsWatched, worktreeWatched, objectsWatched)
+		}
+		return
+	}
 	if !refsWatched || !logsWatched || !worktreeWatched || objectsWatched {
 		t.Fatalf("git watches refs=%v logs=%v worktrees=%v objects=%v", refsWatched, logsWatched, worktreeWatched, objectsWatched)
 	}

--- a/desktop/workspace_watch_windows_test.go
+++ b/desktop/workspace_watch_windows_test.go
@@ -4,6 +4,10 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -29,4 +33,317 @@ func TestWorkspaceGitProbesHideConsoleWindowOnWindows(t *testing.T) {
 			t.Fatalf("%s: CREATE_NO_WINDOW not set; CreationFlags=%#x", flag, cmd.SysProcAttr.CreationFlags)
 		}
 	}
+}
+
+func TestWorkspaceWatcherDoesNotLockNestedParentOnWindows(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "parent")
+	if err := os.MkdirAll(filepath.Join(from, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	if state := app.WorkspaceRevisionForTab("a").WatchState; state == "unavailable" {
+		t.Fatalf("watcher unavailable: %s", state)
+	}
+	before := app.WorkspaceRevisionForTab("a").Revisions.Content
+
+	to := filepath.Join(root, "renamed")
+	if err := os.Rename(from, to); err != nil {
+		t.Fatalf("rename parent while workspace watcher is active: %v", err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+	before = waitForWorkspaceRevisionToSettle(t, app)
+	if err := os.WriteFile(filepath.Join(to, "child", "after.txt"), []byte("after"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+	before = waitForWorkspaceRevisionToSettle(t, app)
+	if err := os.RemoveAll(to); err != nil {
+		t.Fatalf("delete renamed parent while workspace watcher is active: %v", err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+}
+
+func TestWorkspaceWatcherUsesOneRecursiveWorkspaceHandleOnWindows(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "one", "two", "three"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	app.WorkspaceRevisionForTab("a")
+
+	key := canonicalWorkspaceRoot(root)
+	app.workspaceHub.mu.Lock()
+	r := app.workspaceHub.roots[key]
+	dirs := 0
+	if r != nil {
+		dirs = r.dirs
+	}
+	app.workspaceHub.mu.Unlock()
+	if dirs != 1 {
+		t.Fatalf("workspace handles = %d, want 1 recursive root handle", dirs)
+	}
+}
+
+func TestWindowsWorkspaceWatcherPreservesUnicodeEventPath(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "one", "two")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	w, err := newWorkspaceWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	if err := w.Add(root, true); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(deep, "unicode-\u6587\u4ef6-\U0001F600.txt")
+	if err := os.WriteFile(target, []byte("deep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case ev := <-w.Events():
+			if filepath.Clean(ev.Name) == target {
+				return
+			}
+		case err := <-w.Errors():
+			t.Fatalf("watcher error: %v", err)
+		case <-timer.C:
+			t.Fatalf("no event for exact Unicode path %q", target)
+		}
+	}
+}
+
+func TestWorkspaceWatcherReportsPreexistingDeepFileChangesOnWindows(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "one", "two", "three")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	before := app.WorkspaceRevisionForTab("a").Revisions.Content
+	if err := os.WriteFile(filepath.Join(deep, "file.txt"), []byte("deep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+}
+
+func TestWorkspaceWatcherReportsFilesInNewDeepDirectoriesOnWindows(t *testing.T) {
+	root := t.TempDir()
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	before := app.WorkspaceRevisionForTab("a").Revisions.Content
+	deep := filepath.Join(root, "new", "nested")
+	if err := os.MkdirAll(deep, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+	before = waitForWorkspaceRevisionToSettle(t, app)
+	if err := os.WriteFile(filepath.Join(deep, "later.txt"), []byte("later"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+}
+
+func TestWorkspaceWatcherIgnoresGeneratedSubtreeChurnOnWindows(t *testing.T) {
+	root := t.TempDir()
+	generated := filepath.Join(root, "node_modules", "pkg")
+	if err := os.MkdirAll(generated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	before := app.WorkspaceRevisionForTab("a").Revisions.Content
+	for i := range 256 {
+		name := filepath.Join(generated, fmt.Sprintf("generated-%03d.js", i))
+		if err := os.WriteFile(name, []byte("generated"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(300 * time.Millisecond)
+	view := app.WorkspaceRevisionForTab("a")
+	after := view.Revisions.Content
+	if after != before {
+		t.Fatalf("generated subtree advanced content revision: before=%d after=%d", before, after)
+	}
+	if view.WatchState != "active" {
+		t.Fatalf("generated subtree degraded recursive watcher: %s", view.WatchState)
+	}
+}
+
+func TestWorkspaceWatcherCloseReleasesNestedDirectoriesOnWindows(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "parent")
+	if err := os.MkdirAll(filepath.Join(from, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	app.WorkspaceRevisionForTab("a")
+	app.workspaceHub.close()
+	if err := os.Rename(from, filepath.Join(root, "after-close")); err != nil {
+		t.Fatalf("rename after workspace watcher close: %v", err)
+	}
+}
+
+func TestWorkspaceWatcherSwitchReleasesOldWorkspaceOnWindows(t *testing.T) {
+	rootA, rootB := t.TempDir(), t.TempDir()
+	from := filepath.Join(rootA, "parent")
+	if err := os.MkdirAll(filepath.Join(from, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: rootA}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	app.WorkspaceRevisionForTab("a")
+	app.mu.Lock()
+	app.tabs["a"].WorkspaceRoot = rootB
+	app.mu.Unlock()
+	app.WorkspaceRevisionForTab("a")
+	app.workspaceHub.reconcileRoots()
+
+	if err := os.Rename(from, filepath.Join(rootA, "after-switch")); err != nil {
+		t.Fatalf("rename in released workspace: %v", err)
+	}
+	before := app.WorkspaceRevisionForTab("a").Revisions.Content
+	if err := os.WriteFile(filepath.Join(rootB, "active.txt"), []byte("active"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceContentRevision(t, app, before)
+}
+
+func TestWorkspaceWatcherKeepsGitMetadataScopeOnWindows(t *testing.T) {
+	root := t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	before := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+	ref := filepath.Join(root, ".git", "refs", "heads", "watch-test")
+	if err := os.WriteFile(ref, []byte("0000000000000000000000000000000000000000\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceGitRevision(t, app, before)
+	before = waitForWorkspaceGitRevisionToSettle(t, app)
+	objectDir := filepath.Join(root, ".git", "objects", "ff")
+	if err := os.MkdirAll(objectDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(objectDir, "ignored"), []byte("object"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	after := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+	if after != before {
+		t.Fatalf("git object churn advanced metadata revision: before=%d after=%d", before, after)
+	}
+}
+
+func TestWorkspaceWatcherTracksExternalGitMetadataOnWindows(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "workspace")
+	gitDir := filepath.Join(base, "git-dir")
+	if out, err := exec.Command("git", "init", "--separate-git-dir", gitDir, root).CombinedOutput(); err != nil {
+		t.Fatalf("git init --separate-git-dir: %v: %s", err, out)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "parent", "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{tabs: map[string]*WorkspaceTab{"a": {ID: "a", WorkspaceRoot: root}}}
+	app.workspaceHub = newWorkspaceChangeHub(app)
+	t.Cleanup(func() { app.workspaceHub.close() })
+	before := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+	ref := filepath.Join(gitDir, "refs", "heads", "watch-test")
+	if err := os.WriteFile(ref, []byte("0000000000000000000000000000000000000000\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorkspaceGitRevision(t, app, before)
+	if err := os.Rename(filepath.Join(root, "parent"), filepath.Join(root, "renamed")); err != nil {
+		t.Fatalf("external Git watches locked a workspace child: %v", err)
+	}
+}
+
+func waitForWorkspaceContentRevision(t *testing.T, app *App, before uint64) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got := app.WorkspaceRevisionForTab("a").Revisions.Content
+		if got > before {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("content revision did not advance beyond %d", before)
+	return before
+}
+
+func waitForWorkspaceRevisionToSettle(t *testing.T, app *App) uint64 {
+	t.Helper()
+	last := app.WorkspaceRevisionForTab("a").Revisions.Content
+	stableSince := time.Now()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		got := app.WorkspaceRevisionForTab("a").Revisions.Content
+		if got != last {
+			last = got
+			stableSince = time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= 100*time.Millisecond {
+			return got
+		}
+	}
+	t.Fatalf("content revision did not settle")
+	return last
+}
+
+func waitForWorkspaceGitRevision(t *testing.T, app *App, before uint64) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+		if got > before {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("git metadata revision did not advance beyond %d", before)
+	return before
+}
+
+func waitForWorkspaceGitRevisionToSettle(t *testing.T, app *App) uint64 {
+	t.Helper()
+	last := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+	stableSince := time.Now()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+		got := app.WorkspaceRevisionForTab("a").Revisions.GitMeta
+		if got != last {
+			last = got
+			stableSince = time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= 100*time.Millisecond {
+			return got
+		}
+	}
+	t.Fatalf("git metadata revision did not settle")
+	return last
 }

--- a/desktop/workspace_watcher.go
+++ b/desktop/workspace_watcher.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/fsnotify/fsnotify"
+
+// workspaceWatcher isolates the platform-specific directory notification
+// backend from revision coalescing and workspace lifecycle ownership.
+type workspaceWatcher interface {
+	Events() <-chan fsnotify.Event
+	Errors() <-chan error
+	SupportsRecursive() bool
+	Add(path string, recursive bool) error
+	Remove(path string) error
+	Close() error
+}

--- a/desktop/workspace_watcher_other.go
+++ b/desktop/workspace_watcher_other.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import "github.com/fsnotify/fsnotify"
+
+type fsnotifyWorkspaceWatcher struct {
+	watcher *fsnotify.Watcher
+}
+
+func newWorkspaceWatcher() (workspaceWatcher, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &fsnotifyWorkspaceWatcher{watcher: w}, nil
+}
+
+func (w *fsnotifyWorkspaceWatcher) Events() <-chan fsnotify.Event { return w.watcher.Events }
+func (w *fsnotifyWorkspaceWatcher) Errors() <-chan error          { return w.watcher.Errors }
+func (w *fsnotifyWorkspaceWatcher) SupportsRecursive() bool       { return false }
+func (w *fsnotifyWorkspaceWatcher) Add(path string, _ bool) error { return w.watcher.Add(path) }
+func (w *fsnotifyWorkspaceWatcher) Remove(path string) error      { return w.watcher.Remove(path) }
+func (w *fsnotifyWorkspaceWatcher) Close() error                  { return w.watcher.Close() }

--- a/desktop/workspace_watcher_windows.go
+++ b/desktop/workspace_watcher_windows.go
@@ -1,0 +1,354 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	windowsWorkspaceWatchBuffer = 64 * 1024
+	windowsWorkspaceEventBuffer = 256
+)
+
+// Windows keeps a single recursive ReadDirectoryChangesW handle per root.
+// Per-directory handles can prevent renaming an ancestor while a read is
+// pending, even when each handle was opened with FILE_SHARE_DELETE (#8770).
+type windowsWorkspaceWatcher struct {
+	mu       sync.Mutex
+	events   chan fsnotify.Event
+	errors   chan error
+	closed   chan struct{}
+	watches  map[string]*windowsWorkspaceSubscription
+	isClosed bool
+	wg       sync.WaitGroup
+}
+
+type windowsWorkspaceSubscription struct {
+	path      string
+	handle    windows.Handle
+	event     windows.Handle
+	stopEvent windows.Handle
+	recursive bool
+	ready     chan error
+	stop      chan struct{}
+	done      chan struct{}
+	readyOnce sync.Once
+	stopOnce  sync.Once
+	stopErr   error
+}
+
+func newWorkspaceWatcher() (workspaceWatcher, error) {
+	return &windowsWorkspaceWatcher{
+		events:  make(chan fsnotify.Event, windowsWorkspaceEventBuffer),
+		errors:  make(chan error, 1),
+		closed:  make(chan struct{}),
+		watches: make(map[string]*windowsWorkspaceSubscription),
+	}, nil
+}
+
+func (w *windowsWorkspaceWatcher) Events() <-chan fsnotify.Event { return w.events }
+func (w *windowsWorkspaceWatcher) Errors() <-chan error          { return w.errors }
+func (w *windowsWorkspaceWatcher) SupportsRecursive() bool       { return true }
+
+func (w *windowsWorkspaceWatcher) Add(path string, recursive bool) error {
+	path = filepath.Clean(path)
+	handle, err := windows.CreateFile(
+		windows.StringToUTF16Ptr(path),
+		windows.FILE_LIST_DIRECTORY,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OVERLAPPED,
+		0,
+	)
+	if err != nil {
+		return os.NewSyscallError("CreateFile", err)
+	}
+	event, err := windows.CreateEvent(nil, 0, 0, nil)
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		return os.NewSyscallError("CreateEvent", err)
+	}
+	stopEvent, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(event)
+		return os.NewSyscallError("CreateEvent(stop)", err)
+	}
+
+	key := windowsWorkspaceWatchKey(path)
+	w.mu.Lock()
+	if w.isClosed {
+		w.mu.Unlock()
+		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(event)
+		_ = windows.CloseHandle(stopEvent)
+		return fsnotify.ErrClosed
+	}
+	if _, exists := w.watches[key]; exists {
+		w.mu.Unlock()
+		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(event)
+		_ = windows.CloseHandle(stopEvent)
+		return nil
+	}
+	sub := &windowsWorkspaceSubscription{
+		path: path, handle: handle, event: event, stopEvent: stopEvent, recursive: recursive,
+		ready: make(chan error, 1), stop: make(chan struct{}), done: make(chan struct{}),
+	}
+	w.watches[key] = sub
+	w.wg.Add(1)
+	w.mu.Unlock()
+	go w.read(sub)
+	if err := <-sub.ready; err != nil {
+		w.mu.Lock()
+		if w.watches[key] == sub {
+			delete(w.watches, key)
+		}
+		w.mu.Unlock()
+		_ = sub.close()
+		return err
+	}
+	return nil
+}
+
+func (w *windowsWorkspaceWatcher) Remove(path string) error {
+	key := windowsWorkspaceWatchKey(path)
+	w.mu.Lock()
+	sub := w.watches[key]
+	delete(w.watches, key)
+	w.mu.Unlock()
+	if sub == nil {
+		return nil
+	}
+	return sub.close()
+}
+
+func (w *windowsWorkspaceWatcher) Close() error {
+	w.mu.Lock()
+	if w.isClosed {
+		w.mu.Unlock()
+		return nil
+	}
+	w.isClosed = true
+	close(w.closed)
+	subs := make([]*windowsWorkspaceSubscription, 0, len(w.watches))
+	for _, sub := range w.watches {
+		subs = append(subs, sub)
+	}
+	w.watches = make(map[string]*windowsWorkspaceSubscription)
+	w.mu.Unlock()
+
+	var firstErr error
+	for _, sub := range subs {
+		if err := sub.close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	w.wg.Wait()
+	close(w.events)
+	close(w.errors)
+	return firstErr
+}
+
+func (s *windowsWorkspaceSubscription) close() error {
+	s.stopOnce.Do(func() {
+		close(s.stop)
+		if err := windows.SetEvent(s.stopEvent); err != nil {
+			s.stopErr = os.NewSyscallError("SetEvent(stop)", err)
+			_ = windows.CancelIoEx(s.handle, nil)
+		}
+		<-s.done
+		if err := windows.CloseHandle(s.handle); err != nil && s.stopErr == nil {
+			s.stopErr = os.NewSyscallError("CloseHandle", err)
+		}
+		if err := windows.CloseHandle(s.event); err != nil && s.stopErr == nil {
+			s.stopErr = os.NewSyscallError("CloseHandle(event)", err)
+		}
+		if err := windows.CloseHandle(s.stopEvent); err != nil && s.stopErr == nil {
+			s.stopErr = os.NewSyscallError("CloseHandle(stop)", err)
+		}
+	})
+	return s.stopErr
+}
+
+func (w *windowsWorkspaceWatcher) read(sub *windowsWorkspaceSubscription) {
+	defer w.wg.Done()
+	defer close(sub.done)
+	ready := false
+	defer func() {
+		if !ready {
+			sub.signalReady(fsnotify.ErrClosed)
+		}
+	}()
+	buf := make([]byte, windowsWorkspaceWatchBuffer)
+	mask := uint32(windows.FILE_NOTIFY_CHANGE_FILE_NAME | windows.FILE_NOTIFY_CHANGE_DIR_NAME | windows.FILE_NOTIFY_CHANGE_LAST_WRITE)
+	for {
+		if w.stopping(sub) {
+			return
+		}
+		ov := windows.Overlapped{HEvent: sub.event}
+		err := windows.ReadDirectoryChanges(sub.handle, &buf[0], uint32(len(buf)), sub.recursive, mask, nil, &ov, 0)
+		if err != nil && !errors.Is(err, windows.ERROR_IO_PENDING) {
+			if w.stopping(sub) || errors.Is(err, windows.ERROR_OPERATION_ABORTED) || errors.Is(err, windows.ERROR_INVALID_HANDLE) {
+				return
+			}
+			if !ready {
+				sub.signalReady(os.NewSyscallError("ReadDirectoryChanges", err))
+				ready = true
+				return
+			}
+			if errors.Is(err, windows.ERROR_NOTIFY_ENUM_DIR) {
+				w.sendError(sub, fsnotify.ErrEventOverflow)
+				continue
+			}
+			w.sendError(sub, os.NewSyscallError("ReadDirectoryChanges", err))
+			return
+		}
+		if !ready {
+			sub.signalReady(nil)
+			ready = true
+		}
+		which, err := windows.WaitForMultipleObjects([]windows.Handle{sub.event, sub.stopEvent}, false, windows.INFINITE)
+		if err != nil {
+			if w.stopping(sub) {
+				return
+			}
+			w.sendError(sub, os.NewSyscallError("WaitForMultipleObjects", err))
+			return
+		}
+		if which == windows.WAIT_OBJECT_0+1 {
+			cancelErr := windows.CancelIoEx(sub.handle, &ov)
+			if cancelErr != nil && !errors.Is(cancelErr, windows.ERROR_NOT_FOUND) {
+				w.sendError(sub, os.NewSyscallError("CancelIoEx", cancelErr))
+			}
+			var ignored uint32
+			if err := windows.GetOverlappedResult(sub.handle, &ov, &ignored, true); err != nil && !errors.Is(err, windows.ERROR_OPERATION_ABORTED) {
+				w.sendError(sub, os.NewSyscallError("GetOverlappedResult(cancel)", err))
+			}
+			return
+		}
+		if which != windows.WAIT_OBJECT_0 {
+			w.sendError(sub, fmt.Errorf("WaitForMultipleObjects: unexpected result %d", which))
+			return
+		}
+		var n uint32
+		if err := windows.GetOverlappedResult(sub.handle, &ov, &n, false); err != nil {
+			if w.stopping(sub) || errors.Is(err, windows.ERROR_OPERATION_ABORTED) || errors.Is(err, windows.ERROR_INVALID_HANDLE) {
+				return
+			}
+			if errors.Is(err, windows.ERROR_NOTIFY_ENUM_DIR) || errors.Is(err, windows.ERROR_MORE_DATA) {
+				w.sendError(sub, fsnotify.ErrEventOverflow)
+				continue
+			}
+			w.sendError(sub, os.NewSyscallError("GetOverlappedResult", err))
+			return
+		}
+		if n == 0 {
+			w.sendError(sub, fsnotify.ErrEventOverflow)
+			continue
+		}
+		if err := w.publishBuffer(sub, buf[:n]); err != nil {
+			w.sendError(sub, err)
+		}
+	}
+}
+
+func (s *windowsWorkspaceSubscription) signalReady(err error) {
+	s.readyOnce.Do(func() { s.ready <- err })
+}
+
+func (w *windowsWorkspaceWatcher) publishBuffer(sub *windowsWorkspaceSubscription, buf []byte) error {
+	const header = 12
+	for offset := 0; ; {
+		if len(buf)-offset < header {
+			return fmt.Errorf("ReadDirectoryChanges: malformed notification header")
+		}
+		next := int(binary.LittleEndian.Uint32(buf[offset:]))
+		action := binary.LittleEndian.Uint32(buf[offset+4:])
+		nameBytes := int(binary.LittleEndian.Uint32(buf[offset+8:]))
+		if nameBytes < 0 || nameBytes%2 != 0 || nameBytes > len(buf)-offset-header {
+			return fmt.Errorf("ReadDirectoryChanges: malformed notification name")
+		}
+		units := make([]uint16, nameBytes/2)
+		for i := range units {
+			start := offset + header + i*2
+			units[i] = binary.LittleEndian.Uint16(buf[start:])
+		}
+		name := windows.UTF16ToString(units)
+		if op := windowsWorkspaceOp(action); op != 0 && name != "" {
+			if !w.sendEvent(sub, fsnotify.Event{Name: filepath.Join(sub.path, name), Op: op}) {
+				return nil
+			}
+		}
+		if next == 0 {
+			return nil
+		}
+		if next < header || next > len(buf)-offset {
+			return fmt.Errorf("ReadDirectoryChanges: invalid notification offset")
+		}
+		offset += next
+	}
+}
+
+func windowsWorkspaceOp(action uint32) fsnotify.Op {
+	switch action {
+	case windows.FILE_ACTION_ADDED, windows.FILE_ACTION_RENAMED_NEW_NAME:
+		return fsnotify.Create
+	case windows.FILE_ACTION_REMOVED:
+		return fsnotify.Remove
+	case windows.FILE_ACTION_MODIFIED:
+		return fsnotify.Write
+	case windows.FILE_ACTION_RENAMED_OLD_NAME:
+		return fsnotify.Rename
+	default:
+		return 0
+	}
+}
+
+func (w *windowsWorkspaceWatcher) sendEvent(sub *windowsWorkspaceSubscription, ev fsnotify.Event) bool {
+	select {
+	case <-w.closed:
+		return false
+	case <-sub.stop:
+		return false
+	case w.events <- ev:
+		return true
+	}
+}
+
+func (w *windowsWorkspaceWatcher) sendError(sub *windowsWorkspaceSubscription, err error) bool {
+	select {
+	case <-w.closed:
+		return false
+	case <-sub.stop:
+		return false
+	case w.errors <- err:
+		return true
+	}
+}
+
+func (w *windowsWorkspaceWatcher) stopping(sub *windowsWorkspaceSubscription) bool {
+	select {
+	case <-w.closed:
+		return true
+	case <-sub.stop:
+		return true
+	default:
+		return false
+	}
+}
+
+func windowsWorkspaceWatchKey(path string) string {
+	return strings.ToLower(filepath.Clean(path))
+}


### PR DESCRIPTION
## Summary

- Replace per-directory Windows workspace watches with one recursive overlapped ReadDirectoryChangesW subscription per workspace root.
- Keep the existing fsnotify behavior on non-Windows platforms and preserve targeted external Git metadata watches.
- Add Windows regression coverage for nested rename/delete, recursive events, Unicode paths, generated-subtree filtering, shutdown, workspace switching, and Git metadata.
- Include the cross-platform lint fixes required by the current repository rules.

## Why this is a new PR

This PR integrates and supersedes #8848. The source PR contains the correct core approach, but its fork branch currently has maintainer edits disabled. CI found errorlint and intrange findings, and the fixes could not be pushed back to that branch. A new PR from the maintainer fork lets the contribution be rebased onto the latest main-v2, includes the required CI fixes, and gives the integration branch a writable delivery path.

## Kept and adapted from #8848

- Kept the native recursive ReadDirectoryChangesW design and the workspace watcher abstraction.
- Kept the focused Windows lifecycle and path-behavior tests.
- Adapted syscall error matching to errors.Is and updated the generated-fixture loop to the current integer-range lint rule.

## Repository contributor credit

The original implementation and tests came from #8848 by @Nath-Vikky. The integration commit records @Nath-Vikky as a co-author so the contribution is attributed at repository commit level when merged.

## Security and cache impact

- No new dependencies, network calls, command execution, credential handling, or permission expansion.
- No prompt, provider serialization, tool schema, compaction, or prompt-cache-visible changes.

## Documentation impact

Documentation-impact: none - This changes the Windows watcher implementation without changing user-facing configuration, commands, or documented behavior.

## Verification

- cd desktop && GOOS=windows golangci-lint run --timeout=5m ./... — 0 issues
- cd desktop && go test ./...
- cd desktop && go test -race . -run Workspace(ChangeHub|Watcher)|GitMetadataDirsForWorkspace|TabEventSinkForwardsImmediateWorkspaceMutation -count=1
- cd desktop && go vet .
- Windows desktop test binary cross-compilation with GOOS=windows GOARCH=amd64 CGO_ENABLED=0
- go run ./tools/repolint
- git diff --check origin/main-v2...HEAD

Refs #8848.