### PR TITLE
fix(desktop): make session-group header font larger than session titles / 分组标题字号略大于普通会话标题

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-row-stability.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-row-stability.test.ts
@@ -24,5 +24,15 @@ assert.match(
   /:root\[data-theme-style\] \.sidebar--workbench \.project-tree__topic\s*\{[^}]*height:\s*34px;/s,
   "workbench topic rows keep a fixed height",
 );
+assert.match(
+  styles,
+  /\.project-tree__group-input\s*\{[^}]*font-size:\s*inherit;/s,
+  "group rename inputs keep the group title font size",
+);
+assert.doesNotMatch(
+  styles,
+  /\.project-tree__group-input\s*\{[^}]*font-size:\s*11px;/s,
+  "group rename inputs cannot restore the old smaller font size",
+);
 
 console.log("  PASS  project tree row stability contract");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30357,7 +30357,7 @@ body > .mermaid-diagram--fullscreen {
 .project-tree__group-input {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 11px;
+  font-size: inherit;
   font-weight: 600;
   padding: 1px 4px;
   border-radius: 4px;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -30319,13 +30319,12 @@ body > .mermaid-diagram--fullscreen {
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 3px 6px;
+  padding: 5px 6px;
   border-radius: 6px;
   color: var(--color-text-muted, inherit);
-  font-size: 11px;
+  font-size: var(--text-md);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   cursor: pointer;
   background: transparent;
   border: 1px dashed transparent;


### PR DESCRIPTION
## Summary

The session-group header font is smaller than normal session titles: `.project-tree__group-main` forces `font-size: 11px` + `text-transform: uppercase` with `padding: 3px`, while ordinary session titles render at `12.5px` with `min-height: 34px`. The smaller font compresses the header row height and makes the group (a container title) less prominent than its members, and also shrinks the drop-into-group target area. Fixes #9030.

## Problem

- File: `desktop/frontend/src/styles.css` → `.project-tree__group-main`
- Current: `font-size: 11px; font-weight: 600; text-transform: uppercase; padding: 3px 6px`
- Theme titles: `.project-tree__topic-label` → `font-size: 12.5px`, `.project-tree__topic-main` → `min-height: 34px`

## Fix

- `font-size: 11px` → `var(--text-md)` (13px), slightly larger than the 12.5px session title
- Drop `text-transform: uppercase` so the label renders in natural casing (uppercase + small size is what made it look smaller and shorter)
- `letter-spacing: 0.04em` → `0`
- `padding: 3px 6px` → `5px 6px` to restore comfortable row height / clickable and drop area

## Issues

- Fixes #9030

## Verification

- `node scripts/check-css-syntax.mjs src/styles.css` — pass
- `node scripts/check-z-index-tokens.mjs src/styles.css` — pass
- `npx tsc --noEmit` — pass

## Documentation impact


Documentation-impact: none - CSS-only styling change; no docs/*.md changed.
none - UI style only; no docs/*.md changed.

## Cache impact

none - frontend CSS only; no provider/system-prompt/cache-sensitive paths touched.

## Cache guard

not required - no cache-sensitive files changed.

## System prompt review

not required - no boot/config/memory/skill/task files changed (desktop frontend CSS only).

