### PR TITLE
fix(agent): scope unfinished-todo readiness gate to closed-loop turns / 未完成 todo 只在闭环回合阻塞

### DIFF
--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -11,17 +11,17 @@ func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 
-	gated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
+	gated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}}
 	if gated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("control arm must still gate an incomplete todo after a write")
 	}
 
-	off := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Evidence)}
+	off := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}, ablation: ablation.New(ablation.Evidence)}
 	if got := off.finalReadinessCheckFor().reason; got != "" {
 		t.Fatalf("evidence ablation still gated the final answer: %q", got)
 	}
 
-	unrelated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Planner)}
+	unrelated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}, ablation: ablation.New(ablation.Planner)}
 	if unrelated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("an unrelated ablation must not disable the readiness gate")
 	}

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -14,20 +14,22 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 	open := []evidence.TodoItem{{Content: "push", Status: "completed"}, {Content: "rebase", Status: "pending"}}
 
 	// Turn did work (a successful bash) but issued no todo_write this turn, so the
-	// per-turn ledger has no list — the canonical state must still gate.
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: open}}
+	// per-turn ledger has no list — the canonical state must still gate inside
+	// a closed-loop turn.
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: open}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := a.ReadinessResult(); !strings.Contains(got.Reason, "incomplete") {
 		t.Fatalf("cross-turn gate = %q, want it to report incomplete canonical todos", got.Reason)
 	}
 
-	// A turn that touched nothing (pure Q&A) must never gate on stale canonical state.
-	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, sess: sessionRuntime{todoState: open}}
+	// A closed-loop turn that touched nothing (pure Q&A) must never gate on
+	// stale canonical state.
+	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, sess: sessionRuntime{todoState: open}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := idle.ReadinessResult(); !got.Ready {
 		t.Fatalf("no-work turn gated on canonical todos: %+v", got)
 	}
 
 	// All canonical items completed → no gate even after work.
-	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}}
+	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := done.ReadinessResult(); !got.Ready {
 		t.Fatalf("completed canonical todos still gated: %+v", got)
 	}

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -156,6 +156,10 @@ func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
 	mp := testutil.NewMock("m",
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "w1", Name: "write_file", Arguments: `{"path":"alpha.go"}`}}},
 		testutil.Turn{Text: "all done"},
+		// The closed-loop follow-up must also satisfy verification and review
+		// obligations before the todo sign-off clears the gate.
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "v1", Name: "bash", Arguments: `{"command":"go test ./..."}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "r1", Name: "bash", Arguments: `{"command":"git diff alpha.go"}`}}},
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
 			Arguments: `{"step":"alpha","result":"done","evidence":[{"kind":"diff","summary":"edited","paths":["alpha.go"]}]}`}}},
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "complete_step",
@@ -165,11 +169,11 @@ func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
 	a := New(mp, evidenceRegistry(), sess, Options{}, event.Discard)
 	a.SetSession(sess) // rebuilds canonical {alpha in_progress, beta pending}
 
-	firstErr := a.Run(withNoClosedLoop(context.Background()), "finish up")
+	firstErr := a.Run(withClosedLoopContext(context.Background()), "finish up")
 	if !readinessBlocked(firstErr) {
 		t.Fatalf("premature 'all done' error = %v, want FinalReadinessError from the cross-turn canonical gate", firstErr)
 	}
-	if err := a.Run(withNoClosedLoop(context.Background()), "finish up"); err != nil {
+	if err := a.Run(withClosedLoopContext(context.Background()), "finish up"); err != nil {
 		t.Fatalf("follow-up Run: %v", err)
 	}
 	for i, td := range a.sess.todoState {

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -367,7 +367,7 @@ func TestRunSubAgentSalvagesReadinessExhaustedWork(t *testing.T) {
 		finalText, // block 3 — budget exhausted
 	}}
 	sess := NewSession("sys")
-	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+	answer, err := RunSubAgentWithSession(withClosedLoopContext(context.Background()), prov, reg, sess,
 		"add explanations to the question bank", Options{SubagentDepth: 1}, event.Discard)
 	if err != nil {
 		t.Fatalf("readiness exhaustion with real work must salvage, got err: %v", err)
@@ -466,7 +466,7 @@ func TestExplicitDeliveryRecoveryPreservesEvidenceOnce(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession("sys"), Options{}, event.Discard)
 	var readinessErr *FinalReadinessError
-	if err := a.Run(context.Background(), "implement main"); !errors.As(err, &readinessErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "implement main"); !errors.As(err, &readinessErr) {
 		t.Fatalf("first Run error = %v, want FinalReadinessError", err)
 	}
 	if !a.PrepareDeliveryRecovery() {
@@ -475,7 +475,7 @@ func TestExplicitDeliveryRecoveryPreservesEvidenceOnce(t *testing.T) {
 	if a.PrepareDeliveryRecovery() {
 		t.Fatal("delivery recovery authorization must be one-shot")
 	}
-	if err := a.Run(context.Background(), "continue the remaining delivery checks"); err != nil {
+	if err := a.Run(withClosedLoopContext(context.Background()), "continue the remaining delivery checks"); err != nil {
 		t.Fatalf("recovery Run: %v", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
@@ -496,14 +496,14 @@ func TestOrdinaryFollowUpDoesNotPreserveFailedDeliveryEvidence(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession("sys"), Options{}, event.Discard)
 	var firstErr *FinalReadinessError
-	if err := a.Run(context.Background(), "implement main"); !errors.As(err, &firstErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "implement main"); !errors.As(err, &firstErr) {
 		t.Fatalf("first Run error = %v, want FinalReadinessError", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
 		t.Fatal("first failed delivery should retain its mutation until the next turn is classified")
 	}
 
-	if err := a.Run(withClosedLoopContext(context.Background()), "fix the unrelated crash in other.go"); err != nil {
+	if err := a.Run(withNoClosedLoop(context.Background()), "fix the unrelated crash in other.go"); err != nil {
 		t.Fatalf("ordinary follow-up without a writer = %v, want ready", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {

--- a/internal/agent/delivery_visible_final_test.go
+++ b/internal/agent/delivery_visible_final_test.go
@@ -31,7 +31,7 @@ func TestRunSubAgentSalvagesCurrentAnswerBeforePairedGoalError(t *testing.T) {
 		},
 	}}
 	sess := NewSession("sys")
-	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+	answer, err := RunSubAgentWithSession(withClosedLoopContext(context.Background()), prov, reg, sess,
 		"add explanations to the question bank", Options{SubagentDepth: 1}, event.Discard)
 	if err != nil {
 		t.Fatalf("paired Goal error hid the current salvage answer: %v", err)
@@ -177,7 +177,7 @@ func TestRunSubAgentReadinessSalvageDoesNotReuseStaleToolText(t *testing.T) {
 	}}
 	sess := NewSession("sys")
 	answer, err := RunSubAgentWithSession(
-		context.Background(), deepseekThinkingProvider{prov}, reg, sess,
+		withClosedLoopContext(context.Background()), deepseekThinkingProvider{prov}, reg, sess,
 		"add explanations to the question bank",
 		Options{SubagentDepth: 1}, event.Discard,
 	)

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -662,7 +662,7 @@ func TestFinalReadinessStopsAfterFirstBlock(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
 
-	err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and never sign off")
+	err := a.Run(withClosedLoopContext(context.Background()), "edit with todo and never sign off")
 	if err == nil {
 		t.Fatal("expected the first readiness block to stop the run")
 	}
@@ -852,7 +852,7 @@ func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	sink := &readinessAuditSink{}
 	a := New(prov, reg, NewSession(""), Options{}, sink)
 
-	err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and never sign off")
+	err := a.Run(withClosedLoopContext(context.Background()), "edit with todo and never sign off")
 	if err == nil {
 		t.Fatal("expected the first readiness block to stop the run")
 	}
@@ -862,6 +862,43 @@ func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	last := sink.events[len(sink.events)-1]
 	if last.Result != evidence.ReadinessErrored || last.IncompleteTodos == 0 {
 		t.Fatalf("terminal audit = %+v, want errored with incomplete todos", last)
+	}
+}
+
+// TestOpenTurnMayEndWithIncompleteTodosAfterWrite proves an ordinary (non
+// closed-loop) session can end a turn with a partially completed todo list:
+// the list is a cross-turn work plan there, not a delivery contract, so it
+// must not raise the Goal-flavored FinalReadinessError (#8851).
+func TestOpenTurnMayEndWithIncompleteTodosAfterWrite(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done, more steps remain for later turns"}, {Type: provider.ChunkDone}},
+	}}
+	sink := &readinessAuditSink{}
+	a := New(prov, reg, NewSession(""), Options{}, sink)
+
+	err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and leave remaining steps for later")
+	if err != nil {
+		t.Fatalf("open turn with incomplete todos must not fail the run, got: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2 (write + one final, no readiness retry)", prov.call)
+	}
+	for _, e := range sink.events {
+		if e.Result == evidence.ReadinessErrored {
+			t.Fatalf("open turn recorded an errored readiness audit: %+v", e)
+		}
 	}
 }
 

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -106,7 +106,12 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 	if mutation, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		writer, hasWriter = mutation, true
 	}
-	if hasWriter && hasTodos && len(incomplete) > 0 {
+	// Incomplete todos are a fact contradiction only inside a closed-loop
+	// (Goal/Plan/strict-obligation) turn, where the host guarantees full
+	// delivery. In open turns the todo list is a cross-turn work plan; a
+	// partially completed plan is progress, not a contradiction, and must not
+	// surface the Goal-flavored delivery ceremony (#8851).
+	if a.closedLoopActive() && hasWriter && hasTodos && len(incomplete) > 0 {
 		out.applies = true
 		out.incompleteTodos = len(incomplete)
 		missing = append(missing, finalReadinessIncompleteTodos(incomplete))

--- a/internal/agent/final_readiness_recovery_test.go
+++ b/internal/agent/final_readiness_recovery_test.go
@@ -1,10 +1,8 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"path/filepath"
 	"testing"
 
 	"reasonix/internal/event"
@@ -47,49 +45,30 @@ func TestTargetedVerificationRecoverySurvivesAgentRebuild(t *testing.T) {
 	a := New(first, reg, session, Options{}, event.Discard)
 
 	var readinessErr *FinalReadinessError
-	if err := a.Run(context.Background(), "write docs/verify_v070.md and run the validation script"); !errors.As(err, &readinessErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "write docs/verify_v070.md and run the validation script"); !errors.As(err, &readinessErr) {
 		t.Fatalf("first Run error = %v, want final readiness failure", err)
 	}
+	// Closed-loop turns keep the failure in memory only: the durable LocalOnly
+	// marker is reserved for open turns (persistFinalReadinessRecovery skips
+	// delivery-scoped runs), so no transcript copy of the writer payload can
+	// leak into a checkpoint.
 	var marker *provider.FinalReadinessRecovery
 	for _, message := range session.Snapshot() {
 		if message.FinalReadinessRecovery != nil {
 			marker = message.FinalReadinessRecovery
 		}
 	}
-	if marker == nil || bytes.Contains(marker.Checkpoint, []byte("sensitive-payload")) {
-		t.Fatal("recovery checkpoint missing or duplicated writer content")
+	if marker != nil {
+		t.Fatal("closed-loop readiness failure must not persist a recovery marker")
 	}
-	path := filepath.Join(t.TempDir(), "readiness-recovery.jsonl")
-	if err := session.Save(path); err != nil {
-		t.Fatalf("Save: %v", err)
+	if !a.pending.finalReadinessRecovery {
+		t.Fatal("closed-loop readiness failure must keep the in-memory pending recovery flag")
 	}
-	loaded, err := LoadSession(path)
-	if err != nil {
-		t.Fatalf("LoadSession: %v", err)
-	}
-
-	recoveryProvider := &scriptedProvider{name: "standard-reloaded", turns: [][]provider.Chunk{
-		{toolCallChunk("recognized-check", "bash", `{"command":"git diff --check"}`), {Type: provider.ChunkDone}},
-		{toolCallChunk("signoff", "complete_step", `{"step":"Write verification notes","result":"done","evidence":[{"kind":"verification","summary":"diff check passed","command":"git diff --check"}]}`), {Type: provider.ChunkDone}},
-		{toolCallChunk("todo-done", "todo_write", `{"todos":[{"content":"Write verification notes","status":"completed"}]}`), {Type: provider.ChunkDone}},
-		{{Type: provider.ChunkText, Text: "checks complete"}, {Type: provider.ChunkDone}},
-	}}
-	reloaded := New(recoveryProvider, reg, loaded, Options{}, event.Discard)
-	if !reloaded.PrepareFinalReadinessRecovery() || reloaded.PrepareFinalReadinessRecovery() {
-		t.Fatal("rebuilt recovery authorization was not one-shot")
-	}
-	if err := reloaded.Run(context.Background(), "continue the remaining checks"); err != nil {
-		t.Fatalf("reloaded recovery Run: %v", err)
-	}
-	for _, message := range loaded.Snapshot() {
-		if message.FinalReadinessRecovery != nil && message.FinalReadinessRecovery.Pending {
-			t.Fatal("started recovery left its durable action pending")
-		}
-	}
-	writer, ok := reloaded.task.ledger.LatestSuccessfulWriterIndex()
-	if !ok || !reloaded.task.ledger.HasSuccessfulVerificationCommandAfter(writer) {
-		t.Fatal("reloaded recovery did not preserve write-before-verification ordering")
-	}
+	// The open-turn marker persistence and rebuild continuation this test
+	// originally pinned is unreachable by design after #8851: open turns no
+	// longer fail on unfinished todos, so no recovery marker is ever written
+	// for them; closed-loop recovery stays in memory and is driven by the
+	// explicit PrepareDeliveryRecovery path.
 }
 
 func TestFinalReadinessRecoveryRejectsStaleMarkerAfterUserTurn(t *testing.T) {

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -30,24 +30,26 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 		name        string
 		checks      []instruction.VerifyCheck
 		evidence    *evidence.Ledger
+		closedLoop  bool
 		wantEmpty   bool
 		wantContain string
 	}{
-		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, true, ""},
-		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), true, ""},
-		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), true, ""},
-		{"read-only context plus todo may end with incomplete list", nil, readinessLedger(readOnly, todo), true, ""},
-		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), true, ""},
-		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
-		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},
-		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), true, ""},
-		{"todo writer without complete_step is reported", nil, readinessLedger(writer, todo), false, "incomplete items"},
-		{"complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), false, "latest successful todo_write"},
-		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), true, ""},
+		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, false, true, ""},
+		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), false, true, ""},
+		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), false, true, ""},
+		{"read-only context plus todo may end with incomplete list", nil, readinessLedger(readOnly, todo), false, true, ""},
+		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), false, true, ""},
+		{"writer without checks or todo never gates", nil, readinessLedger(writer), false, true, ""},
+		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, false, "go test ./..."},
+		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), false, true, ""},
+		{"open turn with unfinished todos is not a delivery contradiction", nil, readinessLedger(writer, todo), false, true, ""},
+		{"closed-loop todo writer without complete_step is reported", nil, readinessLedger(writer, todo), true, false, "incomplete items"},
+		{"closed-loop complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), true, false, "latest successful todo_write"},
+		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), false, true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			a := &Agent{task: taskRuntime{ledger: tc.evidence}, projectChecks: tc.checks}
+			a := &Agent{task: taskRuntime{ledger: tc.evidence}, projectChecks: tc.checks, turn: turnRuntime{deliveryScopeActive: tc.closedLoop}}
 			got := a.ReadinessResult()
 			if tc.wantEmpty {
 				if !got.Ready {
@@ -86,9 +88,17 @@ func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
 
-	got := a.finalReadinessCheckFor()
+	// Open (non closed-loop) turns treat the todo list as a cross-turn work
+	// plan: a partially completed plan must not raise the delivery ceremony.
+	if got := a.finalReadinessCheckFor(); got.applies {
+		t.Fatalf("open-turn finalReadinessCheckFor() applies = true, want false (#8851)")
+	}
+
+	// Closed-loop turns keep the fact-contradiction gate.
+	closed := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}}
+	got := closed.finalReadinessCheckFor()
 	if !got.applies {
-		t.Fatalf("finalReadinessCheckFor() applies = false, want true")
+		t.Fatalf("closed-loop finalReadinessCheckFor() applies = false, want true")
 	}
 	if got.incompleteTodos != 1 {
 		t.Fatalf("incompleteTodos = %d, want 1", got.incompleteTodos)
@@ -144,7 +154,7 @@ func TestFinalReadinessLoopGuardPassRevokedByRealProgress(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{task: taskRuntime{ledger: ledger}}
+	a := &Agent{task: taskRuntime{ledger: ledger}, turn: turnRuntime{deliveryScopeActive: true}}
 	a.armLoopGuardPass(ledger.Len())
 
 	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
@@ -164,7 +174,7 @@ func TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput(t *testing.T) {
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
 	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "agent.go:2082: \"[loop guard] %s has now %s %d times\""})
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, sess: sessionRuntime{conversation: sess}}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, sess: sessionRuntime{conversation: sess}, turn: turnRuntime{deliveryScopeActive: true}}
 
 	if got := a.finalReadinessCheckFor(); got.reason == "" {
 		t.Fatal("finalReadinessCheckFor() reason empty, want quoted loop-guard text to be ignored")

--- a/internal/agent/readiness_partial_test.go
+++ b/internal/agent/readiness_partial_test.go
@@ -35,7 +35,7 @@ func TestPartialWaiverDoesNotClearIncompleteTodos(t *testing.T) {
 		task: taskRuntime{ledger: readinessLedger(writer, todo,
 			evidence.Receipt{ToolName: "update_goal", Success: true, Args: []byte(`{"status":"complete","completion":{"unverified":["e2e"]}}`)},
 		)},
-		turn: turnRuntime{engine: runtimepolicy.NewEngine(runtimepolicy.Constraints{})},
+		turn: turnRuntime{engine: runtimepolicy.NewEngine(runtimepolicy.Constraints{}), deliveryScopeActive: true},
 	}
 	got := a.ReadinessResult()
 	if got.Ready || !strings.Contains(got.Reason, "incomplete") {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -519,10 +519,13 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 		return false, a.gracePause(state)
 	}
 	if readiness.reason != "" {
-		// Goal/Plan and fact contradictions (open todos, sign-off, action
-		// receipts) fail the run. Ordinary Recoverable/project/review gaps
-		// become an honest Partial completion instead of a recovery error.
-		if a.closedLoopActive() || readiness.incompleteTodos > 0 || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
+		// Goal/Plan and fact contradictions (open todos in closed-loop turns,
+		// sign-off, action receipts) fail the run. Ordinary Recoverable/
+		// project/review gaps — and unfinished todos in open (non closed-loop)
+		// turns, where the todo list is a cross-turn work plan rather than a
+		// delivery contract — become an honest Partial completion instead of
+		// a recovery error.
+		if a.closedLoopActive() || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
 			event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
 			a.pending.finalReadinessRecovery = true
 			a.persistFinalReadinessRecovery(readiness.missingIDs())

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -910,8 +910,12 @@ func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
 	}
 	jobID := extractJobID(out)
 	res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5)
-	if len(res) != 1 || res[0].Status != jobs.Done || !strings.Contains(res[0].Output, "[unverified]") {
-		t.Fatalf("background salvage = %+v, want done unverified result", res)
+	// An open (non closed-loop) sub-agent treats an unfinished todo list as a
+	// cross-turn work plan: the run completes normally instead of degrading to
+	// the unverified salvage card (#8851). The evidence publication below is
+	// what this test pins.
+	if len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background task = %+v, want done", res)
 	}
 	if parentLedger.Summary().HasMutation() {
 		t.Fatal("background goroutine wrote directly into the parent turn ledger")


### PR DESCRIPTION
### English

**fix(agent): unfinished todos only block closed-loop turns (#8851)**

**Problem**

A plain (non-Goal, balanced) session that used `todo_write` and ended the turn with unfinished items surfaced the Goal-flavored "Delivery checks are not complete" ceremony with a "继续检查" button. The notice cannot be dismissed (`update_goal` rejects it with "no active goal turn"), so the UI stays stuck — confirmed by a third-party user on v1.25.3 and by the maintainer's own #8901 which deliberately kept the unfinished-todo branch hard-closed.

**Root cause**

- `final_readiness.go` — the todo branch (`hasWriter && hasTodos && len(incomplete) > 0`) sits outside any closed-loop gate, so every session that used `todo_write` and left items unfinished is treated as a fact contradiction.
- `run_loop.go` — `readiness.incompleteTodos > 0` is an unconditional hard-fail even when `closedLoopActive()` is false. After #8901 this was the last remaining unconditional hard-fail path for ordinary turns.

In an open turn the todo list is a cross-turn work plan; a partially completed plan is progress, not a contradiction. The ceremony (continue button, `awaiting_delivery` sidebar state, no dismiss path) is designed for Goal/Plan turns that carry a delivery contract.

**Fix**

Gate both the todo branch and the run-loop hard-fail on `closedLoopActive()`:

- `final_readiness.go` — `if a.closedLoopActive() && hasWriter && hasTodos && len(incomplete) > 0`
- `run_loop.go` — drop `readiness.incompleteTodos > 0` from the unconditional hard-fail condition (closed-loop turns still fail via `closedLoopActive()`).

Behavior matrix:

| Session | Unfinished todos | Behavior |
| --- | --- | --- |
| Goal / Plan / strict obligation | yes | unchanged: FinalReadinessError |
| Plain balanced (open) | yes | turn ends normally; todo panel still shows the list |
| Plain balanced (open) | no | unchanged |

Tests updated to the new semantics: open-turn regression test (`TestOpenTurnMayEndWithIncompleteTodosAfterWrite`), plus existing closed-loop/loop-guard/waiver/recovery tests now explicitly run in a closed-loop context. Full `internal/agent` suite passes; gofmt/vet/build/diff-check clean.

**Documentation-impact:** none - existing docs describe compaction and delivery behavior; this restores the documented "plain turns are not goal turns" contract without changing configuration or workflow.

**Design note for maintainers**

This PR intentionally changes a decision #8901 made ("reserve hard closure for unfinished-todo cases"). The trade-off:

- #8901 kept unfinished todos as an unconditional fact-contradiction. In an open turn that conflicts with the todo list's role as a cross-turn work plan: a plan left partially done is progress, not a lie, and the Goal-flavored ceremony it triggers has no working dismissal path in a plain session (update_goal rejects it — confirmed by a v1.25.3 user).
- After this change, open turns can no longer produce a FinalReadinessError at all (signoff/action-receipt obligations are Strict, which already implies closedLoopActive). The open-turn recovery-marker persistence path (persistFinalReadinessRecovery) becomes unreachable by design; tests were updated to pin the closed-loop behavior instead.
- If maintainers prefer to keep open-turn todo enforcement, the alternative is Fix B from #8851: downgrade todo-only final_readiness notices to plain text (no continue_delivery) in the frontend, leaving backend semantics untouched. Happy to switch the PR to that direction.

Fixes #8851.

---

### 中文

**fix(agent): 未完成 todo 只在闭环回合阻塞（#8851）**

**问题**

普通（非 Goal、balanced）会话只要用过 `todo_write` 且回合结束时还有未完成项，就会弹出 Goal 专属的"交付检查尚未完成"通知（含"继续检查"按钮）。该通知无法解除（`update_goal` 报 "no active goal turn"），UI 卡死——v1.25.3 第三方用户已确认，且 maintainer 的 #8901 刻意保留了 unfinished-todo 硬关分支。

**根因**

- `final_readiness.go`：todo 分支（`hasWriter && hasTodos && incomplete>0`）没有闭环门槛，任何用过 `todo_write` 的会话都被当作"事实矛盾"。
- `run_loop.go`：`readiness.incompleteTodos > 0` 无条件硬失败，即使 `closedLoopActive()` 为 false。#8901 之后这是普通回合最后一条无条件硬失败路径。

在开环回合中，todo 列表是跨轮工作计划；部分完成是进展而非矛盾。交付仪式（继续按钮、`awaiting_delivery` 侧边栏状态、无解除路径）是为带交付契约的 Goal/Plan 回合设计的。

**修复**

两处都加 `closedLoopActive()` 门槛：

- `final_readiness.go`：`if a.closedLoopActive() && hasWriter && hasTodos && len(incomplete) > 0`
- `run_loop.go`：从无条件硬失败条件中移除 `readiness.incompleteTodos > 0`（闭环回合仍经 `closedLoopActive()` 失败）

行为矩阵：

| 会话 | 未完成 todo | 行为 |
| --- | --- | --- |
| Goal / Plan / strict 义务 | 有 | 不变：FinalReadinessError |
| 普通 balanced（开环） | 有 | 回合正常结束；todo 面板照常显示 |
| 普通 balanced（开环） | 无 | 不变 |

测试已按新语义更新：新增开环回归测试（`TestOpenTurnMayEndWithIncompleteTodosAfterWrite`），既有 closed-loop/loop-guard/waiver/recovery 测试显式改用闭环上下文。`internal/agent` 全量测试通过；gofmt/vet/build/diff-check 干净。

**Documentation-impact:** none - 现有文档描述的压缩与交付行为不变；本次修复恢复"普通回合不是 goal 回合"的既有契约，不涉及配置或流程。

Fixes #8851。