### PR TITLE
feat(control): fire the Notification hook for pending ask questions

### DIFF
--- a/docs/DESKTOP_HOOKS.zh-CN.md
+++ b/docs/DESKTOP_HOOKS.zh-CN.md
@@ -125,7 +125,7 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 | `SessionStart` | 会话第一次变为活跃，或 `/new`、清空后新会话开始 | 否 | stdout 会作为下一轮模型上下文注入 |
 | `SessionEnd` | 会话关闭、切换、`/new`、清空或控制器释放时 | 否 | 无特殊作用 |
 | `SubagentStop` | 前台 `task` 子代理完成后 | 否 | 无特殊作用 |
-| `Notification` | 需要用户注意时，例如等待工具审批 | 否 | 无特殊作用 |
+| `Notification` | 需要用户注意时，例如等待工具审批或等待回答提问 | 否 | 无特殊作用 |
 | `PreCompact` | 上下文压缩开始前 | 否 | stdout 会追加为压缩摘要的额外指导 |
 
 只有 `PreToolUse` 和 `UserPromptSubmit` 是阻塞型事件。阻塞型事件中，命令 `exit 2` 或超时会阻断后续执行。
@@ -151,7 +151,7 @@ Reasonix 会把一行 JSON 写入 hook 命令的 stdin。所有 payload 都至�
 | `SessionStart` | 无 | `{"event":"SessionStart","cwd":"/repo"}` |
 | `SessionEnd` | 无 | `{"event":"SessionEnd","cwd":"/repo"}` |
 | `SubagentStop` | `lastAssistantText` | `{"event":"SubagentStop","cwd":"/repo","lastAssistantText":"子代理结论"}` |
-| `Notification` | `message` | `{"event":"Notification","cwd":"/repo","message":"approval needed: bash go test ./..."}` |
+| `Notification` | `message`, `notificationType` | `{"event":"Notification","cwd":"/repo","message":"approval needed: bash go test ./...","notificationType":"permission_prompt"}`；等待回答提问时 `notificationType` 为 `question_prompt` |
 | `PreCompact` | `trigger` | `{"event":"PreCompact","cwd":"/repo","trigger":"manual"}` |
 
 `toolArgs` 是工具参数的原始 JSON。比如 `bash` 通常会带 `{"command":"..."}`，其它工具会按自己的 schema 传入。`Notification.message` 会做必要的隐私收敛，例如记忆审批只包含工具名，不把记忆正文发给外部通知 hook。

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -726,6 +726,13 @@ func approvalNotificationText(tool, subject string) string {
 	return fmt.Sprintf(i18n.M.ApprovalNeededWithSubjectFmt, tool, subject)
 }
 
+func askNotificationText(questions []event.AskQuestion) string {
+	if len(questions) == 0 {
+		return fmt.Sprintf(i18n.M.AnswerNeededFmt, "")
+	}
+	return fmt.Sprintf(i18n.M.AnswerNeededFmt, questions[0].Prompt)
+}
+
 func permissionRequestHookPayload(tool, subject string, args json.RawMessage) (string, json.RawMessage, bool) {
 	switch tool {
 	case planApprovalTool:

--- a/internal/control/ask_notification_test.go
+++ b/internal/control/ask_notification_test.go
@@ -1,0 +1,71 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/hook"
+)
+
+// A question blocks the run on the user exactly like an approval prompt, so it
+// must fire the same Notification hook; without it an external channel hears
+// about pending approvals while a blocking ask looks like the agent working.
+func TestAskFiresNotificationHook(t *testing.T) {
+	var mu sync.Mutex
+	var stdins []string
+	hooks := hook.NewRunner([]hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "record-notification"},
+		Event:      hook.Notification,
+		Scope:      hook.ScopeProject,
+	}}, "", func(ctx context.Context, in hook.SpawnInput) hook.SpawnResult {
+		mu.Lock()
+		stdins = append(stdins, in.Stdin)
+		mu.Unlock()
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+
+	sink := &askProbeSink{}
+	c := New(Options{Sink: sink, SessionDir: t.TempDir(), Hooks: hooks})
+
+	go func() { _, _ = c.Ask(t.Context(), askProbeQuestions()) }()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(stdins)
+		mu.Unlock()
+		if n == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("a blocking question never fired the Notification hook")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	var payload struct {
+		Event            string `json:"event"`
+		Message          string `json:"message"`
+		NotificationType string `json:"notificationType"`
+	}
+	mu.Lock()
+	stdin := stdins[0]
+	mu.Unlock()
+	if err := json.Unmarshal([]byte(stdin), &payload); err != nil {
+		t.Fatalf("hook stdin is not JSON: %v", err)
+	}
+	if payload.Event != "Notification" {
+		t.Fatalf("event = %q, want Notification", payload.Event)
+	}
+	if payload.NotificationType != "question_prompt" {
+		t.Fatalf("notificationType = %q, want question_prompt", payload.NotificationType)
+	}
+	if payload.Message != "answer needed: Which fix?" {
+		t.Fatalf("message = %q, want the first question's prompt", payload.Message)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2484,6 +2484,9 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	c.approval.markAskEmitted(id)
 	c.sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{ID: id, Questions: questions}})
 	c.approval.promptEmitMu.Unlock()
+	// A question blocks the run on the user exactly like an approval prompt, so
+	// it gets the same external-attention ping (see requestApprovalDecisionWithOptions).
+	go c.hooks.Notification(ctx, askNotificationText(questions), "question_prompt")
 
 	waitCtx, cancelWait := c.approval.waitContext(ctx)
 	defer cancelWait()

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -122,6 +122,7 @@ type Messages struct {
 	SandboxEscapeApprovalChoices           string // approval choice list for OS sandbox escape prompts
 	ApprovalNeededFmt                      string // notification text for a pending approval, tool only
 	ApprovalNeededWithSubjectFmt           string // notification text for a pending approval with subject
+	AnswerNeededFmt                        string // notification text for a pending ask question
 	ToolApprovalSourceFmt                  string // "Source: %s" / "来源: %s"
 	ToolApprovalBuiltIn                    string // built-in tool source label
 	ToolApprovalImageUse                   string // image-understanding detail for understand_image-style tools

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -112,6 +112,7 @@ var English = Messages{
 	SandboxEscapeApprovalChoices:           "1. Allow once\n2. Use real environment for this session\n3. Deny\nChoose [1/2/3] (y/a/n also work)",
 	ApprovalNeededFmt:                      "approval needed: %s",
 	ApprovalNeededWithSubjectFmt:           "approval needed: %s %s",
+	AnswerNeededFmt:                        "answer needed: %s",
 	ToolApprovalSourceFmt:                  "Source: %s",
 	ToolApprovalBuiltIn:                    "built-in tool",
 	ToolApprovalImageUse:                   "It will read provided image input for image understanding.",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -113,6 +113,7 @@ var Chinese = Messages{
 	SandboxEscapeApprovalChoices:           "1. 允许一次\n2. 本会话使用真实环境\n3. 拒绝\n选择 [1/2/3]（兼容 y/a/n）",
 	ApprovalNeededFmt:                      "需要审批：%s",
 	ApprovalNeededWithSubjectFmt:           "需要审批：%s %s",
+	AnswerNeededFmt:                        "需要回答：%s",
 	ToolApprovalSourceFmt:                  "来源: %s",
 	ToolApprovalBuiltIn:                    "内置工具",
 	ToolApprovalImageUse:                   "将读取提供的图片用于图像理解。",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -109,6 +109,7 @@ var ChineseTraditional = Messages{
 	SandboxEscapeApprovalChoices:           "1. 允許一次\n2. 本會話使用真實環境\n3. 拒絕\n選擇 [1/2/3]（相容 y/a/n）",
 	ApprovalNeededFmt:                      "需要核准：%s",
 	ApprovalNeededWithSubjectFmt:           "需要核准：%s %s",
+	AnswerNeededFmt:                        "需要回答：%s",
 	ToolApprovalSourceFmt:                  "來源: %s",
 	ToolApprovalBuiltIn:                    "內建工具",
 	ToolApprovalImageUse:                   "將讀取提供的圖片用於圖像理解。",


### PR DESCRIPTION
The `ask` tool blocks the run on the user exactly like an approval prompt, but only approval prompts (and plan decisions, which share that path) fire the `Notification` hook. An external channel wired to `Notification` (desktop notice, phone ping) hears about every pending approval while a blocking question looks like the agent still working - the run is waiting and nothing pings.

This fires the same hook when the `AskRequest` is emitted: message `answer needed: <first question prompt>` (localized en/zh/zh-TW), `notificationType: "question_prompt"`.

- The fire site mirrors the approval one in `requestApprovalDecisionWithOptions`: async (`go`), after `promptEmitMu` is released, nil-safe via `Runner.Enabled()`.
- No matcher impact: `Notification` hooks do not use tool matchers, so existing hooks simply start receiving the new event; the new `notificationType` value lets scripts distinguish it from `permission_prompt`.
- `TestAskFiresNotificationHook` asserts the delivered payload (event, message, notificationType) through a fake spawner.
- Docs: the `Notification` rows in `DESKTOP_HOOKS.zh-CN.md` now mention pending questions and document `notificationType`.

Ran locally: gofmt, `go vet ./...`, `make lint`, `go test ./internal/control/ ./internal/tool/builtin/ ./internal/boot/ ./internal/hook/`.

Documentation-impact: updated - DESKTOP_HOOKS.zh-CN.md Notification event row and payload table now cover pending ask questions and the notificationType values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
