### PR TITLE
fix(agent): scope unfinished todo readiness to closed loops / 未完成 todo 只在闭环回合阻塞

### DIFF
--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -149,11 +149,11 @@ Prometheus 会逐个问澄清问题：
 Delivery 收敛为纯 readiness 服务，宿主可消费的结构化结果为
 `ReadinessResult{Ready, Missing, Reason, ProgressKey}`：
 
-- Canonical todos（当前 todo 列表）
+- Canonical todos（当前 todo 列表；未完成项只在 Goal、已批准 Plan 或 strict obligation 等闭环回合中阻塞，普通开环回合将其保留为跨轮工作状态）
 - Project checks（来自 AGENTS.md 的 verify 指令）
 - Delivery 专属验收项（mutation、verification、review、complete_step 签收、capability 门禁）
 
-Delivery 不再自行注入隐藏模型消息做 3/6 次 readiness 重试：普通 Delivery 回合在第一次未满足的最终回答后立即结束并显示恢复卡；Goal + Delivery 回合由 Goal FSM 自动续轮，不显示需要用户点击的重复卡片。
+Delivery 不再自行注入隐藏模型消息做 3/6 次 readiness 重试：普通 Delivery 回合可由宿主针对已确认的缺失项做 1 次通用或最多 2 次高置信有界续跑；遇到新用户输入、取消或无新增进展时立即让路，仍未满足才显示恢复卡。普通开环回合中的未完成 todos 本身不会触发续跑或恢复卡；Goal + Delivery 回合仍由 Goal FSM 自动续轮，不显示需要用户点击的重复卡片。
 
 ### 进展签名
 

--- a/internal/agent/ablation_test.go
+++ b/internal/agent/ablation_test.go
@@ -11,17 +11,17 @@ func TestEvidenceAblationStandsDownTheReadinessGate(t *testing.T) {
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 
-	gated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
+	gated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}}
 	if gated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("control arm must still gate an incomplete todo after a write")
 	}
 
-	off := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Evidence)}
+	off := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}, ablation: ablation.New(ablation.Evidence)}
 	if got := off.finalReadinessCheckFor().reason; got != "" {
 		t.Fatalf("evidence ablation still gated the final answer: %q", got)
 	}
 
-	unrelated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, ablation: ablation.New(ablation.Planner)}
+	unrelated := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}, ablation: ablation.New(ablation.Planner)}
 	if unrelated.finalReadinessCheckFor().reason == "" {
 		t.Fatal("an unrelated ablation must not disable the readiness gate")
 	}

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -14,20 +14,21 @@ func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
 	open := []evidence.TodoItem{{Content: "push", Status: "completed"}, {Content: "rebase", Status: "pending"}}
 
 	// Turn did work (a successful bash) but issued no todo_write this turn, so the
-	// per-turn ledger has no list — the canonical state must still gate.
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: open}}
+	// per-turn ledger has no list — the canonical state must still gate inside a
+	// closed-loop turn.
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: open}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := a.ReadinessResult(); !strings.Contains(got.Reason, "incomplete") {
 		t.Fatalf("cross-turn gate = %q, want it to report incomplete canonical todos", got.Reason)
 	}
 
 	// A turn that touched nothing (pure Q&A) must never gate on stale canonical state.
-	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, sess: sessionRuntime{todoState: open}}
+	idle := &Agent{task: taskRuntime{ledger: evidence.NewLedger()}, sess: sessionRuntime{todoState: open}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := idle.ReadinessResult(); !got.Ready {
 		t.Fatalf("no-work turn gated on canonical todos: %+v", got)
 	}
 
 	// All canonical items completed → no gate even after work.
-	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}}
+	done := &Agent{task: taskRuntime{ledger: readinessLedger(ran)}, sess: sessionRuntime{todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}, turn: turnRuntime{deliveryScopeActive: true}}
 	if got := done.ReadinessResult(); !got.Ready {
 		t.Fatalf("completed canonical todos still gated: %+v", got)
 	}

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -156,6 +156,8 @@ func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
 	mp := testutil.NewMock("m",
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "w1", Name: "write_file", Arguments: `{"path":"alpha.go"}`}}},
 		testutil.Turn{Text: "all done"},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "v1", Name: "bash", Arguments: `{"command":"go test ./..."}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "r1", Name: "bash", Arguments: `{"command":"git diff alpha.go"}`}}},
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
 			Arguments: `{"step":"alpha","result":"done","evidence":[{"kind":"diff","summary":"edited","paths":["alpha.go"]}]}`}}},
 		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "complete_step",
@@ -165,11 +167,11 @@ func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
 	a := New(mp, evidenceRegistry(), sess, Options{}, event.Discard)
 	a.SetSession(sess) // rebuilds canonical {alpha in_progress, beta pending}
 
-	firstErr := a.Run(withNoClosedLoop(context.Background()), "finish up")
+	firstErr := a.Run(withClosedLoopContext(context.Background()), "finish up")
 	if !readinessBlocked(firstErr) {
 		t.Fatalf("premature 'all done' error = %v, want FinalReadinessError from the cross-turn canonical gate", firstErr)
 	}
-	if err := a.Run(withNoClosedLoop(context.Background()), "finish up"); err != nil {
+	if err := a.Run(withClosedLoopContext(context.Background()), "finish up"); err != nil {
 		t.Fatalf("follow-up Run: %v", err)
 	}
 	for i, td := range a.sess.todoState {

--- a/internal/agent/delivery_hardening_test.go
+++ b/internal/agent/delivery_hardening_test.go
@@ -367,7 +367,7 @@ func TestRunSubAgentSalvagesReadinessExhaustedWork(t *testing.T) {
 		finalText, // block 3 — budget exhausted
 	}}
 	sess := NewSession("sys")
-	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+	answer, err := RunSubAgentWithSession(withClosedLoopContext(context.Background()), prov, reg, sess,
 		"add explanations to the question bank", Options{SubagentDepth: 1}, event.Discard)
 	if err != nil {
 		t.Fatalf("readiness exhaustion with real work must salvage, got err: %v", err)
@@ -466,7 +466,7 @@ func TestExplicitDeliveryRecoveryPreservesEvidenceOnce(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession("sys"), Options{}, event.Discard)
 	var readinessErr *FinalReadinessError
-	if err := a.Run(context.Background(), "implement main"); !errors.As(err, &readinessErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "implement main"); !errors.As(err, &readinessErr) {
 		t.Fatalf("first Run error = %v, want FinalReadinessError", err)
 	}
 	if !a.PrepareDeliveryRecovery() {
@@ -475,7 +475,7 @@ func TestExplicitDeliveryRecoveryPreservesEvidenceOnce(t *testing.T) {
 	if a.PrepareDeliveryRecovery() {
 		t.Fatal("delivery recovery authorization must be one-shot")
 	}
-	if err := a.Run(context.Background(), "continue the remaining delivery checks"); err != nil {
+	if err := a.Run(withClosedLoopContext(context.Background()), "continue the remaining delivery checks"); err != nil {
 		t.Fatalf("recovery Run: %v", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
@@ -496,14 +496,14 @@ func TestOrdinaryFollowUpDoesNotPreserveFailedDeliveryEvidence(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession("sys"), Options{}, event.Discard)
 	var firstErr *FinalReadinessError
-	if err := a.Run(context.Background(), "implement main"); !errors.As(err, &firstErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "implement main"); !errors.As(err, &firstErr) {
 		t.Fatalf("first Run error = %v, want FinalReadinessError", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); !ok {
 		t.Fatal("first failed delivery should retain its mutation until the next turn is classified")
 	}
 
-	if err := a.Run(withClosedLoopContext(context.Background()), "fix the unrelated crash in other.go"); err != nil {
+	if err := a.Run(withNoClosedLoop(context.Background()), "fix the unrelated crash in other.go"); err != nil {
 		t.Fatalf("ordinary follow-up without a writer = %v, want ready", err)
 	}
 	if _, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {

--- a/internal/agent/delivery_visible_final_test.go
+++ b/internal/agent/delivery_visible_final_test.go
@@ -31,7 +31,7 @@ func TestRunSubAgentSalvagesCurrentAnswerBeforePairedGoalError(t *testing.T) {
 		},
 	}}
 	sess := NewSession("sys")
-	answer, err := RunSubAgentWithSession(context.Background(), prov, reg, sess,
+	answer, err := RunSubAgentWithSession(withClosedLoopContext(context.Background()), prov, reg, sess,
 		"add explanations to the question bank", Options{SubagentDepth: 1}, event.Discard)
 	if err != nil {
 		t.Fatalf("paired Goal error hid the current salvage answer: %v", err)
@@ -177,7 +177,7 @@ func TestRunSubAgentReadinessSalvageDoesNotReuseStaleToolText(t *testing.T) {
 	}}
 	sess := NewSession("sys")
 	answer, err := RunSubAgentWithSession(
-		context.Background(), deepseekThinkingProvider{prov}, reg, sess,
+		withClosedLoopContext(context.Background()), deepseekThinkingProvider{prov}, reg, sess,
 		"add explanations to the question bank",
 		Options{SubagentDepth: 1}, event.Discard,
 	)

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -662,7 +662,7 @@ func TestFinalReadinessStopsAfterFirstBlock(t *testing.T) {
 	}}
 	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
 
-	err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and never sign off")
+	err := a.Run(withClosedLoopContext(context.Background()), "edit with todo and never sign off")
 	if err == nil {
 		t.Fatal("expected the first readiness block to stop the run")
 	}
@@ -852,7 +852,7 @@ func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	sink := &readinessAuditSink{}
 	a := New(prov, reg, NewSession(""), Options{}, sink)
 
-	err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and never sign off")
+	err := a.Run(withClosedLoopContext(context.Background()), "edit with todo and never sign off")
 	if err == nil {
 		t.Fatal("expected the first readiness block to stop the run")
 	}

--- a/internal/agent/final_readiness.go
+++ b/internal/agent/final_readiness.go
@@ -167,7 +167,9 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 	if mutation, ok := a.task.ledger.LatestSuccessfulMutationIndex(); ok {
 		writer, hasWriter = mutation, true
 	}
-	if hasWriter && hasTodos && len(incomplete) > 0 {
+	// Incomplete todos contradict closed-loop delivery only. In open turns they
+	// are cross-turn work plans and must not trigger the recovery ceremony.
+	if a.closedLoopActive() && hasWriter && hasTodos && len(incomplete) > 0 {
 		out.applies = true
 		out.continuationHighConfidence = true
 		out.incompleteTodos = len(incomplete)
@@ -201,7 +203,7 @@ func (a *Agent) finalReadinessCheckFor() finalReadinessCheck {
 		stop = a.turn.engine.BeforeStop(runtimepolicy.StopContext{
 			GoalActive:     a.turn.deliveryScopeActive,
 			ApprovedPlan:   a.planContractSnapshot() != nil,
-			IncompleteTodo: hasTodos && len(incomplete) > 0,
+			IncompleteTodo: a.closedLoopActive() && hasTodos && len(incomplete) > 0,
 			Opts: taskcontract.StopOptions{
 				LoopGuard:        a.loopGuardAllowsFinal(),
 				EnvUnavailable:   a.turn.constraints.ForbidTests,

--- a/internal/agent/final_readiness_recovery_test.go
+++ b/internal/agent/final_readiness_recovery_test.go
@@ -1,10 +1,8 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"path/filepath"
 	"testing"
 
 	"reasonix/internal/event"
@@ -36,7 +34,7 @@ func TestTargetedVerificationGapDoesNotArmRecovery(t *testing.T) {
 	}
 }
 
-func TestTargetedVerificationRecoverySurvivesAgentRebuild(t *testing.T) {
+func TestClosedLoopReadinessRecoveryStaysInMemory(t *testing.T) {
 	reg := evidenceRegistry()
 	first := &scriptedProvider{name: "standard", turns: [][]provider.Chunk{
 		{toolCallChunk("todo", "todo_write", `{"todos":[{"content":"Write verification notes","status":"in_progress"}]}`), {Type: provider.ChunkDone}},
@@ -47,48 +45,22 @@ func TestTargetedVerificationRecoverySurvivesAgentRebuild(t *testing.T) {
 	a := New(first, reg, session, Options{}, event.Discard)
 
 	var readinessErr *FinalReadinessError
-	if err := a.Run(context.Background(), "write docs/verify_v070.md and run the validation script"); !errors.As(err, &readinessErr) {
+	if err := a.Run(withClosedLoopContext(context.Background()), "write docs/verify_v070.md and run the validation script"); !errors.As(err, &readinessErr) {
 		t.Fatalf("first Run error = %v, want final readiness failure", err)
 	}
+	// Closed-loop failures stay in memory; durable recovery markers are for
+	// ordinary turns, which no longer fail solely because todos remain open.
 	var marker *provider.FinalReadinessRecovery
 	for _, message := range session.Snapshot() {
 		if message.FinalReadinessRecovery != nil {
 			marker = message.FinalReadinessRecovery
 		}
 	}
-	if marker == nil || bytes.Contains(marker.Checkpoint, []byte("sensitive-payload")) {
-		t.Fatal("recovery checkpoint missing or duplicated writer content")
+	if marker != nil {
+		t.Fatal("closed-loop readiness failure must not persist a recovery marker")
 	}
-	path := filepath.Join(t.TempDir(), "readiness-recovery.jsonl")
-	if err := session.Save(path); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-	loaded, err := LoadSession(path)
-	if err != nil {
-		t.Fatalf("LoadSession: %v", err)
-	}
-
-	recoveryProvider := &scriptedProvider{name: "standard-reloaded", turns: [][]provider.Chunk{
-		{toolCallChunk("recognized-check", "bash", `{"command":"git diff --check"}`), {Type: provider.ChunkDone}},
-		{toolCallChunk("signoff", "complete_step", `{"step":"Write verification notes","result":"done","evidence":[{"kind":"verification","summary":"diff check passed","command":"git diff --check"}]}`), {Type: provider.ChunkDone}},
-		{toolCallChunk("todo-done", "todo_write", `{"todos":[{"content":"Write verification notes","status":"completed"}]}`), {Type: provider.ChunkDone}},
-		{{Type: provider.ChunkText, Text: "checks complete"}, {Type: provider.ChunkDone}},
-	}}
-	reloaded := New(recoveryProvider, reg, loaded, Options{}, event.Discard)
-	if !reloaded.PrepareFinalReadinessRecovery() || reloaded.PrepareFinalReadinessRecovery() {
-		t.Fatal("rebuilt recovery authorization was not one-shot")
-	}
-	if err := reloaded.Run(context.Background(), "continue the remaining checks"); err != nil {
-		t.Fatalf("reloaded recovery Run: %v", err)
-	}
-	for _, message := range loaded.Snapshot() {
-		if message.FinalReadinessRecovery != nil && message.FinalReadinessRecovery.Pending {
-			t.Fatal("started recovery left its durable action pending")
-		}
-	}
-	writer, ok := reloaded.task.ledger.LatestSuccessfulWriterIndex()
-	if !ok || !reloaded.task.ledger.HasSuccessfulVerificationCommandAfter(writer) {
-		t.Fatal("reloaded recovery did not preserve write-before-verification ordering")
+	if !a.pending.finalReadinessRecovery {
+		t.Fatal("closed-loop readiness failure must keep the in-memory pending recovery flag")
 	}
 }
 

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -30,24 +30,26 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 		name        string
 		checks      []instruction.VerifyCheck
 		evidence    *evidence.Ledger
+		closedLoop  bool
 		wantEmpty   bool
 		wantContain string
 	}{
-		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, true, ""},
-		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), true, ""},
-		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), true, ""},
-		{"read-only context plus todo may end with incomplete list", nil, readinessLedger(readOnly, todo), true, ""},
-		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), true, ""},
-		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
-		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},
-		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), true, ""},
-		{"todo writer without complete_step is reported", nil, readinessLedger(writer, todo), false, "incomplete items"},
-		{"complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), false, "latest successful todo_write"},
-		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), true, ""},
+		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, false, true, ""},
+		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), false, true, ""},
+		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), false, true, ""},
+		{"read-only context plus todo may end with incomplete list", nil, readinessLedger(readOnly, todo), false, true, ""},
+		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), false, true, ""},
+		{"writer without checks or todo never gates", nil, readinessLedger(writer), false, true, ""},
+		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, false, "go test ./..."},
+		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), false, true, ""},
+		{"open turn with unfinished todos is not a delivery contradiction", nil, readinessLedger(writer, todo), false, true, ""},
+		{"closed-loop todo writer without complete_step is reported", nil, readinessLedger(writer, todo), true, false, "incomplete items"},
+		{"closed-loop complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), true, false, "latest successful todo_write"},
+		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), false, true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			a := &Agent{task: taskRuntime{ledger: tc.evidence}, projectChecks: tc.checks}
+			a := &Agent{task: taskRuntime{ledger: tc.evidence}, projectChecks: tc.checks, turn: turnRuntime{deliveryScopeActive: tc.closedLoop}}
 			got := a.ReadinessResult()
 			if tc.wantEmpty {
 				if !got.Ready {
@@ -84,11 +86,15 @@ func TestFinalReadinessAllowsIncompleteTodosInPlanMode(t *testing.T) {
 func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
+	open := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}}
+	if got := open.finalReadinessCheckFor(); got.applies {
+		t.Fatalf("open-turn finalReadinessCheckFor() applies = true, want false: %+v", got)
+	}
 
-	got := a.finalReadinessCheckFor()
+	closed := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, turn: turnRuntime{deliveryScopeActive: true}}
+	got := closed.finalReadinessCheckFor()
 	if !got.applies {
-		t.Fatalf("finalReadinessCheckFor() applies = false, want true")
+		t.Fatalf("closed-loop finalReadinessCheckFor() applies = false, want true")
 	}
 	if got.incompleteTodos != 1 {
 		t.Fatalf("incompleteTodos = %d, want 1", got.incompleteTodos)
@@ -106,7 +112,7 @@ func TestFinalReadinessAllowsFinalAfterLoopGuardedToolBlocker(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{task: taskRuntime{ledger: ledger}}
+	a := &Agent{task: taskRuntime{ledger: ledger}, turn: turnRuntime{deliveryScopeActive: true}}
 	a.armLoopGuardPass(ledger.Len())
 
 	got := a.finalReadinessCheckFor()
@@ -125,7 +131,7 @@ func TestFinalReadinessLoopGuardPassSurvivesBookkeeping(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{task: taskRuntime{ledger: ledger}}
+	a := &Agent{task: taskRuntime{ledger: ledger}, turn: turnRuntime{deliveryScopeActive: true}}
 	a.armLoopGuardPass(ledger.Len())
 
 	ledger.Record(evidence.Receipt{ToolName: "ask", Success: true})
@@ -144,7 +150,7 @@ func TestFinalReadinessLoopGuardPassRevokedByRealProgress(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
 	ledger := readinessLedger(writer, todo)
-	a := &Agent{task: taskRuntime{ledger: ledger}}
+	a := &Agent{task: taskRuntime{ledger: ledger}, turn: turnRuntime{deliveryScopeActive: true}}
 	a.armLoopGuardPass(ledger.Len())
 
 	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
@@ -164,7 +170,7 @@ func TestFinalReadinessIgnoresLoopGuardQuotedInToolOutput(t *testing.T) {
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "edit"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash"}}})
 	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "b1", Name: "bash", Content: "agent.go:2082: \"[loop guard] %s has now %s %d times\""})
-	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, sess: sessionRuntime{conversation: sess}}
+	a := &Agent{task: taskRuntime{ledger: readinessLedger(writer, todo)}, sess: sessionRuntime{conversation: sess}, turn: turnRuntime{deliveryScopeActive: true}}
 
 	if got := a.finalReadinessCheckFor(); got.reason == "" {
 		t.Fatal("finalReadinessCheckFor() reason empty, want quoted loop-guard text to be ignored")

--- a/internal/agent/readiness_partial_test.go
+++ b/internal/agent/readiness_partial_test.go
@@ -35,7 +35,7 @@ func TestPartialWaiverDoesNotClearIncompleteTodos(t *testing.T) {
 		task: taskRuntime{ledger: readinessLedger(writer, todo,
 			evidence.Receipt{ToolName: "update_goal", Success: true, Args: []byte(`{"status":"complete","completion":{"unverified":["e2e"]}}`)},
 		)},
-		turn: turnRuntime{engine: runtimepolicy.NewEngine(runtimepolicy.Constraints{})},
+		turn: turnRuntime{engine: runtimepolicy.NewEngine(runtimepolicy.Constraints{}), deliveryScopeActive: true},
 	}
 	got := a.ReadinessResult()
 	if got.Ready || !strings.Contains(got.Reason, "incomplete") {

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -549,9 +549,9 @@ func (a *Agent) handleFinalResponse(ctx context.Context, state *turnRuntime, tex
 	if readiness.reason != "" {
 		// The host owns the concrete missing requirements. Return them to the
 		// controller when automatic continuation is armed (or for the existing
-		// strict/Goal path). Unarmed ordinary agents retain their Partial
-		// contract and do not unexpectedly change the direct Agent API.
-		if a.turn.automaticReadinessContinuation || a.closedLoopActive() || readiness.incompleteTodos > 0 || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
+		// strict/Goal path). Unfinished todos are hard failures only in closed-loop
+		// turns; in ordinary turns they remain visible cross-turn work state.
+		if a.turn.automaticReadinessContinuation || a.closedLoopActive() || readiness.missingSignoff > 0 || readiness.missingActionEvidence > 0 {
 			event.RecordReadinessAudit(a.svc.sink, readiness.audit(evidence.ReadinessErrored, false))
 			a.pending.finalReadinessRecovery = true
 			a.persistFinalReadinessRecovery(readiness.missingIDs())

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -883,7 +883,7 @@ func TestTaskToolBackgroundCapRefusesFanOut(t *testing.T) {
 	}
 }
 
-func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
+func TestTaskToolBackgroundRunPublishesEvidenceForCollection(t *testing.T) {
 	reg := evidenceRegistry()
 	finalText := []provider.Chunk{{Type: provider.ChunkText, Text: "done, explanations added"}, {Type: provider.ChunkDone}}
 	sub := &scriptedProvider{name: "sub", turns: [][]provider.Chunk{
@@ -910,8 +910,8 @@ func TestTaskToolBackgroundSalvagePublishesEvidenceForCollection(t *testing.T) {
 	}
 	jobID := extractJobID(out)
 	res := jm.WaitForSession(context.Background(), "parent-session", []string{jobID}, 5)
-	if len(res) != 1 || res[0].Status != jobs.Done || !strings.Contains(res[0].Output, "[unverified]") {
-		t.Fatalf("background salvage = %+v, want done unverified result", res)
+	if len(res) != 1 || res[0].Status != jobs.Done {
+		t.Fatalf("background task = %+v, want done", res)
 	}
 	if parentLedger.Summary().HasMutation() {
 		t.Fatal("background goroutine wrote directly into the parent turn ledger")

--- a/internal/agent/unfinished_todo_readiness_test.go
+++ b/internal/agent/unfinished_todo_readiness_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestOpenTurnMayEndWithIncompleteTodosAfterWrite proves an ordinary session
+// can leave a partial cross-turn plan without entering delivery recovery.
+func TestOpenTurnMayEndWithIncompleteTodosAfterWrite(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done, more steps remain for later turns"}, {Type: provider.ChunkDone}},
+	}}
+	sink := &readinessAuditSink{}
+	a := New(prov, reg, NewSession(""), Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "edit with todo and leave remaining steps for later"); err != nil {
+		t.Fatalf("open turn with incomplete todos must not fail the run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2 (write + final, no readiness retry)", prov.call)
+	}
+	for _, audit := range sink.events {
+		if audit.Result == evidence.ReadinessErrored {
+			t.Fatalf("open turn recorded errored readiness audit: %+v", audit)
+		}
+	}
+}

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"reasonix/internal/agent"
@@ -161,7 +162,7 @@ func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error
 // unchanged.
 func readinessContinuationPrompt(todos []evidence.TodoItem, missing []string, reason string) string {
 	var parts []string
-	if incomplete := evidence.IncompleteTodos(todos); readinessGapIncludes(missing, "todo") && len(incomplete) > 0 {
+	if incomplete := evidence.IncompleteTodos(todos); slices.Contains(missing, "todo") && len(incomplete) > 0 {
 		var b strings.Builder
 		b.WriteString("these tasks are still incomplete:")
 		for _, todo := range incomplete {
@@ -182,13 +183,4 @@ func readinessContinuationPrompt(todos []evidence.TodoItem, missing []string, re
 	}
 	b.WriteString("Address only the readiness items above within the original request. Do not expand scope or repeat destructive or external actions. If an item cannot be completed because the environment or permissions are unavailable, record the exact limitation and stop.")
 	return b.String()
-}
-
-func readinessGapIncludes(missing []string, want string) bool {
-	for _, id := range missing {
-		if id == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/control/readiness_continuation.go
+++ b/internal/control/readiness_continuation.go
@@ -123,7 +123,7 @@ func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error
 		if automaticTurns > 0 && !readinessMadeProgress(previousProgress, readinessErr.ProgressKey) {
 			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 		}
-		prompt := readinessContinuationPrompt(o.c.goalTodos(), readinessErr.Reason)
+		prompt := readinessContinuationPrompt(o.c.goalTodos(), readinessErr.Missing, readinessErr.Reason)
 		if prompt == "" {
 			return finalReadinessWithAttempts(turnErr, initialAttempts+automaticTurns)
 		}
@@ -159,9 +159,9 @@ func (o *turnOrchestrator) continueUntilReady(ctx context.Context, turnErr error
 // readinessContinuationPrompt states only host-observed missing work. It is an
 // append-only user turn, leaving the system prompt and tool-schema cache prefix
 // unchanged.
-func readinessContinuationPrompt(todos []evidence.TodoItem, reason string) string {
+func readinessContinuationPrompt(todos []evidence.TodoItem, missing []string, reason string) string {
 	var parts []string
-	if incomplete := evidence.IncompleteTodos(todos); len(incomplete) > 0 {
+	if incomplete := evidence.IncompleteTodos(todos); readinessGapIncludes(missing, "todo") && len(incomplete) > 0 {
 		var b strings.Builder
 		b.WriteString("these tasks are still incomplete:")
 		for _, todo := range incomplete {
@@ -182,4 +182,13 @@ func readinessContinuationPrompt(todos []evidence.TodoItem, reason string) strin
 	}
 	b.WriteString("Address only the readiness items above within the original request. Do not expand scope or repeat destructive or external actions. If an item cannot be completed because the environment or permissions are unavailable, record the exact limitation and stop.")
 	return b.String()
+}
+
+func readinessGapIncludes(missing []string, want string) bool {
+	for _, id := range missing {
+		if id == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/control/readiness_continuation_test.go
+++ b/internal/control/readiness_continuation_test.go
@@ -9,6 +9,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/i18n"
 	"reasonix/internal/instruction"
 	"reasonix/internal/provider"
@@ -89,7 +90,7 @@ func TestOrdinaryTurnAutomaticallyFinishesKnownChecks(t *testing.T) {
 }
 
 func TestReadinessContinuationPromptStaysHiddenFromUserHistory(t *testing.T) {
-	prompt := readinessContinuationPrompt(nil, "run the missing verification")
+	prompt := readinessContinuationPrompt(nil, []string{"verification"}, "run the missing verification")
 	if !IsSyntheticUserMessage(prompt) {
 		t.Fatalf("readiness continuation was treated as user-authored text: %q", prompt)
 	}
@@ -97,6 +98,19 @@ func TestReadinessContinuationPromptStaysHiddenFromUserHistory(t *testing.T) {
 		if !strings.Contains(prompt, forbidden) {
 			t.Fatalf("readiness continuation prompt = %q, want safety clause %q", prompt, forbidden)
 		}
+	}
+}
+
+func TestReadinessContinuationPromptIncludesOnlyReportedTodoGaps(t *testing.T) {
+	todos := []evidence.TodoItem{{Content: "future task", Status: "pending"}}
+	verification := readinessContinuationPrompt(todos, []string{"verification"}, "run verification")
+	if strings.Contains(verification, "future task") || strings.Contains(verification, "tasks are still incomplete") {
+		t.Fatalf("verification-only continuation leaked ordinary cross-turn todos: %q", verification)
+	}
+
+	todoGap := readinessContinuationPrompt(todos, []string{"todo"}, "finish the delivery plan")
+	if !strings.Contains(todoGap, "future task") || !strings.Contains(todoGap, "tasks are still incomplete") {
+		t.Fatalf("todo readiness gap omitted its incomplete task context: %q", todoGap)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Let ordinary open turns finish normally when a partially completed todo list is cross-turn work state rather than a delivery contradiction.
- Preserve unfinished-todo enforcement for Goal, approved Plan, and strict-obligation turns.
- Integrate with #8947 so bounded ordinary readiness continuations include todo context only when `todo` is one of the host-reported missing requirements.
- Document the current closed-loop todo and bounded continuation behavior.

## Behavior

| Turn | Unfinished todos | Result |
| --- | --- | --- |
| Ordinary open turn, todo-only gap | Yes | End normally; keep the todo state for later turns |
| Ordinary turn with verification/review gap | Yes | Continue only the host-reported readiness gap; do not inject unrelated todos |
| Goal / approved Plan / strict obligation | Yes | Keep returning `FinalReadinessError` until the delivery contract is satisfied or genuinely blocked |

## Issues

Fixes #8851

Supersedes #8951

Refs #8947

## Consolidation notes

### Kept and adapted

- Kept #8951's closed-loop unfinished-todo gate and open-turn regression coverage from @erphenheimer.
- Reimplemented the change on the current `main-v2` readiness architecture after #8947.
- Added controller-side filtering by `FinalReadinessError.Missing`, retained ordinary verification/review continuation, extracted the regression test to stay within repository capacity budgets, and updated the delivery documentation.
- The adopted contributor work is preserved with a commit-level `Co-authored-by` trailer using the contributor's public commit identity.

### Reviewed but not adopted

- The frontend-only alternative proposed in #8951 was not used because the incorrect distinction belongs to the backend readiness contract; hiding the recovery UI would leave the underlying retry semantics unchanged.

## Verification

- `go test ./...`
- `go test -race ./internal/agent ./internal/control`
- `go vet ./...`
- `go run ./tools/repolint`
- `scripts/check-docs-impact.sh`
- `scripts/check-cache-impact.sh`
- `git diff --check`

## Documentation impact

Documentation-impact: updated - documented closed-loop-only unfinished-todo blocking and bounded ordinary readiness continuations.

## Cache impact

Cache-impact: none - readiness recovery context remains an append-only user turn; the stable system, memory, and tool-schema prefixes are unchanged.
Cache-guard: focused readiness continuation prompt coverage plus the repository cache-impact guard.
System-prompt-review: not required - no provider-visible system prompt, memory prefix, output style, or tool schema changed.
