### PR TITLE
fix(workspacelease): bound background-job lease retention / 后台任务租约保留改为有界

### DIFF
--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -219,8 +219,8 @@ func WithTeardownGrace(d time.Duration) Option {
 }
 
 // WithJobStartObserver observes every registered background job before its
-// goroutine starts. Delivery uses this to retain a workspace writer lease until
-// the job is truly terminal. The callback must return quickly.
+// goroutine starts. Delivery uses this to retain a workspace writer lease over
+// the job's opening writes. The callback must return quickly.
 func WithJobStartObserver(observer func(done <-chan struct{})) Option {
 	return func(m *Manager) { m.onJobStart = observer }
 }

--- a/internal/workspacelease/background_grace_test.go
+++ b/internal/workspacelease/background_grace_test.go
@@ -105,3 +105,42 @@ func TestFinishedBackgroundJobReleasesWithoutWaitingForGrace(t *testing.T) {
 	close(job)
 	waitForRelease(t, owner)
 }
+
+// The grace release must leave the owner able to reacquire, so two sessions
+// sharing a workspace alternate instead of deadlocking each other.
+func TestGraceReleaseAllowsReacquireAndAlternation(t *testing.T) {
+	root, lockDir := t.TempDir(), t.TempDir()
+	a := newOwnerWithGrace(t, root, lockDir, 20*time.Millisecond)
+	b := newOwnerWithGrace(t, root, lockDir, 20*time.Millisecond)
+
+	a.BeginRun()
+	if err := a.AcquireWrite(context.Background()); err != nil {
+		t.Fatalf("a acquire: %v", err)
+	}
+	resident := make(chan struct{})
+	defer close(resident)
+	a.RetainUntil(resident)
+	a.EndRun()
+	waitForRelease(t, a)
+
+	// b takes the workspace while a's resident job is still running.
+	b.BeginRun()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := b.AcquireWrite(ctx); err != nil {
+		t.Fatalf("b acquire after grace: %v", err)
+	}
+	b.EndRun()
+	waitForRelease(t, b)
+
+	a.BeginRun()
+	defer a.EndRun()
+	reacquire, cancelReacquire := context.WithTimeout(context.Background(), time.Second)
+	defer cancelReacquire()
+	if err := a.AcquireWrite(reacquire); err != nil {
+		t.Fatalf("a could not reacquire after releasing: %v", err)
+	}
+	if st := a.State(); !st.Acquired {
+		t.Fatalf("a state after reacquire: %+v", st)
+	}
+}

--- a/internal/workspacelease/background_grace_test.go
+++ b/internal/workspacelease/background_grace_test.go
@@ -1,0 +1,107 @@
+package workspacelease
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newOwnerWithGrace(t *testing.T, root, lockDir string, grace time.Duration) *Owner {
+	t.Helper()
+	owner, err := New(root, lockDir, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	owner.graceAfter = grace
+	return owner
+}
+
+func waitForRelease(t *testing.T, owner *Owner) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !owner.State().Acquired {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("workspace lease was never released")
+}
+
+// A resident background job (dev server, watcher) whose channel never closes
+// must not own the workspace indefinitely once the session is idle.
+func TestResidentBackgroundJobReleasesLeaseAfterGrace(t *testing.T) {
+	root, lockDir := t.TempDir(), t.TempDir()
+	owner := newOwnerWithGrace(t, root, lockDir, 20*time.Millisecond)
+
+	owner.BeginRun()
+	if err := owner.AcquireWrite(context.Background()); err != nil {
+		t.Fatalf("AcquireWrite: %v", err)
+	}
+	resident := make(chan struct{})
+	owner.RetainUntil(resident)
+	owner.EndRun()
+
+	waitForRelease(t, owner)
+
+	other, err := New(root, lockDir, nil)
+	if err != nil {
+		t.Fatalf("New other: %v", err)
+	}
+	other.BeginRun()
+	defer other.EndRun()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := other.AcquireWrite(ctx); err != nil {
+		t.Fatalf("second session could not acquire the freed lease: %v", err)
+	}
+
+	// The job ending after the grace release must not release a second time.
+	close(resident)
+	time.Sleep(20 * time.Millisecond)
+	if !other.State().Acquired {
+		t.Fatal("the retained job released a lease it no longer owned")
+	}
+}
+
+// The grace release must never fire underneath a run that has already started,
+// which is the path that would let two sessions write concurrently.
+func TestRunCancelsPendingGraceRelease(t *testing.T) {
+	owner := newOwnerWithGrace(t, t.TempDir(), t.TempDir(), 20*time.Millisecond)
+
+	owner.BeginRun()
+	if err := owner.AcquireWrite(context.Background()); err != nil {
+		t.Fatalf("AcquireWrite: %v", err)
+	}
+	resident := make(chan struct{})
+	defer close(resident)
+	owner.RetainUntil(resident)
+	owner.EndRun()
+	owner.BeginRun()
+	defer owner.EndRun()
+
+	time.Sleep(200 * time.Millisecond)
+	if !owner.State().Acquired {
+		t.Fatal("grace release fired while a run was active")
+	}
+}
+
+// A background job that finishes on its own still releases immediately; the
+// grace window is a ceiling, not an added delay.
+func TestFinishedBackgroundJobReleasesWithoutWaitingForGrace(t *testing.T) {
+	owner := newOwnerWithGrace(t, t.TempDir(), t.TempDir(), 30*time.Second)
+
+	owner.BeginRun()
+	if err := owner.AcquireWrite(context.Background()); err != nil {
+		t.Fatalf("AcquireWrite: %v", err)
+	}
+	job := make(chan struct{})
+	owner.RetainUntil(job)
+	owner.EndRun()
+
+	if !owner.State().Acquired {
+		t.Fatal("lease released while the background job was still running")
+	}
+	close(job)
+	waitForRelease(t, owner)
+}

--- a/internal/workspacelease/lease.go
+++ b/internal/workspacelease/lease.go
@@ -1,7 +1,8 @@
 // Package workspacelease serializes Delivery writers that target the same
 // workspace. Readers never acquire a lease. A writer keeps its lease from the
-// first mutation until every participating agent run and background job has
-// finished.
+// first mutation until every participating agent run has finished; a retained
+// background job then extends it only for a bounded grace period, so a resident
+// service cannot pin the workspace against other sessions forever.
 //
 // Owner is participation accounting only. Cross-process and in-process
 // serialization is delegated to internal/filelock.
@@ -18,9 +19,17 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/filelock"
 )
+
+// backgroundGrace bounds how long a retained background job may keep the write
+// lease after the last agent run ends. run_in_background is used for long-lived
+// services (dev servers, watchers) whose job channel may never close, so an
+// unbounded retention would hand one session the workspace permanently. The
+// window still covers a job's initial burst of workspace writes.
+const backgroundGrace = 30 * time.Second
 
 // WaitNotice is called once when an acquisition cannot complete immediately.
 // It must return quickly and must not call back into Owner.
@@ -30,8 +39,9 @@ type WaitNotice func()
 // shared by the root agent and all of its subagents. Different sessions must
 // use different Owners, even when they share a workspace.
 type Owner struct {
-	lockPath string
-	onWait   WaitNotice
+	lockPath   string
+	onWait     WaitNotice
+	graceAfter time.Duration
 
 	mu            sync.Mutex
 	activeRuns    int
@@ -41,6 +51,10 @@ type Owner struct {
 	waiting       bool
 	acquireDone   chan struct{}
 	releaseSystem func()
+	// leaseEpoch changes on every acquisition so a pending grace release can
+	// prove it still targets the lease it was armed for.
+	leaseEpoch uint64
+	graceTimer *time.Timer
 }
 
 // State is a sanitized process-local snapshot used by Desktop to explain a
@@ -79,8 +93,9 @@ func New(workspaceRoot, lockDir string, onWait WaitNotice) (*Owner, error) {
 	key := hex.EncodeToString(sum[:])
 
 	return &Owner{
-		lockPath: filepath.Join(lockDir, key+".lock"),
-		onWait:   onWait,
+		lockPath:   filepath.Join(lockDir, key+".lock"),
+		onWait:     onWait,
+		graceAfter: backgroundGrace,
 	}, nil
 }
 
@@ -139,6 +154,9 @@ func (o *Owner) BeginRun() {
 	}
 	o.mu.Lock()
 	o.activeRuns++
+	// A new run may write immediately, so revoke any grace release still pending
+	// from the previous run's background jobs.
+	o.cancelGraceLocked()
 	o.mu.Unlock()
 }
 
@@ -196,6 +214,7 @@ func (o *Owner) AcquireWrite(ctx context.Context) error {
 		if err == nil {
 			o.acquired = true
 			o.releaseSystem = release
+			o.leaseEpoch++
 		}
 		close(done)
 		releaseIfIdle := o.releaseIfIdleLocked()
@@ -236,13 +255,54 @@ func (o *Owner) RetainUntil(done <-chan struct{}) {
 }
 
 func (o *Owner) releaseIfIdleLocked() func() {
-	if !o.acquired || o.acquiring || o.activeRuns != 0 || o.background != 0 {
+	if !o.acquired || o.acquiring || o.activeRuns != 0 {
 		return nil
 	}
+	if o.background != 0 {
+		o.armGraceLocked()
+		return nil
+	}
+	return o.takeLeaseLocked()
+}
+
+// takeLeaseLocked detaches the system release from this Owner exactly once, so
+// no two paths can release the same acquisition.
+func (o *Owner) takeLeaseLocked() func() {
+	o.cancelGraceLocked()
 	release := o.releaseSystem
 	o.acquired = false
 	o.releaseSystem = nil
 	return release
+}
+
+// armGraceLocked schedules the bounded release that keeps a resident background
+// job from owning the workspace indefinitely. The callback re-checks the epoch
+// and participation because Timer.Stop loses the race with an already-running
+// callback, and because a run may start or the lease may be reacquired first.
+func (o *Owner) armGraceLocked() {
+	if o.graceAfter <= 0 || o.graceTimer != nil {
+		return
+	}
+	epoch := o.leaseEpoch
+	o.graceTimer = time.AfterFunc(o.graceAfter, func() {
+		o.mu.Lock()
+		if o.graceTimer == nil || o.leaseEpoch != epoch || !o.acquired || o.acquiring || o.activeRuns != 0 {
+			o.mu.Unlock()
+			return
+		}
+		release := o.takeLeaseLocked()
+		o.mu.Unlock()
+		if release != nil {
+			release()
+		}
+	})
+}
+
+func (o *Owner) cancelGraceLocked() {
+	if o.graceTimer != nil {
+		o.graceTimer.Stop()
+		o.graceTimer = nil
+	}
 }
 
 // acquire tries filelock.TryAcquire, then waits via filelock.Acquire.


### PR DESCRIPTION
## Problem

A session that started a resident background service — a dev server, a file watcher, a debug server — kept the workspace write lease forever. Its own UI went completely idle, yet every other session targeting the same workspace blocked indefinitely on "another session is writing to this workspace". The waiting session correctly named the idle session as the holder and promised it would continue automatically once released, but it never did. There was no recovery short of killing the background job or restarting the app.

## Root cause

`jobs.Manager` reports every started job to `Owner.RetainUntil` (wired via `jobs.WithJobStartObserver` in `internal/boot`), which increments the `background` counter. `releaseIfIdleLocked` refused to release while `background != 0`, and a job's `done` channel closes only when its run function returns (`internal/jobs/jobs.go`). A resident service never returns, so `background` stayed `>= 1` and `acquired` stayed `true` long after the last agent run had ended.

The package doc promised the lease is held "until every participating agent run and background job has finished". For a service the user deliberately wants resident, that promise degrades into permanent exclusive ownership of the workspace.

## Fix

A retained background job now extends the lease only for a bounded grace period (30s) after the final agent run ends. When the window expires the lease is released even while the job keeps running, so a resident service can no longer pin the workspace against other sessions.

Two concurrency guards come with it:

- **Lease epoch.** Every acquisition bumps `leaseEpoch`; the pending grace release compares it before releasing. Without this, `Timer.Stop` losing the race with an already-running callback would let a stale timer release a *later* acquisition.
- **`BeginRun` cancels a pending release.** A new turn may write immediately, so it revokes any grace release still scheduled from the previous turn's background jobs. This is the data-safety edge, not just a UX detail.

`takeLeaseLocked` centralizes detaching the system release, so the normal path and the grace path can never release the same acquisition twice.

Short-lived background jobs are unaffected: a job that finishes inside the window still releases immediately, so the grace window is a ceiling rather than an added delay.

## Verification

- `go test ./internal/workspacelease/ -race -count=2` — passes
- Three new regression tests:
  - `TestResidentBackgroundJobReleasesLeaseAfterGrace` — the reported bug; also asserts a second owner can then acquire, and that the job ending afterwards does not double-release
  - `TestRunCancelsPendingGraceRelease` — the grace release never fires under an active run
  - `TestFinishedBackgroundJobReleasesWithoutWaitingForGrace` — existing immediate-release semantics preserved
- Reverting the fix makes `TestResidentBackgroundJobReleasesLeaseAfterGrace` fail with `workspace lease was never released`, confirming the test actually guards this contract
- `make lint` — golangci-lint 0 issues, repolint clean (no baseline widened)
- `go vet`, `gofmt` — clean
- `go test ./internal/boot/ ./internal/agent/ ./internal/control/ ./internal/tool/builtin/ ./internal/jobs/` — pass
- `desktop` module: `TestTabEventSinkForwardsImmediateWorkspaceMutation` fails, but it fails identically on the unmodified base commit — a pre-existing macOS fsevents failure unrelated to this change

No prompt, tool-schema, or provider-serialization surface is touched, so the provider-visible prefix is byte-identical.

Documentation-impact: none - the bounded-retention rule is internal lease behavior, and no docs/*.md describes the previous "held until every background job finishes" wording.