### PR TITLE
Studio gets its own CI gates and release line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
+# studio is a parallel release line, not a feature branch: it carries the
+# kernel changes Studio is built on, so it needs the same kernel gates main-v2
+# has. Studio's own surface (desktop/next, desktop/frontend-next) exists only
+# there and is covered by studio.yml.
 on:
   push:
-    branches: [main-v2]
+    branches: [main-v2, studio]
   pull_request:
-    branches: [main-v2]
+    branches: [main-v2, studio]
 
 permissions:
   contents: read

--- a/.github/workflows/release-studio.yml
+++ b/.github/workflows/release-studio.yml
@@ -1,0 +1,252 @@
+name: Release Studio
+run-name: Release Studio ${{ inputs.tag || github.ref_name }}
+
+# Studio's release line, parallel to the desktop/CLI/npm set and deliberately
+# separate from it. release-stable.yml validates that every tag it publishes sits
+# on main-v2 history, which studio commits never do, so this line has its own tag
+# namespace (studio-v*), its own environment gate, and its own rollback catalog
+# at dl.reasonix.io/studio/versions.json.
+#
+# What it must never touch: the repository-wide "latest" release (every Studio
+# release is a prerelease) and the root dl.reasonix.io/versions.json, which is
+# the desktop line's catalog. Studio artifacts land under the tag prefix, which
+# cannot collide because the tag name itself differs.
+#
+# Windows artifacts are unsigned. The production SignPath policy allows exactly
+# one origin (protected main-v2), so a build from this branch cannot request it
+# and users will see a SmartScreen warning.
+on:
+  push:
+    tags: ['studio-v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing studio tag to recover (for example studio-v0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write # create the release and upload artifacts
+
+concurrency:
+  group: release-studio-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: resolve Studio release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag and version
+        id: release
+        env:
+          IN_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag="${IN_TAG:-$REF_NAME}"
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$tag" =~ ^studio-v(.+)$ ]] || [[ ! "${BASH_REMATCH[1]}" =~ $semver ]]; then
+            echo "::error::studio release tag must be studio-vMAJOR.MINOR.PATCH[-PRERELEASE], got: $tag"
+            exit 1
+          fi
+          # A dispatch recovers an existing tag; it must not invent one.
+          sha="$(git rev-parse --verify "refs/tags/$tag^{commit}")"
+          # The tag has to be on the studio line. Publishing a main-v2 commit
+          # from here would produce a Studio build without Studio in it.
+          if ! git merge-base --is-ancestor "$sha" origin/studio; then
+            echo "::error::$tag is not on studio history"
+            exit 1
+          fi
+          version="${tag#studio-}"
+          { echo "tag=$tag"; echo "version=$version"; echo "sha=$sha"; } >> "$GITHUB_OUTPUT"
+          echo "resolved $tag -> $version at $sha"
+
+  build:
+    name: build (${{ matrix.platform }})
+    needs: resolve
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows/amd64
+            runner: windows-latest
+          - platform: darwin/universal
+            runner: macos-latest
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      - uses: pnpm/action-setup@v6.0.9
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/frontend-next/pnpm-lock.yaml
+
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: Build
+        shell: bash
+        run: bash scripts/studio-build.sh "${{ matrix.platform }}" "${{ needs.resolve.outputs.version }}"
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: studio-${{ strategy.job-index }}
+          path: dist/ReasonixStudio-*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: sign, publish and mirror
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    # Owner approval for the whole line. The gate sits here rather than before
+    # build so the approval is given with the artifacts already proven to build.
+    environment: studio-release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      - uses: actions/download-artifact@v6
+        with:
+          path: staging
+          merge-multiple: true
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p dist
+          find staging -type f -name 'ReasonixStudio-*' -exec mv {} dist/ \;
+          ls -la dist
+          # Three platforms were built; fewer files means an artifact was lost
+          # between jobs, and a partial release is worse than a failed one.
+          count=$(find dist -type f -name 'ReasonixStudio-*' | wc -l)
+          if [ "$count" -lt 3 ]; then
+            echo "::error::expected 3 platform artifacts, found $count"
+            exit 1
+          fi
+
+      # The same minisign key the desktop line uses, because the public key that
+      # verifies it is compiled into the client (update.PublicKey).
+      - name: Sign
+        working-directory: desktop
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          go run ./cmd/sign sign ../dist/*
+          for f in ../dist/ReasonixStudio-*; do
+            case "$f" in *.minisig) continue ;; esac
+            go run ./cmd/sign verify "$f"
+          done
+
+      - name: Generate manifest
+        working-directory: desktop
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: go run ./cmd/studio-manifest ../dist "${{ needs.resolve.outputs.version }}" "${{ needs.resolve.outputs.tag }}"
+
+      # Always a prerelease: this line is not the public product line, and
+      # GitHub never promotes a prerelease to the repository-wide "latest".
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          notes=$(cat <<EOF
+          Reasonix Studio $VERSION — parallel preview line, built from the \`studio\` branch.
+
+          Windows and macOS artifacts are **unsigned**: production signing is bound to
+          protected \`main-v2\`, so expect a SmartScreen warning on Windows and to clear
+          the quarantine attribute on macOS (\`xattr -dr com.apple.quarantine\`).
+
+          Self-update is not available on this line yet — download and replace manually.
+          EOF
+          )
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --title "Reasonix Studio $VERSION" \
+              --notes "$notes" \
+              --prerelease \
+              --latest=false
+          fi
+
+      - name: Mirror to R2 and update the Studio catalog
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
+        run: |
+          if [ "$HAS_R2" != "true" ]; then
+            echo "::warning::R2 credentials are not configured; the GitHub release is published but the Studio catalog was not updated, so running builds will not see this version"
+            exit 0
+          fi
+          aws configure set aws_access_key_id "${{ secrets.R2_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          aws configure set default.region auto
+          endpoint="https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+
+          # Immutable per-tag objects. The tag prefix cannot collide with the
+          # desktop line's because the tag names differ (studio-v* vs desktop-v*).
+          aws s3 cp dist/ "s3://${R2_BUCKET}/${TAG}/" --recursive --endpoint-url "$endpoint"
+
+          # Studio's own catalog. Writing the ROOT versions.json here would hand
+          # desktop users Studio releases, so the prefix is not optional.
+          current=/tmp/studio-versions-current.json
+          next=/tmp/studio-versions-next.json
+          source=-
+          if aws s3 cp "s3://${R2_BUCKET}/studio/versions.json" "$current" --endpoint-url "$endpoint" 2>/dev/null; then
+            source="$current"
+          else
+            echo "no existing Studio catalog; starting a new one"
+          fi
+          bash scripts/update-versions-index.sh "$source" "$VERSION" "$TAG" studio \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$next"
+          jq -e --arg v "$VERSION" '.versions | map(select(.version == $v)) | length == 1' "$next" >/dev/null
+          aws s3 cp "$next" "s3://${R2_BUCKET}/studio/versions.json" \
+            --endpoint-url "$endpoint" \
+            --content-type "application/json; charset=utf-8" \
+            --cache-control "public, max-age=300, stale-if-error=86400"
+          echo "Studio catalog -> $VERSION"

--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -1,0 +1,93 @@
+name: Studio
+
+# Studio's own surface — desktop/next (the Wails shell) and desktop/frontend-next
+# (the SPA it serves) — exists only on the studio branch, so it cannot live in
+# ci.yml without failing on main-v2 where neither directory is present. ci.yml
+# covers the kernel and the desktop module's Go side; this file covers the
+# frontend build and proves the shell still compiles on every platform it ships
+# to, which is the same command release-studio.yml runs.
+on:
+  push:
+    branches: [studio]
+  pull_request:
+    branches: [studio]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: studio-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: frontend-next
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: desktop/frontend-next
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6.0.9
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/frontend-next/pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: typecheck
+        run: pnpm typecheck
+
+      # `build` runs tsc -b before vite, so this also proves the project
+      # references resolve — typecheck alone uses --noEmit and does not.
+      - name: build
+        run: pnpm build
+
+      # The published bundle must not carry MockPort's scripted fixtures: a
+      # release that cannot reach the kernel has to say so, not act out a fake
+      # session. main.tsx guards the import behind import.meta.env.DEV, and this
+      # is what proves the guard still holds.
+      - name: no fixtures in the bundle
+        run: |
+          if grep -rl 网关瞬时态 dist/ 2>/dev/null; then
+            echo "::error::MockPort fixtures reached the production bundle - check the import.meta.env.DEV guard in main.tsx"
+            exit 1
+          fi
+
+  shell:
+    name: shell (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest, macos-latest]
+    defaults:
+      run:
+        working-directory: desktop
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: desktop/go.mod
+          cache: true
+          cache-dependency-path: desktop/go.sum
+
+      # WebKitGTK 4.1, matching what release-studio.yml links against: 4.0
+      # (libwebkit2gtk-4.0.so.37) is gone on Ubuntu 24.04+ and Fedora 40+.
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: build shell
+        run: bash ../scripts/studio-build.sh --shell-only

--- a/desktop/cmd/studio-manifest/main.go
+++ b/desktop/cmd/studio-manifest/main.go
@@ -1,0 +1,94 @@
+// Command studio-manifest writes Studio's latest.json from a directory of built
+// artifacts.
+//
+// cmd/sign's manifest subcommand cannot be reused: it is the desktop line's, so
+// it hardcodes desktop's download page and changelog URL, and its artifact
+// matcher drops any windows file that is not -installer.exe.
+//
+// Every artifact lands in downloads and none in platforms. That is the honest
+// state, not an oversight: the shared apply path names the desktop line's
+// release members (see update.ExtractReleaseUnit) and Windows installs through
+// NSIS, so Studio's portable archives have no install path yet. Filling
+// platforms is what turns self-update on, and it may only happen together with
+// an apply path that accepts this layout.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/desktop/internal/update"
+)
+
+const artifactPrefix = "ReasonixStudio-"
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintln(os.Stderr, "usage: studio-manifest <dir> <version> <tag>")
+		os.Exit(2)
+	}
+	if err := run(os.Args[1], os.Args[2], os.Args[3]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(dir, version, tag string) error {
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	if strings.TrimSpace(repo) == "" {
+		return fmt.Errorf("studio-manifest: GITHUB_REPOSITORY is unset, so asset URLs cannot be built")
+	}
+	page := fmt.Sprintf("https://github.com/%s/releases/tag/%s", repo, tag)
+	m := update.Manifest{
+		Version:         version,
+		DownloadPage:    page,
+		ReleaseNotesURL: page,
+		Platforms:       map[string]update.Asset{},
+		Downloads:       map[string]update.Asset{},
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, artifactPrefix) || strings.HasSuffix(name, ".minisig") {
+			continue
+		}
+		size, sum, err := hashFile(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+		url := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, name)
+		m.Downloads[name] = update.Asset{URL: url, Sig: url + ".minisig", Size: size, SHA256: sum}
+		fmt.Printf("download: %s (%d bytes)\n", name, size)
+	}
+	if len(m.Downloads) == 0 {
+		return fmt.Errorf("studio-manifest: no %s* artifacts in %s", artifactPrefix, dir)
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "latest.json"), append(b, '\n'), 0o644)
+}
+
+func hashFile(path string) (int64, string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	size, err := io.Copy(h, f)
+	if err != nil {
+		return 0, "", err
+	}
+	return size, hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/desktop/cmd/studio-manifest/main_test.go
+++ b/desktop/cmd/studio-manifest/main_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/desktop/internal/update"
+)
+
+func TestManifestRecordsEveryArtifactWithItsSignature(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_REPOSITORY", "esengine/DeepSeek-Reasonix")
+	body := []byte("studio archive bytes")
+	for _, name := range []string{
+		"ReasonixStudio-windows-amd64.zip",
+		"ReasonixStudio-darwin-universal.zip",
+		"ReasonixStudio-linux-amd64.tar.gz",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name+".minisig"), []byte("sig"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := run(dir, "v0.1.0", "studio-v0.1.0"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var m update.Manifest
+	raw, err := os.ReadFile(filepath.Join(dir, "latest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("the manifest must parse as the type the updater reads: %v", err)
+	}
+	if len(m.Downloads) != 3 {
+		t.Fatalf("downloads = %d, want the 3 archives (the .minisig files are not artifacts)", len(m.Downloads))
+	}
+	sum := sha256.Sum256(body)
+	for name, a := range m.Downloads {
+		if a.Sig != a.URL+".minisig" {
+			t.Errorf("%s: sig %q does not point at the artifact's signature", name, a.Sig)
+		}
+		if a.Size != int64(len(body)) {
+			t.Errorf("%s: size %d, want %d", name, a.Size, len(body))
+		}
+		if a.SHA256 != hex.EncodeToString(sum[:]) {
+			t.Errorf("%s: sha256 %q does not match the bytes on disk", name, a.SHA256)
+		}
+	}
+}
+
+// A manifest that lists a platform asset is a claim that this build can install
+// it, and the shared apply path cannot install Studio's archives yet. The claim
+// has to arrive with the apply path that honours it, not before.
+func TestManifestClaimsNoInstallableAsset(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_REPOSITORY", "esengine/DeepSeek-Reasonix")
+	if err := os.WriteFile(filepath.Join(dir, "ReasonixStudio-linux-amd64.tar.gz"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(dir, "v0.1.0", "studio-v0.1.0"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var m update.Manifest
+	raw, err := os.ReadFile(filepath.Join(dir, "latest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Platforms) != 0 {
+		t.Errorf("platforms = %v, want none until the apply path accepts Studio's layout", m.Platforms)
+	}
+	if m.DownloadPage == "" {
+		t.Error("with no installable asset the download page is the only way forward, and it is empty")
+	}
+}
+
+func TestEmptyDirIsAFailedRelease(t *testing.T) {
+	t.Setenv("GITHUB_REPOSITORY", "esengine/DeepSeek-Reasonix")
+	if err := run(t.TempDir(), "v0.1.0", "studio-v0.1.0"); err == nil {
+		t.Fatal("a release with no artifacts must fail, not publish an empty manifest")
+	}
+}

--- a/desktop/next/Info.plist.in
+++ b/desktop/next/Info.plist.in
@@ -1,0 +1,14 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleName</key><string>Reasonix Studio</string>
+    <key>CFBundleExecutable</key><string>ReasonixStudio</string>
+    <key>CFBundleIdentifier</key><string>io.reasonix.studio</string>
+    <key>CFBundleIconFile</key><string>appicon</string>
+    <key>CFBundleShortVersionString</key><string>@VERSION@</string>
+    <key>CFBundleVersion</key><string>@NUMVER@</string>
+    <key>LSMinimumSystemVersion</key><string>10.13.0</string>
+    <key>NSHighResolutionCapable</key><string>true</string>
+  </dict>
+</plist>

--- a/desktop/next/catalog_test.go
+++ b/desktop/next/catalog_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"reasonix/desktop/internal/update"
+)
+
+func TestStudioCatalogIsNotTheDesktopLine(t *testing.T) {
+	if studioCatalog == "" {
+		t.Fatal("studioCatalog is empty, so update.Options would fall back to the desktop catalog")
+	}
+	if studioCatalog == update.IndexURL {
+		t.Fatalf("studioCatalog is the desktop line's catalog (%q); its entries name desktop artifacts", update.IndexURL)
+	}
+}
+
+// The version panel and the installer each build their own update.Options, and
+// a release listed by one catalog cannot be installed from another. An Options
+// that omits IndexURL silently reads the desktop line, so this asserts on the
+// package's source rather than on any single call: the failure mode is a new
+// call site, not a changed one.
+func TestEveryUpdaterOptionsSetsIndexURL(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+	found := 0
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok || !isUpdateOptions(lit.Type) {
+					return true
+				}
+				found++
+				for _, elt := range lit.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					if id, ok := kv.Key.(*ast.Ident); ok && id.Name == "IndexURL" {
+						return true
+					}
+				}
+				t.Errorf("%s: update.Options does not set IndexURL, so it reads the desktop catalog", fset.Position(lit.Pos()))
+				return true
+			})
+		}
+	}
+	if found == 0 {
+		t.Fatal("no update.Options literal found; this guard is no longer watching anything")
+	}
+}
+
+func isUpdateOptions(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Options" {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "update"
+}

--- a/desktop/next/install.go
+++ b/desktop/next/install.go
@@ -56,13 +56,27 @@ func (a *App) GoToVersion(target string) error {
 	if err != nil {
 		return a.failUpdate(target, err)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
+	defer cancel()
+	// The shared apply path names the desktop line's release members
+	// (ExtractReleaseUnit), so Studio's manifest lists no installable asset yet.
+	// Ask it rather than assume: filling platforms is what turns self-update on.
+	m, err := u.ManifestFor(ctx, target)
+	if err != nil {
+		return a.failUpdate(target, err)
+	}
+	if _, ok := m.Asset(); !ok {
+		return a.failUpdate(target, fmt.Errorf("%s 没有 %s 的可安装包，请到 %s 手动下载", target, update.CurrentPlatform(), m.DownloadPage))
+	}
 	if err := a.PinVersion(target); err != nil {
 		return a.failUpdate(target, err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
-	defer cancel()
 	inst := update.VersionedInstaller{Layout: layout, Staging: dir, Current: version}
-	if err := u.Apply(ctx, target, inst, a.updateReport(target)); err != nil {
+	cached, err := u.DownloadManifest(ctx, m, a.updateReport(target))
+	if err != nil {
+		return a.failUpdate(target, err)
+	}
+	if err := inst.Install(ctx, cached); err != nil {
 		return a.failUpdate(target, err)
 	}
 	a.emit(UpdateProgress{Version: target, Phase: "relaunching"})
@@ -123,6 +137,7 @@ func studioUpdater(target, cacheDir string) (*update.Updater, error) {
 		HTTP:     client,
 		Fallback: v4,
 		CacheDir: cacheDir,
+		IndexURL: studioCatalog,
 		// Go's default user agent is what release-edge bot protection scores
 		// worst (#6005), and a 403 there looks like "no versions" to the panel.
 		UserAgent:      fmt.Sprintf("Reasonix-Studio/%s (%s/%s)", version, goruntime.GOOS, goruntime.GOARCH),

--- a/desktop/next/versions.go
+++ b/desktop/next/versions.go
@@ -15,6 +15,12 @@ import (
 // says so rather than pretending to be a release.
 var version = "dev"
 
+// studioCatalog is Studio's own rollback catalog, published by
+// release-studio.yml. Leaving it empty falls back to update.IndexURL, the
+// desktop line's catalog, whose entries name desktop artifacts — Studio would
+// offer to "update" itself into reasonix-desktop. Every Options here sets it.
+const studioCatalog = "https://dl.reasonix.io/studio/versions.json"
+
 // VersionEntry is one published release as the panel shows it.
 type VersionEntry struct {
 	Version     string `json:"version"`
@@ -54,7 +60,7 @@ func (a *App) Versions() VersionHub {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	st, err := update.New(update.Options{Current: version, Pinned: pinned, HTTP: client}).Check(ctx)
+	st, err := update.New(update.Options{Current: version, Pinned: pinned, HTTP: client, IndexURL: studioCatalog}).Check(ctx)
 	hub.Latest, hub.Newer, hub.StalePin = st.Latest, st.Newer, st.StalePin
 	hub.Versions = versionRows(st.Entries, version)
 	if err != nil {

--- a/docs/STUDIO_RELEASE.md
+++ b/docs/STUDIO_RELEASE.md
@@ -1,0 +1,109 @@
+# Releasing Reasonix Studio
+
+Studio ships from the `studio` branch, in parallel with `main-v2`. It is a
+preview line: it does not enter the website's download page, does not claim the
+repository-wide "latest" release, and does not touch the desktop line's rollback
+catalog. Nothing here changes how `main-v2` publishes.
+
+## Why it cannot use the stable pipeline
+
+`release-stable.yml` validates that the CLI, npm and desktop tags all point at a
+reviewed candidate on **main-v2 history**. Studio commits are never on that
+history, so they cannot pass its preflight — hence a separate line rather than a
+new input to the existing one.
+
+The same boundary applies to signing. The production SignPath policy allows
+exactly one origin (protected `main-v2`), which is what lets it avoid trusting
+wildcard tag-like branch names. A build from `studio` cannot request it, so
+**Windows artifacts are unsigned** and users see a SmartScreen warning. macOS
+artifacts are ad-hoc signed, not notarized: users clear the quarantine attribute
+with `xattr -dr com.apple.quarantine`.
+
+## One-time setup
+
+`release-studio.yml` gates publication on a GitHub environment named
+`studio-release`. Create it with the owner as a required reviewer:
+
+- Settings → Environments → New environment → `studio-release`
+- Required reviewers: the owner
+
+It reuses these existing repository secrets — none are Studio-specific:
+
+| Secret | Used for |
+| --- | --- |
+| `MINISIGN_PRIVATE_KEY`, `MINISIGN_PASSWORD` | detached signatures |
+| `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID`, `R2_BUCKET` | catalog + artifact mirror |
+
+The minisign key is deliberately the desktop line's: the public key that verifies
+it is compiled into the client (`update.PublicKey`), so a separate key would not
+verify. If R2 secrets are absent the GitHub release still publishes, but the
+catalog is not updated and running builds will not see the new version.
+
+## Cutting a release
+
+```bash
+git checkout studio
+git tag studio-v0.1.0
+git push origin studio-v0.1.0
+```
+
+The tag triggers `release-studio.yml`, which:
+
+1. validates the tag shape (`studio-vMAJOR.MINOR.PATCH[-PRERELEASE]`) and that
+   it sits on `studio` history;
+2. builds Windows x64, macOS universal and Linux x64 via
+   `scripts/studio-build.sh`;
+3. waits for the `studio-release` approval;
+4. minisign-signs every artifact and verifies each signature;
+5. generates `latest.json` with `desktop/cmd/studio-manifest`;
+6. publishes a GitHub **prerelease** (never `latest`);
+7. mirrors artifacts to `dl.reasonix.io/<tag>/` and updates
+   `dl.reasonix.io/studio/versions.json`.
+
+`workflow_dispatch` with an existing tag recovers a failed run.
+
+## R2 layout
+
+```
+dl.reasonix.io/
+  versions.json              # desktop line — release-studio.yml never writes this
+  studio/versions.json       # Studio's catalog; studioCatalog in desktop/next
+  studio-v0.1.0/…            # Studio artifacts, latest.json, signatures
+  desktop-v1.26.0/…          # desktop artifacts
+```
+
+Tag prefixes cannot collide because the tag names differ, so Studio artifacts sit
+beside desktop ones without a separate bucket.
+
+## Self-update is not available yet
+
+The version panel reads Studio's catalog and will show that a newer version
+exists, but installing it is not wired up, so `latest.json` lists artifacts under
+`downloads` and leaves `platforms` empty. Asking for a version then reports that
+no installable package exists for this platform and points at the download page.
+
+That is a property of the shared install path, not an oversight:
+
+- **Windows** installs through the NSIS updater (`installerCommand` passes `/D=`),
+  and Studio has no `wails.json`, so it produces no installer.
+- **Linux** reads fixed member names out of the tarball —
+  `update.ExtractReleaseUnit` requires `reasonix-desktop`, `reasonix-guard` and
+  `reasonix` — which Studio's archive does not contain.
+- **macOS** self-update additionally requires a Developer ID signature and
+  notarization (`update.MacSelfUpdate`), which this line cannot obtain.
+
+Turning self-update on means teaching the apply path Studio's layout and filling
+`platforms` in the same change. `desktop/cmd/studio-manifest`'s tests assert that
+the manifest claims nothing it cannot install, so the claim and the capability
+have to land together.
+
+## Known gaps
+
+- No Windows installer and no `versioninfo` stamp: `desktop/next` builds with
+  plain `go build`, not the Wails CLI. Windows x64 gets its icon from the
+  committed `rsrc_windows_amd64.syso`; **arm64 has no `.syso`, so it is not built**.
+- Giving `desktop/next` its own `wails.json` fixes the installer, the version
+  stamp and arm64 at once, and is the prerequisite for self-update. When doing
+  it, keep Studio's install directory and uninstall registry key distinct from
+  `reasonix-desktop` — sharing them would let installing Studio overwrite an
+  existing desktop install.

--- a/scripts/studio-build.sh
+++ b/scripts/studio-build.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Build Reasonix Studio (desktop/next + desktop/frontend-next) for one platform.
+#
+# Studio has no wails.json yet, so this drives `go build` directly rather than
+# the Wails CLI. That costs the NSIS installer and the versioninfo stamp the
+# desktop line gets for free (see docs/STUDIO_RELEASE.md), which is why the
+# Windows artifact here is a portable archive and not an updater-installable
+# installer. The Wails build tags are still required: without them the shell
+# opens a "will not build without the correct build tags" dialog at runtime
+# instead of failing to compile, so a missing tag ships silently.
+#
+# frontendAssets() resolves the SPA next to the executable first, so every
+# archive carries frontend-next/dist as a sibling of the binary. Nothing is
+# embedded; a binary shipped on its own cannot draw its UI.
+#
+# Usage:
+#   studio-build.sh --shell-only            compile the shell for the host (CI smoke)
+#   studio-build.sh <os/arch> <version>     full artifact into dist/
+#
+#   e.g. studio-build.sh windows/amd64 v0.1.0
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APPNAME="ReasonixStudio"
+BINNAME="reasonix-studio"
+# Wails v2 refuses to run without these; production also drops the devtools.
+TAGS="desktop production"
+
+# make_zip archives a staging directory's contents. Git for Windows ships no
+# `zip`, and this has to work both on a windows runner and on a maintainer's
+# machine, so the tool is whichever of the three is present rather than assumed.
+make_zip() {
+	local out="$1" src="$2"
+	rm -f "$out"
+	if command -v 7z >/dev/null 2>&1; then
+		(cd "$src" && 7z a -tzip -mx=9 "$out" . >/dev/null)
+	elif command -v zip >/dev/null 2>&1; then
+		(cd "$src" && zip -qr "$out" .)
+	elif command -v powershell >/dev/null 2>&1; then
+		powershell -NoProfile -Command \
+			"Compress-Archive -Path '$src/*' -DestinationPath '$out' -CompressionLevel Optimal"
+	else
+		echo "no zip tool found (need 7z, zip, or powershell)" >&2
+		return 1
+	fi
+	[ -f "$out" ] || {
+		echo "zip produced no $out" >&2
+		return 1
+	}
+}
+
+build_shell() {
+	local goos="$1" goarch="$2" version="$3" out="$4"
+	local ldflags="-s -w -X main.version=$version"
+	[ "$goos" = windows ] && ldflags="$ldflags -H windowsgui"
+	local args=(-trimpath -tags "$TAGS" -ldflags "$ldflags" -o "$out")
+	# WebKitGTK 4.1: 4.0 (libwebkit2gtk-4.0.so.37) is gone on Ubuntu 24.04+ and
+	# Fedora 40+, while 4.1 ships from Ubuntu 22.04 onward.
+	[ "$goos" = linux ] && args=(-tags "$TAGS webkit2_41" "${args[@]:2}")
+	echo "==> go build $goos/$goarch"
+	(cd "$ROOT/desktop" && GOOS="$goos" GOARCH="$goarch" go build "${args[@]}" ./next)
+}
+
+# CI smoke: the host's own platform, no frontend, no packaging. This is the
+# check that a kernel change did not break the shell's compile.
+if [ "${1:-}" = "--shell-only" ]; then
+	goos=$(cd "$ROOT/desktop" && go env GOOS)
+	goarch=$(cd "$ROOT/desktop" && go env GOARCH)
+	out="$ROOT/dist/$BINNAME-smoke"
+	[ "$goos" = windows ] && out="$out.exe"
+	mkdir -p "$ROOT/dist"
+	build_shell "$goos" "$goarch" dev "$out"
+	echo "==> ok: $out"
+	exit 0
+fi
+
+PLATFORM="${1:?usage: studio-build.sh <os/arch> <version> | --shell-only}"
+VERSION="${2:?usage: studio-build.sh <os/arch> <version> | --shell-only}"
+os="${PLATFORM%/*}"
+arch="${PLATFORM#*/}"
+
+echo "==> frontend"
+(cd "$ROOT/desktop/frontend-next" && pnpm install --frozen-lockfile && pnpm build)
+[ -f "$ROOT/desktop/frontend-next/dist/index.html" ] || {
+	echo "frontend build produced no dist/index.html" >&2
+	exit 1
+}
+
+staging=$(mktemp -d)
+trap 'rm -rf "$staging"' EXIT
+mkdir -p "$ROOT/dist"
+
+case "$os" in
+windows)
+	build_shell windows "$arch" "$VERSION" "$staging/$BINNAME.exe"
+	mkdir -p "$staging/frontend-next"
+	cp -R "$ROOT/desktop/frontend-next/dist" "$staging/frontend-next/dist"
+	make_zip "$ROOT/dist/${APPNAME}-windows-${arch}.zip" "$staging"
+	;;
+darwin)
+	# LaunchServices only treats a process as a GUI app inside a bundle with an
+	# Info.plist; a bare binary opens NSOpenPanel and loses focus in the same
+	# beat, which reads as a broken "Add a folder…". Same reason as run-studio.sh.
+	app="$staging/${APPNAME}.app"
+	mkdir -p "$app/Contents/MacOS/frontend-next" "$app/Contents/Resources"
+	if [ "$arch" = universal ]; then
+		build_shell darwin amd64 "$VERSION" "$staging/amd64"
+		build_shell darwin arm64 "$VERSION" "$staging/arm64"
+		lipo -create "$staging/amd64" "$staging/arm64" -output "$app/Contents/MacOS/$APPNAME"
+		rm -f "$staging/amd64" "$staging/arm64"
+	else
+		build_shell darwin "$arch" "$VERSION" "$app/Contents/MacOS/$APPNAME"
+	fi
+	cp -R "$ROOT/desktop/frontend-next/dist" "$app/Contents/MacOS/frontend-next/dist"
+	cp "$ROOT/desktop/next/appicon.icns" "$app/Contents/Resources/appicon.icns"
+	# CFBundleVersion must be strictly numeric, so a -preview.N tag keeps its
+	# full form in ldflags and contributes only its base here.
+	numver="${VERSION#v}"
+	numver="${numver%%-*}"
+	sed -e "s/@VERSION@/${VERSION#v}/g" -e "s/@NUMVER@/$numver/g" \
+		"$ROOT/desktop/next/Info.plist.in" >"$app/Contents/Info.plist"
+	# Ad-hoc signature only. Studio releases from the studio branch, and the
+	# production SignPath/Apple policies are bound to main-v2, so this is NOT
+	# notarized: users clear the quarantine attribute (docs/STUDIO_RELEASE.md).
+	codesign --force --deep -s - "$app"
+	ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-${arch}.zip"
+	;;
+linux)
+	build_shell linux "$arch" "$VERSION" "$staging/$BINNAME"
+	mkdir -p "$staging/frontend-next"
+	cp -R "$ROOT/desktop/frontend-next/dist" "$staging/frontend-next/dist"
+	tar -czf "$ROOT/dist/${APPNAME}-linux-${arch}.tar.gz" -C "$staging" .
+	;;
+*)
+	echo "unsupported os: $os" >&2
+	exit 1
+	;;
+esac
+
+echo "==> packaged into dist/:"
+ls -la "$ROOT/dist"


### PR DESCRIPTION
Studio releases from `studio` in parallel with `main-v2`: its own tag namespace, its own environment gate, its own rollback catalog. Nothing in main-v2's stable orchestration changes.

## Why a separate line

`release-stable.yml` validates that every tag it publishes sits on **main-v2 history**, which studio commits never do, so they cannot pass its preflight. The same boundary applies to signing: the production SignPath policy allows exactly one origin (protected `main-v2`), which is what lets it avoid trusting wildcard tag-like branch names. Windows artifacts from this branch are therefore unsigned.

## What lands

**CI covers this branch at all.** `ci.yml` triggered on `main-v2` only, so the 178 commits here — most of them kernel changes — had never run it. Adding `studio` to `push`/`pull_request` gives them the same kernel gates main-v2 has.

**Studio's own surface gets its own file.** `desktop/next` and `desktop/frontend-next` exist only on this branch, so covering them inside `ci.yml` would fail on main-v2 where neither directory is present. `studio.yml` runs the frontend's typecheck and build, asserts MockPort's fixtures stay out of the bundle, and compiles the shell on all three platforms with the same command the release uses.

**A self-update bug that would have shipped.** `Versions()` and `studioUpdater()` both left `IndexURL` empty, which falls back to `update.IndexURL` — the desktop line's catalog. A Studio release would have listed desktop versions and offered to "update" users into reasonix-desktop. Both now read `studio/versions.json`, and an AST guard fails if a new `update.Options` in that package omits it (verified by probe: it reports the offending file and line).

**`release-studio.yml`**: `studio-v*` tag → validate tag shape and studio ancestry → build 3 platforms → `studio-release` approval → minisign → GitHub prerelease → mirror to R2. It never writes the root `versions.json` and never claims the repository-wide latest. `scripts/update-versions-index.sh` is reused unchanged: Studio's tag prefix already isolates its manifest URL.

## Self-update stays off, deliberately

`latest.json` lists artifacts under `downloads` and leaves `platforms` empty, because the shared apply path is the desktop line's:

- Windows installs through the NSIS updater (`installerCommand` passes `/D=`), and `desktop/next` has no `wails.json`, so it produces no installer.
- Linux reads fixed member names out of the tarball — `ExtractReleaseUnit` requires `reasonix-desktop`, `reasonix-guard`, `reasonix`.
- macOS additionally requires Developer ID signing and notarization (`update.MacSelfUpdate`).

Claiming a platform asset would make "switch version" download an archive and then fail to install it. `GoToVersion` now asks the manifest whether this platform has an installable asset and points at the download page when it does not — by structure, not by matching an error string. `studio-manifest`'s tests assert the manifest claims nothing it cannot install, so the claim and the capability have to land together.

## Owner action required

Create a `studio-release` GitHub environment with yourself as a required reviewer; the publish job gates on it. Everything else reuses existing repository secrets — including the desktop line's minisign key, because the public key that verifies it is compiled into the client.

## Verification

- `go test ./next/ ./cmd/studio-manifest/` (desktop module) passes; the IndexURL guard was probe-tested to fail on a missing field
- `go vet`, `gofmt`, and diff-scoped `repolint` clean
- all three workflow files parse as YAML; `scripts/release-workflows.test.sh` passes
- `bash -n scripts/studio-build.sh`
- Not verified locally: the release workflow end to end. It needs the `studio-release` environment and R2 credentials, so the first real tag is its own first test.

Documentation-impact: updated - docs/STUDIO_RELEASE.md is new: the release procedure, the environment and secret setup, the R2 layout, why self-update is off, and the wails.json prerequisite for turning it on.
