### PR TITLE
fix(bot/qq): 自动协商 gateway intents

### DIFF
--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -45,26 +45,6 @@ const (
 	opHeartbeatAck = 11
 )
 
-// QQ gateway intents（QQ 开放平台 Bot API v2）。
-// 注意：只声明已授权/必需的 intent。未授权的 intent（如 GUILD_MESSAGES
-// 1<<9、INTERACTION 1<<26）会让 gateway 以 op=9 INVALID_SESSION 断开——
-// 未认证/未发布的 bot 没有频道消息权限，传 1<<9 必然握手失败（#7512 有
-// 逐 bit 协议级验证）。频道消息用 PUBLIC_GUILD_MESSAGES (1<<30) 替代
-// GUILD_MESSAGES，普通 bot 即有权限。
-const (
-	intentGuilds              = 1 << 0  // 频道（含 AT_MESSAGE_CREATE 等频道事件）
-	intentGuildMembers        = 1 << 1  // 频道成员
-	intentDirectMessage       = 1 << 12 // 私信（DIRECT_MESSAGE_CREATE）
-	intentGroupAndC2C         = 1 << 25 // 群聊与 C2C 消息（GROUP_AT_MESSAGE_CREATE / C2C_MESSAGE_CREATE）
-	intentPublicGuildMessages = 1 << 30 // 公共频道消息（替代 1<<9 GUILD_MESSAGES）
-)
-
-// qqIdentifyIntents 是 Identify 时声明的 intent 集合：覆盖 Reasonix 需要的
-// 群聊/C2C @、私信与频道事件，且全部为普通 bot 有权限的 intent（不包含
-// 1<<9 GUILD_MESSAGES / 1<<26 INTERACTION 等需申请的高阶能力）。
-const qqIdentifyIntents = intentGuilds | intentGuildMembers | intentDirectMessage |
-	intentGroupAndC2C | intentPublicGuildMessages
-
 var qqMarkdownWrapperRe = regexp.MustCompile("(?is)^```(?:markdown|md)\\s*\\r?\\n([\\s\\S]*?)\\r?\\n```$")
 
 var qqHTTPClient = &http.Client{Timeout: qqHTTPTimeout}
@@ -129,6 +109,7 @@ type wsClient struct {
 }
 
 func (a *adapter) gatewayLoop(ctx context.Context) {
+	selectedIntents := qqPrivateIdentifyIntents
 	bot.RunWithRetry(ctx, a.logger, "qq gateway", bot.RetryConfig{}, func(ctx context.Context) error {
 		token, err := a.getAccessToken(ctx)
 		if err != nil {
@@ -137,7 +118,10 @@ func (a *adapter) gatewayLoop(ctx context.Context) {
 		// connectGateway blocks for the connection's lifetime, returning on
 		// disconnect or error; RunWithRetry handles the cancellation-aware
 		// backoff and reconnect.
-		return a.connectGateway(ctx, token)
+		_, err = connectQQGatewayWithIntentFallback(ctx, token, &selectedIntents, a.connectGateway, func() {
+			a.logger.Warn("qq private-guild intent rejected; retrying with public-guild events")
+		})
+		return err
 	})
 }
 
@@ -234,7 +218,7 @@ func qqExpiresInSeconds(value any) (int, error) {
 	}
 }
 
-func (a *adapter) connectGateway(ctx context.Context, token string) error {
+func (a *adapter) connectGateway(ctx context.Context, token string, intents int) error {
 	gatewayURL, err := a.getGatewayURL(ctx, token)
 	if err != nil {
 		return err
@@ -276,7 +260,7 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 	// Identify
 	identify := identifyData{
 		Token:   fmt.Sprintf("QQBot %s", token),
-		Intents: qqIdentifyIntents,
+		Intents: intents,
 		Shard:   [2]int{0, 1},
 		Properties: properties{
 			OS:      "linux",
@@ -293,20 +277,19 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 	if err := decoder.Decode(&msg); err != nil {
 		return fmt.Errorf("read ready: %w", err)
 	}
-	if msg.Op == opDispatch && msg.T == "READY" {
-		var ready struct {
-			SessionID string `json:"session_id"`
-		}
-		if err := json.Unmarshal(msg.D, &ready); err != nil {
-			return fmt.Errorf("decode ready: %w", err)
-		}
-		ws.sessionID = ready.SessionID
-		a.sessionID = ready.SessionID
-		a.seq = msg.S
-		a.logger.Info("qq gateway ready", "sandbox", a.cfg.Sandbox, "heartbeat_ms", ws.heartbeatMs)
-	} else {
-		a.logger.Warn("qq gateway expected ready event", "op", msg.Op, "event", msg.T)
+	if err := validateQQReadyPayload(msg); err != nil {
+		return err
 	}
+	var ready struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(msg.D, &ready); err != nil {
+		return fmt.Errorf("decode ready: %w", err)
+	}
+	ws.sessionID = ready.SessionID
+	a.sessionID = ready.SessionID
+	a.seq = msg.S
+	a.logger.Info("qq gateway ready", "sandbox", a.cfg.Sandbox, "heartbeat_ms", ws.heartbeatMs)
 
 	// 启动 heartbeat
 	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -45,6 +45,26 @@ const (
 	opHeartbeatAck = 11
 )
 
+// QQ gateway intents（QQ 开放平台 Bot API v2）。
+// 注意：只声明已授权/必需的 intent。未授权的 intent（如 GUILD_MESSAGES
+// 1<<9、INTERACTION 1<<26）会让 gateway 以 op=9 INVALID_SESSION 断开——
+// 未认证/未发布的 bot 没有频道消息权限，传 1<<9 必然握手失败（#7512 有
+// 逐 bit 协议级验证）。频道消息用 PUBLIC_GUILD_MESSAGES (1<<30) 替代
+// GUILD_MESSAGES，普通 bot 即有权限。
+const (
+	intentGuilds              = 1 << 0  // 频道（含 AT_MESSAGE_CREATE 等频道事件）
+	intentGuildMembers        = 1 << 1  // 频道成员
+	intentDirectMessage       = 1 << 12 // 私信（DIRECT_MESSAGE_CREATE）
+	intentGroupAndC2C         = 1 << 25 // 群聊与 C2C 消息（GROUP_AT_MESSAGE_CREATE / C2C_MESSAGE_CREATE）
+	intentPublicGuildMessages = 1 << 30 // 公共频道消息（替代 1<<9 GUILD_MESSAGES）
+)
+
+// qqIdentifyIntents 是 Identify 时声明的 intent 集合：覆盖 Reasonix 需要的
+// 群聊/C2C @、私信与频道事件，且全部为普通 bot 有权限的 intent（不包含
+// 1<<9 GUILD_MESSAGES / 1<<26 INTERACTION 等需申请的高阶能力）。
+const qqIdentifyIntents = intentGuilds | intentGuildMembers | intentDirectMessage |
+	intentGroupAndC2C | intentPublicGuildMessages
+
 var qqMarkdownWrapperRe = regexp.MustCompile("(?is)^```(?:markdown|md)\\s*\\r?\\n([\\s\\S]*?)\\r?\\n```$")
 
 var qqHTTPClient = &http.Client{Timeout: qqHTTPTimeout}
@@ -256,7 +276,7 @@ func (a *adapter) connectGateway(ctx context.Context, token string) error {
 	// Identify
 	identify := identifyData{
 		Token:   fmt.Sprintf("QQBot %s", token),
-		Intents: 1<<0 | 1<<1 | 1<<9 | 1<<10 | 1<<12 | 1<<25 | 1<<26,
+		Intents: qqIdentifyIntents,
 		Shard:   [2]int{0, 1},
 		Properties: properties{
 			OS:      "linux",

--- a/internal/bot/qq/gateway_test.go
+++ b/internal/bot/qq/gateway_test.go
@@ -75,6 +75,35 @@ func TestHandleDispatchC2CUsesUserOpenID(t *testing.T) {
 	}
 }
 
+func TestHandleDispatchPublicGuildMessageUsesGuildChatType(t *testing.T) {
+	a := &adapter{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		msgCh:  make(chan bot.InboundMessage, 1),
+	}
+	raw, err := json.Marshal(map[string]any{
+		"id":         "msg-1",
+		"content":    "hello",
+		"channel_id": "channel-1",
+		"author": map[string]string{
+			"member_openid": "member-1",
+			"username":      "user",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a.handleDispatch(gatewayPayload{T: "AT_MESSAGE_CREATE", D: raw})
+
+	msg := <-a.msgCh
+	if msg.ChatType != bot.ChatGuild {
+		t.Fatalf("chat type = %q, want %q", msg.ChatType, bot.ChatGuild)
+	}
+	if msg.ChatID != "channel-1" {
+		t.Fatalf("chat id = %q, want channel-1", msg.ChatID)
+	}
+}
+
 func TestQQSendURLDirectMessage(t *testing.T) {
 	got := qqSendURL(bot.OutboundMessage{ChatType: bot.ChatDirect, ChatID: "guild-1"})
 	want := fmt.Sprintf("%s/v2/dms/%s/messages", qqBaseURL, "guild-1")
@@ -351,25 +380,5 @@ func jsonResponse(status int, v any) *http.Response {
 		StatusCode: status,
 		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       io.NopCloser(bytes.NewReader(data)),
-	}
-}
-
-// TestQQIdentifyIntentsAvoidUnauthorizedBits: Identify 的 intent 集合不得
-// 包含未授权即被 gateway 以 op=9 断开的位（GUILD_MESSAGES 1<<9、INTERACTION
-// 1<<26 等），且必须覆盖 Reasonix 核心的群聊/C2C 事件（1<<25）。
-func TestQQIdentifyIntentsAvoidUnauthorizedBits(t *testing.T) {
-	if qqIdentifyIntents&(1<<9) != 0 {
-		t.Fatalf("qqIdentifyIntents contains GUILD_MESSAGES (1<<9): gateway rejects it with op=9 INVALID_SESSION for bots without guild-message permission")
-	}
-	if qqIdentifyIntents&(1<<26) != 0 {
-		t.Fatalf("qqIdentifyIntents contains INTERACTION (1<<26): requires applied high-level capability")
-	}
-	if qqIdentifyIntents&intentGroupAndC2C == 0 {
-		t.Fatalf("qqIdentifyIntents must include GROUP_AND_C2C_EVENT (1<<25) for QQ group/C2C messaging")
-	}
-	// 全部位都来自已命名 intent，防止未来误加未授权位。
-	allowed := intentGuilds | intentGuildMembers | intentDirectMessage | intentGroupAndC2C | intentPublicGuildMessages
-	if qqIdentifyIntents&^allowed != 0 {
-		t.Fatalf("qqIdentifyIntents contains undeclared bits %b", qqIdentifyIntents&^allowed)
 	}
 }

--- a/internal/bot/qq/gateway_test.go
+++ b/internal/bot/qq/gateway_test.go
@@ -353,3 +353,23 @@ func jsonResponse(status int, v any) *http.Response {
 		Body:       io.NopCloser(bytes.NewReader(data)),
 	}
 }
+
+// TestQQIdentifyIntentsAvoidUnauthorizedBits: Identify 的 intent 集合不得
+// 包含未授权即被 gateway 以 op=9 断开的位（GUILD_MESSAGES 1<<9、INTERACTION
+// 1<<26 等），且必须覆盖 Reasonix 核心的群聊/C2C 事件（1<<25）。
+func TestQQIdentifyIntentsAvoidUnauthorizedBits(t *testing.T) {
+	if qqIdentifyIntents&(1<<9) != 0 {
+		t.Fatalf("qqIdentifyIntents contains GUILD_MESSAGES (1<<9): gateway rejects it with op=9 INVALID_SESSION for bots without guild-message permission")
+	}
+	if qqIdentifyIntents&(1<<26) != 0 {
+		t.Fatalf("qqIdentifyIntents contains INTERACTION (1<<26): requires applied high-level capability")
+	}
+	if qqIdentifyIntents&intentGroupAndC2C == 0 {
+		t.Fatalf("qqIdentifyIntents must include GROUP_AND_C2C_EVENT (1<<25) for QQ group/C2C messaging")
+	}
+	// 全部位都来自已命名 intent，防止未来误加未授权位。
+	allowed := intentGuilds | intentGuildMembers | intentDirectMessage | intentGroupAndC2C | intentPublicGuildMessages
+	if qqIdentifyIntents&^allowed != 0 {
+		t.Fatalf("qqIdentifyIntents contains undeclared bits %b", qqIdentifyIntents&^allowed)
+	}
+}

--- a/internal/bot/qq/intents.go
+++ b/internal/bot/qq/intents.go
@@ -1,0 +1,50 @@
+package qq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// QQ rejects Identify when it contains an intent the bot is not authorized
+// for. Try the private-guild profile first to preserve MESSAGE_CREATE support,
+// then remember a public-guild fallback for this adapter lifetime if rejected.
+const (
+	intentGuilds               = 1 << 0
+	intentGuildMembers         = 1 << 1
+	intentPrivateGuildMessages = 1 << 9
+	intentDirectMessage        = 1 << 12
+	intentGroupAndC2C          = 1 << 25
+	intentPublicGuildMessages  = 1 << 30
+
+	qqSharedIdentifyIntents  = intentGuilds | intentGuildMembers | intentDirectMessage | intentGroupAndC2C
+	qqPrivateIdentifyIntents = qqSharedIdentifyIntents | intentPrivateGuildMessages
+	qqPublicIdentifyIntents  = qqSharedIdentifyIntents | intentPublicGuildMessages
+)
+
+var errQQIdentifyRejected = errors.New("qq gateway identify rejected")
+
+func connectQQGatewayWithIntentFallback(ctx context.Context, token string, selected *int, connect func(context.Context, string, int) error, onFallback func()) (bool, error) {
+	err := connect(ctx, token, *selected)
+	if *selected != qqPrivateIdentifyIntents || !errors.Is(err, errQQIdentifyRejected) {
+		return false, err
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	*selected = qqPublicIdentifyIntents
+	if onFallback != nil {
+		onFallback()
+	}
+	return true, connect(ctx, token, *selected)
+}
+
+func validateQQReadyPayload(msg gatewayPayload) error {
+	if msg.Op == opInvalid {
+		return fmt.Errorf("%w: op=%d", errQQIdentifyRejected, msg.Op)
+	}
+	if msg.Op != opDispatch || msg.T != "READY" {
+		return fmt.Errorf("expected op=%d READY, got op=%d event=%q", opDispatch, msg.Op, msg.T)
+	}
+	return nil
+}

--- a/internal/bot/qq/intents_test.go
+++ b/internal/bot/qq/intents_test.go
@@ -1,0 +1,96 @@
+package qq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestQQIdentifyIntentProfiles(t *testing.T) {
+	const shared = 1<<0 | 1<<1 | 1<<12 | 1<<25
+	if qqPrivateIdentifyIntents != shared|1<<9 {
+		t.Fatalf("private intents = %b, want %b", qqPrivateIdentifyIntents, shared|1<<9)
+	}
+	if qqPublicIdentifyIntents != shared|1<<30 {
+		t.Fatalf("public intents = %b, want %b", qqPublicIdentifyIntents, shared|1<<30)
+	}
+	if qqPrivateIdentifyIntents&(1<<26) != 0 || qqPublicIdentifyIntents&(1<<26) != 0 {
+		t.Fatal("identify profiles contain privileged INTERACTION intent")
+	}
+}
+
+func TestQQIntentFallbackPreservesPrivateProfileWhenAuthorized(t *testing.T) {
+	selected := qqPrivateIdentifyIntents
+	var attempts []int
+	downgraded, err := connectQQGatewayWithIntentFallback(context.Background(), "token", &selected, func(_ context.Context, _ string, intents int) error {
+		attempts = append(attempts, intents)
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if downgraded {
+		t.Fatal("authorized private profile was downgraded")
+	}
+	if selected != qqPrivateIdentifyIntents || len(attempts) != 1 || attempts[0] != qqPrivateIdentifyIntents {
+		t.Fatalf("selected = %b, attempts = %v", selected, attempts)
+	}
+}
+
+func TestQQIntentFallbackDowngradesOnceAndRemembersPublicProfile(t *testing.T) {
+	selected := qqPrivateIdentifyIntents
+	var attempts []int
+	connect := func(_ context.Context, _ string, intents int) error {
+		attempts = append(attempts, intents)
+		if intents == qqPrivateIdentifyIntents {
+			return errQQIdentifyRejected
+		}
+		return nil
+	}
+
+	downgraded, err := connectQQGatewayWithIntentFallback(context.Background(), "token", &selected, connect, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !downgraded || selected != qqPublicIdentifyIntents {
+		t.Fatalf("downgraded = %v, selected = %b", downgraded, selected)
+	}
+	wantAttempts := []int{qqPrivateIdentifyIntents, qqPublicIdentifyIntents}
+	if fmt.Sprint(attempts) != fmt.Sprint(wantAttempts) {
+		t.Fatalf("attempts = %v, want %v", attempts, wantAttempts)
+	}
+
+	attempts = nil
+	downgraded, err = connectQQGatewayWithIntentFallback(context.Background(), "token", &selected, connect, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if downgraded || len(attempts) != 1 || attempts[0] != qqPublicIdentifyIntents {
+		t.Fatalf("second attempt downgraded = %v, attempts = %v", downgraded, attempts)
+	}
+}
+
+func TestQQIntentFallbackDoesNotReconnectAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	selected := qqPrivateIdentifyIntents
+	attempts := 0
+	_, err := connectQQGatewayWithIntentFallback(ctx, "token", &selected, func(_ context.Context, _ string, _ int) error {
+		attempts++
+		cancel()
+		return errQQIdentifyRejected
+	}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+	if attempts != 1 || selected != qqPrivateIdentifyIntents {
+		t.Fatalf("attempts = %d, selected = %b", attempts, selected)
+	}
+}
+
+func TestQQReadyPayloadClassifiesInvalidSession(t *testing.T) {
+	err := validateQQReadyPayload(gatewayPayload{Op: opInvalid})
+	if !errors.Is(err, errQQIdentifyRejected) {
+		t.Fatalf("validateQQReadyPayload() error = %v, want identify rejection", err)
+	}
+}

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -647,6 +647,7 @@
       "file-size": 31
     },
     "internal/bot/qq/gateway.go": {
+      "file-size": 13,
       "function-size": 11
     },
     "internal/bot/render.go": {

--- a/tools/repolint/baseline.json
+++ b/tools/repolint/baseline.json
@@ -647,7 +647,6 @@
       "file-size": 31
     },
     "internal/bot/qq/gateway.go": {
-      "file-size": 13,
       "function-size": 11
     },
     "internal/bot/render.go": {


### PR DESCRIPTION
## 变更摘要

修复 QQ Bot 在不同频道消息权限下无法兼容的问题：未获私域频道权限的 Bot 会因 `GUILD_MESSAGES (1<<9)` 收到 `op=9 INVALID_SESSION`，而固定改用 `PUBLIC_GUILD_MESSAGES (1<<30)` 又会让已获私域权限的 Bot 丢失普通 `MESSAGE_CREATE`。

## 根因

QQ 会在 Identify 包含未授权 intent 时拒绝整个连接，但单一固定 intent 组合无法同时覆盖两类 Bot：

- 私域频道 Bot 依赖 `GUILD_MESSAGES (1<<9)` 接收 `MESSAGE_CREATE`
- 普通/公域 Bot 需要 `PUBLIC_GUILD_MESSAGES (1<<30)` 接收 `AT_MESSAGE_CREATE`
- `INTERACTION (1<<26)` 属于高阶能力，Reasonix 当前不需要，不应默认声明

## 修复

不增加用户设置项，改为在网关握手时自动协商：

1. 首次使用私域 intent 组合，保留已授权 Bot 的 `MESSAGE_CREATE`
2. 若 READY 前收到 `op=9`，立即且仅一次切换到公域 intent 组合重连
3. 在当前 adapter 生命周期内记住公域选择，后续断线重连不再重复探测
4. 若上下文已取消，不启动降级重连

共享 intent 保留 `GUILDS (1<<0)`、`GUILD_MEMBERS (1<<1)`、`DIRECT_MESSAGE (1<<12)` 与 `GROUP_AND_C2C_EVENT (1<<25)`；两个组合均不包含 `INTERACTION (1<<26)`。

## 验证

- `go test ./internal/bot/qq/`
- `go test -race ./internal/bot/qq/`
- `go vet ./internal/bot/qq/`
- 在最新 `main-v2` 合并树运行 `go test ./...`
- `go run ./tools/repolint`
- `git diff --check`

以上均通过。测试覆盖私域成功、公域自动降级且只发生一次、后续重连记住选择、取消后不再连接，以及公域 `AT_MESSAGE_CREATE` 路由。

Fixes #8108, #7512, #7816, #7424

Documentation-impact: none - 自动能力协商，不新增用户设置或配置项。

Cache-impact: none - 仅修改 QQ gateway intent 握手与相关测试；provider 可见系统提示词前缀字节不变。

Cache-guard: `go test ./internal/bot/qq/ && go run ./tools/repolint`
