### PR TITLE
fix(desktop): converge transcript tail on native geometry / 以原生几何收敛会话物理底部

### DIFF
--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -17,6 +17,12 @@ Keep to it when touching anything that can move the transcript viewport.
   and programmatic writers preempt an in-flight recovery through reducer
   events that end it in a terminal state (done / cancelled / expired), each
   reported to `noteTranscriptRecoveryTerminal`. No silent exits.
+- **Native geometry is authoritative**: Virtuoso's `atBottomStateChange` is a
+  delivery signal, not the bottom truth. Derive bottom ownership from the live
+  scroller's `scrollHeight - scrollTop - clientHeight`. Browser clamps may not
+  leave manual reading; only a delivered scroll with explicit reader intent
+  may re-enter tail-follow. Tail-follow persists across later measurements and
+  layout growth until explicit user intent releases it.
 - **No keyed remounts on content patches**: patches flow through `data` only;
   Virtuoso re-measures mounted rows itself. Remounts happen only on surface
   switches and blank-watchdog rebuilds, and restore from the measured-size

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -132,18 +132,41 @@ try {
     const settle = () => frames-- <= 0 ? resolve() : requestAnimationFrame(settle);
     requestAnimationFrame(settle);
   }));
-  await page.evaluate(() => {
-    const element = document.querySelector(".transcript");
-    if (!(element instanceof HTMLElement)) return;
-    element.scrollTop = element.scrollHeight;
-    element.dispatchEvent(new Event("scroll"));
-  });
+  await page.mouse.move(hydrationBox.x + hydrationBox.width / 2, hydrationBox.y + hydrationBox.height / 2);
+  await page.mouse.wheel(0, 100_000);
   await page.waitForFunction(() => {
     const element = document.querySelector(".transcript");
     return element instanceof HTMLElement
       && element.dataset.scrollMode === "tail-follow"
       && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
   });
+  // Rapid A→B→A switches reproduce the report where a callback from the
+  // previous session landed on the newly mounted scrollport. The last topic
+  // owns the surface and opens at its physical tail.
+  await page.evaluate(() => {
+    const topic = (label) => [...document.querySelectorAll(".project-tree__topic-main")]
+      .find((candidate) => candidate.textContent?.includes(label));
+    topic("bench:reported-long-turn")?.click();
+    topic("bench:tools-38t")?.click();
+    topic("bench:reported-long-turn")?.click();
+  });
+  await page.waitForFunction(
+    () => document.querySelector(".project-tree__topic--active .project-tree__topic-label")?.textContent?.includes("bench:reported-long-turn"),
+    undefined,
+    { timeout: 30_000 },
+  );
+  await page.waitForFunction(
+    () => document.querySelector(".transcript")?.textContent?.includes("Reported long turn complete."),
+    undefined,
+    { timeout: 30_000 },
+  );
+  await page.waitForFunction(() => {
+    const element = document.querySelector(".transcript");
+    return element instanceof HTMLElement
+      && element.dataset.scrollMode === "tail-follow"
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
+  });
+  assert(true, "rapid A→B→A switching leaves the reported long-turn session at its physical bottom");
   await page.click('.project-tree__topic-main:has-text("bench:tools-38t")');
   await page.waitForFunction(() => document.querySelector(".project-tree__topic--active .project-tree__topic-label")?.textContent?.includes("bench:tools-38t"));
   await page.waitForFunction(() => document.querySelector(".transcript")?.textContent?.includes("pkg-41/mod.go"), undefined, { timeout: 30_000 });
@@ -430,6 +453,7 @@ try {
     return {
       x: Math.min(rect.right - 1, contentRight + Math.max(1, (rect.right - contentRight) / 2)),
       y: rect.top + 5,
+      bottomY: rect.bottom - 5,
       knownSize: Number.parseFloat(row.dataset.knownSize || "0"),
       gutter: rect.right - contentRight,
       scrollHeight: element.scrollHeight,
@@ -469,27 +493,34 @@ try {
     assert(duringNativeThumbDrag.knownSize === nativeThumbProbe.knownSize, `native thumb drag freezes new row measurements (${duringNativeThumbDrag.knownSize}px)`);
     assert(duringNativeThumbDrag.fixedHeight === `${nativeThumbProbe.knownSize}px`, `native thumb drag fixes mounted row layout (${duringNativeThumbDrag.fixedHeight})`);
     assert(Math.abs(duringNativeThumbDrag.scrollHeight - nativeThumbProbe.scrollHeight) <= 8, `native thumb drag keeps the physical scroll range stable (${nativeThumbProbe.scrollHeight} → ${duringNativeThumbDrag.scrollHeight}; row ${duringNativeThumbDrag.rowHeight}; list ${duringNativeThumbDrag.listHeight})`);
+    await page.mouse.move(nativeThumbProbe.x, nativeThumbProbe.bottomY, { steps: 8 });
+    await page.waitForFunction(() => {
+      const element = document.querySelector(".transcript");
+      return element && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
+    });
     await page.mouse.up();
-    await page.waitForFunction(
-      (knownSize) => {
-        const transcriptElement = document.querySelector(".transcript");
-        const row = document.querySelector('[data-native-scrollbar-probe="true"]');
-        return transcriptElement?.dataset.nativeScrollbarDrag !== "true"
-          && row instanceof HTMLElement
-          && Number.parseFloat(row.dataset.knownSize || "0") > knownSize + 800;
-      },
-      nativeThumbProbe.knownSize,
-    );
-    assert(true, "native thumb release resumes real row measurement");
+    await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.nativeScrollbarDrag !== "true");
+    await transcript.evaluate((element) => {
+      const tail = [...element.querySelectorAll(".transcript__row")].at(-1);
+      if (tail instanceof HTMLElement) tail.style.paddingBottom = `${Number.parseFloat(tail.style.paddingBottom || "0") + 900}px`;
+    });
+    assert(true, "native thumb release ends the measurement freeze");
+    await page.waitForFunction(() => {
+      const element = document.querySelector(".transcript");
+      return element
+        && element.dataset.scrollMode === "tail-follow"
+        && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
+    });
+    assert(true, "native thumb release keeps the remeasured transcript at the physical bottom");
   }
 
   // Explicit bottom owns the tail. Subsequent async growth must use Virtuoso's
   // autoscroll API and remain at the physical bottom without Reasonix scrollTop
   // correction loops.
   const jumpBottom = page.locator(".transcript__jump-bottom");
-  await transcript.evaluate((element) => {
-    element.scrollTop = Math.max(0, element.scrollHeight - element.clientHeight * 2);
-  });
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, -800);
+  await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual");
   await jumpBottom.waitFor({ state: "visible" });
   await jumpBottom.click();
   await page.waitForFunction(() => {
@@ -498,15 +529,27 @@ try {
       && element.dataset.scrollMode === "tail-follow"
       && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
   });
-  await transcript.evaluate((element) => {
-    const tail = [...element.querySelectorAll(".transcript__row")].at(-1);
-    if (tail instanceof HTMLElement) tail.style.paddingBottom = `${Number.parseFloat(tail.style.paddingBottom || "0") + 320}px`;
-  });
+  await transcript.evaluate((element) => new Promise((resolve) => {
+    const growthFrames = new Set([2, 7, 12]);
+    let frame = 0;
+    const grow = () => {
+      frame += 1;
+      if (growthFrames.has(frame)) {
+        const tail = [...element.querySelectorAll(".transcript__row")].at(-1);
+        if (tail instanceof HTMLElement) {
+          tail.style.paddingBottom = `${Number.parseFloat(tail.style.paddingBottom || "0") + 160}px`;
+        }
+      }
+      if (frame < 14) requestAnimationFrame(grow);
+      else resolve();
+    };
+    requestAnimationFrame(grow);
+  }));
   await page.waitForFunction(() => {
     const element = document.querySelector(".transcript");
     return element && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
   });
-  assert(true, "pinned dynamic tail growth remains at the physical bottom");
+  assert(true, "pinned multi-frame tail growth remains at the physical bottom");
 
   // ── #8657 residual: long session + measurement churn must still reach the
   // bottom. The v1.25.3 report: on very long sessions the user could never
@@ -607,6 +650,16 @@ try {
   // exact moment the old chain remounted) and require: bottom reached, no
   // multi-screen upward snap, zero recovery-owned writes, tail holds.
   await page.click('.project-tree__topic-main:has-text("bench:storm-40t")');
+  await page.waitForFunction(
+    () => document.querySelector(".project-tree__topic--active .project-tree__topic-label")?.textContent?.includes("bench:storm-40t"),
+    undefined,
+    { timeout: 30_000 },
+  );
+  await page.waitForFunction(
+    () => document.querySelector(".transcript")?.textContent?.includes("storm turn 40"),
+    undefined,
+    { timeout: 30_000 },
+  );
   await page.waitForFunction(() => document.querySelectorAll(".transcript__row").length > 2, undefined, { timeout: 30_000 });
   await page.evaluate(() => new Promise((resolve) => {
     let frames = 6;
@@ -620,7 +673,9 @@ try {
     element.scrollTop = Math.max(0, Math.floor((element.scrollHeight - element.clientHeight) / 2));
     element.dispatchEvent(new Event("scroll"));
   });
-  await page.mouse.move(stormBox.x + stormBox.width / 2, stormBox.y + stormBox.height / 2);
+  // Use the reserved right transcript gutter, not a nested tool/code
+  // scrollport, so this wheel explicitly transfers outer reader ownership.
+  await page.mouse.move(stormBox.x + stormBox.width - 6, stormBox.y + stormBox.height / 2);
   await page.mouse.wheel(0, -240);
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual", undefined, { timeout: 5_000 });
   await stormTranscript.evaluate(() => {

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -518,7 +518,9 @@ try {
   // autoscroll API and remain at the physical bottom without Reasonix scrollTop
   // correction loops.
   const jumpBottom = page.locator(".transcript__jump-bottom");
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  // Target the reserved transcript gutter so expanded nested tool/code
+  // scrollers cannot correctly retain this outer-reader intent.
+  await page.mouse.move(box.x + box.width - 6, box.y + box.height / 2);
   await page.mouse.wheel(0, -800);
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual");
   await jumpBottom.waitFor({ state: "visible" });

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -623,7 +623,9 @@ try {
   for (let attempt = 0; attempt < 40 && !reachedBottom; attempt += 1) {
     await page.mouse.wheel(0, 640);
     await page.waitForTimeout(50);
-    reachedBottom = await transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
+    reachedBottom = await transcript.evaluate((element) =>
+      element.dataset.scrollMode === "tail-follow"
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
   }
   assert(reachedBottom, "repeated downward wheels reach the physical bottom through measurement churn (#8657)");
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "tail-follow", undefined, { timeout: 5_000 });
@@ -720,7 +722,9 @@ try {
     // Every sixth gesture, pause into scroll idle — the moment the pre-fix
     // chain fired its revision-driven remount mid-approach.
     if (attempt % 6 === 5) await page.waitForTimeout(500);
-    stormReached = await stormTranscript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
+    stormReached = await stormTranscript.evaluate((element) =>
+      element.dataset.scrollMode === "tail-follow"
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 1);
   }
   assert(stormReached, "repeated downward wheels reach the physical bottom through the ref-resolution storm (#8657)");
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "tail-follow", undefined, { timeout: 5_000 });

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -197,7 +197,7 @@ import { ThemeBackground } from "./components/ThemeBackground";
 import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./lib/textSize";
 import { useViewportHeightVar, useWindowStatePersistence } from "./lib/windowState";
 import { resolveLiveWorkspacePanelWidth, resolveWorkspacePanelPlacement, workspacePanelAriaMinWidth } from "./lib/workspaceLayout";
-import { createRafResizeUpdater } from "./lib/resizeDrag";
+import { createPointerResizeLifecycle, createRafResizeUpdater } from "./lib/resizeDrag";
 import { useGlobalShortcut } from "./lib/keyboardShortcuts";
 import { useWarmTerminalPanel } from "./lib/useWarmTerminalPanel";
 import { topicShortcutIndexFromEvent, useTopicShortcuts, type TopicShortcutEntry } from "./lib/topicShortcuts";
@@ -1297,12 +1297,14 @@ export default function App() {
   const topicRenameCommitHandledRef = useRef(false);
   const appRef = useRef<HTMLDivElement>(null);
   const layoutRef = useRef<HTMLDivElement>(null);
+  const workspacePanelResizeFinishRef = useRef<(() => void) | null>(null);
   const sidebarTogglePressTimerRef = useRef<number | null>(null);
   const workspaceTogglePressTimerRef = useRef<number | null>(null);
 
   // Persist window geometry across launches.
   useWindowStatePersistence();
   useViewportHeightVar();
+  useEffect(() => () => workspacePanelResizeFinishRef.current?.(), []);
   useEffect(() => {
     document.documentElement.setAttribute("data-platform", desktopPlatform);
   }, [desktopPlatform]);
@@ -2722,18 +2724,21 @@ export default function App() {
 
   const startWorkspacePanelResize = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
-      if (!workspacePanelOpen) return;
+      if (event.button !== 0 || !workspacePanelOpen) return;
       const layout = layoutRef.current;
       if (!layout) return;
       event.preventDefault();
+      workspacePanelResizeFinishRef.current?.();
       closeTransientOverlays();
       setWorkspacePanelResizing(true);
+      const separator = event.currentTarget;
+      const pointerId = event.pointerId;
       const startX = event.clientX;
       const startDockWidth = workspacePanelRenderWidth;
       let nextDockWidth = startDockWidth;
       const liveResize = createRafResizeUpdater({
         target: layout,
-        separator: event.currentTarget,
+        separator,
         cssVar: "--workspace-width",
         onApply: setLiveWorkspacePanelRenderWidth,
       });
@@ -2747,22 +2752,23 @@ export default function App() {
         }
         liveResize.schedule(resolveLiveWorkspacePanelRenderWidth(nextDockWidth));
       };
-      const onDone = () => {
-        liveResize.flush();
-        setSavedWorkspacePanelWidth(nextDockWidth);
-        setLiveWorkspacePanelRenderWidth(null);
-        setWorkspacePanelResizing(false);
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onDone);
-        window.removeEventListener("pointercancel", onDone);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      };
+      const lifecycle = createPointerResizeLifecycle({
+        separator,
+        pointerId,
+        onMove,
+        onFinish: () => {
+          liveResize.flush();
+          setSavedWorkspacePanelWidth(nextDockWidth);
+          setLiveWorkspacePanelRenderWidth(null);
+          setWorkspacePanelResizing(false);
+          workspacePanelResizeFinishRef.current = null;
+          document.body.style.cursor = "";
+          document.body.style.userSelect = "";
+        },
+      });
+      workspacePanelResizeFinishRef.current = lifecycle.finish;
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onDone);
-      window.addEventListener("pointercancel", onDone);
     },
     [closeTransientOverlays, resolveLiveWorkspacePanelRenderWidth, rightDockDetailActive, rightDockTreeWidthClamp, setSavedWorkspacePanelWidth, workspacePanelOpen, workspacePanelRenderWidth],
   );

--- a/desktop/frontend/src/__tests__/resize-drag.test.ts
+++ b/desktop/frontend/src/__tests__/resize-drag.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/resize-drag.test.ts
 
-import { createRafResizeUpdater } from "../lib/resizeDrag";
+import { JSDOM } from "jsdom";
+import { createPointerResizeLifecycle, createRafResizeUpdater } from "../lib/resizeDrag";
 
 let passed = 0;
 let failed = 0;
@@ -96,6 +97,43 @@ try {
   eq(appliedValues.length, 0, "live resize callback waits for animation frame");
   frames[0](0);
   eq(appliedValues.join(","), "300", "live resize callback receives the applied rounded value");
+
+  const dom = new JSDOM('<!doctype html><button id="separator"></button>');
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  const separator = dom.window.document.getElementById("separator") as HTMLButtonElement;
+  let capturedPointer: number | null = null;
+  let finished = 0;
+  let moved = 0;
+  separator.setPointerCapture = (pointerId) => { capturedPointer = pointerId; };
+  separator.hasPointerCapture = (pointerId) => capturedPointer === pointerId;
+  separator.releasePointerCapture = (pointerId) => {
+    capturedPointer = null;
+    const lost = new dom.window.Event("lostpointercapture") as Event & { pointerId: number };
+    Object.defineProperty(lost, "pointerId", { value: pointerId });
+    separator.dispatchEvent(lost);
+  };
+  const pointerEvent = (type: string, pointerId: number) => {
+    const event = new dom.window.Event(type) as Event & { pointerId: number };
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  };
+  const lifecycle = createPointerResizeLifecycle({
+    separator,
+    pointerId: 7,
+    onMove: () => { moved += 1; },
+    onFinish: () => { finished += 1; },
+  });
+  dom.window.dispatchEvent(pointerEvent("pointermove", 8));
+  dom.window.dispatchEvent(pointerEvent("pointermove", 7));
+  eq(moved, 1, "resize lifecycle ignores other pointers and delivers the active pointer");
+  dom.window.dispatchEvent(pointerEvent("pointercancel", 7));
+  eq(finished, 1, "pointer cancellation finishes the resize once");
+  lifecycle.finish();
+  separator.dispatchEvent(pointerEvent("lostpointercapture", 7));
+  dom.window.dispatchEvent(new dom.window.Event("blur"));
+  eq(finished, 1, "capture loss, blur, and component cleanup cannot finish a gesture twice");
+  eq(capturedPointer, null, "resize finish releases active pointer capture");
+  dom.window.close();
 } finally {
   globalThis.requestAnimationFrame = originalRequestAnimationFrame;
   globalThis.cancelAnimationFrame = originalCancelAnimationFrame;

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -107,7 +107,12 @@ const rowElement = scrollElement.querySelector<HTMLElement>(".transcript__row")!
 scrollElement.getBoundingClientRect = () => rectAt(0);
 rowElement.getBoundingClientRect = () => rectAt(200);
 Object.defineProperty(scrollElement, "clientHeight", { configurable: true, value: 100 });
-Object.defineProperty(scrollElement, "scrollHeight", { configurable: true, value: 500 });
+let scrollExtent = 500;
+Object.defineProperty(scrollElement, "scrollHeight", { configurable: true, get: () => scrollExtent });
+Object.defineProperty(scrollElement, "scrollTop", { configurable: true, writable: true, value: 0 });
+Object.defineProperty(scrollElement, "offsetWidth", { configurable: true, value: 800 });
+Object.defineProperty(scrollElement, "clientWidth", { configurable: true, value: 780 });
+Object.defineProperty(scrollElement, "clientLeft", { configurable: true, value: 0 });
 
 const item: Item = { kind: "assistant", id: "a", text: "answer", reasoning: "", streaming: false };
 const baseRows: TranscriptRow[] = [{ kind: "answer", key: "row-a", item }];
@@ -116,12 +121,18 @@ let scrollByCalls = 0;
 let scrollToIndexCalls = 0;
 let scrollToCalls = 0;
 let scrollToBottomCalls = 0;
+let tailWriteStep = 0;
+let snapTailOnWrite = false;
 // Null disables snapshot capture; the snapshot sections opt in explicitly so
 // the pre-snapshot scenarios keep their first-mount scrollToBottom behavior.
 let stubSnapshot: StateSnapshot | null = null;
 const virtuosoHandle = {
   scrollBy: () => { scrollByCalls += 1; },
-  scrollToIndex: () => { scrollToIndexCalls += 1; },
+  scrollToIndex: () => {
+    scrollToIndexCalls += 1;
+    if (snapTailOnWrite) scrollElement.scrollTop = scrollExtent - scrollElement.clientHeight;
+    else if (tailWriteStep > 0) scrollElement.scrollTop = Math.min(scrollExtent - scrollElement.clientHeight, scrollElement.scrollTop + tailWriteStep);
+  },
   scrollTo: () => { scrollToCalls += 1; },
   getState: (callback: (state: StateSnapshot) => void) => {
     if (stubSnapshot) callback(stubSnapshot);
@@ -179,6 +190,96 @@ await act(async () => {
   (arbiter!.virtuosoRef as { current: VirtuosoHandle | null }).current = virtuosoHandle;
   arbiter!.scrollerRef(scrollElement);
 });
+
+// The native extent is authoritative even when Virtuoso reports a stale
+// logical atBottom value after delayed row measurement.
+scrollElement.scrollTop = 400;
+await act(async () => arbiter?.atBottomStateChange(false));
+check(arbiter?.isAtBottom === true, "physical bottom overrides a stale Virtuoso atBottom=false report");
+
+// A thumb gesture that reaches the frozen native bottom must claim the tail
+// before release resumes real row measurements and changes the extent.
+scrollElement.scrollTop = 0;
+await act(async () => arbiter?.onPointerDownIntent({
+  button: 0,
+  nativeEvent: { button: 0, clientX: 795 },
+} as React.PointerEvent<HTMLElement>));
+scrollElement.scrollTop = 400;
+await act(async () => window.dispatchEvent(new dom.window.Event("pointerup")));
+check(arbiter?.modeRef.current === "tail-follow", "native thumb release at the physical bottom resumes tail-follow");
+scrollExtent = 900;
+snapTailOnWrite = true;
+await act(async () => arbiter?.deliverScroll());
+await flushFrames();
+check(scrollElement.scrollTop === 800, "post-release remeasurement reconverges the claimed native bottom");
+snapTailOnWrite = false;
+scrollExtent = 500;
+
+// A nested code/tool scrollport owns the wheel until it reaches its edge.
+// Capturing the event on Transcript must not release tail-follow early.
+const nestedScroller = dom.window.document.createElement("div");
+nestedScroller.style.overflowY = "auto";
+Object.defineProperty(nestedScroller, "clientHeight", { configurable: true, value: 100 });
+Object.defineProperty(nestedScroller, "scrollHeight", { configurable: true, value: 300 });
+Object.defineProperty(nestedScroller, "scrollTop", { configurable: true, writable: true, value: 50 });
+rowElement.appendChild(nestedScroller);
+await act(async () => arbiter?.reset());
+let nestedWheelAccepted = true;
+await act(async () => {
+  nestedWheelAccepted = arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: -40,
+    target: nestedScroller,
+  } as React.WheelEvent<HTMLElement>) ?? true;
+});
+check(!nestedWheelAccepted && arbiter?.modeRef.current === "tail-follow", "a scrollable nested surface keeps wheel ownership");
+nestedScroller.scrollTop = 0;
+await act(async () => {
+  nestedWheelAccepted = arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: -40,
+    target: nestedScroller,
+  } as React.WheelEvent<HTMLElement>) ?? false;
+});
+check(nestedWheelAccepted && arbiter?.modeRef.current === "manual", "a nested edge hands wheel ownership to the transcript");
+nestedScroller.remove();
+
+// If measurement/clamping reaches the physical bottom between scroll events,
+// a fresh downward gesture must still claim tail-follow even though the
+// browser has no remaining pixels to deliver.
+scrollElement.scrollTop = 400;
+let bottomWheelAccepted = false;
+await act(async () => {
+  bottomWheelAccepted = arbiter?.onWheelIntent({
+    ctrlKey: false,
+    deltaX: 0,
+    deltaY: 40,
+    target: scrollElement,
+  } as React.WheelEvent<HTMLElement>) ?? false;
+});
+check(bottomWheelAccepted && arbiter?.modeRef.current === "tail-follow", "a downward gesture claims an already-clamped physical bottom");
+
+// A queued confirmation belongs to the surface that requested it. Resetting
+// before its frame runs must prevent the old request from writing the new one.
+scrollToIndexCalls = 0;
+scrollElement.scrollTop = 0;
+await act(async () => arbiter?.scrollToBottom());
+check(scrollToIndexCalls === 1, "bottom request performs its immediate LAST write");
+await act(async () => arbiter?.reset());
+await flushFrames();
+check(scrollToIndexCalls === 1, "a reset invalidates the previous surface's queued tail confirmation");
+
+// Tail-follow is a persistent mode, not a six-frame retry window. Each
+// delivered non-bottom position must request another coalesced convergence.
+scrollToIndexCalls = 0;
+tailWriteStep = 20;
+await act(async () => arbiter?.scrollToBottom());
+for (let i = 0; i < 10; i += 1) await flushFrames();
+check(scrollToIndexCalls > 8, "tail convergence remains live beyond the former six-frame budget");
+tailWriteStep = 0;
+
 await act(async () => integrity?.scheduleBlankViewportCheck());
 await switchSurface("surface-b");
 check(integrity?.resetKey === "surface-b:0", "surface switch cancels the previous blank-viewport watchdog");

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -35,18 +35,21 @@ function run(events: readonly TranscriptScrollEvent[], initial = INITIAL_TRANSCR
 console.log("\ntranscript scroll controller");
 
 const streaming = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "TAIL_CONTENT_CHANGED" },
-  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "LAYOUT_HEIGHT_CHANGED" },
 ]);
 check(streaming.state.mode === "tail-follow", "dynamic atBottom=false does not steal tail ownership");
-check(streaming.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM", "tail growth emits only Virtuoso autoscroll commands");
+check(
+  streaming.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM",
+  "tail growth and delivered displacement emit only Virtuoso autoscroll commands",
+);
 
 const manual = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "USER_SCROLL_INTENT" },
-  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "TAIL_CONTENT_CHANGED" },
   { type: "VIEWPORT_RESIZED" },
 ]);
@@ -54,30 +57,52 @@ check(manual.state.mode === "manual", "explicit user intent releases tail-follow
 check(manual.commands.length === 0, "manual reading never receives tail commands");
 
 const returned = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "USER_SCROLL_INTENT" },
-  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
 ]);
 check(returned.state.mode === "tail-follow", "reaching the real bottom re-engages tail-follow");
 
+const browserClamp = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT" },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "READER_INTENT_ENDED" },
+  { type: "CONTENT_SHRANK" },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+]);
+check(browserClamp.state.mode === "manual", "a browser clamp without fresh reader intent does not resume tail-follow");
+
+const manualResize = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT" },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "READER_INTENT_ENDED" },
+  { type: "USER_RESIZE_BEGIN" },
+  { type: "LAYOUT_HEIGHT_CHANGED" },
+  { type: "USER_RESIZE_END" },
+]);
+check(manualResize.state.mode === "manual", "a resize preserves manual reading ownership");
+check(manualResize.commands.length === 0, "manual reading receives no tail write during resize");
+
 const shortTranscript = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: false },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: false },
   { type: "USER_SCROLL_INTENT" },
 ]);
 check(shortTranscript.state.mode === "tail-follow", "non-overflow transcript always stays tail-follow");
 
 const fold = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "USER_RESIZE_BEGIN" },
   { type: "LAYOUT_HEIGHT_CHANGED" },
   { type: "USER_RESIZE_END" },
 ]);
-check(fold.state.mode === "manual", "user fold resize settles in manual mode");
-check(fold.commands.length === 0, "user fold resize cannot tug the viewport to the tail");
+check(fold.state.mode === "tail-follow", "a fold resize preserves existing tail ownership");
+check(fold.commands.join(",") === "AUTOSCROLL_TO_BOTTOM", "a fold resize reconverges only when it began at the tail");
 
 const selection = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "SELECTION_BEGIN" },
   { type: "SCROLL_TO_OFFSET", owner: "selection-edge-scroll", top: 120 },
   { type: "LAYOUT_HEIGHT_CHANGED" },
@@ -87,15 +112,22 @@ check(selection.state.mode === "manual", "selection returns to manual reading");
 check(selection.commands.join(",") === "SCROLL_TO_OFFSET", "selection owns only its explicit edge-scroll command");
 
 const jump = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "USER_SCROLL_INTENT" },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "JUMP_TO_BOTTOM", behavior: "smooth" },
 ]);
 check(jump.state.mode === "tail-follow", "jump-bottom explicitly owns the tail");
 check(jump.commands.join(",") === "SCROLL_TO_LAST", "jump-bottom uses Virtuoso scrollToIndex only");
 
+const repeatedJump = run([
+  { type: "JUMP_TO_BOTTOM" },
+  { type: "JUMP_TO_BOTTOM" },
+]);
+check(repeatedJump.commands.join(",") === "SCROLL_TO_LAST,SCROLL_TO_LAST", "repeated bottom requests each produce a fresh command");
+
 const restore = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "JUMP_TO_INDEX", index: 42 },
   { type: "PROGRAMMATIC_END" },
 ]);
@@ -103,20 +135,23 @@ check(restore.state.mode === "manual", "question/rewind navigation settles in ma
 check(restore.commands.join(",") === "SCROLL_TO_INDEX", "navigation emits one indexed Virtuoso command");
 
 const shrink = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
   { type: "CONTENT_SHRANK" },
 ]);
 check(shrink.state.mode === "tail-follow", "auto fold collapse keeps tail-follow");
 check(shrink.commands.length === 0, "auto fold collapse does not tug the viewport to the tail");
 
 const shrinkOffBottom = run([
-  { type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: true },
-  { type: "AT_BOTTOM_CHANGED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "CONTENT_SHRANK" },
   { type: "LAYOUT_HEIGHT_CHANGED" },
 ]);
 check(shrinkOffBottom.state.mode === "tail-follow", "a shrink does not steal tail ownership");
-check(shrinkOffBottom.commands.join(",") === "AUTOSCROLL_TO_BOTTOM", "only later growth after a shrink may follow the tail");
+check(
+  shrinkOffBottom.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM",
+  "delivered displacement and later growth both reconverge while tail-follow owns the viewport",
+);
 
 check(isTranscriptContentShrink(-48), "a fold-sized height drop is a shrink");
 check(!isTranscriptContentShrink(-8), "measurement jitter is not a shrink");

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -165,6 +165,18 @@ eq(
   "closing the dock clears the transient render width, hides the panel, and persists the collapsed preference",
 );
 eq(
+  /\.workspace-panel-resizer \{[\s\S]*?grid-column: 3;[\s\S]*?justify-self: start;[\s\S]*?width: 1px;/.test(stylesSource)
+    && /\.workspace-panel-resizer::before \{[\s\S]*?left: 0;[\s\S]*?right: -7px;/.test(stylesSource),
+  true,
+  "workspace resize hit area starts at the dock boundary and never overlaps the chat scrollbar gutter",
+);
+eq(
+  /createPointerResizeLifecycle\(\{[\s\S]*?separator,[\s\S]*?pointerId,[\s\S]*?onMove,[\s\S]*?onFinish: \(\) => \{[\s\S]*?liveResize\.flush\(\);/.test(appSource)
+    && /workspacePanelResizeFinishRef\.current = lifecycle\.finish/.test(appSource),
+  true,
+  "workspace resize has one guarded finish path for capture loss, blur, cancellation, and unmount",
+);
+eq(
   /setWorkspacePanelOpen\(true\);[\s\S]*?saveWorkspacePanelOpen\(true\);/.test(appSource),
   true,
   "opening the dock persists the expanded preference for the next launch",

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type TouchEvent as ReactTouchEvent, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore, type WheelEvent as ReactWheelEvent } from "react";
+import { forwardRef, memo, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode, type TouchEvent as ReactTouchEvent, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type WheelEvent as ReactWheelEvent } from "react";
 import { Virtuoso, type Components, type ItemProps, type ListItem, type ListProps } from "react-virtuoso";
 import type { ControllerLiveStore, Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
@@ -305,10 +305,12 @@ export function Transcript({
     onNestedScrollIntent,
     onTouchStartIntent,
     onTouchMoveIntent,
+    onTouchEndIntent,
     onKeyScrollIntent,
     isAtBottom,
     scrollerRef,
     atBottomStateChange,
+    deliverScroll,
     scrollToBottom,
     followGrowingTail,
     beginUserResize,
@@ -384,7 +386,7 @@ export function Transcript({
   // starts at the bottom. Without this, stick.current from the previous tab
   // persists across React re-renders (Transcript is not keyed by tabId) and
   // disables auto-scroll when the user had scrolled up in the old tab (#4584).
-  useEffect(() => {
+  useLayoutEffect(() => {
     resetScroll();
     virtuosoReadyRef.current = false;
   }, [resetScroll, revealSignal, tabId]);
@@ -559,30 +561,34 @@ export function Transcript({
   // any in-flight recovery restore on its own intent events (#8657/#8688
   // follow-up).
   const onWheelIntentWithRecovery = useCallback((event: ReactWheelEvent<HTMLElement>) => {
-    noteUserScrollIntent();
-    return onWheelIntent(event);
+    const accepted = onWheelIntent(event);
+    if (accepted) noteUserScrollIntent();
+    return accepted;
   }, [noteUserScrollIntent, onWheelIntent]);
   const onTouchStartIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    noteUserScrollIntent();
     onTouchStartIntent(event);
-  }, [noteUserScrollIntent, onTouchStartIntent]);
+  }, [onTouchStartIntent]);
   const onTouchMoveIntentWithRecovery = useCallback((event: ReactTouchEvent<HTMLElement>) => {
-    noteUserScrollIntent();
-    return onTouchMoveIntent(event);
+    const accepted = onTouchMoveIntent(event);
+    if (accepted) noteUserScrollIntent();
+    return accepted;
   }, [noteUserScrollIntent, onTouchMoveIntent]);
   const onKeyScrollIntentWithRecovery = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
-    noteUserScrollIntent();
-    return onKeyScrollIntent(event);
+    const accepted = onKeyScrollIntent(event);
+    if (accepted) noteUserScrollIntent();
+    return accepted;
   }, [noteUserScrollIntent, onKeyScrollIntent]);
   const onPointerDownIntentWithRecovery = useCallback((event: ReactPointerEvent<HTMLElement>) => {
-    noteUserScrollIntent();
-    return onPointerDownIntent(event);
+    const accepted = onPointerDownIntent(event);
+    if (accepted) noteUserScrollIntent();
+    return accepted;
   }, [noteUserScrollIntent, onPointerDownIntent]);
   const scrollInteractions = useTranscriptScrollInteractions({
-    scrollRef,
+    scrollElement,
     cancelStreamingScroll: cancelStreamingAutoScroll,
     onWheelIntent: onWheelIntentWithRecovery,
     onTouchMoveIntent: onTouchMoveIntentWithRecovery,
+    onTouchEndIntent,
     onKeyScrollIntent: onKeyScrollIntentWithRecovery,
     onPointerDownIntent: onPointerDownIntentWithRecovery,
     onNestedScrollIntent,
@@ -602,10 +608,11 @@ export function Transcript({
     entranceRef.current = node instanceof HTMLElement ? node as HTMLDivElement : null;
   }, [entranceRef, scrollerRef]);
   const handleTranscriptScroll = useCallback(() => {
+    deliverScroll();
     noteScrollActivity();
     if (creationMode) handleCreationScroll();
     scheduleBlankViewportCheck();
-  }, [creationMode, handleCreationScroll, noteScrollActivity, scheduleBlankViewportCheck]);
+  }, [creationMode, deliverScroll, handleCreationScroll, noteScrollActivity, scheduleBlankViewportCheck]);
   // ── JumpBar integration ───────────────────────────────────────────────────
   const handleJumpToQuestion = useCallback((question: QuestionAnchor) => {
     const index = rowIndexByKey.get(String(userRowKey(question.id)));
@@ -960,6 +967,8 @@ export function Transcript({
             onWheelCapture={scrollInteractions.onWheelCapture}
             onTouchStartCapture={onTouchStartIntentWithRecovery}
             onTouchMoveCapture={scrollInteractions.onTouchMoveCapture}
+            onTouchEndCapture={scrollInteractions.onTouchEndCapture}
+            onTouchCancelCapture={scrollInteractions.onTouchEndCapture}
             onKeyDownCapture={scrollInteractions.onKeyDownCapture}
             onPointerDownCapture={scrollInteractions.onPointerDownCapture}
           />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1834,7 +1834,8 @@ function makeMockApp(): AppBindings {
         { key: "topic_bench_tools", kind: "topic", label: "● bench:tools-38t", root: "~/projects/reasonix", topicId: "topic_bench_tools", projectColor: "blue", turns: 38, lastActivityAt: mockNow - 120_000, open: true },
         { key: "topic_bench_small", kind: "topic", label: "bench:small-6t", root: "~/projects/reasonix", topicId: "topic_bench_small", projectColor: "green", turns: 6, lastActivityAt: mockNow - 180_000 },
         { key: "topic_bench_giant_turn", kind: "topic", label: "bench:giant-turn", root: "~/projects/reasonix", topicId: "topic_bench_giant_turn", projectColor: "amber", turns: 1, lastActivityAt: mockNow - 240_000 },
-        { key: "topic_bench_storm", kind: "topic", label: "bench:storm-40t", root: "~/projects/reasonix", topicId: "topic_bench_storm", projectColor: "red", turns: 40, lastActivityAt: mockNow - 300_000 },
+        { key: "topic_bench_reported_long_turn", kind: "topic", label: "bench:reported-long-turn", root: "~/projects/reasonix", topicId: "topic_bench_reported_long_turn", projectColor: "amber", turns: 1, lastActivityAt: mockNow - 300_000 },
+        { key: "topic_bench_storm", kind: "topic", label: "bench:storm-40t", root: "~/projects/reasonix", topicId: "topic_bench_storm", projectColor: "red", turns: 40, lastActivityAt: mockNow - 360_000 },
       ],
     },
   ] : [

--- a/desktop/frontend/src/lib/bridgeBenchFixtures.ts
+++ b/desktop/frontend/src/lib/bridgeBenchFixtures.ts
@@ -130,6 +130,51 @@ const benchGiantTurnHistory = (): HistoryMessage[] => {
   return benchToolTurn(1, 1000, "Single-turn sweep complete.");
 };
 
+const benchReportedLongTurnHistory = (): HistoryMessage[] => {
+  // Sanitized reproduction of the reported shape: one user turn, 70 tool
+  // results, and 44 separately measured assistant blocks. Keeping the height
+  // distribution matters; no user content or exported session data is used.
+  const messages: HistoryMessage[] = [
+    { role: "user", content: "Inspect the workspace, apply the changes, and verify the result." },
+  ];
+  for (let block = 0; block < 44; block += 1) {
+    const callCount = block < 26 ? 2 : 1;
+    const toolCalls: HistoryToolCall[] = [];
+    for (let call = 0; call < callCount; call += 1) {
+      const id = `reported-block-${block}-call-${call}`;
+      toolCalls.push({
+        id,
+        name: block % 3 === 0 ? "bash" : "read_file",
+        arguments: JSON.stringify(block % 3 === 0
+          ? { command: `pnpm test --filter reported-${block}-${call}` }
+          : { path: `src/reported/section-${block}-${call}.ts` }),
+        resolvedReadOnly: block % 3 !== 0,
+        subject: `reported section ${block + 1}.${call + 1}`,
+      });
+    }
+    messages.push({
+      role: "assistant",
+      content: [
+        `### Verification block ${block + 1}`,
+        "",
+        `Processed the deterministic fixture section ${block + 1}.`,
+        "",
+        ...Array.from({ length: 2 + (block % 5) }, (_, row) => `- check ${row + 1}: stable measurement ${block}-${row}`),
+      ].join("\n"),
+      reasoning: `Planning verification block ${block + 1}.`,
+      toolCalls,
+    });
+    messages.push(...toolCalls.map((toolCall, call) => ({
+      role: "tool" as const,
+      toolCallId: toolCall.id,
+      toolName: toolCall.name,
+      content: benchToolOutput(block + 1, call),
+    })));
+  }
+  messages.push({ role: "assistant", content: "Reported long turn complete." });
+  return messages;
+};
+
 // Ref-resolution storm fixture (#8657): the newest page of a long session
 // carries many ref-replaced fields, so opening the session fires a paced
 // stream of history_items_patch invalidations — the exact load that used to
@@ -186,6 +231,8 @@ export function benchTopicHistory(topicId: string): HistoryMessage[] | undefined
       return benchFixture("small", benchSmallHistory);
     case "topic_bench_giant_turn":
       return benchFixture("giant", benchGiantTurnHistory);
+    case "topic_bench_reported_long_turn":
+      return benchFixture("reported-long-turn", benchReportedLongTurnHistory);
     case "topic_bench_storm":
       return benchFixture("storm", benchStormHistory);
     default:

--- a/desktop/frontend/src/lib/resizeDrag.ts
+++ b/desktop/frontend/src/lib/resizeDrag.ts
@@ -21,6 +21,70 @@ export interface RafResizeUpdater {
   cancel(): void;
 }
 
+export interface PointerResizeLifecycle {
+  /** Finish once, remove every listener, and release pointer capture. */
+  finish(): void;
+}
+
+/**
+ * Own one pointer-resize gesture across capture loss, cancellation, blur, and
+ * component cleanup. Every terminal path calls onFinish exactly once.
+ */
+export function createPointerResizeLifecycle({
+  separator,
+  pointerId,
+  onMove,
+  onFinish,
+}: {
+  separator: HTMLElement;
+  pointerId: number;
+  onMove: (event: PointerEvent) => void;
+  onFinish: () => void;
+}): PointerResizeLifecycle {
+  let active = true;
+
+  function removeListeners() {
+    window.removeEventListener("pointermove", handleMove);
+    window.removeEventListener("pointerup", handlePointerDone);
+    window.removeEventListener("pointercancel", handlePointerDone);
+    window.removeEventListener("blur", finish);
+    separator.removeEventListener("lostpointercapture", handlePointerDone);
+  }
+
+  function finish() {
+    if (!active) return;
+    active = false;
+    removeListeners();
+    try {
+      if (separator.hasPointerCapture(pointerId)) separator.releasePointerCapture(pointerId);
+    } catch {
+      // WebView2 can release capture before the terminal pointer event.
+    }
+    onFinish();
+  }
+
+  function handleMove(event: PointerEvent) {
+    if (event.pointerId === pointerId) onMove(event);
+  }
+
+  function handlePointerDone(event: PointerEvent) {
+    if (event.pointerId === pointerId) finish();
+  }
+
+  try {
+    separator.setPointerCapture(pointerId);
+  } catch {
+    // Pointer capture is optional in older embedded browser runtimes.
+  }
+  window.addEventListener("pointermove", handleMove);
+  window.addEventListener("pointerup", handlePointerDone);
+  window.addEventListener("pointercancel", handlePointerDone);
+  window.addEventListener("blur", finish);
+  separator.addEventListener("lostpointercapture", handlePointerDone);
+
+  return { finish };
+}
+
 function roundedPixel(value: number): number {
   return Math.round(value);
 }

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -24,6 +24,7 @@ export type TranscriptScrollState = {
   mode: TranscriptScrollMode;
   atBottom: boolean;
   scrollable: boolean;
+  readerIntent: boolean;
   settleMode: "tail-follow" | "manual";
   /** Id of the in-flight recovery request; at most one at a time. */
   recoveryId: number | null;
@@ -32,7 +33,9 @@ export type TranscriptScrollState = {
 export type TranscriptScrollEvent =
   | { type: "RESET" }
   | { type: "USER_SCROLL_INTENT" }
-  | { type: "AT_BOTTOM_CHANGED"; atBottom: boolean; scrollable: boolean }
+  | { type: "MANUAL_READING" }
+  | { type: "READER_INTENT_ENDED" }
+  | { type: "SCROLL_DELIVERED"; atBottom: boolean; scrollable: boolean }
   | { type: "TAIL_CONTENT_CHANGED" }
   | { type: "CONTENT_SHRANK" }
   | { type: "LAYOUT_HEIGHT_CHANGED" }
@@ -65,6 +68,7 @@ export const INITIAL_TRANSCRIPT_SCROLL_STATE: TranscriptScrollState = {
   mode: "tail-follow",
   atBottom: true,
   scrollable: false,
+  readerIntent: false,
   settleMode: "tail-follow",
   recoveryId: null,
 };
@@ -111,21 +115,34 @@ export function reduceTranscriptScroll(
       return preempt(INITIAL_TRANSCRIPT_SCROLL_STATE, [], "surface-switch");
     case "USER_SCROLL_INTENT":
       if (!state.scrollable) {
-        return preempt({ ...state, mode: "tail-follow", atBottom: true, settleMode: "tail-follow" });
+        return preempt({ ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" });
       }
-      return preempt({ ...state, mode: "manual", atBottom: false, settleMode: "manual" });
-    case "AT_BOTTOM_CHANGED": {
+      return preempt({ ...state, mode: "manual", readerIntent: true, settleMode: "manual" });
+    case "MANUAL_READING":
+      return preempt({ ...state, mode: "manual", readerIntent: false, settleMode: "manual" });
+    case "READER_INTENT_ENDED":
+      return transition(state.readerIntent ? { ...state, readerIntent: false } : state);
+    case "SCROLL_DELIVERED": {
       if (!event.scrollable) {
-        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, settleMode: "tail-follow" });
+        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, readerIntent: false, settleMode: "tail-follow" });
       }
       const next = { ...state, atBottom: event.atBottom, scrollable: true };
-      if (event.atBottom && state.mode !== "selection" && state.mode !== "user-resize" && state.mode !== "restoring") {
+      if (
+        event.atBottom
+        && state.readerIntent
+        && state.mode !== "selection"
+        && state.mode !== "user-resize"
+        && state.mode !== "restoring"
+      ) {
         next.mode = "tail-follow";
         next.settleMode = "tail-follow";
       }
-      // `false` is only a physical report. Dynamic measurement and viewport
-      // changes can produce it, so it never revokes tail ownership by itself.
-      return transition(next);
+      return transition(
+        next,
+        state.mode === "tail-follow" && !event.atBottom && !state.readerIntent
+          ? [{ type: "AUTOSCROLL_TO_BOTTOM" }]
+          : [],
+      );
     }
     case "TAIL_CONTENT_CHANGED":
     case "LAYOUT_HEIGHT_CHANGED":
@@ -137,34 +154,42 @@ export function reduceTranscriptScroll(
       // tail re-aim here visibly tugs the viewport after the collapse.
       return transition(state);
     case "USER_RESIZE_BEGIN":
-      return preempt({ ...state, mode: "user-resize", settleMode: "manual" });
+      return preempt({
+        ...state,
+        mode: "user-resize",
+        readerIntent: false,
+        settleMode: state.mode === "tail-follow" ? "tail-follow" : "manual",
+      });
     case "USER_RESIZE_END":
-      return transition(state.mode === "user-resize" ? { ...state, mode: "manual", settleMode: "manual" } : state);
+      return transition(
+        state.mode === "user-resize" ? { ...state, mode: state.settleMode } : state,
+        state.mode === "user-resize" && state.settleMode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : [],
+      );
     case "SELECTION_BEGIN":
-      return preempt({ ...state, mode: "selection", settleMode: "manual" });
+      return preempt({ ...state, mode: "selection", readerIntent: false, settleMode: "manual" });
     case "SELECTION_END":
       return transition(state.mode === "selection" ? { ...state, mode: "manual", settleMode: "manual" } : state);
     case "PROGRAMMATIC_BEGIN":
-      return preempt({ ...state, mode: "restoring", settleMode: event.settleMode ?? "manual" });
+      return preempt({ ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual" });
     case "PROGRAMMATIC_END":
       return transition(state.mode === "restoring" ? { ...state, mode: state.settleMode } : state);
     case "JUMP_TO_BOTTOM":
       return preempt(
-        { ...state, mode: "tail-follow", atBottom: true, settleMode: "tail-follow" },
+        { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" },
         [{ type: "SCROLL_TO_LAST", behavior: event.behavior === "smooth" ? "smooth" : "auto" }],
       );
     case "JUMP_TO_INDEX":
       return preempt(
-        { ...state, mode: "restoring", atBottom: false, settleMode: "manual" },
+        { ...state, mode: "restoring", atBottom: false, readerIntent: false, settleMode: "manual" },
         [{ type: "SCROLL_TO_INDEX", index: event.index, behavior: event.behavior ?? "auto" }],
       );
     case "SCROLL_TO_OFFSET":
       return preempt(
         event.owner === "selection-edge-scroll"
-          ? { ...state, mode: "selection", settleMode: "manual" }
+          ? { ...state, mode: "selection", readerIntent: false, settleMode: "manual" }
           : event.owner === "jump-bottom"
-            ? { ...state, mode: "tail-follow", atBottom: true, settleMode: "tail-follow" }
-            : { ...state, mode: "restoring", atBottom: false, settleMode: "manual" },
+            ? { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" }
+            : { ...state, mode: "restoring", atBottom: false, readerIntent: false, settleMode: "manual" },
         [{ type: "SCROLL_TO_OFFSET", owner: event.owner, top: event.top, behavior: event.behavior ?? "auto" }],
       );
     case "RECOVERY_BEGIN":
@@ -172,11 +197,11 @@ export function reduceTranscriptScroll(
       // through the same explicit cancel transition a takeover would use.
       if (state.recoveryId !== null && state.recoveryId !== event.id) {
         return transition(
-          { ...state, mode: "restoring", settleMode: event.settleMode ?? "manual", recoveryId: event.id },
+          { ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id },
           [{ type: "CANCEL_RECOVERY", id: state.recoveryId, reason: "superseded" }],
         );
       }
-      return transition({ ...state, mode: "restoring", settleMode: event.settleMode ?? "manual", recoveryId: event.id });
+      return transition({ ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id });
     case "RECOVERY_END":
       if (state.recoveryId !== event.id) return transition(state);
       return transition({

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -7,6 +7,7 @@ import type {
 } from "react";
 import type { FlatIndexLocationWithAlign, SizeFunction, StateSnapshot, VirtuosoHandle } from "react-virtuoso";
 import { isEditableTarget } from "./keyboardShortcuts";
+import { findVerticalScrollTarget } from "./nestedScrollHandoff";
 import { isNativeVerticalScrollbarPointer, measureTranscriptVirtuosoItem } from "./transcriptNativeScrollbar";
 import {
   INITIAL_TRANSCRIPT_SCROLL_STATE,
@@ -30,10 +31,8 @@ export const TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX = 4;
 // vertical padding or fractional row measurements. A bounded positive offset
 // is clamped by the browser and keeps the write within Virtuoso's API.
 const TRANSCRIPT_TAIL_CLAMP_OFFSET_PX = 64;
-// Bounded follow budget: re-aim at the last row across a few frames so late
-// row measurements cannot leave the view parked above the real bottom.
-const TAIL_SETTLE_MAX_ATTEMPTS = 6;
-const TAIL_SETTLE_BUDGET_MS = 500;
+const TAIL_STAGNANT_FRAME_LIMIT = 2;
+const READER_INTENT_IDLE_MS = 180;
 // Anchor restores wait for the anchor row to actually mount. An 8-frame
 // budget (~128 ms) expired before heavy rows mounted on WebView2, stranding
 // the view at the estimate-based (higher) scrollToIndex landing — the
@@ -135,9 +134,13 @@ export function useTranscriptScrollArbiter({
   const modeRef = useRef<TranscriptScrollMode>("tail-follow");
   const touchStartYRef = useRef<number | null>(null);
   const nativeScrollbarDragRef = useRef(false);
+  const middlePointerScrollRef = useRef(false);
+  const generationRef = useRef(0);
   const followFrameRef = useRef<number | null>(null);
   const tailSettleFrameRef = useRef<number | null>(null);
+  const tailSettleProgressRef = useRef<{ distance: number; stagnantFrames: number } | null>(null);
   const resizeSettleFrameRef = useRef<number | null>(null);
+  const readerIntentTimerRef = useRef<number | null>(null);
   const lastFollowExtentRef = useRef<number | null>(null);
   const recoveryRef = useRef<ActiveTranscriptRecovery | null>(null);
   const nextRecoveryIdRef = useRef(0);
@@ -151,10 +154,6 @@ export function useTranscriptScrollArbiter({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
 
-  // Re-aim at the tail across a few frames: the first request can still use
-  // Virtuoso's pre-measurement size tree, and late tail-row measurements
-  // would otherwise leave the view parked above the real bottom.
-  // User-ownership events cancel the pending frame through dispatch().
   const scrollToTail = useCallback((behavior: "auto" | "smooth") => {
     const element = scrollRef.current;
     if (liveTailActiveRef?.current && element) {
@@ -174,24 +173,52 @@ export function useTranscriptScrollArbiter({
     });
   }, [liveTailActiveRef]);
 
-  const scheduleTailSettle = useCallback(() => {
+  const cancelTailSettle = useCallback(() => {
     if (tailSettleFrameRef.current !== null) cancelAnimationFrame(tailSettleFrameRef.current);
-    const deadline = performance.now() + TAIL_SETTLE_BUDGET_MS;
-    let attempts = 0;
+    tailSettleFrameRef.current = null;
+    tailSettleProgressRef.current = null;
+  }, []);
+
+  const scheduleTailSettle = useCallback(() => {
+    if (tailSettleFrameRef.current !== null) return;
+    const generation = generationRef.current;
+    const scrollElement = scrollRef.current;
     const tick = () => {
       tailSettleFrameRef.current = null;
-      if (modeRef.current !== "tail-follow") return;
-      scrollToTail("auto");
-      attempts += 1;
-      const element = scrollRef.current;
-      const settled = !element
-        || nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX;
-      if (!settled && attempts < TAIL_SETTLE_MAX_ATTEMPTS && performance.now() < deadline) {
-        tailSettleFrameRef.current = requestAnimationFrame(tick);
+      if (
+        generationRef.current !== generation
+        || scrollRef.current !== scrollElement
+        || modeRef.current !== "tail-follow"
+      ) {
+        tailSettleProgressRef.current = null;
+        return;
       }
+      scrollToTail("auto");
+      const element = scrollRef.current;
+      if (!element) return;
+      const distance = nativeTranscriptDistanceFromBottom(element);
+      if (distance <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX) {
+        tailSettleProgressRef.current = null;
+        return;
+      }
+      const previous = tailSettleProgressRef.current;
+      const stagnantFrames = previous && Math.abs(previous.distance - distance) <= 0.5
+        ? previous.stagnantFrames + 1
+        : 0;
+      tailSettleProgressRef.current = { distance, stagnantFrames };
+      if (stagnantFrames < TAIL_STAGNANT_FRAME_LIMIT) tailSettleFrameRef.current = requestAnimationFrame(tick);
     };
     tailSettleFrameRef.current = requestAnimationFrame(tick);
   }, [scrollToTail]);
+
+  const invalidateAsyncFrames = useCallback(() => {
+    generationRef.current += 1;
+    if (followFrameRef.current !== null) cancelAnimationFrame(followFrameRef.current);
+    if (resizeSettleFrameRef.current !== null) cancelAnimationFrame(resizeSettleFrameRef.current);
+    followFrameRef.current = null;
+    resizeSettleFrameRef.current = null;
+    cancelTailSettle();
+  }, [cancelTailSettle]);
 
   // Executes the reducer's CANCEL_RECOVERY command. The cancelling event
   // already cleared recoveryId in the published state, so no RECOVERY_END
@@ -252,6 +279,7 @@ export function useTranscriptScrollArbiter({
   const dispatch = useCallback((event: TranscriptScrollEvent) => {
     if (
       event.type === "USER_SCROLL_INTENT"
+      || event.type === "MANUAL_READING"
       || event.type === "USER_RESIZE_BEGIN"
       || event.type === "SELECTION_BEGIN"
       || event.type === "PROGRAMMATIC_BEGIN"
@@ -259,8 +287,7 @@ export function useTranscriptScrollArbiter({
       || event.type === "SCROLL_TO_OFFSET"
       || event.type === "CONTENT_SHRANK"
     ) {
-      if (tailSettleFrameRef.current !== null) cancelAnimationFrame(tailSettleFrameRef.current);
-      tailSettleFrameRef.current = null;
+      cancelTailSettle();
     }
     if (event.type === "RESET") lastGoodAnchorRef.current = null;
     if (event.type === "USER_SCROLL_INTENT") {
@@ -272,7 +299,31 @@ export function useTranscriptScrollArbiter({
     publishState(result.state);
     for (const command of result.commands) runCommand(command);
     return result;
-  }, [publishState, runCommand]);
+  }, [cancelTailSettle, publishState, runCommand]);
+
+  const endReaderIntent = useCallback(() => {
+    if (readerIntentTimerRef.current !== null) window.clearTimeout(readerIntentTimerRef.current);
+    readerIntentTimerRef.current = null;
+    dispatch({ type: "READER_INTENT_ENDED" });
+  }, [dispatch]);
+
+  const armReaderIntentIdle = useCallback(() => {
+    if (readerIntentTimerRef.current !== null) window.clearTimeout(readerIntentTimerRef.current);
+    readerIntentTimerRef.current = window.setTimeout(() => {
+      readerIntentTimerRef.current = null;
+      dispatch({ type: "READER_INTENT_ENDED" });
+    }, READER_INTENT_IDLE_MS);
+  }, [dispatch]);
+
+  const deliverScroll = useCallback((element = scrollRef.current) => {
+    if (!element) return;
+    dispatch({
+      type: "SCROLL_DELIVERED",
+      atBottom: nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
+      scrollable: hasTranscriptScrollableRange(element),
+    });
+    if (stateRef.current.readerIntent) armReaderIntentIdle();
+  }, [armReaderIntentIdle, dispatch]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     if (isTranscriptSelectionMode(modeRef.current)) return;
@@ -394,40 +445,68 @@ export function useTranscriptScrollArbiter({
     launchRecovery(recovery);
   }, [finishRecovery, launchRecovery]);
 
+  const reset = useCallback(() => {
+    invalidateAsyncFrames();
+    endReaderIntent();
+    lastFollowExtentRef.current = null;
+    dispatch({ type: "RESET" });
+  }, [dispatch, endReaderIntent, invalidateAsyncFrames]);
+
   const setMode = useCallback((mode: TranscriptScrollMode, _reason?: string) => {
     switch (mode) {
-      case "tail-follow": dispatch({ type: "RESET" }); break;
-      case "manual": dispatch({ type: "USER_SCROLL_INTENT" }); break;
+      case "tail-follow": reset(); break;
+      case "manual": dispatch({ type: "MANUAL_READING" }); break;
       case "user-resize": dispatch({ type: "USER_RESIZE_BEGIN" }); break;
       case "selection": dispatch({ type: "SELECTION_BEGIN" }); break;
       case "restoring": dispatch({ type: "PROGRAMMATIC_BEGIN" }); break;
     }
-  }, [dispatch]);
+  }, [dispatch, reset]);
 
   const finishNativeScrollbarDrag = useCallback(() => {
     if (!nativeScrollbarDragRef.current) return;
-    nativeScrollbarDragRef.current = false;
     const element = scrollRef.current;
-    if (element) delete element.dataset.nativeScrollbarDrag;
+    if (element) {
+      dispatch({ type: "USER_SCROLL_INTENT" });
+      deliverScroll(element);
+      delete element.dataset.nativeScrollbarDrag;
+    }
+    endReaderIntent();
+    nativeScrollbarDragRef.current = false;
     setNativeScrollbarDragging(false);
-  }, []);
+    if (modeRef.current === "tail-follow") scheduleTailSettle();
+  }, [deliverScroll, dispatch, endReaderIntent, scheduleTailSettle]);
+
+  const finishPointerIntent = useCallback(() => {
+    if (nativeScrollbarDragRef.current) finishNativeScrollbarDrag();
+    if (middlePointerScrollRef.current) {
+      middlePointerScrollRef.current = false;
+      endReaderIntent();
+    }
+  }, [endReaderIntent, finishNativeScrollbarDrag]);
+
+  const finishAllReaderIntent = useCallback(() => {
+    finishPointerIntent();
+    endReaderIntent();
+  }, [endReaderIntent, finishPointerIntent]);
 
   useEffect(() => {
-    window.addEventListener("pointerup", finishNativeScrollbarDrag, true);
-    window.addEventListener("pointercancel", finishNativeScrollbarDrag, true);
-    window.addEventListener("blur", finishNativeScrollbarDrag);
+    window.addEventListener("pointerup", finishPointerIntent, true);
+    window.addEventListener("pointercancel", finishPointerIntent, true);
+    window.addEventListener("blur", finishAllReaderIntent);
     return () => {
-      window.removeEventListener("pointerup", finishNativeScrollbarDrag, true);
-      window.removeEventListener("pointercancel", finishNativeScrollbarDrag, true);
-      window.removeEventListener("blur", finishNativeScrollbarDrag);
+      window.removeEventListener("pointerup", finishPointerIntent, true);
+      window.removeEventListener("pointercancel", finishPointerIntent, true);
+      window.removeEventListener("blur", finishAllReaderIntent);
     };
-  }, [finishNativeScrollbarDrag]);
+  }, [finishAllReaderIntent, finishPointerIntent]);
 
   useEffect(() => () => {
     if (followFrameRef.current !== null) cancelAnimationFrame(followFrameRef.current);
     if (tailSettleFrameRef.current !== null) cancelAnimationFrame(tailSettleFrameRef.current);
     if (resizeSettleFrameRef.current !== null) cancelAnimationFrame(resizeSettleFrameRef.current);
+    if (readerIntentTimerRef.current !== null) window.clearTimeout(readerIntentTimerRef.current);
     if (recoveryRef.current?.frame != null) cancelAnimationFrame(recoveryRef.current.frame);
+    generationRef.current += 1;
     recoveryRef.current = null;
   }, []);
 
@@ -437,36 +516,42 @@ export function useTranscriptScrollArbiter({
 
   const scrollerRef = useCallback((node: HTMLElement | Window | null) => {
     const element = node instanceof HTMLElement ? node as HTMLDivElement : null;
-    if (scrollRef.current !== element) finishNativeScrollbarDrag();
+    if (scrollRef.current !== element) {
+      finishNativeScrollbarDrag();
+      invalidateAsyncFrames();
+    }
     scrollRef.current = element;
     if (element) {
       element.dataset.scrollMode = stateRef.current.mode;
-      dispatch({
-        type: "AT_BOTTOM_CHANGED",
-        atBottom: nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
-        scrollable: hasTranscriptScrollableRange(element),
-      });
+      deliverScroll(element);
     }
     setScrollElement((current) => current === element ? current : element);
-  }, [dispatch, finishNativeScrollbarDrag]);
+  }, [deliverScroll, finishNativeScrollbarDrag, invalidateAsyncFrames]);
 
-  const releaseTailFollow = useCallback(() => {
+  const releaseTailFollow = useCallback((claimPhysicalBottom = false) => {
     if (isTranscriptSelectionMode(modeRef.current)) return;
     const element = scrollRef.current;
     if (element && !stateRef.current.scrollable && hasTranscriptScrollableRange(element)) {
-      dispatch({
-        type: "AT_BOTTOM_CHANGED",
-        atBottom: nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
-        scrollable: true,
-      });
+      deliverScroll(element);
     }
     dispatch({ type: "USER_SCROLL_INTENT" });
-  }, [dispatch]);
+    if (
+      claimPhysicalBottom
+      && element
+      && nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX
+    ) {
+      deliverScroll(element);
+    }
+    armReaderIntentIdle();
+  }, [armReaderIntentIdle, deliverScroll, dispatch]);
 
   const followGrowingTail = useCallback(() => {
     if (followFrameRef.current !== null) return;
+    const generation = generationRef.current;
+    const scrollElement = scrollRef.current;
     followFrameRef.current = requestAnimationFrame(() => {
       followFrameRef.current = null;
+      if (generationRef.current !== generation || scrollRef.current !== scrollElement) return;
       const element = scrollRef.current;
       if (element) {
         const scrollHeight = element.scrollHeight;
@@ -484,27 +569,22 @@ export function useTranscriptScrollArbiter({
   const beginUserResize = useCallback(() => {
     dispatch({ type: "USER_RESIZE_BEGIN" });
     if (resizeSettleFrameRef.current !== null) cancelAnimationFrame(resizeSettleFrameRef.current);
+    const generation = generationRef.current;
+    const scrollElement = scrollRef.current;
     resizeSettleFrameRef.current = requestAnimationFrame(() => {
+      if (generationRef.current !== generation || scrollRef.current !== scrollElement) {
+        resizeSettleFrameRef.current = null;
+        return;
+      }
       resizeSettleFrameRef.current = requestAnimationFrame(() => {
         resizeSettleFrameRef.current = null;
+        if (generationRef.current !== generation || scrollRef.current !== scrollElement) return;
         dispatch({ type: "USER_RESIZE_END" });
       });
     });
   }, [dispatch]);
 
-  const atBottomStateChange = useCallback((atBottom: boolean) => {
-    const element = scrollRef.current;
-    dispatch({
-      type: "AT_BOTTOM_CHANGED",
-      atBottom,
-      scrollable: element ? hasTranscriptScrollableRange(element) : stateRef.current.scrollable,
-    });
-  }, [dispatch]);
-
-  const reset = useCallback(() => {
-    lastFollowExtentRef.current = null;
-    dispatch({ type: "RESET" });
-  }, [dispatch]);
+  const atBottomStateChange = useCallback((_atBottom: boolean) => deliverScroll(), [deliverScroll]);
 
   const writeOffset = useCallback((owner: TranscriptScrollOwner, top: number, behavior: ScrollBehavior = "auto") => {
     if (isTranscriptSelectionMode(modeRef.current) && owner !== "selection-edge-scroll") return false;
@@ -518,7 +598,10 @@ export function useTranscriptScrollArbiter({
     dispatch({ type: "JUMP_TO_INDEX", index: firstItemIndex + dataIndex, behavior });
   }, [dispatch]);
 
-  const finishProgrammaticScroll = useCallback(() => dispatch({ type: "PROGRAMMATIC_END" }), [dispatch]);
+  const finishProgrammaticScroll = useCallback(() => {
+    dispatch({ type: "PROGRAMMATIC_END" });
+    endReaderIntent();
+  }, [dispatch, endReaderIntent]);
 
   // getState invokes its callback synchronously with the live measured tree
   // and scrollTop (header height excluded).
@@ -533,15 +616,17 @@ export function useTranscriptScrollArbiter({
   const restoreTailIfNotScrollable = useCallback(() => {
     const element = scrollRef.current;
     if (!element || hasTranscriptScrollableRange(element)) return false;
-    dispatch({ type: "AT_BOTTOM_CHANGED", atBottom: true, scrollable: false });
+    deliverScroll(element);
     return true;
-  }, [dispatch]);
+  }, [deliverScroll]);
 
   const onWheelIntent = useCallback((event: ReactWheelEvent<HTMLElement>) => {
     if (event.ctrlKey || event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) return false;
+    const element = scrollRef.current;
+    if (element && findVerticalScrollTarget(event.target, element, event.deltaY)) return false;
     if (restoreTailIfNotScrollable()) return false;
     if (event.deltaY < 0 || !pinnedRef.current) {
-      releaseTailFollow();
+      releaseTailFollow(event.deltaY > 0);
       return true;
     }
     return false;
@@ -557,18 +642,23 @@ export function useTranscriptScrollArbiter({
     if (start == null || current == null || Math.abs(current - start) < 2) return false;
     if (restoreTailIfNotScrollable()) return false;
     if (current > start || !pinnedRef.current) {
-      releaseTailFollow();
+      releaseTailFollow(current < start);
       return true;
     }
     return false;
   }, [releaseTailFollow, restoreTailIfNotScrollable]);
+
+  const onTouchEndIntent = useCallback(() => {
+    touchStartYRef.current = null;
+    if (stateRef.current.readerIntent) armReaderIntentIdle();
+  }, [armReaderIntentIdle]);
 
   const onKeyScrollIntent = useCallback((event: ReactKeyboardEvent<HTMLElement>) => {
     if (isEditableTarget(event.target)) return false;
     if (!SCROLL_UP_KEYS.has(event.key) && !SCROLL_DOWN_KEYS.has(event.key)) return false;
     if (restoreTailIfNotScrollable()) return false;
     if (SCROLL_UP_KEYS.has(event.key) || !pinnedRef.current) {
-      releaseTailFollow();
+      releaseTailFollow(SCROLL_DOWN_KEYS.has(event.key));
       return true;
     }
     return false;
@@ -586,6 +676,7 @@ export function useTranscriptScrollArbiter({
       return true;
     }
     if (event.button !== 1 || restoreTailIfNotScrollable()) return false;
+    middlePointerScrollRef.current = true;
     releaseTailFollow();
     return true;
   }, [releaseTailFollow, restoreTailIfNotScrollable]);
@@ -593,7 +684,7 @@ export function useTranscriptScrollArbiter({
   const onNestedScrollIntent = useCallback((deltaY: number) => {
     if (deltaY === 0 || restoreTailIfNotScrollable()) return false;
     if (deltaY < 0 || !pinnedRef.current) {
-      releaseTailFollow();
+      releaseTailFollow(deltaY > 0);
       return true;
     }
     return false;
@@ -619,9 +710,11 @@ export function useTranscriptScrollArbiter({
     releaseTailFollow,
     beginUserResize,
     atBottomStateChange,
+    deliverScroll,
     onWheelIntent,
     onTouchStartIntent,
     onTouchMoveIntent,
+    onTouchEndIntent,
     onKeyScrollIntent,
     onPointerDownIntent,
     onNestedScrollIntent,

--- a/desktop/frontend/src/lib/useTranscriptScrollInteractions.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollInteractions.ts
@@ -1,21 +1,23 @@
-import { useCallback, useEffect, type KeyboardEvent, type PointerEvent, type RefObject, type TouchEvent, type WheelEvent } from "react";
+import { useCallback, useEffect, type KeyboardEvent, type PointerEvent, type TouchEvent, type WheelEvent } from "react";
 import { attachNestedScrollHandoff } from "./nestedScrollHandoff";
 
 export function useTranscriptScrollInteractions({
-  scrollRef,
+  scrollElement,
   cancelStreamingScroll,
   onWheelIntent,
   onTouchMoveIntent,
+  onTouchEndIntent,
   onKeyScrollIntent,
   onPointerDownIntent,
   onNestedScrollIntent,
   onScrollEnd,
   onSelectionPointerDown,
 }: {
-  scrollRef: RefObject<HTMLDivElement | null>;
+  scrollElement: HTMLDivElement | null;
   cancelStreamingScroll: () => void;
   onWheelIntent: (event: WheelEvent<HTMLElement>) => boolean;
   onTouchMoveIntent: (event: TouchEvent<HTMLElement>) => boolean;
+  onTouchEndIntent: () => void;
   onKeyScrollIntent: (event: KeyboardEvent<HTMLElement>) => boolean;
   onPointerDownIntent: (event: PointerEvent<HTMLElement>) => boolean;
   onNestedScrollIntent: (deltaY: number) => boolean;
@@ -23,7 +25,7 @@ export function useTranscriptScrollInteractions({
   onSelectionPointerDown: (event: PointerEvent<HTMLElement>) => void;
 }) {
   useEffect(() => {
-    const element = scrollRef.current;
+    const element = scrollElement;
     if (!element) return;
     const onNestedIntent = (deltaY: number) => {
       if (onNestedScrollIntent(deltaY)) cancelStreamingScroll();
@@ -34,7 +36,7 @@ export function useTranscriptScrollInteractions({
       handoff.detach();
       element.removeEventListener("scrollend", onScrollEnd);
     };
-  }, [cancelStreamingScroll, onNestedScrollIntent, onScrollEnd, scrollRef]);
+  }, [cancelStreamingScroll, onNestedScrollIntent, onScrollEnd, scrollElement]);
 
   const onWheelCapture = useCallback((event: WheelEvent<HTMLElement>) => {
     if (onWheelIntent(event)) cancelStreamingScroll();
@@ -43,6 +45,8 @@ export function useTranscriptScrollInteractions({
   const onTouchMoveCapture = useCallback((event: TouchEvent<HTMLElement>) => {
     if (onTouchMoveIntent(event)) cancelStreamingScroll();
   }, [cancelStreamingScroll, onTouchMoveIntent]);
+
+  const onTouchEndCapture = useCallback(() => onTouchEndIntent(), [onTouchEndIntent]);
 
   const onKeyDownCapture = useCallback((event: KeyboardEvent<HTMLElement>) => {
     if (onKeyScrollIntent(event)) cancelStreamingScroll();
@@ -53,5 +57,5 @@ export function useTranscriptScrollInteractions({
     onSelectionPointerDown(event);
   }, [cancelStreamingScroll, onPointerDownIntent, onSelectionPointerDown]);
 
-  return { onWheelCapture, onTouchMoveCapture, onKeyDownCapture, onPointerDownCapture };
+  return { onWheelCapture, onTouchMoveCapture, onTouchEndCapture, onKeyDownCapture, onPointerDownCapture };
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2793,8 +2793,8 @@ a[href] {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -3px;
-  right: -3px;
+  left: 0;
+  right: -7px;
 }
 .workspace-panel-resizer::after {
   display: none;


### PR DESCRIPTION
## Summary

- Make the live native scroller geometry authoritative for transcript bottom ownership; Virtuoso's `atBottomStateChange` is now only a delivery signal.
- Keep tail-follow converging across delayed row measurements and viewport growth, while explicit wheel/touch/key/thumb intent still transfers ownership to manual reading.
- Bind queued scroll work to the current generation and scrollport so callbacks from a previous session cannot write into the newly selected session.
- Claim a native thumb release at the physical bottom before row measurement resumes, and leave nested code/tool scrollers in control until they reach an edge.
- Move the workspace resize hit area fully into the dock and use one idempotent pointer lifecycle for release, cancellation, capture loss, blur, and unmount.
- Add deterministic race coverage plus a sanitized one-turn fixture with 70 tool results and 44 assistant blocks.

## Issues

Refs #8657

Follow-up to #8960. That PR established the single-writer arbiter; this PR closes the remaining split between Virtuoso's logical tail and the browser's physical tail observed on v1.26.0.

Related: #9027 fixes question-jump index translation. Its code is not incorporated here; it remains an independent change, although both PRs touch the transcript owner files and the later merge may need a routine rebase.

## Verification

- `pnpm test:transcript` — passed, including 66 deterministic recovery-race assertions and 25 reducer assertions.
- `pnpm exec tsx src/__tests__/resize-drag.test.ts` — 14/14 passed.
- `pnpm exec tsx src/__tests__/workspace-layout.test.ts` — 51/51 passed.
- `pnpm build` — passed Hooks lint, WAAPI, single-scroll-writer, CSS, TypeScript, Vite, and bundle budgets.
- Real Chromium transcript selection and scroll-stability gates — passed. The final scroll-stability gate passed four times consecutively after pinning outer wheel intent to the reserved transcript gutter and requiring both physical bottom and tail ownership under churn.
- Rapid-scroll browser probe: p95 frame gap about 9.2 ms, maximum about 16.6 ms, zero long tasks.
- `go run ./tools/repolint` — clean (1286 baselined findings).
- `git diff --check origin/main-v2...HEAD` — passed.
- Windows 11 ARM64 native frontend build and Wails/WebView2 link — passed.

Native WebView2 matrix, using the current VM's 1728×1079 host-logical display and verified renderer DPR values:

| DPR / Windows scale | Session A↔B | Wheel → jump bottom | Composer height round-trip | Native thumb round-trip | Final physical distance |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1.0 / 100% | 30/30 | 30/30 | 20/20 | 10/10 | 0 px |
| 1.25 / 125% | 30/30 | 30/30 | 20/20 | 10/10 | 0 px |
| 1.5 / 150% | 30/30 | 30/30 | 20/20 | 10/10 | 0.67 px |

At every scale, the native scrollbar gutter and workspace resizer had zero geometric overlap, right-gutter hit testing resolved to the transcript, and the 300 px dock width did not change during thumb drags. The VM display and DPI settings were restored after testing.

`pnpm test` still reports one repository-baseline static assertion failure: `Welcome is suppressed only until transcript history has loaded` (127 passed, 1 failed in `app-chrome-tabs.test.ts`). The same focused test fails identically on clean `origin/main-v2`; this branch does not modify that assertion or its source path. All pretest and transcript suites before it passed.

## Documentation impact

Documentation-impact: none - this changes internal desktop scrolling and splitter ownership; contributor-only invariants were updated in `desktop/AGENTS.md`.

## Compatibility and security

- No persisted session format, Wails contract, configuration, provider request, tool schema, dependency, permission, network, or filesystem behavior changes.
- No original user transcript, video, screenshot, machine path, or private content is included; the browser fixture preserves only the reported height distribution.
- The CDP-enabled Windows executable used to measure native WebView2 geometry was test-only, was not committed, and was deleted after the VM was restored.

## Cache impact

Cache-impact: low - `desktop/AGENTS.md` adds six stable directory-scoped native-geometry rules, causing a one-time prefix hash change for desktop workspaces; no per-turn or session-local bytes were added.
Cache-guard: `scripts/check-cache-impact.sh`; the diff contains no runtime prompt construction, tool schema/order, provider serialization, memory, or compaction changes.
System-prompt-review: reviewed - the added standing instruction is static engineering guidance only and contains no dynamic, user, workspace, path, or session data.
