### PR TITLE
test(agent): cover safe Plan todo recovery / 覆盖 Plan 待办安全恢复路径

### DIFF
--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -294,6 +294,55 @@ func TestPlanModeTodoWriteCanCompleteCurrentItem(t *testing.T) {
 	}
 }
 
+func TestPlanModeTodoCreatedInTurnUsesTodoWriteRecovery(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(mustBuiltinTool(t, "todo_write"))
+	reg.Add(mustBuiltinTool(t, "complete_step"))
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.SetPlanMode(true)
+
+	created := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "todo",
+		Name: "todo_write",
+		Arguments: `{"todos":[
+			{"content":"finish the cleanup","status":"in_progress","step_id":"cleanup_step_01"}
+		]}`,
+	})
+	if created.blocked || created.errMsg != "" {
+		t.Fatalf("create Plan todo outcome = %+v", created)
+	}
+
+	signoff := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "sign-off",
+		Name: "complete_step",
+		Arguments: `{
+			"step_id":"cleanup_step_01",
+			"result":"cleanup finished",
+			"evidence":[{"kind":"manual","summary":"confirmed the cleanup output"}]
+		}`,
+	})
+	if !signoff.blocked || !strings.Contains(signoff.output, "only available after plan approval") {
+		t.Fatalf("Plan complete_step outcome = %+v, want phase block", signoff)
+	}
+	if got := a.CanonicalTodoState(); len(got) != 1 || got[0].Status != "in_progress" {
+		t.Fatalf("blocked sign-off changed canonical todos = %+v", got)
+	}
+
+	completed := a.executeOne(context.Background(), &a.turn, provider.ToolCall{
+		ID:   "complete-todo",
+		Name: "todo_write",
+		Arguments: `{"todos":[
+			{"content":"finish the cleanup","status":"completed","step_id":"cleanup_step_01"}
+		]}`,
+	})
+	if completed.blocked || completed.errMsg != "" {
+		t.Fatalf("todo_write recovery outcome = %+v", completed)
+	}
+	if got := a.CanonicalTodoState(); len(got) != 1 || got[0].Status != "completed" {
+		t.Fatalf("todo_write recovery state = %+v, want completed", got)
+	}
+}
+
 func TestPlanModeKeepsCompleteStepUnavailable(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(mustBuiltinTool(t, "complete_step"))


### PR DESCRIPTION
## Summary

- Add an Agent-level regression for a canonical todo created through the real `todo_write` path after Plan mode is already active.
- Prove an evidence-backed `complete_step` remains phase-blocked and cannot advance that todo during planning.
- Prove the same `step_id` can still reach `completed` through `todo_write`, preserving the safe recovery contract merged in #9098.

## Issues

Refs #9094
Refs #9097
Refs #9098

## Consolidation

### Kept / adapted

- Adapted the in-turn todo creation and recovery scenario from #9097 by @poorpaper into the current Agent contract.
- The test commit directly credits that adopted contribution with a public `Co-authored-by` trailer.

### Reviewed but not adopted

- The #9097 runtime override that made `complete_step` Plan-safe whenever any canonical todo was active. An active todo does not distinguish stale execution state from ordinary planning, and the override conflicts with the contract merged in #9098.

## Verification

- `go test ./internal/agent -run '^TestPlanModeTodoCreatedInTurnUsesTodoWriteRecovery$' -count=1`
- `go test -race ./internal/agent -count=1`
- `go vet ./internal/agent`
- `go test ./internal/tool -run '^TestBuiltinToolContractDocumentation$' -count=1`
- `go run ./tools/repolint`
- `git diff --check`

## Documentation impact

Documentation-impact: none - this is test-only coverage for the existing Plan/todo contract; no user-facing behavior or documentation changes.

## Cache impact

Cache-impact: none - the change adds only a Go regression test and does not alter provider-visible schemas, prompts, memory, serialization, or tool ordering.
Cache-guard: `go test ./internal/tool -run '^TestBuiltinToolContractDocumentation$' -count=1`
System-prompt-review: N/A
