### PR TITLE
fix(desktop): stop repeated tail writes during scroll delivery / 修复滚动交付重复触发尾部写入

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -79,6 +79,10 @@ try {
     ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}),
   });
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  // Both 1.27.0 field reports keep completed working steps expanded. Apply the
+  // preference before the app mounts so every long-session, native-thumb, and
+  // measurement-churn assertion exercises the larger virtual row model.
+  await page.addInitScript(() => localStorage.setItem("reasonix-process-fold", "expanded"));
   await page.goto(url, { waitUntil: "domcontentloaded" });
   await page.waitForFunction(() => !document.querySelector(".startup-splash"), undefined, { timeout: 30_000 });
   await page.click('.project-tree__topic-main:has-text("bench:small-6t")');
@@ -574,6 +578,41 @@ try {
         && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
     });
     assert(true, "native thumb release keeps the remeasured transcript at the physical bottom");
+    const idleTail = await transcript.evaluate((element) => new Promise((resolve) => {
+      const writes = [];
+      const tops = [];
+      let geometryStable = false;
+      const stableWrites = [];
+      let lastGeometry = null;
+      window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = (write) => {
+        writes.push(write);
+        if (geometryStable) stableWrites.push(write);
+      };
+      let frames = 0;
+      const sample = () => {
+        tops.push(element.scrollTop);
+        // Virtuoso can still be committing the +900px tail remeasure when the
+        // window opens; a write against changing geometry is legitimate
+        // convergence. Only writes after the geometry itself stops moving are
+        // the oscillation this gate exists to catch.
+        const geometry = `${element.scrollHeight}@${element.clientHeight}`;
+        if (lastGeometry === null) lastGeometry = geometry;
+        else if (geometry === lastGeometry && frames >= 10) geometryStable = true;
+        else lastGeometry = geometry;
+        frames += 1;
+        if (frames < 30) {
+          requestAnimationFrame(sample);
+          return;
+        }
+        window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = undefined;
+        resolve({ writes, stableWrites, tops, geometryStable });
+      };
+      requestAnimationFrame(sample);
+    }));
+    const idleTailRange = Math.max(...idleTail.tops) - Math.min(...idleTail.tops);
+    assert(idleTail.geometryStable, "an idle expanded tail reaches stable geometry within the window");
+    assert(idleTail.stableWrites.length === 0, `a stable idle tail emits no corrective scroll writes (${idleTail.stableWrites.length} of ${idleTail.writes.length}) ${JSON.stringify(idleTail.stableWrites)}`);
+    assert(idleTailRange <= 1, `an idle expanded tail keeps stable native geometry (${idleTailRange}px)`);
   }
 
   // Explicit bottom owns the tail. Subsequent async growth must use Virtuoso's

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -2,6 +2,7 @@
 
 import {
   INITIAL_TRANSCRIPT_SCROLL_STATE,
+  isSubstantialTranscriptDisplacement,
   isTranscriptContentShrink,
   reduceTranscriptScroll,
   type TranscriptScrollEvent,
@@ -172,9 +173,39 @@ check(
   "delivered displacement and later growth both reconverge while tail-follow owns the viewport",
 );
 
+const repeatedDisplacement = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true },
+  { type: "LAYOUT_HEIGHT_CHANGED" },
+]);
+check(
+  repeatedDisplacement.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM",
+  "repeated non-bottom deliveries do not loop tail writes, while a layout change can reconverge",
+);
+
 check(isTranscriptContentShrink(-48), "a fold-sized height drop is a shrink");
 check(!isTranscriptContentShrink(-8), "measurement jitter is not a shrink");
 check(!isTranscriptContentShrink(80), "content growth is not a shrink");
+
+check(isSubstantialTranscriptDisplacement(1200), "a thumb-drop-sized gap is a substantial displacement");
+check(!isSubstantialTranscriptDisplacement(4), "bottom-adjacent jitter is not substantial");
+
+// A misread shrink (native-thumb release remeasure seen as a height drop)
+// leaves layout convergence inert; a later substantial displacement delivery
+// must still reconverge the tail instead of stranding the viewport.
+const strandedAfterMisreadShrink = run([
+  { type: "SCROLL_DELIVERED", atBottom: true, scrollable: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true, substantial: true },
+  { type: "CONTENT_SHRANK" },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true, substantial: true },
+  { type: "SCROLL_DELIVERED", atBottom: false, scrollable: true, substantial: true },
+]);
+check(
+  strandedAfterMisreadShrink.commands.join(",") === "AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM,AUTOSCROLL_TO_BOTTOM",
+  "substantial displacements keep reconverging after a misread shrink",
+);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/transcriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/transcriptScrollArbiter.ts
@@ -36,7 +36,7 @@ export type TranscriptScrollEvent =
   | { type: "USER_SCROLL_INTENT"; canClaimTail: boolean }
   | { type: "MANUAL_READING" }
   | { type: "READER_INTENT_ENDED" }
-  | { type: "SCROLL_DELIVERED"; atBottom: boolean; scrollable: boolean }
+  | { type: "SCROLL_DELIVERED"; atBottom: boolean; scrollable: boolean; substantial?: boolean }
   | { type: "TAIL_CONTENT_CHANGED" }
   | { type: "CONTENT_SHRANK" }
   | { type: "LAYOUT_HEIGHT_CHANGED" }
@@ -78,6 +78,15 @@ export const INITIAL_TRANSCRIPT_SCROLL_STATE: TranscriptScrollState = {
 // Fold collapse drops at least one process row (~28px). Smaller deltas are
 // Virtuoso measurement jitter and must keep following the tail.
 export const TRANSCRIPT_CONTENT_SHRINK_THRESHOLD_PX = 24;
+
+// A delivery this far above the bottom is a real physical displacement (thumb
+// drop, row remeasure), not bottom-adjacent jitter. Re-converging these is the
+// tail writer's job even when the previous delivery was already non-bottom.
+export const TRANSCRIPT_SUBSTANTIAL_DISPLACEMENT_PX = 24;
+
+export function isSubstantialTranscriptDisplacement(distance: number): boolean {
+  return distance >= TRANSCRIPT_SUBSTANTIAL_DISPLACEMENT_PX;
+}
 
 export function isTranscriptContentShrink(delta: number): boolean {
   return delta <= -TRANSCRIPT_CONTENT_SHRINK_THRESHOLD_PX;
@@ -142,7 +151,19 @@ export function reduceTranscriptScroll(
       }
       return transition(
         next,
-        state.mode === "tail-follow" && !event.atBottom && !state.readerIntent
+        // One physical displacement may produce several scroll deliveries
+        // while WebView2/Virtuoso remeasures variable-height rows. Re-arming
+        // the tail writer for every repeated `false` delivery creates a
+        // visible write loop; layout/viewport events remain the convergence
+        // lane for later geometry changes. A substantial displacement is a
+        // real repositioning: the tail writer reconverges even when the
+        // previous delivery was already non-bottom, because a misread shrink
+        // (CONTENT_SHRANK below) can otherwise strand the viewport with no
+        // remaining convergence lane.
+        state.mode === "tail-follow"
+          && !event.atBottom
+          && !state.readerIntent
+          && (state.atBottom || event.substantial === true)
           ? [{ type: "AUTOSCROLL_TO_BOTTOM" }]
           : [],
       );

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -11,6 +11,7 @@ import { findVerticalScrollTarget } from "./nestedScrollHandoff";
 import { isNativeVerticalScrollbarPointer, measureTranscriptVirtuosoItem } from "./transcriptNativeScrollbar";
 import {
   INITIAL_TRANSCRIPT_SCROLL_STATE,
+  isSubstantialTranscriptDisplacement,
   isTranscriptContentShrink,
   isTranscriptSelectionMode,
   reduceTranscriptScroll,
@@ -193,14 +194,16 @@ export function useTranscriptScrollArbiter({
         tailSettleProgressRef.current = null;
         return;
       }
-      scrollToTail("auto");
       const element = scrollRef.current;
       if (!element) return;
       const distance = nativeTranscriptDistanceFromBottom(element);
       if (distance <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX) {
+        // Already converged: a redundant write would still be a visible
+        // programmatic scrollTop touch for an idle tail.
         tailSettleProgressRef.current = null;
         return;
       }
+      scrollToTail("auto");
       const previous = tailSettleProgressRef.current;
       const stagnantFrames = previous && Math.abs(previous.distance - distance) <= 0.5
         ? previous.stagnantFrames + 1
@@ -317,10 +320,12 @@ export function useTranscriptScrollArbiter({
 
   const deliverScroll = useCallback((element = scrollRef.current) => {
     if (!element) return;
+    const distance = nativeTranscriptDistanceFromBottom(element);
     dispatch({
       type: "SCROLL_DELIVERED",
-      atBottom: nativeTranscriptDistanceFromBottom(element) <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
+      atBottom: distance <= TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX,
       scrollable: hasTranscriptScrollableRange(element),
+      substantial: isSubstantialTranscriptDisplacement(distance),
     });
     if (stateRef.current.readerIntent) armReaderIntentIdle();
   }, [armReaderIntentIdle, dispatch]);


### PR DESCRIPTION
## Summary

- Prevent repeated tail-follow writes when Virtuoso/WebView2 emits multiple non-bottom deliveries for one physical displacement.
- Extend the transcript browser gate to cover the reported keep-expanded setting and idle native-tail stability.

## Problem

In v1.27.0, long transcripts with completed working steps kept expanded could flash or oscillate after the native scrollbar reached the bottom. Upward reading stopped the symptom because manual mode released tail-follow; returning to the bottom re-enabled the write loop.

## Root cause

Every `SCROLL_DELIVERED(atBottom=false)` while `tail-follow` was active re-armed `AUTOSCROLL_TO_BOTTOM`, even when the preceding delivery had already recorded the viewport as non-bottom. Variable-height row measurement can emit several such deliveries during one gesture, causing programmatic tail writes to compete with native scrolling.

## Fix

Only the first transition from physical bottom to non-bottom schedules a tail correction for bottom-adjacent jitter. A substantial displacement (>= 24px above the bottom, the same scale as the content-shrink threshold) re-arms the tail writer regardless of the previous delivery state: after a native-thumb release, Virtuoso's remeasure can net a height drop that `followGrowingTail` misreads as `CONTENT_SHRANK`, which deliberately does not re-aim the tail — without this lane the viewport could strand far above the bottom with no remaining convergence path (observed 1200px in the second CI attempt and reproduced locally ~75% of runs before the fix, 0/52 after).

The tail-settle tick also checks convergence before writing: once the scroller sits within the bottom threshold, a late-arriving `LAYOUT_HEIGHT_CHANGED` no longer triggers a redundant `scrollToIndex(LAST)` against an already-settled viewport.

## Verification

- `pnpm test:transcript`
- `pnpm build`
- Expanded-setting Chromium transcript scroll gate: native thumb release, long-session measurement churn, ref-resolution storm, and 30-frame idle-tail stability (52 consecutive local runs on the final head: zero stranded-tail stalls, idle stable-tail writes 0 of 0; the residual intermittent 284/288 waits reproduce at the same rate on the main-v2 base and are pre-existing)
- `git diff --check`

## Compatibility and scope

No provider, prompt-cache, persisted-format, Wails contract, dependency, or security-sensitive behavior changed. This is limited to desktop transcript scroll arbitration and its regression coverage.

Documentation-impact: none - this is an internal scroll arbitration correction; existing user-facing settings and behavior documentation remain accurate.

## Idle-tail gate semantics

The first CI run failed the idle-tail gate by observing one legitimate convergence write: the +900px tail-remasure padding injected by the bench can still be committing when the 30-frame window opens, and a write against that moving geometry is the convergence path working, not the oscillation the gate targets. The gate now separates the two: writes are only violations once the scroller's own geometry (`scrollHeight`/`clientHeight`) has stopped changing for the remainder of the window, and the window must reach that stable state. The redundant-write fix above removes the write that motivated the stricter original assertion in the common case.

Windows WebView2 pixel-compositor validation should still be run on the packaged desktop build.

