### PR TITLE
fix(desktop): hide Windows caption controls in image preview / Windows 图片预览隐藏窗口三键

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -638,15 +638,6 @@ ok(
 );
 
 ok(
-  finalDeclaration(".image-viewer__close", "right") === "16px" &&
-    finalDeclaration(".app--windows-frameless .image-viewer__close", "right") === undefined &&
-    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "opacity") === "0" &&
-    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "visibility") === "hidden" &&
-    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "pointer-events") === "none",
-  "Windows app-level image preview hides caption controls and owns the top-right close action",
-);
-
-ok(
   finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "min-height") === "40px" &&

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -638,6 +638,15 @@ ok(
 );
 
 ok(
+  finalDeclaration(".image-viewer__close", "right") === "16px" &&
+    finalDeclaration(".app--windows-frameless .image-viewer__close", "right") === undefined &&
+    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "opacity") === "0" &&
+    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "visibility") === "hidden" &&
+    finalDeclaration(".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls", "pointer-events") === "none",
+  "Windows app-level image preview hides caption controls and owns the top-right close action",
+);
+
+ok(
   finalDeclaration(".app--windows.app--creation .topicbar", "position") === "relative" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "z-index") === "var(--z-app-chrome)" &&
     finalDeclaration(".app--windows.app--creation .topicbar", "min-height") === "40px" &&

--- a/desktop/frontend/src/__tests__/image-viewer-window-controls.test.ts
+++ b/desktop/frontend/src/__tests__/image-viewer-window-controls.test.ts
@@ -1,0 +1,35 @@
+// Run: tsx src/__tests__/image-viewer-window-controls.test.ts
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const styles = readFileSync(new URL("../styles.css", import.meta.url), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+
+function finalDeclaration(selector: string, property: string): string | undefined {
+  let value: string | undefined;
+  const rule = /([^{}]+)\{([^{}]*)\}/g;
+  let ruleMatch: RegExpExecArray | null;
+
+  while ((ruleMatch = rule.exec(styles)) !== null) {
+    const selectors = ruleMatch[1].split(",").map((part) => part.trim());
+    if (!selectors.includes(selector)) continue;
+
+    const declaration = new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;]+)`, "g");
+    let declarationMatch: RegExpExecArray | null;
+    while ((declarationMatch = declaration.exec(ruleMatch[2])) !== null) {
+      value = declarationMatch[1].trim();
+    }
+  }
+
+  return value;
+}
+
+const windowsPreviewSelector = ".app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls";
+
+assert.equal(finalDeclaration(".image-viewer__close", "right"), "16px");
+assert.equal(finalDeclaration(".app--windows-frameless .image-viewer__close", "right"), undefined);
+assert.equal(finalDeclaration(windowsPreviewSelector, "opacity"), "0");
+assert.equal(finalDeclaration(windowsPreviewSelector, "visibility"), "hidden");
+assert.equal(finalDeclaration(windowsPreviewSelector, "pointer-events"), "none");
+
+console.log("image viewer window controls: 5 passed");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -22212,6 +22212,15 @@ body > .mermaid-diagram--fullscreen {
   transition: opacity var(--dur-base) ease;
 }
 
+/* The image viewer is an app-level fullscreen surface. Hide the custom
+   Windows caption controls while it is open so the preview owns the only
+   visible close affordance; native shortcuts such as Alt+F4 remain intact. */
+.app--windows-frameless:has(.image-viewer-backdrop) > .windows-window-controls {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 /* When the workspace panel is closed (no layout--workspace-open or
    layout--workspace-maximized), make the window controls box transparent so it
    blends into the title bar / background instead of showing a distinct box. */


### PR DESCRIPTION
## Summary

- Treat the app-level image viewer as an immersive fullscreen surface on Windows.
- Hide the custom minimize, maximize, and close controls while the image viewer is open.
- Restore the controls automatically when the viewer closes; keep the viewer close button, Escape, and backdrop dismissal unchanged.
- macOS and Linux retain their existing behavior.

## Root cause

The custom Windows caption controls remained visible above the image viewer, creating two competing close affordances in the same top-right area.

## Verification

- `pnpm check:css`
- `pnpm typecheck`
- `go run ./tools/repolint`
- `pnpm exec tsx src/__tests__/image-viewer-window-controls.test.ts` (5 passed)
- `pnpm exec tsx src/__tests__/composer-image-capability.test.tsx` (15 passed)
- In-app browser Windows simulation: controls hide on open, restore on close, and hide again on reopen.

The pre-existing `src/__tests__/app-chrome-tabs.test.ts` suite still reports one unrelated assertion failure: `Welcome is suppressed only until transcript history has loaded` (127 passed, 1 failed).

Documentation-impact: none - This adjusts a transient Windows-only image-preview affordance and does not change documented workflows or configuration.

Closes the Windows image-preview close-button collision reported by the user.