### PR TITLE
Fix project tree topic-switch jitter / 修复项目树切换抖动

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-row-stability.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-row-stability.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const styles = readFileSync(fileURLToPath(new URL("../styles.css", import.meta.url)), "utf8");
+
+assert.match(
+  styles,
+  /:root\[data-theme-style\] \.sidebar--workbench \.project-tree__topic--active \.project-tree__topic-label\s*\{[^}]*font-weight:\s*500;/s,
+  "active and inactive workbench topics keep the same font weight",
+);
+assert.doesNotMatch(
+  styles,
+  /\.sidebar--workbench \.project-tree__topic--active \.project-tree__topic-label\s*\{[^}]*font-weight:\s*700;/s,
+  "a later workbench rule cannot restore bold active text",
+);
+assert.match(
+  styles,
+  /:root\[data-theme-style\] \.sidebar--workbench \.project-tree__topic\s*\{[^}]*height:\s*34px;/s,
+  "workbench topic rows keep a fixed height",
+);
+
+console.log("  PASS  project tree row stability contract");

--- a/desktop/frontend/src/__tests__/project-tree-runtime-projection.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime-projection.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
-import { projectTreeApplyRuntimeTopics } from "../lib/projectTreeRuntime";
+import { createProjectTreeRuntimeProjection, projectTreeApplyRuntimeTopics } from "../lib/projectTreeRuntime";
 import type { ProjectNode } from "../lib/types";
 
-type RuntimeNode = ProjectNode & { runtimeOnly?: boolean };
 const catalog: ProjectNode[] = [
   { key: "project-a", kind: "project", label: "A", root: "/a", children: [
     { key: "known", kind: "topic", label: "Known", root: "/a", topicId: "known", children: [] },
@@ -21,7 +20,7 @@ const overlaid = projectTreeApplyRuntimeTopics(catalog, [
   } },
 ]);
 const shape = (tree: ProjectNode[]) => tree.map((project) => project.children?.map((topic) => [
-  topic.topicId, topic.running, (topic as RuntimeNode).runtimeOnly,
+  topic.topicId, topic.running, topic.runtimeOnly,
 ]));
 assert.deepEqual(shape(overlaid), [[['known', true, undefined]], [['new', true, true]]]);
 assert.equal(overlaid[0]?.children?.[0]?.children?.length, 2);
@@ -44,4 +43,41 @@ const topics = projects.map((project, index) => ({
 }));
 const hundred = projectTreeApplyRuntimeTopics(projects, topics);
 assert.equal(hundred.reduce((count, project) => count + (project.children?.filter((topic) => topic.running).length ?? 0), 0), 100);
+
+const stableProjection = createProjectTreeRuntimeProjection();
+const stableCatalog: ProjectNode[] = [{
+  key: "stable-project", kind: "project", label: "Stable", root: "/stable", children: [
+    { key: "topic-a", kind: "topic", label: "A", root: "/stable", topicId: "a", createdAt: 300, lastActivityAt: 600, children: [] },
+    { key: "topic-b", kind: "topic", label: "B", root: "/stable", topicId: "b", createdAt: 200, lastActivityAt: 500, children: [] },
+    { key: "topic-c", kind: "topic", label: "C", root: "/stable", topicId: "c", createdAt: 100, lastActivityAt: 400, children: [] },
+  ],
+}];
+const runtimeB = [{
+  scope: "project", workspaceRoot: "/stable", node: {
+    key: "topic-b", kind: "topic" as const, label: "B", root: "/stable", topicId: "b",
+    open: true, running: false, children: [],
+  },
+}];
+const projected = stableProjection.apply(stableCatalog, runtimeB);
+assert.strictEqual(projected[0]?.children?.[0], stableCatalog[0]?.children?.[0], "an unrelated row keeps its object identity");
+assert.strictEqual(projected[0]?.children?.[2], stableCatalog[0]?.children?.[2], "every unrelated row keeps its object identity");
+const repeated = stableProjection.apply(projected, structuredClone(runtimeB));
+assert.strictEqual(repeated, projected, "an equivalent runtime snapshot is a tree-level no-op");
+
+const transientCatalog: ProjectNode[] = [{
+  ...stableCatalog[0],
+  children: [stableCatalog[0]!.children![0]!, stableCatalog[0]!.children![2]!],
+}];
+const transient = stableProjection.apply(transientCatalog, structuredClone(runtimeB));
+const restoredRuntimeB = transient[0]?.children?.find((topic) => topic.topicId === "b");
+assert.equal(restoredRuntimeB?.runtimeOnly, true, "a catalog-lag row remains marked as runtime-only");
+assert.equal(restoredRuntimeB?.createdAt, 200, "a catalog-lag row retains its resident creation time");
+assert.equal(restoredRuntimeB?.lastActivityAt, 500, "a catalog-lag row retains its resident activity time");
+assert.deepEqual(
+  [...(transient[0]?.children ?? [])]
+    .sort((a, b) => (b.lastActivityAt || b.createdAt || 0) - (a.lastActivityAt || a.createdAt || 0))
+    .map((topic) => topic.topicId),
+  ["a", "b", "c"],
+  "catalog lag cannot move the active row to a zero-time sort position",
+);
 console.log("  PASS  project tree runtime projection");

--- a/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-shell-race.test.ts
@@ -34,7 +34,8 @@ assert.match(
 assert.match(runtime, /onProjectTreeRuntimeChanged/, "runtime projection has a dedicated Wails subscription");
 assert.match(runtimeHook, /bindProjectTreeRuntime/, "ProjectTree binds the runtime projection after mount");
 assert.match(runtimeHook, /GetProjectTreeRuntimeSnapshot/, "runtime subscription reconciles with a post-subscribe snapshot");
-assert.match(bridge, /\?\.reason !== "runtime"/, "current frontend ignores tagged legacy runtime invalidations");
+assert.match(bridge, /reason !== "runtime"/, "current frontend ignores tagged legacy runtime invalidations");
+assert.match(bridge, /reason !== "catalog-v2"/, "current frontend ignores catalog v2 compatibility invalidations");
 assert.doesNotMatch(
   runtime,
   /ListProjectTopics/,

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -927,7 +927,10 @@ export function onReady(cb: (tabId?: string) => void): () => void {
 
 export function onProjectTreeChanged(cb: () => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
-    return window.runtime.EventsOn("project-tree:changed", (payload?: unknown) => (payload as { reason?: unknown } | undefined)?.reason !== "runtime" && cb());
+    return window.runtime.EventsOn("project-tree:changed", (payload?: unknown) => {
+      const reason = (payload as { reason?: unknown } | undefined)?.reason;
+      if (reason !== "runtime" && reason !== "catalog-v2") cb();
+    });
   }
   return () => {};
 }

--- a/desktop/frontend/src/lib/projectTreeRuntime.ts
+++ b/desktop/frontend/src/lib/projectTreeRuntime.ts
@@ -1,47 +1,127 @@
 import { asArray } from "./array";
 import type { ProjectNode, ProjectRuntimeTopic, ProjectTreeRuntimeSnapshot } from "./types";
 
-type RuntimeProjectNode = ProjectNode & { runtimeOnly?: boolean };
 const noExcludedTopicIds: ReadonlySet<string> = new Set();
 
 function withoutRuntimeState(node: ProjectNode): ProjectNode {
   return { ...node, open: undefined, running: undefined, status: undefined, children: [] };
 }
 
-// This replace-all overlay is loaded after the project tree mounts so runtime
-// reconciliation does not enlarge the first-paint bundle. Subscription still
-// precedes the initial snapshot read, so loading the module cannot lose an
-// ownership transition.
+function runtimeTopicKey(scope: string, workspaceRoot: string, topicId: string): string {
+  return `${scope}\u0000${workspaceRoot}\u0000${topicId}`;
+}
+
+function sameOwnFields(current: ProjectNode, next: ProjectNode): boolean {
+  const keys = new Set([...Object.keys(current), ...Object.keys(next)]);
+  keys.delete("children");
+  for (const key of keys) {
+    if (current[key as keyof ProjectNode] !== next[key as keyof ProjectNode]) return false;
+  }
+  return true;
+}
+
+function reconcileNode(current: ProjectNode | undefined, next: ProjectNode): ProjectNode {
+  const currentChildren = asArray(current?.children);
+  const currentByKey = new Map(currentChildren.map((child) => [child.key, child]));
+  const nextChildren = asArray(next.children).map((child) => reconcileNode(currentByKey.get(child.key), child));
+  if (current
+    && sameOwnFields(current, next)
+    && currentChildren.length === nextChildren.length
+    && currentChildren.every((child, index) => child === nextChildren[index])) {
+    return current;
+  }
+  return { ...next, children: nextChildren };
+}
+
+function rememberResidentTopics(tree: ProjectNode[], residentTopics: Map<string, ProjectNode>) {
+  for (const project of tree) {
+    if (project.kind !== "project" && project.kind !== "global_folder") continue;
+    const scope = project.kind === "project" ? "project" : "global";
+    const root = scope === "project" ? project.root ?? "" : "";
+    for (const topic of asArray(project.children)) {
+      if (!topic.runtimeOnly && topic.topicId) {
+        residentTopics.set(runtimeTopicKey(scope, root, topic.topicId), topic);
+      }
+    }
+  }
+}
+
+// This structural-sharing overlay is loaded after the project tree mounts so
+// runtime reconciliation does not enlarge the first-paint bundle. Subscription
+// still precedes the initial snapshot read, so loading the module cannot lose
+// an ownership transition.
 export function projectTreeApplyRuntimeTopics(
   tree: ProjectNode[],
   topics: ProjectRuntimeTopic[],
   excludedTopicIds: ReadonlySet<string> = noExcludedTopicIds,
+  residentTopics?: ReadonlyMap<string, ProjectNode>,
 ): ProjectNode[] {
-  return tree.map((project) => {
+  const nextTree = tree.map((project) => {
     if (project.kind !== "project" && project.kind !== "global_folder") return project;
     const scope = project.kind === "project" ? "project" : "global";
-    const base = asArray(project.children)
-      .filter((node) => !(node as RuntimeProjectNode).runtimeOnly && !excludedTopicIds.has(node.topicId ?? ""))
-      .map(withoutRuntimeState);
-    const runtimeOnly: RuntimeProjectNode[] = [];
+    const root = scope === "project" ? project.root ?? "" : "";
+    const runtimeByTopic = new Map(topics
+      .filter((topic) => topic.node.topicId
+        && !excludedTopicIds.has(topic.node.topicId)
+        && topic.scope === scope
+        && (scope !== "project" || topic.workspaceRoot === root))
+      .map((topic) => [topic.node.topicId!, topic]));
+    const currentChildren = asArray(project.children);
+    const base: ProjectNode[] = [];
+    for (const node of currentChildren) {
+      if (node.runtimeOnly || excludedTopicIds.has(node.topicId ?? "")) continue;
+      const runtime = node.topicId ? runtimeByTopic.get(node.topicId) : undefined;
+      if (runtime) runtimeByTopic.delete(node.topicId!);
+      const next = runtime ? {
+        ...withoutRuntimeState(node),
+        sessionPath: runtime.node.sessionPath,
+        open: runtime.node.open,
+        running: runtime.node.running,
+        status: runtime.node.status,
+        children: asArray(runtime.node.children),
+      } : withoutRuntimeState(node);
+      base.push(reconcileNode(node, next));
+    }
+    const runtimeOnly: ProjectNode[] = [];
     for (const topic of topics) {
-      if (!topic.node.topicId || excludedTopicIds.has(topic.node.topicId) || topic.scope !== scope || (scope === "project" && topic.workspaceRoot !== (project.root ?? ""))) continue;
-      const index = base.findIndex((node) => node.topicId === topic.node.topicId);
-      if (index < 0) {
-        runtimeOnly.push({ ...topic.node, runtimeOnly: true, children: asArray(topic.node.children) });
-        continue;
-      }
-      base[index] = {
-        ...base[index],
+      const topicId = topic.node.topicId;
+      if (!topicId || !runtimeByTopic.has(topicId)) continue;
+      runtimeByTopic.delete(topicId);
+      const current = currentChildren.find((node) => node.runtimeOnly && node.topicId === topicId);
+      const resident = residentTopics?.get(runtimeTopicKey(scope, root, topicId));
+      const stable = withoutRuntimeState(resident ?? current ?? topic.node);
+      runtimeOnly.push(reconcileNode(current, {
+        ...stable,
+        key: topic.node.key,
+        kind: topic.node.kind,
+        label: resident?.label ?? topic.node.label,
+        root: topic.node.root,
+        topicId,
         sessionPath: topic.node.sessionPath,
         open: topic.node.open,
         running: topic.node.running,
         status: topic.node.status,
+        runtimeOnly: true,
         children: asArray(topic.node.children),
-      };
+      }));
     }
-    return { ...project, children: [...runtimeOnly, ...base] };
+    return reconcileNode(project, { ...project, children: [...runtimeOnly, ...base] });
   });
+  return nextTree.every((project, index) => project === tree[index]) ? tree : nextTree;
+}
+
+export function createProjectTreeRuntimeProjection() {
+  const residentTopics = new Map<string, ProjectNode>();
+  return {
+    apply(
+      tree: ProjectNode[],
+      topics: ProjectRuntimeTopic[],
+      excludedTopicIds: ReadonlySet<string> = noExcludedTopicIds,
+    ): ProjectNode[] {
+      rememberResidentTopics(tree, residentTopics);
+      return projectTreeApplyRuntimeTopics(tree, topics, excludedTopicIds, residentTopics);
+    },
+  };
 }
 
 export function normalizeProjectTreeRuntimeSnapshot(payload: unknown): ProjectTreeRuntimeSnapshot {
@@ -63,7 +143,8 @@ export function bindProjectTreeRuntime(
 ) {
   let active = true;
   let snapshot: ProjectTreeRuntimeSnapshot | null = null;
-  const apply = (tree: ProjectNode[]) => snapshot ? projectTreeApplyRuntimeTopics(tree, snapshot.topics, excludedTopicIds()) : tree;
+  const projection = createProjectTreeRuntimeProjection();
+  const apply = (tree: ProjectNode[]) => snapshot ? projection.apply(tree, snapshot.topics, excludedTopicIds()) : tree;
   const accept = (next: ProjectTreeRuntimeSnapshot) => {
     if (!active || (snapshot && next.revision < snapshot.revision)) return;
     snapshot = next;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -513,6 +513,7 @@ export interface ProjectNode {
   recoveryUnresolvedCount?: number;
   recoveryCleanupEligibleCount?: number;
   isolatedWorktree?: boolean;
+  runtimeOnly?: boolean;
   children?: ProjectNode[];
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -24553,7 +24553,7 @@ body > .mermaid-diagram--fullscreen {
 }
 :root[data-theme-style] .project-tree__topic-label {
   color: var(--fg);
-  font-weight: 550;
+  font-weight: 500;
 }
 
 /* Extra spacing after expanded project section */
@@ -24622,7 +24622,7 @@ body > .mermaid-diagram--fullscreen {
 /* Active topic: keep text style unchanged (no color/font-weight change) */
 :root[data-theme-style] .sidebar--workbench .project-tree__topic--active .project-tree__topic-label {
   color: var(--fg);
-  font-weight: 550;
+  font-weight: 500;
 }
 
 /* Topic action icons (pin, archive): clean, no background, no border */
@@ -29983,7 +29983,7 @@ body > .mermaid-diagram--fullscreen {
 
 .sidebar--workbench .project-tree__topic--active .project-tree__topic-label {
   color: var(--fg);
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .sidebar--workbench .project-tree__topic-im {

--- a/desktop/project_tree_runtime.go
+++ b/desktop/project_tree_runtime.go
@@ -136,6 +136,22 @@ func (a *App) emitProjectTreeRuntimeChangedWithLegacy() {
 	a.emitRuntimeEvent("project-tree:changed", map[string]string{"reason": "runtime"})
 }
 
+// Runtime ownership changes need an immediate in-memory projection and an
+// asynchronous catalog reconciliation. The tagged compatibility event keeps
+// pre-runtime-projection frontends working without making current frontends
+// invalidate and rebuild the whole resident tree before catalog v2 catches up.
+func (a *App) emitProjectTreeRuntimeChangedWithCatalogRefresh() {
+	a.requestProjectTreeCatalogRefresh()
+	a.emitProjectTreeRuntimeChangedWithLegacy()
+}
+
+func (a *App) emitProjectTreeRuntimeChangedForSessionDirs(dirs ...string) {
+	for _, dir := range dirs {
+		a.requestSessionCatalogReconcile(dir)
+	}
+	a.emitProjectTreeRuntimeChangedWithLegacy()
+}
+
 func (a *App) emitRuntimeEvent(name string, payload ...any) {
 	if a != nil && a.ctx != nil {
 		a.runtimeEvents.Emit(a.ctx, name, payload...)

--- a/desktop/project_tree_runtime_visibility_test.go
+++ b/desktop/project_tree_runtime_visibility_test.go
@@ -136,34 +136,104 @@ func TestKeepOnlyVisibleTabPublishesDetachedRuntimeProjection(t *testing.T) {
 	}
 
 	deadline := time.After(time.Second)
+	foundRuntime := false
+	foundLegacy := false
 	for {
 		select {
 		case emitted := <-events:
-			if emitted.name != "project-tree:runtime-changed" {
+			switch emitted.name {
+			case "project-tree:runtime-changed":
+				if len(emitted.payload) != 1 {
+					t.Fatalf("project-tree:runtime-changed payload count = %d, want 1", len(emitted.payload))
+				}
+				event, ok := emitted.payload[0].(ProjectTreeRuntimeSnapshot)
+				if !ok {
+					t.Fatalf("project-tree:runtime-changed payload type = %T, want ProjectTreeRuntimeSnapshot", emitted.payload[0])
+				}
+				if event.Topics == nil || event.Revision == 0 {
+					t.Fatalf("project-tree:runtime-changed event = %+v, want a versioned runtime snapshot", event)
+				}
+				for _, topic := range event.Topics {
+					if topic.Scope == "project" && sameProjectRoot(topic.WorkspaceRoot, projectA) && topic.Node.TopicID == "topic-a" {
+						foundRuntime = !topic.Node.Open && topic.Node.Running
+					}
+				}
+			case "project-tree:changed":
+				if len(emitted.payload) != 1 {
+					t.Fatalf("legacy runtime invalidation payload = %#v, want one tagged payload", emitted.payload)
+				}
+				reason, ok := emitted.payload[0].(map[string]string)
+				foundLegacy = ok && reason["reason"] == "runtime"
+			}
+			if foundRuntime && foundLegacy {
+				return
+			}
+		case <-deadline:
+			if !foundRuntime {
+				t.Fatal("detaching project A emitted no runtime snapshot; the running conversation stays invisible")
+			}
+			if !foundLegacy {
+				t.Fatal("detaching project A emitted an untagged or missing compatibility invalidation")
+			}
+		}
+	}
+}
+
+func TestProjectTreeCatalogV2CompatibilityEventIsTagged(t *testing.T) {
+	app := NewApp()
+	app.ctx = context.Background()
+	events := make(chan runtimeEventEnvelope, 2)
+	app.runtimeEvents.emit = func(ctx context.Context, name string, payload ...any) {
+		events <- runtimeEventEnvelope{ctx: ctx, name: name, payload: append([]any(nil), payload...)}
+	}
+
+	app.emitProjectTreeChangedV2(7, nil, "metadata")
+	first := <-events
+	second := <-events
+	if first.name != "project-tree:changed-v2" || second.name != "project-tree:changed" {
+		t.Fatalf("catalog events = %#v, %#v, want v2 followed by compatibility event", first, second)
+	}
+	reason, ok := second.payload[0].(map[string]string)
+	if !ok || reason["reason"] != "catalog-v2" {
+		t.Fatalf("catalog compatibility payload = %#v, want reason catalog-v2", second.payload)
+	}
+}
+
+func TestOpenProjectTabPublishesTaggedRuntimeInvalidation(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.ctx = context.Background()
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	events := make(chan runtimeEventEnvelope, 8)
+	app.runtimeEvents.emit = func(ctx context.Context, name string, payload ...any) {
+		events <- runtimeEventEnvelope{ctx: ctx, name: name, payload: append([]any(nil), payload...)}
+	}
+	projectRoot := t.TempDir()
+	topic, err := app.CreateTopic("project", projectRoot, "Stable row")
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	if _, err := app.OpenProjectTab(projectRoot, topic.ID); err != nil {
+		t.Fatalf("OpenProjectTab: %v", err)
+	}
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case event := <-events:
+			if event.name != "project-tree:changed" {
 				continue
 			}
-			if len(emitted.payload) != 1 {
-				t.Fatalf("project-tree:runtime-changed payload count = %d, want 1", len(emitted.payload))
+			if len(event.payload) != 1 {
+				continue
 			}
-			event, ok := emitted.payload[0].(ProjectTreeRuntimeSnapshot)
-			if !ok {
-				t.Fatalf("project-tree:runtime-changed payload type = %T, want ProjectTreeRuntimeSnapshot", emitted.payload[0])
-			}
-			if event.Topics == nil || event.Revision == 0 {
-				t.Fatalf("project-tree:runtime-changed event = %+v, want a versioned runtime snapshot", event)
-			}
-			found := false
-			for _, topic := range event.Topics {
-				if topic.Scope == "project" && sameProjectRoot(topic.WorkspaceRoot, projectA) && topic.Node.TopicID == "topic-a" {
-					found = !topic.Node.Open && topic.Node.Running
-				}
-			}
-			if !found {
-				t.Fatalf("detached runtime topic missing from snapshot: %+v", event.Topics)
+			reason, ok := event.payload[0].(map[string]string)
+			if !ok || reason["reason"] != "runtime" {
+				continue
 			}
 			return
 		case <-deadline:
-			t.Fatal("detaching project A emitted no runtime snapshot; the running conversation stays invisible")
+			t.Fatal("opening a project topic emitted no tagged runtime invalidation")
 		}
 	}
 }

--- a/desktop/session_catalog.go
+++ b/desktop/session_catalog.go
@@ -444,8 +444,9 @@ func (a *App) emitProjectTreeChangedV2(revision uint64, roots []string, reason s
 	}
 	a.emitRuntimeEvent("project-tree:changed-v2", ProjectTreeChangedV2{Revision: revision, Roots: roots, Reason: reason})
 	// One-release compatibility event. Its wrapper is catalog-only, so legacy
-	// frontends refresh without reintroducing synchronous history I/O.
-	a.emitRuntimeEvent("project-tree:changed")
+	// frontends refresh without making current frontends rebuild the whole tree
+	// after they already consumed the targeted v2 revision.
+	a.emitRuntimeEvent("project-tree:changed", map[string]string{"reason": "catalog-v2"})
 }
 
 func (a *App) requestSessionCatalogReconcile(dir string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2458,7 +2458,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	a.startTabControllerBuild(tab)
 	if scope == "project" {
-		a.emitProjectTreeChangedForSessionDirs(sessionDirectoryForPath(sessionPath))
+		a.emitProjectTreeRuntimeChangedForSessionDirs(sessionDirectoryForPath(sessionPath))
 	}
 	return enrichTabMeta(meta), nil
 }
@@ -3368,7 +3368,7 @@ func (a *App) keepOnlyVisibleTab(tabID string) (TabMeta, error) {
 	if err != nil {
 		return TabMeta{}, err
 	}
-	a.emitProjectTreeChanged()
+	a.emitProjectTreeRuntimeChangedWithCatalogRefresh()
 	return enrichTabMeta(meta), nil
 }
 
@@ -6975,11 +6975,15 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 }
 
 func (a *App) emitProjectTreeChanged() {
+	a.requestProjectTreeCatalogRefresh()
+	a.emitProjectTreeChangedEvent()
+}
+
+func (a *App) requestProjectTreeCatalogRefresh() {
 	a.requestSessionCatalogMetadataSync()
 	for _, target := range a.sessionCatalogTargets() {
 		a.requestSessionCatalogReconcile(target.Path)
 	}
-	a.emitProjectTreeChangedEvent()
 }
 
 // emitProjectTreeChangedForSessionDirs schedules only the affected catalog


### PR DESCRIPTION
## Summary

- Stop unchanged project and topic rows from being recreated when runtime state changes.
- Keep resident catalog timestamps while a newly opened topic is temporarily absent from the catalog, preventing transient reordering.
- Tag legacy runtime and catalog compatibility events so the current frontend does not perform redundant full-tree refreshes while older frontends remain compatible.
- Keep active and inactive topic labels at the same font weight to avoid text-metric layout movement.

## Root cause

The v1.25.2 runtime projection path rebuilt every project node and topic row on each topic switch. At the same time, opening a topic emitted both the runtime projection event and an untagged legacy tree invalidation, causing the current frontend to refresh the full catalog again. If that refresh briefly omitted the newly opened topic, its runtime-only replacement lost the resident sort timestamps and moved in the list. The active row also changed from font weight 500 to 600, which could alter its measured geometry.

## Compatibility

No persisted data format changes are introduced. The existing runtimeOnly JSON field is now represented in the TypeScript model. Tagged legacy events remain usable by pre-v1.25.2 frontends, while the current bridge filters only the tagged redundant refreshes.

## Verification

- `pnpm --dir desktop/frontend test`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend check:css`
- `cd desktop && go test ./...`
- `cd desktop && go test -race -run TestKeepOnlyVisibleTabPublishesDetachedRuntimeProjection\\|TestProjectTreeCatalogV2CompatibilityEventIsTagged\\|TestOpenProjectTabPublishesTaggedRuntimeInvalidation .`
- Browser DOM and geometry probe across 16 topic-switch frames: zero row top/height delta, stable element identity, stable font weight, and zero sidebar layout shift.