### PR TITLE
fix(desktop): restore quick jumps in long transcripts

### DIFF
--- a/desktop/frontend/src/__tests__/transcript-question-jump.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-question-jump.test.tsx
@@ -1,0 +1,66 @@
+// Run: tsx src/__tests__/transcript-question-jump.test.tsx
+
+import { createTranscriptHarness } from "./transcript-dom-harness";
+import type { Item } from "../lib/useController";
+import { act } from "react";
+
+let passed = 0;
+let failed = 0;
+
+function ok(condition: unknown, label: string) {
+  if (condition) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function turns(count: number): Item[] {
+  const items: Item[] = [];
+  for (let i = 0; i < count; i += 1) {
+    items.push({ kind: "user", id: `u${i}`, text: `question ${i}` });
+    items.push({ kind: "assistant", id: `a${i}`, text: `answer ${i}`, reasoning: "", streaming: false });
+  }
+  return items;
+}
+
+console.log("\ntranscript question jump");
+
+{
+  const harness = await createTranscriptHarness({ viewportHeight: 200, rowHeight: 100 });
+  try {
+    HTMLElement.prototype.scrollIntoView = () => {};
+    await harness.render(turns(40), { running: false, questionNavigator: true });
+    await harness.settle();
+
+    const jumpItems = harness.container.querySelectorAll<HTMLButtonElement>(".jump-item");
+    ok(jumpItems.length === 40, "long transcript exposes every question marker");
+    const jumpBar = harness.container.querySelector<HTMLElement>(".jump-bar");
+    const jumpScroll = harness.container.querySelector<HTMLElement>(".jump-scroll");
+    if (!jumpBar || !jumpScroll) throw new Error("question jump bar is not mounted");
+    jumpBar.getBoundingClientRect = () => ({ top: 0, bottom: 240, left: 0, right: 56, height: 240, width: 56 } as DOMRect);
+    jumpItems.forEach((item, index) => {
+      item.getBoundingClientRect = () => ({ top: index * 20, bottom: index * 20 + 14, left: 0, right: 32, height: 14, width: 32 } as DOMRect);
+    });
+
+    const targetIndices = [3, 31, 7, 36, 12, 28];
+    for (const targetIndex of targetIndices) {
+      await act(async () => {
+        jumpScroll.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0, clientY: targetIndex * 20 + 7 }));
+        jumpScroll.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, clientY: targetIndex * 20 + 7 }));
+        harness.container.querySelector<HTMLElement>(".transcript")?.dispatchEvent(new Event("scroll", { bubbles: true }));
+      });
+      await harness.settle();
+      const target = harness.container.querySelector(`#question-anchor-u${targetIndex}`);
+      ok(Boolean(target), `jump ${targetIndex + 1} mounts the selected question`);
+    }
+  } finally {
+    await harness.unmount();
+    await harness.close();
+  }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -611,8 +611,8 @@ export function Transcript({
     const index = rowIndexByKey.get(String(userRowKey(question.id)));
     if (index == null) return;
     invalidateAnchors();
-    scrollToDataIndex(firstItemIndex, index, "smooth");
-  }, [firstItemIndex, invalidateAnchors, rowIndexByKey, scrollToDataIndex]);
+    scrollToDataIndex(index, "smooth");
+  }, [invalidateAnchors, rowIndexByKey, scrollToDataIndex]);
 
   // The jump-bottom click is explicit user intent: it outranks any in-flight
   // recovery anchor restore and ends a stale selection gesture whose
@@ -622,7 +622,6 @@ export function Transcript({
     invalidateAnchors();
     scrollToBottom();
   };
-
   // After a non-fork rewind, scroll to the last user message (the
   // rewound-to point) so the user knows where they are.
   useEffect(() => {
@@ -631,7 +630,7 @@ export function Transcript({
     const index = rowIndexByKey.get(String(userRowKey(lastQ.id)));
     if (index == null) return;
     invalidateAnchors();
-    scrollToDataIndex(firstItemIndex, index);
+    scrollToDataIndex(index);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rewindSignal]);
 

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -513,9 +513,9 @@ export function useTranscriptScrollArbiter({
     return true;
   }, [dispatch]);
 
-  const scrollToDataIndex = useCallback((firstItemIndex: number, dataIndex: number, behavior: "auto" | "smooth" = "auto") => {
+  const scrollToDataIndex = useCallback((dataIndex: number, behavior: "auto" | "smooth" = "auto") => {
     if (isTranscriptSelectionMode(modeRef.current)) return;
-    dispatch({ type: "JUMP_TO_INDEX", index: firstItemIndex + dataIndex, behavior });
+    dispatch({ type: "JUMP_TO_INDEX", index: dataIndex, behavior });
   }, [dispatch]);
 
   const finishProgrammaticScroll = useCallback(() => dispatch({ type: "PROGRAMMATIC_END" }), [dispatch]);


### PR DESCRIPTION
## Summary
- Fixed an issue where the right-side quick jump in long conversations used an incorrect Virtuoso index, causing the jump action to fail.
- Preserved the anchor invalidation handling in the main scroll arbitration flow, while making quick jump and rewind use data-relative indexes.
- Added regression tests for continuous jumping in long transcripts, covering multiple positions before and after the target location.

## Issues

This PR fixes an issue where quick jump actions in long conversations either had no response after clicking or incorrectly jumped to the bottom of the transcript.

## Verification

- `transcript-question-jump.test.tsx`: 7 passed, 0 failed
- `pnpm.cmd run build`: passed
- TypeScript, ESLint, single-scroll-writer, CSS syntax, z-index token, and bundle budget checks: passed
- `pnpm.cmd run test:all`: existing `test:task-monitor` still fails (6 passed, 16 failed); failures are concentrated in the task monitoring panel and are unrelated to the files or logic changed in this PR.

## Documentation impact

Documentation-impact: none - This change only fixes the internal desktop transcript scroll indexing logic. Existing documentation remains accurate.

## Cache impact

Cache-impact: none - This change only modifies desktop transcript scroll coordinates and tests. It does not affect provider-visible system prompts, memory prefixes, or tool registration.

Cache-guard: not applicable - No cache-sensitive paths were modified.

System-prompt-review: N/A