### PR TITLE
fix(desktop): stop the reduced-motion transcript flicker loop / 修复 Windows 关闭动画时会话区闪烁与无法到底

### DIFF
--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -50,6 +50,50 @@ async function moveToOuterReaderGutter(page, transcript) {
   await page.mouse.move(point.x, point.y);
 }
 
+async function waitForStableTranscriptGeometry(
+  page,
+  { timeout = 15_000, frames = 8, requireTail = false } = {},
+) {
+  await page.evaluate(({ timeout, frames, requireTail }) => new Promise((resolve, reject) => {
+    const startedAt = performance.now();
+    let previous = null;
+    let stableFrames = 0;
+    const sample = () => {
+      const element = document.querySelector(".transcript");
+      if (element instanceof HTMLElement) {
+        const current = {
+          mode: element.dataset.scrollMode,
+          height: element.scrollHeight,
+          top: element.scrollTop,
+          clientHeight: element.clientHeight,
+        };
+        const unchanged = previous != null
+          && current.mode === previous.mode
+          && Math.abs(current.height - previous.height) <= 0.5
+          && Math.abs(current.top - previous.top) <= 0.5
+          && current.clientHeight === previous.clientHeight;
+        stableFrames = unchanged ? stableFrames + 1 : 0;
+        previous = current;
+        const distance = current.height - current.top - current.clientHeight;
+        const expectedPosition = !requireTail || (current.mode === "tail-follow" && distance <= 4);
+        if (expectedPosition && stableFrames >= frames) {
+          resolve();
+          return;
+        }
+      } else {
+        previous = null;
+        stableFrames = 0;
+      }
+      if (performance.now() - startedAt >= timeout) {
+        reject(new Error(`transcript geometry did not stay stable for ${frames} frames`));
+        return;
+      }
+      requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  }), { timeout, frames, requireTail });
+}
+
 async function waitForServer() {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
@@ -282,18 +326,52 @@ try {
   });
   assert(questionJumpWrites.length === 1, `question navigation clears stale selection and emits one indexed jump (${questionJumpWrites.length})`);
   await page.locator(".transcript__jump-bottom").waitFor({ state: "visible" });
-  // The question jump itself is smooth, so Playwright's actionability check
-  // can see the bottom button moving while the viewport settles. A DOM click
-  // still exercises the same React handler without waiting on button geometry.
-  await page.locator(".transcript__jump-bottom").evaluate((button) => button.click());
+  // The question jump itself is smooth. Wait for its geometry to settle before
+  // clicking the current button: resolving a locator while React remounts the
+  // moving control can otherwise call click() on a detached node, which never
+  // reaches React's delegated handler.
+  await waitForStableTranscriptGeometry(page, { timeout: 5_000, frames: 3 });
+  await page.evaluate(() => {
+    window.__reasonixJumpBottomWrites = [];
+    window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = (write) => window.__reasonixJumpBottomWrites.push(write);
+  });
+  const jumpBottomClicked = await page.evaluate(() => {
+    const button = document.querySelector(".transcript__jump-bottom");
+    if (!(button instanceof HTMLButtonElement) || !button.isConnected) return false;
+    button.click();
+    return true;
+  });
+  assert(jumpBottomClicked, "question jump exposes a connected jump-bottom control");
   // The arbiter's rest threshold is 4px: a late sub-threshold remeasure can
   // legally rest at 2-4px from the extent without earning another write.
-  await page.waitForFunction(() => {
-    const element = document.querySelector(".transcript");
-    return element instanceof HTMLElement
-      && element.dataset.scrollMode === "tail-follow"
-      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
-  });
+  try {
+    await page.waitForFunction(() => {
+      const element = document.querySelector(".transcript");
+      return element instanceof HTMLElement
+        && element.dataset.scrollMode === "tail-follow"
+        && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
+    });
+  } catch (error) {
+    const state = await page.evaluate(() => {
+      const element = document.querySelector(".transcript");
+      return element instanceof HTMLElement ? {
+        mode: element.dataset.scrollMode,
+        distance: element.scrollHeight - element.scrollTop - element.clientHeight,
+        scrollTop: element.scrollTop,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+        jumpVisible: Boolean(document.querySelector(".transcript__jump-bottom")),
+        selectionCollapsed: document.getSelection()?.isCollapsed ?? null,
+        writes: window.__reasonixJumpBottomWrites ?? [],
+      } : null;
+    });
+    throw new Error(`question jump-bottom did not settle (${JSON.stringify(state)})`, { cause: error });
+  } finally {
+    await page.evaluate(() => {
+      window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = undefined;
+      window.__reasonixJumpBottomWrites = undefined;
+    });
+  }
 
   // Stay on the tail. Opening the workspace dock must not crop right-aligned
   // user bubbles — that is a width/padding bug, not the scroll-up overlap.
@@ -889,13 +967,11 @@ try {
     undefined,
     { timeout: 30_000 },
   );
-  // Let the open-time hydration burst converge, then watch the idle tail.
-  await reducedPage.waitForFunction(() => {
-    const element = document.querySelector(".transcript");
-    return element instanceof HTMLElement
-      && element.dataset.scrollMode === "tail-follow"
-      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
-  }, undefined, { timeout: 15_000 });
+  // Let the open-time hydration burst converge, then require several stable
+  // frames before watching the idle tail. A single bottom sample can race a
+  // late markdown/row remeasurement on loaded CI runners and contaminate the
+  // idle probe with legitimate convergence motion.
+  await waitForStableTranscriptGeometry(reducedPage, { requireTail: true });
   const reducedIdle = await reducedPage.evaluate(() => new Promise((resolve) => {
     const element = document.querySelector(".transcript");
     const writes = [];
@@ -929,7 +1005,7 @@ try {
   }));
   assert(
     reducedIdle.reversals <= 2,
-    `reduced-motion idle tail does not ping-pong (${reducedIdle.reversals} direction reversals in 180 frames)`,
+    `reduced-motion idle tail does not ping-pong (${reducedIdle.reversals} direction reversals in 180 frames; ${reducedIdle.tailWrites} writes; ${reducedIdle.finalDistance}px from bottom)`,
   );
   // The #9028 pathology was a sustained loop: ~340 tail writes in 11s (about
   // 2 writes every 3 frames, forever). Late fixture hydration can still land

--- a/desktop/frontend/bench/transcript-scroll-stability.mjs
+++ b/desktop/frontend/bench/transcript-scroll-stability.mjs
@@ -286,11 +286,13 @@ try {
   // can see the bottom button moving while the viewport settles. A DOM click
   // still exercises the same React handler without waiting on button geometry.
   await page.locator(".transcript__jump-bottom").evaluate((button) => button.click());
+  // The arbiter's rest threshold is 4px: a late sub-threshold remeasure can
+  // legally rest at 2-4px from the extent without earning another write.
   await page.waitForFunction(() => {
     const element = document.querySelector(".transcript");
     return element instanceof HTMLElement
       && element.dataset.scrollMode === "tail-follow"
-      && element.scrollHeight - element.scrollTop - element.clientHeight <= 1;
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
   });
 
   // Stay on the tail. Opening the workspace dock must not crop right-aligned
@@ -316,10 +318,17 @@ try {
       fromBottom: +(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight).toFixed(2),
     };
   });
+  // Late hydration can momentarily detach the tail between the previous wait
+  // and this sample; the crop contract only needs a converged viewport.
+  await page.waitForFunction(() => {
+    const element = document.querySelector(".transcript");
+    return element instanceof HTMLElement
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
+  });
   const dockOpen = await measureDockCrop();
   assert(dockOpen.ok, "tail-follow dock check can see the chat and a user bubble");
   assert(dockOpen.workspaceOpen === true, "bench starts with the workspace dock open");
-  assert(dockOpen.fromBottom <= 1, `dock-open check stays on the tail without scrolling up (${dockOpen.fromBottom})`);
+  assert(dockOpen.fromBottom <= 4, `dock-open check stays on the tail without scrolling up (${dockOpen.fromBottom})`);
   assert(dockOpen.overflowChatRight <= 1, `user bubble stays inside the chat column with the dock open (${dockOpen.overflowChatRight})`);
   assert(
     dockOpen.overflowDock == null || dockOpen.overflowDock <= 1,
@@ -358,11 +367,30 @@ try {
     );
   }
 
-  // Start away from either edge and record a visible stable row. Growing an
-  // already-mounted row above it reproduces async Markdown/tool hydration.
+  // Start away from either edge via a real upward gesture: user intent claims
+  // manual mode, which forbids tail writes for the rest of the section. The
+  // previous teleport-based setup left tail-follow armed, so the arbiter's
+  // legitimate pull-back raced the trusted wheel's async landing and the
+  // settle probe could fire on the pull-back instead of the gesture.
+  await moveToOuterReaderGutter(page, transcript);
+  await page.mouse.wheel(0, -1600);
+  // Playwright resolves mouse.wheel before Chromium finishes the trusted
+  // event's native default scroll. Let it land before sampling anchors.
+  await page.waitForTimeout(120);
+  await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.scrollMode === "manual", undefined, { timeout: 5_000 });
+  await transcript.evaluate((element) => new Promise((resolve) => {
+    let previousTop = element.scrollTop;
+    let stableFrames = 0;
+    const sample = () => {
+      const currentTop = element.scrollTop;
+      stableFrames = Math.abs(currentTop - previousTop) <= 0.5 ? stableFrames + 1 : 0;
+      previousTop = currentTop;
+      if (stableFrames >= 2) { resolve(); return; }
+      requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  }));
   const beforeGrowth = await transcript.evaluate((element) => {
-    element.scrollTop = Math.max(0, element.scrollHeight - element.clientHeight * 2);
-    element.dispatchEvent(new Event("scroll"));
     const viewport = element.getBoundingClientRect();
     const rows = [...element.querySelectorAll(".transcript__row")];
     const visible = rows
@@ -381,28 +409,7 @@ try {
   });
   assert(beforeGrowth.anchorKey && beforeGrowth.grownKey, "bench exposes a visible anchor and mounted dynamic row above it");
 
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await transcript.evaluate((element) => {
-    const initialTop = element.scrollTop;
-    let previousTop = initialTop;
-    let stableFrames = 0;
-    element.dataset.benchWheelSettled = "false";
-    const sample = () => {
-      const currentTop = element.scrollTop;
-      const moved = Math.abs(currentTop - initialTop) > 1;
-      stableFrames = moved && Math.abs(currentTop - previousTop) <= 0.5 ? stableFrames + 1 : 0;
-      previousTop = currentTop;
-      if (stableFrames >= 2) {
-        element.dataset.benchWheelSettled = "true";
-        return;
-      }
-      requestAnimationFrame(sample);
-    };
-    requestAnimationFrame(sample);
-  });
-  await page.mouse.wheel(0, -360);
-  await page.waitForFunction(() => document.querySelector(".transcript")?.dataset.benchWheelSettled === "true");
-  const gestureStart = await transcript.evaluate((element) => element.scrollTop);
+  const gestureStart = beforeGrowth.top;
   await transcript.evaluate((element) => {
     const viewport = element.getBoundingClientRect();
     const rows = [...element.querySelectorAll(".transcript__row")];
@@ -858,6 +865,138 @@ try {
     stormProbe.writes.every((write) => write.owner !== "recovery"),
     `zero recovery-owned scroll writes through the storm (${stormProbe.writes.length} writes)`,
   );
+
+  // ── Reduced-motion tail stability (#9028/#9089). Windows reports
+  // prefers-reduced-motion: reduce whenever "Animate controls and elements
+  // inside windows" is off — the default on many machines. The global CSS
+  // reset then collapses every transition to ~0ms, layout churn lands one
+  // whole step per frame, and 1.28.0's tail writer chased each step through
+  // scrollToIndex against a stale size tree: a sustained per-frame flicker
+  // loop with the view never reaching the bottom (#9028 captured 340 no-op
+  // tail writes in 11s). The tail writer must stay calm through churn and
+  // still land on the physical bottom, with no OS setting involved.
+  const reducedPage = await browser.newPage({ viewport: { width: 1280, height: 800 }, reducedMotion: "reduce" });
+  await reducedPage.addInitScript(() => localStorage.setItem("reasonix-process-fold", "expanded"));
+  await reducedPage.goto(url, { waitUntil: "domcontentloaded" });
+  await reducedPage.waitForFunction(() => !document.querySelector(".startup-splash"), undefined, { timeout: 30_000 });
+  assert(
+    await reducedPage.evaluate(() => matchMedia("(prefers-reduced-motion: reduce)").matches),
+    "reduced-motion emulation is active",
+  );
+  await reducedPage.click('.project-tree__topic-main:has-text("bench:reported-long-turn")');
+  await reducedPage.waitForFunction(
+    () => document.querySelector(".transcript")?.textContent?.includes("Reported long turn complete."),
+    undefined,
+    { timeout: 30_000 },
+  );
+  // Let the open-time hydration burst converge, then watch the idle tail.
+  await reducedPage.waitForFunction(() => {
+    const element = document.querySelector(".transcript");
+    return element instanceof HTMLElement
+      && element.dataset.scrollMode === "tail-follow"
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
+  }, undefined, { timeout: 15_000 });
+  const reducedIdle = await reducedPage.evaluate(() => new Promise((resolve) => {
+    const element = document.querySelector(".transcript");
+    const writes = [];
+    window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = (write) => writes.push(write);
+    const tops = [];
+    let frames = 0;
+    const sample = () => {
+      if (element instanceof HTMLElement) tops.push(element.scrollTop);
+      frames += 1;
+      if (frames < 180) { requestAnimationFrame(sample); return; }
+      window.__REASONIX_TRANSCRIPT_SCROLL_WRITE__ = undefined;
+      let reversals = 0;
+      let lastDirection = 0;
+      for (let i = 1; i < tops.length; i += 1) {
+        const delta = tops[i] - tops[i - 1];
+        if (Math.abs(delta) <= 2) continue;
+        const direction = Math.sign(delta);
+        if (lastDirection !== 0 && direction !== lastDirection) reversals += 1;
+        lastDirection = direction;
+      }
+      const live = document.querySelector(".transcript");
+      resolve({
+        reversals,
+        tailWrites: writes.filter((write) => write.owner === "tail-follow").length,
+        finalDistance: live instanceof HTMLElement
+          ? live.scrollHeight - live.scrollTop - live.clientHeight
+          : Number.NaN,
+      });
+    };
+    requestAnimationFrame(sample);
+  }));
+  assert(
+    reducedIdle.reversals <= 2,
+    `reduced-motion idle tail does not ping-pong (${reducedIdle.reversals} direction reversals in 180 frames)`,
+  );
+  // The #9028 pathology was a sustained loop: ~340 tail writes in 11s (about
+  // 2 writes every 3 frames, forever). Late fixture hydration can still land
+  // a legitimate convergence burst inside the window, so gate on an order of
+  // magnitude below the pathology instead of near-zero.
+  assert(
+    reducedIdle.tailWrites < 30,
+    `reduced-motion idle tail never enters a sustained write loop (${reducedIdle.tailWrites} tail writes in 180 frames)`,
+  );
+  assert(
+    reducedIdle.finalDistance <= 4,
+    `reduced-motion tail rests on the physical bottom (${reducedIdle.finalDistance}px)`,
+  );
+  // The #9089 gesture: wheel up, wheel back to the bottom, release, idle.
+  await moveToOuterReaderGutter(reducedPage, reducedPage.locator(".transcript"));
+  await reducedPage.mouse.wheel(0, -900);
+  await reducedPage.waitForTimeout(120);
+  await reducedPage.mouse.wheel(0, 100_000);
+  await reducedPage.waitForFunction(() => {
+    const element = document.querySelector(".transcript");
+    return element instanceof HTMLElement
+      && element.dataset.scrollMode === "tail-follow"
+      && element.scrollHeight - element.scrollTop - element.clientHeight <= 4;
+  }, undefined, { timeout: 10_000 });
+  const reducedReturn = await reducedPage.evaluate(() => new Promise((resolve) => {
+    const element = document.querySelector(".transcript");
+    const tops = [];
+    let frames = 0;
+    const sample = () => {
+      if (element instanceof HTMLElement) tops.push(element.scrollTop);
+      frames += 1;
+      if (frames < 120) { requestAnimationFrame(sample); return; }
+      let movingFrames = 0;
+      let reversals = 0;
+      let lastDirection = 0;
+      for (let i = 1; i < tops.length; i += 1) {
+        const delta = tops[i] - tops[i - 1];
+        if (Math.abs(delta) <= 2) continue;
+        movingFrames += 1;
+        const direction = Math.sign(delta);
+        if (lastDirection !== 0 && direction !== lastDirection) reversals += 1;
+        lastDirection = direction;
+      }
+      const live = document.querySelector(".transcript");
+      resolve({
+        movingFrames,
+        reversals,
+        finalDistance: live instanceof HTMLElement
+          ? live.scrollHeight - live.scrollTop - live.clientHeight
+          : Number.NaN,
+      });
+    };
+    requestAnimationFrame(sample);
+  }));
+  assert(
+    reducedReturn.reversals <= 2,
+    `reduced-motion return-to-bottom does not ping-pong (${reducedReturn.reversals} reversals in 120 frames)`,
+  );
+  assert(
+    reducedReturn.movingFrames < 12,
+    `reduced-motion return-to-bottom idles without sustained self-scrolling (${reducedReturn.movingFrames} moving frames in 120)`,
+  );
+  assert(
+    reducedReturn.finalDistance <= 4,
+    `reduced-motion return-to-bottom rests on the physical bottom (${reducedReturn.finalDistance}px)`,
+  );
+  await reducedPage.close();
 
   process.stdout.write("\ntranscript scroll stability browser gate passed\n");
 } finally {

--- a/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
+++ b/desktop/frontend/src/__tests__/transcript-recovery-race.test.tsx
@@ -121,19 +121,18 @@ let scrollByCalls = 0;
 let scrollToIndexCalls = 0;
 let scrollToCalls = 0;
 let scrollToBottomCalls = 0;
-let tailWriteStep = 0;
-let snapTailOnWrite = false;
 // Null disables snapshot capture; the snapshot sections opt in explicitly so
 // the pre-snapshot scenarios keep their first-mount scrollToBottom behavior.
 let stubSnapshot: StateSnapshot | null = null;
 const virtuosoHandle = {
   scrollBy: () => { scrollByCalls += 1; },
-  scrollToIndex: () => {
-    scrollToIndexCalls += 1;
-    if (snapTailOnWrite) scrollElement.scrollTop = scrollExtent - scrollElement.clientHeight;
-    else if (tailWriteStep > 0) scrollElement.scrollTop = Math.min(scrollExtent - scrollElement.clientHeight, scrollElement.scrollTop + tailWriteStep);
+  scrollToIndex: () => { scrollToIndexCalls += 1; },
+  // Browser semantics: an offset write clamps against the current extent.
+  scrollTo: (options?: { top?: number }) => {
+    scrollToCalls += 1;
+    const top = options?.top ?? 0;
+    scrollElement.scrollTop = Math.max(0, Math.min(scrollExtent - scrollElement.clientHeight, top));
   },
-  scrollTo: () => { scrollToCalls += 1; },
   getState: (callback: (state: StateSnapshot) => void) => {
     if (stubSnapshot) callback(stubSnapshot);
   },
@@ -208,11 +207,11 @@ scrollElement.scrollTop = 400;
 await act(async () => window.dispatchEvent(new dom.window.Event("pointerup")));
 check(arbiter?.modeRef.current === "tail-follow", "native thumb release at the physical bottom resumes tail-follow");
 scrollExtent = 900;
-snapTailOnWrite = true;
 await act(async () => arbiter?.deliverScroll());
 await flushFrames();
+await flushFrames();
+await flushFrames();
 check(scrollElement.scrollTop === 800, "post-release remeasurement reconverges the claimed native bottom");
-snapTailOnWrite = false;
 scrollExtent = 500;
 
 // A nested code/tool scrollport owns the wheel until it reaches its edge.
@@ -263,22 +262,56 @@ check(bottomWheelAccepted && arbiter?.modeRef.current === "tail-follow", "a down
 
 // A queued confirmation belongs to the surface that requested it. Resetting
 // before its frame runs must prevent the old request from writing the new one.
-scrollToIndexCalls = 0;
+scrollToCalls = 0;
 scrollElement.scrollTop = 0;
 await act(async () => arbiter?.scrollToBottom());
-check(scrollToIndexCalls === 1, "bottom request performs its immediate LAST write");
+check(scrollToCalls === 1, "bottom request performs its immediate native-extent write");
 await act(async () => arbiter?.reset());
 await flushFrames();
-check(scrollToIndexCalls === 1, "a reset invalidates the previous surface's queued tail confirmation");
+check(scrollToCalls === 1, "a reset invalidates the previous surface's queued tail confirmation");
 
-// Tail-follow is a persistent mode, not a six-frame retry window. Each
-// delivered non-bottom position must request another coalesced convergence.
-scrollToIndexCalls = 0;
-tailWriteStep = 20;
+// Tail-follow is a persistent mode, not a six-frame retry window. As long as
+// growth keeps arriving (streaming), each height notification re-arms another
+// coalesced convergence and the view keeps landing on the current bottom.
+scrollToCalls = 0;
 await act(async () => arbiter?.scrollToBottom());
-for (let i = 0; i < 10; i += 1) await flushFrames();
-check(scrollToIndexCalls > 8, "tail convergence remains live beyond the former six-frame budget");
-tailWriteStep = 0;
+for (let i = 0; i < 14; i += 1) {
+  scrollExtent += 200;
+  await act(async () => arbiter?.followGrowingTail());
+  await flushFrames();
+}
+for (let i = 0; i < 4; i += 1) await flushFrames();
+check(scrollToCalls > 6, `tail convergence remains live beyond the former six-frame budget (${scrollToCalls} writes)`);
+check(
+  scrollElement.scrollTop === scrollExtent - scrollElement.clientHeight,
+  "sustained growth still lands on the physical bottom after the burst ends",
+);
+
+// ── Reduced-motion flicker filter (#9028/#9089): layout churn alternates the
+// extent between two values on consecutive frames. A tail displacement must
+// survive a full frame before the writer acts, so pure oscillation earns zero
+// writes; once the churn settles off-bottom, one write reconverges.
+const churnBase = scrollExtent;
+scrollToCalls = 0;
+for (let i = 0; i < 8; i += 1) {
+  scrollExtent = i % 2 === 0 ? churnBase + 700 : churnBase;
+  await act(async () => arbiter?.followGrowingTail());
+  await flushFrames();
+}
+check(scrollToCalls === 0, `alternating-extent churn earns zero tail writes (${scrollToCalls})`);
+check(arbiter?.modeRef.current === "tail-follow", "churn does not revoke tail ownership");
+scrollExtent = churnBase + 700;
+await act(async () => arbiter?.followGrowingTail());
+for (let i = 0; i < 4; i += 1) await flushFrames();
+check(
+  scrollElement.scrollTop === scrollExtent - scrollElement.clientHeight,
+  "a settled post-churn displacement reconverges on the physical bottom",
+);
+check(scrollToCalls >= 1 && scrollToCalls <= 2, `post-churn convergence costs at most two writes (${scrollToCalls})`);
+
+scrollExtent = 500;
+scrollElement.scrollTop = 400;
+await act(async () => arbiter?.deliverScroll());
 
 await act(async () => integrity?.scheduleBlankViewportCheck());
 await switchSurface("surface-b");

--- a/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
+++ b/desktop/frontend/src/__tests__/transcript-scroll-release.test.ts
@@ -129,7 +129,7 @@ const jump = run([
   { type: "JUMP_TO_BOTTOM", behavior: "smooth" },
 ]);
 check(jump.state.mode === "tail-follow", "jump-bottom explicitly owns the tail");
-check(jump.commands.join(",") === "SCROLL_TO_LAST", "jump-bottom uses Virtuoso scrollToIndex only");
+check(jump.commands.join(",") === "SCROLL_TO_LAST", "jump-bottom emits only the tail command");
 
 const repeatedJump = run([
   { type: "JUMP_TO_BOTTOM" },

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -294,7 +294,6 @@ export function Transcript({
     [liveProp, liveStore, tabId],
   );
   const live = useSyncExternalStore(subscribeLive, getLiveSnapshot, getLiveSnapshot);
-  const liveTailActiveRef = useRef(false);
   const {
     virtuosoRef,
     scrollRef,
@@ -326,7 +325,7 @@ export function Transcript({
     retryRecoveryRequest,
     lastGoodAnchorRef,
     captureStateSnapshot,
-  } = useTranscriptScrollArbiter({ liveTailActiveRef, onRecoveryTerminal: noteTranscriptRecoveryTerminal });
+  } = useTranscriptScrollArbiter({ onRecoveryTerminal: noteTranscriptRecoveryTerminal });
   const virtuosoReadyRef = useRef(false);
   const layoutSurfaceKey = `${tabId ?? ""}:${revealSignal}`;
 
@@ -866,7 +865,6 @@ export function Transcript({
   }, [holdingLiveRegion]);
   const heldLiveRows = heldSurfaceRef.current === layoutSurfaceKey ? heldLiveRowsRef.current : NO_HELD_ROWS;
   const showLiveRegion = liveSplit.liveActive || (holdingLiveRegion && heldLiveRows.length > 0);
-  liveTailActiveRef.current = showLiveRegion;
 
   const handleItemsRendered = useCallback((rendered: ListItem<TranscriptRow>[]) => {
     noteTranscriptRowCounts(rendered.length, virtualRows.length);

--- a/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
+++ b/desktop/frontend/src/lib/useTranscriptScrollArbiter.ts
@@ -28,11 +28,14 @@ import { captureTranscriptLayoutAnchor, type TranscriptLayoutAnchor } from "./tr
 const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
 const SCROLL_DOWN_KEYS = new Set(["ArrowDown", "PageDown", "End", " ", "Spacebar"]);
 export const TRANSCRIPT_AT_BOTTOM_THRESHOLD_PX = 4;
-// LAST/end can stop just above the native extent when the scroller owns
-// vertical padding or fractional row measurements. A bounded positive offset
-// is clamped by the browser and keeps the write within Virtuoso's API.
-const TRANSCRIPT_TAIL_CLAMP_OFFSET_PX = 64;
 const TAIL_STAGNANT_FRAME_LIMIT = 2;
+// A tail displacement must survive one full frame before the writer acts.
+// Layout churn (row remeasurement, content-visibility flips, md hydration)
+// alternates off-bottom/at-bottom on consecutive frames; writing against it
+// perturbs layout again and sustains the oscillation — the reduced-motion
+// flicker of #9028/#9089. Real growth stays off-bottom and converges one
+// frame (~16ms) later, which is imperceptible.
+const TAIL_CONFIRM_OFF_BOTTOM_FRAMES = 2;
 const READER_INTENT_IDLE_MS = 180;
 // Anchor restores wait for the anchor row to actually mount. An 8-frame
 // budget (~128 ms) expired before heavy rows mounted on WebView2, stranding
@@ -118,12 +121,8 @@ type ActiveTranscriptRecovery = {
  * programmatic > recovery > tail-follow).
  */
 export function useTranscriptScrollArbiter({
-  liveTailActiveRef,
   onRecoveryTerminal,
 }: {
-  /** While the live-region footer is mounted, the true bottom sits below the
-   *  last virtual row; tail writes then aim at the DOM extent instead. */
-  liveTailActiveRef?: RefObject<boolean>;
   /** Receives the terminal state of every recovery request (done /
    *  cancelled / expired); wired into session diagnostics by the caller. */
   onRecoveryTerminal?: (terminal: TranscriptRecoveryTerminal) => void;
@@ -139,7 +138,7 @@ export function useTranscriptScrollArbiter({
   const generationRef = useRef(0);
   const followFrameRef = useRef<number | null>(null);
   const tailSettleFrameRef = useRef<number | null>(null);
-  const tailSettleProgressRef = useRef<{ distance: number; stagnantFrames: number } | null>(null);
+  const tailSettleProgressRef = useRef<{ distance: number; stagnantFrames: number; offBottomFrames: number } | null>(null);
   const resizeSettleFrameRef = useRef<number | null>(null);
   const readerIntentTimerRef = useRef<number | null>(null);
   const lastFollowExtentRef = useRef<number | null>(null);
@@ -155,24 +154,21 @@ export function useTranscriptScrollArbiter({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
 
+  // Tail writes aim at the scroller's native extent, never at Virtuoso's size
+  // tree. scrollToIndex("LAST") resolves against the estimated tree, which can
+  // already believe it is at the bottom while the DOM extent sits hundreds of
+  // pixels lower; the write then lands nowhere, the arbiter still reads a
+  // non-bottom distance, and the settle loop re-arms every frame (#9028: 340
+  // no-op tail writes in 11s with scrollTop frozen — the reduced-motion
+  // flicker loop). The browser clamps scrollTo against the real extent, so a
+  // native-extent write always converges and is idempotent at the bottom.
   const scrollToTail = useCallback((behavior: "auto" | "smooth") => {
     const element = scrollRef.current;
-    if (liveTailActiveRef?.current && element) {
-      // The live-region footer extends past the last virtual row. Virtuoso's
-      // scrollTo clamps against the scroller's real DOM scrollHeight, footer
-      // included, so this lands on the true bottom.
-      noteTranscriptScrollWrite({ owner: "tail-follow", kind: "scrollTo", top: element.scrollHeight });
-      virtuosoRef.current?.scrollTo({ top: element.scrollHeight, behavior });
-      return;
-    }
-    noteTranscriptScrollWrite({ owner: "tail-follow", kind: "scrollToIndex", index: "LAST" });
-    virtuosoRef.current?.scrollToIndex({
-      index: "LAST",
-      align: "end",
-      offset: TRANSCRIPT_TAIL_CLAMP_OFFSET_PX,
-      behavior,
-    });
-  }, [liveTailActiveRef]);
+    if (!element) return;
+    const top = element.scrollHeight;
+    noteTranscriptScrollWrite({ owner: "tail-follow", kind: "scrollTo", top });
+    virtuosoRef.current?.scrollTo({ top, behavior });
+  }, []);
 
   const cancelTailSettle = useCallback(() => {
     if (tailSettleFrameRef.current !== null) cancelAnimationFrame(tailSettleFrameRef.current);
@@ -203,12 +199,18 @@ export function useTranscriptScrollArbiter({
         tailSettleProgressRef.current = null;
         return;
       }
-      scrollToTail("auto");
       const previous = tailSettleProgressRef.current;
+      const offBottomFrames = (previous?.offBottomFrames ?? 0) + 1;
+      if (offBottomFrames < TAIL_CONFIRM_OFF_BOTTOM_FRAMES) {
+        tailSettleProgressRef.current = { distance, stagnantFrames: 0, offBottomFrames };
+        tailSettleFrameRef.current = requestAnimationFrame(tick);
+        return;
+      }
+      scrollToTail("auto");
       const stagnantFrames = previous && Math.abs(previous.distance - distance) <= 0.5
         ? previous.stagnantFrames + 1
         : 0;
-      tailSettleProgressRef.current = { distance, stagnantFrames };
+      tailSettleProgressRef.current = { distance, stagnantFrames, offBottomFrames };
       if (stagnantFrames < TAIL_STAGNANT_FRAME_LIMIT) tailSettleFrameRef.current = requestAnimationFrame(tick);
     };
     tailSettleFrameRef.current = requestAnimationFrame(tick);


### PR DESCRIPTION
## Problem

On Windows, whenever the OS visual-effects switch "Animate controls and elements inside windows" is off (the default that "Let Windows choose" picks on many machines), the transcript oscillates between two scroll positions every frame after scroll interaction, the jump-to-bottom button strobes, and very long sessions can never rest on the newest content. Users found that re-enabling the OS animation setting hides the bug (#9089, and the workaround comments in #9028) — the product must not depend on that setting.

Fixes #9089.
Addresses the scroll-bounce case of #9028 (Case 1, including the runtime capture posted there). The question-anchor mislanding (Case 2) was fixed separately by #9065 and is outside this PR.

## Root cause

That OS switch drives `prefers-reduced-motion` in WebView2. The global reduced-motion CSS reset collapses every transition to ~0.01ms, so layout churn (row remeasurement, markdown hydration, content-visibility flips) lands one whole step per frame instead of being spread across a transition. The tail-follow writer then chased every step through `scrollToIndex("LAST")`, which resolves against Virtuoso's estimated size tree: the tree can already believe it is at the bottom while the DOM extent sits hundreds of pixels lower, so each write landed nowhere, the arbiter still read a non-bottom distance, and the settle loop re-armed every frame. The #9028 runtime capture shows the terminal state: 340 `tail-follow/scrollToIndex(LAST)` writes in 11s with `scrollTop` frozen while `scrollHeight` oscillated. Each no-op write also re-armed Virtuoso's 150ms `listRefresh` retry machinery, which kept the churn alive indefinitely.

## Fix

Two changes, both inside the scroll arbiter (the single writer):

1. **Tail writes aim at the scroller's native extent.** `scrollToTail` now always issues `scrollTo({ top: element.scrollHeight })`. The browser clamps the write against the real DOM extent, so a tail write always converges, is idempotent at the bottom, and never engages the `scrollToIndex` retry machinery. The `liveTailActiveRef` branch became dead (native-extent writes cover both the live-footer and virtual-only cases) and is removed.
2. **A displacement must survive one full frame before the writer acts.** Alternating churn (off-bottom on even frames, at-bottom on odd frames) never earns a write, so the writer cannot feed the oscillation; real growth stays off-bottom and converges one frame (~16ms) later, which is imperceptible.

Together these remove the failure class rather than the instance: writes are effective and idempotent, so even a future new source of layout churn cannot sustain a write loop — the worst case is a bounded number of converging writes.

## Test changes

- `transcript-recovery-race`: the Virtuoso mock's `scrollTo` now models browser clamping; new deterministic cases assert that alternating-extent churn earns zero tail writes, that a settled post-churn displacement reconverges on the physical bottom, and that sustained per-frame growth keeps landing on the bottom well past the former six-frame budget.
- `transcript-scroll-stability` browser gate: new reduced-motion section runs the #9028 idle-tail watch and the #9089 wheel-up/return-to-bottom gesture under `reducedMotion: "reduce"`, gating on direction reversals, sustained-write-loop detection, and physical-bottom rest. CI now exercises the pathological mode on every PR.
- The gate itself now uses settled interaction boundaries: the dynamic-measurement section enters manual mode through a real upward gesture; tail assertions wait for the arbiter's documented 4px rest threshold; the question-jump follow-up waits for stable scroll geometry and atomically clicks the current connected control; and reduced-motion idle sampling begins only after consecutive stable tail frames. Failed jump-bottom convergence now reports mode, extent, selection, and scroll-write state.

## Verification

- `pnpm test:transcript` — all suites green (recovery-race now 72 checks).
- `transcript-scroll-stability` gate: 4/4 consecutive local passes, including the #8657 reach-bottom and storm-40t sections (the long-session convergence shipped in #9044 is preserved) and the new reduced-motion section.
- `transcript-selection` gate green; full `pnpm build` pipeline green (eslint, WAAPI contract, single-scroll-writer check, CSS checks, tsc, bundle budgets).
- Playwright A/B on the bench fixture (`reducedMotion: reduce` vs `no-preference`): reduce-mode idle-tail direction reversals drop to 0-2 per 180 frames (previously a sustained per-frame loop), the return-to-bottom gesture idles without self-scrolling, reading upward drifts 0px, and the tail rests 0-3px from the physical bottom in both motion modes.
- Verified in headless Chromium with forced reduced-motion emulation; the mechanism (media query + same Blink layout path) is identical in WebView2, but a confirmation from the original reporters on a Windows machine — with the OS animation switch left **off** — would be welcome.

Documentation-impact: none - this restores the documented tail-follow contract (pinned view follows the newest content); no docs describe scroll internals or the broken behavior.