### PR TITLE
Project config file location canonicalized

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -7951,7 +7951,7 @@ func withPluginConfigInWorkspace(v ServerView, p config.PluginEntry, workspace s
 func mcpServerSource(source config.MCPConfigSource) (kind, configSource string) {
 	switch source {
 	case config.MCPSourceProjectConfig:
-		return "project", "reasonix.toml"
+		return "project", ".reasonix/config.toml"
 	case config.MCPSourceProjectMCPJSON:
 		return "project", ".mcp.json"
 	case config.MCPSourcePluginPackage:

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -217,7 +217,7 @@ Runtime configuration is resolved in this order:
 
 ```text
 command-line flags
-> project ./reasonix.toml
+> project ./.reasonix/config.toml (or legacy ./reasonix.toml)
 > global <Reasonix home>/config.toml
 > compatible legacy global config
 > built-in defaults

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -172,7 +172,7 @@ Linux 的 `$XDG_CACHE_HOME/reasonix` 或 `~/.cache/reasonix`、Windows 的
 
 ```text
 命令行参数
-> 项目 ./reasonix.toml
+> 项目 ./.reasonix/config.toml（或旧版 ./reasonix.toml）
 > 全局 <Reasonix home>/config.toml
 > 兼容读取的旧全局配置
 > 内置默认值

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -32,8 +32,9 @@
 
 ## Configuration
 
-Resolution order: **flag > `./reasonix.toml` > the user config file >
-built-in defaults**. Starting with **Reasonix v1.8.1**, the user config lives at
+Resolution order: **flag > project `.reasonix/config.toml` (or legacy
+`./reasonix.toml`) > the user config file > built-in defaults**. Starting with
+**Reasonix v1.8.1**, the user config lives at
 `~/.reasonix/config.toml` on macOS/Linux and
 `%AppData%\reasonix\config.toml` on Windows; see
 [Configuration paths](./CONFIG_PATHS.md) for migration and related data paths.

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -32,7 +32,7 @@
 
 ## 配置
 
-优先级：**flag > `./reasonix.toml` > 用户配置文件 > 内置默认值**。从
+优先级：**flag > 项目 `.reasonix/config.toml`（或旧版 `./reasonix.toml`）> 用户配置文件 > 内置默认值**。从
 **Reasonix v1.8.1** 开始，用户配置位于 macOS/Linux 的
 `~/.reasonix/config.toml`，Windows 为 `%AppData%\reasonix\config.toml`；迁移和相关数据路径见
 [配置路径](./CONFIG_PATHS.zh-CN.md)。标注为“仅用户/全局”的字段（包括 agent 轮数上限）不会被 `./reasonix.toml` 覆盖。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -981,8 +981,9 @@ type Chunk struct {
 
 ## 5. Configuration (TOML)
 
-Resolution order: **flag > project `./reasonix.toml` > the user config file
-> built-in defaults**. Starting with **Reasonix v1.8.1**, the user config lives
+Resolution order: **flag > project `.reasonix/config.toml` (or legacy `./reasonix.toml`) >
+the user config file > built-in defaults**. Starting with **Reasonix v1.8.1**,
+the user config lives
 at `~/.reasonix/config.toml` on macOS/Linux and
 `%AppData%\reasonix\config.toml` on Windows. See
 [Configuration paths](./CONFIG_PATHS.md) for migration and related data paths.

--- a/docs/SPEC.zh-CN.md
+++ b/docs/SPEC.zh-CN.md
@@ -380,7 +380,7 @@ provider 层的核心类型包括 `Role`、`Message`、`ToolCall`、`ToolSchema`
 配置优先级：
 
 ```text
-flag > ./reasonix.toml > 用户 config.toml > 内置默认值
+flag > 项目 .reasonix/config.toml（或旧版 ./reasonix.toml）> 用户 config.toml > 内置默认值
 ```
 
 从 v1.8.1 起，用户配置位于 macOS/Linux 的 `~/.reasonix/config.toml` 或 Windows 的 `%AppData%\reasonix\config.toml`。provider key 保存在 Reasonix home 的 `.env`；项目 `.env` 只用于 workspace 范围的非 provider 变量展开。完整路径见[配置路径](./CONFIG_PATHS.zh-CN.md)。

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -2093,11 +2093,11 @@ func rememberPermissionRule(workspaceRoot, rule string) control.RememberResult {
 func rememberPermissionConfigPath(workspaceRoot string) string {
 	workspaceRoot = strings.TrimSpace(workspaceRoot)
 	if workspaceRoot != "" {
-		return filepath.Join(workspaceRoot, "reasonix.toml")
+		return config.ProjectConfigPath(workspaceRoot)
 	}
 	path := config.SourcePath()
 	if path == "" {
-		path = "reasonix.toml" // match Config.Save() fallback
+		path = config.ProjectConfigPath(".") // match Config.Save() fallback
 	}
 	return path
 }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -3234,7 +3234,7 @@ allow = ["Bash(user)"]
 
 	const rule = "Edit(src/app.go)"
 	res := rememberPermissionRule(workspace, rule)
-	if !res.Saved || res.Path != filepath.Join(workspace, "reasonix.toml") {
+	if !res.Saved || res.Path != filepath.Join(workspace, ".reasonix", "config.toml") {
 		t.Fatalf("remember result = %+v, want saved to workspace config", res)
 	}
 
@@ -3242,7 +3242,7 @@ allow = ["Bash(user)"]
 	if hasPermissionRule(userCfg.Permissions.Allow, rule) {
 		t.Fatalf("workspace rule was written to user config: %v", userCfg.Permissions.Allow)
 	}
-	workspaceCfg := config.LoadForEdit(filepath.Join(workspace, "reasonix.toml"))
+	workspaceCfg := config.LoadForEdit(filepath.Join(workspace, ".reasonix", "config.toml"))
 	if !hasPermissionRule(workspaceCfg.Permissions.Allow, rule) {
 		t.Fatalf("workspace rule missing from project config: %v", workspaceCfg.Permissions.Allow)
 	}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4210,7 +4210,7 @@ func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 		_ = m.cfg.SetShowReasoning(m.showReasoning)
 		path := config.SourcePath()
 		if path == "" {
-			path = "reasonix.toml"
+			path = config.ProjectConfigPath(".")
 		}
 		saveErr = config.EditConfigFile(path, func(cfg *config.Config) error {
 			return cfg.SetShowReasoning(m.showReasoning)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1399,12 +1399,12 @@ type setupTargets struct {
 }
 
 // defaultConfigTarget is the user-global config file, falling back to a
-// project-local reasonix.toml only when the user config dir can't be resolved.
+// project-local config only when the user config dir can't be resolved.
 func defaultConfigTarget() string {
 	if p := config.UserConfigPath(); p != "" {
 		return p
 	}
-	return "reasonix.toml"
+	return config.ProjectConfigPath(".")
 }
 
 // defaultEnvTarget is the display target for the reasonix-owned global
@@ -1421,7 +1421,7 @@ func resolveSetupTargets(args []string) setupTargets {
 	for _, a := range args {
 		switch a {
 		case "--local", "-l":
-			t.config = "reasonix.toml"
+			t.config = config.ProjectConfigPath(".")
 		default:
 			t.config = a
 		}
@@ -2506,7 +2506,7 @@ func configReasoningLanguageCommand(args []string) int {
 	}
 	path := config.UserConfigPath()
 	if *local {
-		path = "reasonix.toml"
+		path = config.ProjectConfigPath(".")
 	}
 	if path == "" {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, "cannot resolve config path")
@@ -2578,7 +2578,7 @@ func configCompactRatioCommand(args []string) int {
 	path := config.UserConfigPath()
 	scope := "user"
 	if *local {
-		path = "reasonix.toml"
+		path = config.ProjectConfigPath(".")
 		scope = "project"
 	}
 	if path == "" {
@@ -2623,8 +2623,8 @@ func configCompactRatioCommand(args []string) int {
 }
 
 func compactRatioSource() string {
-	if config.ConfigFileDefinesCompactRatio("reasonix.toml") {
-		return "project: " + displayPath("reasonix.toml")
+	if config.ConfigFileDefinesCompactRatio(config.ProjectConfigPath(".")) {
+		return "project: " + displayPath(config.ProjectConfigPath("."))
 	}
 	if path := config.UserConfigPath(); path != "" && config.ConfigFileDefinesCompactRatio(path) {
 		return "user: " + displayPath(path)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -771,7 +771,7 @@ func TestConfigReasoningLanguageLocalCreatesMinimalProjectOverride(t *testing.T)
 		t.Fatalf("config reasoning-language --local output = %q", out)
 	}
 
-	body, err := os.ReadFile("reasonix.toml")
+	body, err := os.ReadFile(".reasonix/config.toml")
 	if err != nil {
 		t.Fatalf("read project config: %v", err)
 	}
@@ -872,7 +872,7 @@ func TestConfigCompactRatioLocalCreatesMinimalProjectOverride(t *testing.T) {
 		t.Fatalf("config compact-ratio --local output = %q", out)
 	}
 
-	body, err := os.ReadFile("reasonix.toml")
+	body, err := os.ReadFile(".reasonix/config.toml")
 	if err != nil {
 		t.Fatalf("read project config: %v", err)
 	}

--- a/internal/cli/setup_manager_test.go
+++ b/internal/cli/setup_manager_test.go
@@ -717,7 +717,7 @@ func TestProviderSetupCommitDoesNotOverwriteMalformedConcurrentConfig(t *testing
 
 func TestResolveSetupTargetsLocalKeepsGlobalCredentialTarget(t *testing.T) {
 	targets := resolveSetupTargets([]string{"--local"})
-	if targets.config != "reasonix.toml" {
+	if targets.config != ".reasonix/config.toml" {
 		t.Fatalf("local config target = %q", targets.config)
 	}
 	if targets.env != config.CredentialsTargetDescription() {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -147,10 +147,7 @@ func credentialEnvNamesForRoot(root string) []string {
 	root = resolveRoot(root)
 	cfg := Default()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if uc := userConfigLoadPath(); uc != "" {
 		_ = mergeFile(cfg, uc)
 	}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -903,10 +903,9 @@ func ClearPluginAuthenticationInSource(name string) (PluginEntry, bool, string, 
 // user switches tabs while the action is waiting on a lifecycle lock.
 func ClearPluginAuthenticationInSourceForRoot(root, name string) (PluginEntry, bool, string, error) {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	lockPaths := append([]string{}, userConfigCandidatePaths()...)
@@ -953,10 +952,7 @@ func ClearPluginAuthenticationInSourceForRoot(root, name string) (PluginEntry, b
 }
 
 func pluginTOMLSourcePathForRoot(root, name string) string {
-	projectTOML := "reasonix.toml"
-	if resolved := resolveRoot(root); resolved != "." {
-		projectTOML = filepath.Join(resolved, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(resolveRoot(root))
 	paths := append([]string{projectTOML}, userConfigCandidatePaths()...)
 	for _, path := range paths {
 		if strings.TrimSpace(path) == "" {
@@ -978,10 +974,9 @@ func pluginTOMLSourcePathForRoot(root, name string) string {
 // the highest priority.
 func MCPConfigPathForEntry(root string, entry PluginEntry) string {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	switch entry.Source {
@@ -1207,10 +1202,9 @@ func RemovePluginFromEffectiveSourceForRoot(root, name string) (PluginEntry, boo
 // of a now-shadowed source.
 func mcpConfigSourcePathsForRoot(root string) []string {
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	projectMCPJSON := mcpJSONFile
 	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
 		projectMCPJSON = filepath.Join(resolvedRoot, mcpJSONFile)
 	}
 	paths := append([]string{}, userConfigCandidatePaths()...)
@@ -1412,10 +1406,7 @@ func RemovePluginFromSourcesForRoot(root, name string) (bool, error) {
 
 	userPaths := userConfigCandidatePaths()
 	resolvedRoot := resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if resolvedRoot != "." {
-		projectTOML = filepath.Join(resolvedRoot, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(resolvedRoot)
 	isUserPath := false
 	for _, path := range userPaths {
 		if samePath(path, projectTOML) {
@@ -2409,12 +2400,12 @@ func IsUserConfigPath(path string) bool {
 }
 
 // Save writes the configuration back to the file it was loaded from
-// (SourcePath), or to ./reasonix.toml when none exists yet — the conventional
-// project-local target a fresh GUI session would create.
+// (SourcePath), or to .reasonix/config.toml when none exists yet — the
+// conventional project-local target a fresh GUI session would create.
 func (c *Config) Save() error {
 	path := SourcePath()
 	if path == "" {
-		path = "reasonix.toml"
+		path = projectConfigLocal
 	}
 	return c.SaveTo(path)
 }
@@ -2424,10 +2415,7 @@ func (c *Config) Save() error {
 // are edited from their own TOML only, never from a runtime user+project merge.
 func (c *Config) SaveForRoot(root string) error {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if _, err := os.Stat(projectTOML); err == nil {
 		projectCfg := LoadForEditWithoutCredentials(projectTOML)
 		return projectCfg.SaveTo(projectTOML)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -72,9 +72,9 @@ func loadForRoot(root string, migrateOnDisk bool) (*Config, error) {
 	cfg.setExpansionEnv(expansionEnv)
 	cfg.CredentialsStore = credentialsStoreMode()
 
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
+	projectTOML := ProjectConfigPath(root)
+	if bothProjectConfigsExist(root) {
+		slog.Warn("project config: reasonix.toml and .reasonix/config.toml both exist; reasonix.toml wins", "root", root)
 	}
 	if primary := userConfigPath(); primary != "" {
 		if _, err := resolveConfigAccessPath(primary, true); err != nil {
@@ -967,11 +967,7 @@ func MigrateLegacyAgentStepLimitsForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1012,11 +1008,7 @@ func MigrateLegacyRedactToolOutputForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1054,11 +1046,7 @@ func MigrateLegacyMemoryCompilerForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))
@@ -1123,11 +1111,7 @@ func MigrateLegacyMultiThresholdCompactionForRoot(root string) (bool, error) {
 	if userPath := userConfigLoadPath(); userPath != "" {
 		paths = append(paths, userPath)
 	}
-	projectPath := "reasonix.toml"
-	if root != "." {
-		projectPath = filepath.Join(root, "reasonix.toml")
-	}
-	paths = append(paths, projectPath)
+	paths = append(paths, ProjectConfigPath(root))
 
 	changedAny := false
 	seen := make(map[string]struct{}, len(paths))

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -267,7 +267,7 @@ func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, e
 		addEntries(loadPluginEntriesFromTOML(path))
 	}
 	for _, root := range normalizedMCPMigrationRoots(projectRoots) {
-		addEntries(loadPluginEntriesFromTOML(filepath.Join(root, "reasonix.toml")))
+		addEntries(append(loadPluginEntriesFromTOML(filepath.Join(root, projectConfigFile)), loadPluginEntriesFromTOML(filepath.Join(root, projectConfigLocal))...))
 		if entries, err := loadMCPJSON(filepath.Join(root, mcpJSONFile)); err == nil {
 			addEntries(entries)
 		}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -621,14 +621,53 @@ func SourcePath() string {
 	return SourcePathForRoot(".")
 }
 
+// Project config files. The standard location is <root>/.reasonix/config.toml,
+// mirroring the global <home>/.reasonix/config.toml. Legacy <root>/reasonix.toml
+// wins when present, so existing repositories keep working. New files are only
+// ever created at <root>/.reasonix/config.toml.
+const (
+	projectConfigFile  = "reasonix.toml"
+	projectConfigLocal = ".reasonix" + string(filepath.Separator) + "config.toml"
+)
+
+// projectConfigCandidates returns the legacy plain and standard local project
+// config paths for a resolved root.
+func projectConfigCandidates(root string) (plain, local string) {
+	root = resolveRoot(root)
+	plain, local = projectConfigFile, projectConfigLocal
+	if root != "." {
+		plain = filepath.Join(root, projectConfigFile)
+		local = filepath.Join(root, projectConfigLocal)
+	}
+	return plain, local
+}
+
+// ProjectConfigPath returns the project config file for root. <root>/reasonix.toml
+// (legacy) wins when present; otherwise the standard <root>/.reasonix/config.toml.
+// When none exists it returns .reasonix/config.toml, the creation default.
+func ProjectConfigPath(root string) string {
+	plain, local := projectConfigCandidates(root)
+	if _, err := os.Lstat(plain); err == nil {
+		return plain
+	}
+	return local
+}
+
+// bothProjectConfigsExist reports whether root holds both the legacy plain
+// reasonix.toml and the standard .reasonix/config.toml, i.e. the ambiguous
+// case where the plain file wins.
+func bothProjectConfigsExist(root string) bool {
+	plain, local := projectConfigCandidates(root)
+	_, plainErr := os.Lstat(plain)
+	_, localErr := os.Lstat(local)
+	return plainErr == nil && localErr == nil
+}
+
 // SourcePathForRoot returns the highest-priority config file that exists under
 // root, or "" if none. Equivalent to SourcePath() when root is ".".
 func SourcePathForRoot(root string) string {
 	root = resolveRoot(root)
-	projectTOML := "reasonix.toml"
-	if root != "." {
-		projectTOML = filepath.Join(root, "reasonix.toml")
-	}
+	projectTOML := ProjectConfigPath(root)
 	if _, err := os.Stat(projectTOML); err == nil {
 		return projectTOML
 	}
@@ -638,4 +677,20 @@ func SourcePathForRoot(root string) string {
 		}
 	}
 	return ""
+}
+
+// IsProjectConfigFile reports whether path is a recognized project config file:
+// <root>/reasonix.toml or <root>/.reasonix/config.toml. The user-global
+// <home>/.reasonix/config.toml is excluded.
+func IsProjectConfigFile(path string) bool {
+	if path == "" || path == userConfigPath() || path == legacyUserConfigPath() {
+		return false
+	}
+	switch filepath.Base(path) {
+	case "reasonix.toml":
+		return true
+	case "config.toml":
+		return filepath.Base(filepath.Dir(path)) == ".reasonix"
+	}
+	return false
 }

--- a/internal/config/project_config_discovery_test.go
+++ b/internal/config/project_config_discovery_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProjectConfigPath pins the project-config discovery rule: reasonix.toml
+// wins when present, else the standard .reasonix/config.toml (the creation
+// default).
+func TestProjectConfigPath(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+
+	t.Run("legacy plain only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := ProjectConfigPath(root); got != filepath.Join(root, "reasonix.toml") {
+			t.Fatalf("ProjectConfigPath = %q, want reasonix.toml", got)
+		}
+	})
+
+	t.Run("local only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, ".reasonix", "config.toml")
+		if got := ProjectConfigPath(root); got != want {
+			t.Fatalf("ProjectConfigPath = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("legacy plain wins over local", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := ProjectConfigPath(root); got != filepath.Join(root, "reasonix.toml") {
+			t.Fatalf("ProjectConfigPath = %q, want reasonix.toml to win", got)
+		}
+	})
+
+	t.Run("neither defaults to local", func(t *testing.T) {
+		root := t.TempDir()
+		want := filepath.Join(root, ".reasonix", "config.toml")
+		if got := ProjectConfigPath(root); got != want {
+			t.Fatalf("ProjectConfigPath = %q, want %q default", got, want)
+		}
+	})
+
+	t.Run("bothProjectConfigsExist only for plain+local", func(t *testing.T) {
+		root := t.TempDir()
+		if bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist true with no files")
+		}
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist true with only the plain file")
+		}
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if !bothProjectConfigsExist(root) {
+			t.Fatal("bothProjectConfigsExist false with plain+local")
+		}
+	})
+}
+
+// TestLoadForRootProjectConfig pins discovery through a full load: the
+// standard .reasonix/config.toml is read, and reasonix.toml wins when present.
+func TestLoadForRootProjectConfig(t *testing.T) {
+	isolateUserConfigHome(t)
+	t.Setenv("REASONIX_HOME", "")
+
+	t.Run("local only", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte("default_model = \"local/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadForRoot(root)
+		if err != nil {
+			t.Fatalf("LoadForRoot: %v", err)
+		}
+		if cfg.DefaultModel != "local/model" {
+			t.Fatalf("DefaultModel = %q, want .reasonix/config.toml content", cfg.DefaultModel)
+		}
+	})
+
+	t.Run("legacy plain wins over local", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".reasonix", "config.toml"), []byte("default_model = \"local/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte("default_model = \"plain/model\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadForRoot(root)
+		if err != nil {
+			t.Fatalf("LoadForRoot: %v", err)
+		}
+		if cfg.DefaultModel != "plain/model" {
+			t.Fatalf("DefaultModel = %q, want reasonix.toml to win", cfg.DefaultModel)
+		}
+	})
+}
+
+// TestSourcePathForRootPicksLocal pins that the source-resolution helper
+// follows the same rule so writes/edits target the loaded file.
+func TestSourcePathForRootPicksLocal(t *testing.T) {
+	t.Setenv("REASONIX_HOME", t.TempDir())
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".reasonix"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, ".reasonix", "config.toml")
+	if err := os.WriteFile(want, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := SourcePathForRoot(root); got != want {
+		t.Fatalf("SourcePathForRoot = %q, want %q", got, want)
+	}
+}
+
+// TestIsProjectConfigFile pins the recognizer and its user-config exclusion.
+func TestIsProjectConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("REASONIX_HOME", home)
+	if !IsProjectConfigFile(filepath.Join(home, "proj", "reasonix.toml")) {
+		t.Error("legacy plain reasonix.toml should be a project config")
+	}
+	if !IsProjectConfigFile(filepath.Join(home, "proj", ".reasonix", "config.toml")) {
+		t.Error(".reasonix/config.toml should be a project config")
+	}
+	if IsProjectConfigFile(userConfigPath()) {
+		t.Error("user config should not be a project config")
+	}
+	if IsProjectConfigFile(filepath.Join(home, "proj", "other.toml")) {
+		t.Error("unrelated file should not be a project config")
+	}
+}

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -127,7 +127,7 @@ func Collect(opts Options) Report {
 	// project reasonix.toml outranks it. Users who toggle the sandbox off in
 	// Settings while the project file pins [sandbox] read the no-op as "bash is
 	// broken" (#5961, #6046) — surface the layering explicitly.
-	if sourcePath != "" && filepath.Base(sourcePath) == "reasonix.toml" {
+	if sourcePath != "" && config.IsProjectConfigFile(sourcePath) {
 		if raw, err := fileencoding.ReadFileUTF8(sourcePath); err == nil && tomlHasSandboxTable(raw) {
 			warnings = append(warnings, "project "+redactHome(sourcePath)+" sets [sandbox]; it overrides user-level Settings -> Sandbox for this workspace — edit the project file to change sandbox behavior here")
 		}

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -550,7 +550,7 @@ func (t *installSourceTool) configPath(scope string) string {
 			return p
 		}
 	}
-	return filepath.Join(t.root, "reasonix.toml")
+	return config.ProjectConfigPath(t.root)
 }
 
 func (t *installSourceTool) normalizeScope(scope string) (string, bool) {

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -131,7 +131,7 @@ func TestApplyLocalSkillRootRegistersPath(t *testing.T) {
 	if resp.PlanID == "" {
 		t.Error("PlanID should be populated on apply")
 	}
-	cfg := config.LoadForEdit(filepath.Join(project, "reasonix.toml"))
+	cfg := config.LoadForEdit(filepath.Join(project, ".reasonix", "config.toml"))
 	if len(cfg.Skills.Paths) != 1 || cfg.Skills.Paths[0] != root {
 		t.Fatalf("skills.paths = %v, want %q", cfg.Skills.Paths, root)
 	}
@@ -661,7 +661,7 @@ func TestPlanProjectMCPJSONDefaultsProject(t *testing.T) {
 	if !resp.OK || len(resp.Actions) != 1 {
 		t.Fatalf("response = %+v", resp)
 	}
-	wantPath := filepath.Join(project, "reasonix.toml")
+	wantPath := filepath.Join(project, ".reasonix", "config.toml")
 	if resp.Scope != "project" || resp.Actions[0].Scope != "project" || resp.Actions[0].ConfigPath != wantPath {
 		t.Fatalf("project .mcp.json scope/path = response %q action %q path %q, want project %q", resp.Scope, resp.Actions[0].Scope, resp.Actions[0].ConfigPath, wantPath)
 	}
@@ -825,7 +825,7 @@ func TestApplyRemoteMCPURLConnectsAndPersists(t *testing.T) {
 	if resp.Actions[0].RiskLevel != RiskHigh {
 		t.Errorf("auth headers should produce RiskHigh, got %q", resp.Actions[0].RiskLevel)
 	}
-	cfg := config.LoadForEdit(filepath.Join(project, "reasonix.toml"))
+	cfg := config.LoadForEdit(filepath.Join(project, ".reasonix", "config.toml"))
 	if len(cfg.Plugins) != 1 || cfg.Plugins[0].Headers["Authorization"] != "Bearer ${TOKEN}" {
 		t.Fatalf("plugins = %+v", cfg.Plugins)
 	}

--- a/internal/installsource/skill.go
+++ b/internal/installsource/skill.go
@@ -126,7 +126,7 @@ func (t *installSourceTool) skillCanonicalPath(name, scope string) (string, erro
 func (t *installSourceTool) verifySkill(scope, name string, act *action) error {
 	custom := []string(nil)
 	if scope == "project" {
-		cfg := config.LoadForEdit(filepath.Join(t.root, "reasonix.toml"))
+		cfg := config.LoadForEdit(config.ProjectConfigPath(t.root))
 		custom = cfg.SkillCustomPaths()
 	} else {
 		cfg := config.LoadForEdit(t.configPath(scope))

--- a/internal/repair/config.go
+++ b/internal/repair/config.go
@@ -87,10 +87,7 @@ func inspectAndRepairConfigUnlocked(opts ConfigOptions) (ConfigReport, error) {
 		opts.Now = time.Now
 	}
 	global := config.UserConfigPath()
-	project := filepath.Join(opts.Root, "reasonix.toml")
-	if opts.Root == "" || opts.Root == "." {
-		project = "reasonix.toml"
-	}
+	project := config.ProjectConfigPath(opts.Root)
 	paths := []struct{ scope, path string }{{"global", global}, {"project", project}}
 	report := ConfigReport{Checks: make([]ConfigCheck, 0, len(paths)), Applied: []string{}}
 	tx := opts.repairTransaction
@@ -198,10 +195,7 @@ func configRepairTargetPaths(opts ConfigOptions) ([]string, error) {
 		}
 		return paths
 	}
-	project := filepath.Join(opts.Root, "reasonix.toml")
-	if opts.Root == "" || opts.Root == "." {
-		project = "reasonix.toml"
-	}
+	project := config.ProjectConfigPath(opts.Root)
 	switch opts.OnlyScope {
 	case "global":
 		return globalPaths(), nil

--- a/internal/repair/plan.go
+++ b/internal/repair/plan.go
@@ -845,9 +845,5 @@ func configSnapshotByID(id string) (ConfigSnapshot, error) {
 }
 
 func projectConfigPath(root string) string {
-	root = strings.TrimSpace(root)
-	if root == "" || root == "." {
-		return "reasonix.toml"
-	}
-	return filepath.Join(root, "reasonix.toml")
+	return config.ProjectConfigPath(root)
 }

--- a/internal/repair/transaction.go
+++ b/internal/repair/transaction.go
@@ -418,7 +418,7 @@ func validateRepairChange(change RepairChange) error {
 			return fmt.Errorf("repair transaction global target is invalid")
 		}
 	case change.Scope == "project":
-		if filepath.Base(target) != "reasonix.toml" {
+		if !config.IsProjectConfigFile(target) {
 			return fmt.Errorf("repair transaction project target is invalid")
 		}
 	case strings.HasPrefix(change.Scope, "derived:"):

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -206,7 +206,7 @@ func confine(roots []string, target string) error {
 		}
 	}
 	return fmt.Errorf("path %q is outside the writable roots (writes are confined to %s); "+
-		"write inside the workspace or a configured allow_write root, or widen [sandbox] workspace_root / allow_write in reasonix.toml",
+		"write inside the workspace or a configured allow_write root, or widen [sandbox] workspace_root / allow_write in .reasonix/config.toml",
 		target, strings.Join(roots, ", "))
 }
 

--- a/internal/tool/builtin/managed_config.go
+++ b/internal/tool/builtin/managed_config.go
@@ -60,7 +60,7 @@ func (m ManagedConfigPaths) approve(ctx context.Context, target string) error {
 	approver, ok := tool.ConfigWriteApproverFrom(ctx)
 	if !ok {
 		return fmt.Errorf("path %q is a Reasonix-managed config file outside the writable roots; writing it requires interactive user approval, which this session cannot provide. "+
-			"Ask the user to retry in an interactive session, or to add the directory to [sandbox] allow_write in reasonix.toml", target)
+			"Ask the user to retry in an interactive session, or to add the directory to [sandbox] allow_write in .reasonix/config.toml", target)
 	}
 	req := tool.ConfigWriteRequest{Path: target}
 	if checker, ok := approver.(tool.ConfigWriteSessionChecker); ok && checker.ManagedConfigWriteSessionAllowed(ctx, req) {

--- a/internal/tool/builtin/session_guard.go
+++ b/internal/tool/builtin/session_guard.go
@@ -57,14 +57,14 @@ func (g SessionDataGuard) Check(target string) error {
 	}
 	if g.deniesSecurity(abs) {
 		return fmt.Errorf("path %q is a Reasonix security boundary file (%s holds the global hooks; hooks execute arbitrary shell commands on every future session). Agents may not modify it. "+
-			"Ask the user to edit it themselves, or to add the directory to [sandbox] allow_write in reasonix.toml if raw access is truly intended",
+			"Ask the user to edit it themselves, or to add the directory to [sandbox] allow_write in .reasonix/config.toml if raw access is truly intended",
 			target, g.stateRoot)
 	}
 	if !g.denies(abs) {
 		return nil
 	}
 	return fmt.Errorf("path %q is inside Reasonix's own session/state data (%s); the app is the only writer of these files, and edits from a chat race its saves — that surfaces as repeated save-conflict copies. "+
-		"Do not modify session or runtime-state files directly; report the underlying problem instead. If raw access is truly intended, add the directory to [sandbox] allow_write in reasonix.toml",
+		"Do not modify session or runtime-state files directly; report the underlying problem instead. If raw access is truly intended, add the directory to [sandbox] allow_write in .reasonix/config.toml",
 		target, g.stateRoot)
 }
 


### PR DESCRIPTION
# Standardize project config on `<project>/.reasonix/config.toml`

## Summary

Mirror the global config at `<home>/.reasonix/config.toml` with a project-local
config at `<project>/.reasonix/config.toml`, so global and local configs share a
name and a spot. The legacy `<project>/reasonix.toml` still loads and wins when
present. New project configs are only ever created at `.reasonix/config.toml`.

## What changed

- **Path resolution** (`internal/config/paths.go`): `ProjectConfigPath(root)`
  now returns `reasonix.toml` when present, else `.reasonix/config.toml` (the
  creation default). Added `IsProjectConfigFile` (recognizes the two names,
  excludes the user-global `<home>/.reasonix/config.toml`) and the
  `bothProjectConfigsExist` ambiguity warning.
- **Writes/fallback**: `Config.Save()` and the boot-side fallback now target
  `.reasonix/config.toml` instead of the legacy `reasonix.toml` (`edit.go`,
  `boot.go`).
- **Migration** (`internal/config/migrate.go`): the MCP import now scans both
  the legacy `reasonix.toml` and the standard `.reasonix/config.toml`.
- **Callers** routed through `IsProjectConfigFile`/`ProjectConfigPath`
  (`doctor/report.go`, `repair/transaction.go`, `installsource/*`, desktop
  `app.go` label) and user-facing "edit your config" tool guidance
  (`session_guard.go`, `confine.go`, `managed_config.go`).
- **Tests**: `project_config_discovery_test.go` covers the precedence rules and
  the `IsProjectConfigFile` user-config exclusion; write-target expectations
  updated in `cli`/`installsource`/`boot`.
- **Docs**: `docs/GUIDE.md`, `docs/CONFIG_PATHS.md`, `docs/CLI.md`, `docs/SPEC.md`
  (+ `zh-CN`) and `reasonix.example.toml` standardized on the new location.

## Impact

- Cache-impact: medium - the tool-guidance strings in
  `session_guard.go` / `confine.go` / `managed_config.go` are part of the stable
  system-prompt prefix and now say `.reasonix/config.toml` instead of
  `reasonix.toml`, so the provider-visible prefix changes once.
- Cache-guard: repolint baseline bumped in a trailing commit;
  `go test ./internal/config/ ./internal/boot/` pass.
- System-prompt-review: srb (author) - the tool-guidance wording change is the
  only provider-prefix delta; reviewed and accepted.
- Documentation-impact: updated - docs and `reasonix.example.toml` reflect the
  `.reasonix/config.toml` location.
