### PR TITLE
fix(jobs): stop calling quiet background jobs "stalled" / 修复安静后台任务被误报为“卡住”

### DIFF
--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -426,7 +426,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	fmt.Fprintf(&b, "mcp_call_timeout_seconds = %d   # default MCP call safety cap; per-plugin/tool overrides may raise it\n\n", c.MCPCallTimeoutSeconds())
 
 	b.WriteString("[tools.background_jobs]\n")
-	fmt.Fprintf(&b, "stalled_warning_seconds = %d   # warn once per background job after this many quiet seconds; 0 disables\n\n", c.BackgroundJobStalledWarningSeconds())
+	fmt.Fprintf(&b, "stalled_warning_seconds = %d   # heads-up once per background job after this many quiet seconds; a quiet job is not necessarily stuck; 0 disables\n\n", c.BackgroundJobStalledWarningSeconds())
 
 	b.WriteString("[tools.shell]\n")
 	if c.Tools.Shell.Prefer != "" {

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -824,16 +824,20 @@ func (m *Manager) recordStalled(parentSession, id, kind, label string) {
 		m.mu.Unlock()
 		return
 	}
-	text := fmt.Sprintf("%s may be stalled — still running after %s with no visible output. Inspect it with wait or bash_output, or stop it with kill_shell.", tag, m.stalledWarning.Round(time.Second))
+	quietFor := m.stalledWarning.Round(time.Second)
+	text := fmt.Sprintf("%s is still running after %s with no visible output — a quiet long-running job can look like this and is not necessarily stuck. If it should have finished, inspect it with wait or bash_output, or stop it with kill_shell. Tune or disable this check with tools.background_jobs.stalled_warning_seconds in your config (0 disables).", tag, quietFor)
 	m.completed = append(m.completed, completion{sessionID: parentSession, text: text})
 	active := m.active
 	shouldEmit := active == "" || parentSession == "" || active == parentSession
+	noticeText := fmt.Sprintf("background %s still running after %s with no visible output: %s", kind, quietFor, id)
+	noticeDetail := "A quiet long-running job can look like this, so this is a heads-up, not an error. If it should have finished, inspect with wait or bash_output, or stop it with kill_shell. Set tools.background_jobs.stalled_warning_seconds to 0 in your config to disable this notice."
 	m.mu.Unlock()
 	if shouldEmit {
 		m.sink.Emit(event.Event{
-			Kind:  event.Notice,
-			Level: event.LevelWarn,
-			Text:  fmt.Sprintf("background %s may be stalled: %s — still running after %s with no visible output; inspect with wait/bash_output or stop with kill_shell", kind, id, m.stalledWarning.Round(time.Second)),
+			Kind:   event.Notice,
+			Level:  event.LevelWarn,
+			Text:   noticeText,
+			Detail: noticeDetail,
 		})
 	}
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -829,16 +829,12 @@ func (m *Manager) recordStalled(parentSession, id, kind, label string) {
 	m.completed = append(m.completed, completion{sessionID: parentSession, text: text})
 	active := m.active
 	shouldEmit := active == "" || parentSession == "" || active == parentSession
-	noticeText := fmt.Sprintf("background %s still running after %s with no visible output: %s", kind, quietFor, id)
-	noticeDetail := "A quiet long-running job can look like this, so this is a heads-up, not an error. If it should have finished, inspect with wait or bash_output, or stop it with kill_shell. Set tools.background_jobs.stalled_warning_seconds to 0 in your config to disable this notice."
+	notice := event.Event{Kind: event.Notice, Level: event.LevelWarn,
+		Text:   fmt.Sprintf("background %s still running after %s with no visible output: %s", kind, quietFor, id),
+		Detail: "A quiet long-running job can look like this, so this is a heads-up, not an error. If it should have finished, inspect with wait or bash_output, or stop it with kill_shell. Set tools.background_jobs.stalled_warning_seconds to 0 in your config to disable this notice."}
 	m.mu.Unlock()
 	if shouldEmit {
-		m.sink.Emit(event.Event{
-			Kind:   event.Notice,
-			Level:  event.LevelWarn,
-			Text:   noticeText,
-			Detail: noticeDetail,
-		})
+		m.sink.Emit(notice)
 	}
 }
 

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -319,7 +319,7 @@ func TestStalledWarningIgnoresReturnedJobBeforeTerminalStatusPublished(t *testin
 
 	time.Sleep(50 * time.Millisecond)
 	note := m.DrainCompletedNote()
-	if strings.Contains(note, "may be stalled") {
+	if strings.Contains(note, "still running after") {
 		t.Fatalf("got false stalled warning for already-returned job %s: %q", j.ID, note)
 	}
 	if !strings.Contains(note, j.ID) || !strings.Contains(note, string(Done)) {
@@ -443,7 +443,7 @@ func TestStalledWarningEmitsNoticeAndDrainNote(t *testing.T) {
 
 	waitFor(t, func() bool {
 		for _, text := range sink.texts() {
-			if strings.Contains(text, "may be stalled") && strings.Contains(text, j.ID) {
+			if strings.Contains(text, "still running after") && strings.Contains(text, j.ID) {
 				return true
 			}
 		}
@@ -453,7 +453,7 @@ func TestStalledWarningEmitsNoticeAndDrainNote(t *testing.T) {
 		t.Fatalf("stalled job output status = %q ok=%v, want running", st, ok)
 	}
 	note := m.DrainCompletedNote()
-	if !strings.Contains(note, "may be stalled") || !strings.Contains(note, j.ID) {
+	if !strings.Contains(note, "still running after") || !strings.Contains(note, j.ID) {
 		t.Fatalf("stalled drain note = %q, want stalled update for %s", note, j.ID)
 	}
 	// The warning is once per job.

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -28,7 +28,7 @@ func (s *recordingSink) texts() []string {
 	defer s.mu.Unlock()
 	out := make([]string, 0, len(s.events))
 	for _, ev := range s.events {
-		out = append(out, ev.Text)
+		out = append(out, ev.Text+" "+ev.Detail)
 	}
 	return out
 }
@@ -319,7 +319,7 @@ func TestStalledWarningIgnoresReturnedJobBeforeTerminalStatusPublished(t *testin
 
 	time.Sleep(50 * time.Millisecond)
 	note := m.DrainCompletedNote()
-	if strings.Contains(note, "still running after") {
+	if strings.Contains(note, "still running after") || strings.Contains(note, "may be stalled") {
 		t.Fatalf("got false stalled warning for already-returned job %s: %q", j.ID, note)
 	}
 	if !strings.Contains(note, j.ID) || !strings.Contains(note, string(Done)) {
@@ -443,7 +443,7 @@ func TestStalledWarningEmitsNoticeAndDrainNote(t *testing.T) {
 
 	waitFor(t, func() bool {
 		for _, text := range sink.texts() {
-			if strings.Contains(text, "still running after") && strings.Contains(text, j.ID) {
+			if strings.Contains(text, "still running after") && strings.Contains(text, j.ID) && !strings.Contains(text, "may be stalled") && strings.Contains(text, "heads-up, not an error") && strings.Contains(text, "stalled_warning_seconds") {
 				return true
 			}
 		}
@@ -453,7 +453,7 @@ func TestStalledWarningEmitsNoticeAndDrainNote(t *testing.T) {
 		t.Fatalf("stalled job output status = %q ok=%v, want running", st, ok)
 	}
 	note := m.DrainCompletedNote()
-	if !strings.Contains(note, "still running after") || !strings.Contains(note, j.ID) {
+	if !strings.Contains(note, "still running after") || !strings.Contains(note, j.ID) || strings.Contains(note, "may be stalled") || !strings.Contains(note, "stalled_warning_seconds") {
 		t.Fatalf("stalled drain note = %q, want stalled update for %s", note, j.ID)
 	}
 	// The warning is once per job.

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -138,7 +138,7 @@ mcp_startup_timeout_seconds = 30   # background initialize + tools/list safety c
 mcp_call_timeout_seconds = 300   # default MCP call safety cap; per-plugin/tool overrides may raise it
 
 [tools.background_jobs]
-stalled_warning_seconds = 900   # warn once per background job after this many quiet seconds; 0 disables
+stalled_warning_seconds = 900   # heads-up once per background job after this many quiet seconds; a quiet job is not necessarily stuck; 0 disables
 
 # Sandbox confinement bounds the blast radius of tool calls. Writers may only
 # modify workspace_root (empty = current directory) plus allow_write. forbid_read


### PR DESCRIPTION
## Summary

A background job that produces **no visible output** for `tools.background_jobs.stalled_warning_seconds` (default `900`s) was reported with a Warning: *"may be stalled — still running after 15m0s with no visible output"*. But "no visible output" cannot distinguish a hung job from a healthy quiet long-running one (silent installs, builds, test collection, waiting on an external service), so this misleadingly read as an error and was carried into the next turn as a drain note.

This change reframes the notice so it states the observable fact — the job is *still running after N without new output*, a heads-up rather than an error — and points the user at how to tune or disable the check (`stalled_warning_seconds = 0`):

- `internal/jobs/jobs.go` `recordStalled`: new drain-note text, and the Notice now puts the concise headline in `Text` and the tuning guidance in `Detail`.
- `internal/jobs/jobs_test.go`: stalled tests assert the new wording, the `Detail` guidance, and the removal of the old `may be stalled` phrase.
- `internal/config/render.go` + `reasonix.example.toml`: config-key comment updated to say a quiet job is not necessarily stuck and that `0` disables.

No threshold, event kind/level, or notification cadence changes — behavior-wise this is copy/documentation only, so it stays low-risk.

## Issues

Fixes #9114

## Verification

- `gofmt -l internal/jobs/jobs.go internal/jobs/jobs_test.go internal/config/render.go` → clean.
- `git diff --check` → clean.
- `go test ./internal/jobs/ -run Stalled -v` → PASS.
- `go test ./internal/jobs/ ./internal/config/` → PASS.
- `go test -race ./internal/jobs` → PASS.
- `go vet ./internal/jobs/ ./internal/config/` → clean.
- `go run ./tools/repolint` → clean.
- `go test ./...` → all packages PASS on the rebased head.

## Documentation impact

Documentation-impact: none - the only embedded documentation for this setting is its config-key comment and the example TOML, both updated in place; there is no `docs/*.md` that describes background-job notices.

## Cache impact

Cache-impact: none - change is limited to background-job notice copy; it touches no system prompt, memory prefix, output style, skill index, tool surface, or provider request serialization.
Cache-guard: N/A - no cache-relevant surface changes.
System-prompt-review: N/A
