### PR TITLE
feat(desktop): commit completed GFM table rows immediately while streaming (#8972)

### DIFF
--- a/desktop/frontend/src/__tests__/ui-perf-scenarios.test.ts
+++ b/desktop/frontend/src/__tests__/ui-perf-scenarios.test.ts
@@ -193,5 +193,57 @@ const scenario = (id: string): UIPerfScenario => {
   eq(r.reasoningMarkdownParses, 0, "06: background reasoning performs no Markdown parsing");
 }
 
+// --- UI-PERF-07: GFM table rows commit per terminated row (streaming parity) ---
+{
+  // Every terminated table row is a complete block: it commits immediately,
+  // no trailing blank line required.
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n",
+    "07: terminated table rows commit one by one",
+  );
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |\n",
+    "07: table with trailing newline commits fully",
+  );
+  eq(
+    streamingCommitTarget("| a | b |\n"),
+    "",
+    "07: header row alone waits for the delimiter row",
+  );
+  // A plain non-pipe line is swallowed into the table as a single-cell row by
+  // GFM: it rides the tail and keeps the table open, never closes it.
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\nplain"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n",
+    "07: plain line after rows is swallowed into the table (tail)",
+  );
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n\n# heading"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n\n",
+    "07: blank line closes the table and commits",
+  );
+  // Block starts close the table (GFM parity): a terminated heading commits
+  // itself; an unterminated list line rides the tail.
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n# heading\n"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n# heading\n",
+    "07: block start (heading) closes the table and commits itself",
+  );
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n- item"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n",
+    "07: block start (list) closes the table, list rides tail",
+  );
+  // An open fence after the table keeps the whole text parsed (live code
+  // highlighting), matching the pre-existing fence semantics.
+  eq(
+    streamingCommitTarget("| a | b |\n|---|---|\n| 1 | 2 |\n```\ncode"),
+    "| a | b |\n|---|---|\n| 1 | 2 |\n```\ncode",
+    "07: block start (fence) closes the table; open fence keeps whole text",
+  );
+}
+
 process.stdout.write(`\n${passed} passed, ${failed} failed\n`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -143,12 +143,19 @@ function isStreamingListItemLine(line: string): boolean {
   return STREAMING_LIST_ITEM_RE.test(line) && !STREAMING_THEMATIC_BREAK_RE.test(line);
 }
 
+// isTableSeparatorRow reports whether a line is a GFM table delimiter row
+// (|---|---| or --- | ---), the second row that turns two pipe lines into a table.
+function isTableSeparatorRow(line: string): boolean {
+  return /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/.test(line);
+}
+
 // Live parse prefix: last completed block. A later list marker commits prior
 // items only — the new item stays in the tail so indented continuations can join.
 export function streamingCommitTarget(text: string): string {
   let lineStart = 0;
   let fence: { marker: string; length: number } | null = null;
   let displayMath = false;
+  let table = false;
   let boundary = 0;
   while (lineStart < text.length) {
     const newline = text.indexOf("\n", lineStart);
@@ -156,7 +163,7 @@ export function streamingCommitTarget(text: string): string {
     const line = text.slice(lineStart, newline === -1 ? text.length : newline).replace(/\r$/, "");
     const terminated = newline !== -1;
     if (fence) {
-      if (new RegExp(`^ {0,3}${fence.marker}{${fence.length},}[ \\t]*$`).test(line)) {
+      if (new RegExp(`^ {0,3}${fence.marker}{${fence.length},}[ \t]*$`).test(line)) {
         fence = null;
         if (terminated) boundary = lineEnd;
       }
@@ -164,6 +171,39 @@ export function streamingCommitTarget(text: string): string {
       if (line.trim() === "$$") {
         displayMath = false;
         if (terminated) boundary = lineEnd;
+      }
+    } else if (table) {
+      // GFM tables extend row by row: every terminated row is a complete
+      // block, so it commits immediately — no trailing blank line needed.
+      if (line.includes("|")) {
+        if (terminated) boundary = lineEnd;
+      } else if (terminated && line.trim() === "") {
+        table = false;
+        boundary = lineEnd;
+      } else {
+        const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
+        if (fenceMatch) {
+          table = false;
+          fence = { marker: fenceMatch[1][0], length: fenceMatch[1].length };
+        } else if (line.trim() === "$$") {
+          table = false;
+          displayMath = true;
+        } else if (/^ {0,3}#{1,6}[ \t]+/.test(line)) {
+          table = false;
+          boundary = terminated ? lineEnd : lineStart;
+        } else if (
+          /^ {0,3}([-*+]|\d{1,9}[.)])[ \t]+/.test(line) ||
+          /^ {0,3}>[ \t]?/.test(line) ||
+          /^ {0,3}(-{3,}|\*{3,}|_{3,})[ \t]*$/.test(line)
+        ) {
+          // List, blockquote or thematic break: a GFM block start closes the
+          // table. The line itself commits on its own boundary rules and
+          // rides the tail until then.
+          table = false;
+        } else {
+          // Any other non-blank line is swallowed into the table as a
+          // single-cell row by GFM — keep the table open, ride the tail.
+        }
       }
     } else {
       const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
@@ -174,6 +214,14 @@ export function streamingCommitTarget(text: string): string {
       // completes everything before it; a terminated one is itself complete.
       else if (/^ {0,3}#{1,6}[ \t]+/.test(line)) boundary = terminated ? lineEnd : lineStart;
       else if (isStreamingListItemLine(line)) boundary = lineStart;
+      // A terminated pipe line whose next line is a GFM delimiter row starts
+      // a table: the header row commits once the delimiter row lands.
+      else if (terminated && line.includes("|")) {
+        const rest = text.slice(lineEnd);
+        const nl2 = rest.indexOf("\n");
+        const next = (nl2 === -1 ? rest : rest.slice(0, nl2)).replace(/\r$/, "");
+        if (isTableSeparatorRow(next)) table = true;
+      }
     }
     lineStart = lineEnd;
   }


### PR DESCRIPTION
## Summary

`streamingCommitTarget` (`desktop/frontend/src/components/Markdown.tsx`) previously had no rule for GFM tables: table rows rode the plain-text tail until a blank line (or another boundary) landed, so the last completed row stayed unrendered while streaming — the table only "popped" into view when the stream ended or an empty line appeared.

This PR makes **every terminated table row a complete block** that commits immediately (no trailing blank line required), with GFM-parity rules **verified against remark-gfm** (the parser desktop renders with):

- rows containing `|` commit per terminated line;
- a blank line closes the table and commits;
- a **block start** (heading, fence, `$$`, list, blockquote, thematic break) closes the table, then follows its own boundary rules (a terminated heading commits itself; an open fence keeps the whole text parsed for live highlighting, matching existing semantics);
- a **plain non-pipe line is swallowed into the table as a single-cell row by GFM**, so it rides the tail and keeps the table open — committing it as a paragraph would diverge from the final render (verified: `| 1 | 2 |\nplain` → `plain` becomes a third row).

Table start detection: a terminated pipe line whose next line is a GFM delimiter row (`isTableSeparatorRow`) opens the table; the header row commits once the delimiter row lands.

The final full parse was always correct — this closes the streaming-preview timing gap, not a rendering bug.

English: 流式中 GFM 表格行现在逐行即时提交（无需尾随空行），边界规则与 remark-gfm 实际解析行为对齐（块级结构结束表格、普通行被吞进表格、空行结束表格）。

## Issues

Fixes #8972

## Verification

- `npx tsc --noEmit` — pass
- `npx eslint src/components/Markdown.tsx src/__tests__/ui-perf-scenarios.test.ts` — pass
- `npx tsx src/__tests__/ui-perf-scenarios.test.ts` — 24 passed, 0 failed (8 new UI-PERF-07 assertions)
- GFM parity pre-verified against remark-gfm directly (table termination: block starts close, plain lines swallow, blank line closes)

## Documentation impact

Documentation-impact: none- streaming preview timing only; no config, CLI, provider, permission, or tool surface changed.

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (frontend renderer only); explicit maintainer review requested.