### PR TITLE
fix(anthropic): always replay the thinking block on DeepSeek tool-call turns

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -374,12 +374,18 @@ func (c *client) buildRequest(_ context.Context, req provider.Request) anthReque
 			// Replay provider reasoning before the tool_use it led to. DeepSeek uses
 			// unsigned thinking blocks and requires the reasoning from a tool-call
 			// turn in every subsequent request, even if the current request no longer
-			// declares tools or has since disabled thinking. Anthropic proper requires
-			// a signature, so reasoning without one cannot be replayed on that endpoint.
-			if c.deepseek && len(m.ToolCalls) > 0 && m.ReasoningContent != "" {
-				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: m.ReasoningContent})
+			// declares tools or has since disabled thinking. The endpoint 400s an
+			// assistant tool_calls turn whose thinking block is absent from the
+			// request JSON ("content[].thinking … must be passed back"), and accepts
+			// an empty thinking block — so, mirroring the OpenAI-compatible wire's
+			// policy for the same 400 family, always emit the block on DeepSeek
+			// tool-call turns (empty included) rather than fail the request when
+			// reasoning was lost upstream. Anthropic proper requires a signature, so
+			// reasoning without one cannot be replayed on that endpoint.
+			if c.deepseek && len(m.ToolCalls) > 0 {
+				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: strPtr(m.ReasoningContent)})
 			} else if c.thinking == "adaptive" && m.ReasoningContent != "" && m.ReasoningSignature != "" {
-				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: m.ReasoningContent, Signature: m.ReasoningSignature})
+				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: strPtr(m.ReasoningContent), Signature: m.ReasoningSignature})
 			}
 			blocks = appendServerSearchBlocks(blocks, m.ServerSearch)
 			if m.Content != "" {
@@ -734,6 +740,10 @@ const cacheWrite5MinuteInputMultiplier = 1.25
 
 func ephemeral() *cacheControl { return &cacheControl{Type: "ephemeral"} }
 
+// strPtr returns a pointer to s so an empty string still serialises as
+// `"thinking": ""` instead of being dropped by omitempty.
+func strPtr(s string) *string { return &s }
+
 type cacheControl struct {
 	Type string `json:"type"`
 }
@@ -776,7 +786,7 @@ type anthMessage struct {
 type contentBlock struct {
 	Type         string          `json:"type"`
 	Text         string          `json:"text,omitempty"`        // text
-	Thinking     string          `json:"thinking,omitempty"`    // thinking
+	Thinking     *string         `json:"thinking,omitempty"`    // thinking; pointer so DeepSeek tool-call replay always serialises the key (empty included — the endpoint 400s a thinking block without the `thinking` field)
 	Signature    string          `json:"signature,omitempty"`   // thinking
 	ID           string          `json:"id,omitempty"`          // tool_use
 	Name         string          `json:"name,omitempty"`        // tool_use

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -597,7 +597,7 @@ func TestBuildRequestThinking(t *testing.T) {
 	if asst.Role != "assistant" || len(asst.Content) != 2 {
 		t.Fatalf("assistant msg = %+v", asst)
 	}
-	if asst.Content[0].Type != "thinking" || asst.Content[0].Thinking != "Let me check." || asst.Content[0].Signature != "sig-abc" {
+	if asst.Content[0].Type != "thinking" || asst.Content[0].Thinking == nil || *asst.Content[0].Thinking != "Let me check." || asst.Content[0].Signature != "sig-abc" {
 		t.Fatalf("first block should be the signed thinking block: %+v", asst.Content[0])
 	}
 	if asst.Content[1].Type != "tool_use" {
@@ -674,7 +674,7 @@ func TestBuildRequestDeepSeekThinking(t *testing.T) {
 		t.Fatalf("output_config = %+v, want max", r.OutputConfig)
 	}
 	asst := r.Messages[1]
-	if len(asst.Content) != 2 || asst.Content[0].Type != "thinking" || asst.Content[0].Thinking != "I should call the tool." || asst.Content[0].Signature != "" || asst.Content[1].Type != "tool_use" {
+	if len(asst.Content) != 2 || asst.Content[0].Type != "thinking" || asst.Content[0].Thinking == nil || *asst.Content[0].Thinking != "I should call the tool." || asst.Content[0].Signature != "" || asst.Content[1].Type != "tool_use" {
 		t.Fatalf("DeepSeek assistant blocks = %+v, want unsigned thinking before tool_use", asst.Content)
 	}
 	if r.System[0].CacheControl != nil || r.Tools[0].CacheControl != nil {
@@ -727,7 +727,7 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 				t.Fatalf("messages = %+v, want user/assistant/user", r.Messages)
 			}
 			blocks := r.Messages[1].Content
-			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
+			if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking == nil || *blocks[0].Thinking != "I should call the tool." || blocks[1].Type != "tool_use" {
 				t.Fatalf("assistant blocks = %+v, want historical thinking before tool_use", blocks)
 			}
 		})
@@ -744,6 +744,51 @@ func TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory(t *testing.
 		})
 		if len(r.Messages) != 2 || len(r.Messages[1].Content) != 1 || r.Messages[1].Content[0].Type != "text" {
 			t.Fatalf("non-tool assistant blocks = %+v, want visible text only", r.Messages)
+		}
+	})
+
+	t.Run("missing reasoning on a tool-call turn still emits the thinking key", func(t *testing.T) {
+		// DeepSeek thinking mode 400s an assistant tool_calls turn whose thinking
+		// block is absent, and 400s a thinking block that lacks the `thinking`
+		// field; an empty value is accepted. Reasoning can be lost upstream
+		// (filtered/renamed by a gateway, session restore, retry fallback), so
+		// the wire must always emit `"thinking": ""` on such turns instead of
+		// dropping the block or omitting the key.
+		c := &client{model: "deepseek-v4-flash", deepseek: true, thinking: "enabled", effort: "high"}
+		r := c.buildRequest(context.Background(), provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "run ls"},
+				{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "t1", Name: "bash", Arguments: `{"command":"ls"}`}}},
+				{Role: provider.RoleTool, ToolCallID: "t1", Content: "ok"},
+			},
+			Tools: []provider.ToolSchema{{Name: "bash"}},
+		})
+		blocks := r.Messages[1].Content
+		if len(blocks) != 2 || blocks[0].Type != "thinking" || blocks[0].Thinking == nil || *blocks[0].Thinking != "" || blocks[1].Type != "tool_use" {
+			t.Fatalf("assistant blocks = %+v, want thinking (empty) before tool_use", blocks)
+		}
+		wire, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(wire), `"thinking":""`) {
+			t.Fatalf("wire body must serialise the empty thinking key: %s", wire)
+		}
+	})
+
+	t.Run("native Anthropic tool-call turn without reasoning stays unchanged", func(t *testing.T) {
+		c := &client{name: "anthropic", model: "claude-opus-4-8"}
+		r := c.buildRequest(context.Background(), provider.Request{
+			Messages: []provider.Message{
+				{Role: provider.RoleUser, Content: "run ls"},
+				{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "t1", Name: "bash", Arguments: `{"command":"ls"}`}}},
+				{Role: provider.RoleTool, ToolCallID: "t1", Content: "ok"},
+			},
+			Tools: []provider.ToolSchema{{Name: "bash"}},
+		})
+		blocks := r.Messages[1].Content
+		if len(blocks) != 1 || blocks[0].Type != "tool_use" {
+			t.Fatalf("native assistant blocks = %+v, want tool_use only (no synthetic thinking)", blocks)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

DeepSeek's Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) 400s assistant tool-call turns whose thinking block is absent from the replayed history:

- `The content[].thinking in the thinking mode must be passed back to the API.`
- and a thinking block that lacks the `thinking` field: `missing field `thinking``.

Both were reproduced live against the endpoint (2026-08-15). An empty value is accepted: `{"type":"thinking","thinking":""}` → 200.

The OpenAI-compatible wire already implements the verified policy for this 400 family (`internal/provider/openai/openai.go`): on DeepSeek tool-call turns always send the reasoning key, empty included, because reasoning can be lost upstream (gateway rename, filtering, session restore from older builds, the missing-reasoning retry fallback in `run_loop.go`). The Anthropic wire instead emitted the thinking block only when `ReasoningContent != ""`, so after any lost-reasoning turn every subsequent request failed with the user-facing "Malformed request (HTTP 400)" error until the history was rebuilt.

## Change

`internal/provider/anthropic/anthropic.go`:

- For `c.deepseek` assistant turns with tool calls, always emit the thinking block (`Thinking` becomes a `*string` so `"thinking": ""` is serialized instead of being stripped by `omitempty` — a block without the field 400s).
- Native Anthropic / adaptive behavior unchanged.

## Tests

- `TestBuildRequestDeepSeekReplaysOnlyToolCallReasoningFromHistory/missing_reasoning_on_a_tool-call_turn_still_emits_the_thinking_key` — asserts the empty thinking block is emitted and the wire JSON contains `"thinking":""`.
- `.../native_Anthropic_tool-call_turn_without_reasoning_stays_unchanged` — native path untouched.
- `go test ./internal/provider/...` green.

## Verification

- Live API probes against `api.deepseek.com/anthropic` (thinking enabled, effort high/max, deepseek-v4-flash/pro) confirmed the 400 shapes above and that empty thinking blocks are accepted.
- Multi-turn tool-call sessions through the built CLI (10 turns, web search + bash + resume) complete with 200s.
