### PR TITLE
feat(gateway): takeover-session retry via host handoff hook (#8997)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -31,6 +31,7 @@ import (
 
 	"reasonix/desktop/internal/instanceidentity"
 	"reasonix/internal/agent"
+	"reasonix/internal/servepool"
 	"reasonix/internal/billing"
 	"reasonix/internal/boot"
 	"reasonix/internal/botruntime"
@@ -355,6 +356,9 @@ type App struct {
 	// window releases only its registration, while the remote Serve and the SSH
 	// connection keep running. The child deliberately skips local runtimes.
 	remoteWindows          *remoteWindowRegistry
+	servePool              *servepool.Manager
+	gatewaySrv             *http.Server
+	gatewayAddr            string
 	remoteWindowLifecycles remoteWindowLifecycleRegistry
 	remoteWindowOpener     func(remoteWindowLaunch) error // test-only injection
 	// Remote project tabs are in-app surfaces bound to a remote workspace.
@@ -470,6 +474,9 @@ func NewApp() *App {
 	a.webView2Recovery = newWebView2RecoveryCoordinator(a)
 	a.desktopShell.linuxRecovery = newLinuxWebKitRecoveryCoordinator(a)
 	a.desktopShell.coordinator = newDesktopShellCoordinator(a)
+	a.servePool = nil
+	a.gatewayAddr = ""
+	a.gatewaySrv = nil
 	a.workspaceHub = newWorkspaceChangeHub(a)
 	a.terminals = newTerminalManager(a)
 	a.botBridge = a.newBotBridge()
@@ -511,6 +518,8 @@ func (a *App) startup(ctx context.Context) {
 		return
 	}
 	installSystemQuitHook()
+	a.startServePool(ctx)
+	a.startTray()
 	a.enableDeferredRebuildRetry()
 	a.startHistoryIndexMigration()
 	a.goSafe("repairDesktopIconIntegration", func() {

--- a/desktop/servepool_host.go
+++ b/desktop/servepool_host.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/servepool"
 )
@@ -36,7 +37,7 @@ func (a *App) startServePool(ctx context.Context) {
 		return
 	}
 	token := loadOrCreateGatewayToken()
-	gw := servepool.NewGateway(mgr, token)
+	gw := servepool.NewGateway(mgr, token, a)
 	port := gatewayPort()
 	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
@@ -98,4 +99,42 @@ func gatewayPort() int {
 		}
 	}
 	return 18789
+}
+
+// HandoffSession implements servepool.HostHook (#8987): releases a
+// desktop-held session to the requesting serve writer via a handoff
+// reservation. The gateway only calls this for takeover-session 409s whose
+// holder is this process (the desktop), so no cross-machine authorization is
+// involved — the request already passed the gateway token gate.
+func (a *App) HandoffSession(projectID, sessionName, targetWriterID string) error {
+	if strings.TrimSpace(sessionName) == "" || strings.ContainsAny(sessionName, `/\`) {
+		return fmt.Errorf("handoff: invalid session name")
+	}
+	root := ""
+	for _, p := range projectRootsFromRegistry() {
+		if servepool.WorkspaceSlug(p) == projectID {
+			root = p
+			break
+		}
+	}
+	if root == "" {
+		return fmt.Errorf("handoff: unknown project %q", projectID)
+	}
+	dir := config.ProjectSessionDir(root)
+	if dir == "" {
+		return fmt.Errorf("handoff: no session dir for project %q", projectID)
+	}
+	path := filepath.Join(dir, sessionName+".jsonl")
+	if !strings.HasPrefix(filepath.Clean(path), filepath.Clean(dir)+string(filepath.Separator)) {
+		return fmt.Errorf("handoff: path outside session dir")
+	}
+	lease, err := agent.TryReclaimCurrentProcessSessionLease(path)
+	if err != nil {
+		return fmt.Errorf("handoff: %w", err)
+	}
+	defer lease.Release()
+	if err := lease.ReleaseForHandoff(strings.TrimSpace(targetWriterID)); err != nil {
+		return fmt.Errorf("handoff: %w", err)
+	}
+	return nil
 }

--- a/desktop/servepool_host.go
+++ b/desktop/servepool_host.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/config"
+	"reasonix/internal/servepool"
+)
+
+// ServePoolAddress returns the gateway listen address ("" when disabled).
+func (a *App) ServePoolAddress() string {
+	if a == nil {
+		return ""
+	}
+	return a.gatewayAddr
+}
+
+// startServePool starts the single-entry remote gateway in front of a pool of
+// lazily spawned per-project serve processes (#8983). It binds 127.0.0.1 only
+// — the desktop's own tabs stay authoritative; remote clients operate through
+// the pool (one token-protected entry, /p/<project>/... routing). Failures
+// disable the gateway silently (e.g. port taken) and log a warning.
+func (a *App) startServePool(ctx context.Context) {
+	roots := projectRootsFromRegistry()
+	mgr, err := servepool.NewManager(servepool.Config{ProjectRoots: roots})
+	if err != nil {
+		slog.Warn("servepool: disabled", "err", err)
+		return
+	}
+	token := loadOrCreateGatewayToken()
+	gw := servepool.NewGateway(mgr, token)
+	port := gatewayPort()
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		mgr.Close()
+		slog.Warn("servepool: gateway listen failed", "port", port, "err", err)
+		return
+	}
+	a.servePool = mgr
+	a.gatewayAddr = ln.Addr().String()
+	srv := &http.Server{Handler: gw}
+	a.gatewaySrv = srv
+	a.goSafe("servepool-gateway", func() { _ = srv.Serve(ln) })
+	slog.Info("servepool: gateway ready", "addr", a.gatewayAddr)
+}
+
+// closeServePool stops the gateway and all pooled serves.
+func (a *App) closeServePool() {
+	if a.gatewaySrv != nil {
+		_ = a.gatewaySrv.Close()
+		a.gatewaySrv = nil
+	}
+	if a.servePool != nil {
+		a.servePool.Close()
+		a.servePool = nil
+	}
+	a.gatewayAddr = ""
+}
+
+func projectRootsFromRegistry() []string {
+	f := loadProjectsFile()
+	roots := make([]string, 0, len(f.Projects))
+	for _, p := range f.Projects {
+		if strings.TrimSpace(p.Root) != "" {
+			roots = append(roots, p.Root)
+		}
+	}
+	return roots
+}
+
+func loadOrCreateGatewayToken() string {
+	path := filepath.Join(config.MemoryUserDir(), "gateway-token")
+	if b, err := os.ReadFile(path); err == nil {
+		if tok := strings.TrimSpace(string(b)); tok != "" {
+			return tok
+		}
+	}
+	tok := servepool.RandomToken()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.WriteFile(path, []byte(tok), 0o600)
+	return tok
+}
+
+// gatewayPort picks the gateway port: REASONIX_GATEWAY_PORT env override or
+// the default 18789 (the desktop's internal serve keeps 8787).
+func gatewayPort() int {
+	if v := os.Getenv("REASONIX_GATEWAY_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 && p < 65536 {
+			return p
+		}
+	}
+	return 18789
+}

--- a/desktop/servepool_host_test.go
+++ b/desktop/servepool_host_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGatewayPortDefaultAndOverride(t *testing.T) {
+	t.Setenv("REASONIX_GATEWAY_PORT", "")
+	if got := gatewayPort(); got != 18789 {
+		t.Fatalf("default port = %d, want 18789", got)
+	}
+	t.Setenv("REASONIX_GATEWAY_PORT", "0")
+	if got := gatewayPort(); got != 18789 {
+		t.Fatalf("invalid override = %d, want 18789", got)
+	}
+	t.Setenv("REASONIX_GATEWAY_PORT", "99999")
+	if got := gatewayPort(); got != 18789 {
+		t.Fatalf("out-of-range override = %d, want 18789", got)
+	}
+	t.Setenv("REASONIX_GATEWAY_PORT", "23456")
+	if got := gatewayPort(); got != 23456 {
+		t.Fatalf("valid override = %d, want 23456", got)
+	}
+}
+
+func TestProjectRootsFromRegistryEmpty(t *testing.T) {
+	// No desktop-projects.json in the test home -> empty roots, no panic.
+	roots := projectRootsFromRegistry()
+	if roots == nil {
+		t.Fatal("roots = nil, want empty slice")
+	}
+	if len(roots) != 0 {
+		t.Fatalf("roots = %v, want empty", roots)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -841,8 +841,17 @@ func runServeWithOptions(args []string, opts serveRunOptions) int {
 	registerServeCapabilityFlags(fs)
 	openBrowser := fs.Bool("open", opts.openBrowser, "open the Web UI in the default browser")
 	noOpen := fs.Bool("no-open", false, "do not open the Web UI in the default browser")
+	pool := fs.Bool("pool", false, "run as a multi-project pool gateway (single entry for remote clients)")
+	poolAddr := fs.String("pool-addr", "0.0.0.0:8848", "pool gateway listen address")
 	if code, ok := parseCommandFlags(fs, args); !ok {
 		return code
+	}
+	if *pool {
+		if opts.command != "serve" {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "--pool is only valid with `reasonix serve`")
+			return 2
+		}
+		return runServePool(*poolAddr, *tokenFile, *token)
 	}
 	authExplicit := false
 	fs.Visit(func(f *flag.Flag) {

--- a/internal/cli/serve_pool.go
+++ b/internal/cli/serve_pool.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"reasonix/internal/config"
+	"reasonix/internal/i18n"
+	"reasonix/internal/servepool"
+)
+
+// runServePool hosts the single-entry remote gateway as a standalone CLI
+// process (headless Linux/NAS via systemd, #8983 P1b). The gateway serves
+// GET /manifest, POST /projects/open and /p/<id>/* routing exactly like the
+// desktop-embedded host; project roots come from the same
+// desktop-projects.json registry.
+func runServePool(addr, tokenFile, token string) int {
+	roots := readDesktopProjectRoots()
+	mgr, err := servepool.NewManager(servepool.Config{ProjectRoots: roots})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	defer mgr.Close()
+
+	gwToken := strings.TrimSpace(token)
+	if gwToken == "" && tokenFile != "" {
+		if b, err := os.ReadFile(tokenFile); err == nil {
+			gwToken = strings.TrimSpace(string(b))
+		}
+	}
+	if gwToken == "" {
+		gwToken = loadOrCreateGatewayTokenCLI()
+	}
+	gw := servepool.NewGateway(mgr, gwToken, nil)
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	srv := &http.Server{Handler: gw}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close()
+	}()
+
+	fmt.Printf("reasonix serve --pool on http://%s (%d projects)\n", ln.Addr().String(), len(roots))
+	fmt.Println("gateway token file: <reasonix home>/gateway-token")
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	return 0
+}
+
+// readDesktopProjectRoots reads the desktop sidebar's project registry.
+func readDesktopProjectRoots() []string {
+	type project struct {
+		Root string `json:"root"`
+	}
+	type projectFile struct {
+		Projects []project `json:"projects"`
+	}
+	home := config.ReasonixHomeDir()
+	var saved projectFile
+	if data, err := os.ReadFile(filepath.Join(home, "desktop-projects.json")); err == nil {
+		_ = json.Unmarshal(data, &saved)
+	}
+	roots := make([]string, 0, len(saved.Projects))
+	seen := map[string]bool{}
+	for _, p := range saved.Projects {
+		root := filepath.Clean(strings.TrimSpace(p.Root))
+		if root == "" || root == "." || seen[root] {
+			continue
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+// loadOrCreateGatewayTokenCLI reuses the same gateway token file as the
+// desktop host so one token works across both hosts on the same machine.
+func loadOrCreateGatewayTokenCLI() string {
+	path := filepath.Join(config.MemoryUserDir(), "gateway-token")
+	if b, err := os.ReadFile(path); err == nil {
+		if tok := strings.TrimSpace(string(b)); tok != "" {
+			return tok
+		}
+	}
+	tok := servepool.RandomToken()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	_ = os.WriteFile(path, []byte(tok), 0o600)
+	return tok
+}

--- a/internal/cli/serve_pool_test.go
+++ b/internal/cli/serve_pool_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func TestReadDesktopProjectRoots(t *testing.T) {
+	home := config.ReasonixHomeDir()
+	if home == "" {
+		t.Fatal("ReasonixHomeDir empty under isolated test env")
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootA := filepath.Join(t.TempDir(), "a")
+	rootB := filepath.Join(t.TempDir(), "b")
+	type project struct {
+		Root string `json:"root"`
+	}
+	b, err := json.Marshal(struct {
+		Projects []project `json:"projects"`
+	}{Projects: []project{{Root: rootA}, {Root: rootB}, {Root: rootA}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "desktop-projects.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	roots := readDesktopProjectRoots()
+	if len(roots) != 2 {
+		t.Fatalf("roots = %v, want 2 (dedup)", roots)
+	}
+}
+
+func TestReadDesktopProjectRootsAbsent(t *testing.T) {
+	_ = os.Remove(filepath.Join(config.ReasonixHomeDir(), "desktop-projects.json"))
+	roots := readDesktopProjectRoots()
+	if roots == nil || len(roots) != 0 {
+		t.Fatalf("roots = %v, want empty slice", roots)
+	}
+}
+
+func TestServePoolFlagRejectedForWeb(t *testing.T) {
+	// `reasonix web --pool` must be rejected (pool is serve-only).
+	code := runServeWithOptions([]string{"--pool"}, serveRunOptions{command: "web"})
+	if code == 0 {
+		t.Fatal("web --pool accepted; want nonzero exit")
+	}
+}

--- a/internal/servepool/gateway.go
+++ b/internal/servepool/gateway.go
@@ -1,13 +1,27 @@
 package servepool
 
 import (
+	"bytes"
 	"crypto/subtle"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
 )
+
+// HostHook lets the embedding host (the desktop) participate in session
+// ownership handoff (#8987): when a proxied takeover-session request hits a
+// 409 "held by another runtime" and the holder is the gateway's own host,
+// the hook releases the session (with a handoff reservation) so the gateway
+// can retry. A nil hook disables the retry (standalone serve --pool host).
+type HostHook interface {
+	// HandoffSession releases the session (identified by its project id and
+	// session name) to targetWriterID. The host resolves the absolute
+	// session path itself. Return nil when the handoff was granted.
+	HandoffSession(projectID, sessionName, targetWriterID string) error
+}
 
 // Gateway is the single-entry HTTP surface in front of the serve pool.
 // Remote clients (GrandCouncil, Reasonix-web) talk to exactly one endpoint;
@@ -16,16 +30,18 @@ import (
 type Gateway struct {
 	mgr   *Manager
 	token string
+	hook  HostHook
 	proxy map[string]*httputil.ReverseProxy
 }
 
 // NewGateway builds the gateway handler. token must be a non-empty secret
 // (desktop-generated and shown in settings; clients configure it once).
-func NewGateway(mgr *Manager, token string) *Gateway {
+// hook enables takeover-session retry for host-held sessions (nil = off).
+func NewGateway(mgr *Manager, token string, hook HostHook) *Gateway {
 	if strings.TrimSpace(token) == "" {
 		token = newToken()
 	}
-	return &Gateway{mgr: mgr, token: token, proxy: map[string]*httputil.ReverseProxy{}}
+	return &Gateway{mgr: mgr, token: token, hook: hook, proxy: map[string]*httputil.ReverseProxy{}}
 }
 
 // Token returns the gateway bearer token (for UI display / first setup).
@@ -123,8 +139,61 @@ func (g *Gateway) proxyFor(id string, port int) *httputil.ReverseProxy {
 		req.URL.Scheme = target.Scheme
 		req.URL.Host = target.Host
 	}
+	if g.hook != nil {
+		p.Transport = &takeoverRetryTransport{
+			base:      http.DefaultTransport,
+			hook:      g.hook,
+			projectID: id,
+		}
+	}
 	g.proxy[id] = p
 	return p
+}
+
+// takeoverRetryTransport wraps the project-serve transport so a
+// takeover-session 409 ("held by another runtime") can be resolved by the
+// host's HandoffSession hook and retried once (#8987).
+type takeoverRetryTransport struct {
+	base      http.RoundTripper
+	hook      HostHook
+	projectID string
+}
+
+func (t *takeoverRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	isTakeover := strings.HasSuffix(req.URL.Path, "/takeover-session")
+	var body []byte
+	var bodyErr error
+	if isTakeover && req.Body != nil {
+		body, bodyErr = io.ReadAll(req.Body)
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || !isTakeover || resp.StatusCode != http.StatusConflict {
+		return resp, err
+	}
+	if bodyErr != nil || len(body) == 0 {
+		return resp, err
+	}
+	// The project serve cannot hand us the session because its holder is the
+	// gateway's own host (desktop). Ask the host to release it, then retry.
+	var target struct {
+		Name string `json:"name"`
+		From string `json:"from,omitempty"`
+	}
+	_ = json.Unmarshal(body, &target)
+	if strings.TrimSpace(target.Name) == "" {
+		return resp, err
+	}
+	if err := t.hook.HandoffSession(t.projectID, target.Name, target.From); err != nil {
+		// Keep the 409 response (with its body) intact for the client; the
+		// hook error is diagnostic only.
+		return resp, nil
+	}
+	req2 := req.Clone(req.Context())
+	req2.Body = io.NopCloser(bytes.NewReader(body))
+	req2.ContentLength = int64(len(body))
+	return t.base.RoundTrip(req2)
 }
 
 func itoa(n int) string {

--- a/internal/servepool/gateway.go
+++ b/internal/servepool/gateway.go
@@ -1,0 +1,160 @@
+package servepool
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// Gateway is the single-entry HTTP surface in front of the serve pool.
+// Remote clients (GrandCouncil, Reasonix-web) talk to exactly one endpoint;
+// /p/<project-id>/* requests are lazily spawned and reverse-proxied to the
+// project's 127.0.0.1 serve. All endpoints require the gateway bearer token.
+type Gateway struct {
+	mgr   *Manager
+	token string
+	proxy map[string]*httputil.ReverseProxy
+}
+
+// NewGateway builds the gateway handler. token must be a non-empty secret
+// (desktop-generated and shown in settings; clients configure it once).
+func NewGateway(mgr *Manager, token string) *Gateway {
+	if strings.TrimSpace(token) == "" {
+		token = newToken()
+	}
+	return &Gateway{mgr: mgr, token: token, proxy: map[string]*httputil.ReverseProxy{}}
+}
+
+// Token returns the gateway bearer token (for UI display / first setup).
+func (g *Gateway) Token() string { return g.token }
+
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !g.authorized(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/manifest":
+		g.handleManifest(w, r)
+	case r.Method == http.MethodPost && r.URL.Path == "/projects/open":
+		g.handleOpen(w, r)
+	case strings.HasPrefix(r.URL.Path, "/p/"):
+		g.handleProxy(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (g *Gateway) authorized(r *http.Request) bool {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	if !strings.HasPrefix(auth, "Bearer ") {
+		return false
+	}
+	given := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
+	if given == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(given), []byte(g.token)) == 1
+}
+
+func (g *Gateway) handleManifest(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, g.mgr.Projects())
+}
+
+func (g *Gateway) handleOpen(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.ID) == "" {
+		http.Error(w, `missing "id"`, http.StatusBadRequest)
+		return
+	}
+	if err := g.mgr.Open(strings.TrimSpace(body.ID)); err != nil {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]string{"status": "running"})
+}
+
+// handleProxy routes /p/<id>/<rest> to the project's serve, lazily spawning
+// it on first use, stripping the /p/<id> prefix before forwarding.
+func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/p/")
+	id, tail, ok := strings.Cut(rest, "/")
+	if !ok {
+		http.Error(w, "project route must be /p/<id>/...", http.StatusBadRequest)
+		return
+	}
+	id = strings.TrimSpace(id)
+	if err := g.mgr.Open(id); err != nil {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+	g.mgr.Touch(id)
+	port := g.mgr.Port(id)
+	if port == 0 {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]string{"error": "project serve not ready"})
+		return
+	}
+	proxy := g.proxyFor(id, port)
+	// Rewrite the incoming request onto the target path (prefix stripped).
+	out := r.Clone(r.Context())
+	out.URL.Path = "/" + tail
+	if out.URL.RawPath != "" {
+		out.URL.RawPath = "/" + strings.TrimPrefix(out.URL.RawPath, "/p/"+id+"/")
+	}
+	// Forward the per-project token so the serve's auth=token accepts us.
+	if tok := g.mgr.Token(id); tok != "" {
+		out.Header.Set("Authorization", "Bearer "+tok)
+	}
+	proxy.ServeHTTP(w, out)
+}
+
+func (g *Gateway) proxyFor(id string, port int) *httputil.ReverseProxy {
+	if p, ok := g.proxy[id]; ok {
+		return p
+	}
+	target, _ := url.Parse("http://127.0.0.1:" + itoa(port))
+	p := httputil.NewSingleHostReverseProxy(target)
+	p.Director = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+	}
+	g.proxy[id] = p
+	return p
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	writeJSONStatus(w, http.StatusOK, v)
+}
+
+func writeJSONStatus(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/servepool/servepool.go
+++ b/internal/servepool/servepool.go
@@ -1,0 +1,356 @@
+// Package servepool manages a pool of per-project `reasonix serve`
+// sub-processes behind a single-entry HTTP gateway for remote clients
+// (#8983). Serves are spawned lazily (first request for a stopped project),
+// bind 127.0.0.1 with random ports, and are reclaimed after an idle window.
+package servepool
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Config controls the pool.
+type Config struct {
+	// ReasonixBin is the binary used to spawn serve sub-processes. Defaults
+	// to os.Executable() (the desktop process is reasonix itself).
+	ReasonixBin string
+	// PortFileDir is where per-project serve.port / serve.token files are
+	// written; defaults to the project's .reasonix directory.
+	PortFileDir string
+	// IdleTimeout is how long a project serve may sit without traffic before
+	// being reclaimed. Default 15 minutes.
+	IdleTimeout time.Duration
+	// SpawnTimeout bounds waiting for a spawned serve to become ready.
+	// Default 8 seconds.
+	SpawnTimeout time.Duration
+	// ProjectRoots is the initial project list (desktop-projects.json roots
+	// or CLI config); RefreshProjects can update it later.
+	ProjectRoots []string
+}
+
+// ProjectState mirrors the manifest entry a remote client sees.
+type ProjectState struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Root    string `json:"root"`
+	State   string `json:"state"` // stopped | starting | running | degraded | failed
+	Sessions int   `json:"sessions,omitempty"`
+	Err     string `json:"err,omitempty"`
+}
+
+// Manager owns the pool. All methods are safe for concurrent use.
+type Manager struct {
+	cfg     Config
+	mu      sync.Mutex
+	bin     string
+	projects map[string]*project // keyed by project id (workspace slug)
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+type project struct {
+	state    string
+	root     string
+	id       string
+	cmd      *exec.Cmd
+	port     int
+	token    string
+	lastUse  time.Time
+	failures int
+	degradedUntil time.Time
+	err      string
+}
+
+// NewManager builds a pool manager with the given config.
+func NewManager(cfg Config) (*Manager, error) {
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = 15 * time.Minute
+	}
+	if cfg.SpawnTimeout == 0 {
+		cfg.SpawnTimeout = 8 * time.Second
+	}
+	bin := cfg.ReasonixBin
+	if bin == "" {
+		self, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("servepool: resolve own binary: %w", err)
+		}
+		bin = self
+	}
+	m := &Manager{
+		cfg:      cfg,
+		bin:      bin,
+		projects: map[string]*project{},
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	for _, root := range cfg.ProjectRoots {
+		m.addProjectLocked(root)
+	}
+	go m.loop()
+	return m, nil
+}
+
+// WorkspaceSlug mirrors config.WorkspaceSlug: the flat directory name used
+// as the stable project id (avoids importing internal/config into the pool).
+func WorkspaceSlug(root string) string {
+	root = filepath.Clean(root)
+	base := filepath.Base(root)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		base = "workspace"
+	}
+	return base
+}
+
+func (m *Manager) addProjectLocked(root string) {
+	root = filepath.Clean(root)
+	if root == "" {
+		return
+	}
+	id := WorkspaceSlug(root)
+	if _, ok := m.projects[id]; ok {
+		return
+	}
+	m.projects[id] = &project{state: "stopped", root: root, id: id}
+}
+
+// RefreshProjects replaces the project list, preserving running instances
+// and marking newly removed projects for stop on next reclaim.
+func (m *Manager) RefreshProjects(roots []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	seen := map[string]bool{}
+	for _, r := range roots {
+		r = filepath.Clean(r)
+		if r == "" {
+			continue
+		}
+		seen[WorkspaceSlug(r)] = true
+		m.addProjectLocked(r)
+	}
+	for id, p := range m.projects {
+		if !seen[id] && p.state == "stopped" {
+			delete(m.projects, id)
+		}
+	}
+}
+
+// Projects returns the manifest snapshot.
+func (m *Manager) Projects() []ProjectState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]ProjectState, 0, len(m.projects))
+	for _, p := range m.projects {
+		ps := ProjectState{ID: p.id, Root: p.root, State: p.state, Err: p.err}
+		if p.port > 0 {
+			ps.Name = filepath.Base(p.root)
+		} else {
+			ps.Name = filepath.Base(p.root)
+		}
+		out = append(out, ps)
+	}
+	return out
+}
+
+// Open ensures the project's serve is running and returns its id. It blocks
+// until the serve is ready or the spawn times out.
+func (m *Manager) Open(id string) error {
+	m.mu.Lock()
+	p, ok := m.projects[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("servepool: unknown project %q", id)
+	}
+	switch p.state {
+	case "running", "starting":
+		p.lastUse = time.Now()
+		m.mu.Unlock()
+		return nil
+	case "degraded":
+		if time.Now().Before(p.degradedUntil) {
+			m.mu.Unlock()
+			return fmt.Errorf("servepool: project %q is degraded (rapid crashes); retry later", id)
+		}
+		p.state = "stopped"
+		p.failures = 0
+	}
+	p.state = "starting"
+	p.err = ""
+	m.mu.Unlock()
+	return m.spawn(p)
+}
+
+// Touch records activity for the project (idle-reclaim accounting).
+func (m *Manager) Touch(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.projects[id]; ok {
+		p.lastUse = time.Now()
+	}
+}
+
+// Port returns the bound port of a running project serve (0 when not running).
+func (m *Manager) Port(id string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.projects[id]; ok && p.state == "running" {
+		return p.port
+	}
+	return 0
+}
+
+// Token returns the per-project auth token (empty when not running).
+func (m *Manager) Token(id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if p, ok := m.projects[id]; ok {
+		return p.token
+	}
+	return ""
+}
+
+// Close stops every running serve and the manager loop.
+func (m *Manager) Close() {
+	close(m.stop)
+	<-m.done
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, p := range m.projects {
+		m.stopLocked(p)
+	}
+}
+
+func (m *Manager) stopLocked(p *project) {
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+		_, _ = p.cmd.Process.Wait()
+	}
+	p.cmd = nil
+	p.port = 0
+	p.token = ""
+	if p.state != "degraded" {
+		p.state = "stopped"
+	}
+	p.err = ""
+}
+
+// spawn starts the project's serve and waits for readiness.
+func (m *Manager) spawn(p *project) error {
+	portFile := filepath.Join(m.portFileDir(p.root), "serve.port")
+	tokenFile := filepath.Join(m.portFileDir(p.root), "serve.token")
+	if err := os.MkdirAll(filepath.Dir(portFile), 0o755); err != nil {
+		m.markFailed(p, fmt.Errorf("mkdir port dir: %w", err))
+		return err
+	}
+	token := newToken()
+	if err := os.WriteFile(tokenFile, []byte(token), 0o600); err != nil {
+		m.markFailed(p, fmt.Errorf("write token file: %w", err))
+		return err
+	}
+	cmd := exec.Command(m.bin,
+		"serve",
+		"--addr", "127.0.0.1:0",
+		"--port-file", portFile,
+		"--auth", "token",
+		"--token", token,
+	)
+	cmd.Dir = p.root
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		m.markFailed(p, fmt.Errorf("spawn serve: %w", err))
+		return err
+	}
+	p.cmd = cmd
+	p.token = token
+	deadline := time.Now().Add(m.cfg.SpawnTimeout)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(portFile); err == nil {
+			var port int
+			if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &port); err == nil && port > 0 {
+				m.mu.Lock()
+				p.port = port
+				p.state = "running"
+				p.lastUse = time.Now()
+				p.failures = 0
+				p.err = ""
+				m.mu.Unlock()
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+	p.cmd = nil
+	m.markFailed(p, fmt.Errorf("serve did not become ready within %s", m.cfg.SpawnTimeout))
+	return errors.New("servepool: " + p.err)
+}
+
+func (m *Manager) markFailed(p *project, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p.err = err.Error()
+	p.failures++
+	if p.failures >= 3 {
+		p.state = "degraded"
+		p.degradedUntil = time.Now().Add(5 * time.Minute)
+	} else {
+		p.state = "stopped"
+	}
+}
+
+func (m *Manager) portFileDir(root string) string {
+	if m.cfg.PortFileDir != "" {
+		return m.cfg.PortFileDir
+	}
+	return filepath.Join(root, ".reasonix")
+}
+
+// loop ticks health checks and idle reclamation.
+func (m *Manager) loop() {
+	defer close(m.done)
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+			m.sweep()
+		}
+	}
+}
+
+func (m *Manager) sweep() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	for _, p := range m.projects {
+		if p.state == "running" && now.Sub(p.lastUse) > m.cfg.IdleTimeout {
+			m.stopLocked(p)
+		}
+	}
+}
+
+// RandomToken returns a 32-byte hex gateway/per-project token.
+func RandomToken() string { return newToken() }
+
+// newToken returns a 32-byte hex gateway/per-project token.
+func newToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(err) // crypto/rand failure is unrecoverable
+	}
+	return hex.EncodeToString(b)
+}
+

--- a/internal/servepool/servepool_test.go
+++ b/internal/servepool/servepool_test.go
@@ -2,8 +2,10 @@ package servepool
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,7 +36,7 @@ func bearer(token string) map[string]string {
 
 func TestGatewayAuth(t *testing.T) {
 	m := newTestManager(t)
-	g := NewGateway(m, "secret")
+	g := NewGateway(m, "secret", nil)
 	ts := httptest.NewServer(g)
 	defer ts.Close()
 
@@ -66,7 +68,7 @@ func TestGatewayAuth(t *testing.T) {
 func TestGatewayManifestShape(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "proj")
 	m := newTestManager(t, root)
-	g := NewGateway(m, "s")
+	g := NewGateway(m, "s", nil)
 	ts := httptest.NewServer(g)
 	defer ts.Close()
 
@@ -88,7 +90,7 @@ func TestGatewayManifestShape(t *testing.T) {
 
 func TestGatewayOpenMissingID(t *testing.T) {
 	m := newTestManager(t)
-	g := NewGateway(m, "s")
+	g := NewGateway(m, "s", nil)
 	ts := httptest.NewServer(g)
 	defer ts.Close()
 
@@ -106,7 +108,7 @@ func TestGatewayOpenMissingID(t *testing.T) {
 
 func TestGatewayProxyMalformed(t *testing.T) {
 	m := newTestManager(t)
-	g := NewGateway(m, "s")
+	g := NewGateway(m, "s", nil)
 	ts := httptest.NewServer(g)
 	defer ts.Close()
 
@@ -182,5 +184,86 @@ func TestManagerIdleReclaim(t *testing.T) {
 	time.Sleep(120 * time.Millisecond)
 	if len(m.Projects()) != 0 {
 		t.Fatalf("projects = %d, want 0 after removal", len(m.Projects()))
+	}
+}
+
+
+// fakeHook records HandoffSession calls and returns a configurable error.
+type fakeHook struct {
+	calls int
+	err   error
+}
+
+func (f *fakeHook) HandoffSession(projectID, sessionName, targetWriterID string) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	return nil
+}
+
+func TestTakeoverRetryTransport(t *testing.T) {
+	backendCalls := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendCalls++
+		if backendCalls == 1 {
+			http.Error(w, `{"error":"session is held by another runtime"}`, http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+	u, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hook := &fakeHook{}
+	tr := &takeoverRetryTransport{base: http.DefaultTransport, hook: hook, projectID: "proj"}
+
+	// takeover-session 409 -> hook invoked -> retried once -> 204.
+	req, _ := http.NewRequest(http.MethodPost, u.String()+"/takeover-session", strings.NewReader(`{"name":"s1","from":"w1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 after handoff retry", resp.StatusCode)
+	}
+	if hook.calls != 1 {
+		t.Fatalf("hook calls = %d, want 1", hook.calls)
+	}
+	if backendCalls != 2 {
+		t.Fatalf("backend calls = %d, want 2 (409 + retry)", backendCalls)
+	}
+
+	// Non-takeover paths never invoke the hook.
+	backendCalls = 0
+	req2, _ := http.NewRequest(http.MethodGet, u.String()+"/sessions", nil)
+	resp2, err := tr.RoundTrip(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if hook.calls != 1 {
+		t.Fatalf("hook calls after plain request = %d, want still 1", hook.calls)
+	}
+
+	// Hook failure leaves the 409 untouched (no retry).
+	backendCalls = 0
+	hookErr := &fakeHook{err: errors.New("not held by this host")}
+	trErr := &takeoverRetryTransport{base: http.DefaultTransport, hook: hookErr, projectID: "proj"}
+	req3, _ := http.NewRequest(http.MethodPost, u.String()+"/takeover-session", strings.NewReader(`{"name":"s1","from":"w1"}`))
+	resp3, err := trErr.RoundTrip(req3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 when hook fails", resp3.StatusCode)
+	}
+	if backendCalls != 1 {
+		t.Fatalf("backend calls = %d, want 1 (no retry on hook failure)", backendCalls)
 	}
 }

--- a/internal/servepool/servepool_test.go
+++ b/internal/servepool/servepool_test.go
@@ -1,0 +1,186 @@
+package servepool
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestManager(t *testing.T, roots ...string) *Manager {
+	t.Helper()
+	m, err := NewManager(Config{
+		ReasonixBin:  "definitely-not-a-real-binary", // spawn always fails; exercises failure/degraded paths
+		ProjectRoots: roots,
+		IdleTimeout:  50 * time.Millisecond,
+		SpawnTimeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(m.Close)
+	return m
+}
+
+func bearer(token string) map[string]string {
+	if token == "" {
+		return map[string]string{}
+	}
+	return map[string]string{"Authorization": "Bearer " + token}
+}
+
+func TestGatewayAuth(t *testing.T) {
+	m := newTestManager(t)
+	g := NewGateway(m, "secret")
+	ts := httptest.NewServer(g)
+	defer ts.Close()
+
+	// Missing / wrong / correct token.
+	for name, hdr := range map[string]map[string]string{
+		"missing": bearer(""),
+		"wrong":   bearer("nope"),
+		"correct": bearer("secret"),
+	} {
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/manifest", nil)
+		for k, v := range hdr {
+			req.Header.Set(k, v)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		want := http.StatusUnauthorized
+		if name == "correct" {
+			want = http.StatusOK
+		}
+		if resp.StatusCode != want {
+			t.Fatalf("%s: status = %d, want %d", name, resp.StatusCode, want)
+		}
+	}
+}
+
+func TestGatewayManifestShape(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "proj")
+	m := newTestManager(t, root)
+	g := NewGateway(m, "s")
+	ts := httptest.NewServer(g)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/manifest", nil)
+	req.Header.Set("Authorization", "Bearer s")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out []ProjectState
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0].State != "stopped" || out[0].Root != filepath.Clean(root) {
+		t.Fatalf("manifest = %+v, want one stopped project", out)
+	}
+}
+
+func TestGatewayOpenMissingID(t *testing.T) {
+	m := newTestManager(t)
+	g := NewGateway(m, "s")
+	ts := httptest.NewServer(g)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/projects/open", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer s")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestGatewayProxyMalformed(t *testing.T) {
+	m := newTestManager(t)
+	g := NewGateway(m, "s")
+	ts := httptest.NewServer(g)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/p/", nil)
+	req.Header.Set("Authorization", "Bearer s")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestManagerUnknownProject(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.Open("nope"); err == nil {
+		t.Fatal("Open unknown project succeeded; want error")
+	}
+}
+
+func TestManagerRefreshProjects(t *testing.T) {
+	a := filepath.Join(t.TempDir(), "a")
+	b := filepath.Join(t.TempDir(), "b")
+	m := newTestManager(t, a)
+	if len(m.Projects()) != 1 {
+		t.Fatalf("projects = %d, want 1", len(m.Projects()))
+	}
+	m.RefreshProjects([]string{a, b})
+	if len(m.Projects()) != 2 {
+		t.Fatalf("after refresh = %d, want 2", len(m.Projects()))
+	}
+	m.RefreshProjects([]string{a})
+	if len(m.Projects()) != 1 {
+		t.Fatalf("after removal = %d, want 1", len(m.Projects()))
+	}
+}
+
+func TestManagerSpawnFailureAndDegraded(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "proj")
+	m := newTestManager(t, root)
+
+	// First open: spawn fails (fake binary) -> stopped with error.
+	if err := m.Open("proj"); err == nil {
+		t.Fatal("Open with failing binary succeeded; want error")
+	}
+	ps := m.Projects()
+	if ps[0].State != "stopped" || ps[0].Err == "" {
+		t.Fatalf("after first failure: %+v, want stopped+err", ps[0])
+	}
+
+	// Three consecutive failures -> degraded with a cooldown that refuses Open.
+	for i := 0; i < 2; i++ {
+		_ = m.Open("proj")
+	}
+	ps = m.Projects()
+	if ps[0].State != "degraded" {
+		t.Fatalf("state = %s, want degraded", ps[0].State)
+	}
+	if err := m.Open("proj"); err == nil {
+		t.Fatal("Open during degraded cooldown succeeded; want refusal")
+	}
+}
+
+func TestManagerIdleReclaim(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "proj")
+	m := newTestManager(t, root)
+	// Force the project into a "running-like" state is not possible without a
+	// real serve; verify the sweep path is safe on stopped projects and that
+	// a project removed by Refresh is gone after the sweep.
+	m.RefreshProjects(nil)
+	time.Sleep(120 * time.Millisecond)
+	if len(m.Projects()) != 0 {
+		t.Fatalf("projects = %d, want 0 after removal", len(m.Projects()))
+	}
+}


### PR DESCRIPTION
**TL;DR**: takeover 被占用时自动重试，复用 #8749 的会话所有权交接

## Summary

Mobile clients can now **take over a session the desktop app has open**, without any network IPC: the desktop-embedded gateway and the desktop are the same process, so a `takeover-session` 409 from a project serve is resolved in-process.

- **servepool**: `HostHook` interface + `takeoverRetryTransport` — a round-trip wrapper that buffers the takeover body, invokes the hook when the proxied serve answers 409, and retries once. Hook failure keeps the 409 intact for the client.
- **desktop**: implements `HostHook.HandoffSession(projectID, sessionName, targetWriterID)` — resolves to the absolute session path, `agent.TryReclaimCurrentProcessSessionLease` + `ReleaseForHandoff` (the #8749 reservation protocol).
- **standalone `serve --pool`** passes a nil hook (no desktop holder exists there; 409s stay untouched).
- **Security**: the hook only fires behind the gateway bearer-token gate, and only releases sessions this process itself holds — handoff-reservation semantics, never a silent steal; a running turn still rejects (409) via #8749's guard.

⚠️ **Stacked branch**: `feat/8987-session-takeover` is built on `feat/session-ownership-handoff` (#8749, lease handoff API) + `feat/8983-serve-pool-gateway` (#8994, servepool+gateway) + `feat/8995-serve-pool-cli` (#8996). Merge order: #8749 → #8994 → #8996 → this. The diff shrinks automatically as the lower PRs land.

English: 网关接管拦截——手机可接管桌面打开中的会话（同进程 hook，无网络 IPC）：takeover 409 → desktop ReleaseForHandoff → 网关重试。叠加分支（#8749→#8994→#8996→本 PR）。

## Issues

Fixes #8997
Refs #8749, #8983, #8995

## Verification

- `go test ./internal/servepool/` — 9/9 pass (incl. new TestTakeoverRetryTransport: 409→hook→204 retry, no hook on plain paths, hook-failure keeps 409)
- `go test ./internal/agent/ -run TestSessionLeaseHandoff` — pass (base #8749 intact)
- `cd desktop && go build ./...` — pass

## Documentation impact

Documentation-impact: none- internal authorization flow; no docs/*.md changed.

## Cache impact

Cache-impact: none- no prompt, tool schema, or provider request changes.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- @SivanCola — no system-prompt bytes change (gateway transport + desktop hook); explicit maintainer review requested.
