### PR TITLE
fix(control): resume ordinary readiness checks automatically / 自动补齐普通任务的收尾验证

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -778,12 +778,13 @@ func (a *Agent) flushSteerQueue() {
 	a.steerMu.Lock()
 	pending := a.steerQueue
 	a.steerQueue = nil
-	a.steerUnapplied = len(pending) > 0
+	a.steerUnapplied = false
 	if len(pending) > 0 {
 		a.steerConsumed = true
 	}
 	a.steerRunActive = false
 	a.steerMu.Unlock()
+	unapplied := false
 	for _, e := range pending {
 		text := e.text
 		if e.load != nil {
@@ -792,7 +793,11 @@ func (a *Agent) flushSteerQueue() {
 			}
 		}
 		a.RecordUnappliedSteer(text, e.itemID)
+		unapplied = true
 	}
+	a.steerMu.Lock()
+	a.steerUnapplied = unapplied
+	a.steerMu.Unlock()
 }
 
 // UnappliedSteerNotice returns the durable warning shown for guidance that was
@@ -1240,7 +1245,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 		// Explicit readiness recovery is consumed only once beginRunTurn starts.
 		// If an extension blocks earlier, release the in-memory reservation so
 		// the still-pending durable marker can authorize a later retry.
-		a.pending.finalReadinessRecoveryPrepared = false
+		a.RestoreFinalReadinessRecoveryPreparation()
 		return err
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -330,9 +330,10 @@ type Agent struct {
 	// Entries keep a durable inbox item ID plus a loader so full bodies are not
 	// retained in the agent heap beyond need. Cache miss for the next API call
 	// is unavoidable but limited to one call — the prefix stays stable otherwise.
-	steerMu       sync.Mutex
-	steerQueue    []steerEntry
-	steerConsumed bool
+	steerMu        sync.Mutex
+	steerQueue     []steerEntry
+	steerConsumed  bool
+	steerUnapplied bool
 	// steerRunActive is true while Run is executing. Steer only queues while
 	// it is set; once the turn's exit flush has drained the queue, later
 	// steers are rejected so the caller can deliver them as a regular turn
@@ -713,6 +714,15 @@ func (a *Agent) SteerConsumed() bool {
 	return a.steerConsumed
 }
 
+// HasUnappliedSteer reports whether the last Run ended with user guidance that
+// arrived too late to be consumed. Hosts use it to yield before starting an
+// automatic synthetic continuation.
+func (a *Agent) HasUnappliedSteer() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerUnapplied
+}
+
 // SetSink replaces the agent's event sink. Controllers use this to wrap the
 // sink after construction (e.g. durable inbox observation) without rebuilding
 // the agent.
@@ -768,6 +778,7 @@ func (a *Agent) flushSteerQueue() {
 	a.steerMu.Lock()
 	pending := a.steerQueue
 	a.steerQueue = nil
+	a.steerUnapplied = len(pending) > 0
 	if len(pending) > 0 {
 		a.steerConsumed = true
 	}
@@ -1200,6 +1211,7 @@ func (a *Agent) Run(ctx context.Context, input string) (runErr error) {
 	defer a.flushSteerQueue()
 	a.steerMu.Lock()
 	a.steerConsumed = false
+	a.steerUnapplied = false
 	a.steerRunActive = true
 	a.steerMu.Unlock()
 

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -77,12 +77,31 @@ func InspectRunPause(err error) (RunPauseInfo, bool) {
 	return RunPauseInfo{}, false
 }
 
+// ReadinessContinuationClass tells a host whether an observed readiness gap is
+// safe and concrete enough for a bounded synthetic follow-up turn.
+type ReadinessContinuationClass string
+
+const (
+	// ReadinessContinuationNone is also the zero value so older callers that
+	// construct FinalReadinessError directly never opt into another model turn.
+	ReadinessContinuationNone ReadinessContinuationClass = ""
+	// ReadinessContinuationGeneric covers ordinary post-write verification and
+	// review gaps. Hosts may give it one bounded follow-up turn.
+	ReadinessContinuationGeneric ReadinessContinuationClass = "generic"
+	// ReadinessContinuationHighConfidence covers exact or strict, safely
+	// actionable readiness duties. Hosts may give it a second turn only after
+	// host-observable progress.
+	ReadinessContinuationHighConfidence ReadinessContinuationClass = "high_confidence"
+)
+
 // FinalReadinessError reports that the model exhausted its recovery attempts
 // before satisfying the host-observed delivery checks.
 type FinalReadinessError struct {
-	Attempts int
-	Reason   string
-	Missing  []string
+	Attempts          int
+	Reason            string
+	Missing           []string
+	ContinuationClass ReadinessContinuationClass
+	ProgressKey       string
 }
 
 func (e *FinalReadinessError) Error() string {

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -191,7 +191,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 			a.turn.engine.NoteRecoveryAttempt()
 		}
 		out.reason = strings.Join(missing, "; ")
-		if !a.closedLoopActive() {
+		if !a.turn.automaticReadinessContinuation && !a.closedLoopActive() {
 			return a.applyPartialCheckWaiver(out)
 		}
 		return out

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -54,16 +54,19 @@ func (c *finalReadinessCheck) observeObligation(o taskcontract.Obligation) {
 		case taskcontract.ObligationTodo, taskcontract.ObligationCriteria,
 			taskcontract.ObligationFullVerify, taskcontract.ObligationIndependentReview,
 			taskcontract.ObligationSecurityReview, taskcontract.ObligationSignoff:
-			if o.Enforcement == taskcontract.EnforcementStrict ||
-				o.Kind == taskcontract.ObligationTodo || o.Kind == taskcontract.ObligationCriteria {
+			switch {
+			case o.Kind == taskcontract.ObligationTodo || o.Kind == taskcontract.ObligationCriteria:
 				c.continuationHighConfidence = true
-			} else if o.Enforcement == taskcontract.EnforcementRecoverable {
+			case o.Enforcement == taskcontract.EnforcementStrict:
+				c.continuationHighConfidence = true
+			case o.Enforcement == taskcontract.EnforcementRecoverable:
 				c.continuationGeneric = true
 			}
 		case taskcontract.ObligationTargetedVerify, taskcontract.ObligationDiffReview:
-			if o.Enforcement == taskcontract.EnforcementStrict {
+			switch o.Enforcement {
+			case taskcontract.EnforcementStrict:
 				c.continuationHighConfidence = true
-			} else if o.Enforcement == taskcontract.EnforcementRecoverable {
+			case taskcontract.EnforcementRecoverable:
 				c.continuationGeneric = true
 			}
 		default:

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -14,17 +14,74 @@ import (
 // Final readiness: whether the fact contract and ledger allow the turn to stop.
 
 type finalReadinessCheck struct {
-	applies                   bool
-	reason                    string
-	missingProjectChecks      int
-	incompleteTodos           int
-	missingAcceptanceCriteria int
-	missingVerification       int
-	missingReview             int
-	missingSignoff            int
-	missingActionEvidence     int
-	missingMutation           int
-	missingCapabilities       int
+	applies                    bool
+	reason                     string
+	continuationGeneric        bool
+	continuationHighConfidence bool
+	continuationUnsafe         bool
+	missingProjectChecks       int
+	incompleteTodos            int
+	missingAcceptanceCriteria  int
+	missingVerification        int
+	missingReview              int
+	missingSignoff             int
+	missingActionEvidence      int
+	missingMutation            int
+	missingCapabilities        int
+}
+
+func (c finalReadinessCheck) continuationClass() ReadinessContinuationClass {
+	if c.reason == "" || c.continuationUnsafe || c.missingActionEvidence > 0 ||
+		c.missingMutation > 0 || c.missingCapabilities > 0 {
+		return ReadinessContinuationNone
+	}
+	if c.continuationHighConfidence {
+		return ReadinessContinuationHighConfidence
+	}
+	if c.continuationGeneric {
+		return ReadinessContinuationGeneric
+	}
+	return ReadinessContinuationNone
+}
+
+func (c *finalReadinessCheck) observeObligation(o taskcontract.Obligation) {
+	if o.Enforcement != taskcontract.EnforcementAdvisory {
+		switch o.Kind {
+		case taskcontract.ObligationActionReceipt:
+			// Repeating an external/destructive action to manufacture a
+			// receipt is never an automatic readiness operation.
+			c.continuationUnsafe = true
+		case taskcontract.ObligationTodo, taskcontract.ObligationCriteria,
+			taskcontract.ObligationFullVerify, taskcontract.ObligationIndependentReview,
+			taskcontract.ObligationSecurityReview, taskcontract.ObligationSignoff:
+			if o.Enforcement == taskcontract.EnforcementStrict ||
+				o.Kind == taskcontract.ObligationTodo || o.Kind == taskcontract.ObligationCriteria {
+				c.continuationHighConfidence = true
+			} else if o.Enforcement == taskcontract.EnforcementRecoverable {
+				c.continuationGeneric = true
+			}
+		case taskcontract.ObligationTargetedVerify, taskcontract.ObligationDiffReview:
+			if o.Enforcement == taskcontract.EnforcementStrict {
+				c.continuationHighConfidence = true
+			} else if o.Enforcement == taskcontract.EnforcementRecoverable {
+				c.continuationGeneric = true
+			}
+		default:
+			c.continuationUnsafe = true
+		}
+	}
+	switch o.Kind {
+	case taskcontract.ObligationTargetedVerify, taskcontract.ObligationFullVerify:
+		c.missingVerification++
+	case taskcontract.ObligationDiffReview, taskcontract.ObligationIndependentReview, taskcontract.ObligationSecurityReview:
+		c.missingReview++
+	case taskcontract.ObligationSignoff:
+		c.missingSignoff++
+	case taskcontract.ObligationActionReceipt:
+		c.missingActionEvidence++
+	case taskcontract.ObligationCriteria:
+		c.missingAcceptanceCriteria++
+	}
 }
 
 func (c finalReadinessCheck) progressSignature() string {
@@ -89,7 +146,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		a.turn.engine.SyncReceipts(a.task.ledger.Receipts(), a.writeWorkspaceRoot, a.turn.constraints.ForbidTests)
 	}
 	var missing []string
-	out := finalReadinessCheck{}
+	out := finalReadinessCheck{continuationUnsafe: a.turn.constraints.ForbidTests}
 	if a.planMode.Load() {
 		return out
 	}
@@ -99,6 +156,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 	}
 	if msg := a.capabilityGateFailure(); msg != "" {
 		out.applies = true
+		out.continuationUnsafe = true
 		out.missingCapabilities++
 		missing = append(missing, msg)
 	}
@@ -108,6 +166,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 	}
 	if hasWriter && hasTodos && len(incomplete) > 0 {
 		out.applies = true
+		out.continuationHighConfidence = true
 		out.incompleteTodos = len(incomplete)
 		missing = append(missing, finalReadinessIncompleteTodos(incomplete))
 	}
@@ -120,12 +179,16 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 			continue
 		}
 		if !a.task.ledger.HasSuccessfulCommandAfter(command, writer) {
+			out.continuationHighConfidence = true
 			out.missingProjectChecks++
 			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
 		}
 	}
 	if hasWriter {
 		outstanding := a.outstandingPlanCriteria()
+		if len(outstanding) > 0 {
+			out.continuationHighConfidence = true
+		}
 		out.missingAcceptanceCriteria += len(outstanding)
 		missing = append(missing, outstanding...)
 	}
@@ -144,18 +207,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		})
 		for _, o := range a.turn.engine.Snapshot().Unsatisfied() {
 			missing = append(missing, obligationGap(o))
-			switch o.Kind {
-			case taskcontract.ObligationTargetedVerify, taskcontract.ObligationFullVerify:
-				out.missingVerification++
-			case taskcontract.ObligationDiffReview, taskcontract.ObligationIndependentReview, taskcontract.ObligationSecurityReview:
-				out.missingReview++
-			case taskcontract.ObligationSignoff:
-				out.missingSignoff++
-			case taskcontract.ObligationActionReceipt:
-				out.missingActionEvidence++
-			case taskcontract.ObligationCriteria:
-				out.missingAcceptanceCriteria++
-			}
+			out.observeObligation(o)
 		}
 	}
 	if a.loopGuardAllowsFinal() {
@@ -181,6 +233,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		out.reason = strings.Join(missing, "; ")
 		return a.applyPartialCheckWaiver(out)
 	case taskcontract.StopBlocked:
+		out.continuationUnsafe = true
 		out.reason = strings.Join(missing, "; ")
 		return out
 	case taskcontract.StopContinue:

--- a/internal/agent/final_readiness_recovery.go
+++ b/internal/agent/final_readiness_recovery.go
@@ -76,6 +76,20 @@ func (a *Agent) PrepareFinalReadinessRecovery() bool {
 	return true
 }
 
+// RestoreFinalReadinessRecoveryPreparation releases a prepared recovery when
+// the host could not start Agent.Run. The durable marker remains pending, so a
+// later explicit or automatic continuation can authorize the same evidence
+// exactly once instead of treating a pre-run block as successful delivery.
+func (a *Agent) RestoreFinalReadinessRecoveryPreparation() bool {
+	if a == nil || !a.pending.finalReadinessRecoveryPrepared {
+		return false
+	}
+	a.pending.preserveEvidence = false
+	a.pending.finalReadinessRecovery = true
+	a.pending.finalReadinessRecoveryPrepared = false
+	return true
+}
+
 // beginFinalReadinessRecovery consumes a pending card when a user turn truly
 // begins and returns the evidence and audit state for that turn.
 func (a *Agent) beginFinalReadinessRecovery() (preserveEvidence, recovered bool) {

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -256,6 +256,7 @@ func hasLegacyProviderWrapper(content string) bool {
 const (
 	HostRecoveryGuidanceToolFailedPrefix = "A tool failed. Use read-only diagnosis as needed"
 	HostRecoveryGuidanceTransientPrefix  = "The tool timed out or hit a transient execution limit."
+	ReadinessContinuationPrefix          = "This turn ended with work still outstanding:"
 )
 
 // SyntheticUserPrefixes lists the openings of host-injected user-role messages
@@ -269,6 +270,7 @@ var SyntheticUserPrefixes = []string{
 	"<reasoning-language>",
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
+	ReadinessContinuationPrefix,
 	"You are already in the executor phase",
 	"The previous assistant response was interrupted while a tool call",
 	"The previous assistant response was interrupted during streaming",

--- a/internal/agent/readiness_continuation_class_test.go
+++ b/internal/agent/readiness_continuation_class_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import "testing"
+
+func TestReadinessContinuationClassPriority(t *testing.T) {
+	cases := []struct {
+		name  string
+		check finalReadinessCheck
+		want  ReadinessContinuationClass
+	}{
+		{name: "empty", check: finalReadinessCheck{}, want: ReadinessContinuationNone},
+		{name: "generic", check: finalReadinessCheck{reason: "verify", continuationGeneric: true}, want: ReadinessContinuationGeneric},
+		{name: "high confidence", check: finalReadinessCheck{reason: "run exact check", continuationGeneric: true, continuationHighConfidence: true}, want: ReadinessContinuationHighConfidence},
+		{name: "unsafe beats high confidence", check: finalReadinessCheck{reason: "act", continuationHighConfidence: true, continuationUnsafe: true}, want: ReadinessContinuationNone},
+		{name: "action is unsafe", check: finalReadinessCheck{reason: "act", continuationHighConfidence: true, missingActionEvidence: 1}, want: ReadinessContinuationNone},
+		{name: "mutation is unsafe", check: finalReadinessCheck{reason: "mutate", continuationHighConfidence: true, missingMutation: 1}, want: ReadinessContinuationNone},
+		{name: "capability is unsafe", check: finalReadinessCheck{reason: "capability", continuationHighConfidence: true, missingCapabilities: 1}, want: ReadinessContinuationNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.check.continuationClass(); got != tc.want {
+				t.Fatalf("continuationClass() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFinalReadinessErrorContinuationDefaultsToNone(t *testing.T) {
+	err := &FinalReadinessError{Attempts: 1, Reason: "legacy caller"}
+	if err.ContinuationClass != ReadinessContinuationNone {
+		t.Fatalf("ContinuationClass = %q, want conservative zero value", err.ContinuationClass)
+	}
+}

--- a/internal/agent/readiness_continuation_context.go
+++ b/internal/agent/readiness_continuation_context.go
@@ -1,0 +1,19 @@
+package agent
+
+import "context"
+
+type automaticReadinessContinuationKey struct{}
+
+// WithAutomaticReadinessContinuation asks the Agent to return a recoverable
+// readiness gap to its owning controller instead of immediately ending an
+// ordinary turn as Partial. The controller can then preserve the ledger and
+// run bounded synthetic follow-ups. This is host-only and never reaches the
+// provider request or tool schemas.
+func WithAutomaticReadinessContinuation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, automaticReadinessContinuationKey{}, true)
+}
+
+func automaticReadinessContinuationFromContext(ctx context.Context) bool {
+	enabled, _ := ctx.Value(automaticReadinessContinuationKey{}).(bool)
+	return enabled
+}

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -129,6 +129,7 @@ func (a *Agent) beginRunTurn(ctx context.Context, input string) (rawInput string
 	// values are computed below. Cross-turn state (checkpoint, scope, failure
 	// budgets) lives in taskRuntime and is reconciled there.
 	a.turn = turnRuntime{}
+	a.turn.automaticReadinessContinuation = automaticReadinessContinuationFromContext(ctx)
 	a.resetStructuralRunGuards()
 	scope, scoped := DeliveryExecutionScopeFromContext(ctx)
 	preserveEvidence, readinessRecovered := a.beginFinalReadinessRecovery()
@@ -519,10 +520,11 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		return false, a.gracePause(state)
 	}
 	if readiness.reason != "" {
-		// Goal/Plan and fact contradictions (open todos, sign-off, action
-		// receipts) fail the run. Ordinary Recoverable/project/review gaps
-		// become an honest Partial completion instead of a recovery error.
-		if a.closedLoopActive() || readiness.incompleteTodos > 0 || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
+		// The host owns the concrete missing requirements. Return them to the
+		// controller when automatic continuation is armed (or for the existing
+		// strict/Goal path). Unarmed ordinary agents retain their Partial
+		// contract and do not unexpectedly change the direct Agent API.
+		if a.turn.automaticReadinessContinuation || a.closedLoopActive() || readiness.incompleteTodos > 0 || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
 			event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
 			a.pending.finalReadinessRecovery = true
 			a.persistFinalReadinessRecovery(readiness.missingIDs())

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -528,7 +528,13 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 			event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
 			a.pending.finalReadinessRecovery = true
 			a.persistFinalReadinessRecovery(readiness.missingIDs())
-			return false, &FinalReadinessError{Attempts: 1, Reason: readiness.reason, Missing: readiness.missingIDs()}
+			return false, &FinalReadinessError{
+				Attempts:          1,
+				Reason:            readiness.reason,
+				Missing:           readiness.missingIDs(),
+				ContinuationClass: readiness.continuationClass(),
+				ProgressKey:       readiness.progressSignature(),
+			}
 		}
 		event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessAllowed, a.turn.readinessRecovered))
 	}

--- a/internal/agent/steer_flush_test.go
+++ b/internal/agent/steer_flush_test.go
@@ -94,6 +94,9 @@ func TestRunFlushesUnconsumedSteersOnCancel(t *testing.T) {
 	if n := a.steerQueueLen(); n != 0 {
 		t.Fatalf("steer queue should be empty after the turn, len=%d", n)
 	}
+	if !a.HasUnappliedSteer() {
+		t.Fatal("host should observe that the cancelled turn left unapplied guidance")
+	}
 	if a.Steer("after the turn") {
 		t.Fatalf("Steer must be rejected once the turn has exited")
 	}
@@ -116,6 +119,9 @@ func TestCloseSteerIntakeIfIdleMakesAdmissionLinearizable(t *testing.T) {
 	}
 	if n := a.steerQueueLen(); n != 0 {
 		t.Fatalf("rejected steer remained queued, len=%d", n)
+	}
+	if a.HasUnappliedSteer() {
+		t.Fatal("closing an empty steer intake must not report unapplied guidance")
 	}
 }
 

--- a/internal/agent/turnruntime.go
+++ b/internal/agent/turnruntime.go
@@ -49,7 +49,8 @@ type turnRuntime struct {
 	// readinessRecovered marks a run that started with evidence preserved from
 	// (or a pending recovery of) a prior readiness failure, so the final
 	// allowed audit can report Recovered=true.
-	readinessRecovered bool
+	readinessRecovered             bool
+	automaticReadinessContinuation bool
 
 	// recoveryTaskSummary is the bounded task text for this Agent.Run. It lets
 	// a shared recovery gate review sub-agent mutations against the child

--- a/internal/control/goal_runtime_test.go
+++ b/internal/control/goal_runtime_test.go
@@ -687,8 +687,9 @@ func TestGoalDeliveryWorkflowCompletesAfterVerifiedSignoff(t *testing.T) {
 }
 
 // TestPlainDeliveryReadinessFailureRetriesThenSurfacesRecoveryCard covers the
-// plain (non-Goal) closed-loop case: the host retries known readiness gaps and
-// surfaces the recovery card only after the bounded attempts make no progress.
+// plain (non-Goal) closed-loop case: the host retries a known high-confidence
+// readiness gap once, then surfaces the recovery card when that turn makes no
+// host-observable progress instead of spending the second-turn allowance.
 func TestPlainDeliveryReadinessFailureRetriesThenSurfacesRecoveryCard(t *testing.T) {
 	todoWrite, _ := tool.LookupBuiltin("todo_write")
 	reg := tool.NewRegistry()
@@ -719,8 +720,8 @@ func TestPlainDeliveryReadinessFailureRetriesThenSurfacesRecoveryCard(t *testing
 	if ev.Readiness == nil || len(ev.Readiness.Missing) == 0 {
 		t.Fatalf("TurnDone.Readiness = %+v, want missing requirements for the recovery card", ev.Readiness)
 	}
-	if prov.call != 5 {
-		t.Fatalf("provider calls = %d, want 5 (work + final answer + two bounded readiness retries)", prov.call)
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want 4 (work + final answer + one no-progress readiness retry)", prov.call)
 	}
 	if got := c.GoalStatus(); got != GoalStatusStopped {
 		t.Fatalf("GoalStatus() = %q, want stopped (no goal involved)", got)

--- a/internal/control/goal_runtime_test.go
+++ b/internal/control/goal_runtime_test.go
@@ -686,10 +686,10 @@ func TestGoalDeliveryWorkflowCompletesAfterVerifiedSignoff(t *testing.T) {
 	}
 }
 
-// TestPlainDeliveryReadinessFailureSurfacesRecoveryCardWithoutRetries covers
-// the plain (non-Goal) closed-loop case: readiness failure ends the run on
-// the first final answer, surfaces the recovery card, and never auto-continues.
-func TestPlainDeliveryReadinessFailureSurfacesRecoveryCardWithoutRetries(t *testing.T) {
+// TestPlainDeliveryReadinessFailureRetriesThenSurfacesRecoveryCard covers the
+// plain (non-Goal) closed-loop case: the host retries known readiness gaps and
+// surfaces the recovery card only after the bounded attempts make no progress.
+func TestPlainDeliveryReadinessFailureRetriesThenSurfacesRecoveryCard(t *testing.T) {
 	todoWrite, _ := tool.LookupBuiltin("todo_write")
 	reg := tool.NewRegistry()
 	reg.Add(todoWrite)
@@ -698,7 +698,7 @@ func TestPlainDeliveryReadinessFailureSurfacesRecoveryCardWithoutRetries(t *test
 		{toolCallChunk("w1", "write_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
 		{toolCallChunk("t0", "todo_write", `{"todos":[{"content":"Ship main","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
 		textTurn("premature final"),
-		textTurn("extra turn that must never run"),
+		textTurn("still incomplete"),
 	}}
 	// "implement main" is an unanchored mutation: the standard policy derives
 	// closed-loop evidence without any selectable delivery profile.
@@ -719,8 +719,8 @@ func TestPlainDeliveryReadinessFailureSurfacesRecoveryCardWithoutRetries(t *test
 	if ev.Readiness == nil || len(ev.Readiness.Missing) == 0 {
 		t.Fatalf("TurnDone.Readiness = %+v, want missing requirements for the recovery card", ev.Readiness)
 	}
-	if prov.call != 3 {
-		t.Fatalf("provider calls = %d, want 3 (work turn + final answer, no readiness retries)", prov.call)
+	if prov.call != 5 {
+		t.Fatalf("provider calls = %d, want 5 (work + final answer + two bounded readiness retries)", prov.call)
 	}
 	if got := c.GoalStatus(); got != GoalStatusStopped {
 		t.Fatalf("GoalStatus() = %q, want stopped (no goal involved)", got)

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -43,9 +43,10 @@ func finalReadinessWithAttempts(err error, attempts int) error {
 	return &copy
 }
 
-// hasPendingUserWork reads only already-owned in-memory state and an already
-// open inbox Store. It never creates an inbox or holds a Controller lock while
-// taking an Agent/Store lock.
+// hasPendingUserWork reads only already-owned state and an already open inbox
+// Store. It never creates an inbox or holds a Controller lock while taking an
+// Agent/Store lock. A busy or unreadable durable inbox conservatively yields to
+// potential user work.
 func (c *Controller) hasPendingUserWork() bool {
 	if c == nil {
 		return false
@@ -67,7 +68,17 @@ func (c *Controller) hasPendingUserWork() bool {
 	if store == nil {
 		return false
 	}
-	for _, item := range store.CachedSnapshot().Items {
+	snapshot, err := store.TryFreshSnapshot()
+	if err != nil {
+		return true
+	}
+	if snapshot.Readonly {
+		return true
+	}
+	for _, item := range snapshot.Items {
+		if item.RunID != "" && item.RunID != sessioninbox.ProcessRunID() {
+			return true
+		}
 		switch item.State {
 		case sessioninbox.StateQueued, sessioninbox.StateBlocked,
 			sessioninbox.StateUncertain, sessioninbox.StateSteerAccepted:
@@ -122,7 +133,7 @@ func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error
 		if o.c.executor == nil || !o.c.executor.PrepareFinalReadinessRecovery() {
 			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 		}
-		o.c.noticeDetail(i18n.M.ReadinessContinuing, prompt)
+		o.c.notice(i18n.M.ReadinessContinuing)
 		previousProgress = readinessErr.ProgressKey
 		automaticTurns++
 		turnErr = o.runOrchestratedTurn(ctx, orchestratedTurn{

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -135,10 +135,20 @@ func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error
 		}
 		o.c.notice(i18n.M.ReadinessContinuing)
 		previousProgress = readinessErr.ProgressKey
-		automaticTurns++
-		turnErr = o.runOrchestratedTurn(ctx, orchestratedTurn{
+		nextErr := o.runOrchestratedTurn(ctx, orchestratedTurn{
 			input: prompt, raw: prompt, synthetic: true,
 		})
+		if o.c.executor.RestoreFinalReadinessRecoveryPreparation() {
+			// input.receive, PromptSubmit, or another host preflight ended before
+			// Agent.Run consumed the preparation. Preserve the recovery card and
+			// do not count a model turn that never happened as an attempt.
+			if nextErr != nil {
+				return nextErr
+			}
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
+		}
+		automaticTurns++
+		turnErr = nextErr
 		if turnErr == nil {
 			return nil
 		}

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -1,0 +1,88 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/evidence"
+	"reasonix/internal/i18n"
+)
+
+// A turn that ends owing verification has not failed: the host read what is
+// missing from its own receipts, so asking the user to press continue only asks
+// them to relay a message the host already knows. Bound automatic continuation
+// by whether the gap is still shrinking instead.
+const readinessStallRounds = 2
+
+// continueUntilReady runs known missing requirements as synthetic follow-up
+// turns. The returned error is the last turn's outcome, so callers see one
+// foreground operation regardless of how many bounded continuations it used.
+func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error) error {
+	best, stall := -1, 0
+	for {
+		var readinessErr *agent.FinalReadinessError
+		if !errors.As(turnErr, &readinessErr) {
+			return turnErr
+		}
+		gap := len(readinessErr.Missing)
+		switch {
+		case best < 0 || gap < best:
+			best, stall = gap, 0
+		default:
+			// Compare against the best round, not only the previous round, so
+			// an oscillating gap cannot reset the bound and run forever.
+			stall++
+			if stall >= readinessStallRounds {
+				return turnErr
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		prompt := readinessContinuationPrompt(o.c.goalTodos(), readinessErr.Reason)
+		if prompt == "" {
+			return turnErr
+		}
+		// Preserve the finished turn's receipts. Starting with an empty ledger
+		// would make the gap disappear because its evidence was dropped, not
+		// because the remaining checks actually passed.
+		if o.c.executor == nil || !o.c.executor.PrepareFinalReadinessRecovery() {
+			return turnErr
+		}
+		o.c.noticeDetail(i18n.M.ReadinessContinuing, prompt)
+		turnErr = o.runOrchestratedTurn(ctx, orchestratedTurn{
+			input: prompt, raw: prompt, synthetic: true,
+		})
+	}
+}
+
+// readinessContinuationPrompt states only host-observed missing work. It is an
+// append-only user turn, leaving the system prompt and tool-schema cache prefix
+// unchanged.
+func readinessContinuationPrompt(todos []evidence.TodoItem, reason string) string {
+	var parts []string
+	if incomplete := evidence.IncompleteTodos(todos); len(incomplete) > 0 {
+		var b strings.Builder
+		b.WriteString("these tasks are still incomplete:")
+		for _, todo := range incomplete {
+			fmt.Fprintf(&b, "\n  - %s (%s)", todo.Content, todo.Status)
+		}
+		parts = append(parts, b.String())
+	}
+	if reason = strings.TrimSpace(reason); reason != "" {
+		parts = append(parts, reason)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(agent.ReadinessContinuationPrefix + "\n")
+	for _, part := range parts {
+		b.WriteString("- " + part + "\n")
+	}
+	b.WriteString("Finish it now. Do the remaining work, then verify it and record the outcome.")
+	return b.String()
+}

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -9,54 +9,130 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/evidence"
 	"reasonix/internal/i18n"
+	"reasonix/internal/sessioninbox"
 )
 
-// A turn that ends owing verification has not failed: the host read what is
-// missing from its own receipts, so asking the user to press continue only asks
-// them to relay a message the host already knows. Bound automatic continuation
-// by whether the gap is still shrinking instead.
-const readinessStallRounds = 2
+const (
+	readinessGenericTurns        = 1
+	readinessHighConfidenceTurns = 2
+)
+
+func readinessContinuationBudget(class agent.ReadinessContinuationClass) int {
+	switch class {
+	case agent.ReadinessContinuationGeneric:
+		return readinessGenericTurns
+	case agent.ReadinessContinuationHighConfidence:
+		return readinessHighConfidenceTurns
+	default:
+		return 0
+	}
+}
+
+func readinessMadeProgress(previous, current string) bool {
+	return previous != "" && current != "" && previous != current
+}
+
+func finalReadinessWithAttempts(err error, attempts int) error {
+	var readinessErr *agent.FinalReadinessError
+	if !errors.As(err, &readinessErr) || readinessErr == nil {
+		return err
+	}
+	copy := *readinessErr
+	copy.Missing = append([]string(nil), readinessErr.Missing...)
+	copy.Attempts = attempts
+	return &copy
+}
+
+// hasPendingUserWork reads only already-owned in-memory state and an already
+// open inbox Store. It never creates an inbox or holds a Controller lock while
+// taking an Agent/Store lock.
+func (c *Controller) hasPendingUserWork() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	canceling := c.canceling
+	parked := len(c.parkedTurns) > 0
+	executor := c.executor
+	c.mu.Unlock()
+	if canceling || parked {
+		return true
+	}
+	if executor != nil && executor.HasUnappliedSteer() {
+		return true
+	}
+	c.inbox.mu.Lock()
+	store := c.inbox.store
+	c.inbox.mu.Unlock()
+	if store == nil {
+		return false
+	}
+	for _, item := range store.CachedSnapshot().Items {
+		switch item.State {
+		case sessioninbox.StateQueued, sessioninbox.StateBlocked,
+			sessioninbox.StateUncertain, sessioninbox.StateSteerAccepted:
+			return true
+		}
+	}
+	return false
+}
 
 // continueUntilReady runs known missing requirements as synthetic follow-up
 // turns. The returned error is the last turn's outcome, so callers see one
 // foreground operation regardless of how many bounded continuations it used.
 func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error) error {
-	best, stall := -1, 0
-	for {
+	var initial *agent.FinalReadinessError
+	if !errors.As(turnErr, &initial) || initial == nil {
+		return turnErr
+	}
+	budget := readinessContinuationBudget(initial.ContinuationClass)
+	if budget == 0 {
+		return turnErr
+	}
+	initialAttempts := max(initial.Attempts, 1)
+	automaticTurns := 0
+	previousProgress := initial.ProgressKey
+	for automaticTurns < budget {
 		var readinessErr *agent.FinalReadinessError
-		if !errors.As(turnErr, &readinessErr) {
+		if !errors.As(turnErr, &readinessErr) || readinessErr == nil {
 			return turnErr
-		}
-		gap := len(readinessErr.Missing)
-		switch {
-		case best < 0 || gap < best:
-			best, stall = gap, 0
-		default:
-			// Compare against the best round, not only the previous round, so
-			// an oscillating gap cannot reset the bound and run forever.
-			stall++
-			if stall >= readinessStallRounds {
-				return turnErr
-			}
 		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if o.c.CancelRequested() {
+			return context.Canceled
+		}
+		if o.c.hasPendingUserWork() {
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
+		}
+		if readinessContinuationBudget(readinessErr.ContinuationClass) == 0 {
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
+		}
+		if automaticTurns > 0 && !readinessMadeProgress(previousProgress, readinessErr.ProgressKey) {
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
+		}
 		prompt := readinessContinuationPrompt(o.c.goalTodos(), readinessErr.Reason)
 		if prompt == "" {
-			return turnErr
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 		}
 		// Preserve the finished turn's receipts. Starting with an empty ledger
 		// would make the gap disappear because its evidence was dropped, not
 		// because the remaining checks actually passed.
 		if o.c.executor == nil || !o.c.executor.PrepareFinalReadinessRecovery() {
-			return turnErr
+			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 		}
 		o.c.noticeDetail(i18n.M.ReadinessContinuing, prompt)
+		previousProgress = readinessErr.ProgressKey
+		automaticTurns++
 		turnErr = o.runOrchestratedTurn(ctx, orchestratedTurn{
 			input: prompt, raw: prompt, synthetic: true,
 		})
+		if turnErr == nil {
+			return nil
+		}
 	}
+	return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 }
 
 // readinessContinuationPrompt states only host-observed missing work. It is an
@@ -83,6 +159,6 @@ func readinessContinuationPrompt(todos []evidence.TodoItem, reason string) strin
 	for _, part := range parts {
 		b.WriteString("- " + part + "\n")
 	}
-	b.WriteString("Finish it now. Do the remaining work, then verify it and record the outcome.")
+	b.WriteString("Address only the readiness items above within the original request. Do not expand scope or repeat destructive or external actions. If an item cannot be completed because the environment or permissions are unavailable, record the exact limitation and stop.")
 	return b.String()
 }

--- a/internal/control/readiness_continuation_admission_test.go
+++ b/internal/control/readiness_continuation_admission_test.go
@@ -1,0 +1,49 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/extension"
+	"reasonix/internal/extension/dispatch"
+	"reasonix/internal/extension/protocol"
+	"reasonix/internal/provider"
+)
+
+func TestBlockedReadinessContinuationRemainsRecoverable(t *testing.T) {
+	client := &fakeExtClient{interceptFn: func(_ protocol.InterceptEvent, raw json.RawMessage) (protocol.InterceptResult, error) {
+		var payload dispatch.InputPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return protocol.InterceptResult{}, err
+		}
+		if strings.Contains(payload.Text, agent.ReadinessContinuationPrefix) {
+			return protocol.InterceptResult{Decision: protocol.DecisionBlock, Reason: "synthetic turns disabled"}, nil
+		}
+		return protocol.InterceptResult{Decision: protocol.DecisionContinue}, nil
+	}}
+	c, prov := readinessContinuationController(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented without checks"),
+	}, event.Discard)
+	c.SetExtensions(newExtensionTestDispatcher(client, []extension.InterceptorPoint{extension.PointInputReceive}, nil))
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
+	var readinessErr *agent.FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("blocked continuation error = %v, want the original readiness failure", err)
+	}
+	if readinessErr.Attempts != 1 {
+		t.Fatalf("readiness attempts = %d, want only the original completed turn", readinessErr.Attempts)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want no request for the blocked continuation", prov.call)
+	}
+	if !c.executor.PrepareFinalReadinessRecovery() {
+		t.Fatal("blocked continuation consumed the manual recovery action")
+	}
+}

--- a/internal/control/readiness_continuation_test.go
+++ b/internal/control/readiness_continuation_test.go
@@ -9,8 +9,10 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/i18n"
 	"reasonix/internal/instruction"
 	"reasonix/internal/provider"
+	"reasonix/internal/sessioninbox"
 	"reasonix/internal/tool"
 )
 
@@ -46,6 +48,7 @@ func readinessSyntheticTurns(c *Controller) int {
 
 func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
 	notices := 0
+	readinessNoticeDetail := ""
 	c, prov := readinessContinuationController(t, [][]provider.Chunk{
 		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
 		textTurn("implemented"),
@@ -55,6 +58,9 @@ func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
 	}, event.FuncSink(func(e event.Event) {
 		if e.Kind == event.Notice && e.Text != "" {
 			notices++
+			if e.Text == i18n.M.ReadinessContinuing {
+				readinessNoticeDetail = e.Detail
+			}
 		}
 	}))
 
@@ -73,6 +79,9 @@ func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
 	}
 	if notices == 0 {
 		t.Fatal("automatic readiness continuation did not emit a progress notice")
+	}
+	if readinessNoticeDetail != "" {
+		t.Fatalf("automatic readiness continuation exposed notice detail %q", readinessNoticeDetail)
 	}
 	if c.executor.PrepareFinalReadinessRecovery() {
 		t.Fatal("successful automatic continuation left a manual recovery action pending")
@@ -275,6 +284,32 @@ func TestReadinessContinuationYieldsToCancellationAndPendingUserWork(t *testing.
 		var got *agent.FinalReadinessError
 		if !errors.As(err, &got) || got.Attempts != 1 {
 			t.Fatalf("continuation error = %v, want untouched readiness failure", err)
+		}
+	})
+
+	t.Run("queued inbox follow-up from another store", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.jsonl")
+		executor := agent.New(nil, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+		c := New(Options{Runner: executor, Executor: executor, SessionPath: path})
+		t.Cleanup(c.Close)
+		if snap := c.InboxSnapshot(); len(snap.Items) != 0 {
+			t.Fatalf("initial inbox snapshot = %+v, want empty", snap)
+		}
+
+		external, err := sessioninbox.Open(path, sessioninbox.Limits{})
+		if err != nil {
+			t.Fatalf("open external inbox: %v", err)
+		}
+		defer external.Close()
+		if _, err := external.Enqueue(sessioninbox.EnqueueRequest{
+			Intent:   sessioninbox.IntentFollowup,
+			Envelope: sessioninbox.PromptEnvelope{SubmitText: "external user follow-up"},
+		}); err != nil {
+			t.Fatalf("enqueue external follow-up: %v", err)
+		}
+
+		if !c.hasPendingUserWork() {
+			t.Fatal("pending-user check missed a follow-up committed by another Store")
 		}
 	})
 }

--- a/internal/control/readiness_continuation_test.go
+++ b/internal/control/readiness_continuation_test.go
@@ -3,25 +3,45 @@ package control
 import (
 	"context"
 	"errors"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/instruction"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
 func readinessContinuationController(t *testing.T, turns [][]provider.Chunk, sink event.Sink) (*Controller, *scriptedTurns) {
+	return readinessContinuationControllerWithOptions(t, turns, sink, agent.Options{})
+}
+
+func readinessContinuationControllerWithOptions(t *testing.T, turns [][]provider.Chunk, sink event.Sink, opts agent.Options) (*Controller, *scriptedTurns) {
 	t.Helper()
 	reg := tool.NewRegistry()
 	reg.Add(minimalFakeTool{name: "write_file"})
 	reg.Add(minimalFakeTool{name: "read_file", readOnly: true})
 	reg.Add(minimalFakeTool{name: "bash"})
 	prov := &scriptedTurns{turns: turns}
-	executor := agent.New(prov, reg, agent.NewSession(""), agent.Options{}, event.Discard)
+	executor := agent.New(prov, reg, agent.NewSession("stable-system-prefix"), opts, event.Discard)
 	c := New(Options{Runner: executor, Executor: executor, Sink: sink})
 	t.Cleanup(c.Close)
 	return c, prov
+}
+
+func readinessSyntheticTurns(c *Controller) int {
+	if c == nil || c.executor == nil {
+		return 0
+	}
+	count := 0
+	for _, message := range c.executor.Session().Snapshot() {
+		if message.Role == provider.RoleUser && IsSyntheticUserMessage(message.Content) {
+			count++
+		}
+	}
+	return count
 }
 
 func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
@@ -44,6 +64,13 @@ func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
 	if prov.call < 5 {
 		t.Fatalf("provider calls = %d, want the host to continue through verification and review", prov.call)
 	}
+	if got := readinessSyntheticTurns(c); got != 1 {
+		t.Fatalf("synthetic readiness turns = %d, want 1", got)
+	}
+	messages := c.executor.Session().Snapshot()
+	if len(messages) == 0 || messages[0].Role != provider.RoleSystem || messages[0].Content != "stable-system-prefix" {
+		t.Fatalf("automatic continuation changed the stable system prefix: %+v", messages)
+	}
 	if notices == 0 {
 		t.Fatal("automatic readiness continuation did not emit a progress notice")
 	}
@@ -57,9 +84,33 @@ func TestReadinessContinuationPromptStaysHiddenFromUserHistory(t *testing.T) {
 	if !IsSyntheticUserMessage(prompt) {
 		t.Fatalf("readiness continuation was treated as user-authored text: %q", prompt)
 	}
+	for _, forbidden := range []string{"expand scope", "repeat destructive or external actions", "exact limitation"} {
+		if !strings.Contains(prompt, forbidden) {
+			t.Fatalf("readiness continuation prompt = %q, want safety clause %q", prompt, forbidden)
+		}
+	}
 }
 
-func TestOrdinaryReadinessContinuationStopsAfterStalledGap(t *testing.T) {
+func TestReadinessProgressRequiresTwoDistinctEvidenceKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		previous, current string
+		want              bool
+	}{
+		{name: "changed", previous: "before", current: "after", want: true},
+		{name: "unchanged", previous: "same", current: "same", want: false},
+		{name: "missing previous", current: "after", want: false},
+		{name: "missing current", previous: "before", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := readinessMadeProgress(tc.previous, tc.current); got != tc.want {
+				t.Fatalf("readinessMadeProgress(%q, %q) = %v, want %v", tc.previous, tc.current, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOrdinaryGenericReadinessContinuationStopsAfterOneTurn(t *testing.T) {
 	c, prov := readinessContinuationController(t, [][]provider.Chunk{
 		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
 		textTurn("implemented without checks"),
@@ -68,10 +119,176 @@ func TestOrdinaryReadinessContinuationStopsAfterStalledGap(t *testing.T) {
 	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
 	var readinessErr *agent.FinalReadinessError
 	if !errors.As(err, &readinessErr) {
-		t.Fatalf("stalled continuation error = %v, want final readiness failure", err)
+		t.Fatalf("generic continuation error = %v, want final readiness failure", err)
 	}
-	if prov.call > 4 {
-		t.Fatalf("provider calls = %d, want the unchanged gap bounded after two retries", prov.call)
+	if readinessErr.Attempts != 2 {
+		t.Fatalf("readiness attempts = %d, want original + one automatic turn", readinessErr.Attempts)
+	}
+	if readinessErr.ContinuationClass != agent.ReadinessContinuationGeneric || readinessErr.ProgressKey == "" {
+		t.Fatalf("readiness classification = (%q, %q), want generic with a progress key", readinessErr.ContinuationClass, readinessErr.ProgressKey)
+	}
+	if got := readinessSyntheticTurns(c); got != 1 {
+		t.Fatalf("synthetic readiness turns = %d, want 1", got)
+	}
+	if prov.call > 3 {
+		t.Fatalf("provider calls = %d, want the generic gap bounded after one continuation", prov.call)
+	}
+}
+
+func TestHighConfidenceReadinessGetsSecondTurnOnlyAfterProgress(t *testing.T) {
+	c, _ := readinessContinuationControllerWithOptions(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented without the required project check"),
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		textTurn("reviewed but not verified"),
+		{toolCallChunk("verify", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		textTurn("verified"),
+	}, event.Discard, agent.Options{ProjectChecks: []instruction.VerifyCheck{{
+		Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3,
+	}}})
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
+	if err != nil {
+		t.Fatalf("high-confidence continuation returned error: %v", err)
+	}
+	if got := readinessSyntheticTurns(c); got != 2 {
+		t.Fatalf("synthetic readiness turns = %d, want 2 after review progress", got)
+	}
+}
+
+func TestHighConfidenceReadinessStopsAfterOneTurnWithoutProgress(t *testing.T) {
+	c, _ := readinessContinuationControllerWithOptions(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented without the required project check"),
+		textTurn("still not verified"),
+	}, event.Discard, agent.Options{ProjectChecks: []instruction.VerifyCheck{{
+		Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3,
+	}}})
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
+	var readinessErr *agent.FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("high-confidence continuation error = %v, want final readiness failure", err)
+	}
+	if readinessErr.Attempts != 2 {
+		t.Fatalf("readiness attempts = %d, want original + one no-progress turn", readinessErr.Attempts)
+	}
+	if readinessErr.ContinuationClass != agent.ReadinessContinuationHighConfidence {
+		t.Fatalf("ContinuationClass = %q, want high confidence", readinessErr.ContinuationClass)
+	}
+	if got := readinessSyntheticTurns(c); got != 1 {
+		t.Fatalf("synthetic readiness turns = %d, want 1 without progress", got)
+	}
+	if !c.executor.PrepareFinalReadinessRecovery() {
+		t.Fatal("bounded continuation did not preserve the manual recovery action")
+	}
+}
+
+func TestHighConfidenceReadinessNeverExceedsTwoTurns(t *testing.T) {
+	c, _ := readinessContinuationControllerWithOptions(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented without the required project check"),
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		textTurn("reviewed but not verified"),
+		{toolCallChunk("verify-other", "bash", `{"command":"go test ./internal/agent"}`), {Type: provider.ChunkDone}},
+		textTurn("ran a different verification command"),
+	}, event.Discard, agent.Options{ProjectChecks: []instruction.VerifyCheck{{
+		Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3,
+	}}})
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
+	var readinessErr *agent.FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("high-confidence continuation error = %v, want final readiness failure", err)
+	}
+	if readinessErr.Attempts != 3 {
+		t.Fatalf("readiness attempts = %d, want original + two automatic turns", readinessErr.Attempts)
+	}
+	if got := readinessSyntheticTurns(c); got != 2 {
+		t.Fatalf("synthetic readiness turns = %d, want hard cap 2", got)
+	}
+	if !c.executor.PrepareFinalReadinessRecovery() {
+		t.Fatal("hard-cap exhaustion did not preserve the manual recovery action")
+	}
+}
+
+func TestReadinessContinuationYieldsToCancellationAndPendingUserWork(t *testing.T) {
+	readinessErr := &agent.FinalReadinessError{
+		Attempts: 1, Reason: "run verification", Missing: []string{"verification"},
+		ContinuationClass: agent.ReadinessContinuationGeneric, ProgressKey: "initial",
+	}
+
+	t.Run("cancelled context", func(t *testing.T) {
+		c, prov := readinessContinuationController(t, nil, event.Discard)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := newTurnOrchestrator(c).continueUntilReady(ctx, readinessErr)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("continuation error = %v, want context cancellation", err)
+		}
+		if prov.call != 0 {
+			t.Fatalf("provider calls = %d, want 0 after cancellation", prov.call)
+		}
+	})
+
+	t.Run("controller cancellation requested", func(t *testing.T) {
+		c, prov := readinessContinuationController(t, nil, event.Discard)
+		c.mu.Lock()
+		c.canceling = true
+		c.mu.Unlock()
+		err := newTurnOrchestrator(c).continueUntilReady(context.Background(), readinessErr)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("continuation error = %v, want controller cancellation", err)
+		}
+		if prov.call != 0 {
+			t.Fatalf("provider calls = %d, want 0 after controller cancellation", prov.call)
+		}
+	})
+
+	t.Run("parked user turn", func(t *testing.T) {
+		c, prov := readinessContinuationController(t, nil, event.Discard)
+		c.mu.Lock()
+		c.parkedTurns = append(c.parkedTurns, func(context.Context) error { return nil })
+		c.mu.Unlock()
+		err := newTurnOrchestrator(c).continueUntilReady(context.Background(), readinessErr)
+		var got *agent.FinalReadinessError
+		if !errors.As(err, &got) || got.Attempts != 1 {
+			t.Fatalf("continuation error = %v, want untouched readiness failure", err)
+		}
+		if prov.call != 0 {
+			t.Fatalf("provider calls = %d, want 0 with parked user work", prov.call)
+		}
+	})
+
+	t.Run("queued inbox follow-up", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "session.jsonl")
+		executor := agent.New(nil, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+		c := New(Options{Runner: executor, Executor: executor, SessionPath: path})
+		t.Cleanup(c.Close)
+		if _, err := c.EnqueueInbox(InboxRequest{Submit: "user follow-up"}); err != nil {
+			t.Fatalf("EnqueueInbox: %v", err)
+		}
+		if err := c.SetInboxPausedPassive(true); err != nil {
+			t.Fatalf("SetInboxPausedPassive: %v", err)
+		}
+		err := newTurnOrchestrator(c).continueUntilReady(context.Background(), readinessErr)
+		var got *agent.FinalReadinessError
+		if !errors.As(err, &got) || got.Attempts != 1 {
+			t.Fatalf("continuation error = %v, want untouched readiness failure", err)
+		}
+	})
+}
+
+func TestReadinessContinuationZeroClassDefaultsToManualRecovery(t *testing.T) {
+	c, prov := readinessContinuationController(t, nil, event.Discard)
+	want := &agent.FinalReadinessError{Attempts: 1, Reason: "legacy readiness gap", Missing: []string{"verification"}}
+	err := newTurnOrchestrator(c).continueUntilReady(context.Background(), want)
+	var got *agent.FinalReadinessError
+	if !errors.As(err, &got) || got != want {
+		t.Fatalf("continuation error = %v, want the original conservative readiness error", err)
+	}
+	if prov.call != 0 {
+		t.Fatalf("provider calls = %d, want 0 for an unclassified legacy error", prov.call)
 	}
 }
 

--- a/internal/control/readiness_continuation_test.go
+++ b/internal/control/readiness_continuation_test.go
@@ -1,0 +1,96 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func readinessContinuationController(t *testing.T, turns [][]provider.Chunk, sink event.Sink) (*Controller, *scriptedTurns) {
+	t.Helper()
+	reg := tool.NewRegistry()
+	reg.Add(minimalFakeTool{name: "write_file"})
+	reg.Add(minimalFakeTool{name: "read_file", readOnly: true})
+	reg.Add(minimalFakeTool{name: "bash"})
+	prov := &scriptedTurns{turns: turns}
+	executor := agent.New(prov, reg, agent.NewSession(""), agent.Options{}, event.Discard)
+	c := New(Options{Runner: executor, Executor: executor, Sink: sink})
+	t.Cleanup(c.Close)
+	return c, prov
+}
+
+func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
+	notices := 0
+	c, prov := readinessContinuationController(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented"),
+		{toolCallChunk("verify", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented and verified"),
+	}, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice && e.Text != "" {
+			notices++
+		}
+	}))
+
+	if err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", ""); err != nil {
+		t.Fatalf("ordinary turn returned a readiness failure: %v", err)
+	}
+	if prov.call < 5 {
+		t.Fatalf("provider calls = %d, want the host to continue through verification and review", prov.call)
+	}
+	if notices == 0 {
+		t.Fatal("automatic readiness continuation did not emit a progress notice")
+	}
+	if c.executor.PrepareFinalReadinessRecovery() {
+		t.Fatal("successful automatic continuation left a manual recovery action pending")
+	}
+}
+
+func TestReadinessContinuationPromptStaysHiddenFromUserHistory(t *testing.T) {
+	prompt := readinessContinuationPrompt(nil, "run the missing verification")
+	if !IsSyntheticUserMessage(prompt) {
+		t.Fatalf("readiness continuation was treated as user-authored text: %q", prompt)
+	}
+}
+
+func TestOrdinaryReadinessContinuationStopsAfterStalledGap(t *testing.T) {
+	c, prov := readinessContinuationController(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented without checks"),
+	}, event.Discard)
+
+	err := newTurnOrchestrator(c).runGoalLoopWithRawDisplay(context.Background(), "update main.go", "update main.go", "")
+	var readinessErr *agent.FinalReadinessError
+	if !errors.As(err, &readinessErr) {
+		t.Fatalf("stalled continuation error = %v, want final readiness failure", err)
+	}
+	if prov.call > 4 {
+		t.Fatalf("provider calls = %d, want the unchanged gap bounded after two retries", prov.call)
+	}
+}
+
+func TestEditedOrdinaryTurnAlsoFinishesKnownChecks(t *testing.T) {
+	c, prov := readinessContinuationController(t, [][]provider.Chunk{
+		{toolCallChunk("write", "write_file", `{"path":"main.go","content":"package main"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented"),
+		{toolCallChunk("verify", "bash", `{"command":"go test ./..."}`), {Type: provider.ChunkDone}},
+		{toolCallChunk("review", "read_file", `{"path":"main.go"}`), {Type: provider.ChunkDone}},
+		textTurn("implemented and verified"),
+	}, event.Discard)
+
+	err := newTurnOrchestrator(c).runEditedGoalLoopWithRawDisplay(
+		context.Background(), "update main.go", "update main.go", "", "old request",
+	)
+	if err != nil {
+		t.Fatalf("edited ordinary turn returned a readiness failure: %v", err)
+	}
+	if prov.call < 5 {
+		t.Fatalf("provider calls = %d, want edited turns to share automatic readiness continuation", prov.call)
+	}
+}

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -575,11 +575,15 @@ func (o *turnOrchestrator) advanceGoalAfterTurn(ctx context.Context, expectedCon
 	var readinessErr *agent.FinalReadinessError
 	pauseCause, pauseReason, runPaused := goalPauseFromRunError(turnErr)
 	if errors.As(turnErr, &readinessErr) {
+		progressKey := readinessErr.ProgressKey
+		if progressKey == "" {
+			progressKey = readinessErr.Reason
+		}
 		readiness = agent.ReadinessResult{
 			Ready:       false,
 			Missing:     append([]string(nil), readinessErr.Missing...),
 			Reason:      readinessErr.Reason,
-			ProgressKey: readinessErr.Reason,
+			ProgressKey: progressKey,
 		}
 	} else if turnErr != nil && !runPaused {
 		// Terminal provider/host error: stop auto-continue without an FSM

--- a/internal/control/turn_orchestrator.go
+++ b/internal/control/turn_orchestrator.go
@@ -423,6 +423,7 @@ func (o *turnOrchestrator) runGoalLoopWithFrozenImagesRawDisplay(ctx context.Con
 
 func (o *turnOrchestrator) runGoalLoopWithPreparedTurn(ctx context.Context, turn orchestratedTurn) error {
 	expectedContinuationEpoch := o.c.goals.continuationToken()
+	ctx = agent.WithAutomaticReadinessContinuation(ctx)
 	ctx = agent.WithSubagentImageCandidates(ctx, turn.imageCandidates)
 	err := o.runOrchestratedTurn(ctx, turn)
 	if err != nil {
@@ -431,13 +432,17 @@ func (o *turnOrchestrator) runGoalLoopWithPreparedTurn(ctx context.Context, turn
 			o.c.stopGoal(GoalStatusStopped)
 			return err
 		}
-		if !goalTurnErrorAbsorbable(err) || !o.c.goals.active() {
-			// Terminal provider/host error (or a plain non-Goal Delivery
-			// readiness failure): stop auto-continue. With no active Goal the
-			// error surfaces the recovery card; with a Goal it stays running so
-			// the next ordinary user message keeps the same scope.
+		if !goalTurnErrorAbsorbable(err) {
+			// Terminal provider/host error: stop auto-continue. With a Goal it
+			// stays running so the next ordinary user message keeps the scope.
 			o.c.goalUsageTee.setActiveRecorder(nil)
 			return err
+		}
+		if !o.c.goals.active() {
+			// The host knows exactly what this ordinary turn still owes. Finish
+			// it automatically instead of making the user relay "continue".
+			o.c.goalUsageTee.setActiveRecorder(nil)
+			return o.continueUntilReady(ctx, err)
 		}
 		// FinalReadinessError is absorbed below: the Goal FSM continues with
 		// the missing requirements as the next turn's prompt.
@@ -451,6 +456,7 @@ func (o *turnOrchestrator) runEditedGoalLoopWithRawDisplay(ctx context.Context, 
 
 func (o *turnOrchestrator) runEditedGoalLoopWithImageRefsRawDisplay(ctx context.Context, input, raw, imageRefs, display, original string) error {
 	expectedContinuationEpoch := o.c.goals.continuationToken()
+	ctx = agent.WithAutomaticReadinessContinuation(ctx)
 	turn := o.c.prepareOrchestratedTurnImages(orchestratedTurn{
 		input: input, raw: raw, imageRefs: imageRefs, display: display, editedOriginal: original,
 	})
@@ -462,9 +468,13 @@ func (o *turnOrchestrator) runEditedGoalLoopWithImageRefsRawDisplay(ctx context.
 			o.c.stopGoal(GoalStatusStopped)
 			return err
 		}
-		if !goalTurnErrorAbsorbable(err) || !o.c.goals.active() {
+		if !goalTurnErrorAbsorbable(err) {
 			o.c.goalUsageTee.setActiveRecorder(nil)
 			return err
+		}
+		if !o.c.goals.active() {
+			o.c.goalUsageTee.setActiveRecorder(nil)
+			return o.continueUntilReady(ctx, err)
 		}
 	}
 	return o.continueGoal(ctx, expectedContinuationEpoch, err)

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -36,6 +36,7 @@ type Messages struct {
 	TurnCancelled          string // shown when Ctrl-C aborts the in-flight turn but the chat keeps running
 	InterruptedRecovery    string // replay notice for a durable interrupted turn
 	FinalReadinessRecovery string // replay hint for a durable final-readiness pause
+	ReadinessContinuing    string // host is automatically finishing known readiness gaps
 	RecoveryPaused         string // controlled Auto retry pause; user can continue in the next message
 	ReceiptVerified        string // end-of-turn receipt, nothing unproven
 	ReceiptGapsHeader      string // end-of-turn receipt, header above the unproven list

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -12,6 +12,7 @@ var English = Messages{
 	TurnCancelled:          "cancelled — back to prompt",
 	InterruptedRecovery:    "This turn was interrupted. Partial output is kept for reference; only completed tool pairs and a bounded recovery summary enter the next model turn. Inspect the workspace before continuing or reverting changes.",
 	FinalReadinessRecovery: "Task completion checks are paused. Run /continue-checks to preserve completed evidence and finish the remaining checks.",
+	ReadinessContinuing:    "This turn still owes checks; Reasonix is finishing them automatically.",
 	RecoveryPaused:         "Automatic retries paused. Reasonix stopped repeated attempts and kept completed work. Send “Continue” to start a fresh attempt, or add instructions to change direction.",
 	ReceiptVerified:        "nothing left unverified",
 	ReceiptGapsHeader:      "not verified:",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -13,6 +13,7 @@ var Chinese = Messages{
 	TurnCancelled:          "已取消 — 回到提示符",
 	InterruptedRecovery:    "本轮已中断。部分输出会永久保留供查看；只有完整工具调用及结果和有界恢复摘要会进入模型下一轮。继续或回滚前请先检查当前工作区。",
 	FinalReadinessRecovery: "任务收尾检查已暂停。运行 /continue-checks 可保留已完成证据并继续剩余检查。",
+	ReadinessContinuing:    "本轮仍有检查未完成，Reasonix 正在自动补齐。",
 	RecoveryPaused:         "已暂停自动重试。Reasonix 已停止重复尝试，并保留已完成的工作。发送“继续”即可开始新一轮，也可以补充要求来调整方向。",
 	ReceiptVerified:        "没有未经验证的部分",
 	ReceiptGapsHeader:      "未验证:",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -13,6 +13,7 @@ var ChineseTraditional = Messages{
 	TurnCancelled:          "已取消 — 回到提示符",
 	InterruptedRecovery:    "本輪已中斷。部分輸出會永久保留供查看；只有完整工具呼叫及結果和有界恢復摘要會進入模型下一輪。繼續或回復前請先檢查目前工作區。",
 	FinalReadinessRecovery: "任務收尾檢查已暫停。執行 /continue-checks 可保留已完成證據並繼續剩餘檢查。",
+	ReadinessContinuing:    "本輪仍有檢查未完成，Reasonix 正在自動補齊。",
 	RecoveryPaused:         "已暫停自動重試。Reasonix 已停止重複嘗試，並保留已完成的工作。傳送「繼續」即可開始新一輪，也可以補充要求來調整方向。",
 	ReceiptVerified:        "沒有未經驗證的部分",
 	ReceiptGapsHeader:      "未驗證:",

--- a/internal/sessioninbox/fresh_snapshot_test.go
+++ b/internal/sessioninbox/fresh_snapshot_test.go
@@ -1,0 +1,72 @@
+package sessioninbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/filelock"
+)
+
+func TestTryFreshSnapshotReloadsAnotherStoreCommit(t *testing.T) {
+	session := filepath.Join(t.TempDir(), "s.jsonl")
+	first, err := Open(session, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	second, err := Open(session, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+
+	receipt, err := second.Enqueue(EnqueueRequest{Envelope: PromptEnvelope{SubmitText: "new user work"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(first.dir, manifestName)
+	before, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := first.CachedSnapshot(); len(got.Items) != 0 {
+		t.Fatalf("cached snapshot unexpectedly refreshed: %+v", got)
+	}
+	snapshot, err := first.TryFreshSnapshot()
+	if err != nil {
+		t.Fatalf("TryFreshSnapshot: %v", err)
+	}
+	if len(snapshot.Items) != 1 || snapshot.Items[0].ID != receipt.ItemID {
+		t.Fatalf("fresh snapshot = %+v, want external item %q", snapshot, receipt.ItemID)
+	}
+	after, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("TryFreshSnapshot mutated the durable manifest")
+	}
+	if got := first.CachedSnapshot(); len(got.Items) != 0 {
+		t.Fatalf("read-only fresh snapshot mutated the Store cache: %+v", got)
+	}
+}
+
+func TestTryFreshSnapshotDoesNotWaitForDiskLock(t *testing.T) {
+	session := filepath.Join(t.TempDir(), "s.jsonl")
+	s, err := Open(session, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	release, err := filelock.TryAcquire(filepath.Join(s.dir, diskLockName))
+	if err != nil {
+		t.Fatalf("hold inbox disk lock: %v", err)
+	}
+	defer release()
+	if _, err := s.TryFreshSnapshot(); !errors.Is(err, ErrSnapshotBusy) {
+		t.Fatalf("TryFreshSnapshot error = %v, want ErrSnapshotBusy", err)
+	}
+}

--- a/internal/sessioninbox/store.go
+++ b/internal/sessioninbox/store.go
@@ -252,6 +252,18 @@ func (s *Store) Snapshot() InboxSnapshot {
 	return s.snapshotLocked()
 }
 
+// CachedSnapshot returns the Store's current in-memory metadata without taking
+// the cross-process disk lock. It is for owner-local admission decisions that
+// must not add disk-lock latency; Snapshot remains the authoritative refresh.
+func (s *Store) CachedSnapshot() InboxSnapshot {
+	if s == nil {
+		return InboxSnapshot{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshotLocked()
+}
+
 func (s *Store) snapshotLocked() InboxSnapshot {
 	m := s.man
 	if m == nil {

--- a/internal/sessioninbox/store.go
+++ b/internal/sessioninbox/store.go
@@ -264,11 +264,55 @@ func (s *Store) CachedSnapshot() InboxSnapshot {
 	return s.snapshotLocked()
 }
 
+// TryFreshSnapshot reads current metadata from disk without waiting for either
+// the Store mutex or the cross-process transaction lock. It does not perform
+// recovery, migration, cleanup, or any other durable mutation. Callers making
+// latency-sensitive admission decisions should treat any error conservatively.
+func (s *Store) TryFreshSnapshot() (InboxSnapshot, error) {
+	if s == nil {
+		return InboxSnapshot{}, ErrClosed
+	}
+	if !s.mu.TryLock() {
+		return InboxSnapshot{}, ErrSnapshotBusy
+	}
+	defer s.mu.Unlock()
+	if s.closed {
+		return InboxSnapshot{}, ErrClosed
+	}
+	if err := validatePrivateDir(s.dir); err != nil {
+		return InboxSnapshot{}, fmt.Errorf("sessioninbox: validate inbox directory: %w", err)
+	}
+	release, err := filelock.TryAcquire(filepath.Join(s.dir, diskLockName))
+	if err != nil {
+		if errors.Is(err, filelock.ErrHeld) {
+			return InboxSnapshot{}, ErrSnapshotBusy
+		}
+		return InboxSnapshot{}, fmt.Errorf("sessioninbox: acquire disk lock: %w", err)
+	}
+	defer release()
+	data, err := readRegularFile(filepath.Join(s.dir, manifestName), maxManifestBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return s.snapshotLocked(), nil
+	}
+	if err != nil {
+		return InboxSnapshot{}, fmt.Errorf("sessioninbox: read manifest: %w", err)
+	}
+	man, err := decodeManifest(data)
+	if err != nil {
+		return InboxSnapshot{}, fmt.Errorf("sessioninbox: decode manifest: %w", err)
+	}
+	return s.snapshotFromManifestLocked(man, man.SchemaVersion > SchemaVersion), nil
+}
+
 func (s *Store) snapshotLocked() InboxSnapshot {
 	m := s.man
 	if m == nil {
 		m = emptyManifest(s.runID)
 	}
+	return s.snapshotFromManifestLocked(m, s.readonly)
+}
+
+func (s *Store) snapshotFromManifestLocked(m *manifest, readonly bool) InboxSnapshot {
 	items := append([]InboxItemMeta(nil), m.Items...)
 	return InboxSnapshot{
 		SchemaVersion: m.SchemaVersion,
@@ -276,7 +320,7 @@ func (s *Store) snapshotLocked() InboxSnapshot {
 		Paused:        m.Paused,
 		Recovered:     m.Recovered,
 		RecoveredN:    m.RecoveredN,
-		Readonly:      s.readonly,
+		Readonly:      readonly,
 		RunID:         m.RunID,
 		SessionPath:   s.session,
 		Items:         items,

--- a/internal/sessioninbox/types.go
+++ b/internal/sessioninbox/types.go
@@ -60,6 +60,7 @@ var (
 	ErrInvalidState        = errors.New("inbox item state does not allow this operation")
 	ErrSchemaReadonly      = errors.New("inbox schema is newer and is read-only")
 	ErrClosed              = errors.New("inbox is closed")
+	ErrSnapshotBusy        = errors.New("inbox snapshot is busy")
 	ErrEmpty               = errors.New("inbox item body is empty")
 	ErrPaused              = errors.New("inbox is paused")
 	ErrIdempotencyConflict = errors.New("idempotency key was already used for different input")


### PR DESCRIPTION
## Summary

- automatically continue ordinary interactive turns when the host can name a safe remaining verification or review obligation
- classify readiness recovery as `generic`, `high_confidence`, or conservative `none`
- allow one generic follow-up, or at most two high-confidence follow-ups when the first produces host-observed evidence progress
- preserve completed evidence and the existing manual “continue verification” recovery path
- yield to cancellation, parked turns, unapplied steer, and queued inbox follow-ups before starting another model turn
- keep host-generated continuation prompts out of user-visible history

## Root cause

The fact-driven execution refactor allowed recoverable ordinary-turn gaps to end as `Partial` before the controller could observe a readiness error. The first version of this PR restored automatic continuation, but bounded it only by two non-shrinking gap rounds. A shrinking category count could therefore keep ordinary tasks running longer than intended, and the controller lacked a structured way to distinguish safe verification from side-effectful or externally blocked gaps.

## Fix

The Agent now reports a structured continuation class and an evidence-ledger progress key with `FinalReadinessError`.

- `generic`: ordinary targeted verification or diff review; one automatic follow-up
- `high_confidence`: explicit project checks, unfinished Todo or acceptance criteria, and strict verification/review/signoff; at most two follow-ups, with evidence progress required before the second
- `none`: advisory/document-only work, forbidden tests, blocked environment or permissions, and any action, mutation, or capability gap

The controller freezes the budget from the first readiness error, keeps all counters on the current call stack, and checks cancellation and pending user work before each synthetic turn. Non-readiness errors, provider/tool failures, run pauses, and exhausted budgets return immediately. Goal execution remains on its existing FSM and token/round budgets.

The synthetic prompt remains an append-only hidden user turn. It is limited to host-observed gaps, forbids scope expansion and repeated destructive/external actions, and asks the model to record concrete environmental limitations before stopping.

## Safety and compatibility

- Ask, Auto, and Yolo tool-approval semantics are unchanged
- ordinary automatic recovery inherits the original context, sandbox, permissions, and approval gate
- direct Agent API and headless `Controller.Run` retain their single-turn/Partial behavior
- actions, mutations, capability gaps, environment/permission blocks, and forbidden tests do not auto-continue
- no persisted format, Wails/ACP/HTTP/CLI contract, dependency, authentication, privilege, system prompt, or tool-schema changes
- `/continue-checks`, recovery cards, and the legacy delivery recovery entry point remain available

## Cache impact

The stable system prompt and tool schema bytes are unchanged. A follow-up is appended as a synthetic user turn only when a concrete host-observed gap exists, so the preceding request remains cacheable.

Cache-impact: low - only an append-only synthetic user turn is added after a safe concrete readiness gap; stable system and tool-schema prefix bytes are unchanged.
Cache-guard: `TestReadinessContinuationPromptStaysHiddenFromUserHistory` and `TestOrdinaryTurnAutomaticallyFinishesKnownChecks` verify the hidden append-only path and stable system prefix.

Documentation-impact: none - existing user documentation does not describe the manual-only readiness path, and the existing progress notice explains automatic verification in the UI.

## Verification

- `go test ./internal/agent ./internal/control ./internal/acp ./internal/cli`
- `go test -race ./internal/agent ./internal/control`
- `go test ./...`
- `go vet ./...`
- `go run ./tools/repolint`
- `git diff --check`
