### PR TITLE
Fix tool-result cache prefix stability / 修复工具结果缓存前缀稳定性

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -257,9 +257,9 @@ when the sole automatic threshold is crossed.
   `agent.compact_ratio` (default **0.80**; presets 0.70 / 0.80 / 0.85; range
   0.65–0.85).
   `triggerTokens = floor(context_window × compact_ratio)`.
-- **Below the trigger** the model receives complete tool `RawContent` from a
-  temporary request projection; no sidecar is written. Durable `Content` remains
-  bounded for older Reasonix readers.
+- **Below the trigger** ordinary requests remain append-only and no sidecar is
+  written. Every provider request uses the durable, bounded tool `Content`;
+  local `RawContent` is never promoted into sampling, retry, summary, or replay.
 - **At the trigger** one singleflight maintenance transaction first persistently
   prunes every tool result over 8192 Unicode code points to `4096 head +
   "[... tool result middle pruned ...]" + 1024 tail`. If this clears pressure,
@@ -296,10 +296,12 @@ when the sole automatic threshold is crossed.
     the physical remainder. A negative value force-omits optional wire limits;
     if the known auto budget no longer fits, Reasonix compacts instead of
     overriding that choice.
-- Canonical tool storage remains backward compatible: `Content` is a stable
-  ≤32KB form and `RawContent` holds the full original. New request projections
-  promote tool `RawContent` below pressure; prune projections never rewrite either
-  canonical field. Older supported readers therefore remain bounded.
+- Canonical tool storage remains backward compatible: `Content` is the stable
+  provider-visible ≤32KB form and `RawContent` holds the full local original.
+  Full results are returned to the model only after an explicit paged
+  `use_capability` call to `session:tool_result`; sampling, stream retry, summary,
+  and projection replay all use the same bounded `Content`. Prune projections
+  never rewrite either canonical field. Older supported readers remain bounded.
 - Automatic maintenance is planned once in `ContextManager.Prepare` from the
   current projection plus the append-only canonical tail. The canonical
   transcript is never rewritten. Subsequent thresholds merge

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -148,8 +148,8 @@ transcript，仅在唯一自动阈值被跨越时安装 provider 可见的短 **
 - 每个 provider 声明 `context_window`（tokens）。唯一自动触发值是
   `agent.compact_ratio`（默认 **0.80**；预设 0.70 / 0.80 / 0.85；范围 0.65–0.85）。
   `triggerTokens = floor(context_window × compact_ratio)`。
-- **阈值以下**不写 projection；普通请求临时将 tool `RawContent` 提升为模型
-  可见 `Content`，因此新版本可看到完整工具结果，而旧版本仍安全读取有界内容。
+- **阈值以下**普通请求保持 append-only，不写 projection。所有 provider 请求只使用
+  持久化且有界的 tool `Content`；本地 `RawContent` 不会进入 sampling、重试、摘要或 replay。
 - **达到阈值**后，单飞维护事务先持久剪枝：所有超过 8192 个 Unicode code point
   的工具结果变为 `4096 头部 + "[... tool result middle pruned ...]" + 1024 尾部`。
   若已解除压力则不调摘要模型；否则将连续旧前缀摘要，并仅原样保留最近
@@ -166,8 +166,10 @@ transcript，仅在唯一自动阈值被跨越时安装 provider 可见的短 **
   - 官方 DeepSeek Chat/Responses 在剩余共享窗口还能放下 384K 自动预算时继续省略字段，只在临界时注入裁剪值。官方 Anthropic 兼容层因 `max_tokens` 必填，仍发送 384K 或裁剪值。
   - 官方 OpenCode Go 预设会主动发送 `min(模型上限, 物理剩余)`，使用通用 `max_tokens` / `max_output_tokens`。第三方兼容 API 在可信上下文 400 之前不假设共享窗口。
   - 正数是用户显式控费上限，仍可按物理剩余继续下调。负数表示明确省略可选 wire 字段；已知自动预算放不下时压缩，而不是覆盖用户选择。
-- canonical 工具存储保持向后兼容：`Content` 仍是稳定 ≤32KB 版，`RawContent` 保存完整原文。
-  新版请求投影在低压时提升 `RawContent`；prune projection 不改写两个 canonical 字段。
+- canonical 工具存储保持向后兼容：`Content` 是稳定的 provider 可见 ≤32KB 表示，
+  `RawContent` 保存本地完整原文。只有模型显式分页调用 `use_capability` 的
+  `session:tool_result` 后，完整结果页才会进入上下文；sampling、流重试、摘要与 projection
+  replay 均使用同一份有界 `Content`。prune projection 不改写两个 canonical 字段。
 - 自动维护只在 `ContextManager.Prepare` 中规划一次，输入为当前 projection 加上
   append-only canonical tail；canonical 永不改写。后续阈值合并
   **上一摘要 + 新增历史** 为单条 digest（无 multi-span、无应用层重试）。

--- a/docs/TOOL_CONTRACT.md
+++ b/docs/TOOL_CONTRACT.md
@@ -99,6 +99,19 @@ same-name shared client is rejected without process, network, or tool dispatch.
 The fixed proxy's provider-visible name, description, schema, and ordering do
 not change when MCP inventory changes.
 
+When the current frontend has a session reader, the same fixed proxy also lists
+the read-only `session:tool_result` capability. It pages the complete local copy
+of one tool result by UTF-8 byte offset without adding a top-level schema. Calls
+require `tool_call_id`; new truncation markers also provide a stable
+`result_ref`, which is required to disambiguate repeated call IDs. `offset`
+defaults to 0, `limit` defaults to 16KiB and is capped at 24KiB. Each response
+starts with `result_ref`, actual offset, `next_offset`, `total_bytes`, full
+SHA-256, and `complete`, followed by the raw page. The reader is bound to the
+current Agent session and is not inherited from a parent when a capability
+frontend is cloned. A restricted child that already has `use_capability` may
+read only its own results; an allowed-tools profile without the proxy is not
+widened.
+
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,
 `lsp_references`, `memory`, `parallel_tasks`, `read_only_skill`,

--- a/docs/TOOL_CONTRACT.zh-CN.md
+++ b/docs/TOOL_CONTRACT.zh-CN.md
@@ -77,6 +77,15 @@ MCP（含 `auto_start=false`）。宿主根据真实工具动作建立验证义�
 
 固定代理的 provider 可见 name、description、schema 与顺序不会随 MCP inventory 变化。
 
+frontend 绑定当前会话 reader 后，同一个固定代理还会列出只读能力
+`session:tool_result`。它按 UTF-8 字节偏移分页读取某条工具结果的本地完整副本，不新增
+top-level schema。调用必须提供 `tool_call_id`；新截断标记还会给出稳定 `result_ref`，重复
+call ID 时必须用它消除歧义。`offset` 默认 0，`limit` 默认 16KiB、最大 24KiB。响应先返回
+`result_ref`、实际 offset、`next_offset`、`total_bytes`、完整 SHA-256 与 `complete`，随后是
+原文页。reader 只绑定当前 Agent session，clone capability frontend 时不会继承父 reader。
+已经拥有 `use_capability` 的受限子 Agent 只能读取自己的结果；allowed-tools 配置若完全没有
+该代理，不会为了回读而扩大工具面。
+
 `ask`, `docs`, `explore`, `fleet`, `forget`, `history`, `install_skill`, `install_source`,
 `list_sessions`, `lsp_definition`, `lsp_diagnostics`, `lsp_hover`,
 `lsp_references`, `memory`, `parallel_tasks`, `read_only_skill`,

--- a/docs/research/cache-aware-compaction-design.md
+++ b/docs/research/cache-aware-compaction-design.md
@@ -22,7 +22,7 @@ canonical transcript (Session.Messages，普通维护永不改写)
     +-- model-visible context projection / checkpoint
     |       system + one structured summary + recent 16% tail
     |
-    +-- compatibility tool storage (32KB Content + full RawContent)
+    +-- stable provider tool view (≤32KB Content) + local full RawContent
     |
     +-- cache state (warm/cold/unknown，仅成本与观测)
 ```
@@ -83,7 +83,7 @@ stable system / early prefix
 
 ### Tool-result compatibility storage
 
-工具结果创建时把兼容字段 `Content` 限制在约 32KB，完整原文进 `RawContent`。新版本在低压普通请求中临时提升 `RawContent`，因此模型看到全文；只有达到压力阈值或 overflow 才安装 4096/marker/1024 的持久 prune projection。manual `/compact` 不自动 prune。
+工具结果创建时把 provider 可见字段 `Content` 固定限制在 32KB 内，完整原文进本地 `RawContent`。普通 sampling、stream retry、summary 与 projection replay 始终使用同一份有界 `Content`，不再因完整结果大小改变旧请求前缀。模型需要全文时，显式通过稳定 `use_capability` 代理调用 `session:tool_result`，以 UTF-8 字节 offset 分页读取；页面本身保持在单工具输出上限内。只有达到压力阈值或 overflow 时，维护 projection 才可进一步安装 4096/marker/1024 prune，并产生已有的缓存变更诊断。manual `/compact` 不自动 prune。
 
 ## 六、Provider 与输出预算
 
@@ -99,6 +99,8 @@ stable system / early prefix
 | 首次跨过 compact_ratio | 先 prune；必要时前缀变为 system+summary+tail，一次预期 miss |
 | checkpoint 安装后继续对话 | 稳定 prefix 利于 hit；generation 作用域避免重复摘要 |
 | cold resume | 只记 cache 状态，不因 TTL 重写历史 |
+| 大工具结果（低于阈值） | 首次只发送 ≤32KB `Content`；后续旧消息逐字节不变，`RawContent` 大小不线性增加 miss |
+| 显式回读完整结果 | 只将请求的 16–24KiB 页面追加给模型，不自动改写历史前缀 |
 
 ## 八、验证与烟雾
 
@@ -113,7 +115,8 @@ stable system / early prefix
 1. 配置结构体仍可读旧 soft/snip/force 键，加载时清零并迁移删除
 2. sidecar 仍可解码旧 prune/native 字段后忽略
 3. `PruneStaleToolResults` / `SnipStaleToolResults` 保留为 no-op API，避免旧调用点 panic
-4. `Content + RawContent` 双字段继续保证新旧版本都能安全读取同一 session
+4. `Content + RawContent` 双字段继续保证新旧版本都能安全读取同一 session；旧版本可能重新提升 `RawContent`，但不会损坏数据
+5. 旧 promoted-RawContent sidecar 只有在哈希精确匹配历史形式时才反向归一化为当前 bounded hash；无法证明时只丢弃 projection body，canonical 与维护 receipt 保留
 
 ## 十、明确未做
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,9 +37,8 @@ import (
 	"reasonix/internal/workspacelease"
 )
 
-// maxToolOutputBytes keeps Content readable by older Reasonix versions.
-// RawContent retains the complete result and new request projections promote it
-// until pressure-time pruning installs a durable bounded view.
+// maxToolOutputBytes bounds the stable provider-visible Content. RawContent
+// retains the complete local result for explicit session-scoped paging.
 const maxToolOutputBytes = 32 * 1024
 
 var deprecatedContextRetentionWarning sync.Once
@@ -1139,6 +1139,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	}
 	a.SetResponseLanguage(opts.ResponseLanguage)
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
+	a.bindToolResultSessionCapability()
 	a.maybeArmForkFromEnv()
 	a.maybeWrapForkCaptureProvider()
 	if warnDeprecatedRetention {
@@ -2759,16 +2760,15 @@ func firstLine(s string) string {
 	return s
 }
 
-// truncateToolOutput builds the compatibility Content form for a tool result.
-// Under-cap bodies are byte-identical; over-cap bodies keep a tool-aware head
-// and tail while RawContent stores the full original. New request projections
-// promote RawContent until pressure pruning, while older readers remain bounded.
+// truncateToolOutput builds the stable provider-visible Content form for a tool
+// result. Under-cap bodies are byte-identical; over-cap bodies keep a tool-aware
+// head and tail while RawContent stores the full local original.
 func truncateToolOutput(s string) (string, string) {
 	return truncateToolOutputFor(s, "", "")
 }
 
-// truncateToolOutputFor is the tool-aware compatibility-storage limiter.
-// toolName and toolCallID populate the marker used by older readers.
+// truncateToolOutputFor is the tool-aware provider-input limiter. toolName and
+// toolCallID populate the recovery marker.
 func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 	if len(s) <= maxToolOutputBytes {
 		return s, ""
@@ -2802,23 +2802,14 @@ func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 	}
 	head := snapToRuneBoundary(s, 0, headKeep)
 	tail := snapToRuneBoundary(s, len(s)-tailKeep, len(s))
-	omitted := len(s) - len(head) - len(tail)
-	namePart := toolName
-	if namePart == "" {
-		namePart = "tool"
-	}
-	idPart := toolCallID
-	if idPart == "" {
-		idPart = "-"
-	}
-	notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", omitted, len(s))
-	marker := fmt.Sprintf(
-		"\n\n…[truncated tool=%s call_id=%s original_bytes=%d kept_bytes=%d — full original retained in canonical transcript; re-read or retry with narrower args]…\n\n",
-		namePart, idPart, len(s), len(head)+len(tail),
-	)
-	body := head + marker + tail
-	if len(body) > maxToolOutputBytes {
-		overflow := len(body) - maxToolOutputBytes
+	resultRef := toolResultRef(toolCallID, s)
+	marker := toolOutputRecoveryMarker(toolName, toolCallID, resultRef, len(s), len(head)+len(tail))
+	for range 3 {
+		bodyLen := len(head) + len(marker) + len(tail)
+		if bodyLen <= maxToolOutputBytes {
+			break
+		}
+		overflow := bodyLen - maxToolOutputBytes
 		trimHead := overflow / 2
 		trimTail := overflow - trimHead
 		if trimHead < len(head) {
@@ -2827,9 +2818,46 @@ func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 		if trimTail < len(tail) {
 			tail = snapToRuneBoundary(tail, trimTail, len(tail))
 		}
-		body = head + marker + tail
+		marker = toolOutputRecoveryMarker(toolName, toolCallID, resultRef, len(s), len(head)+len(tail))
 	}
-	return body, notice
+	notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", len(s)-len(head)-len(tail), len(s))
+	return head + marker + tail, notice
+}
+
+func toolResultRef(toolCallID, body string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(toolCallID))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(body))
+	return fmt.Sprintf("tr-%x", h.Sum(nil)[:12])
+}
+
+func toolOutputRecoveryMarker(toolName, toolCallID, resultRef string, originalBytes, keptBytes int) string {
+	namePart := boundedMarkerField(toolName, 128, "tool")
+	idPart := boundedMarkerField(toolCallID, 128, "-")
+	exampleID := toolCallID
+	if len(exampleID) > 256 {
+		exampleID = "<full tool_call_id from this tool result>"
+	}
+	args, _ := json.Marshal(struct {
+		ToolCallID string `json:"tool_call_id"`
+		ResultRef  string `json:"result_ref"`
+		Offset     int    `json:"offset"`
+	}{ToolCallID: exampleID, ResultRef: resultRef})
+	return fmt.Sprintf(
+		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
+		namePart, idPart, resultRef, originalBytes, keptBytes, args,
+	)
+}
+
+func boundedMarkerField(value string, maxBytes int, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	return snapToRuneBoundary(value, 0, maxBytes) + "…"
 }
 
 // snapToRuneBoundary returns s[lo:hi] with the bounds nudged outward until

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2822,42 +2821,6 @@ func truncateToolOutputFor(s, toolName, toolCallID string) (string, string) {
 	}
 	notice := fmt.Sprintf("tool output truncated: %d of %d bytes elided", len(s)-len(head)-len(tail), len(s))
 	return head + marker + tail, notice
-}
-
-func toolResultRef(toolCallID, body string) string {
-	h := sha256.New()
-	_, _ = h.Write([]byte(toolCallID))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(body))
-	return fmt.Sprintf("tr-%x", h.Sum(nil)[:12])
-}
-
-func toolOutputRecoveryMarker(toolName, toolCallID, resultRef string, originalBytes, keptBytes int) string {
-	namePart := boundedMarkerField(toolName, 128, "tool")
-	idPart := boundedMarkerField(toolCallID, 128, "-")
-	exampleID := toolCallID
-	if len(exampleID) > 256 {
-		exampleID = "<full tool_call_id from this tool result>"
-	}
-	args, _ := json.Marshal(struct {
-		ToolCallID string `json:"tool_call_id"`
-		ResultRef  string `json:"result_ref"`
-		Offset     int    `json:"offset"`
-	}{ToolCallID: exampleID, ResultRef: resultRef})
-	return fmt.Sprintf(
-		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
-		namePart, idPart, resultRef, originalBytes, keptBytes, args,
-	)
-}
-
-func boundedMarkerField(value string, maxBytes int, fallback string) string {
-	if value == "" {
-		return fallback
-	}
-	if len(value) <= maxBytes {
-		return value
-	}
-	return snapToRuneBoundary(value, 0, maxBytes) + "…"
 }
 
 // snapToRuneBoundary returns s[lo:hi] with the bounds nudged outward until

--- a/internal/agent/cachehit_e2e_test.go
+++ b/internal/agent/cachehit_e2e_test.go
@@ -357,6 +357,10 @@ func TestReleaseCacheHitGuard(t *testing.T) {
 
 	threshold := envInt("REASONIX_CACHE_GUARD_THRESHOLD", 90)
 	maxLowCases := envInt("REASONIX_CACHE_GUARD_MAX_LOW_CASES", 1)
+	for _, size := range []int{64 << 10, 256 << 10} {
+		verifyLargeToolOutputCacheContract(t, size)
+		t.Logf("CACHE_GUARD_RESULT: case=large-tool-%dk status=pass provider_bytes_max=%d", size>>10, maxToolOutputBytes)
+	}
 
 	cases := []struct {
 		name string
@@ -449,6 +453,82 @@ func TestReleaseCacheHitGuard(t *testing.T) {
 			t.Fatal(msg)
 		}
 	}
+}
+
+func TestLargeToolOutputCachePrefixContract(t *testing.T) {
+	visibleSizes := make([]int, 0, 2)
+	for _, size := range []int{64 << 10, 256 << 10} {
+		visibleSizes = append(visibleSizes, verifyLargeToolOutputCacheContract(t, size))
+	}
+	if visibleSizes[1]-visibleSizes[0] > 128 {
+		t.Fatalf("provider-visible growth tracks RawContent: 64KiB=%d 256KiB=%d", visibleSizes[0], visibleSizes[1])
+	}
+}
+
+func verifyLargeToolOutputCacheContract(t *testing.T, size int) int {
+	t.Helper()
+	callID := fmt.Sprintf("large-%d", size)
+	const rawSentinel = "UNIQUE-RAW-MIDDLE-SENTINEL"
+	raw := strings.Repeat("R", size/2) + rawSentinel + strings.Repeat("R", size/2-len(rawSentinel))
+	bounded, notice := truncateToolOutputFor(raw, "large_result", callID)
+	if notice == "" || len(bounded) > maxToolOutputBytes {
+		t.Fatalf("%d-byte result was not bounded: content=%d notice=%q", size, len(bounded), notice)
+	}
+	canonical := []provider.Message{
+		{Role: provider.RoleSystem, Content: systemPrompt},
+		{Role: provider.RoleUser, Content: "produce a large result"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: callID, Name: "large_result", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: callID, Name: "large_result", Content: bounded, RawContent: raw},
+	}
+	first := modelInputMessages(canonical)
+	firstWire := encodeProviderMessages(t, first)
+	if bytes.Contains(mustCacheJSON(t, firstWire), []byte(rawSentinel)) {
+		t.Fatal("provider-visible request contains RawContent sentinel")
+	}
+	if got := first[len(first)-1]; got.RawContent != "" || len(got.Content) > maxToolOutputBytes {
+		t.Fatalf("provider tool result is not bounded: content=%d raw=%d", len(got.Content), len(got.RawContent))
+	}
+
+	secondCanonical := append(append([]provider.Message(nil), canonical...), provider.Message{Role: provider.RoleUser, Content: "continue"})
+	second := modelInputMessages(secondCanonical)
+	secondWire := encodeProviderMessages(t, second)
+	if common := commonPrefixMsgs(firstWire, secondWire); common != len(firstWire) {
+		t.Fatalf("%d-byte result changed old provider prefix at message %d/%d", size, common, len(firstWire))
+	}
+
+	reg := tool.NewRegistry()
+	reg.Add(echoTool{})
+	beforeSchemas, afterSchemas := reg.Schemas(), reg.Schemas()
+	beforeShape := CaptureShape(systemPrompt, beforeSchemas, 0)
+	afterShape := CaptureShape(systemPrompt, afterSchemas, 0)
+	if !bytes.Equal(mustCacheJSON(t, beforeSchemas), mustCacheJSON(t, afterSchemas)) {
+		t.Fatal("large tool result changed provider tool schema bytes or order")
+	}
+	if diag := CompareShape(beforeShape, afterShape, nil, nil); diag.PrefixChanged {
+		t.Fatalf("large append-only result reported PrefixChanged: %+v", diag)
+	}
+	if canonical[len(canonical)-1].RawContent != raw {
+		t.Fatal("canonical RawContent was not retained")
+	}
+	return charsOf(firstWire)
+}
+
+func encodeProviderMessages(t *testing.T, msgs []provider.Message) []json.RawMessage {
+	t.Helper()
+	out := make([]json.RawMessage, len(msgs))
+	for i, msg := range msgs {
+		out[i] = append(json.RawMessage(nil), mustCacheJSON(t, msg)...)
+	}
+	return out
+}
+
+func mustCacheJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }
 
 func cacheCurve(t *testing.T, mock *mockDeepSeek, turns int) []int {

--- a/internal/agent/capability_list_filter.go
+++ b/internal/agent/capability_list_filter.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"maps"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -60,9 +61,7 @@ func cloneBoolMap(src map[string]bool) map[string]bool {
 		return nil
 	}
 	dst := make(map[string]bool, len(src))
-	for key, value := range src {
-		dst[key] = value
-	}
+	maps.Copy(dst, src)
 	return dst
 }
 

--- a/internal/agent/capability_list_filter.go
+++ b/internal/agent/capability_list_filter.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func (t *restrictedCapabilityProxy) bindToolResultSession(session func() *Session) {
+	if binder, ok := t.Tool.(toolResultSessionBinder); ok {
+		binder.bindToolResultSession(session)
+	}
+}
+
+// emptyCapabilityListResult is the fail-closed list payload: no server metadata.
+func emptyCapabilityListResult(note string) string {
+	if strings.TrimSpace(note) == "" {
+		note = "list is filtered to this subagent's allowed MCP servers."
+	}
+	b, err := json.MarshalIndent(map[string]any{
+		"capabilities": []any{},
+		"servers":      []listServerInfo{},
+		"note":         note,
+	}, "", "  ")
+	if err != nil {
+		return `{"servers":[],"note":"list is filtered to this subagent's allowed MCP servers."}`
+	}
+	return string(b)
+}
+
+// filterCapabilityListResult keeps only servers in the allowlist for restricted
+// proxies. Empty allowlist or unreadable payloads fail closed (empty server
+// list) so discovery never leaks the full configured MCP inventory.
+func filterCapabilityListResult(raw string, servers map[string]bool) string {
+	const baseNote = "list is filtered to this subagent's allowed MCP servers."
+	if len(servers) == 0 {
+		return emptyCapabilityListResult(baseNote + " No allowed MCP servers were resolved from the profile allowlist.")
+	}
+	var payload struct {
+		Capabilities []json.RawMessage `json:"capabilities"`
+		Servers      []listServerInfo  `json:"servers"`
+		Note         string            `json:"note"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return emptyCapabilityListResult(baseNote + " List payload was unreadable; returning no servers (fail-closed).")
+	}
+	filtered := make([]listServerInfo, 0, len(payload.Servers))
+	for _, s := range payload.Servers {
+		if servers[strings.TrimSpace(s.Name)] {
+			filtered = append(filtered, s)
+		}
+	}
+	payload.Servers = filtered
+	filteredCapabilities := make([]json.RawMessage, 0, 1)
+	for _, raw := range payload.Capabilities {
+		var entry struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(raw, &entry) == nil && strings.TrimSpace(entry.ID) == sessionToolResultCapabilityID {
+			filteredCapabilities = append(filteredCapabilities, raw)
+		}
+	}
+	payload.Capabilities = filteredCapabilities
+	if payload.Note == "" {
+		payload.Note = baseNote
+	} else if !strings.Contains(payload.Note, "Filtered to this subagent") {
+		payload.Note += " Filtered to this subagent's allowed MCP servers."
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return emptyCapabilityListResult(baseNote + " Failed to encode filtered list (fail-closed).")
+	}
+	return string(b)
+}

--- a/internal/agent/capability_list_filter.go
+++ b/internal/agent/capability_list_filter.go
@@ -3,12 +3,67 @@ package agent
 import (
 	"encoding/json"
 	"strings"
+
+	"reasonix/internal/tool"
 )
 
 func (t *restrictedCapabilityProxy) bindToolResultSession(session func() *Session) {
 	if binder, ok := t.Tool.(toolResultSessionBinder); ok {
 		binder.bindToolResultSession(session)
 	}
+}
+
+// cloneCapabilityFrontend creates an Agent-owned frontend whenever binding a
+// session reader could otherwise mutate a parent Agent's tool. Unknown tools
+// remain shareable only when they cannot participate in session binding.
+func cloneCapabilityFrontend(frontend tool.Tool) tool.Tool {
+	switch typed := frontend.(type) {
+	case nil:
+		return nil
+	case *UseCapabilityTool:
+		if typed == nil {
+			return nil
+		}
+		return typed.CloneForAgent(nil, nil)
+	case *restrictedCapabilityProxy:
+		if typed == nil {
+			return nil
+		}
+		return typed.cloneForAgent()
+	default:
+		if _, sessionBindable := frontend.(toolResultSessionBinder); sessionBindable {
+			return nil
+		}
+		return frontend
+	}
+}
+
+func (t *restrictedCapabilityProxy) cloneForAgent() *restrictedCapabilityProxy {
+	if t == nil {
+		return nil
+	}
+	inner := cloneCapabilityFrontend(t.Tool)
+	resolver, ok := inner.(tool.CallResolver)
+	if inner == nil || !ok {
+		return nil
+	}
+	return &restrictedCapabilityProxy{
+		Tool:     inner,
+		resolver: resolver,
+		allowed:  cloneBoolMap(t.allowed),
+		servers:  cloneBoolMap(t.servers),
+	}
+}
+
+func cloneBoolMap(src map[string]bool) map[string]bool {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]bool, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 // emptyCapabilityListResult is the fail-closed list payload: no server metadata.

--- a/internal/agent/capability_list_filter.go
+++ b/internal/agent/capability_list_filter.go
@@ -31,6 +31,13 @@ func cloneCapabilityFrontend(frontend tool.Tool) tool.Tool {
 			return nil
 		}
 		return typed.cloneForAgent()
+	case pathBoundCapabilityProxy:
+		inner := cloneCapabilityFrontend(typed.inner)
+		resolver, ok := inner.(tool.CallResolver)
+		if inner == nil || !ok {
+			return nil
+		}
+		return pathBoundCapabilityProxy{inner: inner, resolver: resolver}
 	default:
 		if _, sessionBindable := frontend.(toolResultSessionBinder); sessionBindable {
 			return nil

--- a/internal/agent/compact_projection.go
+++ b/internal/agent/compact_projection.go
@@ -364,7 +364,7 @@ func buildVisibleCompressionProjection(visible []provider.Message, plan visibleC
 			projection = append(projection, msg)
 		}
 	}
-	return provider.ProjectionMessages(promoteToolRawContent(projection))
+	return provider.ProjectionMessages(projection)
 }
 
 func compactionTelemetryFromSummary(trigger, cacheState string, sourceTokens int, res foldSummary) CompactionTelemetry {

--- a/internal/agent/live_tool_result_cache_test.go
+++ b/internal/agent/live_tool_result_cache_test.go
@@ -1,0 +1,145 @@
+//go:build live
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/provider/openai"
+	"reasonix/internal/tool"
+)
+
+type liveLargeResultTool struct{}
+
+func (liveLargeResultTool) Name() string { return "live_large_result" }
+func (liveLargeResultTool) Description() string {
+	return "Return the fixed large cache-regression fixture. Call only when the user explicitly requests it."
+}
+func (liveLargeResultTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)
+}
+func (liveLargeResultTool) ReadOnly() bool { return true }
+func (liveLargeResultTool) Execute(context.Context, json.RawMessage) (string, error) {
+	const sentinel = "LIVE-RAW-MIDDLE-SENTINEL"
+	return strings.Repeat("R", 128<<10) + sentinel + strings.Repeat("R", (128<<10)-len(sentinel)), nil
+}
+
+type liveCacheCaptureProvider struct {
+	provider.Provider
+	mu       sync.Mutex
+	requests []provider.Request
+}
+
+func (p *liveCacheCaptureProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	copyReq := req
+	copyReq.Messages = append([]provider.Message(nil), req.Messages...)
+	copyReq.Tools = append([]provider.ToolSchema(nil), req.Tools...)
+	p.requests = append(p.requests, copyReq)
+	p.mu.Unlock()
+	return p.Provider.Stream(ctx, req)
+}
+
+func (p *liveCacheCaptureProvider) snapshot() []provider.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]provider.Request(nil), p.requests...)
+}
+
+func TestLiveDeepSeekLargeToolResultCacheTrend(t *testing.T) {
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		t.Skip("DEEPSEEK_API_KEY not set")
+	}
+	baseURL := strings.TrimRight(os.Getenv("DEEPSEEK_BASE_URL"), "/")
+	if baseURL == "" {
+		baseURL = "https://api.deepseek.com"
+	}
+	base, err := openai.New(provider.Config{
+		Name: "live-tool-cache", BaseURL: baseURL, Model: "deepseek-v4-flash", APIKey: key,
+		Extra: map[string]any{"api_key_env": "DEEPSEEK_API_KEY"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closer, ok := base.(interface{ CloseIdleConnections() }); ok {
+		t.Cleanup(closer.CloseIdleConnections)
+	}
+	capture := &liveCacheCaptureProvider{Provider: base}
+	reg := tool.NewRegistry()
+	reg.Add(liveLargeResultTool{})
+	var usages []*provider.Usage
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Usage && e.Usage != nil {
+			copyUsage := *e.Usage
+			usages = append(usages, &copyUsage)
+		}
+	})
+	system := "You are a concise cache-regression agent. Follow explicit tool instructions. " +
+		strings.Repeat("Keep this stable provider prefix byte-identical across every request. ", 80)
+	a := New(capture, reg, NewSession(system), Options{ContextWindow: 1_000_000, MaxOutputTokens: 256, MaxSteps: 5}, sink)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	turns := []string{
+		"Call live_large_result exactly once, then answer only: received.",
+		"Do not call tools. Reply only: second.",
+		"Do not call tools. Reply only: third.",
+	}
+	for i, prompt := range turns {
+		if err := a.Run(ctx, prompt); err != nil {
+			t.Fatalf("turn %d: %v", i+1, err)
+		}
+	}
+
+	requests := capture.snapshot()
+	if len(requests) < 4 {
+		t.Fatalf("captured requests=%d, want tool loop plus two ordinary turns", len(requests))
+	}
+	seenBoundedTool := false
+	for i, req := range requests {
+		wire, err := json.Marshal(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Contains(wire, []byte("LIVE-RAW-MIDDLE-SENTINEL")) {
+			t.Fatalf("request %d leaked local RawContent sentinel", i+1)
+		}
+		for _, msg := range req.Messages {
+			if msg.Role == provider.RoleTool && msg.Name == "live_large_result" {
+				seenBoundedTool = true
+				if msg.RawContent != "" || len(msg.Content) > maxToolOutputBytes {
+					t.Fatalf("request %d tool bytes: content=%d raw=%d", i+1, len(msg.Content), len(msg.RawContent))
+				}
+			}
+		}
+		if i > 0 {
+			previous := requests[i-1].Messages
+			current := req.Messages
+			if len(current) >= len(previous) {
+				for j := range previous {
+					before, _ := json.Marshal(previous[j])
+					after, _ := json.Marshal(current[j])
+					if !bytes.Equal(before, after) {
+						t.Fatalf("request %d changed prior provider message %d", i+1, j)
+					}
+				}
+			}
+		}
+	}
+	if !seenBoundedTool {
+		t.Fatal("model did not execute the large-result fixture")
+	}
+	for i, usage := range usages {
+		t.Logf("live cache turn=%d prompt=%d hit=%d miss=%d", i+1, usage.PromptTokens, usage.CacheHitTokens, usage.CacheMissTokens)
+	}
+}

--- a/internal/agent/path_bound_tools.go
+++ b/internal/agent/path_bound_tools.go
@@ -29,6 +29,12 @@ type pathBoundCapabilityProxy struct {
 	resolver tool.CallResolver
 }
 
+func (p pathBoundCapabilityProxy) bindToolResultSession(session func() *Session) {
+	if binder, ok := p.inner.(toolResultSessionBinder); ok {
+		binder.bindToolResultSession(session)
+	}
+}
+
 func (p pathBoundCapabilityProxy) Name() string            { return p.inner.Name() }
 func (p pathBoundCapabilityProxy) Description() string     { return p.inner.Description() }
 func (p pathBoundCapabilityProxy) Schema() json.RawMessage { return p.inner.Schema() }

--- a/internal/agent/planner_registry.go
+++ b/internal/agent/planner_registry.go
@@ -38,10 +38,8 @@ func PlannerToolRegistry(parent *tool.Registry) *tool.Registry {
 	}
 	if parent != nil {
 		if tl, ok := parent.Get("use_capability"); ok {
-			if uc, ok := tl.(*UseCapabilityTool); ok {
-				sub.Add(uc.CloneForAgent(nil, nil))
-			} else {
-				sub.Add(tl)
+			if cloned := cloneCapabilityFrontend(tl); cloned != nil {
+				sub.Add(cloned)
 			}
 		}
 	}

--- a/internal/agent/preflight.go
+++ b/internal/agent/preflight.go
@@ -129,7 +129,7 @@ func (a *Agent) LoadProjectionSidecar(sessionPath string) {
 	if a.sess.conversation != nil {
 		msgs, preRepair = a.sess.conversation.projectionValidationMessages()
 	}
-	needsNormalization := migrateBoundedCoveredPrefixHash(&st, msgs)
+	needsNormalization := migratePromotedCoveredPrefixHash(&st, msgs)
 	a.sess.compactionMu.Lock()
 	key := a.currentPromptCacheKeyLocked()
 	normalized, keyOK := lineageKeyCompatible(st.PromptCacheKey, key)

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -288,9 +288,55 @@ func promotedCoveredPrefixHash(msgs []provider.Message, n int) string {
 	return providerVisibleFingerprint(provider.SanitizeToolPairing(provider.ModelMessages(promoted)))
 }
 
+// normalizePromotedProjectionToolBodies converts the provider-visible tool
+// bodies persisted by the temporary RawContent-promoting implementation back
+// to canonical bounded Content. Every tool message must match a canonical tool
+// result exactly by identity and old provider-visible body. Duplicate call IDs
+// are safe only when every matching candidate maps to the same bounded body.
+func normalizePromotedProjectionToolBodies(projection, canonical []provider.Message, n int) ([]provider.Message, bool) {
+	if n <= 0 || n > len(canonical) {
+		return nil, false
+	}
+	normalized := append([]provider.Message(nil), projection...)
+	for i, projected := range normalized {
+		if projected.Role != provider.RoleTool {
+			continue
+		}
+		visibleBody := projected.Content
+		if projected.ProviderContent != "" {
+			visibleBody = projected.ProviderContent
+		}
+		boundedBody := ""
+		matched := false
+		for _, candidate := range canonical[:n] {
+			if candidate.Role != provider.RoleTool || candidate.ToolCallID != projected.ToolCallID || candidate.Name != projected.Name {
+				continue
+			}
+			matchesBounded := visibleBody == candidate.Content
+			matchesPromoted := candidate.RawContent != "" && visibleBody == candidate.RawContent
+			if !matchesBounded && !matchesPromoted {
+				continue
+			}
+			if matched && boundedBody != candidate.Content {
+				return nil, false
+			}
+			boundedBody = candidate.Content
+			matched = true
+		}
+		if !matched {
+			return nil, false
+		}
+		normalized[i].Content = boundedBody
+		normalized[i].RawContent = ""
+		normalized[i].ProviderContent = ""
+	}
+	return normalized, true
+}
+
 // migratePromotedCoveredPrefixHash normalizes a sidecar written while full tool
-// RawContent was model-visible. Migration is exact: unrelated or stale hashes
-// are left invalid so the loader drops only their projection body.
+// RawContent was model-visible. Migration is exact and atomic: both its hash and
+// retained tool bodies must match the historical form. Unrelated, stale, or
+// ambiguous sidecars stay invalid so callers drop only their projection body.
 func migratePromotedCoveredPrefixHash(st *CompactionState, msgs []provider.Message) bool {
 	if st == nil {
 		return false
@@ -302,6 +348,11 @@ func migratePromotedCoveredPrefixHash(st *CompactionState, msgs []provider.Messa
 		stored != promotedCoveredPrefixHash(msgs, n) {
 		return false
 	}
+	normalizedMessages, ok := normalizePromotedProjectionToolBodies(st.Projection.Messages, msgs, n)
+	if !ok {
+		return false
+	}
+	st.Projection.Messages = normalizedMessages
 	st.Projection.CoveredPrefixHash = currentHash
 	if st.LastReceipt != nil && st.LastReceipt.CoveredPrefixHash == stored {
 		receipt := *st.LastReceipt

--- a/internal/agent/projection.go
+++ b/internal/agent/projection.go
@@ -252,10 +252,9 @@ func summaryContentHash(summary string) string {
 }
 
 // coveredPrefixHash fingerprints the current model-visible prefix of msgs[:n].
-// Tool RawContent is promoted here because it is what new requests send to the
-// provider; bounded Content remains only the compatibility representation for
-// older readers. SanitizeToolPairing applies the same deterministic repair used
-// on the wire, keeping hashes stable when LoadSession repairs a transcript.
+// Tool Content is the stable bounded provider representation; RawContent is
+// local-only. SanitizeToolPairing applies the same deterministic repair used on
+// the wire, keeping hashes stable when LoadSession repairs a transcript.
 func coveredPrefixHash(msgs []provider.Message, n int) string {
 	if n <= 0 || n > len(msgs) {
 		return ""
@@ -264,9 +263,8 @@ func coveredPrefixHash(msgs []provider.Message, n int) string {
 	return providerVisibleFingerprint(provider.SanitizeToolPairing(visible))
 }
 
-// boundedCoveredPrefixHash reproduces the pre-RawContent v3 fingerprint. It
-// is accepted only for reading old sidecars; every new checkpoint writes the
-// current hash above so a later RawContent edit cannot reuse stale state.
+// boundedCoveredPrefixHash is the v3 bounded provider fingerprint. Keep the
+// named helper for old sidecar and load-repair compatibility tests.
 func boundedCoveredPrefixHash(msgs []provider.Message, n int) string {
 	if n <= 0 || n > len(msgs) {
 		return ""
@@ -275,11 +273,25 @@ func boundedCoveredPrefixHash(msgs []provider.Message, n int) string {
 	return providerVisibleFingerprint(provider.SanitizeToolPairing(visible))
 }
 
-// migrateBoundedCoveredPrefixHash upgrades a sidecar written before tool
-// RawContent became model-visible. Keeping this as an explicit load migration,
-// rather than a permanent validation fallback, ensures a later RawContent edit
-// invalidates the projection once the sidecar has been observed by this version.
-func migrateBoundedCoveredPrefixHash(st *CompactionState, msgs []provider.Message) bool {
+// promotedCoveredPrefixHash reproduces the temporary v3 behavior that promoted
+// full tool RawContent into every provider request.
+func promotedCoveredPrefixHash(msgs []provider.Message, n int) string {
+	if n <= 0 || n > len(msgs) {
+		return ""
+	}
+	promoted := append([]provider.Message(nil), msgs[:n]...)
+	for i := range promoted {
+		if promoted[i].Role == provider.RoleTool && promoted[i].RawContent != "" {
+			promoted[i].Content = promoted[i].RawContent
+		}
+	}
+	return providerVisibleFingerprint(provider.SanitizeToolPairing(provider.ModelMessages(promoted)))
+}
+
+// migratePromotedCoveredPrefixHash normalizes a sidecar written while full tool
+// RawContent was model-visible. Migration is exact: unrelated or stale hashes
+// are left invalid so the loader drops only their projection body.
+func migratePromotedCoveredPrefixHash(st *CompactionState, msgs []provider.Message) bool {
 	if st == nil {
 		return false
 	}
@@ -287,7 +299,7 @@ func migrateBoundedCoveredPrefixHash(st *CompactionState, msgs []provider.Messag
 	stored := st.Projection.CoveredPrefixHash
 	currentHash := coveredPrefixHash(msgs, n)
 	if stored == "" || currentHash == "" || stored == currentHash ||
-		stored != boundedCoveredPrefixHash(msgs, n) {
+		stored != promotedCoveredPrefixHash(msgs, n) {
 		return false
 	}
 	st.Projection.CoveredPrefixHash = currentHash

--- a/internal/agent/projection_raw_hash_test.go
+++ b/internal/agent/projection_raw_hash_test.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"reasonix/internal/event"
@@ -73,6 +75,162 @@ func TestLoadProjectionSidecarMigratesPromotedV3ToolHash(t *testing.T) {
 	if !projectionValid(a.sess.compactionState, mutated, a.currentPromptCacheKey()) {
 		t.Fatal("local RawContent edit invalidated a bounded provider projection")
 	}
+}
+
+func TestLoadProjectionSidecarNormalizesPromotedToolBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	const fullSentinel = "FULL-PROMOTED-RESULT-MUST-NOT-REPLAY"
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: fullSentinel},
+	}
+	legacyHash := promotedCoveredPrefixHash(msgs, len(msgs))
+	if err := SaveCompactionState(path, CompactionState{
+		SchemaVersion:  compactionStateSchemaV3,
+		PromptCacheKey: promptCacheKey("ws", BranchID(path), "model"),
+		LastReceipt: &ContextMaintenanceReceipt{
+			Status: "applied", Action: "prune", CoveredPrefixHash: legacyHash,
+		},
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				{Role: provider.RoleSystem, Content: "system"},
+				{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
+				{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: fullSentinel},
+			},
+			CoveredCount:      len(msgs),
+			CoveredPrefixHash: legacyHash,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(nil, nil, &Session{Messages: msgs}, Options{SessionPath: path, WorkspaceID: "ws", ModelRef: "model"}, event.Discard)
+	projection := a.sess.compactionState.Projection
+	if len(projection.Messages) != 3 || projection.Messages[2].Content != "bounded" {
+		t.Fatalf("loaded projection tool body = %+v, want bounded Content", projection.Messages)
+	}
+	visible := modelInputMessages(modelVisibleFromProjection(projection, msgs))
+	if encoded := projectionJSON(t, visible); strings.Contains(encoded, fullSentinel) {
+		t.Fatalf("provider-visible migrated projection retained full result: %s", encoded)
+	}
+
+	disk, ok, err := LoadCompactionState(path)
+	if err != nil || !ok {
+		t.Fatalf("load normalized sidecar: ok=%v err=%v", ok, err)
+	}
+	if len(disk.Projection.Messages) != 3 || disk.Projection.Messages[2].Content != "bounded" ||
+		disk.Projection.Messages[2].RawContent != "" || disk.Projection.Messages[2].ProviderContent != "" {
+		t.Fatalf("persisted projection tool body was not normalized: %+v", disk.Projection.Messages)
+	}
+}
+
+func TestLoadProjectionSidecarDropsUnverifiablePromotedToolBody(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: "canonical full result"},
+	}
+	legacyHash := promotedCoveredPrefixHash(msgs, len(msgs))
+	if err := SaveCompactionState(path, CompactionState{
+		PromptCacheKey: promptCacheKey("ws", BranchID(path), "model"),
+		LastReceipt:    &ContextMaintenanceReceipt{Status: "applied", Action: "prune", CoveredPrefixHash: legacyHash},
+		Projection: ContextProjection{
+			Messages: []provider.Message{
+				msgs[0],
+				{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "different unverified full result"},
+			},
+			CoveredCount: len(msgs), CoveredPrefixHash: legacyHash,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	a := New(nil, nil, &Session{Messages: msgs}, Options{SessionPath: path, WorkspaceID: "ws", ModelRef: "model"}, event.Discard)
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
+		t.Fatalf("unverifiable promoted projection survived load: %+v", a.sess.compactionState.Projection.Messages)
+	}
+	if a.sess.compactionState.LastReceipt == nil || a.sess.compactionState.LastReceipt.Action != "prune" {
+		t.Fatalf("maintenance receipt was lost: %+v", a.sess.compactionState.LastReceipt)
+	}
+	if got := a.Session().Snapshot(); !reflect.DeepEqual(got, msgs) {
+		t.Fatalf("canonical transcript changed: got=%+v want=%+v", got, msgs)
+	}
+}
+
+func TestCopyValidContextProjectionNormalizesPromotedToolBodyOrFailsClosed(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: "canonical full result"},
+	}
+	legacyHash := promotedCoveredPrefixHash(msgs, len(msgs))
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantCopied bool
+	}{
+		{name: "exact", body: msgs[1].RawContent, wantCopied: true},
+		{name: "unverifiable", body: "different full result", wantCopied: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			original := filepath.Join(dir, "original.jsonl")
+			target := filepath.Join(dir, "target.jsonl")
+			if err := SaveCompactionState(original, CompactionState{
+				Projection: ContextProjection{
+					Messages: []provider.Message{
+						msgs[0],
+						{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: tc.body},
+					},
+					CoveredCount: len(msgs), CoveredPrefixHash: legacyHash,
+				},
+				LastReceipt: &ContextMaintenanceReceipt{Status: "applied", CoveredPrefixHash: legacyHash},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			copied, err := copyValidContextProjection(original, target, msgs)
+			if err != nil || copied != tc.wantCopied {
+				t.Fatalf("copy result: copied=%v err=%v want=%v", copied, err, tc.wantCopied)
+			}
+			if !copied {
+				if _, ok, err := LoadCompactionState(target); err != nil || ok {
+					t.Fatalf("unverifiable body created target sidecar: ok=%v err=%v", ok, err)
+				}
+				return
+			}
+			disk, ok, err := LoadCompactionState(target)
+			if err != nil || !ok {
+				t.Fatalf("load copied sidecar: ok=%v err=%v", ok, err)
+			}
+			if got := disk.Projection.Messages[1]; got.Content != msgs[1].Content || got.RawContent != "" || got.ProviderContent != "" {
+				t.Fatalf("copied projection body = %+v, want bounded canonical Content", got)
+			}
+		})
+	}
+}
+
+func TestNormalizePromotedProjectionToolBodiesRejectsAmbiguousDuplicateCallID(t *testing.T) {
+	canonical := []provider.Message{
+		{Role: provider.RoleTool, ToolCallID: "repeat", Name: "read", Content: "bounded-1", RawContent: "same promoted body"},
+		{Role: provider.RoleTool, ToolCallID: "repeat", Name: "read", Content: "bounded-2", RawContent: "same promoted body"},
+	}
+	projection := []provider.Message{{
+		Role: provider.RoleTool, ToolCallID: "repeat", Name: "read", Content: "same promoted body",
+	}}
+	if normalized, ok := normalizePromotedProjectionToolBodies(projection, canonical, len(canonical)); ok || normalized != nil {
+		t.Fatalf("ambiguous duplicate was normalized: ok=%v messages=%+v", ok, normalized)
+	}
+}
+
+func projectionJSON(t *testing.T, value any) string {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func TestLoadProjectionSidecarDropsUnverifiableBodyButKeepsReceipt(t *testing.T) {

--- a/internal/agent/projection_raw_hash_test.go
+++ b/internal/agent/projection_raw_hash_test.go
@@ -2,25 +2,30 @@ package agent
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
 
-func TestCoveredPrefixHashTracksModelVisibleToolRawContent(t *testing.T) {
+func TestCoveredPrefixHashIgnoresLocalToolRawContent(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
 		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: "full result A"},
 	}
 	first := coveredPrefixHash(msgs, len(msgs))
 	msgs[1].RawContent = "full result B"
+	if second := coveredPrefixHash(msgs, len(msgs)); second != first {
+		t.Fatal("local RawContent edit changed the provider-visible covered-prefix hash")
+	}
+	msgs[1].Content = "different bounded result"
 	if second := coveredPrefixHash(msgs, len(msgs)); second == first {
-		t.Fatal("tool RawContent edit did not invalidate the covered-prefix hash")
+		t.Fatal("provider-visible Content edit did not invalidate the covered-prefix hash")
 	}
 }
 
-func TestLoadProjectionSidecarMigratesBoundedV3ToolHash(t *testing.T) {
+func TestLoadProjectionSidecarMigratesPromotedV3ToolHash(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 	msgs := []provider.Message{
@@ -29,13 +34,16 @@ func TestLoadProjectionSidecarMigratesBoundedV3ToolHash(t *testing.T) {
 		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
 		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: "full result"},
 	}
-	legacyHash := boundedCoveredPrefixHash(msgs, len(msgs))
+	legacyHash := promotedCoveredPrefixHash(msgs, len(msgs))
 	if legacyHash == coveredPrefixHash(msgs, len(msgs)) {
-		t.Fatal("fixture does not distinguish bounded and model-visible hashes")
+		t.Fatal("fixture does not distinguish promoted and bounded hashes")
 	}
 	if err := SaveCompactionState(path, CompactionState{
 		SchemaVersion:  compactionStateSchemaV3,
 		PromptCacheKey: promptCacheKey("ws", BranchID(path), "model"),
+		LastReceipt: &ContextMaintenanceReceipt{
+			Status: "applied", Action: "prune", CoveredPrefixHash: legacyHash,
+		},
 		Projection: ContextProjection{
 			Messages:          []provider.Message{{Role: provider.RoleSystem, Content: "system"}, formatSummaryMessage("summary")},
 			CoveredCount:      len(msgs),
@@ -57,9 +65,39 @@ func TestLoadProjectionSidecarMigratesBoundedV3ToolHash(t *testing.T) {
 	if got := disk.Projection.CoveredPrefixHash; got != want {
 		t.Fatalf("persisted hash = %q, want %q", got, want)
 	}
+	if disk.LastReceipt == nil || disk.LastReceipt.CoveredPrefixHash != want {
+		t.Fatalf("receipt hash was not normalized: %+v", disk.LastReceipt)
+	}
 	mutated := append([]provider.Message(nil), msgs...)
 	mutated[len(mutated)-1].RawContent = "changed after migration"
-	if projectionValid(a.sess.compactionState, mutated, a.currentPromptCacheKey()) {
-		t.Fatal("migrated projection accepted changed RawContent")
+	if !projectionValid(a.sess.compactionState, mutated, a.currentPromptCacheKey()) {
+		t.Fatal("local RawContent edit invalidated a bounded provider projection")
+	}
+}
+
+func TestLoadProjectionSidecarDropsUnverifiableBodyButKeepsReceipt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	msgs := []provider.Message{{Role: provider.RoleSystem, Content: "system"}, {Role: provider.RoleUser, Content: "task"}}
+	if err := SaveCompactionState(path, CompactionState{
+		SchemaVersion:  compactionStateSchemaV3,
+		PromptCacheKey: promptCacheKey("ws", BranchID(path), "model"),
+		Projection: ContextProjection{
+			Messages:     []provider.Message{{Role: provider.RoleSystem, Content: "system"}, formatSummaryMessage("summary")},
+			CoveredCount: len(msgs), CoveredPrefixHash: "unrelated-stale-hash",
+		},
+		LastReceipt: &ContextMaintenanceReceipt{Status: "applied", Action: "summary", CoveredPrefixHash: "unrelated-stale-hash"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	a := New(nil, nil, &Session{Messages: msgs}, Options{SessionPath: path, WorkspaceID: "ws", ModelRef: "model"}, event.Discard)
+	if len(a.sess.compactionState.Projection.Messages) != 0 {
+		t.Fatal("unverifiable projection body survived load")
+	}
+	if a.sess.compactionState.LastReceipt == nil || a.sess.compactionState.LastReceipt.Action != "summary" {
+		t.Fatalf("maintenance receipt was lost: %+v", a.sess.compactionState.LastReceipt)
+	}
+	if got := a.Session().Snapshot(); !reflect.DeepEqual(got, msgs) {
+		t.Fatalf("canonical transcript changed: got=%+v want=%+v", got, msgs)
 	}
 }

--- a/internal/agent/provider_boundary_regression_test.go
+++ b/internal/agent/provider_boundary_regression_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestNormalizeModelRequestMessagesDoesNotMutateInput(t *testing.T) {
+	const createdAt = int64(99)
+	const storedContent = "task\n<execution-policy>local policy</execution-policy>"
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleUser, Content: storedContent, CreatedAt: createdAt},
+	}
+	wantStored := append([]provider.Message(nil), msgs...)
+	a := New(nil, tool.NewRegistry(), NewSession("system"), Options{}, event.Discard)
+
+	got := a.normalizeModelRequestMessages(msgs)
+	if got[1].CreatedAt != 0 || got[1].Content != "task" {
+		t.Fatalf("provider message = %+v, want stripped local metadata", got[1])
+	}
+	if !reflect.DeepEqual(msgs, wantStored) {
+		t.Fatalf("normalization mutated its input: got=%+v want=%+v", msgs, wantStored)
+	}
+}
+
+func TestPressurePruneNeverPromotesRawToolContent(t *testing.T) {
+	const rawOnlySentinel = "RAW-ONLY-PRESSURE-SENTINEL"
+	bounded := strings.Repeat("b", toolPruneThresholdRunes+1)
+	raw := strings.Repeat("r", 100) + rawOnlySentinel + strings.Repeat("r", toolPruneThresholdRunes+1)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read_file", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read_file", Content: bounded, RawContent: raw},
+	}}
+	a := New(nil, tool.NewRegistry(), sess, Options{}, event.Discard)
+
+	a.sess.compactionRunMu.Lock()
+	advanced, err := a.pruneToolResultsToProjectionLocked(CompactionTriggerPressure)
+	a.sess.compactionRunMu.Unlock()
+	if err != nil || !advanced {
+		t.Fatalf("pressure prune advanced=%v err=%v", advanced, err)
+	}
+	visible := modelInputMessages(a.modelVisibleMessages())
+	if strings.Contains(joinContents(visible), rawOnlySentinel) {
+		t.Fatal("pressure projection promoted local RawContent")
+	}
+	if got := visible[len(visible)-1]; !strings.Contains(got.Content, toolPruneMarker) || got.RawContent != "" {
+		t.Fatalf("provider tool result = %+v, want pruned bounded Content without RawContent", got)
+	}
+	stored := sess.Snapshot()[2]
+	if stored.Content != bounded || stored.RawContent != raw {
+		t.Fatal("pressure prune modified canonical tool content")
+	}
+}

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -80,9 +80,6 @@ func (a *Agent) pruneToolResultsToProjectionLocked(trigger string) (bool, error)
 			continue
 		}
 		source := projected[i].Content
-		if projected[i].RawContent != "" {
-			source = projected[i].RawContent
-		}
 		if projected[i].ProviderContent != "" {
 			source = projected[i].ProviderContent
 		}

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -48,7 +48,7 @@ func TestPruneAndSnipAreNoOps(t *testing.T) {
 	}
 }
 
-func TestBelowThresholdSamplingPromotesFullToolRawContentWithoutProjection(t *testing.T) {
+func TestBelowThresholdSamplingKeepsBoundedToolContentWithoutProjection(t *testing.T) {
 	full := strings.Repeat("完整结果", 10_000)
 	bounded := "legacy bounded result"
 	sess := &Session{Messages: []provider.Message{
@@ -62,8 +62,8 @@ func TestBelowThresholdSamplingPromotesFullToolRawContentWithoutProjection(t *te
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := req.req.Messages[3].Content; got != full {
-		t.Fatalf("provider tool result runes=%d, want full %d", len([]rune(got)), len([]rune(full)))
+	if got := req.req.Messages[3].Content; got != bounded {
+		t.Fatalf("provider tool result = %q, want bounded content", got)
 	}
 	if a.currentProjectionVersion() != 0 {
 		t.Fatalf("below-threshold request installed projection version %d", a.currentProjectionVersion())
@@ -218,7 +218,7 @@ func TestSnipStrategyStillBuildsBoundedCompatibilityContent(t *testing.T) {
 	}
 }
 
-func TestModelInputMessagesPromotesOnlyToolRawContent(t *testing.T) {
+func TestModelInputMessagesKeepsBoundedToolContent(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "display user", RawContent: "raw user"},
 		{Role: provider.RoleTool, Content: "bounded", RawContent: "complete tool result", ToolCallID: "call-1"},
@@ -228,8 +228,8 @@ func TestModelInputMessagesPromotesOnlyToolRawContent(t *testing.T) {
 	if got[0].Content != "display user" {
 		t.Fatalf("user content = %q, want display form", got[0].Content)
 	}
-	if got[1].Content != "complete tool result" {
-		t.Fatalf("tool content = %q, want promoted RawContent", got[1].Content)
+	if got[1].Content != "bounded" {
+		t.Fatalf("tool content = %q, want bounded Content", got[1].Content)
 	}
 	if got[1].RawContent != "" {
 		t.Fatalf("provider-bound RawContent = %q, want empty", got[1].RawContent)

--- a/internal/agent/run_loop.go
+++ b/internal/agent/run_loop.go
@@ -647,8 +647,8 @@ func (a *Agent) handleToolRound(ctx context.Context, state *turnRuntime, step in
 			ToolCallID: call.ID,
 			Name:       call.Name,
 		}
-		// Content is the old-reader-safe bounded form. Full originals ride on
-		// RawContent and are promoted only on the new provider request copy.
+		// Content is the stable bounded provider form. Full originals remain in
+		// local RawContent and enter model context only through explicit paging.
 		if i < len(batch.outcomes) && batch.outcomes[i].rawOutput != "" && batch.outcomes[i].rawOutput != results[i] {
 			msg.RawContent = batch.outcomes[i].rawOutput
 		}

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -27,6 +27,9 @@ func modelInputMessages(msgs []provider.Message) []provider.Message {
 // cleanup. Interceptors deliberately remain outside this helper.
 func (a *Agent) normalizeModelRequestMessages(msgs []provider.Message) []provider.Message {
 	requestMessages := a.providerProjectionMessages(modelInputMessages(msgs))
+	// ModelMessages intentionally has a zero-copy fast path for clean input.
+	// Detach before removing local metadata from the request-only representation.
+	requestMessages = append([]provider.Message(nil), requestMessages...)
 	for i := range requestMessages {
 		requestMessages[i].CreatedAt = 0
 		if requestMessages[i].Role == provider.RoleUser {

--- a/internal/agent/sampling_request.go
+++ b/internal/agent/sampling_request.go
@@ -15,22 +15,11 @@ type samplingRequest struct {
 	req provider.Request
 }
 
-// modelInputMessages derives provider-visible messages from durable storage.
-// Tool RawContent is the canonical full result while Content remains bounded
-// for readers from older Reasonix versions. Only the transport copy promotes
-// that full tool body; other RawContent fields keep their existing semantics.
+// modelInputMessages derives the stable provider-visible view from durable
+// storage. Tool Content is the first-visible bounded result; RawContent stays
+// local and is available only through the explicit session result reader.
 func modelInputMessages(msgs []provider.Message) []provider.Message {
-	return provider.ModelMessages(promoteToolRawContent(msgs))
-}
-
-func promoteToolRawContent(msgs []provider.Message) []provider.Message {
-	prepared := append([]provider.Message(nil), msgs...)
-	for i := range prepared {
-		if prepared[i].Role == provider.RoleTool && prepared[i].RawContent != "" {
-			prepared[i].Content = prepared[i].RawContent
-		}
-	}
-	return prepared
+	return provider.ModelMessages(msgs)
 }
 
 // normalizeModelRequestMessages is shared by ordinary sampling and compaction

--- a/internal/agent/save_recovery_helpers.go
+++ b/internal/agent/save_recovery_helpers.go
@@ -110,7 +110,7 @@ func copyValidContextProjection(originalPath, targetPath string, msgs []provider
 	if !ok {
 		return false, nil
 	}
-	migrateBoundedCoveredPrefixHash(&st, msgs)
+	migratePromotedCoveredPrefixHash(&st, msgs)
 	n := st.Projection.CoveredCount
 	if len(st.Projection.Messages) == 0 || n <= 0 || n > len(msgs) ||
 		st.Projection.CoveredPrefixHash == "" ||

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -61,6 +61,33 @@ func TestSaveLoadPreservesLegacyContentAndRawUserContent(t *testing.T) {
 	}
 }
 
+func TestSaveLoadPreservesBoundedToolContentAndCompleteRawContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	full := strings.Repeat("完整工具结果-🧪", 6000)
+	bounded, notice := truncateToolOutputFor(full, "read_file", "call-save")
+	if notice == "" {
+		t.Fatal("fixture did not produce a bounded tool result")
+	}
+	s := NewSession("system")
+	s.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-save", Name: "read_file", Arguments: `{}`}}})
+	s.Add(provider.Message{Role: provider.RoleTool, Name: "read_file", ToolCallID: "call-save", Content: bounded, RawContent: full})
+	if err := s.SaveSnapshot(path); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := loaded.Snapshot()[2]
+	if stored.Content != bounded || stored.RawContent != full {
+		t.Fatalf("tool result changed across save/load: content=%d raw=%d", len(stored.Content), len(stored.RawContent))
+	}
+	model := provider.ModelMessages(loaded.Snapshot())
+	if model[2].Content != bounded || model[2].RawContent != "" {
+		t.Fatalf("provider projection after resume is not bounded: content=%d raw=%d", len(model[2].Content), len(model[2].RawContent))
+	}
+}
+
 func TestLoadSessionMigratesLegacyInjectedUserContentWithoutChangingProviderBytes(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	const raw = "fix the bug"

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -1152,12 +1152,6 @@ func (t *restrictedCapabilityProxy) Description() string {
 	return t.Tool.Description()
 }
 
-func (t *restrictedCapabilityProxy) bindToolResultSession(session func() *Session) {
-	if binder, ok := t.Tool.(toolResultSessionBinder); ok {
-		binder.bindToolResultSession(session)
-	}
-}
-
 func (t *restrictedCapabilityProxy) check(args json.RawMessage) error {
 	var p struct {
 		Action       string `json:"action"`
@@ -1216,67 +1210,6 @@ func (t *restrictedCapabilityProxy) Execute(ctx context.Context, args json.RawMe
 		return filterCapabilityListResult(out, t.servers), nil
 	}
 	return out, nil
-}
-
-// emptyCapabilityListResult is the fail-closed list payload: no server metadata.
-func emptyCapabilityListResult(note string) string {
-	if strings.TrimSpace(note) == "" {
-		note = "list is filtered to this subagent's allowed MCP servers."
-	}
-	b, err := json.MarshalIndent(map[string]any{
-		"capabilities": []any{},
-		"servers":      []listServerInfo{},
-		"note":         note,
-	}, "", "  ")
-	if err != nil {
-		return `{"servers":[],"note":"list is filtered to this subagent's allowed MCP servers."}`
-	}
-	return string(b)
-}
-
-// filterCapabilityListResult keeps only servers in the allowlist for restricted
-// proxies. Empty allowlist or unreadable payloads fail closed (empty server
-// list) so discovery never leaks the full configured MCP inventory.
-func filterCapabilityListResult(raw string, servers map[string]bool) string {
-	const baseNote = "list is filtered to this subagent's allowed MCP servers."
-	if len(servers) == 0 {
-		return emptyCapabilityListResult(baseNote + " No allowed MCP servers were resolved from the profile allowlist.")
-	}
-	var payload struct {
-		Capabilities []json.RawMessage `json:"capabilities"`
-		Servers      []listServerInfo  `json:"servers"`
-		Note         string            `json:"note"`
-	}
-	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
-		return emptyCapabilityListResult(baseNote + " List payload was unreadable; returning no servers (fail-closed).")
-	}
-	filtered := make([]listServerInfo, 0, len(payload.Servers))
-	for _, s := range payload.Servers {
-		if servers[strings.TrimSpace(s.Name)] {
-			filtered = append(filtered, s)
-		}
-	}
-	payload.Servers = filtered
-	filteredCapabilities := make([]json.RawMessage, 0, 1)
-	for _, raw := range payload.Capabilities {
-		var entry struct {
-			ID string `json:"id"`
-		}
-		if json.Unmarshal(raw, &entry) == nil && strings.TrimSpace(entry.ID) == sessionToolResultCapabilityID {
-			filteredCapabilities = append(filteredCapabilities, raw)
-		}
-	}
-	payload.Capabilities = filteredCapabilities
-	if payload.Note == "" {
-		payload.Note = baseNote
-	} else if !strings.Contains(payload.Note, "Filtered to this subagent") {
-		payload.Note = payload.Note + " Filtered to this subagent's allowed MCP servers."
-	}
-	b, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		return emptyCapabilityListResult(baseNote + " Failed to encode filtered list (fail-closed).")
-	}
-	return string(b)
 }
 
 // validMCPServerCapabilityID accepts mcp-server:<non-empty-name> only.

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -1305,10 +1305,7 @@ func newSubagentCapabilityFrontend(parent *tool.Registry, runtime *MCPCapability
 	if !ok {
 		return nil
 	}
-	if uc, ok := inner.(*UseCapabilityTool); ok {
-		return uc.CloneForAgent(nil, nil)
-	}
-	return inner
+	return cloneCapabilityFrontend(inner)
 }
 
 // mcpCapabilityAllowlist converts profile/call tool names into capability IDs

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -1152,6 +1152,12 @@ func (t *restrictedCapabilityProxy) Description() string {
 	return t.Tool.Description()
 }
 
+func (t *restrictedCapabilityProxy) bindToolResultSession(session func() *Session) {
+	if binder, ok := t.Tool.(toolResultSessionBinder); ok {
+		binder.bindToolResultSession(session)
+	}
+}
+
 func (t *restrictedCapabilityProxy) check(args json.RawMessage) error {
 	var p struct {
 		Action       string `json:"action"`
@@ -1166,6 +1172,9 @@ func (t *restrictedCapabilityProxy) check(args json.RawMessage) error {
 	id := strings.TrimSpace(p.CapabilityID)
 	if id == "" {
 		return fmt.Errorf("capability_id is required")
+	}
+	if id == sessionToolResultCapabilityID {
+		return nil
 	}
 	if !t.allowed[id] {
 		return fmt.Errorf("capability %q is outside this subagent's allowed-tools", id)
@@ -1215,8 +1224,9 @@ func emptyCapabilityListResult(note string) string {
 		note = "list is filtered to this subagent's allowed MCP servers."
 	}
 	b, err := json.MarshalIndent(map[string]any{
-		"servers": []listServerInfo{},
-		"note":    note,
+		"capabilities": []any{},
+		"servers":      []listServerInfo{},
+		"note":         note,
 	}, "", "  ")
 	if err != nil {
 		return `{"servers":[],"note":"list is filtered to this subagent's allowed MCP servers."}`
@@ -1233,8 +1243,9 @@ func filterCapabilityListResult(raw string, servers map[string]bool) string {
 		return emptyCapabilityListResult(baseNote + " No allowed MCP servers were resolved from the profile allowlist.")
 	}
 	var payload struct {
-		Servers []listServerInfo `json:"servers"`
-		Note    string           `json:"note"`
+		Capabilities []json.RawMessage `json:"capabilities"`
+		Servers      []listServerInfo  `json:"servers"`
+		Note         string            `json:"note"`
 	}
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
 		return emptyCapabilityListResult(baseNote + " List payload was unreadable; returning no servers (fail-closed).")
@@ -1246,6 +1257,16 @@ func filterCapabilityListResult(raw string, servers map[string]bool) string {
 		}
 	}
 	payload.Servers = filtered
+	filteredCapabilities := make([]json.RawMessage, 0, 1)
+	for _, raw := range payload.Capabilities {
+		var entry struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(raw, &entry) == nil && strings.TrimSpace(entry.ID) == sessionToolResultCapabilityID {
+			filteredCapabilities = append(filteredCapabilities, raw)
+		}
+	}
+	payload.Capabilities = filteredCapabilities
 	if payload.Note == "" {
 		payload.Note = baseNote
 	} else if !strings.Contains(payload.Note, "Filtered to this subagent") {

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -166,8 +167,7 @@ func (t *sessionToolResultTool) Execute(_ context.Context, args json.RawMessage)
 
 func findToolResultCandidate(msgs []provider.Message, toolCallID, resultRef string) (toolResultCandidate, error) {
 	candidates := make([]toolResultCandidate, 0, 2)
-	for i := len(msgs) - 1; i >= 0; i-- {
-		msg := msgs[i]
+	for _, msg := range slices.Backward(msgs) {
 		if msg.Role != provider.RoleTool || msg.ToolCallID != toolCallID {
 			continue
 		}
@@ -225,7 +225,7 @@ func toolResultRefFromMarker(content string) (string, bool) {
 	if end := strings.Index(marker, "]…"); end >= 0 {
 		marker = marker[:end]
 	}
-	for _, field := range strings.Fields(marker) {
+	for field := range strings.FieldsSeq(marker) {
 		ref, ok := strings.CutPrefix(field, "result_ref=")
 		if !ok || len(ref) != len("tr-")+24 || !strings.HasPrefix(ref, "tr-") {
 			continue

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -178,9 +178,15 @@ func findToolResultCandidate(msgs []provider.Message, toolCallID, resultRef stri
 			recoverable = !looksLikeTruncatedToolResult(msg.Content)
 		}
 		ref := toolResultRef(toolCallID, body)
+		requiresRef := strings.Contains(msg.Content, "…[truncated tool=") && strings.Contains(msg.Content, " result_ref=")
+		if !recoverable && requiresRef {
+			if markerRef, ok := toolResultRefFromMarker(msg.Content); ok {
+				ref = markerRef
+			}
+		}
 		candidate := toolResultCandidate{
 			name: msg.Name, body: body, resultRef: ref, recoverable: recoverable,
-			requiresRef: strings.Contains(msg.Content, "…[truncated tool=") && strings.Contains(msg.Content, " result_ref="),
+			requiresRef: requiresRef,
 		}
 		if resultRef != "" {
 			if ref == resultRef {
@@ -207,6 +213,28 @@ func findToolResultCandidate(msgs []provider.Message, toolCallID, resultRef stri
 		refs = append(refs, candidate.resultRef)
 	}
 	return toolResultCandidate{}, fmt.Errorf("session tool result: tool_call_id %q is ambiguous; retry with one of result_ref=%s", toolCallID, strings.Join(refs, ","))
+}
+
+func toolResultRefFromMarker(content string) (string, bool) {
+	const markerStart = "…[truncated tool="
+	start := strings.Index(content, markerStart)
+	if start < 0 {
+		return "", false
+	}
+	marker := content[start:]
+	if end := strings.Index(marker, "]…"); end >= 0 {
+		marker = marker[:end]
+	}
+	for _, field := range strings.Fields(marker) {
+		ref, ok := strings.CutPrefix(field, "result_ref=")
+		if !ok || len(ref) != len("tr-")+24 || !strings.HasPrefix(ref, "tr-") {
+			continue
+		}
+		if decoded, err := hex.DecodeString(strings.TrimPrefix(ref, "tr-")); err == nil && len(decoded) == 12 {
+			return ref, true
+		}
+	}
+	return "", false
 }
 
 func looksLikeTruncatedToolResult(content string) bool {

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -63,6 +63,42 @@ type toolResultCandidate struct {
 	requiresRef bool
 }
 
+func toolResultRef(toolCallID, body string) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(toolCallID))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(body))
+	return fmt.Sprintf("tr-%x", h.Sum(nil)[:12])
+}
+
+func toolOutputRecoveryMarker(toolName, toolCallID, resultRef string, originalBytes, keptBytes int) string {
+	namePart := boundedMarkerField(toolName, 128, "tool")
+	idPart := boundedMarkerField(toolCallID, 128, "-")
+	exampleID := toolCallID
+	if len(exampleID) > 256 {
+		exampleID = "<full tool_call_id from this tool result>"
+	}
+	args, _ := json.Marshal(struct {
+		ToolCallID string `json:"tool_call_id"`
+		ResultRef  string `json:"result_ref"`
+		Offset     int    `json:"offset"`
+	}{ToolCallID: exampleID, ResultRef: resultRef})
+	return fmt.Sprintf(
+		"\n\n…[truncated tool=%s call_id=%s result_ref=%s original_bytes=%d kept_bytes=%d — full original retained locally; recover with use_capability(action=\"call\", capability_id=\"session:tool_result\", arguments=%s). If use_capability is unavailable, re-run the original tool with narrower arguments]…\n\n",
+		namePart, idPart, resultRef, originalBytes, keptBytes, args,
+	)
+}
+
+func boundedMarkerField(value string, maxBytes int, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	return snapToRuneBoundary(value, 0, maxBytes) + "…"
+}
+
 func (t *sessionToolResultTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
 	var p toolResultReadParams
 	if err := json.Unmarshal(args, &p); err != nil {

--- a/internal/agent/tool_result_capability.go
+++ b/internal/agent/tool_result_capability.go
@@ -1,0 +1,247 @@
+package agent
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+const (
+	sessionToolResultCapabilityID = "session:tool_result"
+	toolResultPageDefaultBytes    = 16 * 1024
+	toolResultPageMaxBytes        = 24 * 1024
+)
+
+type toolResultSessionBinder interface {
+	bindToolResultSession(func() *Session)
+}
+
+type sessionToolResultTool struct {
+	session func() *Session
+}
+
+func (*sessionToolResultTool) Name() string { return "session_tool_result" }
+
+func (*sessionToolResultTool) Description() string {
+	return "Read one bounded UTF-8 page from a complete tool result retained in the current agent session."
+}
+
+func (*sessionToolResultTool) ReadOnly() bool { return true }
+
+func (*sessionToolResultTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"tool_call_id":{"type":"string"},
+			"result_ref":{"type":"string"},
+			"offset":{"type":"integer","minimum":0},
+			"limit":{"type":"integer","minimum":1,"maximum":24576}
+		},
+		"required":["tool_call_id"]
+	}`)
+}
+
+type toolResultReadParams struct {
+	ToolCallID string `json:"tool_call_id"`
+	ResultRef  string `json:"result_ref"`
+	Offset     int    `json:"offset"`
+	Limit      int    `json:"limit"`
+}
+
+type toolResultCandidate struct {
+	name        string
+	body        string
+	resultRef   string
+	recoverable bool
+	requiresRef bool
+}
+
+func (t *sessionToolResultTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var p toolResultReadParams
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("session tool result: invalid args: %w", err)
+	}
+	p.ToolCallID = strings.TrimSpace(p.ToolCallID)
+	p.ResultRef = strings.TrimSpace(p.ResultRef)
+	if p.ToolCallID == "" {
+		return "", fmt.Errorf("session tool result: tool_call_id is required")
+	}
+	if p.Offset < 0 {
+		return "", fmt.Errorf("session tool result: offset must be non-negative")
+	}
+	if p.Limit == 0 {
+		p.Limit = toolResultPageDefaultBytes
+	}
+	if p.Limit < 1 || p.Limit > toolResultPageMaxBytes {
+		return "", fmt.Errorf("session tool result: limit must be between 1 and %d bytes", toolResultPageMaxBytes)
+	}
+	if t == nil || t.session == nil {
+		return "", fmt.Errorf("session tool result: current session is unavailable")
+	}
+	session := t.session()
+	if session == nil {
+		return "", fmt.Errorf("session tool result: current session is unavailable")
+	}
+	candidate, err := findToolResultCandidate(session.Snapshot(), p.ToolCallID, p.ResultRef)
+	if err != nil {
+		return "", err
+	}
+	if !candidate.recoverable {
+		return "", fmt.Errorf("session tool result: full result is unavailable for this legacy truncated record; re-run %s with narrower arguments", candidate.name)
+	}
+	if !utf8.ValidString(candidate.body) {
+		return "", fmt.Errorf("session tool result: retained result is not valid UTF-8")
+	}
+	if p.Offset > len(candidate.body) {
+		return "", fmt.Errorf("session tool result: offset %d exceeds total_bytes %d", p.Offset, len(candidate.body))
+	}
+	if p.Offset < len(candidate.body) && !utf8.RuneStart(candidate.body[p.Offset]) {
+		return "", fmt.Errorf("session tool result: offset %d is not a UTF-8 character boundary", p.Offset)
+	}
+
+	end := min(len(candidate.body), p.Offset+p.Limit)
+	for end > p.Offset && end < len(candidate.body) && !utf8.RuneStart(candidate.body[end]) {
+		end--
+	}
+	if end == p.Offset && end < len(candidate.body) {
+		return "", fmt.Errorf("session tool result: limit %d ends inside the next UTF-8 character; increase limit", p.Limit)
+	}
+	digest := sha256.Sum256([]byte(candidate.body))
+	header, _ := json.Marshal(struct {
+		ResultRef  string `json:"result_ref"`
+		Offset     int    `json:"offset"`
+		NextOffset int    `json:"next_offset"`
+		TotalBytes int    `json:"total_bytes"`
+		SHA256     string `json:"sha256"`
+		Complete   bool   `json:"complete"`
+	}{
+		ResultRef: candidate.resultRef, Offset: p.Offset, NextOffset: end,
+		TotalBytes: len(candidate.body), SHA256: hex.EncodeToString(digest[:]), Complete: end == len(candidate.body),
+	})
+	return string(header) + "\n" + candidate.body[p.Offset:end], nil
+}
+
+func findToolResultCandidate(msgs []provider.Message, toolCallID, resultRef string) (toolResultCandidate, error) {
+	candidates := make([]toolResultCandidate, 0, 2)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		msg := msgs[i]
+		if msg.Role != provider.RoleTool || msg.ToolCallID != toolCallID {
+			continue
+		}
+		body := msg.RawContent
+		recoverable := body != ""
+		if body == "" {
+			body = msg.Content
+			recoverable = !looksLikeTruncatedToolResult(msg.Content)
+		}
+		ref := toolResultRef(toolCallID, body)
+		candidate := toolResultCandidate{
+			name: msg.Name, body: body, resultRef: ref, recoverable: recoverable,
+			requiresRef: strings.Contains(msg.Content, "…[truncated tool=") && strings.Contains(msg.Content, " result_ref="),
+		}
+		if resultRef != "" {
+			if ref == resultRef {
+				return candidate, nil
+			}
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	if resultRef != "" {
+		return toolResultCandidate{}, fmt.Errorf("session tool result: result_ref %q was not found for tool_call_id %q", resultRef, toolCallID)
+	}
+	if len(candidates) == 0 {
+		return toolResultCandidate{}, fmt.Errorf("session tool result: tool_call_id %q was not found in the current session", toolCallID)
+	}
+	if len(candidates) == 1 {
+		if candidates[0].requiresRef {
+			return toolResultCandidate{}, fmt.Errorf("session tool result: result_ref is required for this truncated result; use result_ref=%s from its marker", candidates[0].resultRef)
+		}
+		return candidates[0], nil
+	}
+	refs := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		refs = append(refs, candidate.resultRef)
+	}
+	return toolResultCandidate{}, fmt.Errorf("session tool result: tool_call_id %q is ambiguous; retry with one of result_ref=%s", toolCallID, strings.Join(refs, ","))
+}
+
+func looksLikeTruncatedToolResult(content string) bool {
+	return strings.Contains(content, "…[truncated tool=") ||
+		strings.Contains(content, snippedMarker) ||
+		strings.Contains(content, prunedMarker) ||
+		strings.Contains(content, toolPruneMarker)
+}
+
+func (a *Agent) bindToolResultSessionCapability() {
+	if a == nil || a.svc.tools == nil {
+		return
+	}
+	proxy, ok := a.svc.tools.Get("use_capability")
+	if !ok {
+		return
+	}
+	binder, ok := proxy.(toolResultSessionBinder)
+	if !ok {
+		return
+	}
+	binder.bindToolResultSession(func() *Session { return a.Session() })
+}
+
+func (t *UseCapabilityTool) bindToolResultSession(session func() *Session) {
+	if t == nil {
+		return
+	}
+	t.toolResultMu.Lock()
+	t.toolResultSession = session
+	t.toolResultMu.Unlock()
+}
+
+func (t *UseCapabilityTool) currentToolResultTarget() tool.Tool {
+	if t == nil {
+		return nil
+	}
+	t.toolResultMu.RLock()
+	session := t.toolResultSession
+	t.toolResultMu.RUnlock()
+	if session == nil {
+		return nil
+	}
+	return &sessionToolResultTool{session: session}
+}
+
+func (t *UseCapabilityTool) resolveSessionToolResult(args json.RawMessage, base tool.ResolvedCall) (tool.ResolvedCall, error) {
+	target := t.currentToolResultTarget()
+	if target == nil {
+		return tool.ResolvedCall{}, fmt.Errorf("capability %q is unavailable without a current agent session", sessionToolResultCapabilityID)
+	}
+	base.TargetName = target.Name()
+	base.Target = target
+	base.Args = args
+	base.ReadOnly = true
+	return base, nil
+}
+
+func (t *UseCapabilityTool) inspectSessionToolResult() (string, error) {
+	if t.currentToolResultTarget() == nil {
+		return "", fmt.Errorf("capability %q is unavailable without a current agent session", sessionToolResultCapabilityID)
+	}
+	payload := map[string]any{
+		"id": sessionToolResultCapabilityID, "kind": "session", "name": "tool_result",
+		"description": "Read one bounded page from a complete tool result retained in this agent's current session.",
+		"status":      "ready", "read_only": true,
+		"arguments": map[string]any{
+			"tool_call_id": "required", "result_ref": "required for new truncated results; optional for unambiguous legacy records",
+			"offset": 0, "limit_default": toolResultPageDefaultBytes, "limit_max": toolResultPageMaxBytes,
+		},
+	}
+	b, err := json.MarshalIndent(payload, "", "  ")
+	return string(b), err
+}

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -25,7 +25,7 @@ type toolResultPageHeader struct {
 	Complete   bool   `json:"complete"`
 }
 
-func executeToolResultPage(t *testing.T, proxy *UseCapabilityTool, callID, ref string, offset, limit int) (toolResultPageHeader, string, error) {
+func executeToolResultPage(t *testing.T, proxy tool.Tool, callID, ref string, offset, limit int) (toolResultPageHeader, string, error) {
 	t.Helper()
 	args, _ := json.Marshal(map[string]any{
 		"action": "call", "capability_id": sessionToolResultCapabilityID,
@@ -276,6 +276,90 @@ func TestRestrictedCapabilityProxyListsAndReadsOnlyOwnToolResults(t *testing.T) 
 	out, err := proxy.Execute(context.Background(), args)
 	if err != nil || !strings.HasSuffix(out, "\nown result") {
 		t.Fatalf("restricted self read: err=%v out=%q", err, out)
+	}
+}
+
+func TestRestrictedCapabilityFrontendCloneKeepsAgentSessionsIsolated(t *testing.T) {
+	parentInner := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), nil, nil, nil)
+	parentProxy := &restrictedCapabilityProxy{
+		Tool: parentInner, resolver: parentInner,
+		allowed: map[string]bool{"mcp-server:allowed": true}, servers: map[string]bool{"allowed": true},
+	}
+	parentRegistry := tool.NewRegistry()
+	parentRegistry.Add(parentProxy)
+	_ = New(nil, parentRegistry, &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "parent",
+	}}}, Options{}, event.Discard)
+
+	childTool := newSubagentCapabilityFrontend(parentRegistry, nil)
+	childProxy, ok := childTool.(*restrictedCapabilityProxy)
+	if !ok {
+		t.Fatalf("child frontend type = %T, want *restrictedCapabilityProxy", childTool)
+	}
+	if childProxy == parentProxy || childProxy.Tool == parentProxy.Tool {
+		t.Fatal("child restricted frontend shares the parent's session-bindable proxy")
+	}
+	childRegistry := tool.NewRegistry()
+	childRegistry.Add(childProxy)
+	_ = New(nil, childRegistry, &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "child",
+	}}}, Options{}, event.Discard)
+
+	_, parentPage, parentErr := executeToolResultPage(t, parentProxy, "call", "", 0, 32)
+	_, childPage, childErr := executeToolResultPage(t, childProxy, "call", "", 0, 32)
+	if parentErr != nil || parentPage != "parent" {
+		t.Fatalf("parent page=%q err=%v", parentPage, parentErr)
+	}
+	if childErr != nil || childPage != "child" {
+		t.Fatalf("child page=%q err=%v", childPage, childErr)
+	}
+	childProxy.allowed["mcp-server:child-only"] = true
+	if parentProxy.allowed["mcp-server:child-only"] {
+		t.Fatal("child clone shares the parent's mutable capability allowlist")
+	}
+	beforeRegistry := tool.NewRegistry()
+	beforeRegistry.Add(parentProxy)
+	afterRegistry := tool.NewRegistry()
+	afterRegistry.Add(childProxy)
+	if parentProxy.Name() != childProxy.Name() || parentProxy.Description() != childProxy.Description() ||
+		!reflect.DeepEqual(parentProxy.Schema(), childProxy.Schema()) ||
+		!reflect.DeepEqual(beforeRegistry.Schemas(), afterRegistry.Schemas()) {
+		t.Fatal("cloning or binding changed provider-visible use_capability bytes")
+	}
+}
+
+func TestPlannerRestrictedCapabilityFrontendCloneKeepsExecutorSession(t *testing.T) {
+	inner := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), nil, nil, nil)
+	executorProxy := &restrictedCapabilityProxy{
+		Tool: inner, resolver: inner,
+		allowed: map[string]bool{"mcp-server:allowed": true}, servers: map[string]bool{"allowed": true},
+	}
+	parent := tool.NewRegistry()
+	parent.Add(executorProxy)
+	_ = New(nil, parent, &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "executor",
+	}}}, Options{}, event.Discard)
+
+	plannerRegistry := PlannerToolRegistry(parent)
+	plannerTool, ok := plannerRegistry.Get("use_capability")
+	if !ok {
+		t.Fatal("planner missing use_capability")
+	}
+	plannerProxy, ok := plannerTool.(*restrictedCapabilityProxy)
+	if !ok || plannerProxy == executorProxy || plannerProxy.Tool == executorProxy.Tool {
+		t.Fatalf("planner frontend was not deeply cloned: %T", plannerTool)
+	}
+	_ = New(nil, plannerRegistry, &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "planner",
+	}}}, Options{}, event.Discard)
+
+	_, executorPage, executorErr := executeToolResultPage(t, executorProxy, "call", "", 0, 32)
+	_, plannerPage, plannerErr := executeToolResultPage(t, plannerProxy, "call", "", 0, 32)
+	if executorErr != nil || executorPage != "executor" {
+		t.Fatalf("executor page=%q err=%v", executorPage, executorErr)
+	}
+	if plannerErr != nil || plannerPage != "planner" {
+		t.Fatalf("planner page=%q err=%v", plannerPage, plannerErr)
 	}
 }
 

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -1,0 +1,321 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type toolResultPageHeader struct {
+	ResultRef  string `json:"result_ref"`
+	Offset     int    `json:"offset"`
+	NextOffset int    `json:"next_offset"`
+	TotalBytes int    `json:"total_bytes"`
+	SHA256     string `json:"sha256"`
+	Complete   bool   `json:"complete"`
+}
+
+func executeToolResultPage(t *testing.T, proxy *UseCapabilityTool, callID, ref string, offset, limit int) (toolResultPageHeader, string, error) {
+	t.Helper()
+	args, _ := json.Marshal(map[string]any{
+		"action": "call", "capability_id": sessionToolResultCapabilityID,
+		"arguments": map[string]any{"tool_call_id": callID, "result_ref": ref, "offset": offset, "limit": limit},
+	})
+	out, err := proxy.Execute(context.Background(), args)
+	if err != nil {
+		return toolResultPageHeader{}, "", err
+	}
+	headerText, body, ok := strings.Cut(out, "\n")
+	if !ok {
+		t.Fatalf("page result has no metadata header: %.200q", out)
+	}
+	var header toolResultPageHeader
+	if err := json.Unmarshal([]byte(headerText), &header); err != nil {
+		t.Fatalf("decode page header %q: %v", headerText, err)
+	}
+	return header, body, nil
+}
+
+func newToolResultCapabilityAgent(t *testing.T, session *Session) (*Agent, *UseCapabilityTool) {
+	t.Helper()
+	reg := tool.NewRegistry()
+	proxy := NewUseCapabilityTool(context.Background(), nil, nil, reg, nil, nil, nil)
+	reg.Add(proxy)
+	a := New(nil, reg, session, Options{}, event.Discard)
+	return a, proxy
+}
+
+func TestSessionToolResultPagesReconstructCompleteUTF8Output(t *testing.T) {
+	full := strings.Repeat("ASCII-界-🧪\n", 6000)
+	bounded, notice := truncateToolOutputFor(full, "bash", "call-1")
+	if notice == "" || len(bounded) > maxToolOutputBytes {
+		t.Fatalf("fixture was not bounded: bytes=%d notice=%q", len(bounded), notice)
+	}
+	session := &Session{Messages: []provider.Message{{
+		Role: provider.RoleTool, Name: "bash", ToolCallID: "call-1", Content: bounded, RawContent: full,
+	}}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+	ref := toolResultRef("call-1", full)
+	if _, _, err := executeToolResultPage(t, proxy, "call-1", "", 0, 128); err == nil || !strings.Contains(err.Error(), "result_ref is required") {
+		t.Fatalf("new truncated result accepted no result_ref: %v", err)
+	}
+
+	var rebuilt strings.Builder
+	offset := 0
+	for pages := 0; ; pages++ {
+		if pages > 20 {
+			t.Fatal("pagination did not terminate")
+		}
+		header, page, err := executeToolResultPage(t, proxy, "call-1", ref, offset, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if header.Offset != offset || header.ResultRef != ref || header.TotalBytes != len(full) || header.SHA256 == "" {
+			t.Fatalf("unexpected page header: %+v", header)
+		}
+		if len(page) > toolResultPageDefaultBytes || len(page)+len(toolResultMustJSON(t, header))+1 > maxToolOutputBytes {
+			t.Fatalf("page exceeded bounded output: page=%d", len(page))
+		}
+		rebuilt.WriteString(page)
+		offset = header.NextOffset
+		if header.Complete {
+			break
+		}
+	}
+	if got := rebuilt.String(); got != full {
+		t.Fatalf("rebuilt result differs: got=%d want=%d", len(got), len(full))
+	}
+
+	header, page, err := executeToolResultPage(t, proxy, "call-1", ref, len(full), 1024)
+	if err != nil || !header.Complete || page != "" || header.NextOffset != len(full) {
+		t.Fatalf("terminal page = header=%+v page=%q err=%v", header, page, err)
+	}
+}
+
+func TestToolResultProviderBoundaryAndRecoveryMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "below", body: strings.Repeat("a", maxToolOutputBytes-1)},
+		{name: "equal", body: strings.Repeat("a", maxToolOutputBytes)},
+		{name: "ascii", body: strings.Repeat("a", maxToolOutputBytes+1)},
+		{name: "chinese", body: strings.Repeat("界", maxToolOutputBytes)},
+		{name: "emoji", body: strings.Repeat("🧪", maxToolOutputBytes)},
+		{name: "error-tail", body: strings.Repeat("trace\n", 9000) + "fatal: unique error tail"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			callID := strings.Repeat("调用-🧪", 100)
+			got, notice := truncateToolOutputFor(tc.body, strings.Repeat("tool-界", 100), callID)
+			if len(tc.body) <= maxToolOutputBytes {
+				if got != tc.body || notice != "" {
+					t.Fatalf("under-bound result changed: bytes=%d notice=%q", len(got), notice)
+				}
+				return
+			}
+			if len(got) > maxToolOutputBytes || !utf8.ValidString(got) {
+				t.Fatalf("bounded result invalid: bytes=%d utf8=%v", len(got), utf8.ValidString(got))
+			}
+			ref := toolResultRef(callID, tc.body)
+			for _, want := range []string{"result_ref=" + ref, "original_bytes=", "kept_bytes=", "session:tool_result", "use_capability", "narrower arguments"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("recovery marker missing %q: %.1000s", want, got)
+				}
+			}
+			if tc.name == "error-tail" && !strings.Contains(got, "fatal: unique error tail") {
+				t.Fatal("error-oriented truncation lost the diagnostic tail")
+			}
+		})
+	}
+}
+
+func toolResultMustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	b, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestSessionToolResultRequiresExactRefForDuplicateCallID(t *testing.T) {
+	first := strings.Repeat("first", 8000)
+	second := strings.Repeat("second", 8000)
+	session := &Session{Messages: []provider.Message{
+		{Role: provider.RoleTool, Name: "bash", ToolCallID: "repeat", Content: "bounded-1", RawContent: first},
+		{Role: provider.RoleTool, Name: "bash", ToolCallID: "repeat", Content: "bounded-2", RawContent: second},
+	}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+
+	if _, _, err := executeToolResultPage(t, proxy, "repeat", "", 0, 128); err == nil || !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), toolResultRef("repeat", first)) {
+		t.Fatalf("missing deterministic ambiguity error: %v", err)
+	}
+	_, page, err := executeToolResultPage(t, proxy, "repeat", toolResultRef("repeat", first), 0, 128)
+	if err != nil || page != first[:128] {
+		t.Fatalf("exact ref selected wrong duplicate: page=%q err=%v", page, err)
+	}
+}
+
+func TestSessionToolResultValidatesLegacyAndPagingErrors(t *testing.T) {
+	session := &Session{Messages: []provider.Message{
+		{Role: provider.RoleTool, Name: "read_file", ToolCallID: "complete", Content: "完整结果"},
+		{Role: provider.RoleTool, Name: "read_file", ToolCallID: "lost", Content: "…[truncated tool=read_file call_id=lost]…"},
+	}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+
+	_, page, err := executeToolResultPage(t, proxy, "complete", "", 0, 1024)
+	if err != nil || page != "完整结果" {
+		t.Fatalf("legacy complete result = %q err=%v", page, err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "lost", "", 0, 1024); err == nil || !strings.Contains(err.Error(), "full result is unavailable") {
+		t.Fatalf("legacy truncated result error = %v", err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "complete", "", 1, 1024); err == nil || !strings.Contains(err.Error(), "UTF-8 character boundary") {
+		t.Fatalf("invalid UTF-8 offset error = %v", err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "complete", "", 0, toolResultPageMaxBytes+1); err == nil || !strings.Contains(err.Error(), "limit must be") {
+		t.Fatalf("invalid limit error = %v", err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "missing", "", 0, 10); err == nil || !strings.Contains(err.Error(), "was not found") {
+		t.Fatalf("missing result error = %v", err)
+	}
+}
+
+func TestSessionToolResultBindingTracksSetSessionAndCloneIsIsolated(t *testing.T) {
+	parent := &Session{Messages: []provider.Message{{Role: provider.RoleTool, ToolCallID: "call", Name: "bash", Content: "parent"}}}
+	a, proxy := newToolResultCapabilityAgent(t, parent)
+	clone := proxy.CloneForAgent(nil, nil)
+	if clone.currentToolResultTarget() != nil {
+		t.Fatal("CloneForAgent inherited the parent session reader")
+	}
+	childRegistry := tool.NewRegistry()
+	childRegistry.Add(clone)
+	_ = New(nil, childRegistry, &Session{Messages: []provider.Message{{Role: provider.RoleTool, ToolCallID: "call", Name: "bash", Content: "child"}}}, Options{}, event.Discard)
+
+	_, page, err := executeToolResultPage(t, proxy, "call", "", 0, 32)
+	if err != nil || page != "parent" {
+		t.Fatalf("parent page=%q err=%v", page, err)
+	}
+	a.SetSession(&Session{Messages: []provider.Message{{Role: provider.RoleTool, ToolCallID: "call", Name: "bash", Content: "replacement"}}})
+	_, page, err = executeToolResultPage(t, proxy, "call", "", 0, 32)
+	if err != nil || page != "replacement" {
+		t.Fatalf("replacement page=%q err=%v", page, err)
+	}
+	_, page, err = executeToolResultPage(t, clone, "call", "", 0, 32)
+	if err != nil || page != "child" {
+		t.Fatalf("child page=%q err=%v", page, err)
+	}
+}
+
+func TestSessionToolResultBindingDoesNotChangeUseCapabilitySchema(t *testing.T) {
+	reg := tool.NewRegistry()
+	proxy := NewUseCapabilityTool(context.Background(), nil, nil, reg, nil, nil, nil)
+	reg.Add(proxy)
+	beforeName, beforeDescription := proxy.Name(), proxy.Description()
+	beforeSchema := append([]byte(nil), proxy.Schema()...)
+	beforeProviderSchemas := reg.Schemas()
+
+	_ = New(nil, reg, NewSession("system"), Options{}, event.Discard)
+	if proxy.Name() != beforeName || proxy.Description() != beforeDescription || !reflect.DeepEqual(proxy.Schema(), json.RawMessage(beforeSchema)) {
+		t.Fatal("session reader binding changed the stable use_capability contract")
+	}
+	if !reflect.DeepEqual(reg.Schemas(), beforeProviderSchemas) {
+		t.Fatal("session reader binding changed provider tool schemas")
+	}
+	list, err := proxy.Execute(context.Background(), json.RawMessage(`{"action":"list"}`))
+	if err != nil || !strings.Contains(list, sessionToolResultCapabilityID) {
+		t.Fatalf("bound capability missing from list: err=%v list=%s", err, list)
+	}
+	inspectArgs := json.RawMessage(`{"action":"inspect","capability_id":"session:tool_result"}`)
+	inspect, err := proxy.Execute(context.Background(), inspectArgs)
+	if err != nil || !strings.Contains(inspect, `"limit_max": 24576`) {
+		t.Fatalf("inspect result: err=%v out=%s", err, inspect)
+	}
+}
+
+func TestRestrictedCapabilityProxyListsAndReadsOnlyOwnToolResults(t *testing.T) {
+	inner := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), nil, nil, nil)
+	resolver := tool.CallResolver(inner)
+	proxy := &restrictedCapabilityProxy{
+		Tool: inner, resolver: resolver,
+		allowed: map[string]bool{"mcp-server:allowed": true}, servers: map[string]bool{"allowed": true},
+	}
+	reg := tool.NewRegistry()
+	reg.Add(proxy)
+	_ = New(nil, reg, &Session{Messages: []provider.Message{{Role: provider.RoleTool, Name: "read", ToolCallID: "own", Content: "own result"}}}, Options{}, event.Discard)
+
+	list, err := proxy.Execute(context.Background(), json.RawMessage(`{"action":"list"}`))
+	if err != nil || !strings.Contains(list, sessionToolResultCapabilityID) {
+		t.Fatalf("restricted list omitted session capability: err=%v list=%s", err, list)
+	}
+	args := json.RawMessage(`{"action":"call","capability_id":"session:tool_result","arguments":{"tool_call_id":"own"}}`)
+	out, err := proxy.Execute(context.Background(), args)
+	if err != nil || !strings.HasSuffix(out, "\nown result") {
+		t.Fatalf("restricted self read: err=%v out=%q", err, out)
+	}
+}
+
+func TestProviderRequestsNeverUploadToolRawContent(t *testing.T) {
+	const rawSentinel = "RAW-SENTINEL-MUST-STAY-LOCAL"
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call-1", Name: "read", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call-1", Name: "read", Content: "bounded", RawContent: rawSentinel},
+	}
+	a := New(nil, tool.NewRegistry(), &Session{Messages: msgs}, Options{}, event.Discard)
+	req := a.summaryRequest(msgs, "")
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), rawSentinel) || !strings.Contains(string(b), "bounded") {
+		t.Fatalf("summary request leaked RawContent: %s", b)
+	}
+	projected := buildVisibleCompressionProjection(msgs, visibleCompressionPlan{foldMask: make([]bool, len(msgs)), firstFold: -1}, "")
+	b, _ = json.Marshal(projected)
+	if strings.Contains(string(b), rawSentinel) || !strings.Contains(string(b), "bounded") {
+		t.Fatalf("projection leaked RawContent: %s", b)
+	}
+}
+
+func TestSessionToolResultRejectsPageThatSplitsUTF8Rune(t *testing.T) {
+	session := &Session{Messages: []provider.Message{{Role: provider.RoleTool, Name: "read", ToolCallID: "utf8", Content: "界"}}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+	if _, _, err := executeToolResultPage(t, proxy, "utf8", "", 0, 1); err == nil || !strings.Contains(err.Error(), "increase limit") {
+		t.Fatalf("split-rune limit error = %v", err)
+	}
+}
+
+func TestSessionToolResultSHA256MatchesCompleteBody(t *testing.T) {
+	body := strings.Repeat("hash-界", 100)
+	session := &Session{Messages: []provider.Message{{Role: provider.RoleTool, Name: "read", ToolCallID: "hash", Content: body}}}
+	_, proxy := newToolResultCapabilityAgent(t, session)
+	header, page, err := executeToolResultPage(t, proxy, "hash", "", 0, toolResultPageMaxBytes)
+	if err != nil || page != body {
+		t.Fatalf("page=%q err=%v", page, err)
+	}
+	digest := sha256.Sum256([]byte(body))
+	if !bytes.Equal(mustDecodeHex(t, header.SHA256), digest[:]) {
+		t.Fatalf("sha256=%q does not match complete body", header.SHA256)
+	}
+}
+
+func mustDecodeHex(t *testing.T, value string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -168,9 +168,15 @@ func TestSessionToolResultRequiresExactRefForDuplicateCallID(t *testing.T) {
 }
 
 func TestSessionToolResultValidatesLegacyAndPagingErrors(t *testing.T) {
+	fullLost := strings.Repeat("lost-new-result", 3000)
+	boundedLost, notice := truncateToolOutputFor(fullLost, "read_file", "lost-new")
+	if notice == "" {
+		t.Fatal("new lost-result fixture was not truncated")
+	}
 	session := &Session{Messages: []provider.Message{
 		{Role: provider.RoleTool, Name: "read_file", ToolCallID: "complete", Content: "完整结果"},
 		{Role: provider.RoleTool, Name: "read_file", ToolCallID: "lost", Content: "…[truncated tool=read_file call_id=lost]…"},
+		{Role: provider.RoleTool, Name: "read_file", ToolCallID: "lost-new", Content: boundedLost},
 	}}
 	_, proxy := newToolResultCapabilityAgent(t, session)
 
@@ -180,6 +186,13 @@ func TestSessionToolResultValidatesLegacyAndPagingErrors(t *testing.T) {
 	}
 	if _, _, err := executeToolResultPage(t, proxy, "lost", "", 0, 1024); err == nil || !strings.Contains(err.Error(), "full result is unavailable") {
 		t.Fatalf("legacy truncated result error = %v", err)
+	}
+	fullLostRef := toolResultRef("lost-new", fullLost)
+	if _, _, err := executeToolResultPage(t, proxy, "lost-new", "", 0, 1024); err == nil || !strings.Contains(err.Error(), fullLostRef) {
+		t.Fatalf("new truncated result did not request its marker ref: %v", err)
+	}
+	if _, _, err := executeToolResultPage(t, proxy, "lost-new", fullLostRef, 0, 1024); err == nil || !strings.Contains(err.Error(), "full result is unavailable") {
+		t.Fatalf("new truncated result with missing RawContent error = %v", err)
 	}
 	if _, _, err := executeToolResultPage(t, proxy, "complete", "", 1, 1024); err == nil || !strings.Contains(err.Error(), "UTF-8 character boundary") {
 		t.Fatalf("invalid UTF-8 offset error = %v", err)

--- a/internal/agent/tool_result_capability_test.go
+++ b/internal/agent/tool_result_capability_test.go
@@ -328,6 +328,67 @@ func TestRestrictedCapabilityFrontendCloneKeepsAgentSessionsIsolated(t *testing.
 	}
 }
 
+func TestPathBoundCapabilityFrontendBindsAndClonesAgentSessions(t *testing.T) {
+	for _, restricted := range []bool{false, true} {
+		name := "unrestricted"
+		if restricted {
+			name = "restricted"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			claim, err := NormalizeWritePaths(root, []string{"frontend"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			baseRegistry := tool.NewRegistry()
+			inner := NewUseCapabilityTool(context.Background(), nil, nil, baseRegistry, nil, nil, nil)
+			var frontend tool.Tool = inner
+			if restricted {
+				frontend = &restrictedCapabilityProxy{
+					Tool: inner, resolver: inner,
+					allowed: map[string]bool{"mcp-server:allowed": true}, servers: map[string]bool{"allowed": true},
+				}
+			}
+			baseRegistry.Add(frontend)
+			parentRegistry, removed := BindWritePaths(baseRegistry, claim, root, false)
+			if len(removed) != 0 {
+				t.Fatalf("path-bound registry removed tools: %v", removed)
+			}
+			parentTool, ok := parentRegistry.Get("use_capability")
+			if !ok {
+				t.Fatal("path-bound registry missing use_capability")
+			}
+			_ = New(nil, parentRegistry, &Session{Messages: []provider.Message{{
+				Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "parent",
+			}}}, Options{}, event.Discard)
+
+			childTool := newSubagentCapabilityFrontend(parentRegistry, nil)
+			if childTool == nil {
+				t.Fatal("path-bound child frontend was dropped during clone")
+			}
+			childRegistry := tool.NewRegistry()
+			childRegistry.Add(childTool)
+			_ = New(nil, childRegistry, &Session{Messages: []provider.Message{{
+				Role: provider.RoleTool, ToolCallID: "call", Name: "read", Content: "child",
+			}}}, Options{}, event.Discard)
+
+			_, parentPage, parentErr := executeToolResultPage(t, parentTool, "call", "", 0, 32)
+			_, childPage, childErr := executeToolResultPage(t, childTool, "call", "", 0, 32)
+			if parentErr != nil || parentPage != "parent" {
+				t.Fatalf("path-bound parent page=%q err=%v", parentPage, parentErr)
+			}
+			if childErr != nil || childPage != "child" {
+				t.Fatalf("path-bound child page=%q err=%v", childPage, childErr)
+			}
+			if parentTool.Name() != childTool.Name() || parentTool.Description() != childTool.Description() ||
+				!reflect.DeepEqual(parentTool.Schema(), childTool.Schema()) ||
+				!reflect.DeepEqual(parentRegistry.Schemas(), childRegistry.Schemas()) {
+				t.Fatal("path-bound cloning or binding changed provider-visible use_capability bytes")
+			}
+		})
+	}
+}
+
 func TestPlannerRestrictedCapabilityFrontendCloneKeepsExecutorSession(t *testing.T) {
 	inner := NewUseCapabilityTool(context.Background(), nil, nil, tool.NewRegistry(), nil, nil, nil)
 	executorProxy := &restrictedCapabilityProxy{

--- a/internal/agent/usecapability.go
+++ b/internal/agent/usecapability.go
@@ -421,6 +421,11 @@ type UseCapabilityTool struct {
 	ledger   *capability.Ledger
 	audit    *capability.Audit
 	catalog  func() capability.Catalog
+	// toolResultSession is bound by Agent.New to that frontend's own session.
+	// CloneForAgent intentionally leaves it empty so parent transcripts cannot
+	// leak into planner or child frontends before their Agent binds them.
+	toolResultMu      sync.RWMutex
+	toolResultSession func() *Session
 	// state is session-shared connection observation when built via
 	// MCPCapabilityRuntime; nil falls back to a private map for tests.
 	state *mcpProxySharedState
@@ -594,6 +599,16 @@ func (t *UseCapabilityTool) ResolveCall(ctx context.Context, args json.RawMessag
 		if id == "" {
 			return tool.ResolvedCall{}, fmt.Errorf("capability_id is required for action=inspect")
 		}
+		if id == sessionToolResultCapabilityID {
+			out, err := t.inspectSessionToolResult()
+			if err != nil {
+				return tool.ResolvedCall{}, err
+			}
+			base.SkipExecute = true
+			base.Result = out
+			base.ReadOnly = true
+			return base, nil
+		}
 		out, err := t.inspect(ctx, id)
 		if err != nil {
 			if t.audit != nil {
@@ -641,6 +656,9 @@ func (t *UseCapabilityTool) ResolveCall(ctx context.Context, args json.RawMessag
 	case "call":
 		if id == "" {
 			return tool.ResolvedCall{}, fmt.Errorf("capability_id is required for action=call")
+		}
+		if id == sessionToolResultCapabilityID {
+			return t.resolveSessionToolResult(p.Arguments, base)
 		}
 		return t.resolveCall(ctx, id, p.Arguments, base)
 	default:
@@ -724,6 +742,12 @@ func (t *UseCapabilityTool) listCapabilities() (string, error) {
 		Description string `json:"description,omitempty"`
 	}
 	var caps []capInfo
+	if t.currentToolResultTarget() != nil {
+		caps = append(caps, capInfo{
+			ID: sessionToolResultCapabilityID, Kind: "session", Name: "tool_result", Status: "ready", ReadOnly: true,
+			Description: "Read one bounded page from a complete tool result retained in this agent's current session.",
+		})
+	}
 	if t.catalog != nil {
 		for _, e := range t.catalog().Entries {
 			// Skip provider-visible core tools — they are already top-level.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,9 +47,9 @@ type Message struct {
 	// Content is the provider-visible conversation content. Keeping this legacy
 	// field provider-visible preserves replay for older CLI/Desktop releases.
 	Content string `json:"content,omitempty"`
-	// RawContent holds the full original when it differs from Content. The agent
-	// promotes tool RawContent in current requests and projection hashes, while
-	// bounded Content keeps session files safe for older readers.
+	// RawContent holds the full local original when it differs from Content.
+	// Provider projections always strip it; bounded Content is the stable wire
+	// representation and keeps session files safe for older readers.
 	RawContent string `json:"raw_content,omitempty"`
 	// ProviderContent is a transitional field written by early Context Engine v2
 	// builds. Loaders migrate it into Content/RawContent before normal use.

--- a/release-notes/releases.json
+++ b/release-notes/releases.json
@@ -64,6 +64,17 @@
       ],
       "highlights": [
         {
+          "kind": "fixed",
+          "title": {
+            "en": "Bounded tool results preserve prompt-cache prefixes",
+            "zh": "有界工具结果保持提示词缓存前缀"
+          },
+          "body": {
+            "en": "Large tool results now keep a stable provider-visible 32KB representation while retaining the complete local result for explicit paged recovery. This fixes avoidable context growth and prefix churn; provider-side cache hit rates still depend on model and cache state.",
+            "zh": "大工具结果现在使用稳定的 provider 可见 32KB 表示，同时在本地保留完整结果供显式分页恢复。该修复避免不必要的上下文增长和前缀变化；供应商侧缓存命中率仍取决于模型与缓存状态。"
+          }
+        },
+        {
           "kind": "new",
           "title": {
             "en": "DeepSeek V4 peak and off-peak pricing",
@@ -190,7 +201,18 @@
             ]
           }
         ],
-        "fixed": []
+        "fixed": [
+          {
+            "title": {
+              "en": "Stable large tool-result projection",
+              "zh": "稳定的大工具结果投影"
+            },
+            "body": {
+              "en": "Stops full local RawContent from being automatically promoted into sampling, retries, summaries, and projection replay. Complete text remains losslessly available through the session-scoped paged capability.",
+              "zh": "不再将本地完整 RawContent 自动提升到采样、重试、摘要和投影回放中；完整原文仍可通过会话隔离的分页能力无损读取。"
+            }
+          }
+        ]
       },
       "upgrade": [],
       "risks": [],


### PR DESCRIPTION
## Summary

- Keep each provider-visible tool result on the stable persisted `Content` representation, bounded to 32 KiB, while retaining the complete local value in `RawContent`.
- Add the fixed internal `session:tool_result` capability behind the existing `use_capability` schema for explicit, UTF-8-safe paged recovery.
- Normalize only exactly matching promoted-`RawContent` projection sidecars back to bounded prefix hashes; invalid projections are discarded without rewriting the canonical transcript.

Cache-impact: low - ordinary prefixes become bounded and append-only again; the top-level tool surface and system prompt remain byte-identical.
Cache-guard: `./scripts/cache-guard.sh` passes, including 64 KiB and 256 KiB tool-result cases capped at 32,768 provider-visible bytes.
System-prompt-review: reviewed by the author - no system-prompt text, provider-visible tool schema, description, or order changes; `task.go` only binds and filters the internal session capability.
Documentation-impact: updated - English and Chinese specifications, tool contracts, cache design notes, and release notes now document bounded `Content`, local `RawContent`, explicit paging, and sidecar compatibility.

## Root cause

Recent request preparation promoted complete tool `RawContent` into ordinary sampling, retries, summaries, projection replay, and covered-prefix hashing. Large tool results therefore increased the provider prompt in proportion to the complete local result and made the model-visible representation differ from the bounded `Content` persisted for compatibility.

This change restores one provider projection boundary: tool `Content` is always model-visible, and `RawContent` remains local unless the model explicitly requests a page.

## Behavior

- The existing 32 KiB, UTF-8-safe, tool-aware head/tail truncation policy remains fixed and non-configurable.
- New truncation markers include the tool name, call ID, byte counts, a stable `result_ref`, and an exact `use_capability` recovery example.
- `session:tool_result` uses byte offsets, defaults to 16 KiB pages, caps pages at 24 KiB, and returns `result_ref`, offsets, total bytes, full SHA-256, and completion state.
- Duplicate call IDs require an exact reference; legacy unique call IDs remain readable without one. Legacy truncated records without retained raw data fail explicitly and recommend rerunning the original tool.
- Capability readers bind to the current Agent session. `SetSession` follows the replacement session, capability clones do not inherit a parent reader, and allowed-tool profiles without `use_capability` are not widened.
- The top-level tool name, description, schema, order, system prompt, configuration surface, compaction ratios, and pressure thresholds are unchanged.

## Cache evidence

The deterministic cache guard now includes 64 KiB and 256 KiB tool results. Both keep the maximum provider-visible tool message at 32,768 bytes, preserve prior request messages byte-for-byte on later turns, and pass the existing 90% tail-average guard.

Sanitized DeepSeek live comparisons used the same large-result fixture and prompt shape:

| Build | Provider-visible large result | Second request prompt | Third request cache hit rate | Full-result sentinel on wire |
| --- | ---: | ---: | ---: | --- |
| Current broken baseline | 262,144 bytes | 132,476 tokens | 99.89% after the large cold miss | yes |
| This change | <=32,768 bytes | 9,568 tokens | 98.82% | no |
| v1.23.0 reference | 16,212 bytes | 9,472 tokens | 98.47% | no |

These observations validate bounded, stable request bytes; they do not promise a fixed provider-side hit rate.

## Compatibility and security

- No session JSON field or schema version is added. Existing `Content` / `RawContent` sessions remain bidirectionally readable; older builds may promote `RawContent` again but do not lose data.
- Promoted-`RawContent` sidecars migrate only when the historical hash matches exactly, including the corresponding receipt hash. Unprovable projection bodies are dropped while canonical messages and maintenance records remain intact.
- The session capability performs no file or network access and cannot select another Agent or session. Page contents are returned only after an explicit model call.
- `use_capability` provider serialization is asserted byte-identical before and after reader binding.

## Verification

Passed:

- Focused `internal/agent` tests for bounding, sampling/summary/projection isolation, persistence, paging, duplicate IDs, UTF-8 boundaries, sidecar migration, and Agent/child isolation.
- Focused `go test -race ./internal/agent` coverage for session binding and paged reads.
- `./scripts/cache-guard.sh`, including 64 KiB and 256 KiB tool results.
- `go test ./internal/boot ./tools/repolint`.
- Environment-gated DeepSeek live regression test and comparative runs against the broken baseline and v1.23.0.

Additional post-fix verification passed on commit `0ead5a732`:

- `go test ./internal/agent ./internal/boot`
- `go test ./...`
- `go test -race ./internal/agent`
- `go vet ./...`
- `go run ./tools/repolint`
- `./scripts/cache-guard.sh`

The active-turn compression and overflow-progress regressions are now covered by direct tests, along with request-input immutability and pressure-prune RawContent isolation.

## Related open work

- #8180 targets an older warm-cache pruning path and does not overlap this provider projection boundary.
- #8256 targets Desktop resume/compaction presentation; documentation conflicts may need routine resolution.
- #7911 memoizes tool execution results. It is semantically independent, though both branches touch `internal/agent/agent.go`.
