### PR TITLE
feat(boot): pin official DeepSeek-V4-Pro to the DSH agent persona / 官方 DeepSeek-V4-Pro 自动加载 DSH 人设

### DIFF
--- a/docs/REASONING_LANGUAGE.md
+++ b/docs/REASONING_LANGUAGE.md
@@ -21,7 +21,9 @@ The setting is intentionally small:
 
 - `auto` anchors visible reasoning to Chinese when the raw user prompt is
   clearly Chinese, ignoring injected reference context such as `@file` contents;
-  English and ambiguous turns add no extra instruction.
+  English and ambiguous turns add no extra instruction. Official DeepSeek-V4-Pro
+  is the exception: `auto` pins visible reasoning to English so it cannot
+  override that model's agent persona.
 - `zh` asks visible reasoning to prefer Simplified Chinese.
 - `en` asks visible reasoning to prefer English.
 
@@ -99,11 +101,9 @@ for this auto decision.
 
 When set to `zh` or `en`, Reasonix always adds a small transient
 `<reasoning-language>` block to the user turn. In all modes, this does not
-change:
-
-- the system prompt
-- tool schema bytes or ordering
-- the stable provider-visible prefix
+change tool schema bytes or ordering. Official DeepSeek-V4-Pro also prepends a
+stable first-line persona to the system prompt; other models leave the system
+prompt unchanged.
 
 This keeps high prompt-cache hit rate intact while still letting an explicit
 preference affect the next model call.

--- a/docs/REASONING_LANGUAGE.zh-CN.md
+++ b/docs/REASONING_LANGUAGE.zh-CN.md
@@ -14,7 +14,7 @@
 
 取值只有三种：
 
-- `auto`：用户原始提问明显为中文时锚定中文，并忽略 `@file` 等注入的引用内容；英文或不确定时不额外注入语言指令。
+- `auto`：用户原始提问明显为中文时锚定中文，并忽略 `@file` 等注入的引用内容；英文或不确定时不额外注入语言指令。官方 DeepSeek-V4-Pro 是例外：`auto` 会把可见思考钉在英文，避免覆盖该模型的 agent 人设。
 - `zh`：可见思考过程优先使用简体中文。
 - `en`：可见思考过程优先使用英文。
 
@@ -81,11 +81,7 @@ reasoning_language = "auto" # auto|zh|en
 
 `auto` 仍然对缓存友好。用户原始提问明显是中文时，Reasonix 会为这一轮加入同样很小的 `<reasoning-language>` 临时 block；英文或信号不明确时不注入，只复用已有的稳定语言策略。`@file` 等注入的引用内容不会参与这个自动判断。
 
-当设置为 `zh` 或 `en` 时，Reasonix 总是会把一个很小的 `<reasoning-language>` 临时 block 放进本次 user turn。所有模式下，它都不会改变：
-
-- system prompt
-- 工具 schema 的字节或顺序
-- provider 可见的稳定前缀
+当设置为 `zh` 或 `en` 时，Reasonix 总是会把一个很小的 `<reasoning-language>` 临时 block 放进本次 user turn。所有模式下，它都不会改变工具 schema 的字节或顺序。官方 DeepSeek-V4-Pro 还会在 system prompt 开头稳定写入一句 agent 人设；其他模型的 system prompt 不变。
 
 因此它能在表达明确偏好的同时，尽量保持高 prompt-cache 命中率。
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -669,6 +669,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 			sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 		}
 	}
+	sysPrompt = config.ApplyOfficialDeepSeekV4ProPersona(sysPrompt, entry)
 
 	reg := tool.NewRegistry()
 	writeRoots := cfg.WriteRootsForRoot(root)
@@ -1651,7 +1652,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		RecentKeep:                   cfg.Agent.RecentKeep,
 		ArchiveDir:                   config.ArchiveDir(),
 		KeepPolicy:                   keepPolicy,
-		ReasoningLanguage:            cfg.ReasoningLanguage(),
+		ReasoningLanguage:            config.ReasoningLanguageForEntry(entry, cfg.ReasoningLanguage()),
 		PlanModeReadOnlyCommands:     cfg.Agent.PlanModeReadOnlyCommands,
 		LegacyAnchorSafetyGate:       cfg.Agent.LegacyAnchorSafetyGate,
 		SubagentDepth:                0,
@@ -1710,7 +1711,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 				RecentKeep:                   cfg.Agent.RecentKeep,
 				ArchiveDir:                   config.ArchiveDir(),
 				KeepPolicy:                   keepPolicy,
-				ReasoningLanguage:            cfg.ReasoningLanguage(),
+				ReasoningLanguage:            config.ReasoningLanguageForEntry(pe, cfg.ReasoningLanguage()),
 				PlanModeReadOnlyCommands:     cfg.Agent.PlanModeReadOnlyCommands,
 				CapabilityLedger:             plannerLedger,
 				CapabilityAudit:              plannerAudit,
@@ -1778,7 +1779,7 @@ func build(ctx context.Context, opts Options) (*BuildResult, error) {
 		WorkspaceRoot:          root,
 		ExternalFolderToolRefs: readPathResolver,
 		ResponseLanguage:       cfg.ResponseLanguage(),
-		ReasoningLanguage:      cfg.ReasoningLanguage(),
+		ReasoningLanguage:      config.ReasoningLanguageForEntry(entry, cfg.ReasoningLanguage()),
 		DisableColdResumePrune: !cfg.ColdResumePruneEnabled(),
 		Shell:                  shell,
 		ApprovalTimeout:        opts.ApprovalTimeout,

--- a/internal/boot/deepseek_v4_pro_persona_test.go
+++ b/internal/boot/deepseek_v4_pro_persona_test.go
@@ -1,0 +1,111 @@
+package boot
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestBuildOfficialDeepSeekV4ProPrependsPersona(t *testing.T) {
+	ctrl := buildOfficialDeepSeekModel(t, "deepseek-v4-pro")
+	defer ctrl.Close()
+
+	sys := systemMessage(ctrl.History())
+	wantPrefix := config.OfficialDeepSeekV4ProPersona + "\n\n"
+	if !strings.HasPrefix(sys, wantPrefix) {
+		t.Fatalf("official V4 Pro system prompt must start with the DSH persona:\n%s", sys)
+	}
+	if !strings.Contains(sys, "BASE") {
+		t.Fatalf("persona must keep the configured system prompt, got:\n%s", sys)
+	}
+
+	composed := ctrl.Compose("解释 AuthHandler 的 panic")
+	if strings.Contains(composed, "简体中文") {
+		t.Fatalf("official V4 Pro auto mode must not inject Chinese thinking: %q", composed)
+	}
+	if !strings.Contains(composed, "use English") {
+		t.Fatalf("official V4 Pro auto mode should pin English thinking, got %q", composed)
+	}
+}
+
+func TestBuildOfficialDeepSeekV4FlashDoesNotPrependPersona(t *testing.T) {
+	ctrl := buildOfficialDeepSeekModel(t, "deepseek-v4-flash")
+	defer ctrl.Close()
+
+	sys := systemMessage(ctrl.History())
+	if strings.Contains(sys, config.OfficialDeepSeekV4ProPersona) {
+		t.Fatalf("official V4 Flash must not load the Pro persona:\n%s", sys)
+	}
+	composed := ctrl.Compose("解释 AuthHandler 的 panic")
+	if !strings.Contains(composed, "简体中文") {
+		t.Fatalf("flash auto mode should still infer Chinese thinking, got %q", composed)
+	}
+}
+
+func TestBuildThirdPartyDeepSeekV4ProDoesNotPrependPersona(t *testing.T) {
+	isolateConfigHome(t)
+	const envName = "BOOT_THIRD_PARTY_V4_PRO_KEY"
+	if _, err := config.SetCredential(envName, "test-key"); err != nil {
+		t.Fatalf("store credential: %v", err)
+	}
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "novita/deepseek-v4-pro"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "novita"
+kind = "openai"
+base_url = "https://api.novita.ai/openai"
+model = "deepseek-v4-pro"
+api_key_env = "`+envName+`"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	sys := systemMessage(ctrl.History())
+	if strings.Contains(sys, config.OfficialDeepSeekV4ProPersona) {
+		t.Fatalf("third-party V4 Pro must not load the official persona:\n%s", sys)
+	}
+}
+
+func buildOfficialDeepSeekModel(t *testing.T, model string) *control.Controller {
+	t.Helper()
+	isolateConfigHome(t)
+	const envName = "BOOT_OFFICIAL_V4_PRO_PERSONA_KEY"
+	if _, err := config.SetCredential(envName, "test-key"); err != nil {
+		t.Fatalf("store credential: %v", err)
+	}
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "deepseek/`+model+`"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default = "deepseek-v4-flash"
+api_key_env = "`+envName+`"
+`)
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build %s: %v", model, err)
+	}
+	return ctrl
+}

--- a/internal/config/deepseek_v4_pro_persona.go
+++ b/internal/config/deepseek_v4_pro_persona.go
@@ -1,0 +1,53 @@
+package config
+
+import "strings"
+
+// OfficialDeepSeekV4ProPersona is prepended to the cache-stable system prompt
+// for official DeepSeek-V4-Pro. That model's agent post-training is peaked on
+// this first-line persona and English "We need" thinking.
+const OfficialDeepSeekV4ProPersona = `You are a helpful software engineer assistant. when you thought, thought in ENGLISH, start with "We need.."`
+
+// AppliesOfficialDeepSeekV4ProPersona reports whether the resolved official
+// DeepSeek endpoint is serving V4 Pro. Third-party hosts are excluded even
+// when they reuse the same model id.
+func AppliesOfficialDeepSeekV4ProPersona(e *ProviderEntry) bool {
+	if e == nil || officialProviderKind(e) != "deepseek" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(e.Model), "deepseek-v4-pro")
+}
+
+// ApplyOfficialDeepSeekV4ProPersona keeps the persona as the first system-prompt
+// paragraph for official V4 Pro and strips it when the session is not that model.
+func ApplyOfficialDeepSeekV4ProPersona(prompt string, e *ProviderEntry) string {
+	prompt = stripOfficialDeepSeekV4ProPersona(prompt)
+	if !AppliesOfficialDeepSeekV4ProPersona(e) {
+		return prompt
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return OfficialDeepSeekV4ProPersona
+	}
+	return OfficialDeepSeekV4ProPersona + "\n\n" + prompt
+}
+
+func stripOfficialDeepSeekV4ProPersona(prompt string) string {
+	switch {
+	case strings.HasPrefix(prompt, OfficialDeepSeekV4ProPersona+"\n\n"):
+		return strings.TrimPrefix(prompt, OfficialDeepSeekV4ProPersona+"\n\n")
+	case strings.HasPrefix(prompt, OfficialDeepSeekV4ProPersona+"\n"):
+		return strings.TrimPrefix(prompt, OfficialDeepSeekV4ProPersona+"\n")
+	case prompt == OfficialDeepSeekV4ProPersona:
+		return ""
+	default:
+		return prompt
+	}
+}
+
+// ReasoningLanguageForEntry pins official V4 Pro auto mode to English so the
+// per-turn Chinese auto-inference cannot override the persona.
+func ReasoningLanguageForEntry(e *ProviderEntry, configured string) string {
+	if AppliesOfficialDeepSeekV4ProPersona(e) && NormalizeReasoningLanguage(configured) == "auto" {
+		return "en"
+	}
+	return configured
+}

--- a/internal/config/deepseek_v4_pro_persona_test.go
+++ b/internal/config/deepseek_v4_pro_persona_test.go
@@ -1,0 +1,110 @@
+package config
+
+import "testing"
+
+func TestAppliesOfficialDeepSeekV4ProPersona(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		entry *ProviderEntry
+		want  bool
+	}{
+		{
+			name:  "nil",
+			entry: nil,
+			want:  false,
+		},
+		{
+			name: "official pro",
+			entry: &ProviderEntry{
+				Name:    "deepseek",
+				BaseURL: "https://api.deepseek.com",
+				Model:   "deepseek-v4-pro",
+			},
+			want: true,
+		},
+		{
+			name: "official anthropic pro",
+			entry: &ProviderEntry{
+				Name:    "deepseek",
+				Kind:    "anthropic",
+				BaseURL: "https://api.deepseek.com/anthropic",
+				Model:   "deepseek-v4-pro",
+			},
+			want: true,
+		},
+		{
+			name: "official flash",
+			entry: &ProviderEntry{
+				Name:    "deepseek",
+				BaseURL: "https://api.deepseek.com",
+				Model:   "deepseek-v4-flash",
+			},
+			want: false,
+		},
+		{
+			name: "third party pro name",
+			entry: &ProviderEntry{
+				Name:    "novita",
+				BaseURL: "https://api.novita.ai/openai",
+				Model:   "deepseek/deepseek-v4-pro",
+			},
+			want: false,
+		},
+		{
+			name: "empty model on official host",
+			entry: &ProviderEntry{
+				Name:    "deepseek",
+				BaseURL: "https://api.deepseek.com",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AppliesOfficialDeepSeekV4ProPersona(tt.entry); got != tt.want {
+				t.Fatalf("AppliesOfficialDeepSeekV4ProPersona() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyOfficialDeepSeekV4ProPersonaPrependsOnce(t *testing.T) {
+	t.Parallel()
+	pro := &ProviderEntry{BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"}
+	got := ApplyOfficialDeepSeekV4ProPersona("You are Reasonix, a coding agent.", pro)
+	want := OfficialDeepSeekV4ProPersona + "\n\nYou are Reasonix, a coding agent."
+	if got != want {
+		t.Fatalf("prepend = %q, want %q", got, want)
+	}
+	if again := ApplyOfficialDeepSeekV4ProPersona(got, pro); again != want {
+		t.Fatalf("second apply duplicated persona:\n%s", again)
+	}
+}
+
+func TestApplyOfficialDeepSeekV4ProPersonaStripsForOtherModels(t *testing.T) {
+	t.Parallel()
+	pro := &ProviderEntry{BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"}
+	flash := &ProviderEntry{BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"}
+	withPersona := ApplyOfficialDeepSeekV4ProPersona("BASE", pro)
+	got := ApplyOfficialDeepSeekV4ProPersona(withPersona, flash)
+	if got != "BASE" {
+		t.Fatalf("flash should drop the official pro persona, got %q", got)
+	}
+}
+
+func TestReasoningLanguageForEntryPinsOfficialProAutoToEnglish(t *testing.T) {
+	t.Parallel()
+	pro := &ProviderEntry{BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"}
+	flash := &ProviderEntry{BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"}
+	if got := ReasoningLanguageForEntry(pro, "auto"); got != "en" {
+		t.Fatalf("official pro auto = %q, want en", got)
+	}
+	if got := ReasoningLanguageForEntry(pro, "zh"); got != "zh" {
+		t.Fatalf("explicit zh must stay user-owned, got %q", got)
+	}
+	if got := ReasoningLanguageForEntry(flash, "auto"); got != "auto" {
+		t.Fatalf("flash auto = %q, want auto", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Official DeepSeek-V4-Pro now prepends the DeepSeek Harness minimal-mode
  persona as the first system-prompt paragraph:
  `You are a helpful software engineer assistant. when you thought, thought in ENGLISH, start with "We need.."`.
- Matching is host + model, not provider name: `api.deepseek.com` (including
  `/anthropic`) and `deepseek-v4-pro` only. Official Flash and third-party
  hosts that reuse the model id are unchanged.
- Rebuilds strip and re-apply the paragraph, so switching away from official
  Pro does not leave the persona on another model.
- `reasoning_language = auto` pins visible thinking to English for that entry
  so Chinese auto-inference cannot override the persona. Explicit `zh` / `en`
  remain user-owned.
- Documents the exception in `docs/REASONING_LANGUAGE.md` and
  `docs/REASONING_LANGUAGE.zh-CN.md`.

## Issues

No linked issue.

## Verification

- `go test ./internal/config/ -count=1`
- `go test ./internal/boot/ -count=1`
- `go test ./internal/tool/builtin/ -count=1`
- `make lint`

## Documentation impact

Documentation-impact: updated - official DeepSeek-V4-Pro auto reasoning language and first-line persona documented in REASONING_LANGUAGE.md and REASONING_LANGUAGE.zh-CN.md

## Cache impact

Cache-impact: low - official V4-Pro gets one additional stable first paragraph; bytes stay fixed for that model across turns and sessions. Flash and other models keep the previous prefix. Switching models already rebuilds the prefix.
Cache-guard: TestApplyOfficialDeepSeekV4ProPersonaPrependsOnce, TestBuildOfficialDeepSeekV4ProPrependsPersona, TestBuildOfficialDeepSeekV4FlashDoesNotPrependPersona, TestBuildThirdPartyDeepSeekV4ProDoesNotPrependPersona, TestBuildComposesByteStableSystemPrompt
System-prompt-review: Xinwei requested the official V4-Pro first-line DSH persona; reviewed for model-stable prefix, strip/reapply on rebuild, and no third-party/Flash leakage
