### PR TITLE
fix(desktop): deduplicate pinned project tree conversations / 修复置顶对话在项目树重复显示

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-pinned-shell-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-pinned-shell-runtime.test.ts
@@ -1,8 +1,59 @@
-import { mergeProjectTopicPage, projectTreeShellChildren } from "../components/ProjectTree";
+import { mergeProjectTopicPage, projectTreeShellChildren, splitPinnedProjectTree } from "../components/ProjectTree";
 
 type Equal = (actual: unknown, expected: unknown, label: string) => void;
 
 export function runProjectTreePinnedShellRuntimeTests(eq: Equal, projectTreeSource: string) {
+  eq(
+    splitPinnedProjectTree(
+      [{
+        key: "global_folder",
+        kind: "global_folder",
+        label: "Global",
+        children: [
+          { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
+          { key: "global_topic_duplicate_page", kind: "global_topic", label: "Pinned", topicId: "duplicate" },
+          // A live runtime projection can carry the same topic as a session row
+          // while the catalog still serves the original topic shell.
+          { key: "global_session_duplicate", kind: "global_session", label: "Pinned", topicId: "duplicate" },
+        ],
+      }],
+      "updated",
+      false,
+    ),
+    {
+      pinned: [
+        { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
+      ],
+      projects: [{ key: "global_folder", kind: "global_folder", label: "Global", children: [] }],
+    },
+    "pinned conversations do not repeat as runtime session rows in their source folder",
+  );
+
+  eq(
+    splitPinnedProjectTree(
+      [
+        {
+          key: "project_a",
+          kind: "project",
+          label: "A",
+          root: "/repo/a",
+          children: [{ key: "topic_a", kind: "topic", label: "Pinned A", root: "/repo/a", topicId: "shared", pinned: true }],
+        },
+        {
+          key: "project_b",
+          kind: "project",
+          label: "B",
+          root: "/repo/b",
+          children: [{ key: "topic_b", kind: "topic", label: "Regular B", root: "/repo/b", topicId: "shared" }],
+        },
+      ],
+      "updated",
+      false,
+    ).projects.map((project) => asTopicKeys(project.children)),
+    [[], ["topic_b"]],
+    "a pinned topic does not hide the same topic ID from another project",
+  );
+
   eq(
     mergeProjectTopicPage(
       [
@@ -45,4 +96,8 @@ export function runProjectTreePinnedShellRuntimeTests(eq: Equal, projectTreeSour
     true,
     "shell refresh preserves loaded folders while reconciling pinned topic shells",
   );
+}
+
+function asTopicKeys(children: { key: string }[] | undefined): string[] {
+  return children?.map((node) => node.key) ?? [];
 }

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -551,37 +551,6 @@ eq(
 
 eq(
   splitPinnedProjectTree(
-    [{
-      key: "global_folder",
-      kind: "global_folder",
-      label: "Global",
-      children: [
-        { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
-        { key: "global_topic_duplicate_page", kind: "global_topic", label: "Pinned", topicId: "duplicate" },
-        // A live runtime projection can carry the same topic as a session row
-        // while the catalog still serves the original topic shell.
-        { key: "global_session_duplicate", kind: "global_session", label: "Pinned", topicId: "duplicate" },
-      ],
-    }],
-    "updated",
-    false,
-  ),
-  {
-    pinned: [
-      { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
-    ],
-    projects: [{
-      key: "global_folder",
-      kind: "global_folder",
-      label: "Global",
-      children: [],
-    }],
-  },
-  "pinned conversations do not repeat as runtime session rows in their source folder",
-);
-
-eq(
-  splitPinnedProjectTree(
     [{ key: "project_/repo/a", kind: "project", label: "a", root: "/repo/a", pinned: true, children: [] }],
     "updated",
   ).pinned.map((node) => node.root),

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -551,6 +551,37 @@ eq(
 
 eq(
   splitPinnedProjectTree(
+    [{
+      key: "global_folder",
+      kind: "global_folder",
+      label: "Global",
+      children: [
+        { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
+        { key: "global_topic_duplicate_page", kind: "global_topic", label: "Pinned", topicId: "duplicate" },
+        // A live runtime projection can carry the same topic as a session row
+        // while the catalog still serves the original topic shell.
+        { key: "global_session_duplicate", kind: "global_session", label: "Pinned", topicId: "duplicate" },
+      ],
+    }],
+    "updated",
+    false,
+  ),
+  {
+    pinned: [
+      { key: "global_topic_duplicate", kind: "global_topic", label: "Pinned", topicId: "duplicate", pinned: true },
+    ],
+    projects: [{
+      key: "global_folder",
+      kind: "global_folder",
+      label: "Global",
+      children: [],
+    }],
+  },
+  "pinned conversations do not repeat as runtime session rows in their source folder",
+);
+
+eq(
+  splitPinnedProjectTree(
     [{ key: "project_/repo/a", kind: "project", label: "a", root: "/repo/a", pinned: true, children: [] }],
     "updated",
   ).pinned.map((node) => node.root),

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -12,6 +12,8 @@ import { app } from "../lib/bridge";
 import { onProjectTreeChangedV2 } from "../lib/sessionCatalogBridge";
 import { isRuntimeSessionNode, isTopicNode, loadWorkbenchOrganizeMode, loadWorkbenchSortMode, mergeIncompleteProjectTopicPage, mergeProjectTopicPage, projectTreeDedupedExactTime, projectTreeEventAffectsFolder, projectTreeFolderDisclosure, projectTreeReadActivityKey, projectTreeRevisionIsFresh, projectTreeShellChildren, projectTreeShellSignature, projectTreeShouldApplyShellSnapshot, projectTreeShouldRenderTopicActions, projectTreeShouldSuppressOpenForRename, projectTreeTopicArchiveBlocked, projectTreeTopicHasUnreadActivity, projectTreeTopicHoverCardModel, projectTreeTopicMenuOffersPin, projectTreeTopicMetaLine, projectTreeTopicOpenRequest, projectTreeTopicPageIsFresh, projectTreeTopicPageSignature, projectTreeWithoutTopic, topicActivityAt, topicActivityDateLabel, topicActivityLabel, topicIsActive, topicStatus, topicStatusLabel, topicUnknownTimeLabel, WORKBENCH_ORGANIZE_KEY, WORKBENCH_SORT_KEY, type ProjectTreePendingTopicOpen, type ProjectTreeReadActivity, type ProjectTreeTopicHoverCard, type ProjectTreeVariant, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "../lib/projectTreeTopic";
 export * from "../lib/projectTreeTopic";
+import { arrangeClassicProjectTree, arrangeWorkbenchTree, classicTopicWindow, CLASSIC_TOPIC_PREVIEW_LIMIT, splitPinnedProjectTree, type PinnedTreeSections } from "../lib/projectTreePresentation";
+export * from "../lib/projectTreePresentation";
 import type { ProjectNode, SessionCatalogStatus } from "../lib/types";
 import { topicActivityTime } from "../lib/session";
 import { useT, type Translator } from "../lib/i18n";
@@ -24,7 +26,7 @@ import { Tooltip } from "./Tooltip";
 import { WorktreeBadge } from "./WorktreeBadge";
 import { useProjectCreation } from "./useProjectCreation";
 import { useProjectTreeRuntimeProjection } from "../lib/useProjectTreeRuntimeProjection";
-import { GLOBAL_PROJECT_ORDER_KEY, ProjectTreeFolderActivity, ProjectTreeGroupRows, applyProjectOrder, manualTopicOrder, projectTreeProjectRoots, reorderedProjectRoots, useProjectTreeOrganization, type ProjectDropPosition } from "./ProjectTreeOrganization";
+import { GLOBAL_PROJECT_ORDER_KEY, ProjectTreeFolderActivity, ProjectTreeGroupRows, applyProjectOrder, projectTreeProjectRoots, reorderedProjectRoots, useProjectTreeOrganization, type ProjectDropPosition } from "./ProjectTreeOrganization";
 
 interface ProjectTreeProps {
   activeScope?: string;
@@ -65,11 +67,6 @@ type WorkbenchHeaderMenu = "more" | "add" | null;
 type CollapseSnapshot = {
   expanded: Set<string>;
   manuallyCollapsed: Set<string>;
-};
-
-type PinnedTreeSections = {
-  pinned: ProjectNode[];
-  projects: ProjectNode[];
 };
 
 const READ_ACTIVITY_KEY = "projectTree:readActivity";
@@ -172,130 +169,6 @@ export function defaultExpandedProjectTreeKeys(
   activeSessionPath?: string,
 ): string[] {
   return activeSessionAncestorKeys(nodes, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
-}
-
-function topicSortValue(node: ProjectNode, sortMode: WorkbenchSortMode): number {
-  if (sortMode === "created") return node.createdAt || node.lastActivityAt || 0;
-  return topicActivityTime(node);
-}
-
-function projectSortValue(node: ProjectNode, sortMode: WorkbenchSortMode): number {
-  return asArray(node.children).reduce((max, child) => {
-    if (!isTopicNode(child)) return max;
-    return Math.max(max, topicSortValue(child, sortMode));
-  }, 0);
-}
-
-function sortWorkbenchChildren(children: ProjectNode[], sortMode: WorkbenchSortMode): ProjectNode[] {
-  return [...children].sort((a, b) => {
-    if (!isTopicNode(a) || !isTopicNode(b)) return 0;
-    if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1;
-    const manualOrder = manualTopicOrder(a, b);
-    if (manualOrder !== 0) return manualOrder;
-    const activityOrder = topicSortValue(b, sortMode) - topicSortValue(a, sortMode);
-    if (activityOrder !== 0) return activityOrder;
-    const aKey = a.topicId || a.key;
-    const bKey = b.topicId || b.key;
-    return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
-  });
-}
-
-function arrangeWorkbenchTree(nodes: ProjectNode[], organizeMode: WorkbenchOrganizeMode, sortMode: WorkbenchSortMode): ProjectNode[] {
-  const arranged = nodes.map((node) => {
-    if (node.kind !== "project" && node.kind !== "global_folder") return node;
-    return { ...node, children: sortWorkbenchChildren(asArray(node.children), sortMode) };
-  });
-  if (organizeMode === "project") return arranged;
-  const mode = organizeMode === "recent" ? "updated" : sortMode;
-  return [...arranged].sort((a, b) => {
-    if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1;
-    return projectSortValue(b, mode) - projectSortValue(a, mode);
-  });
-}
-
-// Classic keeps the user's manual project order but sorts topics inside each
-// folder, so row order matches the activity time shown in the meta line
-// instead of the persisted insertion order.
-export function arrangeClassicProjectTree(nodes: ProjectNode[], sortMode: WorkbenchSortMode): ProjectNode[] {
-  return arrangeWorkbenchTree(nodes, "project", sortMode);
-}
-
-// Classic folders preview only the first few topics; the rest sit behind a
-// show-more toggle so one busy project cannot push the others out of view.
-export const CLASSIC_TOPIC_PREVIEW_LIMIT = 5;
-
-export function classicTopicWindow(children: ProjectNode[], showAll: boolean): { visible: ProjectNode[]; hiddenCount: number } {
-  if (showAll || children.length <= CLASSIC_TOPIC_PREVIEW_LIMIT) return { visible: children, hiddenCount: 0 };
-  return {
-    visible: children.slice(0, CLASSIC_TOPIC_PREVIEW_LIMIT),
-    hiddenCount: children.length - CLASSIC_TOPIC_PREVIEW_LIMIT,
-  };
-}
-
-function projectTreeTopicIdentity(node: ProjectNode): string | null {
-  if ((!isTopicNode(node) && !isRuntimeSessionNode(node)) || !node.topicId) return null;
-  const global = node.kind === "global_topic" || node.kind === "global_session";
-  return `${global ? "global" : "project"}\u001f${global ? "" : node.root ?? ""}\u001f${node.topicId}`;
-}
-
-export function splitPinnedProjectTree(
-  nodes: ProjectNode[],
-  sortMode: WorkbenchSortMode,
-  includePinnedProjects = true,
-): PinnedTreeSections {
-  const pinnedTopics: ProjectNode[] = [];
-  const pinnedProjects: ProjectNode[] = [];
-  const projects: ProjectNode[] = [];
-  // A pinned topic shell can coexist briefly with a runtime session projection
-  // for the same logical conversation. Collect canonical pinned identities
-  // first so the source folder cannot paint that conversation a second time.
-  const pinnedTopicIdentities = new Set<string>();
-  for (const node of nodes) {
-    const identity = projectTreeTopicIdentity(node);
-    if (identity && node.pinned) pinnedTopicIdentities.add(identity);
-    if (node.kind !== "project" && node.kind !== "global_folder") continue;
-    for (const child of asArray(node.children)) {
-      const childIdentity = projectTreeTopicIdentity(child);
-      if (childIdentity && child.pinned) pinnedTopicIdentities.add(childIdentity);
-    }
-  }
-
-  for (const node of nodes) {
-    if (!node) continue;
-    const isFolder = node.kind === "project" || node.kind === "global_folder";
-    if (!isFolder) {
-      const identity = projectTreeTopicIdentity(node);
-      if (node.pinned) pinnedTopics.push(node);
-      else if (!identity || !pinnedTopicIdentities.has(identity)) projects.push(node);
-      continue;
-    }
-
-    if (includePinnedProjects && node.pinned && node.kind === "project") {
-      pinnedProjects.push(node);
-      continue;
-    }
-
-    const children = asArray(node.children);
-    const nextChildren: ProjectNode[] = [];
-    for (const child of children) {
-      const identity = projectTreeTopicIdentity(child);
-      if (isTopicNode(child) && child.pinned) {
-        pinnedTopics.push(child);
-        continue;
-      }
-      if (identity && pinnedTopicIdentities.has(identity)) continue;
-      nextChildren.push(child);
-    }
-    projects.push({ ...node, children: nextChildren });
-  }
-
-  pinnedTopics.sort((a, b) => topicSortValue(b, sortMode) - topicSortValue(a, sortMode));
-  pinnedProjects.sort((a, b) => projectSortValue(b, sortMode) - projectSortValue(a, sortMode));
-
-  return {
-    pinned: [...pinnedTopics, ...pinnedProjects],
-    projects,
-  };
 }
 
 // Global rows use the same project tree recipe; the fallback supplies their non-workspace accent.

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -232,6 +232,12 @@ export function classicTopicWindow(children: ProjectNode[], showAll: boolean): {
   };
 }
 
+function projectTreeTopicIdentity(node: ProjectNode): string | null {
+  if ((!isTopicNode(node) && !isRuntimeSessionNode(node)) || !node.topicId) return null;
+  const global = node.kind === "global_topic" || node.kind === "global_session";
+  return `${global ? "global" : "project"}\u001f${global ? "" : node.root ?? ""}\u001f${node.topicId}`;
+}
+
 export function splitPinnedProjectTree(
   nodes: ProjectNode[],
   sortMode: WorkbenchSortMode,
@@ -240,13 +246,27 @@ export function splitPinnedProjectTree(
   const pinnedTopics: ProjectNode[] = [];
   const pinnedProjects: ProjectNode[] = [];
   const projects: ProjectNode[] = [];
+  // A pinned topic shell can coexist briefly with a runtime session projection
+  // for the same logical conversation. Collect canonical pinned identities
+  // first so the source folder cannot paint that conversation a second time.
+  const pinnedTopicIdentities = new Set<string>();
+  for (const node of nodes) {
+    const identity = projectTreeTopicIdentity(node);
+    if (identity && node.pinned) pinnedTopicIdentities.add(identity);
+    if (node.kind !== "project" && node.kind !== "global_folder") continue;
+    for (const child of asArray(node.children)) {
+      const childIdentity = projectTreeTopicIdentity(child);
+      if (childIdentity && child.pinned) pinnedTopicIdentities.add(childIdentity);
+    }
+  }
 
   for (const node of nodes) {
     if (!node) continue;
     const isFolder = node.kind === "project" || node.kind === "global_folder";
     if (!isFolder) {
+      const identity = projectTreeTopicIdentity(node);
       if (node.pinned) pinnedTopics.push(node);
-      else projects.push(node);
+      else if (!identity || !pinnedTopicIdentities.has(identity)) projects.push(node);
       continue;
     }
 
@@ -258,10 +278,12 @@ export function splitPinnedProjectTree(
     const children = asArray(node.children);
     const nextChildren: ProjectNode[] = [];
     for (const child of children) {
+      const identity = projectTreeTopicIdentity(child);
       if (isTopicNode(child) && child.pinned) {
         pinnedTopics.push(child);
         continue;
       }
+      if (identity && pinnedTopicIdentities.has(identity)) continue;
       nextChildren.push(child);
     }
     projects.push({ ...node, children: nextChildren });

--- a/desktop/frontend/src/lib/projectTreePresentation.ts
+++ b/desktop/frontend/src/lib/projectTreePresentation.ts
@@ -1,0 +1,132 @@
+import { asArray } from "./array";
+import { isRuntimeSessionNode, isTopicNode, type WorkbenchOrganizeMode, type WorkbenchSortMode } from "./projectTreeTopic";
+import { topicActivityTime } from "./session";
+import type { ProjectNode } from "./types";
+
+export type PinnedTreeSections = {
+  pinned: ProjectNode[];
+  projects: ProjectNode[];
+};
+
+function topicSortValue(node: ProjectNode, sortMode: WorkbenchSortMode): number {
+  if (sortMode === "created") return node.createdAt || node.lastActivityAt || 0;
+  return topicActivityTime(node);
+}
+
+function projectSortValue(node: ProjectNode, sortMode: WorkbenchSortMode): number {
+  return asArray(node.children).reduce((max, child) => {
+    if (!isTopicNode(child)) return max;
+    return Math.max(max, topicSortValue(child, sortMode));
+  }, 0);
+}
+
+function manualTopicOrder(a: ProjectNode, b: ProjectNode): number {
+  const aOrder = typeof a.sortOrder === "number" && a.sortOrder >= 0 ? a.sortOrder : Number.MAX_SAFE_INTEGER;
+  const bOrder = typeof b.sortOrder === "number" && b.sortOrder >= 0 ? b.sortOrder : Number.MAX_SAFE_INTEGER;
+  return aOrder === bOrder ? 0 : aOrder - bOrder;
+}
+
+function sortWorkbenchChildren(children: ProjectNode[], sortMode: WorkbenchSortMode): ProjectNode[] {
+  return [...children].sort((a, b) => {
+    if (!isTopicNode(a) || !isTopicNode(b)) return 0;
+    if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1;
+    const manualOrder = manualTopicOrder(a, b);
+    if (manualOrder !== 0) return manualOrder;
+    const activityOrder = topicSortValue(b, sortMode) - topicSortValue(a, sortMode);
+    if (activityOrder !== 0) return activityOrder;
+    const aKey = a.topicId || a.key;
+    const bKey = b.topicId || b.key;
+    return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
+  });
+}
+
+export function arrangeWorkbenchTree(
+  nodes: ProjectNode[],
+  organizeMode: WorkbenchOrganizeMode,
+  sortMode: WorkbenchSortMode,
+): ProjectNode[] {
+  const arranged = nodes.map((node) => {
+    if (node.kind !== "project" && node.kind !== "global_folder") return node;
+    return { ...node, children: sortWorkbenchChildren(asArray(node.children), sortMode) };
+  });
+  if (organizeMode === "project") return arranged;
+  const mode = organizeMode === "recent" ? "updated" : sortMode;
+  return [...arranged].sort((a, b) => {
+    if (Boolean(a.pinned) !== Boolean(b.pinned)) return a.pinned ? -1 : 1;
+    return projectSortValue(b, mode) - projectSortValue(a, mode);
+  });
+}
+
+export function arrangeClassicProjectTree(nodes: ProjectNode[], sortMode: WorkbenchSortMode): ProjectNode[] {
+  return arrangeWorkbenchTree(nodes, "project", sortMode);
+}
+
+export const CLASSIC_TOPIC_PREVIEW_LIMIT = 5;
+
+export function classicTopicWindow(children: ProjectNode[], showAll: boolean): { visible: ProjectNode[]; hiddenCount: number } {
+  if (showAll || children.length <= CLASSIC_TOPIC_PREVIEW_LIMIT) return { visible: children, hiddenCount: 0 };
+  return {
+    visible: children.slice(0, CLASSIC_TOPIC_PREVIEW_LIMIT),
+    hiddenCount: children.length - CLASSIC_TOPIC_PREVIEW_LIMIT,
+  };
+}
+
+function projectTreeTopicIdentity(node: ProjectNode): string | null {
+  if ((!isTopicNode(node) && !isRuntimeSessionNode(node)) || !node.topicId) return null;
+  const global = node.kind === "global_topic" || node.kind === "global_session";
+  return `${global ? "global" : "project"}\u001f${global ? "" : node.root ?? ""}\u001f${node.topicId}`;
+}
+
+export function splitPinnedProjectTree(
+  nodes: ProjectNode[],
+  sortMode: WorkbenchSortMode,
+  includePinnedProjects = true,
+): PinnedTreeSections {
+  const pinnedTopics: ProjectNode[] = [];
+  const pinnedProjects: ProjectNode[] = [];
+  const projects: ProjectNode[] = [];
+  // A pinned topic shell can coexist briefly with a runtime session projection.
+  // Collect identities first so its source folder cannot paint it twice.
+  const pinnedTopicIdentities = new Set<string>();
+  for (const node of nodes) {
+    const identity = projectTreeTopicIdentity(node);
+    if (identity && node.pinned) pinnedTopicIdentities.add(identity);
+    if (node.kind !== "project" && node.kind !== "global_folder") continue;
+    for (const child of asArray(node.children)) {
+      const childIdentity = projectTreeTopicIdentity(child);
+      if (childIdentity && child.pinned) pinnedTopicIdentities.add(childIdentity);
+    }
+  }
+
+  for (const node of nodes) {
+    if (!node) continue;
+    const isFolder = node.kind === "project" || node.kind === "global_folder";
+    if (!isFolder) {
+      const identity = projectTreeTopicIdentity(node);
+      if (node.pinned) pinnedTopics.push(node);
+      else if (!identity || !pinnedTopicIdentities.has(identity)) projects.push(node);
+      continue;
+    }
+
+    if (includePinnedProjects && node.pinned && node.kind === "project") {
+      pinnedProjects.push(node);
+      continue;
+    }
+
+    const nextChildren: ProjectNode[] = [];
+    for (const child of asArray(node.children)) {
+      const identity = projectTreeTopicIdentity(child);
+      if (isTopicNode(child) && child.pinned) {
+        pinnedTopics.push(child);
+        continue;
+      }
+      if (identity && pinnedTopicIdentities.has(identity)) continue;
+      nextChildren.push(child);
+    }
+    projects.push({ ...node, children: nextChildren });
+  }
+
+  pinnedTopics.sort((a, b) => topicSortValue(b, sortMode) - topicSortValue(a, sortMode));
+  pinnedProjects.sort((a, b) => projectSortValue(b, sortMode) - projectSortValue(a, sortMode));
+  return { pinned: [...pinnedTopics, ...pinnedProjects], projects };
+}


### PR DESCRIPTION
## Summary

- Prevent a pinned conversation from being rendered again in its Global or project folder.
- Deduplicate catalog topic and runtime session projections by logical conversation identity.
- Move project-tree sorting and pinned-section presentation helpers into a dedicated module so the owner component stays within repository size policy.

## Issues

This fixes the reported desktop sidebar bug where the same conversation appears once under `Pinned` and again in the folder list.

## Verification

- `pnpm exec tsx src/__tests__/project-tree-runtime.test.ts` — 88 passed
- `pnpm exec tsx src/__tests__/project-tree-runtime-projection.test.ts` — passed
- `pnpm exec tsx src/__tests__/project-tree-shell-race.test.ts` — passed
- `pnpm typecheck` — passed
- `pnpm exec eslint src/components/ProjectTree.tsx src/lib/projectTreePresentation.ts src/__tests__/project-tree-runtime.test.ts src/__tests__/project-tree-pinned-shell-runtime.test.ts` — passed
- `pnpm build` — passed, including bundle budgets
- `go run ./tools/repolint` — passed
- Browser cold-start pin/unpin flow — one pinned row, with no repeated row in the source folder
- Full frontend `pnpm test` — one unrelated existing `app-chrome-tabs` static contract check remains failing (`Welcome is suppressed only until transcript history has loaded`); the other suites passed.

## Documentation impact

Documentation-impact: none - this is an internal sidebar rendering fix and the existing documentation remains correct.

## Cache impact

Cache-impact: none - no provider prompts, tool schemas, serialization, or session context construction changed.
Cache-guard: N/A - this change is isolated to frontend project-tree rendering and its regression tests.
System-prompt-review: N/A
