### PR TITLE
fix(provider): canonicalize official Token Rhythm API paths / 自动修复基元律动官方 API 路径

### DIFF
--- a/internal/config/fetch.go
+++ b/internal/config/fetch.go
@@ -70,10 +70,17 @@ func modelFetchAuthMode(e *ProviderEntry) openai.ModelFetchAuthMode {
 
 // BuildModelFetchURLs derives likely OpenAI-compatible model-list endpoints.
 // It keeps Reasonix's historical {base}/models path first, then tries the common
-// {base}/v1/models shape used by many aggregators.
+// {base}/v1/models shape used by many aggregators. Known official Token Rhythm
+// URLs collapse to a single /v1/models candidate because that /v1 route is complete.
 func BuildModelFetchURLs(baseURL, override string) ([]string, error) {
 	if trimmed := strings.TrimSpace(override); trimmed != "" {
+		if canonical, ok := openai.CanonicalTokenRhythmModelsURL(trimmed); ok {
+			return []string{canonical}, nil
+		}
 		return []string{trimmed}, nil
+	}
+	if canonical, ok := openai.CanonicalTokenRhythmModelsURL(baseURL); ok {
+		return []string{canonical}, nil
 	}
 	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if base == "" {

--- a/internal/config/fetch_test.go
+++ b/internal/config/fetch_test.go
@@ -49,6 +49,39 @@ func TestBuildModelFetchURLs(t *testing.T) {
 			override: "https://api.deepseek.com/custom/models",
 			want:     []string{"https://api.deepseek.com/custom/models"},
 		},
+		{
+			name:     "third-party override keeps exact query and slash",
+			base:     "https://api.deepseek.com",
+			override: "https://api.deepseek.com/custom/models/?token=1",
+			want:     []string{"https://api.deepseek.com/custom/models/?token=1"},
+		},
+		{
+			name: "tokenrhythm missing v1 base is unique canonical models",
+			base: "https://tokenrhythm.studio",
+			want: []string{"https://tokenrhythm.studio/v1/models"},
+		},
+		{
+			name: "tokenrhythm correct base is unique canonical models",
+			base: "https://tokenrhythm.studio/v1",
+			want: []string{"https://tokenrhythm.studio/v1/models"},
+		},
+		{
+			name: "tokenrhythm chat url as base is unique canonical models",
+			base: "https://tokenrhythm.studio/v1/chat/completions",
+			want: []string{"https://tokenrhythm.studio/v1/models"},
+		},
+		{
+			name:     "tokenrhythm wrong models override is unique canonical models",
+			base:     "https://example.invalid/v1",
+			override: "https://tokenrhythm.studio/v1/v1/models/",
+			want:     []string{"https://tokenrhythm.studio/v1/models"},
+		},
+		{
+			name:     "tokenrhythm unknown override stays exact",
+			base:     "https://tokenrhythm.studio/v1",
+			override: "https://tokenrhythm.studio/openai/models",
+			want:     []string{"https://tokenrhythm.studio/openai/models"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/provider/openai/chaturl.go
+++ b/internal/provider/openai/chaturl.go
@@ -1,0 +1,29 @@
+package openai
+
+import "strings"
+
+func resolveOpenAIChatURL(baseURL string, extra map[string]any) string {
+	requestURL, _ := extra["request_url"].(string)
+	requestURL = strings.TrimSpace(requestURL)
+	if canonical, ok := canonicalTokenRhythmChatURL(requestURL); ok {
+		return canonical
+	}
+	if requestURL != "" {
+		return requestURL
+	}
+	legacyChatURL, _ := extra["chat_url"].(string)
+	return normalizeChatURL(baseURL, legacyChatURL)
+}
+
+func normalizeChatURL(baseURL, chatURL string) string {
+	if legacy := strings.TrimRight(strings.TrimSpace(chatURL), "/"); legacy != "" {
+		if canonical, ok := canonicalTokenRhythmChatURL(legacy); ok {
+			return canonical
+		}
+		return legacy
+	}
+	if canonical, ok := canonicalTokenRhythmChatURL(baseURL); ok {
+		return canonical
+	}
+	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/chat/completions"
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -84,12 +84,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	// A meaningful explicit list is the endpoint's declared effort vocabulary;
 	// auto remains implicit and is therefore ignored here.
 	supportedEfforts, hasExplicitEfforts := reasoningEffortVocabulary(kimiK3, supportedEfforts)
-	legacyChatURL, _ := cfg.Extra["chat_url"].(string)
-	chatURL, _ := cfg.Extra["request_url"].(string)
-	chatURL = strings.TrimSpace(chatURL)
-	if chatURL == "" {
-		chatURL = normalizeChatURL(cfg.BaseURL, legacyChatURL)
-	}
+	chatURL := resolveOpenAIChatURL(cfg.BaseURL, cfg.Extra)
 	prefixChatURL := deepSeekPrefixChatURL(chatURL)
 	headers, _ := cfg.Extra["headers"].(map[string]string)
 	extraBody, _ := cfg.Extra["extra_body"].(map[string]any)
@@ -377,13 +372,6 @@ func normalizeReasoningProtocol(raw string) string {
 	default:
 		return ""
 	}
-}
-
-func normalizeChatURL(baseURL, chatURL string) string {
-	if legacy := strings.TrimRight(strings.TrimSpace(chatURL), "/"); legacy != "" {
-		return legacy
-	}
-	return strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/chat/completions"
 }
 
 func cleanCustomHeaders(in map[string]string) map[string]string {

--- a/internal/provider/openai/tokenrhythm.go
+++ b/internal/provider/openai/tokenrhythm.go
@@ -1,0 +1,69 @@
+package openai
+
+import (
+	"net/url"
+	"strings"
+)
+
+const (
+	tokenRhythmOrigin     = "https://tokenrhythm.studio"
+	tokenRhythmHost       = "tokenrhythm.studio"
+	tokenRhythmChatPath   = "/v1/chat/completions"
+	tokenRhythmModelsPath = "/v1/models"
+)
+
+// canonicalTokenRhythmEndpoint rewrites known official Token Rhythm URLs.
+// Official /v1 routes are already complete; unknown or unsafe URLs stay untouched.
+func canonicalTokenRhythmEndpoint(raw, canonicalPath string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if strings.ContainsAny(raw, "?#") {
+		return "", false
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.Opaque != "" {
+		return "", false
+	}
+	if !strings.EqualFold(u.Hostname(), tokenRhythmHost) {
+		return "", false
+	}
+	if port := u.Port(); port != "" && port != "443" {
+		return "", false
+	}
+	if u.User != nil || u.RawPath != "" {
+		return "", false
+	}
+	if !tokenRhythmKnownPath(u.Path) {
+		return "", false
+	}
+	return tokenRhythmOrigin + canonicalPath, true
+}
+
+func canonicalTokenRhythmChatURL(raw string) (string, bool) {
+	return canonicalTokenRhythmEndpoint(raw, tokenRhythmChatPath)
+}
+
+// CanonicalTokenRhythmModelsURL rewrites known official Token Rhythm URLs to GET /v1/models.
+func CanonicalTokenRhythmModelsURL(raw string) (string, bool) {
+	return canonicalTokenRhythmEndpoint(raw, tokenRhythmModelsPath)
+}
+
+func tokenRhythmKnownPath(path string) bool {
+	if path != "/" {
+		path = strings.TrimSuffix(path, "/")
+	}
+	switch path {
+	case "", "/", "/v1", "/v1/v1":
+		return true
+	}
+	for _, leaf := range []string{"/chat/completions", "/models"} {
+		for _, prefix := range []string{"", "/v1", "/v1/v1"} {
+			if path == prefix+leaf || path == prefix+leaf+leaf {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/provider/openai/tokenrhythm_test.go
+++ b/internal/provider/openai/tokenrhythm_test.go
@@ -1,0 +1,249 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+const (
+	wantTokenRhythmChat   = "https://tokenrhythm.studio/v1/chat/completions"
+	wantTokenRhythmModels = "https://tokenrhythm.studio/v1/models"
+)
+
+func TestCanonicalTokenRhythmEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		ok   bool
+	}{
+		{name: "v1 base", raw: "https://tokenrhythm.studio/v1", ok: true},
+		{name: "v1 chat", raw: "https://tokenrhythm.studio/v1/chat/completions", ok: true},
+		{name: "v1 models", raw: "https://tokenrhythm.studio/v1/models", ok: true},
+		{name: "missing v1 root", raw: "https://tokenrhythm.studio", ok: true},
+		{name: "missing v1 slash root", raw: "https://tokenrhythm.studio/", ok: true},
+		{name: "missing v1 chat", raw: "https://tokenrhythm.studio/chat/completions", ok: true},
+		{name: "missing v1 models", raw: "https://tokenrhythm.studio/models", ok: true},
+		{name: "double v1 base", raw: "https://tokenrhythm.studio/v1/v1", ok: true},
+		{name: "double v1 chat", raw: "https://tokenrhythm.studio/v1/v1/chat/completions", ok: true},
+		{name: "double v1 models", raw: "https://tokenrhythm.studio/v1/v1/models", ok: true},
+		{name: "repeated chat suffix", raw: "https://tokenrhythm.studio/v1/chat/completions/chat/completions", ok: true},
+		{name: "repeated chat suffix without v1", raw: "https://tokenrhythm.studio/chat/completions/chat/completions", ok: true},
+		{name: "repeated chat suffix with double v1", raw: "https://tokenrhythm.studio/v1/v1/chat/completions/chat/completions", ok: true},
+		{name: "repeated models suffix", raw: "https://tokenrhythm.studio/v1/models/models", ok: true},
+		{name: "repeated models suffix without v1", raw: "https://tokenrhythm.studio/models/models", ok: true},
+		{name: "repeated models suffix with double v1", raw: "https://tokenrhythm.studio/v1/v1/models/models", ok: true},
+		{name: "uppercase hostname", raw: "https://TOKENRHYTHM.STUDIO/v1", ok: true},
+		{name: "mixed-case hostname chat", raw: "https://TokenRhythm.Studio/v1/chat/completions", ok: true},
+		{name: "explicit 443", raw: "https://tokenrhythm.studio:443/v1", ok: true},
+		{name: "explicit 443 models", raw: "https://tokenrhythm.studio:443/v1/models", ok: true},
+		{name: "trailing slash base", raw: "https://tokenrhythm.studio/v1/", ok: true},
+		{name: "trailing slash chat", raw: "https://tokenrhythm.studio/v1/chat/completions/", ok: true},
+		{name: "trailing slash models", raw: "https://tokenrhythm.studio/v1/models/", ok: true},
+		{name: "whitespace around official url", raw: "  https://tokenrhythm.studio/v1  ", ok: true},
+
+		{name: "api subdomain", raw: "https://api.tokenrhythm.studio/v1", ok: false},
+		{name: "suffix domain", raw: "https://tokenrhythm.studio.example.com/v1", ok: false},
+		{name: "third-party gateway", raw: "https://gateway.example.com/v1", ok: false},
+		{name: "http scheme", raw: "http://tokenrhythm.studio/v1", ok: false},
+		{name: "non-443 port", raw: "https://tokenrhythm.studio:8443/v1", ok: false},
+		{name: "userinfo", raw: "https://user@tokenrhythm.studio/v1", ok: false},
+		{name: "userinfo password", raw: "https://user:pass@tokenrhythm.studio/v1", ok: false},
+		{name: "query", raw: "https://tokenrhythm.studio/v1?foo=1", ok: false},
+		{name: "empty query", raw: "https://tokenrhythm.studio/v1?", ok: false},
+		{name: "fragment", raw: "https://tokenrhythm.studio/v1#frag", ok: false},
+		{name: "empty fragment", raw: "https://tokenrhythm.studio/v1#", ok: false},
+		{name: "escaped path slash", raw: "https://tokenrhythm.studio/v1%2Fchat%2Fcompletions", ok: false},
+		{name: "escaped v1", raw: "https://tokenrhythm.studio/%76%31", ok: false},
+		{name: "invalid url", raw: "://tokenrhythm.studio/v1", ok: false},
+		{name: "relative url", raw: "/v1/chat/completions", ok: false},
+		{name: "missing scheme", raw: "tokenrhythm.studio/v1", ok: false},
+		{name: "unknown path", raw: "https://tokenrhythm.studio/openai", ok: false},
+		{name: "triple v1", raw: "https://tokenrhythm.studio/v1/v1/v1", ok: false},
+		{name: "chat suffix repeated twice", raw: "https://tokenrhythm.studio/v1/chat/completions/chat/completions/chat/completions", ok: false},
+		{name: "anthropic messages", raw: "https://tokenrhythm.studio/v1/messages", ok: false},
+		{name: "embeddings", raw: "https://tokenrhythm.studio/v1/embeddings", ok: false},
+		{name: "trailing-dot hostname", raw: "https://tokenrhythm.studio./v1", ok: false},
+		{name: "empty", raw: "", ok: false},
+		{name: "garbage", raw: "not a url", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotChat, chatOK := canonicalTokenRhythmChatURL(tt.raw)
+			gotModels, modelsOK := CanonicalTokenRhythmModelsURL(tt.raw)
+			if chatOK != tt.ok || modelsOK != tt.ok {
+				t.Fatalf("ok chat=%v models=%v, want %v", chatOK, modelsOK, tt.ok)
+			}
+			if !tt.ok {
+				if gotChat != "" || gotModels != "" {
+					t.Fatalf("rewrote unknown input %q to chat=%q models=%q", tt.raw, gotChat, gotModels)
+				}
+				return
+			}
+			if gotChat != wantTokenRhythmChat {
+				t.Fatalf("chat = %q, want %q", gotChat, wantTokenRhythmChat)
+			}
+			if gotModels != wantTokenRhythmModels {
+				t.Fatalf("models = %q, want %q", gotModels, wantTokenRhythmModels)
+			}
+			if strings.Count(gotChat, "/v1") != 1 || strings.Count(gotChat, "/chat/completions") != 1 {
+				t.Fatalf("chat %q is not a single canonical endpoint", gotChat)
+			}
+			if strings.Count(gotModels, "/v1") != 1 || strings.Count(gotModels, "/models") != 1 {
+				t.Fatalf("models %q is not a single canonical endpoint", gotModels)
+			}
+		})
+	}
+}
+
+func TestNewCanonicalizesTokenRhythmChatURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  provider.Config
+		want string
+	}{
+		{
+			name: "request_url wins over legacy chat_url and base_url",
+			cfg: provider.Config{
+				Name:    "律动",
+				BaseURL: "https://tokenrhythm.studio/v1/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"chat_url":    "https://legacy.example.com/chat/completions/",
+					"request_url": "https://exact.example.com/custom/?token=1",
+				},
+			},
+			want: "https://exact.example.com/custom/?token=1",
+		},
+		{
+			name: "legacy chat_url wins over base_url",
+			cfg: provider.Config{
+				Name:    "other",
+				BaseURL: "https://base.example.com/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"chat_url": "https://legacy.example.com/chat/completions/",
+				},
+			},
+			want: "https://legacy.example.com/chat/completions",
+		},
+		{
+			name: "third-party base_url still appends chat completions",
+			cfg: provider.Config{
+				Name:    "other",
+				BaseURL: "https://base.example.com/v1",
+				Model:   "test-model",
+			},
+			want: "https://base.example.com/v1/chat/completions",
+		},
+		{
+			name: "request_url tokenrhythm typo is repaired",
+			cfg: provider.Config{
+				Name:    "custom-gateway",
+				BaseURL: "https://example.invalid/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"chat_url":    "https://legacy.example.com/chat/completions",
+					"request_url": "https://tokenrhythm.studio/v1/v1/chat/completions",
+				},
+			},
+			want: wantTokenRhythmChat,
+		},
+		{
+			name: "legacy chat_url tokenrhythm typo is repaired",
+			cfg: provider.Config{
+				Name:    "律动",
+				BaseURL: "https://example.invalid/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"chat_url": "https://tokenrhythm.studio/chat/completions/",
+				},
+			},
+			want: wantTokenRhythmChat,
+		},
+		{
+			name: "base_url tokenrhythm typo is repaired",
+			cfg: provider.Config{
+				Name:    "anything",
+				BaseURL: "https://tokenrhythm.studio/v1/chat/completions",
+				Model:   "test-model",
+			},
+			want: wantTokenRhythmChat,
+		},
+		{
+			name: "missing v1 base_url is repaired",
+			cfg: provider.Config{
+				Name:    "律动",
+				BaseURL: "https://tokenrhythm.studio",
+				Model:   "test-model",
+			},
+			want: wantTokenRhythmChat,
+		},
+		{
+			name: "third-party request_url keeps query and trailing slash",
+			cfg: provider.Config{
+				Name:    "other",
+				BaseURL: "https://tokenrhythm.studio/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"request_url": "https://exact.example.com/custom/?token=1",
+				},
+			},
+			want: "https://exact.example.com/custom/?token=1",
+		},
+		{
+			name: "third-party request_url keeps trailing slash",
+			cfg: provider.Config{
+				Name:    "other",
+				BaseURL: "https://base.example.com/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"request_url": "https://exact.example.com/custom/",
+				},
+			},
+			want: "https://exact.example.com/custom/",
+		},
+		{
+			name: "unknown official path is not guessed",
+			cfg: provider.Config{
+				Name:    "律动",
+				BaseURL: "https://tokenrhythm.studio/openai",
+				Model:   "test-model",
+			},
+			want: "https://tokenrhythm.studio/openai/chat/completions",
+		},
+		{
+			name: "third-party query on official host is left alone",
+			cfg: provider.Config{
+				Name:    "律动",
+				BaseURL: "https://example.invalid/v1",
+				Model:   "test-model",
+				Extra: map[string]any{
+					"request_url": "https://tokenrhythm.studio/v1/chat/completions?trace=1",
+				},
+			},
+			want: "https://tokenrhythm.studio/v1/chat/completions?trace=1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p, err := New(tt.cfg)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			got := p.(*client).chatURL
+			if got != tt.want {
+				t.Fatalf("chatURL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Automatically repair known official Token Rhythm API path mistakes before the first request.
- Canonicalize Chat to `https://tokenrhythm.studio/v1/chat/completions` and models to `https://tokenrhythm.studio/v1/models`.
- Identify the official host with `net/url` allowlisting only. Provider name, model name, API key, and preset ID are not used.
- Leave all other third-party OpenAI-compatible providers byte-identical, including `request_url > chat_url > base_url` and model-fetch candidate order.
- Do not rewrite `config.toml` or `reasonix.toml`; settings still show the user's original URL.

## Problem

Custom OpenAI providers pointed at `tokenrhythm.studio` often 404 because users omit `/v1`, double `/v1`, or paste a complete chat URL as `base_url`. Reasonix then appends `/chat/completions` or probes `{base}/models`.

## Root cause

Official Token Rhythm routes are already complete under `https://tokenrhythm.studio/v1`. Reasonix treated those values as ordinary OpenAI bases and concatenated another path.

## Fix

Before the first network request, rewrite only URLs that are:

- absolute `https`
- hostname exactly `tokenrhythm.studio` (case-insensitive)
- port empty or `443`
- free of userinfo, query, fragment, and escaped paths
- in the known correct or mistaken path set

Unknown official paths, subdomains, proxies, HTTP, and non-443 ports keep the current error.

## 中文摘要

自定义填写基元律动官方域名时，常见的缺 `/v1`、重复 `/v1`、把完整 Chat URL 当 Base URL 等错误会在首次请求前自动修到官方端点。配置文件不改写，其他第三方 API 行为不变。

## Compatibility

| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| `base_url` / `chat_url` / `request_url` / `models_url` | persisted as typed | runtime rewrite only | same files, old semantics | compatible |
| Config / Wails / migration | no new fields | none | none | no persisted-format change |

## Cache

Provider-visible prompt, tools, headers, and request body are unchanged. Only the request URL is rewritten for known official Token Rhythm paths.

Cache-impact: none - request URL host/path rewrite only; provider-visible prefix, tools, and body are unchanged
Cache-guard: go test ./internal/provider/openai ./internal/config -run 'TestCanonicalTokenRhythmEndpoints|TestNewCanonicalizesTokenRhythmChatURLs|TestNewPrefersExactRequestURLOverLegacyChatURL|TestBuildModelFetchURLs'
Documentation-impact: none - existing docs already document Token Rhythm as https://tokenrhythm.studio/v1; this only repairs mis-typed custom URLs at request time

## Verification

- `go test ./internal/provider/openai ./internal/config`
- `go test ./internal/tool/builtin ./internal/boot`
- `go vet ./internal/provider/openai ./internal/config ./internal/tool/builtin ./internal/boot`
- `golangci-lint run ./internal/provider/openai/... ./internal/config/...`
- `go run ./tools/repolint`
