### PR TITLE
fix(security): pin patched DOMPurify / 固定已修复的 DOMPurify

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -82,6 +82,7 @@
     "vite": "^8.2.0"
   },
   "overrides": {
+    "dompurify": "3.4.13",
     "mdast-util-gfm-autolink-literal": "2.0.0"
   },
   "engines": {

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  dompurify: 3.4.13
   mdast-util-gfm-autolink-literal: 2.0.0
   undici: 7.29.0
 
@@ -1122,8 +1123,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   electron-to-chromium@1.5.399:
     resolution: {integrity: sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==}
@@ -3021,7 +3022,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3635,7 +3636,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0

--- a/desktop/frontend/pnpm-workspace.yaml
+++ b/desktop/frontend/pnpm-workspace.yaml
@@ -2,5 +2,6 @@ allowBuilds:
   esbuild: true
 
 overrides:
+  dompurify: 3.4.13
   mdast-util-gfm-autolink-literal: 2.0.0
   undici: 7.29.0


### PR DESCRIPTION
## Summary

- pin Mermaid transitive DOMPurify to patched 3.4.13
- keep the workspace override and lockfile resolution aligned
- clear the open moderate runtime XSS advisory before v1.25.3

## Verification

- pnpm why dompurify: only 3.4.13
- pnpm audit --prod --audit-level=moderate: no known vulnerabilities
- pnpm test:all: pass
- pnpm build: pass

Documentation-impact: none - this is a transitive security version pin; existing product and operator documentation remains correct.

Release blocker found during the v1.25.3 security gate.