### PR TITLE
fix(todo): let todo_write update progress without complete_step / 待办进度不再被签字工具卡死

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2268,7 +2268,13 @@ func (a *Agent) recoveryPlanTransition(toolName string, args json.RawMessage) (b
 		return false, "", "", ""
 	}
 	after := evidence.ReceiptFromToolCall("todo_write", args, true, true).Todos
-	if len(after) == 0 || evidence.ValidateSerialTodos(after) != nil || !evidence.PreservesCompletedTodoPositions(before, after) {
+	if evidence.ValidateSerialTodos(after) != nil {
+		return false, "", "", ""
+	}
+	if len(after) == 0 {
+		return true, planReviewText(before), planReviewText(after), planTransitionDiff(before, after)
+	}
+	if !evidence.PreservesCompletedTodoPositions(before, after) {
 		// Let todo_write report malformed or invalid state directly; an invalid
 		// task list is not a meaningful plan proposal for the reviewer.
 		return false, "", "", ""

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -120,6 +120,33 @@ func TestE2ESerialPlanHostAdvancesAndAllowsFinalAnswer(t *testing.T) {
 	}
 }
 
+func TestE2ETodoWriteProgressThenOptionalCompleteStep(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "t0", Name: "todo_write",
+			Arguments: `{"todos":[{"content":"test","status":"in_progress"},{"content":"vet","status":"pending"}]}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "t1", Name: "todo_write",
+			Arguments: `{"todos":[{"content":"test","status":"completed"},{"content":"vet","status":"in_progress"}]}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash",
+			Arguments: `{"command":"go vet ./..."}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"vet","result":"vet passes","evidence":[{"kind":"verification","summary":"vet passes","command":"go vet ./..."}]}`}}},
+		testutil.Turn{Text: "all done"},
+	)
+	sink := &recordSink{}
+	a := New(mp, evidenceRegistry(), NewSession("sys"), Options{}, sink)
+
+	if err := a.Run(withNoClosedLoop(context.Background()), "implement the plan"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 2 || got[0].Status != "completed" || got[1].Status != "completed" {
+		t.Fatalf("canonical todos = %+v, want todo_write then complete_step to finish the list", got)
+	}
+	if n := hostAdvances(sink); n < 1 {
+		t.Fatalf("host advanced %d times, want the complete_step path to still advance", n)
+	}
+}
+
 // A command cited with a different string than it ran under (#2917: the model
 // drops the cd-prefix) is still accepted via segment matching, in-turn.
 func TestE2ECommandDriftAcceptedInTurn(t *testing.T) {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -983,7 +983,7 @@ func TestEvidenceFlowAcceptsTodoCompletionAfterCompleteStep(t *testing.T) {
 	}
 }
 
-func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
+func TestEvidenceFlowAcceptsTodoCompletionWithoutCompleteStep(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {
 		t.Fatal("todo_write builtin not registered")
@@ -1005,7 +1005,6 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 				"result":"parser added",
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
-			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -1017,12 +1016,15 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 	}
 
 	results := toolResults(a.sess.conversation, "todo_write")
-	if len(results) < 2 {
-		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
+	if len(results) < 2 || !strings.Contains(results[1], "1 completed") {
+		t.Fatalf("todo_write results = %v, want progress accepted without complete_step", results)
 	}
-	got := results[1]
-	if !strings.Contains(got, "complete_step") {
-		t.Fatalf("todo_write result = %q, want completion rejected until complete_step", got)
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Status != "completed" {
+		t.Fatalf("canonical todos = %+v, want the item completed by todo_write", got)
+	}
+	if step := lastToolResult(a.sess.conversation, "complete_step"); !strings.Contains(step, "signed off") {
+		t.Fatalf("complete_step result = %q, want a later optional receipt", step)
 	}
 }
 
@@ -1140,7 +1142,7 @@ func TestEvidenceFlowAllowsBatchCompleteStepSignoffs(t *testing.T) {
 	}
 }
 
-func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing.T) {
+func TestEvidenceFlowTodoCompletionSurvivesFailedCompleteStep(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {
 		t.Fatal("todo_write builtin not registered")
@@ -1162,12 +1164,6 @@ func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
 			toolCallChunk("c3", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
-			toolCallChunk("c4", "complete_step", `{
-				"step":"Add parser",
-				"result":"parser added",
-				"evidence":[{"kind":"manual","summary":"checked manually"}]
-			}`),
-			toolCallChunk("c5", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -1178,17 +1174,20 @@ func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing
 		t.Fatalf("Run: %v", err)
 	}
 
-	results := toolResults(a.sess.conversation, "todo_write")
-	if len(results) < 2 {
-		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
+	if step := lastToolResult(a.sess.conversation, "complete_step"); strings.Contains(step, "signed off") {
+		t.Fatalf("complete_step result = %q, want the mismatched sign-off to fail", step)
 	}
-	got := results[1]
-	if !strings.Contains(got, "complete_step") {
-		t.Fatalf("todo_write result = %q, want failed complete_step not to authorize completion", got)
+	results := toolResults(a.sess.conversation, "todo_write")
+	if len(results) < 2 || !strings.Contains(results[1], "1 completed") {
+		t.Fatalf("todo_write results = %v, want progress after a failed sign-off", results)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Status != "completed" {
+		t.Fatalf("canonical todos = %+v, want completed despite failed complete_step", got)
 	}
 }
 
-func TestEvidenceFlowRejectsReplacedTodoAfterNumericCompleteStep(t *testing.T) {
+func TestEvidenceFlowRejectsReplacingCompletedTodoAfterNumericCompleteStep(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {
 		t.Fatal("todo_write builtin not registered")
@@ -1210,24 +1209,23 @@ func TestEvidenceFlowRejectsReplacedTodoAfterNumericCompleteStep(t *testing.T) {
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
 			toolCallChunk("c3", "todo_write", `{"todos":[{"content":"Ship parser","status":"completed"}]}`),
-			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
 	}}
 
 	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
-	if err := a.Run(withNoClosedLoop(context.Background()), "try to reuse a numeric sign-off for another todo"); err != nil {
+	if err := a.Run(withNoClosedLoop(context.Background()), "replace the completed todo after a numeric sign-off"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
 	results := toolResults(a.sess.conversation, "todo_write")
-	if len(results) < 2 {
-		t.Fatalf("todo_write results = %v, want the rejected replacement result", results)
+	if len(results) < 2 || !strings.Contains(results[1], "completed prefix") {
+		t.Fatalf("todo_write results = %v, want completed history preserved", results)
 	}
-	got := results[1]
-	if !strings.Contains(got, "Ship parser") || !strings.Contains(got, "complete_step") {
-		t.Fatalf("todo_write result = %q, want replaced todo rejected", got)
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Content != "Add parser" || got[0].Status != "completed" {
+		t.Fatalf("canonical todos = %+v, want the signed-off item kept", got)
 	}
 }
 

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -267,6 +267,61 @@ func TestPlanModeCanReplacePriorExecutionTodoState(t *testing.T) {
 	}
 }
 
+func TestPlanModeTodoWriteCanCompleteCurrentItem(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mustBuiltinTool(t, "todo_write"))
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.SeedTodoState([]evidence.TodoItem{
+		{Content: "inspect the request", Status: "in_progress"},
+		{Content: "draft a plan", Status: "pending"},
+	})
+	a.SetPlanMode(true)
+
+	out := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "mark-done",
+		Name: "todo_write",
+		Arguments: `{"todos":[
+			{"content":"inspect the request","status":"completed"},
+			{"content":"draft a plan","status":"in_progress"}
+		]}`,
+	})
+	if out.errMsg != "" {
+		t.Fatalf("plan-mode todo completion was blocked: %s", out.errMsg)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 2 || got[0].Status != "completed" || got[1].Status != "in_progress" {
+		t.Fatalf("plan-mode todo state = %+v, want first item completed", got)
+	}
+}
+
+func TestPlanModeKeepsCompleteStepUnavailable(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mustBuiltinTool(t, "complete_step"))
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.SeedTodoState([]evidence.TodoItem{{Content: "inspect the request", Status: "in_progress"}})
+	a.SetPlanMode(true)
+
+	out := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "sign-off",
+		Name: "complete_step",
+		Arguments: `{
+			"step":"inspect the request",
+			"result":"inspected",
+			"evidence":[{"kind":"manual","summary":"checked"}]
+		}`,
+	})
+	if !out.blocked {
+		t.Fatalf("plan-mode complete_step outcome = %+v, want blocked", out)
+	}
+	if !strings.Contains(out.output, "plan approval") && !strings.Contains(out.output, "unavailable during planning") && !strings.Contains(out.errMsg, "unavailable") {
+		t.Fatalf("plan-mode complete_step = %+v, want a planning-phase unavailability", out)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Status != "in_progress" {
+		t.Fatalf("blocked complete_step advanced canonical todos: %+v", got)
+	}
+}
+
 // TestPlanModeDoesNotMutateSystemOrTools is the cache-stability test. Toggling
 // plan mode between two stream calls must not change the system prompt or the
 // tool list seen by the provider — those are the cache-key prefix, and any

--- a/internal/agent/recovery_gate_test.go
+++ b/internal/agent/recovery_gate_test.go
@@ -45,6 +45,14 @@ func TestRecoveryPlanTransitionDetectsOnlyStructuralRewriteOfActivePlan(t *testi
 	if !strings.Contains(before, "Implement parser") || !strings.Contains(after, "Replace parser architecture") {
 		t.Fatalf("plan evidence before=%q after=%q", before, after)
 	}
+
+	cleared, _, clearedAfter, _ := a.recoveryPlanTransition("todo_write", json.RawMessage(`{"todos":[]}`))
+	if !cleared {
+		t.Fatal("clearing an active plan must invoke the plan reviewer")
+	}
+	if strings.TrimSpace(clearedAfter) != "" && strings.Contains(clearedAfter, "Implement parser") {
+		t.Fatalf("cleared plan evidence = %q, want an empty replacement", clearedAfter)
+	}
 }
 
 func TestRecoveryPlanTransitionIgnoresCompletedPriorPlan(t *testing.T) {
@@ -104,7 +112,7 @@ func TestAuthorizedRecoveryPlanTransitionCanReplaceCurrentTodo(t *testing.T) {
 	}
 }
 
-func TestPlanTransitionCanReplaceCurrentTodoWithoutDedicatedAuthorization(t *testing.T) {
+func TestPlanTransitionNeedsDedicatedReplacementAuthorization(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(mustBuiltinTool(t, "todo_write"))
 	gate := &recordingRecoveryGate{decision: RecoveryDecision{Allow: true}}
@@ -116,12 +124,45 @@ func TestPlanTransitionCanReplaceCurrentTodoWithoutDedicatedAuthorization(t *tes
 		Name:      "todo_write",
 		Arguments: `{"todos":[{"content":"Replace parser architecture","status":"in_progress"}]}`,
 	})
-	if out.errMsg != "" {
-		t.Fatalf("replacing the current todo should not need dedicated authorization: %+v", out)
+	if out.errMsg == "" || !strings.Contains(out.output, "cannot be removed or replaced") {
+		t.Fatalf("plain allow unexpectedly replaced current todo: %+v", out)
 	}
-	got := a.CanonicalTodoState()
-	if len(got) != 1 || got[0].Content != "Replace parser architecture" {
-		t.Fatalf("canonical todo state = %+v, want the replaced current item", got)
+
+	clearOut := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:        "clear-plan-without-authorization",
+		Name:      "todo_write",
+		Arguments: `{"todos":[]}`,
+	})
+	if clearOut.errMsg == "" || !strings.Contains(clearOut.output, "cannot be cleared") {
+		t.Fatalf("plain allow unexpectedly cleared the current todo: %+v", clearOut)
+	}
+	if got := a.CanonicalTodoState(); len(got) != 1 || got[0].Content != "Implement parser" {
+		t.Fatalf("canonical todo state = %+v, want the original current item", got)
+	}
+}
+
+func TestAuthorizedRecoveryPlanTransitionCanClearCurrentTodo(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mustBuiltinTool(t, "todo_write"))
+	gate := &recordingRecoveryGate{decision: RecoveryDecision{
+		Allow: true, AuthorizePlanReplacement: true,
+	}}
+	a := New(nil, reg, NewSession(""), Options{RecoveryGate: gate}, event.Discard)
+	a.SeedTodoState([]evidence.TodoItem{{Content: "Implement parser", Status: "in_progress"}})
+
+	out := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:        "clear-plan",
+		Name:      "todo_write",
+		Arguments: `{"todos":[]}`,
+	})
+	if out.errMsg != "" {
+		t.Fatalf("authorized plan clear was blocked: %+v", out)
+	}
+	if len(gate.proposals) != 1 || !gate.proposals[0].PlanTransition {
+		t.Fatalf("recovery proposals = %+v, want one plan-clear transition", gate.proposals)
+	}
+	if got := a.CanonicalTodoState(); len(got) != 0 {
+		t.Fatalf("canonical todo state = %+v, want empty after approved clear", got)
 	}
 }
 

--- a/internal/agent/recovery_gate_test.go
+++ b/internal/agent/recovery_gate_test.go
@@ -104,7 +104,7 @@ func TestAuthorizedRecoveryPlanTransitionCanReplaceCurrentTodo(t *testing.T) {
 	}
 }
 
-func TestPlanTransitionNeedsDedicatedReplacementAuthorization(t *testing.T) {
+func TestPlanTransitionCanReplaceCurrentTodoWithoutDedicatedAuthorization(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(mustBuiltinTool(t, "todo_write"))
 	gate := &recordingRecoveryGate{decision: RecoveryDecision{Allow: true}}
@@ -116,8 +116,12 @@ func TestPlanTransitionNeedsDedicatedReplacementAuthorization(t *testing.T) {
 		Name:      "todo_write",
 		Arguments: `{"todos":[{"content":"Replace parser architecture","status":"in_progress"}]}`,
 	})
-	if out.errMsg == "" || !strings.Contains(out.output, "cannot be removed or replaced") {
-		t.Fatalf("plain allow unexpectedly replaced current todo: %+v", out)
+	if out.errMsg != "" {
+		t.Fatalf("replacing the current todo should not need dedicated authorization: %+v", out)
+	}
+	got := a.CanonicalTodoState()
+	if len(got) != 1 || got[0].Content != "Replace parser architecture" {
+		t.Fatalf("canonical todo state = %+v, want the replaced current item", got)
 	}
 }
 

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -228,7 +228,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 		case "verification":
 			command := strings.TrimSpace(e.Command)
 			if command == "" {
-				return 0, 0, fmt.Errorf("evidence %d: verification command is required for host verification — cite the command you ran, or use kind \"manual\"", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: verification command is required for host verification — cite the command you ran in this session, or use kind \"files\", \"diff\", or \"manual\"", i+1)
 			}
 			if !ledger.HasSuccessfulCommand(command) && !verifyCommandFromSession(ctx, command) {
 				if ledger.HasFailedCommand(command) {

--- a/internal/tool/builtin/completestep_evidence_hint_test.go
+++ b/internal/tool/builtin/completestep_evidence_hint_test.go
@@ -1,0 +1,28 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/evidence"
+)
+
+func TestCompleteStepVerificationWithoutCommandSuggestsOtherKinds(t *testing.T) {
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Remove debug files",
+		"result":"debug files removed from git",
+		"evidence":[{"kind":"verification","summary":"git commit abc123 updated .gitignore"}]
+	}`))
+	if err == nil {
+		t.Fatal("verification evidence without a command should be rejected")
+	}
+	got := err.Error()
+	for _, want := range []string{"verification command is required", `"files"`, `"diff"`, `"manual"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error %q missing %q", got, want)
+		}
+	}
+}

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -167,6 +167,24 @@ func TestCompleteStepRejectsUnverifiedHostEvidence(t *testing.T) {
 	}
 }
 
+func TestCompleteStepVerificationWithoutCommandSuggestsOtherKinds(t *testing.T) {
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Remove debug files",
+		"result":"debug files removed from git",
+		"evidence":[{"kind":"verification","summary":"git commit abc123 updated .gitignore"}]
+	}`))
+	if err == nil {
+		t.Fatal("verification evidence without a command should be rejected")
+	}
+	got := err.Error()
+	for _, want := range []string{"verification command is required", `"files"`, `"diff"`, `"manual"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error %q missing %q", got, want)
+		}
+	}
+}
+
 func TestCompleteStepAllowsManualAsUnverified(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
 	out, err := completeStep{}.Execute(ctx, json.RawMessage(`{

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -167,24 +167,6 @@ func TestCompleteStepRejectsUnverifiedHostEvidence(t *testing.T) {
 	}
 }
 
-func TestCompleteStepVerificationWithoutCommandSuggestsOtherKinds(t *testing.T) {
-	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
-	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
-		"step":"Remove debug files",
-		"result":"debug files removed from git",
-		"evidence":[{"kind":"verification","summary":"git commit abc123 updated .gitignore"}]
-	}`))
-	if err == nil {
-		t.Fatal("verification evidence without a command should be rejected")
-	}
-	got := err.Error()
-	for _, want := range []string{"verification command is required", `"files"`, `"diff"`, `"manual"`} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("error %q missing %q", got, want)
-		}
-	}
-}
-
 func TestCompleteStepAllowsManualAsUnverified(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
 	out, err := completeStep{}.Execute(ctx, json.RawMessage(`{

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -95,6 +95,9 @@ func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, err
 		return "", err
 	}
 	if !tool.HasPlanReplacementAuthorization(ctx) {
+		if err := verifyTodoCurrentContinuity(ctx, p.Todos); err != nil {
+			return "", err
+		}
 		if err := verifyStepIDsPreserved(ctx, p.Todos); err != nil {
 			return "", err
 		}
@@ -145,6 +148,30 @@ func verifyStepIDsPreserved(ctx context.Context, todos []todoItem) error {
 			continue
 		}
 		return fmt.Errorf("todo %d %q dropped its step_id %q; re-send it with step_id %q so its completion stays attached across retitles and reordering", match.Index, match.Content, todo.StepID, todo.StepID)
+	}
+	return nil
+}
+
+func verifyTodoCurrentContinuity(ctx context.Context, todos []todoItem) error {
+	previous := todoBaseline(ctx)
+	if len(previous) == 0 {
+		return nil
+	}
+	next := toEvidenceTodos(todos)
+	if len(next) == 0 {
+		return fmt.Errorf("current todo cannot be cleared while the plan is active; get host approval to replace the plan")
+	}
+	for i, todo := range previous {
+		if strings.TrimSpace(todo.Status) != "in_progress" {
+			continue
+		}
+		match, found := evidence.MatchTodoIdentity(todo, next)
+		if !found {
+			return fmt.Errorf("current todo %d %q cannot be removed or replaced while it is in_progress; mark it completed or get host approval to replace the plan", i+1, todo.Content)
+		}
+		if match.Status == "pending" || match.Status == "" {
+			return fmt.Errorf("current todo %d %q cannot move back to pending; keep it in_progress, mark it completed, or get host approval to replace the plan", i+1, todo.Content)
+		}
 	}
 	return nil
 }

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -14,9 +14,9 @@ func init() { tool.RegisterBuiltin(todoWrite{}) }
 
 // todoWrite records the agent's running task list. It has no host side effects —
 // the full list lives in the call's args (the model re-sends it whole on every
-// update), which a frontend renders as a checklist. Execute just validates the
-// shape and acks with a count, so the model gets a stable confirmation. The agent
-// keeps one item in_progress at a time and flips each to completed as it finishes.
+// update), which a frontend renders as a checklist. Execute validates serial
+// shape and stable identities, then acks with a count. Progress is not a
+// delivery receipt: complete_step remains the optional evidence sign-off.
 type todoWrite struct{}
 
 type todoItem struct {
@@ -95,17 +95,11 @@ func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, err
 		return "", err
 	}
 	if !tool.HasPlanReplacementAuthorization(ctx) {
-		if err := verifyTodoCurrentContinuity(ctx, p.Todos); err != nil {
-			return "", err
-		}
 		if err := verifyStepIDsPreserved(ctx, p.Todos); err != nil {
 			return "", err
 		}
 	}
 	if err := verifyCompletedTodoPositions(ctx, p.Todos); err != nil {
-		return "", err
-	}
-	if err := verifyTodoCompletionTransitions(ctx, p.Todos); err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("Todos updated: %d total — %d completed, %d in progress, %d pending.",
@@ -155,29 +149,6 @@ func verifyStepIDsPreserved(ctx context.Context, todos []todoItem) error {
 	return nil
 }
 
-func verifyTodoCurrentContinuity(ctx context.Context, todos []todoItem) error {
-	previous := todoBaseline(ctx)
-	if len(previous) == 0 {
-		return nil
-	}
-	// The single current item must survive the rewrite. In a layered phase this
-	// is either its active sub-step or, after all children finish, the phase
-	// header waiting for final sign-off.
-	for i, todo := range previous {
-		if strings.TrimSpace(todo.Status) != "in_progress" {
-			continue
-		}
-		match, found := evidence.MatchTodoIdentity(todo, toEvidenceTodos(todos))
-		if !found {
-			return fmt.Errorf("current todo %d %q cannot be removed or replaced while it is in_progress; complete it with complete_step before changing the remaining list", i+1, todo.Content)
-		}
-		if match.Status == "pending" || match.Status == "" {
-			return fmt.Errorf("current todo %d %q cannot move back to pending; keep it in_progress or complete it with complete_step", i+1, todo.Content)
-		}
-	}
-	return nil
-}
-
 func verifyCompletedTodoPositions(ctx context.Context, todos []todoItem) error {
 	previous := todoBaseline(ctx)
 	if len(previous) == 0 {
@@ -189,7 +160,7 @@ func verifyCompletedTodoPositions(ctx context.Context, todos []todoItem) error {
 		}
 		match, found := evidence.MatchTodoIdentity(toEvidenceTodo(todo), previous)
 		if !found || match.Index != i+1 {
-			return fmt.Errorf("completed todo %d %q cannot be inserted, duplicated, or reordered; preserve the completed prefix and sign off the current item with complete_step", i+1, todo.Content)
+			return fmt.Errorf("completed todo %d %q cannot be inserted, duplicated, or reordered; preserve the completed prefix", i+1, todo.Content)
 		}
 	}
 	if len(evidence.IncompleteTodos(previous)) > 0 && !evidence.PreservesCompletedTodoPositions(previous, toEvidenceTodos(todos)) {
@@ -206,43 +177,6 @@ func todoBaseline(ctx context.Context) []evidence.TodoItem {
 	}
 	previous, _ := evidence.TodoStateFromContext(ctx)
 	return previous
-}
-
-func verifyTodoCompletionTransitions(ctx context.Context, todos []todoItem) error {
-	ledger, ok := evidence.FromContext(ctx)
-	if !ok {
-		return nil
-	}
-	missing, hasBaseline := ledger.UnverifiedCompletedTodos(toEvidenceTodos(todos))
-	if !hasBaseline {
-		if previous, ok := evidence.TodoStateFromContext(ctx); ok && len(previous) > 0 {
-			for i, todo := range todos {
-				if todo.Status != "completed" {
-					continue
-				}
-				match, found := evidence.MatchTodoIdentity(toEvidenceTodo(todo), previous)
-				if !found || match.Status != "completed" {
-					return fmt.Errorf("todo %d %q cannot become completed without signing off the current item with complete_step", i+1, todo.Content)
-				}
-			}
-			return nil
-		}
-		for i, todo := range todos {
-			if todo.Status == "completed" {
-				return fmt.Errorf("initial todo %d %q cannot start completed; establish the task list before doing the work, then sign off the current item with complete_step", i+1, todo.Content)
-			}
-		}
-		return nil
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-	const hint = "; sign each finished item off with complete_step first, then re-send this todo_write"
-	if len(missing) == 1 {
-		m := missing[0]
-		return fmt.Errorf("todo %d %q is newly completed but has no matching successful complete_step receipt in this turn%s", m.Index, m.Content, hint)
-	}
-	return fmt.Errorf("%d todos are newly completed but have no matching successful complete_step receipts in this turn%s", len(missing), hint)
 }
 
 func toEvidenceTodos(todos []todoItem) []evidence.TodoItem {

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -103,7 +103,7 @@ func TestTodoWriteAcceptsInitialCompletedWithoutBaseline(t *testing.T) {
 	}
 }
 
-func TestTodoWriteAllowsDroppingCurrentTodo(t *testing.T) {
+func TestTodoWriteRejectsDroppingCurrentTodoWithoutReplacementAuth(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -119,9 +119,18 @@ func TestTodoWriteAllowsDroppingCurrentTodo(t *testing.T) {
 		`{"todos":[]}`,
 		`{"todos":[{"content":"Write code","status":"in_progress"}]}`,
 	} {
-		if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(args)); err != nil {
-			t.Fatalf("dropping current todo with %s should be accepted: %v", args, err)
+		_, err := (todoWrite{}).Execute(ctx, json.RawMessage(args))
+		if err == nil || !strings.Contains(err.Error(), "cannot be") {
+			t.Fatalf("dropping current todo with %s should require replacement approval: %v", args, err)
 		}
+	}
+
+	authorized := tool.WithPlanReplacementAuthorization(ctx)
+	if _, err := (todoWrite{}).Execute(authorized, json.RawMessage(`{"todos":[{"content":"Write code","status":"in_progress"}]}`)); err != nil {
+		t.Fatalf("approved replacement of the current todo should succeed: %v", err)
+	}
+	if _, err := (todoWrite{}).Execute(authorized, json.RawMessage(`{"todos":[]}`)); err != nil {
+		t.Fatalf("approved clearing of an incomplete list should succeed: %v", err)
 	}
 }
 
@@ -168,8 +177,8 @@ func TestTodoWriteDoesNotTreatNumericContentAsStepIndex(t *testing.T) {
 		{"content":"Replacement","status":"in_progress"}
 	]}`)
 
-	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
-		t.Fatalf("replacing a numeric-titled current item should be accepted: %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "cannot be removed or replaced") {
+		t.Fatalf("numeric todo content should be matched by identity, got %v", err)
 	}
 
 	completeNumeric := json.RawMessage(`{"todos":[
@@ -424,7 +433,7 @@ func TestTodoWriteRejectsOrphanSubStep(t *testing.T) {
 	}
 }
 
-func TestTodoWriteAllowsReplacingActiveSubStep(t *testing.T) {
+func TestTodoWriteRejectsReplacingActiveSubStepWithoutReplacementAuth(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -436,11 +445,15 @@ func TestTodoWriteAllowsReplacingActiveSubStep(t *testing.T) {
 		},
 	})
 	ctx := evidence.WithLedger(context.Background(), ledger)
-
-	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[
+	args := json.RawMessage(`{"todos":[
 		{"content":"Port the parser","status":"pending"},
-		{"content":"rewrite everything","status":"in_progress","level":1}]}`)); err != nil {
-		t.Fatalf("replacing the active sub-step should be accepted: %v", err)
+		{"content":"rewrite everything","status":"in_progress","level":1}]}`)
+
+	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "cannot be removed or replaced") {
+		t.Fatalf("replacing the active sub-step should require replacement approval: %v", err)
+	}
+	if _, err := (todoWrite{}).Execute(tool.WithPlanReplacementAuthorization(ctx), args); err != nil {
+		t.Fatalf("approved replacement of the active sub-step should succeed: %v", err)
 	}
 }
 
@@ -514,8 +527,8 @@ func TestTodoWriteUpdatesProgressWhilePlanModeIsActive(t *testing.T) {
 	]}`)); err != nil {
 		t.Fatalf("plan mode should still accept todo progress: %v", err)
 	}
-	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[]}`)); err != nil {
-		t.Fatalf("plan mode should still accept an empty todo list: %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[]}`)); err == nil || !strings.Contains(err.Error(), "cannot be cleared") {
+		t.Fatalf("plan mode should still require approval to clear the list: %v", err)
 	}
 }
 

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"reasonix/internal/evidence"
+	"reasonix/internal/planmode"
 	"reasonix/internal/tool"
 )
 
@@ -58,7 +59,7 @@ func TestTodoWriteRejectsNonSerialStates(t *testing.T) {
 	}
 }
 
-func TestTodoWriteRejectsNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
+func TestTodoWriteAcceptsNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -68,9 +69,12 @@ func TestTodoWriteRejectsNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("new completion without complete_step should be rejected, got %v", err)
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("new completion without complete_step should be accepted: %v", err)
+	}
+	if !strings.Contains(out, "1 completed") {
+		t.Fatalf("todo_write output = %q, want 1 completed", out)
 	}
 }
 
@@ -90,16 +94,16 @@ func TestTodoWriteAcceptsNewCompletedWithCompleteStepReceipt(t *testing.T) {
 	}
 }
 
-func TestTodoWriteRejectsInitialCompletedWithoutBaseline(t *testing.T) {
+func TestTodoWriteAcceptsInitialCompletedWithoutBaseline(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "cannot start completed") {
-		t.Fatalf("initial completed todo without baseline should be rejected: %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("initial completed todo without baseline should be accepted: %v", err)
 	}
 }
 
-func TestTodoWriteRejectsDroppingCurrentTodo(t *testing.T) {
+func TestTodoWriteAllowsDroppingCurrentTodo(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -115,9 +119,8 @@ func TestTodoWriteRejectsDroppingCurrentTodo(t *testing.T) {
 		`{"todos":[]}`,
 		`{"todos":[{"content":"Write code","status":"in_progress"}]}`,
 	} {
-		_, err := (todoWrite{}).Execute(ctx, json.RawMessage(args))
-		if err == nil || !strings.Contains(err.Error(), "cannot be removed or replaced") {
-			t.Fatalf("dropping current todo with %s should be rejected: %v", args, err)
+		if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(args)); err != nil {
+			t.Fatalf("dropping current todo with %s should be accepted: %v", args, err)
 		}
 	}
 }
@@ -165,8 +168,16 @@ func TestTodoWriteDoesNotTreatNumericContentAsStepIndex(t *testing.T) {
 		{"content":"Replacement","status":"in_progress"}
 	]}`)
 
-	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "cannot be removed or replaced") {
-		t.Fatalf("numeric todo content should be matched by identity, got %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("replacing a numeric-titled current item should be accepted: %v", err)
+	}
+
+	completeNumeric := json.RawMessage(`{"todos":[
+		{"content":"Finished","status":"completed"},
+		{"content":"2","status":"completed"}
+	]}`)
+	if _, err := (todoWrite{}).Execute(ctx, completeNumeric); err != nil {
+		t.Fatalf("completing numeric todo content should not treat it as a step index: %v", err)
 	}
 }
 
@@ -200,15 +211,15 @@ func TestTodoWritePreservesCanonicalCompletedPrefixAcrossTurns(t *testing.T) {
 	}
 }
 
-func TestTodoWriteCannotCompleteCanonicalCurrentAcrossTurns(t *testing.T) {
+func TestTodoWriteCanCompleteCanonicalCurrentAcrossTurns(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
 	ctx = evidence.WithTodoState(ctx, []evidence.TodoItem{
 		{Content: "Inspect environment", Status: "in_progress"},
 	})
 
 	args := json.RawMessage(`{"todos":[{"content":"Inspect environment","status":"completed"}]}`)
-	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "cannot become completed") {
-		t.Fatalf("cross-turn current todo completion should require complete_step: %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("cross-turn current todo completion should be accepted: %v", err)
 	}
 }
 
@@ -244,7 +255,7 @@ func TestTodoWriteRejectsDuplicatedOrReorderedCompletedPrefix(t *testing.T) {
 	}
 }
 
-func TestTodoWriteRejectsFailedCompleteStepReceipt(t *testing.T) {
+func TestTodoWriteAcceptsCompletedAfterFailedCompleteStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -255,13 +266,12 @@ func TestTodoWriteRejectsFailedCompleteStepReceipt(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step without proof-bearing recovery should not authorize completion, got %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("failed complete_step should not block todo progress: %v", err)
 	}
 }
 
-func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
+func TestTodoWriteAcceptsCompletedWithoutProofBearingSignoff(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -281,13 +291,12 @@ func TestTodoWriteRejectsFailedCompleteStepWithoutProof(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step without proof should not authorize completion, got %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("todo progress should not wait for a proof-bearing complete_step: %v", err)
 	}
 }
 
-func TestTodoWriteRejectsFailedCompleteStepMissingResult(t *testing.T) {
+func TestTodoWriteAcceptsCompletedWhenSignoffLacksResult(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -306,13 +315,12 @@ func TestTodoWriteRejectsFailedCompleteStepMissingResult(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step without result should not authorize completion, got %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("todo progress should not wait for a complete_step result: %v", err)
 	}
 }
 
-func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.T) {
+func TestTodoWriteCompletesWithoutSignoffRecoveryHatch(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -333,11 +341,11 @@ func TestTodoWriteRecoversAfterFailedCompleteStepWithProgressReceipt(t *testing.
 	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
 
 	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
-		t.Fatalf("matching failed complete_step with progress receipt should recover todo completion: %v", err)
+		t.Fatalf("todo completion should not need the failed-signoff recovery hatch: %v", err)
 	}
 }
 
-func TestTodoWriteRejectsRecoveryWhenProgressIsAfterFailedCompleteStep(t *testing.T) {
+func TestTodoWriteCompletesWhenProgressIsAfterFailedCompleteStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -358,9 +366,8 @@ func TestTodoWriteRejectsRecoveryWhenProgressIsAfterFailedCompleteStep(t *testin
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Run project script","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("progress after a failed complete_step should not authorize recovery, got %v", err)
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("later progress should not be required to complete a todo: %v", err)
 	}
 }
 
@@ -417,7 +424,7 @@ func TestTodoWriteRejectsOrphanSubStep(t *testing.T) {
 	}
 }
 
-func TestTodoWriteRejectsDroppingActiveSubStep(t *testing.T) {
+func TestTodoWriteAllowsReplacingActiveSubStep(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -430,10 +437,102 @@ func TestTodoWriteRejectsDroppingActiveSubStep(t *testing.T) {
 	})
 	ctx := evidence.WithLedger(context.Background(), ledger)
 
-	_, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[
+	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[
 		{"content":"Port the parser","status":"pending"},
-		{"content":"rewrite everything","status":"in_progress","level":1}]}`))
-	if err == nil || !strings.Contains(err.Error(), "cannot be removed or replaced") {
-		t.Fatalf("dropping the active sub-step should be rejected: %v", err)
+		{"content":"rewrite everything","status":"in_progress","level":1}]}`)); err != nil {
+		t.Fatalf("replacing the active sub-step should be accepted: %v", err)
+	}
+}
+
+func TestTodoWriteAdvancesFiveItemListWithoutSignoff(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Remove debug files from git", Status: "in_progress", StepID: "cleanup_step_01"},
+			{Content: "Clean leftover artifacts", Status: "pending", StepID: "cleanup_step_02"},
+			{Content: "Update AGENTS.md", Status: "pending", StepID: "cleanup_step_03"},
+			{Content: "Trim unused libraries", Status: "pending", StepID: "cleanup_step_04"},
+			{Content: "Verify the build", Status: "pending", StepID: "cleanup_step_05"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[
+		{"content":"Remove debug files from git","status":"completed","step_id":"cleanup_step_01"},
+		{"content":"Clean leftover artifacts","status":"in_progress","step_id":"cleanup_step_02"},
+		{"content":"Update AGENTS.md","status":"pending","step_id":"cleanup_step_03"},
+		{"content":"Trim unused libraries","status":"pending","step_id":"cleanup_step_04"},
+		{"content":"Verify the build","status":"pending","step_id":"cleanup_step_05"}
+	]}`)
+
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("issue #9094 progress update should succeed without complete_step: %v", err)
+	}
+	if !strings.Contains(out, "1 completed") || !strings.Contains(out, "1 in progress") {
+		t.Fatalf("todo_write output = %q, want 1 completed and 1 in progress", out)
+	}
+}
+
+func TestTodoWriteRetitlesCompletedItemByStepID(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Remove debug files from git", Status: "in_progress", StepID: "cleanup_step_01"},
+			{Content: "Clean leftover artifacts", Status: "pending", StepID: "cleanup_step_02"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[
+		{"content":"Remove output/ debug files from git","status":"completed","step_id":"cleanup_step_01"},
+		{"content":"Clean leftover artifacts","status":"in_progress","step_id":"cleanup_step_02"}
+	]}`)
+
+	if _, err := (todoWrite{}).Execute(ctx, args); err != nil {
+		t.Fatalf("retitling a completed item by step_id should succeed: %v", err)
+	}
+}
+
+func TestTodoWriteUpdatesProgressWhilePlanModeIsActive(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Inspect environment", Status: "in_progress"},
+			{Content: "Draft a plan", Status: "pending"},
+		},
+	})
+	ctx := planmode.WithActive(evidence.WithLedger(context.Background(), ledger), true)
+
+	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[
+		{"content":"Inspect environment","status":"completed"},
+		{"content":"Draft a plan","status":"in_progress"}
+	]}`)); err != nil {
+		t.Fatalf("plan mode should still accept todo progress: %v", err)
+	}
+	if _, err := (todoWrite{}).Execute(ctx, json.RawMessage(`{"todos":[]}`)); err != nil {
+		t.Fatalf("plan mode should still accept an empty todo list: %v", err)
+	}
+}
+
+func TestTodoWriteRejectsUnauthorizedCompletedHistoryRewrite(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []evidence.TodoItem{
+			{Content: "Inspect environment", Status: "completed"},
+			{Content: "Write code", Status: "in_progress"},
+		},
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+	args := json.RawMessage(`{"todos":[{"content":"Write code","status":"in_progress"}]}`)
+
+	if _, err := (todoWrite{}).Execute(ctx, args); err == nil || !strings.Contains(err.Error(), "completed task history") {
+		t.Fatalf("unauthorized drop of completed history should be rejected: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

[#9094](https://github.com/esengine/DeepSeek-Reasonix/issues/9094): the model finished the work (including git commits) but the todo panel stayed at **0/5**. `todo_write` refused to mark the current `in_progress` item completed unless `complete_step` had already succeeded. When `complete_step` was hidden (`planMode`), that became a deadlock. Clearing the list was also rejected.

This is not a frontend refresh bug. A successful `todo_write` already updates `CanonicalTodoState`. The host gate blocked the update.

The reporter labeled the session Goal. The exact `unavailable in the current workflow phase` string only appears when `planMode` is on. Goal itself turns Plan off. The same `todo_write` gate also freezes 0/N in ordinary / Goal execution when the model follows the tool description and flips `completed` without a sign-off.

## Root cause

Three things were bound together that mainstream agents keep apart:

1. `verifyTodoCurrentContinuity` / `verifyTodoCompletionTransitions` treated the checklist as a sign-off ledger.
2. `complete_step.ProviderVisible = !planmode.Active`, while the schema stayed in the cache-stable catalog.
3. The `todo_write` description already says "flip an item to completed"; the gate forbade that.

#5128's failed-signoff recovery hatch cannot help when the phase interceptor never records a proof-bearing `complete_step` receipt.

## Fix

Treat the task list as progress, not delivery proof.

- `todo_write` may mark an item completed in any workflow phase without a prior `complete_step`.
- Replacing, removing, or clearing an active current item remains a structural plan replacement and requires dedicated host authorization (`AuthorizePlanReplacement`); a normal Auto Guard allow does not grant that authorization.
- Serial shape, unique `step_id`, preserved ids, and the completed-history prefix stay in force.
- `complete_step` stays hidden during Plan and still requires evidence. A successful sign-off still auto-advances the list. Delivery `ObligationSignoff` still requires a successful `complete_step`, not a checkbox.
- Verification evidence with no `command` now points at `files` / `diff` / `manual`. A git commit is still not a verifier.

## Related PRs

- #9096 is the scratch / delivery attention-card work. It does **not** fix #9094 and this PR does **not** change that card.
- #9097 (`@poorpaper`) also targets #9094 by making `complete_step` callable in Plan when a canonical `in_progress` item exists. That is a different contract: it keeps sign-off as the only way to advance the list. This PR instead lets `todo_write` record progress and keeps Plan from signing unexecuted work. The two conflict in `completestep.go` and `planmode_test.go` if both merge.

## Compatibility

| Field or format | Old-data behavior | New-reader behavior | Previous-reader behavior | Conclusion |
| --- | --- | --- | --- | --- |
| Todo item JSON | `pending` / `in_progress` / `completed` | Same statuses and fields | Same | Compatible |
| Wails `canonicalTodos` | Host list after successful `todo_write` / `complete_step` | Same shape; progress can move without a sign-off | Old clients still render the list | Compatible |
| Session / ledger receipts | `UnverifiedCompletedTodos` existed | Helper kept; `todo_write` no longer uses it as a gate | Previous readers unchanged | Compatible |
| Frozen 0/5 sessions | Stuck until a successful `complete_step` | Next successful `todo_write` can advance | No migration | Compatible |

## Cache

No tool schema, description, system-prompt, memory, or provider-prefix bytes change.

Cache-impact: none - host-only `todo_write` gate and a `complete_step` error string; provider-visible prefix unchanged
Cache-guard: `go test ./internal/tool -run TestBuiltinToolContractDocumentation`

## Documentation

Documentation-impact: none - existing GUIDE/SPEC and tool documentation already describe progress completion; only runtime host authorization behavior changed, so no documentation files are needed

## Verification

- `go test ./internal/tool/builtin/ ./internal/evidence/ ./internal/agent/ ./internal/control/ ./internal/tool -count=1`
- `go test ./internal/tool -run TestBuiltinToolContractDocumentation`

| Case | Expected |
| --- | --- |
| #9094: 5 items, no sign-off, mark item 1 completed | `todo_write` succeeds; canonical list 1/5 |
| Plan on: mark the current item completed | Succeeds; `complete_step` remains unavailable |
| Plan on: replace or clear an active current item | Requires dedicated host authorization and Auto Guard plan review |
| Ordinary / Goal (`planMode=false`) | `complete_step` visible; progress does not need it |
| Successful `complete_step` | Host still advances the next item |
| Failed verification (no command) | Sign-off fails with files/diff/manual hint; later `todo_write` can still complete |
| Illegal serial shape / rewritten completed prefix | Still rejected |
| Delivery `ObligationSignoff` | Still only a successful `complete_step` |
| Schema / description bytes | Unchanged |

This does **not** change the orange 「本轮仍需处理」 card or the 「本轮验证」 button.

Fixes #9094



