### PR TITLE
fix(desktop): keep the run-strip turn clock across tab switches / 切换标签页后计时器归零 (#7987)

### DIFF
--- a/desktop/frontend/src/__tests__/controller-turn-timing.test.ts
+++ b/desktop/frontend/src/__tests__/controller-turn-timing.test.ts
@@ -1,0 +1,114 @@
+// Run: tsx src/__tests__/controller-turn-timing.test.ts
+
+import { initialState, reducer, type State } from "../lib/useController";
+
+type ReducerState = ReturnType<typeof reducer>;
+
+let passed = 0;
+let failed = 0;
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  if (actual === expected) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}\n`);
+    failed += 1;
+  }
+}
+
+function ok(value: boolean, label: string) {
+  eq(value, true, label);
+}
+
+function runningTurn(overrides: Partial<State> = {}): ReducerState {
+  return {
+    ...initialState,
+    running: true,
+    turnActive: true,
+    turnStartAt: 1_000,
+    backendTurnStartedAtMs: 1_000,
+    ...overrides,
+  };
+}
+
+console.log("\nturn timing across tab switches (#7987)");
+
+{
+  // Full switch-back sequence: activation clears the local lifecycle flags,
+  // then the optimistic runtime status arrives carrying the backend's turn
+  // start. The elapsed clock must continue from the original start.
+  const before = Date.now();
+  let state = runningTurn({ turnStartAt: 1_000, backendTurnStartedAtMs: undefined });
+  state = reducer(state, { type: "backend_activation_start", backendTurnStartedAtMs: 1_000 });
+  eq(state.running, false, "activation_start clears the local running flag");
+  eq(state.backendTurnStartedAtMs, 1_000, "activation_start keeps the backend turn evidence");
+  state = reducer(state, { type: "backend_status", running: true, turnStartedAtMs: 1_000 });
+  eq(state.running, true, "backend_status restores the running flag");
+  eq(state.turnStartAt, 1_000, "switch-back restarts the clock from the original turn start");
+  ok(state.turnStartAt < before || state.turnStartAt <= Date.now(), "restart is not a fresh Date.now() clock");
+}
+
+{
+  // Deferred hydration reset the whole state mid-turn; the next snapshot must
+  // rebuild turnStartAt from the backend timestamp instead of "now".
+  let state = runningTurn();
+  state = reducer(state, { type: "reset" });
+  eq(state.turnStartAt, initialState.turnStartAt, "reset wipes the local turn clock");
+  state = reducer(state, { type: "backend_status", running: true, turnStartedAtMs: 1_700_000_000_000 - 45_000 });
+  eq(state.turnStartAt, 1_700_000_000_000 - 45_000, "rebuilt state ages the turn from backend telemetry");
+  eq(state.backendTurnStartedAtMs, 1_700_000_000_000 - 45_000, "backend evidence is stored alongside");
+}
+
+{
+  // A surviving local clock always wins over the backend timestamp so a
+  // slightly stale snapshot cannot rewind the timer.
+  const state = reducer(runningTurn({ turnStartAt: 2_000, backendTurnStartedAtMs: 2_000 }),
+    { type: "backend_status", running: true, turnStartedAtMs: 1_500 });
+  eq(state.turnStartAt, 2_000, "surviving local clock is preferred over backend timestamp");
+  eq(state.backendTurnStartedAtMs, 1_500, "backend evidence still tracks the fresher snapshot");
+}
+
+{
+  // No backend telemetry (older build / background tab): Date.now() fallback
+  // must keep working exactly as before.
+  const before = Date.now();
+  const state = reducer({ ...initialState }, { type: "backend_status", running: true });
+  ok(state.turnStartAt >= before, "missing backend timestamp falls back to Date.now()");
+}
+
+{
+  // Repeated identical snapshots stay no-ops (referential equality).
+  const first = reducer({ ...initialState }, { type: "backend_status", running: true, turnStartedAtMs: 5_000 });
+  const second = reducer(first, { type: "backend_status", running: true, turnStartedAtMs: 5_000 });
+  ok(second === first, "identical backend_status dispatch remains a no-op");
+}
+
+{
+  // Idle snapshots and turn_done both retire the backend evidence.
+  let state = runningTurn();
+  state = reducer(state, { type: "backend_status", running: false });
+  eq(state.running, false, "idle snapshot stops the turn");
+  eq(state.backendTurnStartedAtMs, undefined, "idle snapshot clears the backend turn evidence");
+
+  state = runningTurn();
+  state = reducer(state, { type: "event", e: { kind: "turn_done" } });
+  eq(state.running, false, "turn_done settles the turn");
+  eq(state.backendTurnStartedAtMs, undefined, "turn_done clears the backend turn evidence");
+}
+
+{
+  // turn_started is a local event, not backend confirmation: it must not
+  // install backend evidence. A lost turn_done would otherwise leave the
+  // evidence behind forever and the deferred-reset guard would never see idle.
+  const state = reducer({ ...initialState, backendTurnStartedAtMs: 123 }, { type: "event", e: { kind: "turn_started" } });
+  eq(state.running, true, "turn_started marks the turn running");
+  eq(state.backendTurnStartedAtMs, 123, "turn_started never installs backend turn evidence");
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} check(s) failed`);
+  process.exitCode = 1;
+} else {
+  console.log(`\n${passed} passed, ${failed} failed`);
+}

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -446,6 +446,8 @@ export interface TabMeta {
   backgroundJobs?: number;
   cancelRequested?: boolean;
   cancellable?: boolean;
+  /** Unix ms start of the turn currently running on this tab; absent when idle. */
+  turnStartedAtMs?: number;
   mode: Mode;
   collaborationMode?: CollaborationMode;
   toolApprovalMode?: ToolApprovalMode;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -374,6 +374,15 @@ interface State {
   discardTurn?: boolean;
   turnStartAt: number;
   turnDoneAt: number;
+  // Backend-reported start (Unix ms) of the turn this tab is currently running,
+  // straight from runtime telemetry. Serves two purposes: the authoritative
+  // fallback when local turnStartAt is rebuilt mid-turn (#7987), and proof that
+  // a turn is still in flight when activation_start has cleared the local
+  // running/turnActive flags. Only backend metadata (activation_start /
+  // backend_status) installs it — never a local turn_started event, so a lost
+  // turn_done cannot leave stale evidence behind. Cleared whenever the backend
+  // reports idle (backend_status running=false) or the turn settles (turn_done).
+  backendTurnStartedAtMs?: number;
   // Completion tokens accumulated across executor usage events within the
   // current turn. ReasoningTokens is a subset of CompletionTokens.
   turnOutputTokens: number;
@@ -528,6 +537,7 @@ type RuntimeMetaSnapshot = {
   backgroundJobs?: number;
   cancelRequested?: boolean;
   cancellable?: boolean;
+  turnStartedAtMs?: number;
 };
 export function foregroundRunningFromRuntimeMeta(meta: RuntimeMetaSnapshot): boolean {
   if (typeof meta.cancellable === "boolean") return meta.cancellable;
@@ -782,7 +792,7 @@ type Action =
   | { type: "unsend" }
   | { type: "send_confirmed"; submissionId: string }
   | { type: "send_failed"; submissionId: string; error: string }
-  | { type: "backend_status"; running: boolean; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; snapshotAt?: number }
+  | { type: "backend_status"; running: boolean; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean; snapshotAt?: number; turnStartedAtMs?: number }
   | { type: "cancel_requested" }
   | { type: "meta"; meta: Meta }
   | { type: "optimistic_meta"; meta: Meta }
@@ -794,7 +804,7 @@ type Action =
   | { type: "hydrate_start"; reason: HydrateReason; placeholderItems?: Item[] }
   | { type: "hydrate_done" }
   | { type: "hydrate_error"; reason: HydrateReason; error: string }
-  | { type: "backend_activation_start"; backendPendingPrompt?: boolean }
+  | { type: "backend_activation_start"; backendPendingPrompt?: boolean; backendTurnStartedAtMs?: number }
   | { type: "backend_activation_done" }
   | { type: "message_action_start"; action: MessageActionState }
   | { type: "message_action_done" }
@@ -828,6 +838,7 @@ function backendStatusFromRuntimeMeta(meta: RuntimeMetaSnapshot): Extract<Action
     backgroundJobs: meta.backgroundJobs ?? 0,
     cancelRequested: Boolean(meta.cancelRequested),
     cancellable: foregroundRunning,
+    turnStartedAtMs: meta.turnStartedAtMs,
   };
 }
 
@@ -1438,8 +1449,9 @@ function applyEvent(s: State, e: WireEvent): State {
     case "turn_started": {
       // Pre-create an empty assistant bubble
       // immediately so the user sees their message + a blinking cursor the
-      // instant the backend acknowledges the turn — no dead gap waiting for
-      // the first text/reasoning token.
+      // instant the backend acknowledges the turn — no dead gap waiting for the
+      // first text/reasoning token.
+      const now = Date.now();
       const fresh = { ...s, pendingSearchSources: undefined };
       const { items, id, seq } = ensureAssistant(fresh);
       return {
@@ -1455,7 +1467,7 @@ function applyEvent(s: State, e: WireEvent): State {
         pendingPrompt: false,
         cancelRequested: false,
         cancellable: true,
-        ...resetTurnTiming(),
+        ...resetTurnTiming(now),
       };
     }
     case "turn_phase": {
@@ -1874,6 +1886,7 @@ function applyEvent(s: State, e: WireEvent): State {
         approval: keepPlanApproval ? s.approval : undefined,
         ask: undefined,
         deliveryRecoveryActive: false,
+        backendTurnStartedAtMs: undefined,
         seq: s.seq + 1,
       };
       // Close user-wait unless the plan approval gate remains open.
@@ -1962,12 +1975,23 @@ export function reducer(s: State, a: Action): State {
       if (!foregroundRunning && runtimeSnapshotPredatesRetry(s, a.snapshotAt)) return s;
       const cancellable = foregroundRunning;
       const clearsRetry = !foregroundRunning && s.retry !== undefined;
+      // Authoritative turn clock (#7987): a surviving local reading first, then
+      // the backend's turn-start telemetry, and only then "now". Local state can
+      // be rebuilt mid-turn by tab-switch hydration, and restarting from
+      // Date.now() resets the run-strip timer to zero.
+      const turnStartAt = foregroundRunning ? (s.turnStartAt || a.turnStartedAtMs || Date.now()) : s.turnStartAt;
+      const backendTurnStartedAtMs = foregroundRunning ? (a.turnStartedAtMs ?? s.backendTurnStartedAtMs) : undefined;
+      // Keep the historical no-op semantics: a flags-identical snapshot stays a
+      // no-op unless it actually fills an empty clock with backend telemetry.
+      const fillsClock = foregroundRunning && s.turnStartAt === 0 && a.turnStartedAtMs !== undefined;
       if (
         foregroundRunning === s.running &&
         pendingPrompt === s.pendingPrompt &&
         backgroundJobs === s.backgroundJobs &&
         cancelRequested === s.cancelRequested &&
         cancellable === s.cancellable &&
+        !fillsClock &&
+        backendTurnStartedAtMs === s.backendTurnStartedAtMs &&
         !clearsRetry
       ) return s;
       if (foregroundRunning) {
@@ -1979,7 +2003,8 @@ export function reducer(s: State, a: Action): State {
           backgroundJobs,
           cancelRequested,
           cancellable,
-          turnStartAt: s.turnStartAt || Date.now(),
+          turnStartAt,
+          backendTurnStartedAtMs,
         };
       }
       const telemetry = snapshotCompletedTurnTelemetry(s);
@@ -2003,6 +2028,7 @@ export function reducer(s: State, a: Action): State {
         approval: undefined,
         ask: undefined,
         retry: undefined,
+        backendTurnStartedAtMs: undefined,
       });
     }
     case "meta": {
@@ -2062,6 +2088,10 @@ export function reducer(s: State, a: Action): State {
         running: preservePrompt,
         turnActive: preservePrompt,
         cancellable: preservePrompt,
+        // Remember the backend's turn evidence even though the local lifecycle
+        // flags are cleared above: deferred hydration must not treat this tab
+        // as idle (and reset its turn clock) while the runtime still runs (#7987).
+        backendTurnStartedAtMs: a.backendTurnStartedAtMs,
       };
     }
     case "backend_activation_done": return s.backendActivationPending ? { ...s, backendActivationPending: false } : s;
@@ -2933,7 +2963,12 @@ export function useController() {
       const stillVisible = () => !requiresVisibleTab || activeTabIdRef.current === tabId;
       const foregroundTurnActive = (): boolean => {
         const state = statesRef.current.get(tabId);
-        return Boolean(state?.running || state?.turnActive || state?.pendingPrompt);
+        if (state?.running || state?.turnActive || state?.pendingPrompt) return true;
+        // backend_activation_start clears the local lifecycle flags above, but
+        // the backend runtime telemetry still reports this turn as running.
+        // Trust that evidence over the just-cleared flags so deferred hydration
+        // cannot reset the tab (and its turn clock) mid-turn (#7987).
+        return Boolean(state?.backendTurnStartedAtMs);
       };
       const noteFailure = (label: string, err: unknown) => {
         addBreadcrumb("tab.hydrate", `${label} failed ${tabId}: ${errorMessage(err)}`);
@@ -3214,6 +3249,7 @@ export function useController() {
       cancelRequested: Boolean(tab.cancelRequested),
       cancellable: foregroundRunning,
       snapshotAt,
+      turnStartedAtMs: tab.turnStartedAtMs,
     });
     // backend_status reconciliation can clear a live prompt from frontend state.
     // If the backend is still blocked, ask it to replay the approval/ask event.
@@ -4446,7 +4482,7 @@ export function useController() {
     addBreadcrumb("tab.switch", `click ${tabId}`);
     setActiveTabId(tabId);
     activeTabIdRef.current = tabId;
-    dispatchTo(tabId, { type: "backend_activation_start", backendPendingPrompt: Boolean(optimisticTab?.pendingPrompt) });
+    dispatchTo(tabId, { type: "backend_activation_start", backendPendingPrompt: Boolean(optimisticTab?.pendingPrompt), backendTurnStartedAtMs: optimisticTab?.turnStartedAtMs });
     noteActivationStarted(switchRequestId, tabId);
     if (optimisticTab) {
       dispatchTo(tabId, { type: "optimistic_meta", meta: metaFromTab(optimisticTab, statesRef.current.get(tabId)?.meta) });

--- a/desktop/tab_meta_turn_timing_test.go
+++ b/desktop/tab_meta_turn_timing_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTabMetaExposesActiveTurnStart(t *testing.T) {
+	app := historySliceTestApp(t)
+	dir := t.TempDir()
+	sess, path := saveHistorySliceSession(t, dir, "turn.jsonl", nil)
+	tab := newLiveHistoryTab(t, app, dir, path, sess)
+
+	if meta := app.tabMeta(tab, true); meta.TurnStartedAtMs != 0 {
+		t.Fatalf("idle tab turnStartedAtMs = %d, want 0", meta.TurnStartedAtMs)
+	}
+
+	start := int64(1_700_000_000_000)
+	tab.recordTurnStarted(start)
+	if got := tab.activeTurnStartedAtMs(); got != start {
+		t.Fatalf("activeTurnStartedAtMs = %d, want %d", got, start)
+	}
+	if meta := app.tabMeta(tab, true); meta.TurnStartedAtMs != start {
+		t.Fatalf("running tab turnStartedAtMs = %d, want %d", meta.TurnStartedAtMs, start)
+	}
+
+	// TurnStarted fires once per turn; a repeated event must not move the start.
+	tab.recordTurnStarted(start + 5_000)
+	if meta := app.tabMeta(tab, true); meta.TurnStartedAtMs != start {
+		t.Fatalf("repeated TurnStarted moved turnStartedAtMs to %d, want %d", meta.TurnStartedAtMs, start)
+	}
+
+	tab.recordTurnDone(start + 60_000)
+	if meta := app.tabMeta(tab, true); meta.TurnStartedAtMs != 0 {
+		t.Fatalf("settled tab turnStartedAtMs = %d, want 0", meta.TurnStartedAtMs)
+	}
+}
+
+func TestTabMetaTurnStartJSONOmitempty(t *testing.T) {
+	idle, err := json.Marshal(TabMeta{})
+	if err != nil {
+		t.Fatalf("marshal idle TabMeta: %v", err)
+	}
+	if strings.Contains(string(idle), "turnStartedAtMs") {
+		t.Fatalf("idle TabMeta marshals turnStartedAtMs: %s", idle)
+	}
+	running, err := json.Marshal(TabMeta{TurnStartedAtMs: 1_700_000_000_000})
+	if err != nil {
+		t.Fatalf("marshal running TabMeta: %v", err)
+	}
+	if !strings.Contains(string(running), `"turnStartedAtMs":1700000000000`) {
+		t.Fatalf("running TabMeta drops turnStartedAtMs: %s", running)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -953,6 +953,14 @@ func (t *WorkspaceTab) recordTurnStarted(now int64) {
 	t.telemMu.Unlock()
 }
 
+// activeTurnStartedAtMs reports the wall-clock start (Unix ms) of the turn
+// currently in flight, or 0 when idle.
+func (t *WorkspaceTab) activeTurnStartedAtMs() int64 {
+	t.telemMu.Lock()
+	defer t.telemMu.Unlock()
+	return t.usageTelemetry.activeTurnStartedAt
+}
+
 func (t *WorkspaceTab) recordTurnDone(now int64) {
 	t.telemMu.Lock()
 	if started := t.usageTelemetry.activeTurnStartedAt; started > 0 && now >= started {
@@ -2171,20 +2179,25 @@ type TabMeta struct {
 	BackgroundJobs    int                `json:"backgroundJobs,omitempty"`
 	CancelRequested   bool               `json:"cancelRequested,omitempty"`
 	Cancellable       bool               `json:"cancellable"`
-	Mode              string             `json:"mode"`
-	CollaborationMode string             `json:"collaborationMode"`
-	ToolApprovalMode  string             `json:"toolApprovalMode"`
-	TokenMode         string             `json:"tokenMode"`
-	AgentPreset       string             `json:"agentPreset,omitempty"`
-	Goal              string             `json:"goal,omitempty"`
-	GoalStatus        string             `json:"goalStatus,omitempty"`
-	Recovered         bool               `json:"recovered,omitempty"`
-	RecoveryReason    string             `json:"recoveryReason,omitempty"`
-	RecoveryDigest    string             `json:"recoveryDigest,omitempty"`
-	RecoveryParentID  string             `json:"recoveryParentId,omitempty"`
-	StartupErr        string             `json:"startupErr,omitempty"`
-	Active            bool               `json:"active"`
-	Cwd               string             `json:"cwd"`
+	// TurnStartedAtMs is the wall-clock start (Unix ms) of the turn currently
+	// running on this tab, or 0 when idle. It is the authoritative source for
+	// the frontend run-strip elapsed timer so a tab switch that rebuilds local
+	// state cannot restart the clock mid-turn (#7987).
+	TurnStartedAtMs   int64  `json:"turnStartedAtMs,omitempty"`
+	Mode              string `json:"mode"`
+	CollaborationMode string `json:"collaborationMode"`
+	ToolApprovalMode  string `json:"toolApprovalMode"`
+	TokenMode         string `json:"tokenMode"`
+	AgentPreset       string `json:"agentPreset,omitempty"`
+	Goal              string `json:"goal,omitempty"`
+	GoalStatus        string `json:"goalStatus,omitempty"`
+	Recovered         bool   `json:"recovered,omitempty"`
+	RecoveryReason    string `json:"recoveryReason,omitempty"`
+	RecoveryDigest    string `json:"recoveryDigest,omitempty"`
+	RecoveryParentID  string `json:"recoveryParentId,omitempty"`
+	StartupErr        string `json:"startupErr,omitempty"`
+	Active            bool   `json:"active"`
+	Cwd               string `json:"cwd"`
 }
 
 func enrichTabMeta(meta TabMeta) TabMeta {
@@ -2254,6 +2267,7 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		m.BackgroundJobs = status.BackgroundJobs
 		m.CancelRequested = status.CancelRequested
 		m.Cancellable = status.Cancellable
+		m.TurnStartedAtMs = tab.activeTurnStartedAtMs()
 	}
 	if a.botBridge != nil {
 		m.RemoteControlled = a.botBridge.remoteControlledTabs()[tab.ID]


### PR DESCRIPTION
## Problem

Run strip 的已耗时计时器完全由前端墙钟驱动（`turnStartAt`）。切换标签页时 `backend_activation_start` 会清除本地 `running`/`turnActive`，而 tab 切换的 deferred hydration 还可能整体 reset 状态；随后到达的 `backend_status` 以 `Date.now()` 重建 `turnStartAt`，于是同一个 turn 的计时从 0 重新累计（#7987）。

## Solution

后端 `usageTelemetry.activeTurnStartedAt`（由每个 `TurnStarted`/`TurnDone` 事件维护，tabs.go）早已精确跟踪 turn 起点，只是私有未序列化。本 PR 把它经 `TabMeta` 下发，前端计时改为三级回填：**本地存活值 → 后端权威时间戳 → Date.now() 兜底**；同时让 deferred hydration 的 reset 守卫在本地 flags 被清空后仍能参考后端"turn 仍在跑"的证据。

选择该方案的原因：让时间戳有单一权威来源，任何本地状态重建路径（reset / hydrate / 逐出）都能恢复正确计时；Go 侧只是暴露已有字段，不引入新状态机。

## Changes

- `desktop/tabs.go` — `TabMeta.TurnStartedAtMs`（`omitempty`，idle 时不出现在 wire 上）；`WorkspaceTab.activeTurnStartedAtMs()` 带锁 getter；`tabMeta()` 在 runtime 分支填充
- `desktop/frontend/src/lib/types.ts` — `TabMeta.turnStartedAtMs?: number`
- `desktop/frontend/src/lib/useController.ts` —
  - `backend_status` action 携带并消费 `turnStartedAtMs`（三级回填）
  - `backend_activation_start` 记录 `backendTurnStartedAtMs` 证据；deferred hydration 的 `foregroundTurnActive` 守卫叠加该证据
  - 证据在 idle 快照 / `turn_done` 时清除，**绝不**由本地 `turn_started` 事件安装
- 测试：`desktop/tab_meta_turn_timing_test.go`（Go）；`src/__tests__/controller-turn-timing.test.ts`（18 项 reducer 级回归）

## Testing

- `go test ./desktop/` 全量通过；`gofmt` / `go vet` 干净
- 前端 `tsc --noEmit` + eslint 通过；13 个 controller/composer 相关测试套件（约 610 断言）全部通过，含 `composer-run-strip`、`pending-prompt-stale-status`、`activate-topic-stale`
- 新增回归用例覆盖：完整切回序列（activation 清 flags → status 以原始起点恢复）、reset 后重建、本地值优先（防时钟回跳）、无后端时间戳时保持 Date.now() 兜底（旧行为兼容）、重复快照 no-op（引用相等）、证据清除时机、"证据不来自本地事件"不变量
- 已 rebase 到 main-v2@56ea9c1：上游 17 个新提交中有 3 个文件与本 PR 重叠，合并零冲突，全部测试在合并树上复跑通过
- 手动场景（Windows 11 桌面版）：A 跑长任务 → 切 B 停 30s → 切回 A，elapsed 连续累计；任务在切走期间结束时，切回后正确显示已结束态

## Notes for Reviewer

- **no-op 语义保持**：`backend_status` 的 early-return 仅在 `fillsClock`（后端时间戳到场且本地时钟为空）时打破——flags 相同的重复快照仍返回原对象。多一次状态变迁会在挂载态的 controller 里触发自续 reconcile 循环，本地实测会让 `activate-topic-stale` 用例挂起，故刻意保留历史语义。
- **证据方向性**：`backendTurnStartedAtMs` 只能来自后端 meta。曾实现为由 `turn_started` 事件一并 seed，但 turn_done 丢失时证据会永久残留、deferred reset 永不触发，已回退并由测试锁定该不变量。
- 顺带观察（与本 PR 无关，未改动）：`pending-prompt-stale-status.test.tsx` 的 "#6432 backstop" 用例在纯 main-v2 上约 3/5 概率失败——150ms 的 `STALE_PROMPT_RECONCILE_MS` 真实定时器与异步断言竞速，机器负载高时必现，或许值得单独跟进。

Fixes #7987

## Documentation impact

Documentation-impact: none - this fixes run timer continuity across tab switches without changing the documented UI, configuration, or user workflow.
