### PR TITLE
fix(release): clear v1.25.3 Windows and policy blockers / 清除 v1.25.3 的 Windows 与策略阻断

### DIFF
--- a/internal/config/write_access_test.go
+++ b/internal/config/write_access_test.go
@@ -40,7 +40,8 @@ func TestPersistProjectWriteAccessDoesNotDuplicateAncestor(t *testing.T) {
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("[sandbox]\nallow_write = [\""+parent+"\"]\n"), 0o644); err != nil {
+	fixture := "[sandbox]\nallow_write = " + renderStringArray([]string{parent}) + "\n"
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := PersistProjectWriteAccess(path, []string{filepath.Join(parent, "bin")}, ""); err != nil {

--- a/internal/runtimepolicy/constraints.go
+++ b/internal/runtimepolicy/constraints.go
@@ -106,11 +106,10 @@ func hasExplicitReadOnlyClause(clause string) bool {
 
 func hasMutationContinuation(clause string) bool {
 	for _, marker := range []string{" then ", " and then ", " but then ", "然后", "再", "接着"} {
-		idx := strings.Index(clause, marker)
-		if idx < 0 {
+		_, tail, ok := strings.Cut(clause, marker)
+		if !ok {
 			continue
 		}
-		tail := clause[idx+len(marker):]
 		if matchesAny(tail, []string{
 			"fix", "repair", "implement", "write", "edit", "change", "modify", "create", "commit", "push",
 			"修复", "实现", "编写", "写入", "编辑", "修改", "创建", "提交", "推送",
@@ -165,11 +164,8 @@ func describesReadOnlyActor(clause string) bool {
 }
 
 func textAfterPhrase(clause, phrase string) (string, bool) {
-	idx := strings.Index(clause, phrase)
-	if idx < 0 {
-		return "", false
-	}
-	return strings.TrimSpace(clause[idx+len(phrase):]), true
+	_, tail, ok := strings.Cut(clause, phrase)
+	return strings.TrimSpace(tail), ok
 }
 
 func globalMutationTail(tail string) bool {

--- a/internal/runtimepolicy/constraints.go
+++ b/internal/runtimepolicy/constraints.go
@@ -23,14 +23,7 @@ type Constraints struct {
 func ParseConstraints(instruction string) Constraints {
 	var c Constraints
 	lower := strings.ToLower(instruction)
-	if matchesAny(lower, []string{
-		"只分析", "只读", "不要修改", "别改", "不要改", "仅分析", "只看不改",
-		"analyze only", "analysis only", "don't modify", "do not modify",
-		"don't change", "do not change", "no changes", "read only", "read-only",
-		"without modifying", "without changes", "don't edit", "do not edit",
-		"复现但不修复", "只复现", "不要修复", "reproduce but don't fix",
-		"reproduce only", "don't fix", "do not fix", "no fix",
-	}) {
+	if hasGlobalMutationBan(lower) {
 		c.ForbidMutation = true
 		c.Notes = append(c.Notes, "user_forbid_mutation")
 	}
@@ -63,6 +56,188 @@ func ParseConstraints(instruction string) Constraints {
 		c.Notes = append(c.Notes, "user_forbid_external")
 	}
 	return c
+}
+
+// hasGlobalMutationBan distinguishes a turn-wide read-only instruction from a
+// scoped protection such as "do not change any config". The latter still lets
+// the requested output or an unrelated implementation target be written.
+func hasGlobalMutationBan(instruction string) bool {
+	for _, clause := range mutationConstraintClauses(instruction) {
+		clause = strings.TrimSpace(strings.TrimLeft(clause, "-*•0123456789. )\t"))
+		if clause == "" {
+			continue
+		}
+		if hasExplicitReadOnlyClause(clause) || hasGlobalNegatedMutationClause(clause) {
+			return true
+		}
+	}
+	return false
+}
+
+func mutationConstraintClauses(instruction string) []string {
+	return strings.FieldsFunc(instruction, func(r rune) bool {
+		switch r {
+		case '\n', '\r', '.', '!', '?', ';', '。', '！', '？', '；':
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func hasExplicitReadOnlyClause(clause string) bool {
+	if hasMutationContinuation(clause) {
+		return false
+	}
+	for _, phrase := range []string{
+		"analyze only", "analysis only", "read-only review", "read only review",
+		"reproduce only", "reproduce but don't fix", "reproduce but do not fix",
+		"只分析", "仅分析", "只看不改", "复现但不修复", "只复现", "仅复现",
+	} {
+		if strings.Contains(clause, phrase) {
+			return true
+		}
+	}
+	trimmed := strings.TrimSpace(clause)
+	return trimmed == "read-only" || strings.HasPrefix(trimmed, "read-only ") ||
+		trimmed == "read only" || strings.HasPrefix(trimmed, "read only ") ||
+		trimmed == "只读" || strings.HasPrefix(trimmed, "只读")
+}
+
+func hasMutationContinuation(clause string) bool {
+	for _, marker := range []string{" then ", " and then ", " but then ", "然后", "再", "接着"} {
+		idx := strings.Index(clause, marker)
+		if idx < 0 {
+			continue
+		}
+		tail := clause[idx+len(marker):]
+		if matchesAny(tail, []string{
+			"fix", "repair", "implement", "write", "edit", "change", "modify", "create", "commit", "push",
+			"修复", "实现", "编写", "写入", "编辑", "修改", "创建", "提交", "推送",
+		}) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasGlobalNegatedMutationClause(clause string) bool {
+	if describesReadOnlyActor(clause) {
+		return false
+	}
+	for _, phrase := range []string{
+		"don't modify", "do not modify", "don't change", "do not change",
+		"don't edit", "do not edit", "without modifying", "without changes",
+	} {
+		if tail, ok := textAfterPhrase(clause, phrase); ok && globalMutationTail(tail) {
+			return true
+		}
+	}
+	for _, phrase := range []string{"don't fix", "do not fix", "no fix"} {
+		if tail, ok := textAfterPhrase(clause, phrase); ok && globalFixTail(tail) {
+			return true
+		}
+	}
+	if tail, ok := textAfterPhrase(clause, "no changes"); ok && globalNoChangesTail(tail) {
+		return true
+	}
+	if tail, ok := textAfterPhrase(clause, "make no changes"); ok && globalNoChangesTail(tail) {
+		return true
+	}
+	for _, phrase := range []string{"不要修改", "不要改动", "不要改", "别修改", "别改", "勿修改"} {
+		if tail, ok := textAfterPhrase(clause, phrase); ok && globalChineseMutationTail(tail) {
+			return true
+		}
+	}
+	for _, phrase := range []string{"不要修复", "不要修", "别修复", "别修"} {
+		if tail, ok := textAfterPhrase(clause, phrase); ok && globalChineseFixTail(tail) {
+			return true
+		}
+	}
+	return false
+}
+
+func describesReadOnlyActor(clause string) bool {
+	return matchesAny(clause, []string{
+		"reviewer", "sub-agent", "subagent", "child agent", "child", "planner",
+		"审查者", "评审者", "子代理", "子 agent", "规划器",
+	}) && matchesAny(clause, []string{"read-only", "read only", "只读"})
+}
+
+func textAfterPhrase(clause, phrase string) (string, bool) {
+	idx := strings.Index(clause, phrase)
+	if idx < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(clause[idx+len(phrase):]), true
+}
+
+func globalMutationTail(tail string) bool {
+	if tail == "" {
+		return true
+	}
+	if strings.HasPrefix(tail, ":") {
+		return false
+	}
+	return hasBroadTarget(tail)
+}
+
+func globalFixTail(tail string) bool {
+	return tail == "" || startsWithAnyWord(tail, []string{"anything", "anything else", "any issue", "any issues"})
+}
+
+func globalNoChangesTail(tail string) bool {
+	if tail == "" {
+		return true
+	}
+	return startsWithAnyWord(tail, []string{
+		"anywhere", "at all", "to anything", "to the workspace", "to the repository", "to the repo", "to the codebase",
+	})
+}
+
+func hasBroadTarget(tail string) bool {
+	return startsWithAnyWord(tail, []string{
+		"anything", "anything else", "the workspace", "this workspace", "workspace",
+		"the repository", "this repository", "repository", "the repo", "this repo", "repo",
+		"the codebase", "this codebase", "codebase", "any file", "any files", "all files", "the source tree",
+	})
+}
+
+func startsWithAnyWord(value string, prefixes []string) bool {
+	value = strings.TrimSpace(value)
+	for _, prefix := range prefixes {
+		if value == prefix || strings.HasPrefix(value, prefix+" ") || strings.HasPrefix(value, prefix+",") {
+			return true
+		}
+	}
+	return false
+}
+
+func globalChineseMutationTail(tail string) bool {
+	if tail == "" {
+		return true
+	}
+	if strings.HasPrefix(tail, "：") || strings.HasPrefix(tail, ":") {
+		return false
+	}
+	return startsWithAnyChinese(tail, []string{
+		"任何内容", "任何东西", "任何文件", "所有文件", "工作区", "当前工作区",
+		"仓库", "当前仓库", "代码库", "当前代码库", "源码树",
+	})
+}
+
+func globalChineseFixTail(tail string) bool {
+	return tail == "" || startsWithAnyChinese(tail, []string{"任何问题", "任何内容", "其他任何问题"})
+}
+
+func startsWithAnyChinese(value string, prefixes []string) bool {
+	value = strings.TrimSpace(value)
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // StripQuotedConstraints removes fenced and quoted spans so cited phrases

--- a/internal/runtimepolicy/constraints_test.go
+++ b/internal/runtimepolicy/constraints_test.go
@@ -1,0 +1,62 @@
+package runtimepolicy
+
+import (
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+func TestParseConstraintsScopesMutationBans(t *testing.T) {
+	tests := []struct {
+		name        string
+		instruction string
+		forbid      bool
+	}{
+		{name: "scoped PR", instruction: "Do not modify PR #10. Create a branch and implement the repair."},
+		{name: "scoped product", instruction: "Do not modify Strategy Lab. Commit the Battleboard fix."},
+		{name: "scoped list", instruction: "Do not modify:\n- main\n- PR #10\nCreate feature/fix and commit."},
+		{name: "unrelated issues", instruction: "Implement the bounded repair. Do not fix unrelated old issues."},
+		{name: "descriptive no changes", instruction: "No changes to Battleboard mission prompts — fix the routing layer instead."},
+		{name: "read only child", instruction: "Implementation writes are allowed; the independent reviewer is a strict read-only child."},
+		{name: "scoped config", instruction: "Write AUDIT.md with the result. Do not change any config."},
+		{name: "mixed analysis and fix", instruction: "Analyze the failure, then fix the implementation."},
+		{name: "read one file then fix", instruction: "Read only the first file, then fix the implementation."},
+		{name: "global analyze only", instruction: "Analyze only the payment flow.", forbid: true},
+		{name: "global trailing analyze only", instruction: "Audit the payment flow, analyze only.", forbid: true},
+		{name: "global read only review", instruction: "Read-only review of PR #10.", forbid: true},
+		{name: "global read only repository", instruction: "Read only the repository.", forbid: true},
+		{name: "bare do not modify", instruction: "Do not modify.", forbid: true},
+		{name: "broad do not modify", instruction: "Do not modify anything.", forbid: true},
+		{name: "without modifying", instruction: "Review the repository without modifying anything.", forbid: true},
+		{name: "without changes", instruction: "Inspect the issue without changes.", forbid: true},
+		{name: "do not edit files", instruction: "Do not edit any files.", forbid: true},
+		{name: "workspace ban", instruction: "Do not change the workspace.", forbid: true},
+		{name: "bare no changes", instruction: "No changes.", forbid: true},
+		{name: "broad no changes", instruction: "Make no changes to anything.", forbid: true},
+		{name: "reproduce only", instruction: "Reproduce only the crash.", forbid: true},
+		{name: "scoped Chinese", instruction: "不要修改配置文件，生成 AUDIT.md。"},
+		{name: "scoped Chinese issue", instruction: "不要修复无关问题，只处理当前缺陷并提交。"},
+		{name: "global Chinese analyze", instruction: "只分析支付流程。", forbid: true},
+		{name: "global Chinese read only", instruction: "只读检查当前仓库。", forbid: true},
+		{name: "bare Chinese mutation ban", instruction: "不要修改。", forbid: true},
+		{name: "global Chinese workspace", instruction: "不要修改当前工作区。", forbid: true},
+		{name: "global Chinese reproduce", instruction: "只复现崩溃。", forbid: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseConstraints(StripQuotedConstraints(tt.instruction))
+			if got.ForbidMutation != tt.forbid {
+				t.Fatalf("ForbidMutation = %v, want %v; constraints=%+v", got.ForbidMutation, tt.forbid, got)
+			}
+			if got.AllowsMutation() == tt.forbid {
+				t.Fatalf("AllowsMutation = %v, want %v", got.AllowsMutation(), !tt.forbid)
+			}
+			decision := (ConstraintGuard{Constraints: got}).BeforeTool(CallContext{
+				Profile: evidence.EffectProfile{Known: true, WorkspaceWrite: true},
+			})
+			if (decision.Action == GuardDeny) != tt.forbid {
+				t.Fatalf("writer decision = %+v, forbid=%v", decision, tt.forbid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- encode the persisted write-access ancestor fixture through the production TOML renderer so Windows absolute paths remain valid
- replace turn-wide substring promotion with clause-aware mutation constraints
- preserve explicit global English and Chinese read-only directives while allowing scoped protections such as `Do not change any config`

## Release qualification findings

- repeated `main-v2` Windows CI failures exposed the invalid TOML fixture
- the first real-provider `/e2e` run on PR head `3a505af38` completed 102 model requests with 91% cache hit and reproduced issue #8932: `Do not change any config` blocked the required `AUDIT.md` output as a global no-mutation constraint
- the post-fix live rerun on `169868fdb` successfully wrote the authorized `AUDIT.md`; the task grader then rejected the answer only because it also mentioned an unchanged setting, proving the host mutation boundary itself is repaired
- both live runs completed normal authentication, streaming, usage accounting, and tool read/write loops; the remaining repeated task failure asked for clarification in an unattended ambiguous task and then produced no visible answer
- the fixed-suite workflow has grown to 73 tasks while retaining an 800k token cap, so most tasks are skipped after the first eight or nine; this is recorded as a harness-budget limitation rather than protocol evidence
- final head `6fb69c41b` differs from the live-tested policy head only by the linter-required mechanical replacement of `Index` slices with `strings.Cut`

## Verification

- `go test ./internal/config`
- `go test ./internal/runtimepolicy ./internal/agent ./internal/control`
- `go test -race ./internal/runtimepolicy ./internal/agent ./internal/control`
- isolated `go test -race ./...`
- `golangci-lint run --timeout=5m ./internal/runtimepolicy/...`
- `git diff --check`
- awaiting renewed full cross-platform PR CI on final head `6fb69c41b`

## Documentation impact

Documentation-impact: none - this restores intended constraint scoping and repairs a test fixture without changing user-facing configuration.

## Cache impact

Cache-impact: none - provider-visible prompts, tool schemas, ordering, and serialization are unchanged.
Cache-guard: passed during v1.25.3 qualification.
System-prompt-review: N/A

Closes #8932