### PR TITLE
Fix desktop runtime reload process replacement / 修复桌面运行时重载进程替换

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -965,6 +965,19 @@ func (a *App) SubmitToTab(tabID, input string) error {
 // reclaim remote control first — typing locally is the grab-back gesture.
 func (a *App) submitToTab(tabID, input string, fromBridge bool, submissionID ...string) error {
 	trimmed := strings.TrimSpace(input)
+	if trimmed == "/reload" {
+		tab, _ := a.tabAndCtrlByID(tabID)
+		if a.tabIsReadOnly(tab) {
+			return readOnlyChannelErr()
+		}
+		if tab == nil {
+			return a.workspaceNotReadyErr(tab)
+		}
+		if !fromBridge && a.botBridge != nil {
+			a.botBridge.reclaimFromDesktop(tab.ID)
+		}
+		return a.ReloadRuntime(tab.ID)
+	}
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		tab, _ := a.tabAndCtrlByID(tabID)
 		if a.tabIsReadOnly(tab) {
@@ -6797,6 +6810,7 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "theme", Description: i18n.M.CmdTheme, Kind: "builtin", Group: "management"},
 		{Name: "skill", Description: i18n.M.CmdSkill, Kind: "builtin", Group: "skills"},
 		{Name: "reload-cmd", Description: i18n.M.CmdReloadCmd, Kind: "builtin", Group: "management"},
+		{Name: "reload", Description: i18n.M.CmdReload, Kind: "builtin", Group: "management"},
 	}
 	a.mu.RLock()
 	ctrl := a.activeCtrlLocked()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -395,6 +395,9 @@ func TestCommandsIncludesDocsAndEffortNotThinking(t *testing.T) {
 	if !hasCommand(cmds, "effort") {
 		t.Fatalf("Commands() should include effort: %+v", cmds)
 	}
+	if !hasCommand(cmds, "reload") {
+		t.Fatalf("Commands() should include reload: %+v", cmds)
+	}
 	if hasCommand(cmds, "thinking") {
 		t.Fatalf("Commands() should not include thinking: %+v", cmds)
 	}

--- a/desktop/reload_runtime_test.go
+++ b/desktop/reload_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/jobs"
+	"reasonix/internal/provider"
 )
 
 // reloadRuntimeFixture writes the config the ReloadRuntime tests share (one
@@ -141,6 +143,42 @@ func TestReloadRuntimeSwapsAndClosesOldAfterSwap(t *testing.T) {
 			t.Fatal("no runtime:rebuilt fence emitted")
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestSubmitReloadRoutesToRuntimeReload pins the desktop slash-command entry:
+// /reload is a local management action, not a user turn sent to the model.
+func TestSubmitReloadRoutesToRuntimeReload(t *testing.T) {
+	dir := reloadRuntimeFixture(t)
+	oldPath := filepath.Join(dir, "old.jsonl")
+	oldExec := agent.New(nil, nil, agent.NewSession("old system prompt"), agent.Options{}, event.Discard)
+	closed := false
+	oldCtrl := control.New(control.Options{
+		Executor:    oldExec,
+		SessionDir:  dir,
+		SessionPath: oldPath,
+		Label:       "old",
+		Sink:        event.Discard,
+		Cleanup:     func() { closed = true },
+	})
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := reloadRuntimeTab(t, app, dir, oldCtrl)
+
+	if err := app.SubmitToTab(tab.ID, "/reload"); err != nil {
+		t.Fatalf("SubmitToTab(/reload): %v", err)
+	}
+	if tab.Ctrl == oldCtrl {
+		t.Fatal("/reload did not replace the outgoing controller")
+	}
+	if !closed {
+		t.Fatal("/reload did not retire the outgoing controller after the swap")
+	}
+	for _, message := range tab.Ctrl.History() {
+		if message.Role == provider.RoleUser && strings.TrimSpace(message.Content) == "/reload" {
+			t.Fatal("/reload leaked into conversation history as a model turn")
+		}
 	}
 }
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -62,7 +62,8 @@ install runtimes you trust completely.
 Changing an installed extension (install, update, enable/disable, or
 `--link` content changes) never mutates a running turn. Reloading is one
 fail-atomic operation through every interactive frontend — CLI `/reload`,
-Desktop **Reload Runtime** (command palette), Serve `/reload`, and the ACP
+Desktop `/reload` (composer slash menu) or **Reload Runtime** (command palette),
+Serve `/reload`, and the ACP
 vendor method `_reasonix.io/session/reloadExtensions`:
 
 1. If a turn or background work is running, CLI/Desktop/ACP queue exactly one

--- a/docs/EXTENSIONS.zh-CN.md
+++ b/docs/EXTENSIONS.zh-CN.md
@@ -55,7 +55,8 @@ reasonix plugin doctor <name>                                      # 校验
 
 已安装扩展发生变化（安装、更新、启用/禁用、`--link` 内容变化）绝不会
 修改正在运行的回合。所有交互前端都提供失败原子的重载入口——CLI
-`/reload`、Desktop「重载运行时」（命令面板）、Serve `/reload`、ACP
+`/reload`、Desktop `/reload`（输入框斜杠菜单）或「重载运行时」（命令面板）、
+Serve `/reload`、ACP
 vendor method `_reasonix.io/session/reloadExtensions`：
 
 1. 回合或后台任务运行中，CLI/Desktop/ACP 只排队一次；Serve 会拒绝本次

--- a/internal/boot/extension_sidecar_test.go
+++ b/internal/boot/extension_sidecar_test.go
@@ -511,6 +511,112 @@ func TestRebuildRetiresOldSidecars(t *testing.T) {
 	waitForCond(t, "new sidecar exit", 10*time.Second, newClient.Exited)
 }
 
+// TestExplicitReloadReplacesUnchangedSidecar pins the linked-development
+// contract: a user-requested reload must start a fresh process even when the
+// manifest graph is unchanged. The provider-visible prefix stays stable when
+// the replacement contributes identical bytes.
+func TestExplicitReloadReplacesUnchangedSidecar(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeRuntimeFixture(t, dir)
+	pidFile := filepath.Join(dir, "linked-sidecar.pid")
+	installBootFakePlugin(t, config.ReasonixHomeDir(), "linkedplugin", map[string]any{
+		"env": map[string]string{bootFakeEnvPIDFile: pidFile},
+	})
+
+	oldRes, err := BuildRuntime(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("BuildRuntime: %v", err)
+	}
+	oldPID := readFakePID(t, pidFile)
+	if err := os.Remove(pidFile); err != nil {
+		oldRes.Controller.Close()
+		t.Fatalf("remove first-generation PID file: %v", err)
+	}
+	newRes, err := RebuildFrom(context.Background(), oldRes, Options{
+		RuntimeReload: RuntimeReload{ForceFullRebuild: true},
+	})
+	if err != nil {
+		oldRes.Controller.Close()
+		t.Fatalf("RebuildFrom: %v", err)
+	}
+	t.Cleanup(newRes.Controller.Close)
+
+	oldClient := oldRes.Extensions.Client("linkedplugin")
+	newClient := newRes.Extensions.Client("linkedplugin")
+	if oldClient == nil || newClient == nil {
+		t.Fatal("both generations must have a sidecar client")
+	}
+	if oldClient == newClient {
+		t.Fatal("explicit reload adopted the outgoing sidecar instead of starting a replacement")
+	}
+	newPID := readFakePID(t, pidFile)
+	if newPID == oldPID {
+		t.Fatalf("explicit reload kept sidecar PID %d", oldPID)
+	}
+	if oldClient.Exited() {
+		t.Fatal("outgoing sidecar exited before the replacement controller published")
+	}
+	if oldRes.Snapshot.CacheHash() != newRes.Snapshot.CacheHash() {
+		t.Fatalf("unchanged extension bytes changed cache hash: old=%s new=%s", oldRes.Snapshot.CacheHash(), newRes.Snapshot.CacheHash())
+	}
+
+	oldRes.Controller.Close()
+	waitForCond(t, "outgoing sidecar exit", 10*time.Second, oldClient.Exited)
+	if newClient.Exited() {
+		t.Fatal("replacement sidecar exited with the outgoing controller")
+	}
+}
+
+// TestExplicitReloadSidecarFailureKeepsOldProcess proves that forcing a fresh
+// linked process does not weaken reload failure atomicity. The replacement can
+// fail before publish while the previous process keeps answering requests.
+func TestExplicitReloadSidecarFailureKeepsOldProcess(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeRuntimeFixture(t, dir)
+	installBootFakePlugin(t, config.ReasonixHomeDir(), "stable-linked", map[string]any{
+		"required": true,
+	})
+
+	oldRes, err := BuildRuntime(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("BuildRuntime: %v", err)
+	}
+	t.Cleanup(oldRes.Controller.Close)
+	oldClient := oldRes.Extensions.Client("stable-linked")
+	if oldClient == nil {
+		t.Fatal("first build has no sidecar client")
+	}
+
+	// Keep the declared graph identical while making the linked program fail on
+	// its next launch. Without the explicit-restart instruction, RebuildFrom
+	// would adopt oldClient and incorrectly report success.
+	installBootFakePlugin(t, config.ReasonixHomeDir(), "stable-linked", map[string]any{
+		"required": true,
+		"env":      map[string]string{bootFakeEnvExitImmediately: "1"},
+	})
+	_, err = RebuildFrom(context.Background(), oldRes, Options{
+		RuntimeReload: RuntimeReload{ForceFullRebuild: true},
+	})
+	if err == nil {
+		t.Fatal("explicit reload succeeded after the replacement sidecar failed")
+	}
+	var requiredErr *sidecar.RequiredStartError
+	if !errors.As(err, &requiredErr) {
+		t.Fatalf("reload error %v is not a RequiredStartError", err)
+	}
+	if oldClient.Exited() || oldRes.Runtime.Closed() {
+		t.Fatal("failed explicit reload retired the outgoing runtime")
+	}
+	result, interceptErr := oldClient.Intercept(context.Background(), protocol.EventSessionStart, json.RawMessage(`{}`), 5*time.Second)
+	if interceptErr != nil || result.Decision != protocol.DecisionContinue {
+		t.Fatalf("outgoing sidecar after failed reload = %+v, %v", result, interceptErr)
+	}
+}
+
 func waitForCond(t *testing.T, what string, timeout time.Duration, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)

--- a/internal/boot/runtime_plan.go
+++ b/internal/boot/runtime_plan.go
@@ -13,8 +13,8 @@ import (
 // RuntimeReload is previous-generation state for incremental sidecar adoption
 // and subgraph-classified rebuild.
 type RuntimeReload struct {
-	// ForceFullRebuild bypasses extension subgraph reuse when config-owned
-	// skills/providers may have changed without changing the native graph.
+	// ForceFullRebuild bypasses extension subgraph reuse and refreshes existing
+	// native sidecars, including linked binaries whose graph metadata is unchanged.
 	ForceFullRebuild bool
 	Extensions       *sidecar.Manager
 	Graph            *extension.DependencyGraph
@@ -170,7 +170,14 @@ func planForPreflight(opts Options, toGen uint64) *extension.RuntimePlan {
 	if err != nil {
 		return nil
 	}
-	return extension.DiffRuntimePlan(opts.Graph, toGraph, opts.Generation, toGen)
+	plan := extension.DiffRuntimePlan(opts.Graph, toGraph, opts.Generation, toGen)
+	if opts.ForceFullRebuild && opts.Extensions != nil {
+		// Explicit reloads refresh linked binaries even when graph metadata is unchanged.
+		// Preflight replaces them beside the live manager; publishing the new
+		// controller retires the old processes.
+		plan.RestartUnchangedSidecars = true
+	}
+	return plan
 }
 
 // finalizeBuildResult attaches the cold-start RuntimePlan and status, then

--- a/internal/extension/runtimeplan.go
+++ b/internal/extension/runtimeplan.go
@@ -84,10 +84,10 @@ func (p *RuntimePlan) MayChangePrefix() bool {
 
 // AffectsSidecars reports whether any native runtime package must start/drain.
 func (p *RuntimePlan) AffectsSidecars() bool {
-	if p == nil || p.IsNoOp() {
+	if p == nil {
 		return false
 	}
-	return true
+	return p.RestartUnchangedSidecars || !p.IsNoOp()
 }
 
 // AffectsInterceptors reports whether the interceptor chain must rebuild.

--- a/internal/extension/runtimeplan.go
+++ b/internal/extension/runtimeplan.go
@@ -52,6 +52,10 @@ type RuntimePlan struct {
 	Kind SubgraphKind
 	// Graph is the resolved target graph (may be nil for pure no-op plans).
 	Graph *DependencyGraph
+	// RestartUnchangedSidecars requests fresh native processes even when their
+	// dependency/capability identity is unchanged. It affects activation only,
+	// so IsNoOp and CacheHash remain stable.
+	RestartUnchangedSidecars bool
 }
 
 // IsNoOp reports whether the plan changes no components.

--- a/internal/extension/runtimeplan_test.go
+++ b/internal/extension/runtimeplan_test.go
@@ -27,6 +27,19 @@ func TestRuntimePlanNoOp(t *testing.T) {
 	}
 }
 
+func TestRuntimePlanRestartUnchangedSidecarsAffectsOnlySidecars(t *testing.T) {
+	plan := &RuntimePlan{RestartUnchangedSidecars: true}
+	if !plan.IsNoOp() {
+		t.Fatal("sidecar process replacement must remain a semantic graph no-op")
+	}
+	if !plan.AffectsSidecars() {
+		t.Fatal("sidecar process replacement must report its lifecycle work")
+	}
+	if plan.MayChangePrefix() || plan.AffectsInterceptors() || plan.AffectsUI() || plan.AffectsProviders() {
+		t.Fatalf("sidecar process replacement affected unrelated subgraphs: %+v", plan)
+	}
+}
+
 func TestRuntimePlanProviderOnlyChange(t *testing.T) {
 	from, err := BuildDependencyGraph([]ComponentDescriptor{
 		{ID: "host", Provides: []extensioncontract.Capability{cap("reasonix", "provider", "p", "1.0.0", "sha256:a")}},

--- a/internal/extension/sidecar/plan.go
+++ b/internal/extension/sidecar/plan.go
@@ -41,7 +41,7 @@ func StartPackagesWithPlan(ctx context.Context, home string, sessionCtx protocol
 		warnings = append(warnings, runtimeWarnings...)
 		return m, warnings, err
 	}
-	if plan.IsNoOp() && previous != nil {
+	if plan.IsNoOp() && previous != nil && !plan.RestartUnchangedSidecars {
 		// No component change: adopt every live client from previous.
 		return adoptAll(previous), warnings, nil
 	}
@@ -60,7 +60,11 @@ func StartPackagesWithPlan(ctx context.Context, home string, sessionCtx protocol
 	unchanged := map[string]bool{}
 	for _, id := range plan.Unchanged {
 		if name := PluginNameFromComponentID(id); name != "" {
-			unchanged[name] = true
+			if plan.RestartUnchangedSidecars {
+				activate[name] = true
+			} else {
+				unchanged[name] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- expose `/reload` in the desktop slash-command catalog and route it directly to runtime reload
- restart unchanged native v2 plugin sidecars during an explicit full reload
- keep the swap fail-atomic: old processes stay available until the replacement runtime publishes successfully
- preserve semantic cache diagnostics and document the desktop reload entry point in English and Chinese

## Problem

Desktop users could not invoke `/reload` from the composer. The Reload Runtime action rebuilt the runtime graph, but unchanged linked plugins adopted their existing sidecar clients, so updated plugin code did not take effect until the desktop app restarted.

## Root cause

The desktop command catalog omitted `/reload`, and the sidecar planner treated manifest-identical native runtimes as unchanged even when the user explicitly requested a full runtime reload.

## Fix

Explicit desktop reloads now mark the runtime plan to replace unchanged native sidecars. Replacement processes are preflighted alongside the old processes; the old controller is retired only after the new runtime is published. A failed required replacement therefore leaves the current runtime and process alive.

## 中文摘要

桌面端现在支持从输入框使用 `/reload`，并在显式重载时为未改变清单的原生插件启动新进程。新运行时发布成功后才会关闭旧进程；若新插件进程启动失败，旧运行时仍保持可用。

## Verification

- `go test ./...`
- `go vet ./...`
- `cd desktop && go test ./...`
- `cd desktop && go vet ./...`
- `go test -race ./internal/boot ./internal/extension ./internal/extension/sidecar`
- `cd desktop && go test -race . -run 'TestSubmitReloadRoutesToRuntimeReload|TestReloadRuntime' -count=1`
- docs-impact check and `git diff --check`

## Compatibility and cache

- no persisted-data or Wails JSON contract changes
- unchanged contributions retain the same `CacheHash`
- shared MCP hosts remain shared; this change targets native v2 plugin sidecars

Cache-impact: low - explicit reload changes sidecar lifecycle only; the semantic graph and `CacheHash` remain stable.

Cache-guard: `go test ./internal/boot -run 'TestExplicitReload(ReplacesUnchangedSidecar|SidecarFailureKeepsOldProcess)' -count=1`

System-prompt-review: SivanCola reviewed - no system prompt content or assembly changed; `internal/boot/*` is matched only by the path-based guard.

Documentation-impact: updated - documented the desktop `/reload` slash entry.
