### PR TITLE
Restore terminal test TypeScript compatibility / 恢复终端测试的 TypeScript 兼容性

### DIFF
--- a/desktop/frontend/src/__tests__/terminal-events.test.ts
+++ b/desktop/frontend/src/__tests__/terminal-events.test.ts
@@ -69,14 +69,14 @@ try {
   check(JSON.stringify(pausable) === JSON.stringify([1, 2]), "inactive terminal does not consume hidden PTY output");
   pausableSubscription.setActive(true);
   check(
-    pausable.length === terminalEventBufferLimit + 2 && pausable[2] === 18 && pausable.at(-1) === 33,
+    pausable.length === terminalEventBufferLimit + 2 && pausable[2] === 18 && pausable[pausable.length - 1] === 33,
     "reactivated terminal replays only the retained missed output once",
   );
   const replayedLength = pausable.length;
   pausableSubscription.setActive(true);
   check(pausable.length === replayedLength, "repeated activation does not duplicate terminal output");
   __emitMockTerminalOutput({ id: "pausable", data: base64(new Uint8Array([99])) });
-  check(pausable.at(-1) === 99, "reactivated terminal resumes live output after replay");
+  check(pausable[pausable.length - 1] === 99, "reactivated terminal resumes live output after replay");
   pausableSubscription.dispose();
 
   __emitMockTerminalOutput({ id: "forgotten", data: base64(new Uint8Array([9])) });

--- a/desktop/frontend/src/__tests__/terminal-selection.test.ts
+++ b/desktop/frontend/src/__tests__/terminal-selection.test.ts
@@ -21,7 +21,7 @@ function mockRect(
 }
 
 function keyEvent(overrides: Partial<ConstructorParameters<typeof KeyboardEvent>[1]> & { key: string }) {
-  return { key: overrides.key, ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, ...overrides };
+  return { ctrlKey: false, metaKey: false, altKey: false, shiftKey: false, ...overrides };
 }
 
 // handleTerminalCopyKey: Ctrl+C copies a live selection and swallows the chord;


### PR DESCRIPTION
## Summary

- replace `Array.prototype.at` in terminal regression tests with indexing supported by the configured TypeScript lib target
- remove the duplicate `key` declaration from the keyboard-event fixture
- keep runtime behavior unchanged while restoring the formal frontend release gate

## Verification

- `pnpm test:typecheck`
- `pnpm test:terminal`
- `pnpm test:all`
- `pnpm build`