### PR TITLE
fix(provider): Recover Responses tool turns without reasoning / 修复 Responses 缺少推理的工具回合

### DIFF
--- a/internal/agent/live_responses_reasoning_test.go
+++ b/internal/agent/live_responses_reasoning_test.go
@@ -1,0 +1,165 @@
+//go:build live
+
+package agent
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider/responses"
+)
+
+// TestLiveDeepSeekResponsesAgentToolLoops verifies the official stateless
+// endpoint accepts tool turns both with and without a reasoning item. Every
+// run must execute the client tool exactly once and reach a visible final.
+func TestLiveDeepSeekResponsesAgentToolLoops(t *testing.T) {
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		t.Skip("DEEPSEEK_API_KEY not set")
+	}
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		t.Run(model, func(t *testing.T) {
+			prov := responses.New(responses.Config{
+				Name: "deepseek-responses", BaseURL: "https://api.deepseek.com", Model: model,
+				APIKey: key, KeyEnv: "DEEPSEEK_API_KEY", Effort: "high", Mode: "stateless", MaxOutputTokens: 512,
+			})
+			if closer, ok := prov.(interface{ CloseIdleConnections() }); ok {
+				t.Cleanup(closer.CloseIdleConnections)
+			}
+			retries, recovered := runLiveAgentToolLoops(t, prov, 10)
+			t.Logf("model=%s runs=10 tool_executions=10 retry_attempts=%d recovered=%d", model, retries, recovered)
+		})
+	}
+}
+
+// TestLiveDeepSeekResponsesMissingReasoningFallback keeps the upstream model
+// and stream real while a localhost proxy removes provider reasoning events
+// from tool-call responses. This deterministically exercises the compatibility
+// fallback without logging model output, tool arguments, or credentials.
+func TestLiveDeepSeekResponsesMissingReasoningFallback(t *testing.T) {
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		t.Skip("DEEPSEEK_API_KEY not set")
+	}
+	for _, tc := range []struct {
+		model          string
+		stripResponses int32
+		wantRetries    int
+	}{
+		{model: "deepseek-v4-flash", stripResponses: 1},
+		{model: "deepseek-v4-pro", stripResponses: 2, wantRetries: 1},
+	} {
+		t.Run(tc.model, func(t *testing.T) {
+			proxy := &liveResponsesReasoningStripProxy{stripResponses: tc.stripResponses}
+			server := httptest.NewServer(proxy)
+			defer server.Close()
+			prov := responses.New(responses.Config{
+				Name: "deepseek-responses", BaseURL: "https://api.deepseek.com", RequestURL: server.URL,
+				Model: tc.model, APIKey: key, KeyEnv: "DEEPSEEK_API_KEY", Effort: "high", Mode: "stateless", MaxOutputTokens: 512,
+			})
+			if closer, ok := prov.(interface{ CloseIdleConnections() }); ok {
+				t.Cleanup(closer.CloseIdleConnections)
+			}
+			retries, recovered := runLiveAgentToolLoops(t, prov, 1)
+			if retries != tc.wantRetries {
+				t.Fatalf("reasoning retries = %d, want %d", retries, tc.wantRetries)
+			}
+			if proxy.toolResponses.Load() < tc.stripResponses {
+				t.Fatalf("tool responses = %d, want at least %d", proxy.toolResponses.Load(), tc.stripResponses)
+			}
+			if tc.wantRetries > 0 && !proxy.firstTwoToolRequestsEqual() {
+				t.Fatal("missing-reasoning retry changed the frozen request")
+			}
+			t.Logf("model=%s upstream_requests=%d tool_responses=%d stripped_events=%d retry_attempts=%d recovered=%d exact_retry=%t",
+				tc.model, proxy.requests.Load(), proxy.toolResponses.Load(), proxy.strippedEvents.Load(), retries, recovered,
+				proxy.firstTwoToolRequestsEqual())
+		})
+	}
+}
+
+type liveResponsesReasoningStripProxy struct {
+	stripResponses int32
+	requests       atomic.Int32
+	toolResponses  atomic.Int32
+	strippedEvents atomic.Int32
+	mu             sync.Mutex
+	toolBodies     [][]byte
+}
+
+func (p *liveResponsesReasoningStripProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read request", http.StatusBadRequest)
+		return
+	}
+	p.requests.Add(1)
+	upstream, err := http.NewRequestWithContext(r.Context(), http.MethodPost,
+		"https://api.deepseek.com/responses", bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "create upstream request", http.StatusInternalServerError)
+		return
+	}
+	upstream.Header.Set("Authorization", r.Header.Get("Authorization"))
+	upstream.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{Timeout: 90 * time.Second}).Do(upstream)
+	if err != nil {
+		http.Error(w, "upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, "read upstream response", http.StatusBadGateway)
+		return
+	}
+	if resp.StatusCode == http.StatusOK && bytes.Contains(responseBody, []byte(`"type":"function_call"`)) {
+		toolResponse := p.toolResponses.Add(1)
+		if toolResponse <= p.stripResponses {
+			p.mu.Lock()
+			p.toolBodies = append(p.toolBodies, append([]byte(nil), body...))
+			p.mu.Unlock()
+			var stripped int
+			responseBody, stripped = stripResponsesReasoningEvents(responseBody)
+			p.strippedEvents.Add(int32(stripped))
+		}
+	}
+	w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(responseBody)
+}
+
+func (p *liveResponsesReasoningStripProxy) firstTwoToolRequestsEqual() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.toolBodies) >= 2 && bytes.Equal(p.toolBodies[0], p.toolBodies[1])
+}
+
+func stripResponsesReasoningEvents(body []byte) ([]byte, int) {
+	lines := bytes.Split(body, []byte("\n"))
+	out := make([][]byte, 0, len(lines))
+	stripped := 0
+	for _, line := range lines {
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if bytes.Equal(data, line) || len(data) == 0 {
+			out = append(out, line)
+			continue
+		}
+		if bytes.Contains(data, []byte(`"type":"response.reasoning`)) ||
+			(bytes.Contains(data, []byte(`"type":"response.output_item`)) && bytes.Contains(data, []byte(`"type":"reasoning"`))) {
+			if len(out) > 0 && bytes.HasPrefix(bytes.TrimSpace(out[len(out)-1]), []byte("event:")) {
+				out = out[:len(out)-1]
+			}
+			stripped++
+			continue
+		}
+		out = append(out, line)
+	}
+	return bytes.Join(out, []byte("\n")), stripped
+}

--- a/internal/agent/responses_reasoning_recovery_e2e_test.go
+++ b/internal/agent/responses_reasoning_recovery_e2e_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/provider/responses"
+)
+
+const responsesToolWithoutReasoningSSE = `data: {"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"echo"}}
+
+data: {"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"echo","arguments":"{\"text\":\"hi\"}"}}
+
+data: {"type":"response.completed","response":{"id":"resp_tool","usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}
+
+`
+
+const responsesFinalAnswerSSE = `data: {"type":"response.output_text.delta","item_id":"msg_1","content_index":0,"delta":"done"}
+
+data: {"type":"response.completed","response":{"id":"resp_final","usage":{"input_tokens":12,"output_tokens":1,"total_tokens":13}}}
+
+`
+
+func TestResponsesToolTurnWithoutReasoningContinuesSafely(t *testing.T) {
+	tests := []struct {
+		name, baseURL, model, effort string
+		wantRequests                 int
+		wantReasoningRetries         int
+	}{
+		{name: "deepseek flash", baseURL: "https://api.deepseek.com", model: "deepseek-v4-flash", effort: "high", wantRequests: 2},
+		{name: "deepseek pro", baseURL: "https://api.deepseek.com", model: "deepseek-v4-pro", effort: "high", wantRequests: 3, wantReasoningRetries: 1},
+		{name: "deepseek pro reasoning disabled", baseURL: "https://api.deepseek.com", model: "deepseek-v4-pro", effort: "none", wantRequests: 2},
+		{name: "mimo", baseURL: "https://api.xiaomimimo.com/v1", model: "mimo-v2.5-pro", effort: "high", wantRequests: 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var bodies [][]byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("read request: %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				mu.Lock()
+				bodies = append(bodies, append([]byte(nil), body...))
+				mu.Unlock()
+
+				w.Header().Set("Content-Type", "text/event-stream")
+				if bytes.Contains(body, []byte(`"type":"function_call_output"`)) {
+					_, _ = io.WriteString(w, responsesFinalAnswerSSE)
+					return
+				}
+				_, _ = io.WriteString(w, responsesToolWithoutReasoningSSE)
+			}))
+			defer srv.Close()
+
+			prov := responses.New(responses.Config{
+				Name: "responses-replay", APIKey: "test-key", BaseURL: tc.baseURL,
+				RequestURL: srv.URL, Model: tc.model, Effort: tc.effort,
+			})
+			sink := &recordSink{}
+			a := New(prov, echoRegistry(), NewSession(""), Options{MissingReasoningWarnStateDir: t.TempDir()}, sink)
+			if err := a.Run(withNoClosedLoop(context.Background()), "go"); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			mu.Lock()
+			gotBodies := append([][]byte(nil), bodies...)
+			mu.Unlock()
+			if len(gotBodies) != tc.wantRequests {
+				t.Fatalf("HTTP requests = %d, want %d", len(gotBodies), tc.wantRequests)
+			}
+			if tc.wantReasoningRetries == 1 && !bytes.Equal(gotBodies[0], gotBodies[1]) {
+				t.Fatal("missing-reasoning probe did not replay the exact frozen request")
+			}
+			if got := sink.recoveryCount(event.ProtocolRecoveryMissingReasoningRetryAttempted); got != tc.wantReasoningRetries {
+				t.Fatalf("reasoning retries = %d, want %d", got, tc.wantReasoningRetries)
+			}
+			if got := len(sink.kinds(event.ToolResult)); got != 1 {
+				t.Fatalf("tool results = %d, want exactly one execution", got)
+			}
+
+			var toolTurns int
+			for _, message := range a.Session().Snapshot() {
+				if message.Role == provider.RoleAssistant && len(message.ToolCalls) > 0 {
+					toolTurns++
+					if message.ReasoningContent != "" {
+						t.Fatalf("missing provider reasoning was fabricated as %q", message.ReasoningContent)
+					}
+				}
+			}
+			if toolTurns != 1 {
+				t.Fatalf("saved tool turns = %d, want 1", toolTurns)
+			}
+		})
+	}
+}

--- a/internal/provider/reasoning_replay.go
+++ b/internal/provider/reasoning_replay.go
@@ -65,8 +65,9 @@ func RequiresAssistantReasoningReplay(p Provider, m Message) bool {
 }
 
 // EmptyReasoningFallbackPolicy is optionally implemented by providers whose
-// wire protocol accepts an explicit empty reasoning field for assistant tool
-// turns. Anthropic thinking blocks do not have that fallback.
+// wire protocol accepts an assistant tool turn without provider-issued
+// reasoning, either as an explicit empty field or by omitting an optional
+// reasoning item. Anthropic thinking blocks do not have that fallback.
 type EmptyReasoningFallbackPolicy interface {
 	AllowsEmptyReasoningFallback() bool
 }

--- a/internal/provider/responses/reasoning_replay.go
+++ b/internal/provider/responses/reasoning_replay.go
@@ -1,0 +1,50 @@
+package responses
+
+import "strings"
+
+// RequiresToolCallReasoning tells the agent to preserve stateless vendors'
+// reasoning on assistant tool-call turns so the follow-up can replay it.
+// DeepSeek and MiMo document this requirement for multi-turn tool calls.
+func (c *client) RequiresToolCallReasoning() bool {
+	return c != nil && c.caps.toolCallReasoning && !responsesReasoningDisabled(c.effort)
+}
+
+// AllowsEmptyReasoningFallback reports that a Responses tool turn remains
+// replayable when the provider emitted no reasoning item. DeepSeek and MiMo
+// both accept the function_call/function_call_output pair without fabricating
+// a reasoning item; any reasoning that was emitted is still preserved above.
+func (c *client) AllowsEmptyReasoningFallback() bool {
+	return c.RequiresToolCallReasoning()
+}
+
+func (c *client) MissingToolCallReasoningWarningIdentity() string {
+	if c == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		"responses", strings.TrimSpace(c.name), strings.TrimSpace(c.requestURL),
+		strings.TrimSpace(c.model), strings.TrimSpace(c.vendor), strings.TrimSpace(c.mode), strings.TrimSpace(c.effort),
+	}, "\x00")
+}
+
+// WarnOnMissingToolCallReasoning reports a tool_calls turn that arrived
+// without reasoning only for vendors whose endpoint reliably emits it.
+// DeepSeek's official API emits tool-call reasoning for its pro-tier models,
+// so a missing chain-of-thought there is a real degradation worth one warning.
+// MiMo documents reasoning alongside tool calls but does not guarantee it on
+// every round (observed: mimo-v2.5-pro tool-call turn with empty reasoning),
+// so a missing chain-of-thought is endpoint-conditional, not a degradation
+// signal — silence the warning. Capability-driven (review #7234):
+// toolCallReasoning=false vendors (DashScope) never warn — no round-trip
+// contract; singleSegmentReasoning=true vendors (MiMo) never warn — their
+// tool-call thinking is a single optional segment. Only multi-segment
+// thinking vendors that require replay (DeepSeek) warn, scoped to non-flash.
+func (c *client) WarnOnMissingToolCallReasoning() bool {
+	if !c.RequiresToolCallReasoning() || c.caps.singleSegmentReasoning {
+		return false
+	}
+	model := strings.ToLower(strings.TrimSpace(c.model))
+	// Flash-tier DeepSeek models do not emit tool-call reasoning (same carve
+	// as openai.go expectsDeepSeekToolCallReasoning).
+	return !strings.Contains(model, "flash")
+}

--- a/internal/provider/responses/reasoning_replay_test.go
+++ b/internal/provider/responses/reasoning_replay_test.go
@@ -1,0 +1,45 @@
+package responses
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestEmptyReasoningFallbackIsScopedToThinkingStatelessVendors(t *testing.T) {
+	deepseek := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"})
+	if !provider.AllowsEmptyReasoningFallback(deepseek) {
+		t.Fatal("DeepSeek Responses provider must accept tool turns whose output omitted reasoning")
+	}
+	mimo := New(Config{Name: "mimo", BaseURL: "https://api.xiaomimimo.com/v1", Model: "mimo-v2.5-pro"})
+	if !provider.AllowsEmptyReasoningFallback(mimo) {
+		t.Fatal("MiMo Responses provider must accept its optional tool-call reasoning")
+	}
+	disabled := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", Effort: "none"})
+	if provider.RequiresToolCallReasoning(disabled) || provider.WarnOnMissingToolCallReasoning(disabled) {
+		t.Fatal("reasoning-disabled Responses provider must not require or diagnose missing reasoning")
+	}
+	unknown := New(Config{Name: "other", BaseURL: "https://example.com", Model: "m"})
+	if provider.AllowsEmptyReasoningFallback(unknown) {
+		t.Fatal("unknown Responses endpoint must not inherit a vendor-specific empty fallback")
+	}
+}
+
+func TestStatelessRequestReplaysToolPairWithoutFabricatingReasoning(t *testing.T) {
+	client := New(Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"}).(*client)
+	body, _, _ := client.buildRequestBody(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "run"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "echo", Content: "hi"},
+	}})
+
+	items := body["input"].([]map[string]any)
+	if len(items) != 3 || items[1]["type"] != "function_call" || items[2]["type"] != "function_call_output" {
+		t.Fatalf("input = %#v, want user/call/output", items)
+	}
+	for _, item := range items {
+		if item["type"] == "reasoning" {
+			t.Fatalf("missing provider reasoning was fabricated: %#v", item)
+		}
+	}
+}

--- a/internal/provider/responses/responses.go
+++ b/internal/provider/responses/responses.go
@@ -189,45 +189,6 @@ func responsesAutoOutputBudget(vendor, effort string) int {
 
 func (c *client) Name() string { return c.name }
 
-// RequiresToolCallReasoning tells the agent to preserve stateless vendors'
-// reasoning on assistant tool-call turns so the follow-up can replay it.
-// DeepSeek and MiMo document this requirement for multi-turn tool calls.
-func (c *client) RequiresToolCallReasoning() bool {
-	return c.caps.toolCallReasoning
-}
-
-func (c *client) MissingToolCallReasoningWarningIdentity() string {
-	if c == nil {
-		return ""
-	}
-	return strings.Join([]string{
-		"responses", strings.TrimSpace(c.name), strings.TrimSpace(c.requestURL),
-		strings.TrimSpace(c.model), strings.TrimSpace(c.vendor), strings.TrimSpace(c.mode), strings.TrimSpace(c.effort),
-	}, "\x00")
-}
-
-// WarnOnMissingToolCallReasoning reports a tool_calls turn that arrived
-// without reasoning only for vendors whose endpoint reliably emits it.
-// DeepSeek's official API emits tool-call reasoning for its pro-tier models,
-// so a missing chain-of-thought there is a real degradation worth one warning.
-// MiMo documents reasoning alongside tool calls but does not guarantee it on
-// every round (observed: mimo-v2.5-pro tool-call turn with empty reasoning),
-// so a missing chain-of-thought is endpoint-conditional, not a degradation
-// signal — silence the warning. Capability-driven (review #7234):
-// toolCallReasoning=false vendors (DashScope) never warn — no round-trip
-// contract; singleSegmentReasoning=true vendors (MiMo) never warn — their
-// tool-call thinking is a single optional segment. Only multi-segment
-// thinking vendors that require replay (DeepSeek) warn, scoped to non-flash.
-func (c *client) WarnOnMissingToolCallReasoning() bool {
-	if !c.caps.toolCallReasoning || c.caps.singleSegmentReasoning {
-		return false
-	}
-	model := strings.ToLower(strings.TrimSpace(c.model))
-	// Flash-tier DeepSeek models do not emit tool-call reasoning (same carve
-	// as openai.go expectsDeepSeekToolCallReasoning).
-	return !strings.Contains(model, "flash")
-}
-
 func (c *client) sendOpts() provider.SendOptions {
 	return provider.SendOptions{Provider: c.name, KeyEnv: c.keyEnv, KeySource: c.keySource, KeyPresent: c.apiKey != "", RetryAuth: c.authed.Load()}
 }


### PR DESCRIPTION
## Summary

- Recover DeepSeek and MiMo Responses tool turns when the provider omits an optional reasoning item.
- Make the replay requirement effort-aware so reasoning-disabled requests do not retry or fail for an expected empty reasoning stream.
- Keep one byte-identical diagnostic retry for DeepSeek Pro, while Flash and MiMo continue without a redundant request.
- Add deterministic SSE coverage and credential-gated live regressions for official DeepSeek Responses Flash and Pro.

## Issues

No linked issue.

## Verification

- `go test ./... -count=1`
- `go test -race ./internal/provider/responses ./internal/agent -run Responses -count=1`
- `go vet ./...`
- `go vet -tags=live ./internal/agent`
- `./scripts/cache-guard.sh`
- `go run ./tools/repolint`
- Paid live provider matrix: LongCat, Zhipu Coding Plan, OpenCode Go, and official DeepSeek; about 126 provider requests completed successfully.
- Official DeepSeek Responses: 10 Agent tool loops each for Flash and Pro, with exactly one tool execution per run.
- Forced missing-reasoning live path: Flash removed 25 reasoning events and continued without retry; Pro removed 57 events across two responses, replayed the frozen request byte-for-byte once, then continued with exactly one tool execution.

## Documentation impact

Documentation-impact: none - the documented Responses protocol and provider configuration are unchanged; this corrects recovery behavior for a valid existing response shape.

## Cache impact

Cache-impact: none - healthy provider-visible requests, prompt prefixes, tool schemas, and serialization order are unchanged. Only local validation/control flow changes when a response omits reasoning.
Cache-guard: `./scripts/cache-guard.sh` passed; deterministic and live tests also assert the DeepSeek Pro recovery replay is byte-identical.
System-prompt-review: N/A