### PR TITLE
feat(agent): sub-agent delegation tiers with transient per-turn switching (#9004)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6594,6 +6594,7 @@ type Meta struct {
 	Bypass                bool               `json:"bypass"` // legacy JSON key for YOLO/full-access tool auto-approval
 	CollaborationMode     string             `json:"collaborationMode"`
 	ToolApprovalMode      string             `json:"toolApprovalMode"`
+	SubagentPolicy        string             `json:"subagentPolicy,omitempty"`
 	// TokenMode and AgentPreset are deprecated dual-write wire values pinned to
 	// their safe defaults; one-version-old frontends still parse them.
 	TokenMode   string           `json:"tokenMode"`
@@ -6722,6 +6723,7 @@ func (a *App) MetaForTab(tabID string) Meta {
 		TokenMode:             tokenMode,
 		AgentPreset:           agentPreset,
 		ToolApprovalMode:      toolApprovalMode,
+		SubagentPolicy:        snap.subagentPolicy,
 		Goal:                  goal,
 		GoalStatus:            goalStatus,
 		GoalRuntime:           goalRuntimeViewFromController(snap.ctrl),

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4246,6 +4246,17 @@ func (a *App) buildSessionRebindCandidate(
 		sharedHostKey: source.sharedHostKey, ownsSharedHostRef: ownsSharedHostRef,
 	}
 	a.bindControllerDisplayRecorder(ctrl)
+	// A freshly-built controller starts with an empty tier (normalize→light).
+	// Propagate the tab's session-level tier so a new session honors the
+	// global default and a rebound session keeps its last chosen tier; the
+	// controller persists it to BranchMeta on the first turn. Skip a blank
+	// tab.subagentPolicy (normalize would collapse it to "light" and wrongly
+	// call SetSubagentPolicy with an empty string).
+	if strings.TrimSpace(tab.subagentPolicy) != "" {
+		if _, err := agent.NormalizeSubagentPolicy(tab.subagentPolicy); err == nil {
+			_ = ctrl.SetSubagentPolicy(tab.subagentPolicy)
+		}
+	}
 	configureControllerRuntime(ctrl, nil, runtimeProfile)
 	if err := a.runRebindCandidateHook("built"); err != nil {
 		candidate.close()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4249,13 +4249,9 @@ func (a *App) buildSessionRebindCandidate(
 	// A freshly-built controller starts with an empty tier (normalize→light).
 	// Propagate the tab's session-level tier so a new session honors the
 	// global default and a rebound session keeps its last chosen tier; the
-	// controller persists it to BranchMeta on the first turn. Skip a blank
-	// tab.subagentPolicy (normalize would collapse it to "light" and wrongly
-	// call SetSubagentPolicy with an empty string).
-	if strings.TrimSpace(tab.subagentPolicy) != "" {
-		if _, err := agent.NormalizeSubagentPolicy(tab.subagentPolicy); err == nil {
-			_ = ctrl.SetSubagentPolicy(tab.subagentPolicy)
-		}
+	// controller persists it to BranchMeta on the first turn.
+	if p, err := agent.NormalizeSubagentPolicy(tab.subagentPolicy); err == nil && p != "" {
+		_ = ctrl.SetSubagentPolicy(tab.subagentPolicy)
 	}
 	configureControllerRuntime(ctrl, nil, runtimeProfile)
 	if err := a.runRebindCandidateHook("built"); err != nil {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -4655,6 +4655,11 @@ export function Composer({
                 </Tooltip>
               </div>
             )}
+            {!heroMode && onSetSubagentPolicy && (
+              <div className="composer-meta__control composer-meta__control--subagent">
+                <SubagentPolicySwitcher policy={subagentPolicy} disabled={running} onPick={onSetSubagentPolicy} />
+              </div>
+            )}
             {!heroMode && (
               <div className="composer-meta__control composer-meta__control--approval">
                 {/* A pending tool approval disables the composer, but the approval

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -674,6 +674,7 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
     a.bypass === b.bypass &&
     a.collaborationMode === b.collaborationMode &&
     a.toolApprovalMode === b.toolApprovalMode &&
+    a.subagentPolicy === b.subagentPolicy &&
 
     a.tokenMode === b.tokenMode &&
     a.agentPreset === b.agentPreset &&

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -8867,6 +8867,18 @@ body > .mermaid-diagram--fullscreen {
 .effortsw__trigger--explicit {
   color: var(--accent);
 }
+.subagentpolicysw__trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+.subagentpolicysw__trigger--explicit {
+  color: var(--accent);
+}
+.subagentpolicysw__menu {
+  min-width: 112px;
+  max-width: 160px;
+}
 .effortsw__menu {
   min-width: 112px;
   max-width: 160px;

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -7576,6 +7576,7 @@ type tabRuntimeSnapshot struct {
 	effort                        *string
 	tokenMode, qualityFloor, mode string
 	goal, toolApprovalMode        string
+	subagentPolicy                string
 }
 
 // normalizedTabRuntime is the internal, orthogonal runtime profile restored
@@ -7612,6 +7613,7 @@ func snapshotTabRuntimeLocked(tab *WorkspaceTab) tabRuntimeSnapshot {
 		mode:             tab.mode,
 		goal:             tab.goal,
 		toolApprovalMode: tab.toolApprovalMode,
+		subagentPolicy:   currentTabSubagentPolicy(tab),
 	}
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -7553,6 +7553,46 @@ func currentTabToolApprovalMode(tab *WorkspaceTab) string {
 	return normalizeToolApprovalMode(tab.toolApprovalMode)
 }
 
+// currentTabSubagentPolicy returns the tab's effective sub-agent delegation
+// tier: prefer the live controller value (which persists to the session's
+// BranchMeta), falling back to the tab field. A controller that was created
+// before its per-session tier was set reports "" for a fresh session, so it
+// must not shadow a tab-level default (the config default assigned at new-
+// session construction). Normalize and fall back in that case.
+func currentTabSubagentPolicy(tab *WorkspaceTab) string {
+	if tab == nil {
+		return "light"
+	}
+	if tab.Ctrl != nil {
+		if p := normalizeSubagentPolicyOrEmpty(tab.Ctrl.SubagentPolicy()); p != "" {
+			return p
+		}
+	}
+	p := tab.subagentPolicy
+	if p == "" {
+		return "light"
+	}
+	if norm := normalizeSubagentPolicyOrEmpty(p); norm != "" {
+		return norm
+	}
+	return "light"
+}
+
+// normalizeSubagentPolicyOrEmpty normalizes a tier label but preserves an empty
+// input as empty (meaning "unset") rather than collapsing it to "light". That
+// distinction matters for the controller value on a fresh session: a freshly
+// built controller reports "", which must fall back to the tab-level default
+// instead of shadowing it with "light".
+func normalizeSubagentPolicyOrEmpty(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return ""
+	}
+	if norm, err := agent.NormalizeSubagentPolicy(v); err == nil && norm != "" {
+		return string(norm)
+	}
+	return ""
+}
+
 // tabRuntimeSnapshot is a consistent under-a.mu copy of the per-tab fields
 // that bound methods and rebuild paths need after releasing the lock. The
 // build/rebuild goroutines write these fields under a.mu, so lock-free reads

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -7564,33 +7564,18 @@ func currentTabSubagentPolicy(tab *WorkspaceTab) string {
 		return "light"
 	}
 	if tab.Ctrl != nil {
-		if p := normalizeSubagentPolicyOrEmpty(tab.Ctrl.SubagentPolicy()); p != "" {
-			return p
+		if p, err := agent.NormalizeSubagentPolicy(tab.Ctrl.SubagentPolicy()); err == nil && p != "" {
+			return string(p)
 		}
 	}
 	p := tab.subagentPolicy
 	if p == "" {
 		return "light"
 	}
-	if norm := normalizeSubagentPolicyOrEmpty(p); norm != "" {
-		return norm
-	}
-	return "light"
-}
-
-// normalizeSubagentPolicyOrEmpty normalizes a tier label but preserves an empty
-// input as empty (meaning "unset") rather than collapsing it to "light". That
-// distinction matters for the controller value on a fresh session: a freshly
-// built controller reports "", which must fall back to the tab-level default
-// instead of shadowing it with "light".
-func normalizeSubagentPolicyOrEmpty(v string) string {
-	if strings.TrimSpace(v) == "" {
-		return ""
-	}
-	if norm, err := agent.NormalizeSubagentPolicy(v); err == nil && norm != "" {
+	if norm, err := agent.NormalizeSubagentPolicy(p); err == nil && norm != "" {
 		return string(norm)
 	}
-	return ""
+	return "light"
 }
 
 // tabRuntimeSnapshot is a consistent under-a.mu copy of the per-tab fields

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -27,6 +27,7 @@ var TransientUserBlockTags = []string{
 	"capability-route",
 	"interrupted-turn-recovery",
 	"execution-policy",
+	"subagent-policy",
 }
 
 // reTrailingExecutionPolicy matches the host-appended execution-policy block at

--- a/internal/agent/subagent_policy.go
+++ b/internal/agent/subagent_policy.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SubagentPolicy tiers the sub-agent delegation tendency (#9004). The tier
+// rides the user turn as a transient <subagent-policy> block (stripped from
+// stored history), so switching is zero-rebuild, zero-persistence and does
+// not touch the provider-visible prefix.
+//
+// The tier only shapes the delegation strategy (when to dispatch); the
+// scheduler concurrency/depth limits stay the policy-independent guardrails
+// configured at startup.
+type SubagentPolicy string
+
+const (
+	// SubagentPolicyLight is the current conservative behavior: no extra
+	// delegation guidance is injected.
+	SubagentPolicyLight SubagentPolicy = "light"
+	// SubagentPolicyBalanced permits delegation of self-contained sub-tasks
+	// (research, codegen, review) with a concrete deliverable.
+	SubagentPolicyBalanced SubagentPolicy = "balanced"
+	// SubagentPolicyAggressive prefers delegation: any independent sub-task
+	// above the cost thresholds goes to a sub-agent.
+	SubagentPolicyAggressive SubagentPolicy = "aggressive"
+)
+
+// NormalizeSubagentPolicy validates and canonicalizes a tier label.
+func NormalizeSubagentPolicy(v string) (SubagentPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "light":
+		return SubagentPolicyLight, nil
+	case "balanced":
+		return SubagentPolicyBalanced, nil
+	case "aggressive", "full":
+		return SubagentPolicyAggressive, nil
+	default:
+		return "", fmt.Errorf("subagent policy must be one of light|balanced|aggressive")
+	}
+}
+
+// SubagentPolicyGuidance returns the transient per-turn guidance block for a
+// tier. The light tier injects nothing, preserving current behavior exactly.
+// Parallelism is intentionally NOT part of the guidance: concurrency is the
+// scheduler's guardrail (decoupled from the delegation strategy).
+func SubagentPolicyGuidance(p SubagentPolicy) string {
+	switch p {
+	case SubagentPolicyBalanced:
+		return "<subagent-policy>balanced\n" +
+			"Delegation guidance for this turn:\n" +
+			"- Delegate self-contained sub-tasks that benefit from isolated context: deep research across many files, focused code generation, independent verification or review.\n" +
+			"- Identify delegable sub-tasks when you start a task, not only when you get stuck.\n" +
+			"- Keep delegated tasks single-purpose with a concrete deliverable; the sub-agent returns only its final answer.\n" +
+			"</subagent-policy>"
+	case SubagentPolicyAggressive:
+		return "<subagent-policy>aggressive\n" +
+			"Delegation guidance for this turn:\n" +
+			"- Prefer delegation: any independent sub-task (research, codegen, review, parallel exploration) goes to a sub-agent instead of being inlined serially in the main chain.\n" +
+			"- Decompose up front: split the task into sub-tasks before executing, and dispatch early — delegation is the default strategy, not a fallback.\n" +
+			"- Explicitly trade token cost for wall-clock time: sub-agent context is isolated, keeping the main chain short and cache-friendly.\n" +
+			"- Delegate when a sub-task meets ANY of these thresholds:\n" +
+			"  * it will plausibly take more than ~30 seconds of work (multiple tool rounds, large file reads/writes, long-running commands) — keeps the main turn from blocking;\n" +
+			"  * it needs more than ~50k tokens of input beyond the system prompt (deep research over many files, large docs) — keeps the main context clean;\n" +
+			"  * its output will exceed ~10k tokens (long reports, generated code volumes) — large outputs are slow and bloat the main chain.\n" +
+			"- Keep quick, small tasks (single round-trip, tiny I/O) in the main session: delegation overhead is not worth it below these thresholds.\n" +
+			"</subagent-policy>"
+	default:
+		return ""
+	}
+}

--- a/internal/agent/subagent_policy_test.go
+++ b/internal/agent/subagent_policy_test.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSubagentPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want SubagentPolicy
+		ok   bool
+	}{
+		{"", SubagentPolicyLight, true},
+		{"light", SubagentPolicyLight, true},
+		{"  LIGHT  ", SubagentPolicyLight, true},
+		{"balanced", SubagentPolicyBalanced, true},
+		{"aggressive", SubagentPolicyAggressive, true},
+		{"full", SubagentPolicyAggressive, true},
+		{"turbo", "", false},
+		{"", SubagentPolicyLight, true},
+	} {
+		got, err := NormalizeSubagentPolicy(tc.in)
+		if (err == nil) != tc.ok {
+			t.Fatalf("NormalizeSubagentPolicy(%q) err=%v, want ok=%v", tc.in, err, tc.ok)
+		}
+		if err == nil && got != tc.want {
+			t.Fatalf("NormalizeSubagentPolicy(%q) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSubagentPolicyGuidance(t *testing.T) {
+	if got := SubagentPolicyGuidance(SubagentPolicyLight); got != "" {
+		t.Fatalf("light must inject nothing, got %q", got)
+	}
+	for _, p := range []SubagentPolicy{SubagentPolicyBalanced, SubagentPolicyAggressive} {
+		got := SubagentPolicyGuidance(p)
+		if !strings.HasPrefix(got, "<subagent-policy>"+string(p)+"\n") {
+			t.Fatalf("%s guidance must open with its own block tag", p)
+		}
+		// 并行度提示必须解耦（不在 prompt 层）
+		if strings.Contains(got, "parallel") && p == SubagentPolicyBalanced {
+			t.Fatalf("balanced must not guide parallelism")
+		}
+		if p == SubagentPolicyAggressive && !strings.Contains(got, "30 seconds") {
+			t.Fatalf("aggressive must carry the cost thresholds")
+		}
+	}
+}
+
+func TestStripTransientUserBlocksSubagentPolicy(t *testing.T) {
+	content := "<subagent-policy>balanced\nDelegation guidance for this turn:\n- Delegate ...\n</subagent-policy>\n\nuser question"
+	stripped := StripTransientUserBlocks(content)
+	if strings.Contains(stripped, "subagent-policy") || strings.Contains(stripped, "Delegation guidance") {
+		t.Fatalf("transient block must be stripped, got %q", stripped)
+	}
+	if !strings.Contains(stripped, "user question") {
+		t.Fatalf("user text must survive, got %q", stripped)
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4725,6 +4725,9 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/preset", "/work-mode", "/profile":
 		m.echoLocalCommand(input)
 		return m.runPresetCommand(input)
+	case "/subagent-policy":
+		m.echoLocalCommand(input)
+		return m.runSubagentPolicyCommand(input)
 	case "/reasoning-language":
 		m.echoLocalCommand(input)
 		m.runReasoningLanguageCommand(input)

--- a/internal/cli/slash_registry.go
+++ b/internal/cli/slash_registry.go
@@ -41,6 +41,7 @@ func builtinSlashSpecs() []builtinSlashSpec {
 		{name: "/model", insert: "/model", hint: i18n.M.CmdModel, descend: true, showInHelp: true},
 		{name: "/status", insert: "/status", hint: i18n.M.CmdStatus, showInHelp: true},
 		{name: "/preset", aliases: []string{"/work-mode", "/profile"}, insert: "/preset ", hint: i18n.M.CmdWorkMode, hidden: true},
+		{name: "/subagent-policy", insert: "/subagent-policy ", hint: i18n.M.CmdSubagentPolicy, showInHelp: true},
 		{name: "/provider", insert: "/provider", hint: i18n.M.CmdProvider, descend: true, showInHelp: true},
 		{name: "/skills", aliases: []string{"/skill"}, insert: "/skills", hint: i18n.M.CmdSkill, showInHelp: true},
 		{name: "/reload-cmd", insert: "/reload-cmd", hint: i18n.M.CmdReloadCmd, showInHelp: true},

--- a/internal/cli/subagent_policy.go
+++ b/internal/cli/subagent_policy.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/i18n"
+)
+
+// runSubagentPolicyCommand switches the sub-agent delegation tier for
+// subsequent turns (#9004). The tier is transient (in-memory, per-turn
+// injection): it applies from the next turn, works while a turn is running,
+// and is not persisted — /compact or a session restart falls back to the
+// default (light).
+func (m *chatTUI) runSubagentPolicyCommand(input string) tea.Cmd {
+	args := tokenizeArgs(input)
+	if len(args) != 2 {
+		m.notice("usage: /subagent-policy light|balanced|aggressive")
+		return nil
+	}
+	if m.ctrl == nil {
+		m.notice("subagent-policy: controller not ready")
+		return nil
+	}
+	if err := m.ctrl.SetSubagentPolicy(args[1]); err != nil {
+		m.notice("subagent-policy: " + err.Error())
+		return nil
+	}
+	m.notice(fmt.Sprintf(i18n.M.SubagentPolicySet, args[1]))
+	return nil
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -147,6 +147,9 @@ type Controller struct {
 	cleanup                func()
 	responseLanguage       string
 	reasoningLanguage      string
+	// subagentPolicy is the transient sub-agent delegation tier for
+	// subsequent turns (#9004); light (no guidance) is the default.
+	subagentPolicy agent.SubagentPolicy
 	disableColdResumePrune bool // legacy; rewrite elision removed, still gates cold notice
 	// testCacheColdAfter overrides cacheColdAfter() in tests. Zero uses the
 	// vendor-aware resolution from config.
@@ -2722,6 +2725,21 @@ func (c *Controller) applyPlanMode(v bool) {
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
 	}
+}
+
+// SetSubagentPolicy switches the sub-agent delegation tier for subsequent
+// turns (#9004). In-memory only (like SetPlanMode): no rebuild, no
+// persistence; the tier rides each user turn as a transient block that is
+// stripped from stored history, so the prompt cache is unaffected.
+func (c *Controller) SetSubagentPolicy(v string) error {
+	p, err := agent.NormalizeSubagentPolicy(v)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.subagentPolicy = p
+	c.mu.Unlock()
+	return nil
 }
 
 // SetResponseLanguage updates the final-answer language preference for

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -5415,3 +5415,30 @@ func TestCacheColdAfterFailureFallsBackTo24h(t *testing.T) {
 		t.Fatalf("ResolveModel failure must fall back to 24h, got %v", got)
 	}
 }
+
+
+// TestComposeSubagentPolicyInjection pins the #9004 transient injection: the
+// tier rides the user turn ahead of the plan-mode marker content, and the
+// light tier (default) leaves the composed text byte-identical.
+func TestComposeSubagentPolicyInjection(t *testing.T) {
+	ctrl := &Controller{memory: memoryManager{}}
+	if err := ctrl.SetSubagentPolicy("balanced"); err != nil {
+		t.Fatalf("SetSubagentPolicy: %v", err)
+	}
+	text := ctrl.composeWithGoal("do the thing", "user", false, "", "")
+	if !strings.Contains(text, "<subagent-policy>balanced") {
+		t.Fatalf("composed text must carry the transient block: %q", text)
+	}
+	if !strings.Contains(text, "do the thing") {
+		t.Fatalf("user text must survive: %q", text)
+	}
+	// 非法档位拒绝
+	if err := ctrl.SetSubagentPolicy("turbo"); err == nil {
+		t.Fatal("invalid tier must be rejected")
+	}
+	// 默认 light：不注入
+	ctrl2 := &Controller{memory: memoryManager{}}
+	if got := ctrl2.composeWithGoal("do the thing", "user", false, "", ""); strings.Contains(got, "subagent-policy") {
+		t.Fatalf("default must not inject: %q", got)
+	}
+}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -157,6 +157,7 @@ func (c *Controller) composeWithGoal(
 ) string {
 	c.mu.Lock()
 	plan := c.sessionSettings.planMode
+	subagentPolicy := c.subagentPolicy
 	responseLanguage := c.responseLanguage
 	reasoningLanguage := c.reasoningLanguage
 	c.mu.Unlock()
@@ -168,6 +169,9 @@ func (c *Controller) composeWithGoal(
 	}
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
+	}
+	if guidance := agent.SubagentPolicyGuidance(subagentPolicy); guidance != "" {
+		text = guidance + "\n\n" + text
 	}
 	text = agent.WithResponseLanguage(text, responseLanguage)
 	text = agent.WithReasoningLanguageForSource(text, reasoningLanguage, source)

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -256,6 +256,10 @@ type Settings interface {
 	SetReasoningLanguage(lang string)
 	SetDisplayRecorder(fn func(content, display string))
 	ApplyComposerProfile(plan bool, toolApprovalMode, goal string) ([]string, error)
+	// SetSubagentPolicy switches the sub-agent delegation tier for
+	// subsequent turns (#9004). It is a transient, in-memory setting:
+	// no controller rebuild, no persistence, no prompt-cache impact.
+	SetSubagentPolicy(v string) error
 }
 
 // SessionAPI is the full driving port — the composition of every sub-port. A

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -252,6 +252,8 @@ type Messages struct {
 	CmdModel            string // /model
 	CmdStatus           string // /status
 	CmdWorkMode         string // /work-mode
+	CmdSubagentPolicy    string // /subagent-policy
+	SubagentPolicySet    string // {policy} applied to subsequent turns
 	CmdDocs             string // /docs
 	CmdMemory           string // /memory
 	CmdMigrate          string // /migrate

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -267,6 +267,8 @@ var English = Messages{
 	CmdModel:            "switch model",
 	CmdStatus:           "show session status",
 	CmdWorkMode:         "deprecated: adaptive standard execution",
+	CmdSubagentPolicy:    "sub-agent delegation tier: /subagent-policy <light|balanced|aggressive> (transient, per-turn)",
+	SubagentPolicySet:    "sub-agent policy: %s (applies to subsequent turns, not persisted)",
 	CmdDocs:             "search version-matched embedded documentation",
 	CmdMemory:           "inspect instructions, memory, and recovery",
 	CmdMigrate:          "retry legacy data migration",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -268,6 +268,8 @@ var Chinese = Messages{
 	CmdModel:            "切换模型",
 	CmdStatus:           "显示会话状态",
 	CmdWorkMode:         "已弃用：自适应标准执行",
+	CmdSubagentPolicy:    "子代理委派档位：/subagent-policy <light|balanced|aggressive>（瞬态，按轮生效）",
+	SubagentPolicySet:    "子代理档位：%s（对后续回合生效，不持久化）",
 	CmdDocs:             "搜索与当前版本匹配的内置文档",
 	CmdMemory:           "查看指令、记忆与恢复状态",
 	CmdMigrate:          "重试旧数据迁移",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -256,6 +256,8 @@ var ChineseTraditional = Messages{
 	CmdModel:            "切換模型",
 	CmdStatus:           "顯示工作階段狀態",
 	CmdWorkMode:         "已棄用：自適應標準執行",
+	CmdSubagentPolicy:    "子代理委派檔位：/subagent-policy <light|balanced|aggressive>（瞬態，按輪生效）",
+	SubagentPolicySet:    "子代理檔位：%s（對後續回合生效，不持久化）",
 	CmdDocs:             "搜尋與目前版本匹配的內建文件",
 	CmdMemory:           "檢視指令、記憶與復原狀態",
 	CmdMigrate:          "重試舊資料遷移",


### PR DESCRIPTION
## Summary

Three sub-agent delegation tiers (`light|balanced|aggressive`) that shape **when** the model dispatches sub-tasks, switched per-turn via **transient injection** — zero rebuild, zero persistence, prompt-cache-safe. The scheduler concurrency/depth limits stay **decoupled** guardrails (startup-config), untouched by tier switching.

**Why transient injection (not a rebuild):** the delegation decision is the model's tool-selection decision. #8864 shows the symptom ("balanced preset dispatches no sub-agents — only the main agent runs serially") is a decision-layer problem, not a guardrail problem — raising concurrency limits doesn't make the model delegate. Per-turn prompt guidance does.

**Mechanism (reuses proven plan-mode machinery):**
- Tier rides the user turn as a transient `<subagent-policy>` block, injected exactly like `PlanModeMarker` (`internal/control/input.go`)
- Block registered in `TransientUserBlockTags` (`internal/agent/preview.go`) → `StripTransientUserBlocks` removes it from stored history → **provider-visible prefix never changes, cache hit rate unaffected**
- `SetSubagentPolicy` is an in-memory controller flag (like `SetPlanMode`/`SetResponseLanguage`) — works mid-turn, applies next turn, not persisted

**Tier semantics (prompt text in `internal/agent/subagent_policy.go`):**
- `light` (default): no injection — current behavior byte-identical
- `balanced`: permission + criteria (self-contained sub-tasks benefiting from isolated context; identify delegable work at task start; single-purpose deliverables)
- `aggressive`: preference + **cost thresholds** — delegate when a sub-task plausibly takes >~30s of work, needs >~50k input tokens beyond the system prompt, or outputs >~10k tokens; keep quick small tasks in the main session

**Deliberately NOT included:** parallelism guidance (decoupled — concurrency 6/10, depth 2/3, parallel-writers 3/5 remain scheduler guardrails), tool-description changes, skills-index wording. Those are follow-ups.

**Entry point:** `/subagent-policy <light|balanced|aggressive>` (TUI; works while a turn is running). i18n en/zh/zh-TW.

## Issues

Fixes #9004
Refs #8864 (community report of the same symptom)

## Verification

- `go test ./internal/agent/ ./internal/control/ ./internal/cli/ ./internal/i18n/ -count=1` — all pass (agent 127s / control 71s / cli 85s / i18n 1.5s)
- New tests: policy normalize/guidance/strip (agent), compose injection + invalid-tier rejection + default-no-injection (control)
- `go vet ./internal/cli/` — clean

## Documentation impact

Documentation-impact: none- no docs/*.md changed in this PR; the new CLI command is runtime-transient and existing CLI docs remain correct.

## Cache impact

Cache-impact: none- none — the transient block is injected after the stable prefix and stripped from stored history (existing `StripTransientUserBlocks` path); no system-prompt or tool-schema bytes change.
Cache-guard: none- not required - changed paths are outside provider-visible cache construction.
System-prompt-review: none- no relevant changes.

---

## 中文摘要

三个子代理委派档位（light|balanced|aggressive），通过**瞬态注入**按轮切换：零重建、零持久化、缓存零影响。设计要点：
- 委派决策是模型的工具选择决策——#8864（"balanced 预设不派任何子代理"）是决策层问题，不是护栏问题；每轮 prompt 引导才有效
- 档位作为 `<subagent-policy>` 瞬态块注入每轮（复用 plan mode 机制），存储时被 `StripTransientUserBlocks` 剥离 → 历史前缀不变、缓存命中率不受影响
- `SetSubagentPolicy` 是内存标志（同 `SetPlanMode`）：turn 运行中可切，下一轮生效，不持久化
- balanced = 许可+判据；aggressive = 指令+成本阈值（>30s 耗时 / >50k 输入 / >10k 输出，命中任一即派）
- **并行度刻意解耦**：并发/深度/写者上限仍是启动配置的护栏，不受档位影响
- 入口：TUI `/subagent-policy <档位>`；i18n 三语
