### PR TITLE
fix(desktop): preserve upward transcript reader intent / 保留向上滚动阅读意图

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -22,6 +22,34 @@ function assert(condition, message) {
   process.stdout.write(`  PASS  ${message}\n`);
 }
 
+async function moveToOuterReaderGutter(page, transcript) {
+  const deadline = Date.now() + 5_000;
+  let point = null;
+  while (!point && Date.now() < deadline) {
+    point = await transcript.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const rows = [...element.querySelectorAll(".transcript__row")];
+      for (const row of rows) {
+        const rowRect = row.getBoundingClientRect();
+        const visibleTop = Math.max(rect.top, rowRect.top);
+        const visibleBottom = Math.min(rect.bottom, rowRect.bottom);
+        if (visibleBottom - visibleTop < 2) continue;
+        const y = visibleTop + (visibleBottom - visibleTop) / 2;
+        // Rows reserve 32px of inline padding outside every tool/code child.
+        // Prefer the left edge because the question navigator can cover the
+        // right edge, and require hit-testing to resolve to the row itself.
+        for (const x of [rowRect.left + 16, rowRect.right - 16]) {
+          if (document.elementFromPoint(x, y) === row) return { x, y };
+        }
+      }
+      return null;
+    });
+    if (!point) await page.waitForTimeout(16);
+  }
+  assert(point != null, "outer reader wheel target resolves to visible row padding");
+  await page.mouse.move(point.x, point.y);
+}
+
 async function waitForServer() {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
@@ -518,10 +546,15 @@ try {
   // autoscroll API and remain at the physical bottom without Reasonix scrollTop
   // correction loops.
   const jumpBottom = page.locator(".transcript__jump-bottom");
-  // Target the reserved transcript gutter so expanded nested tool/code
-  // scrollers cannot correctly retain this outer-reader intent.
-  await page.mouse.move(box.x + box.width - 6, box.y + box.height / 2);
+  // Re-measure and target the reserved row gutter inside the scrollport. The
+  // native scrollbar gutter itself is browser-owned and can swallow this wheel
+  // immediately after a thumb release.
+  await moveToOuterReaderGutter(page, transcript);
   await page.mouse.wheel(0, -800);
+  // Playwright resolves mouse.wheel before Chromium finishes the trusted
+  // event's native default scroll. Let that input settle before sampling the
+  // arbiter state or issuing another protocol command.
+  await page.waitForTimeout(100);
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual");
   await jumpBottom.waitFor({ state: "visible" });
   await jumpBottom.click();
@@ -566,8 +599,9 @@ try {
     element.scrollTop = Math.max(0, Math.floor((element.scrollHeight - element.clientHeight) / 2));
     element.dispatchEvent(new Event("scroll"));
   });
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await moveToOuterReaderGutter(page, transcript);
   await page.mouse.wheel(0, -240);
+  await page.waitForTimeout(100);
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual", undefined, { timeout: 5_000 });
   await transcript.evaluate(() => {
     window.__reachBottomProbe = { writes: [], snaps: [], remounts: 0, done: false };
@@ -677,10 +711,11 @@ try {
     element.scrollTop = Math.max(0, Math.floor((element.scrollHeight - element.clientHeight) / 2));
     element.dispatchEvent(new Event("scroll"));
   });
-  // Use the reserved right transcript gutter, not a nested tool/code
-  // scrollport, so this wheel explicitly transfers outer reader ownership.
-  await page.mouse.move(stormBox.x + stormBox.width - 6, stormBox.y + stormBox.height / 2);
+  // Use reserved row padding, not a nested tool/code scroller or the
+  // browser-owned native scrollbar gutter, for explicit reader ownership.
+  await moveToOuterReaderGutter(page, stormTranscript);
   await page.mouse.wheel(0, -240);
+  await page.waitForTimeout(100);
   await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual", undefined, { timeout: 5_000 });
   await stormTranscript.evaluate(() => {
     window.__stormProbe = { writes: [], snaps: [], remounts: 0, done: false };

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -48,7 +48,7 @@ check(
 
 const manual = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "TAIL_CONTENT_CHANGED" },
   { type: "VIEWPORT_RESIZED" },
@@ -56,9 +56,19 @@ const manual = run([
 check(manual.state.mode === "manual", "explicit user intent releases tail-follow");
 check(manual.commands.length === 0, "manual reading never receives tail commands");
 
+const upwardIntentAtBottomRace = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
+  // A scroll delivery queued before the trusted wheel's native default action
+  // must not reclaim the tail from an upward reader gesture.
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+]);
+check(upwardIntentAtBottomRace.state.mode === "manual", "upward reader intent survives a stale at-bottom delivery");
+
 const returned = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
 ]);
@@ -66,7 +76,7 @@ check(returned.state.mode === "tail-follow", "reaching the real bottom re-engage
 
 const browserClamp = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: true },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "READER_INTENT_ENDED" },
   { type: "CONTENT_SHRANK" },
@@ -76,7 +86,7 @@ check(browserClamp.state.mode === "manual", "a browser clamp without fresh reade
 
 const manualResize = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "READER_INTENT_ENDED" },
   { type: "USER_RESIZE_BEGIN" },
@@ -88,7 +98,7 @@ check(manualResize.commands.length === 0, "manual reading receives no tail write
 
 const shortTranscript = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: false },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
 ]);
 check(shortTranscript.state.mode === "tail-follow", "non-overflow transcript always stays tail-follow");
 
@@ -113,7 +123,7 @@ check(selection.commands.join(",") === "SCROLL_TO_OFFSET", "selection owns only 
 
 const jump = run([
   { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
-  { type: "USER_SCROLL_INTENT" },
+  { type: "USER_SCROLL_INTENT", canClaimTail: false },
   { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
   { type: "JUMP_TO_BOTTOM", behavior: "smooth" },
 ]);

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -25,6 +25,7 @@ export type TranscriptScrollState = {
   atBottom: boolean;
   scrollable: boolean;
   readerIntent: boolean;
+  readerIntentCanClaimTail: boolean;
   settleMode: "tail-follow" | "manual";
   /** Id of the in-flight recovery request; at most one at a time. */
   recoveryId: number | null;
@@ -32,7 +33,7 @@ export type TranscriptScrollState = {
 
 export type TranscriptScrollEvent =
   | { type: "RESET" }
-  | { type: "USER_SCROLL_INTENT" }
+  | { type: "USER_SCROLL_INTENT"; canClaimTail: boolean }
   | { type: "MANUAL_READING" }
   | { type: "READER_INTENT_ENDED" }
   | { type: "SCROLL_DELIVERED"; atBottom: boolean; scrollable: boolean }
@@ -69,6 +70,7 @@ export const INITIAL_TRANSCRIPT_SCROLL_STATE: TranscriptScrollState = {
   atBottom: true,
   scrollable: false,
   readerIntent: false,
+  readerIntentCanClaimTail: false,
   settleMode: "tail-follow",
   recoveryId: null,
 };
@@ -115,21 +117,22 @@ export function reduceTranscriptScroll(
       return preempt(INITIAL_TRANSCRIPT_SCROLL_STATE, [], "surface-switch");
     case "USER_SCROLL_INTENT":
       if (!state.scrollable) {
-        return preempt({ ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" });
+        return preempt({ ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" });
       }
-      return preempt({ ...state, mode: "manual", readerIntent: true, settleMode: "manual" });
+      return preempt({ ...state, mode: "manual", readerIntent: true, readerIntentCanClaimTail: event.canClaimTail, settleMode: "manual" });
     case "MANUAL_READING":
-      return preempt({ ...state, mode: "manual", readerIntent: false, settleMode: "manual" });
+      return preempt({ ...state, mode: "manual", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" });
     case "READER_INTENT_ENDED":
-      return transition(state.readerIntent ? { ...state, readerIntent: false } : state);
+      return transition(state.readerIntent ? { ...state, readerIntent: false, readerIntentCanClaimTail: false } : state);
     case "SCROLL_DELIVERED": {
       if (!event.scrollable) {
-        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, readerIntent: false, settleMode: "tail-follow" });
+        return transition({ ...state, mode: "tail-follow", atBottom: true, scrollable: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" });
       }
       const next = { ...state, atBottom: event.atBottom, scrollable: true };
       if (
         event.atBottom
         && state.readerIntent
+        && state.readerIntentCanClaimTail
         && state.mode !== "selection"
         && state.mode !== "user-resize"
         && state.mode !== "restoring"
@@ -158,6 +161,7 @@ export function reduceTranscriptScroll(
         ...state,
         mode: "user-resize",
         readerIntent: false,
+        readerIntentCanClaimTail: false,
         settleMode: state.mode === "tail-follow" ? "tail-follow" : "manual",
       });
     case "USER_RESIZE_END":
@@ -166,30 +170,30 @@ export function reduceTranscriptScroll(
         state.mode === "user-resize" && state.settleMode === "tail-follow" ? [{ type: "AUTOSCROLL_TO_BOTTOM" }] : [],
       );
     case "SELECTION_BEGIN":
-      return preempt({ ...state, mode: "selection", readerIntent: false, settleMode: "manual" });
+      return preempt({ ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" });
     case "SELECTION_END":
       return transition(state.mode === "selection" ? { ...state, mode: "manual", settleMode: "manual" } : state);
     case "PROGRAMMATIC_BEGIN":
-      return preempt({ ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual" });
+      return preempt({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual" });
     case "PROGRAMMATIC_END":
       return transition(state.mode === "restoring" ? { ...state, mode: state.settleMode } : state);
     case "JUMP_TO_BOTTOM":
       return preempt(
-        { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" },
+        { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" },
         [{ type: "SCROLL_TO_LAST", behavior: event.behavior === "smooth" ? "smooth" : "auto" }],
       );
     case "JUMP_TO_INDEX":
       return preempt(
-        { ...state, mode: "restoring", atBottom: false, readerIntent: false, settleMode: "manual" },
+        { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" },
         [{ type: "SCROLL_TO_INDEX", index: event.index, behavior: event.behavior ?? "auto" }],
       );
     case "SCROLL_TO_OFFSET":
       return preempt(
         event.owner === "selection-edge-scroll"
-          ? { ...state, mode: "selection", readerIntent: false, settleMode: "manual" }
+          ? { ...state, mode: "selection", readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" }
           : event.owner === "jump-bottom"
-            ? { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, settleMode: "tail-follow" }
-            : { ...state, mode: "restoring", atBottom: false, readerIntent: false, settleMode: "manual" },
+            ? { ...state, mode: "tail-follow", atBottom: true, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "tail-follow" }
+            : { ...state, mode: "restoring", atBottom: false, readerIntent: false, readerIntentCanClaimTail: false, settleMode: "manual" },
         [{ type: "SCROLL_TO_OFFSET", owner: event.owner, top: event.top, behavior: event.behavior ?? "auto" }],
       );
     case "RECOVERY_BEGIN":
@@ -197,11 +201,11 @@ export function reduceTranscriptScroll(
       // through the same explicit cancel transition a takeover would use.
       if (state.recoveryId !== null && state.recoveryId !== event.id) {
         return transition(
-          { ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id },
+          { ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id },
           [{ type: "CANCEL_RECOVERY", id: state.recoveryId, reason: "superseded" }],
         );
       }
-      return transition({ ...state, mode: "restoring", readerIntent: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id });
+      return transition({ ...state, mode: "restoring", readerIntent: false, readerIntentCanClaimTail: false, settleMode: event.settleMode ?? "manual", recoveryId: event.id });
     case "RECOVERY_END":
       if (state.recoveryId !== event.id) return transition(state);
       return transition({

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -466,7 +466,7 @@ export function useTranscriptScrollArbiter({
     if (!nativeScrollbarDragRef.current) return;
     const element = scrollRef.current;
     if (element) {
-      dispatch({ type: "USER_SCROLL_INTENT" });
+      dispatch({ type: "USER_SCROLL_INTENT", canClaimTail: true });
       deliverScroll(element);
       delete element.dataset.nativeScrollbarDrag;
     }
@@ -534,7 +534,7 @@ export function useTranscriptScrollArbiter({
     if (element && !stateRef.current.scrollable && hasTranscriptScrollableRange(element)) {
       deliverScroll(element);
     }
-    dispatch({ type: "USER_SCROLL_INTENT" });
+    dispatch({ type: "USER_SCROLL_INTENT", canClaimTail: claimPhysicalBottom });
     if (
       claimPhysicalBottom
       && element


### PR DESCRIPTION
## Summary / 概要

- Preserve upward reader ownership when a stale at-bottom scroll delivery races the trusted wheel default action.
- Harden the transcript browser gate to target live row padding instead of stale or browser-owned scrollbar geometry.
- 保证向上滚动与迟到的底部事件竞态时，阅读模式不会被 tail-follow 抢回。
- 浏览器门禁改为动态命中可见行的保留 padding，避开原生 scrollbar 与嵌套滚动区。

## Root cause / 根因

USER_SCROLL_INTENT did not record whether the gesture was moving toward the physical tail. A queued SCROLL_DELIVERED(atBottom=true) could therefore reclaim tail-follow before Chromium applied an upward wheel default action. The gate also reused stale viewport coordinates after a native thumb drag.

USER_SCROLL_INTENT 未记录手势是否允许认领物理底部；因此 Chromium 尚未应用向上滚轮默认动作时，迟到的 atBottom=true 事件可能错误恢复 tail-follow。测试同时复用了原生滚动条拖拽前的旧坐标。

## Fix / 修复

- Carry canClaimTail through the reader-intent lifecycle.
- Allow only downward or native-bottom gestures to reclaim tail-follow from an at-bottom delivery.
- Re-resolve a visible outer-row padding target before each explicit reader wheel and wait for trusted wheel settlement.

## Documentation impact / 文档影响

Documentation-impact: none - Internal scroll ownership correction and browser regression coverage; existing user documentation remains correct.

## Verification / 验证

- pnpm test:transcript
- pnpm test:transcript-browser
- pnpm test:typecheck
- pnpm build
- transcript-scroll-stability: 10 consecutive Chromium passes after the final change
- go run ./tools/repolint
- git diff --check

This is the separate baseline-flaky fix observed while validating #9046; #9046 remains unchanged.

这是验证 #9046 时发现的基线 flaky 独立修复；#9046 本身未改动。