### PR TITLE
Fix provider reasoning replay recovery / 修复供应商推理重放恢复

### DIFF
--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -27,7 +27,7 @@ func (e *ReasoningReplayError) Error() string {
 	if e != nil && e.Kind == ReasoningReplayOverflow {
 		return "The provider reasoning exceeded the client safety limit, so Reasonix did not run the requested tools. Existing work was kept; retry to continue safely."
 	}
-	return "The provider omitted reasoning required to replay this tool turn, so Reasonix did not run the requested tools. Existing work was kept; retry to continue safely."
+	return "The provider omitted reasoning required to replay this tool turn after an automatic retry, so Reasonix did not run the requested tools. Existing work was kept; retry to make a fresh attempt."
 }
 
 // PauseClass names the guard that deliberately ended a run, so a host can

--- a/internal/agent/live_opencode_go_replay_test.go
+++ b/internal/agent/live_opencode_go_replay_test.go
@@ -1,0 +1,121 @@
+//go:build live
+
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/provider/anthropic"
+	"reasonix/internal/provider/openai"
+	"reasonix/internal/provider/responses"
+	"reasonix/internal/tool"
+)
+
+// TestLiveOpenCodeGoDeepSeekAgentToolLoops repeatedly exercises the production
+// Agent recovery boundary against both strict OpenCode Go Flash protocols.
+func TestLiveOpenCodeGoDeepSeekAgentToolLoops(t *testing.T) {
+	key := os.Getenv("OPENCODE_GO_API_KEY")
+	if key == "" {
+		t.Skip("OPENCODE_GO_API_KEY not set")
+	}
+	providers := []struct {
+		name string
+		new  func() (provider.Provider, error)
+	}{
+		{name: "anthropic", new: func() (provider.Provider, error) {
+			return anthropic.New(provider.Config{
+				Name: "opencode-go-deepseek-anthropic", BaseURL: "https://opencode.ai/zen/go", Model: "deepseek-v4-flash", APIKey: key,
+				Extra: map[string]any{
+					"api_key_env": "OPENCODE_GO_API_KEY", "reasoning_protocol": "deepseek",
+					"thinking": "adaptive", "effort": "high", "web_search": true,
+				},
+			})
+		}},
+		{name: "responses", new: func() (provider.Provider, error) {
+			return responses.New(responses.Config{
+				Name: "opencode-go-deepseek-responses", BaseURL: "https://opencode.ai/zen/go/v1", Model: "deepseek-v4-flash",
+				APIKey: key, KeyEnv: "OPENCODE_GO_API_KEY", Effort: "high", Mode: "stateless", WebSearch: true, MaxOutputTokens: 512,
+			}), nil
+		}},
+	}
+
+	for _, tc := range providers {
+		t.Run(tc.name, func(t *testing.T) {
+			prov, err := tc.new()
+			if err != nil {
+				t.Fatalf("new provider: %v", err)
+			}
+			if closer, ok := prov.(interface{ CloseIdleConnections() }); ok {
+				t.Cleanup(closer.CloseIdleConnections)
+			}
+			retries, recovered := runLiveAgentToolLoops(t, prov, 10)
+			t.Logf("protocol=%s runs=10 tool_executions=10 retry_attempts=%d recovered=%d", tc.name, retries, recovered)
+		})
+	}
+}
+
+func TestLiveCompatibleProviderDefaultReasoningAgentToolLoops(t *testing.T) {
+	providers := []struct {
+		name, keyEnv, baseURL, model string
+		extra                        map[string]any
+	}{
+		{name: "longcat", keyEnv: "LONGCAT_API_KEY", baseURL: "https://api.longcat.chat/openai/v1", model: "LongCat-2.0", extra: map[string]any{"thinking": "enabled", "effort": "enabled"}},
+		{name: "zhipu-coding-plan", keyEnv: "GLM_PLAN_API_KEY", baseURL: "https://open.bigmodel.cn/api/coding/paas/v4", model: "glm-5.2", extra: map[string]any{"reasoning_protocol": "glm"}},
+	}
+	for _, tc := range providers {
+		t.Run(tc.name, func(t *testing.T) {
+			key := os.Getenv(tc.keyEnv)
+			if key == "" {
+				t.Skip(tc.keyEnv + " not set")
+			}
+			tc.extra["api_key_env"] = tc.keyEnv
+			prov, err := openai.New(provider.Config{Name: tc.name, BaseURL: tc.baseURL, Model: tc.model, APIKey: key, Extra: tc.extra})
+			if err != nil {
+				t.Fatalf("new provider: %v", err)
+			}
+			if closer, ok := prov.(interface{ CloseIdleConnections() }); ok {
+				t.Cleanup(closer.CloseIdleConnections)
+			}
+			retries, recovered := runLiveAgentToolLoops(t, prov, 5)
+			t.Logf("provider=%s runs=5 tool_executions=5 retry_attempts=%d recovered=%d", tc.name, retries, recovered)
+		})
+	}
+}
+
+func runLiveAgentToolLoops(t *testing.T, prov provider.Provider, runs int) (retries, recovered int) {
+	t.Helper()
+	stateDir := t.TempDir()
+	for attempt := 1; attempt <= runs; attempt++ {
+		var executions atomic.Int32
+		registry := tool.NewRegistry()
+		registry.Add(liveRecoveryEchoTool{executions: &executions})
+		sink := &recordSink{}
+		session := NewSession("You are a concise tool-using assistant. Call the requested tool exactly once before answering.")
+		a := New(prov, registry, session, Options{
+			MaxSteps: 4, MaxOutputTokens: 512, MissingReasoningWarnStateDir: stateDir,
+		}, sink)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		err := a.Run(ctx, "Call echo exactly once, then reply with the marker result.")
+		cancel()
+		if err != nil {
+			t.Fatalf("attempt %d: %v", attempt, err)
+		}
+		if got := executions.Load(); got != 1 {
+			t.Fatalf("attempt %d tool executions = %d, want 1", attempt, got)
+		}
+		messages := session.Snapshot()
+		if len(messages) == 0 || strings.TrimSpace(messages[len(messages)-1].Content) == "" {
+			t.Fatalf("attempt %d produced no final assistant text", attempt)
+		}
+		retries += sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted)
+		recovered += sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryRecovered)
+	}
+	return retries, recovered
+}

--- a/internal/agent/missing_reasoning_watch.go
+++ b/internal/agent/missing_reasoning_watch.go
@@ -39,12 +39,22 @@ func (a *Agent) observeMissingToolCallReasoning(calls []provider.ToolCall, reaso
 // provider-executed tool activity while preserving its persisted incident and
 // anti-flapping behavior.
 func (a *Agent) observeMissingAssistantReasoning(message provider.Message, complete bool) (missing, shouldRetry bool) {
-	if !provider.RequiresAssistantReasoningReplay(a.svc.prov, message) || !provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
+	if !provider.RequiresAssistantReasoningReplay(a.svc.prov, message) {
 		return false, false
 	}
 	reasoning := message.ReasoningContent
 	if !complete {
 		reasoning = ""
+	}
+	// Strict protocols cannot fall back to empty reasoning. Give each sampling
+	// boundary one exact retry; the retry finalizer rejects a second malformed
+	// response without executing tools.
+	if strings.TrimSpace(reasoning) == "" && !provider.AllowsEmptyReasoningFallback(a.svc.prov) {
+		return true, true
+	}
+	// Persist anti-flapping only when empty reasoning is a valid fallback.
+	if !provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
+		return false, false
 	}
 	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(a.svc.prov)
 	observedAt := time.Now()

--- a/internal/agent/opencode_go_recovery_e2e_test.go
+++ b/internal/agent/opencode_go_recovery_e2e_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/provider/anthropic"
+)
+
+const missingReasoningToolSSE = `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"echo"}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"text\":\"hi\"}"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":8}}
+
+data: {"type":"message_stop"}
+
+`
+
+const recoveredReasoningToolSSE = `data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"call echo safely"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"echo"}}
+
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"text\":\"hi\"}"}}
+
+data: {"type":"content_block_stop","index":1}
+
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":12}}
+
+data: {"type":"message_stop"}
+
+`
+
+const finalAnswerSSE = `data: {"type":"message_start","message":{"usage":{"input_tokens":20}}}
+
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}
+
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}
+
+data: {"type":"content_block_stop","index":0}
+
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+data: {"type":"message_stop"}
+
+`
+
+func TestOpenCodeGoAnthropicMissingReasoningRecoversBeforeToolExecution(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	responses := []string{missingReasoningToolSSE, recoveredReasoningToolSSE, finalAnswerSSE}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		bodies = append(bodies, body)
+		i := len(bodies) - 1
+		mu.Unlock()
+		if i >= len(responses) {
+			t.Errorf("unexpected request %d", i+1)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, responses[i])
+	}))
+	defer srv.Close()
+
+	prov, err := anthropic.New(provider.Config{
+		Name: "opencode-go-deepseek", BaseURL: srv.URL, Model: "deepseek-v4-flash", APIKey: "test-key",
+		Extra: map[string]any{"reasoning_protocol": "deepseek", "thinking": "adaptive", "effort": "high", "web_search": true},
+	})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	sink := &recordSink{}
+	agent := New(prov, echoRegistry(), NewSession(""), Options{}, sink)
+	if err := agent.Run(withNoClosedLoop(context.Background()), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 3 {
+		t.Fatalf("HTTP requests = %d, want malformed turn, exact retry, and final turn", len(bodies))
+	}
+	if !bytes.Equal(bodies[0], bodies[1]) {
+		t.Fatal("missing-reasoning recovery did not retry the exact frozen request")
+	}
+	for _, wire := range [][]byte{
+		[]byte(`"thinking":{"type":"enabled"}`),
+		[]byte(`"output_config":{"effort":"high"}`),
+		[]byte(`{"type":"web_search_20250305","name":"web_search"}`),
+	} {
+		if !bytes.Contains(bodies[0], wire) {
+			t.Fatalf("OpenCode Go preset request is missing %s", wire)
+		}
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != 1 {
+		t.Fatalf("missing-reasoning retries = %d, want 1", got)
+	}
+	if got := len(sink.kinds(event.ToolResult)); got != 1 {
+		t.Fatalf("tool results = %d, want exactly one execution after recovery", got)
+	}
+}

--- a/internal/agent/reasoning_replay.go
+++ b/internal/agent/reasoning_replay.go
@@ -68,13 +68,17 @@ func (a *Agent) finishUnreplayableReasoning(result streamedTurn, sink *deferredS
 		sink.Flush()
 		return result
 	}
-	if len(result.calls) > 0 && !provider.AllowsEmptyReasoningFallback(a.svc.prov) {
+	// Empty can replace reasoning the provider never emitted, never reasoning
+	// truncated by the client limit: preserved-thinking protocols require the
+	// returned content to remain complete and unchanged.
+	allowsFallback := issue == ReasoningReplayMissing && provider.AllowsEmptyReasoningFallback(a.svc.prov)
+	if len(result.calls) > 0 && !allowsFallback {
 		sink.Discard()
 		event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryClientToolRejected})
 		result.err = &ReasoningReplayError{Kind: issue}
 		return result
 	}
-	if len(result.serverSearch) > 0 && !provider.AllowsEmptyReasoningFallback(a.svc.prov) {
+	if len(result.serverSearch) > 0 && !allowsFallback {
 		if strings.TrimSpace(result.text) == "" {
 			sink.Discard()
 			result.err = &ReasoningReplayError{Kind: issue}
@@ -91,7 +95,7 @@ func (a *Agent) finishUnreplayableReasoning(result streamedTurn, sink *deferredS
 		event.RecordProtocolRecovery(a.svc.sink, event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryServerSearchSalvaged})
 		return result
 	}
-	if provider.RequiresReasoningRoundTrip(a.svc.prov) && !provider.AllowsEmptyReasoningFallback(a.svc.prov) {
+	if provider.RequiresReasoningRoundTrip(a.svc.prov) && !allowsFallback {
 		sink.Discard()
 		result.err = &ReasoningReplayError{Kind: issue}
 		return result

--- a/internal/agent/reasoning_replay_recovery_test.go
+++ b/internal/agent/reasoning_replay_recovery_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+type strictNoWarningReasoningProvider struct{ *testutil.MockProvider }
+
+func (p strictNoWarningReasoningProvider) RequiresToolCallReasoning() bool      { return true }
+func (p strictNoWarningReasoningProvider) WarnOnMissingToolCallReasoning() bool { return false }
+
+func TestStrictMissingReasoningRetryIsNotSuppressedAcrossRuns(t *testing.T) {
+	stateDir := t.TempDir()
+	call := provider.ToolCall{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}
+	seedProvider := strictAssistantReasoningProvider{testutil.NewMock("strict-replay")}
+	fingerprint := provider.MissingToolCallReasoningWarningFingerprint(seedProvider)
+	if !newMissingReasoningWarnState(stateDir).claim(fingerprint) {
+		t.Fatal("failed to seed a persisted incident from the previous behavior")
+	}
+
+	firstProvider := testutil.NewMock("strict-replay",
+		testutil.Turn{ToolCalls: []provider.ToolCall{call}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{call}},
+	)
+	firstSink := &recordSink{}
+	first := New(strictAssistantReasoningProvider{firstProvider}, echoRegistry(), NewSession(""), Options{
+		MissingReasoningWarnStateDir: stateDir,
+	}, firstSink)
+	var replayErr *ReasoningReplayError
+	if err := first.Run(withNoClosedLoop(context.Background()), "go"); !errors.As(err, &replayErr) {
+		t.Fatalf("first Run error = %v, want ReasoningReplayError", err)
+	}
+	if message := replayErr.Error(); !strings.Contains(message, "after an automatic retry") || !strings.Contains(message, "fresh attempt") {
+		t.Fatalf("ReasoningReplayError = %q, want attempted recovery and actionable retry guidance", message)
+	}
+	if got := firstSink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != 1 {
+		t.Fatalf("first Run retries = %d, want 1", got)
+	}
+
+	secondProvider := testutil.NewMock("strict-replay",
+		testutil.Turn{ToolCalls: []provider.ToolCall{call}},
+		testutil.Turn{Reasoning: "safe retry", ToolCalls: []provider.ToolCall{call}},
+		testutil.Turn{Text: "done"},
+	)
+	secondSink := &recordSink{}
+	second := New(strictAssistantReasoningProvider{secondProvider}, echoRegistry(), NewSession(""), Options{
+		MissingReasoningWarnStateDir: stateDir,
+	}, secondSink)
+	if err := second.Run(withNoClosedLoop(context.Background()), "go"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if got := secondSink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != 1 {
+		t.Fatalf("second Run retries = %d, want 1 despite the persisted incident", got)
+	}
+	requests := secondProvider.Requests()
+	if len(requests) != 3 || !reflect.DeepEqual(requests[0], requests[1]) {
+		t.Fatalf("strict recovery requests = %d, want identical retry followed by final turn", len(requests))
+	}
+}
+
+func TestStrictNoWarningReplayDoesNotLeakSpeculativeEvents(t *testing.T) {
+	missingTurn := func(id string) testutil.Turn {
+		call := provider.ToolCall{ID: id, Name: "echo", Arguments: `{"text":"must not run"}`}
+		return testutil.Turn{Chunks: []provider.Chunk{
+			{Type: provider.ChunkText, Text: "speculative"},
+			{Type: provider.ChunkToolCallStart, ToolCall: &call},
+			{Type: provider.ChunkToolCall, ToolCall: &call},
+			{Type: provider.ChunkDone},
+		}}
+	}
+	providerMock := testutil.NewMock("strict-no-warning", missingTurn("c1"), missingTurn("c2"))
+	sink := &recordSink{}
+	agent := New(strictNoWarningReasoningProvider{providerMock}, echoRegistry(), NewSession(""), Options{}, sink)
+
+	var replayErr *ReasoningReplayError
+	if err := agent.Run(withNoClosedLoop(context.Background()), "go"); !errors.As(err, &replayErr) {
+		t.Fatalf("Run error = %v, want ReasoningReplayError", err)
+	}
+	if got := providerMock.CallCount(); got != 2 {
+		t.Fatalf("provider calls = %d, want malformed turn plus one exact retry", got)
+	}
+	for _, kind := range []event.Kind{event.ToolDispatch, event.ToolResult, event.Text, event.Message} {
+		if got := len(sink.kinds(kind)); got != 0 {
+			t.Fatalf("speculative %v events = %d, want 0", kind, got)
+		}
+	}
+}

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -178,3 +178,53 @@ func TestDeepSeekFlashMissingReasoningRecoveryWithRealSSE(t *testing.T) {
 		}
 	}
 }
+
+func TestGLMToolTurnWithoutReasoningContinuesWithoutRecovery(t *testing.T) {
+	var mu sync.Mutex
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, append([]byte(nil), body...))
+		requestNo := len(bodies)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if requestNo == 1 {
+			_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"echo","arguments":"{\"text\":\"hi\"}"}}]},"finish_reason":"tool_calls"}]}`+"\n\n")
+		} else {
+			_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}`+"\n\n")
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := openai.New(provider.Config{
+		Name: "glm", BaseURL: srv.URL, Model: "glm-5.2", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "glm"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), NewSession(""), Options{}, sink)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	requestBodies := append([][]byte(nil), bodies...)
+	mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("HTTP requests = %d, want tool turn and final turn without recovery", len(requestBodies))
+	}
+	if bytes.Contains(requestBodies[1], []byte(`"reasoning_content"`)) {
+		t.Fatal("GLM replay invented reasoning_content for a turn that emitted none")
+	}
+	if got := sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != 0 {
+		t.Fatalf("missing-reasoning retries = %d, want 0", got)
+	}
+	if got := len(sink.kinds(event.ToolResult)); got != 1 {
+		t.Fatalf("tool results = %d, want 1", got)
+	}
+}

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -3,12 +3,15 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -20,6 +23,19 @@ type recordSink struct {
 	mu       sync.Mutex
 	evs      []event.Event
 	recovery []event.ProtocolRecoveryAudit
+}
+
+type textSignalSink struct {
+	*recordSink
+	textSeen chan struct{}
+	once     sync.Once
+}
+
+func (s *textSignalSink) Emit(e event.Event) {
+	s.recordSink.Emit(e)
+	if e.Kind == event.Text {
+		s.once.Do(func() { close(s.textSeen) })
+	}
 }
 
 func (s *recordSink) Emit(e event.Event) {
@@ -218,13 +234,91 @@ func TestGLMToolTurnWithoutReasoningContinuesWithoutRecovery(t *testing.T) {
 	if len(requestBodies) != 2 {
 		t.Fatalf("HTTP requests = %d, want tool turn and final turn without recovery", len(requestBodies))
 	}
-	if bytes.Contains(requestBodies[1], []byte(`"reasoning_content"`)) {
-		t.Fatal("GLM replay invented reasoning_content for a turn that emitted none")
+	if !bytes.Contains(requestBodies[1], []byte(`"reasoning_content":""`)) {
+		t.Fatal("GLM replay did not preserve the empty reasoning_content field required for tool history")
 	}
 	if got := sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != 0 {
 		t.Fatalf("missing-reasoning retries = %d, want 0", got)
 	}
 	if got := len(sink.kinds(event.ToolResult)); got != 1 {
 		t.Fatalf("tool results = %d, want 1", got)
+	}
+}
+
+func TestGLMTextWithoutReasoningStreamsBeforeResponseCompletes(t *testing.T) {
+	responseStarted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	var releaseOnce sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"streamed"}}]}`+"\n\n")
+		w.(http.Flusher).Flush()
+		close(responseStarted)
+		<-releaseResponse
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseResponse) }) })
+
+	prov, err := openai.New(provider.Config{
+		Name: "glm", BaseURL: srv.URL, Model: "glm-5.2", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "glm"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	sink := &textSignalSink{recordSink: &recordSink{}, textSeen: make(chan struct{})}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, sink)
+	done := make(chan error, 1)
+	go func() { done <- a.Run(withNoClosedLoop(context.Background()), "reply with streamed") }()
+
+	<-responseStarted
+	select {
+	case <-sink.textSeen:
+	case err := <-done:
+		t.Fatalf("Run completed before the held response was released: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GLM text stayed buffered until the response completed")
+	}
+	releaseOnce.Do(func() { close(releaseResponse) })
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestGLMReasoningOverflowFailsBeforeToolExecution(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestNo := requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if requestNo == 1 {
+			_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"reasoning_content":"`+strings.Repeat("reason", 16)+`"}}]}`+"\n\n")
+			_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"echo","arguments":"{\"text\":\"must not run\"}"}}]},"finish_reason":"tool_calls"}]}`+"\n\n")
+		} else {
+			_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"content":"unexpected continuation"},"finish_reason":"stop"}]}`+"\n\n")
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := openai.New(provider.Config{
+		Name: "glm", BaseURL: srv.URL, Model: "glm-5.2", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "glm"},
+	})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+	sink := &recordSink{}
+	a := New(prov, echoRegistry(), NewSession(""), Options{ReasoningByteLimit: 16}, sink)
+	var replayErr *ReasoningReplayError
+	if err := a.Run(withNoClosedLoop(context.Background()), "go"); !errors.As(err, &replayErr) || replayErr.Kind != ReasoningReplayOverflow {
+		t.Fatalf("Run error = %v, want ReasoningReplayOverflow", err)
+	}
+	if got := len(sink.kinds(event.ToolResult)); got != 0 {
+		t.Fatalf("tool results = %d, want 0 after incomplete GLM reasoning", got)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("HTTP requests = %d, want no continuation after incomplete GLM reasoning", got)
 	}
 }

--- a/internal/agent/sampling_attempt.go
+++ b/internal/agent/sampling_attempt.go
@@ -26,7 +26,11 @@ func (a *Agent) runSamplingAttempt(ctx context.Context, turn int, sink event.Sin
 }
 
 func (a *Agent) samplingAttemptSinks() (*deferredStreamSink, event.Sink) {
-	if provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
+	// Replay requirements own speculative event visibility. Even providers that
+	// suppress diagnostics must hide tool cards until replayability is known.
+	if provider.RequiresToolCallReasoning(a.svc.prov) ||
+		provider.RequiresReasoningRoundTrip(a.svc.prov) ||
+		provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
 		streamSink := newReasoningAwareStreamSink(a.svc.sink)
 		return streamSink, streamSink
 	}

--- a/internal/agent/sampling_attempt.go
+++ b/internal/agent/sampling_attempt.go
@@ -26,11 +26,15 @@ func (a *Agent) runSamplingAttempt(ctx context.Context, turn int, sink event.Sin
 }
 
 func (a *Agent) samplingAttemptSinks() (*deferredStreamSink, event.Sink) {
-	// Replay requirements own speculative event visibility. Even providers that
-	// suppress diagnostics must hide tool cards until replayability is known.
-	if provider.RequiresToolCallReasoning(a.svc.prov) ||
+	// Buffer when missing reasoning can reject or replace the attempt. Protocols
+	// that adopt an empty fallback without retry must keep streaming live because
+	// their first response always wins.
+	warnOnMissing := provider.WarnOnMissingToolCallReasoning(a.svc.prov)
+	replaySensitive := provider.RequiresToolCallReasoning(a.svc.prov) ||
 		provider.RequiresReasoningRoundTrip(a.svc.prov) ||
-		provider.WarnOnMissingToolCallReasoning(a.svc.prov) {
+		warnOnMissing
+	if replaySensitive && (!provider.AllowsEmptyReasoningFallback(a.svc.prov) ||
+		warnOnMissing) {
 		streamSink := newReasoningAwareStreamSink(a.svc.sink)
 		return streamSink, streamSink
 	}

--- a/internal/provider/anthropic/realdeepseek_test.go
+++ b/internal/provider/anthropic/realdeepseek_test.go
@@ -28,10 +28,11 @@ func TestRealOpenCodeGoDeepSeekAnthropicWebSearch(t *testing.T) {
 		Model:   "deepseek-v4-flash",
 		APIKey:  key,
 		Extra: map[string]any{
-			"api_key_env": "OPENCODE_GO_API_KEY",
-			"thinking":    "adaptive",
-			"effort":      "high",
-			"web_search":  true,
+			"api_key_env":        "OPENCODE_GO_API_KEY",
+			"reasoning_protocol": "deepseek",
+			"thinking":           "adaptive",
+			"effort":             "high",
+			"web_search":         true,
 		},
 	})
 	if err != nil {
@@ -56,7 +57,10 @@ func TestRealOpenCodeGoDeepSeekAnthropicToolLoop(t *testing.T) {
 	}
 	p, err := New(provider.Config{
 		Name: "opencode-go-deepseek-anthropic", BaseURL: "https://opencode.ai/zen/go", Model: "deepseek-v4-flash", APIKey: key,
-		Extra: map[string]any{"api_key_env": "OPENCODE_GO_API_KEY", "thinking": "adaptive", "effort": "high"},
+		Extra: map[string]any{
+			"api_key_env": "OPENCODE_GO_API_KEY", "reasoning_protocol": "deepseek",
+			"thinking": "adaptive", "effort": "high",
+		},
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -312,7 +312,7 @@ func (c *client) RequiresToolCallReasoning() bool {
 }
 
 func (c *client) AllowsEmptyReasoningFallback() bool {
-	return c.RequiresToolCallReasoning()
+	return c != nil && (c.RequiresToolCallReasoning() || c.glmThinkingEnabled())
 }
 
 func (c *client) RequiresReasoningRoundTrip() bool {
@@ -733,11 +733,10 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 				if c.RequiresToolCallReasoning() || m.ReasoningContent != "" {
 					cm.ReasoningContent = &m.ReasoningContent
 				}
-			case c.zhipu && m.ReasoningContent != "":
+			case c.zhipu && (m.ReasoningContent != "" || (c.glmThinkingEnabled() && len(m.ToolCalls) > 0)):
 				// GLM interleaved and preserved thinking require provider-issued
-				// reasoning content to be returned unchanged in later history. Keep
-				// an existing value even after thinking is turned off so an
-				// enabled→disabled session retains its valid history bytes.
+				// reasoning unchanged. Coding Plan includes the field on tool turns
+				// even when empty; preserve non-empty history after disabling too.
 				cm.ReasoningContent = &m.ReasoningContent
 			}
 		}

--- a/internal/provider/openai/reasoning_replay_policy.go
+++ b/internal/provider/openai/reasoning_replay_policy.go
@@ -1,0 +1,24 @@
+package openai
+
+import (
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// RequiresAssistantReasoningReplay narrows GLM's broad preservation policy to
+// reasoning the endpoint actually emitted. GLM may omit reasoning on valid
+// thinking-enabled tool turns; those turns remain replayable without inventing
+// an empty chain. Kimi K3 still requires every complete assistant message.
+func (c *client) RequiresAssistantReasoningReplay(m provider.Message) bool {
+	if c == nil {
+		return false
+	}
+	if c.kimiK3 {
+		return true
+	}
+	if c.zhipu {
+		return strings.TrimSpace(m.ReasoningContent) != ""
+	}
+	return len(m.ToolCalls) > 0 && c.RequiresToolCallReasoning()
+}

--- a/internal/provider/openai/reasoning_replay_policy_test.go
+++ b/internal/provider/openai/reasoning_replay_policy_test.go
@@ -6,7 +6,7 @@ import (
 	"reasonix/internal/provider"
 )
 
-func TestGLMRequiresOnlyProviderIssuedReasoningReplay(t *testing.T) {
+func TestGLMPreservesIssuedReasoningAndAllowsEmptyToolFallback(t *testing.T) {
 	p, err := New(provider.Config{
 		Name: "glm", BaseURL: "https://open.bigmodel.cn/api/coding/paas/v4", Model: "glm-5.2", APIKey: "k",
 		Extra: map[string]any{"reasoning_protocol": "glm"},
@@ -22,5 +22,29 @@ func TestGLMRequiresOnlyProviderIssuedReasoningReplay(t *testing.T) {
 	}
 	if provider.RequiresAssistantReasoningReplay(p, provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "read_file"}}}) {
 		t.Fatal("GLM tool turns without provider reasoning must remain replayable")
+	}
+	if !provider.AllowsEmptyReasoningFallback(p) {
+		t.Fatal("GLM must accept an empty reasoning_content value when the provider emitted none")
+	}
+	if provider.RequiresAssistantReasoningReplay(p, provider.Message{Role: provider.RoleAssistant, Content: "plain answer"}) {
+		t.Fatal("GLM plain answers without reasoning must remain replayable")
+	}
+}
+
+func TestGLMSerializesEmptyReasoningContentForToolHistory(t *testing.T) {
+	p, err := New(provider.Config{
+		Name: "glm", BaseURL: "https://open.bigmodel.cn/api/coding/paas/v4", Model: "glm-5.2", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "glm"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req := p.(*client).buildRequest(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "inspect"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "read_file", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main"},
+	}})
+	if got := req.Messages[1].ReasoningContent; got == nil || *got != "" {
+		t.Fatalf("GLM empty tool reasoning_content = %v, want explicit empty string", got)
 	}
 }

--- a/internal/provider/openai/reasoning_replay_policy_test.go
+++ b/internal/provider/openai/reasoning_replay_policy_test.go
@@ -1,0 +1,26 @@
+package openai
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestGLMRequiresOnlyProviderIssuedReasoningReplay(t *testing.T) {
+	p, err := New(provider.Config{
+		Name: "glm", BaseURL: "https://open.bigmodel.cn/api/coding/paas/v4", Model: "glm-5.2", APIKey: "k",
+		Extra: map[string]any{"reasoning_protocol": "glm"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !provider.RequiresReasoningRoundTrip(p) {
+		t.Fatal("thinking-enabled GLM must preserve provider-issued reasoning")
+	}
+	if !provider.RequiresAssistantReasoningReplay(p, provider.Message{Role: provider.RoleAssistant, ReasoningContent: "provider reasoning"}) {
+		t.Fatal("GLM must replay reasoning the provider emitted")
+	}
+	if provider.RequiresAssistantReasoningReplay(p, provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "read_file"}}}) {
+		t.Fatal("GLM tool turns without provider reasoning must remain replayable")
+	}
+}


### PR DESCRIPTION
## Summary

- give strict reasoning-replay providers one exact retry per sampling boundary, independent of the persisted diagnostic incident state
- buffer only attempts whose replay policy can reject or replace the first response; keep fallback-compatible GLM responses streaming live
- keep a second malformed strict response and truncated preserved reasoning fail-closed before client tools execute
- preserve provider-issued GLM reasoning byte-for-byte and serialize the explicit empty `reasoning_content` field for valid tool turns where Coding Plan emitted none
- add deterministic production-adapter coverage and credential-gated live matrices for OpenCode Go, DeepSeek, LongCat, and Zhipu Coding Plan

## Problem

Strict Anthropic/Responses-compatible providers could omit reasoning on a tool-call turn. The Agent detected the unsafe turn, but its single retry was coupled to a persisted warning circuit breaker, so a previous incident could suppress recovery for later user retries. Providers that required replay but suppressed diagnostics could also emit speculative text/tool cards before validation, leaving the UI showing tool work that was never executed.

The same broad replay capability caused every thinking-enabled GLM response to be buffered until the complete SSE response arrived. Real Zhipu Coding Plan responses demonstrated that GLM tool turns may validly omit reasoning, so long text-only or valid empty-reasoning turns appeared stalled even though their chunks had already arrived.

## Official GLM protocol basis

- Zhipu's [Coding Plan integration guide](https://docs.bigmodel.cn/cn/guide/develop/others) documents the OpenAI-compatible Coding Plan endpoint used by this provider.
- Zhipu's [thinking-mode guide](https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode) requires interleaved/preserved reasoning to be returned complete and unmodified, and its tool-history example includes `reasoning_content` even when the value is empty.
- The [OpenCode Coding Plan guide](https://docs.bigmodel.cn/cn/coding-plan/tool/opencode) uses streaming requests for the supported workflow.

## Fix

- Recovery ownership now follows the provider's replay/fallback contract. Strict protocols always receive one exact frozen-request retry; the retry finalizer rejects a second malformed response without recursion or tool execution.
- Event buffering follows whether the first response can be rejected or replaced. A no-retry empty-fallback GLM turn now publishes SSE text immediately instead of waiting for `[DONE]`.
- GLM uses message-aware replay policy: provider-issued reasoning is retained byte-for-byte, while a valid tool turn with no emitted reasoning is serialized as `"reasoning_content":""` on continuation.
- Empty fallback applies only to genuinely missing reasoning. Reasoning truncated by the client byte limit is rejected before any tool executes, preserving the official complete-and-unmodified requirement.
- The terminal message now states that the automatic retry already ran and recommends a fresh attempt.

## Related work

- Refs #8927 by @oll4com. That PR explores serializing an empty Anthropic thinking block. I reviewed that approach but did not adopt it here: strict Anthropic/Responses turns remain fail-closed, and this change first retries the exact provider request before any client tool execution.

## Verification

- deterministic red/green regression: GLM text must reach the event sink before the held SSE response completes
- deterministic wire regression: GLM tool history contains an explicit empty `reasoning_content`
- deterministic safety regression: overflowed GLM reasoning stops before tool execution or continuation
- `go test ./...`
- `go test -race -count=1 ./internal/agent ./internal/provider/openai ./internal/provider/anthropic`
- `(cd desktop && go test ./...)`
- `go vet ./...`
- `go run ./tools/repolint`
- `./scripts/cache-guard.sh` — all scenarios passed; tail averages remained 92%–96% against the 90% threshold
- `go test -tags=live ./internal/agent ./internal/provider/openai ./internal/provider/anthropic ./internal/provider/responses -run '^$' -count=1`

Earlier credential-gated live verification used disposable homes/workspaces and covered:

- OpenCode Go DeepSeek Flash: OpenAI tool replay, strict Anthropic tool/search replay, stateless Responses search replay, and 10 production Agent tool loops on each strict protocol
- DeepSeek official: Anthropic tool/search continuation, Responses search, interrupted save/load resume, transient missing-reasoning recovery, persistent omission fallback, and a 17-round tool loop
- LongCat: reasoning replay, five repeated Agent tool loops, deterministic error recovery, and a 17-round tool loop
- Zhipu Coding Plan: OpenAI tool replay, deterministic error recovery, a 17-round tool loop, and five clean Agent tool loops after the GLM policy correction

## Compatibility, cache, and security

- no persisted config, session, state, or Wails contract changed
- normal schemas, ordering, and stable prompt/tool prefixes are unchanged; GLM empty tool history gains only the deterministic documented field
- no dependency, privilege, sandbox, filesystem, or credential-handling changes
- live credentials were process-local, were not added to source/config/artifacts, and the final diff passed a secret and machine-local path scan

Cache-impact: low - GLM tool history with provider-omitted reasoning now adds a deterministic empty reasoning_content field; normal schemas and ordering stay unchanged, and malformed strict retries remain exact.
Cache-guard: `./scripts/cache-guard.sh` passed every scenario with 92%–96% tail averages against the 90% threshold.
Documentation-impact: none - This follows the existing official GLM Coding Plan protocol without adding Reasonix configuration or workflow.
