### PR TITLE
fix(desktop): honor default model on restart and new session / 设置里改默认模型后重启与新会话生效

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1969,10 +1969,12 @@ func (a *App) NewSessionForTab(tabID string) error {
 	if ctrl == nil {
 		return a.workspaceNotReadyErr(tab)
 	}
-	// Tab is already blank — just persist and skip the new-session dance.
+	// Tab is already blank — skip rotation, but still apply the configured
+	// default. A reused empty tab otherwise keeps the previous session's
+	// provider after a default-model change (#9080).
 	if !controllerHasActiveRuntimeWork(ctrl) && !messagesHaveConversationContent(ctrl.History()) {
 		a.persistTabSessionPath(tab, ctrl.SessionPath())
-		return nil
+		return a.applyNewSessionDefaultModel(tab)
 	}
 
 	if err := ctrl.NewSession(); err != nil {
@@ -1990,7 +1992,26 @@ func (a *App) NewSessionForTab(tabID string) error {
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	a.invalidatePromptHistoryCache()
 	a.emitProjectTreeChangedForSessionDirs(ctrl.SessionDir())
-	return nil
+	return a.applyNewSessionDefaultModel(tab)
+}
+
+// applyNewSessionDefaultModel makes a freshly rotated or reused blank session
+// obey the same default as EnsureBlankTab. Existing conversations keep their
+// saved model until the user starts a new one.
+func (a *App) applyNewSessionDefaultModel(tab *WorkspaceTab) error {
+	if tab == nil {
+		return nil
+	}
+	a.mu.RLock()
+	scope := tab.Scope
+	root := tab.WorkspaceRoot
+	a.mu.RUnlock()
+	if strings.TrimSpace(scope) != "project" {
+		scope = "global"
+		root = ""
+	}
+	defaultModel, _ := desktopNewSessionDefaults(scope, root)
+	return a.alignReusableBlankTabModel(tab, defaultModel)
 }
 
 func (a *App) assignFreshSessionTopic(tab *WorkspaceTab) {

--- a/desktop/default_model_race_test.go
+++ b/desktop/default_model_race_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestSetDefaultModelConcurrentTabModelUpdateIsRaceFree(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	oldRef, newRef := configureSwitchableDefaultModels(t)
+
+	app := NewApp()
+	tab := testTab("default-model-race", globalWorkspaceRoot())
+	tab.Scope = "global"
+	tab.model = oldRef
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.mu.Lock()
+		tab.model = oldRef
+		app.mu.Unlock()
+		close(started)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				app.mu.Lock()
+				tab.model = oldRef
+				app.mu.Unlock()
+			}
+		}
+	}()
+	<-started
+
+	err := app.SetDefaultModel(newRef)
+	close(stop)
+	<-done
+	if err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+}

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -12,6 +12,8 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
 )
 
 func TestEnsureBlankTabInheritsActiveTabLocalSettings(t *testing.T) {
@@ -601,4 +603,179 @@ func TestDesktopNewSessionDefaultsUsesProjectDefaultAndSkipsItsKeylessProvider(t
 	if !strings.Contains(filepath.Base(created.SessionPath), "test-model") {
 		t.Fatalf("new project session path = %q, want filename seeded by fallback model", created.SessionPath)
 	}
+}
+
+func TestSetDefaultModelPersistsSessionSidecar(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	oldRef, newRef := configureSwitchableDefaultModels(t)
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	cfg.DefaultModel = oldRef
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("seed previous default: %v", err)
+	}
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), "old-model")
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+
+	app := NewApp()
+	tab := testTab("default-sidecar", globalRoot)
+	tab.Scope = "global"
+	tab.WorkspaceRoot = globalRoot
+	tab.SessionPath = path
+	tab.model = oldRef
+	tab.Ctrl.SetSessionPath(path)
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+	})
+
+	if err := app.SetDefaultModel(newRef); err != nil {
+		t.Fatalf("SetDefaultModel: %v", err)
+	}
+	if got := config.LoadForEdit(config.UserConfigPath()).DefaultModel; got != newRef {
+		t.Fatalf("default_model = %q, want %q", got, newRef)
+	}
+	if tab.model != newRef {
+		t.Fatalf("tab model = %q, want %q", tab.model, newRef)
+	}
+	if stored, ok := agent.LoadSessionModel(path); !ok || stored != newRef {
+		t.Fatalf("stored session model = %q, %v, want %q", stored, ok, newRef)
+	}
+}
+
+func TestNewSessionForTabUsesConfiguredDefaultModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	oldRef, newRef := configureSwitchableDefaultModels(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	oldSession := agent.NewSession("sys")
+	oldSession.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	oldExec := agent.New(nil, nil, oldSession, agent.Options{}, event.Discard)
+	oldPath := filepath.Join(dir, "old.jsonl")
+	if err := os.WriteFile(oldPath, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write old session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(oldPath, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+	oldCtrl := control.New(control.Options{Executor: oldExec, SessionDir: dir, SessionPath: oldPath, Label: oldRef, Sink: event.Discard})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:          "new-session-default",
+		Scope:       "global",
+		Ready:       true,
+		model:       oldRef,
+		SessionPath: oldPath,
+		Ctrl:        oldCtrl,
+		sink:        &tabEventSink{tabID: "new-session-default", app: app},
+		disabledMCP: map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.NewSessionForTab(tab.ID); err != nil {
+		t.Fatalf("NewSessionForTab: %v", err)
+	}
+	if tab.model != newRef {
+		t.Fatalf("new session tab model = %q, want configured default %q", tab.model, newRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != newRef {
+		t.Fatalf("new session stored model = %q, %v, want %q", stored, ok, newRef)
+	}
+	if oldStored, ok := agent.LoadSessionModel(oldPath); !ok || oldStored != oldRef {
+		t.Fatalf("previous session model = %q, %v, want unchanged %q", oldStored, ok, oldRef)
+	}
+}
+
+func TestNewSessionForTabAlignsBlankTabToDefault(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	oldRef, newRef := configureSwitchableDefaultModels(t)
+
+	globalRoot := globalWorkspaceRoot()
+	path, err := createEmptySessionFile(desktopSessionDir(globalRoot), "old-model")
+	if err != nil {
+		t.Fatalf("create empty session: %v", err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, oldRef); err != nil {
+		t.Fatalf("seed old session model: %v", err)
+	}
+
+	blank := agent.NewSession("sys")
+	exec := agent.New(nil, nil, blank, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: desktopSessionDir(globalRoot), SessionPath: path, Label: oldRef, Sink: event.Discard})
+
+	app := NewApp()
+	app.ctx = context.Background()
+	tab := &WorkspaceTab{
+		ID:            "blank-default",
+		Scope:         "global",
+		WorkspaceRoot: globalRoot,
+		Ready:         true,
+		model:         oldRef,
+		SessionPath:   path,
+		Ctrl:          ctrl,
+		sink:          &tabEventSink{tabID: "blank-default", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+	t.Cleanup(func() {
+		if tab.Ctrl != nil {
+			tab.Ctrl.Close()
+		}
+		tab.releaseSessionLease()
+	})
+
+	if err := app.NewSessionForTab(tab.ID); err != nil {
+		t.Fatalf("NewSessionForTab: %v", err)
+	}
+	if tab.model != newRef {
+		t.Fatalf("blank tab model = %q, want configured default %q", tab.model, newRef)
+	}
+	if stored, ok := agent.LoadSessionModel(tab.currentSessionPath()); !ok || stored != newRef {
+		t.Fatalf("blank stored model = %q, %v, want %q", stored, ok, newRef)
+	}
+}
+
+func configureSwitchableDefaultModels(t *testing.T) (oldRef, newRef string) {
+	t.Helper()
+	setDesktopTestCredential(t, "OLD_MODEL_KEY", "sk-test")
+	setDesktopTestCredential(t, "NEW_MODEL_KEY", "sk-test")
+	oldRef = "old/old-model"
+	newRef = "new/new-model"
+	cfg := config.Default()
+	cfg.DefaultModel = newRef
+	cfg.Desktop.ProviderAccess = []string{"old", "new"}
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "old", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "old-model", APIKeyEnv: "OLD_MODEL_KEY"},
+		{Name: "new", Kind: "openai", BaseURL: "https://example.invalid/v1", Model: "new-model", APIKeyEnv: "NEW_MODEL_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	return oldRef, newRef
 }

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2084,9 +2084,10 @@ func (a *App) SetDefaultModel(ref string) error {
 		if err != nil {
 			return err
 		}
-		c.DefaultModel = resolved
+		ref = resolved
+		c.DefaultModel = ref
 		a.mu.Lock()
-		tab.model = resolved
+		tab.model = ref
 		a.mu.Unlock()
 		return nil
 	}); err != nil {
@@ -2095,7 +2096,7 @@ func (a *App) SetDefaultModel(ref string) error {
 		a.mu.Unlock()
 		return err
 	}
-	return a.persistTabModelIfCurrent(tab, tab.model)
+	return a.persistTabModelIfCurrent(tab, ref)
 }
 
 // SetPlannerModel sets (or, with "", clears) the two-model planner.

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2095,7 +2095,7 @@ func (a *App) SetDefaultModel(ref string) error {
 		a.mu.Unlock()
 		return err
 	}
-	return nil
+	return a.persistTabModelIfCurrent(tab, tab.model)
 }
 
 // SetPlannerModel sets (or, with "", clears) the two-model planner.


### PR DESCRIPTION
Closes #9080

Changing **Default model** in Settings wrote `default_model` and switched the live tab, but restart and New Session still came back on the previous provider.

## Problem

On v1.27+, users change the default model, then:

1. restart the app, or
2. start a new session

and the previous conversation's model is still selected.

## Root cause

- Empty sessions do not autosave a turn. `SetDefaultModel` never wrote the session sidecar, so startup preferred the stale provider via `LoadSessionModel`.
- Composer **New Session** inherited the current tab model. A reused blank tab was a no-op, so it never consulted `default_model`. `EnsureBlankTab` already used the global default; New Session did not.

## Fix

- Persist the selected default onto the current session sidecar, same last-writer-wins helper as `SetModelForTab`.
- After New Session rotation, or when the current tab is already blank, apply the same default as `EnsureBlankTab`.
- Existing conversations still keep their saved model until the user starts a new one. That matches the Settings hint.

## Verification

- `go test . -count=1 -run TestSetDefaultModelPersistsSessionSidecar`
- `go test . -count=1 -run TestNewSessionForTabUsesConfiguredDefaultModel`
- `go test . -count=1 -run TestNewSessionForTabAlignsBlankTabToDefault`
- `go test . -count=1 -run 'TestNewSession|TestSetDefaultModel|TestEnsureBlankTab|TestDesktopNewSession'`
- `go test -race . -count=1 -run 'TestSetDefaultModelPersistsSessionSidecar|TestNewSessionForTabUsesConfiguredDefaultModel|TestNewSessionForTabAlignsBlankTabToDefault'`
- `make lint`

Cache-impact: none - desktop session sidecar and new-session model selection only; no provider-visible prefix change
Documentation-impact: none - Settings copy already says the default is for new sessions and existing sessions keep their saved model