### PR TITLE
ci: scope SA4023 suppression to the Windows agent stub call site / 定点豁免 Windows agent 桩的 SA4023

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,14 @@ linters:
         linters:
           - staticcheck
         text: SA5011
+      # SA4023 is trivially true on GOOS=windows: dialAgent's Windows stub
+      # (agent_windows.go) always returns a non-nil error until named-pipe
+      # transport lands. Suppress only this call site; the comparison stays
+      # meaningful on Unix where dialAgent can succeed.
+      - path: internal/remote/auth\.go
+        linters:
+          - staticcheck
+        text: SA4023
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## Summary

- Scopes a single staticcheck suppression in `.golangci.yml`: `SA4023` on
  `internal/remote/auth.go` only, following the existing SA5011
  scoped-suppression pattern.

## Problem

Every PR's `lint` job (GOOS=windows cross-platform leg) started failing today with:

```
internal/remote/auth.go:150-151: SA4023: this comparison is always true
```

Frontend-only PRs #9062 and #9065 both hit it deterministically, although their
merge trees are byte-identical to `main-v2` in every Go file. The same leg
passed on the 2026-08-17 23:36 UTC `main-v2` push run with the same tree, same
tool pins (golangci-lint v2.12.2, Go 1.26.6), and same runner image hash. It is
not reproducible locally (macOS binary, clean cache, CI Go toolchain: 0
issues), so a runner-side analysis-cache state flipped this pre-existing
finding to visible today.

## Root cause

`dialAgent`'s Windows stub (`agent_windows.go`) always returns a non-nil error
(named-pipe transport is a documented V2 follow-up), so staticcheck is correct
that `err != nil` after the call is trivially true under `GOOS=windows`. The
comparison stays meaningful on Unix where `dialAgent` can succeed. This is
dormant debt of the stub, not a regression any recent PR introduced.

## Fix

One scoped exclusion — path `internal/remote/auth.go`, linter `staticcheck`,
rule `SA4023` — with a comment naming the stub and the removal condition.
SA4023 keeps guarding every other file; the exclusion self-justifies removal
when the Windows agent dialer is implemented.

## Verification

- `GOOS=windows golangci-lint run ./internal/remote/`: 0 issues
- `GOOS=darwin` and native legs on the same package: 0 issues
- Unblocks the currently-red `lint` check on open PRs #9062/#9065

Cache-impact: none - CI lint configuration only; no provider-visible prompt, memory prefix, or tool registration is touched

Cache-guard: not applicable - no cache-sensitive path modified

Documentation-impact: none - internal lint configuration with no user-facing behavior; existing docs remain accurate
