### PR TITLE
fix(desktop): harden Linux window lifecycle recovery / 加固 Linux 桌面窗口生命周期恢复

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
       - name: Install Linux build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.0-dev xvfb
+          sudo apt-get install -y dbus-daemon gcc libgtk-3-dev libwebkit2gtk-4.0-dev xvfb
 
       - name: Build frontend
         run: |
@@ -443,7 +443,7 @@ jobs:
       - name: Install WebKitGTK 4.1 build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev xvfb
+          sudo apt-get install -y dbus-daemon gcc libgtk-3-dev libwebkit2gtk-4.1-dev xvfb
 
       - name: Build and test WebKitGTK 4.1 observer
         run: go test -tags webkit2_41 ./...

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -227,9 +227,17 @@ handled here, and what to reach for if a target misbehaves:
 - **Linux / WebKitGTK** is the one real pain point — rendering varies by distro &
   GPU driver. `main.go` keeps `WebviewGpuPolicy: OnDemand` when a DRI render node
   is usable, and falls back to `Never` for xrdp/headless/software-rendered sessions
-  that cannot access `/dev/dri`. If artifacts persist, launch with
-  `WEBKIT_DISABLE_COMPOSITING_MODE=1`. Test on at least one GTK target before release;
+  that cannot access `/dev/dri`. If the React + Wails heartbeat does not arrive,
+  Reasonix automatically restarts once with GPU acceleration and WebKit compositing
+  disabled; a per-version five-minute journal prevents restart loops. The manual
+  `WEBKIT_DISABLE_COMPOSITING_MODE=1` fallback remains supported. Test on at least
+  one GTK target before release;
   the CSS deliberately avoids `backdrop-filter`/blur (slow & inconsistent there).
+  Linux close-to-background is enabled only after a private DBus health probe
+  confirms a live StatusNotifierWatcher, a registered visual host, and this
+  process's registered StatusNotifierItem. If any of them disappears while the
+  main window is hidden, Reasonix presents the window again and later closes
+  normally until the tray recovers.
   - **Wayland + NVIDIA**: On KDE Plasma Wayland with NVIDIA GPUs, WebKitGTK can
     crash at startup (`Error 71: Protocol error`) due to an upstream WebKit
     explicit-sync bug (WebKit #280210, #317089, NVIDIA/egl-wayland #179).

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -294,6 +294,7 @@ type App struct {
 	desktopLocale       atomic.Int32
 	trayReady           bool
 	tray                *desktopTray
+	desktopShell        desktopShellRuntimeState
 	hangWatchdogMu      sync.Mutex
 	hangWatchdogCancel  context.CancelFunc
 
@@ -372,10 +373,17 @@ type App struct {
 	// never a rewritten or later same-version retry.
 	healthyUpdateCreatedAt     string
 	healthyUpdateTransactionID string
-	// startupReady records that the window reached domReady so LKG config
-	// snapshots and update health are only committed after a real UI boot.
+	// startupReady records that React rendered and the Wails bridge heartbeat
+	// succeeded. DOM navigation alone is not application health.
 	startupReady     atomic.Bool
 	webView2Recovery *webView2RecoveryCoordinator
+}
+
+type desktopShellRuntimeState struct {
+	coordinator   *desktopShellCoordinator
+	linuxRecovery *linuxWebKitRecoveryCoordinator
+	trayState     string
+	trayReason    string
 }
 
 type skillRootsCache struct {
@@ -412,7 +420,10 @@ func NewApp() *App {
 		remoteWindows:        newRemoteWindowRegistry(),
 		remoteWindowOwnerID:  newRemoteWindowOwnerID(),
 	}
+	a.desktopShell.trayState = "probing"
 	a.webView2Recovery = newWebView2RecoveryCoordinator(a)
+	a.desktopShell.linuxRecovery = newLinuxWebKitRecoveryCoordinator(a)
+	a.desktopShell.coordinator = newDesktopShellCoordinator(a)
 	a.workspaceHub = newWorkspaceChangeHub(a)
 	a.terminals = newTerminalManager(a)
 	a.botBridge = a.newBotBridge()
@@ -444,6 +455,7 @@ func (a *App) startup(ctx context.Context) {
 	initializeLifecycleDiagnostics(a)
 	a.startWindowsWebView2StartupFallback(ctx)
 	a.webView2Recovery.startGuidance(ctx)
+	a.desktopShell.coordinator.start(ctx)
 	a.lifecycle.tracker.markAsync("ready")
 	if a.remoteWindowTicket != "" {
 		// Remote web window child: no local tabs, tray, heartbeat, providers,
@@ -453,7 +465,6 @@ func (a *App) startup(ctx context.Context) {
 		return
 	}
 	installSystemQuitHook()
-	a.startTray()
 	a.enableDeferredRebuildRetry()
 	a.startHistoryIndexMigration()
 	a.goSafe("repairDesktopIconIntegration", func() {
@@ -512,6 +523,11 @@ func (a *App) beforeClose(ctx context.Context) bool {
 		a.backgroundMaximised.Store(a.lastKnownMaximised())
 		a.saveWindowStateSync()
 		a.snapshotAllTabs()
+		if a.desktopShell.coordinator != nil {
+			return a.desktopShell.coordinator.hideToBackground(ctx, func() bool {
+				return backgroundCloseUsesApplicationHide(goruntime.GOOS) || a.isTrayReady()
+			})
+		}
 		hideForBackground(ctx)
 		return true
 	}
@@ -621,20 +637,6 @@ func hideForBackground(ctx context.Context) {
 		return
 	}
 	runtime.WindowHide(ctx)
-}
-
-func showFromBackground(ctx context.Context, wasMaximised bool) {
-	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
-		runtime.Show(ctx)
-	}
-	plan := backgroundRestorePlanFor(goruntime.GOOS, wasMaximised)
-	if plan.maximiseBeforeShow {
-		runtime.WindowMaximise(ctx)
-	}
-	runtime.WindowShow(ctx)
-	if plan.unminimiseAfterShow {
-		runtime.WindowUnminimise(ctx)
-	}
 }
 
 func backgroundCloseUsesApplicationHide(goos string) bool {
@@ -855,9 +857,8 @@ func (a *App) shutdown(context.Context) {
 }
 
 // domReady is called (via OnDomReady) after the webview finishes loading its DOM
-// but before the window is shown (StartHidden). It restores the saved window
-// position and size, then calls WindowShow so the user never sees the default
-// size/position flash.
+// but before the StartHidden window is presented. It restores saved geometry,
+// then delegates presentation to the platform-aware shell coordinator.
 func (a *App) domReady(_ context.Context) {
 	// JSC has installed its lazy signal handlers by this point. Restore the
 	// SA_ONSTACK flags required by Go; this is a no-op outside Linux.
@@ -867,7 +868,9 @@ func (a *App) domReady(_ context.Context) {
 		a.domReadyRemoteWindow()
 		return
 	}
-	a.webView2Recovery.reportReady()
+	if a.desktopShell.coordinator != nil {
+		a.desktopShell.coordinator.markDOMReady()
+	}
 
 	state, ok := loadWindowState()
 	if ok {
@@ -897,10 +900,19 @@ func (a *App) domReady(_ context.Context) {
 	}
 
 	if ok && state.Maximised {
-		runtime.WindowMaximise(a.ctx)
+		if goruntime.GOOS == "windows" {
+			// Preserve the established Windows maximise -> show ordering through
+			// the unified presentation plan without appending SW_RESTORE.
+			a.backgroundMaximised.Store(true)
+		} else {
+			runtime.WindowMaximise(a.ctx)
+		}
 	}
 
-	runtime.WindowShow(a.ctx)
+	a.showMainWindowFrom("startup_dom_ready")
+}
+
+func (a *App) completeFrontendStartup() {
 	a.markDesktopHealthy()
 	ctx := a.ctx
 	a.goSafe("recordHealthyConfig", func() {
@@ -929,10 +941,25 @@ func (a *App) domReady(_ context.Context) {
 // native navigation completed; this bound call additionally proves that React
 // and the Wails bridge are responsive after a renderer reload.
 func (a *App) ReportDesktopWebViewReady() {
-	if a == nil || a.webView2Recovery == nil {
+	if a == nil || a.shuttingDown.Load() || a.forceQuit.Load() {
 		return
 	}
-	a.webView2Recovery.reportReady()
+	if a.webView2Recovery != nil {
+		a.webView2Recovery.reportReady()
+	}
+	a.reportLinuxWebKitFrontendReady()
+	if a.desktopShell.coordinator != nil {
+		first, healthy := a.desktopShell.coordinator.markFrontendHeartbeat(time.Now())
+		if first {
+			a.goSafe("startDesktopTrayAfterFrontendReady", func() { a.startTray() })
+		}
+		if healthy {
+			if a.desktopShell.linuxRecovery != nil {
+				a.desktopShell.linuxRecovery.frontendHealthy()
+			}
+			a.completeFrontendStartup()
+		}
+	}
 }
 
 func (a *App) commitPendingUpdateHealth() error {

--- a/desktop/crash_diagnostics_test.go
+++ b/desktop/crash_diagnostics_test.go
@@ -375,7 +375,8 @@ func resetFatalCrashArtifacts(t *testing.T) {
 
 func TestWindowRestoreFailureReportSeparatesTimeoutAndSource(t *testing.T) {
 	report := windowRestoreFailureReport("timeout", "second_instance", "2026-07-24T08:00:00Z")
-	if report.Label != "windows.window_restore.timeout" || report.TopFrame != "windows.window_restore.second_instance" {
+	platform := metricBucket(runtime.GOOS)
+	if report.Label != platform+".window_restore.timeout" || report.TopFrame != platform+".window_restore.second_instance" {
 		t.Fatalf("report = %+v", report)
 	}
 }

--- a/desktop/desktop_shell.go
+++ b/desktop/desktop_shell.go
@@ -229,15 +229,6 @@ func (c *desktopShellCoordinator) trayStateChanged(ready bool) {
 	}
 }
 
-func (c *desktopShellCoordinator) isBackgroundHidden() bool {
-	if c == nil {
-		return false
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.backgroundHidden
-}
-
 type desktopPresentAction uint8
 
 const (

--- a/desktop/desktop_shell.go
+++ b/desktop/desktop_shell.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	goruntime "runtime"
+	"sync"
+	"time"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+const (
+	desktopShellEvent = "desktop:shell-status"
+
+	desktopDOMReadyTimeout      = 3 * time.Second
+	desktopFrontendReadyTimeout = 15 * time.Second
+)
+
+type desktopShellPhase string
+
+const (
+	desktopShellStarting             desktopShellPhase = "starting"
+	desktopShellDOMReady             desktopShellPhase = "dom_ready"
+	desktopShellFrontendReady        desktopShellPhase = "frontend_ready"
+	desktopShellVisible              desktopShellPhase = "visible"
+	desktopShellBackgroundHidden     desktopShellPhase = "background_hidden"
+	desktopShellRendererRecovering   desktopShellPhase = "renderer_recovering"
+	desktopShellCompatibilityRestart desktopShellPhase = "compatibility_restart"
+	desktopShellFailed               desktopShellPhase = "failed"
+)
+
+// desktopShellCoordinator is the single owner of main-window lifecycle state.
+// Native window commands remain on the Wails runtime boundary, while every
+// startup, tray, second-instance, menu and watchdog presentation goes through
+// Present so platform ordering cannot drift again.
+type desktopShellCoordinator struct {
+	app *App
+
+	mu               sync.Mutex
+	phase            desktopShellPhase
+	domReady         bool
+	frontendReady    bool
+	frontendFirstAt  time.Time
+	healthy          bool
+	presented        bool
+	backgroundHidden bool
+	watchdogCancel   context.CancelFunc
+	presentOverride  func(string) // test-only, set before concurrent use
+}
+
+func newDesktopShellCoordinator(app *App) *desktopShellCoordinator {
+	return &desktopShellCoordinator{app: app, phase: desktopShellStarting}
+}
+
+func (c *desktopShellCoordinator) start(ctx context.Context) {
+	if c == nil || c.app == nil || c.app.remoteWindowTicket != "" {
+		return
+	}
+	c.mu.Lock()
+	if c.watchdogCancel != nil {
+		c.watchdogCancel()
+	}
+	watchdogCtx, cancel := context.WithCancel(ctx)
+	c.watchdogCancel = cancel
+	c.phase = desktopShellStarting
+	c.mu.Unlock()
+
+	c.app.goSafe("desktopDOMReadyWatchdog", func() {
+		timer := time.NewTimer(desktopDOMReadyTimeout)
+		defer timer.Stop()
+		select {
+		case <-watchdogCtx.Done():
+			return
+		case <-timer.C:
+		}
+		c.mu.Lock()
+		ready := c.domReady
+		c.mu.Unlock()
+		if !ready {
+			// A native surface is more useful than a StartHidden process with no
+			// visible recovery path, even when the renderer is still starting.
+			c.app.showMainWindowFrom("startup_dom_timeout")
+		}
+	})
+
+	c.app.goSafe("desktopFrontendReadyWatchdog", func() {
+		timer := time.NewTimer(desktopFrontendReadyTimeout)
+		defer timer.Stop()
+		select {
+		case <-watchdogCtx.Done():
+			return
+		case <-timer.C:
+		}
+		c.mu.Lock()
+		ready := c.frontendReady
+		if !ready {
+			c.phase = desktopShellRendererRecovering
+		}
+		c.mu.Unlock()
+		if !ready {
+			c.app.handleDesktopFrontendTimeout("startup")
+		}
+	})
+}
+
+func (c *desktopShellCoordinator) stop() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.watchdogCancel != nil {
+		c.watchdogCancel()
+		c.watchdogCancel = nil
+	}
+	c.mu.Unlock()
+}
+
+func (c *desktopShellCoordinator) markDOMReady() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.domReady = true
+	if c.presented {
+		c.phase = desktopShellVisible
+	} else if !c.frontendReady {
+		c.phase = desktopShellDOMReady
+	}
+	c.mu.Unlock()
+}
+
+// markFrontendHeartbeat separates the first React + Wails bridge frame from a
+// stable renderer. Health requires a later heartbeat at least two seconds
+// after the first, so one lucky bridge call cannot commit update/LKG state.
+func (c *desktopShellCoordinator) markFrontendHeartbeat(now time.Time) (first, healthy bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mu.Lock()
+	first = !c.frontendReady
+	c.frontendReady = true
+	if first {
+		c.frontendFirstAt = now
+	}
+	healthy = !c.healthy && !c.frontendFirstAt.IsZero() && now.Sub(c.frontendFirstAt) >= 2*time.Second
+	if healthy {
+		c.healthy = true
+	}
+	if c.backgroundHidden {
+		c.phase = desktopShellBackgroundHidden
+	} else if c.presented {
+		c.phase = desktopShellVisible
+	} else {
+		c.phase = desktopShellFrontendReady
+	}
+	if c.watchdogCancel != nil {
+		c.watchdogCancel()
+		c.watchdogCancel = nil
+	}
+	c.mu.Unlock()
+	return first, healthy
+}
+
+func (c *desktopShellCoordinator) markCompatibilityRestart() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.phase = desktopShellCompatibilityRestart
+	c.mu.Unlock()
+}
+
+func (c *desktopShellCoordinator) markFailed() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.phase = desktopShellFailed
+	c.mu.Unlock()
+}
+
+func (c *desktopShellCoordinator) Present(source string) {
+	if c == nil || c.app == nil || c.app.ctx == nil {
+		return
+	}
+	c.mu.Lock()
+	wasMaximised := c.app.backgroundMaximised.Swap(false)
+	applyDesktopPresentPlan(c.app.ctx, desktopPresentPlanFor(goruntime.GOOS, wasMaximised))
+	c.backgroundHidden = false
+	c.presented = true
+	c.phase = desktopShellVisible
+	c.mu.Unlock()
+	slog.Debug("desktop: present main window", "source", metricBucket(source), "platform", goruntime.GOOS)
+}
+
+// hideToBackground linearizes the final tray check with the hide transition.
+// If the tray disappears immediately afterwards, trayStateChanged waits for
+// this critical section and re-presents the now-hidden window.
+func (c *desktopShellCoordinator) hideToBackground(ctx context.Context, canHide func() bool) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if canHide != nil && !canHide() {
+		return false
+	}
+	c.backgroundHidden = true
+	c.presented = false
+	c.phase = desktopShellBackgroundHidden
+	hideForBackground(ctx)
+	return true
+}
+
+func (c *desktopShellCoordinator) trayStateChanged(ready bool) {
+	if c == nil || ready {
+		return
+	}
+	c.mu.Lock()
+	hidden := c.backgroundHidden
+	c.mu.Unlock()
+	if hidden {
+		if c.presentOverride != nil {
+			c.presentOverride("tray_unavailable")
+		} else {
+			c.app.showMainWindowFrom("tray_unavailable")
+		}
+	}
+}
+
+func (c *desktopShellCoordinator) isBackgroundHidden() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.backgroundHidden
+}
+
+type desktopPresentAction uint8
+
+const (
+	desktopPresentApplicationShow desktopPresentAction = iota + 1
+	desktopPresentMaximise
+	desktopPresentWindowShow
+	desktopPresentUnminimise
+)
+
+// desktopPresentPlanFor deliberately emits only gtk_window_present on Linux.
+// Wails maps WindowUnminimise to gtk_window_present; preceding it with
+// gtk_widget_show breaks maximised -> minimised restoration on GNOME (#7552).
+func desktopPresentPlanFor(goos string, wasMaximised bool) []desktopPresentAction {
+	if goos == "linux" {
+		return []desktopPresentAction{desktopPresentUnminimise}
+	}
+	actions := make([]desktopPresentAction, 0, 3)
+	if goos == "darwin" {
+		actions = append(actions, desktopPresentApplicationShow)
+	}
+	if wasMaximised && goos != "darwin" {
+		actions = append(actions, desktopPresentMaximise, desktopPresentWindowShow)
+		return actions
+	}
+	return append(actions, desktopPresentWindowShow, desktopPresentUnminimise)
+}
+
+func applyDesktopPresentPlan(ctx context.Context, actions []desktopPresentAction) {
+	for _, action := range actions {
+		switch action {
+		case desktopPresentApplicationShow:
+			wailsruntime.Show(ctx)
+		case desktopPresentMaximise:
+			wailsruntime.WindowMaximise(ctx)
+		case desktopPresentWindowShow:
+			wailsruntime.WindowShow(ctx)
+		case desktopPresentUnminimise:
+			wailsruntime.WindowUnminimise(ctx)
+		}
+	}
+}

--- a/desktop/desktop_shell_status.go
+++ b/desktop/desktop_shell_status.go
@@ -1,0 +1,65 @@
+package main
+
+import goruntime "runtime"
+
+type DesktopShellStatusView struct {
+	TrayState                string `json:"trayState"`
+	BackgroundCloseAvailable bool   `json:"backgroundCloseAvailable"`
+	Reason                   string `json:"reason,omitempty"`
+}
+
+func (a *App) GetDesktopShellStatus() DesktopShellStatusView {
+	if a == nil {
+		return DesktopShellStatusView{TrayState: "unavailable", Reason: "shell_unavailable"}
+	}
+	a.mu.RLock()
+	state := a.desktopShell.trayState
+	reason := a.desktopShell.trayReason
+	ready := a.trayReady
+	a.mu.RUnlock()
+	if state == "" {
+		state = "probing"
+	}
+	return DesktopShellStatusView{
+		TrayState:                state,
+		BackgroundCloseAvailable: backgroundCloseUsesApplicationHide(goruntime.GOOS) || ready,
+		Reason:                   reason,
+	}
+}
+
+func (a *App) setTrayHealth(t *desktopTray, state, reason string) {
+	if a == nil {
+		return
+	}
+	if state != "probing" && state != "ready" && state != "unavailable" {
+		state = "unavailable"
+		reason = "invalid_state"
+	}
+	ready := state == "ready"
+	a.mu.Lock()
+	if t != nil && a.tray != t {
+		a.mu.Unlock()
+		return
+	}
+	changed := a.desktopShell.trayState != state || a.desktopShell.trayReason != reason || a.trayReady != ready
+	a.desktopShell.trayState = state
+	a.desktopShell.trayReason = reason
+	a.trayReady = ready
+	ctx := a.ctx
+	a.mu.Unlock()
+
+	if ready && t != nil {
+		t.markReady()
+	}
+	if changed {
+		bucket := reason
+		if ready {
+			bucket = "ready"
+		}
+		a.recordDiagnosticMetric("desktop_tray", metricBucket(bucket))
+		if a.desktopShell.coordinator != nil && !a.shuttingDown.Load() && !a.forceQuit.Load() {
+			a.desktopShell.coordinator.trayStateChanged(ready)
+		}
+		a.runtimeEvents.Emit(ctx, desktopShellEvent, a.GetDesktopShellStatus())
+	}
+}

--- a/desktop/desktop_shell_test.go
+++ b/desktop/desktop_shell_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDesktopPresentPlanUsesGtkPresentOnlyOnLinux(t *testing.T) {
+	if got, want := desktopPresentPlanFor("linux", true), []desktopPresentAction{desktopPresentUnminimise}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("linux present actions = %v, want %v", got, want)
+	}
+	if got, want := desktopPresentPlanFor("linux", false), []desktopPresentAction{desktopPresentUnminimise}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("linux normal present actions = %v, want %v", got, want)
+	}
+}
+
+func TestDesktopPresentPlanPreservesWindowsAndMacOrdering(t *testing.T) {
+	tests := []struct {
+		name      string
+		goos      string
+		maximised bool
+		want      []desktopPresentAction
+	}{
+		{name: "windows maximised", goos: "windows", maximised: true, want: []desktopPresentAction{desktopPresentMaximise, desktopPresentWindowShow}},
+		{name: "windows normal", goos: "windows", want: []desktopPresentAction{desktopPresentWindowShow, desktopPresentUnminimise}},
+		{name: "mac", goos: "darwin", maximised: true, want: []desktopPresentAction{desktopPresentApplicationShow, desktopPresentWindowShow, desktopPresentUnminimise}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := desktopPresentPlanFor(tt.goos, tt.maximised); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("actions = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDesktopShellFrontendReadyIsSeparateFromDOMReady(t *testing.T) {
+	shell := newDesktopShellCoordinator(&App{})
+	shell.markDOMReady()
+	if shell.frontendReady {
+		t.Fatal("DOM readiness must not imply frontend readiness")
+	}
+	first, healthy := shell.markFrontendHeartbeat(time.Unix(10, 0))
+	if !first || healthy {
+		t.Fatal("first bridge heartbeat should transition frontend readiness")
+	}
+	if first, healthy = shell.markFrontendHeartbeat(time.Unix(11, 0)); first || healthy {
+		t.Fatal("an immediate later heartbeat must not commit stable health")
+	}
+	if first, healthy = shell.markFrontendHeartbeat(time.Unix(13, 0)); first || !healthy {
+		t.Fatal("a later heartbeat should commit stable health once")
+	}
+	if first, healthy = shell.markFrontendHeartbeat(time.Unix(16, 0)); first || healthy {
+		t.Fatal("later heartbeats must not recommit process health")
+	}
+}
+
+func TestDesktopShellHeartbeatPreservesVisiblePhase(t *testing.T) {
+	shell := newDesktopShellCoordinator(&App{})
+	shell.mu.Lock()
+	shell.presented = true
+	shell.phase = desktopShellVisible
+	shell.mu.Unlock()
+
+	shell.markDOMReady()
+	shell.markFrontendHeartbeat(time.Unix(10, 0))
+	shell.mu.Lock()
+	defer shell.mu.Unlock()
+	if shell.phase != desktopShellVisible {
+		t.Fatalf("visible shell phase = %q, want %q", shell.phase, desktopShellVisible)
+	}
+}
+
+func TestTrayLossWhileBackgroundHiddenRequestsPresentation(t *testing.T) {
+	app := NewApp()
+	called := make(chan string, 1)
+	app.desktopShell.coordinator.presentOverride = func(source string) { called <- source }
+	app.desktopShell.coordinator.backgroundHidden = true
+	tray := newDesktopTray()
+	app.mu.Lock()
+	app.tray = tray
+	app.trayReady = true
+	app.desktopShell.trayState = "ready"
+	app.mu.Unlock()
+
+	app.setTrayHealth(tray, "unavailable", "no_host")
+	select {
+	case source := <-called:
+		if source != "tray_unavailable" {
+			t.Fatalf("presentation source = %q", source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tray loss did not request presentation")
+	}
+	status := app.GetDesktopShellStatus()
+	if status.TrayState != "unavailable" || status.Reason != "no_host" {
+		t.Fatalf("shell status = %+v", status)
+	}
+}
+
+func TestEvaluateStatusNotifierSnapshot(t *testing.T) {
+	const item = "org.kde.StatusNotifierItem-42-1"
+	tests := []struct {
+		name   string
+		state  statusNotifierSnapshot
+		ready  bool
+		reason string
+	}{
+		{name: "no watcher", reason: "no_watcher"},
+		{name: "no host", state: statusNotifierSnapshot{WatcherOwner: ":1.2"}, reason: "no_host"},
+		{name: "item has no owner", state: statusNotifierSnapshot{WatcherOwner: ":1.2", Host: true}, reason: "item_no_owner"},
+		{name: "item absent", state: statusNotifierSnapshot{WatcherOwner: ":1.2", Host: true, ItemOwner: ":1.9"}, reason: "item_not_registered"},
+		{name: "well-known registered", state: statusNotifierSnapshot{WatcherOwner: ":1.2", Host: true, ItemOwner: ":1.9", Items: []string{item + "/StatusNotifierItem"}}, ready: true},
+		{name: "unique owner registered", state: statusNotifierSnapshot{WatcherOwner: ":1.2", Host: true, ItemOwner: ":1.9", Items: []string{":1.9/StatusNotifierItem"}}, ready: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ready, reason := evaluateStatusNotifierSnapshot(tt.state, item)
+			if ready != tt.ready || reason != tt.reason {
+				t.Fatalf("evaluate = (%v, %q), want (%v, %q)", ready, reason, tt.ready, tt.reason)
+			}
+		})
+	}
+}
+
+func TestLinuxRendererCompatibilityRestartJournalPreventsLoop(t *testing.T) {
+	oldVersion := version
+	version = "journal-test"
+	oldCompatibility := os.Getenv(linuxRendererCompatibilityEnv)
+	_ = os.Unsetenv(linuxRendererCompatibilityEnv)
+	t.Cleanup(func() {
+		version = oldVersion
+		_ = os.Setenv(linuxRendererCompatibilityEnv, oldCompatibility)
+	})
+	_ = os.Remove(linuxRendererRecoveryJournalPath())
+	t.Cleanup(func() { _ = os.Remove(linuxRendererRecoveryJournalPath()) })
+	now := time.Now()
+	if !claimLinuxRendererCompatibilityRestart(now, "startup") {
+		t.Fatal("first compatibility restart was not claimed")
+	}
+	if claimLinuxRendererCompatibilityRestart(now.Add(time.Minute), "startup") {
+		t.Fatal("same-version restart loop was not blocked")
+	}
+	if !claimLinuxRendererCompatibilityRestart(now.Add(linuxRendererRecoveryWindow+time.Second), "startup") {
+		t.Fatal("restart was not allowed after the five-minute guard window")
+	}
+}
+
+func TestProcessEnvWithOverridesReplacesInsteadOfDuplicating(t *testing.T) {
+	got := processEnvWithOverrides([]string{"A=old", "B=kept", "A=duplicate"}, map[string]string{"A": "new", "C": "added"})
+	counts := map[string]int{}
+	values := map[string]string{}
+	for _, entry := range got {
+		for _, key := range []string{"A", "B", "C"} {
+			prefix := key + "="
+			if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+				counts[key]++
+				values[key] = entry[len(prefix):]
+			}
+		}
+	}
+	if counts["A"] != 1 || values["A"] != "new" || values["B"] != "kept" || values["C"] != "added" {
+		t.Fatalf("overridden environment = %v", got)
+	}
+}
+
+func TestWebKitReloadNeedsPostReloadFrontendHeartbeat(t *testing.T) {
+	app := NewApp()
+	recovery := app.desktopShell.linuxRecovery
+	recovery.nativeEvent(webKitNativeEvent{recovery: webKitRecoverySucceeded, generation: 7}, false)
+	recovery.mu.Lock()
+	pending := recovery.pendingEvent
+	recovery.mu.Unlock()
+	if pending == nil || pending.generation != 7 {
+		t.Fatal("native load-finished was incorrectly treated as complete recovery")
+	}
+
+	recovery.frontendReady()
+	recovery.mu.Lock()
+	pending = recovery.pendingEvent
+	recovery.mu.Unlock()
+	if pending != nil {
+		t.Fatal("post-reload frontend heartbeat did not complete recovery")
+	}
+}
+
+func TestWebKitRecoveryStopClearsPendingHeartbeat(t *testing.T) {
+	app := NewApp()
+	recovery := app.desktopShell.linuxRecovery
+	recovery.nativeEvent(webKitNativeEvent{recovery: webKitRecoverySucceeded, generation: 11}, false)
+	recovery.stop()
+
+	recovery.mu.Lock()
+	defer recovery.mu.Unlock()
+	if !recovery.stopped || recovery.pendingTimer != nil || recovery.pendingEvent != nil {
+		t.Fatalf("stopped recovery retained pending work: %+v", recovery)
+	}
+}

--- a/desktop/frontend/src/__tests__/desktop-close-behavior-hint.test.tsx
+++ b/desktop/frontend/src/__tests__/desktop-close-behavior-hint.test.tsx
@@ -1,0 +1,38 @@
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { DesktopCloseBehaviorHint } from "../components/DesktopCloseBehaviorHint";
+import type { AppBindings } from "../lib/bridge";
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+window.go = {
+  main: {
+    App: {
+      GetDesktopShellStatus: async () => ({
+        trayState: "unavailable",
+        backgroundCloseAvailable: false,
+        reason: "no_host",
+      }),
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+await act(async () => {
+  root.render(<DesktopCloseBehaviorHint backgroundSelected hint="Keep running after close." unavailableHint="Closing this time will quit." />);
+  await Promise.resolve();
+});
+if (rootElement.textContent !== "Keep running after close.Closing this time will quit.") {
+  throw new Error(`unexpected close fallback hint: ${JSON.stringify(rootElement.textContent)}`);
+}
+await act(async () => root.unmount());
+console.log("desktop close behavior hint: ok");

--- a/desktop/frontend/src/components/DesktopCloseBehaviorHint.tsx
+++ b/desktop/frontend/src/components/DesktopCloseBehaviorHint.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { app, type DesktopShellStatusView } from "../lib/bridge";
+
+export function DesktopCloseBehaviorHint({
+  backgroundSelected,
+  hint,
+  unavailableHint,
+}: {
+  backgroundSelected: boolean;
+  hint: string;
+  unavailableHint: string;
+}) {
+  const [status, setStatus] = useState<DesktopShellStatusView | null>(null);
+  useEffect(() => {
+    let active = true;
+    const update = (value: unknown) => {
+      if (!active || !value || typeof value !== "object") return;
+      const candidate = value as Partial<DesktopShellStatusView>;
+      setStatus({
+        trayState: candidate.trayState === "ready" || candidate.trayState === "unavailable" ? candidate.trayState : "probing",
+        backgroundCloseAvailable: candidate.backgroundCloseAvailable === true,
+        reason: typeof candidate.reason === "string" ? candidate.reason : undefined,
+      });
+    };
+    const getStatus = app.GetDesktopShellStatus;
+    if (typeof getStatus === "function") void getStatus.call(app).then(update).catch(() => undefined);
+    const off = window.runtime?.EventsOn("desktop:shell-status", update);
+    return () => {
+      active = false;
+      off?.();
+    };
+  }, []);
+  if (!backgroundSelected || !status || status.backgroundCloseAvailable) return hint;
+  return <>{hint}<br />{unavailableHint}</>;
+}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -76,6 +76,7 @@ import { ModalCloseButton } from "./ModalCloseButton";
 import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 import { SettingsNavigation, SETTINGS_NAV_TABS } from "./SettingsNavigation";
 import { StatusBarItemsEditor } from "./StatusBarItemsEditor";
+import { DesktopCloseBehaviorHint } from "./DesktopCloseBehaviorHint";
 export type SettingsInitialFocus =
   | { target: "bot-allowlist"; connectionId?: string; requestId?: number }
   | { target: "model-access"; requestId?: number }
@@ -1592,7 +1593,6 @@ function thinkingModeLabel(mode: string, t: ReturnType<typeof useT>): string {
       return t("settings.thinkingMode.auto");
   }
 }
-
 function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agentRunning: boolean }) {
   const { t, setPref } = useI18n();
   const closeBehavior = normalizeCloseBehavior(s.closeBehavior);
@@ -1739,7 +1739,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
       </SettingsSection>
 
       <SettingsSection title={t("settings.general.sectionSystem")} description={t("settings.general.sectionSystemHint")}>
-      <SettingsField label={t("settings.closeBehavior")} hint={t("settings.closeBehaviorHint")} icon={<Power size={18} />}>
+      <SettingsField label={t("settings.closeBehavior")} hint={<DesktopCloseBehaviorHint backgroundSelected={closeBehavior === "background"} hint={t("settings.closeBehaviorHint")} unavailableHint={t("settings.closeBehaviorUnavailable")} />} icon={<Power size={18} />}>
         <div className="set-seg">
           {(["background", "quit"] as const).map((mode) => (
             <button

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -129,6 +129,12 @@ import type {
   WorkspaceView,
   SessionClearResult,
 } from "./types";
+
+export interface DesktopShellStatusView {
+  trayState: "probing" | "ready" | "unavailable";
+  backgroundCloseAvailable: boolean;
+  reason?: string;
+}
 import type { MarkdownImageView } from "./markdownImage";
 const GLOBAL_PROJECT_ORDER_KEY = "__global__";
 
@@ -555,6 +561,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   GetDesktopZoomFactor(): Promise<number>;
   RestartApplication(): Promise<void>;
   ReportDesktopWebViewReady(): Promise<void>;
+  GetDesktopShellStatus(): Promise<DesktopShellStatusView>;
   SetDesktopCheckUpdates(enabled: boolean): Promise<void>;
   SetDesktopUpdateChannel(channel: string): Promise<void>;
   SetDesktopTelemetry(enabled: boolean): Promise<void>;
@@ -4846,6 +4853,9 @@ function makeMockApp(): AppBindings {
         },
         async ReportDesktopWebViewReady() {
           // no-op in mock
+        },
+        async GetDesktopShellStatus() {
+          return { trayState: "ready", backgroundCloseAvailable: true } as DesktopShellStatusView;
         },
         async SetDesktopCheckUpdates(enabled: boolean) {
           settings.checkUpdates = enabled;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1701,6 +1701,7 @@ export const en = {
   "settings.shortcutsEnterOnly": "{action} only supports Enter with optional modifier keys.",
   "settings.closeBehavior": "When closing window",
   "settings.closeBehaviorHint": "Choose whether Reasonix keeps running after its main window closes.",
+  "settings.closeBehaviorUnavailable": "The system tray is unavailable; closing this time will quit Reasonix.",
   "settings.closeBehavior.background": "Keep running",
   "settings.closeBehavior.quit": "Quit Reasonix",
   "settings.desktopLayoutStyle": "Desktop style",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1339,6 +1339,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.shortcutsEnterOnly": "{action} 僅支援 Enter 與可選修飾鍵的組合。",
   "settings.closeBehavior": "關閉視窗時",
   "settings.closeBehaviorHint": "選擇關閉主視窗後 Reasonix 是否繼續執行。",
+  "settings.closeBehaviorUnavailable": "系統匣目前不可用，本次關閉將退出 Reasonix。",
   "settings.closeBehavior.background": "保持背景執行",
   "settings.closeBehavior.quit": "退出 Reasonix",
   "settings.desktopLayoutStyle": "桌面風格",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1703,6 +1703,7 @@ export const zh: Record<DictKey, string> = {
   "settings.shortcutsEnterOnly": "{action} 仅支持 Enter 与可选修饰键的组合。",
   "settings.closeBehavior": "关闭窗口时",
   "settings.closeBehaviorHint": "选择关闭主窗口后 Reasonix 是否继续运行。",
+  "settings.closeBehaviorUnavailable": "系统托盘当前不可用，本次关闭将退出 Reasonix。",
   "settings.closeBehavior.background": "保持后台运行",
   "settings.closeBehavior.quit": "退出 Reasonix",
   "settings.desktopLayoutStyle": "桌面风格",

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -13,7 +13,7 @@ require reasonix v0.0.0
 
 require (
 	aead.dev/minisign v0.3.0
-	fyne.io/systray v1.12.2
+	fyne.io/systray v1.12.3-0.20260814134402-f60f01be81c6
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.10.1

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -1,7 +1,7 @@
 aead.dev/minisign v0.3.0 h1:8Xafzy5PEVZqYDNP60yJHARlW1eOQtsKNp/Ph2c0vRA=
 aead.dev/minisign v0.3.0/go.mod h1:NLvG3Uoq3skkRMDuc3YHpWUTMTrSExqm+Ij73W13F6Y=
-fyne.io/systray v1.12.2 h1:Y8DZxgLHsVQt6rY9Zrkkg+j67S7vv/1F2viOWKPpVeA=
-fyne.io/systray v1.12.2/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+fyne.io/systray v1.12.3-0.20260814134402-f60f01be81c6 h1:NA/PjWixk00cUFQZjMj0GRsTKm2D077n2yVvPEmCc30=
+fyne.io/systray v1.12.3-0.20260814134402-f60f01be81c6/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=

--- a/desktop/lifecycle_diagnostics.go
+++ b/desktop/lifecycle_diagnostics.go
@@ -137,7 +137,14 @@ func (a *App) releaseDesktopDiagnosticsOwnership() {
 }
 
 func initializeLifecycleDiagnostics(app *App) {
-	if app == nil || app.remoteWindowTicket != "" || !app.diagnosticsOwner {
+	if app == nil || app.remoteWindowTicket != "" {
+		return
+	}
+	// Native WebKit recovery is a reliability mechanism, not telemetry. Always
+	// install it; the flag only controls whether sanitized diagnostics upload.
+	telemetry := app.diagnosticsOwner && app.diagnosticsConfigLoaded && version != "dev" && app.diagnosticsTelemetry
+	installWebKitProcessObserver(app, telemetry)
+	if !app.diagnosticsOwner {
 		return
 	}
 	if !app.diagnosticsConfigLoaded || version == "dev" {
@@ -153,7 +160,6 @@ func initializeLifecycleDiagnostics(app *App) {
 		app.lifecycle.previousRun = legacy
 	}
 	app.lifecycle.previousRuns = tracker.consumePrevious(enabled)
-	installWebKitProcessObserver(app, enabled)
 	if enabled {
 		refreshWebRuntimeContext()
 	}

--- a/desktop/linux_renderer_recovery.go
+++ b/desktop/linux_renderer_recovery.go
@@ -1,0 +1,353 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+
+	"reasonix/internal/config"
+	"reasonix/internal/fileutil"
+)
+
+const (
+	linuxRendererCompatibilityEnv    = "REASONIX_WEBKIT_COMPATIBILITY_RESTART"
+	linuxRendererRecoveryParentEnv   = "REASONIX_WEBKIT_RECOVERY_PARENT_PID"
+	linuxDisableCompositingEnv       = "WEBKIT_DISABLE_COMPOSITING_MODE"
+	linuxRendererRecoveryWindow      = 5 * time.Minute
+	linuxRendererHeartbeatTimeout    = 10 * time.Second
+	linuxRendererRecoveryStateSchema = 1
+)
+
+type linuxRendererRecoveryJournal struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Version       string `json:"version"`
+	AttemptedAt   string `json:"attemptedAt"`
+	Source        string `json:"source"`
+	Outcome       string `json:"outcome,omitempty"`
+}
+
+var linuxRendererRecoveryJournalMu sync.Mutex
+
+type linuxWebKitRecoveryCoordinator struct {
+	app *App
+
+	mu                 sync.Mutex
+	pendingTimer       *time.Timer
+	pendingEvent       *webKitNativeEvent
+	pendingTelemetry   bool
+	restartRequested   bool
+	failureDialogShown bool
+	healthyRecorded    bool
+	stopped            bool
+}
+
+func newLinuxWebKitRecoveryCoordinator(app *App) *linuxWebKitRecoveryCoordinator {
+	return &linuxWebKitRecoveryCoordinator{app: app}
+}
+
+func linuxRendererCompatibilityMode() bool {
+	return goruntime.GOOS == "linux" && os.Getenv(linuxRendererCompatibilityEnv) == "1"
+}
+
+func prepareLinuxRendererCompatibilityEnvironment() {
+	waitForLinuxRendererRecoveryParent()
+	if linuxRendererCompatibilityMode() {
+		_ = os.Setenv(linuxDisableCompositingEnv, "1")
+	}
+}
+
+func waitForLinuxRendererRecoveryParent() {
+	if goruntime.GOOS != "linux" {
+		return
+	}
+	raw := os.Getenv(linuxRendererRecoveryParentEnv)
+	_ = os.Unsetenv(linuxRendererRecoveryParentEnv)
+	pid, err := strconv.Atoi(raw)
+	if err != nil || pid <= 0 || pid == os.Getpid() {
+		return
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for desktopProcessAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func linuxRendererRecoveryJournalPath() string {
+	return filepath.Join(config.MemoryUserDir(), "repair", "linux-renderer-recovery.json")
+}
+
+func readLinuxRendererRecoveryJournal() (linuxRendererRecoveryJournal, error) {
+	body, err := os.ReadFile(linuxRendererRecoveryJournalPath())
+	if err != nil {
+		return linuxRendererRecoveryJournal{}, err
+	}
+	var state linuxRendererRecoveryJournal
+	if err := json.Unmarshal(body, &state); err != nil {
+		return linuxRendererRecoveryJournal{}, err
+	}
+	return state, nil
+}
+
+func writeLinuxRendererRecoveryJournal(state linuxRendererRecoveryJournal) error {
+	body, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	path := linuxRendererRecoveryJournalPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return fileutil.AtomicWriteFileStrict(path, body, 0o600)
+}
+
+func claimLinuxRendererCompatibilityRestart(now time.Time, source string) bool {
+	linuxRendererRecoveryJournalMu.Lock()
+	defer linuxRendererRecoveryJournalMu.Unlock()
+	if linuxRendererCompatibilityMode() {
+		return false
+	}
+	if previous, err := readLinuxRendererRecoveryJournal(); err == nil && previous.Version == version {
+		if attemptedAt, err := time.Parse(time.RFC3339Nano, previous.AttemptedAt); err == nil && now.Sub(attemptedAt) < linuxRendererRecoveryWindow {
+			return false
+		}
+	}
+	state := linuxRendererRecoveryJournal{
+		SchemaVersion: linuxRendererRecoveryStateSchema,
+		Version:       version,
+		AttemptedAt:   now.UTC().Format(time.RFC3339Nano),
+		Source:        metricBucket(source),
+		Outcome:       "restarting",
+	}
+	return writeLinuxRendererRecoveryJournal(state) == nil
+}
+
+func recordLinuxRendererRecoveryOutcome(outcome string) {
+	linuxRendererRecoveryJournalMu.Lock()
+	defer linuxRendererRecoveryJournalMu.Unlock()
+	state, err := readLinuxRendererRecoveryJournal()
+	if err != nil || state.Version != version {
+		return
+	}
+	state.Outcome = metricBucket(outcome)
+	_ = writeLinuxRendererRecoveryJournal(state)
+}
+
+func (a *App) handleDesktopFrontendTimeout(source string) {
+	if a == nil || goruntime.GOOS != "linux" || a.desktopShell.linuxRecovery == nil {
+		return
+	}
+	a.desktopShell.linuxRecovery.requestCompatibilityRestart(source)
+}
+
+func (a *App) reportLinuxWebKitFrontendReady() {
+	if a == nil || a.desktopShell.linuxRecovery == nil {
+		return
+	}
+	a.desktopShell.linuxRecovery.frontendReady()
+}
+
+func (c *linuxWebKitRecoveryCoordinator) requestCompatibilityRestart(source string) {
+	if c == nil || c.app == nil || goruntime.GOOS != "linux" {
+		return
+	}
+	c.mu.Lock()
+	if c.stopped || c.restartRequested || c.app.shuttingDown.Load() || c.app.forceQuit.Load() {
+		c.mu.Unlock()
+		return
+	}
+	c.restartRequested = true
+	c.mu.Unlock()
+	if !c.canRun() {
+		return
+	}
+
+	// Present before any journal, relaunch or dialog work. A failed relaunch
+	// must still leave a native recovery surface instead of a headless process.
+	if c.app.desktopShell.coordinator != nil {
+		c.app.desktopShell.coordinator.Present("renderer_" + metricBucket(source))
+	}
+	if claimLinuxRendererCompatibilityRestart(time.Now(), source) {
+		if c.app.desktopShell.coordinator != nil {
+			c.app.desktopShell.coordinator.markCompatibilityRestart()
+		}
+		c.app.saveWindowStateSync()
+		c.app.snapshotAllTabs()
+		if !c.canRun() {
+			return
+		}
+		err := relaunchThroughLauncherWithEnv(map[string]string{
+			linuxRendererCompatibilityEnv:  "1",
+			linuxRendererRecoveryParentEnv: strconv.Itoa(os.Getpid()),
+			linuxDisableCompositingEnv:     "1",
+		})
+		if err == nil {
+			c.app.forceQuit.Store(true)
+			wailsruntime.Quit(c.app.ctx)
+			return
+		}
+		slog.Error("desktop: renderer compatibility relaunch failed", "err", err)
+		recordLinuxRendererRecoveryOutcome("relaunch_failed")
+	}
+	c.showCompatibilityFailure()
+}
+
+func (c *linuxWebKitRecoveryCoordinator) showCompatibilityFailure() {
+	if c == nil || c.app == nil || c.app.ctx == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.stopped || c.failureDialogShown {
+		c.mu.Unlock()
+		return
+	}
+	c.failureDialogShown = true
+	c.mu.Unlock()
+	if c.app.desktopShell.coordinator != nil {
+		c.app.desktopShell.coordinator.markFailed()
+	}
+	recordLinuxRendererRecoveryOutcome("failed")
+	result, err := wailsruntime.MessageDialog(c.app.ctx, wailsruntime.MessageDialogOptions{
+		Type:  wailsruntime.WarningDialog,
+		Title: "Reasonix renderer unavailable / Reasonix 渲染器不可用",
+		Message: "Reasonix could not confirm that the desktop interface is responsive, including in software-rendering compatibility mode. You can keep waiting or exit safely.\n\n" +
+			"Reasonix 无法确认桌面界面已恢复响应，软件渲染兼容模式也未通过检查。你可以继续等待，或安全退出。",
+		Buttons:       []string{"Keep waiting / 继续等待", "Exit / 退出"},
+		DefaultButton: "Keep waiting / 继续等待",
+		CancelButton:  "Keep waiting / 继续等待",
+	})
+	if err == nil && result == "Exit / 退出" {
+		c.app.forceQuit.Store(true)
+		wailsruntime.Quit(c.app.ctx)
+	}
+}
+
+func (c *linuxWebKitRecoveryCoordinator) nativeEvent(event webKitNativeEvent, telemetry bool) {
+	if c == nil || c.app == nil {
+		return
+	}
+	c.mu.Lock()
+	stopped := c.stopped
+	c.mu.Unlock()
+	if stopped {
+		return
+	}
+	if event.recovery != webKitRecoverySucceeded {
+		if telemetry {
+			c.app.recordWebKitNativeDiagnostic(event)
+		}
+		if event.recovery == webKitRecoveryFailed {
+			c.requestCompatibilityRestart("webkit_reload_failed")
+		}
+		return
+	}
+
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	if c.pendingTimer != nil {
+		c.pendingTimer.Stop()
+	}
+	pending := event
+	c.pendingEvent = &pending
+	c.pendingTelemetry = telemetry
+	c.pendingTimer = time.AfterFunc(linuxRendererHeartbeatTimeout, func() {
+		c.mu.Lock()
+		if c.pendingEvent == nil || c.pendingEvent.generation != event.generation {
+			c.mu.Unlock()
+			return
+		}
+		failed := *c.pendingEvent
+		failed.recovery = webKitRecoveryFailed
+		report := c.pendingTelemetry
+		c.pendingEvent = nil
+		c.pendingTelemetry = false
+		c.pendingTimer = nil
+		c.mu.Unlock()
+		if report {
+			c.app.recordWebKitNativeDiagnostic(failed)
+		}
+		c.requestCompatibilityRestart("webkit_heartbeat_timeout")
+	})
+	c.mu.Unlock()
+}
+
+func (c *linuxWebKitRecoveryCoordinator) frontendReady() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	pending := c.pendingEvent
+	report := c.pendingTelemetry
+	if c.pendingTimer != nil {
+		c.pendingTimer.Stop()
+	}
+	c.pendingTimer = nil
+	c.pendingEvent = nil
+	c.pendingTelemetry = false
+	c.mu.Unlock()
+	if pending != nil && report {
+		c.app.recordWebKitNativeDiagnostic(*pending)
+	}
+}
+
+func (c *linuxWebKitRecoveryCoordinator) frontendHealthy() {
+	if c == nil || !linuxRendererCompatibilityMode() {
+		return
+	}
+	c.mu.Lock()
+	if c.stopped || c.healthyRecorded {
+		c.mu.Unlock()
+		return
+	}
+	c.healthyRecorded = true
+	c.mu.Unlock()
+	recordLinuxRendererRecoveryOutcome("healthy")
+}
+
+func (c *linuxWebKitRecoveryCoordinator) stop() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.stopped = true
+	c.restartRequested = true
+	if c.pendingTimer != nil {
+		c.pendingTimer.Stop()
+	}
+	c.pendingTimer = nil
+	c.pendingEvent = nil
+	c.pendingTelemetry = false
+	c.mu.Unlock()
+}
+
+func (c *linuxWebKitRecoveryCoordinator) canRun() bool {
+	if c == nil || c.app == nil || c.app.shuttingDown.Load() || c.app.forceQuit.Load() {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return !c.stopped
+}
+
+func (a *App) recordWebKitNativeDiagnostic(event webKitNativeEvent) {
+	if a == nil {
+		return
+	}
+	report, outcome, failureBucket := webKitNativeFailureReport(event)
+	_ = writePendingReport(report, true)
+	a.recordDiagnosticMetric("desktop_web_runtime_failure", failureBucket)
+	a.recordDiagnosticMetric("desktop_web_runtime_outcome", outcome)
+}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -82,6 +82,9 @@ func windowsWebview2GPUDisabled() bool {
 }
 
 func linuxWebviewGpuPolicy(pattern string) linux.WebviewGpuPolicy {
+	if linuxRendererCompatibilityMode() {
+		return linux.WebviewGpuPolicyNever
+	}
 	matches, err := filepath.Glob(pattern)
 	if err == nil {
 		for _, path := range matches {
@@ -103,6 +106,7 @@ func preparePrimaryDesktopRuntime(app *App) {
 }
 
 func main() {
+	prepareLinuxRendererCompatibilityEnvironment()
 	// Detached macOS self-update child: wait for the old PID, hold the shared
 	// repair mutation lock, then swap the .app bundle. Must run before Wails.
 	if handled, exitCode := maybeRunMacUpdateHandoff(os.Args[1:]); handled {

--- a/desktop/relauncher.go
+++ b/desktop/relauncher.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"reasonix/internal/installlayout"
+	"reasonix/internal/proc"
+)
+
+// relaunchThroughLauncher starts the permanent thin launcher (or falls back to
+// the running executable). A legacy Guard binary is considered only as a
+// one-release migration fallback for flat 1.18-1.19.1 installations.
+func relaunchThroughLauncher() error {
+	return relaunchThroughLauncherWithEnv(nil)
+}
+
+func relaunchThroughLauncherWithEnv(overrides map[string]string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	root := filepath.Dir(exe)
+	if resolved, err := installlayout.ResolveInstallRoot(exe); err == nil && resolved != "" {
+		root = resolved
+	}
+	candidates := []string{
+		filepath.Join(root, "reasonix-launcher"),
+		filepath.Join(root, "Reasonix.exe"),
+		filepath.Join(root, "reasonix-guard"), // migration window only
+	}
+	if runtime.GOOS == "windows" {
+		candidates[0] += ".exe"
+		candidates[2] += ".exe"
+	}
+	launcher := exe
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			launcher = path
+			break
+		}
+	}
+	args := []string{}
+	// Only legacy guard understands "launch --detach"; the thin launcher strips it.
+	if strings.Contains(strings.ToLower(filepath.Base(launcher)), "guard") {
+		args = []string{"launch", "--detach"}
+	}
+	cmd := proc.VisibleCommand(launcher, args...)
+	if len(overrides) > 0 {
+		cmd.Env = processEnvWithOverrides(os.Environ(), overrides)
+	}
+	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
+	return cmd.Start()
+}
+
+func processEnvWithOverrides(base []string, overrides map[string]string) []string {
+	env := make([]string, 0, len(base)+len(overrides))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, overridden := overrides[key]; overridden {
+				continue
+			}
+		}
+		env = append(env, entry)
+	}
+	for key, value := range overrides {
+		env = append(env, key+"="+value)
+	}
+	return env
+}

--- a/desktop/shutdown.go
+++ b/desktop/shutdown.go
@@ -22,6 +22,12 @@ func completeDesktopShutdown(tracker *desktopLifecycleTracker, body func()) {
 }
 
 func (a *App) shutdownBody() {
+	if a.desktopShell.linuxRecovery != nil {
+		a.desktopShell.linuxRecovery.stop()
+	}
+	if a.desktopShell.coordinator != nil {
+		a.desktopShell.coordinator.stop()
+	}
 	if a.workspaceHub != nil {
 		a.workspaceHub.close()
 	}
@@ -93,8 +99,8 @@ func (a *App) shutdownBody() {
 		a.mu.Unlock()
 	}
 	if a.startupReady.Load() {
-		// A visible UI is sufficient health evidence even if the user closes the
-		// window before the delayed post-DOM task runs.
+		// A stable React + Wails heartbeat is sufficient health evidence even if
+		// the user closes before the delayed commit task runs.
 		if err := a.commitPendingUpdateHealth(); err != nil {
 			slog.Warn("desktop: commit healthy update during shutdown", "err", err)
 		}

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -3,18 +3,23 @@
 package main
 
 import (
+	"context"
+	goruntime "runtime"
 	"sync"
 
 	"fyne.io/systray"
 )
 
 type desktopTray struct {
-	end       func()
-	openItem  *systray.MenuItem
-	quitItem  *systray.MenuItem
-	once      sync.Once
-	ready     chan struct{}
-	readyOnce sync.Once
+	end           func()
+	openItem      *systray.MenuItem
+	quitItem      *systray.MenuItem
+	once          sync.Once
+	ready         chan struct{}
+	readyOnce     sync.Once
+	healthMu      sync.Mutex
+	cancel        context.CancelFunc
+	healthStopped bool
 }
 
 func newDesktopTray() *desktopTray {
@@ -28,7 +33,15 @@ func (t *desktopTray) markReady() {
 }
 
 func (a *App) startTray() bool {
+	if a == nil || a.shuttingDown.Load() || a.forceQuit.Load() {
+		return false
+	}
 	if !traySupported() {
+		reason := "no_session_bus"
+		if goruntime.GOOS == "darwin" {
+			reason = "platform_no_tray"
+		}
+		a.setTrayHealth(nil, "unavailable", reason)
 		return false
 	}
 	a.mu.Lock()
@@ -38,6 +51,9 @@ func (a *App) startTray() bool {
 	}
 	t := newDesktopTray()
 	a.tray = t
+	a.desktopShell.trayState = "probing"
+	a.desktopShell.trayReason = ""
+	a.trayReady = false
 	a.mu.Unlock()
 
 	end := startDesktopTray(func() {
@@ -61,9 +77,8 @@ func (a *App) startTray() bool {
 		a.mu.Lock()
 		t.openItem = openItem
 		t.quitItem = quitItem
-		a.trayReady = true
 		a.mu.Unlock()
-		t.markReady()
+		a.trayConfigured(t)
 
 		a.goSafe("trayOpenLoop", func() {
 			for range openItem.ClickedCh {
@@ -76,9 +91,10 @@ func (a *App) startTray() bool {
 			}
 		})
 	}, func() {
+		t.stopHealthMonitor()
+		a.setTrayHealth(t, "unavailable", "tray_exited")
 		a.mu.Lock()
 		if a.tray == t {
-			a.trayReady = false
 			a.tray = nil
 		}
 		a.mu.Unlock()
@@ -86,6 +102,11 @@ func (a *App) startTray() bool {
 	a.mu.Lock()
 	t.end = end
 	a.mu.Unlock()
+	if a.shuttingDown.Load() || a.forceQuit.Load() {
+		t.once.Do(end)
+		return false
+	}
+	a.startTrayHealthMonitor(t)
 	return true
 }
 
@@ -101,6 +122,20 @@ func (a *App) stopTray() {
 		return
 	}
 	t.once.Do(end)
+}
+
+func (t *desktopTray) stopHealthMonitor() {
+	if t == nil {
+		return
+	}
+	t.healthMu.Lock()
+	t.healthStopped = true
+	cancel := t.cancel
+	t.cancel = nil
+	t.healthMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 func (a *App) updateTrayLocale(locale string) {

--- a/desktop/tray_health.go
+++ b/desktop/tray_health.go
@@ -1,0 +1,29 @@
+package main
+
+import "strings"
+
+type statusNotifierSnapshot struct {
+	WatcherOwner string
+	Host         bool
+	ItemOwner    string
+	Items        []string
+}
+
+func evaluateStatusNotifierSnapshot(snapshot statusNotifierSnapshot, itemName string) (bool, string) {
+	if strings.TrimSpace(snapshot.WatcherOwner) == "" {
+		return false, "no_watcher"
+	}
+	if !snapshot.Host {
+		return false, "no_host"
+	}
+	if strings.TrimSpace(snapshot.ItemOwner) == "" {
+		return false, "item_no_owner"
+	}
+	for _, registered := range snapshot.Items {
+		service := strings.TrimSpace(strings.SplitN(registered, "/", 2)[0])
+		if service == itemName || service == snapshot.ItemOwner {
+			return true, ""
+		}
+	}
+	return false, "item_not_registered"
+}

--- a/desktop/tray_health_other.go
+++ b/desktop/tray_health_other.go
@@ -1,0 +1,6 @@
+//go:build darwin || (!windows && !cgo)
+
+package main
+
+func (a *App) startTrayHealthMonitor(*desktopTray) {}
+func (a *App) trayConfigured(*desktopTray)         {}

--- a/desktop/tray_health_unix.go
+++ b/desktop/tray_health_unix.go
@@ -19,6 +19,118 @@ const (
 	statusNotifierProbeTimeout = 750 * time.Millisecond
 )
 
+type statusNotifierBusConnection struct {
+	conn   *dbus.Conn
+	cancel context.CancelFunc
+}
+
+func (c *statusNotifierBusConnection) close() {
+	if c == nil {
+		return
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+}
+
+type statusNotifierProbe struct {
+	connection *statusNotifierBusConnection
+	connect    func(context.Context) (*statusNotifierBusConnection, error)
+}
+
+func newStatusNotifierProbe() *statusNotifierProbe {
+	return &statusNotifierProbe{connect: connectStatusNotifierSessionBus}
+}
+
+func connectStatusNotifierSessionBus(ctx context.Context) (*statusNotifierBusConnection, error) {
+	type connectionResult struct {
+		conn *dbus.Conn
+		err  error
+	}
+
+	connCtx, cancelConn := context.WithCancel(context.Background())
+	resultCh := make(chan connectionResult, 1)
+	go func() {
+		conn, err := dbus.SessionBusPrivateNoAutoStartup(dbus.WithContext(connCtx))
+		if err == nil {
+			err = conn.Auth(nil)
+		}
+		if err == nil {
+			err = conn.Hello()
+		}
+		resultCh <- connectionResult{conn: conn, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			cancelConn()
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+			return nil, err
+		}
+		if result.err != nil {
+			cancelConn()
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+			return nil, result.err
+		}
+		return &statusNotifierBusConnection{conn: result.conn, cancel: cancelConn}, nil
+	case <-ctx.Done():
+		// Canceling the connection context closes the private transport. That
+		// interrupts Auth and Hello even though godbus does not expose
+		// context-aware variants for those operations.
+		cancelConn()
+		return nil, ctx.Err()
+	}
+}
+
+func (p *statusNotifierProbe) close() {
+	if p == nil {
+		return
+	}
+	p.connection.close()
+	p.connection = nil
+}
+
+func (p *statusNotifierProbe) reset() {
+	p.close()
+}
+
+func (p *statusNotifierProbe) probe(ctx context.Context, itemName string) (bool, string) {
+	if p == nil {
+		return false, "no_session_bus"
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, statusNotifierProbeTimeout)
+	defer cancel()
+	if p.connection == nil {
+		connect := p.connect
+		if connect == nil {
+			connect = connectStatusNotifierSessionBus
+		}
+		connection, err := connect(probeCtx)
+		if err != nil {
+			return false, "no_session_bus"
+		}
+		p.connection = connection
+	}
+	conn := p.connection.conn
+	if err := conn.BusObject().CallWithContext(probeCtx, "org.freedesktop.DBus.Peer.Ping", 0).Err; err != nil {
+		p.reset()
+		return false, "no_session_bus"
+	}
+	snapshot, err := readStatusNotifierSnapshot(probeCtx, conn, itemName)
+	if err != nil {
+		return false, "watcher_unresponsive"
+	}
+	return evaluateStatusNotifierSnapshot(snapshot, itemName)
+}
+
 func readStatusNotifierSnapshot(ctx context.Context, conn *dbus.Conn, itemName string) (statusNotifierSnapshot, error) {
 	snapshot := statusNotifierSnapshot{}
 	bus := conn.Object("org.freedesktop.DBus", dbus.ObjectPath("/org/freedesktop/DBus"))
@@ -57,40 +169,11 @@ func (a *App) startTrayHealthMonitor(t *desktopTray) {
 	t.healthMu.Unlock()
 	a.goSafe("trayStatusNotifierMonitor", func() {
 		itemName := fmt.Sprintf("org.kde.StatusNotifierItem-%d-1", os.Getpid())
-		var conn *dbus.Conn
-		defer func() {
-			if conn != nil {
-				_ = conn.Close()
-			}
-		}()
-		probe := func() (bool, string) {
-			if conn == nil {
-				var err error
-				conn, err = dbus.SessionBusPrivateNoAutoStartup()
-				if err != nil || conn.Auth(nil) != nil || conn.Hello() != nil {
-					if conn != nil {
-						_ = conn.Close()
-						conn = nil
-					}
-					return false, "no_session_bus"
-				}
-			}
-			probeCtx, cancel := context.WithTimeout(ctx, statusNotifierProbeTimeout)
-			defer cancel()
-			if err := conn.BusObject().CallWithContext(probeCtx, "org.freedesktop.DBus.Peer.Ping", 0).Err; err != nil {
-				_ = conn.Close()
-				conn = nil
-				return false, "no_session_bus"
-			}
-			snapshot, err := readStatusNotifierSnapshot(probeCtx, conn, itemName)
-			if err != nil {
-				return false, "watcher_unresponsive"
-			}
-			return evaluateStatusNotifierSnapshot(snapshot, itemName)
-		}
+		probe := newStatusNotifierProbe()
+		defer probe.close()
 
 		for {
-			ready, reason := probe()
+			ready, reason := probe.probe(ctx, itemName)
 			if ready {
 				a.setTrayHealth(t, "ready", "")
 			} else {

--- a/desktop/tray_health_unix.go
+++ b/desktop/tray_health_unix.go
@@ -1,0 +1,111 @@
+//go:build !windows && !darwin && cgo
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	statusNotifierWatcherName  = "org.kde.StatusNotifierWatcher"
+	statusNotifierWatcherPath  = dbus.ObjectPath("/StatusNotifierWatcher")
+	statusNotifierWatcherIFace = "org.kde.StatusNotifierWatcher"
+	statusNotifierPollInterval = time.Second
+	statusNotifierProbeTimeout = 750 * time.Millisecond
+)
+
+func readStatusNotifierSnapshot(ctx context.Context, conn *dbus.Conn, itemName string) (statusNotifierSnapshot, error) {
+	snapshot := statusNotifierSnapshot{}
+	bus := conn.Object("org.freedesktop.DBus", dbus.ObjectPath("/org/freedesktop/DBus"))
+	if err := bus.CallWithContext(ctx, "org.freedesktop.DBus.GetNameOwner", 0, statusNotifierWatcherName).Store(&snapshot.WatcherOwner); err != nil {
+		return snapshot, nil
+	}
+	if snapshot.WatcherOwner == "" {
+		return snapshot, nil
+	}
+	watcher := conn.Object(statusNotifierWatcherName, statusNotifierWatcherPath)
+	var value dbus.Variant
+	if err := watcher.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, statusNotifierWatcherIFace, "IsStatusNotifierHostRegistered").Store(&value); err != nil {
+		return snapshot, err
+	}
+	snapshot.Host, _ = value.Value().(bool)
+	if err := watcher.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, statusNotifierWatcherIFace, "RegisteredStatusNotifierItems").Store(&value); err != nil {
+		return snapshot, err
+	}
+	snapshot.Items, _ = value.Value().([]string)
+	_ = bus.CallWithContext(ctx, "org.freedesktop.DBus.GetNameOwner", 0, itemName).Store(&snapshot.ItemOwner)
+	return snapshot, nil
+}
+
+func (a *App) startTrayHealthMonitor(t *desktopTray) {
+	if a == nil || t == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(a.bootContext())
+	t.healthMu.Lock()
+	if t.healthStopped {
+		t.healthMu.Unlock()
+		cancel()
+		return
+	}
+	t.cancel = cancel
+	t.healthMu.Unlock()
+	a.goSafe("trayStatusNotifierMonitor", func() {
+		itemName := fmt.Sprintf("org.kde.StatusNotifierItem-%d-1", os.Getpid())
+		var conn *dbus.Conn
+		defer func() {
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}()
+		probe := func() (bool, string) {
+			if conn == nil {
+				var err error
+				conn, err = dbus.SessionBusPrivateNoAutoStartup()
+				if err != nil || conn.Auth(nil) != nil || conn.Hello() != nil {
+					if conn != nil {
+						_ = conn.Close()
+						conn = nil
+					}
+					return false, "no_session_bus"
+				}
+			}
+			probeCtx, cancel := context.WithTimeout(ctx, statusNotifierProbeTimeout)
+			defer cancel()
+			if err := conn.BusObject().CallWithContext(probeCtx, "org.freedesktop.DBus.Peer.Ping", 0).Err; err != nil {
+				_ = conn.Close()
+				conn = nil
+				return false, "no_session_bus"
+			}
+			snapshot, err := readStatusNotifierSnapshot(probeCtx, conn, itemName)
+			if err != nil {
+				return false, "watcher_unresponsive"
+			}
+			return evaluateStatusNotifierSnapshot(snapshot, itemName)
+		}
+
+		for {
+			ready, reason := probe()
+			if ready {
+				a.setTrayHealth(t, "ready", "")
+			} else {
+				a.setTrayHealth(t, "unavailable", reason)
+			}
+			timer := time.NewTimer(statusNotifierPollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+	})
+}
+
+// Linux readiness is established by the DBus monitor, not systray.onReady.
+func (a *App) trayConfigured(*desktopTray) {}

--- a/desktop/tray_health_unix_test.go
+++ b/desktop/tray_health_unix_test.go
@@ -1,0 +1,340 @@
+//go:build !windows && !darwin && cgo
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+type fakeStatusNotifierWatcher struct {
+	mu    sync.RWMutex
+	host  bool
+	items []string
+}
+
+func (w *fakeStatusNotifierWatcher) set(host bool, items []string) {
+	w.mu.Lock()
+	w.host = host
+	w.items = append([]string(nil), items...)
+	w.mu.Unlock()
+}
+
+func (w *fakeStatusNotifierWatcher) Get(iface, property string) (dbus.Variant, *dbus.Error) {
+	if iface != statusNotifierWatcherIFace {
+		return dbus.Variant{}, dbus.NewError("org.freedesktop.DBus.Error.UnknownInterface", []any{iface})
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	switch property {
+	case "IsStatusNotifierHostRegistered":
+		return dbus.MakeVariant(w.host), nil
+	case "RegisteredStatusNotifierItems":
+		return dbus.MakeVariant(append([]string(nil), w.items...)), nil
+	default:
+		return dbus.Variant{}, dbus.NewError("org.freedesktop.DBus.Error.UnknownProperty", []any{property})
+	}
+}
+
+func startPrivateDBusDaemon(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("dbus-daemon")
+	if err != nil {
+		t.Skip("dbus-daemon is required for the StatusNotifier integration test")
+	}
+	cmd := exec.Command(path, "--session", "--nofork", "--nopidfile", "--print-address=1")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		select {
+		case <-waitCh:
+		case <-time.After(2 * time.Second):
+			_ = cmd.Process.Kill()
+			<-waitCh
+		}
+	})
+
+	type addressResult struct {
+		address string
+		err     error
+	}
+	addressCh := make(chan addressResult, 1)
+	go func() {
+		line, readErr := bufio.NewReader(stdout).ReadString('\n')
+		addressCh <- addressResult{address: strings.TrimSpace(line), err: readErr}
+	}()
+	select {
+	case result := <-addressCh:
+		if result.err != nil {
+			t.Fatalf("read private dbus address: %v", result.err)
+		}
+		if result.address == "" {
+			t.Fatal("private dbus daemon returned an empty address")
+		}
+		return result.address
+	case <-time.After(5 * time.Second):
+		t.Fatal("private dbus daemon did not publish its address")
+		return ""
+	}
+}
+
+func connectTestBus(t *testing.T, address string) *dbus.Conn {
+	t.Helper()
+	conn, err := dbus.Connect(address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func requestTestBusName(t *testing.T, conn *dbus.Conn, name string) {
+	t.Helper()
+	reply, err := conn.RequestName(name, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		t.Fatalf("request %s: got reply %d", name, reply)
+	}
+}
+
+func releaseTestBusName(t *testing.T, conn *dbus.Conn, name string) {
+	t.Helper()
+	reply, err := conn.ReleaseName(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reply != dbus.ReleaseNameReplyReleased {
+		t.Fatalf("release %s: got reply %d", name, reply)
+	}
+}
+
+func installFakeStatusNotifierWatcher(t *testing.T, conn *dbus.Conn, watcher *fakeStatusNotifierWatcher) {
+	t.Helper()
+	if err := conn.Export(watcher, statusNotifierWatcherPath, "org.freedesktop.DBus.Properties"); err != nil {
+		t.Fatal(err)
+	}
+	requestTestBusName(t, conn, statusNotifierWatcherName)
+}
+
+func TestStatusNotifierProbeIntegration(t *testing.T) {
+	address := startPrivateDBusDaemon(t)
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+	const itemName = "org.kde.StatusNotifierItem-4242-1"
+
+	probe := newStatusNotifierProbe()
+	t.Cleanup(probe.close)
+	assertState := func(wantReady bool, wantReason string) {
+		t.Helper()
+		ready, reason := probe.probe(context.Background(), itemName)
+		if ready != wantReady || reason != wantReason {
+			t.Fatalf("probe = (%v, %q), want (%v, %q)", ready, reason, wantReady, wantReason)
+		}
+	}
+
+	assertState(false, "no_watcher")
+
+	watcherConn := connectTestBus(t, address)
+	watcher := &fakeStatusNotifierWatcher{}
+	installFakeStatusNotifierWatcher(t, watcherConn, watcher)
+	assertState(false, "no_host")
+
+	watcher.set(true, []string{itemName + "/StatusNotifierItem"})
+	assertState(false, "item_no_owner")
+
+	itemConn := connectTestBus(t, address)
+	requestTestBusName(t, itemConn, itemName)
+	watcher.set(true, nil)
+	assertState(false, "item_not_registered")
+
+	watcher.set(true, []string{itemName + "/StatusNotifierItem"})
+	assertState(true, "")
+
+	watcher.set(false, []string{itemName + "/StatusNotifierItem"})
+	assertState(false, "no_host")
+	watcher.set(true, []string{itemName + "/StatusNotifierItem"})
+	assertState(true, "")
+
+	releaseTestBusName(t, watcherConn, statusNotifierWatcherName)
+	assertState(false, "no_watcher")
+
+	replacementConn := connectTestBus(t, address)
+	replacement := &fakeStatusNotifierWatcher{}
+	replacement.set(true, []string{itemName + "/StatusNotifierItem"})
+	installFakeStatusNotifierWatcher(t, replacementConn, replacement)
+	assertState(true, "")
+
+	releaseTestBusName(t, itemConn, itemName)
+	assertState(false, "item_no_owner")
+	replacementItemConn := connectTestBus(t, address)
+	requestTestBusName(t, replacementItemConn, itemName)
+	assertState(true, "")
+}
+
+func startStallingDBusSocket(t *testing.T, serve func(*net.UnixConn) error) (string, <-chan error) {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "bus.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	done := make(chan error, 1)
+	go func() {
+		conn, acceptErr := listener.AcceptUnix()
+		if acceptErr != nil {
+			done <- acceptErr
+			return
+		}
+		defer conn.Close()
+		done <- serve(conn)
+	}()
+	return "unix:path=" + dbus.EscapeBusAddressValue(socketPath), done
+}
+
+func waitForConnectionResult(t *testing.T, resultCh <-chan error, serverDone <-chan error) {
+	t.Helper()
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("connect error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled DBus connection did not return")
+	}
+	select {
+	case err := <-serverDone:
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("fake DBus server: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled DBus connection did not close its transport")
+	}
+}
+
+func TestConnectStatusNotifierSessionBusCancellationInterruptsAuth(t *testing.T) {
+	accepted := make(chan struct{})
+	address, serverDone := startStallingDBusSocket(t, func(conn *net.UnixConn) error {
+		close(accepted)
+		_, err := io.Copy(io.Discard, conn)
+		return err
+	})
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		connection, err := connectStatusNotifierSessionBus(ctx)
+		if connection != nil {
+			connection.close()
+		}
+		resultCh <- err
+	}()
+	select {
+	case <-accepted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		t.Fatal("fake DBus server did not accept the connection")
+	}
+	waitForConnectionResult(t, resultCh, serverDone)
+}
+
+func serveUntilHello(conn *net.UnixConn, helloStarted chan<- struct{}) error {
+	reader := bufio.NewReader(conn)
+	first, err := reader.ReadByte()
+	if err != nil {
+		return err
+	}
+	if first != 0 {
+		return fmt.Errorf("authentication prefix = %d, want 0", first)
+	}
+	readLine := func(wantPrefix string) error {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			return readErr
+		}
+		if !strings.HasPrefix(strings.TrimSpace(line), wantPrefix) {
+			return fmt.Errorf("authentication line = %q, want prefix %q", line, wantPrefix)
+		}
+		return nil
+	}
+	writeLine := func(line string) error {
+		_, writeErr := io.WriteString(conn, line+"\r\n")
+		return writeErr
+	}
+	if err := readLine("AUTH"); err != nil {
+		return err
+	}
+	if err := writeLine("REJECTED EXTERNAL"); err != nil {
+		return err
+	}
+	if err := readLine("AUTH EXTERNAL"); err != nil {
+		return err
+	}
+	if err := writeLine("OK 0123456789abcdef0123456789abcdef"); err != nil {
+		return err
+	}
+	if err := readLine("NEGOTIATE_UNIX_FD"); err != nil {
+		return err
+	}
+	if err := writeLine("ERROR"); err != nil {
+		return err
+	}
+	if err := readLine("BEGIN"); err != nil {
+		return err
+	}
+	if _, err := reader.ReadByte(); err != nil {
+		return err
+	}
+	close(helloStarted)
+	_, err = io.Copy(io.Discard, reader)
+	return err
+}
+
+func TestConnectStatusNotifierSessionBusCancellationInterruptsHello(t *testing.T) {
+	helloStarted := make(chan struct{})
+	address, serverDone := startStallingDBusSocket(t, func(conn *net.UnixConn) error {
+		return serveUntilHello(conn, helloStarted)
+	})
+	t.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		connection, err := connectStatusNotifierSessionBus(ctx)
+		if connection != nil {
+			connection.close()
+		}
+		resultCh <- err
+	}()
+	select {
+	case <-helloStarted:
+		cancel()
+	case err := <-serverDone:
+		t.Fatalf("fake DBus server exited before Hello cancellation: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not start the DBus Hello call")
+	}
+	waitForConnectionResult(t, resultCh, serverDone)
+}

--- a/desktop/tray_health_windows.go
+++ b/desktop/tray_health_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+func (a *App) startTrayHealthMonitor(*desktopTray) {}
+
+func (a *App) trayConfigured(t *desktopTray) {
+	a.setTrayHealth(t, "ready", "")
+}

--- a/desktop/tray_nocgo.go
+++ b/desktop/tray_nocgo.go
@@ -2,14 +2,27 @@
 
 package main
 
+import "sync"
+
 // desktopTray remains part of App's shape in pure-Go builds, but native tray
 // implementations require platform UI libraries. Desktop startup already
 // treats a missing tray as an optional capability.
 type desktopTray struct {
-	ready chan struct{}
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func newDesktopTray() *desktopTray { return &desktopTray{ready: make(chan struct{})} }
+
+func (t *desktopTray) markReady() {
+	t.readyOnce.Do(func() { close(t.ready) })
 }
 
 func (a *App) startTray() bool {
+	if a == nil || a.shuttingDown.Load() || a.forceQuit.Load() {
+		return false
+	}
+	a.setTrayHealth(nil, "unavailable", "native_tray_unavailable")
 	return false
 }
 

--- a/desktop/tray_supported_unix.go
+++ b/desktop/tray_supported_unix.go
@@ -5,13 +5,10 @@ package main
 import "github.com/godbus/dbus/v5"
 
 func traySupported() bool {
-	conn, err := dbus.SessionBus()
+	conn, err := dbus.SessionBusPrivateNoAutoStartup()
 	if err != nil {
 		return false
 	}
-	// SessionBus returns a shared singleton connection. Do not close it here:
-	// other desktop integrations in this process may still be using it.
-	obj := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
-	var owner string
-	return obj.Call("org.freedesktop.DBus.GetNameOwner", 0, "org.kde.StatusNotifierWatcher").Store(&owner) == nil && owner != ""
+	defer conn.Close()
+	return conn.Auth(nil) == nil && conn.Hello() == nil
 }

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -28,7 +28,6 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/installlayout"
 	"reasonix/internal/netclient"
-	"reasonix/internal/proc"
 	"reasonix/internal/repair"
 )
 
@@ -1374,44 +1373,6 @@ func updateSiblingNames(goos string) []string {
 	default:
 		return nil
 	}
-}
-
-// relaunchThroughLauncher starts the permanent thin launcher (or falls back to
-// the running executable). A legacy Guard binary is considered only as a
-// one-release migration fallback for flat 1.18-1.19.1 installations.
-func relaunchThroughLauncher() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-	root := filepath.Dir(exe)
-	if resolved, err := installlayout.ResolveInstallRoot(exe); err == nil && resolved != "" {
-		root = resolved
-	}
-	candidates := []string{
-		filepath.Join(root, "reasonix-launcher"),
-		filepath.Join(root, "Reasonix.exe"),
-		filepath.Join(root, "reasonix-guard"), // migration window only
-	}
-	if runtime.GOOS == "windows" {
-		candidates[0] += ".exe"
-		candidates[2] += ".exe"
-	}
-	launcher := exe
-	for _, path := range candidates {
-		if _, err := os.Stat(path); err == nil {
-			launcher = path
-			break
-		}
-	}
-	args := []string{}
-	// Only legacy guard understands "launch --detach"; the thin launcher strips it.
-	if strings.Contains(strings.ToLower(filepath.Base(launcher)), "guard") {
-		args = []string{"launch", "--detach"}
-	}
-	cmd := proc.VisibleCommand(launcher, args...)
-	cmd.Stdout, cmd.Stderr, cmd.Stdin = os.Stdout, os.Stderr, os.Stdin
-	return cmd.Start()
 }
 
 func currentLauncherPath() string {

--- a/desktop/webkit_diagnostics.go
+++ b/desktop/webkit_diagnostics.go
@@ -65,9 +65,10 @@ func webKitNativeFailureReport(event webKitNativeEvent) (crashReport, string, st
 	if gpuMode == "" {
 		gpuMode = "unknown"
 	}
+	compatibilityMode := linuxRendererCompatibilityMode()
 	diagnostic := &webRuntimeDiagnostic{
 		Engine: "webkitgtk", Kind: "web_process", Reason: reason,
-		RuntimeVersion: runtimeVersion, GPUMode: gpuMode, Recovery: recovery,
+		RuntimeVersion: runtimeVersion, GPUMode: gpuMode, CompatibilityMode: compatibilityMode, Recovery: recovery,
 	}
 	report := baseCrashReport(reportKind)
 	report.SchemaVersion = 3
@@ -87,6 +88,7 @@ reason: %s
 exit code: unavailable
 runtime version: %s
 GPU mode: %s
-recovery: %s`, reason, runtimeVersion, gpuMode, recovery), maxCrashDetailBytes)
+compatibility mode: %t
+recovery: %s`, reason, runtimeVersion, gpuMode, compatibilityMode, recovery), maxCrashDetailBytes)
 	return report, outcome, strings.Join([]string{"webkitgtk", "web_process", reason}, ".")
 }

--- a/desktop/webkit_diagnostics_linux.go
+++ b/desktop/webkit_diagnostics_linux.go
@@ -27,17 +27,20 @@ var webKitObserverState = struct {
 var observeWebKitNativeEvent = func(webKitNativeEvent) {}
 
 func installWebKitProcessObserver(app *App, enabled bool) {
-	if app == nil || !enabled || !app.diagnosticsOwner {
+	if app == nil {
 		return
 	}
 	webKitObserverState.Do(func() {
 		go func() {
 			for event := range webKitObserverState.events {
-				report, outcome, failureBucket := webKitNativeFailureReport(event)
-				_ = writePendingReport(report, true)
-				app.recordDiagnosticMetric("desktop_web_runtime_failure", failureBucket)
-				app.recordDiagnosticMetric("desktop_web_runtime_outcome", outcome)
-				recordDroppedWebRuntimeEvents(app, "webkitgtk", &webKitObserverState.dropped)
+				if app.desktopShell.linuxRecovery != nil {
+					app.desktopShell.linuxRecovery.nativeEvent(event, enabled)
+				} else if enabled {
+					app.recordWebKitNativeDiagnostic(event)
+				}
+				if enabled {
+					recordDroppedWebRuntimeEvents(app, "webkitgtk", &webKitObserverState.dropped)
+				}
 			}
 		}()
 		C.reasonix_install_webkit_observer()

--- a/desktop/webview2_diagnostics.go
+++ b/desktop/webview2_diagnostics.go
@@ -37,6 +37,7 @@ type webRuntimeDiagnostic struct {
 	FailureSourceModule string `json:"failureSourceModule,omitempty"`
 	RuntimeVersion      string `json:"runtimeVersion"`
 	GPUMode             string `json:"gpuMode"`
+	CompatibilityMode   bool   `json:"compatibilityMode,omitempty"`
 	Recovery            string `json:"recovery"`
 }
 

--- a/desktop/webview2_recovery.go
+++ b/desktop/webview2_recovery.go
@@ -335,6 +335,9 @@ func (c *webView2RecoveryCoordinator) startGuidance(ctx context.Context) {
 			return
 		case <-timer.C:
 		}
+		if c.app != nil {
+			c.app.showMainWindowFrom("webview2_recovery_guidance")
+		}
 		showWindowsWebView2RecoveryGuidance(ctx)
 		_ = c.journal.append("guidance_shown", "crash_loop_guard")
 	}()

--- a/desktop/webview2_recovery_windows.go
+++ b/desktop/webview2_recovery_windows.go
@@ -9,7 +9,6 @@ import (
 )
 
 func showWindowsWebView2RecoveryGuidance(ctx context.Context) {
-	runtime.WindowShow(ctx)
 	_, _ = runtime.MessageDialog(ctx, runtime.MessageDialogOptions{
 		Type:  runtime.WarningDialog,
 		Title: "Reasonix WebView2 recovery / WebView2 恢复",

--- a/desktop/webview2_startup.go
+++ b/desktop/webview2_startup.go
@@ -33,7 +33,7 @@ func (a *App) startWindowsWebView2StartupFallback(ctx context.Context) {
 
 		// Show the native shell first so a dialog failure can never leave the app
 		// completely invisible. The dark native background is already configured.
-		runtime.WindowShow(ctx)
+		a.showMainWindowFrom("webview2_startup_timeout")
 		if a.startupReady.Load() {
 			return
 		}

--- a/desktop/window_restore_diagnostics.go
+++ b/desktop/window_restore_diagnostics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	goruntime "runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -91,7 +92,11 @@ func (a *App) showMainWindowFrom(source string) {
 		return
 	}
 	if !windowRestoreDiagnosticsSupported() {
-		showFromBackground(a.ctx, a.backgroundMaximised.Swap(false))
+		if a.desktopShell.coordinator != nil {
+			a.desktopShell.coordinator.Present(source)
+		} else {
+			applyDesktopPresentPlan(a.ctx, desktopPresentPlanFor("", a.backgroundMaximised.Swap(false)))
+		}
 		a.kickDeferredRebuildRetry()
 		return
 	}
@@ -108,7 +113,11 @@ func (a *App) showMainWindowFrom(source string) {
 	_ = writeWindowRestoreState(state)
 	windowRestoreMu.Unlock()
 
-	showFromBackground(a.ctx, a.backgroundMaximised.Swap(false))
+	if a.desktopShell.coordinator != nil {
+		a.desktopShell.coordinator.Present(source)
+	} else {
+		applyDesktopPresentPlan(a.ctx, desktopPresentPlanFor("", a.backgroundMaximised.Swap(false)))
+	}
 	a.goSafe("windowRestoreMonitor", func() {
 		restored := waitForWindowRestoreConfirmation()
 		a.completeWindowRestoreAttempt(attemptID, state, restored)
@@ -158,6 +167,9 @@ func (a *App) completeWindowRestoreAttempt(attemptID uint64, state windowRestore
 	}
 	windowRestoreMu.Unlock()
 	a.recordDiagnosticMetric("desktop_restore", metric)
+	if !restored {
+		showWindowRestoreFailure(a)
+	}
 }
 
 func windowRestoreFailureReport(kind, source, startedAt string) crashReport {
@@ -166,18 +178,19 @@ func windowRestoreFailureReport(kind, source, startedAt string) crashReport {
 	report := baseCrashReport("performance")
 	report.SchemaVersion = 2
 	report.Source = "native.window"
-	report.Label = "windows.window_restore." + kind
-	report.ErrorType = "WindowsWindowRestoreFailure"
-	report.ErrorMessage = sanitizeCrashText("Windows window restoration did not complete normally.", maxCrashFieldBytes)
-	report.TopFrame = "windows.window_restore." + source
-	report.FingerprintHint = "windows.window_restore." + kind + "." + source
+	platform := metricBucket(goruntime.GOOS)
+	report.Label = platform + ".window_restore." + kind
+	report.ErrorType = "DesktopWindowRestoreFailure"
+	report.ErrorMessage = sanitizeCrashText("Desktop window restoration did not complete normally.", maxCrashFieldBytes)
+	report.TopFrame = platform + ".window_restore." + source
+	report.FingerprintHint = platform + ".window_restore." + kind + "." + source
 	report.OccurredAt = time.Now().UTC().Format(time.RFC3339)
-	report.Message = sanitizeCrashText(fmt.Sprintf(`[windows.window_restore.%s]
+	report.Message = sanitizeCrashText(fmt.Sprintf(`[%s.window_restore.%s]
 
 Reasonix could not confirm that the hidden window was restored.
 
 source: %s
 attempt started at: %s
-timeout: %s`, kind, source, sanitizeCrashField(startedAt, 64), windowRestoreTimeout), maxCrashDetailBytes)
+timeout: %s`, platform, kind, source, sanitizeCrashField(startedAt, 64), windowRestoreTimeout), maxCrashDetailBytes)
 	return report
 }

--- a/desktop/window_restore_diagnostics_linux.go
+++ b/desktop/window_restore_diagnostics_linux.go
@@ -5,6 +5,9 @@ package main
 /*
 #cgo pkg-config: gtk+-3.0
 #include <gtk/gtk.h>
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
 #include <string.h>
 
 typedef struct {
@@ -22,6 +25,34 @@ static void reasonix_window_probe_unref(ReasonixWindowProbe *probe) {
   g_free(probe);
 }
 
+static gboolean reasonix_display_requires_active_window(void) {
+#ifdef GDK_WINDOWING_WAYLAND
+  // Mutter may keep a minimised Wayland surface visible and mapped in GTK's
+  // client-side state. Activation is the compositor acknowledgement that
+  // gtk_window_present actually restored it.
+  GdkDisplay *display = gdk_display_get_default();
+  return display != NULL && GDK_IS_WAYLAND_DISPLAY(display);
+#else
+  return FALSE;
+#endif
+}
+
+static gboolean reasonix_window_has_active_transient(GtkWindow *parent, GList *windows) {
+  for (GList *item = windows; item != NULL; item = item->next) {
+    GtkWidget *widget = GTK_WIDGET(item->data);
+    if (!GTK_IS_WINDOW(widget) || gtk_window_get_transient_for(GTK_WINDOW(widget)) != parent) continue;
+    GdkWindow *window = gtk_widget_get_window(widget);
+    if (window == NULL) continue;
+    GdkWindowState state = gdk_window_get_state(window);
+    if (gtk_widget_get_visible(widget) && gtk_widget_get_mapped(widget) &&
+        (state & (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_WITHDRAWN)) == 0 &&
+        gtk_window_is_active(GTK_WINDOW(widget))) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 static gboolean reasonix_probe_main_window(gpointer data) {
   ReasonixWindowProbe *probe = (ReasonixWindowProbe *)data;
   gboolean presented = FALSE;
@@ -34,8 +65,12 @@ static gboolean reasonix_probe_main_window(gpointer data) {
     GdkWindow *window = gtk_widget_get_window(widget);
     if (window == NULL) continue;
     GdkWindowState state = gdk_window_get_state(window);
+    gboolean compositor_confirmed = !reasonix_display_requires_active_window() ||
+        gtk_window_is_active(GTK_WINDOW(widget)) ||
+        reasonix_window_has_active_transient(GTK_WINDOW(widget), windows);
     if (gtk_widget_get_visible(widget) && gtk_widget_get_mapped(widget) &&
-        (state & (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_WITHDRAWN)) == 0) {
+        (state & (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_WITHDRAWN)) == 0 &&
+        compositor_confirmed) {
       presented = TRUE;
       break;
     }

--- a/desktop/window_restore_diagnostics_linux.go
+++ b/desktop/window_restore_diagnostics_linux.go
@@ -1,0 +1,100 @@
+//go:build linux && cgo
+
+package main
+
+/*
+#cgo pkg-config: gtk+-3.0
+#include <gtk/gtk.h>
+#include <string.h>
+
+typedef struct {
+  GMutex mutex;
+  GCond cond;
+  gint refs;
+  gboolean done;
+  gboolean presented;
+} ReasonixWindowProbe;
+
+static void reasonix_window_probe_unref(ReasonixWindowProbe *probe) {
+  if (!g_atomic_int_dec_and_test(&probe->refs)) return;
+  g_cond_clear(&probe->cond);
+  g_mutex_clear(&probe->mutex);
+  g_free(probe);
+}
+
+static gboolean reasonix_probe_main_window(gpointer data) {
+  ReasonixWindowProbe *probe = (ReasonixWindowProbe *)data;
+  gboolean presented = FALSE;
+  GList *windows = gtk_window_list_toplevels();
+  for (GList *item = windows; item != NULL; item = item->next) {
+    GtkWidget *widget = GTK_WIDGET(item->data);
+    if (!GTK_IS_WINDOW(widget)) continue;
+    const gchar *title = gtk_window_get_title(GTK_WINDOW(widget));
+    if (title == NULL || strcmp(title, "Reasonix") != 0) continue;
+    GdkWindow *window = gtk_widget_get_window(widget);
+    if (window == NULL) continue;
+    GdkWindowState state = gdk_window_get_state(window);
+    if (gtk_widget_get_visible(widget) && gtk_widget_get_mapped(widget) &&
+        (state & (GDK_WINDOW_STATE_ICONIFIED | GDK_WINDOW_STATE_WITHDRAWN)) == 0) {
+      presented = TRUE;
+      break;
+    }
+  }
+  g_list_free(windows);
+  g_mutex_lock(&probe->mutex);
+  probe->presented = presented;
+  probe->done = TRUE;
+  g_cond_signal(&probe->cond);
+  g_mutex_unlock(&probe->mutex);
+  reasonix_window_probe_unref(probe);
+  return G_SOURCE_REMOVE;
+}
+
+static int reasonix_main_window_is_presented(void) {
+  ReasonixWindowProbe *probe = g_new0(ReasonixWindowProbe, 1);
+  g_mutex_init(&probe->mutex);
+  g_cond_init(&probe->cond);
+  probe->refs = 2;
+  g_main_context_invoke(NULL, reasonix_probe_main_window, probe);
+  g_mutex_lock(&probe->mutex);
+  gint64 deadline = g_get_monotonic_time() + G_TIME_SPAN_SECOND;
+  while (!probe->done && g_cond_wait_until(&probe->cond, &probe->mutex, deadline)) {}
+  gboolean result = probe->done && probe->presented;
+  g_mutex_unlock(&probe->mutex);
+  reasonix_window_probe_unref(probe);
+  return result ? 1 : 0;
+}
+*/
+import "C"
+
+import (
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+func windowRestoreDiagnosticsSupported() bool { return true }
+
+func windowRestoreOwnerAlive(pid int) bool {
+	return desktopProcessAlive(pid)
+}
+
+func windowRestoreConfirmed() bool {
+	return C.reasonix_main_window_is_presented() == 1
+}
+
+func showWindowRestoreFailure(app *App) {
+	if app == nil || app.ctx == nil {
+		return
+	}
+	// gtk_window_present is safe to repeat and is the only Linux presentation
+	// action. Show the native warning after it, so failure cannot strand a
+	// background-only process.
+	runtime.WindowUnminimise(app.ctx)
+	_, _ = runtime.MessageDialog(app.ctx, runtime.MessageDialogOptions{
+		Type:  runtime.WarningDialog,
+		Title: "Reasonix window recovery / Reasonix 窗口恢复",
+		Message: "Reasonix could not confirm that the main window is visible. The window was presented again; if it remains unavailable, exit Reasonix normally and restart it.\n\n" +
+			"Reasonix 无法确认主窗口已可见，已再次尝试呈现窗口；若仍不可用，请正常退出后重新启动。",
+		Buttons:       []string{"OK"},
+		DefaultButton: "OK",
+	})
+}

--- a/desktop/window_restore_diagnostics_linux.go
+++ b/desktop/window_restore_diagnostics_linux.go
@@ -99,12 +99,43 @@ static int reasonix_main_window_is_presented(void) {
   reasonix_window_probe_unref(probe);
   return result ? 1 : 0;
 }
+
+static gboolean reasonix_quit_unreachable_window_on_main(gpointer data) {
+  (void)data;
+  GtkWidget *main_window = NULL;
+  GList *windows = gtk_window_list_toplevels();
+  for (GList *item = windows; item != NULL; item = item->next) {
+    GtkWidget *widget = GTK_WIDGET(item->data);
+    if (!GTK_IS_WINDOW(widget)) continue;
+    const gchar *title = gtk_window_get_title(GTK_WINDOW(widget));
+    if (title != NULL && strcmp(title, "Reasonix") == 0) {
+      main_window = widget;
+      break;
+    }
+  }
+  g_list_free(windows);
+  if (main_window != NULL) {
+    // Destroying the parent also terminates a nested gtk_dialog_run used by
+    // Wails' recovery warning, allowing the outer GTK loop to exit cleanly.
+    gtk_widget_destroy(main_window);
+  }
+  gtk_main_quit();
+  return G_SOURCE_REMOVE;
+}
+
+static void reasonix_quit_unreachable_window(void) {
+  g_main_context_invoke(NULL, reasonix_quit_unreachable_window_on_main, NULL);
+}
 */
 import "C"
 
 import (
+	"time"
+
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
+
+const windowRestoreFailureVisibilityTimeout = 2 * time.Second
 
 func windowRestoreDiagnosticsSupported() bool { return true }
 
@@ -124,6 +155,24 @@ func showWindowRestoreFailure(app *App) {
 	// action. Show the native warning after it, so failure cannot strand a
 	// background-only process.
 	runtime.WindowUnminimise(app.ctx)
+	dialogDone := make(chan struct{})
+	app.goSafe("windowRestoreFailureVisibility", func() {
+		timer := time.NewTimer(windowRestoreFailureVisibilityTimeout)
+		defer timer.Stop()
+		select {
+		case <-dialogDone:
+		case <-timer.C:
+		}
+		if windowRestoreConfirmed() {
+			return
+		}
+		// A Wayland compositor may reject presentation when the triggering
+		// process has no activation token. If neither the main window nor its
+		// warning dialog became usable, a controlled exit is safer than an
+		// unreachable background process.
+		app.forceQuit.Store(true)
+		C.reasonix_quit_unreachable_window()
+	})
 	_, _ = runtime.MessageDialog(app.ctx, runtime.MessageDialogOptions{
 		Type:  runtime.WarningDialog,
 		Title: "Reasonix window recovery / Reasonix 窗口恢复",
@@ -132,4 +181,5 @@ func showWindowRestoreFailure(app *App) {
 		Buttons:       []string{"OK"},
 		DefaultButton: "OK",
 	})
+	close(dialogDone)
 }

--- a/desktop/window_restore_diagnostics_linux.go
+++ b/desktop/window_restore_diagnostics_linux.go
@@ -166,10 +166,9 @@ func showWindowRestoreFailure(app *App) {
 		if windowRestoreConfirmed() {
 			return
 		}
-		// A Wayland compositor may reject presentation when the triggering
-		// process has no activation token. If neither the main window nor its
-		// warning dialog became usable, a controlled exit is safer than an
-		// unreachable background process.
+		// A Wayland compositor may reject presentation without an activation token.
+		// If neither the main window nor its warning became usable, exit cleanly
+		// instead of leaving an unreachable background process.
 		app.forceQuit.Store(true)
 		C.reasonix_quit_unreachable_window()
 	})

--- a/desktop/window_restore_diagnostics_linux_nocgo.go
+++ b/desktop/window_restore_diagnostics_linux_nocgo.go
@@ -1,7 +1,8 @@
-//go:build !windows && !linux
+//go:build linux && !cgo
 
 package main
 
 func windowRestoreDiagnosticsSupported() bool { return false }
 func windowRestoreOwnerAlive(int) bool        { return false }
 func windowRestoreConfirmed() bool            { return false }
+func showWindowRestoreFailure(*App)           {}

--- a/desktop/window_restore_failure_other.go
+++ b/desktop/window_restore_failure_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package main
+
+func showWindowRestoreFailure(*App) {}


### PR DESCRIPTION
## Summary

- Coordinate every main-window presentation through one App-owned lifecycle path while preserving Windows/macOS ordering and using GTK present-only recovery on Linux.
- Gate Linux close-to-background on live StatusNotifier watcher/host/item registration, re-present a hidden window if the restore path disappears, and expose a sanitized shell-status contract to settings.
- Separate DOM, React/Wails frontend, and stable-health signals; restart WebKitGTK once in software-rendering compatibility mode with a five-minute loop guard and require a post-reload heartbeat.
- Bound private session-bus connection, authentication, and Hello work; keep one safely closable probe connection and verify watcher/host/item loss and recovery against a private fake D-Bus daemon.
- Treat Wayland activation as compositor acknowledgement so Mutter cannot clear recovery evidence merely because a minimised client surface still looks visible and mapped to GTK.

## Issues

Refs #5421
Refs #5214
Refs #5492
Refs #6422
Refs #7552

Related: #7742 must retain `showMainWindowFrom` for summon and should route its hide path through the shell coordinator when rebased.

## Verification

- Current-head GitHub CI passed completely, including Linux WebKitGTK 4.0 native recovery smoke, WebKitGTK 4.1 observer/tests, desktop Linux/macOS/Windows, race, coverage, cross-platform lint, CodeQL, govulncheck, and Windows installer/portable archive builds
- `cd desktop && go vet ./...`
- `cd desktop && golangci-lint run --timeout=5m`
- Focused desktop `go test -race` coverage for shell lifecycle, compatibility restart, tray loss, close races, renderer recovery, window recovery, and project-tree integration after merging `main-v2` base `7b62956f`
- Private D-Bus integration coverage for no watcher, no host, missing item owner, unregistered item, ready, watcher/host/item loss and re-registration, plus cancellation during stalled Auth and Hello
- `cd desktop/frontend && pnpm build` (hooks lint, bridge/CSS checks, typecheck, production bundle, and bundle budgets passed)
- Linux and Windows pure-Go cross compilation
- Ubuntu 24.04.3 ARM64 / GNOME Wayland native smoke in Parallels:
  - production WebKitGTK 4.1 build and native `.desktop` launch produced a visible mapped window
  - maximised -> minimised -> second `.desktop` launch restored the existing instance and cleared the restore journal
  - a launch without a Wayland activation token no longer produces a false success; after the restore timeout and native warning attempt, the primary process exits cleanly if the compositor still exposes no usable surface, so no unreachable process remains
  - no StatusNotifierWatcher/Host kept the window visible, reported the stable tray bucket, and window close exited normally instead of leaving an unreachable process
- Linux ARM64 `go vet -tags webkit2_41 ./...`, focused CGO tests, and focused CGO race tests passed
- Linux ARM64 full `go test -tags webkit2_41 ./...` passed with only `TestFetchManifestSkipsMalformedSuccessfulResponse` excluded; that existing release-manifest fixture has no `linux-arm64` platform key and reproduces unchanged outside this PR
- `git diff --check`

Not yet run:

- Preview/native matrix: Deepin 25; Ubuntu 24.04 GNOME X11; KDE Plasma Wayland + NVIDIA; Linux Mint Cinnamon X11 with and without StatusNotifierHost

## Documentation impact

Documentation-impact: none - the embedded documentation catalog has no desktop shell lifecycle contract; the recovery behavior is documented in `desktop/README.md` and the session-specific tray fallback is explained inline in localized Settings copy.

## Cache impact

Cache-impact: none - no provider-visible prompt, tool schema, memory, compaction, or request serialization changes.
Cache-guard: N/A - desktop native shell and settings-only change.
System-prompt-review: N/A