### PR TITLE
Fix composer timer across tab switches / 修复切换会话后运行计时归零

### DIFF
--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -124,7 +124,6 @@ globalThis.MouseEvent = dom.window.MouseEvent;
 globalThis.localStorage = dom.window.localStorage;
 globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
 globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
-
 const context: ContextInfo = { used: 12, window: 100, sessionTokens: 12 };
 const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
 const balance: BalanceInfo = { available: false, display: "" };
@@ -134,7 +133,7 @@ const tabA = tabMeta("tab-a", { active: true });
 const tabB = tabMeta("tab-b");
 const tabC = tabMeta("tab-c");
 const tabD = tabMeta("tab-d");
-const tabE = tabMeta("tab-e");
+const tabE = tabMeta("tab-e", { turnStartedAt: Date.now() - 45_000 });
 const tabF = tabMeta("tab-f");
 const tabG = tabMeta("tab-g");
 const tabH = tabMeta("tab-h");
@@ -515,6 +514,7 @@ await act(async () => {
 });
 eq(controller?.activeTabId, "tab-e", "switching to a backend-running tab updates the active tab immediately");
 eq(controller?.state.running, true, "backend-running tab restores the stop state before backend activation settles");
+eq(controller?.state.turnStartAt, tabE.turnStartedAt, "backend-running tab restores the original turn timer before activation settles");
 eq(controller?.state.cancellable, true, "backend-running tab remains cancellable before backend activation settles");
 await act(async () => {
   controller?.cancel();

--- a/desktop/frontend/src/__tests__/turn-timing-race.test.ts
+++ b/desktop/frontend/src/__tests__/turn-timing-race.test.ts
@@ -1,0 +1,88 @@
+// Run: tsx src/__tests__/turn-timing-race.test.ts
+
+import { initialState, promptEventClock, reducer } from "../lib/useController";
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+process.stdout.write("turn timing snapshot ordering\n");
+
+const originalNow = Date.now;
+let now = 2_000;
+Date.now = () => now;
+try {
+  let state = reducer(initialState, {
+    type: "event",
+    e: { kind: "turn_started", submissionId: "turn-a", turnStartedAt: 2_000 },
+  });
+  const staleSnapshotAt = promptEventClock();
+  state = reducer(state, { type: "event", e: { kind: "turn_done", submissionId: "turn-a" } });
+
+  const staleAfterDone = reducer(state, {
+    type: "backend_status",
+    running: true,
+    cancellable: true,
+    turnStartedAt: 2_000,
+    snapshotAt: staleSnapshotAt,
+  });
+  eq(staleAfterDone.running, false, "a stale running snapshot cannot resurrect a completed turn");
+
+  now = 4_000;
+  state = reducer(state, {
+    type: "event",
+    e: { kind: "turn_started", submissionId: "turn-b", turnStartedAt: 4_000 },
+  });
+
+  const staleRunning = reducer(state, {
+    type: "backend_status",
+    running: true,
+    cancellable: true,
+    turnStartedAt: 2_000,
+    snapshotAt: staleSnapshotAt,
+  });
+  eq(staleRunning.turnStartAt, 4_000, "a stale running snapshot cannot rewind a newer turn clock");
+
+  const unorderedRunning = reducer(state, {
+    type: "backend_status",
+    running: true,
+    cancellable: true,
+    turnStartedAt: 2_000,
+  });
+  eq(unorderedRunning.turnStartAt, 4_000, "an unordered status keeps a surviving newer local clock");
+
+  const staleIdle = reducer(state, {
+    type: "backend_status",
+    running: false,
+    cancellable: false,
+    snapshotAt: staleSnapshotAt,
+  });
+  eq(staleIdle.running, true, "a stale idle snapshot cannot stop a newer live turn");
+
+  now = 5_000;
+  const correctedFallback = reducer({ ...state, turnStartAt: 3_900 }, {
+    type: "backend_status",
+    running: true,
+    cancellable: true,
+    turnStartedAt: 4_000,
+  });
+  eq(correctedFallback.turnStartAt, 4_000, "a newer backend start still corrects an earlier local fallback");
+} finally {
+  Date.now = originalNow;
+}
+
+if (failed > 0) {
+  process.stderr.write(`\n${failed} check(s) failed\n`);
+  process.exitCode = 1;
+} else {
+  process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
+}

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -492,6 +492,38 @@ eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "pl
   let now = 1_000;
   Date.now = () => now;
   try {
+    let s = reducer(initialState, { type: "user", text: "keep timing", seq: 0, submissionId: "timing-submit" });
+    now = 8_000;
+    s = reducer(s, {
+      type: "event",
+      e: { kind: "turn_started", submissionId: "timing-submit", turnStartedAt: 1_200 },
+    });
+    eq(s.turnStartAt, 1_200, "a delayed turn_started event keeps the backend turn start instead of restarting the timer");
+
+    now = 12_000;
+    s = reducer(initialState, {
+      type: "backend_status",
+      running: true,
+      cancellable: true,
+      turnStartedAt: 1_200,
+    });
+    eq(s.turnStartAt, 1_200, "a rehydrated running tab restores the backend turn start instead of restarting the timer");
+
+    now = 13_000;
+    s = reducer(s, { type: "event", e: { kind: "turn_done" } });
+    now = 20_000;
+    s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+    eq(s.turnStartAt, 20_000, "a legacy turn_started event begins a new remote turn instead of reusing completed-turn timing");
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+{
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
     let s = reducer(initialState, { type: "event", e: { kind: "turn_started" } });
     now = 1_200;
     s = reducer(s, { type: "event", e: { kind: "reasoning", reasoning: "plan" } });

--- a/desktop/frontend/src/lib/runtimeMeta.ts
+++ b/desktop/frontend/src/lib/runtimeMeta.ts
@@ -1,0 +1,14 @@
+export type RuntimeMetaSnapshot = {
+  running: boolean;
+  turnStartedAt?: number;
+  pendingPrompt?: boolean;
+  backgroundJobs?: number;
+  cancelRequested?: boolean;
+  cancellable?: boolean;
+};
+
+export function foregroundRunningFromRuntimeMeta(meta: RuntimeMetaSnapshot): boolean {
+  if (typeof meta.cancellable === "boolean") return meta.cancellable;
+  if ((meta.backgroundJobs ?? 0) > 0 && !meta.pendingPrompt) return false;
+  return Boolean(meta.running);
+}

--- a/desktop/frontend/src/lib/turnTiming.ts
+++ b/desktop/frontend/src/lib/turnTiming.ts
@@ -1,0 +1,5 @@
+export function resolveTurnStartedAt(current: number, reported: number | undefined, now = Date.now()): number {
+  if (typeof reported === "number" && Number.isFinite(reported) && reported > 0 && reported <= now) return reported;
+  if (Number.isFinite(current) && current > 0 && current <= now) return current;
+  return now;
+}

--- a/desktop/frontend/src/lib/turnTiming.ts
+++ b/desktop/frontend/src/lib/turnTiming.ts
@@ -3,3 +3,16 @@ export function resolveTurnStartedAt(current: number, reported: number | undefin
   if (Number.isFinite(current) && current > 0 && current <= now) return current;
   return now;
 }
+
+// Snapshots may complete out of order, so a live clock can advance but never rewind.
+export function resolveSnapshotTurnStartedAt(current: number, reported: number | undefined, now = Date.now()): number {
+  const resolved = resolveTurnStartedAt(current, reported, now);
+  if (!Number.isFinite(current) || current <= 0 || current > now) return resolved;
+  return Math.max(current, resolved);
+}
+
+// Both values come from the same monotonic clock; ties are conservatively stale.
+export function snapshotPredatesTurnLifecycle(observedAt: number | undefined, snapshotAt: number | undefined): boolean {
+  if (snapshotAt === undefined || observedAt === undefined) return false;
+  return snapshotAt <= observedAt;
+}

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -352,6 +352,8 @@ export interface WireEvent {
   completion?: WireCompletionSummary;
   tabId?: string; // Go's tabEventSink tags events for the correct per-tab reducer.
   runtimeEpoch?: string;
+  /** Unix milliseconds recorded by the desktop host when this turn began. */
+  turnStartedAt?: number;
   sessionHitTokens?: number;
   sessionMissTokens?: number;
   sessionCost?: number;
@@ -442,6 +444,8 @@ export interface TabMeta {
   ready: boolean;
   runtime?: SessionRuntimeView;
   running: boolean;
+  /** Unix milliseconds for the currently active foreground turn. */
+  turnStartedAt?: number;
   pendingPrompt?: boolean;
   backgroundJobs?: number;
   cancelRequested?: boolean;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -13,6 +13,7 @@ import { completionSummaryNeedsAttention, completionSummaryNotice, normalizeComp
 import { invalidateSharedQuery } from "./queryCoalesce";
 import { replayPendingPromptsForActiveTab } from "./promptReplay";
 import { createRafBatch } from "./rafBatch";
+import { foregroundRunningFromRuntimeMeta, type RuntimeMetaSnapshot } from "./runtimeMeta";
 import { aliasActivationRequest, noteActivationRequested, noteActivationSettled, noteActivationStarted } from "./sessionDiagnostics";
 import { applyLiveSegments, coalesceStreamDeltas, completeLiveReasoning, type StreamDeltaEntry, type StreamSegment } from "./streamDeltaBatch";
 import { getTranscriptStore } from "./transcriptStore";
@@ -23,6 +24,7 @@ import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
+import { resolveTurnStartedAt } from "./turnTiming";
 import { useStaleTurnWatchdog } from "./useStaleTurnWatchdog";
 import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
@@ -62,6 +64,7 @@ import type {
   WireUsage,
   WireShellExecution,
 } from "./types";
+export { foregroundRunningFromRuntimeMeta } from "./runtimeMeta";
 export type ToolStatus = "running" | "done" | "error" | "stopped";
 // Reserved ToolProgress channel names for sub-agent progress previews (the Go
 // tracker emits these; ordinary tool progress must never use them).
@@ -522,18 +525,6 @@ function usageTotalTokens(usage?: WireUsage): number {
   const promptTokens = usage.promptTokens || usage.cacheHitTokens + usage.cacheMissTokens;
   return Math.max(0, promptTokens + usage.completionTokens);
 }
-type RuntimeMetaSnapshot = {
-  running: boolean;
-  pendingPrompt?: boolean;
-  backgroundJobs?: number;
-  cancelRequested?: boolean;
-  cancellable?: boolean;
-};
-export function foregroundRunningFromRuntimeMeta(meta: RuntimeMetaSnapshot): boolean {
-  if (typeof meta.cancellable === "boolean") return meta.cancellable;
-  if ((meta.backgroundJobs ?? 0) > 0 && !meta.pendingPrompt) return false;
-  return Boolean(meta.running);
-}
 // Clock used to order live prompt events against runtime snapshot fetches.
 // Monotonic (immune to wall-clock jumps) with sub-millisecond resolution, so
 // an event and a snapshot initiated in the same millisecond still order
@@ -782,7 +773,7 @@ type Action =
   | { type: "unsend" }
   | { type: "send_confirmed"; submissionId: string }
   | { type: "send_failed"; submissionId: string; error: string }
-  | { type: "backend_status"; running: boolean; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; snapshotAt?: number }
+  | { type: "backend_status"; running: boolean; turnStartedAt?: number; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; snapshotAt?: number }
   | { type: "cancel_requested" }
   | { type: "meta"; meta: Meta }
   | { type: "optimistic_meta"; meta: Meta }
@@ -824,6 +815,7 @@ function backendStatusFromRuntimeMeta(meta: RuntimeMetaSnapshot): Extract<Action
   return {
     type: "backend_status",
     running: foregroundRunning,
+    turnStartedAt: meta.turnStartedAt,
     pendingPrompt: Boolean(meta.pendingPrompt),
     backgroundJobs: meta.backgroundJobs ?? 0,
     cancelRequested: Boolean(meta.cancelRequested),
@@ -1455,7 +1447,7 @@ function applyEvent(s: State, e: WireEvent): State {
         pendingPrompt: false,
         cancelRequested: false,
         cancellable: true,
-        ...resetTurnTiming(),
+        ...resetTurnTiming(resolveTurnStartedAt(fresh.running || fresh.turnActive ? fresh.turnStartAt : 0, e.turnStartedAt)),
       };
     }
     case "turn_phase": {
@@ -1956,6 +1948,7 @@ export function reducer(s: State, a: Action): State {
       const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
       const cancelRequested = Boolean(a.cancelRequested);
       const foregroundRunning = foregroundRunningFromRuntimeMeta({ running: a.running, pendingPrompt, backgroundJobs, cancellable: a.cancellable });
+      const turnStartedAt = foregroundRunning ? resolveTurnStartedAt(s.running || s.turnActive ? s.turnStartAt : 0, a.turnStartedAt) : s.turnStartAt;
       // A retry event is newer evidence of foreground activity than an idle
       // snapshot whose fetch started earlier. Keep the turn cancellable until
       // a snapshot started after the retry confirms that it is actually idle.
@@ -1968,6 +1961,7 @@ export function reducer(s: State, a: Action): State {
         backgroundJobs === s.backgroundJobs &&
         cancelRequested === s.cancelRequested &&
         cancellable === s.cancellable &&
+        turnStartedAt === s.turnStartAt &&
         !clearsRetry
       ) return s;
       if (foregroundRunning) {
@@ -1979,7 +1973,7 @@ export function reducer(s: State, a: Action): State {
           backgroundJobs,
           cancelRequested,
           cancellable,
-          turnStartAt: s.turnStartAt || Date.now(),
+          turnStartAt: turnStartedAt,
         };
       }
       const telemetry = snapshotCompletedTurnTelemetry(s);
@@ -3209,6 +3203,7 @@ export function useController() {
     dispatchTo(tabId, {
       type: "backend_status",
       running: foregroundRunning,
+      turnStartedAt: tab.turnStartedAt,
       pendingPrompt: Boolean(tab.pendingPrompt),
       backgroundJobs: tab.backgroundJobs ?? 0,
       cancelRequested: Boolean(tab.cancelRequested),

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -24,7 +24,7 @@ import { isHostRecoveryGuidance } from "./hostRecoverySteer";
 import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
-import { resolveTurnStartedAt } from "./turnTiming";
+import { resolveSnapshotTurnStartedAt, resolveTurnStartedAt, snapshotPredatesTurnLifecycle } from "./turnTiming";
 import { useStaleTurnWatchdog } from "./useStaleTurnWatchdog";
 import type { SearchSource } from "./searchSources";
 import { attachWebSearchOutput, historySearchAndAnswer } from "./searchTranscript";
@@ -377,6 +377,7 @@ interface State {
   discardTurn?: boolean;
   turnStartAt: number;
   turnDoneAt: number;
+  turnLifecycleObservedAt?: number;
   // Completion tokens accumulated across executor usage events within the
   // current turn. ReasoningTokens is a subset of CompletionTokens.
   turnOutputTokens: number;
@@ -1384,6 +1385,7 @@ function applyEvent(s: State, e: WireEvent): State {
         pendingPrompt: false,
         cancelRequested: false,
         cancellable: false,
+        turnLifecycleObservedAt: promptEventClock(),
         currentAssistant: undefined,
         live: undefined,
       };
@@ -1402,13 +1404,8 @@ function applyEvent(s: State, e: WireEvent): State {
     return applyExtensionSurfaceEvent(s, e.extension);
   }
   if (e.kind === "retrying") {
-    // Retrying is emitted synchronously from inside the foreground provider
-    // request, immediately before its cancellation-aware backoff. Treat it as
-    // authoritative proof that the turn is still active. An idle ListTabs
-    // snapshot fetched before this event can otherwise clear `running`,
-    // regardless of which one reaches the reducer first, and leave the
-    // composer showing "retrying (n/m)" without its Stop button (or Escape
-    // cancellation) until all retries are exhausted.
+    // Retrying is synchronous proof that the foreground turn is active. Keep
+    // older idle ListTabs completions from hiding Stop/Escape during backoff.
     return {
       ...s,
       retry: {
@@ -1447,6 +1444,7 @@ function applyEvent(s: State, e: WireEvent): State {
         pendingPrompt: false,
         cancelRequested: false,
         cancellable: true,
+        turnLifecycleObservedAt: promptEventClock(),
         ...resetTurnTiming(resolveTurnStartedAt(fresh.running || fresh.turnActive ? fresh.turnStartAt : 0, e.turnStartedAt)),
       };
     }
@@ -1866,6 +1864,7 @@ function applyEvent(s: State, e: WireEvent): State {
         approval: keepPlanApproval ? s.approval : undefined,
         ask: undefined,
         deliveryRecoveryActive: false,
+        turnLifecycleObservedAt: promptEventClock(),
         seq: s.seq + 1,
       };
       // Close user-wait unless the plan approval gate remains open.
@@ -1890,6 +1889,7 @@ export function reducer(s: State, a: Action): State {
         cancelRequested: false,
         cancellable: true,
         ...resetTurnTiming(),
+        turnLifecycleObservedAt: promptEventClock(),
         // New turn epoch: forget the previous prompt anchor so a genuinely new
         // prompt re-anchors freshly instead of inheriting a stale id/time.
         promptArrivedAt: undefined,
@@ -1915,6 +1915,7 @@ export function reducer(s: State, a: Action): State {
         promptArrivedAt: undefined,
         promptArrivedId: undefined,
         live: undefined,
+        turnLifecycleObservedAt: promptEventClock(),
       });
       return cleared;
     }
@@ -1936,19 +1937,16 @@ export function reducer(s: State, a: Action): State {
       const idx = s.items.findIndex((it) => it.kind === "user" && it.submissionId === a.submissionId);
       const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, submissionId: undefined, failed: true } : it)) : s.items;
       const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
-      return { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
+      return { ...s, pendingUser: undefined, pendingSubmissionId: undefined, deliveryRecoveryActive: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, live: undefined, turnLifecycleObservedAt: promptEventClock(), seq: s.seq + 1, items: [...items, notice] };
     }
     case "backend_status": {
-      // A snapshot fetched before the live approval/ask event arrived cannot
-      // know about the prompt; everything it reports about the turn lifecycle
-      // is equally stale. Ignore it and let an explicit answer/cancel or a
-      // fresher snapshot settle the state (#6429).
-      if (runtimeSnapshotPredatesPrompt(s, a.snapshotAt)) return s;
+      // Reject snapshots that began before newer prompt or turn lifecycle evidence.
+      if (runtimeSnapshotPredatesPrompt(s, a.snapshotAt) || snapshotPredatesTurnLifecycle(s.turnLifecycleObservedAt, a.snapshotAt)) return s;
       const pendingPrompt = Boolean(a.pendingPrompt);
       const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
       const cancelRequested = Boolean(a.cancelRequested);
       const foregroundRunning = foregroundRunningFromRuntimeMeta({ running: a.running, pendingPrompt, backgroundJobs, cancellable: a.cancellable });
-      const turnStartedAt = foregroundRunning ? resolveTurnStartedAt(s.running || s.turnActive ? s.turnStartAt : 0, a.turnStartedAt) : s.turnStartAt;
+      const turnStartedAt = foregroundRunning ? resolveSnapshotTurnStartedAt(s.running || s.turnActive ? s.turnStartAt : 0, a.turnStartedAt) : s.turnStartAt;
       // A retry event is newer evidence of foreground activity than an idle
       // snapshot whose fetch started earlier. Keep the turn cancellable until
       // a snapshot started after the retry confirms that it is actually idle.

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -945,14 +945,6 @@ func (t *WorkspaceTab) recordReadFile(rec readFileRecord) {
 	t.telemMu.Unlock()
 }
 
-func (t *WorkspaceTab) recordTurnStarted(now int64) {
-	t.telemMu.Lock()
-	if t.usageTelemetry.activeTurnStartedAt == 0 {
-		t.usageTelemetry.activeTurnStartedAt = now
-	}
-	t.telemMu.Unlock()
-}
-
 func (t *WorkspaceTab) recordTurnDone(now int64) {
 	t.telemMu.Lock()
 	if started := t.usageTelemetry.activeTurnStartedAt; started > 0 && now >= started {
@@ -1541,6 +1533,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 		s.mu.Unlock()
 	}
 	tabID, app := s.binding()
+	var turnStartedAt int64
 	if app != nil {
 		if e.Kind == event.TurnDone {
 			// Keep the legacy completion as a cheap missed-event safety net. The
@@ -1550,7 +1543,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 		switch e.Kind {
 		case event.TurnStarted:
 			s.resetDisplayTurn()
-			s.recordTurnStarted()
+			turnStartedAt = s.recordTurnStarted()
 		case event.Usage:
 			s.recordUsageTelemetry(e)
 		case event.TurnDone:
@@ -1570,7 +1563,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			s.flushDisplay(e.Cancelled)
 		}
 	}
-	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot()))
+	s.emitRuntimeEvent(eventChannel, toWireTabWithSubmission(e, tabID, s.runtimeEpochSnapshot(), s.submissionIDSnapshot(), turnStartedAt))
 	if app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update {
 			changed := app.setTabActivityStatus(tabID, status)
@@ -1957,18 +1950,19 @@ func (s *tabEventSink) recordReadTelemetry(e event.Event) {
 	}
 }
 
-func (s *tabEventSink) recordTurnStarted() {
+func (s *tabEventSink) recordTurnStarted() int64 {
 	tab, sp := s.telemetryTab()
 	if tab == nil {
-		return
+		return 0
 	}
 	if sp != "" {
 		tab.syncTelemetryToSession(sp)
 	}
-	tab.recordTurnStarted(time.Now().UnixMilli())
+	startedAt := tab.recordTurnStarted(time.Now().UnixMilli())
 	if sp != "" {
 		_ = saveTelemetry(sp+".telemetry.json", tab.telemetrySnapshot())
 	}
+	return startedAt
 }
 
 func (s *tabEventSink) recordTurnDone() {
@@ -2130,8 +2124,9 @@ func toWireTab(e event.Event, tabID string, runtimeEpoch ...string) wireEventTab
 // uses tabId to dispatch to the correct per-tab state.
 type wireEventTab struct {
 	eventwire.Event
-	TabID        string `json:"tabId"`
-	RuntimeEpoch string `json:"runtimeEpoch,omitempty"`
+	TabID         string `json:"tabId"`
+	RuntimeEpoch  string `json:"runtimeEpoch,omitempty"`
+	TurnStartedAt int64  `json:"turnStartedAt,omitempty"`
 	// Session-cumulative tokens per tab.
 	SessionHitTokens  int `json:"sessionHitTokens,omitempty"`
 	SessionMissTokens int `json:"sessionMissTokens,omitempty"`
@@ -2166,6 +2161,7 @@ type TabMeta struct {
 	Ready             bool               `json:"ready"`
 	Runtime           SessionRuntimeView `json:"runtime"`
 	Running           bool               `json:"running"`
+	TurnStartedAt     int64              `json:"turnStartedAt,omitempty"`
 	PendingPrompt     bool               `json:"pendingPrompt,omitempty"`
 	RemoteControlled  bool               `json:"remoteControlled,omitempty"`
 	BackgroundJobs    int                `json:"backgroundJobs,omitempty"`
@@ -2228,6 +2224,7 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		Label:             tab.Label,
 		Ready:             runtimeView.Phase == sessionRuntimeReady && tab.Ctrl != nil,
 		Runtime:           runtimeView,
+		TurnStartedAt:     tab.turnStartedAt(),
 		Mode:              currentTabMode(tab),
 		CollaborationMode: currentTabCollaborationMode(tab),
 		ToolApprovalMode:  currentTabToolApprovalMode(tab),

--- a/desktop/tabs_telemetry_test.go
+++ b/desktop/tabs_telemetry_test.go
@@ -100,6 +100,17 @@ func TestWorkspaceTabAggregatesSessionUsageTelemetry(t *testing.T) {
 	}
 }
 
+func TestTabMetaReportsActiveTurnStartedAt(t *testing.T) {
+	const startedAt = int64(1_723_456_789_000)
+	tab := &WorkspaceTab{ID: "tab", WorkspaceRoot: t.TempDir()}
+	tab.recordTurnStarted(startedAt)
+	app := &App{tabs: map[string]*WorkspaceTab{"tab": tab}}
+
+	if got := app.tabMeta(tab, true).TurnStartedAt; got != startedAt {
+		t.Fatalf("turn started at = %d, want %d", got, startedAt)
+	}
+}
+
 func TestWorkspaceTabMarksEstimatedExecutorTurn(t *testing.T) {
 	tab := &WorkspaceTab{}
 	tab.recordUsage(event.Event{

--- a/desktop/turn_submission_app.go
+++ b/desktop/turn_submission_app.go
@@ -7,6 +7,24 @@ type turnSubmissionState struct {
 	submissionID string
 }
 
+func (t *WorkspaceTab) recordTurnStarted(now int64) int64 {
+	t.telemMu.Lock()
+	defer t.telemMu.Unlock()
+	if t.usageTelemetry.activeTurnStartedAt == 0 {
+		t.usageTelemetry.activeTurnStartedAt = now
+	}
+	return t.usageTelemetry.activeTurnStartedAt
+}
+
+func (t *WorkspaceTab) turnStartedAt() int64 {
+	if t == nil {
+		return 0
+	}
+	t.telemMu.Lock()
+	defer t.telemMu.Unlock()
+	return t.usageTelemetry.activeTurnStartedAt
+}
+
 // setBinding reroutes the sink while invalidating correlations that were
 // created for a different frontend tab.
 func (s *tabEventSink) setBinding(tabID string, app *App) {
@@ -62,8 +80,11 @@ type correlatedWireEventTab struct {
 	SubmissionID string `json:"submissionId,omitempty"`
 }
 
-func toWireTabWithSubmission(e event.Event, tabID, runtimeEpoch, submissionID string) any {
+func toWireTabWithSubmission(e event.Event, tabID, runtimeEpoch, submissionID string, turnStartedAt int64) any {
 	wire := toWireTab(e, tabID, runtimeEpoch)
+	if e.Kind == event.TurnStarted {
+		wire.TurnStartedAt = turnStartedAt
+	}
 	if submissionID == "" {
 		return wire
 	}

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -24,13 +24,26 @@ func TestWireEventTabPreservesSharedRetryingFields(t *testing.T) {
 
 func TestWireEventTabPreservesTurnDoneCheckpointZero(t *testing.T) {
 	turn := 0
-	b, err := json.Marshal(toWireTabWithSubmission(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn}, "tab-1", "runtime-1", "submission-1"))
+	b, err := json.Marshal(toWireTabWithSubmission(event.Event{Kind: event.TurnDone, CheckpointTurn: &turn}, "tab-1", "runtime-1", "submission-1", 0))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	for _, want := range []string{`"kind":"turn_done"`, `"checkpointTurn":0`, `"tabId":"tab-1"`, `"runtimeEpoch":"runtime-1"`, `"submissionId":"submission-1"`} {
 		if !strings.Contains(string(b), want) {
 			t.Fatalf("tab TurnDone JSON = %s, want it to contain %s", b, want)
+		}
+	}
+}
+
+func TestWireEventTabCarriesAuthoritativeTurnStart(t *testing.T) {
+	const startedAt = int64(1_723_456_789_000)
+	b, err := json.Marshal(toWireTabWithSubmission(event.Event{Kind: event.TurnStarted}, "tab-1", "runtime-1", "submission-1", startedAt))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, want := range []string{`"kind":"turn_started"`, `"turnStartedAt":1723456789000`, `"tabId":"tab-1"`, `"submissionId":"submission-1"`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("tab TurnStarted JSON = %s, want it to contain %s", b, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve the desktop host's authoritative active-turn start timestamp in `turn_started` events and tab metadata.
- Reconcile that timestamp when a running tab is restored, so the composer timer continues instead of restarting at zero.
- Reject async runtime snapshots that began before a newer local turn lifecycle transition, preventing stale snapshots from rewinding, stopping, or resurrecting a turn.
- Keep legacy mixed-version behavior safe when the timestamp field is absent.

## Root cause

The frontend reconstructed turn timing from when it received a delayed event or tab snapshot. Switching away and back therefore replaced the original start time with a new `Date.now()` value. In addition, a `ListTabs` snapshot captured for an earlier turn could complete after a newer `turn_started` or `turn_done` event and overwrite the newer lifecycle state.

## Issue

Fixes #7987

## Related work and attribution

- Adapted the surviving-local-clock invariant from #8959 by @guomengjia618-dot.
- The adopted contribution is also credited with a commit-level `Co-authored-by` trailer. This PR retains the authoritative `turn_started` event timestamp and adds a general lifecycle freshness fence for ordered snapshots.

## Verification

- `cd desktop && go test ./...`
- `cd desktop && go test -race . -run 'TestTabMetaReportsActiveTurnStartedAt|TestWireEventTabCarriesAuthoritativeTurnStart|TestWorkspaceTabAggregatesSessionUsageTelemetry' -count=1`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/turn-timing-race.test.ts`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/use-controller-meta.test.ts`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/tab-switch-hydration.test.tsx`
- Focused prompt, cancel, stream, send-failure, and composer run-strip suites
- `cd desktop/frontend && pnpm typecheck && pnpm test:typecheck && pnpm lint:hooks && pnpm build`
- `go run ./tools/repolint`

The full frontend `pnpm test` command was also attempted on the initial PR head. Its pretest suites passed, then `activate-topic-stale.test.tsx` reported 17/17 passing assertions but kept an open process handle and did not advance; the run was stopped after seven minutes. The directly affected suites and the production build pass.

## Compatibility

- `turnStartedAt` is additive and optional (`omitempty`) on the Wails wire contract.
- Older frontends ignore it; newer frontends fall back to local timing when an older backend omits it.
- The frontend-only lifecycle observation is ephemeral and does not alter persisted data.
- No persisted data format or array wire shape changes.

## Impact review

Documentation-impact: none - this restores existing composer timer behavior without changing documented UI or configuration.

Cache-impact: none - prompt, provider, and cache serialization paths are untouched.

Cache-guard: not required - no cache-sensitive files changed.

System-prompt-review: not applicable - no system-prompt-sensitive files changed.