### PR TITLE
Fix cross-session navigation ghost content / 修复跨会话导航幽灵内容

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4094,13 +4094,25 @@ export default function App() {
   // Workspace: open the folder chooser and switch projects. The hook resets the
   // transcript and refreshes meta on a pick. A cancel is a no-op.
   const switchFolder = useCallback(async (path?: string) => {
-    const picked = path === undefined ? await pickWorkspace() : await switchWorkspace(path);
-    if (picked) {
-      setProjectRevision((value) => value + 1);
-      await refreshTabMetas(undefined, { afterMutation: true });
+    const navigationIntentSeq = noteNavigationIntent();
+    beginNavigationSurface(navigationIntentSeq);
+    try {
+      const picked = path === undefined
+        ? await pickWorkspace(navigationIntentSeq)
+        : await switchWorkspace(path, navigationIntentSeq);
+      if (!isNavigationIntentCurrent(navigationIntentSeq)) return picked;
+      if (picked) {
+        setProjectRevision((value) => value + 1);
+        await refreshTabMetas(
+          () => isNavigationIntentCurrent(navigationIntentSeq),
+          { afterMutation: true },
+        );
+      }
+      return picked;
+    } finally {
+      settleNavigationSurface(navigationIntentSeq);
     }
-    return picked;
-  }, [pickWorkspace, switchWorkspace, refreshTabMetas]);
+  }, [beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, pickWorkspace, refreshTabMetas, settleNavigationSurface, switchWorkspace]);
 
   const refreshProjectsAndTabs = useCallback(async () => {
     setProjectRevision((value) => value + 1);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { flushSync } from "react-dom";
 import { ShellExpandProvider, useShellExpand } from "./lib/shellExpand";
 import {
   Activity,
@@ -178,6 +179,7 @@ import { hydrateDisplayMode } from "./lib/displayMode";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId } from "./lib/statusBarItems";
 import { paletteSessionDisplayTitle, paletteSessionHint, paletteSessionKeywords, sessionActivityTime } from "./lib/session";
 import { enqueueNavigationRequest, type PendingNavigationRequest } from "./lib/openTopicCoalescing";
+import { settleNavigationSurfaceIntent } from "./lib/navigationSurfaceTransition";
 import {
   applyTheme,
   clearLegacyThemePreference,
@@ -1113,6 +1115,13 @@ export default function App() {
   const userPlanModeByTabRef = useRef<UserPlanModeIntents>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
+  const [navigationSurfaceIntent, setNavigationSurfaceIntent] = useState<number | null>(null);
+  const beginNavigationSurface = useCallback((intent: number) => {
+    flushSync(() => setNavigationSurfaceIntent(intent));
+  }, []);
+  const settleNavigationSurface = useCallback((intent: number) => {
+    setNavigationSurfaceIntent((current) => settleNavigationSurfaceIntent(current, intent));
+  }, []);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
   const startupSplashVisible = useOverlayStore((s) => s.startupSplashVisible);
@@ -1698,7 +1707,7 @@ export default function App() {
   const goal = composerProfile.goal;
   const collaborationMode = displayedComposerProfileCollaborationMode(composerProfile);
   const toolApprovalMode = composerProfile.toolApprovalMode;
-  const runtimeTransitioning = false;
+  const runtimeTransitioning = navigationSurfaceIntent !== null;
   const controllerReady =
     state.meta?.ready === true &&
     (!state.meta.runtime || state.meta.runtime.phase === "ready") &&
@@ -1718,6 +1727,8 @@ export default function App() {
     if (clearContextPending) return "clear_context";
     return null;
   }, [clearContextPending, pendingClose, state.approval, state.ask, state.extensionForm, workspaceConflict]);
+  const visibleDecisionSurface = runtimeTransitioning ? null : decisionSurface;
+  const composerSurfaceHidden = runtimeTransitioning || Boolean(decisionSurface);
   decisionSurfaceRef.current = decisionSurface;
   useEffect(() => {
     // Close composer menus/popovers when a decision takes over the footer.
@@ -3111,32 +3122,42 @@ export default function App() {
       // can wait behind an older tab switch. That immediately invalidates any
       // in-flight blank/topic completion from a previous user intent.
       const navigationIntentSeq = noteNavigationIntent();
+      beginNavigationSurface(navigationIntentSeq);
       return enqueueNavigationRequest(
         { seqRef: tabSwitchSeqRef, runningRef: tabSwitchRunningRef, pendingRef: tabSwitchPendingRef },
         { tabId, optimisticTab, navigationIntentSeq },
         async (request) => {
-          if (!isNavigationIntentCurrent(request.navigationIntentSeq)) return;
-          await switchTab(request.tabId, request.optimisticTab, request.navigationIntentSeq);
-          if (!isNavigationIntentCurrent(request.navigationIntentSeq)) return;
-          await refreshTabMetas(
-            () => isNavigationIntentCurrent(request.navigationIntentSeq),
-            { afterMutation: true },
-          );
+          try {
+            if (!isNavigationIntentCurrent(request.navigationIntentSeq)) return;
+            await switchTab(request.tabId, request.optimisticTab, request.navigationIntentSeq);
+            if (!isNavigationIntentCurrent(request.navigationIntentSeq)) return;
+            await refreshTabMetas(
+              () => isNavigationIntentCurrent(request.navigationIntentSeq),
+              { afterMutation: true },
+            );
+          } finally {
+            settleNavigationSurface(request.navigationIntentSeq);
+          }
         },
       );
     },
-    [isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, switchTab],
+    [beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, switchTab],
   );
 
   const revealBackgroundRuntime = useCallback(async (tabId: string): Promise<void> => {
+    const navigationIntentSeq = noteNavigationIntent();
+    beginNavigationSurface(navigationIntentSeq);
     try {
       const meta = await app.RevealBackgroundRuntime(tabId);
-      await switchTab(meta.id, meta);
+      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
+      await switchTab(meta.id, meta, navigationIntentSeq);
       await refreshTabMetas(undefined, { afterMutation: true });
     } catch (err) {
-      showToast(err instanceof Error ? err.message : String(err), "error");
+      if (isNavigationIntentCurrent(navigationIntentSeq)) showToast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      settleNavigationSurface(navigationIntentSeq);
     }
-  }, [refreshTabMetas, showToast, switchTab]);
+  }, [beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
 
   const handleTabChange = useCallback((id: string) => {
     closeTransientOverlays();
@@ -3203,28 +3224,37 @@ export default function App() {
 
   const revealWorkspaceWriter = useCallback(async () => {
     if (!activeTabId) return;
+    const navigationIntentSeq = noteNavigationIntent();
+    beginNavigationSurface(navigationIntentSeq);
     try {
       const meta = await app.RevealWorkspaceWriterForTab(activeTabId);
+      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
       setWorkspaceConflict(null);
-      await switchTab(meta.id, meta);
+      await switchTab(meta.id, meta, navigationIntentSeq);
       await refreshTabMetas(undefined, { afterMutation: true });
     } catch (err) {
-      showToast(err instanceof Error ? err.message : String(err), "error");
+      if (isNavigationIntentCurrent(navigationIntentSeq)) showToast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      settleNavigationSurface(navigationIntentSeq);
     }
-  }, [activeTabId, refreshTabMetas, showToast, switchTab]);
+  }, [activeTabId, beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
 
   const continueInDeliveryWorktree = useCallback(async () => {
     const root = state.meta?.workspaceRoot || state.meta?.workspacePath || state.meta?.cwd;
     if (!root) return;
     cancel();
     setWorkspaceConflict(null);
+    const navigationIntentSeq = noteNavigationIntent();
+    beginNavigationSurface(navigationIntentSeq);
     try {
-      await createIsolatedWorktree(root);
+      await createIsolatedWorktree(root, navigationIntentSeq);
       await refreshTabMetas(undefined, { afterMutation: true });
     } catch (err) {
-      showToast(err instanceof Error ? err.message : String(err), "error");
+      if (isNavigationIntentCurrent(navigationIntentSeq)) showToast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      settleNavigationSurface(navigationIntentSeq);
     }
-  }, [cancel, createIsolatedWorktree, refreshTabMetas, showToast, state.meta?.cwd, state.meta?.workspacePath, state.meta?.workspaceRoot]);
+  }, [beginNavigationSurface, cancel, createIsolatedWorktree, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, showToast, state.meta?.cwd, state.meta?.workspacePath, state.meta?.workspaceRoot]);
 
   const handleTabsClose = useCallback(async (ids: string[], nextActiveTabId?: string) => {
     closeTransientOverlays();
@@ -3319,6 +3349,7 @@ export default function App() {
   // (desktopLayoutStyle is available here; sidebarCreation is declared later.)
   const creationEmptyHero =
     desktopLayoutStyle === "creation" &&
+    !runtimeTransitioning &&
     !sidebarImDetailConnection &&
     !sessionHasContent &&
     !transcriptHydrating &&
@@ -3695,12 +3726,19 @@ export default function App() {
   }, [activateTopic, createIsolatedWorktree, ensureBlankSurface, ensureBlankTab, isNavigationIntentCurrent, openChannelSession, openGlobalTab, openProjectTab, openTopicSession, refreshHistoryView, resumeSession, seedActiveTabMeta, showToast, singleSurfaceLayout, t]);
 
   const enqueueNavigationWithIntent = useCallback((input: DesktopNavigationIntent, navigationIntentSeq: number): Promise<void> => {
+    beginNavigationSurface(navigationIntentSeq);
     return enqueueNavigationRequest(
       { seqRef: navigationSeqRef, runningRef: navigationRunningRef, pendingRef: navigationPendingRef },
       { ...input, navigationIntentSeq } as DesktopNavigationInput,
-      runNavigationRequest,
+      async (request) => {
+        try {
+          await runNavigationRequest(request);
+        } finally {
+          settleNavigationSurface(request.navigationIntentSeq);
+        }
+      },
     );
-  }, [runNavigationRequest]);
+  }, [beginNavigationSurface, runNavigationRequest, settleNavigationSurface]);
 
   const enqueueNavigation = useCallback((input: DesktopNavigationIntent): Promise<void> => {
     // Invalidate any in-flight activation's stale apply at ENQUEUE time. The
@@ -3753,19 +3791,29 @@ export default function App() {
     // switches tabs while the task/session lookup is pending, its completion is
     // stale and must not enqueue a newer navigation request.
     const navigationIntentSeq = noteNavigationIntent();
-    const session = await resolveTaskMonitorSession({
-      tabID,
-      taskID,
-      intentSeq: navigationIntentSeq,
-      isIntentCurrent: isNavigationIntentCurrent,
-      openTaskSessionForTab: (sourceTabID, sourceTaskID) => app.OpenTaskSessionForTab(sourceTabID, sourceTaskID),
-      listSessionsForTab: async (sourceTabID) => asArray(await app.ListSessionsForTab(sourceTabID)),
-      sessionIDFromPath: taskSessionIDFromPath,
-    });
-    if (!session) return false;
+    beginNavigationSurface(navigationIntentSeq);
+    let session: SessionMeta | null;
+    try {
+      session = await resolveTaskMonitorSession({
+        tabID,
+        taskID,
+        intentSeq: navigationIntentSeq,
+        isIntentCurrent: isNavigationIntentCurrent,
+        openTaskSessionForTab: (sourceTabID, sourceTaskID) => app.OpenTaskSessionForTab(sourceTabID, sourceTaskID),
+        listSessionsForTab: async (sourceTabID) => asArray(await app.ListSessionsForTab(sourceTabID)),
+        sessionIDFromPath: taskSessionIDFromPath,
+      });
+    } catch (error) {
+      settleNavigationSurface(navigationIntentSeq);
+      throw error;
+    }
+    if (!session) {
+      settleNavigationSurface(navigationIntentSeq);
+      return false;
+    }
     await enqueueNavigationWithIntent({ kind: "resume-session", session }, navigationIntentSeq);
     return isNavigationIntentCurrent(navigationIntentSeq);
-  }, [enqueueNavigationWithIntent, isNavigationIntentCurrent, noteNavigationIntent, singleSurfaceLayout, state.running, t]);
+  }, [beginNavigationSurface, enqueueNavigationWithIntent, isNavigationIntentCurrent, noteNavigationIntent, settleNavigationSurface, singleSurfaceLayout, state.running, t]);
 
   // Command palette: ⌘K / Ctrl+K opens a fuzzy navigator over commands and
   // recent sessions. Sessions are snapshotted on open so the list is stable
@@ -4727,7 +4775,7 @@ export default function App() {
           />
 
           <main className="main">
-            {sidebarImDetailConnection ? (
+            {sidebarImDetailConnection && !runtimeTransitioning ? (
               <SidebarImConnectionDetail
                 connection={sidebarImDetailConnection}
                 onClose={() => setSidebarImDetailConnectionId("")}
@@ -4740,8 +4788,8 @@ export default function App() {
             ) : (
               <>
                 <Transcript
-                  items={displayItems}
-                  live={state.live}
+                  items={runtimeTransitioning ? [] : displayItems}
+                  live={runtimeTransitioning ? undefined : state.live}
                   liveStore={liveStore}
                   tabId={activeTabId}
                   footerHeight={footerHeight}
@@ -4757,24 +4805,24 @@ export default function App() {
                   turnStartAt={state.turnStartAt}
                   welcomeVariant={sidebarCreation ? "creation" : "default"}
                   creationMode={sidebarCreation}
-                  actionHoverMenus={sidebarCreation && !hydratePlaceholderActive}
+                  actionHoverMenus={sidebarCreation && !hydratePlaceholderActive && !runtimeTransitioning}
                   rewindSignal={rewindSignal}
                   revealSignal={transcriptRevealSignal}
-                  hydrating={transcriptHydrating}
-                  hasOlderHistory={state.historyHasOlder && !rewindState}
+                  hydrating={runtimeTransitioning || transcriptHydrating}
+                  hasOlderHistory={!runtimeTransitioning && state.historyHasOlder && !rewindState}
                   olderHistoryCount={state.historyStartTurn}
                   loadingOlderHistory={state.historyOlderLoading}
                   onLoadOlderHistory={() => activeTabId && loadOlderHistory(activeTabId)}
                   invocationMetadata={activeTabId ? invocationMetadataByTab[activeTabId] : undefined}
                 />
-                {state.hydrateError ? <div className="history-load-error" role="alert"><span>{state.hydrateError}</span><button type="button" className="btn btn--small" onClick={() => void retrySessionHistory(activeTabId)}>{t("common.retry")}</button></div> : null}
+                {!runtimeTransitioning && state.hydrateError ? <div className="history-load-error" role="alert"><span>{state.hydrateError}</span><button type="button" className="btn btn--small" onClick={() => void retrySessionHistory(activeTabId)}>{t("common.retry")}</button></div> : null}
               </>
             )}
           </main>
 
           {!sidebarImDetailConnection && (
-          <footer className={["footer", terminalPanelOpen && !sidebarCreation ? "footer--compact" : "", decisionSurface ? "footer--decision" : ""].filter(Boolean).join(" ")} ref={footerRef}>
-            {showTodos && (
+          <footer className={["footer", terminalPanelOpen && !sidebarCreation ? "footer--compact" : "", visibleDecisionSurface ? "footer--decision" : ""].filter(Boolean).join(" ")} ref={footerRef}>
+            {!runtimeTransitioning && showTodos && (
               <TodoPanel
                 key={scopedTodoBatch}
                 stateKey={scopedTodoBatch}
@@ -4782,7 +4830,7 @@ export default function App() {
                 onDismiss={dismissTodos}
               />
             )}
-            {rewindState && (
+            {!runtimeTransitioning && rewindState && (
               <Suspense fallback={null}><UndoRewindBanner
                 meta={{
                   turns: rewindState.turnDiff,
@@ -4809,7 +4857,7 @@ export default function App() {
                 }}
               /></Suspense>
             )}
-            {decisionSurface === "tool_approval" || decisionSurface === "plan_approval"
+            {visibleDecisionSurface === "tool_approval" || visibleDecisionSurface === "plan_approval"
               ? state.approval && (
               <ApprovalModal
                 key={`${activeTabId ?? ""}:${state.approval.id}`}
@@ -4853,7 +4901,7 @@ export default function App() {
                 toolApprovalMode={toolApprovalMode}
               />
               )
-            : decisionSurface === "ask"
+            : visibleDecisionSurface === "ask"
               ? state.ask && (
               <AskCard
                 key={`${activeTabId ?? ""}:${state.ask.id}`}
@@ -4865,7 +4913,7 @@ export default function App() {
                 }}
               />
               )
-            : decisionSurface === "extension_form"
+            : visibleDecisionSurface === "extension_form"
               ? state.extensionForm && (
               <ExtensionFormDialog
                 key={`${activeTabId ?? ""}:${state.extensionForm.pluginId}:${state.extensionForm.surfaceId}`}
@@ -4875,7 +4923,7 @@ export default function App() {
                 onCancel={() => void cancelExtensionForm()}
               />
               )
-            : decisionSurface === "workspace_conflict" && workspaceConflict ? (
+            : visibleDecisionSurface === "workspace_conflict" && workspaceConflict ? (
               <RuntimeDecisionCard
                 id="workspace-conflict"
                 title={t("runtime.workspaceConflictTitle")}
@@ -4904,7 +4952,7 @@ export default function App() {
                 }}
               />
             )
-            : decisionSurface === "close_active" && pendingClose ? (
+            : visibleDecisionSurface === "close_active" && pendingClose ? (
               <RuntimeDecisionCard
                 id="close-active"
                 title={t("runtime.closeTitle")}
@@ -4928,7 +4976,7 @@ export default function App() {
                 }}
               />
             )
-            : decisionSurface === "clear_context" ? (
+            : visibleDecisionSurface === "clear_context" ? (
               <ClearContextCard
                 onCancel={cancelClearContext}
                 onConfirm={() => {
@@ -4941,12 +4989,12 @@ export default function App() {
             <div
               className={[
                 "composer-decision-host",
-                decisionSurface ? "composer-decision-host--hidden" : "",
+                composerSurfaceHidden ? "composer-decision-host--hidden" : "",
                 creationEmptyHero ? "composer-decision-host--creation-hero" : "",
               ].filter(Boolean).join(" ")}
-              hidden={Boolean(decisionSurface) || undefined}
-              inert={decisionSurface ? true : undefined}
-              aria-hidden={decisionSurface ? true : undefined}
+              hidden={composerSurfaceHidden || undefined}
+              inert={composerSurfaceHidden ? true : undefined}
+              aria-hidden={composerSurfaceHidden ? true : undefined}
             >
             {creationEmptyHero && (
               <h2 className="welcome-creation__headline">{t("welcome.creation.title")}</h2>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -179,7 +179,7 @@ import { hydrateDisplayMode } from "./lib/displayMode";
 import { DEFAULT_STATUS_BAR_ITEMS, normalizeStatusBarItems, type StatusBarItemId } from "./lib/statusBarItems";
 import { paletteSessionDisplayTitle, paletteSessionHint, paletteSessionKeywords, sessionActivityTime } from "./lib/session";
 import { enqueueNavigationRequest, type PendingNavigationRequest } from "./lib/openTopicCoalescing";
-import { settleNavigationSurfaceIntent } from "./lib/navigationSurfaceTransition";
+import { guardBackendNavigationResult, settleNavigationSurfaceIntent } from "./lib/navigationSurfaceTransition";
 import {
   applyTheme,
   clearLegacyThemePreference,
@@ -1104,6 +1104,7 @@ export default function App() {
     activateTopic,
     noteNavigationIntent,
     isNavigationIntentCurrent,
+    reassertVisibleTabAfterStaleNavigation,
     syncActiveTab,
     ensureBlankTab,
     ensureBlankSurface,
@@ -3149,15 +3150,25 @@ export default function App() {
     beginNavigationSurface(navigationIntentSeq);
     try {
       const meta = await app.RevealBackgroundRuntime(tabId);
-      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
+      if (!await guardBackendNavigationResult({
+        intent: navigationIntentSeq,
+        targetTabId: meta.id,
+        kind: "tab.reveal-background",
+        isIntentCurrent: isNavigationIntentCurrent,
+        reassert: reassertVisibleTabAfterStaleNavigation,
+      })) return;
       await switchTab(meta.id, meta, navigationIntentSeq);
-      await refreshTabMetas(undefined, { afterMutation: true });
+      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
+      await refreshTabMetas(
+        () => isNavigationIntentCurrent(navigationIntentSeq),
+        { afterMutation: true },
+      );
     } catch (err) {
       if (isNavigationIntentCurrent(navigationIntentSeq)) showToast(err instanceof Error ? err.message : String(err), "error");
     } finally {
       settleNavigationSurface(navigationIntentSeq);
     }
-  }, [beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
+  }, [beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, reassertVisibleTabAfterStaleNavigation, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
 
   const handleTabChange = useCallback((id: string) => {
     closeTransientOverlays();
@@ -3228,16 +3239,26 @@ export default function App() {
     beginNavigationSurface(navigationIntentSeq);
     try {
       const meta = await app.RevealWorkspaceWriterForTab(activeTabId);
-      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
+      if (!await guardBackendNavigationResult({
+        intent: navigationIntentSeq,
+        targetTabId: meta.id,
+        kind: "tab.reveal-workspace-writer",
+        isIntentCurrent: isNavigationIntentCurrent,
+        reassert: reassertVisibleTabAfterStaleNavigation,
+      })) return;
       setWorkspaceConflict(null);
       await switchTab(meta.id, meta, navigationIntentSeq);
-      await refreshTabMetas(undefined, { afterMutation: true });
+      if (!isNavigationIntentCurrent(navigationIntentSeq)) return;
+      await refreshTabMetas(
+        () => isNavigationIntentCurrent(navigationIntentSeq),
+        { afterMutation: true },
+      );
     } catch (err) {
       if (isNavigationIntentCurrent(navigationIntentSeq)) showToast(err instanceof Error ? err.message : String(err), "error");
     } finally {
       settleNavigationSurface(navigationIntentSeq);
     }
-  }, [activeTabId, beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
+  }, [activeTabId, beginNavigationSurface, isNavigationIntentCurrent, noteNavigationIntent, reassertVisibleTabAfterStaleNavigation, refreshTabMetas, settleNavigationSurface, showToast, switchTab]);
 
   const continueInDeliveryWorktree = useCallback(async () => {
     const root = state.meta?.workspaceRoot || state.meta?.workspacePath || state.meta?.cwd;

--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -1,6 +1,8 @@
 // Run: tsx src/__tests__/hydrate-history-apply.test.ts
 
 import {
+  activeTabHydrationPlan,
+  canAdoptUnboundLiveSurface,
   duplicateLiveItemIds,
   hasCachedLiveTurn,
   hydratedHistoryApplyMode,
@@ -93,6 +95,58 @@ ok(
 ok(
   !sameSessionHydrateIdentity({ sessionPath: "" }, { sessionPath: "" }),
   "empty identities cannot prove the same session",
+);
+const sameSessionPlan = activeTabHydrationPlan(
+  { sessionPath: "a.jsonl", sessionGeneration: 3, sessionRevision: 8, sessionDigest: "rev-8" },
+  { sessionPath: "a.jsonl", sessionGeneration: 3 },
+  false,
+);
+ok(sameSessionPlan.surfacePolicy === "preserve-current", "backend sync preserves a proven same-session surface");
+ok(sameSessionPlan.loadOptions.preserveCachedHistory, "same-session backend sync may reuse its resident history");
+const reboundPlan = activeTabHydrationPlan(
+  { sessionPath: "a.jsonl", sessionGeneration: 4, sessionRevision: 9, sessionDigest: "rev-9" },
+  { sessionPath: "a.jsonl", sessionGeneration: 3 },
+  false,
+);
+ok(reboundPlan.surfacePolicy === "replace-surface", "backend sync replaces a generation-rebound surface");
+ok(reboundPlan.loadOptions.sessionGeneration === 4, "replace-surface hydration carries the target generation fence");
+ok(
+  canAdoptUnboundLiveSurface(
+    { sessionPath: "a.jsonl", sessionGeneration: 3 },
+    undefined,
+    { running: true, live: { text: "partial" }, items: [{ kind: "assistant", streaming: true }] },
+    true,
+  ),
+  "an unbound live runtime tail can be adopted before its first metadata snapshot",
+);
+ok(
+  !canAdoptUnboundLiveSurface(
+    { sessionPath: "a.jsonl" },
+    { sessionPath: "b.jsonl" },
+    { running: true, live: { text: "stale" }, items: [{ kind: "assistant", streaming: true }] },
+    true,
+  ),
+  "a differently identified surface cannot be adopted as a live tail",
+);
+ok(
+  !canAdoptUnboundLiveSurface(
+    { sessionPath: "a.jsonl" },
+    undefined,
+    { running: true, historyTotalTurns: 1, hydrateHistoryLoaded: true, items: [{ kind: "assistant", streaming: true }] },
+    true,
+  ),
+  "a surface with persisted history is never adopted without session identity",
+);
+ok(
+  !canAdoptUnboundLiveSurface(
+    { sessionPath: "a.jsonl" },
+    undefined,
+    { running: true, live: { text: "stale epoch" }, items: [{ kind: "assistant", streaming: true }] },
+    true,
+    "runtime-new",
+    "runtime-old",
+  ),
+  "a mismatched runtime epoch rejects an unbound live tail",
 );
 
 ok(

--- a/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-history-apply.test.ts
@@ -4,6 +4,7 @@ import {
   duplicateLiveItemIds,
   hasCachedLiveTurn,
   hydratedHistoryApplyMode,
+  sameSessionHydrateIdentity,
   sameSessionPlaceholderItems,
   shouldPreferResidentHistory,
 } from "../lib/hydrateHistoryApply";
@@ -68,12 +69,30 @@ ok(
   "a live tail the page does not carry is kept",
 );
 ok(
-  sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "b.jsonl" }, items: [{ kind: "user" }] }) === undefined,
+  sameSessionPlaceholderItems({ sessionPath: "a.jsonl" }, { meta: { sessionPath: "b.jsonl" }, items: [{ kind: "user" }] }) === undefined,
   "foreign session items are not placeholders",
 );
 ok(
-  (sameSessionPlaceholderItems("a.jsonl", { meta: { sessionPath: "a.jsonl" }, items: [{ kind: "user" }] }) ?? []).length === 1,
+  (sameSessionPlaceholderItems({ sessionPath: "a.jsonl" }, { meta: { sessionPath: "a.jsonl" }, items: [{ kind: "user" }] }) ?? []).length === 1,
   "same-session items stay placeholders",
+);
+ok(
+  sameSessionHydrateIdentity(
+    { sessionPath: "a.jsonl", sessionGeneration: 3 },
+    { sessionPath: "a.jsonl", sessionGeneration: 3 },
+  ),
+  "same path and generation prove the same session",
+);
+ok(
+  !sameSessionHydrateIdentity(
+    { sessionPath: "a.jsonl", sessionGeneration: 4 },
+    { sessionPath: "a.jsonl", sessionGeneration: 3 },
+  ),
+  "different generations reject placeholders even when paths match",
+);
+ok(
+  !sameSessionHydrateIdentity({ sessionPath: "" }, { sessionPath: "" }),
+  "empty identities cannot prove the same session",
 );
 
 ok(

--- a/desktop/frontend/src/__tests__/hydrate-replace-surface-failure.test.ts
+++ b/desktop/frontend/src/__tests__/hydrate-replace-surface-failure.test.ts
@@ -1,0 +1,27 @@
+// Run: tsx src/__tests__/hydrate-replace-surface-failure.test.ts
+
+import { initialState, reducer, type Item } from "../lib/useController";
+
+let passed = 0;
+let failed = 0;
+function ok(value: boolean, label: string) {
+  process.stdout.write(`  ${value ? "PASS" : "FAIL"}  ${label}\n`);
+  if (value) passed += 1;
+  else failed += 1;
+}
+
+console.log("\nreplace-surface hydrate failure");
+const sourceItems: Item[] = [{ kind: "user", id: "source-only", text: "SOURCE SESSION SENTINEL" }];
+const source = { ...initialState, items: sourceItems };
+const targetLoading = reducer(
+  reducer(reducer(source, { type: "hydrate_start", reason: "open-topic" }), { type: "reset" }),
+  { type: "hydrate_start", reason: "open-topic" },
+);
+ok(targetLoading.items.length === 0, "replace-surface clears source rows before target history settles");
+const targetFailed = reducer(targetLoading, { type: "hydrate_error", reason: "open-topic", error: "history failed" });
+ok(targetFailed.hydrating === false, "target history failure exits the loading state");
+ok(targetFailed.hydrateError === "history failed", "target history failure exposes a retryable error");
+ok(!targetFailed.items.some((item) => item.kind === "user" && item.text === "SOURCE SESSION SENTINEL"), "target history failure never restores source rows");
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -64,6 +64,15 @@ ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the 
 ok(appSource.includes("!runtimeTransitioning && showTodos"), "source-session Todo content is isolated");
 ok(appSource.includes("!runtimeTransitioning && rewindState"), "source-session rewind content is isolated");
 ok((appSource.match(/guardBackendNavigationResult\(\{/g) ?? []).length === 2, "both Reveal paths guard stale backend activation results");
+const switchFolderSource = appSource.slice(
+  appSource.indexOf("const switchFolder = useCallback"),
+  appSource.indexOf("const refreshProjectsAndTabs = useCallback"),
+);
+ok(switchFolderSource.includes("const navigationIntentSeq = noteNavigationIntent()"), "workspace navigation claims the shared intent before Wails");
+ok(switchFolderSource.includes("beginNavigationSurface(navigationIntentSeq)"), "workspace navigation masks the source surface before Wails");
+ok(switchFolderSource.includes("pickWorkspace(navigationIntentSeq)"), "folder-pick navigation carries the shared intent into the controller");
+ok(switchFolderSource.includes("switchWorkspace(path, navigationIntentSeq)"), "direct workspace navigation carries the shared intent into the controller");
+ok(switchFolderSource.includes("settleNavigationSurface(navigationIntentSeq)"), "workspace navigation compare-clears its surface mask");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -1,7 +1,7 @@
 // Run: tsx src/__tests__/navigation-surface-transition.test.ts
 
 import { readFileSync } from "node:fs";
-import { settleNavigationSurfaceIntent } from "../lib/navigationSurfaceTransition";
+import { guardBackendNavigationResult, settleNavigationSurfaceIntent } from "../lib/navigationSurfaceTransition";
 
 let passed = 0;
 let failed = 0;
@@ -24,6 +24,37 @@ ok(active === 3, "coalesced B completion cannot release C's mask");
 active = settleNavigationSurfaceIntent(active, 3);
 ok(active === null, "the latest completion releases its own mask");
 
+let reasserted = "";
+const currentAccepted = await guardBackendNavigationResult({
+  intent: 4,
+  targetTabId: "tab-current",
+  kind: "tab.reveal-background",
+  isIntentCurrent: (intent) => intent === 4,
+  reassert: async (kind, tabId) => { reasserted = `${kind}:${tabId}`; },
+});
+ok(currentAccepted, "the current backend navigation result is accepted");
+ok(reasserted === "", "the current backend navigation result does not reassert");
+
+let releaseReassert!: () => void;
+const reassertGate = new Promise<void>((resolve) => { releaseReassert = resolve; });
+let staleReassertStarted = false;
+const staleAcceptedPromise = guardBackendNavigationResult({
+  intent: 4,
+  targetTabId: "tab-stale",
+  kind: "tab.reveal-background",
+  isIntentCurrent: (intent) => intent === 5,
+  reassert: async (kind, tabId) => {
+    staleReassertStarted = true;
+    reasserted = `${kind}:${tabId}`;
+    await reassertGate;
+  },
+});
+await Promise.resolve();
+ok(staleReassertStarted, "a stale backend-activating result starts visible-tab reassertion");
+releaseReassert();
+ok(await staleAcceptedPromise === false, "a stale backend-activating result is rejected after reassertion");
+ok(reasserted === "tab.reveal-background:tab-stale", "stale reassertion receives the mutating target identity");
+
 const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
 ok(appSource.includes("flushSync(() => setNavigationSurfaceIntent(intent))"), "navigation masking commits synchronously before the Wails await");
 ok(appSource.includes("items={runtimeTransitioning ? [] : displayItems}"), "App removes source transcript rows during navigation");
@@ -32,6 +63,7 @@ ok(appSource.includes("hidden={composerSurfaceHidden || undefined}"), "App keeps
 ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the hidden composer is inert during navigation");
 ok(appSource.includes("!runtimeTransitioning && showTodos"), "source-session Todo content is isolated");
 ok(appSource.includes("!runtimeTransitioning && rewindState"), "source-session rewind content is isolated");
+ok((appSource.match(/guardBackendNavigationResult\(\{/g) ?? []).length === 2, "both Reveal paths guard stale backend activation results");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
+++ b/desktop/frontend/src/__tests__/navigation-surface-transition.test.ts
@@ -1,0 +1,37 @@
+// Run: tsx src/__tests__/navigation-surface-transition.test.ts
+
+import { readFileSync } from "node:fs";
+import { settleNavigationSurfaceIntent } from "../lib/navigationSurfaceTransition";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  process.stdout.write(`  ${value ? "PASS" : "FAIL"}  ${label}\n`);
+  if (value) passed += 1;
+  else failed += 1;
+}
+
+console.log("\nnavigation surface transition");
+
+let active: number | null = 1;
+active = 2; // B supersedes A before A completes.
+active = 3; // C supersedes queued B.
+active = settleNavigationSurfaceIntent(active, 1);
+ok(active === 3, "A completion cannot release C's mask");
+active = settleNavigationSurfaceIntent(active, 2);
+ok(active === 3, "coalesced B completion cannot release C's mask");
+active = settleNavigationSurfaceIntent(active, 3);
+ok(active === null, "the latest completion releases its own mask");
+
+const appSource = readFileSync(new URL("../App.tsx", import.meta.url), "utf8");
+ok(appSource.includes("flushSync(() => setNavigationSurfaceIntent(intent))"), "navigation masking commits synchronously before the Wails await");
+ok(appSource.includes("items={runtimeTransitioning ? [] : displayItems}"), "App removes source transcript rows during navigation");
+ok(appSource.includes("live={runtimeTransitioning ? undefined : state.live}"), "App removes source live output during navigation");
+ok(appSource.includes("hidden={composerSurfaceHidden || undefined}"), "App keeps the composer mounted but hidden during navigation");
+ok(appSource.includes("inert={composerSurfaceHidden ? true : undefined}"), "the hidden composer is inert during navigation");
+ok(appSource.includes("!runtimeTransitioning && showTodos"), "source-session Todo content is isolated");
+ok(appSource.includes("!runtimeTransitioning && rewindState"), "source-session rewind content is isolated");
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-hydration.test.tsx
@@ -642,7 +642,7 @@ await act(async () => {
 });
 eq(controller?.activeTabId, "tab-d", "openProjectTab activates the opened tab");
 eq(controller?.state.items.length, 0, "open topic keeps the new tab transcript empty while hydrating");
-ok(controller?.state.hydratePlaceholderItems?.some((item) => item.kind === "user" && item.text === "streaming C") ?? false, "open topic stores previous transcript only as a hydration placeholder");
+eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "cross-session open never reuses the source transcript as a placeholder");
 
 await act(async () => {
   historyD.resolve([userMessage("history D")]);
@@ -792,10 +792,9 @@ await act(async () => {
   await controller?.openProjectTab(tabH.workspaceRoot, tabH.topicId || "");
   await flushPromises();
 });
-await waitFor("reopened tab-h treats stale late meta as discarded", () =>
-  controller?.activeTabId === "tab-h" &&
-  controller.state.hydrating === true &&
-  (controller.state.hydratePlaceholderItems?.some((item) => item.kind === "user" && item.text === "history G") ?? false)
+await waitFor("reopened tab-h isolates the prior surface while loading", () =>
+  controller?.activeTabId === "tab-h" && controller.state.hydrating === true && controller.state.items.length === 0 &&
+  (controller.state.hydratePlaceholderItems?.length ?? 0) === 0
 );
 await act(async () => {
   historyH.resolve([userMessage("history H after stale meta")]);

--- a/desktop/frontend/src/__tests__/tab-switch-session-rebind.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-session-rebind.test.tsx
@@ -130,7 +130,9 @@ const tabO = tabMeta("tab-o", 1);
 const tabsById = new Map([tabA, tabO].map((tab) => [tab.id, tab]));
 let backendActiveId = "tab-a";
 let generationTwoHistory = deferred<HistoryMessage[]>();
-let holdGenerationTwoHistory = false;
+let heldTabOHistory: Promise<HistoryMessage[]> | null = null;
+let heldListTabs: Promise<TabMeta[]> | null = null;
+let heldListTabsStarted = false;
 
 function currentTabs(): TabMeta[] {
   return Array.from(tabsById.values()).map((tab) => ({ ...tab, active: tab.id === backendActiveId }));
@@ -143,7 +145,15 @@ window.runtime = {
 window.go = {
   main: {
     App: {
-      ListTabs: async () => currentTabs(),
+      ListTabs: async () => {
+        if (heldListTabs) {
+          const promise = heldListTabs;
+          heldListTabs = null;
+          heldListTabsStarted = true;
+          return promise;
+        }
+        return currentTabs();
+      },
       MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
       ContextUsageForTab: async () => context,
       EffortForTab: async () => effort,
@@ -151,11 +161,13 @@ window.go = {
       JobsForTab: async () => jobs,
       CheckpointsForTab: async () => checkpoints,
       HistoryForTab: async (tabID: string) => {
-        if (tabID === "tab-o" && holdGenerationTwoHistory) {
-          holdGenerationTwoHistory = false;
-          return generationTwoHistory.promise;
+        if (tabID === "tab-o" && heldTabOHistory) {
+          const promise = heldTabOHistory;
+          heldTabOHistory = null;
+          return promise;
         }
-        return [userMessage(tabID === "tab-o" ? "history O generation 1" : "history A")];
+        const generation = tabsById.get(tabID)?.sessionGeneration ?? 0;
+        return [userMessage(tabID === "tab-o" ? `history O generation ${generation}` : "history A")];
       },
       HistorySliceForTab: async (tabID: string, request: HistorySliceRequest) => {
         const messages = await window.go.main.App.HistoryForTab(tabID);
@@ -191,7 +203,7 @@ await waitFor("source restored", () => controller?.activeTabId === "tab-a");
 const reboundTabO = { ...tabO, sessionGeneration: 2 };
 tabsById.set("tab-o", reboundTabO);
 generationTwoHistory = deferred<HistoryMessage[]>();
-holdGenerationTwoHistory = true;
+heldTabOHistory = generationTwoHistory.promise;
 await act(async () => { await controller?.switchTab("tab-o", reboundTabO); await flushPromises(); });
 
 eq(controller?.activeTabId, "tab-o", "generation-rebound tab becomes the selected target");
@@ -206,6 +218,47 @@ await act(async () => {
 });
 await waitFor("target history error", () => Boolean(controller?.state.hydrateError));
 ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "history O generation 1") ?? false), "target history failure never restores the prior generation");
+
+// A mount/ready sync can start before a same-tab session rebind and resolve
+// afterwards. Its tab id still matches, so the navigation generation — not the
+// id — must fence the stale snapshot before it can rewrite optimistic meta.
+const staleGenerationTwoTabs = currentTabs();
+const staleListTabs = deferred<TabMeta[]>();
+heldListTabs = staleListTabs.promise;
+heldListTabsStarted = false;
+let staleSync: Promise<string | undefined> | undefined;
+await act(async () => {
+  staleSync = controller?.syncActiveTab(false);
+  await flushPromises();
+});
+ok(heldListTabsStarted, "backend sync is held before the newer same-tab navigation");
+
+const reboundTabOGenerationThree = { ...tabO, sessionGeneration: 3, active: true };
+tabsById.set("tab-o", reboundTabOGenerationThree);
+backendActiveId = "tab-o";
+const generationThreeHistory = deferred<HistoryMessage[]>();
+heldTabOHistory = generationThreeHistory.promise;
+await act(async () => {
+  await controller?.openProjectTab(reboundTabOGenerationThree.workspaceRoot, reboundTabOGenerationThree.topicId || "");
+  await flushPromises();
+});
+eq(controller?.state.meta?.sessionGeneration, 3, "newer same-tab navigation installs generation three identity");
+eq(controller?.state.hydrating, true, "generation three history remains pending");
+
+await act(async () => {
+  staleListTabs.resolve(staleGenerationTwoTabs);
+  await flushPromises();
+});
+eq(controller?.state.meta?.sessionGeneration, 3, "stale same-tab sync cannot restore generation two metadata");
+eq(controller?.state.hydrating, true, "stale same-tab sync cannot cancel generation three hydration");
+
+await act(async () => {
+  generationThreeHistory.resolve([userMessage("history O generation 3")]);
+  await Promise.all([generationThreeHistory.promise, staleSync]);
+  await flushPromises();
+});
+await waitFor("generation three history", () => controller?.state.items.some((item) => item.kind === "user" && item.text === "history O generation 3") ?? false);
+eq(controller?.state.meta?.sessionGeneration, 3, "generation three remains the settled session identity");
 
 await act(async () => { root.unmount(); });
 dom.window.close();

--- a/desktop/frontend/src/__tests__/tab-switch-session-rebind.test.tsx
+++ b/desktop/frontend/src/__tests__/tab-switch-session-rebind.test.tsx
@@ -1,0 +1,214 @@
+// Run: tsx src/__tests__/tab-switch-session-rebind.test.tsx
+
+import { JSDOM } from "jsdom";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { AppBindings } from "../lib/bridge";
+import { useController } from "../lib/useController";
+import { historySliceFromMessages } from "./mockHistorySlice";
+import type {
+  BalanceInfo,
+  CheckpointMeta,
+  ContextInfo,
+  EffortInfo,
+  HistoryMessage,
+  HistorySliceRequest,
+  JobView,
+  Meta,
+  TabMeta,
+} from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  process.stdout.write(`  ${value ? "PASS" : "FAIL"}  ${label}\n`);
+  if (value) passed += 1;
+  else failed += 1;
+}
+
+function eq(actual: unknown, expected: unknown, label: string) {
+  ok(actual === expected, actual === expected ? label : `${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(label: string, predicate: () => boolean) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await act(async () => { await flushPromises(); });
+    if (predicate()) return;
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function tabMeta(id: string, sessionGeneration: number, active = false): TabMeta {
+  const workspaceRoot = `/repo/${id}`;
+  return {
+    id,
+    scope: "project",
+    workspaceRoot,
+    workspaceName: id,
+    workspacePath: workspaceRoot,
+    gitBranch: "main",
+    topicId: `topic-${id}`,
+    topicTitle: id,
+    sessionPath: `${workspaceRoot}/sessions/${id}.jsonl`,
+    sessionGeneration,
+    label: `model-${id}`,
+    ready: true,
+    running: false,
+    mode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    active,
+    cwd: workspaceRoot,
+  };
+}
+
+function metaFor(tab: TabMeta): Meta {
+  return {
+    label: tab.label,
+    ready: tab.ready,
+    eventChannel: "agent:event",
+    cwd: tab.cwd || tab.workspaceRoot,
+    workspaceRoot: tab.workspaceRoot,
+    workspaceName: tab.workspaceName,
+    workspacePath: tab.workspacePath,
+    sessionPath: tab.sessionPath,
+    sessionGeneration: tab.sessionGeneration,
+    gitBranch: tab.gitBranch,
+    autoApproveTools: false,
+    bypass: false,
+    collaborationMode: "normal",
+    toolApprovalMode: "ask",
+    tokenMode: "full",
+    goal: "",
+    goalStatus: "stopped",
+  };
+}
+
+function userMessage(content: string): HistoryMessage {
+  return { role: "user", content };
+}
+
+console.log("\ntab switch session rebind");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+
+const context: ContextInfo = { used: 0, window: 100, sessionTokens: 0 };
+const effort: EffortInfo = { supported: true, current: "auto", default: "auto", levels: ["auto"] };
+const balance: BalanceInfo = { available: false, display: "" };
+const jobs: JobView[] = [];
+const checkpoints: CheckpointMeta[] = [];
+const tabA = tabMeta("tab-a", 1, true);
+const tabO = tabMeta("tab-o", 1);
+const tabsById = new Map([tabA, tabO].map((tab) => [tab.id, tab]));
+let backendActiveId = "tab-a";
+let generationTwoHistory = deferred<HistoryMessage[]>();
+let holdGenerationTwoHistory = false;
+
+function currentTabs(): TabMeta[] {
+  return Array.from(tabsById.values()).map((tab) => ({ ...tab, active: tab.id === backendActiveId }));
+}
+
+window.runtime = {
+  EventsOn: () => () => {},
+  BrowserOpenURL: () => {},
+};
+window.go = {
+  main: {
+    App: {
+      ListTabs: async () => currentTabs(),
+      MetaForTab: async (tabID: string) => metaFor(tabsById.get(tabID) ?? tabA),
+      ContextUsageForTab: async () => context,
+      EffortForTab: async () => effort,
+      BalanceForTab: async () => balance,
+      JobsForTab: async () => jobs,
+      CheckpointsForTab: async () => checkpoints,
+      HistoryForTab: async (tabID: string) => {
+        if (tabID === "tab-o" && holdGenerationTwoHistory) {
+          holdGenerationTwoHistory = false;
+          return generationTwoHistory.promise;
+        }
+        return [userMessage(tabID === "tab-o" ? "history O generation 1" : "history A")];
+      },
+      HistorySliceForTab: async (tabID: string, request: HistorySliceRequest) => {
+        const messages = await window.go.main.App.HistoryForTab(tabID);
+        return historySliceFromMessages(tabID, messages, request);
+      },
+      HistoryCheckpointTurnsForTab: async () => [],
+      ReplayPendingPrompts: async () => {},
+      SetActiveTab: async (tabID: string) => { backendActiveId = tabID; },
+      OpenProjectTab: async (workspaceRoot: string) => {
+        const target = Array.from(tabsById.values()).find((tab) => tab.workspaceRoot === workspaceRoot) ?? tabA;
+        backendActiveId = target.id;
+        return { ...target, active: true };
+      },
+    } as Partial<AppBindings> as AppBindings,
+  },
+};
+
+type Controller = ReturnType<typeof useController>;
+let controller: Controller | undefined;
+function Probe() { controller = useController(); return null; }
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("missing root");
+const root = createRoot(rootElement);
+
+await act(async () => { root.render(<Probe />); await flushPromises(); });
+await waitFor("initial session", () => controller?.state.items.some((item) => item.kind === "user" && item.text === "history A") ?? false);
+await act(async () => { await controller?.openProjectTab(tabO.workspaceRoot, tabO.topicId || ""); await flushPromises(); });
+await waitFor("generation one", () => controller?.state.items.some((item) => item.kind === "user" && item.text === "history O generation 1") ?? false);
+await act(async () => { await controller?.openProjectTab(tabA.workspaceRoot, tabA.topicId || ""); await flushPromises(); });
+await waitFor("source restored", () => controller?.activeTabId === "tab-a");
+
+const reboundTabO = { ...tabO, sessionGeneration: 2 };
+tabsById.set("tab-o", reboundTabO);
+generationTwoHistory = deferred<HistoryMessage[]>();
+holdGenerationTwoHistory = true;
+await act(async () => { await controller?.switchTab("tab-o", reboundTabO); await flushPromises(); });
+
+eq(controller?.activeTabId, "tab-o", "generation-rebound tab becomes the selected target");
+eq(controller?.state.items.length, 0, "generation-rebound tab clears its prior session before history settles");
+eq(controller?.state.hydratePlaceholderItems?.length ?? 0, 0, "generation-rebound tab never exposes prior-session placeholders");
+eq(controller?.state.hydrating, true, "generation-rebound tab remains in target hydration after the App mask hands off");
+
+await act(async () => {
+  generationTwoHistory.reject(new Error("generation 2 history failed"));
+  await generationTwoHistory.promise.catch(() => undefined);
+  await flushPromises();
+});
+await waitFor("target history error", () => Boolean(controller?.state.hydrateError));
+ok(!(controller?.state.items.some((item) => item.kind === "user" && item.text === "history O generation 1") ?? false), "target history failure never restores the prior generation");
+
+await act(async () => { root.unmount(); });
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-virtualization.test.tsx
@@ -52,6 +52,20 @@ function firstTextNode(root: Node): Text | null {
   return null;
 }
 
+// ── Empty hydration uses a stable loading surface ────────────────────────────
+{
+  const harness = await createTranscriptHarness();
+  try {
+    await harness.render([], { hydrating: true });
+    ok(harness.container.querySelector(".transcript__loading")?.textContent?.trim() === "Loading…", "hydrating empty transcript shows the localized loading surface");
+    ok(harness.container.querySelector(".welcome") === null, "hydration never flashes the welcome surface");
+    ok(harness.scrollElement().getAttribute("aria-busy") === "true", "loading transcript exposes busy state to assistive technology");
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
 // ── Windowed mounting ─────────────────────────────────────────────────────────
 {
   const harness = await createTranscriptHarness({ viewportHeight: 200, rowHeight: 100 });

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -7,7 +7,7 @@ import { useT } from "../lib/i18n";
 import { AssistantMessage, InvocationMetadataContext, TurnActions, UserMessage } from "./Message";
 import { ToolCard } from "./ToolCard";
 import { ExtensionCard } from "./ExtensionCard";
-import { ArrowDown } from "lucide-react";
+import { ArrowDown, Loader2 } from "lucide-react";
 import { Welcome } from "./Welcome";
 import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { ToolGroup } from "./ToolGroup";
@@ -917,8 +917,14 @@ export function Transcript({
         <div
           className={`transcript transcript--empty${creationMode ? " transcript--creation-scrollbar" : ""}`}
           ref={(node) => handleScrollerRef(node)}
+          aria-busy={hydrating || undefined}
         >
-          {!hydrating && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
+          {hydrating ? (
+            <div className="transcript__loading" role="status" aria-live="polite">
+              <Loader2 className="transcript__loading-icon" aria-hidden="true" />
+              <span>{t("common.loading")}</span>
+            </div>
+          ) : <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
         </div>
       ) : (
         <LiveStreamContext.Provider value={live}>

--- a/desktop/frontend/src/lib/hydrateErrorState.ts
+++ b/desktop/frontend/src/lib/hydrateErrorState.ts
@@ -29,8 +29,6 @@ export function applyHydrateErrorState<
 
 export function hydratePlaceholderItems<TItem>(
   optionsItems: TItem[] | undefined,
-  existing: TItem[] | undefined,
 ): TItem[] | undefined {
-  if (optionsItems?.length) return optionsItems;
-  return existing?.length ? existing : undefined;
+  return optionsItems?.length ? optionsItems : undefined;
 }

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -19,6 +19,27 @@ export type HydrateProjection = {
   digest?: string;
 };
 
+export type SessionHydrateIdentity = {
+  sessionPath?: string;
+  sessionGeneration?: number;
+};
+
+/** A surface may retain content only when the target session is provably the same. */
+export function sameSessionHydrateIdentity(
+  target: SessionHydrateIdentity | undefined,
+  current: SessionHydrateIdentity | undefined,
+): boolean {
+  const targetPath = (target?.sessionPath ?? "").trim();
+  const currentPath = (current?.sessionPath ?? "").trim();
+  if (!targetPath || !currentPath || targetPath !== currentPath) return false;
+  if (
+    target?.sessionGeneration !== undefined &&
+    current?.sessionGeneration !== undefined &&
+    target.sessionGeneration !== current.sessionGeneration
+  ) return false;
+  return true;
+}
+
 export function shouldPreferResidentHistory(reset: boolean, preserveCachedHistory?: boolean): boolean {
   return !reset && preserveCachedHistory !== false;
 }
@@ -113,11 +134,8 @@ export function duplicateLiveItemIds(
 }
 
 export function sameSessionPlaceholderItems<T>(
-  targetSessionPath: string | undefined,
-  prev: { meta?: { sessionPath?: string }; items?: T[] } | undefined,
+  target: SessionHydrateIdentity | undefined,
+  prev: { meta?: SessionHydrateIdentity; items?: T[] } | undefined,
 ): T[] | undefined {
-  const target = (targetSessionPath ?? "").trim();
-  const current = (prev?.meta?.sessionPath ?? "").trim();
-  if (!target || !current || target !== current) return undefined;
-  return prev?.items;
+  return sameSessionHydrateIdentity(target, prev?.meta) ? prev?.items : undefined;
 }

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -75,6 +75,25 @@ export function hasCachedLiveTurn(state: HydrateLiveState | undefined): boolean 
   );
 }
 
+export function hasReusableCachedTranscript(
+  state: (HydrateLiveState & { meta?: SessionHydrateIdentity }) | undefined,
+  sessionPath?: string,
+  revision?: number,
+  digest?: string,
+): boolean {
+  if (!state || state.items.length === 0 || state.historyTotalTurns === 0) return false;
+  const expectedSessionPath = (sessionPath ?? "").trim();
+  if (!expectedSessionPath) return true;
+  if ((state.meta?.sessionPath ?? "").trim() !== expectedSessionPath) return false;
+  if (typeof revision === "number" && revision > 0) {
+    return state.historyRevision === revision && (digest ?? "") === (state.historyDigest ?? "");
+  }
+  if ((digest ?? "").trim() !== "") return state.historyDigest === digest;
+  // Missing backend fingerprints must not bless a resident page that already
+  // has one; the sidecar may be between atomic replacements.
+  return state.historyRevision === undefined && !state.historyDigest;
+}
+
 // An empty surface has to apply history or switch-back shows Welcome. A turn
 // that has already streamed rows keeps them — but a tab with no history page
 // behind it still gets one, prepended, instead of a blank transcript above the

--- a/desktop/frontend/src/lib/hydrateHistoryApply.ts
+++ b/desktop/frontend/src/lib/hydrateHistoryApply.ts
@@ -24,6 +24,61 @@ export type SessionHydrateIdentity = {
   sessionGeneration?: number;
 };
 
+export type HydrateSurfacePolicy = "preserve-current" | "replace-surface";
+
+type ActiveTabHydrationTarget = SessionHydrateIdentity & {
+  sessionRevision?: number;
+  sessionDigest?: string;
+};
+
+export type ActiveTabHydrationLoadOptions = ActiveTabHydrationTarget & {
+  preserveCachedHistory: boolean;
+  surfacePolicy?: HydrateSurfacePolicy;
+};
+
+export function activeTabHydrationPlan(
+  target: ActiveTabHydrationTarget,
+  current: SessionHydrateIdentity | undefined,
+  reset: boolean,
+  requestedPolicy?: HydrateSurfacePolicy,
+  requestedCache?: boolean,
+): {
+  sameSession: boolean;
+  surfacePolicy: HydrateSurfacePolicy;
+  loadOptions: ActiveTabHydrationLoadOptions;
+} {
+  const sameSession = sameSessionHydrateIdentity(target, current);
+  const surfacePolicy = requestedPolicy ?? (sameSession ? "preserve-current" : "replace-surface");
+  if (surfacePolicy === "replace-surface") {
+    return {
+      sameSession,
+      surfacePolicy,
+      loadOptions: {
+        preserveCachedHistory: false,
+        surfacePolicy,
+        sessionPath: target.sessionPath,
+        sessionRevision: target.sessionRevision,
+        sessionDigest: target.sessionDigest,
+        sessionGeneration: target.sessionGeneration,
+      },
+    };
+  }
+  return {
+    sameSession,
+    surfacePolicy,
+    loadOptions: {
+      preserveCachedHistory: sameSession && (requestedCache ?? !reset),
+      sessionPath: target.sessionPath,
+      sessionRevision: target.sessionRevision,
+      sessionDigest: target.sessionDigest,
+    },
+  };
+}
+
+type UnboundLiveSurfaceState = HydrateLiveState & {
+  hydrateHistoryLoaded?: boolean;
+};
+
 /** A surface may retain content only when the target session is provably the same. */
 export function sameSessionHydrateIdentity(
   target: SessionHydrateIdentity | undefined,
@@ -38,6 +93,38 @@ export function sameSessionHydrateIdentity(
     target.sessionGeneration !== current.sessionGeneration
   ) return false;
   return true;
+}
+
+/**
+ * Adopt only a live runtime tail that has never been bound to persisted
+ * history. This is the compatibility bridge for background runtime events
+ * that predate the tab metadata snapshot: it must never retain a resident
+ * transcript merely because the tab id matches.
+ */
+export function canAdoptUnboundLiveSurface(
+  target: SessionHydrateIdentity | undefined,
+  current: SessionHydrateIdentity | undefined,
+  state: UnboundLiveSurfaceState | undefined,
+  backendRunning: boolean,
+  targetRuntimeEpoch?: string,
+  currentRuntimeEpoch?: string,
+): boolean {
+  if (!backendRunning || !state) return false;
+  if (!(target?.sessionPath ?? "").trim()) return false;
+  if ((current?.sessionPath ?? "").trim()) return false;
+  if (state.hydrateHistoryLoaded || (state.historyTotalTurns ?? 0) > 0) return false;
+  if (state.historyRevision !== undefined || (state.historyDigest ?? "").trim()) return false;
+  if (!state.running && !state.turnActive) return false;
+  if (targetRuntimeEpoch && currentRuntimeEpoch && targetRuntimeEpoch !== currentRuntimeEpoch) return false;
+  return Boolean(
+    state.live ||
+    state.currentAssistant ||
+    state.pendingUser !== undefined ||
+    state.items.some((item) =>
+      (item.kind === "assistant" && item.streaming) ||
+      (item.kind === "tool" && item.status === "running"),
+    ),
+  );
 }
 
 export function shouldPreferResidentHistory(reset: boolean, preserveCachedHistory?: boolean): boolean {

--- a/desktop/frontend/src/lib/navigationSurfaceTransition.ts
+++ b/desktop/frontend/src/lib/navigationSurfaceTransition.ts
@@ -1,0 +1,9 @@
+export type NavigationSurfaceIntent = number | null;
+
+/** Older completions must never release the latest navigation surface mask. */
+export function settleNavigationSurfaceIntent(
+  current: NavigationSurfaceIntent,
+  completedIntent: number,
+): NavigationSurfaceIntent {
+  return current === completedIntent ? null : current;
+}

--- a/desktop/frontend/src/lib/navigationSurfaceTransition.ts
+++ b/desktop/frontend/src/lib/navigationSurfaceTransition.ts
@@ -7,3 +7,27 @@ export function settleNavigationSurfaceIntent(
 ): NavigationSurfaceIntent {
   return current === completedIntent ? null : current;
 }
+
+type BackendNavigationResultGuard = {
+  intent: number;
+  targetTabId: string;
+  kind: string;
+  isIntentCurrent: (intent: number) => boolean;
+  reassert: (kind: string, staleTabId: string) => Promise<void>;
+};
+
+/**
+ * Backend reveal calls activate their returned tab before resolving. A stale
+ * frontend result therefore needs an active repair, not just an ignored value.
+ */
+export async function guardBackendNavigationResult({
+  intent,
+  targetTabId,
+  kind,
+  isIntentCurrent,
+  reassert,
+}: BackendNavigationResultGuard): Promise<boolean> {
+  if (isIntentCurrent(intent)) return true;
+  await reassert(kind, targetTabId);
+  return false;
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -23,7 +23,7 @@ import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
-import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
+import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
 import { resolveSnapshotTurnStartedAt, resolveTurnStartedAt, snapshotPredatesTurnLifecycle } from "./turnTiming";
@@ -209,6 +209,7 @@ export type ControllerLiveStore = {
 export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversation" | "code" | "both";
 export type MessageActionState = { turn: number; scope: MessageActionScope };
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup" | "rewind";
+type HydrateSurfacePolicy = "preserve-current" | "replace-surface";
 type SyncActiveTabOptions = {
   preserveCachedHistory?: boolean;
 };
@@ -219,6 +220,7 @@ type PendingTopicActivation = {
   navigationSeq: number;
   tabId?: string;
   placeholderItems?: Item[];
+  surfacePolicy: HydrateSurfacePolicy;
   /** Terminal event that arrived before the ticket resolved. */
   terminal?: TopicActivationEvent;
 };
@@ -2888,15 +2890,16 @@ export function useController() {
       sessionDigest?: string;
       sessionGeneration?: number;
       cancelHydrateGeneration?: number;
-      deferResetUntilHistory?: boolean;
+      deferResetUntilHistory?: boolean; surfacePolicy?: HydrateSurfacePolicy;
     } = {},
   ) => {
+    const surfacePolicy = options.surfacePolicy ?? "preserve-current"; const resetSurface = reset || surfacePolicy === "replace-surface";
     const stateMeta = statesRef.current.get(tabId)?.meta;
     const sessionPath = (options.sessionPath ?? stateMeta?.sessionPath ?? "").trim();
     const sessionRevision = options.sessionRevision ?? stateMeta?.sessionRevision;
     const sessionDigest = options.sessionDigest ?? stateMeta?.sessionDigest;
     const sessionGeneration = options.sessionGeneration ?? stateMeta?.sessionGeneration;
-    const canJoinInFlight = !reset && !options.skipHistory;
+    const canJoinInFlight = !resetSurface && !options.skipHistory;
     const shouldTrackInFlight = !options.skipHistory;
     if (canJoinInFlight) {
       const existing = sessionLoadInFlight.current.get(tabId);
@@ -2912,9 +2915,9 @@ export function useController() {
       const hydrateStartedAt = Date.now();
       const skipHistory = Boolean(
         options.skipHistory ||
-        (options.preserveCachedHistory && !reset && hasReusableCachedTranscript(statesRef.current.get(tabId), sessionPath, sessionRevision, sessionDigest)),
+        (options.preserveCachedHistory && !resetSurface && hasReusableCachedTranscript(statesRef.current.get(tabId), sessionPath, sessionRevision, sessionDigest)),
       );
-      const deferResetUntilHistory = Boolean((options.deferResetUntilHistory ?? true) && reset && !skipHistory);
+      const deferResetUntilHistory = Boolean(surfacePolicy === "preserve-current" && (options.deferResetUntilHistory ?? true) && resetSurface && !skipHistory);
       // Request seq alone cannot stop clear→mode-switch races: a load started
       // after clear with stale meta.sessionPath must also be rejected.
       const stillCurrent = () => {
@@ -2926,8 +2929,8 @@ export function useController() {
       if (!stillCurrent()) return;
       addBreadcrumb("tab.hydrate", `start ${reason} ${tabId}`);
       ensureTranscriptSubscription(tabId);
-      dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: resolveHydratePlaceholders(options.placeholderItems, statesRef.current.get(tabId)?.items) });
-      if (reset && !deferResetUntilHistory && stillCurrent()) dispatchTo(tabId, { type: "reset" });
+      dispatchTo(tabId, { type: "hydrate_start", reason, placeholderItems: resolveHydratePlaceholders(options.placeholderItems) });
+      if (resetSurface && !deferResetUntilHistory && stillCurrent()) dispatchTo(tabId, { type: "reset" });
       const requiresVisibleTab = reason === "startup" || reason === "switch-tab" || reason === "open-topic";
       const stillVisible = () => !requiresVisibleTab || activeTabIdRef.current === tabId;
       const foregroundTurnActive = (): boolean => {
@@ -2958,7 +2961,7 @@ export function useController() {
             // Resident LRU only when the caller keeps cache; reset/no-cache re-fetch.
             getTranscriptStore().loadLatest(tabId, sessionPath, {
               turns: HISTORY_PAGE_TURNS,
-              preferResident: shouldPreferResidentHistory(reset, options.preserveCachedHistory),
+              preferResident: shouldPreferResidentHistory(resetSurface, options.preserveCachedHistory),
               expectedRevision: sessionRevision,
               expectedDigest: sessionDigest,
             }),
@@ -3395,7 +3398,7 @@ export function useController() {
     }
     noteActivationSettled(event.requestId, "ready");
     ensureTranscriptSubscription(tabId);
-    void loadSessionDataForTab(tabId, true, "open-topic", { placeholderItems: pending.placeholderItems })
+    void loadSessionDataForTab(tabId, true, "open-topic", { placeholderItems: pending.placeholderItems, surfacePolicy: pending.surfacePolicy })
       .then(() => reconcileTabRuntime(tabId, { hydrateSessionData: false }))
       .catch(() => {});
   }, [dispatchTo, ensureTranscriptSubscription, isNavigationIntentCurrent, loadSessionDataForTab, reconcileTabRuntime]);
@@ -4112,14 +4115,16 @@ export function useController() {
     const targetTabId = tabId || activeTabId;
     if (!targetTabId) return;
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
-    const existingMeta = statesRef.current.get(targetTabId)?.meta;
-    if (existingMeta) dispatchTo(targetTabId, { type: "optimistic_meta", meta: { ...existingMeta, sessionPath: path } });
-    void loadSessionDataForTab(targetTabId, false, "resume-session", { sessionPath: path, preserveCachedHistory: true });
+    const existingState = statesRef.current.get(targetTabId);
+    const sameSession = sameSessionHydrateIdentity({ sessionPath: path }, existingState?.meta); const placeholderItems = sameSessionPlaceholderItems({ sessionPath: path }, existingState);
+    if (existingState?.meta) dispatchTo(targetTabId, { type: "optimistic_meta", meta: { ...existingState.meta, sessionPath: path } });
+    dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session", placeholderItems });
+    if (!sameSession) dispatchTo(targetTabId, { type: "reset" });
     if (tabId) await waitForTabReady(tabId);
     else if (!(await waitForBackendActiveTab(targetTabId))) return;
     if (!navigationCompletionCurrent(navigationSeq, "session.resume", targetTabId)) return;
     const seq = bumpSessionLoadSeq(targetTabId);
-    dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session" });
+    dispatchTo(targetTabId, { type: "hydrate_start", reason: "resume-session", placeholderItems });
     let page: HistoryPage;
     try {
       page = tabId
@@ -4139,15 +4144,18 @@ export function useController() {
     if (!(await reconcileSessionNavigationForTab(targetTabId, navigationSeq, seq))) return;
     app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
     void refreshCheckpoints(targetTabId);
-  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, loadSessionDataForTab, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
+  }, [activeTabId, beginActiveNavigation, bumpSessionLoadSeq, dispatchTo, navigationCompletionCurrent, reconcileSessionNavigationForTab, refreshCheckpoints, sessionLoadCurrent, waitForBackendActiveTab, waitForTabReady]);
 
   const openChannelSession = useCallback(async (path: string, tabId: string, navigationIntentSeq?: number) => {
     if (!tabId) return;
     const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
     await waitForTabReady(tabId);
     if (!navigationCompletionCurrent(navigationSeq, "session.channel", tabId)) return;
+    const existingState = statesRef.current.get(tabId); const sameSession = sameSessionHydrateIdentity({ sessionPath: path }, existingState?.meta);
+    if (existingState?.meta) dispatchTo(tabId, { type: "optimistic_meta", meta: { ...existingState.meta, sessionPath: path } });
     const seq = bumpSessionLoadSeq(tabId);
-    dispatchTo(tabId, { type: "hydrate_start", reason: "resume-session" });
+    dispatchTo(tabId, { type: "hydrate_start", reason: "resume-session", placeholderItems: sameSessionPlaceholderItems({ sessionPath: path }, existingState) });
+    if (!sameSession) dispatchTo(tabId, { type: "reset" });
     let page: HistoryPage;
     try {
       page = await app.OpenChannelSessionPageForTab(tabId, path, HISTORY_PAGE_TURNS);
@@ -4519,21 +4527,18 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-project", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
-    const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
+    const sameSession = sameSessionHydrateIdentity(meta, prevState?.meta);
+    const preserveCachedHistory = sameSession && hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
-      sessionPath: meta.sessionPath,
-      sessionRevision: meta.sessionRevision,
-      sessionDigest: meta.sessionDigest,
+    const load = loadSessionDataForTab(meta.id, !sameSession, "open-topic", {
+      placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
+      sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
     else void load;
@@ -4548,21 +4553,18 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-global", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
-    const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
+    const sameSession = sameSessionHydrateIdentity(meta, prevState?.meta);
+    const preserveCachedHistory = sameSession && hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
-      sessionPath: meta.sessionPath,
-      sessionRevision: meta.sessionRevision,
-      sessionDigest: meta.sessionDigest,
+    const load = loadSessionDataForTab(meta.id, !sameSession, "open-topic", {
+      placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
+      sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
     else void load;
@@ -4577,21 +4579,18 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.open-session", meta.id);
       return meta;
     }
-    const prevItems = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current)?.items : undefined;
     const prevState = statesRef.current.get(meta.id);
     const isNewTab = !prevState;
-    const preserveCachedHistory = hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
+    const sameSession = sameSessionHydrateIdentity(meta, prevState?.meta);
+    const preserveCachedHistory = sameSession && hasReusableCachedTranscript(prevState, meta.sessionPath, meta.sessionRevision, meta.sessionDigest);
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic", {
-      placeholderItems: isNewTab ? prevItems : undefined,
-      preserveCachedHistory,
-      sessionPath: meta.sessionPath,
-      sessionRevision: meta.sessionRevision,
-      sessionDigest: meta.sessionDigest,
+    const load = loadSessionDataForTab(meta.id, !sameSession, "open-topic", {
+      placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface", preserveCachedHistory,
+      sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
     });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
     else void load;
@@ -4607,8 +4606,7 @@ export function useController() {
     // pending ticket before the call so synchronously-emitted events match.
     topicActivationSeqRef.current += 1;
     const pending: PendingTopicActivation = {
-      requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`,
-      navigationSeq,
+      requestId: `fe-act-${Date.now()}-${topicActivationSeqRef.current}`, navigationSeq, surfacePolicy: "replace-surface",
     };
     pendingTopicActivationRef.current = pending;
     noteActivationRequested(pending.requestId);
@@ -4637,11 +4635,10 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("topic.activate", meta.id);
       return meta;
     }
-    const prevItems = sameSessionPlaceholderItems(
-      meta.sessionPath,
-      activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined,
-    );
-    pending.placeholderItems = prevItems;
+    const previousSurface = activeTabIdRef.current ? statesRef.current.get(activeTabIdRef.current) : undefined;
+    const sameSession = sameSessionHydrateIdentity(meta, previousSurface?.meta);
+    const prevItems = sameSessionPlaceholderItems(meta, previousSurface);
+    pending.placeholderItems = prevItems; pending.surfacePolicy = sameSession ? "preserve-current" : "replace-surface";
     for (const id of Array.from(statesRef.current.keys())) {
       if (id !== meta.id) {
         invalidateProviderStateForTab(id);
@@ -4656,6 +4653,7 @@ export function useController() {
     noteActivationStarted(pending.requestId, meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
+    if (!sameSession) dispatchTo(meta.id, { type: "reset" });
     // Ready hydrates; only same-session items are a safe placeholder.
     dispatchTo(meta.id, { type: "hydrate_start", reason: "open-topic", placeholderItems: prevItems });
     if (pending.terminal && pendingTopicActivationRef.current === pending) {
@@ -4685,7 +4683,7 @@ export function useController() {
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    const load = loadSessionDataForTab(meta.id, true, "new-session", { sessionPath: meta.sessionPath });
+    const load = loadSessionDataForTab(meta.id, true, "new-session", { surfacePolicy: "replace-surface", sessionPath: meta.sessionPath, sessionGeneration: meta.sessionGeneration });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
     else void load;
     return meta;
@@ -4712,7 +4710,7 @@ export function useController() {
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    void loadSessionDataForTab(meta.id, true, "open-topic")
+    void loadSessionDataForTab(meta.id, true, "new-session", { surfacePolicy: "replace-surface", sessionPath: meta.sessionPath, sessionGeneration: meta.sessionGeneration })
       .then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false }))
       .catch(() => {});
     return meta;
@@ -4727,13 +4725,18 @@ export function useController() {
       await reassertVisibleTabAfterStaleNavigation("tab.isolated-worktree", meta.id);
       return result;
     }
-    const isNewTab = !statesRef.current.has(meta.id);
+    const prevState = statesRef.current.get(meta.id);
+    const isNewTab = !prevState;
+    const sameSession = sameSessionHydrateIdentity(meta, prevState?.meta);
     setActiveTabId(meta.id);
     activeTabIdRef.current = meta.id;
     confirmBackendActiveTab(meta.id);
     dispatchTo(meta.id, { type: "optimistic_meta", meta: metaFromTab(meta, statesRef.current.get(meta.id)?.meta) });
     dispatchRuntimeStatusForTab(meta.id, meta, snapshotAt);
-    const load = loadSessionDataForTab(meta.id, isNewTab, "open-topic");
+    const load = loadSessionDataForTab(meta.id, !sameSession, "open-topic", {
+      placeholderItems: sameSessionPlaceholderItems(meta, prevState), surfacePolicy: sameSession ? "preserve-current" : "replace-surface",
+      sessionPath: meta.sessionPath, sessionRevision: meta.sessionRevision, sessionDigest: meta.sessionDigest, sessionGeneration: meta.sessionGeneration,
+    });
     if (isNewTab) void load.then(() => reconcileTabRuntime(meta.id, { hydrateSessionData: false })).catch(() => {});
     else void load;
     return result;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -23,7 +23,7 @@ import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
-import { duplicateLiveItemIds, hasCachedLiveTurn, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
+import { duplicateLiveItemIds, hasCachedLiveTurn, hasReusableCachedTranscript, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
 import { resolveSnapshotTurnStartedAt, resolveTurnStartedAt, snapshotPredatesTurnLifecycle } from "./turnTiming";
@@ -693,22 +693,6 @@ const CANCEL_RECONCILE_DELAYS_MS = [0, 100, 300, 1_000] as const;
 const STALE_PROMPT_RECONCILE_MS = 150;
 const STARTUP_READY_META_RECONCILE_MS = 250;
 const STARTUP_READY_META_RECONCILE_ATTEMPTS = 60;
-
-function hasReusableCachedTranscript(state: State | undefined, sessionPath?: string, revision?: number, digest?: string): boolean {
-  if (!state || state.items.length === 0) return false;
-  const expectedSessionPath = (sessionPath ?? "").trim();
-  if (!expectedSessionPath) return true;
-  if ((state.meta?.sessionPath ?? "").trim() !== expectedSessionPath) return false;
-  if (typeof revision === "number" && revision > 0) {
-    return state.historyRevision === revision && (digest ?? "") === (state.historyDigest ?? "");
-  }
-  if ((digest ?? "").trim() !== "") return state.historyDigest === digest;
-  // A cached page with a known fingerprint must not be reused when the
-  // backend temporarily cannot provide one (for example while its metadata
-  // sidecar is being atomically replaced). Reloading is the only way to avoid
-  // presenting a stale persisted transcript as current.
-  return state.historyRevision === undefined && !state.historyDigest;
-}
 
 function historyFingerprintMatchesMeta(history: { revision: number; revisionKnown?: boolean; digest?: string }, meta: Meta): boolean {
   const expectedDigest = (meta.sessionDigest ?? "").trim();
@@ -2595,6 +2579,7 @@ export function useController() {
   const modelSwitchQueueByTab = useRef(new Map<string, ModelSwitchQueueState>());
   const lastTurnActivityAtByTab = useRef(new Map<string, number>());
   const runtimeEpochByTabRef = useRef(new Map<string, string>());
+  const listedSessionIdentityByTabRef = useRef(new Map<string, { sessionPath?: string; sessionGeneration?: number }>());
   const appliedComposerProfileByTabRef = useRef(new Map<string, string>());
   const composerProfileInFlightByTabRef = useRef(new Map<string, { key: string; promise: Promise<boolean> }>());
   const composerProfileQueueByTabRef = useRef(new Map<string, Promise<void>>());
@@ -2895,10 +2880,10 @@ export function useController() {
   ) => {
     const surfacePolicy = options.surfacePolicy ?? "preserve-current"; const resetSurface = reset || surfacePolicy === "replace-surface";
     const stateMeta = statesRef.current.get(tabId)?.meta;
-    const sessionPath = (options.sessionPath ?? stateMeta?.sessionPath ?? "").trim();
-    const sessionRevision = options.sessionRevision ?? stateMeta?.sessionRevision;
-    const sessionDigest = options.sessionDigest ?? stateMeta?.sessionDigest;
-    const sessionGeneration = options.sessionGeneration ?? stateMeta?.sessionGeneration;
+    const sessionPath = ("sessionPath" in options ? options.sessionPath ?? "" : stateMeta?.sessionPath ?? "").trim();
+    const sessionRevision = "sessionRevision" in options ? options.sessionRevision : stateMeta?.sessionRevision;
+    const sessionDigest = "sessionDigest" in options ? options.sessionDigest : stateMeta?.sessionDigest;
+    const sessionGeneration = "sessionGeneration" in options ? options.sessionGeneration : stateMeta?.sessionGeneration;
     const canJoinInFlight = !resetSurface && !options.skipHistory;
     const shouldTrackInFlight = !options.skipHistory;
     if (canJoinInFlight) {
@@ -3196,6 +3181,7 @@ export function useController() {
 
   const activeTabFromBackend = useCallback(async (): Promise<TabMeta | undefined> => {
     const tabs = asArray(await app.ListTabs().catch(() => [] as TabMeta[]));
+    for (const tab of tabs) listedSessionIdentityByTabRef.current.set(tab.id, tab);
     return tabs.find((tab) => tab.active) ?? tabs[0];
   }, []);
 
@@ -4444,10 +4430,16 @@ export function useController() {
     const switchRequestId = `fe-switch-${Date.now()}-${topicActivationSeqRef.current}`;
     noteActivationRequested(switchRequestId);
     const previousTabId = activeTabIdRef.current;
-    const targetSessionPath = optimisticTab?.sessionPath ?? statesRef.current.get(tabId)?.meta?.sessionPath;
-    const targetSessionRevision = optimisticTab?.sessionRevision ?? statesRef.current.get(tabId)?.meta?.sessionRevision;
-    const targetSessionDigest = optimisticTab?.sessionDigest ?? statesRef.current.get(tabId)?.meta?.sessionDigest;
-    const preserveCachedHistory = hasReusableCachedTranscript(statesRef.current.get(tabId), targetSessionPath, targetSessionRevision, targetSessionDigest);
+    const targetState = statesRef.current.get(tabId);
+    const currentTargetIdentity = targetState?.meta ?? listedSessionIdentityByTabRef.current.get(tabId);
+    const targetIdentity = optimisticTab ? { sessionPath: optimisticTab.sessionPath, sessionGeneration: optimisticTab.sessionGeneration } : undefined;
+    const targetSessionPath = optimisticTab?.sessionPath;
+    const targetSessionRevision = optimisticTab?.sessionRevision;
+    const targetSessionDigest = optimisticTab?.sessionDigest;
+    const targetSessionGeneration = optimisticTab?.sessionGeneration;
+    const sameSession = sameSessionHydrateIdentity(targetIdentity, currentTargetIdentity);
+    const placeholderItems = sameSession ? targetState?.items : undefined;
+    const preserveCachedHistory = sameSession && hasReusableCachedTranscript(targetState, targetSessionPath, targetSessionRevision, targetSessionDigest);
     addBreadcrumb("tab.switch", `click ${tabId}`);
     setActiveTabId(tabId);
     activeTabIdRef.current = tabId;
@@ -4455,10 +4447,13 @@ export function useController() {
     noteActivationStarted(switchRequestId, tabId);
     if (optimisticTab) {
       dispatchTo(tabId, { type: "optimistic_meta", meta: metaFromTab(optimisticTab, statesRef.current.get(tabId)?.meta) });
+    }
+    if (!sameSession) dispatchTo(tabId, { type: "reset" });
+    if (optimisticTab) {
       const optimisticStatus = backendStatusFromRuntimeMeta(optimisticTab);
       if (optimisticStatus.running) dispatchTo(tabId, optimisticStatus);
     }
-    dispatchTo(tabId, { type: "hydrate_start", reason: "switch-tab" });
+    dispatchTo(tabId, { type: "hydrate_start", reason: "switch-tab", placeholderItems });
     addBreadcrumb("tab.switch", `active-rendered ${tabId} ms=${Date.now() - startedAt}`);
     const backendActivation = app.SetActiveTab(tabId)
       .then(async () => {
@@ -4500,11 +4495,14 @@ export function useController() {
         const tabs = await reconcileTabRuntime(tabId, { hydrateSessionData: false });
         if (!isNavigationIntentCurrent(navigationSeq)) return tabs;
         void loadSessionDataForTab(tabId, false, "switch-tab", {
-          skipHistory: hasCachedLiveTurn(statesRef.current.get(tabId)),
+          skipHistory: sameSession && hasCachedLiveTurn(statesRef.current.get(tabId)),
+          placeholderItems,
+          surfacePolicy: sameSession ? "preserve-current" : "replace-surface",
           preserveCachedHistory,
           sessionPath: targetSessionPath,
           sessionRevision: targetSessionRevision,
           sessionDigest: targetSessionDigest,
+          sessionGeneration: targetSessionGeneration,
         });
         noteActivationSettled(switchRequestId, "ready");
         return tabs;
@@ -4789,6 +4787,7 @@ export function useController() {
     // the surface the user just clicked.
     noteNavigationIntent: beginActiveNavigation,
     isNavigationIntentCurrent,
+    reassertVisibleTabAfterStaleNavigation,
     syncActiveTab: syncActiveTabFromBackend,
   };
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -23,7 +23,7 @@ import { uiPerfTracker } from "./uiPerf";
 import { getLocale, t, type DictKey } from "./i18n";
 import { applyHydrateErrorState, hydratePlaceholderItems as resolveHydratePlaceholders } from "./hydrateErrorState";
 import { isHostRecoveryGuidance } from "./hostRecoverySteer";
-import { duplicateLiveItemIds, hasCachedLiveTurn, hasReusableCachedTranscript, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory } from "./hydrateHistoryApply";
+import { activeTabHydrationPlan, canAdoptUnboundLiveSurface, duplicateLiveItemIds, hasCachedLiveTurn, hasReusableCachedTranscript, hydratedHistoryApplyMode, sameSessionHydrateIdentity, sameSessionPlaceholderItems, shouldPreferResidentHistory, type HydrateSurfacePolicy } from "./hydrateHistoryApply";
 import { hydrateIdentityCurrent } from "./sessionIdentity";
 import { sameStringList, sameTodoList } from "./todoVisibility";
 import { resolveSnapshotTurnStartedAt, resolveTurnStartedAt, snapshotPredatesTurnLifecycle } from "./turnTiming";
@@ -209,10 +209,7 @@ export type ControllerLiveStore = {
 export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversation" | "code" | "both";
 export type MessageActionState = { turn: number; scope: MessageActionScope };
 export type HydrateReason = "switch-tab" | "new-session" | "resume-session" | "open-topic" | "startup" | "rewind";
-type HydrateSurfacePolicy = "preserve-current" | "replace-surface";
-type SyncActiveTabOptions = {
-  preserveCachedHistory?: boolean;
-};
+type SyncActiveTabOptions = { preserveCachedHistory?: boolean; navigationIntentSeq?: number; surfacePolicy?: HydrateSurfacePolicy };
 // A ticketed StartTopicActivation in flight. Only the latest one is tracked:
 // superseded requests get "cancelled" from the backend and are ignored.
 type PendingTopicActivation = {
@@ -791,7 +788,7 @@ type Action =
   | { type: "history_items_patch"; patches: Record<string, Item> }
   | { type: "history_older_start" }
   | { type: "history_older_error" }
-  | { type: "local_notice"; level: "info" | "warn"; text: string }
+  | { type: "local_notice"; level: "info" | "warn"; text: string; preserveRuntime?: boolean }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
   | { type: "clearExtensionForm" }
@@ -2119,7 +2116,7 @@ export function reducer(s: State, a: Action): State {
       });
       return changed ? { ...s, items: next, historyLayoutRevision: s.historyLayoutRevision + 1 } : s;
     }
-    case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
+    case "local_notice": return { ...s, running: a.preserveRuntime ? s.running : false, turnActive: a.preserveRuntime ? s.turnActive : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": {
       const next = { ...s, approval: undefined, pendingPrompt: Boolean(s.ask), resolvedPromptId: s.approval?.id ?? s.resolvedPromptId };
       return endPromptWaitIfIdle(next);
@@ -2956,7 +2953,8 @@ export function useController() {
       if (!skipHistory && projection === undefined) {
         const errText = t("history.failedLoadHistory");
         dispatchTo(tabId, { type: "hydrate_error", reason, error: errText });
-        dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText });
+        // Hydration failure is not turn completion; keep any raced Ask/approval blocked.
+        dispatchTo(tabId, { type: "local_notice", level: "warn", text: errText, preserveRuntime: true });
         addBreadcrumb("tab.hydrate", `history failed ${tabId} ms=${Date.now() - historyStartedAt}`); return;
       }
       const applyProj = projection && {
@@ -3233,32 +3231,30 @@ export function useController() {
 
   const syncActiveTabFromBackend = useCallback(async (reset = false, guard = false, options: SyncActiveTabOptions = {}): Promise<string | undefined> => {
     const snapshotAt = promptEventClock();
+    // The navigation generation fences same-tab session rebinds as well as tab-id changes.
+    const expectedNavigationSeq = options.navigationIntentSeq ?? activeNavigationSeqRef.current;
     const active = await activeTabFromBackend();
     if (!active) return undefined;
+    if (!isNavigationIntentCurrent(expectedNavigationSeq)) return active.id;
     // When guard is true, skip if the frontend already settled on a
     // different tab while we were fetching — this prevents fire-and-forget
     // calls from mount/onReady from overwriting a user-initiated tab switch
     // (e.g. handleNewTab → ensureBlankSurface / switchTab).
-    if (guard && activeTabIdRef.current && activeTabIdRef.current !== active.id) {
-      return active.id;
-    }
-    if (activeTabIdRef.current !== active.id) beginActiveNavigation();
+    if (guard && activeTabIdRef.current && activeTabIdRef.current !== active.id) return active.id;
+    if (activeTabIdRef.current !== active.id && options.navigationIntentSeq === undefined) beginActiveNavigation();
+    const previousState = statesRef.current.get(active.id);
+    const hydration = activeTabHydrationPlan(active, previousState?.meta, reset, options.surfacePolicy, options.preserveCachedHistory);
     setActiveTabId(active.id);
     activeTabIdRef.current = active.id;
     confirmBackendActiveTab(active.id);
     if (active.runtime?.epoch) runtimeEpochByTabRef.current.set(active.id, active.runtime.epoch);
-    dispatchTo(active.id, { type: "optimistic_meta", meta: metaFromTab(active, statesRef.current.get(active.id)?.meta) });
-    const preserveCachedHistory = options.preserveCachedHistory ?? !reset;
-    if (!reset) dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
-    await loadSessionDataForTab(active.id, reset, "startup", {
-      preserveCachedHistory,
-      sessionPath: active.sessionPath,
-      sessionRevision: active.sessionRevision,
-      sessionDigest: active.sessionDigest,
-    });
-    if (reset) dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
+    dispatchTo(active.id, { type: "optimistic_meta", meta: metaFromTab(active, previousState?.meta) });
+    if (!reset && hydration.surfacePolicy === "preserve-current") dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
+    const load = loadSessionDataForTab(active.id, reset, "startup", hydration.loadOptions);
+    if (reset || hydration.surfacePolicy === "replace-surface") dispatchRuntimeStatusForTab(active.id, active, snapshotAt);
+    await load;
     return active.id;
-  }, [activeTabFromBackend, beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, loadSessionDataForTab]);
+  }, [activeTabFromBackend, beginActiveNavigation, confirmBackendActiveTab, dispatchRuntimeStatusForTab, dispatchTo, isNavigationIntentCurrent, loadSessionDataForTab]);
 
   const reconcileTabRuntime = useCallback(async (
     tabId: string,
@@ -4172,20 +4168,25 @@ export function useController() {
     await refreshMetaForTab(activeTabId);
   }, [activeTabId, refreshMetaForTab]);
 
-  const refreshWorkspaceState = useCallback(async (path: string): Promise<string> => {
-    if (path) await syncActiveTabFromBackend(true);
+  const refreshWorkspaceState = useCallback(async (path: string, navigationSeq: number): Promise<string> => {
+    if (!path) return path;
+    if (!isNavigationIntentCurrent(navigationSeq)) await reassertVisibleTabAfterStaleNavigation("workspace.switch", "");
+    else {
+      const activatedTabId = await syncActiveTabFromBackend(true, false, { navigationIntentSeq: navigationSeq, surfacePolicy: "replace-surface" });
+      if (!isNavigationIntentCurrent(navigationSeq)) await reassertVisibleTabAfterStaleNavigation("workspace.switch", activatedTabId ?? "");
+    }
     return path;
-  }, [syncActiveTabFromBackend]);
+  }, [isNavigationIntentCurrent, reassertVisibleTabAfterStaleNavigation, syncActiveTabFromBackend]);
 
-  const pickWorkspace = useCallback(async (): Promise<string> => {
-    beginActiveNavigation();
+  const pickWorkspace = useCallback(async (navigationIntentSeq?: number): Promise<string> => {
+    const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
     const path = await app.PickWorkspace();
-    return refreshWorkspaceState(path);
+    return refreshWorkspaceState(path, navigationSeq);
   }, [beginActiveNavigation, refreshWorkspaceState]);
-  const switchWorkspace = useCallback(async (path: string): Promise<string> => {
-    beginActiveNavigation();
+  const switchWorkspace = useCallback(async (path: string, navigationIntentSeq?: number): Promise<string> => {
+    const navigationSeq = navigationIntentSeq ?? beginActiveNavigation();
     const next = await app.SwitchWorkspace(path);
-    return refreshWorkspaceState(next);
+    return refreshWorkspaceState(next, navigationSeq);
   }, [beginActiveNavigation, refreshWorkspaceState]);
 
   const compact = useCallback(() => {
@@ -4438,6 +4439,9 @@ export function useController() {
     const targetSessionDigest = optimisticTab?.sessionDigest;
     const targetSessionGeneration = optimisticTab?.sessionGeneration;
     const sameSession = sameSessionHydrateIdentity(targetIdentity, currentTargetIdentity);
+    const optimisticStatus = optimisticTab ? backendStatusFromRuntimeMeta(optimisticTab) : undefined;
+    const adoptUnboundLiveSurface = canAdoptUnboundLiveSurface(targetIdentity, currentTargetIdentity, targetState, Boolean(optimisticStatus?.running), optimisticTab?.runtime?.epoch, runtimeEpochByTabRef.current.get(tabId));
+    const preserveTargetSurface = sameSession || adoptUnboundLiveSurface;
     const placeholderItems = sameSession ? targetState?.items : undefined;
     const preserveCachedHistory = sameSession && hasReusableCachedTranscript(targetState, targetSessionPath, targetSessionRevision, targetSessionDigest);
     addBreadcrumb("tab.switch", `click ${tabId}`);
@@ -4448,11 +4452,8 @@ export function useController() {
     if (optimisticTab) {
       dispatchTo(tabId, { type: "optimistic_meta", meta: metaFromTab(optimisticTab, statesRef.current.get(tabId)?.meta) });
     }
-    if (!sameSession) dispatchTo(tabId, { type: "reset" });
-    if (optimisticTab) {
-      const optimisticStatus = backendStatusFromRuntimeMeta(optimisticTab);
-      if (optimisticStatus.running) dispatchTo(tabId, optimisticStatus);
-    }
+    if (!preserveTargetSurface) dispatchTo(tabId, { type: "reset" });
+    if (optimisticStatus?.running) dispatchTo(tabId, optimisticStatus);
     dispatchTo(tabId, { type: "hydrate_start", reason: "switch-tab", placeholderItems });
     addBreadcrumb("tab.switch", `active-rendered ${tabId} ms=${Date.now() - startedAt}`);
     const backendActivation = app.SetActiveTab(tabId)
@@ -4497,7 +4498,7 @@ export function useController() {
         void loadSessionDataForTab(tabId, false, "switch-tab", {
           skipHistory: sameSession && hasCachedLiveTurn(statesRef.current.get(tabId)),
           placeholderItems,
-          surfacePolicy: sameSession ? "preserve-current" : "replace-surface",
+          surfacePolicy: preserveTargetSurface ? "preserve-current" : "replace-surface",
           preserveCachedHistory,
           sessionPath: targetSessionPath,
           sessionRevision: targetSessionRevision,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3572,6 +3572,22 @@ a[href] {
   margin-block: auto;
   margin-inline: 0;
 }
+.transcript__loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: auto;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.transcript__loading-icon {
+  width: 16px;
+  height: 16px;
+  animation: navigation-surface-spin 0.8s linear infinite;
+}
+@keyframes navigation-surface-spin {
+  to { transform: rotate(360deg); }
+}
 .warm-collapse {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary

- Add an App-level navigation surface intent that synchronously hides source-session content before asynchronous Wails navigation begins.
- Keep the Composer mounted while making it hidden, inert, and unavailable during navigation; isolate transcript, live output, Todo, Ask/approval, rewind, and draft surfaces.
- Split hydration into `preserve-current` and `replace-surface` policies, and retain placeholders only when a matching non-empty session path and compatible generation prove the target is the same session.
- Use compare-and-clear intent sequencing so stale, coalesced, and out-of-order completions cannot release the latest navigation mask.
- Show a localized centered loading surface through App navigation and target hydration, with target-side retry errors that never restore source rows.

## Root cause

Navigation and hydration previously had separate ownership. App rendering could keep source-session content visible while a target Wails request was pending, and controller hydration could implicitly reuse resident items without proving session identity. There was also no shared visual intent generation protecting the loading surface from stale async completions.

## User impact

Cross-session navigation now has one consistent interaction model: the first committed frame removes the source transcript and session-only actions, a lightweight loading surface remains until the target is ready, and rapid A to B to C navigation resolves only to C. A pre-activation open failure restores the source surface, while a target history failure remains on the target with retry UI.

## Scope

- Frontend App, Transcript, hydration policy, and focused tests only.
- No Wails or Go public API changes.
- No persisted format, configuration, migration, or native-shell changes.

## Related PRs

- #9016 is merged into this PR head. It improves project-tree catalog/runtime publication and has no changed-file overlap with this App/hydration fix. The combined head passes the navigation, hydration, project-tree, build, and repository checks listed below.

## Verification

- Focused navigation, hydration identity, tab-switch, topic activation, new-session race, coalescing, and project-tree completeness tests passed on the combined head.
- `pnpm test:transcript`
- `pnpm build`
- `go run ./tools/repolint`
- `git diff --check`
- Embedded-browser delayed navigation inspection confirmed that source messages disappear, Welcome never flashes, the Composer remains mounted but inert, and only the loading surface is visible before target hydration.

## Documentation impact

Documentation-impact: none - this restores the intended cross-session navigation behavior without changing user configuration, public APIs, or documented workflows.

## Compatibility impact

Compatibility-impact: none. No persisted session format, Wails JSON contract, CLI behavior, or migration boundary changes.

## Cache impact

Cache-impact: none. No prompt, memory, tool schema/order, provider serialization, compaction, reasoning upload, MCP, or sub-agent context path changed.
Cache-guard: N/A.
System-prompt-review: N/A.