### PR TITLE
fix(desktop): stop transcript scroll snap-backs and keep the todo panel live / 根治对话滚动回跳并让待办面板实时更新

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -77,7 +77,7 @@ const virtuosoRef = {
 };
 let recovery: ReturnType<typeof useTranscriptVirtuosoRecovery> | undefined;
 
-function Probe({ surfaceKey, revision = 0 }: { surfaceKey: string; revision?: number }) {
+function Probe({ surfaceKey, revision = 0, hold = false }: { surfaceKey: string; revision?: number; hold?: boolean }) {
   recovery = useTranscriptVirtuosoRecovery({
     surfaceKey,
     historyLayoutRevision: revision,
@@ -88,6 +88,7 @@ function Probe({ surfaceKey, revision = 0 }: { surfaceKey: string; revision?: nu
     virtuosoRef,
     readyRef,
     scrollToBottom: () => { scrollToBottomCalls += 1; },
+    holdRevisionResets: hold,
   });
   return null;
 }
@@ -212,6 +213,36 @@ const settledScrollBy = scrollByCalls;
 const settledScrollToIndex = scrollToIndexCalls;
 await flushFrames();
 check(scrollByCalls === settledScrollBy && scrollToIndexCalls === settledScrollToIndex, "restore settles on the mounted anchor within the wall-clock budget");
+
+// ── Streaming hold: revisions defer until the stream ends
+await act(async () => root.render(<Probe surfaceKey="surface-g" hold={true} />));
+await flushFrames();
+const keySurfaceG = recovery?.resetKey;
+await act(async () => root.render(<Probe surfaceKey="surface-g" revision={1} hold={true} />));
+await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await flushFrames();
+check(recovery?.resetKey === keySurfaceG, "layout revision does not rebuild while the turn is streaming");
+await act(async () => root.render(<Probe surfaceKey="surface-g" revision={1} hold={false} />));
+await flushFrames();
+check(recovery?.resetKey !== keySurfaceG && recovery?.resetKey.startsWith("surface-g:"), "the deferred rebuild runs when the stream ends");
+
+// ── Revision rebuilds coalesce within the min interval
+await act(async () => root.render(<Probe surfaceKey="surface-h" />));
+await flushFrames();
+const keySurfaceH0 = recovery?.resetKey;
+await act(async () => root.render(<Probe surfaceKey="surface-h" revision={1} />));
+await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await flushFrames();
+check(recovery?.resetKey !== keySurfaceH0 && recovery?.resetKey.startsWith("surface-h:"), "first layout revision rebuilds after the batch window");
+await act(async () => recovery?.invalidateAnchors()); // simulate the restore completing
+const keySurfaceH1 = recovery?.resetKey;
+await act(async () => root.render(<Probe surfaceKey="surface-h" revision={2} />));
+await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await flushFrames();
+check(recovery?.resetKey === keySurfaceH1, "a second revision inside the coalescing window does not rebuild again");
+await act(async () => new Promise((resolve) => setTimeout(resolve, 620)));
+await flushFrames();
+check(recovery?.resetKey !== keySurfaceH1, "the coalesced rebuild fires when the interval lapses");
 
 await act(async () => root.unmount());
 dom.window.close();

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -48,6 +48,43 @@ globalThis.cancelAnimationFrame = cancelFrame;
 dom.window.requestAnimationFrame = requestFrame;
 dom.window.cancelAnimationFrame = cancelFrame;
 
+let clockNow = 10_000;
+let nextTimer = 1;
+const timers = new Map<number, { dueAt: number; run: () => void }>();
+const originalDateNow = Date.now;
+const originalSetTimeout = dom.window.setTimeout;
+const originalClearTimeout = dom.window.clearTimeout;
+Date.now = () => clockNow;
+dom.window.setTimeout = ((handler: TimerHandler, timeout = 0, ...args: unknown[]) => {
+  const id = nextTimer;
+  nextTimer += 1;
+  const run = typeof handler === "function"
+    ? () => handler(...args)
+    : () => { throw new Error("string timer handlers are unsupported in this test"); };
+  timers.set(id, { dueAt: clockNow + Math.max(0, timeout), run });
+  return id;
+}) as typeof dom.window.setTimeout;
+dom.window.clearTimeout = ((id: number | undefined) => {
+  if (id !== undefined) timers.delete(id);
+}) as typeof dom.window.clearTimeout;
+
+async function advanceClock(milliseconds: number) {
+  await act(async () => {
+    const target = clockNow + milliseconds;
+    while (true) {
+      const next = [...timers.entries()]
+        .filter(([, timer]) => timer.dueAt <= target)
+        .sort(([leftID, left], [rightID, right]) => left.dueAt - right.dueAt || leftID - rightID)[0];
+      if (!next) break;
+      const [id, timer] = next;
+      timers.delete(id);
+      clockNow = timer.dueAt;
+      timer.run();
+    }
+    clockNow = target;
+  });
+}
+
 async function flushFrames() {
   const pending = [...frames.entries()];
   frames.clear();
@@ -126,7 +163,7 @@ check(scrollToBottomCalls === 1, "a reset without an anchor settles at the botto
 
 // ── Blank-recovery cooldown: revision bump rebuilds, immediate re-blank is blocked
 await act(async () => root.render(<Probe surfaceKey="surface-c" revision={1} />));
-await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await advanceClock(60);
 await flushFrames();
 check(recovery?.resetKey === "surface-c:3", "layout revision rebuilds the size tree after the batch window");
 await act(async () => recovery?.handleItemsRendered(1));
@@ -150,10 +187,10 @@ await flushFrames();
 const keyBeforeIntent = recovery?.resetKey;
 await act(async () => recovery?.noteUserScrollIntent());
 await act(async () => root.render(<Probe surfaceKey="surface-d" revision={1} />));
-await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await advanceClock(60);
 await flushFrames();
 check(recovery?.resetKey === keyBeforeIntent, "layout revision does not rebuild the size tree mid-scroll");
-await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+await advanceClock(350);
 await flushFrames();
 check(recovery?.resetKey !== keyBeforeIntent && recovery?.resetKey.startsWith("surface-d:"), "deferred layout rebuild fires once the scroll goes quiet");
 
@@ -171,7 +208,7 @@ await flushFrames();
 await flushFrames();
 await flushFrames();
 check(scrollByCalls === frozenScrollBy && scrollToIndexCalls === frozenScrollToIndex, "a user scroll gesture aborts the in-flight restore");
-await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+await advanceClock(350);
 
 // ── Blank detection is gated while the user scrolls, armed again at idle
 await act(async () => root.render(<Probe surfaceKey="surface-e" />));
@@ -182,7 +219,7 @@ await act(async () => recovery?.scheduleBlankViewportCheck());
 await flushFrames();
 await flushFrames();
 check(recovery?.resetKey === keySurfaceE, "blank viewport during active user scrolling does not rebuild");
-await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+await advanceClock(350);
 await flushFrames();
 await flushFrames();
 check(recovery?.resetKey !== keySurfaceE && recovery?.resetKey.startsWith("surface-e:"), "a blank that persists into scroll idle earns a rebuild");
@@ -219,7 +256,7 @@ await act(async () => root.render(<Probe surfaceKey="surface-g" hold={true} />))
 await flushFrames();
 const keySurfaceG = recovery?.resetKey;
 await act(async () => root.render(<Probe surfaceKey="surface-g" revision={1} hold={true} />));
-await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await advanceClock(60);
 await flushFrames();
 check(recovery?.resetKey === keySurfaceG, "layout revision does not rebuild while the turn is streaming");
 await act(async () => root.render(<Probe surfaceKey="surface-g" revision={1} hold={false} />));
@@ -231,20 +268,23 @@ await act(async () => root.render(<Probe surfaceKey="surface-h" />));
 await flushFrames();
 const keySurfaceH0 = recovery?.resetKey;
 await act(async () => root.render(<Probe surfaceKey="surface-h" revision={1} />));
-await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await advanceClock(60);
 await flushFrames();
 check(recovery?.resetKey !== keySurfaceH0 && recovery?.resetKey.startsWith("surface-h:"), "first layout revision rebuilds after the batch window");
 await act(async () => recovery?.invalidateAnchors()); // simulate the restore completing
 const keySurfaceH1 = recovery?.resetKey;
 await act(async () => root.render(<Probe surfaceKey="surface-h" revision={2} />));
-await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await advanceClock(60);
 await flushFrames();
 check(recovery?.resetKey === keySurfaceH1, "a second revision inside the coalescing window does not rebuild again");
-await act(async () => new Promise((resolve) => setTimeout(resolve, 620)));
+await advanceClock(620);
 await flushFrames();
 check(recovery?.resetKey !== keySurfaceH1, "the coalesced rebuild fires when the interval lapses");
 
 await act(async () => root.unmount());
+Date.now = originalDateNow;
+dom.window.setTimeout = originalSetTimeout;
+dom.window.clearTimeout = originalClearTimeout;
 dom.window.close();
 
 if (failed > 0) {

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -129,13 +129,89 @@ await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
 await flushFrames();
 check(recovery?.resetKey === "surface-c:3", "layout revision rebuilds the size tree after the batch window");
 await act(async () => recovery?.handleItemsRendered(1));
+// Let the in-flight restore converge: place the anchor row at its target
+// offset so the correction loop settles within two stable frames (real DOMs
+// converge after each scrollBy; the stubbed rects here do not move unless we
+// move them, and the wall-clock budget would otherwise keep it alive).
+rowElement.getBoundingClientRect = () => ({ top: 0, bottom: 100, height: 100, left: 0, right: 800, width: 800, x: 0, y: 0, toJSON: () => ({}) });
 for (let i = 0; i < 10; i += 1) await flushFrames();
+rowElement.getBoundingClientRect = () => ({ top: 200, bottom: 300, height: 100, left: 0, right: 800, width: 800, x: 0, y: 200, toJSON: () => ({}) });
 scrollByCalls = 0;
 await act(async () => recovery?.scheduleBlankViewportCheck());
 await flushFrames();
 await flushFrames();
 check(recovery?.resetKey === "surface-c:3", "blank recovery within the cooldown window is ignored");
 check(scrollByCalls === 0, "cooldown-blocked blank check performs no correction");
+
+// ── User-scroll quiescence: a layout revision must not rebuild mid-scroll
+await act(async () => root.render(<Probe surfaceKey="surface-d" />));
+await flushFrames();
+const keyBeforeIntent = recovery?.resetKey;
+await act(async () => recovery?.noteUserScrollIntent());
+await act(async () => root.render(<Probe surfaceKey="surface-d" revision={1} />));
+await act(async () => new Promise((resolve) => setTimeout(resolve, 60)));
+await flushFrames();
+check(recovery?.resetKey === keyBeforeIntent, "layout revision does not rebuild the size tree mid-scroll");
+await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+await flushFrames();
+check(recovery?.resetKey !== keyBeforeIntent && recovery?.resetKey.startsWith("surface-d:"), "deferred layout rebuild fires once the scroll goes quiet");
+
+// ── A user scroll gesture aborts the restore that rebuild just started
+scrollByCalls = 0;
+scrollToIndexCalls = 0;
+scrollToBottomCalls = 0;
+await act(async () => recovery?.handleItemsRendered(1));
+await flushFrames();
+check(scrollByCalls > 0 || scrollToIndexCalls > 0, "anchor restore is in flight after the deferred rebuild");
+await act(async () => recovery?.noteUserScrollIntent());
+const frozenScrollBy = scrollByCalls;
+const frozenScrollToIndex = scrollToIndexCalls;
+await flushFrames();
+await flushFrames();
+await flushFrames();
+check(scrollByCalls === frozenScrollBy && scrollToIndexCalls === frozenScrollToIndex, "a user scroll gesture aborts the in-flight restore");
+await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+
+// ── Blank detection is gated while the user scrolls, armed again at idle
+await act(async () => root.render(<Probe surfaceKey="surface-e" />));
+await flushFrames();
+const keySurfaceE = recovery?.resetKey;
+await act(async () => recovery?.noteUserScrollIntent());
+await act(async () => recovery?.scheduleBlankViewportCheck());
+await flushFrames();
+await flushFrames();
+check(recovery?.resetKey === keySurfaceE, "blank viewport during active user scrolling does not rebuild");
+await act(async () => new Promise((resolve) => setTimeout(resolve, 350)));
+await flushFrames();
+await flushFrames();
+check(recovery?.resetKey !== keySurfaceE && recovery?.resetKey.startsWith("surface-e:"), "a blank that persists into scroll idle earns a rebuild");
+
+// ── Restore waits for a slow-mounting anchor row beyond the old 8-frame budget
+await act(async () => root.render(<Probe surfaceKey="surface-f" />));
+await flushFrames();
+const keySurfaceF = recovery?.resetKey;
+await act(async () => recovery?.scheduleBlankViewportCheck());
+await flushFrames();
+await flushFrames();
+check(recovery?.resetKey !== keySurfaceF, "rebuild armed for the slow-mount restore");
+rowElement.remove();
+scrollByCalls = 0;
+scrollToIndexCalls = 0;
+await act(async () => recovery?.handleItemsRendered(1));
+for (let i = 0; i < 10; i += 1) await flushFrames();
+check(scrollToIndexCalls > 8, "restore keeps re-aiming past the old 8-frame budget while the anchor row is unmounted");
+scrollElement.appendChild(rowElement);
+rowElement.getBoundingClientRect = () => ({ top: 50, bottom: 150, height: 100, left: 0, right: 800, width: 800, x: 0, y: 50, toJSON: () => ({}) });
+await flushFrames();
+check(scrollByCalls > 0, "restore corrects once the anchor row mounts");
+rowElement.getBoundingClientRect = () => ({ top: 0, bottom: 100, height: 100, left: 0, right: 800, width: 800, x: 0, y: 0, toJSON: () => ({}) });
+await flushFrames();
+await flushFrames();
+await flushFrames();
+const settledScrollBy = scrollByCalls;
+const settledScrollToIndex = scrollToIndexCalls;
+await flushFrames();
+check(scrollByCalls === settledScrollBy && scrollToIndexCalls === settledScrollToIndex, "restore settles on the mounted anchor within the wall-clock budget");
 
 await act(async () => root.unmount());
 dom.window.close();

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -706,5 +706,32 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   eq(s.historyOlderLoading, false, "older history clears loading");
 }
 
+// ── Todo-only readiness cards retract once the list shows all complete ──────
+{
+  const args = JSON.stringify({ todos: [{ content: "Write verification notes", status: "completed" }] });
+  let s = reducer(initialState, { type: "event", e: { kind: "turn_done", outcome: "final_readiness", readiness: { missing: ["todo"], attempts: 1 } } });
+  ok(s.items.some((item) => item.kind === "notice" && item.variant === "delivery"), "todo-only readiness card shows at the gated turn");
+  s = reducer(s, { type: "event", e: { kind: "tool_dispatch", tool: { id: "tw1", name: "todo_write", args, readOnly: true } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "tw1", name: "todo_write", args, readOnly: true, output: "task list updated" } } });
+  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+  ok(!s.items.some((item) => item.kind === "notice" && item.variant === "delivery"), "an all-complete todo list retracts the stale todo-only card");
+}
+{
+  const args = JSON.stringify({ todos: [{ content: "Write verification notes", status: "completed" }] });
+  let s = reducer(initialState, { type: "event", e: { kind: "turn_done", outcome: "final_readiness", readiness: { missing: ["todo", "verification"], attempts: 1 } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_dispatch", tool: { id: "tw2", name: "todo_write", args, readOnly: true } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "tw2", name: "todo_write", args, readOnly: true, output: "task list updated" } } });
+  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+  ok(s.items.some((item) => item.kind === "notice" && item.variant === "delivery"), "a card listing non-todo gaps survives todo completion");
+}
+{
+  const args = JSON.stringify({ todos: [{ content: "Write verification notes", status: "in_progress" }] });
+  let s = reducer(initialState, { type: "event", e: { kind: "turn_done", outcome: "final_readiness", readiness: { missing: ["todo"], attempts: 1 } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_dispatch", tool: { id: "tw3", name: "todo_write", args, readOnly: true } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "tw3", name: "todo_write", args, readOnly: true, output: "task list updated" } } });
+  s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+  ok(s.items.some((item) => item.kind === "notice" && item.variant === "delivery"), "an incomplete todo list keeps the todo-only card");
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -453,7 +453,7 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   });
   liveState = reducer(liveState, {
     type: "event",
-    e: { kind: "tool_result", tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated" } },
+    e: { kind: "tool_result_preview", tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated" } },
   });
   const liveTodo = liveState.items.find(
     (item): item is Extract<Item, { kind: "tool" }> => item.kind === "tool" && item.name === "todo_write",
@@ -461,7 +461,16 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   eq(
     JSON.stringify(resolveTodoPanelTodos(liveState.meta?.canonicalTodos, liveTodo ? parseTodos(liveTodo.args) : undefined)),
     JSON.stringify(JSON.parse(liveArgs).todos),
-    "panel switches to the live todo_write snapshot after it arrives",
+    "panel switches to the live todo_write snapshot when its result preview arrives",
+  );
+  liveState = reducer(liveState, {
+    type: "event",
+    e: { kind: "tool_result", tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 4 } },
+  });
+  eq(
+    liveState.items.filter((item) => item.kind === "tool" && item.id === "todo-live").length,
+    1,
+    "provider-ordered terminal result upserts the preview instead of duplicating the card",
   );
 }
 

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { forwardRef, memo, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type TouchEvent as ReactTouchEvent, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore, type WheelEvent as ReactWheelEvent } from "react";
 import { Virtuoso, type Components, type ItemProps, type ListItem, type ListProps } from "react-virtuoso";
 import type { ControllerLiveStore, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
@@ -50,7 +50,7 @@ import { TranscriptSelectionOverlay } from "./TranscriptSelectionOverlay";
 import { useCreationTranscriptScrollbar } from "../lib/useCreationTranscriptScrollbar";
 import { useTranscriptScrollInteractions } from "../lib/useTranscriptScrollInteractions";
 import { hasTranscriptScrollableRange, TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX, useTranscriptVirtuosoScroll } from "../lib/useTranscriptVirtuosoScroll";
-import { useTranscriptVirtuosoRecovery } from "../lib/useTranscriptVirtuosoRecovery";
+import { useTranscriptVirtuosoRecovery, type TranscriptRecoveryControl } from "../lib/useTranscriptVirtuosoRecovery";
 import { TranscriptLayoutIntentProvider } from "./TranscriptLayoutIntentContext";
 import { MarkdownImageTabContext } from "./MarkdownImageContext";
 
@@ -521,13 +521,41 @@ export function Transcript({
     writeOffset,
     cancelStreamingScroll: cancelStreamingAndFollow,
   });
+  // Recovery control is bridged through a ref: these intent wrappers are
+  // created before useTranscriptVirtuosoRecovery returns its API below. User
+  // scroll intent aborts in-flight anchor restores and holds layout rebuilds
+  // until the scroll goes quiet (#8657/#8688 follow-up).
+  const recoveryControlRef = useRef<TranscriptRecoveryControl | null>(null);
+  const notifyRecoveryScrollIntent = useCallback(() => {
+    recoveryControlRef.current?.noteUserScrollIntent();
+  }, []);
+  const onWheelIntentWithRecovery = useCallback((event: ReactWheelEvent<HTMLElement>) => {
+    notifyRecoveryScrollIntent();
+    return onWheelIntent(event);
+  }, [notifyRecoveryScrollIntent, onWheelIntent]);
+  const onTouchStartIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
+    notifyRecoveryScrollIntent();
+    onTouchStartIntent(event);
+  }, [notifyRecoveryScrollIntent, onTouchStartIntent]);
+  const onTouchMoveIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
+    notifyRecoveryScrollIntent();
+    return onTouchMoveIntent(event);
+  }, [notifyRecoveryScrollIntent, onTouchMoveIntent]);
+  const onKeyScrollIntentWithRecovery = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
+    notifyRecoveryScrollIntent();
+    return onKeyScrollIntent(event);
+  }, [notifyRecoveryScrollIntent, onKeyScrollIntent]);
+  const onPointerDownIntentWithRecovery = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    notifyRecoveryScrollIntent();
+    return onPointerDownIntent(event);
+  }, [notifyRecoveryScrollIntent, onPointerDownIntent]);
   const scrollInteractions = useTranscriptScrollInteractions({
     scrollRef,
     cancelStreamingScroll: cancelStreamingAutoScroll,
-    onWheelIntent,
-    onTouchMoveIntent,
-    onKeyScrollIntent,
-    onPointerDownIntent,
+    onWheelIntent: onWheelIntentWithRecovery,
+    onTouchMoveIntent: onTouchMoveIntentWithRecovery,
+    onKeyScrollIntent: onKeyScrollIntentWithRecovery,
+    onPointerDownIntent: onPointerDownIntentWithRecovery,
     onNestedScrollIntent,
     onScrollEnd: finishProgrammaticScroll,
     onSelectionPointerDown: selectionRetention.onPointerDownCapture,
@@ -539,6 +567,8 @@ export function Transcript({
     handleItemsRendered: handleRecoveryItemsRendered,
     scheduleBlankViewportCheck,
     invalidateAnchors,
+    noteUserScrollIntent,
+    noteScrollActivity,
   } = useTranscriptVirtuosoRecovery({
     surfaceKey: layoutSurfaceKey,
     historyLayoutRevision,
@@ -550,6 +580,7 @@ export function Transcript({
     readyRef: virtuosoReadyRef,
     scrollToBottom,
   });
+  recoveryControlRef.current = { noteUserScrollIntent, invalidateAnchors };
   const heightEstimates = useMemo(() => virtualRows.map((row) => estimateTranscriptRowSize(row)), [virtualRows]);
   const overlayRevision = useMemo(
     () => virtualRows.map((row) => String(row.key)).join("|"),
@@ -560,9 +591,10 @@ export function Transcript({
     entranceRef.current = node instanceof HTMLElement ? node as HTMLDivElement : null;
   }, [entranceRef, scrollerRef]);
   const handleTranscriptScroll = useCallback(() => {
+    noteScrollActivity();
     if (creationMode) handleCreationScroll();
     scheduleBlankViewportCheck();
-  }, [creationMode, handleCreationScroll, scheduleBlankViewportCheck]);
+  }, [creationMode, handleCreationScroll, noteScrollActivity, scheduleBlankViewportCheck]);
   // ── JumpBar integration ───────────────────────────────────────────────────
   const handleJumpToQuestion = useCallback((question: QuestionAnchor) => {
     const index = rowIndexByKey.get(String(userRowKey(question.id)));
@@ -903,7 +935,7 @@ export function Transcript({
             itemContent={renderVirtuosoRow}
             onScroll={handleTranscriptScroll}
             onWheelCapture={scrollInteractions.onWheelCapture}
-            onTouchStartCapture={onTouchStartIntent}
+            onTouchStartCapture={onTouchStartIntentWithRecovery}
             onTouchMoveCapture={scrollInteractions.onTouchMoveCapture}
             onKeyDownCapture={scrollInteractions.onKeyDownCapture}
             onPointerDownCapture={scrollInteractions.onPointerDownCapture}

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -579,6 +579,7 @@ export function Transcript({
     virtuosoRef,
     readyRef: virtuosoReadyRef,
     scrollToBottom,
+    holdRevisionResets: liveSplit.liveActive,
   });
   recoveryControlRef.current = { noteUserScrollIntent, invalidateAnchors };
   const heightEstimates = useMemo(() => virtualRows.map((row) => estimateTranscriptRowSize(row)), [virtualRows]);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -13,6 +13,7 @@ export type EventKind =
   | "message"
   | "tool_dispatch"
   | "tool_result"
+  | "tool_result_preview"
   | "tool_progress"
   | "usage"
   | "notice"

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -72,7 +72,7 @@ export const SUBAGENT_PROGRESS_NOTICE = "reasonix.subagent.notice";
 // Reserved names are matched by prefix so a future channel never falls back
 // to ordinary tool output on older frontends.
 const SUBAGENT_PROGRESS_PREFIX = "reasonix.subagent.";
-const TURN_ACTIVITY_KINDS = new Set(["turn_started", "text", "reasoning", "message", "tool_dispatch", "tool_progress", "tool_result"]);
+const TURN_ACTIVITY_KINDS = new Set(["turn_started", "text", "reasoning", "message", "tool_dispatch", "tool_progress", "tool_result_preview", "tool_result"]);
 const SUBAGENT_PROGRESS_PHASES = new Set([
   "queued", "running", "reasoning", "responding", "tool", "retrying", "completed", "failed", "cancelled",
 ]);
@@ -1595,7 +1595,7 @@ function applyEvent(s: State, e: WireEvent): State {
       if (t.parentId) touchSubagentParent(items, t.parentId);
       return { ...settled, seq: settled.seq + 1, items };
     }
-    case "tool_result": {
+    case "tool_result_preview": case "tool_result": {
       const t = e.tool;
       if (!t) return s;
       const next = [...s.items];

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -26,7 +26,7 @@ import { sameStringList, sameTodoList } from "./todoVisibility";
 import { useStaleTurnWatchdog } from "./useStaleTurnWatchdog";
 import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
-import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
+import { fileDiffFromWire, parseTodos, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
 import { modeHasAutoApproveTools, normalizeMode, normalizeToolApprovalMode } from "./types";
 import type {
   BalanceInfo,
@@ -235,7 +235,7 @@ export type Item =
   | { kind: "user"; id: string; submissionId?: string; text: string; submitText?: string; failed?: boolean; createdAt?: number; checkpointTurn?: number }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean; reasoningComplete?: boolean; reasoningDurationMs?: number; workDurationMs?: number; memoryCitations?: MemoryCitation[]; searchSources?: SearchSource[] }
   | { kind: "phase"; id: string; text: string }
-  | { kind: "notice"; id: string; level: "info" | "warn"; text: string; detail?: string; title?: string; variant?: "delivery" | "completion"; action?: "continue_delivery" | "open_changes"; decisionReceipt?: WireDecisionReceipt }
+  | { kind: "notice"; id: string; level: "info" | "warn"; text: string; detail?: string; title?: string; variant?: "delivery" | "completion"; action?: "continue_delivery" | "open_changes"; decisionReceipt?: WireDecisionReceipt; missing?: string[] }
   | {
       kind: "compaction";
       id: string;
@@ -867,6 +867,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           text: t("notice.deliveryIncompleteBody"),
           detail: deliveryReadinessDetail(m.readiness),
           action: "continue_delivery",
+          missing: readinessMissingIds(m.readiness),
         });
         seq++;
         continue;
@@ -1819,9 +1820,15 @@ function applyEvent(s: State, e: WireEvent): State {
         if (it.kind === "tool" && it.status === "running") return { ...it, status: "stopped" as const };
         return it;
       });
-      let items: Item[] = s.deliveryRecoveryActive && !e.err
-        ? finalized.filter((item) => item.kind !== "notice" || item.variant !== "delivery")
-        : finalized;
+      // A todo-only readiness card is retracted once the turn's own items
+      // show an all-complete todo list (the panel is already green).
+      const todoGapResolved = !e.err && latestTodosAllComplete(finalized);
+      let items: Item[] = finalized;
+      if (s.deliveryRecoveryActive && !e.err) {
+        items = finalized.filter((item) => item.kind !== "notice" || item.variant !== "delivery");
+      } else if (todoGapResolved) {
+        items = finalized.filter((item) => item.kind !== "notice" || item.variant !== "delivery" || !todoOnlyMissing(item.missing));
+      }
       if (e.outcome === "final_readiness") {
         const previous = items.map((item) => item.kind === "notice" && item.variant === "delivery"
           ? { ...item, action: undefined }
@@ -1835,6 +1842,7 @@ function applyEvent(s: State, e: WireEvent): State {
           text: t("notice.deliveryIncompleteBody"),
           detail: deliveryReadinessDetail(e.readiness, e.err),
           action: "continue_delivery",
+          missing: readinessMissingIds(e.readiness),
         }];
       } else if (e.outcome === "recovery_paused") {
         // Informational pause — not a send failure. Composer is immediately free.
@@ -2305,6 +2313,27 @@ const deliveryRequirementKeys: Record<string, DictKey> = {
   mutation: "notice.deliveryRequirementMutation",
   capability: "notice.deliveryRequirementCapability",
 };
+
+export function readinessMissingIds(readiness: WireFinalReadiness | undefined): string[] {
+  return asArray(readiness?.missing).map((id) => String(id));
+}
+
+// A delivery notice whose only gap was unfinished todos becomes stale the
+// moment the list shows every item completed.
+function todoOnlyMissing(missing: string[] | undefined): boolean {
+  return Array.isArray(missing) && missing.length > 0 && missing.every((id) => id === "todo");
+}
+
+function latestTodosAllComplete(items: Item[]): boolean {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (item.kind === "tool" && item.name === "todo_write" && !item.parentId && item.status === "done" && !item.error) {
+      const todos = parseTodos(item.args);
+      return todos.length > 0 && todos.every((todo) => String(todo.status ?? "").trim() === "completed");
+    }
+  }
+  return false;
+}
 
 export function deliveryReadinessDetail(readiness: WireFinalReadiness | undefined, fallback = ""): string {
   const labels = asArray(readiness?.missing)

--- a/desktop/frontend/src/lib/useTranscriptVirtuosoRecovery.ts
+++ b/desktop/frontend/src/lib/useTranscriptVirtuosoRecovery.ts
@@ -11,6 +11,22 @@ import {
 
 const LAYOUT_INVALIDATION_BATCH_MS = 48;
 const BLANK_RECOVERY_COOLDOWN_MS = 2_000;
+// A viewport that blanks while the user is actively scrolling is almost always
+// a transient mount lag (slow renderer outrunning the fling), not a broken
+// size tree. Resets wait for the scroll to go quiet; only a blank that
+// survives into idle earns a rebuild.
+const USER_SCROLL_IDLE_MS = 320;
+// Anchor restores wait for the anchor row to actually mount. An 8-frame
+// budget (~128 ms) expired before heavy rows mounted on WebView2, stranding
+// the view at the estimate-based (higher) scrollToIndex landing — the
+// scroll-down/snap-up loop. Bound by wall clock instead.
+const ANCHOR_RESTORE_BUDGET_MS = 1_000;
+
+/** User-scroll signals the Transcript wires into its intent handlers. */
+export type TranscriptRecoveryControl = {
+  noteUserScrollIntent: () => void;
+  invalidateAnchors: () => void;
+};
 
 /** Rebuilds stale Virtuoso size trees while preserving the logical viewport. */
 export function useTranscriptVirtuosoRecovery({
@@ -43,6 +59,10 @@ export function useTranscriptVirtuosoRecovery({
   const stableManualAnchorRef = useRef<Extract<TranscriptLayoutAnchor, { mode: "manual" }> | null>(null);
   const lastBlankRecoveryRef = useRef("");
   const lastBlankRecoveryAtRef = useRef(0);
+  const userScrollActiveRef = useRef(false);
+  const userScrollIdleTimerRef = useRef<number | null>(null);
+  const deferredLayoutResetRef = useRef(false);
+  const deferredResetTimerRef = useRef<number | null>(null);
   latestRevisionRef.current = historyLayoutRevision;
 
   useEffect(() => {
@@ -51,15 +71,23 @@ export function useTranscriptVirtuosoRecovery({
     stableManualAnchorRef.current = null;
     lastBlankRecoveryRef.current = "";
     lastBlankRecoveryAtRef.current = 0;
+    userScrollActiveRef.current = false;
+    deferredLayoutResetRef.current = false;
     if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
     if (blankCheckFrameRef.current !== null) cancelAnimationFrame(blankCheckFrameRef.current);
+    if (userScrollIdleTimerRef.current !== null) window.clearTimeout(userScrollIdleTimerRef.current);
+    if (deferredResetTimerRef.current !== null) window.clearTimeout(deferredResetTimerRef.current);
     resetTimerRef.current = null;
     blankCheckFrameRef.current = null;
+    userScrollIdleTimerRef.current = null;
+    deferredResetTimerRef.current = null;
   }, [surfaceKey]);
 
   useEffect(() => () => {
     if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
     if (blankCheckFrameRef.current !== null) cancelAnimationFrame(blankCheckFrameRef.current);
+    if (userScrollIdleTimerRef.current !== null) window.clearTimeout(userScrollIdleTimerRef.current);
+    if (deferredResetTimerRef.current !== null) window.clearTimeout(deferredResetTimerRef.current);
   }, []);
 
   const requestReset = useCallback((): boolean => {
@@ -91,6 +119,11 @@ export function useTranscriptVirtuosoRecovery({
         // A previous rebuild may still be restoring its anchor. Retry instead
         // of dropping a later lazy-content invalidation in that narrow window.
         resetTimerRef.current = window.setTimeout(flush, LAYOUT_INVALIDATION_BATCH_MS);
+        return;
+      }
+      if (userScrollActiveRef.current) {
+        // Never swap the floor mid-scroll: rebuild once the fling goes quiet.
+        deferredLayoutResetRef.current = true;
         return;
       }
       // If the surface disappeared during the batch window, there is nothing
@@ -129,6 +162,7 @@ export function useTranscriptVirtuosoRecovery({
     blankCheckFrameRef.current = requestAnimationFrame(() => {
       blankCheckFrameRef.current = requestAnimationFrame(() => {
         blankCheckFrameRef.current = null;
+        if (userScrollActiveRef.current) return;
         const element = scrollRef.current;
         if (!element || !transcriptElementViewportIsBlank(element)) return;
         // Dedup on surface + content revision only. scrollTop drifts
@@ -145,6 +179,61 @@ export function useTranscriptVirtuosoRecovery({
     });
   }, [historyLayoutRevision, pinnedRef, requestReset, scrollRef, surfaceKey]);
 
+  // Runs when user-driven scrolling has been quiet for USER_SCROLL_IDLE_MS:
+  // flush a layout rebuild deferred mid-scroll, then re-check the viewport —
+  // a blank that persists into idle is genuine breakage, not mount lag.
+  const handleUserScrollIdle = useCallback(function handleIdle() {
+    userScrollActiveRef.current = false;
+    if (deferredLayoutResetRef.current) {
+      deferredLayoutResetRef.current = false;
+      if (appliedRevisionRef.current !== latestRevisionRef.current) {
+        if (pendingAnchorRef.current?.surfaceKey === surfaceKey) {
+          // A restore is still in flight; retry shortly instead of stacking a
+          // second reset on top of it.
+          deferredLayoutResetRef.current = true;
+          if (deferredResetTimerRef.current !== null) window.clearTimeout(deferredResetTimerRef.current);
+          deferredResetTimerRef.current = window.setTimeout(() => {
+            deferredResetTimerRef.current = null;
+            handleIdle();
+          }, LAYOUT_INVALIDATION_BATCH_MS);
+          return;
+        }
+        // Anchor captures pause once a revision is pending; refresh from the
+        // user's resting position so the rebuild restores where they stopped.
+        const element = scrollRef.current;
+        const fresh = element ? captureTranscriptLayoutAnchor(element, pinnedRef.current) : undefined;
+        if (fresh?.mode === "manual") stableManualAnchorRef.current = fresh;
+        else if (fresh?.mode === "tail") stableManualAnchorRef.current = null;
+        requestReset();
+        appliedRevisionRef.current = latestRevisionRef.current;
+      }
+    }
+    scheduleBlankViewportCheck();
+  }, [pinnedRef, requestReset, scheduleBlankViewportCheck, scrollRef, surfaceKey]);
+
+  const armUserScrollIdleTimer = useCallback(() => {
+    if (userScrollIdleTimerRef.current !== null) window.clearTimeout(userScrollIdleTimerRef.current);
+    userScrollIdleTimerRef.current = window.setTimeout(() => {
+      userScrollIdleTimerRef.current = null;
+      handleUserScrollIdle();
+    }, USER_SCROLL_IDLE_MS);
+  }, [handleUserScrollIdle]);
+
+  // Wheel/touch/keyboard/pointer intent is explicit user scroll intent: it
+  // aborts any in-flight recovery restore (user intent > recovery) and holds
+  // layout rebuilds until the scroll goes quiet (#8657/#8688 follow-up).
+  const noteUserScrollIntent = useCallback(() => {
+    userScrollActiveRef.current = true;
+    invalidateAnchors();
+    armUserScrollIdleTimer();
+  }, [armUserScrollIdleTimer, invalidateAnchors]);
+
+  // Scroll events after an intent keep the active window alive; programmatic
+  // scrolls (tail follow, restores) never arm it on their own.
+  const noteScrollActivity = useCallback(() => {
+    if (userScrollActiveRef.current) armUserScrollIdleTimer();
+  }, [armUserScrollIdleTimer]);
+
   const restoreAnchor = useCallback((anchor: TranscriptLayoutAnchor) => {
     if (pendingAnchorRef.current?.surfaceKey !== surfaceKey) return;
     if (anchor.mode === "tail") {
@@ -152,7 +241,8 @@ export function useTranscriptVirtuosoRecovery({
       scrollToBottom();
       return;
     }
-    const restore = (remainingAttempts: number, stableFrames: number) => {
+    const deadline = Date.now() + ANCHOR_RESTORE_BUDGET_MS;
+    const restore = (stableFrames: number) => {
       if (pendingAnchorRef.current?.surfaceKey !== surfaceKey) return;
       const element = scrollRef.current;
       if (!element) {
@@ -161,28 +251,31 @@ export function useTranscriptVirtuosoRecovery({
       }
       const row = Array.from(element.querySelectorAll<HTMLElement>(".transcript__row[data-row-key]"))
         .find((candidate) => candidate.dataset.rowKey === anchor.rowKey);
-      if (!row && remainingAttempts > 0) {
+      if (!row) {
+        // Heavy rows can take far longer than a few frames to mount after a
+        // rebuild on slow renderers. Keep re-aiming until the wall-clock
+        // budget expires; a user gesture drops the anchor instead (#8657/#8688).
+        if (Date.now() >= deadline) {
+          pendingAnchorRef.current = null;
+          return;
+        }
         const location = transcriptAnchorInitialLocation(anchor, rowIndexByKey, firstItemIndex);
         if (location) virtuosoRef.current?.scrollToIndex(location);
-        requestAnimationFrame(() => restore(remainingAttempts - 1, 0));
-        return;
-      }
-      if (!row) {
-        pendingAnchorRef.current = null;
+        requestAnimationFrame(() => restore(0));
         return;
       }
       const viewportTop = element.getBoundingClientRect().top;
       const correction = row.getBoundingClientRect().top - viewportTop - anchor.offset;
       if (Math.abs(correction) > 1) virtuosoRef.current?.scrollBy({ top: correction, behavior: "auto" });
       const nextStableFrames = Math.abs(correction) <= 1 ? stableFrames + 1 : 0;
-      if (remainingAttempts > 0 && nextStableFrames < 2) {
-        requestAnimationFrame(() => restore(remainingAttempts - 1, nextStableFrames));
+      if (Date.now() < deadline && nextStableFrames < 2) {
+        requestAnimationFrame(() => restore(nextStableFrames));
         return;
       }
       pendingAnchorRef.current = null;
       stableManualAnchorRef.current = anchor;
     };
-    requestAnimationFrame(() => restore(8, 0));
+    requestAnimationFrame(() => restore(0));
   }, [firstItemIndex, rowIndexByKey, scrollRef, scrollToBottom, virtuosoRef]);
 
   const handleItemsRendered = useCallback((renderedCount: number) => {
@@ -202,5 +295,7 @@ export function useTranscriptVirtuosoRecovery({
     handleItemsRendered,
     scheduleBlankViewportCheck,
     invalidateAnchors,
+    noteUserScrollIntent,
+    noteScrollActivity,
   };
 }

--- a/desktop/frontend/src/lib/useTranscriptVirtuosoRecovery.ts
+++ b/desktop/frontend/src/lib/useTranscriptVirtuosoRecovery.ts
@@ -21,6 +21,10 @@ const USER_SCROLL_IDLE_MS = 320;
 // the view at the estimate-based (higher) scrollToIndex landing — the
 // scroll-down/snap-up loop. Bound by wall clock instead.
 const ANCHOR_RESTORE_BUDGET_MS = 1_000;
+// Ref-resolution patch bursts (session open, stream end) each bump the layout
+// revision; rebuilding the size tree per patch is a remount storm. Coalesce
+// revision-driven rebuilds to at most one per interval.
+const REVISION_RESET_MIN_INTERVAL_MS = 600;
 
 /** User-scroll signals the Transcript wires into its intent handlers. */
 export type TranscriptRecoveryControl = {
@@ -39,6 +43,7 @@ export function useTranscriptVirtuosoRecovery({
   virtuosoRef,
   readyRef,
   scrollToBottom,
+  holdRevisionResets = false,
 }: {
   surfaceKey: string;
   historyLayoutRevision: number;
@@ -49,6 +54,12 @@ export function useTranscriptVirtuosoRecovery({
   virtuosoRef: RefObject<VirtuosoHandle | null>;
   readyRef: RefObject<boolean>;
   scrollToBottom: () => void;
+  // While true (the turn is streaming), revision-driven rebuilds are deferred:
+  // a mid-stream remount snaps a tail-following view up to the last history
+  // row because the live footer is not part of the restored frame, and it
+  // blanks the region a history-reading user is looking at. One rebuild runs
+  // when the stream ends.
+  holdRevisionResets?: boolean;
 }) {
   const [resetEpoch, setResetEpoch] = useState(0);
   const appliedRevisionRef = useRef(historyLayoutRevision);
@@ -63,6 +74,9 @@ export function useTranscriptVirtuosoRecovery({
   const userScrollIdleTimerRef = useRef<number | null>(null);
   const deferredLayoutResetRef = useRef(false);
   const deferredResetTimerRef = useRef<number | null>(null);
+  const lastRevisionResetAtRef = useRef(0);
+  const holdRevisionResetsRef = useRef(holdRevisionResets);
+  holdRevisionResetsRef.current = holdRevisionResets;
   latestRevisionRef.current = historyLayoutRevision;
 
   useEffect(() => {
@@ -73,6 +87,7 @@ export function useTranscriptVirtuosoRecovery({
     lastBlankRecoveryAtRef.current = 0;
     userScrollActiveRef.current = false;
     deferredLayoutResetRef.current = false;
+    lastRevisionResetAtRef.current = 0;
     if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
     if (blankCheckFrameRef.current !== null) cancelAnimationFrame(blankCheckFrameRef.current);
     if (userScrollIdleTimerRef.current !== null) window.clearTimeout(userScrollIdleTimerRef.current);
@@ -110,33 +125,62 @@ export function useTranscriptVirtuosoRecovery({
     stableManualAnchorRef.current = null;
   }, []);
 
+  // Single attempt path for revision-driven rebuilds. Every gate either
+  // settles the defer marker (already applied / reset issued) or leaves it
+  // set for the next trigger — scroll idle, streaming-hold lift, or the
+  // retry timer armed below.
+  const flushDeferredLayoutReset = useCallback(function flushDeferred() {
+    if (!deferredLayoutResetRef.current) return;
+    if (appliedRevisionRef.current === latestRevisionRef.current) {
+      deferredLayoutResetRef.current = false;
+      return;
+    }
+    if (userScrollActiveRef.current || holdRevisionResetsRef.current) return;
+    if (deferredResetTimerRef.current !== null) window.clearTimeout(deferredResetTimerRef.current);
+    if (pendingAnchorRef.current?.surfaceKey === surfaceKey) {
+      // A restore is still in flight; retry shortly instead of stacking a
+      // second reset on top of it.
+      deferredResetTimerRef.current = window.setTimeout(() => {
+        deferredResetTimerRef.current = null;
+        flushDeferred();
+      }, LAYOUT_INVALIDATION_BATCH_MS);
+      return;
+    }
+    const sinceLastReset = Date.now() - lastRevisionResetAtRef.current;
+    if (sinceLastReset < REVISION_RESET_MIN_INTERVAL_MS) {
+      // Patch bursts (session open, stream end) each bump the revision;
+      // coalesce their rebuilds instead of remounting per patch.
+      deferredResetTimerRef.current = window.setTimeout(() => {
+        deferredResetTimerRef.current = null;
+        flushDeferred();
+      }, REVISION_RESET_MIN_INTERVAL_MS - sinceLastReset);
+      return;
+    }
+    // Anchor captures pause once a revision is pending; refresh from the
+    // user's resting position so the rebuild restores where they stopped.
+    const element = scrollRef.current;
+    const fresh = element ? captureTranscriptLayoutAnchor(element, pinnedRef.current) : undefined;
+    if (fresh?.mode === "manual") stableManualAnchorRef.current = fresh;
+    else if (fresh?.mode === "tail") stableManualAnchorRef.current = null;
+    deferredLayoutResetRef.current = false;
+    if (requestReset()) lastRevisionResetAtRef.current = Date.now();
+    appliedRevisionRef.current = latestRevisionRef.current;
+  }, [pinnedRef, requestReset, scrollRef, surfaceKey]);
+
   useEffect(() => {
     if (appliedRevisionRef.current === historyLayoutRevision) return;
     if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
     const flush = () => {
       resetTimerRef.current = null;
-      if (pendingAnchorRef.current?.surfaceKey === surfaceKey) {
-        // A previous rebuild may still be restoring its anchor. Retry instead
-        // of dropping a later lazy-content invalidation in that narrow window.
-        resetTimerRef.current = window.setTimeout(flush, LAYOUT_INVALIDATION_BATCH_MS);
-        return;
-      }
-      if (userScrollActiveRef.current) {
-        // Never swap the floor mid-scroll: rebuild once the fling goes quiet.
-        deferredLayoutResetRef.current = true;
-        return;
-      }
-      // If the surface disappeared during the batch window, there is nothing
-      // left to rebuild. Mark the revision consumed rather than polling forever.
-      requestReset();
-      appliedRevisionRef.current = historyLayoutRevision;
+      deferredLayoutResetRef.current = true;
+      flushDeferredLayoutReset();
     };
     resetTimerRef.current = window.setTimeout(flush, LAYOUT_INVALIDATION_BATCH_MS);
     return () => {
       if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
       resetTimerRef.current = null;
     };
-  }, [historyLayoutRevision, requestReset, surfaceKey]);
+  }, [historyLayoutRevision, flushDeferredLayoutReset, surfaceKey]);
 
   const resetKey = `${surfaceKey}:${resetEpoch}`;
   const firstItemIndex = useTranscriptVirtuosoFirstItemIndex(rows, resetKey);
@@ -182,34 +226,11 @@ export function useTranscriptVirtuosoRecovery({
   // Runs when user-driven scrolling has been quiet for USER_SCROLL_IDLE_MS:
   // flush a layout rebuild deferred mid-scroll, then re-check the viewport —
   // a blank that persists into idle is genuine breakage, not mount lag.
-  const handleUserScrollIdle = useCallback(function handleIdle() {
+  const handleUserScrollIdle = useCallback(() => {
     userScrollActiveRef.current = false;
-    if (deferredLayoutResetRef.current) {
-      deferredLayoutResetRef.current = false;
-      if (appliedRevisionRef.current !== latestRevisionRef.current) {
-        if (pendingAnchorRef.current?.surfaceKey === surfaceKey) {
-          // A restore is still in flight; retry shortly instead of stacking a
-          // second reset on top of it.
-          deferredLayoutResetRef.current = true;
-          if (deferredResetTimerRef.current !== null) window.clearTimeout(deferredResetTimerRef.current);
-          deferredResetTimerRef.current = window.setTimeout(() => {
-            deferredResetTimerRef.current = null;
-            handleIdle();
-          }, LAYOUT_INVALIDATION_BATCH_MS);
-          return;
-        }
-        // Anchor captures pause once a revision is pending; refresh from the
-        // user's resting position so the rebuild restores where they stopped.
-        const element = scrollRef.current;
-        const fresh = element ? captureTranscriptLayoutAnchor(element, pinnedRef.current) : undefined;
-        if (fresh?.mode === "manual") stableManualAnchorRef.current = fresh;
-        else if (fresh?.mode === "tail") stableManualAnchorRef.current = null;
-        requestReset();
-        appliedRevisionRef.current = latestRevisionRef.current;
-      }
-    }
+    flushDeferredLayoutReset();
     scheduleBlankViewportCheck();
-  }, [pinnedRef, requestReset, scheduleBlankViewportCheck, scrollRef, surfaceKey]);
+  }, [flushDeferredLayoutReset, scheduleBlankViewportCheck]);
 
   const armUserScrollIdleTimer = useCallback(() => {
     if (userScrollIdleTimerRef.current !== null) window.clearTimeout(userScrollIdleTimerRef.current);
@@ -233,6 +254,14 @@ export function useTranscriptVirtuosoRecovery({
   const noteScrollActivity = useCallback(() => {
     if (userScrollActiveRef.current) armUserScrollIdleTimer();
   }, [armUserScrollIdleTimer]);
+
+  // Stream end lifts the revision hold: run the rebuild deferred mid-stream,
+  // unless the user is mid-scroll (the idle handler owns that flush).
+  useEffect(() => {
+    if (holdRevisionResets) return;
+    if (userScrollActiveRef.current) return;
+    flushDeferredLayoutReset();
+  }, [holdRevisionResets, flushDeferredLayoutReset]);
 
   const restoreAnchor = useCallback((anchor: TranscriptLayoutAnchor) => {
     if (pendingAnchorRef.current?.surfaceKey !== surfaceKey) return;

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1785,7 +1785,7 @@ func (e *asyncRuntimeEmitter) run() {
 
 func topicActivityStatusFromEvent(e event.Event) (string, bool) {
 	switch e.Kind {
-	case event.TurnStarted, event.Reasoning, event.ToolDispatch, event.ToolProgress, event.ToolResult, event.CompactionStarted, event.CompactionDone, event.Retrying:
+	case event.TurnStarted, event.Reasoning, event.ToolDispatch, event.ToolProgress, event.ToolResultPreview, event.ToolResult, event.CompactionStarted, event.CompactionDone, event.Retrying:
 		return topicStatusThinking, true
 	case event.Text, event.Message:
 		return topicStatusStreaming, true

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1475,6 +1475,7 @@ func (a *Agent) rebuildTodoState(msgs []provider.Message) {
 		}
 	}
 	a.setTodoState(todos)
+	a.consumeTodoOnlyReadinessMarkerIfResolved()
 }
 
 func successfulToolCallIDs(msgs []provider.Message) map[string]bool {

--- a/internal/agent/final_readiness_recovery_test.go
+++ b/internal/agent/final_readiness_recovery_test.go
@@ -110,3 +110,91 @@ func TestFinalReadinessRecoveryRejectsStaleMarkerAfterUserTurn(t *testing.T) {
 		t.Fatal("stale readiness marker after a newer user turn must be rejected")
 	}
 }
+
+func TestTodoOnlyReadinessMarkerConsumedOnReloadWhenTodosComplete(t *testing.T) {
+	session := NewSession("sys")
+	// A completed todo list already lives in the transcript, and a todo-only
+	// readiness marker is still pending (the gated turn was the last one).
+	session.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+		{ID: "todo-done", Name: "todo_write", Arguments: `{"todos":[{"content":"Write verification notes","status":"completed"}]}`},
+	}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "todo-done", Content: "task list updated"})
+	session.Add(provider.Message{
+		Role:       provider.RoleTool,
+		ToolCallID: provider.LocalOnlyToolID,
+		Name:       provider.LocalOnlyToolName,
+		LocalOnly:  true,
+		FinalReadinessRecovery: &provider.FinalReadinessRecovery{
+			Pending: true,
+			Missing: []string{"todo"},
+		},
+	})
+
+	reloaded := New(nil, evidenceRegistry(), session, Options{}, event.Discard)
+	reloaded.SetSession(session)
+	for _, message := range session.Snapshot() {
+		if message.FinalReadinessRecovery != nil && message.FinalReadinessRecovery.Pending {
+			t.Fatal("todo-only readiness marker stayed pending after the rebuilt canonical list showed every todo complete")
+		}
+	}
+}
+
+func TestReadinessMarkerSurvivesReloadWhenGapExceedsTodos(t *testing.T) {
+	session := NewSession("sys")
+	session.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+		{ID: "todo-done", Name: "todo_write", Arguments: `{"todos":[{"content":"Write verification notes","status":"completed"}]}`},
+	}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "todo-done", Content: "task list updated"})
+	session.Add(provider.Message{
+		Role:       provider.RoleTool,
+		ToolCallID: provider.LocalOnlyToolID,
+		Name:       provider.LocalOnlyToolName,
+		LocalOnly:  true,
+		FinalReadinessRecovery: &provider.FinalReadinessRecovery{
+			Pending: true,
+			Missing: []string{"todo", "verification"},
+		},
+	})
+
+	reloaded := New(nil, evidenceRegistry(), session, Options{}, event.Discard)
+	reloaded.SetSession(session)
+	pending := 0
+	for _, message := range session.Snapshot() {
+		if message.FinalReadinessRecovery != nil && message.FinalReadinessRecovery.Pending {
+			pending++
+		}
+	}
+	if pending != 1 {
+		t.Fatalf("pending markers = %d, want 1: a marker listing non-todo gaps must survive", pending)
+	}
+}
+
+func TestTodoOnlyReadinessMarkerSurvivesReloadWhileTodosIncomplete(t *testing.T) {
+	session := NewSession("sys")
+	session.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+		{ID: "todo-open", Name: "todo_write", Arguments: `{"todos":[{"content":"Write verification notes","status":"in_progress"}]}`},
+	}})
+	session.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "todo-open", Content: "task list updated"})
+	session.Add(provider.Message{
+		Role:       provider.RoleTool,
+		ToolCallID: provider.LocalOnlyToolID,
+		Name:       provider.LocalOnlyToolName,
+		LocalOnly:  true,
+		FinalReadinessRecovery: &provider.FinalReadinessRecovery{
+			Pending: true,
+			Missing: []string{"todo"},
+		},
+	})
+
+	reloaded := New(nil, evidenceRegistry(), session, Options{}, event.Discard)
+	reloaded.SetSession(session)
+	pending := 0
+	for _, message := range session.Snapshot() {
+		if message.FinalReadinessRecovery != nil && message.FinalReadinessRecovery.Pending {
+			pending++
+		}
+	}
+	if pending != 1 {
+		t.Fatalf("pending markers = %d, want 1: incomplete todos keep the marker actionable", pending)
+	}
+}

--- a/internal/agent/nested_sink.go
+++ b/internal/agent/nested_sink.go
@@ -19,7 +19,7 @@ type nestedSink struct {
 
 func (s nestedSink) Emit(e event.Event) {
 	switch e.Kind {
-	case event.ToolDispatch, event.ToolResult, event.ToolProgress:
+	case event.ToolDispatch, event.ToolResult, event.ToolProgress, event.ToolResultPreview:
 		e.Tool.ParentID = s.parentID
 		e.Tool.ID = s.parentID + "/" + e.Tool.ID
 		s.parent.Emit(e)

--- a/internal/agent/todo_state.go
+++ b/internal/agent/todo_state.go
@@ -34,6 +34,32 @@ func (a *Agent) CanonicalTodoState() []evidence.TodoItem {
 	return append([]evidence.TodoItem(nil), a.sess.todoState...)
 }
 
+// consumeTodoOnlyReadinessMarkerIfResolved retires a pending final-readiness
+// marker whose only gap was unfinished todos once the canonical list shows
+// every item completed, so a reload no longer replays the stale wrap-up card.
+// In-turn consumption stays with beginFinalReadinessRecovery (next user turn).
+func (a *Agent) consumeTodoOnlyReadinessMarkerIfResolved() {
+	if a == nil || a.sess.conversation == nil {
+		return
+	}
+	a.sess.todoMu.Lock()
+	state := append([]evidence.TodoItem(nil), a.sess.todoState...)
+	a.sess.todoMu.Unlock()
+	if len(state) == 0 || len(evidence.IncompleteTodos(state)) > 0 {
+		return
+	}
+	marker := a.pendingFinalReadinessRecovery()
+	if marker == nil || len(marker.Missing) == 0 {
+		return
+	}
+	for _, id := range marker.Missing {
+		if id != "todo" {
+			return
+		}
+	}
+	a.sess.conversation.ConsumeFinalReadinessRecovery()
+}
+
 func (a *Agent) incompleteCanonicalTodos() ([]evidence.TodoStepMatch, bool) {
 	a.sess.todoMu.Lock()
 	defer a.sess.todoMu.Unlock()

--- a/internal/agent/tool_receipts.go
+++ b/internal/agent/tool_receipts.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	"reasonix/internal/evidence"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
@@ -14,6 +16,20 @@ func (a *Agent) finalizeObservedToolReceipts(plan *toolCallPlan, result string, 
 	a.observeAfterMutation(plan)
 	plan.mutationAfterDone = true
 	a.recordToolReceipts(plan, result, execution, err)
+}
+
+// emitEarlyTodoResult flips the todo_write card to done the moment the call
+// executes: batch ToolResult events wait for the whole provider batch, which
+// would freeze the task panel on the previous list. The batch-end emission
+// for the same call id re-emits with full metadata and lands idempotently.
+func (a *Agent) emitEarlyTodoResult(call provider.ToolCall, output string) {
+	if a == nil || a.svc.sink == nil {
+		return
+	}
+	a.svc.sink.Emit(event.Event{
+		Kind: event.ToolResult,
+		Tool: event.Tool{ID: call.ID, Name: call.Name, Args: call.Arguments, ReadOnly: true, Output: output},
+	})
 }
 
 func (a *Agent) recordToolReceipts(plan *toolCallPlan, result string, execution *tool.ShellExecution, err error) {
@@ -45,6 +61,7 @@ func (a *Agent) recordToolReceipts(plan *toolCallPlan, result string, execution 
 			if len(rec.Todos) > 0 {
 				a.turn.deliveryCriteriaEstablished = true
 			}
+			a.emitEarlyTodoResult(call, result)
 		}
 	}
 }

--- a/internal/agent/tool_receipts.go
+++ b/internal/agent/tool_receipts.go
@@ -3,8 +3,8 @@ package agent
 import (
 	"encoding/json"
 
-	"reasonix/internal/evidence"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -18,16 +18,16 @@ func (a *Agent) finalizeObservedToolReceipts(plan *toolCallPlan, result string, 
 	a.recordToolReceipts(plan, result, execution, err)
 }
 
-// emitEarlyTodoResult flips the todo_write card to done the moment the call
-// executes: batch ToolResult events wait for the whole provider batch, which
-// would freeze the task panel on the previous list. The batch-end emission
-// for the same call id re-emits with full metadata and lands idempotently.
-func (a *Agent) emitEarlyTodoResult(call provider.ToolCall, output string) {
+// emitTodoResultPreview flips the todo_write card to done the moment the call
+// executes without publishing a second terminal result. Batch ToolResult
+// events still wait for the whole provider batch and remain the only terminal
+// events observed by append-only sinks.
+func (a *Agent) emitTodoResultPreview(call provider.ToolCall, output string) {
 	if a == nil || a.svc.sink == nil {
 		return
 	}
 	a.svc.sink.Emit(event.Event{
-		Kind: event.ToolResult,
+		Kind: event.ToolResultPreview,
 		Tool: event.Tool{ID: call.ID, Name: call.Name, Args: call.Arguments, ReadOnly: true, Output: output},
 	})
 }
@@ -61,7 +61,7 @@ func (a *Agent) recordToolReceipts(plan *toolCallPlan, result string, execution 
 			if len(rec.Todos) > 0 {
 				a.turn.deliveryCriteriaEstablished = true
 			}
-			a.emitEarlyTodoResult(call, result)
+			a.emitTodoResultPreview(call, result)
 		}
 	}
 }

--- a/internal/agent/tool_receipts_test.go
+++ b/internal/agent/tool_receipts_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type toolReceiptSignalSink struct {
+	mu       sync.Mutex
+	events   []event.Event
+	previews chan event.Event
+}
+
+func (s *toolReceiptSignalSink) Emit(e event.Event) {
+	s.mu.Lock()
+	s.events = append(s.events, e)
+	s.mu.Unlock()
+	if e.Kind == event.ToolResultPreview {
+		s.previews <- e
+	}
+}
+
+func (s *toolReceiptSignalSink) kinds(kind event.Kind) []event.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []event.Event
+	for _, e := range s.events {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func TestTodoResultPreviewPreservesSingleProviderOrderedTerminalResult(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "todo_write", readOnly: true})
+	reg.Add(blockingTool{name: "slow_read", started: started, release: release})
+	sink := &toolReceiptSignalSink{previews: make(chan event.Event, 1)}
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.executeBatch(context.Background(), &a.turn, []provider.ToolCall{
+			{ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Ship the fix","status":"in_progress"}]}`},
+			{ID: "read-1", Name: "slow_read", Arguments: `{}`},
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("later tool did not start")
+	}
+	select {
+	case preview := <-sink.previews:
+		if preview.Tool.ID != "todo-1" || preview.Tool.Name != "todo_write" || preview.Tool.Err != "" {
+			t.Fatalf("todo preview = %+v", preview.Tool)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("todo result preview did not arrive while the later tool was running")
+	}
+	if results := sink.kinds(event.ToolResult); len(results) != 0 {
+		t.Fatalf("terminal ToolResult published before the batch completed: %+v", results)
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("batch did not finish after releasing the later tool")
+	}
+	if previews := sink.kinds(event.ToolResultPreview); len(previews) != 1 {
+		t.Fatalf("ToolResultPreview events = %d, want 1", len(previews))
+	}
+	results := sink.kinds(event.ToolResult)
+	if len(results) != 2 || results[0].Tool.ID != "todo-1" || results[1].Tool.ID != "read-1" {
+		t.Fatalf("provider-ordered ToolResult events = %+v", results)
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -118,6 +118,11 @@ const (
 	// CompletionSummary reports a content-free end-of-turn quality summary for
 	// role-setting strategies (preset, verdict, check counts, review status).
 	CompletionSummary
+	// ToolResultPreview reports that a tool has finished locally before its
+	// provider-ordered ToolResult can be emitted. Upsert-capable frontends may
+	// render the successful state early; append-only consumers should ignore it.
+	// The later ToolResult remains the call's only terminal event.
+	ToolResultPreview
 	// KindCount is a sentinel one past the last real Kind. New event kinds must
 	// be inserted above it so completeness tests cover them automatically.
 	KindCount

--- a/internal/eventwire/wire.go
+++ b/internal/eventwire/wire.go
@@ -109,7 +109,7 @@ func ToWire(e event.Event) Event {
 		} else {
 			w.Level = "info"
 		}
-	case event.ToolDispatch, event.ToolResult, event.ToolProgress:
+	case event.ToolDispatch, event.ToolResult, event.ToolProgress, event.ToolResultPreview:
 		wt := &Tool{
 			ID: e.Tool.ID, Name: e.Tool.Name, Args: e.Tool.Args,
 			ResolvedName: e.Tool.ResolvedName, CapabilityID: e.Tool.CapabilityID,
@@ -573,6 +573,7 @@ var kindNames = map[event.Kind]string{
 	event.WorkspaceChanged:        "workspace_changed",
 	event.TurnPhase:               "turn_phase",
 	event.CompletionSummary:       "completion_summary",
+	event.ToolResultPreview:       "tool_result_preview",
 }
 
 // ContextMaintenance is the JSON form of event.ContextMaintenance.


### PR DESCRIPTION
## Summary

Follow-up to #8903 for the Windows/WebView2 transcript regressions (refs #8657, refs #8688). Five commits:

1. **Defer transcript layout rebuilds until user scroll idles** — fixes settled-history blanking and snap-back.
2. **Hold rebuilds while streaming and coalesce revision resets** — fixes tail loss and session-switch rebuild bursts.
3. **Keep the todo panel live and retire stale wrap-up notices** — fixes delayed task state and stale readiness cards.
4. **Keep terminal tool results unique** — uses an additive preview event for live UI state while preserving exactly one terminal result.
5. **Make recovery timing tests deterministic** — replaces wall-clock sleeps with an explicit in-test clock.

## Problem

On the v1.25.3-test.8903 build, testers still reported:

1. Long settled transcripts could blank and snap upward during continuous scrolling.
2. Streaming in auto/expanded reasoning modes could lose the tail; switching to a long session also stuttered.
3. The task panel did not update until an entire provider tool batch drained, and a todo-only readiness notice could remain after every todo completed.

## Root cause

- Ref-resolution revisions remounted Virtuoso while the user was scrolling or a turn was streaming.
- Anchor recovery stopped after eight animation frames, too early for heavy WebView2 rows.
- Wheel, touch, keyboard, and pointer intent did not cancel an in-flight recovery anchor.
- The blank watchdog could mistake transient mid-scroll mount lag for a broken size tree.
- Live todo state was tied to the terminal provider-ordered ToolResult, and todo-only readiness markers had no precise retraction path.
- Recovery race tests depended on real 60–620 ms delays.

## Fix

- Defer revision-driven rebuilds during active user scrolling and streaming; flush once at scroll idle or stream completion, re-capturing the resting anchor.
- Coalesce revision rebuilds to at most one per 600 ms.
- Treat wheel, touch-start, touch-move, key, and pointer-down as user intent that invalidates in-flight recovery.
- Give anchor restore a 1 s wall-clock budget and wait for the target row to mount.
- Keep the blank watchdog armed, but allow it to rebuild only after scrolling becomes idle.
- Emit an additive `tool_result_preview` event when `todo_write` finishes locally so the desktop can update immediately. The provider-ordered `ToolResult` remains the call's single terminal result; nested runtimes forward the preview as activity.
- Retract a live delivery notice when its only missing requirement was todos and the turn completes with an all-complete list. Consume the equivalent pending marker during canonical-list rebuild so reload does not replay it.
- Use a deterministic test clock for `Date.now` and window timers; each idle, batching, and coalescing boundary advances explicitly.

## Verification

- `transcript-recovery-race`: 25/25; repeated 20 times with the deterministic clock.
- Full transcript suite, frontend typecheck, hooks lint, production build, and repolint: pass.
- `go test ./internal/agent ./internal/control ./internal/evidence ./internal/event ./internal/eventwire`: pass.
- `cd desktop && go test ./...`: pass.
- Latest-base merge tree against `main-v2@d473b5a9`: clean; the frontend and Go checks above also pass on that merge tree.
- Native Windows 11 validation at head `192426eb1`: Wails `windows/amd64` build succeeds and runs in WebView2. A disposable 320-round (~303 KB) transcript:
  - scrolls upward and downward without blanking or snap-back;
  - remains at the same rows after more than two seconds idle;
  - preserves the visible row when prepending older history;
  - exposes the newly loaded older rows after prepend.
- GitHub CI on head `192426eb1`: all required Linux, macOS, Windows, race, lint, coverage, CodeQL, cache-impact, docs-impact, and desktop jobs pass.

## Boundaries

Known residuals remain deliberately out of scope:

- The first session-switch frame can briefly paint the list top before the tail scroll lands; the attempted `initialTopMostItemIndex` approach is incompatible with the current JSDOM harness.
- The auto-mode reasoning-collapse clamp jump is a product decision.
- Selection mode intentionally releases tail follow and keeps the jump-bottom recovery path from #8903.

Cache-impact: none - prompt construction, provider serialization, tool schemas/order, and provider bytes are unchanged. `tool_result_preview` is an additive internal event-sink notification for local UI state; the terminal provider result remains unique.
Cache-guard: `scripts/cache-guard.sh` (including `TestReleaseCacheHitGuard`) passes on this head; focused `internal/agent` tests cover marker consumption and unique terminal-result behavior.

Documentation-impact: none - existing docs remain correct because user-facing settings and documented workflows are unchanged; the additive internal event is covered by event-wire, nested-runtime, and desktop reducer tests.
