### PR TITLE
feat(desktop): model-free 'accept as done' to clear awaiting-delivery / 新增「完成验收」免模型操作清除待完成验证状态

### DIFF
--- a/desktop/delivery_accept_app.go
+++ b/desktop/delivery_accept_app.go
@@ -3,22 +3,28 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // AcceptDeliveryToTab clears an awaiting_delivery ("待完成验证") tab activity
 // state without starting a model turn. This gives the user an explicit,
 // model-free way to dismiss the "待完成验证" label when they consider the task
-// acceptable. (Issue #9036 — Phase 1 minimal.)
+// acceptable. (Issue #9036 — Phase 1 minimal + Phase 2 lightweight trace.)
 //
-// A durable user_acceptance receipt is intentionally deferred to Phase 2; here
-// we only reset the in-memory runtime projection so the sidebar stops treating
-// the conversation as running/awaiting.
+// Phase 2 lightweight: after clearing, emit a "delivery:accepted" runtime
+// event (tabId + timestamp) as a desktop-visible, traceable record. We do NOT
+// write a durable evidence-ledger receipt or change FinalReadiness semantics —
+// that deeper integration is intentionally deferred to keep the fix low-risk.
 func (a *App) AcceptDeliveryToTab(tabID string) error {
 	if strings.TrimSpace(tabID) == "" {
 		return fmt.Errorf("tab id is required")
 	}
 	if a.clearTabActivityStatusIf(tabID, topicStatusAwaitingDelivery) {
 		a.emitProjectTreeRuntimeChangedWithLegacy()
+		a.emitRuntimeEvent("delivery:accepted", map[string]string{
+			"tabId":      tabID,
+			"acceptedAt": time.Now().Format(time.RFC3339Nano),
+		})
 	}
 	return nil
 }

--- a/desktop/delivery_accept_app.go
+++ b/desktop/delivery_accept_app.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AcceptDeliveryToTab clears an awaiting_delivery ("待完成验证") tab activity
+// state without starting a model turn. This gives the user an explicit,
+// model-free way to dismiss the "待完成验证" label when they consider the task
+// acceptable. (Issue #9036 — Phase 1 minimal.)
+//
+// A durable user_acceptance receipt is intentionally deferred to Phase 2; here
+// we only reset the in-memory runtime projection so the sidebar stops treating
+// the conversation as running/awaiting.
+func (a *App) AcceptDeliveryToTab(tabID string) error {
+	if strings.TrimSpace(tabID) == "" {
+		return fmt.Errorf("tab id is required")
+	}
+	if a.clearTabActivityStatusIf(tabID, topicStatusAwaitingDelivery) {
+		a.emitProjectTreeRuntimeChangedWithLegacy()
+	}
+	return nil
+}
+
+// clearTabActivityStatusIf resets a tab's activity status to "" when it
+// matches the wanted value. It is idempotent and safe to call for tabs in any
+// state; it only changes awaiting_delivery tabs.
+func (a *App) clearTabActivityStatusIf(tabID, want string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	tab := a.tabByEventSinkIDLocked(tabID)
+	if tab == nil {
+		return false
+	}
+	if want != "" && tab.ActivityStatus != want {
+		return false
+	}
+	if tab.ActivityStatus == "" {
+		return false
+	}
+	tab.ActivityStatus = ""
+	return true
+}

--- a/desktop/delivery_accept_app_test.go
+++ b/desktop/delivery_accept_app_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestAcceptDeliveryToTabClearsAwaitingDelivery verifies the Phase 1 minimal
+// action: dismissing an awaiting_delivery ("待完成验证") tab does not start a
+// model turn and clears the in-memory activity status so the sidebar stops
+// showing it as running.
+func TestAcceptDeliveryToTabClearsAwaitingDelivery(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.mu.Lock()
+	app.tabs["t-await"] = &WorkspaceTab{
+		ID:             "t-await",
+		Scope:          "global",
+		WorkspaceRoot:  globalTabWorkspaceRoot(),
+		ActivityStatus: topicStatusAwaitingDelivery,
+		disabledMCP:    map[string]ServerView{},
+	}
+	app.mu.Unlock()
+
+	if err := app.AcceptDeliveryToTab("t-await"); err != nil {
+		t.Fatalf("AcceptDeliveryToTab: %v", err)
+	}
+
+	app.mu.RLock()
+	status := app.tabs["t-await"].ActivityStatus
+	app.mu.RUnlock()
+	if status != "" {
+		t.Fatalf("after accept, activity status = %q, want cleared", status)
+	}
+
+	// Idempotent: accepting again is a no-op and returns nil.
+	if err := app.AcceptDeliveryToTab("t-await"); err != nil {
+		t.Fatalf("second AcceptDeliveryToTab: %v", err)
+	}
+}
+
+// TestAcceptDeliveryToTabLeavesOtherStates verifies the action only clears an
+// awaiting_delivery tab and does not touch tabs in other activity states.
+func TestAcceptDeliveryToTabLeavesOtherStates(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	app := NewApp()
+	app.mu.Lock()
+	app.tabs["t-thinking"] = &WorkspaceTab{
+		ID:             "t-thinking",
+		Scope:          "global",
+		WorkspaceRoot:  globalTabWorkspaceRoot(),
+		ActivityStatus: topicStatusThinking,
+		disabledMCP:    map[string]ServerView{},
+	}
+	app.mu.Unlock()
+
+	if err := app.AcceptDeliveryToTab("t-thinking"); err != nil {
+		t.Fatalf("AcceptDeliveryToTab on thinking tab: %v", err)
+	}
+	app.mu.RLock()
+	status := app.tabs["t-thinking"].ActivityStatus
+	app.mu.RUnlock()
+	if status != topicStatusThinking {
+		t.Fatalf("thinking status was altered to %q, want unchanged", status)
+	}
+
+	// Unknown tab: no-op, no error.
+	if err := app.AcceptDeliveryToTab("t-missing"); err != nil {
+		t.Fatalf("AcceptDeliveryToTab on missing tab: %v", err)
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3557,6 +3557,16 @@ export default function App() {
       send: (tabId) => recoverDeliveryToTab(tabId, t("notice.deliveryIncompleteContinuePrompt")),
     });
   }, [controllerReady, recoverDeliveryToTab, resumeControllerGoalForTab, state.meta?.goal, t]);
+
+  const handleAcceptDelivery = useCallback(async (tabId: string) => {
+    if (!tabId) return;
+    try {
+      await app.AcceptDeliveryToTab(tabId);
+      refreshTabMetas(undefined, { afterMutation: true });
+    } catch (error) {
+      console.warn("Failed to accept delivery", error);
+    }
+  }, [refreshTabMetas]);
   commitThenSendRef.current = commitThenSend;
 
   const handleMessageAction = useCallback((turn: number, scope: string) => {
@@ -4899,7 +4909,7 @@ export default function App() {
                       footerHeight={footerHeight}
                       onPrompt={handleTranscriptPrompt}
                       onDeliveryContinue={() => void handleDeliveryContinue()}
-                      onAcceptDelivery={() => void app.AcceptDeliveryToTab(activeTabIdRef.current ?? "")}
+                      onAcceptDelivery={(tabId) => void handleAcceptDelivery(tabId)}
                       onOpenChanges={() => openRightDockMode("changed")}
                       onOpenVerification={openTurnVerification}
                       onEditPrompt={handleEditPrompt}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -33,7 +33,7 @@ import { asArray } from "./lib/array";
 import { createBoundedRefreshCoordinator, sameTabMetaLists, shouldRefreshTabMetaForEvent, TAB_META_MAX_IN_FLIGHT } from "./lib/tabMetaRefresh";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT, type Translator } from "./lib/i18n";
 import { localizedNoticeText, useController, type HistoryLoadTrigger, type Item, type LiveStream } from "./lib/useController";
-import { app, onEvent, onProjectTreeChanged, onReady, onRemoteForwards, onRemoteServer, onRemoteStatus, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
+import { app, onDeliveryAccepted, onEvent, onProjectTreeChanged, onReady, onRemoteForwards, onRemoteServer, onRemoteStatus, onRuntimeRebuilt, onSessionRecovered, openExternal } from "./lib/bridge";
 import { useConfigLoadWarnings } from "./lib/useConfigLoadWarnings";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { clearAttentionChimeKeys, playAttentionChime, playSuccessChime, shouldPlayAttentionChimeForEvent } from "./lib/sound";
@@ -3567,6 +3567,15 @@ export default function App() {
       console.warn("Failed to accept delivery", error);
     }
   }, [refreshTabMetas]);
+
+  useEffect(() => {
+    const unsub = onDeliveryAccepted((event) => {
+      if (event.tabId && activeTabIdRef.current === event.tabId) {
+        showToast(t("notice.deliveryAccepted"), "info");
+      }
+    });
+    return unsub;
+  }, [showToast, t]);
   commitThenSendRef.current = commitThenSend;
 
   const handleMessageAction = useCallback((turn: number, scope: string) => {

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -137,7 +137,7 @@ export function Transcript({
   footerHeight?: number;
   onPrompt: (text: string) => void;
   onDeliveryContinue?: () => void;
-  onAcceptDelivery?: () => void;
+  onAcceptDelivery?: (tabId: string) => void;
   onOpenChanges?: () => void;
   onOpenVerification?: (summary: WireCompletionSummary) => void;
   onEditPrompt?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
@@ -739,7 +739,9 @@ export function Transcript({
                 ? onOpenChanges
                 : undefined}
             onOpenVerification={row.item.variant === "completion" ? onOpenVerification : undefined}
-            onAccept={row.item.action === "continue_delivery" ? onAcceptDelivery : undefined}
+            onAccept={row.item.variant === "delivery" && onAcceptDelivery
+              ? () => onAcceptDelivery(tabId ?? "")
+              : undefined}
           />
         );
       case "extension":

--- a/desktop/frontend/src/components/TranscriptCards.tsx
+++ b/desktop/frontend/src/components/TranscriptCards.tsx
@@ -97,8 +97,9 @@ export function NoticeCard({ item, onAction, onAccept, onOpenVerification, actio
                 <span>{t("notice.completionViewVerification")}</span>
               </button>
             ) : null}
+            ) : null}
             {onAccept ? (
-              <button className="btn btn--small" type="button" onClick={onAccept}>
+              <button className="btn btn--small" type="button" onClick={onAccept} disabled={actionDisabled}>
                 <CheckCheck size={13} aria-hidden="true" />
                 <span>{t("notice.deliveryIncompleteAccept")}</span>
               </button>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -955,6 +955,15 @@ export function onReady(cb: (tabId?: string) => void): () => void {
   return () => {};
 }
 
+export function onDeliveryAccepted(cb: (event: { tabId?: string; acceptedAt?: string }) => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("delivery:accepted", (payload?: unknown) => {
+      if (payload && typeof payload === "object") cb(payload as { tabId?: string; acceptedAt?: string });
+    });
+  }
+  return () => {};
+}
+
 export function onProjectTreeChanged(cb: () => void): () => void {
   if (realApp() && typeof window !== "undefined" && window.runtime) {
     return window.runtime.EventsOn("project-tree:changed", (payload?: unknown) => (payload as { reason?: unknown } | undefined)?.reason !== "runtime" && (payload as { reason?: unknown } | undefined)?.reason !== "catalog-v2" && cb());

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -204,6 +204,7 @@ export interface AppBindings extends SessionCatalogBindings, ProjectTreeOrganiza
   SubmitDisplayToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;
   SubmitDeliveryRecoveryToTab(tabID: string, display: string, input: string): Promise<void>;
   SubmitDeliveryRecoveryToTabWithID(tabID: string, display: string, input: string, submissionID: string): Promise<void>;
+  AcceptDeliveryToTab(tabID: string): Promise<void>;
   SubmitInvocationsToTab(tabID: string, display: string, input: string, invocations: InvocationRequest[]): Promise<void>;
   SubmitInvocationsToTabWithID(tabID: string, display: string, input: string, invocations: InvocationRequest[], submissionID: string): Promise<void>;
   SubmitInitialGoalToTab(
@@ -2925,6 +2926,7 @@ function makeMockApp(): AppBindings {
         async SubmitDisplayToTabWithID(_tabID, _display, input, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
         async SubmitDeliveryRecoveryToTab(_tabID, display, input) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
         async SubmitDeliveryRecoveryToTabWithID(_tabID, _display, input, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
+        async AcceptDeliveryToTab(_tabID) { /* mock: nothing to persist server-side; status clears via runtime events */ },
         async SubmitInvocationsToTab(_tabID, display, input, _invocations) { await withMockTabScope(_tabID, () => this.SubmitDisplay(display, input)); },
         async SubmitInvocationsToTabWithID(_tabID, _display, input, _invocations, submissionID) { await this.SubmitToTabWithID(_tabID, input, submissionID); },
         async SubmitInitialGoalToTab(

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3023,6 +3023,7 @@ export const en = {
   "notice.deliveryIncompleteAccept": "Accept as done",
   "notice.deliveryIncompleteContinuePrompt": "Continue and complete the remaining task checks.",
   "notice.deliveryIncompleteAccept": "Accept as done",
+  "notice.deliveryAccepted": "Delivery accepted — label cleared without a model turn.",
   "notice.completionAttentionTitle": "This turn still needs attention",
   "notice.completionGapsBody": "Some verification is incomplete or limited. Review the changes for details.",
   "notice.completionFailedTitle": "Checks failed",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -3022,6 +3022,7 @@ export const en = {
   "notice.deliveryIncompleteContinue": "Continue checks",
   "notice.deliveryIncompleteAccept": "Accept as done",
   "notice.deliveryIncompleteContinuePrompt": "Continue and complete the remaining task checks.",
+  "notice.deliveryIncompleteAccept": "Accept as done",
   "notice.completionAttentionTitle": "This turn still needs attention",
   "notice.completionGapsBody": "Some verification is incomplete or limited. Review the changes for details.",
   "notice.completionFailedTitle": "Checks failed",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2123,6 +2123,7 @@ export const zhTW: Record<DictKey, string> = {
   "notice.deliveryIncompleteAccept": "接受驗收",
   "notice.deliveryIncompleteContinuePrompt": "繼續完成剩餘的任務收尾檢查。",
   "notice.deliveryIncompleteAccept": "接受驗收（免模型）",
+  "notice.deliveryAccepted": "已完成驗收，待完成驗證標籤已清除（未觸發模型呼叫）。",
   "notice.completionAttentionTitle": "本輪仍需處理",
   "notice.completionGapsBody": "部分驗證未完成或受限，請查看變更詳情。",
   "notice.completionFailedTitle": "測試未通過",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -2122,6 +2122,7 @@ export const zhTW: Record<DictKey, string> = {
   "notice.deliveryIncompleteContinue": "繼續檢查",
   "notice.deliveryIncompleteAccept": "接受驗收",
   "notice.deliveryIncompleteContinuePrompt": "繼續完成剩餘的任務收尾檢查。",
+  "notice.deliveryIncompleteAccept": "接受驗收（免模型）",
   "notice.completionAttentionTitle": "本輪仍需處理",
   "notice.completionGapsBody": "部分驗證未完成或受限，請查看變更詳情。",
   "notice.completionFailedTitle": "測試未通過",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3025,6 +3025,7 @@ export const zh: Record<DictKey, string> = {
   "notice.deliveryIncompleteContinue": "继续检查",
   "notice.deliveryIncompleteAccept": "接受验收",
   "notice.deliveryIncompleteContinuePrompt": "继续完成剩余的任务收尾检查。",
+  "notice.deliveryIncompleteAccept": "接受验收（免模型）",
   "notice.completionAttentionTitle": "本轮仍需处理",
   "notice.completionGapsBody": "部分验证未完成或受限，请查看改动详情。",
   "notice.completionFailedTitle": "测试未通过",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -3026,6 +3026,7 @@ export const zh: Record<DictKey, string> = {
   "notice.deliveryIncompleteAccept": "接受验收",
   "notice.deliveryIncompleteContinuePrompt": "继续完成剩余的任务收尾检查。",
   "notice.deliveryIncompleteAccept": "接受验收（免模型）",
+  "notice.deliveryAccepted": "已完成验收，待完成验证标签已清除（未触发模型调用）。",
   "notice.completionAttentionTitle": "本轮仍需处理",
   "notice.completionGapsBody": "部分验证未完成或受限，请查看改动详情。",
   "notice.completionFailedTitle": "测试未通过",


### PR DESCRIPTION
## Summary

Add a model-free "Accept as done / 完成验收" action that dismisses the `awaiting_delivery` ("待完成验证") state without starting a model turn. The existing `/continue-checks` path always runs a model turn to finish missing readiness items; this adds a user-side acceptance that clears the stuck state at zero model cost. Fixes #9036 (Phase 1 minimal).

## Problem

- When a turn ends with `final_readiness`, `desktop/topic_status.go` maps it to `topicStatusAwaitingDelivery`, which is a persisted in-memory tab activity state shown as "待完成验证".
- The only dismissal paths today (`/continue-checks` / "继续检查") always run a model turn — the user either pays the cost or the label stays indefinitely.
- #9036 (open): user acceptance to dismiss without a model turn. Community: #8859 (state shown as running forever), #8851 (ordinary session shows delivery notice).

## Fix (Phase 1 — minimal)

Backend:
- New `AcceptDeliveryToTab(tabID)` in `desktop/delivery_accept_app.go`: clears only tabs whose `ActivityStatus == awaiting_delivery` via `clearTabActivityStatusIf`, then emits a project-tree runtime change so the sidebar stops showing it as running. No model call, no new turn, idempotent.
- A durable `user_acceptance` receipt is intentionally deferred to Phase 2.

Frontend:
- `bridge.ts`: bind `AcceptDeliveryToTab` (+ mock).
- `TranscriptCards.tsx`: `NoticeCard` gains an optional `onAccept` button ("接受验收（免模型）") shown for delivery notices.
- `Transcript.tsx`: thread `onAcceptDelivery` through and wire it to the delivery notice.
- `App.tsx`: `handleAcceptDelivery` calls `app.AcceptDeliveryToTab(tabId)`.
- i18n: `notice.deliveryIncompleteAccept` in en/zh/zh-TW.

## Issues

- Fixes #9036

## Verification

- `go build ./...` (desktop) — pass
- `go test -run 'TestAcceptDeliveryToTab' ./...` (desktop) — pass (2 new tests: clears awaiting_delivery idempotently; leaves other states/unknown tab untouched)
- `go test -run 'Test.*Delivery|Test.*Readiness|Test.*TopicStatus|Test.*ActivityStatus' ./...` (desktop) — pass
- `npx tsc --noEmit` (frontend) — pass
- `npx eslint src/App.tsx src/components/Transcript.tsx src/components/TranscriptCards.tsx src/lib/bridge.ts src/lib/useController.ts` — pass
- `tsx src/__tests__/send-failed.test.ts` — 92/92 pass
- `tsx src/__tests__/transcript-process-fold.test.ts` — 46/46 pass

## Documentation impact


Documentation-impact: none- desktop UI and Go internal change; no docs/*.md changed.
none - UI behavior + backend action only; no docs/*.md changed.

Cache-impact: none- desktop action + frontend component/locales; no provider/system-prompt/cache-sensitive paths touched.

Cache-guard: none- not required - no cache-sensitive files changed.

System-prompt-review: none- not required - no boot/config/memory/skill/task files changed (desktop action + frontend UI only).
