### PR TITLE
feat(desktop): group changed files by folder

### DIFF
--- a/desktop/frontend/src/__tests__/workspace-change-tree.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-change-tree.test.ts
@@ -1,0 +1,75 @@
+// Run: tsx src/__tests__/workspace-change-tree.test.ts
+
+import { buildWorkspaceChangeTree } from "../lib/workspaceChangeTree";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (JSON.stringify(a) === JSON.stringify(b)) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nworkspace change tree");
+
+const changes = [
+  { path: "src/main.ts", kind: "modified" },
+  { path: "README.md", kind: "added" },
+  { path: "src/components/App.tsx", kind: "modified" },
+  { path: "src/components/panels/Changes.tsx", kind: "added" },
+];
+
+const tree = buildWorkspaceChangeTree(changes);
+
+eq(
+  tree.map((node) => ({ kind: node.kind, name: node.name, path: node.path })),
+  [
+    { kind: "folder", name: "src", path: "src/" },
+    { kind: "file", name: "README.md", path: "README.md" },
+  ],
+  "groups changed files under their top-level folder while keeping root files visible",
+);
+
+const src = tree[0];
+eq(
+  src.kind === "folder" ? src.children.map((node) => ({ kind: node.kind, name: node.name, path: node.path })) : [],
+  [
+    { kind: "folder", name: "components", path: "src/components/" },
+    { kind: "file", name: "main.ts", path: "src/main.ts" },
+  ],
+  "builds nested folder nodes and keeps files attached to their parent",
+);
+
+const components = src.kind === "folder" ? src.children[0] : undefined;
+eq(
+  components?.kind === "folder" ? components.children.map((node) => node.path) : [],
+  ["src/components/panels/", "src/components/App.tsx"],
+  "preserves deeper nesting beneath a folder node",
+);
+
+eq(
+  tree.find((node) => node.kind === "file" && node.path === "README.md")?.change,
+  changes[1],
+  "file nodes retain the original change record for rendering actions and metadata",
+);
+
+const duplicatePaths = buildWorkspaceChangeTree([
+  { key: "first", path: "src/shared.ts" },
+  { key: "second", path: "src/shared.ts" },
+]);
+const duplicateFiles = duplicatePaths[0]?.kind === "folder" ? duplicatePaths[0].children : [];
+eq(
+  duplicateFiles.map((node) => node.key),
+  ["file:first", "file:second"],
+  "scoped change keys keep duplicate paths as distinct file rows",
+);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}
+process.stdout.write(`\n${passed} passed, ${failed} failed\n`);

--- a/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
+++ b/desktop/frontend/src/__tests__/workspace-changes-errors.test.tsx
@@ -116,6 +116,26 @@ console.log("\nworkspace changes git errors");
 }
 
 {
+  const { dom, root } = await renderFilesWorkspace({}, {
+    changeListRequest: {
+      id: 1,
+      changes: [
+        { key: "a", path: "src/components/App.tsx", meta: "M", time: "", detail: "" },
+        { key: "b", path: "src/components/panels/Changes.tsx", meta: "A", time: "", detail: "" },
+      ],
+    },
+  });
+
+  await waitFor("scoped hierarchical changed files", () => document.querySelector('[data-workspace-change-folder="src/"]') !== null);
+  ok(document.querySelector('[data-workspace-change-folder="src/components/"]') !== null, "scoped changed files reuse the folder hierarchy");
+  ok(document.querySelectorAll(".workspace-change").length === 2, "scoped changed files keep each file action row");
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
   const { dom, root } = await renderWorkspace(
     {
       files: [
@@ -141,6 +161,37 @@ console.log("\nworkspace changes git errors");
   });
   await waitFor("expanded creation commit history", () => document.body.textContent?.includes("older commit") === true);
   ok(document.body.textContent?.includes("older commit") === true, "Creation commit history expands on demand");
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const { dom, root } = await renderWorkspace({
+    files: [
+      { path: "src/main.ts", sources: ["session"], gitStatus: "M" },
+      { path: "src/components/App.tsx", sources: ["session"], gitStatus: "M" },
+      { path: "src/components/panels/Changes.tsx", sources: ["session"], gitStatus: "A" },
+      { path: "README.md", sources: ["session"], gitStatus: "M" },
+    ],
+    gitAvailable: true,
+  });
+
+  await waitFor("hierarchical changed files", () => document.querySelector('[data-workspace-change-folder="src/"]') !== null);
+  ok(document.querySelector('[data-workspace-change-folder="src/"]') !== null, "changed files render a top-level folder node");
+  ok(document.querySelector('[data-workspace-change-folder="src/components/"]') !== null, "changed files render nested folder nodes");
+  ok(document.body.textContent?.includes("main.ts") === true && document.body.textContent?.includes("README.md") === true, "expanded folders and root files are visible together");
+
+  const srcFolder = document.querySelector<HTMLButtonElement>('[data-workspace-change-folder="src/"]');
+  await act(async () => {
+    srcFolder?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    await flushPromises();
+  });
+  await waitFor("collapsed changed folder", () => document.querySelector('[data-workspace-change-folder="src/components/"]') === null);
+  ok(document.querySelector('[data-workspace-change-folder="src/components/"]') === null, "collapsing a changed folder hides its descendants");
+  ok(document.body.textContent?.includes("README.md") === true, "collapsing a changed folder keeps root files visible");
+
   await act(async () => {
     root.unmount();
   });

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type {
   CSSProperties,
@@ -6,11 +6,13 @@ import type {
   KeyboardEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
+  ReactElement,
 } from "react";
 import {
   ChevronDown,
   ChevronRight,
   FileText,
+  Folder,
   FolderTree,
   FolderX,
   GitBranch,
@@ -47,6 +49,8 @@ import {
 import { shouldScrollWorkspaceTreeSelection } from "../lib/workspaceTreeReveal";
 import { mergeWorkspaceSearchResults } from "../lib/workspaceTreeSearch";
 import { useWorkspaceTreeScrollPersistence } from "../lib/useWorkspaceTreeScrollPersistence";
+import { buildWorkspaceChangeTree, type WorkspaceChangeTreeInput, type WorkspaceChangeTreeNode } from "../lib/workspaceChangeTree";
+import { WorkspaceFileIcon } from "./WorkspaceFileIcon";
 import {
   readWorkspaceTreeMemory,
   rememberWorkspaceTreeOpenDirs,
@@ -255,6 +259,7 @@ export function WorkspacePanel({
   const [codeSearchRequestPath, setCodeSearchRequestPath] = useState<string | null>(null);
   /** Changes overview: commit history is secondary and starts collapsed. */
   const [commitHistoryOpen, setCommitHistoryOpen] = useState(false);
+  const [collapsedChangeDirs, setCollapsedChangeDirs] = useState<Set<string>>(() => new Set());
   const lastPreviewModeActiveRef = useRef<boolean | null>(null);
   const lastRevealRequestIdRef = useRef<number | null>(null);
   const dismissedRevealRequestIdRef = useRef<number | null>(null);
@@ -560,6 +565,7 @@ export function WorkspacePanel({
     setExpandedCommit(null);
     setCommitDetail(null);
     setScopedChangeRows(null);
+    setCollapsedChangeDirs(new Set());
     lastChangeRevealRequestIdRef.current = null;
     dismissedChangeRevealRequestIdRef.current = null;
     lastChangeListRequestIdRef.current = null;
@@ -916,6 +922,53 @@ export function WorkspacePanel({
     ? t("workspace.gitUnavailable")
     : null;
 
+  const toggleChangeDir = useCallback((path: string) => {
+    setCollapsedChangeDirs((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  function renderChangeTree<T extends WorkspaceChangeTreeInput>(
+    changes: readonly T[],
+    renderFile: (change: T, depth: number) => ReactElement,
+  ): ReactElement {
+    const tree = buildWorkspaceChangeTree(changes);
+
+    const renderNodes = (nodes: WorkspaceChangeTreeNode<T>[], depth: number): ReactElement[] =>
+      nodes.map((node) => {
+        if (node.kind === "folder") {
+          const collapsed = collapsedChangeDirs.has(node.path);
+          return (
+            <div key={node.key} className="workspace-change-tree__folder">
+              <button
+                type="button"
+                className="workspace-change-folder"
+                data-workspace-change-folder={node.path}
+                aria-expanded={!collapsed}
+                onClick={() => toggleChangeDir(node.path)}
+                style={{ paddingLeft: 8 + depth * 14 }}
+              >
+                <ChevronRight
+                  size={13}
+                  aria-hidden="true"
+                  className={`workspace-change-folder__chev${collapsed ? "" : " workspace-change-folder__chev--open"}`}
+                />
+                <Folder size={14} aria-hidden="true" className="workspace-change-folder__icon" />
+                <span className="workspace-change-folder__name">{node.name}</span>
+              </button>
+              {!collapsed && <div className="workspace-change-tree__children">{renderNodes(node.children, depth + 1)}</div>}
+            </div>
+          );
+        }
+        return <Fragment key={node.key}>{renderFile(node.change, depth)}</Fragment>;
+      });
+
+    return <div className="workspace-change-tree">{renderNodes(tree, 0)}</div>;
+  }
+
   const renderChangeScope = (title: string, changes: typeof sessionChanges) => (
     <div className="workspace-change-scope">
       <div className="workspace-change-scope__head">
@@ -923,16 +976,17 @@ export function WorkspacePanel({
         <span className="workspace-change-scope__meta">{t("context.changedMeta", { count: changes.length })}</span>
       </div>
       <div className="workspace-change-scope__list">
-        {changes.map((change) => {
+        {renderChangeTree(changes, (change, depth) => {
           const dir = parentPath(change.path);
           return (
-            <div key={change.path} className="workspace-change-row">
+            <div className="workspace-change-row">
               <button
                 className="workspace-change"
                 type="button"
                 onClick={() => selectFile(change.path)}
+                style={{ paddingLeft: 8 + depth * 14 }}
               >
-                <FileText size={14} />
+                <WorkspaceFileIcon fileName={basename(change.path)} />
                 <span className="workspace-change__body">
                   <span className="workspace-change__name">{basename(change.path)}</span>
                   {dir && <span className="workspace-change__path">{dir}</span>}
@@ -1650,13 +1704,13 @@ export function WorkspacePanel({
                 </Tooltip>
               </div>
               <div className="workspace-change-scope__list">
-                {scopedChangeRows.map((change) => {
+                {renderChangeTree(scopedChangeRows, (change, depth) => {
                   const dir = parentPath(change.path);
                   return (
                     <button
-                      key={change.key}
                       className="workspace-change"
                       type="button"
+                      style={{ paddingLeft: 8 + depth * 14 }}
                       onClick={() => {
                         dismissedChangeListRequestIdRef.current = lastChangeListRequestIdRef.current;
                         setScopedChangeRows(null);

--- a/desktop/frontend/src/lib/workspaceChangeTree.ts
+++ b/desktop/frontend/src/lib/workspaceChangeTree.ts
@@ -1,0 +1,66 @@
+export type WorkspaceChangeTreeInput = { path: string; key?: string };
+
+export type WorkspaceChangeTreeNode<T extends WorkspaceChangeTreeInput> =
+  | {
+      kind: "folder";
+      key: string;
+      name: string;
+      path: string;
+      children: WorkspaceChangeTreeNode<T>[];
+    }
+  | {
+      kind: "file";
+      key: string;
+      name: string;
+      path: string;
+      change: T;
+    };
+
+function compareNodes<T extends WorkspaceChangeTreeInput>(
+  left: WorkspaceChangeTreeNode<T>,
+  right: WorkspaceChangeTreeNode<T>,
+): number {
+  if (left.kind !== right.kind) return left.kind === "folder" ? -1 : 1;
+  return left.name.localeCompare(right.name);
+}
+
+/** Convert slash-delimited changed paths into a stable folder/file tree. */
+export function buildWorkspaceChangeTree<T extends WorkspaceChangeTreeInput>(
+  changes: readonly T[],
+): WorkspaceChangeTreeNode<T>[] {
+  const root: WorkspaceChangeTreeNode<T>[] = [];
+  const fileKeyCounts = new Map<string, number>();
+
+  for (const change of changes) {
+    const parts = change.path.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+
+    let children = root;
+    let folderPath = "";
+    for (const part of parts.slice(0, -1)) {
+      folderPath += `${part}/`;
+      let folder = children.find((node) => node.kind === "folder" && node.path === folderPath);
+      if (!folder || folder.kind !== "folder") {
+        folder = { kind: "folder", key: `folder:${folderPath}`, name: part, path: folderPath, children: [] };
+        children.push(folder);
+      }
+      children = folder.children;
+    }
+
+    const name = parts[parts.length - 1];
+    const fileKeyBase = change.key?.trim() || change.path;
+    const occurrence = fileKeyCounts.get(fileKeyBase) ?? 0;
+    fileKeyCounts.set(fileKeyBase, occurrence + 1);
+    const fileKeySuffix = occurrence === 0 ? "" : `:${occurrence}`;
+    children.push({ kind: "file", key: `file:${fileKeyBase}${fileKeySuffix}`, name, path: change.path, change });
+  }
+
+  const sortTree = (nodes: WorkspaceChangeTreeNode<T>[]) => {
+    nodes.sort(compareNodes);
+    for (const node of nodes) {
+      if (node.kind === "folder") sortTree(node.children);
+    }
+  };
+  sortTree(root);
+  return root;
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11030,6 +11030,59 @@ body > .mermaid-diagram--fullscreen {
   outline: 2px solid color-mix(in srgb, var(--danger) 24%, transparent);
   outline-offset: 2px;
 }
+.workspace-change-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.workspace-change-tree__folder,
+.workspace-change-tree__children {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.workspace-change-folder {
+  --wails-draggable: no-drag;
+  width: 100%;
+  min-width: 0;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding-top: 5px;
+  padding-right: 8px;
+  padding-bottom: 5px;
+  border: 0;
+  border-radius: var(--tree-row-radius);
+  background: transparent;
+  color: var(--fg-dim);
+  font: inherit;
+  text-align: left;
+}
+.workspace-change-folder:hover {
+  background: var(--tree-row-hover-bg);
+  color: var(--fg);
+}
+.workspace-change-folder__chev {
+  flex: 0 0 auto;
+  transition: transform 0.15s ease;
+}
+.workspace-change-folder__chev--open {
+  transform: rotate(90deg);
+}
+.workspace-change-folder__icon {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+.workspace-change-folder__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg);
+  font-size: 12px;
+  font-weight: 600;
+}
 .workspace-change--disabled {
   cursor: default;
 }
@@ -34718,6 +34771,30 @@ body > .mermaid-diagram--fullscreen {
 
 .app--creation .workbench-dock .workspace-change-row:has(.workspace-change--active),
 :root[data-theme-style] .app--creation .workbench-dock .workspace-change-row:has(.workspace-change--active) {
+  background: color-mix(in srgb, var(--fg-faint) 6%, transparent);
+}
+.app--creation .workbench-dock .workspace-change-folder,
+::root[data-theme-style] .app--creation .workbench-dock .workspace-change-folder {
+  min-height: 34px;
+  color: color-mix(in srgb, var(--fg-dim) 88%, transparent);
+}
+
+.app--creation .workbench-dock .workspace-change-folder:hover,
+::root[data-theme-style] .app--creation .workbench-dock .workspace-change-folder:hover {
+  background: color-mix(in srgb, var(--fg-faint) 5%, transparent);
+  color: var(--fg);
+}
+
+.app--creation .workbench-dock .workspace-change-folder__name,
+::root[data-theme-style] .app--creation .workbench-dock .workspace-change-folder__name {
+  font-size: calc(12px * var(--font-scale));
+  font-weight: 560;
+}
+
+.app--creation .workbench-dock .workspace-change--active,
+.app--creation .workbench-dock .workspace-change--active:hover,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-change--active,
+:root[data-theme-style] .app--creation .workbench-dock .workspace-change--active:hover {
   background: color-mix(in srgb, var(--fg-faint) 6%, transparent);
 }
 .app--creation .workbench-dock .workspace-change-row:has(.workspace-change--active) .workspace-change,


### PR DESCRIPTION
## Summary

- Render changed files as an expandable folder tree in the desktop workspace panel.
- Reuse the tree renderer for ordinary and scoped change lists.
- Preserve file selection, status metadata, and session revert actions.

## Issues

N/A

## Verification

- Focused workspace change-tree tests — passed (5 tests).
- Focused workspace changes tests — passed (59 tests).
- ESLint on changed TypeScript files — passed.
- CSS syntax validation — passed.
- git diff --check — passed.
- go test ./internal/acp -run TestE2ECancelMidTurn -count=10 -v — passed (10/10). The earlier full go test ./... run was blocked by this timing-sensitive test.
- Task Monitor panel test — 6 passed, 16 failed. The failures are caused by the test environment switching from English to Chinese after asynchronous locale loading, not by this PR.
- Task Monitor navigation test — passed (3 tests).
- tsc --noEmit — passed (exit code 0).

## Documentation impact

Documentation-impact: none - This PR only changes desktop UI rendering; no README or docs files are included, and existing documentation remains accurate.

## Cache impact

Cache-impact: none - no provider-visible prompts, tools, or model request serialization changed.
Cache-guard: N/A - the change only affects desktop UI rendering.
System-prompt-review: N/A