### PR TITLE
feat(evidence): record runway as shadow-only telemetry / 将 runway 作为纯影子遥测记录

### DIFF
--- a/cmd/e2ebench/outcome.go
+++ b/cmd/e2ebench/outcome.go
@@ -48,15 +48,28 @@ type outcomeSummary struct {
 	GovernorEligibleRounds int `json:"governor_eligible_rounds,omitempty"`
 	GovernorEngagedRounds  int `json:"governor_engaged_rounds,omitempty"`
 	GovernorFirstRound     int `json:"governor_first_round,omitempty"`
+
+	// Runway shadow fields are absent for trajectories recorded before the
+	// experiment. FirstSpentRound is the counterfactual intervention point.
+	RunwaySamples         int `json:"runway_samples,omitempty"`
+	RunwayMin             int `json:"runway_min,omitempty"`
+	RunwayFinal           int `json:"runway_final,omitempty"`
+	RunwayDryMax          int `json:"runway_dry_max,omitempty"`
+	RunwayIdleMax         int `json:"runway_idle_max,omitempty"`
+	RunwayFirstSpentRound int `json:"runway_first_spent_round,omitempty"`
 }
 
 // outcomePoint is one recorded shadow sample plus its observation time.
 type outcomePoint struct {
 	ts                                                      int64
+	round                                                   int
 	exploration, verification, objective, regression, churn int
 	legacyGain, discriminating, debtAge, blindMutations     int
 	ebmEligible, ebmFired                                   bool
 	governorEligible, governorEngaged                       bool
+	runway                                                  *int
+	runwayDry, runwayIdle                                   int
+	runwaySpent                                             bool
 }
 
 // verifyPoint is one backfilled verification-transition observation.
@@ -108,7 +121,7 @@ func summarizeOutcomePoints(points []outcomePoint, firstTS, lastTS int64) *outco
 	verifying, solution, stall := false, false, 0
 	score, best := 0, 0
 	var bestTS int64
-	for _, p := range points {
+	for i, p := range points {
 		if p.verification > 0 {
 			verifying = true
 		}
@@ -120,6 +133,22 @@ func summarizeOutcomePoints(points []outcomePoint, firstTS, lastTS int64) *outco
 		o.Regression += p.regression
 		if p.legacyGain > 0 {
 			o.ProgressRounds++
+		}
+		if p.runway != nil {
+			if o.RunwaySamples == 0 {
+				o.RunwayMin = *p.runway
+			}
+			o.RunwaySamples++
+			o.RunwayMin = min(o.RunwayMin, *p.runway)
+			o.RunwayFinal = *p.runway
+			o.RunwayDryMax = max(o.RunwayDryMax, p.runwayDry)
+			o.RunwayIdleMax = max(o.RunwayIdleMax, p.runwayIdle)
+			if o.RunwayFirstSpentRound == 0 && p.runwaySpent {
+				o.RunwayFirstSpentRound = p.round
+				if o.RunwayFirstSpentRound == 0 {
+					o.RunwayFirstSpentRound = i + 1
+				}
+			}
 		}
 		// The solution stall clock only starts once the run enters its solution
 		// phase (a verification attempt or a mutation); pure research runs with
@@ -354,6 +383,7 @@ func renderOutcomeProgress(results []result) string {
 		}
 	}
 	line += governorShadowLine(results)
+	line += runwayShadowLine(results)
 	if progress > 0 {
 		line += fmt.Sprintf(" · **false progress** %d/%d (%s)", falseProgress, progress, pct(falseProgress, progress))
 	}
@@ -367,4 +397,30 @@ func renderOutcomeProgress(results []result) string {
 		line += fmt.Sprintf(" · backfilled %d", backfilled)
 	}
 	return line + "\n\n"
+}
+
+func runwayShadowLine(results []result) string {
+	measured, spent, dryMax, idleMax := 0, 0, 0, 0
+	var spentRounds []int64
+	for _, r := range results {
+		if r.Trajectory == nil || r.Trajectory.Outcome == nil || r.Trajectory.Outcome.RunwaySamples == 0 {
+			continue
+		}
+		o := r.Trajectory.Outcome
+		measured++
+		dryMax = max(dryMax, o.RunwayDryMax)
+		idleMax = max(idleMax, o.RunwayIdleMax)
+		if o.RunwayFirstSpentRound > 0 {
+			spent++
+			spentRounds = append(spentRounds, int64(o.RunwayFirstSpentRound))
+		}
+	}
+	if measured == 0 {
+		return ""
+	}
+	line := fmt.Sprintf(" · **runway shadow** would spend in %d/%d runs (%s)", spent, measured, pct(spent, measured))
+	if spent > 0 {
+		line += fmt.Sprintf(" at median round %d", median(spentRounds))
+	}
+	return fmt.Sprintf("%s · max dry/idle %d/%d", line, dryMax, idleMax)
 }

--- a/cmd/e2ebench/outcome_test.go
+++ b/cmd/e2ebench/outcome_test.go
@@ -126,6 +126,46 @@ func TestSummarizeOutcomeTracksDebtAndTTFDC(t *testing.T) {
 	}
 }
 
+func TestSummarizeRunwayShadowDistinguishesOldDataFromZeroBalance(t *testing.T) {
+	path := writeTrajectory(t, "runway.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,
+		`{"seq":2,"ts":2000,"outcome_progress":{"round":1,"runway":8,"runway_dry":4,"runway_idle":4}}`,
+		`{"seq":3,"ts":3000,"outcome_progress":{"round":2,"runway":4,"runway_dry":5,"runway_idle":5}}`,
+		`{"seq":4,"ts":4000,"outcome_progress":{"round":3,"runway":0,"runway_dry":6,"runway_idle":6,"runway_spent":true}}`,
+	})
+	s, err := summarizeTrajectory(path)
+	if err != nil {
+		t.Fatalf("summarizeTrajectory: %v", err)
+	}
+	o := s.Outcome
+	if o == nil || o.RunwaySamples != 3 || o.RunwayMin != 0 || o.RunwayFinal != 0 || o.RunwayFirstSpentRound != 3 {
+		t.Fatalf("runway summary = %+v, want 3 samples and spent at round 3", o)
+	}
+	if o.RunwayDryMax != 6 || o.RunwayIdleMax != 6 {
+		t.Fatalf("runway maxima = dry %d idle %d, want 6/6", o.RunwayDryMax, o.RunwayIdleMax)
+	}
+	got := renderOutcomeProgress([]result{{Trajectory: s}})
+	for _, want := range []string{"**runway shadow** would spend in 1/1 runs (100%)", "median round 3", "max dry/idle 6/6"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("render missing %q in:\n%s", want, got)
+		}
+	}
+
+	old := writeTrajectory(t, "pre-runway.trajectory.jsonl", []string{
+		`{"seq":1,"ts":1000,"outcome_progress":{"round":1,"exploration":1}}`,
+	})
+	legacy, err := summarizeTrajectory(old)
+	if err != nil {
+		t.Fatalf("summarize old trajectory: %v", err)
+	}
+	if legacy.Outcome == nil || legacy.Outcome.RunwaySamples != 0 {
+		t.Fatalf("old outcome = %+v, want no runway observations", legacy.Outcome)
+	}
+	if strings.Contains(renderOutcomeProgress([]result{{Trajectory: legacy}}), "runway shadow") {
+		t.Fatal("old trajectory was misclassified as a spent runway")
+	}
+}
+
 func TestSummarizeOutcomeDerivesEBMChain(t *testing.T) {
 	path := writeTrajectory(t, "ebm.trajectory.jsonl", []string{
 		`{"seq":1,"ts":1000,"event":{"kind":"turn_started"}}`,

--- a/cmd/e2ebench/trajectory.go
+++ b/cmd/e2ebench/trajectory.go
@@ -159,6 +159,7 @@ type trajectoryRecord struct {
 		ClaimsUnbacked int      `json:"claims_unbacked"`
 	} `json:"completion_report"`
 	OutcomeProgress *struct {
+		Round            int  `json:"round"`
 		Exploration      int  `json:"exploration"`
 		Verification     int  `json:"verification"`
 		Objective        int  `json:"objective"`
@@ -173,6 +174,10 @@ type trajectoryRecord struct {
 		LocalExecSeen    bool `json:"local_exec_seen"`
 		GovernorEligible bool `json:"governor_eligible"`
 		GovernorEngaged  bool `json:"governor_engaged"`
+		Runway           *int `json:"runway"`
+		RunwayDry        int  `json:"runway_dry"`
+		RunwayIdle       int  `json:"runway_idle"`
+		RunwaySpent      bool `json:"runway_spent"`
 	} `json:"outcome_progress"`
 	DelegationAdmission *struct {
 		Tool    string `json:"tool"`
@@ -380,11 +385,12 @@ func (t *trajScan) record(rec trajectoryRecord) {
 	}
 	if op := rec.OutcomeProgress; op != nil {
 		t.outcomePoints = append(t.outcomePoints, outcomePoint{
-			ts: rec.TS, exploration: op.Exploration, verification: op.Verification,
+			ts: rec.TS, round: op.Round, exploration: op.Exploration, verification: op.Verification,
 			objective: op.Objective, regression: op.Regression, churn: op.Churn,
 			legacyGain: op.LegacyGain, discriminating: op.Discriminating, debtAge: op.DebtAge,
 			blindMutations: op.BlindMutations, ebmEligible: op.EBMEligible, ebmFired: op.EBMFired,
 			governorEligible: op.GovernorEligible, governorEngaged: op.GovernorEngaged,
+			runway: op.Runway, runwayDry: op.RunwayDry, runwayIdle: op.RunwayIdle, runwaySpent: op.RunwaySpent,
 		})
 	}
 	if da := rec.DelegationAdmission; da != nil {

--- a/internal/agent/fork.go
+++ b/internal/agent/fork.go
@@ -17,15 +17,19 @@ import (
 // Versioned from day one: this format is shared infrastructure for every
 // policy experiment (EBM, reasoning governor, delegation admission, rollback).
 type ForkBundle struct {
-	Version       int                `json:"version"`
-	Policy        string             `json:"policy"`
-	Input         string             `json:"input"`
-	EligibleRound int                `json:"eligible_round"`
-	BlindAtFork   int                `json:"blind_at_fork"`
-	DebtAtFork    int                `json:"debt_at_fork"`
-	MutatedBases  []string           `json:"mutated_bases,omitempty"`
-	LocalExecSeen bool               `json:"local_exec_seen,omitempty"`
-	Messages      []provider.Message `json:"messages"`
+	Version        int                `json:"version"`
+	Policy         string             `json:"policy"`
+	Input          string             `json:"input"`
+	EligibleRound  int                `json:"eligible_round"`
+	BlindAtFork    int                `json:"blind_at_fork"`
+	DebtAtFork     int                `json:"debt_at_fork"`
+	MutatedBases   []string           `json:"mutated_bases,omitempty"`
+	LocalExecSeen  bool               `json:"local_exec_seen,omitempty"`
+	RunwayBalance  int                `json:"runway_balance,omitempty"`
+	RunwayDry      int                `json:"runway_dry,omitempty"`
+	RunwayIdle     int                `json:"runway_idle,omitempty"`
+	RunwayObserved bool               `json:"runway_observed,omitempty"`
+	Messages       []provider.Message `json:"messages"`
 }
 
 const forkBundleVersion = 1
@@ -105,7 +109,10 @@ func (p *forkCaptureProvider) Stream(ctx context.Context, req provider.Request) 
 			Input:         forkTurnInput(messages),
 			EligibleRound: a.task.ebm.captureRound, BlindAtFork: seed.BlindMutations,
 			DebtAtFork: seed.DebtAge, MutatedBases: seed.MutatedBases,
-			LocalExecSeen: seed.LocalExecSeen, Messages: messages,
+			LocalExecSeen: seed.LocalExecSeen,
+			RunwayBalance: seed.RunwayBalance, RunwayDry: seed.RunwayDry,
+			RunwayIdle: seed.RunwayIdle, RunwayObserved: seed.RunwayObserved,
+			Messages: messages,
 		}
 		if err := writeForkBundle(os.Getenv("REASONIX_EXPERIMENT_FORK_CAPTURE_DIR"), b); err != nil {
 			fmt.Fprintln(os.Stderr, "fork capture:", err)
@@ -222,6 +229,8 @@ func (a *Agent) armForkContinuation(b *ForkBundle, nudge string) {
 		a.task.outcome = evidence.RestoreOutcomeTracker(evidence.OutcomeSeed{
 			MutatedBases: b.MutatedBases, DebtAge: b.DebtAtFork,
 			BlindMutations: b.BlindAtFork, LocalExecSeen: b.LocalExecSeen,
+			RunwayBalance: b.RunwayBalance, RunwayDry: b.RunwayDry,
+			RunwayIdle: b.RunwayIdle, RunwayObserved: b.RunwayObserved,
 		})
 		a.task.ebm = ebmState{fired: true, captured: true, captureRound: b.EligibleRound}
 	}

--- a/internal/agent/fork_test.go
+++ b/internal/agent/fork_test.go
@@ -55,6 +55,9 @@ func TestForkControlContinuationMatchesOriginalRequest(t *testing.T) {
 	if b.BlindAtFork != 3 || b.DebtAtFork == 0 || b.EligibleRound != 3 {
 		t.Fatalf("bundle = blind %d debt %d round %d, want 3/>0/3", b.BlindAtFork, b.DebtAtFork, b.EligibleRound)
 	}
+	if !b.RunwayObserved || b.RunwayBalance <= 0 {
+		t.Fatalf("bundle runway = observed %v balance %d, want an observed solvent account", b.RunwayObserved, b.RunwayBalance)
+	}
 	if b.Input != "fix the widget" {
 		t.Fatalf("bundle input = %q", b.Input)
 	}
@@ -75,6 +78,20 @@ func TestForkControlContinuationMatchesOriginalRequest(t *testing.T) {
 	want, got := orig.requests[3], cont.requests[0]
 	if !reflect.DeepEqual(want.Messages, got.Messages) {
 		t.Fatalf("control fork payload diverged from original continuation:\nwant %d messages\ngot  %d messages", len(want.Messages), len(got.Messages))
+	}
+}
+
+func TestLoadLegacyForkBundleLeavesRunwayUnobserved(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-bundle.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"policy":"ebm","input":"x","messages":[]}`), 0o600); err != nil {
+		t.Fatalf("write legacy bundle: %v", err)
+	}
+	b, err := LoadForkBundle(path)
+	if err != nil {
+		t.Fatalf("LoadForkBundle: %v", err)
+	}
+	if b.RunwayObserved || b.RunwayBalance != 0 || b.RunwayDry != 0 || b.RunwayIdle != 0 {
+		t.Fatalf("legacy runway fields = %+v, want unobserved zero values", b)
 	}
 }
 

--- a/internal/agent/progress_guard_test.go
+++ b/internal/agent/progress_guard_test.go
@@ -95,9 +95,13 @@ func TestOutcomeShadowRecordsEveryRoundWithoutTouchingGuards(t *testing.T) {
 	}
 	if s := sink.samples[0]; s.Round != 1 || s.Exploration != 1 || s.Objective != 0 {
 		t.Fatalf("round 1 sample = %+v, want exploration 1 objective 0", s)
+	} else if s.Runway != 23 || s.RunwayDry != 0 || s.RunwayIdle != 1 || s.RunwaySpent {
+		t.Fatalf("round 1 runway = %+v, want balance 23, idle 1", s)
 	}
 	if s := sink.samples[1]; s.Round != 2 || s.Exploration != 0 || s.LegacyGain != 0 {
 		t.Fatalf("round 2 repeat sample = %+v, want all-zero with legacy gain 0", s)
+	} else if s.Runway != 19 || s.RunwayDry != 1 || s.RunwayIdle != 2 || s.RunwaySpent {
+		t.Fatalf("round 2 runway = %+v, want balance 19, dry 1, idle 2", s)
 	}
 	// The shadow observes; the guard alone decides. Round texts stay untouched
 	// below the nudge threshold exactly as before.

--- a/internal/evidence/outcome.go
+++ b/internal/evidence/outcome.go
@@ -46,6 +46,12 @@ type OutcomeSample struct {
 	// eligibility is stamped on every arm so baselines carry the shadow.
 	GovernorEligible bool
 	GovernorEngaged  bool
+	// Runway fields are a telemetry-only counterfactual stamped by the outcome
+	// shadow. No runtime guard or provider-visible message reads them.
+	Runway      int
+	RunwayDry   int
+	RunwayIdle  int
+	RunwaySpent bool
 }
 
 // OutcomeTracker is the shadow counterpart of ProgressTracker: same per-round
@@ -65,6 +71,7 @@ type OutcomeTracker struct {
 	debtAge      int
 	blind        int
 	localExec    bool
+	runway       runwayShadow
 }
 
 // OutcomeSeed is the fork-portable slice of tracker state: what a
@@ -74,12 +81,20 @@ type OutcomeSeed struct {
 	DebtAge        int      `json:"debt_age"`
 	BlindMutations int      `json:"blind_mutations"`
 	LocalExecSeen  bool     `json:"local_exec_seen"`
+	RunwayBalance  int      `json:"runway_balance,omitempty"`
+	RunwayDry      int      `json:"runway_dry,omitempty"`
+	RunwayIdle     int      `json:"runway_idle,omitempty"`
+	RunwayObserved bool     `json:"runway_observed,omitempty"`
 }
 
 // ForkSeed exports the state a counterfactual fork must carry so post-fork
 // discriminating detection stays continuous with the original run.
 func (t *OutcomeTracker) ForkSeed() OutcomeSeed {
-	seed := OutcomeSeed{DebtAge: t.debtAge, BlindMutations: t.blind, LocalExecSeen: t.localExec}
+	seed := OutcomeSeed{
+		DebtAge: t.debtAge, BlindMutations: t.blind, LocalExecSeen: t.localExec,
+		RunwayBalance: t.runway.balance, RunwayDry: t.runway.dry,
+		RunwayIdle: t.runway.idle, RunwayObserved: t.runway.observed,
+	}
 	for base := range t.mutatedBases {
 		seed.MutatedBases = append(seed.MutatedBases, base)
 	}
@@ -99,6 +114,10 @@ func RestoreOutcomeTracker(seed OutcomeSeed) *OutcomeTracker {
 	t.blind = seed.BlindMutations
 	t.debt = seed.DebtAge > 0 || seed.BlindMutations > 0
 	t.localExec = seed.LocalExecSeen
+	t.runway = runwayShadow{
+		balance: seed.RunwayBalance, dry: seed.RunwayDry,
+		idle: seed.RunwayIdle, observed: seed.RunwayObserved,
+	}
 	return t
 }
 
@@ -143,6 +162,9 @@ func (t *OutcomeTracker) ScoreRound(receipts []Receipt) OutcomeSample {
 	s.DebtAge = t.debtAge
 	s.BlindMutations = t.blind
 	s.LocalExecSeen = t.localExec
+	runway := t.runway.observe(s)
+	s.Runway, s.RunwayDry, s.RunwayIdle, s.RunwaySpent =
+		runway.balance, runway.dry, runway.idle, runway.spent
 	return s
 }
 

--- a/internal/evidence/outcome_test.go
+++ b/internal/evidence/outcome_test.go
@@ -2,6 +2,7 @@ package evidence
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -112,5 +113,38 @@ func TestOutcomeTrackerVerificationDebtLifecycle(t *testing.T) {
 	// counts as discriminating without any mutated-path match.
 	if s := tr.ScoreRound([]Receipt{bashReceipt("go test ./pkg", true)}); s.Discriminating != 1 || s.DebtAge != 0 {
 		t.Fatalf("verification round = %+v, want discriminating 1, no debt", s)
+	}
+}
+
+func TestOutcomeTrackerCarriesRunwayShadowAcrossForks(t *testing.T) {
+	tracker := NewOutcomeTracker()
+	var before OutcomeSample
+	for range 5 {
+		before = tracker.ScoreRound(nil)
+	}
+	if before.Runway != runwayRoundCost || before.RunwaySpent {
+		t.Fatalf("pre-fork runway = %+v, want one empty round remaining", before)
+	}
+
+	restored := RestoreOutcomeTracker(tracker.ForkSeed())
+	after := restored.ScoreRound(nil)
+	if after.Runway != 0 || !after.RunwaySpent || after.RunwayDry != 6 || after.RunwayIdle != 6 {
+		t.Fatalf("post-fork runway = %+v, want continuous spent transition", after)
+	}
+}
+
+func TestRunwayShadowDoesNotReplaceTheLiveNoveltyScorer(t *testing.T) {
+	tracker := NewOutcomeTracker()
+	var sample OutcomeSample
+	for i := range explorationRunLimit + 1 {
+		read := readReceipt(fmt.Sprintf("file-%d.go", i))
+		read.OutputBytes = 1
+		sample = tracker.ScoreRound([]Receipt{read})
+	}
+	if sample.Exploration != 1 || sample.LegacyGain != 0 {
+		t.Fatalf("comparison sample = %+v, want outcome exploration while the unchanged live scorer is zero", sample)
+	}
+	if sample.Runway != runwayStartBalance-(explorationRunLimit+1) {
+		t.Fatalf("runway balance = %d, want independent shadow accounting", sample.Runway)
 	}
 }

--- a/internal/evidence/runway_shadow.go
+++ b/internal/evidence/runway_shadow.go
@@ -1,0 +1,70 @@
+package evidence
+
+// The runway shadow prices one turn's investigation without changing any
+// runtime decision. Every round costs the same; observable outcomes buy some
+// or all of that cost back. Keeping the account private to OutcomeTracker makes
+// the experiment telemetry-only until recorded data justifies a policy change.
+const (
+	runwayRoundCost        = 4
+	runwayYieldFalsifiable = 3 * runwayRoundCost
+	runwayYieldChange      = runwayRoundCost
+	runwayYieldExploration = runwayRoundCost - 1
+
+	// In exploration-rate units, a fresh account covers 24 productive reads and
+	// a fully banked one covers 40. A round producing nothing burns four units.
+	runwayStartBalance = 24
+	runwayMaxBalance   = 40
+)
+
+type runwayShadow struct {
+	balance  int
+	observed bool
+	dry      int
+	idle     int
+}
+
+type runwayShadowState struct {
+	balance int
+	dry     int
+	idle    int
+	spent   bool
+}
+
+func (r *runwayShadow) observe(s OutcomeSample) runwayShadowState {
+	if !r.observed {
+		r.balance, r.observed = runwayStartBalance, true
+	}
+	yield := runwayYield(s)
+	wasSolvent := r.balance > 0
+	r.balance = min(max(r.balance+yield-runwayRoundCost, 0), runwayMaxBalance)
+
+	if s.Discriminating > 0 || s.Objective > 0 || s.Churn > 0 {
+		r.idle = 0
+	} else {
+		r.idle++
+	}
+	if yield > 0 {
+		r.dry = 0
+	} else {
+		r.dry++
+	}
+	return runwayShadowState{
+		balance: r.balance,
+		dry:     r.dry,
+		idle:    r.idle,
+		spent:   wasSolvent && r.balance == 0,
+	}
+}
+
+func runwayYield(s OutcomeSample) int {
+	switch {
+	case s.Discriminating > 0 || s.Objective > 0:
+		return runwayYieldFalsifiable
+	case s.Churn > 0:
+		return runwayYieldChange
+	case s.Exploration > 0:
+		return runwayYieldExploration
+	default:
+		return 0
+	}
+}

--- a/internal/evidence/runway_shadow_test.go
+++ b/internal/evidence/runway_shadow_test.go
@@ -1,0 +1,57 @@
+package evidence
+
+import "testing"
+
+func drainRunwayShadow(r *runwayShadow, sample OutcomeSample) int {
+	for round := 1; round <= 100; round++ {
+		if r.observe(sample).spent {
+			return round
+		}
+	}
+	return -1
+}
+
+func TestRunwayShadowPricesOutcomesWithoutAFixedRoundCliff(t *testing.T) {
+	var repeating runwayShadow
+	if got := drainRunwayShadow(&repeating, OutcomeSample{}); got != runwayStartBalance/runwayRoundCost {
+		t.Errorf("empty rounds lasted %d, want %d", got, runwayStartBalance/runwayRoundCost)
+	}
+
+	var exploring runwayShadow
+	if got := drainRunwayShadow(&exploring, OutcomeSample{Exploration: 1}); got != runwayStartBalance {
+		t.Errorf("exploration rounds lasted %d, want %d", got, runwayStartBalance)
+	}
+
+	for name, sample := range map[string]OutcomeSample{
+		"changing": {Churn: 1},
+		"checking": {Discriminating: 1},
+	} {
+		var productive runwayShadow
+		if got := drainRunwayShadow(&productive, sample); got != -1 {
+			t.Errorf("%s account spent after %d rounds", name, got)
+		}
+	}
+}
+
+func TestRunwayShadowIsBoundedAndSeparatesDryFromIdle(t *testing.T) {
+	var r runwayShadow
+	for range 100 {
+		r.observe(OutcomeSample{Discriminating: 1})
+	}
+	if got := drainRunwayShadow(&r, OutcomeSample{Exploration: 1}); got != runwayMaxBalance {
+		t.Errorf("banked account lasted %d exploration rounds, want %d", got, runwayMaxBalance)
+	}
+
+	var counts runwayShadow
+	for range 3 {
+		counts.observe(OutcomeSample{Exploration: 1})
+	}
+	state := counts.observe(OutcomeSample{})
+	if state.idle != 4 || state.dry != 1 {
+		t.Fatalf("quiet round state = %+v, want idle 4 dry 1", state)
+	}
+	state = counts.observe(OutcomeSample{Churn: 1})
+	if state.idle != 0 || state.dry != 0 {
+		t.Fatalf("change state = %+v, want cleared counters", state)
+	}
+}

--- a/internal/trajectory/recorder.go
+++ b/internal/trajectory/recorder.go
@@ -80,6 +80,12 @@ type OutcomeProgress struct {
 	LocalExecSeen    bool `json:"local_exec_seen,omitempty"`
 	GovernorEligible bool `json:"governor_eligible,omitempty"`
 	GovernorEngaged  bool `json:"governor_engaged,omitempty"`
+	// Runway is a pointer so old records (nil: not observed) stay distinct from
+	// a new record whose counterfactual account genuinely reached zero.
+	Runway      *int `json:"runway,omitempty"`
+	RunwayDry   int  `json:"runway_dry,omitempty"`
+	RunwayIdle  int  `json:"runway_idle,omitempty"`
+	RunwaySpent bool `json:"runway_spent,omitempty"`
 }
 
 // ContractShadowAudit mirrors event.ContractShadowAudit with stable keys.
@@ -246,6 +252,7 @@ func (r *Recorder) RecordCompletionReport(a event.CompletionReportAudit) {
 }
 
 func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
+	runway := sample.Runway
 	r.append(Record{OutcomeProgress: &OutcomeProgress{
 		Round:            sample.Round,
 		Exploration:      sample.Exploration,
@@ -262,6 +269,10 @@ func (r *Recorder) RecordOutcomeProgress(sample evidence.OutcomeSample) {
 		LocalExecSeen:    sample.LocalExecSeen,
 		GovernorEligible: sample.GovernorEligible,
 		GovernorEngaged:  sample.GovernorEngaged,
+		Runway:           &runway,
+		RunwayDry:        sample.RunwayDry,
+		RunwayIdle:       sample.RunwayIdle,
+		RunwaySpent:      sample.RunwaySpent,
 	}})
 	event.RecordOutcomeProgress(r.inner, sample)
 }

--- a/internal/trajectory/recorder_test.go
+++ b/internal/trajectory/recorder_test.go
@@ -121,7 +121,10 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	r.RecordReadinessAudit(evidence.ReadinessAudit{Result: evidence.ReadinessBlocked, MissingVerification: 2})
 	r.RecordProtocolRecovery(event.ProtocolRecoveryAudit{Kind: event.ProtocolRecoveryMissingReasoningDetected})
 	r.RecordTurnCompletion()
-	r.RecordOutcomeProgress(evidence.OutcomeSample{Round: 3, Exploration: 2, Objective: 1, LegacyGain: 4})
+	r.RecordOutcomeProgress(evidence.OutcomeSample{
+		Round: 3, Exploration: 2, Objective: 1, LegacyGain: 4,
+		Runway: 0, RunwayDry: 6, RunwayIdle: 6, RunwaySpent: true,
+	})
 	r.RecordDelegationAdmission(event.DelegationAdmissionAudit{Tool: "research", Verdict: "deny", Reason: "local_fix_no_external_need", Intent: "mutation"})
 	r.RecordCompletionReport(event.CompletionReportAudit{
 		Verdict: "partial", Changes: 2, ChangesUnreviewed: 1, Gaps: 1, GapKinds: []string{"unreviewed_change"},
@@ -148,6 +151,9 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	if recs[3].OutcomeProgress == nil || recs[3].OutcomeProgress.Round != 3 || recs[3].OutcomeProgress.Objective != 1 || recs[3].OutcomeProgress.LegacyGain != 4 {
 		t.Errorf("outcome progress record = %+v", recs[3].OutcomeProgress)
 	}
+	if rec := recs[3].OutcomeProgress; rec.Runway == nil || *rec.Runway != 0 || rec.RunwayDry != 6 || rec.RunwayIdle != 6 || !rec.RunwaySpent {
+		t.Errorf("runway shadow record = %+v, want explicit spent balance", rec)
+	}
 	if recs[4].DelegationAdmission == nil || recs[4].DelegationAdmission.Verdict != "deny" || recs[4].DelegationAdmission.Tool != "research" {
 		t.Errorf("delegation admission record = %+v", recs[4].DelegationAdmission)
 	}
@@ -159,6 +165,37 @@ func TestRecorderRecordsAndForwardsOptionalCapabilities(t *testing.T) {
 	}
 	if len(inner.readiness) != 1 || len(inner.recoveries) != 1 || inner.turns != 1 || len(inner.outcomes) != 1 || len(inner.reports) != 1 {
 		t.Errorf("inner capabilities = %d/%d/%d/%d/%d, want 1/1/1/1/1", len(inner.readiness), len(inner.recoveries), inner.turns, len(inner.outcomes), len(inner.reports))
+	}
+}
+
+func TestOutcomeProgressRunwayIsAdditiveAndPresenceAware(t *testing.T) {
+	var old Record
+	if err := json.Unmarshal([]byte(`{"schema_version":1,"outcome_progress":{"round":1}}`), &old); err != nil {
+		t.Fatalf("decode old record: %v", err)
+	}
+	if old.OutcomeProgress == nil || old.OutcomeProgress.Runway != nil {
+		t.Fatalf("old record runway = %+v, want unobserved nil", old.OutcomeProgress)
+	}
+
+	zero := 0
+	data, err := json.Marshal(Record{
+		SchemaVersion:   SchemaVersion,
+		OutcomeProgress: &OutcomeProgress{Round: 1, Runway: &zero, RunwaySpent: true},
+	})
+	if err != nil {
+		t.Fatalf("encode new record: %v", err)
+	}
+	if !strings.Contains(string(data), `"runway":0`) {
+		t.Fatalf("zero balance was omitted: %s", data)
+	}
+	// A previous reader ignores the additive fields and keeps its known data.
+	var legacy struct {
+		OutcomeProgress *struct {
+			Round int `json:"round"`
+		} `json:"outcome_progress"`
+	}
+	if err := json.Unmarshal(data, &legacy); err != nil || legacy.OutcomeProgress == nil || legacy.OutcomeProgress.Round != 1 {
+		t.Fatalf("legacy decode = %+v, %v", legacy, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- record the #8404 investigation-runway account as shadow-only telemetry inside the existing `OutcomeTracker`
- append balance, dry/idle streaks, and the counterfactual spent transition to `outcome_progress` trajectory records
- make `cmd/e2ebench` report how often the shadow would have spent and at which median round
- carry the optional account state through experiment fork bundles so control/treatment trajectories remain continuous

## Behavior boundary

This PR does not activate runway policy.

- `ProgressTracker` and the live 2/4/6 no-progress ladder are unchanged.
- No runway value reaches the arbiter, notices, Goal state, loop-guard pass, provider messages, prompts, or tool schemas.
- The account is an unexported field owned by `OutcomeTracker`; its only runtime output is the existing content-free `OutcomeProgress` audit channel.

The purpose is to collect counterfactual data before deciding whether the fixed guard should change. With #8411 merged, those audit samples now reach trajectory recorders through the full production sink chain.

## Consolidation

Refs #8404.

### Kept and adapted

- Kept #8404's account economics from @esengine: every round costs four units, falsifiable observations refill the account, changes cover their round, productive exploration burns one unit, and empty rounds burn four.
- Kept the 24 productive-read opening and 40-unit cap, but made the implementation private to the outcome shadow.
- Kept dry/idle/spent observables and added presence-aware persistence plus an offline aggregate so the policy can be evaluated on recorded runs.
- Preserved the adopted work with commit-level co-author attribution using the source commit's public identity.

### Reviewed but not adopted

- Did not remove `ProgressTracker` or `LegacyGain`.
- Did not replace the live guard, inject runway observations, change arbiter verdicts, arm final-readiness bypasses, or alter Goal behavior.
- Did not adopt #8404's user-facing documentation changes because user-visible behavior remains unchanged.
- The read-question novelty fix split into #8407 is already on `main-v2` through #8417 and is not duplicated here.

## Compatibility

| Surface | Old data in the new reader | New data in the current reader | New data in previous readers | Result |
| --- | --- | --- | --- | --- |
| `outcome_progress` JSONL | missing `runway` is `nil` and excluded from runway aggregates | numeric balance is always written, including real zero | unknown additive fields are ignored | compatible; schema stays v1 |
| experiment fork bundle v1 | missing fields start an unobserved fresh shadow | optional counts preserve shadow continuity | unknown additive fields are ignored | compatible; version stays v1 |

No configuration, Wails contract, provider payload, or user-owned state changes.

## Concurrency and security

- The account is updated on the existing per-task outcome-scoring path; no goroutine, lock, or shared ownership was added.
- The trajectory recorder keeps its existing serialized append path.
- New telemetry contains counts and booleans only: no prompts, paths, commands, model names, endpoints, credentials, or tool output.

## Verification

- `go test ./...`
- `go test -race ./internal/evidence ./internal/trajectory ./internal/agent ./cmd/e2ebench`
- `go vet ./...`
- `go run ./tools/repolint`
- `golangci-lint run --timeout=5m ./...`
- `scripts/check-cache-impact.sh`
- `scripts/check-docs-impact.sh`
- `git diff --check`

Documentation-impact: none - this PR records an internal counterfactual and does not change product behavior or configuration.

Cache-impact: none - no provider request, prompt construction, tool schema/order, compaction, memory, or reasoning upload path changes.
Cache-guard: `go test ./internal/boot` plus `TestForkControlContinuationMatchesOriginalRequest`; the stable provider messages remain byte-for-byte equal across control continuation.
System-prompt-review: not required - no system prompt, memory prefix, output style, or provider-visible tool surface changes.
