### PR TITLE
fix(transcript): keep the viewport steady when auto-fold collapse shrinks the transcript / 思考区自动折叠收缩时不再追底跳动

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -2,6 +2,7 @@
 
 import {
   INITIAL_TRANSCRIPT_SCROLL_STATE,
+  isTranscriptContentShrink,
   reduceTranscriptScroll,
   type TranscriptScrollEvent,
   type TranscriptScrollState,
@@ -100,6 +101,26 @@ const restore = run([
 ]);
 check(restore.state.mode === "manual", "question/rewind navigation settles in manual mode");
 check(restore.commands.join(",") === "SCROLL_TO_INDEX", "navigation emits one indexed Virtuoso command");
+
+const shrink = run([
+  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "CONTENT_SHRANK" },
+]);
+check(shrink.state.mode === "tail-follow", "auto fold collapse keeps tail-follow");
+check(shrink.commands.length === 0, "auto fold collapse does not tug the viewport to the tail");
+
+const shrinkOffBottom = run([
+  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
+  { type: "CONTENT_SHRANK" },
+  { type: "LAYOUT_HEIGHT_CHANGED" },
+]);
+check(shrinkOffBottom.state.mode === "tail-follow", "a shrink does not steal tail ownership");
+check(shrinkOffBottom.commands.join(",") === "AUTOSCROLL_TO_BOTTOM", "only later growth after a shrink may follow the tail");
+
+check(isTranscriptContentShrink(-48), "a fold-sized height drop is a shrink");
+check(!isTranscriptContentShrink(-8), "measurement jitter is not a shrink");
+check(!isTranscriptContentShrink(80), "content growth is not a shrink");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/transcriptScrollController.ts
+++ b/desktop/frontend/src/lib/transcriptScrollController.ts
@@ -24,6 +24,7 @@ export type TranscriptScrollEvent =
   | { type: "USER_SCROLL_INTENT" }
   | { type: "AT_BOTTOM_CHANGED"; atBottom: boolean; scrollable: boolean }
   | { type: "TAIL_CONTENT_CHANGED" }
+  | { type: "CONTENT_SHRANK" }
   | { type: "LAYOUT_HEIGHT_CHANGED" }
   | { type: "VIEWPORT_RESIZED" }
   | { type: "USER_RESIZE_BEGIN" }
@@ -53,6 +54,14 @@ export const INITIAL_TRANSCRIPT_SCROLL_STATE: TranscriptScrollState = {
   scrollable: false,
   settleMode: "tail-follow",
 };
+
+// Fold collapse drops at least one process row (~28px). Smaller deltas are
+// Virtuoso measurement jitter and must keep following the tail.
+export const TRANSCRIPT_CONTENT_SHRINK_THRESHOLD_PX = 24;
+
+export function isTranscriptContentShrink(delta: number): boolean {
+  return delta <= -TRANSCRIPT_CONTENT_SHRINK_THRESHOLD_PX;
+}
 
 function transition(state: TranscriptScrollState, commands: readonly TranscriptScrollCommand[] = []): TranscriptScrollTransition {
   return { state, commands };
@@ -91,6 +100,10 @@ export function reduceTranscriptScroll(
     case "LAYOUT_HEIGHT_CHANGED":
     case "VIEWPORT_RESIZED":
       return transition(state, state.mode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : []);
+    case "CONTENT_SHRANK":
+      // Auto-fold collapse shortens the transcript. Keep tail ownership but
+      // do not chase the new bottom — that is what makes the viewport jump.
+      return transition(state);
     case "USER_RESIZE_BEGIN":
       return transition({ ...state, mode: "user-resize", settleMode: "manual" });
     case "USER_RESIZE_END":

--- a/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
+++ b/desktop/frontend/src/lib/useTranscriptVirtuosoScroll.ts
@@ -10,6 +10,7 @@ import { isEditableTarget } from "./keyboardShortcuts";
 import { isNativeVerticalScrollbarPointer, measureTranscriptVirtuosoItem } from "./transcriptNativeScrollbar";
 import {
   INITIAL_TRANSCRIPT_SCROLL_STATE,
+  isTranscriptContentShrink,
   isTranscriptSelectionMode,
   reduceTranscriptScroll,
   type TranscriptScrollCommand,
@@ -74,6 +75,7 @@ export function useTranscriptVirtuosoScroll({
   const followFrameRef = useRef<number | null>(null);
   const tailSettleFrameRef = useRef<number | null>(null);
   const resizeSettleFrameRef = useRef<number | null>(null);
+  const lastFollowExtentRef = useRef<number | null>(null);
   const [nativeScrollbarDragging, setNativeScrollbarDragging] = useState(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
@@ -159,6 +161,7 @@ export function useTranscriptVirtuosoScroll({
       || event.type === "PROGRAMMATIC_BEGIN"
       || event.type === "JUMP_TO_INDEX"
       || event.type === "SCROLL_TO_OFFSET"
+      || event.type === "CONTENT_SHRANK"
     ) {
       if (tailSettleFrameRef.current !== null) cancelAnimationFrame(tailSettleFrameRef.current);
       tailSettleFrameRef.current = null;
@@ -240,6 +243,16 @@ export function useTranscriptVirtuosoScroll({
     if (followFrameRef.current !== null) return;
     followFrameRef.current = requestAnimationFrame(() => {
       followFrameRef.current = null;
+      const element = scrollRef.current;
+      if (element) {
+        const scrollHeight = element.scrollHeight;
+        const previous = lastFollowExtentRef.current;
+        lastFollowExtentRef.current = scrollHeight;
+        if (previous != null && isTranscriptContentShrink(scrollHeight - previous)) {
+          dispatch({ type: "CONTENT_SHRANK" });
+          return;
+        }
+      }
       dispatch({ type: "LAYOUT_HEIGHT_CHANGED" });
     });
   }, [dispatch]);
@@ -264,7 +277,10 @@ export function useTranscriptVirtuosoScroll({
     });
   }, [dispatch]);
 
-  const reset = useCallback(() => dispatch({ type: "RESET" }), [dispatch]);
+  const reset = useCallback(() => {
+    lastFollowExtentRef.current = null;
+    dispatch({ type: "RESET" });
+  }, [dispatch]);
 
   const writeOffset = useCallback((owner: TranscriptScrollOwner, top: number, behavior: ScrollBehavior = "auto") => {
     if (isTranscriptSelectionMode(modeRef.current) && owner !== "selection-edge-scroll") return false;


### PR DESCRIPTION
## Summary

- Auto-fold collapse of the reasoning panel (completion shrink) no longer drags the transcript viewport with an imperative tail re-aim
- A height-drop detector (>=24px, excluding Virtuoso measurement jitter) distinguishes "fold collapse" from normal growth: tail
ownership is kept, but no `AUTOSCROLL_TO_BOTTOM` is emitted — the browser's native `scrollTop` clamp settles the viewport on
the new bottom

## Issues

Fixes #8914

## Verification

- New reducer contract tests (`shrink`, `shrinkOffBottom`, `isTranscriptContentShrink`): fold collapse keeps mode `tail-follow` with zero commands; growth after a shrink still re-engages tail follow
- Transcript suite 18/18 passing, including `history-load-failure-contract.test.ts` (footer resize contract, no regression)
- `tsc --noEmit` clean
- Recommend a manual check per the issue repro steps: long task → reasoning completion collapse → window no longer jumps up

## Documentation impact

Documentation-impact: none - internal scroll-coordination logic only; restores expected scroll behavior with no new config,
command, or permission; embedded documentation stays correct.

## Cache impact

Cache-impact: none - frontend scroll state machine only (`transcriptScrollController` / `useTranscriptVirtuosoScroll`); no cache or persistence path involved.
Cache-guard: no cache code involved; existing transcript suite covers shrink and growth paths.
System-prompt-review: N/A - no provider-visible system prompt, memory prefix, output style, or skill index changes.