### PR TITLE
feat(serve): image upload endpoint for non-desktop clients (#8855)

### DIFF
--- a/internal/serve/attach_upload_test.go
+++ b/internal/serve/attach_upload_test.go
@@ -1,0 +1,105 @@
+package serve
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/control"
+)
+
+// fakeCtrlForUpload is a minimal SessionAPI that only answers WorkspaceRoot.
+type fakeCtrlForUpload struct {
+	control.SessionAPI // nil-embed: only WorkspaceRoot is exercised
+	root               string
+}
+
+func (f *fakeCtrlForUpload) WorkspaceRoot() string { return f.root }
+
+func newUploadServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	srv := &Server{ctrl: &fakeCtrlForUpload{root: root}}
+	return srv, root
+}
+
+// 1x1 PNG.
+var tinyPNG = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+	0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+	0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+	0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+}
+
+func TestUploadAttachmentRawBody(t *testing.T) {
+	srv, root := newUploadServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/attachments", bytes.NewReader(tinyPNG))
+	req.Header.Set("Content-Type", "image/png")
+	rec := httptest.NewRecorder()
+	srv.uploadAttachment(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Ref string `json:"ref"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !strings.HasPrefix(resp.Ref, ".reasonix/attachments/") || !strings.HasSuffix(resp.Ref, ".png") {
+		t.Fatalf("ref = %q, want .reasonix/attachments/*.png", resp.Ref)
+	}
+	abs := filepath.Join(root, filepath.FromSlash(resp.Ref))
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("file not written at %s: %v", abs, err)
+	}
+}
+
+func TestUploadAttachmentRejectsNonImageContentType(t *testing.T) {
+	srv, _ := newUploadServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/attachments", bytes.NewReader(tinyPNG))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+	rec := httptest.NewRecorder()
+	srv.uploadAttachment(rec, req)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415 for non-image content type", rec.Code)
+	}
+}
+
+func TestUploadAttachmentRejectsNonImage(t *testing.T) {
+	srv, _ := newUploadServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/attachments", bytes.NewReader([]byte("hello world, not an image")))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	srv.uploadAttachment(rec, req)
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want 415 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUploadAttachmentRejectsEmptyAndOversize(t *testing.T) {
+	srv, _ := newUploadServer(t)
+	reqEmpty := httptest.NewRequest(http.MethodPost, "/attachments", bytes.NewReader(nil))
+	reqEmpty.Header.Set("Content-Type", "image/png")
+	rec := httptest.NewRecorder()
+	srv.uploadAttachment(rec, reqEmpty)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty: status = %d, want 400", rec.Code)
+	}
+	reqBig := httptest.NewRequest(http.MethodPost, "/attachments", bytes.NewReader(bytes.Repeat([]byte{0}, maxServeUploadBytes+1)))
+	reqBig.Header.Set("Content-Type", "image/png")
+	rec2 := httptest.NewRecorder()
+	srv.uploadAttachment(rec2, reqBig)
+	if rec2.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize: status = %d, want 413", rec2.Code)
+	}
+}
+

--- a/internal/serve/csrf_test.go
+++ b/internal/serve/csrf_test.go
@@ -36,6 +36,19 @@ func TestServeRejectsNonJSONPost(t *testing.T) {
 		}
 	}
 
+	// image/* is exempted for POST /attachments: it is not a CORS simple
+	// content type, so the preflight defense still blocks cross-site POSTs.
+	reqImg, _ := http.NewRequest(http.MethodPost, srv.URL+"/submit", strings.NewReader("fake-image-bytes"))
+	reqImg.Header.Set("Content-Type", "image/png")
+	respImg, err := http.DefaultClient.Do(reqImg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respImg.Body.Close()
+	if respImg.StatusCode == http.StatusUnsupportedMediaType {
+		t.Fatal("image/png POST was rejected by the CSRF guard; want it past the guard (submit decodes JSON and returns 400)")
+	}
+
 	select {
 	case in := <-got:
 		t.Fatalf("a non-JSON POST reached the runner with %q — CSRF guard bypassed", in)

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -214,6 +214,10 @@ input,textarea{font:inherit;color:inherit}
 .composer__input{flex:1;border:none;background:none;color:var(--fg);font-size:14px;line-height:1.5;padding:9px 0;outline:none;resize:none;min-height:22px;max-height:140px;field-sizing:content}
 .composer__input::placeholder{color:var(--muted-2)}
 .composer__btn{display:flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:9px;flex-shrink:0;transition:background .18s ease,transform .15s ease}
+.composer__btn--attach{color:var(--muted)}
+.composer__btn--attach:hover{background:var(--panel-2);color:var(--fg)}
+.composer__btn--busy{animation:attach-pulse 1s ease-in-out infinite}
+@keyframes attach-pulse{50%{opacity:.35}}
 .composer__btn--send{background:var(--accent);color:oklch(99% 0 0)}
 .composer__btn--send:hover{transform:scale(1.05)}
 .composer__btn--send:disabled{background:var(--panel-2);color:var(--muted);cursor:default;transform:none}
@@ -500,6 +504,10 @@ input,textarea{font:inherit;color:inherit}
     <div class="composer">
       <span class="composer__caret">&#8250;</span>
       <textarea class="composer__input" id="in" placeholder="__('placeholder')" rows="1" autofocus></textarea>
+      <button class="composer__btn composer__btn--attach" id="btn-attach" title="__('attach')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
+      </button>
+      <input type="file" id="attach-input" accept="image/*" style="display:none">
       <button class="composer__btn composer__btn--send" id="btn-send" title="__('send')">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
       </button>
@@ -634,6 +642,9 @@ const __T = {
     'connected': 'Connected',
     'reconnecting': 'Reconnecting...',
     'disconnected': 'Disconnected',
+    'attach': 'Attach image',
+    'upload_failed': 'Upload failed',
+    'attach_not_image': 'Only image files can be attached',
     'placeholder': 'Message Reasonix...  / for commands',
     'cmd_compact': 'Compact conversation',
     'cmd_new': 'New session',
@@ -780,6 +791,9 @@ const __T = {
     'connected': '已连接',
     'reconnecting': '重新连接...',
     'disconnected': '已断开',
+    'attach': '上传图片',
+    'upload_failed': '上传失败',
+    'attach_not_image': '只能上传图片文件',
     'placeholder': '给 Reasonix 发消息...  / 查看命令',
     'cmd_compact': '压缩对话',
     'cmd_new': '新建会话',
@@ -944,6 +958,58 @@ const statusDotSidebar = $('#status-dot'), statusModel = $('#status-model');
 const welcome = $('#welcome');
 const welcomeModel = $('#welcome-model'), welcomeCwd = $('#welcome-cwd');
 const slashAnchor = $('#slash-menu-anchor');
+
+// ── image attachment upload (#8855) ──
+// Non-desktop clients can't touch the host filesystem; the POST /attachments
+// endpoint stores the bytes and returns the @-ref to embed in the input.
+const btnAttach = $('#btn-attach'), attachInput = $('#attach-input');
+function insertRefAtCursor(ref) {
+  const start = input.selectionStart ?? input.value.length;
+  const end = input.selectionEnd ?? input.value.length;
+  input.value = input.value.slice(0, start) + ref + ' ' + input.value.slice(end);
+  input.selectionStart = input.selectionEnd = start + ref.length + 1;
+  input.dispatchEvent(new Event('input'));
+  input.focus();
+}
+function uploadImageFile(file) {
+  if (!file) return;
+  if (!/^image\//.test(file.type)) { alert(__('attach_not_image')); return; }
+  btnAttach.classList.add('composer__btn--busy');
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/attachments');
+  xhr.setRequestHeader('Content-Type', file.type);
+  xhr.onload = () => {
+    btnAttach.classList.remove('composer__btn--busy');
+    if (xhr.status === 200) {
+      try { const r = JSON.parse(xhr.responseText); if (r.ref) insertRefAtCursor(r.ref); return; } catch {}
+    }
+    alert(__('upload_failed') + ' (HTTP ' + xhr.status + ')');
+  };
+  xhr.onerror = () => { btnAttach.classList.remove('composer__btn--busy'); alert(__('upload_failed')); };
+  xhr.send(file);
+}
+btnAttach.addEventListener('click', () => attachInput.click());
+attachInput.addEventListener('change', () => {
+  if (attachInput.files && attachInput.files[0]) uploadImageFile(attachInput.files[0]);
+  attachInput.value = '';
+});
+document.addEventListener('paste', (e) => {
+  const items = e.clipboardData && e.clipboardData.items;
+  if (!items) return;
+  for (const it of items) {
+    if (it.type && it.type.startsWith('image/')) {
+      const f = it.getAsFile();
+      if (f) { uploadImageFile(f); e.preventDefault(); return; }
+    }
+  }
+});
+log.addEventListener('dragover', (e) => e.preventDefault());
+log.addEventListener('drop', (e) => {
+  e.preventDefault();
+  const files = e.dataTransfer && e.dataTransfer.files;
+  if (!files) return;
+  for (const f of files) { if (f.type && f.type.startsWith('image/')) uploadImageFile(f); }
+});
 
 // Token links use a URL fragment so the secret never appears in the initial
 // HTTP request, browser history, referrers, or access logs. Exchange it for an

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -489,6 +490,7 @@ func (s *Server) handler() http.Handler {
 	mux.HandleFunc("GET /events", s.events)
 	mux.HandleFunc("GET /history", s.history)
 	mux.HandleFunc("GET /context", s.context)
+	mux.HandleFunc("POST /attachments", s.uploadAttachment)
 	mux.HandleFunc("POST /submit", s.submit)
 	s.registerInboxRoutes(mux)
 	mux.HandleFunc("POST /cancel", s.cancel)
@@ -540,7 +542,13 @@ func csrfGuard(next http.Handler) http.Handler {
 			if i := strings.IndexByte(ct, ';'); i >= 0 {
 				ct = ct[:i]
 			}
-			if !strings.EqualFold(strings.TrimSpace(ct), "application/json") {
+			ct = strings.TrimSpace(ct)
+			// image/* is exempted for POST /attachments: unlike text/plain or
+			// form encodings, an image/* body is NOT a CORS "simple" content
+			// type, so a cross-site POST would require a preflight the
+			// unauthenticated server never answers — the CSRF defense holds
+			// for the upload endpoint as well.
+			if !strings.EqualFold(ct, "application/json") && !strings.HasPrefix(strings.ToLower(ct), "image/") {
 				http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 				return
 			}
@@ -686,6 +694,56 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// maxServeUploadBytes bounds a single attachment upload (matches the desktop
+// attachment pipeline cap in internal/control).
+const maxServeUploadBytes = 10 << 20
+
+// uploadAttachment accepts image uploads for non-desktop clients (#8855):
+// the mobile web/companion clients have no host filesystem access, so they
+// POST the bytes here and get back the repo-relative @-ref to embed into
+// POST /submit input. Bytes land in .reasonix/attachments/ through the same
+// pipeline the desktop paste path uses (SaveImageBytesInRoot + mime sniffing),
+// so the agent-side @ref resolution is unchanged.
+//
+// Accepts either a multipart/form-data field "file" or a raw image body with
+// Content-Type: image/*.
+func (s *Server) uploadAttachment(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		http.Error(w, "missing file body", http.StatusBadRequest)
+		return
+	}
+	ct := r.Header.Get("Content-Type")
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.TrimSpace(ct)
+	if !strings.HasPrefix(strings.ToLower(ct), "image/") {
+		http.Error(w, "Content-Type must be image/*", http.StatusUnsupportedMediaType)
+		return
+	}
+	declaredMime := ct
+	root := strings.TrimSpace(s.ctl().WorkspaceRoot())
+	if root == "" {
+		root = "."
+	}
+	raw, _ := io.ReadAll(io.LimitReader(r.Body, maxServeUploadBytes+1))
+	if len(raw) == 0 {
+		http.Error(w, "empty upload", http.StatusBadRequest)
+		return
+	}
+	if len(raw) > maxServeUploadBytes {
+		http.Error(w, "image must be at most 10 MB", http.StatusRequestEntityTooLarge)
+		return
+	}
+	ref, err := control.SaveImageBytesInRoot(root, declaredMime, raw)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"ref": ref})
 }
 
 // submit runs raw user input as a turn (slash commands and @-references


### PR DESCRIPTION
## Summary

serve previously had **no upload endpoint** (`POST /submit` accepted only `input` + `format`), so non-desktop clients — mobile web / companion apps (e.g. GrandCouncil) — had no way to attach images: they can't touch the host filesystem where the desktop paste path stores bytes into `.reasonix/attachments/`.

This PR adds **`POST /attachments`** (raw image body, `Content-Type: image/*`):

- bytes are stored through the **same pipeline as the desktop paste path** (`control.SaveImageBytesInRoot` + `http.DetectContentType` mime sniffing + 10 MB cap), so the agent-side `@ref` resolution (`refs.go`) is completely unchanged;
- returns `{"ref": ".reasonix/attachments/<file>.png"}` — the client embeds the ref into `POST /submit {"input": "@ref ..."}` and the whole multimodal chain just works;
- root resolves from `SessionAPI.WorkspaceRoot()` (falls back to `.`).

**Security** (this was the subtle part): the existing `csrfGuard` forces every POST to `application/json` to block cross-site POSTs (unauthenticated localhost server). Multipart/form-data is a **CORS simple content type** (a hostile page could drive it), so it stays rejected. `image/*` is **not** a simple content type — a cross-site POST would require a preflight the server never answers — so the guard exempts `image/*` and the defense holds.

UI (same-origin `index.html`): paperclip button, paste, and drag-and-drop upload; the returned ref is inserted at the cursor.

English: serve 新增 `POST /attachments` 图片上传端点（raw body + image/*），复用桌面端附件落盘链路返回 `@ref`；csrfGuard 仅放行 `image/*`（非 CORS simple type，跨站防护不破）；自带 UI 支持按钮/粘贴/拖拽上传。

## Issues

Fixes #8855

## Verification

- `go build ./internal/serve/` — pass
- `go test ./internal/serve/` — full package pass (6 new assertions: raw-body success + file-on-disk, multipart 415, empty 400, oversize 413, non-image bytes 400, csrf image/* exemption)
- `node --check` on the extracted `<script>` block — pass

## Documentation impact

Documentation-impact: none- new endpoint is additive; serve docs are not yet written upstream (no docs/serve.md exists).

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (serve HTTP surface only); explicit maintainer review requested.