### PR TITLE
feat(serve): multi-project session browsing endpoint GET /projects (#8789)

### DIFF
--- a/internal/serve/projects_test.go
+++ b/internal/serve/projects_test.go
@@ -1,0 +1,174 @@
+package serve
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/provider"
+)
+
+// fakeProjectsCtrl answers the workspace/session surface GET /projects uses.
+type fakeProjectsCtrl struct {
+	control.SessionAPI // nil-embed: only the three methods below are exercised
+	root               string
+	dir                string
+	path               string
+}
+
+func (f *fakeProjectsCtrl) WorkspaceRoot() string { return f.root }
+func (f *fakeProjectsCtrl) SessionDir() string    { return f.dir }
+func (f *fakeProjectsCtrl) SessionPath() string   { return f.path }
+
+func newProjectsServer(t *testing.T, root string) *Server {
+	t.Helper()
+	dir := config.ProjectSessionDir(root)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &Server{
+		ctrl:   &fakeProjectsCtrl{root: root, dir: dir, path: filepath.Join(dir, "current.jsonl")},
+		titles: newTitleCache(dir),
+	}
+}
+
+// writeDesktopRegistry writes a desktop-projects.json with the given roots.
+func writeDesktopRegistry(t *testing.T, roots ...string) {
+	t.Helper()
+	home := config.ReasonixHomeDir()
+	if home == "" {
+		t.Fatal("ReasonixHomeDir empty under isolated test env")
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	type project struct {
+		Root string `json:"root"`
+	}
+	b, err := json.Marshal(struct {
+		Projects []project `json:"projects"`
+	}{Projects: func() []project {
+		out := make([]project, 0, len(roots))
+		for _, r := range roots {
+			out = append(out, project{Root: r})
+		}
+		return out
+	}()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "desktop-projects.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedSession writes a valid one-user-turn session file into a project's
+// session dir so SessionPreview reports turns=1.
+func seedSession(t *testing.T, root, name string) {
+	t.Helper()
+	dir := config.ProjectSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess := agent.NewSession("system")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hello from " + name})
+	if err := sess.Save(filepath.Join(dir, name+".jsonl")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type projectsResponse []struct {
+	Root     string         `json:"root"`
+	Sessions []sessionListEntry `json:"sessions"`
+}
+
+func callProjects(t *testing.T, srv *Server) projectsResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	srv.projects(rec, httptest.NewRequest(http.MethodGet, "/projects", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var out projectsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func TestProjectsListsDesktopRegistry(t *testing.T) {
+	rootA := filepath.Join(t.TempDir(), "projA")
+	rootB := filepath.Join(t.TempDir(), "projB")
+	writeDesktopRegistry(t, rootA, rootB)
+	seedSession(t, rootA, "alpha")
+	seedSession(t, rootB, "beta")
+
+	srv := newProjectsServer(t, rootA)
+	out := callProjects(t, srv)
+
+	if len(out) != 2 {
+		t.Fatalf("projects = %d, want 2 (%+v)", len(out), out)
+	}
+	found := map[string]int{}
+	for _, p := range out {
+		found[p.Root] = len(p.Sessions)
+	}
+	if found[filepath.Clean(rootA)] != 1 || found[filepath.Clean(rootB)] != 1 {
+		t.Fatalf("session counts = %+v, want 1 per project", found)
+	}
+	// The session entry carries the same shape as /sessions: turns filled.
+	for _, p := range out {
+		if len(p.Sessions) != 1 || p.Sessions[0].Turns != 1 || p.Sessions[0].Title == "" {
+			t.Fatalf("session entry malformed: %+v", p.Sessions)
+		}
+	}
+}
+
+func TestProjectsFallsBackToServeWorkspace(t *testing.T) {
+	// Other tests may have written a registry into the shared isolated home;
+	// the fallback path must be exercised without one.
+	_ = os.Remove(filepath.Join(config.ReasonixHomeDir(), "desktop-projects.json"))
+	root := filepath.Join(t.TempDir(), "only")
+	seedSession(t, root, "solo")
+	// No desktop-projects.json: the serve's own workspace is the single project.
+	srv := newProjectsServer(t, root)
+	out := callProjects(t, srv)
+	if len(out) != 1 {
+		t.Fatalf("projects = %d, want 1 (fallback)", len(out))
+	}
+	if filepath.Clean(out[0].Root) != filepath.Clean(root) {
+		t.Fatalf("root = %q, want %q", out[0].Root, root)
+	}
+	if len(out[0].Sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(out[0].Sessions))
+	}
+}
+
+func TestProjectsEmptySessionDir(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "empty")
+	writeDesktopRegistry(t, root)
+	srv := newProjectsServer(t, root)
+	out := callProjects(t, srv)
+	if len(out) != 1 || len(out[0].Sessions) != 0 {
+		t.Fatalf("expected one project with zero sessions, got %+v", out)
+	}
+}
+
+func TestProjectsDedupesRoots(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "dup")
+	writeDesktopRegistry(t, root, root)
+	seedSession(t, root, "one")
+	srv := newProjectsServer(t, root)
+	out := callProjects(t, srv)
+	if len(out) != 1 {
+		t.Fatalf("projects = %d, want 1 (dedup)", len(out))
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -537,6 +537,7 @@ func (s *Server) handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.index)
 	mux.HandleFunc("GET /sessions/{id}", s.index)
+	mux.HandleFunc("GET /projects", s.projects)
 	mux.HandleFunc("GET /assets/logo-wordmark.svg", s.logoWordmark)
 	mux.HandleFunc("GET /provider-setup", s.providerSetupStatus)
 	mux.HandleFunc("POST /provider-setup", s.providerSetupSave)

--- a/internal/serve/sessions_http.go
+++ b/internal/serve/sessions_http.go
@@ -1,12 +1,15 @@
 package serve
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/store"
 )
 
@@ -19,6 +22,48 @@ type sessionListEntry struct {
 	Running    bool   `json:"running,omitempty"`
 	TakenOver  bool   `json:"takenOver,omitempty"`
 	MtimeMilli int64  `json:"mtimeMilli"`
+}
+
+// listSessionDir enumerates saved session files in dir with the same
+// enrichment as GET /sessions (event-log aware titles and turn counts,
+// cleanup exclusion), newest first. running maps canonical session paths
+// to detached-runtime activity; callers without detached runtimes pass nil.
+func (s *Server) listSessionDir(ctx context.Context, dir, currentPath string, running map[string]bool) []sessionListEntry {
+	var out []sessionListEntry
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []sessionListEntry{}
+	}
+	current := agent.CanonicalSessionPath(currentPath)
+	for _, entry := range entries {
+		if entry.IsDir() || !store.IsSessionTranscriptName(entry.Name()) {
+			continue
+		}
+		path := agent.CanonicalSessionPath(filepath.Join(dir, entry.Name()))
+		if agent.IsCleanupPending(path) {
+			continue
+		}
+		mtime := agent.SessionContentModTime(path)
+		cleanPath := agent.CanonicalSessionPath(path)
+		row := sessionListEntry{Name: strings.TrimSuffix(entry.Name(), ".jsonl"), Path: path, Current: cleanPath == current, Running: running[cleanPath], MtimeMilli: mtime.UnixMilli()}
+		first, turns, cached := agent.SessionPreviewCached(path)
+		if !cached {
+			first, turns = agent.SessionPreview(path)
+		}
+		if turns > 0 {
+			row.Turns = turns
+			row.Title = s.sessionTitle(ctx, entry.Name(), first, mtime.UnixNano())
+		}
+		out = append(out, row)
+	}
+	// reverse so newest first
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	if out == nil {
+		out = []sessionListEntry{}
+	}
+	return out
 }
 
 // sessions lists saved sessions with event-log-aware titles and turn counts.
@@ -75,6 +120,54 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 	}
 	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
 		out[i], out[j] = out[j], out[i]
+	}
+	writeJSON(w, out)
+}
+
+
+// projects lists saved sessions across every project the serve can see.
+// Read-only multi-project browsing for remote clients (#8789): it reads the
+// desktop project registry (desktop-projects.json) and resolves each
+// project's session dir via config.ProjectSessionDir. Without the registry
+// the serve's own workspace is the single project.
+func (s *Server) projects(w http.ResponseWriter, r *http.Request) {
+	type project struct {
+		Root string `json:"root"`
+	}
+	type projectSessions struct {
+		Root     string             `json:"root"`
+		Sessions []sessionListEntry `json:"sessions"`
+	}
+	roots := []string{}
+	home := config.ReasonixHomeDir()
+	if data, err := os.ReadFile(filepath.Join(home, "desktop-projects.json")); err == nil {
+		var saved struct {
+			Projects []project `json:"projects"`
+		}
+		if json.Unmarshal(data, &saved) == nil {
+			for _, p := range saved.Projects {
+				if root := strings.TrimSpace(p.Root); root != "" {
+					roots = append(roots, root)
+				}
+			}
+		}
+	}
+	if len(roots) == 0 {
+		if w := strings.TrimSpace(s.ctl().WorkspaceRoot()); w != "" {
+			roots = append(roots, w)
+		}
+	}
+	current := s.ctl().SessionPath()
+	out := []projectSessions{}
+	seen := map[string]bool{}
+	for _, root := range roots {
+		root = filepath.Clean(root)
+		if seen[root] {
+			continue
+		}
+		seen[root] = true
+		ps := projectSessions{Root: root, Sessions: s.listSessionDir(r.Context(), config.ProjectSessionDir(root), current, nil)}
+		out = append(out, ps)
 	}
 	writeJSON(w, out)
 }


### PR DESCRIPTION
**TL;DR**: GET /projects 端点对齐上游 detached/缓存逻辑，支持多项目会话浏览

## Summary

A serve instance is bound to exactly one workspace, so remote clients (mobile app, Reasonix-web) could only see the sessions of the serve's startup directory. This adds a **read-only `GET /projects`** endpoint that:

- reads the same project list the desktop sidebar uses (`desktop-projects.json` under the Reasonix home dir);
- resolves each project's session dir via `config.ProjectSessionDir` (existing pure function, paths.go:453) and returns the same per-session shape as `GET /sessions` (name/path/title/turns/current), tagged with the project root;
- falls back to the serve's own workspace when the registry is absent;
- dedupes roots.

Response shape:

```json
[
  { "root": "D:\1.workspace\GrandCouncil", "sessions": [ { "name": "...", "path": "...", "title": "...", "turns": 3, "current": true } ] },
  { "root": "D:\1.workspace\data_platform", "sessions": [ ... ] }
]
```

Scope is deliberately **read-only**: submit/resume/approve stay bound to the serve's own workspace (controller `sessionDir` is construction-fixed; multi-workspace writes are a separate, larger change). The endpoint reuses the /sessions enrichment (event-log aware titles/turns, cleanup exclusion) via an extracted `listSessionDir` helper.

English: serve 新增只读 `GET /projects`——读 desktop 项目注册表，按项目返回全部会话（与 /sessions 同形状），手机端/Web 一次请求看全部项目；无注册表回退当前工作区；写操作仍绑定 serve 自身工作区。

## Issues

Fixes #8789

## Verification

- `go build ./internal/serve/` — pass
- `go test ./internal/serve/ -run TestProjects` — 4/4 pass (registry listing, fallback to serve workspace, empty session dir, root dedup)
- `go test ./internal/serve/` — full package pass

## Documentation impact

Documentation-impact: none- additive read-only endpoint; serve docs are not yet written upstream (no docs/serve.md exists).

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (serve HTTP surface only); explicit maintainer review requested.
