### PR TITLE
fix(agent): recover active todos behind stale plan mode

### DIFF
--- a/internal/agent/execute_one.go
+++ b/internal/agent/execute_one.go
@@ -245,6 +245,14 @@ func (a *Agent) applyPlanModeAndProxy(ctx context.Context, plan *toolCallPlan) (
 				safety = planmode.PlanSafetyUnsafe
 			}
 		}
+		// todo_write requires one canonical in-progress item, while advancing that
+		// item requires a successful complete_step receipt. If a stale Plan flag
+		// survives into execution, blocking the receipt makes the host-owned todo
+		// state impossible to recover. Allow only this existing-item sign-off;
+		// complete_step still validates the item identity and its evidence.
+		if plan.canonicalName == "complete_step" && t.ReadOnly() && a.hasActiveCanonicalTodo() {
+			safety = planmode.PlanSafetySafe
+		}
 		if decision := a.planModeDecision(plan.canonicalName, t.ReadOnly(), safety, json.RawMessage(call.Arguments)); decision.Blocked {
 			return toolOutcome{
 				output:  decision.Message,

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -180,6 +180,58 @@ func TestPlanModeUnsafePhaseToolStopsBeforePermission(t *testing.T) {
 	}
 }
 
+func TestPlanModeAllowsCompleteStepToRecoverCurrentTodo(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mustBuiltinTool(t, "todo_write"))
+	reg.Add(mustBuiltinTool(t, "complete_step"))
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.SetPlanMode(true)
+
+	todoOut := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "todo",
+		Name: "todo_write",
+		Arguments: `{"todos":[
+			{"content":"finish the cleanup","status":"in_progress","step_id":"cleanup_step_01"}
+		]}`,
+	})
+	if todoOut.blocked || todoOut.errMsg != "" {
+		t.Fatalf("seed Plan todo outcome = %+v", todoOut)
+	}
+
+	invalidOut := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "invalid-complete",
+		Name: "complete_step",
+		Arguments: `{
+			"step_id":"cleanup_step_01",
+			"result":"cleanup finished",
+			"evidence":[]
+		}`,
+	})
+	if invalidOut.blocked || invalidOut.errMsg == "" {
+		t.Fatalf("Plan todo recovery bypassed evidence validation: %+v", invalidOut)
+	}
+	if got := a.CanonicalTodoState(); len(got) != 1 || got[0].Status != "in_progress" {
+		t.Fatalf("invalid recovery advanced todo state = %+v", got)
+	}
+
+	stepOut := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "complete",
+		Name: "complete_step",
+		Arguments: `{
+			"step_id":"cleanup_step_01",
+			"result":"cleanup finished",
+			"evidence":[{"kind":"manual","summary":"confirmed the cleanup output"}]
+		}`,
+	})
+	if stepOut.blocked || stepOut.errMsg != "" {
+		t.Fatalf("Plan todo recovery outcome = %+v", stepOut)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Status != "completed" {
+		t.Fatalf("Plan todo recovery state = %+v, want completed", got)
+	}
+}
+
 func TestPlanModeSafeWriterStillUsesWriterPermission(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(planSafeTool{fakeTool: fakeTool{name: "phase_safe_writer"}, planSafe: true})

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -10,7 +10,6 @@ import (
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/instruction"
-	"reasonix/internal/planmode"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -85,16 +84,10 @@ func (completeStep) Schema() json.RawMessage {
 // effect), so it never needs approval and stays available alongside todo_write.
 func (completeStep) ReadOnly() bool { return true }
 
-// complete_step signs off execution work and is unavailable during planning.
-// The host Plan gate remains authoritative for stale or hallucinated calls.
-func (completeStep) ProviderVisible(ctx context.Context) bool {
-	return !planmode.Active(ctx)
-}
-
 // PlanModeSafe reports false: although complete_step is read-only, it signs off a
-// completed execution step, which is meaningful only after plan approval — not
-// during planning. This explicit phase opt-out is the Plan gate's enforced
-// exception to the ordinary Permissions/Sandbox path.
+// completed execution step, which is ordinarily meaningful only after plan
+// approval. The Agent has one narrow recovery exception for an existing
+// canonical in-progress todo whose state otherwise cannot advance.
 func (completeStep) PlanModeSafe() bool { return false }
 
 func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, error) {

--- a/internal/tool/builtin/contextual_visibility_test.go
+++ b/internal/tool/builtin/contextual_visibility_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"reasonix/internal/jobs"
-	"reasonix/internal/planmode"
 	"reasonix/internal/tool"
 )
 
@@ -15,7 +14,6 @@ func (visibilityRecorder) RecordGoalReport(tool.GoalReport) (string, error) { re
 
 func TestContextualBuiltinVisibilityFollowsOwningContext(t *testing.T) {
 	goal, _ := tool.LookupBuiltin("update_goal")
-	step, _ := tool.LookupBuiltin("complete_step")
 	jobNames := []string{"bash_output", "wait", "kill_shell"}
 
 	if goal.(tool.ContextualTool).ProviderVisible(context.Background()) {
@@ -23,12 +21,6 @@ func TestContextualBuiltinVisibilityFollowsOwningContext(t *testing.T) {
 	}
 	if !goal.(tool.ContextualTool).ProviderVisible(tool.WithGoalTurnRecorder(context.Background(), visibilityRecorder{})) {
 		t.Fatal("update_goal hidden during an active Goal turn")
-	}
-	if !step.(tool.ContextualTool).ProviderVisible(context.Background()) {
-		t.Fatal("complete_step hidden outside Plan mode")
-	}
-	if step.(tool.ContextualTool).ProviderVisible(planmode.WithActive(context.Background(), true)) {
-		t.Fatal("complete_step visible during Plan mode")
 	}
 	for _, name := range jobNames {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Allow `complete_step` to sign off an existing canonical `in_progress` todo when stale Plan mode would otherwise leave the task state unable to advance.
- Preserve the existing Plan-mode block when there is no active canonical todo.
- Keep step identity and evidence validation unchanged; invalid or missing evidence still cannot advance todo state.
- Let the Agent's state-aware Plan policy decide this recovery case instead of context-hiding `complete_step` unconditionally.
- Add regression coverage for both successful recovery and rejected evidence.

## Issues

Fixes #9094

## Verification

- Added `TestPlanModeAllowsCompleteStepToRecoverCurrentTodo`.
  - Reproduced the original failure before the fix: `complete_step is only available after plan approval`.
  - Confirmed the todo advances after a valid evidence-backed `complete_step`.
  - Confirmed missing evidence remains rejected and does not advance the todo.
- `go test ./internal/agent -run 'TestPlanMode|TestRunSubAgentWithSessionInheritsPlanWorkflow|TestEvidenceFlowAcceptsTodoCompletionAfterCompleteStep|TestCallContextMirrorsPlanModeOntoLeafKey' -count=1`
- `go test ./internal/tool/builtin -run 'TestContextualBuiltinVisibilityFollowsOwningContext|TestCompleteStep|TestTodoWrite' -count=1`
- `go test ./internal/planmode -count=1`
- `go vet ./internal/agent ./internal/tool/builtin ./internal/planmode`
- `go build ./cmd/reasonix`

Environment note: a broader Windows package run encountered five unrelated loopback `web_fetch` tests returning `127.0.0.1:... EOF`; all focused tests covering this change pass.

## Documentation impact

Documentation-impact: none - the existing `complete_step` evidence contract remains unchanged; this restores a host-side recovery path for stale Plan state.

## Cache impact

Cache-impact: none - provider-visible tool schemas and system-prompt bytes are unchanged; only runtime Plan policy for an existing canonical todo is adjusted.
Cache-guard: `TestPlanModeDoesNotMutateSystemOrTools` is covered by the focused `TestPlanMode` run.
System-prompt-review: N/A