### PR TITLE
fix(desktop): show a clearer disabled style and hint for immutable provider names / 供应商名称不可修改时提供更直观的置灰与提示样式

### DIFF
--- a/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
@@ -292,7 +292,7 @@ const customProviderUrlInput = rootEl.querySelector<HTMLInputElement>(".provider
 ok(rootEl.querySelectorAll('input[type="radio"]').length === 0, "existing custom providers no longer expose an address mode selector");
 ok(customProviderUrlInput?.value === "https://eu.deepseek.com/v1/chat/completions", "legacy base-only providers display their previously effective request URL");
 ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.disabled === true, "existing custom provider name is locked");
-ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.nextElementSibling?.textContent === "Renaming is not supported yet", "existing custom provider editor shows the rename hint");
+ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.nextElementSibling?.textContent === "Changing the provider name is not supported yet", "existing custom provider editor shows the rename hint");
 
 let migratedProvider: ProviderView | undefined;
 await act(async () => {

--- a/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-editor-model-picker.test.tsx
@@ -257,6 +257,8 @@ const providerUrlLabel = Array.from(rootEl.querySelectorAll<HTMLLabelElement>("l
 );
 ok(Boolean(providerUrlLabel) && providerUrlInput?.getAttribute("aria-describedby") !== null, "provider URL input has a programmatic label and description");
 ok(rootEl.textContent?.includes("Reasonix uses it unchanged.") === true, "provider URL helper explains exact request behavior");
+ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.disabled !== true, "new custom provider name stays editable");
+ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.nextElementSibling?.classList.contains("mem-hint") !== true, "new custom provider editor omits the rename hint");
 
 await act(async () => {
   root.render(<div />);
@@ -289,6 +291,8 @@ ok(
 const customProviderUrlInput = rootEl.querySelector<HTMLInputElement>(".provider-url-input");
 ok(rootEl.querySelectorAll('input[type="radio"]').length === 0, "existing custom providers no longer expose an address mode selector");
 ok(customProviderUrlInput?.value === "https://eu.deepseek.com/v1/chat/completions", "legacy base-only providers display their previously effective request URL");
+ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.disabled === true, "existing custom provider name is locked");
+ok(rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]')?.nextElementSibling?.textContent === "Renaming is not supported yet", "existing custom provider editor shows the rename hint");
 
 let migratedProvider: ProviderView | undefined;
 await act(async () => {

--- a/desktop/frontend/src/__tests__/provider-name-readonly.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-name-readonly.test.tsx
@@ -1,0 +1,173 @@
+// Run: tsx src/__tests__/provider-name-readonly.test.tsx
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { ProviderEditor } from "../components/SettingsPanel";
+import { LocaleProvider } from "../lib/i18n";
+import type { ProviderView } from "../lib/types";
+import { en } from "../locales/en";
+import { zh } from "../locales/zh";
+import { zhTW } from "../locales/zh-TW";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const styles = readFileSync(resolve(here, "../styles.css"), "utf8");
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: boolean, label: string) {
+  if (value) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}\n`);
+    failed += 1;
+  }
+}
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function matchingBlocks(selector: string): string[] {
+  const blocks: string[] = [];
+  const rule = /([^{}]+)\{([^{}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rule.exec(styles)) !== null) {
+    const selectors = match[1].split(",").map((part) => part.trim());
+    if (selectors.includes(selector)) blocks.push(match[2]);
+  }
+  return blocks;
+}
+
+function finalDeclaration(selector: string, property: string): string | undefined {
+  let value: string | undefined;
+  for (const block of matchingBlocks(selector)) {
+    const declaration = new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]+)`, "g");
+    let match: RegExpExecArray | null;
+    while ((match = declaration.exec(block)) !== null) {
+      value = match[1].trim();
+    }
+  }
+  return value;
+}
+
+const customProvider: ProviderView = {
+  name: "my-proxy",
+  builtIn: false,
+  added: true,
+  kind: "openai",
+  baseUrl: "https://example.com/v1",
+  models: ["demo"],
+  visionModels: [],
+  visionModelsConfigured: false,
+  modelsUrl: "",
+  default: "demo",
+  apiKeyEnv: "",
+  keySet: false,
+  balanceUrl: "",
+  contextWindow: 128_000,
+  reasoningProtocol: "",
+  thinking: "",
+  supportedEfforts: [],
+  defaultEffort: "",
+};
+
+function nameHint(root: Element): Element | null {
+  const input = root.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]');
+  const next = input?.nextElementSibling;
+  return next?.classList.contains("mem-hint") ? next : null;
+}
+
+function renderEditor(initial?: ProviderView) {
+  return (
+    <LocaleProvider>
+      <ProviderEditor
+        key={initial?.name ?? "new-provider"}
+        initial={initial}
+        kinds={["openai"]}
+        busy={false}
+        onCancel={() => undefined}
+        onSave={() => undefined}
+      />
+    </LocaleProvider>
+  );
+}
+
+console.log("\nprovider name readonly");
+
+eq(en["settings.customProviderNameReadonlyHint"], "Changing the provider name is not supported yet", "English rename hint");
+eq(zh["settings.customProviderNameReadonlyHint"], "暂不支持供应商名称修改", "Simplified Chinese rename hint");
+eq(zhTW["settings.customProviderNameReadonlyHint"], "暫不支援供應商名稱修改", "Traditional Chinese rename hint");
+
+eq(finalDeclaration(".provider-name-input:disabled", "opacity"), "0.6", "disabled provider-name input is faded");
+eq(finalDeclaration(".provider-name-input:disabled", "cursor"), "not-allowed", "disabled provider-name input uses not-allowed cursor");
+eq(finalDeclaration(".mem-input:disabled", "opacity"), undefined, "no global mem-input:disabled fade rule remains");
+eq(finalDeclaration(".mem-select:disabled", "opacity"), undefined, "no global mem-select:disabled fade rule remains");
+
+const dom = new JSDOM("<!doctype html><html><body><div id=\"root\"></div></body></html>", {
+  pretendToBeVisual: true,
+  url: "http://localhost/",
+});
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.window = dom.window as unknown as Window & typeof globalThis;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", { configurable: true, value: dom.window.navigator });
+globalThis.Node = dom.window.Node;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Event = dom.window.Event;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+globalThis.MouseEvent = dom.window.MouseEvent;
+globalThis.localStorage = dom.window.localStorage;
+globalThis.sessionStorage = dom.window.sessionStorage;
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+window.scrollTo = () => {};
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("missing root");
+const root = createRoot(rootEl);
+
+await act(async () => {
+  root.render(renderEditor());
+  await flushPromises();
+});
+const newNameInput = rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]');
+ok(newNameInput?.disabled !== true, "new custom provider name stays editable");
+ok(newNameInput?.classList.contains("mem-input") === true, "provider name keeps mem-input base styling");
+ok(newNameInput?.classList.contains("provider-name-input") === true, "provider name carries the scoped provider-name-input class");
+ok(nameHint(rootEl) === null, "new custom provider editor omits the rename hint");
+
+await act(async () => {
+  root.render(renderEditor(customProvider));
+  await flushPromises();
+});
+const existingNameInput = rootEl.querySelector<HTMLInputElement>('input[placeholder="e.g. my-proxy"]');
+ok(existingNameInput?.disabled === true, "existing custom provider name is locked");
+ok(existingNameInput?.classList.contains("mem-input") === true, "locked provider name keeps mem-input base styling");
+ok(existingNameInput?.classList.contains("provider-name-input") === true, "locked provider name carries the scoped provider-name-input class");
+eq(nameHint(rootEl)?.textContent, en["settings.customProviderNameReadonlyHint"], "existing custom provider editor shows the rename hint");
+
+await act(async () => {
+  root.unmount();
+});
+dom.window.close();
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/provider-name-readonly.test.tsx
+++ b/desktop/frontend/src/__tests__/provider-name-readonly.test.tsx
@@ -117,6 +117,7 @@ eq(zhTW["settings.customProviderNameReadonlyHint"], "暫不支援供應商名稱
 
 eq(finalDeclaration(".provider-name-input:disabled", "opacity"), "0.6", "disabled provider-name input is faded");
 eq(finalDeclaration(".provider-name-input:disabled", "cursor"), "not-allowed", "disabled provider-name input uses not-allowed cursor");
+eq(finalDeclaration(".mem-hint.provider-name-readonly-hint", "color"), "var(--fg-dim)", "readonly hint uses the stronger secondary text color");
 eq(finalDeclaration(".mem-input:disabled", "opacity"), undefined, "no global mem-input:disabled fade rule remains");
 eq(finalDeclaration(".mem-select:disabled", "opacity"), undefined, "no global mem-select:disabled fade rule remains");
 
@@ -152,6 +153,9 @@ const newNameInput = rootEl.querySelector<HTMLInputElement>('input[placeholder="
 ok(newNameInput?.disabled !== true, "new custom provider name stays editable");
 ok(newNameInput?.classList.contains("mem-input") === true, "provider name keeps mem-input base styling");
 ok(newNameInput?.classList.contains("provider-name-input") === true, "provider name carries the scoped provider-name-input class");
+ok(Boolean(newNameInput?.id), "new custom provider name has a stable input id");
+eq(rootEl.querySelector<HTMLLabelElement>(`label[for="${newNameInput?.id}"]`)?.textContent, en["settings.customProviderName"], "new custom provider name has a programmatic label");
+eq(newNameInput?.getAttribute("aria-describedby"), null, "editable provider name omits the readonly description reference");
 ok(nameHint(rootEl) === null, "new custom provider editor omits the rename hint");
 
 await act(async () => {
@@ -162,7 +166,12 @@ const existingNameInput = rootEl.querySelector<HTMLInputElement>('input[placehol
 ok(existingNameInput?.disabled === true, "existing custom provider name is locked");
 ok(existingNameInput?.classList.contains("mem-input") === true, "locked provider name keeps mem-input base styling");
 ok(existingNameInput?.classList.contains("provider-name-input") === true, "locked provider name carries the scoped provider-name-input class");
-eq(nameHint(rootEl)?.textContent, en["settings.customProviderNameReadonlyHint"], "existing custom provider editor shows the rename hint");
+eq(rootEl.querySelector<HTMLLabelElement>(`label[for="${existingNameInput?.id}"]`)?.textContent, en["settings.customProviderName"], "locked provider name has a programmatic label");
+const existingNameHint = nameHint(rootEl);
+eq(existingNameHint?.textContent, en["settings.customProviderNameReadonlyHint"], "existing custom provider editor shows the rename hint");
+ok(existingNameHint?.classList.contains("provider-name-readonly-hint") === true, "rename hint carries the stronger contrast class");
+ok(Boolean(existingNameHint?.id), "rename hint has a stable id");
+eq(existingNameInput?.getAttribute("aria-describedby"), existingNameHint?.id, "locked provider name references the rename hint");
 
 await act(async () => {
   root.unmount();

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6596,7 +6596,7 @@ export function ProviderEditor({
   return (
     <div className={`provider-editor${isNewCustomProvider ? " provider-editor--wizard" : ""}`}>
       <label className="set-label">{t("settings.customProviderName")}</label>
-      <input className="mem-input" placeholder={t("settings.customProviderNamePlaceholder")} value={name} onChange={(e) => setName(e.target.value)} disabled={!!initial} />
+      <input className="mem-input provider-name-input" placeholder={t("settings.customProviderNamePlaceholder")} value={name} onChange={(e) => setName(e.target.value)} disabled={!!initial} />
       {initial && <div className="mem-hint">{t("settings.customProviderNameReadonlyHint")}</div>}
       <label className="set-label">{t("settings.providerProtocol")}</label>
       <select className="mem-select" value={kind} onChange={(e) => setKind(e.target.value)}>

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6209,6 +6209,8 @@ export function ProviderEditor({
     initial?.requestUrl ?? "",
     initial?.chatUrl ?? "",
   ));
+  const providerNameInputId = useId();
+  const providerNameHelpId = useId();
   const providerUrlInputId = useId();
   const providerUrlHelpId = useId();
   const [models, setModels] = useState((initial?.models ?? []).join(", "));
@@ -6595,9 +6597,21 @@ export function ProviderEditor({
 
   return (
     <div className={`provider-editor${isNewCustomProvider ? " provider-editor--wizard" : ""}`}>
-      <label className="set-label">{t("settings.customProviderName")}</label>
-      <input className="mem-input provider-name-input" placeholder={t("settings.customProviderNamePlaceholder")} value={name} onChange={(e) => setName(e.target.value)} disabled={!!initial} />
-      {initial && <div className="mem-hint">{t("settings.customProviderNameReadonlyHint")}</div>}
+      <label className="set-label" htmlFor={providerNameInputId}>{t("settings.customProviderName")}</label>
+      <input
+        id={providerNameInputId}
+        className="mem-input provider-name-input"
+        aria-describedby={initial ? providerNameHelpId : undefined}
+        placeholder={t("settings.customProviderNamePlaceholder")}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={!!initial}
+      />
+      {initial && (
+        <div id={providerNameHelpId} className="mem-hint provider-name-readonly-hint">
+          {t("settings.customProviderNameReadonlyHint")}
+        </div>
+      )}
       <label className="set-label">{t("settings.providerProtocol")}</label>
       <select className="mem-select" value={kind} onChange={(e) => setKind(e.target.value)}>
         {providerKindChoices.map((choice) => (

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -6597,6 +6597,7 @@ export function ProviderEditor({
     <div className={`provider-editor${isNewCustomProvider ? " provider-editor--wizard" : ""}`}>
       <label className="set-label">{t("settings.customProviderName")}</label>
       <input className="mem-input" placeholder={t("settings.customProviderNamePlaceholder")} value={name} onChange={(e) => setName(e.target.value)} disabled={!!initial} />
+      {initial && <div className="mem-hint">{t("settings.customProviderNameReadonlyHint")}</div>}
       <label className="set-label">{t("settings.providerProtocol")}</label>
       <select className="mem-select" value={kind} onChange={(e) => setKind(e.target.value)}>
         {providerKindChoices.map((choice) => (

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2667,7 +2667,7 @@ export const en = {
   "settings.addProvider.confirmResetPreset": "Confirm reset",
   "settings.customProviderName": "Custom provider name",
   "settings.customProviderNamePlaceholder": "e.g. my-proxy",
-  "settings.customProviderNameReadonlyHint": "Renaming is not supported yet",
+  "settings.customProviderNameReadonlyHint": "Changing the provider name is not supported yet",
   "settings.providerNamePlaceholder": "Provider name (e.g. deepseek-proxy)",
   "settings.providerProtocol": "Connection protocol",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -2667,6 +2667,7 @@ export const en = {
   "settings.addProvider.confirmResetPreset": "Confirm reset",
   "settings.customProviderName": "Custom provider name",
   "settings.customProviderNamePlaceholder": "e.g. my-proxy",
+  "settings.customProviderNameReadonlyHint": "Renaming is not supported yet",
   "settings.providerNamePlaceholder": "Provider name (e.g. deepseek-proxy)",
   "settings.providerProtocol": "Connection protocol",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1845,6 +1845,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.confirmResetPreset": "確認重設",
   "settings.customProviderName": "自訂供應商名稱",
   "settings.customProviderNamePlaceholder": "例如 my-proxy",
+  "settings.customProviderNameReadonlyHint": "暫不支援重新命名",
   "settings.providerNamePlaceholder": "供應商名稱（如 deepseek-proxy）",
   "settings.providerProtocol": "接入協定",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1845,7 +1845,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.addProvider.confirmResetPreset": "確認重設",
   "settings.customProviderName": "自訂供應商名稱",
   "settings.customProviderNamePlaceholder": "例如 my-proxy",
-  "settings.customProviderNameReadonlyHint": "暫不支援重新命名",
+  "settings.customProviderNameReadonlyHint": "暫不支援供應商名稱修改",
   "settings.providerNamePlaceholder": "供應商名稱（如 deepseek-proxy）",
   "settings.providerProtocol": "接入協定",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2670,6 +2670,7 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.confirmResetPreset": "确认重置",
   "settings.customProviderName": "自定义供应商名称",
   "settings.customProviderNamePlaceholder": "例如 my-proxy",
+  "settings.customProviderNameReadonlyHint": "暂不支持改名",
   "settings.providerNamePlaceholder": "供应商名称（如 deepseek-proxy）",
   "settings.providerProtocol": "接入协议",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -2670,7 +2670,7 @@ export const zh: Record<DictKey, string> = {
   "settings.addProvider.confirmResetPreset": "确认重置",
   "settings.customProviderName": "自定义供应商名称",
   "settings.customProviderNamePlaceholder": "例如 my-proxy",
-  "settings.customProviderNameReadonlyHint": "暂不支持改名",
+  "settings.customProviderNameReadonlyHint": "暂不支持供应商名称修改",
   "settings.providerNamePlaceholder": "供应商名称（如 deepseek-proxy）",
   "settings.providerProtocol": "接入协议",
   "settings.providerProtocolOpenAI": "OpenAI-compatible",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11835,8 +11835,7 @@ body > .mermaid-diagram--fullscreen {
   outline: none;
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
-.mem-select:disabled,
-.mem-input:disabled {
+.provider-name-input:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11839,6 +11839,9 @@ body > .mermaid-diagram--fullscreen {
   opacity: 0.6;
   cursor: not-allowed;
 }
+.mem-hint.provider-name-readonly-hint {
+  color: var(--fg-dim);
+}
 .mem-input {
   flex: 1;
   min-width: 0;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11835,6 +11835,11 @@ body > .mermaid-diagram--fullscreen {
   outline: none;
   box-shadow: 0 0 0 2px var(--accent-soft);
 }
+.mem-select:disabled,
+.mem-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 .mem-input {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
## Summary

When editing an already-added custom provider, the provider name input is read-only (disabled), but the UI gives no visual indication that the name cannot be changed, so users mistake it for a bug (see #9041). This PR makes the immutability explicit:

- Gray out the locked provider name input (`opacity: 0.6` + `cursor: not-allowed`), scoped to the provider name field via a new `provider-name-input` class — no change to other disabled controls.
- Show a localized hint below the input via the existing `mem-hint` style: "Changing the provider name is not supported yet" (en / zh / zh-TW).
- Add a dedicated test `desktop/frontend/src/__tests__/provider-name-readonly.test.tsx` covering the disabled styling, the hint text, and both states (new provider editable / existing provider read-only).

## Issues

Fixes #9064

Refs #9041

## Verification

All checks ran locally under `desktop/frontend/` and passed:

- `node --import tsx src/__tests__/provider-name-readonly.test.tsx` → 15/15 passed
- `node --import tsx src/__tests__/provider-editor-model-picker.test.tsx` → 45/45 passed
- `npx eslint src/components/SettingsPanel.tsx src/__tests__/provider-editor-model-picker.test.tsx src/__tests__/provider-name-readonly.test.tsx src/locales/en.ts src/locales/zh.ts src/locales/zh-TW.ts` → exit 0
- `node scripts/check-css-syntax.mjs src/styles.css` → exit 0
- `node scripts/check-z-index-tokens.mjs src/styles.css` → exit 0
- `npx tsc --noEmit -p tsconfig.test.json` → exit 0

## Documentation impact

Documentation-impact: none - desktop-only UI hint change; no user-visible CLI/config/provider behavior changes, existing docs stay correct.

## Cache impact

Cache-impact: none - frontend-only UI styling and copy; 
Cache-guard: none added; change does not touch cache-sensitive code paths.
System-prompt-review: N/A